### PR TITLE
planner: lateral join quality updates

### DIFF
--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -495,35 +495,46 @@ func (b *PlanBuilder) buildResultSetNode(ctx context.Context, node ast.ResultSet
 			return nil, err
 		}
 
-		// Clone output names before modifying to avoid mutating shared structs
 		if x.AsName.L != "" {
-			clonedNames := make([]*types.FieldName, len(p.OutputNames()))
-			for i, name := range p.OutputNames() {
-				if name.Hidden {
-					clonedNames[i] = name
-					continue
+			if x.Lateral {
+				// LATERAL derived tables: clone output names to avoid mutating shared
+				// structs that may be referenced by the outer scope's schema.
+				clonedNames := make([]*types.FieldName, len(p.OutputNames()))
+				for i, name := range p.OutputNames() {
+					if name.Hidden {
+						clonedNames[i] = name
+						continue
+					}
+					// Clone the field name and update table name.
+					// For derived tables, clear DBName so that error messages (e.g. only_full_group_by)
+					// show "alias.col" not "db.alias.col".  The current-database qualifier needed for
+					// hint generation (leading()) is set separately on plannerSelectBlockAsName below.
+					// For base-table aliases (isTableName), inherit DBName for DEFAULT() resolution.
+					dbName := ast.NewCIStr("")
+					if isTableName {
+						dbName = name.DBName
+					}
+					clonedNames[i] = &types.FieldName{
+						DBName:            dbName,
+						OrigTblName:       name.OrigTblName,
+						OrigColName:       name.OrigColName,
+						TblName:           x.AsName,
+						ColName:           name.ColName,
+						NotExplicitUsable: name.NotExplicitUsable,
+						Redundant:         name.Redundant,
+						Hidden:            name.Hidden,
+					}
 				}
-				// Clone the field name and update table name.
-				// For derived tables, clear DBName so that error messages (e.g. only_full_group_by)
-				// show "alias.col" not "db.alias.col".  The current-database qualifier needed for
-				// hint generation (leading()) is set separately on plannerSelectBlockAsName below.
-				// For base-table aliases (isTableName), inherit DBName for DEFAULT() resolution.
-				dbName := ast.NewCIStr("")
-				if isTableName {
-					dbName = name.DBName
-				}
-				clonedNames[i] = &types.FieldName{
-					DBName:            dbName,
-					OrigTblName:       name.OrigTblName,
-					OrigColName:       name.OrigColName,
-					TblName:           x.AsName,
-					ColName:           name.ColName,
-					NotExplicitUsable: name.NotExplicitUsable,
-					Redundant:         name.Redundant,
-					Hidden:            name.Hidden,
+				p.SetOutputNames(clonedNames)
+			} else {
+				// Non-LATERAL: update TblName in place (original behavior).
+				for _, name := range p.OutputNames() {
+					if name.Hidden {
+						continue
+					}
+					name.TblName = x.AsName
 				}
 			}
-			p.SetOutputNames(clonedNames)
 		}
 		// Apply column alias list from AS dt(c1, c2, ...) syntax.
 		// Only valid for derived tables (not table names); parser enforces this.
@@ -674,7 +685,15 @@ func findJoinFullSchema(p base.LogicalPlan) (*expression.Schema, types.NameSlice
 func containsLateralTableSource(node ast.ResultSetNode) bool {
 	switch n := node.(type) {
 	case *ast.TableSource:
-		return n.Lateral
+		if n.Lateral {
+			return true
+		}
+		// Descend into the inner source (derived table / set-op) so nested
+		// LATERAL inside a subquery or set-op used as a table source is detected.
+		if inner, ok := n.Source.(ast.ResultSetNode); ok {
+			return containsLateralTableSource(inner)
+		}
+		return false
 	case *ast.Join:
 		// For parenthesized single table refs, the parser creates Join{Left: TableSource, Right: nil}
 		if n.Right == nil {
@@ -982,7 +1001,6 @@ func (b *PlanBuilder) buildLateralJoin(ctx context.Context, leftPlan, rightPlan 
 
 	ap.SetChildren(leftPlan, rightPlan)
 	ap.SetSchema(expression.MergeSchema(leftPlan.Schema(), rightPlan.Schema()))
-	setIsInApplyForCTE(rightPlan, ap.Schema())
 
 	// Note: nullability adjustment is not needed for InnerJoin (the only type supported currently).
 	// When LEFT/RIGHT JOIN support is added, ResetNotNullFlag must be called here.
@@ -1039,6 +1057,10 @@ func (b *PlanBuilder) buildLateralJoin(ctx context.Context, leftPlan, rightPlan 
 		name := *rName
 		ap.FullNames = append(ap.FullNames, &name)
 	}
+
+	// Mark inner CTEs against FullSchema so correlations via USING/NATURAL
+	// merged columns are detected and the CTE storage is reset per outer row.
+	setIsInApplyForCTE(rightPlan, ap.FullSchema)
 
 	// Handle ON conditions if present
 	if joinNode.On != nil {

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -528,11 +528,16 @@ func (b *PlanBuilder) buildResultSetNode(ctx context.Context, node ast.ResultSet
 				p.SetOutputNames(clonedNames)
 			} else {
 				// Non-LATERAL: update TblName in place (original behavior).
+				// For derived tables, clear DBName so that error messages (e.g. only_full_group_by)
+				// show "alias.col" not "db.alias.col".
 				for _, name := range p.OutputNames() {
 					if name.Hidden {
 						continue
 					}
 					name.TblName = x.AsName
+					if !isTableName {
+						name.DBName = ast.NewCIStr("")
+					}
 				}
 			}
 		}

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -496,50 +496,36 @@ func (b *PlanBuilder) buildResultSetNode(ctx context.Context, node ast.ResultSet
 		}
 
 		if x.AsName.L != "" {
-			if x.Lateral {
-				// LATERAL derived tables: clone output names to avoid mutating shared
-				// structs that may be referenced by the outer scope's schema.
-				clonedNames := make([]*types.FieldName, len(p.OutputNames()))
-				for i, name := range p.OutputNames() {
-					if name.Hidden {
-						clonedNames[i] = name
-						continue
-					}
-					// Clone the field name and update table name.
-					// For derived tables, clear DBName so that error messages (e.g. only_full_group_by)
-					// show "alias.col" not "db.alias.col".  The current-database qualifier needed for
-					// hint generation (leading()) is set separately on plannerSelectBlockAsName below.
-					// For base-table aliases (isTableName), inherit DBName for DEFAULT() resolution.
-					dbName := ast.NewCIStr("")
-					if isTableName {
-						dbName = name.DBName
-					}
-					clonedNames[i] = &types.FieldName{
-						DBName:            dbName,
-						OrigTblName:       name.OrigTblName,
-						OrigColName:       name.OrigColName,
-						TblName:           x.AsName,
-						ColName:           name.ColName,
-						NotExplicitUsable: name.NotExplicitUsable,
-						Redundant:         name.Redundant,
-						Hidden:            name.Hidden,
-					}
+			// Clone output names before modifying to avoid mutating shared structs.
+			// This is critical for CTEs whose output names are shared across multiple
+			// references — in-place mutation would corrupt other consumers.
+			clonedNames := make([]*types.FieldName, len(p.OutputNames()))
+			for i, name := range p.OutputNames() {
+				if name.Hidden {
+					clonedNames[i] = name
+					continue
 				}
-				p.SetOutputNames(clonedNames)
-			} else {
-				// Non-LATERAL: update TblName in place (original behavior).
+				// Clone the field name and update table name.
 				// For derived tables, clear DBName so that error messages (e.g. only_full_group_by)
-				// show "alias.col" not "db.alias.col".
-				for _, name := range p.OutputNames() {
-					if name.Hidden {
-						continue
-					}
-					name.TblName = x.AsName
-					if !isTableName {
-						name.DBName = ast.NewCIStr("")
-					}
+				// show "alias.col" not "db.alias.col".  The current-database qualifier needed for
+				// hint generation (leading()) is set separately on plannerSelectBlockAsName below.
+				// For base-table aliases (isTableName), inherit DBName for DEFAULT() resolution.
+				dbName := ast.NewCIStr("")
+				if isTableName {
+					dbName = name.DBName
+				}
+				clonedNames[i] = &types.FieldName{
+					DBName:            dbName,
+					OrigTblName:       name.OrigTblName,
+					OrigColName:       name.OrigColName,
+					TblName:           x.AsName,
+					ColName:           name.ColName,
+					NotExplicitUsable: name.NotExplicitUsable,
+					Redundant:         name.Redundant,
+					Hidden:            name.Hidden,
 				}
 			}
+			p.SetOutputNames(clonedNames)
 		}
 		// Apply column alias list from AS dt(c1, c2, ...) syntax.
 		// Only valid for derived tables (not table names); parser enforces this.

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -690,10 +690,7 @@ func containsLateralTableSource(node ast.ResultSetNode) bool {
 		}
 		// Descend into the inner source (derived table / set-op) so nested
 		// LATERAL inside a subquery or set-op used as a table source is detected.
-		if inner, ok := n.Source.(ast.ResultSetNode); ok {
-			return containsLateralTableSource(inner)
-		}
-		return false
+		return containsLateralTableSource(n.Source)
 	case *ast.Join:
 		// For parenthesized single table refs, the parser creates Join{Left: TableSource, Right: nil}
 		if n.Right == nil {
@@ -701,6 +698,22 @@ func containsLateralTableSource(node ast.ResultSetNode) bool {
 		}
 		// Check both sides for nested LATERAL
 		return containsLateralTableSource(n.Left) || containsLateralTableSource(n.Right)
+	case *ast.SelectStmt:
+		// Descend into the FROM clause of a derived subquery.
+		if n.From != nil {
+			return containsLateralTableSource(n.From.TableRefs)
+		}
+		return false
+	case *ast.SetOprStmt:
+		// Check each operand in the UNION/INTERSECT/EXCEPT list.
+		if n.SelectList != nil {
+			for _, sel := range n.SelectList.Selects {
+				if rs, ok := sel.(ast.ResultSetNode); ok && containsLateralTableSource(rs) {
+					return true
+				}
+			}
+		}
+		return false
 	default:
 		return false
 	}

--- a/pkg/planner/core/operator/logicalop/logical_apply.go
+++ b/pkg/planner/core/operator/logicalop/logical_apply.go
@@ -214,11 +214,10 @@ func (la *LogicalApply) DeriveStats(childStats []*property.StatsInfo, selfSchema
 		if la.JoinType == base.LeftOuterJoin {
 			rowCount = max(rowCount, leftProfile.RowCount)
 		}
-	} else if la.IsLateral && (la.JoinType == base.SemiJoin || la.JoinType == base.AntiSemiJoin) {
-		// For LATERAL SemiJoin/AntiSemiJoin Apply operators, apply SelectionFactor
-		// to the row count estimate, consistent with LogicalJoin.DeriveStats.
-		// Non-lateral Apply (correlated subqueries) keeps the original left row count
-		// to avoid changing existing plan estimates.
+	} else if la.JoinType == base.SemiJoin || la.JoinType == base.AntiSemiJoin {
+		// For SemiJoin and AntiSemiJoin Apply operators (EXISTS / NOT EXISTS
+		// subqueries that cannot be decorrelated), apply SelectionFactor to
+		// the row count estimate, consistent with LogicalJoin.DeriveStats.
 		rowCount *= cost.SelectionFactor
 	}
 	la.SetStats(&property.StatsInfo{

--- a/pkg/planner/core/operator/logicalop/logical_apply.go
+++ b/pkg/planner/core/operator/logicalop/logical_apply.go
@@ -214,10 +214,11 @@ func (la *LogicalApply) DeriveStats(childStats []*property.StatsInfo, selfSchema
 		if la.JoinType == base.LeftOuterJoin {
 			rowCount = max(rowCount, leftProfile.RowCount)
 		}
-	} else if la.JoinType == base.SemiJoin || la.JoinType == base.AntiSemiJoin {
-		// For SemiJoin and AntiSemiJoin Apply operators (EXISTS / NOT EXISTS
-		// subqueries that cannot be decorrelated), apply SelectionFactor to
-		// the row count estimate, consistent with LogicalJoin.DeriveStats.
+	} else if la.IsLateral && (la.JoinType == base.SemiJoin || la.JoinType == base.AntiSemiJoin) {
+		// For LATERAL SemiJoin/AntiSemiJoin Apply operators, apply SelectionFactor
+		// to the row count estimate, consistent with LogicalJoin.DeriveStats.
+		// Non-lateral Apply (correlated subqueries) keeps the original left row count
+		// to avoid changing existing plan estimates.
 		rowCount *= cost.SelectionFactor
 	}
 	la.SetStats(&property.StatsInfo{

--- a/pkg/planner/core/operator/logicalop/logical_cte.go
+++ b/pkg/planner/core/operator/logicalop/logical_cte.go
@@ -218,8 +218,8 @@ func (p *LogicalCTE) DeriveStats(_ []*property.StatsInfo, selfSchema *expression
 			vars := p.SCtx().GetSessionVars()
 			savedParallelApply := vars.EnableParallelApply
 			vars.EnableParallelApply = false
+			defer func() { vars.EnableParallelApply = savedParallelApply }()
 			_, p.Cte.RecursivePartPhysicalPlan, _, err = utilfuncp.DoOptimize(context.TODO(), p.SCtx(), p.Cte.OptFlag, p.Cte.RecursivePartLogicalPlan)
-			vars.EnableParallelApply = savedParallelApply
 			if err != nil {
 				return nil, false, err
 			}

--- a/pkg/planner/core/rule_decorrelate.go
+++ b/pkg/planner/core/rule_decorrelate.go
@@ -237,8 +237,10 @@ func (s *DecorrelateSolver) optimize(ctx context.Context, p base.LogicalPlan, gr
 		// to find the underlying LogicalJoin, matching the schema used for name
 		// resolution in LATERAL subqueries (see logical_plan_builder.go buildJoin).
 		outerSchema := outerPlan.Schema()
-		if fullSchema, _ := findJoinFullSchema(outerPlan); fullSchema != nil {
-			outerSchema = fullSchema
+		if apply.IsLateral {
+			if fullSchema, _ := findJoinFullSchema(outerPlan); fullSchema != nil {
+				outerSchema = fullSchema
+			}
 		}
 		apply.CorCols = coreusage.ExtractCorColumnsBySchema4LogicalPlan(innerPlan, outerSchema)
 		if len(apply.CorCols) == 0 {
@@ -258,7 +260,7 @@ func (s *DecorrelateSolver) optimize(ctx context.Context, p base.LogicalPlan, gr
 			// Notice that no matter what kind of join is, it's always right.
 			newConds := make([]expression.Expression, 0, len(sel.Conditions))
 			for _, cond := range sel.Conditions {
-				newConds = append(newConds, cond.Decorrelate(outerPlan.Schema()))
+				newConds = append(newConds, cond.Decorrelate(outerSchema))
 			}
 			apply.AttachOnConds(newConds)
 			innerPlan = sel.Children()[0]
@@ -296,9 +298,9 @@ func (s *DecorrelateSolver) optimize(ctx context.Context, p base.LogicalPlan, gr
 			}
 			// step2: when it can be substituted all, we then just do the de-correlation (apply conditions included).
 			for i, expr := range proj.Exprs {
-				proj.Exprs[i] = expr.Decorrelate(outerPlan.Schema())
+				proj.Exprs[i] = expr.Decorrelate(outerSchema)
 			}
-			apply.Decorrelate(outerPlan.Schema())
+			apply.Decorrelate(outerSchema)
 
 			innerPlan = proj.Children()[0]
 			apply.SetChildren(outerPlan, innerPlan)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #40328

Problem Summary:

### What changed and how does it work?

During a cherry pick of lateral join to a prior branch - new AI reviews found additional issues with the original implementation. These are addressed in this PR.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better detection of nested LATERAL usage inside derived tables and set-operations, improving correctness of joins with lateral subqueries.
  * Corrected handling of schema propagation for lateral joins to avoid incorrect join planning.
  * Ensure session optimization settings for recursive CTEs are reliably restored on error.
  * More accurate decorrelation of expressions by using the appropriate outer schema only for lateral contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->