### PR TITLE
pkg/util/workloadrepo: stabilize flaky TestCreatePartition

### DIFF
--- a/pkg/util/workloadrepo/BUILD.bazel
+++ b/pkg/util/workloadrepo/BUILD.bazel
@@ -60,6 +60,8 @@ go_test(
         "//pkg/parser/ast",
         "//pkg/parser/auth",
         "//pkg/parser/mysql",
+        "//pkg/session",
+        "//pkg/session/sessionapi",
         "//pkg/sessionctx",
         "//pkg/sessionctx/variable",
         "//pkg/testkit",

--- a/pkg/util/workloadrepo/BUILD.bazel
+++ b/pkg/util/workloadrepo/BUILD.bazel
@@ -60,8 +60,6 @@ go_test(
         "//pkg/parser/ast",
         "//pkg/parser/auth",
         "//pkg/parser/mysql",
-        "//pkg/session",
-        "//pkg/session/sessionapi",
         "//pkg/sessionctx",
         "//pkg/sessionctx/variable",
         "//pkg/testkit",

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/session"
+	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -144,6 +146,10 @@ func waitForTables(ctx context.Context, t *testing.T, wrk *worker, now time.Time
 	require.Eventually(t, func() bool {
 		return wrk.checkTablesExists(ctx, now)
 	}, time.Minute, time.Second)
+}
+
+func anchorPartitionTestTime(now time.Time) time.Time {
+	return time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, now.Location())
 }
 
 func TestRaceToCreateTablesWorker(t *testing.T) {
@@ -641,11 +647,20 @@ func createTableWithParts(ctx context.Context, t *testing.T, tk *testkit.TestKit
 	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, tbl, partitions))
 }
 
+func createTableWithPartsForSession(ctx context.Context, t *testing.T, se sessionapi.Session, tbl *repositoryTable,
+	sess sessionctx.Context, partitions []time.Time) {
+	createSQL, err := buildCreateQuery(ctx, sess, tbl)
+	require.NoError(t, err)
+	createSQL += buildPartitionString(partitions)
+	session.MustExec(t, se, createSQL)
+	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, tbl, partitions))
+}
+
 func validatePartitionCreation(ctx context.Context, now time.Time, t *testing.T,
-	sess sessionctx.Context, tk *testkit.TestKit, wrk *worker,
+	sess sessionctx.Context, se sessionapi.Session, wrk *worker,
 	firstTestFails bool, tableName string, partitions []time.Time, expectedParts []time.Time) {
 	tbl := getTable(t, tableName, wrk)
-	createTableWithParts(ctx, t, tk, tbl, sess, partitions)
+	createTableWithPartsForSession(ctx, t, se, tbl, sess, partitions)
 
 	is := sess.GetLatestInfoSchema().(infoschema.InfoSchema)
 	require.False(t, firstTestFails == checkTableExistsByIS(ctx, is, tbl.destTable, now))
@@ -662,56 +677,57 @@ func validatePartitionCreation(ctx context.Context, now time.Time, t *testing.T,
 func TestCreatePartition(t *testing.T) {
 	ctx, store, dom, addr := setupDomainAndContext(t)
 	wrk := setupWorker(ctx, t, addr, dom, "worker", true)
-	tk := testkit.NewTestKit(t, store)
+	se, err := session.CreateSession4Test(store)
+	require.NoError(t, err)
+	t.Cleanup(se.Close)
 
-	tk.MustExec("create database WORKLOAD_SCHEMA")
-	tk.MustExec("use WORKLOAD_SCHEMA")
+	session.MustExec(t, se, "create database WORKLOAD_SCHEMA")
+	session.MustExec(t, se, "use WORKLOAD_SCHEMA")
 
 	_sessctx := wrk.getSessionWithRetry()
 	sess := _sessctx.(sessionctx.Context)
 
 	wrk.fillInTableNames()
 
-	now := time.Now()
+	now := anchorPartitionTestTime(time.Now())
 
 	/* Tables without partitions are not currently supported. */
 
 	// Should create one partition for today and tomorrow on a table with only old partitions before today.
 	partitions := []time.Time{now.AddDate(0, 0, -1)}
 	expectedParts := []time.Time{now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)}
-	validatePartitionCreation(ctx, now, t, sess, tk, wrk, true, "PROCESSLIST", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, se, wrk, true, "PROCESSLIST", partitions, expectedParts)
 
 	// Should create one partition for tomorrow on a table with only a partition for today.
 	partitions = []time.Time{now}
 	expectedParts = []time.Time{now, now.AddDate(0, 0, 1)}
-	validatePartitionCreation(ctx, now, t, sess, tk, wrk, true, "DATA_LOCK_WAITS", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, se, wrk, true, "DATA_LOCK_WAITS", partitions, expectedParts)
 
 	// Should not create any partitions on a table with only a partition for tomorrow.
 	partitions = []time.Time{now.AddDate(0, 0, 1)}
 	expectedParts = []time.Time{now.AddDate(0, 0, 1)}
-	validatePartitionCreation(ctx, now, t, sess, tk, wrk, false, "TIDB_TRX", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, se, wrk, false, "TIDB_TRX", partitions, expectedParts)
 
 	// Should not create any partitions on a table with only partitions for both today and tomorrow.
 	partitions = []time.Time{now, now.AddDate(0, 0, 1)}
 	expectedParts = []time.Time{now, now.AddDate(0, 0, 1)}
-	validatePartitionCreation(ctx, now, t, sess, tk, wrk, false, "MEMORY_USAGE", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, se, wrk, false, "MEMORY_USAGE", partitions, expectedParts)
 
 	// Should not create any partitions on a table with a partition for the day after tomorrow.
 	partitions = []time.Time{now.AddDate(0, 0, 2)}
 	expectedParts = []time.Time{now.AddDate(0, 0, 2)}
-	validatePartitionCreation(ctx, now, t, sess, tk, wrk, false, "DEADLOCKS", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, se, wrk, false, "DEADLOCKS", partitions, expectedParts)
 
 	// Should not fill in missing partitions on a table with a partition for dates beyond tomorrow.
 	partitions = []time.Time{now, now.AddDate(0, 0, 3)}
 	expectedParts = []time.Time{now, now.AddDate(0, 0, 3)}
-	validatePartitionCreation(ctx, now, t, sess, tk, wrk, false, "TIDB_INDEX_USAGE", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, se, wrk, false, "TIDB_INDEX_USAGE", partitions, expectedParts)
 
 	// this table should be updated when the repository is enabled
 	partitions = []time.Time{now}
-	createTableWithParts(ctx, t, tk, getTable(t, "TIDB_STATEMENTS_STATS", wrk), sess, partitions)
+	createTableWithPartsForSession(ctx, t, se, getTable(t, "TIDB_STATEMENTS_STATS", wrk), sess, partitions)
 
 	// turn on the repository and see if it creates the remaining tables
-	now = time.Now()
 	wrk.setRepositoryDest(ctx, "table")
 	waitForTables(ctx, t, wrk, now)
 }

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/session"
-	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -634,34 +632,20 @@ func buildPartitionString(partitions []time.Time) string {
 	return sb.String()
 }
 
-func createTableWithPartsByExec(ctx context.Context, t *testing.T, tbl *repositoryTable,
-	sess sessionctx.Context, partitions []time.Time, exec func(string)) {
+func createTableWithParts(ctx context.Context, t *testing.T, tk *testkit.TestKit, tbl *repositoryTable,
+	sess sessionctx.Context, partitions []time.Time) {
 	createSQL, err := buildCreateQuery(ctx, sess, tbl)
 	require.NoError(t, err)
 	createSQL += buildPartitionString(partitions)
-	exec(createSQL)
+	tk.MustExec(createSQL)
 	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, tbl, partitions))
 }
 
-func createTableWithParts(ctx context.Context, t *testing.T, tk *testkit.TestKit, tbl *repositoryTable,
-	sess sessionctx.Context, partitions []time.Time) {
-	createTableWithPartsByExec(ctx, t, tbl, sess, partitions, func(createSQL string) {
-		tk.MustExec(createSQL)
-	})
-}
-
-func createTableWithPartsForSession(ctx context.Context, t *testing.T, se sessionapi.Session, tbl *repositoryTable,
-	sess sessionctx.Context, partitions []time.Time) {
-	createTableWithPartsByExec(ctx, t, tbl, sess, partitions, func(createSQL string) {
-		session.MustExec(t, se, createSQL)
-	})
-}
-
 func validatePartitionCreation(ctx context.Context, now time.Time, t *testing.T,
-	sess sessionctx.Context, se sessionapi.Session, wrk *worker,
+	sess sessionctx.Context, tk *testkit.TestKit, wrk *worker,
 	firstTestFails bool, tableName string, partitions []time.Time, expectedParts []time.Time) {
 	tbl := getTable(t, tableName, wrk)
-	createTableWithPartsForSession(ctx, t, se, tbl, sess, partitions)
+	createTableWithParts(ctx, t, tk, tbl, sess, partitions)
 
 	is := sess.GetLatestInfoSchema().(infoschema.InfoSchema)
 	require.False(t, firstTestFails == checkTableExistsByIS(ctx, is, tbl.destTable, now))
@@ -678,12 +662,10 @@ func validatePartitionCreation(ctx context.Context, now time.Time, t *testing.T,
 func TestCreatePartition(t *testing.T) {
 	ctx, store, dom, addr := setupDomainAndContext(t)
 	wrk := setupWorker(ctx, t, addr, dom, "worker", true)
-	se, err := session.CreateSession4Test(store)
-	require.NoError(t, err)
-	t.Cleanup(se.Close)
+	tk := testkit.NewTestKit(t, store)
 
-	session.MustExec(t, se, "create database WORKLOAD_SCHEMA")
-	session.MustExec(t, se, "use WORKLOAD_SCHEMA")
+	tk.MustExec("create database WORKLOAD_SCHEMA")
+	tk.MustExec("use WORKLOAD_SCHEMA")
 
 	_sessctx := wrk.getSessionWithRetry()
 	sess := _sessctx.(sessionctx.Context)
@@ -700,36 +682,36 @@ func TestCreatePartition(t *testing.T) {
 	// Should create one partition for today and tomorrow on a table with only old partitions before today.
 	partitions := []time.Time{now.AddDate(0, 0, -1)}
 	expectedParts := []time.Time{now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)}
-	validatePartitionCreation(ctx, now, t, sess, se, wrk, true, "PROCESSLIST", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, tk, wrk, true, "PROCESSLIST", partitions, expectedParts)
 
 	// Should create one partition for tomorrow on a table with only a partition for today.
 	partitions = []time.Time{now}
 	expectedParts = []time.Time{now, now.AddDate(0, 0, 1)}
-	validatePartitionCreation(ctx, now, t, sess, se, wrk, true, "DATA_LOCK_WAITS", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, tk, wrk, true, "DATA_LOCK_WAITS", partitions, expectedParts)
 
 	// Should not create any partitions on a table with only a partition for tomorrow.
 	partitions = []time.Time{now.AddDate(0, 0, 1)}
 	expectedParts = []time.Time{now.AddDate(0, 0, 1)}
-	validatePartitionCreation(ctx, now, t, sess, se, wrk, false, "TIDB_TRX", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, tk, wrk, false, "TIDB_TRX", partitions, expectedParts)
 
 	// Should not create any partitions on a table with only partitions for both today and tomorrow.
 	partitions = []time.Time{now, now.AddDate(0, 0, 1)}
 	expectedParts = []time.Time{now, now.AddDate(0, 0, 1)}
-	validatePartitionCreation(ctx, now, t, sess, se, wrk, false, "MEMORY_USAGE", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, tk, wrk, false, "MEMORY_USAGE", partitions, expectedParts)
 
 	// Should not create any partitions on a table with a partition for the day after tomorrow.
 	partitions = []time.Time{now.AddDate(0, 0, 2)}
 	expectedParts = []time.Time{now.AddDate(0, 0, 2)}
-	validatePartitionCreation(ctx, now, t, sess, se, wrk, false, "DEADLOCKS", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, tk, wrk, false, "DEADLOCKS", partitions, expectedParts)
 
 	// Should not fill in missing partitions on a table with a partition for dates beyond tomorrow.
 	partitions = []time.Time{now, now.AddDate(0, 0, 3)}
 	expectedParts = []time.Time{now, now.AddDate(0, 0, 3)}
-	validatePartitionCreation(ctx, now, t, sess, se, wrk, false, "TIDB_INDEX_USAGE", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, tk, wrk, false, "TIDB_INDEX_USAGE", partitions, expectedParts)
 
 	// this table should be updated when the repository is enabled
 	partitions = []time.Time{now}
-	createTableWithPartsForSession(ctx, t, se, getTable(t, "TIDB_STATEMENTS_STATS", wrk), sess, partitions)
+	createTableWithParts(ctx, t, tk, getTable(t, "TIDB_STATEMENTS_STATS", wrk), sess, partitions)
 
 	// turn on the repository and see if it creates the remaining tables
 	wrk.setRepositoryDest(ctx, "table")

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -148,10 +148,6 @@ func waitForTables(ctx context.Context, t *testing.T, wrk *worker, now time.Time
 	}, time.Minute, time.Second)
 }
 
-func anchorPartitionTestTime(now time.Time) time.Time {
-	return time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, now.Location())
-}
-
 func TestRaceToCreateTablesWorker(t *testing.T) {
 	ctx, store, dom, addr := setupDomainAndContext(t)
 
@@ -638,22 +634,27 @@ func buildPartitionString(partitions []time.Time) string {
 	return sb.String()
 }
 
-func createTableWithParts(ctx context.Context, t *testing.T, tk *testkit.TestKit, tbl *repositoryTable,
-	sess sessionctx.Context, partitions []time.Time) {
+func createTableWithPartsByExec(ctx context.Context, t *testing.T, tbl *repositoryTable,
+	sess sessionctx.Context, partitions []time.Time, exec func(string)) {
 	createSQL, err := buildCreateQuery(ctx, sess, tbl)
 	require.NoError(t, err)
 	createSQL += buildPartitionString(partitions)
-	tk.MustExec(createSQL)
+	exec(createSQL)
 	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, tbl, partitions))
+}
+
+func createTableWithParts(ctx context.Context, t *testing.T, tk *testkit.TestKit, tbl *repositoryTable,
+	sess sessionctx.Context, partitions []time.Time) {
+	createTableWithPartsByExec(ctx, t, tbl, sess, partitions, func(createSQL string) {
+		tk.MustExec(createSQL)
+	})
 }
 
 func createTableWithPartsForSession(ctx context.Context, t *testing.T, se sessionapi.Session, tbl *repositoryTable,
 	sess sessionctx.Context, partitions []time.Time) {
-	createSQL, err := buildCreateQuery(ctx, sess, tbl)
-	require.NoError(t, err)
-	createSQL += buildPartitionString(partitions)
-	session.MustExec(t, se, createSQL)
-	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, tbl, partitions))
+	createTableWithPartsByExec(ctx, t, tbl, sess, partitions, func(createSQL string) {
+		session.MustExec(t, se, createSQL)
+	})
 }
 
 func validatePartitionCreation(ctx context.Context, now time.Time, t *testing.T,
@@ -689,7 +690,10 @@ func TestCreatePartition(t *testing.T) {
 
 	wrk.fillInTableNames()
 
-	now := anchorPartitionTestTime(time.Now())
+	now := time.Now()
+	// The test builds date-based partitions with AddDate and TO_DAYS, so anchor at noon to avoid
+	// instability around wall-clock day boundaries.
+	now = time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, now.Location())
 
 	/* Tables without partitions are not currently supported. */
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67461

Problem Summary:
Flaky test `TestCreatePartition` in `pkg/util/workloadrepo` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TEST_ISSUE: the original flake is `TestCreatePartition` using unstable wall-clock day boundaries, and this address round fixes only the missing Bazel strict deps introduced by the prior plain-session test fix.

#### Fix

Adding `//pkg/session` and `//pkg/session/sessionapi` to `workloadrepo_test` is necessary so the existing `worker_test.go` imports build under TiDB's Bazel strict-deps validation.

#### Verification

Spec:
- target: `pkg/util/workloadrepo :: TestCreatePartition`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes
Required flaky gate passed.
Build safety gate passed.
Intent guard gate passed.

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/util/workloadrepo -run '^TestCreatePartition$' -count=1`
- `go test -json ./pkg/util/workloadrepo -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved stability of partition behavior tests by normalizing timestamps near day boundaries, reducing flaky test results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/67793)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->