### PR TITLE
executor/test: fix flaky test TestIssue48756

### DIFF
--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -4821,7 +4821,9 @@ func isDuration(str string) bool {
 
 // strDatetimeAddDuration adds duration to datetime string, returns a string value.
 func strDatetimeAddDuration(tc types.Context, d string, arg1 types.Duration) (result string, isNull bool, err error) {
-	arg0, err := types.ParseTime(tc, d, mysql.TypeDatetime, types.MaxFsp)
+	// Clone to avoid retaining chunk buffer-backed strings in warning errors.
+	safeD := strings.Clone(d)
+	arg0, err := types.ParseTime(tc, safeD, mysql.TypeDatetime, types.MaxFsp)
 	if err != nil {
 		// Return a warning regardless of the sql_mode, this is compatible with MySQL.
 		tc.AppendWarning(err)
@@ -4858,7 +4860,9 @@ func strDurationAddDuration(tc types.Context, d string, arg1 types.Duration) (st
 
 // strDatetimeSubDuration subtracts duration from datetime string, returns a string value.
 func strDatetimeSubDuration(tc types.Context, d string, arg1 types.Duration) (result string, isNull bool, err error) {
-	arg0, err := types.ParseTime(tc, d, mysql.TypeDatetime, types.MaxFsp)
+	// Clone to avoid retaining chunk buffer-backed strings in warning errors.
+	safeD := strings.Clone(d)
+	arg0, err := types.ParseTime(tc, safeD, mysql.TypeDatetime, types.MaxFsp)
 	if err != nil {
 		// Return a warning regardless of the sql_mode, this is compatible with MySQL.
 		tc.AppendWarning(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65231

Problem Summary:

### What changed and how does it work?

In `strDatetimeAddDuration` and `strDatetimeSubDuration`, the input datetime string is now cloned before parsing. This ensures any warning error constructed on parse failure captures a stable copy of the value rather than a chunk-backed buffer that may be reused/overwritten during vectorized execution(see https://github.com/pingcap/tidb/issues/65231#issuecomment-3701220469). 

The change prevents warning messages from mutating across rows, fixing the flakiness in `TestIssue48756`.

(I don't think this is the 'perfect' way to fix this issue, but for now, there's no better option in my mind; suggestions are welcome.).

I ran ~30 times before/after this commit with a 100% CPU usage on my laptop:

* Before this PR, 18 loops failed (60% failure rate).
* After this PR, they all passed.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test(`TestIssue48756`)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- None

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
