### PR TITLE
feat(runaway): paginate watch sync using id checkpoints

### DIFF
--- a/pkg/resourcegroup/runaway/manager.go
+++ b/pkg/resourcegroup/runaway/manager.go
@@ -389,22 +389,32 @@ func (rm *Manager) UpdateNewAndDoneWatch() error {
 	if !rm.runawaySyncer.checkWatchTableExist() {
 		return nil
 	}
-	records, err := rm.runawaySyncer.getNewWatchRecords()
-	if err != nil {
-		return err
-	}
-	for _, r := range records {
-		rm.AddWatch(r)
+	for {
+		records, err := rm.runawaySyncer.getNewWatchRecords()
+		if err != nil {
+			return err
+		}
+		for _, r := range records {
+			rm.AddWatch(r)
+		}
+		if len(records) < watchSyncBatchLimit {
+			break
+		}
 	}
 	if !rm.runawaySyncer.checkWatchDoneTableExist() {
 		return nil
 	}
-	doneRecords, err := rm.runawaySyncer.getNewWatchDoneRecords()
-	if err != nil {
-		return err
-	}
-	for _, r := range doneRecords {
-		rm.removeWatch(r)
+	for {
+		doneRecords, err := rm.runawaySyncer.getNewWatchDoneRecords()
+		if err != nil {
+			return err
+		}
+		for _, r := range doneRecords {
+			rm.removeWatch(r)
+		}
+		if len(doneRecords) < watchSyncBatchLimit {
+			break
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65746.

### What changed and how does it work?

- Change runaway watch/watch-done syncing to fetch records in batches (limit 256) until drained
- Switch system table readers from time-based checkpoints to monotonically increasing `id` checkpoints
- Update select queries to order by `id` and apply batch limits, advancing checkpoints to the last fetched row for reliable incremental sync

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
