### PR TITLE
planner: compress large not-in filters for index join probe

### DIFF
--- a/pkg/planner/core/casetest/cbotest/cbo_test.go
+++ b/pkg/planner/core/casetest/cbotest/cbo_test.go
@@ -209,6 +209,27 @@ func TestAnalyzeSuiteRegression(t *testing.T) {
 				}
 			}
 		}
+
+		// issue:67573
+		tk.MustExec("use test")
+		tk.MustExec("drop table if exists issue67573_t1, issue67573_t2")
+		tk.MustExec("create table issue67573_t1 (a int)")
+		tk.MustExec("create table issue67573_t2 (id int primary key, a int, b int, key idx_a(a))")
+		tk.MustExec("insert into issue67573_t1 values (1), (2), (3)")
+		tk.MustExec("insert into issue67573_t2 values (1, 1, 1), (2, 2, 2), (3, 3, 3)")
+		var input67573 []string
+		var output67573 []struct {
+			SQL  string
+			Plan []string
+		}
+		analyzeSuiteData.LoadTestCasesByName("TestIssue67573", t, &input67573, &output67573, cascades, caller)
+		for i, tt := range input67573 {
+			testdata.OnRecord(func() {
+				output67573[i].SQL = tt
+				output67573[i].Plan = testdata.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+			})
+			tk.MustQuery(tt).Check(testkit.Rows(output67573[i].Plan...))
+		}
 	})
 }
 

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
@@ -283,6 +283,14 @@
     ]
   },
   {
+    "name": "TestIssue67573",
+    "cases": [
+      "explain format = 'brief' select /*+ TIDB_INLJ(issue67573_t2) */ * from issue67573_t1 join issue67573_t2 on issue67573_t1.a = issue67573_t2.a where issue67573_t2.b not in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);",
+      "explain format = 'brief' select /*+ TIDB_INLJ(issue67573_t2) */ * from issue67573_t1 join issue67573_t2 on issue67573_t1.a = issue67573_t2.a where issue67573_t2.b not in (1, 2, 3, 10, 11, 12, 100, 101, 102, 103);",
+      "explain format = 'brief' select /*+ TIDB_INLJ(issue67573_t2) */ * from issue67573_t1 join issue67573_t2 on issue67573_t1.a = issue67573_t2.a where issue67573_t2.b not in (1, 3, 5, 7, 9, 11, 13, 15);"
+    ]
+  },
+  {
     "name": "TestIndexJoinPreferIndexCoversMoreJoinKeyCols",
     "cases": [
       "explain format ='brief' SELECT \n  mp.col1,\n  mp.col2,\n  mp.col3,\n  mp.col4,\n  mp.col5,\n  mp.col6\nFROM\n  mp\n  LEFT JOIN ab ON ab.col1 = mp.col2\n  AND ab.col2 = mp.col6\nWHERE\n  mp.col5 = 'PKR'\n  AND mp.col3 = 1\n  AND mp.col6 IN ('1685', '2239')\n  AND mp.col4 >= 1764788400\n  AND mp.col4 <= 1767466799\n  AND ab.col3 IN ('cj9dkqw7', 'del_cj9dkqw7')\nORDER BY\n  mp.col4 DESC\nLIMIT\n  100;"

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
@@ -605,6 +605,56 @@
     ]
   },
   {
+    "Name": "TestIssue67573",
+    "Cases": [
+      {
+        "SQL": "explain format = 'brief' select /*+ TIDB_INLJ(issue67573_t2) */ * from issue67573_t1 join issue67573_t2 on issue67573_t1.a = issue67573_t2.a where issue67573_t2.b not in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);",
+        "Plan": [
+          "Projection 4474.69 root  test.issue67573_t1.a, test.issue67573_t2.id, test.issue67573_t2.a, test.issue67573_t2.b",
+          "└─IndexJoin 4474.69 root  inner join, inner:IndexLookUp, outer key:test.issue67573_t1.a, inner key:test.issue67573_t2.a, equal cond:eq(test.issue67573_t1.a, test.issue67573_t2.a)",
+          "  ├─TableReader(Build) 9990.00 root  data:Selection",
+          "  │ └─Selection 9990.00 cop[tikv]  not(isnull(test.issue67573_t1.a))",
+          "  │   └─TableFullScan 10000.00 cop[tikv] table:issue67573_t1 keep order:false, stats:pseudo",
+          "  └─IndexLookUp(Probe) 4474.69 root  ",
+          "    ├─Selection(Build) 6722.11 cop[tikv]  not(isnull(test.issue67573_t2.a))",
+          "    │ └─IndexRangeScan 6728.84 cop[tikv] table:issue67573_t2, index:idx_a(a) range: decided by [eq(test.issue67573_t2.a, test.issue67573_t1.a)], keep order:false, stats:pseudo",
+          "    └─Selection(Probe) 4474.69 cop[tikv]  or(lt(test.issue67573_t2.b, 1), gt(test.issue67573_t2.b, 12))",
+          "      └─TableRowIDScan 6722.11 cop[tikv] table:issue67573_t2 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ TIDB_INLJ(issue67573_t2) */ * from issue67573_t1 join issue67573_t2 on issue67573_t1.a = issue67573_t2.a where issue67573_t2.b not in (1, 2, 3, 10, 11, 12, 100, 101, 102, 103);",
+        "Plan": [
+          "Projection 5099.06 root  test.issue67573_t1.a, test.issue67573_t2.id, test.issue67573_t2.a, test.issue67573_t2.b",
+          "└─IndexJoin 5099.06 root  inner join, inner:IndexLookUp, outer key:test.issue67573_t1.a, inner key:test.issue67573_t2.a, equal cond:eq(test.issue67573_t1.a, test.issue67573_t2.a)",
+          "  ├─TableReader(Build) 9990.00 root  data:Selection",
+          "  │ └─Selection 9990.00 cop[tikv]  not(isnull(test.issue67573_t1.a))",
+          "  │   └─TableFullScan 10000.00 cop[tikv] table:issue67573_t1 keep order:false, stats:pseudo",
+          "  └─IndexLookUp(Probe) 5099.06 root  ",
+          "    ├─Selection(Build) 7124.91 cop[tikv]  not(isnull(test.issue67573_t2.a))",
+          "    │ └─IndexRangeScan 7132.04 cop[tikv] table:issue67573_t2, index:idx_a(a) range: decided by [eq(test.issue67573_t2.a, test.issue67573_t1.a)], keep order:false, stats:pseudo",
+          "    └─Selection(Probe) 5099.06 cop[tikv]  or(or(lt(test.issue67573_t2.b, 1), and(gt(test.issue67573_t2.b, 3), lt(test.issue67573_t2.b, 10))), or(and(gt(test.issue67573_t2.b, 12), lt(test.issue67573_t2.b, 100)), gt(test.issue67573_t2.b, 103)))",
+          "      └─TableRowIDScan 7124.91 cop[tikv] table:issue67573_t2 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ TIDB_INLJ(issue67573_t2) */ * from issue67573_t1 join issue67573_t2 on issue67573_t1.a = issue67573_t2.a where issue67573_t2.b not in (1, 3, 5, 7, 9, 11, 13, 15);",
+        "Plan": [
+          "Projection 6660.00 root  test.issue67573_t1.a, test.issue67573_t2.id, test.issue67573_t2.a, test.issue67573_t2.b",
+          "└─IndexJoin 6660.00 root  inner join, inner:IndexLookUp, outer key:test.issue67573_t1.a, inner key:test.issue67573_t2.a, equal cond:eq(test.issue67573_t1.a, test.issue67573_t2.a)",
+          "  ├─TableReader(Build) 9990.00 root  data:Selection",
+          "  │ └─Selection 9990.00 cop[tikv]  not(isnull(test.issue67573_t1.a))",
+          "  │   └─TableFullScan 10000.00 cop[tikv] table:issue67573_t1 keep order:false, stats:pseudo",
+          "  └─IndexLookUp(Probe) 6660.00 root  ",
+          "    ├─Selection(Build) 12487.50 cop[tikv]  not(isnull(test.issue67573_t2.a))",
+          "    │ └─IndexRangeScan 12500.00 cop[tikv] table:issue67573_t2, index:idx_a(a) range: decided by [eq(test.issue67573_t2.a, test.issue67573_t1.a)], keep order:false, stats:pseudo",
+          "    └─Selection(Probe) 6660.00 cop[tikv]  not(in(test.issue67573_t2.b, 1, 3, 5, 7, 9, 11, 13, 15))",
+          "      └─TableRowIDScan 12487.50 cop[tikv] table:issue67573_t2 keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
     "Name": "TestIndexJoinPreferIndexCoversMoreJoinKeyCols",
     "Cases": [
       {

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_xut.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_xut.json
@@ -605,6 +605,56 @@
     ]
   },
   {
+    "Name": "TestIssue67573",
+    "Cases": [
+      {
+        "SQL": "explain format = 'brief' select /*+ TIDB_INLJ(issue67573_t2) */ * from issue67573_t1 join issue67573_t2 on issue67573_t1.a = issue67573_t2.a where issue67573_t2.b not in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);",
+        "Plan": [
+          "Projection 4474.69 root  test.issue67573_t1.a, test.issue67573_t2.id, test.issue67573_t2.a, test.issue67573_t2.b",
+          "└─IndexJoin 4474.69 root  inner join, inner:IndexLookUp, outer key:test.issue67573_t1.a, inner key:test.issue67573_t2.a, equal cond:eq(test.issue67573_t1.a, test.issue67573_t2.a)",
+          "  ├─TableReader(Build) 9990.00 root  data:Selection",
+          "  │ └─Selection 9990.00 cop[tikv]  not(isnull(test.issue67573_t1.a))",
+          "  │   └─TableFullScan 10000.00 cop[tikv] table:issue67573_t1 keep order:false, stats:pseudo",
+          "  └─IndexLookUp(Probe) 4474.69 root  ",
+          "    ├─Selection(Build) 6722.11 cop[tikv]  not(isnull(test.issue67573_t2.a))",
+          "    │ └─IndexRangeScan 6728.84 cop[tikv] table:issue67573_t2, index:idx_a(a) range: decided by [eq(test.issue67573_t2.a, test.issue67573_t1.a)], keep order:false, stats:pseudo",
+          "    └─Selection(Probe) 4474.69 cop[tikv]  or(lt(test.issue67573_t2.b, 1), gt(test.issue67573_t2.b, 12))",
+          "      └─TableRowIDScan 6722.11 cop[tikv] table:issue67573_t2 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ TIDB_INLJ(issue67573_t2) */ * from issue67573_t1 join issue67573_t2 on issue67573_t1.a = issue67573_t2.a where issue67573_t2.b not in (1, 2, 3, 10, 11, 12, 100, 101, 102, 103);",
+        "Plan": [
+          "Projection 5099.06 root  test.issue67573_t1.a, test.issue67573_t2.id, test.issue67573_t2.a, test.issue67573_t2.b",
+          "└─IndexJoin 5099.06 root  inner join, inner:IndexLookUp, outer key:test.issue67573_t1.a, inner key:test.issue67573_t2.a, equal cond:eq(test.issue67573_t1.a, test.issue67573_t2.a)",
+          "  ├─TableReader(Build) 9990.00 root  data:Selection",
+          "  │ └─Selection 9990.00 cop[tikv]  not(isnull(test.issue67573_t1.a))",
+          "  │   └─TableFullScan 10000.00 cop[tikv] table:issue67573_t1 keep order:false, stats:pseudo",
+          "  └─IndexLookUp(Probe) 5099.06 root  ",
+          "    ├─Selection(Build) 7124.91 cop[tikv]  not(isnull(test.issue67573_t2.a))",
+          "    │ └─IndexRangeScan 7132.04 cop[tikv] table:issue67573_t2, index:idx_a(a) range: decided by [eq(test.issue67573_t2.a, test.issue67573_t1.a)], keep order:false, stats:pseudo",
+          "    └─Selection(Probe) 5099.06 cop[tikv]  or(or(lt(test.issue67573_t2.b, 1), and(gt(test.issue67573_t2.b, 3), lt(test.issue67573_t2.b, 10))), or(and(gt(test.issue67573_t2.b, 12), lt(test.issue67573_t2.b, 100)), gt(test.issue67573_t2.b, 103)))",
+          "      └─TableRowIDScan 7124.91 cop[tikv] table:issue67573_t2 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ TIDB_INLJ(issue67573_t2) */ * from issue67573_t1 join issue67573_t2 on issue67573_t1.a = issue67573_t2.a where issue67573_t2.b not in (1, 3, 5, 7, 9, 11, 13, 15);",
+        "Plan": [
+          "Projection 6660.00 root  test.issue67573_t1.a, test.issue67573_t2.id, test.issue67573_t2.a, test.issue67573_t2.b",
+          "└─IndexJoin 6660.00 root  inner join, inner:IndexLookUp, outer key:test.issue67573_t1.a, inner key:test.issue67573_t2.a, equal cond:eq(test.issue67573_t1.a, test.issue67573_t2.a)",
+          "  ├─TableReader(Build) 9990.00 root  data:Selection",
+          "  │ └─Selection 9990.00 cop[tikv]  not(isnull(test.issue67573_t1.a))",
+          "  │   └─TableFullScan 10000.00 cop[tikv] table:issue67573_t1 keep order:false, stats:pseudo",
+          "  └─IndexLookUp(Probe) 6660.00 root  ",
+          "    ├─Selection(Build) 12487.50 cop[tikv]  not(isnull(test.issue67573_t2.a))",
+          "    │ └─IndexRangeScan 12500.00 cop[tikv] table:issue67573_t2, index:idx_a(a) range: decided by [eq(test.issue67573_t2.a, test.issue67573_t1.a)], keep order:false, stats:pseudo",
+          "    └─Selection(Probe) 6660.00 cop[tikv]  not(in(test.issue67573_t2.b, 1, 3, 5, 7, 9, 11, 13, 15))",
+          "      └─TableRowIDScan 12487.50 cop[tikv] table:issue67573_t2 keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
     "Name": "TestIndexJoinPreferIndexCoversMoreJoinKeyCols",
     "Cases": [
       {

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/cardinality"
 	"github.com/pingcap/tidb/pkg/planner/cascades/memo"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -794,7 +795,7 @@ func constructDS2TableScanTask(
 		Columns:         ds.Columns,
 		TableAsName:     ds.TableAsName,
 		DBName:          ds.DBName,
-		FilterCondition: ds.PushedDownConds,
+		FilterCondition: rewriteLargeIntNotInFiltersForIndexJoinProbe(ds.SCtx(), ds.PushedDownConds),
 		Ranges:          ranges,
 		RangeInfo:       rangeInfo,
 		KeepOrder:       keepOrder,
@@ -993,6 +994,7 @@ func constructDS2IndexScanTask(
 	}
 	is.InitSchema(append(path.FullIdxCols, ds.CommonHandleCols...), cop.TablePlan != nil)
 	indexConds, tblConds := splitIndexFilterConditions(ds, filterConds, path.FullIdxCols, path.FullIdxColLens)
+	tblConds = rewriteLargeIntNotInFiltersForIndexJoinProbe(ds.SCtx(), tblConds)
 
 	// Note: due to a regression in JOB workload, we use the optimizer fix control to enable this for now.
 	//
@@ -1082,6 +1084,221 @@ func constructDS2IndexScanTask(
 		return nil
 	}
 	return cop
+}
+
+const minLargeNotInListLenForIndexJoinProbeRewrite = 8
+
+// rewriteLargeIntNotInFiltersForIndexJoinProbe compresses large integer NOT IN lists on
+// IndexJoin probe filters into interval predicates. This keeps the point-lookup access path
+// unchanged while shrinking the pushed-down expression payload; we intentionally avoid turning
+// these filters into access ranges because wide range scans can regress MVCC-heavy workloads.
+func rewriteLargeIntNotInFiltersForIndexJoinProbe(sctx base.PlanContext, conds []expression.Expression) []expression.Expression {
+	var rewritten []expression.Expression
+	for i, cond := range conds {
+		newCond, ok := tryRewriteLargeIntNotInFilterForIndexJoinProbe(sctx, cond)
+		if !ok {
+			if rewritten != nil {
+				rewritten = append(rewritten, cond)
+			}
+			continue
+		}
+		if rewritten == nil {
+			rewritten = make([]expression.Expression, 0, len(conds))
+			rewritten = append(rewritten, conds[:i]...)
+		}
+		rewritten = append(rewritten, newCond)
+	}
+	if rewritten == nil {
+		return conds
+	}
+	return rewritten
+}
+
+func tryRewriteLargeIntNotInFilterForIndexJoinProbe(sctx base.PlanContext, expr expression.Expression) (expression.Expression, bool) {
+	notFunc, ok := expr.(*expression.ScalarFunction)
+	if !ok || notFunc.FuncName.L != ast.UnaryNot {
+		return nil, false
+	}
+	inFunc, ok := notFunc.GetArgs()[0].(*expression.ScalarFunction)
+	if !ok || inFunc.FuncName.L != ast.In {
+		return nil, false
+	}
+	args := inFunc.GetArgs()
+	if len(args) < minLargeNotInListLenForIndexJoinProbeRewrite+1 {
+		return nil, false
+	}
+	col, ok := args[0].(*expression.Column)
+	if !ok {
+		return nil, false
+	}
+	colType := col.GetType(sctx.GetExprCtx().GetEvalCtx())
+	if !mysql.IsIntegerType(colType.GetType()) {
+		return nil, false
+	}
+	if mysql.HasUnsignedFlag(colType.GetFlag()) {
+		vals, ok := collectSortedUnsignedNotInValues(args[1:])
+		if !ok {
+			return nil, false
+		}
+		return buildUnsignedNotInIntervalFilter(sctx, col, vals)
+	}
+	vals, ok := collectSortedSignedNotInValues(args[1:])
+	if !ok {
+		return nil, false
+	}
+	return buildSignedNotInIntervalFilter(sctx, col, vals)
+}
+
+func collectSortedSignedNotInValues(args []expression.Expression) ([]int64, bool) {
+	vals := make([]int64, 0, len(args))
+	for _, arg := range args {
+		con, ok := arg.(*expression.Constant)
+		if !ok || con.DeferredExpr != nil || con.ParamMarker != nil {
+			return nil, false
+		}
+		switch con.Value.Kind() {
+		case types.KindNull:
+			return nil, false
+		case types.KindInt64:
+			vals = append(vals, con.Value.GetInt64())
+		case types.KindUint64:
+			u := con.Value.GetUint64()
+			if u > math.MaxInt64 {
+				return nil, false
+			}
+			vals = append(vals, int64(u))
+		default:
+			return nil, false
+		}
+	}
+	slices.Sort(vals)
+	return slices.Compact(vals), true
+}
+
+func collectSortedUnsignedNotInValues(args []expression.Expression) ([]uint64, bool) {
+	vals := make([]uint64, 0, len(args))
+	for _, arg := range args {
+		con, ok := arg.(*expression.Constant)
+		if !ok || con.DeferredExpr != nil || con.ParamMarker != nil {
+			return nil, false
+		}
+		switch con.Value.Kind() {
+		case types.KindNull:
+			return nil, false
+		case types.KindInt64:
+			v := con.Value.GetInt64()
+			if v < 0 {
+				return nil, false
+			}
+			vals = append(vals, uint64(v))
+		case types.KindUint64:
+			vals = append(vals, con.Value.GetUint64())
+		default:
+			return nil, false
+		}
+	}
+	slices.Sort(vals)
+	return slices.Compact(vals), true
+}
+
+func buildSignedNotInIntervalFilter(sctx base.PlanContext, col *expression.Column, vals []int64) (expression.Expression, bool) {
+	if len(vals) < minLargeNotInListLenForIndexJoinProbeRewrite {
+		return nil, false
+	}
+	type interval struct {
+		start int64
+		end   int64
+	}
+	intervals := make([]interval, 0, len(vals))
+	start, end := vals[0], vals[0]
+	for _, v := range vals[1:] {
+		if end != math.MaxInt64 && v == end+1 {
+			end = v
+			continue
+		}
+		intervals = append(intervals, interval{start: start, end: end})
+		start, end = v, v
+	}
+	intervals = append(intervals, interval{start: start, end: end})
+	if len(intervals)*2 >= len(vals) {
+		return nil, false
+	}
+
+	dnfItems := make([]expression.Expression, 0, len(intervals)+1)
+	if intervals[0].start != math.MinInt64 {
+		dnfItems = append(dnfItems, newBinaryCmpExpr(sctx, ast.LT, col, newTypedSignedConst(col, intervals[0].start)))
+	}
+	for i := 1; i < len(intervals); i++ {
+		left := newBinaryCmpExpr(sctx, ast.GT, col, newTypedSignedConst(col, intervals[i-1].end))
+		right := newBinaryCmpExpr(sctx, ast.LT, col, newTypedSignedConst(col, intervals[i].start))
+		dnfItems = append(dnfItems, expression.ComposeCNFCondition(sctx.GetExprCtx(), left, right))
+	}
+	if intervals[len(intervals)-1].end != math.MaxInt64 {
+		dnfItems = append(dnfItems, newBinaryCmpExpr(sctx, ast.GT, col, newTypedSignedConst(col, intervals[len(intervals)-1].end)))
+	}
+	if len(dnfItems) == 0 {
+		return nil, false
+	}
+	return expression.ComposeDNFCondition(sctx.GetExprCtx(), dnfItems...), true
+}
+
+func buildUnsignedNotInIntervalFilter(sctx base.PlanContext, col *expression.Column, vals []uint64) (expression.Expression, bool) {
+	if len(vals) < minLargeNotInListLenForIndexJoinProbeRewrite {
+		return nil, false
+	}
+	type interval struct {
+		start uint64
+		end   uint64
+	}
+	intervals := make([]interval, 0, len(vals))
+	start, end := vals[0], vals[0]
+	for _, v := range vals[1:] {
+		if end != math.MaxUint64 && v == end+1 {
+			end = v
+			continue
+		}
+		intervals = append(intervals, interval{start: start, end: end})
+		start, end = v, v
+	}
+	intervals = append(intervals, interval{start: start, end: end})
+	if len(intervals)*2 >= len(vals) {
+		return nil, false
+	}
+
+	dnfItems := make([]expression.Expression, 0, len(intervals)+1)
+	if intervals[0].start != 0 {
+		dnfItems = append(dnfItems, newBinaryCmpExpr(sctx, ast.LT, col, newTypedUnsignedConst(col, intervals[0].start)))
+	}
+	for i := 1; i < len(intervals); i++ {
+		left := newBinaryCmpExpr(sctx, ast.GT, col, newTypedUnsignedConst(col, intervals[i-1].end))
+		right := newBinaryCmpExpr(sctx, ast.LT, col, newTypedUnsignedConst(col, intervals[i].start))
+		dnfItems = append(dnfItems, expression.ComposeCNFCondition(sctx.GetExprCtx(), left, right))
+	}
+	if intervals[len(intervals)-1].end != math.MaxUint64 {
+		dnfItems = append(dnfItems, newBinaryCmpExpr(sctx, ast.GT, col, newTypedUnsignedConst(col, intervals[len(intervals)-1].end)))
+	}
+	if len(dnfItems) == 0 {
+		return nil, false
+	}
+	return expression.ComposeDNFCondition(sctx.GetExprCtx(), dnfItems...), true
+}
+
+func newBinaryCmpExpr(sctx base.PlanContext, op string, col *expression.Column, con *expression.Constant) expression.Expression {
+	return expression.NewFunctionInternal(sctx.GetExprCtx(), op, types.NewFieldType(mysql.TypeTiny), col, con)
+}
+
+func newTypedSignedConst(col *expression.Column, v int64) *expression.Constant {
+	return &expression.Constant{
+		Value:   types.NewIntDatum(v),
+		RetType: col.RetType,
+	}
+}
+
+func newTypedUnsignedConst(col *expression.Column, v uint64) *expression.Constant {
+	return &expression.Constant{
+		Value:   types.NewUintDatum(v),
+		RetType: col.RetType,
+	}
 }
 
 const (

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1093,22 +1093,18 @@ const minLargeNotInListLenForIndexJoinProbeRewrite = 8
 // unchanged while shrinking the pushed-down expression payload; we intentionally avoid turning
 // these filters into access ranges because wide range scans can regress MVCC-heavy workloads.
 func rewriteLargeIntNotInFiltersForIndexJoinProbe(sctx base.PlanContext, conds []expression.Expression) []expression.Expression {
-	var rewritten []expression.Expression
-	for i, cond := range conds {
+	rewritten := make([]expression.Expression, 0, len(conds))
+	changed := false
+	for _, cond := range conds {
 		newCond, ok := tryRewriteLargeIntNotInFilterForIndexJoinProbe(sctx, cond)
 		if !ok {
-			if rewritten != nil {
-				rewritten = append(rewritten, cond)
-			}
+			rewritten = append(rewritten, cond)
 			continue
 		}
-		if rewritten == nil {
-			rewritten = make([]expression.Expression, 0, len(conds))
-			rewritten = append(rewritten, conds[:i]...)
-		}
+		changed = true
 		rewritten = append(rewritten, newCond)
 	}
-	if rewritten == nil {
+	if !changed {
 		return conds
 	}
 	return rewritten

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -644,6 +644,45 @@ HAVING EXISTS (SELECT 1 FROM t_panic WHERE x IS NULL);`).Check(testkit.Rows("<ni
 		tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).MultiCheckContain([]string{"IndexRangeScan"})
 	}
 
+	// issue-66610-normal-vs-prepared-hashagg
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("create table t0(c0 float unsigned)")
+		tk.MustExec(`insert into t0 (c0)
+with recursive seq as (
+    select 1 as n
+    union all
+    select n + 1 from seq where n < 1000
+)
+select rand() * 10000 from seq`)
+		tk.MustExec("create index i54 on t0(c0)")
+		tk.MustExec("set @a = 107237831")
+		tk.MustExec("set @b = '\t'")
+		tk.MustExec("set @c = 240227228")
+		tk.MustExec("set @d = 160227190")
+		tk.MustExec("set @e = 'B'")
+
+		explainRows := testkit.Rows(
+			"Projection 0.00 root  107237831->Column#7, reverse(cast(and(0, istrue_with_null(test.t0.c0)), var_string(20)))->Column#8, test.t0.c0",
+			"└─TableDual 0.00 root  rows:0")
+
+		tk.MustQuery("select /* issue:66610 */ 107237831, reverse(((radians('\t')) and (t0.c0))), t0.c0 from t0 where 240227228 group by t0.c0 having max(concat_ws(160227190, 'B'));").Check(testkit.Rows())
+		tk.MustQuery("explain format='brief' select /* issue:66610 */ 107237831, reverse(((radians('\t')) and (t0.c0))), t0.c0 from t0 where 240227228 group by t0.c0 having max(concat_ws(160227190, 'B'));").Check(explainRows)
+
+		tk.MustExec("prepare stmt66610 from 'select ?, reverse(((radians(?)) and (t0.c0))), t0.c0 from t0 where ? group by t0.c0 having max(concat_ws(?, ?));'")
+		tk.MustQuery("execute stmt66610 using @a, @b, @c, @d, @e").Check(testkit.Rows())
+		tk.MustExec("deallocate prepare stmt66610")
+
+		tk.MustExec("prepare stmt66610 from 'explain format=''brief'' select ?, reverse(((radians(?)) and (t0.c0))), t0.c0 from t0 where ? group by t0.c0 having max(concat_ws(?, ?));'")
+		tk.MustQuery("execute stmt66610 using @a, @b, @c, @d, @e").Check(explainRows)
+		tk.MustExec("deallocate prepare stmt66610")
+
+		tk.MustQuery("explain format='brief' select 107237831, reverse(((radians('\t')) and (t0.c0))), t0.c0 from t0 where 240227228 group by t0.c0 having min(concat_ws(160227190, 'B'));").Check(explainRows)
+		tk.MustExec("prepare stmt66610 from 'explain format=''brief'' select ?, reverse(((radians(?)) and (t0.c0))), t0.c0 from t0 where ? group by t0.c0 having min(concat_ws(?, ?));'")
+		tk.MustQuery("execute stmt66610 using @a, @b, @c, @d, @e").Check(explainRows)
+		tk.MustExec("deallocate prepare stmt66610")
+	}
+
 	// issue-66399-outer-join-eliminate-must-keep-parent-join-condition-columns
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -683,6 +683,38 @@ select rand() * 10000 from seq`)
 		tk.MustExec("deallocate prepare stmt66610")
 	}
 
+	// issue-66607-normal-vs-prepared-streamagg
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("create table t5(c0 numeric unsigned zerofill)")
+		tk.MustExec(`insert into t5 (c0)
+with recursive seq as (
+    select 1 as n
+    union all
+    select n + 1 from seq where n < 1000
+)
+select rand() * 1000000 from seq`)
+		tk.MustExec("create index i0 on t5(c0 asc)")
+		tk.MustExec("set @a = 1794240494")
+		tk.MustExec("set @b = true")
+		tk.MustExec("set @c = 'g3h'")
+
+		explainRows := testkit.Rows(
+			"Projection 0.00 root  1->Column#6",
+			"└─TableDual 0.00 root  rows:0")
+
+		tk.MustQuery("select /* issue:66607 */ (binary (((1794240494) regexp (true)))) from t5 group by t5.c0 having max('g3h');").Check(testkit.Rows())
+		tk.MustQuery("explain format='brief' select /* issue:66607 */ (binary (((1794240494) regexp (true)))) from t5 group by t5.c0 having max('g3h');").Check(explainRows)
+
+		tk.MustExec("prepare stmt66607 from 'select /* issue:66607 */ (binary (((?) regexp (?)))) from t5 group by t5.c0 having max(?);'")
+		tk.MustQuery("execute stmt66607 using @a, @b, @c").Check(testkit.Rows())
+		tk.MustExec("deallocate prepare stmt66607")
+
+		tk.MustExec("prepare stmt66607 from 'explain format=''brief'' select /* issue:66607 */ (binary (((?) regexp (?)))) from t5 group by t5.c0 having max(?);'")
+		tk.MustQuery("execute stmt66607 using @a, @b, @c").Check(explainRows)
+		tk.MustExec("deallocate prepare stmt66607")
+	}
+
 	// issue-66399-outer-join-eliminate-must-keep-parent-join-condition-columns
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/operator/logicalop/logical_aggregation.go
+++ b/pkg/planner/core/operator/logicalop/logical_aggregation.go
@@ -629,14 +629,23 @@ func (la *LogicalAggregation) pushDownDNFPredicates(cond expression.Expression, 
 
 // splitCondForAggregation splits the condition into those who can be pushed and others.
 func (la *LogicalAggregation) splitCondForAggregation(predicates []expression.Expression) (condsToPush, ret []expression.Expression) {
+	exprCtx := la.SCtx().GetExprCtx()
 	exprsOriginal := make([]expression.Expression, 0, len(la.AggFuncs))
 	for _, fun := range la.AggFuncs {
 		exprsOriginal = append(exprsOriginal, fun.Args[0])
 	}
 	groupByColumns := expression.NewSchema(la.GetGroupByCols()...)
 	aggFirstRowColumns := expression.NewSchema(la.getAggFuncsColsForFirstRow()...)
+	aggConstResultColumns, aggConstResultExprs := la.getAggFuncsColsForConstResult()
+	var aggConstResultSchema *expression.Schema
+	if len(aggConstResultColumns) > 0 {
+		aggConstResultSchema = expression.NewSchema(aggConstResultColumns...)
+	}
 	for _, cond := range predicates {
 		for _, cnfItem := range expression.SplitCNFItems(cond) {
+			if aggConstResultSchema != nil {
+				cnfItem = expression.FoldConstant(exprCtx, expression.ColumnSubstitute(exprCtx, cnfItem, aggConstResultSchema, aggConstResultExprs))
+			}
 			subCondsToPush, subRet := la.pushDownDNFPredicates(cnfItem, groupByColumns, exprsOriginal, la.pushDownPredicatesByGroupby)
 			if len(subCondsToPush) > 0 {
 				condsToPush = append(condsToPush, subCondsToPush...)
@@ -656,6 +665,39 @@ func (la *LogicalAggregation) splitCondForAggregation(predicates []expression.Ex
 		}
 	}
 	return condsToPush, ret
+}
+
+// getAggFuncsColsForConstResult gets aggregate output columns whose values always match their
+// single row-independent argument for every non-empty group.
+func (la *LogicalAggregation) getAggFuncsColsForConstResult() (aggFuncsCols []*expression.Column, aggFuncsExprs []expression.Expression) {
+	if len(la.GroupByItems) == 0 {
+		return nil, nil
+	}
+	aggFuncsCols = make([]*expression.Column, 0, len(la.AggFuncs))
+	aggFuncsExprs = make([]expression.Expression, 0, len(la.AggFuncs))
+	for idx, col := range la.Schema().Columns {
+		if idx >= len(la.AggFuncs) {
+			break
+		}
+		aggFunc := la.AggFuncs[idx]
+		if aggFuncResultMatchesArgForNonEmptyGroup(aggFunc) {
+			aggFuncsCols = append(aggFuncsCols, col)
+			aggFuncsExprs = append(aggFuncsExprs, aggFunc.Args[0])
+		}
+	}
+	return aggFuncsCols, aggFuncsExprs
+}
+
+func aggFuncResultMatchesArgForNonEmptyGroup(aggFunc *aggregation.AggFuncDesc) bool {
+	if aggFunc.HasDistinct || len(aggFunc.Args) != 1 || len(aggFunc.OrderByItems) > 0 {
+		return false
+	}
+	switch aggFunc.Name {
+	case ast.AggFuncMax, ast.AggFuncMin:
+	default:
+		return false
+	}
+	return aggFunc.Args[0].ConstLevel() >= expression.ConstOnlyInContext
 }
 
 // getAggFuncsColsForFirstRow gets the columns that are used by first_row agg functions.

--- a/pkg/resourcegroup/tests/BUILD.bazel
+++ b/pkg/resourcegroup/tests/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "tests_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = ["resource_group_test.go"],
     flaky = True,
     race = "on",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67573

Problem Summary:

`IndexJoin` can amplify the cost of a large `NOT IN` list on the probe side. In the problematic
shape from `#67573`, the join key still uses point lookups on `t2.a`, but the probe-side
`Selection` keeps a very large `not(in(...))` expression on another column such as `t2.b`. That
causes TiKV to spend extra CPU on decoding the cop request and building the selection executor for
every probe.

For this issue, we do not want to turn the large `NOT IN` into access ranges directly. A generic
range rewrite can turn the inner point lookup into wide range scans, which is risky when MVCC
versions are heavy.

### What changed and how does it work?

- Add a targeted rewrite for large integer `NOT IN` filters on `IndexJoin` probe-side table
  filters.
- Compress consecutive values into interval predicates while keeping the original point-lookup
  access path unchanged. For example:
  - `b NOT IN (1, 2, ..., 12)` becomes `b < 1 OR b > 12`
  - `b NOT IN (1, 2, 3, 10, 11, 12, 100, 101, 102, 103)` becomes OR-ed gap intervals between the
    compressed runs
- Apply the rewrite only when all of the following hold:
  - the target column is integer-typed
  - the list contains only constant non-NULL values
  - compression really reduces the expression shape
- Keep sparse lists as `NOT IN` so we do not add complexity without benefit.
- Add regression coverage for:
  - a single consecutive run
  - multiple consecutive runs
  - a sparse list that should stay unchanged

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:

- `pushd pkg/planner/core/casetest/cbotest >/dev/null && go test -run TestAnalyzeSuiteRegression -record -tags=intest,deadlock -count=1 && popd >/dev/null`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected query planning for aggregations with HAVING in both normal and prepared statements.
  * Fixed join planning when large NOT IN filters appear on integer columns, ensuring correct plans.

* **Performance**
  * Improved IndexJoin behavior by rewriting large NOT IN predicates into more efficient interval checks.

* **Tests**
  * Added regression tests validating the above fixes and expected execution plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->