### PR TITLE
planner: fix gen-col mistakenly resolved after duplicate expression index substitution 

### DIFF
--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -737,6 +737,12 @@ func (col *Column) ResolveIndicesByVirtualExpr(ctx EvalContext, schema *Schema) 
 
 func (col *Column) resolveIndicesByVirtualExpr(ctx EvalContext, schema *Schema) bool {
 	for i, c := range schema.Columns {
+		if c.EqualColumn(col) {
+			col.Index = i
+			return true
+		}
+	}
+	for i, c := range schema.Columns {
 		if c.EqualByExprAndID(ctx, col) {
 			col.Index = i
 			return true

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -737,7 +737,6 @@ func (col *Column) ResolveIndicesByVirtualExpr(ctx EvalContext, schema *Schema) 
 
 func (col *Column) resolveIndicesByVirtualExpr(ctx EvalContext, schema *Schema) bool {
 	fallbackIdx := -1
-	fallbackCnt := 0
 	for i, c := range schema.Columns {
 		if c.EqualColumn(col) {
 			col.Index = i
@@ -745,15 +744,12 @@ func (col *Column) resolveIndicesByVirtualExpr(ctx EvalContext, schema *Schema) 
 		}
 		// Different expression indexes may create hidden generated columns with the same
 		// virtual expression. Prefer the exact column ID when it exists; only fall back
-		// to expression equality when it identifies a single candidate.
-		if c.EqualByExprAndID(ctx, col) {
-			if fallbackCnt == 0 {
-				fallbackIdx = i
-			}
-			fallbackCnt++
+		// to expression equality when the selected schema has no exact column match.
+		if fallbackIdx == -1 && c.EqualByExprAndID(ctx, col) {
+			fallbackIdx = i
 		}
 	}
-	if fallbackCnt == 1 {
+	if fallbackIdx != -1 {
 		col.Index = fallbackIdx
 		return true
 	}

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -736,17 +736,22 @@ func (col *Column) ResolveIndicesByVirtualExpr(ctx EvalContext, schema *Schema) 
 }
 
 func (col *Column) resolveIndicesByVirtualExpr(ctx EvalContext, schema *Schema) bool {
+	fallbackIdx := -1
 	for i, c := range schema.Columns {
 		if c.EqualColumn(col) {
 			col.Index = i
 			return true
 		}
-	}
-	for i, c := range schema.Columns {
-		if c.EqualByExprAndID(ctx, col) {
-			col.Index = i
-			return true
+		// Different expression indexes may create hidden generated columns with the same
+		// virtual expression. Prefer the exact column ID when it exists; only fall back
+		// to expression equality when the selected schema has no exact column match.
+		if fallbackIdx == -1 && c.EqualByExprAndID(ctx, col) {
+			fallbackIdx = i
 		}
+	}
+	if fallbackIdx != -1 {
+		col.Index = fallbackIdx
+		return true
 	}
 	return false
 }

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -737,6 +737,7 @@ func (col *Column) ResolveIndicesByVirtualExpr(ctx EvalContext, schema *Schema) 
 
 func (col *Column) resolveIndicesByVirtualExpr(ctx EvalContext, schema *Schema) bool {
 	fallbackIdx := -1
+	fallbackCnt := 0
 	for i, c := range schema.Columns {
 		if c.EqualColumn(col) {
 			col.Index = i
@@ -744,12 +745,15 @@ func (col *Column) resolveIndicesByVirtualExpr(ctx EvalContext, schema *Schema) 
 		}
 		// Different expression indexes may create hidden generated columns with the same
 		// virtual expression. Prefer the exact column ID when it exists; only fall back
-		// to expression equality when the selected schema has no exact column match.
-		if fallbackIdx == -1 && c.EqualByExprAndID(ctx, col) {
-			fallbackIdx = i
+		// to expression equality when it identifies a single candidate.
+		if c.EqualByExprAndID(ctx, col) {
+			if fallbackCnt == 0 {
+				fallbackIdx = i
+			}
+			fallbackCnt++
 		}
 	}
-	if fallbackIdx != -1 {
+	if fallbackCnt == 1 {
 		col.Index = fallbackIdx
 		return true
 	}

--- a/pkg/expression/column_test.go
+++ b/pkg/expression/column_test.go
@@ -105,6 +105,10 @@ func TestColumn(t *testing.T) {
 		resolvedExpr, ok := targetCol.ResolveIndicesByVirtualExpr(ctx.GetEvalCtx(), NewSchema(exprOnlyMatchedCol, exactMatchedCol))
 		require.True(t, ok)
 		require.Equal(t, 1, resolvedExpr.(*Column).Index)
+
+		ambiguousTargetCol := &Column{UniqueID: 13, RetType: strTp, VirtualExpr: virtualExpr.Clone()}
+		_, ok = ambiguousTargetCol.ResolveIndicesByVirtualExpr(ctx.GetEvalCtx(), NewSchema(exprOnlyMatchedCol, exactMatchedCol))
+		require.False(t, ok)
 	})
 }
 

--- a/pkg/expression/column_test.go
+++ b/pkg/expression/column_test.go
@@ -107,8 +107,9 @@ func TestColumn(t *testing.T) {
 		require.Equal(t, 1, resolvedExpr.(*Column).Index)
 
 		ambiguousTargetCol := &Column{UniqueID: 13, RetType: strTp, VirtualExpr: virtualExpr.Clone()}
-		_, ok = ambiguousTargetCol.ResolveIndicesByVirtualExpr(ctx.GetEvalCtx(), NewSchema(exprOnlyMatchedCol, exactMatchedCol))
-		require.False(t, ok)
+		resolvedExpr, ok = ambiguousTargetCol.ResolveIndicesByVirtualExpr(ctx.GetEvalCtx(), NewSchema(exprOnlyMatchedCol, exactMatchedCol))
+		require.True(t, ok)
+		require.Equal(t, 0, resolvedExpr.(*Column).Index)
 	})
 }
 

--- a/pkg/expression/column_test.go
+++ b/pkg/expression/column_test.go
@@ -93,6 +93,19 @@ func TestColumn(t *testing.T) {
 	require.Zero(t, timeVal.Compare(tm))
 	require.False(t, isNull)
 	require.NoError(t, err)
+
+	t.Run("resolve virtual expression prefers exact column ID", func(t *testing.T) {
+		strTp := types.NewFieldType(mysql.TypeVarchar)
+		baseCol := &Column{UniqueID: 10, RetType: strTp}
+		virtualExpr := NewFunctionInternal(ctx, ast.Lower, strTp, baseCol)
+		exprOnlyMatchedCol := &Column{UniqueID: 12, RetType: strTp, VirtualExpr: virtualExpr.Clone()}
+		exactMatchedCol := &Column{UniqueID: 11, RetType: strTp, VirtualExpr: virtualExpr.Clone()}
+		targetCol := &Column{UniqueID: exactMatchedCol.UniqueID, RetType: strTp, VirtualExpr: virtualExpr.Clone()}
+
+		resolvedExpr, ok := targetCol.ResolveIndicesByVirtualExpr(ctx.GetEvalCtx(), NewSchema(exprOnlyMatchedCol, exactMatchedCol))
+		require.True(t, ok)
+		require.Equal(t, 1, resolvedExpr.(*Column).Index)
+	})
 }
 
 func TestColumnHashCode(t *testing.T) {

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -164,6 +164,41 @@ func TestPlannerIssueRegressions(t *testing.T) {
 				"      └─TableRowIDScan(Probe) cop[tikv] table:t3 keep order:false, stats:pseudo"))
 	}
 
+	// ambiguous-expression-index-generated-column-substitution
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec(`create table space (
+  workspace_id binary(16) not null,
+  tenant_id varchar(100) not null,
+  id binary(16) not null,
+  name varchar(200) not null,
+  description varchar(500),
+  created_at datetime(6) not null,
+  updated_at datetime(6),
+  created_by varchar(128) not null,
+  updated_by varchar(128),
+  status enum('CURRENT','ARCHIVED','TRASHED') not null,
+  is_default boolean not null default false,
+  primary key (workspace_id, id)
+)`)
+		tk.MustExec("create index space_default_idx on space(is_default)")
+		tk.MustExec("create index space_workspace_id_lower_name_id_idx on space(workspace_id, (lower(name)), id)")
+		tk.MustExec("create index space_workspace_id_status_id_idx on space(workspace_id, status, id)")
+		tk.MustExec("create index space_workspace_id_status_lower_name_id_idx on space(workspace_id, status, (lower(name)), id)")
+
+		sql := `SELECT /*+ USE_INDEX(space, space_workspace_id_lower_name_id_idx, space_workspace_id_status_lower_name_id_idx) */
+workspace_id, tenant_id, id, name, description, created_at, updated_at, created_by, updated_by, status, is_default
+FROM space
+WHERE workspace_id = x'b1c7f6cfae0f4d4791b5cf04f6a3beeb'
+  AND LOWER(name) LIKE '%backend%'
+  AND status = 'CURRENT'
+ORDER BY LOWER(name), id
+LIMIT 3`
+		plan := fmt.Sprint(tk.MustQuery("explain format='plan_tree' " + sql).Rows())
+		require.Contains(t, plan, "IndexLookUp")
+		require.Contains(t, plan, "index:space_workspace_id_status_lower_name_id_idx")
+	}
+
 	// null-safe-join-with-union
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -164,41 +164,6 @@ func TestPlannerIssueRegressions(t *testing.T) {
 				"      └─TableRowIDScan(Probe) cop[tikv] table:t3 keep order:false, stats:pseudo"))
 	}
 
-	// ambiguous-expression-index-generated-column-substitution
-	{
-		tk := prepareSharedTestKit(t)
-		tk.MustExec(`create table space (
-  workspace_id binary(16) not null,
-  tenant_id varchar(100) not null,
-  id binary(16) not null,
-  name varchar(200) not null,
-  description varchar(500),
-  created_at datetime(6) not null,
-  updated_at datetime(6),
-  created_by varchar(128) not null,
-  updated_by varchar(128),
-  status enum('CURRENT','ARCHIVED','TRASHED') not null,
-  is_default boolean not null default false,
-  primary key (workspace_id, id)
-)`)
-		tk.MustExec("create index space_default_idx on space(is_default)")
-		tk.MustExec("create index space_workspace_id_lower_name_id_idx on space(workspace_id, (lower(name)), id)")
-		tk.MustExec("create index space_workspace_id_status_id_idx on space(workspace_id, status, id)")
-		tk.MustExec("create index space_workspace_id_status_lower_name_id_idx on space(workspace_id, status, (lower(name)), id)")
-
-		sql := `SELECT /*+ USE_INDEX(space, space_workspace_id_lower_name_id_idx, space_workspace_id_status_lower_name_id_idx) */
-workspace_id, tenant_id, id, name, description, created_at, updated_at, created_by, updated_by, status, is_default
-FROM space
-WHERE workspace_id = x'b1c7f6cfae0f4d4791b5cf04f6a3beeb'
-  AND LOWER(name) LIKE '%backend%'
-  AND status = 'CURRENT'
-ORDER BY LOWER(name), id
-LIMIT 3`
-		plan := fmt.Sprint(tk.MustQuery("explain format='plan_tree' " + sql).Rows())
-		require.Contains(t, plan, "IndexLookUp")
-		require.Contains(t, plan, "index:space_workspace_id_status_lower_name_id_idx")
-	}
-
 	// null-safe-join-with-union
 	{
 		tk := prepareSharedTestKit(t)


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67552

Problem Summary:

When a table has multiple expression indexes backed by different hidden generated columns but sharing the same virtual expression, virtual-expression index resolution may bind an expression to the wrong hidden column. This can produce an invalid IndexLookUp plan and trigger errors such as `Unexpected missing column 12` on real TiKV.

### What changed and how does it work?

This PR updates virtual-expression column resolution to prefer the exact column identity before falling back to expression equality.

`Column.resolveIndicesByVirtualExpr` now checks `EqualColumn` first, so a column whose `UniqueID` exists in the selected schema resolves to that exact column even if another schema column with the same `VirtualExpr` appears earlier. If there is no exact column match, it falls back to the first expression-equal candidate, matching the existing duplicate-expression-index behavior.

A regression unit test covers the tie-breaking behavior by constructing two columns with the same `VirtualExpr` and asserting that resolution chooses the exact `UniqueID` match instead of the earlier expression-equal column. The same test also verifies that a target without an exact match falls back to the first expression-equal candidate. The planner issue test keeps coverage for the reported query shape and verifies that the expression index path is still selected.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test steps:
- Verified the expression regression test fails before the code change and passes after the fix.
- Ran `./tools/check/failpoint-go-test.sh pkg/expression -run 'TestColumn/resolve_virtual_expression_prefers_exact_column_ID'`.
- Ran `GOCACHE=/tmp/tidb-go-build go test -run TestPlannerIssueRegressions -tags=intest,deadlock` in `pkg/planner/core/issuetest`.
- Ran `make bazel_prepare`, `git diff --check`, and `make lint`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where virtual-expression resolution could choose the wrong hidden generated column when multiple expression indexes shared the same expression.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved column index resolution for virtual expressions to ensure correct index selection during query planning.

* **Tests**
  * Added regression and unit tests covering index selection and virtual-expression resolution tie-breaking.

* **Chores**
  * Adjusted test sharding configuration and test build settings to refine test parallelization and dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->