### PR TITLE
resourcegroup/runaway: use FNV-64a hash for runaway record dedup key

### DIFF
--- a/pkg/resourcegroup/runaway/manager.go
+++ b/pkg/resourcegroup/runaway/manager.go
@@ -207,12 +207,7 @@ func (rm *Manager) RunawayRecordFlushLoop() {
 		case <-runawayRecordFlusher.tickerCh(): // flush runaway records periodically
 			runawayRecordFlusher.flush()
 		case r := <-recordCh: // add runaway records to the flusher
-			key := recordKey{
-				ResourceGroupName: r.ResourceGroupName,
-				SQLDigest:         r.SQLDigest,
-				PlanDigest:        r.PlanDigest,
-				Match:             r.Match,
-			}
+			key := newRecordKey(r.ResourceGroupName, r.SQLDigest, r.PlanDigest, r.Match)
 			runawayRecordFlusher.add(key, r)
 		case <-runawayRecordGCTicker.C: // delete expired runaway records periodically
 			go rm.deleteExpiredRows(runawayRecordExpiredDuration)

--- a/pkg/resourcegroup/runaway/record.go
+++ b/pkg/resourcegroup/runaway/record.go
@@ -17,6 +17,7 @@ package runaway
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"strings"
 	"time"
 
@@ -60,12 +61,22 @@ type Record struct {
 	Repeats int
 }
 
-// recordKey represents the composite key for record key in `tidb_runaway_queries`.
-type recordKey struct {
-	ResourceGroupName string
-	SQLDigest         string
-	PlanDigest        string
-	Match             string
+// recordKey represents the composite key for record dedup in `tidb_runaway_queries`.
+// It is a pre-computed FNV-64a hash of (ResourceGroupName, SQLDigest, PlanDigest, Match)
+// to reduce map operation cost when merging high-volume runaway records.
+type recordKey uint64
+
+func newRecordKey(resourceGroupName, sqlDigest, planDigest, match string) recordKey {
+	h := fnv.New64a()
+	// Separator byte 0 prevents collisions like ("ab","c") vs ("a","bc").
+	h.Write([]byte(resourceGroupName))
+	h.Write([]byte{0})
+	h.Write([]byte(sqlDigest))
+	h.Write([]byte{0})
+	h.Write([]byte(planDigest))
+	h.Write([]byte{0})
+	h.Write([]byte(match))
+	return recordKey(h.Sum64())
 }
 
 // genRunawayQueriesStmt generates statement with given RunawayRecords.

--- a/pkg/resourcegroup/runaway/record_test.go
+++ b/pkg/resourcegroup/runaway/record_test.go
@@ -21,54 +21,69 @@ import (
 )
 
 func TestRecordKey(t *testing.T) {
-	// Initialize test data
-	key1 := recordKey{
-		ResourceGroupName: "group1",
-		SQLDigest:         "digest1",
-		PlanDigest:        "plan1",
-	}
-	// key2 is identical to key1
-	key2 := recordKey{
-		ResourceGroupName: "group1",
-		SQLDigest:         "digest1",
-		PlanDigest:        "plan1",
-	}
-	key3 := recordKey{
-		ResourceGroupName: "group2",
-	}
+	// Identical inputs produce the same key.
+	key1 := newRecordKey("group1", "digest1", "plan1", "match1")
+	key2 := newRecordKey("group1", "digest1", "plan1", "match1")
+	assert.Equal(t, key1, key2, "identical inputs should produce the same key")
 
-	// Test MapKey method
+	// Different inputs produce different keys.
+	key3 := newRecordKey("group2", "digest1", "plan1", "match1")
+	assert.NotEqual(t, key1, key3, "different resource group should produce different key")
+
+	key4 := newRecordKey("group1", "digest2", "plan1", "match1")
+	assert.NotEqual(t, key1, key4, "different sql digest should produce different key")
+
+	key5 := newRecordKey("group1", "digest1", "plan2", "match1")
+	assert.NotEqual(t, key1, key5, "different plan digest should produce different key")
+
+	key6 := newRecordKey("group1", "digest1", "plan1", "match2")
+	assert.NotEqual(t, key1, key6, "different match type should produce different key")
+
+	// Empty fields.
+	key7 := newRecordKey("", "", "", "")
+	key8 := newRecordKey("", "", "", "")
+	assert.Equal(t, key7, key8, "empty inputs should produce the same key")
+	assert.NotEqual(t, key1, key7, "empty vs non-empty should differ")
+
+	// Separator prevents cross-field collisions: ("ab","c") vs ("a","bc").
+	keyA := newRecordKey("ab", "c", "", "")
+	keyB := newRecordKey("a", "bc", "", "")
+	assert.NotEqual(t, keyA, keyB, "separator should prevent cross-field collision")
+
+	// Map dedup behavior.
 	recordMap := make(map[recordKey]*Record)
 	record1 := &Record{
 		ResourceGroupName: "group1",
 		SQLDigest:         "digest1",
 		PlanDigest:        "plan1",
-	}
-	// put key1 into recordMap
-	recordMap[key1] = record1
-	assert.Len(t, recordMap, 1, "recordMap should have 1 element")
-	assert.Equal(t, "group1", recordMap[key1].ResourceGroupName, "Repeats should not be updated")
-	assert.Equal(t, 0, recordMap[key1].Repeats, "Repeats should be incremented")
-	// key2 is identical to key1, so we can use key2 to get the record
-	assert.NotNil(t, recordMap[key1], "key1 should exist in recordMap")
-	assert.NotNil(t, recordMap[key2], "key2 should exist in recordMap")
-	assert.Nil(t, recordMap[key3], "key3 should not exist in recordMap")
-
-	// put key2 into recordMap and update Repeats
-	record2 := &Record{
-		ResourceGroupName: "group1",
+		Match:             "match1",
 		Repeats:           1,
 	}
+	recordMap[key1] = record1
+	assert.Len(t, recordMap, 1)
+	assert.NotNil(t, recordMap[key2], "same key should find existing record")
+	assert.Nil(t, recordMap[key3], "different key should not find record")
+
+	// Overwrite with same key increments repeats (simulates mergeFn).
+	record2 := &Record{
+		ResourceGroupName: "group1",
+		SQLDigest:         "digest1",
+		PlanDigest:        "plan1",
+		Match:             "match1",
+		Repeats:           2,
+	}
 	recordMap[key2] = record2
-	assert.Len(t, recordMap, 1, "recordMap should have 1 element")
-	assert.Equal(t, 1, recordMap[key1].Repeats, "Repeats should be updated")
-	// change ResourceGroupName of key2 will not affect key1
-	key2.ResourceGroupName = "group2"
+	assert.Len(t, recordMap, 1, "same key should not increase map size")
+	assert.Equal(t, 2, recordMap[key1].Repeats, "value should be updated")
+
+	// Different key adds new entry.
 	record3 := &Record{
 		ResourceGroupName: "group2",
+		SQLDigest:         "digest1",
+		PlanDigest:        "plan1",
+		Match:             "match1",
+		Repeats:           1,
 	}
-	recordMap[key2] = record3
-	assert.Len(t, recordMap, 2, "recordMap should have 1 element")
-	assert.Equal(t, "group1", recordMap[key1].ResourceGroupName, "Repeats should not be updated")
-	assert.Equal(t, "group2", recordMap[key2].ResourceGroupName, "ResourceGroupName should be updated")
+	recordMap[key3] = record3
+	assert.Len(t, recordMap, 2)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65746

Problem Summary: The runaway record deduplication in the flusher uses a 4-string struct (`ResourceGroupName`, `SQLDigest`, `PlanDigest`, `Match`) as map key. Under extreme load (32K merges per 50ms), map operations on these ~148-byte string keys cost ~3.3ms per cycle.

### What changed and how does it work?

Replace recordKey from a 4-string struct to a pre-computed FNV-64a uint64 hash. A `newRecordKey()` function hashes the 4 fields with null-byte separators to prevent cross-field collisions. Per-entry memory for map keys: ~200 bytes -> 8 bytes.

This fix introduce no API or behavioral changes; the deduplication is best-effort by nature (repeat counting), so the negligible hash collision probability (~1/2^64) is acceptable.

In extreme case (32k merges / 50ms): Map operation cost per flush cycle: ~3.3ms -> ~0.33ms (10x reduction, 5.5% reduction on total flush cycle time)

In normal-day scenario (<512 merges / 30s): Hashing overhead introduced per flush cycle: 5µs -> 5.5µs (~0.5µs overhead over 30s, negligiable)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test - no behavioral changes
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced runaway query detection with optimized hash-based deduplication, improving performance and reliability when identifying duplicate queries.

* **Tests**
  * Expanded test coverage to validate deduplication logic and key generation behavior across various input combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->