### PR TITLE
planner: prevent unsafe outer join elimination when parent join predicates reference child columns | tidb-test=pr/2710

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -443,6 +443,26 @@ HAVING EXISTS (SELECT 1 FROM t_panic WHERE x IS NULL);`).Check(testkit.Rows("<ni
 		tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("0"))
 		tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).MultiCheckContain([]string{"IndexRangeScan"})
 	}
+
+	// issue-66399-outer-join-eliminate-must-keep-parent-join-condition-columns
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("set tidb_enable_outer_join_reorder=0")
+		tk.MustExec("create table d(col_varchar_1024_not_null varchar(1024) not null, col_decimal_not_null decimal(10,0) not null, col_datetime_not_null datetime not null, col_int_not_null int not null)")
+		tk.MustExec("create table f(col_datetime datetime default null, pk int not null)")
+		tk.MustExec("create table m(col_varchar_1024_not_null varchar(1024) not null, col_decimal_not_null decimal(10,0) not null, col_datetime_not_null datetime not null, col_int_not_null int not null)")
+		tk.MustExec("create table n(col_decimal_not_null decimal(10,0) not null)")
+
+		tk.MustQuery(`SELECT table2.col_int_not_null AS field1
+FROM d AS table1
+RIGHT JOIN m AS table2 ON table1.col_varchar_1024_not_null = table2.col_varchar_1024_not_null
+LEFT JOIN n AS table3 ON table1.col_decimal_not_null = table3.col_decimal_not_null
+RIGHT JOIN f AS table4 ON table2.col_datetime_not_null = table4.col_datetime
+WHERE table4.pk != 5
+GROUP BY field1
+HAVING (((field1 <> 6 AND field1 <= 8) OR field1 <> 7) OR field1 <= 9)
+ORDER BY field1`).Check(testkit.Rows())
+	}
 }
 
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {

--- a/pkg/planner/core/rule_join_elimination.go
+++ b/pkg/planner/core/rule_join_elimination.go
@@ -262,6 +262,26 @@ func (o *OuterJoinEliminator) doOptimize(p base.LogicalPlan, aggCols []*expressi
 				parentCols = append(parentCols, expression.ExtractColumns(byItem.Expr)...)
 			}
 		}
+	case *logicalop.LogicalJoin:
+		// Besides output columns, a join's own conditions are also required by children.
+		// If we only pass output schema columns to children, we may incorrectly eliminate
+		// a child outer join whose columns are still referenced by this join's predicates.
+		parentCols = append(parentCols[:0], p.Schema().Columns...)
+		for _, eqCond := range x.EqualConditions {
+			parentCols = append(parentCols, expression.ExtractColumns(eqCond)...)
+		}
+		for _, leftCond := range x.LeftConditions {
+			parentCols = append(parentCols, expression.ExtractColumns(leftCond)...)
+		}
+		for _, rightCond := range x.RightConditions {
+			parentCols = append(parentCols, expression.ExtractColumns(rightCond)...)
+		}
+		for _, otherCond := range x.OtherConditions {
+			parentCols = append(parentCols, expression.ExtractColumns(otherCond)...)
+		}
+		for _, naeqCond := range x.NAEQConditions {
+			parentCols = append(parentCols, expression.ExtractColumns(naeqCond)...)
+		}
 	default:
 		parentCols = append(parentCols[:0], p.Schema().Columns...)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #66399

Problem Summary:

### What changed and how does it work?

- In `OuterJoinEliminator.doOptimize`, when visiting a `LogicalJoin`, propagate both output columns and columns used by join predicates (`EqualConditions`, `LeftConditions`, `RightConditions`, `OtherConditions`, `NAEQConditions`) to child elimination checks.
- Added a regression test for the issue query in `TestPlannerIssueRegressions`.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where outer joins were incorrectly eliminated in certain complex join scenarios, ensuring accurate query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->