### PR TITLE
[DNM] poc: tidb_copr_resolve_lock_lite, tidb_copr_sync_resolve_lock, and 67862

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -371,3 +371,5 @@ replace (
 	sourcegraph.com/sourcegraph/appdash => github.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 	sourcegraph.com/sourcegraph/appdash-data => github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
+
+replace github.com/tikv/client-go/v2 => github.com/ekexium/client-go/v2 v2.0.0-alpha.0.20260419041348-e35d46bb803f

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,10 @@ github.com/dolthub/swiss v0.2.1/go.mod h1:8AhKZZ1HK7g18j7v7k6c5cYIGEZJcPn0ARsai8
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/ekexium/client-go/v2 v2.0.0-alpha.0.20260419035554-f132457129c1 h1:K9liFnKnKrhf6Usm9i3wEZEviGYhYPG6VsDPqt9klsU=
+github.com/ekexium/client-go/v2 v2.0.0-alpha.0.20260419035554-f132457129c1/go.mod h1:ZLHQiuG/o3JHzMuE7dT2GnGCf+SPxUNbcr6farUsU18=
+github.com/ekexium/client-go/v2 v2.0.0-alpha.0.20260419041348-e35d46bb803f h1:Ga2kJUimOCsxDBZ54NZJMJjThtAq4fn/LSG3wkjTddA=
+github.com/ekexium/client-go/v2 v2.0.0-alpha.0.20260419041348-e35d46bb803f/go.mod h1:ZLHQiuG/o3JHzMuE7dT2GnGCf+SPxUNbcr6farUsU18=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/pkg/distsql/context/context.go
+++ b/pkg/distsql/context/context.go
@@ -42,6 +42,7 @@ type DistSQLContext struct {
 	EnabledRateLimitAction bool
 	EnableChunkRPC         bool
 	CoprResolveLockLite    bool
+	CoprSyncResolveLock   bool
 	OriginalSQL            string
 	KVVars                 *tikvstore.Variables
 	KvExecCounter          *stmtstats.KvExecCounter

--- a/pkg/distsql/context/context.go
+++ b/pkg/distsql/context/context.go
@@ -42,7 +42,7 @@ type DistSQLContext struct {
 	EnabledRateLimitAction bool
 	EnableChunkRPC         bool
 	CoprResolveLockLite    bool
-	CoprSyncResolveLock   bool
+	CoprSyncResolveLock    bool
 	OriginalSQL            string
 	KVVars                 *tikvstore.Variables
 	KvExecCounter          *stmtstats.KvExecCounter

--- a/pkg/distsql/context/context.go
+++ b/pkg/distsql/context/context.go
@@ -41,6 +41,7 @@ type DistSQLContext struct {
 
 	EnabledRateLimitAction bool
 	EnableChunkRPC         bool
+	CoprResolveLockLite    bool
 	OriginalSQL            string
 	KVVars                 *tikvstore.Variables
 	KvExecCounter          *stmtstats.KvExecCounter

--- a/pkg/distsql/context/context_test.go
+++ b/pkg/distsql/context/context_test.go
@@ -50,6 +50,7 @@ func TestContextDetach(t *testing.T) {
 		InRestrictedSQL:        true,
 		EnabledRateLimitAction: true,
 		EnableChunkRPC:         true,
+		CoprResolveLockLite:    true,
 		OriginalSQL:            "a",
 		KVVars:                 kvVars,
 		KvExecCounter:          &stmtstats.KvExecCounter{},

--- a/pkg/distsql/context/context_test.go
+++ b/pkg/distsql/context/context_test.go
@@ -51,7 +51,7 @@ func TestContextDetach(t *testing.T) {
 		EnabledRateLimitAction: true,
 		EnableChunkRPC:         true,
 		CoprResolveLockLite:    true,
-		CoprSyncResolveLock:   true,
+		CoprSyncResolveLock:    true,
 		OriginalSQL:            "a",
 		KVVars:                 kvVars,
 		KvExecCounter:          &stmtstats.KvExecCounter{},

--- a/pkg/distsql/context/context_test.go
+++ b/pkg/distsql/context/context_test.go
@@ -51,6 +51,7 @@ func TestContextDetach(t *testing.T) {
 		EnabledRateLimitAction: true,
 		EnableChunkRPC:         true,
 		CoprResolveLockLite:    true,
+		CoprSyncResolveLock:   true,
 		OriginalSQL:            "a",
 		KVVars:                 kvVars,
 		KvExecCounter:          &stmtstats.KvExecCounter{},

--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -373,6 +373,7 @@ func (builder *RequestBuilder) SetFromSessionVars(dctx *distsqlctx.DistSQLContex
 	builder.Request.RunawayChecker = dctx.RunawayChecker
 	builder.Request.TiKVClientReadTimeout = dctx.TiKVClientReadTimeout
 	builder.Request.MaxExecutionTime = dctx.MaxExecutionTime
+	builder.Request.CoprResolveLockLite = dctx.CoprResolveLockLite
 	return builder
 }
 

--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -374,6 +374,7 @@ func (builder *RequestBuilder) SetFromSessionVars(dctx *distsqlctx.DistSQLContex
 	builder.Request.TiKVClientReadTimeout = dctx.TiKVClientReadTimeout
 	builder.Request.MaxExecutionTime = dctx.MaxExecutionTime
 	builder.Request.CoprResolveLockLite = dctx.CoprResolveLockLite
+	builder.Request.CoprSyncResolveLock = dctx.CoprSyncResolveLock
 	return builder
 }
 

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -613,6 +613,9 @@ type Request struct {
 	// CoprResolveLockLite controls whether coprocessor uses resolve lock lite.
 	CoprResolveLockLite bool
 
+	// CoprSyncResolveLock controls whether coprocessor resolves locks synchronously.
+	CoprSyncResolveLock bool
+
 	// ConnID stores the session connection id.
 	ConnID uint64
 	// ConnAlias stores the session connection alias.

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -610,6 +610,9 @@ type Request struct {
 
 	RunawayChecker resourcegroup.RunawayChecker
 
+	// CoprResolveLockLite controls whether coprocessor uses resolve lock lite.
+	CoprResolveLockLite bool
+
 	// ConnID stores the session connection id.
 	ConnID uint64
 	// ConnAlias stores the session connection alias.

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2930,6 +2930,7 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 			EnabledRateLimitAction: vars.EnabledRateLimitAction,
 			EnableChunkRPC:         vars.EnableChunkRPC,
 			CoprResolveLockLite:    vars.CoprResolveLockLite,
+			CoprSyncResolveLock:   vars.CoprSyncResolveLock,
 			OriginalSQL:            sc.OriginalSQL,
 			KVVars:                 vars.KVVars,
 			KvExecCounter:          sc.KvExecCounter,

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2930,7 +2930,7 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 			EnabledRateLimitAction: vars.EnabledRateLimitAction,
 			EnableChunkRPC:         vars.EnableChunkRPC,
 			CoprResolveLockLite:    vars.CoprResolveLockLite,
-			CoprSyncResolveLock:   vars.CoprSyncResolveLock,
+			CoprSyncResolveLock:    vars.CoprSyncResolveLock,
 			OriginalSQL:            sc.OriginalSQL,
 			KVVars:                 vars.KVVars,
 			KvExecCounter:          sc.KvExecCounter,

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2929,6 +2929,7 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 
 			EnabledRateLimitAction: vars.EnabledRateLimitAction,
 			EnableChunkRPC:         vars.EnableChunkRPC,
+			CoprResolveLockLite:    vars.CoprResolveLockLite,
 			OriginalSQL:            sc.OriginalSQL,
 			KVVars:                 vars.KVVars,
 			KvExecCounter:          sc.KvExecCounter,

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1066,6 +1066,9 @@ const (
 
 	// TiDBCoprResolveLockLite controls whether coprocessor uses resolve lock lite instead of resolve lock.
 	TiDBCoprResolveLockLite = "tidb_copr_resolve_lock_lite"
+
+	// TiDBCoprSyncResolveLock controls whether coprocessor resolves locks synchronously.
+	TiDBCoprSyncResolveLock = "tidb_copr_sync_resolve_lock"
 )
 
 // TiDB vars that have only global scope
@@ -1721,6 +1724,7 @@ const (
 	DefTiDBCircuitBreakerPDMetaErrorRateRatio         = 0.0
 	DefTiDBAccelerateUserCreationUpdate               = false
 	DefTiDBCoprResolveLockLite                        = true
+	DefTiDBCoprSyncResolveLock                        = true
 	DefTiDBEnableTSValidation                         = true
 	DefTiDBLoadBindingTimeout                         = 200
 	DefTiDBAdvancerCheckPointLagLimit                 = 48 * time.Hour

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1063,6 +1063,9 @@ const (
 
 	// TiDBAccelerateUserCreationUpdate decides whether tidb will load & update the whole user's data in-memory.
 	TiDBAccelerateUserCreationUpdate = "tidb_accelerate_user_creation_update"
+
+	// TiDBCoprResolveLockLite controls whether coprocessor uses resolve lock lite instead of resolve lock.
+	TiDBCoprResolveLockLite = "tidb_copr_resolve_lock_lite"
 )
 
 // TiDB vars that have only global scope
@@ -1717,6 +1720,7 @@ const (
 	DefTiDBTSOClientRPCMode                           = TSOClientRPCModeDefault
 	DefTiDBCircuitBreakerPDMetaErrorRateRatio         = 0.0
 	DefTiDBAccelerateUserCreationUpdate               = false
+	DefTiDBCoprResolveLockLite                        = true
 	DefTiDBEnableTSValidation                         = true
 	DefTiDBLoadBindingTimeout                         = 200
 	DefTiDBAdvancerCheckPointLagLimit                 = 48 * time.Hour

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1191,6 +1191,9 @@ type SessionVars struct {
 	// EnableChunkRPC indicates whether the coprocessor request can use chunk API.
 	EnableChunkRPC bool
 
+	// CoprResolveLockLite controls whether coprocessor uses resolve lock lite.
+	CoprResolveLockLite bool
+
 	writeStmtBufs WriteStmtBufs
 
 	// ConstraintCheckInPlace indicates whether to check the constraint when the SQL executing.

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1194,6 +1194,9 @@ type SessionVars struct {
 	// CoprResolveLockLite controls whether coprocessor uses resolve lock lite.
 	CoprResolveLockLite bool
 
+	// CoprSyncResolveLock controls whether coprocessor resolves locks asynchronously.
+	CoprSyncResolveLock bool
+
 	writeStmtBufs WriteStmtBufs
 
 	// ConstraintCheckInPlace indicates whether to check the constraint when the SQL executing.

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -274,6 +274,10 @@ var defaultSysVars = []*SysVar{
 		s.EnableChunkRPC = TiDBOptOn(val)
 		return nil
 	}},
+	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBCoprResolveLockLite, Value: BoolToOnOff(vardef.DefTiDBCoprResolveLockLite), Type: vardef.TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.CoprResolveLockLite = TiDBOptOn(val)
+		return nil
+	}},
 	{Scope: vardef.ScopeSession, Name: vardef.TxnIsolationOneShot, Value: "", skipInit: true, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope vardef.ScopeFlag) (string, error) {
 		return checkIsolationLevel(vars, normalizedValue, originalValue, scope)
 	}, SetSession: func(s *SessionVars, val string) error {

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -278,6 +278,10 @@ var defaultSysVars = []*SysVar{
 		s.CoprResolveLockLite = TiDBOptOn(val)
 		return nil
 	}},
+	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBCoprSyncResolveLock, Value: BoolToOnOff(vardef.DefTiDBCoprSyncResolveLock), Type: vardef.TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.CoprSyncResolveLock = TiDBOptOn(val)
+		return nil
+	}},
 	{Scope: vardef.ScopeSession, Name: vardef.TxnIsolationOneShot, Value: "", skipInit: true, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope vardef.ScopeFlag) (string, error) {
 		return checkIsolationLevel(vars, normalizedValue, originalValue, scope)
 	}, SetSession: func(s *SessionVars, val string) error {

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -199,7 +199,6 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache stats
 		tblID, statsVer := row.GetInt64(0), row.GetInt64(8)
 		if table == nil || table.PhysicalID != tblID {
 			if table != nil {
-				table.ColAndIdxExistenceMap.SetChecked()
 				cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
 			}
 			var ok bool
@@ -296,7 +295,6 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache stats
 		}
 	}
 	if table != nil {
-		table.ColAndIdxExistenceMap.SetChecked()
 		cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
 	}
 }

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -583,7 +583,6 @@ func TableStatsFromStorage(sctx sessionctx.Context, snapshot uint64, tableInfo *
 			table.StatsVer = statistics.Version0
 		}
 	}
-	table.ColAndIdxExistenceMap.SetChecked()
 	return ExtendedStatsFromStorage(sctx, table.CopyAs(statistics.ExtendedStatsWritable), tableID, loadAll)
 }
 

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -401,9 +401,9 @@ func (s *statsSyncLoad) handleOneItemTask(task *statstypes.NeededItemTask) (err 
 		// If this column is not analyzed yet and we don't have it in memory.
 		// We create a fake one for the pseudo estimation.
 		// Otherwise, it will trigger the sync/async load again, even if the column has not been analyzed.
-		if loadNeeded && !analyzed {
+		if !analyzed {
 			wrapper.col = statistics.EmptyColumn(item.TableID, isPkIsHandle, wrapper.colInfo)
-			s.updateCachedItem(tblInfo, item, wrapper.col, wrapper.idx, task.Item.FullLoad)
+			s.updateCachedItem(item, wrapper.col, wrapper.idx, task.Item.FullLoad)
 			return nil
 		}
 	}
@@ -428,7 +428,7 @@ func (s *statsSyncLoad) handleOneItemTask(task *statstypes.NeededItemTask) (err 
 	}
 	metrics.ReadStatsHistogram.Observe(float64(time.Since(t).Milliseconds()))
 	if needUpdate {
-		s.updateCachedItem(tblInfo, item, wrapper.col, wrapper.idx, task.Item.FullLoad)
+		s.updateCachedItem(item, wrapper.col, wrapper.idx, task.Item.FullLoad)
 	}
 	return nil
 }
@@ -567,7 +567,7 @@ func (*statsSyncLoad) writeToTimeoutChan(taskCh chan *statstypes.NeededItemTask,
 }
 
 // updateCachedItem updates the column/index hist to global statsCache.
-func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.TableItemID, colHist *statistics.Column, idxHist *statistics.Index, fullLoaded bool) (updated bool) {
+func (s *statsSyncLoad) updateCachedItem(item model.TableItemID, colHist *statistics.Column, idxHist *statistics.Index, fullLoaded bool) (updated bool) {
 	s.mutexForStatsCache.Lock()
 	defer s.mutexForStatsCache.Unlock()
 	// Reload the latest stats cache, otherwise the `updateStatsCache` may fail with high probability, because functions
@@ -577,21 +577,6 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 		return false
 	}
 	var tableCopied bool
-	if !tbl.ColAndIdxExistenceMap.Checked() {
-		tbl = tbl.CopyAs(statistics.BothMapsWritable)
-		tableCopied = true
-		for _, col := range tbl.HistColl.GetColSlice() {
-			if tblInfo.FindColumnByID(col.ID) == nil {
-				tbl.DelCol(col.ID)
-			}
-		}
-		for _, idx := range tbl.HistColl.GetIdxSlice() {
-			if tblInfo.FindIndexByID(idx.ID) == nil {
-				tbl.DelIdx(idx.ID)
-			}
-		}
-		tbl.ColAndIdxExistenceMap.SetChecked()
-	}
 	if !item.IsIndex && colHist != nil {
 		c := tbl.GetCol(item.ID)
 		// - If the stats is fully loaded,

--- a/pkg/statistics/table_test.go
+++ b/pkg/statistics/table_test.go
@@ -24,7 +24,6 @@ func TestCloneColAndIdxExistenceMap(t *testing.T) {
 	m := NewColAndIndexExistenceMapWithoutSize()
 	m.InsertCol(1, true)
 	m.InsertIndex(1, true)
-	m.SetChecked()
 
 	m2 := m.Clone()
 	require.Equal(t, m, m2)

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1213,7 +1213,7 @@ func newCopIteratorWorker(it *copIterator, taskCh <-chan *copTask) *copIteratorW
 		respChan:                it.respChan,
 		finishCh:                it.finishCh,
 		vars:                    it.vars,
-		kvclient:                txnsnapshot.NewClientHelper(it.store.store, &it.resolvedLocks, &it.committedLocks, false),
+		kvclient:                txnsnapshot.NewClientHelper(it.store.store, &it.resolvedLocks, &it.committedLocks, it.req.CoprResolveLockLite),
 		memTracker:              it.memTracker,
 		replicaReadSeed:         it.replicaReadSeed,
 		pagingTaskIdx:           &it.pagingTaskIdx,

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -2370,6 +2370,7 @@ func (worker *copIteratorWorker) handleLockErr(bo *Backoffer, lockErr *kvrpcpb.L
 		CallerStartTS: worker.req.StartTs,
 		Locks:         []*txnlock.Lock{txnlock.NewLock(lockErr)},
 		Detail:        resolveLockDetail,
+		SyncResolve:   worker.req.CoprSyncResolveLock,
 	}
 	resolveLocksRes, err1 := worker.kvclient.ResolveLocksWithOpts(bo.TiKVBackoffer(), resolveLocksOpts)
 	err1 = derr.ToTiDBErr(err1)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two system variables to control coprocessor lock resolution behavior (configurable per-session and globally).

* **Bug Fixes**
  * Streamlined statistics loading and cache update logic; removed obsolete internal state tracking to simplify behavior.

* **Chores**
  * Updated module replacement for a dependency used by the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->