### PR TITLE
expression: fix datediff with BIT concat_ws inputs

### DIFF
--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -23,6 +23,7 @@
 package expression
 
 import (
+	stderrors "errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -1908,6 +1909,22 @@ type builtinCastStringAsTimeSig struct {
 	// If a field does not meet these requirements, set SafeToShareAcrossSession to false.
 }
 
+func normalizeCastStringAsTimeError(err error, val string) error {
+	if err == nil {
+		return nil
+	}
+	if types.ErrWrongValue.Equal(err) || types.ErrWrongValueForType.Equal(err) ||
+		types.ErrTruncatedWrongVal.Equal(err) || types.ErrInvalidWeekModeFormat.Equal(err) ||
+		types.ErrDatetimeFunctionOverflow.Equal(err) || types.ErrIncorrectDatetimeValue.Equal(err) ||
+		types.ErrTimestampInDSTTransition.Equal(err) {
+		return err
+	}
+	if stderrors.Is(err, strconv.ErrSyntax) || stderrors.Is(err, strconv.ErrRange) {
+		return types.ErrIncorrectDatetimeValue.GenWithStackByArgs(val)
+	}
+	return types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, val)
+}
+
 func (b *builtinCastStringAsTimeSig) Clone() builtinFunc {
 	newSig := &builtinCastStringAsTimeSig{}
 	newSig.cloneFrom(&b.baseBuiltinFunc)
@@ -1921,7 +1938,7 @@ func (b *builtinCastStringAsTimeSig) evalTime(ctx EvalContext, row chunk.Row) (r
 	}
 	res, err = types.ParseTime(typeCtx(ctx), val, b.tp.GetType(), b.tp.GetDecimal())
 	if err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, normalizeCastStringAsTimeError(err, val))
 	}
 	if res.IsZero() && sqlMode(ctx).HasNoZeroDateMode() {
 		return types.ZeroTime, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, res.String()))

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -1909,6 +1909,9 @@ type builtinCastStringAsTimeSig struct {
 	// If a field does not meet these requirements, set SafeToShareAcrossSession to false.
 }
 
+// normalizeCastStringAsTimeError preserves the SQL-visible error contract for
+// CAST(... AS DATE/DATETIME/TIMESTAMP). Parser failures are downgraded to
+// invalid-time errors, but ErrTimestampInDSTTransition must stay a hard error.
 func normalizeCastStringAsTimeError(err error, val string) error {
 	if err == nil {
 		return nil

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -1400,6 +1400,35 @@ func TestWrapWithCastAsTime(t *testing.T) {
 	}
 }
 
+func TestCastStringAsTimeTreatsInternalParserErrorsAsWarnings(t *testing.T) {
+	ctx := createContext(t)
+	col := &Column{RetType: types.NewFieldType(mysql.TypeVarString), Index: 0}
+	expr := WrapWithCastAsTime(ctx, col, types.NewFieldType(mysql.TypeDatetime))
+
+	_, isNull, err := expr.EvalTime(ctx, chunk.MutRowFromValues("100100\x01").ToRow())
+	require.NoError(t, err)
+	require.True(t, isNull)
+
+	warnings := ctx.GetSessionVars().StmtCtx.GetWarnings()
+	require.NotEmpty(t, warnings)
+	require.True(t, types.ErrWrongValue.Equal(warnings[len(warnings)-1].Err) || types.ErrIncorrectDatetimeValue.Equal(warnings[len(warnings)-1].Err))
+}
+
+func TestCastStringAsTimestampPreservesDSTTransitionError(t *testing.T) {
+	ctx := createContext(t)
+	loc, err := time.LoadLocation("Europe/Amsterdam")
+	require.NoError(t, err)
+	ctx.ResetSessionAndStmtTimeZone(loc)
+
+	col := &Column{RetType: types.NewFieldType(mysql.TypeVarString), Index: 0}
+	expr := WrapWithCastAsTime(ctx, col, types.NewFieldType(mysql.TypeTimestamp))
+
+	_, isNull, err := expr.EvalTime(ctx, chunk.MutRowFromValues("2025-03-30 02:30:00").ToRow())
+	require.Error(t, err)
+	require.True(t, isNull)
+	require.True(t, types.ErrTimestampInDSTTransition.Equal(err))
+}
+
 func TestWrapWithCastAsDuration(t *testing.T) {
 	ctx := createContext(t)
 

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -1412,6 +1412,20 @@ func TestCastStringAsTimeTreatsInternalParserErrorsAsWarnings(t *testing.T) {
 	warnings := ctx.GetSessionVars().StmtCtx.GetWarnings()
 	require.NotEmpty(t, warnings)
 	require.True(t, types.ErrWrongValue.Equal(warnings[len(warnings)-1].Err) || types.ErrIncorrectDatetimeValue.Equal(warnings[len(warnings)-1].Err))
+
+	vecCtx := createContext(t)
+	vecExpr := WrapWithCastAsTime(vecCtx, &Column{RetType: types.NewFieldType(mysql.TypeVarString), Index: 0}, types.NewFieldType(mysql.TypeDatetime))
+	require.True(t, vecExpr.(*ScalarFunction).Function.vectorized() && vecExpr.(*ScalarFunction).Function.isChildrenVectorized())
+	input := chunk.NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeVarString)}, 1)
+	input.AppendString(0, "100100\x01")
+	result := chunk.NewColumn(types.NewFieldType(mysql.TypeDatetime), input.NumRows())
+	err = vecExpr.VecEvalTime(vecCtx, input, result)
+	require.NoError(t, err)
+	require.True(t, result.IsNull(0))
+
+	warnings = vecCtx.GetSessionVars().StmtCtx.GetWarnings()
+	require.NotEmpty(t, warnings)
+	require.True(t, types.ErrWrongValue.Equal(warnings[len(warnings)-1].Err) || types.ErrIncorrectDatetimeValue.Equal(warnings[len(warnings)-1].Err))
 }
 
 func TestCastStringAsTimestampPreservesDSTTransitionError(t *testing.T) {
@@ -1426,6 +1440,18 @@ func TestCastStringAsTimestampPreservesDSTTransitionError(t *testing.T) {
 	_, isNull, err := expr.EvalTime(ctx, chunk.MutRowFromValues("2025-03-30 02:30:00").ToRow())
 	require.Error(t, err)
 	require.True(t, isNull)
+	require.True(t, types.ErrTimestampInDSTTransition.Equal(err))
+
+	vecCtx := createContext(t)
+	vecCtx.ResetSessionAndStmtTimeZone(loc)
+	vecExpr := WrapWithCastAsTime(vecCtx, &Column{RetType: types.NewFieldType(mysql.TypeVarString), Index: 0}, types.NewFieldType(mysql.TypeTimestamp))
+	require.True(t, vecExpr.(*ScalarFunction).Function.vectorized() && vecExpr.(*ScalarFunction).Function.isChildrenVectorized())
+	input := chunk.NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeVarString)}, 1)
+	input.AppendString(0, "2025-03-30 02:30:00")
+	result := chunk.NewColumn(types.NewFieldType(mysql.TypeTimestamp), input.NumRows())
+	err = vecExpr.VecEvalTime(vecCtx, input, result)
+	require.Error(t, err)
+	require.True(t, result.IsNull(0))
 	require.True(t, types.ErrTimestampInDSTTransition.Equal(err))
 }
 

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -15,7 +15,6 @@
 package expression
 
 import (
-	"errors"
 	"math"
 	"strconv"
 	"strings"
@@ -1784,9 +1783,7 @@ func (b *builtinCastStringAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.C
 		}
 		tm, err := types.ParseTime(tc, buf.GetString(i), b.tp.GetType(), fsp)
 		if err != nil {
-			if errors.Is(err, strconv.ErrSyntax) || errors.Is(err, strconv.ErrRange) {
-				err = types.ErrIncorrectDatetimeValue.GenWithStackByArgs(buf.GetString(i))
-			}
+			err = normalizeCastStringAsTimeError(err, buf.GetString(i))
 			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -1784,18 +1784,18 @@ func (b *builtinCastStringAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.C
 		tm, err := types.ParseTime(tc, buf.GetString(i), b.tp.GetType(), fsp)
 		if err != nil {
 			err = normalizeCastStringAsTimeError(err, buf.GetString(i))
+			result.SetNull(i, true)
 			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
-			result.SetNull(i, true)
 			continue
 		}
 		if tm.IsZero() && sqlMode(ctx).HasNoZeroDateMode() {
+			result.SetNull(i, true)
 			err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, tm.String()))
 			if err != nil {
 				return err
 			}
-			result.SetNull(i, true)
 			continue
 		}
 		times[i] = tm

--- a/pkg/expression/expr_to_pb.go
+++ b/pkg/expression/expr_to_pb.go
@@ -261,6 +261,9 @@ func (pc PbConverter) columnToPBExpr(column *Column, checkType bool) *tipb.Expr 
 }
 
 func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
+	if shouldKeepDateDiffWithBitAtRoot(expr) {
+		return nil
+	}
 	// Check whether this function has ProtoBuf signature.
 	pbCode := expr.Function.PbCode()
 	if pbCode <= tipb.ScalarFuncSig_Unspecified {

--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -1624,6 +1624,19 @@ func TestExprPushDownToTiKV(t *testing.T) {
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(exprs))
 
+	// keep DATEDIFF at root when its argument subtree contains a BIT column (#67002).
+	exprs = exprs[:0]
+	constArgs := datumsToConstants(types.MakeDatums(int64(100), int64(100)))
+	concatWSWithBit, err := NewFunction(ctx, ast.ConcatWS, types.NewFieldType(mysql.TypeString), constArgs[0], constArgs[1], byteColumn)
+	require.NoError(t, err)
+	function, err = NewFunction(ctx, ast.DateDiff, types.NewFieldType(mysql.TypeLonglong), concatWSWithBit, datetimeColumn)
+	require.NoError(t, err)
+	exprs = append(exprs, function)
+	pushed, remained = PushDownExprs(pushDownCtx, exprs, kv.TiKV)
+	require.Len(t, pushed, 0)
+	require.Len(t, remained, len(exprs))
+	require.Nil(t, (&PbConverter{client: client, ctx: ctx}).ExprToPB(function.(*ScalarFunction)))
+
 	// Test exprs that can be pushed.
 	exprs = exprs[:0]
 	pushed = pushed[:0]

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -108,7 +108,30 @@ func canFuncBePushed(ctx EvalContext, sf *ScalarFunction, storeType kv.StoreType
 	return ret
 }
 
+func shouldKeepDateDiffWithBitAtRoot(sf *ScalarFunction) bool {
+	if sf.FuncName.L != ast.DateDiff {
+		return false
+	}
+	for _, arg := range sf.GetArgs() {
+		for _, col := range ExtractColumns(arg) {
+			if col.GetStaticType().GetType() == mysql.TypeBit {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func canScalarFuncPushDown(ctx PushDownContext, scalarFunc *ScalarFunction, storeType kv.StoreType) bool {
+	if shouldKeepDateDiffWithBitAtRoot(scalarFunc) {
+		storageName := storeType.Name()
+		if storeType == kv.UnSpecified {
+			storageName = "storage layer"
+		}
+		warnErr := errors.NewNoStackError("Scalar function '" + scalarFunc.FuncName.L + "' can not be pushed down to " + storageName + " when its arguments contain BIT columns.")
+		ctx.AppendWarning(warnErr)
+		return false
+	}
 	pbCode := scalarFunc.Function.PbCode()
 	// Check whether this function can be pushed.
 	if unspecified := pbCode <= tipb.ScalarFuncSig_Unspecified; unspecified || !canFuncBePushed(ctx.EvalCtx(), scalarFunc, storeType) {

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -2213,6 +2213,26 @@ func TestIssue16697(t *testing.T) {
 	}
 }
 
+func TestIssue67002(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists table2")
+	tk.MustExec("create table table2 (count int, status bit(1), ts datetime)")
+	tk.MustExec(`insert into table2(count, status, ts) values(100, 1, '2023-12-01 10:00:00')`)
+
+	tk.MustQuery("explain format = 'brief' select datediff(concat_ws(100, 100, tom12.status), tom12.ts) as c11 from table2 as tom12").Check(testkit.Rows(
+		"Projection 10000.00 root  datediff(cast(concat_ws(100, 100, cast(test.table2.status, var_string(1))), datetime(6) BINARY), test.table2.ts)->Column#6",
+		"└─TableReader 10000.00 root  data:TableFullScan",
+		"  └─TableFullScan 10000.00 cop[tikv] table:tom12 keep order:false, stats:pseudo",
+	))
+
+	tk.MustQuery("select datediff(concat_ws(100, 100, tom12.status), tom12.ts) as c11 from table2 as tom12").Check(testkit.Rows("<nil>"))
+	tk.MustQuery("select datediff(concat_ws(100, 100, 1), tom12.ts) as c11 from table2 as tom12").Check(testkit.Rows("<nil>"))
+	tk.MustExec("drop table if exists table2")
+}
+
 func TestSecurityEnhancedMode(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67002

Problem Summary:

`DATEDIFF(CONCAT_WS(..., bit_col), datetime_col)` could still fail with an internal execution error on the root path. Keeping the expression out of pushdown alone was not enough; the root cast-to-time path also needed to return SQL-visible `NULL` plus warning behavior instead of leaking internal parser failures.

### What changed and how does it work?

- Keep `DATEDIFF` expressions with `BIT` subtrees out of pushdown and protobuf conversion.
- Normalize root `CAST string AS time` parser failures into invalid-time warning/null behavior while preserving DST timestamp errors.
- Add regression coverage for pushdown decisions, scalar/vector cast handling, DST timestamp behavior, and the SQL-level path in issue `#67002`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix `DATEDIFF(CONCAT_WS(..., bit_col), datetime_col)` so TiDB keeps the expression on the root path and returns `NULL` plus warning instead of an internal execution error.
```