### PR TITLE
*: add fzzf678 to OWNERS_ALIASES approver aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -56,11 +56,13 @@ aliases:
     - D3Hunter
     - gmhdbjd
     - wjhuang2016
+    - fzzf678
   sig-approvers-ddl:
     - Benjamin2037
     - wjhuang2016
     - D3Hunter
     - gmhdbjd
+    - fzzf678
   sig-approvers-disttask:
     - Benjamin2037
     - D3Hunter
@@ -75,15 +77,18 @@ aliases:
     - D3Hunter
     - Benjamin2037
     - gmhdbjd
+    - fzzf678
   sig-approvers-meta:
     - Benjamin2037
     - gmhdbjd
     - wjhuang2016
     - D3Hunter
+    - fzzf678
   sig-approvers-owner:
     - Benjamin2037
     - wjhuang2016
     - D3Hunter
+    - fzzf678
   sig-approvers-parser:
     - bb7133
     - Benjamin2037
@@ -99,6 +104,7 @@ aliases:
     - cfzjywxk
     - gmhdbjd
     - wjhuang2016
+    - fzzf678
   sig-approvers-lock:
     - Benjamin2037
     - wjhuang2016


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:
Add `fzzf678` to the selected approver aliases in `OWNERS_ALIASES`.

### What changed and how does it work?

This PR updates `OWNERS_ALIASES` and adds `fzzf678` to these aliases:
- `sig-approvers-domain`
- `sig-approvers-ddl`
- `sig-approvers-infoschema`
- `sig-approvers-meta`
- `sig-approvers-owner`
- `sig-approvers-table`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
