### PR TITLE
pkg/tici: add timeout for shard cache meta request | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature-fts

### DIFF
--- a/pkg/tici/BUILD.bazel
+++ b/pkg/tici/BUILD.bazel
@@ -52,8 +52,9 @@ go_test(
     ],
     embed = [":tici"],
     flaky = True,
-    shard_count = 24,
+    shard_count = 25,
     deps = [
+        "//pkg/config",
         "//pkg/kv",
         "//pkg/lightning/membuf",
         "//pkg/meta/model",

--- a/pkg/tici/tici_manager_client.go
+++ b/pkg/tici/tici_manager_client.go
@@ -23,7 +23,9 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
+	tidbconfig "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -730,7 +732,9 @@ func (t *ManagerCtx) ScanRanges(ctx context.Context, tableID int64, indexID int6
 	if err := t.checkMetaClient(); err != nil {
 		return nil, err
 	}
-	resp, err := t.metaClient.client.GetShardLocalCacheInfo(ctx, request)
+	requestCtx, cancel := context.WithTimeout(ctx, time.Duration(tidbconfig.GetGlobalConfig().PDClient.PDServerTimeout)*time.Second)
+	defer cancel()
+	resp, err := t.metaClient.client.GetShardLocalCacheInfo(requestCtx, request)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tici/tici_manager_client.go
+++ b/pkg/tici/tici_manager_client.go
@@ -25,9 +25,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	tidbconfig "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	tidbconfig "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"

--- a/pkg/tici/tici_manager_client_test.go
+++ b/pkg/tici/tici_manager_client_test.go
@@ -19,7 +19,9 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
+	tidbconfig "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -337,6 +339,46 @@ func TestScanRanges(t *testing.T) {
 	assert.Equal(t, []byte("c"), shardInfos[1].Shard.StartKey)
 	assert.Equal(t, []byte("d"), shardInfos[1].Shard.EndKey)
 	assert.Equal(t, []string{"addr2"}, shardInfos[1].LocalCacheAddrs)
+}
+
+func TestScanRangesTimeout(t *testing.T) {
+	originalCfg := *tidbconfig.GetGlobalConfig()
+	cfg := originalCfg
+	cfg.PDClient.PDServerTimeout = 1
+	tidbconfig.StoreGlobalConfig(&cfg)
+	defer tidbconfig.StoreGlobalConfig(&originalCfg)
+
+	mockClient := new(MockMetaServiceClient)
+	ctx := newTestTiCIManagerCtx(mockClient)
+	tableID, indexID := int64(1), int64(2)
+	keyRanges := []kv.KeyRange{
+		{StartKey: []byte("a"), EndKey: []byte("b")},
+	}
+
+	mockClient.
+		On("GetShardLocalCacheInfo", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			reqCtx, ok := args.Get(0).(context.Context)
+			require.True(t, ok)
+			<-reqCtx.Done()
+		}).
+		Return((*GetShardLocalCacheResponse)(nil), context.DeadlineExceeded).
+		Once()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := ctx.ScanRanges(context.Background(), tableID, indexID, keyRanges, 100)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("ScanRanges did not return within timeout")
+	}
+
+	mockClient.AssertExpectations(t)
 }
 
 func TestModelTableToTiCITableInfo(t *testing.T) {

--- a/pkg/tici/tici_manager_client_test.go
+++ b/pkg/tici/tici_manager_client_test.go
@@ -362,7 +362,7 @@ func TestScanRangesTimeout(t *testing.T) {
 			require.True(t, ok)
 			<-reqCtx.Done()
 		}).
-		Return((*GetShardLocalCacheResponse)(nil), context.DeadlineExceeded).
+		Return(&GetShardLocalCacheResponse{}, context.DeadlineExceeded).
 		Once()
 
 	done := make(chan error, 1)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref pingcap-inc/tici#834

Problem Summary:
TiCI shard cache meta request (`GetShardLocalCacheInfo`) had no timeout. When the meta service is stuck, SQL may hang for a long time.

### What changed and how does it work?

- Add timeout for TiCI shard cache meta RPC in `ManagerCtx.ScanRanges`.
- Reuse `PDClient.PDServerTimeout` from global config, aligned with region-cache/PD timeout settings.
- Add unit test `TestScanRangesTimeout` to verify `ScanRanges` returns `context.DeadlineExceeded` instead of hanging when meta RPC is blocked.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix potential SQL hanging when TiCI shard cache meta request is stuck by adding timeout in ScanRanges.
```
