### PR TITLE
planner, statistics: skip internal column IDs in async stats load queue

### DIFF
--- a/pkg/planner/core/rule/collect_column_stats_usage.go
+++ b/pkg/planner/core/rule/collect_column_stats_usage.go
@@ -153,6 +153,11 @@ func (c *columnStatsUsageCollector) collectPredicateColumnsForDataSource(askedCo
 		c.tblID2PartitionIDs[tblID] = append(c.tblID2PartitionIDs[tblID], ds.PhysicalTableID)
 	}
 	for _, col := range ds.Schema().Columns {
+		// Internal pseudo columns (for example, _tidb_rowid with ID -1) don't have persisted stats.
+		// Skip them when collecting predicate/histogram-needed columns.
+		if col.ID <= 0 {
+			continue
+		}
 		tblColID := model.TableItemID{TableID: tblID, ID: col.ID, IsIndex: false}
 		c.colMap[col.UniqueID] = map[model.TableItemID]struct{}{tblColID: {}}
 	}

--- a/pkg/planner/core/rule/collect_column_stats_usage_test.go
+++ b/pkg/planner/core/rule/collect_column_stats_usage_test.go
@@ -361,6 +361,10 @@ func TestCollectHistNeededColumns(t *testing.T) {
 			res: []string{"t.a full", "t.b full"},
 		},
 		{
+			sql: "select * from t3 where _tidb_rowid > 1",
+			res: []string{},
+		},
+		{
 			sql: "select b, count(a) from t where b > 1 group by b having count(a) > 2",
 			res: []string{"t.a meta", "t.b full"},
 		},

--- a/pkg/statistics/column.go
+++ b/pkg/statistics/column.go
@@ -140,10 +140,11 @@ func ColumnStatsIsInvalid(colStats *Column, sctx planctx.PlanContext, histColl *
 			return true
 		}
 		stmtctx := sctx.GetSessionVars().StmtCtx
+		// Internal pseudo columns (eg: _tidb_rowid with ID -1) don't have persisted column stats.
+		isNonInternalColumnID := cid > 0
 		if (colStats == nil || !colStats.IsStatsInitialized() || colStats.IsLoadNeeded()) &&
 			stmtctx != nil &&
-			// Internal pseudo columns (for example, _tidb_rowid with ID -1) don't have persisted column stats.
-			cid > 0 &&
+			isNonInternalColumnID &&
 			!histColl.CanNotTriggerLoad {
 			asyncload.AsyncLoadHistogramNeededItems.Insert(model.TableItemID{
 				TableID:          histColl.PhysicalID,

--- a/pkg/statistics/column.go
+++ b/pkg/statistics/column.go
@@ -142,6 +142,8 @@ func ColumnStatsIsInvalid(colStats *Column, sctx planctx.PlanContext, histColl *
 		stmtctx := sctx.GetSessionVars().StmtCtx
 		if (colStats == nil || !colStats.IsStatsInitialized() || colStats.IsLoadNeeded()) &&
 			stmtctx != nil &&
+			// Internal pseudo columns (for example, _tidb_rowid with ID -1) don't have persisted column stats.
+			cid > 0 &&
 			!histColl.CanNotTriggerLoad {
 			asyncload.AsyncLoadHistogramNeededItems.Insert(model.TableItemID{
 				TableID:          histColl.PhysicalID,

--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -60,7 +60,7 @@ go_test(
         "stats_read_writer_test.go",
     ],
     flaky = True,
-    shard_count = 31,
+    shard_count = 28,
     deps = [
         ":storage",
         "//pkg/domain",

--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -60,7 +60,7 @@ go_test(
         "stats_read_writer_test.go",
     ],
     flaky = True,
-    shard_count = 26,
+    shard_count = 31,
     deps = [
         ":storage",
         "//pkg/domain",

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -628,6 +628,11 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 	// Regardless of whether the load is successful or not, we must remove the item from the async load list.
 	// The principle is to load the histogram for each column at most once in async load, as we already have a retry mechanism in the sync load.
 	defer asyncload.AsyncLoadHistogramNeededItems.Delete(col)
+	// Internal pseudo columns (for example, _tidb_rowid with ID -1) do not have corresponding column metadata/stats.
+	// Skip them defensively in case they leak into the async-load queue.
+	if col.ID <= 0 {
+		return nil
+	}
 	statsTbl, ok := statsHandle.Get(col.TableID)
 	if !ok {
 		// This could happen when the table is dropped after the async load is triggered.

--- a/pkg/statistics/handle/storage/read_test.go
+++ b/pkg/statistics/handle/storage/read_test.go
@@ -170,15 +170,50 @@ func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
 
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set @@tidb_stats_load_sync_wait = 0")
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
-	tk.MustExec("create table t(a int)")
+	tk.MustExec("create table t(a int, b int)")
+	tk.MustExec("insert into t value(1,1), (2,2);")
+	h := dom.StatsHandle()
+	tk.MustExec("flush stats_delta")
+	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	tk.MustExec("analyze table t")
+	tk.MustExec("set tidb_opt_objective='determinate';")
+	tk.MustQuery("select * from t where a = 2 and b = 2 and _tidb_rowid > 0;").Check(testkit.Rows("2 2"))
 
 	table, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := table.Meta()
-	h := dom.StatsHandle()
-	// Make sure this table exists in stats cache so the old path would touch session context.
+	colAID := tableInfo.Columns[0].ID
+	colBID := tableInfo.Columns[1].ID
+	// 1. query-triggered async loading should enqueue only real columns (a, b) and should never enqueue the internal pseudo column _tidb_rowid (ID=-1).
+	require.Eventually(t, func() bool {
+		items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
+		hasA, hasB := false, false
+		for _, item := range items {
+			if item.TableID != tableInfo.ID || item.IsIndex {
+				continue
+			}
+			// if column _tidb_rowid (ID=-1) should never enqueue,
+			if item.ID <= 0 {
+				return false
+			}
+			if item.ID == colAID {
+				hasA = true
+			}
+			if item.ID == colBID {
+				hasB = true
+			}
+		}
+		return hasA && hasB
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Clear query-triggered items so this test can isolate the nil-sctx internal-column path.
+	clearAsyncLoadHistogramNeededItems()
+
+	// 2. even if an internal pseudo column item (ID=-1) is inserted into the queue by mistake,
+	// LoadNeededHistograms should skip it safely and remove it without panic.
 	statsTbl := h.GetPhysicalTableStats(tableInfo.ID, tableInfo)
 	require.NotNil(t, statsTbl)
 	require.Equal(t, tableInfo.ID, statsTbl.PhysicalID)

--- a/pkg/statistics/handle/storage/read_test.go
+++ b/pkg/statistics/handle/storage/read_test.go
@@ -179,7 +179,6 @@ func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
 	tk.MustExec("flush stats_delta *.*")
 	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
 	tk.MustExec("analyze table t")
-	tk.MustExec("set tidb_opt_objective='determinate';")
 	tk.MustQuery("select * from t where a = 2 and b = 2 and _tidb_rowid > 0;").Check(testkit.Rows("2 2"))
 
 	table, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))

--- a/pkg/statistics/handle/storage/read_test.go
+++ b/pkg/statistics/handle/storage/read_test.go
@@ -176,7 +176,7 @@ func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
 	tk.MustExec("create table t(a int, b int)")
 	tk.MustExec("insert into t value(1,1), (2,2);")
 	h := dom.StatsHandle()
-	tk.MustExec("flush stats_delta")
+	tk.MustExec("flush stats_delta *.*")
 	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
 	tk.MustExec("analyze table t")
 	tk.MustExec("set tidb_opt_objective='determinate';")

--- a/pkg/statistics/handle/storage/read_test.go
+++ b/pkg/statistics/handle/storage/read_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/statistics"
@@ -145,4 +146,59 @@ func TestLoadNonExistentIndexStats(t *testing.T) {
 	// Verify all items were removed from AsyncLoadHistogramNeededItems after loading.
 	items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
 	require.Equal(t, len(items), 0, "AsyncLoadHistogramNeededItems should be empty after loading")
+}
+
+func TestColumnStatsIsInvalidSkipsInternalColumnID(t *testing.T) {
+	clearAsyncLoadHistogramNeededItems()
+	t.Cleanup(clearAsyncLoadHistogramNeededItems)
+
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	histColl := &statistics.HistColl{
+		PhysicalID: 1,
+	}
+	statistics.ColumnStatsIsInvalid(nil, tk.Session().GetPlanCtx(), histColl, -1)
+
+	items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
+	require.Len(t, items, 0)
+}
+
+func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
+	clearAsyncLoadHistogramNeededItems()
+	t.Cleanup(clearAsyncLoadHistogramNeededItems)
+
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int)")
+
+	table, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tableInfo := table.Meta()
+	h := dom.StatsHandle()
+	// Make sure this table exists in stats cache so the old path would touch session context.
+	h.GetPhysicalTableStats(tableInfo.ID, tableInfo)
+
+	rowIDItem := model.TableItemID{
+		TableID: tableInfo.ID,
+		ID:      -1,
+	}
+	asyncload.AsyncLoadHistogramNeededItems.Insert(rowIDItem, true)
+
+	require.NotPanics(t, func() {
+		err = storage.LoadNeededHistograms(nil, dom.InfoSchema(), h)
+		require.NoError(t, err)
+	})
+	require.NotContains(t, asyncload.AsyncLoadHistogramNeededItems.AllItems(), model.StatsLoadItem{
+		TableItemID: rowIDItem,
+		FullLoad:    true,
+	})
+}
+
+func clearAsyncLoadHistogramNeededItems() {
+	for _, item := range asyncload.AsyncLoadHistogramNeededItems.AllItems() {
+		asyncload.AsyncLoadHistogramNeededItems.Delete(item.TableItemID)
+	}
 }

--- a/pkg/statistics/handle/storage/read_test.go
+++ b/pkg/statistics/handle/storage/read_test.go
@@ -179,20 +179,22 @@ func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
 	tableInfo := table.Meta()
 	h := dom.StatsHandle()
 	// Make sure this table exists in stats cache so the old path would touch session context.
-	h.GetPhysicalTableStats(tableInfo.ID, tableInfo)
+	statsTbl := h.GetPhysicalTableStats(tableInfo.ID, tableInfo)
+	require.NotNil(t, statsTbl)
+	require.Equal(t, tableInfo.ID, statsTbl.PhysicalID)
 
-	rowIDItem := model.TableItemID{
+	internalColumnItem := model.TableItemID{
 		TableID: tableInfo.ID,
 		ID:      -1,
 	}
-	asyncload.AsyncLoadHistogramNeededItems.Insert(rowIDItem, true)
+	asyncload.AsyncLoadHistogramNeededItems.Insert(internalColumnItem, true)
 
 	require.NotPanics(t, func() {
 		err = storage.LoadNeededHistograms(nil, dom.InfoSchema(), h)
 		require.NoError(t, err)
 	})
 	require.NotContains(t, asyncload.AsyncLoadHistogramNeededItems.AllItems(), model.StatsLoadItem{
-		TableItemID: rowIDItem,
+		TableItemID: internalColumnItem,
 		FullLoad:    true,
 	})
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64504

Problem Summary:
`_tidb_rowid` uses an internal column ID (`-1`) and does not have persisted column histogram metadata. Under async stats loading, this internal ID could be inserted into the needed-items queue, and the load path later emitted noisy logs such as `columnID=-1`.

### What changed and how does it work?
- Added source filtering for internal column IDs in `statistics.ColumnStatsIsInvalid` so `cid <= 0` is not inserted into `AsyncLoadHistogramNeededItems`.
- Added defensive filtering in `loadNeededColumnHistograms` to skip `col.ID <= 0` early, while still deleting the queue item via `defer`.
- Added planner-side source filtering in `CollectColumnStatsUsage` to skip pseudo/internal columns (`col.ID <= 0`) when collecting predicate/histogram-needed columns.
- Added regression tests:
  - `TestColumnStatsIsInvalidSkipsInternalColumnID`
  - `TestLoadNeededHistogramsSkipsInternalColumnID`
  - Added `_tidb_rowid` case in `TestCollectHistNeededColumns` to assert no stats-load columns are collected.
- Ran `make bazel_lint_changed`, which updated `pkg/statistics/handle/storage/BUILD.bazel` shard count.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:
- `make failpoint-enable && (cd pkg/statistics/handle/storage && go test -run 'TestColumnStatsIsInvalidSkipsInternalColumnID|TestLoadNeededHistogramsSkipsInternalColumnID' -tags=intest,deadlock) && make failpoint-disable`
- `make failpoint-enable && (cd pkg/statistics/handle/storage && go test -run 'TestLoadStats|TestLoadNonExistentIndexStats|TestColumnStatsIsInvalidSkipsInternalColumnID|TestLoadNeededHistogramsSkipsInternalColumnID' -tags=intest,deadlock) && make failpoint-disable`
- `make failpoint-enable && (cd pkg/planner/core/rule && go test -run 'TestCollectHistNeededColumns' -tags=intest,deadlock) && make failpoint-disable`
- `make bazel_lint_changed`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect inclusion of internal pseudo columns in statistics collection and asynchronous histogram loading, preventing unnecessary processing and potential errors when internal columns lack complete metadata.

* **Tests**
  * Added test coverage for statistics operations involving internal column identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->