### PR TITLE
config: fix UpdateGlobal function comment

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1480,7 +1480,7 @@ func (c *Config) Valid() error {
 	return l.UnmarshalText([]byte(c.Log.Level))
 }
 
-// UpdateGlobal updates the global config, and provide a restore function that can be used to restore to the original.
+// UpdateGlobal updates the global config.
 func UpdateGlobal(f func(conf *Config)) {
 	g := GetGlobalConfig()
 	newConf := *g


### PR DESCRIPTION
## Description

Fix the incorrect comment for `UpdateGlobal` function in `pkg/config/config.go`. The comment incorrectly stated that `UpdateGlobal` "provide a restore function that can be used to restore to the original", but the function doesn't return anything. The restore functionality is provided by the separate `RestoreFunc()` function.

## Changes

- Updated the comment for `UpdateGlobal` to accurately describe what the function does.

Issue Number: close #61311

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=146701565