### PR TITLE
WIP: statistics: use adaptive tidb_sysproc_scan_concurrency by default

### DIFF
--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1670,23 +1670,27 @@ const (
 	MinTiDBInstancePlanCacheMemSize                   = 100 * size.MB
 	DefTiDBInstancePlanCacheReservedPercentage        = 0.1
 	// MaxDDLReorgBatchSize is exported for testing.
-	MaxDDLReorgBatchSize                  int32  = 10240
-	MinDDLReorgBatchSize                  int32  = 32
-	MinExpensiveQueryTimeThreshold        uint64 = 10 // 10s
-	MinExpensiveTxnTimeThreshold          uint64 = 60 // 60s
-	DefTiDBAutoBuildStatsConcurrency             = 1
-	DefTiDBSysProcScanConcurrency                = 1
-	DefTiDBRcWriteCheckTs                        = false
-	DefTiDBForeignKeyChecks                      = true
-	DefTiDBForeignKeyCheckInSharedLock           = false
-	DefTiDBOptAdvancedJoinHint                   = true
-	DefTiDBAnalyzePartitionConcurrency           = 2
-	DefTiDBOptRangeMaxSize                       = 64 * int64(size.MB) // 64 MB
-	DefTiDBCostModelVer                          = 2
-	DefTiDBServerMemoryLimitSessMinSize          = 128 << 20
-	DefTiDBMergePartitionStatsConcurrency        = 1
-	DefTiDBServerMemoryLimitGCTrigger            = 0.7
-	DefTiDBEnableGOGCTuner                       = true
+	MaxDDLReorgBatchSize             int32  = 10240
+	MinDDLReorgBatchSize             int32  = 32
+	MinExpensiveQueryTimeThreshold   uint64 = 10 // 10s
+	MinExpensiveTxnTimeThreshold     uint64 = 60 // 60s
+	DefTiDBAutoBuildStatsConcurrency        = 1
+	// DefTiDBSysProcScanConcurrency is the default value of TiDBSysProcScanConcurrency.
+	// It controls the scan concurrency used by backend system processes such as auto-analyze.
+	// NOTE: 0 enables adaptive concurrency; the actual scan concurrency is chosen
+	// from the TiKV store count, with fallback to DefAnalyzeDistSQLScanConcurrency.
+	DefTiDBSysProcScanConcurrency         = 0
+	DefTiDBRcWriteCheckTs                 = false
+	DefTiDBForeignKeyChecks               = true
+	DefTiDBForeignKeyCheckInSharedLock    = false
+	DefTiDBOptAdvancedJoinHint            = true
+	DefTiDBAnalyzePartitionConcurrency    = 2
+	DefTiDBOptRangeMaxSize                = 64 * int64(size.MB) // 64 MB
+	DefTiDBCostModelVer                   = 2
+	DefTiDBServerMemoryLimitSessMinSize   = 128 << 20
+	DefTiDBMergePartitionStatsConcurrency = 1
+	DefTiDBServerMemoryLimitGCTrigger     = 0.7
+	DefTiDBEnableGOGCTuner                = true
 	// DefTiDBGOGCTunerThreshold is to limit TiDBGOGCTunerThreshold.
 	DefTiDBGOGCTunerThreshold                 float64 = 0.6
 	DefTiDBGOGCMaxValue                               = 500


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67195

Problem Summary:

### What changed and how does it work?

Make `tidb_sysproc_scan_concurrency` adaptive by default.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Make the tidb_sysproc_scan_concurrency parameter use adaptive configuration, dynamically determining the concurrency based on the number of TiKV nodes.
让 tidb_sysproc_scan_concurrency 参数使用自适应配置，根据 tikv 的数量动态确定并发数。
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted formatting declarations of multiple exported default configuration constants for improved code consistency.

* **Chores**
  * Updated system scan concurrency default to utilize adaptive concurrency selection, enabling automatic determination of optimal concurrency levels with fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->