### PR TITLE
*: fix invalid failpoints

### DIFF
--- a/br/pkg/restore/misc_test.go
+++ b/br/pkg/restore/misc_test.go
@@ -125,9 +125,9 @@ func TestGetTSWithRetry(t *testing.T) {
 	})
 
 	t.Run("PD leader failure:", func(t *testing.T) {
-		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/utils/set-attempt-to-one", "1*return(true)"))
+		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/utils/set-remaining-attempts-to-one", "1*return(true)"))
 		defer func() {
-			require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/utils/set-attempt-to-one"))
+			require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/utils/set-remaining-attempts-to-one"))
 		}()
 		retryTimes := -1000
 		pDClient := split.NewFakePDClient(nil, true, &retryTimes)

--- a/pkg/ddl/ingest/integration_test.go
+++ b/pkg/ddl/ingest/integration_test.go
@@ -106,9 +106,9 @@ func TestIngestError(t *testing.T) {
 	}
 	tk.MustQuery("split table t between (0) and (50000) regions 5;").Check(testkit.Rows("4 1"))
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockCopSenderError", "1*return"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockScanRecordError", "1*return"))
 	tk.MustExec("alter table t add index idx(a);")
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockCopSenderError"))
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockScanRecordError"))
 	tk.MustExec("admin check table t;")
 	rows := tk.MustQuery("admin show ddl jobs 1;").Rows()
 	//nolint: forcetypeassert

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -164,7 +164,6 @@ func TestInfo(t *testing.T) {
 
 	err = dom.refreshServerIDTTL(goCtx)
 	require.NoError(t, err)
-
 }
 
 func TestStatWorkRecoverFromPanic(t *testing.T) {

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -60,9 +60,6 @@ func TestInfo(t *testing.T) {
 		t.Skip("ETCD use ip:port as unix socket address, skip when it is unavailable.")
 	}
 
-	// NOTICE: this failpoint has been REMOVED, be aware of this if you want to reopen this test.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/domain/infosync/FailPlacement", `return(true)`))
-
 	s, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 
@@ -94,10 +91,8 @@ func TestInfo(t *testing.T) {
 	)
 	ddl.DisableTiFlashPoll(dom.ddl)
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/domain/MockReplaceDDL", `return(true)`))
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/NoDDLDispatchLoop", `return(true)`))
 	require.NoError(t, dom.Init(sysMockFactory, nil))
 	require.NoError(t, dom.Start(ddl.Bootstrap))
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/NoDDLDispatchLoop"))
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/domain/MockReplaceDDL"))
 
 	// Test for GetServerInfo and GetServerInfoByID.
@@ -170,7 +165,6 @@ func TestInfo(t *testing.T) {
 	err = dom.refreshServerIDTTL(goCtx)
 	require.NoError(t, err)
 
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/domain/infosync/FailPlacement"))
 }
 
 func TestStatWorkRecoverFromPanic(t *testing.T) {

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1266,6 +1266,9 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, lockErr error
 
 	// Without this line of code, the result will still be correct. But it can ensure that the update time of for update read
 	// is determined which is beneficial for testing.
+	failpoint.Inject("ExecStmtGetTsError", func() {
+		failpoint.Return(nil, errors.New("mock GetStmtForUpdateTS error"))
+	})
 	if _, err = txnManager.GetStmtForUpdateTS(); err != nil {
 		return nil, err
 	}

--- a/pkg/executor/executor_failpoint_test.go
+++ b/pkg/executor/executor_failpoint_test.go
@@ -387,9 +387,9 @@ func TestCoprocessorBlockIssues56916(t *testing.T) {
 }
 
 func TestIssue21441(t *testing.T) {
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/union/issue21441", `return`))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/unionexec/issue21441", `return`))
 	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/union/issue21441"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/unionexec/issue21441"))
 	}()
 
 	store := testkit.CreateMockStore(t)

--- a/pkg/executor/insert_test.go
+++ b/pkg/executor/insert_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/meta/autoid"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
@@ -32,11 +31,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInsertOnDuplicateKeyWithBinlog(t *testing.T) {
+func TestInsertOnDuplicateKey(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
-	failpoint.Enable("github.com/pingcap/tidb/pkg/table/tblsession/forceWriteBinlog", "return")
-	defer failpoint.Disable("github.com/pingcap/tidb/pkg/table/tblsession/forceWriteBinlog")
 	testInsertOnDuplicateKey(t, tk)
 }
 

--- a/pkg/executor/sortexec/sort_test.go
+++ b/pkg/executor/sortexec/sort_test.go
@@ -47,9 +47,9 @@ func testSortInDisk(t *testing.T, removeDir bool) {
 		conf.TempStoragePath = t.TempDir()
 		conf.Performance.EnableStatsCacheMemQuota = true
 	})
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/sortexec/testSortedRowContainerSpill", "return(true)"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/util/chunk/testSortedRowContainerSpill", "return(true)"))
 	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/sortexec/testSortedRowContainerSpill"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/util/chunk/testSortedRowContainerSpill"))
 	}()
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
@@ -110,8 +110,8 @@ func TestIssue16696(t *testing.T) {
 	vardef.MemoryUsageAlarmRatio.Store(0.0)
 	defer vardef.MemoryUsageAlarmRatio.Store(alarmRatio)
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/sortexec/testSortedRowContainerSpill", "return(true)"))
-	defer require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/sortexec/testSortedRowContainerSpill"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/util/chunk/testSortedRowContainerSpill", "return(true)"))
+	defer require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/util/chunk/testSortedRowContainerSpill"))
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/join/testRowContainerSpill", "return(true)"))
 	defer require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/join/testRowContainerSpill"))
 	store := testkit.CreateMockStore(t)

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -645,7 +645,7 @@ func TestSmallTableAnalyzeV2(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 
 	tk := testkit.NewTestKit(t, store)
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/calcSampleRateByStorageCount", "return(1)"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/internal/pdhelper/calcSampleRateByStorageCount", "return(1)"))
 	tk.MustExec("use test")
 	tk.MustExec("set @@session.tidb_analyze_version = 2")
 	tk.MustExec("create table small_table_inject_pd(a int)")
@@ -683,7 +683,7 @@ create table small_table_inject_pd_with_partition(
 		{"p2", "0", "1"},
 	}
 	tk.MustQuery("show stats_meta where db_name = 'test' and table_name = 'small_table_inject_pd_with_partition'").Sort().CheckAt([]int{2, 4, 5}, rows)
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/calcSampleRateByStorageCount"))
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/internal/pdhelper/calcSampleRateByStorageCount"))
 }
 
 func TestSavedAnalyzeOptions(t *testing.T) {

--- a/pkg/executor/test/cte/cte_test.go
+++ b/pkg/executor/test/cte/cte_test.go
@@ -69,9 +69,9 @@ func TestSpillToDisk(t *testing.T) {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/testCTEStorageSpill"))
 		tk.MustExec("set tidb_mem_quota_query = 1073741824;")
 	}()
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/sortexec/testSortedRowContainerSpill", "return(true)"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/util/chunk/testSortedRowContainerSpill", "return(true)"))
 	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/sortexec/testSortedRowContainerSpill"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/util/chunk/testSortedRowContainerSpill"))
 	}()
 
 	// Use duplicated rows to test UNION DISTINCT.

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -939,11 +939,11 @@ func TestIndexEstimationCrossValidate(t *testing.T) {
 	tk.MustExec("create table t(a int, b int, key(a,b))")
 	tk.MustExec("insert into t values(1, 1), (1, 2), (1, 3), (2, 2)")
 	tk.MustExec("analyze table t")
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/statistics/table/mockQueryBytesMaxUint64", `return(100000)`))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/statistics/mockQueryBytesMaxUint64", `return(100000)`))
 	tk.MustQuery("explain format = 'brief' select * from t where a = 1 and b = 2").Check(testkit.Rows(
 		"IndexReader 1.00 root  index:IndexRangeScan",
 		"└─IndexRangeScan 1.00 cop[tikv] table:t, index:a(a, b) range:[1 2,1 2], keep order:false"))
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/table/mockQueryBytesMaxUint64"))
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/mockQueryBytesMaxUint64"))
 
 	// Test issue 22466
 	tk.MustExec("drop table if exists t2")

--- a/pkg/planner/core/casetest/planstats/plan_stats_test.go
+++ b/pkg/planner/core/casetest/planstats/plan_stats_test.go
@@ -317,9 +317,9 @@ func TestPlanStatsLoadTimeout(t *testing.T) {
 		require.Error(t, err) // fail sql for timeout when pseudo=false
 
 		testKit.MustExec("set global tidb_stats_load_pseudo_timeout=true")
-		require.NoError(t, failpoint.Enable("github.com/pingcap/executor/assertSyncStatsFailed", `return(true)`))
+		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/assertSyncStatsFailed", `return(true)`))
 		testKit.MustExec(sql) // not fail sql for timeout when pseudo=true
-		failpoint.Disable("github.com/pingcap/executor/assertSyncStatsFailed")
+		failpoint.Disable("github.com/pingcap/tidb/pkg/executor/assertSyncStatsFailed")
 
 		// Test Issue #50872.
 		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/planner/core/assertSyncWaitFailed", `return(true)`))

--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -1084,7 +1084,7 @@ func TestTiFlashFallback(t *testing.T) {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/copr/ReduceCopNextMaxBackoff"))
 	}()
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErrtiflash0", "return(\"tiflash0\")"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErr", "return(\"tiflash0\")"))
 	// test COM_STMT_EXECUTE
 	ctx := context.Background()
 	tk.MustExec("set @@tidb_allow_fallback_to_tikv='tiflash'")
@@ -1097,7 +1097,7 @@ func TestTiFlashFallback(t *testing.T) {
 	require.Error(t, cc.handleStmtExecute(ctx, []byte{0x1, 0x0, 0x0, 0x0, 0x1, 0x1, 0x0, 0x0, 0x0}))
 	tk.MustExec("set @@tidb_allow_fallback_to_tikv=''")
 	require.Error(t, cc.handleStmtExecute(ctx, []byte{0x1, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0}))
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErrtiflash0"))
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErr"))
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/server/fetchNextErr", "return(\"firstNext\")"))
 	// test COM_STMT_EXECUTE (cursor mode)
@@ -1120,9 +1120,9 @@ func TestTiFlashFallback(t *testing.T) {
 	// TiFlash query based on batch cop (batch + streaming)
 	tk.MustExec("set @@tidb_allow_batch_cop=1; set @@tidb_allow_mpp=0;")
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErrtiflash0", "return(\"tiflash0\")"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErr", "return(\"tiflash0\")"))
 	testFallbackWork(t, tk, cc, "select count(*) from t")
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErrtiflash0"))
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErr"))
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/batchCopRecvTimeout", "return(true)"))
 	testFallbackWork(t, tk, cc, "select count(*) from t")

--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -251,9 +251,9 @@ func TestRegionsFromMeta(t *testing.T) {
 	}
 
 	// test no panic
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/server/errGetRegionByIDEmpty", `return(true)`))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/server/handler/errGetRegionByIDEmpty", `return(true)`))
 	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/server/errGetRegionByIDEmpty"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/server/handler/errGetRegionByIDEmpty"))
 	}()
 	resp1, err := ts.FetchStatus("/regions/meta")
 	require.NoError(t, err)

--- a/pkg/sessiontxn/txn_context_test.go
+++ b/pkg/sessiontxn/txn_context_test.go
@@ -58,7 +58,6 @@ func setupTxnContextTest(t *testing.T) (kv.Storage, *domain.Domain) {
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/assertTxnManagerAfterPessimisticLockErrorRetry", "return"))
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/assertTxnManagerInShortPointGetPlan", "return"))
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/session/assertTxnManagerInRunStmt", "return"))
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/session/assertTxnManagerInCachedPlanExec", "return"))
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/session/assertTxnManagerForUpdateTSEqual", "return"))
 
 	store, do := testkit.CreateMockStoreAndDomain(t)
@@ -85,7 +84,6 @@ func setupTxnContextTest(t *testing.T) (kv.Storage, *domain.Domain) {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/assertTxnManagerAfterPessimisticLockErrorRetry"))
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/assertTxnManagerInShortPointGetPlan"))
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/session/assertTxnManagerInRunStmt"))
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/session/assertTxnManagerInCachedPlanExec"))
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/session/assertTxnManagerForUpdateTSEqual"))
 
 		tk.Session().SetValue(sessiontxn.AssertRecordsKey, nil)

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -1533,7 +1533,7 @@ func (t *TopNMeta) buildBucket4Merging(d *types.Datum, analyzeVer int) *bucket4M
 	if analyzeVer <= Version2 {
 		res.NDV = 0
 	}
-	failpoint.Inject("github.com/pingcap/pkg/statistics/enableTopNNDV", func(_ failpoint.Value) {
+	failpoint.Inject("enableTopNNDV", func(_ failpoint.Value) {
 		res.NDV = 1
 	})
 	intest.Assert(analyzeVer <= Version2)

--- a/pkg/statistics/histogram_test.go
+++ b/pkg/statistics/histogram_test.go
@@ -436,7 +436,7 @@ func TestMergePartitionLevelHist(t *testing.T) {
 			expBucketNumber: 3,
 		},
 	}
-	failpoint.Enable("github.com/pingcap/pkg/statistics/enableTopNNDV", `return(true)`)
+	failpoint.Enable("github.com/pingcap/tidb/pkg/statistics/enableTopNNDV", `return(true)`)
 
 	for ii, tt := range tests {
 		var expTotColSize int64
@@ -473,7 +473,7 @@ func TestMergePartitionLevelHist(t *testing.T) {
 		}
 		require.Equal(t, expTotColSize, globalHist.TotColSize, "failed at #%d case", ii)
 	}
-	failpoint.Disable("github.com/pingcap/pkg/statistics/enableTopNNDV")
+	failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/enableTopNNDV")
 }
 
 func genBucket4Merging4Test(lower, upper, ndv, disjointNDV int64) bucket4Merging {

--- a/pkg/store/batch_coprocessor_test.go
+++ b/pkg/store/batch_coprocessor_test.go
@@ -77,11 +77,11 @@ func TestStoreErr(t *testing.T) {
 	err = tk.QueryToErr("select count(*) from t")
 	require.Equal(t, context.Canceled, errors.Cause(err))
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErrtiflash0", "1*return(\"tiflash0\")"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErr", "1*return(\"tiflash0\")"))
 
 	tk.MustQuery("select count(*) from t").Check(testkit.Rows("1"))
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErrtiflash0", "return(\"tiflash0\")"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErr", "return(\"tiflash0\")"))
 	err = tk.QueryToErr("select count(*) from t")
 	require.Error(t, err)
 }
@@ -108,11 +108,11 @@ func TestStoreSwitchPeer(t *testing.T) {
 	tk.MustExec("set @@session.tidb_isolation_read_engines=\"tiflash\"")
 	tk.MustExec("set @@session.tidb_allow_mpp=OFF")
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErrtiflash0", "return(\"tiflash0\")"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErr", "return(\"tiflash0\")"))
 
 	tk.MustQuery("select count(*) from t").Check(testkit.Rows("1"))
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErrtiflash1", "return(\"tiflash1\")"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/BatchCopRpcErr", "return(\"tiflash0,tiflash1\")"))
 	err = tk.QueryToErr("select count(*) from t")
 	require.Error(t, err)
 }

--- a/pkg/store/gcworker/gc_worker.go
+++ b/pkg/store/gcworker/gc_worker.go
@@ -1688,6 +1688,7 @@ func doGCPlacementRules(se sessionapi.Session, _ uint64,
 		return
 	}
 
+	failpoint.Inject("gcDeletePlacementRuleCounter", func(_ failpoint.Value) {})
 	if err := infosync.DeleteTiFlashPlacementRules(context.Background(), physicalTableIDs); err != nil {
 		logutil.BgLogger().Error("delete placement rules failed", zap.Error(err), zap.Int64s("tableIDs", physicalTableIDs))
 	}

--- a/pkg/testkit/testkit.go
+++ b/pkg/testkit/testkit.go
@@ -194,12 +194,12 @@ func (tk *TestKit) MustQuery(sql string, args ...any) *Result {
 		strings.Contains(sql, "TIDB_TRX") {
 		return rs1
 	}
-	err := failpoint.Enable("github.com/pingcap/tidb/pkg/planner/core/skipExtractor", "return(true)")
+	err := failpoint.Enable("github.com/pingcap/tidb/pkg/planner/core/operator/logicalop/skipExtractor", "return(true)")
 	if err != nil {
 		panic(err)
 	}
 	rs2 := tk.MustQueryWithContext(context.Background(), sql, args...)
-	err = failpoint.Disable("github.com/pingcap/tidb/pkg/planner/core/skipExtractor")
+	err = failpoint.Disable("github.com/pingcap/tidb/pkg/planner/core/operator/logicalop/skipExtractor")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/util/chunk/row_container.go
+++ b/pkg/util/chunk/row_container.go
@@ -614,6 +614,11 @@ func (c *SortedRowContainer) SpillToDisk() {
 }
 
 func (c *SortedRowContainer) hasEnoughDataToSpill(t *memory.Tracker) bool {
+	failpoint.Inject("testSortedRowContainerSpill", func(val failpoint.Value) {
+		if val.(bool) {
+			failpoint.Return(true)
+		}
+	})
 	// Guarantee that each partition size is at least 10% of the threshold, to avoid opening too many files.
 	return c.GetMemTracker().BytesConsumed() > t.GetBytesLimit()/10
 }

--- a/tests/realtikvtest/addindextest3/ingest_test.go
+++ b/tests/realtikvtest/addindextest3/ingest_test.go
@@ -452,9 +452,9 @@ func TestAddIndexMockFlushError(t *testing.T) {
 	for i := range 4 {
 		tk.MustExec(fmt.Sprintf("insert into t values (%d, %d);", i*10000, i*10000))
 	}
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/ingest/mockFlushError", "1*return"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockFlushError", "1*return"))
 	tk.MustExec("alter table t add index idx(a);")
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/ingest/mockFlushError"))
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockFlushError"))
 	tk.MustExec("admin check table t;")
 	rows := tk.MustQuery("admin show ddl jobs 1;").Rows()
 	//nolint: forcetypeassert

--- a/tests/realtikvtest/txntest/stale_read_test.go
+++ b/tests/realtikvtest/txntest/stale_read_test.go
@@ -1164,7 +1164,7 @@ func TestStmtCtxStaleFlag(t *testing.T) {
 		// assert select statement in stale transaction
 		{
 			sql:          fmt.Sprintf("start transaction read only as of timestamp '%v'", time1),
-			hasStaleFlag: false,
+			hasStaleFlag: true,
 		},
 		{
 			sql:          "select * from t",
@@ -1210,7 +1210,7 @@ func TestStmtCtxStaleFlag(t *testing.T) {
 		// assert execute select statement in stale transaction
 		{
 			sql:          fmt.Sprintf("start transaction read only as of timestamp '%v'", time1),
-			hasStaleFlag: false,
+			hasStaleFlag: true,
 		},
 		{
 			sql:          "execute p1",

--- a/tests/realtikvtest/txntest/stale_read_test.go
+++ b/tests/realtikvtest/txntest/stale_read_test.go
@@ -1223,10 +1223,10 @@ func TestStmtCtxStaleFlag(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		failpoint.Enable("github.com/pingcap/tidb/exector/assertStmtCtxIsStaleness",
+		failpoint.Enable("github.com/pingcap/tidb/pkg/executor/assertStmtCtxIsStaleness",
 			fmt.Sprintf("return(%v)", testcase.hasStaleFlag))
 		tk.MustExec(testcase.sql)
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/exector/assertStmtCtxIsStaleness"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/assertStmtCtxIsStaleness"))
 		// assert stale read flag should be false after each statement execution
 		require.False(t, staleread.IsStmtStaleness(tk.Session()))
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62567

Problem Summary:
- Several tests referenced failpoints that were renamed/moved or were never definable (dynamic names / wrong package paths), breaking failpoint builds.

### What changed and how does it work?
- Fix failpoint names/paths, replace dynamic BatchCopRpc failpoint with a constant name, and add missing injection points.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)

Test Details:
- `make failpoint-enable; go test -run ^TestIssue16696$ --tags=intest ./pkg/executor/sortexec; go test -run ^TestStoreSwitchPeer$ --tags=intest ./pkg/store; go test -run ^TestRegionsFromMeta$ --tags=intest ./pkg/server/handler/tests; go test -run ^TestTxnContextForSimpleCases$ --tags=intest ./pkg/sessiontxn; make failpoint-disable`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
