### PR TITLE
ddl: use scan snapshot ts for full-text TiCI header | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature-fts

### DIFF
--- a/br/tests/br_full_cluster_restore/run.sh
+++ b/br/tests/br_full_cluster_restore/run.sh
@@ -128,7 +128,7 @@ run_sql_as user2 "123456" "select count(*) from db2.t1" || true
 check_contains "SELECT command denied to user"
 # user3 can only query db1.t1 using ssl
 # ci env uses mariadb client, ssl flag is different with mysql client
-run_sql_as user3 "123456" "select count(*) from db1.t1" --ssl-mode=DISABLED || true
+run_sql_as user3 "123456" "select count(*) from db1.t1" || true
 check_contains "Access denied for user"
 run_sql_as user3 "123456" "select count(*) from db1.t1" --ssl
 check_contains "count(*): 2"

--- a/br/tests/br_full_cluster_restore/run.sh
+++ b/br/tests/br_full_cluster_restore/run.sh
@@ -128,7 +128,7 @@ run_sql_as user2 "123456" "select count(*) from db2.t1" || true
 check_contains "SELECT command denied to user"
 # user3 can only query db1.t1 using ssl
 # ci env uses mariadb client, ssl flag is different with mysql client
-run_sql_as user3 "123456" "select count(*) from db1.t1" || true
+run_sql_as user3 "123456" "select count(*) from db1.t1" --ssl-mode=DISABLED || true
 check_contains "Access denied for user"
 run_sql_as user3 "123456" "select count(*) from db1.t1" --ssl
 check_contains "count(*): 2"

--- a/pkg/ddl/backfilling_import_cloud.go
+++ b/pkg/ddl/backfilling_import_cloud.go
@@ -147,10 +147,7 @@ func (e *cloudImportExecutor) RunSubtask(ctx context.Context, subtask *proto.Sub
 
 	_, engineUUID := backend.MakeUUID(e.ptbl.Meta().Name.L, idxID)
 
-	ticiHeaderCommitTS := uint64(0)
-	if currentIdx != nil && currentIdx.GetColumnarIndexType() == model.ColumnarIndexTypeHybrid {
-		ticiHeaderCommitTS = sm.ScanSnapshotTS
-	}
+	ticiHeaderCommitTS := getTiCIHeaderCommitTSForCloudImport(currentIdx, sm.ScanSnapshotTS)
 
 	all := external.SortedKVMeta{}
 	for _, g := range sm.MetaGroups {
@@ -213,6 +210,13 @@ func (e *cloudImportExecutor) RunSubtask(ctx context.Context, subtask *proto.Sub
 		return err
 	}
 	return kv.ErrKeyExists
+}
+
+func getTiCIHeaderCommitTSForCloudImport(currentIdx *model.IndexInfo, scanSnapshotTS uint64) uint64 {
+	if currentIdx == nil || !currentIdx.IsTiCIIndex() {
+		return 0
+	}
+	return scanSnapshotTS
 }
 
 func hasUniqueIndex(idxs []*model.IndexInfo) bool {

--- a/pkg/ddl/backfilling_test.go
+++ b/pkg/ddl/backfilling_test.go
@@ -717,3 +717,20 @@ func TestGetRestoreDataHybridKeepsRawHandleDatum(t *testing.T) {
 	require.Equal(t, types.KindInt64, rsData[0].Kind())
 	require.Equal(t, int64(3), rsData[0].GetInt64())
 }
+
+func TestGetTiCIHeaderCommitTSForCloudImport(t *testing.T) {
+	scanSnapshotTS := uint64(123456789)
+
+	require.Zero(t, getTiCIHeaderCommitTSForCloudImport(nil, scanSnapshotTS))
+	require.Zero(t, getTiCIHeaderCommitTSForCloudImport(&model.IndexInfo{}, scanSnapshotTS))
+
+	fullTextIdx := &model.IndexInfo{
+		FullTextInfo: &model.FullTextIndexInfo{},
+	}
+	require.Equal(t, scanSnapshotTS, getTiCIHeaderCommitTSForCloudImport(fullTextIdx, scanSnapshotTS))
+
+	hybridIdx := &model.IndexInfo{
+		HybridInfo: &model.HybridIndexInfo{},
+	}
+	require.Equal(t, scanSnapshotTS, getTiCIHeaderCommitTSForCloudImport(hybridIdx, scanSnapshotTS))
+}

--- a/pkg/sessionctx/variable/tests/session_test.go
+++ b/pkg/sessionctx/variable/tests/session_test.go
@@ -875,6 +875,8 @@ func TestTiDBOptPartialOrderedIndexForTopN(t *testing.T) {
 }
 
 func TestSetTiDBCloudStorageURI(t *testing.T) {
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
 	vars := variable.NewSessionVars(nil)
 	mock := variable.NewMockGlobalAccessor4Tests()
 	mock.SessionVars = vars


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref pingcap-inc/tici#1205

Problem Summary:

Full-text add-index cloud import currently only uses `ScanSnapshotTS` as the TiCI header ts for hybrid indexes. Full-text indexes still fall back to the ingest ts, so the header ts can be greater than the actual scan read ts.

### What changed and how does it work?

- Make cloud import use `ScanSnapshotTS` as `TiCIHeaderCommitTS` for all TiCI indexes, instead of only hybrid indexes.
- Add a unit test covering non-TiCI, full-text, and hybrid cases.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified cloud-import backfilling timestamp decision into a single helper.

* **Tests**
  * Added a unit test covering timestamp behavior across index configurations.
  * Updated full-cluster restore test script to explicitly disable SSL for a verification step.
  * Adjusted a session test to set AWS_EC2_METADATA_DISABLED in the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->