### PR TITLE
planner: keep mutable join predicates above join | tidb-test=pr/2736

### DIFF
--- a/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_out.json
@@ -95,17 +95,19 @@
       {
         "SQL": "select * from foo join bar on foo.a=bar.a where foo.a = rand();",
         "Plan": [
-          "Projection root  test.foo.a, test.foo.b, test.foo.c, test.bar.a, test.bar.b, test.bar.c",
-          "└─MergeJoin root  inner join, left key:test.bar.a, right key:test.foo.a",
-          "  ├─Selection(Build) root  eq(cast(test.foo.a, double BINARY), rand())",
-          "  │ └─TableReader root  data:TableFullScan",
-          "  │   └─TableFullScan cop[tikv] table:foo keep order:true, stats:pseudo",
-          "  └─TableReader(Probe) root  data:TableFullScan",
-          "    └─TableFullScan cop[tikv] table:bar keep order:true, stats:pseudo"
+          "HashJoin root  inner join, equal:[eq(test.foo.a, test.bar.a) eq(Column, Column)]",
+          "├─Projection(Build) root  test.bar.a, test.bar.b, test.bar.c, rand()->Column",
+          "│ └─TableReader root  data:TableFullScan",
+          "│   └─TableFullScan cop[tikv] table:bar keep order:false, stats:pseudo",
+          "└─Projection(Probe) root  test.foo.a, test.foo.b, test.foo.c, cast(test.foo.a, double BINARY)->Column",
+          "  └─TableReader root  data:TableFullScan",
+          "    └─TableFullScan cop[tikv] table:foo keep order:false, stats:pseudo"
         ],
         "Result": null,
         "Warning": [
-          "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to storage layer now."
+          "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now.",
+          "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now.",
+          "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now."
         ]
       },
       {

--- a/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_out.json
@@ -95,16 +95,17 @@
       {
         "SQL": "select * from foo join bar on foo.a=bar.a where foo.a = rand();",
         "Plan": [
-          "HashJoin root  inner join, equal:[eq(test.foo.a, test.bar.a) eq(Column, Column)]",
+          "MergeJoin root  inner join, left key:test.foo.a, right key:test.bar.a, other cond:eq(Column, Column)",
           "├─Projection(Build) root  test.bar.a, test.bar.b, test.bar.c, rand()->Column",
           "│ └─TableReader root  data:TableFullScan",
-          "│   └─TableFullScan cop[tikv] table:bar keep order:false, stats:pseudo",
+          "│   └─TableFullScan cop[tikv] table:bar keep order:true, stats:pseudo",
           "└─Projection(Probe) root  test.foo.a, test.foo.b, test.foo.c, cast(test.foo.a, double BINARY)->Column",
           "  └─TableReader root  data:TableFullScan",
-          "    └─TableFullScan cop[tikv] table:foo keep order:false, stats:pseudo"
+          "    └─TableFullScan cop[tikv] table:foo keep order:true, stats:pseudo"
         ],
         "Result": null,
         "Warning": [
+          "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now.",
           "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now.",
           "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now.",
           "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now."

--- a/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_xut.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_xut.json
@@ -95,17 +95,19 @@
       {
         "SQL": "select * from foo join bar on foo.a=bar.a where foo.a = rand();",
         "Plan": [
-          "Projection root  test.foo.a, test.foo.b, test.foo.c, test.bar.a, test.bar.b, test.bar.c",
-          "└─MergeJoin root  inner join, left key:test.bar.a, right key:test.foo.a",
-          "  ├─Selection(Build) root  eq(cast(test.foo.a, double BINARY), rand())",
-          "  │ └─TableReader root  data:TableFullScan",
-          "  │   └─TableFullScan cop[tikv] table:foo keep order:true, stats:pseudo",
-          "  └─TableReader(Probe) root  data:TableFullScan",
-          "    └─TableFullScan cop[tikv] table:bar keep order:true, stats:pseudo"
+          "HashJoin root  inner join, equal:[eq(test.foo.a, test.bar.a) eq(Column, Column)]",
+          "├─Projection(Build) root  test.bar.a, test.bar.b, test.bar.c, rand()->Column",
+          "│ └─TableReader root  data:TableFullScan",
+          "│   └─TableFullScan cop[tikv] table:bar keep order:false, stats:pseudo",
+          "└─Projection(Probe) root  test.foo.a, test.foo.b, test.foo.c, cast(test.foo.a, double BINARY)->Column",
+          "  └─TableReader root  data:TableFullScan",
+          "    └─TableFullScan cop[tikv] table:foo keep order:false, stats:pseudo"
         ],
         "Result": null,
         "Warning": [
-          "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to storage layer now."
+          "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now.",
+          "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now.",
+          "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now."
         ]
       },
       {

--- a/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_xut.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_xut.json
@@ -95,16 +95,17 @@
       {
         "SQL": "select * from foo join bar on foo.a=bar.a where foo.a = rand();",
         "Plan": [
-          "HashJoin root  inner join, equal:[eq(test.foo.a, test.bar.a) eq(Column, Column)]",
+          "MergeJoin root  inner join, left key:test.foo.a, right key:test.bar.a, other cond:eq(Column, Column)",
           "├─Projection(Build) root  test.bar.a, test.bar.b, test.bar.c, rand()->Column",
           "│ └─TableReader root  data:TableFullScan",
-          "│   └─TableFullScan cop[tikv] table:bar keep order:false, stats:pseudo",
+          "│   └─TableFullScan cop[tikv] table:bar keep order:true, stats:pseudo",
           "└─Projection(Probe) root  test.foo.a, test.foo.b, test.foo.c, cast(test.foo.a, double BINARY)->Column",
           "  └─TableReader root  data:TableFullScan",
-          "    └─TableFullScan cop[tikv] table:foo keep order:false, stats:pseudo"
+          "    └─TableFullScan cop[tikv] table:foo keep order:true, stats:pseudo"
         ],
         "Result": null,
         "Warning": [
+          "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now.",
           "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now.",
           "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now.",
           "Warning 1105 Scalar function 'rand'(signature: Rand, return type: double) is not supported to push down to tikv now."

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -841,6 +841,41 @@ ORDER BY field1`).Check(testkit.Rows())
 		))
 		tk.MustExec("rollback")
 	}
+
+	// issue-67802-mutable-user-var-join-cond-should-not-become-inner-side-filter
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		resetTestDB(t, tk)
+		tk.MustExec("set @@sql_mode = default")
+		tk.MustExec("set @@tidb_enable_inl_join_inner_multi_pattern='OFF'")
+		tk.MustExec("set @@tidb_enable_unsafe_substitute=0")
+
+		tk.MustExec("create table t1(a int)")
+		tk.MustExec("insert into t1 values (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)")
+		tk.MustExec("create table t2(a int)")
+		tk.MustExec("insert into t2 values (1), (3), (5), (7), (9)")
+		tk.MustExec("create table t3(a int)")
+		tk.MustExec("insert into t3 values (1), (4), (7), (10)")
+		tk.MustExec("set @var1 = 6")
+		tk.MustExec("analyze table t1, t2, t3 all columns")
+
+		query := `SELECT t1.a, t2.a, t3.a, (@var1:= @var1+0) AS var
+FROM t1
+LEFT JOIN t2 ON t1.a=t2.a AND t2.a < @var1
+LEFT JOIN t3 ON t1.a=t3.a AND t3.a < @var1
+ORDER BY t1.a, t2.a, t3.a, var`
+		tk.MustQuery(query).Check(testkit.Rows(
+			"1 1 1 6",
+			"2 <nil> <nil> 6",
+			"3 3 <nil> 6",
+			"4 <nil> 4 6",
+			"5 5 <nil> 6",
+			"6 <nil> <nil> 6",
+			"7 <nil> <nil> 6",
+			"8 <nil> <nil> 6",
+			"9 <nil> <nil> 6",
+			"10 <nil> <nil> 6",
+		))
+	})
 }
 
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {

--- a/pkg/planner/core/joinorder/conflict_detector.go
+++ b/pkg/planner/core/joinorder/conflict_detector.go
@@ -799,6 +799,10 @@ func makeNonInnerJoin(ctx base.PlanContext, checkResult *CheckConnectionResult, 
 	}
 	join.EqualConditions = alignedEQConds
 	for _, cond := range alignedNonEQConds {
+		if expression.IsMutableEffectsExpr(cond) {
+			join.OtherConditions = append(join.OtherConditions, cond)
+			continue
+		}
 		fromLeft := expression.ExprFromSchema(cond, left.Schema())
 		fromRight := expression.ExprFromSchema(cond, right.Schema())
 		if fromLeft && !fromRight {

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -415,11 +415,10 @@ func TestDupRandJoinCondsPushDown(t *testing.T) {
 	require.True(t, ok, comment)
 	join, ok := proj.Children()[0].(*logicalop.LogicalJoin)
 	require.True(t, ok, comment)
-	leftPlan, ok := join.Children()[0].(*logicalop.LogicalSelection)
-	require.True(t, ok, comment)
-	leftCond := expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), leftPlan.Conditions)
-	// Condition with mutable function cannot be de-duplicated when push down join conds.
-	require.Equal(t, "[gt(cast(test.t.a, double BINARY), rand()) gt(cast(test.t.a, double BINARY), rand())]", leftCond, comment)
+	_, ok = join.Children()[0].(*logicalop.LogicalSelection)
+	require.False(t, ok, comment)
+	otherCond := expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), join.OtherConditions)
+	require.Equal(t, "[gt(cast(test.t.a, double BINARY), rand()) gt(cast(test.t.a, double BINARY), rand())]", otherCond, comment)
 }
 
 func TestTablePartition(t *testing.T) {

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -448,6 +448,22 @@ func TestDupRandJoinCondsPushDown(t *testing.T) {
 	require.Same(t, rightProj.Schema().Columns[len(rightProj.Schema().Columns)-1], otherFn.GetArgs()[1], comment)
 	require.Equal(t, "[cast(test.t.a, double BINARY)]", expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), []expression.Expression{leftProj.Exprs[len(leftProj.Exprs)-1]}), comment)
 	require.Equal(t, "[rand()]", expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), []expression.Expression{rightProj.Exprs[len(rightProj.Exprs)-1]}), comment)
+
+	sql = "select * from t as t1 left join t t2 on t1.a = t2.a and t2.a < @var1"
+	comment = fmt.Sprintf("for %s", sql)
+	stmt, err = s.GetParser().ParseOneStmt(sql, "", "")
+	require.NoError(t, err, comment)
+	nodeW = resolve.NewNodeW(stmt)
+	p, err = BuildLogicalPlanForTest(context.Background(), s.GetSCtx(), nodeW, s.GetIS())
+	require.NoError(t, err, comment)
+	p, err = logicalOptimize(context.TODO(), rule.FlagPredicatePushDown, p.(base.LogicalPlan))
+	require.NoError(t, err, comment)
+	join, ok = p.(*logicalop.LogicalJoin)
+	require.True(t, ok, comment)
+	_, ok = join.Children()[1].(*logicalop.LogicalSelection)
+	require.False(t, ok, comment)
+	require.Empty(t, join.RightConditions, comment)
+	require.Equal(t, "[lt(cast(test.t.a, double BINARY), cast(getvar(\"var1\"), double BINARY))]", expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), join.OtherConditions), comment)
 }
 
 func TestTablePartition(t *testing.T) {

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -433,11 +433,10 @@ func TestDupRandJoinCondsPushDown(t *testing.T) {
 	require.True(t, ok, comment)
 	join, ok = proj.Children()[0].(*logicalop.LogicalJoin)
 	require.True(t, ok, comment)
-	selection, ok := join.Children()[0].(*logicalop.LogicalSelection)
-	require.True(t, ok, comment)
-	leftCond := expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), selection.Conditions)
-	require.Equal(t, "[eq(cast(test.t.a, double BINARY), rand())]", leftCond, comment)
-	require.Empty(t, join.OtherConditions, comment)
+	_, ok = join.Children()[0].(*logicalop.LogicalSelection)
+	require.False(t, ok, comment)
+	otherCond = expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), join.OtherConditions)
+	require.Equal(t, "[eq(cast(test.t.a, double BINARY), rand())]", otherCond, comment)
 }
 
 func TestTablePartition(t *testing.T) {

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -435,8 +435,19 @@ func TestDupRandJoinCondsPushDown(t *testing.T) {
 	require.True(t, ok, comment)
 	_, ok = join.Children()[0].(*logicalop.LogicalSelection)
 	require.False(t, ok, comment)
-	otherCond = expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), join.OtherConditions)
-	require.Equal(t, "[eq(cast(test.t.a, double BINARY), rand())]", otherCond, comment)
+	leftProj, ok := join.Children()[0].(*logicalop.LogicalProjection)
+	require.True(t, ok, comment)
+	rightProj, ok := join.Children()[1].(*logicalop.LogicalProjection)
+	require.True(t, ok, comment)
+	require.Len(t, join.OtherConditions, 1, comment)
+	require.Len(t, join.EqualConditions, 1, comment)
+	otherFn, ok := join.OtherConditions[0].(*expression.ScalarFunction)
+	require.True(t, ok, comment)
+	require.Equal(t, ast.EQ, otherFn.FuncName.L, comment)
+	require.Same(t, leftProj.Schema().Columns[len(leftProj.Schema().Columns)-1], otherFn.GetArgs()[0], comment)
+	require.Same(t, rightProj.Schema().Columns[len(rightProj.Schema().Columns)-1], otherFn.GetArgs()[1], comment)
+	require.Equal(t, "[cast(test.t.a, double BINARY)]", expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), []expression.Expression{leftProj.Exprs[len(leftProj.Exprs)-1]}), comment)
+	require.Equal(t, "[rand()]", expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), []expression.Expression{rightProj.Exprs[len(rightProj.Exprs)-1]}), comment)
 }
 
 func TestTablePartition(t *testing.T) {

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -466,7 +466,7 @@ func TestDupRandJoinCondsPushDown(t *testing.T) {
 	_, ok = join.Children()[1].(*logicalop.LogicalSelection)
 	require.False(t, ok, comment)
 	require.Empty(t, join.RightConditions, comment)
-	require.Equal(t, "[lt(cast(test.t.a, double BINARY), cast(getvar(\"var1\"), double BINARY))]", expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), join.OtherConditions), comment)
+	require.Equal(t, "[lt(cast(test.t.a, double BINARY), cast(getvar(var1), double BINARY))]", expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), join.OtherConditions), comment)
 }
 
 func TestTablePartition(t *testing.T) {

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -458,6 +458,9 @@ func TestDupRandJoinCondsPushDown(t *testing.T) {
 	require.NoError(t, err, comment)
 	p, err = logicalOptimize(context.TODO(), rule.FlagPredicatePushDown, p.(base.LogicalPlan))
 	require.NoError(t, err, comment)
+	if proj, isProj := p.(*logicalop.LogicalProjection); isProj {
+		p = proj.Children()[0]
+	}
 	join, ok = p.(*logicalop.LogicalJoin)
 	require.True(t, ok, comment)
 	_, ok = join.Children()[1].(*logicalop.LogicalSelection)

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -419,6 +419,25 @@ func TestDupRandJoinCondsPushDown(t *testing.T) {
 	require.False(t, ok, comment)
 	otherCond := expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), join.OtherConditions)
 	require.Equal(t, "[gt(cast(test.t.a, double BINARY), rand()) gt(cast(test.t.a, double BINARY), rand())]", otherCond, comment)
+
+	sql = "select * from t as t1 join t t2 on t1.a = t2.a where t1.a = rand()"
+	comment = fmt.Sprintf("for %s", sql)
+	stmt, err = s.GetParser().ParseOneStmt(sql, "", "")
+	require.NoError(t, err, comment)
+	nodeW = resolve.NewNodeW(stmt)
+	p, err = BuildLogicalPlanForTest(context.Background(), s.GetSCtx(), nodeW, s.GetIS())
+	require.NoError(t, err, comment)
+	p, err = logicalOptimize(context.TODO(), rule.FlagPredicatePushDown, p.(base.LogicalPlan))
+	require.NoError(t, err, comment)
+	proj, ok = p.(*logicalop.LogicalProjection)
+	require.True(t, ok, comment)
+	join, ok = proj.Children()[0].(*logicalop.LogicalJoin)
+	require.True(t, ok, comment)
+	selection, ok := join.Children()[0].(*logicalop.LogicalSelection)
+	require.True(t, ok, comment)
+	leftCond := expression.StringifyExpressionsWithCtx(s.GetCtx().GetExprCtx().GetEvalCtx(), selection.Conditions)
+	require.Equal(t, "[eq(cast(test.t.a, double BINARY), rand())]", leftCond, comment)
+	require.Empty(t, join.OtherConditions, comment)
 }
 
 func TestTablePartition(t *testing.T) {

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -1511,11 +1511,8 @@ func (p *LogicalJoin) ExtractOnCondition(
 			continue
 		}
 		if expression.IsMutableEffectsExpr(expr) {
-			sf, ok := expr.(*expression.ScalarFunction)
-			if !ok || (sf.FuncName.L != ast.EQ && sf.FuncName.L != ast.NullEQ) {
-				otherCond = append(otherCond, expr)
-				continue
-			}
+			otherCond = append(otherCond, expr)
+			continue
 		}
 		allFromLeft, allFromRight := true, true
 		for _, col := range columns {

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -1503,13 +1503,15 @@ func (p *LogicalJoin) ExtractOnCondition(
 			// The IsMutableEffectsExpr check is primarily designed to prevent mutable expressions
 			// like rand() > 0.5 from being pushed down; instead, such expressions should remain
 			// in other conditions.
-			// Checking len(columns) == 0 first is to let filter like rand() > tbl.col
-			// to be able pushdown as left or right condition
 			if expression.IsMutableEffectsExpr(expr) {
 				otherCond = append(otherCond, expr)
 				continue
 			}
 			leftCond, rightCond = p.pushDownConstExpr(expr, leftCond, rightCond, deriveLeft || deriveRight)
+			continue
+		}
+		if expression.IsMutableEffectsExpr(expr) {
+			otherCond = append(otherCond, expr)
 			continue
 		}
 		allFromLeft, allFromRight := true, true

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -2181,6 +2181,9 @@ func DeriveOtherConditions(
 	ctx := p.SCtx()
 	exprCtx := ctx.GetExprCtx()
 	for _, expr := range p.OtherConditions {
+		if expression.IsMutableEffectsExpr(expr) {
+			continue
+		}
 		if deriveLeft {
 			leftRelaxedCond := expression.DeriveRelaxedFiltersFromDNF(exprCtx, expr, leftSchema)
 			if leftRelaxedCond != nil {

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -1511,8 +1511,11 @@ func (p *LogicalJoin) ExtractOnCondition(
 			continue
 		}
 		if expression.IsMutableEffectsExpr(expr) {
-			otherCond = append(otherCond, expr)
-			continue
+			sf, ok := expr.(*expression.ScalarFunction)
+			if !ok || (sf.FuncName.L != ast.EQ && sf.FuncName.L != ast.NullEQ) {
+				otherCond = append(otherCond, expr)
+				continue
+			}
 		}
 		allFromLeft, allFromRight := true, true
 		for _, col := range columns {

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -1804,6 +1804,7 @@ func (p *LogicalJoin) updateEQCond() {
 			}
 			for i := range leftKeys {
 				lKey, rKey := leftKeys[i], rightKeys[i]
+				keepAsOtherCond := expression.IsMutableEffectsExpr(lKey) || expression.IsMutableEffectsExpr(rKey)
 				lCastCol, lCasted := extractCastSourceColumn(lKey)
 				rCastCol, rCasted := extractCastSourceColumn(rKey)
 				if lCasted && rCasted {
@@ -1850,6 +1851,10 @@ func (p *LogicalJoin) updateEQCond() {
 					}
 					eqCond = expression.NewFunctionInternal(p.SCtx().GetExprCtx(), ast.EQ, types.NewFieldType(mysql.TypeTiny), lKey, rKey)
 					eqSf = eqCond.(*expression.ScalarFunction)
+				}
+				if keepAsOtherCond {
+					p.OtherConditions = append(p.OtherConditions, eqSf)
+					continue
 				}
 				if isNA {
 					p.NAEQConditions = append(p.NAEQConditions, eqSf)

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -850,9 +850,15 @@ func (s *baseSingleGroupJoinOrderSolver) makeJoin(leftPlan, rightPlan base.Logic
 	mergedSchema := expression.MergeSchema(leftPlan.Schema(), rightPlan.Schema())
 
 	remainOtherConds, leftConds = expression.FilterOutInPlace(remainOtherConds, func(expr expression.Expression) bool {
+		if expression.IsMutableEffectsExpr(expr) {
+			return false
+		}
 		return expression.ExprFromSchema(expr, leftPlan.Schema()) && !expression.ExprFromSchema(expr, rightPlan.Schema())
 	})
 	remainOtherConds, rightConds = expression.FilterOutInPlace(remainOtherConds, func(expr expression.Expression) bool {
+		if expression.IsMutableEffectsExpr(expr) {
+			return false
+		}
 		return expression.ExprFromSchema(expr, rightPlan.Schema()) && !expression.ExprFromSchema(expr, leftPlan.Schema())
 	})
 	remainOtherConds, otherConds = expression.FilterOutInPlace(remainOtherConds, func(expr expression.Expression) bool {
@@ -874,9 +880,15 @@ func (s *baseSingleGroupJoinOrderSolver) makeJoin(leftPlan, rightPlan base.Logic
 		remainOBOtherConds := make([]expression.Expression, len(joinType.outerBindCondition))
 		copy(remainOBOtherConds, joinType.outerBindCondition)
 		remainOBOtherConds, obLeftConds = expression.FilterOutInPlace(remainOBOtherConds, func(expr expression.Expression) bool {
+			if expression.IsMutableEffectsExpr(expr) {
+				return false
+			}
 			return expression.ExprFromSchema(expr, leftPlan.Schema()) && !expression.ExprFromSchema(expr, rightPlan.Schema())
 		})
 		remainOBOtherConds, obRightConds = expression.FilterOutInPlace(remainOBOtherConds, func(expr expression.Expression) bool {
+			if expression.IsMutableEffectsExpr(expr) {
+				return false
+			}
 			return expression.ExprFromSchema(expr, rightPlan.Schema()) && !expression.ExprFromSchema(expr, leftPlan.Schema())
 		})
 		// _ here make the linter happy.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67773

Problem Summary:

For inner joins, `LogicalJoin.ExtractOnCondition` kept mutable predicates such as `t1.a > rand()` out of pushdown only when the expression had no extracted columns. A one-sided mutable predicate therefore bypassed that guard and was incorrectly pushed into a child `LogicalSelection`.

### What changed and how does it work?

- keep mutable / non-deterministic predicates in `otherCond` before the one-sided `allFromLeft` / `allFromRight` pushdown branch
- update the existing nearby regression `TestDupRandJoinCondsPushDown` to assert the predicate stays on `join.OtherConditions` instead of being pushed into the left child

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix incorrect join predicate pushdown for mutable expressions such as rand().
```

### Tests

- `./tools/check/failpoint-go-test.sh pkg/planner/core -run TestDupRandJoinCondsPushDown -count=1`
- `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent side-effecting expressions (e.g., rand()) from being pushed into join-side filters; such expressions are kept as non-pushable other-conditions, moved into projections, and affected cases now yield hash joins (ordering/operator structure may change).

* **Tests**
  * Updated test expectations and recorded warnings to reflect refined predicate handling, projection placement, and the new physical plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->