### PR TITLE
planner, executor, parser: implement scoped FLUSH STATS_DELTA

### DIFF
--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/format"
@@ -2784,6 +2785,15 @@ func restoreRefreshStatsSQL(s *ast.RefreshStatsStmt) (string, error) {
 	return sb.String(), nil
 }
 
+func restoreFlushStatsDeltaSQL(s *ast.FlushStmt) (string, error) {
+	var sb strings.Builder
+	restoreCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
+	if err := s.Restore(restoreCtx); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
+}
+
 func (e *SimpleExec) executeRefreshStatsOnCurrentInstance(ctx context.Context, s *ast.RefreshStatsStmt) error {
 	intest.Assert(len(s.RefreshObjects) > 0, "RefreshObjects should not be empty")
 	intest.AssertFunc(func() bool {
@@ -2860,6 +2870,126 @@ func (e *SimpleExec) executeRefreshStatsOnCurrentInstance(ctx context.Context, s
 	return h.InitStats(ctx, is, tableIDs...)
 }
 
+func appendStatsDeltaTargetTableIDs(targetIDs []int64, tableInfo *model.TableInfo) []int64 {
+	targetIDs = append(targetIDs, tableInfo.ID)
+	if partitionInfo := tableInfo.GetPartitionInfo(); partitionInfo != nil {
+		for _, def := range partitionInfo.Definitions {
+			targetIDs = append(targetIDs, def.ID)
+		}
+	}
+	return targetIDs
+}
+
+func (e *SimpleExec) executeFlushStatsDelta(ctx context.Context, s *ast.FlushStmt) error {
+	intest.AssertFunc(func() bool {
+		for _, obj := range s.FlushObjects {
+			switch obj.StatsObjectScope {
+			case ast.StatsObjectScopeDatabase, ast.StatsObjectScopeTable:
+				if obj.DBName.L == "" {
+					return false
+				}
+			}
+		}
+		return true
+	}, "Flush stats delta broadcast requires database-qualified names")
+	// Note: broadcast serializes the statement back to SQL and every peer reparses it
+	// through the broadcast query path, which does not rerun plan building to fill in
+	// the current database for unqualified table names. `FLUSH STATS_DELTA tbl`
+	// executed in database `db` therefore has to be restored as
+	// `FLUSH STATS_DELTA db.tbl`; otherwise a peer without that current database
+	// cannot resolve the target table.
+	sql, err := restoreFlushStatsDeltaSQL(s)
+	if err != nil {
+		statslogutil.StatsErrVerboseLogger().Error("Failed to format flush stats delta statement", zap.Error(err))
+		return err
+	}
+	if e.IsFromRemote {
+		if err := e.executeFlushStatsDeltaOnCurrentInstance(ctx, s); err != nil {
+			statslogutil.StatsErrVerboseLogger().Error("Failed to dump stats delta to KV from remote", zap.String("sql", sql), zap.Error(err))
+			return err
+		}
+		statslogutil.StatsLogger().Info("Successfully dumped stats delta to KV from remote", zap.String("sql", sql))
+		return nil
+	}
+	if s.IsCluster {
+		if err := broadcast(ctx, e.Ctx(), sql); err != nil {
+			statslogutil.StatsErrVerboseLogger().Error("Failed to broadcast flush stats delta command", zap.String("sql", sql), zap.Error(err))
+			return err
+		}
+		logutil.BgLogger().Info("Successfully broadcast query", zap.String("sql", sql))
+		return nil
+	}
+	// This is the local, non-CLUSTER path: remote requests are handled above to
+	// avoid rebroadcasting, and without CLUSTER we flush only the current TiDB
+	// instance because pending stats deltas are buffered per instance.
+	if err := e.executeFlushStatsDeltaOnCurrentInstance(ctx, s); err != nil {
+		statslogutil.StatsErrVerboseLogger().Error("Failed to dump stats delta to KV on the current instance", zap.String("sql", sql), zap.Error(err))
+		return err
+	}
+	statslogutil.StatsLogger().Info("Successfully dumped stats delta to KV on the current instance", zap.String("sql", sql))
+	return nil
+}
+
+func (e *SimpleExec) executeFlushStatsDeltaOnCurrentInstance(ctx context.Context, s *ast.FlushStmt) error {
+	intest.Assert(len(s.FlushObjects) > 0, "FlushObjects should not be empty")
+	intest.AssertFunc(func() bool {
+		origCount := len(s.FlushObjects)
+		s.DedupFlushObjects()
+		return origCount == len(s.FlushObjects)
+	}, "FlushObjects should be deduplicated in the building phase")
+
+	targetIDs := make([]int64, 0, len(s.FlushObjects))
+	isGlobalScope := len(s.FlushObjects) == 1 && s.FlushObjects[0].StatsObjectScope == ast.StatsObjectScopeGlobal
+	is := sessiontxn.GetTxnManager(e.Ctx()).GetTxnInfoSchema()
+	if !isGlobalScope {
+		for _, flushObject := range s.FlushObjects {
+			switch flushObject.StatsObjectScope {
+			case ast.StatsObjectScopeDatabase:
+				if !is.SchemaExists(flushObject.DBName) {
+					e.Ctx().GetSessionVars().StmtCtx.AppendWarning(infoschema.ErrDatabaseNotExists.FastGenByArgs(flushObject.DBName))
+					statslogutil.StatsLogger().Warn("Failed to find database when flushing stats delta", zap.String("db", flushObject.DBName.O))
+					continue
+				}
+				tables, err := is.SchemaTableInfos(ctx, flushObject.DBName)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				if len(tables) == 0 {
+					statslogutil.StatsLogger().Info("No table in the database when flushing stats delta", zap.String("db", flushObject.DBName.O))
+					continue
+				}
+				for _, tableInfo := range tables {
+					targetIDs = appendStatsDeltaTargetTableIDs(targetIDs, tableInfo)
+				}
+			case ast.StatsObjectScopeTable:
+				tableInfo, err := is.TableInfoByName(flushObject.DBName, flushObject.TableName)
+				if err != nil {
+					if infoschema.ErrTableNotExists.Equal(err) {
+						e.Ctx().GetSessionVars().StmtCtx.AppendWarning(infoschema.ErrTableNotExists.FastGenByArgs(flushObject.DBName, flushObject.TableName))
+						statslogutil.StatsLogger().Warn("Failed to find table when flushing stats delta", zap.String("db", flushObject.DBName.O), zap.String("table", flushObject.TableName.O))
+						continue
+					}
+					return errors.Trace(err)
+				}
+				if tableInfo == nil {
+					intest.Assert(false, "Table should not be nil here")
+					e.Ctx().GetSessionVars().StmtCtx.AppendWarning(infoschema.ErrTableNotExists.FastGenByArgs(flushObject.DBName, flushObject.TableName))
+					statslogutil.StatsLogger().Warn("Failed to find table when flushing stats delta", zap.String("db", flushObject.DBName.O), zap.String("table", flushObject.TableName.O))
+					continue
+				}
+				targetIDs = appendStatsDeltaTargetTableIDs(targetIDs, tableInfo)
+			default:
+				intest.Assert(false, "No other scopes should be here")
+			}
+		}
+		if len(targetIDs) == 0 {
+			statslogutil.StatsLogger().Info("No valid database or table to flush stats delta")
+			return nil
+		}
+	}
+	return domain.GetDomain(e.Ctx()).StatsHandle().DumpStatsDeltaToKV(true, targetIDs...)
+}
+
 func broadcast(ctx context.Context, sctx sessionctx.Context, sql string) error {
 	broadcastExec := &tipb.Executor{
 		Tp: tipb.ExecType_TypeBroadcastQuery,
@@ -2933,32 +3063,7 @@ func (e *SimpleExec) executeFlush(ctx context.Context, s *ast.FlushStmt) error {
 	case ast.FlushClientErrorsSummary:
 		errno.FlushStats()
 	case ast.FlushStatsDelta:
-		h := domain.GetDomain(e.Ctx()).StatsHandle()
-		if e.IsFromRemote {
-			err := h.DumpStatsDeltaToKV(true)
-			if err != nil {
-				statslogutil.StatsErrVerboseLogger().Error("Failed to dump stats delta to KV from remote", zap.Error(err))
-			} else {
-				statslogutil.StatsLogger().Info("Successfully dumped stats delta to KV from remote")
-			}
-			return err
-		}
-		if s.IsCluster {
-			var sb strings.Builder
-			restoreCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
-			if err := s.Restore(restoreCtx); err != nil {
-				statslogutil.StatsErrVerboseLogger().Error("Failed to format flush stats delta statement", zap.Error(err))
-				return err
-			}
-			sql := sb.String()
-			if err := broadcast(ctx, e.Ctx(), sql); err != nil {
-				statslogutil.StatsErrVerboseLogger().Error("Failed to broadcast flush stats delta command", zap.String("sql", sql), zap.Error(err))
-				return err
-			}
-			logutil.BgLogger().Info("Successfully broadcast query", zap.String("sql", sql))
-			return nil
-		}
-		return h.DumpStatsDeltaToKV(true)
+		return e.executeFlushStatsDelta(ctx, s)
 	}
 	return nil
 }

--- a/pkg/executor/simple_test.go
+++ b/pkg/executor/simple_test.go
@@ -409,34 +409,138 @@ func TestRefreshStatsConcurrently(t *testing.T) {
 }
 
 func TestFlushStatsDelta(t *testing.T) {
-	store, dom := testkit.CreateMockStoreAndDomain(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t")
-	tk.MustExec("create table t (a int, b int)")
+	t.Run("full scope", func(t *testing.T) {
+		store, dom := testkit.CreateMockStoreAndDomain(t)
+		tk := testkit.NewTestKit(t, store)
+		tk.MustExec("use test")
+		tk.MustExec("drop table if exists t")
+		tk.MustExec("create table t (a int, b int)")
 
-	// Get table ID for later query
-	ctx := context.Background()
-	is := dom.InfoSchema()
-	tbl, err := is.TableByName(ctx, ast.NewCIStr("test"), ast.NewCIStr("t"))
-	require.NoError(t, err)
-	tableID := tbl.Meta().ID
+		ctx := context.Background()
+		is := dom.InfoSchema()
+		tbl, err := is.TableByName(ctx, ast.NewCIStr("test"), ast.NewCIStr("t"))
+		require.NoError(t, err)
+		tableID := tbl.Meta().ID
 
-	// Insert some rows to generate stats delta
-	tk.MustExec("insert into t values (1,1), (2,2), (3,3), (4,4), (5,5)")
-	tk.MustExec("flush stats_delta *.*")
-	rows := tk.MustQuery("select modify_count from mysql.stats_meta where table_id = ?", tableID).Rows()
-	require.Len(t, rows, 1, "stats_meta should have entry for the table")
-	modifyCnt, err := strconv.ParseInt(rows[0][0].(string), 10, 64)
-	require.NoError(t, err)
-	require.Equal(t, int64(5), modifyCnt, "modify_count should be 5 after inserting 5 rows and flushing")
+		tk.MustExec("insert into t values (1,1), (2,2), (3,3), (4,4), (5,5)")
+		tk.MustExec("flush stats_delta *.*")
+		rows := tk.MustQuery("select modify_count from mysql.stats_meta where table_id = ?", tableID).Rows()
+		require.Len(t, rows, 1, "stats_meta should have entry for the table")
+		modifyCnt, err := strconv.ParseInt(rows[0][0].(string), 10, 64)
+		require.NoError(t, err)
+		require.Equal(t, int64(5), modifyCnt, "modify_count should be 5 after inserting 5 rows and flushing")
 
-	// Insert 2 more rows and flush again
-	tk.MustExec("insert into t values (6,6), (7,7)")
-	tk.MustExec("flush stats_delta *.*")
-	rows = tk.MustQuery("select modify_count from mysql.stats_meta where table_id = ?", tableID).Rows()
-	require.Len(t, rows, 1, "stats_meta should have entry for the table")
-	modifyCnt, err = strconv.ParseInt(rows[0][0].(string), 10, 64)
-	require.NoError(t, err)
-	require.Equal(t, int64(7), modifyCnt, "modify_count should be 7 after inserting 2 more rows and flushing")
+		tk.MustExec("insert into t values (6,6), (7,7)")
+		tk.MustExec("flush stats_delta *.*")
+		rows = tk.MustQuery("select modify_count from mysql.stats_meta where table_id = ?", tableID).Rows()
+		require.Len(t, rows, 1, "stats_meta should have entry for the table")
+		modifyCnt, err = strconv.ParseInt(rows[0][0].(string), 10, 64)
+		require.NoError(t, err)
+		require.Equal(t, int64(7), modifyCnt, "modify_count should be 7 after inserting 2 more rows and flushing")
+	})
+
+	t.Run("scoped behavior", func(t *testing.T) {
+		store, dom := testkit.CreateMockStoreAndDomain(t)
+		tk := testkit.NewTestKit(t, store)
+		tk.MustExec("use test")
+		tk.MustExec("drop table if exists t1, t2, tp")
+		tk.MustExec("create table t1 (a int, b int)")
+		tk.MustExec("create table t2 (a int, b int)")
+		tk.MustExec(`create table tp (a int, b int)
+			partition by range(a) (
+				partition p0 values less than (10),
+				partition p1 values less than (20)
+			)`)
+
+		ctx := context.Background()
+		is := dom.InfoSchema()
+		t1, err := is.TableByName(ctx, ast.NewCIStr("test"), ast.NewCIStr("t1"))
+		require.NoError(t, err)
+		t2, err := is.TableByName(ctx, ast.NewCIStr("test"), ast.NewCIStr("t2"))
+		require.NoError(t, err)
+		tp, err := is.TableByName(ctx, ast.NewCIStr("test"), ast.NewCIStr("tp"))
+		require.NoError(t, err)
+		partitionInfo := tp.Meta().GetPartitionInfo()
+		require.NotNil(t, partitionInfo)
+		p0ID := partitionInfo.Definitions[0].ID
+		p1ID := partitionInfo.Definitions[1].ID
+
+		getModifyCount := func(tableID int64) int64 {
+			rows := tk.MustQuery("select modify_count from mysql.stats_meta where table_id = ?", tableID).Rows()
+			if len(rows) == 0 {
+				return -1
+			}
+			modifyCnt, err := strconv.ParseInt(rows[0][0].(string), 10, 64)
+			require.NoError(t, err)
+			return modifyCnt
+		}
+
+		tk.MustExec("insert into t1 values (1,1), (2,2)")
+		tk.MustExec("insert into t2 values (3,3), (4,4), (5,5)")
+		tk.MustExec("insert into tp values (1,1), (2,2), (11,11)")
+
+		tk.MustExec("flush stats_delta t1")
+		require.Equal(t, int64(2), getModifyCount(t1.Meta().ID))
+		require.NotEqual(t, int64(3), getModifyCount(t2.Meta().ID), "unrelated table should not be flushed by table scope")
+		require.NotEqual(t, int64(3), getModifyCount(tp.Meta().ID), "partitioned table should not be flushed by unrelated table scope")
+
+		tk.MustExec("flush stats_delta tp")
+		require.Equal(t, int64(3), getModifyCount(tp.Meta().ID), "global stats for the partitioned table should be flushed")
+		require.Equal(t, int64(2), getModifyCount(p0ID), "partition p0 should be flushed")
+		require.Equal(t, int64(1), getModifyCount(p1ID), "partition p1 should be flushed")
+		require.NotEqual(t, int64(3), getModifyCount(t2.Meta().ID), "database scope has not been flushed yet")
+
+		tk.MustExec("flush stats_delta test.*")
+		require.Equal(t, int64(3), getModifyCount(t2.Meta().ID), "database scope should flush the remaining table")
+	})
+
+	t.Run("privilege checks", func(t *testing.T) {
+		store, _ := testkit.CreateMockStoreAndDomain(t)
+		tk := testkit.NewTestKit(t, store)
+		tk.MustExec("use test")
+		tk.MustExec("drop table if exists t_flush_priv")
+		tk.MustExec("create table t_flush_priv (a int)")
+
+		t.Run("table scope requires select", func(t *testing.T) {
+			tk.MustExec("drop user if exists 'flush_reader'@'%'")
+			tk.MustExec("create user 'flush_reader'@'%'")
+
+			tkUser := testkit.NewTestKit(t, store)
+			require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "flush_reader", Hostname: "%"}, nil, nil, nil))
+			tkUser.MustGetErrCode("flush stats_delta test.t_flush_priv", errno.ErrTableaccessDenied)
+
+			tk.MustExec("grant select on test.t_flush_priv to 'flush_reader'@'%'")
+			tkUser.MustExec("flush stats_delta test.t_flush_priv")
+		})
+
+		t.Run("database scope requires select", func(t *testing.T) {
+			tk.MustExec("drop user if exists 'flush_db_reader'@'%'")
+			tk.MustExec("create user 'flush_db_reader'@'%'")
+
+			tkUser := testkit.NewTestKit(t, store)
+			require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "flush_db_reader", Hostname: "%"}, nil, nil, nil))
+			tkUser.MustGetErrCode("flush stats_delta test.*", errno.ErrDBaccessDenied)
+
+			tk.MustExec("grant select on test.* to 'flush_db_reader'@'%'")
+			tkUser.MustExec("flush stats_delta test.*")
+		})
+
+		t.Run("global scope requires global select", func(t *testing.T) {
+			tk.MustExec("drop user if exists 'flush_global_reader'@'%'")
+			tk.MustExec("create user 'flush_global_reader'@'%'")
+
+			tkUser := testkit.NewTestKit(t, store)
+			require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "flush_global_reader", Hostname: "%"}, nil, nil, nil))
+			tkUser.MustGetErrCode("flush stats_delta *.*", errno.ErrPrivilegeCheckFail)
+
+			tk.MustExec("grant select on *.* to 'flush_global_reader'@'%'")
+			tkUser.MustExec("flush stats_delta *.*")
+		})
+	})
+
+	t.Run("requires default db for bare table", func(t *testing.T) {
+		store, _ := testkit.CreateMockStoreAndDomain(t)
+		tk := testkit.NewTestKit(t, store)
+		tk.MustGetDBError("flush stats_delta t1", plannererrors.ErrNoDB)
+	})
 }

--- a/pkg/parser/ast/stats.go
+++ b/pkg/parser/ast/stats.go
@@ -421,20 +421,28 @@ func (n *RefreshStatsStmt) Accept(v Visitor) (Node, bool) {
 }
 
 func (n *RefreshStatsStmt) Dedup() {
-	if len(n.RefreshObjects) == 0 {
-		return
+	n.RefreshObjects = dedupStatsObjects(n.RefreshObjects)
+}
+
+// DedupFlushObjects removes duplicate or shadowed scoped objects for FLUSH STATS_DELTA.
+func (n *FlushStmt) DedupFlushObjects() {
+	n.FlushObjects = dedupStatsObjects(n.FlushObjects)
+}
+
+func dedupStatsObjects(objects []*StatsObject) []*StatsObject {
+	if len(objects) == 0 {
+		return objects
 	}
 
 	dbSeen := make(map[string]struct{})
 	tableSeen := make(map[string]struct{})
-	result := make([]*StatsObject, 0, len(n.RefreshObjects))
+	result := make([]*StatsObject, 0, len(objects))
 
-	for _, obj := range n.RefreshObjects {
+	for _, obj := range objects {
 		switch obj.StatsObjectScope {
 		// Global scope supersedes everything else. Keep the first global target only.
 		case StatsObjectScopeGlobal:
-			n.RefreshObjects = []*StatsObject{obj}
-			return
+			return []*StatsObject{obj}
 		case StatsObjectScopeDatabase:
 			dbKey := obj.DBName.L
 			if _, exists := dbSeen[dbKey]; exists {
@@ -456,7 +464,6 @@ func (n *RefreshStatsStmt) Dedup() {
 				filtered = append(filtered, existing)
 			}
 			result = append(filtered, obj)
-
 		case StatsObjectScopeTable:
 			dbKey := obj.DBName.L
 			if dbKey != "" {
@@ -473,7 +480,7 @@ func (n *RefreshStatsStmt) Dedup() {
 		}
 	}
 
-	n.RefreshObjects = result
+	return result
 }
 
 type StatsObjectScopeType int

--- a/pkg/parser/ast/stats_test.go
+++ b/pkg/parser/ast/stats_test.go
@@ -129,6 +129,11 @@ func TestFlushStatsDeltaScoped(t *testing.T) {
 			cluster: true,
 		},
 		{
+			sql:     "FLUSH STATS_DELTA table1",
+			want:    "FLUSH STATS_DELTA `table1`",
+			objects: 1,
+		},
+		{
 			sql:     "FLUSH STATS_DELTA db1.t1, db2.*, *.*",
 			want:    "FLUSH STATS_DELTA `db1`.`t1`, `db2`.*, *.*",
 			objects: 3,
@@ -152,6 +157,40 @@ func TestFlushStatsDeltaScoped(t *testing.T) {
 			require.Equal(t, test.cluster, fs.IsCluster)
 			var sb strings.Builder
 			err = stmt.Restore(format.NewRestoreCtx(format.DefaultRestoreFlags, &sb))
+			require.NoError(t, err)
+			require.Equal(t, test.want, sb.String())
+		})
+	}
+
+	dedupTests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			name: "global overrides all",
+			sql:  "FLUSH STATS_DELTA table1, db1.t1, *.*, db2.t2",
+			want: "FLUSH STATS_DELTA *.*",
+		},
+		{
+			name: "database removes prior tables",
+			sql:  "FLUSH STATS_DELTA db1.t1, db2.t1, db1.*, db2.t2",
+			want: "FLUSH STATS_DELTA `db2`.`t1`, `db1`.*, `db2`.`t2`",
+		},
+		{
+			name: "table duplicates case insensitive",
+			sql:  "FLUSH STATS_DELTA db1.t1, db1.T1, db2.t1",
+			want: "FLUSH STATS_DELTA `db1`.`t1`, `db2`.`t1`",
+		},
+	}
+	for _, test := range dedupTests {
+		t.Run(test.name, func(t *testing.T) {
+			stmt, err := p.ParseOneStmt(test.sql, "", "")
+			require.NoError(t, err)
+			fs := stmt.(*ast.FlushStmt)
+			fs.DedupFlushObjects()
+			var sb strings.Builder
+			err = fs.Restore(format.NewRestoreCtx(format.DefaultRestoreFlags, &sb))
 			require.NoError(t, err)
 			require.Equal(t, test.want, sb.String())
 		})

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1472,6 +1472,7 @@ func TestDBAStmt(t *testing.T) {
 		{"flush stats_delta *.* cluster", true, "FLUSH STATS_DELTA *.* CLUSTER"},
 		{"flush stats_delta db1.*", true, "FLUSH STATS_DELTA `db1`.*"},
 		{"flush stats_delta db1.* cluster", true, "FLUSH STATS_DELTA `db1`.* CLUSTER"},
+		{"flush stats_delta t1", true, "FLUSH STATS_DELTA `t1`"},
 		{"flush stats_delta db1.t1", true, "FLUSH STATS_DELTA `db1`.`t1`"},
 		{"flush stats_delta db1.t1 cluster", true, "FLUSH STATS_DELTA `db1`.`t1` CLUSTER"},
 		{"flush stats_delta db1.t1, db2.*", true, "FLUSH STATS_DELTA `db1`.`t1`, `db2`.*"},

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -1363,6 +1363,30 @@ func TestVisitInfo(t *testing.T) {
 			},
 		},
 		{
+			sql: "flush stats_delta ttt",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "ttt", "", nil, false, nil, false},
+			},
+		},
+		{
+			sql: "flush stats_delta test.ttt, test.*",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "", "", nil, false, nil, false},
+			},
+		},
+		{
+			sql: "flush stats_delta test.*",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "", "", nil, false, nil, false},
+			},
+		},
+		{
+			sql: "flush stats_delta *.*",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "", "", "", plannererrors.ErrPrivilegeCheckFail, false, nil, false},
+			},
+		},
+		{
 			sql: "SET GLOBAL wait_timeout=12345",
 			ans: []visitInfo{
 				{mysql.ExtendedPriv, "", "", "", plannererrors.ErrSpecificAccessDenied, false, []string{"SYSTEM_VARIABLES_ADMIN"}, false},

--- a/pkg/planner/core/pb_to_plan.go
+++ b/pkg/planner/core/pb_to_plan.go
@@ -314,6 +314,11 @@ func (b *PBPlanBuilder) pbToBroadcastQuery(e *tipb.Executor) (base.PhysicalPlan,
 			return nil, errors.Errorf("unexpected admin statement %s in broadcast query", *e.BroadcastQuery.Query)
 		}
 		innerPlan = &SQLBindPlan{SQLBindOp: OpReloadBindings, IsFromRemote: true}
+	case *ast.FlushStmt:
+		if x.Tp != ast.FlushStatsDelta {
+			return nil, errors.Errorf("unexpected flush statement %s in broadcast query", *e.BroadcastQuery.Query)
+		}
+		innerPlan = &Simple{Statement: stmt, IsFromRemote: true, ResolveCtx: resolve.NewContext()}
 	case *ast.RefreshStatsStmt:
 		innerPlan = &Simple{Statement: stmt, IsFromRemote: true, ResolveCtx: resolve.NewContext()}
 	default:

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3671,6 +3671,14 @@ func (b *PlanBuilder) buildSimple(ctx context.Context, node ast.StmtNode) (base.
 
 	switch raw := node.(type) {
 	case *ast.FlushStmt:
+		if raw.Tp == ast.FlushStatsDelta {
+			if err := fillDefaultDBForStatsObjects(b.ctx, raw.FlushObjects); err != nil {
+				return nil, err
+			}
+			raw.DedupFlushObjects()
+			b.requireSelectPrivForStatsObjects(raw.FlushObjects)
+			break
+		}
 		err := plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs("RELOAD")
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ReloadPriv, "", "", "", err)
 	case *ast.AlterInstanceStmt:
@@ -4818,11 +4826,11 @@ func (*PlanBuilder) buildLoadStats(ld *ast.LoadStatsStmt) base.Plan {
 }
 
 func (b *PlanBuilder) buildRefreshStats(rs *ast.RefreshStatsStmt) (base.Plan, error) {
-	if err := fillDefaultDBForRefreshStats(b.ctx, rs); err != nil {
+	if err := fillDefaultDBForStatsObjects(b.ctx, rs.RefreshObjects); err != nil {
 		return nil, err
 	}
 	rs.Dedup()
-	b.requireSelectOrRestoreAdminPrivForRefreshStats(rs)
+	b.requireSelectOrRestoreAdminPrivForStatsObjects(rs.RefreshObjects)
 	p := &Simple{
 		Statement:    rs,
 		IsFromRemote: false,
@@ -4831,13 +4839,13 @@ func (b *PlanBuilder) buildRefreshStats(rs *ast.RefreshStatsStmt) (base.Plan, er
 	return p, nil
 }
 
-func fillDefaultDBForRefreshStats(ctx base.PlanContext, rs *ast.RefreshStatsStmt) error {
-	if len(rs.RefreshObjects) == 0 {
+func fillDefaultDBForStatsObjects(ctx base.PlanContext, objects []*ast.StatsObject) error {
+	if len(objects) == 0 {
 		return nil
 	}
 
 	currentDB := ctx.GetSessionVars().CurrentDB
-	for _, obj := range rs.RefreshObjects {
+	for _, obj := range objects {
 		if obj.StatsObjectScope != ast.StatsObjectScopeTable {
 			continue
 		}
@@ -4852,9 +4860,9 @@ func fillDefaultDBForRefreshStats(ctx base.PlanContext, rs *ast.RefreshStatsStmt
 	return nil
 }
 
-func (b *PlanBuilder) requireSelectOrRestoreAdminPrivForRefreshStats(rs *ast.RefreshStatsStmt) {
-	if len(rs.RefreshObjects) == 0 {
-		intest.Assert(len(rs.RefreshObjects) > 0, "RefreshObjects should not be empty")
+func (b *PlanBuilder) requireSelectOrRestoreAdminPrivForStatsObjects(objects []*ast.StatsObject) {
+	if len(objects) == 0 {
+		intest.Assert(len(objects) > 0, "stats objects should not be empty")
 		return
 	}
 
@@ -4866,8 +4874,17 @@ func (b *PlanBuilder) requireSelectOrRestoreAdminPrivForRefreshStats(rs *ast.Ref
 		}
 	}
 
+	b.requireSelectPrivForStatsObjects(objects)
+}
+
+func (b *PlanBuilder) requireSelectPrivForStatsObjects(objects []*ast.StatsObject) {
+	if len(objects) == 0 {
+		intest.Assert(len(objects) > 0, "stats objects should not be empty")
+		return
+	}
+
 	user := b.ctx.GetSessionVars().User
-	for _, obj := range rs.RefreshObjects {
+	for _, obj := range objects {
 		switch obj.StatsObjectScope {
 		case ast.StatsObjectScopeGlobal:
 			var err error
@@ -4885,12 +4902,11 @@ func (b *PlanBuilder) requireSelectOrRestoreAdminPrivForRefreshStats(rs *ast.Ref
 			}
 			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, obj.DBName.L, "", "", err)
 		case ast.StatsObjectScopeTable:
-			dbName := obj.DBName.L
 			var err error
 			if user != nil {
 				err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SELECT", user.AuthUsername, user.AuthHostname, obj.TableName.O)
 			}
-			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, dbName, obj.TableName.L, "", err)
+			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, obj.DBName.L, obj.TableName.L, "", err)
 		}
 	}
 }

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -79,7 +79,7 @@ type StatsUsage interface {
 
 	// DumpStatsDeltaToKV sweeps the whole list and updates the global map, then dumps the selected table deltas to KV.
 	// If tableIDs is empty, it dumps every table that held in the map.
-	DumpStatsDeltaToKV(dumpAll bool, tableIDs ...int64) error
+	DumpStatsDeltaToKV(forceDump bool, tableIDs ...int64) error
 
 	// DumpColStatsUsageToKV sweeps the whole list, updates the column stats usage map and dumps it to KV.
 	DumpColStatsUsageToKV() error

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -62,10 +62,10 @@ type TimeCostRecorderForTest interface {
 
 // needDumpStatsDelta checks whether to dump stats delta.
 // 1. If the table doesn't exist or is a mem table or system table, then return false.
-// 2. If the mode is DumpAll, then return true.
+// 2. If forceDump is true, then return true.
 // 3. If the stats delta haven't been dumped in the past hour, then return true.
 // 4. If the table stats is pseudo or empty or `Modify Count / Table Count` exceeds the threshold.
-func (s *statsUsageImpl) needDumpStatsDelta(is infoschema.InfoSchema, dumpAll bool, id int64, item variable.TableDelta, currentTime time.Time) bool {
+func (s *statsUsageImpl) needDumpStatsDelta(is infoschema.InfoSchema, forceDump bool, id int64, item variable.TableDelta, currentTime time.Time) bool {
 	tableItem, ok := s.statsHandle.TableItemByID(is, id)
 	if !ok {
 		return false
@@ -73,7 +73,7 @@ func (s *statsUsageImpl) needDumpStatsDelta(is infoschema.InfoSchema, dumpAll bo
 	if metadef.IsMemOrSysDB(tableItem.DBName.L) {
 		return false
 	}
-	if dumpAll {
+	if forceDump {
 		return true
 	}
 	intest.Assert(!item.InitTime.IsZero(), "InitTime should be initialized before evaluating dump conditions")
@@ -97,9 +97,10 @@ const (
 )
 
 // DumpStatsDeltaToKV sweeps the whole list and updates the global map, then dumps the selected table deltas to KV.
-// If the mode is `DumpDelta`, it will only dump that delta info that `Modify Count / Table Count` greater than a ratio.
+// If forceDump is false, it dumps only eligible table deltas: ones that have not been dumped for a while,
+// or whose stats are missing/empty, or whose `Modify Count / Table Count` exceeds the ratio threshold.
 // If tableIDs is empty, it dumps every table that held in map to KV.
-func (s *statsUsageImpl) DumpStatsDeltaToKV(dumpAll bool, tableIDs ...int64) error {
+func (s *statsUsageImpl) DumpStatsDeltaToKV(forceDump bool, tableIDs ...int64) error {
 	defer util.Recover(metrics.LabelStats, "DumpStatsDeltaToKV", nil, false)
 	start := time.Now()
 	defer func() {
@@ -142,7 +143,7 @@ func (s *statsUsageImpl) DumpStatsDeltaToKV(dumpAll bool, tableIDs ...int64) err
 					item.InitTime = batchStart
 					deltaMap[id] = item
 				}
-				needDump := s.needDumpStatsDelta(is, dumpAll, id, item, batchStart)
+				needDump := s.needDumpStatsDelta(is, forceDump, id, item, batchStart)
 				if !needDump {
 					continue
 				}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66888

Problem Summary:
Complete scoped `FLUSH STATS_DELTA` after #67728 by adding scoped privilege checks and scoped delta flushing.

### What changed and how does it work?

- derive `SELECT` privileges for `FLUSH STATS_DELTA db.tbl`, `db.*`, and `*.*`
- fill the default DB and deduplicate scoped objects like `REFRESH STATS`
- flush only the requested table / schema / global scope
- expand partitioned tables to physical partition IDs
- support remote execution for `FLUSH STATS_DELTA ... CLUSTER`
- add regression tests for privilege checks and scoped flush behavior

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/release-notes-style-guide.html) to write a quality release note.

```release-note
`FLUSH STATS_DELTA` now enforces scoped `SELECT` privileges and flushes only the requested table or schema, including partitioned tables.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FLUSH STATS DELTA supports targeted flushing for table, database, and global scopes, with partition-aware targeting and deduplication (global overrides narrower selectors).

* **Bug Fixes / Improvements**
  * Improved validation, clearer error/logging for invalid scopes, restore/broadcast, and stricter privilege enforcement; bare-table calls now require a default database.

* **Tests**
  * Expanded tests covering scoped behavior, privilege scenarios, deduplication, restore formatting, and bare-table error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->