### PR TITLE
planner: make pkg integration tests ignore plan-id with explain format as brief

### DIFF
--- a/pkg/planner/core/casetest/integration_test.go
+++ b/pkg/planner/core/casetest/integration_test.go
@@ -360,15 +360,15 @@ func TestIndexMergeJSONMemberOf2FlakyPart(t *testing.T) {
 		tk.MustExec(`insert into t value(2,2,2, '{"b":[3,4,5,6]}');`)
 		tk.MustExec(`set tidb_analyze_version=2;`)
 		tk.MustExec(`analyze table t all columns;`)
-		tk.MustQuery("explain select * from t use index (iad) where a = 1;").Check(testkit.Rows(
-			"TableReader_8 1.00 root  data:Selection_7",
-			"└─Selection_7 1.00 cop[tikv]  eq(test.t.a, 1)",
-			"  └─TableFullScan_6 2.00 cop[tikv] table:t keep order:false",
+		tk.MustQuery("explain format = 'brief' select * from t use index (iad) where a = 1;").Check(testkit.Rows(
+			"TableReader 1.00 root  data:Selection",
+			"└─Selection 1.00 cop[tikv]  eq(test.t.a, 1)",
+			"  └─TableFullScan 2.00 cop[tikv] table:t keep order:false",
 		))
-		tk.MustQuery("explain select * from t use index (iad) where a = 1 and (2 member of (d->'$.b'));").Check(testkit.Rows(
-			"IndexMerge_8 1.00 root  type: union",
-			"├─IndexRangeScan_6(Build) 1.00 cop[tikv] table:t, index:iad(a, cast(json_extract(`d`, _utf8mb4'$.b') as signed array)) range:[1 2,1 2], keep order:false, stats:partial[d:unInitialized]",
-			"└─TableRowIDScan_7(Probe) 1.00 cop[tikv] table:t keep order:false, stats:partial[d:unInitialized]",
+		tk.MustQuery("explain format = 'brief' select * from t use index (iad) where a = 1 and (2 member of (d->'$.b'));").Check(testkit.Rows(
+			"IndexMerge 1.00 root  type: union",
+			"├─IndexRangeScan(Build) 1.00 cop[tikv] table:t, index:iad(a, cast(json_extract(`d`, _utf8mb4'$.b') as signed array)) range:[1 2,1 2], keep order:false, stats:partial[d:unInitialized]",
+			"└─TableRowIDScan(Probe) 1.00 cop[tikv] table:t keep order:false, stats:partial[d:unInitialized]",
 		))
 	})
 }
@@ -527,7 +527,7 @@ FROM (SELECT DISTINCT balance.portfolio_code AS portfolioCode
 		tk.MustQuery(`select * from t_issue52023 where a = 5`).Check(testkit.Rows())
 		tk.MustQuery(`select * from t_issue52023 where a IN (5,55)`).Check(testkit.Rows())
 		tk.MustQuery(`select * from t_issue52023 where a IN (0x5,55)`).Check(testkit.Rows("\u0005"))
-		tk.MustQuery(`explain select * from t_issue52023 where a = 0x5`).Check(testkit.Rows("Point_Get_1 1.00 root table:t_issue52023, partition:P4, clustered index:PRIMARY(a) "))
+		tk.MustQuery(`explain format='brief' select * from t_issue52023 where a = 0x5`).Check(testkit.Rows("Point_Get 1.00 root table:t_issue52023, partition:P4, clustered index:PRIMARY(a) "))
 		tk.MustQuery(`explain format='brief' select * from t_issue52023 where a = 5`).Check(testkit.Rows(""+
 			"TableReader 1.00 root partition:all data:Selection",
 			"└─Selection 1.00 cop[tikv]  eq(cast(test.t_issue52023.a, double BINARY), 5)",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60940 

Problem Summary: Some explain-test cases will record the plan ID in the result file, which will be a burden when some optimization flow is changed, since plan ID allocation is sequential according to the allocation order or space.

### What changed and how does it work?
Made pkg integration tests ignore plan-id with explain format as brief

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
