### PR TITLE
conn: fix the issue that the connection count for resource group is not correctly tracked for `ComUserChange` and `ComReset`

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -177,6 +177,7 @@ go_test(
         "//pkg/parser/mysql",
         "//pkg/parser/terror",
         "//pkg/planner/core/resolve",
+        "//pkg/resourcegroup",
         "//pkg/server/internal",
         "//pkg/server/internal/column",
         "//pkg/server/internal/handshake",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63294 

Problem Summary:

If the user used `ComUserChange` or `ComReset`, the connection count of resource group will not be correctly recorded.

### What changed and how does it work?

Add some logic to track the change of resource group for `ComUserChange` and `ComReset` command.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
