### PR TITLE
Makefile: remove the `GOTOOLCHAIN` env variable from `Makefile.common`

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -26,7 +26,6 @@ FAIL_ON_STDOUT := awk '{ print } END { if (NR > 0) { exit 1 } }'
 CURDIR := $(shell pwd)
 path_to_add := $(addsuffix /bin,$(subst :,/bin:,$(GOPATH))):$(PWD)/tools/bin
 export PATH := $(path_to_add):$(PATH)
-export GOTOOLCHAIN := go1.25.5
 
 GO              := GO111MODULE=on go
 BUILD_FLAG	:= -tags codes


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67326

Problem Summary:

1. The environment has upgraded go from v1.25.5 to v1.25.8
2. Then if the tidb hard coded the `GOTOOLCHAIN`, the version is not aligned with `plugin`.
3. The master branch also didn't set `GOTOOLCHAIN`.

### What changed and how does it work?

Remove the `GOTOOLCHAIN` variable setting.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

It should be protected by all existing tests.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build toolchain flexibility by removing version pinning constraints from build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->