### PR TITLE
distsql, planner: correct the sending kv range for tici unsigned pk | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature-fts

### DIFF
--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -1051,5 +1051,8 @@ func TiCIIndexRangesToKVRanges(
 	if shardType == TiCIShardExtraShardingKey {
 		return IndexRangesToKVRanges(dctx, tids[0], idxID, ranges)
 	}
+	if shardType == TiCIShardIntHandle {
+		ranges, _ = SplitRangesAcrossInt64Boundary(ranges, false, false, false)
+	}
 	return TableHandleRangesToKVRanges(dctx, tids, shardType == TiCIShardCommonHandle, ranges)
 }

--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
@@ -521,7 +521,7 @@
         "SQL": "explain format='brief' select * from t6 where match(title) against ('hello' IN BOOLEAN MODE)",
         "Plan": [
           "IndexReader 1000.00 root  index:IndexRangeScan",
-          "└─IndexRangeScan 1000.00 cop[tici] table:t6, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t6.title), keep order:false, stats:pseudo"
+          "└─IndexRangeScan 1000.00 cop[tici] table:t6, index:idx_title(title) range:[0,+inf], search func:fts_match_word(\"hello\", test.t6.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -529,7 +529,7 @@
         "SQL": "explain format='brief' select * from t6 where match(title) against ('hello*' IN BOOLEAN MODE)",
         "Plan": [
           "IndexReader 1000.00 root  index:IndexRangeScan",
-          "└─IndexRangeScan 1000.00 cop[tici] table:t6, index:idx_title(title) range:[-inf,+inf], search func:fts_match_prefix(\"hello\", test.t6.title), keep order:false, stats:pseudo"
+          "└─IndexRangeScan 1000.00 cop[tici] table:t6, index:idx_title(title) range:[0,+inf], search func:fts_match_prefix(\"hello\", test.t6.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -537,7 +537,7 @@
         "SQL": "explain format='brief' select * from t6 where match(title) against ('\\\"hello world\\\"' IN BOOLEAN MODE)",
         "Plan": [
           "IndexReader 1000.00 root  index:IndexRangeScan",
-          "└─IndexRangeScan 1000.00 cop[tici] table:t6, index:idx_title(title) range:[-inf,+inf], search func:fts_match_phrase(\"hello world\", test.t6.title), keep order:false, stats:pseudo"
+          "└─IndexRangeScan 1000.00 cop[tici] table:t6, index:idx_title(title) range:[0,+inf], search func:fts_match_phrase(\"hello world\", test.t6.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -545,7 +545,7 @@
         "SQL": "explain format='brief' select * from t6 where match(title) against ('\\\"a>b\\\"' IN BOOLEAN MODE)",
         "Plan": [
           "IndexReader 1000.00 root  index:IndexRangeScan",
-          "└─IndexRangeScan 1000.00 cop[tici] table:t6, index:idx_title(title) range:[-inf,+inf], search func:fts_match_phrase(\"a b\", test.t6.title), keep order:false, stats:pseudo"
+          "└─IndexRangeScan 1000.00 cop[tici] table:t6, index:idx_title(title) range:[0,+inf], search func:fts_match_phrase(\"a b\", test.t6.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -553,7 +553,7 @@
         "SQL": "explain format='brief' select id from t6 where match(title) against ('+apple -banana' IN BOOLEAN MODE)",
         "Plan": [
           "IndexReader 1000.00 root  index:IndexRangeScan",
-          "└─IndexRangeScan 1000.00 cop[tici] table:t6, index:idx_title(title) range:[-inf,+inf], search func:and(istrue_with_null(fts_match_word(\"apple\", test.t6.title)), not(fts_match_word(\"banana\", test.t6.title))), keep order:false, stats:pseudo"
+          "└─IndexRangeScan 1000.00 cop[tici] table:t6, index:idx_title(title) range:[0,+inf], search func:and(istrue_with_null(fts_match_word(\"apple\", test.t6.title)), not(fts_match_word(\"banana\", test.t6.title))), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },

--- a/pkg/planner/core/casetest/tici/tici_test.go
+++ b/pkg/planner/core/casetest/tici/tici_test.go
@@ -60,7 +60,7 @@ func TestTiCISearchExplain(t *testing.T) {
 		index idx_field1 (field1)
 	)`)
 	tk.MustExec(`create table t6(
-		id INT PRIMARY KEY, title TEXT,
+		id INT UNSIGNED PRIMARY KEY, title TEXT,
 		FULLTEXT INDEX idx_title (title) WITH PARSER ngram
 	)`)
 	dom := domain.GetDomain(tk.Session())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/64651

Problem Summary:

In previous pr, we've corrected the logical range for unsigned pk.
But the actual physical range is still the wrong one.

This pr corrects it too. And fix potential display issue for unsigned pk.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test may be added later.
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
