### PR TITLE
br/pkg/streamhelper: stabilize flaky TestNormalError

### DIFF
--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -341,12 +341,6 @@ func TestResolveLock(t *testing.T) {
 			fmt.Println(c)
 		}
 	}()
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/streamhelper/NeedResolveLocks", `return(true)`))
-	// make sure asyncResolveLocks stuck in optionalTick later.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/streamhelper/AsyncResolveLocks", `pause`))
-	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/streamhelper/NeedResolveLocks"))
-	}()
 
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx := context.Background()
@@ -375,10 +369,16 @@ func TestResolveLock(t *testing.T) {
 
 	// ensure resolve locks triggered and collect all locks from scan locks
 	resolveLockRef := atomic.NewBool(false)
+	releaseResolveLocks := make(chan struct{})
+	releaseResolveLocksOnce := sync.OnceFunc(func() {
+		close(releaseResolveLocks)
+	})
+	defer releaseResolveLocksOnce()
 	env.resolveLocks = func(locks []*txnlock.Lock, loc *tikv.KeyLocation) (*tikv.KeyLocation, error) {
 		resolveLockRef.Store(true)
 		// The third lock has skipped, because it's less than max version.
 		require.ElementsMatch(t, locks, allLocks[:2])
+		<-releaseResolveLocks
 		return loc, nil
 	}
 	adv := streamhelper.NewCheckpointAdvancer(env)
@@ -407,12 +407,13 @@ func TestResolveLock(t *testing.T) {
 	require.Len(t, r.FailureSubRanges, 0)
 	require.Equal(t, r.Checkpoint, minCheckpoint, "%d %d", r.Checkpoint, minCheckpoint)
 
+	adv.SetLastCheckpointForTest(minCheckpoint, time.Now().Add(-4*time.Minute))
 	env.MaxTS = maxTargetTs + 1
 	require.Eventually(t, func() bool { return adv.OnTick(ctx) == nil },
 		time.Second, 50*time.Millisecond)
-	// now the lock state must be ture. because tick finished and asyncResolveLocks got stuck.
+	// now the lock state must be true because the async resolve is blocked in the test hook.
 	require.True(t, adv.GetInResolvingLock())
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/streamhelper/AsyncResolveLocks"))
+	releaseResolveLocksOnce()
 	require.Eventually(t, func() bool { return resolveLockRef.Load() },
 		8*time.Second, 50*time.Microsecond)
 	// state must set to false after tick

--- a/br/pkg/streamhelper/basic_lib_for_test.go
+++ b/br/pkg/streamhelper/basic_lib_for_test.go
@@ -271,13 +271,18 @@ func (t *testEnv) ResolveLocksInOneRegion(
 	loc *tikv.KeyLocation,
 ) (*tikv.KeyLocation, error) {
 	_ = bo
+	var resolveLocks func([]*txnlock.Lock, *tikv.KeyLocation) (*tikv.KeyLocation, error)
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	for _, r := range t.RegionList() {
 		if loc != nil && loc.Region.GetID() == r.ID {
 			r.Locks = nil
-			return t.resolveLocks(locks, loc)
+			resolveLocks = t.resolveLocks
+			break
 		}
+	}
+	t.mu.Unlock()
+	if resolveLocks != nil {
+		return resolveLocks(locks, loc)
 	}
 	return loc, nil
 }

--- a/br/pkg/streamhelper/export_test.go
+++ b/br/pkg/streamhelper/export_test.go
@@ -49,3 +49,9 @@ func (c *CheckpointAdvancer) UpdateCheckPointLagLimit(limit time.Duration) {
 		vardef.AdvancerCheckPointLagLimit.Store(limit)
 	}
 }
+
+func (c *CheckpointAdvancer) SetLastCheckpointForTest(ts uint64, resolveLockTime time.Time) {
+	cp := newCheckpointWithTS(ts)
+	cp.resolveLockTime = resolveLockTime
+	c.UpdateLastCheckpoint(cp)
+}

--- a/br/pkg/streamhelper/flush_subscriber.go
+++ b/br/pkg/streamhelper/flush_subscriber.go
@@ -266,6 +266,10 @@ func (s *subscription) close(ctx context.Context) {
 func (s *subscription) listenOver(ctx context.Context, cli eventStream) {
 	storeID := s.storeID
 	logutil.CL(ctx).Info("Listen starting.", zap.Uint64("store", storeID))
+	failpoint.Inject("subscription.listenOver.delayMs", func(v failpoint.Value) {
+		//nolint:durationcheck
+		time.Sleep(time.Duration(v.(int)) * time.Millisecond)
+	})
 	defer func() {
 		if s.onDaemonExit != nil {
 			s.onDaemonExit()

--- a/br/pkg/streamhelper/integration_test.go
+++ b/br/pkg/streamhelper/integration_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/log"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
@@ -327,6 +326,16 @@ func testStreamClose(t *testing.T, metaCli streamhelper.AdvancerExt) {
 	ctx := context.Background()
 	taskName := "close_simple"
 	taskInfo := simpleTask(taskName, 4)
+	watchClient, err := clientv3.New(clientv3.Config{
+		Endpoints: metaCli.Endpoints(),
+	})
+	require.NoError(t, err)
+	defer func() {
+		_ = watchClient.Close()
+	}()
+	metaCli = streamhelper.AdvancerExt{
+		MetaDataClient: streamhelper.MetaDataClient{Client: watchClient},
+	}
 
 	require.NoError(t, metaCli.PutTask(ctx, taskInfo))
 	ch := make(chan streamhelper.TaskEvent, 1024)
@@ -340,13 +349,7 @@ func testStreamClose(t *testing.T, metaCli streamhelper.AdvancerExt) {
 	require.Equal(t, second.Type, streamhelper.EventDel, "%s", second)
 	require.Equal(t, second.Name, taskName, "%s", second)
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/streamhelper/advancer_close_channel", "return"))
-	defer failpoint.Disable("github.com/pingcap/tidb/br/pkg/streamhelper/advancer_close_channel")
-	// We need to make the channel file some events hence we can simulate the closed channel.
-	taskName2 := "close_simple2"
-	taskInfo2 := simpleTask(taskName2, 4)
-	require.NoError(t, metaCli.PutTask(ctx, taskInfo2))
-	require.NoError(t, metaCli.DeleteTask(ctx, taskName2))
+	require.NoError(t, watchClient.Close())
 
 	third := <-ch
 	require.Equal(t, third.Type, streamhelper.EventErr)

--- a/br/pkg/streamhelper/subscription_test.go
+++ b/br/pkg/streamhelper/subscription_test.go
@@ -81,8 +81,34 @@ func TestNormalError(t *testing.T) {
 	c := createFakeCluster(t, 4, true)
 	c.splitAndScatter("0001", "0002", "0003", "0008", "0009")
 	installSubscribeSupport(c)
+	req.NoError(failpoint.Enable("github.com/pingcap/tidb/br/pkg/streamhelper/subscription.listenOver.delayMs", "return(200)"))
+	defer func() {
+		req.NoError(failpoint.Disable("github.com/pingcap/tidb/br/pkg/streamhelper/subscription.listenOver.delayMs"))
+	}()
 
 	sub := streamhelper.NewSubscriber(c, c)
+	s := spans.Sorted(spans.NewFullWith(spans.Full(), 1))
+	var sMu sync.Mutex
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for k := range sub.Events() {
+			sMu.Lock()
+			s.Merge(k)
+			sMu.Unlock()
+		}
+	}()
+	defer func() {
+		sub.Drop()
+		<-done
+		if t.Failed() {
+			fmt.Println(c)
+			sMu.Lock()
+			spans.Debug(s)
+			sMu.Unlock()
+		}
+	}()
+
 	c.SetOnGetClient(oneStoreFailure())
 	req.NoError(sub.UpdateStoreTopology(ctx))
 	c.SetOnGetClient(nil)
@@ -94,13 +120,15 @@ func TestNormalError(t *testing.T) {
 		cp = c.advanceCheckpoints()
 		c.flushAll()
 	}
-	waitPendingEvents(t, sub)
-	sub.Drop()
-	s := spans.Sorted(spans.NewFullWith(spans.Full(), 1))
-	for k := range sub.Events() {
-		s.Merge(k)
-	}
+	req.Eventually(func() bool {
+		sMu.Lock()
+		defer sMu.Unlock()
+		return s.MinValue() == cp
+	}, 3*time.Second, 20*time.Millisecond)
+
+	sMu.Lock()
 	req.Equal(cp, s.MinValue(), "%d vs %d", cp, s.MinValue())
+	sMu.Unlock()
 }
 
 func TestHasFailureStores(t *testing.T) {
@@ -248,17 +276,19 @@ func TestEncounterError(t *testing.T) {
 	c := createFakeCluster(t, 4, true)
 	c.splitAndScatter("0001", "0002", "0003", "0008", "0009", "0010", "0100", "0956", "1000")
 
+	o := new(sync.Once)
+	for _, store := range c.storeList() {
+		store.SetSubscribeFlushEventRecvHook(func(err *error) {
+			o.Do(func() {
+				*err = context.Canceled
+			})
+		})
+	}
+
 	sub := streamhelper.NewSubscriber(c, c)
+	defer sub.Drop()
 	installSubscribeSupport(c)
 	req.NoError(sub.UpdateStoreTopology(ctx))
-
-	o := new(sync.Once)
-	failpoint.EnableCall("github.com/pingcap/tidb/br/pkg/streamhelper/listen_flush_stream", func(storeID uint64, err *error) {
-		o.Do(func() {
-			*err = context.Canceled
-		})
-	})
-
 	c.flushAll()
 	require.Eventually(t, func() bool {
 		return sub.PendingErrors() != nil

--- a/br/pkg/utiltest/fakecluster/core.go
+++ b/br/pkg/utiltest/fakecluster/core.go
@@ -138,28 +138,43 @@ func (r *Region) String() string {
 }
 
 type trivialFlushStream struct {
-	c  <-chan *logbackup.SubscribeFlushEventResponse
-	cx context.Context
+	c      <-chan *logbackup.SubscribeFlushEventResponse
+	cx     context.Context
+	onRecv func(*error)
 }
 
 func (t trivialFlushStream) Recv() (*logbackup.SubscribeFlushEventResponse, error) {
+	var (
+		item *logbackup.SubscribeFlushEventResponse
+		err  error
+		ok   bool
+	)
 	select {
-	case item, ok := <-t.c:
+	case item, ok = <-t.c:
 		if !ok {
-			return nil, io.EOF
+			err = io.EOF
+			break
 		}
-		return item, nil
 	case <-t.cx.Done():
 		select {
-		case item, ok := <-t.c:
+		case item, ok = <-t.c:
 			if !ok {
-				return nil, io.EOF
+				err = io.EOF
+				break
 			}
-			return item, nil
 		default:
 		}
-		return nil, status.Error(codes.Canceled, t.cx.Err().Error())
+		if err == nil && item == nil {
+			err = status.Error(codes.Canceled, t.cx.Err().Error())
+		}
 	}
+	if t.onRecv != nil {
+		t.onRecv(&err)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return item, nil
 }
 
 func (t trivialFlushStream) Header() (metadata.MD, error) {
@@ -193,6 +208,7 @@ type Store struct {
 	SupportsSub                      bool
 	BootstrapAt                      uint64
 	OnGetRegionCheckpoint            func(*logbackup.GetLastFlushTSOfRegionRequest) error
+	OnSubscribeFlushEventRecv        func(*error)
 	LegacyRegionCheckpointRPCEnabled bool
 	FlushTaskName                    string
 	subscribers                      map[chan *logbackup.SubscribeFlushEventResponse]struct{}
@@ -245,7 +261,7 @@ func (f *Store) SubscribeFlushEvent(
 		delete(f.subscribers, ch)
 		f.ClientMu.Unlock()
 	}()
-	return trivialFlushStream{c: ch, cx: ctx}, nil
+	return trivialFlushStream{c: ch, cx: ctx, onRecv: f.OnSubscribeFlushEventRecv}, nil
 }
 
 func (f *Store) SetSupportFlushSub(b bool) {
@@ -257,6 +273,12 @@ func (f *Store) SetSupportFlushSub(b bool) {
 
 func (f *Store) SetGetRegionCheckpointHook(hook func(*logbackup.GetLastFlushTSOfRegionRequest) error) {
 	f.OnGetRegionCheckpoint = hook
+}
+
+func (f *Store) SetSubscribeFlushEventRecvHook(hook func(*error)) {
+	f.ClientMu.Lock()
+	defer f.ClientMu.Unlock()
+	f.OnSubscribeFlushEventRecv = hook
 }
 
 func (f *Store) GetLastFlushTSOfRegion(


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67741

Problem Summary:
Flaky test `TestNormalError` in `br/pkg/streamhelper` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TestNormalError was flaky because a quiescent channel-length heuristic could drop the subscriber before a retried listener drained queued flush events, leaving the merged checkpoint stale.

#### Fix

This round was necessary to remove skip-based test narrowing by replacing the new failpoint-only dependencies in TestResolveLock and TestStreamClose with plain-go-test-compatible hooks while preserving the original TestNormalError flaky fix.

#### Verification

Spec:
- target: `br/pkg/streamhelper :: TestNormalError`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, affected_scope_regression_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
Required flaky gate passed.
Affected scope regression gate passed.
Build safety gate passed.
Intent guard gate passed.

Gate checklist:
- Required flaky gate: PASS
- Affected scope regression gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./br/pkg/streamhelper -run '^TestNormalError$' -count=1`
- `go test -json ./br/pkg/streamhelper -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test infrastructure and synchronization mechanisms for stream handling and lock resolution testing.
  * Improved fake cluster testing capabilities with additional hooks for flush event simulation and error injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->