### PR TITLE
[release-nextgen-20251011] topsql: add TopRU state and subscription plumbing (tipb upgrade) (#66642)

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -6608,13 +6608,13 @@ def go_deps():
         name = "com_github_pingcap_tipb",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/pingcap/tipb",
-        sha256 = "ef0cd4e10898c3f6f871bc5bbfe8c3db1cfda6d59fd10772f54eb682796c98ad",
-        strip_prefix = "github.com/pingcap/tipb@v0.0.0-20250928030846-9fd33ded6f2c",
+        sha256 = "2d6aaef873e175599c39f6fe3cf85cabce88a69c157ff7ec4c22fbcbc97648dd",
+        strip_prefix = "github.com/pingcap/tipb@v0.0.0-20260210113932-1447c9d7e9fe",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20250928030846-9fd33ded6f2c.zip",
-            "http://ats.apps.svc/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20250928030846-9fd33ded6f2c.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20250928030846-9fd33ded6f2c.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20250928030846-9fd33ded6f2c.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20260210113932-1447c9d7e9fe.zip",
+            "http://ats.apps.svc/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20260210113932-1447c9d7e9fe.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20260210113932-1447c9d7e9fe.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20260210113932-1447c9d7e9fe.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/pingcap/metering_sdk v0.0.0-20251110022152-dac449ac5389
 	github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20211011031125-9b13dc409c5e
-	github.com/pingcap/tipb v0.0.0-20250928030846-9fd33ded6f2c
+	github.com/pingcap/tipb v0.0.0-20260210113932-1447c9d7e9fe
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.63.0

--- a/go.sum
+++ b/go.sum
@@ -790,8 +790,8 @@ github.com/pingcap/metering_sdk v0.0.0-20251110022152-dac449ac5389 h1:bqbE3bwFSr
 github.com/pingcap/metering_sdk v0.0.0-20251110022152-dac449ac5389/go.mod h1:zie1N5PRttgtqkZmRtpIDM7CuyWtvlX9LTxRd3fVSc4=
 github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5 h1:T4pXRhBflzDeAhmOQHNPRRogMYxP13V7BkYw3ZsoSfE=
 github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5/go.mod h1:rlimy0GcTvjiJqvD5mXTRr8O2eNZPBrcUgiWVYp9530=
-github.com/pingcap/tipb v0.0.0-20250928030846-9fd33ded6f2c h1:tddMjEiXU0d1VlJ+yHwim4gINeHmFR9CCkitatuby2c=
-github.com/pingcap/tipb v0.0.0-20250928030846-9fd33ded6f2c/go.mod h1:RM8iRcMalzOthG2XJxnNBniM4xFGb/lDwHUwqkaVzt4=
+github.com/pingcap/tipb v0.0.0-20260210113932-1447c9d7e9fe h1:Zmz9mON+2NoKDVjkJbk6NZbFoTzVzk8MPTbRnu+MiVM=
+github.com/pingcap/tipb v0.0.0-20260210113932-1447c9d7e9fe/go.mod h1:RM8iRcMalzOthG2XJxnNBniM4xFGb/lDwHUwqkaVzt4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/pkg/util/topsql/BUILD.bazel
+++ b/pkg/util/topsql/BUILD.bazel
@@ -29,7 +29,7 @@ go_test(
     ],
     embed = [":topsql"],
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/config",
         "//pkg/parser",

--- a/pkg/util/topsql/reporter/BUILD.bazel
+++ b/pkg/util/topsql/reporter/BUILD.bazel
@@ -26,7 +26,9 @@ go_library(
         "@com_github_wangjohn_quickselect//:quickselect",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//backoff",
+        "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//credentials/insecure",
+        "@org_golang_google_grpc//status",
         "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",
     ],
@@ -45,7 +47,7 @@ go_test(
     ],
     embed = [":reporter"],
     flaky = True,
-    shard_count = 36,
+    shard_count = 50,
     deps = [
         "//pkg/config",
         "//pkg/testkit/testsetup",
@@ -57,7 +59,9 @@ go_test(
         "@com_github_pingcap_tipb//go-tipb",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/pkg/util/topsql/reporter/datasink.go
+++ b/pkg/util/topsql/reporter/datasink.go
@@ -41,17 +41,23 @@ type DataSinkRegisterer interface {
 	Deregister(dataSink DataSink)
 }
 
-// ReportData contains data that reporter sends to the agent.
+// ReportData contains the payload sent from reporter to agent.
+// DataRecords stores TopSQL CPU records, and RURecords stores TopRU records.
+// SQLMetas and PlanMetas are shared by both record types.
 type ReportData struct {
 	// DataRecords contains the topN records of each second and the `others`
 	// record which aggregation all []tipb.TopSQLRecord that is out of Top N.
 	DataRecords []tipb.TopSQLRecord
-	SQLMetas    []tipb.SQLMeta
-	PlanMetas   []tipb.PlanMeta
+	// RURecords contains TopRU records aggregated by (user, sql_digest, plan_digest).
+	// Stored separately to avoid mixing with CPU-based TopSQLRecord.
+	// Populated by reporter after two-level TopN filtering.
+	RURecords []tipb.TopRURecord
+	SQLMetas  []tipb.SQLMeta
+	PlanMetas []tipb.PlanMeta
 }
 
 func (d *ReportData) hasData() bool {
-	return len(d.DataRecords) != 0 || len(d.SQLMetas) != 0 || len(d.PlanMetas) != 0
+	return len(d.DataRecords) != 0 || len(d.RURecords) != 0 || len(d.SQLMetas) != 0 || len(d.PlanMetas) != 0
 }
 
 var _ DataSinkRegisterer = &DefaultDataSinkRegisterer{}
@@ -60,6 +66,8 @@ var _ DataSinkRegisterer = &DefaultDataSinkRegisterer{}
 type DefaultDataSinkRegisterer struct {
 	ctx       context.Context
 	dataSinks map[DataSink]struct{}
+	// topSQLSinkCount tracks the number of sinks that require TopSQL enabled.
+	topSQLSinkCount int
 	sync.Mutex
 }
 
@@ -80,13 +88,32 @@ func (r *DefaultDataSinkRegisterer) Register(dataSink DataSink) error {
 	case <-r.ctx.Done():
 		return errors.New("DefaultDataSinkRegisterer closed")
 	default:
+		if _, ok := r.dataSinks[dataSink]; ok {
+			return nil
+		}
 		if len(r.dataSinks) >= 10 {
 			return errors.New("too many datasinks")
 		}
-		r.dataSinks[dataSink] = struct{}{}
-		if len(r.dataSinks) > 0 {
-			topsqlstate.EnableTopSQL()
+
+		if ds, ok := dataSink.(*pubSubDataSink); ok && ds.enableTopRU {
+			if err := topsqlstate.SetTopRUItemInterval(ds.itemInterval); err != nil {
+				return err
+			}
+			topsqlstate.EnableTopRU()
 		}
+
+		r.dataSinks[dataSink] = struct{}{}
+
+		// Non-pubsub sinks do not carry subscription collectors; keep TopSQL enabled by default.
+		enableTopSQL := true
+		if ds, ok := dataSink.(*pubSubDataSink); ok {
+			enableTopSQL = ds.enableTopSQL
+		}
+		if enableTopSQL {
+			topsqlstate.EnableTopSQL()
+			r.topSQLSinkCount++
+		}
+
 		return nil
 	}
 }
@@ -99,9 +126,27 @@ func (r *DefaultDataSinkRegisterer) Deregister(dataSink DataSink) {
 	select {
 	case <-r.ctx.Done():
 	default:
+		if _, ok := r.dataSinks[dataSink]; !ok {
+			return
+		}
+
 		delete(r.dataSinks, dataSink)
-		if len(r.dataSinks) == 0 {
-			topsqlstate.DisableTopSQL()
+		// Non-pubsub sinks do not carry subscription collectors; keep TopSQL enabled by default.
+		enableTopSQL := true
+		if ds, ok := dataSink.(*pubSubDataSink); ok {
+			enableTopSQL = ds.enableTopSQL
+		}
+		if enableTopSQL {
+			if r.topSQLSinkCount > 0 {
+				r.topSQLSinkCount--
+			}
+			if r.topSQLSinkCount == 0 {
+				topsqlstate.DisableTopSQL()
+			}
+		}
+
+		if ds, ok := dataSink.(*pubSubDataSink); ok && ds.enableTopRU {
+			topsqlstate.DisableTopRU()
 		}
 	}
 }

--- a/pkg/util/topsql/reporter/datasink_test.go
+++ b/pkg/util/topsql/reporter/datasink_test.go
@@ -16,13 +16,30 @@ package reporter
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
+	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
+	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultDataSinkRegisterer(t *testing.T) {
+	for topsqlstate.TopRUEnabled() {
+		topsqlstate.DisableTopRU()
+	}
+	topsqlstate.DisableTopSQL()
+	topsqlstate.ResetTopRUItemInterval()
+	t.Cleanup(func() {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.DisableTopSQL()
+		topsqlstate.ResetTopRUItemInterval()
+	})
+
 	var err error
 	r := NewDefaultDataSinkRegisterer(context.Background())
 	m1 := newMockDataSink2()
@@ -32,9 +49,260 @@ func TestDefaultDataSinkRegisterer(t *testing.T) {
 	err = r.Register(m2)
 	assert.NoError(t, err)
 	assert.Len(t, r.dataSinks, 2)
+	assert.True(t, topsqlstate.TopSQLEnabled())
+	assert.False(t, topsqlstate.TopRUEnabled())
 	r.Deregister(m1)
 	r.Deregister(m2)
 	assert.Empty(t, r.dataSinks)
+	assert.False(t, topsqlstate.TopSQLEnabled())
+	assert.False(t, topsqlstate.TopRUEnabled())
+}
+
+// TestDefaultDataSinkRegistererTopRUTwoSinksRefCountAndReset verifies TopRU
+// enablement is ref-counted across sinks and the interval resets when the count hits zero.
+// It uses two sinks with different intervals to ensure last-write wins while enabled.
+func TestDefaultDataSinkRegistererTopRUTwoSinksRefCountAndReset(t *testing.T) {
+	for topsqlstate.TopRUEnabled() {
+		topsqlstate.DisableTopRU()
+	}
+	topsqlstate.DisableTopSQL()
+	topsqlstate.ResetTopRUItemInterval()
+	t.Cleanup(func() {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.DisableTopSQL()
+		topsqlstate.ResetTopRUItemInterval()
+	})
+
+	r := NewDefaultDataSinkRegisterer(context.Background())
+	ds1 := &pubSubDataSink{
+		enableTopSQL: true,
+		enableTopRU:  true,
+		itemInterval: tipb.ItemInterval_ITEM_INTERVAL_30S,
+	}
+	ds2 := &pubSubDataSink{
+		enableTopSQL: true,
+		enableTopRU:  true,
+		itemInterval: tipb.ItemInterval_ITEM_INTERVAL_15S,
+	}
+
+	require.NoError(t, r.Register(ds1))
+	require.NoError(t, r.Register(ds2))
+	require.True(t, topsqlstate.TopRUEnabled())
+	require.Equal(t, int64(15), topsqlstate.GetTopRUItemInterval())
+
+	r.Deregister(ds2)
+	require.True(t, topsqlstate.TopRUEnabled())
+	require.Equal(t, int64(15), topsqlstate.GetTopRUItemInterval())
+
+	r.Deregister(ds1)
+	require.False(t, topsqlstate.TopRUEnabled())
+	require.Equal(t, int64(topsqlstate.DefTiDBTopRUItemIntervalSeconds), topsqlstate.GetTopRUItemInterval())
+}
+
+// TestDefaultDataSinkRegistererTopRUDuplicateRegisterIsIdempotent verifies duplicate
+// registrations do not inflate the TopRU ref count or alter the interval.
+func TestDefaultDataSinkRegistererTopRUDuplicateRegisterIsIdempotent(t *testing.T) {
+	for topsqlstate.TopRUEnabled() {
+		topsqlstate.DisableTopRU()
+	}
+	topsqlstate.DisableTopSQL()
+	topsqlstate.ResetTopRUItemInterval()
+	t.Cleanup(func() {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.DisableTopSQL()
+		topsqlstate.ResetTopRUItemInterval()
+	})
+
+	r := NewDefaultDataSinkRegisterer(context.Background())
+	ds := &pubSubDataSink{
+		enableTopSQL: true,
+		enableTopRU:  true,
+		itemInterval: tipb.ItemInterval_ITEM_INTERVAL_15S,
+	}
+
+	require.NoError(t, r.Register(ds))
+	require.NoError(t, r.Register(ds))
+	require.Len(t, r.dataSinks, 1)
+	require.True(t, topsqlstate.TopRUEnabled())
+
+	r.Deregister(ds)
+	require.False(t, topsqlstate.TopRUEnabled())
+	require.Equal(t, int64(topsqlstate.DefTiDBTopRUItemIntervalSeconds), topsqlstate.GetTopRUItemInterval())
+}
+
+// TestDefaultDataSinkRegistererTopRURefCountConcurrentRegisterDeregister verifies
+// concurrent register/deregister cycles do not leak TopRU/TopSQL global state.
+// It uses fixed loop counts with a waitgroup, so there are no timing-based assertions.
+func TestDefaultDataSinkRegistererTopRURefCountConcurrentRegisterDeregister(t *testing.T) {
+	for topsqlstate.TopRUEnabled() {
+		topsqlstate.DisableTopRU()
+	}
+	topsqlstate.DisableTopSQL()
+	topsqlstate.ResetTopRUItemInterval()
+	t.Cleanup(func() {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.DisableTopSQL()
+		topsqlstate.ResetTopRUItemInterval()
+	})
+
+	r := NewDefaultDataSinkRegisterer(context.Background())
+	sinks := []*pubSubDataSink{
+		{enableTopSQL: true, enableTopRU: true, itemInterval: tipb.ItemInterval_ITEM_INTERVAL_15S},
+		{enableTopSQL: true, enableTopRU: true, itemInterval: tipb.ItemInterval_ITEM_INTERVAL_30S},
+		{enableTopSQL: true, enableTopRU: true, itemInterval: tipb.ItemInterval_ITEM_INTERVAL_60S},
+	}
+
+	const (
+		goroutines = 4
+		loops      = 8
+	)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		sink := sinks[g%len(sinks)]
+		go func(ds *pubSubDataSink) {
+			defer wg.Done()
+			for i := 0; i < loops; i++ {
+				if err := r.Register(ds); err != nil {
+					t.Errorf("register failed: %v", err)
+					return
+				}
+				r.Deregister(ds)
+			}
+		}(sink)
+	}
+	wg.Wait()
+
+	// Ensure all known sinks are removed before checking global state.
+	for _, sink := range sinks {
+		r.Deregister(sink)
+	}
+
+	require.False(t, topsqlstate.TopRUEnabled())
+	require.Equal(t, int64(topsqlstate.DefTiDBTopRUItemIntervalSeconds), topsqlstate.GetTopRUItemInterval())
+	require.False(t, topsqlstate.TopSQLEnabled())
+	require.Empty(t, r.dataSinks)
+}
+
+// TestDefaultDataSinkRegistererTopSQLRespectsTopRUOnly verifies TopSQL is only
+// enabled for sinks that request it, while TopRU-only sinks do not toggle TopSQL.
+func TestDefaultDataSinkRegistererTopSQLRespectsTopRUOnly(t *testing.T) {
+	for topsqlstate.TopRUEnabled() {
+		topsqlstate.DisableTopRU()
+	}
+	topsqlstate.DisableTopSQL()
+	topsqlstate.ResetTopRUItemInterval()
+	t.Cleanup(func() {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.DisableTopSQL()
+		topsqlstate.ResetTopRUItemInterval()
+	})
+
+	r := NewDefaultDataSinkRegisterer(context.Background())
+	topSQLSink := &pubSubDataSink{
+		enableTopSQL: true,
+	}
+	topRUSink := &pubSubDataSink{
+		enableTopRU:  true,
+		itemInterval: tipb.ItemInterval_ITEM_INTERVAL_15S,
+	}
+
+	require.NoError(t, r.Register(topSQLSink))
+	require.True(t, topsqlstate.TopSQLEnabled())
+	require.False(t, topsqlstate.TopRUEnabled())
+
+	require.NoError(t, r.Register(topRUSink))
+	require.True(t, topsqlstate.TopSQLEnabled())
+	require.True(t, topsqlstate.TopRUEnabled())
+
+	r.Deregister(topSQLSink)
+	require.False(t, topsqlstate.TopSQLEnabled())
+	require.True(t, topsqlstate.TopRUEnabled())
+
+	r.Deregister(topRUSink)
+	require.False(t, topsqlstate.TopSQLEnabled())
+	require.False(t, topsqlstate.TopRUEnabled())
+}
+
+func TestDefaultDataSinkRegistererSingleTargetTopRUBehavior(t *testing.T) {
+	t.Run("single target does not enable topru", func(t *testing.T) {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.DisableTopSQL()
+		topsqlstate.ResetTopRUItemInterval()
+		t.Cleanup(func() {
+			for topsqlstate.TopRUEnabled() {
+				topsqlstate.DisableTopRU()
+			}
+			topsqlstate.DisableTopSQL()
+			topsqlstate.ResetTopRUItemInterval()
+		})
+
+		r := NewDefaultDataSinkRegisterer(context.Background())
+		ds := &SingleTargetDataSink{}
+
+		require.NoError(t, r.Register(ds))
+		require.True(t, topsqlstate.TopSQLEnabled())
+		require.False(t, topsqlstate.TopRUEnabled())
+		require.Equal(t, int64(topsqlstate.DefTiDBTopRUItemIntervalSeconds), topsqlstate.GetTopRUItemInterval())
+
+		r.Deregister(ds)
+		require.False(t, topsqlstate.TopSQLEnabled())
+		require.False(t, topsqlstate.TopRUEnabled())
+		require.Equal(t, int64(topsqlstate.DefTiDBTopRUItemIntervalSeconds), topsqlstate.GetTopRUItemInterval())
+	})
+
+	t.Run("mixed pubsub and single target", func(t *testing.T) {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.DisableTopSQL()
+		topsqlstate.ResetTopRUItemInterval()
+		t.Cleanup(func() {
+			for topsqlstate.TopRUEnabled() {
+				topsqlstate.DisableTopRU()
+			}
+			topsqlstate.DisableTopSQL()
+			topsqlstate.ResetTopRUItemInterval()
+		})
+
+		r := NewDefaultDataSinkRegisterer(context.Background())
+		pubsubSink := &pubSubDataSink{
+			enableTopSQL: false,
+			enableTopRU:  true,
+			itemInterval: tipb.ItemInterval_ITEM_INTERVAL_15S,
+		}
+		singleTargetSink := &SingleTargetDataSink{}
+
+		require.NoError(t, r.Register(pubsubSink))
+		require.False(t, topsqlstate.TopSQLEnabled())
+		require.True(t, topsqlstate.TopRUEnabled())
+		require.Equal(t, int64(15), topsqlstate.GetTopRUItemInterval())
+
+		require.NoError(t, r.Register(singleTargetSink))
+		require.True(t, topsqlstate.TopSQLEnabled())
+		require.True(t, topsqlstate.TopRUEnabled())
+		require.Equal(t, int64(15), topsqlstate.GetTopRUItemInterval())
+
+		// SingleTarget does not participate in TopRU ref-count.
+		r.Deregister(pubsubSink)
+		require.True(t, topsqlstate.TopSQLEnabled())
+		require.False(t, topsqlstate.TopRUEnabled())
+		require.Equal(t, int64(topsqlstate.DefTiDBTopRUItemIntervalSeconds), topsqlstate.GetTopRUItemInterval())
+
+		r.Deregister(singleTargetSink)
+		require.False(t, topsqlstate.TopSQLEnabled())
+		require.False(t, topsqlstate.TopRUEnabled())
+	})
 }
 
 type mockDataSink2 struct {

--- a/pkg/util/topsql/reporter/metrics/metrics.go
+++ b/pkg/util/topsql/reporter/metrics/metrics.go
@@ -21,22 +21,28 @@ import (
 
 // reporter metrics vars
 var (
-	IgnoreExceedSQLCounter              prometheus.Counter
-	IgnoreExceedPlanCounter             prometheus.Counter
-	IgnoreCollectChannelFullCounter     prometheus.Counter
-	IgnoreCollectStmtChannelFullCounter prometheus.Counter
-	IgnoreReportChannelFullCounter      prometheus.Counter
-	ReportAllDurationSuccHistogram      prometheus.Observer
-	ReportAllDurationFailedHistogram    prometheus.Observer
-	ReportRecordDurationSuccHistogram   prometheus.Observer
-	ReportRecordDurationFailedHistogram prometheus.Observer
-	ReportSQLDurationSuccHistogram      prometheus.Observer
-	ReportSQLDurationFailedHistogram    prometheus.Observer
-	ReportPlanDurationSuccHistogram     prometheus.Observer
-	ReportPlanDurationFailedHistogram   prometheus.Observer
-	TopSQLReportRecordCounterHistogram  prometheus.Observer
-	TopSQLReportSQLCountHistogram       prometheus.Observer
-	TopSQLReportPlanCountHistogram      prometheus.Observer
+	IgnoreExceedSQLCounter                prometheus.Counter
+	IgnoreExceedPlanCounter               prometheus.Counter
+	IgnoreExceedRUKeysCounter             prometheus.Counter
+	IgnoreExceedRUTotalCounter            prometheus.Counter
+	IgnoreCollectChannelFullCounter       prometheus.Counter
+	IgnoreCollectStmtChannelFullCounter   prometheus.Counter
+	IgnoreCollectRUChannelFullCounter     prometheus.Counter
+	IgnoreReportChannelFullCounter        prometheus.Counter
+	ReportAllDurationSuccHistogram        prometheus.Observer
+	ReportAllDurationFailedHistogram      prometheus.Observer
+	ReportRecordDurationSuccHistogram     prometheus.Observer
+	ReportRecordDurationFailedHistogram   prometheus.Observer
+	ReportSQLDurationSuccHistogram        prometheus.Observer
+	ReportSQLDurationFailedHistogram      prometheus.Observer
+	ReportPlanDurationSuccHistogram       prometheus.Observer
+	ReportPlanDurationFailedHistogram     prometheus.Observer
+	TopSQLReportRecordCounterHistogram    prometheus.Observer
+	TopSQLReportRURecordCounterHistogram  prometheus.Observer
+	TopSQLReportSQLCountHistogram         prometheus.Observer
+	TopSQLReportPlanCountHistogram        prometheus.Observer
+	ReportRURecordDurationSuccHistogram   prometheus.Observer
+	ReportRURecordDurationFailedHistogram prometheus.Observer
 )
 
 func init() {
@@ -47,8 +53,11 @@ func init() {
 func InitMetricsVars() {
 	IgnoreExceedSQLCounter = metrics.TopSQLIgnoredCounter.WithLabelValues("ignore_exceed_sql")
 	IgnoreExceedPlanCounter = metrics.TopSQLIgnoredCounter.WithLabelValues("ignore_exceed_plan")
+	IgnoreExceedRUKeysCounter = metrics.TopSQLIgnoredCounter.WithLabelValues("ignore_exceed_ru_keys")
+	IgnoreExceedRUTotalCounter = metrics.TopSQLIgnoredCounter.WithLabelValues("ignore_exceed_ru_total")
 	IgnoreCollectChannelFullCounter = metrics.TopSQLIgnoredCounter.WithLabelValues("ignore_collect_channel_full")
 	IgnoreCollectStmtChannelFullCounter = metrics.TopSQLIgnoredCounter.WithLabelValues("ignore_collect_stmt_channel_full")
+	IgnoreCollectRUChannelFullCounter = metrics.TopSQLIgnoredCounter.WithLabelValues("ignore_collect_ru_channel_full")
 	IgnoreReportChannelFullCounter = metrics.TopSQLIgnoredCounter.WithLabelValues("ignore_report_channel_full")
 	ReportAllDurationSuccHistogram = metrics.TopSQLReportDurationHistogram.WithLabelValues("all", metrics.LblOK)
 	ReportAllDurationFailedHistogram = metrics.TopSQLReportDurationHistogram.WithLabelValues("all", metrics.LblError)
@@ -59,6 +68,9 @@ func InitMetricsVars() {
 	ReportPlanDurationSuccHistogram = metrics.TopSQLReportDurationHistogram.WithLabelValues("plan", metrics.LblOK)
 	ReportPlanDurationFailedHistogram = metrics.TopSQLReportDurationHistogram.WithLabelValues("plan", metrics.LblError)
 	TopSQLReportRecordCounterHistogram = metrics.TopSQLReportDataHistogram.WithLabelValues("record")
+	TopSQLReportRURecordCounterHistogram = metrics.TopSQLReportDataHistogram.WithLabelValues("ru_record")
 	TopSQLReportSQLCountHistogram = metrics.TopSQLReportDataHistogram.WithLabelValues("sql")
 	TopSQLReportPlanCountHistogram = metrics.TopSQLReportDataHistogram.WithLabelValues("plan")
+	ReportRURecordDurationSuccHistogram = metrics.TopSQLReportDurationHistogram.WithLabelValues("ru_record", metrics.LblOK)
+	ReportRURecordDurationFailedHistogram = metrics.TopSQLReportDurationHistogram.WithLabelValues("ru_record", metrics.LblError)
 }

--- a/pkg/util/topsql/reporter/mock/server.go
+++ b/pkg/util/topsql/reporter/mock/server.go
@@ -38,6 +38,7 @@ type mockAgentServer struct {
 	planMetas  map[string]string
 	addr       string
 	records    [][]*tipb.TopSQLRecord
+	ruRecords  [][]*tipb.TopRURecord // RU records storage for tests
 	sync.Mutex
 }
 
@@ -102,6 +103,26 @@ func (svr *mockAgentServer) ReportTopSQLRecords(stream tipb.TopSQLAgent_ReportTo
 	}
 	svr.Lock()
 	svr.records = append(svr.records, records)
+	svr.Unlock()
+	return stream.SendAndClose(&tipb.EmptyResponse{})
+}
+
+// ReportTopRURecords implements tipb.TopSQLAgentServer for TopRU records.
+// Stores RU records for test verification.
+func (svr *mockAgentServer) ReportTopRURecords(stream tipb.TopSQLAgent_ReportTopRURecordsServer) error {
+	ruRecords := make([]*tipb.TopRURecord, 0, 10)
+	for {
+		svr.mayHang()
+		req, err := stream.Recv()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+		ruRecords = append(ruRecords, req)
+	}
+	svr.Lock()
+	svr.ruRecords = append(svr.ruRecords, ruRecords)
 	svr.Unlock()
 	return stream.SendAndClose(&tipb.EmptyResponse{})
 }
@@ -218,6 +239,27 @@ func (svr *mockAgentServer) GetLatestRecords() []*tipb.TopSQLRecord {
 		return nil
 	}
 	return records[len(records)-1]
+}
+
+// GetLatestRURecords returns the latest batch of RU records and clears storage.
+// Used for test verification of TopRU data flow.
+func (svr *mockAgentServer) GetLatestRURecords() []*tipb.TopRURecord {
+	svr.Lock()
+	ruRecords := svr.ruRecords
+	svr.ruRecords = [][]*tipb.TopRURecord{}
+	svr.Unlock()
+
+	if len(ruRecords) == 0 {
+		return nil
+	}
+	return ruRecords[len(ruRecords)-1]
+}
+
+// RURecordsCnt returns the count of RU record batches received.
+func (svr *mockAgentServer) RURecordsCnt() int {
+	svr.Lock()
+	defer svr.Unlock()
+	return len(svr.ruRecords)
 }
 
 func (svr *mockAgentServer) GetTotalSQLMetas() []tipb.SQLMeta {

--- a/pkg/util/topsql/reporter/pubsub.go
+++ b/pkg/util/topsql/reporter/pubsub.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	reporter_metrics "github.com/pingcap/tidb/pkg/util/topsql/reporter/metrics"
+	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
 	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/zap"
 )
@@ -45,8 +46,11 @@ var _ tipb.TopSQLPubSubServer = &TopSQLPubSubService{}
 
 // Subscribe registers dataSinks to the reporter and redirects data received from reporter
 // to subscribers associated with those dataSinks.
-func (ps *TopSQLPubSubService) Subscribe(_ *tipb.TopSQLSubRequest, stream tipb.TopSQLPubSub_SubscribeServer) error {
-	ds := newPubSubDataSink(stream, ps.dataSinkRegisterer)
+func (ps *TopSQLPubSubService) Subscribe(req *tipb.TopSQLSubRequest, stream tipb.TopSQLPubSub_SubscribeServer) error {
+	ds, err := newPubSubDataSink(req, stream, ps.dataSinkRegisterer)
+	if err != nil {
+		return err
+	}
 	if err := ps.dataSinkRegisterer.Register(ds); err != nil {
 		return err
 	}
@@ -62,12 +66,79 @@ type pubSubDataSink struct {
 
 	// for deregister
 	registerer DataSinkRegisterer
+
+	// TopSQL subscription config
+	enableTopSQL bool
+
+	// TopRU subscription config
+	enableTopRU  bool
+	itemInterval tipb.ItemInterval
 }
 
-func newPubSubDataSink(stream tipb.TopSQLPubSub_SubscribeServer, registerer DataSinkRegisterer) *pubSubDataSink {
-	ctx, cancel := context.WithCancel(stream.Context())
+// parseTopSQLSubscription returns true when the request opts in to TopSQL.
+// Empty collectors default to TopSQL enabled for backward compatibility.
+func parseTopSQLSubscription(req *tipb.TopSQLSubRequest) bool {
+	if req == nil {
+		return true
+	}
 
-	return &pubSubDataSink{
+	collectors := req.GetCollectors()
+	if len(collectors) == 0 {
+		return true
+	}
+	for _, collector := range collectors {
+		if collector == tipb.CollectorType_COLLECTOR_TYPE_TOPSQL || collector == tipb.CollectorType_COLLECTOR_TYPE_UNSPECIFIED {
+			return true
+		}
+	}
+	return false
+}
+
+// ErrTopRUConfig indicates the subscription requests TopRU but omits the Topru config.
+var ErrTopRUConfig = errors.New("topru config is empty")
+
+func parseTopRUSubscription(req *tipb.TopSQLSubRequest) (bool, tipb.ItemInterval, error) {
+	if req == nil {
+		return false, tipb.ItemInterval_ITEM_INTERVAL_UNSPECIFIED, nil
+	}
+
+	enabled := false
+	for _, collector := range req.GetCollectors() {
+		if collector == tipb.CollectorType_COLLECTOR_TYPE_TOPRU {
+			enabled = true
+			break
+		}
+	}
+	if !enabled {
+		return false, tipb.ItemInterval_ITEM_INTERVAL_UNSPECIFIED, nil
+	}
+
+	cfg := req.GetTopru()
+	if cfg == nil {
+		return false, tipb.ItemInterval_ITEM_INTERVAL_UNSPECIFIED, ErrTopRUConfig
+	}
+
+	return true, cfg.GetItemIntervalSeconds(), nil
+}
+
+// newPubSubDataSink creates a DataSink for PubSub subscription.
+//
+// It parses TopSQL/TopRU options from the request and stores them in the sink.
+// Register enables TopRU when the sink has enableTopRU; Deregister disables it when the last such sink is removed.
+// item_interval_seconds controls TopRURecordItem.timestamp_sec (15s/30s/60s).
+// Requests without the TOPRU collector entry keep TopRU disabled for backward compatibility.
+// It returns an error when the request includes TOPRU but omits the Topru config.
+func newPubSubDataSink(req *tipb.TopSQLSubRequest, stream tipb.TopSQLPubSub_SubscribeServer, registerer DataSinkRegisterer) (*pubSubDataSink, error) {
+	ctx, cancel := context.WithCancel(stream.Context())
+	enableTopSQL := parseTopSQLSubscription(req)
+	enableTopRU, itemInterval, err := parseTopRUSubscription(req)
+	if err != nil {
+		logutil.BgLogger().Warn("[top-sql] pubsub datasink failed to parse top-ru config", zap.Error(err))
+		cancel()
+		return nil, err
+	}
+
+	ds := &pubSubDataSink{
 		ctx:    ctx,
 		cancel: cancel,
 
@@ -75,7 +146,13 @@ func newPubSubDataSink(stream tipb.TopSQLPubSub_SubscribeServer, registerer Data
 		sendTaskCh: make(chan sendTask, 1),
 
 		registerer: registerer,
+
+		enableTopSQL: enableTopSQL,
+		enableTopRU:  enableTopRU,
+		itemInterval: itemInterval,
 	}
+
+	return ds, nil
 }
 
 var _ DataSink = &pubSubDataSink{}
@@ -160,6 +237,9 @@ func (ds *pubSubDataSink) doSend(ctx context.Context, data *ReportData) error {
 	if err := ds.sendTopSQLRecords(ctx, data.DataRecords); err != nil {
 		return err
 	}
+	if err := ds.sendTopRURecords(ctx, data.RURecords); err != nil {
+		return err
+	}
 	if err := ds.sendSQLMeta(ctx, data.SQLMetas); err != nil {
 		return err
 	}
@@ -167,6 +247,9 @@ func (ds *pubSubDataSink) doSend(ctx context.Context, data *ReportData) error {
 }
 
 func (ds *pubSubDataSink) sendTopSQLRecords(ctx context.Context, records []tipb.TopSQLRecord) (err error) {
+	if !ds.enableTopSQL {
+		return nil
+	}
 	if len(records) == 0 {
 		return
 	}
@@ -187,6 +270,52 @@ func (ds *pubSubDataSink) sendTopSQLRecords(ctx context.Context, records []tipb.
 
 	for i := range records {
 		topSQLRecord.Record = &records[i]
+		if err = ds.stream.Send(r); err != nil {
+			return
+		}
+		sentCount++
+
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+			return
+		default:
+		}
+	}
+
+	return
+}
+
+// sendTopRURecords sends TopRU records to subscriber via PubSub stream.
+//
+// It returns early if there is no record or TopRU is disabled.
+// It uses TopSQLSubResponse_RuRecord (protocol field 4).
+func (ds *pubSubDataSink) sendTopRURecords(ctx context.Context, records []tipb.TopRURecord) (err error) {
+	if len(records) == 0 {
+		return
+	}
+
+	// Defense in depth: only send RU records when TopRU is enabled.
+	if !ds.enableTopRU || !topsqlstate.TopRUEnabled() {
+		return
+	}
+
+	start := time.Now()
+	sentCount := 0
+	defer func() {
+		reporter_metrics.TopSQLReportRURecordCounterHistogram.Observe(float64(sentCount))
+		if err != nil {
+			reporter_metrics.ReportRURecordDurationFailedHistogram.Observe(time.Since(start).Seconds())
+		} else {
+			reporter_metrics.ReportRURecordDurationSuccHistogram.Observe(time.Since(start).Seconds())
+		}
+	}()
+
+	topRURecord := &tipb.TopSQLSubResponse_RuRecord{}
+	r := &tipb.TopSQLSubResponse{RespOneof: topRURecord}
+
+	for i := range records {
+		topRURecord.RuRecord = &records[i]
 		if err = ds.stream.Send(r); err != nil {
 			return
 		}

--- a/pkg/util/topsql/reporter/pubsub_test.go
+++ b/pkg/util/topsql/reporter/pubsub_test.go
@@ -16,11 +16,13 @@ package reporter
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/pingcap/failpoint"
+	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,19 +35,72 @@ func (r *mockPubSubDataSinkRegisterer) Register(dataSink DataSink) error { retur
 
 func (r *mockPubSubDataSinkRegisterer) Deregister(dataSink DataSink) {}
 
+func mockTopRURecord() tipb.TopRURecord {
+	return tipb.TopRURecord{
+		User:      "user1",
+		SqlDigest: []byte("S1"),
+		Items: []*tipb.TopRURecordItem{{
+			TimestampSec: 1,
+			TotalRu:      1.0,
+			ExecCount:    1,
+			ExecDuration: 1,
+		}},
+	}
+}
+
+func mockTopRUSubRequest(itemInterval tipb.ItemInterval) *tipb.TopSQLSubRequest {
+	return &tipb.TopSQLSubRequest{
+		Collectors: []tipb.CollectorType{
+			tipb.CollectorType_COLLECTOR_TYPE_TOPSQL,
+			tipb.CollectorType_COLLECTOR_TYPE_TOPRU,
+		},
+		Topru: &tipb.TopRUConfig{
+			ItemIntervalSeconds: itemInterval,
+		},
+	}
+}
+
+func mockTopRUOnlySubRequest(itemInterval tipb.ItemInterval) *tipb.TopSQLSubRequest {
+	return &tipb.TopSQLSubRequest{
+		Collectors: []tipb.CollectorType{
+			tipb.CollectorType_COLLECTOR_TYPE_TOPRU,
+		},
+		Topru: &tipb.TopRUConfig{
+			ItemIntervalSeconds: itemInterval,
+		},
+	}
+}
+
 type mockPubSubDataSinkStream struct {
+	ctx       context.Context
 	records   []*tipb.TopSQLRecord
+	ruRecords []*tipb.TopRURecord
 	sqlMetas  []*tipb.SQLMeta
 	planMetas []*tipb.PlanMeta
+	sendErr   error
+	sendErrAt int
+	sendCount int
+	onSend    func(*tipb.TopSQLSubResponse, int)
 	sync.Mutex
 }
 
 func (s *mockPubSubDataSinkStream) Send(resp *tipb.TopSQLSubResponse) error {
 	s.Lock()
 	defer s.Unlock()
+	s.sendCount++
+
+	if s.onSend != nil {
+		s.onSend(resp, s.sendCount)
+	}
+	if s.sendErr != nil && s.sendErrAt > 0 && s.sendCount == s.sendErrAt {
+		return s.sendErr
+	}
 
 	if resp.GetRecord() != nil {
 		s.records = append(s.records, resp.GetRecord())
+	}
+	if resp.GetRuRecord() != nil {
+		s.ruRecords = append(s.ruRecords, resp.GetRuRecord())
 	}
 	if resp.GetSqlMeta() != nil {
 		s.sqlMetas = append(s.sqlMetas, resp.GetSqlMeta())
@@ -69,6 +124,9 @@ func (s *mockPubSubDataSinkStream) SetTrailer(metadata.MD) {
 }
 
 func (s *mockPubSubDataSinkStream) Context() context.Context {
+	if s.ctx != nil {
+		return s.ctx
+	}
 	return context.Background()
 }
 
@@ -82,14 +140,17 @@ func (s *mockPubSubDataSinkStream) RecvMsg(m any) error {
 
 func TestPubSubDataSink(t *testing.T) {
 	mockStream := &mockPubSubDataSinkStream{}
-	ds := newPubSubDataSink(mockStream, &mockPubSubDataSinkRegisterer{})
+	// Create a subscription request (TopSQL only).
+	req := &tipb.TopSQLSubRequest{}
+	ds, err := newPubSubDataSink(req, mockStream, &mockPubSubDataSinkRegisterer{})
+	require.NoError(t, err)
 	go func() {
 		_ = ds.run()
 	}()
 
 	panicPath := "github.com/pingcap/tidb/pkg/util/topsql/reporter/mockGrpcLogPanic"
 	require.NoError(t, failpoint.Enable(panicPath, "panic"))
-	err := ds.TrySend(&ReportData{
+	err = ds.TrySend(&ReportData{
 		DataRecords: []tipb.TopSQLRecord{{
 			SqlDigest:  []byte("S1"),
 			PlanDigest: []byte("P1"),
@@ -101,6 +162,7 @@ func TestPubSubDataSink(t *testing.T) {
 				StmtDurationSumNs: 1,
 			}},
 		}},
+		RURecords: []tipb.TopRURecord{mockTopRURecord()},
 		SQLMetas: []tipb.SQLMeta{{
 			SqlDigest:     []byte("S1"),
 			NormalizedSql: "SQL-1",
@@ -116,10 +178,562 @@ func TestPubSubDataSink(t *testing.T) {
 
 	mockStream.Lock()
 	assert.Len(t, mockStream.records, 1)
+	assert.Len(t, mockStream.ruRecords, 0)
 	assert.Len(t, mockStream.sqlMetas, 1)
 	assert.Len(t, mockStream.planMetas, 1)
 	mockStream.Unlock()
 
 	ds.OnReporterClosing()
 	require.NoError(t, failpoint.Disable(panicPath))
+}
+
+type errPubSubDataSinkRegisterer struct{}
+
+func (r *errPubSubDataSinkRegisterer) Register(DataSink) error { return errors.New("register failed") }
+
+func (r *errPubSubDataSinkRegisterer) Deregister(DataSink) {}
+
+// TestNormalizeTopRUItemIntervalInvalid verifies pubsub stores the raw
+// interval value even when it is outside the supported enum range.
+func TestNormalizeTopRUItemIntervalInvalid(t *testing.T) {
+	req := mockTopRUSubRequest(tipb.ItemInterval(99))
+	ds, err := newPubSubDataSink(req, &mockPubSubDataSinkStream{}, &mockPubSubDataSinkRegisterer{})
+	require.NoError(t, err)
+	require.Equal(t, tipb.ItemInterval(99), ds.itemInterval)
+}
+
+// TestParseTopRUSubscription verifies parsing for nil, missing, and valid
+// TopRU requests, including passthrough of unknown intervals.
+func TestParseTopRUSubscription(t *testing.T) {
+	cases := []struct {
+		name         string
+		req          *tipb.TopSQLSubRequest
+		enableTopRU  bool
+		itemInterval tipb.ItemInterval
+		err          error
+	}{
+		{
+			name:         "nil request",
+			req:          nil,
+			enableTopRU:  false,
+			itemInterval: tipb.ItemInterval_ITEM_INTERVAL_UNSPECIFIED,
+			err:          nil,
+		},
+		{
+			name: "missing topru config",
+			req: &tipb.TopSQLSubRequest{
+				Collectors: []tipb.CollectorType{tipb.CollectorType_COLLECTOR_TYPE_TOPRU},
+			},
+			enableTopRU:  false,
+			itemInterval: tipb.ItemInterval_ITEM_INTERVAL_UNSPECIFIED,
+			err:          ErrTopRUConfig,
+		},
+		{
+			name: "missing topru collector",
+			req: &tipb.TopSQLSubRequest{
+				Collectors: []tipb.CollectorType{tipb.CollectorType_COLLECTOR_TYPE_TOPSQL},
+				Topru: &tipb.TopRUConfig{
+					ItemIntervalSeconds: tipb.ItemInterval_ITEM_INTERVAL_30S,
+				},
+			},
+			enableTopRU:  false,
+			itemInterval: tipb.ItemInterval_ITEM_INTERVAL_UNSPECIFIED,
+			err:          nil,
+		},
+		{
+			name:         "enabled with valid collector",
+			req:          mockTopRUSubRequest(tipb.ItemInterval_ITEM_INTERVAL_30S),
+			enableTopRU:  true,
+			itemInterval: tipb.ItemInterval_ITEM_INTERVAL_30S,
+			err:          nil,
+		},
+		{
+			name: "enabled with unknown interval passthrough",
+			req: &tipb.TopSQLSubRequest{
+				Collectors: []tipb.CollectorType{tipb.CollectorType_COLLECTOR_TYPE_TOPRU},
+				Topru: &tipb.TopRUConfig{
+					ItemIntervalSeconds: tipb.ItemInterval(99),
+				},
+			},
+			enableTopRU:  true,
+			itemInterval: tipb.ItemInterval(99),
+			err:          nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enableTopRU, itemInterval, err := parseTopRUSubscription(tc.req)
+			if tc.err == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.err)
+			}
+			require.Equal(t, tc.enableTopRU, enableTopRU)
+			require.Equal(t, tc.itemInterval, itemInterval)
+		})
+	}
+}
+
+// TestParseTopSQLSubscription verifies TopSQL collector parsing, including the
+// legacy behavior that empty collectors imply TopSQL enabled.
+func TestParseTopSQLSubscription(t *testing.T) {
+	cases := []struct {
+		name         string
+		req          *tipb.TopSQLSubRequest
+		enableTopSQL bool
+	}{
+		{
+			name:         "nil request",
+			req:          nil,
+			enableTopSQL: true,
+		},
+		{
+			name:         "empty collectors",
+			req:          &tipb.TopSQLSubRequest{},
+			enableTopSQL: true,
+		},
+		{
+			name: "topsql collector",
+			req: &tipb.TopSQLSubRequest{
+				Collectors: []tipb.CollectorType{tipb.CollectorType_COLLECTOR_TYPE_TOPSQL},
+			},
+			enableTopSQL: true,
+		},
+		{
+			name: "topru only",
+			req: &tipb.TopSQLSubRequest{
+				Collectors: []tipb.CollectorType{tipb.CollectorType_COLLECTOR_TYPE_TOPRU},
+				Topru: &tipb.TopRUConfig{
+					ItemIntervalSeconds: tipb.ItemInterval_ITEM_INTERVAL_30S,
+				},
+			},
+			enableTopSQL: false,
+		},
+		{
+			name: "both collectors",
+			req: &tipb.TopSQLSubRequest{
+				Collectors: []tipb.CollectorType{
+					tipb.CollectorType_COLLECTOR_TYPE_TOPSQL,
+					tipb.CollectorType_COLLECTOR_TYPE_TOPRU,
+				},
+				Topru: &tipb.TopRUConfig{
+					ItemIntervalSeconds: tipb.ItemInterval_ITEM_INTERVAL_15S,
+				},
+			},
+			enableTopSQL: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.enableTopSQL, parseTopSQLSubscription(tc.req))
+		})
+	}
+}
+
+// TestTopRUPubSub verifies TopRU subscription enablement, interval handling,
+// and send gating in the pubsub data sink across related scenarios.
+// It groups TopRU-only tests as subtests to keep package test count bounded.
+func TestTopRUPubSub(t *testing.T) {
+	t.Run("data sink enable topru", func(t *testing.T) {
+		mockStream := &mockPubSubDataSinkStream{}
+		req := mockTopRUSubRequest(tipb.ItemInterval_ITEM_INTERVAL_15S)
+		ds, err := newPubSubDataSink(req, mockStream, &mockPubSubDataSinkRegisterer{})
+		require.NoError(t, err)
+
+		topsqlstate.EnableTopRU()
+		defer func() {
+			for topsqlstate.TopRUEnabled() {
+				topsqlstate.DisableTopRU()
+			}
+		}()
+
+		err = ds.sendTopRURecords(context.Background(), []tipb.TopRURecord{mockTopRURecord()})
+		require.NoError(t, err)
+
+		mockStream.Lock()
+		assert.Len(t, mockStream.ruRecords, 1)
+		mockStream.Unlock()
+	})
+
+	t.Run("multi subscriber isolation", func(t *testing.T) {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.ResetTopRUItemInterval()
+
+		registererCtx, registererCancel := context.WithCancel(context.Background())
+		t.Cleanup(registererCancel)
+		registerer := NewDefaultDataSinkRegisterer(registererCtx)
+		svc := NewTopSQLPubSubService(&registerer)
+
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		ctx2, cancel2 := context.WithCancel(context.Background())
+		t.Cleanup(func() {
+			cancel1()
+			cancel2()
+		})
+
+		stream1 := &mockPubSubDataSinkStream{ctx: ctx1}
+		stream2 := &mockPubSubDataSinkStream{ctx: ctx2}
+
+		req1 := mockTopRUSubRequest(tipb.ItemInterval(30))
+		req2 := mockTopRUSubRequest(tipb.ItemInterval(15))
+
+		// Eventually checks make this test robust to async subscribe goroutines.
+		go func() { _ = svc.Subscribe(req1, stream1) }()
+		require.Eventually(t, func() bool {
+			return topsqlstate.TopRUEnabled() && topsqlstate.GetTopRUItemInterval() == 30
+		}, time.Second, 10*time.Millisecond)
+
+		go func() { _ = svc.Subscribe(req2, stream2) }()
+		require.Eventually(t, func() bool {
+			return topsqlstate.TopRUEnabled() && topsqlstate.GetTopRUItemInterval() == 15
+		}, time.Second, 10*time.Millisecond)
+
+		cancel2()
+		require.Eventually(t, func() bool {
+			return topsqlstate.TopRUEnabled() && topsqlstate.GetTopRUItemInterval() == 15
+		}, time.Second, 10*time.Millisecond)
+
+		cancel1()
+		require.Eventually(t, func() bool {
+			return !topsqlstate.TopRUEnabled() && topsqlstate.GetTopRUItemInterval() == int64(topsqlstate.DefTiDBTopRUItemIntervalSeconds)
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("register fail does not enable topru", func(t *testing.T) {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+
+		req := mockTopRUSubRequest(tipb.ItemInterval_ITEM_INTERVAL_15S)
+		svc := NewTopSQLPubSubService(&errPubSubDataSinkRegisterer{})
+		err := svc.Subscribe(req, &mockPubSubDataSinkStream{})
+		require.Error(t, err)
+		require.False(t, topsqlstate.TopRUEnabled())
+	})
+
+	t.Run("subscribe missing topru config fails", func(t *testing.T) {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.DisableTopSQL()
+		topsqlstate.ResetTopRUItemInterval()
+		t.Cleanup(func() {
+			for topsqlstate.TopRUEnabled() {
+				topsqlstate.DisableTopRU()
+			}
+			topsqlstate.DisableTopSQL()
+			topsqlstate.ResetTopRUItemInterval()
+		})
+
+		registererCtx, registererCancel := context.WithCancel(context.Background())
+		t.Cleanup(registererCancel)
+		registerer := NewDefaultDataSinkRegisterer(registererCtx)
+		svc := NewTopSQLPubSubService(&registerer)
+
+		req := &tipb.TopSQLSubRequest{
+			Collectors: []tipb.CollectorType{tipb.CollectorType_COLLECTOR_TYPE_TOPRU},
+		}
+		err := svc.Subscribe(req, &mockPubSubDataSinkStream{})
+		require.ErrorIs(t, err, ErrTopRUConfig)
+		require.False(t, topsqlstate.TopRUEnabled())
+		require.False(t, topsqlstate.TopSQLEnabled())
+	})
+
+	t.Run("subscribe invalid topru interval does not enable", func(t *testing.T) {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.DisableTopSQL()
+		topsqlstate.ResetTopRUItemInterval()
+		t.Cleanup(func() {
+			for topsqlstate.TopRUEnabled() {
+				topsqlstate.DisableTopRU()
+			}
+			topsqlstate.DisableTopSQL()
+			topsqlstate.ResetTopRUItemInterval()
+		})
+
+		registererCtx, registererCancel := context.WithCancel(context.Background())
+		t.Cleanup(registererCancel)
+		registerer := NewDefaultDataSinkRegisterer(registererCtx)
+		svc := NewTopSQLPubSubService(&registerer)
+
+		req := mockTopRUSubRequest(tipb.ItemInterval(99))
+		err := svc.Subscribe(req, &mockPubSubDataSinkStream{})
+		require.ErrorIs(t, err, topsqlstate.ErrInvalidTopRUItemInterval)
+		require.False(t, topsqlstate.TopRUEnabled())
+		require.False(t, topsqlstate.TopSQLEnabled())
+		require.Equal(t, int64(topsqlstate.DefTiDBTopRUItemIntervalSeconds), topsqlstate.GetTopRUItemInterval())
+	})
+
+	t.Run("subscribe topru only does not enable topsql", func(t *testing.T) {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.DisableTopSQL()
+		topsqlstate.ResetTopRUItemInterval()
+		t.Cleanup(func() {
+			for topsqlstate.TopRUEnabled() {
+				topsqlstate.DisableTopRU()
+			}
+			topsqlstate.DisableTopSQL()
+			topsqlstate.ResetTopRUItemInterval()
+		})
+
+		registererCtx, registererCancel := context.WithCancel(context.Background())
+		t.Cleanup(registererCancel)
+		registerer := NewDefaultDataSinkRegisterer(registererCtx)
+
+		req := mockTopRUOnlySubRequest(tipb.ItemInterval_ITEM_INTERVAL_15S)
+		ds, err := newPubSubDataSink(req, &mockPubSubDataSinkStream{}, &registerer)
+		require.NoError(t, err)
+		require.NoError(t, registerer.Register(ds))
+		t.Cleanup(func() { registerer.Deregister(ds) })
+
+		require.True(t, topsqlstate.TopRUEnabled())
+		require.False(t, topsqlstate.TopSQLEnabled())
+		require.True(t, topsqlstate.TopProfilingEnabled())
+	})
+
+	t.Run("send topru records gating and errors", func(t *testing.T) {
+		setGlobalTopRUEnabled := func(enabled bool) {
+			for topsqlstate.TopRUEnabled() {
+				topsqlstate.DisableTopRU()
+			}
+			if enabled {
+				topsqlstate.EnableTopRU()
+			}
+		}
+		t.Cleanup(func() {
+			setGlobalTopRUEnabled(false)
+		})
+
+		records := []tipb.TopRURecord{
+			{
+				User:      "user1",
+				SqlDigest: []byte("S1"),
+				Items: []*tipb.TopRURecordItem{{
+					TimestampSec: 1,
+					TotalRu:      1.0,
+					ExecCount:    1,
+					ExecDuration: 1,
+				}},
+			},
+			{
+				User:      "user2",
+				SqlDigest: []byte("S2"),
+				Items: []*tipb.TopRURecordItem{{
+					TimestampSec: 2,
+					TotalRu:      2.0,
+					ExecCount:    1,
+					ExecDuration: 1,
+				}},
+			},
+		}
+
+		t.Run("skip when records empty", func(t *testing.T) {
+			setGlobalTopRUEnabled(true)
+			stream := &mockPubSubDataSinkStream{}
+			ds := &pubSubDataSink{
+				stream:       stream,
+				enableTopSQL: true,
+				enableTopRU:  true,
+			}
+
+			err := ds.sendTopRURecords(context.Background(), nil)
+			require.NoError(t, err)
+			require.Len(t, stream.ruRecords, 0)
+		})
+
+		t.Run("skip when sink top ru disabled", func(t *testing.T) {
+			setGlobalTopRUEnabled(true)
+			stream := &mockPubSubDataSinkStream{}
+			ds := &pubSubDataSink{
+				stream:      stream,
+				enableTopRU: false,
+			}
+
+			err := ds.sendTopRURecords(context.Background(), records)
+			require.NoError(t, err)
+			require.Len(t, stream.ruRecords, 0)
+		})
+
+		t.Run("skip when global top ru disabled", func(t *testing.T) {
+			setGlobalTopRUEnabled(false)
+			stream := &mockPubSubDataSinkStream{}
+			ds := &pubSubDataSink{
+				stream:       stream,
+				enableTopSQL: true,
+				enableTopRU:  true,
+			}
+
+			err := ds.sendTopRURecords(context.Background(), records)
+			require.NoError(t, err)
+			require.Len(t, stream.ruRecords, 0)
+		})
+
+		t.Run("return stream send error", func(t *testing.T) {
+			setGlobalTopRUEnabled(true)
+			sendErr := errors.New("stream send failed")
+			stream := &mockPubSubDataSinkStream{
+				sendErr:   sendErr,
+				sendErrAt: 1,
+			}
+			ds := &pubSubDataSink{
+				stream:      stream,
+				enableTopRU: true,
+			}
+
+			err := ds.sendTopRURecords(context.Background(), records)
+			require.ErrorIs(t, err, sendErr)
+			require.Len(t, stream.ruRecords, 0)
+		})
+
+		t.Run("stop on context cancel after first send", func(t *testing.T) {
+			setGlobalTopRUEnabled(true)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			stream := &mockPubSubDataSinkStream{}
+			stream.onSend = func(_ *tipb.TopSQLSubResponse, count int) {
+				if count == 1 {
+					cancel()
+				}
+			}
+			ds := &pubSubDataSink{
+				stream:      stream,
+				enableTopRU: true,
+			}
+
+			err := ds.sendTopRURecords(ctx, records)
+			require.ErrorIs(t, err, context.Canceled)
+			require.Len(t, stream.ruRecords, 1)
+		})
+	})
+}
+
+// TestSendTopSQLRecordsGating verifies TopSQL records are only sent when the
+// sink has TopSQL enabled.
+func TestSendTopSQLRecordsGating(t *testing.T) {
+	records := []tipb.TopSQLRecord{{
+		SqlDigest:  []byte("S1"),
+		PlanDigest: []byte("P1"),
+		Items: []*tipb.TopSQLRecordItem{{
+			TimestampSec: 1,
+			CpuTimeMs:    1,
+		}},
+	}}
+
+	stream := &mockPubSubDataSinkStream{}
+	ds := &pubSubDataSink{
+		stream:       stream,
+		enableTopSQL: false,
+	}
+	require.NoError(t, ds.sendTopSQLRecords(context.Background(), records))
+	require.Len(t, stream.records, 0)
+
+	stream = &mockPubSubDataSinkStream{}
+	ds = &pubSubDataSink{
+		stream:       stream,
+		enableTopSQL: true,
+	}
+	require.NoError(t, ds.sendTopSQLRecords(context.Background(), records))
+	require.Len(t, stream.records, 1)
+}
+
+// TestPubSubDataSinkDoSendOrderIsStable verifies doSend emits records in a
+// deterministic order and stops cleanly on context cancellation.
+func TestPubSubDataSinkDoSendOrderIsStable(t *testing.T) {
+	setGlobalTopRUEnabled := func(enabled bool) {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		if enabled {
+			topsqlstate.EnableTopRU()
+		}
+	}
+	t.Cleanup(func() {
+		setGlobalTopRUEnabled(false)
+	})
+	setGlobalTopRUEnabled(true)
+
+	responseKind := func(resp *tipb.TopSQLSubResponse) string {
+		switch resp.RespOneof.(type) {
+		case *tipb.TopSQLSubResponse_Record:
+			return "record"
+		case *tipb.TopSQLSubResponse_RuRecord:
+			return "ru_record"
+		case *tipb.TopSQLSubResponse_SqlMeta:
+			return "sql_meta"
+		case *tipb.TopSQLSubResponse_PlanMeta:
+			return "plan_meta"
+		default:
+			return "unknown"
+		}
+	}
+
+	data := &ReportData{
+		DataRecords: []tipb.TopSQLRecord{
+			{SqlDigest: []byte("S1"), PlanDigest: []byte("P1")},
+			{SqlDigest: []byte("S2"), PlanDigest: []byte("P2")},
+		},
+		RURecords: []tipb.TopRURecord{
+			{User: "u1", SqlDigest: []byte("R1"), PlanDigest: []byte("RP1")},
+			{User: "u2", SqlDigest: []byte("R2"), PlanDigest: []byte("RP2")},
+		},
+		SQLMetas: []tipb.SQLMeta{
+			{SqlDigest: []byte("S1"), NormalizedSql: "sql1"},
+		},
+		PlanMetas: []tipb.PlanMeta{
+			{PlanDigest: []byte("P1"), NormalizedPlan: "plan1"},
+		},
+	}
+
+	t.Run("stable send order", func(t *testing.T) {
+		stream := &mockPubSubDataSinkStream{}
+		gotOrder := make([]string, 0, 6)
+		stream.onSend = func(resp *tipb.TopSQLSubResponse, _ int) {
+			gotOrder = append(gotOrder, responseKind(resp))
+		}
+		ds := &pubSubDataSink{
+			stream:       stream,
+			enableTopSQL: true,
+			enableTopRU:  true,
+		}
+
+		err := ds.doSend(context.Background(), data)
+		require.NoError(t, err)
+		require.Equal(t,
+			[]string{"record", "record", "ru_record", "ru_record", "sql_meta", "plan_meta"},
+			gotOrder,
+		)
+	})
+
+	t.Run("context cancel stops sending", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stream := &mockPubSubDataSinkStream{}
+		gotOrder := make([]string, 0, 6)
+		stream.onSend = func(resp *tipb.TopSQLSubResponse, count int) {
+			gotOrder = append(gotOrder, responseKind(resp))
+			if count == 3 {
+				cancel()
+			}
+		}
+		ds := &pubSubDataSink{
+			stream:       stream,
+			enableTopSQL: true,
+			enableTopRU:  true,
+		}
+
+		err := ds.doSend(ctx, data)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Len(t, gotOrder, 3)
+		require.Equal(t, []string{"record", "record", "ru_record"}, gotOrder)
+	})
 }

--- a/pkg/util/topsql/reporter/single_target.go
+++ b/pkg/util/topsql/reporter/single_target.go
@@ -29,7 +29,9 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -204,8 +206,8 @@ func (ds *SingleTargetDataSink) doSend(addr string, task sendTask) {
 	}
 
 	var wg sync.WaitGroup
-	errCh := make(chan error, 3)
-	wg.Add(3)
+	errCh := make(chan error, 4)
+	wg.Add(4)
 
 	go func() {
 		defer wg.Done()
@@ -218,6 +220,10 @@ func (ds *SingleTargetDataSink) doSend(addr string, task sendTask) {
 	go func() {
 		defer wg.Done()
 		errCh <- ds.sendBatchTopSQLRecord(ctx, task.data.DataRecords)
+	}()
+	go func() {
+		defer wg.Done()
+		errCh <- ds.sendBatchTopRURecord(ctx, task.data.RURecords)
 	}()
 	wg.Wait()
 	close(errCh)
@@ -260,6 +266,49 @@ func (ds *SingleTargetDataSink) sendBatchTopSQLRecord(ctx context.Context, recor
 	// See https://pkg.go.dev/google.golang.org/grpc#ClientConn.NewStream for how to avoid leaking the stream
 	_, err = stream.CloseAndRecv()
 	return
+}
+
+// sendBatchTopRURecord sends a batch of TopRU records by stream.
+// TopRU over SingleTarget is intentionally unsupported now.
+func (*SingleTargetDataSink) sendBatchTopRURecord(_ context.Context, records []tipb.TopRURecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	return nil
+}
+
+func sendTopRURecords(stream topRURecordStream, records []tipb.TopRURecord) (sentCount int, retErr error) {
+	defer func() {
+		if status.Code(retErr) == codes.Unimplemented {
+			_, _ = stream.CloseAndRecv()
+			retErr = nil
+			return
+		}
+
+		if _, cErr := stream.CloseAndRecv(); cErr != nil {
+			if status.Code(cErr) == codes.Unimplemented {
+				retErr = nil
+				return
+			}
+			if retErr == nil {
+				retErr = cErr
+			}
+		}
+	}()
+
+	for i := range records {
+		if retErr = stream.Send(&records[i]); retErr != nil {
+			return
+		}
+		sentCount++
+	}
+
+	return
+}
+
+type topRURecordStream interface {
+	Send(*tipb.TopRURecord) error
+	CloseAndRecv() (*tipb.EmptyResponse, error)
 }
 
 // sendBatchSQLMeta sends a batch of SQL metas by stream.

--- a/pkg/util/topsql/reporter/single_target_test.go
+++ b/pkg/util/topsql/reporter/single_target_test.go
@@ -15,13 +15,18 @@
 package reporter
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/util/topsql/reporter/mock"
+	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type mockSingleTargetDataSinkRegisterer struct{}
@@ -30,10 +35,37 @@ func (r *mockSingleTargetDataSinkRegisterer) Register(dataSink DataSink) error {
 
 func (r *mockSingleTargetDataSinkRegisterer) Deregister(dataSink DataSink) {}
 
+func mockTopRURecords() []tipb.TopRURecord {
+	return []tipb.TopRURecord{{
+		User:       "user1",
+		SqlDigest:  []byte("S1"),
+		PlanDigest: []byte("P1"),
+		Items: []*tipb.TopRURecordItem{{
+			TimestampSec: 1,
+			TotalRu:      1.5,
+			ExecCount:    1,
+			ExecDuration: 1,
+		}},
+	}}
+}
+
+// TestSingleTargetDataSink verifies the single-target sink forwards TopSQL
+// records and SQL/plan metadata, while TopRU is intentionally not sent.
+// It uses an in-process server with bounded waits, so assertions are not timing fragile.
 func TestSingleTargetDataSink(t *testing.T) {
 	server, err := mock.StartMockAgentServer()
 	assert.NoError(t, err)
 	defer server.Stop()
+
+	for topsqlstate.TopRUEnabled() {
+		topsqlstate.DisableTopRU()
+	}
+	topsqlstate.EnableTopRU()
+	t.Cleanup(func() {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+	})
 
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.TopSQL.ReceiverAddress = server.Address()
@@ -45,6 +77,8 @@ func TestSingleTargetDataSink(t *testing.T) {
 
 	recordsCnt := server.RecordsCnt()
 	sqlMetaCnt := server.SQLMetaCnt()
+	ruRecordsCnt := server.RURecordsCnt()
+	ruRecords := mockTopRURecords()
 
 	err = ds.TrySend(&ReportData{
 		DataRecords: []tipb.TopSQLRecord{{
@@ -58,6 +92,7 @@ func TestSingleTargetDataSink(t *testing.T) {
 				StmtDurationSumNs: 1,
 			}},
 		}},
+		RURecords: ruRecords,
 		SQLMetas: []tipb.SQLMeta{{
 			SqlDigest:     []byte("S1"),
 			NormalizedSql: "SQL-1",
@@ -71,8 +106,13 @@ func TestSingleTargetDataSink(t *testing.T) {
 
 	server.WaitCollectCnt(recordsCnt, 1, 5*time.Second)
 	server.WaitCollectCntOfSQLMeta(sqlMetaCnt, 1, 5*time.Second)
+	require.Never(t, func() bool {
+		return server.RURecordsCnt() != ruRecordsCnt
+	}, 500*time.Millisecond, 10*time.Millisecond)
 
 	assert.Len(t, server.GetLatestRecords(), 1)
+	assert.Equal(t, ruRecordsCnt, server.RURecordsCnt())
+	assert.Empty(t, server.GetLatestRURecords())
 	assert.Len(t, server.GetTotalSQLMetas(), 1)
 	sqlMeta, exist := server.GetSQLMetaByDigestBlocking([]byte("S1"), 5*time.Second)
 	assert.True(t, exist)
@@ -80,4 +120,105 @@ func TestSingleTargetDataSink(t *testing.T) {
 	normalizedPlan, exist := server.GetPlanMetaByDigestBlocking([]byte("P1"), 5*time.Second)
 	assert.True(t, exist)
 	assert.Equal(t, normalizedPlan, "PLAN-1")
+}
+
+// TestSingleTargetDataSinkDropsTopRU verifies TopRU records are dropped by
+// SingleTargetDataSink regardless of global TopRU state.
+func TestSingleTargetDataSinkDropsTopRU(t *testing.T) {
+	t.Run("via TrySend", func(t *testing.T) {
+		server, err := mock.StartMockAgentServer()
+		require.NoError(t, err)
+		defer server.Stop()
+
+		config.UpdateGlobal(func(conf *config.Config) {
+			conf.TopSQL.ReceiverAddress = server.Address()
+		})
+
+		ds := NewSingleTargetDataSink(&mockSingleTargetDataSinkRegisterer{})
+		ds.Start()
+		defer ds.Close()
+
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		t.Cleanup(func() {
+			for topsqlstate.TopRUEnabled() {
+				topsqlstate.DisableTopRU()
+			}
+		})
+
+		records := mockTopRURecords()
+		baseCnt := server.RURecordsCnt()
+
+		err = ds.TrySend(&ReportData{RURecords: records}, time.Now().Add(10*time.Second))
+		require.NoError(t, err)
+		require.Never(t, func() bool {
+			return server.RURecordsCnt() != baseCnt
+		}, 500*time.Millisecond, 10*time.Millisecond)
+
+		topsqlstate.EnableTopRU()
+		err = ds.TrySend(&ReportData{RURecords: records}, time.Now().Add(10*time.Second))
+		require.NoError(t, err)
+		require.Never(t, func() bool {
+			return server.RURecordsCnt() != baseCnt
+		}, 500*time.Millisecond, 10*time.Millisecond)
+
+		latest := server.GetLatestRURecords()
+		require.Empty(t, latest)
+	})
+
+	t.Run("via sendBatchTopRURecord", func(t *testing.T) {
+		ds := NewSingleTargetDataSink(&mockSingleTargetDataSinkRegisterer{})
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.EnableTopRU()
+		t.Cleanup(func() {
+			for topsqlstate.TopRUEnabled() {
+				topsqlstate.DisableTopRU()
+			}
+		})
+
+		records := mockTopRURecords()
+
+		err := ds.sendBatchTopRURecord(ctx, records)
+		require.NoError(t, err)
+		require.True(t, topsqlstate.TopRUEnabled())
+
+		err = ds.sendBatchTopRURecord(ctx, records)
+		require.NoError(t, err)
+		require.True(t, topsqlstate.TopRUEnabled())
+	})
+}
+
+type mockTopRURecordStream struct {
+	sendErr     error
+	closeErr    error
+	closeCalled bool
+}
+
+func (m *mockTopRURecordStream) Send(*tipb.TopRURecord) error {
+	return m.sendErr
+}
+
+func (m *mockTopRURecordStream) CloseAndRecv() (*tipb.EmptyResponse, error) {
+	m.closeCalled = true
+	return &tipb.EmptyResponse{}, m.closeErr
+}
+
+// TestSendTopRURecordsClosesStreamOnUnimplementedSend verifies CloseAndRecv
+// is still invoked when Send returns Unimplemented.
+func TestSendTopRURecordsClosesStreamOnUnimplementedSend(t *testing.T) {
+	stream := &mockTopRURecordStream{
+		sendErr:  status.Error(codes.Unimplemented, "topru rpc not supported"),
+		closeErr: status.Error(codes.Internal, "close failed"),
+	}
+
+	sentCount, err := sendTopRURecords(stream, mockTopRURecords())
+	require.NoError(t, err)
+	require.Zero(t, sentCount)
+	require.True(t, stream.closeCalled)
 }

--- a/pkg/util/topsql/state/BUILD.bazel
+++ b/pkg/util/topsql/state/BUILD.bazel
@@ -1,9 +1,24 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "state",
     srcs = ["state.go"],
     importpath = "github.com/pingcap/tidb/pkg/util/topsql/state",
     visibility = ["//visibility:public"],
-    deps = ["@org_uber_go_atomic//:atomic"],
+    deps = [
+        "//pkg/util/logutil",
+        "@com_github_pingcap_tipb//go-tipb",
+        "@org_uber_go_atomic//:atomic",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "state_test",
+    timeout = "short",
+    srcs = ["state_test.go"],
+    embed = [":state"],
+    flaky = True,
+    shard_count = 3,
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/util/topsql/state/state.go
+++ b/pkg/util/topsql/state/state.go
@@ -14,7 +14,15 @@
 
 package state
 
-import "go.uber.org/atomic"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/pingcap/tipb/go-tipb"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+)
 
 // Default Top-SQL state values.
 const (
@@ -25,14 +33,25 @@ const (
 	DefTiDBTopSQLReportIntervalSeconds = 60
 )
 
+// Default Top-RU state values.
+const (
+	// DefTiDBTopRUItemIntervalSeconds is the default TopRU item interval in seconds.
+	DefTiDBTopRUItemIntervalSeconds = 60
+)
+
 // GlobalState is the global Top-SQL state.
 var GlobalState = State{
-	enable:                atomic.NewBool(false),
-	PrecisionSeconds:      atomic.NewInt64(DefTiDBTopSQLPrecisionSeconds),
-	MaxStatementCount:     atomic.NewInt64(DefTiDBTopSQLMaxTimeSeriesCount),
-	MaxCollect:            atomic.NewInt64(DefTiDBTopSQLMaxMetaCount),
-	ReportIntervalSeconds: atomic.NewInt64(DefTiDBTopSQLReportIntervalSeconds),
+	enable:                   atomic.NewBool(false),
+	PrecisionSeconds:         atomic.NewInt64(DefTiDBTopSQLPrecisionSeconds),
+	MaxStatementCount:        atomic.NewInt64(DefTiDBTopSQLMaxTimeSeriesCount),
+	MaxCollect:               atomic.NewInt64(DefTiDBTopSQLMaxMetaCount),
+	ReportIntervalSeconds:    atomic.NewInt64(DefTiDBTopSQLReportIntervalSeconds),
+	ruConsumerCount:          atomic.NewInt64(0),
+	TopRUItemIntervalSeconds: atomic.NewInt64(DefTiDBTopRUItemIntervalSeconds),
 }
+
+// ErrInvalidTopRUItemInterval is returned when TopRU item interval is not supported.
+var ErrInvalidTopRUItemInterval = errors.New("invalid top ru item interval")
 
 // State is the state for control top sql feature.
 type State struct {
@@ -46,6 +65,12 @@ type State struct {
 	MaxCollect *atomic.Int64
 	// The report data interval of top-sql.
 	ReportIntervalSeconds *atomic.Int64
+
+	// ruConsumerCount is the number of active TopRU subscribers.
+	// TopRU is enabled when ruConsumerCount > 0.
+	ruConsumerCount *atomic.Int64
+	// TopRUItemIntervalSeconds is the TopRU item interval in seconds.
+	TopRUItemIntervalSeconds *atomic.Int64
 }
 
 // EnableTopSQL enables the top SQL feature.
@@ -63,13 +88,89 @@ func TopSQLEnabled() bool {
 	return GlobalState.enable.Load()
 }
 
-// TopProfilingEnabled returns true if any Top Profiling consumer is enabled.
+// TopProfilingEnabled returns true if either TopSQL or TopRU is enabled.
 //
-// In current codebase it is equivalent to TopSQLEnabled(). It is introduced to
-// unify execution-path hooks (SQL/plan registration, stmt lifecycle callbacks,
-// resource group tagging) so they can later be extended to support TopRU.
+// NOTE: This helper is for hooks that should run when any Top* consumer exists.
 func TopProfilingEnabled() bool {
-	// TODO: include TopRUEnabled() here once TopRU is merged.
-	// return TopSQLEnabled() || TopRUEnabled()
-	return TopSQLEnabled()
+	return TopSQLEnabled() || TopRUEnabled()
+}
+
+// EnableTopRU increments the TopRU consumer count.
+// TopRU is enabled when the count is greater than 0.
+func EnableTopRU() {
+	GlobalState.ruConsumerCount.Inc()
+}
+
+// DisableTopRU decrements the TopRU consumer count.
+// When the count reaches 0, ResetTopRUItemInterval is called.
+func DisableTopRU() {
+	for {
+		prevCount := GlobalState.ruConsumerCount.Load()
+		if prevCount <= 0 {
+			// Already at 0, nothing to decrement (defensive guard)
+			return
+		}
+
+		if GlobalState.ruConsumerCount.CAS(prevCount, prevCount-1) {
+			// If this was the last subscriber, reset report interval to default
+			if prevCount == 1 {
+				ResetTopRUItemInterval()
+			}
+			return
+		}
+		// CAS failed, retry
+	}
+}
+
+// TopRUEnabled checks whether TopRU feature is enabled.
+// Returns true if at least one subscriber has enabled TopRU (ruConsumerCount > 0).
+func TopRUEnabled() bool {
+	return GlobalState.ruConsumerCount.Load() > 0
+}
+
+func normalizeTopRUItemIntervalSeconds(intervalSeconds tipb.ItemInterval) (int64, error) {
+	switch intervalSeconds {
+	case tipb.ItemInterval_ITEM_INTERVAL_UNSPECIFIED:
+		return DefTiDBTopRUItemIntervalSeconds, nil
+	case tipb.ItemInterval_ITEM_INTERVAL_15S, tipb.ItemInterval_ITEM_INTERVAL_30S, tipb.ItemInterval_ITEM_INTERVAL_60S:
+		return int64(intervalSeconds), nil
+	default:
+		return 0, fmt.Errorf("%w: %d", ErrInvalidTopRUItemInterval, intervalSeconds)
+	}
+}
+
+// SetTopRUItemInterval sets the report interval for TopRU (in seconds).
+// Valid values are 15, 30, and 60 from tipb.ItemInterval.
+// ITEM_INTERVAL_UNSPECIFIED (0) falls back to the default value.
+func SetTopRUItemInterval(itemIntervalSeconds tipb.ItemInterval) error {
+	intervalSeconds, err := normalizeTopRUItemIntervalSeconds(itemIntervalSeconds)
+	current := GlobalState.TopRUItemIntervalSeconds.Load()
+	if err != nil {
+		logutil.BgLogger().Warn(
+			"[top-sql] top ru item interval invalid",
+			zap.Int64("current_interval_seconds", current),
+			zap.Int64("active_subscribers", GlobalState.ruConsumerCount.Load()),
+			zap.Error(err),
+		)
+		return err
+	}
+
+	logutil.BgLogger().Info(
+		"[top-sql] top ru item interval overridden by later subscription",
+		zap.Int64("current_interval_seconds", current),
+		zap.Int64("new_interval_seconds", intervalSeconds),
+		zap.Int64("active_subscribers", GlobalState.ruConsumerCount.Load()),
+	)
+	GlobalState.TopRUItemIntervalSeconds.Store(intervalSeconds)
+	return nil
+}
+
+// GetTopRUItemInterval returns the report interval for TopRU (in seconds).
+func GetTopRUItemInterval() int64 {
+	return GlobalState.TopRUItemIntervalSeconds.Load()
+}
+
+// ResetTopRUItemInterval resets the report interval to the default value.
+func ResetTopRUItemInterval() {
+	GlobalState.TopRUItemIntervalSeconds.Store(DefTiDBTopRUItemIntervalSeconds)
 }

--- a/pkg/util/topsql/state/state_test.go
+++ b/pkg/util/topsql/state/state_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTopRUEnableDisableAndResetInterval verifies TopRU enablement is ref-counted
+// and that the item interval resets to default only when the last consumer leaves.
+// It also confirms extra disables do not underflow the global counter.
+func TestTopRUEnableDisableAndResetInterval(t *testing.T) {
+	GlobalState.ruConsumerCount.Store(0)
+	ResetTopRUItemInterval()
+
+	require.False(t, TopRUEnabled())
+	EnableTopRU()
+	require.True(t, TopRUEnabled())
+	EnableTopRU()
+	require.True(t, TopRUEnabled())
+
+	require.NoError(t, SetTopRUItemInterval(15))
+	require.Equal(t, int64(15), GetTopRUItemInterval())
+
+	DisableTopRU()
+	require.True(t, TopRUEnabled())
+	require.Equal(t, int64(15), GetTopRUItemInterval())
+
+	DisableTopRU()
+	require.False(t, TopRUEnabled())
+	require.Equal(t, int64(DefTiDBTopRUItemIntervalSeconds), GetTopRUItemInterval())
+
+	DisableTopRU()
+	require.False(t, TopRUEnabled())
+}
+
+// TestTopRUItemIntervalLastWriteWins verifies the global TopRU item interval
+// always reflects the most recent valid setter.
+func TestTopRUItemIntervalLastWriteWins(t *testing.T) {
+	GlobalState.ruConsumerCount.Store(0)
+	ResetTopRUItemInterval()
+
+	require.NoError(t, SetTopRUItemInterval(30))
+	require.Equal(t, int64(30), GetTopRUItemInterval())
+
+	require.NoError(t, SetTopRUItemInterval(60))
+	require.Equal(t, int64(60), GetTopRUItemInterval())
+
+	require.NoError(t, SetTopRUItemInterval(15))
+	require.Equal(t, int64(15), GetTopRUItemInterval())
+}
+
+// TestTopRUItemIntervalRejectsInvalid verifies invalid intervals
+// return errors and do not override existing values.
+func TestTopRUItemIntervalRejectsInvalid(t *testing.T) {
+	GlobalState.ruConsumerCount.Store(0)
+	ResetTopRUItemInterval()
+
+	require.ErrorIs(t, SetTopRUItemInterval(1), ErrInvalidTopRUItemInterval)
+	require.Equal(t, int64(DefTiDBTopRUItemIntervalSeconds), GetTopRUItemInterval())
+
+	require.NoError(t, SetTopRUItemInterval(0))
+	require.Equal(t, int64(DefTiDBTopRUItemIntervalSeconds), GetTopRUItemInterval())
+
+	require.NoError(t, SetTopRUItemInterval(15))
+	require.Equal(t, int64(15), GetTopRUItemInterval())
+
+	require.ErrorIs(t, SetTopRUItemInterval(99), ErrInvalidTopRUItemInterval)
+	require.Equal(t, int64(15), GetTopRUItemInterval())
+
+	require.NoError(t, SetTopRUItemInterval(0)) // normalized to 60.
+	require.Equal(t, int64(DefTiDBTopRUItemIntervalSeconds), GetTopRUItemInterval())
+}

--- a/pkg/util/topsql/stmtstats/BUILD.bazel
+++ b/pkg/util/topsql/stmtstats/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "aggregator.go",
         "kv_exec_count.go",
+        "rustats.go",
         "stmtstats.go",
     ],
     importpath = "github.com/pingcap/tidb/pkg/util/topsql/stmtstats",
@@ -13,6 +14,7 @@ go_library(
         "//pkg/util/topsql/state",
         "@com_github_tikv_client_go_v2//tikvrpc",
         "@com_github_tikv_client_go_v2//tikvrpc/interceptor",
+        "@com_github_tikv_client_go_v2//util",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/pkg/util/topsql/stmtstats/rustats.go
+++ b/pkg/util/topsql/stmtstats/rustats.go
@@ -1,0 +1,65 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stmtstats provides statement statistics collection.
+//
+// This file defines RU data types used by TopRU.
+package stmtstats
+
+import "github.com/tikv/client-go/v2/util"
+
+// RUKey identifies an RU aggregation key by user, SQL digest, and plan digest.
+type RUKey struct {
+	User       string
+	SQLDigest  BinaryDigest
+	PlanDigest BinaryDigest
+}
+
+// ExecutionContext stores RU sampling state for one active SQL execution.
+type ExecutionContext struct {
+	// RUDetails caches *util.RUDetails from execution begin.
+	RUDetails *util.RUDetails
+
+	// Key identifies this execution by (user, sql_digest, plan_digest).
+	Key RUKey
+
+	// LastRUTotal is the last observed cumulative RU total (RRU + WRU).
+	LastRUTotal float64
+}
+
+// RUIncrement represents a delta RU consumption for a specific RUKey.
+// This is the unit of data produced by StatementStats.MergeRUInto() and consumed by RUCollector.CollectRUIncrements().
+type RUIncrement struct {
+	// TotalRU is the delta RU consumption (RRU + WRU).
+	TotalRU float64
+
+	// ExecCount is the number of SQL executions included in this increment.
+	// Begin-based semantics: each execution contributes at most one count on its
+	// first positive RU delta (tick or finish); later deltas carry count=0.
+	ExecCount uint64
+
+	// ExecDuration is the cumulative execution time in nanoseconds.
+	ExecDuration uint64
+}
+
+// Merge merges other into this RUIncrement.
+func (r *RUIncrement) Merge(other *RUIncrement) {
+	r.TotalRU += other.TotalRU
+	r.ExecCount += other.ExecCount
+	r.ExecDuration += other.ExecDuration
+}
+
+// RUIncrementMap maps RUKey to aggregated RU increments.
+// This is the output type of StatementStats.MergeRUInto() and the input type for RUCollector.CollectRUIncrements().
+type RUIncrementMap map[RUKey]*RUIncrement

--- a/pkg/util/topsql/topsql_test.go
+++ b/pkg/util/topsql/topsql_test.go
@@ -383,6 +383,41 @@ func TestPubSubWhenReporterIsStopped(t *testing.T) {
 	require.Error(t, err, "reporter is closed")
 }
 
+func TestTopRUOnlyRegistersSQLAndPlan(t *testing.T) {
+	for topsqlstate.TopRUEnabled() {
+		topsqlstate.DisableTopRU()
+	}
+	topsqlstate.DisableTopSQL()
+	t.Cleanup(func() {
+		for topsqlstate.TopRUEnabled() {
+			topsqlstate.DisableTopRU()
+		}
+		topsqlstate.DisableTopSQL()
+	})
+
+	collector := mock.NewTopSQLCollector()
+	topsql.SetupTopProfilingForTest(collector)
+
+	topsqlstate.EnableTopRU()
+	require.True(t, topsqlstate.TopProfilingEnabled())
+	require.False(t, topsqlstate.TopSQLEnabled())
+
+	ctx := context.Background()
+	sql := "select * from t where a=?"
+	plan := "point-get"
+	sqlDigest := mock.GenSQLDigest(sql)
+	planDigest := genDigest(plan)
+
+	if topsqlstate.TopProfilingEnabled() {
+		topsql.AttachAndRegisterSQLInfo(ctx, sql, sqlDigest, false)
+		topsql.AttachSQLAndPlanInfo(ctx, sqlDigest, planDigest)
+		topsql.RegisterPlan(plan, planDigest)
+	}
+
+	require.Equal(t, sql, collector.GetSQL(sqlDigest.Bytes()))
+	require.Equal(t, plan, collector.GetPlan(planDigest.Bytes()))
+}
+
 func mockExecuteSQL(sql, plan string) {
 	ctx := context.Background()
 	sqlDigest := mock.GenSQLDigest(sql)


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #66625

Problem Summary:
Cherry-pick upstream PR #66642 to release-nextgen-20251011 as the second PR in the backport chain of #65471.

### What changed and how does it work?
- Cherry-picked commit: 89e80e2ce07b2e03f8b1020837ad0a6ec51596e1
- Backport commit on this branch: 19c91409bf67be349c48cf4f5c60f487c4bbcc0f
- This PR introduces TopRU state and subscription plumbing (including tipb upgrade related changes) on top of PR #67238.

### Check List
Tests
- [x] No need to test
  > - [x] This PR is a direct cherry-pick of upstream #66642 and keeps original behavior scope.

Side effects
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note
```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Top Resource Unit (TopRU) monitoring added alongside TopSQL, with configurable intervals (15/30/60s) and RU record reporting.

* **Enhancements**
  * Prometheus metrics for TopRU (counts, durations, ignore/drop counters).
  * Subscription/registerer behavior refined: per-sink TopRU/TopSQL controls, reference-counted enablement, interval management, and improved gating.

* **Tests**
  * Expanded mocks and comprehensive tests for TopRU collection, subscription parsing, concurrency, and integration.

* **Dependencies**
  * Updated TiPB dependency to a newer pinned version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->