### PR TITLE
*: backport _tidb_commit_ts support for unistore cop request

### DIFF
--- a/pkg/store/mockstore/unistore/cophandler/BUILD.bazel
+++ b/pkg/store/mockstore/unistore/cophandler/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "@com_github_pingcap_kvproto//pkg/kvrpcpb",
         "@com_github_pingcap_kvproto//pkg/mpp",
         "@com_github_pingcap_tipb//go-tipb",
+        "@com_github_tikv_client_go_v2//tikv",
         "@com_github_tikv_client_go_v2//tikvrpc",
         "@com_github_twmb_murmur3//:murmur3",
         "@org_uber_go_atomic//:atomic",

--- a/pkg/store/mockstore/unistore/cophandler/analyze.go
+++ b/pkg/store/mockstore/unistore/cophandler/analyze.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/badger/y"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/charset"
@@ -41,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/rowcodec"
 	"github.com/pingcap/tipb/go-tipb"
+	"github.com/tikv/client-go/v2/tikv"
 	"github.com/twmb/murmur3"
 )
 
@@ -189,8 +191,20 @@ type analyzeIndexProcessor struct {
 	topNCurValuePair statistics.TopNMeta
 }
 
-func (p *analyzeIndexProcessor) Process(key, _ []byte) error {
-	values, _, err := tablecodec.CutIndexKeyNew(key, p.colLen)
+func (p *analyzeIndexProcessor) Process(key, _ []byte, _ uint64) error {
+	decodedKey := key
+	if !kv.Key(key).HasPrefix(tablecodec.TablePrefix()) {
+		// If the key is in API V2, then ignore the prefix
+		_, k, err := tikv.DecodeKey(key, kvrpcpb.APIVersion_V2)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		decodedKey = k
+		if !kv.Key(decodedKey).HasPrefix(tablecodec.TablePrefix()) {
+			return errors.Errorf("invalid index key %q after decoded", key)
+		}
+	}
+	values, _, err := tablecodec.CutIndexKeyNew(decodedKey, p.colLen)
 	if err != nil {
 		return err
 	}
@@ -237,7 +251,7 @@ type analyzeCommonHandleProcessor struct {
 	rowBuf       []byte
 }
 
-func (p *analyzeCommonHandleProcessor) Process(key, value []byte) error {
+func (p *analyzeCommonHandleProcessor) Process(key, value []byte, _ uint64) error {
 	values, _, err := tablecodec.CutCommonHandle(key, p.colLen)
 	if err != nil {
 		return err
@@ -483,7 +497,7 @@ func (e *analyzeColumnsExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	return nil
 }
 
-func (e *analyzeColumnsExec) Process(key, value []byte) error {
+func (e *analyzeColumnsExec) Process(key, value []byte, _ uint64) error {
 	handle, err := tablecodec.DecodeRowKey(key)
 	if err != nil {
 		return errors.Trace(err)
@@ -615,9 +629,21 @@ type analyzeMixedExec struct {
 	topNCurValuePair statistics.TopNMeta
 }
 
-func (e *analyzeMixedExec) Process(key, value []byte) error {
+func (e *analyzeMixedExec) Process(key, value []byte, _ uint64) error {
+	decodedKey := key
+	if !kv.Key(key).HasPrefix(tablecodec.TablePrefix()) {
+		// If the key is in API V2, then ignore the prefix
+		_, k, err := tikv.DecodeKey(key, kvrpcpb.APIVersion_V2)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		decodedKey = k
+		if !kv.Key(decodedKey).HasPrefix(tablecodec.TablePrefix()) {
+			return errors.Errorf("invalid index key %q after decoded", key)
+		}
+	}
 	// common handle
-	values, _, err := tablecodec.CutCommonHandle(key, e.colLen)
+	values, _, err := tablecodec.CutCommonHandle(decodedKey, e.colLen)
 	if err != nil {
 		return err
 	}
@@ -653,7 +679,7 @@ func (e *analyzeMixedExec) Process(key, value []byte) error {
 	}
 
 	// columns
-	err = e.analyzeColumnsExec.Process(key, value)
+	err = e.analyzeColumnsExec.Process(key, value, 0)
 	return err
 }
 

--- a/pkg/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/closure_exec.go
@@ -561,7 +561,7 @@ func (e *closureExecutor) execute() ([]tipb.Chunk, error) {
 	for i, ran := range e.kvRanges {
 		e.curNdv = 0
 		if e.isPointGetRange(ran) {
-			val, err := dbReader.Get(ran.StartKey, e.startTS)
+			val, meta, err := dbReader.GetWithMeta(ran.StartKey, e.startTS)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -572,7 +572,7 @@ func (e *closureExecutor) execute() ([]tipb.Chunk, error) {
 				e.counts[i]++
 				e.ndvs[i] = 1
 			}
-			err = e.processor.Process(ran.StartKey, val)
+			err = e.processor.Process(ran.StartKey, val, meta.CommitTS())
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -641,7 +641,7 @@ type countStarProcessor struct {
 }
 
 // countStarProcess is used for `count(*)`.
-func (e *countStarProcessor) Process(key, value []byte) error {
+func (e *countStarProcessor) Process(key, value []byte, _ uint64) error {
 	defer func(begin time.Time) {
 		if e.idxScanCtx != nil {
 			e.idxScanCtx.execDetail.update(begin, true)
@@ -677,7 +677,7 @@ type countColumnProcessor struct {
 	*closureExecutor
 }
 
-func (e *countColumnProcessor) Process(key, value []byte) error {
+func (e *countColumnProcessor) Process(key, value []byte, _ uint64) error {
 	gotRow := false
 	defer func(begin time.Time) {
 		if e.idxScanCtx != nil {
@@ -738,13 +738,13 @@ type tableScanProcessor struct {
 	*closureExecutor
 }
 
-func (e *tableScanProcessor) Process(key, value []byte) error {
+func (e *tableScanProcessor) Process(key, value []byte, commitTS uint64) error {
 	if e.rowCount == e.limit {
 		return dbreader.ErrScanBreak
 	}
 	e.rowCount++
 	e.curNdv++
-	err := e.tableScanProcessCore(key, value)
+	err := e.tableScanProcessCore(key, value, commitTS)
 	if e.scanCtx.chk.NumRows() == chunkMaxRows {
 		err = e.chunkToOldChunk(e.scanCtx.chk)
 	}
@@ -755,14 +755,14 @@ func (e *tableScanProcessor) Finish() error {
 	return e.scanFinish()
 }
 
-func (e *closureExecutor) processCore(key, value []byte) error {
+func (e *closureExecutor) processCore(key, value []byte, commitTS uint64) error {
 	if e.mockReader != nil {
 		return e.mockReadScanProcessCore(key, value)
 	}
 	if e.idxScanCtx != nil {
 		return e.indexScanProcessCore(key, value)
 	}
-	return e.tableScanProcessCore(key, value)
+	return e.tableScanProcessCore(key, value, commitTS)
 }
 
 func (e *closureExecutor) hasSelection() bool {
@@ -832,7 +832,7 @@ func (e *closureExecutor) mockReadScanProcessCore(key, value []byte) error {
 	return nil
 }
 
-func (e *closureExecutor) tableScanProcessCore(key, value []byte) error {
+func (e *closureExecutor) tableScanProcessCore(key, value []byte, commitTS uint64) error {
 	incRow := false
 	defer func(begin time.Time) {
 		e.scanCtx.execDetail.update(begin, incRow)
@@ -841,7 +841,7 @@ func (e *closureExecutor) tableScanProcessCore(key, value []byte) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = e.scanCtx.decoder.DecodeToChunk(value, handle, e.scanCtx.chk)
+	err = e.scanCtx.decoder.DecodeToChunkWithCommitTS(value, commitTS, handle, e.scanCtx.chk)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -864,7 +864,7 @@ type indexScanProcessor struct {
 	*closureExecutor
 }
 
-func (e *indexScanProcessor) Process(key, value []byte) error {
+func (e *indexScanProcessor) Process(key, value []byte, commitTS uint64) error {
 	if e.rowCount == e.limit {
 		return dbreader.ErrScanBreak
 	}
@@ -969,7 +969,7 @@ type selectionProcessor struct {
 	*closureExecutor
 }
 
-func (e *selectionProcessor) Process(key, value []byte) error {
+func (e *selectionProcessor) Process(key, value []byte, commitTS uint64) error {
 	var gotRow bool
 	defer func(begin time.Time) {
 		e.selectionCtx.execDetail.update(begin, gotRow)
@@ -977,7 +977,7 @@ func (e *selectionProcessor) Process(key, value []byte) error {
 	if e.rowCount == e.limit {
 		return dbreader.ErrScanBreak
 	}
-	err := e.processCore(key, value)
+	err := e.processCore(key, value, commitTS)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1003,12 +1003,12 @@ type topNProcessor struct {
 	*closureExecutor
 }
 
-func (e *topNProcessor) Process(key, value []byte) (err error) {
+func (e *topNProcessor) Process(key, value []byte, commitTS uint64) (err error) {
 	gotRow := false
 	defer func(begin time.Time) {
 		e.topNCtx.execDetail.update(begin, gotRow)
 	}(time.Now())
-	if err = e.processCore(key, value); err != nil {
+	if err = e.processCore(key, value, commitTS); err != nil {
 		return err
 	}
 	if e.hasSelection() {
@@ -1052,7 +1052,7 @@ func (e *topNProcessor) Finish() error {
 	sort.Sort(&ctx.heap.topNSorter)
 	chk := e.scanCtx.chk
 	for _, row := range ctx.heap.rows {
-		err := e.processCore(row.data[0], row.data[1])
+		err := e.processCore(row.data[0], row.data[1], 0)
 		if err != nil {
 			return err
 		}
@@ -1076,12 +1076,12 @@ type hashAggProcessor struct {
 	aggCtxsMap   map[string][]*aggregation.AggEvaluateContext
 }
 
-func (e *hashAggProcessor) Process(key, value []byte) (err error) {
+func (e *hashAggProcessor) Process(key, value []byte, commitTS uint64) (err error) {
 	incRow := false
 	defer func(begin time.Time) {
 		e.aggCtx.execDetail.update(begin, incRow)
 	}(time.Now())
-	err = e.processCore(key, value)
+	err = e.processCore(key, value, commitTS)
 	if err != nil {
 		return err
 	}

--- a/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/rowcodec"
 	"github.com/pingcap/tipb/go-tipb"
+	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/tikvrpc"
 )
 
@@ -135,13 +136,13 @@ type tableScanExec struct {
 
 func (e *tableScanExec) SkipValue() bool { return false }
 
-func (e *tableScanExec) Process(key, value []byte) error {
+func (e *tableScanExec) Process(key, value []byte, commitTS uint64) error {
 	handle, err := tablecodec.DecodeRowKey(key)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	err = e.decoder.DecodeToChunk(value, handle, e.chk)
+	err = e.decoder.DecodeToChunkWithCommitTS(value, commitTS, handle, e.chk)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -292,8 +293,20 @@ func (e *indexScanExec) isNewVals(values [][]byte) bool {
 	return false
 }
 
-func (e *indexScanExec) Process(key, value []byte) error {
-	values, err := tablecodec.DecodeIndexKV(key, value, e.numIdxCols, e.hdlStatus, e.colInfos)
+func (e *indexScanExec) Process(key, value []byte, _ uint64) error {
+	decodedKey := key
+	if !kv.Key(key).HasPrefix(tablecodec.TablePrefix()) {
+		// If the key is in API V2, then ignore the prefix
+		_, k, err := tikv.DecodeKey(key, kvrpcpb.APIVersion_V2)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		decodedKey = k
+		if !kv.Key(decodedKey).HasPrefix(tablecodec.TablePrefix()) {
+			return errors.Errorf("invalid index key %q after decoded", key)
+		}
+	}
+	values, err := tablecodec.DecodeIndexKV(decodedKey, value, e.numIdxCols, e.hdlStatus, e.colInfos)
 	if err != nil {
 		return err
 	}

--- a/pkg/store/mockstore/unistore/tikv/dbreader/db_reader.go
+++ b/pkg/store/mockstore/unistore/tikv/dbreader/db_reader.go
@@ -106,22 +106,32 @@ func (r *DBReader) GetMvccInfoByKey(key []byte, _ bool, mvccInfo *kvrpcpb.MvccIn
 
 // Get gets a value with the key and start ts.
 func (r *DBReader) Get(key []byte, startTS uint64) ([]byte, error) {
+	val, _, err := r.GetWithMeta(key, startTS)
+	return val, err
+}
+
+// GetWithMeta gets a value with the key and start ts, and also returns mvcc metadata.
+func (r *DBReader) GetWithMeta(key []byte, startTS uint64) ([]byte, mvcc.DBUserMeta, error) {
 	r.txn.SetReadTS(startTS)
 	if r.RcCheckTS {
 		r.txn.SetReadTS(math.MaxUint64)
 	}
 	item, err := r.txn.Get(key)
 	if err != nil && err != badger.ErrKeyNotFound {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 	if item == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	err = r.CheckWriteItemForRcCheckTSRead(startTS, item)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
-	return item.Value()
+	val, err := item.Value()
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return val, mvcc.DBUserMeta(item.UserMeta()), nil
 }
 
 // GetIter returns the *badger.Iterator of a *DBReader.
@@ -195,7 +205,7 @@ type ScanFunc = func(key, value []byte) error
 type ScanProcessor interface {
 	// Process accepts key and value, should not keep reference to them.
 	// Returns ErrScanBreak will break the scan loop.
-	Process(key, value []byte) error
+	Process(key, value []byte, commitTS uint64) error
 	// SkipValue returns if we can skip the value.
 	SkipValue() bool
 }
@@ -237,7 +247,7 @@ func (r *DBReader) Scan(startKey, endKey []byte, limit int, startTS uint64, proc
 				return errors.Trace(err)
 			}
 		}
-		err = proc.Process(key, val)
+		err = proc.Process(key, val, item.Version())
 		if err != nil {
 			if err == ErrScanBreak {
 				break
@@ -303,7 +313,7 @@ func (r *DBReader) ReverseScan(startKey, endKey []byte, limit int, startTS uint6
 				return errors.Trace(err)
 			}
 		}
-		err = proc.Process(key, val)
+		err = proc.Process(key, val, item.Version())
 		if err != nil {
 			if err == ErrScanBreak {
 				break

--- a/pkg/store/mockstore/unistore/tikv/mvcc.go
+++ b/pkg/store/mockstore/unistore/tikv/mvcc.go
@@ -1937,7 +1937,7 @@ type kvScanProcessor struct {
 	scanCnt    uint32
 }
 
-func (p *kvScanProcessor) Process(key, value []byte) (err error) {
+func (p *kvScanProcessor) Process(key, value []byte, _ uint64) (err error) {
 	if p.sampleStep > 0 {
 		p.scanCnt++
 		if (p.scanCnt-1)%p.sampleStep != 0 {

--- a/tests/integrationtest/r/active_active/commit_ts.result
+++ b/tests/integrationtest/r/active_active/commit_ts.result
@@ -1,0 +1,100 @@
+drop table if exists t;
+create table t (id int primary key, v int, index i_v(v));
+insert into t values (1, 1), (2, 2), (3, 3);
+insert into t values (4, 4);
+explain format = 'brief' select _tidb_commit_ts, id from t where id = 1;
+id	estRows	task	access object	operator info
+Projection	1.00	root		active_active__commit_ts.t._tidb_commit_ts, active_active__commit_ts.t.id
+└─TableReader	1.00	root		data:TableRangeScan
+  └─TableRangeScan	1.00	cop[tikv]	table:t	range:[1,1], keep order:false, stats:pseudo
+select _tidb_commit_ts, id from t where id = 1;
+_tidb_commit_ts	id
+TSO	1
+explain format = 'brief' select _tidb_commit_ts, id from t where id in (1, 2, 3);
+id	estRows	task	access object	operator info
+Projection	3.00	root		active_active__commit_ts.t._tidb_commit_ts, active_active__commit_ts.t.id
+└─TableReader	3.00	root		data:TableRangeScan
+  └─TableRangeScan	3.00	cop[tikv]	table:t	range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo
+select _tidb_commit_ts, id from t where id in (1, 2, 3);
+_tidb_commit_ts	id
+TSO	1
+TSO	2
+TSO	3
+select _tidb_commit_ts, id from t where id in (3, 4) order by _tidb_commit_ts desc;
+_tidb_commit_ts	id
+TSO	4
+TSO	3
+begin;
+select _tidb_commit_ts, id from t where id = 1;
+_tidb_commit_ts	id
+TSO	1
+select _tidb_commit_ts, id from t where id in (1, 2, 3);
+_tidb_commit_ts	id
+TSO	1
+TSO	2
+TSO	3
+insert into t values (5, 5);
+insert into t values (6, 6);
+select _tidb_commit_ts, id from t where id = 1;
+_tidb_commit_ts	id
+TSO	1
+select _tidb_commit_ts, id from t where id = 5;
+_tidb_commit_ts	id
+NULL	5
+select _tidb_commit_ts, id from t where id in (1, 2, 3);
+_tidb_commit_ts	id
+TSO	1
+TSO	2
+TSO	3
+select _tidb_commit_ts, id from t where id in (1, 2, 3, 5, 6);
+_tidb_commit_ts	id
+TSO	1
+TSO	2
+TSO	3
+NULL	5
+NULL	6
+rollback;
+create temporary table tmp (id int primary key, v int);
+insert into tmp values (1, 1), (2, 2), (3, 3), (4, 4);
+select _tidb_commit_ts, id from t where id = 1;
+_tidb_commit_ts	id
+TSO	1
+select _tidb_commit_ts, id from t where id in (1, 2, 3);
+_tidb_commit_ts	id
+TSO	1
+TSO	2
+TSO	3
+# coprocessor request should also return _tidb_commit_ts
+explain format = 'brief' select _tidb_commit_ts, id from t;
+id	estRows	task	access object	operator info
+Projection	10000.00	root		active_active__commit_ts.t._tidb_commit_ts, active_active__commit_ts.t.id
+└─TableReader	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+select _tidb_commit_ts, id from t;
+_tidb_commit_ts	id
+TSO	1
+TSO	2
+TSO	3
+TSO	4
+select _tidb_commit_ts, id from t where id < 5;
+_tidb_commit_ts	id
+TSO	1
+TSO	2
+TSO	3
+TSO	4
+select _tidb_commit_ts, id from t where id < 5 order by id desc;
+_tidb_commit_ts	id
+TSO	4
+TSO	3
+TSO	2
+TSO	1
+explain format = 'brief' select _tidb_commit_ts, v from t use index (i_v) where v = 2;
+id	estRows	task	access object	operator info
+Projection	10.00	root		active_active__commit_ts.t._tidb_commit_ts, active_active__commit_ts.t.v
+└─IndexLookUp	10.00	root		
+  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:i_v(v)	range:[2,2], keep order:false, stats:pseudo
+  └─TableRowIDScan(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+select _tidb_commit_ts, v from t use index (i_v) where v = 2;
+_tidb_commit_ts	v
+TSO	2
+drop table if exists t;

--- a/tests/integrationtest/t/active_active/commit_ts.test
+++ b/tests/integrationtest/t/active_active/commit_ts.test
@@ -1,0 +1,76 @@
+drop table if exists t;
+create table t (id int primary key, v int, index i_v(v));
+insert into t values (1, 1), (2, 2), (3, 3);
+insert into t values (4, 4);
+
+# basic point get
+explain format = 'brief' select _tidb_commit_ts, id from t where id = 1;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id = 1;
+
+# basic batch point get
+explain format = 'brief' select _tidb_commit_ts, id from t where id in (1, 2, 3);
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id in (1, 2, 3);
+
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id in (3, 4) order by _tidb_commit_ts desc;
+
+# point get inside txn
+begin;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id = 1;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id in (1, 2, 3);
+
+insert into t values (5, 5);
+insert into t values (6, 6);
+
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id = 1;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id = 5;
+
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id in (1, 2, 3);
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id in (1, 2, 3, 5, 6);
+rollback;
+
+# on temporary table, cached table
+create temporary table tmp (id int primary key, v int);
+insert into tmp values (1, 1), (2, 2), (3, 3), (4, 4);
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id = 1;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id in (1, 2, 3);
+
+# The test is not quite stable depends on cache is cached or not.
+# alter table t cache;
+# explain format = 'brief' select _tidb_commit_ts, id from t where id = 1;
+# --replace_regex /^[1-9][0-9]+/TSO/
+# select _tidb_commit_ts, id from t where id = 1;
+# sleep(1);
+# --replace_regex /^[1-9][0-9]+/TSO/
+# select _tidb_commit_ts, id from t where id = 1;
+
+# basic batch point get
+# explain format = 'brief' select _tidb_commit_ts, id from t where id in (1, 2, 3);
+# --replace_regex /^[1-9][0-9]+/TSO/
+# select _tidb_commit_ts, id from t where id in (1, 2, 3);
+
+--echo # coprocessor request should also return _tidb_commit_ts
+explain format = 'brief' select _tidb_commit_ts, id from t;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id < 5;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id < 5 order by id desc;
+
+# index lookup should be used, index scan does not support _tidb_commit_ts
+explain format = 'brief' select _tidb_commit_ts, v from t use index (i_v) where v = 2;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, v from t use index (i_v) where v = 2;
+
+drop table if exists t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #66061

Problem Summary:
- `_tidb_commit_ts` hidden column is already supported, but unistore coprocessor requests do not return commit ts in scan paths on this release branch.
- This causes inconsistent behavior between point-get style reads and cop/table scan paths when querying `_tidb_commit_ts`.

### What changed and how does it work?

- Backport pingcap/tidb#65107 for unistore coprocessor `_tidb_commit_ts` support.
- Add release-8.5 compatibility adaptations:
  - Keep `DBReader.Get` signature unchanged and add `GetWithMeta` for commit-ts propagation.
  - Add `rowcodec.ChunkDecoder.DecodeToChunkWithCommitTS` and use it in unistore table/mpp scan decode paths.
  - Keep `active_active/commit_ts` integration coverage focused on `_tidb_commit_ts` for this branch.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix unistore coprocessor scan paths to correctly return `_tidb_commit_ts` for hidden commit-ts column queries on release-8.5 branch.
```