### PR TITLE
pkg/store/gcworker: stabilize flaky gc worker tests

### DIFF
--- a/pkg/store/gcworker/gc_worker_test.go
+++ b/pkg/store/gcworker/gc_worker_test.go
@@ -1144,7 +1144,6 @@ func TestLeaderTick(t *testing.T) {
 	require.NoError(t, err)
 	newSafePoint = s.mustGetSafePointFromPd(t)
 	require.Greater(t, newSafePoint, pdSafePoint)
-	pdSafePoint = newSafePoint
 
 	// No more signals in the channel
 	select {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43793, close #47023

Problem Summary:

`TestRunGCJob` and `TestLeaderTick` were still using old-snapshot probe reads as their stability signal. Once the local txn safe point cache caught up, those reads could fail with `[tikv:9006] GC life time is shorter than transaction duration`, even when the GC-worker behavior under test was otherwise correct.

### What changed and how does it work?

- Switch `gcProbe` to observe explicit `CmdGC` RPCs for `doGCForRegion`-style checks instead of relying on old snapshot reads after safe point changes.
- Keep `TestLeaderTick`, `TestRunGCJob`, and `TestRunGCJobAPI` focused on the behavior those paths really own today by checking PD GC safepoint advancement rather than probe snapshot visibility.
- Add regression tests that force the local txn safe point cache forward and verify `gcProbe` checks stay stable in both the `checkNotCollected` and `checkCollected` cases.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced garbage collection test infrastructure with improved invocation tracking and region-aware validation capabilities.
  * Added new tests to verify safe-point cache interactions during garbage collection operations.
  * Improved test assertions to rely on safe-point observations for more accurate validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->