### PR TITLE
planner: fix legacy ONLY_FULL_GROUP_BY correlated subquery check | tidb-test=pr/2731

### DIFF
--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3997,7 +3997,7 @@ type colNameResolver struct {
 
 func (*colNameResolver) Enter(inNode ast.Node) (ast.Node, bool) {
 	switch inNode.(type) {
-	case *ast.ColumnNameExpr, *ast.SubqueryExpr, *ast.AggregateFuncExpr:
+	case *ast.ColumnNameExpr, *ast.AggregateFuncExpr:
 		return inNode, true
 	}
 	return inNode, false

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -399,6 +399,25 @@ func TestGroupByWhenNotExistCols(t *testing.T) {
 	}
 }
 
+func TestIssue67540CorrelatedScalarSubqueryOnlyFullGroupBy(t *testing.T) {
+	s := coretestsdk.CreatePlannerSuiteElems()
+	defer s.Close()
+
+	sqlMode := s.GetCtx().GetSessionVars().SQLMode
+	s.GetCtx().GetSessionVars().SQLMode = sqlMode | mysql.ModeOnlyFullGroupBy
+	defer func() { s.GetCtx().GetSessionVars().SQLMode = sqlMode }()
+
+	sql := "select a, (select count(*) from t2 where b = t3.b) from t3 where a = 1 group by a"
+	stmt, err := s.GetParser().ParseOneStmt(sql, "", "")
+	require.NoError(t, err)
+
+	nodeW := resolve.NewNodeW(stmt)
+	p, err := BuildLogicalPlanForTest(context.Background(), s.GetSCtx(), nodeW, s.GetIS())
+	require.Nil(t, p)
+	require.Error(t, err)
+	require.Regexp(t, ".*contains nonaggregated column 'test\\.t3\\.b'.*", err.Error())
+}
+
 func TestDupRandJoinCondsPushDown(t *testing.T) {
 	sql := "select * from t as t1 join t t2 on t1.a > rand() and t1.a > rand()"
 	comment := fmt.Sprintf("for %s", sql)

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -2448,10 +2448,7 @@ SELECT m.i,
 (SELECT COUNT(n.j)
 FROM tab2 WHERE j=15) AS o
 FROM tab m, tab2 n GROUP BY 1 order by m.i;
-i	o
-1	4
-2	4
-3	4
+Error 1055 (42000): Expression #2 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'planner__core__integration.n.j' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
 SELECT
 (SELECT COUNT(n.j)
 FROM tab2 WHERE j=15) AS o

--- a/tests/integrationtest/t/planner/core/integration.test
+++ b/tests/integrationtest/t/planner/core/integration.test
@@ -990,6 +990,7 @@ CREATE TABLE tab(i INT);
 CREATE TABLE tab2(j INT);
 insert into tab values(1),(2),(3);
 insert into tab2 values(1),(2),(3),(15);
+-- error 1055
 SELECT m.i,
        (SELECT COUNT(n.j)
            FROM tab2 WHERE j=15) AS o


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67540

Problem Summary:

Legacy `ONLY_FULL_GROUP_BY` checking skipped correlated outer-column references inside scalar
subqueries because `colNameResolver.Enter` treated `*ast.SubqueryExpr` as a leaf node.

### What changed and how does it work?

- removed `*ast.SubqueryExpr` from `colNameResolver.Enter`, so the legacy collector can descend
  into scalar subqueries and see correlated outer-column references
- added a regression in `pkg/planner/core/logical_plans_test.go` covering the correlated
  scalar-subquery `ONLY_FULL_GROUP_BY` path

Local note:

- the scoped planner test below passes in this clean worktree
- `make bazel_prepare` was blocked in the original workspace by an unrelated
  `//tools/tazel:tazel` strict-deps issue on `github.com/pingcap/tidb/pkg/util/set`; this PR does
  not widen scope to address that separate problem

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test details:

- `./tools/check/failpoint-go-test.sh pkg/planner/core -run TestIssue67540CorrelatedScalarSubqueryOnlyFullGroupBy -count=1`
- `PASS`
- `ok github.com/pingcap/tidb/pkg/planner/core 1.596s`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a legacy ONLY_FULL_GROUP_BY check that missed correlated outer-column references inside scalar subqueries.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query validation for correlated scalar subqueries under OnlyFullGroupBy: certain queries that previously returned rows now correctly produce a non-aggregated-column error (1055) when required by SQL mode.

* **Tests**
  * Added and updated tests to assert the corrected error behavior for correlated scalar subqueries under OnlyFullGroupBy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->