### PR TITLE
statistics, planner: prevent stale async stats overwrite

### DIFF
--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -226,6 +226,7 @@ TASKLOOP:
 	if err != nil {
 		sessionVars.StmtCtx.AppendWarning(err)
 	}
+	failpoint.InjectCall("beforeUpdateStatsCacheAfterAnalyze")
 	return statsHandle.Update(ctx, infoSchema, tableAndPartitionIDs...)
 }
 

--- a/pkg/importsdk/BUILD.bazel
+++ b/pkg/importsdk/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//pkg/lightning/config",
         "//pkg/lightning/log",
         "//pkg/lightning/mydump",
+        "//pkg/parser/ast",
         "//pkg/parser/mysql",
         "//pkg/util/table-filter",
         "@com_github_data_dog_go_sqlmock//:go-sqlmock",

--- a/pkg/planner/cardinality/BUILD.bazel
+++ b/pkg/planner/cardinality/BUILD.bazel
@@ -58,7 +58,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":cardinality"],
     flaky = True,
-    shard_count = 48,
+    shard_count = 49,
     deps = [
         "//pkg/config",
         "//pkg/domain",
@@ -86,6 +86,7 @@ go_test(
         "//pkg/statistics/handle/types",
         "//pkg/testkit",
         "//pkg/testkit/testdata",
+        "//pkg/testkit/testfailpoint",
         "//pkg/testkit/testmain",
         "//pkg/testkit/testsetup",
         "//pkg/types",

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -51,6 +52,7 @@ import (
 	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/collate"
@@ -2176,6 +2178,239 @@ func TestSubsetIdxCardinality(t *testing.T) {
 		})
 		testKit.MustQuery(input[i]).Check(testkit.Rows(output[i].Result...))
 	}
+}
+
+// Delay-only repro: a stale async histogram load must not overwrite newer analyze stats.
+func TestSubsetIdxCardinalityStaleAsyncLoadDoesNotOverwriteNewerStats(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	setupTk := testkit.NewTestKit(t, store)
+	analyzeTk := testkit.NewTestKit(t, store)
+	queryTk := testkit.NewTestKit(t, store)
+
+	for _, tk := range []*testkit.TestKit{setupTk, analyzeTk, queryTk} {
+		tk.MustExec("use test")
+	}
+	queryTk.MustExec("set @@session.tidb_stats_load_sync_wait = 0")
+
+	setupTk.MustExec("drop table if exists t")
+	setupTk.MustExec("create table t(a int, b int, c int, index iabc(a, b, c))")
+	setupTk.MustExec("insert into t values (1, 1, 1), (1, 1, 1), (2, 1, 1), (2, 1, 1), (3, 1, 1), (3, 1, 1), (4, 1, 1), (4, 1, 1), (5, 1, 1), (5, 1, 1)")
+	setupTk.MustExec("insert into t select a + 5, a, a from t")
+	for i := 1; i < 3; i++ {
+		setupTk.MustExec(fmt.Sprintf("insert into t select a + 10 + %v, b + 1, c from t", i))
+	}
+	for range 3 {
+		setupTk.MustExec("insert into t select a, b, c from t")
+	}
+	setupTk.MustExec("flush stats_delta *.*")
+	setupTk.MustExec("analyze table t")
+
+	tblInfo := mustGetTableInfo(t, dom, "test", "t")
+	dom.StatsHandle().Clear()
+	require.NoError(t, dom.StatsHandle().InitStatsLite(context.Background(), tblInfo.ID))
+	clearAsyncLoadQueue(tblInfo.ID)
+	requireTableRealtimeCount(t, dom, tblInfo, 640)
+	requireMetaCount(t, setupTk, tblInfo.ID, 640)
+	require.Empty(t, asyncload.AsyncLoadHistogramNeededItems.AllItems())
+
+	statsBeforeRepro := dom.StatsHandle().GetPhysicalTableStats(tblInfo.ID, tblInfo)
+	_, colALoadNeeded, colAAnalyzed := statsBeforeRepro.ColumnIsLoadNeeded(tblInfo.Columns[0].ID, true)
+	_, colBLoadNeeded, colBAnalyzed := statsBeforeRepro.ColumnIsLoadNeeded(tblInfo.Columns[1].ID, true)
+	_, colCLoadNeeded, colCAnalyzed := statsBeforeRepro.ColumnIsLoadNeeded(tblInfo.Columns[2].ID, true)
+	_, idxLoadNeeded := statsBeforeRepro.IndexIsLoadNeeded(tblInfo.Indices[0].ID)
+	t.Logf(
+		"stats before repro: count=%d col(a)=%s loadNeeded=%v analyzed=%v col(b)=%s loadNeeded=%v analyzed=%v col(c)=%s loadNeeded=%v analyzed=%v idx(iabc)=%s loadNeeded=%v",
+		statsBeforeRepro.RealtimeCount,
+		columnLoadState(statsBeforeRepro.GetCol(tblInfo.Columns[0].ID)),
+		colALoadNeeded,
+		colAAnalyzed,
+		columnLoadState(statsBeforeRepro.GetCol(tblInfo.Columns[1].ID)),
+		colBLoadNeeded,
+		colBAnalyzed,
+		columnLoadState(statsBeforeRepro.GetCol(tblInfo.Columns[2].ID)),
+		colCLoadNeeded,
+		colCAnalyzed,
+		indexLoadState(statsBeforeRepro.GetIdx(tblInfo.Indices[0].ID)),
+		idxLoadNeeded,
+	)
+	require.True(t, colALoadNeeded)
+	require.True(t, colBLoadNeeded)
+	require.True(t, colCLoadNeeded)
+	require.True(t, idxLoadNeeded)
+
+	setupTk.MustExec("insert into t select a, b + 10, c from t")
+	setupTk.MustExec("flush stats_delta *.*")
+
+	analyzeBlocked := make(chan struct{}, 1)
+	releaseAnalyze := make(chan struct{})
+	var releaseAnalyzeOnce sync.Once
+	releaseAnalyzeNow := func() {
+		releaseAnalyzeOnce.Do(func() {
+			close(releaseAnalyze)
+		})
+	}
+	t.Cleanup(releaseAnalyzeNow)
+
+	type asyncLoadState struct {
+		tableID       int64
+		histID        int64
+		isIndex       bool
+		fullLoad      bool
+		version       uint64
+		realtimeCount int64
+	}
+	asyncBlocked := make(chan asyncLoadState, 1)
+	releaseAsync := make(chan struct{})
+	var releaseAsyncOnce sync.Once
+	releaseAsyncNow := func() {
+		releaseAsyncOnce.Do(func() {
+			close(releaseAsync)
+		})
+	}
+	t.Cleanup(releaseAsyncNow)
+
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/beforeUpdateStatsCacheAfterAnalyze", func() {
+		select {
+		case analyzeBlocked <- struct{}{}:
+		default:
+		}
+		<-releaseAnalyze
+	})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/statistics/handle/storage/beforeUpdateStatsCacheAfterAsyncLoad",
+		func(tableID, histID int64, isIndex, fullLoad bool, version uint64, realtimeCount int64) {
+			if tableID != tblInfo.ID {
+				return
+			}
+			select {
+			case asyncBlocked <- asyncLoadState{
+				tableID:       tableID,
+				histID:        histID,
+				isIndex:       isIndex,
+				fullLoad:      fullLoad,
+				version:       version,
+				realtimeCount: realtimeCount,
+			}:
+			default:
+			}
+			<-releaseAsync
+		},
+	)
+
+	analyzeErrCh := make(chan error, 1)
+	go func() {
+		_, err := analyzeTk.Exec("analyze table t")
+		analyzeErrCh <- err
+	}()
+	waitForSignal(t, analyzeBlocked, "analyze update failpoint")
+
+	requireMetaCount(t, setupTk, tblInfo.ID, 1280)
+	requireTableRealtimeCount(t, dom, tblInfo, 640)
+
+	queryTk.MustQuery("explain format = 'brief' select a, b from t where a = 1 and b = 1 and c = 1")
+	require.Eventually(t, func() bool {
+		return hasAsyncLoadForTable(tblInfo.ID)
+	}, 5*time.Second, 50*time.Millisecond)
+
+	loadErrCh := make(chan error, 1)
+	go func() {
+		loadErrCh <- dom.StatsHandle().LoadNeededHistograms(dom.InfoSchema())
+	}()
+
+	asyncState := waitForAsyncState(t, asyncBlocked, "async load update failpoint")
+	require.Equal(t, int64(640), asyncState.realtimeCount)
+	require.Equal(t, tblInfo.ID, asyncState.tableID)
+
+	releaseAnalyzeNow()
+	waitForAsyncErr(t, analyzeErrCh, "analyze table t")
+	requireMetaCount(t, setupTk, tblInfo.ID, 1280)
+	requireTableRealtimeCount(t, dom, tblInfo, 1280)
+	require.Contains(t, fmt.Sprint(queryTk.MustQuery("explain format = 'brief' select distinct a from t").Rows()), "IndexFullScan 1280.00")
+
+	releaseAsyncNow()
+	waitForAsyncErr(t, loadErrCh, "LoadNeededHistograms")
+	requireMetaCount(t, setupTk, tblInfo.ID, 1280)
+	requireTableRealtimeCount(t, dom, tblInfo, 1280)
+	require.Contains(t, fmt.Sprint(queryTk.MustQuery("explain format = 'brief' select distinct a from t").Rows()), "IndexFullScan 1280.00")
+}
+
+func mustGetTableInfo(t *testing.T, dom *domain.Domain, schema, table string) *model.TableInfo {
+	t.Helper()
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr(schema), ast.NewCIStr(table))
+	require.NoError(t, err)
+	return tbl.Meta()
+}
+
+func requireTableRealtimeCount(t *testing.T, dom *domain.Domain, tblInfo *model.TableInfo, expected int64) {
+	t.Helper()
+	stats := dom.StatsHandle().GetPhysicalTableStats(tblInfo.ID, tblInfo)
+	require.Equal(t, expected, stats.RealtimeCount)
+}
+
+func requireMetaCount(t *testing.T, tk *testkit.TestKit, tableID, expected int64) {
+	t.Helper()
+	tk.MustQuery(fmt.Sprintf("select count from mysql.stats_meta where table_id = %d", tableID)).Check(testkit.Rows(fmt.Sprintf("%d", expected)))
+}
+
+func hasAsyncLoadForTable(tableID int64) bool {
+	for _, item := range asyncload.AsyncLoadHistogramNeededItems.AllItems() {
+		if item.TableID == tableID {
+			return true
+		}
+	}
+	return false
+}
+
+func clearAsyncLoadQueue(tableID int64) {
+	for _, item := range asyncload.AsyncLoadHistogramNeededItems.AllItems() {
+		if item.TableID == tableID {
+			asyncload.AsyncLoadHistogramNeededItems.Delete(item.TableItemID)
+		}
+	}
+}
+
+func waitForSignal(t *testing.T, ch <-chan struct{}, desc string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for %s", desc)
+	}
+}
+
+func waitForAsyncState[T any](t *testing.T, ch <-chan T, desc string) T {
+	t.Helper()
+	select {
+	case state := <-ch:
+		return state
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for %s", desc)
+		var zero T
+		return zero
+	}
+}
+
+func waitForAsyncErr(t *testing.T, ch <-chan error, desc string) {
+	t.Helper()
+	select {
+	case err := <-ch:
+		require.NoError(t, err, desc)
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for %s", desc)
+	}
+}
+
+func columnLoadState(col *statistics.Column) string {
+	if col == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("initialized=%v allEvicted=%v full=%v", col.IsStatsInitialized(), col.IsAllEvicted(), col.IsFullLoad())
+}
+
+func indexLoadState(idx *statistics.Index) string {
+	if idx == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("initialized=%v allEvicted=%v full=%v", idx.IsStatsInitialized(), idx.IsAllEvicted(), idx.IsFullLoad())
 }
 
 func TestBuiltinInEstWithoutStats(t *testing.T) {

--- a/pkg/statistics/handle/cache/BUILD.bazel
+++ b/pkg/statistics/handle/cache/BUILD.bazel
@@ -45,7 +45,7 @@ go_test(
     ],
     embed = [":cache"],
     flaky = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         "//pkg/config",
         "//pkg/statistics",

--- a/pkg/statistics/handle/cache/statscache_test.go
+++ b/pkg/statistics/handle/cache/statscache_test.go
@@ -118,6 +118,30 @@ func TestUpdateStatsHealthyMetrics(t *testing.T) {
 	}
 }
 
+func TestUpdateSkipsOlderTableVersion(t *testing.T) {
+	current := newMockTable(t, 1, false, 1280, 0, 1)
+	current.Version = 2
+	stale := newMockTable(t, 1, false, 640, 0, 1)
+	stale.Version = 1
+
+	cache := &StatsCache{
+		c: newMockStatsCacheInner(current),
+	}
+
+	cache.Update([]*statistics.Table{stale}, nil, false)
+
+	got, ok := cache.c.Get(current.PhysicalID)
+	require.True(t, ok)
+	require.Equal(t, uint64(2), got.Version)
+	require.Equal(t, int64(1280), got.RealtimeCount)
+
+	copied := cache.CopyAndUpdate([]*statistics.Table{stale}, nil)
+	got, ok = copied.c.Get(current.PhysicalID)
+	require.True(t, ok)
+	require.Equal(t, uint64(2), got.Version)
+	require.Equal(t, int64(1280), got.RealtimeCount)
+}
+
 func newMockTable(t *testing.T, physicalID int64, pseudo bool, realtimeCount, modifyCount int64, analyzeVersion uint64) *statistics.Table {
 	hist := statistics.NewHistColl(physicalID, realtimeCount, modifyCount, 0, 0)
 	table := &statistics.Table{
@@ -162,15 +186,17 @@ func (m *mockStatsCacheInner) Values() []*statistics.Table {
 }
 
 func (m *mockStatsCacheInner) Get(id int64) (*statistics.Table, bool) {
-	panic("not implemented")
+	tbl, ok := m.items[id]
+	return tbl, ok
 }
 
 func (m *mockStatsCacheInner) Put(id int64, tbl *statistics.Table) bool {
-	panic("not implemented")
+	m.items[id] = tbl
+	return true
 }
 
 func (m *mockStatsCacheInner) Del(id int64) {
-	panic("not implemented")
+	delete(m.items, id)
 }
 
 func (m *mockStatsCacheInner) Cost() int64 {
@@ -178,11 +204,15 @@ func (m *mockStatsCacheInner) Cost() int64 {
 }
 
 func (m *mockStatsCacheInner) Len() int {
-	panic("not implemented")
+	return len(m.items)
 }
 
 func (m *mockStatsCacheInner) Copy() internal.StatsCacheInner {
-	panic("not implemented")
+	copied := make(map[int64]*statistics.Table, len(m.items))
+	for id, tbl := range m.items {
+		copied[id] = tbl
+	}
+	return &mockStatsCacheInner{items: copied}
 }
 
 func (*mockStatsCacheInner) SetCapacity(int64) {

--- a/pkg/statistics/handle/cache/statscacheinner.go
+++ b/pkg/statistics/handle/cache/statscacheinner.go
@@ -143,11 +143,19 @@ func (sc *StatsCache) Version() uint64 {
 	return sc.maxTblStatsVer.Load()
 }
 
+func (sc *StatsCache) shouldSkipTableUpdate(tbl *statistics.Table) bool {
+	current, ok := sc.c.Get(tbl.PhysicalID)
+	return ok && current != nil && current.Version > tbl.Version
+}
+
 // CopyAndUpdate copies a new cache and updates the new statistics table cache. It is only used in the COW mode.
 func (sc *StatsCache) CopyAndUpdate(tables []*statistics.Table, deletedIDs []int64) *StatsCache {
 	newCache := &StatsCache{c: sc.c.Copy()}
 	newCache.maxTblStatsVer.Store(sc.maxTblStatsVer.Load())
 	for _, tbl := range tables {
+		if newCache.shouldSkipTableUpdate(tbl) {
+			continue
+		}
 		id := tbl.PhysicalID
 		newCache.c.Put(id, tbl)
 	}
@@ -167,6 +175,9 @@ func (sc *StatsCache) CopyAndUpdate(tables []*statistics.Table, deletedIDs []int
 // Update updates the new statistics table cache.
 func (sc *StatsCache) Update(tables []*statistics.Table, deletedIDs []int64, skipMoveForwardStatsCache bool) {
 	for _, tbl := range tables {
+		if sc.shouldSkipTableUpdate(tbl) {
+			continue
+		}
 		id := tbl.PhysicalID
 		metrics.UpdateCounter.Inc()
 		sc.c.Put(id, tbl)

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -740,6 +741,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 		}
 	}
 	statsTbl.SetCol(col.ID, colHist)
+	failpoint.InjectCall("beforeUpdateStatsCacheAfterAsyncLoad", statsTbl.PhysicalID, col.ID, false, fullLoad, statsTbl.Version, statsTbl.RealtimeCount)
 	statsHandle.UpdateStatsCache(statstypes.CacheUpdate{
 		Updated: []*statistics.Table{statsTbl},
 	})
@@ -838,6 +840,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 		tbl.LastAnalyzeVersion = max(tbl.LastAnalyzeVersion, idxHist.LastUpdateVersion)
 	}
 	tbl.SetIdx(idx.ID, idxHist)
+	failpoint.InjectCall("beforeUpdateStatsCacheAfterAsyncLoad", tbl.PhysicalID, idx.ID, true, true, tbl.Version, tbl.RealtimeCount)
 	statsHandle.UpdateStatsCache(statstypes.CacheUpdate{
 		Updated: []*statistics.Table{tbl},
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67355

Problem Summary:

`TestSubsetIdxCardinality` can report `IndexFullScan 640.00` instead of `1280.00` because a stale async stats load may overwrite newer analyzed table stats in the in-memory cache.

### What changed and how does it work?

This PR treats the flake as a product bug instead of another test warm-up gap.

Root cause:
- `InitStatsLite` can rebuild a table stats object with `RealtimeCount=640` while the columns and index are still absent in memory and marked `loadNeeded=true`.
- After another insert + `ANALYZE`, the analyze path produces a newer table stats object with `RealtimeCount=1280`.
- If an async histogram load that started from the stale `640` table reaches `UpdateStatsCache` after analyze, it can overwrite the newer cache entry with the older table object.
- Once that happens, planning for `select distinct a from t` falls back to `IndexFullScan 640.00`, which matches the flaky symptom exactly.

Timing-only precise repro:
1. Analyze the 640-row table.
2. Clear the stats cache and call `InitStatsLite` to recreate the stale `RealtimeCount=640` table object with histograms still load-needed.
3. Insert another 640 rows and start `ANALYZE`, but delay it right before `UpdateStatsCache`.
4. Trigger async histogram load from the stale cache entry and delay it right before its own `UpdateStatsCache`.
5. Release analyze first, then release the stale async load.
6. Before this fix, the stale async load overwrote the analyzed cache entry and the plan regressed to `IndexFullScan 640.00`.

Fix:
- Add a table-version guard in the stats cache update path so an older table stats object cannot replace a newer one for the same physical table.
- Add a cache unit test for the version guard.
- Add a timing-only planner regression test that reproduces the exact stale-overwrite window.
- Include the required `make bazel_prepare` metadata refresh for the new tests. This also updates one existing missing Bazel test dependency in `pkg/importsdk/BUILD.bazel`.

Validation:
- `go test ./pkg/statistics/handle/cache -run 'Test(UpdateSkipsOlderTableVersion|UpdateStatsHealthyMetrics|CacheOfBatchUpdate)$'`
- `./tools/check/failpoint-go-test.sh pkg/planner/cardinality -run 'TestSubsetIdxCardinality(StaleAsyncLoadDoesNotOverwriteNewerStats)?$' -count=1`
- `./tools/check/failpoint-go-test.sh pkg/planner/cardinality -run '^TestSubsetIdxCardinality$' -count=20`
- `make lint`
- `make bazel_prepare`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where stale asynchronous statistics updates could overwrite newer statistics data. The system now correctly preserves the most up-to-date statistics during concurrent updates.

* **Tests**
  * Added comprehensive test coverage for statistics cache update scenarios to ensure data consistency and prevent regression.

* **Chores**
  * Updated test infrastructure and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->