### PR TITLE
metrics: add resource control diagnosis panels

### DIFF
--- a/pkg/metrics/grafana/tidb_resource_control.json
+++ b/pkg/metrics/grafana/tidb_resource_control.json
@@ -32,108 +32,116 @@
          "id": 2,
          "panels": [
             {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
                "datasource": "${DS_TEST-CLUSTER}",
-               "fieldConfig": {
-                  "overrides": [
-                     {
-                        "matcher": {
-                           "id": "byName",
-                           "options": "Burstable"
-                        },
-                        "properties": [
-                           {
-                              "id": "mappings",
-                              "value": [
-                                 {
-                                    "from": "0",
-                                    "text": "Off",
-                                    "to": "2147483647",
-                                    "type": 2
-                                 },
-                                 {
-                                    "text": "Moderated",
-                                    "type": 1,
-                                    "value": "-2"
-                                 },
-                                 {
-                                    "text": "Unlimited",
-                                    "type": 1,
-                                    "value": "-1"
-                                 }
-                              ]
-                           }
-                        ]
-                     }
-                  ]
-               },
+               "description": "Shows resource-group SQL latency together with instance-level RC queue wait and query throughput.",
+               "fill": 1,
+               "fillGradient": 0,
                "gridPos": {
                   "h": 7,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
                   "y": 0
                },
                "id": 3,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": true,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [
+                  {
+                     "alias": "/-qps$/",
+                     "yaxis": 2
+                  }
+               ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
                "targets": [
                   {
-                     "expr": "max by (resource_group, type) (resource_manager_server_group_config{type=\"priority\"})",
+                     "expr": "histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\"}[1m])) by (le, instance, resource_group))",
                      "format": "time_series",
-                     "instant": true,
                      "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}"
+                     "legendFormat": "{{instance}}-{{resource_group}}-p99",
+                     "refId": "A"
                   },
                   {
-                     "expr": "max by (resource_group, type) (resource_manager_server_group_config{type=\"ru_capacity\"})",
+                     "expr": "histogram_quantile(0.90, sum(rate(tidb_server_handle_query_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\"}[1m])) by (le, instance, resource_group))",
                      "format": "time_series",
-                     "instant": true,
                      "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}"
+                     "legendFormat": "{{instance}}-{{resource_group}}-p90",
+                     "refId": "B"
                   },
                   {
-                     "expr": "max by (resource_group, type) (resource_manager_server_group_config{type=\"ru_per_sec\"})",
+                     "expr": "histogram_quantile(0.99, sum(rate(tidb_server_slow_query_wait_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", sql_type=\"general\"}[1m])) by (le, instance))",
                      "format": "time_series",
-                     "instant": true,
                      "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}"
+                     "legendFormat": "{{instance}}-queue-p99",
+                     "refId": "C"
+                  },
+                  {
+                     "expr": "sum(rate(tidb_server_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\"}[1m])) by (instance, resource_group, result)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}}-{{resource_group}}-{{result}}-qps",
+                     "refId": "D"
                   }
                ],
-               "title": "RU Config",
-               "transformations": [
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "SQL Latency And Query Total",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
                   {
-                     "id": "labelsToFields",
-                     "options": {
-                        "valueLabel": "type"
-                     }
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
                   },
                   {
-                     "id": "organize",
-                     "options": {
-                        "excludeByName": {
-                           "Time": true,
-                           "__name__": true,
-                           "instance": true,
-                           "job": true
-                        },
-                        "indexByName": {
-                           "Time": 0,
-                           "__name__": 1,
-                           "instance": 2,
-                           "job": 3,
-                           "priority": 5,
-                           "resource_group": 4,
-                           "ru_capacity": 7,
-                           "ru_per_sec": 6
-                        },
-                        "renameByName": {
-                           "priority": "Priority",
-                           "resource_group": "Group Name",
-                           "ru_capacity": "Burstable",
-                           "ru_per_sec": "RU_PER_SEC"
-                        }
-                     }
+                     "format": "ops",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
                   }
-               ],
-               "transparent": false,
-               "type": "table"
+               ]
             },
             {
                "aliasColors": { },
@@ -141,13 +149,13 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about request unit cost for all resource groups.",
+               "description": "Shows demand, average RU, fill rate, and throttling together.",
                "fill": 1,
                "fillGradient": 0,
                "gridPos": {
                   "h": 7,
                   "w": 12,
-                  "x": 0,
+                  "x": 12,
                   "y": 0
                },
                "id": 4,
@@ -178,45 +186,38 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
+                     "expr": "resource_manager_client_resource_group_demand_ru_per_sec{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "tp-{{resource_group}}",
+                     "legendFormat": "{{instance}}-{{resource_group}}-demand",
                      "refId": "A"
                   },
                   {
-                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\"}[1m]))",
+                     "expr": "resource_manager_client_resource_group_avg_ru_per_sec{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "tp-total",
+                     "legendFormat": "{{instance}}-{{resource_group}}-avg",
                      "refId": "B"
                   },
                   {
-                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
+                     "expr": "resource_manager_client_resource_group_fill_rate{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "ap-{{resource_group}}",
+                     "legendFormat": "{{instance}}-{{resource_group}}-fill",
                      "refId": "C"
                   },
                   {
-                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\"}[1m]))",
+                     "expr": "resource_manager_client_resource_group_throttled{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "ap-total",
+                     "legendFormat": "{{instance}}-{{resource_group}}-throttled",
                      "refId": "D"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap|tp\"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap|tp\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total",
-                     "refId": "E"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "RU",
+               "title": "Demand And Fill Rate",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -234,7 +235,7 @@
                   {
                      "format": "short",
                      "label": null,
-                     "logBase": 10,
+                     "logBase": 1,
                      "max": null,
                      "min": null,
                      "show": true
@@ -248,107 +249,34 @@
                      "show": true
                   }
                ]
-            },
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "SQL latency / Time_queued_by_rc / query_total",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 5,
+         "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The max request unit cost for resource groups during in a period(20s).",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 5,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(resource_manager_resource_unit_read_request_unit_max_per_sec{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-read",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(resource_manager_resource_unit_write_request_unit_max_per_sec{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-write",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "RU Max(Max Cost During 20s Period)",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The avg request unit cost for each query.",
+               "description": "Shows available token balance and throttling state by resource group and TiDB instance.",
                "fill": 1,
                "fillGradient": 0,
                "gridPos": {
@@ -385,24 +313,24 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "(sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
+                     "expr": "resource_manager_client_resource_group_token_balance{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
+                     "legendFormat": "{{instance}}-{{resource_group}}-balance",
                      "refId": "A"
                   },
                   {
-                     "expr": "(sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\"}[1m]))) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
+                     "expr": "resource_manager_client_resource_group_throttled{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "total",
+                     "legendFormat": "{{instance}}-{{resource_group}}-throttled",
                      "refId": "B"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "RU Per Query",
+               "title": "Token Balance And Throttle",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -420,7 +348,7 @@
                   {
                      "format": "short",
                      "label": null,
-                     "logBase": 10,
+                     "logBase": 1,
                      "max": null,
                      "min": null,
                      "show": true
@@ -441,7 +369,7 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The read request unit cost for all resource groups.",
+               "description": "Shows instance-level token request latency together with per-group request volume.",
                "fill": 1,
                "fillGradient": 0,
                "gridPos": {
@@ -472,30 +400,49 @@
                "points": false,
                "renderer": "flot",
                "repeat": null,
-               "seriesOverrides": [ ],
+               "seriesOverrides": [
+                  {
+                     "alias": "/-req\\/s$/",
+                     "yaxis": 2
+                  }
+               ],
                "spaceLength": 10,
                "stack": false,
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
+                     "expr": "histogram_quantile(0.99, sum(rate(resource_manager_client_token_request_duration_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
+                     "legendFormat": "{{instance}}-p99",
                      "refId": "A"
                   },
                   {
-                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\"}[1m]))",
+                     "expr": "histogram_quantile(0.90, sum(rate(resource_manager_client_token_request_duration_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "total",
+                     "legendFormat": "{{instance}}-p90",
                      "refId": "B"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_client_token_request_duration_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance) / sum(rate(resource_manager_client_token_request_duration_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}}-avg",
+                     "refId": "C"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_client_token_request_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\"}[1m])) by (instance, resource_group)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}}-{{resource_group}}-req/s",
+                     "refId": "D"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "RRU",
+               "title": "Token Request Latency And Volume",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -511,15 +458,15 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "s",
                      "label": null,
-                     "logBase": 10,
+                     "logBase": 1,
                      "max": null,
                      "min": null,
                      "show": true
                   },
                   {
-                     "format": "short",
+                     "format": "ops",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -527,113 +474,40 @@
                      "show": true
                   }
                ]
-            },
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Token balance / throttled / token request latency",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 8,
+         "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The avg read request unit cost for each query.",
+               "description": "Tracks PD-side slot state, outstanding token loan, slot lifecycle, and average trickle duration.",
                "fill": 1,
                "fillGradient": 0,
                "gridPos": {
                   "h": 7,
-                  "w": 12,
+                  "w": 24,
                   "x": 0,
-                  "y": 0
-               },
-               "id": 8,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "RRU Per Query",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The write request unit cost for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
                   "y": 0
                },
                "id": 9,
@@ -664,24 +538,38 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
+                     "expr": "resource_manager_server_token_loan{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
+                     "legendFormat": "{{instance}}-{{resource_group}}-loan",
                      "refId": "A"
                   },
                   {
-                     "expr": "sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\"}[1m]))",
+                     "expr": "resource_manager_server_active_slot_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "total",
+                     "legendFormat": "{{instance}}-{{resource_group}}-slots",
                      "refId": "B"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_server_slot_events_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\"}[1m])) by (instance, resource_group, event)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}}-{{resource_group}}-{{event}}",
+                     "refId": "C"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_server_trickle_duration_ms_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\"}[1m])) / sum(rate(resource_manager_server_trickle_duration_ms_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\"}[1m]))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "trickle-avg-ms",
+                     "refId": "D"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "WRU",
+               "title": "Server Slots, Loan, And Trickle",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -699,7 +587,7 @@
                   {
                      "format": "short",
                      "label": null,
-                     "logBase": 10,
+                     "logBase": 1,
                      "max": null,
                      "min": null,
                      "show": true
@@ -713,14 +601,34 @@
                      "show": true
                   }
                ]
-            },
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "trickle_duration_ms / active_slot_count / token_loan / slot_events_total",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 10,
+         "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The avg write request unit cost for each query.",
+               "description": "Shows configured RU rate and burst capacity for the selected resource groups.",
                "fill": 1,
                "fillGradient": 0,
                "gridPos": {
@@ -729,7 +637,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 10,
+               "id": 11,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -757,24 +665,24 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
+                     "expr": "max by (instance, resource_group, type) (resource_manager_server_group_config{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\", type=\"ru_per_sec\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
+                     "legendFormat": "{{instance}}-{{resource_group}}-ru_per_sec",
                      "refId": "A"
                   },
                   {
-                     "expr": "sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|tp\"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
+                     "expr": "max by (instance, resource_group, type) (resource_manager_server_group_config{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\", type=\"ru_capacity\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "total",
+                     "legendFormat": "{{instance}}-{{resource_group}}-ru_capacity",
                      "refId": "B"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "WRU Per Query",
+               "title": "RU Config",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -792,7 +700,7 @@
                   {
                      "format": "short",
                      "label": null,
-                     "logBase": 10,
+                     "logBase": 1,
                      "max": null,
                      "min": null,
                      "show": true
@@ -806,40 +714,20 @@
                      "show": true
                   }
                ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Resource Unit",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 0
-         },
-         "id": 11,
-         "panels": [
+            },
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about kv request count for all resource groups.",
+               "description": "Shows whether throttling and trickle are caused by group fill/burst or by service_limit.",
                "fill": 1,
                "fillGradient": 0,
                "gridPos": {
                   "h": 7,
                   "w": 12,
-                  "x": 0,
+                  "x": 12,
                   "y": 0
                },
                "id": 12,
@@ -870,1554 +758,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(resource_manager_resource_request_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group, type)",
+                     "expr": "sum(rate(resource_manager_server_request_cause_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\", keyspace_name=~\"$keyspace_name\"}[1m])) by (instance, resource_group, kind, cause)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-{{type}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_request_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "KV Request Count",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The avg kv request count for each query.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 13,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_resource_request_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"read\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-read",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_request_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"write\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-write",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_request_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"read\"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total-read",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_request_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"write\"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total-write",
-                     "refId": "D"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "KV Request Count Per Query",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about bytes read for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 14,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_resource_read_byte_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_read_byte_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Bytes Read",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The avg bytes read for each query.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 15,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_resource_read_byte_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_read_byte_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Bytes Read Per Query",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about bytes written for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 16,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_resource_write_byte_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_write_byte_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Bytes Written",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The avg bytes written for each query.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 17,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_resource_write_byte_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_write_byte_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Bytes Written Per Query",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about kv cpu time for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 18,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_resource_kv_cpu_time_ms_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_kv_cpu_time_ms_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "KV CPU Time",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "ms",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "ms",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about sql cpu time for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 19,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_resource_sql_cpu_time_ms_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_sql_cpu_time_ms_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "SQL CPU Time",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "ms",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "ms",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about cross AZ network traffic involved in queries for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 20,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_resource_cross_az_traffic_byte_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\", type=\"read\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_cross_az_traffic_byte_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"read\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Cross AZ Traffic Bytes(Read)",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about cross AZ network traffic involved in write for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 21,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_resource_cross_az_traffic_byte_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\", type=\"write\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_cross_az_traffic_byte_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"write\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Cross AZ Traffic Bytes(Write)",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Resource Details",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 0
-         },
-         "id": 22,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": true,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about active resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 24,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 23,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "resource_manager_client_resource_group_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{resource_group}}",
+                     "legendFormat": "{{instance}}-{{resource_group}}-{{kind}}-{{cause}}",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Active Resource Groups",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about total kv request count.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 24,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_client_request_success_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance) + sum(rate(resource_manager_client_request_fail{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-total",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_client_request_success_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) + sum(rate(resource_manager_client_request_fail{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Total KV Request Count",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about failed kv request count.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 25,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_client_request_fail{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\"}[1m])) by (instance, resource_group, type)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-{{type}}-{{instance}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_client_request_fail{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance)",
-                     "format": "time_series",
-                     "hide": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Failed KV Request Count",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about successful kv request wait duration.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 26,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(resource_manager_client_request_success_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\"}[1m])) by (instance, resource_group, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{resource_group}}-99",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.9, sum(rate(resource_manager_client_request_success_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\"}[1m])) by (instance, resource_group, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{resource_group}}-90",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Successful KV Request Wait Duration",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about successful kv request count.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 27,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_client_request_success_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-total",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_client_request_success_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\"}[1m])) by (instance, resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{resource_group}}",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Successful KV Request Count",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about token request handle duration.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 28,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(resource_manager_client_token_request_duration_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-99",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.999, sum(rate(resource_manager_client_token_request_duration_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-999",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Token Request Handle Duration",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The metrics about token request count.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 29,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(delta(resource_manager_client_token_request_duration_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-total",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(delta(resource_manager_client_token_request_duration_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", type=\"success\"}[1m])) by (instance)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-successful",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(delta(resource_manager_client_token_request_duration_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", type=\"fail\"}[1m])) by (instance)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-failed",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_client_token_request_resource_group{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\", resource_group=~\"$resource_group\"}[1m])) by (instance, resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{resource_group}}",
-                     "refId": "D"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Token Request Count",
+               "title": "Throttling Causes",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -2455,2546 +806,7 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "Client",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 0
-         },
-         "id": 30,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "TiDB max durations for different resource group",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 31,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(1.0, sum(rate(tidb_server_handle_query_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (le,resource_group))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Query Max Duration",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "Runaway manager events for different resource group",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 32,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(tidb_server_query_runaway_check{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"hit\", resource_group=~\"$resource_group\"}[5m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-hit",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(tidb_server_query_runaway_check{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type!=\"hit\", resource_group=~\"$resource_group\"}[5m])) by (resource_group, type, action)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-{{type}}-{{action}}",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Runaway Event",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The rate of runaway flusher flush operations per second, by flusher name and result.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 33,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(tidb_server_runaway_flusher_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name, result)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}}-{{result}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Runaway Flusher Flush OPS",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The rate of records added to runaway flusher per second, by flusher name.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 34,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(tidb_server_runaway_flusher_add_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Runaway Flusher Add OPS",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The batch size distribution of runaway flusher flush operations.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 35,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(tidb_server_runaway_flusher_batch_size_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}}-P99",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.9, sum(rate(tidb_server_runaway_flusher_batch_size_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}}-P90",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(tidb_server_runaway_flusher_batch_size_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name) / sum(rate(tidb_server_runaway_flusher_batch_size_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}}-avg",
-                     "refId": "C"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Runaway Flusher Batch Size",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The duration of runaway flusher flush operations in seconds.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 36,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(tidb_server_runaway_flusher_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}}-P99",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.9, sum(rate(tidb_server_runaway_flusher_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}}-P90",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(tidb_server_runaway_flusher_duration_seconds_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name) / sum(rate(tidb_server_runaway_flusher_duration_seconds_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}}-avg",
-                     "refId": "C"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Runaway Flusher Duration",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The interval between consecutive runaway flusher flush operations in seconds.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 37,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(tidb_server_runaway_flusher_interval_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}}-P99",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.9, sum(rate(tidb_server_runaway_flusher_interval_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}}-P90",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(tidb_server_runaway_flusher_interval_seconds_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name) / sum(rate(tidb_server_runaway_flusher_interval_seconds_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (name)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}}-avg",
-                     "refId": "C"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Runaway Flusher Interval",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The rate of runaway syncer operations per second, by instance and result.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 38,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(tidb_server_runaway_syncer_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance, result)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{result}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Runaway Syncer OPS",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The duration of runaway syncer read operations in seconds.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 39,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(tidb_server_runaway_syncer_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-P99",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.9, sum(rate(tidb_server_runaway_syncer_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-P90",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(tidb_server_runaway_syncer_duration_seconds_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance) / sum(rate(tidb_server_runaway_syncer_duration_seconds_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-avg",
-                     "refId": "C"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Runaway Syncer Duration",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The interval between consecutive runaway syncer operations in seconds.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 40,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(tidb_server_runaway_syncer_interval_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-P99",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.9, sum(rate(tidb_server_runaway_syncer_interval_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-P90",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(tidb_server_runaway_syncer_interval_seconds_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance) / sum(rate(tidb_server_runaway_syncer_interval_seconds_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-avg",
-                     "refId": "C"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Runaway Syncer Interval",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "decimals": 0,
-               "description": "The current checkpoint (last synced record ID) of runaway syncer for watch and watch_done tables.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 41,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "tidb_server_runaway_syncer_checkpoint{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{type}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Runaway Syncer Checkpoint",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Runaway",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 0
-         },
-         "id": 42,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The total CPU time cost by tasks of each priority.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 43,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(tikv_resource_control_priority_task_exec_duration{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance, priority)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{priority}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Time By Priority",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "µs",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "µs",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The CPU quota limiter applied to each priority.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 44,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "tikv_resource_control_priority_quota_limit{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{priority}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Quota Limit By Priority",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "µs",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "µs",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "Tasks number per second that triggers quota limiter wait",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 45,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(tikv_resource_control_priority_wait_duration_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\"}[1m])) by (instance, priority)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{priority}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Tasks Wait QPS By Priority",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The wait Duration of tasks that triggers quota limiter wait per priority",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 46,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(tikv_resource_control_priority_wait_duration_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}[1m])) by (instance, priority, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{priority}}-P99",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(tikv_resource_control_priority_wait_duration_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}[1m])) by (instance, priority) / sum(rate(tikv_resource_control_priority_wait_duration_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}[1m])) by (instance, priority)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{priority}}-avg",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Priority Task Wait Duration",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Priority Task Control",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 0
-         },
-         "id": 47,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The total background task's request unit cost for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 48,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"background\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"background\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"background\"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"background\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Background Task RU",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The resource(CPU, IO) utilization percentage and limit of background tasks.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 49,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "tikv_resource_control_bg_resource_utilization{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}-{{type}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Background Task Resource Utilization",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percent",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "percent",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The total background task's io limit for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 50,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "tikv_resource_control_background_quota_limiter{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\", resource_group=~\"$resource_group\", type=\"io\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Background Task IO Limit",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The total background task's cpu consumption for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 51,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(tikv_resource_control_background_resource_consumption{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\", resource_group=~\"$resource_group\", type=\"cpu\"}[1m])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Background Task CPU Consumption",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "µs",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "µs",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The total background task's cpu limit for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 52,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "tikv_resource_control_background_quota_limiter{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\", resource_group=~\"$resource_group\", type=\"cpu\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Background Task CPU Limit",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "µs",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "µs",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The total background task's io consumption for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 53,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(tikv_resource_control_background_resource_consumption{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\", resource_group=~\"$resource_group\", type=\"io\"}[1m])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Background Task IO Consumption",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The total background task's wait duration for all resource groups.",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 54,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(tikv_resource_control_background_task_wait_duration{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\", resource_group=~\"$resource_group\"}[1m])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Background Task Total Wait Duration",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "µs",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "µs",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Background Task Control",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 0
-         },
-         "id": 55,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The Duration of sql execute for different resource group",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 56,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.999, sum(rate(tidb_server_handle_query_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",instance=~\"$tidb_instance\",resource_group=~\"$resource_group\"}[1m])) by (le,resource_group))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-P999",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",instance=~\"$tidb_instance\",resource_group=~\"$resource_group\"}[1m])) by (le,resource_group))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-P99",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.9, sum(rate(tidb_server_handle_query_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",instance=~\"$tidb_instance\",resource_group=~\"$resource_group\"}[1m])) by (le,resource_group))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-P90",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.8, sum(rate(tidb_server_handle_query_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",instance=~\"$tidb_instance\",resource_group=~\"$resource_group\"}[1m])) by (le,resource_group))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-P80",
-                     "refId": "D"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Query Duration",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "MySQL commands processing numbers per second. See https://dev.mysql.com/doc/internals/en/text-protocol.html and https://dev.mysql.com/doc/internals/en/prepared-statements.html",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 57,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(tidb_server_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",instance=~\"$tidb_instance\",resource_group=~\"$resource_group\"}[1m])) by (result,resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-{{result}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(tidb_server_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",result=\"OK\",instance=~\"$tidb_instance\",resource_group=~\"$resource_group\"}[1m] offset 1d)) by (result,resource_group)",
-                     "format": "time_series",
-                     "hide": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-yesterday",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Command Per Second",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "TiDB statement statistics",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 58,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(tidb_executor_statement_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",instance=~\"$tidb_instance\",resource_group=~\"$resource_group\"}[1m])) by (type,resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-{{type}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(tidb_executor_statement_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",instance=~\"$tidb_instance\",resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}-total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "QPS",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The number of connections to the TiDB server",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 59,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "tidb_server_connections{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",instance=~\"$tidb_instance\",resource_group=~\"$resource_group\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}--{{resource_group}}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "tidb_server_connections{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",instance=~\"$tidb_instance\",resource_group=~\"$resource_group\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{resource_group}}--total",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Connection Count",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_TEST-CLUSTER}",
-               "description": "The number of failed queries per minute",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 7,
-                  "w": 12,
-                  "x": 0,
-                  "y": 0
-               },
-               "id": 60,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(increase(tidb_server_execute_error_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\",resource_group=~\"$resource_group\"}[1m])) by (type, instance,resource_group)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}}-{{instance}}-{{resource_group}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Failed Query OPM",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 2,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Query Summary",
+         "title": "ru_per_sec / ru_capacity / throttling cause",
          "titleSize": "h6",
          "type": "row"
       }
@@ -5072,11 +884,11 @@
             "datasource": "${DS_TEST-CLUSTER}",
             "hide": 0,
             "includeAll": true,
-            "label": "TiKV Instance",
-            "multi": false,
-            "name": "tikv_instance",
+            "label": "Resource Group",
+            "multi": true,
+            "name": "resource_group",
             "options": [ ],
-            "query": "label_values(tikv_engine_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, instance)",
+            "query": "label_values(tidb_server_connections{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, resource_group)",
             "refresh": 1,
             "regex": "",
             "sort": 1,
@@ -5092,11 +904,11 @@
             "datasource": "${DS_TEST-CLUSTER}",
             "hide": 0,
             "includeAll": true,
-            "label": "Resource Group",
+            "label": "Keyspace Name",
             "multi": true,
-            "name": "resource_group",
+            "name": "keyspace_name",
             "options": [ ],
-            "query": "label_values(tidb_server_connections{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, resource_group)",
+            "query": "label_values(resource_manager_server_group_config{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, keyspace_name)",
             "refresh": 1,
             "regex": "",
             "sort": 1,

--- a/pkg/metrics/grafana/tidb_resource_control.jsonnet
+++ b/pkg/metrics/grafana/tidb_resource_control.jsonnet
@@ -12,20 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local tableNewPanel = import "grafonnet-7.0/panel/table.libsonnet";
 local grafana = import "grafonnet/grafana.libsonnet";
 local dashboard = grafana.dashboard;
 local row = grafana.row;
 local graphPanel = grafana.graphPanel;
 local prometheus = grafana.prometheus;
 local template = grafana.template;
-local transformation = grafana.transformation;
 
 local myNameFlag = "DS_TEST-CLUSTER";
 local myDS = "${" + myNameFlag + "}";
 
-// A new dashboard
-// Add the template variables
 local TiDBResourceControlDash = dashboard.new(
   title="Test-Cluster-TiDB-Resource-Control",
   editable=true,
@@ -39,7 +35,6 @@ local TiDBResourceControlDash = dashboard.new(
   pluginId="prometheus",
   pluginName="Prometheus",
 ).addTemplate(
-  // Default template for tidb-cloud
   template.new(
     allValues=null,
     current=null,
@@ -56,7 +51,6 @@ local TiDBResourceControlDash = dashboard.new(
     tagValuesQuery="",
   )
 ).addTemplate(
-  // Default template for tidb-cloud
   template.new(
     datasource=myDS,
     hide=2,
@@ -89,10 +83,10 @@ local TiDBResourceControlDash = dashboard.new(
     datasource=myDS,
     hide="",
     includeAll=true,
-    label="TiKV Instance",
-    multi=false,
-    name="tikv_instance",
-    query='label_values(tikv_engine_size_bytes{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}, instance)',
+    label="Resource Group",
+    multi=true,
+    name="resource_group",
+    query='label_values(tidb_server_connections{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}, resource_group)',
     refresh="load",
     regex="",
     sort=1,
@@ -105,10 +99,10 @@ local TiDBResourceControlDash = dashboard.new(
     datasource=myDS,
     hide="",
     includeAll=true,
-    label="Resource Group",
+    label="Keyspace Name",
     multi=true,
-    name="resource_group",
-    query='label_values(tidb_server_connections{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}, resource_group)',
+    name="keyspace_name",
+    query='label_values(resource_manager_server_group_config{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}, keyspace_name)',
     refresh="load",
     regex="",
     sort=1,
@@ -116,1470 +110,295 @@ local TiDBResourceControlDash = dashboard.new(
   )
 );
 
-
-//*  ==============Panel (Resource Unit)==================
-//*  Panel Title: Resource Unit
-//*  Description: The metrics about request unit(abstract unit) cost for all resource groups.
-//*  Panels: 7
-//*  ==============Panel (Resource Unit)==================
-local ruRow = row.new(collapse=true, title="Resource Unit");
-
-local ConfigPanel = tableNewPanel.new(
-  title="RU Config",
-  datasource=myDS,
-).addTarget(
-  prometheus.target(
-    'max by (resource_group, type) (resource_manager_server_group_config{type="priority"})',
-    legendFormat="{{resource_group}}",
-    instant=true,
-  )
-).addTarget(
-  prometheus.target(
-    'max by (resource_group, type) (resource_manager_server_group_config{type="ru_capacity"})',
-    legendFormat="{{resource_group}}",
-    instant=true,
-  )
-).addTarget(
-  prometheus.target(
-    'max by (resource_group, type) (resource_manager_server_group_config{type="ru_per_sec"})',
-    legendFormat="{{resource_group}}",
-    instant=true,
-  )
-).addTransformation(
-  transformation.new("labelsToFields", options={
-    valueLabel: "type",
-  })
-).addTransformation(
-  transformation.new("organize", options={
-    excludeByName: {
-      Time: true,
-      __name__: true,
-      instance: true,
-      job: true,
-    },
-    indexByName: {
-      Time: 0,
-      __name__: 1,
-      instance: 2,
-      job: 3,
-      resource_group: 4,
-      priority: 5,
-      ru_per_sec: 6,
-      ru_capacity: 7,
-    },
-    renameByName: {
-      priority: "Priority",
-      ru_per_sec: "RU_PER_SEC",
-      resource_group: "Group Name",
-      ru_capacity: "Burstable",
-    },
-  })
-).addOverride(
-  matcher={
-    id: "byName",
-    options: "Burstable",
-  },
-  properties=[
-    {
-      id: "mappings",
-      value: [
-        {
-          "from": "0",
-          "text": "Off",
-          "to": "2147483647",
-          "type": 2
-        },
-        {
-          "text": "Moderated",
-          "type": 1,
-          "value": "-2"
-        },
-        {
-          "text": "Unlimited",
-          "type": 1,
-          "value": "-1"
-        }
-      ],
-    },
-  ],
-);
-
-local RUPanel = graphPanel.new(
-  title="RU",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  description="The metrics about request unit cost for all resource groups.",
-  logBase1Y=10,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp", resource_group=~"$resource_group"}[1m])) by (resource_group) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="tp-{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m]))',
-    legendFormat="tp-total",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap", resource_group=~"$resource_group"}[1m])) by (resource_group) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="ap-{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap"}[1m]))',
-    legendFormat="ap-total",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap|tp"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap|tp"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local RUMaxPanel = graphPanel.new(
-  title="RU Max(Max Cost During 20s Period)",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  description="The max request unit cost for resource groups during in a period(20s).",
-  logBase1Y=10,
-).addTarget(
-  prometheus.target(
-    'sum(resource_manager_resource_unit_read_request_unit_max_per_sec{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}) by (resource_group)',
-    legendFormat="{{resource_group}}-read",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(resource_manager_resource_unit_write_request_unit_max_per_sec{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}) by (resource_group)',
-    legendFormat="{{resource_group}}-write",
-  )
-);
-
-local RUPerQueryPanel = graphPanel.new(
-  title="RU Per Query",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  description="The avg request unit cost for each query.",
-  logBase1Y=10,
-).addTarget(
-  prometheus.target(
-    '(sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp", resource_group=~"$resource_group"}[1m])) by (resource_group) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp", resource_group=~"$resource_group"}[1m])) by (resource_group)) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    '(sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m]))) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local RRUPanel = graphPanel.new(
-  title="RRU",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  description="The read request unit cost for all resource groups.",
-  logBase1Y=10,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local RRUPerQueryPanel = graphPanel.new(
-  title="RRU Per Query",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  description="The avg read request unit cost for each query.",
-  logBase1Y=10,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp", resource_group=~"$resource_group"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local WRUPanel = graphPanel.new(
-  title="WRU",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  description="The write request unit cost for all resource groups.",
-  logBase1Y=10,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local WRUPerQueryPanel = graphPanel.new(
-  title="WRU Per Query",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  description="The avg write request unit cost for each query.",
-  logBase1Y=10,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp", resource_group=~"$resource_group"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-
-//*  ============== Panel (Resource Details)==================
-//*  Panel Title: Resource Details
-//*  Description: The metrics about actual resource usage for all resource groups.
-//*  Panels: 8
-//*  ============== Panel (Resource Details)==================
-
-local resourceRow = row.new(collapse=true, title="Resource Details");
-local KVRequestCountPanel = graphPanel.new(
-  title="KV Request Count",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  description="The metrics about kv request count for all resource groups.",
-  logBase1Y=2,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_request_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group, type)',
-    legendFormat="{{resource_group}}-{{type}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_request_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}-total",
-  )
-);
-
-local KVRequestCountPerQueryPanel = graphPanel.new(
-  title="KV Request Count Per Query",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  description="The avg kv request count for each query.",
-  logBase1Y=2,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_request_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type="read", resource_group=~"$resource_group"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}-read",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_request_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type="write", resource_group=~"$resource_group"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}-write",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_request_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type="read"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
-    legendFormat="total-read",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_request_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type="write"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
-    legendFormat="total-write",
-  )
-);
-
-local BytesReadPanel = graphPanel.new(
-  title="Bytes Read",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="bytes",
-  description="The metrics about bytes read for all resource groups.",
-  logBase1Y=2,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_read_byte_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_read_byte_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local BytesReadPerQueryPanel = graphPanel.new(
-  title="Bytes Read Per Query",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="bytes",
-  description="The avg bytes read for each query.",
-  logBase1Y=2,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_read_byte_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_read_byte_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local BytesWrittenPanel = graphPanel.new(
-  title="Bytes Written",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="bytes",
-  description="The metrics about bytes written for all resource groups.",
-  logBase1Y=2,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_write_byte_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_write_byte_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local BytesWrittenPerQueryPanel = graphPanel.new(
-  title="Bytes Written Per Query",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="bytes",
-  description="The avg bytes written for each query.",
-  logBase1Y=2,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_write_byte_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_write_byte_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local KVCPUTimePanel = graphPanel.new(
-  title="KV CPU Time",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="ms",
-  description="The metrics about kv cpu time for all resource groups.",
-  logBase1Y=1,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_kv_cpu_time_ms_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_kv_cpu_time_ms_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local SQLCPUTimePanel = graphPanel.new(
-  title="SQL CPU Time",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="ms",
-  description="The metrics about sql cpu time for all resource groups.",
-  logBase1Y=1,
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_sql_cpu_time_ms_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_sql_cpu_time_ms_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local CrossAZTrafficRead = graphPanel.new(
-  title="Cross AZ Traffic Bytes(Read)",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=false,
-  legend_max=true,
-  legend_avg=false,
-  legend_current=false,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="bytes",
-  description="The metrics about cross AZ network traffic involved in queries for all resource groups.",
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_cross_az_traffic_byte_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group", type="read"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_cross_az_traffic_byte_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type="read"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local CrossAZTrafficWrite = graphPanel.new(
-  title="Cross AZ Traffic Bytes(Write)",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=false,
-  legend_max=true,
-  legend_avg=false,
-  legend_current=false,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="bytes",
-  description="The metrics about cross AZ network traffic involved in write for all resource groups.",
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_cross_az_traffic_byte_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group", type="write"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_cross_az_traffic_byte_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type="write"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-//*  ==============Panel (Client)==================
-//*  Row Title: Client
-//*  Description:  The metrics about resource control client
-//*  Panels: 7
-//*  ==============Panel (Client)==================
-
-local clientRow = row.new(collapse=true, title="Client");
-
-local ActiveResourceGroupPanel = graphPanel.new(
-  title="Active Resource Groups",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  bars=true,
-  format="short",
-  description="The metrics about active resource groups.",
-).addTarget(
-  prometheus.target(
-    'resource_manager_client_resource_group_status{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance", resource_group=~"$resource_group"}',
-    legendFormat="{{instance}}-{{resource_group}}",
-  )
-);
-
-local TotalKVRequestCountPanel = graphPanel.new(
-  title="Total KV Request Count",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  description="The metrics about total kv request count.",
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_client_request_success_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance) + sum(rate(resource_manager_client_request_fail{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance)',
-    legendFormat="{{instance}}-total",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_client_request_success_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) + sum(rate(resource_manager_client_request_fail{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-local FailedKVRequestCountPanel = graphPanel.new(
-  title="Failed KV Request Count",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  description="The metrics about failed kv request count.",
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_client_request_fail{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance", resource_group=~"$resource_group"}[1m])) by (instance, resource_group, type)',
-    legendFormat="{{resource_group}}-{{type}}-{{instance}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_client_request_fail{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance)',
-    legendFormat="{{instance}}-total",
-    hide=true,
-  )
-);
-
-local SuccessfulKVRequestWaitDurationPanel = graphPanel.new(
-  title="Successful KV Request Wait Duration",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="s",
-  description="The metrics about successful kv request wait duration.",
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.99, sum(rate(resource_manager_client_request_success_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance", resource_group=~"$resource_group"}[1m])) by (instance, resource_group, le))',
-    legendFormat="{{instance}}-{{resource_group}}-99",
-  )
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.9, sum(rate(resource_manager_client_request_success_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance", resource_group=~"$resource_group"}[1m])) by (instance, resource_group, le))',
-    legendFormat="{{instance}}-{{resource_group}}-90",
-  )
-);
-
-// Successful KV Request Count
-local SuccessfulKVRequestCountPanel = graphPanel.new(
-  title="Successful KV Request Count",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  logBase1Y=2,
-  format="short",
-  description="The metrics about successful kv request count.",
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_client_request_success_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance)',
-    legendFormat="{{instance}}-total",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_client_request_success_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance", resource_group=~"$resource_group"}[1m])) by (instance, resource_group)',
-    legendFormat="{{instance}}-{{resource_group}}",
-  )
-);
-
-// Token Request Handle Duration
-local TokenRequestHandleDurationPanel = graphPanel.new(
-  title="Token Request Handle Duration",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="s",
-  logBase1Y=1,
-  description="The metrics about token request handle duration.",
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.99, sum(rate(resource_manager_client_token_request_duration_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance, le))',
-    legendFormat="{{instance}}-99",
-  )
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.999, sum(rate(resource_manager_client_token_request_duration_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance, le))',
-    legendFormat="{{instance}}-999",
-  )
-);
-
-// Token Request Count
-local TokenRequestCountPanel = graphPanel.new(
-  title="Token Request Count",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  description="The metrics about token request count.",
-).addTarget(
-  prometheus.target(
-    'sum(delta(resource_manager_client_token_request_duration_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance)',
-    legendFormat="{{instance}}-total",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(delta(resource_manager_client_token_request_duration_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance", type="success"}[1m])) by (instance)',
-    legendFormat="{{instance}}-successful",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(delta(resource_manager_client_token_request_duration_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance", type="fail"}[1m])) by (instance)',
-    legendFormat="{{instance}}-failed",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_client_token_request_resource_group{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance", resource_group=~"$resource_group"}[1m])) by (instance, resource_group)',
-    legendFormat="{{instance}}-{{resource_group}}",
-  )
-);
-
-//*  ==============Panel (Runaway)==================
-//*  Row Title: Runaway
-//*  Description: The metrics about runaway resource control
-//*  Panels: 11
-//*  ==============Panel (Runaway)==================
-
-local runawayRow = row.new(collapse=true, title="Runaway");
-// Query Max Duration
-local QueryMaxDurationPanel = graphPanel.new(
-  title="Query Max Duration",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_avg=true,
-  legend_max=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="s",
-  logBase1Y=2,
-  description="TiDB max durations for different resource group",
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(1.0, sum(rate(tidb_server_handle_query_duration_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (le,resource_group))',
-    legendFormat="{{resource_group}}",
-  )
-);
-
-// Runaway Event
-local RunawayEventPanel = graphPanel.new(
-  title="Runaway Event",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_avg=true,
-  legend_max=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  logBase1Y=2,
-  description="Runaway manager events for different resource group",
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_server_query_runaway_check{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type="hit", resource_group=~"$resource_group"}[5m])) by (resource_group)',
-    legendFormat="{{resource_group}}-hit",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_server_query_runaway_check{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type!="hit", resource_group=~"$resource_group"}[5m])) by (resource_group, type, action)',
-    legendFormat="{{resource_group}}-{{type}}-{{action}}",
-  )
-);
-
-// Runaway Flusher Flush OPS
-local RunawayFlusherFlushOPSPanel = graphPanel.new(
-  title="Runaway Flusher Flush OPS",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_avg=true,
-  legend_max=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  logBase1Y=1,
-  description="The rate of runaway flusher flush operations per second, by flusher name and result.",
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_server_runaway_flusher_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name, result)',
-    legendFormat="{{name}}-{{result}}",
-  )
-);
-
-// Runaway Flusher Add OPS
-local RunawayFlusherAddOPSPanel = graphPanel.new(
-  title="Runaway Flusher Add OPS",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_avg=true,
-  legend_max=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  logBase1Y=1,
-  description="The rate of records added to runaway flusher per second, by flusher name.",
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_server_runaway_flusher_add_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name)',
-    legendFormat="{{name}}",
-  )
-);
-
-// Runaway Flusher Batch Size
-local RunawayFlusherBatchSizePanel = graphPanel.new(
-  title="Runaway Flusher Batch Size",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_avg=true,
-  legend_max=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  logBase1Y=1,
-  description="The batch size distribution of runaway flusher flush operations.",
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.99, sum(rate(tidb_server_runaway_flusher_batch_size_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name, le))',
-    legendFormat="{{name}}-P99",
-  )
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.9, sum(rate(tidb_server_runaway_flusher_batch_size_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name, le))',
-    legendFormat="{{name}}-P90",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_server_runaway_flusher_batch_size_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name) / sum(rate(tidb_server_runaway_flusher_batch_size_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name)',
-    legendFormat="{{name}}-avg",
-  )
-);
-
-// Runaway Flusher Duration
-local RunawayFlusherDurationPanel = graphPanel.new(
-  title="Runaway Flusher Duration",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_avg=true,
-  legend_max=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="s",
-  logBase1Y=2,
-  description="The duration of runaway flusher flush operations in seconds.",
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.99, sum(rate(tidb_server_runaway_flusher_duration_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name, le))',
-    legendFormat="{{name}}-P99",
-  )
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.9, sum(rate(tidb_server_runaway_flusher_duration_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name, le))',
-    legendFormat="{{name}}-P90",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_server_runaway_flusher_duration_seconds_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name) / sum(rate(tidb_server_runaway_flusher_duration_seconds_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name)',
-    legendFormat="{{name}}-avg",
-  )
-);
-
-// Runaway Flusher Interval
-local RunawayFlusherIntervalPanel = graphPanel.new(
-  title="Runaway Flusher Interval",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_avg=true,
-  legend_max=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="s",
-  logBase1Y=2,
-  description="The interval between consecutive runaway flusher flush operations in seconds.",
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.99, sum(rate(tidb_server_runaway_flusher_interval_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name, le))',
-    legendFormat="{{name}}-P99",
-  )
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.9, sum(rate(tidb_server_runaway_flusher_interval_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name, le))',
-    legendFormat="{{name}}-P90",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_server_runaway_flusher_interval_seconds_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name) / sum(rate(tidb_server_runaway_flusher_interval_seconds_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (name)',
-    legendFormat="{{name}}-avg",
-  )
-);
-
-// Runaway Syncer OPS
-local RunawaySyncerOPSPanel = graphPanel.new(
-  title="Runaway Syncer OPS",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_avg=true,
-  legend_max=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  logBase1Y=1,
-  description="The rate of runaway syncer operations per second, by instance and result.",
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_server_runaway_syncer_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance, result)',
-    legendFormat="{{instance}}-{{result}}",
-  )
-);
-
-// Runaway Syncer Duration
-local RunawaySyncerDurationPanel = graphPanel.new(
-  title="Runaway Syncer Duration",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_avg=true,
-  legend_max=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="s",
-  logBase1Y=2,
-  description="The duration of runaway syncer read operations in seconds.",
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.99, sum(rate(tidb_server_runaway_syncer_duration_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance, le))',
-    legendFormat="{{instance}}-P99",
-  )
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.9, sum(rate(tidb_server_runaway_syncer_duration_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance, le))',
-    legendFormat="{{instance}}-P90",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_server_runaway_syncer_duration_seconds_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance) / sum(rate(tidb_server_runaway_syncer_duration_seconds_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance)',
-    legendFormat="{{instance}}-avg",
-  )
-);
-
-// Runaway Syncer Interval
-local RunawaySyncerIntervalPanel = graphPanel.new(
-  title="Runaway Syncer Interval",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_avg=true,
-  legend_max=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="s",
-  logBase1Y=2,
-  description="The interval between consecutive runaway syncer operations in seconds.",
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.99, sum(rate(tidb_server_runaway_syncer_interval_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance, le))',
-    legendFormat="{{instance}}-P99",
-  )
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.9, sum(rate(tidb_server_runaway_syncer_interval_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance, le))',
-    legendFormat="{{instance}}-P90",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_server_runaway_syncer_interval_seconds_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance) / sum(rate(tidb_server_runaway_syncer_interval_seconds_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance)',
-    legendFormat="{{instance}}-avg",
-  )
-);
-
-// Runaway Syncer Checkpoint
-local RunawaySyncerCheckpointPanel = graphPanel.new(
-  title="Runaway Syncer Checkpoint",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="none",
-  logBase1Y=1,
-  decimals=0,
-  description="The current checkpoint (last synced record ID) of runaway syncer for watch and watch_done tables.",
-).addTarget(
-  prometheus.target(
-    'tidb_server_runaway_syncer_checkpoint{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}',
-    legendFormat="{{instance}}-{{type}}",
-  )
-);
-
-//*  ==============Panel (Priority Task Control)==================
-//*  Row Title: Priority Task Control
-//*  Description: The metrics about Priority Tasks Control resource control
-//*  Panels: 4
-//*  ==============Panel (Background Task Control)==================
-
-local priorityTaskRow = row.new(collapse=true, title="Priority Task Control");
-
-// The CPU time used of each priority
-local PriorityTaskCPUPanel = graphPanel.new(
-  title="CPU Time By Priority",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="µs",
-  logBase1Y=1,
-  description="The total CPU time cost by tasks of each priority.",
-).addTarget(
-  prometheus.target(
-    'sum(rate(tikv_resource_control_priority_task_exec_duration{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance, priority)',
-    legendFormat="{{instance}}-{{priority}}",
-  )
-);
-
-// The CPU Limiter Quota of each priority
-local PriorityTaskQuotaLimitPanel = graphPanel.new(
-  title="CPU Quota Limit By Priority",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="µs",
-  logBase1Y=1,
-  description="The CPU quota limiter applied to each priority.",
-).addTarget(
-  prometheus.target(
-    'tikv_resource_control_priority_quota_limit{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tikv_instance"}',
-    legendFormat="{{instance}}-{{priority}}",
-  )
-);
-
-// Task QPS that triggers wait
-local PriorityTaskWaitQPSPanel = graphPanel.new(
-  title="Tasks Wait QPS By Priority",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  logBase1Y=1,
-  description="Tasks number per second that triggers quota limiter wait",
-).addTarget(
-  prometheus.target(
-    'sum(rate(tikv_resource_control_priority_wait_duration_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"}[1m])) by (instance, priority)',
-    legendFormat="{{instance}}-{{priority}}",
-  )
-);
-
-// The task wait distribution by priority
-local PriorityTaskWaitDurationPanel = graphPanel.new(
-  title="Priority Task Wait Duration",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="s",
-  logBase1Y=2,
-  description="The wait Duration of tasks that triggers quota limiter wait per priority",
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.99, sum(rate(tikv_resource_control_priority_wait_duration_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tikv_instance"}[1m])) by (instance, priority, le))',
-    legendFormat="{{instance}}-{{priority}}-P99",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(tikv_resource_control_priority_wait_duration_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tikv_instance"}[1m])) by (instance, priority) / sum(rate(tikv_resource_control_priority_wait_duration_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tikv_instance"}[1m])) by (instance, priority)',
-    legendFormat="{{instance}}-{{priority}}-avg",
-  )
-);
-
-
-//*  ==============Panel (Background Task Control)==================
-//*  Row Title: Background Task Control
-//*  Description: The metrics about Background Task Control resource control
-//*  Panels: 7
-//*  ==============Panel (Background Task Control)==================
-
-local backgroundTaskRow = row.new(collapse=true, title="Background Task Control");
-
-// Background Tasks' RU
-local BackgroundTaskRUPanel = graphPanel.new(
-  title="Background Task RU",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  logBase1Y=10,
-  description="The total background task's request unit cost for all resource groups.",
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"background", resource_group=~"$resource_group"}[1m])) by (resource_group) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"background", resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"background"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"background"}[1m]))',
-    legendFormat="total",
-  )
-);
-
-// Background Task Resource Utilization
-local BackgroundTaskResourceUtilizationPanel = graphPanel.new(
-  title="Background Task Resource Utilization",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="percent",
-  logBase1Y=1,
-  description="The resource(CPU, IO) utilization percentage and limit of background tasks.",
-).addTarget(
-  prometheus.target(
-    'tikv_resource_control_bg_resource_utilization{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tikv_instance"}',
-    legendFormat="{{instance}}-{{type}}",
-  )
-);
-
-// Background Task CPU Limit
-local BackgroundTaskCPULimitPanel = graphPanel.new(
-  title="Background Task CPU Limit",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="µs",
-  logBase1Y=1,
-  description="The total background task's cpu limit for all resource groups.",
-).addTarget(
-  prometheus.target(
-    'tikv_resource_control_background_quota_limiter{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tikv_instance", resource_group=~"$resource_group", type="cpu"}',
-    legendFormat="{{resource_group}}-{{instance}}",
-  )
-);
-
-// Background Task IO Limit
-local BackgroundTaskIOLimitPanel = graphPanel.new(
-  title="Background Task IO Limit",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="bytes",
-  logBase1Y=1,
-  description="The total background task's io limit for all resource groups.",
-).addTarget(
-  prometheus.target(
-    'tikv_resource_control_background_quota_limiter{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tikv_instance", resource_group=~"$resource_group", type="io"}',
-    legendFormat="{{resource_group}}-{{instance}}",
-  )
-);
-
-// Background Task CPU Consumption
-local BackgroundTaskCPUConsumptionPanel = graphPanel.new(
-  title="Background Task CPU Consumption",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="µs",
-  logBase1Y=1,
-  description="The total background task's cpu consumption for all resource groups.",
-).addTarget(
-  prometheus.target(
-    'rate(tikv_resource_control_background_resource_consumption{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tikv_instance", resource_group=~"$resource_group", type="cpu"}[1m])',
-    legendFormat="{{resource_group}}-{{instance}}",
-  )
-);
-
-// Background Task IO Consumption
-local BackgroundTaskIOConsumptionPanel = graphPanel.new(
-  title="Background Task IO Consumption",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="bytes",
-  logBase1Y=1,
-  description="The total background task's io consumption for all resource groups.",
-).addTarget(
-  prometheus.target(
-    'rate(tikv_resource_control_background_resource_consumption{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tikv_instance", resource_group=~"$resource_group", type="io"}[1m])',
-    legendFormat="{{resource_group}}-{{instance}}",
-  )
-);
-
-// Background Task Total Wait Duration
-local BackgroundTaskTotalWaitDurationPanel = graphPanel.new(
-  title="Background Task Total Wait Duration",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="µs",
-  logBase1Y=1,
-  description="The total background task's wait duration for all resource groups.",
-).addTarget(
-  prometheus.target(
-    'rate(tikv_resource_control_background_task_wait_duration{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tikv_instance", resource_group=~"$resource_group"}[1m])',
-    legendFormat="{{resource_group}}-{{instance}}",
-  )
-);
-
-//*  ==============Panel (Query Sumary)==================
-//*  Row Title: Query Sumary
-//*  Description: The metrics about query summary
-//*  Panels: 5
-//*  ==============Panel (Query Sumary)==================
-
-local querySummaryRow = row.new(collapse=true, title="Query Summary");
-
-// Query Duration
-local QueryDurationPanel = graphPanel.new(
-  title="Query Duration",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_min=true,
-  legend_max=true,
-  legend_avg=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="s",
-  logBase1Y=2,
-  description="The Duration of sql execute for different resource group",
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.999, sum(rate(tidb_server_handle_query_duration_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster",instance=~"$tidb_instance",resource_group=~"$resource_group"}[1m])) by (le,resource_group))',
-    legendFormat="{{resource_group}}-P999",
-  )
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster",instance=~"$tidb_instance",resource_group=~"$resource_group"}[1m])) by (le,resource_group))',
-    legendFormat="{{resource_group}}-P99",
-  )
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.9, sum(rate(tidb_server_handle_query_duration_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster",instance=~"$tidb_instance",resource_group=~"$resource_group"}[1m])) by (le,resource_group))',
-    legendFormat="{{resource_group}}-P90",
-  )
-).addTarget(
-  prometheus.target(
-    'histogram_quantile(0.8, sum(rate(tidb_server_handle_query_duration_seconds_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster",instance=~"$tidb_instance",resource_group=~"$resource_group"}[1m])) by (le,resource_group))',
-    legendFormat="{{resource_group}}-P80",
-  )
-);
-
-// Command per second
-local CommandPerSecondPanel = graphPanel.new(
-  title="Command Per Second",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  logBase1Y=10,
-  description="MySQL commands processing numbers per second. See https://dev.mysql.com/doc/internals/en/text-protocol.html and https://dev.mysql.com/doc/internals/en/prepared-statements.html",
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_server_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster",instance=~"$tidb_instance",resource_group=~"$resource_group"}[1m])) by (result,resource_group)',
-    legendFormat="{{resource_group}}-{{result}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_server_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster",result="OK",instance=~"$tidb_instance",resource_group=~"$resource_group"}[1m] offset 1d)) by (result,resource_group)',
-    legendFormat="{{resource_group}}-yesterday",
-    hide=true,
-  )
-);
-
-// QPS
-local QPSPanel = graphPanel.new(
-  title="QPS",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_avg=true,
-  legend_max=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  logBase1Y=2,
-  description="TiDB statement statistics",
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_executor_statement_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster",instance=~"$tidb_instance",resource_group=~"$resource_group"}[1m])) by (type,resource_group)',
-    legendFormat="{{resource_group}}-{{type}}",
-  )
-).addTarget(
-  prometheus.target(
-    'sum(rate(tidb_executor_statement_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster",instance=~"$tidb_instance",resource_group=~"$resource_group"}[1m])) by (resource_group)',
-    legendFormat="{{resource_group}}-total",
-  )
-);
-
-// Connection Count
-local ConnectionCountPanel = graphPanel.new(
-  title="Connection Count",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  logBase1Y=1,
-  description="The number of connections to the TiDB server",
-).addTarget(
-  prometheus.target(
-    'tidb_server_connections{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster",instance=~"$tidb_instance",resource_group=~"$resource_group"}',
-    legendFormat="{{instance}}--{{resource_group}}",
-  )
-).addTarget(
-  prometheus.target(
-    'tidb_server_connections{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster",instance=~"$tidb_instance",resource_group=~"$resource_group"}',
-    legendFormat="{{resource_group}}--total",
-  )
-);
-
-// Failed Query OPM
-local FailedQueryOPMPanel = graphPanel.new(
-  title="Failed Query OPM",
-  datasource=myDS,
-  legend_rightSide=true,
-  legend_current=true,
-  legend_max=true,
-  legend_alignAsTable=true,
-  legend_values=true,
-  format="short",
-  logBase1Y=2,
-  description="The number of failed queries per minute",
-).addTarget(
-  prometheus.target(
-    'sum(increase(tidb_server_execute_error_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance",resource_group=~"$resource_group"}[1m])) by (type, instance,resource_group)',
-    legendFormat="{{type}}-{{instance}}-{{resource_group}}",
-  )
-);
-
-//* ============== Dashboard ===============
-//* Merge together
-//* ============== Dashboard ===============
-
-// Position definition
 local panelW = 12;
 local panelH = 7;
 local rowW = 24;
 local rowH = 1;
-
 local rowPos = { x: 0, y: 0, w: rowW, h: rowH };
 local leftPanelPos = { x: 0, y: 0, w: panelW, h: panelH };
 local rightPanelPos = { x: panelW, y: 0, w: panelW, h: panelH };
 local fullPanelPos = { x: 0, y: 0, w: rowW, h: panelH };
 
+local tidbSelector = 'k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance", resource_group=~"$resource_group"';
+local tidbInstanceSelector = 'k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance"';
+local clientRCSelector = tidbSelector + ', keyspace_name=~"$keyspace_name"';
+local pdRCSelector = 'k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group", keyspace_name=~"$keyspace_name"';
+
+local sqlLatencyRow = row.new(collapse=true, title="SQL latency / Time_queued_by_rc / query_total");
+local sqlLatencyPanel = graphPanel.new(
+  title="SQL Latency And Query Total",
+  datasource=myDS,
+  legend_rightSide=true,
+  legend_min=true,
+  legend_max=true,
+  legend_avg=true,
+  legend_current=true,
+  legend_alignAsTable=true,
+  legend_values=true,
+  format="s",
+  description="Shows resource-group SQL latency together with instance-level RC queue wait and query throughput.",
+).addTarget(
+  prometheus.target(
+    'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{' + tidbSelector + '}[1m])) by (le, instance, resource_group))',
+    legendFormat="{{instance}}-{{resource_group}}-p99",
+  )
+).addTarget(
+  prometheus.target(
+    'histogram_quantile(0.90, sum(rate(tidb_server_handle_query_duration_seconds_bucket{' + tidbSelector + '}[1m])) by (le, instance, resource_group))',
+    legendFormat="{{instance}}-{{resource_group}}-p90",
+  )
+).addTarget(
+  prometheus.target(
+    'histogram_quantile(0.99, sum(rate(tidb_server_slow_query_wait_duration_seconds_bucket{' + tidbInstanceSelector + ', sql_type="general"}[1m])) by (le, instance))',
+    legendFormat="{{instance}}-queue-p99",
+  )
+).addTarget(
+  prometheus.target(
+    'sum(rate(tidb_server_query_total{' + tidbSelector + '}[1m])) by (instance, resource_group, result)',
+    legendFormat="{{instance}}-{{resource_group}}-{{result}}-qps",
+  )
+) + {
+  seriesOverrides: [
+    {
+      alias: "/-qps$/",
+      yaxis: 2,
+    },
+  ],
+  yaxes: [
+    {
+      format: "s",
+      label: null,
+      logBase: 1,
+      max: null,
+      min: null,
+      show: true,
+    },
+    {
+      format: "ops",
+      label: null,
+      logBase: 1,
+      max: null,
+      min: null,
+      show: true,
+    },
+  ],
+};
+
+local demandPanel = graphPanel.new(
+  title="Demand And Fill Rate",
+  datasource=myDS,
+  legend_rightSide=true,
+  legend_min=true,
+  legend_max=true,
+  legend_avg=true,
+  legend_current=true,
+  legend_alignAsTable=true,
+  legend_values=true,
+  format="short",
+  description="Shows demand, average RU, fill rate, and throttling together.",
+).addTarget(
+  prometheus.target(
+    'resource_manager_client_resource_group_demand_ru_per_sec{' + clientRCSelector + '}',
+    legendFormat="{{instance}}-{{resource_group}}-demand",
+  )
+).addTarget(
+  prometheus.target(
+    'resource_manager_client_resource_group_avg_ru_per_sec{' + clientRCSelector + '}',
+    legendFormat="{{instance}}-{{resource_group}}-avg",
+  )
+).addTarget(
+  prometheus.target(
+    'resource_manager_client_resource_group_fill_rate{' + clientRCSelector + '}',
+    legendFormat="{{instance}}-{{resource_group}}-fill",
+  )
+).addTarget(
+  prometheus.target(
+    'resource_manager_client_resource_group_throttled{' + clientRCSelector + '}',
+    legendFormat="{{instance}}-{{resource_group}}-throttled",
+  )
+);
+
+local tokenRow = row.new(collapse=true, title="Token balance / throttled / token request latency");
+local tokenBalancePanel = graphPanel.new(
+  title="Token Balance And Throttle",
+  datasource=myDS,
+  legend_rightSide=true,
+  legend_min=true,
+  legend_max=true,
+  legend_avg=true,
+  legend_current=true,
+  legend_alignAsTable=true,
+  legend_values=true,
+  format="short",
+  description="Shows available token balance and throttling state by resource group and TiDB instance.",
+).addTarget(
+  prometheus.target(
+    'resource_manager_client_resource_group_token_balance{' + clientRCSelector + '}',
+    legendFormat="{{instance}}-{{resource_group}}-balance",
+  )
+).addTarget(
+  prometheus.target(
+    'resource_manager_client_resource_group_throttled{' + clientRCSelector + '}',
+    legendFormat="{{instance}}-{{resource_group}}-throttled",
+  )
+);
+
+local tokenLatencyPanel = graphPanel.new(
+  title="Token Request Latency And Volume",
+  datasource=myDS,
+  legend_rightSide=true,
+  legend_min=true,
+  legend_max=true,
+  legend_avg=true,
+  legend_current=true,
+  legend_alignAsTable=true,
+  legend_values=true,
+  format="s",
+  description="Shows instance-level token request latency together with per-group request volume.",
+).addTarget(
+  prometheus.target(
+    'histogram_quantile(0.99, sum(rate(resource_manager_client_token_request_duration_bucket{' + tidbInstanceSelector + '}[1m])) by (instance, le))',
+    legendFormat="{{instance}}-p99",
+  )
+).addTarget(
+  prometheus.target(
+    'histogram_quantile(0.90, sum(rate(resource_manager_client_token_request_duration_bucket{' + tidbInstanceSelector + '}[1m])) by (instance, le))',
+    legendFormat="{{instance}}-p90",
+  )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_client_token_request_duration_sum{' + tidbInstanceSelector + '}[1m])) by (instance) / sum(rate(resource_manager_client_token_request_duration_count{' + tidbInstanceSelector + '}[1m])) by (instance)',
+    legendFormat="{{instance}}-avg",
+  )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_client_token_request_resource_group{' + tidbSelector + '}[1m])) by (instance, resource_group)',
+    legendFormat="{{instance}}-{{resource_group}}-req/s",
+  )
+) + {
+  seriesOverrides: [
+    {
+      alias: "/-req\\/s$/",
+      yaxis: 2,
+    },
+  ],
+  yaxes: [
+    {
+      format: "s",
+      label: null,
+      logBase: 1,
+      max: null,
+      min: null,
+      show: true,
+    },
+    {
+      format: "ops",
+      label: null,
+      logBase: 1,
+      max: null,
+      min: null,
+      show: true,
+    },
+  ],
+};
+
+local serverRow = row.new(collapse=true, title="trickle_duration_ms / active_slot_count / token_loan / slot_events_total");
+local serverAllocationPanel = graphPanel.new(
+  title="Server Slots, Loan, And Trickle",
+  datasource=myDS,
+  legend_rightSide=true,
+  legend_min=true,
+  legend_max=true,
+  legend_avg=true,
+  legend_current=true,
+  legend_alignAsTable=true,
+  legend_values=true,
+  format="short",
+  description="Tracks PD-side slot state, outstanding token loan, slot lifecycle, and average trickle duration.",
+).addTarget(
+  prometheus.target(
+    'resource_manager_server_token_loan{' + pdRCSelector + '}',
+    legendFormat="{{instance}}-{{resource_group}}-loan",
+  )
+).addTarget(
+  prometheus.target(
+    'resource_manager_server_active_slot_count{' + pdRCSelector + '}',
+    legendFormat="{{instance}}-{{resource_group}}-slots",
+  )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_server_slot_events_total{' + pdRCSelector + '}[1m])) by (instance, resource_group, event)',
+    legendFormat="{{instance}}-{{resource_group}}-{{event}}",
+  )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_server_trickle_duration_ms_sum{' + pdRCSelector + '}[1m])) / sum(rate(resource_manager_server_trickle_duration_ms_count{' + pdRCSelector + '}[1m]))',
+    legendFormat="trickle-avg-ms",
+  )
+);
+
+local limitRow = row.new(collapse=true, title="ru_per_sec / ru_capacity / throttling cause");
+local limitConfigPanel = graphPanel.new(
+  title="RU Config",
+  datasource=myDS,
+  legend_rightSide=true,
+  legend_min=true,
+  legend_max=true,
+  legend_avg=true,
+  legend_current=true,
+  legend_alignAsTable=true,
+  legend_values=true,
+  format="short",
+  description="Shows configured RU rate and burst capacity for the selected resource groups.",
+).addTarget(
+  prometheus.target(
+    'max by (instance, resource_group, type) (resource_manager_server_group_config{' + pdRCSelector + ', type="ru_per_sec"})',
+    legendFormat="{{instance}}-{{resource_group}}-ru_per_sec",
+  )
+).addTarget(
+  prometheus.target(
+    'max by (instance, resource_group, type) (resource_manager_server_group_config{' + pdRCSelector + ', type="ru_capacity"})',
+    legendFormat="{{instance}}-{{resource_group}}-ru_capacity",
+  )
+);
+
+local limitCausePanel = graphPanel.new(
+  title="Throttling Causes",
+  datasource=myDS,
+  legend_rightSide=true,
+  legend_min=true,
+  legend_max=true,
+  legend_avg=true,
+  legend_current=true,
+  legend_alignAsTable=true,
+  legend_values=true,
+  format="short",
+  description="Shows whether throttling and trickle are caused by group fill/burst or by service_limit.",
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_server_request_cause_total{' + pdRCSelector + '}[1m])) by (instance, resource_group, kind, cause)',
+    legendFormat="{{instance}}-{{resource_group}}-{{kind}}-{{cause}}",
+  )
+);
+
 TiDBResourceControlDash
 .addPanel(
-  ruRow/* Resource Unit */
-  .addPanel(ConfigPanel, gridPos=fullPanelPos)
-  .addPanel(RUPanel, gridPos=leftPanelPos)
-  .addPanel(RUMaxPanel, gridPos=rightPanelPos)
-  .addPanel(RUPerQueryPanel, gridPos=leftPanelPos)
-  .addPanel(RRUPanel, gridPos=rightPanelPos)
-  .addPanel(RRUPerQueryPanel, gridPos=leftPanelPos)
-  .addPanel(WRUPanel, gridPos=rightPanelPos)
-  .addPanel(WRUPerQueryPanel, gridPos=leftPanelPos)
-  ,
+  sqlLatencyRow
+  .addPanel(sqlLatencyPanel, gridPos=leftPanelPos)
+  .addPanel(demandPanel, gridPos=rightPanelPos),
   gridPos=rowPos
 ).addPanel(
-  resourceRow/* Resource Details */
-  .addPanel(KVRequestCountPanel, gridPos=leftPanelPos)
-  .addPanel(KVRequestCountPerQueryPanel, gridPos=rightPanelPos)
-  .addPanel(BytesReadPanel, gridPos=leftPanelPos)
-  .addPanel(BytesReadPerQueryPanel, gridPos=rightPanelPos)
-  .addPanel(BytesWrittenPanel, gridPos=leftPanelPos)
-  .addPanel(BytesWrittenPerQueryPanel, gridPos=rightPanelPos)
-  .addPanel(KVCPUTimePanel, gridPos=leftPanelPos)
-  .addPanel(SQLCPUTimePanel, gridPos=rightPanelPos)
-  .addPanel(CrossAZTrafficRead, gridPos=leftPanelPos)
-  .addPanel(CrossAZTrafficWrite, gridPos=rightPanelPos)
-  ,
+  tokenRow
+  .addPanel(tokenBalancePanel, gridPos=leftPanelPos)
+  .addPanel(tokenLatencyPanel, gridPos=rightPanelPos),
   gridPos=rowPos
 ).addPanel(
-  clientRow/* Client */
-  .addPanel(ActiveResourceGroupPanel, gridPos=fullPanelPos)
-  .addPanel(TotalKVRequestCountPanel, gridPos=leftPanelPos)
-  .addPanel(FailedKVRequestCountPanel, gridPos=rightPanelPos)
-  .addPanel(SuccessfulKVRequestWaitDurationPanel, gridPos=leftPanelPos)
-  .addPanel(SuccessfulKVRequestCountPanel, gridPos=rightPanelPos)
-  .addPanel(TokenRequestHandleDurationPanel, gridPos=leftPanelPos)
-  .addPanel(TokenRequestCountPanel, gridPos=rightPanelPos)
-  ,
+  serverRow
+  .addPanel(serverAllocationPanel, gridPos=fullPanelPos),
   gridPos=rowPos
 ).addPanel(
-  runawayRow/* Runaway */
-  .addPanel(QueryMaxDurationPanel, gridPos=leftPanelPos)
-  .addPanel(RunawayEventPanel, gridPos=rightPanelPos)
-  .addPanel(RunawayFlusherFlushOPSPanel, gridPos=leftPanelPos)
-  .addPanel(RunawayFlusherAddOPSPanel, gridPos=rightPanelPos)
-  .addPanel(RunawayFlusherBatchSizePanel, gridPos=leftPanelPos)
-  .addPanel(RunawayFlusherDurationPanel, gridPos=rightPanelPos)
-  .addPanel(RunawayFlusherIntervalPanel, gridPos=leftPanelPos)
-  .addPanel(RunawaySyncerOPSPanel, gridPos=rightPanelPos)
-  .addPanel(RunawaySyncerDurationPanel, gridPos=leftPanelPos)
-  .addPanel(RunawaySyncerIntervalPanel, gridPos=rightPanelPos)
-  .addPanel(RunawaySyncerCheckpointPanel, gridPos=leftPanelPos)
-  ,
-  gridPos=rowPos
-).addPanel(
-  priorityTaskRow/* Priority Task Control */
-  .addPanel(PriorityTaskCPUPanel, gridPos=leftPanelPos)
-  .addPanel(PriorityTaskQuotaLimitPanel, gridPos=rightPanelPos)
-  .addPanel(PriorityTaskWaitQPSPanel, gridPos=leftPanelPos)
-  .addPanel(PriorityTaskWaitDurationPanel, gridPos=rightPanelPos)
-  ,
-  gridPos=rowPos
-).addPanel(
-  backgroundTaskRow/* Background Task Control */
-  .addPanel(BackgroundTaskRUPanel, gridPos=leftPanelPos)
-  .addPanel(BackgroundTaskResourceUtilizationPanel, gridPos=rightPanelPos)
-  .addPanel(BackgroundTaskIOLimitPanel, gridPos=leftPanelPos)
-  .addPanel(BackgroundTaskCPUConsumptionPanel, gridPos=rightPanelPos)
-  .addPanel(BackgroundTaskCPULimitPanel, gridPos=leftPanelPos)
-  .addPanel(BackgroundTaskIOConsumptionPanel, gridPos=rightPanelPos)
-  .addPanel(BackgroundTaskTotalWaitDurationPanel, gridPos=leftPanelPos)
-  ,
-  gridPos=rowPos
-).addPanel(
-  querySummaryRow/* Query Summary */
-  .addPanel(QueryDurationPanel, gridPos=leftPanelPos)
-  .addPanel(CommandPerSecondPanel, gridPos=rightPanelPos)
-  .addPanel(QPSPanel, gridPos=leftPanelPos)
-  .addPanel(ConnectionCountPanel, gridPos=rightPanelPos)
-  .addPanel(FailedQueryOPMPanel, gridPos=leftPanelPos)
-  ,
+  limitRow
+  .addPanel(limitConfigPanel, gridPos=leftPanelPos)
+  .addPanel(limitCausePanel, gridPos=rightPanelPos),
   gridPos=rowPos
 )


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref #41574, ref tikv/pd#10488

Problem Summary:
The Resource Control dashboard does not put SQL symptoms, client-side demand, throttling causes, and server allocation state on the same page. This makes it hard to tell whether a slowdown comes from local client pressure, server-side trickle, or a shared `service_limit`.

### What changed and how does it work?

This PR reshapes the Resource Control dashboard so the main diagnosis path can be read from one page.

It adds or rewrites panels for:
- SQL latency and query total
- client demand and fill rate
- token balance, throttling, request latency, and request volume
- server slots, token loan, and trickle
- RU config and throttling causes

The dashboard is organized around `resource_group`, `tidb_instance`, and `keyspace_name` so the main scenarios can be verified directly during diagnosis.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:
- Generated `pkg/metrics/grafana/tidb_resource_control.json` from the updated jsonnet file.
- Ran `make lint` and verified the dashboard linter passes.
- Verified three local scenarios on a `tiup playground` cluster: low fill rate, shared `service_limit`, and single-instance hotspot.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
