### PR TITLE
ddl: fix ALTER TABLE NOCACHE not removing record from mysql.table_cache_meta

### DIFF
--- a/pkg/ddl/db_cache_test.go
+++ b/pkg/ddl/db_cache_test.go
@@ -111,6 +111,43 @@ func TestAlterTableCache(t *testing.T) {
 	checkTableCacheStatus(t, tk, "test", "t3", model.TableCacheStatusDisable)
 }
 
+// TestAlterTableNoCacheRemovesTableCacheMeta verifies that ALTER TABLE NOCACHE
+// removes the record from mysql.table_cache_meta (fix for issue #66042).
+func TestAlterTableNoCacheRemovesTableCacheMeta(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	dom.SetStatsUpdating(true)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists cache_test")
+	defer tk.MustExec("drop table if exists cache_test")
+
+	tk.MustExec("create table cache_test (id int primary key)")
+	tk.MustExec("alter table cache_test cache")
+
+	// Get table ID from information_schema
+	idRows := tk.MustQuery("select TIDB_TABLE_ID from information_schema.tables where TABLE_SCHEMA = database() and TABLE_NAME = 'cache_test'").Rows()
+	require.Len(t, idRows, 1, "table should exist")
+	tableID := idRows[0][0].(string)
+
+	// SELECT triggers READ lock (as in issue #66042)
+	tk.MustQuery("select * from cache_test")
+
+	// Record should exist in mysql.table_cache_meta with expected columns
+	rows := tk.MustQuery("select tid, lock_type, lease, oldReadLease from mysql.table_cache_meta where tid = ?", tableID).Rows()
+	require.Len(t, rows, 1, "record should exist before NOCACHE")
+	require.Equal(t, tableID, rows[0][0], "tid should match")
+	require.Contains(t, []string{"NONE", "READ"}, rows[0][1], "lock_type should be NONE or READ after SELECT")
+
+	// ALTER TABLE NOCACHE should remove the record
+	tk.MustExec("alter table cache_test nocache")
+
+	// Record should be deleted from mysql.table_cache_meta
+	rows = tk.MustQuery("select tid, lock_type, lease, oldReadLease from mysql.table_cache_meta where tid = ?", tableID).Rows()
+	require.Len(t, rows, 0, "record should be deleted after NOCACHE")
+	checkTableCacheStatus(t, tk, "test", "cache_test", model.TableCacheStatusDisable)
+}
+
 func TestCacheTableSizeLimit(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -425,6 +425,14 @@ func (w *worker) finishDDLJob(jobCtx *jobContext, job *model.Job) (err error) {
 			// delete its arguments
 			job.ClearDecodedArgs()
 		}
+	case model.ActionAlterNoCacheTable:
+		if !job.IsCancelled() {
+			ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL)
+			_, err = w.sess.Execute(ctx, fmt.Sprintf("delete from mysql.table_cache_meta where tid = %d", job.TableID), "alter_table_nocache_cleanup")
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
 	}
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66042

Problem Summary:

When executing `ALTER TABLE t NOCACHE`, TiDB correctly updates the table's `TableCacheStatusType` to `Disable`, but does not delete the corresponding row from `mysql.table_cache_meta`. As a result, after `ALTER TABLE NOCACHE`, the stale record remains in `mysql.table_cache_meta` (with `lock_type = READ` if a `SELECT` was issued while the table was cached), violating the expected invariant that cached-table metadata only exists for tables currently in cache mode.

### What changed and how does it work?

In `finishDDLJob` (`pkg/ddl/job_worker.go`), added a new case for `ActionAlterNoCacheTable`: when the job completes successfully, delete the row for the table from `mysql.table_cache_meta`. This mirrors the insert done during `ALTER TABLE CACHE` (in `executor.go`) and ensures the two operations stay symmetric.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix `ALTER TABLE NOCACHE` not removing the stale record from `mysql.table_cache_meta`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper removal of table cache metadata when executing ALTER TABLE NOCACHE, ensuring cache entries are properly cleaned up and no orphaned metadata remains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->