### PR TITLE
executor: skip rebuilding explain-for-connection target plans

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -1443,6 +1443,11 @@ func (b *executorBuilder) buildExplain(v *plannercore.Explain) exec.Executor {
 			b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStatsColl(nil)
 		}
 	}
+	// EXPLAIN FOR CONNECTION can render directly from the stored brief binary plan without
+	// rebuilding the target executor, which may no longer have live parameter values.
+	if !v.Analyze && v.BriefBinaryPlan != "" {
+		return explainExec
+	}
 	// Needs to build the target plan, even if not executing it
 	// to get partition pruning.
 	explainExec.analyzeExec = b.build(v.TargetPlan)

--- a/pkg/executor/explainfor_test.go
+++ b/pkg/executor/explainfor_test.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/session/sessmgr"
@@ -92,6 +93,37 @@ func TestExplainFor(t *testing.T) {
 	ps = []*sessmgr.ProcessInfo{tkRootProcess}
 	tkRoot.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
 	tkRoot.MustExec(fmt.Sprintf("explain for connection %d", tkRootProcess.ID))
+
+	tkRoot.MustExec("set @@tidb_enable_collect_execution_info=0")
+	tkRoot.MustExec("set tidb_enable_non_prepared_plan_cache=1")
+	tkRoot.MustExec("drop table if exists t_explain_for_nonprep")
+	tkRoot.MustExec("create table t_explain_for_nonprep(status int)")
+	tkRoot.MustExec("insert into t_explain_for_nonprep values (1)")
+	tkExplain := testkit.NewTestKit(t, store)
+	tkExplain.MustExec("use test")
+
+	// The cached non-prepared plan keeps parameterized predicates in the recorded ProcessInfo plan.
+	queryDone := make(chan error, 1)
+	querySQL := "select status, sleep(1) from t_explain_for_nonprep where status=1"
+	go func() {
+		queryDone <- tkRoot.QueryToErr(querySQL)
+	}()
+	require.Eventually(t, func() bool {
+		pi := tkRoot.Session().ShowProcess()
+		return pi != nil && strings.Contains(pi.Info, "sleep(1)")
+	}, 5*time.Second, 50*time.Millisecond)
+
+	tkRootProcess = tkRoot.Session().ShowProcess()
+	ps = []*sessmgr.ProcessInfo{tkRootProcess}
+	tkExplain.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
+	tkExplain.MustQuery(fmt.Sprintf("explain for connection %d", tkRootProcess.ID))
+
+	require.NoError(t, <-queryDone)
+
+	tkRootProcess = tkRoot.Session().ShowProcess()
+	ps = []*sessmgr.ProcessInfo{tkRootProcess}
+	tkExplain.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
+	tkExplain.MustQuery(fmt.Sprintf("explain for connection %d", tkRootProcess.ID))
 }
 
 func TestExplainForVerbose(t *testing.T) {

--- a/pkg/executor/explainfor_test.go
+++ b/pkg/executor/explainfor_test.go
@@ -124,6 +124,40 @@ func TestExplainFor(t *testing.T) {
 	ps = []*sessmgr.ProcessInfo{tkRootProcess}
 	tkExplain.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
 	tkExplain.MustQuery(fmt.Sprintf("explain for connection %d", tkRootProcess.ID))
+
+	tkRoot.MustExec("set tidb_enable_prepared_plan_cache=1")
+	tkRoot.MustExec("drop table if exists t_explain_for_prep")
+	tkRoot.MustExec("create table t_explain_for_prep(status int)")
+	tkRoot.MustExec("insert into t_explain_for_prep values (1)")
+	tkRoot.MustExec("prepare stmt_explain_for_connection from 'select status, sleep(1) from t_explain_for_prep where status = ?'")
+	tkRoot.MustExec("set @status = 1")
+	tkRoot.MustQuery("execute stmt_explain_for_connection using @status").Check(testkit.Rows("1 0"))
+	tkRoot.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+
+	// Prepared plan cache also records BriefBinaryPlan through Execute.Plan, so the decode-only path
+	// should stay valid for both running and finished EXPLAIN FOR CONNECTION.
+	queryDone = make(chan error, 1)
+	querySQL = "execute stmt_explain_for_connection using @status"
+	go func() {
+		queryDone <- tkRoot.QueryToErr(querySQL)
+	}()
+	require.Eventually(t, func() bool {
+		pi := tkRoot.Session().ShowProcess()
+		return pi != nil && strings.Contains(pi.Info, "stmt_explain_for_connection")
+	}, 5*time.Second, 50*time.Millisecond)
+
+	tkRootProcess = tkRoot.Session().ShowProcess()
+	ps = []*sessmgr.ProcessInfo{tkRootProcess}
+	tkExplain.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
+	tkExplain.MustQuery(fmt.Sprintf("explain for connection %d", tkRootProcess.ID))
+
+	require.NoError(t, <-queryDone)
+	tkRoot.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+
+	tkRootProcess = tkRoot.Session().ShowProcess()
+	ps = []*sessmgr.ProcessInfo{tkRootProcess}
+	tkExplain.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
+	tkExplain.MustQuery(fmt.Sprintf("explain for connection %d", tkRootProcess.ID))
 }
 
 func TestExplainForVerbose(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65916

Problem Summary:

`EXPLAIN FOR CONNECTION` may fail for a non-prepared plan cache query because the recorded target
plan still contains parameterized predicates, but the explain session no longer has the live
parameter values needed to rebuild that executor.

### What changed and how does it work?

- Skip rebuilding the target executor in `executorBuilder.buildExplain()` when handling a
  non-`ANALYZE` explain that already has `BriefBinaryPlan`.
- Add a regression to `pkg/executor/explainfor_test.go` covering both running and finished
  `EXPLAIN FOR CONNECTION` on a non-prepared plan cache query.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * EXPLAIN FOR CONNECTION no longer rebuilds target plans when a brief binary plan is present, preventing dependence on live parameter values during explain rendering.

* **Tests**
  * Added tests covering EXPLAIN FOR CONNECTION with concurrent queries and toggling of plan-cache behavior to ensure correct explain output under prepared and non-prepared scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->