### PR TITLE
pkg/server/handler/optimizor: stabilize plan replayer tests

### DIFF
--- a/pkg/server/handler/optimizor/plan_replayer_test.go
+++ b/pkg/server/handler/optimizor/plan_replayer_test.go
@@ -93,6 +93,9 @@ func prepareServerAndClientForTest(t *testing.T, store kv.Storage, dom *domain.D
 	cfg.Status.StatusPort = client.StatusPort
 	cfg.Status.ReportStatus = true
 
+	// RunInGoTestChan is a global channel and will be closed after the first server starts.
+	// Recreate it to avoid racing on subsequent server starts in the same test binary.
+	server.RunInGoTestChan = make(chan struct{})
 	srv, err := server.NewServer(cfg, driver)
 	srv.SetDomain(dom)
 	require.NoError(t, err)
@@ -359,6 +362,8 @@ func TestPlanReplayerWithMultiForeignKey(t *testing.T) {
 		config.AllowAllFiles = true
 	}))
 	require.NoError(t, err, "Error connecting")
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 	defer func() {
 		err := db.Close()
 		require.NoError(t, err)
@@ -374,15 +379,31 @@ func TestPlanReplayerWithMultiForeignKey(t *testing.T) {
 	tk.MustExec("drop table planReplayer.c")
 	tk.MustExec(`SET FOREIGN_KEY_CHECKS = 1;`)
 	tk.MustExec(fmt.Sprintf(`plan replayer load "%s"`, path))
+	tk.MustExec("use planReplayer")
+	tk.MustExec("set @@tidb_use_plan_baselines = 1")
+
+	rows := tk.MustQuery("select @@global.tidb_mem_quota_binding_cache")
+	require.True(t, rows.Next(), "unexpected data")
+	var originBindingCacheQuota int64
+	require.NoError(t, rows.Scan(&originBindingCacheQuota))
+	require.NoError(t, rows.Close())
+	tk.MustExec("set global tidb_mem_quota_binding_cache = 268435456") // 256MB
+	defer tk.MustExec(fmt.Sprintf("set global tidb_mem_quota_binding_cache = %d", originBindingCacheQuota))
+
 	tk.MustExec("admin reload bindings")
 	// 3-3. check whether binding takes effect
-	tk.MustExec(`select a, b from t where a in (1, 2, 3)`)
-	rows := tk.MustQuery("select @@last_plan_from_binding")
-	require.True(t, rows.Next(), "unexpected data")
-	var count int64
-	err = rows.Scan(&count)
-	require.NoError(t, err)
-	require.Equal(t, int64(1), count)
+	require.Eventually(t, func() bool {
+		tk.MustExec(`select a, b from t where a in (1, 2, 3)`)
+		rows := tk.MustQuery("select @@last_plan_from_binding")
+		if !rows.Next() {
+			_ = rows.Close()
+			return false
+		}
+		var count int64
+		err := rows.Scan(&count)
+		_ = rows.Close()
+		return err == nil && count == int64(1)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func TestIssue43192(t *testing.T) {
@@ -487,6 +508,13 @@ func prepareData4Issue43192(t *testing.T, client *testserverclient.TestServerCli
 	require.NoError(t, rows.Close())
 	rows = tk.MustQuery("select @@tidb_last_plan_replayer_token")
 	require.True(t, rows.Next(), "unexpected data")
+	var token string
+	require.NoError(t, rows.Scan(&token))
+	require.NoError(t, rows.Close())
+	require.Equal(t, filename, token)
+
+	// Cleanup the binding created for dumping to avoid interference when the same server later loads the replayer file.
+	tk.MustExec("drop global binding for select a, b from t where a in (1, 2, 3)")
 	return filename
 }
 
@@ -494,6 +522,8 @@ func prepareData4Issue56458(t *testing.T, client *testserverclient.TestServerCli
 	h := dom.StatsHandle()
 	db, err := sql.Open("mysql", client.GetDSN())
 	require.NoError(t, err, "Error connecting")
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 	defer func() {
 		err := db.Close()
 		require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65729

Problem Summary:

Plan replayer unit tests were flaky due to shared global server startup state, implicit default DB after `PLAN REPLAYER LOAD`, and async binding propagation/caching.

### What changed and how does it work?

- Recreate `server.RunInGoTestChan` before starting a server in the test helper.
- After `PLAN REPLAYER LOAD`, explicitly `USE planReplayer` and enable plan baselines.
- Use `require.Eventually` to wait until the binding takes effect.
- Cleanup dump-created global bindings to avoid interference.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
  - `go test ./pkg/server/handler/optimizor -run '^TestPlanReplayerWithMultiForeignKey$' -tags=intest`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] The change is for stabilizing unit tests; CI will cover it.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
