### PR TITLE
planner: Ordering for hash join (WIP) | tidb-test=pr/2665

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -1790,6 +1790,9 @@ func (b *executorBuilder) buildHashJoinV2FromChildExecs(leftExec, rightExec exec
 	} else if v.InnerChildIdx == 0 && !v.UseOuterToBuild {
 		e.HashJoinCtxV2.RightAsBuildSide = false
 	}
+	// Pass order-preserving hash join parameters
+	e.HashJoinCtxV2.KeepProbeOrder = v.KeepProbeOrder
+	e.HashJoinCtxV2.ExpectedCnt = v.ExpectedCnt
 
 	lhsTypes, rhsTypes := exec.RetTypes(leftExec), exec.RetTypes(rightExec)
 	joinedTypes := make([]*types.FieldType, 0, len(lhsTypes)+len(rhsTypes))

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -1832,9 +1832,7 @@ func (b *executorBuilder) buildHashJoinV2FromChildExecs(leftExec, rightExec exec
 	} else if v.InnerChildIdx == 0 && !v.UseOuterToBuild {
 		e.HashJoinCtxV2.RightAsBuildSide = false
 	}
-	// Pass order-preserving hash join parameters
 	e.HashJoinCtxV2.KeepProbeOrder = v.KeepProbeOrder
-	e.HashJoinCtxV2.ExpectedCnt = v.ExpectedCnt
 
 	lhsTypes, rhsTypes := exec.RetTypes(leftExec), exec.RetTypes(rightExec)
 	joinedTypes := make([]*types.FieldType, 0, len(lhsTypes)+len(rhsTypes))

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -1832,6 +1832,9 @@ func (b *executorBuilder) buildHashJoinV2FromChildExecs(leftExec, rightExec exec
 	} else if v.InnerChildIdx == 0 && !v.UseOuterToBuild {
 		e.HashJoinCtxV2.RightAsBuildSide = false
 	}
+	// Pass order-preserving hash join parameters
+	e.HashJoinCtxV2.KeepProbeOrder = v.KeepProbeOrder
+	e.HashJoinCtxV2.ExpectedCnt = v.ExpectedCnt
 
 	lhsTypes, rhsTypes := exec.RetTypes(leftExec), exec.RetTypes(rightExec)
 	joinedTypes := make([]*types.FieldType, 0, len(lhsTypes)+len(rhsTypes))

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -1136,19 +1136,6 @@ func (e *IndexLookUpExecutor) calculateBatchSize(initBatchSize, maxBatchSize int
 		// If indexPaging is true means this query has limit, so use initBatchSize to avoid scan some unnecessary data.
 		return min(initBatchSize, maxBatchSize)
 	}
-	// When the parent executor passes a positive initBatchSize (from req.RequiredRows()),
-	// it indicates an expected row count hint (e.g., from LIMIT clause via order-preserving hash join).
-	// Use formula: MIN(maxChunkSize, MAX(expectedCnt, 100)) to:
-	// - Ensure minimum batch size of 100 to avoid excessive RPC overhead
-	// - Cap at maxChunkSize to limit memory usage
-	// - Still allow early termination by fetching in smaller batches
-	if initBatchSize > 0 {
-		const minBatchSize = 100
-		maxChunkSize := e.MaxChunkSize()
-		batchSize := max(initBatchSize, minBatchSize)
-		batchSize = min(batchSize, maxChunkSize)
-		return min(batchSize, maxBatchSize)
-	}
 	var estRows int
 	if len(e.idxPlans) > 0 {
 		estRows = int(e.idxPlans[0].StatsCount())

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -1136,6 +1136,19 @@ func (e *IndexLookUpExecutor) calculateBatchSize(initBatchSize, maxBatchSize int
 		// If indexPaging is true means this query has limit, so use initBatchSize to avoid scan some unnecessary data.
 		return min(initBatchSize, maxBatchSize)
 	}
+	// When the parent executor passes a positive initBatchSize (from req.RequiredRows()),
+	// it indicates an expected row count hint (e.g., from LIMIT clause via order-preserving hash join).
+	// Use formula: MIN(maxChunkSize, MAX(expectedCnt, 100)) to:
+	// - Ensure minimum batch size of 100 to avoid excessive RPC overhead
+	// - Cap at maxChunkSize to limit memory usage
+	// - Still allow early termination by fetching in smaller batches
+	if initBatchSize > 0 {
+		const minBatchSize = 100
+		maxChunkSize := e.MaxChunkSize()
+		batchSize := max(initBatchSize, minBatchSize)
+		batchSize = min(batchSize, maxChunkSize)
+		return min(batchSize, maxBatchSize)
+	}
 	var estRows int
 	if len(e.idxPlans) > 0 {
 		estRows = int(e.idxPlans[0].StatsCount())

--- a/pkg/executor/join/hash_join_spill_helper.go
+++ b/pkg/executor/join/hash_join_spill_helper.go
@@ -166,6 +166,12 @@ func (h *hashJoinSpillHelper) areAllPartitionsSpilled() bool {
 // Set flag so that we can trigger other executor's spill when
 // hash join can not spill.
 func (h *hashJoinSpillHelper) setCanSpillFlag(canSpill bool) {
+	// Spilling re-partitions the probe side and replays it in restore rounds, which
+	// destroys the probe-row order an order-preserving join promised its parent. Such a
+	// join never spills; it falls back to the ordinary memory-quota action instead.
+	if canSpill && h.hashJoinExec != nil && h.hashJoinExec.KeepProbeOrder {
+		canSpill = false
+	}
 	h.canSpillFlag.Store(canSpill)
 }
 

--- a/pkg/executor/join/hash_join_stats.go
+++ b/pkg/executor/join/hash_join_stats.go
@@ -140,8 +140,9 @@ type spillStats struct {
 }
 
 type hashJoinRuntimeStatsV2 struct {
-	concurrent     int
-	probeCollision int64
+	concurrent      int
+	buildConcurrent int
+	probeCollision  int64
 
 	fetchAndBuildHashTable int64
 
@@ -217,7 +218,7 @@ func (e *hashJoinRuntimeStatsV2) String() string {
 	if e.fetchAndBuildHashTable > 0 {
 		if e.isHashJoinGA {
 			buf.WriteString("build_hash_table:{concurrency:")
-			buf.WriteString(strconv.Itoa(e.concurrent))
+			buf.WriteString(strconv.Itoa(e.buildConcurrent))
 			buf.WriteString(", time:")
 			buf.WriteString(execdetails.FormatDuration(time.Duration(e.fetchAndBuildHashTable)))
 			buf.WriteString(", fetch:")
@@ -294,6 +295,7 @@ func (e *hashJoinRuntimeStatsV2) String() string {
 func (e *hashJoinRuntimeStatsV2) Clone() execdetails.RuntimeStats {
 	return &hashJoinRuntimeStatsV2{
 		concurrent:                            e.concurrent,
+		buildConcurrent:                       e.buildConcurrent,
 		probeCollision:                        e.probeCollision,
 		fetchAndBuildHashTable:                e.fetchAndBuildHashTable,
 		partitionData:                         e.partitionData,

--- a/pkg/executor/join/hash_join_stats.go
+++ b/pkg/executor/join/hash_join_stats.go
@@ -140,6 +140,8 @@ type spillStats struct {
 }
 
 type hashJoinRuntimeStatsV2 struct {
+	// concurrent is the probe-side worker count, which an order-preserving join drops to
+	// 1; buildConcurrent is the build-side one, which is always the full concurrency.
 	concurrent      int
 	buildConcurrent int
 	probeCollision  int64

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -281,6 +281,32 @@ type HashJoinCtxV2 struct {
 	maxSpillRound int
 	spillHelper   *hashJoinSpillHelper
 	spillAction   *hashJoinSpillAction
+
+	// KeepProbeOrder indicates whether the join should preserve the order of the probe side.
+	// When true, the join will use single-threaded probing to maintain order from an index scan
+	// on the probe side, allowing ORDER BY ... LIMIT queries to avoid a sort operation.
+	KeepProbeOrder bool
+
+	// ExpectedCnt is the expected number of rows to be returned when KeepProbeOrder is true.
+	// This is used to optimize chunk sizes for ORDER BY ... LIMIT queries by using smaller
+	// chunks when the limit is small, reducing unnecessary row processing.
+	ExpectedCnt float64
+
+	// matchedRows tracks the number of result rows produced so far.
+	// Used for early termination when KeepProbeOrder is true with a LIMIT.
+	matchedRows int64
+}
+
+// probeConcurrency returns the concurrency to use for probe workers.
+// When KeepProbeOrder is true with a positive ExpectedCnt (LIMIT), returns 1 to:
+// 1. Preserve the probe-side order for ORDER BY
+// 2. Enable early termination after finding enough matching rows
+// Otherwise returns full Concurrency for maximum parallelism.
+func (hCtx *HashJoinCtxV2) probeConcurrency() uint {
+	if hCtx.KeepProbeOrder && hCtx.ExpectedCnt > 0 {
+		return 1
+	}
+	return hCtx.Concurrency
 }
 
 func (hCtx *HashJoinCtxV2) resetHashTableContextForRestore() {
@@ -663,7 +689,9 @@ func (e *HashJoinV2Exec) Close() error {
 		for i := range e.ProbeSideTupleFetcher.probeResultChs {
 			channel.Clear(e.ProbeSideTupleFetcher.probeResultChs[i])
 		}
-		for i := range e.ProbeWorkers {
+		// Only close channels for workers that were actually initialized.
+		// When KeepProbeOrder is true, only probeConcurrency() workers are initialized.
+		for i := range e.probeConcurrency() {
 			close(e.ProbeWorkers[i].joinChkResourceCh)
 			channel.Clear(e.ProbeWorkers[i].joinChkResourceCh)
 		}
@@ -671,8 +699,9 @@ func (e *HashJoinV2Exec) Close() error {
 		e.waiterWg.Wait()
 		e.hashTableContext.reset()
 	}
-	for _, w := range e.ProbeWorkers {
-		w.joinChkResourceCh = nil
+	// Only reset channels for workers that were actually initialized.
+	for i := range e.probeConcurrency() {
+		e.ProbeWorkers[i].joinChkResourceCh = nil
 	}
 
 	if e.stats != nil {
@@ -739,7 +768,10 @@ func (e *HashJoinV2Exec) OpenSelf() error {
 
 	if e.RuntimeStats() != nil && e.stats == nil {
 		e.stats = &hashJoinRuntimeStatsV2{}
-		e.stats.concurrent = int(e.Concurrency)
+		// Build phase always uses full concurrency.
+		e.stats.buildConcurrent = int(e.Concurrency)
+		// Probe phase uses probeConcurrency() which returns 1 when KeepProbeOrder is true.
+		e.stats.concurrent = int(e.probeConcurrency())
 	}
 
 	if e.stats != nil {
@@ -777,14 +809,23 @@ func (e *HashJoinV2Exec) canSkipProbeIfHashTableIsEmpty() bool {
 
 func (e *HashJoinV2Exec) initializeForProbe() {
 	e.ProbeSideTupleFetcher.HashJoinCtxV2 = e.HashJoinCtxV2
+	// Use probeConcurrency() to get the number of probe workers.
+	// When KeepProbeOrder is true, this returns 1 to maintain probe-side order.
+	probeConcurrency := e.probeConcurrency()
 	// e.joinResultCh is for transmitting the join result chunks to the main thread.
-	e.joinResultCh = make(chan *hashjoinWorkerResult, e.Concurrency+1)
-	e.ProbeSideTupleFetcher.initializeForProbeBase(e.Concurrency, e.joinResultCh)
+	e.joinResultCh = make(chan *hashjoinWorkerResult, probeConcurrency+1)
+	e.ProbeSideTupleFetcher.initializeForProbeBase(probeConcurrency, e.joinResultCh)
 	e.ProbeSideTupleFetcher.canSkipProbeIfHashTableIsEmpty = e.canSkipProbeIfHashTableIsEmpty()
 	// set buildSuccess to false by default, it will be set to true if build finishes successfully
 	e.ProbeSideTupleFetcher.buildSuccess = false
 
-	for i := range e.Concurrency {
+	// Initialize requiredRows to ExpectedCnt for order-preserving joins with LIMIT.
+	// This ensures the first chunk fetch uses the small LIMIT value instead of maxChunkSize.
+	if e.KeepProbeOrder && e.ExpectedCnt > 0 {
+		atomic.StoreInt64(&e.ProbeSideTupleFetcher.requiredRows, int64(e.ExpectedCnt))
+	}
+
+	for i := range probeConcurrency {
 		e.ProbeWorkers[i].initializeForProbe(e.ProbeSideTupleFetcher.probeChkResourceCh, e.ProbeSideTupleFetcher.probeResultChs[i], e)
 		e.ProbeWorkers[i].JoinProbe.ResetProbeCollision()
 	}
@@ -824,7 +865,10 @@ func (e *HashJoinV2Exec) startProbeJoinWorkers(ctx context.Context) {
 		e.ProbeSideTupleFetcher.buildSuccess = true
 	}
 
-	for i := range e.Concurrency {
+	// Use probeConcurrency() to get the number of probe workers.
+	// When KeepProbeOrder is true, this returns 1 to maintain probe-side order.
+	probeConcurrency := e.probeConcurrency()
+	for i := range probeConcurrency {
 		workerID := i
 		e.workerWg.RunWithRecover(func() {
 			defer trace.StartRegion(ctx, "HashJoinWorker").End()
@@ -867,15 +911,17 @@ func (e *HashJoinV2Exec) waitJoinWorkers(start time.Time) {
 	e.workerWg.Wait()
 	if e.stats != nil {
 		e.HashJoinCtxV2.stats.fetchAndProbe += int64(time.Since(start))
-		for _, prober := range e.ProbeWorkers {
-			e.stats.probeCollision += int64(prober.JoinProbe.GetProbeCollision())
+		// Only collect stats from initialized probe workers.
+		for i := range e.probeConcurrency() {
+			e.stats.probeCollision += int64(e.ProbeWorkers[i].JoinProbe.GetProbeCollision())
 		}
 	}
 
 	if e.ProbeSideTupleFetcher.buildSuccess {
 		// only scan row table if build is successful
+		// Use probeConcurrency() to only scan with initialized workers.
 		if e.ProbeWorkers[0] != nil && e.ProbeWorkers[0].JoinProbe.NeedScanRowTable() {
-			for i := range e.Concurrency {
+			for i := range e.probeConcurrency() {
 				var workerID = i
 				e.workerWg.RunWithRecover(func() {
 					e.ProbeWorkers[workerID].scanRowTableAfterProbeDone()
@@ -954,9 +1000,39 @@ func (w *ProbeWorkerV2) probeAndSendResult(joinResult *hashjoinWorkerResult) (bo
 		}
 
 		failpoint.Inject("processOneProbeChunkPanic", nil)
+
+		// Early termination for ORDER BY LIMIT: check if we have enough rows
+		// even when the chunk is not full. This is critical for small LIMIT values
+		// (e.g., LIMIT 1) where we don't want to process more rows than necessary.
+		// We check the cumulative total (current matchedRows + this chunk) to ensure
+		// consistent behavior with the full chunk case below.
+		if w.HashJoinCtx.KeepProbeOrder && w.HashJoinCtx.ExpectedCnt > 0 {
+			currentRows := atomic.LoadInt64(&w.HashJoinCtx.matchedRows)
+			newTotal := currentRows + int64(joinResult.chk.NumRows())
+			if float64(newTotal) >= w.HashJoinCtx.ExpectedCnt {
+				waitStart := time.Now()
+				w.HashJoinCtx.joinResultCh <- joinResult
+				atomic.StoreInt64(&w.HashJoinCtx.matchedRows, newTotal)
+				w.HashJoinCtx.finished.Store(true)
+				waitTime += int64(time.Since(waitStart))
+				return false, waitTime, joinResult
+			}
+		}
+
 		if joinResult.chk.IsFull() {
 			waitStart := time.Now()
 			w.HashJoinCtx.joinResultCh <- joinResult
+
+			// Track matched rows for early termination (full chunk case).
+			if w.HashJoinCtx.KeepProbeOrder && w.HashJoinCtx.ExpectedCnt > 0 {
+				newTotal := atomic.AddInt64(&w.HashJoinCtx.matchedRows, int64(joinResult.chk.NumRows()))
+				if float64(newTotal) >= w.HashJoinCtx.ExpectedCnt {
+					w.HashJoinCtx.finished.Store(true)
+					waitTime += int64(time.Since(waitStart))
+					return false, waitTime, joinResult
+				}
+			}
+
 			ok, joinResult = w.getNewJoinResult()
 			waitTime += int64(time.Since(waitStart))
 			if !ok {
@@ -1050,6 +1126,9 @@ func (e *HashJoinV2Exec) reset() {
 	e.ProbeSideTupleFetcher.buildSuccess = false
 	e.resetHashTableContextForRestore()
 	e.spillHelper.setCanSpillFlag(true)
+	// Reset matchedRows counter to avoid incorrect early termination when the executor
+	// is reused (e.g., multiple rounds due to spilling, or reuse in Apply operator)
+	atomic.StoreInt64(&e.HashJoinCtxV2.matchedRows, 0)
 	if e.HashJoinCtxV2.stats != nil {
 		e.HashJoinCtxV2.stats.resetCurrentRound()
 	}
@@ -1133,8 +1212,9 @@ func (e *HashJoinV2Exec) startBuildAndProbe(ctx context.Context) {
 }
 
 func (e *HashJoinV2Exec) resetProbeStatus() {
-	for _, probe := range e.ProbeWorkers {
-		probe.JoinProbe.ResetProbe()
+	// Only reset initialized probe workers.
+	for i := range e.probeConcurrency() {
+		e.ProbeWorkers[i].JoinProbe.ResetProbe()
 	}
 }
 

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -282,28 +282,20 @@ type HashJoinCtxV2 struct {
 	spillHelper   *hashJoinSpillHelper
 	spillAction   *hashJoinSpillAction
 
-	// KeepProbeOrder indicates whether the join should preserve the order of the probe side.
-	// When true, the join will use single-threaded probing to maintain order from an index scan
-	// on the probe side, allowing ORDER BY ... LIMIT queries to avoid a sort operation.
+	// KeepProbeOrder makes this join deliver its rows in probe-side order, which the
+	// planner relies on to drop a Sort above the join. Probing then runs on a single
+	// worker so joined rows leave the operator in probe-row order.
 	KeepProbeOrder bool
-
-	// ExpectedCnt is the expected number of rows to be returned when KeepProbeOrder is true.
-	// This is used to optimize chunk sizes for ORDER BY ... LIMIT queries by using smaller
-	// chunks when the limit is small, reducing unnecessary row processing.
-	ExpectedCnt float64
-
-	// matchedRows tracks the number of result rows produced so far.
-	// Used for early termination when KeepProbeOrder is true with a LIMIT.
-	matchedRows int64
 }
 
-// probeConcurrency returns the concurrency to use for probe workers.
-// When KeepProbeOrder is true with a positive ExpectedCnt (LIMIT), returns 1 to:
-// 1. Preserve the probe-side order for ORDER BY
-// 2. Enable early termination after finding enough matching rows
-// Otherwise returns full Concurrency for maximum parallelism.
+// probeConcurrency returns the number of probe workers to run. Joined rows only come out
+// in probe-row order if exactly one worker produces them, so an order-preserving join
+// serializes probing. The build phase is unaffected and still uses Concurrency workers.
+//
+// Anything that indexes into ProbeWorkers, or that splits work by worker id, has to agree
+// with this value rather than with Concurrency - only these workers get initialized.
 func (hCtx *HashJoinCtxV2) probeConcurrency() uint {
-	if hCtx.KeepProbeOrder && hCtx.ExpectedCnt > 0 {
+	if hCtx.KeepProbeOrder {
 		return 1
 	}
 	return hCtx.Concurrency
@@ -689,8 +681,6 @@ func (e *HashJoinV2Exec) Close() error {
 		for i := range e.ProbeSideTupleFetcher.probeResultChs {
 			channel.Clear(e.ProbeSideTupleFetcher.probeResultChs[i])
 		}
-		// Only close channels for workers that were actually initialized.
-		// When KeepProbeOrder is true, only probeConcurrency() workers are initialized.
 		for i := range e.probeConcurrency() {
 			close(e.ProbeWorkers[i].joinChkResourceCh)
 			channel.Clear(e.ProbeWorkers[i].joinChkResourceCh)
@@ -699,7 +689,6 @@ func (e *HashJoinV2Exec) Close() error {
 		e.waiterWg.Wait()
 		e.hashTableContext.reset()
 	}
-	// Only reset channels for workers that were actually initialized.
 	for i := range e.probeConcurrency() {
 		e.ProbeWorkers[i].joinChkResourceCh = nil
 	}
@@ -731,6 +720,12 @@ func (e *HashJoinV2Exec) OpenSelf() error {
 	e.inRestore = false
 	needScanRowTableAfterProbeDone := e.ProbeWorkers[0].JoinProbe.NeedScanRowTable()
 	e.HashJoinCtxV2.needScanRowTableAfterProbeDone = needScanRowTableAfterProbeDone
+	// Rows emitted from the row table after probing has finished do not follow the probe
+	// order, and the scan is split across Concurrency workers while only probeConcurrency()
+	// of them run. canKeepProbeOrder rejects every build-side choice that needs this scan,
+	// so the two must never be set together.
+	intest.Assert(!e.KeepProbeOrder || !needScanRowTableAfterProbeDone,
+		"an order-preserving hash join must not need to scan the row table after probing")
 	if e.RightAsBuildSide {
 		e.hashTableMeta = newTableMeta(e.BuildWorkers[0].BuildKeyColIdx, e.BuildWorkers[0].BuildTypes,
 			e.BuildKeyTypes, e.ProbeKeyTypes, e.RUsedInOtherCondition, e.RUsed, needScanRowTableAfterProbeDone)
@@ -755,7 +750,9 @@ func (e *HashJoinV2Exec) OpenSelf() error {
 	e.spillHelper = newHashJoinSpillHelper(e, int(e.partitionNumber), e.ProbeSideTupleFetcher.ProbeSideExec.RetFieldTypes(), e.FileNamePrefixForTest)
 	e.maxSpillRound = 1
 
-	if vardef.EnableTmpStorageOnOOM.Load() && e.partitionNumber > 1 {
+	// An order-preserving join must not spill, see setCanSpillFlag, so it never installs
+	// the spill action in the first place.
+	if vardef.EnableTmpStorageOnOOM.Load() && e.partitionNumber > 1 && !e.KeepProbeOrder {
 		e.initMaxSpillRound()
 		e.spillAction = newHashJoinSpillAction(e.spillHelper)
 		e.Ctx().GetSessionVars().MemTracker.FallbackOldAndSetNewAction(e.spillAction)
@@ -768,9 +765,8 @@ func (e *HashJoinV2Exec) OpenSelf() error {
 
 	if e.RuntimeStats() != nil && e.stats == nil {
 		e.stats = &hashJoinRuntimeStatsV2{}
-		// Build phase always uses full concurrency.
+		// Build and probe no longer necessarily run at the same width.
 		e.stats.buildConcurrent = int(e.Concurrency)
-		// Probe phase uses probeConcurrency() which returns 1 when KeepProbeOrder is true.
 		e.stats.concurrent = int(e.probeConcurrency())
 	}
 
@@ -809,8 +805,6 @@ func (e *HashJoinV2Exec) canSkipProbeIfHashTableIsEmpty() bool {
 
 func (e *HashJoinV2Exec) initializeForProbe() {
 	e.ProbeSideTupleFetcher.HashJoinCtxV2 = e.HashJoinCtxV2
-	// Use probeConcurrency() to get the number of probe workers.
-	// When KeepProbeOrder is true, this returns 1 to maintain probe-side order.
 	probeConcurrency := e.probeConcurrency()
 	// e.joinResultCh is for transmitting the join result chunks to the main thread.
 	e.joinResultCh = make(chan *hashjoinWorkerResult, probeConcurrency+1)
@@ -818,12 +812,6 @@ func (e *HashJoinV2Exec) initializeForProbe() {
 	e.ProbeSideTupleFetcher.canSkipProbeIfHashTableIsEmpty = e.canSkipProbeIfHashTableIsEmpty()
 	// set buildSuccess to false by default, it will be set to true if build finishes successfully
 	e.ProbeSideTupleFetcher.buildSuccess = false
-
-	// Initialize requiredRows to ExpectedCnt for order-preserving joins with LIMIT.
-	// This ensures the first chunk fetch uses the small LIMIT value instead of maxChunkSize.
-	if e.KeepProbeOrder && e.ExpectedCnt > 0 {
-		atomic.StoreInt64(&e.ProbeSideTupleFetcher.requiredRows, int64(e.ExpectedCnt))
-	}
 
 	for i := range probeConcurrency {
 		e.ProbeWorkers[i].initializeForProbe(e.ProbeSideTupleFetcher.probeChkResourceCh, e.ProbeSideTupleFetcher.probeResultChs[i], e)
@@ -865,8 +853,6 @@ func (e *HashJoinV2Exec) startProbeJoinWorkers(ctx context.Context) {
 		e.ProbeSideTupleFetcher.buildSuccess = true
 	}
 
-	// Use probeConcurrency() to get the number of probe workers.
-	// When KeepProbeOrder is true, this returns 1 to maintain probe-side order.
 	probeConcurrency := e.probeConcurrency()
 	for i := range probeConcurrency {
 		workerID := i
@@ -911,7 +897,6 @@ func (e *HashJoinV2Exec) waitJoinWorkers(start time.Time) {
 	e.workerWg.Wait()
 	if e.stats != nil {
 		e.HashJoinCtxV2.stats.fetchAndProbe += int64(time.Since(start))
-		// Only collect stats from initialized probe workers.
 		for i := range e.probeConcurrency() {
 			e.stats.probeCollision += int64(e.ProbeWorkers[i].JoinProbe.GetProbeCollision())
 		}
@@ -919,7 +904,6 @@ func (e *HashJoinV2Exec) waitJoinWorkers(start time.Time) {
 
 	if e.ProbeSideTupleFetcher.buildSuccess {
 		// only scan row table if build is successful
-		// Use probeConcurrency() to only scan with initialized workers.
 		if e.ProbeWorkers[0] != nil && e.ProbeWorkers[0].JoinProbe.NeedScanRowTable() {
 			for i := range e.probeConcurrency() {
 				var workerID = i
@@ -1000,39 +984,9 @@ func (w *ProbeWorkerV2) probeAndSendResult(joinResult *hashjoinWorkerResult) (bo
 		}
 
 		failpoint.Inject("processOneProbeChunkPanic", nil)
-
-		// Early termination for ORDER BY LIMIT: check if we have enough rows
-		// even when the chunk is not full. This is critical for small LIMIT values
-		// (e.g., LIMIT 1) where we don't want to process more rows than necessary.
-		// We check the cumulative total (current matchedRows + this chunk) to ensure
-		// consistent behavior with the full chunk case below.
-		if w.HashJoinCtx.KeepProbeOrder && w.HashJoinCtx.ExpectedCnt > 0 {
-			currentRows := atomic.LoadInt64(&w.HashJoinCtx.matchedRows)
-			newTotal := currentRows + int64(joinResult.chk.NumRows())
-			if float64(newTotal) >= w.HashJoinCtx.ExpectedCnt {
-				waitStart := time.Now()
-				w.HashJoinCtx.joinResultCh <- joinResult
-				atomic.StoreInt64(&w.HashJoinCtx.matchedRows, newTotal)
-				w.HashJoinCtx.finished.Store(true)
-				waitTime += int64(time.Since(waitStart))
-				return false, waitTime, joinResult
-			}
-		}
-
 		if joinResult.chk.IsFull() {
 			waitStart := time.Now()
 			w.HashJoinCtx.joinResultCh <- joinResult
-
-			// Track matched rows for early termination (full chunk case).
-			if w.HashJoinCtx.KeepProbeOrder && w.HashJoinCtx.ExpectedCnt > 0 {
-				newTotal := atomic.AddInt64(&w.HashJoinCtx.matchedRows, int64(joinResult.chk.NumRows()))
-				if float64(newTotal) >= w.HashJoinCtx.ExpectedCnt {
-					w.HashJoinCtx.finished.Store(true)
-					waitTime += int64(time.Since(waitStart))
-					return false, waitTime, joinResult
-				}
-			}
-
 			ok, joinResult = w.getNewJoinResult()
 			waitTime += int64(time.Since(waitStart))
 			if !ok {
@@ -1126,9 +1080,6 @@ func (e *HashJoinV2Exec) reset() {
 	e.ProbeSideTupleFetcher.buildSuccess = false
 	e.resetHashTableContextForRestore()
 	e.spillHelper.setCanSpillFlag(true)
-	// Reset matchedRows counter to avoid incorrect early termination when the executor
-	// is reused (e.g., multiple rounds due to spilling, or reuse in Apply operator)
-	atomic.StoreInt64(&e.HashJoinCtxV2.matchedRows, 0)
 	if e.HashJoinCtxV2.stats != nil {
 		e.HashJoinCtxV2.stats.resetCurrentRound()
 	}
@@ -1212,7 +1163,6 @@ func (e *HashJoinV2Exec) startBuildAndProbe(ctx context.Context) {
 }
 
 func (e *HashJoinV2Exec) resetProbeStatus() {
-	// Only reset initialized probe workers.
 	for i := range e.probeConcurrency() {
 		e.ProbeWorkers[i].JoinProbe.ResetProbe()
 	}

--- a/pkg/executor/test/jointest/hashjoin/BUILD.bazel
+++ b/pkg/executor/test/jointest/hashjoin/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 24,
+    shard_count = 27,
     deps = [
         "//pkg/config",
         "//pkg/executor/join",

--- a/pkg/executor/test/jointest/hashjoin/hash_join_test.go
+++ b/pkg/executor/test/jointest/hashjoin/hash_join_test.go
@@ -1035,3 +1035,153 @@ func TestIssue56825(t *testing.T) {
 		tk.MustQuery("select * from t1 right join t2 on t1.id = t2.id and t1.col1 <= t2.col1 order by t2.id").Check(testkit.Rows("1 2 1 2 3 4 5 6", "<nil> <nil> 3 4 5 6 7 8", "<nil> <nil> 4 5 6 7 8 9"))
 	}
 }
+
+// orderPreservingHashJoinData builds a probe table with an index on the ordering column
+// and a small build table that only covers part of the probe side's join keys.
+func orderPreservingHashJoinData(t *testing.T, tk *testkit.TestKit) {
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists probe, build")
+	tk.MustExec("create table probe(a int, b int, key(b))")
+	tk.MustExec("create table build(a int, c int)")
+	probeRows := make([]string, 0, 20000)
+	for i := range 20000 {
+		probeRows = append(probeRows, fmt.Sprintf("(%d,%d)", i%50, i))
+	}
+	tk.MustExec("insert into probe values " + strings.Join(probeRows, ","))
+	buildRows := make([]string, 0, 40)
+	for i := range 40 {
+		buildRows = append(buildRows, fmt.Sprintf("(%d,%d)", i, i*10))
+	}
+	tk.MustExec("insert into build values " + strings.Join(buildRows, ","))
+	tk.MustExec("analyze table probe, build")
+}
+
+// requireOrderedBy checks that col of every returned row is non-decreasing, which is what
+// an order-preserving hash join promises the Limit above it.
+func requireOrderedBy(t *testing.T, rows [][]any, col int) {
+	prev := -1
+	for i, row := range rows {
+		s := fmt.Sprintf("%v", row[col])
+		if s == "<nil>" {
+			continue
+		}
+		var v int
+		_, err := fmt.Sscanf(s, "%d", &v)
+		require.NoError(t, err)
+		require.LessOrEqualf(t, prev, v, "row %d breaks the ordering: %d after %d", i, v, prev)
+		prev = v
+	}
+}
+
+// TestOrderPreservingHashJoin covers the hash join that serves ORDER BY from its probe
+// side instead of leaving a Sort above the join.
+func TestOrderPreservingHashJoin(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	orderPreservingHashJoinData(t, tk)
+
+	// The shapes the optimization is meant for: the ordering comes from the probe side and
+	// the parent only wants a few rows, so the Sort/TopN disappears.
+	for _, q := range []string{
+		"select /*+ hash_join(probe, build) */ probe.b from probe join build on probe.a = build.a order by probe.b limit 10",
+		"select /*+ hash_join(probe, build) */ probe.b from probe where probe.a in (select a from build) order by probe.b limit 10",
+		"select /*+ hash_join(probe, build) */ probe.b from probe where not exists (select 1 from build where build.a = probe.a) order by probe.b limit 10",
+	} {
+		plan := tk.MustQuery("explain " + q).String()
+		require.Containsf(t, plan, "keep probe order:true", "expected an order-preserving hash join for %s, got:\n%s", q, plan)
+		require.NotContainsf(t, plan, "TopN", "the TopN should be gone for %s, got:\n%s", q, plan)
+		requireOrderedBy(t, tk.MustQuery(q).Rows(), 0)
+	}
+
+	// A filter between the Limit and the join makes the join produce more rows than the
+	// Limit asks for; every one of them still has to come out.
+	q := "select /*+ hash_join(probe, build) */ probe.b from probe join build on probe.a = build.a where build.c > 100 order by probe.b limit 2000"
+	require.Contains(t, tk.MustQuery("explain "+q).String(), "keep probe order:true")
+	rows := tk.MustQuery(q).Rows()
+	require.Len(t, rows, 2000)
+	requireOrderedBy(t, rows, 0)
+}
+
+// TestOrderPreservingHashJoinRejected pins the cases the planner must not claim it can
+// order, because the executor that would run them does not preserve the probe order.
+func TestOrderPreservingHashJoinRejected(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	orderPreservingHashJoinData(t, tk)
+
+	for _, tc := range []struct {
+		name string
+		prep string
+		sql  string
+	}{
+		{
+			// Hash join v1 has no order-preserving probe at all.
+			name: "hash join v1",
+			prep: "set @@tidb_hash_join_version = 'legacy'",
+			sql:  "select /*+ hash_join(probe, build) */ probe.b from probe join build on probe.a = build.a order by probe.b limit 3000",
+		},
+		{
+			// NullEQ keys are not supported by v2, so this falls back to v1.
+			name: "null-safe equal",
+			sql:  "select /*+ hash_join(probe, build) */ probe.b from probe join build on probe.a <=> build.a order by probe.b limit 3000",
+		},
+		{
+			// A cartesian join has no equal conditions, which v2 does not support either.
+			name: "cartesian join",
+			sql:  "select /*+ hash_join(probe, build) */ probe.b from probe join build on probe.a > build.a order by probe.b limit 3000",
+		},
+		{
+			// outerJoinProbe appends a batch's null-extended rows after that batch's
+			// matched rows, so probe order does not survive an outer join.
+			name: "left outer join",
+			sql:  "select /*+ hash_join(probe, build) */ probe.b from probe left join build on probe.a = build.a order by probe.b limit 3000",
+		},
+		{
+			// Without a limit the probe side is read to the end anyway, so there is
+			// nothing to gain from giving up probe parallelism.
+			name: "no limit",
+			sql:  "select /*+ hash_join(probe, build) */ probe.b from probe join build on probe.a = build.a order by probe.b",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tk := testkit.NewTestKit(t, store)
+			tk.MustExec("use test")
+			if tc.prep != "" {
+				tk.MustExec(tc.prep)
+			}
+			plan := tk.MustQuery("explain " + tc.sql).String()
+			require.NotContainsf(t, plan, "keep probe order:true",
+				"%s must not be planned as an order-preserving hash join, got:\n%s", tc.name, plan)
+			requireOrderedBy(t, tk.MustQuery(tc.sql).Rows(), 0)
+		})
+	}
+}
+
+// TestOrderPreservingHashJoinOuterBuild makes sure a build side that is also the outer
+// side keeps emitting all of its unmatched rows: that scan is split across Concurrency
+// workers, while an order-preserving join only runs one of them.
+func TestOrderPreservingHashJoinOuterBuild(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists big, small")
+	tk.MustExec("create table big(a int, b int)")
+	tk.MustExec("create table small(a int, c int, key(c))")
+	bigRows := make([]string, 0, 20000)
+	for i := range 20000 {
+		bigRows = append(bigRows, fmt.Sprintf("(%d,%d)", i, i))
+	}
+	tk.MustExec("insert into big values " + strings.Join(bigRows, ","))
+	smallRows := make([]string, 0, 3000)
+	for i := range 3000 {
+		smallRows = append(smallRows, fmt.Sprintf("(%d,%d)", i, i))
+	}
+	tk.MustExec("insert into small values " + strings.Join(smallRows, ","))
+	tk.MustExec("analyze table big, small")
+
+	q := "select /*+ hash_join(big, small), hash_join_build(big) */ small.c, big.b from big left join small on big.a = small.a order by small.c limit 20000"
+	require.NotContains(t, tk.MustQuery("explain "+q).String(), "keep probe order:true")
+	rows := tk.MustQuery(q).Rows()
+	require.Len(t, rows, 20000)
+	requireOrderedBy(t, rows, 0)
+}

--- a/pkg/planner/core/casetest/dag/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/dag/testdata/plan_suite_out.json
@@ -318,7 +318,7 @@
       },
       {
         "SQL": "select /*+ TIDB_HJ(t1, t2) */ * from t t1 join t t2 on t1.b = t2.a order by t1.a limit 1",
-        "Best": "LeftHashJoin{TableReader(Table(t))->TableReader(Table(t))}(test.t.b,test.t.a)->TopN([test.t.a],0,1)"
+        "Best": "LeftHashJoin{TableReader(Table(t))->TableReader(Table(t))}(test.t.b,test.t.a)->Limit"
       },
       {
         "SQL": "select * from t t1 left join t t2 on t1.b = t2.a where 1 = 1 limit 1",

--- a/pkg/planner/core/casetest/rule/testdata/order_aware_join_reorder_suite_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/order_aware_join_reorder_suite_out.json
@@ -99,9 +99,9 @@
         "SQL": "explain format = 'plan_tree' select t6.id, t7.payload, t8.payload, t9.payload from t7 join t8 on t7.id = t8.id join t9 on t8.id = t9.id join t6 on t6.id = t7.id where t6.category = 'hot' and t9.payload = 1 order by t6.id limit 2",
         "Plan": [
           "Projection root  test.t6.id, test.t7.payload, test.t8.payload, test.t9.payload",
-          "└─TopN root  test.t6.id, offset:0, count:2",
+          "└─Limit root  offset:0, count:2",
           "  └─Projection root  test.t7.payload, test.t8.payload, test.t9.payload, test.t6.id",
-          "    └─IndexJoin root  inner join, inner:IndexReader, outer key:test.t7.id, inner key:test.t6.id, equal cond:eq(test.t7.id, test.t6.id)",
+          "    └─HashJoin root  inner join, equal:[eq(test.t7.id, test.t6.id)], keep probe order:true",
           "      ├─IndexHashJoin(Build) root  inner join, inner:IndexLookUp, outer key:test.t8.id, inner key:test.t7.id, equal cond:eq(test.t8.id, test.t7.id)",
           "      │ ├─IndexJoin(Build) root  inner join, inner:IndexLookUp, outer key:test.t9.id, inner key:test.t8.id, equal cond:eq(test.t9.id, test.t8.id)",
           "      │ │ ├─IndexReader(Build) root  index:IndexRangeScan",
@@ -113,7 +113,7 @@
           "      │   ├─IndexRangeScan(Build) cop[tikv] table:t7, index:idx_id(id) range: decided by [eq(test.t7.id, test.t8.id)], keep order:false",
           "      │   └─TableRowIDScan(Probe) cop[tikv] table:t7 keep order:false",
           "      └─IndexReader(Probe) root  index:IndexRangeScan",
-          "        └─IndexRangeScan cop[tikv] table:t6, index:idx_category_id_payload(category, id, payload) range: decided by [eq(test.t6.id, test.t7.id) eq(test.t6.category, hot)], keep order:false"
+          "        └─IndexRangeScan cop[tikv] table:t6, index:idx_category_id_payload(category, id, payload) range:[\"hot\",\"hot\"], keep order:true"
         ]
       },
       {
@@ -126,19 +126,19 @@
           "Projection root  test.t6.id, test.t7.payload, test.t8.payload, test.t9.payload",
           "└─Limit root  offset:0, count:2",
           "  └─Projection root  test.t7.payload, test.t8.payload, test.t9.payload, test.t6.id",
-          "    └─IndexJoin root  inner join, inner:IndexReader, outer key:test.t8.id, inner key:test.t9.id, equal cond:eq(test.t8.id, test.t9.id)",
-          "      ├─IndexHashJoin(Build) root  inner join, inner:IndexLookUp, outer key:test.t7.id, inner key:test.t8.id, equal cond:eq(test.t7.id, test.t8.id)",
-          "      │ ├─IndexHashJoin(Build) root  inner join, inner:IndexLookUp, outer key:test.t6.id, inner key:test.t7.id, equal cond:eq(test.t6.id, test.t7.id)",
-          "      │ │ ├─IndexReader(Build) root  index:IndexRangeScan",
-          "      │ │ │ └─IndexRangeScan cop[tikv] table:t6, index:idx_category_id_payload(category, id, payload) range:[\"hot\",\"hot\"], keep order:true",
-          "      │ │ └─IndexLookUp(Probe) root  ",
-          "      │ │   ├─IndexRangeScan(Build) cop[tikv] table:t7, index:idx_id(id) range: decided by [eq(test.t7.id, test.t6.id)], keep order:false",
-          "      │ │   └─TableRowIDScan(Probe) cop[tikv] table:t7 keep order:false",
-          "      │ └─IndexLookUp(Probe) root  ",
-          "      │   ├─IndexRangeScan(Build) cop[tikv] table:t8, index:idx_id(id) range: decided by [eq(test.t8.id, test.t7.id)], keep order:false",
-          "      │   └─TableRowIDScan(Probe) cop[tikv] table:t8 keep order:false",
-          "      └─IndexReader(Probe) root  index:IndexRangeScan",
-          "        └─IndexRangeScan cop[tikv] table:t9, index:idx_payload_id(payload, id) range: decided by [eq(test.t9.id, test.t8.id) eq(test.t9.payload, 1)], keep order:false"
+          "    └─HashJoin root  inner join, equal:[eq(test.t8.id, test.t9.id)], keep probe order:true",
+          "      ├─IndexReader(Build) root  index:IndexRangeScan",
+          "      │ └─IndexRangeScan cop[tikv] table:t9, index:idx_payload_id(payload, id) range:[1,1], keep order:false",
+          "      └─IndexHashJoin(Probe) root  inner join, inner:IndexLookUp, outer key:test.t7.id, inner key:test.t8.id, equal cond:eq(test.t7.id, test.t8.id)",
+          "        ├─IndexHashJoin(Build) root  inner join, inner:IndexLookUp, outer key:test.t6.id, inner key:test.t7.id, equal cond:eq(test.t6.id, test.t7.id)",
+          "        │ ├─IndexReader(Build) root  index:IndexRangeScan",
+          "        │ │ └─IndexRangeScan cop[tikv] table:t6, index:idx_category_id_payload(category, id, payload) range:[\"hot\",\"hot\"], keep order:true",
+          "        │ └─IndexLookUp(Probe) root  ",
+          "        │   ├─IndexRangeScan(Build) cop[tikv] table:t7, index:idx_id(id) range: decided by [eq(test.t7.id, test.t6.id)], keep order:false",
+          "        │   └─TableRowIDScan(Probe) cop[tikv] table:t7 keep order:false",
+          "        └─IndexLookUp(Probe) root  ",
+          "          ├─IndexRangeScan(Build) cop[tikv] table:t8, index:idx_id(id) range: decided by [eq(test.t8.id, test.t7.id)], keep order:false",
+          "          └─TableRowIDScan(Probe) cop[tikv] table:t8 keep order:false"
         ]
       }
     ]

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -130,8 +130,12 @@ func getHashJoins(super base.LogicalPlan, prop *property.PhysicalProperty) (join
 			} else if sortColsFromRight && !sortColsFromLeft {
 				keepProbeOrder = true
 			}
-			// If sort columns from both sides or neither - can't preserve order, but still continue
-			// to generate regular hash joins (keepProbeOrder remains false)
+			// If sort columns come from both sides or neither, hash join cannot satisfy this ORDER BY.
+			// Don't return hash joins here - the planner will try separately with empty property
+			// and add Sort on top if needed. This ensures hash join still competes.
+			if !keepProbeOrder {
+				return
+			}
 		}
 	}
 

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -109,8 +109,61 @@ func exhaustPhysicalPlans(lp base.LogicalPlan, prop *property.PhysicalProperty) 
 
 func getHashJoins(super base.LogicalPlan, prop *property.PhysicalProperty) (joins []base.PhysicalPlan, forced bool) {
 	ge, p := base.GetGEAndLogicalOp[*logicalop.LogicalJoin](super)
-	if !prop.IsSortItemEmpty() { // hash join doesn't promise any orders
-		return
+
+	// Check if we can preserve ordering from the probe side.
+	// This allows ORDER BY ... LIMIT queries to avoid a sort when the probe side has an index.
+	// We should only consider order-preserving hash join when the build side (inner)
+	// cannot provide sorted output on join keys - otherwise MergeJoin is more appropriate.
+	keepProbeOrder := false
+	sortColsFromLeft := false
+	sortColsFromRight := false
+	if !prop.IsSortItemEmpty() {
+		_, _, leftSchema, rightSchema := getJoinChildStatsAndSchema(ge, super)
+		if leftSchema != nil && rightSchema != nil {
+			for _, item := range prop.SortItems {
+				if leftSchema.Contains(item.Col) {
+					sortColsFromLeft = true
+				}
+				if rightSchema.Contains(item.Col) {
+					sortColsFromRight = true
+				}
+			}
+
+			// Only enable order-preserving hash join if all sort columns come from exactly one side
+			if (sortColsFromLeft && !sortColsFromRight) || (sortColsFromRight && !sortColsFromLeft) {
+				// Check if ORDER BY columns match the join keys.
+				// If they do AND the build side can also provide sorted output (has index),
+				// MergeJoin can satisfy ORDER BY directly - don't generate order-preserving hash join.
+				// If ORDER BY matches join keys but build side cannot provide order (no index),
+				// order-preserving hash join is beneficial and should be generated.
+				leftJoinKeys, rightJoinKeys, _, _ := p.GetJoinKeys()
+				sortColsAreJoinKeys := false
+
+				if sortColsFromLeft {
+					sortColsAreJoinKeys = columnsMatchJoinKeys(prop.SortItems, leftJoinKeys)
+				} else {
+					sortColsAreJoinKeys = columnsMatchJoinKeys(prop.SortItems, rightJoinKeys)
+				}
+
+				if sortColsAreJoinKeys {
+					// ORDER BY matches join keys. Check if build side can provide sorted output.
+					// For order-preserving hash join, the ORDER BY side becomes the probe side.
+					// So the OTHER side becomes the build side.
+					// Only skip order-preserving hash join if BOTH sides can provide sorted output
+					// (i.e., both have indexes on join keys), making MergeJoin optimal.
+					buildSideCanProvideOrder := buildSideHasIndexOnJoinKeys(super, sortColsFromLeft, leftJoinKeys, rightJoinKeys)
+					if !buildSideCanProvideOrder {
+						// Build side cannot provide order - order-preserving hash join is beneficial
+						keepProbeOrder = true
+					}
+					// If build side CAN provide order, MergeJoin is optimal - don't set keepProbeOrder
+				} else {
+					// ORDER BY doesn't match join keys - order-preserving hash join helps
+					keepProbeOrder = true
+				}
+			}
+			// If sort columns from both sides or neither - can't preserve order
+		}
 	}
 
 	forceLeftToBuild := ((p.PreferJoinType & h.PreferLeftAsHJBuild) > 0) || ((p.PreferJoinType & h.PreferRightAsHJProbe) > 0)
@@ -133,13 +186,13 @@ func getHashJoins(super base.LogicalPlan, prop *property.PhysicalProperty) (join
 		leftNAJoinKeys, _ := p.GetNAJoinKeys()
 		if p.SCtx().GetSessionVars().UseHashJoinV2 && joinversion.IsHashJoinV2Supported() && physicalop.CanUseHashJoinV2(p.JoinType, leftJoinKeys, isNullEQ, leftNAJoinKeys) {
 			if !forceLeftToBuild {
-				appendHashJoins(getHashJoin(ge, p, prop, 1, false))
+				appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
 			}
 			if !forceRightToBuild {
-				appendHashJoins(getHashJoin(ge, p, prop, 1, true))
+				appendHashJoins(getHashJoin(ge, p, prop, 1, true, keepProbeOrder, sortColsFromLeft))
 			}
 		} else {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, false))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
 			if forceLeftToBuild || forceRightToBuild {
 				p.SCtx().GetSessionVars().StmtCtx.SetHintWarning(fmt.Sprintf(
 					"The HASH_JOIN_BUILD and HASH_JOIN_PROBE hints are not supported for %s with hash join version 1. "+
@@ -150,7 +203,7 @@ func getHashJoins(super base.LogicalPlan, prop *property.PhysicalProperty) (join
 			}
 		}
 	case base.LeftOuterSemiJoin, base.AntiLeftOuterSemiJoin:
-		appendHashJoins(getHashJoin(ge, p, prop, 1, false))
+		appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
 		if forceLeftToBuild || forceRightToBuild {
 			p.SCtx().GetSessionVars().StmtCtx.SetHintWarning(fmt.Sprintf(
 				"HASH_JOIN_BUILD and HASH_JOIN_PROBE hints are not supported for %s because the build side is fixed. "+
@@ -161,37 +214,37 @@ func getHashJoins(super base.LogicalPlan, prop *property.PhysicalProperty) (join
 		}
 	case base.LeftOuterJoin:
 		if !forceLeftToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, false))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
 		}
 		if !forceRightToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, true))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, true, keepProbeOrder, sortColsFromLeft))
 		}
 	case base.RightOuterJoin:
 		if !forceLeftToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 0, true))
+			appendHashJoins(getHashJoin(ge, p, prop, 0, true, keepProbeOrder, sortColsFromLeft))
 		}
 		if !forceRightToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 0, false))
+			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, sortColsFromLeft))
 		}
 	case base.InnerJoin:
 		if forceLeftToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 0, false))
+			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, sortColsFromLeft))
 		} else if forceRightToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, false))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
 		} else {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, false))
-			appendHashJoins(getHashJoin(ge, p, prop, 0, false))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, sortColsFromLeft))
 		}
 	case base.FullOuterJoin:
 		// For full outer join in the root phase, always use the regular
 		// hash join probe path. Build side is still chosen by cost / hints.
 		if forceLeftToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 0, false))
+			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, sortColsFromLeft))
 		} else if forceRightToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, false))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
 		} else {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, false))
-			appendHashJoins(getHashJoin(ge, p, prop, 0, false))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, sortColsFromLeft))
 		}
 	}
 
@@ -207,13 +260,163 @@ func getHashJoins(super base.LogicalPlan, prop *property.PhysicalProperty) (join
 	return
 }
 
-func getHashJoin(ge base.GroupExpression, p *logicalop.LogicalJoin, prop *property.PhysicalProperty, innerIdx int, useOuterToBuild bool) []*physicalop.PhysicalHashJoin {
+// columnsMatchJoinKeys checks if the ORDER BY sort columns match the join keys.
+// This is used to determine if MergeJoin can satisfy the ORDER BY (when both sides have indexes).
+// If sort columns match join keys, we should NOT generate order-preserving hash join.
+func columnsMatchJoinKeys(sortItems []property.SortItem, joinKeys []*expression.Column) bool {
+	if len(sortItems) == 0 || len(joinKeys) == 0 {
+		return false
+	}
+	// Check if all sort columns are in the join keys
+	for _, item := range sortItems {
+		found := false
+		for _, key := range joinKeys {
+			if item.Col.EqualColumn(key) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// buildSideHasIndexOnJoinKeys checks if the build side (opposite of ORDER BY side) has an index
+// on the join keys. If the build side can provide sorted output, MergeJoin is optimal and we
+// should not generate order-preserving hash join.
+// sortColsFromLeft: true if ORDER BY columns come from left side (so right is build side)
+func buildSideHasIndexOnJoinKeys(super base.LogicalPlan, sortColsFromLeft bool, leftJoinKeys, rightJoinKeys []*expression.Column) bool {
+	// Get the join's children
+	children := super.Children()
+	if len(children) != 2 {
+		return false
+	}
+
+	// Determine which child is the build side (opposite of ORDER BY side)
+	var buildChild base.LogicalPlan
+	var buildJoinKeys []*expression.Column
+	if sortColsFromLeft {
+		// ORDER BY from left, so right is build side
+		buildChild = children[1]
+		buildJoinKeys = rightJoinKeys
+	} else {
+		// ORDER BY from right, so left is build side
+		buildChild = children[0]
+		buildJoinKeys = leftJoinKeys
+	}
+
+	// Traverse to find DataSource
+	return hasIndexOnColumns(buildChild, buildJoinKeys)
+}
+
+// hasIndexOnColumns recursively checks if any DataSource under the plan has an index
+// covering the given columns (typically join keys).
+func hasIndexOnColumns(plan base.LogicalPlan, cols []*expression.Column) bool {
+	if len(cols) == 0 {
+		return false
+	}
+
+	// Check if this is a DataSource
+	if ds, ok := plan.(*logicalop.DataSource); ok {
+		// Check if any index covers the join key columns
+		for _, path := range ds.PossibleAccessPaths {
+			if path.IsTablePath() {
+				continue
+			}
+			// Check if this index covers the join key
+			if indexCoversColumns(path, cols, ds) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Recursively check children
+	for _, child := range plan.Children() {
+		if hasIndexOnColumns(child, cols) {
+			return true
+		}
+	}
+	return false
+}
+
+// indexCoversColumns checks if an index path covers the specified columns.
+// This is a simplified check - we verify that the join key columns match leading index columns.
+func indexCoversColumns(path *util.AccessPath, cols []*expression.Column, ds *logicalop.DataSource) bool {
+	if path.Index == nil || len(path.Index.Columns) == 0 {
+		return false
+	}
+
+	// Get the table info to find column offset
+	tblInfo := ds.TableInfo
+	if tblInfo == nil {
+		return false
+	}
+
+	// Check if join key columns match the leading index columns
+	for _, col := range cols {
+		found := false
+		// Find this column's offset in the table
+		colOffset := -1
+		for i, tblCol := range tblInfo.Columns {
+			if col.ID == tblCol.ID {
+				colOffset = i
+				break
+			}
+		}
+		if colOffset < 0 {
+			continue
+		}
+
+		// Check if this column is a leading index column
+		for i, idxCol := range path.Index.Columns {
+			if i >= len(cols) {
+				break
+			}
+			if idxCol.Offset == colOffset {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func getHashJoin(ge base.GroupExpression, p *logicalop.LogicalJoin, prop *property.PhysicalProperty, innerIdx int, useOuterToBuild bool, keepProbeOrder bool, sortColsFromLeft bool) []*physicalop.PhysicalHashJoin {
 	var stats0, stats1 *property.StatsInfo
 	if ge != nil {
 		stats0, stats1, _, _ = ge.GetJoinChildStatsAndSchema()
 	} else {
 		stats0, stats1, _, _ = p.GetJoinChildStatsAndSchema()
 	}
+
+	// Determine which side is the probe side
+	// When useOuterToBuild=false: build = innerIdx, probe = 1-innerIdx
+	// When useOuterToBuild=true: build = 1-innerIdx, probe = innerIdx
+	var probeIdx int
+	if useOuterToBuild {
+		probeIdx = innerIdx
+	} else {
+		probeIdx = 1 - innerIdx
+	}
+
+	// If we need to preserve order, check if the probe side matches the sort columns side
+	if keepProbeOrder {
+		// sortColsFromLeft=true means we need left (idx 0) to be probe
+		// sortColsFromLeft=false means we need right (idx 1) to be probe
+		if sortColsFromLeft && probeIdx != 0 {
+			return nil // Can't preserve order with this configuration
+		}
+		if !sortColsFromLeft && probeIdx != 1 {
+			return nil // Can't preserve order with this configuration
+		}
+	}
+
 	var outerStats *property.StatsInfo
 	if 1-innerIdx == 0 {
 		outerStats = stats0
@@ -221,10 +424,15 @@ func getHashJoin(ge base.GroupExpression, p *logicalop.LogicalJoin, prop *proper
 		outerStats = stats1
 	}
 	newTwoBaseProps := func() [2]*property.PhysicalProperty {
-		return [2]*property.PhysicalProperty{
+		props := [2]*property.PhysicalProperty{
 			{ExpectedCnt: math.MaxFloat64, CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: prop.NoCopPushDown},
 			{ExpectedCnt: math.MaxFloat64, CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: prop.NoCopPushDown},
 		}
+		// If preserving order, pass the sort items down to the probe side child.
+		if keepProbeOrder {
+			props[probeIdx].SortItems = prop.SortItems
+		}
+		return props
 	}
 	adjustStatsAndGetJoin := func(chReqProps [2]*property.PhysicalProperty) *physicalop.PhysicalHashJoin {
 		if prop.ExpectedCnt < p.StatsInfo().RowCount {
@@ -233,6 +441,14 @@ func getHashJoin(ge base.GroupExpression, p *logicalop.LogicalJoin, prop *proper
 		}
 		hashJoin := physicalop.NewPhysicalHashJoin(p, innerIdx, useOuterToBuild, p.StatsInfo().ScaleByExpectCnt(p.SCtx().GetSessionVars(), prop.ExpectedCnt), chReqProps[0], chReqProps[1])
 		hashJoin.SetSchema(p.Schema())
+		// Set KeepProbeOrder for order-preserving hash join.
+		// Note: We don't set Concurrency=1 here because we want full concurrency for the BUILD phase.
+		// Single-threaded PROBING is handled in the executor when KeepProbeOrder is true.
+		if keepProbeOrder {
+			hashJoin.KeepProbeOrder = true
+			// Pass expected count for early termination optimization
+			hashJoin.ExpectedCnt = prop.ExpectedCnt
+		}
 		return hashJoin
 	}
 	res := make([]*physicalop.PhysicalHashJoin, 0, 2)
@@ -2352,7 +2568,7 @@ func pushLimitOrTopNForcibly(p base.LogicalPlan, pp base.PhysicalPlan) (preferPu
 
 // GetHashJoin is public for cascades planner.
 func GetHashJoin(ge base.GroupExpression, la *logicalop.LogicalApply, prop *property.PhysicalProperty) *physicalop.PhysicalHashJoin {
-	joins := getHashJoin(ge, &la.LogicalJoin, prop, 1, false)
+	joins := getHashJoin(ge, &la.LogicalJoin, prop, 1, false, false, false)
 	if len(joins) == 0 {
 		panic("GetHashJoin for LogicalApply should always produce at least one hash join plan")
 	}

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -110,66 +110,32 @@ func exhaustPhysicalPlans(lp base.LogicalPlan, prop *property.PhysicalProperty) 
 func getHashJoins(super base.LogicalPlan, prop *property.PhysicalProperty) (joins []base.PhysicalPlan, forced bool) {
 	ge, p := base.GetGEAndLogicalOp[*logicalop.LogicalJoin](super)
 
-	// Check if we can preserve ordering from the probe side.
-	// This allows ORDER BY ... LIMIT queries to avoid a sort when the probe side has an index.
-	// We should only consider order-preserving hash join when the build side (inner)
-	// cannot provide sorted output on join keys - otherwise MergeJoin is more appropriate.
-	keepProbeOrder := false
-	sortColsFromLeft := false
-	sortColsFromRight := false
+	// A hash join normally promises no order, but it can deliver the order of its probe
+	// side: with a single probe worker the joined rows leave the operator in probe-row
+	// order. canKeepProbeOrder decides whether that is admissible here; when it is not,
+	// this join cannot satisfy prop at all and we bail out just like an ordinary hash join.
+	keepProbeOrder, probeIsLeft := false, false
 	if !prop.IsSortItemEmpty() {
-		_, _, leftSchema, rightSchema := getJoinChildStatsAndSchema(ge, super)
-		if leftSchema != nil && rightSchema != nil {
-			for _, item := range prop.SortItems {
-				if leftSchema.Contains(item.Col) {
-					sortColsFromLeft = true
-				}
-				if rightSchema.Contains(item.Col) {
-					sortColsFromRight = true
-				}
-			}
+		keepProbeOrder, probeIsLeft = canKeepProbeOrder(ge, super, p, prop)
+		if !keepProbeOrder {
+			return
+		}
+	}
 
-			// Only enable order-preserving hash join if all sort columns come from exactly one side
-			if (sortColsFromLeft && !sortColsFromRight) || (sortColsFromRight && !sortColsFromLeft) {
-				// Check if ORDER BY columns match the join keys.
-				// If they do AND the build side can also provide sorted output (has index),
-				// MergeJoin can satisfy ORDER BY directly - don't generate order-preserving hash join.
-				// If ORDER BY matches join keys but build side cannot provide order (no index),
-				// order-preserving hash join is beneficial and should be generated.
-				leftJoinKeys, rightJoinKeys, _, _ := p.GetJoinKeys()
-				sortColsAreJoinKeys := false
-
-				if sortColsFromLeft {
-					sortColsAreJoinKeys = columnsMatchJoinKeys(prop.SortItems, leftJoinKeys)
-				} else {
-					sortColsAreJoinKeys = columnsMatchJoinKeys(prop.SortItems, rightJoinKeys)
-				}
-
-				if sortColsAreJoinKeys {
-					// ORDER BY matches join keys. Check if build side can provide sorted output.
-					// For order-preserving hash join, the ORDER BY side becomes the probe side.
-					// So the OTHER side becomes the build side.
-					// Only skip order-preserving hash join if BOTH sides can provide sorted output
-					// (i.e., both have indexes on join keys), making MergeJoin optimal.
-					buildSideCanProvideOrder := buildSideHasIndexOnJoinKeys(super, sortColsFromLeft, leftJoinKeys, rightJoinKeys)
-					if !buildSideCanProvideOrder {
-						// Build side cannot provide order - order-preserving hash join is beneficial
-						keepProbeOrder = true
-					}
-					// If build side CAN provide order, MergeJoin is optimal - don't set keepProbeOrder
-				} else {
-					// ORDER BY doesn't match join keys - order-preserving hash join helps
-					keepProbeOrder = true
-				}
-			}
-			// If sort columns from both sides or neither - can't preserve order
+	// The hint warnings below say whether a hint is applicable to this join at all, which
+	// has nothing to do with the property being enumerated. A join is enumerated once per
+	// distinct property, so emitting them from every call would repeat them; keep them on
+	// the sort-free call, which is the only one that used to reach this code.
+	warnAboutHint := func(reason string) {
+		if prop.IsSortItemEmpty() {
+			p.SCtx().GetSessionVars().StmtCtx.SetHintWarning(reason)
 		}
 	}
 
 	forceLeftToBuild := ((p.PreferJoinType & h.PreferLeftAsHJBuild) > 0) || ((p.PreferJoinType & h.PreferRightAsHJProbe) > 0)
 	forceRightToBuild := ((p.PreferJoinType & h.PreferRightAsHJBuild) > 0) || ((p.PreferJoinType & h.PreferLeftAsHJProbe) > 0)
 	if forceLeftToBuild && forceRightToBuild {
-		p.SCtx().GetSessionVars().StmtCtx.SetHintWarning("Conflicting HASH_JOIN_BUILD and HASH_JOIN_PROBE hints detected. " +
+		warnAboutHint("Conflicting HASH_JOIN_BUILD and HASH_JOIN_PROBE hints detected. " +
 			"Both sides cannot be specified to use the same table. Please review the hints")
 		forceLeftToBuild = false
 		forceRightToBuild = false
@@ -186,15 +152,15 @@ func getHashJoins(super base.LogicalPlan, prop *property.PhysicalProperty) (join
 		leftNAJoinKeys, _ := p.GetNAJoinKeys()
 		if p.SCtx().GetSessionVars().UseHashJoinV2 && joinversion.IsHashJoinV2Supported() && physicalop.CanUseHashJoinV2(p.JoinType, leftJoinKeys, isNullEQ, leftNAJoinKeys) {
 			if !forceLeftToBuild {
-				appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
+				appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, probeIsLeft))
 			}
 			if !forceRightToBuild {
-				appendHashJoins(getHashJoin(ge, p, prop, 1, true, keepProbeOrder, sortColsFromLeft))
+				appendHashJoins(getHashJoin(ge, p, prop, 1, true, keepProbeOrder, probeIsLeft))
 			}
 		} else {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, probeIsLeft))
 			if forceLeftToBuild || forceRightToBuild {
-				p.SCtx().GetSessionVars().StmtCtx.SetHintWarning(fmt.Sprintf(
+				warnAboutHint(fmt.Sprintf(
 					"The HASH_JOIN_BUILD and HASH_JOIN_PROBE hints are not supported for %s with hash join version 1. "+
 						"Please remove these hints",
 					p.JoinType))
@@ -203,9 +169,9 @@ func getHashJoins(super base.LogicalPlan, prop *property.PhysicalProperty) (join
 			}
 		}
 	case base.LeftOuterSemiJoin, base.AntiLeftOuterSemiJoin:
-		appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
+		appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, probeIsLeft))
 		if forceLeftToBuild || forceRightToBuild {
-			p.SCtx().GetSessionVars().StmtCtx.SetHintWarning(fmt.Sprintf(
+			warnAboutHint(fmt.Sprintf(
 				"HASH_JOIN_BUILD and HASH_JOIN_PROBE hints are not supported for %s because the build side is fixed. "+
 					"Please remove these hints",
 				p.JoinType))
@@ -214,37 +180,37 @@ func getHashJoins(super base.LogicalPlan, prop *property.PhysicalProperty) (join
 		}
 	case base.LeftOuterJoin:
 		if !forceLeftToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, probeIsLeft))
 		}
 		if !forceRightToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, true, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, true, keepProbeOrder, probeIsLeft))
 		}
 	case base.RightOuterJoin:
 		if !forceLeftToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 0, true, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 0, true, keepProbeOrder, probeIsLeft))
 		}
 		if !forceRightToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, probeIsLeft))
 		}
 	case base.InnerJoin:
 		if forceLeftToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, probeIsLeft))
 		} else if forceRightToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, probeIsLeft))
 		} else {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
-			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, probeIsLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, probeIsLeft))
 		}
 	case base.FullOuterJoin:
 		// For full outer join in the root phase, always use the regular
 		// hash join probe path. Build side is still chosen by cost / hints.
 		if forceLeftToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, probeIsLeft))
 		} else if forceRightToBuild {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, probeIsLeft))
 		} else {
-			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, sortColsFromLeft))
-			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, sortColsFromLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 1, false, keepProbeOrder, probeIsLeft))
+			appendHashJoins(getHashJoin(ge, p, prop, 0, false, keepProbeOrder, probeIsLeft))
 		}
 	}
 
@@ -253,141 +219,91 @@ func getHashJoins(super base.LogicalPlan, prop *property.PhysicalProperty) (join
 	if !forced && shouldSkipHashJoin {
 		return nil, false
 	} else if forced && shouldSkipHashJoin {
-		p.SCtx().GetSessionVars().StmtCtx.SetHintWarning(
+		warnAboutHint(
 			"A conflict between the HASH_JOIN hint and the NO_HASH_JOIN hint, " +
 				"or the tidb_opt_enable_hash_join system variable, the HASH_JOIN hint will take precedence.")
 	}
 	return
 }
 
-// columnsMatchJoinKeys checks if the ORDER BY sort columns match the join keys.
-// This is used to determine if MergeJoin can satisfy the ORDER BY (when both sides have indexes).
-// If sort columns match join keys, we should NOT generate order-preserving hash join.
-func columnsMatchJoinKeys(sortItems []property.SortItem, joinKeys []*expression.Column) bool {
-	if len(sortItems) == 0 || len(joinKeys) == 0 {
-		return false
+// canKeepProbeOrder reports whether an order-preserving hash join may be generated for
+// prop, and if so whether the probe side has to be the left child.
+//
+// A hash join delivers its joined rows in probe-row order as long as (a) exactly one probe
+// worker runs, (b) every output row is produced while probing, and (c) the probe walks its
+// rows once, emitting each row's output before moving on.
+//
+// Requirement (b) rules out any build side that is also the outer side: those joins emit
+// their unmatched build rows from the row table once probing is over, appending them after
+// rows that should sort before them. That half of the contract is enforced in getHashJoin,
+// which refuses useOuterToBuild.
+//
+// Requirement (c) is what excludes the outer joins even when the probe side is the outer
+// side. outerJoinProbe.probeForInnerSideBuild fills the chunk with the matched rows for a
+// batch of probe rows and only then calls buildResultForNotMatchedRows to append that same
+// batch's null-extended rows, so a non-matching probe row surfaces after later matching
+// ones. The join types listed below are the ones whose probe emits strictly in ascending
+// probe-row index: innerJoinProbe, the right-side-build paths of semiJoinProbe and
+// antiSemiJoinProbe, and leftOuterSemiJoinProbe.buildResult (whose build side is fixed to
+// the right). The semi paths only hold for right-side build, which useOuterToBuild already
+// guarantees.
+//
+// Only hash join v2 implements single-worker probing (see HashJoinCtxV2.probeConcurrency).
+// If this join would fall back to hash join v1 the executor ignores KeepProbeOrder entirely
+// and the output order is undefined, so v2 admissibility is a hard precondition here rather
+// than something the executor can compensate for.
+//
+// Note that no attempt is made to guess whether some other operator - a merge join, say -
+// could serve the order more cheaply. Both alternatives are enumerated for the same prop
+// and the cost model picks between them.
+func canKeepProbeOrder(ge base.GroupExpression, super base.LogicalPlan, p *logicalop.LogicalJoin, prop *property.PhysicalProperty) (keep bool, probeIsLeft bool) {
+	if prop.ExpectedCnt >= p.StatsInfo().RowCount {
+		// The parent wants every row, so the probe side has to be read to the end either
+		// way and serializing it buys nothing - a parallel probe under a Sort is at least
+		// as good, and the enforcer path enumerates exactly that. Only a parent that stops
+		// early, which is the same condition that shrinks the probe side's ExpectedCnt in
+		// adjustStatsAndGetJoin, makes the trade worthwhile.
+		return false, false
 	}
-	// Check if all sort columns are in the join keys
-	for _, item := range sortItems {
-		found := false
-		for _, key := range joinKeys {
-			if item.Col.EqualColumn(key) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
+	sessVars := p.SCtx().GetSessionVars()
+	if !sessVars.UseHashJoinV2 || !joinversion.IsHashJoinV2Supported() {
+		return false, false
+	}
+	leftJoinKeys, _, isNullEQ, _ := p.GetJoinKeys()
+	leftNAJoinKeys, _ := p.GetNAJoinKeys()
+	if !physicalop.CanUseHashJoinV2(p.JoinType, leftJoinKeys, isNullEQ, leftNAJoinKeys) {
+		return false, false
+	}
+	switch p.JoinType {
+	case base.InnerJoin, base.SemiJoin, base.AntiSemiJoin,
+		base.LeftOuterSemiJoin, base.AntiLeftOuterSemiJoin:
+	default:
+		return false, false
+	}
+	_, _, leftSchema, rightSchema := getJoinChildStatsAndSchema(ge, super)
+	if leftSchema == nil || rightSchema == nil {
+		return false, false
+	}
+	fromLeft, fromRight := false, false
+	for _, item := range prop.SortItems {
+		switch {
+		case leftSchema.Contains(item.Col):
+			fromLeft = true
+		case rightSchema.Contains(item.Col):
+			fromRight = true
+		default:
+			// Produced by neither child, so no child can be asked for this order.
+			return false, false
 		}
 	}
-	return true
+	if fromLeft == fromRight {
+		// The order either spans both children or came from neither of them.
+		return false, false
+	}
+	return true, fromLeft
 }
 
-// buildSideHasIndexOnJoinKeys checks if the build side (opposite of ORDER BY side) has an index
-// on the join keys. If the build side can provide sorted output, MergeJoin is optimal and we
-// should not generate order-preserving hash join.
-// sortColsFromLeft: true if ORDER BY columns come from left side (so right is build side)
-func buildSideHasIndexOnJoinKeys(super base.LogicalPlan, sortColsFromLeft bool, leftJoinKeys, rightJoinKeys []*expression.Column) bool {
-	// Get the join's children
-	children := super.Children()
-	if len(children) != 2 {
-		return false
-	}
-
-	// Determine which child is the build side (opposite of ORDER BY side)
-	var buildChild base.LogicalPlan
-	var buildJoinKeys []*expression.Column
-	if sortColsFromLeft {
-		// ORDER BY from left, so right is build side
-		buildChild = children[1]
-		buildJoinKeys = rightJoinKeys
-	} else {
-		// ORDER BY from right, so left is build side
-		buildChild = children[0]
-		buildJoinKeys = leftJoinKeys
-	}
-
-	// Traverse to find DataSource
-	return hasIndexOnColumns(buildChild, buildJoinKeys)
-}
-
-// hasIndexOnColumns recursively checks if any DataSource under the plan has an index
-// covering the given columns (typically join keys).
-func hasIndexOnColumns(plan base.LogicalPlan, cols []*expression.Column) bool {
-	if len(cols) == 0 {
-		return false
-	}
-
-	// Check if this is a DataSource
-	if ds, ok := plan.(*logicalop.DataSource); ok {
-		// Check if any index covers the join key columns
-		for _, path := range ds.PossibleAccessPaths {
-			if path.IsTablePath() {
-				continue
-			}
-			// Check if this index covers the join key
-			if indexCoversColumns(path, cols, ds) {
-				return true
-			}
-		}
-		return false
-	}
-
-	// Recursively check children
-	for _, child := range plan.Children() {
-		if hasIndexOnColumns(child, cols) {
-			return true
-		}
-	}
-	return false
-}
-
-// indexCoversColumns checks if an index path covers the specified columns.
-// This is a simplified check - we verify that the join key columns match leading index columns.
-func indexCoversColumns(path *util.AccessPath, cols []*expression.Column, ds *logicalop.DataSource) bool {
-	if path.Index == nil || len(path.Index.Columns) == 0 {
-		return false
-	}
-
-	// Get the table info to find column offset
-	tblInfo := ds.TableInfo
-	if tblInfo == nil {
-		return false
-	}
-
-	// Check if join key columns match the leading index columns
-	for _, col := range cols {
-		found := false
-		// Find this column's offset in the table
-		colOffset := -1
-		for i, tblCol := range tblInfo.Columns {
-			if col.ID == tblCol.ID {
-				colOffset = i
-				break
-			}
-		}
-		if colOffset < 0 {
-			continue
-		}
-
-		// Check if this column is a leading index column
-		for i, idxCol := range path.Index.Columns {
-			if i >= len(cols) {
-				break
-			}
-			if idxCol.Offset == colOffset {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-	return true
-}
-
-func getHashJoin(ge base.GroupExpression, p *logicalop.LogicalJoin, prop *property.PhysicalProperty, innerIdx int, useOuterToBuild bool, keepProbeOrder bool, sortColsFromLeft bool) []*physicalop.PhysicalHashJoin {
+func getHashJoin(ge base.GroupExpression, p *logicalop.LogicalJoin, prop *property.PhysicalProperty, innerIdx int, useOuterToBuild bool, keepProbeOrder bool, probeIsLeft bool) []*physicalop.PhysicalHashJoin {
 	var stats0, stats1 *property.StatsInfo
 	if ge != nil {
 		stats0, stats1, _, _ = ge.GetJoinChildStatsAndSchema()
@@ -395,25 +311,17 @@ func getHashJoin(ge base.GroupExpression, p *logicalop.LogicalJoin, prop *proper
 		stats0, stats1, _, _ = p.GetJoinChildStatsAndSchema()
 	}
 
-	// Determine which side is the probe side
-	// When useOuterToBuild=false: build = innerIdx, probe = 1-innerIdx
-	// When useOuterToBuild=true: build = 1-innerIdx, probe = innerIdx
-	var probeIdx int
-	if useOuterToBuild {
-		probeIdx = innerIdx
-	} else {
-		probeIdx = 1 - innerIdx
-	}
-
-	// If we need to preserve order, check if the probe side matches the sort columns side
+	// With useOuterToBuild the build side is the outer side, so the executor appends the
+	// unmatched build rows once probing is over; probe order would not survive that. Only
+	// the inner-as-build shapes can carry the order, and there the probe side is 1-innerIdx.
+	probeIdx := 1 - innerIdx
 	if keepProbeOrder {
-		// sortColsFromLeft=true means we need left (idx 0) to be probe
-		// sortColsFromLeft=false means we need right (idx 1) to be probe
-		if sortColsFromLeft && probeIdx != 0 {
-			return nil // Can't preserve order with this configuration
+		if useOuterToBuild {
+			return nil
 		}
-		if !sortColsFromLeft && probeIdx != 1 {
-			return nil // Can't preserve order with this configuration
+		if probeIsLeft != (probeIdx == 0) {
+			// This build-side choice puts the wrong child on the probe side.
+			return nil
 		}
 	}
 
@@ -436,19 +344,18 @@ func getHashJoin(ge base.GroupExpression, p *logicalop.LogicalJoin, prop *proper
 	}
 	adjustStatsAndGetJoin := func(chReqProps [2]*property.PhysicalProperty) *physicalop.PhysicalHashJoin {
 		if prop.ExpectedCnt < p.StatsInfo().RowCount {
+			// Under a small LIMIT the join stops early, so the probe side is asked for a
+			// proportionally smaller count. For an order-preserving join probeIdx equals
+			// 1-innerIdx, so this is also what pays for the early stop in the cost model:
+			// the probe child is planned and costed for the reduced count.
 			expCntScale := prop.ExpectedCnt / p.StatsInfo().RowCount
 			chReqProps[1-innerIdx].ExpectedCnt = outerStats.RowCount * expCntScale
 		}
 		hashJoin := physicalop.NewPhysicalHashJoin(p, innerIdx, useOuterToBuild, p.StatsInfo().ScaleByExpectCnt(p.SCtx().GetSessionVars(), prop.ExpectedCnt), chReqProps[0], chReqProps[1])
 		hashJoin.SetSchema(p.Schema())
-		// Set KeepProbeOrder for order-preserving hash join.
-		// Note: We don't set Concurrency=1 here because we want full concurrency for the BUILD phase.
-		// Single-threaded PROBING is handled in the executor when KeepProbeOrder is true.
-		if keepProbeOrder {
-			hashJoin.KeepProbeOrder = true
-			// Pass expected count for early termination optimization
-			hashJoin.ExpectedCnt = prop.ExpectedCnt
-		}
+		// Build still runs at full concurrency; only probing is serialized, and the
+		// executor does that itself when it sees KeepProbeOrder.
+		hashJoin.KeepProbeOrder = keepProbeOrder
 		return hashJoin
 	}
 	res := make([]*physicalop.PhysicalHashJoin, 0, 2)

--- a/pkg/planner/core/operator/physicalop/physical_hash_join.go
+++ b/pkg/planner/core/operator/physicalop/physical_hash_join.go
@@ -102,6 +102,11 @@ type PhysicalHashJoin struct {
 	// on the probe side, allowing ORDER BY ... LIMIT queries to avoid a sort operation.
 	KeepProbeOrder bool
 
+	// ExpectedCnt is the expected number of rows to be returned when KeepProbeOrder is true.
+	// This is used to optimize chunk sizes for ORDER BY ... LIMIT queries by using smaller
+	// chunks when the limit is small, reducing unnecessary row processing.
+	ExpectedCnt float64
+
 	// on which store the join executes.
 	StoreTp        kv.StoreType
 	MppShuffleJoin bool
@@ -201,6 +206,7 @@ func (p *PhysicalHashJoin) Clone(newCtx base.PlanContext) (base.PhysicalPlan, er
 	cloned.Concurrency = p.Concurrency
 	cloned.UseOuterToBuild = p.UseOuterToBuild
 	cloned.KeepProbeOrder = p.KeepProbeOrder
+	cloned.ExpectedCnt = p.ExpectedCnt
 	for _, c := range p.EqualConditions {
 		cloned.EqualConditions = append(cloned.EqualConditions, c.Clone().(*expression.ScalarFunction))
 	}

--- a/pkg/planner/core/operator/physicalop/physical_hash_join.go
+++ b/pkg/planner/core/operator/physicalop/physical_hash_join.go
@@ -97,6 +97,11 @@ type PhysicalHashJoin struct {
 	// use the outer table to build a hash table when the outer table is smaller.
 	UseOuterToBuild bool
 
+	// KeepProbeOrder indicates whether the join should preserve the order of the probe side.
+	// When true, the join will use single-threaded probing to maintain order from an index scan
+	// on the probe side, allowing ORDER BY ... LIMIT queries to avoid a sort operation.
+	KeepProbeOrder bool
+
 	// on which store the join executes.
 	StoreTp        kv.StoreType
 	MppShuffleJoin bool
@@ -195,6 +200,7 @@ func (p *PhysicalHashJoin) Clone(newCtx base.PlanContext) (base.PhysicalPlan, er
 	cloned.BasePhysicalJoin = *base
 	cloned.Concurrency = p.Concurrency
 	cloned.UseOuterToBuild = p.UseOuterToBuild
+	cloned.KeepProbeOrder = p.KeepProbeOrder
 	for _, c := range p.EqualConditions {
 		cloned.EqualConditions = append(cloned.EqualConditions, c.Clone().(*expression.ScalarFunction))
 	}

--- a/pkg/planner/core/operator/physicalop/physical_hash_join.go
+++ b/pkg/planner/core/operator/physicalop/physical_hash_join.go
@@ -97,15 +97,11 @@ type PhysicalHashJoin struct {
 	// use the outer table to build a hash table when the outer table is smaller.
 	UseOuterToBuild bool
 
-	// KeepProbeOrder indicates whether the join should preserve the order of the probe side.
-	// When true, the join will use single-threaded probing to maintain order from an index scan
-	// on the probe side, allowing ORDER BY ... LIMIT queries to avoid a sort operation.
+	// KeepProbeOrder makes the join deliver its rows in probe-side order, letting an
+	// ORDER BY be served by an ordered probe child instead of a Sort above the join. The
+	// executor pays for it by probing with a single worker. Only ever set for hash join
+	// v2 and only when the build side is the inner side; see canKeepProbeOrder.
 	KeepProbeOrder bool
-
-	// ExpectedCnt is the expected number of rows to be returned when KeepProbeOrder is true.
-	// This is used to optimize chunk sizes for ORDER BY ... LIMIT queries by using smaller
-	// chunks when the limit is small, reducing unnecessary row processing.
-	ExpectedCnt float64
 
 	// on which store the join executes.
 	StoreTp        kv.StoreType
@@ -206,7 +202,6 @@ func (p *PhysicalHashJoin) Clone(newCtx base.PlanContext) (base.PhysicalPlan, er
 	cloned.Concurrency = p.Concurrency
 	cloned.UseOuterToBuild = p.UseOuterToBuild
 	cloned.KeepProbeOrder = p.KeepProbeOrder
-	cloned.ExpectedCnt = p.ExpectedCnt
 	for _, c := range p.EqualConditions {
 		cloned.EqualConditions = append(cloned.EqualConditions, c.Clone().(*expression.ScalarFunction))
 	}
@@ -306,6 +301,9 @@ func (p *PhysicalHashJoin) explainInfo(normalized bool) string {
 	}
 	if p.TiFlashFineGrainedShuffleStreamCount > 0 {
 		fmt.Fprintf(buffer, ", stream_count: %d", p.TiFlashFineGrainedShuffleStreamCount)
+	}
+	if p.KeepProbeOrder {
+		buffer.WriteString(", keep probe order:true")
 	}
 
 	// for runtime filter

--- a/pkg/planner/core/plan_cost_ver2.go
+++ b/pkg/planner/core/plan_cost_ver2.go
@@ -789,8 +789,9 @@ func getPlanCostVer24PhysicalHashJoin(pp base.PhysicalPlan, taskType property.Ta
 	buildRows := max(MinNumRows, getCardinality(build, option.CostFlag))
 	probeRows := getCardinality(probe, option.CostFlag)
 	buildRowSize := max(MinRowSize, getAvgRowSize(build.StatsInfo(), build.Schema().Columns))
-	// For order-preserving hash join, probe uses single-threaded execution (concurrency=1)
-	// to maintain order from the probe side, so don't divide probe cost by full concurrency.
+	// An order-preserving join probes on one worker to keep the probe-row order, so the
+	// probe half of the cost is not divided down by the join's concurrency. Build is
+	// unaffected and is not divided by concurrency here either way.
 	tidbProbeConcurrency := float64(p.Concurrency)
 	if p.KeepProbeOrder {
 		tidbProbeConcurrency = 1

--- a/pkg/planner/core/plan_cost_ver2.go
+++ b/pkg/planner/core/plan_cost_ver2.go
@@ -789,7 +789,12 @@ func getPlanCostVer24PhysicalHashJoin(pp base.PhysicalPlan, taskType property.Ta
 	buildRows := max(MinNumRows, getCardinality(build, option.CostFlag))
 	probeRows := getCardinality(probe, option.CostFlag)
 	buildRowSize := max(MinRowSize, getAvgRowSize(build.StatsInfo(), build.Schema().Columns))
-	tidbConcurrency := float64(p.Concurrency)
+	// For order-preserving hash join, probe uses single-threaded execution (concurrency=1)
+	// to maintain order from the probe side, so don't divide probe cost by full concurrency.
+	tidbProbeConcurrency := float64(p.Concurrency)
+	if p.KeepProbeOrder {
+		tidbProbeConcurrency = 1
+	}
 	mppConcurrency := float64(3) // TODO: remove this empirical value
 	cpuFactor := getTaskCPUFactorVer2(p, taskType)
 	memFactor := getTaskMemFactorVer2(p, taskType)
@@ -824,7 +829,7 @@ func getPlanCostVer24PhysicalHashJoin(pp base.PhysicalPlan, taskType property.Ta
 			10*3*cpuFactor.Value, // 10rows * 3func * cpuFactor
 			func() string { return fmt.Sprintf("cpu(10*3*%v)", cpuFactor) })
 		p.PlanCostVer2 = costusage.SumCostVer2(startCost, buildChildCost, probeChildCost, buildHashCost, buildFilterCost,
-			costusage.DivCostVer2(costusage.SumCostVer2(probeFilterCost, probeHashCost, scanBuildSideCost), tidbConcurrency))
+			costusage.DivCostVer2(costusage.SumCostVer2(probeFilterCost, probeHashCost, scanBuildSideCost), tidbProbeConcurrency))
 	}
 	p.PlanCostInit = true
 	// Multiply by cost factor - defaults to 1, but can be increased/decreased to influence the cost model


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

A hash join promises no ordering, so `getHashJoins` refused any physical property with
sort items. An `ORDER BY ... LIMIT` over a hash join therefore always paid for a
`Sort`/`TopN` above the join, even when one side could already deliver the ordering from
an index scan and the query only wanted a handful of rows.

```sql
create table probe(a int, b int, key(b));
create table build(a int, c int);

select probe.b from probe join build on probe.a = build.a order by probe.b limit 10;
```

Before, the whole join result had to be built and sorted before the ten rows could be
returned.

### What changed and how does it work?

A hash join can deliver the ordering of its **probe** side, because the joined rows leave
the operator in probe-row order. The planner may now answer a sorted property with such a
join, pushing the sort items down to the probe child and marking the join
`KeepProbeOrder`; the executor then probes on a single worker so that order survives. The
plan above becomes `Limit -> HashJoin(keep probe order:true) -> IndexFullScan(keep
order:true)` with no `TopN`.

This is a physical-plan alternative, not a logical rewrite: the enforcer path enumerates
the ordinary hash join under a `Sort` for the same property, and the cost model picks
between them. The probe side is planned for the parent's reduced `ExpectedCnt`, so the
early stop is paid for in its cost, while the probe half of the join's own cost is no
longer divided by the join concurrency.

`canKeepProbeOrder` admits a join only when every one of these holds. Each corresponds to
a way the executor would otherwise return rows in the wrong order or drop them:

- **Hash join v2 is admissible.** Only v2 implements single-worker probing; v1 ignores
  `KeepProbeOrder` entirely. This excludes a legacy `tidb_hash_join_version`, NullEQ join
  keys, cartesian joins and full outer joins, all of which fall back to v1.
- **The build side is the inner side** (`useOuterToBuild == false`). An outer build side
  emits its unmatched rows from the row table after probing has finished, and that scan is
  split across `Concurrency` workers while an order-preserving join runs only one of them.
- **The probe emits strictly in probe-row order.** This admits `innerJoinProbe`, the
  right-side-build paths of `semiJoinProbe` and `antiSemiJoinProbe`, and
  `leftOuterSemiJoinProbe`. It excludes left and right outer joins *even when the outer
  side is the probe side*, because `outerJoinProbe.probeForInnerSideBuild` fills the chunk
  with a batch's matched rows and only then calls `buildResultForNotMatchedRows` to append
  that batch's null-extended rows.
- **All sort items come from one child**, and that child can be placed on the probe side.
- **The parent stops early** (`prop.ExpectedCnt < StatsInfo().RowCount`). Without a LIMIT
  the probe side is read to the end anyway, so giving up probe parallelism is pure loss
  against a parallel probe under a `Sort`.

Spilling is disabled for these joins: restore rounds re-partition and replay the probe
side, which destroys the order the plan above depends on.

`EXPLAIN` reports `keep probe order:true` on the join so plans can be asserted, and the
runtime stats now track build and probe concurrency separately since they can differ.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

`TestOrderPreservingHashJoin`, `TestOrderPreservingHashJoinRejected` and
`TestOrderPreservingHashJoinOuterBuild` in
`pkg/executor/test/jointest/hashjoin/hash_join_test.go` cover the shapes that are admitted
and pin each shape that must be refused, checking both the plan and that the returned rows
are actually ordered and complete.

Two recorded plans changed, both replacing a `TopN` with a `Limit`:

- `casetest/dag` — one hint-forced hash join.
- `casetest/rule/order_aware_join_reorder_suite_out.json` — the join order chosen by the
  order-aware join reorder rule is unchanged in both of its cases; only the topmost join's
  implementation becomes an order-preserving hash join.

Side effects

- [ ] Performance regression: Consumes more CPU
- [x] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

An order-preserving hash join never spills, so a query whose build side is large enough to
have spilled before can now reach the memory quota instead. The alternative would be to
return rows in an order the plan above has already committed to.

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

`ORDER BY ... LIMIT` queries over a hash join can pick a new plan shape, and `EXPLAIN`
gains a `keep probe order:true` marker on the join that carries the ordering.

### Release note

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support serving `ORDER BY ... LIMIT` from the probe side of a hash join, so that these
queries no longer need a sort above the join when the probe side is already ordered by an
index.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hash joins can now preserve probe-side row order, helping eligible `ORDER BY ... LIMIT` queries avoid an additional sort.
  * Query planning and cost estimates account for order-preserving hash joins.
  * Execution statistics more accurately distinguish build- and probe-side concurrency.

* **Bug Fixes**
  * Order-preserving joins no longer spill and instead follow standard memory-quota handling.

* **Tests**
  * Added coverage for ordered results and unsupported join scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->