### PR TITLE
ttl: fix flaky TestIterationOfRunningJob

### DIFF
--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -1846,11 +1846,11 @@ func TestIterationOfRunningJob(t *testing.T) {
 	waitAndStopTTLManager(t, dom)
 	sessionFactory := sessionFactory(t, dom)
 
-	tk := testkit.NewTestKit(t, store)
 	m := ttlworker.NewJobManager("test-job-manager", dom.AdvancedSysSessionPool(), store, nil, func() bool { return true })
 
 	se, closeSe := sessionFactory()
 	defer closeSe()
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnTTL)
 	for tableID := int64(0); tableID < 100; tableID++ {
 		testTable := &cache.PhysicalTable{ID: tableID, TableInfo: &model.TableInfo{ID: tableID, TTLInfo: &model.TTLInfo{IntervalExprStr: "1", IntervalTimeUnit: int(ast.TimeUnitDay), JobInterval: "1h"}}}
 		m.InfoSchemaCache().Tables[testTable.ID] = testTable
@@ -1858,10 +1858,18 @@ func TestIterationOfRunningJob(t *testing.T) {
 		jobID := uuid.NewString()
 		_, err := m.LockJob(context.Background(), se, testTable, se.Now(), jobID, false)
 		require.NoError(t, err)
-		tk.MustQuery("SELECT current_job_id, current_job_owner_id FROM mysql.tidb_ttl_table_status WHERE table_id = ?", tableID).Check(testkit.Rows(fmt.Sprintf("%s %s", jobID, m.ID())))
+		sql, args := cache.SelectFromTTLTableStatusWithID(tableID)
+		rows, err := se.ExecuteSQL(ctx, sql, args...)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		status, err := cache.RowToTableStatus(se.GetSessionVars().Location(), rows[0])
+		require.NoError(t, err)
+		require.Equal(t, jobID, status.CurrentJobID)
+		require.Equal(t, m.ID(), status.CurrentJobOwnerID)
 
 		// update the owner id
-		tk.MustExec("UPDATE mysql.tidb_ttl_table_status SET current_job_owner_id = 'another-id' WHERE current_job_id = ?", jobID)
+		_, err = se.ExecuteSQL(ctx, "UPDATE mysql.tidb_ttl_table_status SET current_job_owner_id = 'another-id' WHERE current_job_id = %?", jobID)
+		require.NoError(t, err)
 	}
 	require.NoError(t, m.TableStatusCache().Update(context.Background(), se))
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67177

Problem Summary:

`TestIterationOfRunningJob` is flaky under `-race`. The build linked from issue `#67177` showed a data race caused by the test using a regular `TestKit` session while background domain code was reading statement context.

### What changed and how does it work?

This PR switches the status-table query and owner update in `TestIterationOfRunningJob` to use the internal TTL session that the job manager already uses. The test keeps the same assertions and behavior while avoiding the raced session path.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation:
- `make failpoint-enable`
- `cd pkg/ttl/ttlworker && go test -race -run TestIterationOfRunningJob -tags=intest,deadlock`
- `make failpoint-disable`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test implementation for TTL job manager integration testing with internal transaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->