### PR TITLE
pkg/util/ranger: reduce allocs for single-column ranges

### DIFF
--- a/pkg/util/ranger/bench_test.go
+++ b/pkg/util/ranger/bench_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func BenchmarkDetachCondAndBuildRangeForIndex(b *testing.B) {
+	b.ReportAllocs()
 	store := testkit.CreateMockStore(b)
 	testKit := testkit.NewTestKit(b, store)
 	testKit.MustExec("USE test")

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -141,19 +141,7 @@ func points2Ranges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 		}
 		return fullRange, true, nil
 	}
-	ranges := make(Ranges, 0, len(convertedPoints)/2)
-	for i := 0; i < len(convertedPoints); i += 2 {
-		startPoint, endPoint := convertedPoints[i], convertedPoints[i+1]
-		ran := &Range{
-			LowVal:      []types.Datum{startPoint.value},
-			LowExclude:  startPoint.excl,
-			HighVal:     []types.Datum{endPoint.value},
-			HighExclude: endPoint.excl,
-			Collators:   []collate.Collator{collate.GetCollator(newTp.GetCollate())},
-		}
-		ranges = append(ranges, ran)
-	}
-	return ranges, false, nil
+	return buildSingleColumnRanges(convertedPoints, collate.GetCollator(newTp.GetCollate())), false, nil
 }
 
 func convertPoint(sctx *rangerctx.RangerContext, point *point, newTp *types.FieldType) (*point, error) {
@@ -393,19 +381,33 @@ func points2TableRanges(sctx *rangerctx.RangerContext, rangePoints []*point, new
 	if rangeMaxSize > 0 && estimateMemUsageForPoints2Ranges(convertedPoints) > rangeMaxSize {
 		return FullIntRange(mysql.HasUnsignedFlag(newTp.GetFlag())), true, nil
 	}
-	ranges := make(Ranges, 0, len(convertedPoints)/2)
-	for i := 0; i < len(convertedPoints); i += 2 {
-		startPoint, endPoint := convertedPoints[i], convertedPoints[i+1]
-		ran := &Range{
-			LowVal:      []types.Datum{startPoint.value},
-			LowExclude:  startPoint.excl,
-			HighVal:     []types.Datum{endPoint.value},
-			HighExclude: endPoint.excl,
-			Collators:   []collate.Collator{collate.GetCollator(newTp.GetCollate())},
-		}
-		ranges = append(ranges, ran)
+	return buildSingleColumnRanges(convertedPoints, collate.GetCollator(newTp.GetCollate())), false, nil
+}
+
+// buildSingleColumnRanges groups all single-column range payloads into shared backing arrays
+// so range construction does not allocate tiny []Datum/[]Collator slices for every interval.
+func buildSingleColumnRanges(convertedPoints []*point, collator collate.Collator) Ranges {
+	rangeCount := len(convertedPoints) / 2
+	ranges := make(Ranges, 0, rangeCount)
+	lowVals := make([]types.Datum, rangeCount)
+	highVals := make([]types.Datum, rangeCount)
+	collators := make([]collate.Collator, rangeCount)
+	for i := 0; i < rangeCount; i++ {
+		collators[i] = collator
 	}
-	return ranges, false, nil
+	for i := 0; i < rangeCount; i++ {
+		startPoint, endPoint := convertedPoints[i*2], convertedPoints[i*2+1]
+		lowVals[i] = startPoint.value
+		highVals[i] = endPoint.value
+		ranges = append(ranges, &Range{
+			LowVal:      lowVals[i : i+1 : i+1],
+			LowExclude:  startPoint.excl,
+			HighVal:     highVals[i : i+1 : i+1],
+			HighExclude: endPoint.excl,
+			Collators:   collators[i : i+1 : i+1],
+		})
+	}
+	return ranges
 }
 
 // buildColumnRange builds range from CNF conditions.

--- a/tests/realtikvtest/pushdowntest/BUILD.bazel
+++ b/tests/realtikvtest/pushdowntest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 4,
+    shard_count = 5,
     deps = [
         "//pkg/testkit",
         "//pkg/util/logutil",


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #xxx

Problem Summary:

- This is a draft PR for code review on a local optimization idea.
- In long `IN (...)` workloads, `ranger.points2Ranges` and `points2TableRanges` build many single-column ranges and allocate many short-lived `[]Datum` and `[]Collator` slices.
- The goal of this change is to reduce those allocations without changing planner semantics.

### What changed and how does it work?

- Reuse shared backing arrays when building single-column ranges in `points2Ranges` and `points2TableRanges`.
- Keep each range slice capped to length 1 so later writes are isolated and later `append` calls reallocate instead of mutating neighbors.
- Enable `b.ReportAllocs()` in `BenchmarkDetachCondAndBuildRangeForIndex` so the allocation delta is visible in `benchmem`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual verification attempted:

```bash
go test ./pkg/util/ranger -run TestRangeFallbackForDetachCondAndBuildRangeForIndex -count=1
go test ./pkg/util/ranger -run ^$ -bench BenchmarkDetachCondAndBuildRangeForIndex -benchmem -count=1
```

Both commands were blocked locally by `no space left on device` in the Go build temporary directory under `/var/folders/.../go-build*`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
