### PR TITLE
test: stabilize `TestStalenessAndHistoryRead`

### DIFF
--- a/tests/realtikvtest/txntest/stale_read_test.go
+++ b/tests/realtikvtest/txntest/stale_read_test.go
@@ -395,14 +395,34 @@ func TestStalenessAndHistoryRead(t *testing.T) {
 	ON DUPLICATE KEY
 	UPDATE variable_value = '%[2]s', comment = '%[3]s'`, safePointName, safePointValue, safePointComment)
 	tk.MustExec(updateSafePoint)
-	time1 := time.Now()
+	getCurrentTS := func() uint64 {
+		tk.MustExec("begin")
+		tsStr := tk.MustQuery("select @@tidb_current_ts").Rows()[0][0].(string)
+		tk.MustExec("rollback")
+		ts, err := strconv.ParseUint(tsStr, 10, 64)
+		require.NoError(t, err)
+		return ts
+	}
+	waitTSAfter := func(after time.Time) time.Time {
+		for {
+			ts := getCurrentTS()
+			tsTime := oracle.GetTimeFromTS(ts)
+			if tsTime.After(after) {
+				return tsTime
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	time1 := oracle.GetTimeFromTS(getCurrentTS())
 	time1TS := oracle.GoTimeToTS(time1)
 	schemaVer1 := tk.Session().GetInfoSchema().SchemaMetaVersion()
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (id int primary key);")
 	tk.MustExec(`drop table if exists t`)
-	time.Sleep(1000 * time.Millisecond)
-	time2 := time.Now().Add(-500 * time.Millisecond)
+	lastCommitTSStr := tk.MustQuery("select json_extract(@@tidb_last_txn_info, '$.commit_ts')").Rows()[0][0].(string)
+	lastCommitTS, err := strconv.ParseUint(lastCommitTSStr, 10, 64)
+	require.NoError(t, err)
+	time2 := waitTSAfter(oracle.GetTimeFromTS(lastCommitTS))
 	time2TS := oracle.GoTimeToTS(time2)
 	schemaVer2 := tk.Session().GetInfoSchema().SchemaMetaVersion()
 
@@ -450,7 +470,7 @@ func TestStalenessAndHistoryRead(t *testing.T) {
 	require.Equal(t, time2TS, tk.Session().GetSessionVars().TxnCtx.StartTS)
 	require.Nil(t, tk.Session().GetSessionVars().SnapshotInfoschema)
 	require.Equal(t, schemaVer2, tk.Session().GetInfoSchema().SchemaMetaVersion())
-	err := tk.ExecToErr(`set @@tidb_snapshot="2020-10-08 16:45:26";`)
+	err = tk.ExecToErr(`set @@tidb_snapshot="2020-10-08 16:45:26";`)
 	require.Regexp(t, ".*Transaction characteristics can't be changed while a transaction is in progress", err.Error())
 	require.Equal(t, uint64(0), tk.Session().GetSessionVars().SnapshotTS)
 	require.Nil(t, tk.Session().GetSessionVars().SnapshotInfoschema)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65621

Problem Summary: 

Fix flaky `TestStalenessAndHistoryRead` by eliminating reliance on local wall-clock time when asserting snapshot schema versions.

### What changed and how does it work?

- Use PD TSO-driven timestamps (via `@@tidb_current_ts` and last commit TS) and wait for a TSO strictly after the DDL commit before asserting snapshot schema versions, removing clock-skew and same-millisecond races.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] Test-only change; not run locally (CI will cover).

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```