### PR TITLE
store/helper: use hex encoding for region key in log

### DIFF
--- a/pkg/store/helper/BUILD.bazel
+++ b/pkg/store/helper/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/codec",
         "//pkg/util/logutil",
+        "//pkg/util/redact",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_kvproto//pkg/deadlock",
         "@com_github_pingcap_kvproto//pkg/kvrpcpb",

--- a/pkg/store/helper/helper.go
+++ b/pkg/store/helper/helper.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/pingcap/tidb/pkg/util/redact"
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/tikvrpc"
@@ -523,7 +524,7 @@ func NewFrameItemFromRegionKey(key []byte) (frame *FrameItem, err error) {
 		} else {
 			_, _, frame.IndexValues, err = tablecodec.DecodeIndexKey(key)
 		}
-		logutil.BgLogger().Warn("decode region key failed", zap.String("key", hex.EncodeToString(key)), zap.Error(err))
+		logutil.BgLogger().Warn("decode region key failed", zap.String("key", redact.Key(key)), zap.Error(err))
 		// Ignore decode errors.
 		err = nil
 		return


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #65357

Problem Summary: When logging a failed region key decode in `NewFrameItemFromRegionKey`, `zap.ByteString` is used which assumes valid UTF-8. Non-UTF8 binary keys get displayed with Unicode replacement characters (`\uFFFD`), making logs unhelpful for debugging.

### What changed and how does it work?

Use `hex.EncodeToString` instead of `zap.ByteString` to display the region key in hex format, which properly represents all binary data.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > - [x] This is a logging format change only, no functional behavior change

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
