### PR TITLE
executor/importer: speed up TestCheckRequirements

### DIFF
--- a/pkg/executor/importer/precheck_test.go
+++ b/pkg/executor/importer/precheck_test.go
@@ -226,7 +226,11 @@ func TestCheckRequirements(t *testing.T) {
 	c.Plan.CloudStorageURI = "local:///tmp"
 	require.ErrorContains(t, c.CheckRequirements(ctx, tk.Session()), "unsupported cloud storage uri scheme: local")
 	c.Plan.CloudStorageURI = "azblob://test-bucket/path?account-name=test-account&sas-token=xxxxxx&endpoint=http://127.0.0.1:1/devstoreaccount1"
-	require.ErrorContains(t, c.CheckRequirements(ctx, tk.Session()), "check cloud storage uri access")
+	// Azure SDK retries unreachable endpoints aggressively; bound this negative check
+	// so the test still verifies the same failure path without dominating runtime.
+	azblobCtx, cancel := context.WithTimeout(ctx, time.Second)
+	require.ErrorContains(t, c.CheckRequirements(azblobCtx, tk.Session()), "check cloud storage uri access")
+	cancel()
 	// this mock cannot mock credential check, so we just skip it.
 	backend := s3mem.New()
 	faker := gofakes3.New(backend)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67902

Problem Summary:

`TestCheckRequirements` spends most of its time on the negative azblob permission check. The test only verifies that the precheck fails with `"check cloud storage uri access"`, but the unreachable azblob endpoint can wait through Azure SDK retries and stretch the case to roughly 50 seconds.

### What changed and how does it work?

This change wraps only the azblob negative case in a short timeout context. The test still exercises the same failure path and keeps the same outer error assertion, but it no longer waits for the full SDK retry budget on an intentionally unreachable endpoint.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

`./tools/check/failpoint-go-test.sh pkg/executor/importer -run '^TestCheckRequirements$' -count=1`

`make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution efficiency by adding timeout constraints to Azure Blob storage access validation test case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->