### PR TITLE
planner: fix ONLY_FULL_GROUP_BY check for NATURAL JOIN columns

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -146,6 +146,30 @@ func TestPlannerIssueRegressions(t *testing.T) {
 		tk.MustQuery("select * from v")
 	}
 
+	// Test ONLY_FULL_GROUP_BY with NATURAL JOIN.
+	// For NATURAL JOIN, the columns are coalesced in the output schema,
+	// but we should still detect non-aggregated columns from the FullSchema.
+	// only-full-group-by-natural-join
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("create table t0(c0 int)")
+		tk.MustExec("create table t1(c0 int)")
+		tk.MustExec("insert into t0 values (1), (2)")
+		tk.MustExec("insert into t1 values (1), (3)")
+		tk.MustExec("set @@sql_mode = default")
+		tk.MustQuery("select @@sql_mode REGEXP 'ONLY_FULL_GROUP_BY'").Check(testkit.Rows("1"))
+		// Select the coalesced column should error
+		tk.MustContainErrMsg("select c0 from t0 natural right join t1 group by null",
+			"[planner:1055]Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'test.t1.c0' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by")
+		// Select the explicit t0.c0 column should also error (was a bug before fix)
+		tk.MustContainErrMsg("select t0.c0 from t0 natural right join t1 group by null",
+			"[planner:1055]Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'test.t0.c0' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by")
+		// Using aggregation should work
+		tk.MustQuery("select max(t0.c0) from t0 natural right join t1 group by null").Check(testkit.Rows("1"))
+		// Normal query without GROUP BY should work
+		tk.MustQuery("select t0.c0, t1.c0 from t0 natural right join t1 order by t1.c0").Check(testkit.Rows("1 1", "<nil> 3"))
+	}
+
 	// index-merge-with-generated-column
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3497,6 +3497,13 @@ func (c *colNameResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 		idx, err := expression.FindFieldName(c.p.OutputNames(), v.Name)
 		if err == nil && idx >= 0 {
 			c.names[c.p.OutputNames()[idx]] = struct{}{}
+		} else if join, isJoin := c.p.(*logicalop.LogicalJoin); isJoin && join.FullSchema != nil {
+			// For NATURAL JOIN or JOIN ... USING, the output schema is coalesced and
+			// may not contain all original columns. We need to check FullNames as well.
+			idx, err = expression.FindFieldName(join.FullNames, v.Name)
+			if err == nil && idx >= 0 {
+				c.names[join.FullNames[idx]] = struct{}{}
+			}
 		}
 	}
 	return inNode, true


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65387

Problem Summary:

### What changed and how does it work?
When using NATURAL JOIN or JOIN ... USING, the output schema is coalesced and may not contain all original column references. The ONLY_FULL_GROUP_BY validation was only checking OutputNames() which doesn't include the coalesced-away columns from FullSchema.

This caused queries like:
  SELECT t0.c0 FROM t0 NATURAL RIGHT JOIN t1 GROUP BY NULL

to bypass the ONLY_FULL_GROUP_BY check, allowing non-deterministic results when firstrow() picked different values from parallel hash aggregation workers.

The fix checks FullNames in addition to OutputNames() when the plan is a LogicalJoin with a FullSchema, ensuring columns from NATURAL JOINs are properly validated.

### Check List

Tests 

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
planner: fix wrong result for ONLY_FULL_GROUP_BY check for NATURAL JOIN columns.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for NATURAL JOIN queries with ONLY_FULL_GROUP_BY mode, including validation of error handling and aggregation behavior.

* **Bug Fixes**
  * Improved column name resolution for NATURAL JOIN and USING clause scenarios to properly handle complex join schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->