### PR TITLE
parser: redact azure account-key and encryption-key in RedactURL

### DIFF
--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -3833,7 +3833,9 @@ func RedactURL(str string) string {
 		}
 	case "azure", "azblob":
 		redactKeys = map[string]struct{}{
-			"sas-token": {},
+			"account-key":    {},
+			"encryption-key": {},
+			"sas-token":      {},
 		}
 	}
 

--- a/pkg/parser/ast/misc_test.go
+++ b/pkg/parser/ast/misc_test.go
@@ -383,6 +383,9 @@ func TestRedactURL(t *testing.T) {
 		{args{"azure://bucket/file?sas-token=123"}, "azure://bucket/file?sas-token=xxxxxx"},
 		{args{"azblob://container/file?sas-token=123"}, "azblob://container/file?sas-token=xxxxxx"},
 		{args{"azure://container/file?account-name=test&sas_token=123"}, "azure://container/file?account-name=test&sas_token=xxxxxx"},
+		{args{"azure://container/file?account-name=test&account-key=123"}, "azure://container/file?account-key=xxxxxx&account-name=test"},
+		{args{"azblob://container/file?encryption-key=123"}, "azblob://container/file?encryption-key=xxxxxx"},
+		{args{"azure://container/file?account_key=123&encryption_key=456"}, "azure://container/file?account_key=xxxxxx&encryption_key=xxxxxx"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.args.str, func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65275, #67090

Problem Summary:
Azure URLs in `RedactURL` only redacted `sas-token`. `account-key` and `encryption-key` remained visible in redacted SQL text/log paths.

### What changed and how does it work?
- Extend Azure/Azblob redaction keys in `RedactURL` to include:
  - `account-key`
  - `encryption-key`
  - existing `sas-token`
- Add regression test cases in `TestRedactURL` for:
  - `account-key`
  - `encryption-key`
  - underscore variants (`account_key`, `encryption_key`)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Redact Azure storage credentials (`account-key` and `encryption-key`) in URL redaction.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for Azure blob storage URLs by expanding credential redaction. Account keys and encryption keys are now properly masked alongside SAS tokens, preventing sensitive credentials from appearing in logs and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->