### PR TITLE
pkg/lightning: fix panic when migrating to mariadb

### DIFF
--- a/pkg/lightning/backend/tidb/tidb.go
+++ b/pkg/lightning/backend/tidb/tidb.go
@@ -225,8 +225,12 @@ func (b *targetInfoGetter) FetchRemoteTableModels(
 					)
 					for rows.Next() {
 						var tableName, columnName, columnType, generationExpr, columnExtra string
-						if err2 := rows.Scan(&tableName, &columnName, &columnType, &generationExpr, &columnExtra); err2 != nil {
+						var gen sql.NullString
+						if err2 := rows.Scan(&tableName, &columnName, &columnType, &gen, &columnExtra); err2 != nil {
 							return err2
+						}
+						if gen.Valid {
+							generationExpr = gen.String
 						}
 						if tableName != curTableName {
 							tableIdx++


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67453 

Problem Summary:

### What changed and how does it work?

Use sql.NullString to get `generation_expression` column value instead of string due to `generation_expression` could be Null in mariadb.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix panic when migrating data from mysql to mariadb using lighting(tidm)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of NULL values in generation expressions when retrieving table metadata from database sources, ensuring proper data propagation without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
