### PR TITLE
planner: collect column-level visit info during plan build | tidb-test=pr/2532 (cherry-pick #61741)

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -2351,6 +2351,11 @@ error = '''
 %-.128s command denied to user '%-.48s'@'%-.255s' for table '%-.64s'
 '''
 
+["planner:1143"]
+error = '''
+%-.16s command denied to user '%-.48s'@'%-.255s' for column '%-.192s' in table '%-.192s'
+'''
+
 ["planner:1146"]
 error = '''
 Table '%-.192s.%-.192s' doesn't exist

--- a/pkg/extension/auth_test.go
+++ b/pkg/extension/auth_test.go
@@ -281,7 +281,7 @@ func TestAuthPlugin(t *testing.T) {
 	tk2.MustQuery("select * from t1").Check(testkit.Rows("1 10", "2 20"))
 	require.EqualError(t, tk2.ExecToErr("insert into t1 values (3, 30)"), "[planner:1142]INSERT command denied to user 'u2'@'localhost' for table 't1'")
 	// Should verify privilege using plugin impl.
-	p.AssertNumberOfCalls(t, "VerifyPrivilege", 3)
+	p.AssertNumberOfCalls(t, "VerifyPrivilege", 4)
 	p.AssertCalled(t, "VerifyPrivilege", authzMatcher2)
 	p.AssertCalled(t, "VerifyPrivilege", authzMatcher3)
 
@@ -394,7 +394,7 @@ func TestAuthPluginSwitchPlugins(t *testing.T) {
 	tk2.MustQuery("select * from t1").Check(testkit.Rows("1 10", "2 20"))
 	require.EqualError(t, tk2.ExecToErr("insert into t1 values (3, 30)"), "[planner:1142]INSERT command denied to user 'u2'@'localhost' for table 't1'")
 	// Should verify privilege using plugin impl.
-	p.AssertNumberOfCalls(t, "VerifyPrivilege", 3)
+	p.AssertNumberOfCalls(t, "VerifyPrivilege", 4)
 	p.AssertCalled(t, "VerifyPrivilege", selectMatcher)
 	p.AssertCalled(t, "VerifyPrivilege", insertMatcher)
 
@@ -403,7 +403,7 @@ func TestAuthPluginSwitchPlugins(t *testing.T) {
 	// Existing session should still use plugin.
 	tk2.MustQuery("select * from t1 where id=1").Check(testkit.Rows("1 10"))
 	tk2.MustQuery("select * from t1").Check(testkit.Rows("1 10", "2 20"))
-	p.AssertNumberOfCalls(t, "VerifyPrivilege", 5)
+	p.AssertNumberOfCalls(t, "VerifyPrivilege", 7)
 
 	// New session should not use plugin.
 	tk2.RefreshSession()
@@ -414,7 +414,7 @@ func TestAuthPluginSwitchPlugins(t *testing.T) {
 	tk2.MustExec("insert into t1 values (3, 30), (4, 40)")
 	tk2.MustQuery("select * from t1 where id=3").Check(testkit.Rows("3 30"))
 	// Should not verify privilege using plugin impl now that the user is not using the plugin.
-	p.AssertNumberOfCalls(t, "VerifyPrivilege", 5)
+	p.AssertNumberOfCalls(t, "VerifyPrivilege", 7)
 
 	// Switch back to plugin should work.
 	tk.MustExec("alter user 'u2'@'localhost' identified with 'authentication_test_plugin' by 'rawpassword'")
@@ -427,7 +427,7 @@ func TestAuthPluginSwitchPlugins(t *testing.T) {
 	tk2.MustQuery("select * from t1 where id=1").Check(testkit.Rows("1 10"))
 	require.EqualError(t, tk2.ExecToErr("insert into t1 values (5, 50)"), "[planner:1142]INSERT command denied to user 'u2'@'localhost' for table 't1'")
 	// Now it should verify privilege using plugin impl.
-	p.AssertNumberOfCalls(t, "VerifyPrivilege", 7)
+	p.AssertNumberOfCalls(t, "VerifyPrivilege", 9)
 }
 
 func TestCreateUserWhenGrant(t *testing.T) {
@@ -578,7 +578,7 @@ func TestCreateViewWithPluginUser(t *testing.T) {
 	tk2.MustQuery("select * from v1").Check(testkit.Rows("1 10", "2 20"))
 	// Session 1 should also be able to access the view now.
 	tk1.MustQuery("select * from v1").Check(testkit.Rows("1 10", "2 20"))
-	p.AssertNumberOfCalls(t, "VerifyPrivilege", 5)
+	p.AssertNumberOfCalls(t, "VerifyPrivilege", 8)
 
 	tk3 := testkit.NewTestKit(t, store)
 	tk3.Session().SetExtensions(ext.NewSessionExtensions())
@@ -589,7 +589,7 @@ func TestCreateViewWithPluginUser(t *testing.T) {
 	p.On("VerifyPrivilege", selectMatcher).Return(false)
 	tk3.MustQuery("select * from v1").Check(testkit.Rows("1 10", "2 20"))
 	// Should not verify privilege using the plugin since the definer is not in-session.
-	p.AssertNumberOfCalls(t, "VerifyPrivilege", 5)
+	p.AssertNumberOfCalls(t, "VerifyPrivilege", 8)
 }
 
 func TestPluginUserModification(t *testing.T) {

--- a/pkg/extension/registry_test.go
+++ b/pkg/extension/registry_test.go
@@ -311,15 +311,15 @@ func TestCustomAccessCheck(t *testing.T) {
 	tk1.MustQuery("select * from t1 where id=1").Check(testkit.Rows("1 10"))
 	tk1.MustQuery("select * from t1").Check(testkit.Rows("1 10", "2 20"))
 
-	require.EqualError(t, tk2.ExecToErr("select * from t1 where id=1"), "[planner:1142]SELECT command denied to user 'u2'@'localhost' for table 't1'")
+	require.EqualError(t, tk2.ExecToErr("select * from t1 where id=1"), "[planner:1143]SELECT command denied to user 'u2'@'localhost' for column 'id' in table 't1'")
 	require.EqualError(t, tk2.ExecToErr("select * from t1"), "[planner:1142]SELECT command denied to user 'u2'@'localhost' for table 't1'")
 
 	tk.MustExec("GRANT priv1 on *.* TO u2@localhost")
 	tk2.MustQuery("select * from t1 where id=1").Check(testkit.Rows("1 10"))
 	tk2.MustQuery("select * from t1").Check(testkit.Rows("1 10", "2 20"))
 
-	require.EqualError(t, tk2.ExecToErr("update t1 set v=11 where id=1"), "[planner:8121]privilege check for 'Update' fail")
-	require.EqualError(t, tk2.ExecToErr("update t1 set v=11 where id<2"), "[planner:8121]privilege check for 'Update' fail")
+	require.EqualError(t, tk2.ExecToErr("update t1 set v=11 where id=1"), "[planner:1143]UPDATE command denied to user 'u2'@'localhost' for column 'v' in table 't1'")
+	require.EqualError(t, tk2.ExecToErr("update t1 set v=11 where id<2"), "[planner:1143]UPDATE command denied to user 'u2'@'localhost' for column 'v' in table 't1'")
 	tk2.MustQuery("select * from t1 where id=1").Check(testkit.Rows("1 10"))
 
 	tk.MustExec("GRANT priv2 on *.* TO u2@localhost")
@@ -332,12 +332,12 @@ func TestCustomAccessCheck(t *testing.T) {
 	sem.Enable()
 	defer sem.Disable()
 
-	require.EqualError(t, tk1.ExecToErr("update t1 set v=21 where id=1"), "[planner:8121]privilege check for 'Update' fail")
-	require.EqualError(t, tk1.ExecToErr("update t1 set v=21 where id<2"), "[planner:8121]privilege check for 'Update' fail")
+	require.EqualError(t, tk1.ExecToErr("update t1 set v=21 where id=1"), "[planner:1143]UPDATE command denied to user 'root'@'%' for column 'v' in table 't1'")
+	require.EqualError(t, tk1.ExecToErr("update t1 set v=21 where id<2"), "[planner:1143]UPDATE command denied to user 'root'@'%' for column 'v' in table 't1'")
 	tk1.MustQuery("select * from t1 where id=1").Check(testkit.Rows("1 12"))
 
-	require.EqualError(t, tk2.ExecToErr("update t1 set v=21 where id=1"), "[planner:8121]privilege check for 'Update' fail")
-	require.EqualError(t, tk2.ExecToErr("update t1 set v=21 where id<2"), "[planner:8121]privilege check for 'Update' fail")
+	require.EqualError(t, tk2.ExecToErr("update t1 set v=21 where id=1"), "[planner:1143]UPDATE command denied to user 'u2'@'localhost' for column 'v' in table 't1'")
+	require.EqualError(t, tk2.ExecToErr("update t1 set v=21 where id<2"), "[planner:1143]UPDATE command denied to user 'u2'@'localhost' for column 'v' in table 't1'")
 	tk2.MustQuery("select * from t1 where id=1").Check(testkit.Rows("1 12"))
 
 	tk.MustExec("GRANT restricted_priv3 on *.* TO u2@localhost")

--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -660,6 +660,10 @@ func (n SelectLockType) String() string {
 type WildCardField struct {
 	node
 
+	// For example:
+	// `SELECT test.t.* FROM t` -> {Schema: "test", Table: "t"}
+	// `SELECT t.* FROM t` -> {Schema: "", Table: "t"}
+	// `SELECT t.a FROM t` -> nil
 	Table  model.CIStr
 	Schema model.CIStr
 }
@@ -708,6 +712,13 @@ type SelectField struct {
 	Auxiliary             bool
 	AuxiliaryColInAgg     bool
 	AuxiliaryColInOrderBy bool
+
+	// IsUnfoldFromWildCard indicates whether this field is unfolded from a wildcard, which can be used in checking privilege.
+	// Although we always check SELECT privilege in column-level, a table-level access deny error will be return if the
+	// column is unfolded from a wildcard. For example, assume that table t has columns (a,b,c)
+	// Both `SELECT * FROM t` and `SELECT a,b,c FROM t`` require SELECT privilege of a,b and c.
+	// But if lacking privilege, the former reports error code 1142, the latter reports 1143.
+	IsUnfoldFromWildCard bool
 }
 
 // Restore implements Node interface.

--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -2842,6 +2842,8 @@ type PrivElem struct {
 
 	Priv mysql.PrivilegeType
 	Cols []*ColumnName
+
+	// Name stores the extended privilege like dynamic privilege.
 	Name string
 }
 
@@ -2931,7 +2933,7 @@ const (
 	GrantLevelGlobal
 	// GrantLevelDB means the privileges apply to all objects in a given database.
 	GrantLevelDB
-	// GrantLevelTable means the privileges apply to all columns in a given table.
+	// GrantLevelTable means the privileges apply to some or all columns in a given table.
 	GrantLevelTable
 )
 

--- a/pkg/parser/auth/auth.go
+++ b/pkg/parser/auth/auth.go
@@ -93,3 +93,14 @@ func (role *RoleIdentity) String() string {
 	// TODO: Escape username and hostname.
 	return fmt.Sprintf("`%s`@`%s`", role.Username, role.Hostname)
 }
+
+// GetUserAndHostName returns the user and host name if the given user is not nil.
+func GetUserAndHostName(user *UserIdentity) (username string, hostname string) {
+	if user == nil {
+		return "", ""
+	}
+	if len(user.AuthUsername) > 0 && len(user.AuthHostname) > 0 {
+		return user.AuthUsername, user.AuthHostname
+	}
+	return user.Username, user.Hostname
+}

--- a/pkg/planner/core/core_init.go
+++ b/pkg/planner/core/core_init.go
@@ -16,11 +16,14 @@ package core
 
 import (
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/cardinality"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
+	"github.com/pingcap/tidb/pkg/planner/planctx"
 	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/utilfuncp"
 	"github.com/pingcap/tidb/pkg/statistics"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/set"
 	"go.uber.org/atomic"
 )
@@ -81,7 +84,11 @@ func init() {
 	expression.EncodeRecordKeyFromRow = helper.encodeHandleFromRow
 	expression.EncodeIndexKeyFromRow = helper.encodeIndexKeyFromRow
 	plannerutil.EvalAstExprWithPlanCtx = evalAstExprWithPlanCtx
-	plannerutil.RewriteAstExprWithPlanCtx = rewriteAstExprWithPlanCtx
+	plannerutil.RewriteAstExprWithPlanCtx = func(ctx planctx.PlanContext, expr ast.ExprNode,
+		schema *expression.Schema, names types.NameSlice, allowCastArray bool) (expression.Expression, error) {
+		newExpr, _, err := rewriteAstExprWithPlanCtx(ctx, expr, schema, names, allowCastArray)
+		return newExpr, err
+	}
 	DefaultDisabledLogicalRulesList = new(atomic.Value)
 	DefaultDisabledLogicalRulesList.Store(set.NewStringSet())
 }

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -59,7 +60,7 @@ func evalAstExprWithPlanCtx(sctx base.PlanContext, expr ast.ExprNode) (types.Dat
 	if val, ok := expr.(*driver.ValueExpr); ok {
 		return val.Datum, nil
 	}
-	newExpr, err := rewriteAstExprWithPlanCtx(sctx, expr, nil, nil, false)
+	newExpr, _, err := rewriteAstExprWithPlanCtx(sctx, expr, nil, nil, false)
 	if err != nil {
 		return types.Datum{}, err
 	}
@@ -81,7 +82,7 @@ func evalAstExpr(ctx expression.BuildContext, expr ast.ExprNode) (types.Datum, e
 // rewriteAstExprWithPlanCtx rewrites ast expression directly.
 // Different with expression.BuildSimpleExpr, it uses planner context and is more powerful to build some special expressions
 // like subquery, window function, etc.
-func rewriteAstExprWithPlanCtx(sctx base.PlanContext, expr ast.ExprNode, schema *expression.Schema, names types.NameSlice, allowCastArray bool) (expression.Expression, error) {
+func rewriteAstExprWithPlanCtx(sctx base.PlanContext, expr ast.ExprNode, schema *expression.Schema, names types.NameSlice, allowCastArray bool) (expression.Expression, []visitInfo, error) {
 	var is infoschema.InfoSchema
 	// in tests, it may be null
 	if s, ok := sctx.GetInfoSchema().(infoschema.InfoSchema); ok {
@@ -95,12 +96,13 @@ func rewriteAstExprWithPlanCtx(sctx base.PlanContext, expr ast.ExprNode, schema 
 		fakePlan.SetOutputNames(names)
 	}
 	b.curClause = expressionClause
+	b.checkColPriv = reportColumnErrOption
 	newExpr, _, err := b.rewrite(context.TODO(), expr, fakePlan, nil, true)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	sctx.GetSessionVars().PlannerSelectBlockAsName.Store(&savedBlockNames)
-	return newExpr, nil
+	return newExpr, b.visitInfo, nil
 }
 
 func buildSimpleExpr(ctx expression.BuildContext, node ast.ExprNode, opts ...expression.BuildOption) (expression.Expression, error) {
@@ -202,9 +204,9 @@ func (b *PlanBuilder) rewriteInsertOnDuplicateUpdate(ctx context.Context, exprNo
 // aggMapper maps ast.AggregateFuncExpr to the columns offset in p's output schema.
 // asScalar means whether this expression must be treated as a scalar expression.
 // And this function returns a result expression, a new plan that may have apply or semi-join.
-func (b *PlanBuilder) rewrite(ctx context.Context, exprNode ast.ExprNode, p base.LogicalPlan, aggMapper map[*ast.AggregateFuncExpr]int, asScalar bool) (expression.Expression, base.LogicalPlan, error) {
-	expr, resultPlan, err := b.rewriteWithPreprocess(ctx, exprNode, p, aggMapper, nil, asScalar, nil)
-	return expr, resultPlan, err
+func (b *PlanBuilder) rewrite(ctx context.Context, exprNode ast.ExprNode, p base.LogicalPlan,
+	aggMapper map[*ast.AggregateFuncExpr]int, asScalar bool) (expression.Expression, base.LogicalPlan, error) {
+	return b.rewriteWithPreprocess(ctx, exprNode, p, aggMapper, nil, asScalar, nil)
 }
 
 // rewriteWithPreprocess is for handling the situation that we need to adjust the input ast tree
@@ -236,8 +238,7 @@ func (b *PlanBuilder) rewriteWithPreprocess(
 	rewriter.allowBuildCastArray = b.allowBuildCastArray
 	rewriter.preprocess = preprocess
 
-	expr, resultPlan, err := rewriteExprNode(rewriter, exprNode, asScalar)
-	return expr, resultPlan, err
+	return rewriteExprNode(rewriter, exprNode, asScalar)
 }
 
 func (b *PlanBuilder) getExpressionRewriter(ctx context.Context, p base.LogicalPlan) (rewriter *expressionRewriter) {
@@ -251,7 +252,15 @@ func (b *PlanBuilder) getExpressionRewriter(ctx context.Context, p base.LogicalP
 	if len(b.rewriterPool) < b.rewriterCounter {
 		rewriter = &expressionRewriter{
 			sctx: b.ctx.GetExprCtx(), ctx: ctx,
-			planCtx: &exprRewriterPlanCtx{plan: p, builder: b, curClause: b.curClause, rollExpand: b.currentBlockExpand},
+			planCtx: &exprRewriterPlanCtx{
+				plan:    p,
+				builder: b,
+
+				curClause:  b.curClause,
+				rollExpand: b.currentBlockExpand,
+
+				colNamesForLazilyPrivilegeCheck: make([]*ast.ColumnName, 0, 8),
+			},
 		}
 		b.rewriterPool = append(b.rewriterPool, rewriter)
 		return
@@ -271,6 +280,7 @@ func (b *PlanBuilder) getExpressionRewriter(ctx context.Context, p base.LogicalP
 	rewriter.planCtx.aggrMap = nil
 	rewriter.planCtx.insertPlan = nil
 	rewriter.planCtx.rollExpand = b.currentBlockExpand
+	rewriter.planCtx.colNamesForLazilyPrivilegeCheck = make([]*ast.ColumnName, 0, 8)
 	return
 }
 
@@ -298,6 +308,11 @@ func rewriteExprNode(rewriter *expressionRewriter, exprNode ast.ExprNode, asScal
 			planCtx.plan.SetOutputNames(names)
 		}()
 	}
+	defer func() {
+		if planCtx != nil && len(planCtx.colNamesForLazilyPrivilegeCheck) > 0 && planCtx.builder.checkColPriv != noCheckOption {
+			planCtx.builder.appendColNamesToVisitInfo(planCtx.colNamesForLazilyPrivilegeCheck)
+		}
+	}()
 	exprNode.Accept(rewriter)
 	if rewriter.err != nil {
 		return nil, nil, errors.Trace(rewriter.err)
@@ -336,6 +351,10 @@ type exprRewriterPlanCtx struct {
 	insertPlan *Insert
 
 	rollExpand *logicalop.LogicalExpand
+
+	// colNamesForLazilyPrivilegeCheck pre-collects the visited columns during rewriting, These columns
+	// will be added to PlanBuilder.visitInfo, and be later checked in CheckPrivilege after building plan.
+	colNamesForLazilyPrivilegeCheck []*ast.ColumnName
 }
 
 type expressionRewriter struct {
@@ -1459,8 +1478,12 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 	}
 
 	switch v := inNode.(type) {
-	case *ast.AggregateFuncExpr, *ast.ColumnNameExpr, *ast.ParenthesesExpr, *ast.WhenClause,
-		*ast.SubqueryExpr, *ast.ExistsSubqueryExpr, *ast.CompareSubqueryExpr, *ast.ValuesExpr, *ast.WindowFuncExpr, *ast.TableNameExpr:
+	case *ast.AggregateFuncExpr:
+		if v.F == ast.AggFuncCount {
+			er.collectPrivsForCount()
+		}
+	case *ast.ColumnNameExpr, *ast.ParenthesesExpr, *ast.WhenClause, *ast.SubqueryExpr,
+		*ast.ExistsSubqueryExpr, *ast.CompareSubqueryExpr, *ast.ValuesExpr, *ast.WindowFuncExpr, *ast.TableNameExpr:
 	case *driver.ValueExpr:
 		// set right not null flag for constant value
 		retType := v.Type.Clone()
@@ -2439,6 +2462,48 @@ func (er *expressionRewriter) funcCallToExpression(v *ast.FuncCallExpr) {
 	}
 }
 
+// Assume that there are two tables t and t1, which contain a and b columns individually. In MySQL:
+// -- Require `a` or `b` SELECT privilege
+// select count(*) from t;
+// select count(1) from t;
+// -- Require `a` SELECT privilege
+// select count(a) from t;
+// -- Require `b` SELECT privilege
+// select count(b) from t;
+// -- Require `SELCT` privilege of `t.a` and `t1.a`
+// select count(*) from t join t1 on t.a = t1.a;
+func (er *expressionRewriter) collectPrivsForCount() {
+	b := er.planCtx.builder
+	if b == nil {
+		return
+	}
+	// dbName -> tableName
+	tableNames := make(map[string]map[string]struct{})
+	for _, fieldName := range er.names {
+		tblName := &ast.TableName{
+			Name:   fieldName.OrigTblName,
+			Schema: fieldName.DBName,
+		}
+		if b.is != nil && infoschema.TableIsView(b.is, fieldName.DBName, fieldName.TblName) {
+			tblName.Name = fieldName.TblName
+		}
+		if len(tblName.Name.L) > 0 && len(tblName.Schema.L) > 0 {
+			if _, ok := tableNames[tblName.Schema.L]; !ok {
+				tableNames[tblName.Schema.L] = make(map[string]struct{})
+			}
+			tableNames[tblName.Schema.L][tblName.Name.L] = struct{}{}
+		}
+	}
+
+	user, host := auth.GetUserAndHostName(b.ctx.GetSessionVars().User)
+	for db, tables := range tableNames {
+		for table := range tables {
+			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, db, table, "*",
+				plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", user, host, table))
+		}
+	}
+}
+
 // Now TableName in expression only used by sequence function like nextval(seq).
 // The function arg should be evaluated as a table name rather than normal column name like mysql does.
 func (er *expressionRewriter) toTable(v *ast.TableName) {
@@ -2475,6 +2540,12 @@ func (er *expressionRewriter) clause() clauseCode {
 }
 
 func (er *expressionRewriter) toColumn(v *ast.ColumnName) {
+	var fieldName4PrivilegeCheck *types.FieldName
+	defer func() {
+		if fieldName4PrivilegeCheck != nil && er.planCtx != nil {
+			er.precollectColNames(fieldName4PrivilegeCheck)
+		}
+	}()
 	idx, err := expression.FindFieldName(er.names, v)
 	if err != nil {
 		er.err = plannererrors.ErrAmbiguous.GenWithStackByArgs(v.Name, clauseMsg[fieldList])
@@ -2487,6 +2558,7 @@ func (er *expressionRewriter) toColumn(v *ast.ColumnName) {
 			return
 		}
 		er.ctxStackAppend(column, er.names[idx])
+		fieldName4PrivilegeCheck = er.names[idx]
 		return
 	} else if er.planCtx == nil && er.sourceTable != nil &&
 		(v.Table.L == "" || er.sourceTable.Name.L == v.Table.L) {
@@ -2512,6 +2584,7 @@ func (er *expressionRewriter) toColumn(v *ast.ColumnName) {
 		return
 	} else if col != nil {
 		er.ctxStackAppend(col, name)
+		fieldName4PrivilegeCheck = name
 		return
 	}
 	for i := len(planCtx.builder.outerSchemas) - 1; i >= 0; i-- {
@@ -2520,6 +2593,7 @@ func (er *expressionRewriter) toColumn(v *ast.ColumnName) {
 		if idx >= 0 {
 			column := outerSchema.Columns[idx]
 			er.ctxStackAppend(&expression.CorrelatedColumn{Column: *column, Data: new(types.Datum)}, outerName[idx])
+			fieldName4PrivilegeCheck = outerName[idx]
 			return
 		}
 		if err != nil {
@@ -2689,4 +2763,65 @@ func hasLimit(plan base.LogicalPlan) bool {
 		}
 	}
 	return false
+}
+
+func (b *PlanBuilder) appendColNamesToVisitInfo(columnVisited []*ast.ColumnName) {
+	user, host := auth.GetUserAndHostName(b.ctx.GetSessionVars().User)
+	views := b.SavedViews
+	switch {
+	case len(views) > 0:
+		view := views[len(views)-1]
+		for _, colName := range columnVisited {
+			b.visitInfo = appendVisitInfo(b.visitInfo,
+				mysql.SelectPriv,
+				colName.Schema.L,
+				colName.Table.L,
+				colName.Name.L,
+				plannererrors.ErrViewInvalid.GenWithStackByArgs(view.Schema.O, view.Name.O),
+			)
+		}
+	case b.checkColPriv == reportTableErrOption:
+		for _, colName := range columnVisited {
+			b.visitInfo = appendVisitInfo(b.visitInfo,
+				mysql.SelectPriv,
+				colName.Schema.L,
+				colName.Table.L,
+				colName.Name.L,
+				plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", user, host, colName.Table.L),
+			)
+		}
+	default:
+		for _, colName := range columnVisited {
+			b.visitInfo = appendVisitInfo(b.visitInfo,
+				mysql.SelectPriv,
+				colName.Schema.L,
+				colName.Table.L,
+				colName.Name.L,
+				plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", user, host, colName.Name.L, colName.Table.L),
+			)
+		}
+	}
+}
+
+func (er *expressionRewriter) precollectColNames(fieldName *types.FieldName) {
+	colName := &ast.ColumnName{
+		Name:   fieldName.OrigColName,
+		Table:  fieldName.OrigTblName,
+		Schema: fieldName.DBName,
+	}
+	b := er.planCtx.builder
+	if b != nil && b.is != nil && infoschema.TableIsView(b.is, fieldName.DBName, fieldName.TblName) {
+		colName.Name = fieldName.ColName
+		colName.Table = fieldName.TblName
+	}
+
+	// When checking a derived table, its colName.Schema.L would be empty, we can just skip it.
+	// Because the column privilege is checked in the definition of derived table.
+	if len(colName.Name.L) > 0 && len(colName.Table.L) > 0 && len(colName.Schema.L) > 0 {
+		// The column privilege is checked in the definition of CTE.
+		if _, ok := b.nameMapCTE[colName.Table.L]; ok {
+			return
+		}
+		er.planCtx.colNamesForLazilyPrivilegeCheck = append(er.planCtx.colNamesForLazilyPrivilegeCheck, colName)
+	}
 }

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/format"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
@@ -257,6 +258,12 @@ func (b *PlanBuilder) buildAggregation(ctx context.Context, p base.LogicalPlan, 
 	b.optFlag |= rule.FlagPredicatePushDown
 	b.optFlag |= rule.FlagEliminateAgg
 	b.optFlag |= rule.FlagEliminateProjection
+
+	originColPriv := b.checkColPriv
+	b.checkColPriv = reportColumnErrOption
+	defer func() {
+		b.checkColPriv = originColPriv
+	}()
 
 	if b.ctx.GetSessionVars().EnableSkewDistinctAgg {
 		b.optFlag |= rule.FlagSkewDistinctAgg
@@ -669,7 +676,10 @@ func (b *PlanBuilder) buildJoin(ctx context.Context, joinNode *ast.Join) (base.L
 		}
 	} else if joinNode.On != nil {
 		b.curClause = onClause
+		originColPriv := b.checkColPriv
+		b.checkColPriv = reportColumnErrOption
 		onExpr, newPlan, err := b.rewrite(ctx, joinNode.On.Expr, joinPlan, nil, false)
+		b.checkColPriv = originColPriv
 		if err != nil {
 			return nil, err
 		}
@@ -827,6 +837,11 @@ func (b *PlanBuilder) coalesceCommonColumns(p *logicalop.LogicalJoin, leftPlan, 
 		}
 	}
 
+	originColPriv := b.checkColPriv
+	b.checkColPriv = reportColumnErrOption
+	defer func() {
+		b.checkColPriv = originColPriv
+	}()
 	// Find out all the common columns and put them ahead.
 	commonLen := 0
 	for i, lName := range lNames {
@@ -862,6 +877,25 @@ func (b *PlanBuilder) coalesceCommonColumns(p *logicalop.LogicalJoin, leftPlan, 
 			name = rNames[j]
 			copy(rNames[commonLen+1:j+1], rNames[commonLen:j])
 			rNames[commonLen] = name
+
+			for _, fieldName := range []*types.FieldName{lName, rNames[j]} {
+				colName := &ast.ColumnName{
+					Name:   fieldName.OrigColName,
+					Table:  fieldName.OrigTblName,
+					Schema: fieldName.DBName,
+				}
+				if b.is != nil && infoschema.TableIsView(b.is, fieldName.DBName, fieldName.TblName) {
+					colName.Name = fieldName.ColName
+					colName.Table = fieldName.TblName
+				}
+				if len(colName.Name.L) > 0 && len(colName.Table.L) > 0 && len(colName.Schema.L) > 0 {
+					// The column privilege is checked in the definition of CTE.
+					if _, ok := b.nameMapCTE[colName.Table.L]; ok {
+						continue
+					}
+					b.appendColNamesToVisitInfo([]*ast.ColumnName{colName})
+				}
+			}
 
 			commonLen++
 			break
@@ -916,6 +950,11 @@ func (b *PlanBuilder) buildSelection(ctx context.Context, p base.LogicalPlan, wh
 	if b.curClause != havingClause {
 		b.curClause = whereClause
 	}
+	originColPriv := b.checkColPriv
+	b.checkColPriv = reportColumnErrOption
+	defer func() {
+		b.checkColPriv = originColPriv
+	}()
 
 	conditions := splitWhere(where)
 	expressions := make([]expression.Expression, 0, len(conditions))
@@ -1333,7 +1372,14 @@ func (b *PlanBuilder) buildProjection(ctx context.Context, p base.LogicalPlan, f
 			newNames = append(newNames, name)
 			continue
 		}
+		originColPriv := b.checkColPriv
+		if field.IsUnfoldFromWildCard {
+			b.checkColPriv = reportTableErrOption
+		} else {
+			b.checkColPriv = reportColumnErrOption
+		}
 		newExpr, np, err := b.rewriteWithPreprocess(ctx, field.Expr, p, mapper, windowMapper, true, nil)
+		b.checkColPriv = originColPriv
 		if err != nil {
 			return nil, nil, 0, err
 		}
@@ -1928,6 +1974,11 @@ func (b *PlanBuilder) buildSort(ctx context.Context, p base.LogicalPlan, byItems
 
 func (b *PlanBuilder) buildSortWithCheck(ctx context.Context, p base.LogicalPlan, byItems []*ast.ByItem, aggMapper map[*ast.AggregateFuncExpr]int, windowMapper map[*ast.WindowFuncExpr]int,
 	projExprs []expression.Expression, oldLen int, hasDistinct bool) (*logicalop.LogicalSort, error) {
+	originColPriv := b.checkColPriv
+	defer func() {
+		b.checkColPriv = originColPriv
+	}()
+	b.checkColPriv = reportColumnErrOption
 	if _, isUnion := p.(*logicalop.LogicalUnionAll); isUnion {
 		b.curClause = globalOrderByClause
 	} else {
@@ -2126,6 +2177,7 @@ func (b *PlanBuilder) buildLimit(src base.LogicalPlan, limit *ast.Limit) (base.L
 	return li, nil
 }
 
+// resolveFromSelectFields returns the index of v in fields
 func resolveFromSelectFields(v *ast.ColumnNameExpr, fields []*ast.SelectField, ignoreAsName bool) (index int, err error) {
 	var matchedExpr ast.ExprNode
 	index = -1
@@ -2358,9 +2410,7 @@ func (a *havingWindowAndOrderbyExprResolver) Leave(n ast.Node) (node ast.Node, o
 		} else {
 			// We should ignore the err when resolving from schema. Because we could resolve successfully
 			// when considering select fields.
-			var err error
-			index, err = a.resolveFromPlan(v, a.p, resolveFieldsFirst)
-			_ = err
+			index, _ = a.resolveFromPlan(v, a.p, resolveFieldsFirst)
 			if index == -1 && a.curClause != fieldList &&
 				a.curClause != windowOrderByClause && a.curClause != partitionByClause {
 				index, a.err = resolveFromSelectFields(v, a.selectFields, false)
@@ -2442,6 +2492,8 @@ func (b *PlanBuilder) resolveHavingAndOrderBy(ctx context.Context, sel *ast.Sele
 	// this part is used to fetch correlated column from sub-query item in order-by clause, and append the origin
 	// auxiliary select filed in select list, otherwise, sub-query itself won't get the name resolved in outer schema.
 	if sel.OrderBy != nil {
+		originColPriv := b.checkColPriv
+		b.checkColPriv = reportColumnErrOption
 		for _, byItem := range sel.OrderBy.Items {
 			if _, ok := byItem.Expr.(*ast.SubqueryExpr); ok {
 				// correlated agg will be extracted completely latter.
@@ -2483,6 +2535,7 @@ func (b *PlanBuilder) resolveHavingAndOrderBy(ctx context.Context, sel *ast.Sele
 				}
 			}
 		}
+		b.checkColPriv = originColPriv
 	}
 	return havingAggMapper, extractor.aggMapper, nil
 }
@@ -2530,6 +2583,11 @@ func (b *PlanBuilder) extractCorrelatedAggFuncs(ctx context.Context, p base.Logi
 	corCols := make([]*expression.CorrelatedColumn, 0, len(aggFuncs))
 	cols := make([]*expression.Column, 0, len(aggFuncs))
 	aggMapper := make(map[*ast.AggregateFuncExpr]int)
+	originColPriv := b.checkColPriv
+	b.checkColPriv = reportColumnErrOption
+	defer func() {
+		b.checkColPriv = originColPriv
+	}()
 	for _, agg := range aggFuncs {
 		for _, arg := range agg.Args {
 			expr, _, err := b.rewrite(ctx, arg, p, aggMapper, true)
@@ -3505,6 +3563,11 @@ func (b *PlanBuilder) resolveGbyExprs(p base.LogicalPlan, gby *ast.GroupByClause
 		names:      p.OutputNames(),
 		skipAggMap: b.correlatedAggMapper,
 	}
+	originColPriv := b.checkColPriv
+	b.checkColPriv = reportColumnErrOption
+	defer func() {
+		b.checkColPriv = originColPriv
+	}()
 	for _, item := range gby.Items {
 		resolver.inExpr = false
 		resolver.exprDepth = 0
@@ -3580,12 +3643,12 @@ func unfoldWildStar(field *ast.SelectField, outputName types.NameSlice, column [
 					Name:   name.ColName,
 				}}
 			colName.SetType(col.GetStaticType())
-			field := &ast.SelectField{Expr: colName}
+			field := &ast.SelectField{Expr: colName, IsUnfoldFromWildCard: true}
 			field.SetText(nil, name.ColName.O)
 			resultList = append(resultList, field)
 		}
 	}
-	return resultList
+	return
 }
 
 func (b *PlanBuilder) addAliasName(ctx context.Context, selectStmt *ast.SelectStmt, p base.LogicalPlan) (resultList []*ast.SelectField, err error) {
@@ -4435,12 +4498,6 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 		return nil, plannererrors.ErrViewSelectTemporaryTable.GenWithStackByArgs(tn.Name)
 	}
 
-	var authErr error
-	if sessionVars.User != nil {
-		authErr = plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", sessionVars.User.AuthUsername, sessionVars.User.AuthHostname, tableInfo.Name.L)
-	}
-	b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, dbName.L, tableInfo.Name.L, "", authErr)
-
 	if tbl.Type().IsVirtualTable() {
 		if tn.TableSample != nil {
 			return nil, expression.ErrInvalidTableSample.GenWithStackByArgs("Unsupported TABLESAMPLE in virtual tables")
@@ -4713,6 +4770,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 	ds.SampleInfo = tablesampler.NewTableSampleInfo(tn.TableSample, schema, b.partitionedTable)
 	b.isSampling = ds.SampleInfo != nil
 
+	originColPriv := b.checkColPriv
 	for i, colExpr := range ds.Schema().Columns {
 		var expr expression.Expression
 		if i < len(columns) {
@@ -4729,6 +4787,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 			}
 		}
 	}
+	b.checkColPriv = originColPriv
 
 	// Init CommonHandleCols and CommonHandleLens for data source.
 	if tableInfo.IsCommonHandle {
@@ -4951,8 +5010,12 @@ func (b *PlanBuilder) checkRecursiveView(dbName pmodel.CIStr, tableName pmodel.C
 // qbNameMap4View maps the query block name to the view table lists.
 // viewHints group the view hints based on the view's query block name.
 func (b *PlanBuilder) BuildDataSourceFromView(ctx context.Context, dbName pmodel.CIStr, tableInfo *model.TableInfo, qbNameMap4View map[string][]ast.HintTable, viewHints map[string][]*ast.TableOptimizerHint) (base.LogicalPlan, error) {
-	viewDepth := b.ctx.GetSessionVars().StmtCtx.ViewDepth
-	b.ctx.GetSessionVars().StmtCtx.ViewDepth++
+	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	viewDepth := len(b.SavedViews)
+	b.SavedViews = append(b.SavedViews, &ast.TableName{Schema: dbName, Name: tableInfo.Name})
+	defer func() {
+		b.SavedViews = b.SavedViews[:len(b.SavedViews)-1]
+	}()
 	deferFunc, err := b.checkRecursiveView(dbName, tableInfo.Name)
 	if err != nil {
 		return nil, err
@@ -5048,14 +5111,15 @@ func (b *PlanBuilder) BuildDataSourceFromView(ctx context.Context, dbName pmodel
 		return nil, err
 	}
 	pm := privilege.GetPrivilegeManager(b.ctx)
-	if viewDepth != 0 &&
-		b.ctx.GetSessionVars().StmtCtx.InExplainStmt &&
+	if viewDepth > 0 &&
+		stmtCtx.InExplainStmt &&
 		pm != nil &&
 		!pm.RequestVerification(b.ctx.GetSessionVars().ActiveRoles, dbName.L, tableInfo.Name.L, "", mysql.SelectPriv) {
 		return nil, plannererrors.ErrViewNoExplain
 	}
 	if tableInfo.View.Security == pmodel.SecurityDefiner {
 		if pm != nil {
+			// DEFINER VIEWs always use default roles
 			for _, v := range b.visitInfo {
 				if !pm.RequestVerificationWithUser(v.db, v.table, v.column, v.privilege, tableInfo.View.Definer) {
 					return nil, plannererrors.ErrViewInvalid.GenWithStackByArgs(dbName.O, tableInfo.Name.O)
@@ -5066,7 +5130,7 @@ func (b *PlanBuilder) BuildDataSourceFromView(ctx context.Context, dbName pmodel
 	}
 	b.visitInfo = append(originalVisitInfo, b.visitInfo...)
 
-	if b.ctx.GetSessionVars().StmtCtx.InExplainStmt {
+	if stmtCtx.InExplainStmt {
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, dbName.L, tableInfo.Name.L, "", plannererrors.ErrViewNoExplain)
 	}
 
@@ -5522,19 +5586,6 @@ func (b *PlanBuilder) buildUpdate(ctx context.Context, update *ast.UpdateStmt) (
 		return nil, err
 	}
 
-	nodeW := resolve.NewNodeWWithCtx(update.TableRefs.TableRefs, b.resolveCtx)
-	tableList := ExtractTableList(nodeW, false)
-	for _, t := range tableList {
-		dbName := t.Schema.L
-		if dbName == "" {
-			dbName = b.ctx.GetSessionVars().CurrentDB
-		}
-		// Avoid adding CTE table to the SELECT privilege list, maybe we have better way to do this?
-		if _, ok := b.nameMapCTE[t.Name.L]; !ok {
-			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, dbName, t.Name.L, "", nil)
-		}
-	}
-
 	oldSchemaLen := p.Schema().Len()
 	if update.Where != nil {
 		p, err = b.buildSelection(ctx, p, update.Where, nil)
@@ -5746,6 +5797,11 @@ func (b *PlanBuilder) buildUpdateLists(ctx context.Context, tableList []*ast.Tab
 		// We save a flag for the column in map `modifyColumns`
 		// This flag indicated if assign keyword `DEFAULT` to the column
 		modifyColumns[columnFullName] = IsDefaultExprSameColumn(p.OutputNames()[idx:idx+1], assign.Expr)
+
+		// Check column privilege
+		userName, hostName := auth.GetUserAndHostName(b.ctx.GetSessionVars().User)
+		authErr := plannererrors.ErrColumnaccessDenied.FastGenByArgs("UPDATE", userName, hostName, name.OrigColName.L, name.OrigTblName.L)
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.UpdatePriv, name.DBName.L, name.OrigTblName.L, name.OrigColName.L, authErr)
 	}
 
 	// If columns in set list contains generated columns, raise error.
@@ -5796,6 +5852,12 @@ func (b *PlanBuilder) buildUpdateLists(ctx context.Context, tableList []*ast.Tab
 
 	allAssignments := append(list, virtualAssignments...)
 	dependentColumnsModified := make(map[int64]bool)
+
+	originColPriv := b.checkColPriv
+	b.checkColPriv = reportColumnErrOption
+	defer func() {
+		b.checkColPriv = originColPriv
+	}()
 	for i, assign := range allAssignments {
 		var idx int
 		var err error
@@ -5874,15 +5936,6 @@ func (b *PlanBuilder) buildUpdateLists(ctx context.Context, tableList []*ast.Tab
 			b.ctx.GetSessionVars().StmtCtx.ColRefFromUpdatePlan.UnionWith(cols)
 		}
 		newList = append(newList, &expression.Assignment{Col: col, ColName: name.ColName, Expr: newExpr})
-		dbName := name.DBName.L
-		// To solve issue#10028, we need to get database name by the table alias name.
-		if dbNameTmp, ok := tblDbMap[name.TblName.L]; ok {
-			dbName = dbNameTmp
-		}
-		if dbName == "" {
-			dbName = b.ctx.GetSessionVars().CurrentDB
-		}
-		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.UpdatePriv, dbName, name.OrigTblName.L, "", nil)
 	}
 	return newList, p, allAssignmentsAreConstant, nil
 }
@@ -6055,9 +6108,8 @@ func (b *PlanBuilder) buildDelete(ctx context.Context, ds *ast.DeleteStmt) (base
 			if dbName == "" {
 				dbName = b.ctx.GetSessionVars().CurrentDB
 			}
-			if sessionVars.User != nil {
-				authErr = plannererrors.ErrTableaccessDenied.FastGenByArgs("DELETE", sessionVars.User.AuthUsername, sessionVars.User.AuthHostname, v.Name.L)
-			}
+			userName, hostName := auth.GetUserAndHostName(sessionVars.User)
+			authErr = plannererrors.ErrTableaccessDenied.FastGenByArgs("DELETE", userName, hostName, v.Name.L)
 			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.DeletePriv, dbName, v.Name.L, "", authErr)
 		}
 	}
@@ -6432,6 +6484,11 @@ func (b *PlanBuilder) buildWindowFunctionFrame(ctx context.Context, spec *ast.Wi
 }
 
 func (b *PlanBuilder) checkWindowFuncArgs(ctx context.Context, p base.LogicalPlan, windowFuncExprs []*ast.WindowFuncExpr, windowAggMap map[*ast.AggregateFuncExpr]int) error {
+	originColPriv := b.checkColPriv
+	b.checkColPriv = reportColumnErrOption
+	defer func() {
+		b.checkColPriv = originColPriv
+	}()
 	checker := &expression.ParamMarkerInPrepareChecker{}
 	for _, windowFuncExpr := range windowFuncExprs {
 		if strings.ToLower(windowFuncExpr.Name) == ast.AggFuncGroupConcat {
@@ -6518,6 +6575,11 @@ func (b *PlanBuilder) buildWindowFunctions(ctx context.Context, p base.LogicalPl
 	if b.buildingCTE {
 		b.outerCTEs[len(b.outerCTEs)-1].containRecursiveForbiddenOperator = true
 	}
+	originColPriv := b.checkColPriv
+	b.checkColPriv = reportColumnErrOption
+	defer func() {
+		b.checkColPriv = originColPriv
+	}()
 	args := make([]ast.ExprNode, 0, 4)
 	windowMap := make(map[*ast.WindowFuncExpr]int)
 	for _, window := range sortWindowSpecs(groupedFuncs, orderedSpec) {
@@ -7136,6 +7198,20 @@ func appendVisitInfo(vi []visitInfo, priv mysql.PrivilegeType, db, tbl, col stri
 		column:    col,
 		err:       err,
 	})
+}
+
+func appendMultiColumns2VisitInfo(vi []visitInfo, priv mysql.PrivilegeType, db, tbl string, cols []*table.Column, err error) []visitInfo {
+	ret := vi
+	for _, col := range cols {
+		ret = append(ret, visitInfo{
+			privilege: priv,
+			db:        db,
+			table:     tbl,
+			column:    col.Name.L,
+			err:       err,
+		})
+	}
+	return ret
 }
 
 func getInnerFromParenthesesAndUnaryPlus(expr ast.ExprNode) ast.ExprNode {

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -17,6 +17,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -30,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/format"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -78,6 +80,37 @@ func CreatePlannerSuite(sctx sessionctx.Context, is infoschema.InfoSchema) (s *p
 	return s
 }
 
+func mockViewInvoker() *model.TableInfo {
+	selectStmt := "select b,c,d from t"
+	col0 := &model.ColumnInfo{
+		State:  model.StatePublic,
+		Offset: 0,
+		Name:   pmodel.NewCIStr("b"),
+		ID:     1,
+	}
+	col1 := &model.ColumnInfo{
+		State:  model.StatePublic,
+		Offset: 1,
+		Name:   pmodel.NewCIStr("c"),
+		ID:     2,
+	}
+	col2 := &model.ColumnInfo{
+		State:  model.StatePublic,
+		Offset: 2,
+		Name:   pmodel.NewCIStr("d"),
+		ID:     3,
+	}
+	view := &model.ViewInfo{SelectStmt: selectStmt, Security: pmodel.SecurityInvoker, Definer: &auth.UserIdentity{Username: "root", Hostname: ""}, Cols: []pmodel.CIStr{col0.Name, col1.Name, col2.Name}}
+	table := &model.TableInfo{
+		ID:      4,
+		Name:    pmodel.NewCIStr("v2"),
+		Columns: []*model.ColumnInfo{col0, col1, col2},
+		View:    view,
+		State:   model.StatePublic,
+	}
+	return table
+}
+
 func createPlannerSuite() (s *plannerSuite) {
 	s = new(plannerSuite)
 	tblInfos := []*model.TableInfo{
@@ -90,6 +123,7 @@ func createPlannerSuite() (s *plannerSuite) {
 		MockListPartitionTable(),
 		MockStateNoneColumnTable(),
 		MockGlobalIndexHashPartitionTable(),
+		mockViewInvoker(),
 	}
 	id := int64(1)
 	for _, tblInfo := range tblInfos {
@@ -1128,79 +1162,30 @@ func TestAggPrune(t *testing.T) {
 }
 
 func TestVisitInfo(t *testing.T) {
+	t.Run("test non-column privilege visit info", testNormalVisitInfo)
+	t.Run("test column privilege visit info", testColumnPrivilegeVisitInfo)
+}
+
+func testNormalVisitInfo(t *testing.T) {
 	variable.EnableMDL.Store(false)
 	tests := []struct {
 		sql string
 		ans []visitInfo
 	}{
 		{
-			sql: "insert into t (a) values (1)",
-			ans: []visitInfo{
-				{mysql.InsertPriv, "test", "t", "", nil, false, nil, false},
-			},
-		},
-		{
-			sql: "delete from t where a = 1",
-			ans: []visitInfo{
-				{mysql.DeletePriv, "test", "t", "", nil, false, nil, false},
-				{mysql.SelectPriv, "test", "t", "", nil, false, nil, false},
-			},
-		},
-		{
-			sql: "delete from t order by a",
-			ans: []visitInfo{
-				{mysql.DeletePriv, "test", "t", "", nil, false, nil, false},
-				{mysql.SelectPriv, "test", "t", "", nil, false, nil, false},
-			},
-		},
-		{
 			sql: "delete from t",
 			ans: []visitInfo{
-				{mysql.DeletePriv, "test", "t", "", nil, false, nil, false},
+				{mysql.DeletePriv, "test", "t", "", plannererrors.ErrTableaccessDenied.FastGenByArgs("DELETE", "", "", "t"), false, nil, false},
 			},
 		},
 		/* Not currently supported. See https://github.com/pingcap/tidb/issues/23644
 		{
 			sql: "delete from t where 1=1",
 			ans: []visitInfo{
-				{mysql.DeletePriv, "test", "t", "", nil, false, "", false},
+				{mysql.DeletePriv, "test", "t", "", nil, false, nil, false},
 			},
 		},
 		*/
-		{
-			sql: "delete from a1 using t as a1 inner join t as a2 where a1.a = a2.a",
-			ans: []visitInfo{
-				{mysql.DeletePriv, "test", "t", "", nil, false, nil, false},
-				{mysql.SelectPriv, "test", "t", "", nil, false, nil, false},
-			},
-		},
-		{
-			sql: "update t set a = 7 where a = 1",
-			ans: []visitInfo{
-				{mysql.UpdatePriv, "test", "t", "", nil, false, nil, false},
-				{mysql.SelectPriv, "test", "t", "", nil, false, nil, false},
-			},
-		},
-		{
-			sql: "update t, (select * from t) a1 set t.a = a1.a;",
-			ans: []visitInfo{
-				{mysql.UpdatePriv, "test", "t", "", nil, false, nil, false},
-				{mysql.SelectPriv, "test", "t", "", nil, false, nil, false},
-			},
-		},
-		{
-			sql: "update t a1 set a1.a = a1.a + 1",
-			ans: []visitInfo{
-				{mysql.UpdatePriv, "test", "t", "", nil, false, nil, false},
-				{mysql.SelectPriv, "test", "t", "", nil, false, nil, false},
-			},
-		},
-		{
-			sql: "select a, sum(e) from t group by a",
-			ans: []visitInfo{
-				{mysql.SelectPriv, "test", "t", "", nil, false, nil, false},
-			},
-		},
 		{
 			sql: "truncate table t",
 			ans: []visitInfo{
@@ -1526,18 +1511,10 @@ func TestVisitInfo(t *testing.T) {
 			},
 		},
 	}
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
-		// if true, test will too slow to run.
-		conf.Performance.EnableStatsCacheMemQuota = false
-	})
-	s := createPlannerSuite()
-	defer s.Close()
 	for _, tt := range tests {
-		comment := fmt.Sprintf("for %s", tt.sql)
+		s := createPlannerSuite()
 		stmt, err := s.p.ParseOneStmt(tt.sql, "", "")
-		require.NoError(t, err, comment)
+		require.NoError(t, err, tt.sql)
 
 		// TODO: to fix, Table 'test.ttt' doesn't exist
 		nodeW := resolve.NewNodeW(stmt)
@@ -1547,11 +1524,753 @@ func TestVisitInfo(t *testing.T) {
 		domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(s.is)
 		builder.ctx.GetSessionVars().SetHashJoinConcurrency(1)
 		_, err = builder.Build(context.TODO(), nodeW)
-		require.NoError(t, err, comment)
+		require.NoError(t, err, tt.sql)
 
-		checkVisitInfo(t, builder.visitInfo, tt.ans, comment)
+		checkVisitInfo(t, builder.visitInfo, tt.ans, tt.sql)
+		require.Nil(t, TryFastPlan(s.ctx, nodeW))
 
 		domain.GetDomain(sctx).StatsHandle().Close()
+	}
+}
+
+func testColumnPrivilegeVisitInfo(t *testing.T) {
+	variable.EnableMDL.Store(false)
+	tests := []struct {
+		sql string
+		ans []visitInfo
+	}{
+		{
+			sql: "insert into t (a) values (1)",
+			ans: []visitInfo{
+				{mysql.InsertPriv, "test", "t", "a", nil, false, nil, false},
+			},
+		},
+		{
+			sql: "delete from t order by a",
+			ans: []visitInfo{
+				{mysql.DeletePriv, "test", "t", "", plannererrors.ErrTableaccessDenied.FastGenByArgs("DELETE", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: "delete from a1 using t as a1 inner join t as a2 where a1.a = a2.a",
+			ans: []visitInfo{
+				{mysql.DeletePriv, "test", "t", "", nil, false, nil, false},
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: "update t set a = 7 where b = 1",
+			ans: []visitInfo{
+				{mysql.UpdatePriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("UPDATE", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: "update t, (select * from t) a1 set t.a = a1.a;",
+			ans: []visitInfo{
+				{mysql.UpdatePriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("UPDATE", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c_str", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "d", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "d_str", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "e", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "e_str", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "f", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "g", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "h", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "i_date", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+			},
+		},
+
+		{
+			sql: "update t a1 set a1.a = a1.a + 1",
+			ans: []visitInfo{
+				{mysql.UpdatePriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("UPDATE", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: "select a, sum(e) from t group by a",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "e", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "e", "t"), false, nil, false},
+			},
+		},
+
+		// View
+		{
+			sql: `select * from v where b = 1`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "v", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "v", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "v", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "v", "d", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "v"), false, nil, false},
+			},
+		},
+		{
+			sql: `select c,d from v where b = 1`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "v", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "v", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "v", "d", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "d", "v"), false, nil, false},
+			},
+		},
+		{
+			sql: `select * from v2 where b = 1`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrViewInvalid.FastGenByArgs("", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrViewInvalid.FastGenByArgs("", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "d", plannererrors.ErrViewInvalid.FastGenByArgs("", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "v2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "v2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "v2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "v2", "d", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "v2"), false, nil, false},
+			},
+		},
+		{
+			sql: `select c from v2 where b = 1`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrViewInvalid.FastGenByArgs("", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrViewInvalid.FastGenByArgs("", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "d", plannererrors.ErrViewInvalid.FastGenByArgs("", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "v2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "v2", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "v2"), false, nil, false},
+			},
+		},
+
+		// Aggregation
+		{
+			sql: "SELECT min(a), b AS b_alias, max(c) AS c_max FROM t",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: "SELECT min(b), c AS c_alias, max(d) AS d_max FROM v",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "v", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "v", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "v", "d", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "d", "v"), false, nil, false},
+			},
+		},
+
+		// Aggregation with ORDER BY (GROUP_CONCAT)
+		{
+			sql: "SELECT GROUP_CONCAT(a order by b, c) FROM t",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: "SELECT GROUP_CONCAT(d order by b, c) AS a FROM v",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "v", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "v", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "v", "d", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "d", "v"), false, nil, false},
+			},
+		},
+
+		// Aggregation with window function
+		{
+			sql: "SELECT SUM(a) OVER(PARTITION BY b ORDER BY c) AS s FROM t",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: "SELECT SUM(d) OVER(PARTITION BY b ORDER BY c) AS s FROM v",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "v", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "v", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "v", "d", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "d", "v"), false, nil, false},
+			},
+		},
+
+		// CTE
+		{
+			sql: "with cte as (select 1) select * from cte;",
+			ans: []visitInfo{},
+		},
+		{
+			sql: "with recursive cte as (select 1 as a union select a + 1 from cte where a < 3) select * from cte;",
+			ans: []visitInfo{},
+		},
+		{
+			sql: "with cte1 as (with cte2 as (select 1) select * from cte2) select * from cte1;",
+			ans: []visitInfo{},
+		},
+		{
+			sql: "with cte1 as (with cte2 as (SELECT c from t) select b, cte2.c from t, cte2) select a, cte1.b, cte1.c from t, cte1;",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: "with cte1 as (with cte2 as (SELECT c from t) select b, c2.c from t, cte2 as c2) select a, c1.b, c1.c from t, cte1 as c1;",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `WITH
+							cte1 AS (SELECT a, b FROM t),
+							cte2 AS (SELECT c, d FROM t)
+						SELECT b, d FROM cte1 JOIN cte2
+						WHERE cte1.a = cte2.c;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "d", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `WITH cte (col1, col2) AS
+						(
+							SELECT 1, 2
+							UNION ALL
+							SELECT 3, 4
+						)
+						SELECT col1, col2 FROM cte;`,
+			ans: []visitInfo{},
+		},
+		{
+			sql: `WITH RECURSIVE cte (n) AS
+						(
+							SELECT 1
+							UNION ALL
+							SELECT n + 1 FROM cte WHERE n < 5
+						)
+						SELECT * FROM cte;`,
+			ans: []visitInfo{},
+		},
+		{
+			sql: `WITH RECURSIVE cte AS
+						(
+							SELECT 1 AS n, CAST('abc' AS CHAR(20)) AS str
+							UNION ALL
+							SELECT n + 1, CONCAT(str, str) FROM cte WHERE n < 3
+						)
+						SELECT * FROM cte;`,
+			ans: []visitInfo{},
+		},
+
+		// Derived Table
+		{
+			sql: `SELECT
+								b as bid, CAST(UNIX_TIMESTAMP(MIN(c)) AS SIGNED) as cid
+						FROM (
+										SELECT a, b, MAX(c) AS c
+										FROM t WHERE d = 0 GROUP BY a, b
+								) tt
+						GROUP BY b;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "d", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT
+							aa, COUNT(DISTINCT bb) AS bbb
+						FROM (
+								SELECT a as aa, b as bb FROM t
+							) AS D;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT
+							aa, bb
+						FROM (
+								SELECT
+									aa, COUNT(DISTINCT b) AS bb
+								FROM (
+										SELECT a AS aa, b FROM t
+									) AS D1
+								GROUP BY aa
+							) AS D2
+						WHERE
+							bb > 70;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT
+								aa, bb, cc
+						FROM (
+								SELECT a AS aa, b AS bb, c * 2 AS cc FROM t
+							) AS tt
+						WHERE
+							aa > 1;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT
+							AVG(aa)
+						FROM (
+								SELECT SUM(a) AS aa FROM t
+							) AS t1;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT * FROM (SELECT 1, 2, 3, 4) AS dt;`,
+			ans: []visitInfo{},
+		},
+		{
+			sql: `SELECT c FROM t
+						WHERE
+							t.d > (
+								SELECT
+									AVG(dt.a)
+								FROM (
+										SELECT SUM(t2.a) AS a
+										FROM t2 WHERE t2.b = t.b GROUP BY t2.c
+									) dt
+								WHERE
+									dt.a > 10
+							);`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "d", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "d", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t2"), false, nil, false},
+			},
+		},
+
+		// Join without ON
+		{
+			sql: `SELECT t2.* FROM t2 NATURAL JOIN t;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT * FROM (SELECT t2.* FROM t NATURAL JOIN t2) tt;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT t2.* FROM t JOIN t2 USING (a)`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+
+		// Join with View
+		{
+			sql: `SELECT t2.* FROM t2 NATURAL JOIN v;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "v", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "v", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT t2.* FROM t2 NATURAL JOIN v2;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "v2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "v2", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrViewInvalid.FastGenByArgs("", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrViewInvalid.FastGenByArgs("", "v2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "d", plannererrors.ErrViewInvalid.FastGenByArgs("", "v2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT t2.* FROM t2 JOIN v USING (b);`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "v", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "v"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+
+		// Join with CTE/ derived table
+		{
+			sql: `SELECT tt.* FROM t NATURAL JOIN (SELECT * FROM t2) tt;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT tt.* FROM (SELECT * FROM t2) tt JOIN t USING (a)`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `WITH cte AS (SELECT * FROM t2)
+						SELECT cte.* FROM t NATURAL JOIN cte;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `WITH cte AS (SELECT * FROM t2)
+						SELECT cte.* FROM cte JOIN t USING (a)`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+
+		// Subquery
+		{
+			sql: `SELECT * FROM (select 1) t2;`,
+			ans: []visitInfo{},
+		},
+		{
+			sql: `SELECT tt.a FROM (select 1 as a) tt;`,
+			ans: []visitInfo{},
+		},
+		{
+			sql: `SELECT * FROM (select x.a from t2 x) tt;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT b FROM t2 AS t
+						WHERE 2 = (SELECT COUNT(*) FROM t2 WHERE t2.a = t.a);`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT b FROM t WHERE c > ANY (SELECT a FROM t2);`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT * FROM t2 WHERE 1 > ALL (SELECT MAX(a) FROM t);`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT a,b,c
+						FROM t
+						WHERE (a,b,c) IN
+									(SELECT a,b,c FROM t2);`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT DISTINCT a FROM t
+						WHERE NOT EXISTS (
+							SELECT * FROM t2 as t1 WHERE NOT EXISTS (
+								SELECT * FROM t2
+								WHERE t2.a = t1.a
+								AND t2.b = t.b));`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT * FROM t2
+						WHERE a = ANY (SELECT a FROM t WHERE t2.b = t.b);`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT a FROM t2 AS x
+						WHERE x.a = (SELECT a FROM t AS x
+							WHERE x.a = (SELECT a FROM t2 WHERE x.b = t2.a));`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT * FROM t2
+						WHERE ( SELECT a FROM t WHERE t.a=t2.a ) > 0;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT t2.* FROM t JOIN t2 ON t.a = t2.a WHERE t.b > 0`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT t.b FROM t
+						LEFT OUTER JOIN
+								(SELECT a, COUNT(*) AS ct FROM t2 GROUP BY a) AS derived
+						ON  t.a = derived.a AND ct > 0
+						WHERE derived.a > 0;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT min(a) AS a, q.b, q.c, q.d
+						FROM (
+								SELECT b, max(c) AS c, d FROM pt1 PARTITION(p1) p
+								WHERE e > 100 GROUP BY b, d
+							) AS n
+							JOIN pt1 PARTITION(p1) q
+							ON n.b = q.b AND n.c = q.c AND n.d = q.d
+						GROUP BY b, c, d;`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "pt1", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "pt1"), false, nil, false},
+				{mysql.SelectPriv, "test", "pt1", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "pt1"), false, nil, false},
+				{mysql.SelectPriv, "test", "pt1", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "pt1"), false, nil, false},
+				{mysql.SelectPriv, "test", "pt1", "d", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "d", "pt1"), false, nil, false},
+				{mysql.SelectPriv, "test", "pt1", "e", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "e", "pt1"), false, nil, false},
+			},
+			},
+			{
+				sql: `SELECT 1 AS one
+							FROM t
+							WHERE t.a IN (
+									SELECT t3.a
+									FROM t3
+									WHERE t3.b IN (
+											SELECT t2.a
+											FROM t2
+											WHERE t2.c = 1 AND t2.b IN ( 1 )
+									)
+							) AND t.b = 1 LIMIT 1;`,
+				ans: []visitInfo{
+					{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+					{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+					{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t3", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t3"), false, nil, false},
+				{mysql.SelectPriv, "test", "t3", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t3"), false, nil, false},
+				},
+			},
+			{
+				sql: `SELECT t.a
+							FROM t
+							WHERE t.b = 1 AND t.c IN (
+									SELECT t2.a
+									FROM t2
+									WHERE t2.b IS NOT NULL
+							);`,
+				ans: []visitInfo{
+					{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+					{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+					{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				},
+			},
+			{
+				sql: `SELECT COUNT(*)
+							FROM (
+									SELECT 1 AS ONE
+									FROM t
+									WHERE t.a = 1 AND t.b = 1 AND t.c = 1
+									LIMIT 1
+							) sub;`,
+				ans: []visitInfo{
+					{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+					{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+					{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+			},
+			},
+			{
+				sql: `SELECT t.c, t.d, t.e, t2.b, t2.c
+							FROM t
+									LEFT OUTER JOIN t2 ON t2.a = t.a
+							WHERE t.b = 1;`,
+				ans: []visitInfo{
+					{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+					{mysql.SelectPriv, "test", "t", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t"), false, nil, false},
+					{mysql.SelectPriv, "test", "t", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "d", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "d", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "e", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "e", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "b", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "b", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "c", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "c", "t2"), false, nil, false},
+			},
+		},
+
+		// Function Call
+		{
+			sql: `SELECT count(a) FROM t`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "*", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT 1 FROM (SELECT count(a) FROM t) tt`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "*", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT sum(a) FROM t`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT count(*) FROM t`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "*", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT count(1) FROM t`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "*", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+			},
+		},
+		{
+			sql: `SELECT count(*) FROM t JOIN t2 ON t.a = t2.a`,
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "a", plannererrors.ErrColumnaccessDenied.FastGenByArgs("SELECT", "", "", "a", "t2"), false, nil, false},
+				{mysql.SelectPriv, "test", "t", "*", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t"), false, nil, false},
+				{mysql.SelectPriv, "test", "t2", "*", plannererrors.ErrTableaccessDenied.FastGenByArgs("SELECT", "", "", "t2"), false, nil, false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s := createPlannerSuite()
+		stmt, err := s.p.ParseOneStmt(tt.sql, "", "")
+		require.NoError(t, err, tt.sql)
+
+		nodeW := resolve.NewNodeW(stmt)
+		require.NoError(t, Preprocess(context.Background(), s.sctx, nodeW, WithPreprocessorReturn(&PreprocessorReturn{InfoSchema: s.is})))
+		sctx := MockContext()
+		builder, _ := NewPlanBuilder().Init(sctx, s.is, hint.NewQBHintHandler(nil))
+		domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(s.is)
+		builder.ctx.GetSessionVars().SetHashJoinConcurrency(1)
+		_, err = builder.Build(context.TODO(), nodeW)
+		require.NoError(t, err, tt.sql)
+		checkVisitInfo(t, builder.visitInfo, tt.ans, tt.sql)
+
+		require.Nil(t, TryFastPlan(s.ctx, nodeW))
 	}
 }
 
@@ -1562,17 +2281,24 @@ func (v visitInfoArray) Len() int {
 }
 
 func (v visitInfoArray) Less(i, j int) bool {
-	if v[i].privilege < v[j].privilege {
-		return true
+	if v[i].privilege != v[j].privilege {
+		return v[i].privilege < v[j].privilege
 	}
-	if v[i].db < v[j].db {
-		return true
+	if v[i].db != v[j].db {
+		return v[i].db < v[j].db
 	}
-	if v[i].table < v[j].table {
-		return true
+	if v[i].table != v[j].table {
+		return v[i].table < v[j].table
 	}
-	if v[i].column < v[j].column {
+	if v[i].column != v[j].column {
+		return v[i].column < v[j].column
+	}
+	if v[i].err == nil {
 		return true
+	} else if v[j].err == nil {
+		return false
+	} else if v[i].err != nil && v[j].err != nil {
+		return v[i].err.Error() < v[j].err.Error()
 	}
 
 	return false
@@ -1583,9 +2309,27 @@ func (v visitInfoArray) Swap(i, j int) {
 }
 
 func unique(v []visitInfo) []visitInfo {
+	same := func(a, b *visitInfo) bool {
+		if a.privilege == b.privilege &&
+			a.db == b.db &&
+			a.table == b.table &&
+			a.column == b.column &&
+			a.alterWritable == b.alterWritable &&
+			reflect.DeepEqual(a.dynamicPrivs, b.dynamicPrivs) &&
+			a.dynamicWithGrant == b.dynamicWithGrant {
+			if a.err == nil && b.err == nil {
+				return true
+			}
+			if a.err == nil || b.err == nil {
+				return false
+			}
+			return a.err.Error() == b.err.Error()
+		}
+		return false
+	}
 	repeat := 0
 	for i := 1; i < len(v); i++ {
-		if v[i].Equals(&v[i-1]) {
+		if same(&v[i], &v[i-1]) {
 			repeat++
 		} else {
 			v[i-repeat] = v[i]
@@ -1594,19 +2338,33 @@ func unique(v []visitInfo) []visitInfo {
 	return v[:len(v)-repeat]
 }
 
-func checkVisitInfo(t *testing.T, v1, v2 []visitInfo, comment string) {
-	sort.Sort(visitInfoArray(v1))
-	sort.Sort(visitInfoArray(v2))
-	v1 = unique(v1)
-	v2 = unique(v2)
+func checkVisitInfo(t *testing.T, actual, expected []visitInfo, comment string) {
+	sort.Sort(visitInfoArray(actual))
+	sort.Sort(visitInfoArray(expected))
+	actual = unique(actual)
+	expected = unique(expected)
 
-	require.Equal(t, len(v2), len(v1), comment)
-	for i := 0; i < len(v1); i++ {
+	info := func(vs []visitInfo) string {
+		var sb strings.Builder
+		for _, v := range vs {
+			sb.WriteString(mysql.Priv2Str[v.privilege])
+			sb.WriteString(fmt.Sprintf(" %s.%s.%s", v.db, v.table, v.column))
+			if v.err != nil {
+				sb.WriteString(fmt.Sprintf(" err:%s", v.err.Error()))
+			}
+			sb.WriteByte('\n')
+		}
+		return sb.String()
+	}
+	require.Equal(t, len(expected), len(actual), "sql: %s\nactual visitinfo: %s", comment, info(actual))
+	for i := range actual {
 		// loose compare errors for code match
-		require.True(t, terror.ErrorEqual(v1[i].err, v2[i].err), fmt.Sprintf("err1 %v, err2 %v for %s", v1[i].err, v2[i].err, comment))
+		require.True(t, terror.ErrorEqual(expected[i].err, actual[i].err),
+			"expected %v, actual %v for %s\n%s\n%s\n", expected[i].err, actual[i].err, comment,
+			info(expected), info(actual))
 		// compare remainder
-		v1[i].err = v2[i].err
-		require.Equal(t, v2[i], v1[i], comment)
+		actual[i].err = expected[i].err
+		require.Equal(t, expected[i], actual[i], comment)
 	}
 }
 
@@ -2110,7 +2868,6 @@ func TestFastPlanContextTables(t *testing.T) {
 			true,
 		},
 		{
-
 			"update t set f=0 where a=43215",
 			true,
 		},

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -197,6 +197,14 @@ const (
 	handlingScalarSubquery
 )
 
+type checkSelectColumnPrivOption byte
+
+const (
+	noCheckOption checkSelectColumnPrivOption = iota
+	reportColumnErrOption
+	reportTableErrOption
+)
+
 // PlanBuilder builds Plan from an ast.Node.
 // It just builds the ast node straightforwardly.
 type PlanBuilder struct {
@@ -212,6 +220,7 @@ type PlanBuilder struct {
 	colMapper map[*ast.ColumnNameExpr]int
 	// visitInfo is used for privilege check.
 	visitInfo     []visitInfo
+	checkColPriv  checkSelectColumnPrivOption
 	tableHintInfo []*hint.PlanHints
 	// optFlag indicates the flags of the optimizer rules.
 	optFlag uint64
@@ -305,6 +314,11 @@ type PlanBuilder struct {
 	allowBuildCastArray bool
 	// resolveCtx is set when calling Build, it's only effective in the current Build call.
 	resolveCtx *resolve.Context
+
+	// SavedViews is a stack that saves all views when traversing the AST. We depend on it to:
+	// 1. know whether the AST node is under a view
+	// 2. report precise error in appendColNamesToVisitInfo.
+	SavedViews []*ast.TableName
 }
 
 type handleColHelper struct {
@@ -3949,7 +3963,13 @@ func collectVisitInfoFromRevokeStmt(sctx base.PlanContext, vi []visitInfo, stmt 
 			}
 			break
 		}
-		vi = appendVisitInfo(vi, item.Priv, dbName, tableName, "", nil)
+		if len(item.Cols) == 0 {
+			vi = appendVisitInfo(vi, item.Priv, dbName, tableName, "", nil)
+		} else {
+			for _, colName := range item.Cols {
+				vi = appendVisitInfo(vi, item.Priv, dbName, tableName, colName.Name.L, nil)
+			}
+		}
 	}
 
 	for _, priv := range allPrivs {
@@ -4026,7 +4046,13 @@ func collectVisitInfoFromGrantStmt(sctx base.PlanContext, vi []visitInfo, stmt *
 			}
 			break
 		}
-		vi = appendVisitInfo(vi, item.Priv, dbName, tableName, "", authErr)
+		if len(item.Cols) == 0 {
+			vi = appendVisitInfo(vi, item.Priv, dbName, tableName, "", authErr)
+		} else {
+			for _, colName := range item.Cols {
+				vi = appendVisitInfo(vi, item.Priv, dbName, tableName, colName.Name.L, authErr)
+			}
+		}
 	}
 
 	for _, priv := range allPrivs {
@@ -4079,6 +4105,11 @@ func (b *PlanBuilder) getDefaultValueForInsert(col *table.Column) (*expression.C
 // resolveGeneratedColumns resolves generated columns with their generation
 // expressions respectively. onDups indicates which columns are in on-duplicate list.
 func (b *PlanBuilder) resolveGeneratedColumns(ctx context.Context, columns []*table.Column, onDups map[string]struct{}, mockPlan base.LogicalPlan) (igc InsertGeneratedColumns, err error) {
+	originColPriv := b.checkColPriv
+	b.checkColPriv = reportColumnErrOption
+	defer func() {
+		b.checkColPriv = originColPriv
+	}()
 	for _, column := range columns {
 		if !column.IsGenerated() {
 			continue
@@ -4175,29 +4206,54 @@ func (b *PlanBuilder) buildInsert(ctx context.Context, insert *ast.InsertStmt) (
 		return nil, plannererrors.ErrPartitionClauseOnNonpartitioned
 	}
 
+	// INSERT statement requires `INSERT` column-level privilege.
+	// If a column list is given following the table, these columns' privilge is required.
+	// Otherwise, the privilege of all visiable columns in the table is required.
 	user := b.ctx.GetSessionVars().User
+	checkColumnPriv := len(insert.Columns) != 0
 	var authErr error
-	if user != nil {
-		authErr = plannererrors.ErrTableaccessDenied.FastGenByArgs("INSERT", user.AuthUsername, user.AuthHostname, tableInfo.Name.L)
+	if checkColumnPriv {
+		for _, col := range insert.Columns {
+			if user != nil {
+				authErr = plannererrors.ErrColumnaccessDenied.FastGenByArgs("INSERT", user.AuthUsername, user.AuthHostname, col.Name.L, tableInfo.Name.L)
+			}
+			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.InsertPriv, tnW.DBInfo.Name.L,
+				tableInfo.Name.L, col.Name.L, authErr)
+		}
+	} else {
+		if user != nil {
+			authErr = plannererrors.ErrTableaccessDenied.FastGenByArgs("INSERT", user.AuthUsername, user.AuthHostname, tableInfo.Name.L)
+		}
+		b.visitInfo = appendMultiColumns2VisitInfo(b.visitInfo, mysql.InsertPriv, tnW.DBInfo.Name.L,
+			tableInfo.Name.L, tableInPlan.VisibleCols(), authErr)
 	}
-
-	b.visitInfo = appendVisitInfo(b.visitInfo, mysql.InsertPriv, tnW.DBInfo.Name.L,
-		tableInfo.Name.L, "", authErr)
 
 	// `REPLACE INTO` requires both INSERT + DELETE privilege
-	// `ON DUPLICATE KEY UPDATE` requires both INSERT + UPDATE privilege
-	var extraPriv mysql.PrivilegeType
+	authErr = nil
 	if insert.IsReplace {
-		extraPriv = mysql.DeletePriv
-	} else if insert.OnDuplicate != nil {
-		extraPriv = mysql.UpdatePriv
-	}
-	if extraPriv != 0 {
 		if user != nil {
-			cmd := strings.ToUpper(mysql.Priv2Str[extraPriv])
-			authErr = plannererrors.ErrTableaccessDenied.FastGenByArgs(cmd, user.AuthUsername, user.AuthHostname, tableInfo.Name.L)
+			authErr = plannererrors.ErrTableaccessDenied.FastGenByArgs("DELETE", user.AuthUsername, user.AuthHostname, tableInfo.Name.L)
 		}
-		b.visitInfo = appendVisitInfo(b.visitInfo, extraPriv, tnW.DBInfo.Name.L, tableInfo.Name.L, "", authErr)
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.DeletePriv, tnW.DBInfo.Name.L, tableInfo.Name.L, "", authErr)
+	}
+
+	// `ON DUPLICATE KEY UPDATE` requires both INSERT + UPDATE privilege
+	authErr = nil
+	if insert.OnDuplicate != nil {
+		if checkColumnPriv {
+			for _, col := range insert.Columns {
+				if user != nil {
+					authErr = plannererrors.ErrColumnaccessDenied.FastGenByArgs("UPDATE", user.AuthUsername, user.AuthHostname, col.Name.L, tableInfo.Name.L)
+				}
+				b.visitInfo = appendVisitInfo(b.visitInfo, mysql.UpdatePriv, tnW.DBInfo.Name.L, tableInfo.Name.L, col.Name.L, authErr)
+			}
+		} else {
+			if user != nil {
+				authErr = plannererrors.ErrTableaccessDenied.FastGenByArgs("UPDATE", user.AuthUsername, user.AuthHostname, tableInfo.Name.L)
+			}
+			b.visitInfo = appendMultiColumns2VisitInfo(b.visitInfo, mysql.UpdatePriv, tnW.DBInfo.Name.L,
+				tableInfo.Name.L, tableInPlan.VisibleCols(), authErr)
+		}
 	}
 
 	mockTablePlan := logicalop.LogicalTableDual{}.Init(b.ctx, b.getSelectOffset())
@@ -4217,7 +4273,7 @@ func (b *PlanBuilder) buildInsert(ctx context.Context, insert *ast.InsertStmt) (
 
 	if len(insert.Lists) > 0 {
 		// Branch for `INSERT ... VALUES ...`.
-		// Branch for `INSERT ... SET ...`.
+		// Branch for `INSERT ... SET ...`, insert.Setlist == true
 		err := b.buildValuesListOfInsert(ctx, insert, insertPlan, mockTablePlan, checkRefColumn)
 		if err != nil {
 			return nil, err
@@ -4372,8 +4428,11 @@ func (b PlanBuilder) getInsertColExpr(ctx context.Context, insertPlan *Insert, m
 		if _, ok := expr.(*ast.SubqueryExpr); ok {
 			usingPlan = logicalop.LogicalTableDual{}.Init(b.ctx, b.getSelectOffset())
 		}
+		originColPriv := b.checkColPriv
+		b.checkColPriv = reportColumnErrOption
 		var np base.LogicalPlan
 		outExpr, np, err = b.rewriteWithPreprocess(ctx, expr, usingPlan, nil, nil, true, checkRefColumn)
+		b.checkColPriv = originColPriv
 		if np != nil {
 			if _, ok := np.(*logicalop.LogicalTableDual); !ok {
 				// See issue#30626 and the related tests in function TestInsertValuesWithSubQuery for more details.
@@ -4620,21 +4679,35 @@ func (b *PlanBuilder) buildLoadData(ctx context.Context, ld *ast.LoadDataStmt) (
 		ColumnsAndUserVars: ld.ColumnsAndUserVars,
 		Options:            options,
 	}.Init(b.ctx)
-	user := b.ctx.GetSessionVars().User
-	var insertErr, deleteErr error
-	if user != nil {
-		insertErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("INSERT", user.AuthUsername, user.AuthHostname, p.Table.Name.O)
-		deleteErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("DELETE", user.AuthUsername, user.AuthHostname, p.Table.Name.O)
-	}
-	b.visitInfo = appendVisitInfo(b.visitInfo, mysql.InsertPriv, p.Table.Schema.O, p.Table.Name.O, "", insertErr)
-	if p.OnDuplicate == ast.OnDuplicateKeyHandlingReplace {
-		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.DeletePriv, p.Table.Schema.O, p.Table.Name.O, "", deleteErr)
-	}
 	tableInfo := p.Table.TableInfo
 	tableInPlan, ok := b.is.TableByID(ctx, tableInfo.ID)
 	if !ok {
 		db := b.ctx.GetSessionVars().CurrentDB
 		return nil, infoschema.ErrTableNotExists.FastGenByArgs(db, tableInfo.Name.O)
+	}
+	user := b.ctx.GetSessionVars().User
+	var insertErr, deleteErr error
+	userName, hostName := auth.GetUserAndHostName(user)
+	// LOAD DATA statement requires `INSERT` column-level privilege.
+	// If a column list is given following the table, these columns' privilge is required.
+	// Otherwise, the privilege of all visiable columns in the table is required.
+	if len(ld.Columns) == 0 {
+		insertErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("INSERT", userName, hostName, p.Table.Name.O)
+		b.visitInfo = appendMultiColumns2VisitInfo(b.visitInfo, mysql.InsertPriv, p.Table.Schema.L,
+			p.Table.Name.L, tableInPlan.VisibleCols(), insertErr)
+	} else {
+		for _, col := range ld.Columns {
+			insertErr = plannererrors.ErrColumnaccessDenied.GenWithStackByArgs("INSERT", userName, hostName, col.Name.O, p.Table.Name.O)
+			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.InsertPriv, p.Table.Schema.L, p.Table.Name.L, col.Name.L, insertErr)
+		}
+	}
+	for _, colAssign := range ld.ColumnAssignments {
+		insertErr = plannererrors.ErrColumnaccessDenied.GenWithStackByArgs("INSERT", userName, hostName, colAssign.Column.Name.O, p.Table.Name.O)
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.InsertPriv, p.Table.Schema.L, p.Table.Name.L, colAssign.Column.Name.L, insertErr)
+	}
+	if p.OnDuplicate == ast.OnDuplicateKeyHandlingReplace {
+		deleteErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("DELETE", userName, hostName, p.Table.Name.O)
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.DeletePriv, p.Table.Schema.L, p.Table.Name.L, "", deleteErr)
 	}
 	schema, names, err := expression.TableInfo2SchemaAndNames(b.ctx.GetExprCtx(), pmodel.NewCIStr(""), tableInfo)
 	if err != nil {
@@ -5394,6 +5467,9 @@ func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (base.Plan
 			stmt.AsViewSchema = true
 		}
 
+		if v.Definer.CurrentUser && b.ctx.GetSessionVars().User != nil {
+			v.Definer = b.ctx.GetSessionVars().User
+		}
 		nodeW := resolve.NewNodeWWithCtx(v.Select, b.resolveCtx)
 		plan, err := b.Build(ctx, nodeW)
 		if err != nil {
@@ -5417,9 +5493,6 @@ func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (base.Plan
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.CreateViewPriv, v.ViewName.Schema.L,
 			v.ViewName.Name.L, "", authErr)
-		if v.Definer.CurrentUser && b.ctx.GetSessionVars().User != nil {
-			v.Definer = b.ctx.GetSessionVars().User
-		}
 		if b.ctx.GetSessionVars().User != nil && v.Definer.String() != b.ctx.GetSessionVars().User.String() {
 			err = plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs("SUPER")
 			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SuperPriv, "",

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -2117,7 +2117,8 @@ func buildOrderedList(ctx base.PlanContext, plan base.Plan, list []*ast.Assignme
 		if defaultExpr != nil {
 			defaultExpr.Name = assign.Column
 		}
-		expr, err := rewriteAstExprWithPlanCtx(ctx, assign.Expr, plan.Schema(), plan.OutputNames(), false)
+		// FIXME(cbc): we will implement column-privilege for PointGet in next PR
+		expr, _, err := rewriteAstExprWithPlanCtx(ctx, assign.Expr, plan.Schema(), plan.OutputNames(), false)
 		if err != nil {
 			return nil, true
 		}

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -532,12 +532,7 @@ func (p *preprocessor) tableByName(tn *ast.TableName) (table.Table, error) {
 		currentUser, activeRoles := p.sctx.GetSessionVars().User, p.sctx.GetSessionVars().ActiveRoles
 		if pm := privilege.GetPrivilegeManager(p.sctx); pm != nil {
 			if !pm.RequestVerification(activeRoles, sName.L, tn.Name.O, "", mysql.AllPrivMask) {
-				u := currentUser.Username
-				h := currentUser.Hostname
-				if currentUser.AuthHostname != "" {
-					u = currentUser.AuthUsername
-					h = currentUser.AuthHostname
-				}
+				u, h := auth.GetUserAndHostName(currentUser)
 				return nil, plannererrors.ErrTableaccessDenied.GenWithStackByArgs(p.stmtType(), u, h, tn.Name.O)
 			}
 		}

--- a/pkg/privilege/privileges/BUILD.bazel
+++ b/pkg/privilege/privileges/BUILD.bazel
@@ -59,7 +59,9 @@ go_test(
     deps = [
         "//pkg/config",
         "//pkg/errno",
+        "//pkg/executor",
         "//pkg/kv",
+        "//pkg/lightning/mydump",
         "//pkg/parser/auth",
         "//pkg/parser/mysql",
         "//pkg/parser/terror",

--- a/pkg/privilege/privileges/cache.go
+++ b/pkg/privilege/privileges/cache.go
@@ -1399,8 +1399,7 @@ func (p *MySQLPrivilege) RequestVerification(activeRoles []*auth.RoleIdentity, u
 	}
 
 	for _, r := range roleList {
-		tableRecord := p.matchTables(r.Username, r.Hostname, db, table)
-		if tableRecord != nil {
+		if tableRecord := p.matchTables(r.Username, r.Hostname, db, table); tableRecord != nil {
 			tablePriv |= tableRecord.TablePriv
 			if column != "" {
 				columnPriv |= tableRecord.TablePriv

--- a/pkg/privilege/privileges/privileges_test.go
+++ b/pkg/privilege/privileges/privileges_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -31,7 +32,9 @@ import (
 
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/errno"
+	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/lightning/mydump"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
@@ -364,7 +367,7 @@ func TestShowViewPriv(t *testing.T) {
 			tk.MustQuery("explain test.v").Check(testkit.Rows(test.explainRes))
 		}
 		if test.descErr != "" {
-			err = tk.QueryToErr("explain test.v")
+			err = tk.QueryToErr("desc test.v")
 			require.EqualError(t, err, test.descErr, test)
 		} else {
 			tk.MustQuery("desc test.v").Check(testkit.Rows(test.descRes))
@@ -786,18 +789,14 @@ func TestSystemSchema(t *testing.T) {
 	err = tk.ExecToErr("drop table information_schema.tables")
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "denied to user"))
-	err = tk.ExecToErr("update information_schema.tables set table_name = 'tst' where table_name = 'mysql'")
-	require.Error(t, err)
-	require.True(t, terror.ErrorEqual(err, plannererrors.ErrPrivilegeCheckFail))
+	tk.MustGetErrCode(`update information_schema.tables set table_name = 'tst' where table_name = 'mysql'`, errno.ErrColumnaccessDenied)
 
 	// Test metric_schema.
 	tk.MustExec(`select * from metrics_schema.tidb_query_duration`)
 	err = tk.ExecToErr("drop table metrics_schema.tidb_query_duration")
 	require.Error(t, err)
 	require.True(t, terror.ErrorEqual(err, plannererrors.ErrTableaccessDenied))
-	err = tk.ExecToErr("update metrics_schema.tidb_query_duration set instance = 'tst'")
-	require.Error(t, err)
-	require.True(t, terror.ErrorEqual(err, plannererrors.ErrPrivilegeCheckFail))
+	tk.MustGetErrCode(`update metrics_schema.tidb_query_duration set instance = 'tst'`, errno.ErrColumnaccessDenied)
 	err = tk.ExecToErr("delete from metrics_schema.tidb_query_duration")
 	require.Error(t, err)
 	require.True(t, terror.ErrorEqual(err, plannererrors.ErrTableaccessDenied))
@@ -817,9 +816,7 @@ func TestPerformanceSchema(t *testing.T) {
 	tk.MustExec(`CREATE USER 'u1'@'localhost';`)
 
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "u1", Hostname: "localhost"}, nil, nil, nil))
-	err := tk.ExecToErr("select * from performance_schema.events_statements_summary_by_digest where schema_name = 'tst'")
-	require.Error(t, err)
-	require.True(t, terror.ErrorEqual(err, plannererrors.ErrTableaccessDenied))
+	tk.MustGetErrCode(`select * from performance_schema.events_statements_summary_by_digest where schema_name = 'tst'`, errno.ErrColumnaccessDenied)
 
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "localhost"}, nil, nil, nil))
 	tk.MustExec(`GRANT SELECT ON *.* TO 'u1'@'localhost';`)
@@ -827,12 +824,10 @@ func TestPerformanceSchema(t *testing.T) {
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "u1", Hostname: "localhost"}, nil, nil, nil))
 	tk.MustExec("select * from performance_schema.events_statements_summary_by_digest where schema_name = 'tst'")
 	tk.MustExec(`select * from performance_schema.events_statements_summary_by_digest`)
-	err = tk.ExecToErr("drop table performance_schema.events_statements_summary_by_digest")
+	err := tk.ExecToErr("drop table performance_schema.events_statements_summary_by_digest")
 	require.Error(t, err)
 	require.True(t, terror.ErrorEqual(err, plannererrors.ErrTableaccessDenied))
-	err = tk.ExecToErr("update performance_schema.events_statements_summary_by_digest set schema_name = 'tst'")
-	require.Error(t, err)
-	require.True(t, terror.ErrorEqual(err, plannererrors.ErrPrivilegeCheckFail))
+	tk.MustGetErrCode(`update performance_schema.events_statements_summary_by_digest set schema_name = 'tst'`, errno.ErrColumnaccessDenied)
 	err = tk.ExecToErr("delete from performance_schema.events_statements_summary_by_digest")
 	require.Error(t, err)
 	require.True(t, terror.ErrorEqual(err, plannererrors.ErrTableaccessDenied))
@@ -1012,6 +1007,56 @@ func TestLoadDataPrivilege(t *testing.T) {
 	err = tk.ExecToErr("LOAD DATA LOCAL INFILE '/tmp/load_data_priv.csv' REPLACE INTO TABLE t_load")
 	require.Error(t, err)
 	require.True(t, terror.ErrorEqual(err, plannererrors.ErrTableaccessDenied))
+}
+
+func TestLoadDataColumnPrivilege(t *testing.T) {
+	// Create file.
+	path := filepath.Join(t.TempDir(), "load_data_priv.csv")
+	fp, err := os.Create(path)
+	require.NoError(t, err)
+	require.NotNil(t, fp)
+	defer func() {
+		require.NoError(t, fp.Close())
+		require.NoError(t, os.Remove(path))
+	}()
+	_, err = fp.WriteString("1,2,3\n")
+	require.NoError(t, err)
+
+	store := testkit.CreateMockStore(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "localhost"}, nil, nil, nil))
+	tk.MustExec(`CREATE USER 'test_load'@'localhost';`)
+	tk.MustExec(`GRANT SELECT on *.* to 'test_load'@'localhost'`)
+	tk.MustExec(`CREATE TABLE t_load(a int, b int, c int)`)
+	tk1 := testkit.NewTestKit(t, store)
+	require.NoError(t, tk1.Session().Auth(&auth.UserIdentity{Username: "test_load", Hostname: "localhost"}, nil, nil, nil))
+	tk1.MustExec("use test")
+
+	var reader io.ReadCloser = mydump.NewStringReader("1")
+	var readerBuilder executor.LoadDataReaderBuilder = func(_ string) (
+		r io.ReadCloser, err error,
+	) {
+		return reader, nil
+	}
+
+	tk1.Session().(sessionctx.Context).SetValue(executor.LoadDataReaderBuilderKey, readerBuilder)
+	tk1.MustGetErrCode(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t_load(a)", path), mysql.ErrColumnaccessDenied)
+	tk.MustExec(`GRANT INSERT(a) on test.t_load to 'test_load'@'localhost'`)
+	tk1.MustExec(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t_load(a)", path))
+
+	tk1.MustGetErrCode(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t_load(a, @var) set b = @var + 1", path), mysql.ErrColumnaccessDenied)
+	tk.MustExec(`GRANT INSERT(b) on test.t_load to 'test_load'@'localhost'`)
+	tk1.MustExec(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t_load(a, @var) set b = @var + 1", path))
+
+	tk1.MustGetErrCode(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t_load", path), mysql.ErrTableaccessDenied)
+	tk.MustExec(`GRANT INSERT on *.* to 'test_load'@'localhost'`)
+	tk1.MustExec(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t_load", path))
+
+	tk1.MustGetErrCode(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' REPLACE INTO TABLE t_load", path), mysql.ErrTableaccessDenied)
+	tk.MustExec(`GRANT DELETE on *.* to 'test_load'@'localhost'`)
+	tk1.MustExec(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' REPLACE INTO TABLE t_load", path))
 }
 
 func TestAuthHost(t *testing.T) {
@@ -1289,6 +1334,8 @@ func TestSecurityEnhancedModeSysVars(t *testing.T) {
 	tk.MustQuery(`SHOW GLOBAL VARIABLES LIKE 'tidb_top_sql_max_meta_count'`).Check(testkit.Rows())
 	tk.MustQuery(`SELECT * FROM information_schema.variables_info WHERE variable_name = 'tidb_top_sql_max_meta_count'`).Check(testkit.Rows())
 	tk.MustQuery(`SELECT * FROM performance_schema.session_variables WHERE variable_name = 'tidb_top_sql_max_meta_count'`).Check(testkit.Rows())
+	tk.MustGetErrCode(`select * from performance_schema.pd_profile_allocs`, errno.ErrTableaccessDenied)
+	tk.MustGetErrCode(`select count(*) from performance_schema.pd_profile_allocs`, errno.ErrTableaccessDenied)
 
 	_, err := tk.Exec("SET @@global.tidb_force_priority = 'NO_PRIORITY'")
 	require.EqualError(t, err, "[planner:1227]Access denied; you need (at least one of) the RESTRICTED_VARIABLES_ADMIN privilege(s) for this operation")
@@ -1687,14 +1734,14 @@ func TestCreateTmpTablesPriv(t *testing.T) {
 		},
 		{
 			sql:     "update tmp t1, t t2 set t1.id=t2.id where t1.id=t2.id",
-			errcode: mysql.ErrTableaccessDenied,
+			errcode: mysql.ErrColumnaccessDenied,
 		},
 		{
 			sql: "delete from tmp where id=1",
 		},
 		{
 			sql:     "delete t1 from tmp t1 join t t2 where t1.id=t2.id",
-			errcode: mysql.ErrTableaccessDenied,
+			errcode: mysql.ErrColumnaccessDenied,
 		},
 		{
 			sql: "select * from tmp where id=1",
@@ -1707,7 +1754,7 @@ func TestCreateTmpTablesPriv(t *testing.T) {
 		},
 		{
 			sql:     "select * from tmp join t where tmp.id=t.id",
-			errcode: mysql.ErrTableaccessDenied,
+			errcode: mysql.ErrColumnaccessDenied,
 		},
 		{
 			sql:     "(select * from tmp) union (select * from t)",
@@ -2115,4 +2162,300 @@ func TestShowGrantsSQLMode(t *testing.T) {
 		"GRANT USAGE ON *.* TO 'show_sql_mode'@'localhost'",
 		"GRANT SELECT ON \"test\".* TO 'show_sql_mode'@'localhost'",
 	})
+}
+
+func TestSelectColumnPrivilege(t *testing.T) {
+	store := createStoreAndPrepareDB(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`CREATE USER 'testuser'@'localhost'`)
+	tk.MustExec(`DROP TABLE IF EXISTS test.t1, test.t2, test.t3;`)
+	tk.MustExec(`CREATE TABLE test.t1 (a int, b int);`)
+	tk.MustExec(`CREATE TABLE test.t2 (a int, c int);`)
+	tk.MustExec(`CREATE TABLE test.t3 (a int, d int);`)
+	tk.MustExec(`CREATE TABLE test.t4 (a int, b int);`)
+	tk.MustExec(`INSERT INTO test.t1 VALUES (1, 2);`)
+	tk.MustExec(`INSERT INTO test.t2 VALUES (1, 3);`)
+	tk.MustExec(`INSERT INTO test.t3 VALUES (1, 4);`)
+
+	userTk := testkit.NewTestKit(t, store)
+	err := userTk.Session().Auth(&auth.UserIdentity{Username: "testuser", Hostname: "localhost"}, nil, nil, nil)
+	require.NoError(t, err)
+	tk.MustExec(`GRANT SELECT(a) ON test.t1 TO 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(c) ON test.t2 TO 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a, d) ON test.t3 TO 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a) ON test.t4 TO 'testuser'@'localhost';`)
+
+	/* single column field */
+	userTk.MustQuery(`SELECT a FROM test.t1`).Check(testkit.Rows(`1`))
+	userTk.MustQuery(`SELECT c FROM test.t2`).Check(testkit.Rows(`3`))
+	userTk.MustExec(`SET @res = (SELECT a FROM test.t1)`)
+	userTk.MustExec(`DO (SELECT a FROM test.t1)`)
+	userTk.MustGetErrCode(`SELECT b FROM test.t1`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`SET @res = (SELECT b FROM test.t1)`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`SELECT a FROM test.t2`, errno.ErrColumnaccessDenied)
+	/* column accessed in WHERE clause */
+	userTk.MustGetErrCode(`SELECT a FROM test.t1 WHERE b = 2`, errno.ErrColumnaccessDenied)
+	/* column accessed in join */
+	userTk.MustQuery(`SELECT test.t1.a, test.t2.c FROM test.t1, test.t2`).Check(testkit.Rows(`1 3`))
+	userTk.MustQuery(`SELECT test.t1.a, test.t2.c FROM test.t1, test.t2 WHERE test.t1.a = test.t2.c`).Check(testkit.Rows())
+	/* column accessed in wildcard */
+	userTk.MustGetErrCode(`SELECT * FROM test.t1`, errno.ErrTableaccessDenied)
+	userTk.MustGetErrCode(`SELECT * FROM test.t2`, errno.ErrTableaccessDenied)
+	/* column accessed in function */
+	userTk.MustQuery(`SELECT count(test.t1.a) FROM test.t1`).Check(testkit.Rows(`1`))
+	userTk.MustGetErrCode(`SELECT count(test.t1.b) FROM test.t1`, errno.ErrColumnaccessDenied)
+	// The query below compatible with MySQL. Select all fields using wildcard (*) in TiDB requires SELECT privilege in table-level,
+	// OR, SELECT privilege in column-level for all columns.
+	userTk.MustQuery(`SELECT * FROM test.t3`).Check(testkit.Rows(`1 4`))
+
+	/* test `Select` column privilege in clause */
+	userTk.MustGetErrCode(`SELECT test.t1.a FROM test.t1 JOIN test.t2 USING (a)`, errno.ErrColumnaccessDenied)
+	// `Select` column privilege in ON and ORDER BY clause is needed
+	userTk.MustGetErrCode(`SELECT a FROM test.t1 NATURAL JOIN test.t4`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`SELECT test.t1.a FROM test.t1 JOIN test.t2 ON test.t1.a = test.t2.a`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`SELECT test.t2.c FROM test.t2 ORDER BY a`, errno.ErrColumnaccessDenied)
+	tk.MustExec(`GRANT SELECT(a) ON test.t2 TO 'testuser'@'localhost';`)
+	userTk.MustExec(`SELECT test.t1.a FROM test.t1 JOIN test.t2 USING (a)`)
+	userTk.MustExec(`SELECT test.t1.a FROM test.t1 JOIN test.t2 ON test.t1.a = test.t2.a`)
+	userTk.MustExec(`SELECT test.t2.c FROM test.t2 ORDER BY a`)
+	// HAVING and GROUP BY clauses also require `Select` column privilege
+	tk.MustExec(`ALTER TABLE test.t1 ADD COLUMN c int`)
+	userTk.MustGetErrCode(`SELECT SUM(test.t1.a) FROM test.t1 GROUP BY test.t1.b HAVING count(test.t1.c) > 0`, errno.ErrColumnaccessDenied)
+	tk.MustExec(`GRANT SELECT(b) ON test.t1 TO 'testuser'@'localhost';`)
+	userTk.MustGetErrCode(`SELECT SUM(test.t1.a) FROM test.t1 GROUP BY test.t1.b HAVING count(test.t1.c) > 0`, errno.ErrColumnaccessDenied)
+	tk.MustExec(`GRANT SELECT(b) ON test.t4 TO 'testuser'@'localhost';`)
+	userTk.MustExec(`SELECT a FROM test.t1 NATURAL JOIN test.t4`)
+	tk.MustExec(`GRANT SELECT(c) ON test.t1 TO 'testuser'@'localhost';`)
+	userTk.MustExec(`SELECT SUM(test.t1.a) FROM test.t1 GROUP BY test.t1.b HAVING count(test.t1.c) > 0`)
+}
+
+func TestSelectColumnPrivilegeInSubqueryAndCTE(t *testing.T) {
+	store := createStoreAndPrepareDB(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`CREATE USER 'testuser'@'localhost'`)
+	tk.MustExec(`DROP TABLE IF EXISTS test.t1, test.t2;`)
+	tk.MustExec(`CREATE TABLE test.t1 (a int, b int);`)
+	tk.MustExec(`CREATE TABLE test.t2 (a int, b int);`)
+	tk.MustExec(`INSERT INTO test.t1 VALUES (1, 2);`)
+	tk.MustExec(`INSERT INTO test.t2 VALUES (1, 3);`)
+
+	userTk := testkit.NewTestKit(t, store)
+	err := userTk.Session().Auth(&auth.UserIdentity{Username: "testuser", Hostname: "localhost"}, nil, nil, nil)
+	require.NoError(t, err)
+	tk.MustExec(`GRANT SELECT(a) ON test.t1 TO 'testuser'@'localhost';`)
+	userTk.MustExec(`use test;`)
+
+	/* Subquery */
+	userTk.MustQuery(`select a from t1 where a in (select a from t1);`).Check(testkit.Rows(`1`))
+	userTk.MustGetErrCode(`select a from t1 where a in (select a from t2);`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`select a from t1 where exists (select a from t2);`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`select a from t1 where b = (select a from t1);`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`select a from t1 where a = (select b from t1);`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`select a from t1 where b in (select a from t1);`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`select a from t1 where b > any(select a from t1);`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`select a from t1 where b > all(select a from t1);`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`select a from t1 where b = 1 and exists (select a from t1);`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`SELECT (SELECT a FROM t2) FROM t1;`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`SELECT b FROM t2	WHERE a = (SELECT MAX(a) FROM t1);`, errno.ErrColumnaccessDenied)
+
+	/* CTE */
+	userTk.MustGetErrCode(`WITH CTE AS (SELECT b from t1) SELECT * FROM cte t;`, errno.ErrColumnaccessDenied)
+	userTk.MustQuery(`WITH CTE AS (SELECT a from t1) SELECT * FROM cte t;`).Check(testkit.Rows(`1`))
+	userTk.MustQuery(`WITH CTE AS (SELECT 1) SELECT * FROM cte;`).Check(testkit.Rows(`1`))
+	userTk.MustQuery(`WITH recursive cte as (select 1 as a union select a + 1 from cte where a < 3) select * from cte;`).Check(testkit.Rows(`1`, `2`, `3`))
+	userTk.MustQuery(`with cte1 as (with cte2 as (select 1) select * from cte2) select * from cte1;`).Check(testkit.Rows(`1`))
+	userTk.MustQuery(`with cte1 as (with cte2 as (SELECT a from t1) select * from cte2) select * from cte1;`).Check(testkit.Rows(`1`))
+	userTk.MustGetErrCode(`with cte1 as (with cte2 as (SELECT b from t1) select * from cte2) select * from cte1;`, errno.ErrColumnaccessDenied)
+}
+
+func TestInsertColumnPrivilege(t *testing.T) {
+	store := createStoreAndPrepareDB(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`CREATE USER 'testuser'@'localhost'`)
+	tk.MustExec(`DROP TABLE IF EXISTS test.t1;`)
+	tk.MustExec(`CREATE TABLE test.t1 (a int, b int);`)
+	tk.MustExec(`CREATE TABLE test.t2 (a int, b int);`)
+
+	userTk := testkit.NewTestKit(t, store)
+	err := userTk.Session().Auth(&auth.UserIdentity{Username: "testuser", Hostname: "localhost"}, nil, nil, nil)
+	require.NoError(t, err)
+	tk.MustExec(`GRANT INSERT(a) ON test.t1 TO 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a) ON test.t2 TO 'testuser'@'localhost';`)
+
+	userTk.MustExec(`INSERT INTO test.t1(a) VALUES (1);`)
+	userTk.MustGetErrCode(`INSERT INTO test.t1(b) VALUES (1)`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`INSERT INTO test.t1 VALUES (1, 2)`, errno.ErrTableaccessDenied)
+	userTk.MustExec(`INSERT INTO test.t1 SET a = 2;`)
+	userTk.MustGetErrCode(`INSERT INTO test.t1 SET b = 1`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`INSERT INTO test.t1 SET a = 1, b = 2;`, errno.ErrColumnaccessDenied)
+	tk.MustExec(`GRANT INSERT(b) ON test.t1 TO 'testuser'@'localhost';`)
+	userTk.MustExec(`INSERT INTO test.t1 SET a = 1, b = 2;`)
+	userTk.MustExec(`INSERT INTO test.t1 VALUES (1,2);`)
+	// FIXME(cbc): for tidb, the parser will treat `INSERT INTO test.t1 SET a = 1, b = a * 2;` the same
+	// 	as `INSERT INTO test.t1 VALUES (1,2)`, so it does NOT require SELECT privilege of `a`
+	// userTk.MustGetErrCode(`INSERT INTO test.t1 SET a = 1, b = a * 2;`, errno.ErrColumnaccessDenied)
+	tk.MustExec(`GRANT SELECT(a) ON test.t1 TO 'testuser'@'localhost';`)
+	userTk.MustExec(`INSERT INTO test.t1 SET a = 1, b = a * 2;`)
+
+	userTk.MustExec(`INSERT INTO test.t1(a) SELECT a FROM test.t2;`)
+	userTk.MustGetErrCode(`INSERT INTO test.t1(a) SELECT b FROM test.t2;`, errno.ErrColumnaccessDenied)
+}
+
+func TestUpdateColumnPrivilege(t *testing.T) {
+	store := createStoreAndPrepareDB(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`CREATE USER 'testuser'@'localhost'`)
+	tk.MustExec(`DROP TABLE IF EXISTS test.t1;`)
+	tk.MustExec(`CREATE TABLE test.t1 (a int, b int);`)
+	tk.MustExec(`INSERT INTO test.t1 VALUES (1, 2);`)
+
+	userTk := testkit.NewTestKit(t, store)
+	err := userTk.Session().Auth(&auth.UserIdentity{Username: "testuser", Hostname: "localhost"}, nil, nil, nil)
+	require.NoError(t, err)
+
+	userTk.MustGetErrCode(`UPDATE test.t1 SET a = 2`, errno.ErrColumnaccessDenied)
+	tk.MustExec(`GRANT UPDATE(a) ON test.t1 TO 'testuser'@'localhost';`)
+	userTk.MustExec(`UPDATE test.t1 SET a = 2;`)
+	tk.MustQuery(`SELECT * FROM test.t1`).Check(testkit.Rows(`2 2`))
+
+	userTk.MustGetErrCode(`UPDATE test.t1 SET b = 3`, errno.ErrColumnaccessDenied)
+	tk.MustExec(`GRANT UPDATE(b) ON test.t1 TO 'testuser'@'localhost';`)
+	userTk.MustExec(`UPDATE test.t1 SET b = 3`)
+
+	userTk.MustGetErrCode(`UPDATE test.t1 SET b = 3 WHERE b = 1`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`UPDATE test.t1 SET b = 3 ORDER BY b`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`UPDATE test.t1 SET a = b + 1`, errno.ErrColumnaccessDenied)
+	tk.MustExec(`GRANT SELECT(b) ON test.t1 TO 'testuser'@'localhost';`)
+	userTk.MustExec(`UPDATE test.t1 SET b = 3 WHERE b = 1`)
+	userTk.MustExec(`UPDATE test.t1 SET b = 3 ORDER BY b`)
+	userTk.MustExec(`UPDATE test.t1 SET a = b + 1`)
+
+	tk.MustExec(`DROP TABLE IF EXISTS test.t2;`)
+	tk.MustExec(`CREATE TABLE test.t2 (c int, d int);`)
+	tk.MustExec(`INSERT INTO test.t2 VALUES (1, 2);`)
+
+	userTk.MustGetErrCode(`UPDATE test.t1, test.t2 SET a = c WHERE b = d`, errno.ErrColumnaccessDenied)
+	userTk.MustGetErrCode(`UPDATE test.t1, (SELECT c FROM test.t2 WHERE d = 2) AS tt SET a = tt.c	`, errno.ErrColumnaccessDenied)
+	tk.MustExec(`GRANT SELECT(c,d) ON test.t2 TO 'testuser'@'localhost';`)
+	userTk.MustExec(`UPDATE test.t1, test.t2 SET a = c WHERE b = d`)
+	userTk.MustExec(`UPDATE test.t1, (SELECT c FROM test.t2 WHERE d = 2) AS tt SET a = tt.c	`)
+}
+
+func TestColumnPrivilege4NonPreparePlanCache(t *testing.T) {
+	store := createStoreAndPrepareDB(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`CREATE USER 'testuser'@'localhost';`)
+	tk.MustExec(`CREATE TABLE test.t (a INT, b INT, KEY(b));`)
+	userTk := testkit.NewTestKit(t, store)
+	err := userTk.Session().Auth(&auth.UserIdentity{Username: "testuser", Hostname: "localhost"}, nil, nil, nil)
+	require.NoError(t, err)
+
+	for _, planCacheON := range []string{"0", "1"} {
+		userTk.MustExec(fmt.Sprintf("SET tidb_enable_non_prepared_plan_cache = %s", planCacheON))
+		tk.MustExec("GRANT SELECT(a,b) ON test.t TO 'testuser'@'localhost';")
+
+		userTk.MustQuery(`SELECT * FROM test.t WHERE b < 5 AND a = 2;`)
+		userTk.MustQuery(`SELECT * FROM test.t WHERE b < 5 AND a = 2;`)
+		userTk.MustQuery(`SELECT @@last_plan_from_cache;`).Check(testkit.Rows(planCacheON))
+
+		tk.MustExec("REVOKE SELECT(a) ON test.t FROM 'testuser'@'localhost';")
+		userTk.MustGetErrCode(`SELECT * FROM test.t WHERE b < 5 AND a = 2;`, mysql.ErrColumnaccessDenied)
+
+		tk.MustExec("GRANT SELECT(a) ON test.t TO 'testuser'@'localhost';")
+		userTk.MustQuery(`SELECT * FROM test.t WHERE b < 5 AND a = 2;`)
+		userTk.MustQuery(`SELECT @@last_plan_from_cache;`).Check(testkit.Rows(planCacheON))
+	}
+}
+
+func TestColumnPrivilege4Views(t *testing.T) {
+	store := createStoreAndPrepareDB(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`CREATE USER 'testuser'@'localhost';`)
+	tk.MustExec(`CREATE TABLE test.t (a INT);`)
+	tk.MustExec(`CREATE SQL SECURITY DEFINER VIEW test.v1 AS SELECT * FROM test.t`)
+	tk.MustExec(`CREATE SQL SECURITY INVOKER VIEW test.v2 AS SELECT * FROM test.t`)
+	tk.MustExec(`CREATE SQL SECURITY DEFINER VIEW test.v3 AS SELECT * FROM test.v1`)
+	tk.MustExec(`CREATE SQL SECURITY INVOKER VIEW test.v4 AS SELECT * FROM test.v1`)
+	tk.MustExec(`CREATE SQL SECURITY DEFINER VIEW test.v5 AS SELECT * FROM test.v2`)
+	tk.MustExec(`CREATE SQL SECURITY INVOKER VIEW test.v6 AS SELECT * FROM test.v2`)
+
+	// ┌─────┐     ┌─────┐     ┌─────┐     ┌─────┐
+	// │ v3  │     │ v4  │     │ v5  │     │ v6  │
+	// └─────┘     └─────┘     └─────┘     └─────┘
+	//     \          │           │          /
+	//       \        │           │        /
+	//         \   ┌─────┐     ┌─────┐   /
+	//           \ │ v1  │     │  v2 │/
+	//             └─────┘     └─────┘
+	//                 \          /
+	//                  \        /
+	//                   \─────┐/
+	//                   │  t  │
+	//                   └─────┘
+
+	userTk := testkit.NewTestKit(t, store)
+	err := userTk.Session().Auth(&auth.UserIdentity{Username: "testuser", Hostname: "localhost"}, nil, nil, nil)
+	require.NoError(t, err)
+
+	// 1. testuser has only SELECT privilege of test.t
+	tk.MustExec(`GRANT SELECT(a) ON test.t to 'testuser'@'localhost';`)
+	userTk.MustQuery(`SELECT * FROM test.t`)
+	userTk.MustContainErrMsg("SELECT * FROM test.v1",
+		"[planner:1142]SELECT command denied to user 'testuser'@'localhost' for table 'v1'")
+	userTk.MustContainErrMsg("SELECT * FROM test.v2",
+		"[planner:1142]SELECT command denied to user 'testuser'@'localhost' for table 'v2'")
+	userTk.MustContainErrMsg("SELECT * FROM test.v3",
+		"[planner:1142]SELECT command denied to user 'testuser'@'localhost' for table 'v3'")
+	userTk.MustContainErrMsg("SELECT * FROM test.v4",
+		"[planner:1356]View 'test.v4' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them")
+	userTk.MustContainErrMsg("SELECT * FROM test.v5",
+		"[planner:1142]SELECT command denied to user 'testuser'@'localhost' for table 'v5'")
+	userTk.MustContainErrMsg("SELECT * FROM test.v6",
+		"[planner:1356]View 'test.v6' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them")
+
+	// 2. testuser has SELECT privilege of test.v1 and test.v2
+	tk.MustExec(`GRANT SELECT(a) ON test.v1 to 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a) ON test.v2 to 'testuser'@'localhost';`)
+	userTk.MustQuery(`SELECT * FROM test.v1`)
+	userTk.MustQuery(`SELECT * FROM test.v2`)
+	userTk.MustContainErrMsg("SELECT * FROM test.v3",
+		"[planner:1142]SELECT command denied to user 'testuser'@'localhost' for table 'v3'")
+	userTk.MustContainErrMsg("SELECT * FROM test.v4",
+		"[planner:1142]SELECT command denied to user 'testuser'@'localhost' for table 'v4'")
+	userTk.MustContainErrMsg("SELECT * FROM test.v5",
+		"[planner:1142]SELECT command denied to user 'testuser'@'localhost' for table 'v5'")
+	userTk.MustContainErrMsg("SELECT * FROM test.v6",
+		"[planner:1142]SELECT command denied to user 'testuser'@'localhost' for table 'v6'")
+
+	// 3. testuser has SELECT privilege of test.v3, test.v4, test.v5, test.v6
+	tk.MustExec(`REVOKE SELECT(a) ON test.v1 from 'testuser'@'localhost';`)
+	tk.MustExec(`REVOKE SELECT(a) ON test.v2 from 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a) ON test.v3 to 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a) ON test.v4 to 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a) ON test.v5 to 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a) ON test.v6 to 'testuser'@'localhost';`)
+	userTk.MustContainErrMsg(`SELECT * FROM test.v1`,
+		"[planner:1142]SELECT command denied to user 'testuser'@'localhost' for table 'v1'")
+	userTk.MustContainErrMsg(`SELECT * FROM test.v2`,
+		"[planner:1142]SELECT command denied to user 'testuser'@'localhost' for table 'v2'")
+	userTk.MustQuery(`SELECT * FROM test.v3`)
+	userTk.MustContainErrMsg(`SELECT * FROM test.v4`,
+		"[planner:1356]View 'test.v4' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them")
+	userTk.MustQuery(`SELECT * FROM test.v5`)
+	userTk.MustContainErrMsg(`SELECT * FROM test.v6`,
+		"[planner:1356]View 'test.v6' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them")
+
+	// 4. testuser has SELECT privilege of test.v1, test.v2, test.v3, test.v4, test.v5, test.v6
+	tk.MustExec(`GRANT SELECT(a) ON test.v1 to 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a) ON test.v2 to 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a) ON test.v3 to 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a) ON test.v4 to 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a) ON test.v5 to 'testuser'@'localhost';`)
+	tk.MustExec(`GRANT SELECT(a) ON test.v6 to 'testuser'@'localhost';`)
+	userTk.MustQuery(`SELECT * FROM test.v1`)
+	userTk.MustQuery(`SELECT * FROM test.v2`)
+	userTk.MustQuery(`SELECT * FROM test.v3`)
+	userTk.MustQuery(`SELECT * FROM test.v4`)
+	userTk.MustQuery(`SELECT * FROM test.v5`)
+	userTk.MustQuery(`SELECT * FROM test.v6`)
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -442,13 +442,7 @@ func (s *session) FieldList(tableName string) ([]*resolve.ResultField, error) {
 	pm := privilege.GetPrivilegeManager(s)
 	if pm != nil && s.sessionVars.User != nil {
 		if !pm.RequestVerification(s.sessionVars.ActiveRoles, dbName.O, tName.O, "", mysql.AllPrivMask) {
-			user := s.sessionVars.User
-			u := user.Username
-			h := user.Hostname
-			if len(user.AuthUsername) > 0 && len(user.AuthHostname) > 0 {
-				u = user.AuthUsername
-				h = user.AuthHostname
-			}
+			u, h := auth.GetUserAndHostName(s.sessionVars.User)
 			return nil, plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SELECT", u, h, tableName)
 		}
 	}

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -274,7 +274,6 @@ type StatementContext struct {
 	// in stmtCtx
 	IsStaleness     bool
 	InRestrictedSQL bool
-	ViewDepth       int32
 	// mu struct holds variables that change during execution.
 	mu *stmtCtxMu
 

--- a/pkg/util/dbterror/plannererrors/planner_terror.go
+++ b/pkg/util/dbterror/plannererrors/planner_terror.go
@@ -80,6 +80,7 @@ var (
 	ErrTooBigPrecision                       = dbterror.ClassExpression.NewStd(mysql.ErrTooBigPrecision)
 	ErrDBaccessDenied                        = dbterror.ClassOptimizer.NewStd(mysql.ErrDBaccessDenied)
 	ErrTableaccessDenied                     = dbterror.ClassOptimizer.NewStd(mysql.ErrTableaccessDenied)
+	ErrColumnaccessDenied                    = dbterror.ClassOptimizer.NewStd(mysql.ErrColumnaccessDenied)
 	ErrSpecificAccessDenied                  = dbterror.ClassOptimizer.NewStd(mysql.ErrSpecificAccessDenied)
 	ErrViewNoExplain                         = dbterror.ClassOptimizer.NewStd(mysql.ErrViewNoExplain)
 	ErrWrongValueCountOnRow                  = dbterror.ClassOptimizer.NewStd(mysql.ErrWrongValueCountOnRow)

--- a/tests/integrationtest/r/executor/simple.result
+++ b/tests/integrationtest/r/executor/simple.result
@@ -155,7 +155,7 @@ drop user if exists 'testflush'@'localhost';
 CREATE USER 'testflush'@'localhost' IDENTIFIED BY '';
 UPDATE mysql.User SET Select_priv='Y' WHERE User="testflush" and Host="localhost";
 SELECT authentication_string FROM mysql.User WHERE User="testflush" and Host="localhost";
-Error 1142 (42000): SELECT command denied to user 'testflush'@'localhost' for table 'user'
+Error 1143 (42000): SELECT command denied to user 'testflush'@'localhost' for column 'user' in table 'user'
 FLUSH PRIVILEGES;
 SELECT authentication_string FROM mysql.User WHERE User="testflush" and Host="localhost";
 authentication_string
@@ -409,7 +409,7 @@ testuser	%	{"comment": "1234"}
 testuser1	%	{"age": 20, "name": "Tom"}
 testuser2	%	NULL
 SELECT user, host, user_attributes FROM mysql.user ORDER BY user;
-Error 1142 (42000): SELECT command denied to user 'testuser1'@'%' for table 'user'
+Error 1143 (42000): SELECT command denied to user 'testuser1'@'%' for column 'user' in table 'user'
 create user usr1@'%' identified by 'passord';
 alter user usr1 comment 'comment1';
 select user_attributes from mysql.user where user = 'usr1';

--- a/tests/integrationtest/r/privilege/privileges.result
+++ b/tests/integrationtest/r/privilege/privileges.result
@@ -22,7 +22,7 @@ Error 1142 (42000): SHOW command denied to user 'testnotexist'@'localhost' for t
 SHOW CREATE TABLE dbnotexists.t1;
 Error 1142 (42000): SHOW command denied to user 'testnotexist'@'localhost' for table 't1'
 DELETE FROM privilege__privileges.t1 WHERE a=0;
-Error 1142 (42000): SELECT command denied to user 'testnotexist'@'localhost' for table 't1'
+Error 1143 (42000): SELECT command denied to user 'testnotexist'@'localhost' for column 'a' in table 't1'
 DELETE FROM dbnotexists.t1 WHERE a=0;
 Error 1142 (42000): DELETE command denied to user 'testnotexist'@'localhost' for table 't1'
 DELETE FROM privilege__privileges.t1;
@@ -166,9 +166,9 @@ create database if not exists privilege__privileges;
 create table privilege__privileges.t(id int, v int, primary key(id));
 insert into privilege__privileges.t(id, v) values(1, 1);
 select * from privilege__privileges.t where id = 1;
-Error 1142 (42000): SELECT command denied to user 'tester'@'localhost' for table 't'
+Error 1143 (42000): SELECT command denied to user 'tester'@'localhost' for column 'id' in table 't'
 update privilege__privileges.t set v = 2 where id = 1;
-Error 1142 (42000): SELECT command denied to user 'tester'@'localhost' for table 't'
+Error 1143 (42000): SELECT command denied to user 'tester'@'localhost' for column 'id' in table 't'
 DROP USER 'tester'@'localhost';
 CREATE DATABASE if not exists privilege__privileges;
 USE privilege__privileges;
@@ -663,3 +663,174 @@ update privilege__privileges.tt1 inner join t_f
 set t_f.fullname=t_f.fullname
 where tt1.id=t_f.id;
 Error 1288 (HY000): The target table t_f of the UPDATE is not updatable
+create user view_definer_u, view_invoker_u1, view_invoker_u2;
+create database test_view_db;
+use test_view_db;
+CREATE TABLE sensitive_data (
+id INT PRIMARY KEY AUTO_INCREMENT,
+public_col VARCHAR(50),
+sensitive_col VARCHAR(50)
+);
+INSERT INTO sensitive_data (public_col, sensitive_col) VALUES
+('Public Data A', 'Secret A'),
+('Public Data B', 'Secret B'),
+('Public Data C', 'Secret C');
+GRANT SELECT (id, public_col, sensitive_col) ON test_view_db.sensitive_data TO 'view_definer_u';
+GRANT CREATE VIEW, SHOW VIEW ON test_view_db.* to 'view_definer_u';
+GRANT SELECT (id, public_col) ON test_view_db.sensitive_data TO 'view_invoker_u1';
+SHOW GRANTS FOR view_definer_u;
+Grants for view_definer_u@%
+GRANT USAGE ON *.* TO 'view_definer_u'@'%'
+GRANT CREATE VIEW,SHOW VIEW ON `test_view_db`.* TO 'view_definer_u'@'%'
+GRANT SELECT(id, public_col, sensitive_col) ON `test_view_db`.`sensitive_data` TO 'view_definer_u'@'%'
+SHOW GRANTS FOR view_invoker_u1;
+Grants for view_invoker_u1@%
+GRANT USAGE ON *.* TO 'view_invoker_u1'@'%'
+GRANT SELECT(id, public_col) ON `test_view_db`.`sensitive_data` TO 'view_invoker_u1'@'%'
+SHOW GRANTS FOR view_invoker_u2;
+Grants for view_invoker_u2@%
+GRANT USAGE ON *.* TO 'view_invoker_u2'@'%'
+CREATE VIEW definer_view AS
+SELECT id, public_col, sensitive_col
+FROM sensitive_data;
+GRANT SELECT ON test_view_db.definer_view TO 'view_definer_u';
+GRANT SELECT ON test_view_db.definer_view TO 'view_invoker_u1';
+GRANT SELECT ON test_view_db.definer_view TO 'view_invoker_u2';
+SHOW CREATE VIEW definer_view;
+View	Create View	character_set_client	collation_connection
+definer_view	CREATE ALGORITHM=UNDEFINED DEFINER=`view_definer_u`@`%` SQL SECURITY DEFINER VIEW `definer_view` (`id`, `public_col`, `sensitive_col`) AS SELECT `id` AS `id`,`public_col` AS `public_col`,`sensitive_col` AS `sensitive_col` FROM `test_view_db`.`sensitive_data`	utf8mb4	utf8mb4_general_ci
+view_definer_u has all required privileges, so view_invoker_u1 and view_invoker_u2 can access all columns.
+SELECT id, public_col, sensitive_col FROM definer_view;
+id	public_col	sensitive_col
+1	Public Data A	Secret A
+2	Public Data B	Secret B
+3	Public Data C	Secret C
+SELECT id, public_col, sensitive_col FROM definer_view;
+id	public_col	sensitive_col
+1	Public Data A	Secret A
+2	Public Data B	Secret B
+3	Public Data C	Secret C
+CREATE SQL SECURITY INVOKER VIEW invoker_view AS
+SELECT id, public_col, sensitive_col
+FROM sensitive_data;
+GRANT SELECT ON test_view_db.invoker_view TO 'view_definer_u';
+GRANT SELECT ON test_view_db.invoker_view TO 'view_invoker_u1';
+GRANT SELECT ON test_view_db.invoker_view TO 'view_invoker_u2';
+revoke one columns privilege, so view_definer_u can not access definer_view;
+REVOKE SELECT(sensitive_col) ON `test_view_db`.`sensitive_data` FROM 'view_definer_u'@'%';
+SHOW CREATE VIEW invoker_view;
+View	Create View	character_set_client	collation_connection
+invoker_view	CREATE ALGORITHM=UNDEFINED DEFINER=`view_definer_u`@`%` SQL SECURITY INVOKER VIEW `invoker_view` (`id`, `public_col`, `sensitive_col`) AS SELECT `id` AS `id`,`public_col` AS `public_col`,`sensitive_col` AS `sensitive_col` FROM `test_view_db`.`sensitive_data`	utf8mb4	utf8mb4_general_ci
+view_invoker_u1 lacks the SELECT privilege of sensitive_col
+SELECT id, public_col, sensitive_col FROM invoker_view;
+Error 1356 (HY000): View 'test_view_db.invoker_view' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+SELECT * FROM invoker_view;
+Error 1356 (HY000): View 'test_view_db.invoker_view' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+GRANT SELECT(sensitive_col) on test_view_db.sensitive_data to view_invoker_u1;
+SELECT * FROM invoker_view;
+id	public_col	sensitive_col
+1	Public Data A	Secret A
+2	Public Data B	Secret B
+3	Public Data C	Secret C
+SELECT id, public_col, sensitive_col FROM definer_view;
+Error 1356 (HY000): View 'test_view_db.definer_view' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+SELECT * FROM definer_view;
+Error 1356 (HY000): View 'test_view_db.definer_view' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+view_invoker_u2 lacks all columns' SELECT privilege
+SELECT id, public_col, sensitive_col FROM invoker_view;
+Error 1356 (HY000): View 'test_view_db.invoker_view' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+SELECT * FROM invoker_view;
+Error 1356 (HY000): View 'test_view_db.invoker_view' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+GRANT SELECT on test_view_db.sensitive_data to view_invoker_u2;
+SELECT * FROM invoker_view;
+id	public_col	sensitive_col
+1	Public Data A	Secret A
+2	Public Data B	Secret B
+3	Public Data C	Secret C
+SELECT id, public_col, sensitive_col FROM definer_view;
+Error 1356 (HY000): View 'test_view_db.definer_view' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+SELECT * FROM definer_view;
+Error 1356 (HY000): View 'test_view_db.definer_view' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+REVOKE SELECT ON `test_view_db`.`definer_view` FROM 'view_definer_u'@'%';
+REVOKE SELECT ON `test_view_db`.`invoker_view` FROM 'view_definer_u'@'%';
+REVOKE SELECT ON `test_view_db`.`definer_view` FROM 'view_invoker_u1'@'%';
+REVOKE SELECT ON `test_view_db`.`invoker_view` FROM 'view_invoker_u1'@'%';
+REVOKE SELECT ON `test_view_db`.`definer_view` FROM 'view_invoker_u2'@'%';
+REVOKE SELECT ON `test_view_db`.`invoker_view` FROM 'view_invoker_u2'@'%';
+GRANT SELECT(sensitive_col) ON  `test_view_db`.`sensitive_data` TO 'view_definer_u'@'%';
+REVOKE SELECT(sensitive_col) ON  `test_view_db`.`sensitive_data` FROM 'view_invoker_u1'@'%';
+SHOW GRANTS FOR view_definer_u;
+Grants for view_definer_u@%
+GRANT USAGE ON *.* TO 'view_definer_u'@'%'
+GRANT CREATE VIEW,SHOW VIEW ON `test_view_db`.* TO 'view_definer_u'@'%'
+GRANT SELECT(id, public_col, sensitive_col) ON `test_view_db`.`sensitive_data` TO 'view_definer_u'@'%'
+SHOW GRANTS FOR view_invoker_u1;
+Grants for view_invoker_u1@%
+GRANT USAGE ON *.* TO 'view_invoker_u1'@'%'
+GRANT SELECT(id, public_col) ON `test_view_db`.`sensitive_data` TO 'view_invoker_u1'@'%'
+SHOW GRANTS FOR view_invoker_u2;
+Grants for view_invoker_u2@%
+GRANT USAGE ON *.* TO 'view_invoker_u2'@'%'
+GRANT SELECT ON `test_view_db`.`sensitive_data` TO 'view_invoker_u2'@'%'
+test view_definer_u
+GRANT SELECT(id, public_col) ON `test_view_db`.`invoker_view` TO 'view_definer_u'@'%';
+GRANT SELECT(id, public_col) ON `test_view_db`.`definer_view` TO 'view_definer_u'@'%';
+SELECT * FROM invoker_view;
+Error 1142 (42000): SELECT command denied to user 'view_definer_u'@'%' for table 'invoker_view'
+SELECT * FROM definer_view;
+Error 1142 (42000): SELECT command denied to user 'view_definer_u'@'%' for table 'definer_view'
+SELECT id, public_col FROM invoker_view;
+id	public_col
+1	Public Data A
+2	Public Data B
+3	Public Data C
+SELECT id, public_col FROM definer_view;
+id	public_col
+1	Public Data A
+2	Public Data B
+3	Public Data C
+SELECT sensitive_col FROM invoker_view;
+Error 1143 (42000): SELECT command denied to user 'view_definer_u'@'%' for column 'sensitive_col' in table 'invoker_view'
+SELECT sensitive_col FROM definer_view;
+Error 1143 (42000): SELECT command denied to user 'view_definer_u'@'%' for column 'sensitive_col' in table 'definer_view'
+test view_invoker_u1
+GRANT SELECT(id, public_col) ON `test_view_db`.`invoker_view` TO 'view_invoker_u1'@'%';
+GRANT SELECT(id, public_col) ON `test_view_db`.`definer_view` TO 'view_invoker_u1'@'%';
+SELECT * FROM invoker_view;
+Error 1356 (HY000): View 'test_view_db.invoker_view' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+SELECT * FROM definer_view;
+Error 1142 (42000): SELECT command denied to user 'view_invoker_u1'@'%' for table 'definer_view'
+SELECT id, public_col FROM invoker_view;
+Error 1356 (HY000): View 'test_view_db.invoker_view' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+SELECT id, public_col FROM definer_view;
+id	public_col
+1	Public Data A
+2	Public Data B
+3	Public Data C
+SELECT sensitive_col FROM invoker_view;
+Error 1356 (HY000): View 'test_view_db.invoker_view' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+SELECT sensitive_col FROM definer_view;
+Error 1143 (42000): SELECT command denied to user 'view_invoker_u1'@'%' for column 'sensitive_col' in table 'definer_view'
+test view_invoker_u2
+GRANT SELECT(id, public_col) ON `test_view_db`.`invoker_view` TO 'view_invoker_u2'@'%';
+GRANT SELECT(id, public_col) ON `test_view_db`.`definer_view` TO 'view_invoker_u2'@'%';
+SELECT * FROM invoker_view;
+Error 1142 (42000): SELECT command denied to user 'view_invoker_u2'@'%' for table 'invoker_view'
+SELECT * FROM definer_view;
+Error 1142 (42000): SELECT command denied to user 'view_invoker_u2'@'%' for table 'definer_view'
+SELECT id, public_col FROM invoker_view;
+id	public_col
+1	Public Data A
+2	Public Data B
+3	Public Data C
+SELECT id, public_col FROM definer_view;
+id	public_col
+1	Public Data A
+2	Public Data B
+3	Public Data C
+SELECT sensitive_col FROM invoker_view;
+Error 1143 (42000): SELECT command denied to user 'view_invoker_u2'@'%' for column 'sensitive_col' in table 'invoker_view'
+SELECT sensitive_col FROM definer_view;
+Error 1143 (42000): SELECT command denied to user 'view_invoker_u2'@'%' for column 'sensitive_col' in table 'definer_view'
+drop user view_definer_u, view_invoker_u1, view_invoker_u2;
+drop database test_view_db;

--- a/tests/integrationtest/r/session/privileges.result
+++ b/tests/integrationtest/r/session/privileges.result
@@ -53,7 +53,7 @@ create user xxx;
 grant all on session__privileges.t1 to xxx;
 grant select on session__privileges.t2 to xxx;
 update t2 set id = 666 where id = 1;
-Error 8121 (HY000): privilege check for 'Update' fail
+Error 1143 (42000): UPDATE command denied to user 'xxx'@'%' for column 'id' in table 't2'
 ## Cover a bug that t1 and t2 both require update privilege.
 ## In fact, the privlege check for t1 should be update, and for t2 should be select.
 update t1,t2 set t1.id = t2.id;

--- a/tests/integrationtest/t/executor/simple.test
+++ b/tests/integrationtest/t/executor/simple.test
@@ -167,7 +167,7 @@ drop user if exists 'testflush'@'localhost';
 CREATE USER 'testflush'@'localhost' IDENTIFIED BY '';
 UPDATE mysql.User SET Select_priv='Y' WHERE User="testflush" and Host="localhost";
 connect (conn1, localhost, testflush,,);
---error 1142
+--error 1143
 SELECT authentication_string FROM mysql.User WHERE User="testflush" and Host="localhost";
 connection default;
 FLUSH PRIVILEGES;
@@ -443,7 +443,7 @@ SELECT attribute FROM information_schema.user_attributes WHERE user = 'testuser1
 ## but not via the mysql.user table.
 connect (conn1, localhost, testuser1,,);
 SELECT user, host, attribute FROM information_schema.user_attributes where user in ('testuser', 'testuser1', 'testuser2') ORDER BY user;
--- error 1142
+-- error 1143
 SELECT user, host, user_attributes FROM mysql.user ORDER BY user;
 
 ## https://github.com/pingcap/tidb/issues/39207

--- a/tests/integrationtest/t/privilege/privileges.test
+++ b/tests/integrationtest/t/privilege/privileges.test
@@ -34,7 +34,7 @@ SELECT * FROM dbnotexists.t1;
 SHOW CREATE TABLE privilege__privileges.t1;
 --error 1142
 SHOW CREATE TABLE dbnotexists.t1;
---error 1142
+--error 1143
 DELETE FROM privilege__privileges.t1 WHERE a=0;
 --error 1142
 DELETE FROM dbnotexists.t1 WHERE a=0;
@@ -224,9 +224,9 @@ create table privilege__privileges.t(id int, v int, primary key(id));
 insert into privilege__privileges.t(id, v) values(1, 1);
 
 connect (tester,localhost,tester,,);
---error ErrTableaccessDenied
+--error ErrColumnaccessDenied
 select * from privilege__privileges.t where id = 1;
---error ErrTableaccessDenied
+--error ErrColumnaccessDenied
 update privilege__privileges.t set v = 2 where id = 1;
 disconnect tester;
 DROP USER 'tester'@'localhost';
@@ -898,3 +898,158 @@ with t_f as (
 
 disconnect u53490;
 connection default;
+
+# Test DEFINER/INVOKER of view
+
+## Case1: test some users lack column-privileges of the internal table
+connection default;
+create user view_definer_u, view_invoker_u1, view_invoker_u2;
+create database test_view_db;
+use test_view_db;
+CREATE TABLE sensitive_data (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    public_col VARCHAR(50),
+    sensitive_col VARCHAR(50)
+);
+INSERT INTO sensitive_data (public_col, sensitive_col) VALUES
+  ('Public Data A', 'Secret A'),
+  ('Public Data B', 'Secret B'),
+  ('Public Data C', 'Secret C');
+GRANT SELECT (id, public_col, sensitive_col) ON test_view_db.sensitive_data TO 'view_definer_u';
+GRANT CREATE VIEW, SHOW VIEW ON test_view_db.* to 'view_definer_u';
+GRANT SELECT (id, public_col) ON test_view_db.sensitive_data TO 'view_invoker_u1';
+SHOW GRANTS FOR view_definer_u;
+SHOW GRANTS FOR view_invoker_u1;
+SHOW GRANTS FOR view_invoker_u2;
+
+connect (view_definer_u, localhost, view_definer_u, , test_view_db);
+CREATE VIEW definer_view AS
+  SELECT id, public_col, sensitive_col
+  FROM sensitive_data;
+
+connection default;
+GRANT SELECT ON test_view_db.definer_view TO 'view_definer_u';
+GRANT SELECT ON test_view_db.definer_view TO 'view_invoker_u1';
+GRANT SELECT ON test_view_db.definer_view TO 'view_invoker_u2';
+
+connection view_definer_u;
+SHOW CREATE VIEW definer_view;
+
+--echo view_definer_u has all required privileges, so view_invoker_u1 and view_invoker_u2 can access all columns.
+connect (view_invoker_u1, localhost, view_invoker_u1, , test_view_db);
+SELECT id, public_col, sensitive_col FROM definer_view;
+connect (view_invoker_u2, localhost, view_invoker_u2, , test_view_db);
+SELECT id, public_col, sensitive_col FROM definer_view;
+
+connection view_definer_u;
+CREATE SQL SECURITY INVOKER VIEW invoker_view AS
+  SELECT id, public_col, sensitive_col
+  FROM sensitive_data;
+
+connection default;
+GRANT SELECT ON test_view_db.invoker_view TO 'view_definer_u';
+GRANT SELECT ON test_view_db.invoker_view TO 'view_invoker_u1';
+GRANT SELECT ON test_view_db.invoker_view TO 'view_invoker_u2';
+--echo revoke one columns privilege, so view_definer_u can not access definer_view;
+REVOKE SELECT(sensitive_col) ON `test_view_db`.`sensitive_data` FROM 'view_definer_u'@'%';
+
+connection view_definer_u;
+SHOW CREATE VIEW invoker_view;
+
+--echo view_invoker_u1 lacks the SELECT privilege of sensitive_col
+connection view_invoker_u1;
+--error 1356
+SELECT id, public_col, sensitive_col FROM invoker_view;
+--error 1356
+SELECT * FROM invoker_view;
+connection default;
+GRANT SELECT(sensitive_col) on test_view_db.sensitive_data to view_invoker_u1;
+connection view_invoker_u1;
+SELECT * FROM invoker_view;
+--error 1356
+SELECT id, public_col, sensitive_col FROM definer_view;
+--error 1356
+SELECT * FROM definer_view;
+
+--echo view_invoker_u2 lacks all columns' SELECT privilege
+connection view_invoker_u2;
+--error 1356
+SELECT id, public_col, sensitive_col FROM invoker_view;
+--error 1356
+SELECT * FROM invoker_view;
+
+connection default;
+GRANT SELECT on test_view_db.sensitive_data to view_invoker_u2;
+connection view_invoker_u2;
+SELECT * FROM invoker_view;
+--error 1356
+SELECT id, public_col, sensitive_col FROM definer_view;
+--error 1356
+SELECT * FROM definer_view;
+
+connection default;
+
+## Case2: test some users lack column-privileges of the view
+REVOKE SELECT ON `test_view_db`.`definer_view` FROM 'view_definer_u'@'%';
+REVOKE SELECT ON `test_view_db`.`invoker_view` FROM 'view_definer_u'@'%';
+REVOKE SELECT ON `test_view_db`.`definer_view` FROM 'view_invoker_u1'@'%';
+REVOKE SELECT ON `test_view_db`.`invoker_view` FROM 'view_invoker_u1'@'%';
+REVOKE SELECT ON `test_view_db`.`definer_view` FROM 'view_invoker_u2'@'%';
+REVOKE SELECT ON `test_view_db`.`invoker_view` FROM 'view_invoker_u2'@'%';
+GRANT SELECT(sensitive_col) ON  `test_view_db`.`sensitive_data` TO 'view_definer_u'@'%';
+REVOKE SELECT(sensitive_col) ON  `test_view_db`.`sensitive_data` FROM 'view_invoker_u1'@'%';
+SHOW GRANTS FOR view_definer_u;
+SHOW GRANTS FOR view_invoker_u1;
+SHOW GRANTS FOR view_invoker_u2;
+
+--echo test view_definer_u
+GRANT SELECT(id, public_col) ON `test_view_db`.`invoker_view` TO 'view_definer_u'@'%';
+GRANT SELECT(id, public_col) ON `test_view_db`.`definer_view` TO 'view_definer_u'@'%';
+connection view_definer_u;
+--error 1142
+SELECT * FROM invoker_view;
+--error 1142
+SELECT * FROM definer_view;
+SELECT id, public_col FROM invoker_view;
+SELECT id, public_col FROM definer_view;
+--error 1143
+SELECT sensitive_col FROM invoker_view;
+--error 1143
+SELECT sensitive_col FROM definer_view;
+
+--echo test view_invoker_u1
+connection default;
+GRANT SELECT(id, public_col) ON `test_view_db`.`invoker_view` TO 'view_invoker_u1'@'%';
+GRANT SELECT(id, public_col) ON `test_view_db`.`definer_view` TO 'view_invoker_u1'@'%';
+connection view_invoker_u1;
+--error 1356
+SELECT * FROM invoker_view;
+--error 1142
+SELECT * FROM definer_view;
+--error 1356
+SELECT id, public_col FROM invoker_view;
+SELECT id, public_col FROM definer_view;
+--error 1356
+SELECT sensitive_col FROM invoker_view;
+--error 1143
+SELECT sensitive_col FROM definer_view;
+
+--echo test view_invoker_u2
+connection default;
+GRANT SELECT(id, public_col) ON `test_view_db`.`invoker_view` TO 'view_invoker_u2'@'%';
+GRANT SELECT(id, public_col) ON `test_view_db`.`definer_view` TO 'view_invoker_u2'@'%';
+connection view_invoker_u2;
+--error 1142
+SELECT * FROM invoker_view;
+--error 1142
+SELECT * FROM definer_view;
+SELECT id, public_col FROM invoker_view;
+SELECT id, public_col FROM definer_view;
+--error 1143
+SELECT sensitive_col FROM invoker_view;
+--error 1143
+SELECT sensitive_col FROM definer_view;
+
+connection default;
+drop user view_definer_u, view_invoker_u1, view_invoker_u2;
+drop database test_view_db;

--- a/tests/integrationtest/t/session/privileges.test
+++ b/tests/integrationtest/t/session/privileges.test
@@ -57,7 +57,7 @@ grant all on session__privileges.t1 to xxx;
 grant select on session__privileges.t2 to xxx;
 
 connect (conn1, localhost, xxx,,session__privileges);
--- error 8121
+-- error 1143
 update t2 set id = 666 where id = 1;
 -- echo ## Cover a bug that t1 and t2 both require update privilege.
 -- echo ## In fact, the privlege check for t1 should be update, and for t2 should be select.


### PR DESCRIPTION
This is a cherry-pick of #61741 to `release-8.5`.

### What problem does this PR solve?

Issue Number: ref #61706

Problem Summary:
Backport the column-level privilege visit-info collection during plan building.

### What changed and how does it work?

- Utilize `expressionRewriter.toColumn` to collect visited columns while building the logical plan.
- Add column-level privilege visit info for statements like `SELECT`, `INSERT`, `LOAD DATA`, `UPDATE`, `GRANT/REVOKE`.
- Improve error reporting (column vs table vs view invalid) for privilege checks.

Note:
The original automated cherry-pick PR (#66536) contained unresolved conflict markers in `pkg/planner/core/expression_rewriter.go`.
This PR resolves them by merging target-branch changes (e.g. `curClause` handling / existing helpers) with the source PR logic.

Related test: https://github.com/PingCAP-QE/tidb-test/pull/2532

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [ ] Manual test

Unit tests:

- `go test ./pkg/planner/core -run TestVisitInfo -count=1 -tags=intest`
- `go test ./pkg/planner/core -run TestSelectView -count=1 -tags=intest`
- `go test ./pkg/privilege/privileges -count=1 -tags=intest`
- `go test ./pkg/extension/... -count=1 -tags=intest`
- `cd pkg/parser && go test ./ast ./auth -count=1`

Integration tests:

- `cd tests/integrationtest && ./run-tests.sh -t "executor/simple privilege/privileges session/privileges"`

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added column-level privilege system enabling fine-grained access control on specific columns instead of entire tables.
  * Enhanced support for column privileges in views with proper DEFINER/INVOKER semantics.
  
* **Bug Fixes**
  * Improved privilege enforcement to report column-specific access denials with error code 1143.

* **Tests**
  * Added comprehensive test coverage for column-level privileges across SELECT, INSERT, UPDATE, LOAD DATA, and view scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->