### PR TITLE
expression: throw error when search column is not string | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature/fts

### DIFF
--- a/pkg/expression/builtin_fts.go
+++ b/pkg/expression/builtin_fts.go
@@ -103,7 +103,10 @@ func (c *ftsMatchWordFunctionClass) getFunction(ctx BuildContext, args []Express
 
 	argTps := make([]types.EvalType, 0, len(args))
 	argTps = append(argTps, types.ETString)
-	for range argsMatch {
+	for _, arg := range argsMatch {
+		if arg.GetType(ctx.GetEvalCtx()).EvalType() != types.ETString {
+			return nil, ErrNotSupportedYet.GenWithStackByArgs("matching a non-string column")
+		}
 		argTps = append(argTps, types.ETString)
 	}
 
@@ -174,7 +177,10 @@ func (c *ftsMysqlMatchAgainstFunctionClass) getFunction(ctx BuildContext, args [
 
 	argTps := make([]types.EvalType, 0, len(args))
 	argTps = append(argTps, types.ETString)
-	for range argsMatch {
+	for _, arg := range argsMatch {
+		if arg.GetType(ctx.GetEvalCtx()).EvalType() != types.ETString {
+			return nil, ErrNotSupportedYet.GenWithStackByArgs("matching a non-string column")
+		}
 		argTps = append(argTps, types.ETString)
 	}
 
@@ -234,7 +240,10 @@ func (c *ftsMatchPrefixFunctionClass) getFunction(ctx BuildContext, args []Expre
 
 	argTps := make([]types.EvalType, 0, len(args))
 	argTps = append(argTps, types.ETString)
-	for range argsMatch {
+	for _, arg := range argsMatch {
+		if arg.GetType(ctx.GetEvalCtx()).EvalType() != types.ETString {
+			return nil, ErrNotSupportedYet.GenWithStackByArgs("matching a non-string column")
+		}
 		argTps = append(argTps, types.ETString)
 	}
 
@@ -280,7 +289,10 @@ func (c *ftsMatchPhraseFunctionClass) getFunction(ctx BuildContext, args []Expre
 
 	argTps := make([]types.EvalType, 0, len(args))
 	argTps = append(argTps, types.ETString)
-	for range argsMatch {
+	for _, arg := range argsMatch {
+		if arg.GetType(ctx.GetEvalCtx()).EvalType() != types.ETString {
+			return nil, ErrNotSupportedYet.GenWithStackByArgs("matching a non-string column")
+		}
 		argTps = append(argTps, types.ETString)
 	}
 

--- a/pkg/planner/core/casetest/tici/BUILD.bazel
+++ b/pkg/planner/core/casetest/tici/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/config",
         "//pkg/ddl/ingest/testutil",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61185

Problem Summary:

### What changed and how does it work?

When searching a non-string column, there's no correct error msg.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
