### PR TITLE
objstore/locking: don't use "." as prefix when locking

### DIFF
--- a/pkg/objstore/locking.go
+++ b/pkg/objstore/locking.go
@@ -128,6 +128,10 @@ func (w conditionalPut) CommitTo(ctx context.Context, s storeapi.Storage) (uuid.
 func (cx VerifyWriteContext) assertNoOtherOfPrefixExpect(pfx string, expect string) error {
 	fileName := path.Base(pfx)
 	dirName := path.Dir(pfx)
+	// Some object stores reject "." as a directory component in list prefixes.
+	if dirName == "." {
+		dirName = ""
+	}
 
 	return cx.Storage.WalkDir(cx, &storeapi.WalkOption{
 		SubDir:    dirName,

--- a/pkg/objstore/s3store/s3_test.go
+++ b/pkg/objstore/s3store/s3_test.go
@@ -1278,6 +1278,40 @@ func TestWalkDirWithEmptyPrefix(t *testing.T) {
 	require.Equal(t, 1, i)
 }
 
+func TestTryLockRemoteRootPathPrefix(t *testing.T) {
+	controller := gomock.NewController(t)
+	s3API := mock.NewMockS3API(controller)
+	storage := NewS3StorageForTest(
+		s3API,
+		&backuppb.S3{
+			Region:       "us-west-2",
+			Bucket:       "bucket",
+			Prefix:       "",
+			Acl:          "acl",
+			Sse:          "sse",
+			StorageClass: "sc",
+		},
+		nil,
+	)
+	defer controller.Finish()
+
+	s3API.EXPECT().
+		ListObjects(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input *s3.ListObjectsInput, _ ...func(*s3.Options)) (*s3.ListObjectsOutput, error) {
+			require.Equal(t, "truncating.lock", aws.ToString(input.Prefix))
+			return nil, errors.New("stop")
+		})
+	s3API.EXPECT().
+		GetObject(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			return nil, errors.New("no such key")
+		})
+
+	_, err := TryLockRemote(context.Background(), storage, "truncating.lock", "hint")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "during initial check")
+}
+
 func TestSendCreds(t *testing.T) {
 	accessKey := "ab"
 	secretAccessKey := "cd"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65897 

Problem Summary:
BR `log truncate` can fail on S3/MinIO when the lock file is at the storage root, because lock verification builds a `./truncating.lock` prefix that MinIO rejects.

### What changed and how does it work?
Normalize `path.Dir` result from `"."` to `""` before building the list prefix, and add a unit test to ensure root-level lock paths produce an empty SubDir.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug that may cause `br log truncate` fail in S3-compatible storage.
```
