### PR TITLE
executor: enable tidb_store_batch_size for non-integer clustered PK tables

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -5101,13 +5101,22 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 			if err != nil {
 				return nil, err
 			}
-			// Provide row-count hints (1 per KV range) so the store-batch coprocessor
-			// can batch these tasks just as it does for integer-handle tables.
-			hints := make([]int, len(kvRanges))
-			for i := range hints {
-				hints[i] = 1
+			// Only provide row-count hints when each KV range is guaranteed to be a
+			// full-length point range (exactly 1 row). This requires all PK columns to
+			// be covered by the join keys (keyOff2IdxOff) with no dynamic range
+			// expansion (cwc == nil). A partial join key leaves trailing PK columns
+			// unconstrained, producing a prefix range that spans multiple rows; using
+			// hint=1 in that case would misclassify large tasks as small tasks and cause
+			// over-batching in the store-batch coprocessor.
+			pk := tbInfo.GetPrimaryKey()
+			if cwc == nil && pk != nil && len(keyOff2IdxOff) == len(pk.Columns) {
+				hints := make([]int, len(kvRanges))
+				for i := range hints {
+					hints[i] = 1
+				}
+				return builder.buildTableReaderFromKvRangesWithHints(ctx, e, kvRanges, hints)
 			}
-			return builder.buildTableReaderFromKvRangesWithHints(ctx, e, kvRanges, hints)
+			return builder.buildTableReaderFromKvRanges(ctx, e, kvRanges)
 		}
 		handles, _ := dedupHandles(lookUpContents)
 		return builder.buildTableReaderFromHandles(ctx, e, handles, canReorderHandles)
@@ -5128,13 +5137,16 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 		return nil, err
 	}
 	if v.IsCommonHandle {
-		// Provide row-count hints (1 per KV range) so the store-batch coprocessor
-		// can batch these tasks just as it does for integer-handle tables.
-		hints := make([]int, len(kvRanges))
-		for i := range hints {
-			hints[i] = 1
+		// See the non-partitioned IsCommonHandle branch above for the rationale.
+		pk := tbInfo.GetPrimaryKey()
+		if cwc == nil && pk != nil && len(keyOff2IdxOff) == len(pk.Columns) {
+			hints := make([]int, len(kvRanges))
+			for i := range hints {
+				hints[i] = 1
+			}
+			return builder.buildTableReaderFromKvRangesWithHints(ctx, e, kvRanges, hints)
 		}
-		return builder.buildTableReaderFromKvRangesWithHints(ctx, e, kvRanges, hints)
+		return builder.buildTableReaderFromKvRanges(ctx, e, kvRanges)
 	}
 	return builder.buildTableReaderFromKvRanges(ctx, e, kvRanges)
 }

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -5101,7 +5101,13 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 			if err != nil {
 				return nil, err
 			}
-			return builder.buildTableReaderFromKvRanges(ctx, e, kvRanges)
+			// Provide row-count hints (1 per KV range) so the store-batch coprocessor
+			// can batch these tasks just as it does for integer-handle tables.
+			hints := make([]int, len(kvRanges))
+			for i := range hints {
+				hints[i] = 1
+			}
+			return builder.buildTableReaderFromKvRangesWithHints(ctx, e, kvRanges, hints)
 		}
 		handles, _ := dedupHandles(lookUpContents)
 		return builder.buildTableReaderFromHandles(ctx, e, handles, canReorderHandles)
@@ -5120,6 +5126,15 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 		e.dctx, e.rctx, pt, usedPartitionList, usedPartitions, lookUpContents, indexRanges, keyOff2IdxOff, cwc, memTracker, interruptSignal, v.IsCommonHandle)
 	if err != nil {
 		return nil, err
+	}
+	if v.IsCommonHandle {
+		// Provide row-count hints (1 per KV range) so the store-batch coprocessor
+		// can batch these tasks just as it does for integer-handle tables.
+		hints := make([]int, len(kvRanges))
+		for i := range hints {
+			hints[i] = 1
+		}
+		return builder.buildTableReaderFromKvRangesWithHints(ctx, e, kvRanges, hints)
 	}
 	return builder.buildTableReaderFromKvRanges(ctx, e, kvRanges)
 }
@@ -5259,6 +5274,12 @@ func (builder *dataReaderBuilder) buildTableReaderFromHandles(ctx context.Contex
 func (builder *dataReaderBuilder) buildTableReaderFromKvRanges(ctx context.Context, e *TableReaderExecutor, ranges []kv.KeyRange) (exec.Executor, error) {
 	var b distsql.RequestBuilder
 	b.SetKeyRanges(ranges)
+	return builder.buildTableReaderBase(ctx, e, b)
+}
+
+func (builder *dataReaderBuilder) buildTableReaderFromKvRangesWithHints(ctx context.Context, e *TableReaderExecutor, ranges []kv.KeyRange, hints []int) (exec.Executor, error) {
+	var b distsql.RequestBuilder
+	b.SetKeyRangesWithHints(ranges, hints)
 	return builder.buildTableReaderBase(ctx, e, b)
 }
 

--- a/pkg/executor/executor_pkg_test.go
+++ b/pkg/executor/executor_pkg_test.go
@@ -132,6 +132,51 @@ func TestBuildKvRangesForIndexJoinWithoutCwcAndWithMemoryTracker(t *testing.T) {
 	require.Equal(t, int64(23640), bytesConsumed1)
 }
 
+// TestBuildKvRangesForIndexJoinCommonHandle verifies that buildKvRangesForIndexJoin
+// correctly handles tables with a non-integer clustered (common handle) primary key.
+// This is the code path exercised when tidb_store_batch_size is applied to index joins
+// on VARCHAR / composite PK tables (see https://github.com/pingcap/tidb/issues/67150).
+func TestBuildKvRangesForIndexJoinCommonHandle(t *testing.T) {
+	// Create lookup contents with distinct string keys simulating a VARCHAR PK.
+	keys := []string{"aaa", "bbb", "ccc"}
+	lookUpContents := make([]*join.IndexJoinLookUpContent, 0, len(keys))
+	for _, k := range keys {
+		lookUpContents = append(lookUpContents, &join.IndexJoinLookUpContent{
+			Keys: []types.Datum{types.NewStringDatum(k)},
+		})
+	}
+
+	// Single-element base range; its LowVal/HighVal will be overwritten per content.
+	baseRange := &ranger.Range{
+		LowVal:     []types.Datum{types.NewStringDatum("")},
+		HighVal:    []types.Datum{types.NewStringDatum("")},
+		Collators:  collate.GetBinaryCollatorSlice(1),
+		LowExclude: false, HighExclude: false,
+	}
+	keyOff2IdxOff := []int{0} // the single key column maps to index position 0
+
+	ctx := mock.NewContext()
+	// indexID == -1 selects the common handle code path.
+	kvRanges, err := buildKvRangesForIndexJoin(
+		ctx.GetDistSQLCtx(), ctx.GetRangerCtx(),
+		1, -1,
+		lookUpContents, []*ranger.Range{baseRange}, keyOff2IdxOff,
+		nil, nil, nil,
+	)
+	require.NoError(t, err)
+
+	// Each lookup content must produce exactly one KV range.
+	require.Len(t, kvRanges, len(keys))
+
+	// Ranges must be non-empty and in ascending start-key order.
+	for i, kvRange := range kvRanges {
+		require.True(t, kvRange.StartKey.Cmp(kvRange.EndKey) < 0, "range %d: StartKey must be less than EndKey", i)
+		if i > 0 {
+			require.True(t, kvRange.StartKey.Cmp(kvRanges[i-1].EndKey) >= 0, "range %d: must not overlap with previous range", i)
+		}
+	}
+}
+
 func generateIndexRange(vals ...int64) *ranger.Range {
 	lowDatums := generateDatumSlice(vals...)
 	highDatums := slices.Clone(lowDatums)

--- a/tests/integrationtest/r/executor/jointest/join.result
+++ b/tests/integrationtest/r/executor/jointest/join.result
@@ -1621,3 +1621,16 @@ c
 e
 set tidb_store_batch_size = default;
 drop table if exists t67150_outer, t67150_inner;
+drop table if exists t67150_cpk_outer, t67150_cpk_inner;
+create table t67150_cpk_outer (a varchar(32) primary key, val int);
+create table t67150_cpk_inner (a varchar(32), b int, data int, primary key(a, b));
+insert into t67150_cpk_outer values ('x', 100), ('y', 200), ('z', 300);
+insert into t67150_cpk_inner values ('x', 1, 10), ('x', 2, 20), ('y', 1, 30);
+set tidb_store_batch_size = 4;
+select /*+ INL_JOIN(t67150_cpk_inner) */ t67150_cpk_outer.a, t67150_cpk_inner.b, t67150_cpk_inner.data from t67150_cpk_outer join t67150_cpk_inner on t67150_cpk_outer.a = t67150_cpk_inner.a order by t67150_cpk_outer.a, t67150_cpk_inner.b;
+a	b	data
+x	1	10
+x	2	20
+y	1	30
+set tidb_store_batch_size = default;
+drop table if exists t67150_cpk_outer, t67150_cpk_inner;

--- a/tests/integrationtest/r/executor/jointest/join.result
+++ b/tests/integrationtest/r/executor/jointest/join.result
@@ -1607,14 +1607,14 @@ create table t67150_inner (ref_id varchar(64) primary key);
 insert into t67150_outer values ('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5);
 insert into t67150_inner values ('a'), ('c'), ('e');
 set tidb_store_batch_size = 4;
-select t67150_outer.id from t67150_outer left join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
+select /*+ INL_JOIN(t67150_inner) */ t67150_outer.id from t67150_outer left join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
 id
 a
 b
 c
 d
 e
-select t67150_outer.id from t67150_outer join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
+select /*+ INL_JOIN(t67150_inner) */ t67150_outer.id from t67150_outer join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
 id
 a
 c

--- a/tests/integrationtest/r/executor/jointest/join.result
+++ b/tests/integrationtest/r/executor/jointest/join.result
@@ -1601,3 +1601,23 @@ select * from (t1 join t2 on t1.b=t2.b) natural join (t3 natural join t4);
 Error 1052 (23000): Column 'b' in from clause is ambiguous
 select * from (t3 natural join t4) natural join (t1 join t2 on t1.b=t2.b);
 Error 1052 (23000): Column 'b' in from clause is ambiguous
+drop table if exists t67150_outer, t67150_inner;
+create table t67150_outer (id varchar(64) primary key, val int);
+create table t67150_inner (ref_id varchar(64) primary key);
+insert into t67150_outer values ('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5);
+insert into t67150_inner values ('a'), ('c'), ('e');
+set tidb_store_batch_size = 4;
+select t67150_outer.id from t67150_outer left join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
+id
+a
+b
+c
+d
+e
+select t67150_outer.id from t67150_outer join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
+id
+a
+c
+e
+set tidb_store_batch_size = default;
+drop table if exists t67150_outer, t67150_inner;

--- a/tests/integrationtest/t/executor/jointest/join.test
+++ b/tests/integrationtest/t/executor/jointest/join.test
@@ -1116,3 +1116,18 @@ select /*+ INL_JOIN(t67150_inner) */ t67150_outer.id from t67150_outer left join
 select /*+ INL_JOIN(t67150_inner) */ t67150_outer.id from t67150_outer join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
 set tidb_store_batch_size = default;
 drop table if exists t67150_outer, t67150_inner;
+
+# TestIssue67150CompositePKPartialJoin
+# For a composite PK (a, b), joining only on column a produces a prefix-range lookup
+# that covers multiple rows per join key. Row-count hints must NOT be applied in this
+# case to avoid misclassifying large-range tasks as small tasks.
+# Verify that all matching rows across both b values are returned correctly.
+drop table if exists t67150_cpk_outer, t67150_cpk_inner;
+create table t67150_cpk_outer (a varchar(32) primary key, val int);
+create table t67150_cpk_inner (a varchar(32), b int, data int, primary key(a, b));
+insert into t67150_cpk_outer values ('x', 100), ('y', 200), ('z', 300);
+insert into t67150_cpk_inner values ('x', 1, 10), ('x', 2, 20), ('y', 1, 30);
+set tidb_store_batch_size = 4;
+select /*+ INL_JOIN(t67150_cpk_inner) */ t67150_cpk_outer.a, t67150_cpk_inner.b, t67150_cpk_inner.data from t67150_cpk_outer join t67150_cpk_inner on t67150_cpk_outer.a = t67150_cpk_inner.a order by t67150_cpk_outer.a, t67150_cpk_inner.b;
+set tidb_store_batch_size = default;
+drop table if exists t67150_cpk_outer, t67150_cpk_inner;

--- a/tests/integrationtest/t/executor/jointest/join.test
+++ b/tests/integrationtest/t/executor/jointest/join.test
@@ -1111,8 +1111,8 @@ insert into t67150_outer values ('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5)
 insert into t67150_inner values ('a'), ('c'), ('e');
 set tidb_store_batch_size = 4;
 ## LEFT JOIN returns all outer rows; non-matching ones have NULL ref_id.
-select t67150_outer.id from t67150_outer left join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
+select /*+ INL_JOIN(t67150_inner) */ t67150_outer.id from t67150_outer left join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
 ## INNER JOIN returns only matched rows.
-select t67150_outer.id from t67150_outer join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
+select /*+ INL_JOIN(t67150_inner) */ t67150_outer.id from t67150_outer join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
 set tidb_store_batch_size = default;
 drop table if exists t67150_outer, t67150_inner;

--- a/tests/integrationtest/t/executor/jointest/join.test
+++ b/tests/integrationtest/t/executor/jointest/join.test
@@ -1100,3 +1100,19 @@ select * from (t3 cross join t4) natural join t1;
 select * from (t1 join t2 on t1.b=t2.b) natural join (t3 natural join t4);
 --error 1052
 select * from (t3 natural join t4) natural join (t1 join t2 on t1.b=t2.b);
+
+# TestIssue67150StoreBatchSizeCommonHandle
+# tidb_store_batch_size must take effect for tables with a non-integer clustered
+# (common handle) primary key; previously hints were never propagated for this path.
+drop table if exists t67150_outer, t67150_inner;
+create table t67150_outer (id varchar(64) primary key, val int);
+create table t67150_inner (ref_id varchar(64) primary key);
+insert into t67150_outer values ('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5);
+insert into t67150_inner values ('a'), ('c'), ('e');
+set tidb_store_batch_size = 4;
+## LEFT JOIN returns all outer rows; non-matching ones have NULL ref_id.
+select t67150_outer.id from t67150_outer left join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
+## INNER JOIN returns only matched rows.
+select t67150_outer.id from t67150_outer join t67150_inner on t67150_outer.id = t67150_inner.ref_id order by t67150_outer.id;
+set tidb_store_batch_size = default;
+drop table if exists t67150_outer, t67150_inner;


### PR DESCRIPTION
## What problem does this PR solve?

Issue Number: close #67150

`tidb_store_batch_size` had no effect when performing index joins on tables with a non-integer clustered (common handle) primary key (e.g. `VARCHAR PRIMARY KEY`, composite PK). The store-batch coprocessor path is gated on `hints != nil`, but the `IsCommonHandle` branch in `buildTableReaderForIndexJoin` was calling `buildTableReaderFromKvRanges` which never sets hints.

## Root cause

In `buildTableReaderForIndexJoin`, when `v.IsCommonHandle` is true, KV ranges are built via `buildKvRangesForIndexJoin` (with `indexID=-1`) and passed directly to `buildTableReaderFromKvRanges` → `b.SetKeyRanges(ranges)`. That produces a `KeyRanges` with `rowCountHints == nil`.

In `pkg/store/copr/coprocessor.go`:
```go
if req.StoreBatchSize > 0 && hints != nil {  // hints==nil → always false for common handle
    builder = newBatchTaskBuilder(...)
} else {
    builder = newLegacyTaskBuilder(...)
}
```

The integer-handle path goes through `buildTableReaderFromHandles` → `SetTableHandles` → `NewNonParitionedKeyRangesWithHint` which sets hints correctly.

## What changed

- Added `buildTableReaderFromKvRangesWithHints` helper that calls `b.SetKeyRangesWithHints(ranges, hints)`.
- For both the non-partitioned and partitioned `IsCommonHandle` branches, generate hints (1 per KV range, matching the convention in `TableHandlesToKVRanges`) and route through the new helper.
- No changes to `pkg/store/copr/coprocessor.go`, `pkg/distsql/request_builder.go`, or `pkg/kv/kv.go` — the infrastructure already supports this.

## Tests

<!-- At least one of them must be included. -->
- [x] Unit test: `TestBuildKvRangesForIndexJoinCommonHandle` in `pkg/executor/executor_pkg_test.go` — verifies KV ranges are generated correctly for VARCHAR PK with `indexID=-1`.
- [x] Integration test: `TestIssue67150StoreBatchSizeCommonHandle` in `tests/integrationtest/t/executor/jointest/join.test` — LEFT JOIN and INNER JOIN on VARCHAR PK with `tidb_store_batch_size=4` produce correct results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate range/hinting for index joins involving tables with clustered (common-handle) primary keys, improving join execution stability and performance.
  * Better handling of batch-size behavior during index-join execution to maintain expected performance.

* **Tests**
  * Added unit and integration tests validating index-join range construction, join results, and behavior with common-handle primary keys and adjusted batch-size settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->