### PR TITLE
executor: support dump plan replayer for prepare stmt

### DIFF
--- a/pkg/executor/test/planreplayer/plan_replayer_test.go
+++ b/pkg/executor/test/planreplayer/plan_replayer_test.go
@@ -92,6 +92,12 @@ func TestPlanReplayer(t *testing.T) {
 	tk.MustQuery("plan replayer dump explain select * from v2")
 	require.True(t, len(tk.Session().GetSessionVars().LastPlanReplayerToken) > 0)
 
+	tk.MustExec("prepare stmt_dump from 'select * from t where a = ?'")
+	tk.MustExec("set @a = 1")
+	dumpRows := tk.MustQuery("plan replayer dump execute stmt_dump using @a").Rows()
+	require.Len(t, dumpRows, 1)
+	require.NotEmpty(t, dumpRows[0][0])
+
 	// clear the status table and assert
 	tk.MustExec("delete from mysql.plan_replayer_status")
 	tk.MustQuery("plan replayer dump explain select * from v2")

--- a/pkg/parser/ast/misc_test.go
+++ b/pkg/parser/ast/misc_test.go
@@ -343,6 +343,8 @@ func TestPlanReplayerStmtRestore(t *testing.T) {
 			"PLAN REPLAYER DUMP EXPLAIN ANALYZE 'test'"},
 		{"plan replayer dump with stats as of timestamp '12345' explain analyze 'test2'",
 			"PLAN REPLAYER DUMP WITH STATS AS OF TIMESTAMP _UTF8MB4'12345' EXPLAIN ANALYZE 'test2'"},
+		{"plan replayer dump execute stmt1 using @var1",
+			"PLAN REPLAYER DUMP EXPLAIN EXECUTE `stmt1` USING @`var1`"},
 	}
 	extractNodeFunc := func(node ast.Node) ast.Node {
 		return node.(*ast.PlanReplayerStmt)

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -16173,6 +16173,7 @@ RowStmt:
  * 		[DUMP EXPLAIN
  *			[ANALYZE]
  *			{ExplainableStmt
+ *			| ExecuteStmt
  *			| [WHERE where_condition]
  *			  [ORDER BY {col_name | expr | position}
  *    			[ASC | DESC], ... [WITH ROLLUP]]
@@ -16186,6 +16187,44 @@ PlanReplayerStmt:
 	{
 		x := &ast.PlanReplayerStmt{
 			Stmt:    $6,
+			Analyze: false,
+			Load:    false,
+			File:    "",
+			Where:   nil,
+			OrderBy: nil,
+			Limit:   nil,
+		}
+		if $4 != nil {
+			x.HistoricalStatsInfo = $4.(*ast.AsOfClause)
+		}
+		startOffset := parser.startOffset(&yyS[yypt])
+		x.Stmt.SetText(parser.lexer.client, strings.TrimSpace(parser.src[startOffset:]))
+
+		$$ = x
+	}
+|	"PLAN" "REPLAYER" "DUMP" PlanReplayerDumpOpt "EXPLAIN" ExecuteStmt
+	{
+		x := &ast.PlanReplayerStmt{
+			Stmt:    $6,
+			Analyze: false,
+			Load:    false,
+			File:    "",
+			Where:   nil,
+			OrderBy: nil,
+			Limit:   nil,
+		}
+		if $4 != nil {
+			x.HistoricalStatsInfo = $4.(*ast.AsOfClause)
+		}
+		startOffset := parser.startOffset(&yyS[yypt])
+		x.Stmt.SetText(parser.lexer.client, strings.TrimSpace(parser.src[startOffset:]))
+
+		$$ = x
+	}
+|	"PLAN" "REPLAYER" "DUMP" PlanReplayerDumpOpt ExecuteStmt
+	{
+		x := &ast.PlanReplayerStmt{
+			Stmt:    $5,
 			Analyze: false,
 			Load:    false,
 			File:    "",

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -7548,6 +7548,7 @@ func TestPlanReplayer(t *testing.T) {
 		{"PLAN REPLAYER LOAD '/tmp/sdfaalskdjf.zip'", true, "PLAN REPLAYER LOAD '/tmp/sdfaalskdjf.zip'"},
 		{"PLAN REPLAYER DUMP EXPLAIN 'sql.txt'", true, "PLAN REPLAYER DUMP EXPLAIN 'sql.txt'"},
 		{"PLAN REPLAYER DUMP EXPLAIN ANALYZE 'sql.txt'", true, "PLAN REPLAYER DUMP EXPLAIN ANALYZE 'sql.txt'"},
+		{"PLAN REPLAYER DUMP EXECUTE stmt1 USING @a", true, "PLAN REPLAYER DUMP EXPLAIN EXECUTE `stmt1` USING @`a`"},
 		{"PLAN REPLAYER CAPTURE '123' '123'", true, "PLAN REPLAYER CAPTURE '123' '123'"},
 		{"PLAN REPLAYER CAPTURE REMOVE '123' '123'", true, "PLAN REPLAYER CAPTURE REMOVE '123' '123'"},
 	}
@@ -7567,6 +7568,13 @@ func TestPlanReplayer(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "SELECT a FROM t", v.Stmt.Text())
 	require.True(t, v.Analyze)
+
+	sms, _, err = p.Parse("PLAN REPLAYER DUMP EXECUTE stmt1 USING @a", "", "")
+	require.NoError(t, err)
+	v, ok = sms[0].(*ast.PlanReplayerStmt)
+	require.True(t, ok)
+	require.Equal(t, "EXECUTE stmt1 USING @a", v.Stmt.Text())
+	require.False(t, v.Analyze)
 }
 
 func TestTrafficStmt(t *testing.T) {


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #64205

Problem Summary:

### What changed and how does it work?
support dump plan replayer for prepare stmt

### Check List

Tests 

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Support dump plan replayer for prepare stmt
```
