### PR TITLE
ddl: allow SET TIFLASH REPLICA on MV-dependent base tables

### DIFF
--- a/pkg/executor/test/ddl/mview_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_ddl_test.go
@@ -169,9 +169,11 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	tk.MustExec("create index idx_mv_s on mv (s)")
 	tk.MustExec("drop index idx_mv_s on mv")
 
-	// ALTER TABLE ... SET TIFLASH REPLICA is allowed on MV table, but still forbidden on base.
+	// ALTER TABLE ... SET TIFLASH REPLICA is allowed on both base table and MV table.
 	err = tk.ExecToErr("alter table t set tiflash replica 1")
-	require.ErrorContains(t, err, "ALTER TABLE on base table with materialized view dependencies")
+	if err != nil {
+		require.NotContains(t, err.Error(), "ALTER TABLE on base table with materialized view dependencies")
+	}
 	err = tk.ExecToErr("alter table mv set tiflash replica 1")
 	if err != nil {
 		require.NotContains(t, err.Error(), "ALTER TABLE on materialized view table")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #66022

Problem Summary:
`ALTER TABLE ... SET TIFLASH REPLICA` on a base table with materialized view dependencies was rejected by the generic MV dependency guard with:
`Unsupported ALTER TABLE on base table with materialized view dependencies`.

### What changed and how does it work?

- In `ddl.AlterTable`, treat `ALTER TABLE ... SET TIFLASH REPLICA` as a safe metadata-only operation and bypass the MV dependency DDL restriction for this case.
- Keep existing restriction behavior unchanged for other ALTER TABLE specs.
- Update MV DDL test to assert that `SET TIFLASH REPLICA` is allowed on both base table and MV table, while other restricted operations remain blocked.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Test command:

```bash
tools/bin/failpoint-ctl enable pkg/ddl pkg/executor
GOCACHE=/tmp/go-build go test ./pkg/executor/test/ddl/... -run '^TestMaterializedViewDDLBasic$' -tags=intest,deadlock
tools/bin/failpoint-ctl disable pkg/ddl pkg/executor
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix `ALTER TABLE ... SET TIFLASH REPLICA` on base tables with materialized view dependencies being rejected by MV DDL constraints.
```
