### PR TITLE
pkg/domain: close stats handle before closing advanced sys session pool

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -514,7 +514,6 @@ func (do *Domain) Close() {
 
 	do.sysSessionPool.Close()
 	do.dxfSessionPool.Close()
-	do.advancedSysSessionPool.Close()
 	variable.UnregisterStatistics(do.BindingHandle())
 	if do.onClose != nil {
 		do.onClose()
@@ -528,6 +527,8 @@ func (do *Domain) Close() {
 	if handle := do.statsHandle.Load(); handle != nil {
 		handle.Close()
 	}
+
+	do.advancedSysSessionPool.Close()
 
 	do.crossKSSessMgr.Close()
 

--- a/pkg/statistics/handle/handle.go
+++ b/pkg/statistics/handle/handle.go
@@ -16,7 +16,6 @@ package handle
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -310,7 +309,7 @@ func (h *Handle) isSystemTable(physicalTableID int64, tblInfo *model.TableInfo) 
 		})
 	})
 	if err != nil {
-		intest.Assert(strings.Contains(err.Error(), "session pool closed"), "unexpected error: %v, tableID %d, dbID %d", err, physicalTableID, dbID)
+		intest.Assert(err == nil, "unexpected error: %v, tableID %d, dbID %d", err, physicalTableID, dbID)
 		return false, err
 	}
 	if isSystemTable {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65071

Problem Summary:
- `TestTopSQLCPUProfile` could flake because `Domain.Close()` closed `advancedSysSessionPool` before `statsHandle`, so `Handle.isSystemTable()` could hit `session pool closed` and trip the internal `intest.Assert`.

### What changed and how does it work?
- Close `statsHandle` before closing `advancedSysSessionPool` in `Domain.Close()`, so `statsHandle` never runs with a closed session pool and the existing `intest.Assert` invariant can be preserved.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)

Test Details:
- `make failpoint-enable && (go test -run ^TestTopSQLCPUProfile$ -count=20 --tags=intest -timeout 30m ./pkg/server/tests/commontest; rc=$?; make failpoint-disable; exit $rc)`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
