### PR TITLE
server: harden parseBinaryParams against malformed length-encoded values

### DIFF
--- a/pkg/server/conn_stmt_params.go
+++ b/pkg/server/conn_stmt_params.go
@@ -26,6 +26,35 @@ import (
 
 var errUnknownFieldType = dbterror.ClassServer.NewStd(errno.ErrUnknownFieldType)
 
+func parseLengthEncodedParamValueHeader(paramValues []byte, pos int) (length uint64, isNull bool, nextPos int, err error) {
+	if len(paramValues) <= pos {
+		return 0, false, pos, mysql.ErrMalformPacket
+	}
+	need := 1
+	switch paramValues[pos] {
+	case 0xfc:
+		need = 3
+	case 0xfd:
+		need = 4
+	case 0xfe:
+		need = 9
+	}
+	if len(paramValues)-pos < need {
+		return 0, false, pos, mysql.ErrMalformPacket
+	}
+	var n int
+	length, isNull, n = util2.ParseLengthEncodedInt(paramValues[pos:])
+	return length, isNull, pos + n, nil
+}
+
+func takeBinaryParamValue(paramValues []byte, pos int, length uint64) ([]byte, int, error) {
+	if pos > len(paramValues) || length > uint64(len(paramValues)-pos) {
+		return nil, pos, mysql.ErrMalformPacket
+	}
+	end := pos + int(length)
+	return paramValues[pos:end], end, nil
+}
+
 // parseBinaryParams decodes the binary params according to the protocol
 func parseBinaryParams(params []param.BinaryParam, boundParams [][]byte, nullBitmap, paramTypes, paramValues []byte, enc *util2.InputDecoder) (err error) {
 	pos := 0
@@ -106,42 +135,36 @@ func parseBinaryParams(params []param.BinaryParam, boundParams [][]byte, nullBit
 			length = uint64(paramValues[pos])
 			pos++
 		case mysql.TypeNewDecimal, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
-			if len(paramValues) < (pos + 1) {
-				err = mysql.ErrMalformPacket
+			length, isNull, pos, err = parseLengthEncodedParamValueHeader(paramValues, pos)
+			if err != nil {
 				return
 			}
-			var n int
-			length, isNull, n = util2.ParseLengthEncodedInt(paramValues[pos:])
-			pos += n
 		case mysql.TypeUnspecified, mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeString,
 			mysql.TypeEnum, mysql.TypeSet, mysql.TypeGeometry, mysql.TypeBit:
-			if len(paramValues) < (pos + 1) {
-				err = mysql.ErrMalformPacket
+			length, isNull, pos, err = parseLengthEncodedParamValueHeader(paramValues, pos)
+			if err != nil {
 				return
 			}
-			var n int
-			length, isNull, n = util2.ParseLengthEncodedInt(paramValues[pos:])
-			pos += n
 			decodeWithDecoder = true
 		default:
 			err = errUnknownFieldType.GenWithStack("stmt unknown field type %d", tp)
 			return
 		}
 
-		if len(paramValues) < (pos + int(length)) {
-			err = mysql.ErrMalformPacket
-			return
+		val, nextPos, err := takeBinaryParamValue(paramValues, pos, length)
+		if err != nil {
+			return err
 		}
 		params[i] = param.BinaryParam{
 			Tp:         tp,
 			IsUnsigned: isUnsigned,
 			IsNull:     isNull,
-			Val:        paramValues[pos : pos+int(length)],
+			Val:        val,
 		}
 		if decodeWithDecoder {
 			params[i].Val = enc.DecodeInput(params[i].Val)
 		}
-		pos += int(length)
+		pos = nextPos
 	}
 	return
 }

--- a/pkg/server/conn_stmt_params_test.go
+++ b/pkg/server/conn_stmt_params_test.go
@@ -282,6 +282,40 @@ func TestParseExecArgs(t *testing.T) {
 	}
 }
 
+func TestParseExecArgsMalformedLengthEncodedParam(t *testing.T) {
+	tests := []struct {
+		name        string
+		paramValues []byte
+	}{
+		{
+			name:        "truncated length-encoded uint64 header",
+			paramValues: []byte{0xfe},
+		},
+		{
+			name: "overflowing length-encoded uint64",
+			// length = 1<<63, which previously could slip past `pos + int(length)` checks and panic on slicing.
+			paramValues: []byte{0xfe, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				args := expression.Args2Expressions4Test(1)
+				err := decodeAndParse(
+					types.DefaultStmtNoWarningContext,
+					args,
+					[][]byte{nil},
+					[]byte{0x0},
+					[]byte{mysql.TypeVarString, 0},
+					tt.paramValues,
+					nil,
+				)
+				require.Truef(t, terror.ErrorEqual(err, mysql.ErrMalformPacket), "err %v", err)
+			})
+		})
+	}
+}
+
 func TestParseExecArgsAndEncode(t *testing.T) {
 	dt := expression.Args2Expressions4Test(1)
 	err := decodeAndParse(types.DefaultStmtNoWarningContext,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67486

Problem Summary:

Malformed length-encoded parameter payloads in `COM_STMT_EXECUTE` can panic in `parseBinaryParams`. The current code uses `pos + int(length)` before slicing, so crafted large length values may bypass the old check instead of being rejected as malformed packets.

### What changed and how does it work?

This PR tightens binary parameter parsing in two places:

1. Validate that a length-encoded parameter header has enough bytes before calling `ParseLengthEncodedInt`.
2. Validate the payload length against the remaining buffer with `uint64`-safe bounds before converting to `int` and slicing.

It also adds regression tests for a truncated `0xfe` header and an oversized 8-byte length value.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a panic in `COM_STMT_EXECUTE` parameter parsing by rejecting malformed length-encoded parameter payloads before slicing them.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing and bounds-checking for length-encoded binary and string parameters, preventing malformed parameter packets from causing errors during statement execution.

* **Tests**
  * Added tests that validate handling of truncated or oversized length-encoded parameters and ensure parsing returns a malformed-packet error without panicking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->