### PR TITLE
expression: support single-arg MASK_FULL with default masking

### DIFF
--- a/pkg/expression/builtin.go
+++ b/pkg/expression/builtin.go
@@ -652,7 +652,7 @@ var funcs = map[string]functionClass{
 	ast.Greatest:    &greatestFunctionClass{baseFunctionClass{ast.Greatest, 2, -1}},
 	ast.Least:       &leastFunctionClass{baseFunctionClass{ast.Least, 2, -1}},
 	ast.Interval:    &intervalFunctionClass{baseFunctionClass{ast.Interval, 2, -1}},
-	ast.MaskFull:    &maskFullFunctionClass{baseFunctionClass{ast.MaskFull, 2, 2}},
+	ast.MaskFull:    &maskFullFunctionClass{baseFunctionClass{ast.MaskFull, 1, 2}},
 	ast.MaskPartial: &maskPartialFunctionClass{baseFunctionClass{ast.MaskPartial, 4, 4}},
 	ast.MaskNull:    &maskNullFunctionClass{baseFunctionClass{ast.MaskNull, 1, 1}},
 	ast.MaskDate:    &maskDateFunctionClass{baseFunctionClass{ast.MaskDate, 2, 2}},

--- a/pkg/expression/builtin_masking.go
+++ b/pkg/expression/builtin_masking.go
@@ -32,14 +32,19 @@ func (c *maskFullFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	}
 	argType := args[0].GetType(ctx.GetEvalCtx())
 	evalTp := argType.EvalType()
-	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, evalTp, evalTp, types.ETString)
+	argTps := []types.EvalType{evalTp}
+	if len(args) == 2 {
+		argTps = append(argTps, types.ETString)
+	}
+	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, evalTp, argTps...)
 	if err != nil {
 		return nil, err
 	}
 	bf.tp = argType.Clone()
 	switch evalTp {
 	case types.ETString:
-		if types.IsBinaryStr(argType) || types.IsBinaryStr(args[1].GetType(ctx.GetEvalCtx())) {
+		maskArgIsBinary := len(args) == 2 && types.IsBinaryStr(args[1].GetType(ctx.GetEvalCtx()))
+		if types.IsBinaryStr(argType) || maskArgIsBinary {
 			return &builtinMaskFullBinarySig{bf}, nil
 		}
 		return &builtinMaskFullStringSig{bf}, nil
@@ -81,15 +86,19 @@ func (b *builtinMaskFullStringSig) evalString(ctx EvalContext, row chunk.Row) (s
 	if isNull || err != nil {
 		return "", true, err
 	}
-	mask, isNull, err := b.args[1].EvalString(ctx, row)
-	if isNull || err != nil {
-		return "", true, err
+	maskRune := "X"
+	if len(b.args) == 2 {
+		mask, isNull, err := b.args[1].EvalString(ctx, row)
+		if isNull || err != nil {
+			return "", true, err
+		}
+		maskRunes := []rune(mask)
+		if len(maskRunes) != 1 {
+			return "", true, errIncorrectArgs.GenWithStackByArgs("mask_full")
+		}
+		maskRune = string(maskRunes[0])
 	}
-	maskRunes := []rune(mask)
-	if len(maskRunes) != 1 {
-		return "", true, errIncorrectArgs.GenWithStackByArgs("mask_full")
-	}
-	return strings.Repeat(string(maskRunes[0]), len([]rune(str))), false, nil
+	return strings.Repeat(maskRune, len([]rune(str))), false, nil
 }
 
 type builtinMaskFullBinarySig struct {
@@ -110,12 +119,15 @@ func (b *builtinMaskFullBinarySig) evalString(ctx EvalContext, row chunk.Row) (s
 	if isNull || err != nil {
 		return "", true, err
 	}
-	mask, isNull, err := b.args[1].EvalString(ctx, row)
-	if isNull || err != nil {
-		return "", true, err
-	}
-	if len(mask) != 1 {
-		return "", true, errIncorrectArgs.GenWithStackByArgs("mask_full")
+	mask := "X"
+	if len(b.args) == 2 {
+		mask, isNull, err = b.args[1].EvalString(ctx, row)
+		if isNull || err != nil {
+			return "", true, err
+		}
+		if len(mask) != 1 {
+			return "", true, errIncorrectArgs.GenWithStackByArgs("mask_full")
+		}
 	}
 	return strings.Repeat(mask, len(str)), false, nil
 }
@@ -189,7 +201,7 @@ func (b *builtinMaskFullIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 	if isNull || err != nil {
 		return 0, true, err
 	}
-	return 1970, false, nil
+	return 0, false, nil
 }
 
 type maskNullFunctionClass struct {

--- a/pkg/expression/builtin_masking_test.go
+++ b/pkg/expression/builtin_masking_test.go
@@ -28,9 +28,15 @@ import (
 func TestMaskFull(t *testing.T) {
 	ctx := createContext(t)
 
-	f, err := newFunctionForTest(ctx, ast.MaskFull, primitiveValsToConstants(ctx, []any{"abc", "*"})...)
+	f, err := newFunctionForTest(ctx, ast.MaskFull, primitiveValsToConstants(ctx, []any{"abc"})...)
 	require.NoError(t, err)
 	d, err := f.Eval(ctx, chunk.Row{})
+	require.NoError(t, err)
+	require.Equal(t, "XXX", d.GetString())
+
+	f, err = newFunctionForTest(ctx, ast.MaskFull, primitiveValsToConstants(ctx, []any{"abc", "*"})...)
+	require.NoError(t, err)
+	d, err = f.Eval(ctx, chunk.Row{})
 	require.NoError(t, err)
 	require.Equal(t, "***", d.GetString())
 
@@ -40,21 +46,21 @@ func TestMaskFull(t *testing.T) {
 	require.Error(t, err)
 
 	dateInput := types.NewTime(types.FromDate(2020, 1, 2, 0, 0, 0, 0), mysql.TypeDate, 0)
-	f, err = newFunctionForTest(ctx, ast.MaskFull, primitiveValsToConstants(ctx, []any{dateInput, "*"})...)
+	f, err = newFunctionForTest(ctx, ast.MaskFull, primitiveValsToConstants(ctx, []any{dateInput})...)
 	require.NoError(t, err)
 	d, err = f.Eval(ctx, chunk.Row{})
 	require.NoError(t, err)
 	require.Equal(t, "1970-01-01", d.GetMysqlTime().String())
 
 	dtInput := types.NewTime(types.FromDate(2020, 1, 2, 3, 4, 5, 0), mysql.TypeDatetime, 0)
-	f, err = newFunctionForTest(ctx, ast.MaskFull, primitiveValsToConstants(ctx, []any{dtInput, "*"})...)
+	f, err = newFunctionForTest(ctx, ast.MaskFull, primitiveValsToConstants(ctx, []any{dtInput})...)
 	require.NoError(t, err)
 	d, err = f.Eval(ctx, chunk.Row{})
 	require.NoError(t, err)
 	require.Equal(t, "1970-01-01 00:00:00", d.GetMysqlTime().String())
 
 	durationInput := types.Duration{Duration: time.Hour + time.Minute, Fsp: 0}
-	f, err = newFunctionForTest(ctx, ast.MaskFull, primitiveValsToConstants(ctx, []any{durationInput, "*"})...)
+	f, err = newFunctionForTest(ctx, ast.MaskFull, primitiveValsToConstants(ctx, []any{durationInput})...)
 	require.NoError(t, err)
 	d, err = f.Eval(ctx, chunk.Row{})
 	require.NoError(t, err)
@@ -62,11 +68,11 @@ func TestMaskFull(t *testing.T) {
 
 	yearType := types.NewFieldType(mysql.TypeYear)
 	yearArg := &Constant{Value: types.NewIntDatum(2020), RetType: yearType}
-	f, err = newFunctionForTest(ctx, ast.MaskFull, yearArg, primitiveValsToConstants(ctx, []any{"*"})[0])
+	f, err = newFunctionForTest(ctx, ast.MaskFull, yearArg)
 	require.NoError(t, err)
 	d, err = f.Eval(ctx, chunk.Row{})
 	require.NoError(t, err)
-	require.Equal(t, int64(1970), d.GetInt64())
+	require.Equal(t, int64(0), d.GetInt64())
 }
 
 func TestMaskNull(t *testing.T) {


### PR DESCRIPTION
## Summary
- make `MASK_FULL` accept one argument (`MASK_FULL(col)`) while preserving two-argument compatibility for string custom mask chars
- use default full masking char `X` when mask char argument is omitted
- return `0` for year/int mask-full path instead of `1970`
- add/update unit coverage in `pkg/expression/builtin_masking_test.go` for single-arg behavior and compatibility

## Issue
- Fixes #67224

## Test
- `go test ./pkg/expression -run TestMaskFull -count=1`
  - local environment currently fails at link/build stage:
    - linker panic / relocation errors in current macOS toolchain
    - `CGO_ENABLED=0` also fails due dependency build constraints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `MaskFull` function now accepts an optional mask character parameter. When omitted, it defaults to "X" for masking operations, providing greater flexibility for masking values with different characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->