### PR TITLE
*: clarify minimum max paging size semantics

### DIFF
--- a/pkg/distsql/request_builder_test.go
+++ b/pkg/distsql/request_builder_test.go
@@ -325,7 +325,7 @@ func TestRequestBuilder1(t *testing.T) {
 		ResourceGroupName: resourcegroup.DefaultResourceGroupName,
 	}
 	expect.Paging.MinPagingSize = paging.MinPagingSize
-	expect.Paging.MaxPagingSize = paging.MaxPagingSize
+	expect.Paging.MaxPagingSize = paging.MinAllowedMaxPagingSize
 	actual.ResourceGroupTagger = nil
 	require.Equal(t, expect, actual)
 }
@@ -409,7 +409,7 @@ func TestRequestBuilder2(t *testing.T) {
 		ResourceGroupName: resourcegroup.DefaultResourceGroupName,
 	}
 	expect.Paging.MinPagingSize = paging.MinPagingSize
-	expect.Paging.MaxPagingSize = paging.MaxPagingSize
+	expect.Paging.MaxPagingSize = paging.MinAllowedMaxPagingSize
 	actual.ResourceGroupTagger = nil
 	require.Equal(t, expect, actual)
 }
@@ -459,7 +459,7 @@ func TestRequestBuilder3(t *testing.T) {
 		ResourceGroupName: resourcegroup.DefaultResourceGroupName,
 	}
 	expect.Paging.MinPagingSize = paging.MinPagingSize
-	expect.Paging.MaxPagingSize = paging.MaxPagingSize
+	expect.Paging.MaxPagingSize = paging.MinAllowedMaxPagingSize
 	actual.ResourceGroupTagger = nil
 	require.Equal(t, expect, actual)
 }
@@ -508,7 +508,7 @@ func TestRequestBuilder4(t *testing.T) {
 		ResourceGroupName: resourcegroup.DefaultResourceGroupName,
 	}
 	expect.Paging.MinPagingSize = paging.MinPagingSize
-	expect.Paging.MaxPagingSize = paging.MaxPagingSize
+	expect.Paging.MaxPagingSize = paging.MinAllowedMaxPagingSize
 	actual.ResourceGroupTagger = nil
 	require.Equal(t, expect, actual)
 }
@@ -618,7 +618,7 @@ func TestRequestBuilder7(t *testing.T) {
 				ResourceGroupName: resourcegroup.DefaultResourceGroupName,
 			}
 			expect.Paging.MinPagingSize = paging.MinPagingSize
-			expect.Paging.MaxPagingSize = paging.MaxPagingSize
+			expect.Paging.MaxPagingSize = paging.MinAllowedMaxPagingSize
 			actual.ResourceGroupTagger = nil
 			require.Equal(t, expect, actual)
 		})
@@ -646,7 +646,7 @@ func TestRequestBuilder8(t *testing.T) {
 		ResourceGroupName: "test",
 	}
 	expect.Paging.MinPagingSize = paging.MinPagingSize
-	expect.Paging.MaxPagingSize = paging.MaxPagingSize
+	expect.Paging.MaxPagingSize = paging.MinAllowedMaxPagingSize
 	actual.ResourceGroupTagger = nil
 	require.Equal(t, expect, actual)
 }
@@ -673,7 +673,7 @@ func TestRequestBuilderTiKVClientReadTimeout(t *testing.T) {
 		ResourceGroupName:     resourcegroup.DefaultResourceGroupName,
 	}
 	expect.Paging.MinPagingSize = paging.MinPagingSize
-	expect.Paging.MaxPagingSize = paging.MaxPagingSize
+	expect.Paging.MaxPagingSize = paging.MinAllowedMaxPagingSize
 	actual.ResourceGroupTagger = nil
 	require.Equal(t, expect, actual)
 }
@@ -700,7 +700,7 @@ func TestRequestBuilderMaxExecutionTime(t *testing.T) {
 		ResourceGroupName: resourcegroup.DefaultResourceGroupName,
 	}
 	expect.Paging.MinPagingSize = paging.MinPagingSize
-	expect.Paging.MaxPagingSize = paging.MaxPagingSize
+	expect.Paging.MaxPagingSize = paging.MinAllowedMaxPagingSize
 	actual.ResourceGroupTagger = nil
 	require.Equal(t, expect, actual)
 }

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -623,10 +623,15 @@ type Request struct {
 	ResourceGroupTagger *ResourceGroupTagBuilder
 	// Paging indicates whether the request is a paging request.
 	Paging struct {
+		// For coprocessor request in next-gen, the storage may return paging
+		// range even if paging is not enabled. coprocessor have a max_resp_size
+		// to control the response size, the default is 32MiB
 		Enable bool
 		// MinPagingSize is used when Paging is true.
 		MinPagingSize uint64
 		// MaxPagingSize is used when Paging is true.
+		// when enabled, this field is adjusted to be max(MaxPagingSize, paging.MinAllowedMaxPagingSize),
+		// see paging.GrowPagingSize
 		MaxPagingSize uint64
 	}
 	// RequestSource indicates whether the request is an internal request.

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1473,7 +1473,7 @@ const (
 	DefCurretTS                             = 0
 	DefInitChunkSize                        = 32
 	DefMinPagingSize                        = int(paging.MinPagingSize)
-	DefMaxPagingSize                        = int(paging.MaxPagingSize)
+	DefMaxPagingSize                        = int(paging.MinAllowedMaxPagingSize)
 	DefMaxChunkSize                         = 1024
 	DefDMLBatchSize                         = 0
 	DefMaxPreparedStmtCount                 = -1

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -90,6 +90,10 @@ type CopClient struct {
 }
 
 // Send builds the request and gets the coprocessor iterator response.
+// the returned kv.Response might hold at most concurrency * resp-channel-size
+// number of coprocessor responses depending on the request type, this might be
+// a large memory.
+// see BuildCopIterator and buildCopTasks for resp-channel-size.
 func (c *CopClient) Send(ctx context.Context, req *kv.Request, variables any, option *kv.ClientSendOption) kv.Response {
 	vars, ok := variables.(*tikv.Variables)
 	if !ok {
@@ -1761,8 +1765,10 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 	}
 
 	var result *copTaskResult
-	if worker.req.Paging.Enable ||
-		copResp.GetRange() != nil { // For next-gen, the storage may return paging range even if paging is not enabled.
+	// For next-gen, the storage may return paging range even if paging is not
+	// enabled. coprocessor have a max_resp_size to control the response size,
+	// the default is 32MiB
+	if worker.req.Paging.Enable || copResp.GetRange() != nil {
 		result, err = worker.handleCopPagingResult(bo, rpcCtx, &copResponse{pbResp: copResp}, cacheKey, cacheValue, task, costTime)
 	} else {
 		// Handles the response for non-paging copTask.

--- a/pkg/util/paging/paging.go
+++ b/pkg/util/paging/paging.go
@@ -22,21 +22,23 @@ import "math"
 // if it's not drained, then the paging size grows, the new range is calculated like (r100, r200), then send a request again.
 // Compare with the common unary request, paging request allows early access of data, it offers a streaming-like way processing data.
 const (
-	MinPagingSize      uint64 = 128
-	maxPagingSizeShift        = 7
-	pagingSizeGrow            = 2
-	MaxPagingSize             = 50000
-	pagingGrowingSum          = ((2 << maxPagingSizeShift) - 1) * MinPagingSize
-	Threshold          uint64 = 960
+	MinPagingSize           uint64 = 128
+	maxPagingSizeShift             = 7
+	pagingSizeGrow                 = 2
+	MinAllowedMaxPagingSize        = 50000
+	pagingGrowingSum               = ((2 << maxPagingSizeShift) - 1) * MinPagingSize
+	Threshold               uint64 = 960
 )
 
-// GrowPagingSize grows the paging size and ensures it does not exceed MaxPagingSize
+// GrowPagingSize grows the paging size and ensures it does not exceed
+// max(maxv, MinAllowedMaxPagingSize).
 func GrowPagingSize(size uint64, maxv uint64) uint64 {
-	if maxv < MaxPagingSize {
+	if maxv < MinAllowedMaxPagingSize {
 		// Defensive programing, for example, call with max = 0.
-		// max should never less than MaxPagingSize.
-		// Otherwise the session variable maybe wrong, or the distsql request does not obey the session variable setting.
-		maxv = MaxPagingSize
+		// max should never less than MinAllowedMaxPagingSize.
+		// Otherwise, the session variable maybe wrong, or the distsql request
+		// does not obey the session variable setting.
+		maxv = MinAllowedMaxPagingSize
 	}
 
 	size <<= 1
@@ -53,7 +55,7 @@ func CalculateSeekCnt(expectCnt uint64) float64 {
 	}
 	if expectCnt > pagingGrowingSum {
 		// if the expectCnt is larger than pagingGrowingSum, calculate the seekCnt for the excess.
-		return float64(8 + (expectCnt-pagingGrowingSum+MaxPagingSize-1)/MaxPagingSize)
+		return float64(8 + (expectCnt-pagingGrowingSum+MinAllowedMaxPagingSize-1)/MinAllowedMaxPagingSize)
 	}
 	if expectCnt > MinPagingSize {
 		// if the expectCnt is less than pagingGrowingSum,

--- a/pkg/util/paging/paging_test.go
+++ b/pkg/util/paging/paging_test.go
@@ -21,9 +21,9 @@ import (
 )
 
 func TestGrowPagingSize(t *testing.T) {
-	require.Equal(t, GrowPagingSize(MinPagingSize, MaxPagingSize), MinPagingSize*pagingSizeGrow)
-	require.Equal(t, GrowPagingSize(MaxPagingSize, MaxPagingSize), uint64(MaxPagingSize))
-	require.Equal(t, GrowPagingSize(MaxPagingSize/pagingSizeGrow+1, MaxPagingSize), uint64(MaxPagingSize))
+	require.Equal(t, GrowPagingSize(MinPagingSize, MinAllowedMaxPagingSize), MinPagingSize*pagingSizeGrow)
+	require.Equal(t, GrowPagingSize(MinAllowedMaxPagingSize, MinAllowedMaxPagingSize), uint64(MinAllowedMaxPagingSize))
+	require.Equal(t, GrowPagingSize(MinAllowedMaxPagingSize/pagingSizeGrow+1, MinAllowedMaxPagingSize), uint64(MinAllowedMaxPagingSize))
 }
 
 func TestCalculateSeekCnt(t *testing.T) {
@@ -32,5 +32,5 @@ func TestCalculateSeekCnt(t *testing.T) {
 	require.InDelta(t, CalculateSeekCnt(MinPagingSize), 1, 0.1)
 	require.InDelta(t, CalculateSeekCnt(pagingGrowingSum), maxPagingSizeShift+1, 0.1)
 	require.InDelta(t, CalculateSeekCnt(pagingGrowingSum+1), maxPagingSizeShift+2, 0.1)
-	require.InDelta(t, CalculateSeekCnt(pagingGrowingSum+MaxPagingSize), maxPagingSizeShift+2, 0.1)
+	require.InDelta(t, CalculateSeekCnt(pagingGrowingSum+MinAllowedMaxPagingSize), maxPagingSizeShift+2, 0.1)
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:
For next-gen coprocessor requests, storage can still return paging ranges even when paging is not explicitly enabled. The previous naming around `MaxPagingSize` did not clearly reflect its role as a lower bound for safe paging growth behavior.

### What changed and how does it work?
- Rename paging constant `MaxPagingSize` to `MinAllowedMaxPagingSize` to clarify semantics.
- Keep a defensive floor in `GrowPagingSize` by enforcing `max(maxv, MinAllowedMaxPagingSize)`.
- Align default `tidb_max_paging_size` and request-builder test expectations with this lower bound.
- Add clarifying comments in KV/coprocessor request handling about next-gen paging range behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated paging configuration test cases with adjusted size constraints.

* **Documentation**
  * Clarified paging behavior with next-gen coprocessor storage and response size control mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->