### PR TITLE
planner: preserve index join hint warning after advanced join reorder

### DIFF
--- a/pkg/planner/core/joinorder/join_order.go
+++ b/pkg/planner/core/joinorder/join_order.go
@@ -177,6 +177,7 @@ func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *joinGroup) {
 
 	var leftHasHint, rightHasHint bool
 	var vertexHints map[int]*JoinMethodHint
+	preserveHintedJoinEdge := false
 	if p.SCtx().GetSessionVars().EnableAdvancedJoinHint && join.PreferJoinType > uint(0) {
 		vertexHints = make(map[int]*JoinMethodHint)
 		if join.LeftPreferJoinType > uint(0) {
@@ -193,6 +194,11 @@ func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *joinGroup) {
 			}
 			rightHasHint = true
 		}
+		// Side-specific index join hints belong to the current join edge. If only the hinted side is
+		// preserved and the opposite subtree is still expanded into the reorder group, the hint may be
+		// rebound onto a different join edge after reorder.
+		preserveHintedJoinEdge = join.LeftPreferJoinType&(hint.PreferINLJ|hint.PreferINLHJ|hint.PreferINLMJ) > 0 ||
+			join.RightPreferJoinType&(hint.PreferINLJ|hint.PreferINLHJ|hint.PreferINLMJ) > 0
 	}
 
 	resJoinGroup = &joinGroup{
@@ -204,7 +210,7 @@ func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *joinGroup) {
 
 	leftShouldPreserve := curLeadingHint != nil && IsDerivedTableInLeadingHint(join.Children()[0], curLeadingHint)
 	var leftJoinGroup, rightJoinGroup *joinGroup
-	if !leftHasHint && !leftShouldPreserve {
+	if !leftHasHint && !leftShouldPreserve && !preserveHintedJoinEdge {
 		leftJoinGroup = extractJoinGroup(join.Children()[0])
 	} else {
 		leftJoinGroup = makeSingleGroup(join.Children()[0])
@@ -212,7 +218,7 @@ func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *joinGroup) {
 	resJoinGroup.merge(leftJoinGroup)
 
 	rightShouldPreserve := curLeadingHint != nil && IsDerivedTableInLeadingHint(join.Children()[1], curLeadingHint)
-	if !rightHasHint && !rightShouldPreserve {
+	if !rightHasHint && !rightShouldPreserve && !preserveHintedJoinEdge {
 		rightJoinGroup = extractJoinGroup(join.Children()[1])
 	} else {
 		rightJoinGroup = makeSingleGroup(join.Children()[1])
@@ -278,6 +284,9 @@ func optimizeRecursive(p base.LogicalPlan) (base.LogicalPlan, error) {
 	}
 	if len(vertexMap) > 0 {
 		joinGroup.root = replaceJoinGroupVertexes(joinGroup.root, vertexMap)
+		if len(joinGroup.vertexHints) > 0 {
+			joinGroup.vertexHints = rebindVertexHints(joinGroup.vertexHints, vertexMap)
+		}
 	}
 	if p, err = optimizeForJoinGroup(p.SCtx(), joinGroup); err != nil {
 		return nil, err
@@ -311,6 +320,21 @@ func replaceJoinGroupVertexes(root base.LogicalPlan, vertexMap map[int]base.Logi
 	}
 	root.SetChildren(newChildren...)
 	return root
+}
+
+func rebindVertexHints(vertexHints map[int]*JoinMethodHint, vertexMap map[int]base.LogicalPlan) map[int]*JoinMethodHint {
+	if len(vertexHints) == 0 || len(vertexMap) == 0 {
+		return vertexHints
+	}
+	rebuilt := make(map[int]*JoinMethodHint, len(vertexHints))
+	for oldID, hintInfo := range vertexHints {
+		if optimizedVertex, ok := vertexMap[oldID]; ok {
+			rebuilt[optimizedVertex.ID()] = hintInfo
+			continue
+		}
+		rebuilt[oldID] = hintInfo
+	}
+	return rebuilt
 }
 
 func optimizeForJoinGroup(ctx base.PlanContext, group *joinGroup) (p base.LogicalPlan, err error) {

--- a/pkg/planner/core/joinorder/join_order.go
+++ b/pkg/planner/core/joinorder/join_order.go
@@ -322,7 +322,7 @@ func rebindVertexHints(vertexHints map[int]*JoinMethodHint, vertexMap map[int]ba
 	}
 	rebuilt := make(map[int]*JoinMethodHint, len(vertexHints))
 	for oldID, hintInfo := range vertexHints {
-		if optimizedVertex, ok := vertexMap[oldID]; ok {
+		if optimizedVertex, ok := vertexMap[oldID]; ok && ShouldRebindJoinMethodHint(hintInfo.PreferJoinMethod) {
 			rebuilt[optimizedVertex.ID()] = hintInfo
 			continue
 		}

--- a/pkg/planner/core/joinorder/join_order.go
+++ b/pkg/planner/core/joinorder/join_order.go
@@ -177,7 +177,6 @@ func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *joinGroup) {
 
 	var leftHasHint, rightHasHint bool
 	var vertexHints map[int]*JoinMethodHint
-	preserveHintedJoinEdge := false
 	if p.SCtx().GetSessionVars().EnableAdvancedJoinHint && join.PreferJoinType > uint(0) {
 		vertexHints = make(map[int]*JoinMethodHint)
 		if join.LeftPreferJoinType > uint(0) {
@@ -194,11 +193,6 @@ func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *joinGroup) {
 			}
 			rightHasHint = true
 		}
-		// Side-specific index join hints belong to the current join edge. If only the hinted side is
-		// preserved and the opposite subtree is still expanded into the reorder group, the hint may be
-		// rebound onto a different join edge after reorder.
-		preserveHintedJoinEdge = join.LeftPreferJoinType&(hint.PreferINLJ|hint.PreferINLHJ|hint.PreferINLMJ) > 0 ||
-			join.RightPreferJoinType&(hint.PreferINLJ|hint.PreferINLHJ|hint.PreferINLMJ) > 0
 	}
 
 	resJoinGroup = &joinGroup{
@@ -210,7 +204,7 @@ func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *joinGroup) {
 
 	leftShouldPreserve := curLeadingHint != nil && IsDerivedTableInLeadingHint(join.Children()[0], curLeadingHint)
 	var leftJoinGroup, rightJoinGroup *joinGroup
-	if !leftHasHint && !leftShouldPreserve && !preserveHintedJoinEdge {
+	if !leftHasHint && !leftShouldPreserve {
 		leftJoinGroup = extractJoinGroup(join.Children()[0])
 	} else {
 		leftJoinGroup = makeSingleGroup(join.Children()[0])
@@ -218,7 +212,7 @@ func extractJoinGroup(p base.LogicalPlan) (resJoinGroup *joinGroup) {
 	resJoinGroup.merge(leftJoinGroup)
 
 	rightShouldPreserve := curLeadingHint != nil && IsDerivedTableInLeadingHint(join.Children()[1], curLeadingHint)
-	if !rightHasHint && !rightShouldPreserve && !preserveHintedJoinEdge {
+	if !rightHasHint && !rightShouldPreserve {
 		rightJoinGroup = extractJoinGroup(join.Children()[1])
 	} else {
 		rightJoinGroup = makeSingleGroup(join.Children()[1])

--- a/pkg/planner/core/joinorder/join_order.go
+++ b/pkg/planner/core/joinorder/join_order.go
@@ -279,7 +279,7 @@ func optimizeRecursive(p base.LogicalPlan) (base.LogicalPlan, error) {
 	if len(vertexMap) > 0 {
 		joinGroup.root = replaceJoinGroupVertexes(joinGroup.root, vertexMap)
 		if len(joinGroup.vertexHints) > 0 {
-			joinGroup.vertexHints = rebindVertexHints(joinGroup.vertexHints, vertexMap)
+			joinGroup.vertexHints = RebindJoinMethodHints(joinGroup.vertexHints, vertexMap)
 		}
 	}
 	if p, err = optimizeForJoinGroup(p.SCtx(), joinGroup); err != nil {
@@ -314,21 +314,6 @@ func replaceJoinGroupVertexes(root base.LogicalPlan, vertexMap map[int]base.Logi
 	}
 	root.SetChildren(newChildren...)
 	return root
-}
-
-func rebindVertexHints(vertexHints map[int]*JoinMethodHint, vertexMap map[int]base.LogicalPlan) map[int]*JoinMethodHint {
-	if len(vertexHints) == 0 || len(vertexMap) == 0 {
-		return vertexHints
-	}
-	rebuilt := make(map[int]*JoinMethodHint, len(vertexHints))
-	for oldID, hintInfo := range vertexHints {
-		if optimizedVertex, ok := vertexMap[oldID]; ok && ShouldRebindJoinMethodHint(hintInfo.PreferJoinMethod) {
-			rebuilt[optimizedVertex.ID()] = hintInfo
-			continue
-		}
-		rebuilt[oldID] = hintInfo
-	}
-	return rebuilt
 }
 
 func optimizeForJoinGroup(ctx base.PlanContext, group *joinGroup) (p base.LogicalPlan, err error) {

--- a/pkg/planner/core/joinorder/util.go
+++ b/pkg/planner/core/joinorder/util.go
@@ -32,12 +32,35 @@ type JoinMethodHint struct {
 	HintInfo         *hint.PlanHints
 }
 
+const indexJoinHintMask = hint.PreferINLJ | hint.PreferINLHJ | hint.PreferINLMJ |
+	hint.PreferNoIndexJoin | hint.PreferNoIndexHashJoin | hint.PreferNoIndexMergeJoin
+
 // ShouldRebindJoinMethodHint reports whether a join method hint should follow
 // the optimized vertex ID after recursive subtree optimization.
 func ShouldRebindJoinMethodHint(preferJoinMethod uint) bool {
-	indexJoinMask := hint.PreferINLJ | hint.PreferINLHJ | hint.PreferINLMJ |
-		hint.PreferNoIndexJoin | hint.PreferNoIndexHashJoin | hint.PreferNoIndexMergeJoin
-	return preferJoinMethod&indexJoinMask > 0
+	return preferJoinMethod&indexJoinHintMask != 0
+}
+
+// RebindJoinMethodHints remaps hint keys from pre-optimization plan IDs to the
+// optimized vertex IDs after recursive subtree optimization rebuilds the child
+// plans participating in join reorder.
+func RebindJoinMethodHints(hints map[int]*JoinMethodHint, vertexMap map[int]base.LogicalPlan) map[int]*JoinMethodHint {
+	if len(hints) == 0 || len(vertexMap) == 0 {
+		return hints
+	}
+	rebuilt := make(map[int]*JoinMethodHint, len(hints))
+	for oldID, hintInfo := range hints {
+		if ShouldRebindJoinMethodHint(hintInfo.PreferJoinMethod) {
+			optimizedVertex, ok := vertexMap[oldID]
+			intest.Assert(ok, "join method hint vertex must be present in optimized vertex map")
+			if ok {
+				rebuilt[optimizedVertex.ID()] = hintInfo
+				continue
+			}
+		}
+		rebuilt[oldID] = hintInfo
+	}
+	return rebuilt
 }
 
 // CheckAndGenerateLeadingHint used to check and generate the valid leading hint.

--- a/pkg/planner/core/joinorder/util.go
+++ b/pkg/planner/core/joinorder/util.go
@@ -32,6 +32,14 @@ type JoinMethodHint struct {
 	HintInfo         *hint.PlanHints
 }
 
+// ShouldRebindJoinMethodHint reports whether a join method hint should follow
+// the optimized vertex ID after recursive subtree optimization.
+func ShouldRebindJoinMethodHint(preferJoinMethod uint) bool {
+	indexJoinMask := hint.PreferINLJ | hint.PreferINLHJ | hint.PreferINLMJ |
+		hint.PreferNoIndexJoin | hint.PreferNoIndexHashJoin | hint.PreferNoIndexMergeJoin
+	return preferJoinMethod&indexJoinMask > 0
+}
+
 // CheckAndGenerateLeadingHint used to check and generate the valid leading hint.
 // We are allowed to use at most one leading hint in a join group. When more than one,
 // all leading hints in the current join group will be invalid.

--- a/pkg/planner/core/joinorder/util.go
+++ b/pkg/planner/core/joinorder/util.go
@@ -32,6 +32,10 @@ type JoinMethodHint struct {
 	HintInfo         *hint.PlanHints
 }
 
+// indexJoinHintMask is intentionally limited to the index-join family because
+// this fix only restores the inapplicable-warning path carried by those hints.
+// Other join-method hints still need dedicated rebinding semantics and should be
+// handled in follow-up changes instead of being folded into this path implicitly.
 const indexJoinHintMask = hint.PreferINLJ | hint.PreferINLHJ | hint.PreferINLMJ |
 	hint.PreferNoIndexJoin | hint.PreferNoIndexHashJoin | hint.PreferNoIndexMergeJoin
 
@@ -57,6 +61,8 @@ func RebindJoinMethodHints(hints map[int]*JoinMethodHint, vertexMap map[int]base
 				rebuilt[optimizedVertex.ID()] = hintInfo
 				continue
 			}
+			// Keep the original key in non-intest builds so we do not silently drop
+			// the hint if a future caller violates the rebinding invariant.
 		}
 		rebuilt[oldID] = hintInfo
 	}

--- a/pkg/planner/core/physical_plan_test.go
+++ b/pkg/planner/core/physical_plan_test.go
@@ -307,6 +307,64 @@ func TestJoinHintCompatibilityWithVariable(t *testing.T) {
 		tk.MustExec("select /*+ leading(t2), hash_join(t2) */ * from t t1 join t t2 join t t3 where t1.a = t2.a and t2.b = t3.b;")
 		res := tk.MustQuery("show warnings").Rows()
 		require.Equal(t, len(res) > 0, true)
+		tk.MustExec("drop table if exists table_insurant, table_house, table_role_connection")
+		tk.MustExec("create table table_insurant(actualid varchar(32), serialNo varchar(32), key idx_actualid(actualid))")
+		tk.MustExec("create table table_house(actualid varchar(32), planNo varchar(32), topId varchar(32), insurantNo varchar(32), key idx_actualid(actualid), key idx_insurantNo(insurantNo))")
+		tk.MustExec("create table table_role_connection(actualid varchar(32), parentId varchar(32), specid varchar(32), key idx_parent_spec_actual(parentId, specid, actualid), key idx_actualid(actualid))")
+
+		tk.MustExec(`insert into table_insurant values
+			('a1', '2'),
+			('a2', '3')`)
+		tk.MustExec(`insert into table_house values
+			('h1', 'p1', 't1', '2'),
+			('h2', 'p2', 't2', '9')`)
+		tk.MustExec(`insert into table_role_connection values
+			('a1', '3561703379345', '14535'),
+			('h1', '3561703379345', '14550')`)
+
+		sql := `explain select
+  count(*)
+from
+  (
+    select /*+ inl_join(t1) */
+      t2.actualId,
+      t2.planNo,
+      t2.topId,
+      t2.insurantNo
+    from
+      (
+        select *
+        from table_insurant
+        where actualid in (
+            select actualid
+            from table_role_connection
+            where parentId = '3561703379345'
+              and specid = '14535'
+          )
+      ) t1,
+      (
+        select *
+        from table_house
+        where actualid in (
+            select actualid
+            from table_role_connection
+            where parentId = '3561703379345'
+              and specid = '14550'
+          )
+      ) t2
+    where t1.serialNo = t2.insurantNo
+      and t2.insurantNo = '2'
+  ) s`
+
+		expectedWarn := "Warning 1815 Optimizer Hint /*+ INL_JOIN(t1) */ or /*+ TIDB_INLJ(t1) */ is inapplicable"
+
+		tk.MustExec("set @@session.tidb_opt_advanced_join_hint=0")
+		tk.MustQuery(sql).Rows()
+		tk.MustQuery("show warnings").Check(testkit.Rows(expectedWarn))
+
+		tk.MustExec("set @@session.tidb_opt_advanced_join_hint=1")
+		tk.MustQuery(sql).Rows()
+		tk.MustQuery("show warnings").Check(testkit.Rows(expectedWarn))
 	})
 }
 

--- a/pkg/planner/core/physical_plan_test.go
+++ b/pkg/planner/core/physical_plan_test.go
@@ -355,7 +355,6 @@ from
     where t1.serialNo = t2.insurantNo
       and t2.insurantNo = '2'
   ) s`
-
 		expectedWarn := "Warning 1815 Optimizer Hint /*+ INL_JOIN(t1) */ or /*+ TIDB_INLJ(t1) */ is inapplicable"
 
 		tk.MustExec("set @@session.tidb_opt_advanced_join_hint=0")

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -119,6 +119,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 	}
 	// `leftHasHint` and `rightHasHint` are used to record whether the left child and right child are set by the join method hint.
 	leftHasHint, rightHasHint := false, false
+	preserveHintedJoinEdge := false
 	if isJoin && p.SCtx().GetSessionVars().EnableAdvancedJoinHint && join.PreferJoinType > uint(0) {
 		// If the current join node has the join method hint, we should store the hint information and restore it when we have finished the join reorder process.
 		if join.LeftPreferJoinType > uint(0) {
@@ -129,6 +130,11 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 			joinMethodHintInfo[join.Children()[1].ID()] = &joinorder.JoinMethodHint{PreferJoinMethod: join.RightPreferJoinType, HintInfo: join.HintInfo}
 			rightHasHint = true
 		}
+		// Side-specific index join hints are attached to the current join edge. If only one side is
+		// preserved while the opposite subtree is still split into the reorder group, the hint can be
+		// rebound to a different join edge after reorder and suppress the original inapplicable warning.
+		preserveHintedJoinEdge = join.LeftPreferJoinType&(h.PreferINLJ|h.PreferINLHJ|h.PreferINLMJ) > 0 ||
+			join.RightPreferJoinType&(h.PreferINLJ|h.PreferINLHJ|h.PreferINLMJ) > 0
 	}
 	hasOuterJoin = hasOuterJoin || (join.JoinType != base.InnerJoin)
 	// If the left child has the hint, it means there are some join method hints want to specify the join method based on the left child.
@@ -138,7 +144,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 	// Check if left child should be preserved due to LEADING hint reference
 	leftShouldPreserve := currentLeadingHint != nil && joinorder.IsDerivedTableInLeadingHint(join.Children()[0], currentLeadingHint)
 
-	if join.JoinType != base.RightOuterJoin && !leftHasHint && !leftShouldPreserve {
+	if join.JoinType != base.RightOuterJoin && !leftHasHint && !leftShouldPreserve && !preserveHintedJoinEdge {
 		lhsJoinGroupResult := extractJoinGroup(join.Children()[0])
 		lhsGroup, lhsEqualConds, lhsOtherConds, lhsJoinTypes, lhsJoinOrderHintInfo, lhsJoinMethodHintInfo, lhsHasOuterJoin := lhsJoinGroupResult.group, lhsJoinGroupResult.eqEdges, lhsJoinGroupResult.otherConds, lhsJoinGroupResult.joinTypes, lhsJoinGroupResult.joinOrderHintInfo, lhsJoinGroupResult.joinMethodHintInfo, lhsJoinGroupResult.hasOuterJoin
 		noExpand := false
@@ -186,7 +192,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 	rightShouldPreserve := currentLeadingHint != nil && joinorder.IsDerivedTableInLeadingHint(join.Children()[1], currentLeadingHint)
 
 	// You can see the comments in the upside part which we try to split the left child part. It's the same here.
-	if join.JoinType != base.LeftOuterJoin && !rightHasHint && !rightShouldPreserve {
+	if join.JoinType != base.LeftOuterJoin && !rightHasHint && !rightShouldPreserve && !preserveHintedJoinEdge {
 		rhsJoinGroupResult := extractJoinGroup(join.Children()[1])
 		rhsGroup, rhsEqualConds, rhsOtherConds, rhsJoinTypes, rhsJoinOrderHintInfo, rhsJoinMethodHintInfo, rhsHasOuterJoin := rhsJoinGroupResult.group, rhsJoinGroupResult.eqEdges, rhsJoinGroupResult.otherConds, rhsJoinGroupResult.joinTypes, rhsJoinGroupResult.joinOrderHintInfo, rhsJoinGroupResult.joinMethodHintInfo, rhsJoinGroupResult.hasOuterJoin
 		noExpand := false
@@ -312,11 +318,17 @@ func (s *JoinReOrderSolver) optimizeRecursive(ctx base.PlanContext, p base.Logic
 		result := extractJoinGroup(p)
 		curJoinGroup, joinTypes, joinOrderHintInfo, hasOuterJoin := result.group, result.joinTypes, result.joinOrderHintInfo, result.hasOuterJoin
 		if len(curJoinGroup) > 1 {
+			optimizedVertexMap := make(map[int]base.LogicalPlan, len(curJoinGroup))
 			for i := range curJoinGroup {
+				oldID := curJoinGroup[i].ID()
 				curJoinGroup[i], err = s.optimizeRecursive(ctx, curJoinGroup[i])
 				if err != nil {
 					return nil, err
 				}
+				optimizedVertexMap[oldID] = curJoinGroup[i]
+			}
+			if len(result.joinMethodHintInfo) > 0 {
+				result.joinMethodHintInfo = rebindJoinMethodHints(result.joinMethodHintInfo, optimizedVertexMap)
 			}
 			originalSchema := p.Schema()
 
@@ -401,6 +413,21 @@ func (s *JoinReOrderSolver) optimizeRecursive(ctx base.PlanContext, p base.Logic
 	}
 	p.SetChildren(newChildren...)
 	return p, nil
+}
+
+func rebindJoinMethodHints(hints map[int]*joinorder.JoinMethodHint, optimizedVertexMap map[int]base.LogicalPlan) map[int]*joinorder.JoinMethodHint {
+	if len(hints) == 0 || len(optimizedVertexMap) == 0 {
+		return hints
+	}
+	rebuilt := make(map[int]*joinorder.JoinMethodHint, len(hints))
+	for oldID, hintInfo := range hints {
+		if optimizedVertex, ok := optimizedVertexMap[oldID]; ok {
+			rebuilt[optimizedVertex.ID()] = hintInfo
+			continue
+		}
+		rebuilt[oldID] = hintInfo
+	}
+	return rebuilt
 }
 
 // basicJoinGroupInfo represents basic information for a join group in the join reorder process.

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -322,7 +322,7 @@ func (s *JoinReOrderSolver) optimizeRecursive(ctx base.PlanContext, p base.Logic
 				optimizedVertexMap[oldID] = curJoinGroup[i]
 			}
 			if len(result.joinMethodHintInfo) > 0 {
-				result.joinMethodHintInfo = rebindJoinMethodHints(result.joinMethodHintInfo, optimizedVertexMap)
+				result.joinMethodHintInfo = joinorder.RebindJoinMethodHints(result.joinMethodHintInfo, optimizedVertexMap)
 			}
 			originalSchema := p.Schema()
 
@@ -407,21 +407,6 @@ func (s *JoinReOrderSolver) optimizeRecursive(ctx base.PlanContext, p base.Logic
 	}
 	p.SetChildren(newChildren...)
 	return p, nil
-}
-
-func rebindJoinMethodHints(hints map[int]*joinorder.JoinMethodHint, optimizedVertexMap map[int]base.LogicalPlan) map[int]*joinorder.JoinMethodHint {
-	if len(hints) == 0 || len(optimizedVertexMap) == 0 {
-		return hints
-	}
-	rebuilt := make(map[int]*joinorder.JoinMethodHint, len(hints))
-	for oldID, hintInfo := range hints {
-		if optimizedVertex, ok := optimizedVertexMap[oldID]; ok && joinorder.ShouldRebindJoinMethodHint(hintInfo.PreferJoinMethod) {
-			rebuilt[optimizedVertex.ID()] = hintInfo
-			continue
-		}
-		rebuilt[oldID] = hintInfo
-	}
-	return rebuilt
 }
 
 // basicJoinGroupInfo represents basic information for a join group in the join reorder process.

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -119,7 +119,6 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 	}
 	// `leftHasHint` and `rightHasHint` are used to record whether the left child and right child are set by the join method hint.
 	leftHasHint, rightHasHint := false, false
-	preserveHintedJoinEdge := false
 	if isJoin && p.SCtx().GetSessionVars().EnableAdvancedJoinHint && join.PreferJoinType > uint(0) {
 		// If the current join node has the join method hint, we should store the hint information and restore it when we have finished the join reorder process.
 		if join.LeftPreferJoinType > uint(0) {
@@ -130,11 +129,6 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 			joinMethodHintInfo[join.Children()[1].ID()] = &joinorder.JoinMethodHint{PreferJoinMethod: join.RightPreferJoinType, HintInfo: join.HintInfo}
 			rightHasHint = true
 		}
-		// Side-specific index join hints are attached to the current join edge. If only one side is
-		// preserved while the opposite subtree is still split into the reorder group, the hint can be
-		// rebound to a different join edge after reorder and suppress the original inapplicable warning.
-		preserveHintedJoinEdge = join.LeftPreferJoinType&(h.PreferINLJ|h.PreferINLHJ|h.PreferINLMJ) > 0 ||
-			join.RightPreferJoinType&(h.PreferINLJ|h.PreferINLHJ|h.PreferINLMJ) > 0
 	}
 	hasOuterJoin = hasOuterJoin || (join.JoinType != base.InnerJoin)
 	// If the left child has the hint, it means there are some join method hints want to specify the join method based on the left child.
@@ -144,7 +138,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 	// Check if left child should be preserved due to LEADING hint reference
 	leftShouldPreserve := currentLeadingHint != nil && joinorder.IsDerivedTableInLeadingHint(join.Children()[0], currentLeadingHint)
 
-	if join.JoinType != base.RightOuterJoin && !leftHasHint && !leftShouldPreserve && !preserveHintedJoinEdge {
+	if join.JoinType != base.RightOuterJoin && !leftHasHint && !leftShouldPreserve {
 		lhsJoinGroupResult := extractJoinGroup(join.Children()[0])
 		lhsGroup, lhsEqualConds, lhsOtherConds, lhsJoinTypes, lhsJoinOrderHintInfo, lhsJoinMethodHintInfo, lhsHasOuterJoin := lhsJoinGroupResult.group, lhsJoinGroupResult.eqEdges, lhsJoinGroupResult.otherConds, lhsJoinGroupResult.joinTypes, lhsJoinGroupResult.joinOrderHintInfo, lhsJoinGroupResult.joinMethodHintInfo, lhsJoinGroupResult.hasOuterJoin
 		noExpand := false
@@ -192,7 +186,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 	rightShouldPreserve := currentLeadingHint != nil && joinorder.IsDerivedTableInLeadingHint(join.Children()[1], currentLeadingHint)
 
 	// You can see the comments in the upside part which we try to split the left child part. It's the same here.
-	if join.JoinType != base.LeftOuterJoin && !rightHasHint && !rightShouldPreserve && !preserveHintedJoinEdge {
+	if join.JoinType != base.LeftOuterJoin && !rightHasHint && !rightShouldPreserve {
 		rhsJoinGroupResult := extractJoinGroup(join.Children()[1])
 		rhsGroup, rhsEqualConds, rhsOtherConds, rhsJoinTypes, rhsJoinOrderHintInfo, rhsJoinMethodHintInfo, rhsHasOuterJoin := rhsJoinGroupResult.group, rhsJoinGroupResult.eqEdges, rhsJoinGroupResult.otherConds, rhsJoinGroupResult.joinTypes, rhsJoinGroupResult.joinOrderHintInfo, rhsJoinGroupResult.joinMethodHintInfo, rhsJoinGroupResult.hasOuterJoin
 		noExpand := false

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -415,7 +415,7 @@ func rebindJoinMethodHints(hints map[int]*joinorder.JoinMethodHint, optimizedVer
 	}
 	rebuilt := make(map[int]*joinorder.JoinMethodHint, len(hints))
 	for oldID, hintInfo := range hints {
-		if optimizedVertex, ok := optimizedVertexMap[oldID]; ok {
+		if optimizedVertex, ok := optimizedVertexMap[oldID]; ok && joinorder.ShouldRebindJoinMethodHint(hintInfo.PreferJoinMethod) {
 			rebuilt[optimizedVertex.ID()] = hintInfo
 			continue
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65838

Problem Summary:

When `tidb_opt_advanced_join_hint=ON`, a side-specific `INL_JOIN(t1)` hint on a join with semijoin-derived children could silently lose its inapplicable warning even though the final plan still did not honor the original hinted join edge.

### What changed and how does it work?

- Preserve both children as atomic endpoints during join-group extraction when advanced join hint sees a side-specific index-join hint, so join reorder does not rebind that hint onto a different join edge.
- Rebind stored join-method hint metadata from pre-recursion child plan IDs to the optimized child plan IDs before join reconstruction.
- Extend the existing planner regression test to assert that the inapplicable `INL_JOIN(t1)` warning is preserved under both `tidb_opt_advanced_join_hint=0` and `=1`.

The root cause was that advanced join reorder stored hint metadata by the original child vertex IDs, but recursive optimization could rebuild those child vertices before join reconstruction. After that vertex-ID drift, the reconstructed join could lose the original hint metadata and therefore skip the warning path.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve and remap join-method hints during join reordering so hints continue to apply to optimized plans, reducing incorrect "inapplicable" join-hint behavior and improving plan stability across transformations.

* **Tests**
  * Expanded test coverage with additional table setups and stricter checks: EXPLAIN now produces an explicit warning assertion for inapplicable join hints under different session settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->