### PR TITLE
br/pkg/restore/snap_client: stabilize flaky TestConcurrency

### DIFF
--- a/br/pkg/restore/snap_client/pitr_collector_test.go
+++ b/br/pkg/restore/snap_client/pitr_collector_test.go
@@ -11,12 +11,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/pingcap/failpoint"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/tidb/br/pkg/restore"
 	"github.com/pingcap/tidb/br/pkg/restore/utils"
 	"github.com/pingcap/tidb/br/pkg/stream"
 	"github.com/pingcap/tidb/pkg/objstore"
+	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/stretchr/testify/require"
 )
 
@@ -185,6 +185,29 @@ func withRewriteRule(hints ...utils.TableIDRemap) backupFileSetOp {
 	}
 }
 
+type copyInterceptorStorage struct {
+	storeapi.Storage
+	copier storeapi.Copier
+	onCopy func()
+}
+
+func newCopyInterceptorStorage(t *testing.T, s storeapi.Storage, onCopy func()) *copyInterceptorStorage {
+	copier, ok := s.(storeapi.Copier)
+	require.True(t, ok)
+	return &copyInterceptorStorage{
+		Storage: s,
+		copier:  copier,
+		onCopy:  onCopy,
+	}
+}
+
+func (s *copyInterceptorStorage) CopyFrom(ctx context.Context, from storeapi.Storage, spec storeapi.CopySpec) error {
+	if s.onCopy != nil {
+		s.onCopy()
+	}
+	return s.copier.CopyFrom(ctx, from, spec)
+}
+
 func TestCollAFile(t *testing.T) {
 	coll := newPiTRCollForTest(t)
 	batch := restore.BatchBackupFileSet{backupFileSet(withFile(nameFile("foo.txt")))}
@@ -294,10 +317,10 @@ func TestConcurrency(t *testing.T) {
 	fenceOnce := sync.Once{}
 	closeFence := func() { fenceOnce.Do(func() { close(fence) }) }
 
-	require.NoError(t, failpoint.EnableCall("github.com/pingcap/tidb/br/pkg/restore/snap_client/put-sst", func() {
+	coll.coll.taskStorage = newCopyInterceptorStorage(t, coll.coll.taskStorage, func() {
 		atomic.AddInt64(&cnt, 1)
 		<-fence
-	}))
+	})
 
 	type result struct {
 		complete func() error
@@ -311,7 +334,6 @@ func TestConcurrency(t *testing.T) {
 	t.Cleanup(func() {
 		closeFence()
 		wg.Wait()
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/restore/snap_client/put-sst"))
 	})
 
 	for i := range tasks {

--- a/br/pkg/restore/snap_client/pitr_collector_test.go
+++ b/br/pkg/restore/snap_client/pitr_collector_test.go
@@ -202,9 +202,7 @@ func newCopyInterceptorStorage(t *testing.T, s storeapi.Storage, onCopy func()) 
 }
 
 func (s *copyInterceptorStorage) CopyFrom(ctx context.Context, from storeapi.Storage, spec storeapi.CopySpec) error {
-	if s.onCopy != nil {
-		s.onCopy()
-	}
+	s.onCopy()
 	return s.copier.CopyFrom(ctx, from, spec)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/66975

Problem Summary:
Flaky test `TestConcurrency` in `br/pkg/restore/snap_client` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TEST_ISSUE: TestConcurrency depended on a failpoint-based barrier that is not guaranteed on the required test surface, so the concurrency fence was never engaged.

#### Fix

Replacing failpoint gating with a test-local copy-boundary interceptor keeps the same concurrency assertion while removing execution-surface dependence that caused deterministic/flaky failures.

#### Verification

Spec:
- target: `br/pkg/restore/snap_client :: TestConcurrency`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./br/pkg/restore/snap_client -run '^TestConcurrency$' -count=1`
- `go test -json ./br/pkg/restore/snap_client -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #66975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for snapshot concurrency by moving interception to the storage layer, enabling more reliable concurrency gating and removing previous test interception hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->