### PR TITLE
pkg/util/gctuner: stabilize memory tuner GC waits

### DIFF
--- a/pkg/util/gctuner/memory_limit_tuner_test.go
+++ b/pkg/util/gctuner/memory_limit_tuner_test.go
@@ -61,17 +61,21 @@ func TestGlobalMemoryTuner(t *testing.T) {
 	GlobalMemoryLimitTuner.UpdateMemoryLimit()
 	require.True(t, GlobalMemoryLimitTuner.isValidValueSet.Load())
 	defer func() {
+		WaitMemoryLimitTunerExitInTest()
 		// If test.count > 1, wait tuning finished.
 		require.Eventually(t, func() bool {
 			//nolint: all_revive
+			runtime.GC()
 			return GlobalMemoryLimitTuner.isValidValueSet.Load()
 		}, 5*time.Second, 100*time.Millisecond)
 		require.Eventually(t, func() bool {
 			//nolint: all_revive
+			runtime.GC()
 			return !GlobalMemoryLimitTuner.adjustPercentageInProgress.Load()
 		}, 5*time.Second, 100*time.Millisecond)
 		require.Eventually(t, func() bool {
 			//nolint: all_revive
+			runtime.GC()
 			return !GlobalMemoryLimitTuner.nextGCTriggeredByMemoryLimit.Load()
 		}, 5*time.Second, 100*time.Millisecond)
 	}()
@@ -96,6 +100,7 @@ func TestGlobalMemoryTuner(t *testing.T) {
 
 	memory210mb := allocator.alloc(210 << 20)
 	require.Eventually(t, func() bool {
+		runtime.GC()
 		return GlobalMemoryLimitTuner.adjustPercentageInProgress.Load() && gcNum < getNowGCNum()
 	}, 5*time.Second, 100*time.Millisecond)
 	// Test waiting for reset


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67174

Problem Summary:

`TestGlobalMemoryTuner` is flaky because it waits on GC-driven tuner state transitions without deterministically driving the GC boundary that advances and resets those states.

### What changed and how does it work?

- wait for in-flight memory limit tuner work before teardown checks
- trigger `runtime.GC()` while polling the GC-driven state in `TestGlobalMemoryTuner`
- keep the existing assertions intact and limit the change to test stabilization

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced memory limit tuner test reliability and stability through improved garbage collection handling and synchronization in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->