### PR TITLE
statistics: bump max dump duration to 1 hour

### DIFF
--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -78,7 +78,7 @@ func (s *statsUsageImpl) needDumpStatsDelta(is infoschema.InfoSchema, dumpAll bo
 	}
 	intest.Assert(!item.InitTime.IsZero(), "InitTime should be initialized before evaluating dump conditions")
 	if currentTime.Sub(item.InitTime) > dumpStatsMaxDuration {
-		// Dump the stats to kv at least once 5 minutes.
+		// Dump the stats to kv at least once per hour to make sure the stats can be updated when there are only few modifications.
 		return true
 	}
 	// use GetNonPseudoPhysicalTableStats to avoid creating pseudo tables and dropping instantly


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/65426

Problem Summary:

### What changed and how does it work?

Bump the maximum dump duration to 1 hour. We need to increase this value because if it is too small, it will cause excessive stats dumps, which may consume too many resources.
On the other hand, more stats dumps would also lead to increased stats loading.

The test result:
With the same workload: `sysbench oltp_read_write run --mysql-db=test --mysql-user=root --mysql-password="" --mysql-host=10.xxxxx --mysql-port=xxxx --db_prefix=sbtest --dbs=100000 --tables=2 --table_size=50000 --threads=64 --dml_percentage=0.2 --time=7200`

The more objects we need to dispose of, the longer the duration we have.

5m:
<img width="1936" height="532" alt="image" src="https://github.com/user-attachments/assets/1d922b2a-c5bf-4f8b-befc-a8b1ebdb2332" />
1h:
<img width="3672" height="1874" alt="image" src="https://github.com/user-attachments/assets/09f10deb-25af-484c-806b-4edaf52e866d" />


Although this variable never worked before this fix https://github.com/pingcap/tidb/pull/65586, we changed it in https://github.com/pingcap/tidb/pull/56538/changes, and it still doesn't work at all. Therefore, no one knows the best value here. I would prefer a larger value to avoid the risk.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the statistics collection dumping interval to reduce frequency of internal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->