### PR TITLE
pkg/ddl: loose the pre-check for temporary table.

### DIFF
--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -1261,8 +1261,11 @@ func BuildTableInfoWithLike(ident ast.Ident, referTblInfo *model.TableInfo, s *a
 	tblInfo.AutoIncID = 0
 	tblInfo.ForeignKeys = nil
 	tblInfo.TableCacheStatusType = model.TableCacheStatusDisable
-	// Ignore TiFlash replicas for temporary tables.
 	if s.TemporaryKeyword != ast.TemporaryNone {
+		// Ignore TiFlash replicas, shard_row_id_bits and pre_split_regions for temporary tables.
+		tblInfo.ShardRowIDBits = 0
+		tblInfo.MaxShardRowIDBits = 0
+		tblInfo.PreSplitRegions = 0
 		tblInfo.TiFlashReplica = nil
 	} else if tblInfo.TiFlashReplica != nil {
 		replica := *tblInfo.TiFlashReplica

--- a/pkg/ddl/tests/serial/serial_test.go
+++ b/pkg/ddl/tests/serial/serial_test.go
@@ -373,14 +373,18 @@ func TestCreateTableWithLikeAtTemporaryMode(t *testing.T) {
 
 	tk.MustExec("drop table if exists table_pre_split, tmp_pre_split")
 	tk.MustExec("create table table_pre_split(id int) shard_row_id_bits=2 pre_split_regions=2")
-	err = tk.ExecToErr("create temporary table tmp_pre_split like table_pre_split")
-	require.Equal(t, plannererrors.ErrOptOnTemporaryTable.GenWithStackByArgs("pre split regions").Error(), err.Error())
+	tk.MustExec("create temporary table tmp_pre_split like table_pre_split")
+	tk.MustQuery("show create table tmp_pre_split").Check(testkit.Rows("tmp_pre_split CREATE TEMPORARY TABLE `tmp_pre_split` (\n" +
+		"  `id` int(11) DEFAULT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
 	defer tk.MustExec("drop table if exists table_pre_split, tmp_pre_split")
 
 	tk.MustExec("drop table if exists table_shard_row_id, tmp_shard_row_id")
 	tk.MustExec("create table table_shard_row_id(id int) shard_row_id_bits=2")
-	err = tk.ExecToErr("create temporary table tmp_shard_row_id like table_shard_row_id")
-	require.Equal(t, plannererrors.ErrOptOnTemporaryTable.GenWithStackByArgs("shard_row_id_bits").Error(), err.Error())
+	tk.MustExec("create temporary table tmp_shard_row_id like table_shard_row_id")
+	tk.MustQuery("show create table tmp_shard_row_id").Check(testkit.Rows("tmp_shard_row_id CREATE TEMPORARY TABLE `tmp_shard_row_id` (\n" +
+		"  `id` int(11) DEFAULT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
 	defer tk.MustExec("drop table if exists table_shard_row_id, tmp_shard_row_id")
 
 	tk.MustExec("drop table if exists partition_table, tmp_partition_table")

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -1512,17 +1512,12 @@ func checkTableEngine(engineName string) error {
 }
 
 func checkReferInfoForTemporaryTable(tableMetaInfo *model.TableInfo) error {
+	// We allow PreSplitRegions and ShardRowIdBits for temp table by ignoring them.
 	if tableMetaInfo.AutoRandomBits != 0 {
 		return plannererrors.ErrOptOnTemporaryTable.GenWithStackByArgs("auto_random")
 	}
-	if tableMetaInfo.PreSplitRegions != 0 {
-		return plannererrors.ErrOptOnTemporaryTable.GenWithStackByArgs("pre split regions")
-	}
 	if tableMetaInfo.Partition != nil {
 		return plannererrors.ErrPartitionNoTemporary
-	}
-	if tableMetaInfo.ShardRowIDBits != 0 {
-		return plannererrors.ErrOptOnTemporaryTable.GenWithStackByArgs("shard_row_id_bits")
 	}
 	if tableMetaInfo.PlacementPolicyRef != nil {
 		return plannererrors.ErrOptOnTemporaryTable.GenWithStackByArgs("placement")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65430

Problem Summary: The current behavior(reporting errors with those attributes) is actually [by-design](https://github.com/pingcap/tidb/blob/master/docs/design/2021-04-20-temporary-table.md), but now we think it's meaningful to create a temporary table for tables with `SHARD_ROW_ID_BITS` and `PRE_SPLIT_REGIONS`, as long as we ignore those 2 attributes for the temporary table.

### What changed and how does it work?

Allow `CREATE TEMPORARY TABLE ... LIKE` to ignore `SHARD_ROW_ID_BITS` and `PRE_SPLIT_REGIONS` inherited from the source table. The preprocessor no longer rejects temp table creation when the referenced table uses sharding bits, and the table-info clone clears shard/pre-split settings for temporary tables. 

Updated serial DDL tests to expect success and verify `SHOW CREATE TABLE` for the temporary table omits these options.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- NA

Documentation

- [x] We need to update our [user manual doc](https://docs.pingcap.com/tidb/stable/temporary-tables/) by removing the limitations for those 2 attributes(https://github.com/pingcap/docs/pull/22334).

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
DDL: `CREATE TEMPORARY TABLE ... LIKE` now ignores `SHARD_ROW_ID_BITS` and `PRE_SPLIT_REGIONS` from the source table, allowing temporary tables to be created successfully.
```
