### PR TITLE
planner: fix join reorder schema mismatch with full schema columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ MODULE.bazel.lock
 # Testing / coverage / reports
 # Files generated when testing
 out
+/reports/
 test_coverage
 coverage.out
 coverage.txt

--- a/pkg/planner/core/casetest/join/BUILD.bazel
+++ b/pkg/planner/core/casetest/join/BUILD.bazel
@@ -6,9 +6,11 @@ go_test(
     srcs = [
         "join_test.go",
         "main_test.go",
+        "reports_test.go",
     ],
+    data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 5,
+    shard_count = 7,
     deps = [
         "//pkg/config",
         "//pkg/testkit",

--- a/pkg/planner/core/casetest/join/join_test.go
+++ b/pkg/planner/core/casetest/join/join_test.go
@@ -161,14 +161,14 @@ func TestCantFindColumnJoinReorder(t *testing.T) {
 			"left join t1 on ((t0.k0 = t1.k0) and ((t4.k0 < t1.k0) and (t2.k0 != t1.k0))) " +
 			"left join t3 on ((t0.k0 = t3.k0) and ((t0.k0 <= t3.k0) and (t2.k0 < t4.k0))) " +
 			"where (not (t0.k0 in ('s85','s56','s87')) and not (t2.k0 in ((select t0.k0 as c0 from t0 where (t0.k3 = t0.k3)))));"
-		tk.MustQuery(query)
+		tk.MustQuery(query).Check(testkit.Rows())
 
 		tk.MustExec("drop table if exists t1, t2, t3;")
 		// Issue: https://github.com/pingcap/tidb/issues/65454
 		tk.MustExec("create table t1 (id bigint not null, hcode text collate utf8mb4_general_ci not null, primary key (id) /*T![clustered_index] CLUSTERED */);")
 		tk.MustExec("create table t2 (id bigint not null, bid bigint not null, cid bigint not null, primary key (id) /*T![clustered_index] CLUSTERED */);")
 		tk.MustExec("create table t3 (id bigint not null, user_id bigint not null, primary key (id) /*T![clustered_index] CLUSTERED */);")
-		tk.MustQuery("explain format = 'plan_tree' select (select count(t3.user_id) from t2 left join t1 as cm on t2.cid = cm.id left join t3 on t2.bid = t3.id where cm.hcode = t1.hcode) as tt from t1 where t1.id in (select min(id) from t1);")
+		tk.MustExec("explain format = 'plan_tree' select (select count(t3.user_id) from t2 left join t1 as cm on t2.cid = cm.id left join t3 on t2.bid = t3.id where cm.hcode = t1.hcode) as tt from t1 where t1.id in (select min(id) from t1);")
 	})
 }
 

--- a/pkg/planner/core/casetest/join/reports_test.go
+++ b/pkg/planner/core/casetest/join/reports_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package join
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+type reportSummary struct {
+	Error string `json:"error"`
+}
+
+func TestReportsCantFindColumn(t *testing.T) {
+	// issue: 65454
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		reportsDir := filepath.Join("testdata", "reports")
+		summaries, err := filepath.Glob(filepath.Join(reportsDir, "case_*", "summary.json"))
+		require.NoError(t, err)
+		require.NotEmpty(t, summaries, "no deterministic report cases found in %s", reportsDir)
+
+		for _, summaryPath := range summaries {
+			summary, err := readReportSummary(summaryPath)
+			require.NoError(t, err)
+			if !strings.Contains(summary.Error, "Can't find column") {
+				continue
+			}
+			caseDir := filepath.Dir(summaryPath)
+			caseName := filepath.Base(caseDir)
+			t.Run(caseName, func(t *testing.T) {
+				schemaSQL := mustReadFile(t, filepath.Join(caseDir, "schema.sql"))
+				insertSQL := mustReadFile(t, filepath.Join(caseDir, "inserts.sql"))
+				caseSQL := mustReadFile(t, filepath.Join(caseDir, "case.sql"))
+
+				dbNames := collectDBNames(schemaSQL, insertSQL, caseSQL)
+				if len(dbNames) == 0 {
+					dbNames = []string{"report_" + strings.ReplaceAll(caseName, "-", "_")}
+				}
+				for _, dbName := range dbNames {
+					tk.MustExec("drop database if exists " + dbName)
+					tk.MustExec("create database " + dbName)
+				}
+				tk.MustExec("use " + dbNames[0])
+
+				if err := runSQLText(t, tk, schemaSQL, false); err != nil {
+					t.Skipf("skip case due to setup error: %v", err)
+				}
+				if err := runSQLText(t, tk, insertSQL, false); err != nil {
+					t.Skipf("skip case due to setup error: %v", err)
+				}
+				_ = runSQLText(t, tk, caseSQL, true)
+
+				for _, dbName := range dbNames {
+					tk.MustExec("drop database if exists " + dbName)
+				}
+			})
+		}
+	})
+}
+
+func readReportSummary(path string) (*reportSummary, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var summary reportSummary
+	if err := json.Unmarshal(data, &summary); err != nil {
+		return nil, err
+	}
+	return &summary, nil
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func runSQLText(t *testing.T, tk *testkit.TestKit, sqlText string, allowNonCantFind bool) error {
+	for _, stmt := range splitSQL(sqlText) {
+		if err := execSQL(t, tk, stmt, allowNonCantFind); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func execSQL(t *testing.T, tk *testkit.TestKit, stmt string, allowNonCantFind bool) error {
+	sqlText := strings.TrimSpace(stmt)
+	if sqlText == "" {
+		return nil
+	}
+	rs, err := tk.Exec(sqlText)
+	if rs != nil {
+		closeErr := rs.Close()
+		if err == nil && closeErr != nil {
+			return closeErr
+		}
+	}
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "Can't find column") {
+		require.NoError(t, err, "sql:%s", sqlText)
+		return err
+	}
+	if !allowNonCantFind {
+		return err
+	}
+	return nil
+}
+
+func collectDBNames(sqlTexts ...string) []string {
+	dbs := make(map[string]struct{})
+	nameRe := regexp.MustCompile(`(?i)\bshiro_fuzz[0-9a-zA-Z_]*\b`)
+	for _, sqlText := range sqlTexts {
+		for _, name := range nameRe.FindAllString(sqlText, -1) {
+			dbs[strings.ToLower(name)] = struct{}{}
+		}
+		for _, stmt := range splitSQL(sqlText) {
+			fields := strings.Fields(strings.TrimSpace(stmt))
+			if len(fields) == 0 {
+				continue
+			}
+			switch strings.ToLower(fields[0]) {
+			case "use":
+				if len(fields) >= 2 {
+					name := trimDBName(fields[1])
+					if name != "" {
+						dbs[strings.ToLower(name)] = struct{}{}
+					}
+				}
+			case "create":
+				if len(fields) >= 3 && strings.ToLower(fields[1]) == "database" {
+					nameIdx := 2
+					if len(fields) >= 6 && strings.ToLower(fields[2]) == "if" && strings.ToLower(fields[3]) == "not" && strings.ToLower(fields[4]) == "exists" {
+						nameIdx = 5
+					}
+					if len(fields) > nameIdx {
+						name := trimDBName(fields[nameIdx])
+						if name != "" {
+							dbs[strings.ToLower(name)] = struct{}{}
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(dbs) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(dbs))
+	for name := range dbs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func trimDBName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.TrimSuffix(name, ";")
+	name = strings.Trim(name, "`")
+	return name
+}
+
+func splitSQL(sql string) []string {
+	var res []string
+	var b strings.Builder
+	inSingle, inDouble, inBack := false, false, false
+	escaped := false
+	for _, r := range sql {
+		if escaped {
+			escaped = false
+			b.WriteRune(r)
+			continue
+		}
+		if r == '\\' && (inSingle || inDouble) {
+			escaped = true
+			b.WriteRune(r)
+			continue
+		}
+		switch r {
+		case '\'':
+			if !inDouble && !inBack {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle && !inBack {
+				inDouble = !inDouble
+			}
+		case '`':
+			if !inSingle && !inDouble {
+				inBack = !inBack
+			}
+		case ';':
+			if !inSingle && !inDouble && !inBack {
+				res = append(res, b.String())
+				b.Reset()
+				continue
+			}
+		}
+		b.WriteRune(r)
+	}
+	if strings.TrimSpace(b.String()) != "" {
+		res = append(res, b.String())
+	}
+	return res
+}

--- a/pkg/planner/core/casetest/join/testdata/reports/case_65454/case.sql
+++ b/pkg/planner/core/casetest/join/testdata/reports/case_65454/case.sql
@@ -1,0 +1,6 @@
+select distinct length(t0.k3) as c0 from t0
+join t2 on ((t0.k0 = t2.k0) and ((t0.k0 = t2.k0) and (t0.k0 != t2.k0)))
+left join t4 on ((t0.k0 = t4.k0) and not (t0.k0 in ('s0')))
+left join t1 on ((t0.k0 = t1.k0) and ((t4.k0 < t1.k0) and (t2.k0 != t1.k0)))
+left join t3 on ((t0.k0 = t3.k0) and ((t0.k0 <= t3.k0) and (t2.k0 < t4.k0)))
+where (not (t0.k0 in ('s85','s56','s87')) and not (t2.k0 in ((select t0.k0 as c0 from t0 where (t0.k3 = t0.k3)))));

--- a/pkg/planner/core/casetest/join/testdata/reports/case_65454/inserts.sql
+++ b/pkg/planner/core/casetest/join/testdata/reports/case_65454/inserts.sql
@@ -1,0 +1,5 @@
+insert into t0 values (1, 's1', 'k1', 1, 3, 1.0, 1);
+insert into t1 values (1, 's1', 1, 1.0);
+insert into t2 values (1, 'k1', 's1', 1.00, 1.0);
+insert into t3 values (1, 1, 's1', 1.0, '2024-01-01');
+insert into t4 values (1, 3, 's1', '2024-01-01', 1);

--- a/pkg/planner/core/casetest/join/testdata/reports/case_65454/schema.sql
+++ b/pkg/planner/core/casetest/join/testdata/reports/case_65454/schema.sql
@@ -1,0 +1,8 @@
+create database if not exists shiro_fuzz_r1;
+use shiro_fuzz_r1;
+drop table if exists t0, t1, t2, t3, t4;
+create table t0 (id bigint, k0 varchar(64), k1 varchar(64), k2 int, k3 int, p0 float, p1 tinyint(1), primary key (id));
+create table t1 (id bigint, k0 varchar(64), d0 bigint, d1 double, primary key (id));
+create table t2 (id bigint, k1 varchar(64), k0 varchar(64), d0 decimal(12,2), d1 double, primary key (id));
+create table t3 (id bigint, k2 int, k0 varchar(64), d0 float, d1 date, primary key (id), key idx_id_4 (id));
+create table t4 (id bigint, k3 int, k0 varchar(64), d0 date, d1 bigint, primary key (id));

--- a/pkg/planner/core/casetest/join/testdata/reports/case_65454/summary.json
+++ b/pkg/planner/core/casetest/join/testdata/reports/case_65454/summary.json
@@ -1,0 +1,1 @@
+{"error":"Can't find column test.t4.k0 in schema"}

--- a/pkg/planner/core/operator/logicalop/logical_apply.go
+++ b/pkg/planner/core/operator/logicalop/logical_apply.go
@@ -232,9 +232,26 @@ func (la *LogicalApply) CanPullUpAgg() bool {
 	if len(la.EqualConditions)+len(la.LeftConditions)+len(la.RightConditions)+len(la.OtherConditions) > 0 {
 		return false
 	}
-	outerSchema := la.Children()[0].Schema()
+	children := la.Children()
+	if len(children) == 0 || children[0] == nil {
+		return false
+	}
+	outerSchema := children[0].Schema()
+	if outerSchema == nil {
+		return false
+	}
 	for _, key := range outerSchema.PKOrUK {
-		if outerSchema.ColumnsIndices(key) != nil {
+		if len(key) == 0 {
+			continue
+		}
+		allVisible := true
+		for _, keyCol := range key {
+			if keyCol == nil || !outerSchema.Contains(keyCol) {
+				allVisible = false
+				break
+			}
+		}
+		if allVisible {
 			return true
 		}
 	}

--- a/pkg/planner/core/operator/logicalop/logical_apply.go
+++ b/pkg/planner/core/operator/logicalop/logical_apply.go
@@ -232,7 +232,13 @@ func (la *LogicalApply) CanPullUpAgg() bool {
 	if len(la.EqualConditions)+len(la.LeftConditions)+len(la.RightConditions)+len(la.OtherConditions) > 0 {
 		return false
 	}
-	return len(la.Children()[0].Schema().PKOrUK) > 0
+	outerSchema := la.Children()[0].Schema()
+	for _, key := range outerSchema.PKOrUK {
+		if outerSchema.ColumnsIndices(key) != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // DeCorColFromEqExpr checks whether it's an equal condition of form `col = correlated col`. If so we will change the decorrelated

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -173,11 +173,20 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression) (ret
 		)
 	}
 	simplifyOuterJoin(p, predicates)
+	p.OtherConditions, ret = p.filterOtherCondBySchema(p.OtherConditions, ret)
 	var equalCond []*expression.ScalarFunction
 	var leftPushCond, rightPushCond, otherCond, leftCond, rightCond []expression.Expression
 	p.allJoinLeaf = getAllJoinLeaf(p)
 	switch p.JoinType {
 	case base.LeftOuterJoin, base.LeftOuterSemiJoin, base.AntiLeftOuterSemiJoin:
+		var leftOnly []expression.Expression
+		if len(p.OtherConditions) > 0 {
+			leftSchema := p.Children()[0].Schema()
+			rightSchema := p.Children()[1].Schema()
+			p.OtherConditions, leftOnly = expression.FilterOutInPlace(p.OtherConditions, func(expr expression.Expression) bool {
+				return expression.ExprFromSchema(expr, leftSchema) && !expression.ExprFromSchema(expr, rightSchema)
+			})
+		}
 		predicates = p.outerJoinPropConst(predicates, p.isVaildConstantPropagationExpressionForLeftOuterJoinAndAntiSemiJoin)
 		predicates = ruleutil.ApplyPredicateSimplificationForJoin(p.SCtx(), predicates,
 			p.Children()[0].Schema(), p.Children()[1].Schema(), false, nil)
@@ -187,17 +196,28 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression) (ret
 		}
 		// Handle where conditions
 		predicates = expression.ExtractFiltersFromDNFs(p.SCtx().GetExprCtx(), predicates)
+		predicates, ret = p.filterPredicatesBySchema(predicates, ret)
 		// Only derive left where condition, because right where condition cannot be pushed down
 		equalCond, leftPushCond, rightPushCond, otherCond = p.extractOnCondition(predicates, true, false)
-		leftCond = leftPushCond
+		otherCond, ret = p.filterOtherCondBySchema(otherCond, ret)
+		leftCond = append(leftPushCond, leftOnly...)
 		// Handle join conditions, only derive right join condition, because left join condition cannot be pushed down
 		_, derivedRightJoinCond := DeriveOtherConditions(
 			p, p.Children()[0].Schema(), p.Children()[1].Schema(), false, true)
 		rightCond = append(p.RightConditions, derivedRightJoinCond...)
 		p.RightConditions = nil
-		ret = append(expression.ScalarFuncs2Exprs(equalCond), otherCond...)
+		ret = append(ret, expression.ScalarFuncs2Exprs(equalCond)...)
+		ret = append(ret, otherCond...)
 		ret = append(ret, rightPushCond...)
 	case base.RightOuterJoin:
+		var rightOnly []expression.Expression
+		if len(p.OtherConditions) > 0 {
+			leftSchema := p.Children()[0].Schema()
+			rightSchema := p.Children()[1].Schema()
+			p.OtherConditions, rightOnly = expression.FilterOutInPlace(p.OtherConditions, func(expr expression.Expression) bool {
+				return expression.ExprFromSchema(expr, rightSchema) && !expression.ExprFromSchema(expr, leftSchema)
+			})
+		}
 		predicates = ruleutil.ApplyPredicateSimplificationForJoin(p.SCtx(), predicates,
 			p.Children()[0].Schema(), p.Children()[1].Schema(), true, nil)
 		predicates = p.outerJoinPropConst(predicates, p.isVaildConstantPropagationExpressionForRightOuterJoin)
@@ -207,15 +227,18 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression) (ret
 		}
 		// Handle where conditions
 		predicates = expression.ExtractFiltersFromDNFs(p.SCtx().GetExprCtx(), predicates)
+		predicates, ret = p.filterPredicatesBySchema(predicates, ret)
 		// Only derive right where condition, because left where condition cannot be pushed down
 		equalCond, leftPushCond, rightPushCond, otherCond = p.extractOnCondition(predicates, false, true)
-		rightCond = rightPushCond
+		otherCond, ret = p.filterOtherCondBySchema(otherCond, ret)
+		rightCond = append(rightPushCond, rightOnly...)
 		// Handle join conditions, only derive left join condition, because right join condition cannot be pushed down
 		derivedLeftJoinCond, _ := DeriveOtherConditions(
 			p, p.Children()[0].Schema(), p.Children()[1].Schema(), true, false)
 		leftCond = append(p.LeftConditions, derivedLeftJoinCond...)
 		p.LeftConditions = nil
-		ret = append(expression.ScalarFuncs2Exprs(equalCond), otherCond...)
+		ret = append(ret, expression.ScalarFuncs2Exprs(equalCond)...)
+		ret = append(ret, otherCond...)
 		ret = append(ret, leftPushCond...)
 	case base.SemiJoin, base.InnerJoin:
 		tempCond := make([]expression.Expression, 0, len(p.LeftConditions)+len(p.RightConditions)+len(p.EqualConditions)+len(p.OtherConditions)+len(predicates))
@@ -228,12 +251,14 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression) (ret
 		tempCond = ruleutil.ApplyPredicateSimplificationForJoin(p.SCtx(), tempCond,
 			p.Children()[0].Schema(), p.Children()[1].Schema(),
 			true, p.isVaildConstantPropagationExpressionWithInnerJoinOrSemiJoin)
+		tempCond, ret = p.filterPredicatesBySchema(tempCond, ret)
 		// Return table dual when filter is constant false or null.
 		dual := Conds2TableDual(p, tempCond)
 		if dual != nil {
 			return ret, dual, nil
 		}
 		equalCond, leftPushCond, rightPushCond, otherCond = p.extractOnCondition(tempCond, true, true)
+		otherCond, ret = p.filterOtherCondBySchema(otherCond, ret)
 		p.LeftConditions = nil
 		p.RightConditions = nil
 		p.EqualConditions = equalCond
@@ -251,7 +276,9 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression) (ret
 			return ret, dual, nil
 		}
 		// `predicates` should only contain left conditions or constant filters.
-		_, leftPushCond, rightPushCond, _ = p.extractOnCondition(predicates, true, true)
+		predicates, ret = p.filterPredicatesBySchema(predicates, ret)
+		_, leftPushCond, rightPushCond, otherCond = p.extractOnCondition(predicates, true, true)
+		_, ret = p.filterOtherCondBySchema(otherCond, ret)
 		// Do not derive `is not null` for anti join, since it may cause wrong results.
 		// For example:
 		// `select * from t t1 where t1.a not in (select b from t t2)` does not imply `t2.b is not null`,
@@ -395,7 +422,15 @@ func specialNullRejectedCase1(ctx planctx.PlanContext, schema *expression.Schema
 
 // PruneColumns implements the base.LogicalPlan.<2nd> interface.
 func (p *LogicalJoin) PruneColumns(parentUsedCols []*expression.Column) (base.LogicalPlan, error) {
-	leftCols, rightCols := p.ExtractUsedCols(parentUsedCols)
+	usedCols := make([]*expression.Column, 0, len(parentUsedCols))
+	usedCols = append(usedCols, parentUsedCols...)
+	usedCols = append(usedCols, expression.ExtractColumnsFromExpressions(p.OtherConditions, nil)...)
+	usedCols = append(usedCols, expression.ExtractColumnsFromExpressions(p.LeftConditions, nil)...)
+	usedCols = append(usedCols, expression.ExtractColumnsFromExpressions(p.RightConditions, nil)...)
+	usedCols = append(usedCols, expression.ExtractColumnsFromExpressions(expression.ScalarFuncs2Exprs(p.EqualConditions), nil)...)
+	usedCols = append(usedCols, expression.ExtractColumnsFromExpressions(expression.ScalarFuncs2Exprs(p.NAEQConditions), nil)...)
+
+	leftCols, rightCols := p.ExtractUsedCols(usedCols)
 
 	var err error
 	p.Children()[0], err = p.Children()[0].PruneColumns(leftCols)
@@ -409,6 +444,7 @@ func (p *LogicalJoin) PruneColumns(parentUsedCols []*expression.Column) (base.Lo
 	}
 
 	p.MergeSchema()
+	p.appendFullSchemaColumns(parentUsedCols)
 	if p.JoinType == base.LeftOuterSemiJoin || p.JoinType == base.AntiLeftOuterSemiJoin {
 		joinCol := p.Schema().Columns[len(p.Schema().Columns)-1]
 		parentUsedCols = append(parentUsedCols, joinCol)
@@ -448,6 +484,7 @@ func (p *LogicalJoin) appendFullSchemaColumns(parentUsedCols []*expression.Colum
 }
 
 // AppendFullSchemaColumns appends columns from FullSchema into Schema if they are used by upper expressions.
+// It is intended for optimizer rules that rearrange join conditions after column pruning.
 func (p *LogicalJoin) AppendFullSchemaColumns(parentUsedCols []*expression.Column) {
 	p.appendFullSchemaColumns(parentUsedCols)
 }
@@ -1661,6 +1698,38 @@ func (p *LogicalJoin) extractOnCondition(conditions []expression.Expression, der
 	rightSchema := child[1].Schema()
 	leftSchema := child[0].Schema()
 	return p.ExtractOnCondition(conditions, leftSchema, rightSchema, deriveLeft, deriveRight)
+}
+
+func (p *LogicalJoin) filterOtherCondBySchema(otherCond []expression.Expression, ret []expression.Expression) (kept []expression.Expression, remaining []expression.Expression) {
+	if len(otherCond) == 0 {
+		return otherCond, ret
+	}
+	mergedSchema := expression.MergeSchema(p.Children()[0].Schema(), p.Children()[1].Schema())
+	dst := otherCond[:0]
+	for _, cond := range otherCond {
+		if expression.ExprFromSchema(cond, mergedSchema) {
+			dst = append(dst, cond)
+			continue
+		}
+		ret = append(ret, cond)
+	}
+	return dst, ret
+}
+
+func (p *LogicalJoin) filterPredicatesBySchema(predicates []expression.Expression, ret []expression.Expression) (kept []expression.Expression, remaining []expression.Expression) {
+	if len(predicates) == 0 {
+		return predicates, ret
+	}
+	mergedSchema := expression.MergeSchema(p.Children()[0].Schema(), p.Children()[1].Schema())
+	dst := predicates[:0]
+	for _, expr := range predicates {
+		if expression.ExprFromSchema(expr, mergedSchema) {
+			dst = append(dst, expr)
+			continue
+		}
+		ret = append(ret, expr)
+	}
+	return dst, ret
 }
 
 // SetPreferredJoinTypeAndOrder sets the preferred join type and order for the LogicalJoin.

--- a/pkg/planner/core/rule_decorrelate.go
+++ b/pkg/planner/core/rule_decorrelate.go
@@ -120,8 +120,21 @@ func extractOuterApplyCorrelatedColsHelper(p base.PhysicalPlan) ([]*expression.C
 type DecorrelateSolver struct{}
 
 func pickVisibleUniqueKey(schema *expression.Schema) []*expression.Column {
+	if schema == nil {
+		return nil
+	}
 	for _, key := range schema.PKOrUK {
-		if schema.ColumnsIndices(key) != nil {
+		if len(key) == 0 {
+			continue
+		}
+		allVisible := true
+		for _, keyCol := range key {
+			if keyCol == nil || !schema.Contains(keyCol) {
+				allVisible = false
+				break
+			}
+		}
+		if allVisible {
 			return key
 		}
 	}

--- a/pkg/planner/core/rule_decorrelate.go
+++ b/pkg/planner/core/rule_decorrelate.go
@@ -119,6 +119,15 @@ func extractOuterApplyCorrelatedColsHelper(p base.PhysicalPlan) ([]*expression.C
 // DecorrelateSolver tries to convert apply plan to join plan.
 type DecorrelateSolver struct{}
 
+func pickVisibleUniqueKey(schema *expression.Schema) []*expression.Column {
+	for _, key := range schema.PKOrUK {
+		if schema.ColumnsIndices(key) != nil {
+			return key
+		}
+	}
+	return nil
+}
+
 func (*DecorrelateSolver) aggDefaultValueMap(agg *logicalop.LogicalAggregation) map[int]*expression.Constant {
 	defaultValueMap := make(map[int]*expression.Constant, len(agg.AggFuncs))
 	for i, f := range agg.AggFuncs {
@@ -314,11 +323,15 @@ func (s *DecorrelateSolver) optimize(ctx context.Context, p base.LogicalPlan, gr
 			}
 		} else if agg, ok := innerPlan.(*logicalop.LogicalAggregation); ok {
 			if apply.CanPullUpAgg() && agg.CanPullUp() {
+				visibleKey := pickVisibleUniqueKey(outerPlan.Schema())
+				if len(visibleKey) == 0 {
+					goto NoOptimize
+				}
 				innerPlan = agg.Children()[0]
 				apply.JoinType = base.LeftOuterJoin
 				apply.SetChildren(outerPlan, innerPlan)
 				agg.SetSchema(apply.Schema())
-				agg.GroupByItems = expression.Column2Exprs(outerPlan.Schema().PKOrUK[0])
+				agg.GroupByItems = expression.Column2Exprs(visibleKey)
 				newAggFuncs := make([]*aggregation.AggFuncDesc, 0, apply.Schema().Len())
 
 				outerColsInSchema := make([]*expression.Column, 0, outerPlan.Schema().Len())

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -44,7 +44,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 		otherConds         []expression.Expression
 		joinTypes          []*joinTypeWithExtMsg
 		hasOuterJoin       bool
-		currentLeadingHint *h.PlanHints
+		currentLeadingHint *h.PlanHints // Track the active LEADING hint
 	)
 
 	// Check if the current plan is a Selection. If its child is a join, add the selection conditions
@@ -70,6 +70,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 		joinOrderHintInfo = append(joinOrderHintInfo, join.HintInfo)
 		currentLeadingHint = join.HintInfo
 	}
+
 	// If the variable `tidb_opt_advanced_join_hint` is false and the join node has the join method hint, we will not split the current join node to join reorder process.
 	if !isJoin || (join.PreferJoinType > uint(0) && !p.SCtx().GetSessionVars().EnableAdvancedJoinHint) || join.StraightJoin ||
 		(join.JoinType != base.InnerJoin && join.JoinType != base.LeftOuterJoin && join.JoinType != base.RightOuterJoin) ||

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -38,12 +38,13 @@ import (
 func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 	joinMethodHintInfo := make(map[int]*joinorder.JoinMethodHint)
 	var (
-		group             []base.LogicalPlan
-		joinOrderHintInfo []*h.PlanHints
-		eqEdges           []*expression.ScalarFunction
-		otherConds        []expression.Expression
-		joinTypes         []*joinTypeWithExtMsg
-		hasOuterJoin      bool
+		group              []base.LogicalPlan
+		joinOrderHintInfo  []*h.PlanHints
+		eqEdges            []*expression.ScalarFunction
+		otherConds         []expression.Expression
+		joinTypes          []*joinTypeWithExtMsg
+		hasOuterJoin       bool
+		currentLeadingHint *h.PlanHints
 	)
 
 	// Check if the current plan is a Selection. If its child is a join, add the selection conditions
@@ -67,6 +68,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 		// For example, the join type is cross join or straight join, or exists the join algorithm hint, etc.
 		// We need to return the hint information to warn
 		joinOrderHintInfo = append(joinOrderHintInfo, join.HintInfo)
+		currentLeadingHint = join.HintInfo
 	}
 	// If the variable `tidb_opt_advanced_join_hint` is false and the join node has the join method hint, we will not split the current join node to join reorder process.
 	if !isJoin || (join.PreferJoinType > uint(0) && !p.SCtx().GetSessionVars().EnableAdvancedJoinHint) || join.StraightJoin ||

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -38,13 +38,12 @@ import (
 func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 	joinMethodHintInfo := make(map[int]*joinorder.JoinMethodHint)
 	var (
-		group              []base.LogicalPlan
-		joinOrderHintInfo  []*h.PlanHints
-		eqEdges            []*expression.ScalarFunction
-		otherConds         []expression.Expression
-		joinTypes          []*joinTypeWithExtMsg
-		hasOuterJoin       bool
-		currentLeadingHint *h.PlanHints // Track the active LEADING hint
+		group             []base.LogicalPlan
+		joinOrderHintInfo []*h.PlanHints
+		eqEdges           []*expression.ScalarFunction
+		otherConds        []expression.Expression
+		joinTypes         []*joinTypeWithExtMsg
+		hasOuterJoin      bool
 	)
 
 	// Check if the current plan is a Selection. If its child is a join, add the selection conditions
@@ -68,9 +67,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 		// For example, the join type is cross join or straight join, or exists the join algorithm hint, etc.
 		// We need to return the hint information to warn
 		joinOrderHintInfo = append(joinOrderHintInfo, join.HintInfo)
-		currentLeadingHint = join.HintInfo
 	}
-
 	// If the variable `tidb_opt_advanced_join_hint` is false and the join node has the join method hint, we will not split the current join node to join reorder process.
 	if !isJoin || (join.PreferJoinType > uint(0) && !p.SCtx().GetSessionVars().EnableAdvancedJoinHint) || join.StraightJoin ||
 		(join.JoinType != base.InnerJoin && join.JoinType != base.LeftOuterJoin && join.JoinType != base.RightOuterJoin) ||

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -24,6 +24,8 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/joinorder"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
+	"github.com/pingcap/tidb/pkg/planner/util"
+	"github.com/pingcap/tidb/pkg/types"
 	h "github.com/pingcap/tidb/pkg/util/hint"
 )
 
@@ -42,7 +44,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 		otherConds         []expression.Expression
 		joinTypes          []*joinTypeWithExtMsg
 		hasOuterJoin       bool
-		currentLeadingHint *h.PlanHints // Track the active LEADING hint
+		currentLeadingHint *h.PlanHints
 	)
 
 	// Check if the current plan is a Selection. If its child is a join, add the selection conditions
@@ -68,7 +70,6 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 		joinOrderHintInfo = append(joinOrderHintInfo, join.HintInfo)
 		currentLeadingHint = join.HintInfo
 	}
-
 	// If the variable `tidb_opt_advanced_join_hint` is false and the join node has the join method hint, we will not split the current join node to join reorder process.
 	if !isJoin || (join.PreferJoinType > uint(0) && !p.SCtx().GetSessionVars().EnableAdvancedJoinHint) || join.StraightJoin ||
 		(join.JoinType != base.InnerJoin && join.JoinType != base.LeftOuterJoin && join.JoinType != base.RightOuterJoin) ||
@@ -113,7 +114,6 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 	// If the left child has the hint, it means there are some join method hints want to specify the join method based on the left child.
 	// For example: `select .. from t1 join t2 join (select .. from t3 join t4) t5 where ..;` If there are some join method hints related to `t5`, we can't split `t5` into `t3` and `t4`.
 	// So we don't need to split the left child part. The right child part is the same.
-
 	// Check if left child should be preserved due to LEADING hint reference
 	leftShouldPreserve := currentLeadingHint != nil && joinorder.IsDerivedTableInLeadingHint(join.Children()[0], currentLeadingHint)
 
@@ -130,7 +130,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 			expression.ExtractColumnsMapFromExpressionsWithReusedMap(extractedCols, nil, eqConds...)
 			affectedGroups := 0
 			for _, lhs := range lhsGroup {
-				lhsSchema := lhs.Schema()
+				lhsSchema := getPlanSchemaForJoinReorder(lhs)
 				for _, col := range extractedCols {
 					if lhsSchema.Contains(col) {
 						affectedGroups++
@@ -162,7 +162,6 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 
 	// Check if right child should be preserved due to LEADING hint reference
 	rightShouldPreserve := currentLeadingHint != nil && joinorder.IsDerivedTableInLeadingHint(join.Children()[1], currentLeadingHint)
-
 	// You can see the comments in the upside part which we try to split the left child part. It's the same here.
 	if join.JoinType != base.LeftOuterJoin && !rightHasHint && !rightShouldPreserve {
 		rhsJoinGroupResult := extractJoinGroup(join.Children()[1])
@@ -177,7 +176,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 			expression.ExtractColumnsMapFromExpressionsWithReusedMap(extractedCols, nil, eqConds...)
 			affectedGroups := 0
 			for _, rhs := range rhsGroup {
-				rhsSchema := rhs.Schema()
+				rhsSchema := getPlanSchemaForJoinReorder(rhs)
 				for _, col := range extractedCols {
 					if rhsSchema.Contains(col) {
 						affectedGroups++
@@ -240,6 +239,13 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 	}
 }
 
+func getPlanSchemaForJoinReorder(p base.LogicalPlan) *expression.Schema {
+	if join, ok := p.(*logicalop.LogicalJoin); ok && join.FullSchema != nil {
+		return join.FullSchema
+	}
+	return p.Schema()
+}
+
 // JoinReOrderSolver is used to reorder the join nodes in a logical plan.
 type JoinReOrderSolver struct {
 }
@@ -276,6 +282,15 @@ func (s *JoinReOrderSolver) optimizeRecursive(ctx base.PlanContext, p base.Logic
 				curJoinGroup[i], err = s.optimizeRecursive(ctx, curJoinGroup[i])
 				if err != nil {
 					return nil, err
+				}
+			}
+			mergedGroupSchema := expression.NewSchema()
+			for _, node := range curJoinGroup {
+				mergedGroupSchema = expression.MergeSchema(mergedGroupSchema, getPlanSchemaForJoinReorder(node))
+			}
+			for _, cond := range result.otherConds {
+				if !expression.ExprFromSchema(cond, mergedGroupSchema) {
+					return p, nil
 				}
 			}
 			originalSchema := p.Schema()
@@ -336,7 +351,21 @@ func (s *JoinReOrderSolver) optimizeRecursive(ctx base.PlanContext, p base.Logic
 			if err != nil {
 				return nil, err
 			}
-			if !p.Schema().Equal(originalSchema) {
+			if join, ok := p.(*logicalop.LogicalJoin); ok {
+				join.AppendFullSchemaColumns(expression.ExtractColumnsFromExpressions(result.otherConds, nil))
+			}
+			schemaChanged := false
+			if len(p.Schema().Columns) != len(originalSchema.Columns) {
+				schemaChanged = true
+			} else {
+				for i, col := range p.Schema().Columns {
+					if !col.EqualColumn(originalSchema.Columns[i]) {
+						schemaChanged = true
+						break
+					}
+				}
+			}
+			if schemaChanged {
 				proj := logicalop.LogicalProjection{
 					Exprs: expression.Column2Exprs(originalSchema.Columns),
 				}.Init(p.SCtx(), p.QueryBlockOffset())
@@ -492,12 +521,14 @@ func (s *baseSingleGroupJoinOrderSolver) baseNodeCumCost(groupNode base.LogicalP
 func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan base.LogicalPlan) (leftNode, rightNode base.LogicalPlan, usedEdges []*expression.ScalarFunction, joinType *joinTypeWithExtMsg) {
 	joinType = &joinTypeWithExtMsg{JoinType: base.InnerJoin}
 	leftNode, rightNode = leftPlan, rightPlan
+	leftSchema := getPlanSchemaForJoinReorder(leftPlan)
+	rightSchema := getPlanSchemaForJoinReorder(rightPlan)
 	for idx, edge := range s.eqEdges {
 		lCol, rCol := expression.ExtractColumnsFromColOpCol(edge)
-		if leftPlan.Schema().Contains(lCol) && rightPlan.Schema().Contains(rCol) {
+		if leftSchema.Contains(lCol) && rightSchema.Contains(rCol) {
 			joinType = s.joinTypes[idx]
 			usedEdges = append(usedEdges, edge)
-		} else if rightPlan.Schema().Contains(lCol) && leftPlan.Schema().Contains(rCol) {
+		} else if rightSchema.Contains(lCol) && leftSchema.Contains(rCol) {
 			joinType = s.joinTypes[idx]
 			if joinType.JoinType != base.InnerJoin {
 				rightNode, leftNode = leftPlan, rightPlan
@@ -542,13 +573,15 @@ func (s *baseSingleGroupJoinOrderSolver) makeJoin(leftPlan, rightPlan base.Logic
 		obLeftConds  []expression.Expression
 		obRightConds []expression.Expression
 	)
-	mergedSchema := expression.MergeSchema(leftPlan.Schema(), rightPlan.Schema())
+	leftSchema := getPlanSchemaForJoinReorder(leftPlan)
+	rightSchema := getPlanSchemaForJoinReorder(rightPlan)
+	mergedSchema := expression.MergeSchema(leftSchema, rightSchema)
 
 	remainOtherConds, leftConds = expression.FilterOutInPlace(remainOtherConds, func(expr expression.Expression) bool {
-		return expression.ExprFromSchema(expr, leftPlan.Schema()) && !expression.ExprFromSchema(expr, rightPlan.Schema())
+		return expression.ExprFromSchema(expr, leftSchema) && !expression.ExprFromSchema(expr, rightSchema)
 	})
 	remainOtherConds, rightConds = expression.FilterOutInPlace(remainOtherConds, func(expr expression.Expression) bool {
-		return expression.ExprFromSchema(expr, rightPlan.Schema()) && !expression.ExprFromSchema(expr, leftPlan.Schema())
+		return expression.ExprFromSchema(expr, rightSchema) && !expression.ExprFromSchema(expr, leftSchema)
 	})
 	remainOtherConds, otherConds = expression.FilterOutInPlace(remainOtherConds, func(expr expression.Expression) bool {
 		return expression.ExprFromSchema(expr, mergedSchema)
@@ -569,10 +602,10 @@ func (s *baseSingleGroupJoinOrderSolver) makeJoin(leftPlan, rightPlan base.Logic
 		remainOBOtherConds := make([]expression.Expression, len(joinType.outerBindCondition))
 		copy(remainOBOtherConds, joinType.outerBindCondition)
 		remainOBOtherConds, obLeftConds = expression.FilterOutInPlace(remainOBOtherConds, func(expr expression.Expression) bool {
-			return expression.ExprFromSchema(expr, leftPlan.Schema()) && !expression.ExprFromSchema(expr, rightPlan.Schema())
+			return expression.ExprFromSchema(expr, leftSchema) && !expression.ExprFromSchema(expr, rightSchema)
 		})
 		remainOBOtherConds, obRightConds = expression.FilterOutInPlace(remainOBOtherConds, func(expr expression.Expression) bool {
-			return expression.ExprFromSchema(expr, rightPlan.Schema()) && !expression.ExprFromSchema(expr, leftPlan.Schema())
+			return expression.ExprFromSchema(expr, rightSchema) && !expression.ExprFromSchema(expr, leftSchema)
 		})
 		// _ here make the linter happy.
 		_, obOtherConds = expression.FilterOutInPlace(remainOBOtherConds, func(expr expression.Expression) bool {
@@ -597,12 +630,17 @@ func (s *baseSingleGroupJoinOrderSolver) makeBushyJoin(cartesianJoinGroup []base
 				break
 			}
 			newJoin := s.newCartesianJoin(cartesianJoinGroup[i], cartesianJoinGroup[i+1])
+			joinSchema := getPlanSchemaForJoinReorder(newJoin)
 			for i := len(s.otherConds) - 1; i >= 0; i-- {
 				cols := expression.ExtractColumns(s.otherConds[i])
-				if newJoin.Schema().ColumnsIndices(cols) != nil {
+				if joinSchema.ColumnsIndices(cols) != nil {
 					newJoin.OtherConditions = append(newJoin.OtherConditions, s.otherConds[i])
 					s.otherConds = slices.Delete(s.otherConds, i, i+1)
 				}
+			}
+			if len(newJoin.OtherConditions) > 0 {
+				newJoin.AppendFullSchemaColumns(expression.ExtractColumnsFromExpressions(newJoin.OtherConditions, nil))
+				newJoin.EnsureSchemaForConditions(newJoin.OtherConditions)
 			}
 			resultJoinGroup = append(resultJoinGroup, newJoin)
 		}
@@ -630,6 +668,7 @@ func (s *baseSingleGroupJoinOrderSolver) newCartesianJoin(lChild, rChild base.Lo
 	}.Init(s.ctx, offset)
 	join.SetSchema(expression.MergeSchema(lChild.Schema(), rChild.Schema()))
 	join.SetChildren(lChild, rChild)
+	setJoinFullSchemaAndNames(join)
 	joinorder.SetNewJoinWithHint(join, s.joinMethodHintInfo)
 	return join
 }
@@ -642,6 +681,14 @@ func (s *baseSingleGroupJoinOrderSolver) newJoinWithEdges(lChild, rChild base.Lo
 	newJoin.LeftConditions = leftConds
 	newJoin.RightConditions = rightConds
 	newJoin.JoinType = joinType
+	setJoinFullSchemaAndNames(newJoin)
+	if len(otherConds)+len(leftConds)+len(rightConds) > 0 {
+		condCols := expression.ExtractColumnsFromExpressions(otherConds, nil)
+		condCols = append(condCols, expression.ExtractColumnsFromExpressions(leftConds, nil)...)
+		condCols = append(condCols, expression.ExtractColumnsFromExpressions(rightConds, nil)...)
+		newJoin.AppendFullSchemaColumns(condCols)
+		newJoin.EnsureSchemaForConditions(otherConds, leftConds, rightConds)
+	}
 	if newJoin.JoinType == base.InnerJoin {
 		if newJoin.LeftConditions != nil {
 			left := newJoin.Children()[0]
@@ -655,6 +702,43 @@ func (s *baseSingleGroupJoinOrderSolver) newJoinWithEdges(lChild, rChild base.Lo
 		}
 	}
 	return newJoin
+}
+func setJoinFullSchemaAndNames(join *logicalop.LogicalJoin) {
+	lChild := join.Children()[0]
+	rChild := join.Children()[1]
+	var lFullSchema, rFullSchema *expression.Schema
+	var lFullNames, rFullNames types.NameSlice
+	if lJoin, ok := lChild.(*logicalop.LogicalJoin); ok && lJoin.FullSchema != nil {
+		lFullSchema = lJoin.FullSchema
+		lFullNames = lJoin.FullNames
+	} else {
+		lFullSchema = lChild.Schema()
+		lFullNames = lChild.OutputNames()
+	}
+	if rJoin, ok := rChild.(*logicalop.LogicalJoin); ok && rJoin.FullSchema != nil {
+		rFullSchema = rJoin.FullSchema
+		rFullNames = rJoin.FullNames
+	} else {
+		rFullSchema = rChild.Schema()
+		rFullNames = rChild.OutputNames()
+	}
+	if join.JoinType == base.RightOuterJoin {
+		lFullSchema, rFullSchema = rFullSchema, lFullSchema
+		lFullNames, rFullNames = rFullNames, lFullNames
+	}
+	join.FullSchema = expression.MergeSchema(lFullSchema, rFullSchema)
+	if join.JoinType == base.LeftOuterJoin || join.JoinType == base.RightOuterJoin {
+		util.ResetNotNullFlag(join.FullSchema, lFullSchema.Len(), join.FullSchema.Len())
+	}
+	join.FullNames = make([]*types.FieldName, 0, len(lFullNames)+len(rFullNames))
+	for _, lName := range lFullNames {
+		name := *lName
+		join.FullNames = append(join.FullNames, &name)
+	}
+	for _, rName := range rFullNames {
+		name := *rName
+		join.FullNames = append(join.FullNames, &name)
+	}
 }
 
 // calcJoinCumCost calculates the cumulative cost of the join node.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66106, close #66107, close #66108

Problem Summary:
Join reorder may build intermediate join trees whose output schema misses columns referenced by remaining join predicates, causing planner failures like `Can't find column`.
In addition, reports-based regression replay previously depended on local ad-hoc report folders, making coverage non-deterministic.

### What changed and how does it work?

- Add regression coverage in `pkg/planner/core/casetest/join/join_test.go` (`TestCantFindColumnJoinReorder`).
- Add deterministic reports replay test and fixture data:
  - `pkg/planner/core/casetest/join/reports_test.go`
  - `pkg/planner/core/casetest/join/testdata/reports/case_65454/*`
  - `pkg/planner/core/casetest/join/BUILD.bazel`
- In `pkg/planner/core/rule_join_reorder.go`:
  - use join `FullSchema` when checking predicate ownership during reorder
  - preserve/append predicate-related columns for reordered join nodes
  - keep condition/schema consistency when constructing new join nodes
- In `pkg/planner/core/operator/logicalop/logical_join.go`:
  - add helper methods to append required columns from `FullSchema`
  - ensure condition columns can be recovered into join output schema when needed

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test scripts:

- `go test -run TestCantFindColumnJoinReorder --tags=intest ./pkg/planner/core/casetest/join -count=1`
- `go test -run TestReportsCantFindColumn --tags=intest ./pkg/planner/core/casetest/join -count=1`
- `go test -run TestLeadingHintInapplicableKeepsOtherConds --tags=intest ./pkg/planner/core/casetest/rule -count=1`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a planner error where join reorder could produce "Can't find column" due to schema mismatch in reordered join predicates, and make related reports-based regression replay deterministic.
```
