### PR TITLE
br: two-pass pre-split for PiTR log restore

### DIFF
--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -1556,14 +1556,14 @@ func (rc *LogClient) PreSplitRegions(
 
 	logIter, err := rc.LoadDMLFiles(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "pre-split: load DML files")
 	}
 
 	var fileCount int
 	startTime := time.Now()
 	for r := logIter.TryNext(ctx); !r.Finished; r = logIter.TryNext(ctx) {
 		if r.Err != nil {
-			return errors.Trace(r.Err)
+			return errors.Annotate(r.Err, "pre-split: iterate DML files")
 		}
 		file := r.Item
 		if file.IsMeta {
@@ -1600,7 +1600,7 @@ func (rc *LogClient) PreSplitRegions(
 	splitStart := time.Now()
 	accumulations := strategy.GetAccumulations()
 	if err := splitter.ExecuteRegions(ctx, accumulations); err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "pre-split: execute regions")
 	}
 	log.Info("pre-split: completed",
 		zap.Duration("split-took", time.Since(splitStart)),

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -1529,6 +1529,84 @@ func (rc *LogClient) WrapLogFilesIterWithSplitHelper(
 	return wrapper.WithSplit(ctx, logIter, strategy), nil
 }
 
+// PreSplitRegions performs a full pre-scan over ALL DML files and issues region
+// splits based on the total cumulative data volume. This avoids the problem where
+// per-batch splitting (4096 files at a time) resets accumulated sizes at each batch
+// boundary, producing insufficient splits for workloads that spread data across many
+// regions (e.g., secondary index builds).
+func (rc *LogClient) PreSplitRegions(
+	ctx context.Context,
+	rules map[int64]*restoreutils.RewriteRules,
+	g glue.Glue,
+	store kv.Storage,
+) error {
+	se, err := g.CreateSession(store)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	execCtx := se.GetSessionCtx().GetRestrictedSQLExecutor()
+	splitSize, splitKeys := utils.GetRegionSplitInfo(execCtx)
+	log.Info("pre-split: get split threshold from tikv config",
+		zap.Uint64("split-size", splitSize), zap.Int64("split-keys", splitKeys))
+
+	client := split.NewClient(rc.pdClient, rc.pdHTTPClient, rc.tlsConf, maxSplitKeysOnce, 3)
+	splitter := split.NewPipelineRegionsSplitter(client, splitSize, splitKeys)
+	strategy := split.NewBaseSplitStrategy(rules)
+
+	logIter, err := rc.LoadDMLFiles(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	var fileCount int
+	startTime := time.Now()
+	for r := logIter.TryNext(ctx); !r.Finished; r = logIter.TryNext(ctx) {
+		if r.Err != nil {
+			return errors.Trace(r.Err)
+		}
+		file := r.Item
+		if file.IsMeta {
+			continue
+		}
+		if _, exist := rules[file.TableId]; !exist {
+			continue
+		}
+		splitHelper, exist := strategy.TableSplitter[file.TableId]
+		if !exist {
+			splitHelper = split.NewSplitHelper()
+			strategy.TableSplitter[file.TableId] = splitHelper
+		}
+		splitHelper.Merge(split.Valued{
+			Key: split.Span{
+				StartKey: file.StartKey,
+				EndKey:   file.EndKey,
+			},
+			Value: split.Value{
+				Size:   file.Length,
+				Number: file.NumberOfEntries,
+			},
+		})
+		fileCount++
+	}
+	log.Info("pre-split: merged all files",
+		zap.Int("file-count", fileCount),
+		zap.Duration("merge-took", time.Since(startTime)))
+
+	if fileCount == 0 {
+		return nil
+	}
+
+	splitStart := time.Now()
+	accumulations := strategy.GetAccumulations()
+	if err := splitter.ExecuteRegions(ctx, accumulations); err != nil {
+		return errors.Trace(err)
+	}
+	log.Info("pre-split: completed",
+		zap.Duration("split-took", time.Since(splitStart)),
+		zap.Duration("total-took", time.Since(startTime)))
+	return nil
+}
+
 func WrapLogFilesIterWithCheckpointFailpoint(
 	v failpoint.Value,
 	logIter LogIter,

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -1529,6 +1529,26 @@ func (rc *LogClient) WrapLogFilesIterWithSplitHelper(
 	return wrapper.WithSplit(ctx, logIter, strategy), nil
 }
 
+// WrapLogFilesIterWithCheckpointFilter applies only the checkpoint skip filter to
+// the log files iterator, without performing any region splitting. Used when
+// pre-split has already been done and per-batch splitting is skipped, but
+// checkpoint-based file filtering still needs to happen.
+func (rc *LogClient) WrapLogFilesIterWithCheckpointFilter(
+	ctx context.Context,
+	logIter LogIter,
+	logCheckpointMetaManager checkpoint.LogMetaManagerT,
+	rules map[int64]*restoreutils.RewriteRules,
+	updateStatsFn func(uint64, uint64),
+) (LogIter, error) {
+	strategy, err := NewLogSplitStrategy(ctx, rc.useCheckpoint, logCheckpointMetaManager, rules, updateStatsFn, SplitFileThresholdDefault)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return iter.FilterOut(logIter, func(file *LogDataFileInfo) bool {
+		return strategy.ShouldSkip(file)
+	}), nil
+}
+
 // PreSplitRegions performs a full pre-scan over ALL DML files and issues region
 // splits based on the total cumulative data volume. This avoids the problem where
 // per-batch splitting (4096 files at a time) resets accumulated sizes at each batch

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -1522,7 +1522,7 @@ func (rc *LogClient) WrapLogFilesIterWithSplitHelper(
 	wrapper := restore.PipelineRestorerWrapper[*LogDataFileInfo]{
 		PipelineRegionsSplitter: split.NewPipelineRegionsSplitter(client, splitSize, splitKeys),
 	}
-	strategy, err := NewLogSplitStrategy(ctx, rc.useCheckpoint, logCheckpointMetaManager, rules, updateStatsFn)
+	strategy, err := NewLogSplitStrategy(ctx, rc.useCheckpoint, logCheckpointMetaManager, rules, updateStatsFn, SplitFileThresholdDefault)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -1542,16 +1542,9 @@ func (rc *LogClient) WrapLogFilesIterWithSplitHelper(
 func (rc *LogClient) PreSplitRegions(
 	ctx context.Context,
 	rules map[int64]*restoreutils.RewriteRules,
-	g glue.Glue,
-	store kv.Storage,
+	splitSize uint64,
+	splitKeys int64,
 ) (bool, error) {
-	se, err := g.CreateSession(store)
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	defer se.Close()
-	execCtx := se.GetSessionCtx().GetRestrictedSQLExecutor()
-	splitSize, splitKeys := utils.GetRegionSplitInfo(execCtx)
 	log.Info("pre-split: get split threshold from tikv config",
 		zap.Uint64("split-size", splitSize), zap.Int64("split-keys", splitKeys))
 

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -1544,6 +1544,7 @@ func (rc *LogClient) PreSplitRegions(
 	if err != nil {
 		return errors.Trace(err)
 	}
+	defer se.Close()
 	execCtx := se.GetSessionCtx().GetRestrictedSQLExecutor()
 	splitSize, splitKeys := utils.GetRegionSplitInfo(execCtx)
 	log.Info("pre-split: get split threshold from tikv config",

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -1534,15 +1534,20 @@ func (rc *LogClient) WrapLogFilesIterWithSplitHelper(
 // per-batch splitting (4096 files at a time) resets accumulated sizes at each batch
 // boundary, producing insufficient splits for workloads that spread data across many
 // regions (e.g., secondary index builds).
+//
+// Returns (true, nil) when splits were successfully issued; (false, nil) when
+// there are no DML files to split; (false, err) on any failure. Callers that
+// receive true should skip the fallback per-batch split to avoid redundant
+// split+scatter work.
 func (rc *LogClient) PreSplitRegions(
 	ctx context.Context,
 	rules map[int64]*restoreutils.RewriteRules,
 	g glue.Glue,
 	store kv.Storage,
-) error {
+) (bool, error) {
 	se, err := g.CreateSession(store)
 	if err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 	defer se.Close()
 	execCtx := se.GetSessionCtx().GetRestrictedSQLExecutor()
@@ -1556,14 +1561,14 @@ func (rc *LogClient) PreSplitRegions(
 
 	logIter, err := rc.LoadDMLFiles(ctx)
 	if err != nil {
-		return errors.Annotate(err, "pre-split: load DML files")
+		return false, errors.Annotate(err, "pre-split: load DML files")
 	}
 
 	var fileCount int
 	startTime := time.Now()
 	for r := logIter.TryNext(ctx); !r.Finished; r = logIter.TryNext(ctx) {
 		if r.Err != nil {
-			return errors.Annotate(r.Err, "pre-split: iterate DML files")
+			return false, errors.Annotate(r.Err, "pre-split: iterate DML files")
 		}
 		file := r.Item
 		if file.IsMeta {
@@ -1594,18 +1599,18 @@ func (rc *LogClient) PreSplitRegions(
 		zap.Duration("merge-took", time.Since(startTime)))
 
 	if fileCount == 0 {
-		return nil
+		return false, nil
 	}
 
 	splitStart := time.Now()
 	accumulations := strategy.GetAccumulations()
 	if err := splitter.ExecuteRegions(ctx, accumulations); err != nil {
-		return errors.Annotate(err, "pre-split: execute regions")
+		return false, errors.Annotate(err, "pre-split: execute regions")
 	}
 	log.Info("pre-split: completed",
 		zap.Duration("split-took", time.Since(splitStart)),
 		zap.Duration("total-took", time.Since(startTime)))
-	return nil
+	return true, nil
 }
 
 func WrapLogFilesIterWithCheckpointFailpoint(

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -1540,7 +1540,8 @@ func (rc *LogClient) WrapLogFilesIterWithCheckpointFilter(
 	rules map[int64]*restoreutils.RewriteRules,
 	updateStatsFn func(uint64, uint64),
 ) (LogIter, error) {
-	strategy, err := NewLogSplitStrategy(ctx, rc.useCheckpoint, logCheckpointMetaManager, rules, updateStatsFn, SplitFileThresholdDefault)
+	// splitFileThreshold is unused here: Accumulate is never called on this path.
+	strategy, err := NewLogSplitStrategy(ctx, rc.useCheckpoint, logCheckpointMetaManager, rules, updateStatsFn, 0)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1565,9 +1566,6 @@ func (rc *LogClient) PreSplitRegions(
 	splitSize uint64,
 	splitKeys int64,
 ) (bool, error) {
-	log.Info("pre-split: get split threshold from tikv config",
-		zap.Uint64("split-size", splitSize), zap.Int64("split-keys", splitKeys))
-
 	client := split.NewClient(rc.pdClient, rc.pdHTTPClient, rc.tlsConf, maxSplitKeysOnce, 3)
 	splitter := split.NewPipelineRegionsSplitter(client, splitSize, splitKeys)
 	strategy := split.NewBaseSplitStrategy(rules)

--- a/br/pkg/restore/log_client/client_test.go
+++ b/br/pkg/restore/log_client/client_test.go
@@ -1298,7 +1298,7 @@ func TestLogFilesIterWithSplitHelper(t *testing.T) {
 	w := restore.PipelineRestorerWrapper[*logclient.LogDataFileInfo]{
 		PipelineRegionsSplitter: split.NewPipelineRegionsSplitter(split.NewFakeSplitClient(), 144*1024*1024, 1440000),
 	}
-	s, err := logclient.NewLogSplitStrategy(ctx, false, nil, rewriteRulesMap, func(uint64, uint64) {})
+	s, err := logclient.NewLogSplitStrategy(ctx, false, nil, rewriteRulesMap, func(uint64, uint64) {}, logclient.SplitFileThresholdDefault)
 	require.NoError(t, err)
 	logIter := w.WithSplit(context.Background(), mockIter, s)
 	next := 0
@@ -1718,7 +1718,7 @@ func TestLogSplitStrategy(t *testing.T) {
 	}
 
 	// Create a log split strategy with the given rewrite rules.
-	strategy, err := logclient.NewLogSplitStrategy(ctx, false, nil, rules, func(u1, u2 uint64) {})
+	strategy, err := logclient.NewLogSplitStrategy(ctx, false, nil, rules, func(u1, u2 uint64) {}, logclient.SplitFileThresholdDefault)
 	require.NoError(t, err)
 
 	// Set up a mock strategy to control split behavior.

--- a/br/pkg/restore/log_client/log_split_strategy.go
+++ b/br/pkg/restore/log_client/log_split_strategy.go
@@ -64,30 +64,24 @@ func NewLogSplitStrategy(
 	}, nil
 }
 
-const splitFileThreshold = 1024 * 1024 // 1 MB
-
 func (ls *LogSplitStrategy) Accumulate(file *LogDataFileInfo) {
-	// skip accumulate file less than 1MB. to prevent too much split & scatter occurs
-	// and protect the performance of BTreeMap
-	if file.Length > splitFileThreshold {
-		ls.AccumulateCount += 1
-		splitHelper, exist := ls.TableSplitter[file.TableId]
-		if !exist {
-			splitHelper = split.NewSplitHelper()
-			ls.TableSplitter[file.TableId] = splitHelper
-		}
-
-		splitHelper.Merge(split.Valued{
-			Key: split.Span{
-				StartKey: file.StartKey,
-				EndKey:   file.EndKey,
-			},
-			Value: split.Value{
-				Size:   file.Length,
-				Number: file.NumberOfEntries,
-			},
-		})
+	ls.AccumulateCount += 1
+	splitHelper, exist := ls.TableSplitter[file.TableId]
+	if !exist {
+		splitHelper = split.NewSplitHelper()
+		ls.TableSplitter[file.TableId] = splitHelper
 	}
+
+	splitHelper.Merge(split.Valued{
+		Key: split.Span{
+			StartKey: file.StartKey,
+			EndKey:   file.EndKey,
+		},
+		Value: split.Value{
+			Size:   file.Length,
+			Number: file.NumberOfEntries,
+		},
+	})
 
 	ls.maybeUpdateMemUsage()
 }

--- a/br/pkg/restore/log_client/log_split_strategy.go
+++ b/br/pkg/restore/log_client/log_split_strategy.go
@@ -16,10 +16,16 @@ import (
 	"go.uber.org/zap"
 )
 
+// SplitFileThresholdDefault is the minimum file size considered for per-batch
+// split accumulation. Small files are excluded to avoid excessive split/scatter
+// calls and to protect BTreeMap performance.
+const SplitFileThresholdDefault = 1024 * 1024 // 1 MB
+
 type LogSplitStrategy struct {
 	*split.BaseSplitStrategy
 	checkpointSkipMap        *LogFilesSkipMap
 	checkpointFileProgressFn func(uint64, uint64)
+	splitFileThreshold       uint64
 
 	lastMemUsageUpdate time.Time
 }
@@ -32,6 +38,7 @@ func NewLogSplitStrategy(
 	logCheckpointMetaManager checkpoint.LogMetaManagerT,
 	rules map[int64]*restoreutils.RewriteRules,
 	updateStatsFn func(uint64, uint64),
+	splitFileThreshold uint64,
 ) (*LogSplitStrategy, error) {
 	downstreamIdset := make(map[int64]struct{})
 	for _, rule := range rules {
@@ -61,10 +68,14 @@ func NewLogSplitStrategy(
 		BaseSplitStrategy:        split.NewBaseSplitStrategy(rules),
 		checkpointSkipMap:        skipMap,
 		checkpointFileProgressFn: updateStatsFn,
+		splitFileThreshold:       splitFileThreshold,
 	}, nil
 }
 
 func (ls *LogSplitStrategy) Accumulate(file *LogDataFileInfo) {
+	if file.Length <= ls.splitFileThreshold {
+		return
+	}
 	ls.AccumulateCount += 1
 	splitHelper, exist := ls.TableSplitter[file.TableId]
 	if !exist {

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1693,6 +1693,12 @@ func restoreStream(
 		return errors.Trace(err)
 	}
 
+	// Pre-split regions based on total data volume across ALL files.
+	if err := client.PreSplitRegions(ctx, rewriteRules, g, mgr.GetStorage()); err != nil {
+		log.Warn("pre-split regions failed, continuing with per-batch splitting",
+			zap.Error(err))
+	}
+
 	logFilesIter, err := client.LoadDMLFiles(ctx)
 	if err != nil {
 		return errors.Trace(err)

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1693,10 +1693,18 @@ func restoreStream(
 		return errors.Trace(err)
 	}
 
+	se, err := g.CreateSession(mgr.GetStorage())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	execCtx := se.GetSessionCtx().GetRestrictedSQLExecutor()
+	splitSize, splitKeys := utils.GetRegionSplitInfo(execCtx)
+	log.Info("[Log Restore] get split threshold from tikv config", zap.Uint64("split-size", splitSize), zap.Int64("split-keys", splitKeys))
+
 	// Pre-split regions based on total data volume across ALL files.
 	// On success the pipeline-level per-batch split is skipped to avoid
 	// redundant split+scatter work (see WrapLogFilesIterWithSplitHelper below).
-	preSplitDone, preSplitErr := client.PreSplitRegions(ctx, rewriteRules, g, mgr.GetStorage())
+	preSplitDone, preSplitErr := client.PreSplitRegions(ctx, rewriteRules, splitSize, splitKeys)
 	if preSplitErr != nil {
 		log.Warn("pre-split regions failed, continuing with per-batch splitting",
 			zap.Error(preSplitErr))
@@ -1711,14 +1719,6 @@ func restoreStream(
 	if err != nil {
 		return err
 	}
-
-	se, err := g.CreateSession(mgr.GetStorage())
-	if err != nil {
-		return errors.Trace(err)
-	}
-	execCtx := se.GetSessionCtx().GetRestrictedSQLExecutor()
-	splitSize, splitKeys := utils.GetRegionSplitInfo(execCtx)
-	log.Info("[Log Restore] get split threshold from tikv config", zap.Uint64("split-size", splitSize), zap.Int64("split-keys", splitKeys))
 
 	// TODO: need keep the order of ssts for compatible of rewrite rules
 	// compacted ssts will set ts range for filter out irrelevant data

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1755,9 +1755,13 @@ func restoreStream(
 		logFilesIter = iter.WithEmitSizeTrace(logFilesIter, metrics.KVLogFileEmittedMemory.WithLabelValues("0-loaded"))
 		// Skip per-batch splitting when pre-split already covered all files;
 		// doing both passes would produce redundant split+scatter calls.
+		// Checkpoint filtering must still be applied on the pre-split path.
 		var logFilesIterWithSplit logclient.LogIter
 		if preSplitDone {
-			logFilesIterWithSplit = logFilesIter
+			logFilesIterWithSplit, err = client.WrapLogFilesIterWithCheckpointFilter(ctx, logFilesIter, cfg.logCheckpointMetaManager, rewriteRules, updateStatsWithCheckpoint)
+			if err != nil {
+				return errors.Trace(err)
+			}
 		} else {
 			logFilesIterWithSplit, err = client.WrapLogFilesIterWithSplitHelper(ctx, logFilesIter, cfg.logCheckpointMetaManager, rewriteRules, updateStatsWithCheckpoint, splitSize, splitKeys)
 			if err != nil {

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1694,9 +1694,12 @@ func restoreStream(
 	}
 
 	// Pre-split regions based on total data volume across ALL files.
-	if err := client.PreSplitRegions(ctx, rewriteRules, g, mgr.GetStorage()); err != nil {
+	// On success the pipeline-level per-batch split is skipped to avoid
+	// redundant split+scatter work (see WrapLogFilesIterWithSplitHelper below).
+	preSplitDone, preSplitErr := client.PreSplitRegions(ctx, rewriteRules, g, mgr.GetStorage())
+	if preSplitErr != nil {
 		log.Warn("pre-split regions failed, continuing with per-batch splitting",
-			zap.Error(err))
+			zap.Error(preSplitErr))
 	}
 
 	logFilesIter, err := client.LoadDMLFiles(ctx)
@@ -1750,9 +1753,16 @@ func restoreStream(
 		}
 
 		logFilesIter = iter.WithEmitSizeTrace(logFilesIter, metrics.KVLogFileEmittedMemory.WithLabelValues("0-loaded"))
-		logFilesIterWithSplit, err := client.WrapLogFilesIterWithSplitHelper(ctx, logFilesIter, cfg.logCheckpointMetaManager, rewriteRules, updateStatsWithCheckpoint, splitSize, splitKeys)
-		if err != nil {
-			return errors.Trace(err)
+		// Skip per-batch splitting when pre-split already covered all files;
+		// doing both passes would produce redundant split+scatter calls.
+		var logFilesIterWithSplit logclient.LogIter
+		if preSplitDone {
+			logFilesIterWithSplit = logFilesIter
+		} else {
+			logFilesIterWithSplit, err = client.WrapLogFilesIterWithSplitHelper(ctx, logFilesIter, cfg.logCheckpointMetaManager, rewriteRules, updateStatsWithCheckpoint, splitSize, splitKeys)
+			if err != nil {
+				return errors.Trace(err)
+			}
 		}
 		logFilesIterWithSplit = iter.WithEmitSizeTrace(logFilesIterWithSplit, metrics.KVLogFileEmittedMemory.WithLabelValues("1-split"))
 


### PR DESCRIPTION
## What problem does this PR solve?

Issue Number: ref #67309

The existing per-batch splitting in `LogSplitStrategy` processes files in batches of 4096, resetting accumulated region sizes at each batch boundary (`ResetAccumulations`). For workloads that spread data across many regions (e.g., secondary index builds), the per-region data accumulated within any single batch is far below the split threshold, so no splits are triggered.

This produces severely insufficient pre-splits (e.g., 22 instead of 200+), causing regions to grow past `coprocessor.region-max-size` during import. TiKV then triggers auto-splits that produce `EpochNotMatch` cascades and eventual restore failure.

## What is changed and how does it work?

Two changes:

1. **Remove the 1 MiB `splitFileThreshold` from `LogSplitStrategy.Accumulate`.** PiTR backup files are virtual sub-range files typically much smaller than 1 MiB. The threshold caused the split estimator to ignore most files, severely underestimating region sizes.

2. **Add `PreSplitRegions` method** that performs a full pre-scan over all DML file metadata (S3 metadata only, no data reads) before import begins, accumulating sizes across the entire dataset and executing splits once. This aligns with the two-pass approach already used by snapshot restore (`SortAndValidateFileRanges` → `SplitPoints` → `RestoreSSTFiles`). The call is non-fatal: on failure, falls through to existing per-batch splitting.

3. **Fix checkpoint resume with pre-split** (`br: apply checkpoint filter when per-batch split is skipped`): When pre-split succeeds and the per-batch split wrapper is bypassed, `WrapLogFilesIterWithSplitHelper` is never called, so checkpoint-based file filtering (via `LogSplitStrategy.ShouldSkip`) was also skipped. On checkpoint resume this caused already-processed files to pass through unfiltered, triggering the `"has files but not the files skipped before"` panic. Added `WrapLogFilesIterWithCheckpointFilter` which loads the checkpoint skip map and applies the filter without splitting; the `preSplitDone` path now calls this instead of using the raw iterator.

## Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

I ran the change on v8.5.2, rerunning previously failing PiTR restore. Observe the amount of splits during PiTR phase reduced from 300 -> 2, restore started to succeed. 

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Not deterministic logic
- [ ] Lacks unit tests
- [ ] Other

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features

Release note

<!-- bugfix, improvement or new feature need a release note -->

```release-note
br: fix insufficient region pre-splitting for PiTR log restore by performing a full-dataset pre-scan before import begins, so accumulated data volume is not reset at each per-batch boundary. Per-batch splitting is skipped when the pre-scan succeeds; falls back to per-batch splitting on error.
```