### PR TITLE
infoschema: add information_schema.tidb_mviews and tidb_mlogs

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -221,6 +221,7 @@ go_library(
         "//pkg/util/filter",
         "//pkg/util/format",
         "//pkg/util/gcutil",
+        "//pkg/util/generatedexpr",
         "//pkg/util/globalconn",
         "//pkg/util/hack",
         "//pkg/util/hint",

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -2393,6 +2393,8 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) exec.Ex
 			strings.ToLower(infoschema.TableTiDBCheckConstraints),
 			strings.ToLower(infoschema.TableKeywords),
 			strings.ToLower(infoschema.TableTiDBIndexUsage),
+			strings.ToLower(infoschema.TableTiDBMViews),
+			strings.ToLower(infoschema.TableTiDBMLogs),
 			strings.ToLower(infoschema.ClusterTableTiDBIndexUsage):
 			memTracker := memory.NewTracker(v.ID(), -1)
 			memTracker.AttachTo(b.ctx.GetSessionVars().StmtCtx.MemTracker)

--- a/pkg/executor/test/ddl/BUILD.bazel
+++ b/pkg/executor/test/ddl/BUILD.bazel
@@ -6,10 +6,11 @@ go_test(
     srcs = [
         "ddl_test.go",
         "main_test.go",
+        "mview_infoschema_test.go",
         "mview_log_ddl_test.go",
     ],
     flaky = True,
-    shard_count = 26,
+    shard_count = 28,
     deps = [
         "//pkg/autoid_service",
         "//pkg/config",
@@ -21,6 +22,8 @@ go_test(
         "//pkg/kv",
         "//pkg/meta",
         "//pkg/meta/autoid",
+        "//pkg/meta/model",
+        "//pkg/parser/auth",
         "//pkg/parser/model",
         "//pkg/parser/mysql",
         "//pkg/sessionctx/variable",

--- a/pkg/executor/test/ddl/mview_infoschema_test.go
+++ b/pkg/executor/test/ddl/mview_infoschema_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/auth"
+	pmodel "github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfoSchemaTiDBMViewsAndMLogsBasic(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set time_zone='+00:00'")
+
+	tk.MustExec("create database is_mview")
+	tk.MustExec("use is_mview")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("create table `$mlog$t` (a int)")
+	tk.MustExec("create table mv1 (a int)")
+
+	is := dom.InfoSchema()
+	db, ok := is.SchemaByName(pmodel.NewCIStr("is_mview"))
+	require.True(t, ok)
+
+	baseTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("is_mview"), pmodel.NewCIStr("t"))
+	require.NoError(t, err)
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("is_mview"), pmodel.NewCIStr("$mlog$t"))
+	require.NoError(t, err)
+	mviewTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("is_mview"), pmodel.NewCIStr("mv1"))
+	require.NoError(t, err)
+
+	baseID := baseTable.Meta().ID
+	mlogID := mlogTable.Meta().ID
+	mviewID := mviewTable.Meta().ID
+
+	baseTblInfo := baseTable.Meta().Clone()
+	baseTblInfo.MaterializedViewBase = &model.MaterializedViewBaseInfo{
+		MLogID:   mlogID,
+		MViewIDs: []int64{mviewID},
+	}
+	mlogTblInfo := mlogTable.Meta().Clone()
+	mlogTblInfo.MaterializedViewLog = &model.MaterializedViewLogInfo{
+		BaseTableID:    baseID,
+		Columns:        []pmodel.CIStr{pmodel.NewCIStr("a")},
+		PurgeMethod:    "IMMEDIATE",
+		PurgeStartWith: "'2026-01-02 03:04:05'",
+		PurgeNext:      "600",
+	}
+	mviewTblInfo := mviewTable.Meta().Clone()
+	mviewTblInfo.Comment = "mv comment"
+	mviewTblInfo.MaterializedView = &model.MaterializedViewInfo{
+		BaseTableIDs:     []int64{baseID},
+		SQLContent:       "select a, count(*) from t group by a",
+		RefreshMethod:    "FAST",
+		RefreshStartWith: "'2026-01-02 03:04:05'",
+		RefreshNext:      "300",
+	}
+
+	err = kv.RunInNewTxn(kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL), store, false, func(ctx context.Context, txn kv.Transaction) error {
+		m := meta.NewMutator(txn)
+		_, err := m.GenSchemaVersion()
+		require.NoError(t, err)
+		require.NoError(t, m.UpdateTable(db.ID, baseTblInfo))
+		require.NoError(t, m.UpdateTable(db.ID, mlogTblInfo))
+		require.NoError(t, m.UpdateTable(db.ID, mviewTblInfo))
+		return nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, dom.Reload())
+
+	tk.MustQuery(`
+		select table_schema, mview_name, refresh_method, refresh_start, refresh_interval
+		from information_schema.tidb_mviews
+		where table_schema='is_mview' and mview_name='mv1'`,
+	).Check(testkit.Rows("is_mview mv1 FAST 2026-01-02 03:04:05 300"))
+
+	tk.MustQuery(`
+		select base_table_schema, base_table_name, purge_method, purge_start, purge_interval
+		from information_schema.tidb_mlogs
+		where base_table_schema='is_mview' and base_table_name='t'`,
+	).Check(testkit.Rows("is_mview t IMMEDIATE 2026-01-02 03:04:05 600"))
+
+	// Ensure mlog columns list is exposed.
+	tk.MustQuery(`
+		select mlog_columns
+		from information_schema.tidb_mlogs
+		where base_table_schema='is_mview' and base_table_name='t'`,
+	).Check(testkit.Rows("a"))
+
+	// The MVIEW_ID/MLOG_ID should match the underlying physical table IDs.
+	rows := tk.MustQuery("select mview_id from information_schema.tidb_mviews where table_schema='is_mview' and mview_name='mv1'").Rows()
+	require.Len(t, rows, 1)
+	require.Equal(t, fmt.Sprint(mviewID), fmt.Sprint(rows[0][0]))
+	rows = tk.MustQuery("select mlog_id from information_schema.tidb_mlogs where table_schema='is_mview' and mlog_name='$mlog$t'").Rows()
+	require.Len(t, rows, 1)
+	require.Equal(t, fmt.Sprint(mlogID), fmt.Sprint(rows[0][0]))
+}
+
+func TestInfoSchemaTiDBMViewsAndMLogsPrivilegeFilteringBySchema(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set time_zone='+00:00'")
+
+	// db1 objects
+	tk.MustExec("create database is_mview_priv1")
+	tk.MustExec("use is_mview_priv1")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("create table `$mlog$t` (a int)")
+	tk.MustExec("create table mv1 (a int)")
+
+	// db2 objects
+	tk.MustExec("create database is_mview_priv2")
+	tk.MustExec("use is_mview_priv2")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("create table `$mlog$t` (a int)")
+	tk.MustExec("create table mv2 (a int)")
+
+	is := dom.InfoSchema()
+	db1, ok := is.SchemaByName(pmodel.NewCIStr("is_mview_priv1"))
+	require.True(t, ok)
+	db2, ok := is.SchemaByName(pmodel.NewCIStr("is_mview_priv2"))
+	require.True(t, ok)
+
+	base1, err := is.TableByName(context.Background(), pmodel.NewCIStr("is_mview_priv1"), pmodel.NewCIStr("t"))
+	require.NoError(t, err)
+	mlog1, err := is.TableByName(context.Background(), pmodel.NewCIStr("is_mview_priv1"), pmodel.NewCIStr("$mlog$t"))
+	require.NoError(t, err)
+	mv1, err := is.TableByName(context.Background(), pmodel.NewCIStr("is_mview_priv1"), pmodel.NewCIStr("mv1"))
+	require.NoError(t, err)
+
+	base2, err := is.TableByName(context.Background(), pmodel.NewCIStr("is_mview_priv2"), pmodel.NewCIStr("t"))
+	require.NoError(t, err)
+	mlog2, err := is.TableByName(context.Background(), pmodel.NewCIStr("is_mview_priv2"), pmodel.NewCIStr("$mlog$t"))
+	require.NoError(t, err)
+	mv2, err := is.TableByName(context.Background(), pmodel.NewCIStr("is_mview_priv2"), pmodel.NewCIStr("mv2"))
+	require.NoError(t, err)
+
+	base1Info := base1.Meta().Clone()
+	base1Info.MaterializedViewBase = &model.MaterializedViewBaseInfo{MLogID: mlog1.Meta().ID, MViewIDs: []int64{mv1.Meta().ID}}
+	mlog1Info := mlog1.Meta().Clone()
+	mlog1Info.MaterializedViewLog = &model.MaterializedViewLogInfo{BaseTableID: base1.Meta().ID, Columns: []pmodel.CIStr{pmodel.NewCIStr("a")}, PurgeMethod: "IMMEDIATE"}
+	mv1Info := mv1.Meta().Clone()
+	mv1Info.MaterializedView = &model.MaterializedViewInfo{BaseTableIDs: []int64{base1.Meta().ID}, SQLContent: "select 1", RefreshMethod: "FAST"}
+
+	base2Info := base2.Meta().Clone()
+	base2Info.MaterializedViewBase = &model.MaterializedViewBaseInfo{MLogID: mlog2.Meta().ID, MViewIDs: []int64{mv2.Meta().ID}}
+	mlog2Info := mlog2.Meta().Clone()
+	mlog2Info.MaterializedViewLog = &model.MaterializedViewLogInfo{BaseTableID: base2.Meta().ID, Columns: []pmodel.CIStr{pmodel.NewCIStr("a")}, PurgeMethod: "IMMEDIATE"}
+	mv2Info := mv2.Meta().Clone()
+	mv2Info.MaterializedView = &model.MaterializedViewInfo{BaseTableIDs: []int64{base2.Meta().ID}, SQLContent: "select 1", RefreshMethod: "FAST"}
+
+	err = kv.RunInNewTxn(kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL), store, false, func(ctx context.Context, txn kv.Transaction) error {
+		m := meta.NewMutator(txn)
+		_, err := m.GenSchemaVersion()
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateTable(db1.ID, base1Info))
+		require.NoError(t, m.UpdateTable(db1.ID, mlog1Info))
+		require.NoError(t, m.UpdateTable(db1.ID, mv1Info))
+
+		require.NoError(t, m.UpdateTable(db2.ID, base2Info))
+		require.NoError(t, m.UpdateTable(db2.ID, mlog2Info))
+		require.NoError(t, m.UpdateTable(db2.ID, mv2Info))
+		return nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, dom.Reload())
+
+	tk.MustExec("create user 'mv_priv_u1'@'%'")
+	tk.MustExec("grant select on is_mview_priv1.* to 'mv_priv_u1'@'%'")
+
+	tkUser := testkit.NewTestKit(t, store)
+	require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "mv_priv_u1", Hostname: "%"}, nil, nil, nil))
+
+	tkUser.MustQuery("select table_schema, mview_name from information_schema.tidb_mviews order by table_schema, mview_name").
+		Check(testkit.Rows("is_mview_priv1 mv1"))
+	tkUser.MustQuery("select base_table_schema, base_table_name from information_schema.tidb_mlogs order by base_table_schema, base_table_name").
+		Check(testkit.Rows("is_mview_priv1 t"))
+}

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -219,6 +219,10 @@ const (
 	TableKeywords = "KEYWORDS"
 	// TableTiDBIndexUsage is a table to show the usage stats of indexes in the current instance.
 	TableTiDBIndexUsage = "TIDB_INDEX_USAGE"
+	// TableTiDBMViews is a table to show materialized view metadata.
+	TableTiDBMViews = "TIDB_MVIEWS"
+	// TableTiDBMLogs is a table to show materialized view log metadata.
+	TableTiDBMLogs = "TIDB_MLOGS"
 )
 
 const (
@@ -341,6 +345,8 @@ var tableIDMap = map[string]int64{
 	TableTiDBIndexUsage:                  autoid.InformationSchemaDBID + 93,
 	ClusterTableTiDBIndexUsage:           autoid.InformationSchemaDBID + 94,
 	TableTiFlashIndexes:                  autoid.InformationSchemaDBID + 95,
+	TableTiDBMViews:                      autoid.InformationSchemaDBID + 96,
+	TableTiDBMLogs:                       autoid.InformationSchemaDBID + 97,
 }
 
 // columnInfo represents the basic column information of all kinds of INFORMATION_SCHEMA tables
@@ -1740,6 +1746,34 @@ var tableTiDBIndexUsage = []columnInfo{
 	{name: "LAST_ACCESS_TIME", tp: mysql.TypeDatetime, size: 21},
 }
 
+var tableTiDBMViewsCols = []columnInfo{
+	{name: "TABLE_CATALOG", tp: mysql.TypeVarchar, size: 512, flag: mysql.NotNullFlag},
+	{name: "TABLE_SCHEMA", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag},
+	{name: "MVIEW_ID", tp: mysql.TypeLonglong, size: 21, flag: mysql.NotNullFlag},
+	{name: "MVIEW_NAME", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag},
+	{name: "MVIEW_SQL_CONTENT", tp: mysql.TypeLongBlob, size: types.UnspecifiedLength, flag: mysql.NotNullFlag},
+	{name: "MVIEW_COMMENT", tp: mysql.TypeVarchar, size: 128},
+	{name: "MVIEW_MODIFY_TIME", tp: mysql.TypeDatetime, size: 21, flag: mysql.NotNullFlag},
+	{name: "REFRESH_METHOD", tp: mysql.TypeVarchar, size: 32},
+	{name: "REFRESH_START", tp: mysql.TypeDatetime, size: 21},
+	{name: "REFRESH_INTERVAL", tp: mysql.TypeLonglong, size: 21},
+}
+
+var tableTiDBMLogsCols = []columnInfo{
+	{name: "TABLE_CATALOG", tp: mysql.TypeVarchar, size: 512, flag: mysql.NotNullFlag},
+	{name: "TABLE_SCHEMA", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag},
+	{name: "MLOG_ID", tp: mysql.TypeLonglong, size: 21, flag: mysql.NotNullFlag},
+	{name: "MLOG_NAME", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag},
+	{name: "MLOG_COLUMNS", tp: mysql.TypeLongBlob, size: types.UnspecifiedLength, flag: mysql.NotNullFlag},
+	{name: "BASE_TABLE_CATALOG", tp: mysql.TypeVarchar, size: 512, flag: mysql.NotNullFlag},
+	{name: "BASE_TABLE_SCHEMA", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag},
+	{name: "BASE_TABLE_ID", tp: mysql.TypeLonglong, size: 21, flag: mysql.NotNullFlag},
+	{name: "BASE_TABLE_NAME", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag},
+	{name: "PURGE_METHOD", tp: mysql.TypeVarchar, size: 32},
+	{name: "PURGE_START", tp: mysql.TypeDatetime, size: 21},
+	{name: "PURGE_INTERVAL", tp: mysql.TypeLonglong, size: 21},
+}
+
 // GetShardingInfo returns a nil or description string for the sharding information of given TableInfo.
 // The returned description string may be:
 //   - "NOT_SHARDED": for tables that SHARD_ROW_ID_BITS is not specified.
@@ -2387,6 +2421,8 @@ var tableNameToColumns = map[string][]columnInfo{
 	TableTiDBCheckConstraints:               tableTiDBCheckConstraintsCols,
 	TableKeywords:                           tableKeywords,
 	TableTiDBIndexUsage:                     tableTiDBIndexUsage,
+	TableTiDBMViews:                         tableTiDBMViewsCols,
+	TableTiDBMLogs:                          tableTiDBMLogsCols,
 }
 
 func createInfoSchemaTable(_ autoid.Allocators, _ func() (pools.Resource, error), meta *model.TableInfo) (table.Table, error) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023, ref #65936

Problem Summary:
Split from the original large MV PR, this PR adds read-only `information_schema` visibility for materialized views and materialized view logs.

### What changed and how does it work?

- Add `information_schema.tidb_mviews` and `information_schema.tidb_mlogs` memtable definitions.
- Populate rows from MV/MLOG metadata stored in `TableInfo`.
- Apply schema-level privilege filtering when reading these two memtables.
- Add DDL executor tests for:
  - basic visibility of MV/MLOG metadata in `information_schema`
  - privilege-based row filtering across schemas

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test command:
- `go test -tags=intest ./pkg/executor/test/ddl -run "TestInfoSchemaTiDBMViewsAndMLogs(Basic|PrivilegeFilteringBySchema)" -count=1`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
