### PR TITLE
expression: clone constant before PropagateType mutation

### DIFF
--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -1257,6 +1257,9 @@ func PropagateType(ctx EvalContext, evalType types.EvalType, args ...Expression)
 				newCol.(*CorrelatedColumn).RetType = col.RetType.Clone()
 				args[0] = newCol
 			}
+			if con, ok := args[0].(*Constant); ok {
+				args[0] = con.Clone()
+			}
 			if args[0].GetType(ctx).GetType() == mysql.TypeNewDecimal {
 				if newDecimal > mysql.MaxDecimalScale {
 					newDecimal = mysql.MaxDecimalScale

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -4472,3 +4472,17 @@ func TestDeepCopyRetType(t *testing.T) {
 	tk.MustExec("create view v0(c0) as select cast((t1.c0 div t1.c0) as decimal) from t1;")
 	tk.MustQuery("select * from v0 inner join t0 on (v0.c0 like cast(v0.c0 as char) <= t0.c0) and (not atan2(t0.c0, v0.c0));").Check(testkit.Rows())
 }
+
+func TestIssue66706(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t0(c0 numeric);")
+	tk.MustExec("create table t1 like t0;")
+	tk.MustExec("replace into t0 values (-1780864408);")
+	tk.MustExec("insert into t1 values (1448472626);")
+	tk.MustExec("create or replace view v0(c0) as select 0.99 from t1, t0;")
+
+	tk.MustQuery("select v0.c0 from v0 where sign(v0.c0);").Check(testkit.Rows("0.99"))
+	tk.MustQuery("select ref0 from (select v0.c0 as ref0, sign(v0.c0) as ref1 from v0) as s where ref1;").Check(testkit.Rows("0.99"))
+}

--- a/tests/integrationtest/r/executor/aggregate.result
+++ b/tests/integrationtest/r/executor/aggregate.result
@@ -2062,7 +2062,7 @@ delete from mysql.opt_rule_blacklist where name = "decorrelate";
 admin reload opt_rule_blacklist;
 select distinct avg(nullif(77.15, PI()));
 avg(nullif(77.15, PI()))
-77.1500000000000000000000000000000000
+77.150000
 Level	Code	Message
 Warning	1265	Data truncated for column '%s' at row %d
 drop table if exists t_a;

--- a/tests/integrationtest/r/executor/aggregate.result
+++ b/tests/integrationtest/r/executor/aggregate.result
@@ -2063,8 +2063,6 @@ admin reload opt_rule_blacklist;
 select distinct avg(nullif(77.15, PI()));
 avg(nullif(77.15, PI()))
 77.150000
-Level	Code	Message
-Warning	1265	Data truncated for column '%s' at row %d
 drop table if exists t_a;
 CREATE TABLE `t_a` (
 `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'id',


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66706

Problem Summary: expression: clone constant before PropagateType mutation

### What changed and how does it work?

- Clone `*Constant` before `PropagateType` mutates `flen/decimal`.
- Prevent type-metadata side effects from leaking across shared expression nodes between predicate and projection.
- Add regression test `TestIssue66706`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type propagation for constant values so numeric functions and filtered queries that involve constants produce correct results.

* **Tests**
  * Added an integration test covering views, constants and numeric functions to prevent regressions.

* **Result Updates**
  * Normalized numeric output formatting in integration test expectations and removed an obsolete warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->