### PR TITLE
planner: migrate unit tests checking `EXPLAIN` output to `format='plan_tree'`

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -86,23 +86,23 @@ func TestPlannerIssueRegressions(t *testing.T) {
 		tk.MustExec("insert into t7 values (575932053), (-258025139);")
 		tk.MustQuery("select distinct cast(c as decimal), cast(c as signed) from t7").
 			Sort().Check(testkit.Rows("-258025139 -258025139", "575932053 575932053"))
-		tk.MustQuery("explain format='brief' select distinct cast(c as decimal), cast(c as signed) from t7").
+		tk.MustQuery("explain format='plan_tree' select distinct cast(c as decimal), cast(c as signed) from t7").
 			Check(testkit.Rows(
-				"HashAgg 8000.00 root  group by:Column#8, Column#9, funcs:firstrow(Column#8)->Column#4, funcs:firstrow(Column#9)->Column#5",
-				"└─TableReader 8000.00 root  data:HashAgg",
-				"  └─HashAgg 8000.00 cop[tikv]  group by:cast(test.t7.c, bigint(22) BINARY), cast(test.t7.c, decimal(10,0) BINARY), ",
-				"    └─TableFullScan 10000.00 cop[tikv] table:t7 keep order:false, stats:pseudo"))
+				"HashAgg root  group by:Column, Column, funcs:firstrow(Column)->Column, funcs:firstrow(Column)->Column",
+				"└─TableReader root  data:HashAgg",
+				"  └─HashAgg cop[tikv]  group by:cast(test.t7.c, bigint(22) BINARY), cast(test.t7.c, decimal(10,0) BINARY), ",
+				"    └─TableFullScan cop[tikv] table:t7 keep order:false, stats:pseudo"))
 
 		tk.MustExec("analyze table t7 all columns")
 		tk.MustQuery("select distinct cast(c as decimal), cast(c as signed) from t7").
 			Sort().
 			Check(testkit.Rows("-258025139 -258025139", "575932053 575932053"))
-		tk.MustQuery("explain format='brief' select distinct cast(c as decimal), cast(c as signed) from t7").
+		tk.MustQuery("explain format='plan_tree' select distinct cast(c as decimal), cast(c as signed) from t7").
 			Check(testkit.Rows(
-				"HashAgg 2.00 root  group by:Column#12, Column#13, funcs:firstrow(Column#12)->Column#4, funcs:firstrow(Column#13)->Column#5",
-				"└─Projection 2.00 root  cast(test.t7.c, decimal(10,0) BINARY)->Column#12, cast(test.t7.c, bigint(22) BINARY)->Column#13",
-				"  └─TableReader 2.00 root  data:TableFullScan",
-				"    └─TableFullScan 2.00 cop[tikv] table:t7 keep order:false"))
+				"HashAgg root  group by:Column, Column, funcs:firstrow(Column)->Column, funcs:firstrow(Column)->Column",
+				"└─Projection root  cast(test.t7.c, decimal(10,0) BINARY)->Column, cast(test.t7.c, bigint(22) BINARY)->Column",
+				"  └─TableReader root  data:TableFullScan",
+				"    └─TableFullScan cop[tikv] table:t7 keep order:false"))
 	}
 
 	// inl-join-inner-multi-pattern
@@ -114,18 +114,18 @@ func TestPlannerIssueRegressions(t *testing.T) {
 		tk.MustExec("analyze table ta")
 		tk.MustExec("analyze table tb")
 
-		tk.MustQuery("explain format='brief' SELECT /*+ inl_join(tmp) */ * FROM ta, (SELECT b1, COUNT(b3) AS cnt FROM tb GROUP BY b1, b2) as tmp where ta.a1 = tmp.b1").
+		tk.MustQuery("explain format='plan_tree' SELECT /*+ inl_join(tmp) */ * FROM ta, (SELECT b1, COUNT(b3) AS cnt FROM tb GROUP BY b1, b2) as tmp where ta.a1 = tmp.b1").
 			Check(testkit.Rows(
-				"Projection 9990.00 root  test.ta.a1, test.ta.a2, test.ta.a3, test.tb.b1, Column#11",
-				"└─IndexJoin 9990.00 root  inner join, inner:HashAgg, outer key:test.ta.a1, inner key:test.tb.b1, equal cond:eq(test.ta.a1, test.tb.b1)",
-				"  ├─TableReader(Build) 9990.00 root  data:Selection",
-				"  │ └─Selection 9990.00 cop[tikv]  not(isnull(test.ta.a1))",
-				"  │   └─TableFullScan 10000.00 cop[tikv] table:ta keep order:false, stats:pseudo",
-				"  └─HashAgg(Probe) 9990.00 root  group by:test.tb.b1, test.tb.b2, funcs:count(test.tb.b3)->Column#11, funcs:firstrow(test.tb.b1)->test.tb.b1",
-				"    └─IndexLookUp 9990.00 root  ",
-				"      ├─Selection(Build) 9990.00 cop[tikv]  not(isnull(test.tb.b1))",
-				"      │ └─IndexRangeScan 10000.00 cop[tikv] table:tb, index:idx_b(b1) range: decided by [eq(test.tb.b1, test.ta.a1)], keep order:false, stats:pseudo",
-				"      └─TableRowIDScan(Probe) 9990.00 cop[tikv] table:tb keep order:false, stats:pseudo"))
+				"Projection root  test.ta.a1, test.ta.a2, test.ta.a3, test.tb.b1, Column",
+				"└─IndexJoin root  inner join, inner:HashAgg, outer key:test.ta.a1, inner key:test.tb.b1, equal cond:eq(test.ta.a1, test.tb.b1)",
+				"  ├─TableReader(Build) root  data:Selection",
+				"  │ └─Selection cop[tikv]  not(isnull(test.ta.a1))",
+				"  │   └─TableFullScan cop[tikv] table:ta keep order:false, stats:pseudo",
+				"  └─HashAgg(Probe) root  group by:test.tb.b1, test.tb.b2, funcs:count(test.tb.b3)->Column, funcs:firstrow(test.tb.b1)->test.tb.b1",
+				"    └─IndexLookUp root  ",
+				"      ├─Selection(Build) cop[tikv]  not(isnull(test.tb.b1))",
+				"      │ └─IndexRangeScan cop[tikv] table:tb, index:idx_b(b1) range: decided by [eq(test.tb.b1, test.ta.a1)], keep order:false, stats:pseudo",
+				"      └─TableRowIDScan(Probe) cop[tikv] table:tb keep order:false, stats:pseudo"))
 		tk.MustExec("create table t1(col_1 int, index idx_1(col_1));")
 		tk.MustExec("create table t2(col_1 int, col_2 int, index idx_2(col_1));")
 		tk.MustQuery("select /*+ inl_join(tmp) */ * from t1 inner join (select col_1, group_concat(col_2) from t2 group by col_1) tmp on t1.col_1 = tmp.col_1;").Check(testkit.Rows())
@@ -152,21 +152,21 @@ func TestPlannerIssueRegressions(t *testing.T) {
 		tk.MustExec("CREATE TABLE t3 (id int PRIMARY KEY,c1 varchar(256),c2 varchar(256) GENERATED ALWAYS AS (concat(c1, c1)) VIRTUAL,KEY (id));")
 		tk.MustExec("insert into t3(id, c1) values (50, 'c');")
 		tk.MustQuery("SELECT /*+ USE_INDEX_MERGE(`t3`)*/ id FROM `t3` WHERE c2 BETWEEN 'a' AND 'b' GROUP BY id HAVING id < 100 or id > 0;").Check(testkit.Rows())
-		tk.MustQuery("explain format='brief' SELECT /*+ USE_INDEX_MERGE(`t3`)*/ id FROM `t3` WHERE c2 BETWEEN 'a' AND 'b' GROUP BY id HAVING id < 100 or id > 0;").
+		tk.MustQuery("explain format='plan_tree' SELECT /*+ USE_INDEX_MERGE(`t3`)*/ id FROM `t3` WHERE c2 BETWEEN 'a' AND 'b' GROUP BY id HAVING id < 100 or id > 0;").
 			Check(testkit.Rows(
-				"Projection 249.75 root  test.t3.id",
-				"└─Selection 249.75 root  ge(test.t3.c2, \"a\"), le(test.t3.c2, \"b\")",
-				"  └─Projection 9990.00 root  test.t3.id, test.t3.c2",
-				"    └─IndexMerge 9990.00 root  type: union",
-				"      ├─IndexRangeScan(Build) 3323.33 cop[tikv] table:t3, index:id(id) range:[-inf,100), keep order:false, stats:pseudo",
-				"      ├─TableRangeScan(Build) 3333.33 cop[tikv] table:t3 range:(0,+inf], keep order:false, stats:pseudo",
-				"      └─TableRowIDScan(Probe) 9990.00 cop[tikv] table:t3 keep order:false, stats:pseudo"))
+				"Projection root  test.t3.id",
+				"└─Selection root  ge(test.t3.c2, \"a\"), le(test.t3.c2, \"b\")",
+				"  └─Projection root  test.t3.id, test.t3.c2",
+				"    └─IndexMerge root  type: union",
+				"      ├─IndexRangeScan(Build) cop[tikv] table:t3, index:id(id) range:[-inf,100), keep order:false, stats:pseudo",
+				"      ├─TableRangeScan(Build) cop[tikv] table:t3 range:(0,+inf], keep order:false, stats:pseudo",
+				"      └─TableRowIDScan(Probe) cop[tikv] table:t3 keep order:false, stats:pseudo"))
 	}
 
 	// null-safe-join-with-union
 	{
 		tk := prepareSharedTestKit(t)
-		tk.MustQuery(`explain format='brief' SELECT
+		tk.MustQuery(`explain format='plan_tree' SELECT
     base.c1,
     base.c2,
     base2.c1 AS base2_c1,
@@ -177,19 +177,19 @@ INNER JOIN
     (SELECT 1 AS c1, 100 AS c3 UNION SELECT NULL AS c1, NULL AS c3) AS base2
 ON base.c1 <=> base2.c1;
 `).Check(testkit.Rows(
-			"HashJoin 2.00 root  inner join, equal:[nulleq(Column#5, Column#11)]",
-			"├─HashAgg(Build) 2.00 root  group by:Column#5, Column#6, funcs:firstrow(Column#5)->Column#5, funcs:firstrow(Column#6)->Column#6",
-			"│ └─Union 2.00 root  ",
-			"│   ├─HashAgg 1.00 root  group by:1, funcs:firstrow(1)->Column#1, funcs:firstrow(\"Alice\")->Column#2",
-			"│   │ └─TableDual 1.00 root  rows:1",
-			"│   └─Projection 1.00 root  <nil>->Column#5, Bob->Column#6",
-			"│     └─TableDual 1.00 root  rows:1",
-			"└─HashAgg(Probe) 2.00 root  group by:Column#11, Column#12, funcs:firstrow(Column#11)->Column#11, funcs:firstrow(Column#12)->Column#12",
-			"  └─Union 2.00 root  ",
-			"    ├─Projection 1.00 root  1->Column#11, 100->Column#12",
-			"    │ └─TableDual 1.00 root  rows:1",
-			"    └─Projection 1.00 root  <nil>->Column#11, <nil>->Column#12",
-			"      └─TableDual 1.00 root  rows:1"))
+			"HashJoin root  inner join, equal:[nulleq(Column, Column)]",
+			"├─HashAgg(Build) root  group by:Column, Column, funcs:firstrow(Column)->Column, funcs:firstrow(Column)->Column",
+			"│ └─Union root  ",
+			"│   ├─HashAgg root  group by:1, funcs:firstrow(1)->Column, funcs:firstrow(\"Alice\")->Column",
+			"│   │ └─TableDual root  rows:1",
+			"│   └─Projection root  <nil>->Column, Bob->Column",
+			"│     └─TableDual root  rows:1",
+			"└─HashAgg(Probe) root  group by:Column, Column, funcs:firstrow(Column)->Column, funcs:firstrow(Column)->Column",
+			"  └─Union root  ",
+			"    ├─Projection root  1->Column, 100->Column",
+			"    │ └─TableDual root  rows:1",
+			"    └─Projection root  <nil>->Column, <nil>->Column",
+			"      └─TableDual root  rows:1"))
 		tk.MustQuery(`SELECT
     base.c1,
     base.c2,
@@ -221,28 +221,28 @@ ON base.c1 <=> base2.c1;`).Sort().Check(testkit.Rows(
   KEY idx2(id, bal)
 )`)
 
-		tk.MustQuery(`explain format='brief'
+		tk.MustQuery(`explain format='plan_tree'
 update /*+ inl_join(b) use_index(b,idx2) */ a
 join b on a.id = b.id
 set a.bal = b.bal`).Check(testkit.Rows(
-			"Update N/A root  N/A",
-			"└─IndexJoin 12500.00 root  inner join, inner:IndexReader, outer key:test.a.id, inner key:test.b.id, equal cond:eq(test.a.id, test.b.id)",
-			"  ├─TableReader(Build) 10000.00 root  data:TableFullScan",
-			"  │ └─TableFullScan 10000.00 cop[tikv] table:a keep order:false, stats:pseudo",
-			"  └─IndexReader(Probe) 12500.00 root  index:IndexRangeScan",
-			"    └─IndexRangeScan 12500.00 cop[tikv] table:b, index:idx2(id, bal) range: decided by [eq(test.b.id, test.a.id)], keep order:false, stats:pseudo"))
+			"Update root  N/A",
+			"└─IndexJoin root  inner join, inner:IndexReader, outer key:test.a.id, inner key:test.b.id, equal cond:eq(test.a.id, test.b.id)",
+			"  ├─TableReader(Build) root  data:TableFullScan",
+			"  │ └─TableFullScan cop[tikv] table:a keep order:false, stats:pseudo",
+			"  └─IndexReader(Probe) root  index:IndexRangeScan",
+			"    └─IndexRangeScan cop[tikv] table:b, index:idx2(id, bal) range: decided by [eq(test.b.id, test.a.id)], keep order:false, stats:pseudo"))
 
-		tk.MustQuery(`explain format='brief'
+		tk.MustQuery(`explain format='plan_tree'
 update /*+ inl_join(b) use_index(b,idx2) */ a
 join b on a.id = b.id
 set a.bal2 = cast(b.bal2 as double)`).Check(testkit.Rows(
-			"Update N/A root  N/A",
-			"└─IndexJoin 12500.00 root  inner join, inner:IndexLookUp, outer key:test.a.id, inner key:test.b.id, equal cond:eq(test.a.id, test.b.id)",
-			"  ├─TableReader(Build) 10000.00 root  data:TableFullScan",
-			"  │ └─TableFullScan 10000.00 cop[tikv] table:a keep order:false, stats:pseudo",
-			"  └─IndexLookUp(Probe) 12500.00 root  ",
-			"    ├─IndexRangeScan(Build) 12500.00 cop[tikv] table:b, index:idx2(id, bal) range: decided by [eq(test.b.id, test.a.id)], keep order:false, stats:pseudo",
-			"    └─TableRowIDScan(Probe) 12500.00 cop[tikv] table:b keep order:false, stats:pseudo"))
+			"Update root  N/A",
+			"└─IndexJoin root  inner join, inner:IndexLookUp, outer key:test.a.id, inner key:test.b.id, equal cond:eq(test.a.id, test.b.id)",
+			"  ├─TableReader(Build) root  data:TableFullScan",
+			"  │ └─TableFullScan cop[tikv] table:a keep order:false, stats:pseudo",
+			"  └─IndexLookUp(Probe) root  ",
+			"    ├─IndexRangeScan(Build) cop[tikv] table:b, index:idx2(id, bal) range: decided by [eq(test.b.id, test.a.id)], keep order:false, stats:pseudo",
+			"    └─TableRowIDScan(Probe) cop[tikv] table:b keep order:false, stats:pseudo"))
 		tk.MustExec(`insert into a values (1, 0.0000, 0), (2, 5.5000, 5), (3, 9.9000, 9)`)
 		tk.MustExec(`insert into b values (1, 101.1250, 11.0), (2, 202.5000, 22.0), (4, 404.0000, 44.0)`)
 		tk.MustExec(`update /*+ inl_join(b) use_index(b,idx2) */ a
@@ -269,7 +269,7 @@ set a.bal2 = cast(b.bal2 as double)`)
   bal2 float DEFAULT NULL,
   PRIMARY KEY (id) NONCLUSTERED
 )`)
-		plan := fmt.Sprint(tk.MustQuery(`explain format='brief'
+		plan := fmt.Sprint(tk.MustQuery(`explain format='plan_tree'
 update /*+ inl_join(c) use_index(c,idx2) */ c
 join d on c.id = d.id
 set d.bal = c.bal`).Rows())
@@ -293,7 +293,7 @@ set d.bal = c.bal`)
   PRIMARY KEY (id) NONCLUSTERED,
   KEY idx2(id, bal)
 )`)
-		plan = fmt.Sprint(tk.MustQuery(`explain format='brief'
+		plan = fmt.Sprint(tk.MustQuery(`explain format='plan_tree'
 update /*+ inl_join(b) use_index(b,idx2) */ e as a
 join e as b on a.id = b.id
 set a.bal = b.bal`).Rows())
@@ -324,7 +324,7 @@ set a.bal = b.bal`)
 )`)
 			tk.MustExec(`insert into rowid_a values (1, 1.0)`)
 			tk.MustExec(`insert into rowid_b values (1, 2.0)`)
-			plan = fmt.Sprint(tk.MustQuery(`explain format='brief'
+			plan = fmt.Sprint(tk.MustQuery(`explain format='plan_tree'
 update /*+ inl_join(rowid_b) use_index(rowid_b,idx2) */ rowid_a
 join rowid_b on rowid_a.a = rowid_b.a
 set rowid_a._tidb_rowid = rowid_a._tidb_rowid`).Rows())
@@ -454,22 +454,22 @@ left join c on c.g = x.g`).Check(testkit.Rows("1"))
 		tk.MustExec("create table t1 (a1 int, b1 int);")
 		tk.MustExec("create table t2 (a2 int, b2 int);")
 		tk.MustExec("insert into t1 values(1,1);")
-		tk.MustQuery(`explain format='brief'
+		tk.MustQuery(`explain format='plan_tree'
 SELECT (4,5) IN (SELECT 8,0 UNION SELECT 8, 8) AS field1
 FROM t1 AS table1
 WHERE (EXISTS (SELECT SUBQUERY2_t1.a1 AS SUBQUERY2_field1 FROM t1 AS SUBQUERY2_t1)) OR table1.b1 >= 55
-GROUP BY field1;`).Check(testkit.Rows("HashJoin 2.00 root  CARTESIAN left outer semi join, left side:HashAgg",
-			"├─HashAgg(Build) 1.00 root  group by:Column#24, Column#25, funcs:firstrow(1)->Column#51",
-			"│ └─TableDual 0.00 root  rows:0",
-			"└─HashAgg(Probe) 2.00 root  group by:Column#11, funcs:firstrow(1)->Column#48",
-			"  └─HashJoin 10000.00 root  CARTESIAN left outer semi join, left side:TableReader",
-			"    ├─HashAgg(Build) 1.00 root  group by:Column#10, Column#9, funcs:firstrow(1)->Column#50",
-			"    │ └─TableDual 0.00 root  rows:0",
-			"    └─TableReader(Probe) 10000.00 root  data:TableFullScan",
-			"      └─TableFullScan 10000.00 cop[tikv] table:table1 keep order:false, stats:pseudo",
-			"ScalarSubQuery N/A root  Output: ScalarQueryCol#16, ScalarQueryCol#17, ScalarQueryCol#18, ScalarQueryCol#19",
-			"└─TableReader 10000.00 root  data:TableFullScan",
-			"  └─TableFullScan 10000.00 cop[tikv] table:SUBQUERY2_t1 keep order:false, stats:pseudo"))
+GROUP BY field1;`).Check(testkit.Rows("HashJoin root  CARTESIAN left outer semi join, left side:HashAgg",
+			"├─HashAgg(Build) root  group by:Column, Column, funcs:firstrow(1)->Column",
+			"│ └─TableDual root  rows:0",
+			"└─HashAgg(Probe) root  group by:Column, funcs:firstrow(1)->Column",
+			"  └─HashJoin root  CARTESIAN left outer semi join, left side:TableReader",
+			"    ├─HashAgg(Build) root  group by:Column, Column, funcs:firstrow(1)->Column",
+			"    │ └─TableDual root  rows:0",
+			"    └─TableReader(Probe) root  data:TableFullScan",
+			"      └─TableFullScan cop[tikv] table:table1 keep order:false, stats:pseudo",
+			"ScalarSubQuery root  Output: ScalarQueryCol#16, ScalarQueryCol#17, ScalarQueryCol#18, ScalarQueryCol#19",
+			"└─TableReader root  data:TableFullScan",
+			"  └─TableFullScan cop[tikv] table:SUBQUERY2_t1 keep order:false, stats:pseudo"))
 		tk.MustQuery(`SELECT (4,5) IN (SELECT 8,0 UNION SELECT 8, 8) AS field1
 FROM t1 AS table1
 WHERE (EXISTS (SELECT SUBQUERY2_t1.a1 AS SUBQUERY2_field1 FROM t1 AS SUBQUERY2_t1)) OR table1.b1 >= 55
@@ -496,15 +496,15 @@ HAVING EXISTS (SELECT 1 FROM t_panic WHERE x IS NULL);`).Check(testkit.Rows("<ni
 		tk.MustExec("INSERT INTO t1 (a, b) VALUES (1, 100), (2, 200), (3, 300);")
 		tk.MustExec("INSERT INTO t2 (a, b) VALUES (1, 10), (1, 20), (2, 30), (4, 40);")
 		tk.MustExec("set tidb_enable_inl_join_inner_multi_pattern=on;")
-		tk.MustQuery("explain format='brief' select t1.b,(select count(*) from t2 where t2.a=t1.a) as a from t1 where t1.a=1;").
+		tk.MustQuery("explain format='plan_tree' select t1.b,(select count(*) from t2 where t2.a=t1.a) as a from t1 where t1.a=1;").
 			Check(testkit.Rows(
-				"Projection 1.00 root  test.t1.b, ifnull(Column#12, 0)->Column#12",
-				"└─MergeJoin 1.00 root  left outer join, left side:Point_Get, left key:test.t1.a, right key:test.t2.a",
-				"  ├─StreamAgg(Build) 8.00 root  group by:test.t2.a, funcs:count(Column#13)->Column#12, funcs:firstrow(test.t2.a)->test.t2.a",
-				"  │ └─IndexReader 8.00 root  index:StreamAgg",
-				"  │   └─StreamAgg 8.00 cop[tikv]  group by:test.t2.a, funcs:count(1)->Column#13",
-				"  │     └─IndexRangeScan 10.00 cop[tikv] table:t2, index:idx(a) range:[1,1], keep order:true, stats:pseudo",
-				"  └─Point_Get(Probe) 1.00 root table:t1 handle:1"))
+				"Projection root  test.t1.b, ifnull(Column, 0)->Column",
+				"└─MergeJoin root  left outer join, left side:Point_Get, left key:test.t1.a, right key:test.t2.a",
+				"  ├─StreamAgg(Build) root  group by:test.t2.a, funcs:count(Column)->Column, funcs:firstrow(test.t2.a)->test.t2.a",
+				"  │ └─IndexReader root  index:StreamAgg",
+				"  │   └─StreamAgg cop[tikv]  group by:test.t2.a, funcs:count(1)->Column",
+				"  │     └─IndexRangeScan cop[tikv] table:t2, index:idx(a) range:[1,1], keep order:true, stats:pseudo",
+				"  └─Point_Get(Probe) root table:t1 handle:1"))
 		tk.MustQuery("select t1.b,(select count(*) from t2 where t2.a=t1.a) as a from t1 where t1.a=1;").Check(testkit.Rows("100 2"))
 	}
 
@@ -583,29 +583,29 @@ HAVING EXISTS (SELECT 1 FROM t_panic WHERE x IS NULL);`).Check(testkit.Rows("<ni
 		tk.MustExec("create table t1(vkey integer, c10 integer);")
 		tk.MustExec("create table t2(c12 integer, c13 integer, c14 varchar(0), c15 double);")
 		tk.MustExec("create table t3(vkey varchar(0), c20 integer);")
-		tk.MustQuery("explain format='brief' select 0 from t2 join(t3 join t0 a on 0) left join(t1 b left join t1 c on 0) on(c20 = b.vkey) on(c13 = a.vkey) join(select c14 d from(t2 join t3 on c12 = vkey)) e on(c3 = d) where nullif(c15, case when(c.c10) then 0 end);").Check(testkit.Rows(
-			"Projection 0.00 root  0->Column#33",
-			"└─HashJoin 0.00 root  inner join, equal:[eq(Column#34, Column#35)]",
-			"  ├─HashJoin(Build) 0.00 root  inner join, equal:[eq(test.t0.c3, test.t2.c14)]",
-			"  │ ├─Selection(Build) 0.00 root  if(eq(test.t2.c15, cast(case(test.t1.c10, 0), double BINARY)), NULL, test.t2.c15)",
-			"  │ │ └─HashJoin 0.00 root  left outer join, left side:HashJoin, equal:[eq(test.t3.c20, test.t1.vkey)]",
-			"  │ │   ├─HashJoin(Build) 0.00 root  inner join, equal:[eq(test.t0.vkey, test.t2.c13)]",
-			"  │ │   │ ├─TableDual(Build) 0.00 root  rows:0",
-			"  │ │   │ └─TableReader(Probe) 9990.00 root  data:Selection",
-			"  │ │   │   └─Selection 9990.00 cop[tikv]  not(isnull(test.t2.c13))",
-			"  │ │   │     └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
-			"  │ │   └─HashJoin(Probe) 9990.00 root  CARTESIAN left outer join, left side:TableReader",
-			"  │ │     ├─TableDual(Build) 0.00 root  rows:0",
-			"  │ │     └─TableReader(Probe) 9990.00 root  data:Selection",
-			"  │ │       └─Selection 9990.00 cop[tikv]  not(isnull(test.t1.vkey))",
-			"  │ │         └─TableFullScan 10000.00 cop[tikv] table:b keep order:false, stats:pseudo",
-			"  │ └─Projection(Probe) 9990.00 root  test.t2.c14, cast(test.t2.c12, double BINARY)->Column#34",
-			"  │   └─TableReader 9990.00 root  data:Selection",
-			"  │     └─Selection 9990.00 cop[tikv]  not(isnull(test.t2.c14))",
-			"  │       └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
-			"  └─Projection(Probe) 10000.00 root  cast(test.t3.vkey, double BINARY)->Column#35",
-			"    └─TableReader 10000.00 root  data:TableFullScan",
-			"      └─TableFullScan 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo"))
+		tk.MustQuery("explain format='plan_tree' select 0 from t2 join(t3 join t0 a on 0) left join(t1 b left join t1 c on 0) on(c20 = b.vkey) on(c13 = a.vkey) join(select c14 d from(t2 join t3 on c12 = vkey)) e on(c3 = d) where nullif(c15, case when(c.c10) then 0 end);").Check(testkit.Rows(
+			"Projection root  0->Column",
+			"└─HashJoin root  inner join, equal:[eq(Column, Column)]",
+			"  ├─HashJoin(Build) root  inner join, equal:[eq(test.t0.c3, test.t2.c14)]",
+			"  │ ├─Selection(Build) root  if(eq(test.t2.c15, cast(case(test.t1.c10, 0), double BINARY)), NULL, test.t2.c15)",
+			"  │ │ └─HashJoin root  left outer join, left side:HashJoin, equal:[eq(test.t3.c20, test.t1.vkey)]",
+			"  │ │   ├─HashJoin(Build) root  inner join, equal:[eq(test.t0.vkey, test.t2.c13)]",
+			"  │ │   │ ├─TableDual(Build) root  rows:0",
+			"  │ │   │ └─TableReader(Probe) root  data:Selection",
+			"  │ │   │   └─Selection cop[tikv]  not(isnull(test.t2.c13))",
+			"  │ │   │     └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+			"  │ │   └─HashJoin(Probe) root  CARTESIAN left outer join, left side:TableReader",
+			"  │ │     ├─TableDual(Build) root  rows:0",
+			"  │ │     └─TableReader(Probe) root  data:Selection",
+			"  │ │       └─Selection cop[tikv]  not(isnull(test.t1.vkey))",
+			"  │ │         └─TableFullScan cop[tikv] table:b keep order:false, stats:pseudo",
+			"  │ └─Projection(Probe) root  test.t2.c14, cast(test.t2.c12, double BINARY)->Column",
+			"  │   └─TableReader root  data:Selection",
+			"  │     └─Selection cop[tikv]  not(isnull(test.t2.c14))",
+			"  │       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+			"  └─Projection(Probe) root  cast(test.t3.vkey, double BINARY)->Column",
+			"    └─TableReader root  data:TableFullScan",
+			"      └─TableFullScan cop[tikv] table:t3 keep order:false, stats:pseudo"))
 	}
 
 	// issue-58999-view-equality-expression-join-key-panic

--- a/pkg/planner/core/plan_cost_ver2_test.go
+++ b/pkg/planner/core/plan_cost_ver2_test.go
@@ -70,12 +70,12 @@ func TestCostModelVer2ScanRowSize(t *testing.T) {
 			require.Equal(t, formula, c.scanFormula)
 		}
 
-		tk.MustQuery("explain format = 'brief' select a from t where a=1").Check(testkit.Rows(
-			`IndexReader 10.00 root  index:IndexRangeScan`, // use idx_ab automatically since it has the smallest row-size in all access paths.
-			`└─IndexRangeScan 10.00 cop[tikv] table:t, index:ab(a, b) range:[1,1], keep order:false, stats:pseudo`))
-		tk.MustQuery("explain format = 'brief' select a, b, c from t where a=1").Check(testkit.Rows(
-			`IndexReader 10.00 root  index:IndexRangeScan`, // use idx_abc automatically
-			`└─IndexRangeScan 10.00 cop[tikv] table:t, index:abc(a, b, c) range:[1,1], keep order:false, stats:pseudo`))
+		tk.MustQuery("explain format = 'plan_tree' select a from t where a=1").Check(testkit.Rows(
+			`IndexReader root  index:IndexRangeScan`, // use idx_ab automatically since it has the smallest row-size in all access paths.
+			`└─IndexRangeScan cop[tikv] table:t, index:ab(a, b) range:[1,1], keep order:false, stats:pseudo`))
+		tk.MustQuery("explain format = 'plan_tree' select a, b, c from t where a=1").Check(testkit.Rows(
+			`IndexReader root  index:IndexRangeScan`, // use idx_abc automatically
+			`└─IndexRangeScan cop[tikv] table:t, index:abc(a, b, c) range:[1,1], keep order:false, stats:pseudo`))
 	})
 }
 

--- a/pkg/planner/core/plan_test.go
+++ b/pkg/planner/core/plan_test.go
@@ -487,46 +487,46 @@ func TestCopPaging(t *testing.T) {
 
 	// limit 960 should go paging
 	for range 10 {
-		tk.MustQuery("explain format='brief' select * from t force index(i) where id <= 1024 and c1 >= 0 and c1 <= 1024 and c2 in (2, 4, 6, 8) order by c1 limit 960").Check(testkit.Rows(
-			"Limit 4.00 root  offset:0, count:960",
-			"└─IndexLookUp 4.00 root  ",
-			"  ├─Selection(Build) 1024.00 cop[tikv]  le(test.t.id, 1024)",
-			"  │ └─IndexRangeScan 1024.00 cop[tikv] table:t, index:i(c1) range:[0,1024], keep order:true",
-			"  └─Selection(Probe) 4.00 cop[tikv]  in(test.t.c2, 2, 4, 6, 8)",
-			"    └─TableRowIDScan 1024.00 cop[tikv] table:t keep order:false"))
+		tk.MustQuery("explain format='plan_tree' select * from t force index(i) where id <= 1024 and c1 >= 0 and c1 <= 1024 and c2 in (2, 4, 6, 8) order by c1 limit 960").Check(testkit.Rows(
+			"Limit root  offset:0, count:960",
+			"└─IndexLookUp root  ",
+			"  ├─Selection(Build) cop[tikv]  le(test.t.id, 1024)",
+			"  │ └─IndexRangeScan cop[tikv] table:t, index:i(c1) range:[0,1024], keep order:true",
+			"  └─Selection(Probe) cop[tikv]  in(test.t.c2, 2, 4, 6, 8)",
+			"    └─TableRowIDScan cop[tikv] table:t keep order:false"))
 	}
 
 	// selection between limit and indexlookup, limit 960 should also go paging
 	for range 10 {
-		tk.MustQuery("explain format='brief' select * from t force index(i) where mod(id, 2) > 0 and id <= 1024 and c1 >= 0 and c1 <= 1024 and c2 in (2, 4, 6, 8) order by c1 limit 960").Check(testkit.Rows(
-			"Limit 3.20 root  offset:0, count:960",
-			"└─IndexLookUp 3.20 root  ",
-			"  ├─Selection(Build) 819.20 cop[tikv]  gt(mod(test.t.id, 2), 0), le(test.t.id, 1024)",
-			"  │ └─IndexRangeScan 1024.00 cop[tikv] table:t, index:i(c1) range:[0,1024], keep order:true",
-			"  └─Selection(Probe) 3.20 cop[tikv]  in(test.t.c2, 2, 4, 6, 8)",
-			"    └─TableRowIDScan 819.20 cop[tikv] table:t keep order:false"))
+		tk.MustQuery("explain format='plan_tree' select * from t force index(i) where mod(id, 2) > 0 and id <= 1024 and c1 >= 0 and c1 <= 1024 and c2 in (2, 4, 6, 8) order by c1 limit 960").Check(testkit.Rows(
+			"Limit root  offset:0, count:960",
+			"└─IndexLookUp root  ",
+			"  ├─Selection(Build) cop[tikv]  gt(mod(test.t.id, 2), 0), le(test.t.id, 1024)",
+			"  │ └─IndexRangeScan cop[tikv] table:t, index:i(c1) range:[0,1024], keep order:true",
+			"  └─Selection(Probe) cop[tikv]  in(test.t.c2, 2, 4, 6, 8)",
+			"    └─TableRowIDScan cop[tikv] table:t keep order:false"))
 	}
 
 	// limit 961 exceeds the threshold, it should not go paging
 	for range 10 {
-		tk.MustQuery("explain format='brief' select * from t force index(i) where id <= 1024 and c1 >= 0 and c1 <= 1024 and c2 in (2, 4, 6, 8) order by c1 limit 961").Check(testkit.Rows(
-			"Limit 4.00 root  offset:0, count:961",
-			"└─IndexLookUp 4.00 root  ",
-			"  ├─Selection(Build) 1024.00 cop[tikv]  le(test.t.id, 1024)",
-			"  │ └─IndexRangeScan 1024.00 cop[tikv] table:t, index:i(c1) range:[0,1024], keep order:true",
-			"  └─Selection(Probe) 4.00 cop[tikv]  in(test.t.c2, 2, 4, 6, 8)",
-			"    └─TableRowIDScan 1024.00 cop[tikv] table:t keep order:false"))
+		tk.MustQuery("explain format='plan_tree' select * from t force index(i) where id <= 1024 and c1 >= 0 and c1 <= 1024 and c2 in (2, 4, 6, 8) order by c1 limit 961").Check(testkit.Rows(
+			"Limit root  offset:0, count:961",
+			"└─IndexLookUp root  ",
+			"  ├─Selection(Build) cop[tikv]  le(test.t.id, 1024)",
+			"  │ └─IndexRangeScan cop[tikv] table:t, index:i(c1) range:[0,1024], keep order:true",
+			"  └─Selection(Probe) cop[tikv]  in(test.t.c2, 2, 4, 6, 8)",
+			"    └─TableRowIDScan cop[tikv] table:t keep order:false"))
 	}
 
 	// selection between limit and indexlookup, limit 961 should not go paging too
 	for range 10 {
-		tk.MustQuery("explain format='brief' select * from t force index(i) where mod(id, 2) > 0 and id <= 1024 and c1 >= 0 and c1 <= 1024 and c2 in (2, 4, 6, 8) order by c1 limit 961").Check(testkit.Rows(
-			"Limit 3.20 root  offset:0, count:961",
-			"└─IndexLookUp 3.20 root  ",
-			"  ├─Selection(Build) 819.20 cop[tikv]  gt(mod(test.t.id, 2), 0), le(test.t.id, 1024)",
-			"  │ └─IndexRangeScan 1024.00 cop[tikv] table:t, index:i(c1) range:[0,1024], keep order:true",
-			"  └─Selection(Probe) 3.20 cop[tikv]  in(test.t.c2, 2, 4, 6, 8)",
-			"    └─TableRowIDScan 819.20 cop[tikv] table:t keep order:false"))
+		tk.MustQuery("explain format='plan_tree' select * from t force index(i) where mod(id, 2) > 0 and id <= 1024 and c1 >= 0 and c1 <= 1024 and c2 in (2, 4, 6, 8) order by c1 limit 961").Check(testkit.Rows(
+			"Limit root  offset:0, count:961",
+			"└─IndexLookUp root  ",
+			"  ├─Selection(Build) cop[tikv]  gt(mod(test.t.id, 2), 0), le(test.t.id, 1024)",
+			"  │ └─IndexRangeScan cop[tikv] table:t, index:i(c1) range:[0,1024], keep order:true",
+			"  └─Selection(Probe) cop[tikv]  in(test.t.c2, 2, 4, 6, 8)",
+			"    └─TableRowIDScan cop[tikv] table:t keep order:false"))
 	}
 }
 

--- a/pkg/planner/core/tests/cte/cte_test.go
+++ b/pkg/planner/core/tests/cte/cte_test.go
@@ -46,9 +46,9 @@ func TestCTEWithDifferentSchema(t *testing.T) {
                         select ojt.* from rs1 ojt
                         )`)
 	tk.MustExec("use db_b;")
-	tk.MustQuery("explain format = 'brief' select * from db_a.view_test_v1;").Check(testkit.Rows(
-		"CTEFullScan 10000.00 root CTE:rs1 AS ojt data:CTE_0",
-		"CTE_0 10000.00 root  Non-Recursive CTE",
-		"└─TableReader(Seed Part) 10000.00 root  data:TableFullScan",
-		"  └─TableFullScan 10000.00 cop[tikv] table:otn keep order:false, stats:pseudo"))
+	tk.MustQuery("explain format = 'plan_tree' select * from db_a.view_test_v1;").Check(testkit.Rows(
+		"CTEFullScan root CTE:rs1 AS ojt data:CTE_0",
+		"CTE_0 root  Non-Recursive CTE",
+		"└─TableReader(Seed Part) root  data:TableFullScan",
+		"  └─TableFullScan cop[tikv] table:otn keep order:false, stats:pseudo"))
 }

--- a/pkg/planner/core/tests/null/null_test.go
+++ b/pkg/planner/core/tests/null/null_test.go
@@ -33,18 +33,18 @@ func TestIssue54803(t *testing.T) {
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
     PARTITION BY HASH (col_68) PARTITIONS 5;
     `)
-	tk.MustQuery(`EXPLAIN format='brief' SELECT TRIM(t1db47fc1.col_68) AS r0
+	tk.MustQuery(`EXPLAIN format='plan_tree' SELECT TRIM(t1db47fc1.col_68) AS r0
     FROM t1db47fc1
     WHERE ISNULL(t1db47fc1.col_68)
     GROUP BY t1db47fc1.col_68
     HAVING ISNULL(t1db47fc1.col_68) OR t1db47fc1.col_68 IN (62, 200, 196, 99)
     LIMIT 106149535;
-    `).Check(testkit.Rows("Projection 8.00 root  trim(cast(test.t1db47fc1.col_68, var_string(20)))->Column#8",
-		"└─Limit 8.00 root  offset:0, count:106149535",
-		"  └─HashAgg 8.00 root  group by:test.t1db47fc1.col_68, funcs:firstrow(test.t1db47fc1.col_68)->test.t1db47fc1.col_68",
-		"    └─TableReader 10.00 root partition:p0 data:Selection",
-		"      └─Selection 10.00 cop[tikv]  isnull(test.t1db47fc1.col_68), or(isnull(test.t1db47fc1.col_68), in(test.t1db47fc1.col_68, 62, 200, 196, 99))",
-		"        └─TableFullScan 10000.00 cop[tikv] table:t1db47fc1 keep order:false, stats:pseudo"))
+    `).Check(testkit.Rows("Projection root  trim(cast(test.t1db47fc1.col_68, var_string(20)))->Column",
+		"└─Limit root  offset:0, count:106149535",
+		"  └─HashAgg root  group by:test.t1db47fc1.col_68, funcs:firstrow(test.t1db47fc1.col_68)->test.t1db47fc1.col_68",
+		"    └─TableReader root partition:p0 data:Selection",
+		"      └─Selection cop[tikv]  isnull(test.t1db47fc1.col_68), or(isnull(test.t1db47fc1.col_68), in(test.t1db47fc1.col_68, 62, 200, 196, 99))",
+		"        └─TableFullScan cop[tikv] table:t1db47fc1 keep order:false, stats:pseudo"))
 	// Issue55299
 	tk.MustExec(`
 CREATE TABLE tcd8c2aac (
@@ -72,22 +72,22 @@ CREATE TABLE tle50fd846 (
 VALUES
 ('2029-05-09', x'757640736a42316c384162793124246b', '["YXt8UJAnVMWeMEZj1CzhNUzTMDJfzsmTWQkyOvVCsciA3eobvH8heH8gtr6ogxXa"]', x'577340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', 526.0218366710487, '%gMk', '58reJ%D&54', x'39254c48242556737474', x'6c66762b303567236f4068', '[2984188985038968170, 2580328438245089106, 4624130652422829118]');`)
 	tk.MustQuery(`
-EXPLAIN format='brief' SELECT GROUP_CONCAT(tcd8c2aac.col_21 ORDER BY tcd8c2aac.col_21 SEPARATOR ',') AS r0
+EXPLAIN format='plan_tree' SELECT GROUP_CONCAT(tcd8c2aac.col_21 ORDER BY tcd8c2aac.col_21 SEPARATOR ',') AS r0
 FROM tcd8c2aac
 JOIN tle50fd846
 WHERE ISNULL(tcd8c2aac.col_21) OR tcd8c2aac.col_21='yJTkLeL5^yJ'
 GROUP BY tcd8c2aac.col_21
 HAVING ISNULL(tcd8c2aac.col_21)
 LIMIT 48579914;`).Check(testkit.Rows(
-		"Limit 6.40 root  offset:0, count:48579914",
-		"└─HashAgg 6.40 root  group by:test.tcd8c2aac.col_21, funcs:group_concat(test.tcd8c2aac.col_21 order by test.tcd8c2aac.col_21 separator \",\")->Column#16",
-		"  └─HashJoin 80000.00 root  CARTESIAN inner join",
-		"    ├─IndexLookUp(Build) 8.00 root  ",
-		"    │ ├─Selection(Build) 8.00 cop[tikv]  isnull(test.tcd8c2aac.col_21)",
-		"    │ │ └─IndexRangeScan 10.00 cop[tikv] table:tcd8c2aac, index:idx_12(col_21) range:[NULL,NULL], keep order:false, stats:pseudo",
-		"    │ └─TableRowIDScan(Probe) 8.00 cop[tikv] table:tcd8c2aac keep order:false, stats:pseudo",
-		"    └─IndexReader(Probe) 10000.00 root  index:IndexFullScan",
-		"      └─IndexFullScan 10000.00 cop[tikv] table:tle50fd846, index:PRIMARY(col_48) keep order:false, stats:pseudo"))
+		"Limit root  offset:0, count:48579914",
+		"└─HashAgg root  group by:test.tcd8c2aac.col_21, funcs:group_concat(test.tcd8c2aac.col_21 order by test.tcd8c2aac.col_21 separator \",\")->Column",
+		"  └─HashJoin root  CARTESIAN inner join",
+		"    ├─IndexLookUp(Build) root  ",
+		"    │ ├─Selection(Build) cop[tikv]  isnull(test.tcd8c2aac.col_21)",
+		"    │ │ └─IndexRangeScan cop[tikv] table:tcd8c2aac, index:idx_12(col_21) range:[NULL,NULL], keep order:false, stats:pseudo",
+		"    │ └─TableRowIDScan(Probe) cop[tikv] table:tcd8c2aac keep order:false, stats:pseudo",
+		"    └─IndexReader(Probe) root  index:IndexFullScan",
+		"      └─IndexFullScan cop[tikv] table:tle50fd846, index:PRIMARY(col_48) keep order:false, stats:pseudo"))
 	tk.MustQuery(`SELECT GROUP_CONCAT(tcd8c2aac.col_21 ORDER BY tcd8c2aac.col_21 SEPARATOR ',') AS r0
 FROM tcd8c2aac
 JOIN tle50fd846
@@ -110,29 +110,29 @@ LIMIT 48579914;`).Check(testkit.Rows("<nil>"))
 (1065.3222700463314), (7509.347382423184), (7413.331945779306), (986.9882817569359),
 (747.4145098692578), (4850.840161745998), (2607.5009231086797), (6499.136742855925),
 (2501.691252762187), (6138.096783185339);`)
-	tk.MustQuery(`explain format='brief' SELECT BIT_XOR(ta31c32a7.col_63) AS r0
+	tk.MustQuery(`explain format='plan_tree' SELECT BIT_XOR(ta31c32a7.col_63) AS r0
 FROM ta31c32a7
 WHERE ISNULL(ta31c32a7.col_63)
   OR ta31c32a7.col_63 IN (1780.7418079754723, 5904.959667345741, 1531.4023068774668)
 GROUP BY ta31c32a7.col_63
 HAVING ISNULL(ta31c32a7.col_63)
 LIMIT 65122436;`).Check(testkit.Rows(
-		"Limit 6.40 root  offset:0, count:65122436",
-		"└─StreamAgg 6.40 root  group by:test.ta31c32a7.col_63, funcs:bit_xor(Column#7)->Column#4",
-		"  └─IndexReader 6.40 root  index:StreamAgg",
-		"    └─StreamAgg 6.40 cop[tikv]  group by:test.ta31c32a7.col_63, funcs:bit_xor(cast(test.ta31c32a7.col_63, bigint(22) BINARY))->Column#7",
-		"      └─IndexRangeScan 10.00 cop[tikv] table:ta31c32a7, index:idx_24(col_63) range:[NULL,NULL], keep order:true, stats:pseudo"))
-	tk.MustQuery(`explain format='brief' SELECT BIT_XOR(ta31c32a7.col_63) AS r0
+		"Limit root  offset:0, count:65122436",
+		"└─StreamAgg root  group by:test.ta31c32a7.col_63, funcs:bit_xor(Column)->Column",
+		"  └─IndexReader root  index:StreamAgg",
+		"    └─StreamAgg cop[tikv]  group by:test.ta31c32a7.col_63, funcs:bit_xor(cast(test.ta31c32a7.col_63, bigint(22) BINARY))->Column",
+		"      └─IndexRangeScan cop[tikv] table:ta31c32a7, index:idx_24(col_63) range:[NULL,NULL], keep order:true, stats:pseudo"))
+	tk.MustQuery(`explain format='plan_tree' SELECT BIT_XOR(ta31c32a7.col_63) AS r0
 FROM ta31c32a7
 WHERE ISNULL(ta31c32a7.col_63)
   OR ta31c32a7.col_63 IN (1780.7418079754723, 5904.959667345741, 1531.4023068774668)
 GROUP BY ta31c32a7.col_63
 LIMIT 65122436;`).Check(testkit.Rows(
-		"Limit 32.00 root  offset:0, count:65122436",
-		"└─StreamAgg 32.00 root  group by:test.ta31c32a7.col_63, funcs:bit_xor(Column#6)->Column#4",
-		"  └─IndexReader 32.00 root  index:StreamAgg",
-		"    └─StreamAgg 32.00 cop[tikv]  group by:test.ta31c32a7.col_63, funcs:bit_xor(cast(test.ta31c32a7.col_63, bigint(22) BINARY))->Column#6",
-		"      └─IndexRangeScan 40.00 cop[tikv] table:ta31c32a7, index:idx_24(col_63) range:[NULL,NULL], [1531.4023068774668,1531.4023068774668], [1780.7418079754723,1780.7418079754723], [5904.959667345741,5904.959667345741], keep order:true, stats:pseudo"))
+		"Limit root  offset:0, count:65122436",
+		"└─StreamAgg root  group by:test.ta31c32a7.col_63, funcs:bit_xor(Column)->Column",
+		"  └─IndexReader root  index:StreamAgg",
+		"    └─StreamAgg cop[tikv]  group by:test.ta31c32a7.col_63, funcs:bit_xor(cast(test.ta31c32a7.col_63, bigint(22) BINARY))->Column",
+		"      └─IndexRangeScan cop[tikv] table:ta31c32a7, index:idx_24(col_63) range:[NULL,NULL], [1531.4023068774668,1531.4023068774668], [1780.7418079754723,1780.7418079754723], [5904.959667345741,5904.959667345741], keep order:true, stats:pseudo"))
 	tk.MustExec(`CREATE TABLE tl75eff7ba (
 col_1 tinyint(1) DEFAULT '0',
 KEY idx_1 (col_1),

--- a/pkg/planner/core/tests/pointget/point_get_plan_test.go
+++ b/pkg/planner/core/tests/pointget/point_get_plan_test.go
@@ -43,22 +43,22 @@ func TestPointGetPlanCache(t *testing.T) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a bigint unsigned primary key, b int, c int, key idx_bc(b,c))")
 	tk.MustExec("insert into t values(1, 1, 1), (2, 2, 2), (3, 3, 3)")
-	tk.MustQuery("explain format = 'brief' select * from t where a = 1").Check(testkit.Rows(
-		"Point_Get 1.00 root table:t handle:1",
+	tk.MustQuery("explain format = 'plan_tree' select * from t where a = 1").Check(testkit.Rows(
+		"Point_Get root table:t handle:1",
 	))
-	tk.MustQuery("explain format = 'brief' select * from t where 1 = a").Check(testkit.Rows(
-		"Point_Get 1.00 root table:t handle:1",
+	tk.MustQuery("explain format = 'plan_tree' select * from t where 1 = a").Check(testkit.Rows(
+		"Point_Get root table:t handle:1",
 	))
-	tk.MustQuery("explain format = 'brief' update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
-		"Update N/A root  N/A",
-		"└─Point_Get 1.00 root table:t handle:1",
+	tk.MustQuery("explain format = 'plan_tree' update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
+		"Update root  N/A",
+		"└─Point_Get root table:t handle:1",
 	))
-	tk.MustQuery("explain format = 'brief' delete from t where a = 1").Check(testkit.Rows(
-		"Delete N/A root  N/A",
-		"└─Point_Get 1.00 root table:t handle:1",
+	tk.MustQuery("explain format = 'plan_tree' delete from t where a = 1").Check(testkit.Rows(
+		"Delete root  N/A",
+		"└─Point_Get root table:t handle:1",
 	))
-	tk.MustQuery("explain format = 'brief' select a from t where a = -1").Check(testkit.Rows(
-		"TableDual 0.00 root  rows:0",
+	tk.MustQuery("explain format = 'plan_tree' select a from t where a = -1").Check(testkit.Rows(
+		"TableDual root  rows:0",
 	))
 	tk.MustExec(`prepare stmt0 from "select a from t where a = ?"`)
 	tk.MustExec("set @p0 = -1")
@@ -164,22 +164,22 @@ func TestPointGetPlanCacheForNextGen(t *testing.T) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a bigint unsigned primary key, b int, c int, key idx_bc(b,c))")
 	tk.MustExec("insert into t values(1, 1, 1), (2, 2, 2), (3, 3, 3)")
-	tk.MustQuery("explain format = 'brief' select * from t where a = 1").Check(testkit.Rows(
-		"Point_Get 1.00 root table:t handle:1",
+	tk.MustQuery("explain format = 'plan_tree' select * from t where a = 1").Check(testkit.Rows(
+		"Point_Get root table:t handle:1",
 	))
-	tk.MustQuery("explain format = 'brief' select * from t where 1 = a").Check(testkit.Rows(
-		"Point_Get 1.00 root table:t handle:1",
+	tk.MustQuery("explain format = 'plan_tree' select * from t where 1 = a").Check(testkit.Rows(
+		"Point_Get root table:t handle:1",
 	))
-	tk.MustQuery("explain format = 'brief' update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
-		"Update N/A root  N/A",
-		"└─Point_Get 1.00 root table:t handle:1, lock",
+	tk.MustQuery("explain format = 'plan_tree' update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
+		"Update root  N/A",
+		"└─Point_Get root table:t handle:1, lock",
 	))
-	tk.MustQuery("explain format = 'brief' delete from t where a = 1").Check(testkit.Rows(
-		"Delete N/A root  N/A",
-		"└─Point_Get 1.00 root table:t handle:1, lock",
+	tk.MustQuery("explain format = 'plan_tree' delete from t where a = 1").Check(testkit.Rows(
+		"Delete root  N/A",
+		"└─Point_Get root table:t handle:1, lock",
 	))
-	tk.MustQuery("explain format = 'brief' select a from t where a = -1").Check(testkit.Rows(
-		"TableDual 0.00 root  rows:0",
+	tk.MustQuery("explain format = 'plan_tree' select a from t where a = -1").Check(testkit.Rows(
+		"TableDual root  rows:0",
 	))
 	tk.MustExec(`prepare stmt0 from "select a from t where a = ?"`)
 	tk.MustExec("set @p0 = -1")
@@ -294,7 +294,7 @@ func TestPointGetId(t *testing.T) {
 		require.NoError(t, err)
 		p, _, err := planner.Optimize(context.TODO(), ctx, nodeW, ret.InfoSchema)
 		require.NoError(t, err)
-		// Test explain format = 'brief' result is useless, plan id will be reset when running `explain`.
+		// Test explain format = 'plan_tree' result is useless, plan id will be reset when running `explain`.
 		require.Equal(t, 1, p.ID())
 	}
 }
@@ -363,44 +363,44 @@ func TestIssue52592(t *testing.T) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a bigint unsigned primary key, b int, c int, key idx_bc(b,c))")
 	tk.MustExec("insert into t values(1, 1, 1), (2, 2, 2), (3, 3, 3)")
-	tk.MustQuery("explain format = 'brief' select * from t where a = 1").Check(testkit.Rows(
-		"Point_Get 1.00 root table:t handle:1",
+	tk.MustQuery("explain format = 'plan_tree' select * from t where a = 1").Check(testkit.Rows(
+		"Point_Get root table:t handle:1",
 	))
-	tk.MustQuery("explain format = 'brief' select * from t where 1 = a").Check(testkit.Rows(
-		"Point_Get 1.00 root table:t handle:1",
+	tk.MustQuery("explain format = 'plan_tree' select * from t where 1 = a").Check(testkit.Rows(
+		"Point_Get root table:t handle:1",
 	))
-	tk.MustQuery("explain format = 'brief' update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
-		"Update N/A root  N/A",
-		"└─Point_Get 1.00 root table:t handle:1",
+	tk.MustQuery("explain format = 'plan_tree' update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
+		"Update root  N/A",
+		"└─Point_Get root table:t handle:1",
 	))
-	tk.MustQuery("explain format = 'brief' delete from t where a = 1").Check(testkit.Rows(
-		"Delete N/A root  N/A",
-		"└─Point_Get 1.00 root table:t handle:1",
+	tk.MustQuery("explain format = 'plan_tree' delete from t where a = 1").Check(testkit.Rows(
+		"Delete root  N/A",
+		"└─Point_Get root table:t handle:1",
 	))
-	tk.MustQuery("explain format = 'brief' select a from t where a = -1").Check(testkit.Rows(
-		"TableDual 0.00 root  rows:0",
+	tk.MustQuery("explain format = 'plan_tree' select a from t where a = -1").Check(testkit.Rows(
+		"TableDual root  rows:0",
 	))
 	tk.MustExec(`set @@tidb_opt_fix_control = "52592:ON"`)
-	tk.MustQuery("explain format = 'brief' select * from t where a = 1").Check(testkit.Rows(
-		"TableReader 1.00 root  data:TableRangeScan",
-		"└─TableRangeScan 1.00 cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo",
+	tk.MustQuery("explain format = 'plan_tree' select * from t where a = 1").Check(testkit.Rows(
+		"TableReader root  data:TableRangeScan",
+		"└─TableRangeScan cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo",
 	))
-	tk.MustQuery("explain format = 'brief' select * from t where 1 = a").Check(testkit.Rows(
-		"TableReader 1.00 root  data:TableRangeScan",
-		"└─TableRangeScan 1.00 cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo",
+	tk.MustQuery("explain format = 'plan_tree' select * from t where 1 = a").Check(testkit.Rows(
+		"TableReader root  data:TableRangeScan",
+		"└─TableRangeScan cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo",
 	))
-	tk.MustQuery("explain format = 'brief' update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
-		"Update N/A root  N/A",
-		"└─TableReader 1.00 root  data:TableRangeScan",
-		"  └─TableRangeScan 1.00 cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo",
+	tk.MustQuery("explain format = 'plan_tree' update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
+		"Update root  N/A",
+		"└─TableReader root  data:TableRangeScan",
+		"  └─TableRangeScan cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo",
 	))
-	tk.MustQuery("explain format = 'brief' delete from t where a = 1").Check(testkit.Rows(
-		"Delete N/A root  N/A",
-		"└─TableReader 1.00 root  data:TableRangeScan",
-		"  └─TableRangeScan 1.00 cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo",
+	tk.MustQuery("explain format = 'plan_tree' delete from t where a = 1").Check(testkit.Rows(
+		"Delete root  N/A",
+		"└─TableReader root  data:TableRangeScan",
+		"  └─TableRangeScan cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo",
 	))
-	tk.MustQuery("explain format = 'brief' select a from t where a = -1").Check(testkit.Rows(
-		"TableDual 0.00 root  rows:0",
+	tk.MustQuery("explain format = 'plan_tree' select a from t where a = -1").Check(testkit.Rows(
+		"TableDual root  rows:0",
 	))
 }
 
@@ -415,46 +415,46 @@ func TestIssue52592ForNextGen(t *testing.T) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a bigint unsigned primary key, b int, c int, key idx_bc(b,c))")
 	tk.MustExec("insert into t values(1, 1, 1), (2, 2, 2), (3, 3, 3)")
-	tk.MustQuery("explain format = 'brief' select * from t where a = 1").Check(testkit.Rows(
-		"Point_Get 1.00 root table:t handle:1",
+	tk.MustQuery("explain format = 'plan_tree' select * from t where a = 1").Check(testkit.Rows(
+		"Point_Get root table:t handle:1",
 	))
-	tk.MustQuery("explain format = 'brief' select * from t where 1 = a").Check(testkit.Rows(
-		"Point_Get 1.00 root table:t handle:1",
+	tk.MustQuery("explain format = 'plan_tree' select * from t where 1 = a").Check(testkit.Rows(
+		"Point_Get root table:t handle:1",
 	))
-	tk.MustQuery("explain format = 'brief' update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
-		"Update N/A root  N/A",
-		"└─Point_Get 1.00 root table:t handle:1, lock",
+	tk.MustQuery("explain format = 'plan_tree' update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
+		"Update root  N/A",
+		"└─Point_Get root table:t handle:1, lock",
 	))
-	tk.MustQuery("explain format = 'brief' delete from t where a = 1").Check(testkit.Rows(
-		"Delete N/A root  N/A",
-		"└─Point_Get 1.00 root table:t handle:1, lock",
+	tk.MustQuery("explain format = 'plan_tree' delete from t where a = 1").Check(testkit.Rows(
+		"Delete root  N/A",
+		"└─Point_Get root table:t handle:1, lock",
 	))
-	tk.MustQuery("explain format = 'brief' select a from t where a = -1").Check(testkit.Rows(
-		"TableDual 0.00 root  rows:0",
+	tk.MustQuery("explain format = 'plan_tree' select a from t where a = -1").Check(testkit.Rows(
+		"TableDual root  rows:0",
 	))
 	tk.MustExec(`set @@tidb_opt_fix_control = "52592:ON"`)
-	tk.MustQuery("explain format = 'brief' select * from t where a = 1").Check(testkit.Rows(
-		"TableReader 1.00 root  data:TableRangeScan",
-		"└─TableRangeScan 1.00 cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo",
+	tk.MustQuery("explain format = 'plan_tree' select * from t where a = 1").Check(testkit.Rows(
+		"TableReader root  data:TableRangeScan",
+		"└─TableRangeScan cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo",
 	))
-	tk.MustQuery("explain format = 'brief' select * from t where 1 = a").Check(testkit.Rows(
-		"TableReader 1.00 root  data:TableRangeScan",
-		"└─TableRangeScan 1.00 cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo",
+	tk.MustQuery("explain format = 'plan_tree' select * from t where 1 = a").Check(testkit.Rows(
+		"TableReader root  data:TableRangeScan",
+		"└─TableRangeScan cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo",
 	))
-	tk.MustQuery("explain format = 'brief' update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
-		"Update N/A root  N/A",
-		`└─SelectLock 1.00 root  for update 0`,
-		`  └─TableReader 1.00 root  data:TableRangeScan`,
-		`    └─TableRangeScan 1.00 cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo`,
+	tk.MustQuery("explain format = 'plan_tree' update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
+		"Update root  N/A",
+		`└─SelectLock root  for update 0`,
+		`  └─TableReader root  data:TableRangeScan`,
+		`    └─TableRangeScan cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo`,
 	))
-	tk.MustQuery("explain format = 'brief' delete from t where a = 1").Check(testkit.Rows(
-		"Delete N/A root  N/A",
-		`└─SelectLock 1.00 root  for update 0`,
-		`  └─TableReader 1.00 root  data:TableRangeScan`,
-		`    └─TableRangeScan 1.00 cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo`,
+	tk.MustQuery("explain format = 'plan_tree' delete from t where a = 1").Check(testkit.Rows(
+		"Delete root  N/A",
+		`└─SelectLock root  for update 0`,
+		`  └─TableReader root  data:TableRangeScan`,
+		`    └─TableRangeScan cop[tikv] table:t range:[1,1], keep order:false, stats:pseudo`,
 	))
-	tk.MustQuery("explain format = 'brief' select a from t where a = -1").Check(testkit.Rows(
-		"TableDual 0.00 root  rows:0",
+	tk.MustQuery("explain format = 'plan_tree' select a from t where a = -1").Check(testkit.Rows(
+		"TableDual root  rows:0",
 	))
 }
 

--- a/pkg/planner/core/tests/redact/redact_test.go
+++ b/pkg/planner/core/tests/redact/redact_test.go
@@ -41,146 +41,146 @@ func TestRedactExplain(t *testing.T) {
 	// ---------------------------------------------------------------------------
 	tk.MustExec("set global tidb_redact_log=MARKER")
 	// in multi-value
-	tk.MustQuery("explain format='brief' select 1 from t left join tlist on tlist.a=t.a where t.a in (12, 13)").
+	tk.MustQuery("explain format='plan_tree' select 1 from t left join tlist on tlist.a=t.a where t.a in (12, 13)").
 		Check(testkit.Rows(
-			"Projection 2.50 root  ‹1›->Column#7",
-			"└─HashJoin 2.50 root  left outer join, left side:Batch_Point_Get, equal:[eq(test.t.a, test.tlist.a)]",
-			"  ├─Batch_Point_Get(Build) 2.00 root table:t handle:[‹12› ‹13›], keep order:false, desc:false",
-			"  └─TableReader(Probe) 20.00 root partition:dual data:Selection",
-			"    └─Selection 20.00 cop[tikv]  in(test.tlist.a, ‹12›, ‹13›), not(isnull(test.tlist.a))",
-			"      └─TableFullScan 10000.00 cop[tikv] table:tlist keep order:false, stats:pseudo"))
+			"Projection root  ‹1›->Column",
+			"└─HashJoin root  left outer join, left side:Batch_Point_Get, equal:[eq(test.t.a, test.tlist.a)]",
+			"  ├─Batch_Point_Get(Build) root table:t handle:[‹12› ‹13›], keep order:false, desc:false",
+			"  └─TableReader(Probe) root partition:dual data:Selection",
+			"    └─Selection cop[tikv]  in(test.tlist.a, ‹12›, ‹13›), not(isnull(test.tlist.a))",
+			"      └─TableFullScan cop[tikv] table:tlist keep order:false, stats:pseudo"))
 	// TableRangeScan + Limit
-	tk.MustQuery("explain format='brief' select * from t where a > 1 limit 10 offset 10;").
+	tk.MustQuery("explain format='plan_tree' select * from t where a > 1 limit 10 offset 10;").
 		Check(testkit.Rows(
-			"Limit 10.00 root  offset:‹10›, count:‹10›",
-			"└─TableReader 20.00 root  data:Limit",
-			"  └─Limit 20.00 cop[tikv]  offset:‹0›, count:‹20›",
-			"    └─TableRangeScan 20.00 cop[tikv] table:t range:(‹1›,+inf], keep order:false, stats:pseudo"))
-	tk.MustQuery("explain format='brief' select * from t where a < 1;").
+			"Limit root  offset:‹10›, count:‹10›",
+			"└─TableReader root  data:Limit",
+			"  └─Limit cop[tikv]  offset:‹0›, count:‹20›",
+			"    └─TableRangeScan cop[tikv] table:t range:(‹1›,+inf], keep order:false, stats:pseudo"))
+	tk.MustQuery("explain format='plan_tree' select * from t where a < 1;").
 		Check(testkit.Rows(
-			"TableReader 3333.33 root  data:TableRangeScan",
-			"└─TableRangeScan 3333.33 cop[tikv] table:t range:[-inf,‹1›), keep order:false, stats:pseudo"))
+			"TableReader root  data:TableRangeScan",
+			"└─TableRangeScan cop[tikv] table:t range:[-inf,‹1›), keep order:false, stats:pseudo"))
 	// PointGet + order by
-	tk.MustQuery("explain format='brief' select b+1 as vt from t where a = 1 order by vt;").
+	tk.MustQuery("explain format='plan_tree' select b+1 as vt from t where a = 1 order by vt;").
 		Check(testkit.Rows(
-			"Sort 1.00 root  Column#4",
-			"└─Projection 1.00 root  plus(test.t.b, ‹1›)->Column#4",
-			"  └─Point_Get 1.00 root table:t handle:‹1›"))
+			"Sort root  Column",
+			"└─Projection root  plus(test.t.b, ‹1›)->Column",
+			"  └─Point_Get root table:t handle:‹1›"))
 	// expression partition key
-	tk.MustQuery("explain format='brief' select *, row_number() over (partition by deptid+1) FROM employee").Check(testkit.Rows(
-		"TableReader 10000.00 root  MppVersion: 3, data:ExchangeSender",
-		"└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
-		"  └─Projection 10000.00 mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, Column#8, stream_count: 8",
-		"    └─Window 10000.00 mpp[tiflash]  row_number()->Column#8 over(partition by Column#7 rows between current row and current row), stream_count: 8",
-		"      └─Sort 10000.00 mpp[tiflash]  Column#7, stream_count: 8",
-		"        └─ExchangeReceiver 10000.00 mpp[tiflash]  stream_count: 8",
-		"          └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#7, collate: binary], stream_count: 8",
-		"            └─Projection 10000.00 mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, plus(test.employee.deptid, ‹1›)->Column#7", // <- here
-		"              └─TableFullScan 10000.00 mpp[tiflash] table:employee keep order:false, stats:pseudo"))
-	tk.MustQuery("explain format = 'brief' select * from tlist where a in (2)").Check(testkit.Rows(
-		"TableReader 10.00 root partition:p0 data:Selection",
-		"└─Selection 10.00 cop[tikv]  eq(test.tlist.a, ‹2›)",
-		"  └─TableFullScan 10000.00 cop[tikv] table:tlist keep order:false, stats:pseudo"))
+	tk.MustQuery("explain format='plan_tree' select *, row_number() over (partition by deptid+1) FROM employee").Check(testkit.Rows(
+		"TableReader root  MppVersion: 3, data:ExchangeSender",
+		"└─ExchangeSender mpp[tiflash]  ExchangeType: PassThrough",
+		"  └─Projection mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, Column, stream_count: 8",
+		"    └─Window mpp[tiflash]  row_number()->Column over(partition by Column rows between current row and current row), stream_count: 8",
+		"      └─Sort mpp[tiflash]  Column, stream_count: 8",
+		"        └─ExchangeReceiver mpp[tiflash]  stream_count: 8",
+		"          └─ExchangeSender mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column, collate: binary], stream_count: 8",
+		"            └─Projection mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, plus(test.employee.deptid, ‹1›)->Column", // <- here
+		"              └─TableFullScan mpp[tiflash] table:employee keep order:false, stats:pseudo"))
+	tk.MustQuery("explain format = 'plan_tree' select * from tlist where a in (2)").Check(testkit.Rows(
+		"TableReader root partition:p0 data:Selection",
+		"└─Selection cop[tikv]  eq(test.tlist.a, ‹2›)",
+		"  └─TableFullScan cop[tikv] table:tlist keep order:false, stats:pseudo"))
 	// CTE
-	tk.MustQuery("explain format='brief' with recursive cte(a) as (select 1 union select a + 1 from cte where a < 1000) select * from cte, t limit 100 offset 100;").Check(
+	tk.MustQuery("explain format='plan_tree' with recursive cte(a) as (select 1 union select a + 1 from cte where a < 1000) select * from cte, t limit 100 offset 100;").Check(
 		testkit.Rows(
-			"Limit 100.00 root  offset:‹100›, count:‹100›",
-			"└─HashJoin 200.00 root  CARTESIAN inner join",
-			"  ├─CTEFullScan(Build) 2.00 root CTE:cte data:CTE_0",
-			"  └─TableReader(Probe) 100.00 root  data:TableFullScan",
-			"    └─TableFullScan 100.00 cop[tikv] table:t keep order:false, stats:pseudo",
-			"CTE_0 2.00 root  Recursive CTE",
-			"├─Projection(Seed Part) 1.00 root  ‹1›->Column#2",
-			"│ └─TableDual 1.00 root  rows:1",
-			"└─Projection(Recursive Part) 0.80 root  cast(plus(Column#3, ‹1›), bigint(1) BINARY)->Column#5",
-			"  └─Selection 0.80 root  lt(Column#3, ‹1000›)",
-			"    └─CTETable 1.00 root  Scan on CTE_0"))
+			"Limit root  offset:‹100›, count:‹100›",
+			"└─HashJoin root  CARTESIAN inner join",
+			"  ├─CTEFullScan(Build) root CTE:cte data:CTE_0",
+			"  └─TableReader(Probe) root  data:TableFullScan",
+			"    └─TableFullScan cop[tikv] table:t keep order:false, stats:pseudo",
+			"CTE_0 root  Recursive CTE",
+			"├─Projection(Seed Part) root  ‹1›->Column",
+			"│ └─TableDual root  rows:1",
+			"└─Projection(Recursive Part) root  cast(plus(Column, ‹1›), bigint(1) BINARY)->Column",
+			"  └─Selection root  lt(Column, ‹1000›)",
+			"    └─CTETable root  Scan on CTE_0"))
 	// virtual generated column
-	tk.MustQuery("EXPLAIN format = 'brief' SELECT name FROM person where city_no=1").Check(testkit.Rows(
-		"Projection 10.00 root  test.person.name",
-		"└─Projection 10.00 root  test.person.name, test.person.city_no",
-		"  └─IndexLookUp 10.00 root  ",
-		"    ├─IndexRangeScan(Build) 10.00 cop[tikv] table:person, index:city_no(city_no) range:[‹1›,‹1›], keep order:false, stats:pseudo",
-		"    └─TableRowIDScan(Probe) 10.00 cop[tikv] table:person keep order:false, stats:pseudo"))
+	tk.MustQuery("EXPLAIN format = 'plan_tree' SELECT name FROM person where city_no=1").Check(testkit.Rows(
+		"Projection root  test.person.name",
+		"└─Projection root  test.person.name, test.person.city_no",
+		"  └─IndexLookUp root  ",
+		"    ├─IndexRangeScan(Build) cop[tikv] table:person, index:city_no(city_no) range:[‹1›,‹1›], keep order:false, stats:pseudo",
+		"    └─TableRowIDScan(Probe) cop[tikv] table:person keep order:false, stats:pseudo"))
 	// group by
-	tk.MustQuery(" explain format='brief' select 1 from test.t group by 1").Check(testkit.Rows(
-		"Projection 1.00 root  ‹1›->Column#4",
-		"└─HashAgg 1.00 root  group by:Column#8, funcs:firstrow(Column#9)->Column#7",
-		"  └─TableReader 1.00 root  data:HashAgg",
-		"    └─HashAgg 1.00 cop[tikv]  group by:‹1›, funcs:firstrow(‹1›)->Column#9",
-		"      └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+	tk.MustQuery(" explain format='plan_tree' select 1 from test.t group by 1").Check(testkit.Rows(
+		"Projection root  ‹1›->Column",
+		"└─HashAgg root  group by:Column, funcs:firstrow(Column)->Column",
+		"  └─TableReader root  data:HashAgg",
+		"    └─HashAgg cop[tikv]  group by:‹1›, funcs:firstrow(‹1›)->Column",
+		"      └─TableFullScan cop[tikv] table:t keep order:false, stats:pseudo"))
 	// ---------------------------------------------------------------------------
 	// tidb_redact_log=ON
 	// ---------------------------------------------------------------------------
 	tk.MustExec("set global tidb_redact_log=ON")
 	// in multi-value
-	tk.MustQuery("explain format='brief' select 1 from t left join tlist on tlist.a=t.a where t.a in (12, 13)").
+	tk.MustQuery("explain format='plan_tree' select 1 from t left join tlist on tlist.a=t.a where t.a in (12, 13)").
 		Check(testkit.Rows(
-			"Projection 2.50 root  ?->Column#7",
-			"└─HashJoin 2.50 root  left outer join, left side:Batch_Point_Get, equal:[eq(test.t.a, test.tlist.a)]",
-			"  ├─Batch_Point_Get(Build) 2.00 root table:t handle:[? ?], keep order:false, desc:false",
-			"  └─TableReader(Probe) 20.00 root partition:dual data:Selection",
-			"    └─Selection 20.00 cop[tikv]  in(test.tlist.a, ?, ?), not(isnull(test.tlist.a))",
-			"      └─TableFullScan 10000.00 cop[tikv] table:tlist keep order:false, stats:pseudo"))
+			"Projection root  ?->Column",
+			"└─HashJoin root  left outer join, left side:Batch_Point_Get, equal:[eq(test.t.a, test.tlist.a)]",
+			"  ├─Batch_Point_Get(Build) root table:t handle:[? ?], keep order:false, desc:false",
+			"  └─TableReader(Probe) root partition:dual data:Selection",
+			"    └─Selection cop[tikv]  in(test.tlist.a, ?, ?), not(isnull(test.tlist.a))",
+			"      └─TableFullScan cop[tikv] table:tlist keep order:false, stats:pseudo"))
 	// TableRangeScan + Limit
-	tk.MustQuery("explain format='brief' select * from t where a > 1 limit 10 offset 10;").
+	tk.MustQuery("explain format='plan_tree' select * from t where a > 1 limit 10 offset 10;").
 		Check(testkit.Rows(
-			"Limit 10.00 root  offset:?, count:?",
-			"└─TableReader 20.00 root  data:Limit",
-			"  └─Limit 20.00 cop[tikv]  offset:?, count:?",
-			"    └─TableRangeScan 20.00 cop[tikv] table:t range:(?,+inf], keep order:false, stats:pseudo"))
-	tk.MustQuery("explain format='brief' select * from t where a < 1;").
+			"Limit root  offset:?, count:?",
+			"└─TableReader root  data:Limit",
+			"  └─Limit cop[tikv]  offset:?, count:?",
+			"    └─TableRangeScan cop[tikv] table:t range:(?,+inf], keep order:false, stats:pseudo"))
+	tk.MustQuery("explain format='plan_tree' select * from t where a < 1;").
 		Check(testkit.Rows(
-			"TableReader 3333.33 root  data:TableRangeScan",
-			"└─TableRangeScan 3333.33 cop[tikv] table:t range:[-inf,?), keep order:false, stats:pseudo"))
+			"TableReader root  data:TableRangeScan",
+			"└─TableRangeScan cop[tikv] table:t range:[-inf,?), keep order:false, stats:pseudo"))
 	// PointGet + order by
-	tk.MustQuery("explain format='brief' select b+1 as vt from t where a = 1 order by vt;").
+	tk.MustQuery("explain format='plan_tree' select b+1 as vt from t where a = 1 order by vt;").
 		Check(testkit.Rows(
-			"Sort 1.00 root  Column#4",
-			"└─Projection 1.00 root  plus(test.t.b, ?)->Column#4",
-			"  └─Point_Get 1.00 root table:t handle:?"))
+			"Sort root  Column",
+			"└─Projection root  plus(test.t.b, ?)->Column",
+			"  └─Point_Get root table:t handle:?"))
 	// expression partition key
-	tk.MustQuery("explain format='brief' select *, row_number() over (partition by deptid+1) FROM employee").Check(testkit.Rows(
-		"TableReader 10000.00 root  MppVersion: 3, data:ExchangeSender",
-		"└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
-		"  └─Projection 10000.00 mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, Column#8, stream_count: 8",
-		"    └─Window 10000.00 mpp[tiflash]  row_number()->Column#8 over(partition by Column#7 rows between current row and current row), stream_count: 8",
-		"      └─Sort 10000.00 mpp[tiflash]  Column#7, stream_count: 8",
-		"        └─ExchangeReceiver 10000.00 mpp[tiflash]  stream_count: 8",
-		"          └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#7, collate: binary], stream_count: 8",
-		"            └─Projection 10000.00 mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, plus(test.employee.deptid, ?)->Column#7", // <- here
-		"              └─TableFullScan 10000.00 mpp[tiflash] table:employee keep order:false, stats:pseudo"))
-	tk.MustQuery("explain format = 'brief' select * from tlist where a in (2)").Check(testkit.Rows(
-		"TableReader 10.00 root partition:p0 data:Selection",
-		"└─Selection 10.00 cop[tikv]  eq(test.tlist.a, ?)",
-		"  └─TableFullScan 10000.00 cop[tikv] table:tlist keep order:false, stats:pseudo"))
+	tk.MustQuery("explain format='plan_tree' select *, row_number() over (partition by deptid+1) FROM employee").Check(testkit.Rows(
+		"TableReader root  MppVersion: 3, data:ExchangeSender",
+		"└─ExchangeSender mpp[tiflash]  ExchangeType: PassThrough",
+		"  └─Projection mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, Column, stream_count: 8",
+		"    └─Window mpp[tiflash]  row_number()->Column over(partition by Column rows between current row and current row), stream_count: 8",
+		"      └─Sort mpp[tiflash]  Column, stream_count: 8",
+		"        └─ExchangeReceiver mpp[tiflash]  stream_count: 8",
+		"          └─ExchangeSender mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column, collate: binary], stream_count: 8",
+		"            └─Projection mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, plus(test.employee.deptid, ?)->Column", // <- here
+		"              └─TableFullScan mpp[tiflash] table:employee keep order:false, stats:pseudo"))
+	tk.MustQuery("explain format = 'plan_tree' select * from tlist where a in (2)").Check(testkit.Rows(
+		"TableReader root partition:p0 data:Selection",
+		"└─Selection cop[tikv]  eq(test.tlist.a, ?)",
+		"  └─TableFullScan cop[tikv] table:tlist keep order:false, stats:pseudo"))
 	// CTE
-	tk.MustQuery("explain format='brief' with recursive cte(a) as (select 1 union select a + 1 from cte where a < 1000) select * from cte, t limit 100 offset 100;").Check(
-		testkit.Rows("Limit 100.00 root  offset:?, count:?",
-			"└─HashJoin 200.00 root  CARTESIAN inner join",
-			"  ├─CTEFullScan(Build) 2.00 root CTE:cte data:CTE_0",
-			"  └─TableReader(Probe) 100.00 root  data:TableFullScan",
-			"    └─TableFullScan 100.00 cop[tikv] table:t keep order:false, stats:pseudo",
-			"CTE_0 2.00 root  Recursive CTE",
-			"├─Projection(Seed Part) 1.00 root  ?->Column#2",
-			"│ └─TableDual 1.00 root  rows:1",
-			"└─Projection(Recursive Part) 0.80 root  cast(plus(Column#3, ?), bigint(1) BINARY)->Column#5",
-			"  └─Selection 0.80 root  lt(Column#3, ?)",
-			"    └─CTETable 1.00 root  Scan on CTE_0"))
+	tk.MustQuery("explain format='plan_tree' with recursive cte(a) as (select 1 union select a + 1 from cte where a < 1000) select * from cte, t limit 100 offset 100;").Check(
+		testkit.Rows("Limit root  offset:?, count:?",
+			"└─HashJoin root  CARTESIAN inner join",
+			"  ├─CTEFullScan(Build) root CTE:cte data:CTE_0",
+			"  └─TableReader(Probe) root  data:TableFullScan",
+			"    └─TableFullScan cop[tikv] table:t keep order:false, stats:pseudo",
+			"CTE_0 root  Recursive CTE",
+			"├─Projection(Seed Part) root  ?->Column",
+			"│ └─TableDual root  rows:1",
+			"└─Projection(Recursive Part) root  cast(plus(Column, ?), bigint(1) BINARY)->Column",
+			"  └─Selection root  lt(Column, ?)",
+			"    └─CTETable root  Scan on CTE_0"))
 	// virtual generated column
-	tk.MustQuery("EXPLAIN format = 'brief' SELECT name FROM person where city_no=1").Check(testkit.Rows(
-		"Projection 10.00 root  test.person.name",
-		"└─Projection 10.00 root  test.person.name, test.person.city_no",
-		"  └─IndexLookUp 10.00 root  ",
-		"    ├─IndexRangeScan(Build) 10.00 cop[tikv] table:person, index:city_no(city_no) range:[?,?], keep order:false, stats:pseudo",
-		"    └─TableRowIDScan(Probe) 10.00 cop[tikv] table:person keep order:false, stats:pseudo"))
+	tk.MustQuery("EXPLAIN format = 'plan_tree' SELECT name FROM person where city_no=1").Check(testkit.Rows(
+		"Projection root  test.person.name",
+		"└─Projection root  test.person.name, test.person.city_no",
+		"  └─IndexLookUp root  ",
+		"    ├─IndexRangeScan(Build) cop[tikv] table:person, index:city_no(city_no) range:[?,?], keep order:false, stats:pseudo",
+		"    └─TableRowIDScan(Probe) cop[tikv] table:person keep order:false, stats:pseudo"))
 	// group by
-	tk.MustQuery(" explain format='brief' select 1 from test.t group by 1").Check(testkit.Rows(
-		"Projection 1.00 root  ?->Column#4",
-		"└─HashAgg 1.00 root  group by:Column#8, funcs:firstrow(Column#9)->Column#7",
-		"  └─TableReader 1.00 root  data:HashAgg",
-		"    └─HashAgg 1.00 cop[tikv]  group by:?, funcs:firstrow(?)->Column#9",
-		"      └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+	tk.MustQuery(" explain format='plan_tree' select 1 from test.t group by 1").Check(testkit.Rows(
+		"Projection root  ?->Column",
+		"└─HashAgg root  group by:Column, funcs:firstrow(Column)->Column",
+		"  └─TableReader root  data:HashAgg",
+		"    └─HashAgg cop[tikv]  group by:?, funcs:firstrow(?)->Column",
+		"      └─TableFullScan cop[tikv] table:t keep order:false, stats:pseudo"))
 }
 
 func TestRedactForRangeInfo(t *testing.T) {
@@ -193,16 +193,16 @@ func TestRedactForRangeInfo(t *testing.T) {
 	tk.MustExec("create table t1(a int)")
 	tk.MustExec("create table t2(a int, b int, c int, index idx(a, b))")
 	tk.MustExec("set global tidb_redact_log=ON")
-	tk.MustQuery("explain format='brief' select /*+ inl_join(t2) */ * from t1 join t2 on t1.a = t2.a where t2.b in (10, 20, 30)").Check(
+	tk.MustQuery("explain format='plan_tree' select /*+ inl_join(t2) */ * from t1 join t2 on t1.a = t2.a where t2.b in (10, 20, 30)").Check(
 		testkit.Rows(
-			"IndexJoin 37.46 root  inner join, inner:IndexLookUp, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
-			"├─TableReader(Build) 9990.00 root  data:Selection",
-			"│ └─Selection 9990.00 cop[tikv]  not(isnull(test.t1.a))",
-			"│   └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-			"└─IndexLookUp(Probe) 37.46 root  ",
-			"  ├─Selection(Build) 37.46 cop[tikv]  not(isnull(test.t2.a))",
-			"  │ └─IndexRangeScan 37.50 cop[tikv] table:t2, index:idx(a, b) range: decided by [eq(test.t2.a, test.t1.a) in(test.t2.b, ?, ?, ?)], keep order:false, stats:pseudo",
-			"  └─TableRowIDScan(Probe) 37.46 cop[tikv] table:t2 keep order:false, stats:pseudo",
+			"IndexJoin root  inner join, inner:IndexLookUp, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
+			"├─TableReader(Build) root  data:Selection",
+			"│ └─Selection cop[tikv]  not(isnull(test.t1.a))",
+			"│   └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo",
+			"└─IndexLookUp(Probe) root  ",
+			"  ├─Selection(Build) cop[tikv]  not(isnull(test.t2.a))",
+			"  │ └─IndexRangeScan cop[tikv] table:t2, index:idx(a, b) range: decided by [eq(test.t2.a, test.t1.a) in(test.t2.b, ?, ?, ?)], keep order:false, stats:pseudo",
+			"  └─TableRowIDScan(Probe) cop[tikv] table:t2 keep order:false, stats:pseudo",
 		))
 }
 
@@ -219,19 +219,19 @@ func TestJoinNotSupportedByTiFlash(t *testing.T) {
 	tk.MustExec("insert into mysql.expr_pushdown_blacklist values('dayofmonth', 'tiflash', '');")
 	tk.MustExec("admin reload expr_pushdown_blacklist;")
 	tk.MustExec("set global tidb_redact_log=ON")
-	tk.MustQuery("explain format = 'brief' select * from table_1 a left join table_1 b on a.id = b.id and dayofmonth(a.datetime_col) > 100").Check(testkit.Rows(
-		"MergeJoin 2.00 root  left outer join, left side:IndexReader, left key:test.table_1.id, right key:test.table_1.id, left cond:gt(dayofmonth(test.table_1.datetime_col), ?)",
-		"├─IndexReader(Build) 2.00 root  index:IndexFullScan",
-		"│ └─IndexFullScan 2.00 cop[tikv] table:b, index:idx(id, bit_col, datetime_col) keep order:true",
-		"└─IndexReader(Probe) 2.00 root  index:IndexFullScan",
-		"  └─IndexFullScan 2.00 cop[tikv] table:a, index:idx(id, bit_col, datetime_col) keep order:true"))
+	tk.MustQuery("explain format = 'plan_tree' select * from table_1 a left join table_1 b on a.id = b.id and dayofmonth(a.datetime_col) > 100").Check(testkit.Rows(
+		"MergeJoin root  left outer join, left side:IndexReader, left key:test.table_1.id, right key:test.table_1.id, left cond:gt(dayofmonth(test.table_1.datetime_col), ?)",
+		"├─IndexReader(Build) root  index:IndexFullScan",
+		"│ └─IndexFullScan cop[tikv] table:b, index:idx(id, bit_col, datetime_col) keep order:true",
+		"└─IndexReader(Probe) root  index:IndexFullScan",
+		"  └─IndexFullScan cop[tikv] table:a, index:idx(id, bit_col, datetime_col) keep order:true"))
 	tk.MustExec("set global tidb_redact_log=MARKER")
-	tk.MustQuery("explain format = 'brief' select * from table_1 a left join table_1 b on a.id = b.id and dayofmonth(a.datetime_col) > 100").Check(testkit.Rows(
-		"MergeJoin 2.00 root  left outer join, left side:IndexReader, left key:test.table_1.id, right key:test.table_1.id, left cond:gt(dayofmonth(test.table_1.datetime_col), ‹100›)",
-		"├─IndexReader(Build) 2.00 root  index:IndexFullScan",
-		"│ └─IndexFullScan 2.00 cop[tikv] table:b, index:idx(id, bit_col, datetime_col) keep order:true",
-		"└─IndexReader(Probe) 2.00 root  index:IndexFullScan",
-		"  └─IndexFullScan 2.00 cop[tikv] table:a, index:idx(id, bit_col, datetime_col) keep order:true"))
+	tk.MustQuery("explain format = 'plan_tree' select * from table_1 a left join table_1 b on a.id = b.id and dayofmonth(a.datetime_col) > 100").Check(testkit.Rows(
+		"MergeJoin root  left outer join, left side:IndexReader, left key:test.table_1.id, right key:test.table_1.id, left cond:gt(dayofmonth(test.table_1.datetime_col), ‹100›)",
+		"├─IndexReader(Build) root  index:IndexFullScan",
+		"│ └─IndexFullScan cop[tikv] table:b, index:idx(id, bit_col, datetime_col) keep order:true",
+		"└─IndexReader(Probe) root  index:IndexFullScan",
+		"  └─IndexFullScan cop[tikv] table:a, index:idx(id, bit_col, datetime_col) keep order:true"))
 }
 
 func TestRedactTiFlash(t *testing.T) {
@@ -250,21 +250,21 @@ func TestRedactTiFlash(t *testing.T) {
 
 	tk.MustExec(`set @@tidb_max_tiflash_threads=20`)
 	tk.MustExec("set global tidb_redact_log=ON")
-	tk.MustQuery("explain format='brief' select *, first_value(v) over (partition by p order by o range between 3 preceding and 0 following) as a from test.first_range;").Check(testkit.Rows(
-		"TableReader 10000.00 root  MppVersion: 3, data:ExchangeSender",
-		"└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
-		"  └─Window 10000.00 mpp[tiflash]  first_value(test.first_range.v)->Column#9 over(partition by test.first_range.p order by test.first_range.o range between ? preceding and ? following), stream_count: 20",
-		"    └─Sort 10000.00 mpp[tiflash]  test.first_range.p, test.first_range.o, stream_count: 20",
-		"      └─ExchangeReceiver 10000.00 mpp[tiflash]  stream_count: 20",
-		"        └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.first_range.p, collate: binary], stream_count: 20",
-		"          └─TableFullScan 10000.00 mpp[tiflash] table:first_range keep order:false, stats:pseudo"))
+	tk.MustQuery("explain format='plan_tree' select *, first_value(v) over (partition by p order by o range between 3 preceding and 0 following) as a from test.first_range;").Check(testkit.Rows(
+		"TableReader root  MppVersion: 3, data:ExchangeSender",
+		"└─ExchangeSender mpp[tiflash]  ExchangeType: PassThrough",
+		"  └─Window mpp[tiflash]  first_value(test.first_range.v)->Column over(partition by test.first_range.p order by test.first_range.o range between ? preceding and ? following), stream_count: 20",
+		"    └─Sort mpp[tiflash]  test.first_range.p, test.first_range.o, stream_count: 20",
+		"      └─ExchangeReceiver mpp[tiflash]  stream_count: 20",
+		"        └─ExchangeSender mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.first_range.p, collate: binary], stream_count: 20",
+		"          └─TableFullScan mpp[tiflash] table:first_range keep order:false, stats:pseudo"))
 	tk.MustExec("set global tidb_redact_log=MARKER")
-	tk.MustQuery("explain format='brief' select *, first_value(v) over (partition by p order by o range between 3 preceding and 0 following) as a from test.first_range;").Check(testkit.Rows(
-		"TableReader 10000.00 root  MppVersion: 3, data:ExchangeSender",
-		"└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
-		"  └─Window 10000.00 mpp[tiflash]  first_value(test.first_range.v)->Column#9 over(partition by test.first_range.p order by test.first_range.o range between ‹3› preceding and ‹0› following), stream_count: 20",
-		"    └─Sort 10000.00 mpp[tiflash]  test.first_range.p, test.first_range.o, stream_count: 20",
-		"      └─ExchangeReceiver 10000.00 mpp[tiflash]  stream_count: 20",
-		"        └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.first_range.p, collate: binary], stream_count: 20",
-		"          └─TableFullScan 10000.00 mpp[tiflash] table:first_range keep order:false, stats:pseudo"))
+	tk.MustQuery("explain format='plan_tree' select *, first_value(v) over (partition by p order by o range between 3 preceding and 0 following) as a from test.first_range;").Check(testkit.Rows(
+		"TableReader root  MppVersion: 3, data:ExchangeSender",
+		"└─ExchangeSender mpp[tiflash]  ExchangeType: PassThrough",
+		"  └─Window mpp[tiflash]  first_value(test.first_range.v)->Column over(partition by test.first_range.p order by test.first_range.o range between ‹3› preceding and ‹0› following), stream_count: 20",
+		"    └─Sort mpp[tiflash]  test.first_range.p, test.first_range.o, stream_count: 20",
+		"      └─ExchangeReceiver mpp[tiflash]  stream_count: 20",
+		"        └─ExchangeSender mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.first_range.p, collate: binary], stream_count: 20",
+		"          └─TableFullScan mpp[tiflash] table:first_range keep order:false, stats:pseudo"))
 }

--- a/pkg/planner/core/tests/subquery/subquery_test.go
+++ b/pkg/planner/core/tests/subquery/subquery_test.go
@@ -27,22 +27,22 @@ func TestCollateSubQuery(t *testing.T) {
 	tk.MustExec("create table t(id int, col varchar(100), key ix(col)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;")
 	tk.MustExec("create table t1(id varchar(100)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;")
 	samePlan := testkit.Rows(
-		"IndexHashJoin 8000.00 root  inner join, inner:IndexLookUp, outer key:Column#8, inner key:test.t.col, equal cond:eq(Column#8, test.t.col)",
-		"├─HashAgg(Build) 6400.00 root  group by:Column#13, funcs:firstrow(Column#13)->Column#8",
-		"│ └─TableReader 6400.00 root  data:HashAgg",
-		"│   └─HashAgg 6400.00 cop[tikv]  group by:cast(test.t1.id, var_string(100)), ",
-		"│     └─Selection 8000.00 cop[tikv]  not(isnull(cast(test.t1.id, var_string(100))))",
-		"│       └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-		"└─IndexLookUp(Probe) 8000.00 root  ",
-		"  ├─Selection(Build) 8000.00 cop[tikv]  not(isnull(test.t.col))",
-		"  │ └─IndexRangeScan 8008.01 cop[tikv] table:t, index:ix(col) range: decided by [eq(test.t.col, Column#8)], keep order:false, stats:pseudo",
-		"  └─TableRowIDScan(Probe) 8000.00 cop[tikv] table:t keep order:false, stats:pseudo")
-	tk.MustQuery(`explain format="brief" select * from t use index(ix) where col in (select cast(id as char) from t1);`).
+		"IndexHashJoin root  inner join, inner:IndexLookUp, outer key:Column, inner key:test.t.col, equal cond:eq(Column, test.t.col)",
+		"├─HashAgg(Build) root  group by:Column, funcs:firstrow(Column)->Column",
+		"│ └─TableReader root  data:HashAgg",
+		"│   └─HashAgg cop[tikv]  group by:cast(test.t1.id, var_string(100)), ",
+		"│     └─Selection cop[tikv]  not(isnull(cast(test.t1.id, var_string(100))))",
+		"│       └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo",
+		"└─IndexLookUp(Probe) root  ",
+		"  ├─Selection(Build) cop[tikv]  not(isnull(test.t.col))",
+		"  │ └─IndexRangeScan cop[tikv] table:t, index:ix(col) range: decided by [eq(test.t.col, Column)], keep order:false, stats:pseudo",
+		"  └─TableRowIDScan(Probe) cop[tikv] table:t keep order:false, stats:pseudo")
+	tk.MustQuery(`explain format="plan_tree" select * from t use index(ix) where col in (select cast(id as char) from t1);`).
 		Check(samePlan)
 	tk.MustExec(`set collation_connection='utf8_bin';`)
-	tk.MustQuery(`explain format="brief" select * from t use index(ix) where col in (select cast(id as char) from t1);`).
+	tk.MustQuery(`explain format="plan_tree" select * from t use index(ix) where col in (select cast(id as char) from t1);`).
 		Check(samePlan)
 	tk.MustExec(`set collation_connection='latin1_bin';`)
-	tk.MustQuery(`explain format="brief" select * from t use index(ix) where col in (select cast(id as char) from t1);`).
+	tk.MustQuery(`explain format="plan_tree" select * from t use index(ix) where col in (select cast(id as char) from t1);`).
 		Check(samePlan)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #67112

Problem Summary: Test cases that rely on `EXPLAIN` output in `format='brief'` or `format='verbose'`, but only need to validate the structure of the plan, are brittle and will start failing if minor changes in row estimates or table schema occur. This requires regenerating a large number of new plans for optimizer tests when making changes, adding noise to PR diffs and obscuring potential problems that these tests may have otherwise caught.

### What changed and how does it work?

Convert non-analyze `EXPLAIN` tests across multiple test files in pkg/planner/core/ from `format='brief'` to `format='plan_tree'`:

- issuetest/planner_issue_test.go
- tests/pointget/point_get_plan_test.go
- tests/redact/redact_test.go
- tests/null/null_test.go
- tests/subquery/subquery_test.go
- tests/cte/cte_test.go
- plan_test.go
- plan_cost_ver2_test.go

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test expectations to align with revised execution plan output format in `EXPLAIN` statements across multiple test suites.

* **Improvements**
  * Execution plan output now uses simplified formatting, removing numeric cost metrics for clearer readability in diagnostic queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->