### PR TITLE
planner: fix the int handle range for tici index path | tidb-test=a9bf2dca824dc746361234cd4d763178e0eedd13

### DIFF
--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -929,7 +929,8 @@ type TiCIShardType int8
 // Different TiCI index shard types.
 // The three types are corresponding to three kinds of encoding formats.
 const (
-	TiCIShardIntHandle TiCIShardType = iota
+	NotTiCIIndex TiCIShardType = iota
+	TiCIShardIntHandle
 	TiCIShardCommonHandle
 	TiCIShardExtraShardingKey
 )

--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -82,6 +82,7 @@ go_library(
         "//pkg/bindinfo",
         "//pkg/config",
         "//pkg/config/kerneltype",
+        "//pkg/distsql",
         "//pkg/domain",
         "//pkg/errctx",
         "//pkg/executor/join/joinversion",

--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
@@ -6,7 +6,7 @@
         "SQL": "explain format='brief' select * from t1 where fts_match_word('hello', title)",
         "Plan": [
           "IndexLookUp 1000.00 root  ",
-          "├─IndexRangeScan(Build) 1000.00 cop[tici] table:t1, index:idx_title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
+          "├─IndexRangeScan(Build) 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
           "└─TableRowIDScan(Probe) 1000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -15,7 +15,7 @@
         "SQL": "explain format='brief' select * from t1 where fts_match_prefix('hello', title)",
         "Plan": [
           "IndexLookUp 1000.00 root  ",
-          "├─IndexRangeScan(Build) 1000.00 cop[tici] table:t1, index:idx_title(title) range:[NULL,+inf], search func:fts_match_prefix(\"hello\", test.t1.title), keep order:false, stats:pseudo",
+          "├─IndexRangeScan(Build) 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_prefix(\"hello\", test.t1.title), keep order:false, stats:pseudo",
           "└─TableRowIDScan(Probe) 1000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -34,7 +34,7 @@
         "SQL": "explain format='brief' select id from t1 where fts_match_word('hello', title)",
         "Plan": [
           "IndexReader 1000.00 root  index:IndexRangeScan",
-          "└─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
+          "└─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -61,7 +61,7 @@
       {
         "SQL": "explain format='brief' select title from t1 where fts_match_word('hello', title) AND id > 10 AND LENGTH(title) > 1",
         "Plan": [
-          "Projection 888.89 root  test.t1.title",
+          "Projection 66.67 root  test.t1.title",
           "└─IndexReader 0.00 root  index:Selection",
           "  └─Selection 0.00 cop[tici]  gt(length(test.t1.title), 1), gt(test.t1.id, 10)",
           "    └─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:(10,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
@@ -74,7 +74,7 @@
           "HashAgg 1.00 root  funcs:count(Column#6)->Column#5",
           "└─IndexReader 1.00 root  index:HashAgg",
           "  └─HashAgg 1.00 cop[tici]  funcs:count(test.t1.id)->Column#6",
-          "    └─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
+          "    └─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -84,7 +84,7 @@
           "HashAgg 1.00 root  funcs:count(Column#6)->Column#5",
           "└─IndexReader 1.00 root  index:HashAgg",
           "  └─HashAgg 1.00 cop[tici]  funcs:count(1)->Column#6",
-          "    └─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
+          "    └─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -92,7 +92,7 @@
         "SQL": "explain format='brief' select id from t1 where fts_match_word('hello', title)",
         "Plan": [
           "IndexReader 1000.00 root  index:IndexRangeScan",
-          "└─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
+          "└─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -119,7 +119,7 @@
         "Plan": [
           "Projection 8000.00 root  test.t1.id",
           "└─IndexLookUp 8000.00 root  ",
-          "  ├─IndexRangeScan(Build) 1000.00 cop[tici] table:t1, index:idx_title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
+          "  ├─IndexRangeScan(Build) 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
           "  └─Selection(Probe) 8000.00 cop[tikv]  gt(length(test.t1.body), 10)",
           "    └─TableRowIDScan 1000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
@@ -130,7 +130,7 @@
         "Plan": [
           "IndexLookUp 1.00 root  limit embedded(offset:0, count:1)",
           "├─Limit(Build) 0.12 cop[tici]  offset:0, count:1",
-          "│ └─IndexRangeScan 0.12 cop[tici] table:t1, index:idx_title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
+          "│ └─IndexRangeScan 0.12 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
           "└─TableRowIDScan(Probe) 0.12 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -139,7 +139,7 @@
         "SQL": "explain format='brief' select id from t1 where fts_match_word('hello', title) and fts_match_word('world', title)",
         "Plan": [
           "IndexReader 1000.00 root  index:IndexRangeScan",
-          "└─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t1.title), fts_match_word(\"world\", test.t1.title), keep order:false, stats:pseudo"
+          "└─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), fts_match_word(\"world\", test.t1.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -147,7 +147,7 @@
         "SQL": "explain format='brief' select id from t1 where (fts_match_word('apple', title) and fts_match_word('boy', title)) or (fts_match_word('banana', title) and fts_match_word('girl', title))",
         "Plan": [
           "IndexReader 1000.00 root  index:IndexRangeScan",
-          "└─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[NULL,+inf], search func:or(and(istrue_with_null(fts_match_word(\"apple\", test.t1.title)), istrue_with_null(fts_match_word(\"boy\", test.t1.title))), and(istrue_with_null(fts_match_word(\"banana\", test.t1.title)), istrue_with_null(fts_match_word(\"girl\", test.t1.title)))), keep order:false, stats:pseudo"
+          "└─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:or(and(istrue_with_null(fts_match_word(\"apple\", test.t1.title)), istrue_with_null(fts_match_word(\"boy\", test.t1.title))), and(istrue_with_null(fts_match_word(\"banana\", test.t1.title)), istrue_with_null(fts_match_word(\"girl\", test.t1.title)))), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -155,7 +155,7 @@
         "SQL": "explain format='brief' select id from t1 where (fts_match_prefix('apple', title) and fts_match_word('boy', title)) or (fts_match_word('banana', title) and fts_match_word('girl', title))",
         "Plan": [
           "IndexReader 1000.00 root  index:IndexRangeScan",
-          "└─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[NULL,+inf], search func:or(and(istrue_with_null(fts_match_prefix(\"apple\", test.t1.title)), istrue_with_null(fts_match_word(\"boy\", test.t1.title))), and(istrue_with_null(fts_match_word(\"banana\", test.t1.title)), istrue_with_null(fts_match_word(\"girl\", test.t1.title)))), keep order:false, stats:pseudo"
+          "└─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:or(and(istrue_with_null(fts_match_prefix(\"apple\", test.t1.title)), istrue_with_null(fts_match_word(\"boy\", test.t1.title))), and(istrue_with_null(fts_match_word(\"banana\", test.t1.title)), istrue_with_null(fts_match_word(\"girl\", test.t1.title)))), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -471,7 +471,7 @@
         "SQL": "explain format='brief' select * from t1 use index(idx_field) where fts_match_word('hello', title)",
         "Plan": [
           "IndexLookUp 1000.00 root  ",
-          "├─IndexRangeScan(Build) 1000.00 cop[tici] table:t1, index:idx_title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
+          "├─IndexRangeScan(Build) 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
           "└─TableRowIDScan(Probe) 1000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Warn": [

--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/distsql"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -960,7 +961,7 @@ func buildPartialPath4MVIndex(
 		partialPath.FullIdxCols = append(partialPath.FullIdxCols, idxCols[i])
 		partialPath.FullIdxColLens = append(partialPath.FullIdxColLens, length)
 	}
-	if err := detachCondAndBuildRangeForPath(sctx, partialPath, accessFilters, histColl, false); err != nil {
+	if err := detachCondAndBuildRangeForPath(sctx, partialPath, accessFilters, histColl, distsql.NotTiCIIndex); err != nil {
 		return nil, false, err
 	}
 	if len(partialPath.AccessConds) != len(accessFilters) || len(partialPath.TableFilters) > 0 {

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -482,7 +482,7 @@ func detachCondAndBuildRangeForPath(
 }
 
 // fixTiCIIndexRangesForIntHandle fixes the TiCI index ranges for int handle.
-// For normal index range, it's min value is NULL or the MinNotNull, and max value is MaxValue.
+// For normal index range, its min value is NULL or the MinNotNull, and max value is MaxValue.
 // But for TiCI index range which directly uses table's int pk range, we should set the min value to the min int value and max value to max int value.
 func fixTiCIIndexRangesForIntHandle(ranges []*ranger.Range, isUnsigned bool) {
 	var minDatum, maxDatum types.Datum

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -488,7 +488,7 @@ func fixTiCIIndexRangesForIntHandle(ranges []*ranger.Range, isUnsigned bool) {
 	var minDatum, maxDatum types.Datum
 	// isUnsigned indicates whether the handle is unsigned.
 	// Now we just cast the unsigned int to int and then store the int value inside the Datum.
-	// We wrap the uint64/int64 with Datum here to keep us untouched with Datum's ineternal representation.
+	// We wrap the uint64/int64 with Datum here to keep us untouched with Datum's internal representation.
 	if isUnsigned {
 		minDatum = types.NewUintDatum(0)
 		maxDatum = types.NewUintDatum(math.MaxUint64)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #64651 

Problem Summary:

### What changed and how does it work?

Index range's min max is NULL/MinNotNull and MaxValue.
But for int pk, we need a numeric value like MaxInt64.

This pr is to fix the case for the TiCI index.

This is not easy to test via a unit test. I'll see whether we can add one later.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
