### PR TITLE
planner: align FULLTEXT index validation for create and alter | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature-fts

### DIFF
--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -1454,7 +1454,7 @@ func (p *preprocessor) checkAlterTableGrammar(stmt *ast.AlterTableStmt) {
 		case ast.AlterTableAddConstraint:
 			switch spec.Constraint.Tp {
 			case ast.ConstraintKey, ast.ConstraintIndex, ast.ConstraintUniq, ast.ConstraintUniqIndex,
-				ast.ConstraintUniqKey, ast.ConstraintPrimaryKey:
+				ast.ConstraintUniqKey, ast.ConstraintPrimaryKey, ast.ConstraintFulltext:
 				p.err = checkIndexInfo(spec.Constraint.Name, spec.Constraint.Keys)
 				if p.err != nil {
 					return

--- a/pkg/planner/core/preprocess_test.go
+++ b/pkg/planner/core/preprocess_test.go
@@ -170,6 +170,9 @@ func TestValidator(t *testing.T) {
 
 		// issue 2273
 		{"create table t(a char, b char, c char, d char, e char, f char, g char, h char ,i char, j char, k int, l char ,m char , n char, o char , p char, q char, index(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q))", true, errors.New("[schema:1070]Too many key parts specified; max 16 parts allowed")},
+		// issue pingcap-inc/tici#966
+		{"CREATE FULLTEXT INDEX idx ON t(c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17) WITH PARSER STANDARD", true, errors.New(`[schema:1070]Too many key parts specified; max 16 parts allowed`)},
+		{"ALTER TABLE t ADD FULLTEXT INDEX idx(c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17) WITH PARSER STANDARD", true, errors.New(`[schema:1070]Too many key parts specified; max 16 parts allowed`)},
 
 		// issue #4429
 		{"CREATE TABLE `t` (`a` date DEFAULT now());", false, types.ErrInvalidDefault},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: pingcap-inc/tici#966

Problem Summary:
`CREATE FULLTEXT INDEX` and `ALTER TABLE ... ADD FULLTEXT INDEX` were inconsistent for the same invalid input with too many index parts. `CREATE` returned `ErrTooManyKeyParts` while `ALTER` did not apply the same key-parts limit check.

### What changed and how does it work?
- Keep `CREATE FULLTEXT INDEX` behavior unchanged (`ErrTooManyKeyParts`).
- Extend `ALTER TABLE ... ADD FULLTEXT INDEX` grammar validation path to also run `checkIndexInfo` key-parts limit check.
- Add regression cases in `TestValidator` for both `CREATE` and `ALTER` FULLTEXT index with 17 parts; both now return:
  - `Too many key parts specified; max 16 parts allowed` (`schema:1070`).

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix inconsistent key-parts validation between CREATE FULLTEXT INDEX and ALTER TABLE ADD FULLTEXT INDEX.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * FULLTEXT index validation now correctly enforces the 16-column maximum during CREATE and ALTER TABLE operations, returning the appropriate error for oversized key definitions.

* **Tests**
  * Added negative test cases covering FULLTEXT indexes with too many key parts to ensure the validation behavior is enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->