### PR TITLE
statistics: isolate initstats test globals

### DIFF
--- a/pkg/statistics/handle/handletest/initstats/BUILD.bazel
+++ b/pkg/statistics/handle/handletest/initstats/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 9,
+    shard_count = 8,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/statistics/handle/handletest/initstats/BUILD.bazel
+++ b/pkg/statistics/handle/handletest/initstats/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/statistics/handle/handletest/initstats/init_stats_test.go
+++ b/pkg/statistics/handle/handletest/initstats/init_stats_test.go
@@ -128,11 +128,6 @@ func TestLiteInitStatsWithTableIDs(t *testing.T) {
 }
 
 func TestNonLiteInitStatsWithTableIDs(t *testing.T) {
-	runNonLiteInitStatsWithTableIDs(t)
-}
-
-func runNonLiteInitStatsWithTableIDs(t *testing.T) {
-	t.Helper()
 	store, dom := session.CreateStoreAndBootstrap(t)
 	defer store.Close()
 	se := session.CreateSessionAndSetID(t, store)
@@ -194,20 +189,6 @@ func runNonLiteInitStatsWithTableIDs(t *testing.T) {
 
 		dom.Close()
 	})
-}
-
-func TestNonLiteInitStatsWithTableIDsAfterConcurrentlyInitStatsWithMemoryLimit(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.Performance.LiteInitStats = false
-	})
-	withIsFullCacheFunc(t, func(cache types.StatsCache, total uint64) bool {
-		return true
-	}, func() {
-		testConcurrentlyInitStats(t)
-	})
-	runNonLiteInitStatsWithTableIDs(t)
 }
 
 func TestConcurrentlyInitStatsWithMemoryLimit(t *testing.T) {

--- a/pkg/statistics/handle/handletest/initstats/init_stats_test.go
+++ b/pkg/statistics/handle/handletest/initstats/init_stats_test.go
@@ -33,6 +33,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func withStatsLease(t *testing.T, lease time.Duration, body func()) {
+	t.Helper()
+	originalLease := vardef.GetStatsLease()
+	vardef.SetStatsLease(lease)
+	defer vardef.SetStatsLease(originalLease)
+	body()
+}
+
+func withIsFullCacheFunc(t *testing.T, isFullCache func(types.StatsCache, uint64) bool, body func()) {
+	t.Helper()
+	originalIsFullCacheFunc := handle.IsFullCacheFunc
+	handle.IsFullCacheFunc = isFullCache
+	defer func() {
+		handle.IsFullCacheFunc = originalIsFullCacheFunc
+	}()
+	body()
+}
+
 func maxPhysicalTableID(h *handle.Handle, is infoschema.InfoSchema) int64 {
 	var maxID int64
 	for _, statsTbl := range h.StatsCache.Values() {
@@ -74,41 +92,47 @@ func TestLiteInitStatsWithTableIDs(t *testing.T) {
 
 	dom.Close()
 
-	vardef.SetStatsLease(-1)
-	dom, err = session.BootstrapSession(store)
-	require.NoError(t, err)
-	h := dom.StatsHandle()
-	_, ok := h.Get(tbl1.Meta().ID)
-	require.False(t, ok)
-	require.NoError(t, h.InitStatsLite(context.Background(), tbl1.Meta().ID))
-	_, ok = h.Get(tbl1.Meta().ID)
-	require.True(t, ok)
-	_, ok = h.Get(tbl2.Meta().ID)
-	require.False(t, ok)
-	_, ok = h.Get(tbl3.Meta().ID)
-	require.False(t, ok)
+	withStatsLease(t, -1, func() {
+		dom, err = session.BootstrapSession(store)
+		require.NoError(t, err)
+		h := dom.StatsHandle()
+		_, ok := h.Get(tbl1.Meta().ID)
+		require.False(t, ok)
+		require.NoError(t, h.InitStatsLite(context.Background(), tbl1.Meta().ID))
+		_, ok = h.Get(tbl1.Meta().ID)
+		require.True(t, ok)
+		_, ok = h.Get(tbl2.Meta().ID)
+		require.False(t, ok)
+		_, ok = h.Get(tbl3.Meta().ID)
+		require.False(t, ok)
 
-	// Make sure it can be loaded multiple times.
-	require.NoError(t, h.InitStatsLite(context.Background(), tbl1.Meta().ID, tbl2.Meta().ID))
-	_, ok = h.Get(tbl1.Meta().ID)
-	require.True(t, ok)
-	_, ok = h.Get(tbl2.Meta().ID)
-	require.True(t, ok)
-	_, ok = h.Get(tbl3.Meta().ID)
-	require.False(t, ok)
+		// Make sure it can be loaded multiple times.
+		require.NoError(t, h.InitStatsLite(context.Background(), tbl1.Meta().ID, tbl2.Meta().ID))
+		_, ok = h.Get(tbl1.Meta().ID)
+		require.True(t, ok)
+		_, ok = h.Get(tbl2.Meta().ID)
+		require.True(t, ok)
+		_, ok = h.Get(tbl3.Meta().ID)
+		require.False(t, ok)
 
-	require.NoError(t, h.InitStatsLite(context.Background()))
-	_, ok = h.Get(tbl1.Meta().ID)
-	require.True(t, ok)
-	_, ok = h.Get(tbl2.Meta().ID)
-	require.True(t, ok)
-	_, ok = h.Get(tbl3.Meta().ID)
-	require.True(t, ok)
+		require.NoError(t, h.InitStatsLite(context.Background()))
+		_, ok = h.Get(tbl1.Meta().ID)
+		require.True(t, ok)
+		_, ok = h.Get(tbl2.Meta().ID)
+		require.True(t, ok)
+		_, ok = h.Get(tbl3.Meta().ID)
+		require.True(t, ok)
 
-	dom.Close()
+		dom.Close()
+	})
 }
 
 func TestNonLiteInitStatsWithTableIDs(t *testing.T) {
+	runNonLiteInitStatsWithTableIDs(t)
+}
+
+func runNonLiteInitStatsWithTableIDs(t *testing.T) {
+	t.Helper()
 	store, dom := session.CreateStoreAndBootstrap(t)
 	defer store.Close()
 	se := session.CreateSessionAndSetID(t, store)
@@ -130,45 +154,60 @@ func TestNonLiteInitStatsWithTableIDs(t *testing.T) {
 
 	dom.Close()
 
-	vardef.SetStatsLease(-1)
-	dom, err = session.BootstrapSession(store)
-	require.NoError(t, err)
-	is = dom.InfoSchema()
-	h := dom.StatsHandle()
-	_, ok := h.Get(tbl1.Meta().ID)
-	require.False(t, ok)
-	require.NoError(t, h.InitStats(context.Background(), is, tbl1.Meta().ID))
-	stats1, ok := h.Get(tbl1.Meta().ID)
-	require.True(t, ok)
-	require.True(t, stats1.GetIdx(1).IsFullLoad())
-	_, ok = h.Get(tbl2.Meta().ID)
-	require.False(t, ok)
-	_, ok = h.Get(tbl3.Meta().ID)
-	require.False(t, ok)
+	withStatsLease(t, -1, func() {
+		dom, err = session.BootstrapSession(store)
+		require.NoError(t, err)
+		is = dom.InfoSchema()
+		h := dom.StatsHandle()
+		_, ok := h.Get(tbl1.Meta().ID)
+		require.False(t, ok)
+		require.NoError(t, h.InitStats(context.Background(), is, tbl1.Meta().ID))
+		stats1, ok := h.Get(tbl1.Meta().ID)
+		require.True(t, ok)
+		require.True(t, stats1.GetIdx(1).IsFullLoad())
+		_, ok = h.Get(tbl2.Meta().ID)
+		require.False(t, ok)
+		_, ok = h.Get(tbl3.Meta().ID)
+		require.False(t, ok)
 
-	// Make sure it can be loaded multiple times.
-	require.NoError(t, h.InitStats(context.Background(), is, tbl1.Meta().ID, tbl2.Meta().ID))
-	stats1, ok = h.Get(tbl1.Meta().ID)
-	require.True(t, ok)
-	require.True(t, stats1.GetIdx(1).IsFullLoad())
-	stats2, ok := h.Get(tbl2.Meta().ID)
-	require.True(t, ok)
-	require.True(t, stats2.GetIdx(1).IsFullLoad())
-	_, ok = h.Get(tbl3.Meta().ID)
-	require.False(t, ok)
+		// Make sure it can be loaded multiple times.
+		require.NoError(t, h.InitStats(context.Background(), is, tbl1.Meta().ID, tbl2.Meta().ID))
+		stats1, ok = h.Get(tbl1.Meta().ID)
+		require.True(t, ok)
+		require.True(t, stats1.GetIdx(1).IsFullLoad())
+		stats2, ok := h.Get(tbl2.Meta().ID)
+		require.True(t, ok)
+		require.True(t, stats2.GetIdx(1).IsFullLoad())
+		_, ok = h.Get(tbl3.Meta().ID)
+		require.False(t, ok)
 
-	require.NoError(t, h.InitStats(context.Background(), is))
-	stats1, ok = h.Get(tbl1.Meta().ID)
-	require.True(t, ok)
-	require.True(t, stats1.GetIdx(1).IsFullLoad())
-	stats2, ok = h.Get(tbl2.Meta().ID)
-	require.True(t, ok)
-	require.True(t, stats2.GetIdx(1).IsFullLoad())
-	stats3, ok := h.Get(tbl3.Meta().ID)
-	require.True(t, ok)
-	require.True(t, stats3.GetIdx(1).IsFullLoad())
+		require.NoError(t, h.InitStats(context.Background(), is))
+		stats1, ok = h.Get(tbl1.Meta().ID)
+		require.True(t, ok)
+		require.True(t, stats1.GetIdx(1).IsFullLoad())
+		stats2, ok = h.Get(tbl2.Meta().ID)
+		require.True(t, ok)
+		require.True(t, stats2.GetIdx(1).IsFullLoad())
+		stats3, ok := h.Get(tbl3.Meta().ID)
+		require.True(t, ok)
+		require.True(t, stats3.GetIdx(1).IsFullLoad())
 
-	dom.Close()
+		dom.Close()
+	})
+}
+
+func TestNonLiteInitStatsWithTableIDsAfterConcurrentlyInitStatsWithMemoryLimit(t *testing.T) {
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Performance.LiteInitStats = false
+	})
+	withIsFullCacheFunc(t, func(cache types.StatsCache, total uint64) bool {
+		return true
+	}, func() {
+		testConcurrentlyInitStats(t)
+	})
+	runNonLiteInitStatsWithTableIDs(t)
 }
 
 func TestConcurrentlyInitStatsWithMemoryLimit(t *testing.T) {
@@ -177,10 +216,11 @@ func TestConcurrentlyInitStatsWithMemoryLimit(t *testing.T) {
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.LiteInitStats = false
 	})
-	handle.IsFullCacheFunc = func(cache types.StatsCache, total uint64) bool {
+	withIsFullCacheFunc(t, func(cache types.StatsCache, total uint64) bool {
 		return true
-	}
-	testConcurrentlyInitStats(t)
+	}, func() {
+		testConcurrentlyInitStats(t)
+	})
 }
 
 func TestConcurrentlyInitStatsWithoutMemoryLimit(t *testing.T) {
@@ -189,10 +229,11 @@ func TestConcurrentlyInitStatsWithoutMemoryLimit(t *testing.T) {
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.LiteInitStats = false
 	})
-	handle.IsFullCacheFunc = func(cache types.StatsCache, total uint64) bool {
+	withIsFullCacheFunc(t, func(cache types.StatsCache, total uint64) bool {
 		return false
-	}
-	testConcurrentlyInitStats(t)
+	}, func() {
+		testConcurrentlyInitStats(t)
+	})
 }
 
 func testConcurrentlyInitStats(t *testing.T) {
@@ -293,9 +334,6 @@ func TestSkipStatsInitWithSkipInitStats(t *testing.T) {
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.SkipInitStats = true
 	})
-	originalStatsLease := vardef.GetStatsLease()
-	defer vardef.SetStatsLease(originalStatsLease)
-
 	store, dom := session.CreateStoreAndBootstrap(t)
 	defer store.Close()
 	se := session.CreateSessionAndSetID(t, store)
@@ -307,17 +345,18 @@ func TestSkipStatsInitWithSkipInitStats(t *testing.T) {
 
 	// Keep the periodic stats updater enabled, but give the assertion time to
 	// observe the skipped init path before the first background refresh.
-	vardef.SetStatsLease(3 * time.Second)
-	dom, err := session.BootstrapSession(store)
-	require.NoError(t, err)
-	h := dom.StatsHandle()
-	<-h.InitStatsDone
-	is := dom.InfoSchema()
-	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
-	require.NoError(t, err)
-	_, ok := h.StatsCache.Get(tbl.Meta().ID)
-	require.False(t, ok)
-	dom.Close()
+	withStatsLease(t, 3*time.Second, func() {
+		dom, err := session.BootstrapSession(store)
+		require.NoError(t, err)
+		h := dom.StatsHandle()
+		<-h.InitStatsDone
+		is := dom.InfoSchema()
+		tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+		require.NoError(t, err)
+		_, ok := h.StatsCache.Get(tbl.Meta().ID)
+		require.False(t, ok)
+		dom.Close()
+	})
 }
 
 func TestNonLiteInitStatsAndCheckTheLastTableStats(t *testing.T) {
@@ -342,23 +381,24 @@ func TestNonLiteInitStatsAndCheckTheLastTableStats(t *testing.T) {
 
 	dom.Close()
 
-	vardef.SetStatsLease(-1)
-	dom, err = session.BootstrapSession(store)
-	require.NoError(t, err)
-	is = dom.InfoSchema()
-	h := dom.StatsHandle()
-	_, ok := h.Get(tbl1.Meta().ID)
-	require.False(t, ok)
-	require.NoError(t, h.InitStats(context.Background(), is))
-	stats1, ok := h.Get(tbl1.Meta().ID)
-	require.True(t, ok)
-	require.True(t, stats1.GetIdx(1).IsFullLoad())
-	stats2, ok := h.Get(tbl2.Meta().ID)
-	require.True(t, ok)
-	require.True(t, stats2.GetIdx(1).IsFullLoad())
-	stats3, ok := h.Get(tbl3.Meta().ID)
-	require.True(t, ok)
-	require.True(t, stats3.GetIdx(1).IsFullLoad())
+	withStatsLease(t, -1, func() {
+		dom, err = session.BootstrapSession(store)
+		require.NoError(t, err)
+		is = dom.InfoSchema()
+		h := dom.StatsHandle()
+		_, ok := h.Get(tbl1.Meta().ID)
+		require.False(t, ok)
+		require.NoError(t, h.InitStats(context.Background(), is))
+		stats1, ok := h.Get(tbl1.Meta().ID)
+		require.True(t, ok)
+		require.True(t, stats1.GetIdx(1).IsFullLoad())
+		stats2, ok := h.Get(tbl2.Meta().ID)
+		require.True(t, ok)
+		require.True(t, stats2.GetIdx(1).IsFullLoad())
+		stats3, ok := h.Get(tbl3.Meta().ID)
+		require.True(t, ok)
+		require.True(t, stats3.GetIdx(1).IsFullLoad())
 
-	dom.Close()
+		dom.Close()
+	})
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67176

Problem Summary:

`TestNonLiteInitStatsWithTableIDs` can inherit test-only global state from other initstats tests. When `handle.IsFullCacheFunc` is left overridden, the non-lite init path can treat the cache as full and leave the loaded index stats not fully loaded.

### What changed and how does it work?

- Scope the `handle.IsFullCacheFunc` override to the tests that need it.
- Scope `StatsLease` changes in the initstats tests so they do not leak into later tests.
- Factor the non-lite table-ID test body into a helper and add a regression test that verifies the memory-limit initstats path does not affect it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

- `go test ./pkg/statistics/handle/handletest/initstats -run '^TestNonLiteInitStatsWithTableIDsAfterConcurrentlyInitStatsWithMemoryLimit$' -count=1 -tags=intest,deadlock`
- `go test ./pkg/statistics/handle/handletest/initstats -run '^TestNonLiteInitStatsWithTableIDs$' -count=1 -tags=intest,deadlock`
- `go test ./pkg/statistics/handle/handletest/initstats -run '^(TestLiteInitStatsWithTableIDs|TestConcurrentlyInitStatsWithMemoryLimit|TestConcurrentlyInitStatsWithoutMemoryLimit|TestSkipStatsInitWithSkipInitStats|TestNonLiteInitStatsAndCheckTheLastTableStats)$' -count=1 -tags=intest,deadlock`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure and organization with enhanced helper utilities.
  * Optimized test execution configuration.
  * Expanded test coverage with new test scenarios for initialization statistics handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->