### PR TITLE
planner: fix cascades test to ignore plan-id with explain format as brief

### DIFF
--- a/pkg/planner/cascades/cascades_test.go
+++ b/pkg/planner/cascades/cascades_test.go
@@ -33,9 +33,9 @@ func TestCascadesDrive(t *testing.T) {
 
 	// simple select for quick debug of memo, the normal test case is in tests/planner/cascades/integration.test.
 	tk.MustQuery("select 1").Check(testkit.Rows("1"))
-	tk.MustQuery("explain select 1").Check(testkit.Rows(""+
-		"Projection_3 1.00 root  1->Column#1",
-		"└─TableDual_5 1.00 root  rows:1"))
+	tk.MustQuery("explain format = 'brief' select 1").Check(testkit.Rows(""+
+		"Projection 1.00 root  1->Column#1",
+		"└─TableDual 1.00 root  rows:1"))
 }
 
 func TestXFormedOperatorShouldDeriveTheirStatsOwn(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60940 

Problem Summary: Some explain-test cases will record the plan ID in the result file, which will be a burden when some optimization flow is changed, since plan ID allocation is sequential according to the allocation order or space.

### What changed and how does it work?
Made `TestCascadesDrive` test ignore plan-id with explain format as brief

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
