### PR TITLE
importinto: ensure engine cleanup on import error

### DIFF
--- a/pkg/dxf/importinto/task_executor.go
+++ b/pkg/dxf/importinto/task_executor.go
@@ -367,7 +367,6 @@ func (s *importStepExecutor) onFinished(ctx context.Context, subtask *proto.Subt
 		}
 	}
 
-	s.sharedVars.Delete(subtaskMeta.ID)
 	newMeta, err := subtaskMeta.Marshal()
 	if err != nil {
 		return errors.Trace(err)

--- a/pkg/executor/importer/table_import.go
+++ b/pkg/executor/importer/table_import.go
@@ -549,6 +549,7 @@ func (ti *TableImporter) OpenDataEngine(ctx context.Context, engineID int32) (*b
 func (ti *TableImporter) ImportAndCleanup(ctx context.Context, closedEngine *backend.ClosedEngine) (int64, error) {
 	var kvCount int64
 	importErr := closedEngine.Import(ctx, ti.regionSplitSize, ti.regionSplitKeys)
+	failpoint.InjectCall("mockDataEngineImportErr", &importErr)
 	if common.ErrFoundDuplicateKeys.Equal(importErr) {
 		importErr = local.ConvertToErrFoundConflictRecords(importErr, ti.encTable)
 	}

--- a/pkg/lightning/backend/local/engine_mgr.go
+++ b/pkg/lightning/backend/local/engine_mgr.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tikv/client-go/v2/oracle"
 	tikvclient "github.com/tikv/client-go/v2/tikv"
 	"go.uber.org/atomic"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
@@ -351,26 +352,7 @@ func (em *engineManager) closeEngine(
 	}
 
 	engine := engineI.(*Engine)
-	engine.rLock()
-	if engine.closed.Load() {
-		engine.rUnlock()
-		return nil
-	}
-
-	err := engine.flushEngineWithoutLock(ctx)
-	engine.rUnlock()
-
-	// use mutex to make sure we won't close sstMetasChan while other routines
-	// trying to do flush.
-	engine.lock(importMutexStateClose)
-	engine.closed.Store(true)
-	close(engine.sstMetasChan)
-	engine.unlock()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	engine.wg.Wait()
-	return engine.ingestErr.Get()
+	return engine.finishWrite(ctx)
 }
 
 // getImportedKVCount returns the number of imported KV pairs of some engine.
@@ -492,6 +474,27 @@ func (em *engineManager) cleanupEngine(ctx context.Context, engineUUID uuid.UUID
 	localEngine.TotalSize.Store(0)
 	localEngine.Length.Store(0)
 	return nil
+}
+
+// cleanupAllLocalEngines closes and removes all local engines, used for best-effort cleanup on error.
+func (em *engineManager) cleanupAllLocalEngines(ctx context.Context) error {
+	var (
+		retErr  error
+		engines []*Engine
+	)
+	em.engines.Range(func(_, v any) bool {
+		engines = append(engines, v.(*Engine))
+		return true
+	})
+	for _, eng := range engines {
+		if err := eng.finishWrite(ctx); err != nil {
+			retErr = multierr.Append(retErr, err)
+		}
+		if err := em.cleanupEngine(ctx, eng.UUID); err != nil {
+			retErr = multierr.Append(retErr, err)
+		}
+	}
+	return retErr
 }
 
 // LocalWriter returns a new local writer.

--- a/pkg/lightning/backend/local/local.go
+++ b/pkg/lightning/backend/local/local.go
@@ -836,6 +836,11 @@ func (local *Backend) FlushAllEngines(parentCtx context.Context) (err error) {
 	return local.engineMgr.flushAllEngines(parentCtx)
 }
 
+// CleanupAllLocalEngines closes and removes all local engines, used for best-effort cleanup on error.
+func (local *Backend) CleanupAllLocalEngines(ctx context.Context) error {
+	return local.engineMgr.cleanupAllLocalEngines(ctx)
+}
+
 // RetryImportDelay returns the delay time before retrying to import a file.
 func (*Backend) RetryImportDelay() time.Duration {
 	return defaultRetryBackoffTime

--- a/tests/realtikvtest/importintotest3/BUILD.bazel
+++ b/tests/realtikvtest/importintotest3/BUILD.bazel
@@ -4,6 +4,7 @@ go_test(
     name = "importintotest3_test",
     timeout = "moderate",
     srcs = [
+        "cleanup_on_error_test.go",
         "cross_ks_test.go",
         "extra_param_test.go",
         "file_compression_test.go",

--- a/tests/realtikvtest/importintotest3/BUILD.bazel
+++ b/tests/realtikvtest/importintotest3/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "//pkg/planner/core",
         "//pkg/sessionctx/vardef",
         "//pkg/store",
+        "//pkg/store/driver/error",
         "//pkg/testkit",
         "//pkg/testkit/testfailpoint",
         "//tests/realtikvtest",

--- a/tests/realtikvtest/importintotest3/cleanup_on_error_test.go
+++ b/tests/realtikvtest/importintotest3/cleanup_on_error_test.go
@@ -41,7 +41,7 @@ func (s *mockGCSSuite) TestCleanupOnDataEngineImportError() {
 		}
 	})
 	s.tk.MustQuery(fmt.Sprintf("IMPORT INTO t FROM '%s'", dataPath))
-	s.GreaterOrEqual(enterCnt.Load(), 2, "the import should retry on data engine import error")
+	s.GreaterOrEqual(enterCnt.Load(), int32(2), "the import should retry on data engine import error")
 
 	s.tk.MustQuery("select * from t;").Sort().Check(testkit.Rows("1 a", "2 b"))
 }

--- a/tests/realtikvtest/importintotest3/cleanup_on_error_test.go
+++ b/tests/realtikvtest/importintotest3/cleanup_on_error_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importintotest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+
+	drivererr "github.com/pingcap/tidb/pkg/store/driver/error"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+)
+
+func (s *mockGCSSuite) TestCleanupOnDataEngineImportError() {
+	s.prepareAndUseDB("cleanup_on_error")
+	s.tk.MustExec("create table t (a int primary key, b varchar(32));")
+
+	tempDir := s.T().TempDir()
+	dataPath := filepath.Join(tempDir, "data.csv")
+	content := []byte("1,a\n2,b\n")
+	s.NoError(os.WriteFile(dataPath, content, 0o644))
+
+	var enterCnt atomic.Int32
+	testfailpoint.EnableCall(s.T(), "github.com/pingcap/tidb/pkg/executor/importer/mockDataEngineImportErr", func(errP *error) {
+		if enterCnt.Add(1) == 1 {
+			*errP = drivererr.ErrPDServerTimeout
+		}
+	})
+	s.tk.MustQuery(fmt.Sprintf("IMPORT INTO t FROM '%s'", dataPath))
+	s.GreaterOrEqual(enterCnt.Load(), 2, "the import should retry on data engine import error")
+
+	s.tk.MustQuery("select * from t;").Sort().Check(testkit.Rows("1 a", "2 b"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65645

Problem Summary:

### What changed and how does it work?
as title

Why it happens:

- RunSubtask opens both data + index engines and doesn’t defer cleanup on error. If anything fails before
  onFinished, both engines can stay open. See pkg/dxf/importinto/task_executor.go.
- In onFinished, the data engine is imported/cleaned first. If that import fails (PD “not leader” /
  timeouts), the function returns immediately and skips closing/cleaning the index engine. See pkg/dxf/
  importinto/task_executor.go.
- The log’s stack trace is from TableImporter.OpenIndexEngine → pebble.LockDirectory, i.e., it’s the
  index engine reopening and hitting a lock that’s still held.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

without this pr, the case failes, after, it success
```
        	Error:      	Received unexpected error:
        	            	[0]lock held by current process
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
