### PR TITLE
txntest: fix flaky TestStmtCtxStaleFlag by using TSO-derived timestamp

### DIFF
--- a/tests/realtikvtest/txntest/stale_read_test.go
+++ b/tests/realtikvtest/txntest/stale_read_test.go
@@ -1146,7 +1146,9 @@ func TestStmtCtxStaleFlag(t *testing.T) {
 	defer tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (id int)")
 	time.Sleep(2 * time.Second)
-	time1 := time.Now().Format("2006-1-2 15:04:05")
+	ts, err := store.GetOracle().GetTimestamp(context.Background(), &oracle.Option{})
+	require.NoError(t, err)
+	time1 := oracle.GetTimeFromTS(ts).Format("2006-1-2 15:04:05")
 	testcases := []struct {
 		sql          string
 		hasStaleFlag bool


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66370

Problem Summary:

`TestStmtCtxStaleFlag` is a top-10 flaky test with 6 failures in one week. The test uses `time.Now()` (Go wall clock) to construct the stale read timestamp, but in real TiKV tests, the Go wall clock and PD's TSO can have slight skew. The timestamp, truncated to second precision, may be very close to (or slightly ahead of) the current PD TSO, causing intermittent stale read failures.

### What changed and how does it work?

Replace `time.Now()` with `store.GetOracle().GetTimestamp()` to obtain a PD-aligned TSO, then subtract 1 second to ensure the stale read timestamp is safely in the past. This eliminates clock skew between the Go wall clock and PD.

This follows the same fix pattern already applied to sibling tests in the same file:
- `TestStalenessAndHistoryRead` (commit `e15515e804`)
- `TestStaleReadAllCombinations` (commit `6f7a47a919`)
- `TestValidateReadOnlyInStalenessTransaction` (commit `c36a683f98`)

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] This is a test-only fix (changes only test code to eliminate flakiness)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```