### PR TITLE
planner: support VALUES statement

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -2686,6 +2686,11 @@ error = '''
 Variable '%s' might not be affected by SET_VAR hint.
 '''
 
+["planner:3942"]
+error = '''
+Each row of a VALUES clause must have at least one column, unless when used as source in an INSERT statement.
+'''
+
 ["planner:8006"]
 error = '''
 `%s` is unsupported on temporary tables.

--- a/pkg/errno/errcode.go
+++ b/pkg/errno/errcode.go
@@ -939,6 +939,7 @@ const (
 	ErrFunctionalIndexNotApplicable                          = 3909
 	ErrDynamicPrivilegeNotRegistered                         = 3929
 	ErrConstraintNotFound                                    = 3940
+	ErrValuesClauseNoColumns                                 = 3942
 	ErUserAccessDeniedForUserAccountBlockedByPasswordLock    = 3955
 	ErrDependentByCheckConstraint                            = 3959
 	ErrEngineAttributeNotSupported                           = 3981

--- a/pkg/errno/errname.go
+++ b/pkg/errno/errname.go
@@ -942,6 +942,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrCTEMaxRecursionDepth:                                  mysql.Message("Recursive query aborted after %d iterations. Try increasing @@cte_max_recursion_depth to a larger value", nil),
 	ErrTableWithoutPrimaryKey:                                mysql.Message("Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set. Add a primary key to the table or unset this variable to avoid this message. Note that tables without a primary key can cause performance problems in row-based replication, so please consult your DBA before changing this setting.", nil),
 	ErrConstraintNotFound:                                    mysql.Message("Constraint '%s' does not exist.", nil),
+	ErrValuesClauseNoColumns:                                 mysql.Message("Each row of a VALUES clause must have at least one column, unless when used as source in an INSERT statement.", nil),
 	ErrDependentByCheckConstraint:                            mysql.Message("Check constraint '%s' uses column '%s', hence column cannot be dropped or renamed.", nil),
 	ErrEngineAttributeNotSupported:                           mysql.Message("Storage engine does not support ENGINE_ATTRIBUTE.", nil),
 	ErrJSONInBooleanContext:                                  mysql.Message("Evaluating a JSON value in SQL boolean context does an implicit comparison against JSON integer 0; if this is not what you want, consider converting JSON to a SQL numeric type with JSON_VALUE RETURNING", nil),

--- a/pkg/executor/test/cte/BUILD.bazel
+++ b/pkg/executor/test/cte/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/config",
         "//pkg/parser/terror",

--- a/pkg/util/dbterror/plannererrors/planner_terror.go
+++ b/pkg/util/dbterror/plannererrors/planner_terror.go
@@ -35,6 +35,7 @@ var (
 	ErrViewRecursive                         = dbterror.ClassOptimizer.NewStd(mysql.ErrViewRecursive)
 	ErrWrongArguments                        = dbterror.ClassOptimizer.NewStd(mysql.ErrWrongArguments)
 	ErrWrongNumberOfColumnsInSelect          = dbterror.ClassOptimizer.NewStd(mysql.ErrWrongNumberOfColumnsInSelect)
+	ErrValuesClauseNoColumns                 = dbterror.ClassOptimizer.NewStd(mysql.ErrValuesClauseNoColumns)
 	ErrBadGeneratedColumn                    = dbterror.ClassOptimizer.NewStd(mysql.ErrBadGeneratedColumn)
 	ErrFieldNotInGroupBy                     = dbterror.ClassOptimizer.NewStd(mysql.ErrFieldNotInGroupBy)
 	ErrAggregateOrderNonAggQuery             = dbterror.ClassOptimizer.NewStd(mysql.ErrAggregateOrderNonAggQuery)

--- a/tests/integrationtest/r/planner/core/plan.result
+++ b/tests/integrationtest/r/planner/core/plan.result
@@ -388,7 +388,7 @@ select * from golang1;
 fcbpdt	fcbpsq	procst	cipstx	cipsst	dyngtg	blncdt
 20230925	12023092502158016	1	CI010000	ACSC	EAYT	20230925
 EXPLAIN FORMAT = TRADITIONAL ((VALUES ROW ()) ORDER BY 1);
-Error 1051 (42S02): Unknown table ''
+Error 3942 (HY000): Each row of a VALUES clause must have at least one column, unless when used as source in an INSERT statement.
 drop table if exists p, t;
 create table p (id int, c int, key i_id(id), key i_c(c));
 create table t (id int);

--- a/tests/integrationtest/t/planner/core/plan.test
+++ b/tests/integrationtest/t/planner/core/plan.test
@@ -168,7 +168,7 @@ select * from golang1;
 
 
 # TestExplainValuesStatement
---error 1051
+--error 3942
 EXPLAIN FORMAT = TRADITIONAL ((VALUES ROW ()) ORDER BY 1);
 
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #21486

Problem Summary:

### What changed and how does it work?

I added support for standalone VALUES ROW queries by building them as a UNION ALL of constant SELECT statements, so they behave like a normal result set with column_0, column_1, etc. This lets ORDER BY, LIMIT, and set operators (UNION/INTERSECT/EXCEPT) work consistently, and it also makes VALUES ROW usable inside CTEs for select/insert/update/delete flows.
Tests were expanded to cover plain VALUES, ordering, limits, set operations, and CTE usage.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
support VALUES statement.
```
