### PR TITLE
pkg/statistics: add stale-read observability for init stats flake

### DIFF
--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -40,6 +40,14 @@ type LFU struct {
 	closeOnce    sync.Once
 }
 
+type tableShapeSummary struct {
+	columnCount          int
+	indexCount           int
+	version              uint64
+	lastAnalyzeVersion   uint64
+	lastStatsHistVersion uint64
+}
+
 // NewLFU creates a new LFU cache.
 func NewLFU(totalMemCost int64) (*LFU, error) {
 	cost, err := adjustMemCost(totalMemCost)
@@ -93,7 +101,50 @@ func (s *LFU) Get(tid int64) (*statistics.Table, bool) {
 	if !ok {
 		return s.resultKeySet.Get(tid)
 	}
-	return result.(*statistics.Table), ok
+	table := result.(*statistics.Table)
+	if intest.InTest {
+		if latest, latestOK := s.resultKeySet.Get(tid); latestOK && latest != nil && latest != table {
+			cachedShape := summarizeTableShape(table)
+			latestShape := summarizeTableShape(latest)
+			if cachedShape != latestShape {
+				logutil.BgLogger().Warn(
+					"lfu stats cache returned a stale table before the latest update became visible",
+					zap.Int64("tableID", tid),
+					zap.Int("cachedColumnCount", cachedShape.columnCount),
+					zap.Int("latestColumnCount", latestShape.columnCount),
+					zap.Int("cachedIndexCount", cachedShape.indexCount),
+					zap.Int("latestIndexCount", latestShape.indexCount),
+					zap.Uint64("cachedVersion", cachedShape.version),
+					zap.Uint64("latestVersion", latestShape.version),
+					zap.Uint64("cachedLastAnalyzeVersion", cachedShape.lastAnalyzeVersion),
+					zap.Uint64("latestLastAnalyzeVersion", latestShape.lastAnalyzeVersion),
+					zap.Uint64("cachedLastStatsHistVersion", cachedShape.lastStatsHistVersion),
+					zap.Uint64("latestLastStatsHistVersion", latestShape.lastStatsHistVersion),
+				)
+			}
+		}
+	}
+	return table, ok
+}
+
+func summarizeTableShape(table *statistics.Table) tableShapeSummary {
+	if table == nil {
+		return tableShapeSummary{}
+	}
+	summary := tableShapeSummary{
+		version:              table.Version,
+		lastAnalyzeVersion:   table.LastAnalyzeVersion,
+		lastStatsHistVersion: table.LastStatsHistVersion,
+	}
+	table.ForEachColumnImmutable(func(_ int64, _ *statistics.Column) bool {
+		summary.columnCount++
+		return false
+	})
+	table.ForEachIndexImmutable(func(_ int64, _ *statistics.Index) bool {
+		summary.indexCount++
+		return false
+	})
+	return summary
 }
 
 // Put implements statsCacheInner


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67176

Problem Summary:

`TestNonLiteInitStatsWithTableIDs` is flaky in `pkg/statistics/handle/handletest/initstats`. Jenkins build `ghpr_unit_test/54300` showed a SIGSEGV while dereferencing `stats1.GetIdx(1).IsFullLoad()` after repeated `InitStats(...tableIDs...)` calls.

### What changed and how does it work?

This PR adds observability only.

In test mode, the LFU stats cache now logs a warning when `Get(tableID)` returns a table shape from the primary Ristretto cache that differs from the latest table shape stored in `resultKeySet`. The warning records column/index counts and stats versions for both views of the same table.

This is intended to confirm or refute the current hypothesis for #67176: a buffered LFU update can leave later init-stats phases reading an older meta-only table before the latest per-table update becomes visible.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Manual test steps / investigation log:

- `go test -run TestNonLiteInitStatsWithTableIDs -count=1 -tags=intest,deadlock` from `pkg/statistics/handle/handletest/initstats` (blocked locally: `go` is not installed on PATH in this worktree)
- `gh issue view 67176 --repo pingcap/tidb --json number,title,body,comments`
- `curl -L 'https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/54300/artifact/bazel-flaky-summaries.log'`
- `curl -L 'https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/54300/artifact/bazel-go-test-index.log' | rg -n 'initstats|TestNonLiteInitStatsWithTableIDs|FAILED|FAIL' -C 4`
- `curl -L 'https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/54300/artifact/bazel-target-output-L4929-5955.log' | rg -n 'Init stats succeed|Complete loading the stats meta in the lite mode|Complete loading the histogram in the lite mode|Complete loading the stats meta|Complete loading the histogram|Complete loading the topn|Complete loading the bucket|new domain|loadStatsWorker' -C 2`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache validation to detect and log stale cached data, ensuring greater cache accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->