### PR TITLE
planner: fix inconsistent plans for user variables with different casing

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -393,6 +393,18 @@ HAVING EXISTS (SELECT 1 FROM t_panic WHERE x IS NULL);`).Check(testkit.Rows("<ni
 			"      └─TableFullScan_135 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo"))
 	})
 
+	// Regression test for https://github.com/pingcap/tidb/issues/66339
+	// Read-only user variables with uppercase names should be converted to constant
+	// and use IndexRangeScan, same as lowercase names.
+	t.Run("issue-66339-readonly-var-uppercase-uses-index-range", func(t *testing.T) {
+		tk := newTestKit(t)
+		tk.MustExec("create table t(a int, key(a))")
+		tk.MustExec("set @a=1")
+		tk.MustHavePlan("select a from t where a=@a", "IndexRangeScan")
+		tk.MustExec("set @A=1")
+		tk.MustHavePlan("select a from t where a=@A", "IndexRangeScan")
+	})
+
 	t.Run("plan-cache-explain-for-connection", func(t *testing.T) {
 		tk := newTestKit(t)
 		tk.MustExec("create table t(a int, b int, c int)")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66339

Problem Summary: planner: fix inconsistent plans for user variables with different casing

### What changed and how does it work?

**Root cause:** `varsReadonly` / `varsMutable` in preprocess used the original variable name (e.g. `"customerId"`), while `convertReadonlyVarToConst` looks up using the lowercased name (`"customerid"`), so the readonly check failed for mixed-case names.

**Fix:** Use `strings.ToLower(node.Name)` when populating `varsReadonly` and `varsMutable` so the keys match the lookup and align with how user variables are stored elsewhere.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
