### PR TITLE
expression/aggregation: support sum_int in NewDistAggFunc

### DIFF
--- a/pkg/expression/aggregation/BUILD.bazel
+++ b/pkg/expression/aggregation/BUILD.bazel
@@ -70,7 +70,7 @@ go_test(
     ],
     embed = [":aggregation"],
     flaky = True,
-    shard_count = 17,
+    shard_count = 18,
     deps = [
         "//pkg/expression",
         "//pkg/kv",
@@ -82,6 +82,7 @@ go_test(
         "//pkg/testkit/testsetup",
         "//pkg/types",
         "//pkg/util/chunk",
+        "//pkg/util/codec",
         "//pkg/util/mock",
         "@com_github_pingcap_tipb//go-tipb",
         "@com_github_stretchr_testify//require",

--- a/pkg/expression/aggregation/aggregation.go
+++ b/pkg/expression/aggregation/aggregation.go
@@ -64,6 +64,10 @@ func NewDistAggFunc(expr *tipb.Expr, fieldTps []*types.FieldType, ctx expression
 		aggF := newAggFunc(ast.AggFuncSum, args, false)
 		aggF.Mode = AggFunctionMode(*expr.AggFuncMode)
 		return &sumFunction{aggFunction: aggF}, aggF.AggFuncDesc, nil
+	case tipb.ExprType_SumInt:
+		aggF := newAggFunc(ast.AggFuncSumInt, args, false)
+		aggF.Mode = AggFunctionMode(*expr.AggFuncMode)
+		return &sumIntFunction{aggFunction: aggF}, aggF.AggFuncDesc, nil
 	case tipb.ExprType_Count:
 		aggF := newAggFunc(ast.AggFuncCount, args, false)
 		aggF.Mode = AggFunctionMode(*expr.AggFuncMode)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #66085

Problem Summary:

`sum_int` has been introduced and can be pushed down, but mockstore cop execution still failed when decoding pushed-down aggregate functions because `aggregation.NewDistAggFunc` did not handle `tipb.ExprType_SumInt`. This blocked unit tests for `sum_int` pushdown.

### What changed and how does it work?

- Add `tipb.ExprType_SumInt` handling in `NewDistAggFunc` to build `sumIntFunction`.
- Add regression test `TestNewDistAggFuncSumInt` to verify PB decoding and result correctness.
- Include Bazel metadata update generated by `make bazel_lint_changed`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `make failpoint-enable && (pushd pkg/expression/aggregation >/dev/null && go test -run 'Test(NewDistAggFuncSumInt|CheckAggPushDownSumInt|AggFuncSumIntToPb)$' -tags=intest,deadlock && rc=$? && popd >/dev/null && make failpoint-disable && exit $rc)`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
