### PR TITLE
expression: support tiflash pushdown for json_object

### DIFF
--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -544,6 +544,11 @@ func TestJsonPushDownToFlash(t *testing.T) {
 	require.NoError(t, err)
 	exprs = append(exprs, function)
 
+	// json_object
+	function, err = NewFunction(mock.NewContext(), ast.JSONObject, types.NewFieldType(mysql.TypeJSON), stringColumn, jsonColumn, stringColumn, jsonColumn)
+	require.NoError(t, err)
+	exprs = append(exprs, function)
+
 	// json_depth
 	function, err = NewFunction(mock.NewContext(), ast.JSONDepth, types.NewFieldType(mysql.TypeLonglong), jsonColumn)
 	require.NoError(t, err)

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -311,7 +311,7 @@ func scalarExprSupportedByFlash(ctx EvalContext, function *ScalarFunction) bool 
 
 		ast.Sqrt, ast.Log, ast.Log2, ast.Log10, ast.Ln, ast.Exp, ast.Pow, ast.Power, ast.Sign,
 		ast.Radians, ast.Degrees, ast.Conv, ast.CRC32,
-		ast.JSONLength, ast.JSONDepth, ast.JSONExtract, ast.JSONUnquote, ast.JSONArray, ast.JSONContainsPath, ast.JSONValid, ast.JSONKeys,
+		ast.JSONLength, ast.JSONDepth, ast.JSONExtract, ast.JSONUnquote, ast.JSONObject, ast.JSONArray, ast.JSONContainsPath, ast.JSONValid, ast.JSONKeys,
 		ast.Repeat, ast.InetNtoa, ast.InetAton, ast.Inet6Ntoa, ast.Inet6Aton,
 		ast.Coalesce, ast.ASCII, ast.Length, ast.Trim, ast.Position, ast.Format, ast.Elt,
 		ast.LTrim, ast.RTrim, ast.Lpad, ast.Rpad,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67027

Problem Summary:
TiFlash now supports `JSON_OBJECT` pushdown, but TiDB still blocks this scalar function in the TiFlash pushdown whitelist. As a result, expressions using `JSON_OBJECT` cannot be pushed down even when TiFlash can execute them.

Related:
- TiFlash issue: pingcap/tiflash#10743
- TiFlash PR: pingcap/tiflash#10744

### What changed and how does it work?

- add `ast.JSONObject` to the TiFlash scalar-function pushdown whitelist
- extend the existing `TestJsonPushDownToFlash` regression test to cover `JSON_OBJECT`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for JSONObject function in expression pushdown operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->