### PR TITLE
pkg/server: avoid session close race during graceful drain

### DIFF
--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -919,41 +919,49 @@ func TestShutDown(t *testing.T) {
 	require.NoError(t, err)
 	srv.SetDomain(dom)
 
-	cc = &clientConn{server: srv}
-	cc.SetCtx(tc)
-
-	waitMap := [][]bool{
-		// Reading, Not Reading
-		{false, true}, // Not InTxn
-		{true, true},  // InTxn
+	waitCases := []struct {
+		name       string
+		inTxn      bool
+		reading    bool
+		shouldWait bool
+	}{
+		{name: "not-in-txn-reading", inTxn: false, reading: true, shouldWait: false},
+		{name: "not-in-txn-dispatching", inTxn: false, reading: false, shouldWait: true},
+		{name: "in-txn-reading", inTxn: true, reading: true, shouldWait: true},
+		{name: "in-txn-dispatching", inTxn: true, reading: false, shouldWait: true},
 	}
-	for idx, waitMap := range waitMap {
-		inTxn := idx > 0
-		for idx, shouldWait := range waitMap {
-			reading := idx == 0
-			if inTxn {
-				cc.getCtx().GetSessionVars().SetInTxn(true)
+	for _, tt := range waitCases {
+		t.Run(tt.name, func(t *testing.T) {
+			caseSession, err := session.CreateSession4Test(store)
+			require.NoError(t, err)
+			caseConn := &clientConn{server: srv}
+			caseConn.SetCtx(&TiDBContext{Session: caseSession})
+			caseConn.getCtx().GetSessionVars().SetInTxn(tt.inTxn)
+			if tt.reading {
+				caseConn.setStatus(connStatusReading)
 			} else {
-				cc.getCtx().GetSessionVars().SetInTxn(false)
-			}
-			if reading {
-				cc.CompareAndSwapStatus(cc.getStatus(), connStatusReading)
-			} else {
-				cc.CompareAndSwapStatus(cc.getStatus(), connStatusDispatching)
+				caseConn.setStatus(connStatusDispatching)
 			}
 
-			srv.clients[dom.NextConnID()] = cc
+			connID := dom.NextConnID()
+			srv.clients[connID] = caseConn
 
 			waitTime := 100 * time.Millisecond
 			begin := time.Now()
 			srv.DrainClients(waitTime, waitTime)
-
-			if shouldWait {
+			if tt.shouldWait {
 				require.Greater(t, time.Since(begin), waitTime)
 			} else {
 				require.Less(t, time.Since(begin), waitTime)
 			}
-		}
+
+			// `DrainClients` should notify and cancel active work first, instead of directly
+			// closing the session from another goroutine.
+			require.Equal(t, int32(connStatusWaitShutdown), caseConn.getStatus())
+			_, ok := srv.clients[connID]
+			require.True(t, ok)
+			require.NoError(t, caseConn.Close())
+		})
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1046,11 +1046,14 @@ func (s *Server) KillAllConnections() {
 	s.rwlock.RLock()
 	defer s.rwlock.RUnlock()
 	for _, conn := range s.clients {
-		conn.setStatus(connStatusShutdown)
-		if err := conn.closeWithoutLock(); err != nil {
-			terror.Log(err)
-		}
+		// Don't close the session from this goroutine directly. If the connection is
+		// dispatching a statement, closing the session concurrently may race with SQL
+		// execution and invalidate txn state unexpectedly.
+		conn.setStatus(connStatusWaitShutdown)
 		if conn.bufReadConn != nil {
+			if err := conn.bufReadConn.SetWriteDeadline(time.Now()); err != nil {
+				logutil.BgLogger().Warn("error setting write deadline for kill.", zap.Error(err))
+			}
 			if err := conn.bufReadConn.SetReadDeadline(time.Now()); err != nil {
 				logutil.BgLogger().Warn("error setting read deadline for kill.", zap.Error(err))
 			}


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54859

Problem Summary:
`DrainClients -> KillAllConnections` closes sessions from another goroutine via `closeWithoutLock()`. During graceful shutdown, this can race with an in-flight autocommit statement (for example `INSERT ... ON DUPLICATE KEY UPDATE`) and invalidate txn state while SQL execution is still running, causing panic in `LazyTxn` access.

### What changed and how does it work?
- Change `KillAllConnections` to stop doing direct `closeWithoutLock()`.
- Keep shutdown behavior by setting `connStatusWaitShutdown`, sending kill signal, and setting read/write deadlines.
- Let each connection goroutine exit and close its own session instead of cross-goroutine close.
- Extend `TestShutDown` assertions to verify drain timeout path notifies/cancels active work instead of direct close.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a panic risk during graceful shutdown when force-closing active connections.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved connection shutdown test coverage with expanded test case scenarios.

* **Refactor**
  * Enhanced server connection shutdown process for more graceful termination of active database connections with improved timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->