### PR TITLE
executor: normalize tidb_service_scope when updating dist meta

### DIFF
--- a/pkg/executor/set.go
+++ b/pkg/executor/set.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
@@ -192,19 +191,16 @@ func (e *SetExecutor) setSysVariable(ctx context.Context, name string, v *expres
 		logutil.BgLogger().Info(logstr, zap.Uint64("conn", sessionVars.ConnectionID), zap.String("name", name), zap.String("val", showValStr))
 		if name == vardef.TiDBServiceScope {
 			dom := domain.GetDomain(e.Ctx())
-			oldConfig := config.GetGlobalConfig()
-			if oldConfig.Instance.TiDBServiceScope != valStr {
-				newConfig := *oldConfig
-				newConfig.Instance.TiDBServiceScope = valStr
-				config.StoreGlobalConfig(&newConfig)
-			}
+			// SetInstanceSysVar has already updated vardef.ServiceScope in the sysvar hook.
+			// Read it here so InitMetaSession uses the latest canonical (case-insensitive) value.
+			serviceScope := vardef.ServiceScope.Load()
 			serverID := disttaskutil.GenerateSubtaskExecID(ctx, dom.DDL().GetID())
 			taskMgr, err := storage.GetTaskManager()
 			if err != nil {
 				return err
 			}
 			return taskMgr.WithNewSession(func(se sessionctx.Context) error {
-				return taskMgr.InitMetaSession(ctx, se, serverID, valStr)
+				return taskMgr.InitMetaSession(ctx, se, serverID, serviceScope)
 			})
 		}
 		return err

--- a/pkg/executor/set_test.go
+++ b/pkg/executor/set_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/expression"
@@ -1816,4 +1817,28 @@ func TestDivPrecisionIncrement(t *testing.T) {
 
 	// Test set global.
 	tk.MustExec("set global div_precision_increment = 4")
+}
+
+func TestSetTiDBServiceScopeCaseInsensitive(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	originConfig := config.GetGlobalConfig()
+	originServiceScope := vardef.ServiceScope.Load()
+	t.Cleanup(func() {
+		config.StoreGlobalConfig(originConfig)
+		vardef.ServiceScope.Store(originServiceScope)
+	})
+
+	tk.MustExec("set global tidb_service_scope='BaCkGround'")
+	tk.MustQuery("select @@global.tidb_service_scope").Check(testkit.Rows("background"))
+	require.Equal(t, "background", vardef.ServiceScope.Load())
+	require.Equal(t, "background", config.GetGlobalConfig().Instance.TiDBServiceScope)
+	tk.MustQuery("select role from mysql.dist_framework_meta where host=':4000'").Check(testkit.Rows("background"))
+
+	tk.MustExec("set instance tidb_service_scope='BackGround'")
+	tk.MustQuery("select @@global.tidb_service_scope").Check(testkit.Rows("background"))
+	require.Equal(t, "background", vardef.ServiceScope.Load())
+	require.Equal(t, "background", config.GetGlobalConfig().Instance.TiDBServiceScope)
+	tk.MustQuery("select role from mysql.dist_framework_meta where host=':4000'").Check(testkit.Rows("background"))
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66749

Problem Summary:
`tidb_service_scope` is case-insensitive by design, but `SET GLOBAL/INSTANCE tidb_service_scope='BaCkGround'` could still write mixed-case values into `config.Instance.TiDBServiceScope` and `mysql.dist_framework_meta.role` through an extra executor write path. This caused inconsistent state between canonical sysvar value (`background`) and dist meta/config.

### What changed and how does it work?
- Removed the duplicate raw-case overwrite in `pkg/executor/set.go` for `tidb_service_scope`.
- In the `tidb_service_scope` executor branch, use `vardef.ServiceScope.Load()` (already updated by sysvar hook) as the canonical value when calling `InitMetaSession`.
- Added regression test `TestSetTiDBServiceScopeCaseInsensitive` in `pkg/executor/set_test.go` to verify both `SET GLOBAL` and `SET INSTANCE` keep:
  - `@@global.tidb_service_scope = background`
  - `vardef.ServiceScope = background`
  - `config.Instance.TiDBServiceScope = background`
  - `mysql.dist_framework_meta.role = background`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:
- `go test ./pkg/executor -run TestSetTiDBServiceScopeCaseInsensitive -count=1 -tags=intest,deadlock`
- `make failpoint-enable && (pushd pkg/executor >/dev/null; go test -run TestSetTiDBServiceScopeCaseInsensitive -tags=intest,deadlock -count=1; rc=$?; popd >/dev/null; make failpoint-disable; exit $rc)`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix inconsistent case handling for `tidb_service_scope` so `SET GLOBAL/INSTANCE` keeps canonical scope values in TiDB config and dist framework meta.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced TiDB service scope management with improved internal tracking of configuration values

* **Tests**
  * Added comprehensive test validation for case-insensitive tidb_service_scope handling across global and instance-level settings, including role assignment verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->