### PR TITLE
executor: show COLLATE in SHOW CREATE TABLE if explicitly specified

### DIFF
--- a/pkg/ddl/add_column.go
+++ b/pkg/ddl/add_column.go
@@ -313,7 +313,7 @@ func buildColumnAndConstraint(
 	}
 
 	// specifiedCollate refers to the last collate specified in colDef.Options.
-	chs, coll, err := getCharsetAndCollateInColumnDef(colDef, ctx.GetDefaultCollationForUTF8MB4())
+	chs, coll, isExplicit, err := getCharsetAndCollateInColumnDef(colDef, ctx.GetDefaultCollationForUTF8MB4())
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -329,6 +329,9 @@ func buildColumnAndConstraint(
 	if err := setCharsetCollationFlenDecimal(ctx, colDef.Tp, colDef.Name.Name.O, chs, coll); err != nil {
 		return nil, nil, errors.Trace(err)
 	}
+	if isExplicit {
+		colDef.Tp.AddFlag(mysql.ExplicitCollateFlag)
+	}
 	decodeEnumSetBinaryLiteralToUTF8(colDef.Tp, chs)
 	col, cts, err := columnDefToCol(ctx, offset, colDef, outPriKeyConstraint)
 	if err != nil {
@@ -339,24 +342,28 @@ func buildColumnAndConstraint(
 
 // getCharsetAndCollateInColumnDef will iterate collate in the options, validate it by checking the charset
 // of column definition. If there's no collate in the option, the default collate of column's charset will be used.
-func getCharsetAndCollateInColumnDef(def *ast.ColumnDef, defaultUTF8MB4Coll string) (chs, coll string, err error) {
+func getCharsetAndCollateInColumnDef(def *ast.ColumnDef, defaultUTF8MB4Coll string) (chs, coll string, isExplicit bool, err error) {
 	chs = def.Tp.GetCharset()
 	coll = def.Tp.GetCollate()
+	// Note: def.Tp.GetCollate() is never set by the parser (collation always goes into
+	// def.Options as ColumnOptionCollate). Only check Options to determine if collation
+	// was explicitly specified by the user.
 	if chs != "" && coll == "" {
 		if coll, err = GetDefaultCollation(chs, defaultUTF8MB4Coll); err != nil {
-			return "", "", errors.Trace(err)
+			return "", "", false, errors.Trace(err)
 		}
 	}
 	for _, opt := range def.Options {
 		if opt.Tp == ast.ColumnOptionCollate {
+			isExplicit = true
 			info, err := collate.GetCollationByName(opt.StrValue)
 			if err != nil {
-				return "", "", errors.Trace(err)
+				return "", "", false, errors.Trace(err)
 			}
 			if chs == "" {
 				chs = info.CharsetName
 			} else if chs != info.CharsetName {
-				return "", "", dbterror.ErrCollationCharsetMismatch.GenWithStackByArgs(info.Name, chs)
+				return "", "", false, dbterror.ErrCollationCharsetMismatch.GenWithStackByArgs(info.Name, chs)
 			}
 			coll = info.Name
 		}

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -1886,7 +1886,8 @@ func ProcessColumnCharsetAndCollation(ctx *metabuild.Context, col *table.Column,
 		chs = col.FieldType.GetCharset()
 		coll = col.FieldType.GetCollate()
 	} else {
-		chs, coll, err = getCharsetAndCollateInColumnDef(specNewColumn, ctx.GetDefaultCollationForUTF8MB4())
+		var isExplicit bool
+		chs, coll, isExplicit, err = getCharsetAndCollateInColumnDef(specNewColumn, ctx.GetDefaultCollationForUTF8MB4())
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1898,6 +1899,9 @@ func ProcessColumnCharsetAndCollation(ctx *metabuild.Context, col *table.Column,
 		chs, coll = OverwriteCollationWithBinaryFlag(specNewColumn, chs, coll, ctx.GetDefaultCollationForUTF8MB4())
 		if err != nil {
 			return errors.Trace(err)
+		}
+		if isExplicit {
+			newCol.FieldType.AddFlag(mysql.ExplicitCollateFlag)
 		}
 	}
 

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -1094,7 +1094,7 @@ func constructResultOfShowCreateTable(ctx sessionctx.Context, dbName *ast.CIStr,
 			if col.GetCharset() != tblCharset {
 				fmt.Fprintf(buf, " CHARACTER SET %s", col.GetCharset())
 			}
-			if col.GetCollate() != tblCollate {
+			if col.GetCollate() != tblCollate || (col.GetFlag()&mysql.ExplicitCollateFlag != 0) {
 				fmt.Fprintf(buf, " COLLATE %s", col.GetCollate())
 			} else {
 				defcol, err := charset.GetDefaultCollation(col.GetCharset())

--- a/pkg/executor/test/showtest/BUILD.bazel
+++ b/pkg/executor/test/showtest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "show_test.go",
     ],
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/autoid_service",
         "//pkg/config",

--- a/pkg/executor/test/showtest/show_test.go
+++ b/pkg/executor/test/showtest/show_test.go
@@ -1123,3 +1123,42 @@ func TestShowLimitReturnRow(t *testing.T) {
 	rows = result.Rows()
 	require.Equal(t, rows[0][2], "idx_b")
 }
+
+func TestIssue57283(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("DROP TABLE IF EXISTS foo1")
+	tk.MustExec("CREATE TABLE foo1 (bar VARCHAR(250) COLLATE utf8mb4_bin) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
+
+	// COLLATE should be present if explicitly specified, even when it matches the table default.
+	// CHARACTER SET should only appear when it differs from the table charset.
+	tk.MustQuery("show create table foo1").Check(testkit.Rows(
+		"foo1 CREATE TABLE `foo1` (\n" +
+			"  `bar` varchar(250) COLLATE utf8mb4_bin DEFAULT NULL\n" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+	))
+
+	tk.MustExec("CREATE TABLE foo2 (bar VARCHAR(250)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
+	tk.MustQuery("show create table foo2").Check(testkit.Rows(
+		"foo2 CREATE TABLE `foo2` (\n" +
+			"  `bar` varchar(250) DEFAULT NULL\n" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+	))
+
+	tk.MustExec("ALTER TABLE foo2 MODIFY COLUMN bar VARCHAR(250) COLLATE utf8mb4_bin")
+	tk.MustQuery("show create table foo2").Check(testkit.Rows(
+		"foo2 CREATE TABLE `foo2` (\n" +
+			"  `bar` varchar(250) COLLATE utf8mb4_bin DEFAULT NULL\n" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+	))
+
+	tk.MustExec("ALTER TABLE foo2 ADD COLUMN baz VARCHAR(250) COLLATE utf8mb4_bin")
+	tk.MustQuery("show create table foo2").Check(testkit.Rows(
+		"foo2 CREATE TABLE `foo2` (\n" +
+			"  `bar` varchar(250) COLLATE utf8mb4_bin DEFAULT NULL,\n" +
+			"  `baz` varchar(250) COLLATE utf8mb4_bin DEFAULT NULL\n" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+	))
+}

--- a/pkg/parser/mysql/type.go
+++ b/pkg/parser/mysql/type.go
@@ -78,6 +78,8 @@ const (
 	DropColumnIndexFlag   uint = 1 << 22 /* Internal: Used for indicate the column is being dropped with index */
 	GeneratedColumnFlag   uint = 1 << 23 /* Internal: TiFlash will check this flag and add a placeholder for this column */
 	UnderScoreCharsetFlag uint = 1 << 24 /* Internal: Indicate whether charset is specified by underscore like _latin1'abc' */
+	// ExplicitCollateFlag is used to indicate whether the collation is explicitly specified.
+	ExplicitCollateFlag uint = 1 << 25
 )
 
 // TypeInt24 bounds.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #57283

Problem Summary: This pull request shows COLLATE in SHOW CREATE TABLE if explicitly specified since MySQL 8.0.11 introduces this behavior, TiDB should follow the MySQL implementation.

https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-11.html

> Previously, SHOW CREATE TABLE did not show the collation for a column if the collation was the same as the table default, even if the collation was explicitly specified at table-creation time. Now, SHOW CREATE TABLE always shows the column collation if the collation was explicitly specified, even if the collation is the same as the table default. (Bug #11754608, Bug #46239)

### What changed and how does it work?
Add `ExplicitCollateFlag` flag to see if the collation is explicitly specified for the column, when the flag returns true, show create table returns the column level CHARACTER SET and COLLATE.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit column-level collations specified in DDL are now preserved and displayed by SHOW CREATE TABLE, even when they match the table default; explicitness is retained across column modifications and additions.

* **Tests**
  * Added tests covering create, modify, and add-column scenarios for explicit column collations.

* **Chores**
  * Adjusted test shard configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->