### PR TITLE
br: pre-lease log-backup storage and readLock leak fixes

### DIFF
--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -679,25 +679,27 @@ type LockedMigrations struct {
 	ReadLock objstore.RemoteLock
 }
 
-func (rc *LogClient) GetLockedMigrations(ctx context.Context) (*LockedMigrations, error) {
+func (rc *LogClient) GetLockedMigrations(ctx context.Context) (ret *LockedMigrations, retErr error) {
 	ext := stream.MigrationExtension(rc.storage)
 	readLock, err := ext.GetReadLock(ctx, "restore stream")
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if retErr != nil {
+			readLock.UnlockOnCleanUp(ctx)
+		}
+	}()
 
 	migs, err := ext.Load(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	ms := migs.ListAll()
-
-	lms := &LockedMigrations{
-		Migs:     ms,
+	return &LockedMigrations{
+		Migs:     migs.ListAll(),
 		ReadLock: readLock,
-	}
-	return lms, nil
+	}, nil
 }
 
 func (rc *LogClient) InstallLogFileManager(ctx context.Context, startTS, restoreTS uint64, metadataDownloadBatchSize uint,

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -685,25 +685,27 @@ type LockedMigrations struct {
 	ReadLock objstore.RemoteLock
 }
 
-func (rc *LogClient) GetLockedMigrations(ctx context.Context) (*LockedMigrations, error) {
+func (rc *LogClient) GetLockedMigrations(ctx context.Context) (ret *LockedMigrations, retErr error) {
 	ext := stream.MigrationExtension(rc.storage)
 	readLock, err := ext.GetReadLock(ctx, "restore stream")
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if retErr != nil {
+			readLock.UnlockOnCleanUp(ctx)
+		}
+	}()
 
 	migs, err := ext.Load(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	ms := migs.ListAll()
-
-	lms := &LockedMigrations{
-		Migs:     ms,
+	return &LockedMigrations{
+		Migs:     migs.ListAll(),
 		ReadLock: readLock,
-	}
-	return lms, nil
+	}, nil
 }
 
 func (rc *LogClient) InstallLogFileManager(ctx context.Context, startTS, restoreTS uint64, metadataDownloadBatchSize uint,

--- a/br/pkg/restore/log_client/client_test.go
+++ b/br/pkg/restore/log_client/client_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/metadef"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/objstore"
+	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/sessionctx"
@@ -2514,4 +2515,30 @@ func (m *mockBatchProcessor) ProcessBatch(
 	cf string,
 ) ([]*logclient.KvEntryWithTS, error) {
 	return m.processFunc(ctx, files, entries, filterTS, cf)
+}
+
+func TestGetLockedMigrationsReleasesReadLockOnLoadError(t *testing.T) {
+	ctx := context.Background()
+	stg, err := objstore.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+
+	// Inject a malformed migration file so ext.Load()'s migIdOf parser fails.
+	// migIdOf takes the first 8 chars of the filename as an integer; "badfile."
+	// is not parseable, so Load() returns an error and exercises the error path
+	// in GetLockedMigrations.
+	require.NoError(t, stg.WriteFile(ctx, "v1/migrations/badfile.mgrt", []byte("garbage")))
+
+	client := logclient.TEST_NewLogClientWithStorage(stg)
+	_, err = client.GetLockedMigrations(ctx)
+	require.Error(t, err, "expected Load() to fail on malformed migration file")
+
+	var lingering []string
+	require.NoError(t, stg.WalkDir(ctx, &storeapi.WalkOption{
+		SubDir:    "v1",
+		ObjPrefix: "LOCK",
+	}, func(p string, _ int64) error {
+		lingering = append(lingering, p)
+		return nil
+	}))
+	require.Emptyf(t, lingering, "readLock was not released after Load error; lingering files: %v", lingering)
 }

--- a/br/pkg/restore/log_client/client_test.go
+++ b/br/pkg/restore/log_client/client_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/metadef"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/objstore"
+	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/sessionctx"
@@ -2565,4 +2566,30 @@ func (m *mockBatchProcessor) ProcessBatch(
 	cf string,
 ) ([]*logclient.KvEntryWithTS, error) {
 	return m.processFunc(ctx, files, entries, filterTS, cf)
+}
+
+func TestGetLockedMigrationsReleasesReadLockOnLoadError(t *testing.T) {
+	ctx := context.Background()
+	stg, err := objstore.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+
+	// Inject a malformed migration file so ext.Load()'s migIdOf parser fails.
+	// migIdOf takes the first 8 chars of the filename as an integer; "badfile."
+	// is not parseable, so Load() returns an error and exercises the error path
+	// in GetLockedMigrations.
+	require.NoError(t, stg.WriteFile(ctx, "v1/migrations/badfile.mgrt", []byte("garbage")))
+
+	client := logclient.TEST_NewLogClientWithStorage(stg)
+	_, err = client.GetLockedMigrations(ctx)
+	require.Error(t, err, "expected Load() to fail on malformed migration file")
+
+	var lingering []string
+	require.NoError(t, stg.WalkDir(ctx, &storeapi.WalkOption{
+		SubDir:    "v1",
+		ObjPrefix: "LOCK",
+	}, func(p string, _ int64) error {
+		lingering = append(lingering, p)
+		return nil
+	}))
+	require.Emptyf(t, lingering, "readLock was not released after Load error; lingering files: %v", lingering)
 }

--- a/br/pkg/restore/log_client/export_test.go
+++ b/br/pkg/restore/log_client/export_test.go
@@ -107,6 +107,14 @@ func TEST_NewLogClient(clusterID, startTS, restoreTS, upstreamClusterID uint64, 
 	}
 }
 
+// TEST_NewLogClientWithStorage returns a minimal LogClient whose only
+// dependency is the storage. It is intended for tests that exercise
+// storage-level behavior (lock acquisition, migration loading) and do
+// not need the full domain / session / checkpoint wiring.
+func TEST_NewLogClientWithStorage(s storeapi.Storage) *LogClient {
+	return &LogClient{storage: s}
+}
+
 func (rc *LogClient) SetUseCheckpoint() {
 	rc.useCheckpoint = true
 }

--- a/br/pkg/restore/log_client/export_test.go
+++ b/br/pkg/restore/log_client/export_test.go
@@ -108,6 +108,14 @@ func TEST_NewLogClient(clusterID, startTS, restoreTS, upstreamClusterID uint64, 
 	}
 }
 
+// TEST_NewLogClientWithStorage returns a minimal LogClient whose only
+// dependency is the storage. It is intended for tests that exercise
+// storage-level behavior (lock acquisition, migration loading) and do
+// not need the full domain / session / checkpoint wiring.
+func TEST_NewLogClientWithStorage(s storeapi.Storage) *LogClient {
+	return &LogClient{storage: s}
+}
+
 func (rc *LogClient) SetUseCheckpoint() {
 	rc.useCheckpoint = true
 }

--- a/br/pkg/stream/stream_metas.go
+++ b/br/pkg/stream/stream_metas.go
@@ -614,6 +614,7 @@ func MergeMigrations(m1 *pb.Migration, m2 *pb.Migration) *pb.Migration {
 	out.DestructPrefix = append(out.DestructPrefix, m1.GetDestructPrefix()...)
 	out.DestructPrefix = append(out.DestructPrefix, m2.GetDestructPrefix()...)
 	out.IngestedSstPaths = append(out.IngestedSstPaths, m1.GetIngestedSstPaths()...)
+	out.IngestedSstPaths = append(out.IngestedSstPaths, m2.GetIngestedSstPaths()...)
 	return out
 }
 

--- a/br/pkg/stream/stream_metas_test.go
+++ b/br/pkg/stream/stream_metas_test.go
@@ -3004,3 +3004,46 @@ func TestMergeMigrationsPreservesIngestedSstPaths(t *testing.T) {
 		merged.IngestedSstPaths,
 	)
 }
+
+func TestMergeAndMigrateToBoundsIngestedSstPathsOverTruncates(t *testing.T) {
+	ctx := context.Background()
+	s := tmp(t)
+	est := MigrationExtension(s)
+
+	placeholder := func(pfx string) {
+		require.NoError(t, s.WriteFile(ctx, path.Join(pfx, "monolith"), []byte("sst")))
+	}
+
+	// Simulate N rounds of: AppendMigration (one finished ingested-SST group at
+	// ascending AsIfTs) followed by truncate advancing TruncatedTo to that same
+	// ts. Each round the previous round's group becomes eligible for cleanup
+	// (Finished=true, GroupTS < TruncatedTo), while the current round's group
+	// stays (GroupTS == TruncatedTo >= TruncatedTo).
+	const rounds = 10
+	prefixOf := func(i int) string { return fmt.Sprintf("ext_backups/%06d", i) }
+
+	for i := 1; i <= rounds; i++ {
+		ts := uint64(i * 10)
+		pfx := prefixOf(i)
+		placeholder(pfx)
+		ingMeta := extFullBkup(prefix(pfx), asIfTS(ts), makeID(), finished())
+		ingMetaPath := pef(t, ingMeta, i, s)
+		pmig(s, uint64(i), mig(mExtFullBackup(ingMetaPath), mTruncatedTo(ts)))
+
+		res := est.MergeAndMigrateTo(ctx, math.MaxInt,
+			MMOptSkipLockingInTest(), MMOptAlwaysRunTruncate())
+		require.NoError(t, multierr.Combine(res.Warnings...),
+			"round %d warnings: %v", i, res.Warnings)
+
+		require.LessOrEqualf(t, len(res.NewBase.IngestedSstPaths), 1,
+			"round %d: expected at most 1 surviving IngestedSstPath, got %d (%v)",
+			i, len(res.NewBase.IngestedSstPaths), res.NewBase.IngestedSstPaths)
+
+		if i > 1 {
+			require.NoFileExistsf(t,
+				path.Join(s.Base(), prefixOf(i-1), "monolith"),
+				"round %d: previous round's ext_backups directory should have been cleaned",
+				i)
+		}
+	}
+}

--- a/br/pkg/stream/stream_metas_test.go
+++ b/br/pkg/stream/stream_metas_test.go
@@ -2992,3 +2992,15 @@ func TestGroupedExtFullBackup(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeMigrationsPreservesIngestedSstPaths(t *testing.T) {
+	m1 := mig(mExtFullBackup("base/a", "base/b"))
+	m2 := mig(mExtFullBackup("layer/c", "layer/d"))
+
+	merged := MergeMigrations(m1, m2)
+
+	require.ElementsMatch(t,
+		[]string{"base/a", "base/b", "layer/c", "layer/d"},
+		merged.IngestedSstPaths,
+	)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67819

Problem Summary:

This PR bundles two storage-leak fixes in the log-backup subsystem that must land before the lease-based lock expiration work can proceed. Both surface naturally during the same audit of what goes wrong when a process holding a log-backup lock fails to tear down cleanly.

**Fix 1 — `MergeMigrations` drops layer `IngestedSstPaths`** ([br/pkg/stream/stream_metas.go](https://github.com/pingcap/tidb/blob/master/br/pkg/stream/stream_metas.go))

`MergeMigrations()` appends `m1.GetIngestedSstPaths()` but silently drops `m2.GetIngestedSstPaths()`. The other repeated fields in the same function (`Compactions`, `DestructPrefix`) concat both sides, so this is an asymmetric copy-paste omission.

- `MergeAndMigrateTo` (called during `br log truncate`) invokes `MergeMigrations` to fold each layer into the new BASE. Because m2's `IngestedSstPaths` are dropped, `processExtFullBackup` never sees layer-originated paths and cannot evaluate them against the `Finished && GroupTS < TruncatedTo` cleanup condition.
- Every layer's corresponding `v1/ext_backups/` directory becomes a permanent orphan on the log-backup storage — a steady-state storage leak.
- PiTR's read path reads `IngestedSstPaths` per-layer via `ListAll()` (see `br/pkg/restore/log_client/migration.go`), so data consumption is unaffected today.
- Under the forthcoming lease-based lock expiration mechanism, if a read-lock is auto-reclaimed before PiTR consumes these SSTs, a subsequent truncate's merge will silently drop the references — escalating this from "storage leak" to "PiTR cannot find required SSTs" (correctness issue).

**Fix 2 — `GetLockedMigrations` leaks `readLock` on `Load()` error** ([br/pkg/restore/log_client/client.go](https://github.com/pingcap/tidb/blob/master/br/pkg/restore/log_client/client.go))

`GetLockedMigrations()` acquires a read lock on `v1/LOCK` via `GetReadLock`, then calls `ext.Load(ctx)` to enumerate migrations. When `Load()` fails — for instance because a `.mgrt` file is corrupted, the migrations directory is transiently unreadable, or `migIdOf` cannot parse a name — the function returns the error without releasing the lock it just acquired, orphaning `v1/LOCK.READ.*` on remote storage until it is manually removed.

Once lease-based auto-reclamation lands, this path is worse: a caller that never receives the `RemoteLock` cannot register a renewal, so the orphaned lock never refreshes its `ExpireAt` — and the CLI escape hatch becomes the only recourse. Closing the leak now keeps cleanup honest even under today's no-expiration regime.

### What changed and how does it work?

**Fix 1:** one-line append of `m2.GetIngestedSstPaths()` in `MergeMigrations`, symmetric with `Compactions` / `DestructPrefix` handling.

Behavior change note: after this fix, the first `br log truncate` run against a storage that previously suffered the drop will start correctly evaluating layer-originated `IngestedSstPaths` against `processExtFullBackup`'s existing conditions (unchanged logic). Directories satisfying `Finished=true && GroupTS < TruncatedTo` get cleaned; others get carried into the new BASE. This does **not** retroactively recover orphan directories whose references were already lost in a historical merge — a separate scan tool is a follow-up independent task.

Other call sites of `MergeMigrations` audited:

- `MergeAndMigrateTo` (`stream_metas.go` ~L940): the target path — now cleans up properly.
- `MergeToBy` (`stream_metas.go` ~L820): only reachable through `MergeTo` which has no production callers today.
- `doTruncateLogs` (`stream_metas.go` ~L1479): both `r.NewBase` and `aOut.NewBase` have empty `IngestedSstPaths` at this site — fix has no effect here.

**Fix 2:** add `readLock.UnlockOnCleanUp(ctx)` on the error path. Happy path unchanged.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

New tests:

- `TestMergeMigrationsPreservesIngestedSstPaths` — direct primitive-level test; verified to FAIL on unfixed code, PASS after fix.
- `TestMergeAndMigrateToBoundsIngestedSstPathsOverTruncates` — 10-round integration test proving that after the `MergeMigrations` fix, `processExtFullBackup`'s pruning pipeline is reconnected: BASE's `IngestedSstPaths` stays bounded (≤1) and stale `ext_backups/` directories are physically deleted. Also failed against unfixed code, passed after fix.
- `TestGetLockedMigrationsReleasesReadLockOnLoadError` — injects a malformed migration file to force `Load()` failure, asserts no `v1/LOCK.READ.*` remains on storage. Failed against unfixed code (lingering `v1/LOCK.READ.{random}`), passed after fix.

Full `br/pkg/stream` and `br/pkg/restore/log_client` package sweeps (`go test -tags=intest` with failpoints enabled) stay green.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
br: fix two storage leaks in log backup — (1) `MergeMigrations` silently dropped `IngestedSstPaths` from layers, leaking `v1/ext_backups/` directories across `br log truncate` runs; (2) `GetLockedMigrations` orphaned the `v1/LOCK.READ.*` read lock when the migration `Load()` step failed. Both paths now clean up correctly.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed migration merge so ingested SST path entries from all source migrations are preserved.
  * Ensured read locks are released on load errors to avoid lingering lock artifacts after failed operations.

* **Tests**
  * Added tests covering ingested-SST handling, migration truncation/cleanup behavior, and cleanup of locks after load failures.
  * Added test helpers to enable storage-only testing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->