### PR TITLE
tests: add local hybrid vector e2e helper

### DIFF
--- a/tests/integrationtest2/tici/README.md
+++ b/tests/integrationtest2/tici/README.md
@@ -59,7 +59,7 @@ OCI_ARTIFACT_HOST="us-docker.pkg.dev/pingcap-testing-account/hub" ./download_pin
 For local hybrid-vector end-to-end validation against TiUP playground, use:
 
 ```bash
-cd /Users/jin/Desktop/tidb/tests/integrationtest2/tici
+cd tests/integrationtest2/tici
 ./hybrid_vector_e2e.sh all
 ```
 
@@ -130,11 +130,11 @@ By default the helper isolates itself from any existing local playground by usin
 
 If you want different ports, override `PORT_OFFSET`, `TIDB_PORT`, `PD_PORT`, `CDC_PORT`, or `MINIO_PORT`.
 
-The script auto-discovers the current desktop layout by default:
+The script assumes the following default paths (override with environment variables):
 
-- TiDB: `/Users/jin/Desktop/tidb/bin/tidb-server`
-- TiFlash: `/Users/jin/Desktop/tiflash-fts/cmake-build-codex-release/dbms/src/Server/tiflash`
-- TiCI: `/Users/jin/Desktop/tici/target/release/tici-server`
+- TiDB: `<repo_root>/bin/tidb-server`
+- TiFlash: `<workspace>/tiflash-fts/cmake-build-codex-release/dbms/src/Server/tiflash`
+- TiCI: `<workspace>/tici/target/release/tici-server`
 
 Available commands:
 

--- a/tests/integrationtest2/tici/README.md
+++ b/tests/integrationtest2/tici/README.md
@@ -1,0 +1,147 @@
+# TiCI integrationtest2 Guide
+
+## Dependencies
+
+When running `tests/integrationtest2/run-tests.sh`:
+- Required: `bash`
+- Port check: `ss` or `nc` (macOS usually uses `nc`)
+- Config rendering: `envsubst` (from `gettext`)
+
+When downloading binaries (using `tici/download.sh`):
+- `oras`
+- `yq`
+- `tar`/`gzip`
+
+## Run directly (third_bin already prepared)
+
+If `tests/integrationtest2/third_bin` already contains the binaries below, you can run directly:
+- `pd-server`
+- `tikv-server`
+- `tidb-server`
+- `dumpling`
+- `cdc`
+- `tiflash` (if it is a directory, `tiflash/tiflash` must exist)
+- `tici-server`
+- `minio`
+- `mc`
+
+Run:
+```bash
+cd /tidb/tests/integrationtest2
+./run-tests.sh -t tici/tici_integration
+```
+
+## Download binaries (third_bin incomplete)
+
+If `tests/integrationtest2/third_bin` is missing any of the binaries above, `run-tests.sh` will fail.
+Download them first with `https://github.com/PingCAP-QE/ci/blob/main/scripts/artifacts/download_pingcap_oci_artifact.sh`. This script depends on `oras` and `yq`.
+
+Example (download TiFlash from a specific branch):
+```bash
+cd /tidb/tests/integrationtest2/third_bin
+OCI_ARTIFACT_HOST="us-docker.pkg.dev/pingcap-testing-account/hub" ./download_pingcap_oci_artifact.sh --tiflash=feature-fts
+```
+
+Example (download the latest TiCDC):
+```bash
+cd /tidb/tests/integrationtest2/tici/third_bin
+OCI_ARTIFACT_HOST="us-docker.pkg.dev/pingcap-testing-account/hub" ./download_pingcap_oci_artifact.sh --ticdc-new=master
+```
+
+Example (download the latest TiCI):
+```bash
+cd /tidb/tests/integrationtest2/tici/third_bin
+OCI_ARTIFACT_HOST="us-docker.pkg.dev/pingcap-testing-account/hub" ./download_pingcap_oci_artifact.sh --tici=master
+```
+
+## Hybrid vector e2e helper
+
+For local hybrid-vector end-to-end validation against TiUP playground, use:
+
+```bash
+cd /Users/jin/Desktop/tidb/tests/integrationtest2/tici
+./hybrid_vector_e2e.sh all
+```
+
+This helper is meant for iterative local development and covers:
+
+- starting MinIO + `playground:v1.16.2-feature.fts`
+- reusing the TiCDC S3 changefeed created by playground itself
+- preparing a table with `1` inverted column + `1` vector column
+- creating a hybrid index on an empty table
+- loading about `10,000` rows through TiCDC
+- inserting a post-index delta row to exercise CDC ingestion
+- verifying both inverted lookup and `ORDER BY vec_l2_distance(...) LIMIT K`
+
+Current limitation:
+
+- `import into` / add-index backfill is not yet adapted for hybrid/vector index ingestion.
+- For local e2e, use the CDC-only order: `CREATE TABLE` -> `CREATE HYBRID INDEX` -> insert rows.
+- The harness no longer creates or removes changefeeds by itself; it waits for the
+  playground-managed feed and verifies that its sink URI matches the expected
+  `s3://<bucket>/<prefix>/cdc` prefix and includes `use-table-id-as-path=true`.
+
+Latest local e2e notes:
+
+- `2026-03-20`: local CDC-only hybrid-vector e2e passed with
+  `PLAYGROUND_TAG=hybrid-vector-e2e-20260320g`.
+  This run used the playground-managed changefeed directly, without a second
+  manual `changefeed create` from the helper script.
+  The discovered changefeed stayed `normal` with sink URI
+  `s3://ticidefaultbucket/hybrid-vector-e2e-20260320g/cdc?...&use-table-id-as-path=true...`
+  and queried sink config `date_separator = "none"`.
+- `2026-03-20`: an earlier local CDC-only hybrid-vector e2e also passed with
+  `PLAYGROUND_TAG=hybrid-vector-e2e-20260320d`.
+  The table reached `10001` rows, `tici.tici_shard_meta.progress.cdc_s3_last_file`
+  advanced to
+  `hybrid-vector-e2e-20260320d/cdc/124/465034883516071938/2026-03-20/CDC00000000000000000001.json`,
+  and `manifest.fragments[0].f.property.count` reached `10001`.
+  Verified:
+  inverted lookup on `anchor_title_keep` returned `1`,
+  inverted lookup on `post_index_anchor` returned `10001`,
+  vector top1 for the base anchor returned `1`,
+  vector top1 for the post-index delta anchor returned `10001`,
+  and `EXPLAIN FORMAT='brief'` showed `cop[tici]` with `vector search`.
+- `2026-03-20`: inspecting `playground:v1.16.2-feature.fts` showed that the
+  playground-managed changefeed already uses `use-table-id-as-path=true`.
+  Its queried sink config reported `date_separator = "none"` even though that
+  parameter was not explicitly present in the sink URI.
+
+Useful overrides:
+
+```bash
+TIDB_BINPATH=/path/to/tidb-server \
+TIFLASH_BINPATH=/path/to/tiflash \
+TICI_BINPATH=/path/to/tici-server \
+TICDC_BINPATH=/path/to/cdc \
+./hybrid_vector_e2e.sh all
+```
+
+TiUP refresh behavior:
+
+- By default the helper removes local `playground:v1.16.2-feature.fts` and `cdc:nightly`
+  component caches before reinstalling, so a re-pushed mirror binary is picked up.
+- Set `REFRESH_TIUP_COMPONENTS=0` if you explicitly want to reuse the local cache.
+
+By default the helper isolates itself from any existing local playground by using:
+
+- `PORT_OFFSET=20000`
+- `MINIO_PORT=29000`
+
+If you want different ports, override `PORT_OFFSET`, `TIDB_PORT`, `PD_PORT`, `CDC_PORT`, or `MINIO_PORT`.
+
+The script auto-discovers the current desktop layout by default:
+
+- TiDB: `/Users/jin/Desktop/tidb/bin/tidb-server`
+- TiFlash: `/Users/jin/Desktop/tiflash-fts/cmake-build-codex-release/dbms/src/Server/tiflash`
+- TiCI: `/Users/jin/Desktop/tici/target/release/tici-server`
+
+Available commands:
+
+```bash
+./hybrid_vector_e2e.sh up
+./hybrid_vector_e2e.sh prepare
+./hybrid_vector_e2e.sh verify
+./hybrid_vector_e2e.sh status
+./hybrid_vector_e2e.sh down
+```

--- a/tests/integrationtest2/tici/hybrid_vector_e2e.py
+++ b/tests/integrationtest2/tici/hybrid_vector_e2e.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import random
+import subprocess
+import time
+from typing import Iterable, List, Sequence, Tuple
+
+
+VECTOR_DIM = 32
+BASE_ANCHOR_ID = 1
+DELTA_ANCHOR_ID = 10001
+BASE_ANCHOR_TITLE = "anchor_title_keep"
+DELTA_ANCHOR_TITLE = "post_index_anchor"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=["prepare", "verify"])
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=4000)
+    parser.add_argument("--user", default="root")
+    parser.add_argument("--password", default="")
+    parser.add_argument("--database", default="test")
+    parser.add_argument("--table", default="hybrid_vector_docs")
+    parser.add_argument("--index-name", default="idx_hybrid_vector")
+    parser.add_argument("--rows", type=int, default=10_000)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--timeout", type=int, default=600)
+    parser.add_argument("--interval", type=int, default=5)
+    return parser.parse_args()
+
+
+def mysql_base_command(args: argparse.Namespace) -> List[str]:
+    command = [
+        "mysql",
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "--user",
+        args.user,
+        "--batch",
+        "--raw",
+        "--skip-column-names",
+    ]
+    if args.password:
+        command.append(f"--password={args.password}")
+    return command
+
+
+def run_sql(args: argparse.Namespace, sql: str) -> str:
+    process = subprocess.run(
+        mysql_base_command(args),
+        input=sql,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"mysql failed with exit code {process.returncode}: {process.stderr.strip()}"
+        )
+    return process.stdout
+
+
+def query_rows(args: argparse.Namespace, sql: str) -> List[List[str]]:
+    output = run_sql(args, sql)
+    if not output.strip():
+        return []
+    return [line.split("\t") for line in output.strip().splitlines()]
+
+
+def sql_literal(value: object) -> str:
+    if value is None:
+        return "NULL"
+    escaped = str(value).replace("\\", "\\\\").replace("'", "\\'")
+    return f"'{escaped}'"
+
+
+def vector_literal(values: Sequence[float]) -> str:
+    return "[" + ", ".join(f"{value:.6f}" for value in values) + "]"
+
+
+def one_hot(index: int, dim: int = VECTOR_DIM) -> List[float]:
+    values = [0.0] * dim
+    values[index] = 1.0
+    return values
+
+
+def random_vector(rng: random.Random, dim: int = VECTOR_DIM) -> List[float]:
+    return [round(rng.uniform(0.2, 0.8), 6) for _ in range(dim)]
+
+
+def batched(items: Sequence[Tuple[object, ...]], batch_size: int) -> Iterable[Sequence[Tuple[object, ...]]]:
+    for start in range(0, len(items), batch_size):
+        yield items[start : start + batch_size]
+
+
+def prepare_schema(args: argparse.Namespace) -> None:
+    sql = f"""
+    CREATE DATABASE IF NOT EXISTS `{args.database}`;
+    DROP TABLE IF EXISTS `{args.database}`.`{args.table}`;
+    CREATE TABLE `{args.database}`.`{args.table}` (
+      id BIGINT PRIMARY KEY,
+      title_kw VARCHAR(64),
+      payload TEXT,
+      embedding VECTOR({VECTOR_DIM})
+    );
+    ALTER TABLE `{args.database}`.`{args.table}` SET TIFLASH REPLICA 1;
+    """
+    run_sql(args, sql)
+
+
+def wait_for_tiflash_replica(args: argparse.Namespace) -> None:
+    sql = f"""
+    SELECT AVAILABLE, PROGRESS
+    FROM information_schema.tiflash_replica
+    WHERE TABLE_SCHEMA = {sql_literal(args.database)}
+      AND TABLE_NAME = {sql_literal(args.table)};
+    """
+    deadline = time.time() + args.timeout
+    while time.time() < deadline:
+        try:
+            rows = query_rows(args, sql)
+        except RuntimeError:
+            rows = []
+        if rows and rows[0][0] == "1":
+            return
+        time.sleep(args.interval)
+    raise RuntimeError("TiFlash replica did not become available in time")
+
+
+def build_base_rows(row_count: int, rng: random.Random) -> List[Tuple[object, ...]]:
+    if row_count < 4:
+        raise ValueError("rows must be >= 4")
+
+    rows: List[Tuple[object, ...]] = [
+        (
+            BASE_ANCHOR_ID,
+            BASE_ANCHOR_TITLE,
+            "anchor_payload_hot",
+            vector_literal(one_hot(0)),
+        ),
+        (
+            2,
+            "anchor_title_other",
+            "anchor_payload_other",
+            vector_literal(one_hot(2)),
+        ),
+        (
+            3,
+            "anchor_title_extra",
+            "anchor_payload_extra",
+            vector_literal(one_hot(4)),
+        ),
+        (
+            4,
+            "anchor_title_filter",
+            "anchor_payload_filter",
+            vector_literal(one_hot(6)),
+        ),
+    ]
+
+    for row_id in range(5, row_count + 1):
+        rows.append(
+            (
+                row_id,
+                f"rand_title_{row_id:05d}",
+                f"rand_payload_{row_id:05d}",
+                vector_literal(random_vector(rng)),
+            )
+        )
+    return rows
+
+
+def insert_rows(
+    args: argparse.Namespace, rows: Sequence[Tuple[object, ...]], batch_size: int = 500
+) -> None:
+    for batch in batched(rows, batch_size):
+        values = ",\n".join(
+            f"({row_id}, {sql_literal(title_kw)}, {sql_literal(payload)}, {sql_literal(embedding)})"
+            for row_id, title_kw, payload, embedding in batch
+        )
+        sql = f"""
+        INSERT INTO `{args.database}`.`{args.table}`
+          (id, title_kw, payload, embedding)
+        VALUES
+        {values};
+        """
+        run_sql(args, sql)
+
+
+def create_hybrid_index(args: argparse.Namespace) -> None:
+    sql = f"""
+    CREATE HYBRID INDEX `{args.index_name}`
+    ON `{args.database}`.`{args.table}`(title_kw, embedding)
+    PARAMETER '{{
+      "inverted": {{
+        "columns": ["title_kw"]
+      }},
+      "vector": [{{
+        "columns": ["embedding"],
+        "index_info": {{
+          "distance_metric": "L2"
+        }}
+      }}],
+      "sharding_key": {{
+        "columns": ["title_kw"]
+      }}
+    }}';
+    """
+    run_sql(args, sql)
+
+
+def insert_delta_row(args: argparse.Namespace) -> None:
+    sql = f"""
+    INSERT INTO `{args.database}`.`{args.table}`
+      (id, title_kw, payload, embedding)
+    VALUES
+      (
+        {DELTA_ANCHOR_ID},
+        {sql_literal(DELTA_ANCHOR_TITLE)},
+        {sql_literal("delta_payload_hot")},
+        {sql_literal(vector_literal(one_hot(31)))}
+      )
+    ON DUPLICATE KEY UPDATE
+      title_kw = VALUES(title_kw),
+      payload = VALUES(payload),
+      embedding = VALUES(embedding);
+    """
+    run_sql(args, sql)
+
+
+def prepare(args: argparse.Namespace) -> None:
+    rng = random.Random(args.seed)
+    prepare_schema(args)
+    wait_for_tiflash_replica(args)
+    create_hybrid_index(args)
+    insert_rows(args, build_base_rows(args.rows, rng))
+    insert_delta_row(args)
+
+
+def vector_query_sql(args: argparse.Namespace, vector_index: int, limit: int = 3) -> str:
+    return (
+        f"SELECT id FROM `{args.database}`.`{args.table}` "
+        f"ORDER BY vec_l2_distance(embedding, {sql_literal(vector_literal(one_hot(vector_index)))}) "
+        f"LIMIT {limit};"
+    )
+
+
+def vector_explain_sql(args: argparse.Namespace, vector_index: int, limit: int = 3) -> str:
+    return (
+        f"EXPLAIN FORMAT='brief' SELECT id FROM `{args.database}`.`{args.table}` "
+        f"ORDER BY vec_l2_distance(embedding, {sql_literal(vector_literal(one_hot(vector_index)))}) "
+        f"LIMIT {limit};"
+    )
+
+
+def inverted_query_sql(args: argparse.Namespace, title: str) -> str:
+    return (
+        f"SELECT id FROM `{args.database}`.`{args.table}` USE INDEX (`{args.index_name}`) "
+        f"WHERE title_kw = {sql_literal(title)} ORDER BY id;"
+    )
+
+
+def explain_contains(args: argparse.Namespace, sql: str, needle: str) -> bool:
+    rows = query_rows(args, sql)
+    joined = "\n".join("\t".join(row) for row in rows)
+    return needle in joined
+
+
+def fetch_ids(args: argparse.Namespace, sql: str) -> List[int]:
+    rows = query_rows(args, sql)
+    return [int(row[0]) for row in rows]
+
+
+def wait_until(description: str, args: argparse.Namespace, fn) -> None:
+    deadline = time.time() + args.timeout
+    last_error = "no attempts made"
+    while time.time() < deadline:
+        try:
+            if fn():
+                return
+            last_error = "condition returned false"
+        except Exception as exc:  # noqa: BLE001
+            last_error = str(exc)
+        time.sleep(args.interval)
+    raise RuntimeError(f"timed out waiting for {description}: {last_error}")
+
+
+def verify(args: argparse.Namespace) -> None:
+    wait_until(
+        "base inverted anchor",
+        args,
+        lambda: fetch_ids(args, inverted_query_sql(args, BASE_ANCHOR_TITLE))
+        == [BASE_ANCHOR_ID],
+    )
+    wait_until(
+        "delta inverted anchor",
+        args,
+        lambda: fetch_ids(args, inverted_query_sql(args, DELTA_ANCHOR_TITLE))
+        == [DELTA_ANCHOR_ID],
+    )
+    wait_until(
+        "base vector top1",
+        args,
+        lambda: fetch_ids(args, vector_query_sql(args, 0, 1)) == [BASE_ANCHOR_ID],
+    )
+    wait_until(
+        "delta vector top1",
+        args,
+        lambda: fetch_ids(args, vector_query_sql(args, 31, 1)) == [DELTA_ANCHOR_ID],
+    )
+    wait_until(
+        "vector explain path",
+        args,
+        lambda: explain_contains(args, vector_explain_sql(args, 0, 3), "vector search")
+        and explain_contains(args, vector_explain_sql(args, 0, 3), args.index_name),
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    if args.command == "prepare":
+        prepare(args)
+        return
+    if args.command == "verify":
+        verify(args)
+        return
+    raise ValueError(f"unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integrationtest2/tici/hybrid_vector_e2e.py
+++ b/tests/integrationtest2/tici/hybrid_vector_e2e.py
@@ -287,10 +287,10 @@ def inverted_query_sql(args: argparse.Namespace, title: str) -> str:
     )
 
 
-def explain_contains(args: argparse.Namespace, sql: str, needle: str) -> bool:
+def explain_contains_all(args: argparse.Namespace, sql: str, needles: Sequence[str]) -> bool:
     rows = query_rows(args, sql)
     joined = "\n".join("\t".join(row) for row in rows)
-    return needle in joined
+    return all(needle in joined for needle in needles)
 
 
 def fetch_ids(args: argparse.Namespace, sql: str) -> List[int]:
@@ -338,8 +338,9 @@ def verify(args: argparse.Namespace) -> None:
     wait_until(
         "vector explain path",
         args,
-        lambda: explain_contains(args, vector_explain_sql(args, 0, 3), "vector search")
-        and explain_contains(args, vector_explain_sql(args, 0, 3), args.index_name),
+        lambda: explain_contains_all(
+            args, vector_explain_sql(args, 0, 3), ["vector search", args.index_name]
+        ),
     )
 
 

--- a/tests/integrationtest2/tici/hybrid_vector_e2e.py
+++ b/tests/integrationtest2/tici/hybrid_vector_e2e.py
@@ -32,13 +32,14 @@ DELTA_ANCHOR_TITLE = "post_index_anchor"
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("command", choices=["prepare", "verify", "recall"])
+    parser.add_argument("command", choices=["prepare", "verify", "recall", "bench"])
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=4000)
     parser.add_argument("--user", default="root")
     parser.add_argument("--password", default="")
     parser.add_argument("--database", default="test")
     parser.add_argument("--table", default="hybrid_vector_docs")
+    parser.add_argument("--bf-table", default="hybrid_vector_docs_bf")
     parser.add_argument("--index-name", default="idx_hybrid_vector")
     parser.add_argument("--rows", type=int, default=10_000)
     parser.add_argument("--seed", type=int, default=42)
@@ -51,6 +52,11 @@ def parse_args() -> argparse.Namespace:
         default="1,10,50",
         help="comma-separated K values for recall@K",
     )
+    parser.add_argument("--bench-queries", type=int, default=100, help="number of queries for bench")
+    parser.add_argument("--bench-k", type=int, default=10, help="top-K for bench queries")
+    parser.add_argument("--batch-size", type=int, default=0, help="INSERT batch size (0=auto)")
+    parser.add_argument("--hnsw-m", type=int, default=16, help="HNSW M (connectivity)")
+    parser.add_argument("--hnsw-ef-construction", type=int, default=200, help="HNSW ef_construction")
     return parser.parse_args()
 
 
@@ -105,14 +111,13 @@ def vector_literal(values: Sequence[float]) -> str:
     return "[" + ", ".join(f"{value:.6f}" for value in values) + "]"
 
 
-def one_hot(index: int, dim: int = VECTOR_DIM) -> List[float]:
-    values = [0.0] * dim
-    values[index] = 1.0
-    return values
-
-
 def random_vector(rng: random.Random, dim: int = VECTOR_DIM) -> List[float]:
     return [round(rng.uniform(0.2, 0.8), 6) for _ in range(dim)]
+
+
+def anchor_vector(seed: int, index: int, dim: int = VECTOR_DIM) -> List[float]:
+    """Deterministic in-distribution random vector for anchor rows."""
+    return random_vector(random.Random(seed * 1000 + index), dim)
 
 
 def batched(items: Sequence[Tuple[object, ...]], batch_size: int) -> Iterable[Sequence[Tuple[object, ...]]]:
@@ -131,6 +136,11 @@ def prepare_schema(args: argparse.Namespace) -> None:
       embedding VECTOR({VECTOR_DIM})
     );
     ALTER TABLE `{args.database}`.`{args.table}` SET TIFLASH REPLICA 1;
+    DROP TABLE IF EXISTS `{args.database}`.`{args.bf_table}`;
+    CREATE TABLE `{args.database}`.`{args.bf_table}` (
+      id BIGINT PRIMARY KEY,
+      embedding VECTOR({VECTOR_DIM})
+    );
     """
     run_sql(args, sql)
 
@@ -154,7 +164,7 @@ def wait_for_tiflash_replica(args: argparse.Namespace) -> None:
     raise RuntimeError("TiFlash replica did not become available in time")
 
 
-def build_base_rows(row_count: int, rng: random.Random) -> List[Tuple[object, ...]]:
+def build_base_rows(row_count: int, rng: random.Random, seed: int) -> List[Tuple[object, ...]]:
     if row_count < 4:
         raise ValueError("rows must be >= 4")
 
@@ -163,25 +173,25 @@ def build_base_rows(row_count: int, rng: random.Random) -> List[Tuple[object, ..
             BASE_ANCHOR_ID,
             BASE_ANCHOR_TITLE,
             "anchor_payload_hot",
-            vector_literal(one_hot(0)),
+            vector_literal(anchor_vector(seed, 0)),
         ),
         (
             2,
             "anchor_title_other",
             "anchor_payload_other",
-            vector_literal(one_hot(2)),
+            vector_literal(anchor_vector(seed, 1)),
         ),
         (
             3,
             "anchor_title_extra",
             "anchor_payload_extra",
-            vector_literal(one_hot(4)),
+            vector_literal(anchor_vector(seed, 2)),
         ),
         (
             4,
             "anchor_title_filter",
             "anchor_payload_filter",
-            vector_literal(one_hot(6)),
+            vector_literal(anchor_vector(seed, 3)),
         ),
     ]
 
@@ -214,6 +224,22 @@ def insert_rows(
         run_sql(args, sql)
 
 
+def insert_bf_rows(
+    args: argparse.Namespace, rows: Sequence[Tuple[object, ...]], batch_size: int = 500
+) -> None:
+    """Insert id + embedding into the brute-force table (no index)."""
+    for batch in batched(rows, batch_size):
+        values = ",\n".join(
+            f"({row_id}, {sql_literal(embedding)})"
+            for row_id, _title_kw, _payload, embedding in batch
+        )
+        sql = f"""
+        INSERT INTO `{args.database}`.`{args.bf_table}` (id, embedding)
+        VALUES {values};
+        """
+        run_sql(args, sql)
+
+
 def create_hybrid_index(args: argparse.Namespace) -> None:
     sql = f"""
     CREATE HYBRID INDEX `{args.index_name}`
@@ -225,7 +251,9 @@ def create_hybrid_index(args: argparse.Namespace) -> None:
       "vector": [{{
         "columns": ["embedding"],
         "index_info": {{
-          "distance_metric": "L2"
+          "distance_metric": "L2",
+          "hnsw_m": {args.hnsw_m},
+          "hnsw_ef_construction": {args.hnsw_ef_construction}
         }}
       }}],
       "sharding_key": {{
@@ -237,6 +265,7 @@ def create_hybrid_index(args: argparse.Namespace) -> None:
 
 
 def insert_delta_row(args: argparse.Namespace) -> None:
+    delta_vec = anchor_vector(args.seed, 4)
     sql = f"""
     INSERT INTO `{args.database}`.`{args.table}`
       (id, title_kw, payload, embedding)
@@ -245,7 +274,7 @@ def insert_delta_row(args: argparse.Namespace) -> None:
         {DELTA_ANCHOR_ID},
         {sql_literal(DELTA_ANCHOR_TITLE)},
         {sql_literal("delta_payload_hot")},
-        {sql_literal(vector_literal(one_hot(31)))}
+        {sql_literal(vector_literal(delta_vec))}
       )
     ON DUPLICATE KEY UPDATE
       title_kw = VALUES(title_kw),
@@ -255,27 +284,70 @@ def insert_delta_row(args: argparse.Namespace) -> None:
     run_sql(args, sql)
 
 
+def auto_batch_size(args: argparse.Namespace) -> int:
+    if args.batch_size > 0:
+        return args.batch_size
+    if args.rows >= 100_000:
+        return 5000
+    return 500
+
+
+def insert_delta_bf_row(args: argparse.Namespace) -> None:
+    delta_vec = anchor_vector(args.seed, 4)
+    sql = f"""
+    INSERT INTO `{args.database}`.`{args.bf_table}` (id, embedding)
+    VALUES ({DELTA_ANCHOR_ID}, {sql_literal(vector_literal(delta_vec))})
+    ON DUPLICATE KEY UPDATE embedding = VALUES(embedding);
+    """
+    run_sql(args, sql)
+
+
 def prepare(args: argparse.Namespace) -> None:
     rng = random.Random(args.seed)
+    batch_size = auto_batch_size(args)
+
+    t0 = time.time()
     prepare_schema(args)
     wait_for_tiflash_replica(args)
+    t_schema = time.time() - t0
+
+    t0 = time.time()
     create_hybrid_index(args)
-    insert_rows(args, build_base_rows(args.rows, rng))
+    t_index = time.time() - t0
+
+    rows = build_base_rows(args.rows, rng, args.seed)
+    t0 = time.time()
+    insert_rows(args, rows, batch_size=batch_size)
+    insert_bf_rows(args, rows, batch_size=batch_size)
+    t_insert = time.time() - t0
+
+    t0 = time.time()
     insert_delta_row(args)
+    insert_delta_bf_row(args)
+    t_delta = time.time() - t0
+
+    print(f"\nprepare summary ({args.rows} rows, batch_size={batch_size}):")
+    print(f"  schema + tiflash replica: {t_schema:.1f}s")
+    print(f"  create hybrid index:      {t_index:.1f}s")
+    print(f"  insert {args.rows} rows:       {t_insert:.1f}s ({args.rows / max(t_insert, 0.001):.0f} rows/s)")
+    print(f"  insert delta row:         {t_delta:.1f}s")
+    print(f"  total:                    {t_schema + t_index + t_insert + t_delta:.1f}s")
 
 
-def vector_query_sql(args: argparse.Namespace, vector_index: int, limit: int = 3) -> str:
+def vector_query_sql(args: argparse.Namespace, anchor_idx: int, limit: int = 3) -> str:
+    vec = anchor_vector(args.seed, anchor_idx)
     return (
         f"SELECT id FROM `{args.database}`.`{args.table}` "
-        f"ORDER BY vec_l2_distance(embedding, {sql_literal(vector_literal(one_hot(vector_index)))}) "
+        f"ORDER BY vec_l2_distance(embedding, {sql_literal(vector_literal(vec))}) "
         f"LIMIT {limit};"
     )
 
 
-def vector_explain_sql(args: argparse.Namespace, vector_index: int, limit: int = 3) -> str:
+def vector_explain_sql(args: argparse.Namespace, anchor_idx: int, limit: int = 3) -> str:
+    vec = anchor_vector(args.seed, anchor_idx)
     return (
         f"EXPLAIN FORMAT='brief' SELECT id FROM `{args.database}`.`{args.table}` "
-        f"ORDER BY vec_l2_distance(embedding, {sql_literal(vector_literal(one_hot(vector_index)))}) "
+        f"ORDER BY vec_l2_distance(embedding, {sql_literal(vector_literal(vec))}) "
         f"LIMIT {limit};"
     )
 
@@ -333,7 +405,7 @@ def verify(args: argparse.Namespace) -> None:
     wait_until(
         "delta vector top1",
         args,
-        lambda: fetch_ids(args, vector_query_sql(args, 31, 1)) == [DELTA_ANCHOR_ID],
+        lambda: fetch_ids(args, vector_query_sql(args, 4, 1)) == [DELTA_ANCHOR_ID],
     )
     wait_until(
         "vector explain path",
@@ -347,9 +419,9 @@ def verify(args: argparse.Namespace) -> None:
 def brute_force_topk_sql(
     args: argparse.Namespace, query_vec: List[float], k: int
 ) -> str:
-    """Brute-force top-K via TiKV table scan (USE INDEX() bypasses all indexes)."""
+    """Brute-force top-K via table scan on the no-index bf table."""
     return (
-        f"SELECT id FROM `{args.database}`.`{args.table}` USE INDEX() "
+        f"SELECT id FROM `{args.database}`.`{args.bf_table}` "
         f"ORDER BY vec_l2_distance(embedding, {sql_literal(vector_literal(query_vec))}) "
         f"LIMIT {k};"
     )
@@ -419,6 +491,88 @@ def recall(args: argparse.Namespace) -> None:
     print("recall test PASSED")
 
 
+def percentile(sorted_values: List[float], p: float) -> float:
+    idx = int(len(sorted_values) * p)
+    return sorted_values[min(idx, len(sorted_values) - 1)]
+
+
+def bench(args: argparse.Namespace) -> None:
+    k = args.bench_k
+    num_queries = args.bench_queries
+    rng = random.Random(args.seed + 2000)
+
+    query_vectors = [random_vector(rng) for _ in range(num_queries)]
+
+    print(f"bench: {num_queries} queries, top-{k}, {args.rows} rows, dim={VECTOR_DIM}")
+
+    # --- vector search via TiCI index ---
+    print("\nwarming up vector search (3 queries)...")
+    for qvec in query_vectors[:3]:
+        fetch_ids(args, tici_topk_sql(args, qvec, k))
+
+    print(f"running {num_queries} vector search queries...")
+    vec_latencies: List[float] = []
+    for qi, qvec in enumerate(query_vectors):
+        t0 = time.time()
+        fetch_ids(args, tici_topk_sql(args, qvec, k))
+        vec_latencies.append(time.time() - t0)
+        if (qi + 1) % 20 == 0:
+            print(f"  {qi + 1}/{num_queries}")
+
+    vec_latencies.sort()
+    vec_total = sum(vec_latencies)
+    print(f"\nvector search top-{k} latency ({num_queries} queries):")
+    print(f"  avg:  {vec_total / num_queries * 1000:.1f} ms")
+    print(f"  p50:  {percentile(vec_latencies, 0.50) * 1000:.1f} ms")
+    print(f"  p90:  {percentile(vec_latencies, 0.90) * 1000:.1f} ms")
+    print(f"  p99:  {percentile(vec_latencies, 0.99) * 1000:.1f} ms")
+    print(f"  min:  {vec_latencies[0] * 1000:.1f} ms")
+    print(f"  max:  {vec_latencies[-1] * 1000:.1f} ms")
+    print(f"  qps:  {num_queries / vec_total:.1f}")
+
+    # --- brute-force (TiKV table scan) for comparison ---
+    print(f"\nrunning {num_queries} brute-force queries (USE INDEX()) for comparison...")
+    bf_latencies: List[float] = []
+    for qi, qvec in enumerate(query_vectors):
+        t0 = time.time()
+        fetch_ids(args, brute_force_topk_sql(args, qvec, k))
+        bf_latencies.append(time.time() - t0)
+        if (qi + 1) % 20 == 0:
+            print(f"  {qi + 1}/{num_queries}")
+
+    bf_latencies.sort()
+    bf_total = sum(bf_latencies)
+    print(f"\nbrute-force top-{k} latency ({num_queries} queries):")
+    print(f"  avg:  {bf_total / num_queries * 1000:.1f} ms")
+    print(f"  p50:  {percentile(bf_latencies, 0.50) * 1000:.1f} ms")
+    print(f"  p90:  {percentile(bf_latencies, 0.90) * 1000:.1f} ms")
+    print(f"  p99:  {percentile(bf_latencies, 0.99) * 1000:.1f} ms")
+    print(f"  min:  {bf_latencies[0] * 1000:.1f} ms")
+    print(f"  max:  {bf_latencies[-1] * 1000:.1f} ms")
+    print(f"  qps:  {num_queries / bf_total:.1f}")
+
+    speedup = (bf_total / num_queries) / (vec_total / num_queries)
+    print(f"\nspeedup: {speedup:.1f}x (vector index vs brute-force)")
+
+    # --- inverted search ---
+    print(f"\nrunning {num_queries} inverted index queries...")
+    inv_titles = [f"rand_title_{rng.randint(5, args.rows):05d}" for _ in range(num_queries)]
+    inv_latencies: List[float] = []
+    for title in inv_titles:
+        t0 = time.time()
+        fetch_ids(args, inverted_query_sql(args, title))
+        inv_latencies.append(time.time() - t0)
+
+    inv_latencies.sort()
+    inv_total = sum(inv_latencies)
+    print(f"\ninverted search latency ({num_queries} queries):")
+    print(f"  avg:  {inv_total / num_queries * 1000:.1f} ms")
+    print(f"  p50:  {percentile(inv_latencies, 0.50) * 1000:.1f} ms")
+    print(f"  p90:  {percentile(inv_latencies, 0.90) * 1000:.1f} ms")
+    print(f"  p99:  {percentile(inv_latencies, 0.99) * 1000:.1f} ms")
+    print(f"  qps:  {num_queries / inv_total:.1f}")
+
+
 def main() -> None:
     args = parse_args()
     if args.command == "prepare":
@@ -429,6 +583,9 @@ def main() -> None:
         return
     if args.command == "recall":
         recall(args)
+        return
+    if args.command == "bench":
+        bench(args)
         return
     raise ValueError(f"unsupported command: {args.command}")
 

--- a/tests/integrationtest2/tici/hybrid_vector_e2e.py
+++ b/tests/integrationtest2/tici/hybrid_vector_e2e.py
@@ -32,7 +32,7 @@ DELTA_ANCHOR_TITLE = "post_index_anchor"
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("command", choices=["prepare", "verify"])
+    parser.add_argument("command", choices=["prepare", "verify", "recall"])
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=4000)
     parser.add_argument("--user", default="root")
@@ -44,6 +44,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--timeout", type=int, default=600)
     parser.add_argument("--interval", type=int, default=5)
+    parser.add_argument("--recall-queries", type=int, default=20, help="number of random query vectors for recall test")
+    parser.add_argument(
+        "--recall-k",
+        type=str,
+        default="1,10,50",
+        help="comma-separated K values for recall@K",
+    )
     return parser.parse_args()
 
 
@@ -336,6 +343,81 @@ def verify(args: argparse.Namespace) -> None:
     )
 
 
+def brute_force_topk_sql(
+    args: argparse.Namespace, query_vec: List[float], k: int
+) -> str:
+    """Brute-force top-K via TiKV table scan (USE INDEX() bypasses all indexes)."""
+    return (
+        f"SELECT id FROM `{args.database}`.`{args.table}` USE INDEX() "
+        f"ORDER BY vec_l2_distance(embedding, {sql_literal(vector_literal(query_vec))}) "
+        f"LIMIT {k};"
+    )
+
+
+def tici_topk_sql(
+    args: argparse.Namespace, query_vec: List[float], k: int
+) -> str:
+    """Top-K via TiCI hybrid vector index."""
+    return (
+        f"SELECT id FROM `{args.database}`.`{args.table}` "
+        f"ORDER BY vec_l2_distance(embedding, {sql_literal(vector_literal(query_vec))}) "
+        f"LIMIT {k};"
+    )
+
+
+def compute_recall(ground_truth: List[int], predicted: List[int], k: int) -> float:
+    gt_set = set(ground_truth[:k])
+    pred_set = set(predicted[:k])
+    if not gt_set:
+        return 1.0
+    return len(gt_set & pred_set) / len(gt_set)
+
+
+def recall(args: argparse.Namespace) -> None:
+    k_values = [int(x.strip()) for x in args.recall_k.split(",")]
+    max_k = max(k_values)
+    num_queries = args.recall_queries
+    rng = random.Random(args.seed + 1000)  # different seed from data generation
+
+    print(f"recall test: {num_queries} queries, K={k_values}, dim={VECTOR_DIM}")
+
+    query_vectors = [random_vector(rng) for _ in range(num_queries)]
+
+    results: dict[int, List[float]] = {k: [] for k in k_values}
+
+    for qi, qvec in enumerate(query_vectors):
+        gt_ids = fetch_ids(args, brute_force_topk_sql(args, qvec, max_k))
+        tici_ids = fetch_ids(args, tici_topk_sql(args, qvec, max_k))
+
+        for k in k_values:
+            r = compute_recall(gt_ids, tici_ids, k)
+            results[k].append(r)
+
+        if (qi + 1) % 5 == 0 or qi == 0:
+            print(f"  query {qi + 1}/{num_queries} done")
+
+    print()
+    all_pass = True
+    for k in k_values:
+        scores = results[k]
+        avg = sum(scores) / len(scores) if scores else 0.0
+        min_r = min(scores) if scores else 0.0
+        perfect = sum(1 for s in scores if s >= 1.0)
+        threshold = 0.80 if k <= 1 else 0.90
+        status = "PASS" if avg >= threshold else "FAIL"
+        if status == "FAIL":
+            all_pass = False
+        print(
+            f"  recall@{k:>3d}: avg={avg:.4f}  min={min_r:.4f}  "
+            f"perfect={perfect}/{len(scores)}  [{status}] (threshold={threshold:.2f})"
+        )
+
+    print()
+    if not all_pass:
+        raise RuntimeError("recall test FAILED: one or more K values below threshold")
+    print("recall test PASSED")
+
+
 def main() -> None:
     args = parse_args()
     if args.command == "prepare":
@@ -343,6 +425,9 @@ def main() -> None:
         return
     if args.command == "verify":
         verify(args)
+        return
+    if args.command == "recall":
+        recall(args)
         return
     raise ValueError(f"unsupported command: {args.command}")
 

--- a/tests/integrationtest2/tici/hybrid_vector_e2e.sh
+++ b/tests/integrationtest2/tici/hybrid_vector_e2e.sh
@@ -70,6 +70,8 @@ TIFLASH_ENGINE_VERSION=${TIFLASH_ENGINE_VERSION:-""}
 TIFLASH_ENGINE_GIT_HASH=${TIFLASH_ENGINE_GIT_HASH:-""}
 
 ROWS=${ROWS:-10000}
+HNSW_M=${HNSW_M:-16}
+HNSW_EF_CONSTRUCTION=${HNSW_EF_CONSTRUCTION:-200}
 WITHOUT_MONITOR=${WITHOUT_MONITOR:-1}
 REFRESH_TIUP_COMPONENTS=${REFRESH_TIUP_COMPONENTS:-1}
 
@@ -588,6 +590,8 @@ run_python_prepare() {
         --table hybrid_vector_docs \
         --index-name idx_hybrid_vector \
         --rows "${ROWS}" \
+        --hnsw-m "${HNSW_M}" \
+        --hnsw-ef-construction "${HNSW_EF_CONSTRUCTION}" \
         prepare
 }
 
@@ -615,6 +619,21 @@ run_python_recall() {
         --index-name idx_hybrid_vector \
         --rows "${ROWS}" \
         recall
+}
+
+run_python_bench() {
+    require_cmd python3
+    refresh_runtime_ports
+    python3 "${PYTHON_HELPER}" \
+        --host "${TIDB_HOST}" \
+        --port "${TIDB_PORT}" \
+        --database test \
+        --table hybrid_vector_docs \
+        --index-name idx_hybrid_vector \
+        --rows "${ROWS}" \
+        --bench-queries "${BENCH_QUERIES:-100}" \
+        --bench-k "${BENCH_K:-10}" \
+        bench
 }
 
 show_status() {
@@ -647,6 +666,7 @@ Commands:
   prepare   Prepare schema, create hybrid index, load data through CDC, and add delta data
   verify    Verify inverted/vector results and planner path
   recall    Run recall@K test (brute-force vs TiCI vector search)
+  bench     Run latency benchmark (vector search, brute-force, inverted)
   all       Run up + prepare + verify + recall
   status    Print TiUP status and playground display output
   down      Clean playground and stop the MinIO started by this script
@@ -686,6 +706,9 @@ main() {
             ;;
         recall)
             run_python_recall
+            ;;
+        bench)
+            run_python_bench
             ;;
         all)
             start_playground

--- a/tests/integrationtest2/tici/hybrid_vector_e2e.sh
+++ b/tests/integrationtest2/tici/hybrid_vector_e2e.sh
@@ -30,6 +30,10 @@ CHANGEFEED_INFO_FILE="${OUTPUT_ROOT}/playground-changefeed.json"
 
 PLAYGROUND_VERSION=${PLAYGROUND_VERSION:-"v1.16.2-feature.fts"}
 PLAYGROUND_TAG=${PLAYGROUND_TAG:-"hybrid-vector-e2e"}
+if [[ ! "${PLAYGROUND_TAG}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+    echo "ERROR: PLAYGROUND_TAG contains unsafe characters: ${PLAYGROUND_TAG}" >&2
+    exit 1
+fi
 PLAYGROUND_COMPONENT="playground:${PLAYGROUND_VERSION}"
 TIUP_MIRROR=${TIUP_MIRROR:-"http://tiup.pingcap.net:8988"}
 
@@ -201,14 +205,22 @@ wait_for_tiflash() {
     die "TiFlash did not register in time; see ${PLAYGROUND_LOG}"
 }
 
+platform_lib_ext() {
+    case "$(uname -s)" in
+        Darwin) printf 'dylib' ;;
+        *)      printf 'so' ;;
+    esac
+}
+
 resolve_search_lib_dir() {
-    local candidate
+    local ext candidate
+    ext=$(platform_lib_ext)
     for candidate in \
         "${TIFLASH_SEARCH_LIB_DIR}" \
         "${TIFLASH_SEARCH_LIB_DIR%/release}" \
         "$(dirname "${TIFLASH_BINPATH}")"
     do
-        if [ -n "${candidate}" ] && [ -f "${candidate}/libtici_search_lib.dylib" ]; then
+        if [ -n "${candidate}" ] && [ -f "${candidate}/libtici_search_lib.${ext}" ]; then
             printf '%s\n' "${candidate}"
             return 0
         fi
@@ -217,9 +229,10 @@ resolve_search_lib_dir() {
 }
 
 prepare_runtime_env() {
-    local search_lib_dir
-    search_lib_dir=$(resolve_search_lib_dir) || die "cannot find libtici_search_lib.dylib from ${TIFLASH_SEARCH_LIB_DIR}"
-    [ -f "${TIFLASH_PROXY_LIB_DIR}/libtiflash_proxy.dylib" ] || die "cannot find libtiflash_proxy.dylib in ${TIFLASH_PROXY_LIB_DIR}"
+    local ext search_lib_dir
+    ext=$(platform_lib_ext)
+    search_lib_dir=$(resolve_search_lib_dir) || die "cannot find libtici_search_lib.${ext} from ${TIFLASH_SEARCH_LIB_DIR}"
+    [ -f "${TIFLASH_PROXY_LIB_DIR}/libtiflash_proxy.${ext}" ] || die "cannot find libtiflash_proxy.${ext} in ${TIFLASH_PROXY_LIB_DIR}"
 
     if [ -n "${DYLD_LIBRARY_PATH:-}" ]; then
         export DYLD_LIBRARY_PATH="${search_lib_dir}:${TIFLASH_PROXY_LIB_DIR}:${DYLD_LIBRARY_PATH}"

--- a/tests/integrationtest2/tici/hybrid_vector_e2e.sh
+++ b/tests/integrationtest2/tici/hybrid_vector_e2e.sh
@@ -591,6 +591,19 @@ run_python_verify() {
         verify
 }
 
+run_python_recall() {
+    require_cmd python3
+    refresh_runtime_ports
+    python3 "${PYTHON_HELPER}" \
+        --host "${TIDB_HOST}" \
+        --port "${TIDB_PORT}" \
+        --database test \
+        --table hybrid_vector_docs \
+        --index-name idx_hybrid_vector \
+        --rows "${ROWS}" \
+        recall
+}
+
 show_status() {
     tiup status || true
     tiup "${PLAYGROUND_COMPONENT}" display --tag "${PLAYGROUND_TAG}" || true
@@ -620,7 +633,8 @@ Commands:
   up        Start MinIO, TiUP playground, and wait for the playground-managed TiCDC changefeed
   prepare   Prepare schema, create hybrid index, load data through CDC, and add delta data
   verify    Verify inverted/vector results and planner path
-  all       Run up + prepare + verify
+  recall    Run recall@K test (brute-force vs TiCI vector search)
+  all       Run up + prepare + verify + recall
   status    Print TiUP status and playground display output
   down      Clean playground and stop the MinIO started by this script
 
@@ -657,10 +671,14 @@ main() {
         verify)
             run_python_verify
             ;;
+        recall)
+            run_python_recall
+            ;;
         all)
             start_playground
             run_python_prepare
             run_python_verify
+            run_python_recall
             ;;
         status)
             show_status

--- a/tests/integrationtest2/tici/hybrid_vector_e2e.sh
+++ b/tests/integrationtest2/tici/hybrid_vector_e2e.sh
@@ -1,0 +1,681 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+TIDB_ROOT=$(cd "${SCRIPT_DIR}/../../.." && pwd)
+WORKSPACE_ROOT=$(cd "${TIDB_ROOT}/.." && pwd)
+PYTHON_HELPER="${SCRIPT_DIR}/hybrid_vector_e2e.py"
+
+OUTPUT_ROOT=${HYBRID_VECTOR_E2E_OUTPUT_ROOT:-"${SCRIPT_DIR}/output/hybrid-vector-e2e"}
+LOG_DIR="${OUTPUT_ROOT}/log"
+PLAYGROUND_LOG="${LOG_DIR}/playground.log"
+MINIO_LOG="${LOG_DIR}/minio.log"
+MINIO_PID_FILE="${OUTPUT_ROOT}/minio.pid"
+CHANGEFEED_INFO_FILE="${OUTPUT_ROOT}/playground-changefeed.json"
+
+PLAYGROUND_VERSION=${PLAYGROUND_VERSION:-"v1.16.2-feature.fts"}
+PLAYGROUND_TAG=${PLAYGROUND_TAG:-"hybrid-vector-e2e"}
+PLAYGROUND_COMPONENT="playground:${PLAYGROUND_VERSION}"
+TIUP_MIRROR=${TIUP_MIRROR:-"http://tiup.pingcap.net:8988"}
+
+TIDB_HOST=${TIDB_HOST:-"127.0.0.1"}
+PORT_OFFSET=${PORT_OFFSET:-20000}
+BASE_TIDB_PORT=${BASE_TIDB_PORT:-4000}
+BASE_PD_PORT=${BASE_PD_PORT:-2379}
+BASE_CDC_PORT=${BASE_CDC_PORT:-8300}
+BASE_MINIO_PORT=${BASE_MINIO_PORT:-9000}
+BASE_MINIO_CONSOLE_PORT=${BASE_MINIO_CONSOLE_PORT:-9001}
+TIDB_PORT=${TIDB_PORT:-$((BASE_TIDB_PORT + PORT_OFFSET))}
+PD_PORT=${PD_PORT:-$((BASE_PD_PORT + PORT_OFFSET))}
+CDC_PORT=${CDC_PORT:-$((BASE_CDC_PORT + PORT_OFFSET))}
+MINIO_PORT=${MINIO_PORT:-$((BASE_MINIO_PORT + PORT_OFFSET))}
+MINIO_CONSOLE_PORT=${MINIO_CONSOLE_PORT:-$((BASE_MINIO_CONSOLE_PORT + PORT_OFFSET))}
+
+S3_BUCKET=${S3_BUCKET:-"ticidefaultbucket"}
+S3_ACCESS_KEY=${S3_ACCESS_KEY:-"minioadmin"}
+S3_SECRET_KEY=${S3_SECRET_KEY:-"minioadmin"}
+S3_PREFIX=${S3_PREFIX:-"${PLAYGROUND_TAG}"}
+S3_ENDPOINT=${S3_ENDPOINT:-"http://127.0.0.1:${MINIO_PORT}"}
+
+TIDB_BINPATH=${TIDB_BINPATH:-"${TIDB_ROOT}/bin/tidb-server"}
+TIFLASH_REPO=${TIFLASH_REPO:-"${WORKSPACE_ROOT}/tiflash-fts"}
+TIFLASH_BINPATH=${TIFLASH_BINPATH:-"${TIFLASH_REPO}/cmake-build-codex-release/dbms/src/Server/tiflash"}
+TIFLASH_BUILD_DIR=${TIFLASH_BUILD_DIR:-"${TIFLASH_REPO}/cmake-build-codex-release"}
+TIFLASH_CONFIG_VERSION_HEADER=${TIFLASH_CONFIG_VERSION_HEADER:-"${TIFLASH_BUILD_DIR}/dbms/src/Common/config_version.h"}
+TIFLASH_SEARCH_LIB_DIR=${TIFLASH_SEARCH_LIB_DIR:-"${TIFLASH_REPO}/cmake-build-codex-release/contrib/tici-search-lib"}
+TIFLASH_PROXY_LIB_DIR=${TIFLASH_PROXY_LIB_DIR:-"${TIFLASH_REPO}/cmake-build-codex-release/contrib/tiflash-proxy-cmake/release"}
+TICI_REPO=${TICI_REPO:-"${WORKSPACE_ROOT}/tici"}
+TICI_BINPATH=${TICI_BINPATH:-"${TICI_REPO}/target/release/tici-server"}
+TICDC_BINPATH=${TICDC_BINPATH:-""}
+TIFLASH_ENGINE_VERSION=${TIFLASH_ENGINE_VERSION:-""}
+TIFLASH_ENGINE_GIT_HASH=${TIFLASH_ENGINE_GIT_HASH:-""}
+
+ROWS=${ROWS:-10000}
+WITHOUT_MONITOR=${WITHOUT_MONITOR:-1}
+REFRESH_TIUP_COMPONENTS=${REFRESH_TIUP_COMPONENTS:-1}
+
+log() {
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+die() {
+    printf '[%s] ERROR: %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >&2
+    exit 1
+}
+
+ensure_dirs() {
+    mkdir -p "${OUTPUT_ROOT}" "${LOG_DIR}"
+}
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+playground_data_dir() {
+    printf '%s\n' "${HOME}/.tiup/data/${PLAYGROUND_TAG}"
+}
+
+refresh_runtime_dsn() {
+    local dsn_file dsn parsed_host parsed_port
+
+    dsn_file="$(playground_data_dir)/dsn"
+    [ -f "${dsn_file}" ] || return 1
+
+    dsn=$(cat "${dsn_file}")
+    parsed_host=$(printf '%s\n' "${dsn}" | sed -n -E 's#mysql://[^@]+@([^:]+):([0-9]+).*#\1#p' | head -n 1)
+    parsed_port=$(printf '%s\n' "${dsn}" | sed -n -E 's#mysql://[^@]+@([^:]+):([0-9]+).*#\2#p' | head -n 1)
+    [ -n "${parsed_host}" ] || return 1
+    [ -n "${parsed_port}" ] || return 1
+
+    TIDB_HOST="${parsed_host}"
+    TIDB_PORT="${parsed_port}"
+    return 0
+}
+
+resolve_runtime_port_from_process() {
+    local role_dir=${1:-}
+    local port_flag=${2:-}
+    local pid cmd
+
+    [ -n "${role_dir}" ] || return 1
+    [ -n "${port_flag}" ] || return 1
+
+    pid=$(pgrep -f "$(playground_data_dir)/${role_dir}" | head -n 1 || true)
+    [ -n "${pid}" ] || return 1
+
+    cmd=$(ps -p "${pid}" -o command= 2>/dev/null || true)
+    [ -n "${cmd}" ] || return 1
+
+    printf '%s\n' "${cmd}" | sed -n -E "s#.*${port_flag}[^:]+:([0-9]+).*#\\1#p" | head -n 1
+}
+
+refresh_runtime_ports() {
+    local port
+
+    refresh_runtime_dsn >/dev/null 2>&1 || true
+
+    port=$(resolve_runtime_port_from_process "pd-0" "--client-urls=http://" || true)
+    if [ -n "${port}" ]; then
+        PD_PORT="${port}"
+    fi
+
+    port=$(resolve_runtime_port_from_process "cdc-0" "--addr=" || true)
+    if [ -n "${port}" ]; then
+        CDC_PORT="${port}"
+    fi
+}
+
+run_cdc_cli() {
+    if [ -n "${TICDC_BINPATH}" ]; then
+        "${TICDC_BINPATH}" cli "$@"
+    else
+        tiup cdc:nightly cli "$@"
+    fi
+}
+
+mysql_ready() {
+    mysql \
+        --host "${TIDB_HOST}" \
+        --port "${TIDB_PORT}" \
+        --user root \
+        --batch \
+        --raw \
+        --skip-column-names \
+        -e "select 1" >/dev/null 2>&1
+}
+
+wait_for_mysql() {
+    local attempts=${1:-60}
+    local interval=${2:-5}
+    local i
+
+    for ((i = 1; i <= attempts; i++)); do
+        refresh_runtime_ports
+        if mysql_ready; then
+            log "TiDB is ready on ${TIDB_HOST}:${TIDB_PORT}"
+            return 0
+        fi
+        sleep "${interval}"
+    done
+    die "TiDB did not become ready in time; see ${PLAYGROUND_LOG}"
+}
+
+wait_for_tiflash() {
+    local attempts=${1:-60}
+    local interval=${2:-5}
+    local sql="SELECT COUNT(*) FROM information_schema.cluster_info WHERE type='tiflash';"
+    local count
+    local i
+
+    for ((i = 1; i <= attempts; i++)); do
+        refresh_runtime_ports
+        count=$(mysql \
+            --host "${TIDB_HOST}" \
+            --port "${TIDB_PORT}" \
+            --user root \
+            --batch \
+            --raw \
+            --skip-column-names \
+            -e "${sql}" 2>/dev/null || true)
+        if [ "${count:-0}" -ge 1 ] 2>/dev/null; then
+            log "TiFlash is registered in TiDB"
+            return 0
+        fi
+        sleep "${interval}"
+    done
+    die "TiFlash did not register in time; see ${PLAYGROUND_LOG}"
+}
+
+resolve_search_lib_dir() {
+    local candidate
+    for candidate in \
+        "${TIFLASH_SEARCH_LIB_DIR}" \
+        "${TIFLASH_SEARCH_LIB_DIR%/release}" \
+        "$(dirname "${TIFLASH_BINPATH}")"
+    do
+        if [ -n "${candidate}" ] && [ -f "${candidate}/libtici_search_lib.dylib" ]; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+prepare_runtime_env() {
+    local search_lib_dir
+    search_lib_dir=$(resolve_search_lib_dir) || die "cannot find libtici_search_lib.dylib from ${TIFLASH_SEARCH_LIB_DIR}"
+    [ -f "${TIFLASH_PROXY_LIB_DIR}/libtiflash_proxy.dylib" ] || die "cannot find libtiflash_proxy.dylib in ${TIFLASH_PROXY_LIB_DIR}"
+
+    if [ -n "${DYLD_LIBRARY_PATH:-}" ]; then
+        export DYLD_LIBRARY_PATH="${search_lib_dir}:${TIFLASH_PROXY_LIB_DIR}:${DYLD_LIBRARY_PATH}"
+    else
+        export DYLD_LIBRARY_PATH="${search_lib_dir}:${TIFLASH_PROXY_LIB_DIR}"
+    fi
+
+    if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+        export LD_LIBRARY_PATH="${search_lib_dir}:${TIFLASH_PROXY_LIB_DIR}:${LD_LIBRARY_PATH}"
+    else
+        export LD_LIBRARY_PATH="${search_lib_dir}:${TIFLASH_PROXY_LIB_DIR}"
+    fi
+}
+
+resolve_tiflash_engine_version() {
+    if [ -n "${TIFLASH_ENGINE_VERSION}" ]; then
+        printf '%s\n' "${TIFLASH_ENGINE_VERSION}"
+        return 0
+    fi
+    if [ -f "${TIFLASH_CONFIG_VERSION_HEADER}" ]; then
+        sed -n 's/^#define TIFLASH_VERSION "\(.*\)"/\1/p' "${TIFLASH_CONFIG_VERSION_HEADER}" | head -n 1
+        return 0
+    fi
+    if [ -d "${TIFLASH_REPO}" ]; then
+        git -C "${TIFLASH_REPO}" describe --tags --always 2>/dev/null | sed 's/^v//'
+        return 0
+    fi
+    return 1
+}
+
+resolve_tiflash_engine_git_hash() {
+    if [ -n "${TIFLASH_ENGINE_GIT_HASH}" ]; then
+        printf '%s\n' "${TIFLASH_ENGINE_GIT_HASH}"
+        return 0
+    fi
+    if [ -f "${TIFLASH_CONFIG_VERSION_HEADER}" ]; then
+        sed -n 's/^#define TIFLASH_GIT_HASH "\(.*\)"/\1/p' "${TIFLASH_CONFIG_VERSION_HEADER}" | head -n 1
+        return 0
+    fi
+    if [ -d "${TIFLASH_REPO}" ]; then
+        git -C "${TIFLASH_REPO}" rev-parse HEAD 2>/dev/null
+        return 0
+    fi
+    return 1
+}
+
+prepare_tiflash_binpath() {
+    local engine_version=${1:-}
+    local local_version="v0.0.0-local"
+    local patched_binpath
+
+    if [ -z "${engine_version}" ]; then
+        printf '%s\n' "${TIFLASH_BINPATH}"
+        return 0
+    fi
+
+    if ! grep -Fq "${local_version}" < <(strings "${TIFLASH_BINPATH}" 2>/dev/null); then
+        printf '%s\n' "${TIFLASH_BINPATH}"
+        return 0
+    fi
+
+    if [ "${#engine_version}" -ne "${#local_version}" ]; then
+        die "cannot patch TiFlash version string ${local_version} -> ${engine_version}: length mismatch"
+    fi
+
+    require_cmd perl
+    patched_binpath="${OUTPUT_ROOT}/tiflash-patched"
+    cp "${TIFLASH_BINPATH}" "${patched_binpath}"
+    SOURCE_VERSION="${local_version}" TARGET_VERSION="${engine_version}" \
+        perl -0pi -e 's/\Q$ENV{SOURCE_VERSION}\E/$ENV{TARGET_VERSION}/g' "${patched_binpath}"
+
+    if ! grep -Fq "${engine_version}" < <(strings "${patched_binpath}" 2>/dev/null); then
+        die "failed to patch TiFlash binary version string to ${engine_version}"
+    fi
+
+    if [ "$(uname -s)" = "Darwin" ]; then
+        require_cmd codesign
+        codesign -f -s - "${patched_binpath}" >/dev/null
+    fi
+
+    log "patched TiFlash binary version string ${local_version} -> ${engine_version}" >&2
+    printf '%s\n' "${patched_binpath}"
+}
+
+prepare_tiflash_launcher() {
+    local tiflash_binpath=${1:-}
+    local engine_version=${2:-}
+    local engine_git_hash=${3:-}
+    local wrapper wrapper_log
+
+    if [ -z "${tiflash_binpath}" ]; then
+        printf '%s\n' "${TIFLASH_BINPATH}"
+        return 0
+    fi
+
+    if [ -z "${engine_version}" ] || [ -z "${engine_git_hash}" ]; then
+        printf '%s\n' "${tiflash_binpath}"
+        return 0
+    fi
+
+    wrapper="${OUTPUT_ROOT}/tiflash-launcher.sh"
+    wrapper_log="${OUTPUT_ROOT}/tiflash-launcher.args.log"
+    cat > "${wrapper}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+{
+    printf '[%s] ' "\$(date '+%Y-%m-%d %H:%M:%S')"
+    printf '%q ' "${tiflash_binpath}" "\$@" --engine-version "${engine_version}" --engine-git-hash "${engine_git_hash}"
+    printf '\n'
+} >> "${wrapper_log}"
+exec "${tiflash_binpath}" "\$@" --engine-version "${engine_version}" --engine-git-hash "${engine_git_hash}"
+EOF
+    chmod +x "${wrapper}"
+    log "wrapping TiFlash ${tiflash_binpath} with engine-version=${engine_version} engine-git-hash=${engine_git_hash}" >&2
+    printf '%s\n' "${wrapper}"
+}
+
+build_tici_if_needed() {
+    if [ -x "${TICI_BINPATH}" ]; then
+        return 0
+    fi
+    [ -d "${TICI_REPO}" ] || die "TICI_REPO does not exist: ${TICI_REPO}"
+    log "building tici-server in ${TICI_REPO}"
+    (
+        cd "${TICI_REPO}"
+        make release
+    )
+    [ -x "${TICI_BINPATH}" ] || die "tici-server still missing after build: ${TICI_BINPATH}"
+}
+
+ensure_minio() {
+    ensure_dirs
+
+    if mc alias set localminio "http://127.0.0.1:${MINIO_PORT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}" >/dev/null 2>&1; then
+        :
+    else
+        log "starting local MinIO on ${MINIO_PORT}"
+        nohup minio server "${OUTPUT_ROOT}/minio-data" \
+            --address ":${MINIO_PORT}" \
+            --console-address ":${MINIO_CONSOLE_PORT}" \
+            > "${MINIO_LOG}" 2>&1 &
+        echo $! > "${MINIO_PID_FILE}"
+
+        local i
+        for ((i = 1; i <= 30; i++)); do
+            if mc alias set localminio "http://127.0.0.1:${MINIO_PORT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}" >/dev/null 2>&1; then
+                break
+            fi
+            sleep 2
+        done
+        mc alias set localminio "http://127.0.0.1:${MINIO_PORT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}" >/dev/null 2>&1 \
+            || die "failed to start or connect to MinIO; see ${MINIO_LOG}"
+    fi
+
+    if ! mc ls "localminio/${S3_BUCKET}" >/dev/null 2>&1; then
+        mc mb "localminio/${S3_BUCKET}" >/dev/null
+    fi
+    mc rm --recursive --force "localminio/${S3_BUCKET}/${S3_PREFIX}" >/dev/null 2>&1 || true
+}
+
+ensure_tiup_components() {
+    local playground_component_dir cdc_component_dir
+
+    log "using TiUP mirror ${TIUP_MIRROR}"
+    tiup mirror set "${TIUP_MIRROR}" >/dev/null
+    if [ "${REFRESH_TIUP_COMPONENTS}" = "1" ]; then
+        playground_component_dir="${HOME}/.tiup/components/playground/${PLAYGROUND_VERSION}"
+        cdc_component_dir="${HOME}/.tiup/components/cdc/nightly"
+        log "refreshing TiUP components for ${PLAYGROUND_COMPONENT} and cdc:nightly"
+        rm -rf "${playground_component_dir}" "${cdc_component_dir}"
+    fi
+    tiup install "${PLAYGROUND_COMPONENT}" >/dev/null
+    if [ -z "${TICDC_BINPATH}" ]; then
+        tiup install "cdc:nightly" >/dev/null
+    fi
+}
+
+cleanup_previous_playground() {
+    local playground_data_dir="${HOME}/.tiup/data/${PLAYGROUND_TAG}"
+
+    pkill -f "tiup playground:.*--tag ${PLAYGROUND_TAG}" >/dev/null 2>&1 || true
+    pkill -f "tiup-playground .*--tag ${PLAYGROUND_TAG}" >/dev/null 2>&1 || true
+    if [ -d "${playground_data_dir}" ]; then
+        pkill -f "${playground_data_dir}" >/dev/null 2>&1 || true
+    fi
+    tiup clean "${PLAYGROUND_TAG}" >/dev/null 2>&1 || true
+    if [ -d "${playground_data_dir}" ]; then
+        rm -rf "${playground_data_dir}"
+    fi
+}
+
+start_playground() {
+    ensure_dirs
+    require_cmd tiup
+    require_cmd mysql
+    require_cmd minio
+    require_cmd mc
+    require_cmd python3
+
+    [ -x "${TIDB_BINPATH}" ] || die "tidb-server not found: ${TIDB_BINPATH}"
+    [ -x "${TIFLASH_BINPATH}" ] || die "tiflash not found: ${TIFLASH_BINPATH}"
+    [ -f "${PYTHON_HELPER}" ] || die "python helper not found: ${PYTHON_HELPER}"
+
+    build_tici_if_needed
+    prepare_runtime_env
+    ensure_minio
+    ensure_tiup_components
+    cleanup_previous_playground
+
+    local engine_version engine_git_hash effective_tiflash_binpath tiflash_launcher_binpath
+    engine_version=$(resolve_tiflash_engine_version || true)
+    engine_git_hash=$(resolve_tiflash_engine_git_hash || true)
+    effective_tiflash_binpath=$(prepare_tiflash_binpath "${engine_version}")
+    tiflash_launcher_binpath=$(prepare_tiflash_launcher "${effective_tiflash_binpath}" "${engine_version}" "${engine_git_hash}")
+
+    local args=(
+        "--mode" "tidb-fts"
+        "--tag" "${PLAYGROUND_TAG}"
+        "--host" "${TIDB_HOST}"
+        "--db" "1"
+        "--db.host" "${TIDB_HOST}"
+        "--db.port" "${TIDB_PORT}"
+        "--tiflash" "1"
+        "--ticdc" "1"
+        "--ticdc.host" "${TIDB_HOST}"
+        "--ticdc.port" "${CDC_PORT}"
+        "--pd" "1"
+        "--pd.host" "${TIDB_HOST}"
+        "--pd.port" "${PD_PORT}"
+        "--tici.worker" "1"
+        "--port-offset" "${PORT_OFFSET}"
+        "--s3.bucket" "${S3_BUCKET}"
+        "--s3.endpoint" "${S3_ENDPOINT}"
+        "--s3.access_key" "${S3_ACCESS_KEY}"
+        "--s3.secret_key" "${S3_SECRET_KEY}"
+        "--db.binpath" "${TIDB_BINPATH}"
+        "--tiflash.binpath" "${tiflash_launcher_binpath}"
+        "--tici.binpath" "${TICI_BINPATH}"
+    )
+
+    if [ -n "${TICDC_BINPATH}" ]; then
+        args+=("--ticdc.binpath" "${TICDC_BINPATH}")
+    fi
+    if [ "${WITHOUT_MONITOR}" = "1" ]; then
+        args+=("--without-monitor")
+    fi
+
+    log "starting playground ${PLAYGROUND_COMPONENT} with tag ${PLAYGROUND_TAG}"
+    nohup env \
+        TICDC_NEWARCH=true \
+        DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-}" \
+        LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}" \
+        tiup "${PLAYGROUND_COMPONENT}" "${args[@]}" \
+        > "${PLAYGROUND_LOG}" 2>&1 &
+
+    wait_for_mysql
+    wait_for_tiflash
+    wait_for_playground_changefeed
+}
+
+discover_playground_changefeed() {
+    local server_addr=${1:-}
+    local expected_prefix=${2:-}
+    local list_output ids id query_output
+
+    [ -n "${server_addr}" ] || return 1
+    [ -n "${expected_prefix}" ] || return 1
+
+    list_output=$(run_cdc_cli changefeed list --server="${server_addr}" 2>/dev/null) || return 1
+    ids=$(printf '%s' "${list_output}" | python3 -c '
+import json
+import sys
+
+feeds = json.load(sys.stdin)
+for feed in feeds:
+    print(feed.get("id", ""))
+')
+    [ -n "${ids}" ] || return 1
+
+    for id in ${ids}; do
+        [ -n "${id}" ] || continue
+        query_output=$(run_cdc_cli changefeed query --server="${server_addr}" --changefeed-id="${id}" 2>/dev/null) || continue
+        if printf '%s' "${query_output}" | EXPECTED_PREFIX="${expected_prefix}" python3 -c '
+import json
+import os
+import sys
+
+data = json.load(sys.stdin)
+sink_uri = data.get("sink_uri", "")
+state = data.get("state", "")
+date_separator = data.get("config", {}).get("sink", {}).get("date_separator", "")
+expected_prefix = os.environ["EXPECTED_PREFIX"]
+
+if not sink_uri.startswith(expected_prefix):
+    sys.exit(1)
+if "use-table-id-as-path=true" not in sink_uri:
+    sys.exit(1)
+if state != "normal":
+    sys.exit(1)
+
+json.dump(
+    {
+        "id": data.get("id", ""),
+        "state": state,
+        "sink_uri": sink_uri,
+        "date_separator": date_separator,
+        "creator_version": data.get("creator_version", ""),
+    },
+    sys.stdout,
+)
+' > "${CHANGEFEED_INFO_FILE}.tmp"; then
+            mv "${CHANGEFEED_INFO_FILE}.tmp" "${CHANGEFEED_INFO_FILE}"
+            return 0
+        fi
+        rm -f "${CHANGEFEED_INFO_FILE}.tmp"
+    done
+    return 1
+}
+
+wait_for_playground_changefeed() {
+    local i
+    local server_addr expected_prefix changefeed_id sink_uri date_separator creator_version
+
+    refresh_runtime_ports
+    server_addr="http://127.0.0.1:${CDC_PORT}"
+    expected_prefix="s3://${S3_BUCKET}/${S3_PREFIX}/cdc"
+
+    for ((i = 1; i <= 30; i++)); do
+        if discover_playground_changefeed "${server_addr}" "${expected_prefix}"; then
+            changefeed_id=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["id"])' "${CHANGEFEED_INFO_FILE}")
+            sink_uri=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["sink_uri"])' "${CHANGEFEED_INFO_FILE}")
+            date_separator=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("date_separator", ""))' "${CHANGEFEED_INFO_FILE}")
+            creator_version=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("creator_version", ""))' "${CHANGEFEED_INFO_FILE}")
+            log "using playground-managed changefeed ${changefeed_id}"
+            log "changefeed sink: ${sink_uri}"
+            log "changefeed date_separator=${date_separator:-<unknown>} creator_version=${creator_version:-<unknown>}"
+            return 0
+        fi
+        sleep 2
+    done
+    run_cdc_cli changefeed list --server="${server_addr}" >/dev/null 2>&1 \
+        || die "TiCDC is not ready on port ${CDC_PORT}"
+    die "playground-managed changefeed was not ready or did not match ${expected_prefix}; see ${PLAYGROUND_LOG}"
+}
+
+run_python_prepare() {
+    require_cmd python3
+    refresh_runtime_ports
+    python3 "${PYTHON_HELPER}" \
+        --host "${TIDB_HOST}" \
+        --port "${TIDB_PORT}" \
+        --database test \
+        --table hybrid_vector_docs \
+        --index-name idx_hybrid_vector \
+        --rows "${ROWS}" \
+        prepare
+}
+
+run_python_verify() {
+    require_cmd python3
+    refresh_runtime_ports
+    python3 "${PYTHON_HELPER}" \
+        --host "${TIDB_HOST}" \
+        --port "${TIDB_PORT}" \
+        --database test \
+        --table hybrid_vector_docs \
+        --index-name idx_hybrid_vector \
+        --rows "${ROWS}" \
+        verify
+}
+
+show_status() {
+    tiup status || true
+    tiup "${PLAYGROUND_COMPONENT}" display --tag "${PLAYGROUND_TAG}" || true
+}
+
+stop_minio_if_owned() {
+    if [ -f "${MINIO_PID_FILE}" ]; then
+        local pid
+        pid=$(cat "${MINIO_PID_FILE}" 2>/dev/null || true)
+        if [ -n "${pid}" ] && kill -0 "${pid}" >/dev/null 2>&1; then
+            kill "${pid}" >/dev/null 2>&1 || true
+        fi
+        rm -f "${MINIO_PID_FILE}"
+    fi
+}
+
+down() {
+    cleanup_previous_playground
+    stop_minio_if_owned
+}
+
+usage() {
+    cat <<EOF
+Usage: $0 <command>
+
+Commands:
+  up        Start MinIO, TiUP playground, and wait for the playground-managed TiCDC changefeed
+  prepare   Prepare schema, create hybrid index, load data through CDC, and add delta data
+  verify    Verify inverted/vector results and planner path
+  all       Run up + prepare + verify
+  status    Print TiUP status and playground display output
+  down      Clean playground and stop the MinIO started by this script
+
+Common env overrides:
+  PLAYGROUND_VERSION=${PLAYGROUND_VERSION}
+  PLAYGROUND_TAG=${PLAYGROUND_TAG}
+  TIDB_BINPATH=${TIDB_BINPATH}
+  TIFLASH_BINPATH=${TIFLASH_BINPATH}
+  TICI_BINPATH=${TICI_BINPATH}
+  TICDC_BINPATH=${TICDC_BINPATH:-<empty>}
+  PORT_OFFSET=${PORT_OFFSET}
+  TIDB_PORT=${TIDB_PORT}
+  PD_PORT=${PD_PORT}
+  CDC_PORT=${CDC_PORT}
+  MINIO_PORT=${MINIO_PORT}
+  S3_ENDPOINT=${S3_ENDPOINT}
+  TIFLASH_ENGINE_VERSION=${TIFLASH_ENGINE_VERSION:-<auto>}
+  TIFLASH_ENGINE_GIT_HASH=${TIFLASH_ENGINE_GIT_HASH:-<auto>}
+  TIFLASH_SEARCH_LIB_DIR=${TIFLASH_SEARCH_LIB_DIR}
+  TIFLASH_PROXY_LIB_DIR=${TIFLASH_PROXY_LIB_DIR}
+  ROWS=${ROWS}
+EOF
+}
+
+main() {
+    local command=${1:-}
+    case "${command}" in
+        up)
+            start_playground
+            ;;
+        prepare)
+            run_python_prepare
+            ;;
+        verify)
+            run_python_verify
+            ;;
+        all)
+            start_playground
+            run_python_prepare
+            run_python_verify
+            ;;
+        status)
+            show_status
+            ;;
+        down)
+            down
+            ;;
+        help|-h|--help|"")
+            usage
+            ;;
+        *)
+            usage
+            die "unknown command: ${command}"
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a local hybrid-vector e2e helper under tests/integrationtest2/tici
- reuse the playground-managed changefeed instead of creating a second feed manually
- document the local validation flow and current CDC-only limitation

## Validation
- bash -n tests/integrationtest2/tici/hybrid_vector_e2e.sh
- python3 -m py_compile tests/integrationtest2/tici/hybrid_vector_e2e.py
- PLAYGROUND_TAG=hybrid-vector-e2e-20260320g REFRESH_TIUP_COMPONENTS=1 TICI_BINPATH=/Users/jin/Desktop/tici/target/release/tici-server ./hybrid_vector_e2e.sh all


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end hybrid vector integration tests with prepare, verify, recall and bench flows, automated data setup, vector/inverted queries, recall@K validation and performance measurements.
  * Includes readiness polling and failure surfacing for end-to-end verification.

* **Chores**
  * Added orchestration to provision and validate TiDB/TiFlash/TiCDC and local MinIO for full e2e runs, plus start/stop/status helpers.

* **Documentation**
  * Added a detailed how-to covering test commands, prerequisites, environment overrides, example artifact downloads, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->