### PR TITLE
importsdk: redact sensitive source params in outward-facing errors

### DIFF
--- a/pkg/importsdk/BUILD.bazel
+++ b/pkg/importsdk/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//pkg/util/table-filter",
         "@com_github_data_dog_go_sqlmock//:go-sqlmock",
         "@com_github_fsouza_fake_gcs_server//fakestorage",
+        "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_ngaut_pools//:pools",
         "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",

--- a/pkg/importsdk/file_scanner.go
+++ b/pkg/importsdk/file_scanner.go
@@ -48,7 +48,6 @@ type FileScanner interface {
 }
 
 type fileScanner struct {
-	sourcePath         string
 	redactedSourcePath string
 	db                 *sql.DB
 	store              storeapi.Storage
@@ -57,12 +56,20 @@ type fileScanner struct {
 	config             *SDKConfig
 }
 
+const redactedInvalidSourcePath = "<redacted-invalid-source>"
+
 // NewFileScanner creates a new FileScanner
 func NewFileScanner(ctx context.Context, sourcePath string, db *sql.DB, cfg *SDKConfig) (FileScanner, error) {
 	redactedSourcePath := ast.RedactURL(sourcePath)
+	parseErrorSourcePath := redactedSourcePath
+	if parseErrorSourcePath == sourcePath {
+		// ast.RedactURL leaves malformed or unsupported URLs unchanged.
+		// Avoid exposing the original source in outward-facing parse errors.
+		parseErrorSourcePath = redactedInvalidSourcePath
+	}
 	u, err := objstore.ParseBackend(sourcePath, nil)
 	if err != nil {
-		return nil, errors.Annotatef(ErrParseStorageURL, "source=%s", redactedSourcePath)
+		return nil, errors.Annotatef(ErrParseStorageURL, "source=%s", parseErrorSourcePath)
 	}
 	store, err := objstore.New(ctx, u, &storeapi.Options{})
 	if err != nil {
@@ -97,7 +104,6 @@ func NewFileScanner(ctx context.Context, sourcePath string, db *sql.DB, cfg *SDK
 	}
 
 	return &fileScanner{
-		sourcePath:         sourcePath,
 		redactedSourcePath: redactedSourcePath,
 		db:                 db,
 		store:              store,

--- a/pkg/importsdk/file_scanner.go
+++ b/pkg/importsdk/file_scanner.go
@@ -17,7 +17,6 @@ package importsdk
 import (
 	"context"
 	"database/sql"
-	"regexp"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -60,10 +59,10 @@ type fileScanner struct {
 
 // NewFileScanner creates a new FileScanner
 func NewFileScanner(ctx context.Context, sourcePath string, db *sql.DB, cfg *SDKConfig) (FileScanner, error) {
-	redactedSourcePath := redactSourcePath(sourcePath)
+	redactedSourcePath := ast.RedactURL(sourcePath)
 	u, err := objstore.ParseBackend(sourcePath, nil)
 	if err != nil {
-		return nil, errors.Annotatef(ErrParseStorageURL, "source=%s, err=%v", redactedSourcePath, err)
+		return nil, errors.Annotatef(ErrParseStorageURL, "source=%s", redactedSourcePath)
 	}
 	store, err := objstore.New(ctx, u, &storeapi.Options{})
 	if err != nil {
@@ -234,14 +233,6 @@ func (s *fileScanner) EstimateImportDataSize(ctx context.Context) (*ImportDataSi
 		}
 	}
 	return result, nil
-}
-
-var sensitiveSourcePathPattern = regexp.MustCompile(`(?i)(access[-_]key|secret[-_]access[-_]key|session[-_]token|sas[-_]token)=([^&#]*)`)
-
-// redactSourcePath redacts known secret parameters even when the storage URL is
-// malformed or uses a scheme not covered by ast.RedactURL.
-func redactSourcePath(sourcePath string) string {
-	return sensitiveSourcePathPattern.ReplaceAllString(ast.RedactURL(sourcePath), `${1}=xxxxxx`)
 }
 
 func (s *fileScanner) Close() error {

--- a/pkg/importsdk/file_scanner.go
+++ b/pkg/importsdk/file_scanner.go
@@ -17,6 +17,7 @@ package importsdk
 import (
 	"context"
 	"database/sql"
+	"regexp"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -48,23 +49,25 @@ type FileScanner interface {
 }
 
 type fileScanner struct {
-	sourcePath string
-	db         *sql.DB
-	store      storeapi.Storage
-	loader     *mydump.MDLoader
-	logger     log.Logger
-	config     *SDKConfig
+	sourcePath         string
+	redactedSourcePath string
+	db                 *sql.DB
+	store              storeapi.Storage
+	loader             *mydump.MDLoader
+	logger             log.Logger
+	config             *SDKConfig
 }
 
 // NewFileScanner creates a new FileScanner
 func NewFileScanner(ctx context.Context, sourcePath string, db *sql.DB, cfg *SDKConfig) (FileScanner, error) {
+	redactedSourcePath := redactSourcePath(sourcePath)
 	u, err := objstore.ParseBackend(sourcePath, nil)
 	if err != nil {
-		return nil, errors.Annotatef(ErrParseStorageURL, "source=%s, err=%v", sourcePath, err)
+		return nil, errors.Annotatef(ErrParseStorageURL, "source=%s, err=%v", redactedSourcePath, err)
 	}
 	store, err := objstore.New(ctx, u, &storeapi.Options{})
 	if err != nil {
-		return nil, errors.Annotatef(ErrCreateExternalStorage, "source=%s, err=%v", sourcePath, err)
+		return nil, errors.Annotatef(ErrCreateExternalStorage, "source=%s, err=%v", redactedSourcePath, err)
 	}
 
 	ldrCfg := mydump.LoaderConfig{
@@ -90,24 +93,25 @@ func NewFileScanner(ctx context.Context, sourcePath string, db *sql.DB, cfg *SDK
 	loader, err := mydump.NewLoaderWithStore(ctx, ldrCfg, store, loaderOptions...)
 	if err != nil {
 		if loader == nil || !errors.ErrorEqual(err, common.ErrTooManySourceFiles) {
-			return nil, errors.Annotatef(ErrCreateLoader, "source=%s, charset=%s, err=%v", sourcePath, cfg.charset, err)
+			return nil, errors.Annotatef(ErrCreateLoader, "source=%s, charset=%s, err=%v", redactedSourcePath, cfg.charset, err)
 		}
 	}
 
 	return &fileScanner{
-		sourcePath: sourcePath,
-		db:         db,
-		store:      store,
-		loader:     loader,
-		logger:     cfg.logger,
-		config:     cfg,
+		sourcePath:         sourcePath,
+		redactedSourcePath: redactedSourcePath,
+		db:                 db,
+		store:              store,
+		loader:             loader,
+		logger:             cfg.logger,
+		config:             cfg,
 	}, nil
 }
 
 func (s *fileScanner) CreateSchemasAndTables(ctx context.Context) error {
 	dbMetas := s.loader.GetDatabases()
 	if len(dbMetas) == 0 {
-		return errors.Annotatef(ErrNoDatabasesFound, "source=%s", s.sourcePath)
+		return errors.Annotatef(ErrNoDatabasesFound, "source=%s", s.redactedSourcePath)
 	}
 
 	// Create all schemas and tables
@@ -121,7 +125,7 @@ func (s *fileScanner) CreateSchemasAndTables(ctx context.Context) error {
 
 	err := importer.Run(ctx, dbMetas)
 	if err != nil {
-		return errors.Annotatef(ErrCreateSchema, "source=%s, db_count=%d, err=%v", s.sourcePath, len(dbMetas), err)
+		return errors.Annotatef(ErrCreateSchema, "source=%s, db_count=%d, err=%v", s.redactedSourcePath, len(dbMetas), err)
 	}
 
 	return nil
@@ -155,7 +159,7 @@ func (s *fileScanner) CreateSchemaAndTableByName(ctx context.Context, schema, ta
 				Tables:     []*mydump.MDTableMeta{tblMeta},
 			}})
 			if err != nil {
-				return errors.Annotatef(ErrCreateSchema, "source=%s, schema=%s, table=%s, err=%v", s.sourcePath, schema, table, err)
+				return errors.Annotatef(ErrCreateSchema, "source=%s, schema=%s, table=%s, err=%v", s.redactedSourcePath, schema, table, err)
 			}
 
 			return nil
@@ -202,7 +206,7 @@ func (s *fileScanner) GetTotalSize(ctx context.Context) int64 {
 func (s *fileScanner) EstimateImportDataSize(ctx context.Context) (*ImportDataSizeEstimate, error) {
 	dbMetas := s.loader.GetDatabases()
 	if len(dbMetas) == 0 {
-		return nil, errors.Annotatef(ErrNoDatabasesFound, "source=%s", s.sourcePath)
+		return nil, errors.Annotatef(ErrNoDatabasesFound, "source=%s", s.redactedSourcePath)
 	}
 
 	result := &ImportDataSizeEstimate{
@@ -230,6 +234,14 @@ func (s *fileScanner) EstimateImportDataSize(ctx context.Context) (*ImportDataSi
 		}
 	}
 	return result, nil
+}
+
+var sensitiveSourcePathPattern = regexp.MustCompile(`(?i)(access[-_]key|secret[-_]access[-_]key|session[-_]token|sas[-_]token)=([^&#]*)`)
+
+// redactSourcePath redacts known secret parameters even when the storage URL is
+// malformed or uses a scheme not covered by ast.RedactURL.
+func redactSourcePath(sourcePath string) string {
+	return sensitiveSourcePathPattern.ReplaceAllString(ast.RedactURL(sourcePath), `${1}=xxxxxx`)
 }
 
 func (s *fileScanner) Close() error {

--- a/pkg/importsdk/file_scanner_test.go
+++ b/pkg/importsdk/file_scanner_test.go
@@ -26,8 +26,10 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	dmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/tidb/pkg/lightning/config"
 	"github.com/pingcap/tidb/pkg/lightning/mydump"
+	tmysql "github.com/pingcap/tidb/pkg/parser/mysql"
 	filter "github.com/pingcap/tidb/pkg/util/table-filter"
 	"github.com/stretchr/testify/require"
 )
@@ -115,6 +117,59 @@ func TestFileScanner(t *testing.T) {
 		err := scanner.CreateSchemasAndTables(ctx)
 		require.NoError(t, err)
 		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("NewFileScannerRedactsSensitiveSourcePathInInitErrors", func(t *testing.T) {
+		_, err := NewFileScanner(
+			ctx,
+			"foo://bucket/path?access-key=ak&secret-access-key=sk&session-token=token",
+			db,
+			cfg,
+		)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "access-key=xxxxxx")
+		require.ErrorContains(t, err, "secret-access-key=xxxxxx")
+		require.ErrorContains(t, err, "session-token=xxxxxx")
+		require.NotContains(t, err.Error(), "access-key=ak")
+		require.NotContains(t, err.Error(), "secret-access-key=sk")
+		require.NotContains(t, err.Error(), "session-token=token")
+	})
+
+	t.Run("CreateSchemasAndTablesRedactsSensitiveSourcePathOnError", func(t *testing.T) {
+		invalidDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(invalidDir, "db1-schema-create.sql"), []byte("CREATE DATABASE db1;"), 0o644))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(invalidDir, "db1.t1-schema.sql"),
+			[]byte("CREATE TABLE t1 (id INT,);"),
+			0o644,
+		))
+
+		invalidDB, invalidMock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer invalidDB.Close()
+
+		invalidScanner, err := NewFileScanner(ctx, "file://"+invalidDir, invalidDB, defaultSDKConfig())
+		require.NoError(t, err)
+		defer invalidScanner.Close()
+
+		fs := invalidScanner.(*fileScanner)
+		fs.sourcePath = "s3://bucket/path?access-key=ak&secret-access-key=sk&session-token=token"
+		fs.redactedSourcePath = "s3://bucket/path?access-key=xxxxxx&secret-access-key=xxxxxx&session-token=xxxxxx"
+
+		invalidMock.ExpectQuery("SELECT SCHEMA_NAME FROM information_schema.SCHEMATA.*").WillReturnRows(sqlmock.NewRows([]string{"SCHEMA_NAME"}))
+		invalidMock.ExpectExec(regexp.QuoteMeta("CREATE DATABASE IF NOT EXISTS `db1`")).WillReturnResult(sqlmock.NewResult(0, 0))
+		invalidMock.ExpectQuery("SHOW CREATE TABLE `db1`.`t1`").WillReturnError(&dmysql.MySQLError{Number: tmysql.ErrNoSuchTable})
+
+		err = invalidScanner.CreateSchemasAndTables(ctx)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "access-key=xxxxxx")
+		require.ErrorContains(t, err, "secret-access-key=xxxxxx")
+		require.ErrorContains(t, err, "session-token=xxxxxx")
+		require.NotContains(t, err.Error(), "access-key=ak")
+		require.NotContains(t, err.Error(), "secret-access-key=sk")
+		require.NotContains(t, err.Error(), "session-token=token")
+		require.ErrorContains(t, err, "invalid schema statement")
+		require.NoError(t, invalidMock.ExpectationsWereMet())
 	})
 
 	t.Run("CreateSchemaAndTableByName", func(t *testing.T) {

--- a/pkg/importsdk/file_scanner_test.go
+++ b/pkg/importsdk/file_scanner_test.go
@@ -71,6 +71,16 @@ func TestProcessDataFiles(t *testing.T) {
 func TestFileScanner(t *testing.T) {
 	tmpDir := t.TempDir()
 	ctx := context.Background()
+	assertSecretsRedacted := func(t *testing.T, err error) {
+		t.Helper()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "access-key=xxxxxx")
+		require.ErrorContains(t, err, "secret-access-key=xxxxxx")
+		require.ErrorContains(t, err, "session-token=xxxxxx")
+		require.NotContains(t, err.Error(), "access-key=ak")
+		require.NotContains(t, err.Error(), "secret-access-key=sk")
+		require.NotContains(t, err.Error(), "session-token=token")
+	}
 
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "db1-schema-create.sql"), []byte("CREATE DATABASE db1;"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "db1.t1-schema.sql"), []byte("CREATE TABLE t1 (id INT);"), 0644))
@@ -127,13 +137,7 @@ func TestFileScanner(t *testing.T) {
 			db,
 			cfg,
 		)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "access-key=xxxxxx")
-		require.ErrorContains(t, err, "secret-access-key=xxxxxx")
-		require.ErrorContains(t, err, "session-token=xxxxxx")
-		require.NotContains(t, err.Error(), "access-key=ak")
-		require.NotContains(t, err.Error(), "secret-access-key=sk")
-		require.NotContains(t, err.Error(), "session-token=token")
+		assertSecretsRedacted(t, err)
 	})
 
 	t.Run("CreateSchemasAndTablesRedactsSensitiveSourcePathOnError", func(t *testing.T) {
@@ -163,13 +167,7 @@ func TestFileScanner(t *testing.T) {
 		invalidMock.ExpectQuery("SHOW CREATE TABLE `db1`.`t1`").WillReturnError(&dmysql.MySQLError{Number: tmysql.ErrNoSuchTable})
 
 		err = invalidScanner.CreateSchemasAndTables(ctx)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "access-key=xxxxxx")
-		require.ErrorContains(t, err, "secret-access-key=xxxxxx")
-		require.ErrorContains(t, err, "session-token=xxxxxx")
-		require.NotContains(t, err.Error(), "access-key=ak")
-		require.NotContains(t, err.Error(), "secret-access-key=sk")
-		require.NotContains(t, err.Error(), "session-token=token")
+		assertSecretsRedacted(t, err)
 		require.ErrorContains(t, err, "invalid schema statement")
 		require.NoError(t, invalidMock.ExpectationsWereMet())
 	})

--- a/pkg/importsdk/file_scanner_test.go
+++ b/pkg/importsdk/file_scanner_test.go
@@ -153,8 +153,9 @@ func TestFileScanner(t *testing.T) {
 		defer invalidScanner.Close()
 
 		fs := invalidScanner.(*fileScanner)
-		fs.sourcePath = "s3://bucket/path?access-key=ak&secret-access-key=sk&session-token=token"
-		fs.redactedSourcePath = "s3://bucket/path?access-key=xxxxxx&secret-access-key=xxxxxx&session-token=xxxxxx"
+		sourcePath := "s3://bucket/path?access-key=ak&secret-access-key=sk&session-token=token"
+		fs.sourcePath = sourcePath
+		fs.redactedSourcePath = redactSourcePath(sourcePath)
 
 		invalidMock.ExpectQuery("SELECT SCHEMA_NAME FROM information_schema.SCHEMATA.*").WillReturnRows(sqlmock.NewRows([]string{"SCHEMA_NAME"}))
 		invalidMock.ExpectExec(regexp.QuoteMeta("CREATE DATABASE IF NOT EXISTS `db1`")).WillReturnResult(sqlmock.NewResult(0, 0))

--- a/pkg/importsdk/file_scanner_test.go
+++ b/pkg/importsdk/file_scanner_test.go
@@ -130,7 +130,7 @@ func TestFileScanner(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
-	t.Run("NewFileScannerRedactsSensitiveSourcePathInInitErrors", func(t *testing.T) {
+	t.Run("NewFileScannerRedactsSensitiveSourcePathInParseErrors", func(t *testing.T) {
 		_, err := NewFileScanner(
 			ctx,
 			"s3://?access-key=ak&secret-access-key=sk&session-token=token",
@@ -138,6 +138,18 @@ func TestFileScanner(t *testing.T) {
 			cfg,
 		)
 		assertSecretsRedacted(t, err)
+	})
+
+	t.Run("NewFileScannerHidesMalformedSensitiveSourcePathInParseErrors", func(t *testing.T) {
+		_, err := NewFileScanner(
+			ctx,
+			"1invalid:?secret-access-key=sk",
+			db,
+			cfg,
+		)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "source="+redactedInvalidSourcePath)
+		require.NotContains(t, err.Error(), "secret-access-key=sk")
 	})
 
 	t.Run("CreateSchemasAndTablesRedactsSensitiveSourcePathOnError", func(t *testing.T) {
@@ -159,7 +171,6 @@ func TestFileScanner(t *testing.T) {
 
 		fs := invalidScanner.(*fileScanner)
 		sourcePath := "s3://bucket/path?access-key=ak&secret-access-key=sk&session-token=token"
-		fs.sourcePath = sourcePath
 		fs.redactedSourcePath = ast.RedactURL(sourcePath)
 
 		invalidMock.ExpectQuery("SELECT SCHEMA_NAME FROM information_schema.SCHEMATA.*").WillReturnRows(sqlmock.NewRows([]string{"SCHEMA_NAME"}))

--- a/pkg/importsdk/file_scanner_test.go
+++ b/pkg/importsdk/file_scanner_test.go
@@ -29,6 +29,7 @@ import (
 	dmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/tidb/pkg/lightning/config"
 	"github.com/pingcap/tidb/pkg/lightning/mydump"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	tmysql "github.com/pingcap/tidb/pkg/parser/mysql"
 	filter "github.com/pingcap/tidb/pkg/util/table-filter"
 	"github.com/stretchr/testify/require"
@@ -122,7 +123,7 @@ func TestFileScanner(t *testing.T) {
 	t.Run("NewFileScannerRedactsSensitiveSourcePathInInitErrors", func(t *testing.T) {
 		_, err := NewFileScanner(
 			ctx,
-			"foo://bucket/path?access-key=ak&secret-access-key=sk&session-token=token",
+			"s3://?access-key=ak&secret-access-key=sk&session-token=token",
 			db,
 			cfg,
 		)
@@ -155,7 +156,7 @@ func TestFileScanner(t *testing.T) {
 		fs := invalidScanner.(*fileScanner)
 		sourcePath := "s3://bucket/path?access-key=ak&secret-access-key=sk&session-token=token"
 		fs.sourcePath = sourcePath
-		fs.redactedSourcePath = redactSourcePath(sourcePath)
+		fs.redactedSourcePath = ast.RedactURL(sourcePath)
 
 		invalidMock.ExpectQuery("SELECT SCHEMA_NAME FROM information_schema.SCHEMATA.*").WillReturnRows(sqlmock.NewRows([]string{"SCHEMA_NAME"}))
 		invalidMock.ExpectExec(regexp.QuoteMeta("CREATE DATABASE IF NOT EXISTS `db1`")).WillReturnResult(sqlmock.NewResult(0, 0))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67718

Problem Summary:

`pkg/importsdk` wrapped several outward-facing errors with the raw import source path. When the source path contained secret query parameters such as `access-key`, `secret-access-key`, `session-token`, or `sas-token`, those values were leaked in the returned error string.

### What changed and how does it work?

- Add a cached `redactedSourcePath` to `fileScanner` and initialize it once in `NewFileScanner`.
- Route outward-facing `source=%s` error annotations through the redacted path for initialization, schema creation, and size-estimation failures.
- Make the redaction best-effort by applying a second sensitive-parameter scrub after `ast.RedactURL`, so malformed URLs and unsupported schemes do not bypass masking.
- Add regression tests covering both initialization failures and schema-restore failures to ensure secret parameters are not exposed in returned errors.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test details:

- In a temporary `upstream/master` worktree, apply the new regression tests and run:
  - `go test -run 'TestFileScanner/(NewFileScannerRedactsSensitiveSourcePathInInitErrors|CreateSchemasAndTablesRedactsSensitiveSourcePathOnError)$' -tags=intest,deadlock ./pkg/importsdk`
  - Confirm the tests fail before the fix because raw secret parameters appear in the error text.
- In this branch, run:
  - `go test -run 'TestFileScanner/(NewFileScannerRedactsSensitiveSourcePathInInitErrors|CreateSchemasAndTablesRedactsSensitiveSourcePathOnError)$' -tags=intest,deadlock ./pkg/importsdk`
  - `go test -tags=intest,deadlock ./pkg/importsdk`
  - `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive credentials in source URLs are now consistently redacted in error messages across initialization, schema/table discovery, loader creation, and import size estimation — including malformed/parse-failure cases.
* **Tests**
  * Added tests and a helper to verify credential query parameters are masked in initialization and runtime errors (including schema discovery failures) and updated test dependencies to support these cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->