### PR TITLE
session: restore innodb_lock_wait_timeout for advisory locks

### DIFF
--- a/pkg/session/BUILD.bazel
+++ b/pkg/session/BUILD.bazel
@@ -165,7 +165,7 @@ go_test(
     embed = [":session"],
     flaky = True,
     race = "off",
-    shard_count = 47,
+    shard_count = 48,
     deps = [
         "//pkg/autoid_service",
         "//pkg/bindinfo",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66073

Problem Summary:
Advisory locks (GET_LOCK()/IS_USED_LOCK()) temporarily set `innodb_lock_wait_timeout` on a pooled internal session.
The value is not restored when the session is returned to `SysSessionPool`, which can pollute subsequent internal operations
that reuse the same session.

### What changed and how does it work?
- Save the original `innodb_lock_wait_timeout` before changing it, and restore it on `Close()`.
- If rollback or restore fails, destroy the internal session instead of returning it to the pool.
- Add regression tests to ensure both `@@innodb_lock_wait_timeout` and `SessionVars.LockWaitTimeout` are restored.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `make failpoint-enable && ( pushd pkg/session >/dev/null && go test -run TestAdvisoryLockRestoresInnodbLockWaitTimeout --tags=intest -count=1; rc=$?; popd >/dev/null; make failpoint-disable; exit $rc )`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix `GET_LOCK()` / `IS_USED_LOCK()` implementation to avoid leaking `innodb_lock_wait_timeout` into pooled internal sessions.
```
