### PR TITLE
sessiontxn: reject AS OF TIMESTAMP when autocommit is disabled

### DIFF
--- a/pkg/sessiontxn/BUILD.bazel
+++ b/pkg/sessiontxn/BUILD.bazel
@@ -27,7 +27,7 @@ go_test(
         "txn_rc_tso_optimize_test.go",
     ],
     flaky = True,
-    shard_count = 25,
+    shard_count = 27,
     deps = [
         ":sessiontxn",
         "//pkg/config",

--- a/pkg/sessiontxn/staleread/processor_test.go
+++ b/pkg/sessiontxn/staleread/processor_test.go
@@ -384,7 +384,7 @@ func TestStaleReadProcessorInTxn(t *testing.T) {
 	processor = createProcessor(t, tk.Session())
 	err = processor.OnSelectTable(p1.tn)
 	require.Error(t, err)
-	require.Equal(t, "[planner:8135]invalid as of timestamp: as of timestamp can't be set in transaction.", err.Error())
+	require.Equal(t, "[planner:8135]invalid as of timestamp: as of timestamp can't be set in transaction or when autocommit is disabled.", err.Error())
 
 	// return an error when execute prepared stmt with as of
 	processor = createProcessor(t, tk.Session())
@@ -392,7 +392,7 @@ func TestStaleReadProcessorInTxn(t *testing.T) {
 		return p1.ts, nil
 	})
 	require.Error(t, err)
-	require.Equal(t, "[planner:8135]invalid as of timestamp: as of timestamp can't be set in transaction.", err.Error())
+	require.Equal(t, "[planner:8135]invalid as of timestamp: as of timestamp can't be set in transaction or when autocommit is disabled.", err.Error())
 
 	tk.MustExec("rollback")
 

--- a/tests/integrationtest/r/executor/stale_txn.result
+++ b/tests/integrationtest/r/executor/stale_txn.result
@@ -31,8 +31,7 @@ sleep(0.1)
 update t1 set v=100 where id=1;
 set autocommit=0;
 select * from t1 as of timestamp @a;
-id	v
-1	10
+Error 8135 (HY000): invalid as of timestamp: as of timestamp can't be set in transaction or when autocommit is disabled.
 set tidb_txn_mode = default;
 set tx_isolation = default;
 set autocommit = default;

--- a/tests/integrationtest/t/executor/stale_txn.test
+++ b/tests/integrationtest/t/executor/stale_txn.test
@@ -26,6 +26,7 @@ set @a=now(6);
 select sleep(0.1);
 update t1 set v=100 where id=1;
 set autocommit=0;
+--error 8135
 select * from t1 as of timestamp @a;
 
 set tidb_txn_mode = default;


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65957

Problem Summary:

According to the Stale Read product design, `SELECT ... AS OF TIMESTAMP` should only be used in implicit transactions with `autocommit=1`. However, it was possible to execute such statements even when `autocommit=0`.

### What changed and how does it work?

This change adds a check for `!IsAutocommit()` in `OnSelectTable` and `OnExecutePreparedStmt` methods in `pkg/sessiontxn/staleread/processor.go` to properly reject `AS OF TIMESTAMP` queries when autocommit is disabled.

The error message is also updated from:
```
as of timestamp can't be set in transaction.
```
to:
```
as of timestamp can't be set in transaction or when autocommit is disabled.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
`SELECT ... AS OF TIMESTAMP` now returns an error when `autocommit=0`, aligning with the stale read design.
```