### PR TITLE
refactor(runaway): use info cache to check runaway watch tables

### DIFF
--- a/pkg/resourcegroup/runaway/record.go
+++ b/pkg/resourcegroup/runaway/record.go
@@ -38,14 +38,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	// watchTableName is the name of system table which save runaway watch items.
-	watchTableName = "mysql.tidb_runaway_watch"
-	// watchDoneTableName is the name of system table which save done runaway watch items.
-	watchDoneTableName = "mysql.tidb_runaway_watch_done"
-
-	maxIDRetries = 3
-)
+const maxIDRetries = 3
 
 // NullTime is a zero time.Time.
 var NullTime time.Time
@@ -160,7 +153,7 @@ func writeInsert(builder *strings.Builder, tableName string) {
 func (r *QuarantineRecord) genInsertionStmt() (string, []any) {
 	var builder strings.Builder
 	params := make([]any, 0, 9)
-	writeInsert(&builder, watchTableName)
+	writeInsert(&builder, getRunawayWatchTableName())
 	builder.WriteString("(null, %?, %?, %?, %?, %?, %?, %?, %?, %?)")
 	params = append(params, r.ResourceGroupName)
 	params = append(params, r.StartTime)
@@ -182,7 +175,7 @@ func (r *QuarantineRecord) genInsertionStmt() (string, []any) {
 func (r *QuarantineRecord) genInsertionDoneStmt() (string, []any) {
 	var builder strings.Builder
 	params := make([]any, 0, 11)
-	writeInsert(&builder, watchDoneTableName)
+	writeInsert(&builder, getRunawayWatchDoneTableName())
 	builder.WriteString("(null, %?, %?, %?, %?, %?, %?, %?, %?, %?, %?, %?)")
 	params = append(params, r.ID)
 	params = append(params, r.ResourceGroupName)
@@ -207,7 +200,7 @@ func (r *QuarantineRecord) genDeletionStmt() (string, []any) {
 	var builder strings.Builder
 	params := make([]any, 0, 1)
 	builder.WriteString("delete from ")
-	builder.WriteString(watchTableName)
+	builder.WriteString(getRunawayWatchTableName())
 	builder.WriteString(" where id = %?")
 	params = append(params, r.ID)
 	return builder.String(), params


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65746.

Problem Summary:

- Added `infoCache` dependency to runaway `syncer` for in-memory schema checks instead of SQL queries.
- Introduced helper functions to construct `mysql.tidb_runaway_watch` and `mysql.tidb_runaway_watch_done` table names dynamically.
- Simplified `checkWatchTableExist()` and `checkWatchDoneTableExist()` to return boolean values using InfoSchema lookup.

These changes improve startup resilience and performance by relying on cached schema metadata instead of querying `information_schema` tables frequently.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
