### PR TITLE
planner: fix ANALYZE TABLE panic on stored generated column with index

### DIFF
--- a/pkg/executor/analyze_col_sampling.go
+++ b/pkg/executor/analyze_col_sampling.go
@@ -399,17 +399,7 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 	}
 
 	// Generate tasks for building stats for indexes.
-	// Skip special indexes (virtual/stored generated columns or prefix columns): their
-	// FMSketch and NullCount have already been set from the NDV pushdown above, and
-	// their histogram will be a zero-bucket histogram derived from the NDV count.
-	isSpecialIndex := make([]bool, len(e.indexes))
-	for _, offset := range indexesWithVirtualColOffsets {
-		isSpecialIndex[offset] = true
-	}
 	for i, idx := range e.indexes {
-		if isSpecialIndex[i] {
-			continue
-		}
 		buildTaskChan <- &samplingBuildTask{
 			id:               idx.ID,
 			rootRowCollector: rootRowCollector,
@@ -812,7 +802,7 @@ workLoop:
 						consumeBuffered(deltaSize)
 					}
 					sampleItems = append(sampleItems, &statistics.SampleItem{
-						Value:   &val,
+						Value:   val,
 						Ordinal: j,
 					})
 				}
@@ -826,15 +816,30 @@ workLoop:
 					MemSize:   collectorMemSize,
 				}
 			} else {
+				idx := e.indexes[task.slicePos-colLen]
+				// Check if any column has invalid offset.
+				// If so, we cannot build histogram from sampled rows because the column value
+				// is not available in the sample (e.g., stored generated column not in e.colsInfo).
+				hasInvalidOffset := false
+				for _, col := range idx.Columns {
+					if col.Offset < 0 || col.Offset >= len(e.colsInfo) {
+						hasInvalidOffset = true
+						break
+					}
+				}
+				if hasInvalidOffset {
+					hists[task.slicePos] = nil
+					topns[task.slicePos] = nil
+					continue
+				}
 				var tmpDatum types.Datum
 				var err error
-				idx := e.indexes[task.slicePos-colLen]
 				sampleNum := task.rootRowCollector.Base().Samples.Len()
 				sampleItems := make([]*statistics.SampleItem, 0, sampleNum)
 				// consume mandatory memory at the beginning, including all SampleItems, if exceeds, fast fail
 				// 8 is size of reference, 8 is the size of "b := make([]byte, 0, 8)"
-				// types.EmptyDatumSize: same meaning as above branch.
-				collectorMemSize := int64(sampleNum) * (8 + statistics.EmptySampleItemSize + 8 + types.EmptyDatumSize)
+				// statistics.EmptySampleItemSize already accounts for the embedded types.Datum in SampleItem.Value.
+				collectorMemSize := int64(sampleNum) * (8 + statistics.EmptySampleItemSize + 8)
 				e.memTracker.Consume(collectorMemSize)
 				errCtx := e.ctx.GetSessionVars().StmtCtx.ErrCtx()
 			indexSampleCollectLoop:
@@ -871,9 +876,8 @@ workLoop:
 						// here we need to account the remaining bytes.
 						consumeBuffered(int64(cap(b) - 8))
 					}
-					tmp := types.NewBytesDatum(b)
 					sampleItems = append(sampleItems, &statistics.SampleItem{
-						Value: &tmp,
+						Value: types.NewBytesDatum(b),
 					})
 				}
 				flushBuffered(&collectorMemSize)

--- a/pkg/executor/analyze_col_sampling.go
+++ b/pkg/executor/analyze_col_sampling.go
@@ -71,9 +71,18 @@ func (e *AnalyzeColumnsExec) analyzeColumnsPushDown(ctx context.Context, gp *gp.
 	for i, idx := range e.indexes {
 		isSpecial := false
 		for _, col := range idx.Columns {
+			// col.Offset can be -1 or out of bounds when the column is not in e.colsInfo
+			// (e.g., a stored generated column that was not included in the analyze column list).
+			if col.Offset < 0 || col.Offset >= len(e.colsInfo) {
+				isSpecial = true
+				break
+			}
 			colInfo := e.colsInfo[col.Offset]
 			isPrefixCol := col.Length != types.UnspecifiedLength
-			if colInfo.IsVirtualGenerated() || isPrefixCol {
+			// Stored generated columns are not in e.colsInfo when they are indexed but not
+			// in the analyze column list. Virtual generated columns and prefix columns also
+			// need special handling because their values cannot be derived from sampled rows.
+			if colInfo.IsVirtualGenerated() || colInfo.GeneratedStored || isPrefixCol {
 				isSpecial = true
 				break
 			}
@@ -217,9 +226,13 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 		}
 	}()
 
-	totalLen := len(e.analyzePB.ColReq.ColumnsInfo) + len(e.analyzePB.ColReq.ColumnGroups)
-	rootRowCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), totalLen)
-	for range totalLen {
+	// l is the total number of columns + indexes for the collector's arrays (NullCount, FMSketches).
+	// It must be len(e.colsInfo) + len(e.indexes) so that NullCount has enough space for
+	// all indexes. Previously this used len(ColsInfo)+len(ColGroups), but ColGroups only
+	// contains non-special indexes, causing an out-of-bounds access when NullCount was too short.
+	l := len(e.colsInfo) + len(e.indexes)
+	rootRowCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), l)
+	for range l {
 		rootRowCollector.Base().FMSketches = append(rootRowCollector.Base().FMSketches, statistics.NewFMSketch(statistics.MaxSketchSize))
 	}
 
@@ -251,7 +264,7 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 	for i := range samplingStatsConcurrency {
 		id := i
 		gp.Go(func() {
-			e.subMergeWorker(mergeCtx, taskCancel, mergeResultCh, mergeTaskCh, totalLen, id)
+			e.subMergeWorker(mergeCtx, taskCancel, mergeResultCh, mergeTaskCh, l, id)
 		})
 	}
 	// Merge the result from collectors.
@@ -342,6 +355,7 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 		return i.Handle.Compare(j.Handle)
 	})
 
+	totalLen := len(e.colsInfo) + len(e.indexes)
 	hists = make([]*statistics.Histogram, totalLen)
 	topns = make([]*statistics.TopN, totalLen)
 	fmSketches = make([]*statistics.FMSketch, 0, totalLen)
@@ -385,7 +399,17 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 	}
 
 	// Generate tasks for building stats for indexes.
+	// Skip special indexes (virtual/stored generated columns or prefix columns): their
+	// FMSketch and NullCount have already been set from the NDV pushdown above, and
+	// their histogram will be a zero-bucket histogram derived from the NDV count.
+	isSpecialIndex := make([]bool, len(e.indexes))
+	for _, offset := range indexesWithVirtualColOffsets {
+		isSpecialIndex[offset] = true
+	}
 	for i, idx := range e.indexes {
+		if isSpecialIndex[i] {
+			continue
+		}
 		buildTaskChan <- &samplingBuildTask{
 			id:               idx.ID,
 			rootRowCollector: rootRowCollector,
@@ -430,7 +454,7 @@ func (e *AnalyzeColumnsExec) handleNDVForSpecialIndexes(ctx context.Context, ind
 			}
 		}
 	}()
-	tasks := e.buildSubIndexJobForSpecialIndex(ctx, indexInfos)
+	tasks := e.buildSubIndexJobForSpecialIndex(indexInfos)
 	taskCh := make(chan *analyzeTask, len(tasks))
 	pendingJobs := make(map[uint64]*statistics.AnalyzeJob, len(tasks))
 	for _, task := range tasks {
@@ -532,11 +556,11 @@ func (e *AnalyzeColumnsExec) subIndexWorkerForNDV(ctx context.Context, taskCh ch
 
 // buildSubIndexJobForSpecialIndex builds sub index pushed down task to calculate the NDV information for indexes containing virtual column.
 // This is because we cannot push the calculation of the virtual column down to the tikv side.
-func (e *AnalyzeColumnsExec) buildSubIndexJobForSpecialIndex(ctx context.Context, indexInfos []*model.IndexInfo) []*analyzeTask {
+func (e *AnalyzeColumnsExec) buildSubIndexJobForSpecialIndex(indexInfos []*model.IndexInfo) []*analyzeTask {
 	_, offset := timeutil.Zone(e.ctx.GetSessionVars().Location())
 	tasks := make([]*analyzeTask, 0, len(indexInfos))
 	sc := e.ctx.GetSessionVars().StmtCtx
-	concurrency := adaptiveAnlayzeDistSQLConcurrency(ctx, e.ctx)
+	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), e.ctx)
 	for _, indexInfo := range indexInfos {
 		base := baseAnalyzeExec{
 			ctx:         e.ctx,
@@ -601,7 +625,7 @@ func (e *AnalyzeColumnsExec) subMergeWorker(
 	cancel context.CancelCauseFunc,
 	resultCh chan<- *samplingMergeResult,
 	taskCh <-chan []byte,
-	totalLen int,
+	l int,
 	index int,
 ) {
 	// Only close the resultCh in the first worker.
@@ -639,8 +663,8 @@ func (e *AnalyzeColumnsExec) subMergeWorker(
 		}
 	})
 	// Keep one private collector per merge worker and flush it when taskCh is closed.
-	retCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), totalLen)
-	for range totalLen {
+	retCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), l)
+	for range l {
 		retCollector.Base().FMSketches = append(retCollector.Base().FMSketches, statistics.NewFMSketch(statistics.MaxSketchSize))
 	}
 	// Early-return paths need to release the worker-local collector explicitly.
@@ -670,7 +694,7 @@ func (e *AnalyzeColumnsExec) subMergeWorker(
 			inflightRespSize = int64(colResp.Size())
 			e.memTracker.Consume(inflightRespSize)
 
-			subCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), totalLen)
+			subCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), l)
 			subCollector.Base().FromProto(colResp.RowCollector, e.memTracker)
 			statsHandle.UpdateAnalyzeJobProgress(e.job, subCollector.Base().Count)
 
@@ -761,9 +785,9 @@ workLoop:
 				sampleItems := make([]*statistics.SampleItem, 0, sampleNum)
 				// consume mandatory memory at the beginning, including empty SampleItems of all sample rows, if exceeds, fast fail
 				// 8 means the pointer size of sampleItems slice.
-				// statistics.EmptySampleItemSize already accounts for the embedded types.Datum in SampleItem.Value.
+				// types.EmptyDatumSize means the empty datum size we shallow copied from row.Columns to SampleItem.Value.
 				// The real underlying byte slice of Datum in row.Columns has already be accounted FromProto().
-				collectorMemSize := int64(sampleNum) * (8 + statistics.EmptySampleItemSize)
+				collectorMemSize := int64(sampleNum) * (8 + statistics.EmptySampleItemSize + types.EmptyDatumSize)
 				e.memTracker.Consume(collectorMemSize)
 				var collator collate.Collator
 				ft := e.colsInfo[task.slicePos].FieldType
@@ -788,7 +812,7 @@ workLoop:
 						consumeBuffered(deltaSize)
 					}
 					sampleItems = append(sampleItems, &statistics.SampleItem{
-						Value:   val,
+						Value:   &val,
 						Ordinal: j,
 					})
 				}
@@ -809,8 +833,8 @@ workLoop:
 				sampleItems := make([]*statistics.SampleItem, 0, sampleNum)
 				// consume mandatory memory at the beginning, including all SampleItems, if exceeds, fast fail
 				// 8 is size of reference, 8 is the size of "b := make([]byte, 0, 8)"
-				// statistics.EmptySampleItemSize already accounts for the embedded types.Datum in SampleItem.Value.
-				collectorMemSize := int64(sampleNum) * (8 + statistics.EmptySampleItemSize + 8)
+				// types.EmptyDatumSize: same meaning as above branch.
+				collectorMemSize := int64(sampleNum) * (8 + statistics.EmptySampleItemSize + 8 + types.EmptyDatumSize)
 				e.memTracker.Consume(collectorMemSize)
 				errCtx := e.ctx.GetSessionVars().StmtCtx.ErrCtx()
 			indexSampleCollectLoop:
@@ -847,8 +871,9 @@ workLoop:
 						// here we need to account the remaining bytes.
 						consumeBuffered(int64(cap(b) - 8))
 					}
+					tmp := types.NewBytesDatum(b)
 					sampleItems = append(sampleItems, &statistics.SampleItem{
-						Value: types.NewBytesDatum(b),
+						Value: &tmp,
 					})
 				}
 				flushBuffered(&collectorMemSize)

--- a/pkg/executor/analyze_col_sampling.go
+++ b/pkg/executor/analyze_col_sampling.go
@@ -762,6 +762,7 @@ workLoop:
 				// consume mandatory memory at the beginning, including empty SampleItems of all sample rows, if exceeds, fast fail
 				// 8 means the pointer size of sampleItems slice.
 				// statistics.EmptySampleItemSize already accounts for the embedded types.Datum in SampleItem.Value.
+				// The real underlying byte slice of Datum in row.Columns has already be accounted FromProto().
 				collectorMemSize := int64(sampleNum) * (8 + statistics.EmptySampleItemSize)
 				e.memTracker.Consume(collectorMemSize)
 				var collator collate.Collator

--- a/pkg/executor/analyze_col_sampling.go
+++ b/pkg/executor/analyze_col_sampling.go
@@ -63,7 +63,7 @@ func (e *AnalyzeColumnsExec) analyzeColumnsPushDown(ctx context.Context, gp *gp.
 	}
 
 	// specialIndexes holds indexes that include virtual or prefix columns. For these indexes,
-	// only the number of distinct values (NDV) is computed using TiKV. Other statistic
+	// only the number of distinct values (NDV) is computed using TiKV. Other statistics
 	// are derived from sample data processed within TiDB.
 	// The reason is that we want to keep the same row sampling for all columns.
 	specialIndexes := make([]*model.IndexInfo, 0, len(e.indexes))
@@ -71,18 +71,9 @@ func (e *AnalyzeColumnsExec) analyzeColumnsPushDown(ctx context.Context, gp *gp.
 	for i, idx := range e.indexes {
 		isSpecial := false
 		for _, col := range idx.Columns {
-			// col.Offset can be -1 or out of bounds when the column is not in e.colsInfo
-			// (e.g., a stored generated column that was not included in the analyze column list).
-			if col.Offset < 0 || col.Offset >= len(e.colsInfo) {
-				isSpecial = true
-				break
-			}
 			colInfo := e.colsInfo[col.Offset]
 			isPrefixCol := col.Length != types.UnspecifiedLength
-			// Stored generated columns are not in e.colsInfo when they are indexed but not
-			// in the analyze column list. Virtual generated columns and prefix columns also
-			// need special handling because their values cannot be derived from sampled rows.
-			if colInfo.IsVirtualGenerated() || colInfo.GeneratedStored || isPrefixCol {
+			if colInfo.IsVirtualGenerated() || isPrefixCol {
 				isSpecial = true
 				break
 			}
@@ -226,13 +217,9 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 		}
 	}()
 
-	// l is the total number of columns + indexes for the collector's arrays (NullCount, FMSketches).
-	// It must be len(e.colsInfo) + len(e.indexes) so that NullCount has enough space for
-	// all indexes. Previously this used len(ColsInfo)+len(ColGroups), but ColGroups only
-	// contains non-special indexes, causing an out-of-bounds access when NullCount was too short.
-	l := len(e.colsInfo) + len(e.indexes)
-	rootRowCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), l)
-	for range l {
+	totalLen := len(e.analyzePB.ColReq.ColumnsInfo) + len(e.analyzePB.ColReq.ColumnGroups)
+	rootRowCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), totalLen)
+	for range totalLen {
 		rootRowCollector.Base().FMSketches = append(rootRowCollector.Base().FMSketches, statistics.NewFMSketch(statistics.MaxSketchSize))
 	}
 
@@ -264,7 +251,7 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 	for i := range samplingStatsConcurrency {
 		id := i
 		gp.Go(func() {
-			e.subMergeWorker(mergeCtx, taskCancel, mergeResultCh, mergeTaskCh, l, id)
+			e.subMergeWorker(mergeCtx, taskCancel, mergeResultCh, mergeTaskCh, totalLen, id)
 		})
 	}
 	// Merge the result from collectors.
@@ -355,7 +342,6 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 		return i.Handle.Compare(j.Handle)
 	})
 
-	totalLen := len(e.colsInfo) + len(e.indexes)
 	hists = make([]*statistics.Histogram, totalLen)
 	topns = make([]*statistics.TopN, totalLen)
 	fmSketches = make([]*statistics.FMSketch, 0, totalLen)
@@ -444,7 +430,7 @@ func (e *AnalyzeColumnsExec) handleNDVForSpecialIndexes(ctx context.Context, ind
 			}
 		}
 	}()
-	tasks := e.buildSubIndexJobForSpecialIndex(indexInfos)
+	tasks := e.buildSubIndexJobForSpecialIndex(ctx, indexInfos)
 	taskCh := make(chan *analyzeTask, len(tasks))
 	pendingJobs := make(map[uint64]*statistics.AnalyzeJob, len(tasks))
 	for _, task := range tasks {
@@ -546,11 +532,11 @@ func (e *AnalyzeColumnsExec) subIndexWorkerForNDV(ctx context.Context, taskCh ch
 
 // buildSubIndexJobForSpecialIndex builds sub index pushed down task to calculate the NDV information for indexes containing virtual column.
 // This is because we cannot push the calculation of the virtual column down to the tikv side.
-func (e *AnalyzeColumnsExec) buildSubIndexJobForSpecialIndex(indexInfos []*model.IndexInfo) []*analyzeTask {
+func (e *AnalyzeColumnsExec) buildSubIndexJobForSpecialIndex(ctx context.Context, indexInfos []*model.IndexInfo) []*analyzeTask {
 	_, offset := timeutil.Zone(e.ctx.GetSessionVars().Location())
 	tasks := make([]*analyzeTask, 0, len(indexInfos))
 	sc := e.ctx.GetSessionVars().StmtCtx
-	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), e.ctx)
+	concurrency := adaptiveAnlayzeDistSQLConcurrency(ctx, e.ctx)
 	for _, indexInfo := range indexInfos {
 		base := baseAnalyzeExec{
 			ctx:         e.ctx,
@@ -615,7 +601,7 @@ func (e *AnalyzeColumnsExec) subMergeWorker(
 	cancel context.CancelCauseFunc,
 	resultCh chan<- *samplingMergeResult,
 	taskCh <-chan []byte,
-	l int,
+	totalLen int,
 	index int,
 ) {
 	// Only close the resultCh in the first worker.
@@ -653,8 +639,8 @@ func (e *AnalyzeColumnsExec) subMergeWorker(
 		}
 	})
 	// Keep one private collector per merge worker and flush it when taskCh is closed.
-	retCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), l)
-	for range l {
+	retCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), totalLen)
+	for range totalLen {
 		retCollector.Base().FMSketches = append(retCollector.Base().FMSketches, statistics.NewFMSketch(statistics.MaxSketchSize))
 	}
 	// Early-return paths need to release the worker-local collector explicitly.
@@ -684,7 +670,7 @@ func (e *AnalyzeColumnsExec) subMergeWorker(
 			inflightRespSize = int64(colResp.Size())
 			e.memTracker.Consume(inflightRespSize)
 
-			subCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), l)
+			subCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), totalLen)
 			subCollector.Base().FromProto(colResp.RowCollector, e.memTracker)
 			statsHandle.UpdateAnalyzeJobProgress(e.job, subCollector.Base().Count)
 
@@ -775,9 +761,8 @@ workLoop:
 				sampleItems := make([]*statistics.SampleItem, 0, sampleNum)
 				// consume mandatory memory at the beginning, including empty SampleItems of all sample rows, if exceeds, fast fail
 				// 8 means the pointer size of sampleItems slice.
-				// types.EmptyDatumSize means the empty datum size we shallow copied from row.Columns to SampleItem.Value.
-				// The real underlying byte slice of Datum in row.Columns has already be accounted FromProto().
-				collectorMemSize := int64(sampleNum) * (8 + statistics.EmptySampleItemSize + types.EmptyDatumSize)
+				// statistics.EmptySampleItemSize already accounts for the embedded types.Datum in SampleItem.Value.
+				collectorMemSize := int64(sampleNum) * (8 + statistics.EmptySampleItemSize)
 				e.memTracker.Consume(collectorMemSize)
 				var collator collate.Collator
 				ft := e.colsInfo[task.slicePos].FieldType
@@ -816,24 +801,9 @@ workLoop:
 					MemSize:   collectorMemSize,
 				}
 			} else {
-				idx := e.indexes[task.slicePos-colLen]
-				// Check if any column has invalid offset.
-				// If so, we cannot build histogram from sampled rows because the column value
-				// is not available in the sample (e.g., stored generated column not in e.colsInfo).
-				hasInvalidOffset := false
-				for _, col := range idx.Columns {
-					if col.Offset < 0 || col.Offset >= len(e.colsInfo) {
-						hasInvalidOffset = true
-						break
-					}
-				}
-				if hasInvalidOffset {
-					hists[task.slicePos] = nil
-					topns[task.slicePos] = nil
-					continue
-				}
 				var tmpDatum types.Datum
 				var err error
+				idx := e.indexes[task.slicePos-colLen]
 				sampleNum := task.rootRowCollector.Base().Samples.Len()
 				sampleItems := make([]*statistics.SampleItem, 0, sampleNum)
 				// consume mandatory memory at the beginning, including all SampleItems, if exceeds, fast fail

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3136,13 +3136,26 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 	if len(task.Indexes) > 0 {
 		for _, idx := range task.Indexes {
 			availableIdx = append(availableIdx, idx)
+			hasInvalidOffset := false
 			colGroup := &tipb.AnalyzeColumnGroup{
 				ColumnOffsets: make([]int64, 0, len(idx.Columns)),
 			}
 			for _, col := range idx.Columns {
+				if col.Offset < 0 {
+					// Skip this column offset; the corresponding index will be handled as
+					// a special index in analyzeColumnsPushDown. We still add the valid
+					// column offsets below.
+					hasInvalidOffset = true
+					continue
+				}
 				colGroup.ColumnOffsets = append(colGroup.ColumnOffsets, int64(col.Offset))
 			}
-			colGroups = append(colGroups, colGroup)
+			// Only add to colGroups if all columns have valid offsets.
+			// colGroups is used by coprocessor to compute FMSketch for index values.
+			// If any column has invalid offset (-1), the coprocessor would panic.
+			if !hasInvalidOffset {
+				colGroups = append(colGroups, colGroup)
+			}
 		}
 	}
 

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3136,26 +3136,13 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 	if len(task.Indexes) > 0 {
 		for _, idx := range task.Indexes {
 			availableIdx = append(availableIdx, idx)
-			hasInvalidOffset := false
 			colGroup := &tipb.AnalyzeColumnGroup{
 				ColumnOffsets: make([]int64, 0, len(idx.Columns)),
 			}
 			for _, col := range idx.Columns {
-				if col.Offset < 0 {
-					// Skip this column offset; the corresponding index will be handled as
-					// a special index in analyzeColumnsPushDown. We still add the valid
-					// column offsets below.
-					hasInvalidOffset = true
-					continue
-				}
 				colGroup.ColumnOffsets = append(colGroup.ColumnOffsets, int64(col.Offset))
 			}
-			// Only add to colGroups if all columns have valid offsets.
-			// colGroups is used by coprocessor to compute FMSketch for index values.
-			// If any column has invalid offset (-1), the coprocessor would panic.
-			if !hasInvalidOffset {
-				colGroups = append(colGroups, colGroup)
-			}
+			colGroups = append(colGroups, colGroup)
 		}
 	}
 

--- a/pkg/executor/test/analyzetest/BUILD.bazel
+++ b/pkg/executor/test/analyzetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 38,
+    shard_count = 39,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -479,7 +479,7 @@ func TestAdjustSampleRateNote(t *testing.T) {
 		"Note 1105 Analyze use auto adjusted sample rate 0.500000 for table test.t, reason to use this rate is \"use min(1, 110000/220000) as the sample-rate=0.5\"",
 	))
 	tk.MustExec("insert into t values(1),(1),(1)")
-	tk.MustExec("flush stats_delta *.*")
+	tk.MustExec("flush stats_delta")
 	require.NoError(t, statsHandle.Update(context.Background(), is))
 	result = tk.MustQuery("show stats_meta where table_name = 't'")
 	require.Equal(t, "3", result.Rows()[0][5])
@@ -638,7 +638,7 @@ func TestAnalyzeColumnsAfterAnalyzeAll(t *testing.T) {
 			tk.MustExec("set @@tidb_analyze_version = 2")
 			tk.MustExec("create table t (a int, b int)")
 			tk.MustExec("insert into t (a,b) values (1,1), (1,1), (2,2), (2,2), (3,3), (4,4)")
-			tk.MustExec("flush stats_delta *.*")
+			tk.MustExec("flush stats_delta")
 
 			is := dom.InfoSchema()
 			tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
@@ -662,7 +662,7 @@ func TestAnalyzeColumnsAfterAnalyzeAll(t *testing.T) {
 				testkit.Rows("test t  a 0 0 2 1 3 4 0",
 					"test t  b 0 0 2 1 3 4 0"))
 			tk.MustExec("insert into t (a,b) values (1,1), (6,6)")
-			tk.MustExec("flush stats_delta *.*")
+			tk.MustExec("flush stats_delta")
 
 			switch choice {
 			case ast.ColumnList:
@@ -705,14 +705,14 @@ func TestAnalyzeSampleRateReason(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a int, b int)")
-	tk.MustExec("flush stats_delta *.*")
+	tk.MustExec("flush stats_delta")
 	analyzehelper.TriggerPredicateColumnsCollection(t, tk, store, "t", "a", "b")
 
 	tk.MustExec(`analyze table t`)
 	tk.MustQuery(`show warnings`).Sort().Check(testkit.Rows(
 		`Note 1105 Analyze use auto adjusted sample rate 1.000000 for table test.t, reason to use this rate is "use min(1, 110000/10000) as the sample-rate=1"`))
 	tk.MustExec(`insert into t values (1, 1), (2, 2), (3, 3)`)
-	tk.MustExec("flush stats_delta *.*")
+	tk.MustExec("flush stats_delta")
 	tk.MustExec(`analyze table t`)
 	tk.MustQuery(`show warnings`).Sort().Check(testkit.Rows(
 		`Note 1105 Analyze use auto adjusted sample rate 1.000000 for table test.t, reason to use this rate is "TiDB assumes that the table is empty, use sample-rate=1"`))
@@ -783,10 +783,10 @@ func testKillAutoAnalyze(t *testing.T) {
 	analyzehelper.TriggerPredicateColumnsCollection(t, tk, store, "t", "a", "b")
 	is := dom.InfoSchema()
 	h := dom.StatsHandle()
-	tk.MustExec("flush stats_delta *.*")
+	tk.MustExec("flush stats_delta")
 	tk.MustExec("analyze table t")
 	tk.MustExec("insert into t values (5,6), (7,8), (9, 10)")
-	tk.MustExec("flush stats_delta *.*")
+	tk.MustExec("flush stats_delta")
 	require.NoError(t, h.Update(context.Background(), is))
 	table, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)
@@ -856,7 +856,7 @@ func TestKillAutoAnalyzeIndex(t *testing.T) {
 	analyzehelper.TriggerPredicateColumnsCollection(t, tk, store, "t", "a", "b")
 	is := dom.InfoSchema()
 	h := dom.StatsHandle()
-	tk.MustExec("flush stats_delta *.*")
+	tk.MustExec("flush stats_delta")
 	tk.MustExec("analyze table t")
 	tk.MustExec("alter table t add index idx(b)")
 	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
@@ -1177,6 +1177,7 @@ func TestAnalyzePartitionTableStaticToDynamic(t *testing.T) {
 	tableInfo := table.Meta()
 	pi := tableInfo.GetPartitionInfo()
 	require.NotNil(t, pi)
+
 	// analyze partition under static mode with options
 	tk.MustExec("analyze table t partition p0 columns a,c with 1 topn, 3 buckets")
 	tk.MustQuery("select * from t where a > 1 and b > 1 and c > 1")
@@ -1188,10 +1189,7 @@ func TestAnalyzePartitionTableStaticToDynamic(t *testing.T) {
 	require.Equal(t, 3, len(p0.GetCol(tableInfo.Columns[0].ID).Buckets))
 	require.Equal(t, 3, len(p0.GetCol(tableInfo.Columns[2].ID).Buckets))
 	require.Equal(t, 0, len(p1.GetCol(tableInfo.Columns[0].ID).Buckets))
-	// Static partition analyze may flush pending partition deltas into the
-	// logical/global stats_meta row, but it must not build a global column
-	// histogram. In that meta-only global stats case, the global column is absent.
-	require.Nil(t, tbl.GetCol(tableInfo.Columns[0].ID))
+	require.Equal(t, 0, len(tbl.GetCol(tableInfo.Columns[0].ID).Buckets))
 	rs := tk.MustQuery("select buckets,topn from mysql.analyze_options where table_id=" + strconv.FormatInt(pi.Definitions[0].ID, 10))
 	require.Equal(t, 1, len(rs.Rows()))
 	require.Equal(t, "3", rs.Rows()[0][0])
@@ -1334,76 +1332,6 @@ PARTITION BY RANGE ( a ) (
 	))
 	tbl = h.GetPhysicalTableStats(tableInfo.ID, tableInfo)
 	require.Greater(t, tbl.Version, lastVersion) // global stats updated
-
-	tk.MustExec("analyze table t")
-	// HACK: Downgrade the persisted stats version to simulate legacy v1 stats left on the table.
-	legacyTableIDs := []int64{tableInfo.ID, pi.Definitions[0].ID, pi.Definitions[1].ID}
-	tk.MustExec(
-		"update mysql.stats_histograms set stats_ver = 1 where table_id in (?,?,?)",
-		legacyTableIDs[0], legacyTableIDs[1], legacyTableIDs[2],
-	)
-	h.Clear()
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema(), legacyTableIDs...))
-	require.Equal(t, statistics.Version1, h.GetPhysicalTableStats(tableInfo.ID, tableInfo).StatsVer)
-	require.Equal(t, statistics.Version1, h.GetPhysicalTableStats(pi.Definitions[0].ID, tableInfo).StatsVer)
-	require.Equal(t, statistics.Version1, h.GetPhysicalTableStats(pi.Definitions[1].ID, tableInfo).StatsVer)
-
-	tk.MustExec("analyze table t partition p0")
-	tk.MustQuery("show warnings").CheckContain(
-		"The analyze version from the session is not compatible with the existing statistics of the table. TiDB will analyze all partitions to rewrite the table statistics with the session-selected version",
-	)
-	tk.MustQuery(
-		"select table_id, stats_ver from mysql.stats_histograms where table_id in (?,?,?) group by table_id, stats_ver order by table_id",
-		legacyTableIDs[0], legacyTableIDs[1], legacyTableIDs[2],
-	).Check(testkit.Rows(
-		fmt.Sprintf("%d 2", legacyTableIDs[0]),
-		fmt.Sprintf("%d 2", legacyTableIDs[1]),
-		fmt.Sprintf("%d 2", legacyTableIDs[2]),
-	))
-}
-
-func TestAnalyzePartitionStaticModeMismatchKeepsColumnScope(t *testing.T) {
-	store, dom := testkit.CreateMockStoreAndDomain(t)
-	tk := testkit.NewTestKit(t, store)
-	testkit.WithPruneMode(tk, variable.Static, func() {
-		tk.MustExec("use test")
-		tk.MustExec("drop table if exists t")
-		tk.MustExec(`create table t (a int, b int, c int, primary key(a))
-partition by range (a) (
-	partition p0 values less than (10),
-	partition p1 values less than (20)
-)`)
-		tk.MustExec("insert into t values (1, 1, 1), (2, 2, 2), (11, 11, 11), (12, 12, 12)")
-
-		tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
-		require.NoError(t, err)
-		tblInfo := tbl.Meta()
-		pi := tblInfo.GetPartitionInfo()
-		require.NotNil(t, pi)
-		require.Len(t, pi.Definitions, 2)
-		h := dom.StatsHandle()
-
-		tk.MustExec("analyze table t partition p0 columns b")
-		tk.MustExec("analyze table t partition p1")
-		// HACK: Downgrade the persisted stats version of p1 to simulate legacy v1 stats left on the partition, which is incompatible with the session's analyze version.
-		tk.MustExec("update mysql.stats_histograms set stats_ver = 1 where table_id = ?", pi.Definitions[1].ID)
-		h.Clear()
-		require.NoError(t, h.Update(context.Background(), dom.InfoSchema(), pi.Definitions[0].ID, pi.Definitions[1].ID))
-
-		p0HistSQL := fmt.Sprintf(
-			"select hist_id, stats_ver from mysql.stats_histograms where table_id = %d and is_index = 0 order by hist_id",
-			pi.Definitions[0].ID,
-		)
-		expected := testkit.Rows(
-			fmt.Sprintf("%d 2", tblInfo.Columns[0].ID),
-			fmt.Sprintf("%d 2", tblInfo.Columns[1].ID),
-		)
-		tk.MustQuery(p0HistSQL).Check(expected)
-
-		// analyze partition p0 again, it should keep the column scope and not be affected by the incompatible stats of partition p1.
-		tk.MustExec("analyze table t partition p0 columns b")
-		tk.MustQuery(p0HistSQL).Check(expected)
-	})
 }
 
 func TestAnalyzePartitionStaticToDynamic(t *testing.T) {
@@ -1577,7 +1505,7 @@ func TestAutoAnalyzeAwareGlobalVariableChange(t *testing.T) {
 	require.NoError(t, err)
 	tid := tbl.Meta().ID
 	tk.MustExec("insert into t values(1),(2),(3)")
-	tk.MustExec("flush stats_delta *.*")
+	tk.MustExec("flush stats_delta")
 	err = h.Update(context.Background(), dom.InfoSchema())
 	require.NoError(t, err)
 	tk.MustExec("analyze table t")
@@ -1600,7 +1528,7 @@ func TestAutoAnalyzeAwareGlobalVariableChange(t *testing.T) {
 	startTS := txn.StartTS()
 	tk.MustExec("commit")
 	tk.MustExec("insert into t values(4),(5),(6)")
-	tk.MustExec("flush stats_delta *.*")
+	tk.MustExec("flush stats_delta")
 	err = h.Update(context.Background(), dom.InfoSchema())
 	require.NoError(t, err)
 
@@ -1631,7 +1559,7 @@ func TestAnalyzeColumnsSkipMVIndexJsonCol(t *testing.T) {
 	tk.MustExec("set @@tidb_analyze_version = 2")
 	tk.MustExec("create table t (a int, b int, c json, index idx_b(b), index idx_c((cast(json_extract(c, _utf8mb4'$') as char(32) array))))")
 	tk.MustExec(`insert into t values (1, 1, '["a1", "a2"]'), (2, 2, '["b1", "b2"]'), (3, 3, '["c1", "c2"]'), (2, 2, '["c1", "c2"]')`)
-	tk.MustExec("flush stats_delta *.*")
+	tk.MustExec("flush stats_delta")
 
 	tk.MustExec("analyze table t columns a")
 	tk.MustQuery("show warnings").Sort().Check(testkit.Rows(""+
@@ -1773,7 +1701,7 @@ func TestAnalyzeMVIndex(t *testing.T) {
 		require.NoError(t, err)
 		tk.MustExec(fmt.Sprintf("insert into t values (%d, '%s')", 1, jsonValueStr))
 	}
-	tk.MustExec("flush stats_delta *.*")
+	tk.MustExec("flush stats_delta")
 
 	// 2. analyze and check analyze jobs
 	tk.MustExec("analyze table t with 1 samplerate, 3 topn")
@@ -2148,76 +2076,33 @@ func TestSkipStatsForGeneratedColumnsOnSkippedColumns(t *testing.T) {
 	require.True(t, tblStats.GetCol(tbl.Meta().Columns[3].ID).IsAnalyzed())
 }
 
-func TestDynamicExpandMustForceAllColumns(t *testing.T) {
-	store, dom := testkit.CreateMockStoreAndDomain(t)
+// TestIssue66918 tests that ANALYZE TABLE on a table with stored generated column + index should not panic.
+// Issue: https://github.com/pingcap/tidb/issues/66918
+// Root cause: When analyzing a table with stored generated column that has an index,
+// the column offset could be -1, causing "index out of range [-1]" panic.
+func TestIssue66918(t *testing.T) {
+	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
-	originalVal := tk.MustQuery("select @@tidb_persist_analyze_options").Rows()[0][0].(string)
-	defer func() {
-		tk.MustExec(fmt.Sprintf("set global tidb_persist_analyze_options = %v", originalVal))
-	}()
-	tk.MustExec("set global tidb_persist_analyze_options = true")
 	tk.MustExec("use test")
-	tk.MustExec("set @@session.tidb_partition_prune_mode = 'dynamic'")
-	tk.MustExec(`create table t (a int, b int, c int, d int, primary key(a))
-partition by range (a) (
-	partition p0 values less than (10),
-	partition p1 values less than (20)
-)`)
-	tk.MustExec("insert into t values (1,1,1,1),(2,2,2,2),(11,11,11,11),(12,12,12,12)")
 
-	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
-	require.NoError(t, err)
-	tblInfo := tbl.Meta()
-	pi := tblInfo.GetPartitionInfo()
-	require.NotNil(t, pi)
-	p1ID := pi.Definitions[1].ID
-	p0ID := pi.Definitions[0].ID
-	h := dom.StatsHandle()
+	// Create table with stored generated column + index
+	tk.MustExec(`DROP TABLE IF EXISTS t`)
+	tk.MustExec(`CREATE TABLE t (
+		j JSON,
+		g VARCHAR(255) GENERATED ALWAYS AS ((j->'$.v')) STORED,
+		UNIQUE INDEX g_idx (g)
+	)`)
 
-	// Only mark columns a and b as predicate columns. c and d are not.
-	analyzehelper.TriggerPredicateColumnsCollection(t, tk, store, "t", "a", "b")
+	// Insert some data
+	tk.MustExec(`INSERT INTO t(j) VALUES ('{"v":1}'), ('{"v":2}')`)
 
-	// First full-table analyze creates v2 stats for all columns on all partitions.
-	tk.MustExec("analyze table t all columns")
+	// ANALYZE TABLE should not panic - this is the main test
+	tk.MustExec(`ANALYZE TABLE t`)
 
-	// Verify p1 has column histograms for all 4 columns.
-	p1AllColHists := tk.MustQuery(fmt.Sprintf(
-		"select count(*) from mysql.stats_histograms where table_id = %d and is_index = 0 and stats_ver = 2",
-		p1ID,
-	)).Rows()[0][0].(string)
-	require.Equal(t, "4", p1AllColHists)
-
-	// Override saved table-level column choice to PREDICATE.
-	// In dynamic mode, partition analyze reuses the saved table-level choice.
-	// With PREDICATE, only predicate columns (a, b) are analyzed — unless mustAllColumns
-	// forces all columns to be included.
-	tk.MustExec(fmt.Sprintf(
-		"update mysql.analyze_options set column_choice = 'PREDICATE', column_ids = '' where table_id = %d",
-		tblInfo.ID,
-	))
-
-	// Downgrade ALL of p1's histograms to v1 to simulate legacy stats.
-	tk.MustExec(fmt.Sprintf(
-		"update mysql.stats_histograms set stats_ver = 1 where table_id = %d", p1ID,
-	))
-	h.Clear()
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema(), p1ID, p0ID, tblInfo.ID))
-	require.Equal(t, statistics.Version1, h.GetPhysicalTableStats(p1ID, tblInfo).StatsVer)
-	require.Equal(t, statistics.Version2, h.GetPhysicalTableStats(p0ID, tblInfo).StatsVer)
-
-	tk.MustExec("analyze table t partition p0")
-	tk.MustQuery("show warnings").MultiCheckContain([]string{
-		"TiDB will analyze all partitions to rewrite the table statistics with the session-selected version",
-	})
-
-	// After the rewrite, ALL column histograms on p1 must be v2.
-	// If mustAllColumns was incorrectly false, c and d stay at v1.
-	tk.MustQuery(fmt.Sprintf(
-		"select count(*) from mysql.stats_histograms where table_id = %d and is_index = 0 and stats_ver = 1",
-		p1ID,
-	)).Check(testkit.Rows("0"))
-	tk.MustQuery(fmt.Sprintf(
-		"select count(*) from mysql.stats_histograms where table_id = %d and is_index = 0 and stats_ver = 2",
-		p1ID,
-	)).Check(testkit.Rows("4"))
+	// Verify the table is still queryable
+	result := tk.MustQuery(`SELECT * FROM t ORDER BY j`)
+	rows := result.Rows()
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
 }

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -2148,6 +2148,30 @@ func TestSkipStatsForGeneratedColumnsOnSkippedColumns(t *testing.T) {
 	require.True(t, tblStats.GetCol(tbl.Meta().Columns[3].ID).IsAnalyzed())
 }
 
+func TestIssue66918(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE t (
+		j JSON,
+		g VARCHAR(255) GENERATED ALWAYS AS ((j->'$.v')) STORED,
+		UNIQUE INDEX g_idx (g)
+	)`)
+	tk.MustExec(`INSERT INTO t(j) VALUES ('{"v":1}'), ('{"v":2}')`)
+
+	tk.MustExec("ANALYZE TABLE t")
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tblInfo := tbl.Meta()
+	tk.MustQuery("select is_index, stats_ver from mysql.stats_histograms where table_id = ? order by is_index, hist_id", tblInfo.ID).Check(testkit.Rows(
+		"0 2",
+		"1 2",
+	))
+
+	tblStats := dom.StatsHandle().GetPhysicalTableStats(tblInfo.ID, tblInfo)
+	require.True(t, tblStats.GetIdx(tblInfo.Indices[0].ID).IsAnalyzed())
+}
+
 func TestDynamicExpandMustForceAllColumns(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -479,7 +479,7 @@ func TestAdjustSampleRateNote(t *testing.T) {
 		"Note 1105 Analyze use auto adjusted sample rate 0.500000 for table test.t, reason to use this rate is \"use min(1, 110000/220000) as the sample-rate=0.5\"",
 	))
 	tk.MustExec("insert into t values(1),(1),(1)")
-	tk.MustExec("flush stats_delta")
+	tk.MustExec("flush stats_delta *.*")
 	require.NoError(t, statsHandle.Update(context.Background(), is))
 	result = tk.MustQuery("show stats_meta where table_name = 't'")
 	require.Equal(t, "3", result.Rows()[0][5])
@@ -638,7 +638,7 @@ func TestAnalyzeColumnsAfterAnalyzeAll(t *testing.T) {
 			tk.MustExec("set @@tidb_analyze_version = 2")
 			tk.MustExec("create table t (a int, b int)")
 			tk.MustExec("insert into t (a,b) values (1,1), (1,1), (2,2), (2,2), (3,3), (4,4)")
-			tk.MustExec("flush stats_delta")
+			tk.MustExec("flush stats_delta *.*")
 
 			is := dom.InfoSchema()
 			tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
@@ -662,7 +662,7 @@ func TestAnalyzeColumnsAfterAnalyzeAll(t *testing.T) {
 				testkit.Rows("test t  a 0 0 2 1 3 4 0",
 					"test t  b 0 0 2 1 3 4 0"))
 			tk.MustExec("insert into t (a,b) values (1,1), (6,6)")
-			tk.MustExec("flush stats_delta")
+			tk.MustExec("flush stats_delta *.*")
 
 			switch choice {
 			case ast.ColumnList:
@@ -705,14 +705,14 @@ func TestAnalyzeSampleRateReason(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a int, b int)")
-	tk.MustExec("flush stats_delta")
+	tk.MustExec("flush stats_delta *.*")
 	analyzehelper.TriggerPredicateColumnsCollection(t, tk, store, "t", "a", "b")
 
 	tk.MustExec(`analyze table t`)
 	tk.MustQuery(`show warnings`).Sort().Check(testkit.Rows(
 		`Note 1105 Analyze use auto adjusted sample rate 1.000000 for table test.t, reason to use this rate is "use min(1, 110000/10000) as the sample-rate=1"`))
 	tk.MustExec(`insert into t values (1, 1), (2, 2), (3, 3)`)
-	tk.MustExec("flush stats_delta")
+	tk.MustExec("flush stats_delta *.*")
 	tk.MustExec(`analyze table t`)
 	tk.MustQuery(`show warnings`).Sort().Check(testkit.Rows(
 		`Note 1105 Analyze use auto adjusted sample rate 1.000000 for table test.t, reason to use this rate is "TiDB assumes that the table is empty, use sample-rate=1"`))
@@ -783,10 +783,10 @@ func testKillAutoAnalyze(t *testing.T) {
 	analyzehelper.TriggerPredicateColumnsCollection(t, tk, store, "t", "a", "b")
 	is := dom.InfoSchema()
 	h := dom.StatsHandle()
-	tk.MustExec("flush stats_delta")
+	tk.MustExec("flush stats_delta *.*")
 	tk.MustExec("analyze table t")
 	tk.MustExec("insert into t values (5,6), (7,8), (9, 10)")
-	tk.MustExec("flush stats_delta")
+	tk.MustExec("flush stats_delta *.*")
 	require.NoError(t, h.Update(context.Background(), is))
 	table, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)
@@ -856,7 +856,7 @@ func TestKillAutoAnalyzeIndex(t *testing.T) {
 	analyzehelper.TriggerPredicateColumnsCollection(t, tk, store, "t", "a", "b")
 	is := dom.InfoSchema()
 	h := dom.StatsHandle()
-	tk.MustExec("flush stats_delta")
+	tk.MustExec("flush stats_delta *.*")
 	tk.MustExec("analyze table t")
 	tk.MustExec("alter table t add index idx(b)")
 	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
@@ -1177,7 +1177,6 @@ func TestAnalyzePartitionTableStaticToDynamic(t *testing.T) {
 	tableInfo := table.Meta()
 	pi := tableInfo.GetPartitionInfo()
 	require.NotNil(t, pi)
-
 	// analyze partition under static mode with options
 	tk.MustExec("analyze table t partition p0 columns a,c with 1 topn, 3 buckets")
 	tk.MustQuery("select * from t where a > 1 and b > 1 and c > 1")
@@ -1189,7 +1188,10 @@ func TestAnalyzePartitionTableStaticToDynamic(t *testing.T) {
 	require.Equal(t, 3, len(p0.GetCol(tableInfo.Columns[0].ID).Buckets))
 	require.Equal(t, 3, len(p0.GetCol(tableInfo.Columns[2].ID).Buckets))
 	require.Equal(t, 0, len(p1.GetCol(tableInfo.Columns[0].ID).Buckets))
-	require.Equal(t, 0, len(tbl.GetCol(tableInfo.Columns[0].ID).Buckets))
+	// Static partition analyze may flush pending partition deltas into the
+	// logical/global stats_meta row, but it must not build a global column
+	// histogram. In that meta-only global stats case, the global column is absent.
+	require.Nil(t, tbl.GetCol(tableInfo.Columns[0].ID))
 	rs := tk.MustQuery("select buckets,topn from mysql.analyze_options where table_id=" + strconv.FormatInt(pi.Definitions[0].ID, 10))
 	require.Equal(t, 1, len(rs.Rows()))
 	require.Equal(t, "3", rs.Rows()[0][0])
@@ -1332,6 +1334,76 @@ PARTITION BY RANGE ( a ) (
 	))
 	tbl = h.GetPhysicalTableStats(tableInfo.ID, tableInfo)
 	require.Greater(t, tbl.Version, lastVersion) // global stats updated
+
+	tk.MustExec("analyze table t")
+	// HACK: Downgrade the persisted stats version to simulate legacy v1 stats left on the table.
+	legacyTableIDs := []int64{tableInfo.ID, pi.Definitions[0].ID, pi.Definitions[1].ID}
+	tk.MustExec(
+		"update mysql.stats_histograms set stats_ver = 1 where table_id in (?,?,?)",
+		legacyTableIDs[0], legacyTableIDs[1], legacyTableIDs[2],
+	)
+	h.Clear()
+	require.NoError(t, h.Update(context.Background(), dom.InfoSchema(), legacyTableIDs...))
+	require.Equal(t, statistics.Version1, h.GetPhysicalTableStats(tableInfo.ID, tableInfo).StatsVer)
+	require.Equal(t, statistics.Version1, h.GetPhysicalTableStats(pi.Definitions[0].ID, tableInfo).StatsVer)
+	require.Equal(t, statistics.Version1, h.GetPhysicalTableStats(pi.Definitions[1].ID, tableInfo).StatsVer)
+
+	tk.MustExec("analyze table t partition p0")
+	tk.MustQuery("show warnings").CheckContain(
+		"The analyze version from the session is not compatible with the existing statistics of the table. TiDB will analyze all partitions to rewrite the table statistics with the session-selected version",
+	)
+	tk.MustQuery(
+		"select table_id, stats_ver from mysql.stats_histograms where table_id in (?,?,?) group by table_id, stats_ver order by table_id",
+		legacyTableIDs[0], legacyTableIDs[1], legacyTableIDs[2],
+	).Check(testkit.Rows(
+		fmt.Sprintf("%d 2", legacyTableIDs[0]),
+		fmt.Sprintf("%d 2", legacyTableIDs[1]),
+		fmt.Sprintf("%d 2", legacyTableIDs[2]),
+	))
+}
+
+func TestAnalyzePartitionStaticModeMismatchKeepsColumnScope(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	testkit.WithPruneMode(tk, variable.Static, func() {
+		tk.MustExec("use test")
+		tk.MustExec("drop table if exists t")
+		tk.MustExec(`create table t (a int, b int, c int, primary key(a))
+partition by range (a) (
+	partition p0 values less than (10),
+	partition p1 values less than (20)
+)`)
+		tk.MustExec("insert into t values (1, 1, 1), (2, 2, 2), (11, 11, 11), (12, 12, 12)")
+
+		tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+		require.NoError(t, err)
+		tblInfo := tbl.Meta()
+		pi := tblInfo.GetPartitionInfo()
+		require.NotNil(t, pi)
+		require.Len(t, pi.Definitions, 2)
+		h := dom.StatsHandle()
+
+		tk.MustExec("analyze table t partition p0 columns b")
+		tk.MustExec("analyze table t partition p1")
+		// HACK: Downgrade the persisted stats version of p1 to simulate legacy v1 stats left on the partition, which is incompatible with the session's analyze version.
+		tk.MustExec("update mysql.stats_histograms set stats_ver = 1 where table_id = ?", pi.Definitions[1].ID)
+		h.Clear()
+		require.NoError(t, h.Update(context.Background(), dom.InfoSchema(), pi.Definitions[0].ID, pi.Definitions[1].ID))
+
+		p0HistSQL := fmt.Sprintf(
+			"select hist_id, stats_ver from mysql.stats_histograms where table_id = %d and is_index = 0 order by hist_id",
+			pi.Definitions[0].ID,
+		)
+		expected := testkit.Rows(
+			fmt.Sprintf("%d 2", tblInfo.Columns[0].ID),
+			fmt.Sprintf("%d 2", tblInfo.Columns[1].ID),
+		)
+		tk.MustQuery(p0HistSQL).Check(expected)
+
+		// analyze partition p0 again, it should keep the column scope and not be affected by the incompatible stats of partition p1.
+		tk.MustExec("analyze table t partition p0 columns b")
+		tk.MustQuery(p0HistSQL).Check(expected)
+	})
 }
 
 func TestAnalyzePartitionStaticToDynamic(t *testing.T) {
@@ -1505,7 +1577,7 @@ func TestAutoAnalyzeAwareGlobalVariableChange(t *testing.T) {
 	require.NoError(t, err)
 	tid := tbl.Meta().ID
 	tk.MustExec("insert into t values(1),(2),(3)")
-	tk.MustExec("flush stats_delta")
+	tk.MustExec("flush stats_delta *.*")
 	err = h.Update(context.Background(), dom.InfoSchema())
 	require.NoError(t, err)
 	tk.MustExec("analyze table t")
@@ -1528,7 +1600,7 @@ func TestAutoAnalyzeAwareGlobalVariableChange(t *testing.T) {
 	startTS := txn.StartTS()
 	tk.MustExec("commit")
 	tk.MustExec("insert into t values(4),(5),(6)")
-	tk.MustExec("flush stats_delta")
+	tk.MustExec("flush stats_delta *.*")
 	err = h.Update(context.Background(), dom.InfoSchema())
 	require.NoError(t, err)
 
@@ -1559,7 +1631,7 @@ func TestAnalyzeColumnsSkipMVIndexJsonCol(t *testing.T) {
 	tk.MustExec("set @@tidb_analyze_version = 2")
 	tk.MustExec("create table t (a int, b int, c json, index idx_b(b), index idx_c((cast(json_extract(c, _utf8mb4'$') as char(32) array))))")
 	tk.MustExec(`insert into t values (1, 1, '["a1", "a2"]'), (2, 2, '["b1", "b2"]'), (3, 3, '["c1", "c2"]'), (2, 2, '["c1", "c2"]')`)
-	tk.MustExec("flush stats_delta")
+	tk.MustExec("flush stats_delta *.*")
 
 	tk.MustExec("analyze table t columns a")
 	tk.MustQuery("show warnings").Sort().Check(testkit.Rows(""+
@@ -1701,7 +1773,7 @@ func TestAnalyzeMVIndex(t *testing.T) {
 		require.NoError(t, err)
 		tk.MustExec(fmt.Sprintf("insert into t values (%d, '%s')", 1, jsonValueStr))
 	}
-	tk.MustExec("flush stats_delta")
+	tk.MustExec("flush stats_delta *.*")
 
 	// 2. analyze and check analyze jobs
 	tk.MustExec("analyze table t with 1 samplerate, 3 topn")
@@ -2076,33 +2148,76 @@ func TestSkipStatsForGeneratedColumnsOnSkippedColumns(t *testing.T) {
 	require.True(t, tblStats.GetCol(tbl.Meta().Columns[3].ID).IsAnalyzed())
 }
 
-// TestIssue66918 tests that ANALYZE TABLE on a table with stored generated column + index should not panic.
-// Issue: https://github.com/pingcap/tidb/issues/66918
-// Root cause: When analyzing a table with stored generated column that has an index,
-// the column offset could be -1, causing "index out of range [-1]" panic.
-func TestIssue66918(t *testing.T) {
-	store := testkit.CreateMockStore(t)
+func TestDynamicExpandMustForceAllColumns(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
+	originalVal := tk.MustQuery("select @@tidb_persist_analyze_options").Rows()[0][0].(string)
+	defer func() {
+		tk.MustExec(fmt.Sprintf("set global tidb_persist_analyze_options = %v", originalVal))
+	}()
+	tk.MustExec("set global tidb_persist_analyze_options = true")
 	tk.MustExec("use test")
+	tk.MustExec("set @@session.tidb_partition_prune_mode = 'dynamic'")
+	tk.MustExec(`create table t (a int, b int, c int, d int, primary key(a))
+partition by range (a) (
+	partition p0 values less than (10),
+	partition p1 values less than (20)
+)`)
+	tk.MustExec("insert into t values (1,1,1,1),(2,2,2,2),(11,11,11,11),(12,12,12,12)")
 
-	// Create table with stored generated column + index
-	tk.MustExec(`DROP TABLE IF EXISTS t`)
-	tk.MustExec(`CREATE TABLE t (
-		j JSON,
-		g VARCHAR(255) GENERATED ALWAYS AS ((j->'$.v')) STORED,
-		UNIQUE INDEX g_idx (g)
-	)`)
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tblInfo := tbl.Meta()
+	pi := tblInfo.GetPartitionInfo()
+	require.NotNil(t, pi)
+	p1ID := pi.Definitions[1].ID
+	p0ID := pi.Definitions[0].ID
+	h := dom.StatsHandle()
 
-	// Insert some data
-	tk.MustExec(`INSERT INTO t(j) VALUES ('{"v":1}'), ('{"v":2}')`)
+	// Only mark columns a and b as predicate columns. c and d are not.
+	analyzehelper.TriggerPredicateColumnsCollection(t, tk, store, "t", "a", "b")
 
-	// ANALYZE TABLE should not panic - this is the main test
-	tk.MustExec(`ANALYZE TABLE t`)
+	// First full-table analyze creates v2 stats for all columns on all partitions.
+	tk.MustExec("analyze table t all columns")
 
-	// Verify the table is still queryable
-	result := tk.MustQuery(`SELECT * FROM t ORDER BY j`)
-	rows := result.Rows()
-	if len(rows) != 2 {
-		t.Fatalf("expected 2 rows, got %d", len(rows))
-	}
+	// Verify p1 has column histograms for all 4 columns.
+	p1AllColHists := tk.MustQuery(fmt.Sprintf(
+		"select count(*) from mysql.stats_histograms where table_id = %d and is_index = 0 and stats_ver = 2",
+		p1ID,
+	)).Rows()[0][0].(string)
+	require.Equal(t, "4", p1AllColHists)
+
+	// Override saved table-level column choice to PREDICATE.
+	// In dynamic mode, partition analyze reuses the saved table-level choice.
+	// With PREDICATE, only predicate columns (a, b) are analyzed — unless mustAllColumns
+	// forces all columns to be included.
+	tk.MustExec(fmt.Sprintf(
+		"update mysql.analyze_options set column_choice = 'PREDICATE', column_ids = '' where table_id = %d",
+		tblInfo.ID,
+	))
+
+	// Downgrade ALL of p1's histograms to v1 to simulate legacy stats.
+	tk.MustExec(fmt.Sprintf(
+		"update mysql.stats_histograms set stats_ver = 1 where table_id = %d", p1ID,
+	))
+	h.Clear()
+	require.NoError(t, h.Update(context.Background(), dom.InfoSchema(), p1ID, p0ID, tblInfo.ID))
+	require.Equal(t, statistics.Version1, h.GetPhysicalTableStats(p1ID, tblInfo).StatsVer)
+	require.Equal(t, statistics.Version2, h.GetPhysicalTableStats(p0ID, tblInfo).StatsVer)
+
+	tk.MustExec("analyze table t partition p0")
+	tk.MustQuery("show warnings").MultiCheckContain([]string{
+		"TiDB will analyze all partitions to rewrite the table statistics with the session-selected version",
+	})
+
+	// After the rewrite, ALL column histograms on p1 must be v2.
+	// If mustAllColumns was incorrectly false, c and d stay at v1.
+	tk.MustQuery(fmt.Sprintf(
+		"select count(*) from mysql.stats_histograms where table_id = %d and is_index = 0 and stats_ver = 1",
+		p1ID,
+	)).Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf(
+		"select count(*) from mysql.stats_histograms where table_id = %d and is_index = 0 and stats_ver = 2",
+		p1ID,
+	)).Check(testkit.Rows("4"))
 }

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -2614,13 +2614,13 @@ func (b *PlanBuilder) filterSkipColumnTypes(origin []*model.ColumnInfo, tbl *res
 		shouldSkip := false
 		if colInfo.IsGenerated() {
 			_, keep := mustAnalyze[colInfo.ID]
-			// Indexed stored generated columns can be decoded directly from TiKV.
-			// This only keeps the generated column itself; its skipped dependencies
-			// remain skipped.
-			canIgnoreSkippedDeps := colInfo.GeneratedStored && keep
+			// Stored generated columns that must be analyzed are materialized in storage.
+			// They can be decoded directly without reading skipped base columns, while the
+			// skipped dependencies remain skipped.
+			decodableFromStorage := colInfo.GeneratedStored && keep
 			// Check if any dependency is in the skip list.
 			for depName := range colInfo.Dependences {
-				if _, exists := skipColNameMap[depName]; exists && !canIgnoreSkippedDeps {
+				if _, exists := skipColNameMap[depName]; exists && !decodableFromStorage {
 					skipCol = append(skipCol, colInfo)
 					shouldSkip = true
 					break

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -2614,13 +2614,13 @@ func (b *PlanBuilder) filterSkipColumnTypes(origin []*model.ColumnInfo, tbl *res
 		shouldSkip := false
 		if colInfo.IsGenerated() {
 			_, keep := mustAnalyze[colInfo.ID]
-			// Indexed stored generated columns are in mustAnalyze and can be
-			// collected directly from TiKV even when a skipped column appears
-			// in their expression.
-			canCollectStoredGenerated := colInfo.GeneratedStored && keep
+			// Indexed stored generated columns can be decoded directly from TiKV.
+			// This only keeps the generated column itself; its skipped dependencies
+			// remain skipped.
+			canIgnoreSkippedDeps := colInfo.GeneratedStored && keep
 			// Check if any dependency is in the skip list.
 			for depName := range colInfo.Dependences {
-				if _, exists := skipColNameMap[depName]; exists && !canCollectStoredGenerated {
+				if _, exists := skipColNameMap[depName]; exists && !canIgnoreSkippedDeps {
 					skipCol = append(skipCol, colInfo)
 					shouldSkip = true
 					break

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -2613,9 +2613,14 @@ func (b *PlanBuilder) filterSkipColumnTypes(origin []*model.ColumnInfo, tbl *res
 	for _, colInfo := range result {
 		shouldSkip := false
 		if colInfo.IsGenerated() {
-			// Check if any dependency is in the skip list
+			_, keep := mustAnalyze[colInfo.ID]
+			// Indexed stored generated columns are in mustAnalyze and can be
+			// collected directly from TiKV even when a skipped column appears
+			// in their expression.
+			canCollectStoredGenerated := colInfo.GeneratedStored && keep
+			// Check if any dependency is in the skip list.
 			for depName := range colInfo.Dependences {
-				if _, exists := skipColNameMap[depName]; exists {
+				if _, exists := skipColNameMap[depName]; exists && !canCollectStoredGenerated {
 					skipCol = append(skipCol, colInfo)
 					shouldSkip = true
 					break

--- a/tests/integrationtest/r/generated_columns.result
+++ b/tests/integrationtest/r/generated_columns.result
@@ -68,7 +68,7 @@ VALUES ('{"a": 1}', '{"1": "1"}'),
 ('{"a": 1}', '{"1": "1"}');
 INSERT INTO sgc2(j1, j2)
 VALUES ('{"a": 1}', '{"1": "1"}');
-ANALYZE TABLE sgc1, sgc2 predicate columns;
+ANALYZE TABLE sgc1, sgc2;
 EXPLAIN format = 'plan_tree' SELECT /*+ TIDB_INLJ(sgc1, sgc2) */ * from sgc1 join sgc2 on sgc1.a=sgc2.a;
 id	task	access object	operator info
 Projection	root		generated_columns.sgc1.j1, generated_columns.sgc1.j2, generated_columns.sgc1.a, generated_columns.sgc1.b, generated_columns.sgc2.j1, generated_columns.sgc2.j2, generated_columns.sgc2.a, generated_columns.sgc2.b

--- a/tests/integrationtest/t/generated_columns.test
+++ b/tests/integrationtest/t/generated_columns.test
@@ -65,7 +65,6 @@ VALUES ('{"a": 1}', '{"1": "1"}'),
 INSERT INTO sgc2(j1, j2)
 VALUES ('{"a": 1}', '{"1": "1"}');
 
-
 ANALYZE TABLE sgc1, sgc2;
 
 EXPLAIN format = 'plan_tree' SELECT /*+ TIDB_INLJ(sgc1, sgc2) */ * from sgc1 join sgc2 on sgc1.a=sgc2.a;

--- a/tests/integrationtest/t/generated_columns.test
+++ b/tests/integrationtest/t/generated_columns.test
@@ -65,8 +65,8 @@ VALUES ('{"a": 1}', '{"1": "1"}'),
 INSERT INTO sgc2(j1, j2)
 VALUES ('{"a": 1}', '{"1": "1"}');
 
-# FIXME: With all options on, it got runtime error: index out of range [-1]
-ANALYZE TABLE sgc1, sgc2 predicate columns;
+
+ANALYZE TABLE sgc1, sgc2;
 
 EXPLAIN format = 'plan_tree' SELECT /*+ TIDB_INLJ(sgc1, sgc2) */ * from sgc1 join sgc2 on sgc1.a=sgc2.a;
 EXPLAIN format = 'plan_tree' SELECT * from sgc1 join sgc2 on sgc1.a=sgc2.a;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66918, close #66359 

Problem Summary:
`ANALYZE TABLE` can fail for an indexed stored generated column when the column depends on a skipped type such as JSON.

### What changed and how does it work?

The generated column filter skipped generated columns when their expressions referenced skipped columns. This remains correct for virtual generated columns and for generated columns that have to be evaluated from their base columns.

For stored generated columns that must be analyzed, such as indexed stored generated columns, the generated values are materialized in TiKV and can be decoded directly. This PR keeps those stored generated columns in `filterSkipColumnTypes` even when their expressions reference skipped base columns. The skipped base columns remain skipped, so normal generated columns still follow the existing dependency skip rule.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix ANALYZE TABLE for indexed stored generated columns depending on skipped column types.
```