### PR TITLE
metrics: deduplicate TiDB Server Status panel by instance

### DIFF
--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -2191,7 +2191,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "count(up{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"} == 1)",
+              "expr": "count(max(up{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"}) by (instance) == 1)",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -2202,7 +2202,7 @@
             },
             {
               "exemplar": true,
-              "expr": "count(up{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"} == 0)",
+              "expr": "count(max(up{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"}) by (instance) == 0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Down",

--- a/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
+++ b/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
@@ -2259,7 +2259,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "count(up{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"} == 1)",
+              "expr": "count(max(up{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"}) by (instance) == 1)",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -2270,7 +2270,7 @@
             },
             {
               "exemplar": true,
-              "expr": "count(up{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"} == 0)",
+              "expr": "count(max(up{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"}) by (instance) == 0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Down",

--- a/pkg/metrics/nextgengrafana/tidb_worker.json
+++ b/pkg/metrics/nextgengrafana/tidb_worker.json
@@ -2259,7 +2259,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "count(up{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"worker-tidb\"} == 1)",
+              "expr": "count(max(up{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"worker-tidb\"}) by (instance) == 1)",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -2270,7 +2270,7 @@
             },
             {
               "exemplar": true,
-              "expr": "count(up{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"worker-tidb\"} == 0)",
+              "expr": "count(max(up{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"worker-tidb\"}) by (instance) == 0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Down",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66193

Problem Summary:
On the TiDB Cluster panel in Clinic, TiDB Server Status directly counts the up metric. When multiple job levels scrape simultaneously, the same instance may be counted repeatedly, resulting in redundant node display.

### What changed and how does it work?
Updated `TiDB Server Status` panel PromQL to deduplicate by `instance` before counting:
- Before: `count(up{...} == 1/0)`
- After: `count(avg(up{...}) by (instance) == 1/0)`

This removes duplicate counting caused by multiple jobs exposing the same `up` series for one instance.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > - [x] Change is limited to Grafana dashboard PromQL expressions.


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated monitoring queries to use aggregated functions (max/sum/avg) grouped by instance/type/le, replacing per-sample checks.
  * Resulting dashboards (main, keyspace, worker) now report aggregated, more stable metrics for availability, error counts, durations, and counters—improving visibility and alert stability in multi-instance deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->