### PR TITLE
statistics: fix flaky TestSkipStatsInitWithSkipInitStats

### DIFF
--- a/pkg/statistics/handle/handletest/initstats/init_stats_test.go
+++ b/pkg/statistics/handle/handletest/initstats/init_stats_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
@@ -287,10 +288,13 @@ func testDropTableBeforeInitStats(t *testing.T) {
 }
 
 func TestSkipStatsInitWithSkipInitStats(t *testing.T) {
-	config.GetGlobalConfig().Performance.SkipInitStats = true
-	defer func() {
-		config.GetGlobalConfig().Performance.SkipInitStats = false
-	}()
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Performance.SkipInitStats = true
+	})
+	originalStatsLease := vardef.GetStatsLease()
+	defer vardef.SetStatsLease(originalStatsLease)
 
 	store, dom := session.CreateStoreAndBootstrap(t)
 	defer store.Close()
@@ -301,7 +305,9 @@ func TestSkipStatsInitWithSkipInitStats(t *testing.T) {
 	session.MustExec(t, se, "analyze table t all columns;")
 	dom.Close()
 
-	vardef.SetStatsLease(3)
+	// Keep the periodic stats updater enabled, but give the assertion time to
+	// observe the skipped init path before the first background refresh.
+	vardef.SetStatsLease(3 * time.Second)
 	dom, err := session.BootstrapSession(store)
 	require.NoError(t, err)
 	h := dom.StatsHandle()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66981

Problem Summary:
`TestSkipStatsInitWithSkipInitStats` temporarily sets the stats lease to `3`, which means `3ns` and lets the background stats updater race the skipped-init assertion.

### What changed and how does it work?

- restore `SkipInitStats` through `config.RestoreFunc()` / `config.UpdateGlobal(...)`
- save and restore the previous stats lease in the test
- use `3 * time.Second` instead of `3` for the temporary positive lease

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test configuration and timing controls for statistics initialization validation to ensure reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->