### PR TITLE
pkg/ddl: cherry-pick #61293 and #65079 to release-8.5 to fix flaky TestAddGlobalIndexInIngestWithUpdate

### DIFF
--- a/pkg/ddl/ingest/integration_test.go
+++ b/pkg/ddl/ingest/integration_test.go
@@ -511,7 +511,7 @@ func TestAddGlobalIndexInIngestWithUpdate(t *testing.T) {
 	tk.MustExec("insert into t (a, b) values (1, 1), (2, 2), (3, 3)")
 	var i atomic.Int32
 	i.Store(3)
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterWaitSchemaSynced", func(job *model.Job) {
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onJobUpdated", func(job *model.Job) {
 		if job.State != model.JobStateSynced {
 			tk2 := testkit.NewTestKit(t, store)
 			tmp := i.Add(1)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66985

Problem Summary:

Backport the flaky test fixes from:
- https://github.com/pingcap/tidb/pull/61293
- https://github.com/pingcap/tidb/pull/65079

to `release-8.5`.

### What changed and how does it work?

This PR cherry-picks the two upstream commits onto `release-8.5`:

- `dc443455c4eda2630f6c661a31a6a71df465eb59`
- `9b5cf852adcd2258b2ff3fd08ba496855ed377b9`

Both commits update `TestAddGlobalIndexInIngestWithUpdate` in `pkg/ddl/ingest/integration_test.go` to reduce flakiness.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Unit test command:
- `make failpoint-enable`
- `go test -run TestAddGlobalIndexInIngestWithUpdate -tags=intest,deadlock ./pkg/ddl/ingest`
- `make failpoint-disable`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined ingestion test logic to only perform follow-up actions when an item hasn't reached the synchronized state, improving validation of state transitions during global index updates.
  * Adjusted the test's data modification to better reflect expected post-update values, improving reliability and accuracy of the checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->