### PR TITLE
executor: fix column privilege metadata after REVOKE ALL(column)

### DIFF
--- a/pkg/executor/revoke.go
+++ b/pkg/executor/revoke.go
@@ -386,6 +386,52 @@ func removePrivFromColumnPriv(ctx context.Context, e sqlexec.SQLExecutor,
 	return err
 }
 
+// syncColumnPrivInTablePriv rebuilds mysql.tables_priv.Column_priv from the
+// remaining mysql.columns_priv rows for the same table.
+func syncColumnPrivInTablePriv(ctx context.Context, sctx sessionctx.Context, host, user, db, table string) error {
+	rs, err := sctx.GetSQLExecutor().ExecuteInternal(ctx,
+		`SELECT Column_priv FROM %n.%n WHERE User=%? AND Host=%? AND DB=%? AND Table_name=%?`,
+		mysql.SystemDB,
+		mysql.ColumnPrivTable,
+		user,
+		host,
+		db,
+		table)
+	if err != nil {
+		return err
+	}
+	rows, fields, err := getRowsAndFields(sctx, rs)
+	if err != nil {
+		return err
+	}
+
+	var columnPrivs []string
+	for _, row := range rows {
+		if fields[0].Column.GetType() != mysql.TypeSet {
+			continue
+		}
+		for _, priv := range SetFromString(row.GetSet(0).Name) {
+			columnPrivs = addToSet(columnPrivs, priv)
+		}
+	}
+
+	sql := new(strings.Builder)
+	sqlescape.MustFormatSQL(sql,
+		"UPDATE %n.%n SET Column_priv=%? WHERE User=%? AND Host=%? AND DB=%? AND Table_name=%?",
+		mysql.SystemDB, mysql.TablePrivTable, setToString(columnPrivs), user, host, db, table)
+	_, err = sctx.GetSQLExecutor().ExecuteInternal(ctx, sql.String())
+	if err != nil {
+		return err
+	}
+
+	sql.Reset()
+	sqlescape.MustFormatSQL(sql,
+		"DELETE FROM %n.%n WHERE User=%? AND Host=%? AND DB=%? AND Table_name=%? AND Table_priv='' AND Column_priv=''",
+		mysql.SystemDB, mysql.TablePrivTable, user, host, db, table)
+	_, err = sctx.GetSQLExecutor().ExecuteInternal(ctx, sql.String())
+	return err
+}
+
 // checkTablePrivTbl indicates whether we should check Column_priv in mysql.tables_priv if no corresponding column privileges
 // exists in mysql.columns_priv anymore.
 func (e *RevokeExec) revokeColumnPriv(ctx context.Context, internalSession sessionctx.Context, priv *ast.PrivElem, user, host string, checkTablePrivTbl bool) error {
@@ -425,8 +471,16 @@ func (e *RevokeExec) revokeColumnPriv(ctx context.Context, internalSession sessi
 	}
 
 	if checkTablePrivTbl {
-		sql := strings.Join([]string{"SELECT * FROM %n.%n WHERE User=%? AND Host=%? AND DB=%? AND Table_name=%? AND Column_priv LIKE '%%", priv.Priv.String(), "%%';"}, "")
-		exists, err := recordExists(internalSession, sql, mysql.SystemDB, mysql.ColumnPrivTable, user, host, dbName, e.Level.TableName)
+		tblName := e.Level.TableName
+		if tbl != nil {
+			tblName = tbl.Meta().Name.O
+		}
+		if priv.Priv == mysql.AllPriv {
+			return syncColumnPrivInTablePriv(ctx, internalSession, host, user, dbName, tblName)
+		}
+		args := []any{mysql.SystemDB, mysql.ColumnPrivTable, user, host, dbName, tblName, mysql.Priv2SetStr[priv.Priv]}
+		sql := "SELECT 1 FROM %n.%n WHERE User=%? AND Host=%? AND DB=%? AND Table_name=%? AND FIND_IN_SET(%?, Column_priv) > 0 LIMIT 1"
+		exists, err := recordExists(internalSession, sql, args...)
 		if err != nil {
 			return err
 		}

--- a/pkg/executor/revoke_test.go
+++ b/pkg/executor/revoke_test.go
@@ -252,3 +252,26 @@ func TestRevokeColumnPriv(t *testing.T) {
 	tk.MustQuery("select table_priv,column_priv from mysql.tables_priv where user='u1'").
 		Check(testkit.Rows())
 }
+
+func TestRevokeAllColumnPrivKeepsOtherColumnPrivs(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("CREATE USER u1")
+	tk.MustExec("CREATE TABLE t2 (c1 int, c2 int)")
+
+	// Revoking ALL from one column must not clear table-level Column_priv aggregation
+	// while other columns on the same table still retain column privileges.
+	tk.MustExec("GRANT SELECT(c1), UPDATE(c2) ON t2 TO u1")
+	tk.MustQuery("select table_priv,column_priv from mysql.tables_priv where user='u1' and table_name='t2'").
+		Check(testkit.RowsWithSep(" | ", " | Select,Update"))
+	tk.MustQuery("select column_name,column_priv from mysql.columns_priv where user='u1' and table_name='t2' order by column_name").
+		Check(testkit.Rows("c1 Select", "c2 Update"))
+
+	tk.MustExec("REVOKE ALL(c1) ON t2 FROM u1")
+
+	tk.MustQuery("select column_name,column_priv from mysql.columns_priv where user='u1' and table_name='t2' order by column_name").
+		Check(testkit.Rows("c2 Update"))
+	tk.MustQuery("select table_priv,column_priv from mysql.tables_priv where user='u1' and table_name='t2'").
+		Check(testkit.RowsWithSep(" | ", " | Update"))
+}

--- a/tests/integrationtest/r/privilege/privileges.result
+++ b/tests/integrationtest/r/privilege/privileges.result
@@ -353,6 +353,18 @@ SHOW GRANTS;
 Grants for User
 GRANT USAGE ON *.* TO 'column'@'%'
 GRANT SELECT(`a`), INSERT(`c`), UPDATE(`a`, `b`) ON `privilege__privileges`.`column_table` TO 'column'@'%'
+CREATE USER revoke_all_column_user;
+CREATE TABLE revoke_all_column_t (c1 int, c2 int);
+GRANT SELECT(c1), UPDATE(c2) ON privilege__privileges.revoke_all_column_t TO revoke_all_column_user;
+REVOKE ALL(c1) ON privilege__privileges.revoke_all_column_t FROM revoke_all_column_user;
+SELECT table_priv, column_priv FROM mysql.tables_priv WHERE user = 'revoke_all_column_user' AND host = '%' AND db = 'privilege__privileges' AND table_name = 'revoke_all_column_t';
+table_priv	column_priv
+	Update
+SELECT column_name, column_priv FROM mysql.columns_priv WHERE user = 'revoke_all_column_user' AND host = '%' AND db = 'privilege__privileges' AND table_name = 'revoke_all_column_t' ORDER BY column_name;
+column_name	column_priv
+c2	Update
+DROP USER revoke_all_column_user;
+DROP TABLE revoke_all_column_t;
 CREATE USER 'tableaccess'@'localhost';
 CREATE TABLE fieldlistt1 (a int);
 desc privilege__privileges.fieldlistt1;

--- a/tests/integrationtest/t/privilege/privileges.test
+++ b/tests/integrationtest/t/privilege/privileges.test
@@ -533,6 +533,16 @@ SHOW GRANTS;
 disconnect show_column_grants;
 connection default;
 
+# issue 67060
+CREATE USER revoke_all_column_user;
+CREATE TABLE revoke_all_column_t (c1 int, c2 int);
+GRANT SELECT(c1), UPDATE(c2) ON privilege__privileges.revoke_all_column_t TO revoke_all_column_user;
+REVOKE ALL(c1) ON privilege__privileges.revoke_all_column_t FROM revoke_all_column_user;
+SELECT table_priv, column_priv FROM mysql.tables_priv WHERE user = 'revoke_all_column_user' AND host = '%' AND db = 'privilege__privileges' AND table_name = 'revoke_all_column_t';
+SELECT column_name, column_priv FROM mysql.columns_priv WHERE user = 'revoke_all_column_user' AND host = '%' AND db = 'privilege__privileges' AND table_name = 'revoke_all_column_t' ORDER BY column_name;
+DROP USER revoke_all_column_user;
+DROP TABLE revoke_all_column_t;
+
 # TestFieldList
 CREATE USER 'tableaccess'@'localhost';
 CREATE TABLE fieldlistt1 (a int);


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67060

Problem Summary:

`REVOKE ALL(column)` can clear the aggregated column privilege state in `mysql.tables_priv` even when `mysql.columns_priv` still contains privileges for other columns on the same table. The inconsistent metadata can make later revoke operations fail with "There is no such grant defined".

### What changed and how does it work?

- Rebuild `mysql.tables_priv.Column_priv` from the remaining `mysql.columns_priv` rows when handling `REVOKE ALL(column)`.
- Use token-safe `FIND_IN_SET` when checking whether a non-`ALL` column privilege still exists.
- Add unit and integration regression tests for the remaining-column-privilege case.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Executed locally:

- `make lint`
- `/bin/zsh -lc '( enabled=0; cleanup(){ [ "${enabled}" -eq 1 ] && make failpoint-disable; }; trap cleanup EXIT INT TERM; make failpoint-enable; enabled=1; pushd pkg/executor >/dev/null; go test -run "TestRevokeColumnPriv|TestRevokeAllColumnPrivKeepsOtherColumnPrivs" -tags=intest,deadlock; rc=$?; popd >/dev/null; exit $rc )'`
- `pushd tests/integrationtest && ./run-tests.sh -r privilege/privileges && popd`

Not run locally:

- `make bazel_prepare`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where `REVOKE ALL(column)` could leave `mysql.tables_priv` inconsistent with `mysql.columns_priv`, causing later revoke operations on remaining column privileges to fail.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed privilege revocation logic to correctly preserve other column-level privileges when revoking all privileges on a specific column. The system now properly maintains column privileges on the same table during revocation operations.

* **Tests**
  * Added comprehensive test cases to verify that revoking all privileges on one column correctly preserves other column privileges on the same table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->