### PR TITLE
planner: move rule_elimate_projection into rules package

### DIFF
--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -52,7 +52,6 @@ go_library(
         "rule_decorrelate.go",
         "rule_derive_topn_from_window.go",
         "rule_eliminate_empty_selection.go",
-        "rule_eliminate_projection.go",
         "rule_eliminate_unionall_dual_item.go",
         "rule_generate_column_substitute.go",
         "rule_inject_extra_projection.go",

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -90,7 +90,7 @@ var optRuleList = []base.LogicalOptRule{
 	&SemiJoinRewriter{},
 	&AggregationEliminator{},
 	&SkewDistinctAggRewriter{},
-	&ProjectionEliminator{},
+	&rule.ProjectionEliminator{},
 	&rule.MaxMinEliminator{},
 	&rule.ConstantPropagationSolver{},
 	&ConvertOuterToInnerJoin{},

--- a/pkg/planner/core/rule/BUILD.bazel
+++ b/pkg/planner/core/rule/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "rule_collect_plan_stats.go",
         "rule_column_pruning.go",
         "rule_constant_propagation.go",
+        "rule_eliminate_projection.go",
         "rule_init.go",
         "rule_max_min_eliminate.go",
         "rule_outer_join_to_semi_join.go",

--- a/pkg/planner/core/rule/rule_eliminate_projection.go
+++ b/pkg/planner/core/rule/rule_eliminate_projection.go
@@ -1,4 +1,4 @@
-// Copyright 2016 PingCAP, Inc.
+// Copyright 2026 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package core
+package rule
 
 import (
 	"context"
 
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/expression"
-	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
-	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	ruleutil "github.com/pingcap/tidb/pkg/planner/core/rule/util"
 )
 
@@ -45,96 +42,6 @@ func canProjectionBeEliminatedLoose(p *logicalop.LogicalProjection) bool {
 		}
 	}
 	return true
-}
-
-// canProjectionBeEliminatedStrict checks whether a projection can be
-// eliminated, returns true if the projection just copy its child's output.
-func canProjectionBeEliminatedStrict(p *physicalop.PhysicalProjection) bool {
-	// This is due to the in-compatibility between TiFlash and TiDB:
-	// For TiDB, the output schema of final agg is all the aggregated functions and for
-	// TiFlash, the output schema of agg(TiFlash not aware of the aggregation mode) is
-	// aggregated functions + group by columns, so to make the things work, for final
-	// mode aggregation that need to be running in TiFlash, always add an extra Project
-	// the align the output schema. In the future, we can solve this in-compatibility by
-	// passing down the aggregation mode to TiFlash.
-	if physicalAgg, ok := p.Children()[0].(*physicalop.PhysicalHashAgg); ok {
-		if physicalAgg.MppRunMode == physicalop.Mpp1Phase || physicalAgg.MppRunMode == physicalop.Mpp2Phase || physicalAgg.MppRunMode == physicalop.MppScalar {
-			if physicalAgg.IsFinalAgg() {
-				return false
-			}
-		}
-	}
-	if physicalAgg, ok := p.Children()[0].(*physicalop.PhysicalStreamAgg); ok {
-		if physicalAgg.MppRunMode == physicalop.Mpp1Phase || physicalAgg.MppRunMode == physicalop.Mpp2Phase || physicalAgg.MppRunMode == physicalop.MppScalar {
-			if physicalAgg.IsFinalAgg() {
-				return false
-			}
-		}
-	}
-	// If this projection is specially added for `DO`, we keep it.
-	if p.CalculateNoDelay {
-		return false
-	}
-	if p.Schema().Len() == 0 {
-		return true
-	}
-	child := p.Children()[0]
-	if p.Schema().Len() != child.Schema().Len() {
-		return false
-	}
-	for i, expr := range p.Exprs {
-		col, ok := expr.(*expression.Column)
-		if !ok || !col.EqualColumn(child.Schema().Columns[i]) {
-			return false
-		}
-	}
-	return true
-}
-
-func doPhysicalProjectionElimination(p base.PhysicalPlan) base.PhysicalPlan {
-	for i, child := range p.Children() {
-		p.Children()[i] = doPhysicalProjectionElimination(child)
-	}
-
-	// eliminate projection in a coprocessor task
-	tableReader, isTableReader := p.(*physicalop.PhysicalTableReader)
-	if isTableReader && tableReader.StoreType == kv.TiFlash {
-		tableReader.TablePlan = eliminatePhysicalProjection(tableReader.TablePlan)
-		tableReader.TablePlans = physicalop.FlattenListPushDownPlan(tableReader.TablePlan)
-		return p
-	}
-
-	proj, isProj := p.(*physicalop.PhysicalProjection)
-	if !isProj || !canProjectionBeEliminatedStrict(proj) {
-		return p
-	}
-	child := p.Children()[0]
-	if childProj, ok := child.(*physicalop.PhysicalProjection); ok {
-		// when current projection is an empty projection(schema pruned by column pruner), no need to reset child's schema
-		// TODO: avoid producing empty projection in column pruner.
-		if p.Schema().Len() != 0 {
-			childProj.SetSchema(p.Schema())
-		}
-	}
-	for i, col := range p.Schema().Columns {
-		if p.SCtx().GetSessionVars().StmtCtx.ColRefFromUpdatePlan.Has(int(col.UniqueID)) && !child.Schema().Columns[i].Equal(nil, col) {
-			return p
-		}
-	}
-	return child
-}
-
-// eliminatePhysicalProjection should be called after physical optimization to
-// eliminate the redundant projection left after logical projection elimination.
-func eliminatePhysicalProjection(p base.PhysicalPlan) base.PhysicalPlan {
-	failpoint.Inject("DisableProjectionPostOptimization", func(val failpoint.Value) {
-		if val.(bool) {
-			failpoint.Return(p)
-		}
-	})
-
-	newRoot := doPhysicalProjectionElimination(p)
-	return newRoot
 }
 
 // For select, insert, delete list
@@ -210,7 +117,7 @@ func (pe *ProjectionEliminator) eliminate(p base.LogicalPlan, replace map[string
 	return p.Children()[0]
 }
 
-// Name implements the logicalOptRule.<1st> interface.
+// Name implements base.LogicalOptRule.<1st> interface.
 func (*ProjectionEliminator) Name() string {
 	return "projection_eliminate"
 }

--- a/pkg/planner/core/rule_inject_extra_projection.go
+++ b/pkg/planner/core/rule_inject_extra_projection.go
@@ -46,6 +46,96 @@ func InjectExtraProjection(plan base.PhysicalPlan) base.PhysicalPlan {
 	return NewProjInjector().inject(plan)
 }
 
+// canProjectionBeEliminatedStrict checks whether a projection can be
+// eliminated, returns true if the projection just copies its child's output.
+func canProjectionBeEliminatedStrict(p *physicalop.PhysicalProjection) bool {
+	// This is due to the incompatibility between TiFlash and TiDB:
+	// For TiDB, the output schema of final agg is all the aggregated functions and for
+	// TiFlash, the output schema of agg(TiFlash not aware of the aggregation mode) is
+	// aggregated functions + group by columns, so to make the things work, for final
+	// mode aggregation that needs to be running in TiFlash, always add an extra Project
+	// to align the output schema. In the future, we can solve this incompatibility by
+	// passing down the aggregation mode to TiFlash.
+	if physicalAgg, ok := p.Children()[0].(*physicalop.PhysicalHashAgg); ok {
+		if physicalAgg.MppRunMode == physicalop.Mpp1Phase || physicalAgg.MppRunMode == physicalop.Mpp2Phase || physicalAgg.MppRunMode == physicalop.MppScalar {
+			if physicalAgg.IsFinalAgg() {
+				return false
+			}
+		}
+	}
+	if physicalAgg, ok := p.Children()[0].(*physicalop.PhysicalStreamAgg); ok {
+		if physicalAgg.MppRunMode == physicalop.Mpp1Phase || physicalAgg.MppRunMode == physicalop.Mpp2Phase || physicalAgg.MppRunMode == physicalop.MppScalar {
+			if physicalAgg.IsFinalAgg() {
+				return false
+			}
+		}
+	}
+	// If this projection is specially added for `DO`, we keep it.
+	if p.CalculateNoDelay {
+		return false
+	}
+	if p.Schema().Len() == 0 {
+		return true
+	}
+	child := p.Children()[0]
+	if p.Schema().Len() != child.Schema().Len() {
+		return false
+	}
+	for i, expr := range p.Exprs {
+		col, ok := expr.(*expression.Column)
+		if !ok || !col.EqualColumn(child.Schema().Columns[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func doPhysicalProjectionElimination(p base.PhysicalPlan) base.PhysicalPlan {
+	for i, child := range p.Children() {
+		p.Children()[i] = doPhysicalProjectionElimination(child)
+	}
+
+	// eliminate projection in a coprocessor task
+	tableReader, isTableReader := p.(*physicalop.PhysicalTableReader)
+	if isTableReader && tableReader.StoreType == kv.TiFlash {
+		tableReader.TablePlan = eliminatePhysicalProjection(tableReader.TablePlan)
+		tableReader.TablePlans = physicalop.FlattenListPushDownPlan(tableReader.TablePlan)
+		return p
+	}
+
+	proj, isProj := p.(*physicalop.PhysicalProjection)
+	if !isProj || !canProjectionBeEliminatedStrict(proj) {
+		return p
+	}
+	child := p.Children()[0]
+	if childProj, ok := child.(*physicalop.PhysicalProjection); ok {
+		// When current projection is an empty projection(schema pruned by column pruner),
+		// no need to reset child's schema.
+		// TODO: avoid producing empty projection in column pruner.
+		if p.Schema().Len() != 0 {
+			childProj.SetSchema(p.Schema())
+		}
+	}
+	for i, col := range p.Schema().Columns {
+		if p.SCtx().GetSessionVars().StmtCtx.ColRefFromUpdatePlan.Has(int(col.UniqueID)) && !child.Schema().Columns[i].Equal(nil, col) {
+			return p
+		}
+	}
+	return child
+}
+
+// eliminatePhysicalProjection should be called after physical optimization to
+// eliminate the redundant projection left after logical projection elimination.
+func eliminatePhysicalProjection(p base.PhysicalPlan) base.PhysicalPlan {
+	failpoint.Inject("DisableProjectionPostOptimization", func(val failpoint.Value) {
+		if val.(bool) {
+			failpoint.Return(p)
+		}
+	})
+
+	return doPhysicalProjectionElimination(p)
+}
+
 type projInjector struct {
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #55231

Problem Summary:

Move `rule_eliminate_projection.go` from `pkg/planner/core/` to `pkg/planner/core/rule/` as part of the logical optimizing rule rearrangement effort.

### What changed and how does it work?

Idea:

After migrating the logical rule, `ProjectionEliminator` and its related methods (`Optimize`, `eliminate`, `Name`) are moved to the `rule` package together with the logical helper `canProjectionBeEliminatedLoose`. The optimizer is updated to reference `rule.ProjectionEliminator` instead of the original `ProjectionEliminator`.

The physical post-optimization projection elimination logic remains in `pkg/planner/core/rule_eliminate_projection.go`, so only the logical rule part is rearranged into the `rule` package.

Changes:

- Created `pkg/planner/core/rule/rule_eliminate_projection.go` with package declaration changed to `rule`
- Moved `ProjectionEliminator`, `Optimize`, `eliminate`, `Name`, and `canProjectionBeEliminatedLoose` into the new file
- Updated `pkg/planner/core/optimizer.go` to use `rule.ProjectionEliminator`
- Updated `pkg/planner/core/rule_eliminate_projection.go` to keep only the physical projection elimination logic
- Updated `pkg/planner/core/rule/BUILD.bazel` to add the new source file
- Updated `pkg/planner/core/BUILD.bazel` to remove the old file reference

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized and simplified internal query optimization logic; restructured projection elimination components for improved maintainability and planner stability.
  * No changes to public APIs or user-facing configuration; behavior and compatibility remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->