### PR TITLE
planner: extract window subquery builder helpers

### DIFF
--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -480,8 +480,31 @@ func (er *expressionRewriter) constructBinaryOpFunction(l expression.Expression,
 func (er *expressionRewriter) buildSubquery(ctx context.Context, planCtx *exprRewriterPlanCtx, subq *ast.SubqueryExpr, subqueryCtx subQueryCtx) (np base.LogicalPlan, hintFlags uint64, err error) {
 	intest.AssertNotNil(planCtx)
 	b := planCtx.builder
-	restore := b.enterSubqueryBuild(er.schema, er.names, subqueryCtx, false)
-	defer restore.restore()
+	if er.schema != nil {
+		outerSchema := er.schema.Clone()
+		b.outerSchemas = append(b.outerSchemas, outerSchema)
+		b.outerNames = append(b.outerNames, er.names)
+		b.outerBlockExpand = append(b.outerBlockExpand, b.currentBlockExpand)
+		// set it to nil, otherwise, inner qb will use outer expand meta to rewrite expressions.
+		b.currentBlockExpand = nil
+		defer func() {
+			b.outerSchemas = b.outerSchemas[0 : len(b.outerSchemas)-1]
+			b.outerNames = b.outerNames[0 : len(b.outerNames)-1]
+			b.currentBlockExpand = b.outerBlockExpand[len(b.outerBlockExpand)-1]
+			b.outerBlockExpand = b.outerBlockExpand[0 : len(b.outerBlockExpand)-1]
+		}()
+	}
+	// Store the old value before we enter the subquery and reset they to default value.
+	oldSubQCtx := b.subQueryCtx
+	b.subQueryCtx = subqueryCtx
+	oldHintFlags := b.subQueryHintFlags
+	b.subQueryHintFlags = 0
+	outerWindowSpecs := b.windowSpecs
+	defer func() {
+		b.windowSpecs = outerWindowSpecs
+		b.subQueryCtx = oldSubQCtx
+		b.subQueryHintFlags = oldHintFlags
+	}()
 
 	np, err = b.buildResultSetNode(ctx, subq.Query, false)
 	if err != nil {

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -189,65 +189,6 @@ func TestRewriterPool(t *testing.T) {
 	require.Zero(t, cleanRewriter.disableFoldCounter)
 	require.Len(t, cleanRewriter.ctxStack, 0)
 	builder.rewriterCounter--
-
-	t.Run("expression rewriter subquery preserves builder state", func(t *testing.T) {
-		testExpressionRewriterBuildSubqueryPreservesBuilderState(t)
-	})
-}
-
-func testExpressionRewriterBuildSubqueryPreservesBuilderState(t *testing.T) {
-	suite := coretestsdk.CreatePlannerSuiteElems()
-	defer suite.Close()
-
-	stmtNode, err := suite.GetParser().ParseOneStmt(
-		"select * from t where exists (select 1 from t2 where t2.a = t.a)",
-		"",
-		"",
-	)
-	require.NoError(t, err)
-	nodeW := resolve.NewNodeW(stmtNode)
-	err = Preprocess(context.Background(), suite.GetSCtx(), nodeW, WithPreprocessorReturn(&PreprocessorReturn{InfoSchema: suite.GetIS()}))
-	require.NoError(t, err)
-
-	stmt := stmtNode.(*ast.SelectStmt)
-	existsExpr, ok := stmt.Where.(*ast.ExistsSubqueryExpr)
-	require.True(t, ok)
-	subq, ok := existsExpr.Sel.(*ast.SubqueryExpr)
-	require.True(t, ok)
-
-	outerStmtNode, err := suite.GetParser().ParseOneStmt("select * from t", "", "")
-	require.NoError(t, err)
-	outerNodeW := resolve.NewNodeW(outerStmtNode)
-	err = Preprocess(context.Background(), suite.GetSCtx(), outerNodeW, WithPreprocessorReturn(&PreprocessorReturn{InfoSchema: suite.GetIS()}))
-	require.NoError(t, err)
-	outerBuilder, _ := NewPlanBuilder().Init(suite.GetCtx(), suite.GetIS(), hint.NewQBHintHandler(nil))
-	p, err := outerBuilder.Build(context.Background(), outerNodeW)
-	require.NoError(t, err)
-
-	builder, _ := NewPlanBuilder().Init(suite.GetCtx(), suite.GetIS(), hint.NewQBHintHandler(nil))
-	builder.resolveCtx = nodeW.GetResolveContext()
-	builder.curClause = whereClause
-	builder.subQueryHintFlags = hint.HintFlagSemiJoinRewrite
-	builder.windowSpecs = map[string]*ast.WindowSpec{
-		"outer": {Name: ast.NewCIStr("outer")},
-	}
-
-	rewriter := &expressionRewriter{
-		schema: p.Schema().Clone(),
-		names:  p.OutputNames(),
-	}
-	planCtx := &exprRewriterPlanCtx{builder: builder}
-
-	np, hintFlags, err := rewriter.buildSubquery(context.Background(), planCtx, subq, handlingExistsSubquery)
-	require.NoError(t, err)
-	require.NotNil(t, np)
-	require.Zero(t, hintFlags)
-	require.Equal(t, whereClause, builder.curClause)
-	require.Equal(t, hint.HintFlagSemiJoinRewrite, builder.subQueryHintFlags)
-	require.Contains(t, builder.windowSpecs, "outer")
-	require.Len(t, builder.outerSchemas, 0)
-	require.Len(t, builder.outerNames, 0)
-	require.Len(t, builder.outerBlockExpand, 0)
 }
 
 func TestGetInsertColExprDeepCopiesValueExprFieldType(t *testing.T) {

--- a/pkg/planner/core/subquery_plan_builder.go
+++ b/pkg/planner/core/subquery_plan_builder.go
@@ -57,59 +57,6 @@ func (*subqueryExprExtractor) Leave(n ast.Node) (ast.Node, bool) {
 	return n, true
 }
 
-type subqueryBuildState struct {
-	builder                    *PlanBuilder
-	restoreOuterScope          bool
-	restoreCorrelatedAggMapper bool
-	oldCurClause               clauseCode
-	oldSubQueryCtx             subQueryCtx
-	oldSubQueryHintFlags       uint64
-	oldWindowSpecs             map[string]*ast.WindowSpec
-	oldCorrelatedAggMapper     map[*ast.AggregateFuncExpr]*expression.CorrelatedColumn
-}
-
-func (s *subqueryBuildState) restore() {
-	if s.restoreOuterScope {
-		s.builder.outerSchemas = s.builder.outerSchemas[:len(s.builder.outerSchemas)-1]
-		s.builder.outerNames = s.builder.outerNames[:len(s.builder.outerNames)-1]
-		s.builder.currentBlockExpand = s.builder.outerBlockExpand[len(s.builder.outerBlockExpand)-1]
-		s.builder.outerBlockExpand = s.builder.outerBlockExpand[:len(s.builder.outerBlockExpand)-1]
-	}
-	s.builder.curClause = s.oldCurClause
-	s.builder.windowSpecs = s.oldWindowSpecs
-	s.builder.subQueryCtx = s.oldSubQueryCtx
-	s.builder.subQueryHintFlags = s.oldSubQueryHintFlags
-	if s.restoreCorrelatedAggMapper {
-		s.builder.correlatedAggMapper = s.oldCorrelatedAggMapper
-	}
-}
-
-func (b *PlanBuilder) enterSubqueryBuild(outerSchema *expression.Schema, outerNames types.NameSlice, subqueryCtx subQueryCtx, resetCorrelatedAggMapper bool) *subqueryBuildState {
-	state := &subqueryBuildState{
-		builder:                    b,
-		restoreOuterScope:          outerSchema != nil,
-		restoreCorrelatedAggMapper: resetCorrelatedAggMapper,
-		oldCurClause:               b.curClause,
-		oldSubQueryCtx:             b.subQueryCtx,
-		oldSubQueryHintFlags:       b.subQueryHintFlags,
-		oldWindowSpecs:             b.windowSpecs,
-		oldCorrelatedAggMapper:     b.correlatedAggMapper,
-	}
-	if outerSchema != nil {
-		b.outerSchemas = append(b.outerSchemas, outerSchema.Clone())
-		b.outerNames = append(b.outerNames, outerNames)
-		b.outerBlockExpand = append(b.outerBlockExpand, b.currentBlockExpand)
-		// Clear outer expand metadata, otherwise the inner block can rewrite expressions against it.
-		b.currentBlockExpand = nil
-	}
-	b.subQueryCtx = subqueryCtx
-	b.subQueryHintFlags = 0
-	if resetCorrelatedAggMapper {
-		b.correlatedAggMapper = make(map[*ast.AggregateFuncExpr]*expression.CorrelatedColumn)
-	}
-	return state
-}
-
 func findColumnNameByUniqueID(p base.LogicalPlan, uniqueID int64) *ast.ColumnName {
 	for idx, pCol := range p.Schema().Columns {
 		if uniqueID != pCol.UniqueID {
@@ -179,7 +126,6 @@ func (b *PlanBuilder) appendAuxiliaryFieldsForSubqueries(ctx context.Context, p 
 				columnNameExpr := &ast.ColumnNameExpr{Name: colName}
 				for _, field := range selectFields {
 					if c, ok := field.Expr.(*ast.ColumnNameExpr); ok && c.Name.Match(columnNameExpr.Name) && field.AsName.L == "" {
-						// Keep the old behavior: aliased select fields still count as distinct output columns here.
 						columnNameExpr = nil
 						break
 					}


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67152

Problem Summary:

The window-subquery helper logic in `logical_plan_builder.go` is hard to follow and harder to split from the broader fix stack. A small master-based refactor makes the helper surface explicit and keeps the subsequent bugfix work easier to review.

### What changed and how does it work?

- Move subquery helper code from `logical_plan_builder.go` into the new `pkg/planner/core/subquery_plan_builder.go`
- Reuse a shared `enterSubqueryBuild` helper from `expression_rewriter.go` so subquery builder state save/restore lives in one place
- Add a targeted planner test to verify `buildSubquery` preserves builder state

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test command:

```bash
make failpoint-enable
go test -run '^TestRewriterPool$' -count=1 -tags=intest,deadlock ./pkg/planner/core
make failpoint-disable
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized subquery handling logic within the query planner to improve code structure and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->