### PR TITLE
expression: prepare with fts search should success | tidb-test=a9bf2dca824dc746361234cd4d763178e0eedd13 tiflash=feature-fts

### DIFF
--- a/pkg/expression/builtin_fts.go
+++ b/pkg/expression/builtin_fts.go
@@ -90,8 +90,8 @@ func (c *ftsMatchWordFunctionClass) getFunction(ctx BuildContext, args []Express
 	if !ok {
 		return nil, ErrNotSupportedYet.GenWithStackByArgs("match against a non-constant string")
 	}
-	if argAgainstConstant.Value.Kind() != types.KindString {
-		return nil, ErrNotSupportedYet.GenWithStackByArgs("match against a non-constant string")
+	if argAgainstConstant.Value.Kind() != types.KindString && !argAgainstConstant.Value.IsNull() {
+		return nil, ErrNotSupportedYet.GenWithStackByArgs("match against a non-string constant")
 	}
 	argsMatch := args[1:]
 	for _, arg := range argsMatch {
@@ -118,12 +118,20 @@ func (c *ftsMatchWordFunctionClass) getFunction(ctx BuildContext, args []Express
 }
 
 func (b *builtinFtsMatchWordSig) evalReal(ctx EvalContext, row chunk.Row) (float64, bool, error) {
-	// Reject executing match against in TiDB side.
+	// Matching NULL returns 0.
+	if b.args[0].(*Constant).Value.IsNull() {
+		return 0, false, nil
+	}
+	// Reject executing match against in TiDB side
 	return 0, false, errors.Errorf("cannot use 'FTS_MATCH_WORD()' outside of fulltext index")
 }
 
 func (b *builtinFtsMatchPhraseSig) evalReal(ctx EvalContext, row chunk.Row) (float64, bool, error) {
-	// Reject executing match against in TiDB side.
+	// Matching NULL returns 0.
+	if b.args[0].(*Constant).Value.IsNull() {
+		return 0, false, nil
+	}
+	// Reject executing match against in TiDB side
 	return 0, false, errors.Errorf("cannot use 'FTS_MATCH_PHRASE()' outside of fulltext index")
 }
 
@@ -152,8 +160,8 @@ func (c *ftsMysqlMatchAgainstFunctionClass) getFunction(ctx BuildContext, args [
 	if !ok {
 		return nil, ErrNotSupportedYet.GenWithStackByArgs("match against a non-constant string")
 	}
-	if argAgainstConstant.Value.Kind() != types.KindString {
-		return nil, ErrNotSupportedYet.GenWithStackByArgs("match against a non-constant string")
+	if argAgainstConstant.Value.Kind() != types.KindString && !argAgainstConstant.Value.IsNull() {
+		return nil, ErrNotSupportedYet.GenWithStackByArgs("match against a non-string constant")
 	}
 
 	argsMatch := args[1:]
@@ -181,7 +189,11 @@ func (c *ftsMysqlMatchAgainstFunctionClass) getFunction(ctx BuildContext, args [
 }
 
 func (b *builtinFtsMysqlMatchAgainstSig) evalReal(ctx EvalContext, row chunk.Row) (float64, bool, error) {
-	// Reject executing match against in TiDB side.
+	// Matching NULL returns 0.
+	if b.args[0].(*Constant).Value.IsNull() {
+		return 0, false, nil
+	}
+	// Reject executing match against in TiDB side
 	return 0, false, errors.Errorf("cannot use 'MATCH ... AGAINST' outside of fulltext index")
 }
 
@@ -209,8 +221,8 @@ func (c *ftsMatchPrefixFunctionClass) getFunction(ctx BuildContext, args []Expre
 	if !ok {
 		return nil, ErrNotSupportedYet.GenWithStackByArgs("match against a non-constant string")
 	}
-	if argAgainstConstant.Value.Kind() != types.KindString {
-		return nil, ErrNotSupportedYet.GenWithStackByArgs("match against a non-constant string")
+	if argAgainstConstant.Value.Kind() != types.KindString && !argAgainstConstant.Value.IsNull() {
+		return nil, ErrNotSupportedYet.GenWithStackByArgs("match against a non-string constant")
 	}
 	argsMatch := args[1:]
 	for _, arg := range argsMatch {
@@ -237,6 +249,10 @@ func (c *ftsMatchPrefixFunctionClass) getFunction(ctx BuildContext, args []Expre
 }
 
 func (b *builtinFtsMatchPrefixSig) evalReal(ctx EvalContext, row chunk.Row) (float64, bool, error) {
+	// Matching NULL returns 0.
+	if b.args[0].(*Constant).Value.IsNull() {
+		return 0, false, nil
+	}
 	// Reject executing match against in TiDB side.
 	return 0, false, errors.Errorf("cannot use 'FTS_MATCH_PREFIX()' outside of fulltext index")
 }
@@ -251,8 +267,8 @@ func (c *ftsMatchPhraseFunctionClass) getFunction(ctx BuildContext, args []Expre
 	if !ok {
 		return nil, ErrNotSupportedYet.GenWithStackByArgs("match against a non-constant string")
 	}
-	if argAgainstConstant.Value.Kind() != types.KindString {
-		return nil, ErrNotSupportedYet.GenWithStackByArgs("match against a non-constant string")
+	if argAgainstConstant.Value.Kind() != types.KindString && !argAgainstConstant.Value.IsNull() {
+		return nil, ErrNotSupportedYet.GenWithStackByArgs("match against a non-string constant")
 	}
 	argsMatch := args[1:]
 	for _, arg := range argsMatch {

--- a/pkg/planner/core/casetest/tici/BUILD.bazel
+++ b/pkg/planner/core/casetest/tici/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         "//pkg/config",
         "//pkg/ddl/ingest/testutil",

--- a/pkg/planner/core/operator/logicalop/logical_datasource.go
+++ b/pkg/planner/core/operator/logicalop/logical_datasource.go
@@ -720,6 +720,7 @@ func (ds *DataSource) buildTiCIFTSPathAndCleanUp(
 	index *model.IndexInfo,
 	matchedFuncs map[*expression.ScalarFunction]struct{},
 ) error {
+	ds.SCtx().GetSessionVars().StmtCtx.SetSkipPlanCache("TiCI Index currently can not be cached")
 	// Fulltext index must be used. So we prune all other possible access paths.
 	ds.PossibleAccessPaths = slices.DeleteFunc(ds.PossibleAccessPaths, func(path *util.AccessPath) bool {
 		return path.Index == nil || path.Index.ID != index.ID


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/64651

Problem Summary:

### What changed and how does it work?

During prepare, the const param will be translated to NULL.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
