### PR TITLE
sessiontxn: do not fetch tso async for some unnecesary statements

### DIFF
--- a/pkg/sessiontxn/BUILD.bazel
+++ b/pkg/sessiontxn/BUILD.bazel
@@ -27,7 +27,7 @@ go_test(
         "txn_rc_tso_optimize_test.go",
     ],
     flaky = True,
-    shard_count = 26,
+    shard_count = 27,
     deps = [
         ":sessiontxn",
         "//pkg/config",

--- a/pkg/sessiontxn/failpoint.go
+++ b/pkg/sessiontxn/failpoint.go
@@ -43,6 +43,9 @@ var BreakPointBeforeExecutorFirstRun = "beforeExecutorFirstRun"
 // Only for test
 var BreakPointOnStmtRetryAfterLockError = "lockErrorAndThenOnStmtRetryCalled"
 
+// WarmupTsoRequestCount is the key for recording tso request counts in warm up
+var WarmupTsoRequestCount stringutil.StringerStr = "warmupTsoRequestCount"
+
 // TsoRequestCount is the key for recording tso request counts in some places
 var TsoRequestCount stringutil.StringerStr = "tsoRequestCount"
 
@@ -133,6 +136,17 @@ func TsoRequestCountInc(sctx sessionctx.Context) {
 	}
 	count++
 	sctx.SetValue(TsoRequestCount, count)
+}
+
+// WarmupTsoRequestCountInc is used only for test
+// When it is called, there is a tso cmd request in warmup.
+func WarmupTsoRequestCountInc(sctx sessionctx.Context) {
+	count, ok := sctx.Value(WarmupTsoRequestCount).(uint64)
+	if !ok {
+		count = 0
+	}
+	count++
+	sctx.SetValue(WarmupTsoRequestCount, count)
 }
 
 // TsoWaitCountInc is used only for test

--- a/pkg/sessiontxn/isolation/readcommitted.go
+++ b/pkg/sessiontxn/isolation/readcommitted.go
@@ -268,7 +268,7 @@ func (p *PessimisticRCTxnContextProvider) AdviseWarmup() error {
 		return err
 	}
 
-	if !p.isTidbSnapshotEnabled() && p.shouldStmtOptimizePrefetchTSO(p.currentStmt) {
+	if !p.isTidbSnapshotEnabled() && !p.currentStmtMayNotNeedTSO {
 		p.prepareStmtTS(true)
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66052 


### What changed and how does it work?

This PR reduces unnecessary PD TSO load by skipping the warmup-time async startTS prefetch (PrepareTSFuture / GetTimestampAsync) for statement types that typically don’t touch KV, such as USE and simple SET (also including COMMIT/ROLLBACK). The behavior is purely an optimization change: we only skip the early prefetch; if a statement later truly needs a startTS/TSO (e.g. [SET @a = (SELECT ...)](app://-/index.html#)), TiDB will still fetch it when the txn is activated / execution requires it.

Implementation-wise, the decision is made inside the txn context provider (not in txnManager), so warmup remains extensible for future non-TSO warmup work:

The provider catches the current ast.StmtNode on OnStmtStart.
In AdviseWarmup, the provider checks isTxnPrepared / stale-read begin and then uses shouldStmtOptimizePrefetchTSO(stmt) to decide whether to call prepareTxn() (which creates the async startTS future).
For RC isolation, AdviseWarmup reuses the same statement-based decision to avoid preparing stmt-level TS futures when the base warmup intentionally skipped startTS prefetch.
A regression test validates the behavior using the existing requestTsoFromPD failpoint to count TSO-prefetch triggering paths across different statement types.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
