### PR TITLE
planner: Implement ParamMarker constant predicate elimination

### DIFF
--- a/pkg/planner/core/casetest/plancache/BUILD.bazel
+++ b/pkg/planner/core/casetest/plancache/BUILD.bazel
@@ -4,6 +4,7 @@ go_test(
     name = "plancache_test",
     timeout = "short",
     srcs = [
+        "issue66609_test.go",
         "main_test.go",
         "plan_cache_param_test.go",
         "plan_cache_partition_table_test.go",
@@ -17,7 +18,7 @@ go_test(
         "//pkg/planner/core:plan_clone_utils.go",
     ],
     flaky = True,
-    shard_count = 44,
+    shard_count = 45,
     deps = [
         "//pkg/expression",
         "//pkg/infoschema",

--- a/pkg/planner/core/casetest/plancache/issue66609_test.go
+++ b/pkg/planner/core/casetest/plancache/issue66609_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plancache
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/session/sessmgr"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParamMarkerConstantPredicateElimination tests that always-true/false
+// ParamMarker constant predicates (e.g. WHERE ?) are eliminated, and that the
+// plan is correctly marked as uncacheable.
+// See https://github.com/pingcap/tidb/issues/66609
+func TestParamMarkerConstantPredicateElimination(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b int, key(a))")
+	tk.MustExec("insert into t values (1, 10), (2, 20), (3, 30)")
+	tk.MustExec("set @@tidb_enable_prepared_plan_cache=1")
+
+	tkProcess := tk.Session().ShowProcess()
+	ps := []*sessmgr.ProcessInfo{tkProcess}
+	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
+
+	// Case 1: WHERE ? with ?=true should eliminate the Selection and NOT cache.
+	tk.MustExec(`prepare stmt1 from 'select * from t where ?'`)
+	tk.MustExec(`set @v=true`)
+	tk.MustQuery(`execute stmt1 using @v`).Sort().Check(testkit.Rows("1 10", "2 20", "3 30"))
+	rows := tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).Rows()
+	for _, row := range rows {
+		op := row[0].(string)
+		require.False(t, strings.Contains(op, "Selection"),
+			"WHERE true should not produce a Selection node, got: %s", op)
+	}
+	// Execute again; plan should NOT come from cache.
+	tk.MustQuery(`execute stmt1 using @v`)
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+
+	// Case 2: WHERE ? with ?=false should return no rows and NOT cache.
+	tk.MustExec(`set @v=false`)
+	tk.MustQuery(`execute stmt1 using @v`).Check(testkit.Rows()) // no rows
+	tk.MustQuery(`execute stmt1 using @v`)
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustExec(`deallocate prepare stmt1`)
+
+	// Case 3: Normal WHERE col = ? should still be cacheable.
+	tk.MustExec(`prepare stmt2 from 'select * from t where a = ?'`)
+	tk.MustExec(`set @a=1`)
+	tk.MustQuery(`execute stmt2 using @a`).Check(testkit.Rows("1 10"))
+	tk.MustExec(`set @a=2`)
+	tk.MustQuery(`execute stmt2 using @a`).Check(testkit.Rows("2 20"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	tk.MustExec(`deallocate prepare stmt2`)
+
+	// Case 4: HAVING ? with ?=true should eliminate the HAVING Selection and NOT cache.
+	tk.MustExec(`prepare stmt3 from 'select a, sum(b) from t group by a having ?'`)
+	tk.MustExec(`set @v=true`)
+	tk.MustQuery(`execute stmt3 using @v`).Sort().Check(testkit.Rows("1 10", "2 20", "3 30"))
+	rows = tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).Rows()
+	for _, row := range rows {
+		op := row[0].(string)
+		if strings.Contains(op, "Selection") {
+			t.Fatalf("HAVING true should not produce a Selection node, got: %s", op)
+		}
+	}
+	tk.MustQuery(`execute stmt3 using @v`)
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustExec(`deallocate prepare stmt3`)
+}

--- a/pkg/planner/core/casetest/plancache/issue66609_test.go
+++ b/pkg/planner/core/casetest/plancache/issue66609_test.go
@@ -84,9 +84,8 @@ func TestParamMarkerConstantPredicateElimination(t *testing.T) {
 	require.Greater(t, len(rows), 0, "EXPLAIN FOR CONNECTION should return rows")
 	for _, row := range rows {
 		op := row[0].(string)
-		if strings.Contains(op, "Selection") {
-			t.Fatalf("HAVING true should not produce a Selection node, got: %s", op)
-		}
+		require.False(t, strings.Contains(op, "Selection"),
+			"HAVING true should not produce a Selection node, got: %s", op)
 	}
 	tk.MustQuery(`execute stmt3 using @v`)
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
@@ -96,30 +95,30 @@ func TestParamMarkerConstantPredicateElimination(t *testing.T) {
 	tk.MustExec("drop table if exists t2")
 	tk.MustExec("create table t2(a int, b int)")
 	tk.MustExec("insert into t2 values (1, 100)")
-	tk.MustExec(`prepare stmt5 from 'select * from t inner join t2 on t.a = t2.a where ?'`)
+	tk.MustExec(`prepare stmt4 from 'select * from t inner join t2 on t.a = t2.a where ?'`)
 	tk.MustExec(`set @v=false`)
-	tk.MustQuery(`execute stmt5 using @v`).Check(testkit.Rows()) // no rows (TableDual)
-	tk.MustQuery(`execute stmt5 using @v`)
+	tk.MustQuery(`execute stmt4 using @v`).Check(testkit.Rows()) // no rows (TableDual)
+	tk.MustQuery(`execute stmt4 using @v`)
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 	// Also verify the true case returns results and is not cached.
 	tk.MustExec(`set @v=true`)
-	tk.MustQuery(`execute stmt5 using @v`).Check(testkit.Rows("1 10 1 100"))
-	tk.MustQuery(`execute stmt5 using @v`)
+	tk.MustQuery(`execute stmt4 using @v`).Check(testkit.Rows("1 10 1 100"))
+	tk.MustQuery(`execute stmt4 using @v`)
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
-	tk.MustExec(`deallocate prepare stmt5`)
+	tk.MustExec(`deallocate prepare stmt4`)
 
 	// Case 6: JOIN USING with WHERE ?=false covers the FullSchema join path.
 	tk.MustExec("drop table if exists t3")
 	tk.MustExec("create table t3(a int, c int)")
 	tk.MustExec("insert into t3 values (1, 100)")
-	tk.MustExec(`prepare stmt6 from 'select * from t join t3 using (a) where ?'`)
+	tk.MustExec(`prepare stmt5 from 'select * from t join t3 using (a) where ?'`)
 	tk.MustExec(`set @v=false`)
-	tk.MustQuery(`execute stmt6 using @v`).Check(testkit.Rows()) // no rows
-	tk.MustQuery(`execute stmt6 using @v`)
+	tk.MustQuery(`execute stmt5 using @v`).Check(testkit.Rows()) // no rows
+	tk.MustQuery(`execute stmt5 using @v`)
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 	tk.MustExec(`set @v=true`)
-	tk.MustQuery(`execute stmt6 using @v`).Check(testkit.Rows("1 10 100"))
-	tk.MustQuery(`execute stmt6 using @v`)
+	tk.MustQuery(`execute stmt5 using @v`).Check(testkit.Rows("1 10 100"))
+	tk.MustQuery(`execute stmt5 using @v`)
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
-	tk.MustExec(`deallocate prepare stmt6`)
+	tk.MustExec(`deallocate prepare stmt5`)
 }

--- a/pkg/planner/core/casetest/plancache/issue66609_test.go
+++ b/pkg/planner/core/casetest/plancache/issue66609_test.go
@@ -37,15 +37,16 @@ func TestParamMarkerConstantPredicateElimination(t *testing.T) {
 	tk.MustExec("insert into t values (1, 10), (2, 20), (3, 30)")
 	tk.MustExec("set @@tidb_enable_prepared_plan_cache=1")
 
-	tkProcess := tk.Session().ShowProcess()
-	ps := []*sessmgr.ProcessInfo{tkProcess}
-	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-
 	// Case 1: WHERE ? with ?=true should eliminate the Selection and NOT cache.
 	tk.MustExec(`prepare stmt1 from 'select * from t where ?'`)
 	tk.MustExec(`set @v=true`)
 	tk.MustQuery(`execute stmt1 using @v`).Sort().Check(testkit.Rows("1 10", "2 20", "3 30"))
+	// Capture ProcessInfo AFTER the execute so the plan is current.
+	tkProcess := tk.Session().ShowProcess()
+	ps := []*sessmgr.ProcessInfo{tkProcess}
+	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
 	rows := tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).Rows()
+	require.Greater(t, len(rows), 0, "EXPLAIN FOR CONNECTION should return rows")
 	for _, row := range rows {
 		op := row[0].(string)
 		require.False(t, strings.Contains(op, "Selection"),
@@ -75,7 +76,12 @@ func TestParamMarkerConstantPredicateElimination(t *testing.T) {
 	tk.MustExec(`prepare stmt3 from 'select a, sum(b) from t group by a having ?'`)
 	tk.MustExec(`set @v=true`)
 	tk.MustQuery(`execute stmt3 using @v`).Sort().Check(testkit.Rows("1 10", "2 20", "3 30"))
+	// Re-capture ProcessInfo after executing stmt3.
+	tkProcess = tk.Session().ShowProcess()
+	ps = []*sessmgr.ProcessInfo{tkProcess}
+	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
 	rows = tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).Rows()
+	require.Greater(t, len(rows), 0, "EXPLAIN FOR CONNECTION should return rows")
 	for _, row := range rows {
 		op := row[0].(string)
 		if strings.Contains(op, "Selection") {

--- a/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
@@ -1175,7 +1175,7 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"skip non-prepared plan-cache: access tables in system schema",
 		"skip non-prepared plan-cache: queries that access views are not supported",
 		"skip non-prepared plan-cache: query has null constants",
-		"skip non-prepared plan-cache: some parameters may be overwritten when constant propagation",
+		"skip non-prepared plan-cache: constant predicate elimination on parameter marker",
 	}
 
 	all := append(supported, unsupported...)

--- a/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
@@ -1175,7 +1175,7 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"skip non-prepared plan-cache: access tables in system schema",
 		"skip non-prepared plan-cache: queries that access views are not supported",
 		"skip non-prepared plan-cache: query has null constants",
-		"skip non-prepared plan-cache: constant predicate elimination on parameter marker",
+		"skip non-prepared plan-cache: constant predicate elimination on mutable constant",
 	}
 
 	all := append(supported, unsupported...)

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -965,7 +965,7 @@ func (b *PlanBuilder) buildSelection(ctx context.Context, p base.LogicalPlan, wh
 						return nil, errors.Trace(err)
 					}
 					if needSkipCache {
-						b.ctx.GetSessionVars().StmtCtx.SetSkipPlanCache("constant predicate elimination on parameter marker")
+						b.ctx.GetSessionVars().StmtCtx.SetSkipPlanCache("constant predicate elimination on mutable constant")
 					}
 					if ret {
 						continue

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -955,7 +955,7 @@ func (b *PlanBuilder) buildSelection(ctx context.Context, p base.LogicalPlan, wh
 			if con, ok := item.(*expression.Constant); ok {
 				canEval := expression.ConstExprConsiderPlanCache(con, useCache)
 				needSkipCache := false
-				if !canEval && useCache && con.ConstLevel() == expression.ConstOnlyInContext {
+				if !canEval && useCache {
 					canEval = true
 					needSkipCache = true
 				}

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -953,35 +953,30 @@ func (b *PlanBuilder) buildSelection(ctx context.Context, p base.LogicalPlan, wh
 		cnfItems := expression.SplitCNFItems(expr)
 		for _, item := range cnfItems {
 			if con, ok := item.(*expression.Constant); ok {
-				canEval := expression.ConstExprConsiderPlanCache(con, useCache)
-				needSkipCache := false
-				if !canEval && useCache {
-					canEval = true
-					needSkipCache = true
+				// For *expression.Constant, ConstLevel is always ConstStrict or ConstOnlyInContext,
+				// so we can always evaluate. We just need to skip plan cache for mutable constants.
+				needSkipCache := useCache && !expression.ConstExprConsiderPlanCache(con, useCache)
+				ret, _, err := expression.EvalBool(b.ctx.GetExprCtx().GetEvalCtx(), expression.CNFExprs{con}, chunk.Row{})
+				if err != nil {
+					return nil, errors.Trace(err)
 				}
-				if canEval {
-					ret, _, err := expression.EvalBool(b.ctx.GetExprCtx().GetEvalCtx(), expression.CNFExprs{con}, chunk.Row{})
-					if err != nil {
-						return nil, errors.Trace(err)
-					}
-					if needSkipCache {
-						b.ctx.GetSessionVars().StmtCtx.SetSkipPlanCache("constant predicate elimination on mutable constant")
-					}
-					if ret {
-						continue
-					}
-					// If there is condition which is always false, return dual plan directly.
-					dual := logicalop.LogicalTableDual{}.Init(b.ctx, b.getSelectOffset())
-					if join, ok := p.(*logicalop.LogicalJoin); ok && join.FullSchema != nil {
-						dual.SetOutputNames(join.FullNames)
-						dual.SetSchema(join.FullSchema)
-					} else {
-						dual.SetOutputNames(p.OutputNames())
-						dual.SetSchema(p.Schema())
-					}
+				if needSkipCache {
+					b.ctx.GetSessionVars().StmtCtx.SetSkipPlanCache("constant predicate elimination on mutable constant")
+				}
+				if ret {
+					continue
+				}
+				// If there is condition which is always false, return dual plan directly.
+				dual := logicalop.LogicalTableDual{}.Init(b.ctx, b.getSelectOffset())
+				if join, ok := p.(*logicalop.LogicalJoin); ok && join.FullSchema != nil {
+					dual.SetOutputNames(join.FullNames)
+					dual.SetSchema(join.FullSchema)
+				} else {
+					dual.SetOutputNames(p.OutputNames())
+					dual.SetSchema(p.Schema())
+				}
 
-					return dual, nil
-				}
+				return dual, nil
 			}
 			cnfExpres = append(cnfExpres, item)
 		}

--- a/tests/integrationtest/r/planner/core/plan_cache.result
+++ b/tests/integrationtest/r/planner/core/plan_cache.result
@@ -139,7 +139,7 @@ a	b
 3	3
 select @@last_plan_from_cache;
 @@last_plan_from_cache
-1
+0
 select * from t1 where 1=1 and (a, b) in ((1, 1), (2, 2), (2, 2));
 a	b
 1	1
@@ -2138,13 +2138,13 @@ c1
 1
 select @@last_plan_from_cache;
 @@last_plan_from_cache
-1
+0
 SELECT c1 FROM t1 WHERE TO_BASE64('哈');
 c1
 1
 select @@last_plan_from_cache;
 @@last_plan_from_cache
-1
+0
 SELECT c1 FROM t1 WHERE TO_BASE64('');
 c1
 set tidb_enable_non_prepared_plan_cache=DEFAULT;
@@ -2160,7 +2160,7 @@ c1
 1
 select @@last_plan_from_cache;
 @@last_plan_from_cache
-1
+0
 set tidb_enable_non_prepared_plan_cache=DEFAULT;
 drop table if exists t;
 create table t (a varchar(10), key(a(5)));


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66609

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plan-cache handling for constant predicates with parameter markers in WHERE/HAVING: constant-elimination is corrected and the planner now flags statements to skip plan-cache when evaluation safety is uncertain; updated explanatory warning text.

* **Tests**
  * Added end-to-end tests covering constant-predicate elimination and plan-cache behavior across multiple scenarios; updated test expectations to reflect corrected last-plan-from-cache results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->