### PR TITLE
store: fix flaky test TestInitStorage

### DIFF
--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -870,18 +870,17 @@ func TestSetAssertion(t *testing.T) {
 
 func TestInitStorage(t *testing.T) {
 	require.NoError(t, Register(config.StoreTypeUniStore, mockstore.EmbedUnistoreDriver{}))
+	bak := *config.GetGlobalConfig()
+	config.GetGlobalConfig().Path = t.TempDir()
+	t.Cleanup(func() {
+		config.StoreGlobalConfig(&bak)
+	})
 	if kerneltype.IsClassic() {
 		storage := MustInitStorage("")
 		defer storage.Close()
 		require.Nil(t, GetSystemStorage())
 	} else {
-		bak := *config.GetGlobalConfig()
-		config.GetGlobalConfig().Path = t.TempDir()
 		config.GetGlobalConfig().KeyspaceName = keyspace.System
-		t.Cleanup(func() {
-			config.StoreGlobalConfig(&bak)
-		})
-
 		storage := MustInitStorage(keyspace.System)
 		require.NotNil(t, GetSystemStorage())
 		defer storage.Close()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65643

Problem Summary:

### What changed and how does it work?

`config.GetGlobalConfig().Path` should always be from `config.GetGlobalConfig().Path` in the UT.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
