### PR TITLE
parser: support RETURNING clause syntax

### DIFF
--- a/cmd/tidb-server/BUILD.bazel
+++ b/cmd/tidb-server/BUILD.bazel
@@ -107,7 +107,7 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":tidb-server_lib"],
     flaky = True,
-    shard_count = 6,
+    shard_count = 7,
     deps = [
         "//pkg/config",
         "//pkg/config/deploymode",

--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -871,6 +871,18 @@ func (n *FieldList) Restore(ctx *format.RestoreCtx) error {
 	return nil
 }
 
+func restoreReturningFields(ctx *format.RestoreCtx, fields []*SelectField) error {
+	for i, field := range fields {
+		if i != 0 {
+			ctx.WritePlain(", ")
+		}
+		if err := field.Restore(ctx); err != nil {
+			return errors.Annotatef(err, "An error occurred while restore Returning[%d]", i)
+		}
+	}
+	return nil
+}
+
 // Accept implements Node Accept interface.
 func (n *FieldList) Accept(v Visitor) (Node, bool) {
 	newNode, skipChildren := v.Enter(n)
@@ -2401,6 +2413,8 @@ type InsertStmt struct {
 	// TableHints represents the table level Optimizer Hint for join type.
 	TableHints     []*TableOptimizerHint
 	PartitionNames []CIStr
+	// Returning represents the RETURNING select_expr list for INSERT statement.
+	Returning []*SelectField
 }
 
 // Restore implements Node interface.
@@ -2526,6 +2540,12 @@ func (n *InsertStmt) Restore(ctx *format.RestoreCtx) error {
 			}
 		}
 	}
+	if len(n.Returning) > 0 {
+		ctx.WriteKeyWord(" RETURNING ")
+		if err := restoreReturningFields(ctx, n.Returning); err != nil {
+			return errors.Annotate(err, "An error occurred while restore InsertStmt.Returning")
+		}
+	}
 
 	return nil
 }
@@ -2574,6 +2594,13 @@ func (n *InsertStmt) Accept(v Visitor) (Node, bool) {
 			return n, false
 		}
 		n.OnDuplicate[i] = node.(*Assignment)
+	}
+	for i, field := range n.Returning {
+		node, ok := field.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.Returning[i] = node.(*SelectField)
 	}
 	return v.Leave(n)
 }
@@ -2634,6 +2661,8 @@ type DeleteStmt struct {
 	// TableHints represents the table level Optimizer Hint for join type.
 	TableHints []*TableOptimizerHint
 	With       *WithClause
+	// Returning represents the RETURNING select_expr list for DELETE statement.
+	Returning []*SelectField
 }
 
 // Restore implements Node interface.
@@ -2723,6 +2752,12 @@ func (n *DeleteStmt) Restore(ctx *format.RestoreCtx) error {
 			return errors.Annotate(err, "An error occurred while restore DeleteStmt.Limit")
 		}
 	}
+	if len(n.Returning) > 0 {
+		ctx.WriteKeyWord(" RETURNING ")
+		if err := restoreReturningFields(ctx, n.Returning); err != nil {
+			return errors.Annotate(err, "An error occurred while restore DeleteStmt.Returning")
+		}
+	}
 
 	return nil
 }
@@ -2776,6 +2811,13 @@ func (n *DeleteStmt) Accept(v Visitor) (Node, bool) {
 			return n, false
 		}
 		n.Limit = node.(*Limit)
+	}
+	for i, field := range n.Returning {
+		node, ok = field.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.Returning[i] = node.(*SelectField)
 	}
 	return v.Leave(n)
 }
@@ -2886,6 +2928,8 @@ type UpdateStmt struct {
 	MultipleTable bool
 	TableHints    []*TableOptimizerHint
 	With          *WithClause
+	// Returning represents the RETURNING select_expr list for UPDATE statement.
+	Returning []*SelectField
 }
 
 // Restore implements Node interface.
@@ -2964,6 +3008,12 @@ func (n *UpdateStmt) Restore(ctx *format.RestoreCtx) error {
 			return errors.Annotate(err, "An error occur while restore UpdateStmt.Limit")
 		}
 	}
+	if len(n.Returning) > 0 {
+		ctx.WriteKeyWord(" RETURNING ")
+		if err := restoreReturningFields(ctx, n.Returning); err != nil {
+			return errors.Annotate(err, "An error occurred while restore UpdateStmt.Returning")
+		}
+	}
 
 	return nil
 }
@@ -3014,6 +3064,13 @@ func (n *UpdateStmt) Accept(v Visitor) (Node, bool) {
 			return n, false
 		}
 		n.Limit = node.(*Limit)
+	}
+	for i, field := range n.Returning {
+		node, ok = field.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.Returning[i] = node.(*SelectField)
 	}
 	return v.Leave(n)
 }

--- a/pkg/parser/keywords.go
+++ b/pkg/parser/keywords.go
@@ -538,6 +538,7 @@ var Keywords = []KeywordsType{
 	{"RESTORE", false, "unreserved"},
 	{"RESTORES", false, "unreserved"},
 	{"RESUME", false, "unreserved"},
+	{"RETURNING", false, "unreserved"},
 	{"REUSE", false, "unreserved"},
 	{"REVERSE", false, "unreserved"},
 	{"ROLE", false, "unreserved"},

--- a/pkg/parser/keywords_test.go
+++ b/pkg/parser/keywords_test.go
@@ -36,7 +36,7 @@ func TestKeywords(t *testing.T) {
 }
 
 func TestKeywordsLength(t *testing.T) {
-	require.Equal(t, 679, len(parser.Keywords))
+	require.Equal(t, 680, len(parser.Keywords))
 
 	reservedNr := 0
 	for _, kw := range parser.Keywords {

--- a/pkg/parser/misc.go
+++ b/pkg/parser/misc.go
@@ -709,6 +709,7 @@ var tokenMap = map[string]int{
 	"RESTORES":                       restores,
 	"RESTORED_TS":                    restoredTS,
 	"RESTRICT":                       restrict,
+	"RETURNING":                      returning,
 	"REVERSE":                        reverse,
 	"REVOKE":                         revoke,
 	"RIGHT":                          right,

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -611,6 +611,7 @@ func getMaskingPolicyRestrictOp(name string) (ast.MaskingPolicyRestrictOps, bool
 	restore                    "RESTORE"
 	restores                   "RESTORES"
 	resume                     "RESUME"
+	returning                  "RETURNING"
 	reuse                      "REUSE"
 	reverse                    "REVERSE"
 	role                       "ROLE"
@@ -1375,6 +1376,7 @@ func getMaskingPolicyRestrictOp(name string) (ast.MaskingPolicyRestrictOps, bool
 	SelectLockOpt                          "SELECT lock options"
 	SelectStmtSQLCache                     "SELECT statement optional SQL_CAHCE/SQL_NO_CACHE"
 	SelectStmtFieldList                    "SELECT statement field list"
+	ReturningClause                        "RETURNING clause for DML"
 	SelectStmtLimit                        "SELECT statement LIMIT clause"
 	SelectStmtLimitOpt                     "SELECT statement optional LIMIT clause"
 	SelectStmtOpt                          "Select statement option"
@@ -1419,6 +1421,7 @@ func getMaskingPolicyRestrictOp(name string) (ast.MaskingPolicyRestrictOps, bool
 	TableAliasRefList                      "table alias reference list"
 	TableAsName                            "table alias name"
 	TableAsNameOpt                         "table alias name optional"
+	TableAsNameOptDelete                   "table alias name optional for delete"
 	TableElement                           "table definition element"
 	TableElementList                       "table definition element list"
 	TableElementListOpt                    "table definition element list optional"
@@ -1719,6 +1722,8 @@ func getMaskingPolicyRestrictOp(name string) (ast.MaskingPolicyRestrictOps, bool
 %precedence remove
 %precedence lowerThenOrder
 %precedence order
+%precedence returning
+%precedence higherThanReturning
 %precedence lowerThanFunction
 %precedence function
 %precedence constraint
@@ -5555,7 +5560,7 @@ DoStmt:
  *
  *******************************************************************/
 DeleteWithoutUsingStmt:
-	"DELETE" TableOptimizerHintsOpt PriorityOpt QuickOptional IgnoreOptional "FROM" TableName PartitionNameListOpt TableAsNameOpt IndexHintListOpt WhereClauseOptional OrderByOptional LimitClause
+	"DELETE" TableOptimizerHintsOpt PriorityOpt QuickOptional IgnoreOptional "FROM" TableName PartitionNameListOpt TableAsNameOptDelete IndexHintListOpt WhereClauseOptional OrderByOptional LimitClause ReturningClause
 	{
 		// Single Table
 		tn := $7.(*ast.TableName)
@@ -5579,6 +5584,9 @@ DeleteWithoutUsingStmt:
 		}
 		if $13 != nil {
 			x.Limit = $13.(*ast.Limit)
+		}
+		if $14 != nil {
+			x.Returning = $14.([]*ast.SelectField)
 		}
 
 		$$ = x
@@ -6904,7 +6912,7 @@ Field:
 	}
 
 FieldAsNameOpt:
-	/* EMPTY */
+	/* EMPTY */ %prec higherThanReturning
 	{
 		$$ = ""
 	}
@@ -7591,6 +7599,7 @@ UnReservedKeyword:
 |	"PERCENT"
 |	"PAUSE"
 |	"RESUME"
+|	"RETURNING"
 |	"OFF"
 |	"OPTIONAL"
 |	"REQUIRED"
@@ -7876,7 +7885,7 @@ ProcedureCall:
  *
  **********************************************************************************/
 InsertIntoStmt:
-	"INSERT" TableOptimizerHintsOpt PriorityOpt IgnoreOptional IntoOpt TableName PartitionNameListOpt InsertValues OnDuplicateKeyUpdate
+	"INSERT" TableOptimizerHintsOpt PriorityOpt IgnoreOptional IntoOpt TableName PartitionNameListOpt InsertValues OnDuplicateKeyUpdate ReturningClause
 	{
 		x := $8.(*ast.InsertStmt)
 		x.Priority = $3.(mysql.PriorityEnum)
@@ -7891,6 +7900,9 @@ InsertIntoStmt:
 			x.TableHints = $2.([]*ast.TableOptimizerHint)
 		}
 		x.PartitionNames = $7.([]ast.CIStr)
+		if $10 != nil {
+			x.Returning = $10.([]*ast.SelectField)
+		}
 		$$ = x
 	}
 
@@ -8036,6 +8048,16 @@ OnDuplicateKeyUpdate:
 |	"ON" "DUPLICATE" "KEY" "UPDATE" AssignmentList
 	{
 		$$ = $5
+	}
+
+ReturningClause:
+	%prec empty
+	{
+		$$ = nil
+	}
+|	"RETURNING" FieldList
+	{
+		$$ = $2
 	}
 
 /************************************************************************************
@@ -8248,6 +8270,7 @@ OptOrder:
 	}
 
 OrderByOptional:
+	%prec empty
 	{
 		$$ = nil
 	}
@@ -10472,6 +10495,13 @@ TableAsNameOpt:
 	}
 |	TableAsName
 
+TableAsNameOptDelete:
+	%prec higherThanReturning
+	{
+		$$ = ast.CIStr{}
+	}
+|	TableAsName
+
 TableAsName:
 	Identifier
 	{
@@ -10627,6 +10657,7 @@ CrossOpt:
 |	"INNER" "JOIN"
 
 LimitClause:
+	%prec empty
 	{
 		$$ = nil
 	}
@@ -14285,7 +14316,7 @@ UpdateStmt:
 	}
 
 UpdateStmtNoWith:
-	"UPDATE" TableOptimizerHintsOpt PriorityOpt IgnoreOptional TableRef "SET" AssignmentList WhereClauseOptional OrderByOptional LimitClause
+	"UPDATE" TableOptimizerHintsOpt PriorityOpt IgnoreOptional TableRef "SET" AssignmentList WhereClauseOptional OrderByOptional LimitClause ReturningClause
 	{
 		var refs *ast.Join
 		if x, ok := $5.(*ast.Join); ok {
@@ -14311,9 +14342,12 @@ UpdateStmtNoWith:
 		if $10 != nil {
 			st.Limit = $10.(*ast.Limit)
 		}
+		if $11 != nil {
+			st.Returning = $11.([]*ast.SelectField)
+		}
 		$$ = st
 	}
-|	"UPDATE" TableOptimizerHintsOpt PriorityOpt IgnoreOptional TableRefs "SET" AssignmentList WhereClauseOptional
+|	"UPDATE" TableOptimizerHintsOpt PriorityOpt IgnoreOptional TableRefs "SET" AssignmentList WhereClauseOptional ReturningClause
 	{
 		st := &ast.UpdateStmt{
 			Priority:  $3.(mysql.PriorityEnum),
@@ -14326,6 +14360,9 @@ UpdateStmtNoWith:
 		}
 		if $8 != nil {
 			st.Where = $8.(ast.ExprNode)
+		}
+		if $9 != nil {
+			st.Returning = $9.([]*ast.SelectField)
 		}
 		$$ = st
 	}
@@ -14343,6 +14380,7 @@ WhereClause:
 	}
 
 WhereClauseOptional:
+	%prec empty
 	{
 		$$ = nil
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -917,6 +917,19 @@ func TestDMLStmt(t *testing.T) {
 		{"INSERT IGNORE INTO t (a,b,c) VALUES (1,2,3),(4,5,6) ON DUPLICATE KEY UPDATE c=VALUES(a)+VALUES(b);", true, "INSERT IGNORE INTO `t` (`a`,`b`,`c`) VALUES (1,2,3),(4,5,6) ON DUPLICATE KEY UPDATE `c`=VALUES(`a`)+VALUES(`b`)"},
 		{"INSERT IGNORE INTO t (a,b,c) VALUES (1,2,3),(4,5,6) ON DUPLICATE KEY UPDATE c:=VALUES(a)+VALUES(b);", true, "INSERT IGNORE INTO `t` (`a`,`b`,`c`) VALUES (1,2,3),(4,5,6) ON DUPLICATE KEY UPDATE `c`=VALUES(`a`)+VALUES(`b`)"},
 
+		// for RETURNING clause
+		{"INSERT INTO t (a) VALUES (1) RETURNING *", true, "INSERT INTO `t` (`a`) VALUES (1) RETURNING *"},
+		{"INSERT INTO t (a) VALUES (1) RETURNING id", true, "INSERT INTO `t` (`a`) VALUES (1) RETURNING `id`"},
+		{"INSERT INTO t (a) VALUES (1) RETURNING id, name", true, "INSERT INTO `t` (`a`) VALUES (1) RETURNING `id`, `name`"},
+		{"INSERT INTO t2(id,animal) VALUES (1,'Dog'),(2,'Lion'),(3,'Tiger'),(4,'Leopard') RETURNING id,id+id,id&id,id||id", true, "INSERT INTO `t2` (`id`,`animal`) VALUES (1,_UTF8MB4'Dog'),(2,_UTF8MB4'Lion'),(3,_UTF8MB4'Tiger'),(4,_UTF8MB4'Leopard') RETURNING `id`, `id`+`id`, `id`&`id`, `id` OR `id`"},
+		{"INSERT INTO t (a) VALUES (1) ON DUPLICATE KEY UPDATE a=2 RETURNING id", true, "INSERT INTO `t` (`a`) VALUES (1) ON DUPLICATE KEY UPDATE `a`=2 RETURNING `id`"},
+		{"UPDATE t SET a=1 RETURNING *", true, "UPDATE `t` SET `a`=1 RETURNING *"},
+		{"UPDATE t SET a=1 WHERE id=1 RETURNING id, a", true, "UPDATE `t` SET `a`=1 WHERE `id`=1 RETURNING `id`, `a`"},
+		{"UPDATE t SET a=1 LIMIT 1 RETURNING *", true, "UPDATE `t` SET `a`=1 LIMIT 1 RETURNING *"},
+		{"DELETE FROM t RETURNING *", true, "DELETE FROM `t` RETURNING *"},
+		{"DELETE FROM t WHERE id=1 RETURNING id", true, "DELETE FROM `t` WHERE `id`=1 RETURNING `id`"},
+		{"DELETE FROM t ORDER BY id LIMIT 1 RETURNING *", true, "DELETE FROM `t` ORDER BY `id` LIMIT 1 RETURNING *"},
+
 		// for insert ... set
 		{"INSERT INTO t SET a=1,b=2", true, "INSERT INTO `t` SET `a`=1,`b`=2"},
 		{"INSERT INTO t (a) SET a=1", false, ""},


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #58939

Problem Summary:

This PR is the parser-only part of `RETURNING` support, split out after review feedback from @mjonss.

The executor/planner implementation has been moved to the follow-up stacked PR: https://github.com/bb7133/tidb/pull/49

### What changed and how does it work?

This PR only teaches the parser/AST layer to recognize and restore DML `RETURNING` syntax:

- adds `RETURNING` grammar for INSERT / UPDATE / DELETE statements
- stores the parsed field list in the corresponding AST nodes
- keeps `RETURNING` as an unreserved keyword
- regenerates `parser.go` / `keywords.go`
- adds parser tests for INSERT / UPDATE / DELETE `RETURNING` syntax

No executor or planner behavior is included in this PR.

  ### Check List

  Tests <!-- At least one of them must be included. -->

  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual test 
  - [ ] No need to test
    > - [ ] I checked and no code files have been changed.
    > <!-- Or your custom  "No need to test" reasons -->

Validation run:

- `make parser_yacc`
- `cd pkg/parser && go test . -run 'TestDMLStmt|TestKeywords' -count=1`
- `go test ./pkg/executor ./pkg/planner/core -run TestNonExistentReturningCompileOnly -count=1`

Side effects

This is parser-only syntax support. Runtime execution support is intentionally kept out of this PR and moved to the follow-up stacked PR.

Documentation

- [ ] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional RETURNING clauses for INSERT, UPDATE, and DELETE so statements can return specified columns/expressions.

* **Parser**
  * Recognizes the RETURNING keyword and parses an optional returning field list; grammar updated to handle new clause without conflicts and to restore normalized SQL with RETURNING.

* **Tests**
  * Added/extended tests validating RETURNING clause parsing and restored/normalized SQL output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/65633)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->