### PR TITLE
chore: bump pd client to include resourcegroup signal-aware wait fix

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -6907,13 +6907,13 @@ def go_deps():
         name = "com_github_tikv_pd_client",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/pd/client",
-        sha256 = "b89c6017c0e766b00e8524c6dbb8aee2247364f1f6739a470ee77039b0db7d4e",
-        strip_prefix = "github.com/tikv/pd/client@v0.0.0-20251219084741-029eb6e7d5d0",
+        sha256 = "af89b7a867ec8dd05ceaa0509c38d560d6dd619317aa1e5b1c7c725a7e59f2dc",
+        strip_prefix = "github.com/tikv/pd/client@v0.0.0-20260330105957-ebf9af006aac",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20251219084741-029eb6e7d5d0.zip",
-            "http://ats.apps.svc/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20251219084741-029eb6e7d5d0.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20251219084741-029eb6e7d5d0.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20251219084741-029eb6e7d5d0.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260330105957-ebf9af006aac.zip",
+            "http://ats.apps.svc/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260330105957-ebf9af006aac.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260330105957-ebf9af006aac.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260330105957-ebf9af006aac.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/tdakkota/asciicheck v0.2.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
 	github.com/tikv/client-go/v2 v2.0.8-0.20260112052152-1d3c5ec76bf8
-	github.com/tikv/pd/client v0.0.0-20251219084741-029eb6e7d5d0
+	github.com/tikv/pd/client v0.0.0-20260330105957-ebf9af006aac
 	github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a
 	github.com/twmb/murmur3 v1.1.6
 	github.com/uber/jaeger-client-go v2.22.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -762,8 +762,8 @@ github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
 github.com/tikv/client-go/v2 v2.0.8-0.20260112052152-1d3c5ec76bf8 h1:zXvmqjetn+Kvs7PL98PahiIp/IswDlT0G39p95OuSPg=
 github.com/tikv/client-go/v2 v2.0.8-0.20260112052152-1d3c5ec76bf8/go.mod h1:iVLG2tuDVyBd9BN6e9JNFtUeEQarvKN7pTcW+pb3nFw=
-github.com/tikv/pd/client v0.0.0-20251219084741-029eb6e7d5d0 h1:fguMZ4sSn/oLbUt+zDoNPd6+OE3Li4Rop2/3vFhu8lM=
-github.com/tikv/pd/client v0.0.0-20251219084741-029eb6e7d5d0/go.mod h1:X3T+jK+4bLbDKgupmzvVXuySnCNV4Lfdm/bL8TAw3ik=
+github.com/tikv/pd/client v0.0.0-20260330105957-ebf9af006aac h1:RmpwJKGhY7+PN3IohrwDN5gqmIQ/g5HBgxd7ICPEYNw=
+github.com/tikv/pd/client v0.0.0-20260330105957-ebf9af006aac/go.mod h1:X3T+jK+4bLbDKgupmzvVXuySnCNV4Lfdm/bL8TAw3ik=
 github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a h1:A6uKudFIfAEpoPdaal3aSqGxBzLyU8TqyXImLwo6dIo=
 github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a/go.mod h1:mkjARE7Yr8qU23YcGMSALbIxTQ9r9QBVahQOBRfU460=
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref tikv/pd#10251

Update `github.com/tikv/pd/client` to pick up tikv/pd#10505 (cherry-pick of tikv/pd#10252: `resourcegroup: replace blind sleep with signal-aware wait in acquireTokens`).

### What changed and how does it work?

Bump `github.com/tikv/pd/client` from `v0.0.0-20251219084741-029eb6e7d5d0` to `v0.0.0-20260330105957-ebf9af006aac` to include the signal-aware wait fix in `acquireTokens`, which replaces blind sleep with a channel-based notification on `Reconfigure()`.

### Check List

Tests

- [x] No need to test
  > - [x] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the TiKV PD client dependency to a newer pinned release and refreshed related build/dependency metadata. No public APIs or application behavior were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->