### PR TITLE
ddl: add dedicated DDL KV store with smaller gRPC windows for add index

### DIFF
--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -176,7 +176,15 @@ func (s *backfillDistExecutor) newBackfillStepExecutor(
 		jc := ddlObj.jobContext(jobMeta.ID, jobMeta.ReorgMeta)
 		ddlObj.attachTopProfilingInfo(jobMeta.ID, jobMeta.Query)
 		ddlObj.setDDLSourceForDiagnosis(jobMeta.ID, jobMeta.Type)
-		return newReadIndexExecutor(store, sessPool, ddlObj.etcdCli, jobMeta, indexInfos, tbl, jc, cloudStorageURI, estRowSize)
+		// For the read-index step, prefer the dedicated DDL store which has
+		// smaller gRPC window sizes to reduce memory during global sort ADD
+		// INDEX. Only use it when we haven't switched to a cross-keyspace
+		// store (i.e., store is still the original ddlObj.store).
+		readStore := store
+		if len(cloudStorageURI) > 0 && store == ddlObj.store && ddlObj.ddlStore != nil {
+			readStore = ddlObj.ddlStore
+		}
+		return newReadIndexExecutor(readStore, sessPool, ddlObj.etcdCli, jobMeta, indexInfos, tbl, jc, cloudStorageURI, estRowSize)
 	case proto.BackfillStepMergeSort:
 		return newMergeSortExecutor(&s.task.TaskBase, store, jobMeta.ID, indexInfos, tbl, cloudStorageURI)
 	case proto.BackfillStepWriteAndIngest:

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -354,6 +354,13 @@ type ddlCtx struct {
 	schemaVerSyncer   schemaver.Syncer
 	serverStateSyncer serverstate.Syncer
 
+	// ddlStore is a dedicated kv.Storage for DDL backfill (read-index)
+	// operations. It uses smaller gRPC window sizes (4 MiB vs 128 MiB) to
+	// reduce memory consumption during global sort ADD INDEX without
+	// affecting OLTP workloads. It may be nil for non-TiKV stores (e.g.,
+	// unistore in tests), in which case the main store is used.
+	ddlStore kv.Storage
+
 	ddlEventCh   chan<- *notifier.SchemaChangeEvent
 	lease        time.Duration // lease is schema lease, default 45s, see config.Lease.
 	infoCache    *infoschema.InfoCache
@@ -782,9 +789,23 @@ func newDDL(ctx context.Context, options ...Option) (*ddl, *executor) {
 		panic("infoCache should not be nil")
 	}
 
+	// Create a dedicated DDL store with smaller gRPC window sizes to reduce
+	// memory consumption during global sort ADD INDEX. Falls back to the
+	// main store if creation fails or if the factory is not registered
+	// (e.g., in tests with unistore).
+	ddlStore := opt.Store
+	if kv.OpenDDLStoreFunc != nil {
+		if ds, err := kv.OpenDDLStoreFunc(opt.Store); err != nil {
+			logutil.DDLLogger().Warn("failed to open dedicated DDL store, falling back to main store", zap.Error(err))
+		} else {
+			ddlStore = ds
+		}
+	}
+
 	ddlCtx := &ddlCtx{
 		uuid:              id,
 		store:             opt.Store,
+		ddlStore:          ddlStore,
 		lease:             opt.Lease,
 		ownerManager:      manager,
 		schemaVerSyncer:   schemaVerSyncer,
@@ -1199,6 +1220,14 @@ func (d *ddl) close() {
 	}
 	if d.sessPool != nil {
 		d.sessPool.Close()
+	}
+	// Close the dedicated DDL store if it differs from the main store.
+	// This must happen before the main store is closed to avoid issues
+	// with shared cluster resources.
+	if d.ddlStore != nil && d.ddlStore != d.store {
+		if err := d.ddlStore.Close(); err != nil {
+			logutil.DDLLogger().Warn("failed to close DDL store", zap.Error(err))
+		}
 	}
 	variable.UnregisterStatistics(d)
 

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -910,3 +910,8 @@ func decodeTableID(key Key) int64 {
 	}
 	return 0
 }
+
+// OpenDDLStoreFunc is a factory function that creates a dedicated Storage for
+// DDL backfill operations with tuned gRPC settings. It is set by
+// pkg/store/driver to avoid import cycles. If nil, the main store is used.
+var OpenDDLStoreFunc func(mainStore Storage) (Storage, error)

--- a/pkg/store/driver/BUILD.bazel
+++ b/pkg/store/driver/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "driver",
-    srcs = ["tikv_driver.go"],
+    srcs = [
+        "ddl_store.go",
+        "tikv_driver.go",
+    ],
     importpath = "github.com/pingcap/tidb/pkg/store/driver",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/store/driver/ddl_store.go
+++ b/pkg/store/driver/ddl_store.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -29,7 +30,9 @@ import (
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/tikv"
+	"github.com/tikv/client-go/v2/tikvrpc"
 	"github.com/tikv/client-go/v2/util"
+	"github.com/tikv/client-go/v2/util/async"
 	pd "github.com/tikv/pd/client"
 	pdhttp "github.com/tikv/pd/client/http"
 	"github.com/tikv/pd/client/opt"
@@ -51,7 +54,14 @@ const (
 	// ddlGRPCInitialConnWindowSize is the gRPC initial connection-level window
 	// size for DDL backfill operations (4 MiB), matching the stream-level size.
 	ddlGRPCInitialConnWindowSize int32 = 4 * 1024 * 1024
+
+	// ddlGRPCConnectionCount is the connection count per TiKV store for the
+	// dedicated DDL store. Using a single connection further caps the per-store
+	// in-flight gRPC memory during read-index global sort.
+	ddlGRPCConnectionCount uint = 1
 )
+
+var ddlClientConfigMu sync.Mutex
 
 // OpenDDLStore creates a dedicated kv.Storage for DDL backfill (read-index)
 // operations with smaller gRPC window sizes to reduce memory consumption.
@@ -158,7 +168,15 @@ func OpenDDLStore(mainStore kv.Storage) (kv.Storage, error) {
 	clusterID := pdCli.GetClusterID(context.TODO())
 	uuid := fmt.Sprintf("tikv-%v/%s/ddl", clusterID, keyspaceName)
 
-	s, err := tikv.NewKVStore(uuid, pdClient, spkv, &injectTraceClient{Client: rpcClient},
+	ddlClient := &ddlRPCClient{
+		Client: rpcClient,
+		cfg: ddlRPCClientConfig{
+			grpcConnectionCount: ddlGRPCConnectionCount,
+			maxBatchSize:        0,
+		},
+	}
+
+	s, err := tikv.NewKVStore(uuid, pdClient, spkv, &injectTraceClient{Client: ddlClient},
 		tikv.WithPDHTTPClient("tikv-ddl-store", etcdAddrs,
 			pdhttp.WithTLSConfig(tlsConfig),
 			pdhttp.WithMetrics(metrics.PDAPIRequestCounter, metrics.PDAPIExecutionHistogram)))
@@ -189,6 +207,8 @@ func OpenDDLStore(mainStore kv.Storage) (kv.Storage, error) {
 	}
 
 	logutil.BgLogger().Info("opened dedicated DDL store with reduced gRPC window sizes",
+		zap.Uint("grpcConnectionCount", ddlGRPCConnectionCount),
+		zap.Uint("maxBatchSize", ddlClient.cfg.maxBatchSize),
 		zap.Int32("initialWindowSize", ddlGRPCInitialWindowSize),
 		zap.Int32("initialConnWindowSize", ddlGRPCInitialConnWindowSize),
 		zap.String("uuid", uuid))
@@ -223,4 +243,42 @@ func setRPCClientGRPCDialOptions(rpcClient any, opts []grpc.DialOption) {
 	}
 	// Write to the unexported field via unsafe pointer.
 	*(*[]grpc.DialOption)(unsafe.Pointer(grpcField.UnsafeAddr())) = opts
+}
+
+type ddlRPCClientConfig struct {
+	grpcConnectionCount uint
+	maxBatchSize        uint
+}
+
+// ddlRPCClient wraps the dedicated DDL RPC client and temporarily overrides
+// client-go's global TiKV config for the duration of request dispatch. This is
+// a hack for validation until client-go exports per-client connection-count
+// configuration.
+type ddlRPCClient struct {
+	tikv.Client
+	cfg ddlRPCClientConfig
+}
+
+func (c *ddlRPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
+	restore := c.overrideConfig()
+	defer restore()
+	return c.Client.SendRequest(ctx, addr, req, timeout)
+}
+
+func (c *ddlRPCClient) SendRequestAsync(ctx context.Context, addr string, req *tikvrpc.Request, cb async.Callback[*tikvrpc.Response]) {
+	restore := c.overrideConfig()
+	defer restore()
+	c.Client.SendRequestAsync(ctx, addr, req, cb)
+}
+
+func (c *ddlRPCClient) overrideConfig() func() {
+	ddlClientConfigMu.Lock()
+	restore := config.UpdateGlobal(func(conf *config.Config) {
+		conf.TiKVClient.GrpcConnectionCount = c.cfg.grpcConnectionCount
+		conf.TiKVClient.MaxBatchSize = c.cfg.maxBatchSize
+	})
+	return func() {
+		restore()
+		ddlClientConfigMu.Unlock()
+	}
 }

--- a/pkg/store/driver/ddl_store.go
+++ b/pkg/store/driver/ddl_store.go
@@ -1,0 +1,226 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"reflect"
+	"time"
+	"unsafe"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/metrics"
+	"github.com/pingcap/tidb/pkg/store/copr"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/tikv/client-go/v2/config"
+	"github.com/tikv/client-go/v2/tikv"
+	"github.com/tikv/client-go/v2/util"
+	pd "github.com/tikv/pd/client"
+	pdhttp "github.com/tikv/pd/client/http"
+	"github.com/tikv/pd/client/opt"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+)
+
+const (
+	// ddlGRPCInitialWindowSize is the gRPC initial window size for DDL backfill
+	// operations (4 MiB). This is much smaller than the default 128 MiB to reduce
+	// memory consumption during global sort ADD INDEX. With large regions (1 GiB),
+	// the default 128 MiB windows across multiple connections per store can consume
+	// over 1.5 GiB just for flow-control buffers (4 conns * 3 stores * 128 MiB).
+	// Using 4 MiB windows reduces this to ~48 MiB while still allowing sufficient
+	// throughput for DDL coprocessor scans.
+	ddlGRPCInitialWindowSize int32 = 4 * 1024 * 1024
+
+	// ddlGRPCInitialConnWindowSize is the gRPC initial connection-level window
+	// size for DDL backfill operations (4 MiB), matching the stream-level size.
+	ddlGRPCInitialConnWindowSize int32 = 4 * 1024 * 1024
+)
+
+// OpenDDLStore creates a dedicated kv.Storage for DDL backfill (read-index)
+// operations with smaller gRPC window sizes to reduce memory consumption.
+//
+// The returned store has its own RPC client and gRPC connection pools, so its
+// tuned window sizes do not affect the main OLTP store. It shares the same PD
+// cluster and TLS configuration but creates independent PD client and safepoint
+// KV instances so that closing the DDL store does not affect the main store.
+//
+// The caller is responsible for closing the returned store when it is no longer
+// needed. The DDL store must be closed before the main store.
+func OpenDDLStore(mainStore kv.Storage) (kv.Storage, error) {
+	ts, ok := mainStore.(*tikvStore)
+	if !ok {
+		// Not a real TiKV store (e.g., unistore for tests). Return the main
+		// store directly; DDL will work the same way but without separate gRPC
+		// window tuning.
+		logutil.BgLogger().Info("main store is not a TiKV store, DDL store will reuse it")
+		return mainStore, nil
+	}
+
+	etcdAddrs := ts.etcdAddrs
+	if len(etcdAddrs) == 0 {
+		return mainStore, nil
+	}
+
+	tidbCfg := config.GetGlobalConfig()
+	security := tidbCfg.Security
+	tikvConfig := tidbCfg.TiKVClient
+	pdConfig := tidbCfg.PDClient
+
+	keyspaceName := ts.keyspace
+	var apiCtx = pd.NewAPIContextV1()
+	if len(keyspaceName) > 0 {
+		apiCtx = pd.NewAPIContextV2(keyspaceName)
+	}
+
+	pdCli, err := pd.NewClientWithAPIContext(
+		context.Background(), apiCtx, "tidb-ddl-store", etcdAddrs,
+		pd.SecurityOption{
+			CAPath:   security.ClusterSSLCA,
+			CertPath: security.ClusterSSLCert,
+			KeyPath:  security.ClusterSSLKey,
+		},
+		opt.WithGRPCDialOptions(
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
+			grpc.WithKeepaliveParams(keepalive.ClientParameters{
+				Time:    time.Duration(tikvConfig.GrpcKeepAliveTime) * time.Second,
+				Timeout: time.Duration(tikvConfig.GrpcKeepAliveTimeout) * time.Second,
+			}),
+		),
+		opt.WithCustomTimeoutOption(time.Duration(pdConfig.PDServerTimeout)*time.Second),
+		opt.WithForwardingOption(tidbCfg.EnableForwarding),
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	pdCli = util.InterceptedPDClient{Client: pdCli}
+
+	tlsConfig, err := security.ToTLSConfig()
+	if err != nil {
+		pdCli.Close()
+		return nil, errors.Trace(err)
+	}
+
+	spkv, err := tikv.NewEtcdSafePointKV(etcdAddrs, tlsConfig)
+	if err != nil {
+		pdCli.Close()
+		return nil, errors.Trace(err)
+	}
+
+	var pdClient *tikv.CodecPDClient
+	if keyspaceName == "" {
+		pdClient = tikv.NewCodecPDClient(tikv.ModeTxn, pdCli)
+	} else {
+		pdClient, err = tikv.NewCodecPDClientWithKeyspace(tikv.ModeTxn, pdCli, keyspaceName)
+		if err != nil {
+			spkv.Close()
+			pdCli.Close()
+			return nil, errors.Trace(err)
+		}
+	}
+
+	codec := pdClient.GetCodec()
+
+	rpcClient := tikv.NewRPCClient(
+		tikv.WithSecurity(security),
+		tikv.WithCodec(codec),
+	)
+
+	// Override gRPC window sizes on the DDL RPC client to use smaller buffers.
+	// This reduces memory consumption during global sort ADD INDEX.
+	//
+	// NOTE: client-go does not currently export WithGRPCDialOptions from the
+	// tikv package (it is in internal/client). We use reflect+unsafe to set
+	// the field directly. This should be replaced with a proper API call once
+	// client-go exports tikv.WithGRPCDialOptions.
+	// Tracked in: https://github.com/pingcap/tidb/issues/64911
+	setRPCClientGRPCDialOptions(rpcClient, []grpc.DialOption{
+		grpc.WithInitialWindowSize(ddlGRPCInitialWindowSize),
+		grpc.WithInitialConnWindowSize(ddlGRPCInitialConnWindowSize),
+	})
+
+	clusterID := pdCli.GetClusterID(context.TODO())
+	uuid := fmt.Sprintf("tikv-%v/%s/ddl", clusterID, keyspaceName)
+
+	s, err := tikv.NewKVStore(uuid, pdClient, spkv, &injectTraceClient{Client: rpcClient},
+		tikv.WithPDHTTPClient("tikv-ddl-store", etcdAddrs,
+			pdhttp.WithTLSConfig(tlsConfig),
+			pdhttp.WithMetrics(metrics.PDAPIRequestCounter, metrics.PDAPIExecutionHistogram)))
+	if err != nil {
+		_ = rpcClient.Close()
+		_ = spkv.Close()
+		pdCli.Close()
+		return nil, errors.Trace(err)
+	}
+
+	coprCacheConfig := &config.GetGlobalConfig().TiKVClient.CoprCache
+	coprStore, err := copr.NewStore(s, coprCacheConfig)
+	if err != nil {
+		s.Close()
+		return nil, errors.Trace(err)
+	}
+
+	store := &tikvStore{
+		KVStore:   s,
+		etcdAddrs: etcdAddrs,
+		tlsConfig: tlsConfig,
+		memCache:  kv.NewCacheDB(),
+		enableGC:  false, // DDL store does not run GC.
+		coprStore: coprStore,
+		codec:     codec,
+		clusterID: clusterID,
+		keyspace:  keyspaceName,
+	}
+
+	logutil.BgLogger().Info("opened dedicated DDL store with reduced gRPC window sizes",
+		zap.Int32("initialWindowSize", ddlGRPCInitialWindowSize),
+		zap.Int32("initialConnWindowSize", ddlGRPCInitialConnWindowSize),
+		zap.String("uuid", uuid))
+
+	// Do not cache in mc.cache — this is a purpose-specific store.
+	return store, nil
+}
+
+// setRPCClientGRPCDialOptions sets custom gRPC dial options on an RPCClient
+// using reflect+unsafe. This is necessary because client-go's
+// internal/client.WithGRPCDialOptions is not exported from the tikv package.
+//
+// Both field lookups use FieldByName (not offset assumptions) for resilience
+// against struct reordering in client-go upgrades. If the internal layout
+// changes in a way that breaks this, the function logs a warning and the DDL
+// store falls back to default window sizes (still functional, just larger).
+//
+// TODO: remove this once client-go exports tikv.WithGRPCDialOptions.
+func setRPCClientGRPCDialOptions(rpcClient any, opts []grpc.DialOption) {
+	rv := reflect.ValueOf(rpcClient).Elem()
+	optionField := rv.FieldByName("option")
+	if !optionField.IsValid() || optionField.IsNil() {
+		logutil.BgLogger().Warn("failed to set DDL gRPC dial options: 'option' field not found on RPCClient")
+		return
+	}
+	// Dereference the *option pointer to access the option struct fields.
+	optionStruct := reflect.NewAt(optionField.Type().Elem(), unsafe.Pointer(optionField.Pointer())).Elem()
+	grpcField := optionStruct.FieldByName("gRPCDialOptions")
+	if !grpcField.IsValid() {
+		logutil.BgLogger().Warn("failed to set DDL gRPC dial options: 'gRPCDialOptions' field not found on option struct")
+		return
+	}
+	// Write to the unexported field via unsafe pointer.
+	*(*[]grpc.DialOption)(unsafe.Pointer(grpcField.UnsafeAddr())) = opts
+}

--- a/pkg/store/driver/tikv_driver.go
+++ b/pkg/store/driver/tikv_driver.go
@@ -63,6 +63,10 @@ func init() {
 	// Setup the Hooks to dynamic control global resource controller.
 	variable.EnableGlobalResourceControlFunc = tikv.EnableResourceControl
 	variable.DisableGlobalResourceControlFunc = tikv.DisableResourceControl
+
+	// Register the DDL store factory so pkg/ddl can create a dedicated store
+	// with tuned gRPC settings without importing this package directly.
+	kv.OpenDDLStoreFunc = OpenDDLStore
 }
 
 // Option is a function that changes some config of Driver


### PR DESCRIPTION
To reduce memory consumption during global sort ADD INDEX under large-region (1 GiB) NextGen clusters, create a separate tikv.KVStore for DDL backfill operations with 4 MiB gRPC window sizes (vs 128 MiB default). This avoids OOM from gRPC flow-control buffers without affecting OLTP workloads.

The implementation:
- Adds OpenDDLStore() in pkg/store/driver that creates a lightweight store with its own RPC client and tuned gRPC dial options
- Uses reflect+unsafe to set gRPC dial options on the RPC client because client-go does not currently export WithGRPCDialOptions from the tikv package (tracked in issue #64911)
- Registers the factory via kv.OpenDDLStoreFunc to avoid import cycles
- Plumbs the DDL store to readIndexStepExecutor for global sort path only
- Falls back to the main store for non-TiKV backends and local sort

Issue: https://github.com/pingcap/tidb/issues/64911

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized DDL backfill operations by introducing a dedicated storage layer for read-index operations, reducing memory overhead during distributed backfill scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->