### PR TITLE
*: clarify comments related to job version handling

### DIFF
--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -966,6 +966,9 @@ func (d *ddl) Start(startMode StartMode, ctxPool *pools.ResourcePool) error {
 	return nil
 }
 
+// this detection is only used for Classic kernel. for NextGen(TiDB-X), the job
+// version is always started with V2, no need to detect kernel version.
+//
 // detect versions of all TiDB instances and choose a job version to use, rules:
 //   - if it's in test or run in uni-store, use V2 directly if ForceDDLJobVersionToV1InTest
 //     is not set, else use V1, we use this rule to run unit-tests using V1.

--- a/pkg/dxf/importinto/planner.go
+++ b/pkg/dxf/importinto/planner.go
@@ -691,7 +691,6 @@ func getRangeSplitter(
 		zap.Int64("range-keys", rangeKeys),
 	)
 
-	// no matter region split size and keys, we always split range jobs by 96MB
 	return external.NewRangeSplitter(
 		ctx,
 		kvMeta.MultipleFilesStats,

--- a/pkg/meta/model/job.go
+++ b/pkg/meta/model/job.go
@@ -1356,7 +1356,8 @@ func init() {
 	// initially, and then we detect the right version when DDL start.
 	ver := JobVersion1
 	if kerneltype.IsNextGen() {
-		// nextgen doesn't need to consider the compatibility with old TiDB versions,
+		// NextGen doesn't need to consider the compatibility with old TiDB
+		// versions, the initial version can be set to v2 directly.
 		ver = JobVersion2
 	}
 	SetJobVerInUse(ver)


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref #61702

Problem Summary:
Some comments around DDL job version selection and import range split behavior were misleading or inconsistent.

### What changed and how does it work?
- Clarified comments in `pkg/ddl/ddl.go` to explicitly scope kernel-version detection to classic kernel and explain NextGen behavior.
- Improved wording in `pkg/meta/model/job.go` about initializing job version `v2` for NextGen.
- Removed an outdated/misleading comment in `pkg/dxf/importinto/planner.go` before `NewRangeSplitter`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] Only comments were changed; no executable logic changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal code comments to clarify kernel version detection behavior for Classic kernel and job version initialization for NextGen environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->