### PR TITLE
*: change default tidb_auto_analyze_concurrency to 3

### DIFF
--- a/pkg/session/test/bootstraptest/BUILD.bazel
+++ b/pkg/session/test/bootstraptest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 40,
+    shard_count = 41,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1232,6 +1232,33 @@ func TestAnalyzeDistsqlConcurrencyByUpgrade750To850(t *testing.T) {
 	require.Equal(t, int64(32), row.GetInt64(0))
 }
 
+func TestAutoAnalyzeConcurrencyDefaultOnlyAffectsFreshBootstrap(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
+	}
+	store, dom := session.CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustQuery("select variable_value from mysql.global_variables where variable_name='tidb_auto_analyze_concurrency'").Check(testkit.Rows(strconv.Itoa(vardef.DefTiDBAutoAnalyzeConcurrency)))
+
+	upgradeFromVersion := session.CurrentBootstrapVersion - 1
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	require.NoError(t, meta.NewMutator(txn).FinishBootstrap(upgradeFromVersion))
+	require.NoError(t, txn.Commit(context.Background()))
+	revertVersionAndVariables(t, tk.Session(), int(upgradeFromVersion))
+	tk.MustExec("update mysql.global_variables set variable_value='8' where variable_name='tidb_auto_analyze_concurrency'")
+	store.SetOption(session.StoreBootstrappedKey, nil)
+	dom.Close()
+
+	domUpgraded, err := session.BootstrapSession(store)
+	require.NoError(t, err)
+	defer domUpgraded.Close()
+
+	testkit.NewTestKit(t, store).MustQuery("select variable_value from mysql.global_variables where variable_name='tidb_auto_analyze_concurrency'").Check(testkit.Rows("8"))
+}
+
 func TestBootstrapInNextGenInvalidSystemTable(t *testing.T) {
 	if kerneltype.IsClassic() {
 		t.Skip("this is only checked in next-gen kernel")

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1646,7 +1646,7 @@ const (
 	DefTiDBAnalyzeColumnOptions                       = "ALL"
 	DefTiDBMemOOMAction                               = "CANCEL"
 	DefTiDBMaxAutoAnalyzeTime                         = 12 * 60 * 60
-	DefTiDBAutoAnalyzeConcurrency                     = 1
+	DefTiDBAutoAnalyzeConcurrency                     = 3
 	DefTiDBEnablePrepPlanCache                        = true
 	DefTiDBPrepPlanCacheSize                          = 100
 	DefTiDBSessionPlanCacheSize                       = 100

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -1800,6 +1800,9 @@ func TestTiDBHashJoinVersion(t *testing.T) {
 
 func TestTiDBAutoAnalyzeConcurrencyValidation(t *testing.T) {
 	vars := NewSessionVars(nil)
+	sysVar := GetSysVar(vardef.TiDBAutoAnalyzeConcurrency)
+	require.NotNil(t, sysVar)
+	require.Equal(t, "3", sysVar.Value)
 
 	tests := []struct {
 		name                string
@@ -1843,9 +1846,6 @@ func TestTiDBAutoAnalyzeConcurrencyValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			vardef.RunAutoAnalyze.Store(tt.autoAnalyze)
 			vardef.EnableAutoAnalyzePriorityQueue.Store(tt.autoAnalyzePriority)
-
-			sysVar := GetSysVar(vardef.TiDBAutoAnalyzeConcurrency)
-			require.NotNil(t, sysVar)
 
 			_, err := sysVar.Validate(vars, tt.input, vardef.ScopeGlobal)
 			if tt.expectError {

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
@@ -127,6 +127,8 @@ func TestChangePruneMode(t *testing.T) {
 	handle := dom.StatsHandle()
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
+	tk.MustExec("set global tidb_enable_auto_analyze=1")
+	tk.MustExec("set global tidb_auto_analyze_concurrency=1")
 	tk.MustExec("create table t1 (a int, b int, index idx(a)) partition by range (a) (partition p0 values less than (10), partition p1 values less than (140))")
 	tk.MustExec("insert into t1 values (0, 0)")
 	tk.MustExec("flush stats_delta *.*")

--- a/pkg/statistics/handle/handletest/analyze/analyze_test.go
+++ b/pkg/statistics/handle/handletest/analyze/analyze_test.go
@@ -299,6 +299,10 @@ func TestAnalyzeMetricsCounters(t *testing.T) {
 		statistics.AutoAnalyzeMinCnt = origMinCnt
 	}()
 
+	// Keep this test scoped to the single unanalyzed table created above. The
+	// global default may schedule multiple auto-analyze jobs in parallel.
+	autoAnalyzeConcurrencySysVar := variable.GetSysVar("tidb_auto_analyze_concurrency")
+	require.NoError(t, autoAnalyzeConcurrencySysVar.SetGlobalFromHook(context.Background(), tk.Session().GetSessionVars(), "1", false))
 	beforeAutoSucc := readCounter(autoSucc)
 	beforeAutoFail := readCounter(autoFail)
 

--- a/tests/integrationtest/r/session/variable.result
+++ b/tests/integrationtest/r/session/variable.result
@@ -20,6 +20,17 @@ show variables like 'collation_server';
 Variable_name	Value
 collation_server	utf8mb4_general_ci
 set @@global.collation_server=default;
+select @@global.tidb_auto_analyze_concurrency;
+@@global.tidb_auto_analyze_concurrency
+3
+set global tidb_auto_analyze_concurrency=8;
+select @@global.tidb_auto_analyze_concurrency;
+@@global.tidb_auto_analyze_concurrency
+8
+set global tidb_auto_analyze_concurrency=default;
+select @@global.tidb_auto_analyze_concurrency;
+@@global.tidb_auto_analyze_concurrency
+3
 set @@global.tidb_memory_usage_alarm_ratio=1;
 select @@global.tidb_memory_usage_alarm_ratio;
 @@global.tidb_memory_usage_alarm_ratio

--- a/tests/integrationtest/t/session/variable.test
+++ b/tests/integrationtest/t/session/variable.test
@@ -23,6 +23,13 @@ show variables like 'collation_server';
 disconnect conn1;
 set @@global.collation_server=default;
 
+# TestAutoAnalyzeConcurrencyDefault
+select @@global.tidb_auto_analyze_concurrency;
+set global tidb_auto_analyze_concurrency=8;
+select @@global.tidb_auto_analyze_concurrency;
+set global tidb_auto_analyze_concurrency=default;
+select @@global.tidb_auto_analyze_concurrency;
+
 # TestMemoryUsageAlarmVariable
 set @@global.tidb_memory_usage_alarm_ratio=1;
 select @@global.tidb_memory_usage_alarm_ratio;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67782

Problem Summary:
`tidb_auto_analyze_concurrency` defaults to `1`, which can make auto-analyze backlog draining slow on untuned clusters.

**This change only affects the new clusters. For the old clusters that upgrade to this version, nothing will change.**

### What changed and how does it work?
- Change the default `tidb_auto_analyze_concurrency` from `1` to `3`.
- Add unit coverage for the sysvar default.
- Add integration coverage for `SET GLOBAL ... = DEFAULT`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Validation:
- `./tools/check/failpoint-go-test.sh pkg/sessionctx/variable -run TestTiDBAutoAnalyzeConcurrencyValidation`
- `pushd tests/integrationtest >/dev/null && ./run-tests.sh -r session/variable && popd >/dev/null`
- `make lint`

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The default value of `tidb_auto_analyze_concurrency` is changed from `1` to `3`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default auto-analyze concurrency increased from 1 to 3.

* **Tests**
  * Added and updated integration and unit tests to validate the new default, exercise setting/resetting the concurrency and related auto-analyze flags, and ensure global state is snapshotted and restored after runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->