### PR TITLE
*: add RU v2 design doc

### DIFF
--- a/docs/design/2026-03-21-ru-v2.md
+++ b/docs/design/2026-03-21-ru-v2.md
@@ -29,8 +29,8 @@ The most important user-visible changes are:
 
 - a new `[ru-v2]` TiDB configuration block and an expanded `[tikv-client.ru-v2]` block,
 - `EXPLAIN ANALYZE` still prints `RU:`, but the value now comes from RU v2 total,
-- slow log gains an optional `RUv2_metrics` field with both totals and a detailed breakdown,
-- `INFORMATION_SCHEMA.SLOW_QUERY` and `INFORMATION_SCHEMA.CLUSTER_SLOW_QUERY` gain a new `RUv2_metrics` column,
+- slow log gains optional `Request_unit_v2` and `Request_unit_v2_detail` fields for the total and detailed breakdown,
+- `INFORMATION_SCHEMA.SLOW_QUERY` and `INFORMATION_SCHEMA.CLUSTER_SLOW_QUERY` gain new `Request_unit_v2` and `Request_unit_v2_detail` columns,
 - `INFORMATION_SCHEMA.STATEMENTS_SUMMARY` and related tables gain `AVG_REQUEST_UNIT_V2` and `MAX_REQUEST_UNIT_V2` columns for aggregated RU v2 statistics,
 - Prometheus gains a `tidb_ruv2_*` metric family for the underlying counters.
 
@@ -219,18 +219,20 @@ result is generated, and it is not double-counted again during statement finish.
 
 ### Slow log
 
-Slow log gains a new optional field:
+Slow log gains two new optional fields:
 
 ```text
-# RUv2_metrics: total_ru:19983.42, tidb_ru:8750.10, tikv_ru:10987.32, tiflash_ru:246.00, result_chunk_cells:1000, resource_manager_write_cnt:20, tikv_coprocessor_executor_work_total:{BatchTopN:10}
+# Request_unit_v2: 19983.42
+# Request_unit_v2_detail: total_ru:19983.42, tidb_ru:8750.10, tikv_ru:10987.32, tiflash_ru:246.00, result_chunk_cells:1000, resource_manager_write_cnt:20, tikv_coprocessor_executor_work_total:{BatchTopN:10}
 ```
 
 The formatting rules are:
 
-- the field name is exactly `RUv2_metrics`,
-- the output always starts with `total_ru`, `tidb_ru`, `tikv_ru`, and `tiflash_ru`,
-- those four RU fields are formatted as decimal `float64` values with exactly two fractional digits,
-- additional counters are appended only when their value is non-zero, in the
+- the field names are exactly `Request_unit_v2` and `Request_unit_v2_detail`,
+- `Request_unit_v2` stores the final RU v2 total formatted as a decimal `float64` value with exactly two fractional digits,
+- `Request_unit_v2_detail` always starts with `total_ru`, `tidb_ru`, `tikv_ru`, and `tiflash_ru`,
+- those four RU fields inside `Request_unit_v2_detail` are formatted as decimal `float64` values with exactly two fractional digits,
+- additional counters are appended to `Request_unit_v2_detail` only when their value is non-zero, in the
   following fixed declaration order:
   1. `result_chunk_cells`
   2. `executor_l1`
@@ -252,26 +254,30 @@ The formatting rules are:
   18. `tikv_coprocessor_executor_work_total`
 - label maps (`executor_l1`/`executor_l2`/`executor_l3`/`tikv_coprocessor_executor_work_total`)
   are formatted as `{label:value,...}` with keys sorted lexicographically,
-- the whole field is omitted when all RU v2 counters and TiKV/TiFlash RU values are zero.
+- both fields are omitted when all RU v2 counters and TiKV/TiFlash RU values are zero.
 
 This format is intentionally more detailed than the legacy RU output. It lets users
 inspect both the final total and the source of that total directly from the slow log.
 
 ### `INFORMATION_SCHEMA.SLOW_QUERY` and `CLUSTER_SLOW_QUERY`
 
-The slow-query table schema gains a new `LONGBLOB` column named
-`RUv2_metrics`. The stored payload is the same formatted text written in the raw
-slow log.
+The slow-query table schema gains:
+
+- a `DOUBLE` column named `Request_unit_v2`,
+- a `LONGBLOB` column named `Request_unit_v2_detail`.
+
+The stored payload in `Request_unit_v2_detail` is the same formatted text
+written in the raw slow log.
 
 From a user perspective:
 
-- `SELECT * FROM information_schema.slow_query` now returns one extra column,
-- `SELECT RUv2_metrics FROM information_schema.slow_query` returns the same text
-  payload written in the raw slow log,
-- old slow log files that do not contain the field are still readable; the
-  column is exposed as an empty string for those rows.
+- `SELECT * FROM information_schema.slow_query` now returns two extra columns,
+- `SELECT Request_unit_v2, Request_unit_v2_detail FROM information_schema.slow_query`
+  returns the same total/detail payload written in the raw slow log,
+- old slow log files that do not contain these fields are still readable; the
+  columns are exposed as `0` and an empty string for those rows.
 
-The new column is inserted after `Storage_from_mpp` and before the plan-related
+The new columns are inserted after `Storage_from_mpp` and before the plan-related
 blob columns. Users with strict column-position assumptions on
 `SELECT * FROM information_schema.slow_query` or
 `SELECT * FROM information_schema.cluster_slow_query` should update those consumers.
@@ -279,7 +285,7 @@ blob columns. Users with strict column-position assumptions on
 An example query is:
 
 ```sql
-SELECT time, query, RUv2_metrics
+SELECT time, query, Request_unit_v2, Request_unit_v2_detail
 FROM information_schema.slow_query
 ORDER BY time DESC
 LIMIT 5;
@@ -376,9 +382,9 @@ The implementation should add or update unit tests for:
 - RU v2 value calculation and formatting,
 - `EXPLAIN ANALYZE` RU output,
 - slow log formatting,
-- TiFlash RU contribution in `RUv2_metrics`,
+- TiFlash RU contribution in `Request_unit_v2_detail`,
 - TiKV zero-scale configuration passthrough,
-- `INFORMATION_SCHEMA.SLOW_QUERY` parsing when `RUv2_metrics` is absent,
+- `INFORMATION_SCHEMA.SLOW_QUERY` parsing when `Request_unit_v2` and `Request_unit_v2_detail` are absent,
 - statement-scoped metrics lifecycle in session execution,
 - DistSQL and transaction interceptor collection,
 - cursor delta reporting.
@@ -396,7 +402,7 @@ Important scenarios that should be covered by tests are:
 
 Compatibility-sensitive behaviors that should be covered are:
 
-- old slow log rows without `RUv2_metrics` are still readable through `INFORMATION_SCHEMA.SLOW_QUERY`,
+- old slow log rows without `Request_unit_v2` and `Request_unit_v2_detail` are still readable through `INFORMATION_SCHEMA.SLOW_QUERY`,
 - `EXPLAIN ANALYZE` output keeps the existing `RU:` label,
 - zero `ru-scale` on the TiKV client side is preserved rather than silently rewritten,
 - RU v2 metrics objects do not leak across statements inside an explicit transaction.
@@ -409,7 +415,7 @@ Follow-up benchmarking should focus on:
 
 - executor `Next()` wrapper overhead after adding RU v2 accounting,
 - impact of the new DistSQL and transaction RPC interceptors,
-- slow-log size growth when `RUv2_metrics` contains a large breakdown.
+- slow-log size growth when `Request_unit_v2_detail` contains a large breakdown.
 
 ## Impacts & Risks
 
@@ -426,12 +432,13 @@ Impacts:
 Risks:
 
 - Consumers that parse `SELECT * FROM information_schema.slow_query` by column
-  position may break because of the new `RUv2_metrics` column.
+  position may break because of the new `Request_unit_v2` and
+  `Request_unit_v2_detail` columns.
 - Consumers that parse `SELECT * FROM information_schema.statements_summary` (or
   related tables) by column position may break because of the new `AVG_REQUEST_UNIT_V2`
   and `MAX_REQUEST_UNIT_V2` columns.
 - Slow-log parsers that assume a fixed list of `# key: value` fields may need to
-  tolerate the optional `RUv2_metrics` line.
+  tolerate the optional `Request_unit_v2` and `Request_unit_v2_detail` lines.
 - If `[ru-v2].ru-scale` and `[tikv-client.ru-v2].ru-scale` diverge, `total_ru`
   becomes harder to interpret as a single uniformly scaled value.
 - The design switches `EXPLAIN ANALYZE` display logic to RU v2 while
@@ -463,8 +470,9 @@ reduces compatibility by changing more user-facing output shapes and makes it
 harder to compare old and new tooling side by side.
 
 Instead, this proposal keeps the existing top-level surfaces stable where possible
-and introduces the richer breakdown mainly through an additive field
-(`RUv2_metrics`) and additive Prometheus metrics.
+and introduces the richer breakdown mainly through additive slow-log and
+slow-query fields (`Request_unit_v2`, `Request_unit_v2_detail`) and additive
+Prometheus metrics.
 
 ## Unresolved Questions
 

--- a/docs/design/2026-03-21-ru-v2.md
+++ b/docs/design/2026-03-21-ru-v2.md
@@ -429,6 +429,15 @@ Risks:
   keeping the label `RU:`. This is intentional for compatibility, but users must
   know the semantic change.
 
+### Known Issues
+
+- **Statement summary underreports RU v2 for server-side cursors**: `TotalRUV2` is
+  snapshotted at `SummaryStmt` time, but server-side cursor fetches continue to
+  add RU afterwards via `ReportCursorRUV2Delta` and `CursorRUV2Tracker`. This means
+  `AVG_REQUEST_UNIT_V2` and `MAX_REQUEST_UNIT_V2` columns in statement summary tables
+  do not include post-execute fetch costs for cursor statements. This behavior is
+  consistent with RU v1 and is intentionally kept unchanged.
+
 ## Investigation & Alternatives
 
 Two simpler alternatives were available:

--- a/docs/design/2026-03-21-ru-v2.md
+++ b/docs/design/2026-03-21-ru-v2.md
@@ -1,7 +1,7 @@
 # RU v2 Statement Accounting and Observability
 
 - Author(s): disksing
-- Discussion PR: TBD
+- Discussion PR: https://github.com/pingcap/tidb/pull/67200
 - Tracking Issue: https://github.com/pingcap/tidb/issues/67199
 
 ## Table of Contents

--- a/docs/design/2026-03-21-ru-v2.md
+++ b/docs/design/2026-03-21-ru-v2.md
@@ -1,0 +1,384 @@
+# RU v2 Statement Accounting and Observability
+
+- Author(s): disksing
+- Discussion PR: TBD
+- Tracking Issue: https://github.com/pingcap/tidb/issues/67199
+
+## Table of Contents
+
+* [Introduction](#introduction)
+* [Motivation or Background](#motivation-or-background)
+* [Detailed Design](#detailed-design)
+* [Test Design](#test-design)
+  * [Functional Tests](#functional-tests)
+  * [Scenario Tests](#scenario-tests)
+  * [Compatibility Tests](#compatibility-tests)
+  * [Benchmark Tests](#benchmark-tests)
+* [Impacts & Risks](#impacts--risks)
+* [Investigation & Alternatives](#investigation--alternatives)
+* [Unresolved Questions](#unresolved-questions)
+
+## Introduction
+
+This document proposes statement-level RU v2 accounting on the TiDB side,
+merging it with the RU v2 signals already produced by TiKV and TiFlash, and
+exposing the result through user-visible surfaces including `EXPLAIN ANALYZE`,
+slow log, and `INFORMATION_SCHEMA.SLOW_QUERY`.
+
+The most important user-visible changes are:
+
+- a new `[ru-v2]` TiDB configuration block and an expanded `[tikv-client.ru-v2]` block,
+- `EXPLAIN ANALYZE` still prints `RU:`, but the value now comes from RU v2 total,
+- slow log gains an optional `RUv2_metrics` field with both totals and a detailed breakdown,
+- `INFORMATION_SCHEMA.SLOW_QUERY` and `INFORMATION_SCHEMA.CLUSTER_SLOW_QUERY` gain a new `RUv2_metrics` column,
+- Prometheus gains a `tidb_ruv2_*` metric family for the underlying counters.
+
+## Motivation or Background
+
+Legacy RU reporting is mostly a single final value. That is enough for charging,
+but it is weak for debugging. When the RU value looks too high, users still need
+another way to answer questions such as:
+
+- how much RU came from TiDB itself versus TiKV or TiFlash,
+- whether the cost was dominated by plan building, executor work, parsing, result materialization, or transaction work,
+- whether the number shown in `EXPLAIN ANALYZE` matches what is written to slow log and what is later queryable from `INFORMATION_SCHEMA.SLOW_QUERY`.
+
+This proposal addresses this gap by introducing a statement-scoped RU v2 metrics
+container in TiDB, feeding it throughout the statement lifecycle, and then
+reusing the same snapshot for all user-facing outputs.
+
+The design intentionally keeps the output shape conservative where possible:
+
+- `EXPLAIN ANALYZE` continues to use the label `RU:` instead of introducing a new output column,
+- slow log keeps the new field optional so old log entries remain readable,
+- the default TiDB-side weights are chosen to stay numerically close to legacy RU values under the same workload.
+
+## Detailed Design
+
+### High-level data flow
+
+Each SQL statement gets a fresh `RUV2Metrics` container. TiDB fills it from four places:
+
+1. Session and parser phase:
+   `session.Parse()` and `session.ParseWithParams()` count `session_parser_total`.
+2. Planner phase:
+   recursive `PlanBuilder.Build()` calls count `plan_cnt`, and
+   `deriveStats4DataSource()` counts `plan_derive_stats_paths`.
+3. Executor phase:
+   the generic executor `Next()` wrapper counts input/output rows or cells for
+   selected executor types, and `INSERT` statements additionally record
+   `executor_l5_insert_rows`.
+4. KV and transaction phase:
+   DistSQL and transaction RPC interceptors count TiKV-side request classes and
+   copy `ExecDetailsV2.RuV2` fields from responses into the same statement
+   metrics snapshot.
+
+At the end of the statement, TiDB combines:
+
+- TiDB-side RU calculated from `[ru-v2]` weights and the statement counters,
+- TiKV-side RU v2 reported by client-go,
+- TiFlash RU already carried by `RUDetails`.
+
+The combined value is then reused for:
+
+- `EXPLAIN ANALYZE`,
+- slow log,
+- `INFORMATION_SCHEMA.SLOW_QUERY`,
+- resource-group consumption observation.
+
+### TiDB-side RU v2 weights
+
+The design adds a new top-level configuration block:
+
+```toml
+[ru-v2]
+ru-scale = 5697.054498
+result-chunk-cells = 0.00010000
+executor-l1 = 0.00013278
+executor-l2 = 0.00000383
+executor-l3 = 0.00141739
+executor-l5-insert-rows = 0.00472572
+plan-cnt = 0.15392217
+plan-derive-stats-paths = 0.24968182
+resource-manager-read-cnt = 0.02072003
+resource-manager-write-cnt = 0.07179779
+session-parser-total = 0.19230499
+txn-cnt = 0.03013709
+```
+
+The weights are used only for TiDB-side RU calculation. They control how raw
+statement counters are converted into `tidb_ru`.
+
+The design also extends the TiKV client configuration:
+
+```toml
+[tikv-client.ru-v2]
+ru-scale = 5697.054498
+tikv-kv-engine-cache-miss = 0.45975389
+resource-manager-write-cnt-tikv = 0.09642181
+executor-inputs = 0.00003150
+tikv-coprocessor-executor-iterations = 0.05775369
+tikv-coprocessor-response-bytes = 0.00000087
+tikv-raftstore-store-write-trigger-wb-bytes = 0.00006100
+tikv-storage-processed-keys-batch-get = 0.00266791
+tikv-storage-processed-keys-get = 0.01416829
+```
+
+`[ru-v2].ru-scale` and `[tikv-client.ru-v2].ru-scale` are independent on purpose.
+This lets TiDB-side and TiKV-side RU v2 evolve separately, but it also means the
+operator must keep the two scales aligned manually if a single comparable total
+is desired.
+
+This design does not add a SQL variable for RU v2 tuning. The interface is
+configuration-driven.
+
+### Statement counters collected inside TiDB
+
+The TiDB-side counters exposed in RU v2 are:
+
+- `result_chunk_cells`: cells materialized into result chunks,
+- `executor_l1`, `executor_l2`, `executor_l3`: executor-specific row or cell counters,
+- `executor_l5_insert_rows`: affected insert rows,
+- `plan_cnt`,
+- `plan_derive_stats_paths`,
+- `resource_manager_read_cnt`,
+- `resource_manager_write_cnt`,
+- `session_parser_total`,
+- `txn_cnt`.
+
+The executor groups are defined as follows:
+
+- `executor_l1`: `BatchPointGetExec`, `PointGetExecutor`, `LimitExec`
+- `executor_l2`: `HashAggExec`, `HashJoinExec`, `IndexLookUpJoin`,
+  `IndexLookUpExecutor`, `IndexReaderExecutor`, `MemTableReaderExec`,
+  `SelectionExec`, `TableDualExec`, `TableReaderExecutor`, `UnionScanExec`,
+  `SelectLockExec`
+- `executor_l3`: `SortExec`, `StreamAggExec`
+- `executor_l5_insert_rows`: not tied to an executor type; recorded from
+  `StatementContext.AffectedRows()`
+
+The implementation is statement-scoped, not transaction-scoped. In explicit
+transactions, each statement gets a fresh RU v2 metrics object, so one statement
+does not leak its counters into the next one.
+
+### TiKV-side and TiFlash-side signals
+
+The design also copies TiKV response-side RU v2 information into the statement
+snapshot. The visible keys are:
+
+- `tikv_kv_engine_cache_miss`
+- `tikv_coprocessor_executor_iterations`
+- `tikv_coprocessor_response_bytes`
+- `tikv_raftstore_store_write_trigger_wb_bytes`
+- `tikv_storage_processed_keys_batch_get`
+- `tikv_storage_processed_keys_get`
+- `tikv_coprocessor_executor_work_total`
+
+`tikv_coprocessor_executor_work_total` is a label map. The labels
+include executor names such as `BatchIndexScan`, `BatchTableScan`,
+`BatchSelection`, `BatchTopN`, `BatchLimit`, `BatchSimpleAggr`, and
+`BatchFastHashAggr`.
+
+TiFlash RU is not recalculated inside TiDB. It continues to come from the
+existing `RUDetails` path and is folded into the final `tiflash_ru` field.
+
+### `EXPLAIN ANALYZE`
+
+`EXPLAIN ANALYZE` remains text-compatible at the surface level: it still prints a
+single `RU:` entry in runtime stats.
+
+The semantic change is that the value now comes from RU v2 total:
+
+```text
+RU = tidb_ru + tikv_ru + tiflash_ru
+```
+
+The design keeps the label as `RU:` instead of `RUv2:` to avoid churn in
+existing output consumers. Users should therefore read the field as “RU total,
+calculated with RU v2 accounting”.
+
+This also applies to `EXPLAIN ANALYZE INSERT`. The design makes insert-row
+accounting idempotent so the `RU:` value is already complete when the explain
+result is generated, and it is not double-counted again during statement finish.
+
+### Slow log
+
+Slow log gains a new optional field:
+
+```text
+# RUv2_metrics: total_ru:19983, tidb_ru:8750, tikv_ru:10987, tiflash_ru:246, result_chunk_cells:1000, resource_manager_write_cnt:20, tikv_coprocessor_executor_work_total:{BatchTopN:10}
+```
+
+The formatting rules are:
+
+- the field name is exactly `RUv2_metrics`,
+- the output always starts with `total_ru`, `tidb_ru`, `tikv_ru`, and `tiflash_ru`,
+- additional counters are appended only when their value is non-zero,
+- label maps are formatted as `{label:value,...}` with keys sorted lexicographically,
+- the whole field is omitted when all RU v2 counters and TiKV/TiFlash RU values are zero.
+
+This format is intentionally more detailed than the legacy RU output. It lets users
+inspect both the final total and the source of that total directly from the slow log.
+
+### `INFORMATION_SCHEMA.SLOW_QUERY` and `CLUSTER_SLOW_QUERY`
+
+The slow-query table schema gains a new `LONG BLOB` column named
+`RUv2_metrics`. The stored payload is the same formatted text written in the raw
+slow log.
+
+From a user perspective:
+
+- `SELECT * FROM information_schema.slow_query` now returns one extra column,
+- `SELECT RUv2_metrics FROM information_schema.slow_query` returns the same text
+  payload written in the raw slow log,
+- old slow log files that do not contain the field are still readable; the
+  column is exposed as an empty string for those rows.
+
+The new column is inserted after `Storage_from_mpp` and before the plan-related
+blob columns. Users with strict column-position assumptions on
+`SELECT * FROM information_schema.slow_query` or
+`SELECT * FROM information_schema.cluster_slow_query` should update those consumers.
+
+An example query is:
+
+```sql
+SELECT time, query, RUv2_metrics
+FROM information_schema.slow_query
+ORDER BY time DESC
+LIMIT 5;
+```
+
+### Prometheus metrics
+
+The design registers a `tidb_ruv2_*` metric family so operators can inspect the
+raw counters outside SQL and slow log. The exported metrics include:
+
+- `tidb_ruv2_result_chunk_cells`
+- `tidb_ruv2_executor_l1`
+- `tidb_ruv2_executor_l2`
+- `tidb_ruv2_executor_l3`
+- `tidb_ruv2_executor_l5_insert_rows`
+- `tidb_ruv2_plan_cnt`
+- `tidb_ruv2_plan_derive_stats_paths`
+- `tidb_ruv2_resource_manager_read_cnt`
+- `tidb_ruv2_resource_manager_write_cnt`
+- `tidb_ruv2_session_parser_total`
+- `tidb_ruv2_txn_cnt`
+- `tidb_ruv2_tikv_kv_engine_cache_miss`
+- `tidb_ruv2_tikv_coprocessor_executor_iterations`
+- `tidb_ruv2_tikv_coprocessor_response_bytes`
+- `tidb_ruv2_tikv_raftstore_store_write_trigger_wb_bytes`
+- `tidb_ruv2_tikv_storage_processed_keys_batch_get`
+- `tidb_ruv2_tikv_storage_processed_keys_get`
+- `tidb_ruv2_tikv_coprocessor_executor_work_total`
+
+These metrics are primarily for observability. This design does not introduce a
+new `METRICS_SCHEMA` table definition for them.
+
+### Resource-group observation and cursor accounting
+
+The resource-group consumption reporter interface is extended so TiDB can report
+TiDB-side RU v2 and TiKV-side RU v2 separately.
+
+This is especially important for server-side cursors. Statement execution may
+already consume some RU before the first `FETCH`, while later `FETCH` and `CLOSE`
+operations may consume more result materialization or TiKV RU. The design adds a
+cursor tracker so only the delta after execution is reported during fetch/close.
+
+This change is mostly internal, but it is important for correctness because it
+keeps resource-group observation consistent with the slow log and `EXPLAIN ANALYZE`
+numbers.
+
+## Test Design
+
+### Functional Tests
+
+The implementation should add or update unit tests for:
+
+- RU v2 value calculation and formatting,
+- `EXPLAIN ANALYZE` RU output,
+- slow log formatting,
+- TiFlash RU contribution in `RUv2_metrics`,
+- TiKV zero-scale configuration passthrough,
+- `INFORMATION_SCHEMA.SLOW_QUERY` parsing when `RUv2_metrics` is absent,
+- statement-scoped metrics lifecycle in session execution,
+- DistSQL and transaction interceptor collection,
+- cursor delta reporting.
+
+### Scenario Tests
+
+Important scenarios that should be covered by tests are:
+
+- explicit transactions with multiple statements, to ensure per-statement isolation,
+- `EXPLAIN ANALYZE INSERT`, to ensure insert-row RU is visible without double counting,
+- prepared statements with server-side cursors, to ensure execute/fetch/close deltas are reported correctly,
+- first `Next()` failure during cursor fetch, to ensure result chunk accounting does not touch columns before the first successful batch.
+
+### Compatibility Tests
+
+Compatibility-sensitive behaviors that should be covered are:
+
+- old slow log rows without `RUv2_metrics` are still readable through `INFORMATION_SCHEMA.SLOW_QUERY`,
+- `EXPLAIN ANALYZE` output keeps the existing `RU:` label,
+- zero `ru-scale` on the TiKV client side is preserved rather than silently rewritten,
+- RU v2 metrics objects do not leak across statements inside an explicit transaction.
+
+### Benchmark Tests
+
+This proposal does not include dedicated RU v2 benchmark coverage yet.
+
+Follow-up benchmarking should focus on:
+
+- executor `Next()` wrapper overhead after adding RU v2 accounting,
+- impact of the new DistSQL and transaction RPC interceptors,
+- slow-log size growth when `RUv2_metrics` contains a large breakdown.
+
+## Impacts & Risks
+
+Impacts:
+
+- Users get a richer and more consistent RU story across `EXPLAIN ANALYZE`,
+  slow log, and `INFORMATION_SCHEMA.SLOW_QUERY`.
+- Operators can inspect the TiDB-side share of RU instead of seeing only the
+  storage-side total.
+- Prometheus can capture the raw RU v2 components directly.
+
+Risks:
+
+- Consumers that parse `SELECT * FROM information_schema.slow_query` by column
+  position may break because of the new `RUv2_metrics` column.
+- Slow-log parsers that assume a fixed list of `# key: value` fields may need to
+  tolerate the optional `RUv2_metrics` line.
+- If `[ru-v2].ru-scale` and `[tikv-client.ru-v2].ru-scale` diverge, `total_ru`
+  becomes harder to interpret as a single uniformly scaled value.
+- The design switches `EXPLAIN ANALYZE` display logic to RU v2 while
+  keeping the label `RU:`. This is intentional for compatibility, but users must
+  know the semantic change.
+
+## Investigation & Alternatives
+
+Two simpler alternatives were available:
+
+1. Keep RU v2 only as internal counters and continue exposing a single final RU
+   value to users.
+2. Add a brand new output field such as `RUv2:` or a separate JSON payload,
+   leaving existing `RU:` behavior untouched.
+
+This proposal does not choose either of them.
+
+The first option loses the main debugging value of RU v2. The second option
+reduces compatibility by changing more user-facing output shapes and makes it
+harder to compare old and new tooling side by side.
+
+Instead, this proposal keeps the existing top-level surfaces stable where possible
+and introduces the richer breakdown mainly through an additive field
+(`RUv2_metrics`) and additive Prometheus metrics.
+
+## Unresolved Questions
+
+- The runtime stats formatter will need a clear notion of an RU display
+  version. If TiDB needs to support a runtime
+  switch between RU v1 and RU v2 later, the final user-facing contract for that
+  toggle still needs to be defined.
+- This proposal exports raw RU v2 Prometheus metrics but does not yet define
+  `METRICS_SCHEMA` tables or dashboards for them.

--- a/docs/design/2026-03-21-ru-v2.md
+++ b/docs/design/2026-03-21-ru-v2.md
@@ -85,7 +85,8 @@ The combined value is then reused for:
 - `EXPLAIN ANALYZE`,
 - slow log,
 - `INFORMATION_SCHEMA.SLOW_QUERY`,
-- resource-group consumption observation.
+- `INFORMATION_SCHEMA.STATEMENTS_SUMMARY`,
+- engine-split resource-group consumption observation.
 
 ### TiDB-side RU v2 weights
 
@@ -221,13 +222,14 @@ result is generated, and it is not double-counted again during statement finish.
 Slow log gains a new optional field:
 
 ```text
-# RUv2_metrics: total_ru:19983, tidb_ru:8750, tikv_ru:10987, tiflash_ru:246, result_chunk_cells:1000, resource_manager_write_cnt:20, tikv_coprocessor_executor_work_total:{BatchTopN:10}
+# RUv2_metrics: total_ru:19983.42, tidb_ru:8750.10, tikv_ru:10987.32, tiflash_ru:246.00, result_chunk_cells:1000, resource_manager_write_cnt:20, tikv_coprocessor_executor_work_total:{BatchTopN:10}
 ```
 
 The formatting rules are:
 
 - the field name is exactly `RUv2_metrics`,
 - the output always starts with `total_ru`, `tidb_ru`, `tikv_ru`, and `tiflash_ru`,
+- those four RU fields are formatted as decimal `float64` values with exactly two fractional digits,
 - additional counters are appended only when their value is non-zero, in the
   following fixed declaration order:
   1. `result_chunk_cells`
@@ -315,6 +317,9 @@ The RU v2 values are computed using the same formula as the slow log:
 total_ru = tidb_ru + tikv_ru + tiflash_ru
 ```
 
+As with slow log formatting, the underlying RU v2 calculation uses `float64`
+values rather than integer truncation.
+
 This provides users with aggregated RU v2 statistics alongside existing RU metrics, making it easier to identify high-cost statements from a resource consumption perspective.
 
 ### Prometheus metrics
@@ -347,16 +352,20 @@ new `METRICS_SCHEMA` table definition for them.
 ### Resource-group observation and cursor accounting
 
 The resource-group consumption reporter interface is extended so TiDB can report
-TiDB-side RU v2 and TiKV-side RU v2 separately.
+engine-split RU v2 in a single call:
+
+```text
+ReportRUV2Consumption(resourceGroupName, tikv_ru, tidb_ru, tiflash_ru)
+```
 
 This is especially important for server-side cursors. Statement execution may
 already consume some RU before the first `FETCH`, while later `FETCH` and `CLOSE`
-operations may consume more result materialization or TiKV RU. The design adds a
+operations may consume more result materialization, TiKV RU, or TiFlash RU. The design adds a
 cursor tracker so only the delta after execution is reported during fetch/close.
 
 This change is mostly internal, but it is important for correctness because it
-keeps resource-group observation consistent with the slow log and `EXPLAIN ANALYZE`
-numbers.
+keeps engine-split resource-group observation consistent with the slow log and
+`EXPLAIN ANALYZE` numbers.
 
 ## Test Design
 

--- a/docs/design/2026-03-21-ru-v2.md
+++ b/docs/design/2026-03-21-ru-v2.md
@@ -198,7 +198,7 @@ existing `RUDetails` path and is folded into the final `tiflash_ru` field.
 
 ### `EXPLAIN ANALYZE`
 
-`EXPLAIN ANALYZE` remains text-compatible at the surface level: it still prints a
+`EXPLAIN ANALYZE` remains text-compatible at the surface: it still prints a
 single `RU:` entry in runtime stats.
 
 The semantic change is that the value now comes from RU v2 total:
@@ -227,8 +227,28 @@ The formatting rules are:
 
 - the field name is exactly `RUv2_metrics`,
 - the output always starts with `total_ru`, `tidb_ru`, `tikv_ru`, and `tiflash_ru`,
-- additional counters are appended only when their value is non-zero,
-- label maps are formatted as `{label:value,...}` with keys sorted lexicographically,
+- additional counters are appended only when their value is non-zero, in the
+  following fixed declaration order:
+  1. `result_chunk_cells`
+  2. `executor_l1`
+  3. `executor_l2`
+  4. `executor_l3`
+  5. `executor_l5_insert_rows`
+  6. `plan_cnt`
+  7. `plan_derive_stats_paths`
+  8. `session_parser_total`
+  9. `txn_cnt`
+  10. `resource_manager_read_cnt`
+  11. `resource_manager_write_cnt`
+  12. `tikv_kv_engine_cache_miss`
+  13. `tikv_coprocessor_executor_iterations`
+  14. `tikv_coprocessor_response_bytes`
+  15. `tikv_raftstore_store_write_trigger_wb_bytes`
+  16. `tikv_storage_processed_keys_batch_get`
+  17. `tikv_storage_processed_keys_get`
+  18. `tikv_coprocessor_executor_work_total`
+- label maps (`executor_l1`/`executor_l2`/`executor_l3`/`tikv_coprocessor_executor_work_total`)
+  are formatted as `{label:value,...}` with keys sorted lexicographically,
 - the whole field is omitted when all RU v2 counters and TiKV/TiFlash RU values are zero.
 
 This format is intentionally more detailed than the legacy RU output. It lets users

--- a/docs/design/2026-03-21-ru-v2.md
+++ b/docs/design/2026-03-21-ru-v2.md
@@ -129,6 +129,20 @@ This lets TiDB-side and TiKV-side RU v2 evolve separately, but it also means the
 operator must keep the two scales aligned manually if a single comparable total
 is desired.
 
+Two keys in `[tikv-client.ru-v2]` have no direct counterpart in the visible-keys
+list because they represent inputs that are not sourced from `ExecDetailsV2.RuV2`:
+
+- `resource-manager-write-cnt-tikv`: weight applied to the count of completed
+  write RPCs to TiKV (`writeRPCCount`), which is tracked client-side in
+  client-go rather than returned in the TiKV response payload.  It therefore
+  does not appear as a snapshot field and is not emitted in the slow log.
+- `executor-inputs`: weight applied to the **sum** of all per-executor work
+  counters returned in `ExecDetailsV2.RuV2.ExecutorInputs`
+  (`TikvCoprocessorExecutorWorkTotalBatch*`).  The visible-keys section lists
+  `tikv_coprocessor_executor_work_total` as a per-label map (one entry per
+  executor type) for observability; the config key collapses all of those
+  labels into a single scalar weight for the RU calculation.
+
 This design does not add a SQL variable for RU v2 tuning. The interface is
 configuration-driven.
 

--- a/docs/design/2026-03-21-ru-v2.md
+++ b/docs/design/2026-03-21-ru-v2.md
@@ -149,7 +149,7 @@ The TiDB-side counters exposed in RU v2 are:
 The executor groups are defined as follows:
 
 - `executor_l1`: `BatchPointGetExec`, `PointGetExecutor`, `LimitExec`
-- `executor_l2`: `HashAggExec`, `HashJoinExec`, `IndexLookUpJoin`,
+- `executor_l2`: `HashAggExec`, `HashJoinV1Exec`/`HashJoinV2Exec` (reported as `HashJoinExec`), `IndexLookUpJoin`,
   `IndexLookUpExecutor`, `IndexReaderExecutor`, `MemTableReaderExec`,
   `SelectionExec`, `TableDualExec`, `TableReaderExecutor`, `UnionScanExec`,
   `SelectLockExec`
@@ -222,7 +222,7 @@ inspect both the final total and the source of that total directly from the slow
 
 ### `INFORMATION_SCHEMA.SLOW_QUERY` and `CLUSTER_SLOW_QUERY`
 
-The slow-query table schema gains a new `LONG BLOB` column named
+The slow-query table schema gains a new `LONGBLOB` column named
 `RUv2_metrics`. The stored payload is the same formatted text written in the raw
 slow log.
 

--- a/docs/design/2026-03-21-ru-v2.md
+++ b/docs/design/2026-03-21-ru-v2.md
@@ -94,7 +94,7 @@ The design adds a new top-level configuration block:
 
 ```toml
 [ru-v2]
-ru-scale = 5697.054498
+ru-scale = 1.34
 result-chunk-cells = 0.00010000
 executor-l1 = 0.00013278
 executor-l2 = 0.00000383
@@ -115,7 +115,7 @@ The design also extends the TiKV client configuration:
 
 ```toml
 [tikv-client.ru-v2]
-ru-scale = 5697.054498
+ru-scale = 1.40
 tikv-kv-engine-cache-miss = 0.45975389
 resource-manager-write-cnt-tikv = 0.09642181
 executor-inputs = 0.00003150

--- a/docs/design/2026-03-21-ru-v2.md
+++ b/docs/design/2026-03-21-ru-v2.md
@@ -31,6 +31,7 @@ The most important user-visible changes are:
 - `EXPLAIN ANALYZE` still prints `RU:`, but the value now comes from RU v2 total,
 - slow log gains an optional `RUv2_metrics` field with both totals and a detailed breakdown,
 - `INFORMATION_SCHEMA.SLOW_QUERY` and `INFORMATION_SCHEMA.CLUSTER_SLOW_QUERY` gain a new `RUv2_metrics` column,
+- `INFORMATION_SCHEMA.STATEMENTS_SUMMARY` and related tables gain `AVG_REQUEST_UNIT_V2` and `MAX_REQUEST_UNIT_V2` columns for aggregated RU v2 statistics,
 - Prometheus gains a `tidb_ruv2_*` metric family for the underlying counters.
 
 ## Motivation or Background
@@ -282,6 +283,40 @@ ORDER BY time DESC
 LIMIT 5;
 ```
 
+### `INFORMATION_SCHEMA.STATEMENTS_SUMMARY` and related tables
+
+The statements summary tables also gain new columns for RU v2 metrics:
+
+- `AVG_REQUEST_UNIT_V2`: The average request-unit v2 cost of these statements (aggregated),
+- `MAX_REQUEST_UNIT_V2`: The maximum request-unit v2 cost of these statements.
+
+These columns are added to the following tables:
+- `INFORMATION_SCHEMA.STATEMENTS_SUMMARY`
+- `INFORMATION_SCHEMA.STATEMENTS_SUMMARY_HISTORY`
+- `INFORMATION_SCHEMA.CLUSTER_STATEMENTS_SUMMARY`
+- `INFORMATION_SCHEMA.CLUSTER_STATEMENTS_SUMMARY_HISTORY`
+
+The RU v2 values are aggregated across all executions of the same statement digest:
+- `AVG_REQUEST_UNIT_V2` is calculated as the total RU v2 divided by the execution count,
+- `MAX_REQUEST_UNIT_V2` tracks the maximum RU v2 value observed for any single execution.
+
+An example query to inspect RU v2 metrics from statement summaries:
+
+```sql
+SELECT digest_text, exec_count, avg_request_unit_v2, max_request_unit_v2
+FROM information_schema.statements_summary
+WHERE avg_request_unit_v2 > 0
+ORDER BY avg_request_unit_v2 DESC
+LIMIT 5;
+```
+
+The RU v2 values are computed using the same formula as the slow log:
+```text
+total_ru = tidb_ru + tikv_ru + tiflash_ru
+```
+
+This provides users with aggregated RU v2 statistics alongside existing RU metrics, making it easier to identify high-cost statements from a resource consumption perspective.
+
 ### Prometheus metrics
 
 The design registers a `tidb_ruv2_*` metric family so operators can inspect the
@@ -372,15 +407,20 @@ Follow-up benchmarking should focus on:
 Impacts:
 
 - Users get a richer and more consistent RU story across `EXPLAIN ANALYZE`,
-  slow log, and `INFORMATION_SCHEMA.SLOW_QUERY`.
+  slow log, `INFORMATION_SCHEMA.SLOW_QUERY`, and `INFORMATION_SCHEMA.STATEMENTS_SUMMARY`.
 - Operators can inspect the TiDB-side share of RU instead of seeing only the
   storage-side total.
 - Prometheus can capture the raw RU v2 components directly.
+- Statement summary tables provide aggregated RU v2 statistics for workload analysis
+  and identifying high-cost queries over time.
 
 Risks:
 
 - Consumers that parse `SELECT * FROM information_schema.slow_query` by column
   position may break because of the new `RUv2_metrics` column.
+- Consumers that parse `SELECT * FROM information_schema.statements_summary` (or
+  related tables) by column position may break because of the new `AVG_REQUEST_UNIT_V2`
+  and `MAX_REQUEST_UNIT_V2` columns.
 - Slow-log parsers that assume a fixed list of `# key: value` fields may need to
   tolerate the optional `RUv2_metrics` line.
 - If `[ru-v2].ru-scale` and `[tikv-client.ru-v2].ru-scale` diverge, `total_ru`


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67199

Problem Summary:

RU v2 needs a design document that explains the user-visible behavior changes, especially the new observability surfaces such as `EXPLAIN ANALYZE`, slow log, and `INFORMATION_SCHEMA.SLOW_QUERY`.

### What changed and how does it work?

- Add `docs/design/2026-03-21-ru-v2.md`.
- Document the proposed RU v2 accounting model, configuration, observability outputs, and compatibility considerations.
- Call out the user-visible changes explicitly, including `RUv2_metrics` in slow log and `INFORMATION_SCHEMA.SLOW_QUERY`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > - [x] I ran `git diff --check -- docs/design/2026-03-21-ru-v2.md`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design spec for statement-scoped RU v2 accounting and observability.
  * Defines unified RU totals combining TiDB, TiKV, and TiFlash signals and new RU v2 configuration options.
  * Describes user-visible changes: EXPLAIN ANALYZE reports combined RU totals (with idempotent handling for INSERT), slow log may include a formatted RUv2_metrics breakdown, and slow-query schemas gain a RUv2_metrics column.
  * Documents new Prometheus tidb_ruv2_* metrics and cursor/resource-group reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->