### PR TITLE
pkg/planner: support semi join rewrite as an alternative logical plan

### DIFF
--- a/pkg/planner/core/casetest/rule/rule_outer_to_semi_join_test.go
+++ b/pkg/planner/core/casetest/rule/rule_outer_to_semi_join_test.go
@@ -79,5 +79,13 @@ func TestSemiJoinRewrite(t *testing.T) {
 		tk.MustHavePlan(`delete from t1 where t1.id in (select /*+ semi_join_rewrite() */ /* issue:58829 */ cast(id as char) from t2 where k=1)`, "IndexHashJoin")
 		tk.MustExec(`delete from t1 where t1.id in (select /*+ semi_join_rewrite() */ cast(id as char) from t2 where k=1)`)
 		tk.MustQuery(`select id from t1 order by id`).Check(testkit.Rows("2", "3"))
+
+		tk.MustExec(`insert into t1 values ("1")`)
+		tk.MustExec(`set @@tidb_opt_enable_alternative_logical_plans=off`)
+		tk.MustExec(`set @@tidb_opt_enable_semi_join_rewrite=off`)
+		tk.MustNotHavePlan(`delete from t1 where t1.id in (select /* issue:58829 */ cast(id as char) from t2 where k=1)`, "IndexHashJoin")
+
+		tk.MustExec(`set @@tidb_opt_enable_alternative_logical_plans=on`)
+		tk.MustHavePlan(`delete from t1 where t1.id in (select /* issue:58829 */ cast(id as char) from t2 where k=1)`, "IndexHashJoin")
 	})
 }

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -5754,6 +5754,12 @@ func (b *PlanBuilder) buildSemiJoin(outerPlan, innerPlan base.LogicalPlan, onCon
 			joinPlan.JoinType = base.SemiJoin
 		}
 	}
+	if b.ctx.GetSessionVars().EnableAlternativeLogicalPlans &&
+		!forceRewrite &&
+		!b.ctx.GetSessionVars().EnableSemiJoinRewrite &&
+		joinPlan.JoinType == base.SemiJoin {
+		b.ctx.GetSessionVars().StmtCtx.MarkAlternativeLogicalPlanSemiJoinRewrite()
+	}
 	// Apply forces to choose hash join currently, so don't worry the hints will take effect if the semi join is in one apply.
 	joinPlan.SetPreferredJoinTypeAndOrder(b.TableHints())
 	// Make the session variable behave like the hint by setting the same prefer bit.

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -480,11 +480,19 @@ func buildAndOptimizeLogicalPlanRound(
 	bestCost *float64,
 	bestLogicalPlanCtx *logicalPlanBuildCtx,
 	optFlagAdjust func(uint64) uint64,
+	sessVarAdjust func(*variable.SessionVars) func(),
 ) (base.Plan, types.NameSlice, bool, error) {
 	builder := planBuilderPool.Get().(*core.PlanBuilder)
 	defer planBuilderPool.Put(builder.ResetForReuse())
 	// TODO: when buildRound > 1, only emit unused view-hint warnings for the winner build.
 	defer builder.HandleUnusedViewHints()
+
+	if sessVarAdjust != nil {
+		restoreSessVars := sessVarAdjust(sctx.GetSessionVars())
+		if restoreSessVars != nil {
+			defer restoreSessVars()
+		}
+	}
 
 	builder.Init(sctx, is, hintProcessor)
 
@@ -557,6 +565,12 @@ func shouldTryAlternativeLogicalPlanRound(sessVars *variable.SessionVars) bool {
 		!sessVars.StmtCtx.AlternativeLogicalPlanSameOrderIndexJoin
 }
 
+func shouldTryAlternativeSemiJoinRewriteRound(sessVars *variable.SessionVars) bool {
+	return sessVars.EnableAlternativeLogicalPlans &&
+		sessVars.StmtCtx.AlternativeLogicalPlanSemiJoinRewrite &&
+		!sessVars.EnableSemiJoinRewrite
+}
+
 func optimize(ctx context.Context, sctx planctx.PlanContext, node *resolve.NodeW, is infoschema.InfoSchema) (base.Plan, types.NameSlice, float64, error) {
 	failpoint.Inject("checkOptimizeCountOne", func(val failpoint.Value) {
 		// only count the optimization for SQL with specified text
@@ -617,6 +631,7 @@ func optimize(ctx context.Context, sctx planctx.PlanContext, node *resolve.NodeW
 		&bestCost,
 		&bestLogicalPlanCtx,
 		nil,
+		nil,
 	)
 	if err != nil {
 		return nil, nil, 0, err
@@ -649,6 +664,39 @@ func optimize(ctx context.Context, sctx planctx.PlanContext, node *resolve.NodeW
 			&bestCost,
 			&bestLogicalPlanCtx,
 			func(flag uint64) uint64 { return flag &^ rule.FlagDecorrelate },
+			nil,
+		)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		if nonLogical {
+			return p, names, 0, nil
+		}
+	}
+	if shouldTryAlternativeSemiJoinRewriteRound(sessVars) {
+		restoreLogicalPlanBuildCtx(sessVars, initialLogicalPlanCtx)
+		p, names, nonLogical, err = buildAndOptimizeLogicalPlanRound(
+			ctx,
+			sctx,
+			node,
+			is,
+			hintProcessor,
+			&checked,
+			&optimizeStarted,
+			&beginOpt,
+			needRestoreLogicalPlanCtx,
+			&bestPlan,
+			&bestNames,
+			&bestCost,
+			&bestLogicalPlanCtx,
+			nil,
+			func(sessVars *variable.SessionVars) func() {
+				prev := sessVars.EnableSemiJoinRewrite
+				sessVars.EnableSemiJoinRewrite = true
+				return func() {
+					sessVars.EnableSemiJoinRewrite = prev
+				}
+			},
 		)
 		if err != nil {
 			return nil, nil, 0, err

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -478,6 +478,9 @@ type StatementContext struct {
 	// AlternativeLogicalPlanSameOrderIndexJoin indicates whether the current first
 	// round already produced a same-order index join candidate for a decorrelated Apply.
 	AlternativeLogicalPlanSameOrderIndexJoin bool
+	// AlternativeLogicalPlanSemiJoinRewrite indicates whether the current logical
+	// build found a semi join that can try an additional SEMI_JOIN_REWRITE round.
+	AlternativeLogicalPlanSemiJoinRewrite bool
 
 	// IsExplainAnalyzeDML is true if the statement is "explain analyze DML executors", before responding the explain
 	// results to the client, the transaction should be committed first. See issue #37373 for more details.
@@ -657,6 +660,7 @@ func (sc *StatementContext) RestoreLogicalPlanBuildState(state LogicalPlanBuildS
 func (sc *StatementContext) ResetAlternativeLogicalPlanSignals() {
 	sc.AlternativeLogicalPlanDecorrelatedApply = false
 	sc.AlternativeLogicalPlanSameOrderIndexJoin = false
+	sc.AlternativeLogicalPlanSemiJoinRewrite = false
 }
 
 // MarkAlternativeLogicalPlanDecorrelatedApply records that at least one Apply has
@@ -669,6 +673,12 @@ func (sc *StatementContext) MarkAlternativeLogicalPlanDecorrelatedApply() {
 // has already produced a same-order index join candidate for a decorrelated Apply.
 func (sc *StatementContext) MarkAlternativeLogicalPlanSameOrderIndexJoin() {
 	sc.AlternativeLogicalPlanSameOrderIndexJoin = true
+}
+
+// MarkAlternativeLogicalPlanSemiJoinRewrite records that the current first round
+// found a semi join that can try an extra SEMI_JOIN_REWRITE-based logical round.
+func (sc *StatementContext) MarkAlternativeLogicalPlanSemiJoinRewrite() {
+	sc.AlternativeLogicalPlanSemiJoinRewrite = true
 }
 
 // CtxID returns the context id of the statement


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67467

Problem Summary:   The alternative logical plan framework introduced by #66995 can explore a non-decorrelated path and compare physical costs, but it cannot explore the semi-join rewrite path unless
  the query explicitly uses `SEMI_JOIN_REWRITE()` or the session variable `tidb_opt_enable_semi_join_rewrite` is enabled. That means the optimizer may still miss a cheaper plan shape
  for `EXISTS` / `IN` subqueries when semi-join rewrite is beneficial but not explicitly requested.

### What changed and how does it work?

  - add a statement-local signal to record whether the first logical build finds a semi-join that is eligible for trying a semi-join-rewrite alternative
  - extend the alternative logical plan flow in `planner.Optimize` with an extra round that temporarily enables `tidb_opt_enable_semi_join_rewrite`
  - rebuild and optimize that alternative logical plan, then compare its physical cost with the other candidates and keep the cheapest one
  - add a regression test showing that, even without an explicit `SEMI_JOIN_REWRITE()` hint, enabling `tidb_opt_enable_alternative_logical_plans` can still choose the rewritten semi-
  join plan

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alternative semi-join rewrite optimization path to improve query planning flexibility.

* **Tests**
  * Extended semi-join optimization tests to validate behavior across different optimizer configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->