### PR TITLE
br: fix --check-requirements=false not skipping version checks in RunRestore

### DIFF
--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1019,13 +1019,17 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	cfg.RestoreRegistry = restoreRegistry
 
 	if IsStreamRestore(cmdName) {
-		if err := version.CheckClusterVersion(c, mgr.GetPDClient(), version.CheckVersionForBRPiTR); err != nil {
-			return errors.Trace(err)
+		if cfg.CheckRequirements {
+			if err := version.CheckClusterVersion(c, mgr.GetPDClient(), version.CheckVersionForBRPiTR); err != nil {
+				return errors.Trace(err)
+			}
 		}
 		restoreErr = RunStreamRestore(c, mgr, g, cfg)
 	} else {
-		if err := version.CheckClusterVersion(c, mgr.GetPDClient(), version.CheckVersionForBR); err != nil {
-			return errors.Trace(err)
+		if cfg.CheckRequirements {
+			if err := version.CheckClusterVersion(c, mgr.GetPDClient(), version.CheckVersionForBR); err != nil {
+				return errors.Trace(err)
+			}
 		}
 		snapshotRestoreConfig := SnapshotRestoreConfig{
 			RestoreConfig: cfg,

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1018,19 +1018,18 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	defer restoreRegistry.Close()
 	cfg.RestoreRegistry = restoreRegistry
 
-	if IsStreamRestore(cmdName) {
-		if cfg.CheckRequirements {
-			if err := version.CheckClusterVersion(c, mgr.GetPDClient(), version.CheckVersionForBRPiTR); err != nil {
-				return errors.Trace(err)
-			}
+	if cfg.CheckRequirements {
+		verChecker := version.CheckVersionForBR
+		if IsStreamRestore(cmdName) {
+			verChecker = version.CheckVersionForBRPiTR
 		}
+		if err := version.CheckClusterVersion(c, mgr.GetPDClient(), verChecker); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if IsStreamRestore(cmdName) {
 		restoreErr = RunStreamRestore(c, mgr, g, cfg)
 	} else {
-		if cfg.CheckRequirements {
-			if err := version.CheckClusterVersion(c, mgr.GetPDClient(), version.CheckVersionForBR); err != nil {
-				return errors.Trace(err)
-			}
-		}
 		snapshotRestoreConfig := SnapshotRestoreConfig{
 			RestoreConfig: cfg,
 		}

--- a/br/pkg/version/version_test.go
+++ b/br/pkg/version/version_test.go
@@ -332,6 +332,27 @@ func TestCheckClusterVersion(t *testing.T) {
 	}
 
 	{
+		// BR v26.x and TiKV v8.x: major version difference > 2, should fail
+		build.ReleaseVersion = "v26.3.0"
+		mock.getAllStores = func() []*metapb.Store {
+			return []*metapb.Store{{Version: "v8.5.4"}}
+		}
+		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBR)
+		require.Error(t, err)
+		require.Regexp(t, "major version mismatch", err.Error())
+	}
+
+	{
+		// nightly-dirty (test build) skips all version checks
+		build.ReleaseVersion = build.ReleaseVersionForTest
+		mock.getAllStores = func() []*metapb.Store {
+			return []*metapb.Store{{Version: "v8.5.4"}}
+		}
+		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBR)
+		require.NoError(t, err)
+	}
+
+	{
 		mock.getAllStores = func() []*metapb.Store {
 			return []*metapb.Store{{Version: "v6.4.0"}}
 		}


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67402

Problem Summary:

`--check-requirements=false` is supposed to skip version compatibility checks between BR and TiKV. However, `RunRestore` in `br/pkg/task/restore.go` contains two hard-coded calls to `version.CheckClusterVersion` that are not guarded by `cfg.CheckRequirements`:

- Line 1022: `CheckVersionForBRPiTR` (stream restore path)
- Line 1027: `CheckVersionForBR` (snapshot restore path)

Only the call inside `NewMgr` (`conn.go:177`) respects the flag. The calls in `RunRestore` always execute, making `--check-requirements=false` ineffective.

### What changed and how does it work?

Wrap both `CheckClusterVersion` calls in `RunRestore` with `if cfg.CheckRequirements { ... }`, consistent with how the check is handled in `NewMgr`.

Also add two test cases to `TestCheckClusterVersion` in `br/pkg/version/version_test.go`:
- BR v26.x vs TiKV v8.x: major version difference > 2, expect error
- `nightly-dirty` build skips all version checks, expect no error

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix `--check-requirements=false` not taking effect when BR's `RunRestore` calls version compatibility checks directly, causing restore to fail even when version checking is explicitly disabled.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Version checking during restore operations is now conditional and configurable. Validation logic dynamically adapts based on restore type (stream vs. snapshot).

* **Tests**
  * Added test scenarios for version compatibility validation, including major version mismatch detection and test build compatibility verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->