### PR TITLE
executor: support min_count/max_count one-phase agg pushdown to tiflash

### DIFF
--- a/pkg/expression/aggregation/BUILD.bazel
+++ b/pkg/expression/aggregation/BUILD.bazel
@@ -71,7 +71,7 @@ go_test(
     ],
     embed = [":aggregation"],
     flaky = True,
-    shard_count = 20,
+    shard_count = 22,
     deps = [
         "//pkg/expression",
         "//pkg/kv",

--- a/pkg/expression/aggregation/agg_to_pb.go
+++ b/pkg/expression/aggregation/agg_to_pb.go
@@ -39,6 +39,10 @@ func (desc *baseFuncDesc) GetTiPBExpr(tryWindowDesc bool) (tp tipb.ExprType) {
 		tp = tipb.ExprType_Max
 	case ast.AggFuncMin:
 		tp = tipb.ExprType_Min
+	case ast.AggFuncMaxCount:
+		tp = tipb.ExprType_MaxCount
+	case ast.AggFuncMinCount:
+		tp = tipb.ExprType_MinCount
 	case ast.AggFuncSum:
 		tp = tipb.ExprType_Sum
 	case ast.AggFuncSumInt:
@@ -189,6 +193,10 @@ func PBExprToAggFuncDesc(ctx expression.BuildContext, aggFunc *tipb.Expr, fieldT
 		name = ast.AggFuncMax
 	case tipb.ExprType_Min:
 		name = ast.AggFuncMin
+	case tipb.ExprType_MaxCount:
+		name = ast.AggFuncMaxCount
+	case tipb.ExprType_MinCount:
+		name = ast.AggFuncMinCount
 	case tipb.ExprType_Sum:
 		name = ast.AggFuncSum
 	case tipb.ExprType_SumInt:

--- a/pkg/expression/aggregation/agg_to_pb_test.go
+++ b/pkg/expression/aggregation/agg_to_pb_test.go
@@ -101,3 +101,29 @@ func TestAggFuncSumIntToPb(t *testing.T) {
 		}
 	}
 }
+
+func TestAggFuncMaxMinCountToPb(t *testing.T) {
+	ctx := mock.NewContext()
+	client := new(mock.Client)
+	args := []expression.Expression{genColumn(mysql.TypeLonglong, 1)}
+	cases := []struct {
+		name string
+		tp   tipb.ExprType
+	}{
+		{name: ast.AggFuncMaxCount, tp: tipb.ExprType_MaxCount},
+		{name: ast.AggFuncMinCount, tp: tipb.ExprType_MinCount},
+	}
+
+	for _, tc := range cases {
+		aggFunc, err := NewAggFuncDesc(ctx, tc.name, args, false)
+		require.NoError(t, err)
+		pushCtx := expression.NewPushDownContextFromSessionVars(
+			ctx,
+			ctx.GetSessionVars(),
+			client,
+		)
+		pbExpr, err := AggFuncToPBExpr(pushCtx, aggFunc, kv.TiFlash)
+		require.NoError(t, err)
+		require.Equal(t, tc.tp, pbExpr.Tp)
+	}
+}

--- a/pkg/expression/aggregation/aggregation.go
+++ b/pkg/expression/aggregation/aggregation.go
@@ -88,6 +88,22 @@ func NewDistAggFunc(expr *tipb.Expr, fieldTps []*types.FieldType, ctx expression
 		aggF := newAggFunc(ast.AggFuncMin, args, false)
 		aggF.Mode = AggFunctionMode(*expr.AggFuncMode)
 		return &maxMinFunction{aggFunction: aggF, ctor: collate.GetCollator(args[0].GetType(ctx.GetEvalCtx()).GetCollate())}, aggF.AggFuncDesc, nil
+	case tipb.ExprType_MaxCount:
+		aggF := newAggFunc(ast.AggFuncMaxCount, args, false)
+		aggF.Mode = AggFunctionMode(*expr.AggFuncMode)
+		cmpArgIdx := 0
+		if (aggF.Mode == FinalMode || aggF.Mode == Partial2Mode) && len(args) > 1 {
+			cmpArgIdx = 1
+		}
+		return &maxMinCountFunction{aggFunction: aggF, isMax: true, ctor: collate.GetCollator(args[cmpArgIdx].GetType(ctx.GetEvalCtx()).GetCollate())}, aggF.AggFuncDesc, nil
+	case tipb.ExprType_MinCount:
+		aggF := newAggFunc(ast.AggFuncMinCount, args, false)
+		aggF.Mode = AggFunctionMode(*expr.AggFuncMode)
+		cmpArgIdx := 0
+		if (aggF.Mode == FinalMode || aggF.Mode == Partial2Mode) && len(args) > 1 {
+			cmpArgIdx = 1
+		}
+		return &maxMinCountFunction{aggFunction: aggF, isMax: false, ctor: collate.GetCollator(args[cmpArgIdx].GetType(ctx.GetEvalCtx()).GetCollate())}, aggF.AggFuncDesc, nil
 	case tipb.ExprType_First:
 		aggF := newAggFunc(ast.AggFuncFirstRow, args, false)
 		aggF.Mode = AggFunctionMode(*expr.AggFuncMode)
@@ -242,9 +258,16 @@ func CheckAggPushDown(ctx expression.EvalContext, aggFunc *AggFuncDesc, storeTyp
 	if len(aggFunc.OrderByItems) > 0 && aggFunc.Name != ast.AggFuncGroupConcat {
 		return false
 	}
-	// max_count/min_count are currently implemented only in TiDB.
 	if aggFunc.Name == ast.AggFuncMaxCount || aggFunc.Name == ast.AggFuncMinCount {
-		return false
+		// TiFlash currently supports max_count/min_count only in one-stage aggregation.
+		// In planner, max_count/min_count may carry Final/Partial2 mode while still using
+		// the one-stage single-arg shape. The true two-stage shape is [count, extrema value].
+		if storeType != kv.TiFlash {
+			return false
+		}
+		if (aggFunc.Mode == FinalMode || aggFunc.Mode == Partial2Mode) && len(aggFunc.Args) > 1 {
+			return false
+		}
 	}
 	if aggFunc.Name == ast.AggFuncApproxPercentile {
 		return false
@@ -290,7 +313,7 @@ func CheckAggPushFlash(ctx expression.EvalContext, aggFunc *AggFuncDesc) bool {
 		}
 	}
 	switch aggFunc.Name {
-	case ast.AggFuncCount, ast.AggFuncMin, ast.AggFuncMax, ast.AggFuncFirstRow, ast.AggFuncApproxCountDistinct:
+	case ast.AggFuncCount, ast.AggFuncMin, ast.AggFuncMax, ast.AggFuncMaxCount, ast.AggFuncMinCount, ast.AggFuncFirstRow, ast.AggFuncApproxCountDistinct:
 		return true
 	case ast.AggFuncSum, ast.AggFuncSumInt, ast.AggFuncAvg, ast.AggFuncGroupConcat:
 		// Now tiflash doesn't support CastJsonAsReal and CastJsonAsString.

--- a/pkg/expression/aggregation/aggregation.go
+++ b/pkg/expression/aggregation/aggregation.go
@@ -264,17 +264,14 @@ func CheckAggPushDown(ctx expression.EvalContext, aggFunc *AggFuncDesc, storeTyp
 	}
 	if IsMaxMinCount(aggFunc.Name) {
 		// TiFlash currently supports max_count/min_count only in one-stage aggregation.
-		// We accept only the one-stage shape (single argument) and modes used by planner
-		// for this shape. The true two-stage shape is [count, extrema value].
+		// The true two-stage shape is [count, extrema value].
 		if storeType != kv.TiFlash {
 			return false
 		}
 		if len(aggFunc.Args) != 1 {
 			return false
 		}
-		switch aggFunc.Mode {
-		case CompleteMode, Partial1Mode, FinalMode, Partial2Mode:
-		default:
+		if aggFunc.Mode == DedupMode {
 			return false
 		}
 	}

--- a/pkg/expression/aggregation/aggregation.go
+++ b/pkg/expression/aggregation/aggregation.go
@@ -227,8 +227,12 @@ func (af *aggFunction) updateSum(ctx types.Context, evalCtx *AggEvaluateContext,
 
 // NeedCount indicates whether the aggregate function should record count.
 func NeedCount(name string) bool {
-	return name == ast.AggFuncCount || name == ast.AggFuncAvg ||
-		name == ast.AggFuncMaxCount || name == ast.AggFuncMinCount
+	return name == ast.AggFuncCount || name == ast.AggFuncAvg || IsMaxMinCount(name)
+}
+
+// IsMaxMinCount checks whether name is max_count/min_count.
+func IsMaxMinCount(name string) bool {
+	return name == ast.AggFuncMaxCount || name == ast.AggFuncMinCount
 }
 
 // NeedValue indicates whether the aggregate function should record value.
@@ -258,14 +262,19 @@ func CheckAggPushDown(ctx expression.EvalContext, aggFunc *AggFuncDesc, storeTyp
 	if len(aggFunc.OrderByItems) > 0 && aggFunc.Name != ast.AggFuncGroupConcat {
 		return false
 	}
-	if aggFunc.Name == ast.AggFuncMaxCount || aggFunc.Name == ast.AggFuncMinCount {
+	if IsMaxMinCount(aggFunc.Name) {
 		// TiFlash currently supports max_count/min_count only in one-stage aggregation.
-		// In planner, max_count/min_count may carry Final/Partial2 mode while still using
-		// the one-stage single-arg shape. The true two-stage shape is [count, extrema value].
+		// We accept only the one-stage shape (single argument) and modes used by planner
+		// for this shape. The true two-stage shape is [count, extrema value].
 		if storeType != kv.TiFlash {
 			return false
 		}
-		if (aggFunc.Mode == FinalMode || aggFunc.Mode == Partial2Mode) && len(aggFunc.Args) > 1 {
+		if len(aggFunc.Args) != 1 {
+			return false
+		}
+		switch aggFunc.Mode {
+		case CompleteMode, Partial1Mode, FinalMode, Partial2Mode:
+		default:
 			return false
 		}
 	}

--- a/pkg/expression/aggregation/aggregation_test.go
+++ b/pkg/expression/aggregation/aggregation_test.go
@@ -182,6 +182,43 @@ func TestCheckAggPushDownSumInt(t *testing.T) {
 	require.True(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), desc, kv.TiKV))
 }
 
+func TestCheckAggPushDownMaxMinCount(t *testing.T) {
+	ctx := mock.NewContext()
+	col := &expression.Column{
+		Index:   0,
+		RetType: types.NewFieldType(mysql.TypeLonglong),
+	}
+	for _, funcName := range []string{ast.AggFuncMaxCount, ast.AggFuncMinCount} {
+		desc, err := NewAggFuncDesc(ctx, funcName, []expression.Expression{col}, false)
+		require.NoError(t, err)
+
+		desc.Mode = CompleteMode
+		require.True(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), desc, kv.TiFlash))
+		require.False(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), desc, kv.TiKV))
+
+		desc.Mode = Partial1Mode
+		require.True(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), desc, kv.TiFlash))
+
+		desc.Mode = FinalMode
+		require.True(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), desc, kv.TiFlash))
+
+		desc.Mode = Partial2Mode
+		require.True(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), desc, kv.TiFlash))
+
+		finalCountCol := &expression.Column{Index: 0, RetType: types.NewFieldType(mysql.TypeLonglong)}
+		finalValueCol := &expression.Column{Index: 1, RetType: types.NewFieldType(mysql.TypeLonglong)}
+		finalDesc, err := NewAggFuncDesc(ctx, funcName, []expression.Expression{finalCountCol, finalValueCol}, false)
+		require.NoError(t, err)
+		finalDesc.Mode = FinalMode
+		require.False(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), finalDesc, kv.TiFlash))
+		finalDesc.Mode = Partial2Mode
+		require.False(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), finalDesc, kv.TiFlash))
+
+		// Still denied on TiKV even if two-stage shape.
+		require.False(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), finalDesc, kv.TiKV))
+	}
+}
+
 func TestNewDistAggFuncSumInt(t *testing.T) {
 	ctx := mock.NewContext()
 	fieldTps := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}

--- a/pkg/expression/aggregation/aggregation_test.go
+++ b/pkg/expression/aggregation/aggregation_test.go
@@ -213,9 +213,16 @@ func TestCheckAggPushDownMaxMinCount(t *testing.T) {
 		require.False(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), finalDesc, kv.TiFlash))
 		finalDesc.Mode = Partial2Mode
 		require.False(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), finalDesc, kv.TiFlash))
+		finalDesc.Mode = CompleteMode
+		require.False(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), finalDesc, kv.TiFlash))
+		finalDesc.Mode = Partial1Mode
+		require.False(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), finalDesc, kv.TiFlash))
 
 		// Still denied on TiKV even if two-stage shape.
 		require.False(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), finalDesc, kv.TiKV))
+
+		desc.Mode = DedupMode
+		require.False(t, CheckAggPushDown(ctx.GetExprCtx().GetEvalCtx(), desc, kv.TiFlash))
 	}
 }
 

--- a/pkg/kv/checker.go
+++ b/pkg/kv/checker.go
@@ -53,7 +53,7 @@ func (RequestTypeSupportedChecker) supportExpr(exprType tipb.ExprType) bool {
 	// aggregate functions.
 	// NOTE: tipb.ExprType_GroupConcat is only supported by TiFlash, So checking it for TiKV case outside.
 	case tipb.ExprType_Count, tipb.ExprType_First, tipb.ExprType_Max, tipb.ExprType_Min, tipb.ExprType_Sum, tipb.ExprType_Avg,
-		tipb.ExprType_SumInt,
+		tipb.ExprType_SumInt, tipb.ExprType_MaxCount, tipb.ExprType_MinCount,
 		tipb.ExprType_Agg_BitXor, tipb.ExprType_Agg_BitAnd, tipb.ExprType_Agg_BitOr, tipb.ExprType_ApproxCountDistinct, tipb.ExprType_GroupConcat:
 		return true
 	// window functions.

--- a/pkg/kv/checker_test.go
+++ b/pkg/kv/checker_test.go
@@ -29,6 +29,8 @@ func TestIsRequestTypeSupported(t *testing.T) {
 	assert.True(t, checker(kv.ReqTypeDAG, kv.ReqSubTypeDesc))
 	assert.True(t, checker(kv.ReqTypeDAG, kv.ReqSubTypeSignature))
 	assert.True(t, checker(kv.ReqTypeSelect, int64(tipb.ExprType_SumInt)))
+	assert.True(t, checker(kv.ReqTypeSelect, int64(tipb.ExprType_MaxCount)))
+	assert.True(t, checker(kv.ReqTypeSelect, int64(tipb.ExprType_MinCount)))
 	assert.False(t, checker(kv.ReqTypeDAG, kv.ReqSubTypeAnalyzeIdx))
 	assert.True(t, checker(kv.ReqTypeAnalyze, 0))
 	assert.False(t, checker(kv.ReqTypeChecksum, 0))

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -2698,6 +2698,13 @@ func tryToGetMppHashAggs(la *logicalop.LogicalAggregation, prop *property.Physic
 	// Is this aggregate a final stage aggregate?
 	// Final agg can't be split into multi-stage aggregate
 	hasFinalAgg := len(la.AggFuncs) > 0 && la.AggFuncs[0].Mode == aggregation.FinalMode
+	hasTiFlashOnePhaseOnlyAgg := false
+	for _, aggFunc := range la.AggFuncs {
+		if aggFunc.Name == ast.AggFuncMaxCount || aggFunc.Name == ast.AggFuncMinCount {
+			hasTiFlashOnePhaseOnlyAgg = true
+			break
+		}
+	}
 	// count final agg should become sum for MPP execution path.
 	// In the traditional case, TiDB take up the final agg role and push partial agg to TiKV,
 	// while TiDB can tell the partialMode and do the sum computation rather than counting but MPP doesn't
@@ -2771,17 +2778,19 @@ func tryToGetMppHashAggs(la *logicalop.LogicalAggregation, prop *property.Physic
 
 		// 2-phase agg
 		// no partition property down，record partition cols inside agg itself, enforce shuffler latter.
-		childProp := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, MPPPartitionTp: property.AnyType, RejectSort: true, CTEProducerStatus: prop.CTEProducerStatus}
-		agg := NewPhysicalHashAgg(la, la.StatsInfo().ScaleByExpectCnt(prop.ExpectedCnt), childProp)
-		agg.SetSchema(la.Schema().Clone())
-		agg.MppRunMode = Mpp2Phase
-		agg.MppPartitionCols = partitionCols
-		if validMppAgg(agg) {
-			hashAggs = append(hashAggs, agg)
+		if !hasTiFlashOnePhaseOnlyAgg {
+			childProp := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, MPPPartitionTp: property.AnyType, RejectSort: true, CTEProducerStatus: prop.CTEProducerStatus}
+			agg := NewPhysicalHashAgg(la, la.StatsInfo().ScaleByExpectCnt(prop.ExpectedCnt), childProp)
+			agg.SetSchema(la.Schema().Clone())
+			agg.MppRunMode = Mpp2Phase
+			agg.MppPartitionCols = partitionCols
+			if validMppAgg(agg) {
+				hashAggs = append(hashAggs, agg)
+			}
 		}
 
 		// agg runs on TiDB with a partial agg on TiFlash if possible
-		if prop.TaskTp == property.RootTaskType {
+		if prop.TaskTp == property.RootTaskType && !hasTiFlashOnePhaseOnlyAgg {
 			childProp := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, RejectSort: true, CTEProducerStatus: prop.CTEProducerStatus}
 			agg := NewPhysicalHashAgg(la, la.StatsInfo().ScaleByExpectCnt(prop.ExpectedCnt), childProp)
 			agg.SetSchema(la.Schema().Clone())
@@ -2793,7 +2802,7 @@ func tryToGetMppHashAggs(la *logicalop.LogicalAggregation, prop *property.Physic
 		childProp := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, RejectSort: true, CTEProducerStatus: prop.CTEProducerStatus}
 		agg := NewPhysicalHashAgg(la, la.StatsInfo().ScaleByExpectCnt(prop.ExpectedCnt), childProp)
 		agg.SetSchema(la.Schema().Clone())
-		if la.HasDistinct() || la.HasOrderBy() {
+		if la.HasDistinct() || la.HasOrderBy() || hasTiFlashOnePhaseOnlyAgg {
 			// mpp scalar mode means the data will be pass through to only one tiFlash node at last.
 			agg.MppRunMode = MppScalar
 		} else {

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -2698,13 +2698,7 @@ func tryToGetMppHashAggs(la *logicalop.LogicalAggregation, prop *property.Physic
 	// Is this aggregate a final stage aggregate?
 	// Final agg can't be split into multi-stage aggregate
 	hasFinalAgg := len(la.AggFuncs) > 0 && la.AggFuncs[0].Mode == aggregation.FinalMode
-	hasTiFlashOnePhaseOnlyAgg := false
-	for _, aggFunc := range la.AggFuncs {
-		if aggFunc.Name == ast.AggFuncMaxCount || aggFunc.Name == ast.AggFuncMinCount {
-			hasTiFlashOnePhaseOnlyAgg = true
-			break
-		}
-	}
+	hasTiFlashOnePhaseOnlyAgg := hasTiFlashOnePhaseOnlyAggFunc(la.AggFuncs)
 	// count final agg should become sum for MPP execution path.
 	// In the traditional case, TiDB take up the final agg role and push partial agg to TiKV,
 	// while TiDB can tell the partialMode and do the sum computation rather than counting but MPP doesn't

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -2698,7 +2698,7 @@ func tryToGetMppHashAggs(la *logicalop.LogicalAggregation, prop *property.Physic
 	// Is this aggregate a final stage aggregate?
 	// Final agg can't be split into multi-stage aggregate
 	hasFinalAgg := len(la.AggFuncs) > 0 && la.AggFuncs[0].Mode == aggregation.FinalMode
-	hasTiFlashOnePhaseOnlyAgg := hasTiFlashOnePhaseOnlyAggFunc(la.AggFuncs)
+	containsMaxMinCount := containsMaxMinCountAgg(la.AggFuncs)
 	// count final agg should become sum for MPP execution path.
 	// In the traditional case, TiDB take up the final agg role and push partial agg to TiKV,
 	// while TiDB can tell the partialMode and do the sum computation rather than counting but MPP doesn't
@@ -2765,26 +2765,24 @@ func tryToGetMppHashAggs(la *logicalop.LogicalAggregation, prop *property.Physic
 			}
 		}
 
-		// Final agg can't be split into multi-stage aggregate, so exit early
-		if hasFinalAgg {
+		// Final agg and max/min_count agg can't be split into multi-stage aggregate.
+		if hasFinalAgg || containsMaxMinCount {
 			return
 		}
 
 		// 2-phase agg
 		// no partition property down，record partition cols inside agg itself, enforce shuffler latter.
-		if !hasTiFlashOnePhaseOnlyAgg {
-			childProp := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, MPPPartitionTp: property.AnyType, RejectSort: true, CTEProducerStatus: prop.CTEProducerStatus}
-			agg := NewPhysicalHashAgg(la, la.StatsInfo().ScaleByExpectCnt(prop.ExpectedCnt), childProp)
-			agg.SetSchema(la.Schema().Clone())
-			agg.MppRunMode = Mpp2Phase
-			agg.MppPartitionCols = partitionCols
-			if validMppAgg(agg) {
-				hashAggs = append(hashAggs, agg)
-			}
+		childProp := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, MPPPartitionTp: property.AnyType, RejectSort: true, CTEProducerStatus: prop.CTEProducerStatus}
+		agg := NewPhysicalHashAgg(la, la.StatsInfo().ScaleByExpectCnt(prop.ExpectedCnt), childProp)
+		agg.SetSchema(la.Schema().Clone())
+		agg.MppRunMode = Mpp2Phase
+		agg.MppPartitionCols = partitionCols
+		if validMppAgg(agg) {
+			hashAggs = append(hashAggs, agg)
 		}
 
 		// agg runs on TiDB with a partial agg on TiFlash if possible
-		if prop.TaskTp == property.RootTaskType && !hasTiFlashOnePhaseOnlyAgg {
+		if prop.TaskTp == property.RootTaskType {
 			childProp := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, RejectSort: true, CTEProducerStatus: prop.CTEProducerStatus}
 			agg := NewPhysicalHashAgg(la, la.StatsInfo().ScaleByExpectCnt(prop.ExpectedCnt), childProp)
 			agg.SetSchema(la.Schema().Clone())
@@ -2796,7 +2794,7 @@ func tryToGetMppHashAggs(la *logicalop.LogicalAggregation, prop *property.Physic
 		childProp := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, RejectSort: true, CTEProducerStatus: prop.CTEProducerStatus}
 		agg := NewPhysicalHashAgg(la, la.StatsInfo().ScaleByExpectCnt(prop.ExpectedCnt), childProp)
 		agg.SetSchema(la.Schema().Clone())
-		if la.HasDistinct() || la.HasOrderBy() || hasTiFlashOnePhaseOnlyAgg {
+		if la.HasDistinct() || la.HasOrderBy() || containsMaxMinCount {
 			// mpp scalar mode means the data will be pass through to only one tiFlash node at last.
 			agg.MppRunMode = MppScalar
 		} else {

--- a/pkg/planner/core/exhaust_physical_plans_test.go
+++ b/pkg/planner/core/exhaust_physical_plans_test.go
@@ -16,11 +16,13 @@ package core
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/expression/aggregation"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -502,4 +504,70 @@ func TestRangeFallbackForAnalyzeLookUpFilters(t *testing.T) {
 	ijHelper := testAnalyzeLookUpFilters(t, ijCtx, ijCase)
 	checkRangeFallbackAndReset(t, ctx, false)
 	require.Greater(t, ijHelper.chosenRanges.Range().MemUsage(), ijCase.rangeMaxSize)
+}
+
+func TestTryToGetMppHashAggsForMaxMinCount(t *testing.T) {
+	buildAgg := func(aggName string, withGroupBy bool) *logicalop.LogicalAggregation {
+		ctx := MockContext()
+		argCol := &expression.Column{
+			UniqueID: ctx.GetSessionVars().AllocPlanColumnID(),
+			RetType:  types.NewFieldType(mysql.TypeLonglong),
+		}
+		aggDesc, err := aggregation.NewAggFuncDesc(ctx.GetExprCtx(), aggName, []expression.Expression{argCol}, false)
+		require.NoError(t, err)
+		groupByItems := make([]expression.Expression, 0, 1)
+		schemaCols := make([]*expression.Column, 0, 2)
+		schemaCols = append(schemaCols, &expression.Column{
+			UniqueID: ctx.GetSessionVars().AllocPlanColumnID(),
+			RetType:  aggDesc.RetTp,
+		})
+		if withGroupBy {
+			groupByCol := &expression.Column{
+				UniqueID: ctx.GetSessionVars().AllocPlanColumnID(),
+				RetType:  types.NewFieldType(mysql.TypeLonglong),
+			}
+			groupByItems = append(groupByItems, groupByCol)
+			schemaCols = append(schemaCols, groupByCol)
+		}
+		la := logicalop.LogicalAggregation{
+			AggFuncs:     []*aggregation.AggFuncDesc{aggDesc},
+			GroupByItems: groupByItems,
+		}.Init(ctx.GetPlanCtx(), 0)
+		la.SetSchema(expression.NewSchema(schemaCols...))
+		la.SetStats(&property.StatsInfo{RowCount: 1024})
+		return la
+	}
+
+	containsRunMode := func(plans []base.PhysicalPlan, mode AggMppRunMode) bool {
+		for _, plan := range plans {
+			hashAgg, ok := plan.(*PhysicalHashAgg)
+			if ok && hashAgg.MppRunMode == mode {
+				return true
+			}
+		}
+		return false
+	}
+
+	prop := &property.PhysicalProperty{
+		TaskTp:         property.RootTaskType,
+		ExpectedCnt:    math.MaxFloat64,
+		MPPPartitionTp: property.AnyType,
+	}
+
+	normalAggPlans := tryToGetMppHashAggs(buildAgg(ast.AggFuncMax, true), prop)
+	require.True(t, containsRunMode(normalAggPlans, Mpp2Phase))
+
+	for _, aggName := range []string{ast.AggFuncMaxCount, ast.AggFuncMinCount} {
+		plans := tryToGetMppHashAggs(buildAgg(aggName, true), prop)
+		require.NotEmpty(t, plans)
+		require.False(t, containsRunMode(plans, Mpp2Phase))
+		require.False(t, containsRunMode(plans, MppTiDB))
+	}
+
+	for _, aggName := range []string{ast.AggFuncMaxCount, ast.AggFuncMinCount} {
+		plans := tryToGetMppHashAggs(buildAgg(aggName, false), prop)
+		require.NotEmpty(t, plans)
+		require.True(t, containsRunMode(plans, MppScalar))
+		require.False(t, containsRunMode(plans, MppTiDB))
+	}
 }

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1586,6 +1586,15 @@ func (p *basePhysicalAgg) convertAvgForMPP() *PhysicalProjection {
 }
 
 func (p *basePhysicalAgg) newPartialAggregate(copTaskType kv.StoreType, isMPPTask bool) (partial, final base.PhysicalPlan) {
+	// max_count/min_count currently support only one-stage execution on TiFlash.
+	// Do not split them into partial/final here.
+	if copTaskType == kv.TiFlash {
+		for _, aggFunc := range p.AggFuncs {
+			if aggFunc.Name == ast.AggFuncMaxCount || aggFunc.Name == ast.AggFuncMinCount {
+				return nil, p.Self
+			}
+		}
+	}
 	// Check if this aggregation can push down.
 	if !CheckAggCanPushCop(p.SCtx(), p.AggFuncs, p.GroupByItems, copTaskType) {
 		return nil, p.Self
@@ -2268,6 +2277,28 @@ func (p *PhysicalHashAgg) attach2TaskForMpp(tasks ...base.Task) base.Task {
 		attachPlan2Task(finalAgg, t)
 		return t
 	case MppScalar:
+		hasTiFlashOnePhaseOnlyAgg := false
+		for _, aggFunc := range p.AggFuncs {
+			if aggFunc.Name == ast.AggFuncMaxCount || aggFunc.Name == ast.AggFuncMinCount {
+				hasTiFlashOnePhaseOnlyAgg = true
+				break
+			}
+		}
+		if hasTiFlashOnePhaseOnlyAgg {
+			prop := &property.PhysicalProperty{
+				TaskTp:         property.MppTaskType,
+				ExpectedCnt:    math.MaxFloat64,
+				MPPPartitionTp: property.SinglePartitionType,
+			}
+			if mpp.needEnforceExchanger(prop) {
+				newMpp := mpp.enforceExchanger(prop)
+				if newMpp.Invalid() {
+					return newMpp
+				}
+				mpp = newMpp
+			}
+			return p.attach2TaskForMpp1Phase(mpp)
+		}
 		prop := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, MPPPartitionTp: property.SinglePartitionType}
 		if !mpp.needEnforceExchanger(prop) {
 			// On the one hand: when the low layer already satisfied the single partition layout, just do the all agg computation in the single node.

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1586,17 +1586,13 @@ func (p *basePhysicalAgg) convertAvgForMPP() *PhysicalProjection {
 }
 
 func (p *basePhysicalAgg) newPartialAggregate(copTaskType kv.StoreType, isMPPTask bool) (partial, final base.PhysicalPlan) {
-	// max_count/min_count currently support only one-stage execution on TiFlash.
-	// Do not split them into partial/final here.
-	if copTaskType == kv.TiFlash {
-		for _, aggFunc := range p.AggFuncs {
-			if aggFunc.Name == ast.AggFuncMaxCount || aggFunc.Name == ast.AggFuncMinCount {
-				return nil, p.Self
-			}
-		}
-	}
 	// Check if this aggregation can push down.
 	if !CheckAggCanPushCop(p.SCtx(), p.AggFuncs, p.GroupByItems, copTaskType) {
+		return nil, p.Self
+	}
+	// max_count/min_count currently support only one-stage execution on TiFlash.
+	// Do not split them into partial/final here.
+	if copTaskType == kv.TiFlash && hasTiFlashOnePhaseOnlyAggFunc(p.AggFuncs) {
 		return nil, p.Self
 	}
 	partialPref, finalPref, firstRowFuncMap := BuildFinalModeAggregation(p.SCtx(), &AggInfo{
@@ -1832,6 +1828,15 @@ func computePartialCursorOffset(name string) int {
 		offset++
 	}
 	return offset
+}
+
+func hasTiFlashOnePhaseOnlyAggFunc(aggFuncs []*aggregation.AggFuncDesc) bool {
+	for _, aggFunc := range aggFuncs {
+		if aggregation.IsMaxMinCount(aggFunc.Name) {
+			return true
+		}
+	}
+	return false
 }
 
 // Attach2Task implements PhysicalPlan interface.
@@ -2277,14 +2282,7 @@ func (p *PhysicalHashAgg) attach2TaskForMpp(tasks ...base.Task) base.Task {
 		attachPlan2Task(finalAgg, t)
 		return t
 	case MppScalar:
-		hasTiFlashOnePhaseOnlyAgg := false
-		for _, aggFunc := range p.AggFuncs {
-			if aggFunc.Name == ast.AggFuncMaxCount || aggFunc.Name == ast.AggFuncMinCount {
-				hasTiFlashOnePhaseOnlyAgg = true
-				break
-			}
-		}
-		if hasTiFlashOnePhaseOnlyAgg {
+		if hasTiFlashOnePhaseOnlyAggFunc(p.AggFuncs) {
 			prop := &property.PhysicalProperty{
 				TaskTp:         property.MppTaskType,
 				ExpectedCnt:    math.MaxFloat64,

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1592,7 +1592,7 @@ func (p *basePhysicalAgg) newPartialAggregate(copTaskType kv.StoreType, isMPPTas
 	}
 	// max_count/min_count currently support only one-stage execution on TiFlash.
 	// Do not split them into partial/final here.
-	if copTaskType == kv.TiFlash && hasTiFlashOnePhaseOnlyAggFunc(p.AggFuncs) {
+	if copTaskType == kv.TiFlash && containsMaxMinCountAgg(p.AggFuncs) {
 		return nil, p.Self
 	}
 	partialPref, finalPref, firstRowFuncMap := BuildFinalModeAggregation(p.SCtx(), &AggInfo{
@@ -1830,7 +1830,7 @@ func computePartialCursorOffset(name string) int {
 	return offset
 }
 
-func hasTiFlashOnePhaseOnlyAggFunc(aggFuncs []*aggregation.AggFuncDesc) bool {
+func containsMaxMinCountAgg(aggFuncs []*aggregation.AggFuncDesc) bool {
 	for _, aggFunc := range aggFuncs {
 		if aggregation.IsMaxMinCount(aggFunc.Name) {
 			return true
@@ -2282,7 +2282,7 @@ func (p *PhysicalHashAgg) attach2TaskForMpp(tasks ...base.Task) base.Task {
 		attachPlan2Task(finalAgg, t)
 		return t
 	case MppScalar:
-		if hasTiFlashOnePhaseOnlyAggFunc(p.AggFuncs) {
+		if containsMaxMinCountAgg(p.AggFuncs) {
 			prop := &property.PhysicalProperty{
 				TaskTp:         property.MppTaskType,
 				ExpectedCnt:    math.MaxFloat64,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/66124

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MaxCount and MinCount aggregate functions.

* **Behavior**
  * Expanded push-down and expression translation support so these aggregates are recognized end-to-end.

* **Performance**
  * Query planner now prefers single-stage aggregation for MaxCount/MinCount on compatible storage, reducing unnecessary multi-phase work.

* **Tests**
  * Added tests for translation, push-down eligibility, and distributed planning for MaxCount/MinCount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->