### PR TITLE
build(deps): bump client-go to include pd#10522

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -7805,13 +7805,13 @@ def go_deps():
         build_tags = ["nextgen", "intest"],
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sha256 = "a61a12cdc04ec464a219ea73afd1dc5ba2ed10af399b9df65465cb6ac94e48d7",
-        strip_prefix = "github.com/okJiang/client-go/v2@v2.0.0-20260401074418-fc616bb272c2",
+        sha256 = "46ee8c64e0f95ad1514e824506e49ea1d9f75329ee6419aae4b0817336550557",
+        strip_prefix = "github.com/tikv/client-go/v2@v2.0.8-0.20260401083018-b7f9a9e9d2ab",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/okJiang/client-go/v2/com_github_okjiang_client_go_v2-v2.0.0-20260401074418-fc616bb272c2.zip",
-            "http://ats.apps.svc/gomod/github.com/okJiang/client-go/v2/com_github_okjiang_client_go_v2-v2.0.0-20260401074418-fc616bb272c2.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/okJiang/client-go/v2/com_github_okjiang_client_go_v2-v2.0.0-20260401074418-fc616bb272c2.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/okJiang/client-go/v2/com_github_okjiang_client_go_v2-v2.0.0-20260401074418-fc616bb272c2.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260401083018-b7f9a9e9d2ab.zip",
+            "http://ats.apps.svc/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260401083018-b7f9a9e9d2ab.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260401083018-b7f9a9e9d2ab.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260401083018-b7f9a9e9d2ab.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	github.com/stathat/consistent v1.0.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.8-0.20260330060945-282ada62b856
+	github.com/tikv/client-go/v2 v2.0.8-0.20260401083018-b7f9a9e9d2ab
 	github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67
 	github.com/twmb/murmur3 v1.1.6
@@ -375,5 +375,3 @@ replace (
 	sourcegraph.com/sourcegraph/appdash => github.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 	sourcegraph.com/sourcegraph/appdash-data => github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
-
-replace github.com/tikv/client-go/v2 => github.com/okJiang/client-go/v2 v2.0.0-20260401074418-fc616bb272c2

--- a/go.sum
+++ b/go.sum
@@ -687,8 +687,6 @@ github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/okJiang/client-go/v2 v2.0.0-20260401074418-fc616bb272c2 h1:mEyNRogB/eoPq3Va08VFgYtSScEr/ujjBPxP1NvbxsQ=
-github.com/okJiang/client-go/v2 v2.0.0-20260401074418-fc616bb272c2/go.mod h1:lfRxHwyBp1rjTmNC04SUZ+dqk7i1R1AeJ2zraMQaNvY=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
@@ -897,6 +895,8 @@ github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
+github.com/tikv/client-go/v2 v2.0.8-0.20260401083018-b7f9a9e9d2ab h1:t9Kh7tVsSSUMuSPpHChPF6W3VtN4Kq7Gi8EgWPbYRyY=
+github.com/tikv/client-go/v2 v2.0.8-0.20260401083018-b7f9a9e9d2ab/go.mod h1:lfRxHwyBp1rjTmNC04SUZ+dqk7i1R1AeJ2zraMQaNvY=
 github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71 h1:5hCQ6J2fwUpYqIgQGR625bW98wvYS9FUpTiVszIbVSg=
 github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71/go.mod h1:4kxXuAQAREpH+lVbydVwGNNDmcwdj0RG4Ofwky08W/k=
 github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 h1:9LPGD+jzxMlnk5r6+hJnar67cgpDIz/iyD+rfl5r2Vk=


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref #67511, 

ref tikv/pd#10522, ref tikv/client-go#1935

Problem Summary:
TiDB should consume the merged upstream `client-go` change that includes the RM fallback warning-spam fix from `tikv/pd#10522`.

### What changed and how does it work?
- bump `github.com/tikv/client-go/v2` to `v2.0.8-0.20260401083018-b7f9a9e9d2ab`, which is the merged upstream commit from `tikv/client-go#1935`
- keep the resolved `github.com/tikv/pd/client` version at `v0.0.0-20260401072359-048f0d8f6f71`
- refresh `DEPS.bzl` so Bazel fetches the upstream `client-go` artifact instead of the temporary fork artifact used earlier in this PR

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Manual test steps:
- `go mod tidy`
- `make bazel_prepare`
- `go test -run TestNonExistent ./br/pkg/... ./lightning/pkg/... ./dumpling/export`
- `go list ./cmd/tidb-server ./pkg/store/... ./pkg/server/... ./pkg/session/... ./pkg/executor/... ./pkg/planner/... | rg -v '/test/|/tests/|_test$|^github.com/pingcap/tidb/pkg/planner/implementation$' | xargs -n 40 go test -run TestNonExistent`

Side effects
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TiKV client dependencies to latest versions for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->