### PR TITLE
importer: include file name in row encode error

### DIFF
--- a/pkg/executor/importer/chunk_process.go
+++ b/pkg/executor/importer/chunk_process.go
@@ -357,6 +357,11 @@ func (p *chunkEncoder) encodeLoop(ctx context.Context) error {
 		data.resetFn()
 		if encodeErr != nil {
 			err2 := common.ErrEncodeKV.Wrap(encodeErr).GenWithStackByArgs(p.chunkName, data.startPos)
+			// Use the source pos/offset to tell whether this chunk comes from a file:
+			// query chunks use -1 as a sentinel, while file chunks always carry it.
+			if p.offset >= 0 {
+				return errors.Annotatef(err2, "when encoding %d-th data row in file %s", rowNumber, p.chunkName)
+			}
 			return errors.Annotatef(err2, "when encoding %d-th data row in this chunk", rowNumber)
 		}
 		encodeDur += time.Since(encodeDurStart)

--- a/pkg/executor/importer/chunk_process_testkit_test.go
+++ b/pkg/executor/importer/chunk_process_testkit_test.go
@@ -182,6 +182,7 @@ func TestFileChunkProcess(t *testing.T) {
 		indexWriter.EXPECT().AppendRows(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		chunkInfo := &checkpoints.ChunkCheckpoint{
+			Key:   checkpoints.ChunkCheckpointKey{Path: "db.table.2.sql"},
 			Chunk: mydump.Chunk{EndOffset: int64(len(sourceData)), RowIDMax: 10000},
 		}
 		processor := importer.NewFileChunkProcessor(
@@ -190,7 +191,7 @@ func TestFileChunkProcess(t *testing.T) {
 		)
 		err2 := processor.Process(ctx)
 		require.ErrorIs(t, err2, common.ErrEncodeKV)
-		require.ErrorContains(t, err2, "encoding 2-th data row in this chunk")
+		require.ErrorContains(t, err2, "when encoding 2-th data row in file db.table.2.sql:0")
 		require.ErrorContains(t, err2, "at offset 6")
 		require.True(t, ctrl.Satisfied())
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with \"Issue Number:  \" and
linking the relevant issues via the \"close\" or \"ref\".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #66916

Problem Summary:
- IMPORT INTO row encoding errors still annotate failures with `this chunk`, so the outer error context does not immediately tell users which input file failed.
- This is a follow-up to #66917 to include the file key in the outer row-level error message.

### What changed and how does it work?
- Change the row encoding annotation in the file chunk processor from `this chunk` to `file <chunk key>`.
- Keep the existing `ErrEncodeKV` wrapping and offset information unchanged.
- Add a regression test that asserts the error now includes `db.table.2.sql:0` in the outer message.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  \"No need to test\" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve IMPORT INTO row encoding errors to include the source file name in the outer error context.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Encoding error messages during data import now clearly indicate the failing row number and, when applicable, the originating source file for improved diagnostics.

* **Tests**
  * Test expectations updated to match the more file-qualified encoding error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->