### PR TITLE
fix(runaway): drop syncer mutex

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -4576,13 +4576,13 @@ def go_deps():
         name = "com_github_jellydator_ttlcache_v3",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/jellydator/ttlcache/v3",
-        sha256 = "75cabcc118414bc9e42cef6769fffc0c500954f2ef1988a3797aee0f4351f306",
-        strip_prefix = "github.com/jellydator/ttlcache/v3@v3.0.1",
+        sha256 = "b3f31d5c4ea68698f1de6f85dbaacb176b2fadeaa6d426a38f48f4f752f974fb",
+        strip_prefix = "github.com/jellydator/ttlcache/v3@v3.4.0",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/jellydator/ttlcache/v3/com_github_jellydator_ttlcache_v3-v3.0.1.zip",
-            "http://ats.apps.svc/gomod/github.com/jellydator/ttlcache/v3/com_github_jellydator_ttlcache_v3-v3.0.1.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/jellydator/ttlcache/v3/com_github_jellydator_ttlcache_v3-v3.0.1.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/jellydator/ttlcache/v3/com_github_jellydator_ttlcache_v3-v3.0.1.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/jellydator/ttlcache/v3/com_github_jellydator_ttlcache_v3-v3.4.0.zip",
+            "http://ats.apps.svc/gomod/github.com/jellydator/ttlcache/v3/com_github_jellydator_ttlcache_v3-v3.4.0.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/jellydator/ttlcache/v3/com_github_jellydator_ttlcache_v3-v3.4.0.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/jellydator/ttlcache/v3/com_github_jellydator_ttlcache_v3-v3.4.0.zip",
         ],
     )
     go_repository(
@@ -10913,13 +10913,13 @@ def go_deps():
         name = "org_golang_x_lint",
         build_file_proto_mode = "disable_global",
         importpath = "golang.org/x/lint",
-        sha256 = "4620205ccd1fd5c5ced7ccbc264217f407c53924e847f4219e48c04c7480b294",
-        strip_prefix = "golang.org/x/lint@v0.0.0-20201208152925-83fdc39ff7b5",
+        sha256 = "8bffecf110daa2ee6302f692052293b779926200327af2118e034c9c4d1aa1c2",
+        strip_prefix = "golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/golang.org/x/lint/org_golang_x_lint-v0.0.0-20201208152925-83fdc39ff7b5.zip",
-            "http://ats.apps.svc/gomod/golang.org/x/lint/org_golang_x_lint-v0.0.0-20201208152925-83fdc39ff7b5.zip",
-            "https://cache.hawkingrei.com/gomod/golang.org/x/lint/org_golang_x_lint-v0.0.0-20201208152925-83fdc39ff7b5.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/golang.org/x/lint/org_golang_x_lint-v0.0.0-20201208152925-83fdc39ff7b5.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/golang.org/x/lint/org_golang_x_lint-v0.0.0-20200302205851-738671d3881b.zip",
+            "http://ats.apps.svc/gomod/golang.org/x/lint/org_golang_x_lint-v0.0.0-20200302205851-738671d3881b.zip",
+            "https://cache.hawkingrei.com/gomod/golang.org/x/lint/org_golang_x_lint-v0.0.0-20200302205851-738671d3881b.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/golang.org/x/lint/org_golang_x_lint-v0.0.0-20200302205851-738671d3881b.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/hashicorp/go-version v1.8.0
 	github.com/jedib0t/go-pretty/v6 v6.2.2
-	github.com/jellydator/ttlcache/v3 v3.0.1
+	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/jfcg/sorty/v2 v2.1.0
 	github.com/jingyugao/rowserrcheck v1.1.1
 	github.com/johannesboyne/gofakes3 v0.0.0-20230506070712-04da935ef877

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,8 @@ github.com/influxdata/tdigest v0.0.1 h1:XpFptwYmnEKUqmkcDjrzffswZ3nvNeevbUSLPP/Z
 github.com/influxdata/tdigest v0.0.1/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=
 github.com/jedib0t/go-pretty/v6 v6.2.2 h1:o3McN0rQ4X+IU+HduppSp9TwRdGLRW2rhJXy9CJaCRw=
 github.com/jedib0t/go-pretty/v6 v6.2.2/go.mod h1:+nE9fyyHGil+PuISTCrp7avEdo6bqoMwqZnuiK2r2a0=
-github.com/jellydator/ttlcache/v3 v3.0.1 h1:cHgCSMS7TdQcoprXnWUptJZzyFsqs18Lt8VVhRuZYVU=
-github.com/jellydator/ttlcache/v3 v3.0.1/go.mod h1:WwTaEmcXQ3MTjOm4bsZoDFiCu/hMvNWLO1w67RXz6h4=
+github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=
+github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jfcg/opt v0.3.1 h1:6zgKvv3fR5OlX2nxUYJC4wtosY30N4vypILgXmRNr34=
 github.com/jfcg/opt v0.3.1/go.mod h1:3ZUYQhiqKM6vVjMRYV1fVZ9a91EQ47b5kg7KsnfRClk=
 github.com/jfcg/rng v1.0.4 h1:wCAgNN4UaNAL7pMHNkXjHzPuNkNmvVa0vzk5ntYl9gY=

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -3826,10 +3826,6 @@ func (e *memtableRetriever) setDataFromPlacementPolicies(sctx sessionctx.Context
 
 func (e *memtableRetriever) setDataFromRunawayWatches(sctx sessionctx.Context) error {
 	do := domain.GetDomain(sctx)
-	err := do.RunawayManager().UpdateNewAndDoneWatch()
-	if err != nil {
-		logutil.BgLogger().Warn("read runaway watch list", zap.Error(err))
-	}
 	watches := do.RunawayManager().GetWatchList()
 	rows := make([][]types.Datum, 0, len(watches))
 	for _, watch := range watches {

--- a/pkg/executor/internal/querywatch/BUILD.bazel
+++ b/pkg/executor/internal/querywatch/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     ],
     embed = [":querywatch"],
     flaky = True,
-    shard_count = 2,
+    shard_count = 3,
     deps = [
         "//pkg/config",
         "//pkg/errno",

--- a/pkg/executor/internal/querywatch/BUILD.bazel
+++ b/pkg/executor/internal/querywatch/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     ],
     embed = [":querywatch"],
     flaky = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         "//pkg/config",
         "//pkg/errno",

--- a/pkg/executor/internal/querywatch/query_watch_test.go
+++ b/pkg/executor/internal/querywatch/query_watch_test.go
@@ -168,6 +168,12 @@ func TestQueryWatch(t *testing.T) {
 	require.Nil(t, rs)
 	r = tk.MustQuery("select * from information_schema.runaway_watches where resource_group_name = 'rg1'")
 	require.Equal(t, 0, len(r.Rows()))
+	// verify done records: rg1 watches (IDs 3,4,5) should be moved to done table with all fields
+	tk.MustQuery("select SQL_NO_CACHE record_id, resource_group_name, end_time, watch, watch_text, source, action, switch_group_name, rule from mysql.tidb_runaway_watch_done where resource_group_name = 'rg1' order by record_id").Check(
+		testkit.Rows(
+			"3 rg1 <nil> 1 select * from test.t1 manual 3  None",
+			"4 rg1 <nil> 2 02576c15e1f35a8aa3eb7e3b1f977c9f9f9921a22421b3e9f42bad5ab632b4f6 manual 3  None",
+			"5 rg1 <nil> 3 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 manual 1  None"))
 	// test user variable
 	r = tk.MustQuery("select * from information_schema.runaway_watches where resource_group_name = 'rg2'")
 	require.Equal(t, 1, len(r.Rows()))
@@ -179,10 +185,20 @@ func TestQueryWatch(t *testing.T) {
 	require.Nil(t, rs)
 	r = tk.MustQuery("select * from information_schema.runaway_watches where resource_group_name = 'rg2'")
 	require.Equal(t, 0, len(r.Rows()))
+	// verify done record: rg2 watch (ID 9) should be moved to done table with all fields
+	tk.MustQuery("select SQL_NO_CACHE record_id, resource_group_name, end_time, watch, watch_text, source, action, switch_group_name, rule from mysql.tidb_runaway_watch_done where resource_group_name = 'rg2'").Check(
+		testkit.Rows("9 rg2 <nil> 3 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 manual 3  None"))
 	// test remove by id
 	rs, err = tk.Exec("query watch remove 1")
 	require.NoError(t, err)
 	require.Nil(t, rs)
+	// verify done record: watch ID 1 should be moved to done table with all fields
+	tk.MustQuery("select SQL_NO_CACHE record_id, resource_group_name, end_time, watch, watch_text, source, action, switch_group_name, rule from mysql.tidb_runaway_watch_done where record_id = 1").Check(
+		testkit.Rows("1 default <nil> 1 select * from test.t1 manual 1  None"))
+	// verify total: exactly 5 done records (3 from rg1 + 1 from rg2 + 1 from id=1), no duplicates
+	tk.MustQuery("select SQL_NO_CACHE count(*) from mysql.tidb_runaway_watch_done").Check(testkit.Rows("5"))
+	// verify start_time and done_time are populated for all done records
+	tk.MustQuery("select SQL_NO_CACHE count(*) from mysql.tidb_runaway_watch_done where start_time IS NULL or done_time IS NULL").Check(testkit.Rows("0"))
 	var lastObservedErr any
 	require.Eventuallyf(t, func() bool {
 		err := tk.ExecToErr("select * from test.t1")
@@ -239,6 +255,62 @@ func TestConcurrentQueryWatchRemove(t *testing.T) {
 	tk.MustQuery("select SQL_NO_CACHE count(*) from mysql.tidb_runaway_watch where id = 1").Check(testkit.Rows("0"))
 	// Verify: exactly 1 done record for record_id = 1 (no duplicates from concurrent removes).
 	tk.MustQuery("select SQL_NO_CACHE count(*) from mysql.tidb_runaway_watch_done where record_id = 1").Check(testkit.Rows("1"))
+}
+
+func TestNonManualWatchRuleField(t *testing.T) {
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC", `return(20000)`))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC"))
+	}()
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1(a int)")
+	tk.MustExec("insert into t1 values(1)")
+
+	// Create resource group with WATCH in QUERY_LIMIT to trigger automatic watch creation.
+	tk.MustExec("create resource group rg_auto RU_PER_SEC=1000 QUERY_LIMIT=(EXEC_ELAPSED='50ms' ACTION=KILL WATCH EXACT DURATION '10m')")
+
+	// Simulate a slow query that exceeds the 50ms threshold.
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/copr/sleepCoprRequest", fmt.Sprintf("return(%d)", 60)))
+	err := tk.QueryToErr("select /*+ resource_group(rg_auto) */ * from t1")
+	require.ErrorContains(t, err, "[executor:8253]Query execution was interrupted, identified as runaway query")
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/copr/sleepCoprRequest"))
+
+	tryInterval := time.Millisecond * 200
+	maxWaitDuration := time.Second * 10
+
+	// Wait for the automatic watch to be flushed to the system table.
+	tk.EventuallyMustQueryAndCheck(
+		"select SQL_NO_CACHE resource_group_name, watch_text, action, watch from mysql.tidb_runaway_watch where resource_group_name = 'rg_auto'",
+		nil,
+		testkit.Rows("rg_auto select /*+ resource_group(rg_auto) */ * from t1 3 1"),
+		maxWaitDuration, tryInterval)
+
+	// Verify the auto-created watch has non-manual source and ElapsedTime rule.
+	tk.MustQuery("select SQL_NO_CACHE count(*) from mysql.tidb_runaway_watch" +
+		" where resource_group_name = 'rg_auto'" +
+		" AND source != 'manual'" +
+		" AND rule LIKE 'ElapsedTime = %'" +
+		" AND end_time IS NOT NULL").Check(testkit.Rows("1"))
+
+	// Remove the watch and verify done record preserves all fields correctly.
+	rs, err := tk.Exec("query watch remove resource group rg_auto")
+	require.NoError(t, err)
+	require.Nil(t, rs)
+
+	// Verify the done record has the correct non-manual rule and all fields.
+	tk.MustQuery("select SQL_NO_CACHE count(*) from mysql.tidb_runaway_watch_done" +
+		" where resource_group_name = 'rg_auto'" +
+		" AND rule LIKE 'ElapsedTime = %'" +
+		" AND source != 'manual'" +
+		" AND watch_text = 'select /*+ resource_group(rg_auto) */ * from t1'" +
+		" AND watch = 1" +
+		" AND action = 3" +
+		" AND switch_group_name = ''" +
+		" AND end_time IS NOT NULL" +
+		" AND start_time IS NOT NULL" +
+		" AND done_time IS NOT NULL").Check(testkit.Rows("1"))
 }
 
 func TestQueryWatchIssue56897(t *testing.T) {

--- a/pkg/resourcegroup/runaway/manager.go
+++ b/pkg/resourcegroup/runaway/manager.go
@@ -409,8 +409,6 @@ func (rm *Manager) Stop() {
 
 // UpdateNewAndDoneWatch is used to update new and done watch items.
 func (rm *Manager) UpdateNewAndDoneWatch() error {
-	rm.runawaySyncer.mu.Lock()
-	defer rm.runawaySyncer.mu.Unlock()
 	if !rm.runawaySyncer.checkWatchTableExist() {
 		return nil
 	}

--- a/pkg/resourcegroup/runaway/record.go
+++ b/pkg/resourcegroup/runaway/record.go
@@ -461,8 +461,6 @@ func (rm *Manager) AddRunawayWatch(record *QuarantineRecord) (uint64, error) {
 
 // RemoveRunawayWatch is used to remove runaway watch item manually.
 func (rm *Manager) RemoveRunawayWatch(recordID int64) error {
-	rm.runawaySyncer.mu.Lock()
-	defer rm.runawaySyncer.mu.Unlock()
 	records, err := rm.runawaySyncer.getWatchRecordByID(recordID)
 	if err != nil {
 		return err
@@ -477,8 +475,6 @@ func (rm *Manager) RemoveRunawayWatch(recordID int64) error {
 
 // RemoveRunawayResourceGroupWatch is used to remove all runaway watch items of a resource group.
 func (rm *Manager) RemoveRunawayResourceGroupWatch(groupName string) error {
-	rm.runawaySyncer.mu.Lock()
-	defer rm.runawaySyncer.mu.Unlock()
 	records, err := rm.runawaySyncer.getWatchRecordByGroup(groupName)
 	if err != nil {
 		return errors.Annotate(err, "get watch records by resource group failed")

--- a/pkg/resourcegroup/runaway/syncer.go
+++ b/pkg/resourcegroup/runaway/syncer.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
@@ -53,8 +52,6 @@ type syncer struct {
 	deletionWatchReader *systemTableReader
 	sysSessionPool      util.SessionPool
 	infoCache           *infoschema.InfoCache
-
-	mu sync.Mutex
 }
 
 func newSyncer(sysSessionPool util.SessionPool, infoCache *infoschema.InfoCache) *syncer {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65746.

### What changed and how does it work?

The mutex has been fully removed. The changes are safe because:
                                              
  - `UpdateNewAndDoneWatch()` is now only called from a single goroutine (`RunawayWatchSyncLoop`), eliminating the need for mutex protection of `CheckPoint`.
  - `RemoveRunawayWatch()` and `RemoveRunawayResourceGroupWatch()` never accessed `CheckPoint` (they use `push=false` queries), so their locks were unnecessary.
  - `GetWatchList()` uses a thread-safe ttlcache internally, so the infoschema reader doesn't need to call `UpdateNewAndDoneWatch()` — data is at most 1 second stale from the background sync loop.
  - Update `jellydator/ttlcache` to adopt https://github.com/jellydator/ttlcache/pull/146.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
