### PR TITLE
planner: fast-path stable null-reject checks for outer join plan cache

### DIFF
--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -311,6 +311,13 @@ func simplifyOuterJoin(p *LogicalJoin, predicates []expression.Expression) {
 		if expression.ExprFromSchema(expr, outerTable.Schema()) {
 			continue
 		}
+		if known, rejected := stableNullRejectForPlanCache(p.SCtx(), innerTable.Schema(), expr); known {
+			if rejected {
+				canBeSimplified = true
+				break
+			}
+			continue
+		}
 		isOk := isNullRejected(p.SCtx(), innerTable.Schema(), expr)
 		if isOk {
 			canBeSimplified = true
@@ -319,6 +326,27 @@ func simplifyOuterJoin(p *LogicalJoin, predicates []expression.Expression) {
 	}
 	if canBeSimplified {
 		p.JoinType = base.InnerJoin
+	}
+}
+
+// stableNullRejectForPlanCache only applies the structural classifier to predicates
+// that are plan-cache-sensitive. Otherwise callers should keep the legacy null-reject
+// path unchanged.
+func stableNullRejectForPlanCache(
+	ctx planctx.PlanContext,
+	schema *expression.Schema,
+	expr expression.Expression,
+) (known bool, rejected bool) {
+	if !expression.MaybeOverOptimized4PlanCache(ctx.GetExprCtx(), expr) {
+		return false, false
+	}
+	switch util.ClassifyStableNullRejectBySchema(ctx, schema, expr) {
+	case util.StableNullRejectYes:
+		return true, true
+	case util.StableNullRejectNo:
+		return true, false
+	default:
+		return false, false
 	}
 }
 
@@ -790,6 +818,13 @@ func (p *LogicalJoin) ConvertOuterToInnerJoin(predicates []expression.Expression
 	if p.JoinType == base.LeftOuterJoin || p.JoinType == base.RightOuterJoin {
 		canBeSimplified := false
 		for _, expr := range predicates {
+			if known, rejected := stableNullRejectForPlanCache(p.SCtx(), innerTable.Schema(), expr); known {
+				if rejected {
+					canBeSimplified = true
+					break
+				}
+				continue
+			}
 			isOk := util.IsNullRejected(p.SCtx(), innerTable.Schema(), expr, true)
 			if isOk {
 				canBeSimplified = true

--- a/pkg/planner/core/partidx/BUILD.bazel
+++ b/pkg/planner/core/partidx/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/expression",
         "//pkg/parser/ast",
         "//pkg/planner/planctx",
+        "//pkg/planner/util",
         "//pkg/util/intest",
         "//pkg/util/ranger",
         "//pkg/util/ranger/context",

--- a/pkg/planner/core/partidx/check_constraint.go
+++ b/pkg/planner/core/partidx/check_constraint.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/planctx"
+	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/ranger"
 	"github.com/pingcap/tidb/pkg/util/ranger/context"
@@ -148,7 +149,8 @@ func implIsNotNull(rangerctx *context.RangerContext, targetCol *expression.Colum
 // AlwaysMeetConstraints checks whether the filters always meet the constraints from the predefined predicates in index meta.
 // This check is only applied to the pre condition that is single IS NOT NULL.
 // e.g. for partial index idx(b) where a IS NOT NULL, if the filter is b = ? and a is not null/a > 10, then we can guarantee that a IS NOT NULL is always true.
-// Because the `IsNullRejected` has correctness issues. So we implement a simpler version here.
+// Reuse the shared structural fast path so outer-join rewrite and partial-index reasoning
+// stay aligned on the same small set of parameter-stable cases.
 func AlwaysMeetConstraints(sctx planctx.PlanContext, prePredicates, filters []expression.Expression) bool {
 	if len(prePredicates) != 1 {
 		return false
@@ -165,55 +167,8 @@ func AlwaysMeetConstraints(sctx planctx.PlanContext, prePredicates, filters []ex
 	if !ok {
 		return false
 	}
-	// When the index is chosen, the given filters can not be empty.
 	for _, filter := range filters {
-		sf, ok := filter.(*expression.ScalarFunction)
-		if !ok {
-			continue
-		}
-		if checkIsNullRejected(sctx, col, sf) {
-			return true
-		}
-	}
-	return false
-}
-
-func checkIsNullRejected(sctx planctx.PlanContext, targetCol *expression.Column, filter *expression.ScalarFunction) bool {
-	if filter.FuncName.L == ast.LogicOr {
-		leavesAllRejected := true
-		for _, arg := range filter.GetArgs() {
-			sf, ok := arg.(*expression.ScalarFunction)
-			if !ok || !checkIsNullRejected(sctx, targetCol, sf) {
-				leavesAllRejected = false
-				break
-			}
-		}
-		return leavesAllRejected
-	}
-	if filter.FuncName.L == ast.LogicAnd {
-		for _, arg := range filter.GetArgs() {
-			sf, ok := arg.(*expression.ScalarFunction)
-			if ok && checkIsNullRejected(sctx, targetCol, sf) {
-				return true
-			}
-		}
-		return false
-	}
-	if filter.FuncName.L == ast.IsNull {
-		col, ok := filter.GetArgs()[0].(*expression.Column)
-		if ok && col.Equal(sctx.GetExprCtx().GetEvalCtx(), targetCol) {
-			return false
-		}
-	}
-	if _, ok := expression.CompareOpMap[filter.FuncName.L]; ok {
-		if filter.FuncName.L == ast.NullEQ {
-			return false
-		}
-		col, ok := filter.GetArgs()[0].(*expression.Column)
-		if !ok {
-			col, ok = filter.GetArgs()[1].(*expression.Column)
-		}
-		if ok && col.Equal(sctx.GetExprCtx().GetEvalCtx(), targetCol) {
+		if plannerutil.ClassifyStableNullRejectByColumn(sctx, col, filter) == plannerutil.StableNullRejectYes {
 			return true
 		}
 	}

--- a/pkg/planner/util/null_misc.go
+++ b/pkg/planner/util/null_misc.go
@@ -22,6 +22,213 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/planctx"
 )
 
+// StableNullRejectStatus describes whether a predicate's null-reject property stays fixed
+// after replacing the probed inner-side columns with NULL while leaving parameters symbolic.
+type StableNullRejectStatus uint8
+
+const (
+	// StableNullRejectUnknown means the structural fast path cannot prove the outcome.
+	StableNullRejectUnknown StableNullRejectStatus = iota
+	// StableNullRejectYes means the predicate is always null-rejected for the probed input.
+	StableNullRejectYes
+	// StableNullRejectNo means the predicate is always non-null-rejected for the probed input.
+	StableNullRejectNo
+)
+
+// stableNullRejectNullPropagatingFuncs is the conservative set of scalar
+// operator/function names whose result is guaranteed to be NULL once any argument is
+// forced to NULL.
+//
+// Boolean predicate nodes with their own three-valued-logic folding rules, such as
+// AND/OR/IS NULL/NOT IS NULL, are classified separately below.
+var stableNullRejectNullPropagatingFuncs = map[string]struct{}{
+	ast.Abs:        {},
+	ast.Cast:       {},
+	ast.Div:        {},
+	ast.EQ:         {},
+	ast.GE:         {},
+	ast.GT:         {},
+	ast.IntDiv:     {},
+	ast.LE:         {},
+	ast.LT:         {},
+	ast.Minus:      {},
+	ast.Mod:        {},
+	ast.Mul:        {},
+	ast.NE:         {},
+	ast.Plus:       {},
+	ast.UnaryMinus: {},
+	ast.UnaryPlus:  {},
+}
+
+// stableNullRejectProbe describes which columns are conceptually replaced with NULL
+// during the structural null-reject classification.
+type stableNullRejectProbe struct {
+	evalCtx   expression.EvalContext
+	schema    *expression.Schema
+	targetCol *expression.Column
+}
+
+func (p stableNullRejectProbe) matches(col *expression.Column) bool {
+	if p.schema != nil {
+		return p.schema.Contains(col)
+	}
+	return p.targetCol != nil && col.Equal(p.evalCtx, p.targetCol)
+}
+
+// ClassifyStableNullRejectBySchema classifies whether a predicate's null-reject property
+// stays fixed after replacing the referenced inner-side schema columns with NULL.
+func ClassifyStableNullRejectBySchema(
+	ctx planctx.PlanContext,
+	innerSchema *expression.Schema,
+	predicate expression.Expression,
+) StableNullRejectStatus {
+	predicate = expression.PushDownNot(ctx.GetNullRejectCheckExprCtx(), predicate)
+	if expression.ContainOuterNot(predicate) {
+		return StableNullRejectUnknown
+	}
+	return classifyStableNullReject(ctx, predicate, stableNullRejectProbe{
+		evalCtx: ctx.GetExprCtx().GetEvalCtx(),
+		schema:  innerSchema,
+	})
+}
+
+// ClassifyStableNullRejectByColumn classifies whether a predicate's null-reject property
+// stays fixed after replacing the target column with NULL.
+func ClassifyStableNullRejectByColumn(
+	ctx planctx.PlanContext,
+	targetCol *expression.Column,
+	predicate expression.Expression,
+) StableNullRejectStatus {
+	predicate = expression.PushDownNot(ctx.GetNullRejectCheckExprCtx(), predicate)
+	if expression.ContainOuterNot(predicate) {
+		return StableNullRejectUnknown
+	}
+	return classifyStableNullReject(ctx, predicate, stableNullRejectProbe{
+		evalCtx:   ctx.GetExprCtx().GetEvalCtx(),
+		targetCol: targetCol,
+	})
+}
+
+func classifyStableNullReject(
+	ctx planctx.PlanContext,
+	predicate expression.Expression,
+	probe stableNullRejectProbe,
+) StableNullRejectStatus {
+	// Constant-only predicates do not depend on the probed columns at all, so we can
+	// classify them directly once they are known to be free of mutable constants.
+	if allConstants(ctx.GetExprCtx(), predicate) {
+		return classifyStableNullRejectImmutablePredicate(ctx, predicate)
+	}
+	if expr, ok := predicate.(*expression.ScalarFunction); ok {
+		switch expr.FuncName.L {
+		case ast.LogicAnd:
+			allNo := true
+			for _, arg := range expr.GetArgs() {
+				result := classifyStableNullReject(ctx, arg, probe)
+				if result == StableNullRejectYes {
+					return StableNullRejectYes
+				}
+				if result != StableNullRejectNo {
+					allNo = false
+				}
+			}
+			if allNo {
+				return StableNullRejectNo
+			}
+			return StableNullRejectUnknown
+		case ast.LogicOr:
+			allYes := true
+			for _, arg := range expr.GetArgs() {
+				result := classifyStableNullReject(ctx, arg, probe)
+				if result == StableNullRejectNo {
+					return StableNullRejectNo
+				}
+				if result != StableNullRejectYes {
+					allYes = false
+				}
+			}
+			if allYes {
+				return StableNullRejectYes
+			}
+			return StableNullRejectUnknown
+		case ast.IsNull:
+			if exprAlwaysNullWhenProbeColumnsNull(expr.GetArgs()[0], probe) {
+				return StableNullRejectNo
+			}
+			return StableNullRejectUnknown
+		case ast.UnaryNot:
+			child, ok := expr.GetArgs()[0].(*expression.ScalarFunction)
+			if ok && child.FuncName.L == ast.IsNull && exprAlwaysNullWhenProbeColumnsNull(child.GetArgs()[0], probe) {
+				return StableNullRejectYes
+			}
+			return StableNullRejectUnknown
+		}
+	}
+
+	if exprAlwaysNullWhenProbeColumnsNull(predicate, probe) {
+		return StableNullRejectYes
+	}
+	return StableNullRejectUnknown
+}
+
+// classifyStableNullRejectImmutablePredicate handles the degenerate case where the predicate is
+// already fully constant and therefore independent from the probed columns.
+//
+// false/NULL means null-reject, because the outer-join generated row can never make the
+// predicate true; true means non-null-reject.
+func classifyStableNullRejectImmutablePredicate(ctx planctx.PlanContext, predicate expression.Expression) StableNullRejectStatus {
+	result, err := expression.EvaluateExprWithNull(ctx.GetNullRejectCheckExprCtx(), expression.NewSchema(), predicate, false)
+	if err != nil {
+		return StableNullRejectUnknown
+	}
+	x, ok := result.(*expression.Constant)
+	if !ok || isMutableConst(x) {
+		return StableNullRejectUnknown
+	}
+	if x.Value.IsNull() {
+		return StableNullRejectYes
+	}
+	isTrue, err := x.Value.ToBool(ctx.GetSessionVars().StmtCtx.TypeCtxOrDefault())
+	if err != nil {
+		return StableNullRejectUnknown
+	}
+	if isTrue == 0 {
+		return StableNullRejectYes
+	}
+	return StableNullRejectNo
+}
+
+// exprAlwaysNullWhenProbeColumnsNull answers a narrower question than full null-reject:
+// after replacing the probed columns with NULL, is this expression guaranteed to become
+// NULL regardless of the remaining symbolic parameters?
+//
+// This helper is intentionally conservative. It only recognizes columns/constant NULLs
+// directly, then recurses through a small set of operators/functions whose result is NULL
+// whenever one argument is NULL. More complex boolean forms are handled by
+// classifyStableNullReject.
+func exprAlwaysNullWhenProbeColumnsNull(expr expression.Expression, probe stableNullRejectProbe) bool {
+	switch x := expr.(type) {
+	case *expression.Column:
+		return probe.matches(x)
+	case *expression.Constant:
+		return !isMutableConst(x) && x.Value.IsNull()
+	case *expression.ScalarFunction:
+		if _, ok := stableNullRejectNullPropagatingFuncs[x.FuncName.L]; !ok {
+			return false
+		}
+		for _, arg := range x.GetArgs() {
+			if exprAlwaysNullWhenProbeColumnsNull(arg, probe) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isMutableConst(expr *expression.Constant) bool {
+	return expr.ParamMarker != nil || expr.DeferredExpr != nil
+}
+
 // allConstants checks if only the expression has only constants.
 func allConstants(ctx expression.BuildContext, expr expression.Expression) bool {
 	if expression.MaybeOverOptimized4PlanCache(ctx, expr) {

--- a/pkg/planner/util/path_test.go
+++ b/pkg/planner/util/path_test.go
@@ -18,7 +18,10 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/coretestsdk"
 	"github.com/pingcap/tidb/pkg/types"
@@ -120,4 +123,180 @@ func TestOnlyPointRange(t *testing.T) {
 	indexPath.Index.Columns = make([]*model.IndexColumn, 2)
 	indexPath.Ranges = []*ranger.Range{&onePointRange}
 	require.False(t, indexPath.OnlyPointRange(tc))
+
+	t.Run("stable null reject fast path", func(t *testing.T) {
+		col := &expression.Column{
+			UniqueID: sctx.GetSessionVars().AllocPlanColumnID(),
+			RetType:  types.NewFieldType(mysql.TypeLonglong),
+		}
+		schema := expression.NewSchema(col)
+		one := &expression.Constant{
+			Value:   types.NewIntDatum(1),
+			RetType: types.NewFieldType(mysql.TypeLonglong),
+		}
+
+		gtExpr := expression.NewFunctionInternal(
+			sctx.GetExprCtx(),
+			ast.GT,
+			types.NewFieldType(mysql.TypeTiny),
+			col,
+			one,
+		)
+		require.Equal(t, util.StableNullRejectYes, util.ClassifyStableNullRejectBySchema(sctx.GetPlanCtx(), schema, gtExpr))
+		require.Equal(t, util.StableNullRejectYes, util.ClassifyStableNullRejectByColumn(sctx.GetPlanCtx(), col, gtExpr))
+
+		addExpr := expression.NewFunctionInternal(
+			sctx.GetExprCtx(),
+			ast.Plus,
+			types.NewFieldType(mysql.TypeLonglong),
+			col,
+			one,
+		)
+		addGTExpr := expression.NewFunctionInternal(
+			sctx.GetExprCtx(),
+			ast.GT,
+			types.NewFieldType(mysql.TypeTiny),
+			addExpr,
+			one,
+		)
+		require.Equal(t, util.StableNullRejectYes, util.ClassifyStableNullRejectBySchema(sctx.GetPlanCtx(), schema, addGTExpr))
+		require.Equal(t, util.StableNullRejectYes, util.ClassifyStableNullRejectBySchema(sctx.GetPlanCtx(), schema, addExpr))
+
+		two := &expression.Constant{
+			Value:   types.NewIntDatum(2),
+			RetType: types.NewFieldType(mysql.TypeLonglong),
+		}
+		strictCases := []struct {
+			name  string
+			build func() expression.Expression
+		}{
+			{
+				name: "abs",
+				build: func() expression.Expression {
+					return expression.NewFunctionInternal(
+						sctx.GetExprCtx(),
+						ast.Abs,
+						types.NewFieldType(mysql.TypeLonglong),
+						col,
+					)
+				},
+			},
+			{
+				name: "minus",
+				build: func() expression.Expression {
+					return expression.NewFunctionInternal(
+						sctx.GetExprCtx(),
+						ast.Minus,
+						types.NewFieldType(mysql.TypeLonglong),
+						col,
+						one,
+					)
+				},
+			},
+			{
+				name: "mul",
+				build: func() expression.Expression {
+					return expression.NewFunctionInternal(
+						sctx.GetExprCtx(),
+						ast.Mul,
+						types.NewFieldType(mysql.TypeLonglong),
+						col,
+						two,
+					)
+				},
+			},
+			{
+				name: "div",
+				build: func() expression.Expression {
+					return expression.NewFunctionInternal(
+						sctx.GetExprCtx(),
+						ast.Div,
+						types.NewFieldType(mysql.TypeNewDecimal),
+						col,
+						two,
+					)
+				},
+			},
+			{
+				name: "int div",
+				build: func() expression.Expression {
+					return expression.NewFunctionInternal(
+						sctx.GetExprCtx(),
+						ast.IntDiv,
+						types.NewFieldType(mysql.TypeLonglong),
+						col,
+						two,
+					)
+				},
+			},
+			{
+				name: "mod",
+				build: func() expression.Expression {
+					return expression.NewFunctionInternal(
+						sctx.GetExprCtx(),
+						ast.Mod,
+						types.NewFieldType(mysql.TypeLonglong),
+						col,
+						two,
+					)
+				},
+			},
+			{
+				name: "unary minus",
+				build: func() expression.Expression {
+					return expression.NewFunctionInternal(
+						sctx.GetExprCtx(),
+						ast.UnaryMinus,
+						types.NewFieldType(mysql.TypeLonglong),
+						col,
+					)
+				},
+			},
+		}
+		for _, tc := range strictCases {
+			t.Run(tc.name, func(t *testing.T) {
+				strictExpr := tc.build()
+				predicate := expression.NewFunctionInternal(
+					sctx.GetExprCtx(),
+					ast.GT,
+					types.NewFieldType(mysql.TypeTiny),
+					strictExpr,
+					one,
+				)
+				require.Equal(t, util.StableNullRejectYes, util.ClassifyStableNullRejectBySchema(sctx.GetPlanCtx(), schema, predicate))
+			})
+		}
+
+		isNullExpr := expression.NewFunctionInternal(
+			sctx.GetExprCtx(),
+			ast.IsNull,
+			types.NewFieldType(mysql.TypeTiny),
+			col,
+		)
+		orExpr := expression.NewFunctionInternal(
+			sctx.GetExprCtx(),
+			ast.LogicOr,
+			types.NewFieldType(mysql.TypeTiny),
+			gtExpr,
+			isNullExpr,
+		)
+		require.Equal(t, util.StableNullRejectNo, util.ClassifyStableNullRejectBySchema(sctx.GetPlanCtx(), schema, orExpr))
+
+		notIsNullExpr := expression.NewFunctionInternal(
+			sctx.GetExprCtx(),
+			ast.UnaryNot,
+			types.NewFieldType(mysql.TypeTiny),
+			isNullExpr,
+		)
+		require.Equal(t, util.StableNullRejectYes, util.ClassifyStableNullRejectBySchema(sctx.GetPlanCtx(), schema, notIsNullExpr))
+
+		nullEQExpr := expression.NewFunctionInternal(
+			sctx.GetExprCtx(),
+			ast.NullEQ,
+			types.NewFieldType(mysql.TypeTiny),
+			col,
+			one,
+		)
+		require.Equal(t, util.StableNullRejectUnknown, util.ClassifyStableNullRejectBySchema(sctx.GetPlanCtx(), schema, nullEQExpr))
+	})
 }

--- a/tests/integrationtest/r/planner/core/plan_cache.result
+++ b/tests/integrationtest/r/planner/core/plan_cache.result
@@ -320,6 +320,183 @@ set @p0 = '1', @p1 = '1';
 execute stmt using @p0, @p1;
 count(1)
 1
+drop table if exists t1, t2;
+create table t1 (a int, b int);
+create table t2 (a int, b int);
+insert into t1 values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+insert into t2 values (2, 2), (3, 3), (4, 4), (5, 5);
+set tidb_enable_prepared_plan_cache=1;
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a > ? order by t1.a';
+set @v = 1;
+execute stmt using @v;
+t1_a	t2_a
+2	2
+3	3
+4	4
+5	5
+set @v = 2;
+execute stmt using @v;
+t1_a	t2_a
+3	3
+4	4
+5	5
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a + ? > 3 order by t1.a';
+set @v = 0;
+execute stmt using @v;
+t1_a	t2_a
+4	4
+5	5
+set @v = 1;
+execute stmt using @v;
+t1_a	t2_a
+3	3
+4	4
+5	5
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where abs(t2.a) > ? order by t1.a';
+set @v = 1;
+execute stmt using @v;
+t1_a	t2_a
+2	2
+3	3
+4	4
+5	5
+set @v = 2;
+execute stmt using @v;
+t1_a	t2_a
+3	3
+4	4
+5	5
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where -t2.a > ? order by t1.a';
+set @v = -6;
+execute stmt using @v;
+t1_a	t2_a
+2	2
+3	3
+4	4
+5	5
+set @v = -5;
+execute stmt using @v;
+t1_a	t2_a
+2	2
+3	3
+4	4
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a - ? > 1 order by t1.a';
+set @v = 1;
+execute stmt using @v;
+t1_a	t2_a
+3	3
+4	4
+5	5
+set @v = 2;
+execute stmt using @v;
+t1_a	t2_a
+4	4
+5	5
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a / ? > 1 order by t1.a';
+set @v = 1;
+execute stmt using @v;
+t1_a	t2_a
+2	2
+3	3
+4	4
+5	5
+set @v = 2;
+execute stmt using @v;
+t1_a	t2_a
+3	3
+4	4
+5	5
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a * ? > 6 order by t1.a';
+set @v = 2;
+execute stmt using @v;
+t1_a	t2_a
+4	4
+5	5
+set @v = 3;
+execute stmt using @v;
+t1_a	t2_a
+3	3
+4	4
+5	5
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a > ? or t2.a is null order by t1.a';
+set @v = 1;
+execute stmt using @v;
+t1_a	t2_a
+1	NULL
+2	2
+3	3
+4	4
+5	5
+set @v = 2;
+execute stmt using @v;
+t1_a	t2_a
+1	NULL
+3	3
+4	4
+5	5
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where not (t2.a is null) and ? > 0 order by t1.a';
+set @v = 1;
+execute stmt using @v;
+t1_a	t2_a
+2	2
+3	3
+4	4
+5	5
+set @v = 2;
+execute stmt using @v;
+t1_a	t2_a
+2	2
+3	3
+4	4
+5	5
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a <=> ? order by t1.a';
+set @v = 1;
+execute stmt using @v;
+t1_a	t2_a
+set @v = 1;
+execute stmt using @v;
+t1_a	t2_a
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+deallocate prepare stmt;
+set tidb_enable_prepared_plan_cache=DEFAULT;
 drop table if exists t;
 create table t (a int);
 set @@tidb_enable_non_prepared_plan_cache=1;

--- a/tests/integrationtest/t/planner/core/plan_cache.test
+++ b/tests/integrationtest/t/planner/core/plan_cache.test
@@ -236,6 +236,97 @@ set @p0 = '1', @p1 = '1';
 execute stmt using @p0, @p1;
 
 
+# TestPlanCacheNullRejectFastPath
+drop table if exists t1, t2;
+create table t1 (a int, b int);
+create table t2 (a int, b int);
+insert into t1 values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+insert into t2 values (2, 2), (3, 3), (4, 4), (5, 5);
+set tidb_enable_prepared_plan_cache=1;
+
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a > ? order by t1.a';
+set @v = 1;
+execute stmt using @v;
+set @v = 2;
+execute stmt using @v;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a + ? > 3 order by t1.a';
+set @v = 0;
+execute stmt using @v;
+set @v = 1;
+execute stmt using @v;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where abs(t2.a) > ? order by t1.a';
+set @v = 1;
+execute stmt using @v;
+set @v = 2;
+execute stmt using @v;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where -t2.a > ? order by t1.a';
+set @v = -6;
+execute stmt using @v;
+set @v = -5;
+execute stmt using @v;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a - ? > 1 order by t1.a';
+set @v = 1;
+execute stmt using @v;
+set @v = 2;
+execute stmt using @v;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a / ? > 1 order by t1.a';
+set @v = 1;
+execute stmt using @v;
+set @v = 2;
+execute stmt using @v;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a * ? > 6 order by t1.a';
+set @v = 2;
+execute stmt using @v;
+set @v = 3;
+execute stmt using @v;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a > ? or t2.a is null order by t1.a';
+set @v = 1;
+execute stmt using @v;
+set @v = 2;
+execute stmt using @v;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where not (t2.a is null) and ? > 0 order by t1.a';
+set @v = 1;
+execute stmt using @v;
+set @v = 2;
+execute stmt using @v;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+prepare stmt from 'select t1.a as t1_a, t2.a as t2_a from t1 left join t2 on t1.a = t2.b where t2.a <=> ? order by t1.a';
+set @v = 1;
+execute stmt using @v;
+set @v = 1;
+execute stmt using @v;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+set tidb_enable_prepared_plan_cache=DEFAULT;
+
+
 # TestNonPreparedPlanCacheDMLHints
 drop table if exists t;
 create table t (a int);


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67048

Problem Summary:
When an outer join is analyzed for outer-to-inner conversion, parameterized predicates may go through `EvaluateExprWithNull()` during null-reject checking. In prepared plan cache scenarios, this can mark the statement as uncacheable before we know whether the null-reject property actually depends on the parameter values.

For some common predicates, the null-reject outcome is parameter-invariant:

- always null-rejected, regardless of parameter bindings
- always non-null-rejected, regardless of parameter bindings

These cases do not need to fall back to the old path immediately. We can classify them structurally first and avoid unnecessary plan-cache skips.

### What changed and how does it work?

This PR adds a small shared tri-state structural helper for parameter-stable null-reject classification:

- `Yes`: always null-rejected
- `No`: always non-null-rejected
- `Unknown`: cannot be proven by the fast path

The helper is reused in two places:

1. Outer-join to inner-join conversion
   - Apply the fast path in both outer-to-inner entry points.
   - If the result is `Yes` or `No`, short-circuit directly.
   - If the result is `Unknown`, fall back to the existing call-site behavior.

2. Partial index `IS NOT NULL` implication checks
   - Reuse the same helper instead of maintaining a separate recursive checker.

This PR intentionally does **not** change the generic `util.IsNullRejected()` behavior. It only adds a shared fast path for cases whose null-reject property is provably parameter-invariant, which keeps the scope and behavior change minimal.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a stable null-rejection classification used across planning to make predicate reasoning more precise.

* **Performance Improvements**
  * Enables earlier, safer simplification of outer joins to inner joins and speeds predicate evaluation during plan caching.

* **Tests**
  * Added unit and integration tests covering null-rejection fast paths and plan-cache behavior under varied predicate scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->