### PR TITLE
*: revert bump client to latest | tidb-test=release-8.5-20260121-v8.5.5 pd=release-8.5-20260121-v8.5.5

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -6898,26 +6898,26 @@ def go_deps():
         patches = [
             "//build/patches:com_github_tikv_client_go_v2.patch",
         ],
-        sha256 = "7dfbbcc48d3315c2a86c7e17f7afc8f00a72ba251c658cd416f2d18e3b5f2a55",
-        strip_prefix = "github.com/tikv/client-go/v2@v2.0.8-0.20260213124824-70d01fdd40a8",
+        sha256 = "35eced5142baa3cbb065e0e370e4cf5f81b32f9f1395fbc79e1043af814ea5b8",
+        strip_prefix = "github.com/tikv/client-go/v2@v2.0.8-0.20260209035304-621e353d128b",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260213124824-70d01fdd40a8.zip",
-            "http://ats.apps.svc/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260213124824-70d01fdd40a8.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260213124824-70d01fdd40a8.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260213124824-70d01fdd40a8.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260209035304-621e353d128b.zip",
+            "http://ats.apps.svc/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260209035304-621e353d128b.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260209035304-621e353d128b.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260209035304-621e353d128b.zip",
         ],
     )
     go_repository(
         name = "com_github_tikv_pd_client",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/pd/client",
-        sha256 = "516ae754ef5269c413a7e1d63a7665251e19fc4c00c66a7e9ce532ec9136a0d9",
-        strip_prefix = "github.com/tikv/pd/client@v0.0.0-20260130064140-38b7a823c76d",
+        sha256 = "b89c6017c0e766b00e8524c6dbb8aee2247364f1f6739a470ee77039b0db7d4e",
+        strip_prefix = "github.com/tikv/pd/client@v0.0.0-20251219084741-029eb6e7d5d0",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260130064140-38b7a823c76d.zip",
-            "http://ats.apps.svc/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260130064140-38b7a823c76d.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260130064140-38b7a823c76d.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260130064140-38b7a823c76d.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20251219084741-029eb6e7d5d0.zip",
+            "http://ats.apps.svc/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20251219084741-029eb6e7d5d0.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20251219084741-029eb6e7d5d0.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20251219084741-029eb6e7d5d0.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -110,8 +110,8 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/tdakkota/asciicheck v0.2.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.8-0.20260213124824-70d01fdd40a8
-	github.com/tikv/pd/client v0.0.0-20260130064140-38b7a823c76d
+	github.com/tikv/client-go/v2 v2.0.8-0.20260209035304-621e353d128b
+	github.com/tikv/pd/client v0.0.0-20251219084741-029eb6e7d5d0
 	github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a
 	github.com/twmb/murmur3 v1.1.6
 	github.com/uber/jaeger-client-go v2.22.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -760,10 +760,10 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJf
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW93SG+q0F8KI+yFrcIDT4c/RNoc4=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
-github.com/tikv/client-go/v2 v2.0.8-0.20260213124824-70d01fdd40a8 h1:FPENa3v6ZyyNY7ppDSG/7MrerLOTEiubLui4yr+LCRY=
-github.com/tikv/client-go/v2 v2.0.8-0.20260213124824-70d01fdd40a8/go.mod h1:IaLDNrPv/UtpTZPEeLnXlt+3tkEarTk6YHq8xY+0kJA=
-github.com/tikv/pd/client v0.0.0-20260130064140-38b7a823c76d h1:FeP05UtWzZsXYTsxpgHZNxiYiw0FoxFGY/ioOzOqrPA=
-github.com/tikv/pd/client v0.0.0-20260130064140-38b7a823c76d/go.mod h1:X3T+jK+4bLbDKgupmzvVXuySnCNV4Lfdm/bL8TAw3ik=
+github.com/tikv/client-go/v2 v2.0.8-0.20260209035304-621e353d128b h1:MV+bMPuL/WSFRVA6ES5p7qBk5rBUJXVMhEzSRaS8a+A=
+github.com/tikv/client-go/v2 v2.0.8-0.20260209035304-621e353d128b/go.mod h1:QTFGkElz5Rp7+poaUZqusJceL8ZjSFu/xMDUGhuScUg=
+github.com/tikv/pd/client v0.0.0-20251219084741-029eb6e7d5d0 h1:fguMZ4sSn/oLbUt+zDoNPd6+OE3Li4Rop2/3vFhu8lM=
+github.com/tikv/pd/client v0.0.0-20251219084741-029eb6e7d5d0/go.mod h1:X3T+jK+4bLbDKgupmzvVXuySnCNV4Lfdm/bL8TAw3ik=
 github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a h1:A6uKudFIfAEpoPdaal3aSqGxBzLyU8TqyXImLwo6dIo=
 github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a/go.mod h1:mkjARE7Yr8qU23YcGMSALbIxTQ9r9QBVahQOBRfU460=
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=


### PR DESCRIPTION
Reverts pingcap/tidb#66263

ref: https://github.com/tikv/pd/pull/10340, pd client doesn't bump

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66970

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to latest versions.

* **Bug Fixes**
  * Fixed region bucket metadata tracking to ensure accurate version information is maintained during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->