### PR TITLE
planner: avoid nil TiFlash path when enforcing MPP

### DIFF
--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -1441,6 +1441,25 @@ func TestTiFlashReadForWriteStmt(t *testing.T) {
 			testKit.MustQuery("show warnings").Check(testkit.Rows(
 				"Warning 1105 MPP mode may be blocked because operator `SelectLock` is not supported now."))
 		}
+
+		testKit.MustExec("drop table if exists t3")
+		testKit.MustExec("create table t3(a int, b int, c int, primary key(a))")
+		testKit.MustExec("insert into t3 values(1, 2, 3), (4, 5, 6)")
+		testKit.MustExec("drop table if exists t4")
+		testKit.MustExec("create table t4(a int, b int)")
+		tbl3, err := dom.InfoSchema().TableByName(context.Background(), ast.CIStr{O: "test", L: "test"}, ast.CIStr{O: "t3", L: "t3"})
+		require.NoError(t, err)
+		tbl3.Meta().TiFlashReplica = &model.TiFlashReplicaInfo{Count: 1, Available: true}
+		testKit.MustExec("set @@sql_mode = ''")
+		testKit.MustExec("set @@tidb_enforce_mpp=1")
+		testKit.MustExec("set @@tidb_isolation_read_engines = 'tidb, tikv'")
+		rs := testKit.MustQuery("explain insert into t4 select a, b from t3 where a in (1, 2)").Rows()
+		require.NotEmpty(t, rs)
+		for _, row := range rs {
+			require.NotEqual(t, "mpp[tiflash]", row[2])
+		}
+		testKit.MustQuery("show warnings").Check(testkit.Rows(
+			"Warning 1105 MPP mode may be blocked because 'tidb_isolation_read_engines'(value: 'tidb,tikv') not match, need 'tiflash'."))
 	})
 }
 

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -703,8 +703,10 @@ func derivePathStatsAndTryHeuristics(ds *logicalop.DataSource) error {
 		ds.PossibleAccessPaths = ds.PossibleAccessPaths[:1]
 		// if user wanna tiFlash read, while current heuristic choose a TiKV path. so we shouldn't prune tiFlash path.
 		keep := (ds.PreferStoreType&h.PreferTiFlash != 0 || isMPPEnforced) && selected.StoreType != kv.TiFlash
-		if keep {
-			// also keep tiflash path as well.
+		if keep && tiflashPath != nil {
+			// TiFlash replicas may exist while the current session has filtered TiFlash out of
+			// the available access paths, for example via tidb_isolation_read_engines.
+			// Only keep the TiFlash path when it was actually built.
 			ds.PossibleAccessPaths = append(ds.PossibleAccessPaths, tiflashPath)
 			return nil
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67333

Problem Summary:

When a table has TiFlash replicas and the session uses `tidb_isolation_read_engines='tidb,tikv'` together with `tidb_enforce_mpp=1`, planner path filtering removes the actual TiFlash access path first, but `derivePathStatsAndTryHeuristics()` still tries to keep a TiFlash path for MPP. That appends a nil path into `ds.PossibleAccessPaths` and later triggers a nil pointer dereference in index-merge path generation for `INSERT ... SELECT ... WHERE a IN (...)`.

### What changed and how does it work?

Add a nil guard before keeping the TiFlash path in `derivePathStatsAndTryHeuristics()`. The planner now only preserves the TiFlash path when it was actually built and remains available after isolation-read filtering.

Also add a regression test for:

- TiFlash replica exists
- `tidb_isolation_read_engines='tidb,tikv'`
- `tidb_enforce_mpp=1`
- `EXPLAIN INSERT ... SELECT ... WHERE a IN (...)`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a planner panic caused by a missing TiFlash path under `tidb_enforce_mpp=1` and `tidb_isolation_read_engines='tidb,tikv'`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential issue in query optimization logic that could occur during plan evaluation.

* **Tests**
  * Added test coverage for TiFlash functionality in write operation scenarios to validate correct execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->