### PR TITLE
ddl: enforce masking policy dynamic privilege checks in executor

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -6348,6 +6348,9 @@ func (e *executor) CreateMaskingPolicy(ctx sessionctx.Context, stmt *ast.CreateM
 	if stmt.OrReplace && stmt.IfNotExists {
 		return dbterror.ErrWrongUsage.GenWithStackByArgs("OR REPLACE", "IF NOT EXISTS")
 	}
+	if err := requireMaskingPolicyDynamicPrivilege(ctx, "CREATE MASKING POLICY"); err != nil {
+		return err
+	}
 
 	tableIdent := ast.Ident{Schema: stmt.Table.Schema, Name: stmt.Table.Name}
 	if tableIdent.Schema.L == "" {
@@ -6389,6 +6392,9 @@ func (e *executor) CreateMaskingPolicy(ctx sessionctx.Context, stmt *ast.CreateM
 }
 
 func (e *executor) AddMaskingPolicy(ctx sessionctx.Context, ident ast.Ident, spec *ast.AlterTableSpec) error {
+	if err := requireMaskingPolicyDynamicPrivilege(ctx, "CREATE MASKING POLICY"); err != nil {
+		return err
+	}
 	schema, tbl, err := e.getSchemaAndTableByIdent(ident)
 	if err != nil {
 		return errors.Trace(err)
@@ -6447,6 +6453,9 @@ LIMIT 1`,
 }
 
 func (e *executor) AlterTableMaskingPolicy(ctx sessionctx.Context, ident ast.Ident, spec *ast.AlterTableSpec) error {
+	if err := requireMaskingPolicyDynamicPrivilege(ctx, "ALTER MASKING POLICY"); err != nil {
+		return err
+	}
 	schema, tbl, err := e.getSchemaAndTableByIdent(ident)
 	if err != nil {
 		return errors.Trace(err)
@@ -6508,6 +6517,9 @@ func (e *executor) AlterTableMaskingPolicy(ctx sessionctx.Context, ident ast.Ide
 }
 
 func (e *executor) AlterTableMaskingPolicyState(ctx sessionctx.Context, ident ast.Ident, spec *ast.AlterTableSpec, enabled bool) error {
+	if err := requireMaskingPolicyDynamicPrivilege(ctx, "ALTER MASKING POLICY"); err != nil {
+		return err
+	}
 	schema, tbl, err := e.getSchemaAndTableByIdent(ident)
 	if err != nil {
 		return errors.Trace(err)
@@ -6561,6 +6573,9 @@ func (e *executor) AlterTableMaskingPolicyState(ctx sessionctx.Context, ident as
 }
 
 func (e *executor) DropMaskingPolicy(ctx sessionctx.Context, ident ast.Ident, spec *ast.AlterTableSpec) error {
+	if err := requireMaskingPolicyDynamicPrivilege(ctx, "DROP MASKING POLICY"); err != nil {
+		return err
+	}
 	schema, tbl, err := e.getSchemaAndTableByIdent(ident)
 	if err != nil {
 		return errors.Trace(err)
@@ -6603,6 +6618,18 @@ func (e *executor) DropMaskingPolicy(ctx sessionctx.Context, ident ast.Ident, sp
 		PolicyID:   policy.ID,
 	}
 	return errors.Trace(e.doDDLJob2(ctx, job, args))
+}
+
+func requireMaskingPolicyDynamicPrivilege(ctx sessionctx.Context, dynamicPriv string) error {
+	checker := privilege.GetPrivilegeManager(ctx)
+	if checker == nil {
+		// Keep behavior for internal/bootstrap sessions without privilege manager.
+		return nil
+	}
+	if checker.RequestDynamicVerification(ctx.GetSessionVars().ActiveRoles, dynamicPriv, false) {
+		return nil
+	}
+	return plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs("SUPER or " + dynamicPriv)
 }
 
 func (e *executor) createMaskingPolicyWithInfo(ctx sessionctx.Context, schemaID int64, policy *model.MaskingPolicyInfo, onExist OnExist) error {


### PR DESCRIPTION
## Summary
- add executor-layer dynamic privilege checks for masking policy DDL operations
- enforce `CREATE MASKING POLICY` for:
  - `CREATE MASKING POLICY`
  - `ALTER TABLE ... ADD MASKING POLICY`
- enforce `ALTER MASKING POLICY` for:
  - `ALTER TABLE ... ENABLE/DISABLE MASKING POLICY`
  - `ALTER TABLE ... MODIFY MASKING POLICY ...`
- enforce `DROP MASKING POLICY` for:
  - `ALTER TABLE ... DROP MASKING POLICY`
- keep bootstrap/internal sessions compatible when privilege manager is absent

This hardens authorization at DDL executor layer, so enforcement does not rely only on planner visitInfo checks.

## Issue
- Fixes #67221

## Test
- `go test ./pkg/ddl -run TestMaskingPolicyDDLBasic -count=1`
  - local environment currently fails before test execution due Go toolchain/ABI guard:
    - `The hack package only supports go1.25`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added dynamic privilege verification for masking policy operations (CREATE, ALTER, DROP) to enforce proper access control. Users without appropriate permissions will receive access denied errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->