### PR TITLE
planner: simplify is null compare predicate

### DIFF
--- a/pkg/planner/core/casetest/rule/testdata/predicate_simplification_in.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_simplification_in.json
@@ -8,7 +8,10 @@
       "with cte_263 ( col_1350,col_1351,col_1352 ) AS ( select /*+ read_from_storage(tiflash[ tad03b424,tlfdfece63 ]) */ /*+ use_index_merge( tlfdfece63,tad03b424 ) */ /*+ merge_join( tlfdfece63 , tad03b424 */ rpad( tad03b424.col_44 , 6 , tad03b424.col_48 ) as r0 , insert( tlfdfece63.col_44 , 0 , 10 , tlfdfece63.col_43 ) as r1 , tad03b424.col_41 as r2 from tlfdfece63 , tad03b424 where not( tlfdfece63.col_42 = '[\"Sl9DRlDnSdIOxbfequ02VeikDWiphuDO6suBf0F7esJeCWrRJWQbd3BK3vT58Coz\",\"MmC5saHdTUqosY50IrxprAR52oD08XgGhqJCcYeoaDJKrYxBdbi0QuVDDArCghyL\"]' ) order by r0,r1,r2 limit 348170821 ) ( select 1,col_1350,col_1351,col_1352 from cte_263 where not( cte_263.col_1352 != '2020-06-30' ) and cte_263.col_1352 in ( null ,'1983-08-09' ) order by 1,2,3,4  );",
       "select * from t6 where  (a, b, c) in ((1, 1, 1), (2, 2, 2))",
       "SELECT column_1, column_2, column_3, column_4, column_5, column_6 FROM ISSUE64263 WHERE column_3 = 'M 5 9 2 9 2 5 4 6 8 4 9' AND (column_2 IN (1) OR column_4 = 121092106) ORDER BY column_6 DESC, column_1 DESC LIMIT 1000;",
-      "SELECT STRAIGHT_JOIN * FROM t1 LEFT JOIN t0 ON t1.a = t0.a WHERE t1.a = t0.a OR t1.a = t0.b;"
+      "SELECT STRAIGHT_JOIN * FROM t1 LEFT JOIN t0 ON t1.a = t0.a WHERE t1.a = t0.a OR t1.a = t0.b;",
+      "select * from t6 where (a > 1) is null",
+      "select count(*) from (select ps_t1.id from ps_t2 right join ps_t1 using(id) left join ps_t3 on (ps_t2.c0 = ps_t3.c1)) q",
+      "select count(*) from (select ps_t1.id from ps_t2 right join ps_t1 using(id) left join ps_t3 on (ps_t2.c0 = ps_t3.c1) where (ps_t2.c2 >= '2024-01-12 08:50:00') union all select ps_t1.id from ps_t2 right join ps_t1 using(id) left join ps_t3 on (ps_t2.c0 = ps_t3.c1) where not (ps_t2.c2 >= '2024-01-12 08:50:00') union all select ps_t1.id from ps_t2 right join ps_t1 using(id) left join ps_t3 on (ps_t2.c0 = ps_t3.c1) where ((ps_t2.c2 >= '2024-01-12 08:50:00') is null)) u"
     ]
   }
 ]

--- a/pkg/planner/core/casetest/rule/testdata/predicate_simplification_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_simplification_out.json
@@ -32,6 +32,7 @@
           "            └─Selection 0.01 cop[tikv]  eq(test.t5.c2, \"production\")",
           "              └─TableRangeScan 12.50 cop[tikv] table:t5 range: decided by [eq(test.t5.c1, test.t1.id) eq(test.t5.c2, production)], keep order:false, stats:pseudo"
         ],
+        "Result": null,
         "LastPlanFromCache": [
           "0"
         ],
@@ -53,6 +54,7 @@
           "          └─Selection 8000.00 cop[tikv]  eq(test.t7c899916.col_44, cast(\"[17764220206423580415]\", json BINARY)), ne(test.t7c899916.col_44, cast(\"[5725396597060626308,5860284933591136807,11766074999769332834,11...(len:83)\", json BINARY))",
           "            └─TableFullScan 10000.00 cop[tikv] table:t7c899916 keep order:false, stats:pseudo"
         ],
+        "Result": null,
         "LastPlanFromCache": [
           "0"
         ],
@@ -63,6 +65,7 @@
         "Plan": [
           "TableDual 0.00 root  rows:0"
         ],
+        "Result": null,
         "LastPlanFromCache": [
           "0"
         ],
@@ -74,6 +77,7 @@
           "Projection 0.00 root  1->Column#48, Column#46, Column#47, test.tad03b424.col_41",
           "└─TableDual 0.00 root  rows:0"
         ],
+        "Result": null,
         "LastPlanFromCache": [
           "0"
         ],
@@ -94,6 +98,9 @@
           "└─Selection(Probe) 1.00 cop[tikv]  or(and(eq(test.t6.a, 1), and(eq(test.t6.b, 1), eq(test.t6.c, 1))), and(eq(test.t6.a, 2), and(eq(test.t6.b, 2), eq(test.t6.c, 2))))",
           "  └─TableRowIDScan 1.25 cop[tikv] table:t6 keep order:false, stats:pseudo"
         ],
+        "Result": [
+          "1 1 1 1"
+        ],
         "LastPlanFromCache": [
           "1"
         ],
@@ -109,6 +116,7 @@
           "    └─Selection 1.00 cop[tikv]  or(eq(test.issue64263.column_2, 1), eq(test.issue64263.column_4, 121092106))",
           "      └─TableRowIDScan 10.00 cop[tikv] table:ISSUE64263 keep order:false, stats:pseudo"
         ],
+        "Result": null,
         "LastPlanFromCache": [
           "1"
         ],
@@ -125,8 +133,88 @@
           "  └─Selection 9990.00 cop[tikv]  not(isnull(test.t1.a))",
           "    └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
+        "Result": null,
         "LastPlanFromCache": [
           "1"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "select * from t6 where (a > 1) is null",
+        "Plan": [
+          "IndexLookUp 10.00 root  ",
+          "├─IndexRangeScan(Build) 10.00 cop[tikv] table:t6, index:a(a, b) range:[NULL,NULL], keep order:false, stats:pseudo",
+          "└─TableRowIDScan(Probe) 10.00 cop[tikv] table:t6 keep order:false, stats:pseudo"
+        ],
+        "Result": null,
+        "LastPlanFromCache": [
+          "0"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "select count(*) from (select ps_t1.id from ps_t2 right join ps_t1 using(id) left join ps_t3 on (ps_t2.c0 = ps_t3.c1)) q",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(1)->Column#13",
+          "└─HashJoin 15609.38 root  right outer join, left side:HashJoin, equal:[eq(test.ps_t2.id, test.ps_t1.id)]",
+          "  ├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "  │ └─TableFullScan 10000.00 cop[tikv] table:ps_t1 keep order:false, stats:pseudo",
+          "  └─HashJoin(Probe) 12487.50 root  left outer join, left side:TableReader, equal:[eq(test.ps_t2.c0, test.ps_t3.c1)]",
+          "    ├─TableReader(Build) 9990.00 root  data:Selection",
+          "    │ └─Selection 9990.00 cop[tikv]  not(isnull(test.ps_t3.c1))",
+          "    │   └─TableFullScan 10000.00 cop[tikv] table:ps_t3 keep order:false, stats:pseudo",
+          "    └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+          "      └─TableFullScan 10000.00 cop[tikv] table:ps_t2 keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ],
+        "LastPlanFromCache": [
+          "0"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "select count(*) from (select ps_t1.id from ps_t2 right join ps_t1 using(id) left join ps_t3 on (ps_t2.c0 = ps_t3.c1) where (ps_t2.c2 >= '2024-01-12 08:50:00') union all select ps_t1.id from ps_t2 right join ps_t1 using(id) left join ps_t3 on (ps_t2.c0 = ps_t3.c1) where not (ps_t2.c2 >= '2024-01-12 08:50:00') union all select ps_t1.id from ps_t2 right join ps_t1 using(id) left join ps_t3 on (ps_t2.c0 = ps_t3.c1) where ((ps_t2.c2 >= '2024-01-12 08:50:00') is null)) u",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(1)->Column#38",
+          "└─Union 22901.04 root  ",
+          "  ├─HashJoin 5208.33 root  inner join, equal:[eq(test.ps_t2.id, test.ps_t1.id)]",
+          "  │ ├─HashJoin(Build) 4166.67 root  left outer join, left side:TableReader, equal:[eq(test.ps_t2.c0, test.ps_t3.c1)]",
+          "  │ │ ├─TableReader(Build) 3333.33 root  data:Selection",
+          "  │ │ │ └─Selection 3333.33 cop[tikv]  ge(test.ps_t2.c2, 2024-01-12 08:50:00.000000)",
+          "  │ │ │   └─TableFullScan 10000.00 cop[tikv] table:ps_t2 keep order:false, stats:pseudo",
+          "  │ │ └─TableReader(Probe) 9990.00 root  data:Selection",
+          "  │ │   └─Selection 9990.00 cop[tikv]  not(isnull(test.ps_t3.c1))",
+          "  │ │     └─TableFullScan 10000.00 cop[tikv] table:ps_t3 keep order:false, stats:pseudo",
+          "  │ └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+          "  │   └─TableFullScan 10000.00 cop[tikv] table:ps_t1 keep order:false, stats:pseudo",
+          "  ├─HashJoin 5192.71 root  inner join, equal:[eq(test.ps_t2.id, test.ps_t1.id)]",
+          "  │ ├─HashJoin(Build) 4154.17 root  left outer join, left side:TableReader, equal:[eq(test.ps_t2.c0, test.ps_t3.c1)]",
+          "  │ │ ├─TableReader(Build) 3323.33 root  data:Selection",
+          "  │ │ │ └─Selection 3323.33 cop[tikv]  lt(test.ps_t2.c2, 2024-01-12 08:50:00.000000)",
+          "  │ │ │   └─TableFullScan 10000.00 cop[tikv] table:ps_t2 keep order:false, stats:pseudo",
+          "  │ │ └─TableReader(Probe) 9990.00 root  data:Selection",
+          "  │ │   └─Selection 9990.00 cop[tikv]  not(isnull(test.ps_t3.c1))",
+          "  │ │     └─TableFullScan 10000.00 cop[tikv] table:ps_t3 keep order:false, stats:pseudo",
+          "  │ └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+          "  │   └─TableFullScan 10000.00 cop[tikv] table:ps_t1 keep order:false, stats:pseudo",
+          "  └─HashJoin 12500.00 root  left outer join, left side:Selection, equal:[eq(test.ps_t2.c0, test.ps_t3.c1)]",
+          "    ├─TableReader(Build) 9990.00 root  data:Selection",
+          "    │ └─Selection 9990.00 cop[tikv]  not(isnull(test.ps_t3.c1))",
+          "    │   └─TableFullScan 10000.00 cop[tikv] table:ps_t3 keep order:false, stats:pseudo",
+          "    └─Selection(Probe) 10000.00 root  isnull(test.ps_t2.c2)",
+          "      └─MergeJoin 12500.00 root  right outer join, left side:TableReader, left key:test.ps_t2.id, right key:test.ps_t1.id",
+          "        ├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "        │ └─TableFullScan 10000.00 cop[tikv] table:ps_t2 keep order:true, stats:pseudo",
+          "        └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+          "          └─TableFullScan 10000.00 cop[tikv] table:ps_t1 keep order:true, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ],
+        "LastPlanFromCache": [
+          "0"
         ],
         "Warning": null
       }

--- a/pkg/planner/core/casetest/rule/testdata/predicate_simplification_xut.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_simplification_xut.json
@@ -32,6 +32,7 @@
           "            └─Selection 0.01 cop[tikv]  eq(test.t5.c2, \"production\")",
           "              └─TableRangeScan 12.50 cop[tikv] table:t5 range: decided by [eq(test.t5.c1, test.t1.id) eq(test.t5.c2, production)], keep order:false, stats:pseudo"
         ],
+        "Result": null,
         "LastPlanFromCache": [
           "0"
         ],
@@ -53,6 +54,7 @@
           "          └─Selection 8000.00 cop[tikv]  eq(test.t7c899916.col_44, cast(\"[17764220206423580415]\", json BINARY)), ne(test.t7c899916.col_44, cast(\"[5725396597060626308,5860284933591136807,11766074999769332834,11...(len:83)\", json BINARY))",
           "            └─TableFullScan 10000.00 cop[tikv] table:t7c899916 keep order:false, stats:pseudo"
         ],
+        "Result": null,
         "LastPlanFromCache": [
           "0"
         ],
@@ -63,6 +65,7 @@
         "Plan": [
           "TableDual 0.00 root  rows:0"
         ],
+        "Result": null,
         "LastPlanFromCache": [
           "0"
         ],
@@ -74,6 +77,7 @@
           "Projection 0.00 root  1->Column#48, Column#46, Column#47, test.tad03b424.col_41",
           "└─TableDual 0.00 root  rows:0"
         ],
+        "Result": null,
         "LastPlanFromCache": [
           "0"
         ],
@@ -94,6 +98,9 @@
           "└─Selection(Probe) 1.00 cop[tikv]  or(and(eq(test.t6.a, 1), and(eq(test.t6.b, 1), eq(test.t6.c, 1))), and(eq(test.t6.a, 2), and(eq(test.t6.b, 2), eq(test.t6.c, 2))))",
           "  └─TableRowIDScan 1.25 cop[tikv] table:t6 keep order:false, stats:pseudo"
         ],
+        "Result": [
+          "1 1 1 1"
+        ],
         "LastPlanFromCache": [
           "1"
         ],
@@ -109,6 +116,7 @@
           "    └─Selection 1.00 cop[tikv]  or(eq(test.issue64263.column_2, 1), eq(test.issue64263.column_4, 121092106))",
           "      └─TableRowIDScan 10.00 cop[tikv] table:ISSUE64263 keep order:false, stats:pseudo"
         ],
+        "Result": null,
         "LastPlanFromCache": [
           "1"
         ],
@@ -125,8 +133,88 @@
           "  └─Selection 9990.00 cop[tikv]  not(isnull(test.t1.a))",
           "    └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
+        "Result": null,
         "LastPlanFromCache": [
           "1"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "select * from t6 where (a > 1) is null",
+        "Plan": [
+          "IndexLookUp 10.00 root  ",
+          "├─IndexRangeScan(Build) 10.00 cop[tikv] table:t6, index:a(a, b) range:[NULL,NULL], keep order:false, stats:pseudo",
+          "└─TableRowIDScan(Probe) 10.00 cop[tikv] table:t6 keep order:false, stats:pseudo"
+        ],
+        "Result": null,
+        "LastPlanFromCache": [
+          "0"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "select count(*) from (select ps_t1.id from ps_t2 right join ps_t1 using(id) left join ps_t3 on (ps_t2.c0 = ps_t3.c1)) q",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(1)->Column#13",
+          "└─HashJoin 15609.38 root  right outer join, left side:HashJoin, equal:[eq(test.ps_t2.id, test.ps_t1.id)]",
+          "  ├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "  │ └─TableFullScan 10000.00 cop[tikv] table:ps_t1 keep order:false, stats:pseudo",
+          "  └─HashJoin(Probe) 12487.50 root  left outer join, left side:TableReader, equal:[eq(test.ps_t2.c0, test.ps_t3.c1)]",
+          "    ├─TableReader(Build) 9990.00 root  data:Selection",
+          "    │ └─Selection 9990.00 cop[tikv]  not(isnull(test.ps_t3.c1))",
+          "    │   └─TableFullScan 10000.00 cop[tikv] table:ps_t3 keep order:false, stats:pseudo",
+          "    └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+          "      └─TableFullScan 10000.00 cop[tikv] table:ps_t2 keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ],
+        "LastPlanFromCache": [
+          "0"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "select count(*) from (select ps_t1.id from ps_t2 right join ps_t1 using(id) left join ps_t3 on (ps_t2.c0 = ps_t3.c1) where (ps_t2.c2 >= '2024-01-12 08:50:00') union all select ps_t1.id from ps_t2 right join ps_t1 using(id) left join ps_t3 on (ps_t2.c0 = ps_t3.c1) where not (ps_t2.c2 >= '2024-01-12 08:50:00') union all select ps_t1.id from ps_t2 right join ps_t1 using(id) left join ps_t3 on (ps_t2.c0 = ps_t3.c1) where ((ps_t2.c2 >= '2024-01-12 08:50:00') is null)) u",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(1)->Column#38",
+          "└─Union 22901.04 root  ",
+          "  ├─HashJoin 5208.33 root  inner join, equal:[eq(test.ps_t2.id, test.ps_t1.id)]",
+          "  │ ├─HashJoin(Build) 4166.67 root  left outer join, left side:TableReader, equal:[eq(test.ps_t2.c0, test.ps_t3.c1)]",
+          "  │ │ ├─TableReader(Build) 3333.33 root  data:Selection",
+          "  │ │ │ └─Selection 3333.33 cop[tikv]  ge(test.ps_t2.c2, 2024-01-12 08:50:00.000000)",
+          "  │ │ │   └─TableFullScan 10000.00 cop[tikv] table:ps_t2 keep order:false, stats:pseudo",
+          "  │ │ └─TableReader(Probe) 9990.00 root  data:Selection",
+          "  │ │   └─Selection 9990.00 cop[tikv]  not(isnull(test.ps_t3.c1))",
+          "  │ │     └─TableFullScan 10000.00 cop[tikv] table:ps_t3 keep order:false, stats:pseudo",
+          "  │ └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+          "  │   └─TableFullScan 10000.00 cop[tikv] table:ps_t1 keep order:false, stats:pseudo",
+          "  ├─HashJoin 5192.71 root  inner join, equal:[eq(test.ps_t2.id, test.ps_t1.id)]",
+          "  │ ├─HashJoin(Build) 4154.17 root  left outer join, left side:TableReader, equal:[eq(test.ps_t2.c0, test.ps_t3.c1)]",
+          "  │ │ ├─TableReader(Build) 3323.33 root  data:Selection",
+          "  │ │ │ └─Selection 3323.33 cop[tikv]  lt(test.ps_t2.c2, 2024-01-12 08:50:00.000000)",
+          "  │ │ │   └─TableFullScan 10000.00 cop[tikv] table:ps_t2 keep order:false, stats:pseudo",
+          "  │ │ └─TableReader(Probe) 9990.00 root  data:Selection",
+          "  │ │   └─Selection 9990.00 cop[tikv]  not(isnull(test.ps_t3.c1))",
+          "  │ │     └─TableFullScan 10000.00 cop[tikv] table:ps_t3 keep order:false, stats:pseudo",
+          "  │ └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+          "  │   └─TableFullScan 10000.00 cop[tikv] table:ps_t1 keep order:false, stats:pseudo",
+          "  └─HashJoin 12500.00 root  left outer join, left side:Selection, equal:[eq(test.ps_t2.c0, test.ps_t3.c1)]",
+          "    ├─TableReader(Build) 9990.00 root  data:Selection",
+          "    │ └─Selection 9990.00 cop[tikv]  not(isnull(test.ps_t3.c1))",
+          "    │   └─TableFullScan 10000.00 cop[tikv] table:ps_t3 keep order:false, stats:pseudo",
+          "    └─Selection(Probe) 10000.00 root  isnull(test.ps_t2.c2)",
+          "      └─MergeJoin 12500.00 root  right outer join, left side:TableReader, left key:test.ps_t2.id, right key:test.ps_t1.id",
+          "        ├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "        │ └─TableFullScan 10000.00 cop[tikv] table:ps_t2 keep order:true, stats:pseudo",
+          "        └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+          "          └─TableFullScan 10000.00 cop[tikv] table:ps_t1 keep order:true, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ],
+        "LastPlanFromCache": [
+          "0"
         ],
         "Warning": null
       }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65695

Problem Summary:

  `(col op const) IS NULL` could be treated as null‑rejecting in planner logic, which makes outer joins incorrectly simplified
  and causes result mismatches (e.g., TLP partitions vs. base query). To avoid this misclassification, we further simplify
  this pattern to `col IS NULL`.

  ### What changed and how does it work?
  - Add a predicate simplification rewrite for `(col op const) IS NULL` to `col IS NULL` for normal comparison operators.
  - Add a test case to validate the rewrite and a minimal TLP repro with right outer join and NULL semantics.



### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
