### PR TITLE
planner, executor: standardize how `EXPLAIN` output is formatted in `testkit.Rows`

### DIFF
--- a/pkg/executor/test/showtest/show_test.go
+++ b/pkg/executor/test/showtest/show_test.go
@@ -480,41 +480,40 @@ func TestShow2(t *testing.T) {
 				);`)
 
 	tk.MustQuery(`show full columns from test_full_column`).Check(testkit.Rows(
-		"" +
-			"c_int int(11) <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_float float <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_bit bit(1) <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_bool tinyint(1) <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_char char(1) ascii_bin YES  <nil>  select,insert,update,references ]\n" +
-			"[c_nchar char(1) ascii_bin YES  <nil>  select,insert,update,references ]\n" +
-			"[c_binary binary(1) <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_varchar varchar(1) ascii_bin YES  <nil>  select,insert,update,references ]\n" +
-			"[c_varchar_default varchar(20) ascii_bin YES  cUrrent_tImestamp  select,insert,update,references ]\n" +
-			"[c_nvarchar varchar(1) ascii_bin YES  <nil>  select,insert,update,references ]\n" +
-			"[c_varbinary varbinary(1) <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_year year(4) <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_date date <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_time time <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_datetime datetime <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_datetime_default datetime <nil> YES  CURRENT_TIMESTAMP  select,insert,update,references ]\n" +
-			"[c_datetime_default_2 datetime(2) <nil> YES  CURRENT_TIMESTAMP(2)  select,insert,update,references ]\n" +
-			"[c_timestamp timestamp <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_timestamp_default timestamp <nil> YES  CURRENT_TIMESTAMP  select,insert,update,references ]\n" +
-			"[c_timestamp_default_3 timestamp(3) <nil> YES  CURRENT_TIMESTAMP(3)  select,insert,update,references ]\n" +
-			"[c_timestamp_default_4 timestamp(3) <nil> YES  CURRENT_TIMESTAMP(3) DEFAULT_GENERATED on update CURRENT_TIMESTAMP(3) select,insert,update,references ]\n" +
-			"[c_date_default date <nil> YES  CURRENT_DATE  select,insert,update,references ]\n" +
-			"[c_date_default_2 date <nil> YES  CURRENT_DATE  select,insert,update,references ]\n" +
-			"[c_blob blob <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_tinyblob tinyblob <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_mediumblob mediumblob <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_longblob longblob <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_text text ascii_bin YES  <nil>  select,insert,update,references ]\n" +
-			"[c_tinytext tinytext ascii_bin YES  <nil>  select,insert,update,references ]\n" +
-			"[c_mediumtext mediumtext ascii_bin YES  <nil>  select,insert,update,references ]\n" +
-			"[c_longtext longtext ascii_bin YES  <nil>  select,insert,update,references ]\n" +
-			"[c_json json <nil> YES  <nil>  select,insert,update,references ]\n" +
-			"[c_enum enum('1') ascii_bin YES  <nil>  select,insert,update,references ]\n" +
-			"[c_set set('1') ascii_bin YES  <nil>  select,insert,update,references "))
+		"c_int int(11) <nil> YES  <nil>  select,insert,update,references ",
+		"c_float float <nil> YES  <nil>  select,insert,update,references ",
+		"c_bit bit(1) <nil> YES  <nil>  select,insert,update,references ",
+		"c_bool tinyint(1) <nil> YES  <nil>  select,insert,update,references ",
+		"c_char char(1) ascii_bin YES  <nil>  select,insert,update,references ",
+		"c_nchar char(1) ascii_bin YES  <nil>  select,insert,update,references ",
+		"c_binary binary(1) <nil> YES  <nil>  select,insert,update,references ",
+		"c_varchar varchar(1) ascii_bin YES  <nil>  select,insert,update,references ",
+		"c_varchar_default varchar(20) ascii_bin YES  cUrrent_tImestamp  select,insert,update,references ",
+		"c_nvarchar varchar(1) ascii_bin YES  <nil>  select,insert,update,references ",
+		"c_varbinary varbinary(1) <nil> YES  <nil>  select,insert,update,references ",
+		"c_year year(4) <nil> YES  <nil>  select,insert,update,references ",
+		"c_date date <nil> YES  <nil>  select,insert,update,references ",
+		"c_time time <nil> YES  <nil>  select,insert,update,references ",
+		"c_datetime datetime <nil> YES  <nil>  select,insert,update,references ",
+		"c_datetime_default datetime <nil> YES  CURRENT_TIMESTAMP  select,insert,update,references ",
+		"c_datetime_default_2 datetime(2) <nil> YES  CURRENT_TIMESTAMP(2)  select,insert,update,references ",
+		"c_timestamp timestamp <nil> YES  <nil>  select,insert,update,references ",
+		"c_timestamp_default timestamp <nil> YES  CURRENT_TIMESTAMP  select,insert,update,references ",
+		"c_timestamp_default_3 timestamp(3) <nil> YES  CURRENT_TIMESTAMP(3)  select,insert,update,references ",
+		"c_timestamp_default_4 timestamp(3) <nil> YES  CURRENT_TIMESTAMP(3) DEFAULT_GENERATED on update CURRENT_TIMESTAMP(3) select,insert,update,references ",
+		"c_date_default date <nil> YES  CURRENT_DATE  select,insert,update,references ",
+		"c_date_default_2 date <nil> YES  CURRENT_DATE  select,insert,update,references ",
+		"c_blob blob <nil> YES  <nil>  select,insert,update,references ",
+		"c_tinyblob tinyblob <nil> YES  <nil>  select,insert,update,references ",
+		"c_mediumblob mediumblob <nil> YES  <nil>  select,insert,update,references ",
+		"c_longblob longblob <nil> YES  <nil>  select,insert,update,references ",
+		"c_text text ascii_bin YES  <nil>  select,insert,update,references ",
+		"c_tinytext tinytext ascii_bin YES  <nil>  select,insert,update,references ",
+		"c_mediumtext mediumtext ascii_bin YES  <nil>  select,insert,update,references ",
+		"c_longtext longtext ascii_bin YES  <nil>  select,insert,update,references ",
+		"c_json json <nil> YES  <nil>  select,insert,update,references ",
+		"c_enum enum('1') ascii_bin YES  <nil>  select,insert,update,references ",
+		"c_set set('1') ascii_bin YES  <nil>  select,insert,update,references "))
 
 	tk.MustExec("drop table if exists test_full_column")
 

--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -886,11 +886,11 @@ func TestAggPushToCopForCachedTable(t *testing.T) {
 		testKit.MustExec("alter table t32157 cache")
 
 		testKit.MustQuery("explain format = 'brief' select /*+AGG_TO_COP()*/ count(*) from t32157 ignore index(primary) where process_code = 'GDEP0071'").Check(testkit.Rows(
-			"StreamAgg 1.00 root  funcs:count(1)->Column#9]\n" +
-				"[└─UnionScan 10.00 root  eq(test.t32157.process_code, \"GDEP0071\")]\n" +
-				"[  └─TableReader 10.00 root  data:Selection]\n" +
-				"[    └─Selection 10.00 cop[tikv]  eq(test.t32157.process_code, \"GDEP0071\")]\n" +
-				"[      └─TableFullScan 10000.00 cop[tikv] table:t32157 keep order:false, stats:pseudo"))
+			"StreamAgg 1.00 root  funcs:count(1)->Column#9",
+			"└─UnionScan 10.00 root  eq(test.t32157.process_code, \"GDEP0071\")",
+			"  └─TableReader 10.00 root  data:Selection",
+			"    └─Selection 10.00 cop[tikv]  eq(test.t32157.process_code, \"GDEP0071\")",
+			"      └─TableFullScan 10000.00 cop[tikv] table:t32157 keep order:false, stats:pseudo"))
 
 		require.Eventually(t, func() bool {
 			testKit.MustQuery("select /*+AGG_TO_COP()*/ count(*) from t32157 ignore index(primary) where process_code = 'GDEP0071'").Check(testkit.Rows("2"))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67269 

Problem Summary:

Most existing tests that check `EXPLAIN` plan output use separate arguments for each line. For example:

```go
tk.MustQuery(`explain format='plan_tree' select * from t1 join t2 on t1.a=t2.b where t1.a in (1,2);`).Check(testkit.Rows(
	`HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.b)]`,
	`├─Batch_Point_Get(Build) root table:t1 handle:[1 2], keep order:false, desc:false`,
	`└─TableReader(Probe) root  MppVersion: 3, data:ExchangeSender`,
	`  └─ExchangeSender mpp[tiflash]  ExchangeType: PassThrough`,
	`    └─TableFullScan mpp[tiflash] table:t2 pushed down filter:in(test.t2.b, 1, 2), not(isnull(test.t2.b)), keep order:false, stats:pseudo`))
```

However, a couple of tests instead tests used a single concatenated string with literal `]\n[` separators, instead of separate arguments to `testkit.Rows()`, like this:

```go
testKit.MustQuery("explain format = 'brief' select /*+AGG_TO_COP()*/ count(*) from t32157 ignore index(primary) where process_code = 'GDEP0071'").Check(testkit.Rows(
	"StreamAgg 1.00 root  funcs:count(1)->Column#9]\n" +
		"[└─UnionScan 10.00 root  eq(test.t32157.process_code, \"GDEP0071\")]\n" +
		"[  └─TableReader 10.00 root  data:Selection]\n" +
		"[    └─Selection 10.00 cop[tikv]  eq(test.t32157.process_code, \"GDEP0071\")]\n" +
		"[      └─TableFullScan 10000.00 cop[tikv] table:t32157 keep order:false, stats:pseudo"))
```

While this worked because `testkit.Rows` splits on `\n` and strips brackets, it is unnecessarily inconsistent with every other test case that checks `EXPLAIN` output.

### What changed and how does it work?

Instead, convert these two tests to use separate arguments, like all of the other tests that check `EXPLAIN` output:

* `pkg/planner/core/integration_test.go` (`TestAggPushToCopForCachedTable`)
* `pkg/executor/test/showtest/show_test.go` (`TestShow2`)

No functional changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test assertion formatting for improved code maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->