### PR TITLE
planner: fix indexHashJoin cost formula

### DIFF
--- a/pkg/bindinfo/binding_auto_test.go
+++ b/pkg/bindinfo/binding_auto_test.go
@@ -60,7 +60,7 @@ func TestGenPlanWithSCtx(t *testing.T) {
 	sctx.GetSessionVars().StreamAggCostFactor = 1
 
 	check("select * from t1, t2 where t1.a=t2.a and t2.b=1",
-		"inl_hash_join", "IndexHashJoin")
+		"inl_join", "IndexJoin")
 
 	sctx.GetSessionVars().IndexJoinCostFactor = 100000
 	sctx.GetSessionVars().HashJoinCostFactor = 100000

--- a/pkg/bindinfo/testdata/binding_auto_suite_out.json
+++ b/pkg/bindinfo/testdata/binding_auto_suite_out.json
@@ -85,6 +85,26 @@
         "SQL": "explain explore select * from t1, t2 where t1.a=t2.a",
         "Plan": [
           [
+            "IndexJoin  12487.50  root    inner join, inner:IndexLookUp, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
+            "├─IndexLookUp(Build)  9990.00  root    ",
+            "│ ├─IndexFullScan(Build)  9990.00  cop[tikv]  table:t1, index:a(a)  keep order:false, stats:pseudo",
+            "│ └─TableRowIDScan(Probe)  9990.00  cop[tikv]  table:t1  keep order:false, stats:pseudo",
+            "└─IndexLookUp(Probe)  12487.50  root    ",
+            "  ├─Selection(Build)  12487.50  cop[tikv]    not(isnull(test.t2.a))",
+            "  │ └─IndexRangeScan  12500.00  cop[tikv]  table:t2, index:a(a)  range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo",
+            "  └─TableRowIDScan(Probe)  12487.50  cop[tikv]  table:t2  keep order:false, stats:pseudo"
+          ],
+          [
+            "IndexJoin  12487.50  root    inner join, inner:IndexLookUp, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
+            "├─TableReader(Build)  9990.00  root    data:Selection",
+            "│ └─Selection  9990.00  cop[tikv]    not(isnull(test.t1.a))",
+            "│   └─TableFullScan  10000.00  cop[tikv]  table:t1  keep order:false, stats:pseudo",
+            "└─IndexLookUp(Probe)  12487.50  root    ",
+            "  ├─Selection(Build)  12487.50  cop[tikv]    not(isnull(test.t2.a))",
+            "  │ └─IndexRangeScan  12500.00  cop[tikv]  table:t2, index:a(a)  range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo",
+            "  └─TableRowIDScan(Probe)  12487.50  cop[tikv]  table:t2  keep order:false, stats:pseudo"
+          ],
+          [
             "MergeJoin  12487.50  root    inner join, left key:test.t1.a, right key:test.t2.a",
             "├─Projection(Probe)  9990.00  root    test.t1.a, test.t1.b, test.t1.c",
             "│ └─IndexLookUp  9990.00  root    ",
@@ -96,16 +116,6 @@
             "    └─TableRowIDScan(Probe)  9990.00  cop[tikv]  table:t2  keep order:false, stats:pseudo"
           ],
           [
-            "IndexHashJoin  12487.50  root    inner join, inner:IndexLookUp, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
-            "├─TableReader(Build)  9990.00  root    data:Selection",
-            "│ └─Selection  9990.00  cop[tikv]    not(isnull(test.t1.a))",
-            "│   └─TableFullScan  10000.00  cop[tikv]  table:t1  keep order:false, stats:pseudo",
-            "└─IndexLookUp(Probe)  12487.50  root    ",
-            "  ├─Selection(Build)  12487.50  cop[tikv]    not(isnull(test.t2.a))",
-            "  │ └─IndexRangeScan  12500.00  cop[tikv]  table:t2, index:a(a)  range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo",
-            "  └─TableRowIDScan(Probe)  12487.50  cop[tikv]  table:t2  keep order:false, stats:pseudo"
-          ],
-          [
             "HashJoin  12487.50  root    inner join, equal:[eq(test.t1.a, test.t2.a)]",
             "├─TableReader(Probe)  9990.00  root    data:Selection",
             "│ └─Selection  9990.00  cop[tikv]    not(isnull(test.t1.a))",
@@ -113,16 +123,6 @@
             "└─TableReader(Build)  9990.00  root    data:Selection",
             "  └─Selection  9990.00  cop[tikv]    not(isnull(test.t2.a))",
             "    └─TableFullScan  10000.00  cop[tikv]  table:t2  keep order:false, stats:pseudo"
-          ],
-          [
-            "IndexHashJoin  12487.50  root    inner join, inner:IndexLookUp, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
-            "├─IndexLookUp(Build)  9990.00  root    ",
-            "│ ├─IndexFullScan(Build)  9990.00  cop[tikv]  table:t1, index:a(a)  keep order:false, stats:pseudo",
-            "│ └─TableRowIDScan(Probe)  9990.00  cop[tikv]  table:t1  keep order:false, stats:pseudo",
-            "└─IndexLookUp(Probe)  12487.50  root    ",
-            "  ├─Selection(Build)  12487.50  cop[tikv]    not(isnull(test.t2.a))",
-            "  │ └─IndexRangeScan  12500.00  cop[tikv]  table:t2, index:a(a)  range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo",
-            "  └─TableRowIDScan(Probe)  12487.50  cop[tikv]  table:t2  keep order:false, stats:pseudo"
           ]
         ]
       }

--- a/pkg/planner/core/plan_cost_ver2.go
+++ b/pkg/planner/core/plan_cost_ver2.go
@@ -778,12 +778,11 @@ func getIndexJoinCostVer24PhysicalIndexJoin(pp base.PhysicalPlan, taskType prope
 		return costusage.ZeroCostVer2, err
 	}
 
-	// IndexJoin family uses OuterHashKeys/InnerHashKeys as the actual hash key set during execution.
-	// These two slices should be non-empty and aligned (same length), and Outer/InnerJoinKeys are prefixes
-	// of them. If not, it's either an incomplete plan or a bug in key construction.
-	intest.Assert(len(p.OuterHashKeys) > 0, "index join hash keys should be initialized before costing")
-	intest.Assert(len(p.InnerHashKeys) > 0, "index join hash keys should be initialized before costing")
+	// IndexJoin family uses OuterHashKeys/InnerHashKeys as the execution-time hash key set.
+	// Note: for non-equi/range index join (e.g. only CompareFilters), hash keys can be empty.
+	// When join keys exist, they must be prefixes of the hash keys. Outer/Inner hash keys should be aligned.
 	intest.Assert(len(p.OuterHashKeys) == len(p.InnerHashKeys), "outer/inner hash keys should be aligned")
+	intest.Assert(len(p.OuterJoinKeys) == len(p.InnerJoinKeys), "outer/inner join keys should be aligned")
 	intest.Assert(len(p.OuterJoinKeys) <= len(p.OuterHashKeys), "OuterJoinKeys should be prefix of OuterHashKeys")
 	intest.Assert(len(p.InnerJoinKeys) <= len(p.InnerHashKeys), "InnerJoinKeys should be prefix of InnerHashKeys")
 	outerHashKeyCnt := float64(len(p.OuterHashKeys))

--- a/pkg/planner/core/plan_cost_ver2.go
+++ b/pkg/planner/core/plan_cost_ver2.go
@@ -751,6 +751,9 @@ func getIndexJoinCostVer24PhysicalIndexJoin(pp base.PhysicalPlan, taskType prope
 	probeRowsTot := probeRowsOne * buildRows
 	probeRowSize := getAvgRowSize(probe.StatsInfo(), probe.Schema().Columns)
 	buildFilters, probeFilters := p.LeftConditions, p.RightConditions
+	if p.InnerChildIdx == 0 {
+		buildFilters, probeFilters = p.RightConditions, p.LeftConditions
+	}
 	probeConcurrency := float64(p.SCtx().GetSessionVars().IndexLookupJoinConcurrency())
 	cpuFactor := getTaskCPUFactorVer2(p, taskType)
 	memFactor := getTaskMemFactorVer2(p, taskType)
@@ -775,14 +778,31 @@ func getIndexJoinCostVer24PhysicalIndexJoin(pp base.PhysicalPlan, taskType prope
 		return costusage.ZeroCostVer2, err
 	}
 
+	// IndexJoin family uses OuterHashKeys/InnerHashKeys as the actual hash key set during execution.
+	// These two slices should be non-empty and aligned (same length), and Outer/InnerJoinKeys are prefixes
+	// of them. If not, it's either an incomplete plan or a bug in key construction.
+	intest.Assert(len(p.OuterHashKeys) > 0, "index join hash keys should be initialized before costing")
+	intest.Assert(len(p.InnerHashKeys) > 0, "index join hash keys should be initialized before costing")
+	intest.Assert(len(p.OuterHashKeys) == len(p.InnerHashKeys), "outer/inner hash keys should be aligned")
+	intest.Assert(len(p.OuterJoinKeys) <= len(p.OuterHashKeys), "OuterJoinKeys should be prefix of OuterHashKeys")
+	intest.Assert(len(p.InnerJoinKeys) <= len(p.InnerHashKeys), "InnerJoinKeys should be prefix of InnerHashKeys")
+	outerHashKeyCnt := float64(len(p.OuterHashKeys))
+	innerHashKeyCnt := float64(len(p.InnerHashKeys))
+
 	var hashTableCost costusage.CostVer2
 	switch indexJoinType {
 	case 1: // IndexHashJoin
-		hashTableCost = hashBuildCostVer2(option, buildRows, buildRowSize, float64(len(p.RightJoinKeys)), cpuFactor, memFactor)
+		// IndexHashJoin builds a hash table from the outer rows, then probes it with the
+		// fetched inner rows. The hash key set is p.OuterHashKeys/p.InnerHashKeys (p.OuterJoinKeys is
+		// only the prefix used for index ranges).
+		hashTableCost = costusage.SumCostVer2(
+			hashBuildCostVer2(option, buildRows, buildRowSize, outerHashKeyCnt, cpuFactor, memFactor),
+			hashProbeCostVer2(option, probeRowsTot, innerHashKeyCnt, cpuFactor),
+		)
 	case 2: // IndexMergeJoin
 		hashTableCost = costusage.NewZeroCostVer2(costusage.TraceCost(option))
 	default: // IndexJoin
-		hashTableCost = hashBuildCostVer2(option, probeRowsTot, probeRowSize, float64(len(p.LeftJoinKeys)), cpuFactor, memFactor)
+		hashTableCost = hashBuildCostVer2(option, probeRowsTot, probeRowSize, innerHashKeyCnt, cpuFactor, memFactor)
 	}
 
 	// IndexJoin executes a batch of rows at a time, so the actual cost of this part should be

--- a/tests/integrationtest/r/executor/explain.result
+++ b/tests/integrationtest/r/executor/explain.result
@@ -349,7 +349,7 @@ Update	root		N/A
     └─HashJoin	root		left outer join, left side:IndexLookUp, equal:[eq(executor__explain.t1.id2, executor__explain.t2.id2)]
       ├─HashAgg(Build)	root		group by:executor__explain.t2.id2, funcs:count(1)->Column, funcs:firstrow(executor__explain.t2.id2)->executor__explain.t2.id2
       │ └─IndexJoin	root		inner join, inner:IndexReader, outer key:executor__explain.t2.id10, inner key:executor__explain.t3.id20, equal cond:eq(executor__explain.t2.id10, executor__explain.t3.id20)
-      │   ├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:executor__explain.t1.id2, inner key:executor__explain.t2.id2, equal cond:eq(executor__explain.t1.id2, executor__explain.t2.id2)
+      │   ├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:executor__explain.t1.id2, inner key:executor__explain.t2.id2, equal cond:eq(executor__explain.t1.id2, executor__explain.t2.id2)
       │   │ ├─Projection(Build)	root		executor__explain.t1.id2
       │   │ │ └─IndexLookUp	root		
       │   │ │   ├─IndexRangeScan(Build)	cop[tikv]	table:rn, index:ix_id1(id1)	range:["03","03"], keep order:false, stats:pseudo
@@ -368,7 +368,7 @@ create table t (a int, b int, index (a));
 insert into t values (1, 1);
 explain analyze format='brief' select * from t t1, t t2 where t1.b = t2.a and t1.b = 2333;
 id	estRows	actRows	task	access object	execution info	operator info	memory	disk
-IndexHashJoin	12.50	0	root		<execution_info>	inner join, inner:IndexLookUp, outer key:executor__explain.t.b, inner key:executor__explain.t.a, equal cond:eq(executor__explain.t.b, executor__explain.t.a)	<memory>	<disk>
+IndexJoin	12.50	0	root		<execution_info>	inner join, inner:IndexLookUp, outer key:executor__explain.t.b, inner key:executor__explain.t.a, equal cond:eq(executor__explain.t.b, executor__explain.t.a)	<memory>	<disk>
 ├─TableReader(Build)	10.00	0	root		<execution_info>	data:Selection	<memory>	<disk>
 │ └─Selection	10.00	0	cop[tikv]		<execution_info>	eq(executor__explain.t.b, 2333)	<memory>	<disk>
 │   └─TableFullScan	10000.00	1	cop[tikv]	table:t1	<execution_info>	keep order:false, stats:pseudo	<memory>	<disk>

--- a/tests/integrationtest/r/globalindex/index_join.result
+++ b/tests/integrationtest/r/globalindex/index_join.result
@@ -79,7 +79,7 @@ analyze table t all columns;
 explain format='plan_tree' select * from p inner join t on p.id = t.id;
 id	task	access object	operator info
 Projection	root		globalindex__index_join.p.id, globalindex__index_join.p.c, globalindex__index_join.p.d, globalindex__index_join.p.e, globalindex__index_join.t.id, globalindex__index_join.t.c
-└─IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:globalindex__index_join.t.id, inner key:globalindex__index_join.p.id, equal cond:eq(globalindex__index_join.t.id, globalindex__index_join.p.id)
+└─IndexJoin	root		inner join, inner:IndexLookUp, outer key:globalindex__index_join.t.id, inner key:globalindex__index_join.p.id, equal cond:eq(globalindex__index_join.t.id, globalindex__index_join.p.id)
   ├─TableReader(Build)	root		data:Selection
   │ └─Selection	cop[tikv]		not(isnull(globalindex__index_join.t.id))
   │   └─TableFullScan	cop[tikv]	table:t	keep order:false
@@ -93,7 +93,7 @@ id	c	d	e	id	c
 explain format='plan_tree' select * from p inner join t on p.id = t.id;
 id	task	access object	operator info
 Projection	root		globalindex__index_join.p.id, globalindex__index_join.p.c, globalindex__index_join.p.d, globalindex__index_join.p.e, globalindex__index_join.t.id, globalindex__index_join.t.c
-└─IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:globalindex__index_join.t.id, inner key:globalindex__index_join.p.id, equal cond:eq(globalindex__index_join.t.id, globalindex__index_join.p.id)
+└─IndexJoin	root		inner join, inner:IndexLookUp, outer key:globalindex__index_join.t.id, inner key:globalindex__index_join.p.id, equal cond:eq(globalindex__index_join.t.id, globalindex__index_join.p.id)
   ├─TableReader(Build)	root		data:Selection
   │ └─Selection	cop[tikv]		not(isnull(globalindex__index_join.t.id))
   │   └─TableFullScan	cop[tikv]	table:t	keep order:false
@@ -108,7 +108,7 @@ id
 explain format='plan_tree' select * from p partition(p1) inner join t on p.id = t.id;
 id	task	access object	operator info
 Projection	root	NULL	globalindex__index_join.p.id, globalindex__index_join.p.c, globalindex__index_join.p.d, globalindex__index_join.p.e, globalindex__index_join.t.id, globalindex__index_join.t.c
-└─IndexHashJoin	root	NULL	inner join, inner:IndexLookUp, outer key:globalindex__index_join.t.id, inner key:globalindex__index_join.p.id, equal cond:eq(globalindex__index_join.t.id, globalindex__index_join.p.id)
+└─IndexJoin	root	NULL	inner join, inner:IndexLookUp, outer key:globalindex__index_join.t.id, inner key:globalindex__index_join.p.id, equal cond:eq(globalindex__index_join.t.id, globalindex__index_join.p.id)
   ├─TableReader(Build)	root	NULL	data:Selection
   │ └─Selection	cop[tikv]	NULL	not(isnull(globalindex__index_join.t.id))
   │   └─TableFullScan	cop[tikv]	table:t	keep order:false

--- a/tests/integrationtest/r/planner/core/casetest/integration.result
+++ b/tests/integrationtest/r/planner/core/casetest/integration.result
@@ -391,8 +391,8 @@ create table t2 (pk char(32) primary key nonclustered, col1 varchar(100));
 create table t3 (pk char(32) primary key nonclustered, keycol varchar(100), pad1 tinyint(1) default null, pad2 varchar(40), key (keycol,pad1,pad2));
 explain format='plan_tree' SELECT t1.pk FROM t1 INNER JOIN t2 ON t1.col1 = t2.pk INNER JOIN t3 ON t1.col3 = t3.pk WHERE t2.col1 IN ('a' , 'b') AND t3.keycol = 'c' AND t1.col2 = 'a' AND t1.col1 != 'abcdef' AND t1.col1 != 'aaaaaa';
 id	task	access object	operator info
-IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__integration.t1.col1, inner key:planner__core__casetest__integration.t2.pk, equal cond:eq(planner__core__casetest__integration.t1.col1, planner__core__casetest__integration.t2.pk)
-├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__integration.t3.pk, inner key:planner__core__casetest__integration.t1.col3, equal cond:eq(planner__core__casetest__integration.t3.pk, planner__core__casetest__integration.t1.col3)
+IndexJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__integration.t1.col1, inner key:planner__core__casetest__integration.t2.pk, equal cond:eq(planner__core__casetest__integration.t1.col1, planner__core__casetest__integration.t2.pk)
+├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__integration.t3.pk, inner key:planner__core__casetest__integration.t1.col3, equal cond:eq(planner__core__casetest__integration.t3.pk, planner__core__casetest__integration.t1.col3)
 │ ├─IndexLookUp(Build)	root		
 │ │ ├─IndexRangeScan(Build)	cop[tikv]	table:t3, index:keycol(keycol, pad1, pad2)	range:["c","c"], keep order:false, stats:pseudo
 │ │ └─TableRowIDScan(Probe)	cop[tikv]	table:t3	keep order:false, stats:pseudo
@@ -408,8 +408,8 @@ IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__case
     └─TableRowIDScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format='plan_tree' SELECT t1.pk FROM t1 LEFT JOIN t2 ON t1.col1 = t2.pk LEFT JOIN t3 ON t1.col3 = t3.pk WHERE t2.col1 IN ('a' , 'b') AND t3.keycol = 'c' AND t1.col2 = 'a' AND t1.col1 != 'abcdef' AND t1.col1 != 'aaaaaa';
 id	task	access object	operator info
-IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__integration.t1.col1, inner key:planner__core__casetest__integration.t2.pk, equal cond:eq(planner__core__casetest__integration.t1.col1, planner__core__casetest__integration.t2.pk)
-├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__integration.t3.pk, inner key:planner__core__casetest__integration.t1.col3, equal cond:eq(planner__core__casetest__integration.t3.pk, planner__core__casetest__integration.t1.col3)
+IndexJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__integration.t1.col1, inner key:planner__core__casetest__integration.t2.pk, equal cond:eq(planner__core__casetest__integration.t1.col1, planner__core__casetest__integration.t2.pk)
+├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__integration.t3.pk, inner key:planner__core__casetest__integration.t1.col3, equal cond:eq(planner__core__casetest__integration.t3.pk, planner__core__casetest__integration.t1.col3)
 │ ├─IndexLookUp(Build)	root		
 │ │ ├─IndexRangeScan(Build)	cop[tikv]	table:t3, index:keycol(keycol, pad1, pad2)	range:["c","c"], keep order:false, stats:pseudo
 │ │ └─TableRowIDScan(Probe)	cop[tikv]	table:t3	keep order:false, stats:pseudo

--- a/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
@@ -3395,7 +3395,7 @@ show warnings;
 Level	Code	Message
 explain format = 'plan_tree' SELECT ta.NAME,(SELECT sum(tb.CODE) FROM tb WHERE ta.id = tb.id) tb_sum_code FROM ta WHERE ta.NAME LIKE 'chad999%';
 id	task	access object	operator info
-IndexHashJoin	root		left outer join, inner:StreamAgg, left side:IndexLookUp, outer key:planner__core__casetest__physicalplantest__physical_plan.ta.id, inner key:planner__core__casetest__physicalplantest__physical_plan.tb.id, equal cond:eq(planner__core__casetest__physicalplantest__physical_plan.ta.id, planner__core__casetest__physicalplantest__physical_plan.tb.id)
+IndexJoin	root		left outer join, inner:StreamAgg, left side:IndexLookUp, outer key:planner__core__casetest__physicalplantest__physical_plan.ta.id, inner key:planner__core__casetest__physicalplantest__physical_plan.tb.id, equal cond:eq(planner__core__casetest__physicalplantest__physical_plan.ta.id, planner__core__casetest__physicalplantest__physical_plan.tb.id)
 ├─IndexLookUp(Build)	root		
 │ ├─Selection(Build)	cop[tikv]		like(planner__core__casetest__physicalplantest__physical_plan.ta.name, "chad999%", 92)
 │ │ └─IndexRangeScan	cop[tikv]	table:ta, index:idx_ta_name(name)	range:["chad999","chad99:"), keep order:false, stats:pseudo
@@ -3460,7 +3460,7 @@ Projection	root		planner__core__casetest__physicalplantest__physical_plan.ta.nam
   └─MaxOneRow(Probe)	root		
     └─StreamAgg	root		funcs:sum(Column)->Column
       └─Projection	root		cast(planner__core__casetest__physicalplantest__physical_plan.tb.code, decimal(10,0) BINARY)->Column
-        └─IndexHashJoin	root		semi join, inner:IndexLookUp, left side:IndexLookUp, outer key:planner__core__casetest__physicalplantest__physical_plan.tb.name, inner key:planner__core__casetest__physicalplantest__physical_plan.tc.name, equal cond:eq(planner__core__casetest__physicalplantest__physical_plan.tb.name, planner__core__casetest__physicalplantest__physical_plan.tc.name)
+        └─IndexJoin	root		semi join, inner:IndexLookUp, left side:IndexLookUp, outer key:planner__core__casetest__physicalplantest__physical_plan.tb.name, inner key:planner__core__casetest__physicalplantest__physical_plan.tc.name, equal cond:eq(planner__core__casetest__physicalplantest__physical_plan.tb.name, planner__core__casetest__physicalplantest__physical_plan.tc.name)
           ├─IndexLookUp(Build)	root		
           │ ├─IndexRangeScan(Build)	cop[tikv]	table:tb, index:idx_tb_id(id)	range: decided by [eq(planner__core__casetest__physicalplantest__physical_plan.ta.id, planner__core__casetest__physicalplantest__physical_plan.tb.id)], keep order:false, stats:pseudo
           │ └─Selection(Probe)	cop[tikv]		not(isnull(planner__core__casetest__physicalplantest__physical_plan.tb.name))
@@ -3594,7 +3594,7 @@ id	task	access object	operator info
 Projection	root		planner__core__casetest__physicalplantest__physical_plan.ta.name
 └─Apply	root		CARTESIAN inner join
   ├─Apply(Build)	root		CARTESIAN inner join
-  │ ├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__physicalplantest__physical_plan.tb.code, inner key:planner__core__casetest__physicalplantest__physical_plan.ta.code, equal cond:eq(planner__core__casetest__physicalplantest__physical_plan.tb.code, planner__core__casetest__physicalplantest__physical_plan.ta.code)
+  │ ├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__physicalplantest__physical_plan.tb.code, inner key:planner__core__casetest__physicalplantest__physical_plan.ta.code, equal cond:eq(planner__core__casetest__physicalplantest__physical_plan.tb.code, planner__core__casetest__physicalplantest__physical_plan.ta.code)
   │ │ ├─HashAgg(Build)	root		group by:planner__core__casetest__physicalplantest__physical_plan.tb.code, funcs:firstrow(planner__core__casetest__physicalplantest__physical_plan.tb.code)->planner__core__casetest__physicalplantest__physical_plan.tb.code
   │ │ │ └─TableReader	root		data:Selection
   │ │ │   └─Selection	cop[tikv]		like(planner__core__casetest__physicalplantest__physical_plan.tb.name, "chad9%", 92), not(isnull(planner__core__casetest__physicalplantest__physical_plan.tb.code))

--- a/tests/integrationtest/r/planner/core/casetest/rule/rule_join_reorder.result
+++ b/tests/integrationtest/r/planner/core/casetest/rule/rule_join_reorder.result
@@ -528,7 +528,7 @@ MergeJoin	root		inner join
   └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format='plan_tree' select /*+ no_hash_join(t1) */ * from t1, t2 where t1.a=t2.a;
 id	task	access object	operator info
-IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+IndexJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
 ├─TableReader(Build)	root		data:Selection
 │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a))
 │   └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
@@ -549,7 +549,7 @@ MergeJoin	root		inner join, left key:planner__core__casetest__rule__rule_join_re
       └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format='plan_tree' select /*+ no_hash_join(t1) */ * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
 id	task	access object	operator info
-IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a), eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t2.b)
+IndexJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a), eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t2.b)
 ├─TableReader(Build)	root		data:Selection
 │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a)), not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.b))
 │   └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
@@ -570,7 +570,7 @@ MergeJoin	root		left outer join, left side:Sort, left key:planner__core__casetes
     └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format='plan_tree' select /*+ no_hash_join(t2) */ * from t1 left join t2 on t1.a=t2.a;
 id	task	access object	operator info
-IndexHashJoin	root		left outer join, inner:IndexLookUp, left side:TableReader, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+IndexJoin	root		left outer join, inner:IndexLookUp, left side:TableReader, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
 ├─TableReader(Build)	root		data:TableFullScan
 │ └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
 └─IndexLookUp(Probe)	root		
@@ -589,7 +589,7 @@ MergeJoin	root		right outer join, left side:Sort, left key:planner__core__casete
     └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format='plan_tree' select /*+ no_hash_join(t2) */ * from t1 right join t2 on t1.a=t2.a;
 id	task	access object	operator info
-IndexHashJoin	root		right outer join, inner:IndexLookUp, left side:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t2.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+IndexJoin	root		right outer join, inner:IndexLookUp, left side:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t2.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
 ├─TableReader(Build)	root		data:TableFullScan
 │ └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
 └─IndexLookUp(Probe)	root		
@@ -4641,7 +4641,7 @@ id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, Column
 └─Apply	root		CARTESIAN left outer join, left side:StreamAgg
   ├─StreamAgg(Build)	root		funcs:min(planner__core__casetest__rule__rule_join_reorder.t1.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t1.a)->planner__core__casetest__rule__rule_join_reorder.t1.a
-  │ └─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+  │ └─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   │   ├─IndexReader(Build)	root		index:IndexFullScan
   │   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   │   └─IndexReader(Probe)	root		index:Selection
@@ -4750,7 +4750,7 @@ ScalarSubQuery	root		Output: ScalarQueryCol#11
 explain format='plan_tree' select /*+ straight_join() */ t1.a, (select min(t2.a) from t2) from t1 join t3 on t1.a = t3.a;
 id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, ScalarQueryCol#14(<nil>)->Column
-└─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+└─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   ├─IndexReader(Build)	root		index:IndexFullScan
   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   └─IndexReader(Probe)	root		index:Selection
@@ -5144,7 +5144,7 @@ id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, Column
 └─Apply	root		CARTESIAN left outer join, left side:StreamAgg
   ├─StreamAgg(Build)	root		funcs:min(planner__core__casetest__rule__rule_join_reorder.t1.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t1.a)->planner__core__casetest__rule__rule_join_reorder.t1.a
-  │ └─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+  │ └─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   │   ├─IndexReader(Build)	root		index:IndexFullScan
   │   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   │   └─IndexReader(Probe)	root		index:Selection
@@ -5160,7 +5160,7 @@ id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, Column
 └─Apply	root		CARTESIAN left outer join, left side:StreamAgg
   ├─StreamAgg(Build)	root		funcs:min(planner__core__casetest__rule__rule_join_reorder.t1.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t1.a)->planner__core__casetest__rule__rule_join_reorder.t1.a
-  │ └─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+  │ └─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   │   ├─IndexReader(Build)	root		index:IndexFullScan
   │   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   │   └─IndexReader(Probe)	root		index:Selection
@@ -5178,7 +5178,7 @@ id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, Column
 └─Apply	root		CARTESIAN left outer join, left side:StreamAgg
   ├─StreamAgg(Build)	root		funcs:min(planner__core__casetest__rule__rule_join_reorder.t1.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t1.a)->planner__core__casetest__rule__rule_join_reorder.t1.a
-  │ └─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+  │ └─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   │   ├─IndexReader(Build)	root		index:IndexFullScan
   │   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   │   └─IndexReader(Probe)	root		index:Selection
@@ -5196,7 +5196,7 @@ id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, Column
 └─Apply	root		CARTESIAN left outer join, left side:StreamAgg
   ├─StreamAgg(Build)	root		funcs:min(planner__core__casetest__rule__rule_join_reorder.t1.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t1.a)->planner__core__casetest__rule__rule_join_reorder.t1.a
-  │ └─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+  │ └─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   │   ├─IndexReader(Build)	root		index:IndexFullScan
   │   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   │   └─IndexReader(Probe)	root		index:Selection
@@ -5215,7 +5215,7 @@ id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, Column
 └─Apply	root		CARTESIAN left outer join, left side:StreamAgg
   ├─StreamAgg(Build)	root		funcs:min(planner__core__casetest__rule__rule_join_reorder.t1.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t1.a)->planner__core__casetest__rule__rule_join_reorder.t1.a
-  │ └─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+  │ └─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   │   ├─IndexReader(Build)	root		index:IndexFullScan
   │   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   │   └─IndexReader(Probe)	root		index:Selection
@@ -5233,7 +5233,7 @@ id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, Column
 └─Apply	root		CARTESIAN left outer join, left side:StreamAgg
   ├─StreamAgg(Build)	root		funcs:min(planner__core__casetest__rule__rule_join_reorder.t1.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t1.a)->planner__core__casetest__rule__rule_join_reorder.t1.a
-  │ └─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+  │ └─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   │   ├─IndexReader(Build)	root		index:IndexFullScan
   │   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   │   └─IndexReader(Probe)	root		index:Selection
@@ -5250,8 +5250,8 @@ Warning	1815	leading hint is inapplicable, check if the leading hint table is va
 explain format='plan_tree' select /*+ leading(t4, t3@sel_2) */ * from t1 join t2 on t1.a=t2.a join t4 on t1.b = t4.b where t1.a = (select max(t3.a) from t3 where t1.b = t3.b);
 id	task	access object	operator info
 HashJoin	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t4.b)]
-├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
-│ ├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:Column, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(Column, planner__core__casetest__rule__rule_join_reorder.t1.a), eq(planner__core__casetest__rule__rule_join_reorder.t3.b, planner__core__casetest__rule__rule_join_reorder.t1.b)
+├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+│ ├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:Column, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(Column, planner__core__casetest__rule__rule_join_reorder.t1.a), eq(planner__core__casetest__rule__rule_join_reorder.t3.b, planner__core__casetest__rule__rule_join_reorder.t1.b)
 │ │ ├─Selection(Build)	root		not(isnull(Column))
 │ │ │ └─HashAgg	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.b, funcs:max(planner__core__casetest__rule__rule_join_reorder.t3.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.b)->planner__core__casetest__rule__rule_join_reorder.t3.b
 │ │ │   └─TableReader	root		data:Selection
@@ -5275,7 +5275,7 @@ Warning	1815	leading hint is inapplicable, check if the leading hint table is va
 explain format='plan_tree' select /*+ leading(t4) */ * from t1 join t2 on t1.a=t2.a join t4 on t1.b = t4.b where t1.a = (select max(t3.a) from t3 where t1.b = t3.b);
 id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t2.b, planner__core__casetest__rule__rule_join_reorder.t4.a, planner__core__casetest__rule__rule_join_reorder.t4.b
-└─IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+└─IndexJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
   ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t3.b) eq(planner__core__casetest__rule__rule_join_reorder.t1.a, Column)]
   │ ├─Selection(Build)	root		not(isnull(Column))
   │ │ └─HashAgg	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.b, funcs:max(planner__core__casetest__rule__rule_join_reorder.t3.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.b)->planner__core__casetest__rule__rule_join_reorder.t3.b
@@ -5296,8 +5296,8 @@ Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner_
 explain format='plan_tree' select /*+ leading(t3@sel_2) */ * from t1 join t2 on t1.a=t2.a join t4 on t1.b = t4.b where t1.a = (select max(t3.a) from t3 where t1.b = t3.b);
 id	task	access object	operator info
 HashJoin	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t4.b)]
-├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
-│ ├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:Column, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(Column, planner__core__casetest__rule__rule_join_reorder.t1.a), eq(planner__core__casetest__rule__rule_join_reorder.t3.b, planner__core__casetest__rule__rule_join_reorder.t1.b)
+├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+│ ├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:Column, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(Column, planner__core__casetest__rule__rule_join_reorder.t1.a), eq(planner__core__casetest__rule__rule_join_reorder.t3.b, planner__core__casetest__rule__rule_join_reorder.t1.b)
 │ │ ├─Selection(Build)	root		not(isnull(Column))
 │ │ │ └─HashAgg	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.b, funcs:max(planner__core__casetest__rule__rule_join_reorder.t3.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.b)->planner__core__casetest__rule__rule_join_reorder.t3.b
 │ │ │   └─TableReader	root		data:Selection
@@ -5320,8 +5320,8 @@ Warning	1815	There are no matching table names for (t3) in optimizer hint /*+ LE
 explain format='plan_tree' select /*+ leading(t3@sel_2, t2) */ * from t1 join t2 on t1.a=t2.a join t4 on t1.b = t4.b where t1.a = (select max(t3.a) from t3 where t1.b = t3.b);
 id	task	access object	operator info
 HashJoin	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t4.b)]
-├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
-│ ├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:Column, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(Column, planner__core__casetest__rule__rule_join_reorder.t1.a), eq(planner__core__casetest__rule__rule_join_reorder.t3.b, planner__core__casetest__rule__rule_join_reorder.t1.b)
+├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+│ ├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:Column, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(Column, planner__core__casetest__rule__rule_join_reorder.t1.a), eq(planner__core__casetest__rule__rule_join_reorder.t3.b, planner__core__casetest__rule__rule_join_reorder.t1.b)
 │ │ ├─Selection(Build)	root		not(isnull(Column))
 │ │ │ └─HashAgg	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.b, funcs:max(planner__core__casetest__rule__rule_join_reorder.t3.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.b)->planner__core__casetest__rule__rule_join_reorder.t3.b
 │ │ │   └─TableReader	root		data:Selection
@@ -5345,7 +5345,7 @@ Warning	1815	leading hint is inapplicable, check if the leading hint table is va
 explain format='plan_tree' select /*+ leading(t4, t3@sel_2) */ * from t1 join t2 on t1.a=t2.a join t4 on t1.b = t4.b where t1.a > (select min(t3.a) from t3 where t1.b = t3.b);
 id	task	access object	operator info
 HashJoin	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t4.b)]
-├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
 │ ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t3.b, planner__core__casetest__rule__rule_join_reorder.t1.b)], other cond:gt(planner__core__casetest__rule__rule_join_reorder.t1.a, Column)
 │ │ ├─Selection(Build)	root		not(isnull(Column))
 │ │ │ └─HashAgg	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.b, funcs:min(planner__core__casetest__rule__rule_join_reorder.t3.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.b)->planner__core__casetest__rule__rule_join_reorder.t3.b
@@ -5368,7 +5368,7 @@ Warning	1815	leading hint is inapplicable, check if the leading hint table is va
 explain format='plan_tree' select /*+ leading(t4) */ * from t1 join t2 on t1.a=t2.a join t4 on t1.b = t4.b where t1.a > (select min(t3.a) from t3 where t1.b = t3.b);
 id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t2.b, planner__core__casetest__rule__rule_join_reorder.t4.a, planner__core__casetest__rule__rule_join_reorder.t4.b
-└─IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+└─IndexJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
   ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t3.b)], other cond:gt(planner__core__casetest__rule__rule_join_reorder.t1.a, Column)
   │ ├─Selection(Build)	root		not(isnull(Column))
   │ │ └─HashAgg	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.b, funcs:min(planner__core__casetest__rule__rule_join_reorder.t3.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.b)->planner__core__casetest__rule__rule_join_reorder.t3.b
@@ -5389,7 +5389,7 @@ Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner_
 explain format='plan_tree' select /*+ leading(t3@sel_2) */ * from t1 join t2 on t1.a=t2.a join t4 on t1.b = t4.b where t1.a > (select min(t3.a) from t3 where t1.b = t3.b);
 id	task	access object	operator info
 HashJoin	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t4.b)]
-├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
 │ ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t3.b, planner__core__casetest__rule__rule_join_reorder.t1.b)], other cond:gt(planner__core__casetest__rule__rule_join_reorder.t1.a, Column)
 │ │ ├─Selection(Build)	root		not(isnull(Column))
 │ │ │ └─HashAgg	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.b, funcs:min(planner__core__casetest__rule__rule_join_reorder.t3.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.b)->planner__core__casetest__rule__rule_join_reorder.t3.b
@@ -5411,7 +5411,7 @@ Warning	1815	There are no matching table names for (t3) in optimizer hint /*+ LE
 explain format='plan_tree' select /*+ leading(t3@sel_2, t2) */ * from t1 join t2 on t1.a=t2.a join t4 on t1.b = t4.b where t1.a > (select min(t3.a) from t3 where t1.b = t3.b);
 id	task	access object	operator info
 HashJoin	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t4.b)]
-├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
 │ ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t3.b, planner__core__casetest__rule__rule_join_reorder.t1.b)], other cond:gt(planner__core__casetest__rule__rule_join_reorder.t1.a, Column)
 │ │ ├─Selection(Build)	root		not(isnull(Column))
 │ │ │ └─HashAgg	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.b, funcs:min(planner__core__casetest__rule__rule_join_reorder.t3.a)->Column, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.b)->planner__core__casetest__rule__rule_join_reorder.t3.b
@@ -5434,7 +5434,7 @@ Warning	1815	leading hint is inapplicable, check if the leading hint table is va
 explain format='plan_tree' select /*+ leading(t4) */ * from t1 join t2 on t1.a=t2.a join t4 on t1.b = t4.b where t1.a in (select t3.a from t3);
 id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t2.b, planner__core__casetest__rule__rule_join_reorder.t4.a, planner__core__casetest__rule__rule_join_reorder.t4.b
-└─IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+└─IndexJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
   ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t3.a)]
   │ ├─StreamAgg(Build)	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.a)->planner__core__casetest__rule__rule_join_reorder.t3.a
   │ │ └─IndexReader	root		index:StreamAgg
@@ -5453,8 +5453,8 @@ Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner_
     └─TableRowIDScan(Probe)	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format='plan_tree' select /*+ leading(t3@sel_2) */ * from t1 join t2 on t1.a=t2.a where t1.a in (select t3.a from t3);
 id	task	access object	operator info
-IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
-├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+IndexJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
 │ ├─StreamAgg(Build)	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.a)->planner__core__casetest__rule__rule_join_reorder.t3.a
 │ │ └─IndexReader	root		index:StreamAgg
 │ │   └─StreamAgg	cop[tikv]		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, 
@@ -5484,8 +5484,8 @@ Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner_
         └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format='plan_tree' select /*+ leading(t1, t3@sel_2) */ * from t1 join t2 on t1.a=t2.a where t1.a in (select t3.a from t3);
 id	task	access object	operator info
-IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
-├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+IndexJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
 │ ├─StreamAgg(Build)	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.a)->planner__core__casetest__rule__rule_join_reorder.t3.a
 │ │ └─IndexReader	root		index:StreamAgg
 │ │   └─StreamAgg	cop[tikv]		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, 
@@ -5515,8 +5515,8 @@ Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner_
         └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format='plan_tree' select /*+ leading(t3@sel_2, t1) */ * from t1 join t2 on t1.a=t2.a where t1.a in (select t3.a from t3);
 id	task	access object	operator info
-IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
-├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+IndexJoin	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)
+├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
 │ ├─StreamAgg(Build)	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.a)->planner__core__casetest__rule__rule_join_reorder.t3.a
 │ │ └─IndexReader	root		index:StreamAgg
 │ │   └─StreamAgg	cop[tikv]		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, 
@@ -5806,7 +5806,7 @@ Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner_
 explain format='plan_tree' select /*+ leading(t1) */ t1.a, (select min(t2.a) from t2) from t1 join t3 on t1.a = t3.a;
 id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, ScalarQueryCol#14(<nil>)->Column
-└─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+└─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   ├─IndexReader(Build)	root		index:IndexFullScan
   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   └─IndexReader(Probe)	root		index:Selection
@@ -5822,7 +5822,7 @@ ScalarSubQuery	root		Output: ScalarQueryCol#14
 explain format='plan_tree' select /*+ leading(t1, t2@sel_2) */ t1.a, (select min(t2.a) from t2) from t1 join t3 on t1.a = t3.a;
 id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, ScalarQueryCol#14(<nil>)->Column
-└─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+└─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   ├─IndexReader(Build)	root		index:IndexFullScan
   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   └─IndexReader(Probe)	root		index:Selection
@@ -5841,7 +5841,7 @@ Warning	1815	leading hint is inapplicable, check if the leading hint table is va
 explain format='plan_tree' select /*+ leading(t1, t3) */ t1.a, (select min(t2.a) from t2) from t1 join t3 on t1.a = t3.a;
 id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, ScalarQueryCol#14(<nil>)->Column
-└─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+└─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   ├─IndexReader(Build)	root		index:IndexFullScan
   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   └─IndexReader(Probe)	root		index:Selection
@@ -5857,7 +5857,7 @@ ScalarSubQuery	root		Output: ScalarQueryCol#14
 explain format='plan_tree' select /*+ leading(t2@sel_2, t1) */ t1.a, (select min(t2.a) from t2) from t1 join t3 on t1.a = t3.a;
 id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, ScalarQueryCol#14(<nil>)->Column
-└─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+└─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   ├─IndexReader(Build)	root		index:IndexFullScan
   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   └─IndexReader(Probe)	root		index:Selection
@@ -5876,7 +5876,7 @@ Warning	1815	leading hint is inapplicable, check if the leading hint table is va
 explain format='plan_tree' select /*+ leading(t2@sel_2, t3) */ t1.a, (select min(t2.a) from t2) from t1 join t3 on t1.a = t3.a;
 id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, ScalarQueryCol#14(<nil>)->Column
-└─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+└─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   ├─IndexReader(Build)	root		index:IndexFullScan
   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   └─IndexReader(Probe)	root		index:Selection
@@ -5895,7 +5895,7 @@ Warning	1815	leading hint is inapplicable, check if the leading hint table is va
 explain format='plan_tree' select /*+ leading(t1, t2@sel_2) */ t1.a, (select min(t2.a) from t2) from t1 join t3 on t1.a = t3.a;
 id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, ScalarQueryCol#14(<nil>)->Column
-└─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+└─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   ├─IndexReader(Build)	root		index:IndexFullScan
   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   └─IndexReader(Probe)	root		index:Selection
@@ -5914,7 +5914,7 @@ Warning	1815	leading hint is inapplicable, check if the leading hint table is va
 explain format='plan_tree' select /*+ leading(t3, t2@sel_2) */ t1.a, (select min(t2.a) from t2) from t1 join t3 on t1.a = t3.a;
 id	task	access object	operator info
 Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, ScalarQueryCol#14(<nil>)->Column
-└─IndexHashJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
+└─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a, equal cond:eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)
   ├─IndexReader(Build)	root		index:IndexFullScan
   │ └─IndexFullScan	cop[tikv]	table:t3, index:a(a)	keep order:false
   └─IndexReader(Probe)	root		index:Selection

--- a/tests/integrationtest/r/planner/core/physical_plan.result
+++ b/tests/integrationtest/r/planner/core/physical_plan.result
@@ -2,7 +2,7 @@ drop table if exists t;
 create table t(a int, b int, c int, key(b), key(c));
 explain format='hint' select /*+ inl_merge_join(t2) */ * from t t1 inner join t t2 on t1.b = t2.b and t1.c = 1;
 hint
-inl_hash_join(`planner__core__physical_plan`.`t2`), use_index(@`sel_1` `planner__core__physical_plan`.`t1` `c`), no_order_index(@`sel_1` `planner__core__physical_plan`.`t1` `c`), use_index(@`sel_1` `planner__core__physical_plan`.`t2` `b`), no_order_index(@`sel_1` `planner__core__physical_plan`.`t2` `b`), inl_merge_join(`t2`)
+inl_join(`planner__core__physical_plan`.`t2`), use_index(@`sel_1` `planner__core__physical_plan`.`t1` `c`), no_order_index(@`sel_1` `planner__core__physical_plan`.`t1` `c`), use_index(@`sel_1` `planner__core__physical_plan`.`t2` `b`), no_order_index(@`sel_1` `planner__core__physical_plan`.`t2` `b`), inl_merge_join(`t2`)
 show warnings;
 Level	Code	Message
 Warning	1815	The INDEX MERGE JOIN hint is deprecated for usage, try other hints.

--- a/tests/integrationtest/r/planner/core/plan_cost_ver2.result
+++ b/tests/integrationtest/r/planner/core/plan_cost_ver2.result
@@ -212,7 +212,7 @@ select @@tidb_index_join_double_read_penalty_cost_rate;
 0
 explain format='verbose' select /*+ tidb_inlj(t1, t2) */ * from t1, t2 where t1.a=t2.a;
 id	estRows	estCost	task	access object	operator info
-IndexJoin_12	12487.50	5277413.38	root		inner join, inner:IndexReader_33, outer key:planner__core__plan_cost_ver2.t1.a, inner key:planner__core__plan_cost_ver2.t2.a, equal cond:eq(planner__core__plan_cost_ver2.t1.a, planner__core__plan_cost_ver2.t2.a)
+IndexJoin_12	12487.50	5402038.63	root		inner join, inner:IndexReader_33, outer key:planner__core__plan_cost_ver2.t1.a, inner key:planner__core__plan_cost_ver2.t2.a, equal cond:eq(planner__core__plan_cost_ver2.t1.a, planner__core__plan_cost_ver2.t2.a)
 ├─IndexReader_30(Build)	9990.00	150622.56	root		index:IndexFullScan_29
 │ └─IndexFullScan_29	9990.00	1626372.00	cop[tikv]	table:t1, index:a(a)	keep order:false, stats:pseudo
 └─IndexReader_33(Probe)	12487.50	23.02	root		index:Selection_32
@@ -221,7 +221,7 @@ IndexJoin_12	12487.50	5277413.38	root		inner join, inner:IndexReader_33, outer k
 set tidb_index_join_double_read_penalty_cost_rate=0.5;
 explain format='verbose' select /*+ tidb_inlj(t1, t2) */ * from t1, t2 where t1.a=t2.a;
 id	estRows	estCost	task	access object	operator info
-IndexJoin_12	12487.50	250791653.38	root		inner join, inner:IndexReader_33, outer key:planner__core__plan_cost_ver2.t1.a, inner key:planner__core__plan_cost_ver2.t2.a, equal cond:eq(planner__core__plan_cost_ver2.t1.a, planner__core__plan_cost_ver2.t2.a)
+IndexJoin_12	12487.50	250916278.63	root		inner join, inner:IndexReader_33, outer key:planner__core__plan_cost_ver2.t1.a, inner key:planner__core__plan_cost_ver2.t2.a, equal cond:eq(planner__core__plan_cost_ver2.t1.a, planner__core__plan_cost_ver2.t2.a)
 ├─IndexReader_30(Build)	9990.00	150622.56	root		index:IndexFullScan_29
 │ └─IndexFullScan_29	9990.00	1626372.00	cop[tikv]	table:t1, index:a(a)	keep order:false, stats:pseudo
 └─IndexReader_33(Probe)	12487.50	23.02	root		index:Selection_32
@@ -230,7 +230,7 @@ IndexJoin_12	12487.50	250791653.38	root		inner join, inner:IndexReader_33, outer
 set tidb_index_join_double_read_penalty_cost_rate=1;
 explain format='verbose' select /*+ tidb_inlj(t1, t2) */ * from t1, t2 where t1.a=t2.a;
 id	estRows	estCost	task	access object	operator info
-IndexJoin_12	12487.50	496305893.38	root		inner join, inner:IndexReader_33, outer key:planner__core__plan_cost_ver2.t1.a, inner key:planner__core__plan_cost_ver2.t2.a, equal cond:eq(planner__core__plan_cost_ver2.t1.a, planner__core__plan_cost_ver2.t2.a)
+IndexJoin_12	12487.50	496430518.63	root		inner join, inner:IndexReader_33, outer key:planner__core__plan_cost_ver2.t1.a, inner key:planner__core__plan_cost_ver2.t2.a, equal cond:eq(planner__core__plan_cost_ver2.t1.a, planner__core__plan_cost_ver2.t2.a)
 ├─IndexReader_30(Build)	9990.00	150622.56	root		index:IndexFullScan_29
 │ └─IndexFullScan_29	9990.00	1626372.00	cop[tikv]	table:t1, index:a(a)	keep order:false, stats:pseudo
 └─IndexReader_33(Probe)	12487.50	23.02	root		index:Selection_32

--- a/tests/integrationtest/r/planner/core/rule_join_reorder.result
+++ b/tests/integrationtest/r/planner/core/rule_join_reorder.result
@@ -37,8 +37,8 @@ id	task	access object	operator info
 Sort	root		planner__core__rule_join_reorder.queries_identifier.id
 └─Projection	root		planner__core__rule_join_reorder.queries_identifier.id, planner__core__rule_join_reorder.queries_identifier.name
   └─Selection	root		or(and(eq(planner__core__rule_join_reorder.queries_channel.id, 5), eq(planner__core__rule_join_reorder.queries_program.id, 9)), eq(planner__core__rule_join_reorder.queries_program.id, 8))
-    └─IndexJoin	root		left outer join, inner:IndexReader, left side:IndexHashJoin, outer key:planner__core__rule_join_reorder.queries_identifier.id, inner key:planner__core__rule_join_reorder.queries_channel.identifier_id, equal cond:eq(planner__core__rule_join_reorder.queries_identifier.id, planner__core__rule_join_reorder.queries_channel.identifier_id)
-      ├─IndexHashJoin(Build)	root		inner join, inner:TableReader, outer key:planner__core__rule_join_reorder.queries_program.identifier_id, inner key:planner__core__rule_join_reorder.queries_identifier.id, equal cond:eq(planner__core__rule_join_reorder.queries_program.identifier_id, planner__core__rule_join_reorder.queries_identifier.id)
+    └─IndexJoin	root		left outer join, inner:IndexReader, left side:IndexJoin, outer key:planner__core__rule_join_reorder.queries_identifier.id, inner key:planner__core__rule_join_reorder.queries_channel.identifier_id, equal cond:eq(planner__core__rule_join_reorder.queries_identifier.id, planner__core__rule_join_reorder.queries_channel.identifier_id)
+      ├─IndexJoin(Build)	root		inner join, inner:TableReader, outer key:planner__core__rule_join_reorder.queries_program.identifier_id, inner key:planner__core__rule_join_reorder.queries_identifier.id, equal cond:eq(planner__core__rule_join_reorder.queries_program.identifier_id, planner__core__rule_join_reorder.queries_identifier.id)
       │ ├─Batch_Point_Get(Build)	root	table:queries_program	handle:[8 9], keep order:false, desc:false
       │ └─TableReader(Probe)	root		data:TableRangeScan
       │   └─TableRangeScan	cop[tikv]	table:queries_identifier	range: decided by [planner__core__rule_join_reorder.queries_program.identifier_id], keep order:false, stats:pseudo

--- a/tests/integrationtest/r/tpch.result
+++ b/tests/integrationtest/r/tpch.result
@@ -247,7 +247,7 @@ Projection	root		tpch50.lineitem.l_orderkey, Column, tpch50.orders.o_orderdate, 
 └─TopN	root		Column:desc, tpch50.orders.o_orderdate, offset:0, count:10
   └─HashAgg	root		group by:Column, Column, Column, funcs:sum(Column)->Column, funcs:firstrow(Column)->tpch50.orders.o_orderdate, funcs:firstrow(Column)->tpch50.orders.o_shippriority, funcs:firstrow(Column)->tpch50.lineitem.l_orderkey
     └─Projection	root		mul(tpch50.lineitem.l_extendedprice, minus(1, tpch50.lineitem.l_discount))->Column, tpch50.orders.o_orderdate->Column, tpch50.orders.o_shippriority->Column, tpch50.lineitem.l_orderkey->Column
-      └─IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:tpch50.orders.o_orderkey, inner key:tpch50.lineitem.l_orderkey, equal cond:eq(tpch50.orders.o_orderkey, tpch50.lineitem.l_orderkey)
+      └─IndexJoin	root		inner join, inner:IndexLookUp, outer key:tpch50.orders.o_orderkey, inner key:tpch50.lineitem.l_orderkey, equal cond:eq(tpch50.orders.o_orderkey, tpch50.lineitem.l_orderkey)
         ├─HashJoin(Build)	root		inner join, equal:[eq(tpch50.customer.c_custkey, tpch50.orders.o_custkey)]
         │ ├─TableReader(Build)	root		data:Selection
         │ │ └─Selection	cop[tikv]		eq(tpch50.customer.c_mktsegment, "AUTOMOBILE")
@@ -292,7 +292,7 @@ id	task	access object	operator info
 Sort	root		tpch50.orders.o_orderpriority
 └─Projection	root		tpch50.orders.o_orderpriority, Column
   └─HashAgg	root		group by:tpch50.orders.o_orderpriority, funcs:count(1)->Column, funcs:firstrow(tpch50.orders.o_orderpriority)->tpch50.orders.o_orderpriority
-    └─IndexHashJoin	root		semi join, inner:IndexLookUp, left side:TableReader, outer key:tpch50.orders.o_orderkey, inner key:tpch50.lineitem.l_orderkey, equal cond:eq(tpch50.orders.o_orderkey, tpch50.lineitem.l_orderkey)
+    └─IndexJoin	root		semi join, inner:IndexLookUp, left side:TableReader, outer key:tpch50.orders.o_orderkey, inner key:tpch50.lineitem.l_orderkey, equal cond:eq(tpch50.orders.o_orderkey, tpch50.lineitem.l_orderkey)
       ├─TableReader(Build)	root		data:Selection
       │ └─Selection	cop[tikv]		ge(tpch50.orders.o_orderdate, 1995-01-01 00:00:00.000000), lt(tpch50.orders.o_orderdate, 1995-04-01 00:00:00.000000)
       │   └─TableFullScan	cop[tikv]	table:orders	keep order:false
@@ -660,7 +660,7 @@ Projection	root		tpch50.customer.c_custkey, tpch50.customer.c_name, Column, tpch
   └─HashAgg	root		group by:Column, Column, Column, Column, Column, Column, Column, funcs:sum(Column)->Column, funcs:firstrow(Column)->tpch50.customer.c_custkey, funcs:firstrow(Column)->tpch50.customer.c_name, funcs:firstrow(Column)->tpch50.customer.c_address, funcs:firstrow(Column)->tpch50.customer.c_phone, funcs:firstrow(Column)->tpch50.customer.c_acctbal, funcs:firstrow(Column)->tpch50.customer.c_comment, funcs:firstrow(Column)->tpch50.nation.n_name
     └─Projection	root		mul(tpch50.lineitem.l_extendedprice, minus(1, tpch50.lineitem.l_discount))->Column, tpch50.customer.c_custkey->Column, tpch50.customer.c_name->Column, tpch50.customer.c_address->Column, tpch50.customer.c_phone->Column, tpch50.customer.c_acctbal->Column, tpch50.customer.c_comment->Column, tpch50.nation.n_name->Column
       └─Projection	root		tpch50.customer.c_custkey, tpch50.customer.c_name, tpch50.customer.c_address, tpch50.customer.c_phone, tpch50.customer.c_acctbal, tpch50.customer.c_comment, tpch50.lineitem.l_extendedprice, tpch50.lineitem.l_discount, tpch50.nation.n_name
-        └─IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:tpch50.orders.o_orderkey, inner key:tpch50.lineitem.l_orderkey, equal cond:eq(tpch50.orders.o_orderkey, tpch50.lineitem.l_orderkey)
+        └─IndexJoin	root		inner join, inner:IndexLookUp, outer key:tpch50.orders.o_orderkey, inner key:tpch50.lineitem.l_orderkey, equal cond:eq(tpch50.orders.o_orderkey, tpch50.lineitem.l_orderkey)
           ├─HashJoin(Build)	root		inner join, equal:[eq(tpch50.customer.c_custkey, tpch50.orders.o_custkey)]
           │ ├─TableReader(Build)	root		data:Selection
           │ │ └─Selection	cop[tikv]		ge(tpch50.orders.o_orderdate, 1993-08-01 00:00:00.000000), lt(tpch50.orders.o_orderdate, 1993-11-01 00:00:00.000000)
@@ -936,7 +936,7 @@ Sort	root		Column:desc, tpch50.part.p_brand, tpch50.part.p_type, tpch50.part.p_s
       │ └─Selection	cop[tikv]		like(tpch50.supplier.s_comment, "%Customer%Complaints%", 92)
       │   └─TableFullScan	cop[tikv]	table:supplier	keep order:false
       └─Projection(Probe)	root		tpch50.partsupp.ps_suppkey, tpch50.part.p_brand, tpch50.part.p_type, tpch50.part.p_size
-        └─IndexHashJoin	root		inner join, inner:IndexReader, outer key:tpch50.part.p_partkey, inner key:tpch50.partsupp.ps_partkey, equal cond:eq(tpch50.part.p_partkey, tpch50.partsupp.ps_partkey)
+        └─IndexJoin	root		inner join, inner:IndexReader, outer key:tpch50.part.p_partkey, inner key:tpch50.partsupp.ps_partkey, equal cond:eq(tpch50.part.p_partkey, tpch50.partsupp.ps_partkey)
           ├─TableReader(Build)	root		data:Selection
           │ └─Selection	cop[tikv]		in(tpch50.part.p_size, 48, 19, 12, 4, 41, 7, 21, 39), ne(tpch50.part.p_brand, "Brand#34"), not(like(tpch50.part.p_type, "LARGE BRUSHED%", 92))
           │   └─TableFullScan	cop[tikv]	table:part	keep order:false
@@ -1030,7 +1030,7 @@ id	task	access object	operator info
 Projection	root		tpch50.customer.c_name, tpch50.customer.c_custkey, tpch50.orders.o_orderkey, tpch50.orders.o_orderdate, tpch50.orders.o_totalprice, Column
 └─TopN	root		tpch50.orders.o_totalprice:desc, tpch50.orders.o_orderdate, offset:0, count:100
   └─HashAgg	root		group by:tpch50.customer.c_custkey, tpch50.customer.c_name, tpch50.orders.o_orderdate, tpch50.orders.o_orderkey, tpch50.orders.o_totalprice, funcs:sum(tpch50.lineitem.l_quantity)->Column, funcs:firstrow(tpch50.customer.c_custkey)->tpch50.customer.c_custkey, funcs:firstrow(tpch50.customer.c_name)->tpch50.customer.c_name, funcs:firstrow(tpch50.orders.o_orderkey)->tpch50.orders.o_orderkey, funcs:firstrow(tpch50.orders.o_totalprice)->tpch50.orders.o_totalprice, funcs:firstrow(tpch50.orders.o_orderdate)->tpch50.orders.o_orderdate
-    └─IndexHashJoin	root		inner join, inner:IndexLookUp, outer key:tpch50.orders.o_orderkey, inner key:tpch50.lineitem.l_orderkey, equal cond:eq(tpch50.orders.o_orderkey, tpch50.lineitem.l_orderkey)
+    └─HashJoin	root		inner join, equal:[eq(tpch50.orders.o_orderkey, tpch50.lineitem.l_orderkey)]
       ├─HashJoin(Build)	root		inner join, equal:[eq(tpch50.orders.o_orderkey, tpch50.lineitem.l_orderkey)]
       │ ├─Selection(Build)	root		gt(Column, 314)
       │ │ └─HashAgg	root		group by:tpch50.lineitem.l_orderkey, funcs:sum(Column)->Column, funcs:firstrow(tpch50.lineitem.l_orderkey)->tpch50.lineitem.l_orderkey
@@ -1042,9 +1042,8 @@ Projection	root		tpch50.customer.c_name, tpch50.customer.c_custkey, tpch50.order
       │   │ └─TableFullScan	cop[tikv]	table:customer	keep order:false
       │   └─TableReader(Probe)	root		data:TableFullScan
       │     └─TableFullScan	cop[tikv]	table:orders	keep order:false
-      └─IndexLookUp(Probe)	root		
-        ├─IndexRangeScan(Build)	cop[tikv]	table:lineitem, index:PRIMARY(L_ORDERKEY, L_LINENUMBER)	range: decided by [eq(tpch50.lineitem.l_orderkey, tpch50.orders.o_orderkey)], keep order:false
-        └─TableRowIDScan(Probe)	cop[tikv]	table:lineitem	keep order:false
+      └─TableReader(Probe)	root		data:TableFullScan
+        └─TableFullScan	cop[tikv]	table:lineitem	keep order:false
 /*
 Q19 Discounted Revenue Query
 The Discounted Revenue Query reports the gross discounted revenue attributed to the sale of selected parts handled
@@ -1152,8 +1151,8 @@ Sort	root		tpch50.supplier.s_name
   ├─HashAgg(Build)	root		group by:tpch50.partsupp.ps_suppkey, funcs:firstrow(tpch50.partsupp.ps_suppkey)->tpch50.partsupp.ps_suppkey
   │ └─Selection	root		gt(cast(tpch50.partsupp.ps_availqty, decimal(10,0) BINARY), mul(0.5, Column))
   │   └─HashAgg	root		group by:tpch50.partsupp.ps_partkey, tpch50.partsupp.ps_suppkey, funcs:firstrow(tpch50.partsupp.ps_suppkey)->tpch50.partsupp.ps_suppkey, funcs:firstrow(tpch50.partsupp.ps_availqty)->tpch50.partsupp.ps_availqty, funcs:sum(tpch50.lineitem.l_quantity)->Column
-  │     └─HashJoin	root		left outer join, left side:IndexHashJoin, equal:[eq(tpch50.partsupp.ps_partkey, tpch50.lineitem.l_partkey) eq(tpch50.partsupp.ps_suppkey, tpch50.lineitem.l_suppkey)]
-  │       ├─IndexHashJoin(Build)	root		inner join, inner:IndexLookUp, outer key:tpch50.part.p_partkey, inner key:tpch50.partsupp.ps_partkey, equal cond:eq(tpch50.part.p_partkey, tpch50.partsupp.ps_partkey)
+  │     └─HashJoin	root		left outer join, left side:IndexJoin, equal:[eq(tpch50.partsupp.ps_partkey, tpch50.lineitem.l_partkey) eq(tpch50.partsupp.ps_suppkey, tpch50.lineitem.l_suppkey)]
+  │       ├─IndexJoin(Build)	root		inner join, inner:IndexLookUp, outer key:tpch50.part.p_partkey, inner key:tpch50.partsupp.ps_partkey, equal cond:eq(tpch50.part.p_partkey, tpch50.partsupp.ps_partkey)
   │       │ ├─TableReader(Build)	root		data:Selection
   │       │ │ └─Selection	cop[tikv]		like(tpch50.part.p_name, "green%", 92)
   │       │ │   └─TableFullScan	cop[tikv]	table:part	keep order:false
@@ -1221,8 +1220,8 @@ id	task	access object	operator info
 Projection	root		tpch50.supplier.s_name, Column
 └─TopN	root		Column:desc, tpch50.supplier.s_name, offset:0, count:100
   └─HashAgg	root		group by:tpch50.supplier.s_name, funcs:count(1)->Column, funcs:firstrow(tpch50.supplier.s_name)->tpch50.supplier.s_name
-    └─IndexHashJoin	root		anti semi join, inner:IndexLookUp, left side:IndexHashJoin, outer key:tpch50.lineitem.l_orderkey, inner key:tpch50.lineitem.l_orderkey, equal cond:eq(tpch50.lineitem.l_orderkey, tpch50.lineitem.l_orderkey), other cond:ne(tpch50.lineitem.l_suppkey, tpch50.lineitem.l_suppkey)
-      ├─IndexHashJoin(Build)	root		semi join, inner:IndexLookUp, left side:IndexJoin, outer key:tpch50.lineitem.l_orderkey, inner key:tpch50.lineitem.l_orderkey, equal cond:eq(tpch50.lineitem.l_orderkey, tpch50.lineitem.l_orderkey), other cond:ne(tpch50.lineitem.l_suppkey, tpch50.lineitem.l_suppkey)
+    └─IndexJoin	root		anti semi join, inner:IndexLookUp, left side:IndexJoin, outer key:tpch50.lineitem.l_orderkey, inner key:tpch50.lineitem.l_orderkey, equal cond:eq(tpch50.lineitem.l_orderkey, tpch50.lineitem.l_orderkey), other cond:ne(tpch50.lineitem.l_suppkey, tpch50.lineitem.l_suppkey)
+      ├─IndexJoin(Build)	root		semi join, inner:IndexLookUp, left side:IndexJoin, outer key:tpch50.lineitem.l_orderkey, inner key:tpch50.lineitem.l_orderkey, equal cond:eq(tpch50.lineitem.l_orderkey, tpch50.lineitem.l_orderkey), other cond:ne(tpch50.lineitem.l_suppkey, tpch50.lineitem.l_suppkey)
       │ ├─IndexJoin(Build)	root		inner join, inner:TableReader, outer key:tpch50.lineitem.l_orderkey, inner key:tpch50.orders.o_orderkey, equal cond:eq(tpch50.lineitem.l_orderkey, tpch50.orders.o_orderkey)
       │ │ ├─HashJoin(Build)	root		inner join, equal:[eq(tpch50.supplier.s_suppkey, tpch50.lineitem.l_suppkey)]
       │ │ │ ├─HashJoin(Build)	root		inner join, equal:[eq(tpch50.nation.n_nationkey, tpch50.supplier.s_nationkey)]


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/65556

Problem Summary:
- Cost Model v2 underestimates `IndexHashJoin`: the cost formula missed probe-side hash cost and could use incorrect join key count, leading to wrong plan preference.

### What changed and how does it work?
  - Fix cost model v2 for index-join family in `pkg/planner/core/plan_cost_ver2.go:getIndexJoinCostVer24PhysicalIndexJoin`:
    - Map build/probe filters by `InnerChildIdx` (Left/RightConditions are bound to physical child order, not outer/inner).
    - For `IndexHashJoin`, add missing probe-side hash cost (`hashProbeCostVer2(probeRowsTot, ...)`) so the formula scales with total fetched inner rows; This is critical when probeRowsTot is large (e.g., due to low index selectivity or partial index matching), where the probe CPU cost dominates the execution.
    - Use `OuterHashKeys/InnerHashKeys` (the execution-time hash key set) to count hash key columns, and add `intest.Assert` invariants (non-empty, aligned, join keys are prefixes) to avoid silently underestimating as `hashkey(*0*)`.
    - For `IndexJoin`, fix hash key count source to use `InnerHashKeys` to prevent `hashkey(*0*)` underestimation, but do not add a separate `hashprobe` term in this PR: IndexJoin probes the lookup map with outer rows (often much smaller than `probeRowsTot`) and uses pre-encoded keys; modeling its probe/join CPU precisely (and placing it outside the inner-worker concurrency division) needs separate calibration and could have broader impact. This may still leave some bias in extreme large-outer cases.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
