### PR TITLE
ddl/ingest: flush engines in registration order

### DIFF
--- a/pkg/ddl/ingest/backend.go
+++ b/pkg/ddl/ingest/backend.go
@@ -95,10 +95,11 @@ type CheckpointOperator interface {
 
 // litBackendCtx implements BackendCtx.
 type litBackendCtx struct {
-	engines map[int64]*engineInfo
-	memRoot MemRoot
-	jobID   int64
-	tbl     table.Table
+	engines        map[int64]*engineInfo
+	orderedEngines []*engineInfo
+	memRoot        MemRoot
+	jobID          int64
+	tbl            table.Table
 	// litBackendCtx doesn't manage the lifecycle of backend, caller should do it.
 	backend *local.Backend
 	ctx     context.Context
@@ -228,7 +229,7 @@ func (bc *litBackendCtx) Ingest(ctx context.Context) error {
 }
 
 func (bc *litBackendCtx) flushEngines(ctx context.Context) error {
-	for _, ei := range bc.engines {
+	for _, ei := range bc.orderedEngines {
 		ei.flushLock.Lock()
 		if err := ei.Flush(); err != nil {
 			logutil.Logger(ctx).Error("flush error", zap.Error(err))

--- a/pkg/ddl/ingest/backend_mgr.go
+++ b/pkg/ddl/ingest/backend_mgr.go
@@ -260,6 +260,7 @@ func newBackendContext(
 ) *litBackendCtx {
 	bCtx := &litBackendCtx{
 		engines:        make(map[int64]*engineInfo, 10),
+		orderedEngines: make([]*engineInfo, 0, 10),
 		memRoot:        memRoot,
 		jobID:          jobID,
 		backend:        be,

--- a/pkg/ddl/ingest/engine_mgr.go
+++ b/pkg/ddl/ingest/engine_mgr.go
@@ -88,6 +88,7 @@ func (bc *litBackendCtx) Register(indexIDs []int64, uniques []bool, tbl table.Ta
 		ei := openedEngines[indexID]
 		ret = append(ret, ei)
 		bc.engines[indexID] = ei
+		bc.orderedEngines = append(bc.orderedEngines, ei)
 	}
 	bc.tbl = tbl
 
@@ -137,6 +138,7 @@ func (bc *litBackendCtx) FinishAndUnregisterEngines(opt UnregisterOpt) error {
 	}
 
 	bc.engines = make(map[int64]*engineInfo, 10)
+	bc.orderedEngines = bc.orderedEngines[:0]
 
 	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67083

Problem Summary:

When local ingest adds multiple indexes in one DDL job, `writeChunk()` acquires per-index `RLock`s in index order, while `flushEngines()` acquires `Lock`s by iterating `bc.engines`. Because `bc.engines` is a map, flush can take the same locks in a different order and deadlock with writers.

### What changed and how does it work?

This change stores engines in registration order and uses that stable order in `flushEngines()`.

`Register()` already receives `indexIDs` in the same order used to build the ingest writers, so flushing now acquires `flushLock`s in the same global order as `writeChunk()`. This removes the AB-BA lock inversion without changing the other engine loops.

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Manual test steps:
1. Reproduced the lock ordering problem locally by running writer-side `RLock` acquisition in index order and flush-side `Lock` acquisition in the reverse order on the same set of index engines.
2. Verified that with this change `flushEngines()` acquires locks in registration order, which matches the writer order and removes the deadlock condition.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a possible deadlock in local ingest when adding multiple indexes in one DDL job.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in the ordering of engine operations during data ingestion to ensure deterministic execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->