### PR TITLE
planner: guard firstrow pushdown for constant groups

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -533,6 +533,30 @@ HAVING EXISTS (SELECT 1 FROM t_panic WHERE x IS NULL);`).Check(testkit.Rows("<ni
 		tk2.MustExec("set global tidb_enable_instance_plan_cache = 0;")
 	}
 
+	// constant-group-having-firstrow-pushdown
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("create table t0 (c0 int)")
+		tk.MustExec("create table t84 (c0 int)")
+		tk.MustExec("insert into t0 values (1), (0), (NULL)")
+		tk.MustExec("insert into t84 values (1), (0), (NULL)")
+
+		baseQuery := "SELECT /* issue:65945 */ t84.c0 FROM t84 NATURAL RIGHT JOIN t0 WHERE true GROUP BY NULL ORDER BY t84.c0"
+		trueQuery := "SELECT /* issue:65945 */ t84.c0 FROM t84 NATURAL RIGHT JOIN t0 WHERE true GROUP BY NULL HAVING t84.c0 ORDER BY t84.c0"
+		notQuery := "SELECT /* issue:65945 */ t84.c0 FROM t84 NATURAL RIGHT JOIN t0 WHERE true GROUP BY NULL HAVING NOT (t84.c0) ORDER BY t84.c0"
+		isNullQuery := "SELECT /* issue:65945 */ t84.c0 FROM t84 NATURAL RIGHT JOIN t0 WHERE true GROUP BY NULL HAVING (t84.c0 IS NULL) ORDER BY t84.c0"
+
+		tk.MustQuery(baseQuery).Check(testkit.Rows("1"))
+		tk.MustQuery(trueQuery).Check(testkit.Rows("1"))
+		tk.MustQuery(notQuery).Check(testkit.Rows())
+		tk.MustQuery(isNullQuery).Check(testkit.Rows())
+		tk.MustQuery(`SELECT /* issue:65945 */ t84.c0 FROM t84 NATURAL RIGHT JOIN t0 WHERE true GROUP BY NULL HAVING t84.c0
+UNION ALL
+SELECT t84.c0 FROM t84 NATURAL RIGHT JOIN t0 WHERE true GROUP BY NULL HAVING NOT (t84.c0)
+UNION ALL
+SELECT t84.c0 FROM t84 NATURAL RIGHT JOIN t0 WHERE true GROUP BY NULL HAVING (t84.c0 IS NULL)`).Check(testkit.Rows("1"))
+	}
+
 	// virtual-generated-column-substitute
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/operator/logicalop/logical_aggregation.go
+++ b/pkg/planner/core/operator/logicalop/logical_aggregation.go
@@ -667,6 +667,18 @@ func (la *LogicalAggregation) splitCondForAggregation(predicates []expression.Ex
 	return condsToPush, ret
 }
 
+func (la *LogicalAggregation) hasOnlyConstGroupByItems() bool {
+	if len(la.GroupByItems) == 0 {
+		return true
+	}
+	for _, item := range la.GroupByItems {
+		if item.ConstLevel() < expression.ConstOnlyInContext {
+			return false
+		}
+	}
+	return true
+}
+
 // getAggFuncsColsForConstResult gets aggregate output columns whose values always match their
 // single row-independent argument for every non-empty group.
 func (la *LogicalAggregation) getAggFuncsColsForConstResult() (aggFuncsCols []*expression.Column, aggFuncsExprs []expression.Expression) {
@@ -702,6 +714,11 @@ func aggFuncResultMatchesArgForNonEmptyGroup(aggFunc *aggregation.AggFuncDesc) b
 
 // getAggFuncsColsForFirstRow gets the columns that are used by first_row agg functions.
 func (la *LogicalAggregation) getAggFuncsColsForFirstRow() (aggFuncsCols []*expression.Column) {
+	// Constant-group aggregations (for example GROUP BY NULL) choose an arbitrary input row for
+	// firstrow() outputs, so pushing HAVING predicates on those outputs back to base rows is unsound.
+	if la.hasOnlyConstGroupByItems() {
+		return nil
+	}
 	aggFuncsCols = make([]*expression.Column, 0, len(la.AggFuncs))
 	for idx, col := range la.Schema().Columns {
 		aggFunc := la.AggFuncs[idx]


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65945

Problem Summary:

For constant-group aggregations such as `GROUP BY NULL`, `HAVING` predicates on `firstrow(...)`
outputs are not safe to push below the aggregation. Before this change, TiDB treated those
`firstrow(...)` outputs as pushdown anchors and could rewrite issue queries into pre-aggregation
filters that returned wrong rows for `HAVING NOT (t84.c0)` and `HAVING (t84.c0 IS NULL)`.

### What changed and how does it work?

- add a narrow guard in `LogicalAggregation.getAggFuncsColsForFirstRow()`
  - when all `GroupByItems` are constant, TiDB no longer uses `firstrow(...)` outputs for
    predicate pushdown
- add regression coverage in `TestPlannerIssueRegressions` for:
  - the base query
  - `HAVING t84.c0`
  - `HAVING NOT (t84.c0)`
  - `HAVING (t84.c0 IS NULL)`
  - the union control

This keeps the fix bounded to the constant-group corridor and does not widen into broader
`HAVING` semantics changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected query execution behavior for grouped operations combining `GROUP BY NULL` with `HAVING` filter predicates. Fixed the underlying filtering mechanism to produce accurate row results across different predicate types, including positive filter conditions, negated predicates, and null-value checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->