### PR TITLE
planner: fix IN-subquery join+agg rewrite duplication with implicit casted RHS keys

### DIFF
--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1291,8 +1291,52 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 		planCtx.builder.optFlag |= rule.FlagEliminateProjection
 		planCtx.builder.optFlag |= rule.FlagJoinReOrder
 		planCtx.builder.optFlag |= rule.FlagEmptySelectionEliminator
+		distinctChild := np
+		distinctLen := np.Schema().Len()
+		joinCondition := checkCondition
+		// IN-subquery rewrite turns:
+		//   outer_col IN (SELECT inner_col ...)
+		// into:
+		//   outer JOIN DISTINCT(inner_col) ON outer_col = inner_col
+		//
+		// DISTINCT must be applied on the same comparison domain as the join predicate.
+		// If "=" injects an implicit cast on the RHS (e.g. blob/string -> number), deduplicating
+		// raw inner values is insufficient: different raw values may become equal after cast and
+		// multiply outer rows in the rewritten inner join.
+		//
+		// To keep semantics equivalent to IN, we project the RHS comparison expression first,
+		// then distinct on that projected key.
+		if lLen == 1 {
+			if eqCond, ok := checkCondition.(*expression.ScalarFunction); ok && eqCond.FuncName.L == ast.EQ {
+				rhs := eqCond.GetArgs()[1]
+				if expression.ExprFromSchema(rhs, np.Schema()) {
+					if _, isCol := rhs.(*expression.Column); !isCol {
+						// rhs is computed from inner columns (typically with an implicit cast generated
+						// by type coercion rules). Materialize it as an inner projection column so both
+						// DISTINCT and JOIN use exactly this coerced key.
+						proj := logicalop.LogicalProjection{Exprs: []expression.Expression{rhs}}.Init(planCtx.builder.ctx, planCtx.builder.getSelectOffset())
+						projCol := &expression.Column{
+							UniqueID: planCtx.builder.ctx.GetSessionVars().AllocPlanColumnID(),
+							RetType:  rhs.GetType(er.sctx.GetEvalCtx()).Clone(),
+						}
+						proj.SetChildren(np)
+						proj.SetSchema(expression.NewSchema(projCol))
+						proj.SetOutputNames([]*types.FieldName{types.EmptyName})
+						distinctChild = proj
+						distinctLen = 1
+						// Rebuild join condition against the projected key; this preserves
+						// the same coercion behavior while preventing duplicate matches.
+						joinCondition, err = er.constructBinaryOpFunction(lexpr, projCol, ast.EQ)
+						if err != nil {
+							er.err = err
+							return v, true
+						}
+					}
+				}
+			}
+		}
 		// Build distinct for the inner query.
-		agg, err := planCtx.builder.buildDistinct(np, np.Schema().Len())
+		agg, err := planCtx.builder.buildDistinct(distinctChild, distinctLen)
 		if err != nil {
 			er.err = err
 			return v, true
@@ -1304,7 +1348,7 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 		join.SetOutputNames(make([]*types.FieldName, planCtx.plan.Schema().Len()+agg.Schema().Len()))
 		copy(join.OutputNames(), planCtx.plan.OutputNames())
 		copy(join.OutputNames()[planCtx.plan.Schema().Len():], agg.OutputNames())
-		join.AttachOnConds(expression.SplitCNFItems(checkCondition))
+		join.AttachOnConds(expression.SplitCNFItems(joinCondition))
 		// set FullSchema and FullNames for this join
 		if left, ok := planCtx.plan.(*logicalop.LogicalJoin); ok && left.FullSchema != nil {
 			join.FullSchema = left.FullSchema

--- a/tests/integrationtest/r/executor/jointest/join.result
+++ b/tests/integrationtest/r/executor/jointest/join.result
@@ -162,6 +162,14 @@ select * from t1 where a not in (select * from t2 where false);
 a
 1
 2
+drop table if exists t0;
+create table t0 (c1 blob);
+insert into t0 values ('gO'), ('W');
+select hex(t0.c1) from t0 where 0 in (select t0.c1 from t0) order by hex(t0.c1);
+hex(t0.c1)
+57
+674F
+drop table if exists t0;
 drop table if exists t1, t2;
 create table t1 (a int, key b (a));
 create table t2 (a int, key b (a));

--- a/tests/integrationtest/t/executor/jointest/join.test
+++ b/tests/integrationtest/t/executor/jointest/join.test
@@ -137,6 +137,11 @@ select * from t1 where a in (select * from t2);
 select * from t1 where a in (select * from t2 where false);
 --sorted_result
 select * from t1 where a not in (select * from t2 where false);
+drop table if exists t0;
+create table t0 (c1 blob);
+insert into t0 values ('gO'), ('W');
+select hex(t0.c1) from t0 where 0 in (select t0.c1 from t0) order by hex(t0.c1);
+drop table if exists t0;
 drop table if exists t1, t2;
 create table t1 (a int, key b (a));
 create table t2 (a int, key b (a));


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64230

Problem Summary: planner: fix IN-subquery join+agg rewrite duplication with implicit casted RHS keys

### What changed and how does it work?

Fix a semantic mismatch in `IN (subquery)` rewrite (`tidb_opt_insubq_to_join_and_agg=1`) that could duplicate outer rows when the inner comparison key is implicitly cast.

Before this change, TiDB could rewrite:

- `outer_col IN (SELECT inner_col ...)`

into `INNER JOIN + DISTINCT(inner_col)` and deduplicate on raw inner values. In some cases (for example `BLOB`/string values compared to numeric), different raw inner values become equal after implicit cast during `=` comparison, so the rewritten join could match multiple inner rows and return duplicated outer rows.

This patch makes deduplication happen on the same RHS comparison key domain used by the join predicate:

- materialize RHS comparison expression via inner projection when needed
- apply `DISTINCT` on that projected key
- rebuild join condition against the projected key

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IN-subquery to join conversion to better handle type coercion in certain scenarios.

* **Tests**
  * Added test coverage for blob data handling in join operations.
  * Expanded join test scenarios with additional edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->