### PR TITLE
planner: keep covering indexes for read-only tables in update join | tidb-test=pr/2706 

### DIFF
--- a/tests/integrationtest/r/planner/core/casetest/pushdown/push_down.result
+++ b/tests/integrationtest/r/planner/core/casetest/pushdown/push_down.result
@@ -123,6 +123,11 @@ id	task	access object	operator info
 Projection	root		md5(planner__core__casetest__pushdown__push_down.t.s)->Column
 └─TableReader	root		data:TableFullScan
   └─TableFullScan	cop[tikv]	table:t	keep order:false, stats:pseudo
+explain format = 'plan_tree' select * from t where sha2(s, 256) = 'abc';
+id	task	access object	operator info
+TableReader	root		data:Selection
+└─Selection	cop[tikv]		eq(sha2(planner__core__casetest__pushdown__push_down.t.s, 256), "abc")
+  └─TableFullScan	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'plan_tree' select c from t where a+1=3;
 id	task	access object	operator info
 Projection	root		planner__core__casetest__pushdown__push_down.t.c

--- a/tests/integrationtest/r/planner/core/indexmerge_path.result
+++ b/tests/integrationtest/r/planner/core/indexmerge_path.result
@@ -955,6 +955,30 @@ Selection	root		or(json_contains(planner__core__indexmerge_path.t1.col_45, cast(
   └─Selection(Probe)	cop[tikv]		or(lt(planner__core__indexmerge_path.t1.col_44, 1980-03-18 00:00:00.000000), gt(planner__core__indexmerge_path.t1.col_44, 2011-10-24 00:00:00.000000))
     └─TableRowIDScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
 drop table if exists t;
+create table if not exists t (
+id int,
+a int,
+b int,
+primary key (id, a),
+key ka (id, a),
+key kb (id, b)
+);
+explain format='plan_tree' select /*+ use_index_merge(t, primary, kb) */ * from t where id=1 and (a=1 or b=1);
+id	task	access object	operator info
+IndexMerge	root		type: union
+├─IndexRangeScan(Build)	cop[tikv]	table:t, index:PRIMARY(id, a)	range:[1 1,1 1], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	cop[tikv]	table:t, index:kb(id, b)	range:[1 1,1 1], keep order:false, stats:pseudo
+└─Selection(Probe)	cop[tikv]		eq(planner__core__indexmerge_path.t.id, 1), or(eq(planner__core__indexmerge_path.t.a, 1), eq(planner__core__indexmerge_path.t.b, 1))
+  └─TableRowIDScan	cop[tikv]	table:t	keep order:false, stats:pseudo
+explain format='plan_tree' select /*+ use_index_merge(t, ka, kb) */ * from t where id=1 and (a=1 or b=1);
+id	task	access object	operator info
+IndexMerge	root		type: union
+├─IndexRangeScan(Build)	cop[tikv]	table:t, index:ka(id, a)	range:[1 1,1 1], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	cop[tikv]	table:t, index:kb(id, b)	range:[1 1,1 1], keep order:false, stats:pseudo
+└─Selection(Probe)	cop[tikv]		eq(planner__core__indexmerge_path.t.id, 1), or(eq(planner__core__indexmerge_path.t.a, 1), eq(planner__core__indexmerge_path.t.b, 1))
+  └─TableRowIDScan	cop[tikv]	table:t	keep order:false, stats:pseudo
+drop table if exists t;
+drop table if exists t;
 create table t(pk varbinary(255) primary key, a int, b varchar(50), c int, d varchar(45), index ia(a), index ib(b), index ic(c), index id(d));
 explain format='plan_tree' SELECT /*+ use_index_merge(t) */ * FROM t WHERE a = 1 AND (b = '2' OR c = 3 OR d = '4');
 id	task	access object	operator info

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -1482,3 +1482,68 @@ select * from t1 natural join t2 order by t1.a;
 a
 1
 drop table t1, t2;
+set @old_db := database();
+drop database if exists lock_db1;
+drop database if exists lock_db2;
+create database lock_db1;
+create database lock_db2;
+use lock_db1;
+create table t(id int primary key, v int);
+insert into t values (1, 100);
+select ue1_0.id from t ue1_0 where ue1_0.id=1 for update of t;
+id
+1
+Level	Code	Message
+Warning	1105	FOR UPDATE OF references the base table name while the table is aliased. Use the alias 'ue1_0' in OF to make the lock target explicit.
+select ue1_0.id from t ue1_0 where ue1_0.id=1 for update of ue1_0;
+id
+1
+select * from t ue1_0 for update of t;
+id	v
+1	100
+Level	Code	Message
+Warning	1105	FOR UPDATE OF references the base table name while the table is aliased. Use the alias 'ue1_0' in OF to make the lock target explicit.
+select * from t ue1_0 for update of t, t, ue1_0;
+id	v
+1	100
+Level	Code	Message
+Warning	1105	FOR UPDATE OF references the base table name while the table is aliased. Use the alias 'ue1_0' in OF to make the lock target explicit.
+select * from t ue1_0 for update of lock_db1.t;
+id	v
+1	100
+Level	Code	Message
+Warning	1105	FOR UPDATE OF references the base table name while the table is aliased. Use the alias 'ue1_0' in OF to make the lock target explicit.
+select * from t ue1_0 for update of lock_db1.ue1_0;
+id	v
+1	100
+select * from t ue1_0, t where ue1_0.id = t.id for update of t;
+id	v	id	v
+1	100	1	100
+select * from t, t ue1_0 where ue1_0.id = t.id for update of lock_db1.t;
+id	v	id	v
+1	100	1	100
+select * from t ue1_0 for update of non_exist_table;
+Error 1109 (42S02): Unknown table 'non_exist_table' in locking clause
+use lock_db2;
+create table t(id int primary key, v int);
+insert into t values (1, 200);
+select * from lock_db1.t ue1_0 for update of t;
+id	v
+1	100
+Level	Code	Message
+Warning	1105	FOR UPDATE OF references the base table name while the table is aliased. Use the alias 'ue1_0' in OF to make the lock target explicit.
+select * from lock_db1.t ue1_0, lock_db2.t ue1_1 for update of t;
+id	v	id	v
+1	100	1	200
+Level	Code	Message
+Warning	1105	FOR UPDATE OF references the base table name while the table is aliased. Use the alias 'ue1_0' in OF to make the lock target explicit.
+with cte_t as (select * from t) select * from cte_t for update of cte_t;
+id	v
+1	200
+set @old_db = ifnull(@old_db, 'test');
+set @stmt = concat('use ', @old_db);
+prepare _ldbstmt from @stmt;
+execute _ldbstmt;
+drop database if exists lock_db1;
+drop database if exists lock_db2;
+deallocate prepare _ldbstmt;

--- a/tests/integrationtest/t/planner/core/casetest/pushdown/push_down.test
+++ b/tests/integrationtest/t/planner/core/casetest/pushdown/push_down.test
@@ -35,6 +35,7 @@ explain format = 'plan_tree' select json_unquote(a) from t2;
 explain format = 'plan_tree' select i * 2 from t;
 explain format = 'plan_tree' select DATE_FORMAT(t, '%Y-%m-%d %H') as date from t;
 explain format = 'plan_tree' select md5(s) from t;
+explain format = 'plan_tree' select * from t where sha2(s, 256) = 'abc';
 explain format = 'plan_tree' select c from t where a+1=3;
 explain format = 'plan_tree' select /*+ hash_agg()*/ count(b) from  (select id + 1 as b from t)A;
 explain format = 'plan_tree' select /*+ hash_agg()*/ count(*) from  (select id + 1 as b from t)A;

--- a/tests/integrationtest/t/planner/core/indexmerge_path.test
+++ b/tests/integrationtest/t/planner/core/indexmerge_path.test
@@ -393,6 +393,21 @@ INSERT INTO t1 VALUES('1988-07-19','[0.9233398239291353, 0.9396459773262974, 0.5
 SELECT col_44, col_45 FROM t1 WHERE NOT (col_44 BETWEEN '1980-03-18' AND '2011-10-24') GROUP BY col_46,col_45 HAVING JSON_CONTAINS(col_45, '0.540018481999012') OR JSON_OVERLAPS(col_45, '[0.5785147169732324,0.8314968898215304,0.5226516826882698]');
 explain format='plan_tree' SELECT /*+ use_index_merge(t1) */ col_44, col_45 FROM t1 WHERE NOT (col_44 BETWEEN '1980-03-18' AND '2011-10-24') GROUP BY col_46,col_45 HAVING JSON_CONTAINS(col_45, '0.540018481999012') OR JSON_OVERLAPS(col_45, '[0.5785147169732324,0.8314968898215304,0.5226516826882698]');
 
+# TestIndexMergeWithPrimaryKey (issue #66668)
+# IndexMerge should support primary key as partial path for id=? and (a=? or b=?)
+drop table if exists t;
+create table if not exists t (
+    id int,
+    a int,
+    b int,
+    primary key (id, a),
+    key ka (id, a),
+    key kb (id, b)
+);
+explain format='plan_tree' select /*+ use_index_merge(t, primary, kb) */ * from t where id=1 and (a=1 or b=1);
+explain format='plan_tree' select /*+ use_index_merge(t, ka, kb) */ * from t where id=1 and (a=1 or b=1);
+drop table if exists t;
+
 # TestIssue52869
 drop table if exists t;
 create table t(pk varbinary(255) primary key, a int, b varchar(50), c int, d varchar(45), index ia(a), index ib(b), index ic(c), index id(d));

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -914,3 +914,42 @@ insert into t1 values (1);
 insert into t2 values (1);
 select * from t1 natural join t2 order by t1.a;
 drop table t1, t2;
+
+# Issue63035
+set @old_db := database();
+drop database if exists lock_db1;
+drop database if exists lock_db2;
+create database lock_db1;
+create database lock_db2;
+
+use lock_db1;
+create table t(id int primary key, v int);
+insert into t values (1, 100);
+--enable_warnings
+select ue1_0.id from t ue1_0 where ue1_0.id=1 for update of t;
+select ue1_0.id from t ue1_0 where ue1_0.id=1 for update of ue1_0;
+select * from t ue1_0 for update of t;
+select * from t ue1_0 for update of t, t, ue1_0;
+select * from t ue1_0 for update of lock_db1.t;
+select * from t ue1_0 for update of lock_db1.ue1_0;
+select * from t ue1_0, t where ue1_0.id = t.id for update of t;
+select * from t, t ue1_0 where ue1_0.id = t.id for update of lock_db1.t;
+
+--error 1109
+select * from t ue1_0 for update of non_exist_table;
+
+use lock_db2;
+create table t(id int primary key, v int);
+insert into t values (1, 200);
+select * from lock_db1.t ue1_0 for update of t;
+select * from lock_db1.t ue1_0, lock_db2.t ue1_1 for update of t;
+with cte_t as (select * from t) select * from cte_t for update of cte_t;
+--disable_warnings
+
+set @old_db = ifnull(@old_db, 'test');
+set @stmt = concat('use ', @old_db);
+prepare _ldbstmt from @stmt;
+execute _ldbstmt;
+drop database if exists lock_db1;
+drop database if exists lock_db2;
+deallocate prepare _ldbstmt;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59876

Problem Summary:

`UPDATE ... JOIN` freezes the join output before optimization and disables projection elimination for the update sub-plan. Before this change, the frozen projection kept the full mixed row for every joined table, including read-only source tables. That polluted the required column set with extra writable columns and row handles, so a covering index on the read-only side could not stay as `IndexReader`.

### What changed and how does it work?

- identify which joined tables are actually updated after `buildUpdateLists()`
- prune the frozen update projection so that it keeps:
  - full writable-column ranges and handle columns only for updated tables
  - assignment-source columns collected in `StmtCtx.ColRefFromUpdatePlan`
- drop handle metadata for read-only tables before building `TblColPosInfos`
- add exact-plan regression coverage for both the covering and non-covering `UPDATE ... JOIN` cases
- add a planner note with the verified root cause, fix boundary, and validation command

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where `UPDATE ... JOIN` could force a lookup on a read-only joined table even when the chosen index covered all required columns.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * UPDATE ... JOIN now prefers covering indexes and avoids unnecessary table lookups when inputs are read-only, improving update plan selection and performance.

* **Documentation**
  * Added a detailed note explaining UPDATE ... JOIN behavior with covering indexes, symptom, root-cause analysis, and validation steps.

* **Tests**
  * Added regression tests covering multiple UPDATE ... JOIN scenarios to verify index-join plan shapes, alias handling, and rowid paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->