### PR TITLE
br/pkg/streamhelper: fix flaky TestGCServiceSafePoint assertion

### DIFF
--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -209,6 +209,9 @@ func TestGCServiceSafePoint(t *testing.T) {
 
 	req.NoError(adv.OnTick(ctx))
 	req.Equal(env.serviceGCSafePoint, cp-1)
+	env.fakeCluster.mu.Lock()
+	req.True(env.serviceGCSafePointSet)
+	env.fakeCluster.mu.Unlock()
 
 	env.unregisterTask()
 	req.Eventually(func() bool {

--- a/br/pkg/streamhelper/basic_lib_for_test.go
+++ b/br/pkg/streamhelper/basic_lib_for_test.go
@@ -108,6 +108,7 @@ type fakeCluster struct {
 	onGetClient               func(uint64) error
 	onClearCache              func(uint64) error
 	serviceGCSafePoint        uint64
+	serviceGCSafePointSet     bool
 	serviceGCSafePointDeleted bool
 	currentTS                 uint64
 }
@@ -279,6 +280,7 @@ func (f *fakeCluster) BlockGCUntil(ctx context.Context, at uint64) (uint64, erro
 		return f.serviceGCSafePoint, errors.Errorf("minimal safe point %d is greater than the target %d", f.serviceGCSafePoint, at)
 	}
 	f.serviceGCSafePoint = at
+	f.serviceGCSafePointSet = true
 	return at, nil
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66731

Problem Summary:

`TestGCServiceSafePoint` in `br/pkg/streamhelper` is flaky because it waits for `serviceGCSafePoint != 0` after task removal. In this test setup, `cp` can be `1`, so `cp-1` is validly `0`, causing intermittent false failures.

### What changed and how does it work?

- Updated `TestGCServiceSafePoint` to wait only for `serviceGCSafePointDeleted` after unregistering the task.
- Kept the existing earlier assertion `serviceGCSafePoint == cp-1`, so the safe point value is still verified.

This removes the nondeterministic `!= 0` condition while preserving the intended behavior checks.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > - [x] Test-only assertion update for flaky behavior; no production logic changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified retry assertion for clarity and added a focused check to verify the GC safe-point is marked as set after the tick.
  * Added a test-only flag to track when the service GC safe-point is updated, improving test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->