### PR TITLE
planner: fix projection pushdown for double-read index lookup

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -338,6 +338,41 @@ set rowid_a._tidb_rowid = rowid_a._tidb_rowid`)
 		}()
 	}
 
+	// index-join-derived-projection-needs-table-column
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("set @@tidb_opt_index_join_build_v2 = on")
+		tk.MustExec("create table a (u varchar(20), q varchar(20), index iu(u))")
+		tk.MustExec("create table b (u varchar(20), index iu2(u))")
+		tk.MustExec("create table c (g varchar(20), index ig(g))")
+		tk.MustExec(`insert into a values ('u1', '{"g":"g1"}')`)
+		tk.MustExec(`insert into b values ('u1')`)
+		tk.MustExec(`insert into c values ('g1')`)
+
+		plan := fmt.Sprint(tk.MustQuery(`explain format='brief'
+select /* issue:65938 */ 1
+from
+  (select u, json_unquote(json_extract(cast(q as json), '$.g')) as g
+  from a) x
+join
+  (select u from b where u = 'u1') b1
+on x.u = b1.u
+left join c on c.g = x.g`).Rows())
+		require.Contains(t, plan, "IndexLookUp")
+		require.Contains(t, plan, "table:a")
+		require.Contains(t, plan, "test.a.q")
+		require.Contains(t, plan, "TableRowIDScan")
+
+		tk.MustQuery(`select /* issue:65938 */ 1
+from
+  (select u, json_unquote(json_extract(cast(q as json), '$.g')) as g
+  from a) x
+join
+  (select u from b where u = 'u1') b1
+on x.u = b1.u
+left join c on c.g = x.g`).Check(testkit.Rows("1"))
+	}
+
 	// right-outer-join-view-rollup-runtime-panic
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1426,8 +1426,19 @@ func estimateMaxXForPartialOrder() uint64 {
 func attach2Task4PhysicalProjection(pp base.PhysicalPlan, tasks ...base.Task) base.Task {
 	p := pp.(*physicalop.PhysicalProjection)
 	t := tasks[0].Copy()
+	// when it's a copTask, we can push down projection to indexPlan or tablePlan respectively, say logical plan: proj->ds, when ds can supply the needed columns to proj
+	// doesn't mean its index plan can supply needed columns to proj when it's double read and index plan is not finished. When it's not, we should finish the index plan
+	// immediately and push down projection to table plan if possible. For the case of index merge, we can only push down projection to table plan since index plan and table
+	// plan will be union-ed together and the final output will be used by projection, so both of them should provide needed columns to projection.
 	if cop, ok := t.(*physicalop.CopTask); ok {
 		if (len(cop.RootTaskConds) == 0 && len(cop.IdxMergePartPlans) == 0) && expression.CanExprsPushDown(util.GetPushDownCtx(p.SCtx()), p.Exprs, cop.GetStoreType()) {
+			if !cop.IndexPlanFinished {
+				// when index plan is not finished, and index plan can not supply the columns the proj needed.
+				if !canPushToIndexPlan(cop.IndexPlan, expression.ExtractColumnsFromExpressions(p.Exprs, nil)) {
+					// finish index plan and push down projection to table plan.
+					cop.FinishIndexPlan()
+				}
+			}
 			copTask := attachPlan2Task(p, cop)
 			return copTask
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close pingcap/tidb#65938

Problem Summary:

A query can fail during planning with `Can't find column ... in schema [<index columns>, _tidb_rowid]` when an unfinished double-read path pushes a projection to the index side even though the projection expression still needs table columns.

### What changed and how does it work?

- Check whether projection expressions are fully covered by the unfinished index plan before pushing the projection into a cop task.
- If the index side cannot provide all referenced columns, call `FinishIndexPlan()` first so the projection is attached to the table side.
- Add a regression test using the public repro from issue 65938.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query execution reliability in specific scenarios involving projection operations in complex joins.

* **Tests**
  * Added regression test to ensure query execution consistency for specific query patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->