### PR TITLE
ddl: preserve binary operation precedence in view restore for correlated subquery MOD

### DIFF
--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -1754,7 +1754,9 @@ func ShouldBuildClusteredIndex(mode vardef.ClusteredIndexDefMode, opt *ast.Index
 // BuildViewInfo builds a ViewInfo structure from an ast.CreateViewStmt.
 func BuildViewInfo(s *ast.CreateViewStmt) (*model.ViewInfo, error) {
 	// Always Use `format.RestoreNameBackQuotes` to restore `SELECT` statement despite the `ANSI_QUOTES` SQL Mode is enabled or not.
-	restoreFlag := format.RestoreStringSingleQuotes | format.RestoreKeyWordUppercase | format.RestoreNameBackQuotes
+	// Preserve operator precedence when view SQL is restored and re-parsed.
+	restoreFlag := format.RestoreStringSingleQuotes | format.RestoreKeyWordUppercase | format.RestoreNameBackQuotes |
+		format.RestoreBracketAroundBinaryOperation
 	var sb strings.Builder
 	if err := s.Select.Restore(format.NewRestoreCtx(restoreFlag, &sb)); err != nil {
 		return nil, err

--- a/pkg/planner/core/casetest/correlated/BUILD.bazel
+++ b/pkg/planner/core/casetest/correlated/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         "//pkg/testkit",
         "//pkg/testkit/testdata",

--- a/pkg/planner/core/casetest/correlated/correlated_test.go
+++ b/pkg/planner/core/casetest/correlated/correlated_test.go
@@ -114,3 +114,21 @@ func TestWrongDecorrelate(t *testing.T) {
 		" 30025.20000000000000000000 60121022342",
 		"X 6.23000000000000000000 60021022342"))
 }
+
+func TestViewCorrelatedSubqueryMOD(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop view if exists vtable0")
+	tk.MustExec("drop table if exists t1, t3")
+	tk.MustExec("create table t1 (c1 int)")
+	tk.MustExec("create table t3 (c0 int)")
+	tk.MustExec("insert into t1 values (10)")
+	tk.MustExec("insert into t3 values (9)")
+	tk.MustExec(`create view vtable0 as (
+		select (select t1.c1 from t1 where mod(t1.c1, t3.c0 + 1) = 0) as c1
+		from t3
+		join t1 on true
+	)`)
+	tk.MustQuery("select vtable0.c1 from vtable0").Check(testkit.Rows("10"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63289

Problem Summary: ddl: preserve binary operation precedence in view restore for correlated subquery MOD

### What changed and how does it work?

- Fix view definition restore to preserve binary-operation precedence by enabling `RestoreBracketAroundBinaryOperation` in `BuildViewInfo`.
- Add a regression test for correlated scalar subquery in a view using `MOD(t1.c1, t3.c0 + 1)`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed operator precedence handling in view SQL restoration to ensure correct query interpretation.

* **Tests**
  * Added test coverage for view-correlated subquery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->