### PR TITLE
br/backup: reject future timestamps in --backupts

### DIFF
--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -467,6 +467,18 @@ func (bc *Client) GetTS(ctx context.Context, duration time.Duration, ts uint64) 
 	}
 	if ts > 0 {
 		backupTS = ts
+		// check that the user-specified backup ts is not in the future
+		p, l, err := bc.mgr.GetPDClient().GetTS(ctx)
+		if err != nil {
+			return 0, errors.Trace(err)
+		}
+		currentTS := oracle.ComposeTS(p, l)
+		if backupTS > currentTS {
+			return 0, errors.Annotatef(berrors.ErrInvalidArgument,
+				"backup timestamp %d(%s) must not be later than current timestamp %d(%s)",
+				backupTS, oracle.GetTimeFromTS(backupTS),
+				currentTS, oracle.GetTimeFromTS(currentTS))
+		}
 	} else {
 		p, l, err := bc.mgr.GetPDClient().GetTS(ctx)
 		if err != nil {

--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -189,10 +189,18 @@ func TestGetTS(t *testing.T) {
 	require.Regexp(t, ".*GC safepoint [0-9]+ exceed TS [0-9]+.*", err.Error())
 
 	// timeago and backupts both exists, use backupts
-	backupts := oracle.ComposeTS(p+10, l)
+	p2, l2, err := s.mockPDClient.GetTS(s.ctx)
+	require.NoError(t, err)
+	backupts := oracle.ComposeTS(p2, l2)
 	ts, err = s.backupClient.GetTS(s.ctx, time.Minute, backupts)
 	require.NoError(t, err)
 	require.Equal(t, backupts, ts)
+
+	// backupts in the future should be rejected
+	futureTS := oracle.ComposeTS(time.Now().UnixMilli()+60*1000, 0) // 1 minute in the future
+	_, err = s.backupClient.GetTS(s.ctx, 0, futureTS)
+	require.Error(t, err)
+	require.Regexp(t, ".*must not be later than current timestamp.*", err.Error())
 }
 
 func TestGetHistoryDDLJobs(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #66280, ref #66279

Problem Summary:

BR's `--backupts` flag accepts future timestamps without any validation. Users can specify a timestamp like `2099-12-31 23:59:59` and BR will proceed without error, which is semantically invalid since point-in-time backup should only work for past timestamps.

### What changed and how does it work?

Added future timestamp validation in `GetTS()` (`br/pkg/backup/client.go`). When a user specifies `--backupts`, the function now fetches the current TSO from PD and rejects the backup if the specified timestamp is later than the current time.

This follows the same pattern used by `adjustAndCheckStartTS()` in `br/pkg/task/stream.go` for log backup start timestamp validation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to prevent backup timestamps from being set to a future time. The system now rejects any timestamp that exceeds the cluster's current time with an appropriate error message.

* **Tests**
  * Updated test coverage to verify the new timestamp validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->