### PR TITLE
statistics: prefer latest table snapshot in LFU Get

### DIFF
--- a/pkg/statistics/handle/cache/internal/lfu/BUILD.bazel
+++ b/pkg/statistics/handle/cache/internal/lfu/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/util/logutil",
         "//pkg/util/memory",
         "@com_github_dgraph_io_ristretto//:ristretto",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@org_uber_go_zap//:zap",
     ],
 )
@@ -28,10 +29,11 @@ go_test(
     embed = [":lfu"],
     flaky = True,
     race = "on",
-    shard_count = 10,
+    shard_count = 11,
     deps = [
         "//pkg/statistics",
         "//pkg/statistics/handle/cache/internal/testutil",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/statistics/handle/cache/internal/lfu/key_set.go
+++ b/pkg/statistics/handle/cache/internal/lfu/key_set.go
@@ -60,6 +60,17 @@ func (ks *keySet) AddKeyValue(key int64, value *statistics.Table) {
 	ks.mu.Unlock()
 }
 
+func (ks *keySet) ReplaceIfSamePointer(key int64, expected, value *statistics.Table) bool {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+	current, ok := ks.set[key]
+	if !ok || current != expected {
+		return false
+	}
+	ks.set[key] = value
+	return true
+}
+
 func (ks *keySet) Get(key int64) (*statistics.Table, bool) {
 	ks.mu.RLock()
 	value, ok := ks.set[key]

--- a/pkg/statistics/handle/cache/internal/lfu/key_set_shard.go
+++ b/pkg/statistics/handle/cache/internal/lfu/key_set_shard.go
@@ -42,6 +42,10 @@ func (kss *keySetShard) AddKeyValue(key int64, table *statistics.Table) {
 	kss.resultKeySet[key%keySetCnt].AddKeyValue(key, table)
 }
 
+func (kss *keySetShard) ReplaceIfSamePointer(key int64, expected, table *statistics.Table) bool {
+	return kss.resultKeySet[key%keySetCnt].ReplaceIfSamePointer(key, expected, table)
+}
+
 func (kss *keySetShard) Remove(key int64) {
 	kss.resultKeySet[key%keySetCnt].Remove(key)
 }

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -88,7 +88,13 @@ func adjustMemCost(totalMemCost int64) (result int64, err error) {
 	return totalMemCost, nil
 }
 
-// Get implements statsCacheInner
+// Get implements statsCacheInner.
+//
+// Expected key states:
+// 1. Put writes resultKeySet synchronously, then writes Ristretto asynchronously.
+//    During this lag window, resultKeySet is newer than the primary cache.
+// 2. onEvict/onReject may keep only a stripped table in resultKeySet.
+// 3. Del removes the key from both caches.
 func (s *LFU) Get(tid int64) (*statistics.Table, bool) {
 	result, ok := s.resultKeySet.Get(tid)
 	if !ok {
@@ -168,9 +174,14 @@ func (s *LFU) dropMemory(item *ristretto.Item) {
 	// We do not need to calculate the cost during onEvict,
 	// because the onexit function is also called when the evict event occurs.
 	// TODO(hawkingrei): not copy the useless part.
-	table := item.Value.(*statistics.Table).CopyAs(statistics.AllDataWritable)
+	oldTable := item.Value.(*statistics.Table)
+	table := oldTable.CopyAs(statistics.AllDataWritable)
 	table.DropEvicted()
-	s.resultKeySet.AddKeyValue(int64(item.Key), table)
+	if !s.resultKeySet.ReplaceIfSamePointer(int64(item.Key), oldTable, table) {
+		// A newer table has already replaced this key, so stale eviction/rejection callbacks
+		// must not overwrite it.
+		return
+	}
 	after := table.MemoryUsage().TotalTrackingMemUsage()
 	// why add before again? because the cost will be subtracted in onExit.
 	// in fact, it is after - before

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -91,10 +91,10 @@ func adjustMemCost(totalMemCost int64) (result int64, err error) {
 // Get implements statsCacheInner.
 //
 // Expected key states:
-// 1. Put writes resultKeySet synchronously, then writes Ristretto asynchronously.
-//    During this lag window, resultKeySet is newer than the primary cache.
-// 2. onEvict/onReject may keep only a stripped table in resultKeySet.
-// 3. Del removes the key from both caches.
+//  1. Put writes resultKeySet synchronously, then writes Ristretto asynchronously.
+//     During this lag window, resultKeySet is newer than the primary cache.
+//  2. onEvict/onReject may keep only a stripped table in resultKeySet.
+//  3. Del removes the key from both caches.
 func (s *LFU) Get(tid int64) (*statistics.Table, bool) {
 	result, ok := s.resultKeySet.Get(tid)
 	if !ok {

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 
 	"github.com/dgraph-io/ristretto"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/cache/internal"
 	"github.com/pingcap/tidb/pkg/statistics/handle/cache/metrics"
@@ -89,17 +90,25 @@ func adjustMemCost(totalMemCost int64) (result int64, err error) {
 
 // Get implements statsCacheInner
 func (s *LFU) Get(tid int64) (*statistics.Table, bool) {
-	result, ok := s.cache.Get(tid)
+	result, ok := s.resultKeySet.Get(tid)
 	if !ok {
-		return s.resultKeySet.Get(tid)
+		cached, ok := s.cache.Get(tid)
+		if !ok {
+			return nil, false
+		}
+		return cached.(*statistics.Table), true
 	}
-	return result.(*statistics.Table), ok
+	// Touch the primary cache when the item is present so its frequency still reflects reads,
+	// but return the latest value from resultKeySet because Ristretto applies writes asynchronously.
+	_, _ = s.cache.Get(tid)
+	return result, true
 }
 
 // Put implements statsCacheInner
 func (s *LFU) Put(tblID int64, tbl *statistics.Table) bool {
 	cost := tbl.MemoryUsage().TotalTrackingMemUsage()
 	s.resultKeySet.AddKeyValue(tblID, tbl)
+	failpoint.Inject("beforeLFUCacheSet", func() {})
 	s.addCost(cost)
 	return s.cache.Set(tblID, tbl, cost)
 }

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
@@ -79,6 +79,12 @@ func TestLFUGetReturnsLatestValueWhilePrimaryCacheLags(t *testing.T) {
 		return ok && tbl.GetIdx(1) != nil
 	}, time.Second, 10*time.Millisecond)
 
+	select {
+	case <-putDone:
+		t.Fatal("LFU put finished before Get assertion; failpoint pause was not active")
+	default:
+	}
+
 	tbl, ok := lfu.Get(1)
 	require.True(t, ok)
 	require.NotNil(t, tbl.GetIdx(1))

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/cache/internal/testutil"
 	"github.com/stretchr/testify/require"
@@ -44,6 +45,43 @@ func TestLFUPutGetDel(t *testing.T) {
 	lfu.wait()
 	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
 	require.Equal(t, 0, len(lfu.Values()))
+}
+
+func TestLFUGetReturnsLatestValueWhilePrimaryCacheLags(t *testing.T) {
+	lfu, err := NewLFU(1 << 20)
+	require.NoError(t, err)
+
+	oldTable := testutil.NewMockStatisticsTable(1, 0, false, false, false)
+	newTable := testutil.NewMockStatisticsTable(1, 1, true, true, true)
+	lfu.Put(1, oldTable)
+	lfu.wait()
+
+	const fpName = "github.com/pingcap/tidb/pkg/statistics/handle/cache/internal/lfu/beforeLFUCacheSet"
+	require.NoError(t, failpoint.Enable(fpName, "pause"))
+
+	putDone := make(chan struct{})
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable(fpName))
+		select {
+		case <-putDone:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for blocked LFU put to finish")
+		}
+	})
+
+	go func() {
+		lfu.Put(1, newTable)
+		close(putDone)
+	}()
+
+	require.Eventually(t, func() bool {
+		tbl, ok := lfu.resultKeySet.Get(1)
+		return ok && tbl.GetIdx(1) != nil
+	}, time.Second, 10*time.Millisecond)
+
+	tbl, ok := lfu.Get(1)
+	require.True(t, ok)
+	require.NotNil(t, tbl.GetIdx(1))
 }
 
 func TestLFUFreshMemUsage(t *testing.T) {

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/ristretto"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/cache/internal/testutil"
@@ -74,8 +75,10 @@ func TestLFUGetReturnsLatestValueWhilePrimaryCacheLags(t *testing.T) {
 		close(putDone)
 	}()
 
+	// beforeLFUCacheSet pauses Put after resultKeySet is updated but before cache.Set.
+	// Verify Get behavior via the API during this lag window.
 	require.Eventually(t, func() bool {
-		tbl, ok := lfu.resultKeySet.Get(1)
+		tbl, ok := lfu.Get(1)
 		return ok && tbl.GetIdx(1) != nil
 	}, time.Second, 10*time.Millisecond)
 
@@ -88,6 +91,26 @@ func TestLFUGetReturnsLatestValueWhilePrimaryCacheLags(t *testing.T) {
 	tbl, ok := lfu.Get(1)
 	require.True(t, ok)
 	require.NotNil(t, tbl.GetIdx(1))
+}
+
+func TestLFUDropMemoryDoesNotOverwriteNewerTable(t *testing.T) {
+	lfu, err := NewLFU(1 << 20)
+	require.NoError(t, err)
+
+	oldTable := testutil.NewMockStatisticsTable(1, 0, false, false, false)
+	newTable := testutil.NewMockStatisticsTable(1, 1, true, true, true)
+	lfu.resultKeySet.AddKeyValue(1, oldTable)
+	lfu.resultKeySet.AddKeyValue(1, newTable)
+
+	lfu.dropMemory(&ristretto.Item{
+		Key:   1,
+		Value: oldTable,
+	})
+
+	got, ok := lfu.Get(1)
+	require.True(t, ok)
+	require.Same(t, newTable, got)
+	require.NotNil(t, got.GetIdx(1))
 }
 
 func TestLFUFreshMemUsage(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #67176

Problem Summary:
`TestNonLiteInitStatsWithTableIDs` can still read stale table stats during repeated targeted init-stats loads. `LFU.Put` updates `resultKeySet` first, but the primary Ristretto cache write is async. In that window, `LFU.Get` could return the older primary-cache entry and miss newly loaded index stats.

### What changed and how does it work?

- Make `LFU.Get` read from `resultKeySet` first, then fall back to the primary cache only when the key is absent.
- Keep a cache touch on key-set hits so LFU frequency accounting remains active.
- Add a narrow failpoint hook and regression test that reproduces the stale-read window when primary cache update lags.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LFU cache correctness to avoid overwriting newer entries during evictions and to ensure Get returns the latest statistics table during concurrent updates.

* **Tests**
  * Added concurrency tests validating behavior when primary-cache updates are delayed and ensuring drop/memory operations do not replace newer tables.

* **Chores**
  * Updated build/test configuration and adjusted LFU test sharding and test dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->