### PR TITLE
executor/importer: fix flaky TestVerifyChecksum cancellation path

### DIFF
--- a/pkg/executor/importer/importer_testkit_test.go
+++ b/pkg/executor/importer/importer_testkit_test.go
@@ -130,7 +130,7 @@ func TestVerifyChecksum(t *testing.T) {
 	ctx2, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 	err = importer.VerifyChecksum(ctx2, plan2, localChecksum, logutil.BgLogger(), func() (*local.RemoteChecksum, error) {
-		return importer.RemoteChecksumTableBySQL(ctx2, tk.Session(), plan, logutil.BgLogger())
+		return importer.RemoteChecksumTableBySQL(ctx2, tk.Session(), plan2, logutil.BgLogger())
 	})
 	require.ErrorContains(t, err, "Query execution was interrupted")
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67091

Problem Summary:
`TestVerifyChecksum` is flaky because the cancel-check branch accidentally checksums `db.tb` (`plan`) instead of the intended slow table `db.tb2` (`plan2`). When `db.tb` is used, checksum can complete around the timeout boundary and return checksum mismatch before interruption, making the assertion nondeterministic.

### What changed and how does it work?
- Changed the cancel-check callback in `TestVerifyChecksum` to call `RemoteChecksumTableBySQL(..., plan2, ...)` instead of `plan`.
- This restores the test's intended behavior: run checksum on the slow table (many index tasks) so timeout interruption is consistently observed in that branch.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:
`(
  enabled=0
  cleanup() { [ "$enabled" -eq 1 ] && make failpoint-disable >/dev/null 2>&1 || true; }
  trap cleanup EXIT INT TERM
  make failpoint-enable >/dev/null
  enabled=1
  pushd pkg/executor/importer >/dev/null
  go test -run '^TestVerifyChecksum$' -tags=intest,deadlock -count=1
  popd >/dev/null
)`

`(
  set -e
  enabled=0
  cleanup() { [ "$enabled" -eq 1 ] && make failpoint-disable >/dev/null 2>&1 || true; }
  trap cleanup EXIT INT TERM
  make failpoint-enable >/dev/null
  enabled=1
  pushd pkg/executor/importer >/dev/null
  for i in $(seq 1 40); do
    go test -run '^TestVerifyChecksum$' -tags=intest,deadlock -count=1 > /tmp/testverifychecksum-fixed.log 2>&1
  done
  popd >/dev/null
)`

`make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated checksum verification test scenario to use an alternative query plan during timeout-interrupt conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->