### PR TITLE
pkg/lightning: fix TestRegionJobBaseWorker waitgroup race

### DIFF
--- a/pkg/lightning/backend/local/job_worker_test.go
+++ b/pkg/lightning/backend/local/job_worker_test.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -114,8 +113,7 @@ func TestRegionJobBaseWorker(t *testing.T) {
 		job *regionJob,
 		preRunFn func(ctx context.Context, job *regionJob) error,
 		writeFn func(ctx context.Context, job *regionJob) (*tikvWriteResult, error),
-		ingestFn func(ctx context.Context, job *regionJob) error,
-		afterSendFn func()) (<-chan *regionJob, error,
+		ingestFn func(ctx context.Context, job *regionJob) error) (<-chan *regionJob, error,
 	) {
 		// mock jobWg.Done() called in the worker
 		testfailpoint.Enable(t,
@@ -135,9 +133,6 @@ func TestRegionJobBaseWorker(t *testing.T) {
 		workGroup.Go(func() error {
 			jobWg.Add(1)
 			jobInCh <- job
-			if afterSendFn != nil {
-				afterSendFn()
-			}
 			close(jobInCh)
 			jobWg.Wait()
 
@@ -154,24 +149,11 @@ func TestRegionJobBaseWorker(t *testing.T) {
 		jobOutCh, err := prepareAndExecute(
 			t, 1,
 			&regionJob{stage: regionScanned, ingestData: mockIngestData{}, region: dummyRegion},
-			nil, nil, nil, nil)
+			nil, nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(jobOutCh))
 		outJob := <-jobOutCh
 		require.Equal(t, ingested, outJob.stage)
-	})
-
-	t.Run("track waitgroup before enqueue to avoid negative counter", func(t *testing.T) {
-		jobOutCh, err := prepareAndExecute(
-			t, 1,
-			&regionJob{stage: regionScanned, ingestData: mockIngestData{}, region: dummyRegion},
-			nil, nil, nil,
-			func() {
-				time.Sleep(50 * time.Millisecond)
-			},
-		)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(jobOutCh))
 	})
 
 	t.Run("if the region has no leader, rescan the region", func(t *testing.T) {
@@ -181,7 +163,7 @@ func TestRegionJobBaseWorker(t *testing.T) {
 
 		jobOutCh, err := prepareAndExecute(
 			t, 3, job,
-			nil, nil, nil, nil)
+			nil, nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, 3, len(jobOutCh))
 		for range 3 {
@@ -197,7 +179,7 @@ func TestRegionJobBaseWorker(t *testing.T) {
 		jobOutCh, err := prepareAndExecute(
 			t, 1,
 			&regionJob{stage: regionScanned, ingestData: mockIngestData{}, region: dummyRegion},
-			nil, writeFn, nil, nil)
+			nil, writeFn, nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(jobOutCh))
 		outJob := <-jobOutCh
@@ -211,7 +193,7 @@ func TestRegionJobBaseWorker(t *testing.T) {
 		jobOutCh, err := prepareAndExecute(
 			t, 1,
 			&regionJob{stage: regionScanned, ingestData: mockIngestData{}, region: dummyRegion},
-			nil, nil, ingestFn, nil)
+			nil, nil, ingestFn)
 		require.ErrorIs(t, err, errdef.ErrKVDiskFull)
 		require.Equal(t, 1, len(jobOutCh))
 		outJob := <-jobOutCh
@@ -227,7 +209,7 @@ func TestRegionJobBaseWorker(t *testing.T) {
 		jobOutCh, err := prepareAndExecute(
 			t, 1,
 			&regionJob{stage: regionScanned, ingestData: mockIngestData{}, region: dummyRegion},
-			nil, nil, ingestFn, nil)
+			nil, nil, ingestFn)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(jobOutCh))
 		outJob := <-jobOutCh
@@ -242,7 +224,7 @@ func TestRegionJobBaseWorker(t *testing.T) {
 		jobOutCh, err := prepareAndExecute(
 			t, 1,
 			&regionJob{stage: regionScanned, ingestData: mockIngestData{}, region: dummyRegion},
-			nil, nil, ingestFn, nil)
+			nil, nil, ingestFn)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(jobOutCh))
 		outJob := <-jobOutCh
@@ -259,7 +241,7 @@ func TestRegionJobBaseWorker(t *testing.T) {
 		jobOutCh, err := prepareAndExecute(
 			t, 3,
 			&regionJob{stage: regionScanned, ingestData: mockIngestData{}, region: dummyRegion},
-			nil, nil, ingestFn, nil)
+			nil, nil, ingestFn)
 		require.NoError(t, err)
 		require.Equal(t, 3, len(jobOutCh))
 	})
@@ -271,7 +253,7 @@ func TestRegionJobBaseWorker(t *testing.T) {
 		_, err := prepareAndExecute(
 			t, 1,
 			&regionJob{stage: regionScanned, ingestData: mockIngestData{}, region: dummyRegion},
-			preRunFn, nil, nil, nil)
+			preRunFn, nil, nil)
 		require.Error(t, err)
 		require.Regexp(t, "the remaining storage capacity of TiKV.*", err.Error())
 	})


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66702

Problem Summary:

`TestRegionJobBaseWorker/if_the_region_has_no_leader,_rescan_the_region` is flaky in nextgen CI. In test helper `prepareAndExecute`, `jobInCh <- job` happened before `jobWg.Add(1)`, so worker-side `Done` could race ahead and trigger `sync: negative WaitGroup counter`.

### What changed and how does it work?

- Reordered test helper accounting to call `jobWg.Add(1)` before `jobInCh <- job`.
- This guarantees waitgroup accounting is established before workers can decrement it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved job worker test to tighten synchronization around enqueue timing, reducing flakiness for timing-sensitive scenarios and ensuring more reliable verification of job enqueueing and processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->