### PR TITLE
br/pkg/streamhelper: stabilize flaky TestNormalError

### DIFF
--- a/br/pkg/streamhelper/subscription_test.go
+++ b/br/pkg/streamhelper/subscription_test.go
@@ -35,13 +35,24 @@ func installSubscribeSupportForRandomN(c *fakeCluster, n int) {
 }
 
 func waitPendingEvents(t *testing.T, sub *streamhelper.FlushSubscriber) {
+	t.Helper()
+	const (
+		quietWindow = 500 * time.Millisecond
+		timeout     = 30 * time.Second
+		checkEvery  = 50 * time.Millisecond
+	)
+
 	last := len(sub.Events())
-	time.Sleep(100 * time.Microsecond)
+	stableSince := time.Now()
 	require.Eventually(t, func() bool {
-		noProg := len(sub.Events()) == last
-		last = len(sub.Events())
-		return noProg
-	}, 3*time.Second, 100*time.Millisecond)
+		current := len(sub.Events())
+		if current != last {
+			last = current
+			stableSince = time.Now()
+			return false
+		}
+		return time.Since(stableSince) >= quietWindow
+	}, timeout, checkEvery)
 }
 
 func TestSubBasic(t *testing.T) {

--- a/br/pkg/streamhelper/subscription_test.go
+++ b/br/pkg/streamhelper/subscription_test.go
@@ -43,12 +43,20 @@ func waitPendingEvents(t *testing.T, sub *streamhelper.FlushSubscriber) {
 	)
 
 	last := len(sub.Events())
+	seenEvents := last > 0
 	stableSince := time.Now()
 	require.Eventually(t, func() bool {
 		current := len(sub.Events())
 		if current != last {
 			last = current
+			seenEvents = seenEvents || current > 0
 			stableSince = time.Now()
+			return false
+		}
+		if current > 0 {
+			seenEvents = true
+		}
+		if !seenEvents {
 			return false
 		}
 		return time.Since(stableSince) >= quietWindow
@@ -87,6 +95,36 @@ func TestSubBasic(t *testing.T) {
 }
 
 func TestNormalError(t *testing.T) {
+	t.Run("waits for first event before dropping", func(t *testing.T) {
+		const delayedFlush = 700 * time.Millisecond
+
+		req := require.New(t)
+		ctx := context.Background()
+		c := createFakeCluster(t, 4, true)
+		c.splitAndScatter("0001", "0002", "0003", "0008", "0009")
+		installSubscribeSupport(c)
+
+		sub := streamhelper.NewSubscriber(c, c)
+		req.NoError(sub.UpdateStoreTopology(ctx))
+
+		checkpointReady := make(chan uint64, 1)
+		go func() {
+			time.Sleep(delayedFlush)
+			cp := c.advanceCheckpoints()
+			c.flushAll()
+			checkpointReady <- cp
+		}()
+
+		waitPendingEvents(t, sub)
+		sub.Drop()
+		s := spans.Sorted(spans.NewFullWith(spans.Full(), 1))
+		for k := range sub.Events() {
+			s.Merge(k)
+		}
+
+		req.Equal(<-checkpointReady, s.MinValue())
+	})
+
 	req := require.New(t)
 	ctx := context.Background()
 	c := createFakeCluster(t, 4, true)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67741

Problem Summary:
Flaky test `TestNormalError` in `br/pkg/streamhelper` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

`waitPendingEvents` had a brittle one-sample timing assumption and could return before delayed events arrived, making `TestNormalError` flaky.

#### Fix

A sustained-quiet-window wait is necessary to deterministically observe event-settlement before `Drop`, preventing premature truncation of in-flight events in the test.

#### Verification

Spec:
- target: `br/pkg/streamhelper :: TestNormalError`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./br/pkg/streamhelper -run '^TestNormalError$' -count=1`
- `go test -json ./br/pkg/streamhelper -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test helper reliability by replacing a brief sleep-and-check with a stable-wait strategy (waits for event count to stabilize over a quiet window) and longer overall timeout to reduce flakiness.
  * Added a subtest that verifies events are retained when a delayed flush occurs, preventing loss during subscriber shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->