### PR TITLE
br: increase bazel timeout for backup_test

### DIFF
--- a/br/pkg/backup/BUILD.bazel
+++ b/br/pkg/backup/BUILD.bazel
@@ -62,7 +62,7 @@ go_library(
 
 go_test(
     name = "backup_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "client_test.go",
         "limit_test.go",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66027

Problem Summary:
`TestBackupSchemasForSystemTable` is sometimes slow in CI although it is fast locally. The Bazel test target currently uses `timeout = "short"`, which can be too strict under CI environment variability.

### What changed and how does it work?
- Updated `br/pkg/backup/BUILD.bazel` for `go_test(name = "backup_test")`
- Increased Bazel timeout class from `short` to `moderate`

This keeps test logic unchanged and only relaxes Bazel timeout budget to reduce CI flakes caused by environment/runtime variance.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands run:
- `make bazel_prepare`
- `./tools/check/failpoint-go-test.sh br/pkg/backup -run TestBackupSchemasForSystemTable -count=1`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test execution timeout configuration for internal build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->