### PR TITLE
ttl: disable async commit for softdelete / ttl jobs | tidb-test=release-8.5-20260121-v8.5.5 pd=release-8.5-20260121-v8.5.5

### DIFF
--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -71,8 +71,8 @@ func TestGetSession(t *testing.T) {
 	tk.MustExec("set @@time_zone = 'Asia/Shanghai'")
 	tk.MustExec("set @@global.time_zone= 'Europe/Berlin'")
 	tk.MustExec("set @@tidb_retry_limit=1")
-	tk.MustExec("set @@tidb_enable_1pc=0")
-	tk.MustExec("set @@tidb_enable_async_commit=0")
+	tk.MustExec("set @@tidb_enable_1pc=1")
+	tk.MustExec("set @@tidb_enable_async_commit=1")
 	tk.MustExec("set @@tidb_isolation_read_engines='tiflash,tidb'")
 	var getCnt atomic.Int32
 
@@ -97,12 +97,12 @@ func TestGetSession(t *testing.T) {
 
 	// session variables should be set
 	tk.MustQuery("select @@time_zone, @@tidb_retry_limit, @@tidb_enable_1pc, @@tidb_enable_async_commit, @@tidb_isolation_read_engines").
-		Check(testkit.Rows("UTC 0 1 1 tikv,tiflash,tidb"))
+		Check(testkit.Rows("UTC 0 0 0 tikv,tiflash,tidb"))
 
 	// all session variables should be restored after close
 	se.Close()
 	tk.MustQuery("select @@time_zone, @@tidb_retry_limit, @@tidb_enable_1pc, @@tidb_enable_async_commit, @@tidb_isolation_read_engines").
-		Check(testkit.Rows("Asia/Shanghai 1 0 0 tiflash,tidb"))
+		Check(testkit.Rows("Asia/Shanghai 1 1 1 tiflash,tidb"))
 }
 
 func TestParallelLockNewJob(t *testing.T) {

--- a/pkg/ttl/ttlworker/session.go
+++ b/pkg/ttl/ttlworker/session.go
@@ -95,14 +95,14 @@ func getSession(pool util.SessionPool) (session.Session, error) {
 			logutil.BgLogger().Warn("fail to reset tidb_retry_limit", zap.Int64("originalRetryLimit", originalRetryLimit), zap.Error(err))
 		}
 
-		if !originalEnable1PC {
-			_, err = se.ExecuteSQL(context.Background(), "set tidb_enable_1pc=OFF")
+		if originalEnable1PC {
+			_, err = se.ExecuteSQL(context.Background(), "set tidb_enable_1pc=ON")
 			intest.AssertNoError(err)
 			terror.Log(err)
 		}
 
-		if !originalEnableAsyncCommit {
-			_, err = se.ExecuteSQL(context.Background(), "set tidb_enable_async_commit=OFF")
+		if originalEnableAsyncCommit {
+			_, err = se.ExecuteSQL(context.Background(), "set tidb_enable_async_commit=ON")
 			intest.AssertNoError(err)
 			terror.Log(err)
 		}
@@ -133,15 +133,15 @@ func getSession(pool util.SessionPool) (session.Session, error) {
 		return nil, err
 	}
 
-	// set enable 1pc to ON
-	_, err = se.ExecuteSQL(context.Background(), "set tidb_enable_1pc=ON")
+	// set disable 1pc to OFF
+	_, err = se.ExecuteSQL(context.Background(), "set tidb_enable_1pc=OFF")
 	if err != nil {
 		se.Close()
 		return nil, err
 	}
 
-	// set enable async commit to ON
-	_, err = se.ExecuteSQL(context.Background(), "set tidb_enable_async_commit=ON")
+	// set disable async commit to OFF
+	_, err = se.ExecuteSQL(context.Background(), "set tidb_enable_async_commit=OFF")
 	if err != nil {
 		se.Close()
 		return nil, err
@@ -340,6 +340,10 @@ func (s *ttlTableSession) ExecuteSQLWithCheck(ctx context.Context, sql string) (
 	err := s.RunInTxn(ctx, func() error {
 		tracer.EnterPhase(metrics.PhaseQuery)
 		defer tracer.EnterPhase(tracer.Phase())
+		// In active-active scene, disable async commit for avoid some
+		// unexpected (unknown) issues caused by stale locks.
+		intest.Assert(!s.GetSessionVars().EnableAsyncCommit)
+		intest.Assert(!s.GetSessionVars().Enable1PC)
 		rows, err := s.ExecuteSQL(ctx, sql)
 		tracer.EnterPhase(metrics.PhaseCheckTTL)
 		// We must check the configuration after ExecuteSQL because of MDL and the meta the current transaction used


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #64281

### What changed and how does it work?

Disable 1pc / async commit for TTL / softdelete retention jobs.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected initialization and restoration of transaction-related session settings during TTL cleanup to ensure consistent transaction behavior in concurrent scenarios.
  * Added runtime checks to validate critical transaction configuration before executing operations.

* **Tests**
  * Updated tests to verify propagation and restoration of session state across different configuration scenarios and ensure assertions reflect expected states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->