### PR TITLE
[DNM] pkg/planner: stabilize TestSubsetIdxCardinality first-run plan checks

### DIFF
--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -2163,6 +2163,17 @@ func TestSubsetIdxCardinality(t *testing.T) {
 	require.True(t, stat.GetCol(tblInfo.Columns[2].ID).IsFullLoad())
 	require.True(t, stat.GetIdx(tblInfo.Indices[0].ID).IsFullLoad())
 	require.False(t, hasAsyncLoadForTable())
+	for _, sql := range input {
+		if !strings.HasPrefix(sql, "explain") {
+			continue
+		}
+		// Prewarm every recorded explain once to avoid first-run plan drift in checks.
+		testKit.MustQuery(sql).Rows()
+		if hasAsyncLoadForTable() {
+			require.NoError(t, h.LoadNeededHistograms(dom.InfoSchema()))
+		}
+		require.False(t, hasAsyncLoadForTable())
+	}
 	for i := range input {
 		testdata.OnRecord(func() {
 			output[i].Query = input[i]
@@ -2175,6 +2186,10 @@ func TestSubsetIdxCardinality(t *testing.T) {
 			output[i].Result = testdata.ConvertRowsToStrings(testKit.MustQuery(input[i]).Rows())
 		})
 		testKit.MustQuery(input[i]).Check(testkit.Rows(output[i].Result...))
+		if hasAsyncLoadForTable() {
+			require.NoError(t, h.LoadNeededHistograms(dom.InfoSchema()))
+		}
+		require.False(t, hasAsyncLoadForTable())
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67355

Problem Summary:
`TestSubsetIdxCardinality` was reopened as flaky. Recent failures show the first checked `EXPLAIN` (`select distinct a from t`) can still observe unstable cardinality (`1280` expected vs `640` actual) even after the previous warm-up change.

### What changed and how does it work?

- Keep the existing async-load bootstrap (`tidb_stats_load_sync_wait=0` + initial `LoadNeededHistograms`).
- Prewarm every recorded `EXPLAIN` query once before golden checks.
- If warm-up or checked `EXPLAIN` re-enqueues async histogram items for table `t`, immediately call `LoadNeededHistograms` again and assert the queue is drained.

This closes the remaining first-run gap left by the prior fix and keeps assertions on stabilized stats state.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for query cardinality selectivity by adding prewarm query execution and histogram loading validation phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->