### PR TITLE
executor: fix SCHEMATA_EXTENSIONS read-only option display | tidb-test=release-8.5.2

### DIFF
--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -3979,6 +3979,8 @@ func (e *memtableRetriever) setDataFromSchemataExtensions(ctx sessionctx.Context
 		)
 		if schema.ReadOnly {
 			record = append(record, types.NewStringDatum(readOnly))
+		} else {
+			record = append(record, types.NewStringDatum(""))
 		}
 		rows = append(rows, record)
 	}

--- a/tests/integrationtest/r/ddl/db_read_only.result
+++ b/tests/integrationtest/r/ddl/db_read_only.result
@@ -41,9 +41,15 @@ def	mysql
 def	PERFORMANCE_SCHEMA	
 def	sys	
 def	test	
-alter schema test read only 1;
+create schema aa;
+create schema bb;
+create schema cc;
+alter schema bb read only 1;
 select * from information_schema.schemata_extensions;
 CATALOG_NAME	SCHEMA_NAME	OPTIONS
+def	aa	
+def	bb	READ ONLY=1
+def	cc	
 def	db_read_only	
 def	db_read_only_1	
 def	ddl__db_read_only	
@@ -52,10 +58,13 @@ def	METRICS_SCHEMA
 def	mysql	
 def	PERFORMANCE_SCHEMA	
 def	sys	
-def	test	READ ONLY=1
-alter schema test read only 0;
+def	test	
+alter schema bb read only 0;
 select * from information_schema.schemata_extensions;
 CATALOG_NAME	SCHEMA_NAME	OPTIONS
+def	aa	
+def	bb	
+def	cc	
 def	db_read_only	
 def	db_read_only_1	
 def	ddl__db_read_only	

--- a/tests/integrationtest/t/ddl/db_read_only.test
+++ b/tests/integrationtest/t/ddl/db_read_only.test
@@ -29,9 +29,12 @@ partition by range (year(dob)) (
 # test information_schema.schemata_extensions
 desc information_schema.schemata_extensions;
 select * from information_schema.schemata_extensions;
-alter schema test read only 1;
+create schema aa;
+create schema bb;
+create schema cc;
+alter schema bb read only 1;
 select * from information_schema.schemata_extensions;
-alter schema test read only 0;
+alter schema bb read only 0;
 select * from information_schema.schemata_extensions;
 
 # DDL can NOT be executed in read-only mode


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what\x27s changed
2. *: what\x27s changed

-->

### What problem does this PR solve?

Issue Number: ref #62122 close #66573

Problem Summary:
- `INFORMATION_SCHEMA.SCHEMATA_EXTENSIONS` may incorrectly display `OPTIONS=READ ONLY=1` for schemas after a read-only schema.
- Root cause: memtable scan reuses the same `mutableRow`. `mutableRow.SetDatums(row...)` only overwrites the first N columns and does not clear the remaining columns. Before this fix, some `SCHEMATA_EXTENSIONS` rows were built with only 2 datums (missing the `OPTIONS` datum) for read-write schemas, so after a read-only schema wrote `READ ONLY=1` into `OPTIONS`, subsequent short rows did not overwrite that third column and “stuck” with the previous value.

### What changed and how does it work?

- Always return a 3-column row for `SCHEMATA_EXTENSIONS` (`CATALOG_NAME`, `SCHEMA_NAME`, `OPTIONS`). For read-write schemas, `OPTIONS` is an empty string; for read-only schemas, it is `READ ONLY=1`. This prevents a stale `OPTIONS` value from leaking to subsequent rows due to memtable row reuse.
- Update the `ddl/db_read_only` integration test to cover toggling a schema in the middle of the list and verify the display is correct.

### Check List

Tests

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix incorrect READ ONLY option display in INFORMATION_SCHEMA.SCHEMATA_EXTENSIONS.
```
