### PR TITLE
planner: short-circuit cross join with limit via pushdown

### DIFF
--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -510,6 +510,27 @@ func (p *LogicalJoin) PushDownTopN(topNLogicalPlan base.LogicalPlan) base.Logica
 	case base.RightOuterJoin:
 		p.Children()[1], topnEliminated = p.pushDownTopNToChild(topN, 1)
 		p.Children()[0] = p.Children()[0].PushDownTopN(nil)
+	case base.InnerJoin:
+		if p.canPushLimitDownToCartesianChildren(topN) {
+			limitCount, carry := bits.Add64(topN.Count, topN.Offset, 0)
+			if carry > 0 {
+				limitCount = math.MaxUint64
+			}
+			leftLimit := LogicalTopN{
+				Count:            limitCount,
+				Offset:           0,
+				PreferLimitToCop: topN.PreferLimitToCop,
+			}.Init(topN.SCtx(), topN.QueryBlockOffset())
+			rightLimit := LogicalTopN{
+				Count:            limitCount,
+				Offset:           0,
+				PreferLimitToCop: topN.PreferLimitToCop,
+			}.Init(topN.SCtx(), topN.QueryBlockOffset())
+			p.Children()[0] = p.Children()[0].PushDownTopN(leftLimit)
+			p.Children()[1] = p.Children()[1].PushDownTopN(rightLimit)
+			return topN.AttachChild(p.Self())
+		}
+		return p.BaseLogicalPlan.PushDownTopN(topN)
 	default:
 		return p.BaseLogicalPlan.PushDownTopN(topN)
 	}
@@ -529,6 +550,20 @@ func (p *LogicalJoin) PushDownTopN(topNLogicalPlan base.LogicalPlan) base.Logica
 		return topN.AttachChild(p.Self())
 	}
 	return p.Self()
+}
+
+func (p *LogicalJoin) canPushLimitDownToCartesianChildren(topN *LogicalTopN) bool {
+	if topN == nil || !topN.IsLimit() {
+		return false
+	}
+	if _, isApply := p.Self().(*LogicalApply); isApply {
+		return false
+	}
+	return len(p.EqualConditions) == 0 &&
+		len(p.NAEQConditions) == 0 &&
+		len(p.LeftConditions) == 0 &&
+		len(p.RightConditions) == 0 &&
+		len(p.OtherConditions) == 0
 }
 
 // DeriveTopN inherits the BaseLogicalPlan.LogicalPlan.<6th> implementation.

--- a/pkg/planner/core/testdata/plan_suite_unexported_out.json
+++ b/pkg/planner/core/testdata/plan_suite_unexported_out.json
@@ -148,7 +148,7 @@
       "DataScan(t)->Aggr(count(test.t.b),firstrow(test.t.a))->Limit->Projection",
       "DataScan(t)->Aggr(count(test.t.b),firstrow(test.t.a),firstrow(test.t.c))->TopN([test.t.c],0,5)->Projection",
       "Join{DataScan(t)->DataScan(s)}->TopN([test.t.a],0,5)->Projection",
-      "Join{DataScan(t)->DataScan(s)}->Limit->Projection",
+      "Join{DataScan(t)->Limit->DataScan(s)->Limit}->Limit->Projection",
       "DataScan(t)->Projection->TopN([Column#14 true],0,1)->Projection",
       "Join{DataScan(t)->TopN([test.t.a],0,5)->DataScan(s)}(test.t.a,test.t.a)->Sort->Projection",
       "Join{DataScan(t)->TopN([test.t.a],5,5)->DataScan(s)}(test.t.a,test.t.a)->Sort->Projection",


### PR DESCRIPTION
planner: short-circuit cross join with limit via pushdown

### What problem does this PR solve?

Issue Number: close #63872

Problem Summary:

在 `CROSS JOIN` 场景下，语句 `SELECT * FROM t1 a CROSS JOIN t2 b LIMIT 1` 仍可能读取和处理过多数据，导致内存压力过高，甚至触发 memory limit cancel。

该语句没有 `ORDER BY`，语义上允许返回任意 1 行，因此应尽早短路，而不是让笛卡尔积路径继续读取大规模输入。

### What changed and how does it work?

本 PR 在 planner 的 TopN/Limit 下推阶段新增了对“纯笛卡尔内连接”的优化：

1. 在 `LogicalJoin.PushDownTopN` 中新增 `InnerJoin` 分支处理。
2. 当满足以下条件时，将根部 `LIMIT`（按 `count + offset`，溢出时饱和到 `math.MaxUint64`）分别下推到 join 两侧子计划：
   - `topN` 是纯 `LIMIT`（无 `ORDER BY`）
   - join 是 `InnerJoin`
   - join 条件为空（`EqualConditions/NAEQConditions/LeftConditions/RightConditions/OtherConditions` 均为空）
   - 当前节点不是 `LogicalApply`（避免影响相关子查询语义）
3. 保留 join 上层原始 `LIMIT`，保证最终结果语义不变。
4. 同步更新 `TestTopNPushDown` 的期望计划输出，覆盖已有 `select * from t, t s limit 5` 用例的新计划形态。

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  > - `./tools/check/failpoint-go-test.sh pkg/planner/core -run TestTopNPushDown -count=1`
  > - `make lint`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Optimize `CROSS JOIN ... LIMIT` by pushing limit down to both sides of pure cartesian inner joins, so execution can short-circuit earlier and avoid unnecessary large input processing.
```
