### PR TITLE
planner: prune impossible ISNULL/IN OR branches

### DIFF
--- a/pkg/planner/core/rule/rule_predicate_simplification.go
+++ b/pkg/planner/core/rule/rule_predicate_simplification.go
@@ -47,6 +47,7 @@ const (
 	greaterThanPredicate
 	lessThanOrEqualPredicate
 	greaterThanOrEqualPredicate
+	isNullPredicate
 	orPredicate
 	andPredicate
 	scalarPredicate
@@ -83,6 +84,7 @@ func logicalConstant(bc base.PlanContext, cond expression.Expression) predicateT
 // The function handles different expression types, including constants, scalar functions, and their specific cases:
 // - Logical operators (`OR` and `AND`).
 // - Comparison operators (`EQ`, `NE`, `LT`, `GT`, `LE`, `GE`).
+// - `ISNULL` predicates on a column.
 // - IN predicates with a list of constants.
 // If the expression doesn't match any of these recognized patterns, it returns an `otherPredicate` type.
 func FindPredicateType(bc base.PlanContext, expr expression.Expression) (*expression.Column, predicateType) {
@@ -103,6 +105,9 @@ func FindPredicateType(bc base.PlanContext, expr expression.Expression) (*expres
 		col, colOk := args[0].(*expression.Column)
 		if !colOk {
 			return nil, otherPredicate
+		}
+		if v.FuncName.L == ast.IsNull {
+			return col, isNullPredicate
 		}
 		if len(args) > 1 {
 			if _, ok := args[1].(*expression.Constant); !ok {
@@ -280,19 +285,25 @@ func unsatisfiableExpression(ctx base.PlanContext, p expression.Expression) bool
 func unsatisfiable(ctx base.PlanContext, p1, p2 expression.Expression) bool {
 	var equalPred expression.Expression
 	var otherPred expression.Expression
+	var otherPredType predicateType
 	col1, p1Type := FindPredicateType(ctx, p1)
 	col2, p2Type := FindPredicateType(ctx, p2)
 	if col1 == nil || !col1.Equals(col2) {
 		return false
 	}
+	if isNullInListContradiction(ctx, p1, p1Type, p2, p2Type) {
+		return true
+	}
 	if p1Type == equalPredicate {
 		equalPred = p1
 		otherPred = p2
+		otherPredType = p2Type
 	} else if p2Type == equalPredicate {
 		equalPred = p2
 		otherPred = p1
+		otherPredType = p1Type
 	}
-	if equalPred == nil || otherPred == nil {
+	if equalPred == nil || otherPred == nil || !binaryComparisonPredicate(otherPredType) {
 		return false
 	}
 	// Copy constant from equal predicate into other predicate.
@@ -325,13 +336,49 @@ func unsatisfiable(ctx base.PlanContext, p1, p2 expression.Expression) bool {
 	return false
 }
 
+func binaryComparisonPredicate(predType predicateType) bool {
+	return predType == equalPredicate || predType == notEqualPredicate ||
+		predType == lessThanPredicate || predType == greaterThanPredicate ||
+		predType == lessThanOrEqualPredicate || predType == greaterThanOrEqualPredicate
+}
+
+func isNullInListContradiction(ctx base.PlanContext, p1 expression.Expression, p1Type predicateType, p2 expression.Expression, p2Type predicateType) bool {
+	var inPred expression.Expression
+	switch {
+	case p1Type == isNullPredicate && p2Type == inListPredicate:
+		inPred = p2
+	case p2Type == isNullPredicate && p1Type == inListPredicate:
+		inPred = p1
+	default:
+		return false
+	}
+	if expression.MaybeOverOptimized4PlanCache(ctx.GetExprCtx(), inPred) {
+		return false
+	}
+	inList := inPred.(*expression.ScalarFunction)
+	for _, arg := range inList.GetArgs()[1:] {
+		con := arg.(*expression.Constant)
+		// `col IS NULL AND col IN (<all non-null consts>)` can never be true.
+		// Keep NULL or mutable items out of this shortcut so the simplification stays exact.
+		if con.Value.IsNull() {
+			return false
+		}
+	}
+	return true
+}
+
 func comparisonPred(predType predicateType) predicateType {
 	if predType == equalPredicate || predType == lessThanPredicate ||
 		predType == greaterThanPredicate || predType == lessThanOrEqualPredicate ||
+		predType == isNullPredicate ||
 		predType == greaterThanOrEqualPredicate {
 		return scalarPredicate
 	}
 	return predType
+}
+
+func prunableORBranchPredicate(predType predicateType) bool {
+	return comparisonPred(predType) == scalarPredicate || predType == inListPredicate
 }
 
 // updateOrPredicate simplifies OR predicates by dropping OR predicates if they are empty.
@@ -355,12 +402,12 @@ func updateOrPredicate(ctx base.PlanContext, orPredicateList expression.Expressi
 	emptyFirst := false
 	emptySecond := false
 	var isFirstConditionChanged, isSecondConditionChanged bool
-	if comparisonPred(firstConditionType) == scalarPredicate {
+	if prunableORBranchPredicate(firstConditionType) {
 		emptyFirst = unsatisfiable(ctx, firstCondition, scalarPredicatePtr)
 	} else if firstConditionType == orPredicate {
 		firstCondition, isFirstConditionChanged = updateOrPredicate(ctx, firstCondition, scalarPredicatePtr)
 	}
-	if comparisonPred(secondConditionType) == scalarPredicate {
+	if prunableORBranchPredicate(secondConditionType) {
 		emptySecond = unsatisfiable(ctx, secondCondition, scalarPredicatePtr)
 	} else if secondConditionType == orPredicate {
 		secondCondition, isSecondConditionChanged = updateOrPredicate(ctx, secondCondition, scalarPredicatePtr)

--- a/pkg/planner/core/tests/null/null_test.go
+++ b/pkg/planner/core/tests/null/null_test.go
@@ -33,6 +33,15 @@ func TestIssue54803(t *testing.T) {
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
     PARTITION BY HASH (col_68) PARTITIONS 5;
     `)
+	tk.MustQuery(`EXPLAIN format='plan_tree' SELECT col_68
+    FROM t1db47fc1
+    WHERE ISNULL(t1db47fc1.col_68)
+    GROUP BY t1db47fc1.col_68
+    HAVING ISNULL(t1db47fc1.col_68) OR t1db47fc1.col_68 IN (62, 200, 196, 99);
+    `).Check(testkit.Rows("HashAgg root  group by:test.t1db47fc1.col_68, funcs:firstrow(test.t1db47fc1.col_68)->test.t1db47fc1.col_68",
+		"└─TableReader root partition:p0 data:Selection",
+		"  └─Selection cop[tikv]  isnull(test.t1db47fc1.col_68)",
+		"    └─TableFullScan cop[tikv] table:t1db47fc1 keep order:false, stats:pseudo"))
 	tk.MustQuery(`EXPLAIN format='plan_tree' SELECT TRIM(t1db47fc1.col_68) AS r0
     FROM t1db47fc1
     WHERE ISNULL(t1db47fc1.col_68)
@@ -43,7 +52,7 @@ func TestIssue54803(t *testing.T) {
 		"└─Limit root  offset:0, count:106149535",
 		"  └─HashAgg root  group by:test.t1db47fc1.col_68, funcs:firstrow(test.t1db47fc1.col_68)->test.t1db47fc1.col_68",
 		"    └─TableReader root partition:p0 data:Selection",
-		"      └─Selection cop[tikv]  isnull(test.t1db47fc1.col_68), or(isnull(test.t1db47fc1.col_68), in(test.t1db47fc1.col_68, 62, 200, 196, 99))",
+		"      └─Selection cop[tikv]  isnull(test.t1db47fc1.col_68)",
 		"        └─TableFullScan cop[tikv] table:t1db47fc1 keep order:false, stats:pseudo"))
 	// Issue55299
 	tk.MustExec(`


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65048

Problem Summary:

`PredicateSimplification` did not prune impossible `IN` branches under an outer `ISNULL(col)` predicate.

For the reduced repro:

```sql
EXPLAIN format='plan_tree'
SELECT col_68
FROM t1db47fc1
WHERE ISNULL(col_68)
GROUP BY col_68
HAVING ISNULL(col_68) OR col_68 IN (62, 200, 196, 99);
```

the pushed-down cop `Selection` still kept the redundant condition:

```sql
isnull(col_68), or(isnull(col_68), in(col_68, ...))
```

even though `ISNULL(col_68)` and `IN(col_68, non-null constants...)` cannot both be true.

### What changed and how does it work?

- classify `ISNULL(column)` in `PredicateSimplification`
- teach the contradiction-pruning path the narrow case:
  - `ISNULL(col)` vs `IN(col, non-null constants...)`
- keep the old equality-based contradiction path restricted to real binary comparisons
- add regression coverage to `TestIssue54803` for the reduced single-table repro
- update the original issue query expectation so the pushed-down `Selection` keeps only `isnull(...)`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect plan behavior when a column is checked for IS NULL alongside IN lists of only non-NULL values; optimizer now avoids producing contradictory or redundant predicates.

* **Performance**
  * Improved plan simplification and OR-branch pruning for queries with NULL checks and IN operators, yielding cleaner and more efficient execution plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->