### PR TITLE
planner, partial_order: fix index out of range error when query has pruned column

### DIFF
--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1184,12 +1184,19 @@ func matchPartialOrderProperty(path *util.AccessPath, partialOrderInfo *property
 	// Check if index columns can match ORDER BY columns (allowing prefix index)
 	//
 	// NOTE: We use path.Index.Columns to get the actual index definition columns count,
-	// because path.IdxCols may include additional handle columns (e.g., primary key `id`)
+	// because path.FullIdxCols may include additional handle columns (e.g., primary key `id`)
 	// appended for non-unique indexes on tables with PKIsHandle.
 	// For example, for `index idx_name_prefix (name(10))` on a table with `id int primary key`,
-	// path.IdxCols = [name, id] but path.Index.Columns only contains [name].
+	// path.FullIdxCols = [name, id] but path.Index.Columns only contains [name].
 	// We should only consider the actual index definition columns for partial order matching.
 	indexColCount := len(path.Index.Columns)
+
+	// Constraint 0: The full idx cols length must >= all the index definition columns length, no matter column is pruned or not
+	// Theoretically, the preceding function logic ”IndexInfo2FullCols“ can guarantee that this constraint will always hold.
+	// Therefore, this is merely a defensive check to prevent the array from going out of bounds in the subsequent for loop.
+	if len(path.FullIdxCols) < indexColCount || len(path.FullIdxColLens) < indexColCount {
+		return emptyResult
+	}
 
 	// Constraint 1: The number of index definition columns must be <= the number of ORDER BY columns
 	if indexColCount > len(sortItems) {
@@ -1209,13 +1216,17 @@ func matchPartialOrderProperty(path *util.AccessPath, partialOrderInfo *property
 
 	// Only iterate over the actual index definition columns, not the appended handle columns
 	for i := range indexColCount {
+		idxCol := path.FullIdxCols[i]
+		if idxCol == nil {
+			return emptyResult
+		}
 		// check if the same column
-		if !orderByCols[i].EqualColumn(path.IdxCols[i]) {
+		if !orderByCols[i].EqualColumn(idxCol) {
 			return emptyResult
 		}
 
 		// meet prefix index column, match termination
-		if path.IdxColLens[i] != types.UnspecifiedLength {
+		if path.FullIdxColLens[i] != types.UnspecifiedLength {
 			// If we meet a prefix column but it's not the last index definition column, it's not supported.
 			// e.g. prefix(a), b cannot provide partial order for ORDER BY a, b.
 			if i != indexColCount-1 {
@@ -1225,8 +1236,8 @@ func matchPartialOrderProperty(path *util.AccessPath, partialOrderInfo *property
 			// This prefix index column can provide partial order, but subsequent columns cannot match.
 			return property.PartialOrderMatchResult{
 				Matched:   true,
-				PrefixCol: path.IdxCols[i],
-				PrefixLen: path.IdxColLens[i],
+				PrefixCol: idxCol,
+				PrefixLen: path.FullIdxColLens[i],
 			}
 		}
 	}

--- a/tests/integrationtest/r/planner/core/partial_order_topn.result
+++ b/tests/integrationtest/r/planner/core/partial_order_topn.result
@@ -371,6 +371,34 @@ Projection	5.00	root		planner__core__partial_order_topn.t_varchar.id, length(pla
         ├─IndexFullScan(Build)	10000.00	cop[tikv]	table:t_varchar, index:idx_name_prefix(name)	keep order:false, stats:pseudo
         └─TopN(Probe)	5.00	cop[tikv]		length(planner__core__partial_order_topn.t_varchar.name), offset:0, count:5
           └─TableRowIDScan	10000.00	cop[tikv]	table:t_varchar	keep order:false, stats:pseudo
+drop table if exists t12, t15;
+CREATE TABLE `t12` (
+`c0` varchar(30) DEFAULT NULL,
+`c1` varchar(30) DEFAULT NULL,
+`c2` varchar(30) DEFAULT NULL,
+KEY `idx1` (`c0`,`c2`(10))
+);
+CREATE TABLE `t15` (
+`c1` int DEFAULT NULL,
+`c2` varchar(30) DEFAULT NULL,
+`c3` varchar(30) DEFAULT NULL,
+`c4` varchar(30) DEFAULT NULL,
+KEY `idx1` (`c1`,`c2`,`c3`(10))
+);
+explain format='brief' select /*+ use_index(t15, idx1) */ c1 from t15 where length(c1) > 13 order by c1, c4, c3 limit 10922 offset 55010;
+id	estRows	task	access object	operator info
+TopN	8000.00	root		planner__core__partial_order_topn.t15.c1, planner__core__partial_order_topn.t15.c4, planner__core__partial_order_topn.t15.c3, offset:55010, count:10922
+└─IndexLookUp	8000.00	root		
+  ├─Selection(Build)	8000.00	cop[tikv]		gt(length(cast(planner__core__partial_order_topn.t15.c1, var_string(20))), 13)
+  │ └─IndexFullScan	10000.00	cop[tikv]	table:t15, index:idx1(c1, c2, c3)	keep order:false, stats:pseudo
+  └─TableRowIDScan(Probe)	8000.00	cop[tikv]	table:t15	keep order:false, stats:pseudo
+explain format='brief' select /*+ use_index(t12, idx1) */ c0, c1 from t12 where length(c0) > 13 order by c0, c1 limit 10922 offset 55010;
+id	estRows	task	access object	operator info
+TopN	8000.00	root		planner__core__partial_order_topn.t12.c0, planner__core__partial_order_topn.t12.c1, offset:55010, count:10922
+└─IndexLookUp	8000.00	root		
+  ├─Selection(Build)	8000.00	cop[tikv]		gt(length(planner__core__partial_order_topn.t12.c0), 13)
+  │ └─IndexFullScan	10000.00	cop[tikv]	table:t12, index:idx1(c0, c2)	keep order:false, stats:pseudo
+  └─TableRowIDScan(Probe)	8000.00	cop[tikv]	table:t12	keep order:false, stats:pseudo
 begin;
 insert into t_varchar (name, data) values ('zebra', 'animal');
 explain format='brief' select /*+ force_index(t_varchar, idx_name_prefix) */ * from t_varchar order by name limit 5;
@@ -577,3 +605,4 @@ select @@tidb_opt_partial_ordered_index_for_topn;
 DISABLE
 drop table if exists t_varchar, t_char, t_text, t_multi_col, t_no_prefix;
 drop table if exists t_join1, t_join2, t_empty, t_prefix_len, t_null;
+drop table if exists t12, t15;

--- a/tests/integrationtest/t/planner/core/partial_order_topn.test
+++ b/tests/integrationtest/t/planner/core/partial_order_topn.test
@@ -297,6 +297,29 @@ explain format='brief' select  /*+ force_index(t_varchar, idx_name_prefix) */ id
 explain format='brief' select /*+ force_index(t_varchar, idx_name_prefix) */ id, length(name) as name_len from t_varchar order by name_len limit 5;
 
 # ==========================================
+# Section 5.7: The index column has been pruned - NOT supported
+# ==========================================
+drop table if exists t12, t15;
+CREATE TABLE `t12` (
+  `c0` varchar(30) DEFAULT NULL,
+  `c1` varchar(30) DEFAULT NULL,
+  `c2` varchar(30) DEFAULT NULL,
+  KEY `idx1` (`c0`,`c2`(10))
+);
+CREATE TABLE `t15` (
+  `c1` int DEFAULT NULL,
+  `c2` varchar(30) DEFAULT NULL,
+  `c3` varchar(30) DEFAULT NULL,
+  `c4` varchar(30) DEFAULT NULL,
+  KEY `idx1` (`c1`,`c2`,`c3`(10))
+);
+
+# The middle column of the index is pruned, partial order optimization cannot be applied
+explain format='brief' select /*+ use_index(t15, idx1) */ c1 from t15 where length(c1) > 13 order by c1, c4, c3 limit 10922 offset 55010;
+# The last column of index which is prefix column is pruned, partial order optimization cannot be applied
+explain format='brief' select /*+ use_index(t12, idx1) */ c0, c1 from t12 where length(c0) > 13 order by c0, c1 limit 10922 offset 55010;
+
+# ==========================================
 # Section 6: Dirty write scenarios (uncommitted data)
 # ==========================================
 
@@ -511,4 +534,5 @@ select @@tidb_opt_partial_ordered_index_for_topn;
 
 drop table if exists t_varchar, t_char, t_text, t_multi_col, t_no_prefix;
 drop table if exists t_join1, t_join2, t_empty, t_prefix_len, t_null;
+drop table if exists t12, t15;
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: fix #65813 

Problem Summary:

### What changed and how does it work?

In the logic of mapping the index and order by columns, `fullidxcols` will be used instead of the previous `idxcols` for comparison.

The main difference is that the columns in `idxcols` do not match the original columns of the index one-to-one. After column pruning, the number of `idxcols` columns will be less than the original number of columns in the index, making it impossible to match with the order by columns.

However, the number of columns in `fullidxcols` corresponds one-to-one with the number of columns in the order by columns (although there will be an extra handle at the end), but this does not affect the matching logic.

Even if pruned, `fullidxcols` will leave a `nil` as a placeholder, so this more accurate attribute is needed for match judgment.

### Incorrect case information：

```
 CREATE TABLE `t12` (
  `c0` varchar(30) DEFAULT NULL,
  `c1` varchar(30) DEFAULT NULL,
  `c2` varchar(30) DEFAULT NULL,
  KEY `idx1` (`c0`,`c2`(10))
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
explain select /*+ use_index(t12, idx1) */ c0, c1 from t12 where length(c0) > 13 order by c0, c1 limit 10922 offset 55010
[err="runtime error: index out of range [1] with length 1
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
