### PR TITLE
pkg/server/tests/commontest: stabilize flaky TestSumAvg

### DIFF
--- a/pkg/server/internal/testserverclient/server_client.go
+++ b/pkg/server/internal/testserverclient/server_client.go
@@ -2416,6 +2416,8 @@ func (cli *TestServerClient) RunReloadTLS(t *testing.T, overrider configOverride
 
 func (cli *TestServerClient) RunTestSumAvg(t *testing.T) {
 	cli.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
+		dbt.GetDB().SetMaxOpenConns(1)
+		dbt.GetDB().SetMaxIdleConns(1)
 		dbt.MustExec("create table sumavg (a int, b decimal, c double)")
 		dbt.MustExec("insert sumavg values (1, 1, 1)")
 		rows := dbt.MustQuery("select sum(a), sum(b), sum(c) from sumavg")
@@ -2426,6 +2428,7 @@ func (cli *TestServerClient) RunTestSumAvg(t *testing.T) {
 		require.Equal(t, 1.0, outA)
 		require.Equal(t, 1.0, outB)
 		require.Equal(t, 1.0, outC)
+		require.NoError(t, rows.Close())
 		rows = dbt.MustQuery("select avg(a), avg(b), avg(c) from sumavg")
 		require.True(t, rows.Next())
 		err = rows.Scan(&outA, &outB, &outC)
@@ -2433,6 +2436,7 @@ func (cli *TestServerClient) RunTestSumAvg(t *testing.T) {
 		require.Equal(t, 1.0, outA)
 		require.Equal(t, 1.0, outB)
 		require.Equal(t, 1.0, outC)
+		require.NoError(t, rows.Close())
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67571

Problem Summary:
Flaky test `TestSumAvg` in `pkg/server/tests/commontest` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TEST_ISSUE: `RunTestSumAvg` did not close its first result set before issuing another query, which can block under connection/resource pressure and manifest as flaky timeout behavior.

#### Fix

Closing `rows` and keeping a one-connection pool in this test removes the leak window and makes the original sum/avg assertion path deterministic.

#### Verification

Spec:
- target: `pkg/server/tests/commontest :: TestSumAvg`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/server/tests/commontest -run '^TestSumAvg$' -count=1`
- `go test -json ./pkg/server/tests/commontest -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test database connection handling with explicit resource cleanup to ensure proper connection management during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->