### PR TITLE
s3: log more info when detecting region

### DIFF
--- a/pkg/objstore/s3store/logger.go
+++ b/pkg/objstore/s3store/logger.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/aws/smithy-go/logging"
-	"github.com/pingcap/log"
 	"go.uber.org/zap"
 )
 
@@ -26,9 +25,9 @@ type pingcapLogger struct {
 	logger *zap.Logger
 }
 
-func newLogger(extraFields ...zap.Field) pingcapLogger {
+func newLogger(logger *zap.Logger) pingcapLogger {
 	return pingcapLogger{
-		logger: log.L().WithOptions(zap.AddCallerSkip(1)).With(extraFields...),
+		logger: logger.WithOptions(zap.AddCallerSkip(1)),
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #66019

Problem Summary:

### What changed and how does it work?
one tidb might access multiple buckets, we log bucket/prefix/provider to differentiate between them
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

tested on minio, now we can different between global sort bucket and dataset bucket
```log
[2026/02/09 11:24:26.340 +08:00] [INFO] [store.go:275] ["succeed to get bucket region from s3"] [keyspaceName=SYSTEM] [bucket=mybucket] [prefix=] [context=s3] [provider=] ["bucket region"=us-east-1]
[2026/02/09 11:24:26.341 +08:00] [INFO] [store.go:275] ["succeed to get bucket region from s3"] [keyspaceName=SYSTEM] [bucket=mybucket] [prefix=gsort-tmp/7604700665860720834] [context=s3] [provider=minio] ["bucket region"=]
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
