### PR TITLE
planner, executor: support merge sort for IN conditions in IndexMerge…

### DIFF
--- a/pkg/executor/test/indexmergereadtest/BUILD.bazel
+++ b/pkg/executor/test/indexmergereadtest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 19,
+    shard_count = 20,
     deps = [
         "//pkg/config",
         "//pkg/executor",

--- a/pkg/executor/test/indexmergereadtest/index_merge_reader_test.go
+++ b/pkg/executor/test/indexmergereadtest/index_merge_reader_test.go
@@ -905,9 +905,6 @@ func TestOrderByWithLimitForINConditions(t *testing.T) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b int, c int, index idx_ac(a, c), index idx_bc(b, c))")
 
-	// Analyze before insert to speed up UT.
-	tk.MustExec("analyze table t")
-
 	valueSlice := make([]*valueStruct, 0, 500)
 	vals := make([]string, 0, 500)
 	for range 500 {

--- a/pkg/planner/core/operator/physicalop/physical_index_scan.go
+++ b/pkg/planner/core/operator/physicalop/physical_index_scan.go
@@ -295,6 +295,9 @@ func (p *PhysicalIndexScan) OperatorInfo(normalized bool) string {
 	}
 	buffer.WriteString("keep order:")
 	buffer.WriteString(strconv.FormatBool(p.KeepOrder))
+	if len(p.GroupedRanges) > 0 {
+		buffer.WriteString(", sort-merge:true")
+	}
 	if p.Desc {
 		buffer.WriteString(", desc")
 	}

--- a/pkg/planner/core/operator/physicalop/physical_table_scan.go
+++ b/pkg/planner/core/operator/physicalop/physical_table_scan.go
@@ -481,6 +481,9 @@ func (p *PhysicalTableScan) OperatorInfo(normalized bool) string {
 	}
 	buffer.WriteString("keep order:")
 	buffer.WriteString(strconv.FormatBool(p.KeepOrder))
+	if len(p.GroupedRanges) > 0 {
+		buffer.WriteString(", sort-merge:true")
+	}
 	if p.Desc {
 		buffer.WriteString(", desc")
 	}

--- a/tests/integrationtest/r/index_merge.result
+++ b/tests/integrationtest/r/index_merge.result
@@ -898,7 +898,7 @@ IndexMerge	5.00	root		type: union, limit embedded(offset:0, count:5)
 ├─Limit(Build)	1.67	cop[tikv]		offset:0, count:5
 │ └─IndexRangeScan	1.67	cop[tikv]	table:t, index:idx_a_c(a, c)	range:[1,1], keep order:true, stats:pseudo
 ├─Limit(Build)	3.34	cop[tikv]		offset:0, count:5
-│ └─IndexRangeScan	3.34	cop[tikv]	table:t, index:idx_b_c(b, c)	range:[1,1], [2,2], keep order:true, stats:pseudo
+│ └─IndexRangeScan	3.34	cop[tikv]	table:t, index:idx_b_c(b, c)	range:[1,1], [2,2], keep order:true, sort-merge:true, stats:pseudo
 └─TableRowIDScan(Probe)	5.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a = 1 or b in (1,2) order by c limit 5;
 id	a	b	c	padding
@@ -912,9 +912,9 @@ explain format = 'brief' select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * fr
 id	estRows	task	access object	operator info
 IndexMerge	5.00	root		type: union, limit embedded(offset:0, count:5)
 ├─Limit(Build)	2.50	cop[tikv]		offset:0, count:5
-│ └─IndexRangeScan	2.50	cop[tikv]	table:t, index:idx_a_c(a, c)	range:[1,1], [2,2], keep order:true, stats:pseudo
+│ └─IndexRangeScan	2.50	cop[tikv]	table:t, index:idx_a_c(a, c)	range:[1,1], [2,2], keep order:true, sort-merge:true, stats:pseudo
 ├─Limit(Build)	2.50	cop[tikv]		offset:0, count:5
-│ └─IndexRangeScan	2.50	cop[tikv]	table:t, index:idx_b_c(b, c)	range:[1,1], [2,2], keep order:true, stats:pseudo
+│ └─IndexRangeScan	2.50	cop[tikv]	table:t, index:idx_b_c(b, c)	range:[1,1], [2,2], keep order:true, sort-merge:true, stats:pseudo
 └─TableRowIDScan(Probe)	5.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a in (1,2) or b in (1,2) order by c limit 5;
 id	a	b	c	padding
@@ -930,7 +930,7 @@ IndexMerge	5.00	root		type: union, limit embedded(offset:0, count:5)
 ├─Limit(Build)	1.67	cop[tikv]		offset:0, count:5
 │ └─IndexRangeScan	1.67	cop[tikv]	table:t, index:idx_a_c(a, c)	range:[1,1], keep order:true, desc, stats:pseudo
 ├─Limit(Build)	3.34	cop[tikv]		offset:0, count:5
-│ └─IndexRangeScan	3.34	cop[tikv]	table:t, index:idx_b_c(b, c)	range:[1,1], [2,2], keep order:true, desc, stats:pseudo
+│ └─IndexRangeScan	3.34	cop[tikv]	table:t, index:idx_b_c(b, c)	range:[1,1], [2,2], keep order:true, sort-merge:true, desc, stats:pseudo
 └─TableRowIDScan(Probe)	5.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a = 1 or b in (1,2) order by c desc limit 5;
 id	a	b	c	padding

--- a/tests/integrationtest/r/index_merge.result
+++ b/tests/integrationtest/r/index_merge.result
@@ -885,3 +885,75 @@ c1	c2	c3
 8	8	8
 9	9	9
 10	10	10
+///// IndexMerge with IN conditions and ORDER BY LIMIT (issue#65712)
+// This tests that IndexMerge can use keep order with merge sort for IN conditions in partial paths.
+drop table if exists t;
+create table t (id int not null, a int, b int, c int, padding varchar(100), primary key(id), key idx_a_c(a, c), key idx_b_c(b, c));
+insert into t values (1, 1, 1, 1, 'a'), (2, 1, 1, 2, 'b'), (3, 1, 2, 3, 'c'), (4, 2, 1, 4, 'd'), (5, 2, 2, 5, 'e');
+insert into t values (6, 1, 1, 6, 'f'), (7, 1, 2, 7, 'g'), (8, 2, 1, 8, 'h'), (9, 2, 2, 9, 'i'), (10, 3, 3, 10, 'j');
+// Case 1: a=1 can keep order directly, b in (1,2) needs merge sort
+explain format = 'brief' select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a = 1 or b in (1,2) order by c limit 5;
+id	estRows	task	access object	operator info
+IndexMerge	5.00	root		type: union, limit embedded(offset:0, count:5)
+├─Limit(Build)	1.67	cop[tikv]		offset:0, count:5
+│ └─IndexRangeScan	1.67	cop[tikv]	table:t, index:idx_a_c(a, c)	range:[1,1], keep order:true, stats:pseudo
+├─Limit(Build)	3.34	cop[tikv]		offset:0, count:5
+│ └─IndexRangeScan	3.34	cop[tikv]	table:t, index:idx_b_c(b, c)	range:[1,1], [2,2], keep order:true, stats:pseudo
+└─TableRowIDScan(Probe)	5.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a = 1 or b in (1,2) order by c limit 5;
+id	a	b	c	padding
+1	1	1	1	a
+2	1	1	2	b
+3	1	2	3	c
+4	2	1	4	d
+5	2	2	5	e
+// Case 2: Both partial paths need merge sort (IN conditions on both)
+explain format = 'brief' select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a in (1,2) or b in (1,2) order by c limit 5;
+id	estRows	task	access object	operator info
+IndexMerge	5.00	root		type: union, limit embedded(offset:0, count:5)
+├─Limit(Build)	2.50	cop[tikv]		offset:0, count:5
+│ └─IndexRangeScan	2.50	cop[tikv]	table:t, index:idx_a_c(a, c)	range:[1,1], [2,2], keep order:true, stats:pseudo
+├─Limit(Build)	2.50	cop[tikv]		offset:0, count:5
+│ └─IndexRangeScan	2.50	cop[tikv]	table:t, index:idx_b_c(b, c)	range:[1,1], [2,2], keep order:true, stats:pseudo
+└─TableRowIDScan(Probe)	5.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a in (1,2) or b in (1,2) order by c limit 5;
+id	a	b	c	padding
+1	1	1	1	a
+2	1	1	2	b
+3	1	2	3	c
+4	2	1	4	d
+5	2	2	5	e
+// Case 3: ORDER BY DESC with IN condition
+explain format = 'brief' select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a = 1 or b in (1,2) order by c desc limit 5;
+id	estRows	task	access object	operator info
+IndexMerge	5.00	root		type: union, limit embedded(offset:0, count:5)
+├─Limit(Build)	1.67	cop[tikv]		offset:0, count:5
+│ └─IndexRangeScan	1.67	cop[tikv]	table:t, index:idx_a_c(a, c)	range:[1,1], keep order:true, desc, stats:pseudo
+├─Limit(Build)	3.34	cop[tikv]		offset:0, count:5
+│ └─IndexRangeScan	3.34	cop[tikv]	table:t, index:idx_b_c(b, c)	range:[1,1], [2,2], keep order:true, desc, stats:pseudo
+└─TableRowIDScan(Probe)	5.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a = 1 or b in (1,2) order by c desc limit 5;
+id	a	b	c	padding
+9	2	2	9	i
+8	2	1	8	h
+7	1	2	7	g
+6	1	1	6	f
+5	2	2	5	e
+// Case 4: Verify correctness with more data
+insert into t select id+10, a, b, c+10, padding from t;
+insert into t select id+20, a, b, c+20, padding from t;
+select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a = 1 or b in (1,2) order by c limit 5;
+id	a	b	c	padding
+1	1	1	1	a
+2	1	1	2	b
+3	1	2	3	c
+4	2	1	4	d
+5	2	2	5	e
+select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a in (1,2) or b in (1,2) order by c limit 5;
+id	a	b	c	padding
+1	1	1	1	a
+2	1	1	2	b
+3	1	2	3	c
+4	2	1	4	d
+5	2	2	5	e
+drop table if exists t;

--- a/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
@@ -3771,7 +3771,7 @@ Projection	root		planner__core__casetest__physicalplantest__physical_plan.t.a, p
   ├─Limit(Build)	cop[tikv]		offset:0, count:2
   │ └─IndexRangeScan	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], keep order:true, stats:pseudo
   ├─Limit(Build)	cop[tikv]		offset:0, count:2
-  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], [2,2], [3,3], keep order:true, stats:pseudo
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], [2,2], [3,3], keep order:true, sort-merge:true, stats:pseudo
   └─TableRowIDScan(Probe)	cop[tikv]	table:t	keep order:false, stats:pseudo
 show warnings;
 Level	Code	Message
@@ -3780,7 +3780,7 @@ id	task	access object	operator info
 Projection	root		planner__core__casetest__physicalplantest__physical_plan.t.a, planner__core__casetest__physicalplantest__physical_plan.t.b, planner__core__casetest__physicalplantest__physical_plan.t.c
 └─IndexMerge	root		type: union, limit embedded(offset:0, count:2)
   ├─Limit(Build)	cop[tikv]		offset:0, count:2
-  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], [2,2], [3,3], keep order:true, stats:pseudo
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], [2,2], [3,3], keep order:true, sort-merge:true, stats:pseudo
   ├─Limit(Build)	cop[tikv]		offset:0, count:2
   │ └─IndexRangeScan	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], keep order:true, stats:pseudo
   └─TableRowIDScan(Probe)	cop[tikv]	table:t	keep order:false, stats:pseudo
@@ -3791,9 +3791,9 @@ id	task	access object	operator info
 Projection	root		planner__core__casetest__physicalplantest__physical_plan.t.a, planner__core__casetest__physicalplantest__physical_plan.t.b, planner__core__casetest__physicalplantest__physical_plan.t.c
 └─IndexMerge	root		type: union, limit embedded(offset:0, count:2)
   ├─Limit(Build)	cop[tikv]		offset:0, count:2
-  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], [2,2], [3,3], keep order:true, stats:pseudo
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], [2,2], [3,3], keep order:true, sort-merge:true, stats:pseudo
   ├─Limit(Build)	cop[tikv]		offset:0, count:2
-  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], [2,2], [3,3], keep order:true, stats:pseudo
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], [2,2], [3,3], keep order:true, sort-merge:true, stats:pseudo
   └─TableRowIDScan(Probe)	cop[tikv]	table:t	keep order:false, stats:pseudo
 show warnings;
 Level	Code	Message
@@ -3815,7 +3815,7 @@ Projection	root		planner__core__casetest__physicalplantest__physical_plan.t.a, p
   ├─Limit(Build)	cop[tikv]		offset:0, count:2
   │ └─IndexRangeScan	cop[tikv]	table:t, index:idx(a, c)	range:[1 2,1 2], keep order:true, stats:pseudo
   ├─Limit(Build)	cop[tikv]		offset:0, count:2
-  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], [2,2], [3,3], keep order:true, stats:pseudo
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], [2,2], [3,3], keep order:true, sort-merge:true, stats:pseudo
   └─TableRowIDScan(Probe)	cop[tikv]	table:t	keep order:false, stats:pseudo
 show warnings;
 Level	Code	Message

--- a/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
@@ -3766,32 +3766,35 @@ show warnings;
 Level	Code	Message
 explain format = 'plan_tree' select * from t where a = 1 or b in (1, 2, 3) order by c limit 2;
 id	task	access object	operator info
-TopN	root		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
-└─IndexMerge	root		type: union
-  ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], keep order:false, stats:pseudo
-  ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo
-  └─TopN(Probe)	cop[tikv]		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
-    └─TableRowIDScan	cop[tikv]	table:t	keep order:false, stats:pseudo
+Projection	root		planner__core__casetest__physicalplantest__physical_plan.t.a, planner__core__casetest__physicalplantest__physical_plan.t.b, planner__core__casetest__physicalplantest__physical_plan.t.c
+└─IndexMerge	root		type: union, limit embedded(offset:0, count:2)
+  ├─Limit(Build)	cop[tikv]		offset:0, count:2
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], keep order:true, stats:pseudo
+  ├─Limit(Build)	cop[tikv]		offset:0, count:2
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], [2,2], [3,3], keep order:true, stats:pseudo
+  └─TableRowIDScan(Probe)	cop[tikv]	table:t	keep order:false, stats:pseudo
 show warnings;
 Level	Code	Message
 explain format = 'plan_tree' select * from t where a in (1, 2, 3) or b = 1 order by c limit 2;
 id	task	access object	operator info
-TopN	root		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
-└─IndexMerge	root		type: union
-  ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo
-  ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], keep order:false, stats:pseudo
-  └─TopN(Probe)	cop[tikv]		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
-    └─TableRowIDScan	cop[tikv]	table:t	keep order:false, stats:pseudo
+Projection	root		planner__core__casetest__physicalplantest__physical_plan.t.a, planner__core__casetest__physicalplantest__physical_plan.t.b, planner__core__casetest__physicalplantest__physical_plan.t.c
+└─IndexMerge	root		type: union, limit embedded(offset:0, count:2)
+  ├─Limit(Build)	cop[tikv]		offset:0, count:2
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], [2,2], [3,3], keep order:true, stats:pseudo
+  ├─Limit(Build)	cop[tikv]		offset:0, count:2
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], keep order:true, stats:pseudo
+  └─TableRowIDScan(Probe)	cop[tikv]	table:t	keep order:false, stats:pseudo
 show warnings;
 Level	Code	Message
 explain format = 'plan_tree' select * from t where a in (1, 2, 3) or b in (1, 2, 3) order by c limit 2;
 id	task	access object	operator info
-TopN	root		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
-└─IndexMerge	root		type: union
-  ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo
-  ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo
-  └─TopN(Probe)	cop[tikv]		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
-    └─TableRowIDScan	cop[tikv]	table:t	keep order:false, stats:pseudo
+Projection	root		planner__core__casetest__physicalplantest__physical_plan.t.a, planner__core__casetest__physicalplantest__physical_plan.t.b, planner__core__casetest__physicalplantest__physical_plan.t.c
+└─IndexMerge	root		type: union, limit embedded(offset:0, count:2)
+  ├─Limit(Build)	cop[tikv]		offset:0, count:2
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], [2,2], [3,3], keep order:true, stats:pseudo
+  ├─Limit(Build)	cop[tikv]		offset:0, count:2
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], [2,2], [3,3], keep order:true, stats:pseudo
+  └─TableRowIDScan(Probe)	cop[tikv]	table:t	keep order:false, stats:pseudo
 show warnings;
 Level	Code	Message
 explain format = 'plan_tree' select * from t where (a = 1 and c = 2) or (b = 1) order by c limit 2;
@@ -3807,12 +3810,13 @@ show warnings;
 Level	Code	Message
 explain format = 'plan_tree' select * from t where (a = 1 and c = 2) or b in (1, 2, 3) order by c limit 2;
 id	task	access object	operator info
-TopN	root		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
-└─IndexMerge	root		type: union
-  ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx(a, c)	range:[1 2,1 2], keep order:false, stats:pseudo
-  ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo
-  └─TopN(Probe)	cop[tikv]		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
-    └─TableRowIDScan	cop[tikv]	table:t	keep order:false, stats:pseudo
+Projection	root		planner__core__casetest__physicalplantest__physical_plan.t.a, planner__core__casetest__physicalplantest__physical_plan.t.b, planner__core__casetest__physicalplantest__physical_plan.t.c
+└─IndexMerge	root		type: union, limit embedded(offset:0, count:2)
+  ├─Limit(Build)	cop[tikv]		offset:0, count:2
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx(a, c)	range:[1 2,1 2], keep order:true, stats:pseudo
+  ├─Limit(Build)	cop[tikv]		offset:0, count:2
+  │ └─IndexRangeScan	cop[tikv]	table:t, index:idx2(b, c)	range:[1,1], [2,2], [3,3], keep order:true, stats:pseudo
+  └─TableRowIDScan(Probe)	cop[tikv]	table:t	keep order:false, stats:pseudo
 show warnings;
 Level	Code	Message
 explain format = 'plan_tree' select * from t where (a = 1 and c = 2) or (b in (1, 2, 3) and c = 3) order by c limit 2;

--- a/tests/integrationtest/r/planner/core/grouped_ranges_order_by.result
+++ b/tests/integrationtest/r/planner/core/grouped_ranges_order_by.result
@@ -82,7 +82,7 @@ id	estRows	task	access object	operator info
 TableReader	1.00	root		data:Projection
 └─Projection	1.00	cop[tikv]		planner__core__grouped_ranges_order_by.t.a, planner__core__grouped_ranges_order_by.t.c
   └─Selection	1.00	cop[tikv]		gt(planner__core__grouped_ranges_order_by.t.d, 100)
-    └─TableRangeScan	1.25	cop[tikv]	table:t	range:[3 1,3 1], [3 3,3 3], [3 5,3 5], keep order:true, stats:pseudo
+    └─TableRangeScan	1.25	cop[tikv]	table:t	range:[3 1,3 1], [3 3,3 3], [3 5,3 5], keep order:true, sort-merge:true, stats:pseudo
 select a,c from t where a = 3 and b in (1, 3, 5) and d > 100 order by c;
 a	c
 3	1
@@ -102,7 +102,7 @@ id	estRows	task	access object	operator info
 TableReader	1.00	root		data:Projection
 └─Projection	1.00	cop[tikv]		planner__core__grouped_ranges_order_by.t.c
   └─Selection	1.00	cop[tikv]		lt(planner__core__grouped_ranges_order_by.t.d, 200)
-    └─TableRangeScan	1.25	cop[tikv]	table:t	range:[1 1,1 1], [1 3,1 3], [1 5,1 5], keep order:true, stats:pseudo
+    └─TableRangeScan	1.25	cop[tikv]	table:t	range:[1 1,1 1], [1 3,1 3], [1 5,1 5], keep order:true, sort-merge:true, stats:pseudo
 select c from t where a = 1 and b in (1, 3, 5) and d < 200 order by c;
 c
 1
@@ -139,7 +139,7 @@ id	estRows	task	access object	operator info
 Projection	1.00	root		planner__core__grouped_ranges_order_by.t2.c
 └─Projection	1.00	root		planner__core__grouped_ranges_order_by.t2.a, planner__core__grouped_ranges_order_by.t2.b, planner__core__grouped_ranges_order_by.t2.c, planner__core__grouped_ranges_order_by.t2.d
   └─IndexLookUp	1.00	root		
-    ├─IndexRangeScan(Build)	1.25	cop[tikv]	table:t2, index:iabc(a, b, c)	range:[1 1,1 1], [1 3,1 3], [3 1,3 1], [3 3,3 3], keep order:true, stats:pseudo
+    ├─IndexRangeScan(Build)	1.25	cop[tikv]	table:t2, index:iabc(a, b, c)	range:[1 1,1 1], [1 3,1 3], [3 1,3 1], [3 3,3 3], keep order:true, sort-merge:true, stats:pseudo
     └─Selection(Probe)	1.00	cop[tikv]		lt(planner__core__grouped_ranges_order_by.t2.d, 150)
       └─TableRowIDScan	1.25	cop[tikv]	table:t2	keep order:false, stats:pseudo
 select c from t2 where a in (1, 3) and b in (1, 3) and d < 150 order by c;
@@ -156,7 +156,7 @@ explain format = 'brief' select /*+ order_index(t2,iabc) */ a,c from t2 where a 
 id	estRows	task	access object	operator info
 IndexReader	1.00	root		index:Projection
 └─Projection	1.00	cop[tikv]		planner__core__grouped_ranges_order_by.t2.a, planner__core__grouped_ranges_order_by.t2.c
-  └─IndexRangeScan	1.25	cop[tikv]	table:t2, index:iabc(a, b, c)	range:[3 1,3 1], [3 3,3 3], [3 5,3 5], keep order:true, desc, stats:pseudo
+  └─IndexRangeScan	1.25	cop[tikv]	table:t2, index:iabc(a, b, c)	range:[3 1,3 1], [3 3,3 3], [3 5,3 5], keep order:true, sort-merge:true, desc, stats:pseudo
 select /*+ order_index(t2,iabc) */ a,c from t where a = 3 and b in (1, 3, 5) order by a desc, c desc;
 a	c
 3	10
@@ -176,7 +176,7 @@ id	estRows	task	access object	operator info
 Projection	1.00	root		planner__core__grouped_ranges_order_by.t2.a, planner__core__grouped_ranges_order_by.t2.c
 └─Projection	1.00	root		planner__core__grouped_ranges_order_by.t2.a, planner__core__grouped_ranges_order_by.t2.b, planner__core__grouped_ranges_order_by.t2.c, planner__core__grouped_ranges_order_by.t2.d
   └─IndexLookUp	1.00	root		
-    ├─IndexRangeScan(Build)	1.25	cop[tikv]	table:t2, index:iabc(a, b, c)	range:[2 1,2 1], [2 3,2 3], [2 5,2 5], keep order:true, desc, stats:pseudo
+    ├─IndexRangeScan(Build)	1.25	cop[tikv]	table:t2, index:iabc(a, b, c)	range:[2 1,2 1], [2 3,2 3], [2 5,2 5], keep order:true, sort-merge:true, desc, stats:pseudo
     └─Selection(Probe)	1.00	cop[tikv]		gt(planner__core__grouped_ranges_order_by.t2.d, 60)
       └─TableRowIDScan	1.25	cop[tikv]	table:t2	keep order:false, stats:pseudo
 select /*+ order_index(t2,iabc) */ a,c from t where a = 2 and b in (1, 3, 5) and d > 60 order by a desc, c desc;
@@ -278,7 +278,7 @@ explain format = 'brief' select a,d from tp where a in (1,4) and b in (1, 3, 5) 
 id	estRows	task	access object	operator info
 TableReader	1.00	root	partition:all	data:Projection
 └─Projection	1.00	cop[tikv]		planner__core__grouped_ranges_order_by.tp.a, planner__core__grouped_ranges_order_by.tp.d
-  └─TableRangeScan	1.25	cop[tikv]	table:tp	range:[1 1,1 1], [1 3,1 3], [1 5,1 5], [4 1,4 1], [4 3,4 3], [4 5,4 5], keep order:true, stats:pseudo
+  └─TableRangeScan	1.25	cop[tikv]	table:tp	range:[1 1,1 1], [1 3,1 3], [1 5,1 5], [4 1,4 1], [4 3,4 3], [4 5,4 5], keep order:true, sort-merge:true, stats:pseudo
 select a,d from tp where a in (1,4) and b in (1, 3, 5) order by a, d;
 a	d
 1	10
@@ -315,7 +315,7 @@ explain format = 'brief' select d from tp where a = 1 and b in (1, 3, 5) order b
 id	estRows	task	access object	operator info
 TableReader	1.00	root	partition:all	data:Projection
 └─Projection	1.00	cop[tikv]		planner__core__grouped_ranges_order_by.tp.d
-  └─TableRangeScan	1.25	cop[tikv]	table:tp	range:[1 1,1 1], [1 3,1 3], [1 5,1 5], keep order:true, stats:pseudo
+  └─TableRangeScan	1.25	cop[tikv]	table:tp	range:[1 1,1 1], [1 3,1 3], [1 5,1 5], keep order:true, sort-merge:true, stats:pseudo
 select d from tp where a = 1 and b in (1, 3, 5) order by d;
 d
 10
@@ -334,7 +334,7 @@ explain format = 'brief' select a,d from tp where a = 3 and b in (1, 3, 5) and d
 id	estRows	task	access object	operator info
 TableReader	1.00	root	partition:p0,p1	data:Projection
 └─Projection	1.00	cop[tikv]		planner__core__grouped_ranges_order_by.tp.a, planner__core__grouped_ranges_order_by.tp.d
-  └─TableRangeScan	1.25	cop[tikv]	table:tp	range:[3 1 -inf,3 1 200), [3 3 -inf,3 3 200), [3 5 -inf,3 5 200), keep order:true, stats:pseudo
+  └─TableRangeScan	1.25	cop[tikv]	table:tp	range:[3 1 -inf,3 1 200), [3 3 -inf,3 3 200), [3 5 -inf,3 5 200), keep order:true, sort-merge:true, stats:pseudo
 select a,d from tp where a = 3 and b in (1, 3, 5) and d < 200 order by a, d;
 a	d
 3	17
@@ -414,7 +414,7 @@ explain format = 'brief' select a,c from tp where a in (3,5) and b in (1, 3, 5) 
 id	estRows	task	access object	operator info
 IndexReader	1.00	root	partition:all	index:Projection
 └─Projection	1.00	cop[tikv]		planner__core__grouped_ranges_order_by.tp.a, planner__core__grouped_ranges_order_by.tp.c
-  └─IndexRangeScan	1.25	cop[tikv]	table:tp, index:iabc(a, b, c)	range:[3 1,3 1], [3 3,3 3], [3 5,3 5], [5 1,5 1], [5 3,5 3], [5 5,5 5], keep order:true, stats:pseudo
+  └─IndexRangeScan	1.25	cop[tikv]	table:tp, index:iabc(a, b, c)	range:[3 1,3 1], [3 3,3 3], [3 5,3 5], [5 1,5 1], [5 3,5 3], [5 5,5 5], keep order:true, sort-merge:true, stats:pseudo
 select a,c from tp where a in (3,5) and b in (1, 3, 5) order by a, c;
 a	c
 3	1
@@ -460,7 +460,7 @@ id	estRows	task	access object	operator info
 Projection	1.00	root		planner__core__grouped_ranges_order_by.tp.c
 └─Projection	1.00	root		planner__core__grouped_ranges_order_by.tp.a, planner__core__grouped_ranges_order_by.tp.b, planner__core__grouped_ranges_order_by.tp.c, planner__core__grouped_ranges_order_by.tp.d
   └─IndexLookUp	1.00	root	partition:p0,p1	
-    ├─IndexRangeScan(Build)	1.25	cop[tikv]	table:tp, index:iabc(a, b, c)	range:[1 1,1 1], [1 3,1 3], [1 5,1 5], keep order:true, stats:pseudo
+    ├─IndexRangeScan(Build)	1.25	cop[tikv]	table:tp, index:iabc(a, b, c)	range:[1 1,1 1], [1 3,1 3], [1 5,1 5], keep order:true, sort-merge:true, stats:pseudo
     └─Selection(Probe)	1.00	cop[tikv]		lt(planner__core__grouped_ranges_order_by.tp.d, 200)
       └─TableRowIDScan	1.25	cop[tikv]	table:tp	keep order:false, stats:pseudo
 select /*+ order_index(tp, iabc) */ c from tp where a = 1 and b in (1, 3, 5) and d < 200 order by c;
@@ -1060,7 +1060,7 @@ explain format = 'brief' select a,c from t2 where a in (3, null, 4) and b in (1,
 id	estRows	task	access object	operator info
 IndexReader	1.00	root		index:Projection
 └─Projection	1.00	cop[tikv]		planner__core__grouped_ranges_order_by.t2.a, planner__core__grouped_ranges_order_by.t2.c
-  └─IndexRangeScan	1.25	cop[tikv]	table:t2, index:iabc(a, b, c)	range:[3 1,3 1], [3 3,3 3], [4 1,4 1], [4 3,4 3], keep order:true, stats:pseudo
+  └─IndexRangeScan	1.25	cop[tikv]	table:t2, index:iabc(a, b, c)	range:[3 1,3 1], [3 3,3 3], [4 1,4 1], [4 3,4 3], keep order:true, sort-merge:true, stats:pseudo
 select a,c from t2 where a in (3, null, 4) and b in (1, 3, null) order by a, c;
 a	c
 3	1
@@ -1083,14 +1083,14 @@ explain format = 'brief' select * from t where a in (10,20,30,40,50) and b in (1
 id	estRows	task	access object	operator info
 Projection	2.00	root		planner__core__grouped_ranges_order_by.t.a, planner__core__grouped_ranges_order_by.t.b, planner__core__grouped_ranges_order_by.t.c, planner__core__grouped_ranges_order_by.t.d
 └─IndexLookUp	2.00	root		
-  ├─IndexRangeScan(Build)	6.00	cop[tikv]	table:t, index:iabc(a, b, c)	range:[10 1,10 1], [10 3,10 3], [10 5,10 5], [10 11,10 11], [10 13,10 13], [10 15,10 15], [10 21,10 21], [10 23,10 23], [10 25,10 25], [10 31,10 31], [10 33,10 33], [10 35,10 35], [20 1,20 1], [20 3,20 3], [20 5,20 5], [20 11,20 11], [20 13,20 13], [20 15,20 15], [20 21,20 21], [20 23,20 23], [20 25,20 25], [20 31,20 31], [20 33,20 33], [20 35,20 35], [30 1,30 1], [30 3,30 3], [30 5,30 5], [30 11,30 11], [30 13,30 13], [30 15,30 15], [30 21,30 21], [30 23,30 23], [30 25,30 25], [30 31,30 31], [30 33,30 33], [30 35,30 35], [40 1,40 1], [40 3,40 3], [40 5,40 5], [40 11,40 11], [40 13,40 13], [40 15,40 15], [40 21,40 21], [40 23,40 23], [40 25,40 25], [40 31,40 31], [40 33,40 33], [40 35,40 35], [50 1,50 1], [50 3,50 3], [50 5,50 5], [50 11,50 11], [50 13,50 13], [50 15,50 15], [50 21,50 21], [50 23,50 23], [50 25,50 25], [50 31,50 31], [50 33,50 33], [50 35,50 35], keep order:true, stats:pseudo
+  ├─IndexRangeScan(Build)	6.00	cop[tikv]	table:t, index:iabc(a, b, c)	range:[10 1,10 1], [10 3,10 3], [10 5,10 5], [10 11,10 11], [10 13,10 13], [10 15,10 15], [10 21,10 21], [10 23,10 23], [10 25,10 25], [10 31,10 31], [10 33,10 33], [10 35,10 35], [20 1,20 1], [20 3,20 3], [20 5,20 5], [20 11,20 11], [20 13,20 13], [20 15,20 15], [20 21,20 21], [20 23,20 23], [20 25,20 25], [20 31,20 31], [20 33,20 33], [20 35,20 35], [30 1,30 1], [30 3,30 3], [30 5,30 5], [30 11,30 11], [30 13,30 13], [30 15,30 15], [30 21,30 21], [30 23,30 23], [30 25,30 25], [30 31,30 31], [30 33,30 33], [30 35,30 35], [40 1,40 1], [40 3,40 3], [40 5,40 5], [40 11,40 11], [40 13,40 13], [40 15,40 15], [40 21,40 21], [40 23,40 23], [40 25,40 25], [40 31,40 31], [40 33,40 33], [40 35,40 35], [50 1,50 1], [50 3,50 3], [50 5,50 5], [50 11,50 11], [50 13,50 13], [50 15,50 15], [50 21,50 21], [50 23,50 23], [50 25,50 25], [50 31,50 31], [50 33,50 33], [50 35,50 35], keep order:true, sort-merge:true, stats:pseudo
   └─Selection(Probe)	2.00	cop[tikv]		gt(planner__core__grouped_ranges_order_by.t.d, 100)
     └─TableRowIDScan	6.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select b,c from t where a in (10,20,30,40,50) and b in (1, 3, 5, 11, 13, 15, 21, 23, 25, 31, 33, 35) and c > 1 order by b, c;
 id	estRows	task	access object	operator info
 IndexReader	20.00	root		index:Projection
 └─Projection	20.00	cop[tikv]		planner__core__grouped_ranges_order_by.t.b, planner__core__grouped_ranges_order_by.t.c
-  └─IndexRangeScan	20.00	cop[tikv]	table:t, index:iabc(a, b, c)	range:(10 1 1,10 1 +inf], (10 3 1,10 3 +inf], (10 5 1,10 5 +inf], (10 11 1,10 11 +inf], (10 13 1,10 13 +inf], (10 15 1,10 15 +inf], (10 21 1,10 21 +inf], (10 23 1,10 23 +inf], (10 25 1,10 25 +inf], (10 31 1,10 31 +inf], (10 33 1,10 33 +inf], (10 35 1,10 35 +inf], (20 1 1,20 1 +inf], (20 3 1,20 3 +inf], (20 5 1,20 5 +inf], (20 11 1,20 11 +inf], (20 13 1,20 13 +inf], (20 15 1,20 15 +inf], (20 21 1,20 21 +inf], (20 23 1,20 23 +inf], (20 25 1,20 25 +inf], (20 31 1,20 31 +inf], (20 33 1,20 33 +inf], (20 35 1,20 35 +inf], (30 1 1,30 1 +inf], (30 3 1,30 3 +inf], (30 5 1,30 5 +inf], (30 11 1,30 11 +inf], (30 13 1,30 13 +inf], (30 15 1,30 15 +inf], (30 21 1,30 21 +inf], (30 23 1,30 23 +inf], (30 25 1,30 25 +inf], (30 31 1,30 31 +inf], (30 33 1,30 33 +inf], (30 35 1,30 35 +inf], (40 1 1,40 1 +inf], (40 3 1,40 3 +inf], (40 5 1,40 5 +inf], (40 11 1,40 11 +inf], (40 13 1,40 13 +inf], (40 15 1,40 15 +inf], (40 21 1,40 21 +inf], (40 23 1,40 23 +inf], (40 25 1,40 25 +inf], (40 31 1,40 31 +inf], (40 33 1,40 33 +inf], (40 35 1,40 35 +inf], (50 1 1,50 1 +inf], (50 3 1,50 3 +inf], (50 5 1,50 5 +inf], (50 11 1,50 11 +inf], (50 13 1,50 13 +inf], (50 15 1,50 15 +inf], (50 21 1,50 21 +inf], (50 23 1,50 23 +inf], (50 25 1,50 25 +inf], (50 31 1,50 31 +inf], (50 33 1,50 33 +inf], (50 35 1,50 35 +inf], keep order:true, stats:pseudo
+  └─IndexRangeScan	20.00	cop[tikv]	table:t, index:iabc(a, b, c)	range:(10 1 1,10 1 +inf], (10 3 1,10 3 +inf], (10 5 1,10 5 +inf], (10 11 1,10 11 +inf], (10 13 1,10 13 +inf], (10 15 1,10 15 +inf], (10 21 1,10 21 +inf], (10 23 1,10 23 +inf], (10 25 1,10 25 +inf], (10 31 1,10 31 +inf], (10 33 1,10 33 +inf], (10 35 1,10 35 +inf], (20 1 1,20 1 +inf], (20 3 1,20 3 +inf], (20 5 1,20 5 +inf], (20 11 1,20 11 +inf], (20 13 1,20 13 +inf], (20 15 1,20 15 +inf], (20 21 1,20 21 +inf], (20 23 1,20 23 +inf], (20 25 1,20 25 +inf], (20 31 1,20 31 +inf], (20 33 1,20 33 +inf], (20 35 1,20 35 +inf], (30 1 1,30 1 +inf], (30 3 1,30 3 +inf], (30 5 1,30 5 +inf], (30 11 1,30 11 +inf], (30 13 1,30 13 +inf], (30 15 1,30 15 +inf], (30 21 1,30 21 +inf], (30 23 1,30 23 +inf], (30 25 1,30 25 +inf], (30 31 1,30 31 +inf], (30 33 1,30 33 +inf], (30 35 1,30 35 +inf], (40 1 1,40 1 +inf], (40 3 1,40 3 +inf], (40 5 1,40 5 +inf], (40 11 1,40 11 +inf], (40 13 1,40 13 +inf], (40 15 1,40 15 +inf], (40 21 1,40 21 +inf], (40 23 1,40 23 +inf], (40 25 1,40 25 +inf], (40 31 1,40 31 +inf], (40 33 1,40 33 +inf], (40 35 1,40 35 +inf], (50 1 1,50 1 +inf], (50 3 1,50 3 +inf], (50 5 1,50 5 +inf], (50 11 1,50 11 +inf], (50 13 1,50 13 +inf], (50 15 1,50 15 +inf], (50 21 1,50 21 +inf], (50 23 1,50 23 +inf], (50 25 1,50 25 +inf], (50 31 1,50 31 +inf], (50 33 1,50 33 +inf], (50 35 1,50 35 +inf], keep order:true, sort-merge:true, stats:pseudo
 insert into t values
 (10, 35, 9, 230), (10, 31, 10, 240), (10, 23, 11, 250), (10, 35, 12, 260),
 (20, 13, 5, 190), (20, 15, 6, 200), (20, 21, 7, 210), (20, 23, 8, 220),
@@ -1107,7 +1107,7 @@ id	estRows	task	access object	operator info
 Projection	2.00	root		planner__core__grouped_ranges_order_by.t.a, planner__core__grouped_ranges_order_by.t.b, planner__core__grouped_ranges_order_by.t.c, planner__core__grouped_ranges_order_by.t.d
 └─UnionScan	2.00	root		gt(planner__core__grouped_ranges_order_by.t.d, 100), in(planner__core__grouped_ranges_order_by.t.a, 10, 20, 30, 40, 50), in(planner__core__grouped_ranges_order_by.t.b, 1, 3, 5, 11, 13, 15, 21, 23, 25, 31, 33, 35)
   └─IndexLookUp	2.00	root		
-    ├─IndexRangeScan(Build)	6.00	cop[tikv]	table:t, index:iabc(a, b, c)	range:[10 1,10 1], [10 3,10 3], [10 5,10 5], [10 11,10 11], [10 13,10 13], [10 15,10 15], [10 21,10 21], [10 23,10 23], [10 25,10 25], [10 31,10 31], [10 33,10 33], [10 35,10 35], [20 1,20 1], [20 3,20 3], [20 5,20 5], [20 11,20 11], [20 13,20 13], [20 15,20 15], [20 21,20 21], [20 23,20 23], [20 25,20 25], [20 31,20 31], [20 33,20 33], [20 35,20 35], [30 1,30 1], [30 3,30 3], [30 5,30 5], [30 11,30 11], [30 13,30 13], [30 15,30 15], [30 21,30 21], [30 23,30 23], [30 25,30 25], [30 31,30 31], [30 33,30 33], [30 35,30 35], [40 1,40 1], [40 3,40 3], [40 5,40 5], [40 11,40 11], [40 13,40 13], [40 15,40 15], [40 21,40 21], [40 23,40 23], [40 25,40 25], [40 31,40 31], [40 33,40 33], [40 35,40 35], [50 1,50 1], [50 3,50 3], [50 5,50 5], [50 11,50 11], [50 13,50 13], [50 15,50 15], [50 21,50 21], [50 23,50 23], [50 25,50 25], [50 31,50 31], [50 33,50 33], [50 35,50 35], keep order:true, stats:pseudo
+    ├─IndexRangeScan(Build)	6.00	cop[tikv]	table:t, index:iabc(a, b, c)	range:[10 1,10 1], [10 3,10 3], [10 5,10 5], [10 11,10 11], [10 13,10 13], [10 15,10 15], [10 21,10 21], [10 23,10 23], [10 25,10 25], [10 31,10 31], [10 33,10 33], [10 35,10 35], [20 1,20 1], [20 3,20 3], [20 5,20 5], [20 11,20 11], [20 13,20 13], [20 15,20 15], [20 21,20 21], [20 23,20 23], [20 25,20 25], [20 31,20 31], [20 33,20 33], [20 35,20 35], [30 1,30 1], [30 3,30 3], [30 5,30 5], [30 11,30 11], [30 13,30 13], [30 15,30 15], [30 21,30 21], [30 23,30 23], [30 25,30 25], [30 31,30 31], [30 33,30 33], [30 35,30 35], [40 1,40 1], [40 3,40 3], [40 5,40 5], [40 11,40 11], [40 13,40 13], [40 15,40 15], [40 21,40 21], [40 23,40 23], [40 25,40 25], [40 31,40 31], [40 33,40 33], [40 35,40 35], [50 1,50 1], [50 3,50 3], [50 5,50 5], [50 11,50 11], [50 13,50 13], [50 15,50 15], [50 21,50 21], [50 23,50 23], [50 25,50 25], [50 31,50 31], [50 33,50 33], [50 35,50 35], keep order:true, sort-merge:true, stats:pseudo
     └─Selection(Probe)	2.00	cop[tikv]		gt(planner__core__grouped_ranges_order_by.t.d, 100)
       └─TableRowIDScan	6.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select * from t where a in (10,20,30,40,50) and b in (1, 3, 5, 11, 13, 15, 21, 23, 25, 31, 33, 35) and d > 100 order by a, c;
@@ -1148,7 +1148,7 @@ id	estRows	task	access object	operator info
 Projection	20.00	root		planner__core__grouped_ranges_order_by.t.b, planner__core__grouped_ranges_order_by.t.c
 └─UnionScan	20.00	root		gt(planner__core__grouped_ranges_order_by.t.c, 1), in(planner__core__grouped_ranges_order_by.t.a, 10, 20, 30, 40, 50), in(planner__core__grouped_ranges_order_by.t.b, 1, 3, 5, 11, 13, 15, 21, 23, 25, 31, 33, 35)
   └─IndexReader	20.00	root		index:IndexRangeScan
-    └─IndexRangeScan	20.00	cop[tikv]	table:t, index:iabc(a, b, c)	range:(10 1 1,10 1 +inf], (10 3 1,10 3 +inf], (10 5 1,10 5 +inf], (10 11 1,10 11 +inf], (10 13 1,10 13 +inf], (10 15 1,10 15 +inf], (10 21 1,10 21 +inf], (10 23 1,10 23 +inf], (10 25 1,10 25 +inf], (10 31 1,10 31 +inf], (10 33 1,10 33 +inf], (10 35 1,10 35 +inf], (20 1 1,20 1 +inf], (20 3 1,20 3 +inf], (20 5 1,20 5 +inf], (20 11 1,20 11 +inf], (20 13 1,20 13 +inf], (20 15 1,20 15 +inf], (20 21 1,20 21 +inf], (20 23 1,20 23 +inf], (20 25 1,20 25 +inf], (20 31 1,20 31 +inf], (20 33 1,20 33 +inf], (20 35 1,20 35 +inf], (30 1 1,30 1 +inf], (30 3 1,30 3 +inf], (30 5 1,30 5 +inf], (30 11 1,30 11 +inf], (30 13 1,30 13 +inf], (30 15 1,30 15 +inf], (30 21 1,30 21 +inf], (30 23 1,30 23 +inf], (30 25 1,30 25 +inf], (30 31 1,30 31 +inf], (30 33 1,30 33 +inf], (30 35 1,30 35 +inf], (40 1 1,40 1 +inf], (40 3 1,40 3 +inf], (40 5 1,40 5 +inf], (40 11 1,40 11 +inf], (40 13 1,40 13 +inf], (40 15 1,40 15 +inf], (40 21 1,40 21 +inf], (40 23 1,40 23 +inf], (40 25 1,40 25 +inf], (40 31 1,40 31 +inf], (40 33 1,40 33 +inf], (40 35 1,40 35 +inf], (50 1 1,50 1 +inf], (50 3 1,50 3 +inf], (50 5 1,50 5 +inf], (50 11 1,50 11 +inf], (50 13 1,50 13 +inf], (50 15 1,50 15 +inf], (50 21 1,50 21 +inf], (50 23 1,50 23 +inf], (50 25 1,50 25 +inf], (50 31 1,50 31 +inf], (50 33 1,50 33 +inf], (50 35 1,50 35 +inf], keep order:true, stats:pseudo
+    └─IndexRangeScan	20.00	cop[tikv]	table:t, index:iabc(a, b, c)	range:(10 1 1,10 1 +inf], (10 3 1,10 3 +inf], (10 5 1,10 5 +inf], (10 11 1,10 11 +inf], (10 13 1,10 13 +inf], (10 15 1,10 15 +inf], (10 21 1,10 21 +inf], (10 23 1,10 23 +inf], (10 25 1,10 25 +inf], (10 31 1,10 31 +inf], (10 33 1,10 33 +inf], (10 35 1,10 35 +inf], (20 1 1,20 1 +inf], (20 3 1,20 3 +inf], (20 5 1,20 5 +inf], (20 11 1,20 11 +inf], (20 13 1,20 13 +inf], (20 15 1,20 15 +inf], (20 21 1,20 21 +inf], (20 23 1,20 23 +inf], (20 25 1,20 25 +inf], (20 31 1,20 31 +inf], (20 33 1,20 33 +inf], (20 35 1,20 35 +inf], (30 1 1,30 1 +inf], (30 3 1,30 3 +inf], (30 5 1,30 5 +inf], (30 11 1,30 11 +inf], (30 13 1,30 13 +inf], (30 15 1,30 15 +inf], (30 21 1,30 21 +inf], (30 23 1,30 23 +inf], (30 25 1,30 25 +inf], (30 31 1,30 31 +inf], (30 33 1,30 33 +inf], (30 35 1,30 35 +inf], (40 1 1,40 1 +inf], (40 3 1,40 3 +inf], (40 5 1,40 5 +inf], (40 11 1,40 11 +inf], (40 13 1,40 13 +inf], (40 15 1,40 15 +inf], (40 21 1,40 21 +inf], (40 23 1,40 23 +inf], (40 25 1,40 25 +inf], (40 31 1,40 31 +inf], (40 33 1,40 33 +inf], (40 35 1,40 35 +inf], (50 1 1,50 1 +inf], (50 3 1,50 3 +inf], (50 5 1,50 5 +inf], (50 11 1,50 11 +inf], (50 13 1,50 13 +inf], (50 15 1,50 15 +inf], (50 21 1,50 21 +inf], (50 23 1,50 23 +inf], (50 25 1,50 25 +inf], (50 31 1,50 31 +inf], (50 33 1,50 33 +inf], (50 35 1,50 35 +inf], keep order:true, sort-merge:true, stats:pseudo
 select b,c from t where a in (10,20,30,40,50) and b in (1, 3, 5, 11, 13, 15, 21, 23, 25, 31, 33, 35) and c > 1 order by b, c;
 b	c
 1	21
@@ -1262,7 +1262,7 @@ explain format = 'brief' select * from t3 where a in (1,2,3,4,5,6,7) and b > 1 o
 id	estRows	task	access object	operator info
 UnionScan	233.33	root		gt(planner__core__grouped_ranges_order_by.t3.b, 1), in(planner__core__grouped_ranges_order_by.t3.a, 1, 2, 3, 4, 5, 6, 7)
 └─TableReader	233.33	root		data:TableRangeScan
-  └─TableRangeScan	233.33	cop[tikv]	table:t3	range:(1 1,1 +inf], (2 1,2 +inf], (3 1,3 +inf], (4 1,4 +inf], (5 1,5 +inf], (6 1,6 +inf], (7 1,7 +inf], keep order:true, stats:pseudo
+  └─TableRangeScan	233.33	cop[tikv]	table:t3	range:(1 1,1 +inf], (2 1,2 +inf], (3 1,3 +inf], (4 1,4 +inf], (5 1,5 +inf], (6 1,6 +inf], (7 1,7 +inf], keep order:true, sort-merge:true, stats:pseudo
 select * from t3 where a in (1,2,3,4,5,6,7) and b > 1 order by b;
 a	b
 3	2

--- a/tests/integrationtest/t/index_merge.test
+++ b/tests/integrationtest/t/index_merge.test
@@ -238,3 +238,30 @@ with recursive cte1 as (select /*+ use_index_merge(t1) */ c1 from t1 where c1 < 
 explain format = 'plan_tree' with recursive cte1 as (select 1 c1, 1 c2, 1 c3 UNION ALL select /*+ use_index_merge(t_alias) */ c1 + 1, c2 + 1, c3 + 1 from cte1 t_alias where c1 < 10 or c2 < 10 and c3 < 10) select * from cte1 order by 1;
 show warnings;
 with recursive cte1 as (select 1 c1, 1 c2, 1 c3 UNION ALL select /*+ use_index_merge(t_alias) */ c1 + 1, c2 + 1, c3 + 1 from cte1 t_alias where c1 < 10 or c2 < 10 and c3 < 10) select * from cte1 order by 1;
+
+--echo ///// IndexMerge with IN conditions and ORDER BY LIMIT (issue#65712)
+--echo // This tests that IndexMerge can use keep order with merge sort for IN conditions in partial paths.
+drop table if exists t;
+create table t (id int not null, a int, b int, c int, padding varchar(100), primary key(id), key idx_a_c(a, c), key idx_b_c(b, c));
+insert into t values (1, 1, 1, 1, 'a'), (2, 1, 1, 2, 'b'), (3, 1, 2, 3, 'c'), (4, 2, 1, 4, 'd'), (5, 2, 2, 5, 'e');
+insert into t values (6, 1, 1, 6, 'f'), (7, 1, 2, 7, 'g'), (8, 2, 1, 8, 'h'), (9, 2, 2, 9, 'i'), (10, 3, 3, 10, 'j');
+
+--echo // Case 1: a=1 can keep order directly, b in (1,2) needs merge sort
+explain format = 'brief' select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a = 1 or b in (1,2) order by c limit 5;
+select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a = 1 or b in (1,2) order by c limit 5;
+
+--echo // Case 2: Both partial paths need merge sort (IN conditions on both)
+explain format = 'brief' select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a in (1,2) or b in (1,2) order by c limit 5;
+select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a in (1,2) or b in (1,2) order by c limit 5;
+
+--echo // Case 3: ORDER BY DESC with IN condition
+explain format = 'brief' select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a = 1 or b in (1,2) order by c desc limit 5;
+select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a = 1 or b in (1,2) order by c desc limit 5;
+
+--echo // Case 4: Verify correctness with more data
+insert into t select id+10, a, b, c+10, padding from t;
+insert into t select id+20, a, b, c+20, padding from t;
+select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a = 1 or b in (1,2) order by c limit 5;
+select /*+ use_index_merge(t, idx_a_c, idx_b_c) */ * from t where a in (1,2) or b in (1,2) order by c limit 5;
+
+drop table if exists t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65712

Problem Summary:

For queries like `SELECT * FROM t WHERE (a = 1 OR b IN (1,2)) ORDER BY c LIMIT 5`:
- The `a = 1` partial path can keep order → `matchProperty()` returns `PropMatched`
- The `b IN (1,2)` partial path needs merge sort → `matchProperty()` returns `PropMatchedNeedMergeSort`

Previously, `PropMatchedNeedMergeSort` was rejected for partial paths in IndexMerge, causing fallback to global TopN without Limit pushdown. This results in reading more rows than necessary.

### What changed and how does it work?

This PR extends IndexMerge to accept `PropMatchedNeedMergeSort` for partial paths by leveraging the merge sort infrastructure from PR #63449.

**Planner changes:**
- Modified `matchPropForIndexMergeAlternatives()` to accept both `PropMatched` and `PropMatchedNeedMergeSort` using the `.Matched()` method
- Copy `GroupedRanges` and `GroupByColIdxs` from AccessPath to PhysicalIndexScan in `ConvertToPartialIndexScan()`
- Similar changes in `convertToPartialTableScan()` for table scan paths

**Executor changes:**
- In `startPartialIndexWorker()`: Build separate key ranges for each group in `GroupedRanges` to enable merge sort
- In `startPartialTableWorker()`: Pass grouped ranges to TableReaderExecutor

**After this fix, the execution plan shows:**
```
IndexMerge  type: union, limit embedded(offset:0, count:5)
├─Limit(Build)  offset:0, count:5
│ └─IndexRangeScan  range:[1,1], keep order:true
├─Limit(Build)  offset:0, count:5
│ └─IndexRangeScan  range:[1,1], [2,2], keep order:true
└─TableRowIDScan(Probe)  keep order:false
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Improve IndexMerge performance with ORDER BY LIMIT when partial paths have IN conditions. Previously, queries like `SELECT * FROM t WHERE (a = 1 OR b IN (1,2)) ORDER BY c LIMIT 5` could not push Limit down to the IN condition path. Now merge sort is supported for IN conditions in IndexMerge partial paths, enabling Limit pushdown to all paths.
```