### PR TITLE
planner: parallel apply keep order

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -2806,6 +2806,7 @@ func (b *executorBuilder) buildApply(v *physicalop.PhysicalApply) exec.Executor 
 			joiners:      joiners,
 			corCols:      corCols,
 			concurrency:  v.Concurrency,
+			keepOrder:    v.KeepOrder,
 			useCache:     v.CanUseCache,
 		}
 	}

--- a/pkg/executor/parallel_apply.go
+++ b/pkg/executor/parallel_apply.go
@@ -92,7 +92,23 @@ type ParallelNestedLoopApplyExec struct {
 
 	// ordered-mode channels (keepOrder == true)
 	orderedResultCh chan orderedResult
-	outerPaceCh     chan struct{} // bounds how far the outer worker dispatches ahead of the reorder worker
+	// outerPaceCh is a backpressure mechanism that prevents unbounded memory
+	// growth in ordered mode.
+	//
+	// Without it the outer worker can race arbitrarily far ahead of the
+	// reorder worker. If an early-sequence row is slow (e.g. seq=0), the
+	// outer worker keeps dispatching seq=1, 2, …, 10 000+. Inner workers
+	// complete those quickly and their results accumulate in the reorder
+	// worker's pending map, waiting for seq=0, causing O(outerRows) memory.
+	//
+	// Example with concurrency=2, outerPaceCh capacity=8:
+	//   1. Outer worker dispatches seq 0–7, filling outerPaceCh (8 tokens).
+	//   2. Outer worker blocks on seq=8 because the channel is full.
+	//   3. Inner workers finish seq 1–7, but reorder worker is stuck on seq=0.
+	//   4. seq=0 finally completes → reorder worker emits seq 0–7, releasing
+	//      8 tokens → outer worker can resume dispatching.
+	//   At most 8 results are buffered in the pending map, not 10 000+.
+	outerPaceCh chan struct{}
 
 	// fields about cache
 	cache              *applycache.ApplyCache
@@ -420,42 +436,44 @@ func (e *ParallelNestedLoopApplyExec) reorderWorker(ctx context.Context) {
 		return
 	}
 
-	flushOutput := func() bool {
-		if e.putResult(outputChk, nil) {
-			return true // exit signalled
+	flushOutput := func(output *chunk.Chunk) (*chunk.Chunk, bool) {
+		if e.putResult(output, nil) {
+			return nil, true // exit signalled
 		}
 		select {
-		case outputChk = <-e.freeChkCh:
+		case newOutput := <-e.freeChkCh:
 			// Reset is required because the consumer may reuse the
 			// same req chunk across Next() calls (e.g. writeChunks).
 			// After SwapColumns the recycled chunk can carry leftover
 			// column data; Reset clears it before we append new rows.
-			outputChk.Reset()
-			return false
+			newOutput.Reset()
+			return newOutput, false
 		case <-e.exit:
-			return true
+			return nil, true
 		}
 	}
 
 	// appendRow copies a row into the current output chunk, flushing when full.
-	appendRow := func(row chunk.Row) bool {
-		outputChk.AppendRow(row)
-		if outputChk.IsFull() {
-			return flushOutput()
+	appendRow := func(output *chunk.Chunk, row chunk.Row) (*chunk.Chunk, bool) {
+		output.AppendRow(row)
+		if output.IsFull() {
+			return flushOutput(output)
 		}
-		return false
+		return output, false
 	}
 
 	// emitResult appends all rows from an orderedResult to the output stream.
-	emitResult := func(r orderedResult) bool {
+	emitResult := func(output *chunk.Chunk, r orderedResult) (*chunk.Chunk, bool) {
 		for _, chk := range r.chks {
 			for i := range chk.NumRows() {
-				if appendRow(chk.GetRow(i)) {
-					return true
+				var exit bool
+				output, exit = appendRow(output, chk.GetRow(i))
+				if exit {
+					return nil, true
 				}
 			}
 		}
-		return false
+		return output, false
 	}
 
 	for {
@@ -486,7 +504,9 @@ func (e *ParallelNestedLoopApplyExec) reorderWorker(ctx context.Context) {
 				// Release a pace token so the outer worker can
 				// dispatch the next row, bounding the pending map.
 				<-e.outerPaceCh
-				if emitResult(pr) {
+				var exit bool
+				outputChk, exit = emitResult(outputChk, pr)
+				if exit {
 					return
 				}
 			}
@@ -497,7 +517,9 @@ func (e *ParallelNestedLoopApplyExec) reorderWorker(ctx context.Context) {
 			// termination: the Limit stops calling Next() and Close()
 			// propagates the exit signal to all workers.
 			if outputChk.NumRows() > 0 {
-				if flushOutput() {
+				var exit bool
+				outputChk, exit = flushOutput(outputChk)
+				if exit {
 					return
 				}
 			}

--- a/pkg/executor/parallel_apply.go
+++ b/pkg/executor/parallel_apply.go
@@ -19,6 +19,7 @@ import (
 	"runtime/trace"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/executor/internal/applycache"
@@ -356,6 +357,15 @@ func (e *ParallelNestedLoopApplyExec) innerWorkerOrdered(ctx context.Context, id
 		}
 
 		failpoint.Inject("parallelApplyInnerWorkerOrderedPanic", nil)
+		failpoint.Inject("parallelApplyOrderedSleep", func(val failpoint.Value) {
+			if ms, ok := val.(int); ok {
+				select {
+				case <-time.After(time.Duration(ms) * time.Millisecond):
+				case <-e.exit:
+					failpoint.Return()
+				}
+			}
+		})
 		chks, err := e.processOneOuterRow(ctx, id, or)
 		if err != nil {
 			select {

--- a/pkg/executor/parallel_apply.go
+++ b/pkg/executor/parallel_apply.go
@@ -43,6 +43,15 @@ type result struct {
 type outerRow struct {
 	row      *chunk.Row
 	selected bool // if this row is selected by the outer side
+	seq      uint64
+}
+
+// orderedResult carries the join output for a single outer row, tagged with
+// a sequence number so the reorder worker can emit results in outer-row order.
+type orderedResult struct {
+	seq  uint64
+	chks []*chunk.Chunk // result rows for this outer row (may be empty)
+	err  error
 }
 
 // ParallelNestedLoopApplyExec is the executor for apply.
@@ -71,6 +80,7 @@ type ParallelNestedLoopApplyExec struct {
 
 	// fields about concurrency control
 	concurrency int
+	keepOrder   bool // when true, use reorder buffer to preserve outer-side ordering
 	started     uint32
 	drained     uint32 // drained == true indicates there is no more data
 	freeChkCh   chan *chunk.Chunk
@@ -79,6 +89,9 @@ type ParallelNestedLoopApplyExec struct {
 	exit        chan struct{}
 	workerWg    sync.WaitGroup
 	notifyWg    sync.WaitGroup
+
+	// ordered-mode channels (keepOrder == true)
+	orderedResultCh chan orderedResult
 
 	// fields about cache
 	cache              *applycache.ApplyCache
@@ -120,6 +133,13 @@ func (e *ParallelNestedLoopApplyExec) Open(ctx context.Context) error {
 	e.resultChkCh = make(chan result, e.concurrency+1) // innerWorkers + outerWorker
 	e.outerRowCh = make(chan outerRow)
 	e.exit = make(chan struct{})
+
+	if e.keepOrder {
+		// In ordered mode, freeChkCh is consumed by the reorder worker.
+		// Inner workers allocate their own temporary chunks.
+		e.orderedResultCh = make(chan orderedResult, e.concurrency*2)
+	}
+
 	for range e.concurrency {
 		e.freeChkCh <- exec.NewFirstChunk(e)
 	}
@@ -143,13 +163,28 @@ func (e *ParallelNestedLoopApplyExec) Next(ctx context.Context, req *chunk.Chunk
 	if atomic.CompareAndSwapUint32(&e.started, 0, 1) {
 		e.workerWg.Add(1)
 		go e.outerWorker(ctx)
-		for i := range e.concurrency {
-			e.workerWg.Add(1)
-			workID := i
-			go e.innerWorker(ctx, workID)
+		if e.keepOrder {
+			for i := range e.concurrency {
+				e.workerWg.Add(1)
+				go e.innerWorkerOrdered(ctx, i)
+			}
+			// Bridge goroutine: when all outer+inner workers finish,
+			// close orderedResultCh so the reorder worker can drain and exit.
+			go func() {
+				e.workerWg.Wait()
+				close(e.orderedResultCh)
+			}()
+			e.notifyWg.Add(1)
+			go e.reorderWorker(ctx)
+		} else {
+			for i := range e.concurrency {
+				e.workerWg.Add(1)
+				workID := i
+				go e.innerWorker(ctx, workID)
+			}
+			e.notifyWg.Add(1)
+			go e.notifyWorker(ctx)
 		}
-		e.notifyWg.Add(1)
-		go e.notifyWorker(ctx)
 	}
 	result := <-e.resultChkCh
 	if result.err != nil {
@@ -196,6 +231,7 @@ func (e *ParallelNestedLoopApplyExec) Close() error {
 
 // notifyWorker waits for all inner/outer-workers finishing and then put an empty
 // chunk into the resultCh to notify the upper executor there is no more data.
+// Used only in unordered mode.
 func (e *ParallelNestedLoopApplyExec) notifyWorker(ctx context.Context) {
 	defer e.handleWorkerPanic(ctx, &e.notifyWg)
 	e.workerWg.Wait()
@@ -207,6 +243,7 @@ func (e *ParallelNestedLoopApplyExec) outerWorker(ctx context.Context) {
 	defer e.handleWorkerPanic(ctx, &e.workerWg)
 	var selected []bool
 	var err error
+	var seq uint64
 	for {
 		failpoint.Inject("parallelApplyOuterWorkerPanic", nil)
 		chk := exec.TryNewCacheChunk(e.outerExec)
@@ -227,8 +264,10 @@ func (e *ParallelNestedLoopApplyExec) outerWorker(ctx context.Context) {
 		}
 		for i := range chk.NumRows() {
 			row := chk.GetRow(i)
+			or := outerRow{row: &row, selected: selected[i], seq: seq}
+			seq++
 			select {
-			case e.outerRowCh <- outerRow{&row, selected[i]}:
+			case e.outerRowCh <- or:
 			case <-e.exit:
 				return
 			}
@@ -236,6 +275,8 @@ func (e *ParallelNestedLoopApplyExec) outerWorker(ctx context.Context) {
 	}
 }
 
+// innerWorker is used in unordered mode. Workers compete for outer rows from
+// a shared channel and emit result chunks in arbitrary order.
 func (e *ParallelNestedLoopApplyExec) innerWorker(ctx context.Context, id int) {
 	defer trace.StartRegion(ctx, "ParallelApplyInnerWorker").End()
 	defer e.handleWorkerPanic(ctx, &e.workerWg)
@@ -252,6 +293,187 @@ func (e *ParallelNestedLoopApplyExec) innerWorker(ctx context.Context, id int) {
 			return
 		}
 		if e.putResult(chk, err) {
+			return
+		}
+	}
+}
+
+// innerWorkerOrdered is used in keepOrder mode. Each worker processes one
+// outer row at a time and tags the result with the row's sequence number.
+// Results are sent to orderedResultCh for the reorder worker to sort.
+func (e *ParallelNestedLoopApplyExec) innerWorkerOrdered(ctx context.Context, id int) {
+	defer trace.StartRegion(ctx, "ParallelApplyInnerWorkerOrdered").End()
+	defer e.handleWorkerPanic(ctx, &e.workerWg)
+
+	for {
+		var or outerRow
+		var ok bool
+		select {
+		case or, ok = <-e.outerRowCh:
+			if !ok {
+				return // outer channel closed – no more work
+			}
+		case <-e.exit:
+			return
+		}
+
+		chks, err := e.processOneOuterRow(ctx, id, or)
+		if err != nil {
+			select {
+			case e.orderedResultCh <- orderedResult{seq: or.seq, err: err}:
+			case <-e.exit:
+			}
+			return
+		}
+		select {
+		case e.orderedResultCh <- orderedResult{seq: or.seq, chks: chks}:
+		case <-e.exit:
+			return
+		}
+	}
+}
+
+// processOneOuterRow executes the inner side for a single outer row and
+// returns the joined result chunks. For semi-joins this is typically 0–1 rows.
+func (e *ParallelNestedLoopApplyExec) processOneOuterRow(ctx context.Context, id int, or outerRow) ([]*chunk.Chunk, error) {
+	chk := exec.NewFirstChunk(e)
+
+	if !or.selected {
+		if e.outer {
+			e.joiners[id].OnMissMatch(false, *or.row, chk)
+		}
+		return []*chunk.Chunk{chk}, nil
+	}
+
+	e.outerRow[id] = or.row
+	e.hasMatch[id] = false
+	e.hasNull[id] = false
+
+	if err := e.fetchAllInners(ctx, id); err != nil {
+		return nil, err
+	}
+
+	e.innerIter[id] = chunk.NewIterator4List(e.innerList[id])
+	e.innerIter[id].Begin()
+
+	var chks []*chunk.Chunk
+	for e.innerIter[id].Current() != e.innerIter[id].End() {
+		matched, isNull, err := e.joiners[id].TryToMatchInners(*e.outerRow[id], e.innerIter[id], chk)
+		e.hasMatch[id] = e.hasMatch[id] || matched
+		e.hasNull[id] = e.hasNull[id] || isNull
+		if err != nil {
+			return nil, err
+		}
+		if chk.IsFull() {
+			chks = append(chks, chk)
+			chk = exec.NewFirstChunk(e)
+		}
+	}
+
+	if !e.hasMatch[id] {
+		e.joiners[id].OnMissMatch(e.hasNull[id], *or.row, chk)
+	}
+	chks = append(chks, chk)
+	return chks, nil
+}
+
+// reorderWorker collects orderedResults from inner workers and emits them to
+// resultChkCh in monotonically increasing sequence order, batching small
+// per-row results into full output chunks. Used only in keepOrder mode.
+func (e *ParallelNestedLoopApplyExec) reorderWorker(ctx context.Context) {
+	defer e.handleWorkerPanic(ctx, &e.notifyWg)
+
+	pending := make(map[uint64]orderedResult)
+	nextSeq := uint64(0)
+
+	// Get the first output chunk from the free pool.
+	var outputChk *chunk.Chunk
+	select {
+	case outputChk = <-e.freeChkCh:
+	case <-e.exit:
+		return
+	}
+
+	flushOutput := func() bool {
+		if e.putResult(outputChk, nil) {
+			return true // exit signalled
+		}
+		select {
+		case outputChk = <-e.freeChkCh:
+			// Reset is required because the consumer may reuse the
+			// same req chunk across Next() calls (e.g. writeChunks).
+			// After SwapColumns the recycled chunk can carry leftover
+			// column data; Reset clears it before we append new rows.
+			outputChk.Reset()
+			return false
+		case <-e.exit:
+			return true
+		}
+	}
+
+	// appendRow copies a row into the current output chunk, flushing when full.
+	appendRow := func(row chunk.Row) bool {
+		outputChk.AppendRow(row)
+		if outputChk.IsFull() {
+			return flushOutput()
+		}
+		return false
+	}
+
+	// emitResult appends all rows from an orderedResult to the output stream.
+	emitResult := func(r orderedResult) bool {
+		for _, chk := range r.chks {
+			for i := range chk.NumRows() {
+				if appendRow(chk.GetRow(i)) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	for {
+		select {
+		case r, ok := <-e.orderedResultCh:
+			if !ok {
+				// Channel closed – all workers done. Flush remaining rows.
+				if outputChk.NumRows() > 0 {
+					e.putResult(outputChk, nil)
+				}
+				e.putResult(nil, nil) // signal EOF
+				return
+			}
+			if r.err != nil {
+				e.putResult(nil, r.err)
+				return
+			}
+			pending[r.seq] = r
+
+			// Drain as many in-order results as possible.
+			for {
+				pr, exists := pending[nextSeq]
+				if !exists {
+					break
+				}
+				delete(pending, nextSeq)
+				nextSeq++
+				if emitResult(pr) {
+					return
+				}
+			}
+
+			// Flush partial output so the consumer (e.g. Limit) can
+			// receive rows as soon as they are ready in order, rather
+			// than waiting for a full chunk.  This allows early
+			// termination: the Limit stops calling Next() and Close()
+			// propagates the exit signal to all workers.
+			if outputChk.NumRows() > 0 {
+				if flushOutput() {
+					return
+				}
+			}
+
+		case <-e.exit:
 			return
 		}
 	}

--- a/pkg/executor/parallel_apply.go
+++ b/pkg/executor/parallel_apply.go
@@ -194,15 +194,15 @@ func (e *ParallelNestedLoopApplyExec) Next(ctx context.Context, req *chunk.Chunk
 			}
 			// Bridge goroutine: when all outer+inner workers finish,
 			// close orderedResultCh so the reorder worker can drain and exit.
-			// It is tracked by notifyWg so that Close() waits for all
-			// outer/inner workers to finish even if reorderWorker exits
-			// early (e.g. on e.exit signal).
 			e.notifyWg.Add(1)
 			go func() {
 				defer e.handleWorkerPanic(ctx, &e.notifyWg)
 				e.workerWg.Wait()
 				close(e.orderedResultCh)
 			}()
+			// The reorder worker is tracked by notifyWg so that
+			// Close() waits for it to fully exit before returning.
+			e.notifyWg.Add(1)
 			go e.reorderWorker(ctx)
 		} else {
 			for i := range e.concurrency {
@@ -355,6 +355,7 @@ func (e *ParallelNestedLoopApplyExec) innerWorkerOrdered(ctx context.Context, id
 			return
 		}
 
+		failpoint.Inject("parallelApplyInnerWorkerOrderedPanic", nil)
 		chks, err := e.processOneOuterRow(ctx, id, or)
 		if err != nil {
 			select {
@@ -376,7 +377,9 @@ func (e *ParallelNestedLoopApplyExec) innerWorkerOrdered(ctx context.Context, id
 func (e *ParallelNestedLoopApplyExec) processOneOuterRow(ctx context.Context, id int, or outerRow) ([]*chunk.Chunk, error) {
 	if !or.selected {
 		if e.outer {
-			chk := exec.NewFirstChunk(e)
+			// OnMissMatch appends at most one row; use capacity 1
+			// instead of the full chunk size to reduce allocation.
+			chk := chunk.New(exec.RetTypes(e), 1, 1)
 			e.joiners[id].OnMissMatch(false, *or.row, chk)
 			return []*chunk.Chunk{chk}, nil
 		}
@@ -413,7 +416,9 @@ func (e *ParallelNestedLoopApplyExec) processOneOuterRow(ctx context.Context, id
 	if !e.hasMatch[id] {
 		e.joiners[id].OnMissMatch(e.hasNull[id], *or.row, chk)
 	}
-	chks = append(chks, chk)
+	if chk.NumRows() > 0 {
+		chks = append(chks, chk)
+	}
 	return chks, nil
 }
 
@@ -421,9 +426,7 @@ func (e *ParallelNestedLoopApplyExec) processOneOuterRow(ctx context.Context, id
 // resultChkCh in monotonically increasing sequence order, batching small
 // per-row results into full output chunks. Used only in keepOrder mode.
 func (e *ParallelNestedLoopApplyExec) reorderWorker(ctx context.Context) {
-	// Panic recovery only; lifecycle is not tracked by notifyWg because
-	// the bridge goroutine (which waits on workerWg) owns that role.
-	defer e.handleWorkerPanic(ctx, nil)
+	defer e.handleWorkerPanic(ctx, &e.notifyWg)
 
 	pending := make(map[uint64]orderedResult)
 	nextSeq := uint64(0)
@@ -493,35 +496,54 @@ func (e *ParallelNestedLoopApplyExec) reorderWorker(ctx context.Context) {
 			}
 			pending[r.seq] = r
 
-			// Drain as many in-order results as possible.
+			// Drain in-order results and opportunistically batch more
+			// arrivals before flushing, so non-LIMIT queries get full
+			// chunks while LIMIT queries still receive rows promptly
+			// when the pipeline is idle.
 			for {
-				pr, exists := pending[nextSeq]
-				if !exists {
-					break
+				// Drain as many consecutive results as possible.
+				for {
+					pr, exists := pending[nextSeq]
+					if !exists {
+						break
+					}
+					delete(pending, nextSeq)
+					nextSeq++
+					<-e.outerPaceCh
+					var exit bool
+					outputChk, exit = emitResult(outputChk, pr)
+					if exit {
+						return
+					}
 				}
-				delete(pending, nextSeq)
-				nextSeq++
-				// Release a pace token so the outer worker can
-				// dispatch the next row, bounding the pending map.
-				<-e.outerPaceCh
-				var exit bool
-				outputChk, exit = emitResult(outputChk, pr)
-				if exit {
-					return
-				}
-			}
 
-			// Flush partial output so the consumer (e.g. Limit) can
-			// receive rows as soon as they are ready in order, rather
-			// than waiting for a full chunk.  This allows early
-			// termination: the Limit stops calling Next() and Close()
-			// propagates the exit signal to all workers.
-			if outputChk.NumRows() > 0 {
+				if outputChk.NumRows() == 0 {
+					break // nothing to flush
+				}
+				// Check if more results are immediately available;
+				// if so, buffer them and re-drain before flushing.
+				select {
+				case next, ok2 := <-e.orderedResultCh:
+					if !ok2 {
+						e.putResult(outputChk, nil)
+						e.putResult(nil, nil)
+						return
+					}
+					if next.err != nil {
+						e.putResult(nil, next.err)
+						return
+					}
+					pending[next.seq] = next
+					continue // re-drain with the new result
+				default:
+					// No more results ready — flush now.
+				}
 				var exit bool
 				outputChk, exit = flushOutput(outputChk)
 				if exit {
 					return
 				}
+				break
 			}
 
 		case <-e.exit:

--- a/pkg/executor/parallel_apply.go
+++ b/pkg/executor/parallel_apply.go
@@ -178,11 +178,15 @@ func (e *ParallelNestedLoopApplyExec) Next(ctx context.Context, req *chunk.Chunk
 			}
 			// Bridge goroutine: when all outer+inner workers finish,
 			// close orderedResultCh so the reorder worker can drain and exit.
+			// It is tracked by notifyWg so that Close() waits for all
+			// outer/inner workers to finish even if reorderWorker exits
+			// early (e.g. on e.exit signal).
+			e.notifyWg.Add(1)
 			go func() {
+				defer e.handleWorkerPanic(ctx, &e.notifyWg)
 				e.workerWg.Wait()
 				close(e.orderedResultCh)
 			}()
-			e.notifyWg.Add(1)
 			go e.reorderWorker(ctx)
 		} else {
 			for i := range e.concurrency {
@@ -401,7 +405,9 @@ func (e *ParallelNestedLoopApplyExec) processOneOuterRow(ctx context.Context, id
 // resultChkCh in monotonically increasing sequence order, batching small
 // per-row results into full output chunks. Used only in keepOrder mode.
 func (e *ParallelNestedLoopApplyExec) reorderWorker(ctx context.Context) {
-	defer e.handleWorkerPanic(ctx, &e.notifyWg)
+	// Panic recovery only; lifecycle is not tracked by notifyWg because
+	// the bridge goroutine (which waits on workerWg) owns that role.
+	defer e.handleWorkerPanic(ctx, nil)
 
 	pending := make(map[uint64]orderedResult)
 	nextSeq := uint64(0)

--- a/pkg/executor/parallel_apply.go
+++ b/pkg/executor/parallel_apply.go
@@ -92,6 +92,7 @@ type ParallelNestedLoopApplyExec struct {
 
 	// ordered-mode channels (keepOrder == true)
 	orderedResultCh chan orderedResult
+	outerPaceCh     chan struct{} // bounds how far the outer worker dispatches ahead of the reorder worker
 
 	// fields about cache
 	cache              *applycache.ApplyCache
@@ -138,6 +139,13 @@ func (e *ParallelNestedLoopApplyExec) Open(ctx context.Context) error {
 		// In ordered mode, freeChkCh is consumed by the reorder worker.
 		// Inner workers allocate their own temporary chunks.
 		e.orderedResultCh = make(chan orderedResult, e.concurrency*2)
+		// outerPaceCh bounds the gap between the outer worker's dispatch
+		// sequence and the reorder worker's consumption sequence.  Without
+		// this, a slow early-sequence row lets fast workers race ahead,
+		// growing the pending map to O(outerRows).  The outer worker
+		// acquires a token before dispatching; the reorder worker releases
+		// one each time it advances nextSeq.
+		e.outerPaceCh = make(chan struct{}, e.concurrency*4)
 	}
 
 	for range e.concurrency {
@@ -263,6 +271,16 @@ func (e *ParallelNestedLoopApplyExec) outerWorker(ctx context.Context) {
 			return
 		}
 		for i := range chk.NumRows() {
+			// In ordered mode, acquire a pace token to bound how far
+			// ahead we dispatch relative to the reorder worker's
+			// consumption.  This caps the pending map at O(concurrency).
+			if e.keepOrder {
+				select {
+				case e.outerPaceCh <- struct{}{}:
+				case <-e.exit:
+					return
+				}
+			}
 			row := chk.GetRow(i)
 			or := outerRow{row: &row, selected: selected[i], seq: seq}
 			seq++
@@ -336,14 +354,16 @@ func (e *ParallelNestedLoopApplyExec) innerWorkerOrdered(ctx context.Context, id
 // processOneOuterRow executes the inner side for a single outer row and
 // returns the joined result chunks. For semi-joins this is typically 0–1 rows.
 func (e *ParallelNestedLoopApplyExec) processOneOuterRow(ctx context.Context, id int, or outerRow) ([]*chunk.Chunk, error) {
-	chk := exec.NewFirstChunk(e)
-
 	if !or.selected {
 		if e.outer {
+			chk := exec.NewFirstChunk(e)
 			e.joiners[id].OnMissMatch(false, *or.row, chk)
+			return []*chunk.Chunk{chk}, nil
 		}
-		return []*chunk.Chunk{chk}, nil
+		return nil, nil // no allocation needed for filtered-out rows
 	}
+
+	chk := exec.NewFirstChunk(e)
 
 	e.outerRow[id] = or.row
 	e.hasMatch[id] = false
@@ -457,6 +477,9 @@ func (e *ParallelNestedLoopApplyExec) reorderWorker(ctx context.Context) {
 				}
 				delete(pending, nextSeq)
 				nextSeq++
+				// Release a pace token so the outer worker can
+				// dispatch the next row, bounding the pending map.
+				<-e.outerPaceCh
 				if emitResult(pr) {
 					return
 				}

--- a/pkg/executor/parallel_apply.go
+++ b/pkg/executor/parallel_apply.go
@@ -42,7 +42,7 @@ type result struct {
 }
 
 type outerRow struct {
-	row      *chunk.Row
+	row      chunk.Row
 	selected bool // if this row is selected by the outer side
 	seq      uint64
 }
@@ -303,7 +303,7 @@ func (e *ParallelNestedLoopApplyExec) outerWorker(ctx context.Context) {
 				}
 			}
 			row := chk.GetRow(i)
-			or := outerRow{row: &row, selected: selected[i], seq: seq}
+			or := outerRow{row: row, selected: selected[i], seq: seq}
 			seq++
 			select {
 			case e.outerRowCh <- or:
@@ -390,7 +390,7 @@ func (e *ParallelNestedLoopApplyExec) processOneOuterRow(ctx context.Context, id
 			// OnMissMatch appends at most one row; use capacity 1
 			// instead of the full chunk size to reduce allocation.
 			chk := chunk.New(exec.RetTypes(e), 1, 1)
-			e.joiners[id].OnMissMatch(false, *or.row, chk)
+			e.joiners[id].OnMissMatch(false, or.row, chk)
 			return []*chunk.Chunk{chk}, nil
 		}
 		return nil, nil // no allocation needed for filtered-out rows
@@ -398,7 +398,7 @@ func (e *ParallelNestedLoopApplyExec) processOneOuterRow(ctx context.Context, id
 
 	chk := exec.NewFirstChunk(e)
 
-	e.outerRow[id] = or.row
+	e.outerRow[id] = &or.row
 	e.hasMatch[id] = false
 	e.hasNull[id] = false
 
@@ -424,7 +424,7 @@ func (e *ParallelNestedLoopApplyExec) processOneOuterRow(ctx context.Context, id
 	}
 
 	if !e.hasMatch[id] {
-		e.joiners[id].OnMissMatch(e.hasNull[id], *or.row, chk)
+		e.joiners[id].OnMissMatch(e.hasNull[id], or.row, chk)
 	}
 	if chk.NumRows() > 0 {
 		chks = append(chks, chk)
@@ -661,14 +661,14 @@ func (e *ParallelNestedLoopApplyExec) fetchNextOuterRow(id int, req *chunk.Chunk
 			}
 			if !outerRow.selected {
 				if e.outer {
-					e.joiners[id].OnMissMatch(false, *outerRow.row, req)
+					e.joiners[id].OnMissMatch(false, outerRow.row, req)
 					if req.IsFull() {
 						return nil, false
 					}
 				}
 				continue // try the next outer row
 			}
-			return outerRow.row, false
+			return &outerRow.row, false
 		case <-e.exit:
 			return nil, true
 		}

--- a/pkg/executor/parallel_apply_test.go
+++ b/pkg/executor/parallel_apply_test.go
@@ -65,9 +65,12 @@ func TestParallelApplyPlan(t *testing.T) {
 	q3 := "select t1.b from t t1 where t1.b > (select max(b) from t t2 where t1.a > t2.a) order by t1.a"
 	checkApplyPlan(t, tk, q3, 0)
 	tk.MustExec("alter table t add index idx(a)")
+	// With ordered parallel apply, ordering is now preserved via a reorder
+	// buffer so we no longer reject the plan.  The Apply should show the
+	// configured concurrency.
 	checkApplyPlan(t, tk, q3, 1)
-	tk.MustQuery(q3).Sort().Check(testkit.Rows("1", "2", "3", "4", "5", "6", "7", "8", "9"))
-	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 Parallel Apply rejects the possible order properties of its outer child currently"))
+	tk.MustQuery(q3).Check(testkit.Rows("1", "2", "3", "4", "5", "6", "7", "8", "9"))
+	tk.MustQuery("show warnings").Check(testkit.Rows())
 }
 
 func TestApplyColumnType(t *testing.T) {
@@ -504,4 +507,98 @@ func TestParallelApplyCorrectness(t *testing.T) {
 
 	tk.MustExec("set tidb_enable_parallel_apply=false")
 	tk.MustQuery(sql).Sort().Check(testkit.Rows("1", "3"))
+}
+
+func TestOrderedParallelApply(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1 (a int, b int, index idx_a(a))")
+	tk.MustExec("create table t2 (a int, b int)")
+	tk.MustExec("insert into t1 values (1,10),(2,20),(3,30),(4,40),(5,50),(6,60),(7,70),(8,80),(9,90),(10,100)")
+	tk.MustExec("insert into t2 values (1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8),(9,9),(10,10)")
+
+	// ----------------------------------------------------------------
+	// 1. ORDER BY with scalar correlated subquery – verify row order
+	//    is preserved (not just sorted after the fact).
+	// ----------------------------------------------------------------
+	q1 := "select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a"
+	// Serial: get baseline
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	serialResult := tk.MustQuery(q1)
+	serialRows := serialResult.Rows()
+
+	// Parallel ordered: should produce identical order.
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustExec("set tidb_executor_concurrency=5")
+	checkApplyPlan(t, tk, q1, 5)
+	tk.MustQuery(q1).Check(testkit.RowsWithSep(" ", flattenRows(serialRows)...))
+
+	// ----------------------------------------------------------------
+	// 2. ORDER BY + LIMIT – should use Limit (not TopN) because the
+	//    ordered parallel apply preserves outer order.
+	// ----------------------------------------------------------------
+	q2 := "select t1.a, t1.b from t1 where t1.b > (select min(t2.b) from t2 where t2.a >= t1.a) order by t1.a limit 5"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	serialResult2 := tk.MustQuery(q2)
+	serialRows2 := serialResult2.Rows()
+
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	checkApplyPlan(t, tk, q2, 5)
+	tk.MustQuery(q2).Check(testkit.RowsWithSep(" ", flattenRows(serialRows2)...))
+
+	// ----------------------------------------------------------------
+	// 3. EXISTS semi-join with ORDER BY – common pattern from the
+	//    correlate branch.
+	// ----------------------------------------------------------------
+	q3 := "select t1.a from t1 where exists (select 1 from t2 where t2.a = t1.a and t2.b > 3) order by t1.a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	serialResult3 := tk.MustQuery(q3)
+	serialRows3 := serialResult3.Rows()
+
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustQuery(q3).Check(testkit.RowsWithSep(" ", flattenRows(serialRows3)...))
+
+	// ----------------------------------------------------------------
+	// 4. Varying concurrency levels – results must be identical.
+	// ----------------------------------------------------------------
+	q4 := "select t1.a, (select count(*) from t2 where t2.a > t1.a) from t1 order by t1.a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected := tk.MustQuery(q4).Rows()
+
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	for _, cc := range []int{2, 3, 5, 7, 10} {
+		tk.MustExec(fmt.Sprintf("set tidb_executor_concurrency=%d", cc))
+		tk.MustQuery(q4).Check(testkit.RowsWithSep(" ", flattenRows(expected)...))
+	}
+
+	// ----------------------------------------------------------------
+	// 5. Ordered parallel apply with OFFSET.
+	// ----------------------------------------------------------------
+	q5 := "select t1.a, t1.b from t1 where t1.b > (select min(t2.b) from t2 where t2.a >= t1.a) order by t1.a limit 3 offset 2"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	serialResult5 := tk.MustQuery(q5)
+	serialRows5 := serialResult5.Rows()
+
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustExec("set tidb_executor_concurrency=5")
+	tk.MustQuery(q5).Check(testkit.RowsWithSep(" ", flattenRows(serialRows5)...))
+}
+
+// flattenRows converts [][]interface{} from MustQuery().Rows() into
+// []string suitable for testkit.RowsWithSep(" ", ...).
+func flattenRows(rows [][]any) []string {
+	result := make([]string, 0, len(rows))
+	for _, row := range rows {
+		s := ""
+		for i, col := range row {
+			if i > 0 {
+				s += " "
+			}
+			s += fmt.Sprintf("%v", col)
+		}
+		result = append(result, s)
+	}
+	return result
 }

--- a/pkg/executor/parallel_apply_test.go
+++ b/pkg/executor/parallel_apply_test.go
@@ -546,6 +546,33 @@ func TestOrderedParallelApply(t *testing.T) {
 
 	tk.MustExec("set tidb_enable_parallel_apply=true")
 	checkApplyPlan(t, tk, q2, 5)
+	// The planner should use a streamable Limit (not TopN) because the
+	// ordered parallel apply preserves the outer scan order.
+	// Verify the outer plan uses a streamable Limit (not TopN).
+	// TopN may legitimately appear inside the inner (Probe) side
+	// (e.g. for min/max optimization), so only check operators at
+	// or above the Apply level.
+	planRows := tk.MustQuery("explain " + q2).Rows()
+	hasLimit := false
+	hasOuterTopN := false
+	seenApply := false
+	for _, row := range planRows {
+		line := fmt.Sprintf("%v", row)
+		if strings.Contains(line, "Apply") {
+			seenApply = true
+		}
+		if !seenApply {
+			// Operators above Apply — check for Limit vs TopN.
+			if strings.Contains(line, "Limit") {
+				hasLimit = true
+			}
+			if strings.Contains(line, "TopN") {
+				hasOuterTopN = true
+			}
+		}
+	}
+	require.True(t, hasLimit, "plan should contain Limit above Apply for ORDER BY + LIMIT with ordered apply")
+	require.False(t, hasOuterTopN, "plan should not contain TopN above Apply when ordered apply preserves order")
 	tk.MustQuery(q2).Check(testkit.RowsWithSep(" ", flattenRows(serialRows2)...))
 
 	// ----------------------------------------------------------------
@@ -785,6 +812,28 @@ func TestOrderedParallelApplyLeftOuterSemiJoin(t *testing.T) {
 	expected3 := tk.MustQuery(q3).Rows()
 	tk.MustExec("set tidb_enable_parallel_apply=true")
 	tk.MustQuery(q3).Check(testkit.RowsWithSep(" ", flattenRows(expected3)...))
+
+	// ----------------------------------------------------------------
+	// Left outer semi-join with outer-side WHERE conditions.
+	// Note: the planner pushes outer-side filters below the Apply
+	// into the outer child (e.g. IndexRangeScan), so the outerFilter
+	// field on the Apply is empty and selected=true for all rows
+	// reaching processOneOuterRow.  These tests verify correctness
+	// of the left outer semi join with reduced outer row sets and
+	// nullable columns.
+	// ----------------------------------------------------------------
+	tk.MustExec("insert into t1 values (null, null), (6, null)")
+	q4 := "select a, a in (select /*+ NO_DECORRELATE() */ a from t2 where t2.a = t1.a) from t1 where t1.b is not null order by a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected4 := tk.MustQuery(q4).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustQuery(q4).Check(testkit.RowsWithSep(" ", flattenRows(expected4)...))
+
+	q5 := "select a, a in (select /*+ NO_DECORRELATE() */ a from t2 where t2.a = t1.a) from t1 where t1.a > 2 order by a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected5 := tk.MustQuery(q5).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustQuery(q5).Check(testkit.RowsWithSep(" ", flattenRows(expected5)...))
 }
 
 func TestOrderedParallelApplyGoroutinePanic(t *testing.T) {

--- a/pkg/executor/parallel_apply_test.go
+++ b/pkg/executor/parallel_apply_test.go
@@ -686,6 +686,137 @@ func TestOrderedParallelApplyEdgeCases(t *testing.T) {
 	tk.MustQuery(q7).Check(testkit.RowsWithSep(" ", flattenRows(expected7)...))
 }
 
+func TestOrderedParallelApplyLargeInner(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustExec("set tidb_executor_concurrency=4")
+
+	// ----------------------------------------------------------------
+	// Each outer row joins with many inner rows, forcing the chunk to
+	// fill to capacity in processOneOuterRow (chk.IsFull path) and
+	// the reorder worker's appendRow→flushOutput path.
+	// ----------------------------------------------------------------
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1 (a int, index idx_a(a))")
+	tk.MustExec("create table t2 (a int, b int)")
+	tk.MustExec("insert into t1 values (1),(2),(3)")
+	// Insert enough rows to exceed chunk capacity for each outer row.
+	vals := ""
+	for i := 1; i <= 2000; i++ {
+		if i > 1 {
+			vals += ","
+		}
+		vals += fmt.Sprintf("(%d, %d)", i%3+1, i)
+	}
+	tk.MustExec("insert into t2 values " + vals)
+
+	q := "select t1.a, (select /*+ NO_DECORRELATE() */ count(*) from t2 where t2.a = t1.a) from t1 order by t1.a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected := tk.MustQuery(q).Rows()
+
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	checkApplyPlan(t, tk, q, 4)
+	tk.MustQuery(q).Check(testkit.RowsWithSep(" ", flattenRows(expected)...))
+
+	// ----------------------------------------------------------------
+	// Cartesian-style: every outer row pairs with every inner row to
+	// produce a large result set (exercises multi-chunk flush in the
+	// reorder worker).
+	// ----------------------------------------------------------------
+	tk.MustExec("drop table if exists t3, t4")
+	tk.MustExec("create table t3 (a int, index idx_a(a))")
+	tk.MustExec("create table t4 (b int)")
+	tk.MustExec("insert into t3 values (1),(2),(3)")
+	vals = ""
+	for i := 1; i <= 500; i++ {
+		if i > 1 {
+			vals += ","
+		}
+		vals += fmt.Sprintf("(%d)", i)
+	}
+	tk.MustExec("insert into t4 values " + vals)
+
+	q2 := "select t3.a, (select /*+ NO_DECORRELATE() */ sum(t4.b) from t4 where t4.b <= t3.a * 100) from t3 order by t3.a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected2 := tk.MustQuery(q2).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustQuery(q2).Check(testkit.RowsWithSep(" ", flattenRows(expected2)...))
+}
+
+func TestOrderedParallelApplyLeftOuterSemiJoin(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustExec("set tidb_executor_concurrency=4")
+
+	// ----------------------------------------------------------------
+	// Left outer semi-join with outer filter: some outer rows are
+	// not selected, exercising the e.outer && !or.selected path in
+	// processOneOuterRow. Also exercises OnMissMatch in ordered mode.
+	// ----------------------------------------------------------------
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1 (a int, b int, index idx_a(a))")
+	tk.MustExec("create table t2 (a int, b int)")
+	tk.MustExec("insert into t1 values (1,10),(2,20),(3,30),(4,40),(5,50)")
+	tk.MustExec("insert into t2 values (2,2),(4,4)")
+
+	// IN subquery → left outer semi join; the NOT IN variant produces
+	// anti-semi join with OnMissMatch for non-matching rows.
+	q1 := "select a, a in (select /*+ NO_DECORRELATE() */ a from t2 where t2.a = t1.a) from t1 order by a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected1 := tk.MustQuery(q1).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustQuery(q1).Check(testkit.RowsWithSep(" ", flattenRows(expected1)...))
+
+	// NOT IN subquery — anti-semi-join path
+	q2 := "select a from t1 where a not in (select /*+ NO_DECORRELATE() */ a from t2 where t2.b < t1.b) order by a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected2 := tk.MustQuery(q2).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustQuery(q2).Check(testkit.RowsWithSep(" ", flattenRows(expected2)...))
+
+	// Left outer join with ORDER BY — the subquery returns a value for
+	// every outer row, exercising both matched and unmatched paths.
+	q3 := "select t1.a, (select t2.b from t2 where t2.a = t1.a) from t1 order by t1.a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected3 := tk.MustQuery(q3).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustQuery(q3).Check(testkit.RowsWithSep(" ", flattenRows(expected3)...))
+}
+
+func TestOrderedParallelApplyGoroutinePanic(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1 (a int, b int, index idx_a(a))")
+	tk.MustExec("create table t2 (a int, b int)")
+	tk.MustExec("insert into t1 values (1,1),(2,2),(3,3),(4,4),(5,5)")
+	tk.MustExec("insert into t2 values (1,10),(2,20),(3,30)")
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustExec("set tidb_executor_concurrency=3")
+
+	sql := "select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a"
+	// Verify baseline works.
+	checkApplyPlan(t, tk, sql, 3)
+	tk.MustQuery(sql).Check(testkit.Rows("1 10", "2 20", "3 30", "4 30", "5 30"))
+
+	// Panic in ordered inner worker — error should propagate through
+	// reorder worker to the consumer.
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/parallelApplyInnerWorkerOrderedPanic", "panic"))
+	require.Error(t, tk.QueryToErr(sql))
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/parallelApplyInnerWorkerOrderedPanic"))
+
+	// Panic in outer worker (shared with unordered, but verify it
+	// works with the reorder worker present).
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/parallelApplyOuterWorkerPanic", "panic"))
+	require.Error(t, tk.QueryToErr(sql))
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/parallelApplyOuterWorkerPanic"))
+}
+
 // flattenRows converts [][]interface{} from MustQuery().Rows() into
 // []string suitable for testkit.RowsWithSep(" ", ...).
 func flattenRows(rows [][]any) []string {

--- a/pkg/executor/parallel_apply_test.go
+++ b/pkg/executor/parallel_apply_test.go
@@ -586,6 +586,106 @@ func TestOrderedParallelApply(t *testing.T) {
 	tk.MustQuery(q5).Check(testkit.RowsWithSep(" ", flattenRows(serialRows5)...))
 }
 
+func TestOrderedParallelApplyEdgeCases(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustExec("set tidb_executor_concurrency=4")
+
+	// ----------------------------------------------------------------
+	// 1. Outer filter with unselected rows — exercises the
+	//    processOneOuterRow !or.selected path.
+	// ----------------------------------------------------------------
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1 (a int, b int, index idx_a(a))")
+	tk.MustExec("create table t2 (a int, b int)")
+	tk.MustExec("insert into t1 values (1,1),(2,2),(3,3),(4,4),(5,5)")
+	tk.MustExec("insert into t2 values (1,10),(2,20),(3,30)")
+	// The WHERE t1.a > 2 acts as an outer filter so rows with a<=2 hit
+	// the unselected path in processOneOuterRow.
+	q1 := "select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 where t1.a > 2 order by t1.a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected1 := tk.MustQuery(q1).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	checkApplyPlan(t, tk, q1, 4)
+	tk.MustQuery(q1).Check(testkit.RowsWithSep(" ", flattenRows(expected1)...))
+
+	// ----------------------------------------------------------------
+	// 2. NOT EXISTS (anti-semi-join) with ORDER BY — exercises
+	//    OnMissMatch in the ordered path.
+	// ----------------------------------------------------------------
+	q2 := "select t1.a from t1 where not exists (select 1 from t2 where t2.a = t1.a) order by t1.a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected2 := tk.MustQuery(q2).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustQuery(q2).Check(testkit.RowsWithSep(" ", flattenRows(expected2)...))
+
+	// ----------------------------------------------------------------
+	// 3. ORDER BY + LIMIT 1 — the primary use-case for eager flush.
+	//    Verifies the reorder worker flushes partial output early.
+	// ----------------------------------------------------------------
+	q3 := "select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a limit 1"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected3 := tk.MustQuery(q3).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustQuery(q3).Check(testkit.RowsWithSep(" ", flattenRows(expected3)...))
+
+	// ----------------------------------------------------------------
+	// 4. Empty outer side — orderedResultCh closes immediately.
+	// ----------------------------------------------------------------
+	q4 := "select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 where t1.a > 999 order by t1.a"
+	tk.MustQuery(q4).Check(testkit.Rows())
+
+	// ----------------------------------------------------------------
+	// 5. Single row outer — minimal ordered path exercise.
+	// ----------------------------------------------------------------
+	q5 := "select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 where t1.a = 3 order by t1.a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected5 := tk.MustQuery(q5).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustQuery(q5).Check(testkit.RowsWithSep(" ", flattenRows(expected5)...))
+
+	// ----------------------------------------------------------------
+	// 6. Left outer semi-join with ORDER BY — exercises the e.outer
+	//    path where OnMissMatch must emit the outer row.
+	// ----------------------------------------------------------------
+	tk.MustExec("drop table if exists t3, t4")
+	tk.MustExec("create table t3 (a int, index idx_a(a))")
+	tk.MustExec("create table t4 (a int)")
+	tk.MustExec("insert into t3 values (1),(2),(3),(4),(5)")
+	tk.MustExec("insert into t4 values (2),(4)")
+	// The IN subquery uses left-outer-semi-join producing a boolean column.
+	q6 := "select a, a in (select /*+ NO_DECORRELATE() */ a from t4 where t4.a = t3.a) from t3 order by a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected6 := tk.MustQuery(q6).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustQuery(q6).Check(testkit.RowsWithSep(" ", flattenRows(expected6)...))
+
+	// ----------------------------------------------------------------
+	// 7. Large result set — exercises the appendRow→IsFull→flushOutput
+	//    path where the output chunk fills to capacity and must be
+	//    flushed mid-drain.
+	// ----------------------------------------------------------------
+	tk.MustExec("drop table if exists t5, t6")
+	tk.MustExec("create table t5 (a int, index idx_a(a))")
+	tk.MustExec("create table t6 (a int)")
+	vals := ""
+	for i := 1; i <= 2000; i++ {
+		if i > 1 {
+			vals += ","
+		}
+		vals += fmt.Sprintf("(%d)", i)
+	}
+	tk.MustExec("insert into t5 values " + vals)
+	tk.MustExec("insert into t6 values (1),(2),(3)")
+	q7 := "select t5.a, (select count(*) from t6 where t6.a <= t5.a) from t5 order by t5.a"
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	expected7 := tk.MustQuery(q7).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustQuery(q7).Check(testkit.RowsWithSep(" ", flattenRows(expected7)...))
+}
+
 // flattenRows converts [][]interface{} from MustQuery().Rows() into
 // []string suitable for testkit.RowsWithSep(" ", ...).
 func flattenRows(rows [][]any) []string {

--- a/pkg/executor/parallel_apply_test.go
+++ b/pkg/executor/parallel_apply_test.go
@@ -17,10 +17,13 @@ package executor_test
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"github.com/stretchr/testify/require"
 )
 
@@ -864,6 +867,163 @@ func TestOrderedParallelApplyGoroutinePanic(t *testing.T) {
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/parallelApplyOuterWorkerPanic", "panic"))
 	require.Error(t, tk.QueryToErr(sql))
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/parallelApplyOuterWorkerPanic"))
+}
+
+func TestOrderedParallelApplyKillSignal(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1 (a int, b int, index idx_a(a))")
+	tk.MustExec("create table t2 (a int, b int)")
+	tk.MustExec("insert into t1 values (1,1),(2,2),(3,3),(4,4),(5,5)")
+	tk.MustExec("insert into t2 values (1,10),(2,20),(3,30)")
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	tk.MustExec("set tidb_executor_concurrency=3")
+
+	sql := "select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a"
+
+	// Verify baseline works before testing kill.
+	checkApplyPlan(t, tk, sql, 3)
+	tk.MustQuery(sql).Check(testkit.Rows("1 10", "2 20", "3 30", "4 30", "5 30"))
+
+	// Enable a failpoint that makes inner workers sleep, giving us time
+	// to send a kill signal while the ordered pipeline is active.
+	fpPath := "github.com/pingcap/tidb/pkg/executor/parallelApplyOrderedSleep"
+	require.NoError(t, failpoint.Enable(fpPath, "return(500)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable(fpPath))
+	}()
+
+	// Kill signal during inner worker processing.
+	// The kill signal is sent after 200ms while inner workers are sleeping
+	// for 500ms each. The exec.Next() kill check after the sleep should
+	// detect the signal and return ErrQueryInterrupted, which propagates
+	// through orderedResultCh → reorder worker → resultChkCh → consumer.
+	tk.Session().GetSessionVars().SQLKiller.Reset()
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(200 * time.Millisecond)
+		tk.Session().GetSessionVars().SQLKiller.SendKillSignal(sqlkiller.QueryInterrupted)
+	}()
+
+	start := time.Now()
+	err := tk.QueryToErr(sql)
+	elapsed := time.Since(start)
+	require.Error(t, err, "query should be interrupted by kill signal")
+	// The query should be interrupted well before all 5 rows × 500ms
+	// sleep would complete (~2.5s). Allow generous headroom but verify
+	// it didn't run to completion.
+	require.Less(t, elapsed, 2*time.Second,
+		"kill signal should abort execution promptly, but took %v", elapsed)
+	wg.Wait()
+}
+
+func TestOrderedParallelApplyNested(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1, t2, t3")
+	tk.MustExec("create table t1 (a int, b int, index idx_a(a))")
+	tk.MustExec("create table t2 (a int, b int)")
+	tk.MustExec("create table t3 (a int, b int)")
+	tk.MustExec("insert into t1 values (1,10),(2,20),(3,30),(4,40),(5,50)")
+	tk.MustExec("insert into t2 values (1,100),(2,200),(3,300)")
+	tk.MustExec("insert into t3 values (1,1000),(2,2000),(3,3000),(4,4000)")
+	tk.MustExec("set tidb_executor_concurrency=3")
+
+	// ----------------------------------------------------------------
+	// Case 1: Two correlated subqueries in SELECT with ORDER BY.
+	// This produces two stacked Apply operators:
+	//   Apply_outer(outer=Apply_inner(outer=IndexScan, inner=t2_subq), inner=t3_subq)
+	// Both Apply operators are on the outer-child path, so both are
+	// parallelized with KeepOrder=true.
+	// ----------------------------------------------------------------
+	q1 := `select t1.a,
+		(select /*+ NO_DECORRELATE() */ max(t2.b) from t2 where t2.a = t1.a),
+		(select /*+ NO_DECORRELATE() */ max(t3.b) from t3 where t3.a = t1.a)
+	from t1 order by t1.a`
+
+	// Verify both Apply operators are parallel with Concurrency:3.
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	rows := tk.MustQuery("explain analyze " + q1).Rows()
+	applyCount := 0
+	for _, row := range rows {
+		id := fmt.Sprintf("%v", row[0])
+		if strings.Contains(id, "Apply") {
+			applyCount++
+			execInfo := fmt.Sprintf("%v", row[5])
+			require.Contains(t, execInfo, "Concurrency:3",
+				"nested Apply %s should be parallel", id)
+		}
+	}
+	require.Equal(t, 2, applyCount, "should have two Apply operators")
+
+	// Verify ordering: compare parallel vs serial results.
+	expected1 := tk.MustQuery(q1).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	serial1 := tk.MustQuery(q1).Rows()
+	require.Equal(t, serial1, expected1, "nested parallel apply should match serial results")
+
+	// ----------------------------------------------------------------
+	// Case 2: Subquery inside subquery (Apply inside inner child).
+	// This produces: Apply_outer(outer=IndexScan, inner=Apply_inner(...))
+	// Per limitation 2, Apply_inner stays serial while Apply_outer is
+	// parallel with KeepOrder=true.
+	// ----------------------------------------------------------------
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	q2 := `select t1.a,
+		(select /*+ NO_DECORRELATE() */ max(t2.b) +
+			(select /*+ NO_DECORRELATE() */ max(t3.b) from t3 where t3.a = t2.a)
+		from t2 where t2.a = t1.a)
+	from t1 order by t1.a`
+
+	rows2 := tk.MustQuery("explain analyze " + q2).Rows()
+	parallelApplyCount := 0
+	serialApplyCount := 0
+	for _, row := range rows2 {
+		id := fmt.Sprintf("%v", row[0])
+		execInfo := fmt.Sprintf("%v", row[5])
+		if !strings.Contains(id, "Apply") {
+			continue
+		}
+		if strings.Contains(execInfo, "concurrency:OFF") {
+			serialApplyCount++
+		} else if strings.Contains(execInfo, "Concurrency:") {
+			parallelApplyCount++
+		}
+	}
+	// Outer Apply is parallel; inner-side Apply stays serial (limitation 2).
+	require.Equal(t, 1, parallelApplyCount, "outer Apply should be parallel")
+	require.Equal(t, 1, serialApplyCount, "inner-side Apply should be serial")
+
+	expected2 := tk.MustQuery(q2).Rows()
+	tk.MustExec("set tidb_enable_parallel_apply=false")
+	serial2 := tk.MustQuery(q2).Rows()
+	require.Equal(t, serial2, expected2, "nested inner apply should match serial results")
+
+	// ----------------------------------------------------------------
+	// Case 3: Two stacked Apply with LIMIT — verify ordering preserved
+	// through both layers.
+	// ----------------------------------------------------------------
+	tk.MustExec("set tidb_enable_parallel_apply=true")
+	q3 := `select t1.a,
+		(select /*+ NO_DECORRELATE() */ max(t2.b) from t2 where t2.a = t1.a),
+		(select /*+ NO_DECORRELATE() */ max(t3.b) from t3 where t3.a = t1.a)
+	from t1 order by t1.a limit 3`
+	tk.MustQuery(q3).Check(testkit.Rows("1 100 1000", "2 200 2000", "3 300 3000"))
+
+	// ----------------------------------------------------------------
+	// Case 4: Varying concurrency with nested apply.
+	// ----------------------------------------------------------------
+	for _, conc := range []int{1, 2, 5} {
+		tk.MustExec(fmt.Sprintf("set tidb_executor_concurrency=%d", conc))
+		result := tk.MustQuery(q1).Rows()
+		require.Equal(t, serial1, result,
+			"nested parallel apply with concurrency=%d should match serial", conc)
+	}
 }
 
 // flattenRows converts [][]interface{} from MustQuery().Rows() into

--- a/pkg/planner/core/casetest/parallelapply/BUILD.bazel
+++ b/pkg/planner/core/casetest/parallelapply/BUILD.bazel
@@ -8,9 +8,11 @@ go_test(
         "parallel_apply_test.go",
     ],
     flaky = True,
+    shard_count = 2,
     deps = [
         "//pkg/testkit",
         "//pkg/testkit/testsetup",
+        "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/pkg/planner/core/casetest/parallelapply/parallel_apply_test.go
+++ b/pkg/planner/core/casetest/parallelapply/parallel_apply_test.go
@@ -15,9 +15,12 @@
 package parallelapply
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParallelApplyWarnning(t *testing.T) {
@@ -49,4 +52,69 @@ func TestParallelApplyWarnning(t *testing.T) {
 				"            └─TableRowIDScan 124875000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"))
 		testKit.MustQuery("show warnings;").Check(testkit.Rows())
 	})
+}
+
+// TestParallelApplyOrderedPlan verifies that the planner produces valid plans
+// for parallel apply with ORDER BY and LIMIT.  This exercises the
+// outerExpectedCnt computation in exhaustPhysicalPlans4LogicalApply and
+// the KeepOrder setting in enableParallelApply.
+func TestParallelApplyOrderedPlan(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (a int, b int, index idx_a(a))")
+	tk.MustExec("create table t2 (a int, b int)")
+	tk.MustExec("set tidb_enable_parallel_apply=on")
+	tk.MustExec("set tidb_executor_concurrency=5")
+
+	// Helper: check that EXPLAIN output contains Apply and the outer
+	// side has keep order:true (indicating ordered parallel apply is used).
+	checkHasApply := func(sql string) {
+		rows := tk.MustQuery("explain " + sql).Rows()
+		foundApply := false
+		for _, row := range rows {
+			line := fmt.Sprintf("%v", row)
+			if strings.Contains(line, "Apply") {
+				foundApply = true
+				break
+			}
+		}
+		require.True(t, foundApply, "plan should contain Apply: %s", sql)
+	}
+
+	// 1. ORDER BY with correlated subquery — should produce Apply with
+	//    ordered outer scan (keep order:true).  Exercises enableParallelApply
+	//    setting KeepOrder = true.
+	checkHasApply("select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a")
+
+	// 2. ORDER BY + LIMIT — exercises the outerExpectedCnt computation
+	//    in exhaustPhysicalPlans4LogicalApply.  The planner should still
+	//    produce an Apply (not reject it due to sort properties).
+	checkHasApply("select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a limit 5")
+
+	// 3. No ORDER BY — basic unordered parallel apply still works.
+	checkHasApply("select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1")
+
+	// 4. ORDER BY with EXISTS (semi-join) + LIMIT — exercises the
+	//    selectivity-based outerExpectedCnt calculation where
+	//    applyRowCount < outerRowCount.
+	checkHasApply("select t1.a from t1 where exists (select /*+ NO_DECORRELATE() */ 1 from t2 where t2.a = t1.a) order by t1.a limit 3")
+
+	// 5. Verify no warnings are emitted for ordered parallel apply
+	//    (the old code would emit "Parallel Apply rejects the possible
+	//    order properties" which we removed).
+	tk.MustQuery("explain select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a")
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+
+	// 6. Verify correctness: parallel + ordered should match serial.
+	tk.MustExec("insert into t1 values (1,10),(2,20),(3,30),(4,40),(5,50)")
+	tk.MustExec("insert into t2 values (1,1),(2,2),(3,3)")
+
+	tk.MustExec("set tidb_enable_parallel_apply=off")
+	serialRows := tk.MustQuery("select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a limit 3").Rows()
+
+	tk.MustExec("set tidb_enable_parallel_apply=on")
+	parallelRows := tk.MustQuery("select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a limit 3").Rows()
+
+	require.Equal(t, serialRows, parallelRows)
 }

--- a/pkg/planner/core/casetest/parallelapply/parallel_apply_test.go
+++ b/pkg/planner/core/casetest/parallelapply/parallel_apply_test.go
@@ -67,38 +67,53 @@ func TestParallelApplyOrderedPlan(t *testing.T) {
 	tk.MustExec("set tidb_enable_parallel_apply=on")
 	tk.MustExec("set tidb_executor_concurrency=5")
 
-	// Helper: check that EXPLAIN output contains Apply and the outer
-	// side has keep order:true (indicating ordered parallel apply is used).
-	checkHasApply := func(sql string) {
+	// Helper: check that EXPLAIN output contains Apply and, when
+	// expectKeepOrder is true, that the outer (Build) subtree contains
+	// "keep order:true" — indicating ordered parallel apply is used.
+	checkHasApply := func(sql string, expectKeepOrder bool) {
 		rows := tk.MustQuery("explain " + sql).Rows()
 		foundApply := false
+		foundKeepOrder := false
+		inBuildSide := false
 		for _, row := range rows {
 			line := fmt.Sprintf("%v", row)
 			if strings.Contains(line, "Apply") {
 				foundApply = true
-				break
+			}
+			// Track when we enter the Build subtree (outer side)
+			// and leave it when we hit the Probe subtree.
+			if strings.Contains(line, "Build") {
+				inBuildSide = true
+			} else if strings.Contains(line, "Probe") {
+				inBuildSide = false
+			}
+			if inBuildSide && strings.Contains(line, "keep order:true") {
+				foundKeepOrder = true
 			}
 		}
 		require.True(t, foundApply, "plan should contain Apply: %s", sql)
+		if expectKeepOrder {
+			require.True(t, foundKeepOrder, "plan should have keep order:true on outer (Build) side: %s", sql)
+		}
 	}
 
 	// 1. ORDER BY with correlated subquery — should produce Apply with
 	//    ordered outer scan (keep order:true).  Exercises enableParallelApply
 	//    setting KeepOrder = true.
-	checkHasApply("select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a")
+	checkHasApply("select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a", true)
 
 	// 2. ORDER BY + LIMIT — exercises the outerExpectedCnt computation
 	//    in exhaustPhysicalPlans4LogicalApply.  The planner should still
 	//    produce an Apply (not reject it due to sort properties).
-	checkHasApply("select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a limit 5")
+	checkHasApply("select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1 order by t1.a limit 5", true)
 
 	// 3. No ORDER BY — basic unordered parallel apply still works.
-	checkHasApply("select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1")
+	checkHasApply("select t1.a, (select max(t2.b) from t2 where t2.a <= t1.a) from t1", false)
 
 	// 4. ORDER BY with EXISTS (semi-join) + LIMIT — exercises the
 	//    selectivity-based outerExpectedCnt calculation where
 	//    applyRowCount < outerRowCount.
-	checkHasApply("select t1.a from t1 where exists (select /*+ NO_DECORRELATE() */ 1 from t2 where t2.a = t1.a) order by t1.a limit 3")
+	checkHasApply("select t1.a from t1 where exists (select /*+ NO_DECORRELATE() */ 1 from t2 where t2.a = t1.a) order by t1.a limit 3", true)
 
 	// 5. Verify no warnings are emitted for ordered parallel apply
 	//    (the old code would emit "Parallel Apply rejects the possible

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -19,7 +19,6 @@ import (
 	"math"
 	"slices"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/executor/join/joinversion"
 	"github.com/pingcap/tidb/pkg/expression"
@@ -2846,16 +2845,14 @@ func GetHashJoin(ge base.GroupExpression, la *logicalop.LogicalApply, prop *prop
 // exhaustPhysicalPlans4LogicalApply generates the physical plan for a logical apply.
 func exhaustPhysicalPlans4LogicalApply(super base.LogicalPlan, prop *property.PhysicalProperty) ([]base.PhysicalPlan, bool, error) {
 	ge, la := base.GetGEAndLogicalOp[*logicalop.LogicalApply](super)
-	_, _, schema0, _ := getJoinChildStatsAndSchema(ge, la)
+	stats0, _, schema0, _ := getJoinChildStatsAndSchema(ge, la)
 	if !prop.AllColsFromSchema(schema0) || prop.IsFlashProp() { // for convenient, we don't pass through any prop
 		la.SCtx().GetSessionVars().RaiseWarningWhenMPPEnforced(
 			"MPP mode may be blocked because operator `Apply` is not supported now.")
 		return nil, true, nil
 	}
-	if !prop.IsSortItemEmpty() && la.SCtx().GetSessionVars().EnableParallelApply {
-		la.SCtx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError("Parallel Apply rejects the possible order properties of its outer child currently"))
-		return nil, true, nil
-	}
+	// Parallel Apply now supports ordered output via a reorder buffer,
+	// so we no longer reject sort properties here.
 	join := GetHashJoin(ge, la, prop)
 	var columns = make([]*expression.Column, 0, len(la.CorCols))
 	for _, colColumn := range la.CorCols {
@@ -2878,6 +2875,27 @@ func exhaustPhysicalPlans4LogicalApply(super base.LogicalPlan, prop *property.Ph
 		canUseCache = false
 	}
 
+	// Compute the expected row count for the outer child.  For a semi/anti-semi
+	// join, each outer row produces at most one output row, so if the parent
+	// expects N rows we need N / selectivity outer rows.  For other join types
+	// the ratio may differ, but using the Apply's own selectivity is still a
+	// reasonable approximation.
+	outerExpectedCnt := math.MaxFloat64
+	if prop.ExpectedCnt < math.MaxFloat64 {
+		outerRowCount := stats0.RowCount
+		applyRowCount := la.StatsInfo().RowCount
+		if applyRowCount > 0 && outerRowCount > 0 {
+			selectivity := applyRowCount / outerRowCount
+			if selectivity > 0 {
+				outerExpectedCnt = prop.ExpectedCnt / selectivity
+			}
+		}
+		// The outer side can never need fewer rows than the parent expects.
+		if outerExpectedCnt < prop.ExpectedCnt {
+			outerExpectedCnt = prop.ExpectedCnt
+		}
+	}
+
 	apply := physicalop.PhysicalApply{
 		PhysicalHashJoin: *join,
 		OuterSchema:      la.CorCols,
@@ -2886,7 +2904,7 @@ func exhaustPhysicalPlans4LogicalApply(super base.LogicalPlan, prop *property.Ph
 	}.Init(la.SCtx(),
 		la.StatsInfo().ScaleByExpectCnt(la.SCtx().GetSessionVars(), prop.ExpectedCnt),
 		la.QueryBlockOffset(),
-		&property.PhysicalProperty{ExpectedCnt: math.MaxFloat64, SortItems: prop.SortItems, CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: true},
+		&property.PhysicalProperty{ExpectedCnt: outerExpectedCnt, SortItems: prop.SortItems, CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: true},
 		&property.PhysicalProperty{ExpectedCnt: math.MaxFloat64, CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: prop.NoCopPushDown})
 	apply.SetSchema(la.Schema())
 	return []base.PhysicalPlan{apply}, true, nil

--- a/pkg/planner/core/operator/physicalop/physical_apply.go
+++ b/pkg/planner/core/operator/physicalop/physical_apply.go
@@ -32,6 +32,11 @@ type PhysicalApply struct {
 
 	CanUseCache bool
 	Concurrency int
+	// KeepOrder indicates that parallel apply must emit results in the same
+	// order as the outer child produces rows.  When true the executor uses a
+	// reorder buffer so that inner workers can run concurrently while the
+	// consumer still sees rows in outer-order.
+	KeepOrder   bool
 	OuterSchema []*expression.CorrelatedColumn
 	// NoDecorrelate is used to flag that an Apply operator remained undecorrelated due to the no_decorrelate hint exists. This allows the EXPLAIN EXPLORE feature to know exactly when to suggest adding a no_decorrelate hint when reverse-generating the sql recommended hints from the physical plan tree."
 	NoDecorrelate bool
@@ -67,6 +72,7 @@ func (p *PhysicalApply) Clone(newCtx base.PlanContext) (base.PhysicalPlan, error
 	cloned.PhysicalHashJoin = *hj
 	cloned.CanUseCache = p.CanUseCache
 	cloned.Concurrency = p.Concurrency
+	cloned.KeepOrder = p.KeepOrder
 	cloned.NoDecorrelate = p.NoDecorrelate
 	for _, col := range p.OuterSchema {
 		cloned.OuterSchema = append(cloned.OuterSchema, col.Clone().(*expression.CorrelatedColumn))

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -929,12 +929,13 @@ func enableParallelApply(sctx base.PlanContext, plan base.PhysicalPlan) base.Phy
 	if !sctx.GetSessionVars().EnableParallelApply {
 		return plan
 	}
-	// the parallel apply has three limitation:
-	// 1. the parallel implementation now cannot keep order;
-	// 2. the inner child has to support clone;
-	// 3. if one Apply is in the inner side of another Apply, it cannot be parallel, for example:
+	// the parallel apply has two limitations:
+	// 1. the inner child has to support clone;
+	// 2. if one Apply is in the inner side of another Apply, it cannot be parallel, for example:
 	//		The topology of 3 Apply operators are A1(A2, A3), which means A2 is the outer child of A1
 	//		while A3 is the inner child. Then A1 and A2 can be parallel and A3 cannot.
+	// Note: ordering is now preserved via a reorder buffer (KeepOrder=true)
+	// when the outer side requires sorted output, so order is no longer a limitation.
 	if apply, ok := plan.(*physicalop.PhysicalApply); ok {
 		outerIdx := 1 - apply.InnerChildIdx
 		hasOrder := len(apply.GetChildReqProps(outerIdx).SortItems) > 0

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -937,17 +937,19 @@ func enableParallelApply(sctx base.PlanContext, plan base.PhysicalPlan) base.Phy
 	//		while A3 is the inner child. Then A1 and A2 can be parallel and A3 cannot.
 	if apply, ok := plan.(*physicalop.PhysicalApply); ok {
 		outerIdx := 1 - apply.InnerChildIdx
-		noOrder := len(apply.GetChildReqProps(outerIdx).SortItems) == 0 // limitation 1
+		hasOrder := len(apply.GetChildReqProps(outerIdx).SortItems) > 0
 		_, err := physicalop.SafeClone(sctx, apply.Children()[apply.InnerChildIdx])
 		supportClone := err == nil // limitation 2
-		if noOrder && supportClone {
+		if supportClone {
 			apply.Concurrency = sctx.GetSessionVars().ExecutorConcurrency
-		} else {
-			if err != nil {
-				sctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf("Some apply operators can not be executed in parallel: %v", err))
-			} else {
-				sctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError("Some apply operators can not be executed in parallel"))
+			// When the outer side requires ordering, use a reorder buffer
+			// in the executor to preserve row order while still running
+			// inner workers in parallel.
+			if hasOrder {
+				apply.KeepOrder = true
 			}
+		} else {
+			sctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf("Some apply operators can not be executed in parallel: %v", err))
 		}
 		// because of the limitation 3, we cannot parallelize Apply operators in this Apply's inner size,
 		// so we only invoke recursively for its outer child.

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -929,18 +929,18 @@ func enableParallelApply(sctx base.PlanContext, plan base.PhysicalPlan) base.Phy
 	if !sctx.GetSessionVars().EnableParallelApply {
 		return plan
 	}
-	// the parallel apply has two limitations:
-	// 1. the inner child has to support clone;
-	// 2. if one Apply is in the inner side of another Apply, it cannot be parallel, for example:
+	// The parallel apply has two limitations:
+	// 1. The inner child has to support clone.
+	// 2. If one Apply is in the inner side of another Apply, it cannot be parallel, for example:
 	//		The topology of 3 Apply operators are A1(A2, A3), which means A2 is the outer child of A1
 	//		while A3 is the inner child. Then A1 and A2 can be parallel and A3 cannot.
 	// Note: ordering is now preserved via a reorder buffer (KeepOrder=true)
 	// when the outer side requires sorted output, so order is no longer a limitation.
 	if apply, ok := plan.(*physicalop.PhysicalApply); ok {
 		outerIdx := 1 - apply.InnerChildIdx
-		hasOrder := len(apply.GetChildReqProps(outerIdx).SortItems) > 0
+		hasOrder := apply.GetChildReqProps(outerIdx).NeedKeepOrder()
 		_, err := physicalop.SafeClone(sctx, apply.Children()[apply.InnerChildIdx])
-		supportClone := err == nil // limitation 2
+		supportClone := err == nil // limitation 1
 		if supportClone {
 			apply.Concurrency = sctx.GetSessionVars().ExecutorConcurrency
 			// When the outer side requires ordering, use a reorder buffer
@@ -952,7 +952,7 @@ func enableParallelApply(sctx base.PlanContext, plan base.PhysicalPlan) base.Phy
 		} else {
 			sctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf("Some apply operators can not be executed in parallel: %v", err))
 		}
-		// because of the limitation 3, we cannot parallelize Apply operators in this Apply's inner size,
+		// Because of limitation 2, we cannot parallelize Apply operators in this Apply's inner side,
 		// so we only invoke recursively for its outer child.
 		apply.SetChild(outerIdx, enableParallelApply(sctx, apply.Children()[outerIdx]))
 		return apply


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #66716

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ordered parallel apply: preserves outer-row order while inner work runs concurrently.

* **Bug Fixes**
  * Removed spurious rejections/warnings for sorted outputs with parallel apply; ordered plans no longer get rejected.

* **Chores**
  * Planner now estimates and propagates expected outer-row counts and enables an ordering-preservation path when needed.

* **Tests**
  * Added extensive tests validating ordered parallel apply, edge cases, large-result handling, and panic propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->