### PR TITLE
planner: avoid max/min elimination for bit type

### DIFF
--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -1486,6 +1486,21 @@ func TestPointGetWithSelectLock(t *testing.T) {
 	}
 }
 
+func TestIssue67041BitMaxWithGroupByOrderBy(t *testing.T) {
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		tk.MustExec("use test")
+		tk.MustExec("set @@sql_mode='';")
+		tk.MustExec("drop table if exists t")
+		tk.MustExec("create table t (c0 bit(5), c1 bit(1), primary key(c0))")
+		tk.MustExec("insert into t values (b'10', b'0')")
+		tk.MustQuery("select abs(max(b'10')) as r from t group by c0 order by c1").Check(testkit.Rows("2"))
+		tk.MustExec("drop table if exists t")
+		tk.MustExec("create table t (c0 bit(5), c1 bit(1))")
+		tk.MustExec("insert into t values (b'10', b'0')")
+		tk.MustQuery("select abs(max(b'10')) as r from t group by c0 order by c1").Check(testkit.Rows("2"))
+	})
+}
+
 func TestPlanCacheForIndexRangeFallback(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
 		tk.MustExec(`set @@tidb_enable_prepared_plan_cache=1`)

--- a/pkg/planner/core/rule/rule_max_min_eliminate.go
+++ b/pkg/planner/core/rule/rule_max_min_eliminate.go
@@ -232,10 +232,12 @@ func (a *MaxMinEliminator) eliminateMaxMin(p base.LogicalPlan) base.LogicalPlan 
 				return agg
 			}
 		}
-		// Limit+Sort operators are sorted by value, but ENUM/SET field types are sorted by name.
+		// Limit+Sort operators are sorted by value, but ENUM/SET/BIT field types are sorted differently from MAX/MIN.
+		// ENUM/SET are sorted by name, while BIT literals are evaluated as numbers in aggregation.
 		cols := agg.GetUsedCols()
 		for _, col := range cols {
-			if col.RetType.GetType() == mysql.TypeEnum || col.RetType.GetType() == mysql.TypeSet {
+			switch col.RetType.GetType() {
+			case mysql.TypeEnum, mysql.TypeSet, mysql.TypeBit:
 				return agg
 			}
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67041

Problem Summary: When MAX/MIN elimination rewrites an aggregation as Sort+Limit, BIT typed expressions produce incorrect results. BIT literals are evaluated numerically in aggregation, but the elimination path sorts by raw BIT values, causing different results depending on whether a unique index (e.g. PRIMARY KEY) triggers the optimization.

### What changed and how does it work?

Extend the existing ENUM/SET guard in `rule_max_min_eliminate.go` to also exclude BIT typed columns from the max/min-to-sort+limit elimination. This ensures MAX/MIN on BIT expressions always uses the correct numeric semantics.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix incorrect query results when MAX/MIN aggregation on BIT typed expressions is rewritten by the max/min elimination optimization rule.
```