### PR TITLE
docs: replace deprecated PingCAP domains

### DIFF
--- a/br/tests/download_tools.sh
+++ b/br/tests/download_tools.sh
@@ -34,7 +34,7 @@ done
 
 if [ ! -e "$BIN/tiflash" ]; then
     echo "Downloading nightly Tiflash..."
-    curl -L -f -o "$BIN/tiflash.tar.gz" "https://download.pingcap.org/tiflash-nightly-linux-amd64.tar.gz"
+    curl -L -f -o "$BIN/tiflash.tar.gz" "https://download.pingcap.com/tiflash-nightly-linux-amd64.tar.gz"
     tar -xf "$BIN/tiflash.tar.gz" -C "$BIN/"
     rm "$BIN/tiflash.tar.gz"
     mkdir "$BIN"/flash_cluster_manager
@@ -46,7 +46,7 @@ fi
 
 if [ -n "$MISSING_TIDB_COMPONENTS" ]; then
     echo "Downloading latest TiDB bundle..."
-    curl -L -f -o "$BIN/tidb.tar.gz" "https://download.pingcap.org/tidb-nightly-linux-amd64.tar.gz"
+    curl -L -f -o "$BIN/tidb.tar.gz" "https://download.pingcap.com/tidb-nightly-linux-amd64.tar.gz"
     tar -x -f "$BIN/tidb.tar.gz" -C "$BIN/" $MISSING_TIDB_COMPONENTS
     rm "$BIN/tidb.tar.gz"
     mv "$BIN"/tidb-nightly-linux-amd64/bin/* "$BIN/"
@@ -80,7 +80,7 @@ fi
 
 if [ ! -e "$BIN/cdc" ]; then
     echo "Downloading cdc..."
-    curl -L -f -o "$BIN/cdc.tar.gz" "https://download.pingcap.org/ticdc-nightly-linux-amd64.tar.gz"
+    curl -L -f -o "$BIN/cdc.tar.gz" "https://download.pingcap.com/ticdc-nightly-linux-amd64.tar.gz"
     tar -x -f "$BIN/cdc.tar.gz" -C "$BIN/" ticdc-nightly-linux-amd64/bin/cdc
     mv "$BIN"/ticdc-nightly-linux-amd64/bin/cdc "$BIN/cdc"
 fi

--- a/dumpling/README.md
+++ b/dumpling/README.md
@@ -34,9 +34,9 @@ Building
 3. Run `make dumpling_unit_test` to run the unit tests.
 4. Run `make dumpling_integration_test` to run integration tests. For integration test:
   - The following executables must be copied or generated or linked into these locations:
-    * `bin/sync_diff_inspector` (download from [tidb-enterprise-tools-latest-linux-amd64](http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz))
-    * `bin/tidb-server` (download from [tidb-master-linux-amd64](https://download.pingcap.org/tidb-master-linux-amd64.tar.gz))
-    * `bin/tidb-lightning` (download from [tidb-toolkit-latest-linux-amd64](https://download.pingcap.org/tidb-toolkit-latest-linux-amd64.tar.gz))
+    * `bin/sync_diff_inspector` (download from [tidb-enterprise-tools-latest-linux-amd64](http://download.pingcap.com/tidb-enterprise-tools-latest-linux-amd64.tar.gz))
+    * `bin/tidb-server` (download from [tidb-master-linux-amd64](https://download.pingcap.com/tidb-master-linux-amd64.tar.gz))
+    * `bin/tidb-lightning` (download from [tidb-toolkit-latest-linux-amd64](https://download.pingcap.com/tidb-toolkit-latest-linux-amd64.tar.gz))
     * `bin/minio` (download from <https://min.io/download>)
     * Now, you can run `sh ./dumpling/install.sh` to get the above binary files.
   - The following programs must be installed:

--- a/dumpling/install.sh
+++ b/dumpling/install.sh
@@ -5,11 +5,7 @@ mkdir -p bin/
 
 # download lightning and sync_diff_inspector
 TOOLS_TAG="nightly"
-<<<<<<< HEAD
 wget http://download.pingcap.com/tidb-toolkit-$TOOLS_TAG-linux-amd64.tar.gz -O tools.tar.gz
-=======
-wget http://download.pingcap.com/tidb-toolkit-$TOOLS_TAG-linux-$ARCH_SUFFIX.tar.gz -O tools.tar.gz
->>>>>>> 2caf3752b (docs: replace deprecated PingCAP domains)
 tar -xzvf tools.tar.gz
 mv tidb-toolkit-$TOOLS_TAG-linux-amd64/bin/* bin/
 

--- a/dumpling/install.sh
+++ b/dumpling/install.sh
@@ -5,7 +5,11 @@ mkdir -p bin/
 
 # download lightning and sync_diff_inspector
 TOOLS_TAG="nightly"
-wget http://download.pingcap.org/tidb-toolkit-$TOOLS_TAG-linux-amd64.tar.gz -O tools.tar.gz
+<<<<<<< HEAD
+wget http://download.pingcap.com/tidb-toolkit-$TOOLS_TAG-linux-amd64.tar.gz -O tools.tar.gz
+=======
+wget http://download.pingcap.com/tidb-toolkit-$TOOLS_TAG-linux-$ARCH_SUFFIX.tar.gz -O tools.tar.gz
+>>>>>>> 2caf3752b (docs: replace deprecated PingCAP domains)
 tar -xzvf tools.tar.gz
 mv tidb-toolkit-$TOOLS_TAG-linux-amd64/bin/* bin/
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67527

Problem Summary:

`download.pingcap.org` is being deprecated in favor of `download.pingcap.com`, and release-7.1 still has old-domain references in Dumpling install/docs and BR test download helpers.

### What changed and how does it work?

- backport the domain migration from `master` to release-7.1
- replace deprecated `download.pingcap.org` references with `download.pingcap.com` in `br/tests/download_tools.sh`, `dumpling/README.md`, and `dumpling/install.sh`
- preserve the existing release-7.1-specific script behavior while only changing the download host

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test steps:
- `git diff --check`
- verify no remaining old-domain references in `br/tests/download_tools.sh`, `dumpling/README.md`, and `dumpling/install.sh`
- `curl -I https://download.pingcap.com/tiflash-nightly-linux-amd64.tar.gz`
- `curl -I https://download.pingcap.com/tidb-nightly-linux-amd64.tar.gz`
- `curl -I https://download.pingcap.com/ticdc-nightly-linux-amd64.tar.gz`
- `curl -I http://download.pingcap.com/tidb-enterprise-tools-latest-linux-amd64.tar.gz`
- `curl -I https://download.pingcap.com/tidb-toolkit-latest-linux-amd64.tar.gz`
- `curl -I http://download.pingcap.com/tidb-toolkit-nightly-linux-amd64.tar.gz`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
none
```
