### PR TITLE
statistics: persist stats delta init time

### DIFF
--- a/pkg/dxf/importinto/scheduler.go
+++ b/pkg/dxf/importinto/scheduler.go
@@ -660,7 +660,6 @@ func (sch *importScheduler) finishJob(ctx context.Context, logger *zap.Logger,
 			Delta:    taskMeta.Summary.ImportedRows,
 			Count:    taskMeta.Summary.ImportedRows,
 			InitTime: time.Now(),
-			TableID:  taskMeta.Plan.TableInfo.ID,
 		},
 		TableID: taskMeta.Plan.TableInfo.ID,
 	}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -969,9 +969,9 @@ func addTableNameInTableIDField(ctx context.Context, tableIDField any, is infosc
 func (s *session) updateStatsDeltaToCollector() {
 	mapper := s.GetSessionVars().TxnCtx.TableDeltaMap
 	if s.statsCollector != nil && mapper != nil {
-		for _, item := range mapper {
-			if item.TableID > 0 {
-				s.statsCollector.Update(item.TableID, item.Delta, item.Count)
+		for tableID, item := range mapper {
+			if tableID > 0 {
+				s.statsCollector.Update(tableID, item.Delta, item.Count)
 			}
 		}
 	}

--- a/pkg/sessionctx/variable/tests/session_test.go
+++ b/pkg/sessionctx/variable/tests/session_test.go
@@ -454,7 +454,6 @@ func TestTableDeltaClone(t *testing.T) {
 		Delta:    1,
 		Count:    2,
 		InitTime: time.Now(),
-		TableID:  5,
 	}
 	td1 := td0.Clone()
 	require.Equal(t, td0, td1)
@@ -473,7 +472,6 @@ func TestTransactionContextSavepoint(t *testing.T) {
 					Delta:    1,
 					Count:    2,
 					InitTime: time.Now(),
-					TableID:  5,
 				},
 			},
 		},
@@ -494,7 +492,6 @@ func TestTransactionContextSavepoint(t *testing.T) {
 		Delta:    6,
 		Count:    7,
 		InitTime: time.Now(),
-		TableID:  9,
 	}
 	tc.SetPessimisticLockCache([]byte{'b'}, []byte{'b'})
 	tc.FlushStmtPessimisticLockCache()
@@ -510,7 +507,6 @@ func TestTransactionContextSavepoint(t *testing.T) {
 		Delta:    10,
 		Count:    11,
 		InitTime: time.Now(),
-		TableID:  13,
 	}
 	tc.SetPessimisticLockCache([]byte{'c'}, []byte{'c'})
 	tc.FlushStmtPessimisticLockCache()

--- a/pkg/statistics/handle/usage/BUILD.bazel
+++ b/pkg/statistics/handle/usage/BUILD.bazel
@@ -37,14 +37,15 @@ go_test(
     name = "usage_test",
     timeout = "short",
     srcs = [
+        "export_test.go",
         "index_usage_integration_test.go",
         "predicate_column_test.go",
         "session_stats_collect_test.go",
     ],
+    embed = [":usage"],
     flaky = True,
-    shard_count = 13,
+    shard_count = 15,
     deps = [
-        ":usage",
         "//pkg/meta/model",
         "//pkg/parser/ast",
         "//pkg/statistics/handle/usage/indexusage",

--- a/pkg/statistics/handle/usage/export_test.go
+++ b/pkg/statistics/handle/usage/export_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package usage
+
+import "time"
+
+// GetDumpStatsMaxDurationForTest exposes dumpStatsMaxDuration for tests.
+func GetDumpStatsMaxDurationForTest() time.Duration {
+	return dumpStatsMaxDuration
+}
+
+// SetDumpStatsMaxDurationForTest updates dumpStatsMaxDuration for tests.
+func SetDumpStatsMaxDurationForTest(d time.Duration) {
+	dumpStatsMaxDuration = d
+}

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -586,6 +586,7 @@ func (m *TableDelta) GetDeltaAndReset() map[int64]variable.TableDelta {
 
 // Update updates the delta of the table.
 func (m *TableDelta) Update(id int64, delta int64, count int64) {
+	intest.Assert(id > 0, "table ID should be greater than 0")
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	item := m.delta[id]

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -76,6 +76,7 @@ func (s *statsUsageImpl) needDumpStatsDelta(is infoschema.InfoSchema, dumpAll bo
 	if dumpAll {
 		return true
 	}
+	intest.Assert(!item.InitTime.IsZero(), "InitTime should be initialized before evaluating dump conditions")
 	if currentTime.Sub(item.InitTime) > dumpStatsMaxDuration {
 		// Dump the stats to kv at least once 5 minutes.
 		return true

--- a/pkg/table/tblsession/table_test.go
+++ b/pkg/table/tblsession/table_test.go
@@ -107,7 +107,6 @@ func TestSessionMutateContextFields(t *testing.T) {
 	)
 	require.Equal(t, 1, len(txnCtx.TableDeltaMap))
 	deltaMap := txnCtx.TableDeltaMap[12]
-	require.Equal(t, int64(12), deltaMap.TableID)
 	require.Equal(t, int64(1), deltaMap.Delta)
 	require.Equal(t, int64(2), deltaMap.Count)
 	// cached table support


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65426

Problem Summary:
- Small post-ANALYZE modifications could stay unflushed because delta InitTime wasn't persisted, so the time-based dump never triggered.

### What changed and how does it work?
- Persist TableDelta.InitTime across sweeps and write it back when deciding to skip a dump.
- Add some regression tests and test-only accessors for the dump duration threshold.
- Removed the unnecessary table ID field, as we do not use it in any meaningful way.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix stats delta flushing after small modifications by persisting delta init time for time-based dumps.
```
