### PR TITLE
pkg/planner: avoid wrong outer join simplification with nested IN

### DIFF
--- a/pkg/importsdk/BUILD.bazel
+++ b/pkg/importsdk/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//pkg/lightning/config",
         "//pkg/lightning/log",
         "//pkg/lightning/mydump",
+        "//pkg/parser/ast",
         "//pkg/parser/mysql",
         "//pkg/util/table-filter",
         "@com_github_data_dog_go_sqlmock//:go-sqlmock",

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -535,6 +535,26 @@ HAVING EXISTS (SELECT 1 FROM t_panic WHERE x IS NULL);`).Check(testkit.Rows("<ni
 		require.Equal(t, cteRows, derivedRows)
 	}
 
+	// safe-nested-in-still-allows-outer-to-inner
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("create table t2 (c0 tinyint default null, c2 mediumint unsigned default null, unique key c0 (c0), unique key c2 (c2), key i1 (c0, c2))")
+		tk.MustExec("insert into t2 values (1, null), (0, null), (-128, 0), (null, 1), (null, null)")
+
+		query := `select /* issue:67373 safe nested in */ _col_12 as c0
+		from (
+				select * from (
+					select t_lhs_2.c2 as _col_11, t_rhs_2.c0 as _col_12
+					from t2 as t_lhs_2 right join t2 as t_rhs_2 on (false)
+				) as derived
+				where ((true >= (false in (_col_11, _col_11, 1))) <> 1)
+		) as wrapper`
+		tk.MustQuery("explain format='plan_tree' " + query).Check(testkit.Rows(
+			"TableDual root  rows:0",
+		))
+		tk.MustQuery(query).Check(testkit.Rows())
+	}
+
 	// merge-join-with-correlated-count
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -488,6 +488,53 @@ GROUP BY x WITH ROLLUP
 HAVING EXISTS (SELECT 1 FROM t_panic WHERE x IS NULL);`).Check(testkit.Rows("<nil>"))
 	}
 
+	// repeated-derived-union-all-keeps-all-rows
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("create table t2 (c0 tinyint default null, c2 mediumint unsigned default null, unique key c0 (c0), unique key c2 (c2), key i1 (c0, c2))")
+		tk.MustExec("insert into t2 values (1, null), (0, null), (-128, 0), (null, 1), (null, null)")
+
+		cteQuery := `with t as (
+			select t_lhs_2.c2 as _col_11, t_rhs_2.c0 as _col_12, t_rhs_2.c2 as _col_13
+			from t2 as t_lhs_2 right join t2 as t_rhs_2 on (false)
+		)
+		select /* issue:67373 cte */ _col_12 as c0
+		from (
+			select * from t as derived
+			where ((true >= (false in (_col_11, _col_11, _col_13))) <> _col_13)
+			union all
+			select * from t as derived
+			where not ((true >= (false in (_col_11, _col_11, _col_13))) <> _col_13)
+			union all
+			select * from t as derived
+			where (((true >= (false in (_col_11, _col_11, _col_13))) <> _col_13) is null)
+		) as wrapper`
+		derivedQuery := `select /* issue:67373 derived */ _col_12 as c0
+		from (
+				select * from (
+					select t_lhs_2.c2 as _col_11, t_rhs_2.c0 as _col_12, t_rhs_2.c2 as _col_13
+					from t2 as t_lhs_2 right join t2 as t_rhs_2 on (false)
+				) as derived
+				where ((true >= (false in (_col_11, _col_11, _col_13))) <> _col_13)
+				union all
+				select * from (
+					select t_lhs_2.c2 as _col_11, t_rhs_2.c0 as _col_12, t_rhs_2.c2 as _col_13
+					from t2 as t_lhs_2 right join t2 as t_rhs_2 on (false)
+				) as derived
+				where not ((true >= (false in (_col_11, _col_11, _col_13))) <> _col_13)
+				union all
+				select * from (
+					select t_lhs_2.c2 as _col_11, t_rhs_2.c0 as _col_12, t_rhs_2.c2 as _col_13
+					from t2 as t_lhs_2 right join t2 as t_rhs_2 on (false)
+				) as derived
+				where (((true >= (false in (_col_11, _col_11, _col_13))) <> _col_13) is null)
+		) as wrapper`
+		cteRows := tk.MustQuery(cteQuery).Sort().Rows()
+		derivedRows := tk.MustQuery(derivedQuery).Sort().Rows()
+		require.Len(t, cteRows, 5)
+		require.Equal(t, cteRows, derivedRows)
+	}
+
 	// merge-join-with-correlated-count
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -348,7 +348,7 @@ func isNullRejected(ctx planctx.PlanContext, schema *expression.Schema, expr exp
 		if isNullRejectedSpecially(ctx, schema, expr) {
 			return true
 		}
-		if hasNestedIn(cond) && !util.IsNullRejected(ctx, schema, cond, true) {
+		if containsNestedInDescendant(cond) && !util.IsNullRejected(ctx, schema, cond, true) {
 			return false
 		}
 
@@ -369,7 +369,7 @@ func isNullRejected(ctx planctx.PlanContext, schema *expression.Schema, expr exp
 	return false
 }
 
-func hasNestedIn(expr expression.Expression) bool {
+func containsNestedInDescendant(expr expression.Expression) bool {
 	sf, ok := expr.(*expression.ScalarFunction)
 	if !ok {
 		return false
@@ -379,7 +379,7 @@ func hasNestedIn(expr expression.Expression) bool {
 		if !ok {
 			continue
 		}
-		if child.FuncName.L == ast.In || hasNestedIn(child) {
+		if child.FuncName.L == ast.In || containsNestedInDescendant(child) {
 			return true
 		}
 	}

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -348,6 +348,9 @@ func isNullRejected(ctx planctx.PlanContext, schema *expression.Schema, expr exp
 		if isNullRejectedSpecially(ctx, schema, expr) {
 			return true
 		}
+		if hasNestedIn(cond) {
+			return false
+		}
 
 		result, err := expression.EvaluateExprWithNull(exprCtx, schema, cond, true)
 		if err != nil {
@@ -360,6 +363,23 @@ func isNullRejected(ctx planctx.PlanContext, schema *expression.Schema, expr exp
 		if x.Value.IsNull() {
 			return true
 		} else if isTrue, err := x.Value.ToBool(sc.TypeCtxOrDefault()); err == nil && isTrue == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasNestedIn(expr expression.Expression) bool {
+	sf, ok := expr.(*expression.ScalarFunction)
+	if !ok {
+		return false
+	}
+	for _, arg := range sf.GetArgs() {
+		child, ok := arg.(*expression.ScalarFunction)
+		if !ok {
+			continue
+		}
+		if child.FuncName.L == ast.In || hasNestedIn(child) {
 			return true
 		}
 	}

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -348,7 +348,7 @@ func isNullRejected(ctx planctx.PlanContext, schema *expression.Schema, expr exp
 		if isNullRejectedSpecially(ctx, schema, expr) {
 			return true
 		}
-		if hasNestedIn(cond) {
+		if hasNestedIn(cond) && !util.IsNullRejected(ctx, schema, cond, true) {
 			return false
 		}
 

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -348,6 +348,9 @@ func isNullRejected(ctx planctx.PlanContext, schema *expression.Schema, expr exp
 		if isNullRejectedSpecially(ctx, schema, expr) {
 			return true
 		}
+		// Keep the join-local null-reject fast path for top-level IN, but defer to
+		// planner/util once a descendant IN appears because EvaluateExprWithNull
+		// can incorrectly treat some nested IN predicates as null-rejected.
 		if containsNestedInDescendant(cond) && !util.IsNullRejected(ctx, schema, cond, true) {
 			return false
 		}
@@ -369,6 +372,9 @@ func isNullRejected(ctx planctx.PlanContext, schema *expression.Schema, expr exp
 	return false
 }
 
+// containsNestedInDescendant reports whether expr contains an IN below the root
+// node. The join-layer fast path handles top-level IN itself, so only descendant
+// IN nodes need the planner/util null-reject fallback.
 func containsNestedInDescendant(expr expression.Expression) bool {
 	sf, ok := expr.(*expression.ScalarFunction)
 	if !ok {

--- a/pkg/planner/util/BUILD.bazel
+++ b/pkg/planner/util/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//pkg/testkit/testsetup",
         "//pkg/types",
         "//pkg/util/collate",
+        "//pkg/util/mock",
         "//pkg/util/ranger",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",

--- a/pkg/planner/util/column_test.go
+++ b/pkg/planner/util/column_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,4 +78,81 @@ func TestIndexInfo2Cols(t *testing.T) {
 	require.True(t, resCols[0].EqualColumn(col0))
 	require.Nil(t, resCols[1])
 	require.True(t, resCols[2].EqualColumn(col2))
+
+	t.Run("null-rejected-nested-in", func(t *testing.T) {
+		ctx := mock.NewContext()
+		tbl := buildNullableNullRejectTestTable()
+		schema, names, err := expression.TableInfo2SchemaAndNames(ctx.GetExprCtx(), ast.NewCIStr(""), tbl)
+		require.NoError(t, err)
+		colE := findColumnByName(t, schema, names, "e")
+		innerSchema := expression.NewSchema(colE)
+
+		safeIn, err := expression.NewFunction(
+			ctx.GetExprCtx(),
+			ast.In,
+			types.NewFieldType(mysql.TypeLonglong),
+			expression.NewOne(),
+			colE,
+			newIntConstant(2),
+		)
+		require.NoError(t, err)
+		safeExpr, err := expression.NewFunction(ctx.GetExprCtx(), ast.NE, types.NewFieldType(mysql.TypeLonglong), safeIn, expression.NewOne())
+		require.NoError(t, err)
+		require.True(t, IsNullRejected(ctx, innerSchema, safeExpr, true))
+
+		unsafeListItem, err := expression.NewFunction(
+			ctx.GetExprCtx(),
+			ast.Ifnull,
+			types.NewFieldType(mysql.TypeLonglong),
+			colE,
+			expression.NewOne(),
+		)
+		require.NoError(t, err)
+		unsafeIn, err := expression.NewFunction(
+			ctx.GetExprCtx(),
+			ast.In,
+			types.NewFieldType(mysql.TypeLonglong),
+			expression.NewOne(),
+			colE,
+			unsafeListItem,
+		)
+		require.NoError(t, err)
+		unsafeExpr, err := expression.NewFunction(ctx.GetExprCtx(), ast.NE, types.NewFieldType(mysql.TypeLonglong), unsafeIn, expression.NewOne())
+		require.NoError(t, err)
+		require.False(t, IsNullRejected(ctx, innerSchema, unsafeExpr, true))
+	})
+}
+
+func buildNullableNullRejectTestTable() *model.TableInfo {
+	return &model.TableInfo{
+		Name: ast.NewCIStr("t"),
+		Columns: []*model.ColumnInfo{
+			{
+				ID:        1,
+				Offset:    0,
+				Name:      ast.NewCIStr("e"),
+				FieldType: *types.NewFieldType(mysql.TypeLonglong),
+				State:     model.StatePublic,
+			},
+		},
+		State: model.StatePublic,
+	}
+}
+
+func newIntConstant(v int64) *expression.Constant {
+	return &expression.Constant{
+		Value:   types.NewIntDatum(v),
+		RetType: types.NewFieldType(mysql.TypeLonglong),
+	}
+}
+
+func findColumnByName(t *testing.T, schema *expression.Schema, names types.NameSlice, colName string) *expression.Column {
+	t.Helper()
+	for i, name := range names {
+		if name.ColName.L == colName {
+			return schema.Columns[i]
+		}
+	}
+	t.Fatalf("column %s not found", colName)
+	return nil
 }

--- a/pkg/planner/util/null_misc.go
+++ b/pkg/planner/util/null_misc.go
@@ -125,7 +125,12 @@ func isNullRejectedSimpleExpr(ctx base.PlanContext, schema *expression.Schema, e
 	return false
 }
 
-func hasUnsafeNestedIn(ctx base.PlanContext, schema *expression.Schema, expr expression.Expression, skipPlanCacheCheck bool) bool {
+func hasUnsafeNestedIn(
+	ctx base.PlanContext,
+	schema *expression.Schema,
+	expr expression.Expression,
+	skipPlanCacheCheck bool,
+) bool {
 	sf, ok := expr.(*expression.ScalarFunction)
 	if !ok {
 		return false

--- a/pkg/planner/util/null_misc.go
+++ b/pkg/planner/util/null_misc.go
@@ -125,6 +125,10 @@ func isNullRejectedSimpleExpr(ctx base.PlanContext, schema *expression.Schema, e
 	return false
 }
 
+// hasUnsafeNestedIn finds descendant IN predicates that are not null-rejected by
+// the IN-list semantics. In that case, EvaluateExprWithNull can be too aggressive
+// after substituting inner columns with NULL, so the caller must avoid treating
+// the whole predicate as null-rejected.
 func hasUnsafeNestedIn(
 	ctx base.PlanContext,
 	schema *expression.Schema,

--- a/pkg/planner/util/null_misc.go
+++ b/pkg/planner/util/null_misc.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
-	"github.com/pingcap/tidb/pkg/planner/planctx"
 )
 
 // allConstants checks if only the expression has only constants.
@@ -100,10 +99,13 @@ func IsNullRejected(ctx base.PlanContext, innerSchema *expression.Schema, predic
 // A condition would be null-rejected in one of following cases:
 // If it is a predicate containing a reference to an inner table (null producing side) that evaluates
 // to UNKNOWN or FALSE when one of its arguments is NULL.
-func isNullRejectedSimpleExpr(ctx planctx.PlanContext, schema *expression.Schema, expr expression.Expression,
+func isNullRejectedSimpleExpr(ctx base.PlanContext, schema *expression.Schema, expr expression.Expression,
 	skipPlanCacheCheck bool) bool {
 	// The expression should reference at least one field in innerSchema or all constants.
 	if !expression.ExprReferenceSchema(expr, schema) && !allConstants(ctx.GetExprCtx(), expr) {
+		return false
+	}
+	if hasUnsafeNestedIn(ctx, schema, expr, skipPlanCacheCheck) {
 		return false
 	}
 	exprCtx := ctx.GetNullRejectCheckExprCtx()
@@ -117,6 +119,26 @@ func isNullRejectedSimpleExpr(ctx planctx.PlanContext, schema *expression.Schema
 		if x.Value.IsNull() {
 			return true
 		} else if isTrue, err := x.Value.ToBool(sc.TypeCtxOrDefault()); err == nil && isTrue == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasUnsafeNestedIn(ctx base.PlanContext, schema *expression.Schema, expr expression.Expression, skipPlanCacheCheck bool) bool {
+	sf, ok := expr.(*expression.ScalarFunction)
+	if !ok {
+		return false
+	}
+	for _, arg := range sf.GetArgs() {
+		child, ok := arg.(*expression.ScalarFunction)
+		if !ok {
+			continue
+		}
+		if child.FuncName.L == ast.In && !isNullRejectedInList(ctx, child, schema, skipPlanCacheCheck) {
+			return true
+		}
+		if hasUnsafeNestedIn(ctx, schema, child, skipPlanCacheCheck) {
 			return true
 		}
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67373

Problem Summary:

`RIGHT OUTER JOIN` can be incorrectly simplified to `INNER JOIN` when the filter is considered
null-rejected too aggressively. For expressions with nested `IN`, this drops rows in repeated
derived-table `UNION ALL` queries, while the equivalent CTE form keeps the correct result.

### What changed and how does it work?

- Make the local outer-join null-reject check in `logical_join.go` conservative for predicates
  containing nested `IN`.
- Add a regression case that keeps the original issue shape and verifies the derived-table query
  matches the CTE result.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fixed an issue where repeated derived tables over a RIGHT OUTER JOIN in UNION ALL could lose rows because the join was incorrectly simplified to an inner join.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed planner handling of nested IN expressions so null-rejection logic is correct.
  * Corrected EXPLAIN and execution behavior for queries with “safe nested IN” to report and return empty results when appropriate.
  * Ensured queries using CTEs and equivalent derived-table + UNION ALL yield consistent results.

* **Tests**
  * Added regression tests covering the nested-IN behaviors and CTE vs. UNION ALL equivalence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->