### PR TITLE
pkg/session/test/txn: increase txn_test timeout budget to moderate

### DIFF
--- a/pkg/session/test/txn/BUILD.bazel
+++ b/pkg/session/test/txn/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "txn_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "main_test.go",
         "txn_test.go",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66040

Problem Summary:
`//pkg/session/test/txn:txn_test` is configured with `timeout = "short"` (150s in CI), while shard `2/11` repeatedly runs close to that limit due to `TestTxnLazyInitialize` taking ~112-126s in race+coverage mode. This causes flaky timeout failures after test logic passes.

### What changed and how does it work?
- Updated `pkg/session/test/txn/BUILD.bazel` to set `txn_test` timeout from `short` to `moderate`.
- This increases the allowed execution budget for the slow shard so retries are less likely to fail on timeout when tests themselves pass.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > - [x] Change is Bazel test timeout metadata only (`BUILD.bazel`).

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test timeout configuration to improve execution stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->