### PR TITLE
pkg/statistics/handle/globalstats: stabilize flaky TestGlobalStatsMergeCombined

### DIFF
--- a/pkg/statistics/handle/globalstats/global_stats.go
+++ b/pkg/statistics/handle/globalstats/global_stats.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -53,7 +54,11 @@ func (sg *statsGlobalImpl) MergePartitionStats2GlobalStatsByTableID(sc sessionct
 	info *statstypes.GlobalStatsInfo,
 	physicalID int64,
 ) (err error) {
-	globalStats, err := MergePartitionStats2GlobalStatsByTableID(sc, sg.statsHandler, opts, is, physicalID, info.IsIndex == 1, info.HistIDs)
+	analyzeVersion := info.StatsVersion
+	if analyzeVersion == 0 {
+		analyzeVersion = sc.GetSessionVars().AnalyzeVersion
+	}
+	globalStats, err := MergePartitionStats2GlobalStatsByTableID(sc, sg.statsHandler, opts, is, physicalID, info.IsIndex == 1, info.HistIDs, analyzeVersion)
 	if err != nil {
 		if types.ErrPartitionStatsMissing.Equal(err) || types.ErrPartitionColumnStatsMissing.Equal(err) {
 			// When we find some partition-level stats are missing, we need to report warning.
@@ -101,7 +106,9 @@ func MergePartitionStats2GlobalStats(
 	globalTableInfo *model.TableInfo,
 	isIndex bool,
 	histIDs []int64,
+	analyzeVersion int,
 ) (globalStats *GlobalStats, err error) {
+	failpoint.InjectCall("mergeGlobalStatsAnalyzeVersion", analyzeVersion)
 	if sc.GetSessionVars().EnableAsyncMergeGlobalStats {
 		statslogutil.StatsSampleLogger().Info("use async merge global stats",
 			zap.Int64("tableID", globalTableInfo.ID),
@@ -111,7 +118,7 @@ func MergePartitionStats2GlobalStats(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		err = worker.MergePartitionStats2GlobalStats(sc, opts, isIndex)
+		err = worker.MergePartitionStats2GlobalStats(sc, opts, isIndex, analyzeVersion)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -121,7 +128,7 @@ func MergePartitionStats2GlobalStats(
 		zap.Int64("tableID", globalTableInfo.ID),
 		zap.String("table", globalTableInfo.Name.L),
 	)
-	return blockingMergePartitionStats2GlobalStats(sc, statsHandle.GPool(), opts, is, globalTableInfo, isIndex, histIDs, nil, statsHandle)
+	return blockingMergePartitionStats2GlobalStats(sc, statsHandle.GPool(), opts, is, globalTableInfo, isIndex, histIDs, nil, statsHandle, analyzeVersion)
 }
 
 // MergePartitionStats2GlobalStatsByTableID merge the partition-level stats to global-level stats based on the tableID.
@@ -133,6 +140,7 @@ func MergePartitionStats2GlobalStatsByTableID(
 	tableID int64,
 	isIndex bool,
 	histIDs []int64,
+	analyzeVersion int,
 ) (globalStats *GlobalStats, err error) {
 	// Get the partition table IDs.
 	globalTable, ok := statsHandle.TableInfoByID(is, tableID)
@@ -142,7 +150,7 @@ func MergePartitionStats2GlobalStatsByTableID(
 	}
 
 	globalTableInfo := globalTable.Meta()
-	globalStats, err = MergePartitionStats2GlobalStats(sc, statsHandle, opts, is, globalTableInfo, isIndex, histIDs)
+	globalStats, err = MergePartitionStats2GlobalStats(sc, statsHandle, opts, is, globalTableInfo, isIndex, histIDs, analyzeVersion)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -175,6 +183,7 @@ func blockingMergePartitionStats2GlobalStats(
 	histIDs []int64,
 	allPartitionStats map[int64]*statistics.Table,
 	statsHandle statstypes.StatsHandle,
+	analyzeVersion int,
 ) (globalStats *GlobalStats, err error) {
 	externalCache := false
 	if allPartitionStats != nil {
@@ -336,14 +345,14 @@ func blockingMergePartitionStats2GlobalStats(
 		var poppedTopN []statistics.TopNMeta
 		wrapper := NewStatsWrapper(allHg[i], allTopN[i])
 		globalStats.TopN[i], poppedTopN, allHg[i], err = mergeGlobalStatsTopN(gpool, sc, wrapper,
-			sc.GetSessionVars().StmtCtx.TimeZone(), sc.GetSessionVars().AnalyzeVersion, uint32(opts[ast.AnalyzeOptNumTopN]), isIndex)
+			sc.GetSessionVars().StmtCtx.TimeZone(), analyzeVersion, uint32(opts[ast.AnalyzeOptNumTopN]), isIndex)
 		if err != nil {
 			return
 		}
 
 		// Merge histogram.
 		globalStats.Hg[i], err = statistics.MergePartitionHist2GlobalHist(sc.GetSessionVars().StmtCtx, allHg[i], poppedTopN,
-			int64(opts[ast.AnalyzeOptNumBuckets]), isIndex, sc.GetSessionVars().AnalyzeVersion)
+			int64(opts[ast.AnalyzeOptNumBuckets]), isIndex, analyzeVersion)
 		if err != nil {
 			return
 		}

--- a/pkg/statistics/handle/globalstats/global_stats_async.go
+++ b/pkg/statistics/handle/globalstats/global_stats_async.go
@@ -310,10 +310,10 @@ func (a *AsyncMergePartitionStats2GlobalStats) MergePartitionStats2GlobalStats(
 	sctx sessionctx.Context,
 	opts map[ast.AnalyzeOptionType]uint64,
 	isIndex bool,
+	analyzeVersion int,
 ) error {
 	a.skipMissingPartitionStats = sctx.GetSessionVars().SkipMissingPartitionStats
 	tz := sctx.GetSessionVars().StmtCtx.TimeZone()
-	analyzeVersion := sctx.GetSessionVars().AnalyzeVersion
 	stmtCtx := sctx.GetSessionVars().StmtCtx
 	return util.CallWithSCtx(a.statsHandle.SPool(),
 		func(sctx sessionctx.Context) error {

--- a/pkg/statistics/handle/globalstats/global_stats_test.go
+++ b/pkg/statistics/handle/globalstats/global_stats_test.go
@@ -976,6 +976,7 @@ func TestEmptyHists(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_analyze_version=2")
 	tk.MustExec(`create table t (
 	id int,
 	fname varchar(30),
@@ -995,4 +996,21 @@ partitions 12;`)
 	tk.MustExec("set @@tidb_enable_async_merge_global_stats=OFF;")
 	tk.MustQuery("show warnings").Check(testkit.Rows(asyncMergeWarn))
 	dom.StatsHandle().MergePartitionStats2GlobalStatsByTableID(se, core.GetAnalyzeOptionDefaultV2ForTest(), infoSchema, &types.GlobalStatsInfo{StatsVersion: 2}, tbl.Meta().ID)
+
+	// Global merge should follow the target stats version from GlobalStatsInfo rather than session analyze version.
+	called := false
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/statistics/handle/globalstats/mergeGlobalStatsAnalyzeVersion", func(version int) {
+		called = true
+		require.Equal(t, 1, version)
+	})
+	tk.MustExec("set @@tidb_enable_async_merge_global_stats=ON;")
+	tk.MustQuery("show warnings").Check(testkit.Rows(asyncMergeWarn))
+	require.NoError(t, dom.StatsHandle().MergePartitionStats2GlobalStatsByTableID(
+		se,
+		core.GetAnalyzeOptionDefaultV2ForTest(),
+		infoSchema,
+		&types.GlobalStatsInfo{StatsVersion: 1},
+		tbl.Meta().ID,
+	))
+	require.True(t, called)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67559

Problem Summary:
Flaky test `TestGlobalStatsMergeCombined` in `pkg/statistics/handle/globalstats` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Global stats merge used session AnalyzeVersion instead of target GlobalStatsInfo.StatsVersion, allowing version drift and unstable TopN/hist merge results.

#### Fix

Propagated explicit analyzeVersion from GlobalStatsInfo through global stats merge (async and blocking) and added a failpoint-backed regression assertion in TestEmptyHists.

#### Verification

Failpoint-enabled targeted tests passed (TestEmptyHists and TestGlobalStatsVersion); payload command for TestGlobalStatsMergeCombined reports no tests to run on this branch.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statistics merging for partitioned tables to ensure the correct analysis version is applied during global stats computation, enhancing accuracy of query optimization decisions.

* **Tests**
  * Added validation tests for statistics merging with different analysis versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->