### PR TITLE
pkg/store/gcworker: stabilize flaky TestRunGCJob

### DIFF
--- a/pkg/store/gcworker/gc_worker_test.go
+++ b/pkg/store/gcworker/gc_worker_test.go
@@ -1741,9 +1741,18 @@ func TestResolveLocksNearTxnSafePoint(t *testing.T) {
 }
 
 func TestRunGCJob(t *testing.T) {
+	require.NoError(t, failpoint.Enable("tikvclient/noBuiltInTxnSafePointUpdater", "return"))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable("tikvclient/noBuiltInTxnSafePointUpdater"))
+	})
+
 	s := createGCWorkerSuite(t)
 
+	originalTxnSafePointSyncWaitTime := txnSafePointSyncWaitTime
 	txnSafePointSyncWaitTime = 0
+	t.Cleanup(func() {
+		txnSafePointSyncWaitTime = originalTxnSafePointSyncWaitTime
+	})
 
 	// Test distributed mode
 	useDistributedGC := s.gcWorker.checkUseDistributedGC()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67665

Problem Summary:
Flaky test `TestRunGCJob` in `pkg/store/gcworker` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TestRunGCJob had a test-only race with the TiKV client’s background txn-safe-point updater, which could advance the cache between GC completion and the old-version probe read and trigger a false `[tikv:9006]` failure.

#### Fix

Disabling that updater for this test and restoring the global sync-wait knob removes the invalid timing dependency without changing product behavior.

#### Verification

Spec:
- target: `pkg/store/gcworker :: TestRunGCJob`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/store/gcworker -run '^TestRunGCJob$' -count=1`
- `go test -json ./pkg/store/gcworker -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test isolation and reliability by improving management of test environment state and cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->