### PR TITLE
parser: skip SQL comments in convertBinaryStringLiterals

### DIFF
--- a/pkg/parser/ast/base.go
+++ b/pkg/parser/ast/base.go
@@ -274,99 +274,89 @@ func convertBinaryStringLiterals(text string, enc charset.Encoding, noBackslashE
 }
 
 // skipComment checks whether the current position in utf8Text is the start of
-// a SQL comment. If so it advances both i (in utf8Text) and origIdx (in src)
-// past the comment and returns true. For each quote byte (' or ") encountered
-// inside the comment, origIdx is advanced past the corresponding byte in src so
-// that subsequent string-literal pairing stays correct.
+// a SQL comment. If so it advances *i past the comment in utf8Text and returns
+// true. While scanning the comment bytes, it also advances *origIdx past any
+// quote bytes (' or ") found inside the comment so that the dual-index pairing
+// used by the caller for string-literal matching stays correct. Bytes that are
+// not quote characters do NOT advance *origIdx.
 //
-// Recognised comment forms (matching the TiDB lexer):
-//   - "--" followed by whitespace or end-of-input: line comment to end of line
-//   - "#": line comment to end of line
-//   - "/*" NOT followed by "!", "+", "T!", "M!": block comment to "*/"
+// Recognised comment forms:
+//   - "--" followed by Unicode whitespace or end-of-input: line comment to EOL
+//     (matches lexer startWithDash which uses unicode.IsSpace)
+//   - "#": line comment to EOL
+//   - "/*" ... "*/": block comment, UNLESS the opener is "/*!" or "/*+"
+//     which are MySQL executable/hint comments whose content is parsed as SQL
 //
-// Executable comments (/*! */, /*+ */, /*T! */, /*M! */) are intentionally
-// left alone because their content is parsed as SQL.
+// TiDB-specific "/*T!" and MariaDB "/*M!" comments are always skipped here
+// because their executability depends on runtime feature gates that are not
+// available in the ast package. This is conservative: string literals inside
+// an actually-executed /*T![feature] block will not be hex-encoded by this
+// fallback path, but the primary litRange path handles them correctly.
 func skipComment(utf8Text, src []byte, i, origIdx *int) bool {
 	pos := *i
 	ch := utf8Text[pos]
 
-	// -- line comment (MySQL requires space/control/EOL after --)
+	// -- line comment (MySQL requires whitespace after --, checked via
+	// unicode.IsSpace to match the lexer's startWithDash predicate).
 	if ch == '-' && pos+1 < len(utf8Text) && utf8Text[pos+1] == '-' {
-		if pos+2 >= len(utf8Text) || isSpaceOrControl(utf8Text[pos+2]) {
-			skipLineComment(utf8Text, src, i, origIdx)
+		if pos+2 >= len(utf8Text) || unicode.IsSpace(rune(utf8Text[pos+2])) {
+			skipToEOL(utf8Text, src, i, origIdx)
 			return true
 		}
 	}
 
 	// # line comment
 	if ch == '#' {
-		skipLineComment(utf8Text, src, i, origIdx)
+		skipToEOL(utf8Text, src, i, origIdx)
 		return true
 	}
 
-	// /* */ block comment (but not executable variants)
+	// /* */ block comment — only /*! and /*+ are executable (MySQL syntax).
 	if ch == '/' && pos+1 < len(utf8Text) && utf8Text[pos+1] == '*' {
-		rest := utf8Text[pos+2:]
-		// /*! ... */ — MySQL version comment (executable)
-		// /*+ ... */ — optimizer hint
-		if len(rest) > 0 && (rest[0] == '!' || rest[0] == '+') {
-			return false
+		if pos+2 < len(utf8Text) {
+			next := utf8Text[pos+2]
+			if next == '!' || next == '+' {
+				// MySQL version comment or optimizer hint — content is SQL.
+				return false
+			}
 		}
-		// /*T! ... */ — TiDB executable comment
-		// /*M! ... */ — MariaDB comment
-		if len(rest) > 1 && (rest[0] == 'T' || rest[0] == 'M') && rest[1] == '!' {
-			return false
-		}
-		skipBlockComment(utf8Text, src, i, origIdx)
+		skipToBlockEnd(utf8Text, src, i, origIdx)
 		return true
 	}
 
 	return false
 }
 
-func isSpaceOrControl(b byte) bool {
-	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
-}
-
-// skipLineComment advances *i to the end of a line comment (past \n or to EOF)
-// and advances *origIdx past any quote bytes in the skipped region of src.
-func skipLineComment(utf8Text, src []byte, i, origIdx *int) {
-	start := *i
-	nlPos := bytes.IndexByte(utf8Text[start:], '\n')
-	var end int
-	if nlPos < 0 {
-		end = len(utf8Text)
-	} else {
-		end = start + nlPos + 1
-	}
-	skipCommentQuotes(utf8Text, src, start, end, origIdx)
-	*i = end
-}
-
-// skipBlockComment advances *i past a /* ... */ block comment and advances
-// *origIdx past any quote bytes in the skipped region of src.
-func skipBlockComment(utf8Text, src []byte, i, origIdx *int) {
-	start := *i
-	endMarker := bytes.Index(utf8Text[start+2:], []byte("*/"))
-	var end int
-	if endMarker < 0 {
-		end = len(utf8Text) // unterminated comment
-	} else {
-		end = start + 2 + endMarker + 2
-	}
-	skipCommentQuotes(utf8Text, src, start, end, origIdx)
-	*i = end
-}
-
-// skipCommentQuotes advances origIdx past each ' or " byte in the comment
-// region [start, end) of utf8Text. This keeps the dual-index pairing in sync
-// so that the next real string literal is matched correctly in src.
-func skipCommentQuotes(utf8Text, src []byte, start, end int, origIdx *int) {
-	for j := start; j < end; j++ {
-		ch := utf8Text[j]
+// skipToEOL advances *i to past the newline (or EOF) and advances *origIdx
+// past any quote bytes encountered along the way, in a single pass.
+func skipToEOL(utf8Text, src []byte, i, origIdx *int) {
+	for *i < len(utf8Text) {
+		ch := utf8Text[*i]
 		if ch == '\'' || ch == '"' {
 			advanceOrigTo(src, origIdx, ch)
 		}
+		*i++
+		if ch == '\n' {
+			return
+		}
+	}
+}
+
+// skipToBlockEnd advances *i past the closing "*/" (or EOF) and advances
+// *origIdx past any quote bytes encountered along the way, in a single pass.
+func skipToBlockEnd(utf8Text, src []byte, i, origIdx *int) {
+	// Skip past the opening "/*".
+	*i += 2
+	for *i < len(utf8Text) {
+		ch := utf8Text[*i]
+		if ch == '\'' || ch == '"' {
+			advanceOrigTo(src, origIdx, ch)
+		}
+		if ch == '*' && *i+1 < len(utf8Text) && utf8Text[*i+1] == '/' {
+			*i += 2 // skip past "*/"
+			return
+		}
+		*i++
 	}
 }
 

--- a/pkg/parser/ast/base.go
+++ b/pkg/parser/ast/base.go
@@ -152,6 +152,12 @@ func convertBinaryStringLiterals(text string, enc charset.Encoding, noBackslashE
 	i := 0             // scan position in utf8Text
 
 	for i < len(utf8Text) {
+		// Skip SQL comments so that quote characters inside comments are not
+		// mistaken for string-literal boundaries.
+		if skipped := skipComment(utf8Text, src, &i, &origIdx); skipped {
+			continue
+		}
+
 		if utf8Text[i] != '\'' && utf8Text[i] != '"' {
 			i++
 			continue
@@ -265,6 +271,103 @@ func convertBinaryStringLiterals(text string, enc charset.Encoding, noBackslashE
 		buf.Write(utf8Text[lastCopiedIdx:])
 	}
 	return buf.String()
+}
+
+// skipComment checks whether the current position in utf8Text is the start of
+// a SQL comment. If so it advances both i (in utf8Text) and origIdx (in src)
+// past the comment and returns true. For each quote byte (' or ") encountered
+// inside the comment, origIdx is advanced past the corresponding byte in src so
+// that subsequent string-literal pairing stays correct.
+//
+// Recognised comment forms (matching the TiDB lexer):
+//   - "--" followed by whitespace or end-of-input: line comment to end of line
+//   - "#": line comment to end of line
+//   - "/*" NOT followed by "!", "+", "T!", "M!": block comment to "*/"
+//
+// Executable comments (/*! */, /*+ */, /*T! */, /*M! */) are intentionally
+// left alone because their content is parsed as SQL.
+func skipComment(utf8Text, src []byte, i, origIdx *int) bool {
+	pos := *i
+	ch := utf8Text[pos]
+
+	// -- line comment (MySQL requires space/control/EOL after --)
+	if ch == '-' && pos+1 < len(utf8Text) && utf8Text[pos+1] == '-' {
+		if pos+2 >= len(utf8Text) || isSpaceOrControl(utf8Text[pos+2]) {
+			skipLineComment(utf8Text, src, i, origIdx)
+			return true
+		}
+	}
+
+	// # line comment
+	if ch == '#' {
+		skipLineComment(utf8Text, src, i, origIdx)
+		return true
+	}
+
+	// /* */ block comment (but not executable variants)
+	if ch == '/' && pos+1 < len(utf8Text) && utf8Text[pos+1] == '*' {
+		rest := utf8Text[pos+2:]
+		// /*! ... */ — MySQL version comment (executable)
+		// /*+ ... */ — optimizer hint
+		if len(rest) > 0 && (rest[0] == '!' || rest[0] == '+') {
+			return false
+		}
+		// /*T! ... */ — TiDB executable comment
+		// /*M! ... */ — MariaDB comment
+		if len(rest) > 1 && (rest[0] == 'T' || rest[0] == 'M') && rest[1] == '!' {
+			return false
+		}
+		skipBlockComment(utf8Text, src, i, origIdx)
+		return true
+	}
+
+	return false
+}
+
+func isSpaceOrControl(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// skipLineComment advances *i to the end of a line comment (past \n or to EOF)
+// and advances *origIdx past any quote bytes in the skipped region of src.
+func skipLineComment(utf8Text, src []byte, i, origIdx *int) {
+	start := *i
+	nlPos := bytes.IndexByte(utf8Text[start:], '\n')
+	var end int
+	if nlPos < 0 {
+		end = len(utf8Text)
+	} else {
+		end = start + nlPos + 1
+	}
+	skipCommentQuotes(utf8Text, src, start, end, origIdx)
+	*i = end
+}
+
+// skipBlockComment advances *i past a /* ... */ block comment and advances
+// *origIdx past any quote bytes in the skipped region of src.
+func skipBlockComment(utf8Text, src []byte, i, origIdx *int) {
+	start := *i
+	endMarker := bytes.Index(utf8Text[start+2:], []byte("*/"))
+	var end int
+	if endMarker < 0 {
+		end = len(utf8Text) // unterminated comment
+	} else {
+		end = start + 2 + endMarker + 2
+	}
+	skipCommentQuotes(utf8Text, src, start, end, origIdx)
+	*i = end
+}
+
+// skipCommentQuotes advances origIdx past each ' or " byte in the comment
+// region [start, end) of utf8Text. This keeps the dual-index pairing in sync
+// so that the next real string literal is matched correctly in src.
+func skipCommentQuotes(utf8Text, src []byte, start, end int, origIdx *int) {
+	for j := start; j < end; j++ {
+		ch := utf8Text[j]
+		if ch == '\'' || ch == '"' {
+			advanceOrigTo(src, origIdx, ch)
+		}
+	}
 }
 
 // advanceOrigTo scans src from *idx forward until it finds a byte equal to b.

--- a/pkg/parser/ast/base_test.go
+++ b/pkg/parser/ast/base_test.go
@@ -158,11 +158,38 @@ func TestBinaryStringLiteralSkipsComments(t *testing.T) {
 			"/*\n * don't modify\n */ SELECT 'value' FROM t",
 			"/*\n * don't modify\n */ SELECT 'value' FROM t",
 		},
+		// -- with form-feed and vertical-tab (unicode.IsSpace matches these)
+		{
+			"-- with form-feed after dashes",
+			"--\f don't\nSELECT 'hello' FROM t",
+			"--\f don't\nSELECT 'hello' FROM t",
+		},
+		{
+			"-- with vertical-tab after dashes",
+			"--\v don't\nSELECT 'hello' FROM t",
+			"--\v don't\nSELECT 'hello' FROM t",
+		},
 		// Executable comments must NOT be skipped (quotes inside are SQL)
 		{
 			"/*! executable - binary inside",
 			"/*!80000 SELECT '\xd2\xe4' */",
 			"/*!80000 SELECT 0xd2e4 */",
+		},
+		{
+			"/*+ hint - binary inside",
+			"/*+ SET_VAR(charset='\xd2\xe4') */ SELECT 1",
+			"/*+ SET_VAR(charset=0xd2e4) */ SELECT 1",
+		},
+		// /*T! and /*M! are skipped as comments (conservative: can't check feature gates from ast)
+		{
+			"/*T! skipped as comment",
+			"/*T![unsupported] don't */ SELECT 'hello' FROM t",
+			"/*T![unsupported] don't */ SELECT 'hello' FROM t",
+		},
+		{
+			"/*M! skipped as comment",
+			"/*M! don't */ SELECT 'hello' FROM t",
+			"/*M! don't */ SELECT 'hello' FROM t",
 		},
 		// Real-world CDC case
 		{

--- a/pkg/parser/ast/base_test.go
+++ b/pkg/parser/ast/base_test.go
@@ -102,6 +102,87 @@ func TestBinaryStringLiteralConversion(t *testing.T) {
 	}
 }
 
+func TestBinaryStringLiteralSkipsComments(t *testing.T) {
+	n := &node{}
+
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		// -- line comments with quotes must not corrupt the SQL
+		{
+			"-- with apostrophe",
+			"-- don't do this\nSELECT 'hello' FROM t",
+			"-- don't do this\nSELECT 'hello' FROM t",
+		},
+		{
+			"-- with commented-out SQL (even quotes)",
+			"-- SELECT * FROM t WHERE name='John'\nSELECT 1",
+			"-- SELECT * FROM t WHERE name='John'\nSELECT 1",
+		},
+		{
+			"-- double-quote in comment",
+			"-- see table \"users\"\nSELECT \"bar\" FROM t",
+			"-- see table \"users\"\nSELECT \"bar\" FROM t",
+		},
+		{
+			"-- at end of input",
+			"SELECT 1 -- don't",
+			"SELECT 1 -- don't",
+		},
+		{
+			"-- quote at end of comment line",
+			"-- ending with '\nSELECT 'hello'",
+			"-- ending with '\nSELECT 'hello'",
+		},
+		{
+			"-- without space is NOT a comment",
+			"SELECT 1 --1",
+			"SELECT 1 --1",
+		},
+		// # line comments
+		{
+			"# with apostrophe",
+			"# user's config\nSELECT 'value' FROM t",
+			"# user's config\nSELECT 'value' FROM t",
+		},
+		// /* */ block comments
+		{
+			"block comment with apostrophe",
+			"/* it's a test */ SELECT 'value' FROM t",
+			"/* it's a test */ SELECT 'value' FROM t",
+		},
+		{
+			"multi-line block comment with quote",
+			"/*\n * don't modify\n */ SELECT 'value' FROM t",
+			"/*\n * don't modify\n */ SELECT 'value' FROM t",
+		},
+		// Executable comments must NOT be skipped (quotes inside are SQL)
+		{
+			"/*! executable - binary inside",
+			"/*!80000 SELECT '\xd2\xe4' */",
+			"/*!80000 SELECT 0xd2e4 */",
+		},
+		// Real-world CDC case
+		{
+			"CREATE VIEW with comment quote",
+			"-- (don't use parenthesis)\n\nCREATE OR REPLACE VIEW v AS SELECT 'Attribute' AS t FROM t1 UNION ALL SELECT 'Reference' AS t FROM t2",
+			"-- (don't use parenthesis)\n\nCREATE OR REPLACE VIEW v AS SELECT 'Attribute' AS t FROM t1 UNION ALL SELECT 'Reference' AS t FROM t2",
+		},
+		// Binary string after comment still gets hex-encoded
+		{
+			"comment + binary string",
+			"-- don't\nSELECT '\xd2\xe4' FROM t",
+			"-- don't\nSELECT 0xd2e4 FROM t",
+		},
+	}
+	for _, tt := range tests {
+		n.SetText(charset.EncodingUTF8Impl, tt.text)
+		require.Equal(t, tt.want, n.Text(), tt.name)
+	}
+}
+
 func TestBinaryStringLiteralNoBackslashEscapes(t *testing.T) {
 	n := &node{}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #66591, close #67780

Problem Summary:

`convertBinaryStringLiterals` (introduced in #66592) scans for quote boundaries to hex-encode non-printable string literals. However, it does not recognize SQL comments, so a quote inside a comment (e.g. `-- don't`) is incorrectly treated as the start of a string literal. This causes the content between the comment's quote and the next real SQL string quote to be hex-encoded — capturing newlines as literal `0a` bytes and breaking the SQL structure.

This was reported by TiCDC which calls `ParseOneStmt` on the `Text()` output of a `CREATE VIEW` DDL that had a comment containing an apostrophe (`don't`). The hex encoding swallowed the entire `CREATE VIEW` into a `--` comment line, leaving an orphaned `FROM` clause that failed to parse:

```
line 3 column 11 near "FROM MMR_MODELS JOIN MMR_OBJECTS ON ..."
```

**Affected patterns** — any SQL where a comment contains an odd number of same-type quotes:
| Pattern | Example | Severity |
|---|---|---|
| `--` line comment | `-- don't do this\nSELECT 'x'` | SQL swallowed into comment |
| `#` line comment | `# user's config\nSELECT 'x'` | Same |
| `/* */` block comment (multi-line) | `/*\n * don't\n */ SELECT 'x'` | **Worst**: `*/` also hex-encoded, comment never closes |

### What changed and how does it work?

At the top of the scanning loop in `convertBinaryStringLiterals`, detect SQL comments and skip over them before checking for quotes:

- `--` (followed by whitespace/EOL) and `#`: skip to end of line
- `/* */`: skip to `*/` (excluding executable variants `/*! */`, `/*+ */`, `/*T! */`, `/*M! */`)
- When skipping, advance `origIdx` past any quote bytes inside the comment to keep the dual-index pairing in sync

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a bug where `convertBinaryStringLiterals` incorrectly treated quote characters inside SQL comments as string literal boundaries, causing the `Text()` output to be corrupted with hex-encoded content that broke downstream consumers like TiCDC.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL comment handling so `--`, `#`, and `/* ... */` comments are skipped when detecting binary string literals, preventing quotes inside regular comments from being misinterpreted as string delimiters.
  * Preserved behavior for executable/hint comments (e.g., `/*! ... */`, `/*+ ... */`), which are still processed for binary literal conversion.

* **Tests**
  * Added tests covering line/block comments, edge cases, and conversion behavior before/after comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->