### PR TITLE
*: stabilize integrationtest stale read timestamp

### DIFF
--- a/tests/integrationtest/r/executor/index_lookup_pushdown.result
+++ b/tests/integrationtest/r/executor/index_lookup_pushdown.result
@@ -512,13 +512,13 @@ IndexLookUp_7	10000.00	root
 │ └─TableRowIDScan_8(Probe)	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 └─TableRowIDScan_6(Probe)	0.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 do sleep(0.1);
-explain select /*+ index_lookup_pushdown(t1, i) */ * from t1 as of timestamp NOW(6) - interval 0.05 second;
+explain select /*+ index_lookup_pushdown(t1, i) */ * from t1 as of timestamp NOW(6) - interval 0.1 second;
 id	estRows	task	access object	operator info
 TableReader_6	10000.00	root		data:TableFullScan_5
 └─TableFullScan_5	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 Level	Code	Message
 Warning	1815	hint INDEX_LOOKUP_PUSHDOWN is inapplicable, stale read is not supported
-start transaction read only as of timestamp now(6) - interval 0.05 second;
+start transaction read only as of timestamp now(6) - interval 0.1 second;
 explain select /*+ index_lookup_pushdown(t1, i) */ * from t1;
 id	estRows	task	access object	operator info
 TableReader_6	10000.00	root		data:TableFullScan_5
@@ -526,7 +526,7 @@ TableReader_6	10000.00	root		data:TableFullScan_5
 Level	Code	Message
 Warning	1815	hint INDEX_LOOKUP_PUSHDOWN is inapplicable, stale read is not supported
 rollback;
-set transaction read only as of timestamp now(6) - interval 0.05 second;
+set transaction read only as of timestamp now(6) - interval 0.1 second;
 explain select /*+ index_lookup_pushdown(t1, i) */ * from t1;
 id	estRows	task	access object	operator info
 TableReader_6	10000.00	root		data:TableFullScan_5
@@ -534,7 +534,7 @@ TableReader_6	10000.00	root		data:TableFullScan_5
 Level	Code	Message
 Warning	1815	hint INDEX_LOOKUP_PUSHDOWN is inapplicable, stale read is not supported
 insert ignore into mysql.tidb VALUES ('tikv_gc_safe_point', '20240131-00:00:00.000 +0800', 'mock for index lookup push down test');
-set @@tidb_snapshot=(now(6) - interval 0.05 second);
+set @@tidb_snapshot=(now(6) - interval 0.1 second);
 explain select /*+ index_lookup_pushdown(t1, i) */ * from t1;
 id	estRows	task	access object	operator info
 TableReader_6	10000.00	root		data:TableFullScan_5

--- a/tests/integrationtest/r/executor/stale_txn.result
+++ b/tests/integrationtest/r/executor/stale_txn.result
@@ -1,4 +1,4 @@
-select * from information_schema.ddl_jobs as of timestamp now(6) - interval 1 microsecond;
+select * from information_schema.ddl_jobs as of timestamp now(6) - interval 0.1 second;
 drop table if exists t1;
 create table t1 (id int primary key, v int);
 insert into t1 values(1, 10);

--- a/tests/integrationtest/t/executor/index_lookup_pushdown.test
+++ b/tests/integrationtest/t/executor/index_lookup_pushdown.test
@@ -173,17 +173,17 @@ set @@tidb_replica_read='leader';
 explain select /*+ index_lookup_pushdown(t1, i) */ * from t1;
 ## stale read is not supported
 do sleep(0.1);
-explain select /*+ index_lookup_pushdown(t1, i) */ * from t1 as of timestamp NOW(6) - interval 0.05 second;
-start transaction read only as of timestamp now(6) - interval 0.05 second;
+explain select /*+ index_lookup_pushdown(t1, i) */ * from t1 as of timestamp NOW(6) - interval 0.1 second;
+start transaction read only as of timestamp now(6) - interval 0.1 second;
 explain select /*+ index_lookup_pushdown(t1, i) */ * from t1;
 rollback;
-set transaction read only as of timestamp now(6) - interval 0.05 second;
+set transaction read only as of timestamp now(6) - interval 0.1 second;
 explain select /*+ index_lookup_pushdown(t1, i) */ * from t1;
 ## historical read is not supported
 --disable_warnings
 insert ignore into mysql.tidb VALUES ('tikv_gc_safe_point', '20240131-00:00:00.000 +0800', 'mock for index lookup push down test');
 --enable_warnings
-set @@tidb_snapshot=(now(6) - interval 0.05 second);
+set @@tidb_snapshot=(now(6) - interval 0.1 second);
 explain select /*+ index_lookup_pushdown(t1, i) */ * from t1;
 set @@tidb_snapshot='';
 delete from mysql.tidb where VARIABLE_NAME='tikv_gc_safe_point' and COMMENT='mock for index lookup push down test';

--- a/tests/integrationtest/t/executor/stale_txn.test
+++ b/tests/integrationtest/t/executor/stale_txn.test
@@ -1,7 +1,7 @@
 # TestIssue35686
 ## This query should not panic
 --disable_result_log
-select * from information_schema.ddl_jobs as of timestamp now(6) - interval 1 microsecond;
+select * from information_schema.ddl_jobs as of timestamp now(6) - interval 0.1 second;
 --enable_result_log
 
 # TestIssue31954


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65952

Problem Summary:

Some `tests/integrationtest` stale read / historical read cases compute the read timestamp from TiDB local time via `now(6)`.
On CI, small clock skews between TiDB and PD/TSO (or rounding on millisecond boundaries) can make the derived `readTS` slightly larger than `currentTS`, causing:

```
Error 1105 (HY000): cannot set read timestamp to a future time
```

This makes related integration tests flaky.

### What changed and how does it work?

- Increase the time offset used in stale read / historical read statements from a too-small delta (e.g. `0.05s`) to `0.1s` to provide enough margin for clock skew and TSO millisecond granularity.
- Keep the offset at `0.1s` (instead of a much larger value) to avoid taking a snapshot too early (before the table exists) in very fast test runs.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
