### PR TITLE
executor: add simple unique-limit fast path for HashAgg

### DIFF
--- a/pkg/executor/aggregate/agg_hash_executor.go
+++ b/pkg/executor/aggregate/agg_hash_executor.go
@@ -155,6 +155,11 @@ type HashAggExec struct {
 	// isChildDrained indicates whether the all data from child has been taken out.
 	isChildDrained bool
 
+	// UniqueLimitTarget controls early stop for unique-limit optimization.
+	// When it is greater than 0, HashAgg can stop scanning child after collecting this
+	// many unique groups.
+	UniqueLimitTarget uint64
+
 	invalidMemoryUsageForTrackingTest bool
 
 	FileNamePrefixForTest string
@@ -766,6 +771,7 @@ func (e *HashAggExec) execute(ctx context.Context) (err error) {
 		var tmpBuf [1]chunk.Row
 		for j := 0; j < e.childResult.NumRows(); j++ {
 			groupKey := string(e.groupKeyBuffer[j]) // do memory copy here, because e.groupKeyBuffer may be reused.
+			isNewGroup := false
 			if _, ok := e.groupSet.M[groupKey]; !ok {
 				if atomic.LoadUint32(&e.inSpillMode) == 1 && len(e.groupSet.M) > 0 {
 					sel = append(sel, j)
@@ -773,6 +779,7 @@ func (e *HashAggExec) execute(ctx context.Context) (err error) {
 				}
 				allMemDelta += e.groupSet.Insert(groupKey)
 				e.groupKeys = append(e.groupKeys, groupKey)
+				isNewGroup = true
 			}
 			partialResults := e.getPartialResults(groupKey)
 			for i, af := range e.PartialAggFuncs {
@@ -782,6 +789,11 @@ func (e *HashAggExec) execute(ctx context.Context) (err error) {
 					return err
 				}
 				allMemDelta += memDelta
+			}
+			if isNewGroup && e.UniqueLimitTarget > 0 && uint64(len(e.groupSet.M)) >= e.UniqueLimitTarget {
+				failpoint.Inject("ConsumeRandomPanic", nil)
+				e.memTracker.Consume(allMemDelta)
+				return nil
 			}
 		}
 

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -122,6 +122,10 @@ type executorBuilder struct {
 
 	// Used when building MPPGather.
 	encounterUnionScan bool
+
+	// hashAggUniqueLimitTargets stores the target unique group count for HashAgg plan ID.
+	// The target is usually `offset+count` from parent Limit.
+	hashAggUniqueLimitTargets map[int]uint64
 }
 
 // CTEStorages stores resTbl and iterInTbl for CTEExec.
@@ -811,6 +815,7 @@ func (b *executorBuilder) buildSelectLock(v *plannercore.PhysicalLock) exec.Exec
 }
 
 func (b *executorBuilder) buildLimit(v *plannercore.PhysicalLimit) exec.Executor {
+	b.tryMarkHashAggUniqueLimit(v)
 	childExec := b.build(v.Children()[0])
 	if b.err != nil {
 		return nil
@@ -835,6 +840,35 @@ func (b *executorBuilder) buildLimit(v *plannercore.PhysicalLimit) exec.Executor
 		e.columnSwapHelper = chunk.NewColumnSwapHelper(e.columnIdxsUsedByChild)
 	}
 	return e
+}
+
+func (b *executorBuilder) tryMarkHashAggUniqueLimit(v *plannercore.PhysicalLimit) {
+	threshold := b.ctx.GetSessionVars().HashAggUniqueLimitThreshold
+	if threshold <= 0 {
+		return
+	}
+
+	hashAggPlan, ok := v.Children()[0].(*plannercore.PhysicalHashAgg)
+	if !ok || !canUseHashAggUniqueLimit(hashAggPlan) {
+		return
+	}
+
+	target := v.Offset + v.Count
+	if target > uint64(threshold) {
+		return
+	}
+
+	if b.hashAggUniqueLimitTargets == nil {
+		b.hashAggUniqueLimitTargets = make(map[int]uint64)
+	}
+	b.hashAggUniqueLimitTargets[hashAggPlan.ID()] = target
+}
+
+func canUseHashAggUniqueLimit(v *plannercore.PhysicalHashAgg) bool {
+	if len(v.GroupByItems) == 0 || !aggregation.IsAllFirstRow(v.AggFuncs) {
+		return false
+	}
+	return true
 }
 
 func (b *executorBuilder) buildPrepare(v *plannercore.Prepare) exec.Executor {
@@ -2050,6 +2084,10 @@ func (b *executorBuilder) buildHashAggFromChildExec(childExec exec.Executor, v *
 		if aggDesc.HasDistinct || len(aggDesc.OrderByItems) > 0 {
 			e.IsUnparallelExec = true
 		}
+	}
+	if target, ok := b.hashAggUniqueLimitTargets[v.ID()]; ok {
+		e.IsUnparallelExec = true
+		e.UniqueLimitTarget = target
 	}
 	// When we set both tidb_hashagg_final_concurrency and tidb_hashagg_partial_concurrency to 1,
 	// we do not need to parallelly execute hash agg,

--- a/pkg/executor/test/aggregate/aggregate_test.go
+++ b/pkg/executor/test/aggregate/aggregate_test.go
@@ -252,6 +252,49 @@ func TestAggInDisk(t *testing.T) {
 	tk.MustQuery("select /*+ HASH_AGG() */ count(c) from t group by c1;").Check(testkit.Rows())
 }
 
+func TestHashAggUniqueLimitThreshold(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t_hashagg_unique_limit")
+	tk.MustExec("create table t_hashagg_unique_limit(a int)")
+
+	var insertSQL strings.Builder
+	insertSQL.WriteString("insert into t_hashagg_unique_limit values ")
+	for i := 0; i < 200; i++ {
+		if i > 0 {
+			insertSQL.WriteString(",")
+		}
+		insertSQL.WriteString(fmt.Sprintf("(%d)", i%20))
+	}
+	tk.MustExec(insertSQL.String())
+
+	tk.MustExec("set @@tidb_hashagg_partial_concurrency = 4")
+	tk.MustExec("set @@tidb_hashagg_final_concurrency = 4")
+
+	sql := "explain analyze select /*+ HASH_AGG() */ distinct a from t_hashagg_unique_limit limit 3"
+	hasParallelWorkerStat := func(rows [][]any) bool {
+		for _, row := range rows {
+			line := fmt.Sprintf("%v", row)
+			if strings.Contains(line, "HashAgg") && strings.Contains(line, "partial_worker") {
+				return true
+			}
+		}
+		return false
+	}
+
+	tk.MustExec("set @@tidb_hashagg_unique_limit_threshold = 0")
+	require.True(t, hasParallelWorkerStat(tk.MustQuery(sql).Rows()))
+
+	tk.MustExec("set @@tidb_hashagg_unique_limit_threshold = 2")
+	require.True(t, hasParallelWorkerStat(tk.MustQuery(sql).Rows()))
+
+	tk.MustExec("set @@tidb_hashagg_unique_limit_threshold = 3")
+	require.False(t, hasParallelWorkerStat(tk.MustQuery(sql).Rows()))
+
+	require.Len(t, tk.MustQuery("select /*+ HASH_AGG() */ distinct a from t_hashagg_unique_limit limit 3").Rows(), 3)
+}
+
 func TestRandomPanicConsume(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1380,6 +1380,10 @@ type SessionVars struct {
 	// TrackAggregateMemoryUsage indicates whether to track the memory usage of aggregate function.
 	TrackAggregateMemoryUsage bool
 
+	// HashAggUniqueLimitThreshold controls when HashAgg can use unique-limit optimization.
+	// Set 0 to disable this optimization.
+	HashAggUniqueLimitThreshold int64
+
 	// TiDBEnableExchangePartition indicates whether to enable exchange partition
 	TiDBEnableExchangePartition bool
 
@@ -2267,6 +2271,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		RemoveOrderbyInSubquery:       DefTiDBRemoveOrderbyInSubquery,
 		EnableSkewDistinctAgg:         DefTiDBSkewDistinctAgg,
 		Enable3StageDistinctAgg:       DefTiDB3StageDistinctAgg,
+		HashAggUniqueLimitThreshold:   DefTiDBHashAggUniqueLimitThreshold,
 		MaxAllowedPacket:              DefMaxAllowedPacket,
 		TiFlashFastScan:               DefTiFlashFastScan,
 		EnableTiFlashReadForWriteStmt: true,

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2247,6 +2247,10 @@ var defaultSysVars = []*SysVar{
 		appendDeprecationWarning(vars, TiDBHashAggFinalConcurrency, TiDBExecutorConcurrency)
 		return normalizedValue, nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBHashAggUniqueLimitThreshold, Value: strconv.Itoa(DefTiDBHashAggUniqueLimitThreshold), Type: TypeInt, MinValue: 0, MaxValue: math.MaxInt64, SetSession: func(s *SessionVars, val string) error {
+		s.HashAggUniqueLimitThreshold = TidbOptInt64(val, DefTiDBHashAggUniqueLimitThreshold)
+		return nil
+	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBWindowConcurrency, Value: strconv.Itoa(DefTiDBWindowConcurrency), Type: TypeInt, MinValue: 1, MaxValue: MaxConfigurableConcurrency, AllowAutoValue: true, SetSession: func(s *SessionVars, val string) error {
 		s.windowConcurrency = tidbOptPositiveInt32(val, ConcurrencyUnset)
 		return nil

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -519,6 +519,12 @@ const (
 	// tidb_hashagg_final_concurrency is deprecated, use tidb_executor_concurrency instead.
 	TiDBHashAggFinalConcurrency = "tidb_hashagg_final_concurrency"
 
+	// TiDBHashAggUniqueLimitThreshold controls when HashAgg can use unique-limit optimization.
+	// If the optimization conditions are met and `offset+count` of parent Limit is less than or
+	// equal to this threshold, HashAgg can stop after collecting enough unique groups.
+	// Set 0 to disable this optimization.
+	TiDBHashAggUniqueLimitThreshold = "tidb_hashagg_unique_limit_threshold"
+
 	// TiDBWindowConcurrency is used for window parallel executor.
 	// tidb_window_concurrency is deprecated, use tidb_executor_concurrency instead.
 	TiDBWindowConcurrency = "tidb_window_concurrency"
@@ -1412,6 +1418,7 @@ const (
 	DefTiDBEnableAutoIncrementInGenerated   = false
 	DefTiDBHashAggPartialConcurrency        = ConcurrencyUnset
 	DefTiDBHashAggFinalConcurrency          = ConcurrencyUnset
+	DefTiDBHashAggUniqueLimitThreshold      = 0
 	DefTiDBWindowConcurrency                = ConcurrencyUnset
 	DefTiDBMergeJoinConcurrency             = 1 // disable optimization by default
 	DefTiDBStreamAggConcurrency             = 1


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/63850

Problem Summary:

```sql
mysql> select count(*) from t_hashagg_ul_poc;
+----------+
| count(*) |
+----------+
|  4194304 |
+----------+
1 row in set (0.13 sec)

mysql> set @@tidb_hashagg_unique_limit_threshold = 0;
Query OK, 0 rows affected (0.00 sec)

mysql> explain analyze select /*+ HASH_AGG() */ distinct k from t_hashagg_ul_poc limit 500;
+------------------------------+------------+---------+-----------+------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------+----------+---------+
| id                           | estRows    | actRows | task      | access object          | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                          | operator info                                                                                      | memory   | disk    |
+------------------------------+------------+---------+-----------+------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------+----------+---------+
| Limit_9                      | 500.00     | 500     | root      |                        | time:653.2ms, loops:2, RU:11085.72                                                                                                                                                                                                                                                                                                                                                                                                                      | offset:0, count:500                                                                                | N/A      | N/A     |
| └─HashAgg_14                 | 500.00     | 1024    | root      |                        | time:653.1ms, loops:1, partial_worker:{wall_time:358.541125ms, concurrency:5, task_num:234, tot_wait:41.955086ms, tot_exec:1.725862075s, tot_time:1.792419917s, max:358.486917ms, p95:358.486917ms}, final_worker:{wall_time:665.10175ms, concurrency:5, task_num:21, tot_wait:22.543µs, tot_exec:1.501372959s, tot_time:3.294184958s, max:665.044125ms, p95:665.044125ms}                                                                              | group by:test.t_hashagg_ul_poc.k, funcs:firstrow(test.t_hashagg_ul_poc.k)->test.t_hashagg_ul_poc.k | 603.9 MB | 0 Bytes |
|   └─TableReader_15           | 500.00     | 4194304 | root      |                        | time:52.3ms, loops:235, cop_task: {num: 234, max: 17.3ms, min: 343.5µs, avg: 5.2ms, p95: 13.3ms, max_proc_keys: 50176, p95_proc_keys: 50176, tot_proc: 1.01s, tot_wait: 66.4ms, copr_cache_hit_ratio: 0.09, build_task_duration: 56µs, max_distsql_concurrency: 15}, rpc_info:{Cop:{num_rpc:234, total_time:1.21s}}                                                                                                                                     | data:HashAgg_10                                                                                    | 6.04 MB  | N/A     |
|     └─HashAgg_10             | 500.00     | 4194304 | cop[tikv] |                        | tikv_task:{proc max:16ms, min:0s, avg: 4.82ms, p80:10ms, p95:12ms, iters:4112, tasks:234}, scan_detail: {total_process_keys: 4077568, total_process_keys_size: 697223043, total_keys: 4077780, get_snapshot_time: 4.68ms, rocksdb: {key_skipped_count: 4077568, block: {cache_hit_count: 21347}}}, time_detail: {total_process_time: 1.01s, total_suspend_time: 38.1ms, total_wait_time: 66.4ms, total_kv_read_wall_time: 922ms, tikv_wall_time: 1.11s} | group by:test.t_hashagg_ul_poc.k,                                                                  | N/A      | N/A     |
|       └─TableFullScan_13     | 6291456.00 | 4194304 | cop[tikv] | table:t_hashagg_ul_poc | tikv_task:{proc max:16ms, min:0s, avg: 4.34ms, p80:9ms, p95:12ms, iters:4112, tasks:234}                                                                                                                                                                                                                                                                                                                                                                | keep order:false                                                                                   | N/A      | N/A     |
+------------------------------+------------+---------+-----------+------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------+----------+---------+
5 rows in set (0.67 sec)

mysql> set @@tidb_hashagg_unique_limit_threshold = 1000;
Query OK, 0 rows affected (0.01 sec)

mysql> explain analyze select /*+ HASH_AGG() */ distinct k from t_hashagg_ul_poc limit 500;
+------------------------------+------------+---------+-----------+------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------+----------+---------+
| id                           | estRows    | actRows | task      | access object          | execution info                                                                                                                                                                                                                                   | operator info                                                                                      | memory   | disk    |
+------------------------------+------------+---------+-----------+------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------+----------+---------+
| Limit_9                      | 500.00     | 500     | root      |                        | time:5.85ms, loops:2, RU:42.71                                                                                                                                                                                                                   | offset:0, count:500                                                                                | N/A      | N/A     |
| └─HashAgg_14                 | 500.00     | 500     | root      |                        | time:5.84ms, loops:1                                                                                                                                                                                                                             | group by:test.t_hashagg_ul_poc.k, funcs:firstrow(test.t_hashagg_ul_poc.k)->test.t_hashagg_ul_poc.k | 44.9 KB  | 0 Bytes |
|   └─TableReader_15           | 500.00     | 1024    | root      |                        | time:4.81ms, loops:1, cop_task: {num: 1, max: 4.34ms, proc_keys: 0, tot_proc: 3.42µs, tot_wait: 168.8µs, copr_cache_hit_ratio: 1.00, build_task_duration: 132.9µs, max_distsql_concurrency: 15}, rpc_info:{Cop:{num_rpc:1, total_time:4.3ms}}    | data:HashAgg_10                                                                                    | 132.9 KB | N/A     |
|     └─HashAgg_10             | 500.00     | 1024    | cop[tikv] |                        | tikv_task:{time:3ms, loops:1}, scan_detail: {get_snapshot_time: 76.2µs, rocksdb: {block: {}}}, time_detail: {total_process_time: 3.42µs, total_wait_time: 168.8µs, tikv_wall_time: 402.5µs}                                                      | group by:test.t_hashagg_ul_poc.k,                                                                  | N/A      | N/A     |
|       └─TableFullScan_13     | 6291456.00 | 1024    | cop[tikv] | table:t_hashagg_ul_poc | tikv_task:{time:3ms, loops:1}                                                                                                                                                                                                                    | keep order:false                                                                                   | N/A      | N/A     |
+------------------------------+------------+---------+-----------+------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------+----------+---------+
5 rows in set (0.01 sec)
```

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
