### PR TITLE
ddl: resolve cherry-pick conflict for #62014

### DIFF
--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -525,7 +525,7 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 	logutil.Logger(w.ctx).Info("start a table scan task",
 		zap.Int("id", task.ID), zap.Stringer("task", task))
 
-	var idxResult IndexRecordChunk
+	var idxResults []IndexRecordChunk
 	err := wrapInBeginRollback(w.se, func(startTS uint64) error {
 		failpoint.Inject("mockScanRecordError", func() {
 			failpoint.Return(errors.New("mock scan record error"))
@@ -547,17 +547,24 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 				terror.Call(rs.Close)
 				return err
 			}
-			idxResult = IndexRecordChunk{ID: task.ID, Chunk: srcChk, Done: done}
-			if w.cpOp != nil {
-				w.cpOp.UpdateChunk(task.ID, srcChk.NumRows(), done)
-			}
-			w.totalCount.Add(int64(srcChk.NumRows()))
-			sender(idxResult)
+			idxResults = append(idxResults, IndexRecordChunk{ID: task.ID, Chunk: srcChk, Done: done})
 		}
 		return rs.Close()
 	})
+	if err != nil {
+		return err
+	}
+	for i, idxResult := range idxResults {
+		sender(idxResult)
+		rowCnt := idxResult.Chunk.NumRows()
+		if w.cpOp != nil {
+			done := i == len(idxResults)-1
+			w.cpOp.UpdateChunk(task.ID, rowCnt, done)
+		}
+		w.totalCount.Add(int64(rowCnt))
+	}
 
-	return err
+	return nil
 }
 
 func (w *tableScanWorker) getChunk() *chunk.Chunk {

--- a/pkg/ddl/index_cop.go
+++ b/pkg/ddl/index_cop.go
@@ -54,7 +54,9 @@ func wrapInBeginRollback(se *sess.Session, f func(startTS uint64) error) error {
 	}
 	startTS := txn.StartTS()
 	failpoint.InjectCall("wrapInBeginRollbackStartTS", startTS)
-	return f(startTS)
+	err = f(startTS)
+	failpoint.InjectCall("wrapInBeginRollbackAfterFn")
+	return err
 }
 
 func buildTableScan(ctx context.Context, c *copr.CopContextBase, startTS uint64, start, end kv.Key) (distsql.SelectResult, error) {

--- a/pkg/lightning/backend/local/local.go
+++ b/pkg/lightning/backend/local/local.go
@@ -1473,7 +1473,7 @@ func (local *Backend) ImportEngine(
 		zap.Float64("maxReqPerSec", maxReqPerSec),
 	)
 
-	failpoint.Inject("ReadyForImportEngine", func() {})
+	failpoint.InjectCall("ReadyForImportEngine")
 
 	err = local.doImport(ctx, e, splitKeys, regionSplitSize, regionSplitKeys)
 	if err == nil {

--- a/tests/realtikvtest/addindextest3/ingest_test.go
+++ b/tests/realtikvtest/addindextest3/ingest_test.go
@@ -454,12 +454,12 @@ func TestAddIndexDiskQuotaTS(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 
 	tk.MustExec("set @@global.tidb_enable_dist_task = 0;")
-	testAddIndexDiskQuotaTS(tk)
+	testAddIndexDiskQuotaTS(t, tk)
 	tk.MustExec("set @@global.tidb_enable_dist_task = 1;")
-	testAddIndexDiskQuotaTS(tk)
+	testAddIndexDiskQuotaTS(t, tk)
 }
 
-func testAddIndexDiskQuotaTS(tk *testkit.TestKit) {
+func testAddIndexDiskQuotaTS(t *testing.T, tk *testkit.TestKit) {
 	tk.MustExec("drop database if exists addindexlit;")
 	tk.MustExec("create database addindexlit;")
 	tk.MustExec("use addindexlit;")
@@ -473,8 +473,20 @@ func testAddIndexDiskQuotaTS(tk *testkit.TestKit) {
 
 	ingest.ForceSyncFlagForTest.Store(true)
 	tk.MustExec("alter table t add index idx_test(b);")
-	ingest.ForceSyncFlagForTest.Store(false)
 	tk.MustExec("update t set b = b + 1;")
+
+	counter := 0
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/wrapInBeginRollbackStartTS", func(uint64) {
+		counter++
+	})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/wrapInBeginRollbackAfterFn", func() {
+		counter--
+	})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/lightning/backend/local/ReadyForImportEngine", func() {
+		assert.Equal(t, counter, 0)
+	})
+	tk.MustExec("alter table t add index idx_test2(b);")
+	ingest.ForceSyncFlagForTest.Store(false)
 }
 
 func TestAddIndexAdvanceWatermarkFailed(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Backport #62014 to release-8.5. This replacement branch keeps only the intended delayed-send behavior from the upstream fix and adapts it to the older release-8.5 backfilling pipeline.

### What is changed and how it works?

- buffer `IndexRecordChunk`s per scan task in `tableScanWorker.scanRecords`
- send buffered chunks to writers only after the scan task finishes successfully
- keep release-8.5 workerpool/checkpoint/operator APIs intact instead of carrying over newer abstractions
- include the small failpoint hooks/tests needed to verify no import happens while the scan transaction is still open

### Test

- `GOTOOLCHAIN=go1.25.5 go test ./pkg/ddl -run TestNonExistent -count=0`
- `GOTOOLCHAIN=go1.25.5 go test ./pkg/lightning/backend/local -run TestNonExistent -count=0`
- `GOTOOLCHAIN=go1.25.5 go test ./tests/realtikvtest/addindextest3 -run TestAddIndexDiskQuotaTS -count=1` *(fails in this environment because no PD is listening on `127.0.0.1:2379`)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized checkpoint updates to process in batches instead of per-chunk
  * Restructured chunk collection and emission patterns for improved efficiency

* **Bug Fixes**
  * Enhanced error handling and explicit propagation in index operations

* **Tests**
  * Expanded verification for index ingestion scenarios with additional monitoring hooks and assertions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->