### PR TITLE
expression, planner: guard mixed outer-join filter propagation | tidb-test=pr/2729

### DIFF
--- a/pkg/expression/constant_propagation.go
+++ b/pkg/expression/constant_propagation.go
@@ -864,6 +864,9 @@ func (s *propOuterJoinConstSolver) deriveConds(outerCol, innerCol *Column, schem
 			visited[k+offset] = true
 			continue
 		}
+		if filterConds && !ExprFromSchema(cond, s.outerSchema) {
+			continue
+		}
 		replaced, _, newExpr := tryToReplaceCond(s.ctx, outerCol, innerCol, cond, true)
 		if replaced {
 			// TODO(hawkingrei): if it is the true expression, we can remvoe it.
@@ -929,6 +932,9 @@ func (s *propOuterJoinConstSolver) propagateColumnEQ() {
 				continue
 			}
 			visited = s.deriveConds(outerCol, innerCol, mergedSchema, lenJoinConds, visited, false)
+			// Deriving new join filters from WHERE predicates is only safe when the
+			// original predicate is fully on the preserved side. Mixed outer/inner
+			// predicates can change outer-join semantics after null extension.
 			visited = s.deriveConds(outerCol, innerCol, mergedSchema, lenJoinConds, visited, true)
 		}
 	}

--- a/pkg/planner/core/casetest/rule/rule_outer2inner_test.go
+++ b/pkg/planner/core/casetest/rule/rule_outer2inner_test.go
@@ -100,6 +100,20 @@ func TestOuter2Inner(t *testing.T) {
   from t1 left join t0 on t0.c0 <> t1.c0
   where (null and t1.c0) <=> (t0.c0 is not null)`).Check(testkit.Rows("1"))
 
+		// Issue #66833: outer-join constant propagation must not turn a WHERE predicate
+		// into an inner-side join filter and remove the matched row before null extension.
+		tk.MustExec("drop table if exists t0, t1")
+		tk.MustExec("create table t0(c0 int)")
+		tk.MustExec("create table t1 like t0")
+		tk.MustExec("insert into t0 values (1)")
+		tk.MustExec("insert into t1 values (1)")
+		tk.MustQuery(`explain format = 'plan_tree' select t1.c0 as ref0, t0.c0 as ref1
+  from t1 left join t0 on t1.c0 = t0.c0
+  where coalesce(t0.c0 < t1.c0, t1.c0)`).CheckContain("left outer join")
+		tk.MustQuery(`select t1.c0 as ref0, t0.c0 as ref1
+  from t1 left join t0 on t1.c0 = t0.c0
+  where coalesce(t0.c0 < t1.c0, t1.c0)`).Check(testkit.Rows())
+
 		tk.MustExec("drop table if exists t_outer, t")
 		tk.MustExec(`CREATE TABLE t_outer (
 			id bigint(20) NOT NULL,

--- a/tests/integrationtest/r/executor/merge_join.result
+++ b/tests/integrationtest/r/executor/merge_join.result
@@ -10,7 +10,7 @@ Selection	root		or(eq(executor__merge_join.t.c1, 1), gt(executor__merge_join.t1.
 └─MergeJoin	root		left outer join, left side:Sort, left key:executor__merge_join.t.c1, right key:executor__merge_join.t1.c1
   ├─Sort(Build)	root		executor__merge_join.t1.c1
   │ └─TableReader	root		data:Selection
-  │   └─Selection	cop[tikv]		not(isnull(executor__merge_join.t1.c1)), or(eq(executor__merge_join.t1.c1, 1), gt(executor__merge_join.t1.c2, 20))
+  │   └─Selection	cop[tikv]		not(isnull(executor__merge_join.t1.c1))
   │     └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
   └─Sort(Probe)	root		executor__merge_join.t.c1
     └─TableReader	root		data:TableFullScan
@@ -276,7 +276,7 @@ Selection	root		or(eq(executor__merge_join.t.c1, 1), gt(executor__merge_join.t1.
     ├─Sort(Build)	root		executor__merge_join.t1.c1
     │ └─ShuffleReceiver	root		
     │   └─TableReader	root		data:Selection
-    │     └─Selection	cop[tikv]		not(isnull(executor__merge_join.t1.c1)), or(eq(executor__merge_join.t1.c1, 1), gt(executor__merge_join.t1.c2, 20))
+    │     └─Selection	cop[tikv]		not(isnull(executor__merge_join.t1.c1))
     │       └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
     └─Sort(Probe)	root		executor__merge_join.t.c1
       └─ShuffleReceiver	root		

--- a/tests/integrationtest/r/executor/merge_join.result
+++ b/tests/integrationtest/r/executor/merge_join.result
@@ -24,7 +24,7 @@ Selection	root		or(eq(executor__merge_join.t.c1, 1), gt(executor__merge_join.t1.
 └─MergeJoin	root		right outer join, left side:Sort, left key:executor__merge_join.t1.c1, right key:executor__merge_join.t.c1
   ├─Sort(Build)	root		executor__merge_join.t1.c1
   │ └─TableReader	root		data:Selection
-  │   └─Selection	cop[tikv]		not(isnull(executor__merge_join.t1.c1)), or(eq(executor__merge_join.t1.c1, 1), gt(executor__merge_join.t1.c2, 20))
+  │   └─Selection	cop[tikv]		not(isnull(executor__merge_join.t1.c1))
   │     └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
   └─Sort(Probe)	root		executor__merge_join.t.c1
     └─TableReader	root		data:TableFullScan
@@ -293,7 +293,7 @@ Selection	root		or(eq(executor__merge_join.t.c1, 1), gt(executor__merge_join.t1.
     ├─Sort(Build)	root		executor__merge_join.t1.c1
     │ └─ShuffleReceiver	root		
     │   └─TableReader	root		data:Selection
-    │     └─Selection	cop[tikv]		not(isnull(executor__merge_join.t1.c1)), or(eq(executor__merge_join.t1.c1, 1), gt(executor__merge_join.t1.c2, 20))
+    │     └─Selection	cop[tikv]		not(isnull(executor__merge_join.t1.c1))
     │       └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
     └─Sort(Probe)	root		executor__merge_join.t.c1
       └─ShuffleReceiver	root		

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -3422,9 +3422,8 @@ explain format='plan_tree' SELECT * FROM t1 LEFT JOIN t2 ON t1.a=t2.a WHERE not(
 id	task	access object	operator info
 Selection	root		not(istrue_with_null(plus(0, and(eq(planner__core__integration.t1.a, 30), eq(planner__core__integration.t2.b, 1)))))
 └─MergeJoin	root		left outer join, left side:TableReader, left key:planner__core__integration.t1.a, right key:planner__core__integration.t2.a
-  ├─TableReader(Build)	root		data:Selection
-  │ └─Selection	cop[tikv]		not(istrue_with_null(plus(0, and(eq(planner__core__integration.t2.a, 30), eq(planner__core__integration.t2.b, 1)))))
-  │   └─TableFullScan	cop[tikv]	table:t2	keep order:true, stats:pseudo
+  ├─TableReader(Build)	root		data:TableFullScan
+  │ └─TableFullScan	cop[tikv]	table:t2	keep order:true, stats:pseudo
   └─TableReader(Probe)	root		data:TableFullScan
     └─TableFullScan	cop[tikv]	table:t1	keep order:true, stats:pseudo
 SELECT * FROM t1 LEFT JOIN t2 ON t1.a=t2.a WHERE not(0+(t1.a=30 and t2.b=1));

--- a/tests/integrationtest/r/planner/core/rule_outer2inner.result
+++ b/tests/integrationtest/r/planner/core/rule_outer2inner.result
@@ -222,7 +222,7 @@ id	task	access object	operator info
 Selection	root		isfalse(and(planner__core__rule_outer2inner.t1.c0, ne(planner__core__rule_outer2inner.t0.c0, NULL)))
 └─HashJoin	root		right outer join, left side:TableReader, equal:[eq(planner__core__rule_outer2inner.t0.c0, planner__core__rule_outer2inner.t1.c0)]
   ├─TableReader(Build)	root		data:Selection
-  │ └─Selection	cop[tikv]		isfalse(and(planner__core__rule_outer2inner.t0.c0, ne(planner__core__rule_outer2inner.t0.c0, NULL))), not(isnull(planner__core__rule_outer2inner.t0.c0))
+  │ └─Selection	cop[tikv]		not(isnull(planner__core__rule_outer2inner.t0.c0))
   │   └─TableFullScan	cop[tikv]	table:t0	keep order:false, stats:pseudo
   └─TableReader(Probe)	root		data:TableFullScan
     └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66833

Problem Summary:

`PropConstForOuterJoin` could derive a new join-side filter from a `WHERE` predicate that mixed preserved-side and inner-side columns. For `LEFT JOIN ... WHERE COALESCE(...)`, that derived filter could remove the matched inner row before null extension and produce a wrong result.

### What changed and how does it work?

- Restrict outer-join `filterConds -> joinConds` derivation to predicates that are fully on the preserved side.
- Keep the existing join-condition derivation path unchanged.
- Add a regression to `TestOuter2Inner` for the exact `LEFT JOIN + WHERE COALESCE(...)` wrong-result shape from `#66833`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test details:

- Fail before fix:
  - `./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/rule -run TestOuter2Inner -count=1`
- Pass after fix:
  - `./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/rule -run TestOuter2Inner -count=1`
- Completion gate:
  - `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsafe propagation of WHERE-derived predicates into join filters to preserve LEFT/outer join semantics and correct results.

* **Behavior**
  * Simplified pushed predicates on some join build-sides and coprocessor selections, yielding more accurate and stable plan trees.

* **Tests**
  * Added a regression test ensuring LEFT JOINs are not incorrectly transformed by certain WHERE patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->