### PR TITLE
planner: support `flush stats_delta cluster`

### DIFF
--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -158,7 +158,7 @@ func (e *SimpleExec) Next(ctx context.Context, _ *chunk.Chunk) (err error) {
 	case *ast.UseStmt:
 		err = e.executeUse(x)
 	case *ast.FlushStmt:
-		err = e.executeFlush(x)
+		err = e.executeFlush(ctx, x)
 	case *ast.AlterInstanceStmt:
 		err = e.executeAlterInstance(x)
 	case *ast.BeginStmt:
@@ -2913,7 +2913,7 @@ func broadcast(ctx context.Context, sctx sessionctx.Context, sql string) error {
 	return nil
 }
 
-func (e *SimpleExec) executeFlush(s *ast.FlushStmt) error {
+func (e *SimpleExec) executeFlush(ctx context.Context, s *ast.FlushStmt) error {
 	switch s.Tp {
 	case ast.FlushTables:
 		if s.ReadLock {
@@ -2933,10 +2933,31 @@ func (e *SimpleExec) executeFlush(s *ast.FlushStmt) error {
 	case ast.FlushClientErrorsSummary:
 		errno.FlushStats()
 	case ast.FlushStatsDelta:
-		if s.IsCluster {
-			return errors.New("FLUSH STATS_DELTA CLUSTER is not supported yet")
-		}
 		h := domain.GetDomain(e.Ctx()).StatsHandle()
+		if e.IsFromRemote {
+			err := h.DumpStatsDeltaToKV(true)
+			if err != nil {
+				statslogutil.StatsErrVerboseLogger().Error("Failed to dump stats delta to KV from remote", zap.Error(err))
+			} else {
+				statslogutil.StatsLogger().Info("Successfully dumped stats delta to KV from remote")
+			}
+			return err
+		}
+		if s.IsCluster {
+			var sb strings.Builder
+			restoreCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
+			if err := s.Restore(restoreCtx); err != nil {
+				statslogutil.StatsErrVerboseLogger().Error("Failed to format flush stats delta statement", zap.Error(err))
+				return err
+			}
+			sql := sb.String()
+			if err := broadcast(ctx, e.Ctx(), sql); err != nil {
+				statslogutil.StatsErrVerboseLogger().Error("Failed to broadcast flush stats delta command", zap.String("sql", sql), zap.Error(err))
+				return err
+			}
+			logutil.BgLogger().Info("Successfully broadcast query", zap.String("sql", sql))
+			return nil
+		}
 		return h.DumpStatsDeltaToKV(true)
 	}
 	return nil

--- a/pkg/executor/simple_test.go
+++ b/pkg/executor/simple_test.go
@@ -439,6 +439,4 @@ func TestFlushStatsDelta(t *testing.T) {
 	modifyCnt, err = strconv.ParseInt(rows[0][0].(string), 10, 64)
 	require.NoError(t, err)
 	require.Equal(t, int64(7), modifyCnt, "modify_count should be 7 after inserting 2 more rows and flushing")
-
-	tk.MustGetErrMsg("flush stats_delta cluster", "FLUSH STATS_DELTA CLUSTER is not supported yet")
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65668

Problem Summary: planner: support `flush stats_delta cluster`

### What changed and how does it work?

It's hard to write a UT to test the cluster-level flush statement, I tested it locally, it can work well:
<img width="3334" height="550" alt="image" src="https://github.com/user-attachments/assets/2c2f05a1-aa7d-48eb-aef8-e03fb2fa2261" />


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
