### PR TITLE
executor: avoid LOAD DATA panic on VECTOR NOT NULL rows

### DIFF
--- a/pkg/executor/load_data.go
+++ b/pkg/executor/load_data.go
@@ -66,6 +66,11 @@ var (
 	taskQueueSize = 16 // the maximum number of pending tasks to commit in queue
 )
 
+const (
+	vectorNotNullErrPrefix = "VECTOR column '"
+	vectorNotNullErrSuffix = "' cannot be null"
+)
+
 // LoadDataReaderBuilder stores a function to start background goroutines to read from connection and
 // a `Wg` to wait for all background goroutines to finish.
 type LoadDataReaderBuilder struct {
@@ -582,10 +587,9 @@ func (w *encodeWorker) parserData2TableData(
 		if w.controller.Restrictive {
 			return nil, err
 		}
-		// ErrInvalidAutoRandom should always be returned as a real error,
-		// not treated as a warning, because returning nil row causes panic
-		// when looking up index. See https://github.com/pingcap/tidb/issues/65585
-		if dbterror.ErrInvalidAutoRandom.Equal(err) {
+		// AUTO_RANDOM and VECTOR NOT NULL do not have a warning fallback.
+		// Returning nil rows for these errors will panic later during duplicate-key checking.
+		if shouldReturnLoadDataGetRowError(err) {
 			return nil, err
 		}
 		w.handleWarning(err)
@@ -595,6 +599,15 @@ func (w *encodeWorker) parserData2TableData(
 	}
 
 	return newRow, nil
+}
+
+func shouldReturnLoadDataGetRowError(err error) bool {
+	return dbterror.ErrInvalidAutoRandom.Equal(err) || isVectorNotNullError(err)
+}
+
+func isVectorNotNullError(err error) bool {
+	msg := err.Error()
+	return strings.HasPrefix(msg, vectorNotNullErrPrefix) && strings.HasSuffix(msg, vectorNotNullErrSuffix)
 }
 
 // commitWorker is a sub-worker of LoadDataWorker that dedicated to commit data.

--- a/pkg/executor/test/loaddatatest/load_data_test.go
+++ b/pkg/executor/test/loaddatatest/load_data_test.go
@@ -66,6 +66,20 @@ func checkCases(
 	}
 }
 
+func runLoadDataWithStringReader(t *testing.T, tk *testkit.TestKit, data, loadSQL string) error {
+	t.Helper()
+
+	ctx := tk.Session().(sessionctx.Context)
+	readerBuilder := executor.LoadDataReaderBuilder{
+		Build: func(_ string) (io.ReadCloser, error) {
+			return mydump.NewStringReader(data), nil
+		},
+		Wg: &sync.WaitGroup{},
+	}
+	ctx.SetValue(executor.LoadDataReaderBuilderKey, readerBuilder)
+	return tk.ExecToErr(loadSQL)
+}
+
 func TestLoadDataInitParam(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -508,21 +522,42 @@ func TestLoadDataAutoRandomError(t *testing.T) {
 	tk.MustExec("drop table if exists t_auto_random")
 	tk.MustExec("create table t_auto_random (a bigint primary key auto_random(5), b int)")
 
+	// Reproduce the non-restrictive path where LOAD DATA would otherwise downgrade row errors to warnings.
+	tk.MustExec("set sql_mode = ''")
 	// Ensure allow_auto_random_explicit_insert is disabled (default)
 	tk.MustExec("set @@allow_auto_random_explicit_insert = false")
 
-	ctx := tk.Session().(sessionctx.Context)
-
-	// Create a reader with explicit value for auto_random column
-	var reader io.ReadCloser = mydump.NewStringReader("1,2\n")
-	var readerBuilder executor.LoadDataReaderBuilder = executor.LoadDataReaderBuilder{
-		Build: func(_ string) (r io.ReadCloser, err error) {
-			return reader, nil
-		},
-		Wg: &sync.WaitGroup{},
-	}
-	ctx.SetValue(executor.LoadDataReaderBuilderKey, readerBuilder)
-
-	err := tk.ExecToErr("load data local infile '/tmp/test.csv' into table t_auto_random")
+	err := runLoadDataWithStringReader(t, tk, "1,2\n", "load data local infile 'test.csv' into table t_auto_random")
 	require.ErrorIs(t, err, dbterror.ErrInvalidAutoRandom)
+}
+
+func TestLoadDataVectorNotNullError(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t_vector_not_null")
+	tk.MustExec("create table t_vector_not_null (id bigint primary key, v vector(3) not null)")
+	tk.MustExec("set sql_mode = ''")
+
+	err := runLoadDataWithStringReader(t, tk, "1\n", "load data local infile 'test.csv' into table t_vector_not_null")
+	require.ErrorContains(t, err, "VECTOR column 'v' cannot be null")
+	tk.MustQuery("select count(*) from t_vector_not_null").Check(testkit.Rows("0"))
+}
+
+func TestLoadDataNonVectorNotNullStillUsesWarning(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t_regular_not_null")
+	tk.MustExec("create table t_regular_not_null (id bigint primary key, v varchar(8) not null)")
+	tk.MustExec("set sql_mode = ''")
+
+	err := runLoadDataWithStringReader(t, tk, "1\n", "load data local infile 'test.csv' into table t_regular_not_null")
+	require.NoError(t, err)
+	require.Equal(t, "Records: 1  Deleted: 0  Skipped: 0  Warnings: 2", tk.Session().LastMessage())
+	tk.MustQuery("show warnings").Check(testkit.Rows(
+		"Warning 1261 Row 1 doesn't contain data for all columns",
+		"Warning 1263 Column set to default value; NULL supplied to NOT NULL column 'v' at row 1",
+	))
+	tk.MustQuery("select id, length(v) from t_regular_not_null").Check(testkit.Rows("1 0"))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67533

Problem Summary:

`LOAD DATA` can panic in non-strict mode when an input row omits a `VECTOR NOT NULL` column. The row builder returns a hard error because vector columns do not have a zero-value fallback, but the `LOAD DATA` path downgrades that error into a warning and returns a nil row. The later duplicate-key checking path assumes the row is valid and panics with `index out of range`.

### What changed and how does it work?

This change keeps the existing non-strict warning behavior for normal `NOT NULL` columns, but returns the row error directly for the two `LOAD DATA` cases that cannot safely fall back to warnings:

- `ErrInvalidAutoRandom`
- `VECTOR column '...' cannot be null`

That keeps the fix scoped to the confirmed panic triggers instead of changing the full `LOAD DATA` error contract.

The tests add coverage for:

- `AUTO_RANDOM` explicit insert in non-strict `LOAD DATA`
- `VECTOR NOT NULL` missing-column input returning an error instead of panicking
- regular `NOT NULL` columns still using warning-and-insert behavior in non-strict mode

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
