### PR TITLE
importinto: use real file size when calculate resource

### DIFF
--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -386,10 +386,11 @@ type LoadDataController struct {
 	// - ref columns in set clause is allowed in mysql, but not in tidb
 	InsertColumns []*table.Column
 
-	logger        *zap.Logger
-	dataStore     storeapi.Storage
-	dataFiles     []*mydump.SourceFileMeta
-	totalRealSize int64
+	logger    *zap.Logger
+	dataStore storeapi.Storage
+	dataFiles []*mydump.SourceFileMeta
+	// exported for testing.
+	TotalRealSize int64
 	// globalSortStore is used to store sorted data when using global sort.
 	globalSortStore storeapi.Storage
 	// ExecuteNodesCnt is the count of execute nodes.
@@ -1500,7 +1501,7 @@ func (e *LoadDataController) InitDataFiles(ctx context.Context) error {
 
 	e.dataFiles = dataFiles
 	e.TotalFileSize = totalSize
-	e.totalRealSize = totalRealSize
+	e.TotalRealSize = totalRealSize
 
 	return nil
 }
@@ -1517,7 +1518,7 @@ func (e *LoadDataController) CalResourceParams(ctx context.Context, ksCodec []by
 	if err != nil {
 		return err
 	}
-	totalSize := e.totalRealSize
+	totalSize := e.TotalRealSize
 	numOfIndexGenKV := GetNumOfIndexGenKV(e.TableInfo)
 	var indexSizeRatio float64
 	if numOfIndexGenKV > 0 {

--- a/pkg/executor/importer/importer_testkit_test.go
+++ b/pkg/executor/importer/importer_testkit_test.go
@@ -434,14 +434,14 @@ func TestCalResourceParams(t *testing.T) {
 	_, tm, ctx := testutil.InitTableTest(t)
 
 	require.NoError(t, tm.InitMeta(ctx, "tidb1", handle.GetTargetScope()))
-	c := &importer.LoadDataController{Plan: &importer.Plan{TotalFileSize: 200 * units.TiB, TableInfo: &model.TableInfo{}}}
+	c := &importer.LoadDataController{TotalRealSize: 200 * units.TiB, Plan: &importer.Plan{TableInfo: &model.TableInfo{}}}
 	importer.WithLogger(zap.NewNop())(c)
 	require.NoError(t, c.CalResourceParams(ctx, nil))
 	require.Equal(t, 8, c.ThreadCnt)
 	require.Equal(t, 32, c.MaxNodeCnt)
 	require.Equal(t, 256, c.DistSQLScanConcurrency)
 
-	c = &importer.LoadDataController{Plan: &importer.Plan{TotalFileSize: 300 * units.GiB, TableInfo: &model.TableInfo{}}}
+	c = &importer.LoadDataController{TotalRealSize: 300 * units.GiB, Plan: &importer.Plan{TableInfo: &model.TableInfo{}}}
 	importer.WithLogger(zap.NewNop())(c)
 	require.NoError(t, c.CalResourceParams(ctx, nil))
 	require.Equal(t, 8, c.ThreadCnt)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
use real file size to calculate resource, so for compressed data files, we can use expected resources
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

with `totalRealSize=5.518GiB` and `amplifyFactor=10`, the calculated thread is 2
```
[2026/02/02 17:31:53.914 +08:00] [INFO] [import.go:1533] ["auto calculate resource related params"] [keyspaceName=SYSTEM] [table=t] [thread=2] [maxNode=1] [distsqlScanConcurrency=30] [targetNodeCPU=10] [totalFileSize=1.148GiB] [totalRealSize=5.518GiB] [fileCount=10] [numOfIndexGenKV=0] [indexSizeRatio=0] [amplifyFactor=10] [costTime=2.048125ms]
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
