### PR TITLE
ddl: retry modify column reorg on transient errors

### DIFF
--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -233,7 +233,7 @@ func (*backfillDistExecutor) IsIdempotent(*proto.Subtask) bool {
 }
 
 func (*backfillDistExecutor) IsRetryableError(err error) bool {
-	return common.IsRetryableError(err) || isRetryableError(err)
+	return common.IsRetryableError(err) || isRetryableError(err, true)
 }
 
 func (s *backfillDistExecutor) Close() {

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1757,15 +1757,18 @@ func isRetryableJobError(err error, jobErrCnt int64) bool {
 	if jobErrCnt+1 >= variable.GetDDLErrorCountLimit() {
 		return false
 	}
-	return isRetryableError(err)
+	return isRetryableError(err, true)
 }
 
-func isRetryableError(err error) bool {
+func isRetryableError(err error, retryUnknown bool) bool {
 	errMsg := err.Error()
 	for _, m := range dbterror.ReorgRetryableErrMsgs {
 		if strings.Contains(errMsg, m) {
 			return true
 		}
+	}
+	if strings.Contains(errMsg, "All returned regions have no leaders") {
+		return true
 	}
 	originErr := errors.Cause(err)
 	if tErr, ok := originErr.(*terror.Error); ok {
@@ -1773,8 +1776,7 @@ func isRetryableError(err error) bool {
 		_, ok := dbterror.ReorgRetryableErrCodes[sqlErr.Code]
 		return ok
 	}
-	// For the unknown errors, we should retry.
-	return true
+	return retryUnknown
 }
 
 func runReorgJobAndHandleErr(

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -1371,6 +1371,9 @@ func doReorgWorkForModifyColumn(
 		if kv.IsTxnRetryableError(err) || dbterror.ErrNotOwner.Equal(err) {
 			return false, ver, errors.Trace(err)
 		}
+		if isRetryableJobError(err, job.ErrorCount) {
+			return false, ver, errors.Trace(err)
+		}
 		if err1 := rh.RemoveDDLReorgHandle(job, reorgInfo.elements); err1 != nil {
 			logutil.DDLLogger().Warn("run modify column job failed, RemoveDDLReorgHandle failed, can't convert job to rollback",
 				zap.String("job", job.String()), zap.Error(err1))

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -41,7 +41,6 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/format"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
@@ -1390,28 +1389,9 @@ func isRetryableModifyColumnReorgJobError(err error, jobErrCnt int64) bool {
 	if jobErrCnt+1 >= variable.GetDDLErrorCountLimit() {
 		return false
 	}
-
-	// Only retry explicit transient errors here.
-	// Do NOT treat unknown errors as retryable, otherwise it may cause retry loops on deterministic
-	// data conversion errors (e.g. VECTOR dimension mismatch) and block the DDL from rolling back.
-	errMsg := err.Error()
-	for _, m := range dbterror.ReorgRetryableErrMsgs {
-		if strings.Contains(errMsg, m) {
-			return true
-		}
-	}
-	// TiKV client/PD region scan may return leaderless regions during rolling restart or network issues.
-	// That error is transient and should be retried by the DDL worker.
-	if strings.Contains(errMsg, "All returned regions have no leaders") {
-		return true
-	}
-	originErr := errors.Cause(err)
-	if tErr, ok := originErr.(*terror.Error); ok {
-		sqlErr := terror.ToSQLError(tErr)
-		_, ok := dbterror.ReorgRetryableErrCodes[sqlErr.Code]
-		return ok
-	}
-	return false
+	// Modify column reorg can return deterministic data conversion errors. Retrying unknown errors may
+	// cause long retry loops and block the job from rolling back.
+	return isRetryableError(err, false)
 }
 
 func checkModifyColumnWithGeneratedColumnsConstraint(allCols []*table.Column, oldColName pmodel.CIStr) error {

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/format"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
@@ -1371,7 +1372,7 @@ func doReorgWorkForModifyColumn(
 		if kv.IsTxnRetryableError(err) || dbterror.ErrNotOwner.Equal(err) {
 			return false, ver, errors.Trace(err)
 		}
-		if isRetryableJobError(err, job.ErrorCount) {
+		if isRetryableModifyColumnReorgJobError(err, job.ErrorCount) {
 			return false, ver, errors.Trace(err)
 		}
 		if err1 := rh.RemoveDDLReorgHandle(job, reorgInfo.elements); err1 != nil {
@@ -1383,6 +1384,34 @@ func doReorgWorkForModifyColumn(
 		return false, ver, errors.Trace(err)
 	}
 	return true, ver, nil
+}
+
+func isRetryableModifyColumnReorgJobError(err error, jobErrCnt int64) bool {
+	if jobErrCnt+1 >= variable.GetDDLErrorCountLimit() {
+		return false
+	}
+
+	// Only retry explicit transient errors here.
+	// Do NOT treat unknown errors as retryable, otherwise it may cause retry loops on deterministic
+	// data conversion errors (e.g. VECTOR dimension mismatch) and block the DDL from rolling back.
+	errMsg := err.Error()
+	for _, m := range dbterror.ReorgRetryableErrMsgs {
+		if strings.Contains(errMsg, m) {
+			return true
+		}
+	}
+	// TiKV client/PD region scan may return leaderless regions during rolling restart or network issues.
+	// That error is transient and should be retried by the DDL worker.
+	if strings.Contains(errMsg, "All returned regions have no leaders") {
+		return true
+	}
+	originErr := errors.Cause(err)
+	if tErr, ok := originErr.(*terror.Error); ok {
+		sqlErr := terror.ToSQLError(tErr)
+		_, ok := dbterror.ReorgRetryableErrCodes[sqlErr.Code]
+		return ok
+	}
+	return false
 }
 
 func checkModifyColumnWithGeneratedColumnsConstraint(allCols []*table.Column, oldColName pmodel.CIStr) error {

--- a/pkg/ddl/modify_column_test.go
+++ b/pkg/ddl/modify_column_test.go
@@ -1517,3 +1517,25 @@ func TestStatsAfterModifyColumn(t *testing.T) {
 		})
 	}
 }
+
+func TestModifyColumnLoadTableRangeError(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("drop database if exists modifycol;")
+	tk.MustExec("create database modifycol;")
+	tk.MustExec("use modifycol;")
+	tk.MustExec(`set global tidb_enable_dist_task=off;`)
+
+	// Use a type conversion that definitely requires reorg.
+	tk.MustExec("create table t (a int primary key, b int, c int);")
+	batchInsert(tk, "t", 0, 100)
+
+	// Simulate transient PD errors (e.g. "regions have no leader") when splitting table ranges.
+	// We also disable the internal retry in loadTableRanges to make the error visible to the DDL job logic,
+	// otherwise it will be retried and recovered inside loadTableRanges.
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/loadTableRangesNoRetry", "return")
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/validateAndFillRangesErr", "1*return")
+
+	tk.MustExec("alter table t change column b b varchar(16);")
+	tk.MustExec("admin check table t;")
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number:  

Problem Summary:

During TiUP rolling upgrade (PD/TiKV restart, leader transfer), `modify/change column` DDL reorg may hit transient PD/region cache errors (e.g. "All returned regions have no leaders"). The current modify-column reorg error handling can convert the job to `rollingback` immediately, leading to `rollback done` and user-visible DDL failure.

In the reported upgrade from v8.4.0, the DDL job was converted to rollback *before* TiDB restarted to the target version, which indicates this is a transient-infra error classification issue in reorg (not tied to the target TiDB binary).

### What changed and how does it work?

- Treat reorg errors in `modify/change column` as retryable when `isRetryableJobError(err, job.ErrorCount)` is true (aligning behavior with add-index reorg).
- Add a regression unit test `TestModifyColumnLoadTableRangeError` to simulate a transient failure when splitting/loading table ranges and ensure the DDL job retries instead of rolling back.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `make failpoint-enable && go test ./pkg/ddl -run TestModifyColumnLoadTableRangeError -count=1 -tags 'failpoint intest' -v && make failpoint-disable`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix modify/change column DDL reorg to retry on transient errors (e.g. leaderless regions) instead of rolling back during cluster upgrade.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for column-modification reorganizations and distributed backfill so transient errors are retried more appropriately and unnecessary rollbacks are reduced.
  * Expanded detection to treat leader-less region errors as retryable and made unknown-error retryability controllable by callers.

* **Tests**
  * Added a test that simulates range-loading failures during a column change and verifies schema/data consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
