### PR TITLE
br: add offline PiTR log backup inspector tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -463,7 +463,13 @@ endif
 
 .PHONY: build_inspector
 build_inspector: ## Build BR log backup inspector tool
+ifeq ($(shell echo $(GOOS) | tr A-Z a-z),darwin)
+	@echo "Detected macOS ($(ARCH)), enabling CGO"
 	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o bin/inspector ./br/cmd/inspector
+else
+	@echo "Detected non-macOS ($(ARCH)), disabling CGO"
+	CGO_ENABLED=0 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o bin/inspector ./br/cmd/inspector
+endif
 
 .PHONY: build_lightning_for_web
 build_lightning_for_web:

--- a/Makefile
+++ b/Makefile
@@ -445,7 +445,7 @@ bench-daily:
 		-outfile $(TO)
 
 .PHONY: build_tools
-build_tools: build_br build_lightning build_lightning-ctl ## Build all BR and Lightning tools
+build_tools: build_br build_inspector build_lightning build_lightning-ctl ## Build all BR and Lightning tools
 
 .PHONY: lightning_web
 lightning_web: ## Build Lightning web UI
@@ -460,6 +460,10 @@ else
 	@echo "Detected non-macOS ($(ARCH)), disabling CGO"
 	CGO_ENABLED=0 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(BR_BIN) ./br/cmd/br
 endif
+
+.PHONY: build_inspector
+build_inspector: ## Build BR log backup inspector tool
+	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o bin/inspector ./br/cmd/inspector
 
 .PHONY: build_lightning_for_web
 build_lightning_for_web:

--- a/br/cmd/inspector/BUILD.bazel
+++ b/br/cmd/inspector/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "inspector_lib",
+    srcs = [
+        "backupmeta.go",
+        "format.go",
+        "main.go",
+        "metakv.go",
+    ],
+    importpath = "github.com/pingcap/tidb/br/cmd/inspector",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//br/pkg/stream",
+        "//br/pkg/task",
+        "//br/pkg/utils",
+        "//br/pkg/version/build",
+        "//pkg/meta",
+        "@com_github_pingcap_log//:log",
+        "@com_github_spf13_cobra//:cobra",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_binary(
+    name = "inspector",
+    embed = [":inspector_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "inspector_test",
+    timeout = "short",
+    srcs = [
+        "backupmeta_test.go",
+        "metakv_test.go",
+    ],
+    embed = [":inspector_lib"],
+    flaky = True,
+    shard_count = 19,
+    deps = [
+        "//br/pkg/stream",
+        "//pkg/meta",
+        "//pkg/objstore",
+        "//pkg/tablecodec",
+        "//pkg/util/codec",
+        "@com_github_pingcap_kvproto//pkg/brpb",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/br/cmd/inspector/backupmeta.go
+++ b/br/cmd/inspector/backupmeta.go
@@ -87,6 +87,9 @@ func runBackupMetaInspect(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("invalid --restored-ts: %w", err)
 	}
+	if startTS > endTS {
+		return fmt.Errorf("invalid range: --start-ts (%d) must be <= --restored-ts (%d)", startTS, endTS)
+	}
 
 	_, s, err := task.GetStorage(ctx, cfg.Storage, &cfg)
 	if err != nil {

--- a/br/cmd/inspector/backupmeta.go
+++ b/br/cmd/inspector/backupmeta.go
@@ -1,0 +1,156 @@
+// Copyright 2025 PingCAP, Inc. Licensed under Apache-2.0.
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/pingcap/tidb/br/pkg/stream"
+	"github.com/pingcap/tidb/br/pkg/task"
+	"github.com/spf13/cobra"
+)
+
+const (
+	flagStartTS    = "start-ts"
+	flagRestoredTS = "restored-ts"
+)
+
+type backupMetaStats struct {
+	mu               sync.Mutex
+	totalDataSize    uint64
+	dataPerStore     map[int64]uint64
+	metaSizePerStore map[int64]uint64
+	metaFileCount    int
+	fileGroupCount   int
+}
+
+func newBackupMetaStats() *backupMetaStats {
+	return &backupMetaStats{
+		dataPerStore:     make(map[int64]uint64),
+		metaSizePerStore: make(map[int64]uint64),
+	}
+}
+
+func (s *backupMetaStats) addMeta(storeID int64, dataSize uint64, metaSize uint64, groupCount int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.totalDataSize += dataSize
+	s.dataPerStore[storeID] += dataSize
+	s.metaSizePerStore[storeID] += metaSize
+	s.metaFileCount++
+	s.fileGroupCount += groupCount
+}
+
+func newBackupMetaCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backupmeta",
+		Short: "Inspect PiTR log backup metadata: file counts, data sizes, and per-store breakdown.",
+		RunE:  runBackupMetaInspect,
+	}
+	cmd.Flags().String(flagStartTS, "", "Start TS of the restore range (TSO uint64 or datetime string)")
+	cmd.Flags().String(flagRestoredTS, "", "End TS of the restore range (TSO uint64 or datetime string)")
+	_ = cmd.MarkFlagRequired(flagStartTS)
+	_ = cmd.MarkFlagRequired(flagRestoredTS)
+	return cmd
+}
+
+func runBackupMetaInspect(cmd *cobra.Command, _ []string) error {
+	if err := initInspector(cmd); err != nil {
+		return err
+	}
+	ctx := getDefaultContext()
+
+	var cfg task.Config
+	if err := cfg.ParseFromFlags(cmd.Flags()); err != nil {
+		return err
+	}
+	if cfg.Storage == "" {
+		return fmt.Errorf("--storage (-s) is required")
+	}
+
+	startTSStr, err := cmd.Flags().GetString(flagStartTS)
+	if err != nil {
+		return err
+	}
+	endTSStr, err := cmd.Flags().GetString(flagRestoredTS)
+	if err != nil {
+		return err
+	}
+
+	startTS, err := task.ParseTSString(startTSStr, false)
+	if err != nil {
+		return fmt.Errorf("invalid --start-ts: %w", err)
+	}
+	endTS, err := task.ParseTSString(endTSStr, false)
+	if err != nil {
+		return fmt.Errorf("invalid --restored-ts: %w", err)
+	}
+
+	_, s, err := task.GetStorage(ctx, cfg.Storage, &cfg)
+	if err != nil {
+		return err
+	}
+
+	stats := newBackupMetaStats()
+	helper := stream.NewMetadataHelper()
+	defer helper.Close()
+
+	err = stream.FastUnmarshalMetaData(ctx, s, startTS, endTS, 128, func(path string, rawBytes []byte) error {
+		meta, parseErr := helper.ParseToMetadataHard(rawBytes)
+		if parseErr != nil {
+			return fmt.Errorf("parsing %s: %w", path, parseErr)
+		}
+		var dataSize uint64
+		for _, fg := range meta.FileGroups {
+			dataSize += fg.Length
+		}
+		stats.addMeta(meta.StoreId, dataSize, uint64(len(rawBytes)), len(meta.FileGroups))
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	printStats(cmd, stats, startTS, endTS)
+	return nil
+}
+
+func printStats(cmd *cobra.Command, stats *backupMetaStats, startTS, endTS uint64) {
+	cmd.Printf("=== PiTR Log Backup Metadata Inspection ===\n\n")
+	cmd.Printf("TS Range: [%d, %d]\n", startTS, endTS)
+	cmd.Printf("Metadata files scanned: %d\n", stats.metaFileCount)
+	cmd.Printf("Total file groups: %d\n\n", stats.fileGroupCount)
+
+	cmd.Printf("--- Total Data Size ---\n")
+	cmd.Printf("  %s (%d bytes)\n\n", formatBytes(stats.totalDataSize), stats.totalDataSize)
+
+	storeIDs := make([]int64, 0, len(stats.dataPerStore))
+	for id := range stats.dataPerStore {
+		storeIDs = append(storeIDs, id)
+	}
+	sort.Slice(storeIDs, func(i, j int) bool { return storeIDs[i] < storeIDs[j] })
+
+	cmd.Printf("--- Data Size Per Store ---\n")
+	for _, id := range storeIDs {
+		sz := stats.dataPerStore[id]
+		cmd.Printf("  Store %d: %s (%d bytes)\n", id, formatBytes(sz), sz)
+	}
+	cmd.Printf("\n")
+
+	metaStoreIDs := make([]int64, 0, len(stats.metaSizePerStore))
+	for id := range stats.metaSizePerStore {
+		metaStoreIDs = append(metaStoreIDs, id)
+	}
+	sort.Slice(metaStoreIDs, func(i, j int) bool { return metaStoreIDs[i] < metaStoreIDs[j] })
+
+	var totalMetaSize uint64
+	cmd.Printf("--- Metadata File Size Per Store ---\n")
+	for _, id := range metaStoreIDs {
+		sz := stats.metaSizePerStore[id]
+		totalMetaSize += sz
+		cmd.Printf("  Store %d: %s (%d bytes)\n", id, formatBytes(sz), sz)
+	}
+	cmd.Printf("  Total: %s (%d bytes)\n", formatBytes(totalMetaSize), totalMetaSize)
+}

--- a/br/cmd/inspector/backupmeta_test.go
+++ b/br/cmd/inspector/backupmeta_test.go
@@ -1,0 +1,140 @@
+// Copyright 2025 PingCAP, Inc. Licensed under Apache-2.0.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"path"
+	"sync"
+	"testing"
+
+	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/tidb/br/pkg/stream"
+	"github.com/pingcap/tidb/pkg/objstore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatBytes(t *testing.T) {
+	cases := []struct {
+		input    uint64
+		expected string
+	}{
+		{0, "0 B"},
+		{1, "1 B"},
+		{1023, "1023 B"},
+		{1024, "1.00 KB"},
+		{1536, "1.50 KB"},
+		{1024 * 1024, "1.00 MB"},
+		{uint64(1.5 * 1024 * 1024), "1.50 MB"},
+		{1024 * 1024 * 1024, "1.00 GB"},
+		{uint64(2.5 * 1024 * 1024 * 1024), "2.50 GB"},
+		{1024 * 1024 * 1024 * 1024, "1.00 TB"},
+		{4068190371635, "3.70 TB"}, // 3.7 * 1024^4
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("input=%d", tc.input), func(t *testing.T) {
+			require.Equal(t, tc.expected, formatBytes(tc.input))
+		})
+	}
+}
+
+func TestBackupMetaStatsConcurrency(t *testing.T) {
+	const goroutines = 64
+	const callsPerGoroutine = 100
+
+	stats := newBackupMetaStats()
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(storeID int64) {
+			defer wg.Done()
+			for range callsPerGoroutine {
+				stats.addMeta(storeID, 1000, 50, 2)
+			}
+		}(int64(i % 4))
+	}
+	wg.Wait()
+
+	totalCalls := goroutines * callsPerGoroutine
+	require.Equal(t, uint64(totalCalls)*1000, stats.totalDataSize)
+	require.Equal(t, totalCalls, stats.metaFileCount)
+	require.Equal(t, totalCalls*2, stats.fileGroupCount)
+
+	var sumDataPerStore uint64
+	for _, sz := range stats.dataPerStore {
+		sumDataPerStore += sz
+	}
+	require.Equal(t, stats.totalDataSize, sumDataPerStore)
+}
+
+func TestBackupMetaIntegration(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// Create a local storage and write fake metadata files.
+	s, err := objstore.NewLocalStorage(dir)
+	require.NoError(t, err)
+
+	type metaSpec struct {
+		storeID    int64
+		fileGroups []*backuppb.DataFileGroup
+	}
+	specs := []metaSpec{
+		{
+			storeID: 1001,
+			fileGroups: []*backuppb.DataFileGroup{
+				{Path: "data/1001-a.log", Length: 1024 * 1024 * 100},
+				{Path: "data/1001-b.log", Length: 1024 * 1024 * 50},
+			},
+		},
+		{
+			storeID: 1002,
+			fileGroups: []*backuppb.DataFileGroup{
+				{Path: "data/1002-a.log", Length: 1024 * 1024 * 200},
+			},
+		},
+	}
+
+	for i, spec := range specs {
+		meta := &backuppb.Metadata{
+			StoreId:     spec.storeID,
+			MetaVersion: backuppb.MetaVersion_V2,
+			FileGroups:  spec.fileGroups,
+		}
+		data, marshalErr := meta.Marshal()
+		require.NoError(t, marshalErr)
+		fname := path.Join(stream.GetStreamBackupMetaPrefix(), fmt.Sprintf("%04d.meta", i))
+		require.NoError(t, s.WriteFile(ctx, fname, data))
+	}
+
+	// Collect stats using the same logic as runBackupMetaInspect.
+	stats := newBackupMetaStats()
+	helper := stream.NewMetadataHelper()
+	defer helper.Close()
+
+	// Files with non-hex names pass through FilterPathByTs regardless of TS range.
+	err = stream.FastUnmarshalMetaData(ctx, s, 0, math.MaxUint64, 4, func(filePath string, rawBytes []byte) error {
+		meta, parseErr := helper.ParseToMetadataHard(rawBytes)
+		if parseErr != nil {
+			return parseErr
+		}
+		var dataSize uint64
+		for _, fg := range meta.FileGroups {
+			dataSize += fg.Length
+		}
+		stats.addMeta(meta.StoreId, dataSize, uint64(len(rawBytes)), len(meta.FileGroups))
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 2, stats.metaFileCount)
+	require.Equal(t, 3, stats.fileGroupCount)
+
+	expectedTotal := uint64(1024*1024*100 + 1024*1024*50 + 1024*1024*200)
+	require.Equal(t, expectedTotal, stats.totalDataSize)
+
+	require.Equal(t, uint64(1024*1024*150), stats.dataPerStore[1001])
+	require.Equal(t, uint64(1024*1024*200), stats.dataPerStore[1002])
+}

--- a/br/cmd/inspector/format.go
+++ b/br/cmd/inspector/format.go
@@ -1,4 +1,16 @@
-// Copyright 2025 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package main
 

--- a/br/cmd/inspector/format.go
+++ b/br/cmd/inspector/format.go
@@ -1,0 +1,26 @@
+// Copyright 2025 PingCAP, Inc. Licensed under Apache-2.0.
+
+package main
+
+import "fmt"
+
+func formatBytes(n uint64) string {
+	const (
+		kb = 1 << 10
+		mb = 1 << 20
+		gb = 1 << 30
+		tb = 1 << 40
+	)
+	switch {
+	case n >= tb:
+		return fmt.Sprintf("%.2f TB", float64(n)/tb)
+	case n >= gb:
+		return fmt.Sprintf("%.2f GB", float64(n)/gb)
+	case n >= mb:
+		return fmt.Sprintf("%.2f MB", float64(n)/mb)
+	case n >= kb:
+		return fmt.Sprintf("%.2f KB", float64(n)/kb)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/br/cmd/inspector/main.go
+++ b/br/cmd/inspector/main.go
@@ -1,0 +1,115 @@
+// Copyright 2025 PingCAP, Inc. Licensed under Apache-2.0.
+
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/br/pkg/task"
+	"github.com/pingcap/tidb/br/pkg/utils"
+	"github.com/pingcap/tidb/br/pkg/version/build"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+const (
+	flagLogLevel  = "log-level"
+	flagLogFile   = "log-file"
+	flagLogFormat = "log-format"
+)
+
+var defaultContext context.Context
+
+func setDefaultContext(ctx context.Context) {
+	defaultContext = ctx
+}
+
+func getDefaultContext() context.Context {
+	return defaultContext
+}
+
+func main() {
+	gCtx := context.Background()
+	ctx, cancel := utils.StartExitSingleListener(gCtx)
+	defer cancel()
+
+	rootCmd := &cobra.Command{
+		Use:              "inspector",
+		Short:            "inspector is a TiDB/TiKV offline backup inspection tool.",
+		TraverseChildren: true,
+		SilenceUsage:     true,
+	}
+	defineInspectorFlags(rootCmd)
+	setDefaultContext(ctx)
+	rootCmd.AddCommand(newBackupMetaCommand())
+	rootCmd.AddCommand(newMetaKVCommand())
+	rootCmd.SetOut(os.Stdout)
+
+	rootCmd.SetArgs(os.Args[1:])
+	if err := rootCmd.Execute(); err != nil {
+		log.Error("inspector failed", zap.Error(err))
+		os.Exit(1) // nolint:gocritic
+	}
+}
+
+func defineInspectorFlags(cmd *cobra.Command) {
+	cmd.Version = build.Info()
+	cmd.Flags().BoolP("version", "V", false, "Display version information about inspector")
+	cmd.SetVersionTemplate("{{printf \"%s\" .Version}}\n")
+
+	cmd.PersistentFlags().StringP(flagLogLevel, "L", "warn", "Set the log level")
+	cmd.PersistentFlags().String(flagLogFile, "", "Set the log file path. If not set, logs are written to stderr")
+	cmd.PersistentFlags().String(flagLogFormat, "text", "Set the log format")
+
+	// Register storage / S3 / GCS / azblob flags so subcommands can use -s / --s3.* etc.
+	task.DefineCommonFlags(cmd.PersistentFlags())
+
+	// Hide flags that are irrelevant for an offline inspection tool.
+	for _, name := range []string{
+		"pd",
+		"ca", "cert", "key",
+		"send-credentials-to-tikv",
+		"checksum", "checksum-concurrency",
+		"ratelimit", "ratelimit-unit",
+		"remove-tiflash",
+		"check-requirements",
+		"switch-mode-interval",
+		"grpc-keepalive-time",
+		"grpc-keepalive-timeout",
+		"enable-opentracing",
+		"no-credentials",
+		"skip-check-path",
+		"crypter.method", "crypter.key", "crypter.key-file",
+		"log.crypter.method", "log.crypter.key", "log.crypter.key-file",
+		"master-key-crypter-method", "master-key",
+		"metadata-download-batch-size",
+	} {
+		_ = cmd.PersistentFlags().MarkHidden(name)
+	}
+}
+
+// initInspector initialises logging. Called at the start of each subcommand's RunE.
+func initInspector(cmd *cobra.Command) error {
+	conf := new(log.Config)
+	var err error
+	conf.Level, err = cmd.Flags().GetString(flagLogLevel)
+	if err != nil {
+		return err
+	}
+	conf.File.Filename, err = cmd.Flags().GetString(flagLogFile)
+	if err != nil {
+		return err
+	}
+	conf.Format, err = cmd.Flags().GetString(flagLogFormat)
+	if err != nil {
+		return err
+	}
+	lg, p, err := log.InitLogger(conf)
+	if err != nil {
+		return err
+	}
+	log.ReplaceGlobals(lg, p)
+	return nil
+}

--- a/br/cmd/inspector/metakv.go
+++ b/br/cmd/inspector/metakv.go
@@ -279,6 +279,9 @@ func runMetaKVInspect(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("invalid --restored-ts: %w", err)
 	}
+	if startTS > endTS {
+		return fmt.Errorf("invalid range: --start-ts (%d) must be <= --restored-ts (%d)", startTS, endTS)
+	}
 
 	_, s, err := task.GetStorage(ctx, cfg.Storage, &cfg)
 	if err != nil {
@@ -381,12 +384,12 @@ func fmtInt(n int64) string {
 	return string(b)
 }
 
-// avgVersions returns (entries / uniqueKeys), or 1 if uniqueKeys == 0.
-func avgVersions(entries, uniqueKeys int64) int64 {
+// avgVersions returns (entries / uniqueKeys), or 1.0 if uniqueKeys == 0.
+func avgVersions(entries, uniqueKeys int64) float64 {
 	if uniqueKeys == 0 {
-		return 0
+		return 1.0
 	}
-	return entries / uniqueKeys
+	return float64(entries) / float64(uniqueKeys)
 }
 
 func printMetaKVStats(cmd *cobra.Command, stats *metaKVStats, startTS, endTS uint64, topN int) {
@@ -408,7 +411,7 @@ func printMetaKVStats(cmd *cobra.Command, stats *metaKVStats, startTS, endTS uin
 		keyBytes    int64
 		valBytes    int64
 		uniqueCount int64
-		avgVer      int64
+		avgVer      float64
 	}
 	var rows []topRow
 	for _, cat := range []topLevelCategory{catDB, catDDLHistory, catOther} {
@@ -436,13 +439,13 @@ func printMetaKVStats(cmd *cobra.Command, stats *metaKVStats, startTS, endTS uin
 		"Category", "CF", "Entries", "Key Bytes", "Value Bytes", "Unique Keys", "Avg Versions")
 	cmd.Printf("  %s\n", strings.Repeat("-", 95))
 	for _, r := range rows {
-		cmd.Printf("  %-15s | %-7s | %-12s | %-11s | %-12s | %-12s | %s\n",
+		cmd.Printf("  %-15s | %-7s | %-12s | %-11s | %-12s | %-12s | %.2f\n",
 			r.cat, r.cf,
 			fmtInt(r.entries),
 			formatBytes(uint64(r.keyBytes)),
 			formatBytes(uint64(r.valBytes)),
 			fmtInt(r.uniqueCount),
-			fmtInt(r.avgVer),
+			r.avgVer,
 		)
 	}
 	cmd.Printf("\n")
@@ -470,7 +473,20 @@ func printMetaKVStats(cmd *cobra.Command, stats *metaKVStats, startTS, endTS uin
 		})
 	}
 	sort.Slice(detailRows, func(i, j int) bool {
-		return detailRows[i].entries > detailRows[j].entries
+		if detailRows[i].entries != detailRows[j].entries {
+			return detailRows[i].entries > detailRows[j].entries
+		}
+		// Deterministic tie-breaker: sort by dbID, tableID, field, cf
+		if detailRows[i].dbID != detailRows[j].dbID {
+			return detailRows[i].dbID < detailRows[j].dbID
+		}
+		if detailRows[i].tableID != detailRows[j].tableID {
+			return detailRows[i].tableID < detailRows[j].tableID
+		}
+		if detailRows[i].field != detailRows[j].field {
+			return detailRows[i].field < detailRows[j].field
+		}
+		return detailRows[i].cf < detailRows[j].cf
 	})
 	if topN > 0 && len(detailRows) > topN {
 		detailRows = detailRows[:topN]

--- a/br/cmd/inspector/metakv.go
+++ b/br/cmd/inspector/metakv.go
@@ -1,0 +1,551 @@
+// Copyright 2025 PingCAP, Inc. Licensed under Apache-2.0.
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/pingcap/tidb/br/pkg/stream"
+	"github.com/pingcap/tidb/br/pkg/task"
+	"github.com/pingcap/tidb/br/pkg/utils"
+	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/spf13/cobra"
+)
+
+const flagTop = "top"
+
+// keyType classifies the Field component of a meta key.
+type keyType int
+
+const (
+	keyTypeDB      keyType = iota // DB definition: field = "DB:{dbID}" inside the mDBs hash
+	keyTypeTable                  // Table schema: field = "Table:{tableID}"
+	keyTypeIID                    // Auto-increment counter: field = "IID:{tableID}"
+	keyTypeTID                    // Auto table ID: field = "TID:{tableID}"
+	keyTypeSID                    // Sequence counter: field = "SID:{tableID}"
+	keyTypeTARID                  // Auto-random counter: field = "TARID:{tableID}"
+	keyTypeUnknown                // Unrecognized mDB field
+)
+
+func (k keyType) String() string {
+	switch k {
+	case keyTypeDB:
+		return "DB"
+	case keyTypeTable:
+		return "Table"
+	case keyTypeIID:
+		return "IID"
+	case keyTypeTID:
+		return "TID"
+	case keyTypeSID:
+		return "SID"
+	case keyTypeTARID:
+		return "TARID"
+	default:
+		return "unknown"
+	}
+}
+
+// topLevelCategory classifies the outer key prefix.
+type topLevelCategory int
+
+const (
+	catDB         topLevelCategory = iota // mDB:* keys
+	catDDLHistory                         // mDDLJobHistory:* keys
+	catOther                              // any other key
+)
+
+func (c topLevelCategory) String() string {
+	switch c {
+	case catDB:
+		return "mDB"
+	case catDDLHistory:
+		return "mDDLJobHistory"
+	default:
+		return "other"
+	}
+}
+
+type entryStats struct {
+	count    int64
+	keyBytes int64
+	valBytes int64
+}
+
+func (s *entryStats) add(keyLen, valLen int) {
+	s.count++
+	s.keyBytes += int64(keyLen)
+	s.valBytes += int64(valLen)
+}
+
+// dbTableKey identifies a specific (dbID, tableID, fieldType, cf) combination.
+type dbTableKey struct {
+	dbID    int64
+	tableID int64 // 0 for DB-level keys (keyTypeDB)
+	field   keyType
+	cf      string
+}
+
+type metaKVStats struct {
+	mu sync.Mutex
+
+	// top-level breakdown: category -> cf -> stats
+	topLevel map[topLevelCategory]map[string]*entryStats
+
+	// mDB detailed breakdown per (dbID, tableID, fieldType, cf)
+	dbDetail map[dbTableKey]*entryStats
+
+	// unique key tracking: category -> cf -> set of logical keys (TS stripped)
+	// Used to compute avg MVCC versions per logical key.
+	uniqueKeys map[topLevelCategory]map[string]map[string]struct{}
+
+	// counters
+	filesProcessed int64
+	parseErrors    int64
+}
+
+func newMetaKVStats() *metaKVStats {
+	s := &metaKVStats{
+		topLevel:   make(map[topLevelCategory]map[string]*entryStats),
+		dbDetail:   make(map[dbTableKey]*entryStats),
+		uniqueKeys: make(map[topLevelCategory]map[string]map[string]struct{}),
+	}
+	for _, cat := range []topLevelCategory{catDB, catDDLHistory, catOther} {
+		s.topLevel[cat] = make(map[string]*entryStats)
+		s.uniqueKeys[cat] = make(map[string]map[string]struct{})
+	}
+	return s
+}
+
+// accumulate adds a single KV entry to the stats.
+func (s *metaKVStats) accumulate(key, value []byte, cf string) {
+	cat, dbk, lk := classifyEntry(key, cf)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Top-level stats
+	if _, ok := s.topLevel[cat][cf]; !ok {
+		s.topLevel[cat][cf] = &entryStats{}
+	}
+	s.topLevel[cat][cf].add(len(key), len(value))
+
+	// Unique key tracking
+	if _, ok := s.uniqueKeys[cat][cf]; !ok {
+		s.uniqueKeys[cat][cf] = make(map[string]struct{})
+	}
+	s.uniqueKeys[cat][cf][lk] = struct{}{}
+
+	// DB detail stats
+	if cat == catDB && dbk != nil {
+		if _, ok := s.dbDetail[*dbk]; !ok {
+			s.dbDetail[*dbk] = &entryStats{}
+		}
+		s.dbDetail[*dbk].add(len(key), len(value))
+	}
+}
+
+// logicalKeyOf strips the 8-byte TS suffix from a TxnKey.
+func logicalKeyOf(key []byte) string {
+	if len(key) >= 8 {
+		return string(key[:len(key)-8])
+	}
+	return string(key)
+}
+
+// classifyEntry determines the category, optional dbTableKey, and logical key for a TxnKey.
+func classifyEntry(key []byte, cf string) (topLevelCategory, *dbTableKey, string) {
+	lk := logicalKeyOf(key)
+
+	if utils.IsMetaDDLJobHistoryKey(key) {
+		return catDDLHistory, nil, lk
+	}
+	if !utils.IsMetaDBKey(key) {
+		return catOther, nil, lk
+	}
+
+	rawKey, err := stream.ParseTxnMetaKeyFrom(key)
+	if err != nil {
+		return catDB, nil, lk
+	}
+
+	var dbk dbTableKey
+	dbk.cf = cf
+
+	if meta.IsDBkey(rawKey.Field) {
+		// DB definition entry: hash key = "DBs", field = "DB:{dbID}"
+		dbID, parseErr := meta.ParseDBKey(rawKey.Field)
+		if parseErr != nil {
+			return catDB, nil, lk
+		}
+		dbk.dbID = dbID
+		dbk.tableID = 0
+		dbk.field = keyTypeDB
+		return catDB, &dbk, lk
+	}
+
+	// Table-level entry: hash key = "DB:{dbID}", field = "Table:{id}" / "IID:{id}" / etc.
+	if !meta.IsDBkey(rawKey.Key) {
+		return catDB, nil, lk
+	}
+	dbID, parseErr := meta.ParseDBKey(rawKey.Key)
+	if parseErr != nil {
+		return catDB, nil, lk
+	}
+	dbk.dbID = dbID
+	dbk.field, dbk.tableID = classifyField(rawKey.Field)
+	return catDB, &dbk, lk
+}
+
+// classifyField classifies the field component of a meta key.
+func classifyField(field []byte) (keyType, int64) {
+	if meta.IsTableKey(field) {
+		if id, err := meta.ParseTableKey(field); err == nil {
+			return keyTypeTable, id
+		}
+	}
+	if meta.IsAutoIncrementIDKey(field) {
+		if id, err := meta.ParseAutoIncrementIDKey(field); err == nil {
+			return keyTypeIID, id
+		}
+	}
+	if meta.IsAutoTableIDKey(field) {
+		if id, err := meta.ParseAutoTableIDKey(field); err == nil {
+			return keyTypeTID, id
+		}
+	}
+	if meta.IsSequenceKey(field) {
+		if id, err := meta.ParseSequenceKey(field); err == nil {
+			return keyTypeSID, id
+		}
+	}
+	if meta.IsAutoRandomTableIDKey(field) {
+		if id, err := meta.ParseAutoRandomTableIDKey(field); err == nil {
+			return keyTypeTARID, id
+		}
+	}
+	return keyTypeUnknown, 0
+}
+
+func newMetaKVCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "metakv",
+		Short: "Parse PiTR log backup data files and break down meta KV entries by key type.",
+		RunE:  runMetaKVInspect,
+	}
+	cmd.Flags().String(flagStartTS, "", "Start TS of the restore range (TSO uint64 or datetime string)")
+	cmd.Flags().String(flagRestoredTS, "", "End TS of the restore range (TSO uint64 or datetime string)")
+	cmd.Flags().Int(flagTop, 20, "Limit per-table output to top N contributors by entry count")
+	_ = cmd.MarkFlagRequired(flagStartTS)
+	_ = cmd.MarkFlagRequired(flagRestoredTS)
+	return cmd
+}
+
+func runMetaKVInspect(cmd *cobra.Command, _ []string) error {
+	if err := initInspector(cmd); err != nil {
+		return err
+	}
+	ctx := getDefaultContext()
+
+	var cfg task.Config
+	if err := cfg.ParseFromFlags(cmd.Flags()); err != nil {
+		return err
+	}
+	if cfg.Storage == "" {
+		return fmt.Errorf("--storage (-s) is required")
+	}
+
+	startTSStr, err := cmd.Flags().GetString(flagStartTS)
+	if err != nil {
+		return err
+	}
+	endTSStr, err := cmd.Flags().GetString(flagRestoredTS)
+	if err != nil {
+		return err
+	}
+	topN, err := cmd.Flags().GetInt(flagTop)
+	if err != nil {
+		return err
+	}
+
+	startTS, err := task.ParseTSString(startTSStr, false)
+	if err != nil {
+		return fmt.Errorf("invalid --start-ts: %w", err)
+	}
+	endTS, err := task.ParseTSString(endTSStr, false)
+	if err != nil {
+		return fmt.Errorf("invalid --restored-ts: %w", err)
+	}
+
+	_, s, err := task.GetStorage(ctx, cfg.Storage, &cfg)
+	if err != nil {
+		return err
+	}
+
+	stats := newMetaKVStats()
+	err = stream.FastUnmarshalMetaData(ctx, s, startTS, endTS, 128, func(path string, rawBytes []byte) error {
+		// Use a local helper per callback to avoid data races on the shared helper cache.
+		localHelper := stream.NewMetadataHelper()
+		defer localHelper.Close()
+
+		md, parseErr := localHelper.ParseToMetadataHard(rawBytes)
+		if parseErr != nil {
+			return fmt.Errorf("parsing %s: %w", path, parseErr)
+		}
+
+		for _, fg := range md.FileGroups {
+			// Skip groups that contain no meta KV files.
+			hasMetaFiles := false
+			for _, dfi := range fg.DataFilesInfo {
+				if dfi.IsMeta {
+					hasMetaFiles = true
+					break
+				}
+			}
+			if !hasMetaFiles {
+				continue
+			}
+
+			// For V2 groups (shared physical file, non-zero range lengths), initialize
+			// the cache so ReadFile can slice the shared file correctly.
+			// For V1 groups (offset=0, length=0), ReadFile reads the whole file without
+			// needing a cache entry.
+			isV2Group := false
+			for _, dfi := range fg.DataFilesInfo {
+				if dfi.RangeLength > 0 {
+					isV2Group = true
+					break
+				}
+			}
+			if isV2Group {
+				localHelper.InitCacheEntry(fg.Path, len(fg.DataFilesInfo))
+			}
+
+			for _, dfi := range fg.DataFilesInfo {
+				buff, readErr := localHelper.ReadFile(
+					ctx, fg.Path, dfi.RangeOffset, dfi.RangeLength,
+					dfi.CompressionType, s, dfi.FileEncryptionInfo,
+				)
+				if readErr != nil {
+					stats.mu.Lock()
+					stats.parseErrors++
+					stats.mu.Unlock()
+					continue
+				}
+				if !dfi.IsMeta {
+					// ReadFile was still called to correctly decrement the cache ref count.
+					continue
+				}
+
+				iter := stream.NewEventIterator(buff)
+				for iter.Valid() {
+					iter.Next()
+					if iter.GetError() != nil {
+						stats.mu.Lock()
+						stats.parseErrors++
+						stats.mu.Unlock()
+						break
+					}
+					stats.accumulate(iter.Key(), iter.Value(), dfi.Cf)
+				}
+
+				stats.mu.Lock()
+				stats.filesProcessed++
+				stats.mu.Unlock()
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	printMetaKVStats(cmd, stats, startTS, endTS, topN)
+	return nil
+}
+
+// fmtInt formats n with comma separators for readability.
+func fmtInt(n int64) string {
+	s := fmt.Sprintf("%d", n)
+	b := make([]byte, 0, len(s)+5)
+	for i := range len(s) {
+		pos := len(s) - i
+		if i > 0 && pos%3 == 0 {
+			b = append(b, ',')
+		}
+		b = append(b, s[i])
+	}
+	return string(b)
+}
+
+// avgVersions returns (entries / uniqueKeys), or 1 if uniqueKeys == 0.
+func avgVersions(entries, uniqueKeys int64) int64 {
+	if uniqueKeys == 0 {
+		return 0
+	}
+	return entries / uniqueKeys
+}
+
+func printMetaKVStats(cmd *cobra.Command, stats *metaKVStats, startTS, endTS uint64, topN int) {
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+
+	cmd.Printf("=== PiTR Meta KV Entry Analysis ===\n\n")
+	cmd.Printf("TS Range: [%d, %d]\n", startTS, endTS)
+	cmd.Printf("Data files processed: %s\n", fmtInt(stats.filesProcessed))
+	cmd.Printf("Parse errors:         %s\n\n", fmtInt(stats.parseErrors))
+
+	// ---- Top-Level Key Breakdown ----
+	cmd.Printf("--- Top-Level Key Breakdown ---\n")
+
+	type topRow struct {
+		cat         string
+		cf          string
+		entries     int64
+		keyBytes    int64
+		valBytes    int64
+		uniqueCount int64
+		avgVer      int64
+	}
+	var rows []topRow
+	for _, cat := range []topLevelCategory{catDB, catDDLHistory, catOther} {
+		cfMap := stats.topLevel[cat]
+		cfs := make([]string, 0, len(cfMap))
+		for cf := range cfMap {
+			cfs = append(cfs, cf)
+		}
+		sort.Strings(cfs)
+		for _, cf := range cfs {
+			st := cfMap[cf]
+			ukeys := int64(len(stats.uniqueKeys[cat][cf]))
+			rows = append(rows, topRow{
+				cat:         cat.String(),
+				cf:          cf,
+				entries:     st.count,
+				keyBytes:    st.keyBytes,
+				valBytes:    st.valBytes,
+				uniqueCount: ukeys,
+				avgVer:      avgVersions(st.count, ukeys),
+			})
+		}
+	}
+	cmd.Printf("  %-15s | %-7s | %-12s | %-11s | %-12s | %-12s | %s\n",
+		"Category", "CF", "Entries", "Key Bytes", "Value Bytes", "Unique Keys", "Avg Versions")
+	cmd.Printf("  %s\n", strings.Repeat("-", 95))
+	for _, r := range rows {
+		cmd.Printf("  %-15s | %-7s | %-12s | %-11s | %-12s | %-12s | %s\n",
+			r.cat, r.cf,
+			fmtInt(r.entries),
+			formatBytes(uint64(r.keyBytes)),
+			formatBytes(uint64(r.valBytes)),
+			fmtInt(r.uniqueCount),
+			fmtInt(r.avgVer),
+		)
+	}
+	cmd.Printf("\n")
+
+	// ---- mDB Breakdown by Field Type (top N) ----
+	type detailRow struct {
+		dbID    int64
+		tableID int64
+		field   keyType
+		cf      string
+		entries int64
+		keyB    int64
+		valB    int64
+	}
+	var detailRows []detailRow
+	for k, st := range stats.dbDetail {
+		detailRows = append(detailRows, detailRow{
+			dbID:    k.dbID,
+			tableID: k.tableID,
+			field:   k.field,
+			cf:      k.cf,
+			entries: st.count,
+			keyB:    st.keyBytes,
+			valB:    st.valBytes,
+		})
+	}
+	sort.Slice(detailRows, func(i, j int) bool {
+		return detailRows[i].entries > detailRows[j].entries
+	})
+	if topN > 0 && len(detailRows) > topN {
+		detailRows = detailRows[:topN]
+	}
+
+	cmd.Printf("--- mDB Breakdown by Field Type (top %d) ---\n", topN)
+	cmd.Printf("  %-8s | %-8s | %-7s | %-7s | %-12s | %-11s | %s\n",
+		"DB ID", "Table ID", "Type", "CF", "Entries", "Key Bytes", "Value Bytes")
+	cmd.Printf("  %s\n", strings.Repeat("-", 80))
+	for _, r := range detailRows {
+		tableIDStr := fmtInt(r.tableID)
+		if r.field == keyTypeDB {
+			tableIDStr = "-"
+		}
+		cmd.Printf("  %-8s | %-8s | %-7s | %-7s | %-12s | %-11s | %s\n",
+			fmtInt(r.dbID), tableIDStr,
+			r.field.String(), r.cf,
+			fmtInt(r.entries),
+			formatBytes(uint64(r.keyB)),
+			formatBytes(uint64(r.valB)),
+		)
+	}
+	cmd.Printf("\n")
+
+	// ---- mDB Summary by Field Type ----
+	type summaryKey struct {
+		field keyType
+		cf    string
+	}
+	type summaryVal struct {
+		entries int64
+	}
+	summaryMap := make(map[summaryKey]*summaryVal)
+	mdbTotalByCF := make(map[string]int64)
+	for k, st := range stats.dbDetail {
+		sk := summaryKey{field: k.field, cf: k.cf}
+		if _, ok := summaryMap[sk]; !ok {
+			summaryMap[sk] = &summaryVal{}
+		}
+		summaryMap[sk].entries += st.count
+		mdbTotalByCF[k.cf] += st.count
+	}
+
+	type summaryRow struct {
+		field   keyType
+		cf      string
+		entries int64
+		pct     float64
+	}
+	var summaryRows []summaryRow
+	for sk, sv := range summaryMap {
+		total := mdbTotalByCF[sk.cf]
+		var pct float64
+		if total > 0 {
+			pct = float64(sv.entries) / float64(total) * 100
+		}
+		summaryRows = append(summaryRows, summaryRow{
+			field:   sk.field,
+			cf:      sk.cf,
+			entries: sv.entries,
+			pct:     pct,
+		})
+	}
+	sort.Slice(summaryRows, func(i, j int) bool {
+		if summaryRows[i].cf != summaryRows[j].cf {
+			return summaryRows[i].cf < summaryRows[j].cf
+		}
+		return summaryRows[i].entries > summaryRows[j].entries
+	})
+
+	cmd.Printf("--- mDB Summary by Field Type ---\n")
+	cmd.Printf("  %-7s | %-7s | %-12s | %s\n", "Type", "CF", "Entries", "% of mDB")
+	cmd.Printf("  %s\n", strings.Repeat("-", 50))
+	for _, r := range summaryRows {
+		cmd.Printf("  %-7s | %-7s | %-12s | %.1f%%\n",
+			r.field.String(), r.cf, fmtInt(r.entries), r.pct)
+	}
+}

--- a/br/cmd/inspector/metakv_test.go
+++ b/br/cmd/inspector/metakv_test.go
@@ -1,0 +1,218 @@
+// Copyright 2025 PingCAP, Inc. Licensed under Apache-2.0.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/tablecodec"
+	"github.com/pingcap/tidb/pkg/util/codec"
+	"github.com/stretchr/testify/require"
+)
+
+// encodeTxnMetaKey builds a TxnKey from raw hash key, field, and timestamp —
+// the same encoding used by TiDB when writing meta KV entries to TiKV.
+func encodeTxnMetaKey(key []byte, field []byte, ts uint64) []byte {
+	k := tablecodec.EncodeMetaKey(key, field)
+	txnKey := codec.EncodeBytes(nil, k)
+	return codec.EncodeUintDesc(txnKey, ts)
+}
+
+// mDBs is the outer hash key that holds all database definitions.
+var mDBs = []byte("DBs")
+
+func TestClassifyFieldTable(t *testing.T) {
+	field := meta.TableKey(42)
+	kt, tableID := classifyField(field)
+	require.Equal(t, keyTypeTable, kt)
+	require.Equal(t, int64(42), tableID)
+}
+
+func TestClassifyFieldIID(t *testing.T) {
+	field := meta.AutoIncrementIDKey(99)
+	kt, tableID := classifyField(field)
+	require.Equal(t, keyTypeIID, kt)
+	require.Equal(t, int64(99), tableID)
+}
+
+func TestClassifyFieldTID(t *testing.T) {
+	field := meta.AutoTableIDKey(7)
+	kt, tableID := classifyField(field)
+	require.Equal(t, keyTypeTID, kt)
+	require.Equal(t, int64(7), tableID)
+}
+
+func TestClassifyFieldSID(t *testing.T) {
+	field := meta.SequenceKey(13)
+	kt, tableID := classifyField(field)
+	require.Equal(t, keyTypeSID, kt)
+	require.Equal(t, int64(13), tableID)
+}
+
+func TestClassifyFieldTARID(t *testing.T) {
+	field := meta.AutoRandomTableIDKey(55)
+	kt, tableID := classifyField(field)
+	require.Equal(t, keyTypeTARID, kt)
+	require.Equal(t, int64(55), tableID)
+}
+
+func TestClassifyFieldDBKey(t *testing.T) {
+	field := meta.DBkey(3)
+	kt, tableID := classifyField(field)
+	// DBkey fields are not a table-level field; classifyField returns unknown for them
+	// because classifyField only handles table-level fields.
+	require.Equal(t, keyTypeUnknown, kt)
+	require.Equal(t, int64(0), tableID)
+}
+
+func TestClassifyFieldUnknown(t *testing.T) {
+	field := []byte("UnknownField:42")
+	kt, tableID := classifyField(field)
+	require.Equal(t, keyTypeUnknown, kt)
+	require.Equal(t, int64(0), tableID)
+}
+
+// TestClassifyEntryDBDefinition verifies that an mDBs/DB:{id} TxnKey is
+// classified as catDB with keyTypeDB and the correct dbID.
+func TestClassifyEntryDBDefinition(t *testing.T) {
+	const (
+		dbID int64  = 5
+		ts   uint64 = 400036290571534337
+	)
+	txnKey := encodeTxnMetaKey(mDBs, meta.DBkey(dbID), ts)
+	cat, dbk, lk := classifyEntry(txnKey, "default")
+
+	require.Equal(t, catDB, cat)
+	require.NotNil(t, dbk)
+	require.Equal(t, dbID, dbk.dbID)
+	require.Equal(t, int64(0), dbk.tableID)
+	require.Equal(t, keyTypeDB, dbk.field)
+	require.Equal(t, "default", dbk.cf)
+	// logical key is TxnKey with last 8 bytes (TS) stripped
+	require.Equal(t, string(txnKey[:len(txnKey)-8]), lk)
+}
+
+// TestClassifyEntryTableSchema verifies that a DB:{id}/Table:{id} TxnKey
+// is classified as catDB with keyTypeTable.
+func TestClassifyEntryTableSchema(t *testing.T) {
+	const (
+		dbID    int64  = 1
+		tableID int64  = 57
+		ts      uint64 = 400036290571534337
+	)
+	txnKey := encodeTxnMetaKey(meta.DBkey(dbID), meta.TableKey(tableID), ts)
+	cat, dbk, _ := classifyEntry(txnKey, "write")
+
+	require.Equal(t, catDB, cat)
+	require.NotNil(t, dbk)
+	require.Equal(t, dbID, dbk.dbID)
+	require.Equal(t, tableID, dbk.tableID)
+	require.Equal(t, keyTypeTable, dbk.field)
+	require.Equal(t, "write", dbk.cf)
+}
+
+// TestClassifyEntryAutoIncrement verifies IID entry classification.
+func TestClassifyEntryAutoIncrement(t *testing.T) {
+	const (
+		dbID    int64  = 2
+		tableID int64  = 100
+		ts      uint64 = 400036290571534337
+	)
+	txnKey := encodeTxnMetaKey(meta.DBkey(dbID), meta.AutoIncrementIDKey(tableID), ts)
+	cat, dbk, _ := classifyEntry(txnKey, "default")
+
+	require.Equal(t, catDB, cat)
+	require.NotNil(t, dbk)
+	require.Equal(t, dbID, dbk.dbID)
+	require.Equal(t, tableID, dbk.tableID)
+	require.Equal(t, keyTypeIID, dbk.field)
+}
+
+// TestClassifyEntryAutoTableID verifies TID entry classification.
+func TestClassifyEntryAutoTableID(t *testing.T) {
+	txnKey := encodeTxnMetaKey(meta.DBkey(3), meta.AutoTableIDKey(200), 1000)
+	cat, dbk, _ := classifyEntry(txnKey, "default")
+	require.Equal(t, catDB, cat)
+	require.NotNil(t, dbk)
+	require.Equal(t, keyTypeTID, dbk.field)
+	require.Equal(t, int64(200), dbk.tableID)
+}
+
+// TestClassifyEntryAutoRandom verifies TARID entry classification.
+func TestClassifyEntryAutoRandom(t *testing.T) {
+	txnKey := encodeTxnMetaKey(meta.DBkey(4), meta.AutoRandomTableIDKey(300), 2000)
+	cat, dbk, _ := classifyEntry(txnKey, "write")
+	require.Equal(t, catDB, cat)
+	require.NotNil(t, dbk)
+	require.Equal(t, keyTypeTARID, dbk.field)
+	require.Equal(t, int64(300), dbk.tableID)
+}
+
+// TestClassifyEntryDDLHistory verifies that mDDLJobHistory keys map to catDDLHistory.
+func TestClassifyEntryDDLHistory(t *testing.T) {
+	// The TiDB meta layer stores DDL history under hash key "DDLJobHistory".
+	// EncodeMetaKey prepends "m", producing a TxnKey that starts with "mDDLJobH",
+	// which IsMetaDDLJobHistoryKey recognises.
+	ddlHistKey := []byte("DDLJobHistory")
+	txnKey := encodeTxnMetaKey(ddlHistKey, []byte("job:1"), 5000)
+	cat, dbk, _ := classifyEntry(txnKey, "default")
+	require.Equal(t, catDDLHistory, cat)
+	require.Nil(t, dbk)
+}
+
+// TestClassifyEntryOther verifies that non-meta keys fall into catOther.
+func TestClassifyEntryOther(t *testing.T) {
+	// A random non-meta key that doesn't start with "mDB" or "mDDLJobH"
+	txnKey := encodeTxnMetaKey([]byte("SomeOtherKey"), []byte("field"), 9000)
+	cat, dbk, _ := classifyEntry(txnKey, "default")
+	require.Equal(t, catOther, cat)
+	require.Nil(t, dbk)
+}
+
+// TestFmtInt verifies comma-separated integer formatting.
+func TestFmtInt(t *testing.T) {
+	cases := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{999, "999"},
+		{1000, "1,000"},
+		{1234, "1,234"},
+		{1000000, "1,000,000"},
+		{12345678, "12,345,678"},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, fmtInt(tc.n), "fmtInt(%d)", tc.n)
+	}
+}
+
+// TestAccumulateConcurrency verifies that concurrent accumulate calls produce
+// consistent totals without data races.
+func TestAccumulateConcurrency(t *testing.T) {
+	const goroutines = 32
+	const callsEach = 1000
+
+	stats := newMetaKVStats()
+	txnKey := encodeTxnMetaKey(meta.DBkey(1), meta.AutoIncrementIDKey(42), 1000)
+
+	done := make(chan struct{})
+	for range goroutines {
+		go func() {
+			for range callsEach {
+				stats.accumulate(txnKey, []byte("val"), "default")
+			}
+			done <- struct{}{}
+		}()
+	}
+	for range goroutines {
+		<-done
+	}
+
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+	total := stats.topLevel[catDB]["default"].count
+	require.Equal(t, int64(goroutines*callsEach), total)
+}


### PR DESCRIPTION
### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67311

Problem Summary:

When investigating PiTR log backup issues (slow restores, large metadata, unexpectedly high MVCC version counts), operators currently have no offline tool to inspect the backup contents without attempting a full restore. This PR adds a lightweight CLI inspector that reads backup storage directly and produces summary statistics.

### What changed and how does it work?

Adds `br/cmd/inspector` with two subcommands:

**`backupmeta`** — scans PiTR metadata files in a TS range and reports:
- Total metadata files and file group counts
- Total and per-store data sizes
- Per-store metadata file sizes

**`metakv`** — parses PiTR data files, iterates meta KV entries, and reports:
- Top-level breakdown by key category (mDB, mDDLJobHistory, other) and column family
- Unique key counts and average MVCC versions per logical key
- Per-(dbID, tableID, field type) detail table with configurable top-N
- Summary by field type (Table, IID, TID, SID, TARID) with percentage breakdown

The tool reuses existing BR storage (`task.GetStorage`) and stream packages (`stream.FastUnmarshalMetaData`, `stream.NewMetadataHelper`), supports S3/GCS/Azure/local backends via `--storage`, and requires `--start-ts`/`--restored-ts` to scope the inspection range.

#### Example usage

```
$ ./inspector metakv \
    -s s3://bucket/path/to/log-backup \
    --start-ts 465149443263692803 \
    --restored-ts 465149600550092800

=== PiTR Meta KV Entry Analysis ===

TS Range: [465149443263692803, 465149600550092800]
Data files processed: 50
Parse errors:         0

--- Top-Level Key Breakdown ---
  Category        | CF      | Entries      | Key Bytes   | Value Bytes  | Unique Keys  | Avg Versions
  -----------------------------------------------------------------------------------------------
  mDB             | write   | 182,580      | 9.91 MB     | 5.39 MB      | 47           | 3,884

--- mDB Breakdown by Field Type (top 20) ---
  DB ID    | Table ID | Type    | CF      | Entries      | Key Bytes   | Value Bytes
  --------------------------------------------------------------------------------
  66,915   | 66,925   | IID     | write   | 67,463       | 3.99 MB     | 1.99 MB
  66,915   | 66,949   | IID     | write   | 54,399       | 3.22 MB     | 1.61 MB
  80       | 801      | IID     | write   | 27,617       | 1.16 MB     | 836.06 KB
  80       | 12,525   | IID     | write   | 9,420        | 487.56 KB   | 285.18 KB
  80       | 757      | IID     | write   | 7,035        | 302.29 KB   | 212.97 KB
  ... (truncated)

--- mDB Summary by Field Type ---
  Type    | CF      | Entries      | % of mDB
  --------------------------------------------------
  IID     | write   | 176,941      | 96.9%
  TID     | write   | 5,639        | 3.1%
```

```
$ ./inspector backupmeta \
    -s s3://bucket/path/to/log-backup \
    --start-ts 465149443263692803 \
    --restored-ts 465149600550092800

=== PiTR Log Backup Metadata Inspection ===

TS Range: [465149443263692803, 465149600550092800]
Metadata files scanned: 715
Total file groups: 767

--- Total Data Size ---
  7.83 GB (8405271070 bytes)

--- Data Size Per Store ---
  Store 1: 21.63 MB (22681854 bytes)
  Store 4: 30.20 MB (31667761 bytes)
  Store 5: 28.10 MB (29466345 bytes)
  ... (truncated)

--- Metadata File Size Per Store ---
  Store 1: 580.10 KB (594027 bytes)
  Store 4: 645.46 KB (660950 bytes)
  Store 5: 602.83 KB (617297 bytes)
  ... (truncated)
  Total: 82.39 MB (86392101 bytes)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  > See manual execution examples above
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Add `inspector` CLI tool for offline PiTR log backup inspection with `backupmeta` (metadata file statistics) and `metakv` (meta KV entry breakdown) subcommands.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a BR Inspector CLI tool with commands to scan backup metadata and metadata-KV ranges, producing reports: TS ranges, metadata/file-group counts, total and per-store data sizes, category/CF breakdowns, and top-N DB field contributors.
* **Tests**
  * Added unit and integration tests covering formatting, parsing, and concurrent statistics aggregation.
* **Chores**
  * Added build targets to produce an inspector binary and include it in tool build steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->