### PR TITLE
parser: replace raw-text rescanning with lexer-recorded string literal positions

### DIFF
--- a/pkg/parser/ast/base.go
+++ b/pkg/parser/ast/base.go
@@ -36,6 +36,12 @@ type node struct {
 
 	text   string
 	offset int
+
+	// litRanges holds [start, end) byte offsets of string literals
+	// within text (relative to start of text, not parser.src).
+	// When set, Text() uses these known ranges for hex encoding
+	// instead of rescanning the raw text.
+	litRanges [][2]int
 }
 
 // SetOriginTextPosition implements Node interface.
@@ -68,6 +74,15 @@ func (n *node) SetNoBackslashEscapes(val bool) {
 	}
 }
 
+// SetLitRanges sets the byte offset ranges of string literals within the
+// node's text. Each range is [start, end) relative to the start of text.
+func (n *node) SetLitRanges(ranges [][2]int) {
+	n.litRanges = ranges
+	if n.once != nil {
+		n.once = &sync.Once{} // invalidate cache
+	}
+}
+
 // Text implements Node interface.
 func (n *node) Text() string {
 	if n.once == nil {
@@ -78,7 +93,12 @@ func (n *node) Text() string {
 			n.utf8Text = n.text
 			return
 		}
-		n.utf8Text = convertBinaryStringLiterals(n.text, n.enc, n.noBackslashEscapes)
+		if n.litRanges != nil {
+			n.utf8Text = convertWithLitRanges(n.text, n.enc, n.noBackslashEscapes, n.litRanges)
+		} else {
+			// Fallback for external SetText() callers without lexer ranges
+			n.utf8Text = convertBinaryStringLiterals(n.text, n.enc, n.noBackslashEscapes)
+		}
 	})
 	return n.utf8Text
 }
@@ -117,6 +137,130 @@ func needsSpaceBeforeHexLiteral(utf8Text []byte, quoteStart int) bool {
 		return false
 	}
 	return isIdentChar(utf8Text[quoteStart-1])
+}
+
+// convertWithLitRanges hex-encodes non-printable string literals using
+// pre-recorded byte ranges from the lexer. Unlike convertBinaryStringLiterals,
+// it does not rescan the text for quote boundaries — it operates only on the
+// known litRanges, so comments and other SQL constructs are ignored entirely.
+func convertWithLitRanges(text string, enc charset.Encoding, noBackslashEscapes bool, litRanges [][2]int) string {
+	src := charset.HackSlice(text)
+
+	// Transform entire text to UTF-8.
+	utf8Text, _ := enc.Transform(nil, src, charset.OpDecodeReplace)
+
+	if len(litRanges) == 0 {
+		return charset.HackString(utf8Text)
+	}
+
+	// For non-UTF-8 encodings, character widths change during Transform
+	// (e.g. GBK 2-byte → UTF-8 3-byte), so we need a mapping from original
+	// byte offsets to UTF-8 byte offsets. For UTF-8, offsets are identical.
+	isUTF8 := enc.Tp() == charset.EncodingTpUTF8 ||
+		enc.Tp() == charset.EncodingTpUTF8MB3Strict ||
+		enc.Tp() == charset.EncodingTpASCII
+	origPos := 0
+	utf8Pos := 0
+
+	// mapOffset advances the orig→utf8 position tracker to targetOrig and
+	// returns the corresponding UTF-8 position.
+	mapOffset := func(targetOrig int) int {
+		if isUTF8 {
+			return targetOrig
+		}
+		for origPos < targetOrig && origPos < len(src) && utf8Pos < len(utf8Text) {
+			charBytes := enc.Peek(src[origPos:])
+			origStep := len(charBytes)
+			if origStep == 0 {
+				origStep = 1
+			}
+			_, utf8Step := utf8.DecodeRune(utf8Text[utf8Pos:])
+			if utf8Step == 0 {
+				utf8Step = 1
+			}
+			origPos += origStep
+			utf8Pos += utf8Step
+		}
+		return utf8Pos
+	}
+
+	var buf *bytes.Buffer
+	lastCopied := 0 // position in utf8Text up to which we've copied
+
+	for _, lr := range litRanges {
+		origStart, origEnd := lr[0], lr[1]
+		if origStart < 0 || origEnd > len(src) || origStart >= origEnd {
+			continue
+		}
+
+		// Quotes are at src[origStart] and src[origEnd-1].
+		innerStart := origStart + 1
+		innerEnd := origEnd - 1
+		if innerStart >= innerEnd {
+			continue // empty string ''
+		}
+
+		// Check printability of the content inside the quotes.
+		decoded, err := enc.Transform(nil, src[innerStart:innerEnd], charset.OpDecode)
+		if err == nil && isPrintable(decoded) {
+			continue
+		}
+
+		// Non-printable: extract content (processing escape sequences) and hex-encode.
+		quote := src[origStart]
+		content := extractLiteralContent(src, innerStart, innerEnd, quote, noBackslashEscapes)
+
+		utf8Start := mapOffset(origStart)
+		utf8End := mapOffset(origEnd)
+
+		if buf == nil {
+			buf = &bytes.Buffer{}
+			buf.Grow(len(utf8Text))
+		}
+		buf.Write(utf8Text[lastCopied:utf8Start])
+		if needsSpaceBeforeHexLiteral(utf8Text, utf8Start) {
+			buf.WriteByte(' ')
+		}
+		buf.WriteString("0x")
+		for _, b := range content {
+			buf.WriteByte(hexDigits[b>>4])
+			buf.WriteByte(hexDigits[b&0xf])
+		}
+		lastCopied = utf8End
+	}
+
+	if buf == nil {
+		return charset.HackString(utf8Text)
+	}
+	if lastCopied < len(utf8Text) {
+		buf.Write(utf8Text[lastCopied:])
+	}
+	return buf.String()
+}
+
+// extractLiteralContent extracts the decoded byte content from a string
+// literal in src[start:end], processing doubled-quote and backslash escapes.
+func extractLiteralContent(src []byte, start, end int, quote byte, noBackslashEscapes bool) []byte {
+	var content []byte
+	j := start
+	for j < end {
+		ch := src[j]
+		if ch == quote {
+			j++
+			if j < end && src[j] == quote {
+				content = append(content, quote)
+				j++
+			}
+		} else if ch == '\\' && !noBackslashEscapes && j+1 < end {
+			j++
+			content = append(content, util.UnescapeChar(src[j])...)
+			j++
+		} else {
+			content = append(content, ch)
+			j++
+		}
+	}
+	return content
 }
 
 // convertBinaryStringLiterals processes raw SQL text, converting non-printable

--- a/pkg/parser/ast/base.go
+++ b/pkg/parser/ast/base.go
@@ -58,6 +58,7 @@ func (n *node) OriginTextPosition() int {
 func (n *node) SetText(enc charset.Encoding, text string) {
 	n.enc = enc
 	n.text = text
+	n.litRanges = nil
 	n.once = &sync.Once{}
 }
 

--- a/pkg/parser/ast/base_test.go
+++ b/pkg/parser/ast/base_test.go
@@ -144,6 +144,85 @@ func TestBinaryStringLiteralGBK(t *testing.T) {
 	require.Equal(t, "select '筡', 'after'", n.Text(), "GBK 0x5c before quote")
 }
 
+func TestConvertWithLitRanges(t *testing.T) {
+	n := &node{}
+	tests := []struct {
+		name      string
+		text      string
+		litRanges [][2]int
+		want      string
+	}{
+		{
+			// Binary literal: '\xd2\xe4' (2 bytes) is non-printable → hex-encoded
+			// "SELECT '\xd2\xe4' FROM t": 'SELECT ' = 7 bytes (0-6), quote at 7, \xd2\xe4 at 8-9, quote at 10 → [7,11)
+			name:      "binary literal",
+			text:      "SELECT '\xd2\xe4' FROM t",
+			litRanges: [][2]int{{7, 11}},
+			want:      "SELECT 0xd2e4 FROM t",
+		},
+		{
+			// Printable literal: 'hello' → passes through unchanged
+			// "SELECT 'hello' FROM t": quote at 7, closes at 13 → [7,14)
+			name:      "printable literal",
+			text:      "SELECT 'hello' FROM t",
+			litRanges: [][2]int{{7, 14}},
+			want:      "SELECT 'hello' FROM t",
+		},
+		{
+			// Comment containing quote + printable literal: comment must NOT be corrupted
+			// "-- don't\nSELECT 'hello' FROM t": comment is 9 bytes (0-8), SELECT at 9, 'hello' at [16,23)
+			name:      "comment with quote and printable literal",
+			text:      "-- don't\nSELECT 'hello' FROM t",
+			litRanges: [][2]int{{16, 23}},
+			want:      "-- don't\nSELECT 'hello' FROM t",
+		},
+		{
+			// Comment containing quote + binary literal: binary in SQL hex-encoded, comment intact
+			// "-- don't\nSELECT '\xd2\xe4' FROM t": comment = 9 bytes, SELECT at 9, '\xd2\xe4' at [16,20)
+			name:      "comment with quote and binary literal",
+			text:      "-- don't\nSELECT '\xd2\xe4' FROM t",
+			litRanges: [][2]int{{16, 20}},
+			want:      "-- don't\nSELECT 0xd2e4 FROM t",
+		},
+		{
+			// Multiple literals, only the binary one gets hex-encoded
+			// "SELECT 'hello', '\xd2\xe4' FROM t": 'hello' at [7,14), '\xd2\xe4' at [16,20)
+			name:      "multiple literals one binary",
+			text:      "SELECT 'hello', '\xd2\xe4' FROM t",
+			litRanges: [][2]int{{7, 14}, {16, 20}},
+			want:      "SELECT 'hello', 0xd2e4 FROM t",
+		},
+		{
+			// No litRanges (nil): should just do UTF-8 transform
+			name:      "nil litRanges",
+			text:      "SELECT 1 + 2",
+			litRanges: nil,
+			want:      "SELECT 1 + 2",
+		},
+		{
+			// _binary prefix: space must be inserted before 0x to avoid _binary0x...
+			// "SELECT _binary '\xd2\xe4'": SELECT(7) + _binary (8) = 15 → quote at 15, ends at 18, [15,19)
+			name:      "_binary prefix inserts space",
+			text:      "SELECT _binary '\xd2\xe4'",
+			litRanges: [][2]int{{15, 19}},
+			want:      "SELECT _binary 0xd2e4",
+		},
+		{
+			// Empty string literal '': innerStart == innerEnd → skip (no encoding)
+			// "SELECT ''": quote at 7, closes at 8 → [7,9)
+			name:      "empty string literal skipped",
+			text:      "SELECT ''",
+			litRanges: [][2]int{{7, 9}},
+			want:      "SELECT ''",
+		},
+	}
+	for _, tt := range tests {
+		n.SetText(charset.EncodingUTF8Impl, tt.text)
+		n.SetLitRanges(tt.litRanges)
+		require.Equal(t, tt.want, n.Text(), tt.name)
+	}
+}
+
 func buildBinaryClause() string {
 	return "c1 = _binary '\xd2\xe4\xa6\xb8\xc1\xf3\xe5\xd7\xa9\xb2\xc4\xd6\xe8\xf1\xa3\xb5'"
 }

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -84,6 +84,10 @@ type Scanner struct {
 
 	// keepHint, if true, Scanner will keep hint when normalizing .
 	keepHint bool
+
+	// stringLitRanges records [start, end) byte offsets of each string literal
+	// token within the source text, in scan order.
+	stringLitRanges [][2]int
 }
 
 // Errors returns the errors and warns during a scan.
@@ -103,6 +107,7 @@ func (s *Scanner) reset(sql string) {
 	s.inBangComment = false
 	s.lastKeyword = 0
 	s.identifierDot = false
+	s.stringLitRanges = s.stringLitRanges[:0]
 }
 
 func (s *Scanner) stmtText() string {
@@ -768,6 +773,7 @@ func (s *Scanner) scanString() (tok int, pos Pos, lit string) {
 		if ch0 == ending {
 			if s.r.peek() != ending {
 				lit = s.buf.String()
+				s.stringLitRanges = append(s.stringLitRanges, [2]int{pos.Offset, s.r.pos().Offset})
 				return
 			}
 			s.r.inc()

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -1092,3 +1092,15 @@ func (r *reader) skipRune(enc charset.Encoding) bool {
 	r.incN(c)
 	return c > 0
 }
+
+// litRangesFor returns string literal ranges that fall within [srcStart, srcEnd)
+// of the source text, with offsets adjusted to be relative to srcStart.
+func (s *Scanner) litRangesFor(srcStart, srcEnd int) [][2]int {
+	var result [][2]int
+	for _, r := range s.stringLitRanges {
+		if r[0] >= srcStart && r[1] <= srcEnd {
+			result = append(result, [2]int{r[0] - srcStart, r[1] - srcStart})
+		}
+	}
+	return result
+}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -8241,3 +8241,30 @@ func TestSplitPartition(t *testing.T) {
 	}
 	RunTest(t, cases, false, false)
 }
+
+func TestLitRangeRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"comment with quote", "-- don't\nSELECT 'hello' FROM t"},
+		{"block comment with quote", "/* it's a test */\nSELECT 'value' FROM t"},
+		{"CREATE VIEW with comment", "-- (don't use parenthesis)\n\nCREATE OR REPLACE VIEW v AS SELECT 'Attr' AS t FROM t1 UNION ALL SELECT 'Ref' AS t FROM t2"},
+		{"multiple string literals", "SELECT 'a', 'b', 'c' FROM t"},
+		{"no string literals", "SELECT 1 + 2"},
+	}
+
+	p := parser.New()
+	for _, tt := range tests {
+		stmts, _, err := p.ParseSQL(tt.sql)
+		require.NoError(t, err, tt.name)
+		require.NotEmpty(t, stmts, tt.name)
+
+		text := stmts[0].Text()
+		// Text() should not corrupt the SQL
+		require.Equal(t, tt.sql, text, tt.name+": Text() changed")
+		// Re-parse should succeed
+		_, _, err = p.ParseSQL(text)
+		require.NoError(t, err, tt.name+": re-parse failed")
+	}
+}

--- a/pkg/parser/yy_parser.go
+++ b/pkg/parser/yy_parser.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 	"strconv"
 	"unicode"
+	"unsafe"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -103,6 +104,16 @@ type Parser struct {
 	yyVAL  *yySymType
 }
 
+// srcOffset returns the byte offset of text within parser.src.
+// text must be a substring of parser.src sharing the backing array.
+func (parser *Parser) srcOffset(text string) int {
+	if len(text) == 0 || len(parser.src) == 0 {
+		return 0
+	}
+	return int(uintptr(unsafe.Pointer(unsafe.StringData(text))) -
+		uintptr(unsafe.Pointer(unsafe.StringData(parser.src))))
+}
+
 // setNodeText sets the raw text on a parsed AST node and propagates the
 // NO_BACKSLASH_ESCAPES SQL mode so that Text() can correctly handle
 // backslash escapes when converting binary string literals to hex.
@@ -112,6 +123,14 @@ func (parser *Parser) setNodeText(n interface {
 	n.SetText(parser.lexer.client, text)
 	if setter, ok := n.(interface{ SetNoBackslashEscapes(bool) }); ok {
 		setter.SetNoBackslashEscapes(parser.lexer.sqlMode.HasNoBackslashEscapesMode())
+	}
+	// Pipe lexer-recorded string literal ranges to the node.
+	if setter, ok := n.(interface{ SetLitRanges([][2]int) }); ok {
+		srcStart := parser.srcOffset(text)
+		srcEnd := srcStart + len(text)
+		if ranges := parser.lexer.litRangesFor(srcStart, srcEnd); len(ranges) > 0 {
+			setter.SetLitRanges(ranges)
+		}
 	}
 }
 
@@ -257,7 +276,12 @@ func (parser *Parser) setLastSelectFieldText(st *ast.SelectStmt, lastEnd int) {
 	}
 	lastField := st.Fields.Fields[len(st.Fields.Fields)-1]
 	if lastField.Offset+len(lastField.OriginalText()) >= len(parser.src)-1 {
-		lastField.SetText(parser.lexer.client, parser.src[lastField.Offset:lastEnd])
+		text := parser.src[lastField.Offset:lastEnd]
+		lastField.SetText(parser.lexer.client, text)
+		// Pass litRanges for the new text range.
+		if ranges := parser.lexer.litRangesFor(lastField.Offset, lastEnd); len(ranges) > 0 {
+			lastField.SetLitRanges(ranges)
+		}
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #66591

Problem Summary:

`convertBinaryStringLiterals` (introduced in #66592) re-scans raw SQL text for quote boundaries to hex-encode non-printable string literals. This is a mini-lexer that doesn't understand comments, `ANSI_QUOTES`, or executable comments. Each blind spot produces a bug:

- #67747: quotes inside `--` comments caused SQL corruption (reported by TiCDC)
- Unaddressed: `ANSI_QUOTES` mode where `"foo"` is an identifier, not a string

This PR eliminates the need for raw-text rescanning by having the **lexer record string literal byte ranges during parsing**, then using those known ranges in `Text()` for targeted hex encoding.

### What changed and how does it work?

**Architecture: lexer records → parser pipes → node uses**

1. **Scanner.scanString()** — appends `[openQuoteOffset, afterCloseQuoteOffset)` to `stringLitRanges` on each successful string literal token
2. **Parser.setNodeText()** — computes the text's source offset via `unsafe.StringData` pointer arithmetic, filters `stringLitRanges` to the node's text range, passes adjusted offsets via `SetLitRanges()`
3. **node.Text()** — when `litRanges` is set, uses `convertWithLitRanges` which only inspects known ranges. Comments, identifiers, and other SQL constructs are inherently ignored because the lexer never records them as string literals

`convertBinaryStringLiterals` is retained as fallback for external `SetText()` callers that don't have lexer-recorded ranges.

Zero changes to `parser.y` — all 38 `setNodeText` call sites are unchanged.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string literal handling during parsing and text conversion to better preserve content, including proper handling of non-printable characters.

* **Tests**
  * Added comprehensive testing for string literal preservation, round-trip parsing validation, and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->