### PR TITLE
pkg/ddl: add partition-aware modify-column regression tests

### DIFF
--- a/pkg/ddl/ddl_workerpool_test.go
+++ b/pkg/ddl/ddl_workerpool_test.go
@@ -19,6 +19,12 @@ import (
 	"testing"
 
 	"github.com/ngaut/pools"
+	sess "github.com/pingcap/tidb/pkg/ddl/session"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,4 +41,69 @@ func TestDDLWorkerPool(t *testing.T) {
 	require.Zero(t, pool.available())
 	pool.put(nil)
 	require.Zero(t, pool.available())
+}
+
+type mockSessionResource struct {
+	*mock.Context
+}
+
+func (*mockSessionResource) Close() {}
+
+func newMockDDLSessionPool() *sess.Pool {
+	resourcePool := pools.NewResourcePool(func() (pools.Resource, error) {
+		return &mockSessionResource{Context: mock.NewContext()}, nil
+	}, 1, 1, 0)
+	return sess.NewSessionPool(resourcePool)
+}
+
+func newRangePartitionTableInfo() *model.TableInfo {
+	colA := &model.ColumnInfo{ID: 1, Name: ast.NewCIStr("a"), Offset: 0}
+	colA.FieldType = *types.NewFieldType(mysql.TypeLong)
+	colB := &model.ColumnInfo{ID: 2, Name: ast.NewCIStr("b"), Offset: 1}
+	colB.FieldType = *types.NewFieldType(mysql.TypeLong)
+	return &model.TableInfo{
+		Name:    ast.NewCIStr("t"),
+		Columns: []*model.ColumnInfo{colA, colB},
+		Partition: &model.PartitionInfo{
+			Type:   ast.PartitionTypeRange,
+			Expr:   "`a`",
+			Enable: true,
+			Definitions: []model.PartitionDefinition{
+				{ID: 101, Name: ast.NewCIStr("p0"), LessThan: []string{"10"}},
+				{ID: 102, Name: ast.NewCIStr("pMax"), LessThan: []string{"MAXVALUE"}},
+			},
+		},
+	}
+}
+
+func TestPostCheckPartitionModifiableColumnErrorBranches(t *testing.T) {
+	t.Run("session pool get failure", func(t *testing.T) {
+		tblInfo := newRangePartitionTableInfo()
+		sessPool := newMockDDLSessionPool()
+		sessPool.Close()
+		w := &worker{sessPool: sessPool}
+		err := postCheckPartitionModifiableColumn(w, tblInfo, tblInfo.Columns[0], tblInfo.Columns[0].Clone())
+		require.ErrorContains(t, err, "session pool is closed")
+	})
+
+	t.Run("extract partition columns parse error", func(t *testing.T) {
+		tblInfo := newRangePartitionTableInfo()
+		tblInfo.Partition.Expr = "`a`+"
+		sessPool := newMockDDLSessionPool()
+		defer sessPool.Close()
+		w := &worker{sessPool: sessPool}
+		err := postCheckPartitionModifiableColumn(w, tblInfo, tblInfo.Columns[0], tblInfo.Columns[0].Clone())
+		require.Error(t, err)
+		require.ErrorContains(t, err, "line 1 column")
+	})
+
+	t.Run("generated partition info parse error", func(t *testing.T) {
+		tblInfo := newRangePartitionTableInfo()
+		tblInfo.Partition.Type = ast.PartitionTypeNone
+		sessPool := newMockDDLSessionPool()
+		defer sessPool.Close()
+		w := &worker{sessPool: sessPool}
+		err := postCheckPartitionModifiableColumn(w, tblInfo, tblInfo.Columns[0], tblInfo.Columns[0].Clone())
+		require.ErrorContains(t, err, "cannot parse generated PartitionInfo")
+	})
 }


### PR DESCRIPTION
Add regression tests for partition-aware ALTER TABLE ... MODIFY COLUMN.

New coverage includes:
- LIST expression partition: partition key modify success path.
- LIST COLUMNS partition: partition key modify success path.
- Concurrent DML during StateWriteOnly and StateWriteReorganization for modify-column reorg.
- Partition key modified to disallowed type (ErrNotAllowedTypeInPartition).
- Partition definitions incompatible with new column (ErrUnsupportedModifyColumn with mismatch detail).
- postCheckPartitionModifiableColumn internal error branches: 1) session pool Get() failure 2) extractPartitionColumns parse error 3) generated partition-info parse error (cannot parse generated PartitionInfo)

Tests:
- GOCACHE=/tmp/tidb-gocache go test ./pkg/ddl/tests/partition -run 'TestAlterModifyPartitionColumnOnListPartitionedTable|TestAlterModifyPartitionColumnOnListColumnsPartitionedTable|TestAlterModifyPartitionColumnToNotAllowedType|TestAlterModifyPartitionColumnIncompatibleDefinitions|TestMultiSchemaModifyColumnConcurrentDMLInWriteStates' --tags=intest -count=1
- GOCACHE=/tmp/tidb-gocache go test ./pkg/ddl -run TestPostCheckPartitionModifiableColumnErrorBranches --tags=intest -count=1

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
