### PR TITLE
cmd: fix tidb can not start inside wsl2

### DIFF
--- a/pkg/util/cgroup/cgroup_cpu_linux.go
+++ b/pkg/util/cgroup/cgroup_cpu_linux.go
@@ -98,3 +98,16 @@ func inContainer(path string) bool {
 
 	return false
 }
+
+func InWSL2() bool {
+	v, err := os.ReadFile(procPathMountInfo)
+	if err != nil {
+		return false
+	}
+	for line := range strings.SplitSeq(string(v), "\n") {
+		if strings.Contains(line, "microsoft-standard-WSL2") {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/memory/meminfo.go
+++ b/pkg/util/memory/meminfo.go
@@ -172,10 +172,10 @@ func init() {
 
 // InitMemoryHook initializes the memory hook.
 // It is to solve the problem that tidb cannot read cgroup in the systemd.
-// so if we are not in the container, we compare the cgroup memory limit and the physical memory,
+// so if we are not in the container/wsl, we compare the cgroup memory limit and the physical memory,
 // the cgroup memory limit is smaller, we use the cgroup memory hook.
 func InitMemoryHook() error {
-	if cgroup.InContainer() {
+	if cgroup.InContainer() || cgroup.InWSL2() {
 		logutil.BgLogger().Info("use cgroup memory hook because TiDB is in the container")
 		return nil
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65852

Problem Summary:

### What changed and how does it work?

The current memory check may block tidb run inside wsl2.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
