### PR TITLE
dxf: fix flaky test TestNextGenMetering

### DIFF
--- a/pkg/dxf/framework/taskexecutor/task_executor.go
+++ b/pkg/dxf/framework/taskexecutor/task_executor.go
@@ -349,6 +349,9 @@ func (e *BaseTaskExecutor) Run() {
 			e.logger.Warn("get first subtask meets error", zap.Error(err))
 			continue
 		} else if subtask == nil {
+			failpoint.Inject("avoidTaskExecutorExitWhenNoSubtask", func() {
+				noSubtaskCheckCnt = 0
+			})
 			if noSubtaskCheckCnt >= maxChecksWhenNoSubtask {
 				e.logger.Info("no subtask to run for a while, exit")
 				break

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -967,6 +967,8 @@ func TestNextGenMetering(t *testing.T) {
 		*ts = baseTime
 		baseTime += 60
 	})
+	// this failpoint can make sure we only get one gotMeterData
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/avoidTaskExecutorExitWhenNoSubtask", "return(true)")
 	var gotMeterData uberatomic.String
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/dxf/framework/metering/meteringFinalFlush", func(s fmt.Stringer) {
 		gotMeterData.Store(s.String())

--- a/tests/realtikvtest/importintotest4/global_sort_test.go
+++ b/tests/realtikvtest/importintotest4/global_sort_test.go
@@ -486,6 +486,8 @@ func TestNextGenMetering(t *testing.T) {
 		*ts = baseTime
 		baseTime += 60
 	})
+	// this failpoint can make sure we only get one gotMeterData
+	testfailpoint.Enable(s.T(), "github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/avoidTaskExecutorExitWhenNoSubtask", "return(true)")
 	var gotMeterData atomic.String
 	testfailpoint.EnableCall(s.T(), "github.com/pingcap/tidb/pkg/dxf/framework/metering/meteringFinalFlush", func(s fmt.Stringer) {
 		gotMeterData.Store(s.String())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66367

Problem Summary:

### What changed and how does it work?
as title, task executor might exit early and cause multiple unregister of meter recorder
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
