### PR TITLE
import-into: reduce needed tidb count for some steps in nextgen

### DIFF
--- a/pkg/dxf/framework/handle/BUILD.bazel
+++ b/pkg/dxf/framework/handle/BUILD.bazel
@@ -50,7 +50,7 @@ go_test(
     ],
     embed = [":handle"],
     flaky = True,
-    shard_count = 10,
+    shard_count = 11,
     deps = [
         "//pkg/config/kerneltype",
         "//pkg/dxf/framework/proto",

--- a/pkg/dxf/framework/handle/status.go
+++ b/pkg/dxf/framework/handle/status.go
@@ -180,7 +180,8 @@ func CalculateRequiredNodes(tasks []*proto.TaskBase, cpuCount int) int {
 }
 
 func getNeededNodes(task *proto.TaskBase) int {
-	// for below steps of IMPORT INTO task, we only have 1 subtask now.
+	// for below steps of IMPORT INTO task, we only have 1 subtask and only need
+	// 1 node.
 	if task.Type == proto.ImportInto && (task.Step == proto.ImportStepCollectConflicts ||
 		task.Step == proto.ImportStepConflictResolution ||
 		task.Step == proto.ImportStepPostProcess) {

--- a/pkg/dxf/framework/handle/status_test.go
+++ b/pkg/dxf/framework/handle/status_test.go
@@ -73,3 +73,60 @@ func TestCalculateRequiredNodes(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNeededNodes(t *testing.T) {
+	cases := []struct {
+		name     string
+		taskType proto.TaskType
+		step     proto.Step
+		maxNodes int
+		expected int
+	}{
+		{
+			name:     "import-collect-conflicts",
+			taskType: proto.ImportInto,
+			step:     proto.ImportStepCollectConflicts,
+			maxNodes: 8,
+			expected: 1,
+		},
+		{
+			name:     "import-conflict-resolution",
+			taskType: proto.ImportInto,
+			step:     proto.ImportStepConflictResolution,
+			maxNodes: 8,
+			expected: 1,
+		},
+		{
+			name:     "import-post-process",
+			taskType: proto.ImportInto,
+			step:     proto.ImportStepPostProcess,
+			maxNodes: 8,
+			expected: 1,
+		},
+		{
+			name:     "import-regular-step",
+			taskType: proto.ImportInto,
+			step:     proto.ImportStepEncodeAndSort,
+			maxNodes: 6,
+			expected: 6,
+		},
+		{
+			name:     "non-import-type",
+			taskType: proto.TaskTypeExample,
+			step:     proto.StepOne,
+			maxNodes: 5,
+			expected: 5,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			task := &proto.TaskBase{
+				Type:         c.taskType,
+				Step:         c.step,
+				MaxNodeCount: c.maxNodes,
+			}
+			require.Equal(t, c.expected, getNeededNodes(task))
+		})
+	}
+}

--- a/tests/realtikvtest/importintotest2/BUILD.bazel
+++ b/tests/realtikvtest/importintotest2/BUILD.bazel
@@ -6,6 +6,7 @@ go_test(
     srcs = [
         "from_select_test.go",
         "main_test.go",
+        "subtask_count_test.go",
         "write_after_import_test.go",
     ],
     flaky = True,
@@ -13,7 +14,12 @@ go_test(
     deps = [
         "//pkg/config/kerneltype",
         "//pkg/domain",
+        "//pkg/dxf/framework/handle",
+        "//pkg/dxf/framework/proto",
+        "//pkg/dxf/framework/schstatus",
+        "//pkg/dxf/framework/storage",
         "//pkg/dxf/framework/testutil",
+        "//pkg/dxf/importinto",
         "//pkg/executor/importer",
         "//pkg/infoschema",
         "//pkg/kv",
@@ -23,7 +29,10 @@ go_test(
         "//pkg/testkit/testfailpoint",
         "//pkg/util/dbterror/plannererrors",
         "//tests/realtikvtest",
+        "@com_github_docker_go_units//:go-units",
         "@com_github_fsouza_fake_gcs_server//fakestorage",
+        "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",
+        "@com_github_tikv_client_go_v2//util",
     ],
 )

--- a/tests/realtikvtest/importintotest2/main_test.go
+++ b/tests/realtikvtest/importintotest2/main_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/pkg/dxf/framework/testutil"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/tests/realtikvtest"
 	"github.com/stretchr/testify/suite"
 )
@@ -57,6 +58,7 @@ func (s *mockGCSSuite) SetupSuite() {
 		Port:       gcsPort,
 		PublicHost: gcsHost,
 	}
+	testfailpoint.Enable(s.T(), "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", "return(16)")
 	s.server, err = fakestorage.NewServerWithOptions(opt)
 	s.Require().NoError(err)
 	s.store = realtikvtest.CreateMockStoreAndSetup(s.T())

--- a/tests/realtikvtest/importintotest2/subtask_count_test.go
+++ b/tests/realtikvtest/importintotest2/subtask_count_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importintotest
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/docker/go-units"
+	"github.com/fsouza/fake-gcs-server/fakestorage"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/pingcap/tidb/pkg/dxf/framework/handle"
+	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
+	"github.com/pingcap/tidb/pkg/dxf/framework/schstatus"
+	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
+	"github.com/pingcap/tidb/pkg/dxf/importinto"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	"github.com/pingcap/tidb/tests/realtikvtest"
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/util"
+)
+
+func (s *mockGCSSuite) TestStepSubtaskCount() {
+	if kerneltype.IsClassic() {
+		s.T().Skip("it's related to the DXF status API, we only test it in next-gen")
+	}
+	ctx := util.WithInternalSourceType(context.Background(), "taskManager")
+	s.prepareAndUseDB("step_subtasks")
+	s.tk.MustExec("create table t (a int primary key, b int, c int, d int, unique(c), unique(d))")
+	s.server.CreateObject(fakestorage.Object{
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "step-subtasks", Name: "1.csv"},
+		Content:     []byte("1,1,1,1\n2,2,2,2\n3,3,3,3\n"),
+	})
+	s.server.CreateObject(fakestorage.Object{
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "step-subtasks", Name: "2.csv"},
+		// first 3 rows conflicts with the first file.
+		Content: []byte("1,1,1,1\n4,4,4,2\n5,5,3,5\n6,6,6,6\n"),
+	})
+	// after amplify, the real size is 58*14G=812G, and we mock the node as 16c,
+	// so the computed resource should be at least 2 nodes
+	var status *schstatus.Status
+	testfailpoint.Enable(s.T(), "github.com/pingcap/tidb/pkg/executor/importer/amplifyRealSize", fmt.Sprintf("return(%d)", 14*units.GiB))
+	testfailpoint.EnableCall(s.T(), "github.com/pingcap/tidb/pkg/dxf/importinto/syncBeforePostProcess", func(int64) {
+		var err error
+		status, err = handle.GetScheduleStatus(ctx)
+		s.NoError(err)
+	})
+	importSQL := fmt.Sprintf(`import into t FROM 'gs://step-subtasks/*.csv?endpoint=%s'
+		with __force_merge_step, __max_engine_size='1', cloud_storage_uri='%s'`, gcsEndpoint,
+		realtikvtest.GetNextGenObjStoreURI("gl-sort"))
+	rs := s.tk.MustQuery(importSQL).Rows()
+	jobID, err := strconv.Atoi(rs[0][0].(string))
+	require.NoError(s.T(), err)
+	s.tk.MustQuery("select * from t").Sort().Check(testkit.Rows("6 6 6 6"))
+	s.NotNil(status)
+	// only 1 node is required in post process step.
+	s.Equal(status.TiDBWorker.RequiredCount, 1)
+
+	taskKey := importinto.TaskKey(int64(jobID))
+	mgr, err := storage.GetTaskManager()
+	s.NoError(err)
+	task, err := mgr.GetTaskByKeyWithHistory(ctx, taskKey)
+	s.NoError(err)
+	s.EqualValues(16, task.RequiredSlots)
+	s.Greater(task.MaxNodeCount, 2)
+	for step, stCnt := range map[proto.Step]int{
+		proto.ImportStepEncodeAndSort:  2,
+		proto.ImportStepMergeSort:      3,
+		proto.ImportStepWriteAndIngest: 3,
+		// if later we support resolve conflicts distributedly, should also
+		// change getNeededNodes to make sure the status API works.
+		proto.ImportStepCollectConflicts:   1,
+		proto.ImportStepConflictResolution: 1,
+		proto.ImportStepPostProcess:        1,
+	} {
+		sts, err := mgr.GetSubtasksWithHistory(ctx, task.ID, step)
+		s.NoError(err)
+		s.Len(sts, stCnt)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
for resolve conflicts and post-process, we don't support to run them distributedly, so only 1 node is needed. with this pr, cluster controller can scale in nodes earlier for import into tasks
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
