### PR TITLE
server/executor: port #66191 admin check index inconsistency API to master

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -119,7 +119,6 @@ go_library(
         "//pkg/dxf/framework/proto",
         "//pkg/dxf/framework/storage",
         "//pkg/dxf/importinto",
-        "//pkg/dxf/operator",
         "//pkg/errctx",
         "//pkg/errno",
         "//pkg/executor/aggfuncs",

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -536,7 +536,6 @@ func (b *executorBuilder) buildCheckTable(v *plannercore.CheckTable) exec.Execut
 			dbName:       v.DBName,
 			table:        v.Table,
 			indexInfos:   v.IndexInfos,
-			is:           b.is,
 		}
 		return e
 	}

--- a/pkg/executor/check_table_index.go
+++ b/pkg/executor/check_table_index.go
@@ -315,7 +315,7 @@ type adminCheckIndexCollectorCtxKeyType struct{}
 
 var adminCheckIndexCollectorCtxKey = adminCheckIndexCollectorCtxKeyType{}
 
-// WithAdminCheckIndexInconsistentCollector enables collecting all inconsistent handles in fast check.
+// WithAdminCheckIndexInconsistentCollector enables collecting inconsistent handles in fast check.
 func WithAdminCheckIndexInconsistentCollector(
 	ctx context.Context,
 	collector *AdminCheckIndexInconsistentCollector,

--- a/pkg/executor/check_table_index.go
+++ b/pkg/executor/check_table_index.go
@@ -20,19 +20,16 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
-	"github.com/pingcap/tidb/pkg/dxf/operator"
-	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
-	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/resourcemanager/pool/workerpool"
 	poolutil "github.com/pingcap/tidb/pkg/resourcemanager/util"
 	"github.com/pingcap/tidb/pkg/sessionctx"
-	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/tablecodec"
@@ -41,17 +38,12 @@ import (
 	"github.com/pingcap/tidb/pkg/util/admin"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
-	"github.com/pingcap/tidb/pkg/util/dbterror"
-	"github.com/pingcap/tidb/pkg/util/execdetails"
-	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/logutil/consistency"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	atomicutil "go.uber.org/atomic"
 	"go.uber.org/zap"
 )
-
-var errCheckPartialIndexWithoutFastCheck = dbterror.ClassExecutor.NewStd(errno.ErrCheckPartialIndexWithoutFastCheck)
 
 // CheckTableExec represents a check table executor.
 // It is built from the "admin check table" statement, and it checks if the
@@ -150,9 +142,6 @@ func (e *CheckTableExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 		if idx.MVIndex || idx.IsColumnarIndex() {
 			continue
 		}
-		if idx.HasCondition() {
-			return errors.Trace(errCheckPartialIndexWithoutFastCheck)
-		}
 		idxNames = append(idxNames, idx.Name.O)
 	}
 	greater, idxOffset, err := admin.CheckIndicesCount(e.Ctx(), e.dbName, e.table.Meta().Name.O, idxNames)
@@ -234,10 +223,7 @@ func (e *CheckTableExec) checkTableRecord(ctx context.Context, idxOffset int) er
 		return err
 	}
 	if e.table.Meta().GetPartitionInfo() == nil {
-		idx, err := tables.NewIndex(e.table.Meta().ID, e.table.Meta(), idxInfo)
-		if err != nil {
-			return err
-		}
+		idx := tables.NewIndex(e.table.Meta().ID, e.table.Meta(), idxInfo)
 		return admin.CheckRecordAndIndex(ctx, e.Ctx(), txn, e.table, idx)
 	}
 
@@ -245,10 +231,7 @@ func (e *CheckTableExec) checkTableRecord(ctx context.Context, idxOffset int) er
 	for _, def := range info.Definitions {
 		pid := def.ID
 		partition := e.table.(table.PartitionedTable).GetPartition(pid)
-		idx, err := tables.NewIndex(def.ID, e.table.Meta(), idxInfo)
-		if err != nil {
-			return err
-		}
+		idx := tables.NewIndex(def.ID, e.table.Meta(), idxInfo)
 		if err := admin.CheckRecordAndIndex(ctx, e.Ctx(), txn, partition, idx); err != nil {
 			return errors.Trace(err)
 		}
@@ -267,8 +250,187 @@ type FastCheckTableExec struct {
 	table      table.Table
 	indexInfos []*model.IndexInfo
 	done       bool
-	is         infoschema.InfoSchema
+	err        *atomic.Pointer[error]
+	collector  *AdminCheckIndexInconsistentCollector
+	wg         sync.WaitGroup
 	contextCtx context.Context
+}
+
+// AdminCheckIndexInconsistentType describes the inconsistency category found by
+// fast `admin check index`.
+type AdminCheckIndexInconsistentType string
+
+const (
+	// AdminCheckIndexRowWithoutIndex means one table row exists but the index row is missing.
+	AdminCheckIndexRowWithoutIndex AdminCheckIndexInconsistentType = "row_without_index"
+	// AdminCheckIndexIndexWithoutRow means one index row exists but the table row is missing.
+	AdminCheckIndexIndexWithoutRow AdminCheckIndexInconsistentType = "index_without_row"
+	// AdminCheckIndexRowIndexMismatch means table and index rows both exist but values don't match.
+	AdminCheckIndexRowIndexMismatch AdminCheckIndexInconsistentType = "row_index_mismatch"
+)
+
+// AdminCheckIndexInconsistentRow stores one inconsistent handle and mismatch type.
+type AdminCheckIndexInconsistentRow struct {
+	Handle       string                          `json:"handle"`
+	MismatchType AdminCheckIndexInconsistentType `json:"mismatch_type"`
+}
+
+// AdminCheckIndexInconsistentSummary is returned by HTTP API.
+type AdminCheckIndexInconsistentSummary struct {
+	InconsistentRowCount uint64                           `json:"inconsistent_row_count"`
+	Rows                 []AdminCheckIndexInconsistentRow `json:"rows"`
+}
+
+// AdminCheckIndexInconsistentCollector collects all inconsistent handles for one statement execution.
+// It is enabled only when the execution context carries this collector.
+type AdminCheckIndexInconsistentCollector struct {
+	count atomic.Uint64
+	first atomic.Pointer[error]
+
+	mu     sync.Mutex
+	rows   []AdminCheckIndexInconsistentRow
+	rowSet map[string]struct{}
+}
+
+// NewAdminCheckIndexInconsistentCollector creates a collector for fast `admin check index`.
+func NewAdminCheckIndexInconsistentCollector() *AdminCheckIndexInconsistentCollector {
+	return &AdminCheckIndexInconsistentCollector{
+		rowSet: make(map[string]struct{}),
+	}
+}
+
+type adminCheckIndexCollectorCtxKeyType struct{}
+
+var adminCheckIndexCollectorCtxKey = adminCheckIndexCollectorCtxKeyType{}
+
+// WithAdminCheckIndexInconsistentCollector enables collecting all inconsistent handles in fast check.
+func WithAdminCheckIndexInconsistentCollector(
+	ctx context.Context,
+	collector *AdminCheckIndexInconsistentCollector,
+) context.Context {
+	if collector == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, adminCheckIndexCollectorCtxKey, collector)
+}
+
+func adminCheckIndexCollectorFromContext(ctx context.Context) *AdminCheckIndexInconsistentCollector {
+	collector, ok := ctx.Value(adminCheckIndexCollectorCtxKey).(*AdminCheckIndexInconsistentCollector)
+	if !ok {
+		return nil
+	}
+	return collector
+}
+
+func (c *AdminCheckIndexInconsistentCollector) recordInconsistent(
+	handle string,
+	mismatchType AdminCheckIndexInconsistentType,
+	err error,
+) {
+	if err == nil {
+		return
+	}
+	c.first.CompareAndSwap(nil, &err)
+	if handle == "" {
+		return
+	}
+
+	rowKey := handle + "\x00" + string(mismatchType)
+	c.mu.Lock()
+	if _, exists := c.rowSet[rowKey]; exists {
+		c.mu.Unlock()
+		return
+	}
+	c.rowSet[rowKey] = struct{}{}
+	c.rows = append(c.rows, AdminCheckIndexInconsistentRow{Handle: handle, MismatchType: mismatchType})
+	c.mu.Unlock()
+
+	c.count.Add(1)
+}
+
+func (c *AdminCheckIndexInconsistentCollector) firstErr() error {
+	if c == nil {
+		return nil
+	}
+	err := c.first.Load()
+	if err == nil {
+		return nil
+	}
+	return *err
+}
+
+// Summary returns a copy of collected inconsistency rows.
+func (c *AdminCheckIndexInconsistentCollector) Summary() *AdminCheckIndexInconsistentSummary {
+	if c == nil {
+		return &AdminCheckIndexInconsistentSummary{}
+	}
+
+	c.mu.Lock()
+	rows := make([]AdminCheckIndexInconsistentRow, len(c.rows))
+	copy(rows, c.rows)
+	c.mu.Unlock()
+
+	return &AdminCheckIndexInconsistentSummary{
+		InconsistentRowCount: c.count.Load(),
+		Rows:                 rows,
+	}
+}
+
+type checksumBucketTask struct {
+	offset int
+	mod    int
+	depth  int
+}
+
+type mismatchBucket struct {
+	bucket uint64
+	count  int64
+}
+
+type leafRowStream struct {
+	ctx context.Context
+	rs  sqlexec.RecordSet
+	chk *chunk.Chunk
+	idx int
+}
+
+func newLeafRowStream(ctx context.Context, se sessionctx.Context, sql string) (*leafRowStream, error) {
+	rs, err := se.GetSQLExecutor().ExecuteInternal(ctx, sql)
+	if err != nil {
+		return nil, err
+	}
+	return &leafRowStream{
+		ctx: ctx,
+		rs:  rs,
+		chk: rs.NewChunk(nil),
+	}, nil
+}
+
+func (s *leafRowStream) Next() (chunk.Row, bool, error) {
+	for {
+		if s.idx < s.chk.NumRows() {
+			row := s.chk.GetRow(s.idx)
+			s.idx++
+			return row, true, nil
+		}
+		err := s.rs.Next(s.ctx, s.chk)
+		if err != nil {
+			return chunk.Row{}, false, err
+		}
+		if s.chk.NumRows() == 0 {
+			return chunk.Row{}, false, nil
+		}
+		s.idx = 0
+	}
+}
+
+func (s *leafRowStream) Close() {
+	if s == nil || s.rs == nil {
+		return
+	}
+	if err := s.rs.Close(); err != nil {
+		logutil.BgLogger().Warn("close leaf row stream failed", zap.Error(err))
+	}
 }
 
 var _ exec.Executor = &FastCheckTableExec{}
@@ -290,6 +452,7 @@ func (e *FastCheckTableExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 		return nil
 	}
 	defer func() { e.done = true }()
+	e.collector = adminCheckIndexCollectorFromContext(ctx)
 
 	// Here we need check all indexes, includes invisible index
 	e.Ctx().GetSessionVars().OptimizerUseInvisibleIndexes = true
@@ -297,32 +460,29 @@ func (e *FastCheckTableExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 		e.Ctx().GetSessionVars().OptimizerUseInvisibleIndexes = false
 	}()
 
-	ch := make(chan checkIndexTask)
-	dc := operator.NewSimpleDataChannel(ch)
+	workerPool := workerpool.NewWorkerPool("checkIndex",
+		poolutil.CheckTable, 3, e.createWorker)
+	workerPool.Start(ctx)
 
-	wctx := workerpool.NewContext(ctx)
-	op := operator.NewAsyncOperator(wctx,
-		workerpool.NewWorkerPool("checkIndex",
-			poolutil.CheckTable, 3, e.createWorker))
-	op.SetSource(dc)
-	//nolint: errcheck
-	op.Open()
-
-OUTER:
+	e.wg.Add(len(e.indexInfos))
 	for i := range e.indexInfos {
-		select {
-		case ch <- checkIndexTask{indexOffset: i}:
-		case <-wctx.Done():
-			break OUTER
+		workerPool.AddTask(checkIndexTask{indexOffset: i, err: e.err})
+	}
+
+	e.wg.Wait()
+	workerPool.ReleaseAndWait()
+
+	if e.collector != nil {
+		if firstErr := e.collector.firstErr(); firstErr != nil {
+			return firstErr
 		}
 	}
-	close(ch)
 
-	err := op.Close()
-	if opErr := wctx.OperatorErr(); opErr != nil {
-		return opErr
+	p := e.err.Load()
+	if p == nil {
+		return nil
 	}
-	return err
+	return *p
 }
 
 func (e *FastCheckTableExec) createWorker() workerpool.Worker[checkIndexTask, workerpool.None] {
@@ -337,54 +497,13 @@ type checkIndexWorker struct {
 	e          *FastCheckTableExec
 }
 
-type fastCheckSysSessionVarsBackup struct {
-	optimizerUseInvisibleIndexes bool
-	memQuotaQuery                int64
-	distSQLScanConcurrency       int
-	executorConcurrency          int
-	maxExecutionTime             uint64
-	tikvClientReadTimeout        uint64
-}
-
-func backupFastCheckSysSessionVars(sv *variable.SessionVars) fastCheckSysSessionVarsBackup {
-	return fastCheckSysSessionVarsBackup{
-		optimizerUseInvisibleIndexes: sv.OptimizerUseInvisibleIndexes,
-		memQuotaQuery:                sv.MemQuotaQuery,
-		distSQLScanConcurrency:       sv.DistSQLScanConcurrency(),
-		executorConcurrency:          sv.ExecutorConcurrency,
-		maxExecutionTime:             sv.MaxExecutionTime,
-		tikvClientReadTimeout:        sv.TiKVClientReadTimeout,
-	}
-}
-
-func (b fastCheckSysSessionVarsBackup) restoreTo(sv *variable.SessionVars) {
-	sv.OptimizerUseInvisibleIndexes = b.optimizerUseInvisibleIndexes
-	sv.MemQuotaQuery = b.memQuotaQuery
-	if sv.MemTracker != nil {
-		sv.MemTracker.SetBytesLimit(sv.MemQuotaQuery)
-	}
-	sv.SetDistSQLScanConcurrency(b.distSQLScanConcurrency)
-	sv.ExecutorConcurrency = b.executorConcurrency
-	sv.MaxExecutionTime = b.maxExecutionTime
-	sv.TiKVClientReadTimeout = b.tikvClientReadTimeout
-}
-
-func applyFastCheckSysSessionVars(sysVars, userVars *variable.SessionVars) {
-	sysVars.OptimizerUseInvisibleIndexes = true
-	sysVars.MemQuotaQuery = userVars.MemQuotaQuery
-	if sysVars.MemTracker != nil {
-		sysVars.MemTracker.SetBytesLimit(sysVars.MemQuotaQuery)
-	}
-	sysVars.SetDistSQLScanConcurrency(userVars.DistSQLScanConcurrency())
-	sysVars.ExecutorConcurrency = userVars.ExecutorConcurrency
-	sysVars.MaxExecutionTime = userVars.MaxExecutionTime
-	sysVars.TiKVClientReadTimeout = userVars.TiKVClientReadTimeout
-}
-
 func (w *checkIndexWorker) initSessCtx(se sessionctx.Context) (restore func()) {
 	sessVars := se.GetSessionVars()
-	backup := backupFastCheckSysSessionVars(sessVars)
-	applyFastCheckSysSessionVars(sessVars, w.sctx.GetSessionVars())
+	originOptUseInvisibleIdx := sessVars.OptimizerUseInvisibleIndexes
+	originMemQuotaQuery := sessVars.MemQuotaQuery
+
+	sessVars.OptimizerUseInvisibleIndexes = true
+	sessVars.MemQuotaQuery = w.sctx.GetSessionVars().MemQuotaQuery
 	snapshot := w.e.Ctx().GetSessionVars().SnapshotTS
 	if snapshot != 0 {
 		_, err := se.GetSQLExecutor().ExecuteInternal(w.e.contextCtx, fmt.Sprintf("set session tidb_snapshot = %d", snapshot))
@@ -394,7 +513,8 @@ func (w *checkIndexWorker) initSessCtx(se sessionctx.Context) (restore func()) {
 	}
 
 	return func() {
-		backup.restoreTo(sessVars)
+		sessVars.OptimizerUseInvisibleIndexes = originOptUseInvisibleIdx
+		sessVars.MemQuotaQuery = originMemQuotaQuery
 		if snapshot != 0 {
 			_, err := se.GetSQLExecutor().ExecuteInternal(w.e.contextCtx, "set session tidb_snapshot = 0")
 			if err != nil {
@@ -404,97 +524,40 @@ func (w *checkIndexWorker) initSessCtx(se sessionctx.Context) (restore func()) {
 	}
 }
 
-func queryToRow(ctx context.Context, se sessionctx.Context, sql string) ([]chunk.Row, error) {
-	rs, err := se.GetSQLExecutor().ExecuteInternal(ctx, sql)
-	if err != nil {
-		return nil, err
-	}
-	return sqlexec.DrainRecordSetAndClose(ctx, rs, 4096)
-}
-
-func verifyIndexSideQuery(ctx context.Context, se sessionctx.Context, sql string) bool {
-	rows, err := queryToRow(ctx, se, "explain "+sql)
-	if err != nil {
-		return false
-	}
-
-	isTableScan := false
-	isIndexScan := false
-	for _, row := range rows {
-		op := row.GetString(0)
-		if strings.Contains(op, "TableFullScan") {
-			isTableScan = true
-		} else if strings.Contains(op, "IndexFullScan") || strings.Contains(op, "IndexRangeScan") {
-			// It's also possible to be index range scan if the index has condition.
-			// TODO: if the planner eliminates the range in the index scan, we can remove the `IndexRangeScan` check.
-			isIndexScan = true
-		} else if strings.Contains(op, "PointGet") || strings.Contains(op, "BatchPointGet") {
-			if row.Len() > 3 {
-				accessObject := row.GetString(3)
-				// accessObject is a normalized string with components separated by ", ".
-				// Match ", index:" to identify non-clustered index paths and avoid
-				// treating ", clustered index:" (PRIMARY/handle path) as index access.
-				if strings.Contains(accessObject, ", index:") {
-					isIndexScan = true
-				}
-			}
-		}
-	}
-
-	if isTableScan || !isIndexScan {
-		return false
-	}
-	return true
-}
-
-func (w *checkIndexWorker) quickPassGlobalChecksum(ctx context.Context, se sessionctx.Context, tblName string, idxInfo *model.IndexInfo, rowChecksumExpr, idxCondition string) (bool, error) {
-	tableGlobalQuery := fmt.Sprintf(
-		"select /*+ read_from_storage(tikv[%s]), AGG_TO_COP() */ bit_xor(%s), count(*) from %s use index() where %s(0 = 0)",
-		tblName, rowChecksumExpr, tblName, idxCondition)
-	indexGlobalQuery := fmt.Sprintf(
-		"select /*+ AGG_TO_COP() */ bit_xor(%s), count(*) from %s use index(`%s`) where %s(0 = 0)",
-		rowChecksumExpr, tblName, idxInfo.Name, idxCondition)
-
-	tableGlobalChecksum, tableGlobalCnt, err := getGlobalCheckSum(w.e.contextCtx, se, tableGlobalQuery)
-	if err != nil {
-		return false, err
-	}
-	intest.AssertFunc(func() bool {
-		return verifyIndexSideQuery(ctx, se, indexGlobalQuery)
-	}, "index side query plan is not correct: %s", indexGlobalQuery)
-	indexGlobalChecksum, indexGlobalCnt, err := getGlobalCheckSum(w.e.contextCtx, se, indexGlobalQuery)
-	if err != nil {
-		return false, err
-	}
-
-	return tableGlobalCnt == indexGlobalCnt && tableGlobalChecksum == indexGlobalChecksum, nil
-}
-
 // HandleTask implements the Worker interface.
-func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.None)) error {
-	failpoint.Inject("mockFastCheckTableError", func() {
-		failpoint.Return(errors.New("mock fast check table error"))
-	})
-
+func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.None)) {
+	defer w.e.wg.Done()
 	idxInfo := w.indexInfos[task.indexOffset]
 	bucketSize := int(CheckTableFastBucketSize.Load())
 
 	ctx := kv.WithInternalSourceType(w.e.contextCtx, kv.InternalTxnAdmin)
 
+	trySaveErr := func(err error) {
+		w.e.err.CompareAndSwap(nil, &err)
+	}
+	reportErr := func(err error) bool {
+		if err == nil {
+			return false
+		}
+		if w.e.collector == nil {
+			trySaveErr(err)
+			return true
+		}
+		w.e.collector.first.CompareAndSwap(nil, &err)
+		trySaveErr(err)
+		return true
+	}
+
 	se, err := w.e.BaseExecutor.GetSysSession()
 	if err != nil {
-		return err
+		trySaveErr(err)
+		return
 	}
 	restoreCtx := w.initSessCtx(se)
 	defer func() {
 		restoreCtx()
 		w.e.BaseExecutor.ReleaseSysSession(ctx, se)
 	}()
-	var fpErr error
-	failpoint.InjectCall("fastCheckTableAfterInitSessCtx", se.GetSessionVars(), &fpErr)
-	if fpErr != nil {
-		return fpErr
-	}
 
 	tblMeta := w.table.Meta()
 	tblName := TableName(w.e.dbName, tblMeta.Name.String())
@@ -532,330 +595,360 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 	// Used to group by and order.
 	md5Handle := fmt.Sprintf("crc32(md5(concat_ws(0x2, %s)))", handleColumns)
 
-	tableRowCntToCheck := int64(0)
-
-	offset := 0
-	mod := 1
-	meetError := false
-
 	lookupCheckThreshold := int64(100)
-	checkOnce := false
-
-	idxCondition := ""
-	if idxInfo.HasCondition() {
-		idxCondition = fmt.Sprintf("(%s) AND ", idxInfo.ConditionExprString)
-	}
 
 	_, err = se.GetSQLExecutor().ExecuteInternal(ctx, "begin")
 	if err != nil {
-		return err
+		trySaveErr(err)
+		return
 	}
 
-	// Quick pass: avoid bucketed grouping if table/index checksum already matches.
-	match, err := w.quickPassGlobalChecksum(ctx, se, tblName, idxInfo, md5HandleAndIndexCol, idxCondition)
-	if err != nil {
-		return err
-	}
-	failpoint.Inject("forceAdminCheckBucketed", func() {
-		match = false
-	})
-	if match {
-		return nil
-	}
-
-	failpoint.Inject("mockFastCheckTableBucketedCalled", func() {
-		failpoint.Return(errors.New("mock fast check table bucketed called"))
-	})
-
-	times := 0
-	const maxTimes = 10
-	for tableRowCntToCheck > lookupCheckThreshold || !checkOnce {
-		times++
-		if times == maxTimes {
-			logutil.BgLogger().Warn("compare checksum by group reaches time limit", zap.Int("times", times))
-			break
+	errCtx := w.sctx.GetSessionVars().StmtCtx.ErrCtx()
+	getHandleFromRow := func(row chunk.Row) (kv.Handle, error) {
+		if tblMeta.IsCommonHandle {
+			handleDatum := make([]types.Datum, 0, len(pkTypes))
+			for i, t := range pkTypes {
+				handleDatum = append(handleDatum, row.GetDatum(i, t))
+			}
+			handleBytes, err := codec.EncodeKey(w.sctx.GetSessionVars().StmtCtx.TimeZone(), nil, handleDatum...)
+			err = errCtx.HandleError(err)
+			if err != nil {
+				return nil, err
+			}
+			return kv.NewCommonHandle(handleBytes)
 		}
-		whereKey := fmt.Sprintf("((cast(%s as signed) - %d) %% %d)", md5Handle, offset, mod)
-		groupByKey := fmt.Sprintf("((cast(%s as signed) - %d) div %d %% %d)", md5Handle, offset, mod, bucketSize)
-		if !checkOnce {
+		return kv.IntHandle(row.GetInt64(0)), nil
+	}
+	getValueFromRow := func(row chunk.Row) ([]types.Datum, error) {
+		valueDatum := make([]types.Datum, 0, len(idxInfo.Columns))
+		for i, t := range idxInfo.Columns {
+			valueDatum = append(valueDatum, row.GetDatum(i+len(pkCols), &tblMeta.Columns[t.Offset].FieldType))
+		}
+		return valueDatum, nil
+	}
+	getRowChecksum := func(row chunk.Row) uint64 {
+		return row.GetUint64(len(pkCols) + len(idxInfo.Columns))
+	}
+
+	buildRecordData := func(row chunk.Row) (*consistency.RecordData, error) {
+		handle, err := getHandleFromRow(row)
+		if err != nil {
+			return nil, err
+		}
+		value, err := getValueFromRow(row)
+		if err != nil {
+			return nil, err
+		}
+		return &consistency.RecordData{Handle: handle, Values: value}, nil
+	}
+	cloneRecordData := func(record *consistency.RecordData) *consistency.RecordData {
+		if record == nil {
+			return nil
+		}
+		return &consistency.RecordData{Handle: record.Handle, Values: types.CloneRow(record.Values)}
+	}
+	newReporter := func() *consistency.Reporter {
+		return &consistency.Reporter{
+			HandleEncode: func(handle kv.Handle) kv.Key {
+				return tablecodec.EncodeRecordKey(w.table.RecordPrefix(), handle)
+			},
+			IndexEncode: func(idxRow *consistency.RecordData) kv.Key {
+				var idx table.Index
+				for _, v := range w.table.Indices() {
+					if strings.EqualFold(v.Meta().Name.String(), idxInfo.Name.O) {
+						idx = v
+						break
+					}
+				}
+				if idx == nil {
+					return nil
+				}
+				sc := w.sctx.GetSessionVars().StmtCtx
+				k, _, err := idx.GenIndexKey(sc.ErrCtx(), sc.TimeZone(), idxRow.Values[:len(idx.Meta().Columns)], idxRow.Handle, nil)
+				if err != nil {
+					return nil
+				}
+				return k
+			},
+			Tbl:             tblMeta,
+			Idx:             idxInfo,
+			EnableRedactLog: w.sctx.GetSessionVars().EnableRedactLog,
+			Storage:         w.sctx.GetStore(),
+		}
+	}
+	reportInconsistent := func(reporter *consistency.Reporter, mismatchType AdminCheckIndexInconsistentType, handle kv.Handle, idxRecord, tblRecord *consistency.RecordData) bool {
+		err := reporter.ReportAdminCheckInconsistent(w.e.contextCtx, handle, idxRecord, tblRecord)
+		if err == nil {
+			return false
+		}
+		if w.e.collector == nil {
+			trySaveErr(err)
+			return true
+		}
+		w.e.collector.recordInconsistent(handle.String(), mismatchType, err)
+		return false
+	}
+
+	compareChecksumBuckets := func(tableChecksum, indexChecksum []groupByChecksum) []mismatchBucket {
+		mismatch := make([]mismatchBucket, 0)
+		i, j := 0, 0
+		for i < len(tableChecksum) && j < len(indexChecksum) {
+			if tableChecksum[i].bucket == indexChecksum[j].bucket {
+				if tableChecksum[i].checksum != indexChecksum[j].checksum {
+					mismatch = append(mismatch, mismatchBucket{bucket: tableChecksum[i].bucket, count: max(tableChecksum[i].count, indexChecksum[j].count)})
+				}
+				i++
+				j++
+				continue
+			}
+			if tableChecksum[i].bucket < indexChecksum[j].bucket {
+				mismatch = append(mismatch, mismatchBucket{bucket: tableChecksum[i].bucket, count: tableChecksum[i].count})
+				i++
+				continue
+			}
+			mismatch = append(mismatch, mismatchBucket{bucket: indexChecksum[j].bucket, count: indexChecksum[j].count})
+			j++
+		}
+		for ; i < len(tableChecksum); i++ {
+			mismatch = append(mismatch, mismatchBucket{bucket: tableChecksum[i].bucket, count: tableChecksum[i].count})
+		}
+		for ; j < len(indexChecksum); j++ {
+			mismatch = append(mismatch, mismatchBucket{bucket: indexChecksum[j].bucket, count: indexChecksum[j].count})
+		}
+		return mismatch
+	}
+	sumChecksumCount := func(checksums []groupByChecksum) int64 {
+		total := int64(0)
+		for _, checksum := range checksums {
+			total += checksum.count
+		}
+		return total
+	}
+	buildChecksumQueries := func(task checksumBucketTask, forceRoot bool) (tblQuery, idxQuery string) {
+		whereKey := fmt.Sprintf("((cast(%s as signed) - %d) %% %d)", md5Handle, task.offset, task.mod)
+		if forceRoot {
 			whereKey = "0"
 		}
-		checkOnce = true
+		groupByKey := fmt.Sprintf("((cast(%s as signed) - %d) div %d %% %d)", md5Handle, task.offset, task.mod, bucketSize)
+		tblQuery = fmt.Sprintf(
+			"select /*+ read_from_storage(tikv[%s]) */ bit_xor(%s), %s, count(*) from %s use index() where %s = 0 group by %s",
+			tblName, md5HandleAndIndexCol, groupByKey, tblName, whereKey, groupByKey)
+		idxQuery = fmt.Sprintf(
+			"select bit_xor(%s), %s, count(*) from %s use index(`%s`) where %s = 0 group by %s",
+			md5HandleAndIndexCol, groupByKey, tblName, idxInfo.Name, whereKey, groupByKey)
+		return tblQuery, idxQuery
+	}
+	buildRowQueries := func(task checksumBucketTask) (tableSQL, indexSQL string) {
+		groupByKey := fmt.Sprintf("((cast(%s as signed) - %d) %% %d)", md5Handle, task.offset, task.mod)
+		indexSQL = fmt.Sprintf(
+			"select %s, %s, %s from %s use index(`%s`) where %s = 0 order by %s",
+			handleColumns, indexColumns, md5HandleAndIndexCol, tblName, idxInfo.Name, groupByKey, handleColumns)
+		tableSQL = fmt.Sprintf(
+			"select /*+ read_from_storage(tikv[%s]) */ %s, %s, %s from %s use index() where %s = 0 order by %s",
+			tblName, handleColumns, indexColumns, md5HandleAndIndexCol, tblName, groupByKey, handleColumns)
+		return tableSQL, indexSQL
+	}
+	nextRecord := func(stream *leafRowStream) (*consistency.RecordData, chunk.Row, bool, error) {
+		row, ok, err := stream.Next()
+		if err != nil || !ok {
+			return nil, chunk.Row{}, ok, err
+		}
+		record, err := buildRecordData(row)
+		if err != nil {
+			return nil, chunk.Row{}, false, err
+		}
+		return record, row, true, nil
+	}
+	checkLeafBucket := func(task checksumBucketTask) bool {
+		tableSQL, indexSQL := buildRowQueries(task)
+		tableStream, err := newLeafRowStream(ctx, se, tableSQL)
+		if err != nil {
+			return reportErr(err)
+		}
+		defer tableStream.Close()
+		indexStream, err := newLeafRowStream(ctx, se, indexSQL)
+		if err != nil {
+			return reportErr(err)
+		}
+		defer indexStream.Close()
 
-		tblQuery := fmt.Sprintf(
-			"select /*+ read_from_storage(tikv[%s]), AGG_TO_COP() */ bit_xor(%s), %s, count(*) from %s use index() where %s(%s = 0) group by %s",
-			tblName, md5HandleAndIndexCol, groupByKey, tblName, idxCondition, whereKey, groupByKey)
-		idxQuery := fmt.Sprintf(
-			"select /*+ AGG_TO_COP() */ bit_xor(%s), %s, count(*) from %s use index(`%s`) where %s (%s = 0) group by%s",
-			md5HandleAndIndexCol, groupByKey, tblName, idxInfo.Name, idxCondition, whereKey, groupByKey)
+		reporter := newReporter()
+		var lastTableRecord *consistency.RecordData
+		tableRecord, tableRow, hasTable, err := nextRecord(tableStream)
+		if err != nil {
+			return reportErr(err)
+		}
+		indexRecord, indexRow, hasIndex, err := nextRecord(indexStream)
+		if err != nil {
+			return reportErr(err)
+		}
+		// Merge two ordered streams by handle and classify each mismatch.
+		for hasTable || hasIndex {
+			switch {
+			case !hasTable:
+				if lastTableRecord != nil && lastTableRecord.Handle.Equal(indexRecord.Handle) {
+					tableRecord = lastTableRecord
+				}
+				if reportInconsistent(reporter, AdminCheckIndexIndexWithoutRow, indexRecord.Handle, indexRecord, tableRecord) {
+					return true
+				}
+				indexRecord, indexRow, hasIndex, err = nextRecord(indexStream)
+				if err != nil {
+					return reportErr(err)
+				}
+			case !hasIndex:
+				if reportInconsistent(reporter, AdminCheckIndexRowWithoutIndex, tableRecord.Handle, nil, tableRecord) {
+					return true
+				}
+				lastTableRecord = cloneRecordData(tableRecord)
+				tableRecord, tableRow, hasTable, err = nextRecord(tableStream)
+				if err != nil {
+					return reportErr(err)
+				}
+			case tableRecord.Handle.Equal(indexRecord.Handle):
+				if getRowChecksum(tableRow) != getRowChecksum(indexRow) {
+					if reportInconsistent(reporter, AdminCheckIndexRowIndexMismatch, tableRecord.Handle, indexRecord, tableRecord) {
+						return true
+					}
+				}
+				lastTableRecord = cloneRecordData(tableRecord)
+				tableRecord, tableRow, hasTable, err = nextRecord(tableStream)
+				if err != nil {
+					return reportErr(err)
+				}
+				indexRecord, indexRow, hasIndex, err = nextRecord(indexStream)
+				if err != nil {
+					return reportErr(err)
+				}
+			case tableRecord.Handle.Compare(indexRecord.Handle) < 0:
+				if reportInconsistent(reporter, AdminCheckIndexRowWithoutIndex, tableRecord.Handle, nil, tableRecord) {
+					return true
+				}
+				lastTableRecord = cloneRecordData(tableRecord)
+				tableRecord, tableRow, hasTable, err = nextRecord(tableStream)
+				if err != nil {
+					return reportErr(err)
+				}
+			default:
+				compareTableRecord := lastTableRecord
+				if compareTableRecord != nil && compareTableRecord.Handle.Equal(indexRecord.Handle) {
+					if reportInconsistent(reporter, AdminCheckIndexRowIndexMismatch, indexRecord.Handle, indexRecord, compareTableRecord) {
+						return true
+					}
+				} else if reportInconsistent(reporter, AdminCheckIndexIndexWithoutRow, indexRecord.Handle, indexRecord, nil) {
+					return true
+				}
+				indexRecord, indexRow, hasIndex, err = nextRecord(indexStream)
+				if err != nil {
+					return reportErr(err)
+				}
+			}
+		}
+		return false
+	}
 
-		logger := logutil.BgLogger().With(
+	queue := make([]checksumBucketTask, 0, 16)
+	queue = append(queue, checksumBucketTask{offset: 0, mod: 1, depth: 0})
+	const maxRefineDepth = 10
+	for len(queue) > 0 {
+		task := queue[0]
+		queue = queue[1:]
+
+		tblQuery, idxQuery := buildChecksumQueries(task, task.depth == 0)
+		logutil.BgLogger().Info(
+			"fast check table by group",
 			zap.String("table name", tblMeta.Name.String()),
 			zap.String("index name", idxInfo.Name.String()),
-			zap.Int("times", times),
-			zap.Int("current offset", offset), zap.Int("current mod", mod),
-			zap.Int("bucket size", bucketSize),
+			zap.Int("depth", task.depth),
+			zap.Int("current offset", task.offset),
+			zap.Int("current mod", task.mod),
+			zap.String("table sql", tblQuery),
+			zap.String("index sql", idxQuery),
 		)
-		logger.Info("fast check table by group",
-			zap.String("table sql", tblQuery), zap.String("index sql", idxQuery))
 
-		// compute table side checksum.
 		tableChecksum, err := getCheckSum(w.e.contextCtx, se, tblQuery)
 		if err != nil {
-			return err
+			reportErr(err)
+			return
 		}
 		slices.SortFunc(tableChecksum, func(i, j groupByChecksum) int {
 			return cmp.Compare(i.bucket, j.bucket)
 		})
-
-		// compute index side checksum.
-		intest.AssertFunc(func() bool {
-			return verifyIndexSideQuery(ctx, se, idxQuery)
-		}, "index side query plan is not correct: %s", idxQuery)
 		indexChecksum, err := getCheckSum(w.e.contextCtx, se, idxQuery)
 		if err != nil {
-			return err
+			reportErr(err)
+			return
 		}
 		slices.SortFunc(indexChecksum, func(i, j groupByChecksum) int {
 			return cmp.Compare(i.bucket, j.bucket)
 		})
-
-		tableChecksumMap, indexChecksumMap := make(map[uint64]groupByChecksum), make(map[uint64]groupByChecksum)
-		for _, c := range tableChecksum {
-			tableChecksumMap[c.bucket] = c
+		if task.depth == 0 {
+			logutil.BgLogger().Info(
+				"fast check index root row count",
+				zap.String("table name", tblMeta.Name.String()),
+				zap.String("index name", idxInfo.Name.String()),
+				zap.Int64("table row count", sumChecksumCount(tableChecksum)),
+				zap.Int64("index row count", sumChecksumCount(indexChecksum)),
+			)
 		}
-		for _, c := range indexChecksum {
-			indexChecksumMap[c.bucket] = c
-		}
 
-		for bktIdx := range bucketSize {
-			tblBktSum, tblOk := tableChecksumMap[uint64(bktIdx)]
-			idxBktSum, idxOk := indexChecksumMap[uint64(bktIdx)]
-			if tblOk {
-				if idxOk {
-					if tblBktSum.checksum != idxBktSum.checksum || tblBktSum.count != idxBktSum.count {
-						logger.Info("found different checksum in the same bucket",
-							zap.Int("bucket", bktIdx), zap.Stringer("tblBktSum", tblBktSum),
-							zap.Stringer("idxBktSum", idxBktSum))
-					}
-				} else {
-					logger.Info("found bucket only exists in table side",
-						zap.Int("bucket", bktIdx), zap.Stringer("tblBktSum", tblBktSum))
-				}
-			} else {
-				if !idxOk {
-					continue
-				}
-				logger.Info("found bucket only exists in index side",
-					zap.Int("bucket", bktIdx), zap.Stringer("idxBktSum", idxBktSum))
+		mismatches := compareChecksumBuckets(tableChecksum, indexChecksum)
+		if len(mismatches) == 0 {
+			continue
+		}
+		// Fast path keeps original fail-fast behavior; collector mode keeps all mismatches.
+		if w.e.collector == nil {
+			mismatches = mismatches[:1]
+		}
+		for _, mismatch := range mismatches {
+			nextTask := checksumBucketTask{
+				offset: task.offset + int(mismatch.bucket)*task.mod,
+				mod:    task.mod * bucketSize,
+				depth:  task.depth + 1,
 			}
-		}
-
-		currentOffset := 0
-
-		meetError = false
-		// Every checksum in table side should be the same as the index side.
-		i := 0
-		for i < len(tableChecksum) && i < len(indexChecksum) {
-			if tableChecksum[i].bucket != indexChecksum[i].bucket || tableChecksum[i].checksum != indexChecksum[i].checksum {
-				if tableChecksum[i].bucket <= indexChecksum[i].bucket {
-					currentOffset = int(tableChecksum[i].bucket)
-					tableRowCntToCheck = tableChecksum[i].count
-				} else {
-					currentOffset = int(indexChecksum[i].bucket)
-					tableRowCntToCheck = indexChecksum[i].count
+			if nextTask.mod <= 0 {
+				if checkLeafBucket(task) {
+					return
 				}
-				meetError = true
+				if w.e.collector == nil {
+					break
+				}
+				continue
+			}
+			if w.e.collector == nil && (mismatch.count <= lookupCheckThreshold || nextTask.depth >= maxRefineDepth) {
+				if checkLeafBucket(nextTask) {
+					return
+				}
 				break
 			}
-			i++
-		}
-
-		if !meetError && i < len(indexChecksum) && i == len(tableChecksum) {
-			// Table side has fewer buckets.
-			currentOffset = int(indexChecksum[i].bucket)
-			tableRowCntToCheck = indexChecksum[i].count
-			meetError = true
-		} else if !meetError && i < len(tableChecksum) && i == len(indexChecksum) {
-			// Index side has fewer buckets.
-			currentOffset = int(tableChecksum[i].bucket)
-			tableRowCntToCheck = tableChecksum[i].count
-			meetError = true
-		}
-
-		if !meetError {
-			if times != 1 {
-				logutil.BgLogger().Error(
-					"unexpected result, no error detected in this round, but an error is detected in the previous round",
-					zap.Int("times", times), zap.Int("offset", offset), zap.Int("mod", mod))
-			}
-			break
-		}
-
-		offset += currentOffset * mod
-		mod *= bucketSize
-	}
-
-	if meetError {
-		groupByKey := fmt.Sprintf("((cast(%s as signed) - %d) %% %d)", md5Handle, offset, mod)
-		indexSQL := fmt.Sprintf(
-			"select /*+ AGG_TO_COP() */ %s, %s, %s from %s use index(`%s`) where %s(%s = 0) order by %s",
-			handleColumns, indexColumns, md5HandleAndIndexCol, tblName, idxInfo.Name, idxCondition, groupByKey, handleColumns)
-		tableSQL := fmt.Sprintf(
-			"select /*+ read_from_storage(tikv[%s]), AGG_TO_COP() */ %s, %s, %s from %s use index() where %s(%s = 0) order by %s",
-			tblName, handleColumns, indexColumns, md5HandleAndIndexCol, tblName, idxCondition, groupByKey, handleColumns)
-		intest.AssertFunc(func() bool {
-			return verifyIndexSideQuery(ctx, se, indexSQL)
-		}, "index side query plan is not correct: %s", indexSQL)
-		idxRow, err := queryToRow(ctx, se, indexSQL)
-		if err != nil {
-			return err
-		}
-		tblRow, err := queryToRow(ctx, se, tableSQL)
-		if err != nil {
-			return err
-		}
-
-		errCtx := w.sctx.GetSessionVars().StmtCtx.ErrCtx()
-		getHandleFromRow := func(row chunk.Row) (kv.Handle, error) {
-			if tblMeta.IsCommonHandle {
-				handleDatum := make([]types.Datum, 0)
-				for i, t := range pkTypes {
-					handleDatum = append(handleDatum, row.GetDatum(i, t))
+			if w.e.collector != nil && (mismatch.count <= 1 || nextTask.depth >= maxRefineDepth) {
+				if checkLeafBucket(nextTask) {
+					return
 				}
-				handleBytes, err := codec.EncodeKey(w.sctx.GetSessionVars().StmtCtx.TimeZone(), nil, handleDatum...)
-				err = errCtx.HandleError(err)
-				if err != nil {
-					return nil, err
-				}
-				return kv.NewCommonHandle(handleBytes)
+				continue
 			}
-			return kv.IntHandle(row.GetInt64(0)), nil
-		}
-		getValueFromRow := func(row chunk.Row) ([]types.Datum, error) {
-			valueDatum := make([]types.Datum, 0)
-			for i, t := range idxInfo.Columns {
-				valueDatum = append(valueDatum, row.GetDatum(i+len(pkCols), &tblMeta.Columns[t.Offset].FieldType))
-			}
-			return valueDatum, nil
-		}
-
-		ir := func() *consistency.Reporter {
-			return &consistency.Reporter{
-				HandleEncode: func(handle kv.Handle) kv.Key {
-					return tablecodec.EncodeRecordKey(w.table.RecordPrefix(), handle)
-				},
-				IndexEncode: func(idxRow *consistency.RecordData) kv.Key {
-					var idx table.Index
-					for _, v := range w.table.Indices() {
-						if strings.EqualFold(v.Meta().Name.String(), idxInfo.Name.O) {
-							idx = v
-							break
-						}
-					}
-					if idx == nil {
-						return nil
-					}
-					sc := w.sctx.GetSessionVars().StmtCtx
-					k, _, err := idx.GenIndexKey(sc.ErrCtx(), sc.TimeZone(), idxRow.Values[:len(idx.Meta().Columns)], idxRow.Handle, nil)
-					if err != nil {
-						return nil
-					}
-					return k
-				},
-				Tbl:             tblMeta,
-				Idx:             idxInfo,
-				EnableRedactLog: w.sctx.GetSessionVars().EnableRedactLog,
-				Storage:         w.sctx.GetStore(),
-			}
-		}
-
-		getCheckSum := func(row chunk.Row) uint64 {
-			return row.GetUint64(len(pkCols) + len(idxInfo.Columns))
-		}
-
-		var handle kv.Handle
-		var tableRecord *consistency.RecordData
-		var lastTableRecord *consistency.RecordData
-		var indexRecord *consistency.RecordData
-		i := 0
-		for i < len(tblRow) || i < len(idxRow) {
-			if i == len(tblRow) {
-				// No more rows in table side.
-				tableRecord = nil
-			} else {
-				handle, err = getHandleFromRow(tblRow[i])
-				if err != nil {
-					return err
-				}
-				value, err := getValueFromRow(tblRow[i])
-				if err != nil {
-					return err
-				}
-				tableRecord = &consistency.RecordData{Handle: handle, Values: value}
-			}
-			if i == len(idxRow) {
-				// No more rows in index side.
-				indexRecord = nil
-			} else {
-				indexHandle, err := getHandleFromRow(idxRow[i])
-				if err != nil {
-					return err
-				}
-				indexValue, err := getValueFromRow(idxRow[i])
-				if err != nil {
-					return err
-				}
-				indexRecord = &consistency.RecordData{Handle: indexHandle, Values: indexValue}
-			}
-
-			if tableRecord == nil {
-				if lastTableRecord != nil && lastTableRecord.Handle.Equal(indexRecord.Handle) {
-					tableRecord = lastTableRecord
-				}
-				err = ir().ReportAdminCheckInconsistent(w.e.contextCtx, indexRecord.Handle, indexRecord, tableRecord)
-			} else if indexRecord == nil {
-				err = ir().ReportAdminCheckInconsistent(w.e.contextCtx, tableRecord.Handle, indexRecord, tableRecord)
-			} else if tableRecord.Handle.Equal(indexRecord.Handle) && getCheckSum(tblRow[i]) != getCheckSum(idxRow[i]) {
-				err = ir().ReportAdminCheckInconsistent(w.e.contextCtx, tableRecord.Handle, indexRecord, tableRecord)
-			} else if !tableRecord.Handle.Equal(indexRecord.Handle) {
-				if tableRecord.Handle.Compare(indexRecord.Handle) < 0 {
-					err = ir().ReportAdminCheckInconsistent(w.e.contextCtx, tableRecord.Handle, nil, tableRecord)
-				} else {
-					if lastTableRecord != nil && lastTableRecord.Handle.Equal(indexRecord.Handle) {
-						err = ir().ReportAdminCheckInconsistent(w.e.contextCtx, indexRecord.Handle, indexRecord, lastTableRecord)
-					} else {
-						err = ir().ReportAdminCheckInconsistent(w.e.contextCtx, indexRecord.Handle, indexRecord, nil)
-					}
-				}
-			}
-			if err != nil {
-				return err
-			}
-			i++
-			if tableRecord != nil {
-				lastTableRecord = &consistency.RecordData{Handle: tableRecord.Handle, Values: tableRecord.Values}
-			} else {
-				lastTableRecord = nil
+			queue = append(queue, nextTask)
+			if w.e.collector == nil {
+				break
 			}
 		}
 	}
-
-	return nil
 }
 
 // Close implements the Worker interface.
-func (*checkIndexWorker) Close() error {
-	return nil
-}
+func (*checkIndexWorker) Close() {}
 
 type checkIndexTask struct {
 	indexOffset int
+	err         *atomic.Pointer[error]
 }
 
 // RecoverArgs implements workerpool.TaskMayPanic interface.
-func (checkIndexTask) RecoverArgs() (metricsLabel string, funcInfo string, err error) {
-	return "fast_check_table", "checkIndexTask", nil
+func (c checkIndexTask) RecoverArgs() (metricsLabel string, funcInfo string, recoverFn func(), quit bool) {
+	return "fast_check_table", "RecoverArgs", func() {
+		err := errors.Errorf("checkIndexTask panicked, indexOffset: %d", c.indexOffset)
+		c.err.CompareAndSwap(nil, &err)
+	}, false
 }
 
 type groupByChecksum struct {
@@ -864,15 +957,8 @@ type groupByChecksum struct {
 	count    int64
 }
 
-func (c groupByChecksum) String() string {
-	return fmt.Sprintf("{bkt:%d,sum:%d,cnt:%d}", c.bucket, c.checksum, c.count)
-}
-
 func getCheckSum(ctx context.Context, se sessionctx.Context, sql string) ([]groupByChecksum, error) {
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnAdmin)
-	// Create a new ExecDetails for the internal SQL to avoid data race with the parent statement.
-	// The parent context may carry an ExecDetails that is still being written to by concurrent goroutines.
-	ctx = execdetails.ContextWithInitializedExecDetails(ctx)
 	rs, err := se.GetSQLExecutor().ExecuteInternal(ctx, sql)
 	if err != nil {
 		return nil, err
@@ -892,35 +978,6 @@ func getCheckSum(ctx context.Context, se sessionctx.Context, sql string) ([]grou
 		checksums = append(checksums, groupByChecksum{bucket: row.GetUint64(1), checksum: row.GetUint64(0), count: row.GetInt64(2)})
 	}
 	return checksums, nil
-}
-
-func getGlobalCheckSum(ctx context.Context, se sessionctx.Context, sql string) (checksum uint64, count int64, err error) {
-	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnAdmin)
-	rs, err := se.GetSQLExecutor().ExecuteInternal(ctx, sql)
-	if err != nil {
-		return 0, 0, err
-	}
-	defer func(rs sqlexec.RecordSet) {
-		err := rs.Close()
-		if err != nil {
-			logutil.BgLogger().Error("close record set failed", zap.Error(err))
-		}
-	}(rs)
-
-	rows, err := sqlexec.DrainRecordSet(ctx, rs, 1)
-	if err != nil {
-		return 0, 0, err
-	}
-	if len(rows) == 0 {
-		return 0, 0, nil
-	}
-
-	row := rows[0]
-	if !row.IsNull(0) {
-		checksum = row.GetUint64(0)
-	}
-	count = row.GetInt64(1)
-	return checksum, count, nil
 }
 
 // TableName returns `schema`.`table`

--- a/pkg/executor/check_table_index.go
+++ b/pkg/executor/check_table_index.go
@@ -360,6 +360,15 @@ func (c *AdminCheckIndexInconsistentCollector) recordErr(err error) {
 	c.mu.Unlock()
 }
 
+func (c *AdminCheckIndexInconsistentCollector) reachedLimit() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.collectLimit > 0 && len(c.rows) >= c.collectLimit
+}
+
 func (c *AdminCheckIndexInconsistentCollector) firstErr() error {
 	if c == nil {
 		return nil
@@ -520,7 +529,7 @@ type checkIndexWorker struct {
 	e          *FastCheckTableExec
 }
 
-func (w *checkIndexWorker) initSessCtx(se sessionctx.Context) (restore func()) {
+func (w *checkIndexWorker) initSessCtx(execCtx context.Context, se sessionctx.Context) (restore func()) {
 	sessVars := se.GetSessionVars()
 	srcVars := w.sctx.GetSessionVars()
 
@@ -548,7 +557,7 @@ func (w *checkIndexWorker) initSessCtx(se sessionctx.Context) (restore func()) {
 
 	snapshot := w.e.Ctx().GetSessionVars().SnapshotTS
 	if snapshot != 0 {
-		_, err := se.GetSQLExecutor().ExecuteInternal(w.e.contextCtx, fmt.Sprintf("set session tidb_snapshot = %d", snapshot))
+		_, err := se.GetSQLExecutor().ExecuteInternal(execCtx, fmt.Sprintf("set session tidb_snapshot = %d", snapshot))
 		if err != nil {
 			logutil.BgLogger().Error("fail to set tidb_snapshot", zap.Error(err), zap.Uint64("snapshot ts", snapshot))
 		}
@@ -565,7 +574,7 @@ func (w *checkIndexWorker) initSessCtx(se sessionctx.Context) (restore func()) {
 			sessVars.MemTracker.SetBytesLimit(originMemTrackerBytesLimit)
 		}
 		if snapshot != 0 {
-			_, err := se.GetSQLExecutor().ExecuteInternal(w.e.contextCtx, "set session tidb_snapshot = 0")
+			_, err := se.GetSQLExecutor().ExecuteInternal(execCtx, "set session tidb_snapshot = 0")
 			if err != nil {
 				logutil.BgLogger().Error("fail to set tidb_snapshot to 0", zap.Error(err))
 			}
@@ -573,12 +582,42 @@ func (w *checkIndexWorker) initSessCtx(se sessionctx.Context) (restore func()) {
 	}
 }
 
+func quickPassGlobalChecksum(
+	ctx context.Context,
+	se sessionctx.Context,
+	tblName, idxName, rowChecksumExpr, idxCondition string,
+) (bool, error) {
+	quotedIdxName := ColumnName(idxName)
+	tableGlobalQuery := fmt.Sprintf(
+		"select /*+ read_from_storage(tikv[%s]), AGG_TO_COP() */ bit_xor(%s), count(*) from %s use index() where %s(0 = 0)",
+		tblName, rowChecksumExpr, tblName, idxCondition,
+	)
+	indexGlobalQuery := fmt.Sprintf(
+		"select /*+ AGG_TO_COP() */ bit_xor(%s), count(*) from %s use index(%s) where %s(0 = 0)",
+		rowChecksumExpr, tblName, quotedIdxName, idxCondition,
+	)
+	tableGlobalChecksum, tableGlobalCnt, err := getGlobalCheckSum(ctx, se, tableGlobalQuery)
+	if err != nil {
+		return false, err
+	}
+	indexGlobalChecksum, indexGlobalCnt, err := getGlobalCheckSum(ctx, se, indexGlobalQuery)
+	if err != nil {
+		return false, err
+	}
+	return tableGlobalCnt == indexGlobalCnt && tableGlobalChecksum == indexGlobalChecksum, nil
+}
+
 // HandleTask implements the Worker interface.
 func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.None)) (retErr error) {
+	failpoint.Inject("mockFastCheckTableError", func() {
+		failpoint.Return(errors.New("mock fast check table error"))
+	})
+
 	idxInfo := w.indexInfos[task.indexOffset]
 	bucketSize := int(CheckTableFastBucketSize.Load())
 
 	ctx := kv.WithInternalSourceType(w.e.contextCtx, kv.InternalTxnAdmin)
+	ctx = execdetails.ContextWithInitializedExecDetails(ctx)
 
 	trySaveErr := func(err error) {
 		if err == nil {
@@ -609,7 +648,7 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 		trySaveErr(err)
 		return
 	}
-	restoreCtx := w.initSessCtx(se)
+	restoreCtx := w.initSessCtx(ctx, se)
 	defer func() {
 		restoreCtx()
 		w.e.BaseExecutor.ReleaseSysSession(ctx, se)
@@ -733,7 +772,10 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 		}
 	}
 	reportInconsistent := func(reporter *consistency.Reporter, mismatchType AdminCheckIndexInconsistentType, handle kv.Handle, idxRecord, tblRecord *consistency.RecordData) bool {
-		err := reporter.ReportAdminCheckInconsistent(w.e.contextCtx, handle, idxRecord, tblRecord)
+		if w.e.collector != nil && w.e.collector.reachedLimit() {
+			return false
+		}
+		err := reporter.ReportAdminCheckInconsistent(ctx, handle, idxRecord, tblRecord)
 		if err == nil {
 			return false
 		}
@@ -748,6 +790,20 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 	if idxInfo.HasCondition() {
 		idxCondition = fmt.Sprintf("(%s) AND ", idxInfo.ConditionExprString)
 	}
+	match, err := quickPassGlobalChecksum(ctx, se, tblName, idxInfo.Name.O, md5HandleAndIndexCol, idxCondition)
+	if err != nil {
+		trySaveErr(err)
+		return
+	}
+	failpoint.Inject("forceAdminCheckBucketed", func() {
+		match = false
+	})
+	if match {
+		return
+	}
+	failpoint.Inject("mockFastCheckTableBucketedCalled", func() {
+		failpoint.Return(errors.New("mock fast check table bucketed called"))
+	})
 
 	nextRecord := func(stream *leafRowStream) (*consistency.RecordData, chunk.Row, bool, error) {
 		row, ok, err := stream.Next()
@@ -868,7 +924,7 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 			zap.String("index sql", idxQuery),
 		)
 
-		tableChecksum, err := getCheckSum(w.e.contextCtx, se, tblQuery)
+		tableChecksum, err := getCheckSum(ctx, se, tblQuery)
 		if err != nil {
 			reportErr(err)
 			return
@@ -876,7 +932,7 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 		slices.SortFunc(tableChecksum, func(i, j groupByChecksum) int {
 			return cmp.Compare(i.bucket, j.bucket)
 		})
-		indexChecksum, err := getCheckSum(w.e.contextCtx, se, idxQuery)
+		indexChecksum, err := getCheckSum(ctx, se, idxQuery)
 		if err != nil {
 			reportErr(err)
 			return
@@ -1026,10 +1082,10 @@ func buildChecksumQueries(
 	}
 	groupByKey := fmt.Sprintf("((cast(%s as signed) - %d) div %d %% %d)", md5Handle, task.offset, task.mod, bucketSize)
 	tblQuery = fmt.Sprintf(
-		"select /*+ read_from_storage(tikv[%s]) */ bit_xor(%s), %s, count(*) from %s use index() where %s(%s = 0) group by %s",
+		"select /*+ read_from_storage(tikv[%s]), AGG_TO_COP() */ bit_xor(%s), %s, count(*) from %s use index() where %s(%s = 0) group by %s",
 		tblName, md5HandleAndIndexCol, groupByKey, tblName, idxCondition, whereKey, groupByKey)
 	idxQuery = fmt.Sprintf(
-		"select bit_xor(%s), %s, count(*) from %s use index(%s) where %s(%s = 0) group by %s",
+		"select /*+ AGG_TO_COP() */ bit_xor(%s), %s, count(*) from %s use index(%s) where %s(%s = 0) group by %s",
 		md5HandleAndIndexCol, groupByKey, tblName, quotedIdxName, idxCondition, whereKey, groupByKey)
 	return tblQuery, idxQuery
 }
@@ -1043,10 +1099,10 @@ func buildRowQueries(
 	quotedIdxName := ColumnName(idxName)
 	groupByKey := fmt.Sprintf("((cast(%s as signed) - %d) %% %d)", md5Handle, task.offset, task.mod)
 	indexSQL = fmt.Sprintf(
-		"select %s, %s, %s from %s use index(%s) where %s(%s = 0) order by %s",
+		"select /*+ AGG_TO_COP() */ %s, %s, %s from %s use index(%s) where %s(%s = 0) order by %s",
 		handleColumns, indexColumns, md5HandleAndIndexCol, tblName, quotedIdxName, idxCondition, groupByKey, handleColumns)
 	tableSQL = fmt.Sprintf(
-		"select /*+ read_from_storage(tikv[%s]) */ %s, %s, %s from %s use index() where %s(%s = 0) order by %s",
+		"select /*+ read_from_storage(tikv[%s]), AGG_TO_COP() */ %s, %s, %s from %s use index() where %s(%s = 0) order by %s",
 		tblName, handleColumns, indexColumns, md5HandleAndIndexCol, tblName, idxCondition, groupByKey, handleColumns)
 	return tableSQL, indexSQL
 }
@@ -1105,6 +1161,35 @@ func getCheckSum(ctx context.Context, se sessionctx.Context, sql string) ([]grou
 		checksums = append(checksums, groupByChecksum{bucket: row.GetUint64(1), checksum: row.GetUint64(0), count: row.GetInt64(2)})
 	}
 	return checksums, nil
+}
+
+func getGlobalCheckSum(ctx context.Context, se sessionctx.Context, sql string) (checksum uint64, count int64, err error) {
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnAdmin)
+	ctx = execdetails.ContextWithInitializedExecDetails(ctx)
+	rs, err := se.GetSQLExecutor().ExecuteInternal(ctx, sql)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer func(rs sqlexec.RecordSet) {
+		err := rs.Close()
+		if err != nil {
+			logutil.BgLogger().Error("close record set failed", zap.Error(err))
+		}
+	}(rs)
+	rows, err := sqlexec.DrainRecordSet(ctx, rs, 1)
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(rows) == 0 {
+		return 0, 0, nil
+	}
+
+	row := rows[0]
+	if !row.IsNull(0) {
+		checksum = row.GetUint64(0)
+	}
+	count = row.GetInt64(1)
+	return checksum, count, nil
 }
 
 // TableName returns `schema`.`table`

--- a/pkg/executor/check_table_index.go
+++ b/pkg/executor/check_table_index.go
@@ -288,7 +288,7 @@ type AdminCheckIndexInconsistentCollector struct {
 	mu     sync.Mutex
 	first  error
 	rows   []AdminCheckIndexInconsistentRow
-	rowSet map[string]struct{}
+	rowSet map[AdminCheckIndexInconsistentRow]struct{}
 }
 
 // NewAdminCheckIndexInconsistentCollector creates an uncapped collector for fast `admin check index`.
@@ -304,7 +304,7 @@ func NewAdminCheckIndexInconsistentCollectorWithLimit(limit int) *AdminCheckInde
 	}
 	return &AdminCheckIndexInconsistentCollector{
 		collectLimit: limit,
-		rowSet:       make(map[string]struct{}),
+		rowSet:       make(map[AdminCheckIndexInconsistentRow]struct{}),
 	}
 }
 
@@ -313,7 +313,7 @@ func (c *AdminCheckIndexInconsistentCollector) recordInconsistent(
 	mismatchType AdminCheckIndexInconsistentType,
 	err error,
 ) {
-	if err == nil {
+	if c == nil || err == nil {
 		return
 	}
 
@@ -326,17 +326,15 @@ func (c *AdminCheckIndexInconsistentCollector) recordInconsistent(
 		return
 	}
 
-	// Deduplicate by (handle, mismatch_type) so one handle can still appear
-	// multiple times when different mismatch types are detected.
-	rowKey := handle + "\x00" + string(mismatchType)
-	if _, exists := c.rowSet[rowKey]; exists {
-		return
-	}
 	if c.collectLimit > 0 && len(c.rows) >= c.collectLimit {
 		return
 	}
-	c.rowSet[rowKey] = struct{}{}
-	c.rows = append(c.rows, AdminCheckIndexInconsistentRow{Handle: handle, MismatchType: mismatchType})
+	row := AdminCheckIndexInconsistentRow{Handle: handle, MismatchType: mismatchType}
+	if _, exists := c.rowSet[row]; exists {
+		return
+	}
+	c.rowSet[row] = struct{}{}
+	c.rows = append(c.rows, row)
 }
 
 func (c *AdminCheckIndexInconsistentCollector) recordErr(err error) {
@@ -703,65 +701,6 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 		return false
 	}
 
-	compareChecksumBuckets := func(tableChecksum, indexChecksum []groupByChecksum) []mismatchBucket {
-		mismatch := make([]mismatchBucket, 0)
-		i, j := 0, 0
-		for i < len(tableChecksum) && j < len(indexChecksum) {
-			if tableChecksum[i].bucket == indexChecksum[j].bucket {
-				if tableChecksum[i].checksum != indexChecksum[j].checksum {
-					mismatch = append(mismatch, mismatchBucket{bucket: tableChecksum[i].bucket, count: max(tableChecksum[i].count, indexChecksum[j].count)})
-				}
-				i++
-				j++
-				continue
-			}
-			if tableChecksum[i].bucket < indexChecksum[j].bucket {
-				mismatch = append(mismatch, mismatchBucket{bucket: tableChecksum[i].bucket, count: tableChecksum[i].count})
-				i++
-				continue
-			}
-			mismatch = append(mismatch, mismatchBucket{bucket: indexChecksum[j].bucket, count: indexChecksum[j].count})
-			j++
-		}
-		for ; i < len(tableChecksum); i++ {
-			mismatch = append(mismatch, mismatchBucket{bucket: tableChecksum[i].bucket, count: tableChecksum[i].count})
-		}
-		for ; j < len(indexChecksum); j++ {
-			mismatch = append(mismatch, mismatchBucket{bucket: indexChecksum[j].bucket, count: indexChecksum[j].count})
-		}
-		return mismatch
-	}
-	sumChecksumCount := func(checksums []groupByChecksum) int64 {
-		total := int64(0)
-		for _, checksum := range checksums {
-			total += checksum.count
-		}
-		return total
-	}
-	buildChecksumQueries := func(task checksumBucketTask, forceRoot bool) (tblQuery, idxQuery string) {
-		whereKey := fmt.Sprintf("((cast(%s as signed) - %d) %% %d)", md5Handle, task.offset, task.mod)
-		if forceRoot {
-			whereKey = "0"
-		}
-		groupByKey := fmt.Sprintf("((cast(%s as signed) - %d) div %d %% %d)", md5Handle, task.offset, task.mod, bucketSize)
-		tblQuery = fmt.Sprintf(
-			"select /*+ read_from_storage(tikv[%s]) */ bit_xor(%s), %s, count(*) from %s use index() where %s = 0 group by %s",
-			tblName, md5HandleAndIndexCol, groupByKey, tblName, whereKey, groupByKey)
-		idxQuery = fmt.Sprintf(
-			"select bit_xor(%s), %s, count(*) from %s use index(`%s`) where %s = 0 group by %s",
-			md5HandleAndIndexCol, groupByKey, tblName, idxInfo.Name, whereKey, groupByKey)
-		return tblQuery, idxQuery
-	}
-	buildRowQueries := func(task checksumBucketTask) (tableSQL, indexSQL string) {
-		groupByKey := fmt.Sprintf("((cast(%s as signed) - %d) %% %d)", md5Handle, task.offset, task.mod)
-		indexSQL = fmt.Sprintf(
-			"select %s, %s, %s from %s use index(`%s`) where %s = 0 order by %s",
-			handleColumns, indexColumns, md5HandleAndIndexCol, tblName, idxInfo.Name, groupByKey, handleColumns)
-		tableSQL = fmt.Sprintf(
-			"select /*+ read_from_storage(tikv[%s]) */ %s, %s, %s from %s use index() where %s = 0 order by %s",
-			tblName, handleColumns, indexColumns, md5HandleAndIndexCol, tblName, groupByKey, handleColumns)
-		return tableSQL, indexSQL
-	}
 	nextRecord := func(stream *leafRowStream) (*consistency.RecordData, chunk.Row, bool, error) {
 		row, ok, err := stream.Next()
 		if err != nil || !ok {
@@ -774,7 +713,7 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 		return record, row, true, nil
 	}
 	checkLeafBucket := func(task checksumBucketTask) bool {
-		tableSQL, indexSQL := buildRowQueries(task)
+		tableSQL, indexSQL := buildRowQueries(md5Handle, handleColumns, indexColumns, md5HandleAndIndexCol, tblName, idxInfo.Name.O, task)
 		tableStream, err := newLeafRowStream(ctx, se, tableSQL)
 		if err != nil {
 			return reportErr(err)
@@ -844,9 +783,8 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 					return reportErr(err)
 				}
 			default:
-				compareTableRecord := lastTableRecord
-				if compareTableRecord != nil && compareTableRecord.Handle.Equal(indexRecord.Handle) {
-					if reportInconsistent(reporter, AdminCheckIndexRowIndexMismatch, indexRecord.Handle, indexRecord, compareTableRecord) {
+				if lastTableRecord != nil && lastTableRecord.Handle.Equal(indexRecord.Handle) {
+					if reportInconsistent(reporter, AdminCheckIndexRowIndexMismatch, indexRecord.Handle, indexRecord, lastTableRecord) {
 						return true
 					}
 				} else if reportInconsistent(reporter, AdminCheckIndexIndexWithoutRow, indexRecord.Handle, indexRecord, nil) {
@@ -870,9 +808,8 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 		task := queue[0]
 		queue = queue[1:]
 
-		tblQuery, idxQuery := buildChecksumQueries(task, task.depth == 0)
-		logutil.BgLogger().Info(
-			"fast check table by group",
+		tblQuery, idxQuery := buildChecksumQueries(md5Handle, md5HandleAndIndexCol, tblName, idxInfo.Name.O, task, task.depth == 0, bucketSize)
+		logger := logutil.BgLogger().With(
 			zap.String("table name", tblMeta.Name.String()),
 			zap.String("index name", idxInfo.Name.String()),
 			zap.Int("depth", task.depth),
@@ -912,10 +849,33 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 		if len(mismatches) == 0 {
 			continue
 		}
-		// Fast path keeps original fail-fast behavior; collector mode keeps all mismatches.
+		logChecksumBucketDiffs(logger, tableChecksum, indexChecksum, bucketSize)
+
+		// Keep fail-fast behavior unchanged for SQL path.
 		if w.e.collector == nil {
-			mismatches = mismatches[:1]
+			mismatch := mismatches[0]
+			nextTask := checksumBucketTask{
+				offset: task.offset + int(mismatch.bucket)*task.mod,
+				mod:    task.mod * bucketSize,
+				depth:  task.depth + 1,
+			}
+			if nextTask.mod <= 0 {
+				if checkLeafBucket(task) {
+					return
+				}
+				continue
+			}
+			if mismatch.count <= lookupCheckThreshold || nextTask.depth >= maxRefineDepth {
+				if checkLeafBucket(nextTask) {
+					return
+				}
+				continue
+			}
+			queue = append(queue, nextTask)
+			continue
 		}
+
+		// Collector mode: keep refining all mismatched buckets and collect every mismatch.
 		for _, mismatch := range mismatches {
 			nextTask := checksumBucketTask{
 				offset: task.offset + int(mismatch.bucket)*task.mod,
@@ -926,30 +886,16 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 				if checkLeafBucket(task) {
 					return
 				}
-				if w.e.collector == nil {
-					break
-				}
 				continue
 			}
-			// Fail-fast mode: stop refining early once one candidate bucket is small enough.
-			if w.e.collector == nil && (mismatch.count <= lookupCheckThreshold || nextTask.depth >= maxRefineDepth) {
-				if checkLeafBucket(nextTask) {
-					return
-				}
-				break
-			}
-			// Collector mode: continue refining until row-level scan can enumerate
-			// all inconsistent handles deterministically.
-			if w.e.collector != nil && (mismatch.count <= 1 || nextTask.depth >= maxRefineDepth) {
+			// Continue refining until row-level scan can enumerate all inconsistent handles.
+			if mismatch.count <= 1 || nextTask.depth >= maxRefineDepth {
 				if checkLeafBucket(nextTask) {
 					return
 				}
 				continue
 			}
 			queue = append(queue, nextTask)
-			if w.e.collector == nil {
-				break
-			}
 		}
 	}
 }
@@ -976,6 +922,115 @@ type groupByChecksum struct {
 	count    int64
 }
 
+func (c groupByChecksum) String() string {
+	return fmt.Sprintf("{bkt:%d,sum:%d,cnt:%d}", c.bucket, c.checksum, c.count)
+}
+
+func compareChecksumBuckets(tableChecksum, indexChecksum []groupByChecksum) []mismatchBucket {
+	mismatch := make([]mismatchBucket, 0)
+	i, j := 0, 0
+	for i < len(tableChecksum) && j < len(indexChecksum) {
+		if tableChecksum[i].bucket == indexChecksum[j].bucket {
+			if tableChecksum[i].checksum != indexChecksum[j].checksum {
+				mismatch = append(mismatch, mismatchBucket{bucket: tableChecksum[i].bucket, count: max(tableChecksum[i].count, indexChecksum[j].count)})
+			}
+			i++
+			j++
+			continue
+		}
+		if tableChecksum[i].bucket < indexChecksum[j].bucket {
+			mismatch = append(mismatch, mismatchBucket{bucket: tableChecksum[i].bucket, count: tableChecksum[i].count})
+			i++
+			continue
+		}
+		mismatch = append(mismatch, mismatchBucket{bucket: indexChecksum[j].bucket, count: indexChecksum[j].count})
+		j++
+	}
+	for ; i < len(tableChecksum); i++ {
+		mismatch = append(mismatch, mismatchBucket{bucket: tableChecksum[i].bucket, count: tableChecksum[i].count})
+	}
+	for ; j < len(indexChecksum); j++ {
+		mismatch = append(mismatch, mismatchBucket{bucket: indexChecksum[j].bucket, count: indexChecksum[j].count})
+	}
+	return mismatch
+}
+
+func sumChecksumCount(checksums []groupByChecksum) int64 {
+	total := int64(0)
+	for _, checksum := range checksums {
+		total += checksum.count
+	}
+	return total
+}
+
+func buildChecksumQueries(
+	md5Handle, md5HandleAndIndexCol, tblName string,
+	idxName string,
+	task checksumBucketTask,
+	forceRoot bool,
+	bucketSize int,
+) (tblQuery, idxQuery string) {
+	whereKey := fmt.Sprintf("((cast(%s as signed) - %d) %% %d)", md5Handle, task.offset, task.mod)
+	if forceRoot {
+		whereKey = "0"
+	}
+	groupByKey := fmt.Sprintf("((cast(%s as signed) - %d) div %d %% %d)", md5Handle, task.offset, task.mod, bucketSize)
+	tblQuery = fmt.Sprintf(
+		"select /*+ read_from_storage(tikv[%s]) */ bit_xor(%s), %s, count(*) from %s use index() where %s = 0 group by %s",
+		tblName, md5HandleAndIndexCol, groupByKey, tblName, whereKey, groupByKey)
+	idxQuery = fmt.Sprintf(
+		"select bit_xor(%s), %s, count(*) from %s use index(`%s`) where %s = 0 group by %s",
+		md5HandleAndIndexCol, groupByKey, tblName, idxName, whereKey, groupByKey)
+	return tblQuery, idxQuery
+}
+
+func buildRowQueries(
+	md5Handle, handleColumns, indexColumns, md5HandleAndIndexCol, tblName string,
+	idxName string,
+	task checksumBucketTask,
+) (tableSQL, indexSQL string) {
+	groupByKey := fmt.Sprintf("((cast(%s as signed) - %d) %% %d)", md5Handle, task.offset, task.mod)
+	indexSQL = fmt.Sprintf(
+		"select %s, %s, %s from %s use index(`%s`) where %s = 0 order by %s",
+		handleColumns, indexColumns, md5HandleAndIndexCol, tblName, idxName, groupByKey, handleColumns)
+	tableSQL = fmt.Sprintf(
+		"select /*+ read_from_storage(tikv[%s]) */ %s, %s, %s from %s use index() where %s = 0 order by %s",
+		tblName, handleColumns, indexColumns, md5HandleAndIndexCol, tblName, groupByKey, handleColumns)
+	return tableSQL, indexSQL
+}
+
+func logChecksumBucketDiffs(logger *zap.Logger, tableChecksum, indexChecksum []groupByChecksum, bucketSize int) {
+	tableChecksumMap, indexChecksumMap := make(map[uint64]groupByChecksum), make(map[uint64]groupByChecksum)
+	for _, c := range tableChecksum {
+		tableChecksumMap[c.bucket] = c
+	}
+	for _, c := range indexChecksum {
+		indexChecksumMap[c.bucket] = c
+	}
+
+	for bktIdx := range bucketSize {
+		tblBktSum, tblOk := tableChecksumMap[uint64(bktIdx)]
+		idxBktSum, idxOk := indexChecksumMap[uint64(bktIdx)]
+		if tblOk {
+			if idxOk {
+				if tblBktSum.checksum != idxBktSum.checksum || tblBktSum.count != idxBktSum.count {
+					logger.Info("found different checksum in the same bucket",
+						zap.Int("bucket", bktIdx), zap.Stringer("tblBktSum", tblBktSum),
+						zap.Stringer("idxBktSum", idxBktSum))
+				}
+			} else {
+				logger.Info("found bucket only exists in table side",
+					zap.Int("bucket", bktIdx), zap.Stringer("tblBktSum", tblBktSum))
+			}
+		} else {
+			if !idxOk {
+				continue
+			}
+			logger.Info("found bucket only exists in index side",
+				zap.Int("bucket", bktIdx), zap.Stringer("idxBktSum", idxBktSum))
+		}
+	}
+}
 func getCheckSum(ctx context.Context, se sessionctx.Context, sql string) ([]groupByChecksum, error) {
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnAdmin)
 	rs, err := se.GetSQLExecutor().ExecuteInternal(ctx, sql)

--- a/pkg/executor/check_table_index.go
+++ b/pkg/executor/check_table_index.go
@@ -21,7 +21,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
@@ -223,7 +222,10 @@ func (e *CheckTableExec) checkTableRecord(ctx context.Context, idxOffset int) er
 		return err
 	}
 	if e.table.Meta().GetPartitionInfo() == nil {
-		idx := tables.NewIndex(e.table.Meta().ID, e.table.Meta(), idxInfo)
+		idx, err := tables.NewIndex(e.table.Meta().ID, e.table.Meta(), idxInfo)
+		if err != nil {
+			return err
+		}
 		return admin.CheckRecordAndIndex(ctx, e.Ctx(), txn, e.table, idx)
 	}
 
@@ -231,7 +233,10 @@ func (e *CheckTableExec) checkTableRecord(ctx context.Context, idxOffset int) er
 	for _, def := range info.Definitions {
 		pid := def.ID
 		partition := e.table.(table.PartitionedTable).GetPartition(pid)
-		idx := tables.NewIndex(def.ID, e.table.Meta(), idxInfo)
+		idx, err := tables.NewIndex(def.ID, e.table.Meta(), idxInfo)
+		if err != nil {
+			return err
+		}
 		if err := admin.CheckRecordAndIndex(ctx, e.Ctx(), txn, partition, idx); err != nil {
 			return errors.Trace(err)
 		}
@@ -250,9 +255,7 @@ type FastCheckTableExec struct {
 	table      table.Table
 	indexInfos []*model.IndexInfo
 	done       bool
-	err        *atomic.Pointer[error]
 	collector  *AdminCheckIndexInconsistentCollector
-	wg         sync.WaitGroup
 	contextCtx context.Context
 }
 
@@ -468,17 +471,23 @@ func (e *FastCheckTableExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 		e.Ctx().GetSessionVars().OptimizerUseInvisibleIndexes = false
 	}()
 
+	wctx := workerpool.NewContext(ctx)
+	taskCh := make(chan checkIndexTask)
 	workerPool := workerpool.NewWorkerPool("checkIndex",
 		poolutil.CheckTable, 3, e.createWorker)
-	workerPool.Start(ctx)
+	workerPool.SetTaskReceiver(taskCh)
+	workerPool.Start(wctx)
 
-	e.wg.Add(len(e.indexInfos))
+OUTER:
 	for i := range e.indexInfos {
-		workerPool.AddTask(checkIndexTask{indexOffset: i, err: e.err})
+		select {
+		case taskCh <- checkIndexTask{indexOffset: i}:
+		case <-wctx.Done():
+			break OUTER
+		}
 	}
-
-	e.wg.Wait()
-	workerPool.ReleaseAndWait()
+	close(taskCh)
+	workerPool.Release()
 
 	if e.collector != nil {
 		sessVars.FastCheckTableInconsistentSummary = e.collector.Summary()
@@ -487,11 +496,10 @@ func (e *FastCheckTableExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 		}
 	}
 
-	p := e.err.Load()
-	if p == nil {
-		return nil
+	if opErr := wctx.OperatorErr(); opErr != nil {
+		return opErr
 	}
-	return *p
+	return nil
 }
 
 func (e *FastCheckTableExec) createWorker() workerpool.Worker[checkIndexTask, workerpool.None] {
@@ -534,15 +542,19 @@ func (w *checkIndexWorker) initSessCtx(se sessionctx.Context) (restore func()) {
 }
 
 // HandleTask implements the Worker interface.
-func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.None)) {
-	defer w.e.wg.Done()
+func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.None)) (retErr error) {
 	idxInfo := w.indexInfos[task.indexOffset]
 	bucketSize := int(CheckTableFastBucketSize.Load())
 
 	ctx := kv.WithInternalSourceType(w.e.contextCtx, kv.InternalTxnAdmin)
 
 	trySaveErr := func(err error) {
-		w.e.err.CompareAndSwap(nil, &err)
+		if err == nil {
+			return
+		}
+		if retErr == nil {
+			retErr = err
+		}
 	}
 	reportErr := func(err error) bool {
 		if err == nil {
@@ -899,22 +911,21 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 			queue = append(queue, nextTask)
 		}
 	}
+	return retErr
 }
 
 // Close implements the Worker interface.
-func (*checkIndexWorker) Close() {}
+func (*checkIndexWorker) Close() error {
+	return nil
+}
 
 type checkIndexTask struct {
 	indexOffset int
-	err         *atomic.Pointer[error]
 }
 
 // RecoverArgs implements workerpool.TaskMayPanic interface.
-func (c checkIndexTask) RecoverArgs() (metricsLabel string, funcInfo string, recoverFn func(), quit bool) {
-	return "fast_check_table", "RecoverArgs", func() {
-		err := errors.Errorf("checkIndexTask panicked, indexOffset: %d", c.indexOffset)
-		c.err.CompareAndSwap(nil, &err)
-	}, false
+func (c checkIndexTask) RecoverArgs() (metricsLabel string, funcInfo string, err error) {
+	return "fast_check_table", "RecoverArgs", errors.Errorf("checkIndexTask panicked, indexOffset: %d", c.indexOffset)
 }
 
 type groupByChecksum struct {

--- a/pkg/executor/check_table_index.go
+++ b/pkg/executor/check_table_index.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -37,12 +39,16 @@ import (
 	"github.com/pingcap/tidb/pkg/util/admin"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
+	"github.com/pingcap/tidb/pkg/util/dbterror"
+	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/logutil/consistency"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	atomicutil "go.uber.org/atomic"
 	"go.uber.org/zap"
 )
+
+var errCheckPartialIndexWithoutFastCheck = dbterror.ClassExecutor.NewStd(errno.ErrCheckPartialIndexWithoutFastCheck)
 
 // CheckTableExec represents a check table executor.
 // It is built from the "admin check table" statement, and it checks if the
@@ -140,6 +146,9 @@ func (e *CheckTableExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	for _, idx := range e.indexInfos {
 		if idx.MVIndex || idx.IsColumnarIndex() {
 			continue
+		}
+		if idx.HasCondition() {
+			return errors.Trace(errCheckPartialIndexWithoutFastCheck)
 		}
 		idxNames = append(idxNames, idx.Name.O)
 	}
@@ -513,11 +522,30 @@ type checkIndexWorker struct {
 
 func (w *checkIndexWorker) initSessCtx(se sessionctx.Context) (restore func()) {
 	sessVars := se.GetSessionVars()
+	srcVars := w.sctx.GetSessionVars()
+
 	originOptUseInvisibleIdx := sessVars.OptimizerUseInvisibleIndexes
 	originMemQuotaQuery := sessVars.MemQuotaQuery
+	originDistSQLScanConcurrency := sessVars.DistSQLScanConcurrency()
+	originExecutorConcurrency := sessVars.ExecutorConcurrency
+	originMaxExecutionTime := sessVars.MaxExecutionTime
+	originTiKVClientReadTimeout := sessVars.TiKVClientReadTimeout
+	originMemTrackerBytesLimit := int64(0)
+	if sessVars.MemTracker != nil {
+		originMemTrackerBytesLimit = sessVars.MemTracker.GetBytesLimit()
+	}
 
 	sessVars.OptimizerUseInvisibleIndexes = true
-	sessVars.MemQuotaQuery = w.sctx.GetSessionVars().MemQuotaQuery
+	sessVars.MemQuotaQuery = srcVars.MemQuotaQuery
+	sessVars.SetDistSQLScanConcurrency(srcVars.DistSQLScanConcurrency())
+	sessVars.ExecutorConcurrency = srcVars.ExecutorConcurrency
+	sessVars.MaxExecutionTime = srcVars.MaxExecutionTime
+	sessVars.TiKVClientReadTimeout = srcVars.TiKVClientReadTimeout
+	if sessVars.MemTracker != nil {
+		sessVars.MemTracker.SetBytesLimit(sessVars.MemQuotaQuery)
+	}
+	failpoint.InjectCall("fastCheckTableAfterInitSessCtx", sessVars, new(error))
+
 	snapshot := w.e.Ctx().GetSessionVars().SnapshotTS
 	if snapshot != 0 {
 		_, err := se.GetSQLExecutor().ExecuteInternal(w.e.contextCtx, fmt.Sprintf("set session tidb_snapshot = %d", snapshot))
@@ -529,6 +557,13 @@ func (w *checkIndexWorker) initSessCtx(se sessionctx.Context) (restore func()) {
 	return func() {
 		sessVars.OptimizerUseInvisibleIndexes = originOptUseInvisibleIdx
 		sessVars.MemQuotaQuery = originMemQuotaQuery
+		sessVars.SetDistSQLScanConcurrency(originDistSQLScanConcurrency)
+		sessVars.ExecutorConcurrency = originExecutorConcurrency
+		sessVars.MaxExecutionTime = originMaxExecutionTime
+		sessVars.TiKVClientReadTimeout = originTiKVClientReadTimeout
+		if sessVars.MemTracker != nil {
+			sessVars.MemTracker.SetBytesLimit(originMemTrackerBytesLimit)
+		}
 		if snapshot != 0 {
 			_, err := se.GetSQLExecutor().ExecuteInternal(w.e.contextCtx, "set session tidb_snapshot = 0")
 			if err != nil {
@@ -709,6 +744,10 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 		w.e.collector.recordInconsistent(handle.String(), mismatchType, err)
 		return false
 	}
+	idxCondition := ""
+	if idxInfo.HasCondition() {
+		idxCondition = fmt.Sprintf("(%s) AND ", idxInfo.ConditionExprString)
+	}
 
 	nextRecord := func(stream *leafRowStream) (*consistency.RecordData, chunk.Row, bool, error) {
 		row, ok, err := stream.Next()
@@ -722,7 +761,7 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 		return record, row, true, nil
 	}
 	checkLeafBucket := func(task checksumBucketTask) bool {
-		tableSQL, indexSQL := buildRowQueries(md5Handle, handleColumns, indexColumns, md5HandleAndIndexCol, tblName, idxInfo.Name.O, task)
+		tableSQL, indexSQL := buildRowQueries(md5Handle, handleColumns, indexColumns, md5HandleAndIndexCol, tblName, idxInfo.Name.O, idxCondition, task)
 		tableStream, err := newLeafRowStream(ctx, se, tableSQL)
 		if err != nil {
 			return reportErr(err)
@@ -818,7 +857,7 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 		task := queue[0]
 		queue = queue[1:]
 
-		tblQuery, idxQuery := buildChecksumQueries(md5Handle, md5HandleAndIndexCol, tblName, idxInfo.Name.O, task, task.depth == 0, bucketSize)
+		tblQuery, idxQuery := buildChecksumQueries(md5Handle, md5HandleAndIndexCol, tblName, idxInfo.Name.O, idxCondition, task, task.depth == 0, bucketSize)
 		logger := logutil.BgLogger().With(
 			zap.String("table name", tblMeta.Name.String()),
 			zap.String("index name", idxInfo.Name.String()),
@@ -975,36 +1014,40 @@ func sumChecksumCount(checksums []groupByChecksum) int64 {
 func buildChecksumQueries(
 	md5Handle, md5HandleAndIndexCol, tblName string,
 	idxName string,
+	idxCondition string,
 	task checksumBucketTask,
 	forceRoot bool,
 	bucketSize int,
 ) (tblQuery, idxQuery string) {
+	quotedIdxName := ColumnName(idxName)
 	whereKey := fmt.Sprintf("((cast(%s as signed) - %d) %% %d)", md5Handle, task.offset, task.mod)
 	if forceRoot {
 		whereKey = "0"
 	}
 	groupByKey := fmt.Sprintf("((cast(%s as signed) - %d) div %d %% %d)", md5Handle, task.offset, task.mod, bucketSize)
 	tblQuery = fmt.Sprintf(
-		"select /*+ read_from_storage(tikv[%s]) */ bit_xor(%s), %s, count(*) from %s use index() where %s = 0 group by %s",
-		tblName, md5HandleAndIndexCol, groupByKey, tblName, whereKey, groupByKey)
+		"select /*+ read_from_storage(tikv[%s]) */ bit_xor(%s), %s, count(*) from %s use index() where %s(%s = 0) group by %s",
+		tblName, md5HandleAndIndexCol, groupByKey, tblName, idxCondition, whereKey, groupByKey)
 	idxQuery = fmt.Sprintf(
-		"select bit_xor(%s), %s, count(*) from %s use index(`%s`) where %s = 0 group by %s",
-		md5HandleAndIndexCol, groupByKey, tblName, idxName, whereKey, groupByKey)
+		"select bit_xor(%s), %s, count(*) from %s use index(%s) where %s(%s = 0) group by %s",
+		md5HandleAndIndexCol, groupByKey, tblName, quotedIdxName, idxCondition, whereKey, groupByKey)
 	return tblQuery, idxQuery
 }
 
 func buildRowQueries(
 	md5Handle, handleColumns, indexColumns, md5HandleAndIndexCol, tblName string,
 	idxName string,
+	idxCondition string,
 	task checksumBucketTask,
 ) (tableSQL, indexSQL string) {
+	quotedIdxName := ColumnName(idxName)
 	groupByKey := fmt.Sprintf("((cast(%s as signed) - %d) %% %d)", md5Handle, task.offset, task.mod)
 	indexSQL = fmt.Sprintf(
-		"select %s, %s, %s from %s use index(`%s`) where %s = 0 order by %s",
-		handleColumns, indexColumns, md5HandleAndIndexCol, tblName, idxName, groupByKey, handleColumns)
+		"select %s, %s, %s from %s use index(%s) where %s(%s = 0) order by %s",
+		handleColumns, indexColumns, md5HandleAndIndexCol, tblName, quotedIdxName, idxCondition, groupByKey, handleColumns)
 	tableSQL = fmt.Sprintf(
-		"select /*+ read_from_storage(tikv[%s]) */ %s, %s, %s from %s use index() where %s = 0 order by %s",
-		tblName, handleColumns, indexColumns, md5HandleAndIndexCol, tblName, groupByKey, handleColumns)
+		"select /*+ read_from_storage(tikv[%s]) */ %s, %s, %s from %s use index() where %s(%s = 0) order by %s",
+		tblName, handleColumns, indexColumns, md5HandleAndIndexCol, tblName, idxCondition, groupByKey, handleColumns)
 	return tableSQL, indexSQL
 }
 
@@ -1042,6 +1085,7 @@ func logChecksumBucketDiffs(logger *zap.Logger, tableChecksum, indexChecksum []g
 }
 func getCheckSum(ctx context.Context, se sessionctx.Context, sql string) ([]groupByChecksum, error) {
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnAdmin)
+	ctx = execdetails.ContextWithInitializedExecDetails(ctx)
 	rs, err := se.GetSQLExecutor().ExecuteInternal(ctx, sql)
 	if err != nil {
 		return nil, err

--- a/pkg/executor/check_table_index.go
+++ b/pkg/executor/check_table_index.go
@@ -740,9 +740,10 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 			switch {
 			case !hasTable:
 				if lastTableRecord != nil && lastTableRecord.Handle.Equal(indexRecord.Handle) {
-					tableRecord = lastTableRecord
-				}
-				if reportInconsistent(reporter, AdminCheckIndexIndexWithoutRow, indexRecord.Handle, indexRecord, tableRecord) {
+					if reportInconsistent(reporter, AdminCheckIndexRowIndexMismatch, indexRecord.Handle, indexRecord, lastTableRecord) {
+						return true
+					}
+				} else if reportInconsistent(reporter, AdminCheckIndexIndexWithoutRow, indexRecord.Handle, indexRecord, nil) {
 					return true
 				}
 				indexRecord, indexRow, hasIndex, err = nextRecord(indexStream)
@@ -931,7 +932,7 @@ func compareChecksumBuckets(tableChecksum, indexChecksum []groupByChecksum) []mi
 	i, j := 0, 0
 	for i < len(tableChecksum) && j < len(indexChecksum) {
 		if tableChecksum[i].bucket == indexChecksum[j].bucket {
-			if tableChecksum[i].checksum != indexChecksum[j].checksum {
+			if tableChecksum[i].checksum != indexChecksum[j].checksum || tableChecksum[i].count != indexChecksum[j].count {
 				mismatch = append(mismatch, mismatchBucket{bucket: tableChecksum[i].bucket, count: max(tableChecksum[i].count, indexChecksum[j].count)})
 			}
 			i++

--- a/pkg/executor/check_table_index.go
+++ b/pkg/executor/check_table_index.go
@@ -496,10 +496,7 @@ OUTER:
 		}
 	}
 
-	if opErr := wctx.OperatorErr(); opErr != nil {
-		return opErr
-	}
-	return nil
+	return wctx.OperatorErr()
 }
 
 func (e *FastCheckTableExec) createWorker() workerpool.Worker[checkIndexTask, workerpool.None] {

--- a/pkg/executor/check_table_index.go
+++ b/pkg/executor/check_table_index.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/resourcemanager/pool/workerpool"
 	poolutil "github.com/pingcap/tidb/pkg/resourcemanager/util"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/tablecodec"
@@ -268,30 +269,24 @@ type FastCheckTableExec struct {
 	contextCtx context.Context
 }
 
-// AdminCheckIndexInconsistentType describes the inconsistency category found by
-// fast `admin check index`.
-type AdminCheckIndexInconsistentType string
-
-const (
-	// AdminCheckIndexRowWithoutIndex means one table row exists but the index row is missing.
-	AdminCheckIndexRowWithoutIndex AdminCheckIndexInconsistentType = "row_without_index"
-	// AdminCheckIndexIndexWithoutRow means one index row exists but the table row is missing.
-	AdminCheckIndexIndexWithoutRow AdminCheckIndexInconsistentType = "index_without_row"
-	// AdminCheckIndexRowIndexMismatch means table and index rows both exist but values don't match.
-	AdminCheckIndexRowIndexMismatch AdminCheckIndexInconsistentType = "row_index_mismatch"
+// Type aliases for admin check index types defined in sessionctx/variable package.
+// These aliases are kept for backward compatibility.
+type (
+	// AdminCheckIndexInconsistentType describes the inconsistency category found by
+	// fast `admin check index`.
+	AdminCheckIndexInconsistentType = variable.AdminCheckIndexInconsistentType
+	// AdminCheckIndexInconsistentRow stores one inconsistent handle and mismatch type.
+	AdminCheckIndexInconsistentRow = variable.AdminCheckIndexInconsistentRow
+	// AdminCheckIndexInconsistentSummary is returned by HTTP API.
+	AdminCheckIndexInconsistentSummary = variable.AdminCheckIndexInconsistentSummary
 )
 
-// AdminCheckIndexInconsistentRow stores one inconsistent handle and mismatch type.
-type AdminCheckIndexInconsistentRow struct {
-	Handle       string                          `json:"handle"`
-	MismatchType AdminCheckIndexInconsistentType `json:"mismatch_type"`
-}
-
-// AdminCheckIndexInconsistentSummary is returned by HTTP API.
-type AdminCheckIndexInconsistentSummary struct {
-	InconsistentRowCount uint64                           `json:"inconsistent_row_count"`
-	Rows                 []AdminCheckIndexInconsistentRow `json:"rows"`
-}
+// Constants for admin check index inconsistency types.
+const (
+	AdminCheckIndexRowWithoutIndex  = variable.AdminCheckIndexRowWithoutIndex
+	AdminCheckIndexIndexWithoutRow  = variable.AdminCheckIndexIndexWithoutRow
+	AdminCheckIndexRowIndexMismatch = variable.AdminCheckIndexRowIndexMismatch
+)
 
 // AdminCheckIndexInconsistentCollector collects inconsistent handles for one statement execution.
 type AdminCheckIndexInconsistentCollector struct {
@@ -388,11 +383,13 @@ func (c *AdminCheckIndexInconsistentCollector) Summary() *AdminCheckIndexInconsi
 	rows := make([]AdminCheckIndexInconsistentRow, len(c.rows))
 	copy(rows, c.rows)
 	count := uint64(len(c.rows))
+	truncated := c.collectLimit > 0 && len(c.rows) >= c.collectLimit
 	c.mu.Unlock()
 
 	return &AdminCheckIndexInconsistentSummary{
-		InconsistentRowCount: count,
-		Rows:                 rows,
+		CollectedRowCount: count,
+		Truncated:         truncated,
+		Rows:              rows,
 	}
 }
 
@@ -509,12 +506,21 @@ OUTER:
 
 	if e.collector != nil {
 		sessVars.FastCheckTableInconsistentSummary = e.collector.Summary()
+	}
+
+	// Prioritize runtime errors (context cancellation, timeout, region errors)
+	// over collected inconsistency errors to avoid masking fatal failures.
+	if opErr := wctx.OperatorErr(); opErr != nil {
+		return opErr
+	}
+
+	if e.collector != nil {
 		if firstErr := e.collector.firstErr(); firstErr != nil {
 			return firstErr
 		}
 	}
 
-	return wctx.OperatorErr()
+	return nil
 }
 
 func (e *FastCheckTableExec) createWorker() workerpool.Worker[checkIndexTask, workerpool.None] {
@@ -910,6 +916,10 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 	queue = append(queue, checksumBucketTask{offset: 0, mod: 1, depth: 0})
 	const maxRefineDepth = 10
 	for len(queue) > 0 {
+		// Stop refinement early in collector mode when limit is reached.
+		if w.e.collector != nil && w.e.collector.reachedLimit() {
+			break
+		}
 		task := queue[0]
 		queue = queue[1:]
 

--- a/pkg/executor/test/admintest/BUILD.bazel
+++ b/pkg/executor/test/admintest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 30,
+    shard_count = 33,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -2235,10 +2235,15 @@ func TestAdminCheckIndexCollectInconsistentBySessionVar(t *testing.T) {
 			tk.MustExec("set @@tidb_fast_check_table_collect_inconsistent = OFF")
 		}
 
-		collector := executor.NewAdminCheckIndexInconsistentCollector()
-		checkCtx := executor.WithAdminCheckIndexInconsistentCollector(context.Background(), collector)
-		_, execErr := tk.ExecWithContext(checkCtx, "admin check index admin_collect_test idx_a")
-		return collector.Summary(), execErr
+		sessVars := tk.Session().GetSessionVars()
+		sessVars.FastCheckTableInconsistentLimit = 0
+		sessVars.FastCheckTableInconsistentSummary = nil
+		_, execErr := tk.ExecWithContext(context.Background(), "admin check index admin_collect_test idx_a")
+		summary, _ := sessVars.FastCheckTableInconsistentSummary.(*executor.AdminCheckIndexInconsistentSummary)
+		if summary == nil {
+			summary = &executor.AdminCheckIndexInconsistentSummary{}
+		}
+		return summary, execErr
 	}
 
 	// Default path (variable OFF) keeps fail-fast behavior and does not fill collector.
@@ -2295,13 +2300,15 @@ func TestAdminCheckIndexCollectInconsistentMultiLayerLocate(t *testing.T) {
 	tk.MustExec("set @@tidb_enable_fast_table_check = ON")
 	tk.MustExec("set @@tidb_fast_check_table_collect_inconsistent = ON")
 
-	collector := executor.NewAdminCheckIndexInconsistentCollector()
-	checkCtx := executor.WithAdminCheckIndexInconsistentCollector(context.Background(), collector)
-	_, err = tk.ExecWithContext(checkCtx, "admin check index admin_collect_deep idx_a")
+	sessVars := tk.Session().GetSessionVars()
+	sessVars.FastCheckTableInconsistentLimit = 0
+	sessVars.FastCheckTableInconsistentSummary = nil
+	_, err = tk.ExecWithContext(context.Background(), "admin check index admin_collect_deep idx_a")
 	require.Error(t, err)
 	require.True(t, consistency.ErrAdminCheckInconsistent.Equal(err))
 
-	summary := collector.Summary()
+	summary, _ := sessVars.FastCheckTableInconsistentSummary.(*executor.AdminCheckIndexInconsistentSummary)
+	require.NotNil(t, summary)
 	require.Equal(t, uint64(1), summary.InconsistentRowCount)
 	require.Equal(t, []executor.AdminCheckIndexInconsistentRow{
 		{Handle: "512", MismatchType: executor.AdminCheckIndexRowWithoutIndex},

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -2315,6 +2315,50 @@ func TestAdminCheckIndexCollectInconsistentMultiLayerLocate(t *testing.T) {
 	}, summary.Rows)
 }
 
+func TestAdminCheckIndexCollectInconsistentTrailingDuplicateIndex(t *testing.T) {
+	store, domain := testkit.CreateMockStoreAndDomain(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists admin_collect_tail")
+	tk.MustExec("create table admin_collect_tail (id int primary key, a int, key idx_a(a))")
+	tk.MustExec("insert admin_collect_tail values (1, 10), (2, 20)")
+
+	sctx := mock.NewContext()
+	sctx.Store = store
+	is := domain.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("admin_collect_tail"))
+	require.NoError(t, err)
+	tblInfo := tbl.Meta()
+	idxInfo := tblInfo.FindIndexByName("idx_a")
+	require.NotNil(t, idxInfo)
+	idxOp := tables.NewIndex(tblInfo.ID, tblInfo, idxInfo)
+
+	// Inject an extra trailing index entry for an existing handle without removing
+	// the original one. It should be classified as row_index_mismatch.
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	_, err = idxOp.Create(sctx.GetTableCtx(), txn, types.MakeDatums(200), kv.IntHandle(2), nil)
+	require.NoError(t, err)
+	err = txn.Commit(context.Background())
+	require.NoError(t, err)
+
+	tk.MustExec("set @@tidb_enable_fast_table_check = ON")
+	tk.MustExec("set @@tidb_fast_check_table_collect_inconsistent = ON")
+
+	sessVars := tk.Session().GetSessionVars()
+	sessVars.FastCheckTableInconsistentLimit = 0
+	sessVars.FastCheckTableInconsistentSummary = nil
+	_, err = tk.ExecWithContext(context.Background(), "admin check index admin_collect_tail idx_a")
+	require.Error(t, err)
+	require.True(t, consistency.ErrAdminCheckInconsistent.Equal(err))
+
+	summary, _ := sessVars.FastCheckTableInconsistentSummary.(*executor.AdminCheckIndexInconsistentSummary)
+	require.NotNil(t, summary)
+	require.Contains(t, summary.Rows, executor.AdminCheckIndexInconsistentRow{Handle: "2", MismatchType: executor.AdminCheckIndexRowIndexMismatch})
+	require.NotContains(t, summary.Rows, executor.AdminCheckIndexInconsistentRow{Handle: "2", MismatchType: executor.AdminCheckIndexIndexWithoutRow})
+}
+
 func TestAdminCheckGlobalIndexDuringDDL(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -2212,7 +2212,8 @@ func TestAdminCheckIndexCollectInconsistentBySessionVar(t *testing.T) {
 	tblInfo := tbl.Meta()
 	idxInfo := tblInfo.FindIndexByName("idx_a")
 	require.NotNil(t, idxInfo)
-	idxOp := tables.NewIndex(tblInfo.ID, tblInfo, idxInfo)
+	idxOp, err := tables.NewIndex(tblInfo.ID, tblInfo, idxInfo)
+	require.NoError(t, err)
 
 	txn, err := store.Begin()
 	require.NoError(t, err)
@@ -2283,7 +2284,8 @@ func TestAdminCheckIndexCollectInconsistentMultiLayerLocate(t *testing.T) {
 	tblInfo := tbl.Meta()
 	idxInfo := tblInfo.FindIndexByName("idx_a")
 	require.NotNil(t, idxInfo)
-	idxOp := tables.NewIndex(tblInfo.ID, tblInfo, idxInfo)
+	idxOp, err := tables.NewIndex(tblInfo.ID, tblInfo, idxInfo)
+	require.NoError(t, err)
 
 	// Remove one index row so this handle becomes row_without_index.
 	txn, err := store.Begin()
@@ -2332,7 +2334,8 @@ func TestAdminCheckIndexCollectInconsistentTrailingDuplicateIndex(t *testing.T) 
 	tblInfo := tbl.Meta()
 	idxInfo := tblInfo.FindIndexByName("idx_a")
 	require.NotNil(t, idxInfo)
-	idxOp := tables.NewIndex(tblInfo.ID, tblInfo, idxInfo)
+	idxOp, err := tables.NewIndex(tblInfo.ID, tblInfo, idxInfo)
+	require.NoError(t, err)
 
 	// Inject an extra trailing index entry for an existing handle without removing
 	// the original one. It should be classified as row_index_mismatch.

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -2191,6 +2191,75 @@ func TestAdminCheckGlobalIndexWithClusterIndex(t *testing.T) {
 	}
 }
 
+func TestAdminCheckIndexCollectInconsistentBySessionVar(t *testing.T) {
+	store, domain := testkit.CreateMockStoreAndDomain(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists admin_collect_test")
+	tk.MustExec("create table admin_collect_test (id int primary key, a int, b int, key idx_a(a))")
+	tk.MustExec("insert admin_collect_test values (1, 10, 100), (2, 20, 200), (3, 30, 300), (4, 40, 400)")
+
+	// Build one inconsistency for each mismatch type:
+	// 1) row_without_index: remove index(handle=1)
+	// 2) row_index_mismatch: replace index(handle=2) with wrong index value
+	// 3) index_without_row: add phantom index(handle=999)
+	sctx := mock.NewContext()
+	sctx.Store = store
+	is := domain.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("admin_collect_test"))
+	require.NoError(t, err)
+	tblInfo := tbl.Meta()
+	idxInfo := tblInfo.FindIndexByName("idx_a")
+	require.NotNil(t, idxInfo)
+	idxOp := tables.NewIndex(tblInfo.ID, tblInfo, idxInfo)
+
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	err = idxOp.Delete(sctx.GetTableCtx(), txn, types.MakeDatums(10), kv.IntHandle(1))
+	require.NoError(t, err)
+	err = idxOp.Delete(sctx.GetTableCtx(), txn, types.MakeDatums(20), kv.IntHandle(2))
+	require.NoError(t, err)
+	_, err = idxOp.Create(sctx.GetTableCtx(), txn, types.MakeDatums(200), kv.IntHandle(2), nil)
+	require.NoError(t, err)
+	_, err = idxOp.Create(sctx.GetTableCtx(), txn, types.MakeDatums(999), kv.IntHandle(999), nil)
+	require.NoError(t, err)
+	err = txn.Commit(context.Background())
+	require.NoError(t, err)
+
+	tk.MustExec("set @@tidb_enable_fast_table_check = ON")
+	runCheck := func(collectAll bool) (*executor.AdminCheckIndexInconsistentSummary, error) {
+		if collectAll {
+			tk.MustExec("set @@tidb_fast_check_table_collect_inconsistent = ON")
+		} else {
+			tk.MustExec("set @@tidb_fast_check_table_collect_inconsistent = OFF")
+		}
+
+		collector := executor.NewAdminCheckIndexInconsistentCollector()
+		checkCtx := executor.WithAdminCheckIndexInconsistentCollector(context.Background(), collector)
+		_, execErr := tk.ExecWithContext(checkCtx, "admin check index admin_collect_test idx_a")
+		return collector.Summary(), execErr
+	}
+
+	// Default path (variable OFF) keeps fail-fast behavior and does not fill collector.
+	summaryOff, err := runCheck(false)
+	require.Error(t, err)
+	require.True(t, consistency.ErrAdminCheckInconsistent.Equal(err))
+	require.Equal(t, uint64(0), summaryOff.InconsistentRowCount)
+	require.Empty(t, summaryOff.Rows)
+
+	// Collector path (variable ON) collects all mismatches with explicit type.
+	summaryOn, err := runCheck(true)
+	require.Error(t, err)
+	require.True(t, consistency.ErrAdminCheckInconsistent.Equal(err))
+	require.Equal(t, uint64(3), summaryOn.InconsistentRowCount)
+	require.ElementsMatch(t, []executor.AdminCheckIndexInconsistentRow{
+		{Handle: "1", MismatchType: executor.AdminCheckIndexRowWithoutIndex},
+		{Handle: "2", MismatchType: executor.AdminCheckIndexRowIndexMismatch},
+		{Handle: "999", MismatchType: executor.AdminCheckIndexIndexWithoutRow},
+	}, summaryOn.Rows)
+}
+
 func TestAdminCheckGlobalIndexDuringDDL(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -2260,6 +2260,54 @@ func TestAdminCheckIndexCollectInconsistentBySessionVar(t *testing.T) {
 	}, summaryOn.Rows)
 }
 
+func TestAdminCheckIndexCollectInconsistentMultiLayerLocate(t *testing.T) {
+	store, domain := testkit.CreateMockStoreAndDomain(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists admin_collect_deep")
+	tk.MustExec("create table admin_collect_deep (id int primary key, a int, key idx_a(a))")
+	tk.MustExec("set cte_max_recursion_depth=2000")
+	tk.MustExec("insert into admin_collect_deep with recursive cte(a) as (select 1 union select a+1 from cte where a < 1024) select a, a from cte")
+
+	sctx := mock.NewContext()
+	sctx.Store = store
+	is := domain.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("admin_collect_deep"))
+	require.NoError(t, err)
+	tblInfo := tbl.Meta()
+	idxInfo := tblInfo.FindIndexByName("idx_a")
+	require.NotNil(t, idxInfo)
+	idxOp := tables.NewIndex(tblInfo.ID, tblInfo, idxInfo)
+
+	// Remove one index row so this handle becomes row_without_index.
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	err = idxOp.Delete(sctx.GetTableCtx(), txn, types.MakeDatums(512), kv.IntHandle(512))
+	require.NoError(t, err)
+	err = txn.Commit(context.Background())
+	require.NoError(t, err)
+
+	oldBucketSize := executor.CheckTableFastBucketSize.Load()
+	executor.CheckTableFastBucketSize.Store(8)
+	defer executor.CheckTableFastBucketSize.Store(oldBucketSize)
+
+	tk.MustExec("set @@tidb_enable_fast_table_check = ON")
+	tk.MustExec("set @@tidb_fast_check_table_collect_inconsistent = ON")
+
+	collector := executor.NewAdminCheckIndexInconsistentCollector()
+	checkCtx := executor.WithAdminCheckIndexInconsistentCollector(context.Background(), collector)
+	_, err = tk.ExecWithContext(checkCtx, "admin check index admin_collect_deep idx_a")
+	require.Error(t, err)
+	require.True(t, consistency.ErrAdminCheckInconsistent.Equal(err))
+
+	summary := collector.Summary()
+	require.Equal(t, uint64(1), summary.InconsistentRowCount)
+	require.Equal(t, []executor.AdminCheckIndexInconsistentRow{
+		{Handle: "512", MismatchType: executor.AdminCheckIndexRowWithoutIndex},
+	}, summary.Rows)
+}
+
 func TestAdminCheckGlobalIndexDuringDDL(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -2240,7 +2240,7 @@ func TestAdminCheckIndexCollectInconsistentBySessionVar(t *testing.T) {
 		sessVars.FastCheckTableInconsistentLimit = 0
 		sessVars.FastCheckTableInconsistentSummary = nil
 		_, execErr := tk.ExecWithContext(context.Background(), "admin check index admin_collect_test idx_a")
-		summary, _ := sessVars.FastCheckTableInconsistentSummary.(*executor.AdminCheckIndexInconsistentSummary)
+		summary := sessVars.FastCheckTableInconsistentSummary
 		if summary == nil {
 			summary = &executor.AdminCheckIndexInconsistentSummary{}
 		}
@@ -2251,14 +2251,14 @@ func TestAdminCheckIndexCollectInconsistentBySessionVar(t *testing.T) {
 	summaryOff, err := runCheck(false)
 	require.Error(t, err)
 	require.True(t, consistency.ErrAdminCheckInconsistent.Equal(err))
-	require.Equal(t, uint64(0), summaryOff.InconsistentRowCount)
+	require.Equal(t, uint64(0), summaryOff.CollectedRowCount)
 	require.Empty(t, summaryOff.Rows)
 
 	// Collector path (variable ON) collects all mismatches with explicit type.
 	summaryOn, err := runCheck(true)
 	require.Error(t, err)
 	require.True(t, consistency.ErrAdminCheckInconsistent.Equal(err))
-	require.Equal(t, uint64(3), summaryOn.InconsistentRowCount)
+	require.Equal(t, uint64(3), summaryOn.CollectedRowCount)
 	require.ElementsMatch(t, []executor.AdminCheckIndexInconsistentRow{
 		{Handle: "1", MismatchType: executor.AdminCheckIndexRowWithoutIndex},
 		{Handle: "2", MismatchType: executor.AdminCheckIndexRowIndexMismatch},
@@ -2309,9 +2309,9 @@ func TestAdminCheckIndexCollectInconsistentMultiLayerLocate(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, consistency.ErrAdminCheckInconsistent.Equal(err))
 
-	summary, _ := sessVars.FastCheckTableInconsistentSummary.(*executor.AdminCheckIndexInconsistentSummary)
+	summary := sessVars.FastCheckTableInconsistentSummary
 	require.NotNil(t, summary)
-	require.Equal(t, uint64(1), summary.InconsistentRowCount)
+	require.Equal(t, uint64(1), summary.CollectedRowCount)
 	require.Equal(t, []executor.AdminCheckIndexInconsistentRow{
 		{Handle: "512", MismatchType: executor.AdminCheckIndexRowWithoutIndex},
 	}, summary.Rows)
@@ -2356,7 +2356,7 @@ func TestAdminCheckIndexCollectInconsistentTrailingDuplicateIndex(t *testing.T) 
 	require.Error(t, err)
 	require.True(t, consistency.ErrAdminCheckInconsistent.Equal(err))
 
-	summary, _ := sessVars.FastCheckTableInconsistentSummary.(*executor.AdminCheckIndexInconsistentSummary)
+	summary := sessVars.FastCheckTableInconsistentSummary
 	require.NotNil(t, summary)
 	require.Contains(t, summary.Rows, executor.AdminCheckIndexInconsistentRow{Handle: "2", MismatchType: executor.AdminCheckIndexRowIndexMismatch})
 	require.NotContains(t, summary.Rows, executor.AdminCheckIndexInconsistentRow{Handle: "2", MismatchType: executor.AdminCheckIndexIndexWithoutRow})

--- a/pkg/executor/utils_test.go
+++ b/pkg/executor/utils_test.go
@@ -15,7 +15,6 @@
 package executor
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -365,13 +364,14 @@ func TestAdminCheckIndexInconsistentCollectorIgnoreEmptyHandle(t *testing.T) {
 	require.EqualError(t, collector.firstErr(), "first")
 }
 
-func TestAdminCheckIndexInconsistentCollectorContextHelper(t *testing.T) {
-	baseCtx := context.Background()
-
-	require.Nil(t, adminCheckIndexCollectorFromContext(baseCtx))
-	require.Equal(t, baseCtx, WithAdminCheckIndexInconsistentCollector(baseCtx, nil))
-
+func TestAdminCheckIndexInconsistentCollectorRecordErr(t *testing.T) {
 	collector := NewAdminCheckIndexInconsistentCollector()
-	ctx := WithAdminCheckIndexInconsistentCollector(baseCtx, collector)
-	require.Same(t, collector, adminCheckIndexCollectorFromContext(ctx))
+
+	collector.recordErr(errors.New("first"))
+	collector.recordErr(errors.New("second"))
+
+	require.EqualError(t, collector.firstErr(), "first")
+	summary := collector.Summary()
+	require.Equal(t, uint64(0), summary.InconsistentRowCount)
+	require.Empty(t, summary.Rows)
 }

--- a/pkg/executor/utils_test.go
+++ b/pkg/executor/utils_test.go
@@ -15,6 +15,7 @@
 package executor
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -315,4 +316,45 @@ func TestEncodedPassword(t *testing.T) {
 	pwd, ok = encodedPassword(&u, "")
 	require.True(t, ok)
 	require.Equal(t, "", pwd)
+}
+
+func TestAdminCheckIndexInconsistentCollectorDeduplicate(t *testing.T) {
+	collector := NewAdminCheckIndexInconsistentCollector()
+
+	collector.recordInconsistent("1", AdminCheckIndexRowWithoutIndex, errors.New("first"))
+	collector.recordInconsistent("1", AdminCheckIndexRowWithoutIndex, errors.New("duplicate"))
+	collector.recordInconsistent("1", AdminCheckIndexIndexWithoutRow, errors.New("second"))
+	collector.recordInconsistent("2", AdminCheckIndexRowIndexMismatch, errors.New("third"))
+
+	summary := collector.Summary()
+	require.Equal(t, uint64(3), summary.InconsistentRowCount)
+	require.ElementsMatch(t, []AdminCheckIndexInconsistentRow{
+		{Handle: "1", MismatchType: AdminCheckIndexRowWithoutIndex},
+		{Handle: "1", MismatchType: AdminCheckIndexIndexWithoutRow},
+		{Handle: "2", MismatchType: AdminCheckIndexRowIndexMismatch},
+	}, summary.Rows)
+
+	require.EqualError(t, collector.firstErr(), "first")
+}
+
+func TestAdminCheckIndexInconsistentCollectorIgnoreEmptyHandle(t *testing.T) {
+	collector := NewAdminCheckIndexInconsistentCollector()
+
+	collector.recordInconsistent("", AdminCheckIndexRowWithoutIndex, errors.New("first"))
+
+	summary := collector.Summary()
+	require.Equal(t, uint64(0), summary.InconsistentRowCount)
+	require.Empty(t, summary.Rows)
+	require.EqualError(t, collector.firstErr(), "first")
+}
+
+func TestAdminCheckIndexInconsistentCollectorContextHelper(t *testing.T) {
+	baseCtx := context.Background()
+
+	require.Nil(t, adminCheckIndexCollectorFromContext(baseCtx))
+	require.Equal(t, baseCtx, WithAdminCheckIndexInconsistentCollector(baseCtx, nil))
+
+	collector := NewAdminCheckIndexInconsistentCollector()
+	ctx := WithAdminCheckIndexInconsistentCollector(baseCtx, collector)
+	require.Same(t, collector, adminCheckIndexCollectorFromContext(ctx))
 }

--- a/pkg/executor/utils_test.go
+++ b/pkg/executor/utils_test.go
@@ -346,7 +346,7 @@ func TestAdminCheckIndexInconsistentCollectorWithLimit(t *testing.T) {
 
 	summary := collector.Summary()
 	require.Equal(t, uint64(2), summary.InconsistentRowCount)
-	require.Equal(t, []AdminCheckIndexInconsistentRow{
+	require.ElementsMatch(t, []AdminCheckIndexInconsistentRow{
 		{Handle: "1", MismatchType: AdminCheckIndexRowWithoutIndex},
 		{Handle: "2", MismatchType: AdminCheckIndexIndexWithoutRow},
 	}, summary.Rows)

--- a/pkg/executor/utils_test.go
+++ b/pkg/executor/utils_test.go
@@ -337,6 +337,23 @@ func TestAdminCheckIndexInconsistentCollectorDeduplicate(t *testing.T) {
 	require.EqualError(t, collector.firstErr(), "first")
 }
 
+func TestAdminCheckIndexInconsistentCollectorWithLimit(t *testing.T) {
+	collector := NewAdminCheckIndexInconsistentCollectorWithLimit(2)
+
+	collector.recordInconsistent("1", AdminCheckIndexRowWithoutIndex, errors.New("first"))
+	collector.recordInconsistent("1", AdminCheckIndexRowWithoutIndex, errors.New("duplicate"))
+	collector.recordInconsistent("2", AdminCheckIndexIndexWithoutRow, errors.New("second"))
+	collector.recordInconsistent("3", AdminCheckIndexRowIndexMismatch, errors.New("third"))
+
+	summary := collector.Summary()
+	require.Equal(t, uint64(2), summary.InconsistentRowCount)
+	require.Equal(t, []AdminCheckIndexInconsistentRow{
+		{Handle: "1", MismatchType: AdminCheckIndexRowWithoutIndex},
+		{Handle: "2", MismatchType: AdminCheckIndexIndexWithoutRow},
+	}, summary.Rows)
+	require.EqualError(t, collector.firstErr(), "first")
+}
+
 func TestAdminCheckIndexInconsistentCollectorIgnoreEmptyHandle(t *testing.T) {
 	collector := NewAdminCheckIndexInconsistentCollector()
 

--- a/pkg/executor/utils_test.go
+++ b/pkg/executor/utils_test.go
@@ -326,7 +326,8 @@ func TestAdminCheckIndexInconsistentCollectorDeduplicate(t *testing.T) {
 	collector.recordInconsistent("2", AdminCheckIndexRowIndexMismatch, errors.New("third"))
 
 	summary := collector.Summary()
-	require.Equal(t, uint64(3), summary.InconsistentRowCount)
+	require.Equal(t, uint64(3), summary.CollectedRowCount)
+	require.False(t, summary.Truncated)
 	require.ElementsMatch(t, []AdminCheckIndexInconsistentRow{
 		{Handle: "1", MismatchType: AdminCheckIndexRowWithoutIndex},
 		{Handle: "1", MismatchType: AdminCheckIndexIndexWithoutRow},
@@ -345,7 +346,8 @@ func TestAdminCheckIndexInconsistentCollectorWithLimit(t *testing.T) {
 	collector.recordInconsistent("3", AdminCheckIndexRowIndexMismatch, errors.New("third"))
 
 	summary := collector.Summary()
-	require.Equal(t, uint64(2), summary.InconsistentRowCount)
+	require.Equal(t, uint64(2), summary.CollectedRowCount)
+	require.True(t, summary.Truncated)
 	require.ElementsMatch(t, []AdminCheckIndexInconsistentRow{
 		{Handle: "1", MismatchType: AdminCheckIndexRowWithoutIndex},
 		{Handle: "2", MismatchType: AdminCheckIndexIndexWithoutRow},
@@ -359,7 +361,8 @@ func TestAdminCheckIndexInconsistentCollectorIgnoreEmptyHandle(t *testing.T) {
 	collector.recordInconsistent("", AdminCheckIndexRowWithoutIndex, errors.New("first"))
 
 	summary := collector.Summary()
-	require.Equal(t, uint64(0), summary.InconsistentRowCount)
+	require.Equal(t, uint64(0), summary.CollectedRowCount)
+	require.False(t, summary.Truncated)
 	require.Empty(t, summary.Rows)
 	require.EqualError(t, collector.firstErr(), "first")
 }
@@ -372,6 +375,7 @@ func TestAdminCheckIndexInconsistentCollectorRecordErr(t *testing.T) {
 
 	require.EqualError(t, collector.firstErr(), "first")
 	summary := collector.Summary()
-	require.Equal(t, uint64(0), summary.InconsistentRowCount)
+	require.Equal(t, uint64(0), summary.CollectedRowCount)
+	require.False(t, summary.Truncated)
 	require.Empty(t, summary.Rows)
 }

--- a/pkg/server/handler/tikvhandler/BUILD.bazel
+++ b/pkg/server/handler/tikvhandler/BUILD.bazel
@@ -67,11 +67,16 @@ go_library(
 go_test(
     name = "tikvhandler_test",
     timeout = "short",
-    srcs = ["dxf_test.go"],
+    srcs = [
+        "dxf_test.go",
+        "tikv_handler_test.go",
+    ],
     embed = [":tikvhandler"],
     flaky = True,
     deps = [
         "//pkg/dxf/framework/schstatus",
+        "//pkg/executor",
+        "//pkg/server/handler",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/server/handler/tikvhandler/BUILD.bazel
+++ b/pkg/server/handler/tikvhandler/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/util/hack",
         "//pkg/util/intest",
         "//pkg/util/logutil",
+        "//pkg/util/logutil/consistency",
         "//pkg/util/naming",
         "//pkg/util/sqlexec",
         "@com_github_gorilla_mux//:mux",
@@ -73,6 +74,7 @@ go_test(
     ],
     embed = [":tikvhandler"],
     flaky = True,
+    shard_count = 3,
     deps = [
         "//pkg/dxf/framework/schstatus",
         "//pkg/executor",

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -1193,6 +1193,9 @@ func (h AdminCheckIndexHandler) checkIndexByName(dbName, tableName, indexName st
 	if err = se.GetSessionVars().SetSystemVar(vardef.TiDBFastCheckTable, vardef.On); err != nil {
 		return nil, err
 	}
+	if err = se.GetSessionVars().SetSystemVar(vardef.TiDBFastCheckTableCollectInconsistent, vardef.On); err != nil {
+		return nil, err
+	}
 
 	collector := executor.NewAdminCheckIndexInconsistentCollector()
 	// Attach collector to execution context so fast admin check can collect

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl"
+	ddlutil "github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/domain/serverinfo"
@@ -54,6 +55,7 @@ import (
 	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/session/txninfo"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/store/gcworker"
@@ -66,6 +68,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/deadlockhistory"
 	"github.com/pingcap/tidb/pkg/util/gcutil"
 	"github.com/pingcap/tidb/pkg/util/hack"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/logutil/consistency"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
@@ -2123,6 +2126,124 @@ func (h *TestHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	default:
 		handler.WriteError(w, errors.NotSupportedf("module(%s)", mod))
 	}
+}
+
+type rowKeyDeleteResponse struct {
+	Key string `json:"key"`
+}
+
+// DeleteKeyHandler is the handler for deleting row/index keys. It's used for testing GC and lock resolving.
+type DeleteKeyHandler struct {
+	*handler.TikvHandlerTool
+}
+
+// NewDeleteKeyHandler creates a new DeleteKeyHandler.
+func NewDeleteKeyHandler(tool *handler.TikvHandlerTool) *DeleteKeyHandler {
+	return &DeleteKeyHandler{
+		TikvHandlerTool: tool,
+	}
+}
+
+// Supported operations:
+//   - /test/delete/rowkey/{db}/{table}?handle={intHandle}
+//   - /test/delete/rowkey/{db}/{table}?{pkCol}={pkVal}[&{pkCol2}={pkVal2}...]
+//     (for clustered common handle tables)
+//   - /test/delete/indexkey/{db}/{table}/{index}?handle={intHandle}&{idxCol}={idxVal}[&{idxCol2}={idxVal2}...]
+//   - /test/delete/indexkey/{db}/{table}/{index}?{idxCol}={idxVal}[&{idxCol2}={idxVal2}...]
+//     (for index keys; clustered common handle tables can use PK columns instead of handle)
+func (h *DeleteKeyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		handler.WriteError(w, errors.Errorf("This api only support POST method"))
+		return
+	}
+	pathParams := mux.Vars(req)
+	values := make(url.Values)
+	if err := parseQuery(req.URL.RawQuery, values, true); err != nil {
+		handler.WriteError(w, err)
+		return
+	}
+
+	indexName := pathParams[handler.IndexName]
+	handleStr := values.Get(handler.Handle)
+	dbName := pathParams[handler.DBName]
+	if dbName == "" {
+		handler.WriteError(w, errors.BadRequestf("db is required"))
+		return
+	}
+	tableName := pathParams[handler.TableName]
+	if tableName == "" {
+		handler.WriteError(w, errors.BadRequestf("table is required"))
+		return
+	}
+
+	tb, err := h.GetTable(dbName, tableName)
+	if err != nil {
+		handler.WriteError(w, err)
+		return
+	}
+
+	handleParams := make(map[string]string, 1)
+	if handleStr != "" {
+		handleParams[handler.Handle] = handleStr
+	}
+	handle, err := h.GetHandle(tb, handleParams, values)
+	if err != nil {
+		handler.WriteError(w, err)
+		return
+	}
+
+	store, ok := h.Store.(kv.Storage)
+	if !ok {
+		handler.WriteError(w, errors.New("store does not support kv operations"))
+		return
+	}
+
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnTools)
+	var encodedKey []byte
+	if indexName == "" {
+		encodedKey = tablecodec.EncodeRecordKey(tb.RecordPrefix(), handle)
+	} else {
+		var idxCols []*model.ColumnInfo
+		var idx table.Index
+		for _, v := range tb.Indices() {
+			if strings.EqualFold(v.Meta().Name.String(), indexName) {
+				for _, c := range v.Meta().Columns {
+					idxCols = append(idxCols, tb.Meta().Columns[c.Offset])
+				}
+				idx = v
+				break
+			}
+		}
+		if idx == nil {
+			handler.WriteError(w, errors.NotFoundf("Index %s not found!", indexName))
+			return
+		}
+		sc := stmtctx.NewStmtCtxWithTimeZone(time.UTC)
+		idxRow, err := h.FormValue2DatumRow(sc, values, idxCols)
+		if err != nil {
+			handler.WriteError(w, err)
+			return
+		}
+		encodedKey, _, err = idx.GenIndexKey(sc.ErrCtx(), sc.TimeZone(), idxRow, handle, nil)
+		if err != nil {
+			handler.WriteError(w, err)
+			return
+		}
+	}
+	err = kv.RunInNewTxn(ctx, store, true, func(_ context.Context, txn kv.Transaction) error {
+		if intest.InTest {
+			// since CheckResourceTagForTopSQLInGoTest is enabled in TestMain,
+			// this tagger is required.
+			txn.SetOption(kv.ResourceGroupTagger, ddlutil.GetInternalResourceGroupTaggerForTopSQL())
+		}
+		return txn.Delete(encodedKey)
+	})
+	if err != nil {
+		handler.WriteError(w, err)
+		return
+	}
+
+	handler.WriteData(w, rowKeyDeleteResponse{Key: strings.ToUpper(hex.EncodeToString(encodedKey))})
 }
 
 // Supported operations:

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -167,9 +167,19 @@ type DDLResignOwnerHandler struct {
 	store kv.Storage
 }
 
+// DDLCheckHandler is the handler for triggering admin check index.
+type DDLCheckHandler struct {
+	*handler.TikvHandlerTool
+}
+
 // NewDDLResignOwnerHandler creates a new DDLResignOwnerHandler.
 func NewDDLResignOwnerHandler(store kv.Storage) *DDLResignOwnerHandler {
 	return &DDLResignOwnerHandler{store}
+}
+
+// NewDDLCheckHandler creates a new DDLCheckHandler.
+func NewDDLCheckHandler(tool *handler.TikvHandlerTool) *DDLCheckHandler {
+	return &DDLCheckHandler{tool}
 }
 
 // ServerInfoHandler is the handler for getting statistics.
@@ -197,19 +207,9 @@ type ProfileHandler struct {
 	*handler.TikvHandlerTool
 }
 
-// AdminCheckIndexHandler is the handler for admin check index inconsistency summary.
-type AdminCheckIndexHandler struct {
-	store kv.Storage
-}
-
 // NewProfileHandler creates a new ProfileHandler.
 func NewProfileHandler(tool *handler.TikvHandlerTool) *ProfileHandler {
 	return &ProfileHandler{tool}
-}
-
-// NewAdminCheckIndexHandler creates a new AdminCheckIndexHandler.
-func NewAdminCheckIndexHandler(store kv.Storage) *AdminCheckIndexHandler {
-	return &AdminCheckIndexHandler{store: store}
 }
 
 // DDLHookHandler is the handler for use pre-defined ddl callback.
@@ -1186,8 +1186,123 @@ func (h DDLResignOwnerHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 	handler.WriteData(w, "success!")
 }
 
-func (h AdminCheckIndexHandler) checkIndexByName(dbName, tableName, indexName string, limit int) (*executor.AdminCheckIndexInconsistentSummary, error) {
-	se, err := session.CreateSession(h.store)
+// ServeHTTP handles both:
+// 1. /ddl/check/{db}/{table}/{index} (legacy DDL check endpoint)
+// 2. /admin/check/index (inconsistency summary endpoint)
+func (h DDLCheckHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		handler.WriteError(w, errors.Errorf("This api only support POST method"))
+		return
+	}
+
+	params := mux.Vars(req)
+	dbName := params[handler.DBName]
+	tableName := params[handler.TableName]
+	indexName := params[handler.IndexName]
+	if dbName != "" || tableName != "" || indexName != "" {
+		h.serveDDLCheckByPath(w, req, dbName, tableName, indexName)
+		return
+	}
+	h.serveAdminCheckIndexSummary(w, req)
+}
+
+func (h DDLCheckHandler) serveDDLCheckByPath(w http.ResponseWriter, req *http.Request, dbName, tableName, indexName string) {
+	if dbName == "" || tableName == "" || indexName == "" {
+		handler.WriteError(w, errors.Errorf("db, table and index are required"))
+		return
+	}
+
+	sctx, err := session.CreateSession(h.Store)
+	if err != nil {
+		handler.WriteError(w, err)
+		return
+	}
+	defer sctx.Close()
+
+	if err := sctx.GetSessionVars().SetSystemVar(vardef.TiDBFastCheckTable, vardef.On); err != nil {
+		handler.WriteError(w, err)
+		return
+	}
+
+	quotedTableName := executor.TableName(dbName, tableName)
+	quotedIndexName := "`" + strings.ReplaceAll(indexName, "`", "``") + "`"
+	checkSQL := fmt.Sprintf("admin check index %s %s", quotedTableName, quotedIndexName)
+
+	rs, err := sctx.Execute(req.Context(), checkSQL)
+	rows, rowsErr := collectRecordSetRows(req.Context(), sctx, rs)
+	if rowsErr != nil {
+		handler.WriteError(w, rowsErr)
+		return
+	}
+
+	result := map[string]any{
+		"db":        dbName,
+		"table":     tableName,
+		"index":     indexName,
+		"check_sql": checkSQL,
+	}
+	if len(rows) > 0 {
+		result["rows"] = rows
+	}
+
+	if err != nil {
+		result["result"] = "failed"
+		result["error"] = err.Error()
+		handler.WriteData(w, result)
+		return
+	}
+
+	result["result"] = "success"
+	handler.WriteData(w, result)
+}
+
+func (h DDLCheckHandler) serveAdminCheckIndexSummary(w http.ResponseWriter, req *http.Request) {
+	dbName := req.FormValue(handler.DBName)
+	tableName := req.FormValue(handler.TableName)
+	indexName := req.FormValue(handler.IndexName)
+	if dbName == "" || tableName == "" || indexName == "" {
+		handler.WriteError(w, errors.Errorf("db, table and index are required"))
+		return
+	}
+
+	limit, err := parseAdminCheckIndexLimit(req)
+	if err != nil {
+		handler.WriteError(w, err)
+		return
+	}
+
+	summary, err := h.checkIndexByName(dbName, tableName, indexName, limit)
+	if err != nil && summary == nil {
+		handler.WriteError(w, err)
+		return
+	}
+	if summary == nil {
+		summary = &executor.AdminCheckIndexInconsistentSummary{}
+	}
+
+	// For inconsistency errors from `admin check index`, summary already contains
+	// mismatched handles and mismatch types required by this API.
+	handler.WriteData(w, summary)
+}
+
+func collectRecordSetRows(ctx context.Context, se sessionapi.Session, rss []sqlexec.RecordSet) ([][]string, error) {
+	rows := make([][]string, 0)
+	for _, one := range rss {
+		if one == nil {
+			continue
+		}
+		sRows, err := session.ResultSetToStringSlice(ctx, se, one)
+		if err != nil {
+			terror.Call(one.Close)
+			return nil, err
+		}
+		rows = append(rows, sRows...)
+	}
+	return rows, nil
+}
+
+func (h DDLCheckHandler) checkIndexByName(dbName, tableName, indexName string, limit int) (*executor.AdminCheckIndexInconsistentSummary, error) {
+	se, err := session.CreateSession(h.Store)
 	if err != nil {
 		return nil, err
 	}
@@ -1227,41 +1342,6 @@ func (h AdminCheckIndexHandler) checkIndexByName(dbName, tableName, indexName st
 		return nil, execErr
 	}
 	return summary, execErr
-}
-
-// ServeHTTP handles request of admin check index summary.
-func (h AdminCheckIndexHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if req.Method != http.MethodPost {
-		handler.WriteError(w, errors.Errorf("This api only support POST method"))
-		return
-	}
-
-	dbName := req.FormValue(handler.DBName)
-	tableName := req.FormValue(handler.TableName)
-	indexName := req.FormValue(handler.IndexName)
-	if dbName == "" || tableName == "" || indexName == "" {
-		handler.WriteError(w, errors.Errorf("db, table and index are required"))
-		return
-	}
-
-	limit, err := parseAdminCheckIndexLimit(req)
-	if err != nil {
-		handler.WriteError(w, err)
-		return
-	}
-
-	summary, err := h.checkIndexByName(dbName, tableName, indexName, limit)
-	if err != nil && summary == nil {
-		handler.WriteError(w, err)
-		return
-	}
-	if summary == nil {
-		summary = &executor.AdminCheckIndexInconsistentSummary{}
-	}
-
-	// For inconsistency errors from `admin check index`, summary already contains
-	// mismatched handles and mismatch types required by this API.
-	handler.WriteData(w, summary)
 }
 
 func parseAdminCheckIndexLimit(req *http.Request) (int, error) {

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl"
-	ddlutil "github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/domain/serverinfo"
@@ -55,7 +54,6 @@ import (
 	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/session/txninfo"
 	"github.com/pingcap/tidb/pkg/sessionctx"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/store/gcworker"
@@ -68,7 +66,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/deadlockhistory"
 	"github.com/pingcap/tidb/pkg/util/gcutil"
 	"github.com/pingcap/tidb/pkg/util/hack"
-	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/tikv/client-go/v2/tikv"
@@ -167,19 +164,9 @@ type DDLResignOwnerHandler struct {
 	store kv.Storage
 }
 
-// DDLCheckHandler is the handler for triggering admin check index.
-type DDLCheckHandler struct {
-	*handler.TikvHandlerTool
-}
-
 // NewDDLResignOwnerHandler creates a new DDLResignOwnerHandler.
 func NewDDLResignOwnerHandler(store kv.Storage) *DDLResignOwnerHandler {
 	return &DDLResignOwnerHandler{store}
-}
-
-// NewDDLCheckHandler creates a new DDLCheckHandler.
-func NewDDLCheckHandler(tool *handler.TikvHandlerTool) *DDLCheckHandler {
-	return &DDLCheckHandler{tool}
 }
 
 // ServerInfoHandler is the handler for getting statistics.
@@ -207,9 +194,19 @@ type ProfileHandler struct {
 	*handler.TikvHandlerTool
 }
 
+// AdminCheckIndexHandler is the handler for admin check index inconsistency summary.
+type AdminCheckIndexHandler struct {
+	store kv.Storage
+}
+
 // NewProfileHandler creates a new ProfileHandler.
 func NewProfileHandler(tool *handler.TikvHandlerTool) *ProfileHandler {
 	return &ProfileHandler{tool}
+}
+
+// NewAdminCheckIndexHandler creates a new AdminCheckIndexHandler.
+func NewAdminCheckIndexHandler(store kv.Storage) *AdminCheckIndexHandler {
+	return &AdminCheckIndexHandler{store: store}
 }
 
 // DDLHookHandler is the handler for use pre-defined ddl callback.
@@ -1186,81 +1183,69 @@ func (h DDLResignOwnerHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 	handler.WriteData(w, "success!")
 }
 
-// ServeHTTP handles request of triggering admin check index.
-// This endpoint is used for online diagnosis and relies on fast check table mode.
-func (h DDLCheckHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+func (h AdminCheckIndexHandler) checkIndexByName(dbName, tableName, indexName string) (*executor.AdminCheckIndexInconsistentSummary, error) {
+	se, err := session.CreateSession(h.store)
+	if err != nil {
+		return nil, err
+	}
+	defer se.Close()
+
+	if err = se.GetSessionVars().SetSystemVar(vardef.TiDBFastCheckTable, vardef.On); err != nil {
+		return nil, err
+	}
+
+	collector := executor.NewAdminCheckIndexInconsistentCollector()
+	checkCtx := executor.WithAdminCheckIndexInconsistentCollector(context.Background(), collector)
+	checkSQL := fmt.Sprintf("admin check index %s %s", quoteTable(dbName, tableName), quoteName(indexName))
+
+	rs, execErr := se.Execute(checkCtx, checkSQL)
+	for _, one := range rs {
+		if one != nil {
+			terror.Call(one.Close)
+		}
+	}
+
+	summary := collector.Summary()
+	if execErr != nil && summary.InconsistentRowCount == 0 {
+		return nil, execErr
+	}
+	return summary, execErr
+}
+
+// ServeHTTP handles request of admin check index summary.
+func (h AdminCheckIndexHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		handler.WriteError(w, errors.Errorf("This api only support POST method"))
 		return
 	}
 
-	params := mux.Vars(req)
-	dbName := params[handler.DBName]
-	tableName := params[handler.TableName]
-	indexName := params[handler.IndexName]
+	dbName := req.FormValue(handler.DBName)
+	tableName := req.FormValue(handler.TableName)
+	indexName := req.FormValue(handler.IndexName)
 	if dbName == "" || tableName == "" || indexName == "" {
 		handler.WriteError(w, errors.Errorf("db, table and index are required"))
 		return
 	}
 
-	sctx, err := session.CreateSession(h.Store)
-	if err != nil {
+	summary, err := h.checkIndexByName(dbName, tableName, indexName)
+	if err != nil && summary == nil {
 		handler.WriteError(w, err)
 		return
 	}
-	defer sctx.Close()
-
-	if err := sctx.GetSessionVars().SetSystemVar(vardef.TiDBFastCheckTable, vardef.On); err != nil {
-		handler.WriteError(w, err)
-		return
+	if summary == nil {
+		summary = &executor.AdminCheckIndexInconsistentSummary{}
 	}
-
-	quotedTableName := executor.TableName(dbName, tableName)
-	quotedIndexName := "`" + strings.ReplaceAll(indexName, "`", "``") + "`"
-	checkSQL := fmt.Sprintf("admin check index %s %s", quotedTableName, quotedIndexName)
-
-	rs, err := sctx.Execute(req.Context(), checkSQL)
-	rows, rowsErr := collectRecordSetRows(req.Context(), sctx, rs)
-	if rowsErr != nil {
-		handler.WriteError(w, rowsErr)
-		return
-	}
-
-	result := map[string]any{
-		"db":        dbName,
-		"table":     tableName,
-		"index":     indexName,
-		"check_sql": checkSQL,
-	}
-	if len(rows) > 0 {
-		result["rows"] = rows
-	}
-
-	if err != nil {
-		result["result"] = "failed"
-		result["error"] = err.Error()
-		handler.WriteData(w, result)
-		return
-	}
-
-	result["result"] = "success"
-	handler.WriteData(w, result)
+	// For inconsistency errors from `admin check index`, summary already contains
+	// all mismatched handles and mismatch types, which are required by this API.
+	handler.WriteData(w, summary)
 }
 
-func collectRecordSetRows(ctx context.Context, se sessionapi.Session, rss []sqlexec.RecordSet) ([][]string, error) {
-	rows := make([][]string, 0)
-	for _, one := range rss {
-		if one == nil {
-			continue
-		}
-		sRows, err := session.ResultSetToStringSlice(ctx, se, one)
-		if err != nil {
-			terror.Call(one.Close)
-			return nil, err
-		}
-		rows = append(rows, sRows...)
-	}
-	return rows, nil
+func quoteName(name string) string {
+	return fmt.Sprintf("`%s`", strings.ReplaceAll(name, "`", "``"))
+}
+
+func quoteTable(schema, table string) string {
+	return fmt.Sprintf("%s.%s", quoteName(schema), quoteName(table))
 }
 
 func (h *TableHandler) getPDAddr() ([]string, error) {
@@ -2009,124 +1994,6 @@ func (h *TestHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	default:
 		handler.WriteError(w, errors.NotSupportedf("module(%s)", mod))
 	}
-}
-
-type rowKeyDeleteResponse struct {
-	Key string `json:"key"`
-}
-
-// DeleteKeyHandler is the handler for deleting row/index keys. It's used for testing GC and lock resolving.
-type DeleteKeyHandler struct {
-	*handler.TikvHandlerTool
-}
-
-// NewDeleteKeyHandler creates a new DeleteKeyHandler.
-func NewDeleteKeyHandler(tool *handler.TikvHandlerTool) *DeleteKeyHandler {
-	return &DeleteKeyHandler{
-		TikvHandlerTool: tool,
-	}
-}
-
-// Supported operations:
-//   - /test/delete/rowkey/{db}/{table}?handle={intHandle}
-//   - /test/delete/rowkey/{db}/{table}?{pkCol}={pkVal}[&{pkCol2}={pkVal2}...]
-//     (for clustered common handle tables)
-//   - /test/delete/indexkey/{db}/{table}/{index}?handle={intHandle}&{idxCol}={idxVal}[&{idxCol2}={idxVal2}...]
-//   - /test/delete/indexkey/{db}/{table}/{index}?{idxCol}={idxVal}[&{idxCol2}={idxVal2}...]
-//     (for index keys; clustered common handle tables can use PK columns instead of handle)
-func (h *DeleteKeyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if req.Method != http.MethodPost {
-		handler.WriteError(w, errors.Errorf("This api only support POST method"))
-		return
-	}
-	pathParams := mux.Vars(req)
-	values := make(url.Values)
-	if err := parseQuery(req.URL.RawQuery, values, true); err != nil {
-		handler.WriteError(w, err)
-		return
-	}
-
-	indexName := pathParams[handler.IndexName]
-	handleStr := values.Get(handler.Handle)
-	dbName := pathParams[handler.DBName]
-	if dbName == "" {
-		handler.WriteError(w, errors.BadRequestf("db is required"))
-		return
-	}
-	tableName := pathParams[handler.TableName]
-	if tableName == "" {
-		handler.WriteError(w, errors.BadRequestf("table is required"))
-		return
-	}
-
-	tb, err := h.GetTable(dbName, tableName)
-	if err != nil {
-		handler.WriteError(w, err)
-		return
-	}
-
-	handleParams := make(map[string]string, 1)
-	if handleStr != "" {
-		handleParams[handler.Handle] = handleStr
-	}
-	handle, err := h.GetHandle(tb, handleParams, values)
-	if err != nil {
-		handler.WriteError(w, err)
-		return
-	}
-
-	store, ok := h.Store.(kv.Storage)
-	if !ok {
-		handler.WriteError(w, errors.New("store does not support kv operations"))
-		return
-	}
-
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnTools)
-	var encodedKey []byte
-	if indexName == "" {
-		encodedKey = tablecodec.EncodeRecordKey(tb.RecordPrefix(), handle)
-	} else {
-		var idxCols []*model.ColumnInfo
-		var idx table.Index
-		for _, v := range tb.Indices() {
-			if strings.EqualFold(v.Meta().Name.String(), indexName) {
-				for _, c := range v.Meta().Columns {
-					idxCols = append(idxCols, tb.Meta().Columns[c.Offset])
-				}
-				idx = v
-				break
-			}
-		}
-		if idx == nil {
-			handler.WriteError(w, errors.NotFoundf("Index %s not found!", indexName))
-			return
-		}
-		sc := stmtctx.NewStmtCtxWithTimeZone(time.UTC)
-		idxRow, err := h.FormValue2DatumRow(sc, values, idxCols)
-		if err != nil {
-			handler.WriteError(w, err)
-			return
-		}
-		encodedKey, _, err = idx.GenIndexKey(sc.ErrCtx(), sc.TimeZone(), idxRow, handle, nil)
-		if err != nil {
-			handler.WriteError(w, err)
-			return
-		}
-	}
-	err = kv.RunInNewTxn(ctx, store, true, func(_ context.Context, txn kv.Transaction) error {
-		if intest.InTest {
-			// since CheckResourceTagForTopSQLInGoTest is enabled in TestMain,
-			// this tagger is required.
-			txn.SetOption(kv.ResourceGroupTagger, ddlutil.GetInternalResourceGroupTaggerForTopSQL())
-		}
-		return txn.Delete(encodedKey)
-	})
-	if err != nil {
-		handler.WriteError(w, err)
-		return
-	}
-
-	handler.WriteData(w, rowKeyDeleteResponse{Key: strings.ToUpper(hex.EncodeToString(encodedKey))})
 }
 
 // Supported operations:

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -82,6 +82,7 @@ import (
 const (
 	requestDefaultTimeout       = 10 * time.Second
 	adminCheckIndexDefaultLimit = 1000
+	adminCheckIndexMaxLimit     = 10000
 )
 
 // SettingsHandler is the handler for list tidb server settings.
@@ -1368,6 +1369,9 @@ func parseAdminCheckIndexLimit(req *http.Request) (int, error) {
 	}
 	if limit <= 0 {
 		return 0, errors.New("limit must be greater than 0")
+	}
+	if limit > adminCheckIndexMaxLimit {
+		return adminCheckIndexMaxLimit, nil
 	}
 	return limit, nil
 }

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -172,10 +172,13 @@ type DDLResignOwnerHandler struct {
 	store kv.Storage
 }
 
-// DDLCheckHandler is the handler for triggering admin check index.
+// DDLCheckHandler handles admin check index requests.
+// It serves two endpoints:
+// 1. /ddl/check/{db}/{table}/{index} - legacy DDL check endpoint (returns rows on error)
+// 2. /admin/check/index - inconsistency summary endpoint (returns collected summary)
 type DDLCheckHandler struct {
 	*handler.TikvHandlerTool
-	adminCheckIndexFn func(ctx context.Context, dbName, tableName, indexName string, limit int) (*executor.AdminCheckIndexInconsistentSummary, error)
+	adminCheckIndexFn func(ctx context.Context, dbName, tableName, indexName string, limit int) (*variable.AdminCheckIndexInconsistentSummary, error)
 }
 
 // NewDDLResignOwnerHandler creates a new DDLResignOwnerHandler.
@@ -1287,7 +1290,7 @@ func (h DDLCheckHandler) serveAdminCheckIndexSummary(w http.ResponseWriter, req 
 		return
 	}
 	if summary == nil {
-		summary = &executor.AdminCheckIndexInconsistentSummary{}
+		summary = &variable.AdminCheckIndexInconsistentSummary{}
 	}
 
 	// For inconsistency errors from `admin check index`, summary already contains
@@ -1311,7 +1314,7 @@ func collectRecordSetRows(ctx context.Context, se sessionapi.Session, rss []sqle
 	return rows, nil
 }
 
-func (h DDLCheckHandler) checkIndexByName(ctx context.Context, dbName, tableName, indexName string, limit int) (*executor.AdminCheckIndexInconsistentSummary, error) {
+func (h DDLCheckHandler) checkIndexByName(ctx context.Context, dbName, tableName, indexName string, limit int) (*variable.AdminCheckIndexInconsistentSummary, error) {
 	se, err := session.CreateSession(h.Store)
 	if err != nil {
 		return nil, err
@@ -1342,16 +1345,16 @@ func (h DDLCheckHandler) checkIndexByName(ctx context.Context, dbName, tableName
 		}
 	}
 
-	summary, _ := sessVars.FastCheckTableInconsistentSummary.(*executor.AdminCheckIndexInconsistentSummary)
+	summary := sessVars.FastCheckTableInconsistentSummary
 	if summary == nil {
-		summary = &executor.AdminCheckIndexInconsistentSummary{}
+		summary = &variable.AdminCheckIndexInconsistentSummary{}
 	}
 	// Return SQL error only when no inconsistency rows were collected.
 	// If rows are collected, ServeHTTP still returns the summary payload.
 	if execErr != nil && !consistency.ErrAdminCheckInconsistent.Equal(execErr) {
 		return nil, execErr
 	}
-	if execErr != nil && summary.InconsistentRowCount == 0 {
+	if execErr != nil && summary.CollectedRowCount == 0 {
 		return nil, execErr
 	}
 	return summary, execErr
@@ -1377,11 +1380,11 @@ func parseAdminCheckIndexLimit(req *http.Request) (int, error) {
 }
 
 func quoteName(name string) string {
-	return fmt.Sprintf("`%s`", strings.ReplaceAll(name, "`", "``"))
+	return executor.ColumnName(name)
 }
 
 func quoteTable(schema, table string) string {
-	return fmt.Sprintf("%s.%s", quoteName(schema), quoteName(table))
+	return executor.TableName(schema, table)
 }
 
 func (h *TableHandler) getPDAddr() ([]string, error) {

--- a/pkg/server/handler/tikvhandler/tikv_handler_test.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler_test.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/server/handler"
 	"github.com/stretchr/testify/require"
 )
@@ -37,27 +36,7 @@ func TestParseAdminCheckIndexLimit(t *testing.T) {
 
 	_, err = parseAdminCheckIndexLimit(&http.Request{Form: map[string][]string{handler.Limit: {"0"}}})
 	require.ErrorContains(t, err, "greater than 0")
-}
 
-func TestTruncateAdminCheckIndexSummaryRows(t *testing.T) {
-	summary := &executor.AdminCheckIndexInconsistentSummary{
-		InconsistentRowCount: 4,
-		Rows: []executor.AdminCheckIndexInconsistentRow{
-			{Handle: "h1", MismatchType: executor.AdminCheckIndexRowWithoutIndex},
-			{Handle: "h2", MismatchType: executor.AdminCheckIndexIndexWithoutRow},
-			{Handle: "h3", MismatchType: executor.AdminCheckIndexRowIndexMismatch},
-			{Handle: "h4", MismatchType: executor.AdminCheckIndexRowWithoutIndex},
-		},
-	}
-
-	truncateAdminCheckIndexSummaryRows(summary, 2)
-	require.Equal(t, uint64(4), summary.InconsistentRowCount)
-	require.Len(t, summary.Rows, 2)
-	require.Equal(t, "h1", summary.Rows[0].Handle)
-	require.Equal(t, "h2", summary.Rows[1].Handle)
-
-	truncateAdminCheckIndexSummaryRows(summary, 10)
-	require.Len(t, summary.Rows, 2)
-
-	truncateAdminCheckIndexSummaryRows(nil, 1)
+	_, err = parseAdminCheckIndexLimit(&http.Request{Form: map[string][]string{handler.Limit: {"-1"}}})
+	require.ErrorContains(t, err, "greater than 0")
 }

--- a/pkg/server/handler/tikvhandler/tikv_handler_test.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikvhandler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/executor"
+	"github.com/pingcap/tidb/pkg/server/handler"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAdminCheckIndexLimit(t *testing.T) {
+	limit, err := parseAdminCheckIndexLimit(&http.Request{})
+	require.NoError(t, err)
+	require.Equal(t, adminCheckIndexDefaultLimit, limit)
+
+	limit, err = parseAdminCheckIndexLimit(&http.Request{Form: map[string][]string{handler.Limit: {"200"}}})
+	require.NoError(t, err)
+	require.Equal(t, 200, limit)
+
+	_, err = parseAdminCheckIndexLimit(&http.Request{Form: map[string][]string{handler.Limit: {"abc"}}})
+	require.ErrorContains(t, err, "invalid limit")
+
+	_, err = parseAdminCheckIndexLimit(&http.Request{Form: map[string][]string{handler.Limit: {"0"}}})
+	require.ErrorContains(t, err, "greater than 0")
+}
+
+func TestTruncateAdminCheckIndexSummaryRows(t *testing.T) {
+	summary := &executor.AdminCheckIndexInconsistentSummary{
+		InconsistentRowCount: 4,
+		Rows: []executor.AdminCheckIndexInconsistentRow{
+			{Handle: "h1", MismatchType: executor.AdminCheckIndexRowWithoutIndex},
+			{Handle: "h2", MismatchType: executor.AdminCheckIndexIndexWithoutRow},
+			{Handle: "h3", MismatchType: executor.AdminCheckIndexRowIndexMismatch},
+			{Handle: "h4", MismatchType: executor.AdminCheckIndexRowWithoutIndex},
+		},
+	}
+
+	truncateAdminCheckIndexSummaryRows(summary, 2)
+	require.Equal(t, uint64(4), summary.InconsistentRowCount)
+	require.Len(t, summary.Rows, 2)
+	require.Equal(t, "h1", summary.Rows[0].Handle)
+	require.Equal(t, "h2", summary.Rows[1].Handle)
+
+	truncateAdminCheckIndexSummaryRows(summary, 10)
+	require.Len(t, summary.Rows, 2)
+
+	truncateAdminCheckIndexSummaryRows(nil, 1)
+}

--- a/pkg/server/handler/tikvhandler/tikv_handler_test.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler_test.go
@@ -42,6 +42,10 @@ func TestParseAdminCheckIndexLimit(t *testing.T) {
 
 	_, err = parseAdminCheckIndexLimit(&http.Request{Form: map[string][]string{handler.Limit: {"-1"}}})
 	require.ErrorContains(t, err, "greater than 0")
+
+	limit, err = parseAdminCheckIndexLimit(&http.Request{Form: map[string][]string{handler.Limit: {"999999"}}})
+	require.NoError(t, err)
+	require.Equal(t, adminCheckIndexMaxLimit, limit)
 }
 
 func TestDDLCheckHandlerAdminCheckIndexCancelContext(t *testing.T) {

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -279,6 +279,7 @@ func (s *Server) startHTTPServer() {
 
 	// HTTP path for upgrade operations.
 	router.Handle("/upgrade/{op}", handler.NewClusterUpgradeHandler(tikvHandlerTool.Store.(kv.Storage))).Name("upgrade operations")
+	router.Handle("/admin/check/index", tikvhandler.NewAdminCheckIndexHandler(tikvHandlerTool.Store.(kv.Storage))).Name("AdminCheckIndex")
 
 	// HTTP path for ingest configurations
 	router.Handle("/ingest/max-batch-split-ranges", tikvhandler.NewIngestConcurrencyHandler(

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -279,7 +279,7 @@ func (s *Server) startHTTPServer() {
 
 	// HTTP path for upgrade operations.
 	router.Handle("/upgrade/{op}", handler.NewClusterUpgradeHandler(tikvHandlerTool.Store.(kv.Storage))).Name("upgrade operations")
-	router.Handle("/admin/check/index", tikvhandler.NewAdminCheckIndexHandler(tikvHandlerTool.Store.(kv.Storage))).Name("AdminCheckIndex")
+	router.Handle("/admin/check/index", tikvhandler.NewDDLCheckHandler(tikvHandlerTool)).Name("AdminCheckIndex")
 
 	// HTTP path for ingest configurations
 	router.Handle("/ingest/max-batch-split-ranges", tikvhandler.NewIngestConcurrencyHandler(

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1056,6 +1056,9 @@ const (
 	// TiDBFastCheckTable enables fast check table.
 	TiDBFastCheckTable = "tidb_enable_fast_table_check"
 
+	// TiDBFastCheckTableCollectInconsistent enables collecting all inconsistencies in fast check table/index.
+	TiDBFastCheckTableCollectInconsistent = "tidb_fast_check_table_collect_inconsistent"
+
 	// TiDBAnalyzeSkipColumnTypes indicates the column types whose statistics would not be collected when executing the ANALYZE command.
 	TiDBAnalyzeSkipColumnTypes = "tidb_analyze_skip_column_types"
 
@@ -1738,6 +1741,7 @@ const (
 	DefAuthenticationLDAPSimpleMaxPoolSize            = 1000
 	DefTiFlashReplicaRead                             = AllReplicaStr
 	DefTiDBEnableFastCheckTable                       = true
+	DefTiDBFastCheckTableCollectInconsistent          = false
 	DefRuntimeFilterType                              = "IN"
 	DefRuntimeFilterMode                              = "OFF"
 	DefTiDBLockUnchangedKeys                          = true

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1746,6 +1746,10 @@ type SessionVars struct {
 	// FastCheckTable is used to control whether fast check table is enabled.
 	FastCheckTable bool
 
+	// FastCheckTableCollectInconsistent controls whether fast check table/index
+	// should continue collecting all inconsistencies instead of fail-fast.
+	FastCheckTableCollectInconsistent bool
+
 	// HypoIndexes are for the Index Advisor.
 	HypoIndexes map[string]map[string]map[string]*model.IndexInfo // dbName -> tblName -> idxName -> idxInfo
 

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1750,6 +1750,14 @@ type SessionVars struct {
 	// should continue collecting all inconsistencies instead of fail-fast.
 	FastCheckTableCollectInconsistent bool
 
+	// FastCheckTableInconsistentLimit limits collected inconsistency rows
+	// in fast check table/index. 0 means no limit.
+	FastCheckTableInconsistentLimit int
+
+	// FastCheckTableInconsistentSummary stores fast check inconsistency summary
+	// for the last executed statement in current session.
+	FastCheckTableInconsistentSummary any
+
 	// HypoIndexes are for the Index Advisor.
 	HypoIndexes map[string]map[string]map[string]*model.IndexInfo // dbName -> tblName -> idxName -> idxInfo
 

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -773,6 +773,35 @@ type SessionVarsProvider interface {
 	GetSessionVars() *SessionVars
 }
 
+// AdminCheckIndexInconsistentType describes the type of inconsistency found during admin check index.
+type AdminCheckIndexInconsistentType string
+
+const (
+	// AdminCheckIndexRowWithoutIndex means the table row exists but the index entry is missing.
+	AdminCheckIndexRowWithoutIndex AdminCheckIndexInconsistentType = "row_without_index"
+	// AdminCheckIndexIndexWithoutRow means the index entry exists but the table row is missing.
+	AdminCheckIndexIndexWithoutRow AdminCheckIndexInconsistentType = "index_without_row"
+	// AdminCheckIndexRowIndexMismatch means table and index rows both exist but values don't match.
+	AdminCheckIndexRowIndexMismatch AdminCheckIndexInconsistentType = "row_index_mismatch"
+)
+
+// AdminCheckIndexInconsistentRow stores one inconsistent handle and mismatch type.
+type AdminCheckIndexInconsistentRow struct {
+	Handle       string                          `json:"handle"`
+	MismatchType AdminCheckIndexInconsistentType `json:"mismatch_type"`
+}
+
+// AdminCheckIndexInconsistentSummary is returned by HTTP API.
+type AdminCheckIndexInconsistentSummary struct {
+	// CollectedRowCount is the number of collected inconsistent rows,
+	// which may be capped by the limit parameter.
+	CollectedRowCount uint64 `json:"collected_row_count"`
+	// Truncated indicates whether the result was truncated due to reaching the limit.
+	Truncated bool `json:"truncated"`
+	// Rows contains the collected inconsistent row details.
+	Rows []AdminCheckIndexInconsistentRow `json:"rows"`
+}
+
 // SessionVars should implement `SessionVarsProvider`
 var _ SessionVarsProvider = &SessionVars{}
 
@@ -1756,7 +1785,7 @@ type SessionVars struct {
 
 	// FastCheckTableInconsistentSummary stores fast check inconsistency summary
 	// for the last executed statement in current session.
-	FastCheckTableInconsistentSummary any
+	FastCheckTableInconsistentSummary *AdminCheckIndexInconsistentSummary
 
 	// HypoIndexes are for the Index Advisor.
 	HypoIndexes map[string]map[string]map[string]*model.IndexInfo // dbName -> tblName -> idxName -> idxInfo

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -3402,6 +3402,10 @@ var defaultSysVars = []*SysVar{
 		s.FastCheckTable = TiDBOptOn(val)
 		return nil
 	}},
+	{Scope: vardef.ScopeSession, Name: vardef.TiDBFastCheckTableCollectInconsistent, Value: BoolToOnOff(vardef.DefTiDBFastCheckTableCollectInconsistent), Type: vardef.TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.FastCheckTableCollectInconsistent = TiDBOptOn(val)
+		return nil
+	}},
 	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBSkipMissingPartitionStats, Value: BoolToOnOff(vardef.DefTiDBSkipMissingPartitionStats), Type: vardef.TypeBool, SetSession: func(s *SessionVars, val string) error {
 		s.SkipMissingPartitionStats = TiDBOptOn(val)
 		return nil

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -2005,3 +2005,25 @@ func TestSkipInitIsUsed(t *testing.T) {
 		}
 	}
 }
+
+func TestTiDBFastCheckTableCollectInconsistentVar(t *testing.T) {
+	sv := GetSysVar(vardef.TiDBFastCheckTableCollectInconsistent)
+	require.NotNil(t, sv)
+	require.Equal(t, vardef.ScopeSession, sv.Scope)
+	require.Equal(t, BoolToOnOff(vardef.DefTiDBFastCheckTableCollectInconsistent), sv.Value)
+
+	vars := NewSessionVars(nil)
+	require.False(t, vars.FastCheckTableCollectInconsistent)
+
+	val, err := sv.Validate(vars, vardef.On, vardef.ScopeSession)
+	require.NoError(t, err)
+	require.Equal(t, vardef.On, val)
+	require.NoError(t, sv.SetSessionFromHook(vars, val))
+	require.True(t, vars.FastCheckTableCollectInconsistent)
+
+	val, err = sv.Validate(vars, vardef.Off, vardef.ScopeSession)
+	require.NoError(t, err)
+	require.Equal(t, vardef.Off, val)
+	require.NoError(t, sv.SetSessionFromHook(vars, val))
+	require.False(t, vars.FastCheckTableCollectInconsistent)
+}


### PR DESCRIPTION
## Summary
- Port changes from #66191 (`release-nextgen-20251011`) to `master`.
- Keep `DDLCheckHandler` path handling and merge `/admin/check/index` into the same handler.
- Add fast `admin check index` inconsistency summary collection and HTTP response flow.
- Carry related tests for executor/session variable/server handler.

## Notes
- During porting, resolved API differences against current `master` (workerpool/task interfaces, `tables.NewIndex` return values, and test delete-key handler wiring).

Ref: https://github.com/pingcap/tidb/pull/66191


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session variable to enable collecting detailed table/index inconsistency rows during admin checks (with configurable limit).
  * New HTTP endpoint /admin/check/index to retrieve index-consistency summaries with limit support.

* **Improvements**
  * Optional collector mode records inconsistencies (instead of immediate fail-fast) and stores a summary in session state.
  * Bucketed checksum comparison with concurrent workers for more scalable checks and clearer mismatch reports.

* **Tests**
  * Added unit and integration tests for collector behavior, limits, HTTP handlers, and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->