### PR TITLE
planner: fix DEFAULT() resolution after NATURAL JOIN

### DIFF
--- a/pkg/planner/core/casetest/join/join_test.go
+++ b/pkg/planner/core/casetest/join/join_test.go
@@ -210,6 +210,11 @@ func TestJoinRegression(t *testing.T) {
 				`  └─Selection cop[tikv]  not(isnull(test.t0.c0))`,
 				`    └─TableFullScan cop[tikv] table:t0 keep order:false, stats:pseudo`))
 
+		tk.MustExec(`drop table if exists issue65325_t0, issue65325_t1`)
+		tk.MustExec(`create table issue65325_t0(c0 bool)`)
+		tk.MustExec(`create table issue65325_t1(c0 double)`)
+		tk.MustQuery(`SELECT /* issue:65325 */ issue65325_t1.c0, issue65325_t1.c0 FROM issue65325_t0 NATURAL JOIN issue65325_t1 ORDER BY CASE DEFAULT(issue65325_t1.c0) WHEN issue65325_t1.c0 THEN 397344251 ELSE issue65325_t0.c0 END`).Check(testkit.Rows())
+
 		tk.MustExec(`create table t1 (a int)`)
 		tk.MustExec(`create table t2 (a int, b int, c int, d int, key ab(a, b), key abcd(a, b, c, d))`)
 		tk.MustUseIndex(`select /* issue:63949 */ /*+ tidb_inlj(t2) */ t2.a from t1, t2 where t1.a=t2.a and t2.b=1 and t2.d=1`, "abcd")

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4391,7 +4391,14 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 	// buildSort is after buildProjection, so we need get OutputNames before BuildProjection and store in allNames.
 	// Otherwise, we will get select fields instead of all OutputNames, so that we can't find the column b in the
 	// above example.
-	b.allNames = append(b.allNames, p.OutputNames())
+	//
+	// For USING/NATURAL JOIN, the canonical OutputNames coalesce common columns and may hide qualified base-table
+	// names like t1.a. DEFAULT(t1.a) still needs the base-table field name, so prefer FullNames when available.
+	namesForDefault := p.OutputNames()
+	if _, fullNames := findJoinFullSchema(p); fullNames != nil {
+		namesForDefault = fullNames
+	}
+	b.allNames = append(b.allNames, namesForDefault)
 	defer func() { b.allNames = b.allNames[:len(b.allNames)-1] }()
 
 	if sel.Where != nil {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65325

Problem Summary:

`DEFAULT(tbl.col)` in `ORDER BY` after a `NATURAL JOIN` can fail with `[expression:1052] Column ... is ambiguous`.
The planner caches `OutputNames()` before projection building, but for `USING`/`NATURAL JOIN` those names coalesce common columns and may drop qualified base-table names that `DEFAULT()` still needs during resolution.

### What changed and how does it work?

- Use join `FullNames` for `DEFAULT()` name resolution when they are available, instead of relying only on coalesced `OutputNames()`.
- Add a regression case to the existing join regression suite for the `NATURAL JOIN` + `ORDER BY CASE DEFAULT(...)` shape from `#65325`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```bash
go test ./pkg/planner/core/casetest/join -run '^TestJoinRegression$' -tags=intest,deadlock -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed name resolution for `DEFAULT()` expressions in NATURAL JOIN queries to properly preserve base-table-qualified column names.

* **Tests**
  * Added regression test for NATURAL JOIN scenarios with `DEFAULT()` expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->