### PR TITLE
pkg/ddl: stabilize flaky TestTwoStates

### DIFF
--- a/pkg/ddl/db_change_test.go
+++ b/pkg/ddl/db_change_test.go
@@ -179,9 +179,20 @@ func TestDropNotNullColumn(t *testing.T) {
 
 func TestTwoStates(t *testing.T) {
 	store := testkit.CreateMockStoreWithSchemaLease(t, 200*time.Millisecond)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("create database test_db_state default charset utf8 default collate utf8_bin")
-	tk.MustExec("use test_db_state")
+	setupSess, err := session.CreateSession4Test(store)
+	require.NoError(t, err)
+	defer setupSess.Close()
+
+	mustExec := func(sql string) {
+		rss, err := setupSess.Execute(context.Background(), sql)
+		require.NoError(t, err)
+		for _, rs := range rss {
+			require.NoError(t, rs.Close())
+		}
+	}
+
+	mustExec("create database test_db_state default charset utf8 default collate utf8_bin")
+	mustExec("use test_db_state")
 
 	cnt := 5
 	// New the testExecInfo.
@@ -210,73 +221,129 @@ func TestTwoStates(t *testing.T) {
 	testInfo.sqlInfos[3].sql = "replace into t values(5, 'e', 'N', '2017-07-05')"
 	testInfo.sqlInfos[3].cases[4].expectedCompileErr = "[planner:1136]Column count doesn't match value count at row 1"
 	alterTableSQL := "alter table t add column d3 enum('a', 'b') not null default 'a' after c3"
-	tk.MustExec(`create table t (
+	mustExec(`create table t (
 		c1 int,
 		c2 varchar(64),
 		c3 enum('N','Y') not null default 'N',
 		c4 timestamp on update current_timestamp,
 		key(c1, c2))`)
-	tk.MustExec("insert into t values(1, 'a', 'N', '2017-07-01')")
+	mustExec("insert into t values(1, 'a', 'N', '2017-07-01')")
+	dom := domain.GetDomain(setupSess)
+	require.NotNil(t, dom)
+	tblInfo, err := dom.InfoSchema().TableInfoByName(ast.NewCIStr("test_db_state"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tableID := tblInfo.ID
 
-	prevState := model.StateNone
 	require.NoError(t, testInfo.parseSQLs(parser.New()))
 
-	times := 0
-	var checkErr error
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterWaitSchemaSynced", func(job *model.Job) {
-		if job.SchemaState == prevState || checkErr != nil || times >= 3 {
-			return
+	alterErrCh := make(chan error, 1)
+	go backgroundExec(store, "test_db_state", alterTableSQL, alterErrCh)
+
+	controlSess, err := session.CreateSession4Test(store)
+	require.NoError(t, err)
+	defer controlSess.Close()
+	_, err = controlSess.Execute(context.Background(), "use test_db_state")
+	require.NoError(t, err)
+
+	getAlterJob := func() (*model.Job, error) {
+		jobs, err := ddl.GetAllDDLJobs(context.Background(), controlSess)
+		if err != nil {
+			return nil, err
 		}
-		times++
-		switch job.SchemaState {
-		case model.StateDeleteOnly:
-			// This state we execute every sqlInfo one time using the first session and other information.
-			err := testInfo.compileSQL(0)
-			if err != nil {
-				checkErr = err
-				break
-			}
-			err = testInfo.execSQL(0)
-			if err != nil {
-				checkErr = err
-			}
-		case model.StateWriteOnly:
-			// This state we put the schema information to the second case.
-			err := testInfo.compileSQL(1)
-			if err != nil {
-				checkErr = err
-			}
-		case model.StateWriteReorganization:
-			// This state we execute every sqlInfo one time using the third session and other information.
-			err := testInfo.compileSQL(2)
-			if err != nil {
-				checkErr = err
-				break
-			}
-			err = testInfo.execSQL(2)
-			if err != nil {
-				checkErr = err
-				break
-			}
-			// Mock the server is in `write only` state.
-			err = testInfo.execSQL(1)
-			if err != nil {
-				checkErr = err
-				break
-			}
-			// This state we put the schema information to the fourth case.
-			err = testInfo.compileSQL(3)
-			if err != nil {
-				checkErr = err
+		for _, job := range jobs {
+			if job.TableID == tableID && job.Type == model.ActionAddColumn {
+				return job, nil
 			}
 		}
+		return nil, nil
+	}
+	waitColumnState := func(expected model.SchemaState) {
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			require.NoError(t, dom.Reload())
+			is := dom.InfoSchema()
+			current, err := is.TableInfoByName(ast.NewCIStr("test_db_state"), ast.NewCIStr("t"))
+			require.NoError(t, err)
+			for _, col := range current.Columns {
+				if col.Name.L == "d3" && col.State == expected {
+					return
+				}
+			}
+			time.Sleep(time.Millisecond)
+		}
+		require.FailNowf(t, "state barrier", "timed out waiting for infoschema state %s", expected)
+	}
+	pauseAtState := func(expected model.SchemaState) int64 {
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			job, err := getAlterJob()
+			require.NoError(t, err)
+			if job != nil && job.SchemaState == expected {
+				if !job.IsPaused() && !job.IsPausing() {
+					errs, err := ddl.PauseJobs(context.Background(), controlSess, []int64{job.ID})
+					require.NoError(t, err)
+					require.Len(t, errs, 1)
+					require.NoError(t, errs[0])
+				}
+				if job.IsPaused() || job.IsPausing() {
+					pauseDeadline := time.Now().Add(10 * time.Second)
+					for time.Now().Before(pauseDeadline) {
+						pausedJob, err := getAlterJob()
+						require.NoError(t, err)
+						if pausedJob != nil && pausedJob.ID == job.ID && pausedJob.IsPaused() && pausedJob.SchemaState == expected {
+							waitColumnState(expected)
+							return pausedJob.ID
+						}
+						time.Sleep(time.Millisecond)
+					}
+					require.FailNowf(t, "state barrier", "timed out pausing job %d at schema state %s", job.ID, expected)
+				}
+			}
+			select {
+			case err := <-alterErrCh:
+				require.NoError(t, err)
+				require.FailNowf(t, "state barrier", "alter table finished before reaching schema state %s", expected)
+			default:
+			}
+			time.Sleep(time.Millisecond)
+		}
+		require.FailNowf(t, "state barrier", "timed out waiting to pause schema state %s", expected)
+		return 0
+	}
+	resumeJob := func(jobID int64) {
+		errs, err := ddl.ResumeJobs(context.Background(), controlSess, []int64{jobID})
+		require.NoError(t, err)
+		require.Len(t, errs, 1)
+		require.NoError(t, errs[0])
+	}
+	runAtState := func(expected model.SchemaState, fn func()) {
+		jobID := pauseAtState(expected)
+		fn()
+		resumeJob(jobID)
+	}
+
+	runAtState(model.StateDeleteOnly, func() {
+		require.NoError(t, testInfo.compileSQL(0))
+		require.NoError(t, testInfo.execSQL(0))
 	})
-	tk.MustExec(alterTableSQL)
+
+	runAtState(model.StateWriteOnly, func() {
+		require.NoError(t, testInfo.compileSQL(1))
+	})
+
+	runAtState(model.StateWriteReorganization, func() {
+		require.NoError(t, testInfo.compileSQL(2))
+		require.NoError(t, testInfo.execSQL(2))
+		// Mock the server is in `write only` state.
+		require.NoError(t, testInfo.execSQL(1))
+		require.NoError(t, testInfo.compileSQL(3))
+	})
+
+	require.NoError(t, <-alterErrCh)
 	require.NoError(t, testInfo.compileSQL(4))
 	require.NoError(t, testInfo.execSQL(4))
 	// Mock the server is in `write reorg` state.
 	require.NoError(t, testInfo.execSQL(3))
-	require.NoError(t, checkErr)
 }
 
 type stateCase struct {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67557

Problem Summary:
Flaky test `TestTwoStates` in `pkg/ddl` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TEST_ISSUE; the prior snapshot-based fix only observed a schema state and then tested pinned old infoschemas after the live ALTER had been allowed to continue, so it no longer proved behavior while the DDL was actually in DeleteOnly/WriteOnly/WriteReorganization.

#### Fix

The current change is necessary because plain `go test` in this workspace does not activate the failpoint inject path, so the safe way to restore the original test intent is to pause the real add-column job at each target schema state and run the assertions while that live job is held there.

#### Verification

Spec:
- target: `pkg/ddl :: TestTwoStates`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes
- scope debt: Package-level validation still shows remaining failures outside the target flaky acceptance gate: TestDetectAndUpdateJobVersion/all_support_v2_and_global_index_v1
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
Package-level validation still shows remaining failures outside the target flaky acceptance gate: TestDetectAndUpdateJobVersion/all_support_v2_and_global_index_v1
Required flaky gate passed.
Build safety gate passed.
Intent guard gate passed.

Gate checklist:
- Required flaky gate: PASS
- Affected scope regression gate: FAIL
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/ddl -run '^TestTwoStates$' -count=1`
- `go test -json ./pkg/ddl -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved DDL operation test reliability by refactoring schema state transition testing to use explicit job control mechanisms instead of failpoint hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->