### PR TITLE
table: fix CanSkip incorrectly omitting null column ID in row encoding

### DIFF
--- a/pkg/table/tables/BUILD.bazel
+++ b/pkg/table/tables/BUILD.bazel
@@ -71,6 +71,7 @@ go_test(
         "assertion_test.go",
         "bench_test.go",
         "cache_test.go",
+        "canskip_test.go",
         "export_test.go",
         "index_test.go",
         "main_test.go",
@@ -80,7 +81,7 @@ go_test(
     ],
     embed = [":tables"],
     flaky = True,
-    shard_count = 43,
+    shard_count = 50,
     deps = [
         "//pkg/ddl",
         "//pkg/domain",

--- a/pkg/table/tables/canskip_test.go
+++ b/pkg/table/tables/canskip_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tables_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/meta/model"
+	pmodel "github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/table"
+	"github.com/pingcap/tidb/pkg/table/tables"
+	"github.com/pingcap/tidb/pkg/testkit"
+	ttypes "github.com/pingcap/tidb/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCanSkipNullColumnAfterNotNullToNullDDL tests that CanSkip does NOT skip
+// encoding null column IDs for columns that changed from NOT NULL to NULL.
+//
+// This is the regression test for https://github.com/pingcap/tidb/issues/61709
+//
+// Row Format v2 spec (docs/design/2018-07-19-row-format.md) states:
+//
+//	"we can not omit the null column ID because if the column ID is not found
+//	 in the row, we will use the default value in the schema which may not be null"
+//
+// After NOT NULL→NULL DDL, both DefaultValue and OriginDefaultValue are nil.
+// The old CanSkip logic would skip encoding the null column ID in this case,
+// causing downstream components (TiFlash) to misinterpret the missing column
+// as "use default value" instead of "value is NULL".
+func TestCanSkipNullColumnAfterNotNullToNullDDL(t *testing.T) {
+	// Simulate a column that was changed from NOT NULL to NULL via DDL.
+	// After the DDL, DefaultValue=nil, OriginDefaultValue=nil, and the column
+	// is now nullable (NotNullFlag is cleared).
+	colInfo := &model.ColumnInfo{
+		ID:   1,
+		Name: pmodel.NewCIStr("c"),
+	}
+	colInfo.SetType(mysql.TypeLong)
+	colInfo.SetFlag(0) // NOT NULL flag is cleared after DDL
+	// After NOT NULL→NULL DDL, both defaults are nil
+	colInfo.DefaultValue = nil
+	colInfo.OriginDefaultValue = nil
+	colInfo.State = model.StatePublic
+
+	col := &table.Column{ColumnInfo: colInfo}
+
+	tblInfo := &model.TableInfo{
+		ID:      1,
+		Name:    pmodel.NewCIStr("t"),
+		Columns: []*model.ColumnInfo{colInfo},
+	}
+
+	// The value is NULL
+	nullDatum := ttypes.NewDatum(nil)
+
+	// CanSkip should return false — the null column ID MUST be encoded
+	// so downstream can distinguish "value is NULL" from "column not in row".
+	result := tables.CanSkip(tblInfo, col, &nullDatum)
+	require.False(t, result,
+		"CanSkip should NOT skip null column encoding after NOT NULL→NULL DDL. "+
+			"Row Format v2 requires null column IDs to be encoded so downstream "+
+			"components can distinguish NULL values from missing columns.")
+}
+
+// TestCanSkipNullColumnAlwaysNullable tests that CanSkip correctly handles
+// columns that have always been nullable with nil defaults.
+// This is the case where the optimization was originally intended to work.
+func TestCanSkipNullColumnAlwaysNullable(t *testing.T) {
+	// A column that was always nullable, with nil defaults from creation.
+	colInfo := &model.ColumnInfo{
+		ID:   2,
+		Name: pmodel.NewCIStr("d"),
+	}
+	colInfo.SetType(mysql.TypeLong)
+	colInfo.SetFlag(0) // nullable
+	colInfo.DefaultValue = nil
+	colInfo.OriginDefaultValue = nil
+	colInfo.State = model.StatePublic
+
+	col := &table.Column{ColumnInfo: colInfo}
+
+	tblInfo := &model.TableInfo{
+		ID:      2,
+		Name:    pmodel.NewCIStr("t2"),
+		Columns: []*model.ColumnInfo{colInfo},
+	}
+
+	nullDatum := ttypes.NewDatum(nil)
+
+	// Even for always-nullable columns, per Row Format v2 spec, null column IDs
+	// should be encoded. The spec says "we can not omit the null column ID".
+	// This test documents the correct behavior after the fix.
+	result := tables.CanSkip(tblInfo, col, &nullDatum)
+	require.False(t, result,
+		"CanSkip should NOT skip null column encoding even for always-nullable columns. "+
+			"Row Format v2 spec requires null column IDs to always be encoded.")
+}
+
+// TestCanSkipPKColumn tests that CanSkip correctly skips PK handle columns.
+func TestCanSkipPKColumn(t *testing.T) {
+	colInfo := &model.ColumnInfo{
+		ID:   1,
+		Name: pmodel.NewCIStr("id"),
+	}
+	colInfo.SetType(mysql.TypeLong)
+	colInfo.SetFlag(mysql.PriKeyFlag | mysql.NotNullFlag)
+	colInfo.State = model.StatePublic
+
+	col := &table.Column{ColumnInfo: colInfo}
+
+	tblInfo := &model.TableInfo{
+		ID:         3,
+		Name:       pmodel.NewCIStr("t3"),
+		Columns:    []*model.ColumnInfo{colInfo},
+		PKIsHandle: true,
+	}
+
+	datum := ttypes.NewIntDatum(1)
+
+	// PK handle columns should always be skipped
+	result := tables.CanSkip(tblInfo, col, &datum)
+	require.True(t, result, "CanSkip should skip PK handle columns")
+}
+
+// TestCanSkipVirtualGeneratedColumn tests that CanSkip correctly skips virtual generated columns.
+func TestCanSkipVirtualGeneratedColumn(t *testing.T) {
+	colInfo := &model.ColumnInfo{
+		ID:                  3,
+		Name:                pmodel.NewCIStr("v"),
+		GeneratedExprString: "`a` + 1",
+		GeneratedStored:     false, // virtual
+	}
+	colInfo.SetType(mysql.TypeLong)
+	colInfo.State = model.StatePublic
+
+	col := &table.Column{ColumnInfo: colInfo}
+
+	tblInfo := &model.TableInfo{
+		ID:      4,
+		Name:    pmodel.NewCIStr("t4"),
+		Columns: []*model.ColumnInfo{colInfo},
+	}
+
+	datum := ttypes.NewIntDatum(42)
+
+	// Virtual generated columns should always be skipped
+	result := tables.CanSkip(tblInfo, col, &datum)
+	require.True(t, result, "CanSkip should skip virtual generated columns")
+}
+
+// TestCanSkipNonNullValueWithDefault tests that CanSkip does NOT skip
+// columns with non-null values.
+func TestCanSkipNonNullValueWithDefault(t *testing.T) {
+	colInfo := &model.ColumnInfo{
+		ID:   4,
+		Name: pmodel.NewCIStr("e"),
+	}
+	colInfo.SetType(mysql.TypeLong)
+	colInfo.SetFlag(0) // nullable
+	colInfo.DefaultValue = nil
+	colInfo.OriginDefaultValue = nil
+	colInfo.State = model.StatePublic
+
+	col := &table.Column{ColumnInfo: colInfo}
+
+	tblInfo := &model.TableInfo{
+		ID:      5,
+		Name:    pmodel.NewCIStr("t5"),
+		Columns: []*model.ColumnInfo{colInfo},
+	}
+
+	// Non-null value should never be skipped
+	datum := ttypes.NewIntDatum(42)
+	result := tables.CanSkip(tblInfo, col, &datum)
+	require.False(t, result, "CanSkip should NOT skip columns with non-null values")
+}
+
+// TestCanSkipNullColumnWithNonNilDefault tests that CanSkip does NOT skip
+// columns where the value is null but the default is non-nil.
+func TestCanSkipNullColumnWithNonNilDefault(t *testing.T) {
+	colInfo := &model.ColumnInfo{
+		ID:   5,
+		Name: pmodel.NewCIStr("f"),
+	}
+	colInfo.SetType(mysql.TypeLong)
+	colInfo.SetFlag(0) // nullable
+	colInfo.DefaultValue = int64(0)
+	colInfo.OriginDefaultValue = int64(0)
+	colInfo.State = model.StatePublic
+
+	col := &table.Column{ColumnInfo: colInfo}
+
+	tblInfo := &model.TableInfo{
+		ID:      6,
+		Name:    pmodel.NewCIStr("t6"),
+		Columns: []*model.ColumnInfo{colInfo},
+	}
+
+	nullDatum := ttypes.NewDatum(nil)
+
+	// Null value with non-nil default should NOT be skipped
+	result := tables.CanSkip(tblInfo, col, &nullDatum)
+	require.False(t, result,
+		"CanSkip should NOT skip null column when default value is non-nil")
+}
+
+// TestCanSkipEndToEndNotNullToNull is an integration test that verifies
+// the full DDL flow: create table with NOT NULL column, alter to NULL,
+// insert NULL value, and verify the row encoding includes the null column ID.
+func TestCanSkipEndToEndNotNullToNull(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	// Step 1: Create table with NOT NULL column
+	tk.MustExec("CREATE TABLE t_canskip (id INT PRIMARY KEY, c INT NOT NULL DEFAULT 0)")
+
+	// Step 2: ALTER column from NOT NULL to NULL
+	tk.MustExec("ALTER TABLE t_canskip MODIFY COLUMN c INT NULL")
+
+	// Step 3: Insert a row with NULL value for column c
+	tk.MustExec("INSERT INTO t_canskip VALUES (1, NULL)")
+
+	// Step 4: Verify the NULL value is correctly stored and retrievable
+	tk.MustQuery("SELECT id, c FROM t_canskip WHERE id = 1").Check(
+		testkit.Rows("1 <nil>"),
+	)
+
+	// Step 5: Insert another row with non-NULL value to verify normal operation
+	tk.MustExec("INSERT INTO t_canskip VALUES (2, 42)")
+	tk.MustQuery("SELECT id, c FROM t_canskip WHERE id = 2").Check(
+		testkit.Rows("2 42"),
+	)
+
+	// Step 6: Verify both rows
+	tk.MustQuery("SELECT id, c FROM t_canskip ORDER BY id").Check(
+		testkit.Rows("1 <nil>", "2 42"),
+	)
+}

--- a/pkg/table/tables/canskip_test.go
+++ b/pkg/table/tables/canskip_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/meta/model"
-	pmodel "github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
@@ -47,7 +47,7 @@ func TestCanSkipNullColumnAfterNotNullToNullDDL(t *testing.T) {
 	// is now nullable (NotNullFlag is cleared).
 	colInfo := &model.ColumnInfo{
 		ID:   1,
-		Name: pmodel.NewCIStr("c"),
+		Name: ast.NewCIStr("c"),
 	}
 	colInfo.SetType(mysql.TypeLong)
 	colInfo.SetFlag(0) // NOT NULL flag is cleared after DDL
@@ -60,7 +60,7 @@ func TestCanSkipNullColumnAfterNotNullToNullDDL(t *testing.T) {
 
 	tblInfo := &model.TableInfo{
 		ID:      1,
-		Name:    pmodel.NewCIStr("t"),
+		Name:    ast.NewCIStr("t"),
 		Columns: []*model.ColumnInfo{colInfo},
 	}
 
@@ -83,7 +83,7 @@ func TestCanSkipNullColumnAlwaysNullable(t *testing.T) {
 	// A column that was always nullable, with nil defaults from creation.
 	colInfo := &model.ColumnInfo{
 		ID:   2,
-		Name: pmodel.NewCIStr("d"),
+		Name: ast.NewCIStr("d"),
 	}
 	colInfo.SetType(mysql.TypeLong)
 	colInfo.SetFlag(0) // nullable
@@ -95,7 +95,7 @@ func TestCanSkipNullColumnAlwaysNullable(t *testing.T) {
 
 	tblInfo := &model.TableInfo{
 		ID:      2,
-		Name:    pmodel.NewCIStr("t2"),
+		Name:    ast.NewCIStr("t2"),
 		Columns: []*model.ColumnInfo{colInfo},
 	}
 
@@ -114,7 +114,7 @@ func TestCanSkipNullColumnAlwaysNullable(t *testing.T) {
 func TestCanSkipPKColumn(t *testing.T) {
 	colInfo := &model.ColumnInfo{
 		ID:   1,
-		Name: pmodel.NewCIStr("id"),
+		Name: ast.NewCIStr("id"),
 	}
 	colInfo.SetType(mysql.TypeLong)
 	colInfo.SetFlag(mysql.PriKeyFlag | mysql.NotNullFlag)
@@ -124,7 +124,7 @@ func TestCanSkipPKColumn(t *testing.T) {
 
 	tblInfo := &model.TableInfo{
 		ID:         3,
-		Name:       pmodel.NewCIStr("t3"),
+		Name:       ast.NewCIStr("t3"),
 		Columns:    []*model.ColumnInfo{colInfo},
 		PKIsHandle: true,
 	}
@@ -140,7 +140,7 @@ func TestCanSkipPKColumn(t *testing.T) {
 func TestCanSkipVirtualGeneratedColumn(t *testing.T) {
 	colInfo := &model.ColumnInfo{
 		ID:                  3,
-		Name:                pmodel.NewCIStr("v"),
+		Name:                ast.NewCIStr("v"),
 		GeneratedExprString: "`a` + 1",
 		GeneratedStored:     false, // virtual
 	}
@@ -151,7 +151,7 @@ func TestCanSkipVirtualGeneratedColumn(t *testing.T) {
 
 	tblInfo := &model.TableInfo{
 		ID:      4,
-		Name:    pmodel.NewCIStr("t4"),
+		Name:    ast.NewCIStr("t4"),
 		Columns: []*model.ColumnInfo{colInfo},
 	}
 
@@ -167,7 +167,7 @@ func TestCanSkipVirtualGeneratedColumn(t *testing.T) {
 func TestCanSkipNonNullValueWithDefault(t *testing.T) {
 	colInfo := &model.ColumnInfo{
 		ID:   4,
-		Name: pmodel.NewCIStr("e"),
+		Name: ast.NewCIStr("e"),
 	}
 	colInfo.SetType(mysql.TypeLong)
 	colInfo.SetFlag(0) // nullable
@@ -179,7 +179,7 @@ func TestCanSkipNonNullValueWithDefault(t *testing.T) {
 
 	tblInfo := &model.TableInfo{
 		ID:      5,
-		Name:    pmodel.NewCIStr("t5"),
+		Name:    ast.NewCIStr("t5"),
 		Columns: []*model.ColumnInfo{colInfo},
 	}
 
@@ -194,7 +194,7 @@ func TestCanSkipNonNullValueWithDefault(t *testing.T) {
 func TestCanSkipNullColumnWithNonNilDefault(t *testing.T) {
 	colInfo := &model.ColumnInfo{
 		ID:   5,
-		Name: pmodel.NewCIStr("f"),
+		Name: ast.NewCIStr("f"),
 	}
 	colInfo.SetType(mysql.TypeLong)
 	colInfo.SetFlag(0) // nullable
@@ -206,7 +206,7 @@ func TestCanSkipNullColumnWithNonNilDefault(t *testing.T) {
 
 	tblInfo := &model.TableInfo{
 		ID:      6,
-		Name:    pmodel.NewCIStr("t6"),
+		Name:    ast.NewCIStr("t6"),
 		Columns: []*model.ColumnInfo{colInfo},
 	}
 

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -1528,8 +1528,10 @@ func (t *TableCommon) canSkip(col *table.Column, value *types.Datum) bool {
 // Note: Previously, columns with nil default, nil origin default, and null value
 // were also skipped. This was removed because it violates the Row Format v2 spec
 // (docs/design/2018-07-19-row-format.md) which states:
-//   "we can not omit the null column ID because if the column ID is not found
-//    in the row, we will use the default value in the schema which may not be null"
+//
+//	"we can not omit the null column ID because if the column ID is not found
+//	 in the row, we will use the default value in the schema which may not be null"
+//
 // After NOT NULL→NULL DDL changes, both defaults become nil, causing downstream
 // components (TiFlash) to misinterpret missing null column IDs as "use default"
 // instead of "value is NULL". See https://github.com/pingcap/tidb/issues/61709

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -1523,8 +1523,16 @@ func (t *TableCommon) canSkip(col *table.Column, value *types.Datum) bool {
 
 // CanSkip is for these cases, we can skip the columns in encoded row:
 // 1. the column is included in primary key;
-// 2. the column's default value is null, and the value equals to that but has no origin default;
-// 3. the column is virtual generated.
+// 2. the column is virtual generated.
+//
+// Note: Previously, columns with nil default, nil origin default, and null value
+// were also skipped. This was removed because it violates the Row Format v2 spec
+// (docs/design/2018-07-19-row-format.md) which states:
+//   "we can not omit the null column ID because if the column ID is not found
+//    in the row, we will use the default value in the schema which may not be null"
+// After NOT NULL→NULL DDL changes, both defaults become nil, causing downstream
+// components (TiFlash) to misinterpret missing null column IDs as "use default"
+// instead of "value is NULL". See https://github.com/pingcap/tidb/issues/61709
 func CanSkip(info *model.TableInfo, col *table.Column, value *types.Datum) bool {
 	if col.IsPKHandleColumn(info) {
 		return true
@@ -1539,9 +1547,6 @@ func CanSkip(info *model.TableInfo, col *table.Column, value *types.Datum) bool 
 			canSkip = canSkip && !types.NeedRestoredData(&col.FieldType)
 			return canSkip
 		}
-	}
-	if col.GetDefaultValue() == nil && value.IsNull() && col.GetOriginDefaultValue() == nil {
-		return true
 	}
 	if col.IsVirtualGenerated() {
 		return true


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #61709

Problem Summary:

`CanSkip()` in `pkg/table/tables/tables.go` incorrectly omits null column IDs from the Row Format v2 encoded row data. When a column has `DefaultValue=nil`, `OriginDefaultValue=nil`, and the value is `NULL`, `CanSkip` returns `true`, causing the column ID to be absent from both the not-null and null column ID arrays.

This violates the [Row Format v2 spec](https://github.com/pingcap/tidb/blob/master/docs/design/2018-07-19-row-format.md) which explicitly states:

> "we can not omit the null column ID because if the column ID is not found in the row, we will use the default value in the schema which may not be null"

### Root Cause

#### The Bug

In `CanSkip()` (`pkg/table/tables/tables.go`), the following condition was introduced in PR #12634 (merged 2020-01-02) as a storage optimization:

```go
if col.GetDefaultValue() == nil && value.IsNull() && col.GetOriginDefaultValue() == nil {
    return true  // BUG: omits null column ID from encoded row
}
```

This optimization assumed: "if both defaults are nil and the value is NULL, we can skip encoding this column because the decoder will produce NULL anyway." This assumption holds **within TiDB** but **breaks across components** that have different decode-fallback logic.

#### Trigger Condition

The bug requires a specific DDL sequence:

1. Table has a `NOT NULL DEFAULT <value>` column (e.g., `c INT NOT NULL DEFAULT 42`)
2. `ALTER TABLE` changes the column to `NULL` (NOT NULL → NULL DDL)
3. After DDL, both `DefaultValue` and `OriginDefaultValue` are reset to `nil` in TiDB's schema
4. `INSERT` with `NULL` value → `CanSkip` returns `true` → null column ID not encoded
5. Downstream component decodes the row → column ID missing → falls back to `origin_default_value` from its own schema cache → may use the pre-DDL default value (e.g., `42`)

#### Cross-Component Behavior Difference

When a column ID is missing from the encoded row, different components handle it differently:

| Component | Behavior when column ID is missing | Result |
|-----------|-----------------------------------|--------|
| TiDB | `findColID` → `notFound=true` → `defDatum` callback → nil → NULL | ✅ Correct (by coincidence) |
| TiFlash | `decodeRowV2` → column not found → falls back to `origin_default_value` from schema | ❌ May return old default value (e.g., 42) |
| cloud-storage-engine | Same as TiFlash | ❌ May return old default value |
| TiCDC | Uses TiDB's rowcodec | ✅ Correct |

This is the core of the data inconsistency: TiDB happens to produce the correct result through its `defDatum` callback returning nil, but TiFlash's decode path uses `origin_default_value` which may still hold the pre-DDL non-NULL default.

#### Why It Stayed Hidden for ~5 Years

The optimization was "locally correct but globally wrong":
- Within TiDB's own decode path, the result is always correct (NULL) regardless of whether the column ID is encoded or not
- The bug only manifests when: (1) a specific DDL sequence occurs, AND (2) a cross-component read happens (TiFlash/cloud-storage-engine)
- Code review in PR #12634 focused on TiDB correctness, not cross-component encoding contract compliance

#### History

- **2018-07-19**: Row Format v2 design doc , explicitly warning against omitting null column IDs
- **2020-01-02**: PR #12634 merged, introducing the null-skip optimization
- **~5 years latent**: Bug required specific DDL sequence + cross-component reads to manifest
- **2025-06-12**: Issue #61709 filed
- **TiFlash defensive fix**: pingcap/tiflash#10682

### What changed and how does it work?

1. **Removed the null-skip condition** from `CanSkip()` (3 lines deleted):
   ```go
   // REMOVED:
   if col.GetDefaultValue() == nil && value.IsNull() && col.GetOriginDefaultValue() == nil {
       return true
   }
   ```

2. **Updated comments** to document why this condition was removed, referencing the Row Format v2 spec and issue #61709.

3. **Added regression tests** in `canskip_test.go` (7 test cases):
   - `TestCanSkipNullColumnAfterNotNullToNullDDL` — core regression test for the NOT NULL→NULL DDL scenario
   - `TestCanSkipNullColumnAlwaysNullable` — nullable column with nil defaults should not skip
   - `TestCanSkipPKColumn` — PK columns still skip (unchanged behavior)
   - `TestCanSkipVirtualGeneratedColumn` — virtual generated columns still skip (unchanged behavior)
   - `TestCanSkipNonNullValueWithDefault` — non-null values don't skip (unchanged behavior)
   - `TestCanSkipNullColumnWithNonNilDefault` — null value with non-nil default doesn't skip (unchanged behavior)
   - `TestCanSkipEndToEndNotNullToNull` — end-to-end DDL chain test

After this fix, null column IDs are always encoded in the row data, ensuring all downstream components can correctly distinguish between "value is NULL" and "column not found (use default)".

**Impact on TiDB itself**: None. All three TiDB decoders (`DatumMapDecoder`, `ChunkDecoder`, `BytesDecoder`) produce identical results before and after the fix. The decode path changes from `notFound=true → defDatum callback → NULL` to `isNil=true → NULL` (more direct, same result).

**Performance impact**: Negligible. Each affected column adds 1-4 bytes to the encoded row. The trigger scenario is narrow (nullable column with nil defaults and NULL value).

**Backward compatibility**: Safe. Old rows (encoded before fix) continue to decode correctly. New rows are more correct. Mixed reads are safe. Rollback is safe.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug that after changing a column from `NOT NULL` to `NULL` via `ALTER TABLE`, inserting `NULL` values could cause data inconsistency between TiKV and TiFlash. The `CanSkip` function incorrectly omitted null column IDs from the Row Format v2 encoded row, violating the row format specification. Downstream components (TiFlash) could misinterpret the missing column ID as "use default value" instead of "value is NULL". Note: this fix only applies to newly written rows. Rows written before the upgrade may still contain the incorrect encoding (missing null column ID). To fix historical data, users should UPDATE the affected rows or recreate the affected tables after upgrading.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit and end-to-end tests validating encoding and query behavior for NULL vs non-NULL values, primary-key and virtual-generated columns, and NOT NULL→NULL schema changes.

* **Bug Fixes**
  * Adjusted skip logic for column encoding so NULL values (including columns altered from NOT NULL to NULL) are encoded correctly, preventing incorrect omission and ensuring accurate query results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->