### PR TITLE
expression: enable SHA2 function pushdown to TiKV

### DIFF
--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -241,7 +241,7 @@ func scalarExprSupportedByTiKV(ctx EvalContext, sf *ScalarFunction) bool {
 		ast.Sysdate, /* ast.StrToDate, */
 
 		// encryption functions.
-		ast.MD5, ast.SHA1, ast.UncompressedLength,
+		ast.MD5, ast.SHA1, ast.SHA2, ast.UncompressedLength,
 
 		ast.Cast,
 

--- a/tests/integrationtest/r/planner/core/casetest/pushdown/push_down.result
+++ b/tests/integrationtest/r/planner/core/casetest/pushdown/push_down.result
@@ -123,10 +123,10 @@ id	task	access object	operator info
 Projection	root		md5(planner__core__casetest__pushdown__push_down.t.s)->Column
 └─TableReader	root		data:TableFullScan
   └─TableFullScan	cop[tikv]	table:t	keep order:false, stats:pseudo
-explain format = 'plan_tree' select sha2(s, 256) from t;
+explain format = 'plan_tree' select * from t where sha2(s, 256) = 'abc';
 id	task	access object	operator info
-Projection	root		sha2(planner__core__casetest__pushdown__push_down.t.s, 256)->Column
-└─TableReader	root		data:TableFullScan
+TableReader	root		data:Selection
+└─Selection	cop[tikv]		eq(sha2(planner__core__casetest__pushdown__push_down.t.s, 256), "abc")
   └─TableFullScan	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'plan_tree' select c from t where a+1=3;
 id	task	access object	operator info

--- a/tests/integrationtest/r/planner/core/casetest/pushdown/push_down.result
+++ b/tests/integrationtest/r/planner/core/casetest/pushdown/push_down.result
@@ -123,6 +123,11 @@ id	task	access object	operator info
 Projection	root		md5(planner__core__casetest__pushdown__push_down.t.s)->Column
 └─TableReader	root		data:TableFullScan
   └─TableFullScan	cop[tikv]	table:t	keep order:false, stats:pseudo
+explain format = 'plan_tree' select sha2(s, 256) from t;
+id	task	access object	operator info
+Projection	root		sha2(planner__core__casetest__pushdown__push_down.t.s, 256)->Column
+└─TableReader	root		data:TableFullScan
+  └─TableFullScan	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'plan_tree' select c from t where a+1=3;
 id	task	access object	operator info
 Projection	root		planner__core__casetest__pushdown__push_down.t.c

--- a/tests/integrationtest/t/planner/core/casetest/pushdown/push_down.test
+++ b/tests/integrationtest/t/planner/core/casetest/pushdown/push_down.test
@@ -35,7 +35,7 @@ explain format = 'plan_tree' select json_unquote(a) from t2;
 explain format = 'plan_tree' select i * 2 from t;
 explain format = 'plan_tree' select DATE_FORMAT(t, '%Y-%m-%d %H') as date from t;
 explain format = 'plan_tree' select md5(s) from t;
-explain format = 'plan_tree' select sha2(s, 256) from t;
+explain format = 'plan_tree' select * from t where sha2(s, 256) = 'abc';
 explain format = 'plan_tree' select c from t where a+1=3;
 explain format = 'plan_tree' select /*+ hash_agg()*/ count(b) from  (select id + 1 as b from t)A;
 explain format = 'plan_tree' select /*+ hash_agg()*/ count(*) from  (select id + 1 as b from t)A;

--- a/tests/integrationtest/t/planner/core/casetest/pushdown/push_down.test
+++ b/tests/integrationtest/t/planner/core/casetest/pushdown/push_down.test
@@ -35,6 +35,7 @@ explain format = 'plan_tree' select json_unquote(a) from t2;
 explain format = 'plan_tree' select i * 2 from t;
 explain format = 'plan_tree' select DATE_FORMAT(t, '%Y-%m-%d %H') as date from t;
 explain format = 'plan_tree' select md5(s) from t;
+explain format = 'plan_tree' select sha2(s, 256) from t;
 explain format = 'plan_tree' select c from t where a+1=3;
 explain format = 'plan_tree' select /*+ hash_agg()*/ count(b) from  (select id + 1 as b from t)A;
 explain format = 'plan_tree' select /*+ hash_agg()*/ count(*) from  (select id + 1 as b from t)A;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67087

Problem Summary: The `SHA2` function is not pushed down to TiKV for coprocessor evaluation, even though TiKV already implements it. This causes unnecessary data transfer when SHA2 is used in WHERE clauses.

Related: https://github.com/pingcap/tidb-tools/pull/886 (from customer)

### What changed and how does it work?

Added `ast.SHA2` to the `scalarExprSupportedByTiKV` allowlist in `pkg/expression/infer_pushdown.go`, alongside the already-supported `MD5` and `SHA1`.

All infrastructure was already in place:
- TiKV: `SHA2` implemented in `components/tidb_query_expr/src/impl_encryption.rs` (SHA-0/224/256/384/512)
- tipb: `ScalarFuncSig_SHA2` defined in protobuf
- TiDB: PbCode mapping (`builtin_encryption.go`) and distsql deserialization (`distsql_builtin.go`) already existed

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
  > Verified with tiup playground (PD + TiKV + two TiDB instances: stock vs modified) that:
  > - EXPLAIN shows `Selection` moves from `root` to `cop[tikv]` after the change
  > - All hash lengths (0/224/256/384/512) produce identical results
  > - All column types (varchar, char, text, blob, binary, int, bigint, double, decimal, datetime, date, time, bit, enum, set) produce identical results
  > - NULL handling and invalid hash length (123) produce identical results
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
The `SHA2` function can now be pushed down to TiKV for coprocessor evaluation, improving performance for queries that use `SHA2` in `WHERE` clauses.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SHA2 hashing is now eligible for push-down execution to TiKV, improving query performance for SHA-2–based predicates.

* **Tests**
  * Updated and added integration tests to cover SHA2 query planning and plan_tree expectations for pushed-down execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->