### PR TITLE
planner: make cbotests ignore plan-id with explain format as brief

### DIFF
--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
@@ -272,7 +272,7 @@
   {
     "name": "TestIssue61792",
     "cases": [
-      "explain select * from tbl_cardcore_statement s where  s.latest_stmt_print_date = '2024-10-16';"
+      "explain format = 'brief' select * from tbl_cardcore_statement s where  s.latest_stmt_print_date = '2024-10-16';"
     ]
   },
   {

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
@@ -576,11 +576,11 @@
     "Name": "TestIssue61792",
     "Cases": [
       {
-        "SQL": "explain select * from tbl_cardcore_statement s where  s.latest_stmt_print_date = '2024-10-16';",
+        "SQL": "explain format = 'brief' select * from tbl_cardcore_statement s where  s.latest_stmt_print_date = '2024-10-16';",
         "Plan": [
-          "IndexLookUp_11 53778.89 root  ",
-          "├─IndexRangeScan_9(Build) 53778.89 cop[tikv] table:s, index:tbl_cardcore_statement_ix7(latest_stmt_print_date) range:[2024-10-16,2024-10-16], keep order:false",
-          "└─TableRowIDScan_10(Probe) 53778.89 cop[tikv] table:s keep order:false"
+          "IndexLookUp 53778.89 root  ",
+          "├─IndexRangeScan(Build) 53778.89 cop[tikv] table:s, index:tbl_cardcore_statement_ix7(latest_stmt_print_date) range:[2024-10-16,2024-10-16], keep order:false",
+          "└─TableRowIDScan(Probe) 53778.89 cop[tikv] table:s keep order:false"
         ],
         "Warn": null
       }

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_xut.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_xut.json
@@ -576,11 +576,11 @@
     "Name": "TestIssue61792",
     "Cases": [
       {
-        "SQL": "explain select * from tbl_cardcore_statement s where  s.latest_stmt_print_date = '2024-10-16';",
+        "SQL": "explain format = 'brief' select * from tbl_cardcore_statement s where  s.latest_stmt_print_date = '2024-10-16';",
         "Plan": [
-          "IndexLookUp_11 53778.89 root  ",
-          "├─IndexRangeScan_9(Build) 53778.89 cop[tikv] table:s, index:tbl_cardcore_statement_ix7(latest_stmt_print_date) range:[2024-10-16,2024-10-16], keep order:false",
-          "└─TableRowIDScan_10(Probe) 53778.89 cop[tikv] table:s keep order:false"
+          "IndexLookUp 53778.89 root  ",
+          "├─IndexRangeScan(Build) 53778.89 cop[tikv] table:s, index:tbl_cardcore_statement_ix7(latest_stmt_print_date) range:[2024-10-16,2024-10-16], keep order:false",
+          "└─TableRowIDScan(Probe) 53778.89 cop[tikv] table:s keep order:false"
         ],
         "Warn": null
       }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60940 

Problem Summary: Some explain-test cases will record the plan ID in the result file, which will be a burden when some optimization flow is changed, since plan ID allocation is sequential according to the allocation order or space.

### What changed and how does it work?
Made `TestIssue61792` of cbotest ignore plan-id with explain format as brief

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
