### PR TITLE
executor: downgrade TiCI indexlookup inconsistency to warning | tidb-test=a9bf2dca824dc746361234cd4d763178e0eedd13 tiflash=feature-fts

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -1956,19 +1956,34 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 				obtainedHandlesMap.Set(handle, true)
 			}
 			missHds := GetLackHandles(task.handles, obtainedHandlesMap)
-			return reportIndexLookupInconsistency(ctx,
-				w.idxLookup.dctx,
-				w.idxLookup.table.Meta(),
-				w.idxLookup.index,
-				w.idxLookup.enableRedactLog,
-				w.idxLookup.storage,
-				func(hd kv.Handle) kv.Key {
+			if w.idxLookup.index.IsTiCIIndex() {
+				warn := consistency.ErrLookupInconsistent.GenWithStackByArgs(
+					w.idxLookup.table.Meta().Name.O,
+					w.idxLookup.index.Name.O,
+					handleCnt,
+					len(task.rows),
+				)
+				if w.idxLookup.dctx != nil {
+					w.idxLookup.dctx.AppendWarning(warn)
+					return nil
+				}
+				return warn
+			}
+			return (&consistency.Reporter{
+				HandleEncode: func(hd kv.Handle) kv.Key {
 					return tablecodec.EncodeRecordKey(w.idxLookup.table.RecordPrefix(), hd)
 				},
+				Tbl:             w.idxLookup.table.Meta(),
+				Idx:             w.idxLookup.index,
+				EnableRedactLog: w.idxLookup.enableRedactLog,
+				Storage:         w.idxLookup.storage,
+			}).ReportLookupInconsistent(ctx,
 				handleCnt,
 				len(task.rows),
 				missHds,
 				task.handles,
+				nil,
+				//missRecords,
 			)
 		}
 	}
@@ -1997,36 +2012,6 @@ func GetLackHandles(expectedHandles []kv.Handle, obtainedHandlesMap *kv.HandleMa
 	}
 
 	return diffHandles
-}
-
-func reportIndexLookupInconsistency(
-	ctx context.Context,
-	dctx *distsqlctx.DistSQLContext,
-	tblInfo *model.TableInfo,
-	idxInfo *model.IndexInfo,
-	enableRedactLog string,
-	storage kv.Storage,
-	handleEncode func(kv.Handle) kv.Key,
-	indexCnt, recordCnt int,
-	missHd, fullHd []kv.Handle,
-) error {
-	// TiCI index lookup has eventual consistency characteristics in some cases.
-	// Keep returning rows and expose inconsistency through warnings instead of failing the query.
-	if idxInfo.IsTiCIIndex() {
-		warn := consistency.ErrLookupInconsistent.GenWithStackByArgs(tblInfo.Name.O, idxInfo.Name.O, indexCnt, recordCnt)
-		if dctx != nil {
-			dctx.AppendWarning(warn)
-			return nil
-		}
-		return warn
-	}
-	return (&consistency.Reporter{
-		HandleEncode:    handleEncode,
-		Tbl:             tblInfo,
-		Idx:             idxInfo,
-		EnableRedactLog: enableRedactLog,
-		Storage:         storage,
-	}).ReportLookupInconsistent(ctx, indexCnt, recordCnt, missHd, fullHd, nil)
 }
 
 func getPhysicalPlanIDs(plans []base.PhysicalPlan) []int {

--- a/pkg/executor/table_readers_required_rows_test.go
+++ b/pkg/executor/table_readers_required_rows_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
-	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
@@ -36,7 +35,6 @@ import (
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
-	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 )
@@ -264,56 +262,4 @@ func TestIndexReaderRequiredRows(t *testing.T) {
 		}
 		require.NoError(t, executor.Close())
 	}
-}
-
-func TestReportIndexLookupInconsistencyForTiCI(t *testing.T) {
-	warnHandler := contextutil.NewStaticWarnHandler(0)
-	dctx := &distsqlctx.DistSQLContext{WarnHandler: warnHandler}
-	tbl := &model.TableInfo{Name: ast.NewCIStr("t")}
-	idx := &model.IndexInfo{
-		Name:         ast.NewCIStr("idx"),
-		FullTextInfo: &model.FullTextIndexInfo{},
-	}
-
-	err := reportIndexLookupInconsistency(
-		context.Background(),
-		dctx,
-		tbl,
-		idx,
-		"",
-		nil,
-		nil,
-		2,
-		1,
-		nil,
-		nil,
-	)
-	require.NoError(t, err)
-	warns := warnHandler.GetWarnings()
-	require.Len(t, warns, 1)
-	require.Equal(t, contextutil.WarnLevelWarning, warns[0].Level)
-	require.Equal(t, "[executor:8133]data inconsistency in table: t, index: idx, index-count:2 != record-count:1", warns[0].Err.Error())
-}
-
-func TestReportIndexLookupInconsistencyForNonTiCI(t *testing.T) {
-	warnHandler := contextutil.NewStaticWarnHandler(0)
-	dctx := &distsqlctx.DistSQLContext{WarnHandler: warnHandler}
-	tbl := &model.TableInfo{Name: ast.NewCIStr("t")}
-	idx := &model.IndexInfo{Name: ast.NewCIStr("idx")}
-
-	err := reportIndexLookupInconsistency(
-		context.Background(),
-		dctx,
-		tbl,
-		idx,
-		"",
-		nil,
-		func(hd kv.Handle) kv.Key { return nil },
-		1,
-		0,
-		[]kv.Handle{kv.IntHandle(1)},
-		[]kv.Handle{kv.IntHandle(1)},
-	)
-	require.EqualError(t, err, "[executor:8133]data inconsistency in table: t, index: idx, index-count:1 != record-count:0")
-	require.Equal(t, 0, warnHandler.WarningCount())
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close pingcap-inc/tici#762

Problem Summary:
For TiCI indexlookup queries, data inconsistency currently aborts query execution with `[executor:8133]`.
For TiCI, this inconsistency should be reported as warning instead of error.

### What changed and how does it work?

- Refactored indexlookup inconsistency reporting in `pkg/executor/distsql.go` into a helper.
- For TiCI indexlookup (`idxInfo.IsTiCIIndex()`), inconsistency is appended to statement warnings and query execution continues.
- For non-TiCI indexlookup, existing behavior is preserved (still returns inconsistency error).
- Added unit tests in `pkg/executor/table_readers_required_rows_test.go`:
  - `TestReportIndexLookupInconsistencyForTiCI`
  - `TestReportIndexLookupInconsistencyForNonTiCI`


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
For TiCI indexlookup queries, data inconsistency is now reported as a warning instead of returning an error.
```
