### PR TITLE
lightning/web: add deprecation warning to README

### DIFF
--- a/lightning/web/README.md
+++ b/lightning/web/README.md
@@ -1,6 +1,15 @@
 TiDB Lightning Web Interface
 ============================
 
+> **Warning:**
+>
+> The TiDB Lightning Web Interface is deprecated as of v8.5.6 and will be
+> removed in v8.5.7. The web UI build has been broken since v8.4.0. Use the
+> [`tidb-lightning` CLI](https://docs.pingcap.com/tidb/stable/tidb-lightning-overview/)
+> or the [`IMPORT INTO`](https://docs.pingcap.com/tidb/stable/sql-statement-import-into/)
+> statement instead. If this affects your workflow, please comment on
+> [#67697](https://github.com/pingcap/tidb/issues/67697).
+
 TiDB Lightning provides a web interface for local monitoring task control. The
 app is written using [Material-UI] based on [React].
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67697

Problem Summary:

### What changed and how does it work?
- Add a deprecation warning banner to `lightning/web/README.md`
- The Lightning Web Interface is deprecated as of v8.5.6 and will be removed in v8.5.7
- Directs users to the `tidb-lightning` CLI and `IMPORT INTO` statement as alternatives

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notice for TiDB Lightning Web Interface (deprecated as of v8.5.6, removal scheduled for v8.5.7)
  * Web UI build broken since v8.4.0
  * Users should migrate to `tidb-lightning` CLI or `IMPORT INTO` SQL statement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->