### PR TITLE
stats: remove ColAndIdxExistenceMap checked flag (#63626) (#64501)

### DIFF
--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -199,7 +199,6 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache stats
 		tblID, statsVer := row.GetInt64(0), row.GetInt64(8)
 		if table == nil || table.PhysicalID != tblID {
 			if table != nil {
-				table.ColAndIdxExistenceMap.SetChecked()
 				cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
 			}
 			var ok bool
@@ -296,7 +295,6 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache stats
 		}
 	}
 	if table != nil {
-		table.ColAndIdxExistenceMap.SetChecked()
 		cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
 	}
 }

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -583,7 +583,6 @@ func TableStatsFromStorage(sctx sessionctx.Context, snapshot uint64, tableInfo *
 			table.StatsVer = statistics.Version0
 		}
 	}
-	table.ColAndIdxExistenceMap.SetChecked()
 	return ExtendedStatsFromStorage(sctx, table.CopyAs(statistics.ExtendedStatsWritable), tableID, loadAll)
 }
 

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -401,9 +401,9 @@ func (s *statsSyncLoad) handleOneItemTask(task *statstypes.NeededItemTask) (err 
 		// If this column is not analyzed yet and we don't have it in memory.
 		// We create a fake one for the pseudo estimation.
 		// Otherwise, it will trigger the sync/async load again, even if the column has not been analyzed.
-		if loadNeeded && !analyzed {
+		if !analyzed {
 			wrapper.col = statistics.EmptyColumn(item.TableID, isPkIsHandle, wrapper.colInfo)
-			s.updateCachedItem(tblInfo, item, wrapper.col, wrapper.idx, task.Item.FullLoad)
+			s.updateCachedItem(item, wrapper.col, wrapper.idx, task.Item.FullLoad)
 			return nil
 		}
 	}
@@ -428,7 +428,7 @@ func (s *statsSyncLoad) handleOneItemTask(task *statstypes.NeededItemTask) (err 
 	}
 	metrics.ReadStatsHistogram.Observe(float64(time.Since(t).Milliseconds()))
 	if needUpdate {
-		s.updateCachedItem(tblInfo, item, wrapper.col, wrapper.idx, task.Item.FullLoad)
+		s.updateCachedItem(item, wrapper.col, wrapper.idx, task.Item.FullLoad)
 	}
 	return nil
 }
@@ -567,7 +567,7 @@ func (*statsSyncLoad) writeToTimeoutChan(taskCh chan *statstypes.NeededItemTask,
 }
 
 // updateCachedItem updates the column/index hist to global statsCache.
-func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.TableItemID, colHist *statistics.Column, idxHist *statistics.Index, fullLoaded bool) (updated bool) {
+func (s *statsSyncLoad) updateCachedItem(item model.TableItemID, colHist *statistics.Column, idxHist *statistics.Index, fullLoaded bool) (updated bool) {
 	s.mutexForStatsCache.Lock()
 	defer s.mutexForStatsCache.Unlock()
 	// Reload the latest stats cache, otherwise the `updateStatsCache` may fail with high probability, because functions
@@ -577,21 +577,6 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 		return false
 	}
 	var tableCopied bool
-	if !tbl.ColAndIdxExistenceMap.Checked() {
-		tbl = tbl.CopyAs(statistics.BothMapsWritable)
-		tableCopied = true
-		for _, col := range tbl.HistColl.GetColSlice() {
-			if tblInfo.FindColumnByID(col.ID) == nil {
-				tbl.DelCol(col.ID)
-			}
-		}
-		for _, idx := range tbl.HistColl.GetIdxSlice() {
-			if tblInfo.FindIndexByID(idx.ID) == nil {
-				tbl.DelIdx(idx.ID)
-			}
-		}
-		tbl.ColAndIdxExistenceMap.SetChecked()
-	}
 	if !item.IsIndex && colHist != nil {
 		c := tbl.GetCol(item.ID)
 		// - If the stats is fully loaded,

--- a/pkg/statistics/table_test.go
+++ b/pkg/statistics/table_test.go
@@ -24,7 +24,6 @@ func TestCloneColAndIdxExistenceMap(t *testing.T) {
 	m := NewColAndIndexExistenceMapWithoutSize()
 	m.InsertCol(1, true)
 	m.InsertIndex(1, true)
-	m.SetChecked()
 
 	m2 := m.Clone()
 	require.Equal(t, m, m2)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #60316

Problem Summary:

Cherry-pick #64501 to `release-nextgen-20251011`.

### What changed and how does it work?

This cherry-picks commit `6bb7785a4b833d387883d0d66f6d752b97449916` to remove the `checked` flag from `ColAndIdxExistenceMap` and remove the related bootstrap/storage/sync-load logic.

Conflict resolution:
- kept the `release-nextgen-20251011` branch's `CopyAs(statistics.ExtendedStatsWritable)` behavior in `pkg/statistics/handle/storage/read.go`
- removed one leftover `checked`-related assertion in `pkg/statistics/table_test.go`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `go test -run TestCloneColAndIdxExistenceMap ./pkg/statistics`
  - `go test -tags=intest -run TestSyncLoadOnObjectWhichCanNotFoundInStorage ./pkg/statistics/handle/syncload`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal statistics loading and caching mechanism by removing unnecessary state tracking and streamlining cache update logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->