### PR TITLE
tests/realtikvtest/importintotest4: avoid failpoint timestamp race in TestNextGenMetering

### DIFF
--- a/tests/realtikvtest/importintotest4/global_sort_test.go
+++ b/tests/realtikvtest/importintotest4/global_sort_test.go
@@ -478,12 +478,11 @@ func TestNextGenMetering(t *testing.T) {
 	glSortURI := realtikvtest.GetNextGenObjStoreURI("gl-sort")
 	s.tk.MustExec("create table t (a bigint primary key , b varchar(100), index(b));")
 
-	baseTime := time.Now().Truncate(time.Minute).Unix()
+	baseTime := atomic.NewInt64(time.Now().Truncate(time.Minute).Unix() - 60)
 	testfailpoint.EnableCall(s.T(), "github.com/pingcap/tidb/pkg/dxf/framework/metering/forceTSAtMinuteBoundary", func(ts *int64) {
 		// the metering library requires the timestamp to be at minute boundary, but
 		// during test, we want to reduce the flush interval.
-		*ts = baseTime
-		baseTime += 60
+		*ts = baseTime.Add(60)
 	})
 	// this failpoint can make sure we only get one gotMeterData
 	testfailpoint.Enable(s.T(), "github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/avoidTaskExecutorExitWhenNoSubtask", "return(true)")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #66367

Problem Summary:

`TestNextGenMetering` can fail under race detection because the failpoint callback for `forceTSAtMinuteBoundary` mutates a shared `baseTime` variable without synchronization. `WriteMeterData` is invoked from concurrent paths (meter flush loop and cleanup metering send), so the callback can run concurrently and trigger a data race in test code.

### What changed and how does it work?

- Replaced the mutable `int64 baseTime` local variable with `atomic.Int64` in `TestNextGenMetering`.
- Switched callback logic to `baseTime.Add(60)` so each failpoint invocation gets a unique minute-boundary timestamp with atomic update semantics.

This keeps test behavior (advancing one minute per callback) while removing unsynchronized shared-memory access.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test commands/results:

- `go test -c -race -tags=intest,deadlock,nextgen ./tests/realtikvtest/importintotest4` (pass, compile check)
- `make lint` (pass)
- `go test -v -race -run TestNextGenMetering -count=1 -tags=intest,deadlock,nextgen ./tests/realtikvtest/importintotest4/... -timeout 2m -args -with-real-tikv` (fails in local env before assertion path: `Load keyspace SYSTEM failed: keyspace does not exist`)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test implementation to use atomic operations for improved thread-safety handling in timing-related test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->