### PR TITLE
test: make TestLeaderTick case stable

### DIFF
--- a/pkg/store/gcworker/gc_worker_test.go
+++ b/pkg/store/gcworker/gc_worker_test.go
@@ -992,6 +992,15 @@ Loop:
 }
 
 func TestLeaderTick(t *testing.T) {
+	// Disable the background txn safe-point cache updater (10 s poll) so it
+	// does not race with snapshot reads in checkCollected/mustGetNone.
+	// Without this, the updater may cache the advanced safe point before the
+	// test reads old probe timestamps, causing [tikv:9006] errors.
+	require.NoError(t, failpoint.Enable("tikvclient/noBuiltInTxnSafePointUpdater", "return"))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable("tikvclient/noBuiltInTxnSafePointUpdater"))
+	})
+
 	// as we are adjusting the base TS, we need a larger schema lease to avoid
 	// the info schema outdated error.
 	s := createGCWorkerSuite(t, withStoreType(mockstore.EmbedUnistore), withSchemaLease(time.Hour))
@@ -1038,6 +1047,12 @@ func TestLeaderTick(t *testing.T) {
 	// Reset GC last run time
 	err = s.gcWorker.saveTime(gcLastRunTimeKey, oracle.GetTimeFromTS(s.mustAllocTs(t)).Add(-veryLong))
 	require.NoError(t, err)
+	// The "skip gcWaitTime" leaderTick above ran prepare() which advanced the
+	// PD txn safe point as a side effect. Bump the oracle so the next
+	// prepare() computes a strictly higher target (GoTimeToTS truncates to ms,
+	// so without this bump both calls can land in the same millisecond and
+	// AdvanceTxnSafePoint returns NewSafePoint == OldSafePoint → GC skipped).
+	s.oracle.AddOffset(time.Second)
 
 	// Continue GC if all those checks passed.
 	err = s.gcWorker.leaderTick(gcContext())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66729

Problem Summary:

In `TestLeaderTick` test case, the execution flow could be: 
1. The PD txn safe point is updated by the `s.gcWorker.leaderTick` though the GC turn is not executed because of `gcLastRunTime`.
2. The background txn safepoint updator polls the new txn safepoint value when `10s` interval is reached.
3. The checkCollected fails because its read ts is smller than the updated txn safepoint.

The test takes `~10s` due to two GC rounds with 10s timeouts, making it a tight race with the 10s poll interval. 


### What changed and how does it work?

Disable background updater when this case is being executed using fail point.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test reliability by improving transaction safe-point updater isolation to prevent race conditions in snapshot read scenarios.
  * Enhanced oracle timestamp handling in concurrent test scenarios to ensure deterministic behavior and prevent timing contention issues.
  * Improved test cleanup procedures to maintain proper isolation between test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->