### PR TITLE
pkg/server: restore stats lease in TestInitStatsSessionBlockGC

### DIFF
--- a/pkg/server/stat_test.go
+++ b/pkg/server/stat_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/keyspace"
 	"github.com/pingcap/tidb/pkg/server/internal/util"
 	"github.com/pingcap/tidb/pkg/session"
+	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/oracle"
@@ -71,6 +72,9 @@ func TestInitStatsSessionBlockGC(t *testing.T) {
 	defer func() {
 		config.StoreGlobalConfig(origConfig)
 	}()
+	origStatsLease := vardef.GetStatsLease()
+	defer vardef.SetStatsLease(origStatsLease)
+	vardef.SetStatsLease(3 * time.Second)
 	newConfig := *origConfig
 	for _, lite := range []bool{false, true} {
 		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/statistics/handle/beforeInitStats", "pause"))


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67228

Problem Summary:

`TestInitStatsSessionBlockGC` can fail when a previous test in the same `pkg/server` test binary has called `testkit.CreateMockStoreAndDomain()`. That helper disables stats globally by setting the process-wide stats lease to `-1`, so the init-stats code path no longer blocks GC as this test expects.

### What changed and how does it work?

This PR makes `TestInitStatsSessionBlockGC` save the current stats lease, set it to `3s` for the duration of the test, and restore the original value afterward. That keeps the test self-contained even when earlier tests leave the global stats lease disabled.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test commands:

```bash
make failpoint-enable && (
  cd pkg/server &&
  go test -v -run 'TestCursorExistsFlag|TestInitStatsSessionBlockGC' -tags=intest,deadlock
); rc=$?; make failpoint-disable; exit $rc
```

```bash
make bazel_lint_changed
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability and isolation for stats session configuration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->