### PR TITLE
pkg/util: fix workloadrepo interval race

### DIFF
--- a/pkg/util/workloadrepo/sampling.go
+++ b/pkg/util/workloadrepo/sampling.go
@@ -46,7 +46,11 @@ func (w *worker) samplingTable(ctx context.Context, rt *repositoryTable) {
 
 func (w *worker) startSample(ctx context.Context) func() {
 	return func() {
-		w.resetSamplingInterval(w.samplingInterval)
+		w.Lock()
+		if w.samplingTicker != nil {
+			w.resetSamplingInterval(w.samplingInterval)
+		}
+		w.Unlock()
 
 		for {
 			select {

--- a/pkg/util/workloadrepo/snapshot.go
+++ b/pkg/util/workloadrepo/snapshot.go
@@ -202,7 +202,11 @@ func (w *worker) takeSnapshot(ctx context.Context) (uint64, error) {
 
 func (w *worker) startSnapshot(_ctx context.Context) func() {
 	return func() {
-		w.resetSnapshotInterval(w.snapshotInterval)
+		w.Lock()
+		if w.snapshotTicker != nil {
+			w.resetSnapshotInterval(w.snapshotInterval)
+		}
+		w.Unlock()
 
 		// this is for etcd watch
 		// other wise wch won't be collected after the exit of this function


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62929

Problem Summary:
- Data race in `workloadrepo.(*worker).changeSnapshotInterval()` due to unsynchronized reads during ticker initialization.

### What changed and how does it work?
- Guard initial interval resets under the worker mutex and check ticker presence before resetting.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)

Test Details:
- `go test -race -run ^TestRecoverSnapID$ --tags=intest ./pkg/util/workloadrepo`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
