### PR TITLE
executor/join, util/hack: stabilize concurrent map memory usage tests

### DIFF
--- a/pkg/executor/join/concurrent_map.go
+++ b/pkg/executor/join/concurrent_map.go
@@ -16,6 +16,7 @@ package join
 
 import (
 	"github.com/pingcap/tidb/pkg/util/hack"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/syncutil"
 )
 
@@ -38,6 +39,9 @@ func newConcurrentMap() concurrentMap {
 	for i := range ShardCount {
 		m[i] = &concurrentMapShared{}
 		m[i].items.Init(make(map[uint64]*entry))
+		if intest.InTest {
+			m[i].items.MockSeedForTest()
+		}
 	}
 	return m
 }

--- a/pkg/executor/join/concurrent_map_test.go
+++ b/pkg/executor/join/concurrent_map_test.go
@@ -71,7 +71,6 @@ func TestConcurrentMapMemoryUsage(t *testing.T) {
 	m := newConcurrentMap()
 	memUsage := int64(0)
 	for _, s := range m {
-		s.items.MockSeedForTest(4992862800126241206)
 		memUsage += int64(s.items.Bytes)
 	}
 	var iterations = 1024 * 10

--- a/pkg/util/hack/map_abi.go
+++ b/pkg/util/hack/map_abi.go
@@ -318,9 +318,13 @@ type MemAwareMap[K comparable, V any] struct {
 	Bytes          uint64
 }
 
-// MockSeedForTest sets the seed of the swissMap inside MemAwareMap
-func (m *MemAwareMap[K, V]) MockSeedForTest(seed uint64) (oriSeed uint64) {
-	return m.unwrap().MockSeedForTest(seed)
+const mockSeedForTest = 4992862800126241206
+
+// MockSeedForTest sets the seed of the swissMap for testing.
+// It should only be used in tests and should not be called on maps that are already in use, as it may cause issues with map operations.
+// The map should be empty before calling this function.
+func (m *MemAwareMap[K, V]) MockSeedForTest() {
+	m.unwrap().MockSeedForTest(mockSeedForTest)
 }
 
 // MockSeedForTest sets the seed of the swissMap

--- a/pkg/util/hack/map_abi_go126.go
+++ b/pkg/util/hack/map_abi_go126.go
@@ -318,9 +318,13 @@ type MemAwareMap[K comparable, V any] struct {
 	Bytes          uint64
 }
 
-// MockSeedForTest sets the seed of the map internals inside MemAwareMap.
-func (m *MemAwareMap[K, V]) MockSeedForTest(seed uint64) (oriSeed uint64) {
-	return m.unwrap().MockSeedForTest(seed)
+const mockSeedForTest = 4992862800126241206
+
+// MockSeedForTest sets the seed of the swissMap for testing.
+// It should only be used in tests and should not be called on maps that are already in use, as it may cause issues with map operations.
+// The map should be empty before calling this function.
+func (m *MemAwareMap[K, V]) MockSeedForTest() {
+	m.unwrap().MockSeedForTest(mockSeedForTest)
 }
 
 // MockSeedForTest sets the seed of the map internals.

--- a/pkg/util/hack/map_abi_test.go
+++ b/pkg/util/hack/map_abi_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const seed = 4992862800126241206 // set the fixed seed for test
-
 func TestSwissTable(t *testing.T) {
 	require.True(t, maxTableCapacity == 1024)
 	{
@@ -67,7 +65,7 @@ func TestSwissTable(t *testing.T) {
 		const N = 1024
 		mp := make(map[uint64]uint64)
 		sm := ToSwissMap(mp)
-		sm.Data.MockSeedForTest(seed)
+		sm.Data.MockSeedForTest(mockSeedForTest)
 		mp[1234] = 5678
 		for i := range N {
 			mp[uint64(i)] = uint64(i * 2)
@@ -109,7 +107,7 @@ func TestSwissTable(t *testing.T) {
 		const N = 2000
 		mp := make(map[string]int)
 		sm := ToSwissMap(mp)
-		sm.Data.MockSeedForTest(seed)
+		sm.Data.MockSeedForTest(mockSeedForTest)
 		for i := range N {
 			mp[fmt.Sprintf("key-%d", i)] = i
 		}
@@ -123,7 +121,7 @@ func TestSwissTable(t *testing.T) {
 		mp := make(map[int]int)
 		require.Equal(t, 0, len(mp))
 		sm := ToSwissMap(mp)
-		sm.Data.MockSeedForTest(seed)
+		sm.Data.MockSeedForTest(mockSeedForTest)
 		require.Equal(t, 0, int(sm.Data.Used))
 		require.True(t, sm.Type.GroupSize == 136)
 		require.Equal(t, 184, int(sm.Size()))
@@ -142,7 +140,7 @@ func TestSwissTable(t *testing.T) {
 		m := MemAwareMap[complex128, complex128]{}
 		const N = 1024*50 - 1
 		delta := m.Init(mp)
-		m.MockSeedForTest(seed)
+		m.MockSeedForTest()
 		for i := range N {
 			k := complex(float64(i), float64(i))
 			d := m.Set(k, k)
@@ -158,16 +156,16 @@ func TestSwissTable(t *testing.T) {
 		require.True(t, sz == 2165296, sz)
 		require.True(t, delta == 2702278, delta)
 		require.True(t, delta == int64(m.Bytes))
-		require.True(t, seed == m.unwrap().seed)
+		require.True(t, mockSeedForTest == m.unwrap().seed)
 		clearSeq := m.unwrap().clearSeq
 		clear(m.M)
 		require.True(t, m.Len() == 0)
 		require.True(t, clearSeq+1 == m.unwrap().clearSeq)
-		require.True(t, m.unwrap().seed != seed)
+		require.True(t, m.unwrap().seed != mockSeedForTest)
 		require.True(t, sz == m.RealBytes())
 		require.True(t, delta == int64(m.Bytes))
 
-		m.MockSeedForTest(seed)
+		m.MockSeedForTest()
 		for i := range 1024 {
 			k := complex(float64(i), float64(i))
 			d, insert := m.SetExt(k, k)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66725

Problem Summary:

`TestConcurrentMapHashTableMemoryUsage` in `pkg/executor/join` is flaky because the test asserts exact memory usage, while the underlying `MemAwareMap` layout depends on Go map seed randomness. That makes the initial memory footprint nondeterministic in test runs.

### What changed and how does it work?

This PR makes the concurrent map memory-usage tests deterministic by fixing the map seed in test mode.

- Initialize each shard map in `newConcurrentMap()` with a fixed test seed when `intest.InTest` is enabled.
- Move the fixed seed into `pkg/util/hack` as a shared test-only constant.
- Simplify `MemAwareMap.MockSeedForTest()` to use the shared fixed seed directly.
- Keep the safety check that `MockSeedForTest` can only be called on an empty map.
- Remove the per-test manual seed setup in `TestConcurrentMapMemoryUsage`, since the constructor now handles it consistently.

This keeps production behavior unchanged and only stabilizes test-time memory layout.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

```bash
go test ./pkg/executor/join -run TestConcurrentMapHashTableMemoryUsage -tags=intest,deadlock -count=20
go test ./pkg/executor/join -run TestConcurrentMapMemoryUsage -tags=intest,deadlock -count=20
go test ./pkg/util/hack -run TestSwissTable -tags=intest,deadlock -count=5
```

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified test seeding mechanism for internal map structures by standardizing on a fixed internal seed constant rather than accepting variable parameters, streamlining testing infrastructure.

* **Tests**
  * Updated test implementations to align with refined seeding approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->