### PR TITLE
tests/realtikvtest/txntest: stabilize staleness txn test

### DIFF
--- a/tests/realtikvtest/txntest/stale_read_test.go
+++ b/tests/realtikvtest/txntest/stale_read_test.go
@@ -643,7 +643,7 @@ func TestSetTransactionReadOnlyAsOf(t *testing.T) {
 }
 
 func TestValidateReadOnlyInStalenessTransaction(t *testing.T) {
-	const stalenessTSExpr = "NOW(3) - INTERVAL 1 SECOND"
+	const stalenessTSExpr = "NOW(3) - INTERVAL 5 SECOND"
 	errMsg1 := ".*only support read-only statement during read-only staleness transactions.*"
 	errMsg2 := ".*select lock hasn't been supported in stale read yet.*"
 	errMsg3 := "GetForUpdateTS not supported for stalenessTxnProvider"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65731

Problem Summary:

`TestValidateReadOnlyInStalenessTransaction` was flaky because `AS OF TIMESTAMP NOW()` can be too new under safeTS / scheduling lag.

### What changed and how does it work?

- Use an older timestamp expression (`NOW(3) - INTERVAL 5 SECOND`) to add buffer.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
  - `go test ./tests/realtikvtest/txntest -run '^TestValidateReadOnlyInStalenessTransaction$' -tags=intest`
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] The change is for stabilizing an existing RealTiKV test; CI will cover it.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
