### PR TITLE
planner, executor, sessionctx: reject explicit dml on mview / mlog tables

### DIFF
--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -594,6 +594,7 @@ func initCreateMaterializedViewBuildSession(sessCtx sessionctx.Context, reorgMet
 		return nil, errors.Trace(err)
 	}
 	// MV init build should follow the same TiFlash strict-mode bypass path as MV refresh.
+	// Also marks the session as MV maintenance context so writes bypass the explicit-DML guard.
 	sessCtx.GetSessionVars().InMaterializedViewMaintenance = true
 	return func() {
 		restore(sessCtx)

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -82,6 +82,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/ranger"
 	rangerctx "github.com/pingcap/tidb/pkg/util/ranger/context"
@@ -1011,10 +1012,17 @@ func (b *executorBuilder) buildInsert(v *plannercore.Insert) exec.Executor {
 	baseExec := exec.NewBaseExecutor(b.ctx, nil, v.ID(), children...)
 	baseExec.SetInitCap(chunk.ZeroCapacity)
 
-	sourceStmt := tables.MLogSourceInsert
+	op, sourceStmt := "INSERT", tables.MLogSourceInsert
 	if v.IsReplace {
-		sourceStmt = tables.MLogSourceReplace
+		op, sourceStmt = "REPLACE", tables.MLogSourceReplace
 	}
+	tblInfo := v.Table.Meta()
+	// Planner already rejects DML on MV/mlog tables; this catches bypass bugs.
+	intest.AssertFunc(func() bool {
+		sv := b.ctx.GetSessionVars()
+		intest.AssertNoError(plannercore.CheckMViewUpdatable(sv, tblInfo, "", op))
+		return true
+	})
 	insertTable := b.wrapTableWithMLogIfExists(v.Table, sourceStmt)
 	if b.err != nil {
 		return nil
@@ -1064,6 +1072,12 @@ func (b *executorBuilder) buildImportInto(v *plannercore.ImportInto) exec.Execut
 		b.err = errors.Errorf("Can not get table %d", v.Table.TableInfo.ID)
 		return nil
 	}
+	// Planner already rejects DML on MV/mlog tables; this catches bypass bugs.
+	intest.AssertFunc(func() bool {
+		sv := b.ctx.GetSessionVars()
+		intest.AssertNoError(plannercore.CheckMViewUpdatable(sv, tbl.Meta(), "", "IMPORT"))
+		return true
+	})
 	if !tbl.Meta().IsBaseTable() {
 		b.err = plannererrors.ErrNonUpdatableTable.GenWithStackByArgs(tbl.Meta().Name.O, "IMPORT")
 		return nil
@@ -1103,6 +1117,12 @@ func (b *executorBuilder) buildLoadData(v *plannercore.LoadData) exec.Executor {
 		b.err = errors.Errorf("Can not get table %d", v.Table.TableInfo.ID)
 		return nil
 	}
+	// Planner already rejects DML on MV/mlog tables; this catches bypass bugs.
+	intest.AssertFunc(func() bool {
+		sv := b.ctx.GetSessionVars()
+		intest.AssertNoError(plannercore.CheckMViewUpdatable(sv, tbl.Meta(), "", "LOAD"))
+		return true
+	})
 	if !tbl.Meta().IsBaseTable() {
 		b.err = plannererrors.ErrNonUpdatableTable.GenWithStackByArgs(tbl.Meta().Name.O, "LOAD")
 		return nil
@@ -2792,6 +2812,12 @@ func (b *executorBuilder) buildUpdate(v *plannercore.Update) exec.Executor {
 				}
 			}
 		}
+		// Planner already rejects DML on MV/mlog tables; this catches bypass bugs.
+		intest.AssertFunc(func() bool {
+			sv := b.ctx.GetSessionVars()
+			intest.AssertNoError(plannercore.CheckMViewUpdatable(sv, tbl.Meta(), "", "UPDATE"))
+			return true
+		})
 		tbl = b.wrapTableWithMLogIfExists(tbl, tables.MLogSourceUpdate)
 		if b.err != nil {
 			return nil
@@ -2863,6 +2889,13 @@ func (b *executorBuilder) buildDelete(v *plannercore.Delete) exec.Executor {
 	tblID2table := make(map[int64]table.Table, len(v.TblColPosInfos))
 	for _, info := range v.TblColPosInfos {
 		tbl, _ := b.is.TableByID(context.Background(), info.TblID)
+		// Planner already rejects DML on MV/mlog tables; this catches bypass bugs.
+		intest.AssertFunc(func() bool {
+			sv := b.ctx.GetSessionVars()
+			err := plannercore.CheckMViewUpdatable(sv, tbl.Meta(), "", "DELETE")
+			intest.AssertNoError(err)
+			return true
+		})
 		tbl = b.wrapTableWithMLogIfExists(tbl, tables.MLogSourceDelete)
 		if b.err != nil {
 			return nil

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4059,6 +4059,15 @@ func (b *PlanBuilder) buildInsert(ctx context.Context, insert *ast.InsertStmt) (
 		}
 		return nil, err
 	}
+
+	op := "INSERT"
+	if insert.IsReplace {
+		op = "REPLACE"
+	}
+	sessionVars := b.ctx.GetSessionVars()
+	if err := CheckMViewUpdatable(sessionVars, tableInfo, tableInfo.Name.O, op); err != nil {
+		return nil, err
+	}
 	// Build Schema with DBName otherwise ColumnRef with DBName cannot match any Column in Schema.
 	schema, names, err := expression.TableInfo2SchemaAndNames(b.ctx.GetExprCtx(), tn.Schema, tableInfo)
 	if err != nil {
@@ -4524,6 +4533,9 @@ func (b *PlanBuilder) buildLoadData(ctx context.Context, ld *ast.LoadDataStmt) (
 		options = append(options, &loadDataOpt)
 	}
 	tnW := b.resolveCtx.GetTableName(ld.Table)
+	if err := CheckMViewUpdatable(b.ctx.GetSessionVars(), tnW.TableInfo, tnW.TableInfo.Name.O, "LOAD"); err != nil {
+		return nil, err
+	}
 	p := LoadData{
 		FileLocRef:         ld.FileLocRef,
 		OnDuplicate:        ld.OnDuplicate,
@@ -4727,6 +4739,9 @@ func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStm
 	}
 
 	tnW := b.resolveCtx.GetTableName(ld.Table)
+	if err := CheckMViewUpdatable(b.ctx.GetSessionVars(), tnW.TableInfo, tnW.TableInfo.Name.O, "IMPORT"); err != nil {
+		return nil, err
+	}
 	if tnW.TableInfo.TempTableType != model.TempTableNone {
 		return nil, errors.Errorf("IMPORT INTO does not support temporary table")
 	} else if tnW.TableInfo.TableCacheStatusType != model.TableCacheStatusDisable {

--- a/tests/integrationtest/r/executor/mview_log_dml.result
+++ b/tests/integrationtest/r/executor/mview_log_dml.result
@@ -7,18 +7,21 @@ insert into t values (1,10,100,1000);
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 id	uk	v	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 1	10	100	I	1
-delete from `$mlog$t`;
+drop materialized view log on t;
+create materialized view log on t (id, uk, v);
 update t set v=101 where id=1;
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 id	uk	v	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 1	10	100	U	-1
 1	10	101	U	1
-delete from `$mlog$t`;
+drop materialized view log on t;
+create materialized view log on t (id, uk, v);
 update t set extra=2000 where id=1;
 select count(*) from `$mlog$t`;
 count(*)
 0
-delete from `$mlog$t`;
+drop materialized view log on t;
+create materialized view log on t (id, uk, v);
 delete from t where id=1;
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 id	uk	v	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
@@ -67,7 +70,8 @@ select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id
 id	uk	v	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 1	10	100	U	-1
 1	10	101	U	1
-delete from `$mlog$t`;
+drop materialized view log on t;
+create materialized view log on t (id, uk, v);
 insert into t values (1, 10, 200) on duplicate key update id = 3, v = values(v);
 select id, uk, v from t order by id;
 id	uk	v
@@ -81,7 +85,8 @@ drop table if exists `$mlog$t`;
 create table t (id int primary key, tracked int, untracked int);
 create materialized view log on t (id, tracked);
 insert into t values (1, 10, 100);
-delete from `$mlog$t`;
+drop materialized view log on t;
+create materialized view log on t (id, tracked);
 alter table t add column c_new int default 0;
 update t set untracked = 101 where id = 1;
 select count(*) from `$mlog$t`;
@@ -133,4 +138,82 @@ _tidb_rowid	a	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 3	2	U	1
 4	2	I	1
 5	3	I	1
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int);
+create materialized view log on t (a, b);
+insert into `$mlog$t` values (1, 2, 'I', 1);
+Error 1288 (HY000): The target table $mlog$t of the INSERT is not updatable
+replace into `$mlog$t` values (1, 2, 'I', 1);
+Error 1288 (HY000): The target table $mlog$t of the REPLACE is not updatable
+update `$mlog$t` set a=1;
+Error 1288 (HY000): The target table $mlog$t of the UPDATE is not updatable
+delete from `$mlog$t`;
+Error 1288 (HY000): The target table $mlog$t of the DELETE is not updatable
+select * from `$mlog$t`;
+a	b	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int not null);
+create materialized view log on t (a, b);
+create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
+insert into v values (1, 10, 1);
+Error 1288 (HY000): The target table v of the INSERT is not updatable
+replace into v values (1, 10, 1);
+Error 1288 (HY000): The target table v of the REPLACE is not updatable
+update v set s=1;
+Error 1288 (HY000): The target table v of the UPDATE is not updatable
+delete from v;
+Error 1288 (HY000): The target table v of the DELETE is not updatable
+drop materialized view v;
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int);
+create materialized view log on t (a, b);
+prepare stmt_ins from 'insert into `$mlog$t` values (?, ?, ?, ?)';
+Error 1288 (HY000): The target table $mlog$t of the INSERT is not updatable
+prepare stmt_upd from 'update `$mlog$t` set a=?';
+Error 1288 (HY000): The target table $mlog$t of the UPDATE is not updatable
+prepare stmt_del from 'delete from `$mlog$t` where a=?';
+Error 1288 (HY000): The target table $mlog$t of the DELETE is not updatable
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int not null);
+create materialized view log on t (a, b);
+create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
+prepare stmt_ins from 'insert into v values (?, ?, ?)';
+Error 1288 (HY000): The target table v of the INSERT is not updatable
+prepare stmt_upd from 'update v set s=? where a=?';
+Error 1288 (HY000): The target table v of the UPDATE is not updatable
+prepare stmt_del from 'delete from v where a=?';
+Error 1288 (HY000): The target table v of the DELETE is not updatable
+drop materialized view v;
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int);
+create materialized view log on t (a, b);
+load data local infile '/nonexistent.csv' into table `$mlog$t` fields terminated by ',';
+Error 1288 (HY000): The target table $mlog$t of the LOAD is not updatable
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int not null);
+create materialized view log on t (a, b);
+create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
+load data local infile '/nonexistent.csv' into table v fields terminated by ',';
+Error 1288 (HY000): The target table v of the LOAD is not updatable
+drop materialized view v;
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int);
+create materialized view log on t (a, b);
+import into `$mlog$t` from '/nonexistent.csv';
+Error 1288 (HY000): The target table $mlog$t of the IMPORT is not updatable
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int not null);
+create materialized view log on t (a, b);
+create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
+import into v from '/nonexistent.csv';
+Error 1288 (HY000): The target table v of the IMPORT is not updatable
+drop materialized view v;
 drop table if exists t, `$mlog$t`;

--- a/tests/integrationtest/t/executor/mview_log_dml.test
+++ b/tests/integrationtest/t/executor/mview_log_dml.test
@@ -11,15 +11,18 @@ create materialized view log on t (id, uk, v);
 insert into t values (1,10,100,1000);
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 
-delete from `$mlog$t`;
+drop materialized view log on t;
+create materialized view log on t (id, uk, v);
 update t set v=101 where id=1;
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 
-delete from `$mlog$t`;
+drop materialized view log on t;
+create materialized view log on t (id, uk, v);
 update t set extra=2000 where id=1;
 select count(*) from `$mlog$t`;
 
-delete from `$mlog$t`;
+drop materialized view log on t;
+create materialized view log on t (id, uk, v);
 delete from t where id=1;
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 
@@ -65,7 +68,8 @@ insert into t values (1, 10, 101) on duplicate key update v=values(v);
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 
 # IODKU with primary key change
-delete from `$mlog$t`;
+drop materialized view log on t;
+create materialized view log on t (id, uk, v);
 insert into t values (1, 10, 200) on duplicate key update id = 3, v = values(v);
 select id, uk, v from t order by id;
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
@@ -78,7 +82,8 @@ drop table if exists `$mlog$t`;
 create table t (id int primary key, tracked int, untracked int);
 create materialized view log on t (id, tracked);
 insert into t values (1, 10, 100);
-delete from `$mlog$t`;
+drop materialized view log on t;
+create materialized view log on t (id, tracked);
 
 alter table t add column c_new int default 0;
 update t set untracked = 101 where id = 1;
@@ -116,6 +121,99 @@ update t set a = a+1 where a = 1;
 insert into t values (2), (3);
 select _tidb_rowid, a from t;
 select _tidb_rowid, a, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`;
+
+# Explicit DML on mlog table should be rejected
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int);
+create materialized view log on t (a, b);
+--error 1288
+insert into `$mlog$t` values (1, 2, 'I', 1);
+--error 1288
+replace into `$mlog$t` values (1, 2, 'I', 1);
+--error 1288
+update `$mlog$t` set a=1;
+--error 1288
+delete from `$mlog$t`;
+select * from `$mlog$t`;
+
+# Explicit DML on materialized view table should be rejected
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int not null);
+create materialized view log on t (a, b);
+create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
+--error 1288
+insert into v values (1, 10, 1);
+--error 1288
+replace into v values (1, 10, 1);
+--error 1288
+update v set s=1;
+--error 1288
+delete from v;
+drop materialized view v;
+
+# Prepared DML on mlog table should be rejected
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int);
+create materialized view log on t (a, b);
+--error 1288
+prepare stmt_ins from 'insert into `$mlog$t` values (?, ?, ?, ?)';
+--error 1288
+prepare stmt_upd from 'update `$mlog$t` set a=?';
+--error 1288
+prepare stmt_del from 'delete from `$mlog$t` where a=?';
+
+# Prepared DML on materialized view table should be rejected
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int not null);
+create materialized view log on t (a, b);
+create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
+--error 1288
+prepare stmt_ins from 'insert into v values (?, ?, ?)';
+--error 1288
+prepare stmt_upd from 'update v set s=? where a=?';
+--error 1288
+prepare stmt_del from 'delete from v where a=?';
+drop materialized view v;
+
+# LOAD DATA on mlog table should be rejected
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int);
+create materialized view log on t (a, b);
+--error 1288
+load data local infile '/nonexistent.csv' into table `$mlog$t` fields terminated by ',';
+
+# LOAD DATA on materialized view table should be rejected
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int not null);
+create materialized view log on t (a, b);
+create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
+--error 1288
+load data local infile '/nonexistent.csv' into table v fields terminated by ',';
+drop materialized view v;
+
+# IMPORT INTO on mlog table should be rejected
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int);
+create materialized view log on t (a, b);
+--error 1288
+import into `$mlog$t` from '/nonexistent.csv';
+
+# IMPORT INTO on materialized view table should be rejected
+drop table if exists t;
+drop table if exists `$mlog$t`;
+create table t (a int primary key, b int not null);
+create materialized view log on t (a, b);
+create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
+--error 1288
+import into v from '/nonexistent.csv';
+drop materialized view v;
 
 # clean up
 drop table if exists t, `$mlog$t`;


### PR DESCRIPTION
### What problem does this PR solve?

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

Materialized views and their aux tables (`$mlog$...`) are internal implementation details, but users can currently write them explicitly, which leaks internal mechanisms and can break MV/MV log invariants. We should reject explicit writes and only allow MV maintenance (REFRESH/PURGE) and base-table DML side-effects to touch MV/MV log data.

### What changed and how does it work?

#### Core mechanism

Introduce a `MViewInternalDML` enum on `SessionVars` / `StatementContext` to distinguish user-issued DML from internal maintenance operations. The function `CheckMViewUpdatable()` checks the target table's metadata and rejects the operation unless the appropriate context flag is set.

#### Planner-layer guard (authoritative)

The planner is the **single authoritative guard** that rejects DML on MV/mlog tables. It covers all DML paths:

- INSERT/REPLACE (`planbuilder.go`)
- UPDATE (`logical_plan_builder.go`)
- DELETE (`logical_plan_builder.go`)
- LOAD DATA (`planbuilder.go`)
- IMPORT INTO (`planbuilder.go`)

This catches errors early, including at PREPARE time.

#### Executor-layer assertions (defense-in-depth)

The executor build phase contains `intest.AssertNoError` assertions that verify the planner already rejected invalid operations. These are **no-ops in production builds** and only fire in test builds (via the `intest` build tag), catching developer bugs where a code path bypasses the planner guard.

Covered operations: INSERT/REPLACE, UPDATE, DELETE, LOAD DATA, IMPORT INTO (`builder.go`).

#### Bypass rules

| Target table | Allowed when | Example |
|---|---|---|
| MV table | `IsMViewRefreshContext()` | REFRESH MATERIALIZED VIEW |
| MV log table | `IsMViewPurgeContext()` | PURGE MATERIALIZED VIEW LOG |
| Base table with mlog | Always (mlog writes are side-effects via `mlogTable` wrapper) | `INSERT INTO base_table ...` |

#### Error handling

Uses existing `ErrNonUpdatableTable` for consistency with views and sequences (no new error codes).

### Tradeoffs / limitations

- Scope is intentionally **DML-focused** — does not gate TRUNCATE or DDL yet.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Disallow explicit DML (INSERT/REPLACE/UPDATE/DELETE) and bulk operations (LOAD DATA/IMPORT INTO) on materialized view and materialized view log tables. Only internal maintenance operations (REFRESH/PURGE) can modify these tables.
```
