### PR TITLE
executor: cancel inner inflight workers bug fix

### DIFF
--- a/pkg/executor/parallel_apply.go
+++ b/pkg/executor/parallel_apply.go
@@ -193,6 +193,11 @@ func (e *ParallelNestedLoopApplyExec) Next(ctx context.Context, req *chunk.Chunk
 	}
 
 	if atomic.CompareAndSwapUint32(&e.started, 0, 1) {
+		// workerCtx is a cancellable child of ctx. Close() calls
+		// cancelWorkers() to abort in-flight inner/outer workers
+		// (e.g. for LIMIT queries). Coordination goroutines
+		// (notifyWorker, bridge) use the parent ctx instead, since
+		// they must outlive the workers to perform cleanup.
 		workerCtx, cancelWorkers := context.WithCancel(ctx)
 		e.cancelWorkers = cancelWorkers
 		e.workerWg.Add(1)
@@ -200,6 +205,8 @@ func (e *ParallelNestedLoopApplyExec) Next(ctx context.Context, req *chunk.Chunk
 		if e.keepOrder {
 			for i := range e.concurrency {
 				e.workerWg.Add(1)
+				// Uses workerCtx so Close() → cancelWorkers() aborts
+				// in-flight inner-side scans immediately.
 				go e.innerWorkerOrdered(workerCtx, i)
 			}
 			// Bridge goroutine: when all outer+inner workers finish,
@@ -218,10 +225,15 @@ func (e *ParallelNestedLoopApplyExec) Next(ctx context.Context, req *chunk.Chunk
 			for i := range e.concurrency {
 				e.workerWg.Add(1)
 				workID := i
+				// Uses workerCtx so Close() → cancelWorkers() aborts
+				// in-flight inner-side scans immediately.
 				go e.innerWorker(workerCtx, workID)
 			}
 			e.notifyWg.Add(1)
-			go e.notifyWorker(ctx) // deliberately uses parent ctx, not workerCtx
+			// Uses parent ctx (not workerCtx) because notifyWorker
+			// calls workerWg.Wait() and must outlive the workers to
+			// send the EOF result after they have all exited.
+			go e.notifyWorker(ctx)
 		}
 	}
 	result := <-e.resultChkCh


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #66716

Problem Summary:

### What changed and how does it work?

Due to a mistake in resolving a merge conflict (in PR https://github.com/pingcap/tidb/pull/66764) - the incorrect context was set, meaning that the child workers were not canceled correctly. This was an incorrect merge resolution in github (human error).

This caused TestParallelApplyCancelInflight to become flaky. Where, due to timing, it can succeed on a local system or when CI resources are available, but fail on a busy CI system.

The first priority is to fix the context to reduce the flaky test.

Other review comments have come up from AI reviewers - the goal is to address those in this PR https://github.com/pingcap/tidb/pull/66856. But that will require more complex review.

What is the risk of this and the prior PR? In general it is low since it applies only to LIMIT queries when parallel apply is enabled. And parallel apply is disabled by default. When is "apply" used? Mostly when you have a correlated subquery (meaning you are using the NO_DECORRELATE hint or variable). So this is a relatively narrow case. And what happens? Basically it doesn't correctly cancel any existing works that are still executing once the LIMIT value is reached. There is an AI review comment - it is intended to be fixed separately.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parallel execution reliability by fixing cancellation and lifecycle handling so ordered and unordered processing complete and cancel correctly.
  * Ensured end-of-stream signaling now remains reliable even when workers are canceled, preventing premature termination or missed completion messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->