### PR TITLE
executor/metrics: add softdelete implicit delete rows metric and expose stats in INSERT runtime | tidb-test=feature/active-active

### DIFF
--- a/pkg/executor/insert_test.go
+++ b/pkg/executor/insert_test.go
@@ -424,21 +424,26 @@ func TestInsertRuntimeStat(t *testing.T) {
 			CdcConflictSkipCount: 1,
 			UnsafeOriginTSCount:  2,
 		},
+		SoftDelete: &executor.SoftDeleteStats{
+			ImplicitRemoveRows: 7,
+		},
 		CheckInsertTime: 2 * time.Second,
 		Prefetch:        1 * time.Second,
 	}
 	stats.BasicRuntimeStats.Record(5*time.Second, 1)
-	require.Equal(t, "prepare: 3s, check_insert: {total_time: 2s, mem_insert_time: 1s, prefetch: 1s}, active_active: {cdc_conflict_skip_cnt: 1, unsafe_write_origin_ts_cnt: 2}", stats.String())
+	require.Equal(t, "prepare: 3s, check_insert: {total_time: 2s, mem_insert_time: 1s, prefetch: 1s}, active_active: {cdc_conflict_skip_cnt: 1, unsafe_write_origin_ts_cnt: 2}, softdelete: {implicit_remove_rows: 7}", stats.String())
 	require.Equal(t, stats.Clone().String(), stats.String())
 	newStats := stats.Clone().(*executor.InsertRuntimeStat)
 	require.NotSame(t, stats.ActiveActive, newStats.ActiveActive)
+	require.NotSame(t, stats.SoftDelete, newStats.SoftDelete)
 	newStats.BasicRuntimeStats.Record(5*time.Second, 1)
 	newStats.ActiveActive.CdcConflictSkipCount = 3
 	newStats.ActiveActive.UnsafeOriginTSCount = 4
+	newStats.SoftDelete.ImplicitRemoveRows = 11
 	stats.Merge(newStats)
-	require.Equal(t, "prepare: 6s, check_insert: {total_time: 4s, mem_insert_time: 2s, prefetch: 2s}, active_active: {cdc_conflict_skip_cnt: 4, unsafe_write_origin_ts_cnt: 6}", stats.String())
+	require.Equal(t, "prepare: 6s, check_insert: {total_time: 4s, mem_insert_time: 2s, prefetch: 2s}, active_active: {cdc_conflict_skip_cnt: 4, unsafe_write_origin_ts_cnt: 6}, softdelete: {implicit_remove_rows: 18}", stats.String())
 	stats.FKCheckTime = time.Second
-	require.Equal(t, "prepare: 6s, check_insert: {total_time: 4s, mem_insert_time: 2s, prefetch: 2s, fk_check: 1s}, active_active: {cdc_conflict_skip_cnt: 4, unsafe_write_origin_ts_cnt: 6}", stats.String())
+	require.Equal(t, "prepare: 6s, check_insert: {total_time: 4s, mem_insert_time: 2s, prefetch: 2s, fk_check: 1s}, active_active: {cdc_conflict_skip_cnt: 4, unsafe_write_origin_ts_cnt: 6}, softdelete: {implicit_remove_rows: 18}", stats.String())
 
 	stats2 := &executor.InsertRuntimeStat{}
 	stats2.Merge(&executor.InsertRuntimeStat{
@@ -447,6 +452,9 @@ func TestInsertRuntimeStat(t *testing.T) {
 			CdcConflictSkipCount: 2,
 			UnsafeOriginTSCount:  3,
 		},
+		SoftDelete: &executor.SoftDeleteStats{
+			ImplicitRemoveRows: 5,
+		},
 		CheckInsertTime: 2 * time.Second,
 		Prefetch:        500 * time.Millisecond,
 		FKCheckTime:     300 * time.Millisecond,
@@ -454,6 +462,8 @@ func TestInsertRuntimeStat(t *testing.T) {
 	require.NotNil(t, stats2.BasicRuntimeStats)
 	require.Equal(t, uint64(2), stats2.ActiveActive.CdcConflictSkipCount)
 	require.Equal(t, uint64(3), stats2.ActiveActive.UnsafeOriginTSCount)
+	require.NotNil(t, stats2.SoftDelete)
+	require.Equal(t, uint64(5), stats2.SoftDelete.ImplicitRemoveRows)
 	require.Equal(t, 2*time.Second, stats2.CheckInsertTime)
 	require.Equal(t, 500*time.Millisecond, stats2.Prefetch)
 	require.Equal(t, 300*time.Millisecond, stats2.FKCheckTime)

--- a/pkg/executor/load_data.go
+++ b/pkg/executor/load_data.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/lightning/mydump"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
@@ -264,6 +265,9 @@ sendReaderInfoLoop:
 	err = group.Wait()
 	e.setResult(encoder.exprWarnings)
 	committer.reportActiveActiveStats("LoadData")
+	if rows := committer.softDeleteStats.ImplicitRemoveRows; rows > 0 {
+		metrics.SoftDeleteImplicitDeleteRowsLoadData.Observe(float64(rows))
+	}
 	return err
 }
 

--- a/pkg/metrics/executor.go
+++ b/pkg/metrics/executor.go
@@ -72,6 +72,13 @@ var (
 	// ActiveActiveWriteUnsafeOriginTsStmtCounter records the num of unsafe _tidb_origin_ts statements.
 	ActiveActiveWriteUnsafeOriginTsStmtCounter prometheus.Counter
 
+	// SoftDeleteImplicitDeleteRows records the number of soft-deleted rows implicitly removed per DML statement.
+	SoftDeleteImplicitDeleteRows *prometheus.HistogramVec
+	// SoftDeleteImplicitDeleteRowsInsert records SoftDeleteImplicitDeleteRows with Insert label.
+	SoftDeleteImplicitDeleteRowsInsert prometheus.Observer
+	// SoftDeleteImplicitDeleteRowsLoadData records SoftDeleteImplicitDeleteRows with LoadData label.
+	SoftDeleteImplicitDeleteRowsLoadData prometheus.Observer
+
 	// NetworkTransmissionStats records the network transmission for queries
 	NetworkTransmissionStats *prometheus.CounterVec
 )
@@ -177,6 +184,18 @@ func InitExecutorMetrics() {
 			Name:      "write_unsafe_origin_ts_stmt_total",
 			Help:      "stmts written with unsafe _tidb_origin_ts column",
 		})
+
+	SoftDeleteImplicitDeleteRows = metricscommon.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "executor",
+			Name:      "softdelete_implicit_delete_rows",
+			Help:      "Bucketed histogram of soft-deleted rows implicitly removed per DML statement.",
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 16), // 1 ~ 32768
+		}, []string{LblSQLType})
+
+	SoftDeleteImplicitDeleteRowsInsert = SoftDeleteImplicitDeleteRows.WithLabelValues("Insert")
+	SoftDeleteImplicitDeleteRowsLoadData = SoftDeleteImplicitDeleteRows.WithLabelValues("LoadData")
 
 	NetworkTransmissionStats = metricscommon.NewCounterVec(
 		prometheus.CounterOpts{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -202,6 +202,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(OngoingTxnDurationHistogram)
 	prometheus.MustRegister(MppCoordinatorStats)
 	prometheus.MustRegister(MppCoordinatorLatency)
+	prometheus.MustRegister(SoftDeleteImplicitDeleteRows)
 	prometheus.MustRegister(TimeJumpBackCounter)
 	prometheus.MustRegister(TransactionDuration)
 	prometheus.MustRegister(StatementDeadlockDetectDuration)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #64281

### What changed and how does it work?

This PR adds observability for the softdelete feature when DML implicitly removes (hard-deletes) tombstone rows during write conflict handling.

**What’s changed**

  - Added a new Prometheus histogram metric tidb_executor_softdelete_implicit_delete_rows labeled by sql_type to record implicit tombstone removals per DML statement (Insert,
    LoadData).
  - Introduced SoftDeleteStats and wired it into InsertRuntimeStat so EXPLAIN ANALYZE/runtime stats include softdelete: {implicit_remove_rows: ...}.

<img width="1852" height="624" alt="image" src="https://github.com/user-attachments/assets/cea5048c-816e-4304-9735-4b13ba6b81c8" />


**Tests**

  - Updated TestInsertRuntimeStat to cover SoftDeleteStats clone/merge and string formatting.
  - Added a table-driven test validating the metric is recorded for both INSERT and LOAD DATA paths.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
