### PR TITLE
pkg/statistics: fix auto analyze table size calc

### DIFF
--- a/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory.go
@@ -186,10 +186,14 @@ func (f *AnalysisJobFactory) CalculateChangePercentage(tblStats *statistics.Tabl
 // CalculateTableSize calculates the size of the table.
 func (*AnalysisJobFactory) CalculateTableSize(tblStats *statistics.Table) float64 {
 	tblCnt := float64(tblStats.RealtimeCount)
-	colCnt := float64(tblStats.ColAndIdxExistenceMap.ColNum())
-	intest.Assert(colCnt != 0, "Column count should not be 0")
-
-	return tblCnt * colCnt
+	if tblStats.ColAndIdxExistenceMap == nil {
+		return tblCnt
+	}
+	colCnt := tblStats.ColAndIdxExistenceMap.ColNum()
+	if colCnt == 0 {
+		return tblCnt
+	}
+	return tblCnt * float64(colCnt)
 }
 
 // GetTableLastAnalyzeDuration gets the last analyze duration of the table.

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory.go
@@ -186,7 +186,7 @@ func (f *AnalysisJobFactory) CalculateChangePercentage(tblStats *statistics.Tabl
 // CalculateTableSize calculates the size of the table.
 func (*AnalysisJobFactory) CalculateTableSize(tblStats *statistics.Table) float64 {
 	tblCnt := float64(tblStats.RealtimeCount)
-	intest.Assert(tblCnt >= 0, "Table count should not be negative")
+	intest.Assert(tblCnt > 0, "Table count should not be negative")
 	intest.Assert(tblStats.ColAndIdxExistenceMap != nil, "ColAndIdxExistenceMap should not be nil")
 	// Defensive check.
 	if tblStats.ColAndIdxExistenceMap == nil {

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory.go
@@ -186,9 +186,14 @@ func (f *AnalysisJobFactory) CalculateChangePercentage(tblStats *statistics.Tabl
 // CalculateTableSize calculates the size of the table.
 func (*AnalysisJobFactory) CalculateTableSize(tblStats *statistics.Table) float64 {
 	tblCnt := float64(tblStats.RealtimeCount)
+	intest.Assert(tblCnt >= 0, "Table count should not be negative")
+	intest.Assert(tblStats.ColAndIdxExistenceMap != nil, "ColAndIdxExistenceMap should not be nil")
+	// Defensive check.
 	if tblStats.ColAndIdxExistenceMap == nil {
 		return tblCnt
 	}
+	// Column metadata can be missing if a DDL event was missed or not yet processed.
+	// Fall back to row count only in that case.
 	colCnt := tblStats.ColAndIdxExistenceMap.ColNum()
 	if colCnt == 0 {
 		return tblCnt

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory_test.go
@@ -84,21 +84,6 @@ func TestCalculateChangePercentage(t *testing.T) {
 	}
 }
 
-func TestCalculateTableSize(t *testing.T) {
-	factory := priorityqueue.NewAnalysisJobFactory(nil, 0, 0)
-
-	tblStats := &statistics.Table{}
-	tblStats.RealtimeCount = 10
-	require.Equal(t, float64(10), factory.CalculateTableSize(tblStats))
-
-	tblStats.ColAndIdxExistenceMap = statistics.NewColAndIndexExistenceMapWithoutSize()
-	require.Equal(t, float64(10), factory.CalculateTableSize(tblStats))
-
-	tblStats.ColAndIdxExistenceMap.InsertCol(1, true)
-	tblStats.ColAndIdxExistenceMap.InsertCol(2, true)
-	require.Equal(t, float64(20), factory.CalculateTableSize(tblStats))
-}
-
 func TestGetTableLastAnalyzeDuration(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory_test.go
@@ -84,6 +84,21 @@ func TestCalculateChangePercentage(t *testing.T) {
 	}
 }
 
+func TestCalculateTableSize(t *testing.T) {
+	factory := priorityqueue.NewAnalysisJobFactory(nil, 0, 0)
+
+	tblStats := &statistics.Table{}
+	tblStats.RealtimeCount = 10
+	require.Equal(t, float64(10), factory.CalculateTableSize(tblStats))
+
+	tblStats.ColAndIdxExistenceMap = statistics.NewColAndIndexExistenceMapWithoutSize()
+	require.Equal(t, float64(10), factory.CalculateTableSize(tblStats))
+
+	tblStats.ColAndIdxExistenceMap.InsertCol(1, true)
+	tblStats.ColAndIdxExistenceMap.InsertCol(2, true)
+	require.Equal(t, float64(20), factory.CalculateTableSize(tblStats))
+}
+
 func TestGetTableLastAnalyzeDuration(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
@@ -34,7 +34,7 @@ go_test(
         "worker_test.go",
     ],
     flaky = True,
-    shard_count = 12,
+    shard_count = 13,
     deps = [
         ":refresher",
         "//pkg/parser/ast",

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
@@ -605,7 +605,7 @@ func insertFailedJobForPartitionWithStartTime(
 	)
 }
 
-func TestAutoAnalyzePanicsWhenExistenceMapEmptyInCache(t *testing.T) {
+func TestAutoAnalyzeNoPanicsWhenExistenceMapEmptyInCache(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
@@ -605,7 +605,7 @@ func insertFailedJobForPartitionWithStartTime(
 	)
 }
 
-func TestAutoAnalyzeNoPanicsWhenExistenceMapEmptyInCache(t *testing.T) {
+func TestAutoAnalyzeHandlesEmptyExistenceMapInCache(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -613,7 +613,7 @@ func TestAutoAnalyzeNoPanicsWhenExistenceMapEmptyInCache(t *testing.T) {
 	tk.MustExec("insert into t values (1,1),(2,2)")
 	h := dom.StatsHandle()
 	// Make sure the count and modify count are updated.
-	require.NoError(t, h.DumpStatsDeltaToKV(true))
+	tk.MustExec("flush stats_delta")
 
 	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63677

Problem Summary:
- Auto analyze could panic when `ColAndIdxExistenceMap` is nil/empty in `CalculateTableSize`.

### What changed and how does it work?
- Fallback to `RealtimeCount` when column map is nil/empty and add a regression unit test.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)

Test Details:
- `go test -run ^TestCalculateTableSize$ --tags=intest ./pkg/statistics/handle/autoanalyze/priorityqueue`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
