### PR TITLE
pkg/metrics: add query duration metric by resource group

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -181,6 +181,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(PseudoEstimation)
 	prometheus.MustRegister(PacketIOCounter)
 	prometheus.MustRegister(QueryDurationHistogram)
+	prometheus.MustRegister(QueryDurationOnlyByResourceGroupHistogram)
 	prometheus.MustRegister(QueryRPCHistogram)
 	prometheus.MustRegister(QueryProcessedKeyHistogram)
 	prometheus.MustRegister(QueryTotalCounter)

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -28,16 +28,17 @@ var (
 
 // Metrics
 var (
-	PacketIOCounter            *prometheus.CounterVec
-	QueryDurationHistogram     *prometheus.HistogramVec
-	QueryRPCHistogram          *prometheus.HistogramVec
-	QueryProcessedKeyHistogram *prometheus.HistogramVec
-	QueryTotalCounter          *prometheus.CounterVec
-	ConnGauge                  *prometheus.GaugeVec
-	DisconnectionCounter       *prometheus.CounterVec
-	PreparedStmtGauge          prometheus.Gauge
-	ExecuteErrorCounter        *prometheus.CounterVec
-	CriticalErrorCounter       prometheus.Counter
+	PacketIOCounter                           *prometheus.CounterVec
+	QueryDurationHistogram                    *prometheus.HistogramVec
+	QueryDurationOnlyByResourceGroupHistogram *prometheus.HistogramVec
+	QueryRPCHistogram                         *prometheus.HistogramVec
+	QueryProcessedKeyHistogram                *prometheus.HistogramVec
+	QueryTotalCounter                         *prometheus.CounterVec
+	ConnGauge                                 *prometheus.GaugeVec
+	DisconnectionCounter                      *prometheus.CounterVec
+	PreparedStmtGauge                         prometheus.Gauge
+	ExecuteErrorCounter                       *prometheus.CounterVec
+	CriticalErrorCounter                      prometheus.Counter
 
 	ServerStart = "server-start"
 	ServerStop  = "server-stop"
@@ -100,6 +101,15 @@ func InitServerMetrics() {
 			Help:      "Bucketed histogram of processing time (s) of handled queries.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 29), // 0.5ms ~ 1.5days
 		}, []string{LblSQLType, LblDb, LblResourceGroup})
+
+	QueryDurationOnlyByResourceGroupHistogram = metricscommon.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "handle_query_duration_by_resource_group_seconds",
+			Help:      "Bucketed histogram of processing time (s) of handled queries by resource group without sql_type or db labels.",
+			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 29), // 0.5ms ~ 1.5days
+		}, []string{LblResourceGroup})
 
 	QueryRPCHistogram = metricscommon.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -1330,6 +1330,7 @@ func (cc *clientConn) addQueryMetrics(cmd byte, startTime time.Time, err error) 
 			metrics.QueryProcessedKeyHistogram.WithLabelValues(sqlType, dbName).Observe(float64(vars.StmtCtx.GetExecDetails().ScanDetail.ProcessedKeys))
 		}
 	}
+	metrics.QueryDurationOnlyByResourceGroupHistogram.WithLabelValues(vars.StmtCtx.ResourceGroupName).Observe(cost.Seconds())
 }
 
 // dispatch handles client request based on command which is the first byte of the data.

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2162,9 +2162,11 @@ func (s *session) ExecRestrictedStmt(ctx context.Context, stmtNode ast.StmtNode,
 	}
 
 	vars := se.GetSessionVars()
+	queryDuration := time.Since(startTime).Seconds()
 	for _, dbName := range GetDBNames(vars) {
-		metrics.QueryDurationHistogram.WithLabelValues(metrics.LblInternal, dbName, vars.StmtCtx.ResourceGroupName).Observe(time.Since(startTime).Seconds())
+		metrics.QueryDurationHistogram.WithLabelValues(metrics.LblInternal, dbName, vars.StmtCtx.ResourceGroupName).Observe(queryDuration)
 	}
+	metrics.QueryDurationOnlyByResourceGroupHistogram.WithLabelValues(vars.StmtCtx.ResourceGroupName).Observe(queryDuration)
 	return rows, rs.Fields(), err
 }
 
@@ -2340,9 +2342,11 @@ func (s *session) ExecRestrictedSQL(ctx context.Context, opts []sqlexec.OptionFu
 		}
 
 		vars := se.GetSessionVars()
+		queryDuration := time.Since(startTime).Seconds()
 		for _, dbName := range GetDBNames(vars) {
-			metrics.QueryDurationHistogram.WithLabelValues(metrics.LblInternal, dbName, vars.StmtCtx.ResourceGroupName).Observe(time.Since(startTime).Seconds())
+			metrics.QueryDurationHistogram.WithLabelValues(metrics.LblInternal, dbName, vars.StmtCtx.ResourceGroupName).Observe(queryDuration)
 		}
+		metrics.QueryDurationOnlyByResourceGroupHistogram.WithLabelValues(vars.StmtCtx.ResourceGroupName).Observe(queryDuration)
 		return rows, rs.Fields(), err
 	})
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67843

Problem Summary:

When `record-db-label = true`, `tidb_server_handle_query_duration_seconds` records query duration with the `db` label. Clusters with many databases can produce high metric cardinality, while alerting often only needs query duration split by resource group, not by SQL type or database.

### What changed and how does it work?

This PR adds `tidb_server_handle_query_duration_by_resource_group_seconds`, a histogram that uses the same buckets and observation points as `tidb_server_handle_query_duration_seconds`, but only keeps the `resource_group` label.

This metric is intended for alerting rules only. It is not added to Grafana dashboards.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced monitoring: added a new metric that reports query execution duration aggregated by resource group, alongside existing per-database metrics, providing finer-grained visibility into resource-group performance.
  * Minor instrumentation improvements to reduce duplicate duration measurements when recording metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->