### PR TITLE
planner: refine reuse chunk gating for overlong types

### DIFF
--- a/pkg/planner/core/casetest/physicalplantest/physical_plan_test.go
+++ b/pkg/planner/core/casetest/physicalplantest/physical_plan_test.go
@@ -1700,6 +1700,11 @@ func TestSemiJoinRewriter(t *testing.T) {
 func TestDisableReuseChunk(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, _, _ string) {
 		tk.MustExec("use test")
+		originMaxMemoryLimitForOverlongType := core.MaxMemoryLimitForOverlongType
+		defer func() {
+			core.MaxMemoryLimitForOverlongType = originMaxMemoryLimitForOverlongType
+		}()
+
 		tk.MustExec("drop table if exists t1;")
 		tk.MustExec("create table t1(c1 int primary key, c2 mediumtext);")
 		tk.MustExec(`insert into t1 values (1, "abc"), (2, "def");`)

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -1282,13 +1282,11 @@ func allowReuseChunkForOverlongType(plan base.PhysicalPlan, overlongColumns []*e
 		rowsPerReusableChunk = min(rowsPerReusableChunk, float64(plan.SCtx().GetSessionVars().MaxChunkSize))
 	}
 
+	statsInfo := plan.StatsInfo()
 	estimatedBytesPerRow := float64(totalFlen)
-	if hasTrustedStats && hasUsableOverlongTypeSizeStats(plan.StatsInfo(), overlongColumns) {
+	if hasTrustedStats && hasUsableOverlongTypeSizeStats(statsInfo, overlongColumns) {
 		// Real stats let us use the observed average size instead of the schema worst case.
-		estimatedBytesPerRow = getAvgRowSize(plan.StatsInfo(), overlongColumns)
-		if estimatedBytesPerRow <= 0 {
-			return false
-		}
+		estimatedBytesPerRow = getAvgRowSize(statsInfo, overlongColumns)
 	}
 	estimatedReusableChunkBytes := rowsPerReusableChunk * estimatedBytesPerRow
 	return estimatedReusableChunkBytes <= float64(maxFlenForOverlongType)

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -1274,12 +1274,12 @@ func allowReuseChunkForOverlongType(plan base.PhysicalPlan, overlongColumns []*e
 		return totalFlen <= maxFlenForOverlongType
 	}
 
-	// Chunk reuse retains the buffers of one reusable chunk, not the full result set.
-	rowsInReusableChunk := estimatedRows
+	// Estimate the retained reusable chunk size as rows per chunk * bytes per row.
+	rowsPerReusableChunk := estimatedRows
 	switch plan.(type) {
 	case *physicalop.PointGetPlan:
 	default:
-		rowsInReusableChunk = min(rowsInReusableChunk, float64(plan.SCtx().GetSessionVars().MaxChunkSize))
+		rowsPerReusableChunk = min(rowsPerReusableChunk, float64(plan.SCtx().GetSessionVars().MaxChunkSize))
 	}
 
 	estimatedBytesPerRow := float64(totalFlen)
@@ -1290,13 +1290,14 @@ func allowReuseChunkForOverlongType(plan base.PhysicalPlan, overlongColumns []*e
 			return false
 		}
 	}
-	return rowsInReusableChunk*estimatedBytesPerRow <= float64(maxFlenForOverlongType)
+	estimatedReusableChunkBytes := rowsPerReusableChunk * estimatedBytesPerRow
+	return estimatedReusableChunkBytes <= float64(maxFlenForOverlongType)
 }
 
 // estimateReusableChunkRowsForOverlongType returns the row bound used by the reusable-chunk memory
-// estimate together with a flag indicating whether the caller may trust observed average row sizes.
-// Point gets have an operator-level row bound, but they still size rows via the schema-level fallback.
-// Non-point readers only enter the relaxed path when row-count stats are trusted.
+// estimate together with a flag indicating whether the caller may use observed average row sizes.
+// Point gets have an exact operator-level row bound. Non-point readers only enter the relaxed path
+// when row-count stats are trusted.
 func estimateReusableChunkRowsForOverlongType(plan base.PhysicalPlan) (estimatedRows float64, hasTrustedStats bool) {
 	statsInfo := plan.StatsInfo()
 	if statsInfo == nil || statsInfo.RowCount <= 0 {
@@ -1305,7 +1306,7 @@ func estimateReusableChunkRowsForOverlongType(plan base.PhysicalPlan) (estimated
 
 	switch plan.(type) {
 	case *physicalop.PointGetPlan:
-		return math.Ceil(statsInfo.RowCount), false
+		return math.Ceil(statsInfo.RowCount), true
 	case *physicalop.PhysicalTableReader, *physicalop.PhysicalIndexReader,
 		*physicalop.PhysicalIndexLookUpReader, *physicalop.PhysicalIndexMergeReader:
 		// Non-point readers only take the relaxed path when row-count stats are trusted.

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -1226,9 +1226,9 @@ var (
 //	average size of overlong columns * min(estimated row count, MaxChunkSize)
 //
 // All relaxed paths first require server memory >= MaxMemoryLimitForOverlongType; otherwise chunk
-// reuse is unconditionally disabled. When memory is sufficient, point gets and readers without a
-// trusted row bound fall back to the schema-declared flen check. Only readers with trusted row-count
-// stats use observed average sizes.
+// reuse is unconditionally disabled. Point gets and batch point gets have an exact operator-level
+// row bound, while non-point readers only take the relaxed path when row-count stats are trusted.
+// Only readers with trusted row-count stats use observed average sizes.
 func shouldSkipReuseChunkForPhysicalPlan(plan base.PhysicalPlan) bool {
 	schema := plan.Schema()
 	if schema == nil {
@@ -1270,8 +1270,8 @@ func allowReuseChunkForOverlongType(plan base.PhysicalPlan, overlongColumns []*e
 	}
 	estimatedRows, hasTrustedStats := estimateReusableChunkRowsForOverlongType(plan)
 	if estimatedRows <= 0 {
-		// Without a trusted row bound, keep the old schema-level gate instead of forcing disable.
-		return totalFlen <= maxFlenForOverlongType
+		// Without a trusted row bound, keep the old conservative behavior for non-point readers.
+		return false
 	}
 
 	// Estimate the retained reusable chunk size as rows per chunk * bytes per row.

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -1176,7 +1176,7 @@ func disableReuseChunkIfNeeded(sctx base.PlanContext, plan base.PhysicalPlan) {
 	}
 }
 
-// checkOverlongColType Check if read field type is long field.
+// checkOverlongColType checks whether the reader output can safely reuse chunks.
 func checkOverlongColType(sctx base.PlanContext, plan base.PhysicalPlan) (skipReuseChunk bool, continueIterating bool) {
 	if plan == nil {
 		return false, false
@@ -1184,12 +1184,12 @@ func checkOverlongColType(sctx base.PlanContext, plan base.PhysicalPlan) (skipRe
 	switch plan.(type) {
 	case *physicalop.PhysicalTableReader, *physicalop.PhysicalIndexReader,
 		*physicalop.PhysicalIndexLookUpReader, *physicalop.PhysicalIndexMergeReader:
-		if existsOverlongType(plan.Schema(), false) {
+		if existsOverlongType(plan) {
 			sctx.GetSessionVars().ClearAlloc(nil, false)
 			return true, false
 		}
 	case *physicalop.PointGetPlan:
-		if existsOverlongType(plan.Schema(), true) {
+		if existsOverlongType(plan) {
 			sctx.GetSessionVars().ClearAlloc(nil, false)
 			return true, false
 		}
@@ -1214,17 +1214,22 @@ var (
 	maxFlenForOverlongType        = mysql.MaxBlobWidth * 2
 )
 
-// existsOverlongType Check if exists long type column.
-// If pointGet is true, we will check the total Flen of all columns, if it exceeds maxFlenForOverlongType,
-// we will disable chunk reuse.
-// For a point get, there is only one row, so we can easily estimate the size.
-// However, for a non-point get, there may be many rows, and it is impossible to determine the memory size used.
-// Therefore, we can only forcibly skip the reuse chunk.
-func existsOverlongType(schema *expression.Schema, pointGet bool) bool {
+// existsOverlongType checks whether the reader output should disable chunk reuse.
+// We estimate the retained memory of a reusable chunk instead of the total query output.
+// For readers with non-pseudo stats, we use:
+//
+//	average size of overlong columns * min(estimated row count, MaxChunkSize)
+//
+// For point gets or readers without trusted stats, we fall back to the schema-declared flen.
+// Reuse is kept enabled only when the server memory is large enough and the estimate stays within
+// maxFlenForOverlongType.
+func existsOverlongType(plan base.PhysicalPlan) bool {
+	schema := plan.Schema()
 	if schema == nil {
 		return false
 	}
 	totalFlen := 0
+	overlongColumns := make([]*expression.Column, 0, len(schema.Columns))
 	for _, column := range schema.Columns {
 		switch column.RetType.GetType() {
 		case mysql.TypeLongBlob,
@@ -1238,28 +1243,59 @@ func existsOverlongType(schema *expression.Schema, pointGet bool) bool {
 			if column.RetType.GetFlen() <= 1000 {
 				continue
 			}
-			if pointGet {
-				totalFlen += column.RetType.GetFlen()
-				if checkOverlongTypeForPointGet(totalFlen) {
-					return true
-				}
-				continue
-			}
-			return true
+			totalFlen += column.RetType.GetFlen()
+			overlongColumns = append(overlongColumns, column)
 		}
 	}
-	return false
+	if totalFlen == 0 {
+		return false
+	}
+	return !allowReuseChunkForOverlongType(plan, overlongColumns, totalFlen)
 }
 
-func checkOverlongTypeForPointGet(totalFlen int) bool {
+func allowReuseChunkForOverlongType(plan base.PhysicalPlan, overlongColumns []*expression.Column, totalFlen int) bool {
 	totalMemory, err := memory.MemTotal()
-	if err != nil || totalMemory <= 0 {
-		return true
+	if err != nil || totalMemory <= 0 || totalMemory < MaxMemoryLimitForOverlongType {
+		return false
 	}
-	if totalMemory >= MaxMemoryLimitForOverlongType {
-		if totalFlen <= maxFlenForOverlongType {
+	estimatedRows, hasTrustedStats := getEstimatedRowsForOverlongType(plan)
+	if estimatedRows <= 0 {
+		return false
+	}
+
+	rowsInReusableChunk := estimatedRows
+	switch plan.(type) {
+	case *physicalop.PointGetPlan:
+	default:
+		rowsInReusableChunk = min(rowsInReusableChunk, float64(plan.SCtx().GetSessionVars().MaxChunkSize))
+	}
+
+	estimatedBytesPerRow := float64(totalFlen)
+	if hasTrustedStats {
+		estimatedBytesPerRow = getAvgRowSize(plan.StatsInfo(), overlongColumns)
+		if estimatedBytesPerRow <= 0 {
 			return false
 		}
 	}
-	return true
+	return rowsInReusableChunk*estimatedBytesPerRow <= float64(maxFlenForOverlongType)
+}
+
+func getEstimatedRowsForOverlongType(plan base.PhysicalPlan) (estimatedRows float64, hasTrustedStats bool) {
+	statsInfo := plan.StatsInfo()
+	if statsInfo == nil || statsInfo.RowCount <= 0 {
+		return 0, false
+	}
+
+	switch plan.(type) {
+	case *physicalop.PointGetPlan:
+		return math.Ceil(statsInfo.RowCount), false
+	case *physicalop.PhysicalTableReader, *physicalop.PhysicalIndexReader,
+		*physicalop.PhysicalIndexLookUpReader, *physicalop.PhysicalIndexMergeReader:
+		if statsInfo.HistColl == nil || statsInfo.HistColl.Pseudo {
+			return 0, false
+		}
+		return math.Ceil(statsInfo.RowCount), true
+	default:
+		return 0, false
+	}
 }

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -1234,6 +1234,7 @@ func existsOverlongType(plan base.PhysicalPlan) bool {
 		switch column.RetType.GetType() {
 		case mysql.TypeLongBlob,
 			mysql.TypeBlob, mysql.TypeJSON, mysql.TypeTiDBVectorFloat32:
+			// These types are still treated as unbounded here, so keep the old conservative behavior.
 			return true
 		case mysql.TypeVarString, mysql.TypeVarchar, mysql.TypeTinyBlob, mysql.TypeMediumBlob:
 			// if the column is varchar and the length of
@@ -1263,6 +1264,7 @@ func allowReuseChunkForOverlongType(plan base.PhysicalPlan, overlongColumns []*e
 		return false
 	}
 
+	// Chunk reuse retains the buffers of a reusable chunk, not the full result set.
 	rowsInReusableChunk := estimatedRows
 	switch plan.(type) {
 	case *physicalop.PointGetPlan:
@@ -1272,6 +1274,7 @@ func allowReuseChunkForOverlongType(plan base.PhysicalPlan, overlongColumns []*e
 
 	estimatedBytesPerRow := float64(totalFlen)
 	if hasTrustedStats {
+		// Real stats let us use the observed average size instead of the schema worst case.
 		estimatedBytesPerRow = getAvgRowSize(plan.StatsInfo(), overlongColumns)
 		if estimatedBytesPerRow <= 0 {
 			return false
@@ -1291,6 +1294,7 @@ func getEstimatedRowsForOverlongType(plan base.PhysicalPlan) (estimatedRows floa
 		return math.Ceil(statsInfo.RowCount), false
 	case *physicalop.PhysicalTableReader, *physicalop.PhysicalIndexReader,
 		*physicalop.PhysicalIndexLookUpReader, *physicalop.PhysicalIndexMergeReader:
+		// Non-point readers only take the relaxed path when row-count stats are trusted.
 		if statsInfo.HistColl == nil || statsInfo.HistColl.Pseudo {
 			return 0, false
 		}

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -1191,7 +1191,7 @@ func checkSkipReuseChunkForOverlongType(sctx base.PlanContext, plan base.Physica
 			sctx.GetSessionVars().ClearAlloc(nil, false)
 			return true, false
 		}
-	case *physicalop.PointGetPlan:
+	case *physicalop.PointGetPlan, *physicalop.BatchPointGetPlan:
 		if shouldSkipReuseChunkForPhysicalPlan(plan) {
 			sctx.GetSessionVars().ClearAlloc(nil, false)
 			return true, false
@@ -1283,7 +1283,7 @@ func allowReuseChunkForOverlongType(plan base.PhysicalPlan, overlongColumns []*e
 	}
 
 	estimatedBytesPerRow := float64(totalFlen)
-	if hasTrustedStats {
+	if hasTrustedStats && hasUsableOverlongTypeSizeStats(plan.StatsInfo(), overlongColumns) {
 		// Real stats let us use the observed average size instead of the schema worst case.
 		estimatedBytesPerRow = getAvgRowSize(plan.StatsInfo(), overlongColumns)
 		if estimatedBytesPerRow <= 0 {
@@ -1294,10 +1294,28 @@ func allowReuseChunkForOverlongType(plan base.PhysicalPlan, overlongColumns []*e
 	return estimatedReusableChunkBytes <= float64(maxFlenForOverlongType)
 }
 
+func hasUsableOverlongTypeSizeStats(statsInfo *property.StatsInfo, overlongColumns []*expression.Column) bool {
+	if statsInfo == nil || statsInfo.HistColl == nil || statsInfo.HistColl.Pseudo ||
+		statsInfo.HistColl.RealtimeCount == 0 || statsInfo.HistColl.ColNum() == 0 {
+		return false
+	}
+	for _, column := range overlongColumns {
+		colStats := statsInfo.HistColl.GetCol(column.UniqueID)
+		if colStats == nil {
+			return false
+		}
+		// Keep the schema-level fallback when this column would still fall back to EstimateTypeWidth.
+		if !colStats.IsHandle && colStats.TotColSize == 0 && colStats.NullCount != statsInfo.HistColl.RealtimeCount {
+			return false
+		}
+	}
+	return true
+}
+
 // estimateReusableChunkRowsForOverlongType returns the row bound used by the reusable-chunk memory
 // estimate together with a flag indicating whether the caller may use observed average row sizes.
-// Point gets have an exact operator-level row bound. Non-point readers only enter the relaxed path
-// when row-count stats are trusted.
+// Point gets and batch point gets have an exact operator-level row bound. Non-point readers only
+// enter the relaxed path when row-count stats are trusted.
 func estimateReusableChunkRowsForOverlongType(plan base.PhysicalPlan) (estimatedRows float64, hasTrustedStats bool) {
 	statsInfo := plan.StatsInfo()
 	if statsInfo == nil || statsInfo.RowCount <= 0 {
@@ -1307,10 +1325,16 @@ func estimateReusableChunkRowsForOverlongType(plan base.PhysicalPlan) (estimated
 	switch plan.(type) {
 	case *physicalop.PointGetPlan:
 		return math.Ceil(statsInfo.RowCount), true
+	case *physicalop.BatchPointGetPlan:
+		if statsInfo.HistColl == nil || statsInfo.HistColl.Pseudo {
+			return math.Ceil(statsInfo.RowCount), false
+		}
+		return math.Ceil(statsInfo.RowCount), true
 	case *physicalop.PhysicalTableReader, *physicalop.PhysicalIndexReader,
 		*physicalop.PhysicalIndexLookUpReader, *physicalop.PhysicalIndexMergeReader:
 		// Non-point readers only take the relaxed path when row-count stats are trusted.
-		if statsInfo.HistColl == nil || statsInfo.HistColl.Pseudo {
+		if statsInfo.HistColl == nil || statsInfo.HistColl.Pseudo ||
+			statsInfo.HistColl.RealtimeCount == 0 || statsInfo.HistColl.ColNum() == 0 {
 			return 0, false
 		}
 		return math.Ceil(statsInfo.RowCount), true

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -1220,9 +1220,9 @@ var (
 //
 //	average size of overlong columns * min(estimated row count, MaxChunkSize)
 //
-// For point gets or readers without trusted stats, we fall back to the schema-declared flen.
-// Reuse is kept enabled only when the server memory is large enough and the estimate stays within
-// maxFlenForOverlongType.
+// For point gets, or when a reader has no trusted row bound, we fall back to the schema-declared
+// flen check. Reuse is kept enabled only when the server memory is large enough and the estimate
+// stays within maxFlenForOverlongType.
 func existsOverlongType(plan base.PhysicalPlan) bool {
 	schema := plan.Schema()
 	if schema == nil {
@@ -1261,7 +1261,8 @@ func allowReuseChunkForOverlongType(plan base.PhysicalPlan, overlongColumns []*e
 	}
 	estimatedRows, hasTrustedStats := getEstimatedRowsForOverlongType(plan)
 	if estimatedRows <= 0 {
-		return false
+		// Without a trusted row bound, keep the old schema-level gate instead of forcing disable.
+		return totalFlen <= maxFlenForOverlongType
 	}
 
 	// Chunk reuse retains the buffers of a reusable chunk, not the full result set.

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -1168,7 +1168,7 @@ func disableReuseChunkIfNeeded(sctx base.PlanContext, plan base.PhysicalPlan) {
 	if !sctx.GetSessionVars().IsAllocValid() {
 		return
 	}
-	if disableReuseChunk, continueIterating := checkOverlongColType(sctx, plan); disableReuseChunk || !continueIterating {
+	if disableReuseChunk, continueIterating := checkSkipReuseChunkForOverlongType(sctx, plan); disableReuseChunk || !continueIterating {
 		return
 	}
 	for _, child := range plan.Children() {
@@ -1176,20 +1176,23 @@ func disableReuseChunkIfNeeded(sctx base.PlanContext, plan base.PhysicalPlan) {
 	}
 }
 
-// checkOverlongColType checks whether the reader output can safely reuse chunks.
-func checkOverlongColType(sctx base.PlanContext, plan base.PhysicalPlan) (skipReuseChunk bool, continueIterating bool) {
+// checkSkipReuseChunkForOverlongType walks the root-side physical plan tree top-down and stops at
+// the first reader / point get boundary. Only those operators materialize rows into the reusable
+// chunk owned by the current statement, so higher-level physical operators only decide whether the
+// traversal should continue.
+func checkSkipReuseChunkForOverlongType(sctx base.PlanContext, plan base.PhysicalPlan) (skipReuseChunk bool, continueIterating bool) {
 	if plan == nil {
 		return false, false
 	}
 	switch plan.(type) {
 	case *physicalop.PhysicalTableReader, *physicalop.PhysicalIndexReader,
 		*physicalop.PhysicalIndexLookUpReader, *physicalop.PhysicalIndexMergeReader:
-		if existsOverlongType(plan) {
+		if shouldSkipReuseChunkForPhysicalPlan(plan) {
 			sctx.GetSessionVars().ClearAlloc(nil, false)
 			return true, false
 		}
 	case *physicalop.PointGetPlan:
-		if existsOverlongType(plan) {
+		if shouldSkipReuseChunkForPhysicalPlan(plan) {
 			sctx.GetSessionVars().ClearAlloc(nil, false)
 			return true, false
 		}
@@ -1197,8 +1200,8 @@ func checkOverlongColType(sctx base.PlanContext, plan base.PhysicalPlan) (skipRe
 		// Other physical operators do not read data, so we can continue to iterate.
 		return false, true
 	}
-	// PhysicalReader and PointGet is at the root, their children are nil or on the tikv/tiflash side.
-	// So we can stop iterating.
+	// Once we reach a reader / point get, its children are nil or stay on the coprocessor side, so
+	// no other root-side operator can affect the reusable-chunk decision.
 	return false, false
 }
 
@@ -1214,16 +1217,19 @@ var (
 	maxFlenForOverlongType        = mysql.MaxBlobWidth * 2
 )
 
-// existsOverlongType checks whether the reader output should disable chunk reuse.
-// We estimate the retained memory of a reusable chunk instead of the total query output.
-// For readers with non-pseudo stats, we use:
+// shouldSkipReuseChunkForPhysicalPlan checks whether one reader / point get should skip chunk reuse
+// because of overlong output columns. The decision is based on retained reusable-chunk memory rather
+// than full query output size.
+//
+// For readers with trusted row-count stats, we estimate:
 //
 //	average size of overlong columns * min(estimated row count, MaxChunkSize)
 //
-// For point gets, or when a reader has no trusted row bound, we fall back to the schema-declared
-// flen check. Reuse is kept enabled only when the server memory is large enough and the estimate
-// stays within maxFlenForOverlongType.
-func existsOverlongType(plan base.PhysicalPlan) bool {
+// All relaxed paths first require server memory >= MaxMemoryLimitForOverlongType; otherwise chunk
+// reuse is unconditionally disabled. When memory is sufficient, point gets and readers without a
+// trusted row bound fall back to the schema-declared flen check. Only readers with trusted row-count
+// stats use observed average sizes.
+func shouldSkipReuseChunkForPhysicalPlan(plan base.PhysicalPlan) bool {
 	schema := plan.Schema()
 	if schema == nil {
 		return false
@@ -1254,18 +1260,21 @@ func existsOverlongType(plan base.PhysicalPlan) bool {
 	return !allowReuseChunkForOverlongType(plan, overlongColumns, totalFlen)
 }
 
+// allowReuseChunkForOverlongType applies the relaxed rule for bounded overlong columns. It first
+// checks the host-memory gate, then estimates the retained memory of one reusable chunk instead of
+// the whole result set.
 func allowReuseChunkForOverlongType(plan base.PhysicalPlan, overlongColumns []*expression.Column, totalFlen int) bool {
 	totalMemory, err := memory.MemTotal()
 	if err != nil || totalMemory <= 0 || totalMemory < MaxMemoryLimitForOverlongType {
 		return false
 	}
-	estimatedRows, hasTrustedStats := getEstimatedRowsForOverlongType(plan)
+	estimatedRows, hasTrustedStats := estimateReusableChunkRowsForOverlongType(plan)
 	if estimatedRows <= 0 {
 		// Without a trusted row bound, keep the old schema-level gate instead of forcing disable.
 		return totalFlen <= maxFlenForOverlongType
 	}
 
-	// Chunk reuse retains the buffers of a reusable chunk, not the full result set.
+	// Chunk reuse retains the buffers of one reusable chunk, not the full result set.
 	rowsInReusableChunk := estimatedRows
 	switch plan.(type) {
 	case *physicalop.PointGetPlan:
@@ -1284,7 +1293,11 @@ func allowReuseChunkForOverlongType(plan base.PhysicalPlan, overlongColumns []*e
 	return rowsInReusableChunk*estimatedBytesPerRow <= float64(maxFlenForOverlongType)
 }
 
-func getEstimatedRowsForOverlongType(plan base.PhysicalPlan) (estimatedRows float64, hasTrustedStats bool) {
+// estimateReusableChunkRowsForOverlongType returns the row bound used by the reusable-chunk memory
+// estimate together with a flag indicating whether the caller may trust observed average row sizes.
+// Point gets have an operator-level row bound, but they still size rows via the schema-level fallback.
+// Non-point readers only enter the relaxed path when row-count stats are trusted.
+func estimateReusableChunkRowsForOverlongType(plan base.PhysicalPlan) (estimatedRows float64, hasTrustedStats bool) {
 	statsInfo := plan.StatsInfo()
 	if statsInfo == nil || statsInfo.RowCount <= 0 {
 		return 0, false

--- a/pkg/planner/core/optimizer_test.go
+++ b/pkg/planner/core/optimizer_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/executor/join/joinversion"
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -180,6 +181,25 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 
 		reader.SCtx().GetSessionVars().MaxChunkSize = 1024
 		require.True(t, shouldSkipReuseChunkForPhysicalPlan(reader))
+	})
+
+	t.Run("point get uses exact row bound for overlong type estimation", func(t *testing.T) {
+		sctx := coretestsdk.MockContext()
+		defer func() {
+			domain.GetDomain(sctx).StatsHandle().Close()
+		}()
+
+		pointGet := newPointGetPlan(
+			sctx.GetPlanCtx(),
+			"test",
+			expression.NewSchema(),
+			&model.TableInfo{Name: ast.NewCIStr("t")},
+			nil,
+		)
+
+		estimatedRows, hasTrustedStats := estimateReusableChunkRowsForOverlongType(pointGet)
+		require.Equal(t, float64(1), estimatedRows)
+		require.True(t, hasTrustedStats)
 	})
 }
 

--- a/pkg/planner/core/optimizer_test.go
+++ b/pkg/planner/core/optimizer_test.go
@@ -144,19 +144,19 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 			RowCount: 2048,
 			HistColl: &statistics.HistColl{},
 		})
-		require.True(t, existsOverlongType(reader))
+		require.True(t, shouldSkipReuseChunkForPhysicalPlan(reader))
 
 		MaxMemoryLimitForOverlongType = 0
 		reader.SetStats(&property.StatsInfo{
 			RowCount: 2048,
 		})
-		require.False(t, existsOverlongType(reader))
+		require.False(t, shouldSkipReuseChunkForPhysicalPlan(reader))
 
 		reader.SetStats(&property.StatsInfo{
 			RowCount: 2048,
 			HistColl: &statistics.HistColl{Pseudo: true},
 		})
-		require.False(t, existsOverlongType(reader))
+		require.False(t, shouldSkipReuseChunkForPhysicalPlan(reader))
 
 		wideColumns := make([]*expression.Column, 0, 40)
 		for i := range 40 {
@@ -168,7 +168,7 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 		reader.SetStats(&property.StatsInfo{
 			RowCount: 2048,
 		})
-		require.True(t, existsOverlongType(reader))
+		require.True(t, shouldSkipReuseChunkForPhysicalPlan(reader))
 
 		reader.PhysicalSchemaProducer.SetSchema(readerSchema)
 		reader.SCtx().GetSessionVars().MaxChunkSize = 32
@@ -176,10 +176,10 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 			RowCount: 2048,
 			HistColl: &statistics.HistColl{},
 		})
-		require.False(t, existsOverlongType(reader))
+		require.False(t, shouldSkipReuseChunkForPhysicalPlan(reader))
 
 		reader.SCtx().GetSessionVars().MaxChunkSize = 1024
-		require.True(t, existsOverlongType(reader))
+		require.True(t, shouldSkipReuseChunkForPhysicalPlan(reader))
 	})
 }
 

--- a/pkg/planner/core/optimizer_test.go
+++ b/pkg/planner/core/optimizer_test.go
@@ -160,13 +160,13 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 		reader.SetStats(&property.StatsInfo{
 			RowCount: 2048,
 		})
-		require.False(t, shouldSkipReuseChunkForPhysicalPlan(reader))
+		require.True(t, shouldSkipReuseChunkForPhysicalPlan(reader))
 
 		reader.SetStats(&property.StatsInfo{
 			RowCount: 2048,
 			HistColl: &statistics.HistColl{Pseudo: true},
 		})
-		require.False(t, shouldSkipReuseChunkForPhysicalPlan(reader))
+		require.True(t, shouldSkipReuseChunkForPhysicalPlan(reader))
 
 		wideColumns := make([]*expression.Column, 0, 40)
 		for i := range 40 {
@@ -186,7 +186,7 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 			RowCount: 2048,
 			HistColl: &statistics.HistColl{},
 		})
-		require.False(t, shouldSkipReuseChunkForPhysicalPlan(reader))
+		require.True(t, shouldSkipReuseChunkForPhysicalPlan(reader))
 
 		reader.SetStats(&property.StatsInfo{
 			RowCount: 2048,

--- a/pkg/planner/core/optimizer_test.go
+++ b/pkg/planner/core/optimizer_test.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -127,7 +128,6 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 			sctx.GetSessionVars().MaxChunkSize = originMaxChunkSize
 		}()
 
-		MaxMemoryLimitForOverlongType = 0
 		// Keep enough bounded overlong columns so that the same row count flips once MaxChunkSize grows.
 		columns := make([]*expression.Column, 0, 80)
 		for i := range 80 {
@@ -139,6 +139,38 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 		reader := physicalop.PhysicalTableReader{}.Init(sctx.GetPlanCtx(), 0)
 		reader.PhysicalSchemaProducer.SetSchema(readerSchema)
 
+		MaxMemoryLimitForOverlongType = math.MaxInt64
+		reader.SetStats(&property.StatsInfo{
+			RowCount: 2048,
+			HistColl: &statistics.HistColl{},
+		})
+		require.True(t, existsOverlongType(reader))
+
+		MaxMemoryLimitForOverlongType = 0
+		reader.SetStats(&property.StatsInfo{
+			RowCount: 2048,
+		})
+		require.False(t, existsOverlongType(reader))
+
+		reader.SetStats(&property.StatsInfo{
+			RowCount: 2048,
+			HistColl: &statistics.HistColl{Pseudo: true},
+		})
+		require.False(t, existsOverlongType(reader))
+
+		wideColumns := make([]*expression.Column, 0, 40)
+		for i := range 40 {
+			colType := types.NewFieldType(mysql.TypeVarchar)
+			colType.SetFlen(1000001)
+			wideColumns = append(wideColumns, &expression.Column{RetType: colType, UniqueID: int64(1000 + i + 1)})
+		}
+		reader.PhysicalSchemaProducer.SetSchema(expression.NewSchema(wideColumns...))
+		reader.SetStats(&property.StatsInfo{
+			RowCount: 2048,
+		})
+		require.True(t, existsOverlongType(reader))
+
+		reader.PhysicalSchemaProducer.SetSchema(readerSchema)
 		reader.SCtx().GetSessionVars().MaxChunkSize = 32
 		reader.SetStats(&property.StatsInfo{
 			RowCount: 2048,
@@ -147,12 +179,6 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 		require.False(t, existsOverlongType(reader))
 
 		reader.SCtx().GetSessionVars().MaxChunkSize = 1024
-		require.True(t, existsOverlongType(reader))
-
-		reader.SetStats(&property.StatsInfo{
-			RowCount: 2048,
-			HistColl: &statistics.HistColl{Pseudo: true},
-		})
 		require.True(t, existsOverlongType(reader))
 	})
 }

--- a/pkg/planner/core/optimizer_test.go
+++ b/pkg/planner/core/optimizer_test.go
@@ -128,6 +128,7 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 		}()
 
 		MaxMemoryLimitForOverlongType = 0
+		// Keep enough bounded overlong columns so that the same row count flips once MaxChunkSize grows.
 		columns := make([]*expression.Column, 0, 80)
 		for i := range 80 {
 			colType := types.NewFieldType(mysql.TypeVarchar)

--- a/pkg/planner/core/optimizer_test.go
+++ b/pkg/planner/core/optimizer_test.go
@@ -139,6 +139,15 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 		readerSchema := expression.NewSchema(columns...)
 		reader := physicalop.PhysicalTableReader{}.Init(sctx.GetPlanCtx(), 0)
 		reader.PhysicalSchemaProducer.SetSchema(readerSchema)
+		buildTrustedHistColl := func(cols []*expression.Column, rowCount int64, avgColSize int64) *statistics.HistColl {
+			histColl := statistics.NewHistColl(1, rowCount, 0, len(cols), 0)
+			for _, col := range cols {
+				histColl.SetCol(col.UniqueID, &statistics.Column{
+					Histogram: *statistics.NewHistogram(col.UniqueID, rowCount, 0, 0, col.RetType, 0, avgColSize*rowCount),
+				})
+			}
+			return histColl
+		}
 
 		MaxMemoryLimitForOverlongType = math.MaxInt64
 		reader.SetStats(&property.StatsInfo{
@@ -172,11 +181,18 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 		require.True(t, shouldSkipReuseChunkForPhysicalPlan(reader))
 
 		reader.PhysicalSchemaProducer.SetSchema(readerSchema)
-		reader.SCtx().GetSessionVars().MaxChunkSize = 32
+		reader.SCtx().GetSessionVars().MaxChunkSize = 1024
 		reader.SetStats(&property.StatsInfo{
 			RowCount: 2048,
 			HistColl: &statistics.HistColl{},
 		})
+		require.False(t, shouldSkipReuseChunkForPhysicalPlan(reader))
+
+		reader.SetStats(&property.StatsInfo{
+			RowCount: 2048,
+			HistColl: buildTrustedHistColl(columns, 2048, 500),
+		})
+		reader.SCtx().GetSessionVars().MaxChunkSize = 32
 		require.False(t, shouldSkipReuseChunkForPhysicalPlan(reader))
 
 		reader.SCtx().GetSessionVars().MaxChunkSize = 1024
@@ -200,6 +216,56 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 		estimatedRows, hasTrustedStats := estimateReusableChunkRowsForOverlongType(pointGet)
 		require.Equal(t, float64(1), estimatedRows)
 		require.True(t, hasTrustedStats)
+	})
+
+	t.Run("batch point get participates in overlong type chunk reuse gating", func(t *testing.T) {
+		sctx := coretestsdk.MockContext()
+		defer func() {
+			domain.GetDomain(sctx).StatsHandle().Close()
+		}()
+
+		originMaxMemoryLimitForOverlongType := MaxMemoryLimitForOverlongType
+		originMaxChunkSize := sctx.GetSessionVars().MaxChunkSize
+		defer func() {
+			MaxMemoryLimitForOverlongType = originMaxMemoryLimitForOverlongType
+			sctx.GetSessionVars().MaxChunkSize = originMaxChunkSize
+		}()
+
+		MaxMemoryLimitForOverlongType = 0
+
+		columns := make([]*expression.Column, 0, 80)
+		for i := range 80 {
+			colType := types.NewFieldType(mysql.TypeVarchar)
+			colType.SetFlen(1001)
+			columns = append(columns, &expression.Column{RetType: colType, UniqueID: int64(2000 + i + 1)})
+		}
+		batchPointGet := (&physicalop.BatchPointGetPlan{TblInfo: &model.TableInfo{}}).Init(
+			sctx.GetPlanCtx(),
+			&property.StatsInfo{RowCount: 2048},
+			expression.NewSchema(columns...),
+			nil,
+			0,
+		)
+
+		sctx.GetSessionVars().MaxChunkSize = 32
+		require.False(t, shouldSkipReuseChunkForPhysicalPlan(batchPointGet))
+
+		sctx.GetSessionVars().MaxChunkSize = 1024
+		require.True(t, shouldSkipReuseChunkForPhysicalPlan(batchPointGet))
+
+		jsonBatchPointGet := (&physicalop.BatchPointGetPlan{TblInfo: &model.TableInfo{}}).Init(
+			sctx.GetPlanCtx(),
+			&property.StatsInfo{RowCount: 1},
+			expression.NewSchema(&expression.Column{
+				RetType:  types.NewFieldType(mysql.TypeJSON),
+				UniqueID: int64(3001),
+			}),
+			nil,
+			0,
+		)
+		skipReuseChunk, continueIterating := checkSkipReuseChunkForOverlongType(sctx.GetPlanCtx(), jsonBatchPointGet)
+		require.True(t, skipReuseChunk)
+		require.False(t, continueIterating)
 	})
 }
 

--- a/pkg/planner/core/optimizer_test.go
+++ b/pkg/planner/core/optimizer_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/planner/util/coretestsdk"
+	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
@@ -112,6 +113,47 @@ func TestMPPJoinKeyTypeConvert(t *testing.T) {
 	testJoinKeyTypeConvert(t, bigIntType, bigIntType, bigIntType, false, false)
 	testJoinKeyTypeConvert(t, unsignedBigIntType, bigIntType, decimalType, true, true)
 	testJoinKeyTypeConvert(t, bigIntType, unsignedBigIntType, decimalType, true, true)
+
+	t.Run("overlong type chunk reuse uses reusable chunk size", func(t *testing.T) {
+		sctx := coretestsdk.MockContext()
+		defer func() {
+			domain.GetDomain(sctx).StatsHandle().Close()
+		}()
+
+		originMaxMemoryLimitForOverlongType := MaxMemoryLimitForOverlongType
+		originMaxChunkSize := sctx.GetSessionVars().MaxChunkSize
+		defer func() {
+			MaxMemoryLimitForOverlongType = originMaxMemoryLimitForOverlongType
+			sctx.GetSessionVars().MaxChunkSize = originMaxChunkSize
+		}()
+
+		MaxMemoryLimitForOverlongType = 0
+		columns := make([]*expression.Column, 0, 80)
+		for i := range 80 {
+			colType := types.NewFieldType(mysql.TypeVarchar)
+			colType.SetFlen(1001)
+			columns = append(columns, &expression.Column{RetType: colType, UniqueID: int64(i + 1)})
+		}
+		readerSchema := expression.NewSchema(columns...)
+		reader := physicalop.PhysicalTableReader{}.Init(sctx.GetPlanCtx(), 0)
+		reader.PhysicalSchemaProducer.SetSchema(readerSchema)
+
+		reader.SCtx().GetSessionVars().MaxChunkSize = 32
+		reader.SetStats(&property.StatsInfo{
+			RowCount: 2048,
+			HistColl: &statistics.HistColl{},
+		})
+		require.False(t, existsOverlongType(reader))
+
+		reader.SCtx().GetSessionVars().MaxChunkSize = 1024
+		require.True(t, existsOverlongType(reader))
+
+		reader.SetStats(&property.StatsInfo{
+			RowCount: 2048,
+			HistColl: &statistics.HistColl{Pseudo: true},
+		})
+		require.True(t, existsOverlongType(reader))
+	})
 }
 
 // Test for core.handleFineGrainedShuffle()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67108

Problem Summary:

`disableReuseChunkIfNeeded` still disables chunk reuse for some bounded overlong-type queries even when the reusable chunk footprint is small enough to be safe. This causes avoidable allocations and GC overhead for those queries.

### What changed and how does it work?

- Refine the overlong-type reuse-chunk gate in `postOptimize`.
- Keep the hard disable for unbounded large types such as `json/blob/vector`.
- For bounded overlong types, estimate the retained memory of a reusable chunk instead of the total query output:
  `avg size of overlong columns * min(estimated rows, MaxChunkSize)`.
- Only apply the relaxed path when the reader has non-pseudo stats and the host memory is above `MaxMemoryLimitForOverlongType`.
- Add a focused planner unit subtest that covers:
  - small reusable chunk => reuse allowed
  - large reusable chunk => reuse disabled
  - pseudo stats => stay conservative
- Restore `MaxMemoryLimitForOverlongType` in the existing point-get regression test to avoid leaking global state across tests.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test command:

```bash
make failpoint-enable
go test -run TestMPPJoinKeyTypeConvert -vet=off -p 1 -tags=intest,deadlock ./pkg/planner/core
make failpoint-disable
```

Manual test:

1. Replay existing customer plans with this branch in https://github.com/PingCAP-QE/planreplayertest/pull/107.
   - 10 existing plan replayer cases changed from `@@last_sql_use_alloc = 0` to `1`.
   - Covered plan shapes include:
     - wide projection with `ORDER BY ... LIMIT`
     - wide projection with joins / left joins / TiFlash access
     - binding on/off behavior
     - refreshed-stats rerun (`DROP STATS` + `REFRESH STATS`)
2. Local SQL smoke for the conservative branches:

```sql
drop table if exists t_wide, t_json;

create table t_wide (
  id bigint primary key,
  k bigint,
  v1 varchar(2000),
  v2 varchar(2000),
  v3 varchar(2000),
  index idx_k(k)
);

insert into t_wide values
  (1, 1, 'a', 'b', 'c'),
  (2, 2, 'd', 'e', 'f');

explain format = 'brief' select v1, v2, v3 from t_wide where k = 1 limit 1;
select @@last_plan_from_cache, @@last_sql_use_alloc, @@last_plan_from_binding;
-- expect @@last_sql_use_alloc = 0 with pseudo stats

analyze table t_wide;

explain format = 'brief' select v1, v2, v3 from t_wide where k = 1 limit 1;
select @@last_plan_from_cache, @@last_sql_use_alloc, @@last_plan_from_binding;
-- expect @@last_sql_use_alloc = 1 after real stats

create table t_json (
  id bigint primary key,
  j json
);

insert into t_json values (1, json_object('k', 'v'));
analyze table t_json;

explain format = 'brief' select j from t_json where id = 1;
select @@last_plan_from_cache, @@last_sql_use_alloc, @@last_plan_from_binding;
-- expect @@last_sql_use_alloc = 0 because json stays conservative

drop table if exists t_wide, t_json;
```

Not run yet:

- `make lint`
- broader planner/integration validation

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tests now reliably save and restore a global memory-limit setting to prevent cross-test interference.

* **Improvements**
  * Smarter chunk-reuse decisions for very wide/overlong text columns: reuse now considers available server memory, estimated retained rows, per-row size and chunk-size limits rather than blanket disabling.

* **Tests**
  * Added tests covering chunk-reuse gating across memory limits, statistics availability, point/batch lookups, and chunk-size settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
