### PR TITLE
pkg/planner/core/tests/extractor: stabilize flaky TestMemtableInfoschemaExtractorPart2

### DIFF
--- a/pkg/planner/core/tests/extractor/memtable_infoschema_extractor_test.go
+++ b/pkg/planner/core/tests/extractor/memtable_infoschema_extractor_test.go
@@ -399,9 +399,8 @@ func cleanDataSequences(tk *testkit.TestKit) {
 }
 
 func testMemtableInfoschemaExtractor(t *testing.T, tcs []testCase) {
-	store, _ := testkit.CreateMockStoreAndDomain(t)
-	tk := testkit.NewTestKitWithSession(t, store, testkit.NewSession(t, store))
-	tk.MustExec("select 3")
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
 
 	tk.MustExec("set global tidb_enable_check_constraint = true")
 	countSQL := 0

--- a/pkg/planner/core/tests/extractor/memtable_infoschema_extractor_test.go
+++ b/pkg/planner/core/tests/extractor/memtable_infoschema_extractor_test.go
@@ -399,8 +399,9 @@ func cleanDataSequences(tk *testkit.TestKit) {
 }
 
 func testMemtableInfoschemaExtractor(t *testing.T, tcs []testCase) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKitWithSession(t, store, testkit.NewSession(t, store))
+	tk.MustExec("select 3")
 
 	tk.MustExec("set global tidb_enable_check_constraint = true")
 	countSQL := 0
@@ -450,16 +451,19 @@ func TestMemtableInfoschemaExtractorPart2(t *testing.T) {
 			memTableName: infoschema.TableKeyColumn,
 			prepareData:  prepareDataKeyColumnUsage,
 			cleanData:    cleanDataKeyColumnUsage,
+			buildConds:   buildRepresentativeConditions,
 		},
 		{
 			memTableName: infoschema.TableConstraints,
 			prepareData:  prepareDataKeyColumnUsage,
 			cleanData:    cleanDataKeyColumnUsage,
+			buildConds:   buildRepresentativeConditions,
 		},
 		{
 			memTableName: infoschema.TablePartitions,
 			prepareData:  prepareDataPartitions,
 			cleanData:    cleanDataPartitions,
+			buildConds:   buildRepresentativeConditions,
 		},
 	}
 	testMemtableInfoschemaExtractor(t, tcs)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67643

Problem Summary:
Flaky test `TestMemtableInfoschemaExtractorPart2` in `pkg/planner/core/tests/extractor` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

`TestMemtableInfoschemaExtractorPart2` still used Cartesian predicate generation, producing 59,319 SQLs and making the test timeout-sensitive; the prior `Part4` flaky fix did not cover this sibling.

#### Fix

Switching `Part2` to `buildRepresentativeConditions` removes redundant combinatorial work while preserving the intended extractor predicate coverage.

#### Verification

Spec:
- target: `pkg/planner/core/tests/extractor :: TestMemtableInfoschemaExtractorPart2`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, affected_scope_regression_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
Required flaky gate passed.
Affected scope regression gate passed.
Build safety gate passed.
Intent guard gate passed.

Gate checklist:
- Required flaky gate: PASS
- Affected scope regression gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/planner/core/tests/extractor -run '^TestMemtableInfoschemaExtractorPart2$' -count=1`
- `go test -json ./pkg/planner/core/tests/extractor -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test setup and extended coverage for memtable infoschema extraction by explicitly configuring condition-building for specific memtable cases, increasing test reliability and ensuring representative condition validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/67732)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->