### PR TITLE
planner: switch to RWLock to improve binding cache performance

### DIFF
--- a/pkg/bindinfo/binding_cache_test.go
+++ b/pkg/bindinfo/binding_cache_test.go
@@ -159,33 +159,3 @@ func TestBindCache(t *testing.T) {
 	result = bindCache.get(bigBindCacheKey)
 	require.Nil(t, result)
 }
-
-// BenchmarkBindingCacheConcurrentReads benchmarks concurrent read performance of bindingCache.
-// This is mainly to cover the change in https://github.com/pingcap/tidb/issues/65412:
-// switching bindingCache from Mutex to RWMutex so multiple sessions can read concurrently.
-func BenchmarkBindingCacheConcurrentReads(b *testing.B) {
-	variable.MemQuotaBindingCache.Store(100000)
-	bindCache := newBindCache().(*bindingCache)
-
-	const numBindings = 256
-	for i := 0; i < numBindings; i++ {
-		sqlDigest := "digest_" + strconv.Itoa(i)
-		bindings := []Binding{{
-			OriginalSQL: "SELECT * FROM t" + strconv.Itoa(i),
-			SQLDigest:   sqlDigest,
-			BindSQL:     "SELECT * FROM t" + strconv.Itoa(i),
-		}}
-		_ = bindCache.SetBinding(sqlDigest, bindings)
-	}
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		i := 0
-		for pb.Next() {
-			sqlDigest := "digest_" + strconv.Itoa(i&(numBindings-1))
-			i++
-			_ = bindCache.GetBinding(sqlDigest)
-			_ = bindCache.Size()
-		}
-	})
-}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65412

Problem Summary: planner: switch to RWLock to improve binding cache performance

bindingCache.GetBinding and other read paths used a sync.Mutex, so concurrent sessions serialized on the cache lock, showing up as heavy Lock/Unlock time in mutex profiles (see #65412).
Solution:
Use sync.RWMutex for bindingCache and convert read-only operations (GetBinding, GetAllBindings, Size, GetMemUsage, GetMemCapacity) to RLock/RUnlock while keeping mutating operations under Lock/Unlock.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
