### PR TITLE
planner: eliminate unused outer join over window top1

### DIFF
--- a/docs/agents/planner/rule/rule_ai_notes.md
+++ b/docs/agents/planner/rule/rule_ai_notes.md
@@ -109,3 +109,27 @@ Reusable lessons:
   - `HandleCols` / `UnMutableHandleCols` for stable handle identity,
   - `_tidb_rowid` only for tables that truly need extra handle.
 - If two index-merge construction paths both touch handle columns, patch them together. Fixing only the table-scan side or only the partial-index side usually leaves a second latent failure path behind.
+
+## 2026-04-08 - Outer join elimination can treat window top1 as unique (PR #67519)
+
+Background:
+- A planner change extends outer join elimination so the inner side can be treated as unique when it is a `Selection` over a `LogicalWindow` computing `row_number()`.
+
+Key takeaways:
+- The uniqueness proof is shape-sensitive, not a general window-property deduction.
+- The current rule only accepts:
+  - exactly one window function and it is `row_number()`,
+  - a `ROWS BETWEEN CURRENT ROW AND CURRENT ROW` frame,
+  - a selection predicate proving the window result column has upper bound `1`,
+  - partition-by columns fully covered by the inner join keys.
+- `hasRowNumberUpperBoundOne` intentionally covers only simple patterns:
+  - `rn = 1` via `isColEqConst`,
+  - simple `<` / `<=` upper bounds recognized by `expression.FindUpperBound`.
+- More complex forms such as `BETWEEN`, `IN (1)`, or compound rewrites are intentionally left out until there is a concrete need and proof they are normalized reliably before join elimination.
+
+Implementation choice:
+- Keep the helper local to `rule_join_elimination.go` and document the uniqueness argument directly at the helper boundary.
+- Prefer narrow syntactic recognition over broader but fragile expression reasoning, because a false positive here would make outer join elimination unsound.
+
+Review note:
+- Reviewers explicitly asked for comments on both the window-top1 uniqueness helper and the row-number upper-bound matcher, because the correctness argument is not obvious from the function names alone.

--- a/pkg/planner/core/casetest/plan_test.go
+++ b/pkg/planner/core/casetest/plan_test.go
@@ -448,6 +448,7 @@ func TestOuterJoinElimination(t *testing.T) {
 		tk.MustExec(`create table t2_uk (a int, b int, c int, unique key(a))`)
 		tk.MustExec(`create table t2_nnuk (a int not null, b int, c int, unique key(a))`)
 		tk.MustExec(`create table t2_pk (a int, b int, c int, primary key(a))`)
+		tk.MustExec(`create table t1_window (a int, b int, c int, key idx_a(a))`)
 		tk.MustExec(`create table t2_window (a int, b int, c int, key(a))`)
 
 		// only when t2.a has unique attribute, we can eliminate the outer join.
@@ -499,11 +500,18 @@ func TestOuterJoinElimination(t *testing.T) {
 		// next query correlates on t2, so outer join elimination can't be applied
 		tk.MustHavePlan("select t1a.a, if(exists(select 1 from t2_uk t2b where t2b.a = t2.a), 1, 0) as founda from t1 t1a left join t2_pk t2 on t1a.a = t2.a", "Join")
 
-		tk.MustNotHavePlan(`select t1.a from t1 left join (
+		tk.MustExec("insert into t1_window values (1, 10, 100), (2, 20, 200)")
+		tk.MustExec("insert into t2_window values (1, 10, 1), (1, 10, 2), (2, 20, 3)")
+		sql := `select t1.a from t1_window t1 use index(idx_a) left join (
 			select a, row_number() over(partition by a order by c desc) as rn
 			from t2_window
 		) t2 on t1.a = t2.a and t2.rn = 1
-		where t1.a = 1`, "Join")
+		where t1.a = 1`
+		tk.MustQuery(sql).Check(testkit.Rows("1"))
+		tk.MustQuery("explain format = 'plan_tree' " + sql).Check(testkit.Rows(
+			"IndexReader root  index:IndexRangeScan",
+			"└─IndexRangeScan cop[tikv] table:t1, index:idx_a(a) range:[1,1], keep order:false, stats:pseudo",
+		))
 	})
 }
 

--- a/pkg/planner/core/casetest/plan_test.go
+++ b/pkg/planner/core/casetest/plan_test.go
@@ -448,6 +448,7 @@ func TestOuterJoinElimination(t *testing.T) {
 		tk.MustExec(`create table t2_uk (a int, b int, c int, unique key(a))`)
 		tk.MustExec(`create table t2_nnuk (a int not null, b int, c int, unique key(a))`)
 		tk.MustExec(`create table t2_pk (a int, b int, c int, primary key(a))`)
+		tk.MustExec(`create table t2_window (a int, b int, c int, key(a))`)
 
 		// only when t2.a has unique attribute, we can eliminate the outer join.
 		// nullable unique index is not allowed to trigger the outer join elinimation.
@@ -497,6 +498,12 @@ func TestOuterJoinElimination(t *testing.T) {
 		tk.MustNotHavePlan("select t1a.a, if(exists(select 1 from t2_uk t2b where t2b.a = t1a.a), 1, 0) as founda from t1 t1a left join t2_pk t2 on t1a.a = t2.a", "Join")
 		// next query correlates on t2, so outer join elimination can't be applied
 		tk.MustHavePlan("select t1a.a, if(exists(select 1 from t2_uk t2b where t2b.a = t2.a), 1, 0) as founda from t1 t1a left join t2_pk t2 on t1a.a = t2.a", "Join")
+
+		tk.MustNotHavePlan(`select t1.a from t1 left join (
+			select a, row_number() over(partition by a order by c desc) as rn
+			from t2_window
+		) t2 on t1.a = t2.a and t2.rn = 1
+		where t1.a = 1`, "Join")
 	})
 }
 

--- a/pkg/planner/core/rule_join_elimination.go
+++ b/pkg/planner/core/rule_join_elimination.go
@@ -133,6 +133,9 @@ func (*OuterJoinEliminator) extractInnerJoinKeys(join *logicalop.LogicalJoin, in
 
 // check whether one of unique keys sets is contained by inner join keys
 func (*OuterJoinEliminator) isInnerJoinKeysContainUniqueKey(innerPlan base.LogicalPlan, joinKeys *expression.Schema, innerNullEQKeys intset.FastIntSet) (bool, error) {
+	if isSelectionPartitionedRowNumberWindowOneUnique(innerPlan, joinKeys) {
+		return true, nil
+	}
 	for _, keyInfo := range innerPlan.Schema().PKOrUK {
 		joinKeysContainKeyInfo := true
 		for _, col := range keyInfo {
@@ -162,6 +165,72 @@ func (*OuterJoinEliminator) isInnerJoinKeysContainUniqueKey(innerPlan base.Logic
 		}
 	}
 	return false, nil
+}
+
+func isSelectionPartitionedRowNumberWindowOneUnique(innerPlan base.LogicalPlan, joinKeys *expression.Schema) bool {
+	sel, ok := innerPlan.(*logicalop.LogicalSelection)
+	if !ok || len(sel.Conditions) == 0 {
+		return false
+	}
+
+	window, ok := sel.Children()[0].(*logicalop.LogicalWindow)
+	if !ok || len(window.WindowFuncDescs) != 1 || window.WindowFuncDescs[0].Name != "row_number" {
+		return false
+	}
+	if window.Frame == nil || window.Frame.Start == nil || window.Frame.End == nil {
+		return false
+	}
+	if window.Frame.Type != ast.Rows || window.Frame.Start.Type != ast.CurrentRow || window.Frame.End.Type != ast.CurrentRow {
+		return false
+	}
+
+	windowColumns := window.GetWindowResultColumns()
+	if len(windowColumns) != 1 || !hasRowNumberUpperBoundOne(sel.Conditions, windowColumns[0]) {
+		return false
+	}
+
+	for _, partitionCol := range window.GetPartitionByCols() {
+		if !joinKeys.Contains(partitionCol) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasRowNumberUpperBoundOne(conditions []expression.Expression, rowNumberCol *expression.Column) bool {
+	for _, cond := range conditions {
+		if isColEqConst(cond, rowNumberCol, 1) {
+			return true
+		}
+		if col, upperBound := expression.FindUpperBound(cond); col != nil && col.EqualColumn(rowNumberCol) && upperBound <= 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func isColEqConst(expr expression.Expression, targetCol *expression.Column, value int64) bool {
+	sf, ok := expr.(*expression.ScalarFunction)
+	if !ok || sf.FuncName.L != ast.EQ || len(sf.GetArgs()) != 2 {
+		return false
+	}
+	if col, ok := sf.GetArgs()[0].(*expression.Column); ok && col.EqualColumn(targetCol) {
+		constant, ok := sf.GetArgs()[1].(*expression.Constant)
+		if !ok {
+			return false
+		}
+		constantValue, ok := constant.Value.GetValue().(int64)
+		return ok && constantValue == value
+	}
+	if col, ok := sf.GetArgs()[1].(*expression.Column); ok && col.EqualColumn(targetCol) {
+		constant, ok := sf.GetArgs()[0].(*expression.Constant)
+		if !ok {
+			return false
+		}
+		constantValue, ok := constant.Value.GetValue().(int64)
+		return ok && constantValue == value
+	}
+	return false
 }
 
 // check whether one of index sets is contained by inner join index

--- a/pkg/planner/core/rule_join_elimination.go
+++ b/pkg/planner/core/rule_join_elimination.go
@@ -167,6 +167,9 @@ func (*OuterJoinEliminator) isInnerJoinKeysContainUniqueKey(innerPlan base.Logic
 	return false, nil
 }
 
+// isSelectionPartitionedRowNumberWindowOneUnique recognizes Selection(Window(row_number))
+// shapes where the filter keeps at most one row for each partition key, so the
+// inner side is unique on the join keys for outer join elimination.
 func isSelectionPartitionedRowNumberWindowOneUnique(innerPlan base.LogicalPlan, joinKeys *expression.Schema) bool {
 	sel, ok := innerPlan.(*logicalop.LogicalSelection)
 	if !ok || len(sel.Conditions) == 0 {
@@ -197,6 +200,9 @@ func isSelectionPartitionedRowNumberWindowOneUnique(innerPlan base.LogicalPlan, 
 	return true
 }
 
+// hasRowNumberUpperBoundOne matches predicates that keep the row_number() result
+// column at or below 1, either through an equality to 1 or through simple upper
+// bounds recognized by expression.FindUpperBound.
 func hasRowNumberUpperBoundOne(conditions []expression.Expression, rowNumberCol *expression.Column) bool {
 	for _, cond := range conditions {
 		if isColEqConst(cond, rowNumberCol, 1) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67517

Problem Summary:

TiDB misses an outer join elimination opportunity when the inner side is a derived table built from `row_number() over(partition by join_key ...)` and filtered by `rn = 1`.

If the query does not use any inner-side columns, that pattern guarantees at most one matching row per join key, so the `LEFT JOIN` is redundant and can be eliminated.

### What changed and how does it work?

- Teach `outer_join_eliminate` to recognize `Selection(Window(row_number))` with `rn = 1` or `rn <= 1` as unique on the window partition key.
- Add a planner regression test with an anonymized minimal query shape.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

ref https://github.com/PingCAP-QE/planreplayertest/pull/111

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced outer-join elimination so LEFT JOINs can be simplified when the inner side is filtered to a single row per partition (row_number = 1), improving query planning for such windowed patterns.

* **Tests**
  * Added a test covering join optimization when the inner side is derived via a row-number window and filtered to one row.

* **Documentation**
  * Added notes describing the new planner behavior and its structural constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->