### PR TITLE
pkg/server/handler/optimizor: stabilize stats handler test

### DIFF
--- a/pkg/server/handler/optimizor/statistics_handler_test.go
+++ b/pkg/server/handler/optimizor/statistics_handler_test.go
@@ -307,6 +307,9 @@ func TestStatsPriorityQueueAPI(t *testing.T) {
 	cfg.Status.ReportStatus = true
 	cfg.Socket = filepath.Join(tmp, fmt.Sprintf("tidb-mock-%d.sock", time.Now().UnixNano()))
 
+	// RunInGoTestChan is a global channel and will be closed after the first server starts.
+	// Recreate it to avoid racing on subsequent server starts in the same test binary.
+	server2.RunInGoTestChan = make(chan struct{})
 	server, err := server2.NewServer(cfg, driver)
 	require.NoError(t, err)
 	defer server.Close()
@@ -368,6 +371,9 @@ func TestLoadNullStatsFile(t *testing.T) {
 	cfg.Socket = filepath.Join(tmp, fmt.Sprintf("tidb-mock-%d.sock", time.Now().UnixNano()))
 
 	// Creating and running the server
+	// RunInGoTestChan is a global channel and will be closed after the first server starts.
+	// Recreate it to avoid racing on subsequent server starts in the same test binary.
+	server2.RunInGoTestChan = make(chan struct{})
 	server, err := server2.NewServer(cfg, driver)
 	require.NoError(t, err)
 	defer server.Close()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65730

Problem Summary:

`TestDumpStatsAPI` was flaky because it relied on `server.RunInGoTestChan`, a global channel that is closed after the first server starts in the same test binary.

### What changed and how does it work?

- Recreate `server.RunInGoTestChan` before each server start in `statistics_handler_test.go` so `<-RunInGoTestChan` reliably waits for the current instance.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
  - `go test ./pkg/server/handler/optimizor -run '^TestDumpStatsAPI$' -tags=intest`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] The change is for stabilizing an existing unit test; CI will cover it.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
