### PR TITLE
metrics: fix sql type for COM_STMT_CLOSE metrics

### DIFF
--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -1317,11 +1317,7 @@ func (cc *clientConn) addQueryMetrics(cmd byte, startTime time.Time, err error) 
 	affectedRows := cc.ctx.AffectedRows()
 	cc.ctx.GetTxnWriteThroughputSLI().FinishExecuteStmt(cost, affectedRows, sessionVar.InTxn())
 
-	stmtType := sessionVar.StmtCtx.StmtType
-	sqlType := metrics.LblGeneral
-	if stmtType != "" {
-		sqlType = stmtType
-	}
+	sqlType := getSQLTypeForQueryMetrics(cmd, sessionVar.StmtCtx.StmtType)
 
 	for _, dbName := range session.GetDBNames(vars) {
 		metrics.QueryDurationHistogram.WithLabelValues(sqlType, dbName, vars.StmtCtx.ResourceGroupName).Observe(cost.Seconds())
@@ -1330,6 +1326,16 @@ func (cc *clientConn) addQueryMetrics(cmd byte, startTime time.Time, err error) 
 			metrics.QueryProcessedKeyHistogram.WithLabelValues(sqlType, dbName).Observe(float64(vars.StmtCtx.GetExecDetails().ScanDetail.ProcessedKeys))
 		}
 	}
+}
+
+func getSQLTypeForQueryMetrics(cmd byte, stmtType string) string {
+	if cmd != mysql.ComQuery && cmd != mysql.ComStmtExecute {
+		return metrics.LblGeneral
+	}
+	if stmtType == "" {
+		return metrics.LblGeneral
+	}
+	return stmtType
 }
 
 // dispatch handles client request based on command which is the first byte of the data.

--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -2235,6 +2235,54 @@ func TestConnAddMetrics(t *testing.T) {
 	re.Equal(promtestutils.ToFloat64(counter.WithLabelValues("StmtExecute", "OK", "test_rg2")), 1.0)
 }
 
+func TestGetSQLTypeForQueryMetrics(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		cmd      byte
+		stmtType string
+		expected string
+	}{
+		{
+			name:     "query uses stmt type",
+			cmd:      mysql.ComQuery,
+			stmtType: "Select",
+			expected: "Select",
+		},
+		{
+			name:     "stmt execute uses stmt type",
+			cmd:      mysql.ComStmtExecute,
+			stmtType: "Update",
+			expected: "Update",
+		},
+		{
+			name:     "stmt close uses general",
+			cmd:      mysql.ComStmtClose,
+			stmtType: "Select",
+			expected: metrics.LblGeneral,
+		},
+		{
+			name:     "stmt prepare uses general",
+			cmd:      mysql.ComStmtPrepare,
+			stmtType: "Select",
+			expected: metrics.LblGeneral,
+		},
+		{
+			name:     "empty stmt type falls back to general",
+			cmd:      mysql.ComStmtExecute,
+			stmtType: "",
+			expected: metrics.LblGeneral,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, getSQLTypeForQueryMetrics(tc.cmd, tc.stmtType))
+		})
+	}
+}
+
 func TestIssue54335(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66671

Problem Summary:

`tidb_server_handle_query_duration_seconds` and related server query metrics use the previous `StmtCtx.StmtType` for non-execute prepared statement commands. As a result, `COM_STMT_CLOSE` incorrectly inherits the previous statement type such as `Select`, which pollutes SQL-type metrics. `COM_STMT_PREPARE` has the same issue.

### What changed and how does it work?

This PR limits SQL type propagation in server query metrics to real statement execution commands only:

- `COM_QUERY` and `COM_STMT_EXECUTE` keep using `StmtCtx.StmtType`
- Other protocol commands, including `COM_STMT_CLOSE` and `COM_STMT_PREPARE`, now always use the generic `general` label

It also adds a regression test to verify that non-execute prepared statement commands do not inherit the previous statement type.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for query metrics processing to enhance maintainability.

* **Tests**
  * Added comprehensive test coverage for query metrics type determination across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->