### PR TITLE
Release-testing: v8.5.6 tidb repo CI trigger

### DIFF
--- a/.github/release-testing-ci-ft.md
+++ b/.github/release-testing-ci-ft.md
@@ -1,0 +1,8 @@
+<!-- release-testing ci ft placeholder: do not merge -->
+# Release-Testing CI FT Placeholder
+
+- repo: `pingcap/tidb`
+- version: `v8.5.6`
+- base: `release-8.5`
+- branch: `release-testing-tidb-v8.5.6-ci-ft`
+- generated_at: `2026-04-01 15:57:24`


### PR DESCRIPTION
Automated release-testing placeholder PR for pingcap/tidb release-8.5.

This PR exists only to trigger CI FT via `/test` comments.
Do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CI/CD testing infrastructure configuration for release management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->