### PR TITLE
ddl: prohibit indexed generated column type changes | tidb-test=pr/2730

### DIFF
--- a/pkg/ddl/column_modify_test.go
+++ b/pkg/ddl/column_modify_test.go
@@ -669,6 +669,7 @@ func TestIssue37611(t *testing.T) {
 	tk.MustExec("set @@sql_mode=default;")
 	tk.MustQuery("select * from t ignore index(idx) where b = 'aaaaaa';").Check(testkit.Rows("aaa aaaaaa", "aaaa aaaaaa"))
 	tk.MustQuery("select * from t force index(idx) where b = 'aaaaaa';").Check(testkit.Rows("aaa aaaaaa", "aaaa aaaaaa"))
+	tk.MustGetErrCode("alter table t change column b c char(10) as (concat(a, a));", errno.ErrUnsupportedOnGeneratedColumn)
 
 	tk.MustExec("create table t2(a char(5), b char(6) as (concat(a, a)) stored, index idx(b));")
 	tk.MustGetErrCode("alter table t2 modify b char(10) as (concat(a, a)) stored;", errno.ErrUnsupportedOnGeneratedColumn)

--- a/pkg/ddl/column_modify_test.go
+++ b/pkg/ddl/column_modify_test.go
@@ -669,4 +669,7 @@ func TestIssue37611(t *testing.T) {
 	tk.MustExec("set @@sql_mode=default;")
 	tk.MustQuery("select * from t ignore index(idx) where b = 'aaaaaa';").Check(testkit.Rows("aaa aaaaaa", "aaaa aaaaaa"))
 	tk.MustQuery("select * from t force index(idx) where b = 'aaaaaa';").Check(testkit.Rows("aaa aaaaaa", "aaaa aaaaaa"))
+
+	tk.MustExec("create table t2(a char(5), b char(6) as (concat(a, a)) stored, index idx(b));")
+	tk.MustGetErrCode("alter table t2 modify b char(10) as (concat(a, a)) stored;", errno.ErrUnsupportedOnGeneratedColumn)
 }

--- a/pkg/ddl/column_modify_test.go
+++ b/pkg/ddl/column_modify_test.go
@@ -655,3 +655,18 @@ func TestModifyColumnReorgCheckpoint(t *testing.T) {
 	require.Len(t, rangeCnts, 2)                // It should have two rounds for loading table ranges.
 	require.Less(t, rangeCnts[1], rangeCnts[0]) // Verify if the checkpoint is progressing.
 }
+
+func TestIssue37611(t *testing.T) {
+	store := testkit.CreateMockStoreWithSchemaLease(t, columnModifyLease)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a char(5), b char(6) as (concat(a, a)), index idx(b));")
+	tk.MustExec("set @@sql_mode='';")
+	tk.MustExec("insert into t (a) values ('aaa');")
+	tk.MustExec("insert into t (a) values ('aaaa');")
+	tk.MustGetErrCode("alter table t modify b char(10) as (concat(a, a));", errno.ErrUnsupportedOnGeneratedColumn)
+	tk.MustExec("set @@sql_mode=default;")
+	tk.MustQuery("select * from t ignore index(idx) where b = 'aaaaaa';").Check(testkit.Rows("aaa aaaaaa", "aaaa aaaaaa"))
+	tk.MustQuery("select * from t force index(idx) where b = 'aaaaaa';").Check(testkit.Rows("aaa aaaaaa", "aaaa aaaaaa"))
+}

--- a/pkg/ddl/generated_column.go
+++ b/pkg/ddl/generated_column.go
@@ -389,22 +389,32 @@ func checkIllegalFn4Generated(name string, genType int, expr ast.ExprNode) error
 }
 
 func checkIndexOrStored(tbl table.Table, oldCol, newCol *table.Column) error {
+	isIndexed := false
+	for _, idx := range tbl.Indices() {
+		for _, col := range idx.Meta().Columns {
+			if col.Name.L == newCol.Name.L {
+				isIndexed = true
+				break
+			}
+		}
+		if isIndexed {
+			break
+		}
+	}
+
 	if oldCol.GeneratedExprString == newCol.GeneratedExprString {
-		if oldCol.FieldType.Equal(&newCol.FieldType) {
+		if oldCol.FieldType.Equal(&newCol.FieldType) || !isIndexed {
 			return nil
 		}
+		return dbterror.ErrUnsupportedOnGeneratedColumn.GenWithStackByArgs("modifying an indexed column")
 	}
 
 	if newCol.GeneratedStored {
 		return dbterror.ErrUnsupportedOnGeneratedColumn.GenWithStackByArgs("modifying a stored column")
 	}
 
-	for _, idx := range tbl.Indices() {
-		for _, col := range idx.Meta().Columns {
-			if col.Name.L == newCol.Name.L {
-				return dbterror.ErrUnsupportedOnGeneratedColumn.GenWithStackByArgs("modifying an indexed column")
-			}
-		}
+	if isIndexed {
+		return dbterror.ErrUnsupportedOnGeneratedColumn.GenWithStackByArgs("modifying an indexed column")
 	}
 	return nil
 }

--- a/pkg/ddl/generated_column.go
+++ b/pkg/ddl/generated_column.go
@@ -392,7 +392,7 @@ func checkIndexOrStored(tbl table.Table, oldCol, newCol *table.Column) error {
 	isIndexed := false
 	for _, idx := range tbl.Indices() {
 		for _, col := range idx.Meta().Columns {
-			if col.Name.L == newCol.Name.L {
+			if col.Name.L == oldCol.Name.L || col.Name.L == newCol.Name.L {
 				isIndexed = true
 				break
 			}

--- a/pkg/ddl/generated_column.go
+++ b/pkg/ddl/generated_column.go
@@ -390,7 +390,9 @@ func checkIllegalFn4Generated(name string, genType int, expr ast.ExprNode) error
 
 func checkIndexOrStored(tbl table.Table, oldCol, newCol *table.Column) error {
 	if oldCol.GeneratedExprString == newCol.GeneratedExprString {
-		return nil
+		if oldCol.FieldType.Equal(&newCol.FieldType) {
+			return nil
+		}
 	}
 
 	if newCol.GeneratedStored {

--- a/pkg/ddl/generated_column.go
+++ b/pkg/ddl/generated_column.go
@@ -406,7 +406,7 @@ func checkIndexOrStored(tbl table.Table, oldCol, newCol *table.Column) error {
 		if oldCol.FieldType.Equal(&newCol.FieldType) || !isIndexed {
 			return nil
 		}
-		return dbterror.ErrUnsupportedOnGeneratedColumn.GenWithStackByArgs("modifying an indexed column")
+		return dbterror.ErrUnsupportedModifyIndexedGeneratedColumn.GenWithStackByArgs()
 	}
 
 	if newCol.GeneratedStored {
@@ -414,7 +414,7 @@ func checkIndexOrStored(tbl table.Table, oldCol, newCol *table.Column) error {
 	}
 
 	if isIndexed {
-		return dbterror.ErrUnsupportedOnGeneratedColumn.GenWithStackByArgs("modifying an indexed column")
+		return dbterror.ErrUnsupportedModifyIndexedGeneratedColumn.GenWithStackByArgs()
 	}
 	return nil
 }

--- a/pkg/ddl/generated_column.go
+++ b/pkg/ddl/generated_column.go
@@ -406,7 +406,7 @@ func checkIndexOrStored(tbl table.Table, oldCol, newCol *table.Column) error {
 		if oldCol.FieldType.Equal(&newCol.FieldType) || !isIndexed {
 			return nil
 		}
-		return dbterror.ErrUnsupportedModifyIndexedGeneratedColumn.GenWithStackByArgs()
+		return dbterror.ErrUnsupportedOnGeneratedColumn.GenWithStack("Unsupported modification for generated columns covered by an index")
 	}
 
 	if newCol.GeneratedStored {
@@ -414,7 +414,7 @@ func checkIndexOrStored(tbl table.Table, oldCol, newCol *table.Column) error {
 	}
 
 	if isIndexed {
-		return dbterror.ErrUnsupportedModifyIndexedGeneratedColumn.GenWithStackByArgs()
+		return dbterror.ErrUnsupportedOnGeneratedColumn.GenWithStack("Unsupported modification for generated columns covered by an index")
 	}
 	return nil
 }

--- a/pkg/util/dbterror/ddl_terror.go
+++ b/pkg/util/dbterror/ddl_terror.go
@@ -126,6 +126,8 @@ var (
 	ErrWrongFKOptionForGeneratedColumn = ClassDDL.NewStd(mysql.ErrWrongFKOptionForGeneratedColumn)
 	// ErrUnsupportedOnGeneratedColumn is for unsupported actions on generated columns.
 	ErrUnsupportedOnGeneratedColumn = ClassDDL.NewStd(mysql.ErrUnsupportedOnGeneratedColumn)
+	// ErrUnsupportedModifyIndexedGeneratedColumn is for unsupported modifications on generated columns covered by an index.
+	ErrUnsupportedModifyIndexedGeneratedColumn = ClassDDL.NewStdErr(mysql.ErrUnsupportedOnGeneratedColumn, parser_mysql.Message("Unsupported modification for generated columns covered by an index", nil))
 	// ErrGeneratedColumnNonPrior forbids to refer generated column non prior to it.
 	ErrGeneratedColumnNonPrior = ClassDDL.NewStd(mysql.ErrGeneratedColumnNonPrior)
 	// ErrDependentByGeneratedColumn forbids to delete columns which are dependent by generated columns.

--- a/pkg/util/dbterror/ddl_terror.go
+++ b/pkg/util/dbterror/ddl_terror.go
@@ -126,8 +126,6 @@ var (
 	ErrWrongFKOptionForGeneratedColumn = ClassDDL.NewStd(mysql.ErrWrongFKOptionForGeneratedColumn)
 	// ErrUnsupportedOnGeneratedColumn is for unsupported actions on generated columns.
 	ErrUnsupportedOnGeneratedColumn = ClassDDL.NewStd(mysql.ErrUnsupportedOnGeneratedColumn)
-	// ErrUnsupportedModifyIndexedGeneratedColumn is for unsupported modifications on generated columns covered by an index.
-	ErrUnsupportedModifyIndexedGeneratedColumn = ClassDDL.NewStdErr(mysql.ErrUnsupportedOnGeneratedColumn, parser_mysql.Message("Unsupported modification for generated columns covered by an index", nil))
 	// ErrGeneratedColumnNonPrior forbids to refer generated column non prior to it.
 	ErrGeneratedColumnNonPrior = ClassDDL.NewStd(mysql.ErrGeneratedColumnNonPrior)
 	// ErrDependentByGeneratedColumn forbids to delete columns which are dependent by generated columns.

--- a/tests/integrationtest/r/ddl/column_modify.result
+++ b/tests/integrationtest/r/ddl/column_modify.result
@@ -172,7 +172,9 @@ drop table t1;
 create table t1 (a int, b int as (a+1), index idx(b));
 insert into t1 set a=1;
 alter table t1 modify column b bigint as (a+1);
+Error 3106 (HY000): 'modifying an indexed column' is not supported for generated columns.
 alter table t1 modify column b bigint as (a + 1);
+Error 3106 (HY000): 'modifying an indexed column' is not supported for generated columns.
 select * from t1;
 a	b
 1	2

--- a/tests/integrationtest/r/ddl/column_modify.result
+++ b/tests/integrationtest/r/ddl/column_modify.result
@@ -139,7 +139,7 @@ drop table if exists t1;
 create table t1 (a int, b int as (a+1), index idx(b));
 insert into t1 set a=1;
 alter table t1 modify column b int as (a+2);
-Error 3106 (HY000): 'modifying an indexed column' is not supported for generated columns.
+Error 3106 (HY000): Unsupported modification for generated columns covered by an index
 drop index idx on t1;
 alter table t1 modify b int as (a+2);
 select * from t1;
@@ -149,7 +149,7 @@ drop table t1;
 create table t1 (a int, b int as (a+1), index idx(a, b));
 insert into t1 set a=1;
 alter table t1 modify column b int as (a+2);
-Error 3106 (HY000): 'modifying an indexed column' is not supported for generated columns.
+Error 3106 (HY000): Unsupported modification for generated columns covered by an index
 drop index idx on t1;
 alter table t1 modify b int as (a+2);
 select * from t1;
@@ -172,9 +172,9 @@ drop table t1;
 create table t1 (a int, b int as (a+1), index idx(b));
 insert into t1 set a=1;
 alter table t1 modify column b bigint as (a+1);
-Error 3106 (HY000): 'modifying an indexed column' is not supported for generated columns.
+Error 3106 (HY000): Unsupported modification for generated columns covered by an index
 alter table t1 modify column b bigint as (a + 1);
-Error 3106 (HY000): 'modifying an indexed column' is not supported for generated columns.
+Error 3106 (HY000): Unsupported modification for generated columns covered by an index
 select * from t1;
 a	b
 1	2

--- a/tests/integrationtest/t/ddl/column_modify.test
+++ b/tests/integrationtest/t/ddl/column_modify.test
@@ -127,7 +127,9 @@ select * from t1;
 drop table t1;
 create table t1 (a int, b int as (a+1), index idx(b));
 insert into t1 set a=1;
+-- error 3106
 alter table t1 modify column b bigint as (a+1);
+-- error 3106
 alter table t1 modify column b bigint as (a + 1);
 select * from t1;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #37611

Problem Summary:

For the case in #37611, TiDB allows modifying the type of a generated column when the generated expression string is unchanged, even if the generated column is indexed.

This is unsafe. The existing DDL path does not reorganize the related index data for this case, so the index entries may still reflect the old generated-column type while row reads use the new type. As a result, index lookups can return different results from table scans, and `ADMIN CHECK TABLE` reports data/index inconsistency.

### What changed and how does it work?

This PR tightens the generated-column modification check.

Previously, `checkIndexOrStored` returned success as long as the generated expression string was unchanged. After this change, the fast path is allowed only when both of the following are unchanged:

1. the generated expression string
2. the generated column field type

If the generated column type changes, TiDB now rejects the DDL for indexed generated columns. This matches the current DDL capability, because these cases require index/data reorganization that TiDB does not perform here today. Rejecting the DDL avoids creating inconsistent data and index states.

This PR also adds a regression test based on the reproducer in #37611 and includes the required `make bazel_prepare` metadata update for the new top-level test.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

- `GOSUMDB=sum.golang.org GOPATH=/Users/xiaoli/go make bazel_prepare`
- `GOSUMDB=sum.golang.org GOPATH=/Users/xiaoli/go ./tools/check/failpoint-go-test.sh pkg/ddl -run TestIssue37611 -count=1`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
TiDB now rejects `ALTER TABLE ... MODIFY` that changes the type of an indexed generated column, preventing possible data/index inconsistency caused by unsupported index reorganization.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation to block modifying generated columns that are covered by an index and return a clear unsupported-on-generated-column error.

* **Tests**
  * Added tests verifying modification attempts fail for both virtual and stored generated columns and that queries using IGNORE/FORCE INDEX return consistent results (including behavior under an empty SQL mode).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->