### PR TITLE
session, executor: update mview system table schema

### DIFF
--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -661,7 +661,7 @@ func TestColumnTable(t *testing.T) {
 		testkit.RowsWithSep("|",
 			"test|tbl1|col_2"))
 	tk.MustQuery(`select count(*) from information_schema.columns;`).Check(
-		testkit.RowsWithSep("|", "5008"))
+		testkit.RowsWithSep("|", "5009"))
 }
 
 func TestIndexUsageTable(t *testing.T) {

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -773,6 +773,7 @@ const (
 	CreateTiDBMLogPurgeInfoTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mlog_purge_info (
 		MLOG_ID bigint NOT NULL,
 		NEXT_TIME datetime DEFAULT NULL,
+		LAST_PURGED_TSO bigint DEFAULT NULL,
 		PRIMARY KEY(MLOG_ID))`
 
 	// CreateTiDBMViewRefreshHistTable is a table to store mview refresh history.
@@ -780,8 +781,8 @@ const (
 		REFRESH_JOB_ID bigint NOT NULL,
 		MVIEW_ID bigint NOT NULL,
 		REFRESH_METHOD varchar(32) NOT NULL,
-		REFRESH_TIME datetime DEFAULT NULL,
-		REFRESH_ENDTIME datetime DEFAULT NULL,
+		REFRESH_TIME datetime(6) DEFAULT NULL,
+		REFRESH_ENDTIME datetime(6) DEFAULT NULL,
 		REFRESH_STATUS varchar(16) DEFAULT NULL,
 		REFRESH_ROWS bigint DEFAULT NULL,
 		REFRESH_READ_TSO bigint DEFAULT NULL,
@@ -793,8 +794,8 @@ const (
 		PURGE_JOB_ID bigint NOT NULL,
 		MLOG_ID bigint NOT NULL,
 		PURGE_METHOD varchar(32) NOT NULL,
-		PURGE_TIME datetime DEFAULT NULL,
-		PURGE_ENDTIME datetime DEFAULT NULL,
+		PURGE_TIME datetime(6) DEFAULT NULL,
+		PURGE_ENDTIME datetime(6) DEFAULT NULL,
 		PURGE_ROWS bigint NOT NULL,
 		PURGE_STATUS varchar(16) DEFAULT NULL,
 		PURGE_FAILED_REASON text DEFAULT NULL,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:
The MV system table schema needs small adjustments:
1. `mysql.tidb_mview_refresh_hist.REFRESH_TIME` and `REFRESH_ENDTIME` should be `datetime(6)`.
2. `mysql.tidb_mlog_purge_hist.PURGE_TIME` and `PURGE_ENDTIME` should be `datetime(6)`.
3. `mysql.tidb_mlog_purge_info` should include `LAST_PURGED_TSO bigint DEFAULT NULL`.

### What changed and how does it work?
- Updated the system table DDL definitions in bootstrap SQL:
  - `pkg/session/bootstrap.go`
- Updated bootstrap tests for MV system tables:
  - Added assertions for `LAST_PURGED_TSO`
  - Added assertions for `datetime_precision = 6` on the four time columns
  - `pkg/session/bootstraptest/mview_systable_test.go`
- Updated infoschema reader test reference count for `information_schema.columns` due one newly added system column:
  - `pkg/executor/infoschema_reader_test.go`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
