### PR TITLE
planner: migrate `EXPLAIN` output in integration_test.go to `format='plan_tree'`

### DIFF
--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -2273,7 +2273,7 @@ func TestAggregationInWindowFunctionPushDownToTiFlash(t *testing.T) {
 		rows := [][]any{
 			{"TableReader", "root", "MppVersion: 3, data:ExchangeSender"},
 			{"└─ExchangeSender", "mpp[tiflash]", "ExchangeType: PassThrough"},
-			{"  └─Projection", "mpp[tiflash]", "Column->Column, Column->Column, Column->Column, Column->Column, Column->Column, stream_count: 8"},
+			{"  └─Projection", "mpp[tiflash]", "Column, Column, Column, Column, Column, stream_count: 8"},
 			{"    └─Window", "mpp[tiflash]", "sum(cast(test.t.v, decimal(10,0) BINARY))->Column, count(test.t.v)->Column, avg(cast(test.t.v, decimal(10,0) BINARY))->Column, min(test.t.v)->Column, max(test.t.v)->Column over(partition by test.t.p order by test.t.o range between unbounded preceding and current row), stream_count: 8"},
 			{"      └─Sort", "mpp[tiflash]", "test.t.p, test.t.o, stream_count: 8"},
 			{"        └─ExchangeReceiver", "mpp[tiflash]", "stream_count: 8"},


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #67112

Problem Summary: Test cases that rely on `EXPLAIN` output in `format='brief'` or `format='verbose'`, but only need to validate the structure of the plan, are brittle and will start failing if minor changes in row estimates or table schema occur. This requires regenerating a large number of new plans for optimizer tests when making changes, adding noise to PR diffs and obscuring potential problems that these tests may have otherwise caught.

### What changed and how does it work?

Convert non-analyze `EXPLAIN` tests in pkg/planner/core/integration_test.go to use `format='plan_tree'`. This strips operator ID suffixes, omits `estRows`, and normalizes "Column#N" to "Column". This also necessitates updating a number of column indices, because `estRows` is no longer included for example.

`EXPLAIN ANALYZE` tests still use `format='brief'` since `format='plan_tree'` is not supported by `EXPLAIN ANALYZE`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated query-plan tests to match a revised plan-tree output format and adjusted expected plan/operator renderings.
  * Alignments made for projected/aggregated/windowed operator output and index offsets in test assertions.
  * No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->