### PR TITLE
planner: support straight_join() hint in CTEs and subqueries

### DIFF
--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3724,9 +3724,15 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 			return nil, plannererrors.ErrCTERecursiveForbidsAggregation.FastGenByArgs(b.genCTETableNameForError())
 		}
 	}
-	if sel.SelectStmtOpts != nil {
+	// Handle STRAIGHT_JOIN - both keyword and hint forms
+	straightJoinFromKeyword := sel.SelectStmtOpts != nil && sel.SelectStmtOpts.StraightJoin
+	straightJoinFromHint := false
+	if hints := b.TableHints(); hints != nil {
+		straightJoinFromHint = hints.StraightJoinOrder
+	}
+	if straightJoinFromKeyword || straightJoinFromHint {
 		origin := b.inStraightJoin
-		b.inStraightJoin = sel.SelectStmtOpts.StraightJoin
+		b.inStraightJoin = true
 		defer func() { b.inStraightJoin = origin }()
 	}
 

--- a/pkg/util/hint/hint.go
+++ b/pkg/util/hint/hint.go
@@ -565,11 +565,12 @@ type PlanHints struct {
 	NoIndexLookUpPushDown []HintedTable    // no_index_lookup_pushdown
 
 	// Hints belows are not associated with any particular table.
-	PreferAggType    uint // hash_agg, merge_agg, agg_to_cop and so on
-	PreferAggToCop   bool
-	PreferLimitToCop bool // limit_to_cop
-	CTEMerge         bool // merge
-	TimeRangeHint    ast.HintTimeRange
+	PreferAggType     uint // hash_agg, merge_agg, agg_to_cop and so on
+	PreferAggToCop    bool
+	PreferLimitToCop  bool // limit_to_cop
+	CTEMerge          bool // merge
+	TimeRangeHint     ast.HintTimeRange
+	StraightJoinOrder bool // straight_join
 }
 
 // HintedTable indicates which table this hint should take effect on.
@@ -784,6 +785,7 @@ func ParsePlanHints(hints []*ast.TableOptimizerHint,
 		hjBuildTables, hjProbeTables                                                    []HintedTable
 		leadingHintCnt                                                                  int
 		leadingList                                                                     *ast.LeadingList
+		straightJoinHint                                                                bool
 	)
 	for _, hint := range hints {
 		// Set warning for the hint that requires the table name.
@@ -952,6 +954,8 @@ func ParsePlanHints(hints []*ast.TableOptimizerHint,
 				continue
 			}
 			subQueryHintFlags |= HintFlagNoDecorrelate
+		case HintStraightJoin:
+			straightJoinHint = true
 		default:
 			// ignore hints that not implemented
 		}
@@ -988,6 +992,7 @@ func ParsePlanHints(hints []*ast.TableOptimizerHint,
 		HJBuild:               hjBuildTables,
 		HJProbe:               hjProbeTables,
 		NoIndexLookUpPushDown: noIndexLookUpPushDownTables,
+		StraightJoinOrder:     straightJoinHint,
 	}, subQueryHintFlags, nil
 }
 

--- a/tests/integrationtest/r/planner/core/casetest/rule/rule_join_reorder.result
+++ b/tests/integrationtest/r/planner/core/casetest/rule/rule_join_reorder.result
@@ -7474,3 +7474,150 @@ ScalarSubQuery	root		Output: ScalarQueryCol#14
 Level	Code	Message
 Warning	1815	There are no matching table names for (t2) in optimizer hint /*+ LEADING(t3, t2) */. Maybe you can use the table alias name
 Warning	1815	leading hint is inapplicable, check if the leading hint table is valid
+drop table if exists t1, t2, t3, t4, tt;
+create table t1(a int, b int, c int, d int);
+create table t2(a int, b int, c int, d int);
+create table t3(a int, b int, c int, d int);
+create table t4(a int, b int, c int, d int);
+create table tt(a int, b int, c int, d int);
+insert into t3 values(1,1,1,1);
+analyze table t3;
+explain format='plan_tree' with cte as (
+select /*+ straight_join() */ 1 from t1
+join t2 on t1.a = t2.a
+join t3 on t1.b = t3.b
+join t4 on t1.c = t4.c
+)
+select * from cte, tt;
+id	task	access object	operator info
+Projection	root		Column, planner__core__casetest__rule__rule_join_reorder.tt.a, planner__core__casetest__rule__rule_join_reorder.tt.b, planner__core__casetest__rule__rule_join_reorder.tt.c, planner__core__casetest__rule__rule_join_reorder.tt.d
+└─HashJoin	root		CARTESIAN inner join
+  ├─Projection(Build)	root		1->Column
+  │ └─HashJoin	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.c, planner__core__casetest__rule__rule_join_reorder.t4.c)]
+  │   ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t3.b)]
+  │   │ ├─TableReader(Build)	root		data:Selection
+  │   │ │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t3.b))
+  │   │ │   └─TableFullScan	cop[tikv]	table:t3	keep order:false
+  │   │ └─HashJoin(Probe)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)]
+  │   │   ├─TableReader(Build)	root		data:Selection
+  │   │   │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
+  │   │   │   └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
+  │   │   └─TableReader(Probe)	root		data:Selection
+  │   │     └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a)), not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.b)), not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.c))
+  │   │       └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+  │   └─TableReader(Probe)	root		data:Selection
+  │     └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t4.c))
+  │       └─TableFullScan	cop[tikv]	table:t4	keep order:false, stats:pseudo
+  └─TableReader(Probe)	root		data:TableFullScan
+    └─TableFullScan	cop[tikv]	table:tt	keep order:false, stats:pseudo
+explain format='plan_tree' with cte as (
+select 1 from t1
+join t2 on t1.a = t2.a
+join t3 on t1.b = t3.b
+join t4 on t1.c = t4.c
+)
+select * from cte, tt;
+id	task	access object	operator info
+Projection	root		Column, planner__core__casetest__rule__rule_join_reorder.tt.a, planner__core__casetest__rule__rule_join_reorder.tt.b, planner__core__casetest__rule__rule_join_reorder.tt.c, planner__core__casetest__rule__rule_join_reorder.tt.d
+└─HashJoin	root		CARTESIAN inner join
+  ├─Projection(Build)	root		1->Column
+  │ └─HashJoin	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.c, planner__core__casetest__rule__rule_join_reorder.t4.c)]
+  │   ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)]
+  │   │ ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t3.b, planner__core__casetest__rule__rule_join_reorder.t1.b)]
+  │   │ │ ├─TableReader(Build)	root		data:Selection
+  │   │ │ │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t3.b))
+  │   │ │ │   └─TableFullScan	cop[tikv]	table:t3	keep order:false
+  │   │ │ └─TableReader(Probe)	root		data:Selection
+  │   │ │   └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a)), not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.b)), not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.c))
+  │   │ │     └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+  │   │ └─TableReader(Probe)	root		data:Selection
+  │   │   └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
+  │   │     └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
+  │   └─TableReader(Probe)	root		data:Selection
+  │     └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t4.c))
+  │       └─TableFullScan	cop[tikv]	table:t4	keep order:false, stats:pseudo
+  └─TableReader(Probe)	root		data:TableFullScan
+    └─TableFullScan	cop[tikv]	table:tt	keep order:false, stats:pseudo
+explain format='plan_tree' select * from tt, (
+select /*+ straight_join() */ 1 from t1
+join t2 on t1.a = t2.a
+join t3 on t1.b = t3.b
+join t4 on t1.c = t4.c
+) sub;
+id	task	access object	operator info
+HashJoin	root		CARTESIAN inner join
+├─Projection(Build)	root		1->Column
+│ └─HashJoin	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.c, planner__core__casetest__rule__rule_join_reorder.t4.c)]
+│   ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t3.b)]
+│   │ ├─TableReader(Build)	root		data:Selection
+│   │ │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t3.b))
+│   │ │   └─TableFullScan	cop[tikv]	table:t3	keep order:false
+│   │ └─HashJoin(Probe)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)]
+│   │   ├─TableReader(Build)	root		data:Selection
+│   │   │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
+│   │   │   └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
+│   │   └─TableReader(Probe)	root		data:Selection
+│   │     └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a)), not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.b)), not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.c))
+│   │       └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+│   └─TableReader(Probe)	root		data:Selection
+│     └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t4.c))
+│       └─TableFullScan	cop[tikv]	table:t4	keep order:false, stats:pseudo
+└─TableReader(Probe)	root		data:TableFullScan
+  └─TableFullScan	cop[tikv]	table:tt	keep order:false, stats:pseudo
+explain format='plan_tree' with cte as (
+select 1 from t1
+join t2 on t1.a = t2.a
+join t3 on t1.b = t3.b
+join t4 on t1.c = t4.c
+)
+select /*+ straight_join() */ * from cte tt1, cte tt2;
+id	task	access object	operator info
+HashJoin	root		CARTESIAN inner join
+├─CTEFullScan(Build)	root	CTE:cte AS tt2	data:CTE_0
+└─CTEFullScan(Probe)	root	CTE:cte AS tt1	data:CTE_0
+CTE_0	root		Non-Recursive CTE
+└─Projection(Seed Part)	root		1->Column
+  └─HashJoin	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.c, planner__core__casetest__rule__rule_join_reorder.t4.c)]
+    ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t3.b)]
+    │ ├─TableReader(Build)	root		data:Selection
+    │ │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t3.b))
+    │ │   └─TableFullScan	cop[tikv]	table:t3	keep order:false
+    │ └─HashJoin(Probe)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)]
+    │   ├─TableReader(Build)	root		data:Selection
+    │   │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
+    │   │   └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
+    │   └─TableReader(Probe)	root		data:Selection
+    │     └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a)), not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.b)), not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.c))
+    │       └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+    └─TableReader(Probe)	root		data:Selection
+      └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t4.c))
+        └─TableFullScan	cop[tikv]	table:t4	keep order:false, stats:pseudo
+explain format='plan_tree' with
+cte1 as (select t1.a,t2.b,t3.c from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b),
+cte2 as (select /*+ straight_join() */ t1.a a1, t2.b b2, t3.c c1 from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b)
+select * from cte1, cte2;
+id	task	access object	operator info
+Projection	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.b, planner__core__casetest__rule__rule_join_reorder.t3.c, planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.b, planner__core__casetest__rule__rule_join_reorder.t3.c
+└─HashJoin	root		CARTESIAN inner join
+  ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t3.b)]
+  │ ├─TableReader(Build)	root		data:Selection
+  │ │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t3.b))
+  │ │   └─TableFullScan	cop[tikv]	table:t3	keep order:false
+  │ └─HashJoin(Probe)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)]
+  │   ├─TableReader(Build)	root		data:Selection
+  │   │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a)), not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.b))
+  │   │   └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+  │   └─TableReader(Probe)	root		data:Selection
+  │     └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
+  │       └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
+  └─HashJoin(Probe)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)]
+    ├─HashJoin(Build)	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t3.b, planner__core__casetest__rule__rule_join_reorder.t1.b)]
+    │ ├─TableReader(Build)	root		data:Selection
+    │ │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t3.b))
+    │ │   └─TableFullScan	cop[tikv]	table:t3	keep order:false
+    │ └─TableReader(Probe)	root		data:Selection
+    │   └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a)), not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.b))
+    │     └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+    └─TableReader(Probe)	root		data:Selection
+      └─Selection	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
+        └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/planner/core/casetest/rule/rule_join_reorder.test
+++ b/tests/integrationtest/t/planner/core/casetest/rule/rule_join_reorder.test
@@ -519,3 +519,60 @@ explain format='plan_tree' select /*+ leading(t1, t3) */ t1.a, (select min(t2.a)
 explain format='plan_tree' select /*+ leading(t2@sel_2, t1) */ t1.a, (select min(t2.a) from t2) from t1 left join t3 on t1.a = t3.a;
 explain format='plan_tree' select /*+ leading(t3, t2@sel_2) */ t1.a, (select min(t2.a) from t2) from t1 right join t3 on t1.a = t3.a;
 --disable_warnings
+
+# TestStraightJoinHintInCTEAndSubquery
+# Test straight_join hint works inside CTE and subquery
+# The key test is: with straight_join(), different table orders in SQL should produce
+# different join orders in the plan, proving the hint preserves SQL-specified order.
+# Tables without indexes to avoid index-based join reordering decisions
+drop table if exists t1, t2, t3, t4, tt;
+create table t1(a int, b int, c int, d int);
+create table t2(a int, b int, c int, d int);
+create table t3(a int, b int, c int, d int);
+create table t4(a int, b int, c int, d int);
+create table tt(a int, b int, c int, d int);
+insert into t3 values(1,1,1,1);
+analyze table t3;
+
+--enable_warnings
+# straight_join in CTE should preserve join order (t1 -> t2 -> t3 -> t4)
+explain format='plan_tree' with cte as (
+    select /*+ straight_join() */ 1 from t1
+    join t2 on t1.a = t2.a
+    join t3 on t1.b = t3.b
+    join t4 on t1.c = t4.c
+)
+select * from cte, tt;
+
+# without straight_join in CTE, the join order should be (t1 -> t3 -> t2 -> t4)
+explain format='plan_tree' with cte as (
+    select 1 from t1
+    join t2 on t1.a = t2.a
+    join t3 on t1.b = t3.b
+    join t4 on t1.c = t4.c
+)
+select * from cte, tt;
+
+# straight_join in subquery should preserve join order (t1 -> t2 -> t3 -> t4)
+explain format='plan_tree' select * from tt, (
+    select /*+ straight_join() */ 1 from t1
+    join t2 on t1.a = t2.a
+    join t3 on t1.b = t3.b
+    join t4 on t1.c = t4.c
+) sub;
+
+# straight_join in outer query with 2 CTE consumers
+explain format='plan_tree' with cte as (
+    select 1 from t1
+    join t2 on t1.a = t2.a
+    join t3 on t1.b = t3.b
+    join t4 on t1.c = t4.c
+)
+select /*+ straight_join() */ * from cte tt1, cte tt2;
+
+# Test nested CTE - each CTE should handle its own straight_join hint independently
+explain format='plan_tree' with
+    cte1 as (select t1.a,t2.b,t3.c from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b),
+    cte2 as (select /*+ straight_join() */ t1.a a1, t2.b b2, t3.c c1 from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b)
+select * from cte1, cte2;
+--disable_warnings


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #61573

Problem Summary:
Previously, the `straight_join()` hint only worked at the outermost SELECT statement level. When placed inside a CTE or subquery, the hint was ignored and the join reorder optimizer would still reorder joins.

Root cause:
- The hint form `/*+ straight_join() */` sets `StmtCtx.StraightJoinOrder` (a global statement-level flag), but does NOT set `b.inStraightJoin` in PlanBuilder.
- The `b.inStraightJoin` flag is what propagates to `LogicalJoin.StraightJoin` which prevents join reordering.
- Only the KEYWORD form `SELECT STRAIGHT_JOIN ...` was setting `b.inStraightJoin` in buildSelect().

### What changed and how does it work?
- Add `StraightJoinOrder` field to `PlanHints` struct to track the hint at query block level.
- Set `StraightJoinOrder` in `ParsePlanHints()` when `straight_join` hint is encountered.
- In `buildSelect()`, check both the keyword form and the hint form to set `b.inStraightJoin`, allowing the hint to work inside CTEs and subqueries.

### Check List

Tests 

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
