### PR TITLE
*: exclude make bazel_lint_changed from default AGENTS local flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,9 @@ make bazel_bin
 make gogenerate   # optional: regenerate generated code
 go mod tidy       # optional: if go.mod/go.sum changed
 git fetch origin --prune
-make bazel_lint_changed # Optional: skip this step if the resolved Bazel target is //:all.
 ```
+
+`make bazel_lint_changed` is intentionally excluded from the default local flow because it can be slow and resource-intensive on local macOS environments. Agents MUST NOT run `make bazel_lint_changed` unless the user explicitly requests it.
 
 ## Task -> Validation Matrix
 


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref #63847

Problem Summary:

`make bazel_lint_changed` can be slow and resource-intensive on local macOS development machines. The default local workflow guidance in `AGENTS.md` should avoid requiring it for normal local development.

### What changed and how does it work?

In `AGENTS.md` Build Flow:

- Removed `make bazel_lint_changed` from the "Recommended local build flow" command block.
- Added explicit policy text that `make bazel_lint_changed` is intentionally excluded from the default local flow and agents MUST NOT run it unless explicitly requested by the user.

This keeps the guidance clear and prevents unnecessary heavy local lint runs.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Development workflow documentation has been comprehensively updated to clarify build process procedures and lint command requirements. The default lint command specification has been revised to streamline standard development workflows. Explicit guidance has been provided regarding command execution requirements, usage constraints, and specific scenarios where alternative lint procedures should be applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->