### PR TITLE
planner: Remove an unused return value from cardinality.Selectivity.

### DIFF
--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -55,12 +55,11 @@ func Selectivity(
 	filledPaths []*planutil.AccessPath,
 ) (
 	result float64,
-	retStatsNodes []*StatsNode,
 	err error,
 ) {
 	// If the table's count is zero or conditions are empty, we should return 100% selectivity.
 	if coll.RealtimeCount == 0 || len(exprs) == 0 {
-		return 1, nil, nil
+		return 1, nil
 	}
 	ret := 1.0
 	sc := ctx.GetSessionVars().StmtCtx
@@ -70,7 +69,7 @@ func Selectivity(
 	if len(exprs) > 63 || (coll.ColNum() == 0 && coll.IdxNum() == 0) {
 		ret = pseudoSelectivity(ctx, coll, exprs)
 		ctx.GetSessionVars().RecordRelevantOptVar(vardef.TiDBOptSelectivityFactor)
-		return ret, nil, nil
+		return ret, nil
 	}
 
 	var nodes []*StatsNode
@@ -115,7 +114,7 @@ func Selectivity(
 			maskCovered, ranges, _, _, err :=
 				getMaskAndRanges(ctx, remainedExprs, ranger.ColumnRangeType, nil, nil, col)
 			if err != nil {
-				return 0, nil, errors.Trace(err)
+				return 0, errors.Trace(err)
 			}
 			nodes = append(nodes, &StatsNode{Tp: ColType, ID: id, mask: maskCovered, Ranges: ranges, numCols: 1})
 			var cnt float64
@@ -124,7 +123,7 @@ func Selectivity(
 				nodes[len(nodes)-1].Tp = PkType
 				cntEst, err = GetRowCountByColumnRanges(ctx, coll, id, ranges, true)
 				if err != nil {
-					return 0, nil, errors.Trace(err)
+					return 0, errors.Trace(err)
 				}
 				cnt = cntEst.Est
 				nodes[len(nodes)-1].Selectivity = cnt / float64(coll.RealtimeCount)
@@ -132,7 +131,7 @@ func Selectivity(
 			}
 			cntEst, err = GetRowCountByColumnRanges(ctx, coll, id, ranges, false)
 			if err != nil {
-				return 0, nil, errors.Trace(err)
+				return 0, errors.Trace(err)
 			}
 			cnt = cntEst.Est
 			nodes[len(nodes)-1].Selectivity = cnt / float64(coll.RealtimeCount)
@@ -188,11 +187,11 @@ func Selectivity(
 			maskCovered, ranges, partCover, minAccessCondsForDNFCond, err :=
 				getMaskAndRanges(ctx, remainedExprs, ranger.IndexRangeType, lengths, id2Paths[idxStats.ID], idxCols...)
 			if err != nil {
-				return 0, nil, errors.Trace(err)
+				return 0, errors.Trace(err)
 			}
 			countResult, err := GetRowCountByIndexRanges(ctx, coll, id, ranges, nil)
 			if err != nil {
-				return 0, nil, errors.Trace(err)
+				return 0, errors.Trace(err)
 			}
 			countResult.DivideAll(float64(coll.RealtimeCount))
 			selectivity, minSelectivity, maxSelectivity := countResult.Est, countResult.MinEst, countResult.MaxEst
@@ -323,7 +322,7 @@ OUTER:
 				cnfItems = append(cnfItems, cond)
 			}
 
-			curSelectivity, _, err := Selectivity(ctx, coll, cnfItems, nil)
+			curSelectivity, err := Selectivity(ctx, coll, cnfItems, nil)
 			if err != nil {
 				logutil.BgLogger().Debug("something wrong happened, use the default selectivity", zap.Error(err))
 				curSelectivity = ctx.GetSessionVars().SelectivityFactor
@@ -388,7 +387,7 @@ OUTER:
 
 	// Don't allow the result to be less than 1 row
 	ret = max(ret, 1.0/float64(coll.RealtimeCount))
-	return ret, nodes, nil
+	return ret, nil
 }
 
 // CalcTotalSelectivityForMVIdxPath calculates the total selectivity for the given partial paths of an MV index merge path.

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -123,7 +123,7 @@ func BenchmarkSelectivity(b *testing.B) {
 	b.Run("Selectivity", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, _, err := cardinality.Selectivity(sctx.GetPlanCtx(), &statsTbl.HistColl, p.(base.LogicalPlan).Children()[0].(*logicalop.LogicalSelection).Conditions, nil)
+			_, err := cardinality.Selectivity(sctx.GetPlanCtx(), &statsTbl.HistColl, p.(base.LogicalPlan).Children()[0].(*logicalop.LogicalSelection).Conditions, nil)
 			require.NoError(b, err)
 		}
 		b.ReportAllocs()
@@ -849,13 +849,13 @@ func TestSelectivity(t *testing.T) {
 
 		histColl := statsTbl.GenerateHistCollFromColumnInfo(ds.TableInfo, ds.Schema().Columns)
 
-		ratio, _, err := cardinality.Selectivity(sctx.GetPlanCtx(), histColl, sel.Conditions, nil)
+		ratio, err := cardinality.Selectivity(sctx.GetPlanCtx(), histColl, sel.Conditions, nil)
 		require.NoErrorf(t, err, "for %s", tt.exprs)
 		require.Truef(t, math.Abs(ratio-tt.selectivity) < eps, "for %s, needed: %v, got: %v", tt.exprs, tt.selectivity, ratio)
 
 		histColl.RealtimeCount *= 10
 		histColl.ModifyCount = histColl.RealtimeCount * 9
-		ratio, _, err = cardinality.Selectivity(sctx.GetPlanCtx(), histColl, sel.Conditions, nil)
+		ratio, err = cardinality.Selectivity(sctx.GetPlanCtx(), histColl, sel.Conditions, nil)
 		require.NoErrorf(t, err, "for %s", tt.exprs)
 		require.Truef(t, math.Abs(ratio-tt.selectivityAfterIncrease) < eps, "for %s, needed: %v, got: %v", tt.exprs, tt.selectivityAfterIncrease, ratio)
 	}
@@ -908,7 +908,7 @@ func TestDNFCondSelectivity(t *testing.T) {
 
 		histColl := statsTbl.GenerateHistCollFromColumnInfo(ds.TableInfo, ds.Schema().Columns)
 
-		ratio, _, err := cardinality.Selectivity(sctx.GetPlanCtx(), histColl, sel.Conditions, nil)
+		ratio, err := cardinality.Selectivity(sctx.GetPlanCtx(), histColl, sel.Conditions, nil)
 		require.NoErrorf(t, err, "error %v, for expr %s", err, tt)
 		testdata.OnRecord(func() {
 			output[i].SQL = tt

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1230,7 +1230,7 @@ func constructDS2TableScanTask(
 	countAfterAccess := rowCount
 	if len(ts.FilterCondition) > 0 {
 		var err error
-		selectivity, _, err = cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, ts.FilterCondition, ds.PossibleAccessPaths)
+		selectivity, err = cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, ts.FilterCondition, ds.PossibleAccessPaths)
 		if err != nil || selectivity <= 0 {
 			logutil.BgLogger().Debug("unexpected selectivity, use selection factor", zap.Float64("selectivity", selectivity), zap.String("table", ts.TableAsName.L))
 			selectivity = cost.SelectionFactor
@@ -1552,7 +1552,7 @@ func constructDS2IndexScanTask(
 	}
 	// Assume equal conditions used by index join and other conditions are independent.
 	if len(tblConds) > 0 {
-		selectivity, _, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, tblConds, ds.PossibleAccessPaths)
+		selectivity, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, tblConds, ds.PossibleAccessPaths)
 		if err != nil || selectivity <= 0 {
 			logutil.BgLogger().Debug("unexpected selectivity, use selection factor", zap.Float64("selectivity", selectivity), zap.String("table", ds.TableAsName.L))
 			selectivity = cost.SelectionFactor
@@ -1570,7 +1570,7 @@ func constructDS2IndexScanTask(
 		tmpPath.CountAfterAccess = cnt
 	}
 	if len(indexConds) > 0 {
-		selectivity, _, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, indexConds, ds.PossibleAccessPaths)
+		selectivity, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, indexConds, ds.PossibleAccessPaths)
 		if err != nil || selectivity <= 0 {
 			logutil.BgLogger().Debug("unexpected selectivity, use selection factor", zap.Float64("selectivity", selectivity), zap.String("table", ds.TableAsName.L))
 			selectivity = cost.SelectionFactor

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -2183,7 +2183,7 @@ func convertToPartialTableScan(ds *logicalop.DataSource, prop *property.Physical
 		ts.ByItems = byItems
 	}
 	if len(ts.FilterCondition) > 0 {
-		selectivity, _, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, ts.FilterCondition, nil)
+		selectivity, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, ts.FilterCondition, nil)
 		if err != nil {
 			logutil.BgLogger().Debug("calculate selectivity failed, use selection factor", zap.Error(err))
 			selectivity = cost.SelectionFactor
@@ -2395,7 +2395,7 @@ func addPushedDownSelection4PhysicalIndexScan(is *physicalop.PhysicalIndexScan, 
 		copTask.FinishIndexPlan()
 		tableSel := physicalop.PhysicalSelection{Conditions: tableConds}.Init(is.SCtx(), finalStats, is.QueryBlockOffset())
 		if len(copTask.RootTaskConds) != 0 {
-			selectivity, _, err := cardinality.Selectivity(is.SCtx(), copTask.TblColHists, tableConds, nil)
+			selectivity, err := cardinality.Selectivity(is.SCtx(), copTask.TblColHists, tableConds, nil)
 			if err != nil {
 				logutil.BgLogger().Debug("calculate selectivity failed, use selection factor", zap.Error(err))
 				selectivity = cost.SelectionFactor
@@ -2844,7 +2844,7 @@ func addPushedDownSelection4PhysicalTableScan(ts *physicalop.PhysicalTableScan, 
 			return
 		}
 		if len(copTask.RootTaskConds) != 0 {
-			selectivity, _, err := cardinality.Selectivity(ts.SCtx(), copTask.TblColHists, sel.Conditions, nil)
+			selectivity, err := cardinality.Selectivity(ts.SCtx(), copTask.TblColHists, sel.Conditions, nil)
 			if err != nil {
 				logutil.BgLogger().Debug("calculate selectivity failed, use selection factor", zap.Error(err))
 				selectivity = cost.SelectionFactor

--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -388,7 +388,7 @@ func generateANDIndexMerge4NormalIndex(ds *logicalop.DataSource, normalPathCnt i
 	}
 
 	// 3. Estimate the row count after partial paths.
-	sel, _, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, partialFilters, nil)
+	sel, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, partialFilters, nil)
 	if err != nil {
 		logutil.BgLogger().Debug("something wrong happened, use the default selectivity", zap.Error(err))
 		sel = cost.SelectionFactor

--- a/pkg/planner/core/indexmerge_unfinished_path.go
+++ b/pkg/planner/core/indexmerge_unfinished_path.go
@@ -549,7 +549,7 @@ func estimateCountAfterAccessForIndexMergeOR(ds *logicalop.DataSource, decidedPa
 		)
 	} else {
 		var err error
-		sel, _, err = cardinality.Selectivity(
+		sel, err = cardinality.Selectivity(
 			ds.SCtx(),
 			ds.TableStats.HistColl,
 			[]expression.Expression{accessDNF},

--- a/pkg/planner/core/operator/physicalop/physical_table_scan.go
+++ b/pkg/planner/core/operator/physicalop/physical_table_scan.go
@@ -804,7 +804,7 @@ func BuildIndexMergeTableScan(ds *logicalop.DataSource, tableFilters []expressio
 		pushedFilters = pushedFilters1
 		remainingFilters = append(remainingFilters, remainingFilters1...)
 		if len(pushedFilters) != 0 {
-			selectivity, _, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, pushedFilters, nil)
+			selectivity, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, pushedFilters, nil)
 			if err != nil {
 				logutil.BgLogger().Debug("calculate selectivity failed, use selection factor", zap.Error(err))
 				selectivity = cost.SelectionFactor

--- a/pkg/planner/core/operator/physicalop/task.go
+++ b/pkg/planner/core/operator/physicalop/task.go
@@ -46,7 +46,7 @@ func collectPartitionInfosFromMPPPlan(p *PhysicalTableReader, mppPlan base.Physi
 
 func (t *CopTask) handleRootTaskConds(ctx base.PlanContext, newTask *RootTask) {
 	if len(t.RootTaskConds) > 0 {
-		selectivity, _, err := cardinality.Selectivity(ctx, t.TblColHists, t.RootTaskConds, nil)
+		selectivity, err := cardinality.Selectivity(ctx, t.TblColHists, t.RootTaskConds, nil)
 		if err != nil {
 			logutil.BgLogger().Debug("calculate selectivity failed, use selection factor", zap.Error(err))
 			selectivity = cost.SelectionFactor

--- a/pkg/planner/core/operator/physicalop/task_base.go
+++ b/pkg/planner/core/operator/physicalop/task_base.go
@@ -333,7 +333,7 @@ func (t *MppTask) ConvertToRootTaskImpl(ctx base.PlanContext) (rt *RootTask) {
 			logutil.BgLogger().Error("expect Selection or TableScan for mppTask.p", zap.String("mppTask.p", t.p.TP()))
 			return base.InvalidTask.(*RootTask)
 		}
-		selectivity, _, err := cardinality.Selectivity(ctx, t.tblColHists, t.RootTaskConds, nil)
+		selectivity, err := cardinality.Selectivity(ctx, t.tblColHists, t.RootTaskConds, nil)
 		if err != nil {
 			logutil.BgLogger().Debug("calculate selectivity failed, use selection factor", zap.Error(err))
 			selectivity = cost.SelectionFactor

--- a/pkg/planner/core/operator/physicalop/tiflash_predicate_push_down.go
+++ b/pkg/planner/core/operator/physicalop/tiflash_predicate_push_down.go
@@ -105,7 +105,7 @@ func groupByColumnsSortBySelectivity(sctx base.PlanContext, conds []expression.E
 	// Estimate the selectivity of each group and check if it is larger than the selectivityThreshold
 	var exprGroups []expressionGroup
 	for _, group := range groupMap {
-		selectivity, _, err := cardinality.Selectivity(sctx, ts.TblColHists, group, nil)
+		selectivity, err := cardinality.Selectivity(sctx, ts.TblColHists, group, nil)
 		if err != nil {
 			logutil.BgLogger().Warn("calculate selectivity failed, do not push down the conditions group", zap.Error(err))
 			continue
@@ -201,7 +201,7 @@ func predicatePushDownToTableScan(sctx base.PlanContext, conds []expression.Expr
 
 	for _, exprGroup := range sortedConds {
 		mergedConds := append(selectedConds, exprGroup.exprs...)
-		selectivity, _, err := cardinality.Selectivity(sctx, ts.TblColHists, mergedConds, nil)
+		selectivity, err := cardinality.Selectivity(sctx, ts.TblColHists, mergedConds, nil)
 		if err != nil {
 			logutil.BgLogger().Warn("calculate selectivity failed, do not push down the conditions group", zap.Error(err))
 			continue
@@ -333,7 +333,7 @@ func handleTiFlashPredicatePushDown(pctx base.PlanContext, ts *PhysicalTableScan
 			continue
 		}
 		// 3. The selectivity of the predicate is less than 60%.
-		selectivity, _, err := cardinality.Selectivity(pctx, ts.TblColHists, []expression.Expression{cond}, nil)
+		selectivity, err := cardinality.Selectivity(pctx, ts.TblColHists, []expression.Expression{cond}, nil)
 		if err != nil {
 			logutil.BgLogger().Warn("calculate selectivity failed", zap.Error(err))
 			continue
@@ -376,7 +376,7 @@ func handleTiFlashPredicatePushDown(pctx base.PlanContext, ts *PhysicalTableScan
 	// Update the row count of table scan.
 	if len(selectedConditions)+len(ts.LateMaterializationFilterCondition) != 0 {
 		selectedConditions = append(selectedConditions, ts.LateMaterializationFilterCondition...)
-		selectivity, _, err := cardinality.Selectivity(ts.SCtx(), ts.TblColHists, selectedConditions, nil)
+		selectivity, err := cardinality.Selectivity(ts.SCtx(), ts.TblColHists, selectedConditions, nil)
 		if err != nil {
 			logutil.BgLogger().Warn("calculate selectivity failed", zap.Error(err))
 			selectivity = selectivityThreshold

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -244,7 +244,7 @@ func deriveIndexPathStats(ds *logicalop.DataSource, path *util.AccessPath, _ []e
 		adjustCountAfterAccess(ds, path)
 	}
 	if path.IndexFilters != nil {
-		selectivity, _, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, path.IndexFilters, nil)
+		selectivity, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, path.IndexFilters, nil)
 		if err != nil {
 			logutil.BgLogger().Debug("calculate selectivity failed, use selection factor", zap.Error(err))
 			selectivity = cost.SelectionFactor
@@ -530,7 +530,7 @@ func initStats(ds *logicalop.DataSource) {
 }
 
 func deriveStatsByFilter(ds *logicalop.DataSource, conds expression.CNFExprs, filledPaths []*util.AccessPath) *property.StatsInfo {
-	selectivity, _, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, conds, filledPaths)
+	selectivity, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, conds, filledPaths)
 	if err != nil {
 		logutil.BgLogger().Debug("something wrong happened, use the default selectivity", zap.Error(err))
 		selectivity = cost.SelectionFactor


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65899

Problem Summary:

### What changed and how does it work?
This pull request removes the second unused return value in cardinality.Selectivity.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > - [x] This return value is not used. <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
