### PR TITLE
executor: canonicalize db/table names for table-scope GRANT and REVOKE

### DIFF
--- a/pkg/executor/grant.go
+++ b/pkg/executor/grant.go
@@ -124,12 +124,12 @@ func (e *GrantExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 			// This makes `t` and `T` write to the same privilege row.
 			e.Level.TableName = tbl.Meta().Name.O
 		}
-		if db, succ := schema.SchemaByName(dbNameStr); succ {
+		db, succ := schema.SchemaByName(dbNameStr)
+		if succ {
 			dbName = db.Name.O
 		}
 		if len(e.Level.DBName) > 0 {
 			// The database name should also match.
-			db, succ := schema.SchemaByName(dbNameStr)
 			if !succ || db.Name.L != dbNameStr.L {
 				return infoschema.ErrTableNotExists.GenWithStackByArgs(dbName, e.Level.TableName)
 			}

--- a/pkg/executor/grant.go
+++ b/pkg/executor/grant.go
@@ -119,6 +119,14 @@ func (e *GrantExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 		if tbl != nil && tbl.Meta().Name.L != strings.ToLower(e.Level.TableName) {
 			return infoschema.ErrTableNotExists.GenWithStackByArgs(dbName, e.Level.TableName)
 		}
+		if tbl != nil {
+			// Use the real table name from schema metadata.
+			// This makes `t` and `T` write to the same privilege row.
+			e.Level.TableName = tbl.Meta().Name.O
+		}
+		if db, succ := schema.SchemaByName(dbNameStr); succ {
+			dbName = db.Name.O
+		}
 		if len(e.Level.DBName) > 0 {
 			// The database name should also match.
 			db, succ := schema.SchemaByName(dbNameStr)

--- a/pkg/executor/grant_test.go
+++ b/pkg/executor/grant_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/stretchr/testify/require"
 )
@@ -103,6 +104,23 @@ func TestGrantDBScope(t *testing.T) {
 	require.True(t, terror.ErrorEqual(err, exeerrors.ErrWrongUsage.GenWithStackByArgs("DB GRANT", "NON-DB PRIVILEGES")))
 }
 
+func TestGrantDBScopeCaseInsensitiveWithNewCollationDisabled(t *testing.T) {
+	oldNewCollationEnabled := collate.NewCollationEnabled()
+	collate.SetNewCollationEnabledForTest(false)
+	defer collate.SetNewCollationEnabledForTest(oldNewCollationEnabled)
+
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec(`DROP USER IF EXISTS 'testDBCase'@'%'`)
+	tk.MustExec(`CREATE USER 'testDBCase'@'%' IDENTIFIED BY '123'`)
+
+	tk.MustExec(`GRANT SELECT ON test.* TO 'testDBCase'@'%'`)
+	tk.MustExec(`GRANT SELECT ON TEST.* TO 'testDBCase'@'%'`)
+	tk.MustQuery(`SELECT DB, Select_priv FROM mysql.db WHERE User='testDBCase' AND Host='%' ORDER BY DB`).
+		Check(testkit.Rows("test Y"))
+}
+
 func TestGrantTableScope(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 
@@ -144,6 +162,25 @@ func TestGrantTableScope(t *testing.T) {
 
 	tk.MustGetErrMsg("GRANT SUPER ON test2 TO 'testTbl1'@'localhost';",
 		"[executor:1144]Illegal GRANT/REVOKE command; please consult the manual to see which privileges can be used")
+}
+
+func TestGrantTableScopeCaseInsensitiveWithNewCollationDisabled(t *testing.T) {
+	oldNewCollationEnabled := collate.NewCollationEnabled()
+	collate.SetNewCollationEnabledForTest(false)
+	defer collate.SetNewCollationEnabledForTest(oldNewCollationEnabled)
+
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec(`DROP USER IF EXISTS 'testTblCase'@'%'`)
+	tk.MustExec(`CREATE USER 'testTblCase'@'%' IDENTIFIED BY '123'`)
+	tk.MustExec(`DROP TABLE IF EXISTS test.issue66867_grant`)
+	tk.MustExec(`CREATE TABLE test.issue66867_grant(c1 int)`)
+
+	tk.MustExec(`GRANT SELECT ON test.issue66867_grant TO 'testTblCase'@'%'`)
+	tk.MustExec(`GRANT SELECT ON test.ISSUE66867_GRANT TO 'testTblCase'@'%'`)
+	tk.MustQuery(`SELECT Table_name, Table_priv FROM mysql.tables_priv WHERE User='testTblCase' AND Host='%' AND DB='test' ORDER BY Table_name`).
+		Check(testkit.Rows("issue66867_grant Select"))
 }
 
 func TestGrantColumnScope(t *testing.T) {

--- a/pkg/executor/revoke.go
+++ b/pkg/executor/revoke.go
@@ -172,7 +172,24 @@ func (e *RevokeExec) revokeOneUser(ctx context.Context, internalSession sessionc
 			return errors.Errorf("There is no such grant defined for user '%s' on host '%s' on database %s", user, host, dbName)
 		}
 	case ast.GrantLevelTable:
-		ok, err := tableUserExists(internalSession, user, host, dbName, e.Level.TableName)
+		tblName := e.Level.TableName
+		if len(dbName) > 0 {
+			// Normalize db/table names before checking mysql.tables_priv.
+			// Different input case should still map to the same object.
+			dbNameCI := ast.NewCIStr(dbName)
+			if db, succ := e.is.SchemaByName(dbNameCI); succ {
+				dbName = db.Name.O
+			}
+			tbl, err := e.is.TableByName(ctx, dbNameCI, ast.NewCIStr(e.Level.TableName))
+			if err != nil && !terror.ErrorEqual(err, infoschema.ErrTableNotExists) {
+				return err
+			}
+			if err == nil {
+				// Use the real table name from schema metadata.
+				tblName = tbl.Meta().Name.O
+			}
+		}
+		ok, err := tableUserExists(internalSession, user, host, dbName, tblName)
 		if err != nil {
 			return err
 		}

--- a/pkg/executor/revoke_test.go
+++ b/pkg/executor/revoke_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,6 +83,23 @@ func TestRevokeDBScope(t *testing.T) {
 	}
 }
 
+func TestRevokeDBScopeCaseInsensitiveWithNewCollationDisabled(t *testing.T) {
+	oldNewCollationEnabled := collate.NewCollationEnabled()
+	collate.SetNewCollationEnabledForTest(false)
+	defer collate.SetNewCollationEnabledForTest(oldNewCollationEnabled)
+
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec(`DROP USER IF EXISTS 'testDBCaseRevoke'@'%'`)
+	tk.MustExec(`CREATE USER 'testDBCaseRevoke'@'%' IDENTIFIED BY '123'`)
+
+	tk.MustExec(`GRANT SELECT ON test.* TO 'testDBCaseRevoke'@'%'`)
+	tk.MustExec(`REVOKE SELECT ON TEST.* FROM 'testDBCaseRevoke'@'%'`)
+	tk.MustQuery(`SELECT DB FROM mysql.db WHERE User='testDBCaseRevoke' AND Host='%'`).
+		Check(testkit.Rows())
+}
+
 func TestRevokeTableScope(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -121,6 +139,25 @@ func TestRevokeTableScope(t *testing.T) {
 	//delete row when last prv , updated by issue #38421
 	rows := tk.MustQuery(`SELECT Table_priv FROM mysql.Tables_priv WHERE User="testTblRevoke" and host="localhost" and db="test" and Table_name="test1"`).Rows()
 	require.Len(t, rows, 0)
+}
+
+func TestRevokeTableScopeCaseInsensitiveWithNewCollationDisabled(t *testing.T) {
+	oldNewCollationEnabled := collate.NewCollationEnabled()
+	collate.SetNewCollationEnabledForTest(false)
+	defer collate.SetNewCollationEnabledForTest(oldNewCollationEnabled)
+
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec(`DROP USER IF EXISTS 'testTblCaseRevoke'@'%'`)
+	tk.MustExec(`CREATE USER 'testTblCaseRevoke'@'%' IDENTIFIED BY '123'`)
+	tk.MustExec(`DROP TABLE IF EXISTS test.issue66867_revoke`)
+	tk.MustExec(`CREATE TABLE test.issue66867_revoke(c1 int)`)
+
+	tk.MustExec(`GRANT SELECT ON test.issue66867_revoke TO 'testTblCaseRevoke'@'%'`)
+	tk.MustExec(`REVOKE SELECT ON test.ISSUE66867_REVOKE FROM 'testTblCaseRevoke'@'%'`)
+	tk.MustQuery(`SELECT Table_name FROM mysql.tables_priv WHERE User='testTblCaseRevoke' AND Host='%' AND DB='test'`).
+		Check(testkit.Rows())
 }
 
 func TestRevokeColumnScope(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66867

Problem Summary:

When `new_collation_enabled = false`, table-scope privilege operations can use the input identifier casing directly when checking/updating `mysql.tables_priv`.
For the same logical object, mixed-case statements (for example `test.t` vs `test.T`) may not consistently target the same privilege row, which can lead to inconsistent GRANT/REVOKE behavior.

### What changed and how does it work?

- Canonicalize object names in table-scope `GRANT`:
  - Resolve table via infoschema and use `tbl.Meta().Name.O`.
  - Resolve schema via infoschema and use canonical `db.Name.O`.
- Canonicalize object names in table-scope `REVOKE` before checking `mysql.tables_priv` existence:
  - Normalize DB name from infoschema.
  - Normalize table name from table metadata when table exists.
- Keep compatibility for special paths that allow GRANT on a non-existent table (`CREATE`/`ALL`) by not forcing canonicalization when no table object is available.
- Add regression tests for case-insensitive behavior with `new_collation_enabled` disabled:
  - `TestGrantTableScopeCaseInsensitiveWithNewCollationDisabled`
  - `TestRevokeTableScopeCaseInsensitiveWithNewCollationDisabled`
  - `TestGrantDBScopeCaseInsensitiveWithNewCollationDisabled`
  - `TestRevokeDBScopeCaseInsensitiveWithNewCollationDisabled`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Test command:
`GOSUMDB=sum.golang.org GOPROXY=https://proxy.golang.org,direct GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod ./tools/check/failpoint-go-test.sh pkg/executor -run 'TestGrantDBScopeCaseInsensitiveWithNewCollationDisabled|TestRevokeDBScopeCaseInsensitiveWithNewCollationDisabled|TestGrantTableScopeCaseInsensitiveWithNewCollationDisabled|TestRevokeTableScopeCaseInsensitiveWithNewCollationDisabled' -count=1`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix table-scope GRANT/REVOKE to canonicalize database/table names so mixed-case identifiers map to the same privilege row when `new_collation_enabled` is disabled.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-insensitive handling for GRANT and REVOKE so database and table names are normalized to canonical schema names, ensuring consistent privilege application regardless of identifier casing.

* **Tests**
  * Added tests that verify case-insensitive grant and revoke behavior (including legacy collation scenarios) to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->