### PR TITLE
planner: avoid TopN panic on expr index virtual column

### DIFF
--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -1910,6 +1910,18 @@ func TestVirtualExprPushDown(t *testing.T) {
 		}
 		tk.MustQuery("explain format = 'brief' select * from t where c2 > 1;").CheckAt([]int{0, 2, 4}, rows)
 
+		tk.MustExec("drop table if exists t_force_idx;")
+		tk.MustExec(`create table t_force_idx (
+			i bigint,
+			g bigint generated always as (i + 1) virtual,
+			key idx_g (g),
+			key idx_exp_i ((i + 1))
+		)`)
+		tk.MustExec("insert into t_force_idx (i) values (1);")
+		plan := tk.MustQuery("explain format='brief' select g from t_force_idx force index (idx_exp_i) where (i + 1) >= 1 order by g limit 1;").Rows()
+		require.NotEmpty(t, plan)
+		tk.MustQuery("select g from t_force_idx force index (idx_exp_i) where (i + 1) >= 1 order by g limit 1;").Check(testkit.Rows("2"))
+
 		tk.MustExec("set @@tidb_allow_mpp=1; set @@tidb_enforce_mpp=1")
 		tk.MustExec("set @@tidb_isolation_read_engines = 'tiflash'")
 		is := dom.InfoSchema()

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1286,6 +1286,16 @@ func attach2Task4PhysicalTopN(pp base.PhysicalPlan, tasks ...base.Task) base.Tas
 		} else {
 			// It works for both normal index scan and index merge scan.
 			copTask.FinishIndexPlan()
+			if copTask.TablePlan == nil {
+				// Keep TopN at root when the order-by columns cannot be resolved against the
+				// index plan but the reader still has no table-side after finishing the index plan.
+				// This can happen when a virtual generated column is covered by an expression index.
+				rootTask := t.ConvertToRootTask(p.SCtx())
+				if len(p.GetPartitionBy()) > 0 {
+					return t
+				}
+				return attachPlan2Task(p, rootTask)
+			}
 			pushedDownTopN, newGlobalTopN = getPushedDownTopN(p, copTask.TablePlan, copTask.GetStoreType())
 			copTask.TablePlan = pushedDownTopN
 			if newGlobalTopN != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67055

Problem Summary:

`FORCE INDEX` on an expression index can still route `TopN` through the table-side fallback path when
`ORDER BY` references a virtual generated column. In this shape, `FinishIndexPlan()` may still leave
`copTask.TablePlan` empty, and the planner panics while trying to push `TopN` onto a nonexistent
table-side plan.

### What changed and how does it work?

- Keep `TopN` on the root task when index-side `TopN` pushdown is rejected and finishing the index
  plan still yields no table-side plan.
- Add a regression case to `TestVirtualExprPushDown` that covers the exact issue SQL and verifies
  both `EXPLAIN` and query execution succeed.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a planner panic for queries that force an expression index while ordering by a virtual generated column with LIMIT.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an edge case in query optimization where certain index-based queries could fail due to missing validation checks.

* **Tests**
  * Extended integration tests to cover additional scenarios with virtual columns and index selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->