### PR TITLE
test: Refactored TestDDLTableCreateBackfillTable to stop simulating the downgrade through live SQL DDL; it now downgrade

### DIFF
--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -288,7 +288,40 @@ func TestDDLTableCreateBackfillTable(t *testing.T) {
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/skipCheckReservedSchemaObjInNextGen", "return(true)")
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
+	downgradeAndDropDDLTablesForBootstrapTest(t, store, dom)
+
+	// to upgrade session for create ddl related tables
+	dom, err := BootstrapSession(store)
+	require.NoError(t, err)
+
 	se := CreateSessionAndSetID(t, store)
+	MustExec(t, se, "select * from mysql.tidb_background_subtask")
+	MustExec(t, se, "select * from mysql.tidb_background_subtask_history")
+	dom.Close()
+}
+
+func TestDDLTableCreateBackfillTablePreciseRepro(t *testing.T) {
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/skipCheckReservedSchemaObjInNextGen", "return(true)")
+	store, dom := CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+	downgradeAndDropDDLTablesForBootstrapTest(t, store, dom)
+	state := readDDLTableBootstrapState(t, store)
+	require.Equal(t, meta.MDLTableVersion, state.ver)
+	require.False(t, state.backfillExists)
+	require.False(t, state.backfillHistoryExists)
+	require.False(t, state.ddlNotifierExists)
+
+	dom, err := BootstrapSession(store)
+	require.NoError(t, err)
+
+	se := CreateSessionAndSetID(t, store)
+	MustExec(t, se, "select * from mysql.tidb_background_subtask")
+	MustExec(t, se, "select * from mysql.tidb_background_subtask_history")
+	dom.Close()
+}
+
+func downgradeAndDropDDLTablesForBootstrapTest(t *testing.T, store kv.Storage, dom *domain.Domain) {
+	t.Helper()
 
 	txn, err := store.Begin()
 	require.NoError(t, err)
@@ -296,25 +329,62 @@ func TestDDLTableCreateBackfillTable(t *testing.T) {
 	ver, err := m.GetDDLTableVersion()
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, ver, meta.BackfillTableVersion)
+	require.NoError(t, m.SetDDLTableVersion(meta.MDLTableVersion))
+	require.NoError(t, txn.Commit(context.Background()))
 
-	// downgrade `mDDLTableVersion`
-	m.SetDDLTableVersion(meta.MDLTableVersion)
-	MustExec(t, se, "drop table mysql.tidb_background_subtask")
-	MustExec(t, se, "drop table mysql.tidb_background_subtask_history")
+	dom.Close()
+
+	txn, err = store.Begin()
+	require.NoError(t, err)
+	m = meta.NewMutator(txn)
+	systemDBID, err := m.GetSystemDBID()
+	require.NoError(t, err)
+	require.NoError(t, m.DropTableOrView(systemDBID, metadef.TiDBBackgroundSubtaskTableID))
+	require.NoError(t, m.DropTableOrView(systemDBID, metadef.TiDBBackgroundSubtaskHistoryTableID))
 	// TODO(lance6716): remove it after tidb_ddl_notifier GA
-	MustExec(t, se, "drop table mysql.tidb_ddl_notifier")
-	err = txn.Commit(context.Background())
+	require.NoError(t, m.DropTableOrView(systemDBID, metadef.TiDBDDLNotifierTableID))
+	require.NoError(t, txn.Commit(context.Background()))
+}
+
+type ddlTableBootstrapState struct {
+	ver                   meta.DDLTableVersion
+	backfillExists        bool
+	backfillHistoryExists bool
+	ddlNotifierExists     bool
+}
+
+func readDDLTableBootstrapState(t *testing.T, store kv.Storage) ddlTableBootstrapState {
+	t.Helper()
+
+	ver, err := store.CurrentVersion(kv.GlobalTxnScope)
+	require.NoError(t, err)
+	reader := meta.NewReader(store.GetSnapshot(ver))
+	m, ok := reader.(*meta.Mutator)
+	require.True(t, ok)
+	ddlTableVer, err := m.GetDDLTableVersion()
+	require.NoError(t, err)
+	systemDBID, err := m.GetSystemDBID()
 	require.NoError(t, err)
 
-	// to upgrade session for create ddl related tables
-	dom.Close()
-	dom, err = BootstrapSession(store)
-	require.NoError(t, err)
+	return ddlTableBootstrapState{
+		ver:                   ddlTableVer,
+		backfillExists:        tableExistsInBootstrapState(t, m, systemDBID, metadef.TiDBBackgroundSubtaskTableID),
+		backfillHistoryExists: tableExistsInBootstrapState(t, m, systemDBID, metadef.TiDBBackgroundSubtaskHistoryTableID),
+		ddlNotifierExists:     tableExistsInBootstrapState(t, m, systemDBID, metadef.TiDBDDLNotifierTableID),
+	}
+}
 
-	se = CreateSessionAndSetID(t, store)
-	MustExec(t, se, "select * from mysql.tidb_background_subtask")
-	MustExec(t, se, "select * from mysql.tidb_background_subtask_history")
-	dom.Close()
+func tableExistsInBootstrapState(t *testing.T, m *meta.Mutator, dbID, tblID int64) bool {
+	t.Helper()
+
+	tables, err := m.ListTables(context.Background(), dbID)
+	require.NoError(t, err)
+	for _, tbl := range tables {
+		if tbl.ID == tblID {
+			return true
+		}
+	}
+	return false
 }
 
 // TestUpgrade tests upgrading

--- a/pkg/session/test/bootstraptest/boot_test.go
+++ b/pkg/session/test/bootstraptest/boot_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/meta/metadef"
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/statistics"
@@ -188,7 +189,6 @@ func TestDDLTableCreateDDLNotifierTable(t *testing.T) {
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/skipCheckReservedSchemaObjInNextGen", "return(true)")
 	store, dom := session.CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
-	se := session.CreateSessionAndSetID(t, store)
 
 	txn, err := store.Begin()
 	require.NoError(t, err)
@@ -198,17 +198,24 @@ func TestDDLTableCreateDDLNotifierTable(t *testing.T) {
 	require.GreaterOrEqual(t, ver, meta.DDLNotifierTableVersion)
 
 	// downgrade DDL table version
-	m.SetDDLTableVersion(meta.BackfillTableVersion)
-	session.MustExec(t, se, "drop table mysql.tidb_ddl_notifier")
-	err = txn.Commit(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, m.SetDDLTableVersion(meta.BackfillTableVersion))
+	require.NoError(t, txn.Commit(context.Background()))
 
 	// to upgrade session for create ddl notifier table
 	dom.Close()
+
+	txn, err = store.Begin()
+	require.NoError(t, err)
+	m = meta.NewMutator(txn)
+	systemDBID, err := m.GetSystemDBID()
+	require.NoError(t, err)
+	require.NoError(t, m.DropTableOrView(systemDBID, metadef.TiDBDDLNotifierTableID))
+	require.NoError(t, txn.Commit(context.Background()))
+
 	dom, err = session.BootstrapSession(store)
 	require.NoError(t, err)
 
-	se = session.CreateSessionAndSetID(t, store)
+	se := session.CreateSessionAndSetID(t, store)
 	session.MustExec(t, se, "select * from mysql.tidb_ddl_notifier")
 	dom.Close()
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67459


### What changed and how does it work?

#### Root cause
- The flake was caused by the test simulating a bootstrap downgrade in two different live paths: it lowered DDLTableVersion in one uncommitted meta transaction, while dropping the DDL tables through SQL in separate autocommit DDL transactions against a still-running domain. That created a transient but real inconsistent state where the committed cluster still advertised the old DDL table version while mysql.tidb_background_subtask, mysql.tidb_background_subtask_history, and mysql.tidb_ddl_notifier were already gone. In intest, the DDL notifier owner can observe that window and panic on the missing notifier table, which is why the test was flaky


#### Fix

- Refactored TestDDLTableCreateBackfillTable to stop simulating the downgrade through live SQL DDL; it now downgrades the DDL table version, closes the old domain, and removes the DDL tables directly from meta before re-bootstrap
- Added TestDDLTableCreateBackfillTablePreciseRepro plus snapshot-based bootstrap-state inspection so the fixed test can verify there is no committed partial downgrade before bootstrap restarts
- Applied the same meta-based downgrade/drop pattern to TestDDLTableCreateDDLNotifierTable so the adjacent notifier-table bootstrap test does not keep the same split-transaction bug window

#### Verification

- Precise repro passed: `go test --tags=intest,deadlock ./pkg/session -run '^TestDDLTableCreateBackfillTablePreciseRepro$' -count=1`
- Target verifier passed 20/20: `go test --tags=intest,deadlock ./pkg/session -run '^TestDDLTableCreateBackfillTable$' -count=1`
- Regression check passed 1/1: `go test --tags=intest,deadlock ./pkg/session -count=1`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for DDL bootstrap state validation, including new helper utilities and refactored test cases to improve coverage of database initialization and table management scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->