### PR TITLE
planner: block UPDATE/DELETE on mview/mlog via point-get fast path

### DIFF
--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -2012,6 +2012,19 @@ func tryUpdatePointPlan(ctx base.PlanContext, updateStmt *ast.UpdateStmt, resolv
 		return nil
 	}
 
+	tblName, tblAlias := getSingleTableNameAndAlias(updateStmt.TableRefs)
+	if tblName == nil {
+		return nil
+	}
+	// tnW might be nil, in some ut, query is directly 'optimized' without pre-process
+	tnW := resolveCtx.GetTableName(tblName)
+	if tnW == nil {
+		return nil
+	}
+	if CheckMViewUpdatable(ctx.GetSessionVars(), tnW.TableInfo, tblAlias.O, "UPDATE") != nil {
+		return nil
+	}
+
 	selStmt := &ast.SelectStmt{
 		TableHints: updateStmt.TableHints,
 		Fields:     &ast.FieldList{},
@@ -2144,6 +2157,20 @@ func tryDeletePointPlan(ctx base.PlanContext, delStmt *ast.DeleteStmt, resolveCt
 	if delStmt.IsMultiTable {
 		return nil
 	}
+
+	tblName, tblAlias := getSingleTableNameAndAlias(delStmt.TableRefs)
+	if tblName == nil {
+		return nil
+	}
+	// tnW might be nil, in some ut, query is directly 'optimized' without pre-process
+	tnW := resolveCtx.GetTableName(tblName)
+	if tnW == nil {
+		return nil
+	}
+	if CheckMViewUpdatable(ctx.GetSessionVars(), tnW.TableInfo, tblAlias.O, "DELETE") != nil {
+		return nil
+	}
+
 	selStmt := &ast.SelectStmt{
 		TableHints: delStmt.TableHints,
 		Fields:     &ast.FieldList{},

--- a/tests/integrationtest/r/executor/mview_log_dml.result
+++ b/tests/integrationtest/r/executor/mview_log_dml.result
@@ -150,6 +150,14 @@ update `$mlog$t` set a=1;
 Error 1288 (HY000): The target table $mlog$t of the UPDATE is not updatable
 delete from `$mlog$t`;
 Error 1288 (HY000): The target table $mlog$t of the DELETE is not updatable
+update `$mlog$t` set b=1 where _tidb_rowid=1;
+Error 1288 (HY000): The target table $mlog$t of the UPDATE is not updatable
+delete from `$mlog$t` where _tidb_rowid=1;
+Error 1288 (HY000): The target table $mlog$t of the DELETE is not updatable
+update `$mlog$t` set b=1 where _tidb_rowid in (1, 2);
+Error 1288 (HY000): The target table $mlog$t of the UPDATE is not updatable
+delete from `$mlog$t` where _tidb_rowid in (1, 2);
+Error 1288 (HY000): The target table $mlog$t of the DELETE is not updatable
 select * from `$mlog$t`;
 a	b	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 drop table if exists t;
@@ -164,6 +172,14 @@ Error 1288 (HY000): The target table v of the REPLACE is not updatable
 update v set s=1;
 Error 1288 (HY000): The target table v of the UPDATE is not updatable
 delete from v;
+Error 1288 (HY000): The target table v of the DELETE is not updatable
+update v set s=1 where a=1;
+Error 1288 (HY000): The target table v of the UPDATE is not updatable
+delete from v where a=1;
+Error 1288 (HY000): The target table v of the DELETE is not updatable
+update v set s=1 where a in (1, 2);
+Error 1288 (HY000): The target table v of the UPDATE is not updatable
+delete from v where a in (1, 2);
 Error 1288 (HY000): The target table v of the DELETE is not updatable
 drop materialized view v;
 drop table if exists t;

--- a/tests/integrationtest/t/executor/mview_log_dml.test
+++ b/tests/integrationtest/t/executor/mview_log_dml.test
@@ -135,6 +135,16 @@ replace into `$mlog$t` values (1, 2, 'I', 1);
 update `$mlog$t` set a=1;
 --error 1288
 delete from `$mlog$t`;
+# Point-get UPDATE/DELETE on mlog table should also be rejected
+--error 1288
+update `$mlog$t` set b=1 where _tidb_rowid=1;
+--error 1288
+delete from `$mlog$t` where _tidb_rowid=1;
+# Batch point-get UPDATE/DELETE on mlog table should also be rejected
+--error 1288
+update `$mlog$t` set b=1 where _tidb_rowid in (1, 2);
+--error 1288
+delete from `$mlog$t` where _tidb_rowid in (1, 2);
 select * from `$mlog$t`;
 
 # Explicit DML on materialized view table should be rejected
@@ -151,6 +161,16 @@ replace into v values (1, 10, 1);
 update v set s=1;
 --error 1288
 delete from v;
+# Point-get UPDATE/DELETE on materialized view should also be rejected
+--error 1288
+update v set s=1 where a=1;
+--error 1288
+delete from v where a=1;
+# Batch point-get UPDATE/DELETE on materialized view should also be rejected
+--error 1288
+update v set s=1 where a in (1, 2);
+--error 1288
+delete from v where a in (1, 2);
 drop materialized view v;
 
 # Prepared DML on mlog table should be rejected


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->
Issue Number: close #66779

Problem Summary:

UPDATE/DELETE with point-get eligible WHERE clauses (e.g. `UPDATE v SET s=1 WHERE a=1`) bypass `CheckMViewUpdatable` because `TryFastPlan` returns a physical plan directly, skipping logical plan building. Since mview tables always have a PK or unique index, this is the common case in practice.

### What changed and how does it work?

Add the mview/mlog check to `tryUpdatePointPlan` and `tryDeletePointPlan` so they return nil and fall back to the normal optimization path, which returns `ErrNonUpdatableTable`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation checks for UPDATE and DELETE operations on materialized view logs. Operations on non-updatable tables are now properly rejected with appropriate error messages, improving reliability and preventing unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->