### PR TITLE
expression: add evalString functions which converts specific types to string

### DIFF
--- a/pkg/expression/BUILD.bazel
+++ b/pkg/expression/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "builtin_compare_vec.go",
         "builtin_compare_vec_generated.go",
         "builtin_control.go",
+        "builtin_control_vec.go",
         "builtin_control_vec_generated.go",
         "builtin_convert_charset.go",
         "builtin_encryption.go",

--- a/pkg/expression/builtin_control_vec.go
+++ b/pkg/expression/builtin_control_vec.go
@@ -81,13 +81,18 @@ func (b *builtinCaseWhenRealSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	result.ReserveString(n)
 	f64s := buf.Float64s()
 
+	bits := 64
+	if b.tp.GetType() == mysql.TypeFloat {
+		bits = 32
+	}
+
 	for i := range n {
 		if buf.IsNull(i) {
 			result.AppendNull()
 			continue
 		}
 
-		str := strconv.FormatFloat(f64s[i], 'f', -1, 64)
+		str := strconv.FormatFloat(f64s[i], 'f', -1, bits)
 		result.AppendString(str)
 	}
 	return nil

--- a/pkg/expression/builtin_control_vec.go
+++ b/pkg/expression/builtin_control_vec.go
@@ -1,0 +1,119 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression
+
+import (
+	"strconv"
+
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
+)
+
+func (b *builtinCaseWhenIntSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get()
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.vecEvalInt(ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	i64s := buf.Int64s()
+	tp := b.tp
+	isUnsigned := mysql.HasUnsignedFlag(tp.GetFlag())
+	isBitType := tp.GetType() == mysql.TypeBit
+	isYearType := tp.GetType() == mysql.TypeYear
+
+	for i := range n {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+
+		var str string
+		if isBitType {
+			// For BIT type, convert to binary string representation
+			byteSize := (tp.GetFlen() + 7) / 8
+			bl := types.NewBinaryLiteralFromUint(uint64(i64s[i]), byteSize)
+			str = bl.ToString()
+		} else if !isUnsigned {
+			str = strconv.FormatInt(i64s[i], 10)
+		} else {
+			str = strconv.FormatUint(uint64(i64s[i]), 10)
+		}
+
+		if isYearType && str == "0" {
+			str = "0000"
+		}
+
+		result.AppendString(str)
+	}
+	return nil
+}
+
+func (b *builtinCaseWhenRealSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get()
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.vecEvalReal(ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	f64s := buf.Float64s()
+
+	for i := range n {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+
+		str := strconv.FormatFloat(f64s[i], 'f', -1, 64)
+		result.AppendString(str)
+	}
+	return nil
+}
+
+func (b *builtinCaseWhenDecimalSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get()
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.vecEvalDecimal(ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+
+	for i := range n {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+
+		str := buf.GetDecimal(i).String()
+		result.AppendString(str)
+	}
+	return nil
+}

--- a/tests/integrationtest/r/expression/issues.result
+++ b/tests/integrationtest/r/expression/issues.result
@@ -1191,6 +1191,15 @@ select * from t;
 a
 1
 NULL
+drop table if exists t48;
+create table t48 (c1 BIT);
+insert into t48 values (b'1');
+select AES_ENCRYPT(COT(-9749), CASE -65 WHEN c1 THEN c1 END) FROM t48;
+AES_ENCRYPT(COT(-9749), CASE -65 WHEN c1 THEN c1 END)
+NULL
+select HEX(AES_ENCRYPT('test', CASE 1 WHEN c1 THEN c1 END)) FROM t48;
+HEX(AES_ENCRYPT('test', CASE 1 WHEN c1 THEN c1 END))
+5762E490822584EFAA63B1BF05A6A3ED
 DROP TABLE IF EXISTS tmp;
 CREATE TABLE tmp (id int(11) NOT NULL,value int(1) NOT NULL,PRIMARY KEY (id));
 INSERT INTO tmp VALUES (1, 1),(2,2),(3,3),(4,4),(5,5);

--- a/tests/integrationtest/t/expression/issues.test
+++ b/tests/integrationtest/t/expression/issues.test
@@ -768,6 +768,13 @@ insert into t values (1);
 insert into t select values(a) from t;
 select * from t;
 
+# TestBitTypeCaseVecEvalString
+drop table if exists t48;
+create table t48 (c1 BIT);
+insert into t48 values (b'1');
+select AES_ENCRYPT(COT(-9749), CASE -65 WHEN c1 THEN c1 END) FROM t48;
+select HEX(AES_ENCRYPT('test', CASE 1 WHEN c1 THEN c1 END)) FROM t48;
+
 # TestIssue20730
 DROP TABLE IF EXISTS tmp;
 CREATE TABLE tmp (id int(11) NOT NULL,value int(1) NOT NULL,PRIMARY KEY (id));


### PR DESCRIPTION
…hen needed

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67075

Problem Summary: `builtinCaseWhenIntSig` (and other CASE variants that evaluate to non-string types) don't implement `vecEvalString()`, which is needed when the result needs to be converted to string (like for AES_ENCRYPT's key parameter).

### What changed and how does it work?
Implement vecEvalString() for these CASE variants by falling back to row-by-row evaluation when string conversion is needed.

### Check List

Tests <!-- At least one of them must be included. -->

```
tidb> SELECT AES_ENCRYPT(COT(-9749), CASE -65 WHEN c1 THEN c1 END) FROM t48;
+-------------------------------------------------------+
| AES_ENCRYPT(COT(-9749), CASE -65 WHEN c1 THEN c1 END) |
+-------------------------------------------------------+
| NULL                                                  |
+-------------------------------------------------------+
1 row in set (0.002 sec)
```
c1 = b'0' → integer 0
So: -65 == 0 → false
→ result = NULL

`go test -v -run TestBitTypeCaseVecEvalString ./pkg/expression/...`

- [X] Unit test
- [x] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced vectorized evaluation of CASE expressions to produce string results for integer, real, and decimal types, with special handling for BIT formatting and YEAR output.

* **Tests**
  * Added integration tests validating CASE expression behavior on BIT columns, including queries combining CASE with encryption/hex functions and their expected outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->