### PR TITLE
bazel: add mirror for rules_proto

### DIFF
--- a/.github/workflows/update-bazel-files.yml
+++ b/.github/workflows/update-bazel-files.yml
@@ -29,14 +29,29 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_REF: ${{ github.event.workflow_run.head_branch }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
 
-          pr_number="$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}" --jq '.pull_requests[0].number')"
+          pr_number="$(
+            gh api "repos/${REPOSITORY}/pulls" \
+              --method GET \
+              -f state=open \
+              -f head="${HEAD_OWNER}:${HEAD_REF}" \
+              --jq '.[0].number'
+          )"
+
+          if [[ -z "${pr_number}" || "${pr_number}" == "null" ]]; then
+            echo "Unable to resolve pull request for ${HEAD_OWNER}:${HEAD_REF}." >&2
+            exit 1
+          fi
+
           head_repo="$(gh api "repos/${REPOSITORY}/pulls/${pr_number}" --jq '.head.repo.full_name')"
           head_ref="$(gh api "repos/${REPOSITORY}/pulls/${pr_number}" --jq '.head.ref')"
           pr_head_sha="$(gh api "repos/${REPOSITORY}/pulls/${pr_number}" --jq '.head.sha')"
-          run_head_sha="$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}" --jq '.head_sha')"
 
           printf 'pr_number=%s\n' "${pr_number}" >> "${GITHUB_OUTPUT}"
           printf 'head_repo=%s\n' "${head_repo}" >> "${GITHUB_OUTPUT}"
@@ -49,7 +64,7 @@ jobs:
 
           echo "same_repo=true" >> "${GITHUB_OUTPUT}"
 
-          if [[ "${pr_head_sha}" != "${run_head_sha}" ]]; then
+          if [[ "${pr_head_sha}" != "${RUN_HEAD_SHA}" ]]; then
             echo "stale=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -160,6 +160,9 @@ http_archive(
     strip_prefix = "rules_proto-6.0.0",
     urls = [
         "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
+        "https://cache.hawkingrei.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
+        "http://bazel-cache.pingcap.net:8080/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
+        "http://ats.apps.svc/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

```
Download from https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException GET returned 502 Bad Gateway or Proxy Error

ERROR: An error occurred during the fetch of repository 'rules_proto':

   Traceback (most recent call last):

	File "/home/jenkins/.tidb/tmp/903aa8c667333396b92cebbde26882dc/external/bazel_tools/tools/build_defs/repo/http.bzl", line 132, column 45, in _http_archive_impl

		download_info = ctx.download_and_extract(

Error in download_and_extract: java.io.IOException: Error downloading [https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz] to /home/jenkins/.tidb/tmp/903aa8c667333396b92cebbde26882dc/external/rules_proto/temp13923969556053647191/rules_proto-6.0.0.tar.gz: GET returned 502 Bad Gateway or Proxy Error

ERROR: /home/jenkins/agent/workspace/pingcap/tidb/ghpr_check2/tidb/WORKSPACE:131:13: fetching http_archive rule //external:rules_proto: Traceback (most recent call last):

	File "/home/jenkins/.tidb/tmp/903aa8c667333396b92cebbde26882dc/external/bazel_tools/tools/build_defs/repo/http.bzl", line 132, column 45, in _http_archive_impl

		download_info = ctx.download_and_extract(

Error in download_and_extract: java.io.IOException: Error downloading [https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz] to /home/jenkins/.tidb/tmp/903aa8c667333396b92cebbde26882dc/external/rules_proto/temp13923969556053647191/rules_proto-6.0.0.tar.gz: GET returned 502 Bad Gateway or Proxy Error

ERROR: Error computing the main repository mapping: no such package '@rules_proto//proto': java.io.IOException: Error downloading [https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz] to /home/jenkins/.tidb/tmp/903aa8c667333396b92cebbde26882dc/external/rules_proto/temp13923969556053647191/rules_proto-6.0.0.tar.gz: GET returned 502 Bad Gateway or Proxy Error

make: *** [Makefile:679: bazel_ci_simple_prepare] Error 1
```
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added alternative download mirrors for a core dependency to improve build reliability and reduce download failures.
  * Improved CI workflow PR detection and stale-run checks so pull request context is resolved more reliably and runs fail fast if the PR cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->