### PR TITLE
parser: support unquoted masking policy dynamic privileges

### DIFF
--- a/.agents/skills/column-masking-auto-validation/references/column-masking-test-plan.md
+++ b/.agents/skills/column-masking-auto-validation/references/column-masking-test-plan.md
@@ -48,7 +48,7 @@ Execution policy:
 ### 3.2 P0 Scenario Groups
 
 - `P0-DDL`: lifecycle, constraints, unsupported objects/columns, binding stability
-- `P0-AUTH`: dynamic privileges and identity-function semantics
+- `P0-AUTH`: dynamic privileges, GRANT/REVOKE syntax coverage, and identity-function semantics
 - `P0-CORE`: `AT RESULT` correctness in query pipeline
 - `P0-RES`: `RESTRICT ON` deny/allow behavior
 - `P0-FUNC`: masking builtin behavior and boundaries
@@ -59,6 +59,7 @@ Execution policy:
 - Integration:
   - `tests/integrationtest/t/privilege/column_masking_policy.test`
 - Unit:
+  - `pkg/parser/parser_test.go` (GRANT/REVOKE privilege grammar coverage)
   - `pkg/ddl/masking_policy_test.go`
   - `pkg/planner/core/masking_policy_projection_test.go`
   - `pkg/planner/core/masking_policy_restrict_test.go`

--- a/.agents/skills/column-masking-auto-validation/references/p0-scenario-matrix.json
+++ b/.agents/skills/column-masking-auto-validation/references/p0-scenario-matrix.json
@@ -159,16 +159,20 @@
   },
   {
     "id": "P0-AUTH-01",
-    "scenario": "Dynamic privilege boundary for CREATE/ALTER/DROP masking policy",
+    "scenario": "Dynamic privilege boundary and GRANT/REVOKE syntax for CREATE/ALTER/DROP masking policy",
     "coverage_cases": [
       {
         "name": "Privilege matrix for masking policy statements",
         "file": "tests/integrationtest/t/privilege/column_masking_policy.test"
+      },
+      {
+        "name": "Parser coverage for unquoted multi-word masking dynamic privileges in GRANT/REVOKE",
+        "file": "pkg/parser/parser_test.go"
       }
     ],
     "rule": {
       "type": "steps_pass",
-      "steps": ["it_column_masking"]
+      "steps": ["ut_parser_privilege", "it_column_masking"]
     }
   },
   {

--- a/.agents/skills/column-masking-auto-validation/scripts/run_validation.sh
+++ b/.agents/skills/column-masking-auto-validation/scripts/run_validation.sh
@@ -103,6 +103,7 @@ if [[ "${SKIP_TESTS}" -eq 0 ]]; then
   fi
 
   run_step "ut_failpoint_enable" "make failpoint-enable"
+  run_step "ut_parser_privilege" "pushd pkg/parser >/dev/null && go test -run 'TestPrivilege' -count=1 ./... && popd >/dev/null"
   run_step "ut_ddl" "go test -run 'TestMaskingPolicy' -tags=intest,deadlock ./pkg/ddl"
   run_step "ut_meta" "go test -run 'TestMaskingPolicy' -tags=intest,deadlock ./pkg/meta"
   run_step "ut_planner" "go test -run 'TestMaskingPolicy' -tags=intest,deadlock ./pkg/planner/core"

--- a/docs/design/2026-02-27-column-level-masking.md
+++ b/docs/design/2026-02-27-column-level-masking.md
@@ -2,7 +2,7 @@
 
 - Author(s):     [@tiancaiamao](https://github.com/tiancaiamao)
 - PM:            Frank (feature spec owner)
-- Last updated:  2026-02-27
+- Last updated:  2026-04-16
 - Tracking:      FRM-2351
 - Discussion at: https://github.com/pingcap/tidb/issues/65744
 
@@ -245,13 +245,21 @@ Notes:
 
 ![Data Access Authorization Logic](./column-level-masking-2.png)
 
-Administrative privileges:
+Masking policy administration uses dynamic privileges at global scope (`ON *.*`):
 
-- `CREATE MASKING POLICY`
-- `ALTER MASKING POLICY`
-- `DROP MASKING POLICY`
+```sql
+GRANT CREATE MASKING POLICY ON *.* TO 'security_admin'@'%';
+GRANT ALTER MASKING POLICY ON *.* TO 'security_admin'@'%';
+GRANT DROP MASKING POLICY ON *.* TO 'security_admin'@'%';
+```
 
-`ALTER MASKING POLICY` covers:
+| Privilege | Description |
+| --- | --- |
+| `CREATE MASKING POLICY` | Allows creating new policy objects and binding them to columns via `ALTER TABLE ... ADD MASKING POLICY` or `CREATE MASKING POLICY`. |
+| `ALTER MASKING POLICY` | Allows modifying existing masking policy definitions, including `SET EXPRESSION`, `SET RESTRICT ON`, and `ENABLE` / `DISABLE`. |
+| `DROP MASKING POLICY` | Allows permanent removal of masking policies from columns/tables. |
+
+`ALTER MASKING POLICY` includes:
 
 - `SET EXPRESSION`
 - `SET RESTRICT ON`

--- a/docs/design/2026-02-27-column-level-masking.md
+++ b/docs/design/2026-02-27-column-level-masking.md
@@ -172,13 +172,13 @@ Default-deny behavior is recommended: users/roles not matching allow conditions 
   - Example: `MASK_PARTIAL(credit_card, 6, 4, '*')` keeps first 6 and last 4 characters
 
 - `MASK_FULL(col, mask_char)` - Masks the entire column value by repeating the specified character
-  - `col`: The column to mask (string, datetime, or numeric types)
+  - `col`: The column to mask (string/date-time/year types)
   - `mask_char`: Single character used for masking (e.g., '*', 'X')
   - For datetime types: returns '1970-01-01' (date) or '1970-01-01 00:00:00' (datetime)
   - Example: `MASK_FULL(ssn, 'X')` returns 'XXXXXXXXX' for a 9-digit SSN
 
 - `MASK_NULL(col)` - Returns NULL for the column value
-  - `col`: The column to mask (any supported type)
+  - `col`: The column to mask (string/date-time/numeric supported types)
   - Example: `MASK_NULL(salary)` always returns NULL
 
 - `MASK_DATE(col, date_literal)` - Replaces the date value with a fixed date literal
@@ -192,6 +192,7 @@ Primary supported scope:
 
 - String-like: `VARCHAR`, `CHAR`, `TEXT` family, `BLOB` family
 - Temporal: `DATE`, `TIME`, `DATETIME`, `TIMESTAMP`, `YEAR`
+- Numeric: integer family, `DECIMAL`, `FLOAT`, `DOUBLE`
 
 For `LONGTEXT` and `BLOB` types, required minimum behavior is:
 

--- a/pkg/ddl/masking_policy.go
+++ b/pkg/ddl/masking_policy.go
@@ -313,6 +313,9 @@ func isMaskingPolicySupportedType(ft *types.FieldType) bool {
 	if types.IsTypeTime(tp) || tp == mysql.TypeDuration || tp == mysql.TypeYear {
 		return true
 	}
+	if types.IsTypeNumeric(tp) {
+		return true
+	}
 	return false
 }
 

--- a/pkg/expression/builtin_masking.go
+++ b/pkg/expression/builtin_masking.go
@@ -220,10 +220,11 @@ func (c *maskNullFunctionClass) getFunction(ctx BuildContext, args []Expression)
 			return nil, errIncorrectArgs.GenWithStackByArgs("mask_null")
 		}
 		return &builtinMaskNullDurationSig{bf}, nil
+	case types.ETReal:
+		return &builtinMaskNullRealSig{bf}, nil
+	case types.ETDecimal:
+		return &builtinMaskNullDecimalSig{bf}, nil
 	case types.ETInt:
-		if argType.GetType() != mysql.TypeYear {
-			return nil, errIncorrectArgs.GenWithStackByArgs("mask_null")
-		}
 		return &builtinMaskNullIntSig{bf}, nil
 	default:
 		return nil, errIncorrectArgs.GenWithStackByArgs("mask_null")
@@ -324,6 +325,54 @@ func (b *builtinMaskNullIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 		return 0, true, nil
 	}
 	return 0, true, nil
+}
+
+type builtinMaskNullRealSig struct {
+	baseBuiltinFunc
+	// NOTE: Any new fields added here must be thread-safe or immutable during execution,
+	// as this expression may be shared across sessions.
+	// If a field does not meet these requirements, set SafeToShareAcrossSession to false.
+}
+
+func (b *builtinMaskNullRealSig) Clone() builtinFunc {
+	newSig := &builtinMaskNullRealSig{}
+	newSig.cloneFrom(&b.baseBuiltinFunc)
+	return newSig
+}
+
+func (b *builtinMaskNullRealSig) evalReal(ctx EvalContext, row chunk.Row) (float64, bool, error) {
+	_, isNull, err := b.args[0].EvalReal(ctx, row)
+	if err != nil {
+		return 0, true, err
+	}
+	if isNull {
+		return 0, true, nil
+	}
+	return 0, true, nil
+}
+
+type builtinMaskNullDecimalSig struct {
+	baseBuiltinFunc
+	// NOTE: Any new fields added here must be thread-safe or immutable during execution,
+	// as this expression may be shared across sessions.
+	// If a field does not meet these requirements, set SafeToShareAcrossSession to false.
+}
+
+func (b *builtinMaskNullDecimalSig) Clone() builtinFunc {
+	newSig := &builtinMaskNullDecimalSig{}
+	newSig.cloneFrom(&b.baseBuiltinFunc)
+	return newSig
+}
+
+func (b *builtinMaskNullDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row) (*types.MyDecimal, bool, error) {
+	_, isNull, err := b.args[0].EvalDecimal(ctx, row)
+	if err != nil {
+		return nil, true, err
+	}
+	if isNull {
+		return nil, true, nil
+	}
+	return nil, true, nil
 }
 
 type maskPartialFunctionClass struct {

--- a/pkg/expression/builtin_masking_test.go
+++ b/pkg/expression/builtin_masking_test.go
@@ -76,6 +76,31 @@ func TestMaskNull(t *testing.T) {
 	d, err := f.Eval(ctx, chunk.Row{})
 	require.NoError(t, err)
 	require.Equal(t, types.KindNull, d.Kind())
+
+	decType := types.NewFieldType(mysql.TypeNewDecimal)
+	decType.SetFlen(10)
+	decType.SetDecimal(2)
+	decArg := &Constant{
+		Value:   types.NewDecimalDatum(types.NewDecFromStringForTest("85000.00")),
+		RetType: decType,
+	}
+	f, err = newFunctionForTest(ctx, ast.MaskNull, decArg)
+	require.NoError(t, err)
+	d, err = f.Eval(ctx, chunk.Row{})
+	require.NoError(t, err)
+	require.Equal(t, types.KindNull, d.Kind())
+
+	f, err = newFunctionForTest(ctx, ast.MaskNull, primitiveValsToConstants(ctx, []any{float64(1.25)})...)
+	require.NoError(t, err)
+	d, err = f.Eval(ctx, chunk.Row{})
+	require.NoError(t, err)
+	require.Equal(t, types.KindNull, d.Kind())
+
+	f, err = newFunctionForTest(ctx, ast.MaskNull, primitiveValsToConstants(ctx, []any{int64(42)})...)
+	require.NoError(t, err)
+	d, err = f.Eval(ctx, chunk.Row{})
+	require.NoError(t, err)
+	require.Equal(t, types.KindNull, d.Kind())
 }
 
 func TestMaskPartial(t *testing.T) {

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -14607,7 +14607,25 @@ ExtendedPriv:
 	}
 
 RoleOrPrivElem:
-	PrivElem
+	"CREATE" "MASKING" "POLICY"
+	{
+		$$ = &ast.RoleOrPriv{
+			Symbols: "CREATE MASKING POLICY",
+		}
+	}
+|	"ALTER" "MASKING" "POLICY"
+	{
+		$$ = &ast.RoleOrPriv{
+			Symbols: "ALTER MASKING POLICY",
+		}
+	}
+|	"DROP" "MASKING" "POLICY"
+	{
+		$$ = &ast.RoleOrPriv{
+			Symbols: "DROP MASKING POLICY",
+		}
+	}
+|	PrivElem
 	{
 		$$ = &ast.RoleOrPriv{
 			Node: $1,

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5139,6 +5139,9 @@ func TestPrivilege(t *testing.T) {
 		{"GRANT EXECUTE ON PROCEDURE mydb.myproc TO 'someuser'@'somehost'", true, "GRANT EXECUTE ON PROCEDURE `mydb`.`myproc` TO `someuser`@`somehost`"},
 		{"GRANT APPLICATION_PASSWORD_ADMIN,AUDIT_ADMIN ON *.* TO 'root'@'localhost'", true, "GRANT APPLICATION_PASSWORD_ADMIN, AUDIT_ADMIN ON *.* TO `root`@`localhost`"},
 		{"GRANT LOAD FROM S3, SELECT INTO S3, INVOKE LAMBDA, INVOKE SAGEMAKER, INVOKE COMPREHEND ON *.* TO 'root'@'localhost'", true, "GRANT LOAD FROM S3, SELECT INTO S3, INVOKE LAMBDA, INVOKE SAGEMAKER, INVOKE COMPREHEND ON *.* TO `root`@`localhost`"},
+		{"GRANT CREATE MASKING POLICY ON *.* TO 'security_admin'@'%'", true, "GRANT CREATE MASKING POLICY ON *.* TO `security_admin`@`%`"},
+		{"GRANT ALTER MASKING POLICY ON *.* TO 'security_admin'@'%'", true, "GRANT ALTER MASKING POLICY ON *.* TO `security_admin`@`%`"},
+		{"GRANT DROP MASKING POLICY ON *.* TO 'security_admin'@'%'", true, "GRANT DROP MASKING POLICY ON *.* TO `security_admin`@`%`"},
 		{"GRANT PROXY ON 'localuser'@'localhost' TO 'externaluser'@'somehost'", true, "GRANT PROXY ON `localuser`@`localhost` TO `externaluser`@`somehost`"},
 		{"GRANT PROXY ON ''@'' TO 'root'@'localhost' WITH GRANT OPTION", true, "GRANT PROXY ON ``@`` TO `root`@`localhost` WITH GRANT OPTION"},
 		{"GRANT PROXY ON 'proxied_user' TO 'proxy_user1', 'proxy_user2'", true, "GRANT PROXY ON `proxied_user`@`%` TO `proxy_user1`@`%`, `proxy_user2`@`%`"},
@@ -5161,6 +5164,9 @@ func TestPrivilege(t *testing.T) {
 		{"REVOKE EXECUTE ON FUNCTION db.func FROM 'user'@'localhost'", true, "REVOKE EXECUTE ON FUNCTION `db`.`func` FROM `user`@`localhost`"},
 		{"REVOKE EXECUTE ON PROCEDURE db.func FROM 'user'@'localhost'", true, "REVOKE EXECUTE ON PROCEDURE `db`.`func` FROM `user`@`localhost`"},
 		{"REVOKE APPLICATION_PASSWORD_ADMIN,AUDIT_ADMIN ON *.* FROM 'root'@'localhost'", true, "REVOKE APPLICATION_PASSWORD_ADMIN, AUDIT_ADMIN ON *.* FROM `root`@`localhost`"},
+		{"REVOKE CREATE MASKING POLICY ON *.* FROM 'security_admin'@'%'", true, "REVOKE CREATE MASKING POLICY ON *.* FROM `security_admin`@`%`"},
+		{"REVOKE ALTER MASKING POLICY ON *.* FROM 'security_admin'@'%'", true, "REVOKE ALTER MASKING POLICY ON *.* FROM `security_admin`@`%`"},
+		{"REVOKE DROP MASKING POLICY ON *.* FROM 'security_admin'@'%'", true, "REVOKE DROP MASKING POLICY ON *.* FROM `security_admin`@`%`"},
 		{"revoke all privileges, grant option from u1", true, "REVOKE ALL, GRANT OPTION ON *.* FROM `u1`@`%`"},                             // special case syntax
 		{"revoke all privileges, grant option from u1, u2, u3", true, "REVOKE ALL, GRANT OPTION ON *.* FROM `u1`@`%`, `u2`@`%`, `u3`@`%`"}, // special case syntax
 	}

--- a/tests/integrationtest/r/expression/builtin.result
+++ b/tests/integrationtest/r/expression/builtin.result
@@ -3469,9 +3469,9 @@ GET_FORMAT(DATE, 'jis')	GET_FORMAT(DATETIME, 'iso')	GET_FORMAT(TIMESTAMP, 'eur')
 select mask_full('abc', '*'), mask_full(cast('2012-01-02' as date), '*'), mask_full(cast('2012-01-02 03:04:05' as datetime), '*'), mask_full(cast('03:04:05' as time), '*'), mask_full(cast('2012' as year), '*');
 mask_full('abc', '*')	mask_full(cast('2012-01-02' as date), '*')	mask_full(cast('2012-01-02 03:04:05' as datetime), '*')	mask_full(cast('03:04:05' as time), '*')	mask_full(cast('2012' as year), '*')
 ***	1970-01-01	1970-01-01 00:00:00	00:00:00	1970
-select mask_null('abc'), mask_null(cast('2012-01-02' as date)), mask_null(cast('03:04:05' as time)), mask_null(cast('2012' as year));
-mask_null('abc')	mask_null(cast('2012-01-02' as date))	mask_null(cast('03:04:05' as time))	mask_null(cast('2012' as year))
-NULL	NULL	NULL	NULL
+select mask_null('abc'), mask_null(cast('2012-01-02' as date)), mask_null(cast('03:04:05' as time)), mask_null(cast('2012' as year)), mask_null(cast('85000.00' as decimal(10,2))), mask_null(cast('1.25' as double));
+mask_null('abc')	mask_null(cast('2012-01-02' as date))	mask_null(cast('03:04:05' as time))	mask_null(cast('2012' as year))	mask_null(cast('85000.00' as decimal(10,2)))	mask_null(cast('1.25' as double))
+NULL	NULL	NULL	NULL	NULL	NULL
 drop table if exists t_mask_blob_clob;
 create table t_mask_blob_clob(c longtext, b longblob, b2 longblob);
 insert into t_mask_blob_clob values('secret', x'31323334', x'616263');

--- a/tests/integrationtest/r/expression/masking_builtin_signature.result
+++ b/tests/integrationtest/r/expression/masking_builtin_signature.result
@@ -4,11 +4,12 @@ CREATE TABLE issue5_test_masking (
 id INT PRIMARY KEY,
 str_col VARCHAR(100),
 date_col DATE,
-datetime_col DATETIME
+datetime_col DATETIME,
+salary DECIMAL(10,2)
 );
 INSERT INTO issue5_test_masking VALUES
-(1, 'sensitive_data_12345', '1990-05-15', '1990-05-15 14:30:00'),
-(2, 'another_secret_98765', '1985-03-20', '1985-03-20 09:15:00');
+(1, 'sensitive_data_12345', '1990-05-15', '1990-05-15 14:30:00', 75000.00),
+(2, 'another_secret_98765', '1985-03-20', '1985-03-20 09:15:00', 85000.00);
 ## enable_query_log
 ## Verify signature: col (string), preserve_left (int), preserve_right (int), mask_char (single char)
 SELECT id, MASK_PARTIAL(str_col, 9, 5, '*') AS masked
@@ -66,13 +67,18 @@ FROM issue5_test_masking
 WHERE id = 1;
 id	masked
 1	1970-01-01
-## Verify signature: col (any type)
+## Verify signature: col (string/date-time/numeric supported types)
 SELECT id, MASK_NULL(str_col) IS NULL AS is_null
 FROM issue5_test_masking
 WHERE id = 1;
 id	is_null
 1	1
 SELECT id, MASK_NULL(date_col) IS NULL AS is_null
+FROM issue5_test_masking
+WHERE id = 2;
+id	is_null
+2	1
+SELECT id, MASK_NULL(salary) IS NULL AS is_null
 FROM issue5_test_masking
 WHERE id = 2;
 id	is_null

--- a/tests/integrationtest/r/privilege/column_masking_policy.result
+++ b/tests/integrationtest/r/privilege/column_masking_policy.result
@@ -168,13 +168,36 @@ c
 *****
 *****
 *****
+DROP TABLE IF EXISTS privilege__column_masking_policy.employees;
+CREATE TABLE privilege__column_masking_policy.employees (
+id INT PRIMARY KEY,
+name VARCHAR(100),
+email VARCHAR(100),
+salary DECIMAL(10,2),
+ssn VARCHAR(11)
+);
+INSERT INTO privilege__column_masking_policy.employees VALUES
+(1, 'John Doe', 'john.doe@company.com', 75000.00, '123456789'),
+(2, 'Jane Smith', 'jane.smith@company.com', 85000.00, '987654321');
+CREATE MASKING POLICY p_mask_salary ON privilege__column_masking_policy.employees(salary)
+AS MASK_NULL(salary) ENABLE;
+SELECT id, salary FROM privilege__column_masking_policy.employees ORDER BY id;
+id	salary
+1	NULL
+2	NULL
+SELECT id, salary IS NULL AS salary_is_null FROM privilege__column_masking_policy.employees ORDER BY id;
+id	salary_is_null
+1	1
+2	1
+ALTER TABLE privilege__column_masking_policy.employees DROP MASKING POLICY p_mask_salary;
+DROP TABLE privilege__column_masking_policy.employees;
 DROP VIEW IF EXISTS privilege__column_masking_policy.v_mask;
 DROP TABLE IF EXISTS privilege__column_masking_policy.t_gen;
 DROP TABLE IF EXISTS privilege__column_masking_policy.t_unsup;
 DROP TABLE IF EXISTS privilege__column_masking_policy.t_drop_table;
 CREATE VIEW privilege__column_masking_policy.v_mask AS SELECT c FROM privilege__column_masking_policy.t_lifecycle;
 CREATE TABLE privilege__column_masking_policy.t_gen(a INT, b VARCHAR(20) GENERATED ALWAYS AS (CAST(a AS CHAR)) VIRTUAL);
-CREATE TABLE privilege__column_masking_policy.t_unsup(i INT);
+CREATE TABLE privilege__column_masking_policy.t_unsup(i JSON);
 CREATE GLOBAL TEMPORARY TABLE privilege__column_masking_policy.t_tmp(c VARCHAR(20)) ON COMMIT DELETE ROWS;
 CREATE MASKING POLICY p_tmp ON privilege__column_masking_policy.t_tmp(c) AS c;
 Error 8006 (HY000): `masking policy` is unsupported on temporary tables.

--- a/tests/integrationtest/r/privilege/column_masking_policy.result
+++ b/tests/integrationtest/r/privilege/column_masking_policy.result
@@ -264,9 +264,9 @@ GRANT ALTER ON privilege__column_masking_policy.t_auth_priv TO cmp_mask_creator;
 GRANT ALTER ON privilege__column_masking_policy.t_auth_priv TO cmp_mask_alter;
 GRANT ALTER ON privilege__column_masking_policy.t_auth_priv TO cmp_mask_drop;
 GRANT ALTER ON privilege__column_masking_policy.t_auth_priv TO cmp_mask_none;
-GRANT `CREATE MASKING POLICY` ON *.* TO cmp_mask_creator;
-GRANT `ALTER MASKING POLICY` ON *.* TO cmp_mask_alter;
-GRANT `DROP MASKING POLICY` ON *.* TO cmp_mask_drop;
+GRANT CREATE MASKING POLICY ON *.* TO cmp_mask_creator;
+GRANT ALTER MASKING POLICY ON *.* TO cmp_mask_alter;
+GRANT DROP MASKING POLICY ON *.* TO cmp_mask_drop;
 CREATE MASKING POLICY p_auth_priv ON t_auth_priv(c) AS c;
 Error 1227 (42000): Access denied; you need (at least one of) the SUPER or CREATE MASKING POLICY privilege(s) for this operation
 ALTER TABLE t_auth_priv DISABLE MASKING POLICY p_auth_priv;

--- a/tests/integrationtest/r/privilege/privileges.result
+++ b/tests/integrationtest/r/privilege/privileges.result
@@ -62,9 +62,9 @@ GRANT ALTER ON privilege__privileges.mask_t TO mask_creator;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_alter;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_drop;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_none;
-GRANT `CREATE MASKING POLICY` ON *.* TO mask_creator;
-GRANT `ALTER MASKING POLICY` ON *.* TO mask_alter;
-GRANT `DROP MASKING POLICY` ON *.* TO mask_drop;
+GRANT CREATE MASKING POLICY ON *.* TO mask_creator;
+GRANT ALTER MASKING POLICY ON *.* TO mask_alter;
+GRANT DROP MASKING POLICY ON *.* TO mask_drop;
 create masking policy p on mask_t(c) as c;
 Error 1227 (42000): Access denied; you need (at least one of) the SUPER or CREATE MASKING POLICY privilege(s) for this operation
 alter table mask_t disable masking policy p;

--- a/tests/integrationtest/t/expression/builtin.test
+++ b/tests/integrationtest/t/expression/builtin.test
@@ -1674,7 +1674,7 @@ SELECT GET_FORMAT(TIME, 'usa'), GET_FORMAT(TIME, 'USA'), GET_FORMAT(TIME, 'UsA')
 SELECT GET_FORMAT(DATE, 'jis'),GET_FORMAT(DATETIME, 'iso'),GET_FORMAT(TIMESTAMP, 'eur'),GET_FORMAT(TIME, 'internal');
 # Masking functions
 select mask_full('abc', '*'), mask_full(cast('2012-01-02' as date), '*'), mask_full(cast('2012-01-02 03:04:05' as datetime), '*'), mask_full(cast('03:04:05' as time), '*'), mask_full(cast('2012' as year), '*');
-select mask_null('abc'), mask_null(cast('2012-01-02' as date)), mask_null(cast('03:04:05' as time)), mask_null(cast('2012' as year));
+select mask_null('abc'), mask_null(cast('2012-01-02' as date)), mask_null(cast('03:04:05' as time)), mask_null(cast('2012' as year)), mask_null(cast('85000.00' as decimal(10,2))), mask_null(cast('1.25' as double));
 drop table if exists t_mask_blob_clob;
 create table t_mask_blob_clob(c longtext, b longblob, b2 longblob);
 insert into t_mask_blob_clob values('secret', x'31323334', x'616263');

--- a/tests/integrationtest/t/expression/masking_builtin_signature.test
+++ b/tests/integrationtest/t/expression/masking_builtin_signature.test
@@ -8,11 +8,12 @@ CREATE TABLE issue5_test_masking (
   id INT PRIMARY KEY,
   str_col VARCHAR(100),
   date_col DATE,
-  datetime_col DATETIME
+  datetime_col DATETIME,
+  salary DECIMAL(10,2)
 );
 INSERT INTO issue5_test_masking VALUES
-  (1, 'sensitive_data_12345', '1990-05-15', '1990-05-15 14:30:00'),
-  (2, 'another_secret_98765', '1985-03-20', '1985-03-20 09:15:00');
+  (1, 'sensitive_data_12345', '1990-05-15', '1990-05-15 14:30:00', 75000.00),
+  (2, 'another_secret_98765', '1985-03-20', '1985-03-20 09:15:00', 85000.00);
 --echo ## enable_query_log
 
 # Test MASK_PARTIAL with actual signature: MASK_PARTIAL(col, preserve_left, preserve_right, mask_char)
@@ -89,7 +90,7 @@ WHERE id = 1;
 # Expected: '1970-01-01'
 
 # Test MASK_NULL with actual signature: MASK_NULL(col)
---echo ## Verify signature: col (any type)
+--echo ## Verify signature: col (string/date-time/numeric supported types)
 
 # Test case 1: Mask string to NULL
 SELECT id, MASK_NULL(str_col) IS NULL AS is_null
@@ -99,6 +100,12 @@ WHERE id = 1;
 
 # Test case 2: Mask date to NULL
 SELECT id, MASK_NULL(date_col) IS NULL AS is_null
+FROM issue5_test_masking
+WHERE id = 2;
+# Expected: 1 (true)
+
+# Test case 3: Mask numeric to NULL
+SELECT id, MASK_NULL(salary) IS NULL AS is_null
 FROM issue5_test_masking
 WHERE id = 2;
 # Expected: 1 (true)

--- a/tests/integrationtest/t/privilege/column_masking_policy.test
+++ b/tests/integrationtest/t/privilege/column_masking_policy.test
@@ -164,6 +164,25 @@ disconnect cmp_query_conn2;
 
 connection default;
 
+# IT-MASK-P0-007B TestColumnMaskPolicyMaskNullOnNumericColumn
+DROP TABLE IF EXISTS privilege__column_masking_policy.employees;
+CREATE TABLE privilege__column_masking_policy.employees (
+  id INT PRIMARY KEY,
+  name VARCHAR(100),
+  email VARCHAR(100),
+  salary DECIMAL(10,2),
+  ssn VARCHAR(11)
+);
+INSERT INTO privilege__column_masking_policy.employees VALUES
+  (1, 'John Doe', 'john.doe@company.com', 75000.00, '123456789'),
+  (2, 'Jane Smith', 'jane.smith@company.com', 85000.00, '987654321');
+CREATE MASKING POLICY p_mask_salary ON privilege__column_masking_policy.employees(salary)
+  AS MASK_NULL(salary) ENABLE;
+SELECT id, salary FROM privilege__column_masking_policy.employees ORDER BY id;
+SELECT id, salary IS NULL AS salary_is_null FROM privilege__column_masking_policy.employees ORDER BY id;
+ALTER TABLE privilege__column_masking_policy.employees DROP MASKING POLICY p_mask_salary;
+DROP TABLE privilege__column_masking_policy.employees;
+
 # IT-MASK-P0-008 TestColumnMaskPolicyUnsupportedTargetsAndColumns
 DROP VIEW IF EXISTS privilege__column_masking_policy.v_mask;
 DROP TABLE IF EXISTS privilege__column_masking_policy.t_gen;
@@ -171,7 +190,7 @@ DROP TABLE IF EXISTS privilege__column_masking_policy.t_unsup;
 DROP TABLE IF EXISTS privilege__column_masking_policy.t_drop_table;
 CREATE VIEW privilege__column_masking_policy.v_mask AS SELECT c FROM privilege__column_masking_policy.t_lifecycle;
 CREATE TABLE privilege__column_masking_policy.t_gen(a INT, b VARCHAR(20) GENERATED ALWAYS AS (CAST(a AS CHAR)) VIRTUAL);
-CREATE TABLE privilege__column_masking_policy.t_unsup(i INT);
+CREATE TABLE privilege__column_masking_policy.t_unsup(i JSON);
 
 CREATE GLOBAL TEMPORARY TABLE privilege__column_masking_policy.t_tmp(c VARCHAR(20)) ON COMMIT DELETE ROWS;
 --error 8006

--- a/tests/integrationtest/t/privilege/column_masking_policy.test
+++ b/tests/integrationtest/t/privilege/column_masking_policy.test
@@ -236,9 +236,9 @@ GRANT ALTER ON privilege__column_masking_policy.t_auth_priv TO cmp_mask_creator;
 GRANT ALTER ON privilege__column_masking_policy.t_auth_priv TO cmp_mask_alter;
 GRANT ALTER ON privilege__column_masking_policy.t_auth_priv TO cmp_mask_drop;
 GRANT ALTER ON privilege__column_masking_policy.t_auth_priv TO cmp_mask_none;
-GRANT `CREATE MASKING POLICY` ON *.* TO cmp_mask_creator;
-GRANT `ALTER MASKING POLICY` ON *.* TO cmp_mask_alter;
-GRANT `DROP MASKING POLICY` ON *.* TO cmp_mask_drop;
+GRANT CREATE MASKING POLICY ON *.* TO cmp_mask_creator;
+GRANT ALTER MASKING POLICY ON *.* TO cmp_mask_alter;
+GRANT DROP MASKING POLICY ON *.* TO cmp_mask_drop;
 
 connect (cmp_mask_none_conn, localhost, cmp_mask_none,, privilege__column_masking_policy);
 connection cmp_mask_none_conn;

--- a/tests/integrationtest/t/privilege/privileges.test
+++ b/tests/integrationtest/t/privilege/privileges.test
@@ -92,9 +92,9 @@ GRANT ALTER ON privilege__privileges.mask_t TO mask_creator;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_alter;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_drop;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_none;
-GRANT `CREATE MASKING POLICY` ON *.* TO mask_creator;
-GRANT `ALTER MASKING POLICY` ON *.* TO mask_alter;
-GRANT `DROP MASKING POLICY` ON *.* TO mask_drop;
+GRANT CREATE MASKING POLICY ON *.* TO mask_creator;
+GRANT ALTER MASKING POLICY ON *.* TO mask_alter;
+GRANT DROP MASKING POLICY ON *.* TO mask_drop;
 
 connect (mask_none, localhost, mask_none,, privilege__privileges);
 connection mask_none;


### PR DESCRIPTION
## Summary\n- allow unquoted multi-word masking dynamic privileges in GRANT/REVOKE:\n  - CREATE MASKING POLICY\n  - ALTER MASKING POLICY\n  - DROP MASKING POLICY\n- add parser regression coverage for the unquoted GRANT/REVOKE syntax\n- update integration privilege tests to use unquoted syntax\n- update column-masking auto-validation skill to include parser privilege grammar step and map AUTH scenario to syntax+semantic coverage\n\n## Backport\n- cherry-picked from commit: b450dc45fb\n\n## Test\n- [x] cd pkg/parser && go test -run TestPrivilege -count=1 ./...\n- [ ] tests/integrationtest privilege/column_masking_policy (failed locally due environment: Go ABI panic before server startup)\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for GRANT/REVOKE of masking-policy privileges (CREATE/ALTER/DROP MASKING POLICY).

* **Documentation**
  * Clarified masking policy types, numeric support, and explicit authorization examples for privilege administration.

* **Bug Fixes**
  * Removed extraneous backticks from masking-policy GRANT/REVOKE statements.

* **Tests**
  * Added and expanded parser, unit, and integration tests covering masking-policy privileges and numeric MASK_NULL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->