### PR TITLE
pkg/planner: validate FULLTEXT key-part limit in CREATE TABLE | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature-fts

### DIFF
--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -973,6 +973,18 @@ func (p *preprocessor) checkCreateTableGrammar(stmt *ast.CreateTableStmt) {
 				p.err = err
 				return
 			}
+		case ast.ConstraintFulltext, ast.ConstraintColumnar:
+			if constraint.Tp == ast.ConstraintFulltext || (constraint.Option != nil && constraint.Option.Tp == ast.IndexTypeFulltext) {
+				err := checkIndexInfo(constraint.Name, constraint.Keys)
+				if err != nil {
+					p.err = err
+					return
+				}
+				if constraint.IsEmptyIndex {
+					p.err = dbterror.ErrWrongNameForIndex.GenWithStackByArgs(constraint.Name)
+					return
+				}
+			}
 		}
 	}
 	if p.err = checkUnsupportedTableOptions(stmt.Options); p.err != nil {

--- a/pkg/planner/core/preprocess_test.go
+++ b/pkg/planner/core/preprocess_test.go
@@ -173,6 +173,7 @@ func TestValidator(t *testing.T) {
 		// issue pingcap-inc/tici#966
 		{"CREATE FULLTEXT INDEX idx ON t(c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17) WITH PARSER STANDARD", true, errors.New(`[schema:1070]Too many key parts specified; max 16 parts allowed`)},
 		{"ALTER TABLE t ADD FULLTEXT INDEX idx(c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17) WITH PARSER STANDARD", true, errors.New(`[schema:1070]Too many key parts specified; max 16 parts allowed`)},
+		{"CREATE TABLE t(c1 TEXT, c2 TEXT, c3 TEXT, c4 TEXT, c5 TEXT, c6 TEXT, c7 TEXT, c8 TEXT, c9 TEXT, c10 TEXT, c11 TEXT, c12 TEXT, c13 TEXT, c14 TEXT, c15 TEXT, c16 TEXT, c17 TEXT, FULLTEXT INDEX idx(c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17) WITH PARSER STANDARD)", true, errors.New(`[schema:1070]Too many key parts specified; max 16 parts allowed`)},
 
 		// issue #4429
 		{"CREATE TABLE `t` (`a` date DEFAULT now());", false, types.ErrInvalidDefault},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref pingcap-inc/tici#1091

Problem Summary:

`CREATE TABLE ... FULLTEXT INDEX(...)` was not enforcing the common `MaxKeyParts=16` limit in the preprocess stage. As a result, statements with more than 16 FULLTEXT index columns could slip through instead of returning `[schema:1070] Too many key parts specified; max 16 parts allowed`.

### What changed and how does it work?

- Extend `checkCreateTableGrammar` so FULLTEXT constraints also go through `checkIndexInfo`.
- Cover both raw `ConstraintFulltext` and rewritten `ConstraintColumnar + IndexTypeFulltext` forms.
- Add a regression case for `CREATE TABLE ... FULLTEXT INDEX(c1..c17) WITH PARSER STANDARD`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix `CREATE TABLE ... FULLTEXT INDEX` to reject indexes with more than 16 key parts during preprocess validation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for index constraints in `CREATE TABLE` statements to properly reject invalid configurations and ensure consistent error handling with other index definition methods.

* **Tests**
  * Added test coverage validating index constraint validation during table creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->