### PR TITLE
fix: normalize size units in configuration and add corresponding tests

### DIFF
--- a/pkg/executor/set_config.go
+++ b/pkg/executor/set_config.go
@@ -195,6 +195,7 @@ func ConvertConfigItem2JSON(ctx sessionctx.Context, key string, val expression.E
 		var s string
 		s, isNull, err = val.EvalString(ctx.GetExprCtx().GetEvalCtx(), chunk.Row{})
 		if err == nil && !isNull {
+			s = normalizeSizeUnit(s)
 			str = fmt.Sprintf("%q", s)
 		}
 	case types.ETInt:
@@ -233,4 +234,19 @@ func ConvertConfigItem2JSON(ctx sessionctx.Context, key string, val expression.E
 	}
 	body = fmt.Sprintf(`{"%s":%s}`, key, str)
 	return body, nil
+}
+
+func normalizeSizeUnit(s string) string {
+	replacements := []struct{ from, to string }{
+		{"TB", "TiB"},
+		{"GB", "GiB"},
+		{"MB", "MiB"},
+		{"KB", "KiB"},
+	}
+	for _, r := range replacements {
+		if strings.HasSuffix(s, r.from) && !strings.HasSuffix(s, "i"+r.from) {
+			return s[:len(s)-len(r.from)] + r.to
+		}
+	}
+	return s
 }

--- a/pkg/executor/set_config.go
+++ b/pkg/executor/set_config.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -245,7 +246,10 @@ func normalizeSizeUnit(s string) string {
 	}
 	for _, r := range replacements {
 		if strings.HasSuffix(s, r.from) && !strings.HasSuffix(s, "i"+r.from) {
-			return s[:len(s)-len(r.from)] + r.to
+			prefix := strings.TrimSpace(s[:len(s)-len(r.from)])
+			if _, err := strconv.ParseFloat(prefix, 64); err == nil {
+				return prefix + r.to
+			}
 		}
 	}
 	return s

--- a/pkg/executor/set_test.go
+++ b/pkg/executor/set_test.go
@@ -1684,7 +1684,7 @@ func TestSetClusterConfig(t *testing.T) {
 		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 		// The `raftstore.` prefix is stripped.
-		require.JSONEq(t, `{"server.snap-max-write-bytes-per-sec":"500MB"}`, string(body))
+		require.JSONEq(t, `{"server.snap-max-write-bytes-per-sec":"500MiB"}`, string(body))
 		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 	})
 	tk.MustExec("set config tiflash `raftstore-proxy.server.snap-max-write-bytes-per-sec`='500MB'")
@@ -1726,6 +1726,8 @@ func TestSetClusterConfigJSONData(t *testing.T) {
 		{&expression.Constant{Value: types.NewStringDatum("1GB"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"1GiB"}`, true},
 		{&expression.Constant{Value: types.NewStringDatum("512KB"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"512KiB"}`, true},
 		{&expression.Constant{Value: types.NewStringDatum("2TB"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"2TiB"}`, true},
+		{&expression.Constant{Value: types.NewStringDatum("fooMB"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"fooMB"}`, true},     // non-size string must not be converted
+		{&expression.Constant{Value: types.NewStringDatum("dataTB"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"dataTB"}`, true},   // non-size string must not be converted
 		{&expression.Constant{Value: types.NewDecimalDatum(&d), RetType: types.NewFieldType(mysql.TypeNewDecimal)}, `{"k":123.456}`, true},
 		{&expression.Constant{Value: types.NewDatum(nil), RetType: types.NewFieldType(mysql.TypeLonglong)}, "", false},
 		{&expression.Constant{RetType: types.NewFieldType(mysql.TypeJSON)}, "", false}, // unsupported type
@@ -1741,6 +1743,43 @@ func TestSetClusterConfigJSONData(t *testing.T) {
 		} else {
 			require.Error(t, err)
 		}
+	}
+}
+
+func TestSetConfigUnitNormalizationRoundTrip(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	serversInfo := []infoschema.ServerInfo{
+		{ServerType: "tikv", Address: "127.0.0.1:5555", StatusAddr: "127.0.0.1:5555"},
+	}
+	tk.Session().SetValue(executor.TestSetConfigServerInfoKey,
+		func(sessionctx.Context) ([]infoschema.ServerInfo, error) {
+			return serversInfo, nil
+		})
+
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"24MB", "24MiB"},
+		{"1GB", "1GiB"},
+		{"512KB", "512KiB"},
+		{"24MiB", "24MiB"},
+		{"fooMB", "fooMB"},
+	}
+
+	for _, c := range cases {
+		var gotBody string
+		tk.Session().SetValue(executor.TestSetConfigHTTPHandlerKey,
+			func(req *http.Request) (*http.Response, error) {
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				gotBody = string(body)
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
+			})
+		tk.MustExec(fmt.Sprintf("set config tikv `test.size`='%s'", c.input))
+		require.JSONEq(t, fmt.Sprintf(`{"test.size":"%s"}`, c.expected), gotBody)
 	}
 }
 

--- a/pkg/executor/set_test.go
+++ b/pkg/executor/set_test.go
@@ -1721,6 +1721,11 @@ func TestSetClusterConfigJSONData(t *testing.T) {
 		{&expression.Constant{Value: types.NewIntDatum(2333), RetType: types.NewFieldType(mysql.TypeLong)}, `{"k":2333}`, true},
 		{&expression.Constant{Value: types.NewFloat64Datum(23.33), RetType: types.NewFieldType(mysql.TypeDouble)}, `{"k":23.33}`, true},
 		{&expression.Constant{Value: types.NewStringDatum("abcd"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"abcd"}`, true},
+		{&expression.Constant{Value: types.NewStringDatum("24MB"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"24MiB"}`, true},
+		{&expression.Constant{Value: types.NewStringDatum("24MiB"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"24MiB"}`, true},
+		{&expression.Constant{Value: types.NewStringDatum("1GB"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"1GiB"}`, true},
+		{&expression.Constant{Value: types.NewStringDatum("512KB"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"512KiB"}`, true},
+		{&expression.Constant{Value: types.NewStringDatum("2TB"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"2TiB"}`, true},
 		{&expression.Constant{Value: types.NewDecimalDatum(&d), RetType: types.NewFieldType(mysql.TypeNewDecimal)}, `{"k":123.456}`, true},
 		{&expression.Constant{Value: types.NewDatum(nil), RetType: types.NewFieldType(mysql.TypeLonglong)}, "", false},
 		{&expression.Constant{RetType: types.NewFieldType(mysql.TypeJSON)}, "", false}, // unsupported type


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51740

Problem Summary:

When a user sets a TiKV config value using SI units (e.g., `SET CONFIG tikv raftstore.raft-entry-max-size='24MB'`), `SHOW CONFIG` returns the value in IEC units (`24MiB`). 
This is because TiKV internally treats MB and MiB equivalently (both as 1024-based) and always formats output in IEC units. 
The mismatch between input and output units confuses users.

### What changed and how does it work?

Add `normalizeSizeUnit()` in `pkg/executor/set_config.go` that converts SI size suffixes (KB, MB, GB, TB) to IEC suffixes (KiB, MiB, GiB, TiB) before sending the value to TiKV via `ConvertConfigItem2JSON()`. This ensures the unit in `SET CONFIG` matches what TiKV returns in `SHOW CONFIG`.

- Values already using IEC units (e.g., `24MiB`) are not modified (idempotent).
- Non-size string values are passed through unchanged.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that `SHOW CONFIG` displays a different unit (e.g., `MiB`) from the unit specified in `SET CONFIG` (e.g., `MB`) for size-related configuration items 
https://github.com/pingcap/tidb/issues/51740
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration values with decimal storage units (KB/MB/GB/TB) are now normalized to binary units (KiB/MiB/GiB/TiB) when converting config items to JSON, ensuring consistent capacity representation.
* **Tests**
  * Added tests covering unit normalization (including round-trip HTTP cases) and multiple size-suffix scenarios, plus coverage for non-convertible strings remaining unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->