### PR TITLE
parser: support MySQL 8.0.19+ INSERT row alias syntax

### DIFF
--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -2415,6 +2415,12 @@ type InsertStmt struct {
 	PartitionNames []CIStr
 	// Returning represents the RETURNING select_expr list for INSERT statement.
 	Returning []*SelectField
+	// RowAlias is the optional row alias for VALUES/SET clause (MySQL 8.0.19+).
+	// e.g. INSERT INTO t VALUES (1,2) AS new ON DUPLICATE KEY UPDATE b = new.b
+	RowAlias CIStr
+	// ColumnAliases is the optional column alias list for the row alias.
+	// e.g. INSERT INTO t VALUES (1,2) AS new(m, n) ON DUPLICATE KEY UPDATE b = m
+	ColumnAliases []CIStr
 }
 
 // Restore implements Node interface.
@@ -2527,6 +2533,20 @@ func (n *InsertStmt) Restore(ctx *format.RestoreCtx) error {
 			}
 		default:
 			return errors.Errorf("Incorrect type for InsertStmt.Select: %T", v)
+		}
+	}
+	if asName := n.RowAlias.String(); asName != "" {
+		ctx.WriteKeyWord(" AS ")
+		ctx.WriteName(asName)
+		if len(n.ColumnAliases) > 0 {
+			ctx.WritePlain("(")
+			for i, col := range n.ColumnAliases {
+				if i > 0 {
+					ctx.WritePlain(", ")
+				}
+				ctx.WriteName(col.String())
+			}
+			ctx.WritePlain(")")
 		}
 	}
 	if n.OnDuplicate != nil {

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -43,6 +43,11 @@ type likeEscapeSpec struct {
 	explicit bool
 }
 
+type insertRowAlias struct {
+	rowAlias      ast.CIStr
+	columnAliases []ast.CIStr
+}
+
 func getMaskingPolicyRestrictOp(name string) (ast.MaskingPolicyRestrictOps, bool) {
 	switch strings.ToUpper(name) {
 	case ast.MaskingPolicyRestrictNameInsertIntoSelect:
@@ -1276,6 +1281,7 @@ func getMaskingPolicyRestrictOp(name string) (ast.MaskingPolicyRestrictOps, bool
 	IndexPartSpecificationList             "List of index column name or expression"
 	IndexPartSpecificationListOpt          "Optional list of index column name or expression"
 	InsertValues                           "Rest part of INSERT/REPLACE INTO statement"
+	InsertRowAliasOpt                      "optional row alias for INSERT VALUES/SET"
 	IntervalExpr                           "Interval expression"
 	JoinTable                              "join table"
 	JoinType                               "join type"
@@ -7911,12 +7917,18 @@ IntoOpt:
 |	"INTO"
 
 InsertValues:
-	'(' ColumnNameListOpt ')' ValueSym ValuesList
+	'(' ColumnNameListOpt ')' ValueSym ValuesList InsertRowAliasOpt
 	{
-		$$ = &ast.InsertStmt{
+		x := &ast.InsertStmt{
 			Columns: $2.([]*ast.ColumnName),
 			Lists:   $5.([][]ast.ExprNode),
 		}
+		if $6 != nil {
+			alias := $6.(*insertRowAlias)
+			x.RowAlias = alias.rowAlias
+			x.ColumnAliases = alias.columnAliases
+		}
+		$$ = x
 	}
 |	'(' ColumnNameListOpt ')' SetOprStmt
 	{
@@ -7943,9 +7955,15 @@ InsertValues:
 		}
 		$$ = &ast.InsertStmt{Columns: $2.([]*ast.ColumnName), Select: sel}
 	}
-|	ValueSym ValuesList %prec insertValues
+|	ValueSym ValuesList InsertRowAliasOpt %prec insertValues
 	{
-		$$ = &ast.InsertStmt{Lists: $2.([][]ast.ExprNode)}
+		x := &ast.InsertStmt{Lists: $2.([][]ast.ExprNode)}
+		if $3 != nil {
+			alias := $3.(*insertRowAlias)
+			x.RowAlias = alias.rowAlias
+			x.ColumnAliases = alias.columnAliases
+		}
+		$$ = x
 	}
 |	SetOprStmt
 	{
@@ -7972,9 +7990,15 @@ InsertValues:
 		}
 		$$ = &ast.InsertStmt{Select: sel}
 	}
-|	"SET" ColumnSetValueList
+|	"SET" ColumnSetValueList InsertRowAliasOpt
 	{
-		$$ = $2.(*ast.InsertStmt)
+		x := $2.(*ast.InsertStmt)
+		if $3 != nil {
+			alias := $3.(*insertRowAlias)
+			x.RowAlias = alias.rowAlias
+			x.ColumnAliases = alias.columnAliases
+		}
+		$$ = x
 	}
 
 ValueSym:
@@ -8035,6 +8059,24 @@ ColumnSetValueList:
 		ins.Columns = append(ins.Columns, $3.(*ast.ColumnName))
 		ins.Lists[0] = append(ins.Lists[0], $5.(ast.ExprNode))
 		$$ = ins
+	}
+
+/*
+ * Optional row alias for INSERT ... VALUES/SET (MySQL 8.0.19+).
+ * See https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html
+ */
+InsertRowAliasOpt:
+	/* empty */ %prec empty
+	{
+		$$ = nil
+	}
+|	"AS" Identifier
+	{
+		$$ = &insertRowAlias{rowAlias: ast.NewCIStr($2)}
+	}
+|	"AS" Identifier '(' IdentList ')'
+	{
+		$$ = &insertRowAlias{rowAlias: ast.NewCIStr($2), columnAliases: $4.([]ast.CIStr)}
 	}
 
 /*

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -8111,6 +8111,10 @@ ReplaceIntoStmt:
 	"REPLACE" TableOptimizerHintsOpt PriorityOpt IntoOpt TableName PartitionNameListOpt InsertValues
 	{
 		x := $7.(*ast.InsertStmt)
+		if x.RowAlias.O != "" || len(x.ColumnAliases) > 0 {
+			yylex.AppendError(ErrSyntax)
+			return 1
+		}
 		if $2 != nil {
 			x.TableHints = $2.([]*ast.TableOptimizerHint)
 		}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -930,6 +930,16 @@ func TestDMLStmt(t *testing.T) {
 		{"DELETE FROM t WHERE id=1 RETURNING id", true, "DELETE FROM `t` WHERE `id`=1 RETURNING `id`"},
 		{"DELETE FROM t ORDER BY id LIMIT 1 RETURNING *", true, "DELETE FROM `t` ORDER BY `id` LIMIT 1 RETURNING *"},
 
+		// for row alias in INSERT ... ON DUPLICATE KEY UPDATE (MySQL 8.0.19+)
+		{"INSERT INTO t (a,b,c) VALUES (1,2,3) AS new ON DUPLICATE KEY UPDATE c=new.a+new.b;", true, "INSERT INTO `t` (`a`,`b`,`c`) VALUES (1,2,3) AS `new` ON DUPLICATE KEY UPDATE `c`=`new`.`a`+`new`.`b`"},
+		{"INSERT INTO t (a,b,c) VALUES (1,2,3),(4,5,6) AS new(m,n,p) ON DUPLICATE KEY UPDATE c=m+n;", true, "INSERT INTO `t` (`a`,`b`,`c`) VALUES (1,2,3),(4,5,6) AS `new`(`m`, `n`, `p`) ON DUPLICATE KEY UPDATE `c`=`m`+`n`"},
+		{"INSERT INTO t VALUES (1,2) AS new ON DUPLICATE KEY UPDATE b=new.b;", true, "INSERT INTO `t` VALUES (1,2) AS `new` ON DUPLICATE KEY UPDATE `b`=`new`.`b`"},
+		{"INSERT INTO t SET a=1,b=2 AS new ON DUPLICATE KEY UPDATE b=new.a+new.b;", true, "INSERT INTO `t` SET `a`=1,`b`=2 AS `new` ON DUPLICATE KEY UPDATE `b`=`new`.`a`+`new`.`b`"},
+		{"INSERT INTO t SET a=1,b=2 AS new(m,n) ON DUPLICATE KEY UPDATE b=m+n;", true, "INSERT INTO `t` SET `a`=1,`b`=2 AS `new`(`m`, `n`) ON DUPLICATE KEY UPDATE `b`=`m`+`n`"},
+		// row alias without ON DUPLICATE KEY UPDATE
+		{"INSERT INTO t VALUES (1,2) AS new;", true, "INSERT INTO `t` VALUES (1,2) AS `new`"},
+		{"INSERT INTO t VALUES (1,2) AS new(a,b);", true, "INSERT INTO `t` VALUES (1,2) AS `new`(`a`, `b`)"},
+
 		// for insert ... set
 		{"INSERT INTO t SET a=1,b=2", true, "INSERT INTO `t` SET `a`=1,`b`=2"},
 		{"INSERT INTO t (a) SET a=1", false, ""},

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -939,6 +939,9 @@ func TestDMLStmt(t *testing.T) {
 		// row alias without ON DUPLICATE KEY UPDATE
 		{"INSERT INTO t VALUES (1,2) AS new;", true, "INSERT INTO `t` VALUES (1,2) AS `new`"},
 		{"INSERT INTO t VALUES (1,2) AS new(a,b);", true, "INSERT INTO `t` VALUES (1,2) AS `new`(`a`, `b`)"},
+		// row alias is not supported for REPLACE
+		{"REPLACE INTO t VALUES (1,2) AS new;", false, ""},
+		{"REPLACE INTO t SET a=1,b=2 AS new;", false, ""},
 
 		// for insert ... set
 		{"INSERT INTO t SET a=1,b=2", true, "INSERT INTO `t` SET `a`=1,`b`=2"},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #51650, ref #29259

Problem Summary:

TiDB returns a syntax error on the MySQL 8.0.19+ `INSERT ... VALUES (...) AS alias` syntax. MySQL 8.0.20 deprecated `VALUES()` in favor of this syntax, so TiDB can't parse modern MySQL upserts.

### What changed and how does it work?

Parser-only change — adds `AS row_alias[(col_alias, ...)]` to INSERT ... VALUES and INSERT ... SET.

- Added `RowAlias` and `ColumnAliases` fields to `InsertStmt` AST node
- Added `InsertRowAliasOpt` grammar rule inside VALUES/SET alternatives of `InsertValues` (not SELECT, matching MySQL spec)
- Updated `Restore()` for round-trip fidelity, following the existing `TableSource` alias pattern

Planner/executor support for resolving alias references in ON DUPLICATE KEY UPDATE is not included.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support parsing MySQL 8.0.19+ `INSERT ... VALUES (...) AS alias(col1, col2)` and `INSERT ... SET ... AS alias(col1, col2)` row alias syntax. Execution support for resolving row aliases in `ON DUPLICATE KEY UPDATE` is not yet implemented.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MySQL 8.0.19+ row-alias syntax in INSERT statements: optional `AS row_alias` and `AS row_alias(columns...)`, supported for both VALUES and SET forms and usable with ON DUPLICATE KEY UPDATE.
* **Bug Fixes**
  * Explicitly disallow row-alias syntax for REPLACE statements.
* **Tests**
  * Added coverage validating parsing/restoring of INSERT row-alias forms and rejecting them for REPLACE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->