### PR TITLE
pkg/dxf: avoid misleading error log on context cancel

### DIFF
--- a/pkg/dxf/framework/taskexecutor/task_executor.go
+++ b/pkg/dxf/framework/taskexecutor/task_executor.go
@@ -392,8 +392,9 @@ func (e *BaseTaskExecutor) Run() {
 			// might have failed, we rely on scheduler to detect the error, and
 			// notify task executor or manager to cancel.
 			if llog.IsContextCanceledError(err) {
-				// to avoid the log being misleading when context is canceled.
-				e.sampleLogger.Info("meet context cancel when run subtask", llog.ShortError(err))
+				// Context canceled is expected when scheduler/manager cancels executor,
+				// so log as info instead of a subtask failure.
+				e.sampleLogger.Info("subtask run canceled by context", llog.ShortError(err))
 			} else {
 				e.sampleLogger.Error("run subtask failed", zap.Error(err))
 			}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #67631

Problem Summary:

When a distributed task subtask exits because the context is canceled, the executor currently logs it as a failure. This produces misleading error logs for expected cancellation paths.

### What changed and how does it work?

In `BaseTaskExecutor.Run`, handle `runSubtask` errors by type:

- If the error is a context-canceled error (`llog.IsContextCanceledError(err)`), log an info message.
- Otherwise keep logging the error as before.

This preserves error visibility for real failures while reducing noisy/misleading logs for expected cancellations.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test. **just changing log printing**
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced log noise for task execution: subtasks terminated due to context cancellation are now logged as informational messages rather than errors, making logs clearer and avoiding misleading error entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
