### PR TITLE
pkg/executor: fix unstable TestIssue20779

### DIFF
--- a/pkg/executor/test/jointest/join_test.go
+++ b/pkg/executor/test/jointest/join_test.go
@@ -743,7 +743,7 @@ func TestIssue20779(t *testing.T) {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/join/testIssue20779"))
 	}()
 
-	rs, err := tk.Exec("select /*+ inl_hash_join(t2) */ t1.b from t1 left join t1 t2 on t1.b=t2.b order by t1.b;")
+	rs, err := tk.Exec("select /*+ inl_hash_join(t2) */ t1.b from t1 use index(idx) left join t1 t2 use index(idx) on t1.b=t2.b order by t1.b;")
 	require.NoError(t, err)
 	_, err = session.GetRows4Test(context.Background(), nil, rs)
 	require.EqualError(t, err, "testIssue20779")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61353

Problem Summary:
- `TestIssue20779` was unstable because plan selection could change and the join failpoint panic wasn"t triggered deterministically.

### What changed and how does it work?
- Force `t1`/`t2` to `USE INDEX(idx)` so the plan keeps the expected outer order.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)

Test Details:
- `make failpoint-enable && (go test -run ^TestIssue20779$ -count=50 --tags=intest ./pkg/executor/test/jointest; rc=$?; make failpoint-disable; exit $rc)`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
