### PR TITLE
parser: add support for `SELECT ... INTO @var1, @var2 ...`

### DIFF
--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -3744,9 +3744,6 @@ func (n *SelectIntoOption) Restore(ctx *format.RestoreCtx) error {
 				return errors.Annotate(err, "An error occurred while restore SelectInto.LinesInfo")
 			}
 		}
-	case SelectIntoDumpfile:
-		ctx.WriteKeyWord("INTO DUMPFILE ")
-		ctx.WriteString(n.FileName)
 	case SelectIntoVars:
 		ctx.WriteKeyWord("INTO ")
 		for i, v := range n.Variables {

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -288,6 +288,16 @@ func (s *Scanner) Lex(v *yySymType) int {
 			return toTSO
 		}
 	}
+	if tok == into {
+		if tok1 := s.getNextToken(); tok1 == outfile {
+			_, pos, lit = s.scan()
+			v.ident = fmt.Sprintf("%s %s", v.ident, lit)
+			s.lastKeyword = intoOutfile
+			s.lastScanOffset = pos.Offset
+			v.offset = pos.Offset
+			return intoOutfile
+		}
+	}
 	// fix shift/reduce conflict with DEFINED NULL BY xxx OPTIONALLY ENCLOSED
 	if tok == optionally {
 		tok1, tok2 := s.getNextTwoTokens()

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -811,6 +811,12 @@ func TestDMLStmt(t *testing.T) {
 		{"select * from t for update of t skip locked", true, "SELECT * FROM `t` FOR UPDATE OF `t` SKIP LOCKED"},
 		{"select * from t for share of t skip locked", true, "SELECT * FROM `t` FOR SHARE OF `t` SKIP LOCKED"},
 
+		// select into variables
+		{"select score into @game_score from game_records where user_id = 1", true, "SELECT `score` INTO @`game_score` FROM `game_records` WHERE `user_id`=1"},
+		{"select a, b into @v1, @v2 from t", true, "SELECT `a`,`b` INTO @`v1`,@`v2` FROM `t`"},
+		{"select a into v from t", true, "SELECT `a` INTO `v` FROM `t`"},
+		{"select 1 into @a", true, "SELECT 1 INTO @`a`"},
+
 		// select into outfile
 		{"select a, b from t into outfile '/tmp/result.txt'", true, "SELECT `a`,`b` FROM `t` INTO OUTFILE '/tmp/result.txt'"},
 		{"select a from t order by a into outfile '/tmp/abc'", true, "SELECT `a` FROM `t` ORDER BY `a` INTO OUTFILE '/tmp/abc'"},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

- Implemented support for the `SELECT ... INTO @var1, @var2 ...` syntax in `tidb/parser`, as it was previously unsupported despite being essential for MySQL stored procedures.

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #40201

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```go
//go:build ignore

package main

import (
	"fmt"
	"github.com/pingcap/tidb/pkg/parser"
	"github.com/pingcap/tidb/pkg/parser/ast"
	_ "github.com/pingcap/tidb/pkg/types/parser_driver"
)

func main() {
	sql := "SELECT score INTO game_score FROM game_records WHERE user_id = 1"
	p := parser.New()
	stmts, _, err := p.Parse(sql, "", "")
	if err != nil {
		fmt.Printf("Error: %v\n", err)
		return
	}
	
	fmt.Printf("Parse SUCCESS!\n")
	for _, stmt := range stmts {
		if sel, ok := stmt.(*ast.SelectStmt); ok {
			fmt.Printf("SelectStmt found\n")
			fmt.Printf("  Fields count: %d\n", len(sel.Fields.Fields))
			for i, f := range sel.Fields.Fields {
				fmt.Printf("  Field %d: Expr=%T, AsName=%v\n", i, f.Expr, f.AsName)
			}
			if sel.SelectIntoOpt != nil {
				fmt.Printf("  SelectIntoOpt.Tp: %v\n", sel.SelectIntoOpt.Tp)
				fmt.Printf("  SelectIntoOpt.Variables: %v\n", sel.SelectIntoOpt.Variables)
				for i, v := range sel.SelectIntoOpt.Variables {
					fmt.Printf("    [%d] ColumnName=%v, UserVar=%v\n", i, v.ColumnName, v.UserVar)
				}
			} else {
				fmt.Printf("  SelectIntoOpt: nil\n")
			}
		}
	}
}
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
