### PR TITLE
planner: clarify column pruning comments

### DIFF
--- a/pkg/planner/core/operator/logicalop/logical_datasource.go
+++ b/pkg/planner/core/operator/logicalop/logical_datasource.go
@@ -194,6 +194,10 @@ func (ds *DataSource) PruneColumns(parentUsedCols []*expression.Column) (base.Lo
 	originSchemaColumns := ds.Schema().Columns
 	originColumns := ds.Columns
 
+	// Later single-scan/index-covering checks should use columns required by
+	// the DataSource output, not all columns in ds.Schema(). ds.Schema() may
+	// also include columns kept only because ds.AllConds references them, so
+	// build ColsRequiringFullLen from `used` here.
 	ds.ColsRequiringFullLen = make([]*expression.Column, 0, len(used))
 	for i, col := range ds.Schema().Columns {
 		if used[i] || (ds.ContainExprPrefixUk && expression.GcColumnExprIsTidbShard(col.VirtualExpr)) {

--- a/pkg/planner/core/rule/rule_column_pruning.go
+++ b/pkg/planner/core/rule/rule_column_pruning.go
@@ -35,19 +35,26 @@ func (*ColumnPruner) Optimize(_ context.Context, lp base.LogicalPlan) (base.Logi
 		return nil, planChanged, err
 	}
 	intest.AssertFunc(func() bool {
-		return noZeroColumnLayOut(lp)
-	}, "After column pruning, some operator got zero row output. Please fix it.")
+		return noUnexpectedZeroColumnSchema(lp)
+	}, "After column pruning, some operator got an unexpected zero-column output schema. Please fix it.")
 	return lp, planChanged, nil
 }
 
-func noZeroColumnLayOut(p base.LogicalPlan) bool {
+// noUnexpectedZeroColumnSchema checks the post-pruning invariant that a logical
+// operator should not expose an empty output schema.
+//
+// Two cases are exempt:
+//  1. Some operators reuse their first child's schema object instead of owning a
+//     separate schema, so an empty schema check on the node itself is not useful.
+//  2. LogicalTableDual can legitimately end up with zero output columns.
+func noUnexpectedZeroColumnSchema(p base.LogicalPlan) bool {
 	for _, child := range p.Children() {
-		if success := noZeroColumnLayOut(child); !success {
+		if success := noUnexpectedZeroColumnSchema(child); !success {
 			return false
 		}
 	}
 	if p.Schema().Len() == 0 {
-		// The p don't hold its schema. So we don't need check itself.
+		// This node reuses its first child's schema object rather than owning one.
 		if len(p.Children()) > 0 && p.Schema() == p.Children()[0].Schema() {
 			return true
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #52133

Problem Summary:

Clarify two planner column-pruning comments/helpers that were difficult to read during review.

### What changed and how does it work?

- Rename the zero-column schema assertion helper in `ColumnPruner` and make the assertion text match what it checks.
- Clarify why `DataSource` builds `ColsRequiringFullLen` from `used` instead of all columns left in `ds.Schema()`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved query optimizer's column pruning logic to use only output-required columns during planning.
  * Refined validation checks for logical operator schemas to better enforce correctness invariants and handle exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->