### PR TITLE
*: split bazel coverage test into build and test phases

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,4 +26,9 @@ test --test_env=HTTPS_PROXY --test_env=https_proxy
 test --test_env=HTTP_PROXY --test_env=http_proxy
 test:race --test_timeout=1200,6000,18000,72000
 
+build:ci --build_event_publish_all_actions
+test:ci --build_event_publish_all_actions
+build:ci --experimental_build_event_upload_strategy=fully_async
+test:ci --experimental_build_event_upload_strategy=fully_async
+
 try-import /data/bazel

--- a/.bazelrc
+++ b/.bazelrc
@@ -30,5 +30,5 @@ build:ci --bes_keywords=source:ci
 build:ci --build_event_publish_all_actions
 test:ci --bes_keywords=source:ci
 test:ci --build_event_publish_all_actions
-\
+
 try-import /data/bazel

--- a/.bazelrc
+++ b/.bazelrc
@@ -28,9 +28,7 @@ test:race --test_timeout=1200,6000,18000,72000
 
 build:ci --bes_keywords=source:ci
 build:ci --build_event_publish_all_actions
-build:ci --experimental_build_event_upload_strategy=fully_async
 test:ci --bes_keywords=source:ci
 test:ci --build_event_publish_all_actions
-test:ci --experimental_build_event_upload_strategy=fully_async
-
+\
 try-import /data/bazel

--- a/.bazelrc
+++ b/.bazelrc
@@ -26,9 +26,11 @@ test --test_env=HTTPS_PROXY --test_env=https_proxy
 test --test_env=HTTP_PROXY --test_env=http_proxy
 test:race --test_timeout=1200,6000,18000,72000
 
+build:ci --bes_keywords=source:ci
 build:ci --build_event_publish_all_actions
-test:ci --build_event_publish_all_actions
 build:ci --experimental_build_event_upload_strategy=fully_async
+test:ci --bes_keywords=source:ci
+test:ci --build_event_publish_all_actions
 test:ci --experimental_build_event_upload_strategy=fully_async
 
 try-import /data/bazel

--- a/Makefile
+++ b/Makefile
@@ -715,8 +715,6 @@ bazel_test: bazel-failpoint-enable bazel_prepare ## Run all tests using Bazel
 		-- //... -//cmd/... -//tests/graceshutdown/... \
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
 
-BAZEL_COVERAGE_BUILD_JOBS ?= HOST_CPUS*1
-BAZEL_COVERAGE_TEST_JOBS ?= HOST_CPUS*0.4
 BAZEL_COVERAGE_DDL_TARGETS := //pkg/ddl/...
 BAZEL_COVERAGE_TARGETS = \
 	//... -//cmd/... -//tests/graceshutdown/... \
@@ -724,15 +722,7 @@ BAZEL_COVERAGE_TARGETS = \
 
 .PHONY: bazel_coverage_test
 bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
-	@curl http://metadata.google.internal/computeMetadata/v1/instance/machineType -H "Metadata-Flavor: Google" || true
-	@echo "==> phase 1: build instrumented test binaries"
-	bazel --version
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
-		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ --experimental_remote_build_event_upload=all \
-		--define gotags=$(UNIT_TEST_TAGS) \
-		-- $(BAZEL_COVERAGE_DDL_TARGETS)
-	@echo "==> phase 2: run coverage with lower test concurrency"
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=$(BAZEL_COVERAGE_TEST_JOBS) --local_test_jobs=$(BAZEL_COVERAGE_TEST_JOBS) --build_tests_only --test_keep_going=false \
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=HOST_CPUS*0.6 --build_tests_only --test_keep_going=false \
 		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ --experimental_remote_build_event_upload=all \
 		--combined_report=lcov \
 		--define gotags=$(UNIT_TEST_TAGS) \
@@ -740,12 +730,7 @@ bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
 
 .PHONY: bazel_coverage_test_ddlargsv1
 bazel_coverage_test_ddlargsv1: bazel-failpoint-enable bazel_ci_simple_prepare
-	@echo "==> phase 1: build instrumented test binaries"
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
-		--define gotags=$(UNIT_TEST_TAGS),ddlargsv1 \
-		-- $(BAZEL_COVERAGE_TARGETS)
-	@echo "==> phase 2: run coverage with lower test concurrency"
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=$(BAZEL_COVERAGE_TEST_JOBS) --local_test_jobs=$(BAZEL_COVERAGE_TEST_JOBS) --build_tests_only --test_keep_going=false \
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=HOST_CPUS*0.6 --build_tests_only --test_keep_going=false \
 		--combined_report=lcov \
 		--define gotags=$(UNIT_TEST_TAGS),ddlargsv1 \
 		-- $(BAZEL_COVERAGE_TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -726,7 +726,7 @@ bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
 		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ --experimental_remote_build_event_upload=all \
 		--combined_report=lcov \
 		--define gotags=$(UNIT_TEST_TAGS) \
-		-- $(BAZEL_COVERAGE_DDL_TARGETS)
+		-- $(BAZEL_COVERAGE_TARGETS)
 
 .PHONY: bazel_coverage_test_ddlargsv1
 bazel_coverage_test_ddlargsv1: bazel-failpoint-enable bazel_ci_simple_prepare

--- a/Makefile
+++ b/Makefile
@@ -725,12 +725,12 @@ BAZEL_COVERAGE_TARGETS = \
 bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
 	@echo "==> phase 1: build instrumented test binaries"
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
-		--bes_backend=grpcs://beplessproxy.hawkingrei.com --bes_results_url=https://bepless.hawkingrei.com/ \
+		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- $(BAZEL_COVERAGE_TARGETS)
 	@echo "==> phase 2: run coverage with lower test concurrency"
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=$(BAZEL_COVERAGE_TEST_JOBS) --local_test_jobs=$(BAZEL_COVERAGE_TEST_JOBS) --build_tests_only --test_keep_going=false \
-		--bes_backend=grpcs://beplessproxy.hawkingrei.com --bes_results_url=https://bepless.hawkingrei.com/ \
+		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ \
 		--combined_report=lcov \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- $(BAZEL_COVERAGE_TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -717,6 +717,7 @@ bazel_test: bazel-failpoint-enable bazel_prepare ## Run all tests using Bazel
 
 BAZEL_COVERAGE_BUILD_JOBS ?= HOST_CPUS*1
 BAZEL_COVERAGE_TEST_JOBS ?= HOST_CPUS*0.5
+BAZEL_COVERAGE_DDL_TARGETS := //pkg/ddl/...
 BAZEL_COVERAGE_TARGETS = \
 	//... -//cmd/... -//tests/graceshutdown/... \
 	-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
@@ -727,13 +728,13 @@ bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
 		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ \
 		--define gotags=$(UNIT_TEST_TAGS) \
-		-- $(BAZEL_COVERAGE_TARGETS)
+		-- $(BAZEL_COVERAGE_DDL_TARGETS)
 	@echo "==> phase 2: run coverage with lower test concurrency"
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=$(BAZEL_COVERAGE_TEST_JOBS) --local_test_jobs=$(BAZEL_COVERAGE_TEST_JOBS) --build_tests_only --test_keep_going=false \
 		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ \
 		--combined_report=lcov \
 		--define gotags=$(UNIT_TEST_TAGS) \
-		-- $(BAZEL_COVERAGE_TARGETS)
+		-- $(BAZEL_COVERAGE_DDL_TARGETS)
 
 .PHONY: bazel_coverage_test_ddlargsv1
 bazel_coverage_test_ddlargsv1: bazel-failpoint-enable bazel_ci_simple_prepare

--- a/Makefile
+++ b/Makefile
@@ -729,6 +729,7 @@ bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
 		-- $(BAZEL_COVERAGE_TARGETS)
 	@echo "==> phase 2: run coverage with lower test concurrency"
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=$(BAZEL_COVERAGE_TEST_JOBS) --local_test_jobs=$(BAZEL_COVERAGE_TEST_JOBS) --build_tests_only --test_keep_going=false \
+		--bes_backend=grpcs://beplessproxy.hawkingrei.com --bes_results_url=https://bepless.hawkingrei.com/ \
 		--combined_report=lcov \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- $(BAZEL_COVERAGE_TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -716,7 +716,7 @@ bazel_test: bazel-failpoint-enable bazel_prepare ## Run all tests using Bazel
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
 
 BAZEL_COVERAGE_BUILD_JOBS ?= HOST_CPUS*1
-BAZEL_COVERAGE_TEST_JOBS ?= HOST_CPUS*0.5
+BAZEL_COVERAGE_TEST_JOBS ?= HOST_CPUS*0.2
 BAZEL_COVERAGE_DDL_TARGETS := //pkg/ddl/...
 BAZEL_COVERAGE_TARGETS = \
 	//... -//cmd/... -//tests/graceshutdown/... \

--- a/Makefile
+++ b/Makefile
@@ -725,6 +725,7 @@ BAZEL_COVERAGE_TARGETS = \
 bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
 	@echo "==> phase 1: build instrumented test binaries"
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
+		--bes_backend=grpcs://beplessproxy.hawkingrei.com --bes_results_url=https://bepless.hawkingrei.com/ \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- $(BAZEL_COVERAGE_TARGETS)
 	@echo "==> phase 2: run coverage with lower test concurrency"

--- a/Makefile
+++ b/Makefile
@@ -728,12 +728,12 @@ bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
 	@echo "==> phase 1: build instrumented test binaries"
 	bazel --version
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
-		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ --remote_build_event_upload=all \
+		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ ----experimental_remote_build_event_upload=all \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- $(BAZEL_COVERAGE_DDL_TARGETS)
 	@echo "==> phase 2: run coverage with lower test concurrency"
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=$(BAZEL_COVERAGE_TEST_JOBS) --local_test_jobs=$(BAZEL_COVERAGE_TEST_JOBS) --build_tests_only --test_keep_going=false \
-		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ --remote_build_event_upload=all \
+		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ ----experimental_remote_build_event_upload=all \
 		--combined_report=lcov \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- $(BAZEL_COVERAGE_DDL_TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -681,6 +681,15 @@ bazel_ci_simple_prepare:
 		--run_under="cd $(CURDIR) && " \
 		 //tools/tazel:tazel
 
+BAZEL_NO_REMOTE_CACHE_CONFIG := --remote_cache= --noremote_accept_cached --noremote_upload_local_results
+
+.PHONY: bazel_ci_simple_prepare_no_remote_cache
+bazel_ci_simple_prepare_no_remote_cache:
+	bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) //:gazelle
+	bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) \
+		--run_under="cd $(CURDIR) && " \
+		 //tools/tazel:tazel
+
 .PHONY: bazel_prepare
 bazel_prepare: ## Update and generate BUILD.bazel files. Please run this before commit.
 	bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) //:gazelle
@@ -720,13 +729,13 @@ BAZEL_COVERAGE_TARGETS = \
 	-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
 
 .PHONY: bazel_coverage_test
-bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
+bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare_no_remote_cache
 	@echo "==> phase 1: build instrumented test binaries"
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- $(BAZEL_COVERAGE_TARGETS)
 	@echo "==> phase 2: run coverage with lower test concurrency"
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=$(BAZEL_COVERAGE_TEST_JOBS) --local_test_jobs=$(BAZEL_COVERAGE_TEST_JOBS) --build_tests_only --test_keep_going=false \
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=$(BAZEL_COVERAGE_TEST_JOBS) --local_test_jobs=$(BAZEL_COVERAGE_TEST_JOBS) --build_tests_only --test_keep_going=false \
 		--combined_report=lcov \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- $(BAZEL_COVERAGE_TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -715,8 +715,8 @@ bazel_test: bazel-failpoint-enable bazel_prepare ## Run all tests using Bazel
 		-- //... -//cmd/... -//tests/graceshutdown/... \
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
 
-BAZEL_COVERAGE_BUILD_JOBS ?= HOST_CPUS*3
-BAZEL_COVERAGE_TEST_JOBS ?= HOST_CPUS*0.9
+BAZEL_COVERAGE_BUILD_JOBS ?= HOST_CPUS*1
+BAZEL_COVERAGE_TEST_JOBS ?= HOST_CPUS*0.5
 BAZEL_COVERAGE_TARGETS = \
 	//... -//cmd/... -//tests/graceshutdown/... \
 	-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...

--- a/Makefile
+++ b/Makefile
@@ -726,6 +726,7 @@ BAZEL_COVERAGE_TARGETS = \
 bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
 	@curl http://metadata.google.internal/computeMetadata/v1/instance/machineType -H "Metadata-Flavor: Google" || true
 	@echo "==> phase 1: build instrumented test binaries"
+	bazel --version
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
 		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ --remote_build_event_upload=all \
 		--define gotags=$(UNIT_TEST_TAGS) \

--- a/Makefile
+++ b/Makefile
@@ -724,6 +724,7 @@ BAZEL_COVERAGE_TARGETS = \
 
 .PHONY: bazel_coverage_test
 bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
+	@curl http://metadata.google.internal/computeMetadata/v1/instance/machineType -H "Metadata-Flavor: Google" || true
 	@echo "==> phase 1: build instrumented test binaries"
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
 		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ \

--- a/Makefile
+++ b/Makefile
@@ -727,12 +727,12 @@ bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
 	@curl http://metadata.google.internal/computeMetadata/v1/instance/machineType -H "Metadata-Flavor: Google" || true
 	@echo "==> phase 1: build instrumented test binaries"
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
-		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ \
+		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ --remote_build_event_upload=all \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- $(BAZEL_COVERAGE_DDL_TARGETS)
 	@echo "==> phase 2: run coverage with lower test concurrency"
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=$(BAZEL_COVERAGE_TEST_JOBS) --local_test_jobs=$(BAZEL_COVERAGE_TEST_JOBS) --build_tests_only --test_keep_going=false \
-		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ \
+		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ --remote_build_event_upload=all \
 		--combined_report=lcov \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- $(BAZEL_COVERAGE_DDL_TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -683,13 +683,6 @@ bazel_ci_simple_prepare:
 
 BAZEL_NO_REMOTE_CACHE_CONFIG := --remote_cache= --noremote_accept_cached --noremote_upload_local_results
 
-.PHONY: bazel_ci_simple_prepare_no_remote_cache
-bazel_ci_simple_prepare_no_remote_cache:
-	bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) //:gazelle
-	bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) \
-		--run_under="cd $(CURDIR) && " \
-		 //tools/tazel:tazel
-
 .PHONY: bazel_prepare
 bazel_prepare: ## Update and generate BUILD.bazel files. Please run this before commit.
 	bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) //:gazelle
@@ -729,7 +722,7 @@ BAZEL_COVERAGE_TARGETS = \
 	-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
 
 .PHONY: bazel_coverage_test
-bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare_no_remote_cache
+bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
 	@echo "==> phase 1: build instrumented test binaries"
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
 		--define gotags=$(UNIT_TEST_TAGS) \

--- a/Makefile
+++ b/Makefile
@@ -716,7 +716,7 @@ bazel_test: bazel-failpoint-enable bazel_prepare ## Run all tests using Bazel
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
 
 BAZEL_COVERAGE_BUILD_JOBS ?= HOST_CPUS*1
-BAZEL_COVERAGE_TEST_JOBS ?= HOST_CPUS*0.2
+BAZEL_COVERAGE_TEST_JOBS ?= HOST_CPUS*0.4
 BAZEL_COVERAGE_DDL_TARGETS := //pkg/ddl/...
 BAZEL_COVERAGE_TARGETS = \
 	//... -//cmd/... -//tests/graceshutdown/... \

--- a/Makefile
+++ b/Makefile
@@ -728,12 +728,12 @@ bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
 	@echo "==> phase 1: build instrumented test binaries"
 	bazel --version
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
-		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ ----experimental_remote_build_event_upload=all \
+		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ --experimental_remote_build_event_upload=all \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- $(BAZEL_COVERAGE_DDL_TARGETS)
 	@echo "==> phase 2: run coverage with lower test concurrency"
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_NO_REMOTE_CACHE_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=$(BAZEL_COVERAGE_TEST_JOBS) --local_test_jobs=$(BAZEL_COVERAGE_TEST_JOBS) --build_tests_only --test_keep_going=false \
-		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ ----experimental_remote_build_event_upload=all \
+		--bes_backend=grpcs://beplessproxy.channel9.ai  --bes_results_url=https://bepless.hawkingrei.com/ --experimental_remote_build_event_upload=all \
 		--combined_report=lcov \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- $(BAZEL_COVERAGE_DDL_TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -713,21 +713,35 @@ bazel_test: bazel-failpoint-enable bazel_prepare ## Run all tests using Bazel
 		-- //... -//cmd/... -//tests/graceshutdown/... \
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
 
+BAZEL_COVERAGE_BUILD_JOBS ?= HOST_CPUS*3
+BAZEL_COVERAGE_TEST_JOBS ?= HOST_CPUS*0.9
+BAZEL_COVERAGE_TARGETS = \
+	//... -//cmd/... -//tests/graceshutdown/... \
+	-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
+
 .PHONY: bazel_coverage_test
 bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=HOST_CPUS*0.9 --build_tests_only --test_keep_going=false \
+	@echo "==> phase 1: build instrumented test binaries"
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
+		--define gotags=$(UNIT_TEST_TAGS) \
+		-- $(BAZEL_COVERAGE_TARGETS)
+	@echo "==> phase 2: run coverage with lower test concurrency"
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=$(BAZEL_COVERAGE_TEST_JOBS) --local_test_jobs=$(BAZEL_COVERAGE_TEST_JOBS) --build_tests_only --test_keep_going=false \
 		--combined_report=lcov \
 		--define gotags=$(UNIT_TEST_TAGS) \
-		-- //... -//cmd/... -//tests/graceshutdown/... \
-		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
+		-- $(BAZEL_COVERAGE_TARGETS)
 
 .PHONY: bazel_coverage_test_ddlargsv1
 bazel_coverage_test_ddlargsv1: bazel-failpoint-enable bazel_ci_simple_prepare
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=HOST_CPUS*0.9 --build_tests_only --test_keep_going=false \
+	@echo "==> phase 1: build instrumented test binaries"
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc build $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --collect_code_coverage --jobs=$(BAZEL_COVERAGE_BUILD_JOBS) --build_tests_only \
+		--define gotags=$(UNIT_TEST_TAGS),ddlargsv1 \
+		-- $(BAZEL_COVERAGE_TARGETS)
+	@echo "==> phase 2: run coverage with lower test concurrency"
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=$(BAZEL_COVERAGE_TEST_JOBS) --local_test_jobs=$(BAZEL_COVERAGE_TEST_JOBS) --build_tests_only --test_keep_going=false \
 		--combined_report=lcov \
 		--define gotags=$(UNIT_TEST_TAGS),ddlargsv1 \
-		-- //... -//cmd/... -//tests/graceshutdown/... \
-		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
+		-- $(BAZEL_COVERAGE_TARGETS)
 
 .PHONY: bazel_bin
 bazel_bin: ## Build importer/tidb binary files with Bazel build system

--- a/Makefile.common
+++ b/Makefile.common
@@ -150,7 +150,7 @@ ifneq ("$(CI)", "")
 else
     BAZEL_CMD_CONFIG := --remote_cache=https://cache.hawkingrei.com/bazelcache --noremote_upload_local_results
 endif
-BAZEL_INSTRUMENTATION_FILTER := --instrument_test_targets --instrumentation_filter=//pkg/...,//br/...,//dumpling/...,//lightning/...
+BAZEL_INSTRUMENTATION_FILTER := --instrument_test_targets --instrumentation_filter=//pkg/planner/util/...
 TIDB_SERVER_PATH := ./bazel-bin/cmd/tidb-server/tidb-server_/tidb-server
 IMPORTER_PATH := ./bazel-bin/cmd/importer/importer_/importer
 TIDB_SERVER_CHECK_PATH := ./bazel-bin/cmd/tidb-server/tidb-server_/tidb-server_check


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: N/A

Problem Summary:

`bazel_coverage_test` used a single `bazel coverage` invocation, so the build and test phases had to share the same concurrency setting.

### What changed and how does it work?

- Added shared Bazel coverage target and concurrency variables.
- Split `bazel_coverage_test` and `bazel_coverage_test_ddlargsv1` into two phases.
- Phase 1 runs `bazel build --collect_code_coverage` with higher build concurrency.
- Phase 2 runs `bazel coverage` with the existing test concurrency and `local_test_jobs`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```bash
make -n bazel_coverage_test
make -n bazel_coverage_test_ddlargsv1
bazel --nohome_rc build ... --collect_code_coverage '--jobs=HOST_CPUS*3' ... //pkg/objstore/storeapi:storeapi_test
bazel --nohome_rc coverage ... '--jobs=HOST_CPUS*0.9' '--local_test_jobs=HOST_CPUS*0.9' ... //pkg/objstore/storeapi:storeapi_test
make lint
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved code-coverage workflow by splitting coverage into separate build and test phases with clear phase labels for easier CI/log debugging.
  * Added configurable concurrency and target-selection for coverage runs to improve reliability and control.
  * Added an option to disable remote caching for coverage/build runs to avoid stale results.
  * Enabled publishing of build/test events and asynchronous event upload for CI telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->