### PR TITLE
docs: fix unclosed code block in tidb_http_api.md

### DIFF
--- a/docs/tidb_http_api.md
+++ b/docs/tidb_http_api.md
@@ -443,6 +443,7 @@ timezone.*
             }
         }
     }
+    ```
 
 15. Scatter regions of the specified table, add a `scatter-range` scheduler for the PD and the range is same as the table range.
 


### PR DESCRIPTION
## Problem\n\nIn `docs/tidb_http_api.md`, item 14's last JSON code block (the clustered index example response) is missing a closing code fence (` ``` `). This causes all subsequent content (items 15–42, Test-only APIs section, and TiDB-X APIs section) to be rendered inside the code block when viewed on GitHub.\n\n## Fix\n\nAdded the missing closing ` ``` ` after item 14's last JSON response block, before item 15.\n\n## Before\n\nItems 15+ are rendered as part of item 14's code block:\n\n```\n    }\n\n15. Scatter regions of the specified table...\n```\n\n## After\n\nItems 15+ render correctly as separate documentation sections:\n\n```\n    }\n    ```\n\n15. Scatter regions of the specified table...\n```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed markdown formatting in the TiDB HTTP API documentation to ensure code blocks are properly closed and display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->