### PR TITLE
planner: block FK cascade into read-only schema | tidb-test=release-8.5.2

### DIFF
--- a/pkg/ddl/schema_test.go
+++ b/pkg/ddl/schema_test.go
@@ -790,7 +790,7 @@ func TestTTLDeleteError(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
-func TestSchemaReadOnlyBlockFKCascadeOnDuplicateKeyUpdate(t *testing.T) {
+func TestSchemaReadOnlyBlockFKCascadeOnDuplicateKeyUpdateAndReplace(t *testing.T) {
 	enableReadOnlyDDLFp(t)
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/ddl/schema_test.go
+++ b/pkg/ddl/schema_test.go
@@ -798,14 +798,39 @@ func TestSchemaReadOnlyBlockFKCascadeOnDuplicateKeyUpdate(t *testing.T) {
 
 	tk.MustExec("create database ro_fk_parent")
 	tk.MustExec("create database ro_fk_child")
-
 	tk.MustExec("create table ro_fk_parent.parent(id int primary key, val int)")
-	tk.MustExec("create table ro_fk_child.child(id int primary key, parent_id int, foreign key fk_p(parent_id) references ro_fk_parent.parent(id) on update cascade)")
+	tk.MustExec("create table ro_fk_child.child(id int primary key, parent_id int, index idx_parent_id(parent_id), foreign key fk_p(parent_id) references ro_fk_parent.parent(id) on update cascade)")
 
+	// Prepare a real cascade scenario: existing parent/child rows + the duplicate update actually changes the
+	// referenced key value, so the cascade would update the read-only child schema without this fix.
+	tk.MustExec("insert into ro_fk_parent.parent values (2, 200)")
+	tk.MustExec("insert into ro_fk_child.child values (1, 2)")
 	tk.MustExec("alter schema ro_fk_child read only = 1")
-	tk.MustExec("use ro_fk_parent")
-	tk.MustGetErrMsg("insert into parent values (2, 999) on duplicate key update id = 3, val = 999", "[schema:3989]Schema 'ro_fk_child' is in read only mode.")
 
-	tk.MustQuery("select * from ro_fk_parent.parent").Check(testkit.Rows())
-	tk.MustQuery("select * from ro_fk_child.child").Check(testkit.Rows())
+	tk.MustExec("use ro_fk_parent")
+	tk.MustGetErrMsg("insert into parent values (2, 999) on duplicate key update id = 3, val = 999",
+		"[schema:3989]Schema 'ro_fk_child' is in read only mode.")
+
+	tk.MustQuery("select * from ro_fk_parent.parent").Check(testkit.Rows("2 200"))
+	tk.MustQuery("select * from ro_fk_child.child").Check(testkit.Rows("1 2"))
+
+	// Cover the REPLACE code path as well (p.IsReplace branch in foreign_key.go).
+	tk = testkit.NewTestKit(t, store)
+	tk.MustExec("set @@global.tidb_enable_foreign_key=1")
+	tk.MustExec("create database ro_fk_parent_replace")
+	tk.MustExec("create database ro_fk_child_replace")
+	tk.MustExec("create table ro_fk_parent_replace.parent(id int primary key, val int)")
+	tk.MustExec("create table ro_fk_child_replace.child(id int primary key, parent_id int, index idx_parent_id(parent_id), foreign key fk_p(parent_id) references ro_fk_parent_replace.parent(id) on delete set null)")
+
+	// REPLACE on parent will delete the duplicated row first, which triggers the ON DELETE SET NULL cascade.
+	tk.MustExec("insert into ro_fk_parent_replace.parent values (1, 100)")
+	tk.MustExec("insert into ro_fk_child_replace.child values (1, 1)")
+	tk.MustExec("alter schema ro_fk_child_replace read only = 1")
+
+	tk.MustExec("use ro_fk_parent_replace")
+	tk.MustGetErrMsg("replace into parent values (1, 111)",
+		"[schema:3989]Schema 'ro_fk_child_replace' is in read only mode.")
+
+	tk.MustQuery("select * from ro_fk_parent_replace.parent").Check(testkit.Rows("1 100"))
+	tk.MustQuery("select * from ro_fk_child_replace.child").Check(testkit.Rows("1 1"))
 }

--- a/pkg/ddl/schema_test.go
+++ b/pkg/ddl/schema_test.go
@@ -789,3 +789,23 @@ func TestTTLDeleteError(t *testing.T) {
 		return ttlError != nil && strings.Contains(ttlError.Error(), "Schema 'test' is in read only mode")
 	}, 10*time.Second, 100*time.Millisecond)
 }
+
+func TestSchemaReadOnlyBlockFKCascadeOnDuplicateKeyUpdate(t *testing.T) {
+	enableReadOnlyDDLFp(t)
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set @@global.tidb_enable_foreign_key=1")
+
+	tk.MustExec("create database ro_fk_parent")
+	tk.MustExec("create database ro_fk_child")
+
+	tk.MustExec("create table ro_fk_parent.parent(id int primary key, val int)")
+	tk.MustExec("create table ro_fk_child.child(id int primary key, parent_id int, foreign key fk_p(parent_id) references ro_fk_parent.parent(id) on update cascade)")
+
+	tk.MustExec("alter schema ro_fk_child read only = 1")
+	tk.MustExec("use ro_fk_parent")
+	tk.MustGetErrMsg("insert into parent values (2, 999) on duplicate key update id = 3, val = 999", "[schema:3989]Schema 'ro_fk_child' is in read only mode.")
+
+	tk.MustQuery("select * from ro_fk_parent.parent").Check(testkit.Rows())
+	tk.MustQuery("select * from ro_fk_child.child").Check(testkit.Rows())
+}

--- a/pkg/planner/core/foreign_key.go
+++ b/pkg/planner/core/foreign_key.go
@@ -26,27 +26,9 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
-	"github.com/pingcap/tidb/pkg/privilege"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 )
-
-func shouldCheckSchemaReadOnlyForFKCascade(ctx base.PlanContext) bool {
-	vars := ctx.GetSessionVars()
-	// Allow replication threads with explicitly granted RESTRICTED_REPLICA_WRITER_ADMIN to bypass.
-	//
-	// Gate on User != nil so that internal/unauthenticated sessions (including mock-store
-	// test sessions where SkipWithGrant is true) are still blocked.
-	if vars.User == nil {
-		return true
-	}
-
-	pm := privilege.GetPrivilegeManager(ctx)
-	if pm == nil {
-		return true
-	}
-	return !pm.HasExplicitlyGrantedDynamicPrivilege(vars.ActiveRoles, "RESTRICTED_REPLICA_WRITER_ADMIN", false)
-}
 
 // FKCheck indicates the foreign key constraint checker.
 type FKCheck struct {
@@ -182,7 +164,7 @@ func (p *Insert) buildOnInsertFKTriggers(ctx base.PlanContext, is infoschema.Inf
 			fkCascades = append(fkCascades, referredFKCascades...)
 			for _, fk := range referredFKCascades {
 				fkDBInfo, ok := infoschema.SchemaByTable(is, fk.ChildTable.Meta())
-				if ok && fkDBInfo.ReadOnly && shouldCheckSchemaReadOnlyForFKCascade(ctx) {
+				if ok && fkDBInfo.ReadOnly {
 					return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
 				}
 			}
@@ -199,7 +181,7 @@ func (p *Insert) buildOnInsertFKTriggers(ctx base.PlanContext, is infoschema.Inf
 			fkCascades = append(fkCascades, referredFKCascades...)
 			for _, fk := range referredFKCascades {
 				fkDBInfo, ok := infoschema.SchemaByTable(is, fk.ChildTable.Meta())
-				if ok && fkDBInfo.ReadOnly && shouldCheckSchemaReadOnlyForFKCascade(ctx) {
+				if ok && fkDBInfo.ReadOnly {
 					return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
 				}
 			}
@@ -281,7 +263,7 @@ func (updt *Update) buildOnUpdateFKTriggers(ctx base.PlanContext, is infoschema.
 			fkCascades[tid] = append(fkCascades[tid], referredFKCascades...)
 			for _, fk := range referredFKCascades {
 				fkDBInfo, ok := infoschema.SchemaByTable(is, fk.ChildTable.Meta())
-				if ok && fkDBInfo.ReadOnly && shouldCheckSchemaReadOnlyForFKCascade(ctx) {
+				if ok && fkDBInfo.ReadOnly {
 					return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
 				}
 			}
@@ -325,7 +307,7 @@ func (del *Delete) buildOnDeleteFKTriggers(ctx base.PlanContext, is infoschema.I
 			if fkCascade != nil {
 				fkCascades[tid] = append(fkCascades[tid], fkCascade)
 				fkDBInfo, ok := infoschema.SchemaByTable(is, fkCascade.ChildTable.Meta())
-				if ok && fkDBInfo.ReadOnly && shouldCheckSchemaReadOnlyForFKCascade(ctx) {
+				if ok && fkDBInfo.ReadOnly {
 					return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
 				}
 			}

--- a/pkg/planner/core/foreign_key.go
+++ b/pkg/planner/core/foreign_key.go
@@ -26,9 +26,27 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
+	"github.com/pingcap/tidb/pkg/privilege"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 )
+
+func shouldCheckSchemaReadOnlyForFKCascade(ctx base.PlanContext) bool {
+	vars := ctx.GetSessionVars()
+	// Allow replication threads with explicitly granted RESTRICTED_REPLICA_WRITER_ADMIN to bypass.
+	//
+	// Gate on User != nil so that internal/unauthenticated sessions (including mock-store
+	// test sessions where SkipWithGrant is true) are still blocked.
+	if vars.User == nil {
+		return true
+	}
+
+	pm := privilege.GetPrivilegeManager(ctx)
+	if pm == nil {
+		return true
+	}
+	return !pm.HasExplicitlyGrantedDynamicPrivilege(vars.ActiveRoles, "RESTRICTED_REPLICA_WRITER_ADMIN", false)
+}
 
 // FKCheck indicates the foreign key constraint checker.
 type FKCheck struct {
@@ -164,7 +182,7 @@ func (p *Insert) buildOnInsertFKTriggers(ctx base.PlanContext, is infoschema.Inf
 			fkCascades = append(fkCascades, referredFKCascades...)
 			for _, fk := range referredFKCascades {
 				fkDBInfo, ok := infoschema.SchemaByTable(is, fk.ChildTable.Meta())
-				if ok && fkDBInfo.ReadOnly {
+				if ok && fkDBInfo.ReadOnly && shouldCheckSchemaReadOnlyForFKCascade(ctx) {
 					return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
 				}
 			}
@@ -181,7 +199,7 @@ func (p *Insert) buildOnInsertFKTriggers(ctx base.PlanContext, is infoschema.Inf
 			fkCascades = append(fkCascades, referredFKCascades...)
 			for _, fk := range referredFKCascades {
 				fkDBInfo, ok := infoschema.SchemaByTable(is, fk.ChildTable.Meta())
-				if ok && fkDBInfo.ReadOnly {
+				if ok && fkDBInfo.ReadOnly && shouldCheckSchemaReadOnlyForFKCascade(ctx) {
 					return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
 				}
 			}
@@ -263,7 +281,7 @@ func (updt *Update) buildOnUpdateFKTriggers(ctx base.PlanContext, is infoschema.
 			fkCascades[tid] = append(fkCascades[tid], referredFKCascades...)
 			for _, fk := range referredFKCascades {
 				fkDBInfo, ok := infoschema.SchemaByTable(is, fk.ChildTable.Meta())
-				if ok && fkDBInfo.ReadOnly {
+				if ok && fkDBInfo.ReadOnly && shouldCheckSchemaReadOnlyForFKCascade(ctx) {
 					return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
 				}
 			}
@@ -307,7 +325,7 @@ func (del *Delete) buildOnDeleteFKTriggers(ctx base.PlanContext, is infoschema.I
 			if fkCascade != nil {
 				fkCascades[tid] = append(fkCascades[tid], fkCascade)
 				fkDBInfo, ok := infoschema.SchemaByTable(is, fkCascade.ChildTable.Meta())
-				if ok && fkDBInfo.ReadOnly {
+				if ok && fkDBInfo.ReadOnly && shouldCheckSchemaReadOnlyForFKCascade(ctx) {
 					return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
 				}
 			}

--- a/pkg/planner/core/foreign_key.go
+++ b/pkg/planner/core/foreign_key.go
@@ -153,6 +153,7 @@ func (p *Insert) buildOnInsertFKTriggers(ctx base.PlanContext, is infoschema.Inf
 	fkChecks := make([]*FKCheck, 0, len(tblInfo.ForeignKeys))
 	fkCascades := make([]*FKCascade, 0, len(tblInfo.ForeignKeys))
 	updateCols := p.buildOnDuplicateUpdateColumns()
+	skipReadOnlyCheck := skipReadOnlyCheckForReplica(ctx)
 	if len(updateCols) > 0 {
 		referredFKChecks, referredFKCascades, err := buildOnUpdateReferredFKTriggers(ctx, is, dbName, tblInfo, updateCols)
 		if err != nil {
@@ -163,10 +164,12 @@ func (p *Insert) buildOnInsertFKTriggers(ctx base.PlanContext, is infoschema.Inf
 		}
 		if len(referredFKCascades) > 0 {
 			fkCascades = append(fkCascades, referredFKCascades...)
-			for _, fk := range referredFKCascades {
-				fkDBInfo, ok := infoschema.SchemaByTable(is, fk.ChildTable.Meta())
-				if ok && fkDBInfo.ReadOnly {
-					return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
+			if !skipReadOnlyCheck {
+				for _, fk := range referredFKCascades {
+					fkDBInfo, ok := infoschema.SchemaByTable(is, fk.ChildTable.Meta())
+					if ok && fkDBInfo.ReadOnly {
+						return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
+					}
 				}
 			}
 		}
@@ -180,12 +183,6 @@ func (p *Insert) buildOnInsertFKTriggers(ctx base.PlanContext, is infoschema.Inf
 		}
 		if len(referredFKCascades) > 0 {
 			fkCascades = append(fkCascades, referredFKCascades...)
-			for _, fk := range referredFKCascades {
-				fkDBInfo, ok := infoschema.SchemaByTable(is, fk.ChildTable.Meta())
-				if ok && fkDBInfo.ReadOnly {
-					return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
-				}
-			}
 		}
 	}
 	for _, fk := range tblInfo.ForeignKeys {

--- a/pkg/planner/core/foreign_key.go
+++ b/pkg/planner/core/foreign_key.go
@@ -162,6 +162,12 @@ func (p *Insert) buildOnInsertFKTriggers(ctx base.PlanContext, is infoschema.Inf
 		}
 		if len(referredFKCascades) > 0 {
 			fkCascades = append(fkCascades, referredFKCascades...)
+			for _, fk := range referredFKCascades {
+				fkDBInfo, ok := infoschema.SchemaByTable(is, fk.ChildTable.Meta())
+				if ok && fkDBInfo.ReadOnly {
+					return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
+				}
+			}
 		}
 	} else if p.IsReplace {
 		referredFKChecks, referredFKCascades, err := p.buildOnReplaceReferredFKTriggers(ctx, is, dbName, tblInfo)
@@ -173,6 +179,12 @@ func (p *Insert) buildOnInsertFKTriggers(ctx base.PlanContext, is infoschema.Inf
 		}
 		if len(referredFKCascades) > 0 {
 			fkCascades = append(fkCascades, referredFKCascades...)
+			for _, fk := range referredFKCascades {
+				fkDBInfo, ok := infoschema.SchemaByTable(is, fk.ChildTable.Meta())
+				if ok && fkDBInfo.ReadOnly {
+					return errors.Trace(infoschema.ErrSchemaInReadOnlyMode.GenWithStackByArgs(fkDBInfo.Name.O))
+				}
+			}
 		}
 	}
 	for _, fk := range tblInfo.ForeignKeys {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62122

Problem Summary:

Foreign key cascades triggered by `INSERT ... ON DUPLICATE KEY UPDATE` (and `REPLACE`) could write into a read-only schema without being blocked.

### What changed and how does it work?

- Add a schema read-only check when building referred FK cascade triggers for `INSERT ... ON DUPLICATE KEY UPDATE` and `REPLACE`.
- Add a regression unit test to ensure the statement is rejected when the cascade target (child schema) is read-only.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * INSERT (ON DUPLICATE KEY UPDATE), REPLACE, and related cascade actions are blocked when they would cascade into a read-only schema; operations now fail with a read-only error and leave affected rows unchanged.

* **Tests**
  * Added a test that verifies read-only schema enforcement blocks cascade behavior for ON UPDATE (duplicate-key UPDATE) and ON DELETE (REPLACE) paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->