### PR TITLE
planner: add regression coverage for issue 67345

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -585,6 +585,30 @@ HAVING EXISTS (SELECT 1 FROM t_panic WHERE x IS NULL);`).Check(testkit.Rows("<ni
 		tk.MustQuery("SELECT /* issue:58999 */ 1 FROM t0, v0 WHERE t0.c2=(-(-1|v0.c0))").Check(testkit.Rows())
 	}
 
+	// issue-67345-view-where-predicate-internal-error
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("CREATE TABLE t0(c0 BOOL)")
+		tk.MustExec("CREATE VIEW v0(c0) AS SELECT '0.43245565050850177' FROM t0")
+
+		require.NotEmpty(t, tk.MustQuery(`EXPLAIN SELECT v0.c0, t0.c0
+FROM v0, t0
+WHERE ((((CAST(t0.c0 AS SIGNED)) NOT LIKE (((-2056919112) AND (NULL))))) = ((-(((v0.c0) | (-1132301066))))))`).Rows())
+
+		tk.MustQuery(`SELECT /* issue:67345 */ v0.c0, t0.c0
+FROM v0, t0
+WHERE ((((CAST(t0.c0 AS SIGNED)) NOT LIKE (((-2056919112) AND (NULL))))) = ((-(((v0.c0) | (-1132301066))))))`).Check(testkit.Rows())
+
+		tk.MustQuery(`SELECT ref0, ref1
+FROM (
+    SELECT v0.c0 AS ref0,
+           t0.c0 AS ref1,
+           ((((CAST(t0.c0 AS SIGNED)) NOT LIKE (((-2056919112) AND (NULL))))) = ((-(((v0.c0) | (-1132301066)))))) AS ref2
+    FROM v0, t0
+) AS s
+WHERE ref2`).Check(testkit.Rows())
+	}
+
 	// Regression test for https://github.com/pingcap/tidb/issues/66339
 	// Read-only user variables with uppercase names should be converted to constant
 	// and use IndexRangeScan, same as lowercase names.


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67345

Problem Summary:

`#67345` reports an internal error for a query that combines a `VIEW` with a coercion-heavy `WHERE` predicate.
Fresh current master no longer reproduces the panic, and the strongest overlap points to the merged fix in `#66893`.
This PR adds regression coverage so the non-repro behavior stays locked in.

### What changed and how does it work?

- add an `issue:67345` regression block to `pkg/planner/core/issuetest/planner_issue_test.go`
- cover the three issue shapes:
  - `EXPLAIN`
  - direct `SELECT`
  - derived-table `SELECT ... WHERE ref2`
- assert the queries execute successfully and return the expected empty result on current master

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note
<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test for issue 67345 to validate query execution with complex predicates and null-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->