### PR TITLE
session: disable optimistic retry for LOAD DATA LOCAL INFILE

### DIFF
--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3869,3 +3869,111 @@ func TestIssue62673(t *testing.T) {
 		}
 	})
 }
+
+// TestLoadDataLocalRetryDesync reproduces a protocol desync bug where TiDB's
+// optimistic transaction retry re-executes LOAD DATA LOCAL INFILE from
+// StmtHistory, sending a second 0xfb LOCAL_INFILE_REQUEST to a client that
+// is waiting for OK/ERR. This corrupts the MySQL protocol framing.
+//
+// Root cause: LOAD DATA LOCAL is incorrectly added to StmtHistory (in
+// finishStmt) because it is not excluded from the CouldRetry path. File
+// data is a one-shot network resource and cannot be replayed.
+func TestLoadDataLocalRetryDesync(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+	ts.RunTests(t, func(c *mysql.Config) {
+		c.AllowAllFiles = true
+	}, func(dbt *testkit.DBTestKit) {
+		ctx := context.Background()
+
+		filePath := filepath.Join(t.TempDir(), "retry_desync.csv")
+		mysql.RegisterLocalFile(filePath)
+		err := os.WriteFile(filePath, []byte("1\n2\n3\n"), os.ModePerm)
+		require.NoError(t, err)
+
+		conn, err := dbt.GetDB().Conn(ctx)
+		require.NoError(t, err)
+
+		testserverclient.MustExec(ctx, t, conn, "create table t_retry_desync (a int)")
+
+		// Must use optimistic txn mode — pessimistic skips the retry path.
+		testserverclient.MustExec(ctx, t, conn, "SET tidb_txn_mode = 'optimistic'")
+
+		// Inject kv.ErrTxnRetryable during txn commit to trigger optimistic
+		// transaction retry. Fire once so the retry's commit can succeed.
+		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/session/mockCommitError8942",
+			`1*return(true)->return(false)`)
+
+		// Execute LOAD DATA LOCAL INFILE.
+		// Before fix: session.retry() re-executes the statement from StmtHistory,
+		// calling LoadDataExec.Open() again which sends a second 0xfb
+		// LOCAL_INFILE_REQUEST → client gets ErrMalformPkt → protocol desync.
+		// After fix: CouldRetry is set to false for LOAD DATA LOCAL, so the
+		// commit error is returned to the client without retry attempt.
+		_, loadErr := conn.ExecContext(ctx, fmt.Sprintf(
+			"LOAD DATA LOCAL INFILE '%s' INTO TABLE t_retry_desync", filePath))
+		// The commit error should propagate to the client.
+		require.Error(t, loadErr, "LOAD DATA should return commit error instead of retrying")
+		t.Logf("LOAD DATA result: %v", loadErr)
+
+		// The connection must remain usable — no protocol desync.
+		var val int
+		err = conn.QueryRowContext(ctx, "SELECT 1").Scan(&val)
+		require.NoError(t, err, "connection should be usable after LOAD DATA commit error")
+		require.Equal(t, 1, val)
+	})
+}
+
+// TestLoadDataLocalRetryDesyncExplicitTxn is the explicit-transaction variant
+// of TestLoadDataLocalRetryDesync. It verifies that in a multi-statement
+// optimistic transaction (BEGIN; INSERT; LOAD DATA LOCAL; COMMIT), the
+// CouldRetry=false set by LOAD DATA LOCAL correctly prevents retry and that
+// neither the INSERT nor the LOAD DATA rows are committed.
+func TestLoadDataLocalRetryDesyncExplicitTxn(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+	ts.RunTests(t, func(c *mysql.Config) {
+		c.AllowAllFiles = true
+	}, func(dbt *testkit.DBTestKit) {
+		ctx := context.Background()
+
+		filePath := filepath.Join(t.TempDir(), "retry_desync_txn.csv")
+		mysql.RegisterLocalFile(filePath)
+		err := os.WriteFile(filePath, []byte("10\n20\n30\n"), os.ModePerm)
+		require.NoError(t, err)
+
+		conn, err := dbt.GetDB().Conn(ctx)
+		require.NoError(t, err)
+
+		testserverclient.MustExec(ctx, t, conn, "create table t_retry_txn (a int)")
+		testserverclient.MustExec(ctx, t, conn, "SET tidb_txn_mode = 'optimistic'")
+		// Enable retry for explicit transactions.
+		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/sessiontxn/isolation/injectOptimisticTxnRetryable", "return(true)")
+		// Inject one retryable commit error.
+		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/session/mockCommitError8942",
+			`1*return(true)->return(false)`)
+
+		// Explicit transaction: INSERT then LOAD DATA LOCAL.
+		testserverclient.MustExec(ctx, t, conn, "BEGIN")
+		testserverclient.MustExec(ctx, t, conn, "INSERT INTO t_retry_txn VALUES (1)")
+		_, loadErr := conn.ExecContext(ctx, fmt.Sprintf(
+			"LOAD DATA LOCAL INFILE '%s' INTO TABLE t_retry_txn", filePath))
+		require.NoError(t, loadErr, "LOAD DATA should succeed within the transaction")
+
+		// COMMIT should fail because CouldRetry=false prevents retry.
+		_, commitErr := conn.ExecContext(ctx, "COMMIT")
+		require.Error(t, commitErr, "COMMIT should return error since retry is disabled for LOAD DATA LOCAL")
+		require.Contains(t, commitErr.Error(), "8022", "should be kv.ErrTxnRetryable (error code 8022)")
+		t.Logf("COMMIT result: %v", commitErr)
+
+		// Neither INSERT nor LOAD DATA rows should be committed.
+		var count int
+		err = conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM t_retry_txn").Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 0, count, "no rows should be committed after failed transaction")
+
+		// Connection must remain usable.
+		var val int
+		err = conn.QueryRowContext(ctx, "SELECT 1").Scan(&val)
+		require.NoError(t, err, "connection should be usable after failed explicit txn")
+		require.Equal(t, 1, val)
+	})
+}

--- a/pkg/session/tidb.go
+++ b/pkg/session/tidb.go
@@ -221,9 +221,17 @@ func finishStmt(ctx context.Context, se *session, meetsErr error, sql sqlexec.St
 		}
 	})
 	if !sql.IsReadOnly(sessVars) {
-		// All the history should be added here.
 		if meetsErr == nil && sessVars.TxnCtx.CouldRetry {
-			GetHistory(se).Add(sql, sessVars.StmtCtx)
+			// Add only retry-safe write statements to StmtHistory.
+			// LOAD DATA LOCAL INFILE uses a one-shot client file stream via
+			// the 0xfb protocol; retrying would desync the connection.
+			// Disable retry instead of recording it. Only LOCAL is affected;
+			// non-LOCAL reads from server/remote storage and can be safely retried.
+			if isLoadDataLocal(sql) {
+				sessVars.TxnCtx.CouldRetry = false
+			} else {
+				GetHistory(se).Add(sql, sessVars.StmtCtx)
+			}
 		}
 
 		// Handle the stmt commit/rollback.
@@ -251,6 +259,14 @@ func finishStmt(ctx context.Context, se *session, meetsErr error, sql sqlexec.St
 		return err
 	}
 	return checkStmtLimit(ctx, se, true)
+}
+
+// isLoadDataLocal returns true if the statement is LOAD DATA LOCAL INFILE.
+func isLoadDataLocal(sql sqlexec.Statement) bool {
+	if s, ok := sql.GetStmtNode().(*ast.LoadDataStmt); ok {
+		return s.FileLocRef == ast.FileLocClient
+	}
+	return false
 }
 
 func autoCommitAfterStmt(ctx context.Context, se *session, meetsErr error, sql sqlexec.Statement) error {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67663

Problem Summary:

`LOAD DATA LOCAL INFILE` uses a one-shot client file stream via the MySQL 0xfb LOCAL_INFILE_REQUEST protocol. When an optimistic transaction commit fails with a retryable error, session.retry() re-executes the statement from StmtHistory, sending a second 0xfb request to a client already waiting for OK/ERR. This desynchronizes the MySQL protocol, causing the connection to hang permanently or return malformed packet errors.

### What changed and how does it work?

In finishStmt(), detect LOAD DATA LOCAL INFILE and set `TxnCtx.CouldRetry = false` to prevent retry. The commit error is propagated to the client instead.

Only affects LOAD DATA LOCAL INFILE (FileLocClient). Server-side LOAD DATA INFILE (FileLocServerOrRemote) is unaffected.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed behavior for LOAD DATA LOCAL INFILE in optimistic transactions so commit errors are returned to clients instead of causing silent retries; connections remain usable afterward.

* **Tests**
  * Added regression tests covering LOAD DATA LOCAL INFILE with optimistic retry, including explicit-transaction scenarios, to ensure correct error propagation and no partial commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->