### PR TITLE
planner: eliminate outer join on nullable unique keys under EQ

### DIFF
--- a/pkg/planner/core/casetest/plan_test.go
+++ b/pkg/planner/core/casetest/plan_test.go
@@ -419,13 +419,13 @@ func TestOuterJoinElimination(t *testing.T) {
 		// nullable unique index is not allowed to trigger the outer join elinimation.
 		tk.MustHavePlan("select count(*) from t1 left join t2 on t1.a = t2.a", "Join")
 		tk.MustHavePlan("select count(*) from t1 left join t2_k on t1.a = t2_k.a", "Join")
-		tk.MustHavePlan("select count(*) from t1 left join t2_uk on t1.a = t2_uk.a", "Join")
+		tk.MustNotHavePlan("select count(*) from t1 left join t2_uk on t1.a = t2_uk.a", "Join")
 		tk.MustNotHavePlan("select count(*) from t1 left join t2_nnuk on t1.a = t2_nnuk.a", "Join")
 		tk.MustNotHavePlan("select count(*) from t1 left join t2_pk on t1.a = t2_pk.a", "Join")
 
 		tk.MustHavePlan("select count(*) from t1 left join t2 on t1.a = t2.a group by t1.a", "Join")
 		tk.MustHavePlan("select count(*) from t1 left join t2_k on t1.a = t2_k.a group by t1.a", "Join")
-		tk.MustHavePlan("select count(*) from t1 left join t2_uk on t1.a = t2_uk.a group by t1.a", "Join")
+		tk.MustNotHavePlan("select count(*) from t1 left join t2_uk on t1.a = t2_uk.a group by t1.a", "Join")
 		tk.MustNotHavePlan("select count(*) from t1 left join t2_nnuk on t1.a = t2_nnuk.a group by t1.a", "Join")
 		tk.MustNotHavePlan("select count(*) from t1 left join t2_pk on t1.a = t2_pk.a group by t1.a", "Join")
 
@@ -444,9 +444,12 @@ func TestOuterJoinElimination(t *testing.T) {
 		// test constant columns with distinct
 		tk.MustHavePlan("select 1 from t1 left join t2 on t1.a = t2.a", "Join")
 		tk.MustHavePlan("select 1 from t1 left join t2_k t2 on t1.a = t2.a", "Join")
-		tk.MustHavePlan("select 1 from t1 left join t2_uk t2 on t1.a = t2.a", "Join")
+		tk.MustNotHavePlan("select 1 from t1 left join t2_uk t2 on t1.a = t2.a", "Join")
 		tk.MustNotHavePlan("select 1 from t1 left join t2_nnuk t2 on t1.a = t2.a", "Join")
 		tk.MustNotHavePlan("select 1 from t1 left join t2_pk t2 on t1.a = t2.a", "Join")
+		tk.MustHavePlan("select count(*) from t1 left join t2_uk t2 on t1.a <=> t2.a", "Join")
+		tk.MustNotHavePlan("select count(*) from t1 left join t2_nnuk t2 on t1.a <=> t2.a", "Join")
+		tk.MustNotHavePlan("select count(*) from t1 left join t2_pk t2 on t1.a <=> t2.a", "Join")
 		// test subqueries
 		tk.MustHavePlan("select 1 from (select distinct a from t1) t1 left join t2 on t1.a = t2.a", "Join")
 		tk.MustNotHavePlan("select distinct 1 from (select distinct a from t1) t1 left join t2 on t1.a = t2.a", "Join")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65165

Problem Summary:

### What changed and how does it work?
Outer join elimination relies on the inner side join keys guaranteeing at most one match. Previously we only considered Schema.PKOrUK and unique secondary indexes, which effectively excluded nullable unique keys (Schema.NullableUK).
 
This missed the safe case where join keys use normal equality '=': when the inner unique key is nullable, rows with NULL do not match under '=' so the join still cannot introduce extra matches and the outer join can be removed when the parent doesn't reference inner columns. 

This change extends the eliminator to also consider Schema.NullableUK, but only when the nullable key columns are not compared using NullEQ (<=>). For '<=>', NULL values can match NULL and would allow multiple matches on a nullable unique key, so we keep the join. 

Also applies the same logic to cascades outer-join elimination rules, and updates planner tests to cover '=' vs '<=>' behaviors.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a bug where the planner fails to eliminate outer join on nullable unique keys under EQ.
```
