### PR TITLE
br: ensure schemaLease is the normal (45s) instead of test value (1s)

### DIFF
--- a/br/pkg/gluetidb/BUILD.bazel
+++ b/br/pkg/gluetidb/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/session",
         "//pkg/session/sessionapi",
         "//pkg/sessionctx",
+        "//pkg/sessionctx/vardef",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_log//:log",
         "@com_github_tikv_pd_client//:client",

--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -41,11 +41,13 @@ const brComment = `/*from(br)*/`
 // New makes a new tidb glue.
 func New() Glue {
 	log.Debug("enabling no register config")
+	// Set schema lease to production value (45s) instead of test default (1s)
+	// to prevent BR from getting stuck when PD TSO slightly lags wall clock.
+	vardef.SetSchemaLease(config.DefSchemaLease)
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.SkipRegisterToDashboard = true
 		conf.Log.EnableSlowLog.Store(false)
 		conf.TiKVClient.CoprReqTimeout = 1800 * time.Second
-		vardef.SetSchemaLease(config.DefSchemaLease)
 	})
 	return Glue{
 		startDomainMu: &sync.Mutex{},

--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/zap"
 )
@@ -44,6 +45,7 @@ func New() Glue {
 		conf.SkipRegisterToDashboard = true
 		conf.Log.EnableSlowLog.Store(false)
 		conf.TiKVClient.CoprReqTimeout = 1800 * time.Second
+		vardef.SetSchemaLease(config.DefSchemaLease)
 	})
 	return Glue{
 		startDomainMu: &sync.Mutex{},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66110

Problem Summary: Without calling `session.SetSchemaLease`, BR will use the default schema lease duration of 1s which is only intended for testing, not production. When the PD TSO somehow lags the BR wall clock by over 0.5s (1/2 of schemaLease) it will not be able to leave the schema reload loop. 

### What changed and how does it work?

Call `session.SetSchemaLease` with the default lease (45s) when the glue is initialized, which is invoked on start-up for standalone BR.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

* The customer which encountered this bug can successfully perform `br restore point` after applying this fix.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed a bug in PiTR which caused it to be stuck at `Waiting for schema info finishes reloading` for 15 minutes and fail.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the default schema lease applied at startup to use the production value earlier in initialization. This reduces intermittent stalls or delays when external time services lag, yielding more reliable database startup and more consistent readiness for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->