### PR TITLE
expression: fix panic when control functions with BIT type are used in aggregation

### DIFF
--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -134,6 +134,13 @@ func (c *coalesceFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	resultFieldType.AddFlag(flag)
 
 	retEvalTp := resultFieldType.EvalType()
+	// BIT type is a hybrid type that maps to ETInt via EvalType(), but aggregation
+	// functions like MIN/MAX expect BIT values to be evaluated as ETString.
+	// Force ETString here so that the String signature is used, which is consistent
+	// with how Column.EvalString handles BIT (via the Hybrid path).
+	if resultFieldType.GetType() == mysql.TypeBit {
+		retEvalTp = types.ETString
+	}
 	fieldEvalTps := make([]types.EvalType, 0, len(args))
 	for range args {
 		fieldEvalTps = append(fieldEvalTps, retEvalTp)

--- a/pkg/expression/builtin_control.go
+++ b/pkg/expression/builtin_control.go
@@ -337,6 +337,12 @@ func (c *caseWhenFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	types.SetTypeFlag(&tempFlag, mysql.NotNullFlag, false)
 	fieldTp.SetFlag(tempFlag)
 	tp := fieldTp.EvalType()
+	// BIT is a hybrid type whose EvalType() returns ETInt, but downstream
+	// consumers (e.g. MIN/MAX aggregation) call EvalString on the result.
+	// Use ETString to match the expectation, consistent with Column.EvalString.
+	if fieldTp.GetType() == mysql.TypeBit {
+		tp = types.ETString
+	}
 
 	argTps := make([]*types.FieldType, 0, l)
 	for i := 0; i < l-1; i += 2 {
@@ -711,6 +717,12 @@ func (c *ifFunctionClass) getFunction(ctx BuildContext, args []Expression) (sig 
 		return nil, err
 	}
 	evalTps := retTp.EvalType()
+	// BIT is a hybrid type whose EvalType() returns ETInt, but downstream
+	// consumers (e.g. MIN/MAX aggregation) call EvalString on the result.
+	// Use ETString to match the expectation, consistent with Column.EvalString.
+	if retTp.GetType() == mysql.TypeBit {
+		evalTps = types.ETString
+	}
 	args[0], err = wrapWithIsTrue(ctx, true, args[0], false)
 	if err != nil {
 		return nil, err
@@ -967,6 +979,12 @@ func (c *ifNullFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 		types.SetBinChsClnFlag(retTp)
 	}
 	evalTps := retTp.EvalType()
+	// BIT is a hybrid type whose EvalType() returns ETInt, but downstream
+	// consumers (e.g. MIN/MAX aggregation) call EvalString on the result.
+	// Use ETString to match the expectation, consistent with Column.EvalString.
+	if retTp.GetType() == mysql.TypeBit {
+		evalTps = types.ETString
+	}
 	bf, err := newBaseBuiltinFuncWithFieldTypes(ctx, c.funcName, args, evalTps, retTp.Clone(), retTp.Clone())
 	if err != nil {
 		return nil, err

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -4445,3 +4445,36 @@ func TestDeepCopyRetType(t *testing.T) {
 	tk.MustExec("create view v0(c0) as select cast((t1.c0 div t1.c0) as decimal) from t1;")
 	tk.MustQuery("select * from v0 inner join t0 on (v0.c0 like cast(v0.c0 as char) <= t0.c0) and (not atan2(t0.c0, v0.c0));").Check(testkit.Rows())
 }
+
+// TestControlFuncsBitType tests that control functions (COALESCE, CASE WHEN, IF,
+// IFNULL) correctly handle BIT type columns when used inside aggregation
+// functions like MIN/MAX. Previously these would panic with "index out of range"
+// because the control function chose an Int evaluation signature while the
+// aggregation expected a String evaluation signature for BIT types.
+// See https://github.com/pingcap/tidb/issues/67007
+// See https://github.com/pingcap/tidb/issues/67008
+func TestControlFuncsBitType(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1 (active BIT)")
+	tk.MustExec("insert into t1 (active) values (0)")
+
+	// Issue #67007: MIN(COALESCE(bit_col)) panicked with index out of range.
+	tk.MustQuery("select MIN(COALESCE(t1.active)) from t1 group by t1.active").Check(testkit.Rows("\x00"))
+	tk.MustQuery("select MAX(COALESCE(t1.active)) from t1 group by t1.active").Check(testkit.Rows("\x00"))
+
+	// Issue #67008: CASE WHEN with BIT type inside INTERSECT panicked.
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t2 (active BIT, updated_at DATETIME)")
+	tk.MustExec("insert into t2 (active, updated_at) values (1, '2023-12-01 10:00:00')")
+	// This should not panic.
+	tk.MustQuery("select CASE WHEN NULLIF(t2.updated_at, 1) THEN t2.active ELSE t2.active END from t2 INTERSECT select 1").Check(testkit.Rows("1"))
+
+	// IF with BIT column inside aggregation.
+	tk.MustQuery("select MIN(IF(true, t1.active, t1.active)) from t1 group by t1.active").Check(testkit.Rows("\x00"))
+
+	// IFNULL with BIT column inside aggregation.
+	tk.MustQuery("select MIN(IFNULL(t1.active, t1.active)) from t1 group by t1.active").Check(testkit.Rows("\x00"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67007, ref #67008

Problem Summary:

When control functions (`COALESCE`, `CASE WHEN`, `IF`, `IFNULL`) wrap a `BIT` type column and the result is used inside aggregation functions like `MIN`/`MAX`, TiDB panics with:

```
ERROR 1105 (HY000): runtime error: index out of range [7] with length 0
```

Reproducer from #67007:
```sql
CREATE TABLE t1 (active BIT);
INSERT INTO t1 (active) VALUES (0);
SELECT MIN(COALESCE(t1.active)) FROM t1 GROUP BY t1.active;
-- panics with: runtime error: index out of range [7] with length 0
```

### What changed and how does it work?

**Root cause:** `BIT` is a hybrid type whose `FieldType.EvalType()` returns `ETInt`. So control functions like `COALESCE` build an Int evaluation signature (e.g., `builtinCoalesceIntSig`). However, aggregation functions like `MIN`/`MAX` detect `TypeBit` on the return type and force `ETString` evaluation. This creates a type mismatch: the aggregation calls `EvalString` on a function that only implements `evalInt`. The underlying chunk column (sized for int64, with no offsets allocated) gets accessed as a variable-length string column, triggering the out-of-range panic.

**Fix:** Override the eval type to `ETString` when the result type is `mysql.TypeBit` in:
- `coalesceFunctionClass.getFunction()`
- `caseWhenFunctionClass.getFunction()`
- `ifFunctionClass.getFunction()`
- `ifNullFunctionClass.getFunction()`

This is consistent with how `Column.EvalString` already handles BIT via the `Hybrid()` path, and matches the pattern used in aggregation builders (`buildMaxMin`, `buildFirstRow`).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a panic ("index out of range") when using control functions (COALESCE, CASE WHEN, IF, IFNULL) with BIT type columns inside aggregation functions like MIN/MAX.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed BIT type handling with control functions (COALESCE, CASE WHEN, IF, IFNULL) to ensure correct behavior in aggregations and comparisons.

* **Tests**
  * Added test coverage for BIT type operations with control functions and MIN/MAX aggregations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->