### PR TITLE
executor,server: disable auto analyze after plan replayer load

### DIFF
--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -512,13 +512,6 @@ func (e *PlanReplayerLoadInfo) Update(data []byte) error {
 	if err != nil {
 		return err
 	}
-
-	// Notify users that PLAN REPLAYER LOAD disables auto—analyze to keep restored stats stable
-	e.Ctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf(
-		"`PLAN REPLAYER LOAD` sets @@global.%s=OFF to keep restored statistics stable; re-enable it manually if needed",
-		vardef.TiDBEnableAutoAnalyze,
-	))
-
 	// build schema and table first
 	var databaseSets map[string]struct{}
 	databaseSets, err = e.createTable(z)
@@ -558,6 +551,13 @@ func (e *PlanReplayerLoadInfo) Update(data []byte) error {
 	if err != nil {
 		e.Ctx.GetSessionVars().StmtCtx.AppendWarning(fmt.Errorf("load bindings failed, err:%v", err))
 	}
+
+	// Notify users that PLAN REPLAYER LOAD disables auto-analyze to keep restored stats stable.
+	e.Ctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf(
+		"`PLAN REPLAYER LOAD` sets @@global.%s=OFF to keep restored statistics stable; re-enable it manually if needed",
+		vardef.TiDBEnableAutoAnalyze,
+	))
+
 	return nil
 }
 

--- a/pkg/server/handler/optimizor/plan_replayer_test.go
+++ b/pkg/server/handler/optimizor/plan_replayer_test.go
@@ -202,6 +202,22 @@ func TestDumpPlanReplayerAPI(t *testing.T) {
 	tk.MustExec("use planReplayer")
 	tk.MustExec("drop table planReplayer.t")
 	tk.MustExec(fmt.Sprintf(`plan replayer load "%s"`, path))
+
+	warnRows := tk.MustQuery("show warnings")
+	foundAutoAnalyzeWarning := false
+	warnMessages := make([]string, 0)
+	for warnRows.Next() {
+		var level, msg string
+		var code int64
+		require.NoError(t, warnRows.Scan(&level, &code, &msg))
+		warnMessages = append(warnMessages, msg)
+		if strings.Contains(msg, "tidb_enable_auto_analyze=OFF") {
+			foundAutoAnalyzeWarning = true
+		}
+	}
+	require.NoError(t, warnRows.Close())
+	require.True(t, foundAutoAnalyzeWarning, "warnings: %v", warnMessages)
+
 	autoAnalyzeRows = tk.MustQuery("select @@global.tidb_enable_auto_analyze")
 	require.True(t, autoAnalyzeRows.Next(), "unexpected data")
 	var autoAnalyzeValue int64


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63462

Problem Summary:
After restoring with `PLAN REPLAYER LOAD`, auto-analyze may run and overwrite restored statistics. This makes the restored environment unstable for troubleshooting.

### What changed and how does it work?

- Added `disableAutoAnalyzeForPlanReplayerLoad` and invoked it in `PlanReplayerLoadInfo.Update` right after loading variables.
- The load flow now explicitly sets `@@global.tidb_enable_auto_analyze` to `OFF`.
- Extended `TestDumpPlanReplayerAPI` to verify this behavior:
  - save and restore original global value
  - set it to `ON` before `PLAN REPLAYER LOAD`
  - assert it is disabled after load

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
`PLAN REPLAYER LOAD` now disables `tidb_enable_auto_analyze` after restore to prevent restored statistics from being overwritten by auto-analyze.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic table analysis is now disabled at the start of plan replayer load operations; if disabling fails, the load aborts to avoid creating schema/views or loading stats with analysis enabled.
  * A warning is recorded during load to inform users that auto-analysis was turned off to keep restored statistics stable.

* **Tests**
  * Tests updated to verify auto-analysis is temporarily turned off during load and restored afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->