### PR TITLE
ddl: fix BDR check rejecting ADD COLUMN with NULL DEFAULT NULL

### DIFF
--- a/pkg/ddl/bdr.go
+++ b/pkg/ddl/bdr.go
@@ -47,7 +47,7 @@ func deniedByBDRWhenAddColumn(options []*ast.ColumnOption) bool {
 	tpLen := len(options) - comment - generated
 
 	if tpLen == 0 || (tpLen == 1 && nullable) || (tpLen == 1 && !notNull && defaultValue) ||
-		(tpLen == 2 && notNull && defaultValue) {
+		(tpLen == 2 && notNull && defaultValue) || (tpLen == 2 && nullable && defaultValue) {
 		return false
 	}
 

--- a/pkg/ddl/bdr_test.go
+++ b/pkg/ddl/bdr_test.go
@@ -68,6 +68,11 @@ func TestDeniedByBDRWhenAddColumn(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "Test with explicit nullable and defaultValue options (NULL DEFAULT NULL)",
+			options:  []*ast.ColumnOption{{Tp: ast.ColumnOptionNull}, {Tp: ast.ColumnOptionDefaultValue}},
+			expected: false,
+		},
+		{
 			name:     "Test with other options",
 			options:  []*ast.ColumnOption{{Tp: ast.ColumnOptionCheck}},
 			expected: true,


### PR DESCRIPTION
The deniedByBDRWhenAddColumn function was missing the case where both NULL and DEFAULT NULL are specified explicitly. Since NULL DEFAULT NULL is semantically identical to just NULL, it should be allowed on primary BDR clusters.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: Close #67185

Problem Summary: BDR primary role rejects ADD COLUMN with explicit NULL DEFAULT NULL

### What changed and how does it work?

The deniedByBDRWhenAddColumn function was missing the case where both NULL and DEFAULT NULL are specified explicitly. Since NULL DEFAULT NULL is semantically identical to just NULL, it should be allowed on primary BDR clusters.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

Fix tidb node with BDR primary role rejects ADD COLUMN with explicit NULL DEFAULT NULL

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected DDL replication behavior when adding columns with both nullable and default value constraints.

* **Tests**
  * Added test coverage for nullable columns with default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->