### PR TITLE
expression: avoid mutating constant strings in vectorized ILIKE

### DIFF
--- a/pkg/expression/builtin_ilike_test.go
+++ b/pkg/expression/builtin_ilike_test.go
@@ -170,3 +170,71 @@ func TestVectorizedBuiltinIlikeFunc(t *testing.T) {
 	vecBuiltinIlikeCases[ast.Ilike][2].constants[2] = getIntConstant(int64(byte('\\')))
 	testVectorizedBuiltinFunc(t, vecBuiltinIlikeCases)
 }
+
+func TestVectorizedBuiltinIlikeForConstants(t *testing.T) {
+	testCases := []struct {
+		name       string
+		constArg   int
+		constValue string
+		exprs      []string
+		patterns   []string
+	}{
+		{
+			name:       "constant pattern",
+			constArg:   1,
+			constValue: "A",
+			exprs:      []string{"a", "A", "aa", "bb"},
+			patterns:   []string{"A", "A", "A", "A"},
+		},
+		{
+			name:       "constant expr",
+			constArg:   0,
+			constValue: "Aa",
+			exprs:      []string{"Aa", "Aa", "Aa", "Aa"},
+			patterns:   []string{"A", "AA", "B", "%a%"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := createContext(t)
+			fieldTypes := []*types.FieldType{
+				types.NewFieldTypeBuilder().SetType(mysql.TypeVarString).SetCharset(charset.CharsetUTF8MB4).SetCollate("utf8mb4_general_ci").BuildP(),
+				types.NewFieldTypeBuilder().SetType(mysql.TypeVarString).SetCharset(charset.CharsetUTF8MB4).SetCollate("utf8mb4_general_ci").BuildP(),
+				types.NewFieldType(mysql.TypeLong),
+			}
+			input := chunk.New(fieldTypes, len(tc.exprs), len(tc.exprs))
+			for i := range tc.exprs {
+				input.AppendString(0, tc.exprs[i])
+				input.AppendString(1, tc.patterns[i])
+				input.AppendInt64(2, int64(byte('\\')))
+			}
+
+			args := []Expression{
+				&Column{Index: 0, RetType: fieldTypes[0]},
+				&Column{Index: 1, RetType: fieldTypes[1]},
+				getIntConstant(int64(byte('\\'))),
+			}
+			args[tc.constArg] = getStringConstant(tc.constValue, false)
+
+			f, err := funcs[ast.Ilike].getFunction(ctx, args)
+			require.NoError(t, err)
+			f.SetCharsetAndCollation(charset.CharsetUTF8MB4, "utf8mb4_general_ci")
+			f.setCollator(collate.GetCollator("utf8mb4_general_ci"))
+			require.True(t, f.vectorized() && f.isChildrenVectorized())
+
+			output := chunk.NewColumn(eType2FieldType(types.ETInt), len(tc.exprs))
+			output.AppendNull()
+			require.NoError(t, vecEvalType(ctx, f, types.ETInt, input, output))
+
+			i64s := output.Int64s()
+			it := chunk.NewIterator4Chunk(input)
+			for rowIdx, row := 0, it.Begin(); row != it.End(); row, rowIdx = it.Next(), rowIdx+1 {
+				val, err := evalBuiltinFunc(f, ctx, row)
+				require.NoError(t, err)
+				require.False(t, val.IsNull())
+				require.Equal(t, i64s[rowIdx], val.GetInt64())
+			}
+		})
+	}
+}

--- a/pkg/expression/builtin_ilike_vec.go
+++ b/pkg/expression/builtin_ilike_vec.go
@@ -94,9 +94,9 @@ func (b *builtinIlikeSig) lowerExpr(param *funcParam, rowNum int) {
 	col := param.getCol()
 	if col == nil {
 		str := param.getStringVal(0)
-		strBytes := hack.Slice(str)
+		strBytes := []byte(str)
 		stringutil.LowerOneString(strBytes)
-		param.setStrVal(str)
+		param.setStrVal(string(strBytes))
 		return
 	}
 
@@ -109,9 +109,9 @@ func (b *builtinIlikeSig) lowerPattern(param *funcParam, rowNum int, escape int6
 	col := param.getCol()
 	if col == nil {
 		str := param.getStringVal(0)
-		strBytes := hack.Slice(str)
+		strBytes := []byte(str)
 		escape = int64(stringutil.LowerOneStringExcludeEscapeChar(strBytes, byte(escape)))
-		param.setStrVal(str)
+		param.setStrVal(string(strBytes))
 		return escape
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67001

Problem Summary:
Vectorized `ILIKE` lowercased constant string arguments in place. When the pattern argument was constant, the vectorized path could mutate shared string storage and trigger a SIGSEGV during evaluation.

### What changed and how does it work?
- copy constant string values before lowercasing in vectorized `ILIKE`
- add regression coverage for constant-pattern and constant-expression vectorized `ILIKE` cases
- verify fail-before-fix and pass-after-fix with focused expression tests

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a SIGSEGV in vectorized ILIKE when lowering constant string arguments.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for case-insensitive pattern matching when arguments are supplied as constants, ensuring correct vectorized evaluation.

* **Refactor**
  * Optimized internal string handling operations for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->