### PR TITLE
*: update OWNERS_ALIASES membership

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,17 +7,15 @@ aliases:
     - time-and-fate
     - terry1purcell
     - henrybw
-    - wddevries
-    - fixdb
   sig-critical-approvers-tidb-server:
     - yudongusa
-    - BenMeadowcroft
+    - terry1purcell
   sig-critical-approvers-tidb-lightning:
     - yudongusa
-    - BenMeadowcroft
+    - terry1purcell
   sig-critical-approvers-parser:
     - yudongusa
-    - BenMeadowcroft
+    - terry1purcell
   sig-critical-approvers-dep:
     - bb7133
     - cfzjywxk
@@ -115,15 +113,12 @@ aliases:
     - AilinKid
     - 0xPoe
     - elsa0520
-    - fixdb
     - hawkingrei
     - qw4990
     - time-and-fate
     - winoros
     - terry1purcell
-    - ghazalfamilyusa
     - henrybw
-    - wddevries
     - King-Dylan
     - guo-shaoge
   sig-approvers-metrics:
@@ -149,7 +144,6 @@ aliases:
     - fengou1
     - fzzf678
     - gengliqi
-    - ghazalfamilyusa
     - henrybw
     - iamxy
     - js00070
@@ -164,7 +158,6 @@ aliases:
     - spongedu
     - tangwz
     - tsthght
-    - wddevries
     - xzhangxian1008
     - yibin87
     - zhangjinpeng1987
@@ -223,7 +216,6 @@ aliases:
     - ekexium
     - elsa0520
     - eurekaka
-    - fixdb
     - francis0407
     - fzhedu
     - glorv


### PR DESCRIPTION
Replace BenMeadowcroft with terry1purcell in critical approver groups. Remove fixdb, wddevries, and ghazalfamilyusa from all groups.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code reviewer and approver assignments across multiple special interest groups to reflect current team membership and responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->