### PR TITLE
types: enforce VARCHAR/CHAR length after charset replacement

### DIFF
--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -1204,8 +1204,9 @@ func (d *Datum) convertToString(ctx Context, target *FieldType) (Datum, error) {
 	default:
 		return invalidConv(d, target.GetType())
 	}
-	if err == nil {
-		s, err = ProduceStrWithSpecifiedTp(s, target, ctx, true)
+	s, err1 := ProduceStrWithSpecifiedTp(s, target, ctx, true)
+	if err == nil && err1 != nil {
+		err = err1
 	}
 	ret.SetString(s, target.GetCollate())
 	if target.GetCharset() == charset.CharsetBin {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66319

Problem Summary:
`Datum.convertToString` skipped `ProduceStrWithSpecifiedTp` when charset validation returned an error (for example utf8mb4 input into utf8 column). In non-strict mode, this allowed oversize values to bypass `VARCHAR/CHAR` length enforcement after replacement.

### What changed and how does it work?
- In `pkg/types/datum.go`, always call `ProduceStrWithSpecifiedTp` in `convertToString`.
- Preserve existing error precedence: keep the charset error if it exists; otherwise use length/truncation error.
- Add regression test `TestConvertToStringWithCheckStillEnforcesLength` in `pkg/types/convert_test.go` to verify:
  - invalid utf8mb4-in-utf8 still reports charset error,
  - value is truncated to column length,
  - truncation warning is recorded in warning mode.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test commands:
- `pushd pkg/types >/dev/null && go test -run TestConvertToStringWithCheckStillEnforcesLength -tags=intest,deadlock && popd >/dev/null`
- `pushd pkg/types >/dev/null && go test -run 'TestConvertToStringWithCheck|TestConvertToStringWithCheckStillEnforcesLength' -tags=intest,deadlock && popd >/dev/null`
- `make bazel_lint_changed`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue) to write a quality release note.

```release-note
Fix a bug where INSERT-family string casting could skip VARCHAR/CHAR length enforcement after charset replacement errors (for example utf8mb4 input to utf8 in non-strict mode).
```
