### PR TITLE
pkg/planner: build multiple logical plans from shared AST in optimize

### DIFF
--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -471,6 +471,8 @@ func buildAndOptimizeLogicalPlanRound(
 	is infoschema.InfoSchema,
 	hintProcessor *hint.QBHintHandler,
 	checked *bool,
+	optimizeStarted *bool,
+	beginOpt *time.Time,
 	needRestoreLogicalPlanCtx bool,
 	bestPlan *base.PhysicalPlan,
 	bestNames *types.NameSlice,
@@ -520,6 +522,10 @@ func buildAndOptimizeLogicalPlanRound(
 	core.RecheckCTE(logic)
 
 	// todo: also you can customize each round's special logical opt flag here (like decorrelate rule or not)
+	if !*optimizeStarted {
+		*optimizeStarted = true
+		*beginOpt = time.Now()
+	}
 	finalPlan, cost, err := core.DoOptimize(ctx, sctx, builder.GetOptFlag(), logic)
 	if err != nil {
 		return nil, nil, false, err
@@ -554,9 +560,14 @@ func optimize(ctx context.Context, sctx planctx.PlanContext, node *resolve.NodeW
 		topsql.MockHighCPULoad(sctx.GetSessionVars().StmtCtx.OriginalSQL, sqlPrefixes, 10)
 	})
 	sessVars := sctx.GetSessionVars()
-	beginOpt := time.Now()
+	var (
+		beginOpt        time.Time
+		optimizeStarted bool
+	)
 	defer func() {
-		sessVars.DurationOptimizer.Total = time.Since(beginOpt)
+		if optimizeStarted {
+			sessVars.DurationOptimizer.Total = time.Since(beginOpt)
+		}
 	}()
 
 	// Build the logical plan from the raw AST. The hint processor only keeps
@@ -590,6 +601,8 @@ func optimize(ctx context.Context, sctx planctx.PlanContext, node *resolve.NodeW
 			is,
 			hintProcessor,
 			&checked,
+			&optimizeStarted,
+			&beginOpt,
 			needRestoreLogicalPlanCtx,
 			&bestPlan,
 			&bestNames,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #66651

Problem Summary:

This PR implements step 2 of #66651.
Step 1 has already been merged; this step adds the actual multi-build flow in `Optimize` for rebuilding logical plans from a shared AST.

### What changed and how does it work?

- Add multi-round logical-plan build flow in `pkg/planner/optimize.go`.
- Keep privilege/table-lock checks fail-fast after the first successful build round.
- Keep hint-processor AST metadata shared/read-only, and move per-build mutable hint state into `PlanBuilder`.
- Isolate per-round mutable session/statement planner state with baseline save/restore only when restore is needed.
- Keep non-logical-plan behavior compatible with existing flow.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test command:

- `go test -run TestOptimizeHintOnPartitionTable -tags=intest,deadlock ./pkg/planner/core/casetest/hint`

Additional validation:

- `make bazel_lint_changed`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Optimizer now runs multi-round plan selection, choosing the best plan across rounds for more consistent, efficient query execution.
  * Added timing instrumentation to report optimizer durations and help surface slow planning steps.

* **Reliability**
  * Restores per-round planner state when selecting the best plan to avoid regressions between rounds.
  * Adds error handling and cleanup when no valid plan can be produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->