### PR TITLE
*: use task key in TiCI requests | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature-fts

### DIFF
--- a/pkg/ddl/backfilling_dist_scheduler.go
+++ b/pkg/ddl/backfilling_dist_scheduler.go
@@ -23,7 +23,6 @@ import (
 	"math"
 	"slices"
 	"sort"
-	"strconv"
 	"time"
 
 	"github.com/docker/go-units"
@@ -632,7 +631,7 @@ func buildTiCIPreSplitImportShardsRequest(
 	}
 	dataFileCount, statFileCount := countUniqueFilesForTiCIPreSplitRequest(kvMetaGroups)
 	req := &tici.PreSplitImportShardsRequest{
-		TidbTaskId:     strconv.FormatInt(backfillMeta.Job.ID, 10),
+		TidbTaskId:     ticiTaskIDForDDL(backfillMeta.Job.ID),
 		TableId:        backfillMeta.Job.TableID,
 		ScanSnapshotTs: backfillMeta.ScanSnapshotTS,
 		IndexIds:       append([]int64(nil), backfillMeta.EleIDs...),

--- a/pkg/ddl/backfilling_dist_scheduler_test.go
+++ b/pkg/ddl/backfilling_dist_scheduler_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
@@ -388,7 +387,7 @@ func TestBackfillingSchedulerGlobalSortModeTiCIPreSplit(t *testing.T) {
 	require.NotEmpty(t, raw)
 	var req tici.PreSplitImportShardsRequest
 	require.NoError(t, json.Unmarshal(raw, &req))
-	require.Equal(t, strconv.FormatInt(taskMeta.Job.ID, 10), req.TidbTaskId)
+	require.Equal(t, ddl.TaskKey(taskMeta.Job.ID, false), req.TidbTaskId)
 	require.Equal(t, taskMeta.Job.TableID, req.TableId)
 	require.Equal(t, []int64{10}, req.IndexIds)
 	require.Equal(t, scanSnapshotTS, req.ScanSnapshotTs)

--- a/pkg/ddl/backfilling_import_cloud.go
+++ b/pkg/ddl/backfilling_import_cloud.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	goerrors "errors"
-	"strconv"
 	"sync/atomic"
 
 	"github.com/pingcap/errors"
@@ -102,7 +101,7 @@ func (e *cloudImportExecutor) Init(ctx context.Context) error {
 		}
 	}
 	if len(newTiciIndexIDs) > 0 {
-		taskID := strconv.FormatInt(e.job.ID, 10)
+		taskID := ticiTaskIDForDDL(e.job.ID)
 		if err := bd.InitTiCIWriterGroup(ctx, e.ptbl.Meta(), e.job.SchemaName, taskID, newTiciIndexIDs); err != nil {
 			return err
 		}

--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -102,6 +102,11 @@ func TestGetIntervalFromPolicy(t *testing.T) {
 	require.False(t, changed)
 }
 
+func TestTiCITaskIDForDDLUsesTaskKey(t *testing.T) {
+	jobID := int64(12345)
+	require.Equal(t, TaskKey(jobID, false), ticiTaskIDForDDL(jobID))
+}
+
 func colDefStrToColInfo(t *testing.T, str string, ctx *metabuild.Context) *model.ColumnInfo {
 	sqlA := "alter table t modify column a " + str
 	stmt, err := parser.New().ParseOneStmt(sqlA, "", "")

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1735,7 +1735,7 @@ func (w *worker) onCreateFulltextIndex(jobCtx *jobContext, job *model.Job) (ver 
 		case model.AnalyzeStateRunning, model.AnalyzeStateSkipped:
 			// AnalyzeStateSkipped may come from older owners before this branch
 			// was split; run FinishIndexUpload once for compatibility.
-			taskID := strconv.FormatInt(job.ID, 10)
+			taskID := ticiTaskIDForDDL(job.ID)
 			// FinishIndexUpload should run after the reorg ingest
 			// completes using the lightweight helper
 			// to finalize TiCI uploads here.
@@ -1927,7 +1927,7 @@ func (w *worker) onCreateHybridIndex(jobCtx *jobContext, job *model.Job) (ver in
 		case model.AnalyzeStateRunning, model.AnalyzeStateSkipped:
 			// AnalyzeStateSkipped may come from older owners before this branch
 			// was split; run FinishIndexUpload once for compatibility.
-			taskID := strconv.FormatInt(job.ID, 10)
+			taskID := ticiTaskIDForDDL(job.ID)
 			// FinishIndexUpload should run after the reorg ingest
 			// completes using the lightweight helper
 			// to finalize TiCI uploads here.
@@ -4418,16 +4418,14 @@ func (b *TaskKeyBuilder) Build(jobID int64) string {
 
 // TaskKey generates a task key for the backfill job.
 func TaskKey(jobID int64, mergeTempIdx bool) string {
-	labels := make([]string, 0, 8)
-	if kerneltype.IsNextGen() {
-		ks := keyspace.GetKeyspaceNameBySettings()
-		labels = append(labels, ks)
-	}
-	labels = append(labels, "ddl", proto.Backfill.String(), strconv.FormatInt(jobID, 10))
-	if mergeTempIdx {
-		labels = append(labels, "merge")
-	}
-	return strings.Join(labels, "/")
+	return ddlutil.BuildBackfillTaskKey(jobID, mergeTempIdx)
+}
+
+// ticiTaskIDForDDL returns the TiCI-facing task identifier for DDL add-index ingest.
+// TiCI fulltext/hybrid add-index does not enter the merge-temp-index catch-up stage, so
+// it should always use the primary backfill task key.
+func ticiTaskIDForDDL(jobID int64) string {
+	return TaskKey(jobID, false)
 }
 
 func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *reorgInfo) error {

--- a/pkg/ddl/index_modify_test.go
+++ b/pkg/ddl/index_modify_test.go
@@ -16,6 +16,7 @@ package ddl_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/rand"
@@ -1949,7 +1950,9 @@ func TestFullTextIndexSysvarsPassedToTiCI(t *testing.T) {
 
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/MockCheckColumnarIndexProcess", `return(1)`)
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/tici/MockCreateTiCIIndexSuccess", `return(true)`)
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/tici/MockNewTiCIDataWriterGroupManagerCtx", `return(true)`)
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/tici/MockCreateTiCIIndexRequest", `return(1)`)
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/tici/MockGetCloudStoragePrefix", `return(1)`)
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/tici/MockFinishIndexUpload", `return(true)`)
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/tici/MockCheckAddIndexProgress", `return(true)`)
 
@@ -1972,11 +1975,27 @@ func TestFullTextIndexSysvarsPassedToTiCI(t *testing.T) {
 	tk.MustExec("alter table t set tiflash replica 2 location labels 'a','b';")
 
 	tici.ResetMockTiCICreateIndexRequest()
+	tici.ResetMockTiCIGetImportStoragePrefixRequest()
+	tici.ResetMockTiCIFinishIndexUploadRequest()
 	tk.MustExec("alter table t add fulltext index fts_idx(c)")
 
 	raw = tici.GetMockTiCICreateIndexRequest()
 	require.NotEmpty(t, raw)
 	assertTiCIFulltextParserInfo(t, raw)
+
+	rows := tk.MustQuery("admin show ddl jobs 1").Rows()
+	require.Len(t, rows, 1)
+	jobID, err := strconv.ParseInt(rows[0][0].(string), 10, 64)
+	require.NoError(t, err)
+	expectedTaskID := ddl.TaskKey(jobID, false)
+
+	// Empty-table fulltext add-index skips reorg/backfill, so TiCI upload finalization is
+	// still exercised here but GetImportStoragePrefix is not.
+	raw = tici.GetMockTiCIFinishIndexUploadRequest()
+	require.NotEmpty(t, raw)
+	var finishReq tici.FinishImportIndexUploadRequest
+	require.NoError(t, json.Unmarshal(raw, &finishReq))
+	require.Equal(t, expectedTaskID, finishReq.TidbTaskId)
 }
 
 func TestFulltextIndexRequiresGlobalSortForBackfill(t *testing.T) {

--- a/pkg/ddl/ingest/engine_mgr.go
+++ b/pkg/ddl/ingest/engine_mgr.go
@@ -16,10 +16,10 @@ package ingest
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	ddlutil "github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/lightning/backend"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -68,7 +68,7 @@ func (bc *litBackendCtx) Register(indexIDs []int64, uniques []bool, tbl table.Ta
 		}
 	}
 	if len(newTiciIndexIDs) > 0 && !bc.ticiWriterGroupInitialized {
-		taskID := strconv.FormatInt(bc.jobID, 10)
+		taskID := ddlutil.BuildBackfillTaskKey(bc.jobID, false)
 		if err := bc.backend.InitTiCIWriterGroup(bc.ctx, tbl.Meta(), bc.schemaName, taskID, newTiciIndexIDs); err != nil {
 			return nil, err
 		}

--- a/pkg/ddl/util/BUILD.bazel
+++ b/pkg/ddl/util/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/ddl/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config/kerneltype",
         "//pkg/ddl/logutil",
         "//pkg/infoschema/context",
         "//pkg/keyspace",

--- a/pkg/ddl/util/util.go
+++ b/pkg/ddl/util/util.go
@@ -20,11 +20,13 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl/logutil"
 	"github.com/pingcap/tidb/pkg/keyspace"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -64,6 +66,19 @@ const (
 	// SessionTTL is the etcd session's TTL in seconds.
 	SessionTTL = 90
 )
+
+// BuildBackfillTaskKey generates the canonical dist-task key for a DDL backfill job.
+func BuildBackfillTaskKey(jobID int64, mergeTempIdx bool) string {
+	labels := make([]string, 0, 5)
+	if kerneltype.IsNextGen() {
+		labels = append(labels, keyspace.GetKeyspaceNameBySettings())
+	}
+	labels = append(labels, "ddl", "backfill", strconv.FormatInt(jobID, 10))
+	if mergeTempIdx {
+		labels = append(labels, "merge")
+	}
+	return strings.Join(labels, "/")
+}
 
 // DelRangeTask is for run delete-range command in gc_worker.
 type DelRangeTask struct {

--- a/pkg/dxf/importinto/subtask_executor.go
+++ b/pkg/dxf/importinto/subtask_executor.go
@@ -16,7 +16,6 @@ package importinto
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -143,12 +142,12 @@ func (p *postProcessStepExecutor) postProcess(ctx context.Context, subtaskMeta *
 		}()
 		backend := tableImporter.Backend()
 		if backend != nil {
-			// Re-initialize TiCI writer group with the same taskID to get the same ticiJobID
-			taskIDStr := strconv.FormatInt(p.taskID, 10)
-			// The newIndexIDs is not critical here as we only need to get the ticiJobID by taskID.
+			// Re-initialize TiCI writer group with the same task key to get the same TiCI job ID.
+			tidbTaskID := ticiTaskIDForImportInto(p.taskMeta.JobID)
+			// The newIndexIDs is not critical here as we only need to get the ticiJobID by task key.
 			// Now we collect all the tici indexIDs because `InitTiCIWriterGroup` require a non-empty indexIDs.
 			newIndexIDs := tici.GetTiCIIndexIDs(plan.TableInfo)
-			if err := backend.InitTiCIWriterGroup(ctx, plan.TableInfo, plan.DBName, taskIDStr, newIndexIDs); err != nil {
+			if err := backend.InitTiCIWriterGroup(ctx, plan.TableInfo, plan.DBName, tidbTaskID, newIndexIDs); err != nil {
 				logger.Warn("failed to init TiCI writer group for post process", zap.Error(err))
 				// Continue with other post process steps even if we can't init TiCI writer group
 			} else {

--- a/pkg/dxf/importinto/task_executor.go
+++ b/pkg/dxf/importinto/task_executor.go
@@ -85,6 +85,10 @@ type importStepExecutor struct {
 	summary execute.SubtaskSummary
 }
 
+func ticiTaskIDForImportInto(jobID int64) string {
+	return TaskKey(jobID)
+}
+
 func getTableImporter(
 	ctx context.Context,
 	taskID int64,
@@ -108,6 +112,7 @@ func getTableImporter(
 	if err = controller.InitDataStore(ctx); err != nil {
 		return nil, err
 	}
+	controller.TiDBTaskIDForTiCI = ticiTaskIDForImportInto(taskMeta.JobID)
 
 	failpoint.Inject("createTableImporterForTest", func() {
 		failpoint.Return(importer.NewTableImporterForTest(ctx, controller, strconv.FormatInt(taskID, 10), store))

--- a/pkg/dxf/importinto/task_executor_test.go
+++ b/pkg/dxf/importinto/task_executor_test.go
@@ -16,9 +16,12 @@ package importinto
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
 	"strconv"
 	"testing"
 
+	tidbconfig "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor"
 	"github.com/pingcap/tidb/pkg/executor/importer"
@@ -27,6 +30,10 @@ import (
 	"github.com/pingcap/tidb/pkg/lightning/backend/external"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/store/mockstore"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -72,6 +79,63 @@ func TestImportTaskExecutor(t *testing.T) {
 	require.Error(t, err)
 	_, err = executor.GetStepExecutor(&proto.Task{TaskBase: proto.TaskBase{Step: proto.ImportStepImport}, Meta: []byte("")})
 	require.Error(t, err)
+}
+
+func TestTiCITaskIDForImportIntoUsesTaskKey(t *testing.T) {
+	jobID := int64(12345)
+	require.Equal(t, TaskKey(jobID), ticiTaskIDForImportInto(jobID))
+}
+
+func TestGetTableImporterSetsTiCITaskID(t *testing.T) {
+	ctx := context.Background()
+	store, err := mockstore.NewMockStore()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	cfg := tidbconfig.GetGlobalConfig()
+	originalTempDir := cfg.TempDir
+	cfg.TempDir = t.TempDir()
+	t.Cleanup(func() {
+		cfg.TempDir = originalTempDir
+	})
+
+	tableInfo := &model.TableInfo{
+		ID:    2,
+		Name:  ast.NewCIStr("t"),
+		State: model.StatePublic,
+		Columns: []*model.ColumnInfo{{
+			ID:        1,
+			Name:      ast.NewCIStr("a"),
+			Offset:    0,
+			State:     model.StatePublic,
+			FieldType: *types.NewFieldType(mysql.TypeLonglong),
+		}},
+	}
+
+	path := filepath.Join(t.TempDir(), "input.csv")
+	taskMeta := &TaskMeta{
+		JobID: 12345,
+		Plan: importer.Plan{
+			DBID:             1,
+			DBName:           "test",
+			TableInfo:        tableInfo,
+			DesiredTableInfo: tableInfo,
+			Path:             path,
+			Format:           importer.DataFormatCSV,
+			InImportInto:     true,
+			DataSourceType:   importer.DataSourceTypeFile,
+		},
+		Stmt: fmt.Sprintf("IMPORT INTO test.t FROM '%s'", path),
+	}
+
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/dxf/importinto/createTableImporterForTest", `return(true)`)
+	tableImporter, err := getTableImporter(ctx, 99, taskMeta, store, zap.NewNop())
+	require.NoError(t, err)
+	require.Equal(t, TaskKey(taskMeta.JobID), tableImporter.LoadDataController.TiDBTaskIDForTiCI)
+	tableImporter.LoadDataController.Close()
+	tableImporter.Backend().CloseEngineMgr()
 }
 
 func TestGetOnDupForKVGroup(t *testing.T) {

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -370,6 +370,10 @@ type LoadDataController struct {
 
 	Table table.Table
 
+	// TiDBTaskIDForTiCI is the TiDB-side task identifier forwarded to TiCI.
+	// When empty, importer-local id is used as the fallback for non-DXF paths.
+	TiDBTaskIDForTiCI string
+
 	// how input field(or input column) from data file is mapped, either to a column or variable.
 	// if there's NO column list clause in SQL statement, then it's table's columns
 	// else it's user defined list.

--- a/pkg/executor/importer/table_import.go
+++ b/pkg/executor/importer/table_import.go
@@ -166,6 +166,13 @@ func GetRegionSplitSizeKeys(ctx context.Context) (regionSplitSize int64, regionS
 	return local.GetRegionSplitSizeKeys(ctx, pdCli, tls)
 }
 
+func ticiTaskIDForImporter(e *LoadDataController, importerID string) string {
+	if e != nil && len(e.TiDBTaskIDForTiCI) > 0 {
+		return e.TiDBTaskIDForTiCI
+	}
+	return importerID
+}
+
 // NewTableImporter creates a new table importer.
 func NewTableImporter(
 	ctx context.Context,
@@ -207,7 +214,8 @@ func NewTableImporter(
 
 	// Collect all the indexIDs for TiCI writer group initialization.
 	newIndexIDs := tici.GetTiCIIndexIDs(e.Table.Meta())
-	if err := localBackend.InitTiCIWriterGroup(ctx, e.Table.Meta(), e.DBName, id, newIndexIDs); err != nil {
+	tidbTaskID := ticiTaskIDForImporter(e, id)
+	if err := localBackend.InitTiCIWriterGroup(ctx, e.Table.Meta(), e.DBName, tidbTaskID, newIndexIDs); err != nil {
 		return nil, err
 	}
 

--- a/pkg/executor/importer/table_import_test.go
+++ b/pkg/executor/importer/table_import_test.go
@@ -86,6 +86,19 @@ func TestPrepareSortDir(t *testing.T) {
 	require.Nil(t, info)
 }
 
+func TestTiCITaskIDForImporter(t *testing.T) {
+	t.Run("prefer explicit tici task id", func(t *testing.T) {
+		controller := &LoadDataController{TiDBTaskIDForTiCI: "import-into/123"}
+		require.Equal(t, "import-into/123", ticiTaskIDForImporter(controller, "99"))
+	})
+
+	t.Run("fallback to importer id", func(t *testing.T) {
+		controller := &LoadDataController{}
+		require.Equal(t, "99", ticiTaskIDForImporter(controller, "99"))
+		require.Equal(t, "99", ticiTaskIDForImporter(nil, "99"))
+	})
+}
+
 func TestCalculateSubtaskCnt(t *testing.T) {
 	tests := []struct {
 		totalSize       int64

--- a/pkg/tici/tici_manager_client.go
+++ b/pkg/tici/tici_manager_client.go
@@ -53,8 +53,10 @@ type addIndexProgressLogKey struct {
 
 var addIndexProgressLogState sync.Map // map[addIndexProgressLogKey]GetIndexProgressResponse_State
 
-var mockTiCICreateIndexRequest atomic.Value          // stores []byte of CreateIndexRequest for tests.
-var mockTiCIPreSplitImportShardsRequest atomic.Value // stores []byte of PreSplitImportShardsRequest for tests.
+var mockTiCICreateIndexRequest atomic.Value            // stores []byte of CreateIndexRequest for tests.
+var mockTiCIGetImportStoragePrefixRequest atomic.Value // stores []byte of GetImportStoragePrefixRequest for tests.
+var mockTiCIFinishIndexUploadRequest atomic.Value      // stores []byte of FinishImportIndexUploadRequest for tests.
+var mockTiCIPreSplitImportShardsRequest atomic.Value   // stores []byte of PreSplitImportShardsRequest for tests.
 
 // GetMockTiCICreateIndexRequest returns the marshaled CreateIndexRequest bytes captured by the
 // `MockCreateTiCIIndexRequest` failpoint. It returns nil if nothing was captured.
@@ -73,6 +75,44 @@ func GetMockTiCICreateIndexRequest() []byte {
 // ResetMockTiCICreateIndexRequest clears the captured request for tests.
 func ResetMockTiCICreateIndexRequest() {
 	mockTiCICreateIndexRequest.Store([]byte{})
+}
+
+// GetMockTiCIGetImportStoragePrefixRequest returns the marshaled GetImportStoragePrefixRequest bytes captured by the
+// `MockGetCloudStoragePrefix` failpoint. It returns nil if nothing was captured.
+func GetMockTiCIGetImportStoragePrefixRequest() []byte {
+	v := mockTiCIGetImportStoragePrefixRequest.Load()
+	if v == nil {
+		return nil
+	}
+	b, ok := v.([]byte)
+	if !ok || len(b) == 0 {
+		return nil
+	}
+	return append([]byte(nil), b...)
+}
+
+// ResetMockTiCIGetImportStoragePrefixRequest clears the captured request for tests.
+func ResetMockTiCIGetImportStoragePrefixRequest() {
+	mockTiCIGetImportStoragePrefixRequest.Store([]byte{})
+}
+
+// GetMockTiCIFinishIndexUploadRequest returns the marshaled FinishImportIndexUploadRequest bytes captured by the
+// `MockFinishIndexUpload` failpoint. It returns nil if nothing was captured.
+func GetMockTiCIFinishIndexUploadRequest() []byte {
+	v := mockTiCIFinishIndexUploadRequest.Load()
+	if v == nil {
+		return nil
+	}
+	b, ok := v.([]byte)
+	if !ok || len(b) == 0 {
+		return nil
+	}
+	return append([]byte(nil), b...)
+}
+
+// ResetMockTiCIFinishIndexUploadRequest clears the captured request for tests.
+func ResetMockTiCIFinishIndexUploadRequest() {
+	mockTiCIFinishIndexUploadRequest.Store([]byte{})
 }
 
 // GetMockTiCIPreSplitImportShardsRequest returns the marshaled PreSplitImportShardsRequest bytes captured by the
@@ -334,6 +374,14 @@ func (t *ManagerCtx) GetCloudStoragePrefix(
 	indexIDs []int64,
 ) (string, uint64, error) {
 	failpoint.Inject("MockGetCloudStoragePrefix", func(val failpoint.Value) {
+		reqData, marshalErr := json.Marshal(&GetImportStoragePrefixRequest{
+			TidbTaskId: tidbTaskID,
+			TableId:    tableID,
+			IndexIds:   append([]int64(nil), indexIDs...),
+		})
+		if marshalErr == nil {
+			mockTiCIGetImportStoragePrefixRequest.Store(reqData)
+		}
 		mockStorageURI := "s3://mock-tici/t_{table_id}/i_{index_id}/import/mock_job"
 		mockJobID := uint64(1)
 		mockErrorMessage := ""
@@ -685,6 +733,13 @@ func maybeMockFinishIndexUpload(tidbTaskID string) (bool, error) {
 	)
 	failpoint.Inject("MockFinishIndexUpload", func(val failpoint.Value) {
 		handled = true
+		reqData, marshalErr := json.Marshal(&FinishImportIndexUploadRequest{
+			TidbTaskId: tidbTaskID,
+			Status:     ErrorCode_SUCCESS,
+		})
+		if marshalErr == nil {
+			mockTiCIFinishIndexUploadRequest.Store(reqData)
+		}
 		mockSuccess := false
 		if v, ok := val.(bool); ok {
 			mockSuccess = v

--- a/pkg/tici/tici_manager_client_test.go
+++ b/pkg/tici/tici_manager_client_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/pingcap/failpoint"
@@ -141,7 +142,12 @@ func TestGetImportStoragePrefix(t *testing.T) {
 	indexIDs := []int64{2, 3}
 
 	mockClient.
-		On("GetImportStoragePrefix", mock.Anything, mock.MatchedBy(matchKeyspace[*GetImportStoragePrefixRequest](keyspaceID))).
+		On("GetImportStoragePrefix", mock.Anything, mock.MatchedBy(func(req *GetImportStoragePrefixRequest) bool {
+			return matchKeyspace[*GetImportStoragePrefixRequest](keyspaceID)(req) &&
+				req.GetTidbTaskId() == taskID &&
+				req.GetTableId() == tblID &&
+				slices.Equal(req.GetIndexIds(), indexIDs)
+		})).
 		Return(&GetImportStoragePrefixResponse{Status: ErrorCode_SUCCESS, JobId: 100, StorageUri: "/s3/path?endpoint=http://127.0.0.1"}, nil).
 		Once()
 	path, jobID, err := ctx.GetCloudStoragePrefix(context.Background(), taskID, tblID, indexIDs)
@@ -150,14 +156,24 @@ func TestGetImportStoragePrefix(t *testing.T) {
 	assert.Equal(t, "/s3/path?endpoint=http://127.0.0.1", path)
 
 	mockClient.
-		On("GetImportStoragePrefix", mock.Anything, mock.MatchedBy(matchKeyspace[*GetImportStoragePrefixRequest](keyspaceID))).
+		On("GetImportStoragePrefix", mock.Anything, mock.MatchedBy(func(req *GetImportStoragePrefixRequest) bool {
+			return matchKeyspace[*GetImportStoragePrefixRequest](keyspaceID)(req) &&
+				req.GetTidbTaskId() == taskID &&
+				req.GetTableId() == tblID &&
+				slices.Equal(req.GetIndexIds(), indexIDs)
+		})).
 		Return(&GetImportStoragePrefixResponse{Status: ErrorCode_UNKNOWN_ERROR, ErrorMessage: "fail"}, nil).
 		Once()
 	_, _, err = ctx.GetCloudStoragePrefix(context.Background(), taskID, tblID, indexIDs)
 	assert.Error(t, err)
 
 	mockClient.
-		On("GetImportStoragePrefix", mock.Anything, mock.MatchedBy(matchKeyspace[*GetImportStoragePrefixRequest](keyspaceID))).
+		On("GetImportStoragePrefix", mock.Anything, mock.MatchedBy(func(req *GetImportStoragePrefixRequest) bool {
+			return matchKeyspace[*GetImportStoragePrefixRequest](keyspaceID)(req) &&
+				req.GetTidbTaskId() == taskID &&
+				req.GetTableId() == tblID &&
+				slices.Equal(req.GetIndexIds(), indexIDs)
+		})).
 		Return(&GetImportStoragePrefixResponse{}, errors.New("rpc error")).
 		Once()
 	_, _, err = ctx.GetCloudStoragePrefix(context.Background(), taskID, tblID, indexIDs)

--- a/pkg/tici/tici_write.go
+++ b/pkg/tici/tici_write.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	sst "github.com/pingcap/kvproto/pkg/import_sstpb"
 	tidbconfig "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -108,6 +109,31 @@ func getEtcdClient() (cli *clientv3.Client, err error) {
 	})
 }
 
+func newTiCIDataWriterGroupManagerCtx(ctx context.Context, keyspaceID uint32) (*ManagerCtx, *clientv3.Client, error) {
+	failpoint.Inject("MockNewTiCIDataWriterGroupManagerCtx", func(val failpoint.Value) {
+		if enabled, ok := val.(bool); ok && enabled {
+			mockCtx, cancel := context.WithCancel(ctx)
+			mgrCtx := &ManagerCtx{
+				ctx:    mockCtx,
+				cancel: cancel,
+			}
+			mgrCtx.SetKeyspaceID(keyspaceID)
+			failpoint.Return(mgrCtx, (*clientv3.Client)(nil), nil)
+		}
+	})
+	etcdClient, err := getEtcdClientFunc()
+	if err != nil {
+		return nil, nil, err
+	}
+	mgrCtx, err := newManagerCtxFunc(ctx, etcdClient)
+	if err != nil {
+		closeEtcdClient(etcdClient)
+		return nil, nil, err
+	}
+	mgrCtx.SetKeyspaceID(keyspaceID)
+	return mgrCtx, etcdClient, nil
+}
+
 // NewTiCIDataWriterGroup constructs a DataWriterGroup covering the given indexIDs of the given table.
 func NewTiCIDataWriterGroup(ctx context.Context, tblInfo *model.TableInfo, schema string, tidbTaskID string, keyspaceID uint32, newIndexIDs []int64) (*DataWriterGroup, error) {
 	if len(newIndexIDs) == 0 {
@@ -120,18 +146,15 @@ func NewTiCIDataWriterGroup(ctx context.Context, tblInfo *model.TableInfo, schem
 		zap.Int64s("newIndexIDs", newIndexIDs),
 	)
 
-	etcdClient, err := getEtcdClient()
+	mgrCtx, etcdClient, err := newTiCIDataWriterGroupManagerCtx(ctx, keyspaceID)
 	if err != nil {
 		return nil, err
 	}
-	mgrCtx, err := NewManagerCtx(ctx, etcdClient)
-	if err != nil {
-		return nil, err
-	}
-	mgrCtx.SetKeyspaceID(keyspaceID)
 
 	indexMeta, err := NewTiCIIndexMeta(ctx, tblInfo, newIndexIDs, schema, tidbTaskID, mgrCtx)
 	if err != nil {
+		mgrCtx.Close()
+		closeEtcdClient(etcdClient)
 		return nil, err
 	}
 

--- a/pkg/tici/tici_write_test.go
+++ b/pkg/tici/tici_write_test.go
@@ -16,6 +16,7 @@ package tici
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/docker/go-units"
@@ -24,6 +25,8 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -129,4 +132,44 @@ func TestTiCIDataWriterGroup_FinishIndexUpload(t *testing.T) {
 	group := newTiCIDataWriterGroupForTest(ctx, ticiMgr, tbl, "testdb")
 	err := group.FinishIndexUpload(ctx)
 	assert.NoError(t, err)
+}
+
+func TestNewTiCIDataWriterGroupUsesInjectedManagerFactory(t *testing.T) {
+	ctx := context.Background()
+	tbl := &model.TableInfo{ID: 1, Name: ast.NewCIStr("t"), Indices: []*model.IndexInfo{
+		{ID: 2, Name: ast.NewCIStr("idx"), FullTextInfo: &model.FullTextIndexInfo{}},
+	}}
+	mockClient := new(MockMetaServiceClient)
+	ticiMgr := newTestTiCIManagerCtx(mockClient)
+	keyspaceID := uint32(123)
+	taskID := "ddl/backfill/123"
+
+	originalGetEtcdClient := getEtcdClientFunc
+	originalNewManagerCtx := newManagerCtxFunc
+	getEtcdClientFunc = func() (*clientv3.Client, error) {
+		return nil, nil
+	}
+	newManagerCtxFunc = func(_ context.Context, _ *clientv3.Client) (*ManagerCtx, error) {
+		return ticiMgr, nil
+	}
+	t.Cleanup(func() {
+		getEtcdClientFunc = originalGetEtcdClient
+		newManagerCtxFunc = originalNewManagerCtx
+	})
+
+	mockClient.
+		On("GetImportStoragePrefix", mock.Anything, mock.MatchedBy(func(req *GetImportStoragePrefixRequest) bool {
+			return req.GetTidbTaskId() == taskID &&
+				req.GetTableId() == tbl.ID &&
+				slices.Equal(req.GetIndexIds(), []int64{2}) &&
+				req.GetKeyspaceId() == keyspaceID
+		})).
+		Return(&GetImportStoragePrefixResponse{Status: ErrorCode_SUCCESS, JobId: 100, StorageUri: "s3://my-bucket/prefix"}, nil).
+		Once()
+
+	group, err := NewTiCIDataWriterGroup(ctx, tbl, "testdb", taskID, keyspaceID, []int64{2})
+	require.NoError(t, err)
+	require.NotNil(t, group)
+	require.Equal(t, keyspaceID, ticiMgr.getKeyspaceID())
+	mockClient.AssertExpectations(t)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #63937

Problem Summary:
TiCI needs the full TiDB task key instead of only the numeric id, so it can identify task type and query task status for GC.

### What changed and how does it work?

This PR updates the TiDB -> TiCI task identifier wiring for both IMPORT INTO and DDL TiCI paths.

- IMPORT INTO now passes the full task key to TiCI writer-group initialization and post-process requests.
- The importer-local id is kept unchanged for non-TiCI logic.
- DDL TiCI requests now use the DDL backfill task key instead of the raw job id.
- This covers TiCI-related `GetImportStoragePrefix`, `FinishIndexUpload`, and DDL global-sort pre-split requests.
- Add unit tests for the task-key wiring on both IMPORT INTO and DDL paths.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Executed:
- `make failpoint-enable && ( go test -run 'TestTiCITaskIDForImportIntoUsesTaskKey|TestGetTableImporterSetsTiCITaskID' --tags=intest ./pkg/dxf/importinto && go test -run 'TestTiCITaskIDForImporter|TestCheckRequirementsWithTiCIIndexLocalSort' --tags=intest ./pkg/executor/importer ); rc=$?; make failpoint-disable; exit $rc`
- `make failpoint-enable && ( go test -run 'TestNewTiCIDataWriterGroupUsesInjectedManagerFactory|TestGetImportStoragePrefix|TestFinishIndexUploadHelper' --tags=intest ./pkg/tici ); rc=$?; make failpoint-disable; exit $rc`
- `make failpoint-enable && ( go test -run 'TestFullTextIndexSysvarsPassedToTiCI|TestBackfillingSchedulerGlobalSortModeTiCIPreSplit|TestTiCITaskIDForDDLUsesTaskKey' --tags=intest ./pkg/ddl ); rc=$?; make failpoint-disable; exit $rc`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved task identifier generation consistency across import-into and DDL operations, centralizing task key derivation logic.
  * Enhanced TiCI integration with better task ID propagation throughout the import workflow.

* **Tests**
  * Added comprehensive test coverage for task identifier generation and validation.
  * Extended test infrastructure with failpoint support for improved testing of TiCI interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->