### PR TITLE
pkg/ddl: stabilize TestMDLTruncateTable

### DIFF
--- a/pkg/ddl/db_test.go
+++ b/pkg/ddl/db_test.go
@@ -1055,13 +1055,15 @@ func TestSetInvalidDefaultValueAfterModifyColumn(t *testing.T) {
 }
 
 func TestMDLTruncateTable(t *testing.T) {
-	store := testkit.CreateMockStore(t)
+	store, dom := testkit.CreateMockStoreAndDomain(t)
 
 	tk := testkit.NewTestKit(t, store)
 	tk2 := testkit.NewTestKit(t, store)
-	tk3 := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t(a int);")
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	originalTableID := tbl.Meta().ID
 	tk.MustExec("begin")
 	tk.MustExec("select * from t for update")
 
@@ -1070,30 +1072,57 @@ func TestMDLTruncateTable(t *testing.T) {
 	wg.Add(2)
 	var timetk2 time.Time
 	var timetk3 time.Time
+	var errtk2 error
+	var errtk3 error
 
-	one := false
+	waitTableIDChanged := func() error {
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+			if err == nil && tbl.Meta().ID != originalTableID {
+				return nil
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		return errors.New("timed out waiting for truncated table ID to refresh")
+	}
+
+	var once sync.Once
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterWaitSchemaSynced", func(job *model.Job) {
-		if one {
+		if job.Type != model.ActionTruncateTable {
 			return
 		}
-		one = true
-		go func() {
-			tk3.MustExec("truncate table test.t")
-			timetk3 = time.Now()
-			wg.Done()
-		}()
+		once.Do(func() {
+			go func() {
+				defer wg.Done()
+				if err := waitTableIDChanged(); err != nil {
+					errtk3 = err
+					return
+				}
+				tk3 := testkit.NewTestKit(t, store)
+				tk3.MustExec("use test")
+				errtk3 = tk3.ExecToErr("truncate table test.t")
+				if errtk3 == nil {
+					timetk3 = time.Now()
+				}
+			}()
+		})
 	})
 
 	go func() {
-		tk2.MustExec("truncate table test.t")
-		timetk2 = time.Now()
-		wg.Done()
+		defer wg.Done()
+		errtk2 = tk2.ExecToErr("truncate table test.t")
+		if errtk2 == nil {
+			timetk2 = time.Now()
+		}
 	}()
 
 	time.Sleep(2 * time.Second)
 	timeMain := time.Now()
 	tk.MustExec("commit")
 	wg.Wait()
+	require.NoError(t, errtk2)
+	require.NoError(t, errtk3)
 	require.True(t, timetk2.After(timeMain))
 	require.True(t, timetk3.After(timeMain))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67175

Problem Summary:

`TestMDLTruncateTable` can race with session-visible infoschema refresh after the first truncate swaps the table ID, so the second truncate can intermittently run against a stale table definition and fail with `ErrInfoSchemaChanged`.


### What changed and how does it work?

The test now waits until the new table ID is visible through the domain infoschema before issuing the second truncate. It also captures errors from the background truncate goroutines explicitly so the failure surface remains deterministic.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `go test -run TestMDLTruncateTable -count=30 -tags=intest,deadlock ./pkg/ddl`
  - `go test -run TestTruncateTableAndSchemaDependence -count=10 -tags=intest,deadlock ./pkg/ddl`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This pull request contains only internal testing improvements with no user-facing changes.

* **Tests**
  * Enhanced reliability of truncate table test scenarios with improved error tracking and synchronization mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->