### PR TITLE
bindinfo: explore per-table index hints during plan generation

### DIFF
--- a/pkg/bindinfo/binding_plan_generation_test.go
+++ b/pkg/bindinfo/binding_plan_generation_test.go
@@ -109,7 +109,7 @@ func TestStartState(t *testing.T) {
 	}
 	fixes := []uint64{fixcontrol.Fix44855, fixcontrol.Fix45132, fixcontrol.Fix52869}
 
-	state, err := getStartState(vars, fixes)
+	state, err := getStartState(vars, fixes, 0)
 	require.NoError(t, err)
 	require.Equal(t, state.Encode(), "1.0000,1.0000,1.0000,1.0000,1.0000,1.0000,1.0000,1.0000,1.0000,1.0000,1.0000,1.0000,1.0000,1.0000,1.0000,1.0000,1.0000,0.0100,0.0000,0.0000,0.0000,0.8000,true,false,false,0.0000,OFF,1000,OFF")
 }

--- a/pkg/bindinfo/testdata/binding_auto_suite_out.json
+++ b/pkg/bindinfo/testdata/binding_auto_suite_out.json
@@ -96,6 +96,15 @@
           ],
           [
             "HashJoin  12487.50  root    inner join, equal:[eq(test.t1.a, test.t2.a)]",
+            "├─IndexLookUp(Probe)  9990.00  root    ",
+            "│ ├─IndexFullScan(Build)  9990.00  cop[tikv]  table:t1, index:a(a)  keep order:false, stats:pseudo",
+            "│ └─TableRowIDScan(Probe)  9990.00  cop[tikv]  table:t1  keep order:false, stats:pseudo",
+            "└─IndexLookUp(Build)  9990.00  root    ",
+            "  ├─IndexFullScan(Build)  9990.00  cop[tikv]  table:t2, index:a(a)  keep order:false, stats:pseudo",
+            "  └─TableRowIDScan(Probe)  9990.00  cop[tikv]  table:t2  keep order:false, stats:pseudo"
+          ],
+          [
+            "HashJoin  12487.50  root    inner join, equal:[eq(test.t1.a, test.t2.a)]",
             "├─TableReader(Probe)  9990.00  root    data:Selection",
             "│ └─Selection  9990.00  cop[tikv]    not(isnull(test.t1.a))",
             "│   └─TableFullScan  10000.00  cop[tikv]  table:t1  keep order:false, stats:pseudo",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65999

Problem Summary:
Binding plan generation tracked only a single index hint state, so multi-table queries could not explore combinations of index hints across tables and might miss valid bound plans.

### What changed and how does it work?
- Track optional index hints per table in the BFS state.
- Add a no-hint option per table and apply all selected hints when generating the plan.
- Deduplicate per-table index options and update expected test output.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > - Not run (not requested)
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
