### PR TITLE
ddl: split `jobWs` if return error `Transaction is too large`

### DIFF
--- a/pkg/ddl/job_submitter.go
+++ b/pkg/ddl/job_submitter.go
@@ -115,21 +115,44 @@ func (s *JobSubmitter) addBatchDDLJobs(jobWs []*JobWrapper) {
 	}
 	err = s.addBatchDDLJobs2Table(jobWs)
 	var jobs string
+	hasSubmitted := false
+	failedCount := 0
+	var firstJobErr error
 	for _, jobW := range jobWs {
-		if err == nil {
-			err = jobW.cacheErr
+		jobErr := jobW.cacheErr
+		// For non-partial errors, fan out to all jobs without per-job errors.
+		if jobErr == nil && err != nil && !errors.ErrorEqual(err, errPartialJobSubmit) {
+			jobErr = err
 		}
-		jobW.NotifyResult(err)
+		if jobErr != nil {
+			failedCount++
+			if firstJobErr == nil {
+				firstJobErr = jobErr
+			}
+		} else {
+			hasSubmitted = true
+		}
+		jobW.NotifyResult(jobErr)
 		jobs += jobW.Job.String() + "; "
 		metrics.DDLWorkerHistogram.WithLabelValues(metrics.WorkerAddDDLJob, jobW.Job.Type.String(),
-			metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())
+			metrics.RetLabel(jobErr)).Observe(time.Since(startTime).Seconds())
 	}
-	if err != nil {
-		logutil.DDLLogger().Warn("add DDL jobs failed", zap.String("jobs", jobs), zap.Error(err))
+	if hasSubmitted {
+		// Some jobs are already in mysql.tidb_ddl_job, still need to wake scheduler.
+		s.notifyNewJobSubmitted()
+	}
+	if failedCount > 0 {
+		if errors.ErrorEqual(err, errPartialJobSubmit) {
+			logutil.DDLLogger().Warn("add DDL jobs partially failed",
+				zap.String("jobs", jobs),
+				zap.Bool("hasSuccess", hasSubmitted),
+				zap.Int("failedCount", failedCount),
+				zap.Error(firstJobErr))
+			return
+		}
+		logutil.DDLLogger().Warn("add DDL jobs failed", zap.String("jobs", jobs), zap.Error(firstJobErr))
 		return
 	}
-	// Notice worker that we push a new job and wait the job done.
-	s.notifyNewJobSubmitted()
 	logutil.DDLLogger().Info("add DDL jobs",
 		zap.Int("batch count", len(jobWs)),
 		zap.String("jobs", jobs),
@@ -301,6 +324,7 @@ func (s *JobSubmitter) addBatchDDLJobs2Table(jobWs []*JobWrapper) error {
 		return errors.Trace(err)
 	}
 
+	updatedJobWs := make([]*JobWrapper, 0, len(jobWs))
 	for _, jobW := range jobWs {
 		job := jobW.Job
 		intest.Assert(job.Version != 0, "Job version should not be zero")
@@ -331,10 +355,11 @@ func (s *JobSubmitter) addBatchDDLJobs2Table(jobWs []*JobWrapper) error {
 			}
 			logutil.DDLUpgradingLogger().Info("pause user DDL by system successful", zap.Stringer("job", job))
 		}
+		updatedJobWs = append(updatedJobWs, jobW)
 	}
 
 	ddlSe := sess.NewSession(se)
-	if err = s.GenGIDAndInsertJobsWithRetry(ctx, ddlSe, jobWs); err != nil {
+	if err = s.GenGIDAndInsertJobsWithRetry(ctx, ddlSe, updatedJobWs); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -380,10 +405,31 @@ func (s *JobSubmitter) GenGIDAndInsertJobsWithRetry(ctx context.Context, ddlSe *
 	logutil.DDLLogger().Warn("insert DDL jobs meets txn too large, split batch and retry",
 		zap.Int("batchSize", len(jobWs)))
 	mid := len(jobWs) / 2
-	if err = s.GenGIDAndInsertJobsWithRetry(ctx, ddlSe, jobWs[:mid]); err != nil {
-		return err
+	leftErr := s.GenGIDAndInsertJobsWithRetry(ctx, ddlSe, jobWs[:mid])
+	rightErr := s.GenGIDAndInsertJobsWithRetry(ctx, ddlSe, jobWs[mid:])
+	markFailedJobs(jobWs[:mid], leftErr)
+	markFailedJobs(jobWs[mid:], rightErr)
+	if leftErr == nil && rightErr == nil {
+		return nil
 	}
-	return s.GenGIDAndInsertJobsWithRetry(ctx, ddlSe, jobWs[mid:])
+	return errPartialJobSubmit
+}
+
+var errPartialJobSubmit = errors.New("partial DDL jobs submission failed")
+
+func markFailedJobs(jobs []*JobWrapper, err error) {
+	if err == nil {
+		return
+	}
+	// Partial error already has precise per-job cacheErr marked in children.
+	if errors.ErrorEqual(err, errPartialJobSubmit) {
+		return
+	}
+	for _, jobW := range jobs {
+		if jobW.cacheErr == nil {
+			jobW.cacheErr = err
+		}
+	}
 }
 
 type gidAllocator struct {
@@ -621,6 +667,16 @@ func insertDDLJobs2Table(ctx context.Context, se *sess.Session, jobWs ...*JobWra
 	failpoint.Inject("mockInsertDDLJobsTxnTooLargeErr", func(val failpoint.Value) {
 		if val.(bool) && len(jobWs) > 1 {
 			failpoint.Return(kv.ErrTxnTooLarge)
+		}
+	})
+	failpoint.Inject("mockInsertDDLJobsErrOnTableName", func(val failpoint.Value) {
+		tblName, ok := val.(string)
+		if ok {
+			for _, jobW := range jobWs {
+				if jobW.TableName == tblName {
+					failpoint.Return(errors.New("mockInsertDDLJobsErrOnTableName"))
+				}
+			}
 		}
 	})
 	if len(jobWs) == 0 {

--- a/pkg/ddl/job_submitter_test.go
+++ b/pkg/ddl/job_submitter_test.go
@@ -640,6 +640,77 @@ func TestGenGIDAndInsertJobsWithRetrySplitOnTxnTooLarge(t *testing.T) {
 	require.Len(t, submitter.DDLJobDoneChMap().Keys(), len(jobs))
 }
 
+func TestGenGIDAndInsertJobsWithRetrySplitPartialFailure(t *testing.T) {
+	store := testkit.CreateMockStore(t, mockstore.WithStoreType(mockstore.EmbedUnistore))
+	// disable DDL to avoid it interfere the test
+	tk := testkit.NewTestKit(t, store)
+	dom := domain.GetDomain(tk.Session())
+	dom.DDL().OwnerManager().CampaignCancel()
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL)
+
+	ddlSe := sess.NewSession(tk.Session())
+	jobs := []*ddl.JobWrapper{
+		{
+			Job: &model.Job{
+				Version:    model.GetJobVerInUse(),
+				Type:       model.ActionCreateTable,
+				SchemaName: "test",
+				TableName:  "t1",
+			},
+			JobArgs: &model.CreateTableArgs{TableInfo: &model.TableInfo{}},
+		},
+		{
+			Job: &model.Job{
+				Version:    model.GetJobVerInUse(),
+				Type:       model.ActionCreateTable,
+				SchemaName: "test",
+				TableName:  "t2",
+			},
+			JobArgs: &model.CreateTableArgs{TableInfo: &model.TableInfo{}},
+		},
+		{
+			Job: &model.Job{
+				Version:    model.GetJobVerInUse(),
+				Type:       model.ActionCreateTable,
+				SchemaName: "test",
+				TableName:  "t3",
+			},
+			JobArgs: &model.CreateTableArgs{TableInfo: &model.TableInfo{}},
+		},
+		{
+			Job: &model.Job{
+				Version:    model.GetJobVerInUse(),
+				Type:       model.ActionCreateTable,
+				SchemaName: "test",
+				TableName:  "t4",
+			},
+			JobArgs: &model.CreateTableArgs{TableInfo: &model.TableInfo{}},
+		},
+	}
+
+	submitter := ddl.NewJobSubmitterForTest()
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockInsertDDLJobsTxnTooLargeErr", `return(true)`)
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockInsertDDLJobsErrOnTableName", `return("t3")`)
+	err := submitter.GenGIDAndInsertJobsWithRetry(ctx, ddlSe, jobs)
+	require.Error(t, err)
+
+	gotJobs, queryErr := ddl.GetAllDDLJobs(ctx, tk.Session())
+	require.NoError(t, queryErr)
+	require.Len(t, gotJobs, 3)
+	gotTableNames := make(map[string]struct{}, len(gotJobs))
+	for _, j := range gotJobs {
+		gotTableNames[j.TableName] = struct{}{}
+	}
+	_, ok := gotTableNames["t1"]
+	require.True(t, ok)
+	_, ok = gotTableNames["t2"]
+	require.True(t, ok)
+	_, ok = gotTableNames["t4"]
+	require.True(t, ok)
+	_, ok = gotTableNames["t3"]
+	require.False(t, ok)
+}
+
 func TestSubmitJobAfterDDLIsClosed(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t, mockstore.WithStoreType(mockstore.EmbedUnistore))
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64492

Problem Summary:
failed to restore X tables concurrently with the error `Error: [kv:8004]Transaction is too large, size: 108312922`.
### What changed and how does it work?
split `jobWs` if return error `Transaction is too large`
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of oversized batches: large batches are automatically split and retried; partial failures are tracked per-item and reported separately, with scheduler notified when any item succeeds.
* **New Features**
  * Per-item submission status and metrics for clearer visibility into partial vs. full failures.
* **Tests**
  * Added tests covering split-on-oversized-transaction and partial-failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->