### PR TITLE
session: close detached cursor on finishStmt error

### DIFF
--- a/pkg/executor/staticrecordset/integration_test.go
+++ b/pkg/executor/staticrecordset/integration_test.go
@@ -247,6 +247,12 @@ func TestFinishStmtError(t *testing.T) {
 	_, ok, err := drs.TryDetach()
 	require.True(t, ok)
 	require.Error(t, err)
+
+	// The cursor created for the detached record set should also be cleaned up on the error path.
+	tk.Session().GetCursorTracker().RangeCursor(func(_ cursor.Handle) bool {
+		require.Fail(t, "cursor should be closed when TryDetach fails after creating it")
+		return false
+	})
 }
 
 func TestDDLInsideTXNNotBlockMinStartTS(t *testing.T) {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3127,6 +3127,7 @@ func (rs *execStmtResult) TryDetach() (sqlexec.RecordSet, bool, error) {
 	// the session state.
 	err = finishStmt(context.Background(), rs.se, nil, rs.sql)
 	if err != nil {
+		cursorHandle.Close()
 		err2 := detachedRS.Close()
 		if err2 != nil {
 			logutil.BgLogger().Error("close detached record set failed", zap.Error(err2))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66728

Problem Summary:

`TestFinishStmtError` can leave leaked cursor state behind when `execStmtResult.TryDetach()` creates a cursor handle and then `finishStmt()` fails on the error path. The detached record set was closed, but the just-created cursor handle was not, which can contaminate later tests and lead to flakiness.

### What changed and how does it work?

- close the detached cursor handle when `finishStmt()` returns an error in `execStmtResult.TryDetach()`
- keep the cleanup sequence on the error path by closing the detached record set after the cursor is released
- extend `TestFinishStmtError` to assert that no cursor remains in the session tracker after the forced error path

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened tests to ensure session cursors and related resources are properly cleaned up on detach/error paths.

* **Chores**
  * Hardened internal error-path handling and guarded diagnostic/instrumentation hooks to improve reliability and align with updated runtime checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->