### PR TITLE
*: refine AGENTS.md style and wording guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ make bazel_bin
 make gogenerate   # optional: regenerate generated code
 go mod tidy       # optional: if go.mod/go.sum changed
 git fetch origin --prune
-make bazel_lint_changed
+make bazel_lint_changed # Optional: skip this step if the resolved Bazel target is //:all.
 ```
 
 ## Task -> Validation Matrix

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ This file provides guidance to agents working in this repository.
 | RealTiKV tests | MUST start playground in background, run tests, then clean up playground/data (see `docs/agents/testing-flow.md`). |
 | Bug fix | MUST add a regression test and verify it fails before fix and passes after fix. |
 | Fmt-only PR | MUST NOT run costly `realtikvtest`; local compilation is enough. |
-| Before finishing | SHOULD run `make bazel_lint_changed`. |
+| Before finishing | MUST run `make bazel_lint_changed` if there are code changes. SHOULD self-review diff quality before finishing. |
 
 ### Skills
 
@@ -62,9 +62,9 @@ This file provides guidance to agents working in this repository.
 
 - Follow `docs/agents/notes-guide.md`.
 - DDL module-only rules (applies to changes under `pkg/ddl/` and `docs/agents/ddl/`):
-  - **REQUIRED**: Before making/reviewing any DDL changes in the DDL module, read `docs/agents/ddl/README.md` first and use it as the default map of the execution framework.
-  - Debugging: You may reference `docs/agents/ddl/*`, but you **MUST NOT** treat it as authoritative. Treat it as hypotheses until verified in code/tests (avoid hallucination/outdated assumptions).
-  - Doc drift: If implementation and `docs/agents/ddl/*` differ, you **MUST** update the docs to match reality and call it out in the PR/issue. Do not defer.
+  - MUST: Before making/reviewing any DDL changes in the DDL module, read `docs/agents/ddl/README.md` first and use it as the default map of the execution framework.
+  - Debugging: You MAY reference `docs/agents/ddl/*`, but you MUST NOT treat it as authoritative. Treat it as hypotheses until verified in code/tests (avoid hallucination/outdated assumptions).
+  - Doc drift: If implementation and `docs/agents/ddl/*` differ, you MUST update the docs to match reality and call it out in the PR/issue. Do not defer.
 
 ## Build Flow
 
@@ -123,11 +123,15 @@ Typical package unit test command: `go test -run <TestName> -tags=intest,deadloc
 
 ### Go and backend code
 
+- Because TiDB is a complex system, code SHOULD remain maintainable for future readers with basic TiDB familiarity, including readers who are not experts in the specific subsystem/feature.
 - Follow existing package-local conventions first and keep style consistent with nearby files.
+- Code SHOULD be self-documenting through clear naming and structure.
+  - Example: when implementing a well-known algorithm, naming SHOULD be clear enough to make the approach recognizable; if naming alone may not make intent obvious, add a brief comment.
 - Keep changes focused; avoid unrelated refactors, renames, or moves in the same PR.
-- For implementation details, add comments only for non-obvious intent, invariants, concurrency guarantees, SQL/compatibility contracts, or important performance trade-offs; avoid comments that only restate nearby code. Keep exported-symbol doc comments, and prefer semantic constraints over name restatement.
 - Keep error handling actionable and contextual; avoid silently swallowing errors.
 - For new source files (for example `*.go`), include the standard TiDB license header (copyright + Apache 2.0) by copying from a nearby file and updating year if needed.
+- Comments SHOULD explain non-obvious intent, constraints, invariants, concurrency guarantees, SQL/compatibility contracts, or important performance trade-offs, and SHOULD NOT restate what the code already makes clear.
+- Keep exported-symbol doc comments, and prefer semantic constraints over name restatement.
 
 ### Tests and testdata
 
@@ -141,6 +145,7 @@ Typical package unit test command: `go test -run <TestName> -tags=intest,deadloc
 
 - Commands in docs SHOULD be copy-pasteable from repository root unless explicitly scoped.
 - Use explicit placeholders such as `<package_name>`, `<TestName>`, and `<dir>`.
+- Documentation updates SHOULD keep terminology, policy wording, and command conventions consistent across related docs.
 - Keep guidance executable and concrete; avoid ambiguous phrasing.
 - Issues and PRs MUST be written in English (title and description).
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/63847

Problem Summary:
Improve AGENTS.md guidance consistency and readability for code/comment style and document wording.

### What changed and how does it work?

- Unified normative keyword style in DDL notes section (MUST/SHOULD/MAY/MUST NOT style).
- Refined code style/comment style wording and merged guidance into the Go/backend section.
- Improved wording quality and consistency (grammar/typos and actionable phrasing).
- Added a docs consistency guideline under "Docs and command snippets".

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > - [x] This PR only updates AGENTS.md documentation wording and structure.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
