### PR TITLE
lightning: keep started import-into submits alive on cancellation

### DIFF
--- a/lightning/pkg/importinto/BUILD.bazel
+++ b/lightning/pkg/importinto/BUILD.bazel
@@ -46,7 +46,7 @@ go_test(
     ],
     embed = [":importinto"],
     flaky = True,
-    shard_count = 20,
+    shard_count = 23,
     deps = [
         "//lightning/pkg/importinto/mock",
         "//lightning/pkg/precheck",
@@ -57,6 +57,7 @@ go_test(
         "//pkg/lightning/log",
         "@com_github_data_dog_go_sqlmock//:go-sqlmock",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_mock//gomock",
     ],

--- a/lightning/pkg/importinto/job_orchestrator.go
+++ b/lightning/pkg/importinto/job_orchestrator.go
@@ -40,7 +40,7 @@ const (
 	// continue after the batch context is canceled. This gives the client enough
 	// time to get the job ID and record the checkpoint so later cleanup can find
 	// the job reliably.
-	submitGraceTimeout = 30 * time.Second
+	submitGraceTimeout = time.Minute
 )
 
 const (
@@ -339,12 +339,13 @@ func (o *DefaultJobOrchestrator) submitAllJobs(ctx context.Context, tables []*im
 		eg.Go(func() error {
 			logger := o.logger.With(zap.String("database", table.Database), zap.String("table", table.Table))
 
-			if err := egCtx.Err(); err != nil {
-				return errors.Trace(err)
-			}
+			// Still inspect checkpoints after errgroup cancellation so previously
+			// running jobs remain tracked and can be reconciled during cleanup.
+			checkpointCtx, cancelCheckpoint := context.WithTimeout(context.WithoutCancel(ctx), cancelTimeout)
+			defer cancelCheckpoint()
 
 			// Check if we can resume an existing job
-			cp, err := o.cpMgr.Get(egCtx, common.UniqueTable(table.Database, table.Table))
+			cp, err := o.cpMgr.Get(checkpointCtx, common.UniqueTable(table.Database, table.Table))
 			if err != nil {
 				return errors.Annotatef(err, "get checkpoint for %s.%s", table.Database, table.Table)
 			}
@@ -354,47 +355,46 @@ func (o *DefaultJobOrchestrator) submitAllJobs(ctx context.Context, tables []*im
 				return nil
 			}
 
-			var job *ImportJob
 			if cp != nil && cp.JobID > 0 && cp.Status == CheckpointStatusRunning {
 				// Resume existing running job
 				logger.Info("resuming previously running job", zap.Int64("jobID", cp.JobID))
-				job = &ImportJob{
+				appendJob(&ImportJob{
 					JobID:     cp.JobID,
 					TableMeta: table,
 					GroupKey:  o.submitter.GetGroupKey(),
-				}
-			} else {
-				// Need to submit new job
-				// This handles: no checkpoint, failed checkpoint, or cancelled checkpoint
-				if cp != nil {
-					logger.Info("previous job failed or cancelled, submitting new job",
-						zap.String("previousStatus", cp.Status.String()),
-						zap.Int64("previousJobID", cp.JobID),
-					)
-				} else {
-					logger.Info("submitting new import job")
-				}
-
-				if err := egCtx.Err(); err != nil {
-					return errors.Trace(err)
-				}
-
-				submitCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), submitGraceTimeout)
-				defer cancel()
-
-				job, err = o.submitter.SubmitTable(submitCtx, table)
-				if err != nil {
-					return errors.Annotatef(err, "submit table %s.%s", table.Database, table.Table)
-				}
-
-				appendJob(job)
-				if err := o.recordSubmission(submitCtx, job); err != nil {
-					return errors.Annotatef(err, "record submission for %s.%s", table.Database, table.Table)
-				}
+				})
 				return nil
 			}
 
+			// Need to submit new job
+			// This handles: no checkpoint, failed checkpoint, or cancelled checkpoint
+			if cp != nil {
+				logger.Info("previous job failed or cancelled, submitting new job",
+					zap.String("previousStatus", cp.Status.String()),
+					zap.Int64("previousJobID", cp.JobID),
+				)
+			} else {
+				logger.Info("submitting new import job")
+			}
+
+			if err := egCtx.Err(); err != nil {
+				return errors.Trace(err)
+			}
+
+			submitCtx, cancel := newStartedSubmitContext(ctx)
+			defer cancel()
+
+			job, err := o.submitter.SubmitTable(submitCtx, table)
+			if err != nil {
+				return errors.Annotatef(err, "submit table %s.%s", table.Database, table.Table)
+			}
+
 			appendJob(job)
+			recordCtx, cancelRecord := newSubmissionRecordContext(ctx)
+			defer cancelRecord()
+			if err := o.recordSubmission(recordCtx, job); err != nil {
+				return errors.Annotatef(err, "record submission for %s.%s", table.Database, table.Table)
+			}
 			return nil
 		})
 	}
@@ -410,4 +410,43 @@ func (o *DefaultJobOrchestrator) recordSubmission(ctx context.Context, job *Impo
 		Status:    CheckpointStatusRunning,
 		GroupKey:  job.GroupKey,
 	})
+}
+
+func getSubmitGraceTimeout() time.Duration {
+	graceTimeout := submitGraceTimeout
+	failpoint.Inject("setSubmitGraceTimeout", func(val failpoint.Value) {
+		parsedTimeout, err := time.ParseDuration(val.(string))
+		if err == nil {
+			graceTimeout = parsedTimeout
+		}
+	})
+	return graceTimeout
+}
+
+// newStartedSubmitContext is used for submits that have already started.
+// We cannot keep using the parent errgroup context here, because a sibling
+// submit failure or parent cancellation would abort this request immediately
+// and we could return before receiving the detached job ID. Instead, keep the
+// started submit alive for a bounded grace period that begins when the parent
+// context is canceled.
+func newStartedSubmitContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	graceCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	stop := context.AfterFunc(ctx, func() {
+		timer := time.NewTimer(getSubmitGraceTimeout())
+		defer timer.Stop()
+
+		select {
+		case <-graceCtx.Done():
+		case <-timer.C:
+			cancel()
+		}
+	})
+	return graceCtx, func() {
+		stop()
+		cancel()
+	}
+}
+
+func newSubmissionRecordContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), getSubmitGraceTimeout())
 }

--- a/lightning/pkg/importinto/job_orchestrator_test.go
+++ b/lightning/pkg/importinto/job_orchestrator_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/lightning/pkg/importinto"
 	mockimport "github.com/pingcap/tidb/lightning/pkg/importinto/mock"
 	"github.com/pingcap/tidb/pkg/importsdk"
@@ -29,6 +30,24 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+func observeContextDone(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		close(done)
+	}()
+	return done
+}
+
+func channelClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
 
 func TestJobOrchestratorSubmitAndWait(t *testing.T) {
 	tests := []struct {
@@ -218,7 +237,7 @@ func TestJobOrchestratorSubmissionErrorStillRecordsSubmittedJobs(t *testing.T) {
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
-			case <-time.After(100 * time.Millisecond):
+			default:
 			}
 			return &importinto.ImportJob{
 				JobID:     1,
@@ -255,9 +274,65 @@ func TestJobOrchestratorSubmissionErrorStillRecordsSubmittedJobs(t *testing.T) {
 	require.Error(t, orchestrator.SubmitAndWait(context.Background(), tables))
 }
 
-func TestJobOrchestratorContextCancelStillRecordsStartedSubmit(t *testing.T) {
+func TestJobOrchestratorSubmissionErrorStillCancelsRunningCheckpointJobs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	mockSubmitter := mockimport.NewMockJobSubmitter(ctrl)
+	mockCpMgr := mockimport.NewMockCheckpointManager(ctrl)
+	mockMonitor := mockimport.NewMockJobMonitor(ctrl)
+	mockSDK := sdkmock.NewMockSDK(ctrl)
+
+	orchestrator := importinto.NewJobOrchestrator(importinto.OrchestratorConfig{
+		Submitter:         mockSubmitter,
+		CheckpointMgr:     mockCpMgr,
+		SDK:               mockSDK,
+		Monitor:           mockMonitor,
+		SubmitConcurrency: 1,
+		PollInterval:      time.Millisecond,
+		Logger:            log.L(),
+	})
+
+	tables := []*importsdk.TableMeta{
+		{Database: "db", Table: "t2", DataFiles: []importsdk.DataFileMeta{{Path: "f2"}}, TotalSize: 100},
+		{Database: "db", Table: "t1", DataFiles: []importsdk.DataFileMeta{{Path: "f1"}}, TotalSize: 100},
+	}
+
+	gomock.InOrder(
+		mockCpMgr.EXPECT().Get(gomock.Any(), common.UniqueTable("db", "t2")).Return(nil, nil),
+		mockSubmitter.EXPECT().SubmitTable(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, tableMeta *importsdk.TableMeta) (*importinto.ImportJob, error) {
+			require.Equal(t, "t2", tableMeta.Table)
+			return nil, errors.New("submit error")
+		}),
+		mockCpMgr.EXPECT().Get(gomock.Any(), common.UniqueTable("db", "t1")).Return(&importinto.TableCheckpoint{
+			JobID:  1,
+			Status: importinto.CheckpointStatusRunning,
+		}, nil),
+		mockSubmitter.EXPECT().GetGroupKey().Return("group1"),
+		mockSDK.EXPECT().GetJobsByGroup(gomock.Any(), "group1").Return([]*importsdk.JobStatus{
+			{JobID: 1, Status: "running"},
+		}, nil),
+		mockSDK.EXPECT().CancelJob(gomock.Any(), int64(1)).Return(nil),
+		mockCpMgr.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, cp *importinto.TableCheckpoint) error {
+			require.Equal(t, common.UniqueTable("db", "t1"), cp.TableName)
+			require.Equal(t, int64(1), cp.JobID)
+			require.Equal(t, importinto.CheckpointStatusFailed, cp.Status)
+			require.Equal(t, "cancelled by user", cp.Message)
+			require.Equal(t, "group1", cp.GroupKey)
+			return nil
+		}),
+	)
+
+	require.Error(t, orchestrator.SubmitAndWait(context.Background(), tables))
+}
+
+func TestJobOrchestratorSubmitGraceStartsAfterContextCancel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/lightning/pkg/importinto/setSubmitGraceTimeout", `return("50ms")`))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/lightning/pkg/importinto/setSubmitGraceTimeout"))
+	})
 
 	mockSubmitter := mockimport.NewMockJobSubmitter(ctrl)
 	mockCpMgr := mockimport.NewMockCheckpointManager(ctrl)
@@ -284,24 +359,27 @@ func TestJobOrchestratorContextCancelStillRecordsStartedSubmit(t *testing.T) {
 	defer cancel()
 
 	submitStarted := make(chan struct{})
+	parentCanceled := make(chan struct{})
+	submitCheckedAfterCancel := make(chan struct{})
+	allowSubmitReturn := make(chan struct{})
+	var submitCtxDone <-chan struct{}
 	mockSubmitter.EXPECT().SubmitTable(gomock.Any(), gomock.Any()).DoAndReturn(func(submitCtx context.Context, tableMeta *importsdk.TableMeta) (*importinto.ImportJob, error) {
+		submitCtxDone = observeContextDone(submitCtx)
 		close(submitStarted)
+		<-parentCanceled
 		select {
 		case <-submitCtx.Done():
 			return nil, submitCtx.Err()
-		case <-time.After(100 * time.Millisecond):
+		default:
 		}
+		close(submitCheckedAfterCancel)
+		<-allowSubmitReturn
 		return &importinto.ImportJob{
 			JobID:     1,
 			TableMeta: tableMeta,
 			GroupKey:  "group1",
 		}, nil
 	})
-
-	go func() {
-		<-submitStarted
-		cancel()
-	}()
 
 	mockCpMgr.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(func(updateCtx context.Context, cp *importinto.TableCheckpoint) error {
 		require.NoError(t, updateCtx.Err())
@@ -313,7 +391,120 @@ func TestJobOrchestratorContextCancelStillRecordsStartedSubmit(t *testing.T) {
 	})
 	mockMonitor.EXPECT().WaitForJobs(gomock.Any(), gomock.Any()).Return(context.Canceled)
 
-	err := orchestrator.SubmitAndWait(ctx, tables)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- orchestrator.SubmitAndWait(ctx, tables)
+	}()
+
+	<-submitStarted
+	require.Never(t, func() bool {
+		return channelClosed(submitCtxDone)
+	}, 80*time.Millisecond, 10*time.Millisecond)
+	cancel()
+	close(parentCanceled)
+	<-submitCheckedAfterCancel
+	close(allowSubmitReturn)
+
+	err := <-errCh
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestJobOrchestratorRecordSubmissionGetsFreshGraceTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/lightning/pkg/importinto/setSubmitGraceTimeout", `return("50ms")`))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/lightning/pkg/importinto/setSubmitGraceTimeout"))
+	})
+
+	mockSubmitter := mockimport.NewMockJobSubmitter(ctrl)
+	mockCpMgr := mockimport.NewMockCheckpointManager(ctrl)
+	mockMonitor := mockimport.NewMockJobMonitor(ctrl)
+	mockSDK := sdkmock.NewMockSDK(ctrl)
+
+	orchestrator := importinto.NewJobOrchestrator(importinto.OrchestratorConfig{
+		Submitter:         mockSubmitter,
+		CheckpointMgr:     mockCpMgr,
+		SDK:               mockSDK,
+		Monitor:           mockMonitor,
+		SubmitConcurrency: 1,
+		PollInterval:      time.Millisecond,
+		Logger:            log.L(),
+	})
+
+	tables := []*importsdk.TableMeta{
+		{Database: "db", Table: "t1", DataFiles: []importsdk.DataFileMeta{{Path: "f1"}}, TotalSize: 100},
+	}
+
+	mockCpMgr.EXPECT().Get(gomock.Any(), common.UniqueTable("db", "t1")).Return(nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	submitStarted := make(chan struct{})
+	parentCanceled := make(chan struct{})
+	submitCheckedAfterCancel := make(chan struct{})
+	allowSubmitReturn := make(chan struct{})
+	updateStarted := make(chan struct{})
+	allowUpdateReturn := make(chan struct{})
+	var submitCtxDone <-chan struct{}
+	var updateCtxDone <-chan struct{}
+	mockSubmitter.EXPECT().SubmitTable(gomock.Any(), gomock.Any()).DoAndReturn(func(submitCtx context.Context, tableMeta *importsdk.TableMeta) (*importinto.ImportJob, error) {
+		submitCtxDone = observeContextDone(submitCtx)
+		close(submitStarted)
+		<-parentCanceled
+		select {
+		case <-submitCtx.Done():
+			return nil, submitCtx.Err()
+		default:
+		}
+		close(submitCheckedAfterCancel)
+		<-allowSubmitReturn
+		return &importinto.ImportJob{
+			JobID:     1,
+			TableMeta: tableMeta,
+			GroupKey:  "group1",
+		}, nil
+	})
+
+	mockCpMgr.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(func(updateCtx context.Context, cp *importinto.TableCheckpoint) error {
+		updateCtxDone = observeContextDone(updateCtx)
+		close(updateStarted)
+		<-allowUpdateReturn
+		select {
+		case <-updateCtx.Done():
+			return updateCtx.Err()
+		default:
+		}
+		require.Equal(t, common.UniqueTable("db", "t1"), cp.TableName)
+		require.Equal(t, int64(1), cp.JobID)
+		require.Equal(t, importinto.CheckpointStatusRunning, cp.Status)
+		require.Equal(t, "group1", cp.GroupKey)
+		return nil
+	})
+	mockMonitor.EXPECT().WaitForJobs(gomock.Any(), gomock.Any()).Return(context.Canceled)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- orchestrator.SubmitAndWait(ctx, tables)
+	}()
+
+	<-submitStarted
+	cancel()
+	close(parentCanceled)
+	<-submitCheckedAfterCancel
+	require.Never(t, func() bool {
+		return channelClosed(submitCtxDone)
+	}, 40*time.Millisecond, 5*time.Millisecond)
+	close(allowSubmitReturn)
+
+	<-updateStarted
+	require.Never(t, func() bool {
+		return channelClosed(updateCtxDone)
+	}, 20*time.Millisecond, 5*time.Millisecond)
+	close(allowUpdateReturn)
+
+	err := <-errCh
 	require.ErrorIs(t, err, context.Canceled)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66721

Problem Summary:
Concurrent detached `IMPORT INTO` submits share one `errgroup` context today. If one submit fails or the caller cancels the batch while another submit is already in flight, the client can return early before it receives the job ID, while TiDB may still create the detached job later. That leaves the job without a recorded checkpoint and can keep the target table in Import mode.

### What changed and how does it work?
- stop using the shared `errgroup` context for submits that have already started
- run started submits on a bounded `context.WithoutCancel(ctx)` child so they can still return a job ID or a real submit error
- use the same bounded submit context to record the running checkpoint once the job is created
- add regressions for sibling submit failure and parent context cancellation

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bounded a grace period for in-flight submissions to ensure reliable checkpoint recording and proper cancellation propagation.
  * Added safer pre-checks and thread-safe accumulation of job state to avoid lost or contested updates during cancellation.

* **Tests**
  * Added tests covering cyclic submission/cancellation, grace-timeout behavior, and fresh-timeout recording.
  * Enabled failpoint-driven timeout control and adjusted test parallelism to exercise timing-sensitive scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->