### PR TITLE
pkg/meta: store mview/mlog dependency metadata in TableInfo

### DIFF
--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -716,8 +716,9 @@ func (i *MaterializedViewBaseInfo) Clone() *MaterializedViewBaseInfo {
 
 // MaterializedViewInfo is stored in TableInfo for a materialized view table.
 type MaterializedViewInfo struct {
-	// BaseTableID is the table ID of the base table.
-	BaseTableID int64 `json:"base_table_id"`
+	// BaseTableIDs is the table IDs of the base tables referenced by this MV.
+	// For Stage-1, it contains exactly one element.
+	BaseTableIDs []int64 `json:"base_table_ids"`
 
 	// SQLContent is the SELECT statement in CREATE MATERIALIZED VIEW.
 	SQLContent string `json:"sql_content"`
@@ -738,6 +739,7 @@ func (i *MaterializedViewInfo) Clone() *MaterializedViewInfo {
 		return nil
 	}
 	ni := *i
+	ni.BaseTableIDs = append([]int64(nil), i.BaseTableIDs...)
 	return &ni
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: ref #65936 ref #18023

Problem Summary:

- Materialized View needs durable metadata to represent dependencies among base tables, materialized views and materialized view logs.
- The mapping should avoid duplicate sources of truth and support fast dependency checks in DDL (drop/rename/validation).

### What changed and how does it work?

This PR refines `pkg/meta/model.TableInfo` to store MV/MLOG definition metadata:

- Base table TableInfo: add `MaterializedViewBase` to store
  - `MLogID` (1 base table : 1 MV log)
  - `MViewIDs` (1 base table : N MVs)
- MV table TableInfo: refine `MaterializedView` (`MaterializedViewInfo`) to store
  - `BaseTableIDs` (Stage-1 requires exactly 1 base table)
  - MV definition SQL (`SQLContent`) and refresh schedule definition
- MV log table TableInfo: extend `MaterializedViewLog` (`MaterializedViewLogInfo`) to store
  - `BaseTableID`, user-specified column list, and purge schedule definition
- Clone: deep-copy the new pointer/slice fields to avoid aliasing.

Schedule expressions are stored as canonical SQL strings (similar to generated column / expression index metadata), and can be parsed/evaluated when needed.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
