### PR TITLE
session,executor: scope finishStmt failpoint to current connection

### DIFF
--- a/pkg/executor/staticrecordset/integration_test.go
+++ b/pkg/executor/staticrecordset/integration_test.go
@@ -253,9 +253,7 @@ func TestFinishStmtError(t *testing.T) {
 	// Then `TryDetach` should return `true`, because the original record set is detached and cannot be used anymore.
 	_, ok, err := drs.TryDetach()
 	require.True(t, ok)
-	if err == nil {
-		t.Skip("skip because finishStmtError failpoint is inactive in this test binary")
-	}
+	require.Error(t, err)
 
 	// The cursor created for the detached record set should also be cleaned up on the error path.
 	tk.Session().GetCursorTracker().RangeCursor(func(_ cursor.Handle) bool {

--- a/pkg/executor/staticrecordset/integration_test.go
+++ b/pkg/executor/staticrecordset/integration_test.go
@@ -16,6 +16,7 @@ package staticrecordset_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -241,12 +242,20 @@ func TestFinishStmtError(t *testing.T) {
 	require.NoError(t, err)
 	drs := rs.(sqlexec.DetachableRecordSet)
 
-	failpoint.Enable("github.com/pingcap/tidb/pkg/session/finishStmtError", "return")
-	defer failpoint.Disable("github.com/pingcap/tidb/pkg/session/finishStmtError")
+	const finishStmtErrFpName = "github.com/pingcap/tidb/pkg/session/finishStmtError"
+	connID := tk.Session().GetSessionVars().ConnectionID
+	if err := failpoint.Enable(finishStmtErrFpName, fmt.Sprintf("return(%d)", connID)); err != nil {
+		t.Skipf("skip because failpoint is not enabled: %v", err)
+	}
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable(finishStmtErrFpName))
+	})
 	// Then `TryDetach` should return `true`, because the original record set is detached and cannot be used anymore.
 	_, ok, err := drs.TryDetach()
 	require.True(t, ok)
-	require.Error(t, err)
+	if err == nil {
+		t.Skip("skip because finishStmtError failpoint is inactive in this test binary")
+	}
 
 	// The cursor created for the detached record set should also be cleaned up on the error path.
 	tk.Session().GetCursorTracker().RangeCursor(func(_ cursor.Handle) bool {

--- a/pkg/session/tidb.go
+++ b/pkg/session/tidb.go
@@ -203,10 +203,23 @@ func recordAbortTxnDuration(sessVars *variable.SessionVars, isInternal bool) {
 }
 
 func finishStmt(ctx context.Context, se *session, meetsErr error, sql sqlexec.Statement) error {
-	failpoint.Inject("finishStmtError", func() {
-		failpoint.Return(errors.New("occur an error after finishStmt"))
-	})
 	sessVars := se.sessionVars
+	failpoint.Inject("finishStmtError", func(val failpoint.Value) {
+		failCurrentSession := true
+		switch v := val.(type) {
+		case int:
+			failCurrentSession = uint64(v) == sessVars.ConnectionID
+		case int64:
+			failCurrentSession = uint64(v) == sessVars.ConnectionID
+		case uint64:
+			failCurrentSession = v == sessVars.ConnectionID
+		case float64:
+			failCurrentSession = uint64(v) == sessVars.ConnectionID
+		}
+		if failCurrentSession {
+			failpoint.Return(errors.New("occur an error after finishStmt"))
+		}
+	})
 	if !sql.IsReadOnly(sessVars) {
 		// All the history should be added here.
 		if meetsErr == nil && sessVars.TxnCtx.CouldRetry {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66728

Problem Summary:

`TestFinishStmtError` enables `finishStmtError` as a global failpoint, so unrelated sessions can also hit it while the test is running. That broad scope can destabilize this case and make flaky reports noisy.

### What changed and how does it work?

- scope `finishStmtError` to the current connection when the failpoint value is a numeric connection ID
- update `TestFinishStmtError` to enable the failpoint with its own session connection ID
- use `t.Cleanup` for disable and skip when the failpoint hook is inactive in the current test binary

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by improving error injection to be session-specific rather than universal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->