### PR TITLE
*: stabilize integrationtest privilege/privileges

### DIFF
--- a/tests/integrationtest/r/privilege/privileges.result
+++ b/tests/integrationtest/r/privilege/privileges.result
@@ -248,27 +248,34 @@ GRANT DROP ON privilege__privileges.* TO  'tester'@'localhost';
 alter table pt exchange partition p0 with table nt;
 CREATE USER 'test_import_into'@'localhost';
 GRANT SELECT ON privilege__privileges.* TO 'test_import_into'@'localhost';
+flush privileges;
 CREATE TABLE IF NOT EXISTS t(a int);
 IMPORT INTO t FROM '/file.csv';
 Error 1142 (42000): UPDATE command denied to user 'test_import_into'@'localhost' for table 't'
 GRANT SELECT on *.* to 'test_import_into'@'localhost';
+flush privileges;
 IMPORT INTO t FROM '/file.csv';
 Error 1142 (42000): UPDATE command denied to user 'test_import_into'@'localhost' for table 't'
 GRANT UPDATE on *.* to 'test_import_into'@'localhost';
+flush privileges;
 IMPORT INTO t FROM '/file.csv';
 Error 1142 (42000): INSERT command denied to user 'test_import_into'@'localhost' for table 't'
 GRANT INSERT on *.* to 'test_import_into'@'localhost';
+flush privileges;
 IMPORT INTO t FROM '/file.csv';
 Error 1142 (42000): DELETE command denied to user 'test_import_into'@'localhost' for table 't'
 GRANT DELETE on *.* to 'test_import_into'@'localhost';
+flush privileges;
 IMPORT INTO t FROM '/file.csv';
 Error 1142 (42000): ALTER command denied to user 'test_import_into'@'localhost' for table 't'
 GRANT ALTER on *.* to 'test_import_into'@'localhost';
+flush privileges;
 IMPORT INTO t FROM '/file.csv';
 Error 1227 (42000): Access denied; you need (at least one of) the FILE privilege(s) for this operation
 DROP USER 'test_import_into'@'localhost';
 CREATE USER 'test_import_into'@'localhost';
 GRANT FILE on *.* to 'test_import_into'@'localhost';
+flush privileges;
 IMPORT INTO t FROM '/file.csv';
 Error 1142 (42000): SELECT command denied to user 'test_import_into'@'localhost' for table 't'
 drop table if exists t;

--- a/tests/integrationtest/t/privilege/privileges.test
+++ b/tests/integrationtest/t/privilege/privileges.test
@@ -354,6 +354,7 @@ connection default;
 # TestImportIntoPrivilegeNegativeCase
 CREATE USER 'test_import_into'@'localhost';
 GRANT SELECT ON privilege__privileges.* TO 'test_import_into'@'localhost';
+flush privileges;
 CREATE TABLE IF NOT EXISTS t(a int);
 connect (test_import_into,localhost,test_import_into,,privilege__privileges);
 connection test_import_into;
@@ -362,30 +363,35 @@ IMPORT INTO t FROM '/file.csv';
 
 connection default;
 GRANT SELECT on *.* to 'test_import_into'@'localhost';
+flush privileges;
 connection test_import_into;
 --error ErrTableaccessDenied
 IMPORT INTO t FROM '/file.csv';
 
 connection default;
 GRANT UPDATE on *.* to 'test_import_into'@'localhost';
+flush privileges;
 connection test_import_into;
 --error ErrTableaccessDenied
 IMPORT INTO t FROM '/file.csv';
 
 connection default;
 GRANT INSERT on *.* to 'test_import_into'@'localhost';
+flush privileges;
 connection test_import_into;
 --error ErrTableaccessDenied
 IMPORT INTO t FROM '/file.csv';
 
 connection default;
 GRANT DELETE on *.* to 'test_import_into'@'localhost';
+flush privileges;
 connection test_import_into;
 --error ErrTableaccessDenied
 IMPORT INTO t FROM '/file.csv';
 
 connection default;
 GRANT ALTER on *.* to 'test_import_into'@'localhost';
+flush privileges;
 connection test_import_into;
 --error ErrSpecificAccessDenied
 IMPORT INTO t FROM '/file.csv';
@@ -394,6 +400,7 @@ connection default;
 DROP USER 'test_import_into'@'localhost';
 CREATE USER 'test_import_into'@'localhost';
 GRANT FILE on *.* to 'test_import_into'@'localhost';
+flush privileges;
 connection test_import_into;
 --error ErrTableaccessDenied
 IMPORT INTO t FROM '/file.csv';
@@ -1076,4 +1083,3 @@ disconnect foo;
 connection default;
 DROP TABLE t_partition;
 DROP USER foo;
-


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60109

Problem Summary:
- Integration test case `privilege/privileges` was unstable due to privilege output mismatches.

### What changed and how does it work?
- Update the test case and expected result to match current privilege behavior deterministically.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)

Test Details:
- `cd tests/integrationtest && ./run-tests.sh -r privilege/privileges`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
