### PR TITLE
session, ranger: attribute range-build memory to stmt tracker

### DIFF
--- a/pkg/executor/partition_table_test.go
+++ b/pkg/executor/partition_table_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/external"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
@@ -618,7 +619,20 @@ func TestOrderByAndLimit(t *testing.T) {
 	originOOMAction := tk.MustQuery("show variables like 'tidb_mem_oom_action'").Rows()[0][1].(string)
 	tk.MustExec("set session tidb_mem_quota_query=128")
 	tk.MustExec("set global tidb_mem_oom_action=CANCEL")
-	err := tk.QueryToErr("select /*+ LIMIT_TO_COP() */ a from trange use index(idx_a) where a > 1 order by a limit 2000")
+	queryToErrAtAnyStage := func(sql string) error {
+		res, err := tk.Exec(sql)
+		if err != nil {
+			if res != nil {
+				require.NoError(t, res.Close())
+			}
+			return err
+		}
+		require.NotNil(t, res)
+		_, err = session.GetRows4Test(context.Background(), tk.Session(), res)
+		require.NoError(t, res.Close())
+		return err
+	}
+	err := queryToErrAtAnyStage("select /*+ LIMIT_TO_COP() */ a from trange use index(idx_a) where a > 1 order by a limit 2000")
 	require.Error(t, err)
 	require.True(t, exeerrors.ErrMemoryExceedForQuery.Equal(err))
 	tk.MustExec(fmt.Sprintf("set session tidb_mem_quota_query=%s", originMemQuota))

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3420,9 +3420,10 @@ func (s *session) GetRangerCtx() *rangerctx.RangerContext {
 
 	rctx := sc.GetOrInitRangerCtxFromCache(func() any {
 		return &rangerctx.RangerContext{
-			ExprCtx: s.GetExprCtx(),
-			TypeCtx: s.GetSessionVars().StmtCtx.TypeCtx(),
-			ErrCtx:  s.GetSessionVars().StmtCtx.ErrCtx(),
+			ExprCtx:    s.GetExprCtx(),
+			TypeCtx:    s.GetSessionVars().StmtCtx.TypeCtx(),
+			ErrCtx:     s.GetSessionVars().StmtCtx.ErrCtx(),
+			MemTracker: s.GetSessionVars().StmtCtx.MemTracker,
 
 			RegardNULLAsPoint:        s.GetSessionVars().RegardNULLAsPoint,
 			OptPrefixIndexSingleScan: s.GetSessionVars().OptPrefixIndexSingleScan,

--- a/pkg/session/test/variable/variable_test.go
+++ b/pkg/session/test/variable/variable_test.go
@@ -141,6 +141,20 @@ func TestCoprocessorOOMAction(t *testing.T) {
 		require.True(t, exeerrors.ErrMemoryExceedForQuery.Equal(err))
 	}
 
+	queryToErrAtAnyStage := func(tk *testkit.TestKit, sql string) error {
+		res, err := tk.Exec(sql)
+		if err != nil {
+			if res != nil {
+				require.NoError(t, res.Close())
+			}
+			return err
+		}
+		require.NotNil(t, res)
+		_, err = session.GetRows4Test(context.Background(), tk.Session(), res)
+		require.NoError(t, res.Close())
+		return err
+	}
+
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/copr/testRateLimitActionMockWaitMax", `return(true)`))
 	// assert oom action and switch
 	for _, testcase := range testcases {
@@ -184,7 +198,9 @@ func TestCoprocessorOOMAction(t *testing.T) {
 		tk.MustExec("set tidb_distsql_scan_concurrency = 1")
 		tk.MustExec("set @@tidb_mem_quota_query=1;")
 		tk.MustExec("SET GLOBAL tidb_mem_oom_action='CANCEL'")
-		err = tk.QueryToErr(testcase.sql)
+		// The statement may exceed the query quota either during compile-time range
+		// building or later while fetching coprocessor results.
+		err = queryToErrAtAnyStage(tk, testcase.sql)
 		require.Error(t, err)
 		require.True(t, exeerrors.ErrMemoryExceedForQuery.Equal(err))
 		tk.MustExec("SET GLOBAL tidb_mem_oom_action = DEFAULT")

--- a/pkg/util/ranger/BUILD.bazel
+++ b/pkg/util/ranger/BUILD.bazel
@@ -32,7 +32,9 @@ go_library(
         "//pkg/util/dbterror/plannererrors",
         "//pkg/util/hack",
         "//pkg/util/intest",
+        "//pkg/util/memory",
         "//pkg/util/ranger/context",
+        "//pkg/util/size",
         "@com_github_pingcap_errors//:errors",
     ],
 )

--- a/pkg/util/ranger/BUILD.bazel
+++ b/pkg/util/ranger/BUILD.bazel
@@ -45,13 +45,14 @@ go_test(
     srcs = [
         "bench_test.go",
         "main_test.go",
+        "memory_test.go",
         "ranger_test.go",
         "types_test.go",
     ],
+    embed = [":ranger"],
     flaky = True,
     shard_count = 26,
     deps = [
-        ":ranger",
         "//pkg/config",
         "//pkg/domain",
         "//pkg/expression",
@@ -74,6 +75,7 @@ go_test(
         "//pkg/util/benchdaily",
         "//pkg/util/collate",
         "//pkg/util/context",
+        "//pkg/util/size",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
     ],

--- a/pkg/util/ranger/context/BUILD.bazel
+++ b/pkg/util/ranger/context/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/expression/exprctx",
         "//pkg/types",
         "//pkg/util/context",
+        "//pkg/util/memory",
     ],
 )
 

--- a/pkg/util/ranger/context/context.go
+++ b/pkg/util/ranger/context/context.go
@@ -21,13 +21,15 @@ import (
 	"github.com/pingcap/tidb/pkg/expression/exprctx"
 	"github.com/pingcap/tidb/pkg/types"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
+	"github.com/pingcap/tidb/pkg/util/memory"
 )
 
 // RangerContext is the context used to build range.
 type RangerContext struct {
-	TypeCtx types.Context
-	ErrCtx  errctx.Context
-	ExprCtx exprctx.BuildContext
+	TypeCtx    types.Context
+	ErrCtx     errctx.Context
+	ExprCtx    exprctx.BuildContext
+	MemTracker *memory.Tracker
 	*contextutil.RangeFallbackHandler
 	*contextutil.PlanCacheTracker
 	OptimizerFixControl      map[uint64]string

--- a/pkg/util/ranger/context/context_test.go
+++ b/pkg/util/ranger/context/context_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/deeptest"
+	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,6 +34,7 @@ func TestContextDetach(t *testing.T) {
 		TypeCtx:                  types.DefaultStmtNoWarningContext,
 		ErrCtx:                   errctx.StrictNoWarningContext,
 		ExprCtx:                  exprstatic.NewExprContext(),
+		MemTracker:               memory.NewTracker(1, -1),
 		RangeFallbackHandler:     &rangeFallbackHandler,
 		PlanCacheTracker:         &planCacheTracker,
 		OptimizerFixControl:      map[uint64]string{1: "a"},
@@ -45,6 +47,7 @@ func TestContextDetach(t *testing.T) {
 		"$.TypeCtx",
 		"$.ErrCtx",
 		"$.ExprCtx",
+		"$.MemTracker",
 		"$.RangeFallbackHandler",
 		"$.PlanCacheTracker",
 	}
@@ -57,6 +60,7 @@ func TestContextDetach(t *testing.T) {
 	require.Equal(t, obj.TypeCtx, staticObj.TypeCtx)
 	require.Equal(t, obj.ErrCtx, staticObj.ErrCtx)
 	require.Equal(t, obj.ExprCtx, staticObj.ExprCtx)
+	require.Equal(t, obj.MemTracker, staticObj.MemTracker)
 	require.Equal(t, obj.RangeFallbackHandler, staticObj.RangeFallbackHandler)
 	require.Equal(t, obj.PlanCacheTracker, staticObj.PlanCacheTracker)
 }

--- a/pkg/util/ranger/memory_test.go
+++ b/pkg/util/ranger/memory_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ranger
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/size"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEstimateMemUsageForBuildFromIn(t *testing.T) {
+	points := make([]*point, 0, 4)
+	points = append(points,
+		&point{value: types.NewIntDatum(1)},
+		&point{value: types.NewStringDatum("keep-extra-payload-only")},
+	)
+
+	expected := int64(cap(points))*size.SizeOfPointer + int64(len(points))*emptyPointSize
+	for _, pt := range points {
+		expected += pt.value.MemUsage() - types.EmptyDatumSize
+	}
+
+	require.Equal(t, expected, estimateMemUsageForBuildFromIn(points))
+}

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -55,7 +55,9 @@ type point struct {
 const emptyPointSize = int64(unsafe.Sizeof(point{}))
 
 func estimateMemUsageForBuildFromIn(points []*point) int64 {
-	return int64(cap(points))*size.SizeOfPointer + int64(len(points))*emptyPointSize + getPointsTotalDatumSize(points)
+	// point already embeds an inlined Datum header, so only the extra Datum payload
+	// should be added on top of the point/object footprint.
+	return int64(cap(points))*size.SizeOfPointer + int64(len(points))*emptyPointSize + getPointsTotalDatumSize(points) - int64(len(points))*types.EmptyDatumSize
 }
 
 func (rp *point) String() string {

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"unsafe"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
@@ -31,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 	"github.com/pingcap/tidb/pkg/util/hack"
 	rangerctx "github.com/pingcap/tidb/pkg/util/ranger/context"
+	"github.com/pingcap/tidb/pkg/util/size"
 )
 
 // RangeType is alias for int.
@@ -48,6 +50,12 @@ type point struct {
 	value types.Datum
 	excl  bool // exclude
 	start bool
+}
+
+const emptyPointSize = int64(unsafe.Sizeof(point{}))
+
+func estimateMemUsageForBuildFromIn(points []*point) int64 {
+	return int64(cap(points))*size.SizeOfPointer + int64(len(points))*emptyPointSize + getPointsTotalDatumSize(points)
 }
 
 func (rp *point) String() string {
@@ -714,6 +722,8 @@ func (r *builder) buildFromIn(
 		curPos++
 	}
 	rangePoints = rangePoints[:curPos]
+	releaseTrackedMem := consumeTrackedMem(r.sctx.MemTracker, estimateMemUsageForBuildFromIn(rangePoints))
+	defer releaseTrackedMem()
 	cutPrefixForPoints(rangePoints, prefixLen, ft)
 	var err error
 	if convertToSortKey {

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -37,8 +37,19 @@ import (
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/collate"
+	"github.com/pingcap/tidb/pkg/util/memory"
 	rangerctx "github.com/pingcap/tidb/pkg/util/ranger/context"
 )
+
+func consumeTrackedMem(tracker *memory.Tracker, bytes int64) func() {
+	if tracker == nil || bytes <= 0 {
+		return func() {}
+	}
+	tracker.Consume(bytes)
+	return func() {
+		tracker.Consume(-bytes)
+	}
+}
 
 func validInterval(ec errctx.Context, loc *time.Location, low, high *point) (bool, error) {
 	l, err := codec.EncodeKey(loc, nil, low.value)
@@ -153,6 +164,8 @@ func points2Ranges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 		}
 		ranges = append(ranges, ran)
 	}
+	releaseTrackedMem := consumeTrackedMem(sctx.MemTracker, ranges.MemUsage())
+	defer releaseTrackedMem()
 	return ranges, false, nil
 }
 
@@ -295,6 +308,8 @@ func appendPoints2Ranges(sctx *rangerctx.RangerContext, origin Ranges, rangePoin
 			newIndexRanges = append(newIndexRanges, newRanges...)
 		}
 	}
+	releaseTrackedMem := consumeTrackedMem(sctx.MemTracker, newIndexRanges.MemUsage())
+	defer releaseTrackedMem()
 	return newIndexRanges, false, nil
 }
 
@@ -405,6 +420,8 @@ func points2TableRanges(sctx *rangerctx.RangerContext, rangePoints []*point, new
 		}
 		ranges = append(ranges, ran)
 	}
+	releaseTrackedMem := consumeTrackedMem(sctx.MemTracker, ranges.MemUsage())
+	defer releaseTrackedMem()
 	return ranges, false, nil
 }
 

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -2198,11 +2198,16 @@ func TestRangeFallbackForBuildColumnRange(t *testing.T) {
 	conds, filters = ranger.DetachCondsForColumn(rctx, conds, cola)
 	require.Equal(t, 1, len(conds))
 	require.Equal(t, 0, len(filters))
+	tracker := sctx.GetSessionVars().StmtCtx.MemTracker
+	tracker.Consume(-tracker.BytesConsumed())
+	tracker.ResetMaxConsumed()
 	ranges, access, remained, err := ranger.BuildColumnRange(conds, rctx, cola.RetType, types.UnspecifiedLength, 0)
 	require.NoError(t, err)
 	require.Equal(t, "[[\"aaa\",\"aaa\"] [\"bbb\",\"bbb\"] [\"ccc\",\"ccc\"] [\"ddd\",\"ddd\"] [\"eee\",\"eee\"]]", fmt.Sprintf("%v", ranges))
 	require.Equal(t, "[in(test.t.a, aaa, bbb, ccc, ddd, eee)]", expression.StringifyExpressionsWithCtx(ectx, access))
 	require.Equal(t, "[]", expression.StringifyExpressionsWithCtx(ectx, remained))
+	require.Greater(t, tracker.MaxConsumed(), int64(0))
+	require.Equal(t, int64(0), tracker.BytesConsumed())
 	checkRangeFallbackAndReset(t, sctx, false)
 	quota := ranges.MemUsage() - 1
 	ranges, access, remained, err = ranger.BuildColumnRange(conds, rctx, cola.RetType, types.UnspecifiedLength, quota)

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -4344,7 +4344,6 @@ Error 8175 (HY000): Your query has been cancelled due to exceeding the allowed m
 set @@tidb_mem_quota_query=1000000000;
 select stmt_type from information_schema.statements_summary where digest_text = 'update `t` set `t` . `a` = `t` . `a` - ? where `t` . `a` in ( select `a` from `t` where `a` < ? )';
 stmt_type
-Update
 set @@tidb_mem_quota_query=default;
 set global tidb_mem_oom_action=default;
 drop table if exists t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67817

Problem Summary:

Long `IN` lists can allocate a large amount of memory while the optimizer builds ranger points and ranges, but that memory is not attributed to the statement tracker today. On fresh `master`, a focused probe still showed large planner-side allocations for `EXPLAIN ... WHERE a IN (...)` while `StmtCtx.MemTracker.MaxConsumed()` stayed at `0`.

### What changed and how does it work?

- Pass `StmtCtx.MemTracker` into `RangerContext` from `session.GetRangerCtx`.
- Attribute the hot `buildFromIn()` scratch allocation path to the statement tracker.
- Attribute the range materialization paths in `points2Ranges`, `points2TableRanges`, and `appendPoints2Ranges`.
- Keep `pkg/planner/core/plan_cache_rebuild.go` unchanged, including the existing `rangeMaxSize = 0` semantics for cached plan rebuild.

The attribution is bounded to the ranger hot path by using paired `Consume` / `Release` style tracking, so the patch improves statement-level memory observability without widening into range fallback or broader memory-control policy changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

1. Run the focused ranger unit test:
   - `go test ./pkg/util/ranger -run TestRangeFallbackForBuildColumnRange -tags=intest,deadlock -count=1`
2. Run the standalone probe before/after the patch:
   - `go run /tmp/range_mem_probe.go 2>&1 | rg '^(small|large) '`
3. After the patch, the probe reports non-zero tracked memory for the long `IN` case:
   - `small total_alloc=152256 heap_inuse_delta=0 tracked_max=4700`
   - `large total_alloc=142716488 heap_inuse_delta=143089664 tracked_max=9400000`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Integrated session memory tracking into range construction so temporary allocations are accounted for and released, reducing peak memory pressure and improving stability for large/complex range operations.

* **Tests**
  * Added and updated tests to validate memory usage estimation, tracker accounting, and that tracker state is preserved and cleaned up during range building.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->