### PR TITLE
*: backport TestNextGenMetering flaky fixes

### DIFF
--- a/pkg/disttask/framework/taskexecutor/task_executor.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor.go
@@ -356,6 +356,9 @@ func (e *BaseTaskExecutor) Run() {
 			e.sampleLogger.Warn("get first subtask meets error", zap.Error(err))
 			continue
 		} else if subtask == nil {
+			failpoint.Inject("avoidTaskExecutorExitWhenNoSubtask", func() {
+				noSubtaskCheckCnt = 0
+			})
 			if noSubtaskCheckCnt >= maxChecksWhenNoSubtask {
 				e.logger.Info("no subtask to run for a while, exit")
 				break

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -896,6 +896,8 @@ func TestNextGenMetering(t *testing.T) {
 		*ts = baseTime
 		baseTime += 60
 	})
+	// this failpoint can make sure we only get one gotMeterData
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/avoidTaskExecutorExitWhenNoSubtask", "return(true)")
 	var gotMeterData uberatomic.String
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/disttask/framework/metering/meteringFinalFlush", func(s fmt.Stringer) {
 		gotMeterData.Store(s.String())

--- a/tests/realtikvtest/importintotest4/BUILD.bazel
+++ b/tests/realtikvtest/importintotest4/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "//tests/realtikvtest",
         "//tests/realtikvtest/testutils",
         "@com_github_data_dog_go_sqlmock//:go-sqlmock",
+        "@com_github_docker_go_units//:go-units",
         "@com_github_fsouza_fake_gcs_server//fakestorage",
         "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",

--- a/tests/realtikvtest/importintotest4/global_sort_test.go
+++ b/tests/realtikvtest/importintotest4/global_sort_test.go
@@ -19,12 +19,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/disttask/framework/handle"
@@ -45,6 +47,8 @@ import (
 	"go.uber.org/atomic"
 )
 
+var clusterWriteBytesPattern = regexp.MustCompile(`cluster\{r:\s*[^,]+,\s*w:\s*([^}]+)\}`)
+
 func urlEqual(t *testing.T, expected, actual string) {
 	urlExpected, err := url.Parse(expected)
 	require.NoError(t, err)
@@ -54,6 +58,15 @@ func urlEqual(t *testing.T, expected, actual string) {
 	require.Equal(t, urlExpected.Query(), urlGot.Query())
 	urlExpected.RawQuery, urlGot.RawQuery = "", ""
 	require.Equal(t, urlExpected.String(), urlGot.String())
+}
+
+func parseClusterWriteBytes(t *testing.T, meterData string) int64 {
+	t.Helper()
+	match := clusterWriteBytesPattern.FindStringSubmatch(meterData)
+	require.Len(t, match, 2, "invalid metering data format: %s", meterData)
+	bytes, err := units.RAMInBytes(strings.TrimSpace(match[1]))
+	require.NoError(t, err)
+	return bytes
 }
 
 func checkExternalFields(t *testing.T, tk *testkit.TestKit) {
@@ -422,13 +435,14 @@ func TestNextGenMetering(t *testing.T) {
 	glSortURI := realtikvtest.GetNextGenObjStoreURI("gl-sort")
 	s.tk.MustExec("create table t (a bigint primary key , b varchar(100), index(b));")
 
-	baseTime := time.Now().Truncate(time.Minute).Unix()
+	baseTime := atomic.NewInt64(time.Now().Truncate(time.Minute).Unix() - 60)
 	testfailpoint.EnableCall(s.T(), "github.com/pingcap/tidb/pkg/disttask/framework/metering/forceTSAtMinuteBoundary", func(ts *int64) {
 		// the metering library requires the timestamp to be at minute boundary, but
 		// during test, we want to reduce the flush interval.
-		*ts = baseTime
-		baseTime += 60
+		*ts = baseTime.Add(60)
 	})
+	// this failpoint can make sure we only get one gotMeterData
+	testfailpoint.Enable(s.T(), "github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/avoidTaskExecutorExitWhenNoSubtask", "return(true)")
 	var gotMeterData atomic.String
 	testfailpoint.EnableCall(s.T(), "github.com/pingcap/tidb/pkg/disttask/framework/metering/meteringFinalFlush", func(s fmt.Stringer) {
 		gotMeterData.Store(s.String())
@@ -463,6 +477,7 @@ func TestNextGenMetering(t *testing.T) {
 	s.Regexp(`obj_store{r: 2.7\d*KiB, w: 3.\d*KiB}`, gotMeterData.Load())
 	// the write bytes is also not stable, due to retry, but mostly 100B to a few KB.
 	s.Regexp(`cluster{r: 0B, w: (\d{3}|.*Ki)B}`, gotMeterData.Load())
+	clusterWriteBytes := parseClusterWriteBytes(s.T(), gotMeterData.Load())
 
 	sum := s.getStepSummary(ctx, taskManager, task.ID, proto.ImportStepEncodeAndSort)
 	s.EqualValues(3, sum.RowCnt.Load())
@@ -476,7 +491,7 @@ func TestNextGenMetering(t *testing.T) {
 	s.EqualValues(6, sum.PutReqCnt.Load())
 
 	sum = s.getStepSummary(ctx, taskManager, task.ID, proto.ImportStepWriteAndIngest)
-	s.EqualValues(288, sum.Bytes.Load())
+	s.EqualValues(clusterWriteBytes, sum.Bytes.Load())
 	s.EqualValues(6, sum.GetReqCnt.Load())
 	s.EqualValues(0, sum.PutReqCnt.Load())
 


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref #66367

Problem Summary:
`TestNextGenMetering` is flaky on release-nextgen due to metering flush timing races and unstable write-byte assertions.

### What changed and how does it work?
Backport/adapt the following master PRs to `release-nextgen-20251011`:
- #66553
- #67407
- #67652

Changes included:
- Add `avoidTaskExecutorExitWhenNoSubtask` failpoint injection in task executor to avoid early executor exit during metering tests.
- Enable that failpoint in `importintotest4` and `addindextest2` next-gen metering tests.
- Make `TestNextGenMetering` failpoint timestamp counter atomic.
- Parse cluster write size from metering output via regex + `units.RAMInBytes`, and compare against write-and-ingest summary bytes.
- Add Bazel dep `@com_github_docker_go_units//:go-units` for `importintotest4`.

Note:
- On this branch, code paths are `pkg/disttask/...` (master PRs use `pkg/dxf/...`), so backport is adapted accordingly.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Manual verification commands:
- `make bazel_prepare`
- `go test ./pkg/disttask/framework/taskexecutor -run TestTaskExecutorRun -count=1 --tags=intest`
- `go test ./tests/realtikvtest/importintotest4 -run TestNextGenMetering -c --tags=intest,nextgen`
- `go test ./tests/realtikvtest/addindextest2 -run TestNextGenMetering -c --tags=intest,nextgen`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage and reliability for import metering functionality with improved tracking of cluster write-byte metrics during import operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->