### PR TITLE
*: upgrade go1.25.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # production environment, please refer to https://github.com/PingCAP-QE/artifacts/blob/main/dockerfiles/cd/builders/tidb/Dockerfile.
 
 # Builder image
-FROM golang:1.25.6 as builder
+FROM golang:1.25.8 as builder
 WORKDIR /tidb
 
 COPY . .

--- a/Dockerfile.enterprise
+++ b/Dockerfile.enterprise
@@ -14,7 +14,7 @@
 
 # The current dockerfile is only used for development purposes.
 # Builder image
-FROM golang:1.25.6 as builder
+FROM golang:1.25.8 as builder
 WORKDIR /tidb
 
 COPY . .

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -108,7 +108,7 @@ go_download_sdk(
         "https://mirrors.aliyun.com/golang/{}",
         "https://dl.google.com/go/{}",
     ],
-    version = "1.25.6",
+    version = "1.25.8",
 )
 
 gazelle_dependencies(go_sdk = "go_sdk")

--- a/build/image/base
+++ b/build/image/base
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 
 # install golang toolchain
 # renovate: datasource=docker depName=golang
-ARG GOLANG_VERSION=1.25.6
+ARG GOLANG_VERSION=1.25.8
 RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
     curl -fsSL https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin/:$PATH

--- a/build/image/parser_test
+++ b/build/image/parser_test
@@ -14,7 +14,7 @@
 
 FROM rockylinux:9
 
-ENV GOLANG_VERSION 1.25.6
+ENV GOLANG_VERSION 1.25.8
 ENV ARCH amd64
 ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-$ARCH.tar.gz
 ENV GOPATH /home/prow/go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tidb
 
-go 1.25.6
+go 1.25.8
 
 require (
 	cloud.google.com/go/kms v1.15.8

--- a/pkg/parser/go.mod
+++ b/pkg/parser/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tidb/pkg/parser
 
-go 1.24
+go 1.25
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1


### PR DESCRIPTION


### What problem does this PR solve?


Issue Number: ref #66942

Problem Summary:

Upgrade Go from 1.25.6 to 1.25.8 as a security patch release, so TiDB can pick up the upstream Go 1.25.8 cherry-picked fixes and keep the build toolchain aligned across `go.mod`, Bazel, and Docker images.

### What changed and how does it work?

### Check List

Tests 

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > 

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note



Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain from version 1.25.6 to 1.25.8 across build environments and container images
  * Updated Go module language version requirement to 1.25

<!-- end of auto-generated comment: release notes by coderabbit.ai -->