### PR TITLE
planner: flaky test TestBatchDropBindings

### DIFF
--- a/pkg/bindinfo/tests/bind_test.go
+++ b/pkg/bindinfo/tests/bind_test.go
@@ -803,6 +803,11 @@ func TestFuzzyBindingHints(t *testing.T) {
 }
 
 func TestBatchDropBindings(t *testing.T) {
+	originLease := bindinfo.Lease
+	bindinfo.Lease = 0
+	defer func() {
+		bindinfo.Lease = originLease
+	}()
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec(`use test`)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66371

Problem Summary:

### What changed and how does it work?

Decision was made here to fix the test rather than the underlying behavior. The test does expose a race condition - but the likelihood that a customer sees this as a critical issue, or that it has any significant impact to their operations - is arguably low.

The issue is - if the binding cache reload (which occurs every 3 seconds) had begun before the drop completed, then the dropped binding could be reloaded - and exist for 3 seconds longer than the user intended. The solution for that would be to add a mutex to the bindingCacheUpdater - but that would then be executed every 3 seconds. However, if a customer exposes this problem - then it may be necessary to add this fix.

Analysis of the issue:

Root Cause: Race Between Background Binding Loader and DROP

  The test does not set bindinfo.Lease = 0, so the background goroutine globalBindHandleWorkerLoop (started in domain.go:1571) runs every 3  seconds, calling LoadFromStorageToCache(false, false). This races with the DropBinding operation's own deferred LoadFromStorageToCache  call.

  The Race in Detail

  LoadFromStorageToCache (binding_cache.go:64) is not atomic — it first reads bindings from storage via SQL, then iterates over them updating the cache one-by-one. There is no mutex protecting the entire read-process cycle. Two concurrent calls can interleave.

  Here's the problematic sequence:
```
┌──────┬─────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────┐
  │ Step │                    Background goroutine                     │                         Test goroutine                         │
  ├──────┼─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │ 1    │ LoadFromStorageToCache starts, reads storage snapshot →     │                                                                │
  │      │ sees enabled bindings (update_time=T0)                      │                                                                │
  ├──────┼─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │ 2    │                                                             │ DROP binding commits → marks bindings as deleted               │
  │      │                                                             │ (update_time=T1 > T0) in mysql.bind_info                       │
  ├──────┼─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │      │                                                             │ DROP's deferred LoadFromStorageToCache reads storage → sees    │
  │ 3    │                                                             │ deleted bindings → pickCachedBinding(enabled@T0, deleted@T1) → │
  │      │                                                             │  nil → RemoveBinding() → cache is now empty                    │
  ├──────┼─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │      │ Continues processing stale snapshot: GetBinding() returns   │                                                                │
  │ 4    │ nil (just removed). pickCachedBinding(nil, enabled@T0) →    │                                                                │
  │      │ returns enabled@T0 → SetBinding() re-adds the binding to    │                                                                │
  │      │ cache                                                       │                                                                │
  ├──────┼─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │ 5    │                                                             │ SHOW BINDINGS → sees the re-added binding → assertion fails    │
  └──────┴─────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────┘
```
  Why the stale data persists

  At step 4, the background goroutine also stores lastUpdateTime = T0 (from its stale snapshot), potentially overwriting the DROP's stored T1. This makes lastUpdateTime go backwards. The 10-second timeLagTolerance (binding_cache.go:94) means the next incremental load will likely catch the T1 deleted record again, but there's a transient window (up to the next 3-second tick) where the cache has stale data.

  Key code locations

  - Background loop: pkg/domain/domain.go:1571-1626 — ticks every bindinfo.Lease (default 3s)
  - Lease default: pkg/bindinfo/binding_handle.go:26 — var Lease = 3 * time.Second
  - Lease=0 check: pkg/domain/domain.go:1560 — if bindinfo.Lease == 0 { return } (skips starting the background goroutine)
  - DropBinding deferred load: pkg/bindinfo/binding_operator.go:164-167
  - Non-atomic LoadFromStorageToCache: pkg/bindinfo/binding_cache.go:64-136 — reads from storage, then processes into cache without a mutex
  - Mock owner succeeds: pkg/owner/mock.go:135 — CampaignOwner() returns nil, so the background loop does start in mock test environments

  Evidence: other tests avoid this

  TestGCBindRecord (bind_test.go:371-377) explicitly sets bindinfo.Lease = 0 before creating the mock store/domain, preventing the background goroutine from starting. TestBatchDropBindings does not.

  Session bindings are not affected

  removeAllBindings(tk, false) for session bindings uses DropSessionBinding (session_handle.go:90), which is a simple in-memory map delete  with no background reload — no race possible there.

  Summary

  The flakiness is caused by the background globalBindHandleWorkerLoop goroutine's LoadFromStorageToCache interleaving with the DropBinding  deferred LoadFromStorageToCache, re-adding stale (enabled) bindings to the cache after the DROP already removed them. The fix would be to set bindinfo.Lease = 0 at the start of the test (as TestGCBindRecord does), or to add mutual exclusion around LoadFromStorageToCache.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
