### PR TITLE
pkg/executor/sortexec: stabilize flaky TestInterruptedDuringSpilling

### DIFF
--- a/pkg/executor/sortexec/sortexec_pkg_test.go
+++ b/pkg/executor/sortexec/sortexec_pkg_test.go
@@ -82,6 +82,12 @@ func TestInterruptedDuringSort(t *testing.T) {
 }
 
 func TestInterruptedDuringSpilling(t *testing.T) {
+	originalSpillChunkSize := spillChunkSize
+	SetSmallSpillChunkSizeForTest()
+	defer func() {
+		spillChunkSize = originalSpillChunkSize
+	}()
+
 	defer config.RestoreFunc()()
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.TempStoragePath = t.TempDir()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68459

Problem Summary:
Flaky test `TestInterruptedDuringSpilling` in `pkg/executor/sortexec` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The flaky came from a brittle `<1s` wall-clock assumption in the spill interruption test, which is sensitive to spill checkpoint timing under variable runtime pressure.

#### Fix

Forcing small spill chunks only in this test makes interruption checkpoints dense and deterministic, preserving the original assertion intent without product-code changes.

#### Verification

Spec:
- target: `pkg/executor/sortexec :: TestInterruptedDuringSpilling`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/executor/sortexec -run '^TestInterruptedDuringSpilling$' -count=1`
- `go test -json ./pkg/executor/sortexec -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #50799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by configuring a smaller chunk size during spill testing to better validate interrupt handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->