### PR TITLE
pkg/util/workloadrepo: stabilize flaky TestSnapshotTimingWorker

### DIFF
--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -108,10 +108,6 @@ func setupDomainAndContext(t *testing.T) (context.Context, kv.Storage, *domain.D
 	return ctx, store, dom, etcdAddr
 }
 
-func newSessionTestKit(t *testing.T, store kv.Storage) *testkit.TestKit {
-	return testkit.NewTestKitWithSession(t, store, testkit.NewSession(t, store))
-}
-
 func setupWorker(ctx context.Context, t *testing.T, addr string, dom *domain.Domain, id string, testWorker bool) *worker {
 	etcdCli, err := clientv3.New(clientv3.Config{
 		Endpoints: []string{addr},
@@ -172,18 +168,6 @@ func setMemorySnapshotTables(t *testing.T, wrk *worker, destTables ...string) {
 	for _, destTable := range destTables[1:] {
 		wrk.workloadTables = append(wrk.workloadTables, memorySnapshot(destTable))
 	}
-}
-
-func appendMemorySnapshotTables(wrk *worker, count int) []string {
-	destTables := make([]string, 0, count)
-	for i := 0; i < count; i++ {
-		destTable := fmt.Sprintf("HIST_MEMORY_USAGE_PRECISION_%02d", i)
-		wrk.workloadTables = append(wrk.workloadTables, repositoryTable{
-			"INFORMATION_SCHEMA", "MEMORY_USAGE", snapshotTable, destTable, "", "", "",
-		})
-		destTables = append(destTables, destTable)
-	}
-	return destTables
 }
 
 func TestRaceToCreateTablesWorker(t *testing.T) {
@@ -431,6 +415,8 @@ func findMatchingRowForSnapshot(t *testing.T, rowidx int, snapRows [][]any, row 
 }
 
 func SnapshotTimingWorker(t *testing.T, tk *testkit.TestKit, lastRowTs time.Time, lastSnapID int, cnt int, maxSecs int) (time.Time, int) {
+	// END_TIME is updated after all snapshot table goroutines finish. BEGIN_TIME
+	// alone is not a safe completion signal for validating mirrored tables.
 	rows := getRows(t, tk, cnt, maxSecs, "select snap_id, begin_time from "+mysql.WorkloadSchema+"."+histSnapshotsTable+" where begin_time > '"+lastRowTs.Format("2006-01-02 15:04:05")+"' and end_time is not null order by begin_time asc")
 
 	// We want to get all rows if we are starting from 0.
@@ -463,7 +449,7 @@ func SnapshotTimingWorker(t *testing.T, tk *testkit.TestKit, lastRowTs time.Time
 
 func TestSnapshotTimingWorker(t *testing.T) {
 	ctx, store, dom, addr := setupDomainAndContext(t)
-	tk := newSessionTestKit(t, store)
+	tk := testkit.NewTestKitWithSession(t, store, testkit.NewSession(t, store))
 
 	wrk := setupWorker(ctx, t, addr, dom, "worker", true)
 
@@ -483,34 +469,7 @@ func TestSnapshotTimingWorker(t *testing.T) {
 
 	// Change interval and verify new snapshots are taken at new interval
 	wrk.changeSnapshotInterval(ctx, "6")
-	lastRowTs, lastSnapID = SnapshotTimingWorker(t, tk, lastRowTs, lastSnapID, 1, 7)
-
-	appendMemorySnapshotTables(wrk, 48)
-	now = time.Now()
-	require.NoError(t, wrk.createAllTables(ctx, now))
-	waitForTables(ctx, t, wrk, now)
-
-	wrk.changeSnapshotInterval(ctx, "3600")
-	lastSnapID64, err := wrk.takeSnapshot(ctx)
-	require.NoError(t, err)
-
-	// BEGIN_TIME is written before the snapshot goroutines finish, so it is
-	// not a safe completion signal for verifying the mirrored snapshot tables.
-	inProgressQuery := fmt.Sprintf(
-		"select count(*) from %s.%s where snap_id = %d and begin_time is not null and end_time is null",
-		mysql.WorkloadSchema, histSnapshotsTable, lastSnapID64+1,
-	)
-	require.Eventually(t, func() bool {
-		return tk.MustQuery(inProgressQuery).Rows()[0][0] == "1"
-	}, time.Minute, time.Millisecond*20)
-
-	completedQuery := fmt.Sprintf(
-		"select count(*) from %s.%s where snap_id = %d and end_time is not null",
-		mysql.WorkloadSchema, histSnapshotsTable, lastSnapID64+1,
-	)
-	require.Eventually(t, func() bool {
-		return tk.MustQuery(completedQuery).Rows()[0][0] == "1"
-	}, time.Minute, time.Millisecond*20)
+	_, _ = SnapshotTimingWorker(t, tk, lastRowTs, lastSnapID, 1, 7)
 }
 
 func TestStoppingAndRestartingWorker(t *testing.T) {

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -108,6 +108,10 @@ func setupDomainAndContext(t *testing.T) (context.Context, kv.Storage, *domain.D
 	return ctx, store, dom, etcdAddr
 }
 
+func newSessionTestKit(t *testing.T, store kv.Storage) *testkit.TestKit {
+	return testkit.NewTestKitWithSession(t, store, testkit.NewSession(t, store))
+}
+
 func setupWorker(ctx context.Context, t *testing.T, addr string, dom *domain.Domain, id string, testWorker bool) *worker {
 	etcdCli, err := clientv3.New(clientv3.Config{
 		Endpoints: []string{addr},
@@ -144,6 +148,42 @@ func waitForTables(ctx context.Context, t *testing.T, wrk *worker, now time.Time
 	require.Eventually(t, func() bool {
 		return wrk.checkTablesExists(ctx, now)
 	}, time.Minute, time.Second)
+}
+
+func setMemorySnapshotTables(t *testing.T, wrk *worker, destTables ...string) {
+	require.NotEmpty(t, destTables)
+
+	snapshotIdx := -1
+	for i := range wrk.workloadTables {
+		if wrk.workloadTables[i].tableType == snapshotTable {
+			snapshotIdx = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, snapshotIdx, 0)
+
+	memorySnapshot := func(destTable string) repositoryTable {
+		return repositoryTable{
+			"INFORMATION_SCHEMA", "MEMORY_USAGE", snapshotTable, destTable, "", "", "",
+		}
+	}
+
+	wrk.workloadTables[snapshotIdx] = memorySnapshot(destTables[0])
+	for _, destTable := range destTables[1:] {
+		wrk.workloadTables = append(wrk.workloadTables, memorySnapshot(destTable))
+	}
+}
+
+func appendMemorySnapshotTables(wrk *worker, count int) []string {
+	destTables := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		destTable := fmt.Sprintf("HIST_MEMORY_USAGE_PRECISION_%02d", i)
+		wrk.workloadTables = append(wrk.workloadTables, repositoryTable{
+			"INFORMATION_SCHEMA", "MEMORY_USAGE", snapshotTable, destTable, "", "", "",
+		})
+		destTables = append(destTables, destTable)
+	}
+	return destTables
 }
 
 func TestRaceToCreateTablesWorker(t *testing.T) {
@@ -391,7 +431,7 @@ func findMatchingRowForSnapshot(t *testing.T, rowidx int, snapRows [][]any, row 
 }
 
 func SnapshotTimingWorker(t *testing.T, tk *testkit.TestKit, lastRowTs time.Time, lastSnapID int, cnt int, maxSecs int) (time.Time, int) {
-	rows := getRows(t, tk, cnt, maxSecs, "select snap_id, begin_time from "+mysql.WorkloadSchema+"."+histSnapshotsTable+" where begin_time > '"+lastRowTs.Format("2006-01-02 15:04:05")+"' order by begin_time asc")
+	rows := getRows(t, tk, cnt, maxSecs, "select snap_id, begin_time from "+mysql.WorkloadSchema+"."+histSnapshotsTable+" where begin_time > '"+lastRowTs.Format("2006-01-02 15:04:05")+"' and end_time is not null order by begin_time asc")
 
 	// We want to get all rows if we are starting from 0.
 	snapWhere := ""
@@ -423,17 +463,12 @@ func SnapshotTimingWorker(t *testing.T, tk *testkit.TestKit, lastRowTs time.Time
 
 func TestSnapshotTimingWorker(t *testing.T) {
 	ctx, store, dom, addr := setupDomainAndContext(t)
-	tk := testkit.NewTestKit(t, store)
+	tk := newSessionTestKit(t, store)
 
 	wrk := setupWorker(ctx, t, addr, dom, "worker", true)
 
 	// MEMORY_USAGE will contain a single row.  Ideal for testing here.
-	wrk.workloadTables[1] = repositoryTable{
-		"INFORMATION_SCHEMA", "MEMORY_USAGE", snapshotTable, "HIST_MEMORY_USAGE2", "", "", "",
-	}
-	wrk.workloadTables = append(wrk.workloadTables, repositoryTable{
-		"INFORMATION_SCHEMA", "MEMORY_USAGE", snapshotTable, "HIST_MEMORY_USAGE3", "", "", "",
-	})
+	setMemorySnapshotTables(t, wrk, "HIST_MEMORY_USAGE2", "HIST_MEMORY_USAGE3")
 
 	wrk.changeSnapshotInterval(ctx, "2")
 	now := time.Now()
@@ -448,7 +483,34 @@ func TestSnapshotTimingWorker(t *testing.T) {
 
 	// Change interval and verify new snapshots are taken at new interval
 	wrk.changeSnapshotInterval(ctx, "6")
-	_, _ = SnapshotTimingWorker(t, tk, lastRowTs, lastSnapID, 1, 7)
+	lastRowTs, lastSnapID = SnapshotTimingWorker(t, tk, lastRowTs, lastSnapID, 1, 7)
+
+	appendMemorySnapshotTables(wrk, 48)
+	now = time.Now()
+	require.NoError(t, wrk.createAllTables(ctx, now))
+	waitForTables(ctx, t, wrk, now)
+
+	wrk.changeSnapshotInterval(ctx, "3600")
+	lastSnapID64, err := wrk.takeSnapshot(ctx)
+	require.NoError(t, err)
+
+	// BEGIN_TIME is written before the snapshot goroutines finish, so it is
+	// not a safe completion signal for verifying the mirrored snapshot tables.
+	inProgressQuery := fmt.Sprintf(
+		"select count(*) from %s.%s where snap_id = %d and begin_time is not null and end_time is null",
+		mysql.WorkloadSchema, histSnapshotsTable, lastSnapID64+1,
+	)
+	require.Eventually(t, func() bool {
+		return tk.MustQuery(inProgressQuery).Rows()[0][0] == "1"
+	}, time.Minute, time.Millisecond*20)
+
+	completedQuery := fmt.Sprintf(
+		"select count(*) from %s.%s where snap_id = %d and end_time is not null",
+		mysql.WorkloadSchema, histSnapshotsTable, lastSnapID64+1,
+	)
+	require.Eventually(t, func() bool {
+		return tk.MustQuery(completedQuery).Rows()[0][0] == "1"
+	}, time.Minute, time.Millisecond*20)
 }
 
 func TestStoppingAndRestartingWorker(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67462

Problem Summary:
Flaky test `TestSnapshotTimingWorker` in `pkg/util/workloadrepo` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TestSnapshotTimingWorker used hist_snapshots.begin_time as a completion signal even though snapshot completion is only guaranteed once hist_snapshots.end_time is written after all snapshot-table goroutines finish.

#### Fix

The test must wait for end_time and not just begin_time, otherwise it can read hist_snapshots before HIST_MEMORY_USAGE2/3 are fully populated and fail intermittently.

#### Verification

Spec:
- target: `pkg/util/workloadrepo :: TestSnapshotTimingWorker`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes
Required flaky gate passed.
Build safety gate passed.
Intent guard gate passed.

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/util/workloadrepo -run '^TestSnapshotTimingWorker$' -count=1`
- `go test -json ./pkg/util/workloadrepo -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot query filtering so only completed snapshots are considered, preventing partial or in-progress data from affecting workload snapshot processing.

* **Tests**
  * Stabilized snapshot-timing tests to make timing validations more reliable and reduce intermittent failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/67792)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->