### PR TITLE
[DNM]Fix/ddl unregister lightning metrics release 8.5

### DIFF
--- a/pkg/ddl/backfilling_import_cloud.go
+++ b/pkg/ddl/backfilling_import_cloud.go
@@ -175,8 +175,14 @@ func (m *cloudImportExecutor) Cleanup(ctx context.Context) error {
 	logutil.Logger(ctx).Info("cloud import executor clean up subtask env")
 	if m.backendCtx != nil {
 		m.backendCtx.Close()
+		m.backendCtx = nil
 	}
-	m.backend.Close()
+	if m.backend != nil {
+		m.backend.Close()
+		m.backend = nil
+	}
+	metrics.UnregisterLightningCommonMetricsForDDL(m.job.ID, m.metric)
+	m.metric = nil
 	return nil
 }
 

--- a/pkg/ddl/ingest/testutil/testutil.go
+++ b/pkg/ddl/ingest/testutil/testutil.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl/ingest"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 )
@@ -56,6 +57,11 @@ func CheckIngestLeakageForTest(exitCode int) {
 			leakObj = "disk usage tracker"
 		} else if ingest.BackendCounterForTest.Load() != 0 {
 			leakObj = "backend context"
+		}
+		if len(leakObj) == 0 {
+			if registeredJob := metrics.GetRegisteredJob(); len(registeredJob) > 0 {
+				leakObj = "metrics"
+			}
 		}
 		if len(leakObj) > 0 {
 			fmt.Fprintf(os.Stderr, "add index leakage check failed: %s leak\n", leakObj)

--- a/pkg/ddl/metrics_leak_test.go
+++ b/pkg/ddl/metrics_leak_test.go
@@ -1,0 +1,31 @@
+package ddl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/meta/model"
+	tidbmetrics "github.com/pingcap/tidb/pkg/metrics"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLightningCommonMetricsUnregisteredOnCleanup(t *testing.T) {
+	for jobID, m := range tidbmetrics.GetRegisteredJob() {
+		tidbmetrics.UnregisterLightningCommonMetricsForDDL(jobID, m)
+	}
+	require.Empty(t, tidbmetrics.GetRegisteredJob())
+
+	jobID1 := int64(9000001)
+	r := &readIndexStepExecutor{job: &model.Job{ID: jobID1}}
+	r.metric = tidbmetrics.RegisterLightningCommonMetricsForDDL(jobID1)
+	require.Contains(t, tidbmetrics.GetRegisteredJob(), jobID1)
+	require.NoError(t, r.Cleanup(context.Background()))
+	require.NotContains(t, tidbmetrics.GetRegisteredJob(), jobID1)
+
+	jobID2 := int64(9000002)
+	c := &cloudImportExecutor{job: &model.Job{ID: jobID2}}
+	c.metric = tidbmetrics.RegisterLightningCommonMetricsForDDL(jobID2)
+	require.Contains(t, tidbmetrics.GetRegisteredJob(), jobID2)
+	require.NoError(t, c.Cleanup(context.Background()))
+	require.NotContains(t, tidbmetrics.GetRegisteredJob(), jobID2)
+}


### PR DESCRIPTION
Fixes leaked per-job Lightning common metrics in dist backfill step executors by unregistering on Cleanup, and adds a regression test.



<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
