### PR TITLE
pkg/statistics/handle/handletest/initstats: stabilize flaky TestNonLiteInitStatsWithTableIDs

### DIFF
--- a/pkg/statistics/handle/handletest/initstats/init_stats_test.go
+++ b/pkg/statistics/handle/handletest/initstats/init_stats_test.go
@@ -95,6 +95,8 @@ func TestLiteInitStatsWithTableIDs(t *testing.T) {
 	withStatsLease(t, -1, func() {
 		dom, err = session.BootstrapSession(store)
 		require.NoError(t, err)
+		sm := testkit.MockSessionManager{}
+		dom.InfoSyncer().SetSessionManager(&sm)
 		h := dom.StatsHandle()
 		_, ok := h.Get(tbl1.Meta().ID)
 		require.False(t, ok)
@@ -152,6 +154,8 @@ func TestNonLiteInitStatsWithTableIDs(t *testing.T) {
 	withStatsLease(t, -1, func() {
 		dom, err = session.BootstrapSession(store)
 		require.NoError(t, err)
+		sm := testkit.MockSessionManager{}
+		dom.InfoSyncer().SetSessionManager(&sm)
 		is = dom.InfoSchema()
 		h := dom.StatsHandle()
 		_, ok := h.Get(tbl1.Meta().ID)
@@ -365,6 +369,8 @@ func TestNonLiteInitStatsAndCheckTheLastTableStats(t *testing.T) {
 	withStatsLease(t, -1, func() {
 		dom, err = session.BootstrapSession(store)
 		require.NoError(t, err)
+		sm := testkit.MockSessionManager{}
+		dom.InfoSyncer().SetSessionManager(&sm)
 		is = dom.InfoSchema()
 		h := dom.StatsHandle()
 		_, ok := h.Get(tbl1.Meta().ID)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67176

Problem Summary:
Flaky test `TestNonLiteInitStatsWithTableIDs` in `pkg/statistics/handle/handletest/initstats` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Restart-path initstats tests bootstrapped a new domain without reattaching `SessionManager`, leaving internal-session registration in a retry window that can hang `InitStats`.

#### Fix

Adding `MockSessionManager` in the three restart closures removes the invalid setup gap that triggered the flaky hang without changing product behavior.

#### Verification

Spec:
- target: `pkg/statistics/handle/handletest/initstats :: TestNonLiteInitStatsWithTableIDs`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/statistics/handle/handletest/initstats -run '^TestNonLiteInitStatsWithTableIDs$' -count=1`
- `go test -json ./pkg/statistics/handle/handletest/initstats -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup and initialization for statistics module tests to enhance test reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->