### PR TITLE
[release-nextgen-20251011] reporter: decouple othersUser routing from wire label (#67265)

### DIFF
--- a/pkg/util/topsql/reporter/ru_datamodel.go
+++ b/pkg/util/topsql/reporter/ru_datamodel.go
@@ -28,16 +28,18 @@ import (
 // TopN limits for RU aggregation.
 //
 // Two "others" buckets are used to bound cardinality:
-// 1. "others user" (keyRUOthersUser = "<others>") for evicted users.
+// 1. "others user" (othersUserWireLabel = "_TIDB_TOPRU_OTHERS_USER") for evicted users.
 // 2. "others SQL" (nil sqlDigest + nil planDigest) for evicted SQLs per user.
 const (
 	// maxTopUsers is the maximum number of users to keep in global TopN.
 	maxTopUsers = 200
 	// maxTopSQLsPerUser is the maximum number of SQLs to keep per user.
 	maxTopSQLsPerUser = 200
-	// keyRUOthersUser is the special user key for aggregated "others" users.
-	// Use a non-empty sentinel to avoid collision with real empty user names.
-	keyRUOthersUser = "<others>"
+	// othersUserWireLabel is the wire/output label for aggregated "others user".
+	// It is only used when encoding to TopRURecord output.
+	// Under current runtime invariant, real user values come from vars.User.String()
+	// (shape: "user@host" or ""), so this label does not collide with runtime users.
+	othersUserWireLabel = "_TIDB_TOPRU_OTHERS_USER"
 
 	// Pre-TopN memory caps used during collection.
 	maxPreTopNUsers       = maxTopUsers * 2       // 400 users max during collection.
@@ -190,8 +192,10 @@ func (rs ruRecords) topN(n int) (top, evicted ruRecords) {
 
 // userRUCollecting tracks RU data for one user with per-user SQL TopN.
 type userRUCollecting struct {
-	records            map[sqlPlanKey]*ruRecord // sqlPlanKey => ruRecord
-	othersRec          *ruRecord                // Pre-aggregated "others SQL" record
+	records   map[sqlPlanKey]*ruRecord // sqlPlanKey => ruRecord
+	othersRec *ruRecord                // Pre-aggregated "others SQL" record
+	// user is the real user key for entries stored in ruCollecting.users.
+	// Do not use this field to infer whether it is synthetic othersUser.
 	user               string
 	totalRU            float64 // cumulative RU for user-level TopN sorting
 	preTopNSQLsPerUser int
@@ -210,6 +214,10 @@ func newUserRUCollectingWithCap(user string, preTopNSQLsPerUser int) *userRUColl
 		records:            make(map[sqlPlanKey]*ruRecord, preTopNSQLsPerUser),
 		preTopNSQLsPerUser: preTopNSQLsPerUser,
 	}
+}
+
+func newOthersUserRUCollectingWithCap(preTopNSQLsPerUser int) *userRUCollecting {
+	return newUserRUCollectingWithCap("", preTopNSQLsPerUser)
 }
 
 // add adds RU increments for one SQL.
@@ -381,8 +389,10 @@ func (us userRUCollectings) topN(n int) (top, evicted userRUCollectings) {
 // ruCollecting is the top-level RU collector.
 // It keeps global TopN users with per-user SQL TopN.
 type ruCollecting struct {
-	users              map[string]*userRUCollecting // user => userRUCollecting
-	othersUser         *userRUCollecting            // Pre-aggregated "others user"
+	users map[string]*userRUCollecting // user => userRUCollecting
+	// othersUser stores the synthetic global "others user" bucket.
+	// Its identity is determined by this field location, not by userRUCollecting.user value.
+	othersUser         *userRUCollecting
 	preTopNUsers       int
 	preTopNSQLsPerUser int
 	mu                 sync.Mutex
@@ -414,11 +424,7 @@ func (c *ruCollecting) add(timestamp uint64, key stmtstats.RUKey, incr *stmtstat
 	if !ok {
 		// At capacity, merge into "others user".
 		if len(c.users) >= c.preTopNUsers {
-			if c.othersUser == nil {
-				c.othersUser = newUserRUCollectingWithCap(keyRUOthersUser, c.preTopNSQLsPerUser)
-			}
-			// Merge into "others user"'s "others SQL".
-			c.othersUser.addOthers(timestamp, incr)
+			c.getOrCreateOthersUser().addOthers(timestamp, incr)
 			return
 		}
 		userCollecting = newUserRUCollectingWithCap(user, c.preTopNSQLsPerUser)
@@ -521,7 +527,7 @@ func (c *ruCollecting) toTopRURecords(keyspaceName []byte) []tipb.TopRURecord {
 		}
 		result = append(result, tipb.TopRURecord{
 			KeyspaceName: keyspaceName,
-			User:         keyRUOthersUser,
+			User:         othersUserWireLabel,
 			SqlDigest:    nil,
 			PlanDigest:   nil,
 			Items:        c.othersUser.othersRec.items.toProto(),
@@ -606,12 +612,12 @@ func (c *ruCollecting) compactWithLimits(maxUsers, maxSQLsPerUser int) *ruCollec
 	// Merge evicted users into "others user".
 	var othersUser *userRUCollecting
 	if c.othersUser != nil {
-		othersUser = newUserRUCollectingWithCap(keyRUOthersUser, maxSQLsPerUser)
+		othersUser = newOthersUserRUCollectingWithCap(maxSQLsPerUser)
 		mergeUserIntoOthers(othersUser, c.othersUser)
 	}
 	if len(evictedUsers) > 0 {
 		if othersUser == nil {
-			othersUser = newUserRUCollectingWithCap(keyRUOthersUser, maxSQLsPerUser)
+			othersUser = newOthersUserRUCollectingWithCap(maxSQLsPerUser)
 		}
 		for _, evictedUser := range evictedUsers {
 			mergeUserIntoOthers(othersUser, evictedUser)
@@ -622,27 +628,26 @@ func (c *ruCollecting) compactWithLimits(maxUsers, maxSQLsPerUser int) *ruCollec
 	return result
 }
 
-// getOrCreateUser returns userRUCollecting for user and creates it if needed.
-// If at user capacity, it returns othersUser.
-func (c *ruCollecting) getOrCreateUser(user string) *userRUCollecting {
-	if user == keyRUOthersUser {
-		return c.getOrCreateOthersUser()
-	}
+// getOrCreateUser returns userRUCollecting for real users and creates it if needed.
+// It also returns whether the user overflows current user capacity.
+func (c *ruCollecting) getOrCreateUser(user string) (u *userRUCollecting, overflow bool) {
 	u, ok := c.users[user]
 	if !ok {
 		if len(c.users) >= c.preTopNUsers {
-			return c.getOrCreateOthersUser()
+			return nil, true
 		}
 		u = newUserRUCollectingWithCap(user, c.preTopNSQLsPerUser)
 		c.users[user] = u
 	}
-	return u
+	return u, false
 }
 
 // getOrCreateOthersUser returns othersUser and creates it if needed.
 func (c *ruCollecting) getOrCreateOthersUser() *userRUCollecting {
 	if c.othersUser == nil {
-		c.othersUser = newUserRUCollectingWithCap(keyRUOthersUser, c.preTopNSQLsPerUser)
+		// Identity of synthetic global othersUser comes from being stored at
+		// c.othersUser, not from userRUCollecting.user value.
+		c.othersUser = newOthersUserRUCollectingWithCap(c.preTopNSQLsPerUser)
 	}
 	return c.othersUser
 }
@@ -657,7 +662,19 @@ func (c *ruCollecting) mergeFrom(src *ruCollecting, targetTimestamp uint64, rewr
 
 	// Merge regular users.
 	for _, srcUser := range src.users {
-		dstUser := c.getOrCreateUser(srcUser.user)
+		dstUser, overflow := c.getOrCreateUser(srcUser.user)
+		if overflow {
+			// When dst user capacity is full, fold the entire src user footprint into
+			// synthetic global othersUser instead of creating a new real-user bucket.
+			dstOthersUser := c.getOrCreateOthersUser()
+			for _, srcRec := range srcUser.records {
+				dstOthersUser.mergeRecord(othersKey, srcRec, targetTimestamp, rewriteTimestamp)
+			}
+			if srcUser.othersRec != nil {
+				dstOthersUser.mergeRecord(othersKey, srcUser.othersRec, targetTimestamp, rewriteTimestamp)
+			}
+			continue
+		}
 		for _, srcRec := range srcUser.records {
 			key := makeKey(srcRec.sqlDigest, srcRec.planDigest)
 			dstUser.mergeRecord(key, srcRec, targetTimestamp, rewriteTimestamp)

--- a/pkg/util/topsql/reporter/ru_datamodel_test.go
+++ b/pkg/util/topsql/reporter/ru_datamodel_test.go
@@ -226,7 +226,7 @@ func TestRUCollectingHybridTopN(t *testing.T) {
 	// Find "others user" records (empty user string)
 	var hasOthersUser bool
 	for _, rec := range records {
-		if rec.User == keyRUOthersUser {
+		if rec.User == othersUserWireLabel {
 			hasOthersUser = true
 			break
 		}
@@ -254,6 +254,168 @@ func TestRUCollectingPreTopNUserCap(t *testing.T) {
 	require.Len(t, collecting.users, maxPreTopNUsers)
 	require.NotNil(t, collecting.othersUser)
 	require.Equal(t, float64(extra), collecting.othersUser.totalRU)
+}
+
+func TestRUCollectingOthersWireLabelNoCollisionWithRuntimeUserShape(t *testing.T) {
+	collecting := newRUCollectingWithCaps(1, 1)
+	runtimeUser := "app@127.0.0.1"
+
+	// Build per-user others SQL for runtime-shaped user.
+	collecting.add(1000, stmtstats.RUKey{
+		User:       runtimeUser,
+		SQLDigest:  stmtstats.BinaryDigest("sql-top"),
+		PlanDigest: stmtstats.BinaryDigest("plan-top"),
+	}, &stmtstats.RUIncrement{
+		TotalRU:      10,
+		ExecCount:    1,
+		ExecDuration: 10,
+	})
+	collecting.add(1001, stmtstats.RUKey{
+		User:       runtimeUser,
+		SQLDigest:  stmtstats.BinaryDigest("sql-overflow"),
+		PlanDigest: stmtstats.BinaryDigest("plan-overflow"),
+	}, &stmtstats.RUIncrement{
+		TotalRU:      8,
+		ExecCount:    1,
+		ExecDuration: 10,
+	})
+
+	// Add one more user to overflow global user cap and build synthetic global othersUser.
+	collecting.add(1002, stmtstats.RUKey{
+		User:       "other@127.0.0.1",
+		SQLDigest:  stmtstats.BinaryDigest("sql-global-overflow"),
+		PlanDigest: stmtstats.BinaryDigest("plan-global-overflow"),
+	}, &stmtstats.RUIncrement{
+		TotalRU:      7,
+		ExecCount:    1,
+		ExecDuration: 10,
+	})
+
+	records := collecting.toTopRURecords([]byte("ks"))
+
+	var hasPerUserOthers bool
+	var hasGlobalOthers bool
+	for _, rec := range records {
+		if rec.User == runtimeUser && len(rec.SqlDigest) == 0 && len(rec.PlanDigest) == 0 {
+			hasPerUserOthers = true
+		}
+		if rec.User == othersUserWireLabel && len(rec.SqlDigest) == 0 && len(rec.PlanDigest) == 0 {
+			hasGlobalOthers = true
+		}
+	}
+	require.True(t, hasPerUserOthers)
+	require.True(t, hasGlobalOthers)
+}
+
+func TestRUCollectingEmptyUserAndGlobalOthersRemainDistinct(t *testing.T) {
+	collecting := newRUCollectingWithCaps(1, 1)
+
+	// Empty user is a valid runtime user shape.
+	collecting.add(1000, stmtstats.RUKey{
+		User:       "",
+		SQLDigest:  stmtstats.BinaryDigest("sql-empty-top"),
+		PlanDigest: stmtstats.BinaryDigest("plan-empty-top"),
+	}, &stmtstats.RUIncrement{
+		TotalRU:      10,
+		ExecCount:    1,
+		ExecDuration: 10,
+	})
+	collecting.add(1001, stmtstats.RUKey{
+		User:       "",
+		SQLDigest:  stmtstats.BinaryDigest("sql-empty-overflow"),
+		PlanDigest: stmtstats.BinaryDigest("plan-empty-overflow"),
+	}, &stmtstats.RUIncrement{
+		TotalRU:      8,
+		ExecCount:    1,
+		ExecDuration: 10,
+	})
+
+	// Overflow one additional user into synthetic global othersUser.
+	collecting.add(1002, stmtstats.RUKey{
+		User:       "other@127.0.0.1",
+		SQLDigest:  stmtstats.BinaryDigest("sql-global-overflow"),
+		PlanDigest: stmtstats.BinaryDigest("plan-global-overflow"),
+	}, &stmtstats.RUIncrement{
+		TotalRU:      7,
+		ExecCount:    1,
+		ExecDuration: 10,
+	})
+
+	records := collecting.toTopRURecords([]byte("ks"))
+
+	var hasEmptyUserOthers bool
+	var hasGlobalOthers bool
+	for _, rec := range records {
+		if rec.User == "" && len(rec.SqlDigest) == 0 && len(rec.PlanDigest) == 0 {
+			hasEmptyUserOthers = true
+		}
+		if rec.User == othersUserWireLabel && len(rec.SqlDigest) == 0 && len(rec.PlanDigest) == 0 {
+			hasGlobalOthers = true
+		}
+	}
+	require.True(t, hasEmptyUserOthers)
+	require.True(t, hasGlobalOthers)
+}
+
+func TestRUCollectingMergeFromKeepsEmptyUserDistinctFromGlobalOthers(t *testing.T) {
+	dst := newRUCollectingWithCaps(1, 1)
+
+	// Keep a real empty-user bucket in destination, including per-user others SQL.
+	dst.add(1000, stmtstats.RUKey{
+		User:       "",
+		SQLDigest:  stmtstats.BinaryDigest("sql-empty-top"),
+		PlanDigest: stmtstats.BinaryDigest("plan-empty-top"),
+	}, &stmtstats.RUIncrement{
+		TotalRU:      10,
+		ExecCount:    1,
+		ExecDuration: 10,
+	})
+	dst.add(1001, stmtstats.RUKey{
+		User:       "",
+		SQLDigest:  stmtstats.BinaryDigest("sql-empty-overflow"),
+		PlanDigest: stmtstats.BinaryDigest("plan-empty-overflow"),
+	}, &stmtstats.RUIncrement{
+		TotalRU:      8,
+		ExecCount:    1,
+		ExecDuration: 10,
+	})
+
+	src := newRUCollectingWithCaps(1, 1)
+	src.add(1002, stmtstats.RUKey{
+		User:       "other@127.0.0.1",
+		SQLDigest:  stmtstats.BinaryDigest("sql-other-top"),
+		PlanDigest: stmtstats.BinaryDigest("plan-other-top"),
+	}, &stmtstats.RUIncrement{
+		TotalRU:      7,
+		ExecCount:    1,
+		ExecDuration: 10,
+	})
+	// Overflow one more user in source so mergeFrom path also merges src.othersUser.
+	src.add(1003, stmtstats.RUKey{
+		User:       "other2@127.0.0.1",
+		SQLDigest:  stmtstats.BinaryDigest("sql-other-overflow"),
+		PlanDigest: stmtstats.BinaryDigest("plan-other-overflow"),
+	}, &stmtstats.RUIncrement{
+		TotalRU:      6,
+		ExecCount:    1,
+		ExecDuration: 10,
+	})
+
+	dst.mergeFrom(src, 0, false)
+	records := dst.toTopRURecords([]byte("ks"))
+
+	var hasEmptyUserOthers bool
+	var hasGlobalOthers bool
+	for _, rec := range records {
+		if rec.User == "" && len(rec.SqlDigest) == 0 && len(rec.PlanDigest) == 0 {
+			hasEmptyUserOthers = true
+		}
+		if rec.User == othersUserWireLabel && len(rec.SqlDigest) == 0 && len(rec.PlanDigest) == 0 {
+			hasGlobalOthers = true
+		}
+	}
+	require.True(t, hasEmptyUserOthers)
+	require.True(t, hasGlobalOthers)
 }
 
 func TestRUCollectingAddBatch(t *testing.T) {
@@ -398,7 +560,7 @@ var compactWithLimitsCases = []compactWithLimitsCase{
 			})
 			collecting.users["u2"] = u2
 
-			preOthers := newUserRUCollectingWithCap(keyRUOthersUser, 10)
+			preOthers := newOthersUserRUCollectingWithCap(10)
 			preOthers.add(2000, stmtstats.BinaryDigest("sql-pre-others"), stmtstats.BinaryDigest("plan-pre-others"), &stmtstats.RUIncrement{
 				TotalRU:      6,
 				ExecCount:    1,
@@ -419,7 +581,7 @@ var compactWithLimitsCases = []compactWithLimitsCase{
 			require.Contains(t, compacted.users, "u1")
 
 			require.NotNil(t, compacted.othersUser)
-			require.Equal(t, keyRUOthersUser, compacted.othersUser.user)
+			require.Empty(t, compacted.othersUser.user)
 			require.Empty(t, compacted.othersUser.records)
 			require.NotNil(t, compacted.othersUser.othersRec)
 			require.Empty(t, compacted.othersUser.othersRec.sqlDigest)
@@ -432,7 +594,7 @@ var compactWithLimitsCases = []compactWithLimitsCase{
 		setup: func() *ruCollecting {
 			// Precondition: only othersUser.othersRec has data.
 			collecting := newRUCollectingWithCaps(10, 10)
-			collecting.othersUser = newUserRUCollectingWithCap(keyRUOthersUser, 10)
+			collecting.othersUser = newOthersUserRUCollectingWithCap(10)
 			collecting.othersUser.addOthers(3000, &stmtstats.RUIncrement{
 				TotalRU:      11,
 				ExecCount:    1,
@@ -480,7 +642,7 @@ var compactWithLimitsCases = []compactWithLimitsCase{
 		setup: func() *ruCollecting {
 			// Precondition: legacy others data sits in othersUser.records with nil digests.
 			collecting := newRUCollectingWithCaps(10, 10)
-			legacyOthers := newUserRUCollectingWithCap(keyRUOthersUser, 10)
+			legacyOthers := newOthersUserRUCollectingWithCap(10)
 			legacyRec := newOthersRURecord()
 			legacyRec.add(5000, 13, 2, 30)
 			legacyOthers.records[othersKey] = legacyRec

--- a/pkg/util/topsql/reporter/ru_window_aggregator_test.go
+++ b/pkg/util/topsql/reporter/ru_window_aggregator_test.go
@@ -394,11 +394,13 @@ func TestRUWindowAggregatorFinalReportCappedTo100x100(t *testing.T) {
 	var othersUserTotalRU float64
 	for i := range records {
 		rec := records[i]
-		if rec.User == keyRUOthersUser && len(rec.SqlDigest) == 0 && len(rec.PlanDigest) == 0 {
+		if rec.User == othersUserWireLabel && len(rec.SqlDigest) == 0 && len(rec.PlanDigest) == 0 {
 			othersUserTotalRU += sumTopRUItems(rec.Items)
 			continue
 		}
-		if rec.User == keyRUOthersUser {
+		if rec.User == othersUserWireLabel {
+			require.Zero(t, len(rec.SqlDigest))
+			require.Zero(t, len(rec.PlanDigest))
 			continue
 		}
 		if len(rec.SqlDigest) > 0 || len(rec.PlanDigest) > 0 {
@@ -493,7 +495,9 @@ func TestRUWindowAggregatorOverCapBehaviorKeepsHotKeys(t *testing.T) {
 	realUsers := map[string]int{}
 	for i := range records {
 		rec := records[i]
-		if rec.User == keyRUOthersUser {
+		if rec.User == othersUserWireLabel {
+			require.Zero(t, len(rec.SqlDigest))
+			require.Zero(t, len(rec.PlanDigest))
 			continue
 		}
 		if len(rec.SqlDigest) > 0 || len(rec.PlanDigest) > 0 {

--- a/pkg/util/topsql/reporter/topru_case_runner_test.go
+++ b/pkg/util/topsql/reporter/topru_case_runner_test.go
@@ -128,7 +128,7 @@ func runTopRUCase(t *testing.T, cs caseSpec) {
 			key: {TotalRU: 4, ExecCount: 2, ExecDuration: 2000},
 		})
 	case "internal_sql_empty_user_handling":
-		// Empty user is valid and should not be rewritten to "<others>".
+		// Empty user is valid and should not be rewritten to the others-user sentinel.
 		sqlDigest := []byte("S_G10")
 		planDigest := []byte("P_G10")
 		tsr.RegisterSQL(sqlDigest, fmt.Sprintf("/* %s */ select 10", marker), false)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #65471

This is a backport to `release-nextgen-20251011` for upstream PR #67265.

### What changed and how does it work?

- Cherry-pick upstream merged commit `ff0e035ab6` onto `release-nextgen-20251011`.
- Backport commit on this branch: `b4c04c6bc3`.
- Effective backport file set on release branch:
  - `pkg/util/topsql/reporter/ru_datamodel.go`
  - `pkg/util/topsql/reporter/ru_datamodel_test.go`
  - `pkg/util/topsql/reporter/ru_window_aggregator_test.go`
  - `pkg/util/topsql/reporter/topru_case_runner_test.go`
- Note: upstream also touched `docs/workflows/conclude-records/toomanytests-generated-cases.md`, but that file does not exist on `release-nextgen-20251011`, so no diff is produced on this branch.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal structure for resource usage data collection and synthetic user handling.
  * Enhanced separation logic between synthetic and real user data in tracking.

* **Tests**
  * Added comprehensive test coverage for edge cases in resource usage aggregation.
  * Verified correct isolation of synthetic user data from real user records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->