### PR TITLE
txn: Add test for the issue that transaction using fair locking multiple times in the first statement may make keeping-alive fail

### DIFF
--- a/tests/realtikvtest/pessimistictest/pessimistic_test.go
+++ b/tests/realtikvtest/pessimistictest/pessimistic_test.go
@@ -3494,6 +3494,73 @@ func TestPointLockNonExistentKeyWithFairLockingUnderRC(t *testing.T) {
 	tk.MustExec("commit")
 }
 
+func TestIssue66571(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("tidb_pessimistic_txn_fair_locking is not supported in the next generation of TiDB")
+	}
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+
+	test := func(isRetried bool, isPrimaryChanged bool) {
+		tk := testkit.NewTestKit(t, store)
+		tk2 := testkit.NewTestKit(t, store)
+
+		additionalInitStmt := ""
+		earlyConflictingStmt := ""
+		testedStmt := "update t set v = v + 1 where uk = 10"
+		expectedFinalData := []string{"1 10 101"}
+
+		if isRetried {
+			if !isPrimaryChanged {
+				additionalInitStmt = "insert into t values (0, 0, 10)"
+				earlyConflictingStmt = "update t set v = 200 where uk = 10"
+				expectedFinalData = []string{"0 0 10", "1 10 201"}
+			} else {
+				additionalInitStmt = "insert into t values (0, 0, 9)"
+				earlyConflictingStmt = "update t set v = 10 where id = 0"
+				testedStmt = `
+					with 
+						x as (select /*+ MERGE() */ * from t where id = 0) 
+					update x join t on x.v = t.uk set t.v = t.v + 1 where t.uk = 10`
+				expectedFinalData = []string{"0 0 10", "1 10 101"}
+			}
+		}
+
+		defer setLockTTL(100).restore()
+		tk.MustExec("set @@tidb_pessimistic_txn_fair_locking=1")
+		tk.MustExec("use test")
+		tk.MustExec("drop table if exists t")
+		tk.MustExec("create table t (id int primary key, uk int unique, v int)")
+		if additionalInitStmt != "" {
+			tk.MustExec(additionalInitStmt)
+		}
+		tk.MustExec("insert into t values (1, 10, 100)")
+		tk2.MustExec("use test")
+		tk2.MustExec("set innodb_lock_wait_timeout = 1")
+
+		tk.MustExec("begin pessimistic")
+		if earlyConflictingStmt != "" {
+			tk3 := testkit.NewTestKit(t, store)
+			tk3.MustExec("use test")
+			tk3.MustExec(earlyConflictingStmt)
+		}
+		tk.MustExec(testedStmt)
+
+		tk2.MustExec("begin pessimistic")
+		err := tk2.ExecToErr("update t set v = v + 2 where uk = 10")
+		require.Error(t, err)
+		require.ErrorIs(t, err, storeerr.ErrLockWaitTimeout)
+		tk2.MustExec("commit")
+
+		tk.MustExec("commit")
+
+		tk.MustQuery("select * from t").Check(testkit.Rows(expectedFinalData...))
+	}
+
+	test(false, false)
+	test(true, false)
+	test(true, true)
+}
+
 func TestIssueBatchResolveLocks(t *testing.T) {
 	store, domain := realtikvtest.CreateMockStoreAndDomainAndSetup(t)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66571

Problem Summary:

This PR adds test for the issue #66571 .
It includes updating client-go, but was already included by other PRs.

* Requires: https://github.com/tikv/client-go/pull/1903

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that transaction using fair locking multiple times in the first statement may make keeping-alive fail, casuing unable to block other transactions or unexpected commit failure.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for pessimistic transaction fair locking behavior, validating lock timeout handling and concurrent transaction scenarios to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->