### PR TITLE
refactor(runaway): make active watch counting lock-free

### DIFF
--- a/pkg/resourcegroup/runaway/BUILD.bazel
+++ b/pkg/resourcegroup/runaway/BUILD.bazel
@@ -52,9 +52,10 @@ go_test(
     ],
     embed = [":runaway"],
     flaky = True,
-    shard_count = 6,
+    shard_count = 15,
     deps = [
         "//pkg/metrics",
+        "@com_github_pingcap_kvproto//pkg/resource_manager",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//util",

--- a/pkg/resourcegroup/runaway/checker.go
+++ b/pkg/resourcegroup/runaway/checker.go
@@ -99,9 +99,7 @@ func (rm *Manager) DeriveChecker(resourceGroupName, originalSQL, sqlDigest, plan
 	if len(planDigest) == 0 {
 		return nil
 	}
-	rm.ActiveLock.RLock()
-	defer rm.ActiveLock.RUnlock()
-	if group.RunawaySettings == nil && rm.ActiveGroup[resourceGroupName] == 0 {
+	if group.RunawaySettings == nil && rm.getActiveWatchCount(resourceGroupName) == 0 {
 		return nil
 	}
 	counter, ok := rm.MetricsMap.Load(resourceGroupName)

--- a/pkg/resourcegroup/runaway/checker_test.go
+++ b/pkg/resourcegroup/runaway/checker_test.go
@@ -20,9 +20,63 @@ import (
 	"testing"
 	"time"
 
+	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/stretchr/testify/assert"
 	"github.com/tikv/client-go/v2/util"
 )
+
+func TestActiveGroupCounterOrdering(t *testing.T) {
+	t.Run("NormalOrder", func(t *testing.T) {
+		m := &Manager{}
+		group := "rg_normal"
+		// Simulate insertion callback: +1
+		counter, _ := m.loadOrStoreActiveCounter(group)
+		counter.Add(1)
+		// Simulate eviction callback: -1
+		counter, _ = m.loadOrStoreActiveCounter(group)
+		counter.Add(-1)
+		assert.Equal(t, int64(0), m.getActiveWatchCount(group))
+	})
+
+	t.Run("ReversedOrder", func(t *testing.T) {
+		m := &Manager{}
+		group := "rg_reversed"
+		// Simulate eviction callback arriving before insertion callback: -1 first
+		counter, _ := m.loadOrStoreActiveCounter(group)
+		counter.Add(-1)
+		// Then insertion callback: +1
+		counter, _ = m.loadOrStoreActiveCounter(group)
+		counter.Add(1)
+		assert.Equal(t, int64(0), m.getActiveWatchCount(group))
+	})
+
+	t.Run("NonExistentGroup", func(t *testing.T) {
+		m := &Manager{}
+		assert.Equal(t, int64(0), m.getActiveWatchCount("no_such_group"))
+	})
+
+	t.Run("ConcurrentInsertionAndEviction", func(t *testing.T) {
+		m := &Manager{}
+		group := "rg_concurrent"
+		const n = 1000
+		var wg sync.WaitGroup
+		wg.Add(2 * n)
+		for range n {
+			go func() {
+				defer wg.Done()
+				c, _ := m.loadOrStoreActiveCounter(group)
+				c.Add(1)
+			}()
+			go func() {
+				defer wg.Done()
+				c, _ := m.loadOrStoreActiveCounter(group)
+				c.Add(-1)
+			}()
+		}
+		wg.Wait()
+		assert.Equal(t, int64(0), m.getActiveWatchCount(group))
+	})
+}
 
 func TestConcurrentResetAndCheckThresholds(t *testing.T) {
 	checker := &Checker{}
@@ -61,4 +115,295 @@ func TestConcurrentResetAndCheckThresholds(t *testing.T) {
 	// Final check to ensure no race conditions occurred
 	finalValue := atomic.LoadInt64(&checker.totalProcessedKeys)
 	assert.GreaterOrEqual(t, finalValue, int64(0), "unexpected negative totalProcessedKeys value")
+}
+
+func TestNewChecker(t *testing.T) {
+	t.Run("NilSettings", func(t *testing.T) {
+		c := NewChecker(nil, "rg", nil, "SELECT 1", "sql_d", "plan_d", time.Now())
+		assert.True(t, c.deadline.IsZero())
+		assert.Equal(t, int64(0), c.ruThreshold)
+		assert.Equal(t, int64(0), c.processedKeysThreshold)
+		assert.Nil(t, c.settings)
+	})
+
+	t.Run("WithAllThresholds", func(t *testing.T) {
+		start := time.Now()
+		settings := &rmpb.RunawaySettings{
+			Rule: &rmpb.RunawayRule{
+				ExecElapsedTimeMs: 5000,
+				RequestUnit:       1000,
+				ProcessedKeys:     500,
+			},
+		}
+		c := NewChecker(nil, "rg", settings, "SELECT 1", "sql_d", "plan_d", start)
+		assert.Equal(t, start.Add(5000*time.Millisecond), c.deadline)
+		assert.Equal(t, int64(1000), c.ruThreshold)
+		assert.Equal(t, int64(500), c.processedKeysThreshold)
+	})
+
+	t.Run("ZeroElapsedTimeSkipsDeadline", func(t *testing.T) {
+		settings := &rmpb.RunawaySettings{
+			Rule: &rmpb.RunawayRule{
+				ExecElapsedTimeMs: 0,
+				ProcessedKeys:     500,
+			},
+		}
+		c := NewChecker(nil, "rg", settings, "SELECT 1", "sql_d", "plan_d", time.Now())
+		assert.True(t, c.deadline.IsZero())
+		assert.Equal(t, int64(500), c.processedKeysThreshold)
+	})
+}
+
+func TestExceedsThresholds(t *testing.T) {
+	t.Run("NoThresholds", func(t *testing.T) {
+		c := &Checker{}
+		assert.Empty(t, c.exceedsThresholds(time.Now(), nil, 0))
+	})
+
+	t.Run("DeadlineExceeded", func(t *testing.T) {
+		c := &Checker{deadline: time.Now().Add(-time.Second)}
+		cause := c.exceedsThresholds(time.Now(), nil, 0)
+		assert.Contains(t, cause, "ElapsedTime")
+	})
+
+	t.Run("DeadlineNotExceeded", func(t *testing.T) {
+		c := &Checker{deadline: time.Now().Add(time.Hour)}
+		assert.Empty(t, c.exceedsThresholds(time.Now(), nil, 0))
+	})
+
+	t.Run("ProcessedKeysNotExceeded", func(t *testing.T) {
+		c := &Checker{processedKeysThreshold: 100}
+		assert.Empty(t, c.exceedsThresholds(time.Now(), nil, 50))
+	})
+
+	t.Run("ProcessedKeysAtThreshold", func(t *testing.T) {
+		c := &Checker{processedKeysThreshold: 100}
+		cause := c.exceedsThresholds(time.Now(), nil, 100)
+		assert.Contains(t, cause, "ProcessedKeys")
+	})
+
+	t.Run("DeadlineTakesPriority", func(t *testing.T) {
+		c := &Checker{
+			deadline:               time.Now().Add(-time.Second),
+			processedKeysThreshold: 100,
+		}
+		cause := c.exceedsThresholds(time.Now(), nil, 200)
+		assert.Contains(t, cause, "ElapsedTime")
+		assert.NotContains(t, cause, "ProcessedKeys")
+	})
+}
+
+func TestCheckerCheckAction(t *testing.T) {
+	t.Run("Unmarked", func(t *testing.T) {
+		c := &Checker{}
+		assert.Equal(t, rmpb.RunawayAction_NoneAction, c.CheckAction())
+	})
+
+	t.Run("MarkedByWatchRule", func(t *testing.T) {
+		c := &Checker{
+			markedByQueryWatchRule: true,
+			watchAction:            rmpb.RunawayAction_CoolDown,
+		}
+		assert.Equal(t, rmpb.RunawayAction_CoolDown, c.CheckAction())
+	})
+
+	t.Run("MarkedBySettings", func(t *testing.T) {
+		c := &Checker{
+			settings: &rmpb.RunawaySettings{Action: rmpb.RunawayAction_Kill},
+		}
+		c.markedByIdentifyInRunawaySettings.Store(true)
+		assert.Equal(t, rmpb.RunawayAction_Kill, c.CheckAction())
+	})
+
+	t.Run("BothMarked_WatchTakesPriority", func(t *testing.T) {
+		c := &Checker{
+			markedByQueryWatchRule: true,
+			watchAction:            rmpb.RunawayAction_CoolDown,
+			settings:               &rmpb.RunawaySettings{Action: rmpb.RunawayAction_Kill},
+		}
+		c.markedByIdentifyInRunawaySettings.Store(true)
+		assert.Equal(t, rmpb.RunawayAction_CoolDown, c.CheckAction())
+	})
+}
+
+func TestGetSettingConvictIdentifier(t *testing.T) {
+	t.Run("NilSettings", func(t *testing.T) {
+		c := &Checker{}
+		assert.Empty(t, c.getSettingConvictIdentifier())
+	})
+
+	t.Run("NilWatch", func(t *testing.T) {
+		c := &Checker{settings: &rmpb.RunawaySettings{}}
+		assert.Empty(t, c.getSettingConvictIdentifier())
+	})
+
+	t.Run("PlanType", func(t *testing.T) {
+		c := &Checker{
+			planDigest: "plan123", sqlDigest: "sql123", originalSQL: "SELECT 1",
+			settings: &rmpb.RunawaySettings{Watch: &rmpb.RunawayWatch{Type: rmpb.RunawayWatchType_Plan}},
+		}
+		assert.Equal(t, "plan123", c.getSettingConvictIdentifier())
+	})
+
+	t.Run("SimilarType", func(t *testing.T) {
+		c := &Checker{
+			planDigest: "plan123", sqlDigest: "sql123", originalSQL: "SELECT 1",
+			settings: &rmpb.RunawaySettings{Watch: &rmpb.RunawayWatch{Type: rmpb.RunawayWatchType_Similar}},
+		}
+		assert.Equal(t, "sql123", c.getSettingConvictIdentifier())
+	})
+
+	t.Run("ExactType", func(t *testing.T) {
+		c := &Checker{
+			planDigest: "plan123", sqlDigest: "sql123", originalSQL: "SELECT 1",
+			settings: &rmpb.RunawaySettings{Watch: &rmpb.RunawayWatch{Type: rmpb.RunawayWatchType_Exact}},
+		}
+		assert.Equal(t, "SELECT 1", c.getSettingConvictIdentifier())
+	})
+}
+
+func TestNilCheckerSafety(t *testing.T) {
+	var c *Checker
+	assert.Equal(t, rmpb.RunawayAction_NoneAction, c.CheckAction())
+	assert.False(t, c.isMarkedByIdentifyInRunawaySettings())
+	assert.Empty(t, c.getSettingConvictIdentifier())
+
+	switchGroup, err := c.BeforeExecutor()
+	assert.Empty(t, switchGroup)
+	assert.NoError(t, err)
+
+	assert.NoError(t, c.BeforeCopRequest(nil))
+
+	exceedCause, shouldKill := c.CheckRuleKillAction()
+	assert.Empty(t, exceedCause)
+	assert.False(t, shouldKill)
+
+	assert.NoError(t, c.CheckThresholds(nil, 0, nil))
+	c.ResetTotalProcessedKeys() // should not panic
+}
+
+func TestCheckThresholds(t *testing.T) {
+	newCheckerWithAction := func(action rmpb.RunawayAction) (*Checker, *Manager) {
+		m := &Manager{runawayQueriesChan: make(chan *Record, 10)}
+		c := &Checker{
+			manager:                m,
+			resourceGroupName:      "rg_threshold",
+			processedKeysThreshold: 100,
+			settings: &rmpb.RunawaySettings{
+				Action: action,
+				Rule:   &rmpb.RunawayRule{ProcessedKeys: 100},
+			},
+		}
+		return c, m
+	}
+
+	t.Run("BelowThreshold", func(t *testing.T) {
+		c, _ := newCheckerWithAction(rmpb.RunawayAction_Kill)
+		err := c.CheckThresholds(&util.RUDetails{}, 50, nil)
+		assert.NoError(t, err)
+		assert.False(t, c.markedByIdentifyInRunawaySettings.Load())
+	})
+
+	t.Run("KillOnExceed", func(t *testing.T) {
+		c, m := newCheckerWithAction(rmpb.RunawayAction_Kill)
+		err := c.CheckThresholds(&util.RUDetails{}, 200, nil)
+		assert.Error(t, err)
+		assert.True(t, c.markedByIdentifyInRunawaySettings.Load())
+		assert.Equal(t, 1, len(m.runawayQueriesChan))
+	})
+
+	t.Run("CoolDownOnExceed", func(t *testing.T) {
+		c, m := newCheckerWithAction(rmpb.RunawayAction_CoolDown)
+		err := c.CheckThresholds(&util.RUDetails{}, 200, nil)
+		assert.NoError(t, err)
+		assert.True(t, c.markedByIdentifyInRunawaySettings.Load())
+		assert.Equal(t, 1, len(m.runawayQueriesChan))
+	})
+}
+
+func TestCheckRuleKillAction(t *testing.T) {
+	newCheckerWithDeadline := func(action rmpb.RunawayAction) *Checker {
+		m := &Manager{runawayQueriesChan: make(chan *Record, 10)}
+		return &Checker{
+			manager:           m,
+			resourceGroupName: "rg_rule_kill",
+			deadline:          time.Now().Add(-time.Second),
+			settings: &rmpb.RunawaySettings{
+				Action: action,
+				Rule:   &rmpb.RunawayRule{ExecElapsedTimeMs: 1},
+			},
+		}
+	}
+
+	t.Run("NoSettings", func(t *testing.T) {
+		c := &Checker{}
+		cause, kill := c.CheckRuleKillAction()
+		assert.Empty(t, cause)
+		assert.False(t, kill)
+	})
+
+	t.Run("KillActionExceeded", func(t *testing.T) {
+		c := newCheckerWithDeadline(rmpb.RunawayAction_Kill)
+		cause, kill := c.CheckRuleKillAction()
+		assert.Contains(t, cause, "ElapsedTime")
+		assert.True(t, kill)
+		assert.True(t, c.markedByIdentifyInRunawaySettings.Load())
+	})
+
+	t.Run("CoolDownActionExceeded", func(t *testing.T) {
+		c := newCheckerWithDeadline(rmpb.RunawayAction_CoolDown)
+		cause, kill := c.CheckRuleKillAction()
+		assert.Contains(t, cause, "ElapsedTime")
+		assert.False(t, kill)
+	})
+
+	t.Run("NotExceeded", func(t *testing.T) {
+		m := &Manager{runawayQueriesChan: make(chan *Record, 10)}
+		c := &Checker{
+			manager:           m,
+			resourceGroupName: "rg_rule_kill",
+			deadline:          time.Now().Add(time.Hour),
+			settings: &rmpb.RunawaySettings{
+				Action: rmpb.RunawayAction_Kill,
+				Rule:   &rmpb.RunawayRule{ExecElapsedTimeMs: 99999999},
+			},
+		}
+		cause, kill := c.CheckRuleKillAction()
+		assert.Empty(t, cause)
+		assert.False(t, kill)
+	})
+
+	t.Run("AlreadyMarked", func(t *testing.T) {
+		c := newCheckerWithDeadline(rmpb.RunawayAction_Kill)
+		c.markedByIdentifyInRunawaySettings.Store(true)
+		cause, kill := c.CheckRuleKillAction()
+		assert.Empty(t, cause)
+		assert.False(t, kill)
+	})
+}
+
+func TestMarkRunawayBySettingsCAS(t *testing.T) {
+	m := &Manager{runawayQueriesChan: make(chan *Record, 10)}
+	c := &Checker{
+		manager:           m,
+		resourceGroupName: "rg_cas",
+		settings: &rmpb.RunawaySettings{
+			Action: rmpb.RunawayAction_Kill,
+			Rule:   &rmpb.RunawayRule{},
+		},
+	}
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	now := time.Now()
+	for range n {
+		go func() {
+			defer wg.Done()
+			c.markRunawayByIdentifyInRunawaySettings(&now, "test cause")
+		}()
+	}
+	wg.Wait()
+	assert.True(t, c.markedByIdentifyInRunawaySettings.Load())
+	// CAS ensures only one goroutine successfully marks and enqueues a record.
+	assert.Equal(t, 1, len(m.runawayQueriesChan))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65746.

### What changed and how does it work?

- Replace the manager’s `ActiveGroup` map + RWMutex with a `sync.Map` of `atomic.Int64` counters to avoid lock contention on the hot path.
- Update watchlist insertion/eviction hooks to increment/decrement the per-group atomic counter, and switch checker logic to use the new active watch count accessor when deciding whether to derive a runaway checker.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
