### PR TITLE
pkg/lightning, tests/realtikvtest: stabilize next-gen add-index tests

### DIFF
--- a/br/pkg/metautil/BUILD.bazel
+++ b/br/pkg/metautil/BUILD.bazel
@@ -48,7 +48,7 @@ go_test(
     ],
     embed = [":metautil"],
     flaky = True,
-    shard_count = 13,
+    shard_count = 15,
     deps = [
         "//br/pkg/utils",
         "//pkg/meta/model",

--- a/lightning/tests/lightning_local_backend/run.sh
+++ b/lightning/tests/lightning_local_backend/run.sh
@@ -37,7 +37,7 @@ grep -Fq 'table(s) [`cpeng`.`a`, `cpeng`.`b`] are not empty' $TEST_DIR/lightning
 
 
 # First, verify that inject with not leader error is fine.
-export GO_FAILPOINTS='github.com/pingcap/tidb/pkg/lightning/backend/local/FailIngestMeta=1*return("notleader");github.com/pingcap/tidb/br/pkg/restore/split/failToSplit=5*return("");github.com/pingcap/tidb/pkg/lightning/backend/local/failToSplit=5*return("")'
+export GO_FAILPOINTS='github.com/pingcap/tidb/pkg/lightning/backend/local/FailIngestMeta=1*return("notleader");github.com/pingcap/tidb/br/pkg/restore/split/failToSplit=5*return("");github.com/pingcap/tidb/pkg/lightning/backend/local/forceSplitRegion=5*return("")'
 rm -f "$TEST_DIR/lightning-local.log"
 run_sql 'DROP DATABASE IF EXISTS cpeng;'
 run_lightning --backend local --enable-checkpoint=1 --log-file "$TEST_DIR/lightning-local.log" --config "$CUR/config.toml" -L debug

--- a/pkg/importsdk/BUILD.bazel
+++ b/pkg/importsdk/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//pkg/lightning/config",
         "//pkg/lightning/log",
         "//pkg/lightning/mydump",
+        "//pkg/parser/ast",
         "//pkg/parser/mysql",
         "//pkg/util/table-filter",
         "@com_github_data_dog_go_sqlmock//:go-sqlmock",

--- a/pkg/lightning/backend/local/local.go
+++ b/pkg/lightning/backend/local/local.go
@@ -1089,6 +1089,7 @@ func (local *Backend) prepareAndSendJob(
 	failpoint.Inject("failToSplit", func(_ failpoint.Value) {
 		needSplit = true
 	})
+	failpoint.InjectCall("adjustNeedSplit", &needSplit)
 	if needSplit {
 		var err error
 		logger := log.Wrap(tidblogutil.Logger(ctx)).With(zap.String("uuid", engine.ID())).Begin(zap.InfoLevel, "split and scatter ranges")

--- a/pkg/lightning/backend/local/local.go
+++ b/pkg/lightning/backend/local/local.go
@@ -1086,10 +1086,9 @@ func (local *Backend) prepareAndSendJob(
 	// the table when table is created.
 	needSplit := len(regionSplitKeys) > 2 || lfTotalSize > regionSplitSize || lfLength > regionSplitKeyCnt
 	// split region by given ranges
-	failpoint.Inject("failToSplit", func(_ failpoint.Value) {
+	failpoint.Inject("forceSplitRegion", func(_ failpoint.Value) {
 		needSplit = true
 	})
-	failpoint.InjectCall("adjustNeedSplit", &needSplit)
 	if needSplit {
 		var err error
 		logger := log.Wrap(tidblogutil.Logger(ctx)).With(zap.String("uuid", engine.ID())).Begin(zap.InfoLevel, "split and scatter ranges")

--- a/pkg/lightning/backend/local/region_job.go
+++ b/pkg/lightning/backend/local/region_job.go
@@ -1036,7 +1036,9 @@ func (d *dispatcher) run() error {
 			}
 			// max retry backoff time: 2+4+8+16+30*26=810s
 			sleepSecond := min(math.Pow(2, float64(job.retryCount)), float64(maxRetryBackoffSecond))
-			job.waitUntil = time.Now().Add(time.Second * time.Duration(sleepSecond))
+			backoff := time.Second * time.Duration(sleepSecond)
+			failpoint.InjectCall("adjustRegionJobRetryBackoff", &backoff)
+			job.waitUntil = time.Now().Add(backoff)
 			tidblogutil.Logger(d.workerCtx).Info("put job back to jobCh to retry later",
 				logutil.Key("startKey", job.keyRange.Start),
 				logutil.Key("endKey", job.keyRange.End),

--- a/tests/realtikvtest/addindextest/add_index_test.go
+++ b/tests/realtikvtest/addindextest/add_index_test.go
@@ -36,7 +36,7 @@ func init() {
 	})
 }
 
-func alwaysSplitAndReduceBackoff(t *testing.T) {
+func enableFastAddIndexFailpoints(t *testing.T) {
 	t.Helper()
 	// by split all the time, we can nearly avoid all region job re-queues caused
 	// by EpochNotMatch or other errors, and can make those cases faster.
@@ -47,13 +47,13 @@ func alwaysSplitAndReduceBackoff(t *testing.T) {
 			*needSplit = true
 		})
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/lightning/backend/local/adjustRegionJobRetryBackoff",
-		func(seconds *time.Duration) {
-			*seconds = time.Second
+		func(backoff *time.Duration) {
+			*backoff = time.Second
 		})
 }
 
 func TestCreateNonUniqueIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	testutil.ReduceCheckInterval(t)
 	var colIDs = [][]int{
 		{1, 4, 7, 10, 13, 16, 19, 22, 25},
@@ -65,7 +65,7 @@ func TestCreateNonUniqueIndex(t *testing.T) {
 }
 
 func TestCreateUniqueIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	testutil.ReduceCheckInterval(t)
 	var colIDs [][]int = [][]int{
 		{1, 6, 7, 8, 11, 13, 15, 16, 18, 19, 22, 26},
@@ -77,21 +77,21 @@ func TestCreateUniqueIndex(t *testing.T) {
 }
 
 func TestCreatePrimaryKey(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	testutil.ReduceCheckInterval(t)
 	ctx := testutils.InitTest(t)
 	testutils.TestOneIndexFrame(ctx, 0, testutils.AddIndexPK)
 }
 
 func TestCreateGenColIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	testutil.ReduceCheckInterval(t)
 	ctx := testutils.InitTest(t)
 	testutils.TestOneIndexFrame(ctx, 29, testutils.AddIndexGenCol)
 }
 
 func TestCreateMultiColsIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	testutil.ReduceCheckInterval(t)
 	var coliIDs = [][]int{
 		{1, 4, 7},

--- a/tests/realtikvtest/addindextest/add_index_test.go
+++ b/tests/realtikvtest/addindextest/add_index_test.go
@@ -42,10 +42,7 @@ func enableFastAddIndexFailpoints(t *testing.T) {
 	// by EpochNotMatch or other errors, and can make those cases faster.
 	// we also reduce the retry backoff to make the test faster when region job
 	// is re-queued, as CI ENV might be slow and cause more re-queues.
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/lightning/backend/local/adjustNeedSplit",
-		func(needSplit *bool) {
-			*needSplit = true
-		})
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/lightning/backend/local/forceSplitRegion", "return(true)")
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/lightning/backend/local/adjustRegionJobRetryBackoff",
 		func(backoff *time.Duration) {
 			*backoff = time.Second

--- a/tests/realtikvtest/addindextest/add_index_test.go
+++ b/tests/realtikvtest/addindextest/add_index_test.go
@@ -17,6 +17,7 @@ package addindextest
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
@@ -35,7 +36,24 @@ func init() {
 	})
 }
 
+func alwaysSplitAndReduceBackoff(t *testing.T) {
+	t.Helper()
+	// by split all the time, we can nearly avoid all region job re-queues caused
+	// by EpochNotMatch or other errors, and can make those cases faster.
+	// we also reduce the retry backoff to make the test faster when region job
+	// is re-queued, as CI ENV might be slow and cause more re-queues.
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/lightning/backend/local/adjustNeedSplit",
+		func(needSplit *bool) {
+			*needSplit = true
+		})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/lightning/backend/local/adjustRegionJobRetryBackoff",
+		func(seconds *time.Duration) {
+			*seconds = time.Second
+		})
+}
+
 func TestCreateNonUniqueIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	testutil.ReduceCheckInterval(t)
 	var colIDs = [][]int{
 		{1, 4, 7, 10, 13, 16, 19, 22, 25},
@@ -47,6 +65,7 @@ func TestCreateNonUniqueIndex(t *testing.T) {
 }
 
 func TestCreateUniqueIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	testutil.ReduceCheckInterval(t)
 	var colIDs [][]int = [][]int{
 		{1, 6, 7, 8, 11, 13, 15, 16, 18, 19, 22, 26},
@@ -58,18 +77,21 @@ func TestCreateUniqueIndex(t *testing.T) {
 }
 
 func TestCreatePrimaryKey(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	testutil.ReduceCheckInterval(t)
 	ctx := testutils.InitTest(t)
 	testutils.TestOneIndexFrame(ctx, 0, testutils.AddIndexPK)
 }
 
 func TestCreateGenColIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	testutil.ReduceCheckInterval(t)
 	ctx := testutils.InitTest(t)
 	testutils.TestOneIndexFrame(ctx, 29, testutils.AddIndexGenCol)
 }
 
 func TestCreateMultiColsIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	testutil.ReduceCheckInterval(t)
 	var coliIDs = [][]int{
 		{1, 4, 7},

--- a/tests/realtikvtest/addindextest/concurrent_ddl_test.go
+++ b/tests/realtikvtest/addindextest/concurrent_ddl_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestConcurrentDDLCreateNonUniqueIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	testutil.ReduceCheckInterval(t)
 	var colIDs = [][]int{
 		{1, 4, 7, 10, 13},
@@ -37,7 +37,7 @@ func TestConcurrentDDLCreateNonUniqueIndex(t *testing.T) {
 }
 
 func TestConcurrentDDLCreateUniqueIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	testutil.ReduceCheckInterval(t)
 	var colIDs = [][]int{
 		{1, 6, 11, 13},
@@ -51,7 +51,7 @@ func TestConcurrentDDLCreateUniqueIndex(t *testing.T) {
 }
 
 func TestConcurrentDDLCreatePrimaryKey(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	testutil.ReduceCheckInterval(t)
 	ctx := testutils.InitConcurrentDDLTest(t, nil, nil, testutils.TestPK)
 	ctx.CompCtx.Start(ctx)
@@ -60,7 +60,7 @@ func TestConcurrentDDLCreatePrimaryKey(t *testing.T) {
 }
 
 func TestConcurrentDDLCreateGenColIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	testutil.ReduceCheckInterval(t)
 	ctx := testutils.InitConcurrentDDLTest(t, nil, nil, testutils.TestGenIndex)
 	ctx.CompCtx.Start(ctx)
@@ -69,7 +69,7 @@ func TestConcurrentDDLCreateGenColIndex(t *testing.T) {
 }
 
 func TestConcurrentDDLCreateMultiColsIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	testutil.ReduceCheckInterval(t)
 	var coliIDs = [][]int{
 		{7},

--- a/tests/realtikvtest/addindextest/concurrent_ddl_test.go
+++ b/tests/realtikvtest/addindextest/concurrent_ddl_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestConcurrentDDLCreateNonUniqueIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	testutil.ReduceCheckInterval(t)
 	var colIDs = [][]int{
 		{1, 4, 7, 10, 13},
@@ -36,6 +37,7 @@ func TestConcurrentDDLCreateNonUniqueIndex(t *testing.T) {
 }
 
 func TestConcurrentDDLCreateUniqueIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	testutil.ReduceCheckInterval(t)
 	var colIDs = [][]int{
 		{1, 6, 11, 13},
@@ -49,6 +51,7 @@ func TestConcurrentDDLCreateUniqueIndex(t *testing.T) {
 }
 
 func TestConcurrentDDLCreatePrimaryKey(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	testutil.ReduceCheckInterval(t)
 	ctx := testutils.InitConcurrentDDLTest(t, nil, nil, testutils.TestPK)
 	ctx.CompCtx.Start(ctx)
@@ -57,6 +60,7 @@ func TestConcurrentDDLCreatePrimaryKey(t *testing.T) {
 }
 
 func TestConcurrentDDLCreateGenColIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	testutil.ReduceCheckInterval(t)
 	ctx := testutils.InitConcurrentDDLTest(t, nil, nil, testutils.TestGenIndex)
 	ctx.CompCtx.Start(ctx)
@@ -65,6 +69,7 @@ func TestConcurrentDDLCreateGenColIndex(t *testing.T) {
 }
 
 func TestConcurrentDDLCreateMultiColsIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	testutil.ReduceCheckInterval(t)
 	var coliIDs = [][]int{
 		{7},

--- a/tests/realtikvtest/addindextest/failpoints_test.go
+++ b/tests/realtikvtest/addindextest/failpoints_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestFailpointsCreateNonUniqueIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	if !*FullMode {
 		t.Skip()
 	}
@@ -34,6 +35,7 @@ func TestFailpointsCreateNonUniqueIndex(t *testing.T) {
 }
 
 func TestFailpointsCreateUniqueIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	if !*FullMode {
 		t.Skip()
 	}
@@ -50,6 +52,7 @@ func TestFailpointsCreatePrimaryKeyFailpoints(t *testing.T) {
 	if !*FullMode {
 		t.Skip()
 	}
+	alwaysSplitAndReduceBackoff(t)
 	ctx := testutils.InitTest(t)
 	testutils.TestOneIndexFrame(ctx, 0, testutils.AddIndexPK)
 }
@@ -58,11 +61,13 @@ func TestFailpointsCreateGenColIndex(t *testing.T) {
 	if !*FullMode {
 		t.Skip()
 	}
+	alwaysSplitAndReduceBackoff(t)
 	ctx := testutils.InitTestFailpoint(t)
 	testutils.TestOneIndexFrame(ctx, 29, testutils.AddIndexGenCol)
 }
 
 func TestFailpointsCreateMultiColsIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	if !*FullMode {
 		t.Skip()
 	}

--- a/tests/realtikvtest/addindextest/failpoints_test.go
+++ b/tests/realtikvtest/addindextest/failpoints_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestFailpointsCreateNonUniqueIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	if !*FullMode {
 		t.Skip()
 	}
@@ -35,7 +35,7 @@ func TestFailpointsCreateNonUniqueIndex(t *testing.T) {
 }
 
 func TestFailpointsCreateUniqueIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	if !*FullMode {
 		t.Skip()
 	}
@@ -52,7 +52,7 @@ func TestFailpointsCreatePrimaryKeyFailpoints(t *testing.T) {
 	if !*FullMode {
 		t.Skip()
 	}
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	ctx := testutils.InitTest(t)
 	testutils.TestOneIndexFrame(ctx, 0, testutils.AddIndexPK)
 }
@@ -61,13 +61,13 @@ func TestFailpointsCreateGenColIndex(t *testing.T) {
 	if !*FullMode {
 		t.Skip()
 	}
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	ctx := testutils.InitTestFailpoint(t)
 	testutils.TestOneIndexFrame(ctx, 29, testutils.AddIndexGenCol)
 }
 
 func TestFailpointsCreateMultiColsIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	if !*FullMode {
 		t.Skip()
 	}

--- a/tests/realtikvtest/addindextest/multi_schema_change_test.go
+++ b/tests/realtikvtest/addindextest/multi_schema_change_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestMultiSchemaChangeCreateNonUniqueIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	var colIDs = [][]int{
 		{1, 4, 7},
 		{2, 5, 8},
@@ -32,6 +33,7 @@ func TestMultiSchemaChangeCreateNonUniqueIndex(t *testing.T) {
 }
 
 func TestMultiSchemaChangeCreateUniqueIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	var colIDs = [][]int{
 		{1, 6, 8},
 		{2, 19},
@@ -43,18 +45,21 @@ func TestMultiSchemaChangeCreateUniqueIndex(t *testing.T) {
 }
 
 func TestMultiSchemaChangeCreatePrimaryKey(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	ctx := testutils.InitCompCtx(t)
 	ctx.CompCtx.IsMultiSchemaChange = true
 	testutils.TestOneIndexFrame(ctx, 0, testutils.AddIndexPK)
 }
 
 func TestMultiSchemaChangeCreateGenColIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	ctx := testutils.InitCompCtx(t)
 	ctx.CompCtx.IsMultiSchemaChange = true
 	testutils.TestOneIndexFrame(ctx, 29, testutils.AddIndexGenCol)
 }
 
 func TestMultiSchemaChangeMultiColsIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	var coliIDs = [][]int{
 		{1},
 		{2},

--- a/tests/realtikvtest/addindextest/multi_schema_change_test.go
+++ b/tests/realtikvtest/addindextest/multi_schema_change_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestMultiSchemaChangeCreateNonUniqueIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	var colIDs = [][]int{
 		{1, 4, 7},
 		{2, 5, 8},
@@ -33,7 +33,7 @@ func TestMultiSchemaChangeCreateNonUniqueIndex(t *testing.T) {
 }
 
 func TestMultiSchemaChangeCreateUniqueIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	var colIDs = [][]int{
 		{1, 6, 8},
 		{2, 19},
@@ -45,21 +45,21 @@ func TestMultiSchemaChangeCreateUniqueIndex(t *testing.T) {
 }
 
 func TestMultiSchemaChangeCreatePrimaryKey(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	ctx := testutils.InitCompCtx(t)
 	ctx.CompCtx.IsMultiSchemaChange = true
 	testutils.TestOneIndexFrame(ctx, 0, testutils.AddIndexPK)
 }
 
 func TestMultiSchemaChangeCreateGenColIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	ctx := testutils.InitCompCtx(t)
 	ctx.CompCtx.IsMultiSchemaChange = true
 	testutils.TestOneIndexFrame(ctx, 29, testutils.AddIndexGenCol)
 }
 
 func TestMultiSchemaChangeMultiColsIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	var coliIDs = [][]int{
 		{1},
 		{2},

--- a/tests/realtikvtest/addindextest/pitr_test.go
+++ b/tests/realtikvtest/addindextest/pitr_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestPiTRCreateNonUniqueIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	var colIDs = [][]int{
 		{1, 4, 7},
 		{2, 5, 8},
@@ -32,6 +33,7 @@ func TestPiTRCreateNonUniqueIndex(t *testing.T) {
 }
 
 func TestPiTRCreateUniqueIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	var colIDs = [][]int{
 		{1, 6},
 		{11},
@@ -43,18 +45,21 @@ func TestPiTRCreateUniqueIndex(t *testing.T) {
 }
 
 func TestPiTRCreatePrimaryKey(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	ctx := testutils.InitCompCtx(t)
 	ctx.CompCtx.IsPiTR = true
 	testutils.TestOneIndexFrame(ctx, 0, testutils.AddIndexPK)
 }
 
 func TestPiTRCreateGenColIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	ctx := testutils.InitCompCtx(t)
 	ctx.CompCtx.IsPiTR = true
 	testutils.TestOneIndexFrame(ctx, 29, testutils.AddIndexGenCol)
 }
 
 func TestPiTRCreateMultiColsIndex(t *testing.T) {
+	alwaysSplitAndReduceBackoff(t)
 	var coliIDs = [][]int{
 		{1},
 		{8},

--- a/tests/realtikvtest/addindextest/pitr_test.go
+++ b/tests/realtikvtest/addindextest/pitr_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestPiTRCreateNonUniqueIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	var colIDs = [][]int{
 		{1, 4, 7},
 		{2, 5, 8},
@@ -33,7 +33,7 @@ func TestPiTRCreateNonUniqueIndex(t *testing.T) {
 }
 
 func TestPiTRCreateUniqueIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	var colIDs = [][]int{
 		{1, 6},
 		{11},
@@ -45,21 +45,21 @@ func TestPiTRCreateUniqueIndex(t *testing.T) {
 }
 
 func TestPiTRCreatePrimaryKey(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	ctx := testutils.InitCompCtx(t)
 	ctx.CompCtx.IsPiTR = true
 	testutils.TestOneIndexFrame(ctx, 0, testutils.AddIndexPK)
 }
 
 func TestPiTRCreateGenColIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	ctx := testutils.InitCompCtx(t)
 	ctx.CompCtx.IsPiTR = true
 	testutils.TestOneIndexFrame(ctx, 29, testutils.AddIndexGenCol)
 }
 
 func TestPiTRCreateMultiColsIndex(t *testing.T) {
-	alwaysSplitAndReduceBackoff(t)
+	enableFastAddIndexFailpoints(t)
 	var coliIDs = [][]int{
 		{1},
 		{8},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67830

Problem Summary:

Next-gen `tests/realtikvtest/addindextest` cases can spend most of their runtime on split/ingest retry churn and hit the shard timeout budget. The tests need a reliable way to force split-before-ingest and to tune the region-job retry backoff used in the retry path.

### What changed and how does it work?

- add an `adjustNeedSplit` failpoint hook in the local backend so tests can force split-before-ingest
- change `adjustRegionJobRetryBackoff` to override a `time.Duration` directly, so tests can also use sub-second backoff values when needed
- add a shared `alwaysSplitAndReduceBackoff` helper in `tests/realtikvtest/addindextest` and apply it to the next-gen add-index suites
- include the corresponding Bazel metadata updates

Measured result on `TestCreateNonUniqueIndex`:
- original path without the test helper: `276.38s` test time / `279.570s` total
- after this change with the test helper enabled: `64.19s` test time / `67.432s` total

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test steps:

```bash
make failpoint-enable
go test -run TestCreateNonUniqueIndex -tags=intest,deadlock,nextgen -count=1 -v ./tests/realtikvtest/addindextest
make failpoint-disable
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Broadened and unified test instrumentation for index-creation scenarios (concurrent DDL, multi-schema, PiTR and failpoint-driven cases).
  * Added a shared test helper to enable faster, deterministic test paths and to adjust retry/backoff behavior for more reliable test execution.
* **Chores**
  * Tweaked test build configuration to improve test parallelism and ensure required test dependencies are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->