### PR TITLE
[release-nextgen-20251011] *: adapt TopSQL naming for TopProfiling (prepare for TopRU) (#65820)

### DIFF
--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -401,7 +401,7 @@ func main() {
 		executor.Stop()
 		close(exited)
 	})
-	topsql.SetupTopSQL(keyspace.GetKeyspaceNameBytesBySettings(), svr)
+	topsql.SetupTopProfiling(keyspace.GetKeyspaceNameBytesBySettings(), svr)
 	terror.MustNil(svr.Run(dom))
 	<-exited
 	syncLog()

--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -441,7 +441,7 @@ func (w *backfillWorker) run(d *ddlCtx, bf backfiller, job *model.Job) {
 			return
 		}
 		curTaskID = task.id
-		d.setDDLLabelForTopSQL(job.ID, job.Query)
+		d.attachTopProfilingInfo(job.ID, job.Query)
 
 		logger.Debug("backfill worker got task", zap.Int("workerID", w.GetCtx().id), zap.Stringer("task", task))
 		failpoint.Inject("mockBackfillRunErr", func() {

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -174,7 +174,7 @@ func (s *backfillDistExecutor) newBackfillStepExecutor(
 	switch stage {
 	case proto.BackfillStepReadIndex:
 		jc := ddlObj.jobContext(jobMeta.ID, jobMeta.ReorgMeta)
-		ddlObj.setDDLLabelForTopSQL(jobMeta.ID, jobMeta.Query)
+		ddlObj.attachTopProfilingInfo(jobMeta.ID, jobMeta.Query)
 		ddlObj.setDDLSourceForDiagnosis(jobMeta.ID, jobMeta.Type)
 		return newReadIndexExecutor(store, sessPool, ddlObj.etcdCli, jobMeta, indexInfos, tbl, jc, cloudStorageURI, estRowSize)
 	case proto.BackfillStepMergeSort:

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -453,7 +453,7 @@ func (dc *ddlCtx) isOwner() bool {
 	return isOwner
 }
 
-func (dc *ddlCtx) setDDLLabelForTopSQL(jobID int64, jobQuery string) {
+func (dc *ddlCtx) attachTopProfilingInfo(jobID int64, jobQuery string) {
 	dc.jobCtx.Lock()
 	defer dc.jobCtx.Unlock()
 	ctx, exists := dc.jobCtx.jobCtxMap[jobID]
@@ -461,7 +461,7 @@ func (dc *ddlCtx) setDDLLabelForTopSQL(jobID int64, jobQuery string) {
 		ctx = NewReorgContext()
 		dc.jobCtx.jobCtxMap[jobID] = ctx
 	}
-	ctx.setDDLLabelForTopSQL(jobQuery)
+	ctx.attachTopProfilingInfo(jobQuery)
 }
 
 func (dc *ddlCtx) setDDLSourceForDiagnosis(jobID int64, jobType model.ActionType) {

--- a/pkg/ddl/delete_range.go
+++ b/pkg/ddl/delete_range.go
@@ -215,7 +215,7 @@ func (dr *delRange) doTask(sctx sessionctx.Context, r util.DelRangeTask) error {
 		dr.keys = dr.keys[:0]
 		ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL)
 		err := kv.RunInNewTxn(ctx, dr.store, false, func(_ context.Context, txn kv.Transaction) error {
-			if topsqlstate.TopSQLEnabled() {
+			if topsqlstate.TopProfilingEnabled() {
 				// Only when TiDB run without PD(use unistore as storage for test) will run into here, so just set a mock internal resource tagger.
 				txn.SetOption(kv.ResourceGroupTagger, util.GetInternalResourceGroupTaggerForTopSQL())
 			}

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1269,7 +1269,7 @@ func checkIfTableReorgWorkCanSkip(
 	startTS := txn.StartTS()
 	ctx := NewReorgContext()
 	ctx.resourceGroupName = job.ReorgMeta.ResourceGroupName
-	ctx.setDDLLabelForTopSQL(job.Query)
+	ctx.attachTopProfilingInfo(job.Query)
 	if isEmpty, err := checkIfTableIsEmpty(ctx, store, tbl, startTS); err != nil || !isEmpty {
 		return false
 	}
@@ -1365,7 +1365,7 @@ func checkIfTempIndexReorgWorkCanSkip(
 	startTS := txn.StartTS()
 	ctx := NewReorgContext()
 	ctx.resourceGroupName = job.ReorgMeta.ResourceGroupName
-	ctx.setDDLLabelForTopSQL(job.Query)
+	ctx.attachTopProfilingInfo(job.Query)
 	firstIdxID := allIndexInfos[0].ID
 	lastIdxID := allIndexInfos[len(allIndexInfos)-1].ID
 	var globalIdxIDs []int64

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -468,8 +468,8 @@ func finishRecoverSchema(w *worker, job *model.Job) error {
 	return nil
 }
 
-func (w *ReorgContext) setDDLLabelForTopSQL(jobQuery string) {
-	if !topsqlstate.TopSQLEnabled() || jobQuery == "" {
+func (w *ReorgContext) attachTopProfilingInfo(jobQuery string) {
+	if !topsqlstate.TopProfilingEnabled() || jobQuery == "" {
 		return
 	}
 
@@ -547,7 +547,7 @@ func (w *worker) prepareTxn(job *model.Job) (kv.Transaction, error) {
 	if w.tp == addIdxWorker && job.IsRunning() {
 		txn.SetDiskFullOpt(kvrpcpb.DiskFullOpt_NotAllowedOnFull)
 	}
-	w.setDDLLabelForTopSQL(job.ID, job.Query)
+	w.attachTopProfilingInfo(job.ID, job.Query)
 	w.setDDLSourceForDiagnosis(job.ID, job.Type)
 	jobContext := w.jobContext(job.ID, job.ReorgMeta)
 	if tagger := w.getResourceGroupTaggerForTopSQL(job.ID); tagger != nil {

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -366,7 +366,7 @@ func (a *ExecStmt) PointGet(ctx context.Context) (*recordSet, error) {
 		sessiontxn.AssertTxnManagerInfoSchema(a.Ctx, a.InfoSchema)
 	})
 
-	ctx = a.observeStmtBeginForTopSQL(ctx)
+	ctx = a.observeStmtBeginForTopProfiling(ctx)
 	startTs, err := sessiontxn.GetTxnManager(a.Ctx).GetStmtReadTS()
 	if err != nil {
 		return nil, err
@@ -639,7 +639,7 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 			stmtCtx.ResourceGroupName = switchGroupName
 		}
 	}
-	ctx = a.observeStmtBeginForTopSQL(ctx)
+	ctx = a.observeStmtBeginForTopProfiling(ctx)
 
 	e, err := a.buildExecutor()
 	if err != nil {
@@ -1513,7 +1513,7 @@ func (a *ExecStmt) FinishExecuteStmt(txnTS uint64, err error, hasMoreResults boo
 	// `LowSlowQuery` and `SummaryStmt` must be called before recording `PrevStmt`.
 	a.LogSlowQuery(txnTS, succ, hasMoreResults)
 	a.SummaryStmt(succ)
-	a.observeStmtFinishedForTopSQL()
+	a.observeStmtFinishedForTopProfiling()
 	a.UpdatePlanCacheRuntimeInfo()
 	if sessVars.StmtCtx.IsTiFlash.Load() {
 		if succ {
@@ -2202,10 +2202,10 @@ func (a *ExecStmt) updatePrevStmt() {
 	}
 }
 
-func (a *ExecStmt) observeStmtBeginForTopSQL(ctx context.Context) context.Context {
-	if !topsqlstate.TopSQLEnabled() && IsFastPlan(a.Plan) {
+func (a *ExecStmt) observeStmtBeginForTopProfiling(ctx context.Context) context.Context {
+	if !topsqlstate.TopProfilingEnabled() && IsFastPlan(a.Plan) {
 		// To reduce the performance impact on fast plan.
-		// Drop them does not cause notable accuracy issue in TopSQL.
+		// Drop them does not cause notable accuracy issue in Top Profiling.
 		return ctx
 	}
 
@@ -2221,8 +2221,9 @@ func (a *ExecStmt) observeStmtBeginForTopSQL(ctx context.Context) context.Contex
 		planDigestByte = planDigest.Bytes()
 	}
 	stats := a.Ctx.GetStmtStats()
-	if !topsqlstate.TopSQLEnabled() {
-		// Always attach the SQL and plan info uses to catch the running SQL when Top SQL is enabled in execution.
+	if !topsqlstate.TopProfilingEnabled() {
+		// Always attach the SQL and plan info uses to catch the running SQL when Top Profiling is enabled in execution.
+		// Note: Goroutine labels for CPU profiling are only set when TopSQL is enabled.
 		if stats != nil {
 			stats.OnExecutionBegin(sqlDigestByte, planDigestByte)
 		}
@@ -2272,12 +2273,12 @@ func (a *ExecStmt) UpdatePlanCacheRuntimeInfo() {
 	a.Ctx.GetSessionVars().PlanCacheValue = nil // reset
 }
 
-func (a *ExecStmt) observeStmtFinishedForTopSQL() {
+func (a *ExecStmt) observeStmtFinishedForTopProfiling() {
 	vars := a.Ctx.GetSessionVars()
 	if vars == nil {
 		return
 	}
-	if stats := a.Ctx.GetStmtStats(); stats != nil && topsqlstate.TopSQLEnabled() {
+	if stats := a.Ctx.GetStmtStats(); stats != nil && topsqlstate.TopProfilingEnabled() {
 		sqlDigest, planDigest := a.getSQLPlanDigest()
 		execDuration := vars.GetTotalCostDuration()
 		stats.OnExecutionFinished(sqlDigest, planDigest, execDuration)

--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -55,7 +55,7 @@ type Executor interface {
 	RuntimeStats() *execdetails.BasicRuntimeStats
 
 	HandleSQLKillerSignal() error
-	RegisterSQLAndPlanInExecForTopSQL()
+	RegisterSQLAndPlanInExecForTopProfiling()
 
 	AllChildren() []Executor
 	SetAllChildren([]Executor)
@@ -248,9 +248,9 @@ func (e *executorStats) RuntimeStats() *execdetails.BasicRuntimeStats {
 	return e.runtimeStats
 }
 
-// RegisterSQLAndPlanInExecForTopSQL registers the current SQL and Plan on top sql
-func (e *executorStats) RegisterSQLAndPlanInExecForTopSQL() {
-	if topsqlstate.TopSQLEnabled() && e.isSQLAndPlanRegistered.CompareAndSwap(false, true) {
+// RegisterSQLAndPlanInExecForTopProfiling registers the current SQL and Plan on top profiling.
+func (e *executorStats) RegisterSQLAndPlanInExecForTopProfiling() {
+	if topsqlstate.TopProfilingEnabled() && e.isSQLAndPlanRegistered.CompareAndSwap(false, true) {
 		topsql.RegisterSQL(e.normalizedSQL, e.sqlDigest, e.inRestrictedSQL)
 		if len(e.normalizedPlan) > 0 {
 			topsql.RegisterPlan(e.normalizedPlan, e.planDigest)
@@ -456,7 +456,7 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 	r, ctx := tracing.StartRegionEx(ctx, reflect.TypeOf(e).String()+".Next")
 	defer r.End()
 
-	e.RegisterSQLAndPlanInExecForTopSQL()
+	e.RegisterSQLAndPlanInExecForTopProfiling()
 	err = e.Next(ctx, req)
 
 	if err != nil {

--- a/pkg/executor/prepared.go
+++ b/pkg/executor/prepared.go
@@ -144,7 +144,7 @@ func (e *PrepareExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	if err != nil {
 		return err
 	}
-	if topsqlstate.TopSQLEnabled() {
+	if topsqlstate.TopProfilingEnabled() {
 		e.Ctx().GetSessionVars().StmtCtx.IsSQLRegistered.Store(true)
 		topsql.AttachAndRegisterSQLInfo(ctx, stmt.NormalizedSQL, stmt.SQLDigest, vars.InRestrictedSQL)
 	}

--- a/pkg/executor/select.go
+++ b/pkg/executor/select.go
@@ -1063,7 +1063,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 			goCtx = pprof.WithLabels(goCtx, pprof.Labels("sql", FormatSQL(prepareStmt.NormalizedSQL).String()))
 			pprof.SetGoroutineLabels(goCtx)
 		}
-		if topsqlstate.TopSQLEnabled() && prepareStmt.SQLDigest != nil {
+		if topsqlstate.TopProfilingEnabled() && prepareStmt.SQLDigest != nil {
 			sc.IsSQLRegistered.Store(true)
 			topsql.AttachAndRegisterSQLInfo(goCtx, prepareStmt.NormalizedSQL, prepareStmt.SQLDigest, vars.InRestrictedSQL)
 		}

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -1316,7 +1316,7 @@ func (cc *clientConn) dispatch(ctx context.Context, data []byte) error {
 	cc.lastPacket = data
 	cmd := data[0]
 	data = data[1:]
-	if topsqlstate.TopSQLEnabled() {
+	if topsqlstate.TopProfilingEnabled() {
 		rawCtx := ctx
 		defer pprof.SetGoroutineLabels(rawCtx)
 		sqlID := cc.ctx.GetSessionVars().SQLCPUUsages.AllocNewSQLID()
@@ -2018,7 +2018,7 @@ func (cc *clientConn) prefetchPointPlanKeys(ctx context.Context, stmts []ast.Stm
 }
 
 func setResourceGroupTaggerForMultiStmtPrefetch(snapshot kv.Snapshot, sqls string) {
-	if !topsqlstate.TopSQLEnabled() {
+	if !topsqlstate.TopProfilingEnabled() {
 		return
 	}
 	normalized, digest := parser.NormalizeDigest(sqls)

--- a/pkg/server/conn_stmt.go
+++ b/pkg/server/conn_stmt.go
@@ -527,7 +527,7 @@ func (cc *clientConn) handleStmtFetch(ctx context.Context, data []byte) (err err
 		}
 	}()
 
-	if topsqlstate.TopSQLEnabled() {
+	if topsqlstate.TopProfilingEnabled() {
 		prepareObj, _ := cc.preparedStmtID2CachePreparedStmt(stmtID)
 		if prepareObj != nil && prepareObj.SQLDigest != nil {
 			ctx = topsql.AttachAndRegisterSQLInfo(ctx, prepareObj.NormalizedSQL, prepareObj.SQLDigest, false)

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -1178,7 +1178,7 @@ func TestTopSQLCatchRunningSQL(t *testing.T) {
 	}()
 
 	mc := mockTopSQLTraceCPU.NewTopSQLCollector()
-	topsql.SetupTopSQLForTest(mc)
+	topsql.SetupTopProfilingForTest(mc)
 	sqlCPUCollector := collector.NewSQLCPUCollector(mc)
 	sqlCPUCollector.Start()
 	defer sqlCPUCollector.Stop()
@@ -1243,7 +1243,7 @@ func TestTopSQLCPUProfile(t *testing.T) {
 	defer topsqlstate.DisableTopSQL()
 
 	mc := mockTopSQLTraceCPU.NewTopSQLCollector()
-	topsql.SetupTopSQLForTest(mc)
+	topsql.SetupTopProfilingForTest(mc)
 	sqlCPUCollector := collector.NewSQLCPUCollector(mc)
 	sqlCPUCollector.SetProcessCPUUpdater(ts.Server)
 	sqlCPUCollector.Start()

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1783,7 +1783,7 @@ func (s *session) ParseWithParams(ctx context.Context, sql string, args ...any) 
 	for _, warn := range warns {
 		s.sessionVars.StmtCtx.AppendWarning(util.SyntaxWarn(warn))
 	}
-	if topsqlstate.TopSQLEnabled() {
+	if topsqlstate.TopProfilingEnabled() {
 		normalized, digest := parser.NormalizeDigest(sql)
 		if digest != nil {
 			// Reset the goroutine label when internal sql execute finish.
@@ -2209,7 +2209,7 @@ func (s *session) executeStmtImpl(ctx context.Context, stmtNode ast.StmtNode) (s
 
 	normalizedSQL, digest := s.sessionVars.StmtCtx.SQLDigest()
 	cmdByte := byte(atomic.LoadUint32(&s.GetSessionVars().CommandValue))
-	if topsqlstate.TopSQLEnabled() {
+	if topsqlstate.TopProfilingEnabled() {
 		s.sessionVars.StmtCtx.IsSQLRegistered.Store(true)
 		ctx = topsql.AttachAndRegisterSQLInfo(ctx, normalizedSQL, digest, s.sessionVars.InRestrictedSQL)
 	}

--- a/pkg/util/topsql/BUILD.bazel
+++ b/pkg/util/topsql/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/util/plancodec",
         "//pkg/util/topsql/collector",
         "//pkg/util/topsql/reporter",
+        "//pkg/util/topsql/state",
         "//pkg/util/topsql/stmtstats",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_tipb//go-tipb",

--- a/pkg/util/topsql/state/state.go
+++ b/pkg/util/topsql/state/state.go
@@ -62,3 +62,14 @@ func DisableTopSQL() {
 func TopSQLEnabled() bool {
 	return GlobalState.enable.Load()
 }
+
+// TopProfilingEnabled returns true if any Top Profiling consumer is enabled.
+//
+// In current codebase it is equivalent to TopSQLEnabled(). It is introduced to
+// unify execution-path hooks (SQL/plan registration, stmt lifecycle callbacks,
+// resource group tagging) so they can later be extended to support TopRU.
+func TopProfilingEnabled() bool {
+	// TODO: include TopRUEnabled() here once TopRU is merged.
+	// return TopSQLEnabled() || TopRUEnabled()
+	return TopSQLEnabled()
+}

--- a/pkg/util/topsql/topsql.go
+++ b/pkg/util/topsql/topsql.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 	"github.com/pingcap/tidb/pkg/util/topsql/collector"
 	"github.com/pingcap/tidb/pkg/util/topsql/reporter"
+	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
 	"github.com/pingcap/tidb/pkg/util/topsql/stmtstats"
 	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/zap"
@@ -40,35 +41,38 @@ const (
 )
 
 var (
-	globalTopSQLReport   reporter.TopSQLReporter
-	singleTargetDataSink *reporter.SingleTargetDataSink
+	globalTopProfilingReport reporter.TopSQLReporter
+	singleTargetDataSink     *reporter.SingleTargetDataSink
 )
 
 func init() {
 	remoteReporter := reporter.NewRemoteTopSQLReporter(plancodec.DecodeNormalizedPlan, plancodec.Compress)
-	globalTopSQLReport = remoteReporter
+	globalTopProfilingReport = remoteReporter
 	singleTargetDataSink = reporter.NewSingleTargetDataSink(remoteReporter)
 }
 
-// SetupTopSQL sets up the top-sql worker.
-func SetupTopSQL(keyspaceName []byte, updater collector.ProcessCPUTimeUpdater) {
-	globalTopSQLReport.BindKeyspaceName(keyspaceName)
-	globalTopSQLReport.BindProcessCPUTimeUpdater(updater)
-	globalTopSQLReport.Start()
+// SetupTopProfiling sets up the Top Profiling pipeline.
+//
+// NOTE: Despite the legacy package name, this initializer wires the collectors
+// and reporters shared by TopSQL (and future TopRU).
+func SetupTopProfiling(keyspaceName []byte, updater collector.ProcessCPUTimeUpdater) {
+	globalTopProfilingReport.BindKeyspaceName(keyspaceName)
+	globalTopProfilingReport.BindProcessCPUTimeUpdater(updater)
+	globalTopProfilingReport.Start()
 	singleTargetDataSink.Start()
 
-	stmtstats.RegisterCollector(globalTopSQLReport)
+	stmtstats.RegisterCollector(globalTopProfilingReport)
 	stmtstats.SetupAggregator()
 }
 
-// SetupTopSQLForTest sets up the global top-sql reporter, it's exporting for test.
-func SetupTopSQLForTest(r reporter.TopSQLReporter) {
-	globalTopSQLReport = r
+// SetupTopProfilingForTest sets up the global reporter for tests.
+func SetupTopProfilingForTest(r reporter.TopSQLReporter) {
+	globalTopProfilingReport = r
 }
 
 // RegisterPubSubServer registers TopSQLPubSubService to the given gRPC server.
 func RegisterPubSubServer(s *grpc.Server) {
-	if register, ok := globalTopSQLReport.(reporter.DataSinkRegisterer); ok {
+	if register, ok := globalTopProfilingReport.(reporter.DataSinkRegisterer); ok {
 		service := reporter.NewTopSQLPubSubService(register)
 		tipb.RegisterTopSQLPubSubServer(s, service)
 	}
@@ -77,11 +81,11 @@ func RegisterPubSubServer(s *grpc.Server) {
 // Close uses to close and release the top sql resource.
 func Close() {
 	singleTargetDataSink.Close()
-	globalTopSQLReport.Close()
+	globalTopProfilingReport.Close()
 	stmtstats.CloseAggregator()
 }
 
-// RegisterSQL uses to register SQL information into Top SQL.
+// RegisterSQL uses to register SQL information into Top Profiling.
 func RegisterSQL(normalizedSQL string, sqlDigest *parser.Digest, isInternal bool) {
 	if sqlDigest != nil {
 		sqlDigestBytes := sqlDigest.Bytes()
@@ -89,7 +93,7 @@ func RegisterSQL(normalizedSQL string, sqlDigest *parser.Digest, isInternal bool
 	}
 }
 
-// RegisterPlan uses to register plan information into Top SQL.
+// RegisterPlan uses to register plan information into Top Profiling.
 func RegisterPlan(normalizedPlan string, planDigest *parser.Digest) {
 	if planDigest != nil {
 		planDigestBytes := planDigest.Bytes()
@@ -97,14 +101,16 @@ func RegisterPlan(normalizedPlan string, planDigest *parser.Digest) {
 	}
 }
 
-// AttachAndRegisterSQLInfo attach the sql information into Top SQL and register the SQL meta information.
+// AttachAndRegisterSQLInfo attach the sql information into Top Profiling and register the SQL meta information.
 func AttachAndRegisterSQLInfo(ctx context.Context, normalizedSQL string, sqlDigest *parser.Digest, isInternal bool) context.Context {
 	if sqlDigest == nil || len(sqlDigest.String()) == 0 {
 		return ctx
 	}
 	sqlDigestBytes := sqlDigest.Bytes()
 	ctx = collector.CtxWithSQLDigest(ctx, sqlDigest.String())
-	pprof.SetGoroutineLabels(ctx)
+	if topsqlstate.TopSQLEnabled() {
+		pprof.SetGoroutineLabels(ctx)
+	}
 
 	linkSQLTextWithDigest(sqlDigestBytes, normalizedSQL, isInternal)
 
@@ -124,7 +130,7 @@ func AttachAndRegisterSQLInfo(ctx context.Context, normalizedSQL string, sqlDige
 	return ctx
 }
 
-// AttachSQLAndPlanInfo attach the sql and plan information into Top SQL
+// AttachSQLAndPlanInfo attach the sql and plan information into Top Profiling.
 func AttachSQLAndPlanInfo(ctx context.Context, sqlDigest *parser.Digest, planDigest *parser.Digest) context.Context {
 	if sqlDigest == nil || len(sqlDigest.String()) == 0 {
 		return ctx
@@ -135,7 +141,9 @@ func AttachSQLAndPlanInfo(ctx context.Context, sqlDigest *parser.Digest, planDig
 		planDigestStr = planDigest.String()
 	}
 	ctx = collector.CtxWithSQLAndPlanDigest(ctx, sqlDigestStr, planDigestStr)
-	pprof.SetGoroutineLabels(ctx)
+	if topsqlstate.TopSQLEnabled() {
+		pprof.SetGoroutineLabels(ctx)
+	}
 
 	failpoint.Inject("mockHighLoadForEachPlan", func(val failpoint.Value) {
 		// Work like mockHighLoadForEachSQL failpoint.
@@ -151,7 +159,9 @@ func AttachSQLAndPlanInfo(ctx context.Context, sqlDigest *parser.Digest, planDig
 // AttachAndRegisterProcessInfo attach the ProcessInfo into Goroutine labels.
 func AttachAndRegisterProcessInfo(ctx context.Context, connID uint64, sqlID uint64) context.Context {
 	ctx = collector.CtxWithProcessInfo(ctx, connID, sqlID)
-	pprof.SetGoroutineLabels(ctx)
+	if topsqlstate.TopSQLEnabled() {
+		pprof.SetGoroutineLabels(ctx)
+	}
 	return ctx
 }
 
@@ -188,9 +198,9 @@ func linkSQLTextWithDigest(sqlDigest []byte, normalizedSQL string, isInternal bo
 		normalizedSQL = normalizedSQL[:MaxSQLTextSize]
 	}
 
-	globalTopSQLReport.RegisterSQL(sqlDigest, normalizedSQL, isInternal)
+	globalTopProfilingReport.RegisterSQL(sqlDigest, normalizedSQL, isInternal)
 }
 
 func linkPlanTextWithDigest(planDigest []byte, normalizedBinaryPlan string) {
-	globalTopSQLReport.RegisterPlan(planDigest, normalizedBinaryPlan, len(normalizedBinaryPlan) > MaxBinaryPlanSize)
+	globalTopProfilingReport.RegisterPlan(planDigest, normalizedBinaryPlan, len(normalizedBinaryPlan) > MaxBinaryPlanSize)
 }

--- a/pkg/util/topsql/topsql_test.go
+++ b/pkg/util/topsql/topsql_test.go
@@ -43,7 +43,7 @@ func TestTopSQLCPUProfile(t *testing.T) {
 
 	topsqlstate.EnableTopSQL()
 	mc := mock.NewTopSQLCollector()
-	topsql.SetupTopSQLForTest(mc)
+	topsql.SetupTopProfilingForTest(mc)
 	sqlCPUCollector := collector.NewSQLCPUCollector(mc)
 	sqlCPUCollector.Start()
 	defer sqlCPUCollector.Stop()
@@ -109,7 +109,7 @@ func TestTopSQLReporter(t *testing.T) {
 	report.Start()
 	ds := reporter.NewSingleTargetDataSink(report)
 	ds.Start()
-	topsql.SetupTopSQLForTest(report)
+	topsql.SetupTopProfilingForTest(report)
 
 	defer func() {
 		ds.Close()
@@ -185,7 +185,7 @@ func TestMaxSQLAndPlanTest(t *testing.T) {
 	defer cpuprofile.StopCPUProfiler()
 
 	collector := mock.NewTopSQLCollector()
-	topsql.SetupTopSQLForTest(collector)
+	topsql.SetupTopProfilingForTest(collector)
 
 	ctx := context.Background()
 
@@ -230,7 +230,7 @@ func TestTopSQLPubSub(t *testing.T) {
 	report := reporter.NewRemoteTopSQLReporter(mockPlanBinaryDecoderFunc, mockPlanBinaryCompressFunc)
 	report.Start()
 	defer report.Close()
-	topsql.SetupTopSQLForTest(report)
+	topsql.SetupTopProfilingForTest(report)
 
 	server, err := mockServer.NewMockPubSubServer()
 	require.NoError(t, err)


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #65817

Problem Summary:
Cherry-pick upstream PR #65820 to release-nextgen-20251011 as the first PR in the backport chain of #65471.

### What changed and how does it work?
- Cherry-picked commit: 3acb64681ff5b0caba66bd6d37be2b8a5b91e6d9
- Backport commit on this branch: 2527317850038c55b027b73b57422a403792d688
- This PR only contains the TopSQL -> TopProfiling naming/path preparation changes from #65820.

### Check List
Tests
- [x] No need to test
  > - [x] This PR is a direct cherry-pick of upstream #65820 and keeps original behavior scope.

Side effects
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized profiling subsystem infrastructure throughout the database engine to improve modularity and consistency of performance monitoring.
  * Updated internal profiling setup and initialization logic across DDL operations, SQL execution, and statement processing pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->