### PR TITLE
pkg/store/gcworker: stabilize flaky TestPrepareGC

### DIFF
--- a/pkg/store/gcworker/gc_worker_test.go
+++ b/pkg/store/gcworker/gc_worker_test.go
@@ -366,6 +366,14 @@ func TestPrepareGC(t *testing.T) {
 
 	now, err := s.gcWorker.getOracleTime()
 	require.NoError(t, err)
+	lastRunBefore, err := s.gcWorker.loadTime(gcLastRunTimeKey)
+	require.NoError(t, err)
+	require.NotNil(t, lastRunBefore)
+	safePointBefore, err := s.gcWorker.loadTime(gcSafePointKey)
+	require.NoError(t, err)
+	require.NotNil(t, safePointBefore)
+	timeEqual(t, safePointBefore.Add(gcDefaultLifeTime), now, 2*time.Second)
+
 	close(s.gcWorker.done)
 	ok, _, err := s.gcWorker.prepare(gcContext())
 	require.NoError(t, err)
@@ -375,7 +383,9 @@ func TestPrepareGC(t *testing.T) {
 	require.NotNil(t, lastRun)
 	safePoint, err := s.gcWorker.loadTime(gcSafePointKey)
 	require.NoError(t, err)
-	timeEqual(t, safePoint.Add(gcDefaultLifeTime), now, 2*time.Second)
+	require.Equal(t, *lastRunBefore, *lastRun)
+	require.Equal(t, *safePointBefore, *safePoint)
+	timeEqual(t, safePoint.Add(gcDefaultLifeTime), *lastRun, 2*time.Second)
 
 	// Change GC run interval.
 	err = s.gcWorker.saveDuration(gcRunIntervalKey, time.Minute*5)
@@ -397,14 +407,15 @@ func TestPrepareGC(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, ok)
 	s.oracle.AddOffset(time.Minute * 40)
-	now, err = s.gcWorker.getOracleTime()
-	require.NoError(t, err)
 	ok, _, err = s.gcWorker.prepare(gcContext())
 	require.NoError(t, err)
 	require.True(t, ok)
+	lastRun, err = s.gcWorker.loadTime(gcLastRunTimeKey)
+	require.NoError(t, err)
+	require.NotNil(t, lastRun)
 	safePoint, err = s.gcWorker.loadTime(gcSafePointKey)
 	require.NoError(t, err)
-	timeEqual(t, safePoint.Add(time.Minute*30), now, 2*time.Second)
+	timeEqual(t, safePoint.Add(time.Minute*30), *lastRun, 2*time.Second)
 
 	// Change GC concurrency.
 	concurrency, err := s.gcWorker.loadGCConcurrencyWithDefault()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67460

Problem Summary:
Flaky test `TestPrepareGC` in `pkg/store/gcworker` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TEST_ISSUE: the reviewer finding was valid because the first TestPrepareGC assertion had been weakened to only check startup-persisted self-consistency after createGCWorkerSuite() had already seeded the GC keys.

#### Fix

The added startup-state reads and equality checks restore the missing freshness proof while keeping the real flaky fix limited to the later persisted-lastRun assertion.

#### Verification

Spec:
- target: `pkg/store/gcworker :: TestPrepareGC`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes
Required flaky gate passed.
Build safety gate passed.
Intent guard gate passed.

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/store/gcworker -run '^TestPrepareGC$' -count=1`
- `go test -json ./pkg/store/gcworker -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases to enhance verification of garbage collection timing and safe-point handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->