### PR TITLE
dumpling: Fix and improve MySQL 8.4 support

### DIFF
--- a/.github/workflows/integration-test-dumpling.yml
+++ b/.github/workflows/integration-test-dumpling.yml
@@ -49,11 +49,9 @@ jobs:
       fail-fast: true
       matrix:
         mysql_version:
-          - 5.7.35
-          - 8.0.22
-          - 8.0.26
-          - 8.0.37
-          - 8.4.3
+          - 5.7.35 # Note that OpenSSL is upgraded from 1.1.1 to 3.0.x in 5.7.43
+          - 8.0.45
+          - 8.4.8
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:

--- a/Makefile
+++ b/Makefile
@@ -467,11 +467,21 @@ build_lightning_for_web:
 
 .PHONY: build_lightning
 build_lightning: ## Build TiDB Lightning data import tool
+ifeq ("$(GOOS)", "freebsd")
+	@echo "Building lightning for FreeBSD, assuming crossbuild, disabling CGO"
+	CGO_ENABLED=0 $(GOBUILD_NO_TAGS) -tags codes $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_BIN) ./lightning/cmd/tidb-lightning
+else
 	CGO_ENABLED=1 $(GOBUILD_NO_TAGS) -tags codes $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_BIN) ./lightning/cmd/tidb-lightning
+endif
 
 .PHONY: build_lightning-ctl
 build_lightning-ctl: ## Build TiDB Lightning control tool
+	@echo "Building lightning-ctl for FreeBSD, assuming crossbuild, disabling CGO"
+ifeq ("$(GOOS)", "freebsd")
+	CGO_ENABLED=0 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_CTL_BIN) ./lightning/cmd/tidb-lightning-ctl
+else
 	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_CTL_BIN) ./lightning/cmd/tidb-lightning-ctl
+endif
 
 .PHONY: build_for_lightning_integration_test
 build_for_lightning_integration_test:

--- a/br/pkg/version/version.go
+++ b/br/pkg/version/version.go
@@ -353,7 +353,7 @@ type ServerType int
 
 const (
 	// ServerTypeUnknown represents unknown server type
-	ServerTypeUnknown = iota
+	ServerTypeUnknown ServerType = iota
 	// ServerTypeMySQL represents MySQL server type
 	ServerTypeMySQL
 	// ServerTypeMariaDB represents MariaDB server type

--- a/br/pkg/version/version_test.go
+++ b/br/pkg/version/version_test.go
@@ -520,7 +520,7 @@ func TestDetectServerInfo(t *testing.T) {
 		{9, "5.7.25-TiDB-5584f12", ServerTypeTiDB, mkVer(0, 0, 0, "")},
 	}
 	dec := func(d []any) (tag int, verStr string, tp ServerType, v *semver.Version) {
-		return d[0].(int), d[1].(string), ServerType(d[2].(int)), d[3].(*semver.Version)
+		return d[0].(int), d[1].(string), d[2].(ServerType), d[3].(*semver.Version)
 	}
 
 	for _, datum := range data {

--- a/dumpling/export/dump_test.go
+++ b/dumpling/export/dump_test.go
@@ -85,7 +85,7 @@ func TestDumpTableMeta(t *testing.T) {
 	conf.NoSchemas = true
 
 	for serverType := version.ServerTypeUnknown; serverType < version.ServerTypeAll; serverType++ {
-		conf.ServerInfo.ServerType = version.ServerType(serverType)
+		conf.ServerInfo.ServerType = serverType
 		hasImplicitRowID := false
 		mock.ExpectQuery("SHOW COLUMNS FROM").
 			WillReturnRows(sqlmock.NewRows([]string{"Field", "Type", "Null", "Key", "Default", "Extra"}).

--- a/dumpling/export/metadata.go
+++ b/dumpling/export/metadata.go
@@ -69,13 +69,7 @@ func (m *globalMetadata) recordGlobalMetaData(db *sql.Conn, serverInfo version.S
 func recordGlobalMetaData(tctx *tcontext.Context, db *sql.Conn, buffer *bytes.Buffer, serverInfo version.ServerInfo, afterConn bool, snapshot string) error { // revive:disable-line:flag-parameter
 	serverType := serverInfo.ServerType
 	writeMasterStatusHeader := func() {
-		if serverInfo.ServerVersion == nil {
-			buffer.WriteString("SHOW MASTER STATUS:")
-		} else if serverInfo.ServerVersion.LessThan(*minNewTerminologyMySQL) {
-			buffer.WriteString("SHOW MASTER STATUS:")
-		} else {
-			buffer.WriteString("SHOW BINARY LOG STATUS:")
-		}
+		buffer.WriteString("SHOW MASTER STATUS:")
 		if afterConn {
 			buffer.WriteString(" /* AFTER CONNECTION POOL ESTABLISHED */")
 		}
@@ -204,13 +198,14 @@ func recordGlobalMetaData(tctx *tcontext.Context, db *sql.Conn, buffer *bytes.Bu
 				switch col {
 				case "connection_name":
 					connName = data[i].String
-				case "exec_master_log_pos":
+				case "exec_master_log_pos", "exec_source_log_pos":
 					pos = data[i].String
-				case "relay_master_log_file":
+				case "relay_master_log_file", "relay_source_log_file":
 					logFile = data[i].String
-				case "master_host":
+				case "master_host", "source_host":
 					host = data[i].String
-				case "executed_gtid_set":
+				case "executed_gtid_set", // MySQL
+					"gtid_io_pos": // MariaDB
 					gtidSet = data[i].String
 				}
 			}

--- a/dumpling/export/metadata_test.go
+++ b/dumpling/export/metadata_test.go
@@ -23,7 +23,7 @@ const (
 	gtidSet = "6ce40be3-e359-11e9-87e0-36933cb0ca5a:1-29"
 )
 
-func TestMysqlMetaData(t *testing.T) {
+func TestMysqlMetaData_80(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -41,7 +41,45 @@ func TestMysqlMetaData(t *testing.T) {
 		sqlmock.NewRows([]string{"exec_master_log_pos", "relay_master_log_file", "master_host", "Executed_Gtid_Set", "Seconds_Behind_Master"}))
 
 	m := newGlobalMetadata(tcontext.Background(), createStorage(t), "")
-	require.NoError(t, m.recordGlobalMetaData(conn, version.ServerInfo{ServerType: version.ServerTypeMySQL}, false))
+	si := version.ParseServerInfo("8.0.45")
+	require.Equal(t, version.ServerTypeMySQL, si.ServerType)
+	require.NoError(t, m.recordGlobalMetaData(conn, si, false))
+
+	expected := "SHOW MASTER STATUS:\n" +
+		"\tLog: ON.000001\n" +
+		"\tPos: 7502\n" +
+		"\tGTID:6ce40be3-e359-11e9-87e0-36933cb0ca5a:1-29\n\n"
+	require.Equal(t, expected, m.buffer.String())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// MySQL 8.4 no longer supports SHOW MASTER STATUS, but requires SHOW BINARY LOG STATUS
+// Also in column names master is replaced with source
+func TestMysqlMetaData_84(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	conn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+
+	mockerr := errors.New("mock error")
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").WillReturnRows(
+		sqlmock.NewRows([]string{"File", "Position", "Binlog_Do_DB", "Binlog_Ignore_DB", "Executed_Gtid_Set"}).
+			AddRow(logFile, pos, "", "", gtidSet),
+	)
+
+	mock.ExpectQuery("SELECT @@default_master_connection").WillReturnError(mockerr)
+
+	mock.ExpectQuery("SHOW REPLICA STATUS").WillReturnRows(
+		sqlmock.NewRows([]string{"Exec_Source_Log_Pos", "Relay_Source_Log_File", "Source_Host", "Executed_Gtid_Set"}))
+
+	m := newGlobalMetadata(tcontext.Background(), createStorage(t), "")
+	si := version.ParseServerInfo("8.4.8")
+	require.Equal(t, version.ServerTypeMySQL, si.ServerType)
+	require.NoError(t, m.recordGlobalMetaData(conn, si, false))
 
 	expected := "SHOW MASTER STATUS:\n" +
 		"\tLog: ON.000001\n" +
@@ -73,8 +111,10 @@ func TestMetaDataAfterConn(t *testing.T) {
 	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnRows(rows2)
 
 	m := newGlobalMetadata(tcontext.Background(), createStorage(t), "")
-	require.NoError(t, m.recordGlobalMetaData(conn, version.ServerInfo{ServerType: version.ServerTypeMySQL}, false))
-	require.NoError(t, m.recordGlobalMetaData(conn, version.ServerInfo{ServerType: version.ServerTypeMySQL}, true))
+	si := version.ParseServerInfo("8.0.45")
+	require.Equal(t, version.ServerTypeMySQL, si.ServerType)
+	require.NoError(t, m.recordGlobalMetaData(conn, si, false))
+	require.NoError(t, m.recordGlobalMetaData(conn, si, true))
 
 	m.buffer.Write(m.afterConnBuffer.Bytes())
 
@@ -90,7 +130,7 @@ func TestMetaDataAfterConn(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestMysqlWithFollowersMetaData(t *testing.T) {
+func TestMysqlWithFollowersMetaData_80(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -109,7 +149,45 @@ func TestMysqlWithFollowersMetaData(t *testing.T) {
 	mock.ExpectQuery("SHOW SLAVE STATUS").WillReturnRows(followerRows)
 
 	m := newGlobalMetadata(tcontext.Background(), createStorage(t), "")
-	require.NoError(t, m.recordGlobalMetaData(conn, version.ServerInfo{ServerType: version.ServerTypeMySQL}, false))
+	si := version.ParseServerInfo("8.0.45")
+	require.Equal(t, version.ServerTypeMySQL, si.ServerType)
+	require.NoError(t, m.recordGlobalMetaData(conn, si, false))
+
+	expected := "SHOW MASTER STATUS:\n" +
+		"\tLog: ON.000001\n" +
+		"\tPos: 7502\n" +
+		"\tGTID:6ce40be3-e359-11e9-87e0-36933cb0ca5a:1-29\n\n" +
+		"SHOW SLAVE STATUS:\n" +
+		"\tHost: 192.168.1.100\n" +
+		"\tLog: mysql-bin.001821\n" +
+		"\tPos: 256529431\n" +
+		"\tGTID:6ce40be3-e359-11e9-87e0-36933cb0ca5a:1-29\n\n"
+	require.Equal(t, expected, m.buffer.String())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMysqlWithFollowersMetaData_84(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	conn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+
+	rows := sqlmock.NewRows([]string{"File", "Position", "Binlog_Do_DB", "Binlog_Ignore_DB", "Executed_Gtid_Set"}).
+		AddRow(logFile, pos, "", "", gtidSet)
+	followerRows := sqlmock.NewRows([]string{"Exec_Source_Log_Pos", "Relay_Source_Log_File", "Source_Host", "Executed_Gtid_Set"}).
+		AddRow("256529431", "mysql-bin.001821", "192.168.1.100", gtidSet)
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").WillReturnRows(rows)
+	mock.ExpectQuery("SELECT @@default_master_connection").WillReturnError(fmt.Errorf("mock error"))
+	mock.ExpectQuery("SHOW REPLICA STATUS").WillReturnRows(followerRows)
+
+	m := newGlobalMetadata(tcontext.Background(), createStorage(t), "")
+	si := version.ParseServerInfo("8.4.8")
+	require.Equal(t, version.ServerTypeMySQL, si.ServerType)
+	require.NoError(t, m.recordGlobalMetaData(conn, si, false))
 
 	expected := "SHOW MASTER STATUS:\n" +
 		"\tLog: ON.000001\n" +
@@ -141,7 +219,9 @@ func TestMysqlWithNullFollowersMetaData(t *testing.T) {
 	mock.ExpectQuery("SHOW SLAVE STATUS").WillReturnRows(sqlmock.NewRows([]string{"SQL_Remaining_Delay"}).AddRow(nil))
 
 	m := newGlobalMetadata(tcontext.Background(), createStorage(t), "")
-	require.NoError(t, m.recordGlobalMetaData(conn, version.ServerInfo{ServerType: version.ServerTypeMySQL}, false))
+	si := version.ParseServerInfo("8.0.45")
+	require.Equal(t, version.ServerTypeMySQL, si.ServerType)
+	require.NoError(t, m.recordGlobalMetaData(conn, si, false))
 
 	expected := "SHOW MASTER STATUS:\n" +
 		"\tLog: ON.000001\n" +
@@ -172,11 +252,14 @@ func TestMariaDBMetaData(t *testing.T) {
 	mock.ExpectQuery("SELECT @@global.gtid_binlog_pos").WillReturnRows(rows)
 	mock.ExpectQuery("SHOW SLAVE STATUS").WillReturnRows(rows)
 	m := newGlobalMetadata(tcontext.Background(), createStorage(t), "")
-	require.NoError(t, m.recordGlobalMetaData(conn, version.ServerInfo{ServerType: version.ServerTypeMariaDB}, false))
+	si := version.ParseServerInfo("10.11.15-MariaDB-ubu2204-log")
+	require.Equal(t, version.ServerTypeMariaDB, si.ServerType)
+	require.NoError(t, m.recordGlobalMetaData(conn, si, false))
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestMariaDBWithFollowersMetaData(t *testing.T) {
+// MariaDB 10.11 replica without GTID
+func TestMariaDBWithFollowersMetaData_File(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -186,11 +269,11 @@ func TestMariaDBWithFollowersMetaData(t *testing.T) {
 	conn, err := db.Conn(context.Background())
 	require.NoError(t, err)
 
-	rows := sqlmock.NewRows([]string{"File", "Position", "Binlog_Do_DB", "Binlog_Ignore_DB", "Executed_Gtid_Set"}).
-		AddRow(logFile, pos, "", "", gtidSet)
-	followerRows := sqlmock.NewRows([]string{"exec_master_log_pos", "relay_master_log_file", "master_host", "Executed_Gtid_Set", "connection_name", "Seconds_Behind_Master"}).
-		AddRow("256529431", "mysql-bin.001821", "192.168.1.100", gtidSet, "connection_1", 0).
-		AddRow("256529451", "mysql-bin.001820", "192.168.1.102", gtidSet, "connection_2", 200)
+	rows := sqlmock.NewRows([]string{"File", "Position", "Binlog_Do_DB", "Binlog_Ignore_DB"}).
+		AddRow(logFile, pos, "", "")
+	followerRows := sqlmock.NewRows([]string{"exec_master_log_pos", "relay_master_log_file", "master_host", "connection_name", "Seconds_Behind_Master"}).
+		AddRow("256529431", "mysql-bin.001821", "192.168.1.100", "connection_1", 0).
+		AddRow("256529451", "mysql-bin.001820", "192.168.1.102", "connection_2", 200)
 	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnRows(rows)
 	mock.ExpectQuery("SELECT @@default_master_connection").
 		WillReturnRows(sqlmock.NewRows([]string{"@@default_master_connection"}).
@@ -198,28 +281,82 @@ func TestMariaDBWithFollowersMetaData(t *testing.T) {
 	mock.ExpectQuery("SHOW ALL SLAVES STATUS").WillReturnRows(followerRows)
 
 	m := newGlobalMetadata(tcontext.Background(), createStorage(t), "")
-	require.NoError(t, m.recordGlobalMetaData(conn, version.ServerInfo{ServerType: version.ServerTypeMySQL}, false))
+	si := version.ParseServerInfo("10.11.15-MariaDB-ubu2204-log")
+	require.Equal(t, version.ServerTypeMariaDB, si.ServerType)
+	require.NoError(t, m.recordGlobalMetaData(conn, si, false))
 
 	expected := "SHOW MASTER STATUS:\n" +
 		"\tLog: ON.000001\n" +
 		"\tPos: 7502\n" +
-		"\tGTID:6ce40be3-e359-11e9-87e0-36933cb0ca5a:1-29\n\n" +
+		"\tGTID:\n\n" +
 		"SHOW SLAVE STATUS:\n" +
 		"\tConnection name: connection_1\n" +
 		"\tHost: 192.168.1.100\n" +
 		"\tLog: mysql-bin.001821\n" +
 		"\tPos: 256529431\n" +
-		"\tGTID:6ce40be3-e359-11e9-87e0-36933cb0ca5a:1-29\n\n" +
+		"\tGTID:\n\n" +
 		"SHOW SLAVE STATUS:\n" +
 		"\tConnection name: connection_2\n" +
 		"\tHost: 192.168.1.102\n" +
 		"\tLog: mysql-bin.001820\n" +
 		"\tPos: 256529451\n" +
-		"\tGTID:6ce40be3-e359-11e9-87e0-36933cb0ca5a:1-29\n\n"
+		"\tGTID:\n\n"
 	require.Equal(t, expected, m.buffer.String())
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// MariaDB 10.11 replica with GTID
+func TestMariaDBWithFollowersMetaData_GTID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	conn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+
+	rows := sqlmock.NewRows([]string{"File", "Position", "Binlog_Do_DB", "Binlog_Ignore_DB"}).
+		AddRow(logFile, pos, "", "")
+	followerRows := sqlmock.NewRows([]string{"exec_master_log_pos", "relay_master_log_file", "master_host", "connection_name", "Seconds_Behind_Master", "Using_Gtid", "Gtid_IO_Pos"}).
+		AddRow("256529431", "mysql-bin.001821", "192.168.1.100", "connection_1", 0, "Slave_Pos", "0-1-2").
+		AddRow("256529451", "mysql-bin.001820", "192.168.1.102", "connection_2", 200, "Slave_Pos", "0-1-2")
+	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnRows(rows)
+	mock.ExpectQuery("SELECT @@global.gtid_binlog_pos").WillReturnRows(
+		sqlmock.NewRows([]string{"@@global.gtid_binlog_pos"}).
+			AddRow("0-1-3"),
+	)
+	mock.ExpectQuery("SELECT @@default_master_connection").
+		WillReturnRows(sqlmock.NewRows([]string{"@@default_master_connection"}).
+			AddRow("connection_1"))
+	mock.ExpectQuery("SHOW ALL SLAVES STATUS").WillReturnRows(followerRows)
+
+	m := newGlobalMetadata(tcontext.Background(), createStorage(t), "")
+	si := version.ParseServerInfo("10.11.15-MariaDB-ubu2204-log")
+	require.Equal(t, version.ServerTypeMariaDB, si.ServerType)
+	require.NoError(t, m.recordGlobalMetaData(conn, si, false))
+
+	expected := "SHOW MASTER STATUS:\n" +
+		"\tLog: ON.000001\n" +
+		"\tPos: 7502\n" +
+		"\tGTID:0-1-3\n\n" +
+		"SHOW SLAVE STATUS:\n" +
+		"\tConnection name: connection_1\n" +
+		"\tHost: 192.168.1.100\n" +
+		"\tLog: mysql-bin.001821\n" +
+		"\tPos: 256529431\n" +
+		"\tGTID:0-1-2\n\n" +
+		"SHOW SLAVE STATUS:\n" +
+		"\tConnection name: connection_2\n" +
+		"\tHost: 192.168.1.102\n" +
+		"\tLog: mysql-bin.001820\n" +
+		"\tPos: 256529451\n" +
+		"\tGTID:0-1-2\n\n"
+	require.Equal(t, expected, m.buffer.String())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// MySQL 5.5 and earlier don't have `Executed_Gtid_Set` in the output of SHOW MASTER STATUS
 func TestEarlierMysqlMetaData(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -237,10 +374,12 @@ func TestEarlierMysqlMetaData(t *testing.T) {
 	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnRows(rows)
 	mock.ExpectQuery("SELECT @@default_master_connection").WillReturnError(fmt.Errorf("mock error"))
 	mock.ExpectQuery("SHOW SLAVE STATUS").WillReturnRows(
-		sqlmock.NewRows([]string{"exec_master_log_pos", "relay_master_log_file", "master_host", "Executed_Gtid_Set", "Seconds_Behind_Master"}))
+		sqlmock.NewRows([]string{"exec_master_log_pos", "relay_master_log_file", "master_host", "Seconds_Behind_Master"}))
 
 	m := newGlobalMetadata(tcontext.Background(), createStorage(t), "")
-	require.NoError(t, m.recordGlobalMetaData(conn, version.ServerInfo{ServerType: version.ServerTypeMySQL}, false))
+	si := version.ParseServerInfo("5.5.65")
+	require.Equal(t, version.ServerTypeMySQL, si.ServerType)
+	require.NoError(t, m.recordGlobalMetaData(conn, si, false))
 
 	expected := "SHOW MASTER STATUS:\n" +
 		"\tLog: mysql-bin.000001\n" +
@@ -267,7 +406,9 @@ func TestTiDBSnapshotMetaData(t *testing.T) {
 	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnRows(rows)
 
 	m := newGlobalMetadata(tcontext.Background(), createStorage(t), "")
-	require.NoError(t, m.recordGlobalMetaData(conn, version.ServerInfo{ServerType: version.ServerTypeTiDB}, false))
+	si := version.ParseServerInfo("8.0.11-TiDB-v8.5.5")
+	require.Equal(t, version.ServerTypeTiDB, si.ServerType)
+	require.NoError(t, m.recordGlobalMetaData(conn, si, false))
 
 	expected := "SHOW MASTER STATUS:\n" +
 		"\tLog: tidb-binlog\n" +
@@ -280,7 +421,7 @@ func TestTiDBSnapshotMetaData(t *testing.T) {
 		AddRow(logFile, pos, "", "")
 	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnRows(rows)
 	m = newGlobalMetadata(tcontext.Background(), createStorage(t), snapshot)
-	require.NoError(t, m.recordGlobalMetaData(conn, version.ServerInfo{ServerType: version.ServerTypeTiDB}, false))
+	require.NoError(t, m.recordGlobalMetaData(conn, si, false))
 
 	expected = "SHOW MASTER STATUS:\n" +
 		"\tLog: tidb-binlog\n" +
@@ -304,7 +445,9 @@ func TestNoPrivilege(t *testing.T) {
 
 	m := newGlobalMetadata(tcontext.Background(), createStorage(t), "")
 	// some consistencyType will ignore this error, this test make sure no extra message is written
-	require.Error(t, m.recordGlobalMetaData(conn, version.ServerInfo{ServerType: version.ServerTypeTiDB}, false))
+	si := version.ParseServerInfo("8.0.11-TiDB-v8.5.5")
+	require.Equal(t, version.ServerTypeTiDB, si.ServerType)
+	require.Error(t, m.recordGlobalMetaData(conn, si, false))
 	require.Equal(t, "", m.buffer.String())
 }
 

--- a/dumpling/export/sql_test.go
+++ b/dumpling/export/sql_test.go
@@ -153,7 +153,7 @@ func TestBuildSelectAllQuery(t *testing.T) {
 	// Test when config.SortByPk is disabled.
 	mockConf.SortByPk = false
 	for tp := version.ServerTypeUnknown; tp < version.ServerTypeAll; tp++ {
-		mockConf.ServerInfo.ServerType = version.ServerType(tp)
+		mockConf.ServerInfo.ServerType = tp
 		comment := fmt.Sprintf("current server type: %v", tp)
 
 		mock.ExpectQuery("SHOW COLUMNS FROM").

--- a/dumpling/export/util_test.go
+++ b/dumpling/export/util_test.go
@@ -20,7 +20,7 @@ func TestRepeatableRead(t *testing.T) {
 		{version.ServerTypeTiDB, ConsistencyTypeLock, true},
 	}
 	dec := func(d []any) (version.ServerType, string, bool) {
-		return version.ServerType(d[0].(int)), d[1].(string), d[2].(bool)
+		return d[0].(version.ServerType), d[1].(string), d[2].(bool)
 	}
 	for tag, datum := range data {
 		serverTp, consistency, expectRepeatableRead := dec(datum)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53082

Problem Summary:

### What changed and how does it work?

- Add a few fixes from #65131
- Extend and improve unit tests for MySQL and MariaDB
- Record GTID position on MariaDB ( `Gtid_IO_Pos`)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized metadata header to "SHOW MASTER STATUS:" and broadened replica column-name recognition for better compatibility across MySQL, MariaDB, and TiDB.

* **Tests**
  * Expanded and renamed version-specific tests covering MySQL 8.0/8.4, older MySQL, MariaDB 10.x (including follower scenarios), and TiDB variants.

* **Chores**
  * Minor internal declaration adjustment with no user-visible behavior change; updated CI test matrix to newer MySQL versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->