### PR TITLE
planner/test: make reports replay deterministic with repo testdata

### DIFF
--- a/pkg/planner/core/casetest/join/BUILD.bazel
+++ b/pkg/planner/core/casetest/join/BUILD.bazel
@@ -6,9 +6,10 @@ go_test(
     srcs = [
         "join_test.go",
         "main_test.go",
+        "reports_test.go",
     ],
     flaky = True,
-    shard_count = 5,
+    shard_count = 7,
     deps = [
         "//pkg/config",
         "//pkg/testkit",

--- a/pkg/planner/core/casetest/join/reports_test.go
+++ b/pkg/planner/core/casetest/join/reports_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package join
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+type reportSummary struct {
+	Error string `json:"error"`
+}
+
+func TestReportsCantFindColumn(t *testing.T) {
+	// issue: 65454
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		reportsDir := filepath.Join("testdata", "reports")
+		summaries, err := filepath.Glob(filepath.Join(reportsDir, "case_*", "summary.json"))
+		require.NoError(t, err)
+		require.NotEmpty(t, summaries, "no deterministic report cases found in %s", reportsDir)
+
+		for _, summaryPath := range summaries {
+			summary, err := readReportSummary(summaryPath)
+			require.NoError(t, err)
+			if !strings.Contains(summary.Error, "Can't find column") {
+				continue
+			}
+			caseDir := filepath.Dir(summaryPath)
+			caseName := filepath.Base(caseDir)
+			t.Run(caseName, func(t *testing.T) {
+				schemaSQL := mustReadFile(t, filepath.Join(caseDir, "schema.sql"))
+				insertSQL := mustReadFile(t, filepath.Join(caseDir, "inserts.sql"))
+				caseSQL := mustReadFile(t, filepath.Join(caseDir, "case.sql"))
+
+				dbNames := collectDBNames(schemaSQL, insertSQL, caseSQL)
+				if len(dbNames) == 0 {
+					dbNames = []string{"report_" + strings.ReplaceAll(caseName, "-", "_")}
+				}
+				for _, dbName := range dbNames {
+					tk.MustExec("drop database if exists " + dbName)
+					tk.MustExec("create database " + dbName)
+				}
+				tk.MustExec("use " + dbNames[0])
+
+				if err := runSQLText(t, tk, schemaSQL, false); err != nil {
+					t.Skipf("skip case due to setup error: %v", err)
+				}
+				if err := runSQLText(t, tk, insertSQL, false); err != nil {
+					t.Skipf("skip case due to setup error: %v", err)
+				}
+				_ = runSQLText(t, tk, caseSQL, true)
+
+				for _, dbName := range dbNames {
+					tk.MustExec("drop database if exists " + dbName)
+				}
+			})
+		}
+	})
+}
+
+func readReportSummary(path string) (*reportSummary, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var summary reportSummary
+	if err := json.Unmarshal(data, &summary); err != nil {
+		return nil, err
+	}
+	return &summary, nil
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func runSQLText(t *testing.T, tk *testkit.TestKit, sqlText string, allowNonCantFind bool) error {
+	for _, stmt := range splitSQL(sqlText) {
+		if err := execSQL(t, tk, stmt, allowNonCantFind); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func execSQL(t *testing.T, tk *testkit.TestKit, stmt string, allowNonCantFind bool) error {
+	sqlText := strings.TrimSpace(stmt)
+	if sqlText == "" {
+		return nil
+	}
+	rs, err := tk.Exec(sqlText)
+	if rs != nil {
+		closeErr := rs.Close()
+		if err == nil && closeErr != nil {
+			return closeErr
+		}
+	}
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "Can't find column") {
+		require.NoError(t, err, "sql:%s", sqlText)
+		return err
+	}
+	if !allowNonCantFind {
+		return err
+	}
+	return nil
+}
+
+func collectDBNames(sqlTexts ...string) []string {
+	dbs := make(map[string]struct{})
+	nameRe := regexp.MustCompile(`(?i)\bshiro_fuzz[0-9a-zA-Z_]*\b`)
+	for _, sqlText := range sqlTexts {
+		for _, name := range nameRe.FindAllString(sqlText, -1) {
+			dbs[strings.ToLower(name)] = struct{}{}
+		}
+		for _, stmt := range splitSQL(sqlText) {
+			fields := strings.Fields(strings.TrimSpace(stmt))
+			if len(fields) == 0 {
+				continue
+			}
+			switch strings.ToLower(fields[0]) {
+			case "use":
+				if len(fields) >= 2 {
+					name := trimDBName(fields[1])
+					if name != "" {
+						dbs[strings.ToLower(name)] = struct{}{}
+					}
+				}
+			case "create":
+				if len(fields) >= 3 && strings.ToLower(fields[1]) == "database" {
+					nameIdx := 2
+					if len(fields) >= 6 && strings.ToLower(fields[2]) == "if" && strings.ToLower(fields[3]) == "not" && strings.ToLower(fields[4]) == "exists" {
+						nameIdx = 5
+					}
+					if len(fields) > nameIdx {
+						name := trimDBName(fields[nameIdx])
+						if name != "" {
+							dbs[strings.ToLower(name)] = struct{}{}
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(dbs) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(dbs))
+	for name := range dbs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func trimDBName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.TrimSuffix(name, ";")
+	name = strings.Trim(name, "`")
+	return name
+}
+
+func splitSQL(sql string) []string {
+	var res []string
+	var b strings.Builder
+	inSingle, inDouble, inBack := false, false, false
+	escaped := false
+	for _, r := range sql {
+		if escaped {
+			escaped = false
+			b.WriteRune(r)
+			continue
+		}
+		if r == '\\' && (inSingle || inDouble) {
+			escaped = true
+			b.WriteRune(r)
+			continue
+		}
+		switch r {
+		case '\'':
+			if !inDouble && !inBack {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle && !inBack {
+				inDouble = !inDouble
+			}
+		case '`':
+			if !inSingle && !inDouble {
+				inBack = !inBack
+			}
+		case ';':
+			if !inSingle && !inDouble && !inBack {
+				res = append(res, b.String())
+				b.Reset()
+				continue
+			}
+		}
+		b.WriteRune(r)
+	}
+	if strings.TrimSpace(b.String()) != "" {
+		res = append(res, b.String())
+	}
+	return res
+}

--- a/pkg/planner/core/casetest/join/testdata/reports/case_65454/case.sql
+++ b/pkg/planner/core/casetest/join/testdata/reports/case_65454/case.sql
@@ -1,0 +1,6 @@
+select distinct length(t0.k3) as c0 from t0
+join t2 on ((t0.k0 = t2.k0) and ((t0.k0 = t2.k0) and (t0.k0 != t2.k0)))
+left join t4 on ((t0.k0 = t4.k0) and not (t0.k0 in ('s0')))
+left join t1 on ((t0.k0 = t1.k0) and ((t4.k0 < t1.k0) and (t2.k0 != t1.k0)))
+left join t3 on ((t0.k0 = t3.k0) and ((t0.k0 <= t3.k0) and (t2.k0 < t4.k0)))
+where (not (t0.k0 in ('s85','s56','s87')) and not (t2.k0 in ((select t0.k0 as c0 from t0 where (t0.k3 = t0.k3)))));

--- a/pkg/planner/core/casetest/join/testdata/reports/case_65454/inserts.sql
+++ b/pkg/planner/core/casetest/join/testdata/reports/case_65454/inserts.sql
@@ -1,0 +1,5 @@
+insert into t0 values (1, 's1', 'k1', 1, 3, 1.0, 1);
+insert into t1 values (1, 's1', 1, 1.0);
+insert into t2 values (1, 'k1', 's1', 1.00, 1.0);
+insert into t3 values (1, 1, 's1', 1.0, '2024-01-01');
+insert into t4 values (1, 3, 's1', '2024-01-01', 1);

--- a/pkg/planner/core/casetest/join/testdata/reports/case_65454/schema.sql
+++ b/pkg/planner/core/casetest/join/testdata/reports/case_65454/schema.sql
@@ -1,0 +1,8 @@
+create database if not exists shiro_fuzz_r1;
+use shiro_fuzz_r1;
+drop table if exists t0, t1, t2, t3, t4;
+create table t0 (id bigint, k0 varchar(64), k1 varchar(64), k2 int, k3 int, p0 float, p1 tinyint(1), primary key (id));
+create table t1 (id bigint, k0 varchar(64), d0 bigint, d1 double, primary key (id));
+create table t2 (id bigint, k1 varchar(64), k0 varchar(64), d0 decimal(12,2), d1 double, primary key (id));
+create table t3 (id bigint, k2 int, k0 varchar(64), d0 float, d1 date, primary key (id), key idx_id_4 (id));
+create table t4 (id bigint, k3 int, k0 varchar(64), d0 date, d1 bigint, primary key (id));

--- a/pkg/planner/core/casetest/join/testdata/reports/case_65454/summary.json
+++ b/pkg/planner/core/casetest/join/testdata/reports/case_65454/summary.json
@@ -1,0 +1,1 @@
+{"error":"Can't find column test.t4.k0 in schema"}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66107

Problem Summary:
The reports replay test currently depends on local ad-hoc `reports/` files and can become a no-op in CI/dev environments.

### What changed and how does it work?

- Add deterministic reports replay test: `pkg/planner/core/casetest/join/reports_test.go`.
- Add repository-managed testdata under `pkg/planner/core/casetest/join/testdata/reports/case_65454/`.
- Update `pkg/planner/core/casetest/join/BUILD.bazel` to include `reports_test.go`.
- The test now reads `testdata/reports/case_*/summary.json` instead of external local `reports/` directories.

Dependency note:

- This PR contains a regression repro case and is expected to be merged after the join-reorder fix PR (`#66116`).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test scripts:

- `go test -run TestReportsCantFindColumn --tags=intest ./pkg/planner/core/casetest/join -count=1`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
