### PR TITLE
planner: move join reorder exploration into memo-lite

### DIFF
--- a/pkg/planner/cascades/memo/group_expr.go
+++ b/pkg/planner/cascades/memo/group_expr.go
@@ -170,6 +170,14 @@ func (e *GroupExpression) addr() unsafe.Pointer {
 	return unsafe.Pointer(e)
 }
 
+// GetAttachedGroupExpression returns the current GroupExpression itself.
+func (e *GroupExpression) GetAttachedGroupExpression() base.GroupExpression {
+	return e
+}
+
+// SetAttachedGroupExpression is a no-op for GroupExpression because it is already the attachment target.
+func (*GroupExpression) SetAttachedGroupExpression(base.GroupExpression) {}
+
 // GetWrappedLogicalPlan overrides the logical plan interface implemented by BaseLogicalPlan.
 func (e *GroupExpression) GetWrappedLogicalPlan() base.LogicalPlan {
 	return e.LogicalPlan
@@ -206,6 +214,19 @@ func (e *GroupExpression) GetJoinChildStatsAndSchema() (stats0, stats1 *property
 // InputsLen returns the length of inputs.
 func (e *GroupExpression) InputsLen() int {
 	return len(e.Inputs)
+}
+
+// ExtractLogicalPlan materializes a logical tree from the current GE path.
+func (e *GroupExpression) ExtractLogicalPlan() base.LogicalPlan {
+	lp := e.GetWrappedLogicalPlan()
+	children := make([]base.LogicalPlan, 0, len(e.Inputs))
+	for _, childGroup := range e.Inputs {
+		childElem := childGroup.GetFirstElem(pattern.OperandAny)
+		intest.Assert(childElem != nil)
+		children = append(children, childElem.Value.(*GroupExpression).ExtractLogicalPlan())
+	}
+	lp.SetChildren(children...)
+	return lp
 }
 
 // GetInputSchema returns the logical schema of the idx-th child group.

--- a/pkg/planner/cascades/memo/memo.go
+++ b/pkg/planner/cascades/memo/memo.go
@@ -144,6 +144,7 @@ func (mm *Memo) CopyIn(target *Group, lp base.LogicalPlan) (*GroupExpression, er
 			return nil, err
 		}
 	}
+	lp.SetAttachedGroupExpression(groupExpr)
 	return groupExpr, nil
 }
 

--- a/pkg/planner/cascades/memo/memo_test.go
+++ b/pkg/planner/cascades/memo/memo_test.go
@@ -41,9 +41,22 @@ func TestMemo(t *testing.T) {
 	join.SetChildren(t1, t2)
 
 	mm := NewMemo()
-	mm.Init(join)
+	gE, err := mm.Init(join)
+	require.NoError(t, err)
 	require.Equal(t, 3, mm.GetGroups().Len())
 	require.Equal(t, 3, len(mm.GetGroupID2Group()))
+	require.Same(t, gE, join.GetAttachedGroupExpression())
+	var leftGE, rightGE *GroupExpression
+	gE.Inputs[0].ForEachGE(func(ge *GroupExpression) bool {
+		leftGE = ge
+		return false
+	})
+	gE.Inputs[1].ForEachGE(func(ge *GroupExpression) bool {
+		rightGE = ge
+		return false
+	})
+	require.Same(t, leftGE, t1.GetAttachedGroupExpression())
+	require.Same(t, rightGE, t2.GetAttachedGroupExpression())
 
 	// iter memo.groups to assert group ids.
 	cnt := 1

--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -267,6 +267,7 @@ go_test(
         "//pkg/parser/mysql",
         "//pkg/parser/terror",
         "//pkg/planner",
+        "//pkg/planner/cascades/memo",
         "//pkg/planner/core/base",
         "//pkg/planner/core/operator/logicalop",
         "//pkg/planner/core/operator/physicalop",

--- a/pkg/planner/core/base/plan_base.go
+++ b/pkg/planner/core/base/plan_base.go
@@ -263,6 +263,12 @@ type LogicalPlan interface {
 	// GetPlanIDsHash set sub operator tree's ids hash64
 	GetPlanIDsHash() uint64
 
+	// GetAttachedGroupExpression returns the memo GroupExpression currently attached to this logical operator.
+	GetAttachedGroupExpression() GroupExpression
+
+	// SetAttachedGroupExpression attaches the memo GroupExpression currently representing this logical operator.
+	SetAttachedGroupExpression(GroupExpression)
+
 	// GetWrappedLogicalPlan return the wrapped logical plan inside a group expression.
 	// For logicalPlan implementation, it just returns itself as well.
 	GetWrappedLogicalPlan() LogicalPlan

--- a/pkg/planner/core/joinorder/conflict_detector.go
+++ b/pkg/planner/core/joinorder/conflict_detector.go
@@ -244,7 +244,7 @@ func newConflictDetector(ctx base.PlanContext) *ConflictDetector {
 
 // Build constructs the join graph (edges + conflict rules) from a joinGroup.
 // It returns the list of leaf Nodes (vertexes) of current join group, which will be merged to new join by the enumerator.
-func (d *ConflictDetector) Build(group *joinGroup) ([]*Node, error) {
+func (d *ConflictDetector) Build(group *JoinGroup) ([]*Node, error) {
 	d.groupRoot = group.root
 	d.allInnerJoin = group.allInnerJoin
 
@@ -272,7 +272,7 @@ func (d *ConflictDetector) Build(group *joinGroup) ([]*Node, error) {
 //  3. Returns the accumulated edges and the union of all vertex sets seen so far.
 //
 // The returned edges list is used by parent calls to generate conflict rules.
-func (d *ConflictDetector) buildRecursive(group *joinGroup, p base.LogicalPlan, vertexMap map[int]*Node) ([]*edge, intset.FastIntSet, error) {
+func (d *ConflictDetector) buildRecursive(group *JoinGroup, p base.LogicalPlan, vertexMap map[int]*Node) ([]*edge, intset.FastIntSet, error) {
 	if vertexNode, ok := vertexMap[p.ID()]; ok {
 		d.groupVertexes = append(d.groupVertexes, vertexNode)
 		return nil, vertexNode.bitSet, nil

--- a/pkg/planner/core/joinorder/join_order.go
+++ b/pkg/planner/core/joinorder/join_order.go
@@ -35,13 +35,19 @@ import (
 // JoinOrder is the base struct for join order optimization.
 type JoinOrder struct {
 	ctx   base.PlanContext
-	group *joinGroup
+	group *JoinGroup
 }
 
-// A joinGroup is a subtree of the original plan tree. It's the unit for join order.
-// root is the root of the subtree, if root is not a join, then the joinGroup only contains one vertex.
+// ExtractedJoinGroup wraps a pre-extracted join-group so callers can
+// normalize once and optimize later without re-walking the source tree.
+type ExtractedJoinGroup struct {
+	group *JoinGroup
+}
+
+// A JoinGroup is a subtree of the original plan tree. It's the unit for join order.
+// root is the root of the subtree, if root is not a join, then the JoinGroup only contains one vertex.
 // vertexes are the leaf nodes of the subtree, it may have its children, but they are considered as a vertex in this subtree.
-type joinGroup struct {
+type JoinGroup struct {
 	root base.LogicalPlan
 	// All vertexes in this join group.
 	// A vertex means a leaf node in this join group tree,
@@ -64,7 +70,12 @@ type joinGroup struct {
 	selConds map[int][]expression.Expression
 }
 
-func (g *joinGroup) merge(other *joinGroup) {
+// Nodes return all the vertexes in this join group, the vertexes are all leaf nodes in the join group tree.
+func (g *JoinGroup) Nodes() []base.LogicalPlan {
+	return g.vertexes
+}
+
+func (g *JoinGroup) merge(other *JoinGroup) {
 	g.vertexes = append(g.vertexes, other.vertexes...)
 	g.leadingHints = append(g.leadingHints, other.leadingHints...)
 	if len(other.vertexHints) > 0 {
@@ -83,7 +94,7 @@ func (g *joinGroup) merge(other *joinGroup) {
 	}
 }
 
-func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *joinGroup) {
+func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *JoinGroup) {
 	if sel, isSel := p.(*logicalop.LogicalSelection); isSel {
 		if p.SCtx().GetSessionVars().TiDBOptJoinReorderThroughSel &&
 			!slices.ContainsFunc(sel.Conditions, expression.IsMutableEffectsExpr) {
@@ -182,7 +193,7 @@ func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *joinGroup) {
 		}
 	}
 
-	resJoinGroup = &joinGroup{
+	resJoinGroup = &JoinGroup{
 		root:         p,
 		vertexes:     []base.LogicalPlan{},
 		vertexHints:  vertexHints,
@@ -190,7 +201,7 @@ func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *joinGroup) {
 	}
 
 	leftShouldPreserve := curLeadingHint != nil && IsDerivedTableInLeadingHint(join.Children()[0], curLeadingHint)
-	var leftJoinGroup, rightJoinGroup *joinGroup
+	var leftJoinGroup, rightJoinGroup *JoinGroup
 	if !leftHasHint && !leftShouldPreserve {
 		leftJoinGroup = extractJoinGroup(join.Children()[0])
 	} else {
@@ -208,12 +219,30 @@ func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *joinGroup) {
 	return resJoinGroup
 }
 
-func makeSingleGroup(p base.LogicalPlan) *joinGroup {
-	return &joinGroup{
+func makeSingleGroup(p base.LogicalPlan) *JoinGroup {
+	return &JoinGroup{
 		root:         p,
 		vertexes:     []base.LogicalPlan{p},
 		allInnerJoin: true,
 	}
+}
+
+// ExtractJoinGroup precomputes the join-group rooted at p.
+// It returns nil when p does not form a reorderable multi-vertex join-group.
+func ExtractJoinGroup(p base.LogicalPlan) *JoinGroup {
+	group := extractJoinGroup(p)
+	if group == nil || len(group.vertexes) <= 1 {
+		return nil
+	}
+	return group
+}
+
+// Optimize builds a reordered join tree from the pre-extracted join-group.
+func (g *ExtractedJoinGroup) Optimize(ctx base.PlanContext) (base.LogicalPlan, error) {
+	if g == nil || g.group == nil {
+		return nil, nil
+	}
+	return optimizeForJoinGroup(ctx, g.group)
 }
 
 // Optimize performs join order optimization on the given plan.
@@ -272,6 +301,16 @@ func optimizeRecursive(p base.LogicalPlan) (base.LogicalPlan, error) {
 	return p, nil
 }
 
+func OptimizeJoinGroup(ctx base.PlanContext, group *JoinGroup) (base.LogicalPlan, error) {
+	// in memo, logicalMultiJoinNode is generically connected with its child by group.
+	// so we don't need  vertexMap and replaceJoinGroupVertexes here, just directly optimize the join group with the original root is enough.
+	p, err := optimizeForJoinGroup(ctx, group)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
 // replaceJoinGroupVertexes walks the join-group subtree rooted at `root` and
 // swaps every leaf vertex with its optimized replacement from vertexMap.
 //
@@ -300,7 +339,7 @@ func replaceJoinGroupVertexes(root base.LogicalPlan, vertexMap map[int]base.Logi
 	return root
 }
 
-func optimizeForJoinGroup(ctx base.PlanContext, group *joinGroup) (p base.LogicalPlan, err error) {
+func optimizeForJoinGroup(ctx base.PlanContext, group *JoinGroup) (p base.LogicalPlan, err error) {
 	originalSchema := group.root.Schema()
 
 	// TODO impl DP OR merge the old DP impl with the new CD-C impl.
@@ -335,7 +374,7 @@ type joinOrderDP struct {
 	JoinOrder
 }
 
-func newJoinOrderDP(_ base.PlanContext, _ *joinGroup) *joinOrderDP {
+func newJoinOrderDP(_ base.PlanContext, _ *JoinGroup) *joinOrderDP {
 	panic("not implement yet")
 }
 
@@ -347,7 +386,7 @@ type joinOrderGreedy struct {
 	JoinOrder
 }
 
-func newJoinOrderGreedy(ctx base.PlanContext, group *joinGroup) *joinOrderGreedy {
+func newJoinOrderGreedy(ctx base.PlanContext, group *JoinGroup) *joinOrderGreedy {
 	return &joinOrderGreedy{
 		JoinOrder: JoinOrder{
 			ctx:   ctx,

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/format"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
+	"github.com/pingcap/tidb/pkg/planner/cascades/memo"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
@@ -565,12 +566,139 @@ func TestJoinReOrder(t *testing.T) {
 		require.NoError(t, err)
 		p, err = logicalOptimize(context.TODO(), rule.FlagPredicatePushDown|rule.FlagJoinReOrder, p.(base.LogicalPlan))
 		require.NoError(t, err)
-		planString := ToString(p)
+		planString, err := firstMemoLiteJoinReOrderPlan(p.(base.LogicalPlan))
+		require.NoError(t, err)
+		require.NotEmpty(t, planString, comment)
 		testdata.OnRecord(func() {
 			output[i] = planString
 		})
 		require.Equal(t, output[i], planString, fmt.Sprintf("for %s", tt))
 	}
+}
+
+func firstMemoLiteJoinReOrderPlan(logic base.LogicalPlan) (string, error) {
+	// mem the origin logic tree.
+	initialMemo := memo.NewMemo(logic.SCtx().GetSessionVars().StmtCtx.OperatorNum)
+	if _, err := initialMemo.Init(logic); err != nil {
+		return "", err
+	}
+	// flatten join groups into memo first, then optimize the multi-join alternatives.
+	if err := toMultiJoin(initialMemo, logic); err != nil {
+		return "", err
+	}
+
+	candidates := getExploreCandidates(initialMemo, exploreRuleList[0].match)
+	bestPlan := base.LogicalPlan(nil)
+	bestTargetID := 0
+	bestSchemaLen := -1
+	for _, candidate := range candidates {
+		original := candidate.ge.GetWrappedLogicalPlan().(*logicalMultiJoin).LogicalPlan
+		reordered, err := exploreRuleList[0].optimize(candidate.ge)
+		if err != nil {
+			return "", err
+		}
+		if reordered == nil {
+			continue
+		}
+		reorderedString := ToString(reordered)
+		if reorderedString == ToString(original) {
+			continue
+		}
+		schemaLen := candidate.target.GetLogicalProperty().Schema.Len()
+		if schemaLen > bestSchemaLen {
+			bestPlan = reordered
+			bestTargetID = original.ID()
+			bestSchemaLen = schemaLen
+		}
+	}
+	if bestPlan == nil {
+		return "", nil
+	}
+	return ToString(replaceLogicalSubtreeByID(logic, bestTargetID, bestPlan)), nil
+}
+
+func replaceLogicalSubtreeByID(root base.LogicalPlan, targetID int, replacement base.LogicalPlan) base.LogicalPlan {
+	if root.ID() == targetID {
+		return replacement
+	}
+	children := root.Children()
+	if len(children) == 0 {
+		return root
+	}
+	newChildren := make([]base.LogicalPlan, len(children))
+	changed := false
+	for i, child := range children {
+		newChild := replaceLogicalSubtreeByID(child, targetID, replacement)
+		newChildren[i] = newChild
+		if newChild != child {
+			changed = true
+		}
+	}
+	if changed {
+		root.SetChildren(newChildren...)
+	}
+	return root
+}
+
+func TestJoinReOrderExploration(t *testing.T) {
+	s := coretestsdk.CreatePlannerSuiteElems()
+	defer s.Close()
+
+	sql := "select * from t t1, t t2, t t3, t t4, t t5, t t6 where t1.a = t2.b and t2.a = t3.b and t3.c = t4.a and t4.d = t2.c and t5.d = t6.d"
+	stmt, err := s.GetParser().ParseOneStmt(sql, "", "")
+	require.NoError(t, err)
+
+	nodeW := resolve.NewNodeW(stmt)
+	p, err := BuildLogicalPlanForTest(context.Background(), s.GetSCtx(), nodeW, s.GetIS())
+	require.NoError(t, err)
+
+	flags := rule.FlagPredicatePushDown | rule.FlagJoinReOrder
+	logic, err := logicalOptimize(context.Background(), flags, p.(base.LogicalPlan))
+	require.NoError(t, err)
+	initialMemo := memo.NewMemo(logic.SCtx().GetSessionVars().StmtCtx.OperatorNum)
+	_, err = initialMemo.Init(logic)
+	require.NoError(t, err)
+	err = toMultiJoin(initialMemo, logic)
+	require.NoError(t, err)
+
+	candidates := getExploreCandidates(initialMemo, exploreRuleList[0].match)
+	var (
+		targetGroupID memo.GroupID
+		originalPlan  string
+	)
+	for _, candidate := range candidates {
+		originalPlan = ToString(candidate.ge.GetWrappedLogicalPlan().(*logicalMultiJoin).LogicalPlan)
+		reordered, err := exploreRuleList[0].optimize(candidate.ge)
+		require.NoError(t, err)
+		if reordered == nil || ToString(reordered) == originalPlan {
+			continue
+		}
+		targetGroupID = candidate.target.GetGroupID()
+		break
+	}
+	require.NotZero(t, targetGroupID)
+
+	mm, err := exploreLogicalAlternatives(flags, logic)
+	require.NoError(t, err)
+
+	targetGroupElem := mm.GetGroupID2Group()[targetGroupID]
+	require.NotNil(t, targetGroupElem)
+	targetGroup := targetGroupElem.Value.(*memo.Group)
+	require.GreaterOrEqual(t, targetGroup.GetLogicalExpressions().Len(), 2)
+
+	foundOriginal := false
+	foundDifferent := false
+	targetGroup.ForEachGE(func(ge *memo.GroupExpression) bool {
+		planStr := ToString(ge.ExtractLogicalPlan())
+		if planStr == originalPlan {
+			foundOriginal = true
+		} else {
+			foundDifferent = true
+		}
+		return true
+	})
+	require.True(t, foundOriginal)
+	require.True(t, foundDifferent)
 }
 
 func TestEagerAggregation(t *testing.T) {

--- a/pkg/planner/core/operator/logicalop/base_logical_plan.go
+++ b/pkg/planner/core/operator/logicalop/base_logical_plan.go
@@ -50,6 +50,7 @@ type BaseLogicalPlan struct {
 	// taskMapBakTS stores the timestamps of logs.
 	taskMapBakTS []uint64
 	self         base.LogicalPlan
+	attachedGE   base.GroupExpression
 	maxOneRow    bool
 	children     []base.LogicalPlan
 	// fdSet is a set of functional dependencies(FDs) which powers many optimizations,
@@ -414,6 +415,16 @@ func (p *BaseLogicalPlan) SetPlanIDsHash(hash uint64) {
 // GetPlanIDsHash return the plan ids hash rooted from this logical plan.
 func (p *BaseLogicalPlan) GetPlanIDsHash() uint64 {
 	return p.planIDsHash
+}
+
+// GetAttachedGroupExpression returns the memo GroupExpression currently attached to this logical operator.
+func (p *BaseLogicalPlan) GetAttachedGroupExpression() base.GroupExpression {
+	return p.attachedGE
+}
+
+// SetAttachedGroupExpression attaches the memo GroupExpression currently representing this logical operator.
+func (p *BaseLogicalPlan) SetAttachedGroupExpression(ge base.GroupExpression) {
+	p.attachedGE = ge
 }
 
 // GetWrappedLogicalPlan implements the logical plan interface.

--- a/pkg/planner/core/operator/logicalop/logical_projection.go
+++ b/pkg/planner/core/operator/logicalop/logical_projection.go
@@ -677,7 +677,13 @@ func canProjectionBeEliminatedLoose(p *LogicalProjection) bool {
 // InjectExpr injects the expr into a projection above p, and returns the new projection and the new column.
 func InjectExpr(p base.LogicalPlan, expr expression.Expression) (base.LogicalPlan, *expression.Column) {
 	proj, ok := p.(*LogicalProjection)
-	if !ok {
+	if ok {
+		cloned := proj.LogicalProjectionShallowRef()
+		cloned.ReAlloc4Cascades(plancodec.TypeProj, cloned)
+		cloned.ExprsShallowRef()
+		cloned.SetSchema(proj.Schema().Clone())
+		proj = cloned
+	} else {
 		proj = LogicalProjection{Exprs: expression.Column2Exprs(p.Schema().Columns)}.Init(p.SCtx(), p.QueryBlockOffset())
 		proj.SetSchema(p.Schema().Clone())
 		proj.SetChildren(p)

--- a/pkg/planner/core/operator/logicalop/logicalop_test/logical_operator_test.go
+++ b/pkg/planner/core/operator/logicalop/logicalop_test/logical_operator_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
@@ -68,6 +69,33 @@ func TestLogicalSchemaClone(t *testing.T) {
 	// the column slice inside schema will grow at both case.
 	require.Equal(t, cloneSp.Schema().Len(), 2)
 	require.Equal(t, sp.Schema().Len(), 2)
+
+	t.Run("InjectExprClonesProjection", func(t *testing.T) {
+		projCol := &expression.Column{
+			UniqueID: ctx.GetSessionVars().AllocPlanColumnID(),
+			RetType:  types.NewFieldType(mysql.TypeLonglong),
+		}
+		child := logicalop.LogicalSelection{}.Init(ctx, 0)
+		proj := logicalop.LogicalProjection{
+			Exprs: []expression.Expression{projCol},
+		}.Init(ctx, 0)
+		proj.SetSchema(expression.NewSchema(projCol))
+		proj.SetChildren(child)
+
+		origID := proj.ID()
+		newPlan, newCol := logicalop.InjectExpr(proj, expression.NewOne())
+		newProj, ok := newPlan.(*logicalop.LogicalProjection)
+		require.True(t, ok)
+		require.NotSame(t, proj, newProj)
+		require.NotEqual(t, origID, newProj.ID())
+		require.Len(t, proj.Exprs, 1)
+		require.Len(t, proj.Schema().Columns, 1)
+		require.Len(t, newProj.Exprs, 2)
+		require.Len(t, newProj.Schema().Columns, 2)
+		require.NotNil(t, newCol)
+		require.Same(t, projCol, proj.Exprs[0])
+		require.Same(t, child, newProj.Children()[0])
+	})
 }
 
 func TestLogicalApplyClone(t *testing.T) {

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -17,6 +17,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/tidb/pkg/planner/core/joinorder"
 	"math"
 	"slices"
 	"strconv"
@@ -38,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/cascades"
 	"github.com/pingcap/tidb/pkg/planner/cascades/impl"
+	"github.com/pingcap/tidb/pkg/planner/cascades/memo"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
@@ -81,6 +83,7 @@ var (
 	// note this two list will differ when some trade-off rules is moved out of norm phase for cascades.
 )
 
+// LOGICAL OPTIMIZATION PHASE
 var optRuleList = []base.LogicalOptRule{
 	&GcSubstituter{},
 	&rule.ColumnPruner{},
@@ -103,13 +106,41 @@ var optRuleList = []base.LogicalOptRule{
 	&rule.PredicateSimplification{},
 	&PushDownTopNOptimizer{},
 	&rule.SyncWaitStatsLoadPoint{},
-	&JoinReOrderSolver{},
 	&rule.OuterJoinToSemiJoin{},
 	&rule.ColumnPruner{}, // column pruning again at last, note it will mess up the results of buildKeySolver
 	&PushDownSequenceSolver{},
 	&EliminateUnionAllDualItem{},
 	&EmptySelectionEliminator{},
 	&ResolveExpand{},
+}
+
+// EXPLORE PHASE
+type memoLiteExploreRule struct {
+	flag     uint64
+	rule     base.LogicalOptRule
+	match    func(*memo.GroupExpression) bool
+	optimize func(*memo.GroupExpression) (base.LogicalPlan, error)
+}
+
+type memoLiteExploreCandidate struct {
+	ge     *memo.GroupExpression
+	target *memo.Group
+}
+
+var exploreRuleList = []memoLiteExploreRule{
+	{
+		flag: rule.FlagJoinReOrder,
+		// move join reorder rule to the end of optimization for explore more alternatives, otherwise, multi order
+		// alternatives still need to go through other single tree based rules to finish up logical optimization phase.
+		rule: &JoinReOrderSolver{},
+		match: func(ge *memo.GroupExpression) bool {
+			_, ok := ge.GetWrappedLogicalPlan().(*logicalMultiJoin)
+			return ok
+		},
+		optimize: func(ge *memo.GroupExpression) (base.LogicalPlan, error) {
+			return joinorder.OptimizeJoinGroup(ge.GetWrappedLogicalPlan().SCtx(), ge.GetWrappedLogicalPlan().(*logicalMultiJoin).advancedGroup)
+		},
+	},
 }
 
 // Interaction Rule List
@@ -324,10 +355,76 @@ func CascadesOptimize(ctx context.Context, sctx base.PlanContext, flag uint64, l
 	return logic, finalPlan, cost, nil
 }
 
+func getExploreCandidates(mm *memo.Memo, match func(*memo.GroupExpression) bool) []*memoLiteExploreCandidate {
+	candidates := make([]*memoLiteExploreCandidate, 0)
+	mm.ForEachGroup(func(g *memo.Group) bool {
+		g.ForEachGE(func(ge *memo.GroupExpression) bool {
+			if match == nil || match(ge) {
+				candidates = append(candidates, &memoLiteExploreCandidate{
+					ge:     ge,
+					target: g,
+				})
+			}
+			return true
+		})
+		return true
+	})
+	return candidates
+}
+
+func exploreLogicalAlternatives(flag uint64, logic base.LogicalPlan) (*memo.Memo, error) {
+	// init memo
+	mm := memo.NewMemo(logic.SCtx().GetSessionVars().StmtCtx.OperatorNum)
+	if _, err := mm.Init(logic); err != nil {
+		return nil, err
+	}
+	// extract join groups inside as usual, wrapper them as a flatten multi-join node.
+	err := toMultiJoin(mm, logic)
+	if err != nil {
+		return nil, err
+	}
+
+	// explore alternatives in memo.
+	for _, exploreRule := range exploreRuleList {
+		if exploreRule.flag != 0 && flag&exploreRule.flag == 0 {
+			continue
+		}
+		if exploreRule.rule != nil && isLogicalRuleDisabled(exploreRule.rule) {
+			continue
+		}
+		// get explore rule targeted candidate.
+		candidates := getExploreCandidates(mm, exploreRule.match)
+		// dfs for each ge, like tree down calling optimize for valid anchor.
+		for _, candidate := range candidates {
+			var (
+				alt base.LogicalPlan
+				err error
+			)
+			alt, err = exploreRule.optimize(candidate.ge)
+			if err != nil {
+				return nil, err
+			}
+			if alt == nil {
+				continue
+			}
+			// alternative copyIn.
+			if _, err = mm.CopyIn(candidate.target, alt); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return mm, nil
+}
+
 // VolcanoOptimize includes: logicalOptimize, physicalOptimize
 func VolcanoOptimize(ctx context.Context, sctx base.PlanContext, flag uint64, logic base.LogicalPlan) (base.LogicalPlan, base.PhysicalPlan, float64, error) {
 	flag = adjustOptimizationFlags(flag, logic)
+	// logical optimization phase.
 	logic, err := logicalOptimize(ctx, flag, logic)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	mm, err := exploreLogicalAlternatives(flag, logic)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -335,7 +432,11 @@ func VolcanoOptimize(ctx context.Context, sctx base.PlanContext, flag uint64, lo
 		return nil, nil, 0, errors.Trace(plannererrors.ErrCartesianProductUnsupported)
 	}
 	failpoint.Inject("ConsumeVolcanoOptimizePanic", nil)
-	physical, cost, err := physicalOptimize(logic)
+	var (
+		cost     float64
+		physical base.PhysicalPlan
+	)
+	physical, cost, err = impl.ImplementMemoAndCost(mm.GetRootGroup())
 	if err != nil {
 		return nil, nil, 0, err
 	}

--- a/pkg/planner/core/rule/logical_rules.go
+++ b/pkg/planner/core/rule/logical_rules.go
@@ -14,8 +14,8 @@
 
 package rule
 
-// Note: The order of flags is same as the order of optRule in the list.
-// Do not mess up the order.
+// Note: Most flags follow the same order as optRuleList in optimizer.go.
+// FlagJoinReOrder is explored separately in memo-lite after logical optimization.
 const (
 	FlagGcSubstitute uint64 = 1 << iota
 	FlagPruneColumns
@@ -38,13 +38,13 @@ const (
 	FlagPredicateSimplification
 	FlagPushDownTopN
 	FlagSyncWaitStatsLoadPoint
-	FlagJoinReOrder
 	FlagOuterJoinToSemiJoin
 	FlagPruneColumnsAgain
 	FlagPushDownSequence
 	FlagEliminateUnionAllDualItem
 	FlagEmptySelectionEliminator
 	FlagResolveExpand
+	FlagJoinReOrder
 )
 
 func setPredicatePushDownFlag(u uint64) uint64 {

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"context"
+	"github.com/pingcap/tidb/pkg/planner/cascades/memo"
 	"maps"
 	"slices"
 
@@ -286,6 +287,24 @@ type joinTypeWithExtMsg struct {
 	outerBindCondition []expression.Expression
 }
 
+// logicalMultiJoin is a transient normalization node used by memo-lite join
+// reorder. It stores one extracted join-group so reordering can consume the
+// precomputed structure directly while keeping the original join tree as an
+// alternative in memo.
+type logicalMultiJoin struct {
+	base.LogicalPlan // source plan
+	legacyGroup      *joinGroupResult
+	advancedGroup    *joinorder.JoinGroup
+}
+
+// Children implements the base.LogicalPlan interface.
+func (lp *logicalMultiJoin) Children() []base.LogicalPlan {
+	if lp.legacyGroup != nil {
+		return lp.legacyGroup.group
+	}
+	return lp.advancedGroup.Nodes()
+}
+
 // Optimize implements the base.LogicalOptRule.<0th> interface.
 func (s *JoinReOrderSolver) Optimize(_ context.Context, p base.LogicalPlan) (base.LogicalPlan, bool, error) {
 	if p.SCtx().GetSessionVars().TiDBOptEnableAdvancedJoinReorder {
@@ -294,6 +313,68 @@ func (s *JoinReOrderSolver) Optimize(_ context.Context, p base.LogicalPlan) (bas
 	}
 	p, err := s.optimizeRecursive(p.SCtx(), p)
 	return p, false, err
+}
+
+func toMultiJoin(mm *memo.Memo, logic base.LogicalPlan) (err error) {
+	if logic == nil {
+		return nil
+	}
+	if _, ok := logic.(*logicalop.LogicalCTE); ok {
+		return nil
+	}
+
+	// Try to normalize the current root first. If extractJoinGroup/buildLogicalMultiJoin
+	// succeeds here, it has already explored the covered subtree, so we should insert the
+	// new alternative into the current root group and stop descending.
+	multiJoinNode := buildLogicalMultiJoin(logic)
+	if multiJoinNode != nil {
+		attachedGE, ok := logic.GetAttachedGroupExpression().(*memo.GroupExpression)
+		if !ok || attachedGE == nil {
+			return nil
+		}
+		_, err = mm.CopyIn(attachedGE.GetGroup(), multiJoinNode)
+		// simply dive into each node of multi-join node.
+		for _, child := range multiJoinNode.Children() {
+			err = toMultiJoin(mm, child)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		// once this logical operator is simply non-join, dive into its children to find more join groups.
+		for _, child := range logic.Children() {
+			err = toMultiJoin(mm, child)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func buildLogicalMultiJoin(p base.LogicalPlan) *logicalMultiJoin {
+	if p == nil {
+		return nil
+	}
+	if p.SCtx().GetSessionVars().TiDBOptEnableAdvancedJoinReorder {
+		group := joinorder.ExtractJoinGroup(p)
+		if group == nil {
+			return nil
+		}
+		return &logicalMultiJoin{
+			LogicalPlan:   p,
+			advancedGroup: group,
+		}
+	}
+	group := extractJoinGroup(p)
+	if group == nil || len(group.group) <= 1 {
+		return nil
+	}
+	return &logicalMultiJoin{
+		LogicalPlan: p,
+		legacyGroup: group,
+	}
 }
 
 // optimizeRecursive recursively collects join groups and applies join reorder algorithm for each group.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65710

Problem Summary:

Move logical join reorder exploration out of the heuristic logicalOptimize phase and into memo-lite exploration so the original logical alternative remains in memo while reordered alternatives are added as new alternatives.

### What changed and how does it work?

- move join reorder rule application from logicalOptimize into memo-lite exploration.
- add a temporary multi-join carrier for extracted join-group information so reorder can generate new memo alternatives while preserving the original join alternative.
- attach group expressions to logical plans during memo init and copy-in so extracted logical nodes can locate their target memo group during transforms.
- make projection injection in join reorder copy-on-write instead of mutating an existing projection.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced query optimization pipeline with memo-based exploration for join reordering, enabling the optimizer to evaluate multiple join orderings and select better execution plans.

* **Bug Fixes**
  * Improved logical plan handling in projection operations to prevent unintended mutations during expression injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->