### PR TITLE
sessionctx: avoid IMDS leak in TestSetTiDBCloudStorageURI

### DIFF
--- a/pkg/sessionctx/variable/tests/session_test.go
+++ b/pkg/sessionctx/variable/tests/session_test.go
@@ -997,6 +997,8 @@ func TestSetTiDBCloudStorageURI(t *testing.T) {
 	mock := variable.NewMockGlobalAccessor4Tests()
 	mock.SessionVars = vars
 	vars.GlobalVarsAccessor = mock
+	// Prevent AWS SDK IMDS probing from creating background HTTP goroutines.
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 	cloudStorageURI := variable.GetSysVar(vardef.TiDBCloudStorageURI)
 	require.Len(t, vardef.CloudStorageURI.Load(), 0)
 	defer func() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #65526

Problem Summary:
`TestSetTiDBCloudStorageURI` is flaky in CI because it can trigger AWS IMDS credential probing when validating `s3://blackhole` without explicit credentials. The test assertions pass, but background HTTP connection goroutines from that probe can still be alive when goleak runs, causing intermittent shard failures.

### What changed and how does it work?

This PR adds a test-scoped environment guard in `TestSetTiDBCloudStorageURI`:

- `t.Setenv("AWS_EC2_METADATA_DISABLED", "true")`

This disables EC2 IMDS probing only for this test process, removing the flaky goroutine source while keeping the existing behavior checks and assertions unchanged.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability by configuring environment settings to prevent unnecessary background operations during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->