### PR TITLE
.gitignore: add back the bazel gitignore items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,15 @@ genkeyword
 vendor
 
 # Bazel
+# skywalking-eyes 0.4 cannot handle the git glob syntax correctly. As a temporary workaround,
+# we explicitly list the bazel-related files and directories to be ignored.
+# TODO: test and consider upgrading skywalking-eyes in the future.
 /_bazel
 bazel-*
+bazel-bin
+bazel-out
+bazel-testlogs
+bazel-tidb
 MODULE.bazel.lock
 
 # Testing / coverage / reports


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65858

Problem Summary:

#65845 removed some entries from `.gitignore` and replace them with `glob`, which may break the CI :facepalm: . Maybe a bug of skywalking-eyes?

### What changed and how does it work?

Add them back!

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
