### PR TITLE
server: check connection is available in SQLKiller (#60685)

### DIFF
--- a/pkg/server/internal/util/buffered_read_conn.go
+++ b/pkg/server/internal/util/buffered_read_conn.go
@@ -16,7 +16,10 @@ package util
 
 import (
 	"bufio"
+	"io"
 	"net"
+	"sync"
+	"time"
 )
 
 // DefaultReaderSize is the default size of bufio.Reader.
@@ -26,11 +29,15 @@ const DefaultReaderSize = 16 * 1024
 type BufferedReadConn struct {
 	net.Conn
 	rb *bufio.Reader
+	// `mu` is for `IsAlive()` function.
+	// We use this to ensure that `SetReadDeadline` is not called concurrently.
+	mu *sync.Mutex
 }
 
 // NewBufferedReadConn creates a BufferedReadConn.
 func NewBufferedReadConn(conn net.Conn) *BufferedReadConn {
 	return &BufferedReadConn{
+		mu:   &sync.Mutex{},
 		Conn: conn,
 		rb:   bufio.NewReaderSize(conn, DefaultReaderSize),
 	}
@@ -39,4 +46,39 @@ func NewBufferedReadConn(conn net.Conn) *BufferedReadConn {
 // Read reads data from the connection.
 func (conn BufferedReadConn) Read(b []byte) (n int, err error) {
 	return conn.rb.Read(b)
+}
+
+// Peek peeks from the connection.
+func (conn BufferedReadConn) Peek(n int) ([]byte, error) {
+	return conn.rb.Peek(n)
+}
+
+// IsAlive detects the connection is alive or not.
+// return value < 0, means unknow
+// return value = 0, means not alive
+// return value = 1, means still alive
+func (conn BufferedReadConn) IsAlive() int {
+	if conn.mu.TryLock() {
+		defer conn.mu.Unlock()
+		err := conn.SetReadDeadline(time.Now().Add(30 * time.Microsecond))
+		if err != nil {
+			return -1
+		}
+		// nolint:errcheck
+		defer conn.SetReadDeadline(time.Time{})
+		// At the TCP level, a successful `Peek` operation doesn't guarantee
+		// the connection remains active. However, in the MySQL protocol,
+		// clients shouldn't send new data while the server is processing SQL.
+		// Therefore, we can safely assume `Peek` won't intercept any data
+		// during this period. Even if `Peek` does capture data, it only means
+		// the liveness check might be inaccurate - this won't impact the
+		// actual connection state or its operations.
+		_, err = conn.Peek(1)
+		if err == io.EOF {
+			return 0
+		} else if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			return 1
+		}
+	}
+	return -1
 }

--- a/pkg/util/deeptest/statictesthelper.go
+++ b/pkg/util/deeptest/statictesthelper.go
@@ -142,7 +142,7 @@ func (h *staticTestHelper) assertDeepClonedEqual(t require.TestingT, valA, valB 
 		for i := range valA.NumField() {
 			h.assertDeepClonedEqual(t, valA.Field(i), valB.Field(i), path+"."+valA.Type().Field(i).Name)
 		}
-	case reflect.Ptr:
+	case reflect.Ptr, reflect.UnsafePointer:
 		if valA.IsNil() && valB.IsNil() {
 			return
 		}

--- a/pkg/util/sqlkiller/BUILD.bazel
+++ b/pkg/util/sqlkiller/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/dbterror/exeerrors",
+        "//pkg/util/intest",
         "//pkg/util/logutil",
         "@com_github_pingcap_failpoint//:failpoint",
         "@org_uber_go_zap//:zap",


### PR DESCRIPTION
This is a cherry-pick of #60685, and the conflicts are resolved by:

  - `pkg/server/conn_stmt.go`: kept the new SQLKiller connection‑alive hook (`IsConnectionAlive.Store(&fn)` with defer reset) inserted before executing the prepared statement, so the checker uses `bufReadConn.IsAlive()` during plan‑cache prepared statement execution.
  - `pkg/server/tests/commontest/tidb_test.go`: preserved the existing audit plugin tests (`TestAuditPluginInfoForStarting`, `TestAuditPluginRetrying`) from the release branch and appended the new `TestIssue57531` test from the cherry‑picked commit, so both sets of tests remain.

-------------------------------------------------------
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close pingcap/tidb#57531

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- None

Documentation

- None

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
  - Fix the issue that TiDB can't close connection immediately after killing client process.
```
