### PR TITLE
table, sessionctx: fix bug where mlog consumes reserved row IDs from base table

### DIFF
--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -119,6 +119,13 @@ func (r *ReservedRowIDAlloc) Reset(base int64, maxv int64) {
 	r.max = maxv
 }
 
+// Current returns the current base and max of reserved rowIDs.
+func (r *ReservedRowIDAlloc) Current() (base int64, maxv int64) {
+	base = r.base
+	maxv = r.max
+	return
+}
+
 // Consume consumes a reserved rowID.
 // If the second return value is false, it means the reserved rowID is exhausted.
 func (r *ReservedRowIDAlloc) Consume() (int64, bool) {

--- a/pkg/sessionctx/stmtctx/stmtctx_test.go
+++ b/pkg/sessionctx/stmtctx/stmtctx_test.go
@@ -484,6 +484,10 @@ func TestReservedRowIDAlloc(t *testing.T) {
 	require.Equal(t, int64(0), id)
 	// reset some ids
 	reserved.Reset(12, 15)
+	curBase, curMax := reserved.Current()
+	require.Equal(t, int64(12), curBase)
+	require.Equal(t, int64(15), curMax)
+	// consume the reserved ids
 	require.False(t, reserved.Exhausted())
 	id, ok = reserved.Consume()
 	require.True(t, ok)

--- a/tests/integrationtest/r/executor/mview_log_dml.result
+++ b/tests/integrationtest/r/executor/mview_log_dml.result
@@ -109,3 +109,28 @@ update t set untracked = 101 where id = 1;
 Error 1105 (HY000): wrap table with mlog: base column tracked not found
 delete from t where id = 1;
 Error 1105 (HY000): wrap table with mlog: base column tracked not found
+drop table if exists t, `$mlog$t`;
+create table t(a int);
+create materialized view log on t (a);
+insert into t values (1);
+select _tidb_rowid, a from t;
+_tidb_rowid	a
+1	1
+select _tidb_rowid, a, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`;
+_tidb_rowid	a	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
+1	1	I	1
+update t set a = a+1 where a = 1;
+insert into t values (2), (3);
+select _tidb_rowid, a from t;
+_tidb_rowid	a
+1	2
+2	2
+3	3
+select _tidb_rowid, a, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`;
+_tidb_rowid	a	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
+1	1	I	1
+2	1	U	-1
+3	2	U	1
+4	2	I	1
+5	3	I	1
+drop table if exists t, `$mlog$t`;

--- a/tests/integrationtest/t/executor/mview_log_dml.test
+++ b/tests/integrationtest/t/executor/mview_log_dml.test
@@ -104,3 +104,18 @@ insert into t values (1, 100);
 update t set untracked = 101 where id = 1;
 --error 1105
 delete from t where id = 1;
+
+# Test for issue #66245, the mlog table should not use the base table's auto-increment id by mistake.
+drop table if exists t, `$mlog$t`;
+create table t(a int);
+create materialized view log on t (a);
+insert into t values (1);
+select _tidb_rowid, a from t;
+select _tidb_rowid, a, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`;
+update t set a = a+1 where a = 1;
+insert into t values (2), (3);
+select _tidb_rowid, a from t;
+select _tidb_rowid, a, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`;
+
+# clean up
+drop table if exists t, `$mlog$t`;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66245

Problem Summary:
When a statement reserves `_tidb_rowid` values for the base table, the mlog table write in the same statement can incorrectly consume those reserved IDs. This causes the base table to lose reserved IDs and breaks expected rowid continuity/order in mixed UPDATE/INSERT flows.

### What changed and how does it work?
- Added `ReservedRowIDAlloc.Current()` to snapshot the current reserved range.
- In `mlogTable.writeMLogRow`, temporarily clear the statement-level reserved rowid allocator before writing to the mlog table, then restore it with `defer` after the mlog insert.
- Added unit test coverage for `ReservedRowIDAlloc.Current()`.
- Added integration test for issue #66245 to verify mlog writes no longer consume base table reserved row IDs.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:
- `go test ./pkg/sessionctx/stmtctx -run TestReservedRowIDAlloc --tags=intest`
- `tests/integrationtest/run-tests.sh -r executor/mview_log_dml`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug where materialized view log writes could consume reserved `_tidb_rowid` values from the base table within the same statement.
```
