### PR TITLE
lightning: limit seekPropsOffsets concurrency

### DIFF
--- a/pkg/lightning/backend/external/util.go
+++ b/pkg/lightning/backend/external/util.go
@@ -44,6 +44,10 @@ import (
 
 const (
 	metaName = "meta.json"
+	// seekPropsOffsetsConcurrencyLimit limits the number of concurrently opened
+	// stats readers to avoid overwhelming the object storage client and causing
+	// excessive request queueing.
+	seekPropsOffsetsConcurrencyLimit = 512
 )
 
 // seekPropsOffsets reads the statistic files to find the largest offset of
@@ -72,6 +76,7 @@ func seekPropsOffsets(
 	}
 
 	eg, egCtx := util.NewErrorGroupWithRecoverWithCtx(ctx)
+	eg.SetLimit(seekPropsOffsetsConcurrencyLimit)
 	for i := range paths {
 		eg.Go(func() error {
 			r, err2 := newStatsReader(egCtx, exStorage, paths[i], 250*1024)

--- a/pkg/lightning/backend/external/util_test.go
+++ b/pkg/lightning/backend/external/util_test.go
@@ -19,13 +19,51 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/ingestor/engineapi"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/objstore"
+	"github.com/pingcap/tidb/pkg/objstore/objectio"
+	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/stretchr/testify/require"
 )
+
+type openBlockingStorage struct {
+	storeapi.Storage
+
+	startedCh chan struct{}
+	proceedCh chan struct{}
+
+	inFlight    atomic.Int64
+	maxInFlight atomic.Int64
+}
+
+func (s *openBlockingStorage) Open(ctx context.Context, path string, option *storeapi.ReaderOption) (objectio.Reader, error) {
+	cur := s.inFlight.Add(1)
+	defer s.inFlight.Add(-1)
+
+	for {
+		max := s.maxInFlight.Load()
+		if cur <= max {
+			break
+		}
+		if s.maxInFlight.CompareAndSwap(max, cur) {
+			break
+		}
+	}
+
+	s.startedCh <- struct{}{}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.proceedCh:
+	}
+	return s.Storage.Open(ctx, path, option)
+}
 
 func TestSeekPropsOffsets(t *testing.T) {
 	ctx := context.Background()
@@ -131,6 +169,74 @@ func TestSeekPropsOffsets(t *testing.T) {
 	got, err = seekPropsOffsets(ctx, []kv.Key{[]byte("key3"), []byte("key999")}, []string{file1, file2, file3, file4}, store)
 	require.NoError(t, err)
 	require.Equal(t, [][]uint64{{30, 20, 0, 30}, {50, 40, 0, 50}}, got)
+}
+
+func TestSeekPropsOffsetsConcurrencyLimit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	baseStore := objstore.NewMemStorage()
+	paths := make([]string, 0, 1024)
+	for i := range 1024 {
+		p := fmt.Sprintf("/test-%d", i)
+		paths = append(paths, p)
+		require.NoError(t, baseStore.WriteFile(ctx, p, nil))
+	}
+
+	startedCh := make(chan struct{}, len(paths))
+	proceedCh := make(chan struct{})
+	storage := &openBlockingStorage{
+		Storage:   baseStore,
+		startedCh: startedCh,
+		proceedCh: proceedCh,
+	}
+
+	var unblockOnce sync.Once
+	unblock := func() { unblockOnce.Do(func() { close(proceedCh) }) }
+	defer unblock()
+
+	doneCh := make(chan error, 1)
+	go func() {
+		_, err := seekPropsOffsets(ctx, []kv.Key{[]byte("key2.5")}, paths, storage)
+		doneCh <- err
+	}()
+
+	var doneOnce sync.Once
+	var doneErr error
+	waitDone := func(timeout time.Duration) error {
+		doneOnce.Do(func() {
+			select {
+			case doneErr = <-doneCh:
+			case <-time.After(timeout):
+				doneErr = fmt.Errorf("timeout waiting seekPropsOffsets to return")
+			}
+		})
+		return doneErr
+	}
+
+	t.Cleanup(func() {
+		unblock()
+		_ = waitDone(5 * time.Second)
+	})
+
+	const wantLimit = int64(seekPropsOffsetsConcurrencyLimit)
+	for i := int64(0); i < wantLimit; i++ {
+		select {
+		case <-startedCh:
+		case <-ctx.Done():
+			t.Fatalf("timeout waiting for %d concurrent opens", wantLimit)
+		}
+	}
+
+	select {
+	case <-startedCh:
+		t.Fatalf("seekPropsOffsets opened more than %d readers concurrently", wantLimit)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	unblock()
+	require.NoError(t, waitDone(5*time.Second))
+	require.LessOrEqual(t, storage.maxInFlight.Load(), wantLimit)
 }
 
 func TestGetAllFileNames(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67034

Problem Summary:
- `seekPropsOffsets()` opens one stats reader per stats file.
- With large external file sets this can fan out more than 1k concurrent object-store opens and trigger S3 `RequestTimeTooSkewed`.

### What changed and how does it work?
- Cap `seekPropsOffsets()` concurrency at 512.
- Add a regression test to verify the stats-reader `Open()` fan-out does not exceed the limit.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added concurrency limits to enhance system stability when handling parallel operations.

* **Tests**
  * Introduced test coverage to validate concurrency limit enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->