### PR TITLE
planner: fix the HasFTS check for multi table case | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature-fts

### DIFF
--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_in.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_in.json
@@ -44,6 +44,7 @@
       "explain format='brief' select * from t4 where i in (1, 2, 3) and t = 'apple' order by i, ts desc, t, d limit 10 offset 5",
       "explain format='brief' select * from t4 where i in (1, 2, 3) and d between '2025-11-01' and '2025-11-30' order by i, ts desc, d limit 10",
       "explain format='brief' select i from t4 where i in (1, 2, 3) and t = 'apple' order by i, ts desc limit 10",
+      "explain format='brief' select * from t1, t4 where t1.id = t4.i and t4.ts < '2025-11-30 00:00:00' and fts_match_word('hello', t1.title)",
       "explain format='brief' select /*+ inl_join(t4), use_index(t4, idx) */ * from t4, t2 where t2.a=t4.i and t4.t = 'apple'",
       "explain format='brief' select * from t5 where t = 'apple'",
       "explain format='brief' select * from t5 where t = 'apple' and ts < '2025-11-30 00:00:00'",

--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
@@ -402,6 +402,20 @@
         "Warn": null
       },
       {
+        "SQL": "explain format='brief' select * from t1, t4 where t1.id = t4.i and t4.ts < '2025-11-30 00:00:00' and fts_match_word('hello', t1.title)",
+        "Plan": [
+          "Projection 4154.17 root  test.t1.id, test.t1.title, test.t1.body, test.t1.field1, test.t4.i, test.t4.ts, test.t4.d, test.t4.t",
+          "└─IndexJoin 4154.17 root  inner join, inner:TableReader, outer key:test.t1.id, inner key:test.t4.i, equal cond:eq(test.t1.id, test.t4.i)",
+          "  ├─IndexLookUp(Build) 1000.00 root  ",
+          "  │ ├─IndexRangeScan(Build) 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
+          "  │ └─TableRowIDScan(Probe) 1000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─TableReader(Probe) 332.33 root  data:Selection",
+          "    └─Selection 332.33 cop[tikv]  lt(test.t4.ts, 2025-11-30 00:00:00.000000)",
+          "      └─TableRangeScan 1000.00 cop[tikv] table:t4 range: decided by [test.t1.id], keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      },
+      {
         "SQL": "explain format='brief' select /*+ inl_join(t4), use_index(t4, idx) */ * from t4, t2 where t2.a=t4.i and t4.t = 'apple'",
         "Plan": [
           "HashJoin 12.50 root  inner join, equal:[eq(test.t4.i, test.t2.a)]",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/64651

Problem Summary:

### What changed and how does it work?

We will wrongly treat one table has FTS predicates in the multi-table case.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
