### PR TITLE
pkg/ddl/tests/tiflash: stabilize flaky TestTiFlashProgressCache

### DIFF
--- a/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
+++ b/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
@@ -1202,24 +1202,27 @@ func TestTiFlashProgressAfterAvailableForPartitionTable(t *testing.T) {
 func TestTiFlashProgressCache(t *testing.T) {
 	s, teardown := createTiFlashContext(t)
 	defer teardown()
-	tk := testkit.NewTestKit(t, s.store)
+	se := session.CreateSessionAndSetID(t, s.store)
+	defer se.Close()
 
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists ddltiflash")
-	tk.MustExec("create table ddltiflash(z int)")
-	tk.MustExec("alter table ddltiflash set tiflash replica 1")
-	time.Sleep(ddl.PollTiFlashInterval * RoundToBeAvailable * 3)
-	CheckTableAvailable(s.dom, t, 1, []string{})
+	session.MustExec(t, se, "use test")
+	session.MustExec(t, se, "drop table if exists ddltiflash")
+	session.MustExec(t, se, "create table ddltiflash(z int)")
+	session.MustExec(t, se, "alter table ddltiflash set tiflash replica 1")
+	WaitTablesAvailableWithTableName(s.dom, t, 1, []string{}, "test", []string{"ddltiflash"}, ddl.PollTiFlashInterval*RoundToBeAvailable*10)
 
 	tb, err := s.dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("ddltiflash"))
 	require.NoError(t, err)
 	require.NotNil(t, tb)
 	infosync.UpdateTiFlashProgressCache(tb.Meta().ID, 0)
 	// after available, it will still update progress cache.
-	time.Sleep(ddl.PollTiFlashInterval * RoundToBeAvailable * 3)
+	require.Eventually(t, func() bool {
+		progress, isExist := infosync.GetTiFlashProgressFromCache(tb.Meta().ID)
+		return isExist && progress == 1
+	}, ddl.PollTiFlashInterval*RoundToBeAvailable*10, ddl.PollTiFlashInterval/2)
 	progress, isExist := infosync.GetTiFlashProgressFromCache(tb.Meta().ID)
 	require.True(t, isExist)
-	require.True(t, progress == 1)
+	require.Equal(t, 1.0, progress)
 }
 
 func TestTiFlashProgressAvailableList(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67458

Problem Summary:
Flaky test `TestTiFlashProgressCache` in `pkg/ddl/tests/tiflash` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TestTiFlashProgressCache assumed fixed sleeps were enough to observe an asynchronous TiFlash poll loop, so scheduler delay could make the test fail even when product behavior was correct.

#### Fix

Replacing fixed sleeps with state-based waits is necessary because the test is asserting eventual background state, not a guaranteed deadline.

#### Verification

Spec:
- target: `pkg/ddl/tests/tiflash :: TestTiFlashProgressCache`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes
Required flaky gate passed.
Build safety gate passed.
Intent guard gate passed.

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/ddl/tests/tiflash -run '^TestTiFlashProgressCache$' -count=1`
- bash ./tools/check/failpoint-go-test.sh pkg/ddl/tests/tiflash -run '^TestTiFlashProgressCache$' -count=10
- `go test -json ./pkg/ddl/tests/tiflash -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved TiFlash progress cache test reliability with enhanced waiting mechanisms for table availability and assertion verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->