### PR TITLE
statistics: avoid duplicate stats_histograms insert after analyze all columns

### DIFF
--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -32,7 +32,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 25,
+    shard_count = 24,
     deps = [
         ":ddl",
         "//pkg/meta/model",

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -1540,50 +1540,14 @@ func TestDumpStatsDeltaBeforeHandleAddColumnEvent(t *testing.T) {
 	// Insert some data.
 	testKit.MustExec("insert into t values (1, 2), (2, 3), (3, 4)")
 	testKit.MustExec("analyze table t predicate columns")
-	// Add column.
-	testKit.MustExec("alter table t add column c10 int")
+	// Add null column.
+	testKit.MustExec("alter table t add column c3 int")
 	// Insert some data.
 	testKit.MustExec("insert into t values (4, 5, 6)")
-	// Analyze all columns to force creating stats for the newly added column before the DDL event is consumed.
-	testKit.MustExec("analyze table t all columns")
-	metaBefore := testKit.MustQuery(`
-		select version, last_stats_histograms_version
-		from mysql.stats_meta
-		where table_id = (
-			select tidb_table_id
-			from information_schema.tables
-			where table_schema = 'test' and table_name = 't'
-		)
-	`).Rows()
-	require.Len(t, metaBefore, 1)
-	// Find the add column event.
-	event := statstestutil.FindEvent(do.StatsHandle().DDLEventCh(), model.ActionAddColumn)
-	err := statstestutil.HandleDDLEventWithTxn(do.StatsHandle(), event)
-	require.NoError(t, err)
-	metaAfter := testKit.MustQuery(`
-		select version, last_stats_histograms_version
-		from mysql.stats_meta
-		where table_id = (
-			select tidb_table_id
-			from information_schema.tables
-			where table_schema = 'test' and table_name = 't'
-		)
-	`).Rows()
-	require.Equal(t, metaBefore, metaAfter)
-}
-
-func TestDumpStatsDeltaBeforeHandleAddNotNullColumnEvent(t *testing.T) {
-	store, do := testkit.CreateMockStoreAndDomain(t)
-	testKit := testkit.NewTestKit(t, store)
-	testKit.MustExec("use test")
-	testKit.MustExec("create table t (c1 int, c2 int, index idx(c1, c2))")
-	// Insert some data.
-	testKit.MustExec("insert into t values (1, 2), (2, 3), (3, 4)")
-	testKit.MustExec("analyze table t predicate columns")
 	// Add not-null column.
-	testKit.MustExec("alter table t add column c10 int not null default 10")
-	// Insert some data.
-	testKit.MustExec("insert into t(c1, c2) values (4, 5)")
+	testKit.MustExec("alter table t add column c4 int not null default 0")
+	// Insert by explicit column list to keep new columns on default values.
+	testKit.MustExec("insert into t(c1, c2) values (6, 7)")
 	// Analyze all columns to force creating stats for the newly added column before the DDL event is consumed.
 	testKit.MustExec("analyze table t all columns")
 	metaBefore := testKit.MustQuery(`
@@ -1596,10 +1560,12 @@ func TestDumpStatsDeltaBeforeHandleAddNotNullColumnEvent(t *testing.T) {
 		)
 	`).Rows()
 	require.Len(t, metaBefore, 1)
-	// Find the add column event.
-	event := statstestutil.FindEvent(do.StatsHandle().DDLEventCh(), model.ActionAddColumn)
-	err := statstestutil.HandleDDLEventWithTxn(do.StatsHandle(), event)
-	require.NoError(t, err)
+	// Handle two add-column events in order: c3 then c4.
+	for i := 0; i < 2; i++ {
+		event := statstestutil.FindEvent(do.StatsHandle().DDLEventCh(), model.ActionAddColumn)
+		err := statstestutil.HandleDDLEventWithTxn(do.StatsHandle(), event)
+		require.NoError(t, err)
+	}
 	metaAfter := testKit.MustQuery(`
 		select version, last_stats_histograms_version
 		from mysql.stats_meta


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66358

Problem Summary:
When `ANALYZE TABLE ... ALL COLUMNS` runs before queued `ActionAddColumn` stats events are consumed, add-column stats initialization may hit duplicate-key errors on `mysql.stats_histograms`.

### What changed and how does it work?
- Made `InsertColStats2KV` idempotent with `INSERT IGNORE` for `mysql.stats_histograms` and `mysql.stats_buckets`.
- Skip default bucket initialization when histogram metadata already exists.
- Update `stats_meta.version` and `last_stats_histograms_version` only when there are actual histogram/bucket writes.
- Added/updated regression tests to cover both paths:
  - add nullable column
  - add not-null column with default value

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix duplicate-key errors in add-column stats event handling when ANALYZE TABLE ... ALL COLUMNS has already created stats for the new column.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statistics handling for newly added columns, preventing unnecessary version updates and duplicate histogram entries when columns are created via `ANALYZE TABLE ... ALL COLUMNS`.
  * Enhanced statistics version management to update only when actual changes occur, reducing unnecessary metadata modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->