### PR TITLE
resourcegroup/runaway: fix cluster-wide dedup in tidb_runaway_queries

### DIFF
--- a/pkg/meta/metadef/system_tables_def.go
+++ b/pkg/meta/metadef/system_tables_def.go
@@ -599,7 +599,7 @@ const (
 		resource_group_name varchar(32) not null,
 		start_time TIMESTAMP NOT NULL,
 		update_time TIMESTAMP NOT NULL,
-		repeats int default 1,
+		repeats BIGINT default 1,
 		match_type varchar(12) NOT NULL,
 		action varchar(64) NOT NULL,
 		sample_sql TEXT NOT NULL,

--- a/pkg/meta/metadef/system_tables_def.go
+++ b/pkg/meta/metadef/system_tables_def.go
@@ -592,9 +592,13 @@ const (
     );`
 
 	// CreateTiDBRunawayQueriesTable stores the query which is identified as runaway or quarantined because of in watch list.
+	// The composite primary key (resource_group_name, sql_digest, plan_digest, match_type) enforces cluster-wide
+	// deduplication: repeated occurrences of the same query pattern accumulate into one row via ON DUPLICATE KEY UPDATE.
+	// update_time tracks the last activity time and is used by GC instead of start_time.
 	CreateTiDBRunawayQueriesTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_runaway_queries (
 		resource_group_name varchar(32) not null,
 		start_time TIMESTAMP NOT NULL,
+		update_time TIMESTAMP NOT NULL,
 		repeats int default 1,
 		match_type varchar(12) NOT NULL,
 		action varchar(64) NOT NULL,
@@ -603,8 +607,10 @@ const (
 		plan_digest varchar(64) NOT NULL,
 		tidb_server varchar(512),
 		rule VARCHAR(512) DEFAULT '',
+		PRIMARY KEY (resource_group_name, sql_digest, plan_digest, match_type) CLUSTERED,
 		INDEX plan_index(plan_digest(64)) COMMENT "accelerate the speed when select runaway query",
-		INDEX time_index(start_time) COMMENT "accelerate the speed when querying with active watch"
+		INDEX time_index(start_time) COMMENT "accelerate the speed when querying with start time",
+		INDEX update_time_index(update_time) COMMENT "accelerate the speed when GC expired records"
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;`
 
 	// CreateTiDBTimersTable is a table to store all timers for tidb

--- a/pkg/resourcegroup/runaway/flusher_test.go
+++ b/pkg/resourcegroup/runaway/flusher_test.go
@@ -69,34 +69,95 @@ func TestBatchFlusherAdd(t *testing.T) {
 	re.Equal(int32(1), flushCount.Load())
 }
 
+// TestBatchFlusherMergeFn verifies that repeated adds for the same key accumulate Repeats
+// and advance UpdateTime to the latest occurrence, and that the merged state is what gets flushed.
 func TestBatchFlusherMergeFn(t *testing.T) {
 	re := require.New(t)
 
-	var lastBuffer map[string]*Record
+	var lastBuffer map[recordKey]*Record
 	flusher := newTestBatchFlusher(
 		10,
-		func(m map[string]*Record, k string, v *Record) {
+		func(m map[recordKey]*Record, k recordKey, v *Record) {
 			if existing, ok := m[k]; ok {
 				existing.Repeats++
+				if v.UpdateTime.After(existing.UpdateTime) {
+					existing.UpdateTime = v.UpdateTime
+				}
 			} else {
 				m[k] = v
 			}
 		},
-		func(m map[string]*Record) error { lastBuffer = m; return nil },
+		// capture the buffer passed to flushFn so we can assert its contents after flush.
+		func(m map[recordKey]*Record) error { lastBuffer = m; return nil },
 	)
 
-	flusher.add("key1", &Record{SQLDigest: "d1", Repeats: 1})
-	flusher.add("key1", &Record{SQLDigest: "d1", Repeats: 1})
-	flusher.add("key1", &Record{SQLDigest: "d1", Repeats: 1})
-	flusher.add("key2", &Record{SQLDigest: "d2", Repeats: 1})
+	k1 := recordKey{ResourceGroupName: "rg", SQLDigest: "d1", PlanDigest: "p1", Match: "identify"}
+	k2 := recordKey{ResourceGroupName: "rg", SQLDigest: "d2", PlanDigest: "p2", Match: "identify"}
 
+	t0 := time.Now()
+	// same key added three times with advancing timestamps — should be merged into one buffer entry.
+	flusher.add(k1, &Record{SQLDigest: "d1", UpdateTime: t0, Repeats: 1})
+	flusher.add(k1, &Record{SQLDigest: "d1", UpdateTime: t0.Add(time.Second), Repeats: 1})
+	flusher.add(k1, &Record{SQLDigest: "d1", UpdateTime: t0.Add(2 * time.Second), Repeats: 1})
+	// different key added once — must remain independent.
+	flusher.add(k2, &Record{SQLDigest: "d2", UpdateTime: t0, Repeats: 1})
+
+	// two distinct keys in buffer, not three.
 	re.Len(flusher.buffer, 2)
-	re.Equal(3, flusher.buffer["key1"].Repeats)
-	re.Equal(1, flusher.buffer["key2"].Repeats)
+	// three adds for k1 → Repeats=3.
+	re.Equal(3, flusher.buffer[k1].Repeats)
+	// UpdateTime must be the latest of the three timestamps, not the first.
+	re.Equal(t0.Add(2*time.Second), flusher.buffer[k1].UpdateTime, "UpdateTime should advance to the latest occurrence")
+	// k2 was added only once, Repeats stays 1.
+	re.Equal(1, flusher.buffer[k2].Repeats)
 
 	flusher.flush()
+	// buffer is cleared after flush.
 	re.Len(flusher.buffer, 0)
-	re.Equal(3, lastBuffer["key1"].Repeats)
+	// flushFn received the merged state, not three separate records.
+	re.Equal(3, lastBuffer[k1].Repeats)
+	re.Equal(t0.Add(2*time.Second), lastBuffer[k1].UpdateTime)
+}
+
+// TestGenRunawayQueriesStmtODKU verifies the generated SQL contains the ON DUPLICATE KEY UPDATE
+// clause and that start_time/update_time/repeats land in the correct parameter positions.
+func TestGenRunawayQueriesStmtODKU(t *testing.T) {
+	re := require.New(t)
+
+	// t0 = first-seen time (start_time, must never change on duplicate).
+	t0 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	// t1 = latest activity time (update_time, advanced by ODKU on duplicate).
+	t1 := t0.Add(time.Minute)
+	k := recordKey{ResourceGroupName: "rg1", SQLDigest: "sqldig", PlanDigest: "plandig", Match: "identify"}
+	m := map[recordKey]*Record{
+		k: {
+			ResourceGroupName: "rg1",
+			StartTime:         t0,
+			UpdateTime:        t1,
+			Match:             "identify",
+			Action:            "cooldown",
+			SampleText:        "select 1",
+			SQLDigest:         "sqldig",
+			PlanDigest:        "plandig",
+			Source:            "127.0.0.1:4000",
+			ExceedCause:       "cpu",
+			Repeats:           3,
+		},
+	}
+
+	sql, params := genRunawayQueriesStmt(m)
+
+	// ODKU clause must be present for cluster-wide dedup to work.
+	re.Contains(sql, "ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = VALUES(update_time)")
+	// update_time column must appear in the INSERT column list.
+	re.Contains(sql, "update_time")
+	// one row × 11 columns (was 10 before update_time was added).
+	re.Len(params, 11)
+	// positional checks — column order is: resource_group_name, start_time, update_time, …, repeats.
+	re.Equal("rg1", params[0]) // resource_group_name
+	re.Equal(t0, params[1])    // start_time — first-seen, must not be overwritten on duplicate
+	re.Equal(t1, params[2])    // update_time — latest activity, propagated via ODKU
+	re.Equal(3, params[10])    // repeats
 }
 
 func TestBatchFlusherFlush(t *testing.T) {

--- a/pkg/resourcegroup/runaway/flusher_test.go
+++ b/pkg/resourcegroup/runaway/flusher_test.go
@@ -148,7 +148,7 @@ func TestGenRunawayQueriesStmtODKU(t *testing.T) {
 	sql, params := genRunawayQueriesStmt(m)
 
 	// ODKU clause must be present for cluster-wide dedup to work.
-	re.Contains(sql, "ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = VALUES(update_time)")
+	re.Contains(sql, "ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = GREATEST(update_time, VALUES(update_time))")
 	// update_time column must appear in the INSERT column list.
 	re.Contains(sql, "update_time")
 	// one row × 11 columns (was 10 before update_time was added).

--- a/pkg/resourcegroup/runaway/manager.go
+++ b/pkg/resourcegroup/runaway/manager.go
@@ -159,6 +159,9 @@ func (rm *Manager) RunawayRecordFlushLoop() {
 		func(m map[recordKey]*Record, k recordKey, v *Record) {
 			if existing, ok := m[k]; ok {
 				existing.Repeats++
+				if v.UpdateTime.After(existing.UpdateTime) {
+					existing.UpdateTime = v.UpdateTime
+				}
 			} else {
 				m[k] = v
 			}
@@ -339,6 +342,7 @@ func (rm *Manager) markRunaway(checker *Checker, action, matchType string, now *
 	case rm.runawayQueriesChan <- &Record{
 		ResourceGroupName: checker.resourceGroupName,
 		StartTime:         *now,
+		UpdateTime:        *now,
 		Match:             matchType,
 		Action:            action,
 		SampleText:        checker.originalSQL,

--- a/pkg/resourcegroup/runaway/record.go
+++ b/pkg/resourcegroup/runaway/record.go
@@ -46,16 +46,21 @@ var NullTime time.Time
 type Record struct {
 	ResourceGroupName string
 	StartTime         time.Time
-	Match             string
-	Action            string
-	SampleText        string
-	SQLDigest         string
-	PlanDigest        string
-	Source            string
-	ExceedCause       string
-	// Repeats is used to avoid inserting the same record multiple times.
-	// It records the number of times after flushing the record(10s) to the table or len(map) exceeds the threshold(1024).
-	// We only consider `resource_group_name`, `sql_digest`, `plan_digest` and `match_type` when comparing records.
+	// UpdateTime is the time of the latest occurrence within the current flush batch.
+	// It is written to the table and used by GC (instead of start_time).
+	// On INSERT ... ON DUPLICATE KEY UPDATE it advances the stored update_time so GC
+	// does not expire an actively-runaway query pattern prematurely.
+	UpdateTime time.Time
+	Match      string
+	Action     string
+	SampleText string
+	SQLDigest  string
+	PlanDigest string
+	Source     string
+	ExceedCause string
+	// Repeats counts occurrences aggregated in the current flush batch.
+	// The table accumulates these across all batches and TiDB instances via
+	// ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats).
 	// default value is 1.
 	Repeats int
 }
@@ -69,20 +74,25 @@ type recordKey struct {
 }
 
 // genRunawayQueriesStmt generates statement with given RunawayRecords.
+// The primary key is (resource_group_name, sql_digest, plan_digest, match_type).
+// On duplicate the statement accumulates repeats and advances update_time;
+// start_time and sample_sql are intentionally left unchanged (first-seen semantics).
 func genRunawayQueriesStmt(recordMap map[recordKey]*Record) (string, []any) {
 	var builder strings.Builder
-	params := make([]any, 0, len(recordMap)*10)
+	params := make([]any, 0, len(recordMap)*11)
 	builder.WriteString("INSERT INTO mysql.tidb_runaway_queries " +
-		"(resource_group_name, start_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats) VALUES ")
+		"(resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats) VALUES ")
 	firstRecord := true
 	for _, r := range recordMap {
 		if !firstRecord {
 			builder.WriteByte(',')
 		}
 		firstRecord = false
-		builder.WriteString("(%?, %?, %?, %?, %?, %?, %?, %?, %?, %?)")
-		params = append(params, r.ResourceGroupName, r.StartTime, r.Match, r.Action, r.SampleText, r.SQLDigest, r.PlanDigest, r.Source, r.ExceedCause, r.Repeats)
+		builder.WriteString("(%?, %?, %?, %?, %?, %?, %?, %?, %?, %?, %?)")
+		params = append(params, r.ResourceGroupName, r.StartTime, r.UpdateTime,
+			r.Match, r.Action, r.SampleText, r.SQLDigest, r.PlanDigest, r.Source, r.ExceedCause, r.Repeats)
 	}
+	builder.WriteString(" ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = VALUES(update_time)")
 	return builder.String(), params
 }
 
@@ -244,7 +254,7 @@ func genBatchDeleteWatchByIDStmt(records map[int64]*QuarantineRecord) (string, [
 func (rm *Manager) deleteExpiredRows(expiredDuration time.Duration) {
 	const (
 		tableName = "tidb_runaway_queries"
-		colName   = "start_time"
+		colName   = "update_time"
 	)
 	var systemSchemaCIStr = ast.NewCIStr("mysql")
 

--- a/pkg/resourcegroup/runaway/record.go
+++ b/pkg/resourcegroup/runaway/record.go
@@ -92,7 +92,7 @@ func genRunawayQueriesStmt(recordMap map[recordKey]*Record) (string, []any) {
 		params = append(params, r.ResourceGroupName, r.StartTime, r.UpdateTime,
 			r.Match, r.Action, r.SampleText, r.SQLDigest, r.PlanDigest, r.Source, r.ExceedCause, r.Repeats)
 	}
-	builder.WriteString(" ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = VALUES(update_time)")
+	builder.WriteString(" ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = GREATEST(update_time, VALUES(update_time))")
 	return builder.String(), params
 }
 

--- a/pkg/session/test/bootstraptest/boot_test.go
+++ b/pkg/session/test/bootstraptest/boot_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/meta/metadef"
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
@@ -991,6 +992,39 @@ func TestUpgradeToVer255RunawayQueriesDedup(t *testing.T) {
 		dom2.Close()
 	})
 
+	// helperSetupV255BakOnly leaves mysql.tidb_runaway_queries in the given state
+	// (missing or empty with the v255 schema) and stages the already-deduplicated
+	// rows in mysql.tidb_runaway_queries_bak. This simulates an upgrade that
+	// crashed after Step 2 populated bak but before Step 4 finished the re-insert.
+	helperSetupV255BakOnly := func(t *testing.T, se sessionapi.Session, mainMode string) {
+		session.MustExec(t, se, "DROP TABLE IF EXISTS mysql.tidb_runaway_queries")
+		session.MustExec(t, se, "DROP TABLE IF EXISTS mysql.tidb_runaway_queries_bak")
+		session.MustExec(t, se, `CREATE TABLE mysql.tidb_runaway_queries_bak (
+			resource_group_name varchar(32) NOT NULL,
+			start_time TIMESTAMP NOT NULL,
+			update_time TIMESTAMP NOT NULL,
+			repeats BIGINT,
+			match_type varchar(12) NOT NULL,
+			action varchar(64) NOT NULL,
+			sample_sql TEXT NOT NULL,
+			sql_digest varchar(64) NOT NULL,
+			plan_digest varchar(64) NOT NULL,
+			tidb_server varchar(512),
+			rule VARCHAR(512) DEFAULT ''
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin`)
+		session.MustExec(t, se, `INSERT INTO mysql.tidb_runaway_queries_bak
+			(resource_group_name, start_time, update_time, repeats, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule)
+			VALUES
+			('rg1', '2025-01-01 00:00:01', '2025-01-01 00:00:03', 18, 'identify', 'kill',     'SELECT 1', 'digest_aaa', 'plan_aaa', 'tidb1', ''),
+			('rg2', '2025-06-15 12:00:00', '2025-06-15 12:00:00', 1,  'watch',    'cooldown', 'SELECT 2', 'digest_bbb', 'plan_bbb', 'tidb1', 'rule1')`)
+		if mainMode == "empty" {
+			// Main exists in the v255 shape but is empty (crash between Step 3 CREATE and Step 4 INSERT).
+			session.MustExec(t, se, metadef.CreateTiDBRunawayQueriesTable)
+		}
+		// mainMode == "missing" leaves mysql.tidb_runaway_queries dropped (crash between Step 3 DROP and CREATE).
+		session.MustExec(t, se, "commit")
+	}
+
 	// Sub-test 2: idempotency — re-running v255 on already-migrated data.
 	t.Run("idempotent", func(t *testing.T) {
 		se254 := session.CreateSessionAndSetID(t, store)
@@ -1015,5 +1049,53 @@ func TestUpgradeToVer255RunawayQueriesDedup(t *testing.T) {
 		se := session.CreateSessionAndSetID(t, store)
 		helperAssertPostV255(t, se)
 		dom3.Close()
+	})
+
+	// runRecoverySubtest prepares a mid-upgrade state in the store and then drives the
+	// v255 upgrade through that state. Prior subtests have closed their domains, so the
+	// first BootstrapSession here is what brings one back up for the DDL setup work.
+	runRecoverySubtest := func(t *testing.T, mainMode string) {
+		domSetup, err := session.BootstrapSession(store)
+		require.NoError(t, err)
+
+		seSetup := session.CreateSessionAndSetID(t, store)
+		helperSetupV255BakOnly(t, seSetup, mainMode)
+
+		txn, err := store.Begin()
+		require.NoError(t, err)
+		m := meta.NewMutator(txn)
+		err = m.FinishBootstrap(int64(254))
+		require.NoError(t, err)
+		err = txn.Commit(ctx)
+		require.NoError(t, err)
+		session.RevertVersionAndVariables(t, seSetup, 254)
+		session.MustExec(t, seSetup, "commit")
+
+		store.SetOption(session.StoreBootstrappedKey, nil)
+		ver, err := session.GetBootstrapVersion(seSetup)
+		require.NoError(t, err)
+		require.Equal(t, int64(254), ver)
+		domSetup.Close()
+
+		domUpgrade, err := session.BootstrapSession(store)
+		require.NoError(t, err)
+
+		helperAssertPostV255(t, session.CreateSessionAndSetID(t, store))
+		domUpgrade.Close()
+	}
+
+	// Sub-test 3: crash-recovery — main table dropped, bak holds the migrated rows.
+	// Simulates a crash between Step 3 DROP main and Step 3 CREATE main. The upgrade
+	// must recreate main from bak rather than Fatal on ALTER-of-missing-table.
+	t.Run("recover_main_missing", func(t *testing.T) {
+		runRecoverySubtest(t, "missing")
+	})
+
+	// Sub-test 4: crash-recovery — main exists in v255 shape but is empty, bak holds
+	// the migrated rows. Simulates a crash between Step 3 CREATE main and Step 4
+	// INSERT from bak. The upgrade must transfer bak's rows into main (INSERT IGNORE)
+	// rather than silently drop bak and leave main empty.
+	t.Run("recover_main_empty", func(t *testing.T) {
+		runRecoverySubtest(t, "empty")
 	})
 }

--- a/pkg/session/test/bootstraptest/boot_test.go
+++ b/pkg/session/test/bootstraptest/boot_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/session"
+	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
@@ -874,4 +875,145 @@ func TestIndexJoinMultiPatternByUpgrade650To840(t *testing.T) {
 	row := chk.GetRow(0)
 	require.Equal(t, 1, row.Len())
 	require.Equal(t, int64(0), row.GetInt64(0))
+}
+
+func TestUpgradeToVer255RunawayQueriesDedup(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
+	}
+
+	ctx := context.Background()
+
+	// helperSetupPreV255 drops the current table, recreates it with the pre-v255
+	// schema (no clustered PK, no update_time column), and inserts test data
+	// with duplicates on the composite key.
+	helperSetupPreV255 := func(t *testing.T, se sessionapi.Session) {
+		session.MustExec(t, se, "DROP TABLE IF EXISTS mysql.tidb_runaway_queries")
+		session.MustExec(t, se, `CREATE TABLE mysql.tidb_runaway_queries (
+			resource_group_name varchar(32) NOT NULL,
+			start_time TIMESTAMP NOT NULL,
+			repeats int DEFAULT 1,
+			match_type varchar(12) NOT NULL,
+			action varchar(64) NOT NULL,
+			sample_sql TEXT NOT NULL,
+			sql_digest varchar(64) NOT NULL,
+			plan_digest varchar(64) NOT NULL,
+			tidb_server varchar(512),
+			rule VARCHAR(512) DEFAULT '',
+			INDEX plan_index(plan_digest(64)) COMMENT 'accelerate the speed when select runaway query',
+			INDEX time_index(start_time) COMMENT 'accelerate the speed when querying with start time'
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin`)
+
+		// 3 duplicate rows for the same composite key, 1 unique row.
+		session.MustExec(t, se, `INSERT INTO mysql.tidb_runaway_queries
+			(resource_group_name, start_time, repeats, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule)
+			VALUES
+			('rg1', '2025-01-01 00:00:01', 5,  'identify', 'kill', 'SELECT 1', 'digest_aaa', 'plan_aaa', 'tidb1', ''),
+			('rg1', '2025-01-01 00:00:02', 3,  'identify', 'kill', 'SELECT 1', 'digest_aaa', 'plan_aaa', 'tidb2', ''),
+			('rg1', '2025-01-01 00:00:03', 10, 'identify', 'kill', 'SELECT 1', 'digest_aaa', 'plan_aaa', 'tidb3', ''),
+			('rg2', '2025-06-15 12:00:00', 1,  'watch',    'cooldown', 'SELECT 2', 'digest_bbb', 'plan_bbb', 'tidb1', 'rule1')`)
+		session.MustExec(t, se, "commit")
+	}
+
+	// helperAssertPostV255 verifies schema and data after the v255 upgrade.
+	helperAssertPostV255 := func(t *testing.T, se sessionapi.Session) {
+		ver, err := session.GetBootstrapVersion(se)
+		require.NoError(t, err)
+		require.Equal(t, session.CurrentBootstrapVersion, ver)
+
+		// Staging table must not exist.
+		rs := session.MustExecToRecodeSet(t, se, "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='mysql' AND table_name='tidb_runaway_queries_bak'")
+		chk := rs.NewChunk(nil)
+		require.NoError(t, rs.Next(ctx, chk))
+		require.Equal(t, int64(0), chk.GetRow(0).GetInt64(0))
+
+		// Table should have a 4-column composite primary key.
+		rs = session.MustExecToRecodeSet(t, se, "SHOW INDEX FROM mysql.tidb_runaway_queries WHERE Key_name = 'PRIMARY'")
+		chk = rs.NewChunk(nil)
+		require.NoError(t, rs.Next(ctx, chk))
+		require.Equal(t, 4, chk.NumRows(), "expected 4-column composite primary key")
+
+		// 3 duplicates collapsed into 1, plus 1 unique = 2 rows.
+		rs = session.MustExecToRecodeSet(t, se, "SELECT COUNT(*) FROM mysql.tidb_runaway_queries")
+		chk = rs.NewChunk(nil)
+		require.NoError(t, rs.Next(ctx, chk))
+		require.Equal(t, int64(2), chk.GetRow(0).GetInt64(0))
+
+		// Verify aggregation: start_time = MIN, repeats = SUM.
+		rs = session.MustExecToRecodeSet(t, se, `SELECT start_time, repeats FROM mysql.tidb_runaway_queries
+			WHERE resource_group_name='rg1' AND sql_digest='digest_aaa' AND plan_digest='plan_aaa' AND match_type='identify'`)
+		chk = rs.NewChunk(nil)
+		require.NoError(t, rs.Next(ctx, chk))
+		require.Equal(t, 1, chk.NumRows())
+		row := chk.GetRow(0)
+		startTime := row.GetTime(0)
+		require.Equal(t, "2025-01-01 00:00:01", startTime.String())
+		require.Equal(t, int64(18), row.GetInt64(1)) // 5 + 3 + 10
+
+		// Verify unique row is preserved.
+		rs = session.MustExecToRecodeSet(t, se, `SELECT repeats, rule FROM mysql.tidb_runaway_queries
+			WHERE resource_group_name='rg2' AND sql_digest='digest_bbb' AND plan_digest='plan_bbb' AND match_type='watch'`)
+		chk = rs.NewChunk(nil)
+		require.NoError(t, rs.Next(ctx, chk))
+		require.Equal(t, 1, chk.NumRows())
+		require.Equal(t, int64(1), chk.GetRow(0).GetInt64(0))
+		require.Equal(t, "rule1", chk.GetRow(0).GetString(1))
+	}
+
+	store, dom := session.CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	// Sub-test 1: upgrade from v254 with duplicate data.
+	t.Run("dedup", func(t *testing.T) {
+		se254 := session.CreateSessionAndSetID(t, store)
+		txn, err := store.Begin()
+		require.NoError(t, err)
+		m := meta.NewMutator(txn)
+		err = m.FinishBootstrap(int64(254))
+		require.NoError(t, err)
+		err = txn.Commit(ctx)
+		require.NoError(t, err)
+		session.RevertVersionAndVariables(t, se254, 254)
+
+		helperSetupPreV255(t, se254)
+
+		store.SetOption(session.StoreBootstrappedKey, nil)
+		ver, err := session.GetBootstrapVersion(se254)
+		require.NoError(t, err)
+		require.Equal(t, int64(254), ver)
+		dom.Close()
+
+		dom2, err := session.BootstrapSession(store)
+		require.NoError(t, err)
+
+		se := session.CreateSessionAndSetID(t, store)
+		helperAssertPostV255(t, se)
+		dom2.Close()
+	})
+
+	// Sub-test 2: idempotency — re-running v255 on already-migrated data.
+	t.Run("idempotent", func(t *testing.T) {
+		se254 := session.CreateSessionAndSetID(t, store)
+		txn, err := store.Begin()
+		require.NoError(t, err)
+		m := meta.NewMutator(txn)
+		err = m.FinishBootstrap(int64(254))
+		require.NoError(t, err)
+		err = txn.Commit(ctx)
+		require.NoError(t, err)
+		session.RevertVersionAndVariables(t, se254, 254)
+		session.MustExec(t, se254, "commit")
+
+		store.SetOption(session.StoreBootstrappedKey, nil)
+		ver, err := session.GetBootstrapVersion(se254)
+		require.NoError(t, err)
+		require.Equal(t, int64(254), ver)
+
+		dom3, err := session.BootstrapSession(store)
+		require.NoError(t, err)
+
+		se := session.CreateSessionAndSetID(t, store)
+		helperAssertPostV255(t, se)
+		dom3.Close()
+	})
 }

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -2057,9 +2057,93 @@ func upgradeToVer254(s sessionapi.Session, _ int64) {
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_watch_done ADD INDEX idx_done_time(done_time) COMMENT 'accelerate the speed when syncing done watch records'", dbterror.ErrDupKeyName)
 }
 
+// bootstrapScalarCount runs a scalar COUNT(*) query during bootstrap and returns the result.
+// Fatals on error — matches the rest of the bootstrap code's error discipline.
+func bootstrapScalarCount(s sessionapi.Session, sql string, args ...any) int64 {
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
+	rs, err := s.ExecuteInternal(ctx, sql, args...)
+	if err != nil {
+		logutil.BgLogger().Fatal("bootstrapScalarCount query error", zap.String("sql", sql), zap.Error(err))
+	}
+	req := rs.NewChunk(nil)
+	if err := rs.Next(ctx, req); err != nil {
+		logutil.BgLogger().Fatal("bootstrapScalarCount read error", zap.String("sql", sql), zap.Error(err))
+	}
+	if err := rs.Close(); err != nil {
+		logutil.BgLogger().Fatal("bootstrapScalarCount close error", zap.String("sql", sql), zap.Error(err))
+	}
+	if req.NumRows() == 0 {
+		return 0
+	}
+	return req.GetRow(0).GetInt64(0)
+}
+
+// tidbRunawayQueriesHasV255PK returns true when mysql.tidb_runaway_queries already carries the
+// v255 composite primary key, which is the signal that the upgrade succeeded in a prior run.
+func tidbRunawayQueriesHasV255PK(s sessionapi.Session) bool {
+	return bootstrapScalarCount(s,
+		"SELECT COUNT(*) FROM information_schema.statistics "+
+			"WHERE table_schema=%? AND table_name=%? AND index_name=%?",
+		"mysql", "tidb_runaway_queries", "PRIMARY") > 0
+}
+
+// tidbRunawayQueriesTableExists reports whether the main table exists.
+func tidbRunawayQueriesTableExists(s sessionapi.Session) bool {
+	return bootstrapScalarCount(s,
+		"SELECT COUNT(*) FROM information_schema.tables "+
+			"WHERE table_schema=%? AND table_name=%?",
+		"mysql", "tidb_runaway_queries") > 0
+}
+
+// tidbRunawayQueriesBakExists reports whether the v255 migration staging table is present.
+func tidbRunawayQueriesBakExists(s sessionapi.Session) bool {
+	return bootstrapScalarCount(s,
+		"SELECT COUNT(*) FROM information_schema.tables "+
+			"WHERE table_schema=%? AND table_name=%?",
+		"mysql", "tidb_runaway_queries_bak") > 0
+}
+
 func upgradeToVer255(s sessionapi.Session, _ int64) {
 	// TiDB cannot ALTER TABLE ADD PRIMARY KEY ... CLUSTERED on an existing table,
 	// so we must recreate mysql.tidb_runaway_queries with the target schema.
+	//
+	// The upgrade runs as a sequence of DDL statements, and DDL cannot be wrapped in
+	// a single transaction, so we must tolerate crash-and-restart between any two
+	// statements. The three branches below cover every reachable intermediate state:
+	//
+	//   (a) main already in v255 shape — prior run completed, or crashed after Step 3
+	//       CREATE but before Step 4 INSERT. Finish by transferring any data still in
+	//       bak (INSERT IGNORE; identical rows are a no-op) and dropping bak.
+	//   (b) main missing — prior run crashed after Step 3 DROP and before CREATE.
+	//       Recreate main and restore from bak if the staging data is available.
+	//   (c) main still in pre-v255 shape — run the full migration.
+
+	if tidbRunawayQueriesHasV255PK(s) {
+		if tidbRunawayQueriesBakExists(s) {
+			mustExecute(s, "INSERT IGNORE INTO mysql.tidb_runaway_queries "+
+				"(resource_group_name, start_time, update_time, repeats, match_type, "+
+				"action, sample_sql, sql_digest, plan_digest, tidb_server, rule) "+
+				"SELECT resource_group_name, start_time, update_time, repeats, match_type, "+
+				"action, sample_sql, sql_digest, plan_digest, tidb_server, rule "+
+				"FROM mysql.tidb_runaway_queries_bak")
+		}
+		mustExecute(s, "DROP TABLE IF EXISTS mysql.tidb_runaway_queries_bak")
+		return
+	}
+
+	if !tidbRunawayQueriesTableExists(s) {
+		mustExecute(s, metadef.CreateTiDBRunawayQueriesTable)
+		if tidbRunawayQueriesBakExists(s) {
+			mustExecute(s, "INSERT INTO mysql.tidb_runaway_queries "+
+				"(resource_group_name, start_time, update_time, repeats, match_type, "+
+				"action, sample_sql, sql_digest, plan_digest, tidb_server, rule) "+
+				"SELECT resource_group_name, start_time, update_time, repeats, match_type, "+
+				"action, sample_sql, sql_digest, plan_digest, tidb_server, rule "+
+				"FROM mysql.tidb_runaway_queries_bak")
+		}
+		mustExecute(s, "DROP TABLE IF EXISTS mysql.tidb_runaway_queries_bak")
+		return
+	}
 
 	// Step 1: add update_time column to the old table so the migration SELECT works.
 	// DEFAULT CURRENT_TIMESTAMP backfills existing rows.

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -478,6 +478,12 @@ const (
 	// Add index on start_time for mysql.tidb_runaway_watch and done_time for mysql.tidb_runaway_watch_done
 	// to improve the performance of runaway watch sync loop.
 	version254 = 254
+
+	// version255
+	// Deduplicate mysql.tidb_runaway_queries, add update_time column, and add a composite clustered
+	// primary key (resource_group_name, sql_digest, plan_digest, match_type) to eliminate cross-window
+	// duplicate rows and the implicit _tidb_rowid write hotspot.
+	version255 = 255
 )
 
 // versionedUpgradeFunction is a struct that holds the upgrade function related
@@ -491,7 +497,7 @@ type versionedUpgradeFunction struct {
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version254
+var currentBootstrapVersion int64 = version255
 
 var (
 	// this list must be ordered by version in ascending order, and the function
@@ -670,6 +676,7 @@ var (
 		{version: version252, fn: upgradeToVer252},
 		{version: version253, fn: upgradeToVer253},
 		{version: version254, fn: upgradeToVer254},
+		{version: version255, fn: upgradeToVer255},
 	}
 )
 
@@ -2048,4 +2055,23 @@ func upgradeToVer253(s sessionapi.Session, _ int64) {
 func upgradeToVer254(s sessionapi.Session, _ int64) {
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_watch ADD INDEX idx_start_time(start_time) COMMENT 'accelerate the speed when syncing new watch records'", dbterror.ErrDupKeyName)
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_watch_done ADD INDEX idx_done_time(done_time) COMMENT 'accelerate the speed when syncing done watch records'", dbterror.ErrDupKeyName)
+}
+
+func upgradeToVer255(s sessionapi.Session, _ int64) {
+	// Step 1: add update_time column to track last activity time (used by GC).
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_queries ADD COLUMN update_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP", infoschema.ErrColumnExists)
+	// Step 2: remove duplicate rows, keeping the one with the latest start_time per
+	// (resource_group_name, sql_digest, plan_digest, match_type). Safe to re-run:
+	// once deduplicated the self-join produces no further matches.
+	mustExecute(s, "DELETE t1 FROM mysql.tidb_runaway_queries t1 "+
+		"INNER JOIN mysql.tidb_runaway_queries t2 "+
+		"ON  t1.resource_group_name = t2.resource_group_name "+
+		"AND t1.sql_digest           = t2.sql_digest "+
+		"AND t1.plan_digest          = t2.plan_digest "+
+		"AND t1.match_type           = t2.match_type "+
+		"AND t1.start_time           < t2.start_time")
+	// Step 3: add composite clustered primary key for cluster-wide dedup.
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_queries ADD PRIMARY KEY (resource_group_name, sql_digest, plan_digest, match_type) CLUSTERED", infoschema.ErrMultiplePriKey)
+	// Step 4: add index on update_time for efficient GC scans.
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_queries ADD INDEX update_time_index(update_time) COMMENT 'accelerate the speed when GC expired records'", dbterror.ErrDupKeyName)
 }

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -2059,19 +2059,43 @@ func upgradeToVer254(s sessionapi.Session, _ int64) {
 
 func upgradeToVer255(s sessionapi.Session, _ int64) {
 	// Step 1: add update_time column to track last activity time (used by GC).
+	// DEFAULT CURRENT_TIMESTAMP is required to backfill existing rows; the default
+	// is dropped in step 6 so the column definition matches the fresh-bootstrap DDL.
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_queries ADD COLUMN update_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP", infoschema.ErrColumnExists)
-	// Step 2: remove duplicate rows, keeping the one with the latest start_time per
-	// (resource_group_name, sql_digest, plan_digest, match_type). Safe to re-run:
-	// once deduplicated the self-join produces no further matches.
-	mustExecute(s, "DELETE t1 FROM mysql.tidb_runaway_queries t1 "+
-		"INNER JOIN mysql.tidb_runaway_queries t2 "+
-		"ON  t1.resource_group_name = t2.resource_group_name "+
-		"AND t1.sql_digest           = t2.sql_digest "+
-		"AND t1.plan_digest          = t2.plan_digest "+
-		"AND t1.match_type           = t2.match_type "+
-		"AND t1.start_time           < t2.start_time")
+	// Step 2: deduplicate rows by aggregating on the composite key. Uses a temp
+	// table to collapse duplicates correctly even when TIMESTAMP values collide
+	// (second precision), preserving MIN(start_time) for first-seen semantics,
+	// MAX(update_time) for last activity, and SUM(repeats) so historical counts
+	// are not lost. Safe to re-run: on already-deduplicated data the GROUP BY
+	// produces identical rows.
+	mustExecute(s, "DROP TEMPORARY TABLE IF EXISTS tmp_runaway_dedup")
+	mustExecute(s, "CREATE TEMPORARY TABLE tmp_runaway_dedup AS "+
+		"SELECT resource_group_name, "+
+		"MIN(start_time) AS start_time, "+
+		"MAX(update_time) AS update_time, "+
+		"SUM(repeats) AS repeats, "+
+		"match_type, "+
+		"ANY_VALUE(action) AS action, "+
+		"ANY_VALUE(sample_sql) AS sample_sql, "+
+		"sql_digest, "+
+		"plan_digest, "+
+		"ANY_VALUE(tidb_server) AS tidb_server, "+
+		"ANY_VALUE(rule) AS rule "+
+		"FROM mysql.tidb_runaway_queries "+
+		"GROUP BY resource_group_name, sql_digest, plan_digest, match_type")
+	mustExecute(s, "DELETE FROM mysql.tidb_runaway_queries")
+	mustExecute(s, "INSERT INTO mysql.tidb_runaway_queries "+
+		"(resource_group_name, start_time, update_time, repeats, match_type, "+
+		"action, sample_sql, sql_digest, plan_digest, tidb_server, rule) "+
+		"SELECT resource_group_name, start_time, update_time, repeats, match_type, "+
+		"action, sample_sql, sql_digest, plan_digest, tidb_server, rule "+
+		"FROM tmp_runaway_dedup")
+	mustExecute(s, "DROP TEMPORARY TABLE IF EXISTS tmp_runaway_dedup")
 	// Step 3: add composite clustered primary key for cluster-wide dedup.
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_queries ADD PRIMARY KEY (resource_group_name, sql_digest, plan_digest, match_type) CLUSTERED", infoschema.ErrMultiplePriKey)
 	// Step 4: add index on update_time for efficient GC scans.
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_queries ADD INDEX update_time_index(update_time) COMMENT 'accelerate the speed when GC expired records'", dbterror.ErrDupKeyName)
+	// Step 5: drop the DEFAULT added in step 1 so the column metadata matches
+	// the fresh-bootstrap DDL (CreateTiDBRunawayQueriesTable has no default).
+	mustExecute(s, "ALTER TABLE mysql.tidb_runaway_queries ALTER COLUMN update_time DROP DEFAULT")
 }

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -2058,44 +2058,58 @@ func upgradeToVer254(s sessionapi.Session, _ int64) {
 }
 
 func upgradeToVer255(s sessionapi.Session, _ int64) {
-	// Step 1: add update_time column to track last activity time (used by GC).
-	// DEFAULT CURRENT_TIMESTAMP is required to backfill existing rows; the default
-	// is dropped in step 6 so the column definition matches the fresh-bootstrap DDL.
+	// TiDB cannot ALTER TABLE ADD PRIMARY KEY ... CLUSTERED on an existing table,
+	// so we must recreate mysql.tidb_runaway_queries with the target schema.
+
+	// Step 1: add update_time column to the old table so the migration SELECT works.
+	// DEFAULT CURRENT_TIMESTAMP backfills existing rows.
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_queries ADD COLUMN update_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP", infoschema.ErrColumnExists)
-	// Step 2: deduplicate rows by aggregating on the composite key. Uses a temp
-	// table to collapse duplicates correctly even when TIMESTAMP values collide
-	// (second precision), preserving MIN(start_time) for first-seen semantics,
-	// MAX(update_time) for last activity, and SUM(repeats) so historical counts
-	// are not lost. Safe to re-run: on already-deduplicated data the GROUP BY
-	// produces identical rows.
-	mustExecute(s, "DROP TEMPORARY TABLE IF EXISTS tmp_runaway_dedup")
-	mustExecute(s, "CREATE TEMPORARY TABLE tmp_runaway_dedup AS "+
+
+	// Step 2: create staging table and migrate deduplicated data.
+	// Uses GROUP BY on the composite key to collapse duplicates, preserving
+	// MIN(start_time) for first-seen semantics, MAX(update_time) for last activity,
+	// and SUM(repeats) so historical counts are not lost.
+	mustExecute(s, "DROP TABLE IF EXISTS mysql.tidb_runaway_queries_bak")
+	mustExecute(s, "CREATE TABLE mysql.tidb_runaway_queries_bak ("+
+		"resource_group_name varchar(32) NOT NULL, "+
+		"start_time TIMESTAMP NOT NULL, "+
+		"update_time TIMESTAMP NOT NULL, "+
+		"repeats BIGINT, "+
+		"match_type varchar(12) NOT NULL, "+
+		"action varchar(64) NOT NULL, "+
+		"sample_sql TEXT NOT NULL, "+
+		"sql_digest varchar(64) NOT NULL, "+
+		"plan_digest varchar(64) NOT NULL, "+
+		"tidb_server varchar(512), "+
+		"rule VARCHAR(512) DEFAULT ''"+
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
+	mustExecute(s, "INSERT INTO mysql.tidb_runaway_queries_bak "+
 		"SELECT resource_group_name, "+
-		"MIN(start_time) AS start_time, "+
-		"MAX(update_time) AS update_time, "+
-		"SUM(repeats) AS repeats, "+
+		"MIN(start_time), "+
+		"MAX(update_time), "+
+		"SUM(repeats), "+
 		"match_type, "+
-		"ANY_VALUE(action) AS action, "+
-		"ANY_VALUE(sample_sql) AS sample_sql, "+
+		"ANY_VALUE(action), "+
+		"ANY_VALUE(sample_sql), "+
 		"sql_digest, "+
 		"plan_digest, "+
-		"ANY_VALUE(tidb_server) AS tidb_server, "+
-		"ANY_VALUE(rule) AS rule "+
+		"ANY_VALUE(tidb_server), "+
+		"ANY_VALUE(rule) "+
 		"FROM mysql.tidb_runaway_queries "+
 		"GROUP BY resource_group_name, sql_digest, plan_digest, match_type")
-	mustExecute(s, "DELETE FROM mysql.tidb_runaway_queries")
+
+	// Step 3: drop old table and recreate with target schema (CLUSTERED PK).
+	mustExecute(s, "DROP TABLE IF EXISTS mysql.tidb_runaway_queries")
+	mustExecute(s, metadef.CreateTiDBRunawayQueriesTable)
+
+	// Step 4: re-insert deduplicated data into the new table.
 	mustExecute(s, "INSERT INTO mysql.tidb_runaway_queries "+
 		"(resource_group_name, start_time, update_time, repeats, match_type, "+
 		"action, sample_sql, sql_digest, plan_digest, tidb_server, rule) "+
 		"SELECT resource_group_name, start_time, update_time, repeats, match_type, "+
 		"action, sample_sql, sql_digest, plan_digest, tidb_server, rule "+
-		"FROM tmp_runaway_dedup")
-	mustExecute(s, "DROP TEMPORARY TABLE IF EXISTS tmp_runaway_dedup")
-	// Step 3: add composite clustered primary key for cluster-wide dedup.
-	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_queries ADD PRIMARY KEY (resource_group_name, sql_digest, plan_digest, match_type) CLUSTERED", infoschema.ErrMultiplePriKey)
-	// Step 4: add index on update_time for efficient GC scans.
-	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_queries ADD INDEX update_time_index(update_time) COMMENT 'accelerate the speed when GC expired records'", dbterror.ErrDupKeyName)
-	// Step 5: drop the DEFAULT added in step 1 so the column metadata matches
-	// the fresh-bootstrap DDL (CreateTiDBRunawayQueriesTable has no default).
-	mustExecute(s, "ALTER TABLE mysql.tidb_runaway_queries ALTER COLUMN update_time DROP DEFAULT")
+		"FROM mysql.tidb_runaway_queries_bak")
+
+	// Step 5: drop staging table.
+	mustExecute(s, "DROP TABLE IF EXISTS mysql.tidb_runaway_queries_bak")
 }

--- a/tests/integrationtest/r/runaway_queries_dedup.result
+++ b/tests/integrationtest/r/runaway_queries_dedup.result
@@ -1,0 +1,70 @@
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'mysql'
+AND table_name = 'tidb_runaway_queries'
+AND column_name = 'update_time';
+column_name	data_type	is_nullable
+update_time	timestamp	NO
+SELECT column_name, seq_in_index, non_unique
+FROM information_schema.statistics
+WHERE table_schema = 'mysql'
+AND table_name = 'tidb_runaway_queries'
+AND index_name = 'PRIMARY'
+ORDER BY seq_in_index;
+column_name	seq_in_index	non_unique
+resource_group_name	1	0
+sql_digest	2	0
+plan_digest	3	0
+match_type	4	0
+SELECT index_name, column_name
+FROM information_schema.statistics
+WHERE table_schema = 'mysql'
+AND table_name = 'tidb_runaway_queries'
+AND index_name = 'update_time_index';
+index_name	column_name
+update_time_index	update_time
+DELETE FROM mysql.tidb_runaway_queries WHERE resource_group_name = 'rg_inttest_dedup';
+INSERT INTO mysql.tidb_runaway_queries
+(resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats)
+VALUES
+('rg_inttest_dedup','2024-01-01 00:00:00','2024-01-01 00:00:01','identify','DRYRUN','select 1','d1','p1','srv1','',1)
+ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = GREATEST(update_time, VALUES(update_time));
+INSERT INTO mysql.tidb_runaway_queries
+(resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats)
+VALUES
+('rg_inttest_dedup','2024-01-02 00:00:00','2024-01-01 00:00:10','identify','DRYRUN','select 1','d1','p1','srv2','',3)
+ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = GREATEST(update_time, VALUES(update_time));
+SELECT resource_group_name, start_time, update_time, repeats
+FROM mysql.tidb_runaway_queries
+WHERE resource_group_name = 'rg_inttest_dedup';
+resource_group_name	start_time	update_time	repeats
+rg_inttest_dedup	2024-01-01 00:00:00	2024-01-01 00:00:10	4
+DELETE FROM mysql.tidb_runaway_queries WHERE resource_group_name = 'rg_inttest_dedup';
+DELETE FROM mysql.tidb_runaway_queries WHERE resource_group_name = 'rg_inttest_greatest';
+INSERT INTO mysql.tidb_runaway_queries
+(resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats)
+VALUES
+('rg_inttest_greatest','2024-01-01 00:00:00','2024-01-10 12:00:00','identify','DRYRUN','select 1','d2','p2','srv1','',5)
+ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = GREATEST(update_time, VALUES(update_time));
+INSERT INTO mysql.tidb_runaway_queries
+(resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats)
+VALUES
+('rg_inttest_greatest','2024-01-01 00:00:00','2024-01-01 06:00:00','identify','DRYRUN','select 1','d2','p2','srv2','',1)
+ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = GREATEST(update_time, VALUES(update_time));
+SELECT resource_group_name, update_time, repeats
+FROM mysql.tidb_runaway_queries
+WHERE resource_group_name = 'rg_inttest_greatest';
+resource_group_name	update_time	repeats
+rg_inttest_greatest	2024-01-10 12:00:00	6
+DELETE FROM mysql.tidb_runaway_queries WHERE resource_group_name = 'rg_inttest_greatest';
+DELETE FROM mysql.tidb_runaway_queries WHERE resource_group_name = 'rg_inttest_pk';
+INSERT INTO mysql.tidb_runaway_queries
+(resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats)
+VALUES
+('rg_inttest_pk','2024-01-01 00:00:00','2024-01-01 00:00:00','identify','DRYRUN','select 1','d3','p3','srv1','',1);
+INSERT INTO mysql.tidb_runaway_queries
+(resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats)
+VALUES
+('rg_inttest_pk','2024-01-01 00:00:00','2024-01-01 00:00:00','identify','DRYRUN','select 1','d3','p3','srv1','',1);
+Error 1062 (23000): Duplicate entry 'rg_inttest_pk-d3-p3-identify' for key 'tidb_runaway_queries.PRIMARY'
+DELETE FROM mysql.tidb_runaway_queries WHERE resource_group_name = 'rg_inttest_pk';

--- a/tests/integrationtest/t/runaway_queries_dedup.test
+++ b/tests/integrationtest/t/runaway_queries_dedup.test
@@ -1,0 +1,73 @@
+# TestRunawayQueriesDedupSchema
+# TC1: update_time column exists with correct type and is NOT NULL
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'mysql'
+  AND table_name = 'tidb_runaway_queries'
+  AND column_name = 'update_time';
+
+# TC2: composite primary key covers the four dedup columns in the right order
+SELECT column_name, seq_in_index, non_unique
+FROM information_schema.statistics
+WHERE table_schema = 'mysql'
+  AND table_name = 'tidb_runaway_queries'
+  AND index_name = 'PRIMARY'
+ORDER BY seq_in_index;
+
+# TC6: update_time_index exists so GC scans are efficient
+SELECT index_name, column_name
+FROM information_schema.statistics
+WHERE table_schema = 'mysql'
+  AND table_name = 'tidb_runaway_queries'
+  AND index_name = 'update_time_index';
+
+# TestRunawayQueriesODKU
+# TC3: repeats accumulates and update_time advances on duplicate insert;
+#      start_time retains first-seen value (immutable).
+DELETE FROM mysql.tidb_runaway_queries WHERE resource_group_name = 'rg_inttest_dedup';
+INSERT INTO mysql.tidb_runaway_queries
+  (resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats)
+VALUES
+  ('rg_inttest_dedup','2024-01-01 00:00:00','2024-01-01 00:00:01','identify','DRYRUN','select 1','d1','p1','srv1','',1)
+ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = GREATEST(update_time, VALUES(update_time));
+INSERT INTO mysql.tidb_runaway_queries
+  (resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats)
+VALUES
+  ('rg_inttest_dedup','2024-01-02 00:00:00','2024-01-01 00:00:10','identify','DRYRUN','select 1','d1','p1','srv2','',3)
+ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = GREATEST(update_time, VALUES(update_time));
+# expect: 1 row, repeats=4, update_time='2024-01-01 00:00:10', start_time='2024-01-01 00:00:00'
+SELECT resource_group_name, start_time, update_time, repeats
+FROM mysql.tidb_runaway_queries
+WHERE resource_group_name = 'rg_inttest_dedup';
+DELETE FROM mysql.tidb_runaway_queries WHERE resource_group_name = 'rg_inttest_dedup';
+
+# TC4: a stale flush with an earlier update_time must not roll back update_time (GREATEST)
+DELETE FROM mysql.tidb_runaway_queries WHERE resource_group_name = 'rg_inttest_greatest';
+INSERT INTO mysql.tidb_runaway_queries
+  (resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats)
+VALUES
+  ('rg_inttest_greatest','2024-01-01 00:00:00','2024-01-10 12:00:00','identify','DRYRUN','select 1','d2','p2','srv1','',5)
+ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = GREATEST(update_time, VALUES(update_time));
+INSERT INTO mysql.tidb_runaway_queries
+  (resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats)
+VALUES
+  ('rg_inttest_greatest','2024-01-01 00:00:00','2024-01-01 06:00:00','identify','DRYRUN','select 1','d2','p2','srv2','',1)
+ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = GREATEST(update_time, VALUES(update_time));
+# expect: update_time stays '2024-01-10 12:00:00', repeats=6
+SELECT resource_group_name, update_time, repeats
+FROM mysql.tidb_runaway_queries
+WHERE resource_group_name = 'rg_inttest_greatest';
+DELETE FROM mysql.tidb_runaway_queries WHERE resource_group_name = 'rg_inttest_greatest';
+
+# TC5: plain INSERT without ON DUPLICATE KEY UPDATE raises Error 1062 on composite PK collision
+DELETE FROM mysql.tidb_runaway_queries WHERE resource_group_name = 'rg_inttest_pk';
+INSERT INTO mysql.tidb_runaway_queries
+  (resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats)
+VALUES
+  ('rg_inttest_pk','2024-01-01 00:00:00','2024-01-01 00:00:00','identify','DRYRUN','select 1','d3','p3','srv1','',1);
+-- error 1062
+INSERT INTO mysql.tidb_runaway_queries
+  (resource_group_name, start_time, update_time, match_type, action, sample_sql, sql_digest, plan_digest, tidb_server, rule, repeats)
+VALUES
+  ('rg_inttest_pk','2024-01-01 00:00:00','2024-01-01 00:00:00','identify','DRYRUN','select 1','d3','p3','srv1','',1);
+DELETE FROM mysql.tidb_runaway_queries WHERE resource_group_name = 'rg_inttest_pk';


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65746 

Problem Summary:

`mysql.tidb_runaway_queries` had two structural issues:

- Deduplicate only within one flush window. The in-memory `batchFlusher` merges repeated occurrences of the same query pattern within a 30-second flush window, but after each flush the buffer is reset. The same pattern is re-inserted as a new row on the next flush. Across multiple TiDB instances there is no dedup at all.

- Write hotspot. No explicit primary key -> TiDB assigns an implicit `_tidb_rowid`. All nodes write sequential rowids, creating a TiKV write hotspot on a single region.

### What changed and how does it work?

This fix moves the deduplication logic from the application layer (per-instance, single-window) to the storage layer (cluster-wide). The fix adds a composite primary key on `(resource_group_name, sql_digest, plan_digest, match_type)` on `mysql.tidb_runaway_queries`. Now when any TiDB node flushes a record that already exists in the table, the database rejects the duplicate and instead executes the `ON DUPLICATE KEY UPDATE` clause, which increments repeats and advances `update_time` in-place.

List of changes:

- Add `update_time TIMESTAMP NOT NULL` column to track last-activity time per unique query pattern.
- Add `PRIMARY KEY (resource_group_name, sql_digest, plan_digest, match_type) CLUSTERED`. Content-addressed keys naturally distribute across TiKV regions, eliminating the write hotspot.
- Change `INSERT` to `INSERT ... ON DUPLICATE KEY UPDATE repeats = repeats + VALUES(repeats), update_time = VALUES(update_time)`. Duplicate writes from any TiDB node or across flush windows are merged at the DB level.
- `batchFlusher` merge function now also advances `UpdateTime` to the latest occurrence within a window, so the `ON DUPLICATE KEY UPDATE` always carries the freshest timestamp.
- GC now expires rows by `update_time` (last activity) instead of `start_time` (first seen), preventing active runaway patterns from being prematurely removed.
- Bootstrap version 255 migrates existing clusters: adds column, deduplicates rows, adds PK and index.

Caveats:

- This fix introduces semantic change of `repeats` field in `mysql.tidb_runaway_queries` table.
- Upgrade to ver255 involves deleting and recreating existing `mysql.tidb_runaway_queries` table. Idempotency is ensured during the upgrade process.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
mysql.tidb_runaway_queries now uses a composite primary key
(resource_group_name, sql_digest, plan_digest, match_type) and a new
update_time column. Repeated occurrences of the same query pattern are
now accumulated into a single row across flush windows and across TiDB
instances, instead of producing a new row per flush. GC now expires
rows based on update_time (last activity) rather than start_time.
Existing rows are automatically migrated during upgrade to v8.x (bootstrap v255).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added update_time (last activity) column, composite primary key for cluster-wide deduplication, and ON DUPLICATE KEY UPDATE upserts.
  * Added columns for query/sample digests, sample SQL, server identifier, and rule text.
  * Automatic upgrade path (version 255) migrates schema and deduplicates existing data.

* **Improvements**
  * Repeat counts now accumulate across batches and latest activity time is preserved.
  * GC/expiry now uses the new activity timestamp for accurate cleanup.

* **Tests**
  * New unit and integration tests validate deduplication, upsert ordering, and GC behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->