### PR TITLE
planner: fix flaky tests in instanceplancache package

### DIFF
--- a/pkg/planner/core/casetest/instanceplancache/main_test.go
+++ b/pkg/planner/core/casetest/instanceplancache/main_test.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	typeInt      = "int"
-	typeVarchar  = "varchar(255)"
+	typeVarchar  = "varchar(128)"
 	typeFloat    = "float"
 	typeDouble   = "double"
 	typeDecimal  = "decimal(10,2)"


### PR DESCRIPTION
Issue Number: close #64604, #57514

Problem Summary:

### What changed and how does it work?

This commit fixes two sources of flakiness in the instanceplancache test package:

1. TestInstancePlanCache - "key too long" error

   The test randomly generates table schemas with indexes that can include multiple varchar columns. With varchar(255) and UTF8MB4 encoding (4 bytes per char), a single column requires 1020 bytes in an index. When 3+ varchar columns were randomly selected for an index, the total key length exceeded the 3072-byte limit.

   Fix: Reduce varchar(255) to varchar(128). This ensures even the worst case (6 varchar columns in one index) stays within the limit: 6 * 128 * 4 = 3072 bytes.

2. TestInstancePlanCacheConcurrencySysbench - deadlock error

   The test generates DML statements sequentially then randomly distributes them to concurrent workers. Two DMLs targeting the same row ID can be assigned to different workers, causing:
   - Worker A: locks row X in normal.sbtest, waits for prepared.sbtest
   - Worker B: locks row X in prepared.sbtest, waits for normal.sbtest

   This is a classic deadlock scenario that's expected in concurrent
   DML workloads. The test's purpose is to verify the instance plan
   cache works correctly, not to test deadlock-free DML patterns.

   Fix: Handle deadlock errors gracefully by skipping the affected
   DML statement rather than failing the test.



### Check List

Tests 

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note


```release-note
None
```
