### PR TITLE
planner/core: fix flaky test TestMemtableInfoschemaExtractorPart4

### DIFF
--- a/pkg/planner/core/tests/extractor/memtable_infoschema_extractor_test.go
+++ b/pkg/planner/core/tests/extractor/memtable_infoschema_extractor_test.go
@@ -102,6 +102,87 @@ type testCase struct {
 	memTableName string
 	prepareData  func(tk *testkit.TestKit) (names []colPredicates)
 	cleanData    func(tk *testkit.TestKit)
+	buildConds   func(names []colPredicates) []string
+}
+
+func buildCartesianConditions(names []colPredicates) []string {
+	conditions := []string{}
+	for i := len(names) - 1; i >= 0; i-- {
+		all := names[i].enumerateAll()
+		if len(conditions) == 0 {
+			conditions = all
+			continue
+		}
+		newConditions := make([]string, 0, len(all)*len(conditions))
+		for _, a := range all {
+			for _, b := range conditions {
+				newConditions = append(newConditions, fmt.Sprintf("%s and %s", a, b))
+			}
+		}
+		conditions = newConditions
+	}
+	return conditions
+}
+
+func buildRepresentativeConditions(names []colPredicates) []string {
+	predicates := make([][]string, 0, len(names))
+	for _, name := range names {
+		all := name.enumerateAll()
+		if len(all) == 0 {
+			continue
+		}
+		predicates = append(predicates, all)
+	}
+
+	conditions := make([]string, 0)
+	seen := make(map[string]struct{})
+	addCondition := func(parts ...string) {
+		cond := strings.Join(parts, " and ")
+		if _, ok := seen[cond]; ok {
+			return
+		}
+		seen[cond] = struct{}{}
+		conditions = append(conditions, cond)
+	}
+
+	for _, all := range predicates {
+		for _, cond := range all {
+			addCondition(cond)
+		}
+	}
+
+	for i := 0; i < len(predicates); i++ {
+		for j := i + 1; j < len(predicates); j++ {
+			for _, left := range predicates[i] {
+				for _, right := range predicates[j] {
+					addCondition(left, right)
+				}
+			}
+		}
+	}
+
+	if len(predicates) <= 1 {
+		return conditions
+	}
+
+	canonical := make([]string, len(predicates))
+	for i, all := range predicates {
+		canonical[i] = all[0]
+	}
+	addCondition(canonical...)
+
+	// Keep each predicate variant covered in a multi-column query, without using
+	// the full Cartesian product that makes the test timing-sensitive.
+	for i, all := range predicates {
+		for _, cond := range all {
+			parts := make([]string, len(canonical))
+			copy(parts, canonical)
+			parts[i] = cond
+			addCondition(parts...)
+		}
+	}
+
+	return conditions
 }
 
 func prepareDataTables(tk *testkit.TestKit) (names []colPredicates) {
@@ -325,21 +406,11 @@ func testMemtableInfoschemaExtractor(t *testing.T, tcs []testCase) {
 	countSQL := 0
 	for _, tc := range tcs {
 		names := tc.prepareData(tk)
-		conditions := []string{}
-		for i := len(names) - 1; i >= 0; i-- {
-			all := names[i].enumerateAll()
-			if len(conditions) == 0 {
-				conditions = all
-			} else {
-				newConditions := []string{}
-				for _, a := range all {
-					for _, b := range conditions {
-						newConditions = append(newConditions, fmt.Sprintf("%s and %s", a, b))
-					}
-				}
-				conditions = newConditions
-			}
+		buildConds := tc.buildConds
+		if buildConds == nil {
+			buildConds = buildCartesianConditions
 		}
+		conditions := buildConds(names)
 
 		countSQL += len(conditions)
 		for _, c := range conditions {
@@ -421,6 +492,7 @@ func TestMemtableInfoschemaExtractorPart4(t *testing.T) {
 			memTableName: infoschema.TableTiDBCheckConstraints,
 			prepareData:  prepareDataTidbCheckConstraints,
 			cleanData:    cleanDataTidbCheckConstraints,
+			buildConds:   buildRepresentativeConditions,
 		},
 		{
 			memTableName: infoschema.TableSequences,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66974

Problem Summary:

This test was flaky because it generated too many SQL statements, not because of a correctness bug in TIDB_CHECK_CONSTRAINTS itself.

  TestMemtableInfoschemaExtractorPart4 builds predicates by enumerating all supported filter forms for each extractable column, then taking the full Cartesian
  product across columns. For information_schema.tidb_check_constraints, that means:

  - constraint_schema: 13 predicate variants
  - table_name: 13 predicate variants
  - constraint_name: 13 predicate variants
  - table_id: 34 predicate variants

  That expands to 13 * 13 * 13 * 34 = 74,698 SQL statements for this case alone. In practice, this makes the package highly sensitive to machine load and often
  causes timeout-based failures.

  The fix keeps coverage but removes the combinatorial explosion. Instead of using the full Cartesian product for this case, it now generates a representative
  subset of queries:

  - all single-column predicate variants
  - all pairwise combinations
  - a small number of full-column combinations

  This still exercises the extractor across different predicate shapes and multi-column filters, but reduces the query count from 74,698 to 1,976, making the test
  much less timeout-prone.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved condition-building mechanisms for test queries, enabling more flexible and efficient test case configurations.

**Note:** This release contains internal testing improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->