### PR TITLE
pkg/executor, pkg/kv, pkg/store: propagate SQL digest for MPP task metadata

### DIFF
--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -209,11 +209,21 @@ func (c *localMppCoordinator) appendMPPDispatchReq(pf *physicalop.Fragment, allT
 	}
 	zoneHelper := taskZoneInfoHelper{}
 	zoneHelper.init(allTiFlashZoneInfo)
+	_, stmtDigest := c.sessionCtx.GetSessionVars().StmtCtx.SQLDigest()
+	sqlDigest := ""
+	if stmtDigest != nil {
+		sqlDigest = stmtDigest.String()
+	}
+	_, planDigest := c.sessionCtx.GetSessionVars().StmtCtx.GetPlanDigest()
+	planDigestStr := ""
+	if planDigest != nil {
+		planDigestStr = planDigest.String()
+	}
 	for _, mppTask := range pf.Sink.GetSelfTasks() {
 		if mppTask.PartitionTableIDs != nil {
 			err = util.UpdateExecutorTableID(context.Background(), dagReq.RootExecutor, true, mppTask.PartitionTableIDs)
 		} else if !mppTask.TiFlashStaticPrune {
-			// If isDisaggregatedTiFlashStaticPrune is true, it means this TableScan is under PartitionUnoin,
+			// If isDisaggregatedTiFlashStaticPrune is true, it means this TableScan is under PartitionUnion,
 			// tableID in TableScan is already the physical table id of this partition, no need to update again.
 			err = util.UpdateExecutorTableID(context.Background(), dagReq.RootExecutor, true, []int64{mppTask.TableID})
 		}
@@ -244,6 +254,8 @@ func (c *localMppCoordinator) appendMPPDispatchReq(pf *physicalop.Fragment, allT
 			zap.String("exchange-compression-mode", pf.Sink.GetCompressionMode().Name()),
 			zap.Uint64("GatherID", c.gatherID),
 			zap.String("resource_group", rgName),
+			zap.String("sqlDigest", sqlDigest),
+			zap.String("planDigest", planDigestStr),
 		)
 		req := &kv.MPPDispatchRequest{
 			Data:                   pbData,
@@ -262,6 +274,8 @@ func (c *localMppCoordinator) appendMPPDispatchReq(pf *physicalop.Fragment, allT
 			ResourceGroupName:      rgName,
 			ConnectionID:           c.sessionCtx.GetSessionVars().ConnectionID,
 			ConnectionAlias:        c.sessionCtx.ShowProcess().SessionAlias,
+			SQLDigest:              sqlDigest,
+			PlanDigest:             planDigestStr,
 		}
 		c.reqMap[req.ID] = &mppRequestReport{mppReq: req, receivedReport: false, errMsg: "", executionSummaries: nil}
 		c.mppReqs = append(c.mppReqs, req)
@@ -606,14 +620,14 @@ func (c *localMppCoordinator) handleDispatchReq(ctx context.Context, bo *backoff
 			})
 		if retry {
 			// TODO: If we want to retry, we might need to redo the plan fragment cutting and task scheduling. https://github.com/pingcap/tidb/issues/31015
-			logutil.BgLogger().Warn("mpp dispatch meet error and retrying", zap.Error(err), zap.Uint64("timestamp", c.startTS), zap.Int64("task", req.ID), zap.Int64("mpp-version", req.MppVersion.ToInt64()))
+			logutil.BgLogger().Warn("mpp dispatch meet error and retrying", zap.Error(err), zap.Uint64("timestamp", c.startTS), zap.Int64("task", req.ID), zap.Int64("mpp-version", req.MppVersion.ToInt64()), zap.String("sqlDigest", req.SQLDigest), zap.String("planDigest", req.PlanDigest))
 			continue
 		}
 		break
 	}
 
 	if err != nil {
-		logutil.BgLogger().Warn("mpp dispatch meet error", zap.String("error", err.Error()), zap.Uint64("timestamp", req.StartTs), zap.Int64("task", req.ID), zap.Int64("mpp-version", req.MppVersion.ToInt64()))
+		logutil.BgLogger().Warn("mpp dispatch meet error", zap.String("error", err.Error()), zap.Uint64("timestamp", req.StartTs), zap.Int64("task", req.ID), zap.Int64("mpp-version", req.MppVersion.ToInt64()), zap.String("sqlDigest", req.SQLDigest), zap.String("planDigest", req.PlanDigest))
 		atomic.CompareAndSwapUint32(&c.dispatchFailed, 0, 1)
 		// if NeedTriggerFallback is true, we return timeout to trigger tikv's fallback
 		if c.needTriggerFallback {
@@ -624,7 +638,7 @@ func (c *localMppCoordinator) handleDispatchReq(ctx context.Context, bo *backoff
 	}
 
 	if rpcResp.Error != nil {
-		logutil.BgLogger().Warn("mpp dispatch response meet error", zap.String("error", rpcResp.Error.Msg), zap.Uint64("timestamp", req.StartTs), zap.Int64("task", req.ID), zap.Int64("task-mpp-version", req.MppVersion.ToInt64()), zap.Int64("error-mpp-version", rpcResp.Error.GetMppVersion()))
+		logutil.BgLogger().Warn("mpp dispatch response meet error", zap.String("error", rpcResp.Error.Msg), zap.Uint64("timestamp", req.StartTs), zap.Int64("task", req.ID), zap.Int64("task-mpp-version", req.MppVersion.ToInt64()), zap.Int64("error-mpp-version", rpcResp.Error.GetMppVersion()), zap.String("sqlDigest", req.SQLDigest), zap.String("planDigest", req.PlanDigest))
 		atomic.CompareAndSwapUint32(&c.dispatchFailed, 0, 1)
 		c.sendError(errors.New(rpcResp.Error.Msg))
 		return
@@ -645,6 +659,8 @@ func (c *localMppCoordinator) handleDispatchReq(ctx context.Context, bo *backoff
 		Address:           req.Meta.GetAddress(),
 		MppVersion:        req.MppVersion.ToInt64(),
 		ResourceGroupName: req.ResourceGroupName,
+		SqlDigest:         req.SQLDigest,
+		PlanDigest:        req.PlanDigest,
 	}
 	c.receiveResults(req, taskMeta, bo)
 }

--- a/pkg/kv/mpp.go
+++ b/pkg/kv/mpp.go
@@ -162,6 +162,8 @@ type MPPDispatchRequest struct {
 	ResourceGroupName      string
 	ConnectionID           uint64
 	ConnectionAlias        string
+	SQLDigest              string
+	PlanDigest             string
 }
 
 // CancelMPPTasksParam represents parameter for MPPClient's CancelMPPTasks
@@ -242,7 +244,7 @@ type MPPBuildTasksRequest struct {
 // ToString returns a string representation of MPPBuildTasksRequest. Used for CacheKey.
 func (req *MPPBuildTasksRequest) ToString() string {
 	sb := strings.Builder{}
-	if req.KeyRanges != nil { // Non-partiton
+	if req.KeyRanges != nil { // Non-partition
 		for i, keyRange := range req.KeyRanges {
 			sb.WriteString("range_id" + strconv.Itoa(i))
 			sb.WriteString(keyRange.StartKey.String())

--- a/pkg/store/copr/mpp.go
+++ b/pkg/store/copr/mpp.go
@@ -111,6 +111,8 @@ func (c *MPPClient) DispatchMPPTask(param kv.DispatchMPPTaskParam) (resp *mpp.Di
 		ResourceGroupName:      req.ResourceGroupName,
 		ConnectionId:           req.ConnectionID,
 		ConnectionAlias:        req.ConnectionAlias,
+		SqlDigest:              req.SQLDigest,
+		PlanDigest:             req.PlanDigest,
 	}
 
 	mppReq := &mpp.DispatchTaskRequest{
@@ -200,7 +202,7 @@ func (c *MPPClient) CancelMPPTasks(param kv.CancelMPPTasksParam) {
 
 	firstReq := reqs[0]
 	killReq := &mpp.CancelTaskRequest{
-		Meta: &mpp.TaskMeta{StartTs: firstReq.StartTs, GatherId: firstReq.GatherID, QueryTs: firstReq.MppQueryID.QueryTs, LocalQueryId: firstReq.MppQueryID.LocalQueryID, ServerId: firstReq.MppQueryID.ServerID, MppVersion: firstReq.MppVersion.ToInt64(), ResourceGroupName: firstReq.ResourceGroupName},
+		Meta: &mpp.TaskMeta{StartTs: firstReq.StartTs, GatherId: firstReq.GatherID, QueryTs: firstReq.MppQueryID.QueryTs, LocalQueryId: firstReq.MppQueryID.LocalQueryID, ServerId: firstReq.MppQueryID.ServerID, MppVersion: firstReq.MppVersion.ToInt64(), ResourceGroupName: firstReq.ResourceGroupName, SqlDigest: firstReq.SQLDigest, PlanDigest: firstReq.PlanDigest},
 	}
 
 	wrappedReq := tikvrpc.NewRequest(tikvrpc.CmdMPPCancel, killReq, kvrpcpb.Context{})
@@ -244,6 +246,8 @@ func (c *MPPClient) EstablishMPPConns(param kv.EstablishMPPConnsParam) (*tikvrpc
 			MppVersion:        req.MppVersion.ToInt64(),
 			TaskId:            -1,
 			ResourceGroupName: req.ResourceGroupName,
+			SqlDigest:         req.SQLDigest,
+			PlanDigest:        req.PlanDigest,
 		},
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #66762

* rely on https://github.com/pingcap/kvproto/pull/1428
* tiflash PR: https://github.com/pingcap/tiflash/pull/10735

Problem Summary:
Short MPP queries (below slow log threshold) are hard to correlate between TiDB dispatch logs and TiFlash task logs because SQL digest is not propagated in `mpp.TaskMeta`.

### What changed and how does it work?

- Add `SQLDigest` to `kv.MPPDispatchRequest`.
- Extract digest from `StmtCtx.SQLDigest()` in local MPP coordinator, log it in dispatch/retry/error paths, and carry it in dispatch requests.
- Populate `TaskMeta.SqlDigest` in TiDB MPP client for dispatch/cancel/establish connection request metadata.
- Update module wiring to consume the kvproto change (temporary `replace` to the branch containing `TaskMeta.sql_digest`) and refresh Bazel dependency metadata via `make bazel_prepare`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Validation commands run:
- `go test ./pkg/kv -run TestNonExistent`
- `go test ./pkg/store/copr -run TestNonExistent`
- `go test ./pkg/executor/internal/mpp -run TestNonExistent`
- `make lint`
- `make bazel_prepare` (with writable local Bazel cache/output paths in this environment)

Before this PR
```
# tidb.log
[2026/03/07 17:01:43.356 +08:00] [INFO] [local_mpp_coordinator.go:222] ["Dispatch mpp task"] [timestamp=464748308917911554] [ID=1] [QueryTs=1772874103272248530] [LocalQueryId=2] [ServerID=1445] [address=10.2.12.81:3930] [plan="Table(generic_entity)->Sel([eq(test.generic_entity.type_code, CNY) or(ne(test.generic_entity.attr_id_1, ), ne(test.generic_entity.attr_id_2, ))])->Send(-1, )"] [mpp-version=2] [exchange-compression-mode=NONE] [GatherID=1] [resource_group=default]
# tiflash.log
[2026/03/07 17:01:43.369 +08:00] [INFO] [MPPTaskStatistics.cpp:139] ["{\"query_tso\":464748308917911554,\"task_id\":1,\"is_root\":true,\"sender_executor_id\":\"ExchangeSender_18\",\"executors\":[...],...,"status\":\"FINISHED\",\"error_message\":\"\",\"cpu_ru\":0.6666666666666666,\"read_ru\":0.1273956298828125,\"memory_peak\":3059904,..."] [source="mpp_task_tracing MPP<gather_id:1, query_ts:1772874103272248530, local_query_id:2, server_id:1445, start_ts:464748308917911554,task_id:1>"] [thread_id=191]
```

After this PR, the sql digest is added to the logging
```
# tidb.log
[2026/03/08 14:41:45.458 +08:00] [INFO] [local_mpp_coordinator.go:244] ["Dispatch mpp task"] [timestamp=464768756710113282] [ID=1] [QueryTs=1772952105388643615] [LocalQueryId=2] [ServerID=1727] [address=10.2.12.81:3930] [plan="Table(generic_entity)->Sel([eq(test.generic_entity.type_code, CNY) or(ne(test.generic_entity.attr_id_1, ), ne(test.generic_entity.attr_id_2, ))])->Send(-1, )"] [mpp-version=3] [exchange-compression-mode=NONE] [GatherID=1] [resource_group=default] [sqlDigest=212e2a5dbe2a960ed1eb83e179cf830acfa105fe40a941c49699002fca309e74]
# tiflash.log
[2026/03/08 14:41:45.619 +08:00] [INFO] [MPPTaskStatistics.cpp:146] ["{\"query_tso\":464768756710113282,\"task_id\":1,\"is_root\":true,\"sender_executor_id\":\"ExchangeSender_19\",\"executors\":[...],...,\"connection_id\":3621781510,\"connection_alias\":\"\",\"sql_digest\":\"212e2a5dbe2a960ed1eb83e179cf830acfa105fe40a941c49699002fca309e74\",...\"status\":\"FINISHED\",\"error_message\":\"\",\"cpu_ru\":1,\"read_ru\":0.1273956298828125,\"memory_peak\":3060307,..."] [source="mpp_task_tracing MPP<gather_id:1, query_ts:1772952105388643615, local_query_id:2, server_id:1727, start_ts:464768756710113282,task_id:1>"] [thread_id=172]
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Enhance MPP observability by propagating SQL digest in TiDB MPP task metadata and related dispatch logs.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query execution now propagates SQL and plan digests across distributed execution paths for improved tracking and diagnostics.
  * Logs expanded to include these diagnostic identifiers for better troubleshooting and visibility.

* **Chores**
  * Updated a vendored dependency to a newer version with refreshed source metadata and checksum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->