### PR TITLE
skills: move GitHub issue and PR metadata workflows into skills

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -15,6 +15,7 @@ Current operational workflow skills:
 - `tidb-realtikv-runner`: run RealTiKV tests with startup/cleanup discipline.
 - `tidb-test-diff-triage`: triage unexpected test diffs (failpoint vs upstream vs local regression).
 - `tidb-test-guidelines`: test placement, naming, writing conventions, and shard_count guidance.
+- `tidb-pr-metadata-guard`: create or update TiDB PR descriptions without breaking template-required HTML comments or bot-parsed checklist sections.
 
 Use `AGENTS.md` for repository policy, validation/reporting requirements, and the pre-flight checklist.
 Use `docs/agents/testing-flow.md` for canonical build/test command playbooks.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -15,7 +15,8 @@ Current operational workflow skills:
 - `tidb-realtikv-runner`: run RealTiKV tests with startup/cleanup discipline.
 - `tidb-test-diff-triage`: triage unexpected test diffs (failpoint vs upstream vs local regression).
 - `tidb-test-guidelines`: test placement, naming, writing conventions, and shard_count guidance.
-- `tidb-pr-metadata-guard`: create or update TiDB PR descriptions without breaking template-required HTML comments or bot-parsed checklist sections.
+- `tidb-issue-metadata-guard`: create or update TiDB issues without breaking required templates, labels, or issue metadata conventions.
+- `tidb-pr-metadata-guard`: create or update TiDB PR descriptions without breaking PR title scope conventions, required templates, HTML comments, or bot-parsed checklist sections.
 
 Use `AGENTS.md` for repository policy, validation/reporting requirements, and the pre-flight checklist.
 Use `docs/agents/testing-flow.md` for canonical build/test command playbooks.

--- a/.agents/skills/tidb-issue-metadata-guard/SKILL.md
+++ b/.agents/skills/tidb-issue-metadata-guard/SKILL.md
@@ -25,7 +25,8 @@ Before creating an issue, read the matching file under `.github/ISSUE_TEMPLATE/`
    - Severity labeling rule:
      - Wrong-result bugs: use `severity/major`.
      - Query fails to execute on valid SQL, for example an internal planner or runtime error: use `severity/major`.
-   - If label permissions are missing, include `Suggested labels: ...` in the issue body.
+   - If label permissions are missing, first add labels by commenting `/label <label name>`.
+   - If label comments still do not work, add a separate comment with `Suggested labels: ...`.
 5. Prefer file-based edits for GitHub metadata.
    - Materialize the intended issue body in a local Markdown file.
    - Review that file against the matching issue template before calling `gh`.
@@ -34,4 +35,4 @@ Before creating an issue, read the matching file under `.github/ISSUE_TEMPLATE/`
 
 - The issue title and body are in English.
 - The issue still follows the matching template structure.
-- The issue carries the expected labels, or the body includes `Suggested labels: ...` when label permissions are missing.
+- The issue carries the expected labels, or a follow-up label comment / `Suggested labels: ...` comment is present when label permissions are missing.

--- a/.agents/skills/tidb-issue-metadata-guard/SKILL.md
+++ b/.agents/skills/tidb-issue-metadata-guard/SKILL.md
@@ -19,12 +19,22 @@ Before creating an issue, read the matching file under `.github/ISSUE_TEMPLATE/`
 3. Start from the matching issue template instead of writing the body from scratch.
    - Follow the template and fill the required sections.
    - For bug reports, include minimal reproduction, expected behavior, actual behavior, and TiDB version information when available.
+   - Fill issue fields with concrete values from the available artifacts instead of generic placeholders.
+   - Keep the first screen readable: show the top-level repro summary, expected result, actual result, and version directly in the section body.
+   - If a field is long, keep a short visible summary and put the full content in a `<details>` block.
+     - Good candidates: full repro SQL, full schema, long logs, checksum diffs, execution plans, and plan replayer notes.
+     - Do not hide the only reproduction steps or the top-level expected/actual conclusion inside `<details>`.
+   - If supporting artifacts exist, mention them explicitly in the repro steps or attachments summary.
+   - When adding an analysis section, keep it short and evidence-backed:
+     - 1–3 likely causes at most
+     - prefer evidence from SQL shape, plans, errors, or result diffs
 4. If you create an issue with `gh issue create`, add labels explicitly when the GitHub UI would normally auto-apply them.
    - Add at least one `component/*` label.
    - For bug or regression issues, add `severity/*` and affected-version labels when appropriate.
    - Severity labeling rule:
      - Wrong-result bugs: use `severity/major`.
      - Query fails to execute on valid SQL, for example an internal planner or runtime error: use `severity/major`.
+     - Complex-query or compatibility issues that are not confirmed wrong-result and are not execution-blocking: use `severity/moderate`.
    - If label permissions are missing, first add labels by commenting `/label <label name>`.
    - If label comments still do not work, add a separate comment with `Suggested labels: ...`.
 5. Prefer file-based edits for GitHub metadata.
@@ -35,4 +45,5 @@ Before creating an issue, read the matching file under `.github/ISSUE_TEMPLATE/`
 
 - The issue title and body are in English.
 - The issue still follows the matching template structure.
+- Long raw artifacts are folded with `<details>` when needed, while the top-level summary remains visible.
 - The issue carries the expected labels, or a follow-up label comment / `Suggested labels: ...` comment is present when label permissions are missing.

--- a/.agents/skills/tidb-issue-metadata-guard/SKILL.md
+++ b/.agents/skills/tidb-issue-metadata-guard/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: tidb-issue-metadata-guard
+description: Use when creating or editing TiDB GitHub issues so issue templates, labels, issue titles, and issue descriptions stay consistent with repository workflow. Trigger on tasks involving issue creation, bug reports, enhancement tracking issues, label selection, or searching for existing issues and PRs before filing a new one.
+---
+
+# TiDB Issue Metadata Guard
+
+## Overview
+
+Use this skill for TiDB GitHub issue metadata updates.
+The goal is to preserve issue-template structure, label hygiene, and searchable issue descriptions.
+
+Before creating an issue, read the matching file under `.github/ISSUE_TEMPLATE/`.
+
+## Workflow
+
+1. Write issue titles and descriptions in English.
+2. Search existing issues and PRs first when the task is bug reporting or tracking an existing change.
+3. Start from the matching issue template instead of writing the body from scratch.
+   - Follow the template and fill the required sections.
+   - For bug reports, include minimal reproduction, expected behavior, actual behavior, and TiDB version information when available.
+4. If you create an issue with `gh issue create`, add labels explicitly when the GitHub UI would normally auto-apply them.
+   - Add at least one `component/*` label.
+   - For bug or regression issues, add `severity/*` and affected-version labels when appropriate.
+   - If label permissions are missing, include `Suggested labels: ...` in the issue body.
+5. Prefer file-based edits for GitHub metadata.
+   - Materialize the intended issue body in a local Markdown file.
+   - Review that file against the matching issue template before calling `gh`.
+
+## Quick Checks
+
+- The issue title and body are in English.
+- The issue still follows the matching template structure.
+- The issue carries the expected labels, or the body includes `Suggested labels: ...` when label permissions are missing.

--- a/.agents/skills/tidb-issue-metadata-guard/SKILL.md
+++ b/.agents/skills/tidb-issue-metadata-guard/SKILL.md
@@ -22,6 +22,9 @@ Before creating an issue, read the matching file under `.github/ISSUE_TEMPLATE/`
 4. If you create an issue with `gh issue create`, add labels explicitly when the GitHub UI would normally auto-apply them.
    - Add at least one `component/*` label.
    - For bug or regression issues, add `severity/*` and affected-version labels when appropriate.
+   - Severity labeling rule:
+     - Wrong-result bugs: use `severity/major`.
+     - Query fails to execute on valid SQL, for example an internal planner or runtime error: use `severity/major`.
    - If label permissions are missing, include `Suggested labels: ...` in the issue body.
 5. Prefer file-based edits for GitHub metadata.
    - Materialize the intended issue body in a local Markdown file.

--- a/.agents/skills/tidb-issue-metadata-guard/SKILL.md
+++ b/.agents/skills/tidb-issue-metadata-guard/SKILL.md
@@ -10,13 +10,13 @@ description: Use when creating or editing TiDB GitHub issues so issue templates,
 Use this skill for TiDB GitHub issue metadata updates.
 The goal is to preserve issue-template structure, label hygiene, and searchable issue descriptions.
 
-Before creating an issue, read the matching file under `.github/ISSUE_TEMPLATE/`.
+Before creating or editing an issue, read the matching file under `.github/ISSUE_TEMPLATE/`.
 
 ## Workflow
 
 1. Write issue titles and descriptions in English.
 2. Search existing issues and PRs first when the task is bug reporting or tracking an existing change.
-3. Start from the matching issue template instead of writing the body from scratch.
+3. When creating a new issue, start from the matching issue template instead of writing the body from scratch.
    - Follow the template and fill the required sections.
    - For bug reports, include minimal reproduction, expected behavior, actual behavior, and TiDB version information when available.
    - Fill issue fields with concrete values from the available artifacts instead of generic placeholders.
@@ -28,7 +28,13 @@ Before creating an issue, read the matching file under `.github/ISSUE_TEMPLATE/`
    - When adding an analysis section, keep it short and evidence-backed:
      - 1–3 likely causes at most
      - prefer evidence from SQL shape, plans, errors, or result diffs
-4. If you create an issue with `gh issue create`, add labels explicitly when the GitHub UI would normally auto-apply them.
+4. When editing an existing issue, start from the current issue body instead of rewriting it from scratch.
+   - Fetch the current title, body, and labels first.
+   - Patch only the intended template sections and preserve untouched sections, metadata, and still-valid context.
+   - Re-apply the same content rules used for new issues: concrete values, visible top-level summary, `<details>` for long raw artifacts, and short evidence-backed analysis when needed.
+5. When applying labels, do it explicitly instead of assuming the UI or template will fill them in.
+   - For new issues created with `gh issue create`, add labels explicitly when the GitHub UI would normally auto-apply them.
+   - For existing issues, prefer `gh issue edit` so labels reflect the current state after the body update.
    - Add at least one `component/*` label.
    - For bug or regression issues, add `severity/*` and affected-version labels when appropriate.
    - Severity labeling rule:
@@ -37,13 +43,15 @@ Before creating an issue, read the matching file under `.github/ISSUE_TEMPLATE/`
      - Complex-query or compatibility issues that are not confirmed wrong-result and are not execution-blocking: use `severity/moderate`.
    - If label permissions are missing, first add labels by commenting `/label <label name>`.
    - If label comments still do not work, add a separate comment with `Suggested labels: ...`.
-5. Prefer file-based edits for GitHub metadata.
+6. Prefer file-based edits for GitHub metadata.
    - Materialize the intended issue body in a local Markdown file.
-   - Review that file against the matching issue template before calling `gh`.
+   - For new issues, review that file against the matching issue template before calling `gh`.
+   - For existing issues, diff the patched body against the current issue body before calling `gh`.
 
 ## Quick Checks
 
 - The issue title and body are in English.
 - The issue still follows the matching template structure.
 - Long raw artifacts are folded with `<details>` when needed, while the top-level summary remains visible.
+- Existing issue edits preserve untouched sections and metadata outside the intended patch.
 - The issue carries the expected labels, or a follow-up label comment / `Suggested labels: ...` comment is present when label permissions are missing.

--- a/.agents/skills/tidb-pr-metadata-guard/SKILL.md
+++ b/.agents/skills/tidb-pr-metadata-guard/SKILL.md
@@ -10,10 +10,7 @@ description: Use when creating or editing TiDB pull requests so PR template fiel
 Use this skill for TiDB GitHub metadata updates that touch PR descriptions or linked issues.
 The goal is to preserve repository-required template structure while editing only the mutable fields.
 
-Before changing a PR body, read:
-
-- `AGENTS.md` -> `PR requirements`
-- `.github/pull_request_template.md`
+Before changing a PR body, read `.github/pull_request_template.md`.
 
 ## Workflow
 

--- a/.agents/skills/tidb-pr-metadata-guard/SKILL.md
+++ b/.agents/skills/tidb-pr-metadata-guard/SKILL.md
@@ -1,41 +1,44 @@
 ---
 name: tidb-pr-metadata-guard
-description: Use when creating or editing TiDB pull requests so PR template fields, hidden HTML comments, and bot-parsed checklist sections stay intact. Trigger on tasks involving PR body updates, issue linking, test checklist updates, or investigating labels like do-not-merge/needs-tests-checked.
+description: Use when creating or editing TiDB pull requests so PR title scope, PR template fields, hidden HTML comments, and bot-parsed checklist sections stay intact. Trigger on tasks involving PR creation, PR body updates, issue linking from a PR, test checklist updates, or investigating labels like do-not-merge/needs-tests-checked.
 ---
 
 # TiDB PR Metadata Guard
 
 ## Overview
 
-Use this skill for TiDB GitHub metadata updates that touch PR descriptions or linked issues.
-The goal is to preserve repository-required template structure while editing only the mutable fields.
+Use this skill for TiDB GitHub pull request metadata updates.
+The goal is to preserve repository-required PR structure while editing only the mutable fields.
 
 Before changing a PR body, read `.github/pull_request_template.md`.
 
 ## Workflow
 
-1. For a new PR, start from `.github/pull_request_template.md` instead of writing the body from scratch.
+1. Write PR titles and descriptions in English.
+2. For a new PR, start from `.github/pull_request_template.md` instead of writing the body from scratch.
+   - Use a title in the form `pkg [, pkg2, pkg3]: what is changed` or `*: what is changed`.
+   - In that title format, `pkg` means the TiDB module area, not a literal Go package path. For example, changes under `pkg/planner/core` usually map to `planner`, not `pkg/planner/core`.
    - Use `gh pr create -T .github/pull_request_template.md`.
    - Fill in the template in a Markdown file first, then submit it.
-2. For an existing PR, update only the mutable sections.
+3. For an existing PR, update only the mutable sections.
    - Safe targets: `Issue Number:`, `Problem Summary:`, the content under `### What changed and how does it work?`, test checkbox states and concrete commands, and the `release-note` block.
    - Do not rename headings, reorder checklist sections, or rewrite the template wholesale.
-3. Preserve hidden HTML comments exactly.
+4. Preserve hidden HTML comments exactly.
    - Keep `Tests <!-- At least one of them must be included. -->` unchanged.
    - Keep the `No need to test` nested block and its HTML comment unchanged.
    - Do not delete or rewrite template comments that explain issue linking or release-note behavior.
-4. If a PR needs a new linked issue, create or identify the issue first, then patch only the `Issue Number:` line in the PR body.
-5. Prefer file-based edits for GitHub metadata.
+5. If a PR needs a new linked issue, use `tidb-issue-metadata-guard` to create or identify the issue first, then patch only the `Issue Number:` line in the PR body.
+6. Prefer file-based edits for GitHub metadata.
    - Materialize the intended issue body or PR body into a local Markdown file.
-   - Review that file against the repository template before calling `gh`.
-6. After any PR body update, re-read the PR and check whether bot-gated labels changed as expected.
+   - Review that file against the PR template before calling `gh`.
+7. After any PR body update, re-read the PR and check whether bot-gated labels changed as expected.
    - `do-not-merge/needs-linked-issue`
    - `do-not-merge/needs-tests-checked`
    - If a label remains unexpectedly, diff the current body against `.github/pull_request_template.md` before changing anything else.
 
 ## Quick Checks
 
-- The PR body still contains one `Issue Number:` line with `close #<id>` or `ref #<id>`.
+- The PR body still contains an `Issue Number:` line, and that line can reference one or more related issues with full keyword syntax such as `close #<id>` and `ref #<id>`.
+- The PR title uses module-oriented scope names such as `planner`, `executor`, or `*:`, not raw Go package paths such as `pkg/planner/core`.
 - The `Tests` line still includes the template HTML comment verbatim.
 - At least one test checkbox is checked, or `No need to test` is checked with a reason.
-- If you created an issue via `gh issue create`, read the matching template in `.github/ISSUE_TEMPLATE/` and add labels explicitly when the UI would normally auto-apply them.

--- a/.agents/skills/tidb-pr-metadata-guard/SKILL.md
+++ b/.agents/skills/tidb-pr-metadata-guard/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: tidb-pr-metadata-guard
+description: Use when creating or editing TiDB pull requests so PR template fields, hidden HTML comments, and bot-parsed checklist sections stay intact. Trigger on tasks involving PR body updates, issue linking, test checklist updates, or investigating labels like do-not-merge/needs-tests-checked.
+---
+
+# TiDB PR Metadata Guard
+
+## Overview
+
+Use this skill for TiDB GitHub metadata updates that touch PR descriptions or linked issues.
+The goal is to preserve repository-required template structure while editing only the mutable fields.
+
+Before changing a PR body, read:
+
+- `AGENTS.md` -> `PR requirements`
+- `.github/pull_request_template.md`
+
+## Workflow
+
+1. For a new PR, start from `.github/pull_request_template.md` instead of writing the body from scratch.
+   - Use `gh pr create -T .github/pull_request_template.md`.
+   - Fill in the template in a Markdown file first, then submit it.
+2. For an existing PR, update only the mutable sections.
+   - Safe targets: `Issue Number:`, `Problem Summary:`, the content under `### What changed and how does it work?`, test checkbox states and concrete commands, and the `release-note` block.
+   - Do not rename headings, reorder checklist sections, or rewrite the template wholesale.
+3. Preserve hidden HTML comments exactly.
+   - Keep `Tests <!-- At least one of them must be included. -->` unchanged.
+   - Keep the `No need to test` nested block and its HTML comment unchanged.
+   - Do not delete or rewrite template comments that explain issue linking or release-note behavior.
+4. If a PR needs a new linked issue, create or identify the issue first, then patch only the `Issue Number:` line in the PR body.
+5. Prefer file-based edits for GitHub metadata.
+   - Materialize the intended issue body or PR body into a local Markdown file.
+   - Review that file against the repository template before calling `gh`.
+6. After any PR body update, re-read the PR and check whether bot-gated labels changed as expected.
+   - `do-not-merge/needs-linked-issue`
+   - `do-not-merge/needs-tests-checked`
+   - If a label remains unexpectedly, diff the current body against `.github/pull_request_template.md` before changing anything else.
+
+## Quick Checks
+
+- The PR body still contains one `Issue Number:` line with `close #<id>` or `ref #<id>`.
+- The `Tests` line still includes the template HTML comment verbatim.
+- At least one test checkbox is checked, or `No need to test` is checked with a reason.
+- If you created an issue via `gh issue create`, read the matching template in `.github/ISSUE_TEMPLATE/` and add labels explicitly when the UI would normally auto-apply them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@ When writing complex features or significant refactors, use an ExecPlan from des
 | Fmt-only PR | MUST NOT run costly `realtikvtest`; local compilation is enough. |
 | During local coding iterations (not claiming completion) | SHOULD use the `WIP` verification profile from `.agents/skills/tidb-verify-profile` to run only scoped checks. |
 | Claiming task completion / PR readiness | MUST use the `Ready` verification profile from `.agents/skills/tidb-verify-profile`; if there are code changes, this includes `make lint`. `Ready` is mandatory before making final-status claims such as "fixed", "done", "all tests pass", "ready for review", or "ready for PR". |
+| Creating or updating a GitHub issue | SHOULD use `.agents/skills/tidb-issue-metadata-guard` to preserve issue templates and label hygiene. |
+| Creating a PR or editing PR metadata | SHOULD use `.agents/skills/tidb-pr-metadata-guard` to preserve PR templates, title scope, and bot-parsed checklist sections. |
 | Before finishing | SHOULD self-review diff quality before finishing. |
 | Expensive optional sweeps (for example `make bazel_lint_changed`, broad package runs) | MUST run only when required by change scope, CI reproduction, or explicit user request. |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,9 @@ When writing complex features or significant refactors, use an ExecPlan from des
 - `.github/skills` is kept only as a migration note path and should not be used as the primary location for new skill updates.
 - Policy belongs in `AGENTS.md`; detailed command playbooks SHOULD live in `docs/agents/*`, and skills SHOULD provide entrypoint workflows that reference those playbooks.
 - Operational testing/build skills are indexed in `.agents/skills/README.md` to avoid duplicated lists drifting in multiple docs.
+- GitHub metadata workflows are indexed in `.agents/skills/README.md`.
+  - Use `tidb-issue-metadata-guard` for issue creation and issue metadata updates.
+  - Use `tidb-pr-metadata-guard` for PR creation, PR body updates, and PR-linked issue references.
 
 ## Pre-flight Checklist
 
@@ -170,32 +173,6 @@ Command details for package, integration-test, and RealTiKV surfaces live in `do
 - Use explicit placeholders such as `<package_name>`, `<TestName>`, and `<dir>`.
 - Documentation updates SHOULD keep terminology, policy wording, and command conventions consistent across related docs.
 - Keep guidance executable and concrete; avoid ambiguous phrasing.
-- Issues and PRs MUST be written in English (title and description).
-
-## Issue and PR Rules
-
-### Issue rules
-
-- Follow templates under `.github/ISSUE_TEMPLATE/` and fill all required fields.
-- Bug reports should include minimal reproduction, expected/actual behavior, and TiDB version (for example `SELECT tidb_version()` output).
-- Search existing issues/PRs first (for example `gh search issues --repo pingcap/tidb --include-prs "<keywords>"`), then add relevant logs/configuration/SQL plans.
-- Labeling requirements:
-  - `type/*` is usually applied by the issue template (GitHub UI); if creating issues via `gh issue create`, add it explicitly via `--label` (or follow up with `gh issue edit --add-label`).
-  - Add at least one `component/*` label.
-  - For bug/regression, include `severity/*` and affected-version labels (for example `affects-8.5`, or `may-affects-*` if unsure).
-  - If label permissions are missing, include `Suggested labels: ...` in issue body.
-
-### PR requirements
-
-- PR title MUST use one of:
-  - `pkg [, pkg2, pkg3]: what is changed`
-  - `*: what is changed`
-- PR description MUST follow `.github/pull_request_template.md`.
-- PR description MUST contain one line starting with `Issue Number:` and reference related issue(s) using `close #<id>` or `ref #<id>`.
-- If you create PRs via GitHub CLI, start from the template to avoid breaking required HTML comments: `gh pr create -T .github/pull_request_template.md` (then fill in the fields; do not delete/alter the HTML comment markers).
-- Keep HTML comments unchanged, including `Tests <!-- At least one of them must be included. -->`, because CI tooling depends on them.
-- Avoid force-push when possible; prefer follow-up commits and squash merge.
-- If force-push is unavoidable, use `--force-with-lease` and coordinate with reviewers.
 
 ## Agent Output Contract
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,6 @@ When writing complex features or significant refactors, use an ExecPlan from des
 - `.github/skills` is kept only as a migration note path and should not be used as the primary location for new skill updates.
 - Policy belongs in `AGENTS.md`; detailed command playbooks SHOULD live in `docs/agents/*`, and skills SHOULD provide entrypoint workflows that reference those playbooks.
 - Operational testing/build skills are indexed in `.agents/skills/README.md` to avoid duplicated lists drifting in multiple docs.
-- GitHub metadata workflows are indexed in `.agents/skills/README.md`.
-  - Use `tidb-issue-metadata-guard` for issue creation and issue metadata updates.
-  - Use `tidb-pr-metadata-guard` for PR creation, PR body updates, and PR-linked issue references.
 
 ## Pre-flight Checklist
 

--- a/docs/agents/agents-review-guide.md
+++ b/docs/agents/agents-review-guide.md
@@ -40,6 +40,7 @@ Review gate:
 Validate these first because they caused prior drift/regressions:
 
 - [ ] Bazel metadata rule is explicit and unambiguous (no ambiguous wildcard wording).
+- [ ] PR requirements include the `Issue Number:` line with `close #<id>` or `ref #<id>`.
 - [ ] Notes update policy is consistent between `docs/agents/notes-guide.md` and planner notes.
 - [ ] Testing policy in `AGENTS.md` matches testing runbook guidance under `docs/agents/` (no contradiction).
 
@@ -50,7 +51,14 @@ Validate these first because they caused prior drift/regressions:
 - [ ] RealTiKV rule still requires background start and mandatory cleanup.
 - [ ] Bug-fix policy still requires regression tests with fail-before-fix/pass-after-fix evidence (or explicit infeasibility note).
 
-### 5) Reference and Path Hygiene
+### 5) PR/Issue Policy Consistency
+
+- [ ] PR title format rules are intact.
+- [ ] PR description still requires `.github/pull_request_template.md`.
+- [ ] HTML comment preservation requirement remains intact.
+- [ ] English language requirement remains intact for issues and PRs.
+
+### 6) Reference and Path Hygiene
 
 - [ ] Every mentioned path exists.
 - [ ] Removed files are not referenced anywhere.
@@ -65,6 +73,7 @@ Use from repository root.
 
 ```bash
 # Check critical policy anchors in AGENTS.md
+grep -n "Issue Number:" AGENTS.md
 grep -n "Task -> Validation Matrix\|Testing Policy\|make bazel_prepare" AGENTS.md
 
 # Ensure normative keywords are not wrapped in backticks in policy docs.
@@ -87,7 +96,7 @@ git diff --name-status <base_ref>...HEAD | \
 A review is complete only when all are true:
 
 - [ ] No policy contradiction across `AGENTS.md` and the changed docs under `docs/agents/`.
-- [ ] No ambiguous wording for critical rules (especially test/build gates).
+- [ ] No ambiguous wording for critical rules (especially test/build and PR gates).
 - [ ] No stale path references.
 - [ ] `AGENTS.md` preserves policy-level clarity and does not re-accumulate large runbook detail.
 - [ ] Final review comment includes concrete evidence (paths and exact commands run).

--- a/docs/agents/agents-review-guide.md
+++ b/docs/agents/agents-review-guide.md
@@ -40,7 +40,6 @@ Review gate:
 Validate these first because they caused prior drift/regressions:
 
 - [ ] Bazel metadata rule is explicit and unambiguous (no ambiguous wildcard wording).
-- [ ] PR requirements include the `Issue Number:` line with `close #<id>` or `ref #<id>`.
 - [ ] Notes update policy is consistent between `docs/agents/notes-guide.md` and planner notes.
 - [ ] Testing policy in `AGENTS.md` matches testing runbook guidance under `docs/agents/` (no contradiction).
 
@@ -51,14 +50,7 @@ Validate these first because they caused prior drift/regressions:
 - [ ] RealTiKV rule still requires background start and mandatory cleanup.
 - [ ] Bug-fix policy still requires regression tests with fail-before-fix/pass-after-fix evidence (or explicit infeasibility note).
 
-### 5) PR/Issue Policy Consistency
-
-- [ ] PR title format rules are intact.
-- [ ] PR description still requires `.github/pull_request_template.md`.
-- [ ] HTML comment preservation requirement remains intact.
-- [ ] English language requirement remains intact for issues and PRs.
-
-### 6) Reference and Path Hygiene
+### 5) Reference and Path Hygiene
 
 - [ ] Every mentioned path exists.
 - [ ] Removed files are not referenced anywhere.
@@ -73,7 +65,6 @@ Use from repository root.
 
 ```bash
 # Check critical policy anchors in AGENTS.md
-grep -n "Issue Number:" AGENTS.md
 grep -n "Task -> Validation Matrix\|Testing Policy\|make bazel_prepare" AGENTS.md
 
 # Ensure normative keywords are not wrapped in backticks in policy docs.
@@ -96,7 +87,7 @@ git diff --name-status <base_ref>...HEAD | \
 A review is complete only when all are true:
 
 - [ ] No policy contradiction across `AGENTS.md` and the changed docs under `docs/agents/`.
-- [ ] No ambiguous wording for critical rules (especially test/build and PR gates).
+- [ ] No ambiguous wording for critical rules (especially test/build gates).
 - [ ] No stale path references.
 - [ ] `AGENTS.md` preserves policy-level clarity and does not re-accumulate large runbook detail.
 - [ ] Final review comment includes concrete evidence (paths and exact commands run).


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66944

Problem Summary:

The repository had GitHub issue/PR workflow details mixed into root `AGENTS.md`, while the actual day-to-day operations are skill-driven and easy to drift. We also needed narrower skills so issue creation and PR metadata updates do not share one oversized workflow.

### What changed and how does it work?

- add `.agents/skills/tidb-issue-metadata-guard/SKILL.md` for TiDB issue creation and issue metadata updates
- narrow `.agents/skills/tidb-pr-metadata-guard/SKILL.md` back to PR-only workflow, including module-oriented PR title guidance and PR template preservation
- update `.agents/skills/README.md` to index both GitHub metadata skills
- remove the detailed issue/PR workflow rules from `AGENTS.md` and keep only skill indexes there
- add short GitHub metadata skill entries to `AGENTS.md` `Quick Decision Matrix`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new metadata guard skills to help create and update GitHub issues and PRs while maintaining proper structure, labels, and conventions.
  * Updated guidelines directing users to leverage these tools for streamlined issue and PR metadata management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->