### PR TITLE
executor: reduce TestDistSQLSharedKVRequestRace iterations to fix CI timeout

### DIFF
--- a/pkg/executor/test/distsqltest/distsql_test.go
+++ b/pkg/executor/test/distsqltest/distsql_test.go
@@ -138,7 +138,7 @@ func TestDistSQLSharedKVRequestRace(t *testing.T) {
 		// Few iterations suffice: Go's race detector is deterministic (catches on first
 		// occurrence), and RequestBuilder.used guards reuse at build time. Keep this low
 		// to stay well under the Bazel "moderate" timeout with -race enabled.
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			// index lookup
 			tk.MustQuery("select * from t force index(ic) order by c asc limit 500").Check(testkit.Rows(expects...))
 			// index merge

--- a/pkg/executor/test/distsqltest/distsql_test.go
+++ b/pkg/executor/test/distsqltest/distsql_test.go
@@ -135,6 +135,9 @@ func TestDistSQLSharedKVRequestRace(t *testing.T) {
 	}
 	for _, mode := range replicaReadModes {
 		tk.MustExec(fmt.Sprintf("set session tidb_replica_read = '%s'", mode))
+		// Few iterations suffice: Go's race detector is deterministic (catches on first
+		// occurrence), and RequestBuilder.used guards reuse at build time. Keep this low
+		// to stay well under the Bazel "moderate" timeout with -race enabled.
 		for i := 0; i < 5; i++ {
 			// index lookup
 			tk.MustQuery("select * from t force index(ic) order by c asc limit 500").Check(testkit.Rows(expects...))

--- a/pkg/executor/test/distsqltest/distsql_test.go
+++ b/pkg/executor/test/distsqltest/distsql_test.go
@@ -135,7 +135,7 @@ func TestDistSQLSharedKVRequestRace(t *testing.T) {
 	}
 	for _, mode := range replicaReadModes {
 		tk.MustExec(fmt.Sprintf("set session tidb_replica_read = '%s'", mode))
-		for i := 0; i < 20; i++ {
+		for i := 0; i < 5; i++ {
 			// index lookup
 			tk.MustQuery("select * from t force index(ic) order by c asc limit 500").Check(testkit.Rows(expects...))
 			// index merge


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref xxx

Problem Summary:
`TestDistSQLSharedKVRequestRace` frequently times out in CI (`pull_unit_test_next_gen`). With the race detector enabled, the test runs 5 replica-read modes × 20 iterations × 2 queries = 200 queries on a partitioned table, taking ~278s on CI — dangerously close to the 5-minute Bazel "moderate" timeout. This causes flaky timeouts ([example](https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_unit_test_next_gen/367/)).

### What changed and how does it work?

Reduce the inner loop iterations from 20 to 5 (total queries: 200 → 50). The race detector catches data races deterministically on first occurrence, and the `RequestBuilder.used` safety check (added in #61376) catches any builder-reuse regression even with a single iteration. 5 iterations is more than sufficient for confidence.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reduced iteration count in a distributed SQL test to improve test run performance while preserving the same SQL checks and validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->