### PR TITLE
executor: fix flaky TestKillAutoAnalyze by finalizing jobs on early exit

### DIFF
--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -178,7 +178,13 @@ TASKLOOP:
 		// corresponding jobs so they don't stay stuck in "running" status.
 		for results := range resultsCh {
 			if results.Job != nil {
-				finishJobWithLog(statsHandle, results.Job, results.Err)
+				// Use the original error if the individual result has none,
+				// since the stats were not saved even if analysis succeeded.
+				resultErr := results.Err
+				if resultErr == nil {
+					resultErr = err
+				}
+				finishJobWithLog(statsHandle, results.Job, resultErr)
 			}
 		}
 		return err


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66373

Problem Summary:

`TestKillAutoAnalyze` is flaky because killing an auto-analyze job can leave it stuck in "running" status in `mysql.analyze_jobs`. This happens due to a race condition between the result handler goroutine and the analyze worker goroutine.

When `handleResultsErrorWithConcurrency` detects a kill signal via `HandleSignal()`, it returns immediately without processing remaining results. Meanwhile, `analyzeWorker` has already called `StartAnalyzeJob` (setting status to "running"), but the Go `select` between `errExitCh` and `resultsCh` non-deterministically chooses a branch — either discarding the result (errExitCh wins) or buffering it with no reader (resultsCh wins). In both cases, `finishJobWithLog` is never called and the job stays "running" forever.

Reproducible with `GOMAXPROCS=1` which serializes goroutine scheduling and makes the race trigger reliably.

### What changed and how does it work?

Fix both paths where the job can be left unfinalized:

1. **`analyzeWorker`**: Capture the analysis result before the `select` so that if `errExitCh` wins, we call `finishJobWithLog` directly to mark the job as failed.
2. **`Next`**: After `waitFinish` returns an error, drain any remaining unprocessed results from `resultsCh` and finalize their jobs. Results that have no individual error use the `waitFinish` error as fallback, since their stats were never saved even if the analysis itself succeeded.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```