### PR TITLE
ddl: fix 'occuredErr' -> 'occurredErr' typo in rollingback.go

### DIFF
--- a/pkg/ddl/rollingback.go
+++ b/pkg/ddl/rollingback.go
@@ -96,7 +96,7 @@ func convertAddIdxJob2RollbackJob(
 
 // convertNotReorgAddIdxJob2RollbackJob converts the add index job that are not started workers to rollingbackJob,
 // to rollback add index operations. job.SnapshotVer == 0 indicates the workers are not started.
-func convertNotReorgAddIdxJob2RollbackJob(jobCtx *jobContext, job *model.Job, occuredErr error) (ver int64, err error) {
+func convertNotReorgAddIdxJob2RollbackJob(jobCtx *jobContext, job *model.Job, occurredErr error) (ver int64, err error) {
 	schemaID := job.SchemaID
 	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, schemaID)
 	if err != nil {
@@ -120,7 +120,7 @@ func convertNotReorgAddIdxJob2RollbackJob(jobCtx *jobContext, job *model.Job, oc
 		job.State = model.JobStateCancelled
 		return ver, dbterror.ErrCancelledDDLJob
 	}
-	return convertAddIdxJob2RollbackJob(jobCtx, job, tblInfo, indexesInfo, occuredErr)
+	return convertAddIdxJob2RollbackJob(jobCtx, job, tblInfo, indexesInfo, occurredErr)
 }
 
 // rollingbackModifyColumn change the modifying-column job into rolling back state.


### PR DESCRIPTION
## Description

Local parameter name `occuredErr` in `pkg/ddl/rollingback.go` (function `convertNotReorgAddIdxJob2RollbackJob`) was misspelled. Renamed to `occurredErr`.

Only used within this one file as a function parameter — no exported API or interface change.

Issue Number: ref none (trivial typo fix)

## Tests

- [x] No code (parameter rename, no behavior change)
- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)

No test changes needed: this is a local parameter rename, no observable behavior change. Existing tests validate the rollback logic and continue to pass unchanged.

## Side effects

- Breaking backward compatibility: No
- Affect users' behavior: No

## Release note

```release-note
NONE
```