### PR TITLE
resourcegroup: refactor batchFlusher to use mutex-protected buffer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/ckaznocha/intrange v0.3.1
 	github.com/cloudfoundry/gosigar v1.3.6
+	github.com/cockroachdb/errors v1.11.3
 	github.com/cockroachdb/pebble v1.1.4-0.20250120151818-5dd133a1e6fb
 	github.com/coocood/freecache v1.2.1
 	github.com/coreos/go-semver v0.3.1
@@ -191,7 +192,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.28.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.33.2 // indirect
 	github.com/clbanning/mxj/v2 v2.7.0 // indirect
-	github.com/cockroachdb/errors v1.11.3 // indirect
 	github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -291,6 +291,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(RunawayCheckerCounter)
 	prometheus.MustRegister(RunawayFlusherCounter)
 	prometheus.MustRegister(RunawayFlusherAddCounter)
+	prometheus.MustRegister(RunawayFlusherDropCounter)
 	prometheus.MustRegister(RunawayFlusherBatchSizeHistogram)
 	prometheus.MustRegister(RunawayFlusherDurationHistogram)
 	prometheus.MustRegister(RunawayFlusherIntervalHistogram)

--- a/pkg/metrics/resource_group.go
+++ b/pkg/metrics/resource_group.go
@@ -26,6 +26,7 @@ var (
 
 	RunawayFlusherCounter            *prometheus.CounterVec
 	RunawayFlusherAddCounter         *prometheus.CounterVec
+	RunawayFlusherDropCounter        *prometheus.CounterVec
 	RunawayFlusherBatchSizeHistogram *prometheus.HistogramVec
 	RunawayFlusherDurationHistogram  *prometheus.HistogramVec
 	RunawayFlusherIntervalHistogram  *prometheus.HistogramVec
@@ -55,6 +56,14 @@ func InitResourceGroupMetrics() {
 			Subsystem: "server",
 			Name:      "runaway_flusher_add_total",
 			Help:      "Counter of records added to runaway flusher.",
+		}, []string{LblName})
+
+	RunawayFlusherDropCounter = metricscommon.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "runaway_flusher_drop_total",
+			Help:      "Counter of records dropped by runaway flusher due to buffer overflow.",
 		}, []string{LblName})
 
 	RunawayFlusherBatchSizeHistogram = metricscommon.NewHistogramVec(

--- a/pkg/resourcegroup/runaway/BUILD.bazel
+++ b/pkg/resourcegroup/runaway/BUILD.bazel
@@ -52,7 +52,7 @@ go_test(
     ],
     embed = [":runaway"],
     flaky = True,
-    shard_count = 15,
+    shard_count = 18,
     deps = [
         "//pkg/metrics",
         "@com_github_pingcap_kvproto//pkg/resource_manager",

--- a/pkg/resourcegroup/runaway/BUILD.bazel
+++ b/pkg/resourcegroup/runaway/BUILD.bazel
@@ -52,7 +52,7 @@ go_test(
     ],
     embed = [":runaway"],
     flaky = True,
-    shard_count = 18,
+    shard_count = 20,
     deps = [
         "//pkg/metrics",
         "@com_github_pingcap_kvproto//pkg/resource_manager",

--- a/pkg/resourcegroup/runaway/flusher.go
+++ b/pkg/resourcegroup/runaway/flusher.go
@@ -15,6 +15,7 @@
 package runaway
 
 import (
+	"sync"
 	"time"
 
 	"github.com/pingcap/failpoint"
@@ -25,11 +26,29 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	// flushThreshold is the number of unique keys that triggers a flush signal.
+	flushThreshold = 512
+	// maxBufferSize caps the number of unique keys in the buffer to prevent
+	// unbounded memory growth when flush is slow and unique keys are many.
+	// Records whose key already exists are still merged (deduplication).
+	//
+	// Per-flusher worst-case memory at maxBufferSize (32768 entries):
+	//   runawayRecordFlusher:    key ~64B + val(ptr 8B + Record ~232B) ≈ ~304B × 32768 ≈ 9.5 MB
+	//   quarantineRecordFlusher: key ~48B + val(ptr 8B + QuarantineRecord ~200B) ≈ ~256B × 32768 ≈ 8.0 MB
+	//   staleQuarantineFlusher:  key 8B + val(ptr 8B + QuarantineRecord ~200B)  ≈ ~216B × 32768 ≈ 6.8 MB
+	// Total worst-case across all three flushers: ~24 MB.
+	maxBufferSize = 32 * 1024
+)
+
 type batchFlusher[K comparable, V any] struct {
+	mu            sync.Mutex
 	name          string
 	buffer        map[K]V
 	ticker        *time.Ticker
-	threshold     int
+	flushCh       chan struct{} // capacity 1, threshold-triggered signal
+	stopCh        chan struct{} // close to trigger stop
+	done          chan struct{} // closed after run() exits
 	lastFlushTime time.Time
 	mergeFn       func(map[K]V, K, V)
 	flushFn       func(map[K]V) error
@@ -40,21 +59,23 @@ type batchFlusher[K comparable, V any] struct {
 	flushSuccessCounter prometheus.Counter
 	flushErrorCounter   prometheus.Counter
 	addCounter          prometheus.Counter
+	dropCounter         prometheus.Counter
 }
 
 func newBatchFlusher[K comparable, V any](
 	name string,
 	interval time.Duration,
-	threshold int,
 	mergeFn func(map[K]V, K, V),
 	genSQL func(map[K]V) (string, []any),
 	pool util.SessionPool,
 ) *batchFlusher[K, V] {
 	f := &batchFlusher[K, V]{
 		name:                name,
-		buffer:              make(map[K]V, threshold),
+		buffer:              make(map[K]V, flushThreshold),
 		ticker:              time.NewTicker(interval),
-		threshold:           threshold,
+		flushCh:             make(chan struct{}, 1),
+		stopCh:              make(chan struct{}),
+		done:                make(chan struct{}),
 		mergeFn:             mergeFn,
 		batchSizeObserver:   metrics.RunawayFlusherBatchSizeHistogram.WithLabelValues(name),
 		durationObserver:    metrics.RunawayFlusherDurationHistogram.WithLabelValues(name),
@@ -62,17 +83,14 @@ func newBatchFlusher[K comparable, V any](
 		flushSuccessCounter: metrics.RunawayFlusherCounter.WithLabelValues(name, metrics.LblOK),
 		flushErrorCounter:   metrics.RunawayFlusherCounter.WithLabelValues(name, metrics.LblError),
 		addCounter:          metrics.RunawayFlusherAddCounter.WithLabelValues(name),
+		dropCounter:         metrics.RunawayFlusherDropCounter.WithLabelValues(name),
 	}
 	f.flushFn = func(buffer map[K]V) error {
-		count := len(buffer)
-		if count == 0 {
-			return nil
-		}
 		sql, params := genSQL(buffer)
 		if _, err := ExecRCRestrictedSQL(pool, sql, params); err != nil {
 			logutil.BgLogger().Error("batch flush failed",
 				zap.String("name", name),
-				zap.Int("count", count),
+				zap.Int("count", len(buffer)),
 				zap.Error(err))
 			return err
 		}
@@ -81,47 +99,84 @@ func newBatchFlusher[K comparable, V any](
 	return f
 }
 
-func (f *batchFlusher[K, V]) tickerCh() <-chan time.Time {
-	return f.ticker.C
+func (f *batchFlusher[K, V]) run() {
+	defer func() {
+		logutil.BgLogger().Info("flushing remaining records before stop", zap.String("name", f.name))
+		f.flush()
+		logutil.BgLogger().Info("stopped flusher", zap.String("name", f.name))
+		close(f.done)
+	}()
+	for {
+		select {
+		case <-f.stopCh:
+			return
+		case <-f.ticker.C:
+			f.flush()
+		case <-f.flushCh:
+			f.flush()
+		}
+	}
 }
 
 func (f *batchFlusher[K, V]) stop() {
-	logutil.BgLogger().Info("flushing remaining records before stop", zap.String("name", f.name))
-	f.flush()
-	logutil.BgLogger().Info("stopped flusher", zap.String("name", f.name))
 	f.ticker.Stop()
+	close(f.stopCh)
+	<-f.done
+}
+
+func (f *batchFlusher[K, V]) notifyFlush() {
+	select {
+	case f.flushCh <- struct{}{}:
+	default:
+	}
 }
 
 func (f *batchFlusher[K, V]) add(key K, value V) {
 	f.addCounter.Inc()
+	f.mu.Lock()
+	if _, exists := f.buffer[key]; !exists && len(f.buffer) >= maxBufferSize {
+		f.mu.Unlock()
+		f.dropCounter.Inc()
+		return
+	}
 	f.mergeFn(f.buffer, key, value)
-	shouldFlush := len(f.buffer) >= f.threshold
+	shouldFlush := len(f.buffer) >= flushThreshold
+	f.mu.Unlock()
 	failpoint.Inject("FastRunawayGC", func() {
 		shouldFlush = true
 	})
 	if shouldFlush {
-		f.flush()
+		f.notifyFlush()
 	}
+}
+
+func (f *batchFlusher[K, V]) bufferLen() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.buffer)
 }
 
 func (f *batchFlusher[K, V]) flush() {
 	failpoint.Inject("skipFlush", func() {
 		failpoint.Return()
 	})
+	f.mu.Lock()
 	batchSize := len(f.buffer)
 	if batchSize == 0 {
+		f.mu.Unlock()
 		return
 	}
-
+	toFlush := f.buffer
+	f.buffer = make(map[K]V, flushThreshold)
 	now := time.Now()
 	if !f.lastFlushTime.IsZero() {
 		f.intervalObserver.Observe(now.Sub(f.lastFlushTime).Seconds())
 	}
+	f.lastFlushTime = now
+	f.mu.Unlock()
 
-	start := time.Now()
-	err := f.flushFn(f.buffer)
-	duration := time.Since(start)
-
+	err := f.flushFn(toFlush)
+	duration := time.Since(now)
 	f.batchSizeObserver.Observe(float64(batchSize))
 	f.durationObserver.Observe(duration.Seconds())
 	if err != nil {
@@ -129,7 +184,4 @@ func (f *batchFlusher[K, V]) flush() {
 	} else {
 		f.flushSuccessCounter.Inc()
 	}
-
-	f.lastFlushTime = now
-	f.buffer = make(map[K]V, f.threshold)
 }

--- a/pkg/resourcegroup/runaway/flusher.go
+++ b/pkg/resourcegroup/runaway/flusher.go
@@ -100,11 +100,12 @@ func newBatchFlusher[K comparable, V any](
 }
 
 func (f *batchFlusher[K, V]) run() {
+	defer close(f.done)
+	defer util.Recover(metrics.LabelDomain, "batchFlusher-"+f.name, nil, false)
 	defer func() {
 		logutil.BgLogger().Info("flushing remaining records before stop", zap.String("name", f.name))
 		f.flush()
 		logutil.BgLogger().Info("stopped flusher", zap.String("name", f.name))
-		close(f.done)
 	}()
 	for {
 		select {

--- a/pkg/resourcegroup/runaway/flusher_test.go
+++ b/pkg/resourcegroup/runaway/flusher_test.go
@@ -15,6 +15,8 @@
 package runaway
 
 import (
+	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -32,7 +34,9 @@ func newTestBatchFlusher[K comparable, V any](
 		name:                "test",
 		buffer:              make(map[K]V, threshold),
 		ticker:              time.NewTicker(time.Hour),
-		threshold:           threshold,
+		flushCh:             make(chan struct{}, 1),
+		stopCh:              make(chan struct{}),
+		done:                make(chan struct{}),
 		mergeFn:             mergeFn,
 		flushFn:             flushFn,
 		batchSizeObserver:   metrics.RunawayFlusherBatchSizeHistogram.WithLabelValues("test"),
@@ -41,6 +45,7 @@ func newTestBatchFlusher[K comparable, V any](
 		flushSuccessCounter: metrics.RunawayFlusherCounter.WithLabelValues("test", metrics.LblOK),
 		flushErrorCounter:   metrics.RunawayFlusherCounter.WithLabelValues("test", metrics.LblError),
 		addCounter:          metrics.RunawayFlusherAddCounter.WithLabelValues("test"),
+		dropCounter:         metrics.RunawayFlusherDropCounter.WithLabelValues("test"),
 	}
 }
 
@@ -53,19 +58,24 @@ func TestBatchFlusherAdd(t *testing.T) {
 		func(m map[string]int, k string, v int) { m[k] = v },
 		func(m map[string]int) error { flushCount.Add(1); return nil },
 	)
-	re.Empty(flusher.buffer)
+	re.Equal(0, flusher.bufferLen())
 
 	flusher.add("a", 1)
 	flusher.add("b", 2)
-	re.Len(flusher.buffer, 2)
+	re.Equal(2, flusher.bufferLen())
 	re.Equal(int32(0), flushCount.Load())
 
+	// Threshold reached: notifyFlush is called but flush happens asynchronously in run().
+	// Since run() is not started in this test, we manually flush.
 	flusher.add("c", 3)
-	re.Len(flusher.buffer, 0)
+	// The buffer still has 3 items because run() is not consuming flushCh.
+	// Manually flush to simulate what run() would do.
+	flusher.flush()
+	re.Equal(0, flusher.bufferLen())
 	re.Equal(int32(1), flushCount.Load())
 
 	flusher.add("d", 4)
-	re.Len(flusher.buffer, 1)
+	re.Equal(1, flusher.bufferLen())
 	re.Equal(int32(1), flushCount.Load())
 }
 
@@ -90,13 +100,12 @@ func TestBatchFlusherMergeFn(t *testing.T) {
 	flusher.add("key1", &Record{SQLDigest: "d1", Repeats: 1})
 	flusher.add("key2", &Record{SQLDigest: "d2", Repeats: 1})
 
-	re.Len(flusher.buffer, 2)
-	re.Equal(3, flusher.buffer["key1"].Repeats)
-	re.Equal(1, flusher.buffer["key2"].Repeats)
+	re.Equal(2, flusher.bufferLen())
 
 	flusher.flush()
-	re.Len(flusher.buffer, 0)
+	re.Equal(0, flusher.bufferLen())
 	re.Equal(3, lastBuffer["key1"].Repeats)
+	re.Equal(1, lastBuffer["key2"].Repeats)
 }
 
 func TestBatchFlusherFlush(t *testing.T) {
@@ -108,18 +117,18 @@ func TestBatchFlusherFlush(t *testing.T) {
 		func(m map[string]int, k string, v int) { m[k] = v },
 		func(m map[string]int) error { flushCount.Add(1); return nil },
 	)
-	re.Empty(flusher.buffer)
+	re.Equal(0, flusher.bufferLen())
 
 	flusher.add("a", 1)
-	re.Len(flusher.buffer, 1)
+	re.Equal(1, flusher.bufferLen())
 	re.Equal(int32(0), flushCount.Load())
 
 	flusher.flush()
-	re.Len(flusher.buffer, 0)
+	re.Equal(0, flusher.bufferLen())
 	re.Equal(int32(1), flushCount.Load())
 
 	flusher.add("b", 2)
-	re.Len(flusher.buffer, 1)
+	re.Equal(1, flusher.bufferLen())
 	re.Equal(int32(1), flushCount.Load())
 }
 
@@ -142,4 +151,120 @@ func TestBatchFlusherFlushEmpty(t *testing.T) {
 
 	flusher.flush()
 	re.Equal(int32(1), flushCount.Load())
+}
+
+func TestBatchFlusherConcurrentAdd(t *testing.T) {
+	re := require.New(t)
+
+	var flushCount atomic.Int32
+	flusher := newTestBatchFlusher(
+		1000, // high threshold so flush is not triggered during add
+		func(m map[string]int, k string, v int) {
+			if existing, ok := m[k]; ok {
+				m[k] = existing + v
+			} else {
+				m[k] = v
+			}
+		},
+		func(m map[string]int) error { flushCount.Add(1); return nil },
+	)
+
+	const numGoroutines = 100
+	const addsPerGoroutine = 50
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	for i := range numGoroutines {
+		go func(id int) {
+			defer wg.Done()
+			for j := range addsPerGoroutine {
+				key := "key" + string(rune('A'+id%26))
+				flusher.add(key, j)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// All adds should have been captured without panic or race.
+	re.Greater(flusher.bufferLen(), 0)
+	re.LessOrEqual(flusher.bufferLen(), 26) // at most 26 unique keys
+
+	flusher.flush()
+	re.Equal(0, flusher.bufferLen())
+	re.Equal(int32(1), flushCount.Load())
+}
+
+func TestBatchFlusherMaxBufferSize(t *testing.T) {
+	re := require.New(t)
+
+	mergeFn := func(m map[string]int, k string, v int) {
+		if existing, ok := m[k]; ok {
+			m[k] = existing + v
+		} else {
+			m[k] = v
+		}
+	}
+	flusher := newTestBatchFlusher(
+		maxBufferSize+100,
+		mergeFn,
+		func(m map[string]int) error { return nil },
+	)
+
+	// Pre-fill buffer to maxBufferSize.
+	flusher.mu.Lock()
+	for i := range maxBufferSize {
+		flusher.buffer[fmt.Sprintf("prefill-%d", i)] = i
+	}
+	flusher.mu.Unlock()
+	re.Equal(maxBufferSize, flusher.bufferLen())
+
+	// New key should be dropped.
+	flusher.add("new-key-1", 100)
+	re.Equal(maxBufferSize, flusher.bufferLen())
+
+	// Another new key should also be dropped.
+	flusher.add("new-key-2", 200)
+	re.Equal(maxBufferSize, flusher.bufferLen())
+
+	// Existing key should still be merged.
+	flusher.add("prefill-0", 42)
+	re.Equal(maxBufferSize, flusher.bufferLen())
+	flusher.mu.Lock()
+	re.Equal(42, flusher.buffer["prefill-0"]) // merged: 0 + 42 = 42
+	flusher.mu.Unlock()
+
+	// After flush, new keys can be added again.
+	flusher.flush()
+	re.Equal(0, flusher.bufferLen())
+	flusher.add("new-key-1", 100)
+	re.Equal(1, flusher.bufferLen())
+}
+
+func TestBatchFlusherRunAndStop(t *testing.T) {
+	re := require.New(t)
+
+	var flushCount atomic.Int32
+	flusher := newTestBatchFlusher(
+		100,
+		func(m map[string]int, k string, v int) { m[k] = v },
+		func(m map[string]int) error { flushCount.Add(1); return nil },
+	)
+
+	go flusher.run()
+
+	// Add some items and trigger flush via notifyFlush.
+	flusher.add("a", 1)
+	flusher.add("b", 2)
+	flusher.notifyFlush()
+
+	// Wait briefly for the flush goroutine to process.
+	time.Sleep(50 * time.Millisecond)
+	re.Equal(int32(1), flushCount.Load())
+	re.Equal(0, flusher.bufferLen())
+
+	// Add more items, then stop. stop() should flush remaining.
+	flusher.add("c", 3)
+	flusher.stop()
+
+	re.Equal(int32(2), flushCount.Load())
+	re.Equal(0, flusher.bufferLen())
 }

--- a/pkg/resourcegroup/runaway/flusher_test.go
+++ b/pkg/resourcegroup/runaway/flusher_test.go
@@ -256,9 +256,10 @@ func TestBatchFlusherRunAndStop(t *testing.T) {
 	flusher.add("b", 2)
 	flusher.notifyFlush()
 
-	// Wait briefly for the flush goroutine to process.
-	time.Sleep(50 * time.Millisecond)
-	re.Equal(int32(1), flushCount.Load())
+	// Wait for the flush goroutine to process.
+	require.Eventually(t, func() bool {
+		return flushCount.Load() == 1
+	}, time.Second, 100*time.Millisecond)
 	re.Equal(0, flusher.bufferLen())
 
 	// Add more items, then stop. stop() should flush remaining.

--- a/pkg/resourcegroup/runaway/manager.go
+++ b/pkg/resourcegroup/runaway/manager.go
@@ -56,7 +56,7 @@ var sampleLogger = logutil.SampleLoggerFactory(time.Minute, 1, zap.String(loguti
 
 // Manager is used to detect and record runaway queries.
 type Manager struct {
-	exit chan struct{}
+	exit <-chan struct{}
 	// queryLock is used to avoid repeated additions. Since we will add new items to the system table,
 	// in order to avoid repeated additions, we need a lock to ensure that
 	// action "judging whether there is this record in the current watch list and adding records" have atomicity.
@@ -403,7 +403,7 @@ func (rm *Manager) AddWatch(record *QuarantineRecord) {
 	ttl := time.Until(record.EndTime)
 	if record.EndTime.Equal(NullTime) {
 		ttl = 0
-	} else if ttl <= 0 {
+	} else if ttl <= 0 && record.ID != 0 {
 		rm.staleQuarantineFlusher.add(record.ID, record)
 		return
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65746.

### What changed and how does it work?

Replace channel-based record passing with direct flusher integration. Each batchFlusher now owns its goroutine (run/stop lifecycle) and uses a sync.Mutex to guard the buffer, enabling lock-free concurrent adds. Add maxBufferSize cap (32K entries, ~24MB worst-case) to prevent unbounded memory growth when flush is slow, with a drop counter metric for observability. Simplify RunawayRecordFlushLoop by removing the channel-multiplexing select and letting each flusher manage its own flush timing.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
