### PR TITLE
tests/realtikvtest: tolerate next-gen lazy uniqueness conflict reasons

### DIFF
--- a/tests/realtikvtest/pessimistictest/pessimistic_test.go
+++ b/tests/realtikvtest/pessimistictest/pessimistic_test.go
@@ -2763,7 +2763,7 @@ func TestLazyUniquenessCheck(t *testing.T) {
 	if kerneltype.IsClassic() {
 		require.ErrorContains(t, err, "reason=LazyUniquenessCheck")
 	} else {
-		require.ErrorContains(t, err, "reason=NotLockedKeyConflict")
+		requireNextGenLazyUniquenessConflictReason(t, err)
 	}
 
 	// case: DML returns error => abort txn
@@ -3090,8 +3090,21 @@ func TestLazyUniquenessCheckWithInconsistentReadResult(t *testing.T) {
 	if kerneltype.IsClassic() {
 		require.ErrorContains(t, err, "reason=LazyUniquenessCheck")
 	} else {
-		require.ErrorContains(t, err, "reason=NotLockedKeyConflict")
+		requireNextGenLazyUniquenessConflictReason(t, err)
 	}
+}
+
+// Different next-gen engine families currently surface different write-conflict reasons
+// for lazy uniqueness checks, so the TiDB-side assertion should accept both.
+func requireNextGenLazyUniquenessConflictReason(t *testing.T, err error) {
+	t.Helper()
+	errMsg := err.Error()
+	require.Truef(
+		t,
+		strings.Contains(errMsg, "reason=LazyUniquenessCheck") || strings.Contains(errMsg, "reason=NotLockedKeyConflict"),
+		"expected next-gen lazy uniqueness conflict reason, got %s",
+		errMsg,
+	)
 }
 
 func TestLazyUniquenessCheckWithSavepoint(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #67503

Problem Summary:

`pull-integration-realcluster-test-next-gen` started failing in `TestLazyUniquenessCheck` and `TestLazyUniquenessCheckWithInconsistentReadResult` after the next-gen job switched to a different TiKV/TiKV-worker artifact family. The current TiDB tests assume every non-classic environment reports `reason=NotLockedKeyConflict`, but the affected next-gen environment can report `reason=LazyUniquenessCheck` for the same lazy uniqueness conflict.

### What changed and how does it work?

Keep the classic assertion unchanged and relax the next-gen assertion in the two affected tests to accept either `reason=LazyUniquenessCheck` or `reason=NotLockedKeyConflict`.

This matches the current engine-family divergence without changing production behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - `make bazel_prepare`
  - `go test -run '^$' -tags=intest,deadlock ./tests/realtikvtest/pessimistictest/...`
  - Attempted scoped RealTiKV run:
    - `go test -run '^(TestLazyUniquenessCheck|TestLazyUniquenessCheckWithInconsistentReadResult)$' -tags=intest,deadlock ./tests/realtikvtest/pessimistictest/... -args -tikv-path 'tikv://127.0.0.1:12379?disableGC=true'`
    - Local `tiup playground` resolved to `v8.5.5`, whose PD API is too old for current `master` on this machine (`GetGCState` / `QueryRegion` unimplemented), so the full RealTiKV verification needs CI.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated assertions for lazy uniqueness conflict detection in pessimistic transaction tests to provide more flexible validation of error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->