### PR TITLE
executor, parser: support user-defined variables in KILL statements

### DIFF
--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -48,6 +48,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
+	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/plugin"
 	"github.com/pingcap/tidb/pkg/privilege"
 	"github.com/pingcap/tidb/pkg/resourcegroup"
@@ -2617,13 +2618,25 @@ func (e *SimpleExec) executeSetPwd(ctx context.Context, s *ast.SetPwdStmt) error
 }
 
 func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error {
-	if x, ok := s.Expr.(*ast.FuncCallExpr); ok {
-		if x.FnName.L == ast.ConnectionID {
-			sm := e.Ctx().GetSessionManager()
-			sm.Kill(e.Ctx().GetSessionVars().ConnectionID, s.Query, false, false)
-			return nil
+	if s.Expr != nil {
+		if x, ok := s.Expr.(*ast.FuncCallExpr); ok {
+			if x.FnName.L == ast.ConnectionID {
+				sm := e.Ctx().GetSessionManager()
+				sm.Kill(e.Ctx().GetSessionVars().ConnectionID, s.Query, false, false)
+				return nil
+			}
+			return errors.New("Invalid operation. Please use 'KILL TIDB [CONNECTION | QUERY] [connectionID | CONNECTION_ID()]' instead")
 		}
-		return errors.New("Invalid operation. Please use 'KILL TIDB [CONNECTION | QUERY] [connectionID | CONNECTION_ID()]' instead")
+		// Evaluate expression (handles user variables like @id, etc.)
+		val, err := plannerutil.EvalAstExprWithPlanCtx(e.Ctx().GetPlanCtx(), s.Expr)
+		if err != nil {
+			return err
+		}
+		uintVal, err := val.ConvertTo(e.Ctx().GetSessionVars().StmtCtx.TypeCtx(), types.NewFieldType(mysql.TypeLonglong))
+		if err != nil {
+			return errors.Errorf("non-integer value for connection ID: %v", val.GetValue())
+		}
+		s.ConnectionID = uintVal.GetUint64()
 	}
 	if !config.GetGlobalConfig().EnableGlobalKill {
 		conf := config.GetGlobalConfig()

--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -58,6 +58,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/sessiontxn"
 	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
+	handleutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -2632,11 +2633,20 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 		if err != nil {
 			return err
 		}
-		uintVal, err := val.ConvertTo(e.Ctx().GetSessionVars().StmtCtx.TypeCtx(), types.NewFieldType(mysql.TypeLonglong))
+		if val.IsNull() {
+			return errors.New("invalid connection ID: NULL")
+		}
+		intVal, err := val.ToInt64(e.Ctx().GetSessionVars().StmtCtx.TypeCtx())
 		if err != nil {
 			return errors.Errorf("non-integer value for connection ID: %v", val.GetValue())
 		}
-		s.ConnectionID = uintVal.GetUint64()
+		if intVal < 0 {
+			return errors.Errorf("negative value for connection ID: %d", intVal)
+		}
+		s.ConnectionID = uint64(intVal)
+		if err := e.checkKillConnectionPrivilege(ctx, s.ConnectionID); err != nil {
+			return err
+		}
 	}
 	if !config.GetGlobalConfig().EnableGlobalKill {
 		conf := config.GetGlobalConfig()
@@ -2689,6 +2699,41 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 		sm.Kill(s.ConnectionID, s.Query, false, false)
 	}
 
+	return nil
+}
+
+func (e *SimpleExec) checkKillConnectionPrivilege(ctx context.Context, connectionID uint64) error {
+	sm := e.Ctx().GetSessionManager()
+	if sm == nil {
+		return nil
+	}
+
+	var requireConnectionAdmin bool
+	var restrictedUser *auth.UserIdentity
+	if pi, ok := sm.GetProcessInfo(connectionID); ok {
+		loginUser := e.Ctx().GetSessionVars().User
+		if loginUser != nil && pi.User == loginUser.Username {
+			return nil
+		}
+		requireConnectionAdmin = true
+		restrictedUser = &auth.UserIdentity{Username: pi.User, Hostname: pi.Host}
+	} else if handleutil.GlobalAutoAnalyzeProcessList.Contains(connectionID) {
+		requireConnectionAdmin = true
+	}
+	if !requireConnectionAdmin {
+		return nil
+	}
+
+	checker := privilege.GetPrivilegeManager(e.Ctx())
+	activeRoles := e.Ctx().GetSessionVars().ActiveRoles
+	if checker == nil || !checker.RequestDynamicVerification(activeRoles, "CONNECTION_ADMIN", false) {
+		return plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs("SUPER or CONNECTION_ADMIN")
+	}
+	if restrictedUser != nil && sem.IsEnabled() &&
+		checker.RequestDynamicVerificationWithUser(ctx, "RESTRICTED_USER_ADMIN", false, restrictedUser) &&
+		!checker.RequestDynamicVerification(activeRoles, "RESTRICTED_CONNECTION_ADMIN", false) {
+		return plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs("RESTRICTED_CONNECTION_ADMIN")
+	}
 	return nil
 }
 

--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -776,6 +776,23 @@ func TestKillStmt(t *testing.T) {
 	result.Check(testkit.Rows())
 
 	tk.MustExecToErr("kill rand()", "Invalid operation. Please use 'KILL TIDB [CONNECTION | QUERY] [connectionID | CONNECTION_ID()]' instead")
+
+	// Test user variable support in KILL (issue #55369)
+	tk.MustExec(fmt.Sprintf("set @kill_id = %d", killConnID))
+	tk.MustExec("kill @kill_id")
+	result = tk.MustQuery("show warnings")
+	result.Check(testkit.Rows())
+
+	// Test KILL QUERY with user variable
+	tk.MustExec("kill query @kill_id")
+	result = tk.MustQuery("show warnings")
+	result.Check(testkit.Rows())
+
+	// Test KILL CONNECTION with user variable
+	tk.MustExec("kill connection @kill_id")
+	result = tk.MustQuery("show warnings")
+	result.Check(testkit.Rows())
+
 	// remote kill is tested in `tests/globalkilltest`
 }
 

--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -28,12 +28,15 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/server"
 	"github.com/pingcap/tidb/pkg/session"
+	"github.com/pingcap/tidb/pkg/session/sessmgr"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/statistics"
+	handleutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/globalconn"
+	sem "github.com/pingcap/tidb/pkg/util/sem/compat"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/stats/view"
 )
@@ -792,6 +795,32 @@ func TestKillStmt(t *testing.T) {
 	tk.MustExec("kill connection @kill_id")
 	result = tk.MustQuery("show warnings")
 	result.Check(testkit.Rows())
+
+	tk.MustExec("set @kill_id = NULL")
+	tk.MustExecToErr("kill @kill_id", "invalid connection ID: NULL")
+	tk.MustExec("set @kill_id = -1")
+	tk.MustExecToErr("kill @kill_id", "negative value for connection ID: -1")
+
+	tk.MustExec("create user auto_analyze_killer, restricted_killer, restricted_user")
+	tk.MustExec("grant CONNECTION_ADMIN on *.* to restricted_killer")
+	tk.MustExec("grant RESTRICTED_USER_ADMIN on *.* to restricted_user")
+
+	sm := &testkit.MockSessionManager{SerID: dom.ServerID}
+	tk.Session().SetSessionManager(sm)
+	tk.MustExec(fmt.Sprintf("set @kill_id = %d", killConnID))
+
+	handleutil.GlobalAutoAnalyzeProcessList.Tracker(killConnID)
+	defer handleutil.GlobalAutoAnalyzeProcessList.Untracker(killConnID)
+	restoreSEM := sem.SwitchToSEMForTest(t, sem.V1)
+	defer restoreSEM()
+
+	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "auto_analyze_killer", Hostname: "localhost"}, nil, nil, nil))
+	tk.MustExecToErr("kill @kill_id", "[planner:1227]Access denied; you need (at least one of) the SUPER or CONNECTION_ADMIN privilege(s) for this operation")
+
+	handleutil.GlobalAutoAnalyzeProcessList.Untracker(killConnID)
+	sm.PS = []*sessmgr.ProcessInfo{{ID: killConnID, User: "restricted_user", Host: "%"}}
+	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "restricted_killer", Hostname: "localhost"}, nil, nil, nil))
+	tk.MustExecToErr("kill @kill_id", "[planner:1227]Access denied; you need (at least one of) the RESTRICTED_CONNECTION_ADMIN privilege(s) for this operation")
 
 	// remote kill is tested in `tests/globalkilltest`
 }

--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -1217,6 +1217,13 @@ func (n *KillStmt) Accept(v Visitor) (Node, bool) {
 		return v.Leave(newNode)
 	}
 	n = newNode.(*KillStmt)
+	if n.Expr != nil {
+		node, ok := n.Expr.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.Expr = node.(ExprNode)
+	}
 	return v.Leave(n)
 }
 

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -15931,6 +15931,28 @@ KillStmt:
 			Expr:          $2,
 		}
 	}
+|	KillOrKillTiDB Variable
+	{
+		$$ = &ast.KillStmt{
+			TiDBExtension: $1.(bool),
+			Expr:          $2,
+		}
+	}
+|	KillOrKillTiDB "CONNECTION" Variable
+	{
+		$$ = &ast.KillStmt{
+			TiDBExtension: $1.(bool),
+			Expr:          $3,
+		}
+	}
+|	KillOrKillTiDB "QUERY" Variable
+	{
+		$$ = &ast.KillStmt{
+			Query:         true,
+			TiDBExtension: $1.(bool),
+			Expr:          $3,
+		}
+	}
 
 KillOrKillTiDB:
 	"KILL"

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -6137,6 +6137,10 @@ func TestSessionManage(t *testing.T) {
 		{"kill tidb 23123", true, "KILL TIDB 23123"},
 		{"kill tidb connection 23123", true, "KILL TIDB 23123"},
 		{"kill tidb query 23123", true, "KILL TIDB QUERY 23123"},
+		// User variable support (#55369)
+		{"kill @id", true, "KILL @`id`"},
+		{"kill connection @id", true, "KILL @`id`"},
+		{"kill query @id", true, "KILL QUERY @`id`"},
 		{"show processlist", true, "SHOW PROCESSLIST"},
 		{"show full processlist", true, "SHOW FULL PROCESSLIST"},
 		{"shutdown", true, "SHUTDOWN"},

--- a/tests/globalkilltest/global_kill_test.go
+++ b/tests/globalkilltest/global_kill_test.go
@@ -459,7 +459,7 @@ func sleepRoutine(ctx context.Context, sleepTime int, conn *sql.Conn, connID uin
 }
 
 // NOTICE: db1 & db2 can be the same object, for getting conn1 & conn2 from the same TiDB instance.
-func (s *GlobalKillSuite) killByKillStatement(t *testing.T, db1 *sql.DB, db2 *sql.DB, sleepTime int) time.Duration {
+func (s *GlobalKillSuite) killByKillStatement(t *testing.T, db1 *sql.DB, db2 *sql.DB, sleepTime int, variableTarget bool) time.Duration {
 	ctx := context.TODO()
 
 	conn1, err := db1.Conn(ctx)
@@ -488,8 +488,21 @@ func (s *GlobalKillSuite) killByKillStatement(t *testing.T, db1 *sql.DB, db2 *sq
 		zap.String("connID1", "0x"+strconv.FormatUint(connID1, 16)),
 		zap.String("connID2", "0x"+strconv.FormatUint(connID2, 16)),
 	)
-	_, err = conn2.ExecContext(ctx, fmt.Sprintf("KILL QUERY %v", connID1))
+	killSQL := fmt.Sprintf("KILL QUERY %v", connID1)
+	if variableTarget {
+		_, err = conn2.ExecContext(ctx, "SET @kill_id = ?", connID1)
+		require.NoError(t, err)
+		killSQL = "KILL QUERY @kill_id"
+	}
+	_, err = conn2.ExecContext(ctx, killSQL)
 	require.NoError(t, err)
+	if variableTarget {
+		warnings, err := conn2.QueryContext(ctx, "SHOW WARNINGS")
+		require.NoError(t, err)
+		require.False(t, warnings.Next())
+		require.NoError(t, warnings.Err())
+		require.NoError(t, warnings.Close())
+	}
 
 	r := <-ch
 	require.NoError(t, err)
@@ -525,7 +538,7 @@ func doTestWithoutPD(t *testing.T, enable32Bits bool) {
 	s.testKillByCtrlC(t, port, 2)
 
 	// Test KILL statement
-	elapsed := s.killByKillStatement(t, db, db, 2)
+	elapsed := s.killByKillStatement(t, db, db, 2, false)
 	require.Less(t, elapsed, 2*time.Second)
 }
 
@@ -560,7 +573,7 @@ func doTestOneTiDB(t *testing.T, enable32Bits bool) {
 	s.testKillByCtrlC(t, port, sleepTime)
 
 	// Test KILL statement
-	elapsed := s.killByKillStatement(t, db, db, sleepTime)
+	elapsed := s.killByKillStatement(t, db, db, sleepTime, false)
 	require.Less(t, elapsed, sleepTime*time.Second)
 }
 
@@ -610,11 +623,11 @@ func doTestMultipleTiDB(t *testing.T, enable32Bits bool) {
 	s.testKillByCtrlC(t, port1, sleepTime)
 
 	// kill local by KILL
-	elapsed = s.killByKillStatement(t, db1a, db1b, sleepTime)
+	elapsed = s.killByKillStatement(t, db1a, db1b, sleepTime, false)
 	require.Less(t, elapsed, sleepTime*time.Second)
 
 	// kill remotely
-	elapsed = s.killByKillStatement(t, db1a, db2, sleepTime)
+	elapsed = s.killByKillStatement(t, db1a, db2, sleepTime, true)
 	require.Less(t, elapsed, sleepTime*time.Second)
 }
 
@@ -721,10 +734,10 @@ func doTestLostConnection(t *testing.T, enable32Bits bool) {
 		}()
 
 		// [Test Scenario 7] Connections can be killed after PD lost connection for long time and then recovered.
-		elapsed := s.killByKillStatement(t, db1, db1, 2)
+		elapsed := s.killByKillStatement(t, db1, db1, 2, false)
 		require.Less(t, elapsed, 2*time.Second)
 
-		elapsed = s.killByKillStatement(t, db1, db2, 2)
+		elapsed = s.killByKillStatement(t, db1, db2, 2, false)
 		require.Less(t, elapsed, 2*time.Second)
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #55369

Problem Summary:

KILL statements only accept integer literals or `CONNECTION_ID()`. MySQL supports user-defined variables (`SET @id = 100; KILL @id;`), but TiDB rejects them with a parse error. This breaks MySQL compatibility and prevents tools like `pt-kill` from working with TiDB when they use variables.

### What changed and how does it work?

**Parser (`pkg/parser/parser.y`):** Added three new grammar rules to accept `Variable` (user-defined variables like `@id`) in `KillStmt`:
- `KillOrKillTiDB Variable` - for `KILL @id`
- `KillOrKillTiDB "CONNECTION" Variable` - for `KILL CONNECTION @id`
- `KillOrKillTiDB "QUERY" Variable` - for `KILL QUERY @id`

These rules set the `Expr` field on `KillStmt` (the same field already used for `CONNECTION_ID()` built-in function support).

**Executor (`pkg/executor/simple.go`):** When `KillStmt.Expr` is set and is not a `FuncCallExpr`, evaluate it using `plannerutil.EvalAstExprWithPlanCtx` to resolve the connection ID at runtime. The result is converted to uint64 and assigned to `ConnectionID` before the existing kill logic executes.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
The KILL, KILL CONNECTION, and KILL QUERY statements now accept user-defined variables (e.g., `SET @id = 100; KILL @id;`), improving MySQL compatibility.
```

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * KILL statements now accept user-defined variables as connection ID targets, including `KILL `@connection_id``, `KILL CONNECTION `@id``, and `KILL QUERY `@query_id``.

* **Bug Fixes**
  * Improved validation for invalid or negative connection IDs.
  * Enforced required privileges when terminating other users’ connections or restricted processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->