### PR TITLE
pkg/server/handler/tests: stabilize flaky TestServerInfo

### DIFF
--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -552,31 +552,54 @@ func TestTestHandler(t *testing.T) {
 }
 
 func TestServerInfo(t *testing.T) {
+	originalCfg := *config.GetGlobalConfig()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Performance.ForceInitStats = false
+	})
+	defer config.StoreGlobalConfig(&originalCfg)
+
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
-	resp, err := ts.FetchStatus("/info")
-	require.NoError(t, err)
-	defer func() { require.NoError(t, resp.Body.Close()) }()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	decoder := json.NewDecoder(resp.Body)
-
-	info := tikvhandler.ServerInfo{}
-	err = decoder.Decode(&info)
-	require.NoError(t, err)
 
 	cfg := config.GetGlobalConfig()
-	require.True(t, info.IsOwner)
+	store := ts.server.NewTikvHandlerTool().Store.(kv.Storage)
+	do, err := session.GetDomain(store)
+	require.NoError(t, err)
+	d := do.DDL()
+
+	fetchInfo := func() (tikvhandler.ServerInfo, error) {
+		resp, err := ts.FetchStatus("/info")
+		if err != nil {
+			return tikvhandler.ServerInfo{}, err
+		}
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+		if resp.StatusCode != http.StatusOK {
+			return tikvhandler.ServerInfo{}, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		}
+
+		info := tikvhandler.ServerInfo{}
+		err = json.NewDecoder(resp.Body).Decode(&info)
+		return info, err
+	}
+
+	var info tikvhandler.ServerInfo
+	require.Eventually(t, func() bool {
+		current, err := fetchInfo()
+		if err != nil {
+			return false
+		}
+		info = current
+		return info.IsOwner
+	}, 3*time.Second, 50*time.Millisecond)
+
 	require.Equal(t, cfg.AdvertiseAddress, info.IP)
 	require.Equal(t, cfg.Status.StatusPort, info.StatusPort)
 	require.Equal(t, cfg.Lease, info.Lease)
 	require.Equal(t, mysql.ServerVersion, info.Version)
 	require.Equal(t, versioninfo.TiDBGitHash, info.GitHash)
-
-	store := ts.server.NewTikvHandlerTool().Store.(kv.Storage)
-	do, err := session.GetDomain(store)
-	require.NoError(t, err)
-	d := do.DDL()
 	require.Equal(t, d.GetID(), info.ID)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67567

Problem Summary:
Flaky test `TestServerInfo` in `pkg/server/handler/tests` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The previous patch retried the whole `/info` payload instead of the actual flaky owner-election bit, and the reviewer’s untagged command also blocked in server startup because `ForceInitStats` prevented `RunInGoTestChan` from closing.

#### Fix

Scoped the retry to `info.IsOwner` and temporarily disabled `Performance.ForceInitStats` inside `TestServerInfo` so both the flaky path and the reviewer command path complete.

#### Verification

`go test ./pkg/server/handler/tests -run '^TestServerInfo$' -count=1`, `./tools/check/failpoint-go-test.sh pkg/server/handler/tests -run '^TestServerInfo$' -count=1`, and `make lint` all passed.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of server info endpoint tests by temporarily adjusting global config, introducing repeated polling to wait for the server to become owner, ensuring HTTP responses are always closed, moving session/DDL setup earlier, and stabilizing assertions against advertised address, ports, lease, server version, Git hash, and DDL ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->