### PR TITLE
meta,ddl: support must-load filtering for affinity

### DIFF
--- a/pkg/ddl/placement_policy.go
+++ b/pkg/ddl/placement_policy.go
@@ -424,8 +424,9 @@ func getPlacementPolicyDependedObjectsIDs(t *meta.Mutator, policy *model.PolicyI
 		}
 		tables, err := meta.GetTableInfoWithAttributes(
 			t, dbInfo.ID,
-			`"partition":null`,
-			`"policy_ref_info":null`)
+			meta.MustLoadFilterAttr{Attr: `"partition":null`, LoadIfMissing: true},
+			meta.MustLoadFilterAttr{Attr: `"policy_ref_info":null`, LoadIfMissing: true},
+		)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -798,6 +798,16 @@ func TestIsTableInfoMustLoad(t *testing.T) {
 	require.True(t, meta.IsTableInfoMustLoad(b))
 
 	tableInfo = &model.TableInfo{
+		Affinity: &model.TableAffinityInfo{
+			Level: "s",
+		},
+		State: model.StatePublic,
+	}
+	b, err = json.Marshal(tableInfo)
+	require.NoError(t, err)
+	require.True(t, meta.IsTableInfoMustLoad(b))
+
+	tableInfo = &model.TableInfo{
 		TiFlashReplica: &model.TiFlashReplicaInfo{Count: 1},
 		State:          model.StatePublic,
 	}
@@ -892,11 +902,13 @@ func TestIsTableInfoMustLoadSubStringsOrder(t *testing.T) {
 	// The order matter!
 	// IsTableInfoMustLoad relies on the order of the json marshal result,
 	// or the internal of the json marshal in other words.
-	// This test cover the invariance, if Go std library changes, we can catch it.
-	tableInfo := &model.TableInfo{}
+	// This test covers the invariance, if Go std library changes, we can catch it.
+	tableInfo := &model.TableInfo{
+		Affinity: &model.TableAffinityInfo{Level: "s"},
+	}
 	b, err := json.Marshal(tableInfo)
 	require.NoError(t, err)
-	expect := `{"id":0,"name":{"O":"","L":""},"charset":"","collate":"","cols":null,"index_info":null,"constraint_info":null,"fk_info":null,"state":0,"pk_is_handle":false,"is_common_handle":false,"common_handle_version":0,"comment":"","auto_inc_id":0,"auto_id_cache":0,"auto_rand_id":0,"max_col_id":0,"max_idx_id":0,"max_fk_id":0,"max_cst_id":0,"update_timestamp":0,"ShardRowIDBits":0,"max_shard_row_id_bits":0,"auto_random_bits":0,"auto_random_range_bits":0,"pre_split_regions":0,"partition":null,"compression":"","view":null,"sequence":null,"Lock":null,"version":0,"tiflash_replica":null,"is_columnar":false,"temp_table_type":0,"cache_table_status":0,"policy_ref_info":null,"stats_options":null,"exchange_partition_info":null,"ttl_info":null,"revision":0}`
+	expect := `{"id":0,"name":{"O":"","L":""},"charset":"","collate":"","cols":null,"index_info":null,"constraint_info":null,"fk_info":null,"state":0,"pk_is_handle":false,"is_common_handle":false,"common_handle_version":0,"comment":"","auto_inc_id":0,"auto_id_cache":0,"auto_rand_id":0,"max_col_id":0,"max_idx_id":0,"max_fk_id":0,"max_cst_id":0,"update_timestamp":0,"ShardRowIDBits":0,"max_shard_row_id_bits":0,"auto_random_bits":0,"auto_random_range_bits":0,"pre_split_regions":0,"partition":null,"compression":"","view":null,"sequence":null,"Lock":null,"version":0,"tiflash_replica":null,"is_columnar":false,"temp_table_type":0,"cache_table_status":0,"policy_ref_info":null,"stats_options":null,"exchange_partition_info":null,"ttl_info":null,"affinity":{"level":"s"},"revision":0}`
 	require.Equal(t, expect, string(b))
 }
 
@@ -1124,6 +1136,9 @@ func TestInfoSchemaV2SpecialAttributeCorrectnessAfterBootstrap(t *testing.T) {
 			Enable:           true,
 			JobInterval:      "1h",
 		},
+		Affinity: &model.TableAffinityInfo{
+			Level: "1",
+		},
 	}
 
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL)
@@ -1161,6 +1176,10 @@ func TestInfoSchemaV2SpecialAttributeCorrectnessAfterBootstrap(t *testing.T) {
 	tblInfoRes = dom.InfoSchema().ListTablesWithSpecialAttribute(infoschemacontext.TTLAttribute)
 	require.Equal(t, len(tblInfoRes[0].TableInfos), 1)
 	require.Equal(t, tblInfo.TTLInfo, tblInfoRes[0].TableInfos[0].TTLInfo)
+	// affinity
+	tblInfoRes = dom.InfoSchema().ListTablesWithSpecialAttribute(infoschemacontext.AffinityAttribute)
+	require.Equal(t, len(tblInfoRes[0].TableInfos), 1)
+	require.Equal(t, tblInfo.Affinity, tblInfoRes[0].TableInfos[0].Affinity)
 }
 
 func TestInfoSchemaV2DataFieldsCorrectnessAfterBootstrap(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66284, ref #64938

Problem Summary:
The must-load table info filtering only supported "load when attribute is missing" checks. After adding affinity metadata, infoschema-v2 special-attribute paths may skip required tables because these attributes should be loaded when present.

### What changed and how does it work?
- Introduced `meta.MustLoadFilterAttr` with `LoadIfMissing` to support both filter modes.
- Updated `isTableInfoMustLoad` and `GetTableInfoWithAttributes` to consume structured filter rules.
- Added affinity rules to `checkAttributesInOrder` as "load when present" attributes.
- Updated DDL placement policy caller to pass `MustLoadFilterAttr` values.
- Added/updated unit tests in `pkg/meta/meta_test.go` to cover affinity must-load behavior and attribute order invariants.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix infoschema-v2 must-load filtering to correctly include tables with affinity attributes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table information now exposes affinity attributes.

* **Improvements**
  * Granular per-attribute loading rules added to make optional attribute loading more explicit and reliable (controls whether missing attributes are loaded).
  * Attribute filtering behavior refined to honor per-attribute load semantics for more predictable table-info retrieval.

* **Tests**
  * Expanded tests covering affinity propagation and varied attribute-loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->