### PR TITLE
expression, planner: allow more MATCH AGAINST boolean queries | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature-fts

### DIFF
--- a/pkg/expression/fts_helper.go
+++ b/pkg/expression/fts_helper.go
@@ -326,7 +326,15 @@ func rewriteBooleanGroupToFTSExpr(
 		return buildMatchAgainstConstant(foldedRetType, false), nil
 	}
 
-	searchFuncs := make([]Expression, 0, len(group.Must)+len(group.MustNot)+len(group.Should))
+	// TiCI currently executes MATCH ... AGAINST as a no-score filter. When the
+	// boolean query contains at least one MUST term, MySQL treats SHOULD terms as
+	// optional score contributors, which cannot be represented in the filter-only
+	// path. In that case we keep the MUST / MUST NOT filters and ignore SHOULD.
+	includeShouldInFilter := len(group.Must) == 0
+	searchFuncs := make([]Expression, 0, len(group.Must)+len(group.MustNot))
+	if includeShouldInFilter {
+		searchFuncs = make([]Expression, 0, len(group.Must)+len(group.MustNot)+len(group.Should))
+	}
 	for _, item := range group.Must {
 		f, err := rewriteBooleanClauseToFTSExpr(bctx, matchCols, item, parserType)
 		if err != nil {
@@ -342,14 +350,16 @@ func rewriteBooleanGroupToFTSExpr(
 		nf := NewFunctionInternal(bctx, ast.UnaryNot, types.NewFieldType(mysql.TypeDouble), f)
 		searchFuncs = append(searchFuncs, nf)
 	}
-	for _, item := range group.Should {
-		f, err := rewriteBooleanClauseToFTSExpr(bctx, matchCols, item, parserType)
-		if err != nil {
-			return nil, err
+	if includeShouldInFilter {
+		for _, item := range group.Should {
+			f, err := rewriteBooleanClauseToFTSExpr(bctx, matchCols, item, parserType)
+			if err != nil {
+				return nil, err
+			}
+			searchFuncs = append(searchFuncs, f)
 		}
-		searchFuncs = append(searchFuncs, f)
 	}
-	if len(group.Should) > 0 {
+	if includeShouldInFilter && len(group.Should) > 0 {
 		startIdx := len(group.Must) + len(group.MustNot)
 		endIdx := startIdx + len(group.Should)
 		orShould := ComposeDNFCondition(bctx, searchFuncs[startIdx:endIdx]...)
@@ -424,13 +434,6 @@ func buildMatchAgainstConstant(retType *types.FieldType, isNull bool) *Constant 
 func validateMySQLMatchAgainstBooleanGroup(group *matchagainst.BooleanGroup) error {
 	if group == nil {
 		return errors.New("invalid nil boolean group")
-	}
-	// Current limitation of TiDB.
-	if len(group.Must)+len(group.MustNot) > 0 && len(group.Should) > 0 {
-		return errors.Errorf("TiDB only supports multiple terms with +/- modifiers")
-	}
-	if len(group.Must)+len(group.MustNot) == 0 && len(group.Should) > 1 {
-		return errors.Errorf("TiDB only supports multiple terms with +/- modifiers")
 	}
 	return nil
 }

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -797,14 +797,25 @@ func TestRewriteMySQLMatchAgainst(t *testing.T) {
 	require.Equal(t, mysql.TypeDouble, c.RetType.GetType())
 
 	expr, _, err = RewriteMySQLMatchAgainstRecursively(ctx, buildMatchAgainst("hello world"), model.FullTextParserTypeStandardV1)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "TiDB only supports multiple terms with +/- modifiers")
-	require.True(t, hasMySQLMatchAgainst(expr))
+	require.NoError(t, err)
+	require.False(t, hasMySQLMatchAgainst(expr))
+	root, ok := expr.(*ScalarFunction)
+	require.True(t, ok)
+	require.Equal(t, ast.LogicOr, root.FuncName.L)
+	require.ElementsMatch(t, []ftsLeaf{
+		{funcName: ast.FTSMatchWord, query: "hello", columns: []string{"title"}},
+		{funcName: ast.FTSMatchWord, query: "world", columns: []string{"title"}},
+	}, collectFTSLeaves(expr))
 
 	expr, _, err = RewriteMySQLMatchAgainstRecursively(ctx, buildMatchAgainst("+hello world"), model.FullTextParserTypeStandardV1)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "TiDB only supports multiple terms with +/- modifiers")
-	require.True(t, hasMySQLMatchAgainst(expr))
+	require.NoError(t, err)
+	require.False(t, hasMySQLMatchAgainst(expr))
+	root, ok = expr.(*ScalarFunction)
+	require.True(t, ok)
+	require.Equal(t, ast.FTSMatchWord, root.FuncName.L)
+	require.ElementsMatch(t, []ftsLeaf{
+		{funcName: ast.FTSMatchWord, query: "hello", columns: []string{"title"}},
+	}, collectFTSLeaves(expr))
 
 	ngramErrExpr := buildMatchAgainst(">hello")
 	expr, _, err = RewriteMySQLMatchAgainstRecursively(ctx, ngramErrExpr, model.FullTextParserTypeNgramV1)

--- a/pkg/planner/core/casetest/tici/tici_test.go
+++ b/pkg/planner/core/casetest/tici/tici_test.go
@@ -254,15 +254,17 @@ func TestTiCIMatchAgainstValidation(t *testing.T) {
 		"Currently TiDB only supports BOOLEAN MODE in MATCH AGAINST",
 	)
 
-	// BOOLEAN MODE query limitations from RewriteMySQLMatchAgainstRecursively.
-	tk.MustContainErrMsg(
+	// BOOLEAN MODE should allow multiple SHOULD terms. With a no-score TiCI query,
+	// SHOULD terms are only kept as filters when there is no MUST term.
+	tk.MustQuery(
 		"explain format='brief' select * from t1 where match(title) against ('hello world' IN BOOLEAN MODE)",
-		"TiDB only supports multiple terms with +/- modifiers",
-	)
-	tk.MustContainErrMsg(
+	).CheckContain(`search func:or(istrue_with_null(fts_match_word("hello", test.t1.title)), istrue_with_null(fts_match_word("world", test.t1.title)))`)
+	tk.MustQuery(
 		"explain format='brief' select * from t1 where match(title) against ('+hello world' IN BOOLEAN MODE)",
-		"TiDB only supports multiple terms with +/- modifiers",
-	)
+	).CheckContain(`search func:fts_match_word("hello", test.t1.title)`)
+	tk.MustQuery(
+		"explain format='brief' select * from t1 where match(title) against ('+hello world' IN BOOLEAN MODE)",
+	).CheckNotContain(`world`)
 
 	// Parser should follow the fulltext index parser type.
 	tk.MustContainErrMsg(


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref #65626

Problem Summary:

`MATCH ... AGAINST (... IN BOOLEAN MODE)` still rejected some valid boolean queries during TiCI rewrite. Queries like `hello world` and `+hello world` returned `TiDB only supports multiple terms with +/- modifiers`.

### What changed and how does it work?

- Removed the extra BOOLEAN MODE validation that rejected multiple SHOULD clauses and mixed MUST/SHOULD clauses.
- Rewrote pure SHOULD queries into OR-based FTS filters.
- Kept MUST / MUST NOT filters when SHOULD terms appear in a no-score TiCI query, so optional terms no longer become mandatory filters.
- Added regression coverage in expression rewrite tests and planner TiCI validation tests.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  `go test -run TestRewriteMySQLMatchAgainst --tags=intest ./pkg/expression`
  `go test -run TestTiCIMatchAgainstValidation --tags=intest ./pkg/planner/core/casetest/tici`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/release-notes-style-guide.html) to write a quality release note.

```release-note
Allow more valid MATCH ... AGAINST BOOLEAN MODE queries during TiCI rewrite, including multiple SHOULD terms and mixed MUST/SHOULD queries.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed previous limitations on full-text search in BOOLEAN MODE. MATCH AGAINST now supports multi-term search patterns ("hello world", "+hello world") without requiring explicit +/- modifiers, improving alignment with standard MySQL full-text search functionality and expanding supported query types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->