### PR TITLE
collate: fix unicode_0900 weight panic

### DIFF
--- a/pkg/util/collate/BUILD.bazel
+++ b/pkg/util/collate/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "collate_bench_test.go",
         "collate_test.go",
         "main_test.go",
+        "unicode_0900_ai_ci_impl_test.go",
     ],
     embed = [":collate"],
     flaky = True,

--- a/pkg/util/collate/unicode_0900_ai_ci_impl.go
+++ b/pkg/util/collate/unicode_0900_ai_ci_impl.go
@@ -41,7 +41,7 @@ func (unicode0900Impl) Pattern() WildcardPattern {
 }
 
 func convertRuneUnicodeCI0900(r rune) (first, second uint64) {
-	if int(r) > len(ucadata.DUCET0900Table.MapTable4) {
+	if int(r) >= len(ucadata.DUCET0900Table.MapTable4) {
 		return uint64(r>>15) + 0xFBC0 + (uint64((r&0x7FFF)|0x8000) << 16), 0
 	}
 

--- a/pkg/util/collate/unicode_0900_ai_ci_impl_test.go
+++ b/pkg/util/collate/unicode_0900_ai_ci_impl_test.go
@@ -17,19 +17,31 @@ package collate
 import (
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/util/collate/ucadata"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUnicode0900BoundaryRuneUsesImplicitWeight(t *testing.T) {
 	collator := &unicode0900AICICollator{}
-	boundaryRune := rune(0x2CEA1)
+	lastTableRune := rune(len(ucadata.DUCET0900Table.MapTable4) - 1)
+	boundaryRune := lastTableRune + 1
 	boundaryStr := string(boundaryRune)
 
-	// U+2CEA1 is the first rune outside MapTable4 and must use implicit weight.
+	// The first rune outside MapTable4 must use the fallback path instead of indexing the table.
+	lastFirst, lastSecond := convertRuneUnicodeCI0900(lastTableRune)
+	require.Equal(t, ucadata.DUCET0900Table.MapTable4[lastTableRune], lastFirst)
+	require.Zero(t, lastSecond)
+
 	first, second := convertRuneUnicodeCI0900(boundaryRune)
-	require.Equal(t, uint64(0xCEA1_0000|0xFBC5), first)
+	require.NotZero(t, first)
 	require.Zero(t, second)
-	require.Equal(t, []byte{0xFB, 0xC5, 0xCE, 0xA1}, collator.Key(boundaryStr))
+	require.Greater(t, first, lastFirst)
+	require.NotEmpty(t, collator.Key(boundaryStr))
+	require.Equal(t, -1, collator.Compare(string(lastTableRune), boundaryStr))
 	require.Equal(t, 0, collator.Compare(boundaryStr, boundaryStr))
 	require.Equal(t, -1, collator.Compare(boundaryStr, string(boundaryRune+1)))
+
+	pattern := collator.Pattern()
+	pattern.Compile(boundaryStr, '\\')
+	require.True(t, pattern.DoMatch(boundaryStr))
 }

--- a/pkg/util/collate/unicode_0900_ai_ci_impl_test.go
+++ b/pkg/util/collate/unicode_0900_ai_ci_impl_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnicode0900BoundaryRuneUsesImplicitWeight(t *testing.T) {
+	collator := &unicode0900AICICollator{}
+	boundaryRune := rune(0x2CEA1)
+	boundaryStr := string(boundaryRune)
+
+	// U+2CEA1 is the first rune outside MapTable4 and must use implicit weight.
+	first, second := convertRuneUnicodeCI0900(boundaryRune)
+	require.Equal(t, uint64(0xCEA1_0000|0xFBC5), first)
+	require.Zero(t, second)
+	require.Equal(t, []byte{0xFB, 0xC5, 0xCE, 0xA1}, collator.Key(boundaryStr))
+	require.Equal(t, 0, collator.Compare(boundaryStr, boundaryStr))
+	require.Equal(t, -1, collator.Compare(boundaryStr, string(boundaryRune+1)))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67151 

Problem Summary:
Panic on unicode0900 boundary.

### What changed and how does it work?
Fix potential panic on unicode table boundary.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an off-by-one boundary in Unicode collation logic to prevent incorrect handling of an edge-case character and ensure stable, correct ordering in text comparisons.

* **Tests**
  * Added targeted tests validating collation behavior at the boundary to catch regressions and ensure consistent sorting and pattern matching for those edge-case rune values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->