### PR TITLE
tests/realtikvtest: avoid FailNow in failpoint callbacks

### DIFF
--- a/tests/realtikvtest/addindextest2/BUILD.bazel
+++ b/tests/realtikvtest/addindextest2/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "@com_github_fsouza_fake_gcs_server//fakestorage",
         "@com_github_phayes_freeport//:freeport",
         "@com_github_pingcap_failpoint//:failpoint",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//oracle",
         "@com_github_tikv_client_go_v2//util",

--- a/tests/realtikvtest/testkit.go
+++ b/tests/realtikvtest/testkit.go
@@ -77,6 +77,8 @@ func RunTestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 		goleak.IgnoreTopFunction("github.com/lestrrat-go/httprc.runFetchWorker"),
 		goleak.IgnoreTopFunction("github.com/tikv/client-go/v2/config/retry.newBackoffFn.func1"),
+		// net.cgoLookupHostIP can be in-flight when goleak runs (e.g. DNS resolve), which is noisy/flaky in tests.
+		goleak.IgnoreAnyFunction("net.cgoLookupHostIP"),
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/client/v3.waitRetryBackoff"),
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/client/pkg/v3/logutil.(*MergeLogger).outputLoop"),
 		goleak.IgnoreTopFunction("google.golang.org/grpc.(*addrConn).resetTransport"),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65901

Problem Summary:
- Some realtikvtest `addindextest2` failpoint callbacks run in background goroutines (DDL/DXF workers).
- Using `testify/require` (or `TestKit.MustExec` / `MustQuery`) inside those callbacks can call `t.FailNow()`, which only terminates that goroutine and may leave the DDL pipeline in an unexpected state, causing flaky/hanging tests.

### What changed and how does it work?
- Replace `require.*` assertions inside failpoint callbacks with `assert.*`.
- Avoid `MustExec` / `MustQuery` inside callbacks by using `Exec` + proper `RecordSet` close, and convert rows via `session.ResultSetToStringSlice`.
- Ignore `net.cgoLookupHostIP` in goleak options to avoid flaky leaks caused by in-flight DNS resolution during test shutdown.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
