### PR TITLE
planner/core: disable new join reorder when DP is enabled

### DIFF
--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -289,6 +289,8 @@ type joinTypeWithExtMsg struct {
 // Optimize implements the base.LogicalOptRule.<0th> interface.
 func (s *JoinReOrderSolver) Optimize(_ context.Context, p base.LogicalPlan) (base.LogicalPlan, bool, error) {
 	if p.SCtx().GetSessionVars().TiDBOptEnableAdvancedJoinReorder && p.SCtx().GetSessionVars().TiDBOptJoinReorderThreshold <= 0 {
+		// The new join reorder implementation doesn't support DP for now,
+		// So disable new impl when TiDBOptJoinReorderThreshold is greater 0.
 		p, err := joinorder.Optimize(p)
 		return p, false, err
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67073

Problem Summary: 
The original join order of tpch q9 is like: `((nation supplier) (part lineitem)) partsupp orders`, which is generated by DP.

After https://github.com/pingcap/tidb/pull/66349, the join order became: `(((nation suppolier) lineitem) part) partsupp orders`, because https://github.com/pingcap/tidb/pull/66349 enable the new join reorder impl by default, which only support greedy algorithm for now. And the development of DP in the new join reorder impl is still undergoing.

But in our benchbot env, DP is used explicitly by setting `tidb_opt_join_reorder_threshold` as 60(DP is disabled by default, you have to set this variable greater than zero then you can use DP), so we have to respect that value for now. And after DP is supported in the new join reorder impl, I'll revert this pr.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

setup tidb cluster with 2 tiflash with tpch-50G dataset.

before this pr: `(nation supplier) lineitem part`
```
mysql> explain select     nation,     o_year,     sum(amount) as sum_profit from     (         select             n_name as nation,             extract(year from o_orderdate) as o_year,             l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount         from             part,             supplier,             lineitem,             partsupp,             orders,             nation         where             s_suppkey = l_suppkey             and ps_suppkey = l_suppkey             and ps_partkey = l_partkey
      and p_partkey = l_partkey             and o_orderkey = l_orderkey             and s_nationkey = n_nationkey             and p_name like '%dim%'     ) as profit group by     nation,     o_year order by     nation,     o_year desc;
+--------------------------------------------------------------------------------------------+--------------+--------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id                                                                                         | estRows      | task         | access object  | operator info                                                                                                                                                                                                                          |
+--------------------------------------------------------------------------------------------+--------------+--------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Sort_27                                                                                    | 2406.00      | root         |                | test.nation.n_name, Column#57:desc                                                                                                                                                                                                     |
| └─TableReader_344                                                                          | 2406.00      | root         |                | MppVersion: 3, data:ExchangeSender_343                                                                                                                                                                                                 |
|   └─ExchangeSender_343                                                                     | 2406.00      | mpp[tiflash] |                | ExchangeType: PassThrough                                                                                                                                                                                                              |
|     └─Projection_30                                                                        | 2406.00      | mpp[tiflash] |                | test.nation.n_name, Column#57, Column#59                                                                                                                                                                                               |
|       └─Projection_339                                                                     | 2406.00      | mpp[tiflash] |                | Column#59, test.nation.n_name, Column#57                                                                                                                                                                                               |
|         └─HashAgg_340                                                                      | 2406.00      | mpp[tiflash] |                | group by:Column#70, test.nation.n_name, funcs:sum(Column#71)->Column#59, funcs:firstrow(test.nation.n_name)->test.nation.n_name, funcs:firstrow(Column#70)->Column#57, stream_count: 72                                                |
|           └─ExchangeReceiver_342                                                           | 2406.00      | mpp[tiflash] |                | stream_count: 72                                                                                                                                                                                                                       |
|             └─ExchangeSender_341                                                           | 2406.00      | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.nation.n_name, collate: utf8mb4_bin], stream_count: 72                                                                                                          |
|               └─HashAgg_337                                                                | 2406.00      | mpp[tiflash] |                | group by:Column#75, Column#76, funcs:sum(Column#74)->Column#71                                                                                                                                                                         |
|                 └─Projection_347                                                           | 247796839.16 | mpp[tiflash] |                | minus(mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount)), mul(test.partsupp.ps_supplycost, test.lineitem.l_quantity))->Column#74, test.nation.n_name->Column#75, extract(YEAR, test.orders.o_orderdate)->Column#76 |
|                   └─Projection_326                                                         | 247796839.16 | mpp[tiflash] |                | test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.partsupp.ps_supplycost, test.orders.o_orderdate, test.nation.n_name                                                                            |
|                     └─Projection_316                                                       | 247796839.16 | mpp[tiflash] |                | test.nation.n_name, test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.partsupp.ps_supplycost, test.orders.o_orderdate, test.lineitem.l_orderkey                                                  |
|                       └─HashJoin_315                                                       | 247796839.16 | mpp[tiflash] |                | inner join, equal:[eq(test.lineitem.l_orderkey, test.orders.o_orderkey)], stream_count: 72                                                                                                                                             |
|                         ├─ExchangeReceiver_88(Build)                                       | 75000000.00  | mpp[tiflash] |                | stream_count: 72                                                                                                                                                                                                                       |
|                         │ └─ExchangeSender_87                                              | 75000000.00  | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.orders.o_orderkey, collate: binary], stream_count: 72                                                                                                           |
|                         │   └─TableFullScan_86                                             | 75000000.00  | mpp[tiflash] | table:orders   | keep order:false                                                                                                                                                                                                                       |
|                         └─ExchangeReceiver_85(Probe)                                       | 244189657.27 | mpp[tiflash] |                |                                                                                                                                                                                                                                        |
|                           └─ExchangeSender_84                                              | 244189657.27 | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_orderkey, collate: binary]                                                                                                                           |
|                             └─Projection_83                                                | 244189657.27 | mpp[tiflash] |                | test.nation.n_name, test.lineitem.l_orderkey, test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.partsupp.ps_supplycost, test.lineitem.l_suppkey, test.lineitem.l_partkey                         |
|                               └─HashJoin_56                                                | 244189657.27 | mpp[tiflash] |                | inner join, equal:[eq(test.lineitem.l_suppkey, test.partsupp.ps_suppkey) eq(test.lineitem.l_partkey, test.partsupp.ps_partkey)], stream_count: 72                                                                                      |
|                                 ├─ExchangeReceiver_80(Build)                               | 40000000.00  | mpp[tiflash] |                | stream_count: 72                                                                                                                                                                                                                       |
|                                 │ └─ExchangeSender_79                                      | 40000000.00  | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.partsupp.ps_suppkey, collate: binary], [name: test.partsupp.ps_partkey, collate: binary], stream_count: 72                                                      |
|                                 │   └─TableFullScan_78                                     | 40000000.00  | mpp[tiflash] | table:partsupp | keep order:false                                                                                                                                                                                                                       |
|                                 └─ExchangeReceiver_82(Probe)                               | 241498491.89 | mpp[tiflash] |                |                                                                                                                                                                                                                                        |
|                                   └─ExchangeSender_81                                      | 241498491.89 | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_suppkey, collate: binary], [name: test.lineitem.l_partkey, collate: binary]                                                                          |
|                                     └─Projection_77                                        | 241498491.89 | mpp[tiflash] |                | test.nation.n_name, test.lineitem.l_orderkey, test.lineitem.l_partkey, test.lineitem.l_suppkey, test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount                                                      |
|                                       └─HashJoin_57                                        | 241498491.89 | mpp[tiflash] |                | inner join, equal:[eq(test.lineitem.l_partkey, test.part.p_partkey)], stream_count: 72                                                                                                                                                 |
|                                         ├─ExchangeReceiver_76(Build)                       | 8000000.00   | mpp[tiflash] |                | stream_count: 72                                                                                                                                                                                                                       |
|                                         │ └─ExchangeSender_75                              | 8000000.00   | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.part.p_partkey, collate: binary], stream_count: 72                                                                                                              |
|                                         │   └─Selection_74                                 | 8000000.00   | mpp[tiflash] |                | like(test.part.p_name, "%dim%", 92)                                                                                                                                                                                                    |
|                                         │     └─TableFullScan_73                           | 10000000.00  | mpp[tiflash] | table:part     | keep order:false                                                                                                                                                                                                                       |
|                                         └─ExchangeReceiver_72(Probe)                       | 300833705.36 | mpp[tiflash] |                |                                                                                                                                                                                                                                        |
|                                           └─ExchangeSender_71                              | 300833705.36 | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_partkey, collate: binary]                                                                                                                            |
|                                             └─Projection_70                                | 300833705.36 | mpp[tiflash] |                | test.nation.n_name, test.lineitem.l_orderkey, test.lineitem.l_partkey, test.lineitem.l_suppkey, test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount                                                      |
|                                               └─HashJoin_58                                | 300833705.36 | mpp[tiflash] |                | inner join, equal:[eq(test.supplier.s_suppkey, test.lineitem.l_suppkey)], stream_count: 72                                                                                                                                             |
|                                                 ├─ExchangeReceiver_66(Build)               | 500000.00    | mpp[tiflash] |                | stream_count: 72                                                                                                                                                                                                                       |
|                                                 │ └─ExchangeSender_65                      | 500000.00    | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.supplier.s_suppkey, collate: binary], stream_count: 72                                                                                                          |
|                                                 │   └─Projection_64                        | 500000.00    | mpp[tiflash] |                | test.nation.n_name, test.supplier.s_suppkey                                                                                                                                                                                            |
|                                                 │     └─HashJoin_59                        | 500000.00    | mpp[tiflash] |                | inner join, equal:[eq(test.nation.n_nationkey, test.supplier.s_nationkey)]                                                                                                                                                             |
|                                                 │       ├─ExchangeReceiver_62(Build)       | 25.00        | mpp[tiflash] |                |                                                                                                                                                                                                                                        |
|                                                 │       │ └─ExchangeSender_61              | 25.00        | mpp[tiflash] |                | ExchangeType: Broadcast, Compression: FAST                                                                                                                                                                                             |
|                                                 │       │   └─TableFullScan_60             | 25.00        | mpp[tiflash] | table:nation   | keep order:false                                                                                                                                                                                                                       |
|                                                 │       └─TableFullScan_63(Probe)          | 500000.00    | mpp[tiflash] | table:supplier | keep order:false                                                                                                                                                                                                                       |
|                                                 └─ExchangeReceiver_69(Probe)               | 300005811.00 | mpp[tiflash] |                |                                                                                                                                                                                                                                        |
|                                                   └─ExchangeSender_68                      | 300005811.00 | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_suppkey, collate: binary]                                                                                                                            |
|                                                     └─TableFullScan_67                     | 300005811.00 | mpp[tiflash] | table:lineitem | keep order:false                                                                                                                                                                                                                       |
+--------------------------------------------------------------------------------------------+--------------+--------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
46 rows in set (0.01 sec)
```

this pr(setting `tidb_opt_join_reorder_threshold` as 64): `(nation supplier) (part lineitem)`
```
mysql> set session tidb_opt_join_reorder_threshold = 64;
Query OK, 0 rows affected, 1 warning (0.00 sec)

mysql> explain select     nation,     o_year,     sum(amount) as sum_profit from     (         select             n_name as nation,             extract(year from o_orderdate) as o_year,             l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount         from             part,             supplier,             lineitem,             partsupp,
  orders,             nation         where             s_suppkey = l_suppkey             and ps_suppkey = l_suppkey             and ps_partkey = l_partkey             and p_partkey = l_partkey             and o_orderkey = l_orderkey             and s_nationkey = n_nationkey             and p_name like '%dim%'     ) as profit group by     nation,     o_year order by     nation,     o_year desc;
+-------------------------------------------------------------------------------------+--------------+--------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id                                                                                  | estRows      | task         | access object  | operator info                                                                                                                                                                                                                          |
+-------------------------------------------------------------------------------------+--------------+--------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Sort_79                                                                             | 2406.00      | root         |                | test.nation.n_name, Column#57:desc                                                                                                                                                                                                     |
| └─TableReader_388                                                                   | 2406.00      | root         |                | MppVersion: 3, data:ExchangeSender_387                                                                                                                                                                                                 |
|   └─ExchangeSender_387                                                              | 2406.00      | mpp[tiflash] |                | ExchangeType: PassThrough                                                                                                                                                                                                              |
|     └─Projection_82                                                                 | 2406.00      | mpp[tiflash] |                | test.nation.n_name, Column#57, Column#59                                                                                                                                                                                               |
|       └─Projection_383                                                              | 2406.00      | mpp[tiflash] |                | Column#59, test.nation.n_name, Column#57                                                                                                                                                                                               |
|         └─HashAgg_384                                                               | 2406.00      | mpp[tiflash] |                | group by:Column#70, test.nation.n_name, funcs:sum(Column#71)->Column#59, funcs:firstrow(test.nation.n_name)->test.nation.n_name, funcs:firstrow(Column#70)->Column#57, stream_count: 72                                                |
|           └─ExchangeReceiver_386                                                    | 2406.00      | mpp[tiflash] |                | stream_count: 72                                                                                                                                                                                                                       |
|             └─ExchangeSender_385                                                    | 2406.00      | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.nation.n_name, collate: utf8mb4_bin], stream_count: 72                                                                                                          |
|               └─HashAgg_381                                                         | 2406.00      | mpp[tiflash] |                | group by:Column#75, Column#76, funcs:sum(Column#74)->Column#71                                                                                                                                                                         |
|                 └─Projection_391                                                    | 247796839.16 | mpp[tiflash] |                | minus(mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount)), mul(test.partsupp.ps_supplycost, test.lineitem.l_quantity))->Column#74, test.nation.n_name->Column#75, extract(YEAR, test.orders.o_orderdate)->Column#76 |
|                   └─Projection_370                                                  | 247796839.16 | mpp[tiflash] |                | test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.partsupp.ps_supplycost, test.orders.o_orderdate, test.nation.n_name                                                                            |
|                     └─Projection_360                                                | 247796839.16 | mpp[tiflash] |                | test.orders.o_orderdate, test.partsupp.ps_supplycost, test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.nation.n_name, test.lineitem.l_orderkey                                                  |
|                       └─HashJoin_359                                                | 247796839.16 | mpp[tiflash] |                | inner join, equal:[eq(test.orders.o_orderkey, test.lineitem.l_orderkey)], stream_count: 72                                                                                                                                             |
|                         ├─ExchangeReceiver_110(Build)                               | 75000000.00  | mpp[tiflash] |                | stream_count: 72                                                                                                                                                                                                                       |
|                         │ └─ExchangeSender_109                                      | 75000000.00  | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.orders.o_orderkey, collate: binary], stream_count: 72                                                                                                           |
|                         │   └─TableFullScan_108                                     | 75000000.00  | mpp[tiflash] | table:orders   | keep order:false                                                                                                                                                                                                                       |
|                         └─ExchangeReceiver_140(Probe)                               | 244189657.27 | mpp[tiflash] |                |                                                                                                                                                                                                                                        |
|                           └─ExchangeSender_139                                      | 244189657.27 | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_orderkey, collate: binary]                                                                                                                           |
|                             └─Projection_138                                        | 244189657.27 | mpp[tiflash] |                | test.partsupp.ps_supplycost, test.lineitem.l_orderkey, test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.nation.n_name, test.lineitem.l_suppkey, test.lineitem.l_partkey                         |
|                               └─HashJoin_111                                        | 244189657.27 | mpp[tiflash] |                | inner join, equal:[eq(test.partsupp.ps_suppkey, test.lineitem.l_suppkey) eq(test.partsupp.ps_partkey, test.lineitem.l_partkey)], stream_count: 72                                                                                      |
|                                 ├─ExchangeReceiver_114(Build)                       | 40000000.00  | mpp[tiflash] |                | stream_count: 72                                                                                                                                                                                                                       |
|                                 │ └─ExchangeSender_113                              | 40000000.00  | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.partsupp.ps_suppkey, collate: binary], [name: test.partsupp.ps_partkey, collate: binary], stream_count: 72                                                      |
|                                 │   └─TableFullScan_112                             | 40000000.00  | mpp[tiflash] | table:partsupp | keep order:false                                                                                                                                                                                                                       |
|                                 └─ExchangeReceiver_137(Probe)                       | 241498491.89 | mpp[tiflash] |                |                                                                                                                                                                                                                                        |
|                                   └─ExchangeSender_136                              | 241498491.89 | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_suppkey, collate: binary], [name: test.lineitem.l_partkey, collate: binary]                                                                          |
|                                     └─Projection_135                                | 241498491.89 | mpp[tiflash] |                | test.lineitem.l_orderkey, test.lineitem.l_partkey, test.lineitem.l_suppkey, test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.nation.n_name                                                      |
|                                       └─HashJoin_115                                | 241498491.89 | mpp[tiflash] |                | inner join, equal:[eq(test.lineitem.l_suppkey, test.supplier.s_suppkey)], stream_count: 72                                                                                                                                             |
|                                         ├─ExchangeReceiver_134(Build)               | 500000.00    | mpp[tiflash] |                | stream_count: 72                                                                                                                                                                                                                       |
|                                         │ └─ExchangeSender_133                      | 500000.00    | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.supplier.s_suppkey, collate: binary], stream_count: 72                                                                                                          |
|                                         │   └─Projection_132                        | 500000.00    | mpp[tiflash] |                | test.supplier.s_suppkey, test.nation.n_name                                                                                                                                                                                            |
|                                         │     └─HashJoin_127                        | 500000.00    | mpp[tiflash] |                | inner join, equal:[eq(test.supplier.s_nationkey, test.nation.n_nationkey)]                                                                                                                                                             |
|                                         │       ├─ExchangeReceiver_131(Build)       | 25.00        | mpp[tiflash] |                |                                                                                                                                                                                                                                        |
|                                         │       │ └─ExchangeSender_130              | 25.00        | mpp[tiflash] |                | ExchangeType: Broadcast, Compression: FAST                                                                                                                                                                                             |
|                                         │       │   └─TableFullScan_129             | 25.00        | mpp[tiflash] | table:nation   | keep order:false                                                                                                                                                                                                                       |
|                                         │       └─TableFullScan_128(Probe)          | 500000.00    | mpp[tiflash] | table:supplier | keep order:false                                                                                                                                                                                                                       |
|                                         └─ExchangeReceiver_126(Probe)               | 240833888.04 | mpp[tiflash] |                |                                                                                                                                                                                                                                        |
|                                           └─ExchangeSender_125                      | 240833888.04 | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_suppkey, collate: binary]                                                                                                                            |
|                                             └─Projection_124                        | 240833888.04 | mpp[tiflash] |                | test.lineitem.l_orderkey, test.lineitem.l_partkey, test.lineitem.l_suppkey, test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount                                                                          |
|                                               └─HashJoin_116                        | 240833888.04 | mpp[tiflash] |                | inner join, equal:[eq(test.part.p_partkey, test.lineitem.l_partkey)], stream_count: 72                                                                                                                                                 |
|                                                 ├─ExchangeReceiver_120(Build)       | 8000000.00   | mpp[tiflash] |                | stream_count: 72                                                                                                                                                                                                                       |
|                                                 │ └─ExchangeSender_119              | 8000000.00   | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.part.p_partkey, collate: binary], stream_count: 72                                                                                                              |
|                                                 │   └─Selection_118                 | 8000000.00   | mpp[tiflash] |                | like(test.part.p_name, "%dim%", 92)                                                                                                                                                                                                    |
|                                                 │     └─TableFullScan_117           | 10000000.00  | mpp[tiflash] | table:part     | keep order:false                                                                                                                                                                                                                       |
|                                                 └─ExchangeReceiver_123(Probe)       | 300005811.00 | mpp[tiflash] |                |                                                                                                                                                                                                                                        |
|                                                   └─ExchangeSender_122              | 300005811.00 | mpp[tiflash] |                | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_partkey, collate: binary]                                                                                                                            |
|                                                     └─TableFullScan_121             | 300005811.00 | mpp[tiflash] | table:lineitem | keep order:false                                                                                                                                                                                                                       |
+-------------------------------------------------------------------------------------+--------------+--------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
46 rows in set (0.03 sec)

```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Refined join query optimization: the optimizer now checks an additional threshold before using the advanced join-reorder path and otherwise falls back to the recursive optimizer, giving more predictable and controllable query planning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->