### PR TITLE
distsql, session: fix non-transactional DML scan concurrency

### DIFF
--- a/pkg/distsql/context/context.go
+++ b/pkg/distsql/context/context.go
@@ -66,6 +66,9 @@ type DistSQLContext struct {
 	TiFlashHashJoinVersion               string
 
 	DistSQLConcurrency            int
+	// FixedDistSQLConcurrency indicates the concurrency was explicitly set
+	// and should not be overridden by scan optimizations.
+	FixedDistSQLConcurrency bool
 	ReplicaReadType               kv.ReplicaReadType
 	WeakConsistency               bool
 	RCCheckTS                     bool

--- a/pkg/distsql/context/context_test.go
+++ b/pkg/distsql/context/context_test.go
@@ -77,6 +77,7 @@ func TestContextDetach(t *testing.T) {
 		TiFlashHashJoinVersion:               joinversion.HashJoinVersionLegacy,
 
 		DistSQLConcurrency:            1,
+		FixedDistSQLConcurrency:       true,
 		ReplicaReadType:               kv.ReplicaReadFollower,
 		WeakConsistency:               true,
 		RCCheckTS:                     true,

--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -91,7 +91,7 @@ func (builder *RequestBuilder) Build() (*kv.Request, error) {
 	if dag := builder.dag; dag != nil {
 		if execCnt := len(dag.Executors); execCnt == 1 {
 			// select * from t order by id
-			if builder.Request.KeepOrder && builder.Request.Concurrency == vardef.DefDistSQLScanConcurrency {
+			if builder.Request.KeepOrder && !builder.Request.FixedConcurrency && builder.Request.Concurrency == vardef.DefDistSQLScanConcurrency {
 				// When the DAG is just simple scan and keep order, set concurrency to 2.
 				// If a lot data are returned to client, mysql protocol is the bottleneck so concurrency 2 is enough.
 				// If very few data are returned to client, the speed is not optimal but good enough.
@@ -345,6 +345,9 @@ func (builder *RequestBuilder) SetFromSessionVars(dctx *distsqlctx.DistSQLContex
 		// Concurrency is set in SetDAGRequest, check the upper limit.
 		builder.Request.Concurrency = distsqlConcurrency
 	}
+	if dctx.FixedDistSQLConcurrency {
+		builder.Request.FixedConcurrency = true
+	}
 	replicaReadType := dctx.ReplicaReadType
 	if dctx.WeakConsistency {
 		builder.Request.IsolationLevel = kv.RC
@@ -385,6 +388,13 @@ func (builder *RequestBuilder) SetPaging(paging bool) *RequestBuilder {
 // SetConcurrency sets "Concurrency" for "kv.Request".
 func (builder *RequestBuilder) SetConcurrency(concurrency int) *RequestBuilder {
 	builder.Request.Concurrency = concurrency
+	return builder
+}
+
+// SetFixedConcurrency marks the concurrency as explicitly set, preventing
+// Build() from reducing it for simple ordered scans.
+func (builder *RequestBuilder) SetFixedConcurrency() *RequestBuilder {
+	builder.Request.FixedConcurrency = true
 	return builder
 }
 

--- a/pkg/distsql/request_builder_test.go
+++ b/pkg/distsql/request_builder_test.go
@@ -960,3 +960,43 @@ func TestRequestBuilderHandle(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tag.TableId, tableID)
 }
+
+func TestBuildReducesConcurrencyForSimpleOrderedScan(t *testing.T) {
+	// When KeepOrder=true, concurrency=default, and a simple scan executor,
+	// Build() should reduce concurrency to 2.
+	dag := &tipb.DAGRequest{}
+	dag.Executors = []*tipb.Executor{{Tp: tipb.ExecType_TypeTableScan}}
+
+	actual, err := (&RequestBuilder{}).
+		SetDAGRequest(dag).
+		SetKeepOrder(true).
+		SetFromSessionVars(DefaultDistSQLContext).
+		Build()
+	require.NoError(t, err)
+	require.Equal(t, 2, actual.Concurrency)
+}
+
+func TestBuildKeepsConcurrencyWhenFixedConcurrency(t *testing.T) {
+	// When FixedConcurrency=true, Build() must NOT reduce concurrency,
+	// even for a simple ordered scan with default concurrency.
+	dag := &tipb.DAGRequest{}
+	dag.Executors = []*tipb.Executor{{Tp: tipb.ExecType_TypeTableScan}}
+
+	actual, err := (&RequestBuilder{}).
+		SetDAGRequest(dag).
+		SetKeepOrder(true).
+		SetFromSessionVars(DefaultDistSQLContext).
+		SetFixedConcurrency().
+		Build()
+	require.NoError(t, err)
+	require.Equal(t, vardef.DefDistSQLScanConcurrency, actual.Concurrency)
+}
+
+func TestSetFromSessionVarsPropagatesFixedConcurrency(t *testing.T) {
+	dctx := NewDistSQLContextForTest()
+	dctx.FixedDistSQLConcurrency = true
+
+	builder := &RequestBuilder{}
+	builder.SetFromSessionVars(dctx)
+	require.True(t, builder.Request.FixedConcurrency)
+}

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -583,6 +583,10 @@ type Request struct {
 	// ResponseIterator.Next is called. If concurrency is greater than 1, the request will be
 	// sent to multiple storage units concurrently.
 	Concurrency int
+	// FixedConcurrency indicates the concurrency value was explicitly chosen
+	// for this request and should not be reduced by Build() optimizations
+	// (e.g., reducing to 2 for simple ordered scans).
+	FixedConcurrency bool
 	// IsolationLevel is the isolation level, default is SI.
 	IsolationLevel IsoLevel
 	// Priority is the priority of this KV request, its value may be PriorityNormal/PriorityLow/PriorityHigh.

--- a/pkg/session/nontransactional.go
+++ b/pkg/session/nontransactional.go
@@ -452,6 +452,14 @@ func buildShardJobs(ctx context.Context, stmt *ast.NonTransactionalDMLStmt, se s
 		shardColumnCollate = ""
 	}
 
+	// The request_builder reduces concurrency to 2 for simple ordered scans
+	// when concurrency equals the default. Non-transactional DML internal scans
+	// need full concurrency to collect shard keys efficiently.
+	se.GetSessionVars().FixedDistSQLConcurrency = true
+	defer func() {
+		se.GetSessionVars().FixedDistSQLConcurrency = false
+	}()
+
 	// A NT-DML is not a SELECT. We ignore the SelectLimit for selectSQL so that it can read all values.
 	originalSelectLimit := se.GetSessionVars().SelectLimit
 	se.GetSessionVars().SelectLimit = math.MaxUint64

--- a/pkg/session/nontransactional.go
+++ b/pkg/session/nontransactional.go
@@ -455,9 +455,10 @@ func buildShardJobs(ctx context.Context, stmt *ast.NonTransactionalDMLStmt, se s
 	// The request_builder reduces concurrency to 2 for simple ordered scans
 	// when concurrency equals the default. Non-transactional DML internal scans
 	// need full concurrency to collect shard keys efficiently.
+	origFixed := se.GetSessionVars().FixedDistSQLConcurrency
 	se.GetSessionVars().FixedDistSQLConcurrency = true
 	defer func() {
-		se.GetSessionVars().FixedDistSQLConcurrency = false
+		se.GetSessionVars().FixedDistSQLConcurrency = origFixed
 	}()
 
 	// A NT-DML is not a SELECT. We ignore the SelectLimit for selectSQL so that it can read all values.

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3365,6 +3365,7 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 			TiFlashHashJoinVersion:               vars.TiFlashHashJoinVersion,
 
 			DistSQLConcurrency:            vars.DistSQLScanConcurrency(),
+			FixedDistSQLConcurrency:       vars.FixedDistSQLConcurrency,
 			ReplicaReadType:               vars.GetReplicaRead(),
 			WeakConsistency:               sc.WeakConsistency,
 			RCCheckTS:                     sc.RCCheckTS,

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1864,6 +1864,10 @@ type SessionVars struct {
 	// InternalSQLScanUserTable indicates whether to use user table for internal SQL. it will be used by TTL scan
 	InternalSQLScanUserTable bool
 
+	// FixedDistSQLConcurrency indicates the DistSQL scan concurrency was explicitly
+	// set for internal operations and should not be reduced by request builder optimizations.
+	FixedDistSQLConcurrency bool
+
 	// MemArbitrator represents the properties to be controlled by the memory arbitrator.
 	MemArbitrator struct {
 		WaitAverse    MemArbitratorWaitAverseMode

--- a/pkg/util/mock/context.go
+++ b/pkg/util/mock/context.go
@@ -272,6 +272,7 @@ func (c *Context) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 		TiFlashHashJoinVersion:               vars.TiFlashHashJoinVersion,
 		ResourceGroupName:                    sc.ResourceGroupName,
 		ExecDetails:                          &sc.SyncExecDetails,
+		FixedDistSQLConcurrency:              vars.FixedDistSQLConcurrency,
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67329

Problem Summary:

The `request_builder.Build()` reduces scan concurrency from `DefDistSQLScanConcurrency` (15) to 2 for simple ordered scans, assuming the MySQL protocol is the bottleneck for user-facing queries. However, non-transactional DML executes an internal `SELECT ... ORDER BY` to collect shard keys, where this optimization hurts performance — the internal scan benefits from full concurrency.

### What changed and how does it work?

Adds a `FixedConcurrency` flag that flows through the system:

1. **`pkg/kv/kv.go`** — `FixedConcurrency bool` field on `Request`
2. **`pkg/distsql/request_builder.go`** — `Build()` checks `!FixedConcurrency` before reducing concurrency; new `SetFixedConcurrency()` builder method; propagation in `SetFromSessionVars()`
3. **`pkg/distsql/context/context.go`** — `FixedDistSQLConcurrency` on `DistSQLContext`
4. **`pkg/sessionctx/variable/session.go`** — `FixedDistSQLConcurrency` on `SessionVars`
5. **`pkg/session/session.go`** — propagation to `DistSQLContext`
6. **`pkg/session/nontransactional.go`** — sets the flag before the internal shard key scan

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix non-transactional DML internal scan using reduced concurrency (2 instead of 15) when `tidb_distsql_scan_concurrency` is at its default value, which degraded shard key collection performance.
```

---

**Generative AI disclosure:** This PR was co-authored with Claude (Anthropic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mark DistSQL scan concurrency as explicitly configured so it won't be reduced by automatic optimizations, preserving requested concurrency for affected requests.
* **Behavior Changes**
  * Request construction now respects the "fixed concurrency" setting, preventing certain build-time concurrency reductions when set. Session state and internal flows propagate this flag where needed.
* **Tests**
  * Added unit tests validating fixed-vs-default concurrency behavior and propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
