### PR TITLE
planner: skip pure-constant generated column substitution

### DIFF
--- a/pkg/planner/core/casetest/join/join_test.go
+++ b/pkg/planner/core/casetest/join/join_test.go
@@ -320,5 +320,14 @@ JOIN
 			`      └─Selection cop[tikv]  not(isnull(test.t3_issue60076.b))`,
 			`        └─TableFullScan cop[tikv] table:t3_issue60076 keep order:false, stats:pseudo`))
 		tk.MustQuery(`show warnings`).Check(testkit.Rows())
+
+		tk.MustExec(`drop table if exists issue66859_t0, issue66859_t1, issue66859_t2`)
+		tk.MustExec(`create table issue66859_t0(c0 int)`)
+		tk.MustExec(`create table issue66859_t1 like issue66859_t0`)
+		tk.MustExec(`create index i0 on issue66859_t1((5))`)
+		tk.MustExec(`insert into issue66859_t0(c0) values(-1)`)
+		tk.MustQuery(`select /* issue:66859 */ issue66859_t0.c0 as ref0, issue66859_t1.c0 as ref2
+			from issue66859_t0 left join issue66859_t1 on issue66859_t0.c0 = issue66859_t1.c0
+			where 5 >= issue66859_t0.c0`).Check(testkit.Rows("-1 <nil>"))
 	})
 }

--- a/pkg/planner/core/rule_generate_column_substitute.go
+++ b/pkg/planner/core/rule_generate_column_substitute.go
@@ -81,6 +81,12 @@ func collectGenerateColumn(lp base.LogicalPlan, exprToColumn ExprColumnMap) {
 				s := ds.Schema().Columns
 				col := expression.ColInfo2Col(s, colInfo)
 				if col != nil && col.GetType(ectx).PartialEqual(col.VirtualExpr.GetType(ectx), lp.SCtx().GetSessionVars().EnableUnsafeSubstitute) {
+					// Replacing a literal with a generated column that is itself a pure constant is not
+					// semantically neutral across outer joins, because null-augmentation can turn the
+					// generated column into NULL while the original literal stays constant.
+					if len(expression.ExtractColumns(col.VirtualExpr)) == 0 {
+						continue
+					}
 					exprToColumn[col.VirtualExpr] = col
 				}
 			}


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66859

Problem Summary:

`GcSubstituter` may replace the literal `5` in an outer-join predicate with the hidden generated column behind the expression index `((5))`. That hidden column is pure-constant on the inner side, so null augmentation can turn it into `NULL` while the original literal would stay constant. The rewritten predicate then looks null-rejecting to the outer-to-inner conversion logic and produces a wrong-result `inner join`.

### What changed and how does it work?

- Skip generated-column substitution when the hidden generated column's virtual expression is pure-constant (`len(expression.ExtractColumns(col.VirtualExpr)) == 0`).
- Add a join regression in `TestJoinRegression` that reproduces the `LEFT JOIN` wrong result with an expression index on `((5))`.
- Validation evidence:
  - Fail before fix: `go test -run '^TestJoinRegression$' -tags=intest,deadlock ./pkg/planner/core/casetest/join`
  - Pass after fix: the same targeted command returns `ok`
  - Targeted lint: `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of constant-valued generated columns during query optimization

* **Tests**
  * Added regression test for LEFT JOIN query execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->