### PR TITLE
feat(runaway): refactor record flushing with batch flusher abstraction

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -288,6 +288,11 @@ func RegisterMetrics() {
 	dxfmetric.Register(prometheus.DefaultRegisterer)
 
 	prometheus.MustRegister(RunawayCheckerCounter)
+	prometheus.MustRegister(RunawayFlusherCounter)
+	prometheus.MustRegister(RunawayFlusherAddCounter)
+	prometheus.MustRegister(RunawayFlusherBatchSizeHistogram)
+	prometheus.MustRegister(RunawayFlusherDurationHistogram)
+	prometheus.MustRegister(RunawayFlusherIntervalHistogram)
 	prometheus.MustRegister(GlobalSortWriteToCloudStorageDuration)
 	prometheus.MustRegister(GlobalSortWriteToCloudStorageRate)
 	prometheus.MustRegister(GlobalSortReadFromCloudStorageDuration)

--- a/pkg/metrics/resource_group.go
+++ b/pkg/metrics/resource_group.go
@@ -23,6 +23,12 @@ import (
 // Query duration by query is QueryDurationHistogram in `server.go`.
 var (
 	RunawayCheckerCounter *prometheus.CounterVec
+
+	RunawayFlusherCounter            *prometheus.CounterVec
+	RunawayFlusherAddCounter         *prometheus.CounterVec
+	RunawayFlusherBatchSizeHistogram *prometheus.HistogramVec
+	RunawayFlusherDurationHistogram  *prometheus.HistogramVec
+	RunawayFlusherIntervalHistogram  *prometheus.HistogramVec
 )
 
 // InitResourceGroupMetrics initializes resource group metrics.
@@ -34,4 +40,47 @@ func InitResourceGroupMetrics() {
 			Name:      "query_runaway_check",
 			Help:      "Counter of query triggering runaway check.",
 		}, []string{LblResourceGroup, LblType, LblAction})
+
+	RunawayFlusherCounter = metricscommon.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "runaway_flusher_total",
+			Help:      "Counter of runaway flusher operations.",
+		}, []string{LblName, LblResult})
+
+	RunawayFlusherAddCounter = metricscommon.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "runaway_flusher_add_total",
+			Help:      "Counter of records added to runaway flusher.",
+		}, []string{LblName})
+
+	RunawayFlusherBatchSizeHistogram = metricscommon.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "runaway_flusher_batch_size",
+			Help:      "Batch size of runaway flusher operations.",
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1, 2, 4, ..., 512
+		}, []string{LblName})
+
+	RunawayFlusherDurationHistogram = metricscommon.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "runaway_flusher_duration_seconds",
+			Help:      "Duration of runaway flusher operations in seconds.",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15), // 1ms ~ 16s
+		}, []string{LblName})
+
+	RunawayFlusherIntervalHistogram = metricscommon.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "runaway_flusher_interval_seconds",
+			Help:      "Interval between runaway flusher operations in seconds.",
+			Buckets:   prometheus.ExponentialBuckets(0.1, 2, 12), // 0.1s ~ 200s
+		}, []string{LblName})
 }

--- a/pkg/resourcegroup/runaway/BUILD.bazel
+++ b/pkg/resourcegroup/runaway/BUILD.bazel
@@ -52,9 +52,11 @@ go_test(
     ],
     embed = [":runaway"],
     flaky = True,
-    shard_count = 7,
+    shard_count = 6,
     deps = [
+        "//pkg/metrics",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//util",
     ],
 )

--- a/pkg/resourcegroup/runaway/BUILD.bazel
+++ b/pkg/resourcegroup/runaway/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "runaway",
     srcs = [
         "checker.go",
+        "flusher.go",
         "manager.go",
         "record.go",
         "syncer.go",
@@ -46,11 +47,12 @@ go_test(
     timeout = "short",
     srcs = [
         "checker_test.go",
+        "flusher_test.go",
         "record_test.go",
     ],
     embed = [":runaway"],
     flaky = True,
-    shard_count = 2,
+    shard_count = 7,
     deps = [
         "@com_github_stretchr_testify//assert",
         "@com_github_tikv_client_go_v2//util",

--- a/pkg/resourcegroup/runaway/flusher.go
+++ b/pkg/resourcegroup/runaway/flusher.go
@@ -85,6 +85,9 @@ func (f *batchFlusher[K, V]) add(key K, value V) {
 }
 
 func (f *batchFlusher[K, V]) flush() {
+	failpoint.Inject("skipFlush", func() {
+		failpoint.Return()
+	})
 	if len(f.buffer) == 0 {
 		return
 	}

--- a/pkg/resourcegroup/runaway/flusher.go
+++ b/pkg/resourcegroup/runaway/flusher.go
@@ -1,0 +1,93 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runaway
+
+import (
+	"time"
+
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"go.uber.org/zap"
+)
+
+type batchFlusher[K comparable, V any] struct {
+	name      string
+	buffer    map[K]V
+	timer     *time.Timer
+	interval  time.Duration
+	threshold int
+	fired     bool
+	mergeFn   func(map[K]V, K, V)
+	flushFn   func(map[K]V)
+}
+
+func newBatchFlusher[K comparable, V any](
+	name string,
+	interval time.Duration,
+	threshold int,
+	mergeFn func(map[K]V, K, V),
+	genSQL func(map[K]V) (string, []any),
+	pool util.SessionPool,
+) *batchFlusher[K, V] {
+	f := &batchFlusher[K, V]{
+		name:      name,
+		buffer:    make(map[K]V, threshold),
+		timer:     time.NewTimer(interval),
+		interval:  interval,
+		threshold: threshold,
+		mergeFn:   mergeFn,
+	}
+	f.flushFn = func(buffer map[K]V) {
+		sql, params := genSQL(buffer)
+		if _, err := ExecRCRestrictedSQL(pool, sql, params); err != nil {
+			logutil.BgLogger().Error("batch flush failed",
+				zap.String("name", name),
+				zap.Error(err),
+				zap.Int("count", len(buffer)))
+		}
+	}
+	return f
+}
+
+func (f *batchFlusher[K, V]) timerChan() <-chan time.Time {
+	return f.timer.C
+}
+
+func (f *batchFlusher[K, V]) onTimer() {
+	f.flush()
+	f.fired = true
+}
+
+func (f *batchFlusher[K, V]) add(key K, value V) {
+	f.mergeFn(f.buffer, key, value)
+	failpoint.Inject("FastRunawayGC", func() {
+		f.flush()
+	})
+	if len(f.buffer) >= f.threshold {
+		f.flush()
+	} else if f.fired {
+		f.fired = false
+		f.timer.Reset(f.interval)
+	}
+}
+
+func (f *batchFlusher[K, V]) flush() {
+	if len(f.buffer) == 0 {
+		return
+	}
+	f.flushFn(f.buffer)
+	f.buffer = make(map[K]V, f.threshold)
+}

--- a/pkg/resourcegroup/runaway/flusher_test.go
+++ b/pkg/resourcegroup/runaway/flusher_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runaway
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestBatchFlusher[K comparable, V any](
+	threshold int,
+	mergeFn func(map[K]V, K, V),
+	flushFn func(map[K]V),
+) *batchFlusher[K, V] {
+	return &batchFlusher[K, V]{
+		name:      "test",
+		buffer:    make(map[K]V, threshold),
+		timer:     time.NewTimer(time.Hour),
+		interval:  time.Hour,
+		threshold: threshold,
+		mergeFn:   mergeFn,
+		flushFn:   flushFn,
+	}
+}
+
+func TestBatchFlusherAdd(t *testing.T) {
+	var flushCount atomic.Int32
+	flusher := newTestBatchFlusher(
+		3,
+		func(m map[string]int, k string, v int) { m[k] = v },
+		func(m map[string]int) { flushCount.Add(1) },
+	)
+
+	flusher.add("a", 1)
+	flusher.add("b", 2)
+	assert.Len(t, flusher.buffer, 2)
+	assert.Equal(t, int32(0), flushCount.Load())
+
+	flusher.add("c", 3)
+	assert.Len(t, flusher.buffer, 0)
+	assert.Equal(t, int32(1), flushCount.Load())
+}
+
+func TestBatchFlusherMergeFn(t *testing.T) {
+	var lastBuffer map[string]*Record
+	flusher := newTestBatchFlusher(
+		10,
+		func(m map[string]*Record, k string, v *Record) {
+			if existing, ok := m[k]; ok {
+				existing.Repeats++
+			} else {
+				m[k] = v
+			}
+		},
+		func(m map[string]*Record) { lastBuffer = m },
+	)
+
+	flusher.add("key1", &Record{SQLDigest: "d1", Repeats: 1})
+	flusher.add("key1", &Record{SQLDigest: "d1", Repeats: 1})
+	flusher.add("key1", &Record{SQLDigest: "d1", Repeats: 1})
+	flusher.add("key2", &Record{SQLDigest: "d2", Repeats: 1})
+
+	assert.Len(t, flusher.buffer, 2)
+	assert.Equal(t, 3, flusher.buffer["key1"].Repeats)
+	assert.Equal(t, 1, flusher.buffer["key2"].Repeats)
+
+	flusher.flush()
+	assert.Len(t, flusher.buffer, 0)
+	assert.Equal(t, 3, lastBuffer["key1"].Repeats)
+}
+
+func TestBatchFlusherOnTimer(t *testing.T) {
+	var flushCount atomic.Int32
+	flusher := newTestBatchFlusher(
+		100,
+		func(m map[string]int, k string, v int) { m[k] = v },
+		func(m map[string]int) { flushCount.Add(1) },
+	)
+
+	flusher.add("a", 1)
+	assert.Equal(t, int32(0), flushCount.Load())
+	assert.False(t, flusher.fired)
+
+	flusher.onTimer()
+	assert.Equal(t, int32(1), flushCount.Load())
+	assert.True(t, flusher.fired)
+	assert.Len(t, flusher.buffer, 0)
+}
+
+func TestBatchFlusherTimerReset(t *testing.T) {
+	flusher := newTestBatchFlusher(
+		100,
+		func(m map[string]int, k string, v int) { m[k] = v },
+		func(m map[string]int) {},
+	)
+
+	flusher.onTimer()
+	assert.True(t, flusher.fired)
+
+	flusher.add("a", 1)
+	assert.False(t, flusher.fired)
+}
+
+func TestBatchFlusherFlushEmpty(t *testing.T) {
+	var flushCount atomic.Int32
+	flusher := newTestBatchFlusher(
+		10,
+		func(m map[string]int, k string, v int) { m[k] = v },
+		func(m map[string]int) { flushCount.Add(1) },
+	)
+
+	flusher.flush()
+	assert.Equal(t, int32(0), flushCount.Load())
+
+	flusher.add("a", 1)
+	flusher.flush()
+	assert.Equal(t, int32(1), flushCount.Load())
+
+	flusher.flush()
+	assert.Equal(t, int32(1), flushCount.Load())
+}

--- a/pkg/resourcegroup/runaway/flusher_test.go
+++ b/pkg/resourcegroup/runaway/flusher_test.go
@@ -25,7 +25,7 @@ import (
 func newTestBatchFlusher[K comparable, V any](
 	threshold int,
 	mergeFn func(map[K]V, K, V),
-	flushFn func(map[K]V),
+	flushFn func(map[K]V) error,
 ) *batchFlusher[K, V] {
 	return &batchFlusher[K, V]{
 		name:      "test",
@@ -45,7 +45,7 @@ func TestBatchFlusherAdd(t *testing.T) {
 	flusher := newTestBatchFlusher(
 		3,
 		func(m map[string]int, k string, v int) { m[k] = v },
-		func(m map[string]int) { flushCount.Add(1) },
+		func(m map[string]int) error { flushCount.Add(1); return nil },
 	)
 	re.Empty(flusher.buffer)
 
@@ -79,7 +79,7 @@ func TestBatchFlusherMergeFn(t *testing.T) {
 				m[k] = v
 			}
 		},
-		func(m map[string]*Record) { lastBuffer = m },
+		func(m map[string]*Record) error { lastBuffer = m; return nil },
 	)
 
 	flusher.add("key1", &Record{SQLDigest: "d1", Repeats: 1})
@@ -103,7 +103,7 @@ func TestBatchFlusherFlush(t *testing.T) {
 	flusher := newTestBatchFlusher(
 		100,
 		func(m map[string]int, k string, v int) { m[k] = v },
-		func(m map[string]int) { flushCount.Add(1) },
+		func(m map[string]int) error { flushCount.Add(1); return nil },
 	)
 	re.Empty(flusher.buffer)
 
@@ -130,7 +130,7 @@ func TestBatchFlusherFlushEmpty(t *testing.T) {
 	flusher := newTestBatchFlusher(
 		10,
 		func(m map[string]int, k string, v int) { m[k] = v },
-		func(m map[string]int) { flushCount.Add(1) },
+		func(m map[string]int) error { flushCount.Add(1); return nil },
 	)
 
 	flusher.flush()

--- a/pkg/resourcegroup/runaway/manager.go
+++ b/pkg/resourcegroup/runaway/manager.go
@@ -208,7 +208,7 @@ func (rm *Manager) RunawayRecordFlushLoop() {
 			logutil.BgLogger().Info("runaway record flush loop exit")
 			return
 		case <-runawayRecordFlusher.timerChan(): // flush runaway records periodically
-			runawayRecordFlusher.onTimer()
+			runawayRecordFlusher.flush()
 		case r := <-recordCh: // add runaway records to the flusher
 			key := recordKey{
 				ResourceGroupName: r.ResourceGroupName,
@@ -220,11 +220,11 @@ func (rm *Manager) RunawayRecordFlushLoop() {
 		case <-runawayRecordGCTicker.C: // delete expired runaway records periodically
 			go rm.deleteExpiredRows(runawayRecordExpiredDuration)
 		case <-quarantineRecordFlusher.timerChan(): // flush quarantine records periodically
-			quarantineRecordFlusher.onTimer()
+			quarantineRecordFlusher.flush()
 		case r := <-quarantineRecordCh: // add quarantine records to the flusher
 			quarantineRecordFlusher.add(r.getRecordKey(), r)
 		case <-staleQuarantineFlusher.timerChan(): // flush stale quarantine records periodically
-			staleQuarantineFlusher.onTimer()
+			staleQuarantineFlusher.flush()
 		case r := <-staleQuarantineRecordCh: // add stale quarantine records to the flusher
 			if r.ID == 0 {
 				continue

--- a/pkg/resourcegroup/runaway/record.go
+++ b/pkg/resourcegroup/runaway/record.go
@@ -197,7 +197,7 @@ func (r *QuarantineRecord) genDeletionStmt() (string, []any) {
 func genBatchInsertWatchStmt(records map[string]*QuarantineRecord) (string, []any) {
 	var builder strings.Builder
 	params := make([]any, 0, len(records)*9)
-	writeInsert(&builder, watchTableName)
+	writeInsert(&builder, getRunawayWatchTableName())
 	firstRecord := true
 	for _, r := range records {
 		if !firstRecord {
@@ -226,7 +226,7 @@ func genBatchDeleteWatchByIDStmt(records map[int64]*QuarantineRecord) (string, [
 	var builder strings.Builder
 	params := make([]any, 0, len(records))
 	builder.WriteString("delete from ")
-	builder.WriteString(watchTableName)
+	builder.WriteString(getRunawayWatchTableName())
 	builder.WriteString(" where id in (")
 	first := true
 	for id := range records {

--- a/pkg/resourcegroup/runaway/record_test.go
+++ b/pkg/resourcegroup/runaway/record_test.go
@@ -36,13 +36,6 @@ func TestRecordKey(t *testing.T) {
 	key3 := recordKey{
 		ResourceGroupName: "group2",
 	}
-	// Test Hash method
-	hash1 := key1.Hash()
-	hash2 := key2.Hash()
-	hash3 := key3.Hash()
-
-	assert.Equal(t, hash1, hash2, "Hashes should be equal for identical keys")
-	assert.NotEqual(t, hash1, hash3, "Hashes should not be equal for different keys")
 
 	// Test MapKey method
 	recordMap := make(map[recordKey]*Record)

--- a/pkg/resourcegroup/tests/BUILD.bazel
+++ b/pkg/resourcegroup/tests/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     srcs = ["resource_group_test.go"],
     flaky = True,
     race = "on",
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/ddl/resourcegroup",
         "//pkg/domain",
@@ -15,6 +15,7 @@ go_test(
         "//pkg/meta/model",
         "//pkg/parser/ast",
         "//pkg/parser/auth",
+        "//pkg/resourcegroup/runaway",
         "//pkg/server",
         "//pkg/sessionctx",
         "//pkg/testkit",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65746.

Problem Summary:

Refactor record flushing with batch flusher abstraction.

### What changed and how does it work?

- Reworked `RunawayRecordFlushLoop` to use unified `batchFlusher` utility for runaway, quarantine, and stale quarantine records, replacing ad-hoc map and timer handling.
- Added batch SQL generators:
  - `genBatchInsertWatchStmt` for bulk inserting quarantine records.
  - `genBatchDeleteWatchByIDStmt` for bulk deleting stale quarantine records.

This refactor improves flushing performance, reduces SQL overhead, and standardizes record processing for both runaway and quarantine flows.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
