### PR TITLE
planner: merge planner test suites

### DIFF
--- a/docs/agents/planner/rule/rule_ai_notes.md
+++ b/docs/agents/planner/rule/rule_ai_notes.md
@@ -133,3 +133,19 @@ Implementation choice:
 
 Review note:
 - Reviewers explicitly asked for comments on both the window-top1 uniqueness helper and the row-number upper-bound matcher, because the correctness argument is not obvious from the function names alone.
+
+## 2026-04-21 - Prefer larger planner rule suites when using RunTestUnderCascadesWithDomain
+
+Background:
+- `RunTestUnderCascadesWithDomain` initializes domain state and system tables. Splitting small planner rule regressions across many top-level tests adds repeated setup cost with little isolation benefit.
+
+Key takeaways:
+- For planner rule casetests that already share the same domain requirements and schema setup, prefer one larger suite with subtests over multiple small top-level tests.
+- Keep `RunTestUnderCascadesWithDomain` wrappers as few as possible and make each wrapper cover multiple related scenarios when the lifecycle is compatible.
+- When a testdata loader keys off the test name or caller, suite refactors should preserve the old lookup key explicitly instead of relying on nested subtest names.
+
+Implementation choice:
+- Merge `DerivedTopN` cases under one `TestDerivedTopNSuite` wrapper so both TiFlash/domain-dependent and plain TopN scenarios reuse the same domain initialization.
+
+Validation note:
+- Re-run the affected suite after the refactor because nested subtests can silently change testdata caller names and break recordings.

--- a/pkg/planner/core/casetest/rule/BUILD.bazel
+++ b/pkg/planner/core/casetest/rule/BUILD.bazel
@@ -20,7 +20,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 30,
+    shard_count = 20,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/core/casetest/rule/BUILD.bazel
+++ b/pkg/planner/core/casetest/rule/BUILD.bazel
@@ -20,7 +20,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 20,
+    shard_count = 18,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/core/casetest/rule/rule_derive_topn_from_window_test.go
+++ b/pkg/planner/core/casetest/rule/rule_derive_topn_from_window_test.go
@@ -27,54 +27,52 @@ import (
 type Input []string
 
 // TiFlash cases. TopN pushed down to storage only when no partition by.
-func TestPushDerivedTopnFlash(t *testing.T) {
+func TestDerivedTopNSuite(t *testing.T) {
 	testkit.RunTestUnderCascadesWithDomain(t, func(t *testing.T, tk *testkit.TestKit, dom *domain.Domain, cascades, caller string) {
-		tk.MustExec("set tidb_opt_derive_topn=1")
 		tk.MustExec("use test")
-		tk.MustExec("drop table if exists t")
+		tk.MustExec("drop table if exists t, t3")
 		tk.MustExec("create table t(a int, b int, primary key(b,a))")
-		testkit.SetTiFlashReplica(t, dom, "test", "t")
-		tk.MustExec("set tidb_enforce_mpp=1")
-		tk.MustExec("set @@session.tidb_allow_mpp=ON;")
-		var input Input
-		var output []struct {
-			SQL  string
-			Plan []string
-		}
-		suiteData := GetDerivedTopNSuiteData()
-		suiteData.LoadTestCases(t, &input, &output, cascades, caller)
-		for i, sql := range input {
-			plan := tk.MustQuery("explain format = 'plan_tree' " + sql)
-			testdata.OnRecord(func() {
-				output[i].SQL = sql
-				output[i].Plan = testdata.ConvertRowsToStrings(plan.Rows())
-			})
-			plan.Check(testkit.Rows(output[i].Plan...))
-		}
-	})
-}
-
-func TestTopNPushdown(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
-		tk.MustExec("use test")
-
-		tk.MustExec(`drop table if exists t3`)
 		tk.MustExec(`CREATE TABLE t3(c0 INT, primary key(c0))`)
 		tk.MustExec(`insert into t3 values(1), (2), (3), (4), (5), (6), (7), (8), (9), (10)`)
-		rs := tk.MustQuery(`SELECT /* issue:37986 */ v2.c0 FROM (select rand() as c0 from t3) v2 order by v2.c0 limit 10`).Rows()
-		lastVal := -1.0
-		for _, r := range rs {
-			v := r[0].(string)
-			val, err := strconv.ParseFloat(v, 64)
-			require.NoError(t, err)
-			require.True(t, val >= lastVal)
-			lastVal = val
-		}
+		testkit.SetTiFlashReplica(t, dom, "test", "t")
 
-		tk.MustQuery(`explain format = 'plan_tree' SELECT /* issue:37986 */ v2.c0 FROM (select rand() as c0 from t3) v2 order by v2.c0 limit 10`).
-			Check(testkit.Rows(`TopN root  Column, offset:0, count:10`,
-				`└─Projection root  rand()->Column`,
-				`  └─TableReader root  data:TableFullScan`,
-				`    └─TableFullScan cop[tikv] table:t3 keep order:false, stats:pseudo`))
+		t.Run("TestPushDerivedTopnFlash", func(t *testing.T) {
+			tk.MustExec("set tidb_opt_derive_topn=1")
+			tk.MustExec("set tidb_enforce_mpp=1")
+			tk.MustExec("set @@session.tidb_allow_mpp=ON;")
+			var input Input
+			var output []struct {
+				SQL  string
+				Plan []string
+			}
+			suiteData := GetDerivedTopNSuiteData()
+			suiteData.LoadTestCases(t, &input, &output, cascades, "TestPushDerivedTopnFlash")
+			for i, sql := range input {
+				plan := tk.MustQuery("explain format = 'plan_tree' " + sql)
+				testdata.OnRecord(func() {
+					output[i].SQL = sql
+					output[i].Plan = testdata.ConvertRowsToStrings(plan.Rows())
+				})
+				plan.Check(testkit.Rows(output[i].Plan...))
+			}
+		})
+
+		t.Run("TestTopNPushdown", func(t *testing.T) {
+			rs := tk.MustQuery(`SELECT /* issue:37986 */ v2.c0 FROM (select rand() as c0 from t3) v2 order by v2.c0 limit 10`).Rows()
+			lastVal := -1.0
+			for _, r := range rs {
+				v := r[0].(string)
+				val, err := strconv.ParseFloat(v, 64)
+				require.NoError(t, err)
+				require.True(t, val >= lastVal)
+				lastVal = val
+			}
+
+			tk.MustQuery(`explain format = 'plan_tree' SELECT /* issue:37986 */ v2.c0 FROM (select rand() as c0 from t3) v2 order by v2.c0 limit 10`).
+				Check(testkit.Rows(`TopN root  Column, offset:0, count:10`,
+					`└─Projection root  rand()->Column`,
+					`  └─TableReader root  data:TableFullScan`,
+					`    └─TableFullScan cop[tikv] table:t3 keep order:false, stats:pseudo`))
+		})
 	})
 }

--- a/pkg/planner/core/casetest/rule/rule_derive_topn_from_window_test.go
+++ b/pkg/planner/core/casetest/rule/rule_derive_topn_from_window_test.go
@@ -46,7 +46,7 @@ func TestDerivedTopNSuite(t *testing.T) {
 				Plan []string
 			}
 			suiteData := GetDerivedTopNSuiteData()
-			suiteData.LoadTestCases(t, &input, &output, cascades, "TestPushDerivedTopnFlash")
+			suiteData.LoadTestCasesByName("TestPushDerivedTopnFlash", t, &input, &output, cascades, "TestPushDerivedTopnFlash")
 			for i, sql := range input {
 				plan := tk.MustQuery("explain format = 'plan_tree' " + sql)
 				testdata.OnRecord(func() {
@@ -58,6 +58,9 @@ func TestDerivedTopNSuite(t *testing.T) {
 		})
 
 		t.Run("TestTopNPushdown", func(t *testing.T) {
+			tk.MustExec("set tidb_opt_derive_topn=0")
+			tk.MustExec("set tidb_enforce_mpp=0")
+			tk.MustExec("set @@session.tidb_allow_mpp=OFF")
 			rs := tk.MustQuery(`SELECT /* issue:37986 */ v2.c0 FROM (select rand() as c0 from t3) v2 order by v2.c0 limit 10`).Rows()
 			lastVal := -1.0
 			for _, r := range rs {

--- a/pkg/planner/core/casetest/rule/rule_eliminate_projection_test.go
+++ b/pkg/planner/core/casetest/rule/rule_eliminate_projection_test.go
@@ -24,7 +24,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithApply(t *testing.T) {
+func TestEliminateProjectionSuite(t *testing.T) {
+	t.Run("TestWithApply", testWithApply)
+	t.Run("TestElinimateProjectionWithExpressionIndex", testElinimateProjectionWithExpressionIndex)
+}
+
+func testWithApply(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -61,7 +66,7 @@ from temp where id = 1`,
 	}
 }
 
-func TestElinimateProjectionWithExpressionIndex(t *testing.T) {
+func testElinimateProjectionWithExpressionIndex(t *testing.T) {
 	originCfg := config.GetGlobalConfig()
 	newCfg := *originCfg
 	newCfg.Experimental.AllowsExpressionIndex = true

--- a/pkg/planner/core/casetest/rule/rule_join_reorder_test.go
+++ b/pkg/planner/core/casetest/rule/rule_join_reorder_test.go
@@ -46,201 +46,160 @@ func runJoinReorderTestData(t *testing.T, tk *testkit.TestKit, name, cascades st
 }
 
 func TestJoinReorderSuite(t *testing.T) {
-	t.Run("TestOptEnableHashJoin", testOptEnableHashJoin)
-	t.Run("TestJoinOrderHint4TiFlash", testJoinOrderHint4TiFlash)
-	t.Run("TestJoinOrderHint4DynamicPartitionTable", testJoinOrderHint4DynamicPartitionTable)
-	t.Run("TestJoinOrderHint4NestedLeading", testJoinOrderHint4NestedLeading)
-	t.Run("TestJoinOrderHint4NestedLeadingPK", testJoinOrderHint4NestedLeadingPK)
-	t.Run("TestLeadingHintInapplicableKeepsOtherConds", testLeadingHintInapplicableKeepsOtherConds)
-	t.Run("TestLeadingHintWithNonEqJoinUnderOuterJoin", testLeadingHintWithNonEqJoinUnderOuterJoin)
-	t.Run("TestOuterJoinReorderNullExtendedNonEqSafety", testOuterJoinReorderNullExtendedNonEqSafety)
-}
-
-// test the global/session variable tidb_opt_enable_hash_join being set to no
-func testOptEnableHashJoin(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec("use test")
-		testKit.MustExec("set tidb_opt_enable_hash_join=off")
-		testKit.MustExec("create table t1(a int, b int, key(a));")
-		testKit.MustExec("create table t2(a int, b int, key(a));")
-		testKit.MustExec("create table t3(a int, b int, key(a));")
-		testKit.MustExec("create table t4(a int, b int, key(a));")
-		runJoinReorderTestData(t, testKit, "TestOptEnableHashJoin", cascades)
-	})
-}
+		t.Run("PlainCases", func(t *testing.T) {
+			// test the global/session variable tidb_opt_enable_hash_join being set to no
+			t.Run("TestOptEnableHashJoin", func(t *testing.T) {
+				testKit.MustExec("set tidb_opt_enable_hash_join=off")
+				testKit.MustExec("create table t1(a int, b int, key(a));")
+				testKit.MustExec("create table t2(a int, b int, key(a));")
+				testKit.MustExec("create table t3(a int, b int, key(a));")
+				testKit.MustExec("create table t4(a int, b int, key(a));")
+				runJoinReorderTestData(t, testKit, "TestOptEnableHashJoin", cascades)
+			})
 
-func testJoinOrderHint4TiFlash(t *testing.T) {
+			t.Run("TestJoinOrderHint4DynamicPartitionTable", func(t *testing.T) {
+				testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/planner/core/forceDynamicPrune", `return(true)`)
+				testKit.MustExec("drop table if exists t, t1, t2, t3;")
+				testKit.MustExec(`create table t(a int, b int) partition by hash(a) partitions 3`)
+				testKit.MustExec(`create table t1(a int, b int) partition by hash(a) partitions 4`)
+				testKit.MustExec(`create table t2(a int, b int) partition by hash(a) partitions 5`)
+				testKit.MustExec(`create table t3(a int, b int) partition by hash(b) partitions 3`)
+				testKit.MustExec(`create table t4(a int, b int) partition by hash(a) partitions 4`)
+				testKit.MustExec(`create table t5(a int, b int) partition by hash(a) partitions 5`)
+				testKit.MustExec(`create table t6(a int, b int) partition by hash(b) partitions 3`)
+
+				testKit.MustExec(`set @@tidb_partition_prune_mode="dynamic"`)
+				testKit.MustExec("set @@tidb_enable_outer_join_reorder=true")
+				runJoinReorderTestData(t, testKit, "TestJoinOrderHint4DynamicPartitionTable", cascades)
+			})
+
+			t.Run("TestLeadingHintInapplicableKeepsOtherConds", func(t *testing.T) {
+				testKit.MustExec("set @@tidb_enable_outer_join_reorder=true")
+				testKit.MustExec("drop table if exists t0_lh, t1_lh, t2_lh, t3_lh;")
+				testKit.MustExec("create table t0_lh(k0 int, k1 int, k2 int);")
+				testKit.MustExec("create table t1_lh(k0 int, k1 int, k2 int);")
+				testKit.MustExec("create table t2_lh(k0 int, k1 int, k2 int);")
+				testKit.MustExec("create table t3_lh(k0 int, k1 int, k2 int);")
+
+				testKit.MustQuery("explain format = 'plan_tree' " +
+					"select /*+ leading(t0_lh, t2_lh, t3_lh, t1_lh) */ t1_lh.k0 " +
+					"from t0_lh right join t2_lh on (t0_lh.k1 = t2_lh.k1) " +
+					"join t3_lh on (t0_lh.k2 = t3_lh.k2 and t2_lh.k1 < t3_lh.k2) " +
+					"left join t1_lh on (t0_lh.k0 <=> t1_lh.k0);").
+					CheckContain("lt(test.t2_lh.k1, test.t3_lh.k2)")
+				testKit.MustQuery("show warnings").CheckContain("leading hint is inapplicable")
+			})
+
+			t.Run("TestLeadingHintWithNonEqJoinUnderOuterJoin", func(t *testing.T) {
+				testKit.MustExec("set @@tidb_enable_outer_join_reorder=true")
+				testKit.MustExec("drop table if exists t1_56513, t2_56513, t3_56513;")
+				testKit.MustExec("create table t1_56513(a int, b int, c int);")
+				testKit.MustExec("create table t2_56513(a int, b int, c int);")
+				testKit.MustExec("create table t3_56513(a int, b int, c int);")
+
+				orCond := "or(eq(test.t1_56513.a, test.t2_56513.a), eq(test.t1_56513.a, test.t2_56513.b))"
+
+				testKit.MustQuery("explain format = 'plan_tree' " +
+					"select * from t1_56513 " +
+					"join t2_56513 on (t1_56513.a = t2_56513.a or t1_56513.a = t2_56513.b) " +
+					"left join t3_56513 on t1_56513.a = t3_56513.b;").
+					CheckContain(orCond)
+
+				plan132 := testKit.MustQuery("explain format = 'plan_tree' " +
+					"select /*+ leading(t1_56513, t3_56513, t2_56513) */ * from t1_56513 " +
+					"join t2_56513 on (t1_56513.a = t2_56513.a or t1_56513.a = t2_56513.b) " +
+					"left join t3_56513 on t1_56513.a = t3_56513.b;")
+				plan132.CheckContain(orCond)
+				testKit.MustQuery("show warnings").CheckNotContain("leading hint is inapplicable")
+
+				plan123 := testKit.MustQuery("explain format = 'plan_tree' " +
+					"select /*+ leading(t1_56513, t2_56513, t3_56513) */ * from t1_56513 " +
+					"join t2_56513 on (t1_56513.a = t2_56513.a or t1_56513.a = t2_56513.b) " +
+					"left join t3_56513 on t1_56513.a = t3_56513.b;")
+				plan123.CheckContain(orCond)
+				testKit.MustQuery("show warnings").CheckNotContain("leading hint is inapplicable")
+				require.NotEqual(t, plan132.Rows(), plan123.Rows(), caller)
+			})
+
+			t.Run("TestOuterJoinReorderNullExtendedNonEqSafety", func(t *testing.T) {
+				testKit.MustExec("drop table if exists t1_66213, t2_66213, t3_66213;")
+				testKit.MustExec("create table t1_66213(a int);")
+				testKit.MustExec("create table t2_66213(a int, b int);")
+				testKit.MustExec("create table t3_66213(b int);")
+				testKit.MustExec("insert into t1_66213 values (1), (2);")
+				testKit.MustExec("insert into t2_66213 values (1, 5);")
+				testKit.MustExec("insert into t3_66213 values (5);")
+				testKit.MustExec("analyze table t1_66213, t2_66213, t3_66213;")
+
+				query := "select t1_66213.a, t2_66213.b, t3_66213.b from t1_66213 " +
+					"left join t2_66213 on t1_66213.a = t2_66213.a " +
+					"join t3_66213 on (t2_66213.b is null or t2_66213.b = t3_66213.b) " +
+					"order by t1_66213.a, t2_66213.b, t3_66213.b"
+				expectRows := testkit.Rows("1 5 5", "2 <nil> 5")
+
+				testKit.MustExec("set @@tidb_enable_outer_join_reorder=off")
+				testKit.MustQuery(query).Check(expectRows)
+				testKit.MustExec("set @@tidb_enable_outer_join_reorder=on")
+				testKit.MustQuery(query).Check(expectRows)
+
+				testKit.MustQuery("select /*+ leading(t2_66213, t3_66213, t1_66213) */ " +
+					"t1_66213.a, t2_66213.b, t3_66213.b from t1_66213 " +
+					"left join t2_66213 on t1_66213.a = t2_66213.a " +
+					"join t3_66213 on (t2_66213.b is null or t2_66213.b = t3_66213.b) " +
+					"order by t1_66213.a, t2_66213.b, t3_66213.b").Check(expectRows)
+				testKit.MustQuery("show warnings").CheckContain("leading hint is inapplicable")
+			})
+		})
+	})
+
 	testkit.RunTestUnderCascadesWithDomain(t, func(t *testing.T, testKit *testkit.TestKit, dom *domain.Domain, cascades, caller string) {
 		testKit.MustExec("use test")
-		testKit.MustExec("drop table if exists t, t1, t2, t3;")
-		testKit.MustExec("create table t(a int, b int, key(a));")
-		testKit.MustExec("create table t1(a int, b int, key(a));")
-		testKit.MustExec("create table t2(a int, b int, key(a));")
-		testKit.MustExec("create table t3(a int, b int, key(a));")
-		testKit.MustExec("create table t4(a int, b int, key(a));")
-		testKit.MustExec("create table t5(a int, b int, key(a));")
-		testKit.MustExec("create table t6(a int, b int, key(a));")
-		testKit.MustExec("set @@tidb_enable_outer_join_reorder=true")
+		t.Run("DomainCases", func(t *testing.T) {
+			t.Run("TestJoinOrderHint4TiFlash", func(t *testing.T) {
+				testKit.MustExec("drop table if exists t, t1, t2, t3;")
+				testKit.MustExec("create table t(a int, b int, key(a));")
+				testKit.MustExec("create table t1(a int, b int, key(a));")
+				testKit.MustExec("create table t2(a int, b int, key(a));")
+				testKit.MustExec("create table t3(a int, b int, key(a));")
+				testKit.MustExec("create table t4(a int, b int, key(a));")
+				testKit.MustExec("create table t5(a int, b int, key(a));")
+				testKit.MustExec("create table t6(a int, b int, key(a));")
+				testKit.MustExec("set @@tidb_enable_outer_join_reorder=true")
 
-		// Create virtual tiflash replica info.
-		testkit.SetTiFlashReplica(t, dom, "test", "t")
-		testkit.SetTiFlashReplica(t, dom, "test", "t1")
-		testkit.SetTiFlashReplica(t, dom, "test", "t2")
-		testkit.SetTiFlashReplica(t, dom, "test", "t3")
-		testkit.SetTiFlashReplica(t, dom, "test", "t4")
-		testkit.SetTiFlashReplica(t, dom, "test", "t5")
-		testkit.SetTiFlashReplica(t, dom, "test", "t6")
+				testkit.SetTiFlashReplica(t, dom, "test", "t")
+				testkit.SetTiFlashReplica(t, dom, "test", "t1")
+				testkit.SetTiFlashReplica(t, dom, "test", "t2")
+				testkit.SetTiFlashReplica(t, dom, "test", "t3")
+				testkit.SetTiFlashReplica(t, dom, "test", "t4")
+				testkit.SetTiFlashReplica(t, dom, "test", "t5")
+				testkit.SetTiFlashReplica(t, dom, "test", "t6")
 
-		testKit.MustExec("set @@tidb_allow_mpp=1; set @@tidb_enforce_mpp=1;")
-		runJoinReorderTestData(t, testKit, "TestJoinOrderHint4TiFlash", cascades)
-	})
-}
+				testKit.MustExec("set @@tidb_allow_mpp=1; set @@tidb_enforce_mpp=1;")
+				runJoinReorderTestData(t, testKit, "TestJoinOrderHint4TiFlash", cascades)
+			})
 
-func testJoinOrderHint4DynamicPartitionTable(t *testing.T) {
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/planner/core/forceDynamicPrune", `return(true)`)
-	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
-		testKit.MustExec("use test")
-		testKit.MustExec("drop table if exists t, t1, t2, t3;")
-		testKit.MustExec(`create table t(a int, b int) partition by hash(a) partitions 3`)
-		testKit.MustExec(`create table t1(a int, b int) partition by hash(a) partitions 4`)
-		testKit.MustExec(`create table t2(a int, b int) partition by hash(a) partitions 5`)
-		testKit.MustExec(`create table t3(a int, b int) partition by hash(b) partitions 3`)
-		testKit.MustExec(`create table t4(a int, b int) partition by hash(a) partitions 4`)
-		testKit.MustExec(`create table t5(a int, b int) partition by hash(a) partitions 5`)
-		testKit.MustExec(`create table t6(a int, b int) partition by hash(b) partitions 3`)
+			t.Run("TestJoinOrderHint4NestedLeading", func(t *testing.T) {
+				testKit.MustExec("drop table if exists t, t1, t2, t3, t4, t5, t6;")
+				testKit.MustExec("create table t(a int, b int, key(a));")
+				testKit.MustExec("create table t1(a int, b int, key(a));")
+				testKit.MustExec("create table t2(a int, b int, key(a));")
+				testKit.MustExec("create table t3(a int, b int, key(a));")
+				testKit.MustExec("create table t4(a int, b int, key(a));")
+				testKit.MustExec("create table t5(a int, b int, key(a));")
+				testKit.MustExec("create table t6(a int, b int, key(a));")
+				runJoinReorderTestData(t, testKit, "TestJoinOrderHint4NestedLeading", cascades)
+			})
 
-		testKit.MustExec(`set @@tidb_partition_prune_mode="dynamic"`)
-		testKit.MustExec("set @@tidb_enable_outer_join_reorder=true")
-		runJoinReorderTestData(t, testKit, "TestJoinOrderHint4DynamicPartitionTable", cascades)
-	})
-}
-
-func testJoinOrderHint4NestedLeading(t *testing.T) {
-	testkit.RunTestUnderCascadesWithDomain(t, func(t *testing.T, testKit *testkit.TestKit, dom *domain.Domain, cascades, caller string) {
-		testKit.MustExec("use test")
-		testKit.MustExec("drop table if exists t, t1, t2, t3, t4, t5, t6;")
-		testKit.MustExec("create table t(a int, b int, key(a));")
-		testKit.MustExec("create table t1(a int, b int, key(a));")
-		testKit.MustExec("create table t2(a int, b int, key(a));")
-		testKit.MustExec("create table t3(a int, b int, key(a));")
-		testKit.MustExec("create table t4(a int, b int, key(a));")
-		testKit.MustExec("create table t5(a int, b int, key(a));")
-		testKit.MustExec("create table t6(a int, b int, key(a));")
-		runJoinReorderTestData(t, testKit, "TestJoinOrderHint4NestedLeading", cascades)
-	})
-}
-
-func testJoinOrderHint4NestedLeadingPK(t *testing.T) {
-	testkit.RunTestUnderCascadesWithDomain(t, func(t *testing.T, testKit *testkit.TestKit, dom *domain.Domain, cascades, caller string) {
-		testKit.MustExec("use test")
-		testKit.MustExec("drop table if exists t1, t2, t3, t4;")
-		testKit.MustExec("create table t1(a int not null, b int, key(a));")
-		testKit.MustExec("create table t2(a int not null, b int, key(a));")
-		testKit.MustExec("create table t3(a int not null, b int not null, primary key(a));")
-		testKit.MustExec("create table t4(a int not null, b int not null, primary key(b));")
-		runJoinReorderTestData(t, testKit, "TestJoinOrderHint4NestedLeadingPK", cascades)
-	})
-}
-
-func testLeadingHintInapplicableKeepsOtherConds(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
-		testKit.MustExec("use test")
-		testKit.MustExec("set @@tidb_enable_outer_join_reorder=true")
-		testKit.MustExec("drop table if exists t0_lh, t1_lh, t2_lh, t3_lh;")
-		testKit.MustExec("create table t0_lh(k0 int, k1 int, k2 int);")
-		testKit.MustExec("create table t1_lh(k0 int, k1 int, k2 int);")
-		testKit.MustExec("create table t2_lh(k0 int, k1 int, k2 int);")
-		testKit.MustExec("create table t3_lh(k0 int, k1 int, k2 int);")
-
-		testKit.MustQuery("explain format = 'plan_tree' " +
-			"select /*+ leading(t0_lh, t2_lh, t3_lh, t1_lh) */ t1_lh.k0 " +
-			"from t0_lh right join t2_lh on (t0_lh.k1 = t2_lh.k1) " +
-			"join t3_lh on (t0_lh.k2 = t3_lh.k2 and t2_lh.k1 < t3_lh.k2) " +
-			"left join t1_lh on (t0_lh.k0 <=> t1_lh.k0);").
-			CheckContain("lt(test.t2_lh.k1, test.t3_lh.k2)")
-		testKit.MustQuery("show warnings").CheckContain("leading hint is inapplicable")
-	})
-}
-
-// TestLeadingHintWithNonEqJoinUnderOuterJoin tests that the leading hint works
-// correctly when combining a non-equijoin (OR condition) with an outer join.
-// The query has an outer join so the greedy solver is used (useGreedy=true).
-// The leading hint is processed through connectJoinNodes, then the greedy
-// solver's checkConnectionAndMakeJoin handles remaining tables.
-// Regression test for https://github.com/pingcap/tidb/issues/56513
-func testLeadingHintWithNonEqJoinUnderOuterJoin(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
-		testKit.MustExec("use test")
-		testKit.MustExec("set @@tidb_enable_outer_join_reorder=true")
-		testKit.MustExec("drop table if exists t1_56513, t2_56513, t3_56513;")
-		testKit.MustExec("create table t1_56513(a int, b int, c int);")
-		testKit.MustExec("create table t2_56513(a int, b int, c int);")
-		testKit.MustExec("create table t3_56513(a int, b int, c int);")
-
-		orCond := "or(eq(test.t1_56513.a, test.t2_56513.a), eq(test.t1_56513.a, test.t2_56513.b))"
-
-		// No leading hint: greedy solver (checkConnectionAndMakeJoin) picks the
-		// join order autonomously. The OR condition must be preserved.
-		testKit.MustQuery("explain format = 'plan_tree' " +
-			"select * from t1_56513 " +
-			"join t2_56513 on (t1_56513.a = t2_56513.a or t1_56513.a = t2_56513.b) " +
-			"left join t3_56513 on t1_56513.a = t3_56513.b;").
-			CheckContain(orCond)
-
-		// With leading(t1, t3, t2): the leading hint path (connectJoinNodes)
-		// joins t1 with t3 first via the left join eq edge, then the greedy
-		// solver joins the result with t2 via the OR condition.
-		plan132 := testKit.MustQuery("explain format = 'plan_tree' " +
-			"select /*+ leading(t1_56513, t3_56513, t2_56513) */ * from t1_56513 " +
-			"join t2_56513 on (t1_56513.a = t2_56513.a or t1_56513.a = t2_56513.b) " +
-			"left join t3_56513 on t1_56513.a = t3_56513.b;")
-		plan132.CheckContain(orCond)
-		testKit.MustQuery("show warnings").CheckNotContain("leading hint is inapplicable")
-
-		// With leading(t1, t2, t3): connectJoinNodes joins t1 with t2 via the
-		// OR condition (non-equijoin bypass), then joins with t3 via the eq edge.
-		plan123 := testKit.MustQuery("explain format = 'plan_tree' " +
-			"select /*+ leading(t1_56513, t2_56513, t3_56513) */ * from t1_56513 " +
-			"join t2_56513 on (t1_56513.a = t2_56513.a or t1_56513.a = t2_56513.b) " +
-			"left join t3_56513 on t1_56513.a = t3_56513.b;")
-		plan123.CheckContain(orCond)
-		testKit.MustQuery("show warnings").CheckNotContain("leading hint is inapplicable")
-
-		// The two plans should be different since different join orders are specified
-		require.NotEqual(t, plan132.Rows(), plan123.Rows(), caller)
-	})
-}
-
-func testOuterJoinReorderNullExtendedNonEqSafety(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
-		testKit.MustExec("use test")
-		testKit.MustExec("drop table if exists t1_66213, t2_66213, t3_66213;")
-		testKit.MustExec("create table t1_66213(a int);")
-		testKit.MustExec("create table t2_66213(a int, b int);")
-		testKit.MustExec("create table t3_66213(b int);")
-		testKit.MustExec("insert into t1_66213 values (1), (2);")
-		testKit.MustExec("insert into t2_66213 values (1, 5);")
-		testKit.MustExec("insert into t3_66213 values (5);")
-		testKit.MustExec("analyze table t1_66213, t2_66213, t3_66213;")
-
-		query := "select t1_66213.a, t2_66213.b, t3_66213.b from t1_66213 " +
-			"left join t2_66213 on t1_66213.a = t2_66213.a " +
-			"join t3_66213 on (t2_66213.b is null or t2_66213.b = t3_66213.b) " +
-			"order by t1_66213.a, t2_66213.b, t3_66213.b"
-		expectRows := testkit.Rows("1 5 5", "2 <nil> 5")
-
-		// Greedy reorder path must preserve semantics for non-eq predicates on null-extended columns.
-		testKit.MustExec("set @@tidb_enable_outer_join_reorder=off")
-		testKit.MustQuery(query).Check(expectRows)
-		testKit.MustExec("set @@tidb_enable_outer_join_reorder=on")
-		testKit.MustQuery(query).Check(expectRows)
-
-		// LEADING should not force an invalid reassociation across the null-extended side.
-		testKit.MustQuery("select /*+ leading(t2_66213, t3_66213, t1_66213) */ " +
-			"t1_66213.a, t2_66213.b, t3_66213.b from t1_66213 " +
-			"left join t2_66213 on t1_66213.a = t2_66213.a " +
-			"join t3_66213 on (t2_66213.b is null or t2_66213.b = t3_66213.b) " +
-			"order by t1_66213.a, t2_66213.b, t3_66213.b").Check(expectRows)
-		testKit.MustQuery("show warnings").CheckContain("leading hint is inapplicable")
+			t.Run("TestJoinOrderHint4NestedLeadingPK", func(t *testing.T) {
+				testKit.MustExec("drop table if exists t1, t2, t3, t4;")
+				testKit.MustExec("create table t1(a int not null, b int, key(a));")
+				testKit.MustExec("create table t2(a int not null, b int, key(a));")
+				testKit.MustExec("create table t3(a int not null, b int not null, primary key(a));")
+				testKit.MustExec("create table t4(a int not null, b int not null, primary key(b));")
+				runJoinReorderTestData(t, testKit, "TestJoinOrderHint4NestedLeadingPK", cascades)
+			})
+		})
 	})
 }

--- a/pkg/planner/core/casetest/rule/rule_join_reorder_test.go
+++ b/pkg/planner/core/casetest/rule/rule_join_reorder_test.go
@@ -45,8 +45,19 @@ func runJoinReorderTestData(t *testing.T, tk *testkit.TestKit, name, cascades st
 	}
 }
 
+func TestJoinReorderSuite(t *testing.T) {
+	t.Run("TestOptEnableHashJoin", testOptEnableHashJoin)
+	t.Run("TestJoinOrderHint4TiFlash", testJoinOrderHint4TiFlash)
+	t.Run("TestJoinOrderHint4DynamicPartitionTable", testJoinOrderHint4DynamicPartitionTable)
+	t.Run("TestJoinOrderHint4NestedLeading", testJoinOrderHint4NestedLeading)
+	t.Run("TestJoinOrderHint4NestedLeadingPK", testJoinOrderHint4NestedLeadingPK)
+	t.Run("TestLeadingHintInapplicableKeepsOtherConds", testLeadingHintInapplicableKeepsOtherConds)
+	t.Run("TestLeadingHintWithNonEqJoinUnderOuterJoin", testLeadingHintWithNonEqJoinUnderOuterJoin)
+	t.Run("TestOuterJoinReorderNullExtendedNonEqSafety", testOuterJoinReorderNullExtendedNonEqSafety)
+}
+
 // test the global/session variable tidb_opt_enable_hash_join being set to no
-func TestOptEnableHashJoin(t *testing.T) {
+func testOptEnableHashJoin(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec("use test")
 		testKit.MustExec("set tidb_opt_enable_hash_join=off")
@@ -58,7 +69,7 @@ func TestOptEnableHashJoin(t *testing.T) {
 	})
 }
 
-func TestJoinOrderHint4TiFlash(t *testing.T) {
+func testJoinOrderHint4TiFlash(t *testing.T) {
 	testkit.RunTestUnderCascadesWithDomain(t, func(t *testing.T, testKit *testkit.TestKit, dom *domain.Domain, cascades, caller string) {
 		testKit.MustExec("use test")
 		testKit.MustExec("drop table if exists t, t1, t2, t3;")
@@ -85,7 +96,7 @@ func TestJoinOrderHint4TiFlash(t *testing.T) {
 	})
 }
 
-func TestJoinOrderHint4DynamicPartitionTable(t *testing.T) {
+func testJoinOrderHint4DynamicPartitionTable(t *testing.T) {
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/planner/core/forceDynamicPrune", `return(true)`)
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec("use test")
@@ -104,7 +115,7 @@ func TestJoinOrderHint4DynamicPartitionTable(t *testing.T) {
 	})
 }
 
-func TestJoinOrderHint4NestedLeading(t *testing.T) {
+func testJoinOrderHint4NestedLeading(t *testing.T) {
 	testkit.RunTestUnderCascadesWithDomain(t, func(t *testing.T, testKit *testkit.TestKit, dom *domain.Domain, cascades, caller string) {
 		testKit.MustExec("use test")
 		testKit.MustExec("drop table if exists t, t1, t2, t3, t4, t5, t6;")
@@ -119,7 +130,7 @@ func TestJoinOrderHint4NestedLeading(t *testing.T) {
 	})
 }
 
-func TestJoinOrderHint4NestedLeadingPK(t *testing.T) {
+func testJoinOrderHint4NestedLeadingPK(t *testing.T) {
 	testkit.RunTestUnderCascadesWithDomain(t, func(t *testing.T, testKit *testkit.TestKit, dom *domain.Domain, cascades, caller string) {
 		testKit.MustExec("use test")
 		testKit.MustExec("drop table if exists t1, t2, t3, t4;")
@@ -131,7 +142,7 @@ func TestJoinOrderHint4NestedLeadingPK(t *testing.T) {
 	})
 }
 
-func TestLeadingHintInapplicableKeepsOtherConds(t *testing.T) {
+func testLeadingHintInapplicableKeepsOtherConds(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec("use test")
 		testKit.MustExec("set @@tidb_enable_outer_join_reorder=true")
@@ -157,7 +168,7 @@ func TestLeadingHintInapplicableKeepsOtherConds(t *testing.T) {
 // The leading hint is processed through connectJoinNodes, then the greedy
 // solver's checkConnectionAndMakeJoin handles remaining tables.
 // Regression test for https://github.com/pingcap/tidb/issues/56513
-func TestLeadingHintWithNonEqJoinUnderOuterJoin(t *testing.T) {
+func testLeadingHintWithNonEqJoinUnderOuterJoin(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec("use test")
 		testKit.MustExec("set @@tidb_enable_outer_join_reorder=true")
@@ -200,7 +211,7 @@ func TestLeadingHintWithNonEqJoinUnderOuterJoin(t *testing.T) {
 	})
 }
 
-func TestOuterJoinReorderNullExtendedNonEqSafety(t *testing.T) {
+func testOuterJoinReorderNullExtendedNonEqSafety(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec("use test")
 		testKit.MustExec("drop table if exists t1_66213, t2_66213, t3_66213;")

--- a/pkg/planner/core/casetest/rule/rule_join_reorder_test.go
+++ b/pkg/planner/core/casetest/rule/rule_join_reorder_test.go
@@ -51,7 +51,9 @@ func TestJoinReorderSuite(t *testing.T) {
 		t.Run("PlainCases", func(t *testing.T) {
 			// test the global/session variable tidb_opt_enable_hash_join being set to no
 			t.Run("TestOptEnableHashJoin", func(t *testing.T) {
+				testKit.MustExec("drop table if exists t1, t2, t3, t4;")
 				testKit.MustExec("set tidb_opt_enable_hash_join=off")
+				defer testKit.MustExec("set tidb_opt_enable_hash_join=on")
 				testKit.MustExec("create table t1(a int, b int, key(a));")
 				testKit.MustExec("create table t2(a int, b int, key(a));")
 				testKit.MustExec("create table t3(a int, b int, key(a));")
@@ -61,7 +63,8 @@ func TestJoinReorderSuite(t *testing.T) {
 
 			t.Run("TestJoinOrderHint4DynamicPartitionTable", func(t *testing.T) {
 				testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/planner/core/forceDynamicPrune", `return(true)`)
-				testKit.MustExec("drop table if exists t, t1, t2, t3;")
+				testKit.MustExec("drop table if exists t, t1, t2, t3, t4, t5, t6;")
+				testKit.MustExec("set tidb_opt_enable_hash_join=on")
 				testKit.MustExec(`create table t(a int, b int) partition by hash(a) partitions 3`)
 				testKit.MustExec(`create table t1(a int, b int) partition by hash(a) partitions 4`)
 				testKit.MustExec(`create table t2(a int, b int) partition by hash(a) partitions 5`)
@@ -177,11 +180,13 @@ func TestJoinReorderSuite(t *testing.T) {
 				testkit.SetTiFlashReplica(t, dom, "test", "t6")
 
 				testKit.MustExec("set @@tidb_allow_mpp=1; set @@tidb_enforce_mpp=1;")
+				defer testKit.MustExec("set @@tidb_allow_mpp=0; set @@tidb_enforce_mpp=0;")
 				runJoinReorderTestData(t, testKit, "TestJoinOrderHint4TiFlash", cascades)
 			})
 
 			t.Run("TestJoinOrderHint4NestedLeading", func(t *testing.T) {
 				testKit.MustExec("drop table if exists t, t1, t2, t3, t4, t5, t6;")
+				testKit.MustExec("set @@tidb_allow_mpp=0; set @@tidb_enforce_mpp=0;")
 				testKit.MustExec("create table t(a int, b int, key(a));")
 				testKit.MustExec("create table t1(a int, b int, key(a));")
 				testKit.MustExec("create table t2(a int, b int, key(a));")
@@ -194,6 +199,7 @@ func TestJoinReorderSuite(t *testing.T) {
 
 			t.Run("TestJoinOrderHint4NestedLeadingPK", func(t *testing.T) {
 				testKit.MustExec("drop table if exists t1, t2, t3, t4;")
+				testKit.MustExec("set @@tidb_allow_mpp=0; set @@tidb_enforce_mpp=0;")
 				testKit.MustExec("create table t1(a int not null, b int, key(a));")
 				testKit.MustExec("create table t2(a int not null, b int, key(a));")
 				testKit.MustExec("create table t3(a int not null, b int not null, primary key(a));")

--- a/pkg/planner/core/casetest/rule/rule_outer2inner_test.go
+++ b/pkg/planner/core/casetest/rule/rule_outer2inner_test.go
@@ -21,119 +21,120 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
 )
 
-func TestOuter2Inner(t *testing.T) {
+func TestOuter2InnerSuite(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
 		tk.MustExec("use test")
-		tk.MustExec("drop table if exists t")
-		tk.MustExec("create table t1(a1 int, b1 int, c1 int)")
-		tk.MustExec("create table t2(a2 int, b2 int, c2 int)")
-		tk.MustExec("create table t3(a3 int, b3 int, c3 int)")
-		tk.MustExec("create table t4(a4 int, b4 int, c4 int)")
-		tk.MustExec("create table ti(i int)")
-		tk.MustExec("CREATE TABLE lineitem (L_PARTKEY INTEGER ,L_QUANTITY DECIMAL(15,2),L_EXTENDEDPRICE  DECIMAL(15,2))")
-		tk.MustExec("CREATE TABLE part(P_PARTKEY INTEGER,P_BRAND CHAR(10),P_CONTAINER CHAR(10))")
-		tk.MustExec("CREATE TABLE d (pk int, col_blob blob, col_blob_key blob, col_varchar_key varchar(1) , col_date date, col_int_key int)")
-		tk.MustExec("CREATE TABLE dd (pk int, col_blob blob, col_blob_key blob, col_date date, col_int_key int)")
-		tk.MustExec("create table t0 (a0 int, b0 char, c0 char(2))")
-		tk.MustExec("create table t11 (a1 int, b1 char, c1 char)")
+		t.Run("TestOuter2Inner", func(t *testing.T) {
+			tk.MustExec("drop table if exists t")
+			tk.MustExec("create table t1(a1 int, b1 int, c1 int)")
+			tk.MustExec("create table t2(a2 int, b2 int, c2 int)")
+			tk.MustExec("create table t3(a3 int, b3 int, c3 int)")
+			tk.MustExec("create table t4(a4 int, b4 int, c4 int)")
+			tk.MustExec("create table ti(i int)")
+			tk.MustExec("CREATE TABLE lineitem (L_PARTKEY INTEGER ,L_QUANTITY DECIMAL(15,2),L_EXTENDEDPRICE  DECIMAL(15,2))")
+			tk.MustExec("CREATE TABLE part(P_PARTKEY INTEGER,P_BRAND CHAR(10),P_CONTAINER CHAR(10))")
+			tk.MustExec("CREATE TABLE d (pk int, col_blob blob, col_blob_key blob, col_varchar_key varchar(1) , col_date date, col_int_key int)")
+			tk.MustExec("CREATE TABLE dd (pk int, col_blob blob, col_blob_key blob, col_date date, col_int_key int)")
+			tk.MustExec("create table t0 (a0 int, b0 char, c0 char(2))")
+			tk.MustExec("create table t11 (a1 int, b1 char, c1 char)")
 
-		var input Input
-		var output []struct {
-			SQL  string
-			Plan []string
-		}
-		suiteData := GetOuter2InnerSuiteData()
-		suiteData.LoadTestCasesByName("TestOuter2Inner", t, &input, &output, cascades, caller)
-		for i, sql := range input {
-			plan := tk.MustQuery("explain format = 'plan_tree' " + sql)
-			testdata.OnRecord(func() {
-				output[i].SQL = sql
-				output[i].Plan = testdata.ConvertRowsToStrings(plan.Rows())
-			})
-			plan.Check(testkit.Rows(output[i].Plan...))
-		}
+			var input Input
+			var output []struct {
+				SQL  string
+				Plan []string
+			}
+			suiteData := GetOuter2InnerSuiteData()
+			suiteData.LoadTestCasesByName("TestOuter2Inner", t, &input, &output, cascades, "TestOuter2Inner")
+			for i, sql := range input {
+				plan := tk.MustQuery("explain format = 'plan_tree' " + sql)
+				testdata.OnRecord(func() {
+					output[i].SQL = sql
+					output[i].Plan = testdata.ConvertRowsToStrings(plan.Rows())
+				})
+				plan.Check(testkit.Rows(output[i].Plan...))
+			}
 
-		tk.MustExec("drop table if exists t1, t2")
-		tk.MustExec("create table t1 (k int, a int)")
-		tk.MustExec("create table t2 (k int, b int, key(k))")
-		tk.MustHavePlan(`select /* issue:49616 */ /*+ tidb_inlj(t2, t1) */ *
+			tk.MustExec("drop table if exists t1, t2")
+			tk.MustExec("create table t1 (k int, a int)")
+			tk.MustExec("create table t2 (k int, b int, key(k))")
+			tk.MustHavePlan(`select /* issue:49616 */ /*+ tidb_inlj(t2, t1) */ *
   from t2 left join t1 on t1.k=t2.k
   where a>0 or (a=0 and b>0)`, "IndexJoin")
-		// Structural null-reject proof smoke tests.
-		tk.MustQuery(`explain format = 'plan_tree' select *
+			// Structural null-reject proof smoke tests.
+			tk.MustQuery(`explain format = 'plan_tree' select *
   from t1 left join t2 on t1.k=t2.k
   where length(trim(cast(t2.k as char))) > 0`).CheckContain("inner join")
-		tk.MustQuery(`explain format = 'plan_tree' select *
+			tk.MustQuery(`explain format = 'plan_tree' select *
   from t1 left join t2 on t1.k=t2.k
   where length(trim(cast(t2.k as char))) > 0`).CheckNotContain("left outer join")
-		tk.MustQuery(`explain format = 'plan_tree' select *
+			tk.MustQuery(`explain format = 'plan_tree' select *
   from t1 left join t2 on t1.k=t2.k
   where coalesce(t2.k, 1) > 0`).CheckContain("left outer join")
-		tk.MustQuery(`explain format = 'plan_tree' select *
+			tk.MustQuery(`explain format = 'plan_tree' select *
   from t1 left join t2 on t1.k=t2.k
   where 1 in (t2.k, t2.b)`).CheckContain("inner join")
-		tk.MustQuery(`explain format = 'plan_tree' select *
+			tk.MustQuery(`explain format = 'plan_tree' select *
   from t1 left join t2 on t1.k=t2.k
   where 1 in (t2.k, 1)`).CheckContain("left outer join")
 
-		// Issue #66825: IN lists containing NULL can still evaluate TRUE on null-extended rows.
-		tk.MustExec("drop table if exists t0, t1")
-		tk.MustExec("create table t0(c0 int)")
-		tk.MustExec("create table t1(c0 int)")
-		tk.MustExec("insert into t1 values (1)")
-		tk.MustQuery(`explain format = 'plan_tree' select t1.c0 as ref0, t0.c0 as ref1
+			// Issue #66825: IN lists containing NULL can still evaluate TRUE on null-extended rows.
+			tk.MustExec("drop table if exists t0, t1")
+			tk.MustExec("create table t0(c0 int)")
+			tk.MustExec("create table t1(c0 int)")
+			tk.MustExec("insert into t1 values (1)")
+			tk.MustQuery(`explain format = 'plan_tree' select t1.c0 as ref0, t0.c0 as ref1
   from t1 left join t0 on t1.c0 = t0.c0
   where (t1.c0 = 2) in (null, t0.c0 is false)`).CheckContain("left outer join")
-		tk.MustQuery(`select t1.c0 as ref0, t0.c0 as ref1
+			tk.MustQuery(`select t1.c0 as ref0, t0.c0 as ref1
   from t1 left join t0 on t1.c0 = t0.c0
   where (t1.c0 = 2) in (null, t0.c0 is false)`).Check(testkit.Rows("1 <nil>"))
 
-		// Issue #58793: NULL-safe equality with IS NOT NULL is not null-rejected.
-		tk.MustExec("drop table if exists t0, t1")
-		tk.MustExec("create table t0(c0 text(227))")
-		tk.MustExec("create table t1 like t0")
-		tk.MustExec("insert into t1 values ('')")
-		tk.MustQuery(`explain format = 'plan_tree' select count(*)
+			// Issue #58793: NULL-safe equality with IS NOT NULL is not null-rejected.
+			tk.MustExec("drop table if exists t0, t1")
+			tk.MustExec("create table t0(c0 text(227))")
+			tk.MustExec("create table t1 like t0")
+			tk.MustExec("insert into t1 values ('')")
+			tk.MustQuery(`explain format = 'plan_tree' select count(*)
   from t1 left join t0 on t0.c0 <> t1.c0
   where (null and t1.c0) <=> (t0.c0 is not null)`).CheckContain("left outer join")
-		tk.MustQuery(`select count(*)
+			tk.MustQuery(`select count(*)
   from t1 left join t0 on t0.c0 <> t1.c0
   where (null and t1.c0) <=> (t0.c0 is not null)`).Check(testkit.Rows("1"))
 
-		// Issue #66833: outer-join constant propagation must not turn a WHERE predicate
-		// into an inner-side join filter and remove the matched row before null extension.
-		tk.MustExec("drop table if exists t0, t1")
-		tk.MustExec("create table t0(c0 int)")
-		tk.MustExec("create table t1 like t0")
-		tk.MustExec("insert into t0 values (1)")
-		tk.MustExec("insert into t1 values (1)")
-		tk.MustQuery(`explain format = 'plan_tree' select t1.c0 as ref0, t0.c0 as ref1
+			// Issue #66833: outer-join constant propagation must not turn a WHERE predicate
+			// into an inner-side join filter and remove the matched row before null extension.
+			tk.MustExec("drop table if exists t0, t1")
+			tk.MustExec("create table t0(c0 int)")
+			tk.MustExec("create table t1 like t0")
+			tk.MustExec("insert into t0 values (1)")
+			tk.MustExec("insert into t1 values (1)")
+			tk.MustQuery(`explain format = 'plan_tree' select t1.c0 as ref0, t0.c0 as ref1
   from t1 left join t0 on t1.c0 = t0.c0
   where coalesce(t0.c0 < t1.c0, t1.c0)`).CheckContain("left outer join")
-		tk.MustQuery(`select t1.c0 as ref0, t0.c0 as ref1
+			tk.MustQuery(`select t1.c0 as ref0, t0.c0 as ref1
   from t1 left join t0 on t1.c0 = t0.c0
   where coalesce(t0.c0 < t1.c0, t1.c0)`).Check(testkit.Rows())
 
-		tk.MustExec("drop table if exists t_outer, t")
-		tk.MustExec(`CREATE TABLE t_outer (
+			tk.MustExec("drop table if exists t_outer, t")
+			tk.MustExec(`CREATE TABLE t_outer (
 			id bigint(20) NOT NULL,
 			scode varchar(64) NOT NULL,
 			username varchar(60) NOT NULL,
 			real_name varchar(100) NOT NULL DEFAULT '',
 			KEY idx1 ((lower(real_name))),
 			UNIQUE KEY idx2 (username,scode))`)
-		tk.MustExec(`CREATE TABLE t (
+			tk.MustExec(`CREATE TABLE t (
 			id int(11) unsigned NOT NULL,
 			scode varchar(64) NOT NULL DEFAULT '',
 			plat_id varchar(64) NOT NULL)`)
-		tk.MustQuery(`EXPLAIN FORMAT='plan_tree' SELECT /* issue:65166 */ a.id FROM
+			tk.MustQuery(`EXPLAIN FORMAT='plan_tree' SELECT /* issue:65166 */ a.id FROM
 			t AS a LEFT JOIN t_outer b ON b.username = a.plat_id
 			AND b.scode = a.scode ORDER BY a.id`).CheckNotContain("Join")
 
-		tk.MustExec("drop table if exists t")
-		tk.MustExec("create table t (id int primary key, name varchar(100));")
-		tk.MustExec("insert into t values (1, null), (2, 1);")
-		tk.MustQuery(`with tmp as (
+			tk.MustExec("drop table if exists t")
+			tk.MustExec("create table t (id int primary key, name varchar(100));")
+			tk.MustExec("insert into t values (1, null), (2, 1);")
+			tk.MustQuery(`with tmp as (
 select
 row_number() over() as id,
 (select '1' from dual where id in (2)) as name
@@ -141,7 +142,7 @@ from t
 )
 select 'ok' from dual
 where ('1',1) in (select name, id from tmp);`).Check(testkit.Rows())
-		tk.MustQuery(`explain format = 'plan_tree' with tmp as (
+			tk.MustQuery(`explain format = 'plan_tree' with tmp as (
 select
 row_number() over() as id,
 (select '1' from dual where id in (2)) as name
@@ -149,26 +150,26 @@ from t
 )
 select 'ok' from dual
 where ('1',1) in (select name, id from tmp);`).Check(testkit.Rows(
-			`Projection root  ok->Column`,
-			`└─HashJoin root  CARTESIAN inner join`,
-			`  ├─TableDual(Build) root  rows:1`,
-			`  └─HashAgg(Probe) root  group by:Column, Column, funcs:firstrow(1)->Column`,
-			`    └─Selection root  eq(Column, "1"), eq(Column, 1)`,
-			`      └─Window root  row_number()->Column over(rows between current row and current row)`,
-			`        └─Apply root  CARTESIAN left outer join, left side:TableReader`,
-			`          ├─TableReader(Build) root  data:TableFullScan`,
-			`          │ └─TableFullScan cop[tikv] table:t keep order:false, stats:pseudo`,
-			`          └─Projection(Probe) root  1->Column`,
-			`            └─Selection root  eq(test.t.id, 2)`,
-			`              └─TableDual root  rows:1`))
-		// issue:58836
-		tk.MustExec("drop table if exists t0, t2, t3")
-		tk.MustExec(`CREATE TABLE t0(c0 INT);`)
-		tk.MustExec(`CREATE TABLE t2(c0 INT);`)
-		tk.MustExec(`CREATE TABLE t3(c0 INT);`)
-		tk.MustExec(`INSERT INTO t0 VALUES(0);`)
-		tk.MustExec(`INSERT INTO t3 VALUES(3);`)
-		tk.MustQuery(`explain format = 'plan_tree' SELECT *
+				`Projection root  ok->Column`,
+				`└─HashJoin root  CARTESIAN inner join`,
+				`  ├─TableDual(Build) root  rows:1`,
+				`  └─HashAgg(Probe) root  group by:Column, Column, funcs:firstrow(1)->Column`,
+				`    └─Selection root  eq(Column, "1"), eq(Column, 1)`,
+				`      └─Window root  row_number()->Column over(rows between current row and current row)`,
+				`        └─Apply root  CARTESIAN left outer join, left side:TableReader`,
+				`          ├─TableReader(Build) root  data:TableFullScan`,
+				`          │ └─TableFullScan cop[tikv] table:t keep order:false, stats:pseudo`,
+				`          └─Projection(Probe) root  1->Column`,
+				`            └─Selection root  eq(test.t.id, 2)`,
+				`              └─TableDual root  rows:1`))
+			// issue:58836
+			tk.MustExec("drop table if exists t0, t2, t3")
+			tk.MustExec(`CREATE TABLE t0(c0 INT);`)
+			tk.MustExec(`CREATE TABLE t2(c0 INT);`)
+			tk.MustExec(`CREATE TABLE t3(c0 INT);`)
+			tk.MustExec(`INSERT INTO t0 VALUES(0);`)
+			tk.MustExec(`INSERT INTO t3 VALUES(3);`)
+			tk.MustQuery(`explain format = 'plan_tree' SELECT *
 FROM t0
          LEFT JOIN (SELECT NULL AS col_2
                     FROM t2) as subQuery1
@@ -176,17 +177,17 @@ FROM t0
          INNER JOIN t3 ON (((((CASE 1
                                    WHEN subQuery1.col_2 THEN t3.c0
                                    ELSE NULL END)) AND (((t0.c0))))) < 1);`).
-			Check(testkit.Rows(`Projection root  test.t0.c0, Column, test.t3.c0`,
-				`└─HashJoin root  CARTESIAN inner join, other cond:lt(and(case(eq(1, cast(Column, double BINARY)), test.t3.c0, NULL), test.t0.c0), 1)`,
-				`  ├─TableReader(Build) root  data:TableFullScan`,
-				`  │ └─TableFullScan cop[tikv] table:t3 keep order:false, stats:pseudo`,
-				`  └─HashJoin(Probe) root  CARTESIAN left outer join, left side:TableReader`,
-				`    ├─TableReader(Build) root  data:TableFullScan`,
-				`    │ └─TableFullScan cop[tikv] table:t0 keep order:false, stats:pseudo`,
-				`    └─Projection(Probe) root  <nil>->Column`,
-				`      └─TableReader root  data:TableFullScan`,
-				`        └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo`))
-		tk.MustQuery(`SELECT *
+				Check(testkit.Rows(`Projection root  test.t0.c0, Column, test.t3.c0`,
+					`└─HashJoin root  CARTESIAN inner join, other cond:lt(and(case(eq(1, cast(Column, double BINARY)), test.t3.c0, NULL), test.t0.c0), 1)`,
+					`  ├─TableReader(Build) root  data:TableFullScan`,
+					`  │ └─TableFullScan cop[tikv] table:t3 keep order:false, stats:pseudo`,
+					`  └─HashJoin(Probe) root  CARTESIAN left outer join, left side:TableReader`,
+					`    ├─TableReader(Build) root  data:TableFullScan`,
+					`    │ └─TableFullScan cop[tikv] table:t0 keep order:false, stats:pseudo`,
+					`    └─Projection(Probe) root  <nil>->Column`,
+					`      └─TableReader root  data:TableFullScan`,
+					`        └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo`))
+			tk.MustQuery(`SELECT *
 FROM t0
          LEFT JOIN (SELECT NULL AS col_2
                     FROM t2) as subQuery1
@@ -194,111 +195,110 @@ FROM t0
          INNER JOIN t3 ON (((((CASE 1
                                    WHEN subQuery1.col_2 THEN t3.c0
                                    ELSE NULL END)) AND (((t0.c0))))) < 1);`).Check(testkit.Rows("0 <nil> 3"))
-		tk.MustExec("create table chqin(id int, f1 date);")
-		tk.MustExec("insert into chqin values (1,null);")
-		tk.MustExec("insert into chqin values (2,null);")
-		tk.MustExec("insert into chqin values (3,null);")
-		tk.MustExec("create table chqin2(id int, f1 date);")
-		tk.MustExec("insert into chqin2 values (1,'1990-11-27');")
-		tk.MustExec("insert into chqin2 values (2,'1990-11-27');")
-		tk.MustExec("insert into chqin2 values (3,'1990-11-27');")
-		tk.MustQuery(`explain format='plan_tree' select 1 from chqin where  '2008-05-28' NOT IN
+			tk.MustExec("create table chqin(id int, f1 date);")
+			tk.MustExec("insert into chqin values (1,null);")
+			tk.MustExec("insert into chqin values (2,null);")
+			tk.MustExec("insert into chqin values (3,null);")
+			tk.MustExec("create table chqin2(id int, f1 date);")
+			tk.MustExec("insert into chqin2 values (1,'1990-11-27');")
+			tk.MustExec("insert into chqin2 values (2,'1990-11-27');")
+			tk.MustExec("insert into chqin2 values (3,'1990-11-27');")
+			tk.MustQuery(`explain format='plan_tree' select 1 from chqin where  '2008-05-28' NOT IN
 		(select a1.f1 from chqin a1 NATURAL RIGHT JOIN chqin2 a2 WHERE a2.f1  >='1990-11-27' union select f1 from chqin where id=5);`).
-			Check(testkit.Rows(
-				`Projection root  1->Column`,
-				`└─HashJoin root  Null-aware anti semi join, left side:Projection, equal:[eq(Column, Column)]`,
-				`  ├─HashAgg(Build) root  group by:Column, funcs:firstrow(Column)->Column`,
-				`  │ └─Union root  `,
-				`  │   ├─HashJoin root  right outer join, left side:TableReader, equal:[eq(test.chqin.id, test.chqin2.id) eq(test.chqin.f1, test.chqin2.f1)]`,
-				`  │   │ ├─TableReader(Build) root  data:Selection`,
-				`  │   │ │ └─Selection cop[tikv]  ge(test.chqin.f1, 1990-11-27 00:00:00.000000), not(isnull(test.chqin.f1)), not(isnull(test.chqin.id))`,
-				`  │   │ │   └─TableFullScan cop[tikv] table:a1 keep order:false, stats:pseudo`,
-				`  │   │ └─TableReader(Probe) root  data:Selection`,
-				`  │   │   └─Selection cop[tikv]  ge(test.chqin2.f1, 1990-11-27 00:00:00.000000)`,
-				`  │   │     └─TableFullScan cop[tikv] table:a2 keep order:false, stats:pseudo`,
-				`  │   └─TableReader root  data:Projection`,
-				`  │     └─Projection cop[tikv]  test.chqin.f1->Column`,
-				`  │       └─Selection cop[tikv]  eq(test.chqin.id, 5)`,
-				`  │         └─TableFullScan cop[tikv] table:chqin keep order:false, stats:pseudo`,
-				`  └─Projection(Probe) root  2008-05-28 00:00:00.000000->Column`,
-				`    └─TableReader root  data:TableFullScan`,
-				`      └─TableFullScan cop[tikv] table:chqin keep order:false, stats:pseudo`))
-		tk.MustQuery(`select 1 from chqin where  '2008-05-28' NOT IN
+				Check(testkit.Rows(
+					`Projection root  1->Column`,
+					`└─HashJoin root  Null-aware anti semi join, left side:Projection, equal:[eq(Column, Column)]`,
+					`  ├─HashAgg(Build) root  group by:Column, funcs:firstrow(Column)->Column`,
+					`  │ └─Union root  `,
+					`  │   ├─HashJoin root  right outer join, left side:TableReader, equal:[eq(test.chqin.id, test.chqin2.id) eq(test.chqin.f1, test.chqin2.f1)]`,
+					`  │   │ ├─TableReader(Build) root  data:Selection`,
+					`  │   │ │ └─Selection cop[tikv]  ge(test.chqin.f1, 1990-11-27 00:00:00.000000), not(isnull(test.chqin.f1)), not(isnull(test.chqin.id))`,
+					`  │   │ │   └─TableFullScan cop[tikv] table:a1 keep order:false, stats:pseudo`,
+					`  │   │ └─TableReader(Probe) root  data:Selection`,
+					`  │   │   └─Selection cop[tikv]  ge(test.chqin2.f1, 1990-11-27 00:00:00.000000)`,
+					`  │   │     └─TableFullScan cop[tikv] table:a2 keep order:false, stats:pseudo`,
+					`  │   └─TableReader root  data:Projection`,
+					`  │     └─Projection cop[tikv]  test.chqin.f1->Column`,
+					`  │       └─Selection cop[tikv]  eq(test.chqin.id, 5)`,
+					`  │         └─TableFullScan cop[tikv] table:chqin keep order:false, stats:pseudo`,
+					`  └─Projection(Probe) root  2008-05-28 00:00:00.000000->Column`,
+					`    └─TableReader root  data:TableFullScan`,
+					`      └─TableFullScan cop[tikv] table:chqin keep order:false, stats:pseudo`))
+			tk.MustQuery(`select 1 from chqin where  '2008-05-28' NOT IN
 		(select a1.f1 from chqin a1 NATURAL RIGHT JOIN chqin2 a2 WHERE a2.f1  >='1990-11-27' union select f1 from chqin where id=5);`).
-			Check(testkit.Rows())
+				Check(testkit.Rows())
 
-		// issue:66047
-		tk.MustExec("drop table if exists t0, t1")
-		tk.MustExec("CREATE TABLE t0(c0 NUMERIC UNSIGNED ZEROFILL, c1 BLOB(18), c2 NUMERIC UNSIGNED)")
-		tk.MustExec("CREATE TABLE t1 LIKE t0")
-		tk.MustExec("INSERT INTO t0 VALUES (0, 'wj', NULL)")
-		tk.MustQuery("SELECT TRUE FROM t1 RIGHT OUTER JOIN t0 ON NULL WHERE FIELD(t0.c0, 0.0, CAST(t1.c0 AS FLOAT))").
-			Check(testkit.Rows("1"))
-		tk.MustQuery("SELECT FIELD(t0.c0, 0.0, CAST(t1.c0 AS FLOAT)) FROM t1 RIGHT OUTER JOIN t0 ON NULL").
-			Check(testkit.Rows("1"))
-	})
-}
+			// issue:66047
+			tk.MustExec("drop table if exists t0, t1")
+			tk.MustExec("CREATE TABLE t0(c0 NUMERIC UNSIGNED ZEROFILL, c1 BLOB(18), c2 NUMERIC UNSIGNED)")
+			tk.MustExec("CREATE TABLE t1 LIKE t0")
+			tk.MustExec("INSERT INTO t0 VALUES (0, 'wj', NULL)")
+			tk.MustQuery("SELECT TRUE FROM t1 RIGHT OUTER JOIN t0 ON NULL WHERE FIELD(t0.c0, 0.0, CAST(t1.c0 AS FLOAT))").
+				Check(testkit.Rows("1"))
+			tk.MustQuery("SELECT FIELD(t0.c0, 0.0, CAST(t1.c0 AS FLOAT)) FROM t1 RIGHT OUTER JOIN t0 ON NULL").
+				Check(testkit.Rows("1"))
+		})
 
-// TestOuter2InnerLateralSelection verifies LATERAL join decorrelation behavior:
-//
-//   - Cases 1–2 (simple correlated Selection): DecorrelateSolver pulls the
-//     correlated predicate (e.g. t2.b2 = t1.a1) up as a join condition, which
-//     empties CorCols and converts Apply→HashJoin. This is semantically correct
-//     and is NOT the outer2inner rule — the outer2inner IsLateral guard is a
-//     separate code path (pruneRedundantApply).
-//
-//   - Case 3 (aggregate): after the Selection is pulled up, correlated columns
-//     remain inside the aggregate, so DecorrelateSolver cannot proceed and the
-//     Apply is preserved.
-func TestOuter2InnerLateralSelection(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
-		tk.MustExec("use test")
-		tk.MustExec("drop table if exists t1, t2")
-		tk.MustExec("create table t1(a1 int, b1 int)")
-		tk.MustExec("create table t2(a2 int, b2 int)")
+		// TestOuter2InnerLateralSelection verifies LATERAL join decorrelation behavior:
+		//
+		//   - Cases 1–2 (simple correlated Selection): DecorrelateSolver pulls the
+		//     correlated predicate (e.g. t2.b2 = t1.a1) up as a join condition, which
+		//     empties CorCols and converts Apply→HashJoin. This is semantically correct
+		//     and is NOT the outer2inner rule — the outer2inner IsLateral guard is a
+		//     separate code path (pruneRedundantApply).
+		//
+		//   - Case 3 (aggregate): after the Selection is pulled up, correlated columns
+		//     remain inside the aggregate, so DecorrelateSolver cannot proceed and the
+		//     Apply is preserved.
+		t.Run("TestOuter2InnerLateralSelection", func(t *testing.T) {
+			tk.MustExec("drop table if exists t1, t2")
+			tk.MustExec("create table t1(a1 int, b1 int)")
+			tk.MustExec("create table t2(a2 int, b2 int)")
 
-		var input Input
-		var output []struct {
-			SQL  string
-			Plan []string
-		}
-		suiteData := GetOuter2InnerSuiteData()
-		suiteData.LoadTestCasesByName("TestOuter2InnerLateralSelection", t, &input, &output, cascades, caller)
-		for i, sql := range input {
-			plan := tk.MustQuery("explain format = 'plan_tree' " + sql)
-			testdata.OnRecord(func() {
-				output[i].SQL = sql
-				output[i].Plan = testdata.ConvertRowsToStrings(plan.Rows())
-			})
-			plan.Check(testkit.Rows(output[i].Plan...))
-		}
-	})
-}
+			var input Input
+			var output []struct {
+				SQL  string
+				Plan []string
+			}
+			suiteData := GetOuter2InnerSuiteData()
+			suiteData.LoadTestCasesByName("TestOuter2InnerLateralSelection", t, &input, &output, cascades, "TestOuter2InnerLateralSelection")
+			for i, sql := range input {
+				plan := tk.MustQuery("explain format = 'plan_tree' " + sql)
+				testdata.OnRecord(func() {
+					output[i].SQL = sql
+					output[i].Plan = testdata.ConvertRowsToStrings(plan.Rows())
+				})
+				plan.Check(testkit.Rows(output[i].Plan...))
+			}
+		})
 
-// can not add this test case to TestOuter2Inner because the collation_connection is different
-func TestOuter2InnerIssue55886(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
-		tk.MustExec("use test")
-		tk.MustExec("drop table if exists t1")
-		tk.MustExec("drop table if exists t2")
-		tk.MustExec("create table t1(c_foveoe text, c_jbb text, c_cz text not null)")
-		tk.MustExec("create table t2(c_g7eofzlxn int)")
-		tk.MustExec("set collation_connection = 'latin1_bin'")
+		// This case needs a different collation_connection, so restore it explicitly
+		// instead of keeping a separate RunTestUnderCascades wrapper.
+		t.Run("TestOuter2InnerIssue55886", func(t *testing.T) {
+			originCollation := tk.MustQuery("select @@collation_connection").Rows()[0][0].(string)
+			defer tk.MustExec("set collation_connection = '" + originCollation + "'")
 
-		var input Input
-		var output []struct {
-			SQL  string
-			Plan []string
-		}
-		suiteData := GetOuter2InnerSuiteData()
-		suiteData.LoadTestCasesByName("TestOuter2InnerIssue55886", t, &input, &output, cascades, caller)
-		for i, sql := range input {
-			plan := tk.MustQuery("explain format = 'plan_tree' " + sql)
-			testdata.OnRecord(func() {
-				output[i].SQL = sql
-				output[i].Plan = testdata.ConvertRowsToStrings(plan.Rows())
-			})
-			plan.Check(testkit.Rows(output[i].Plan...))
-		}
+			tk.MustExec("drop table if exists t1")
+			tk.MustExec("drop table if exists t2")
+			tk.MustExec("create table t1(c_foveoe text, c_jbb text, c_cz text not null)")
+			tk.MustExec("create table t2(c_g7eofzlxn int)")
+			tk.MustExec("set collation_connection = 'latin1_bin'")
+
+			var input Input
+			var output []struct {
+				SQL  string
+				Plan []string
+			}
+			suiteData := GetOuter2InnerSuiteData()
+			suiteData.LoadTestCasesByName("TestOuter2InnerIssue55886", t, &input, &output, cascades, "TestOuter2InnerIssue55886")
+			for i, sql := range input {
+				plan := tk.MustQuery("explain format = 'plan_tree' " + sql)
+				testdata.OnRecord(func() {
+					output[i].SQL = sql
+					output[i].Plan = testdata.ConvertRowsToStrings(plan.Rows())
+				})
+				plan.Check(testkit.Rows(output[i].Plan...))
+			}
+		})
 	})
 }

--- a/pkg/planner/core/casetest/rule/rule_outer2inner_test.go
+++ b/pkg/planner/core/casetest/rule/rule_outer2inner_test.go
@@ -276,7 +276,7 @@ FROM t0
 		// instead of keeping a separate RunTestUnderCascades wrapper.
 		t.Run("TestOuter2InnerIssue55886", func(t *testing.T) {
 			originCollation := tk.MustQuery("select @@collation_connection").Rows()[0][0].(string)
-			defer tk.MustExec("set collation_connection = '" + originCollation + "'")
+			defer tk.MustExec("set collation_connection = ?", originCollation)
 
 			tk.MustExec("drop table if exists t1")
 			tk.MustExec("drop table if exists t2")

--- a/pkg/planner/core/casetest/rule/rule_predicate_pushdown_test.go
+++ b/pkg/planner/core/casetest/rule/rule_predicate_pushdown_test.go
@@ -77,7 +77,12 @@ func runPredicatePushdownTestDataWithResult(t *testing.T, tk *testkit.TestKit, c
 	}
 }
 
-func TestConstantPropagateWithCollation(t *testing.T) {
+func TestPredicatePushdownSuite(t *testing.T) {
+	t.Run("TestConstantPropagateWithCollation", testConstantPropagateWithCollation)
+	t.Run("TestPredicatePushDown", testPredicatePushDown)
+}
+
+func testConstantPropagateWithCollation(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
 		tk.MustExec("use test")
 		tk.MustExec("create table t (id int primary key, name varchar(20));")
@@ -98,7 +103,7 @@ func TestConstantPropagateWithCollation(t *testing.T) {
 	})
 }
 
-func TestPredicatePushDown(t *testing.T) {
+func testPredicatePushDown(t *testing.T) {
 	testkit.RunTestUnderCascadesWithDomain(t, func(t *testing.T, tk *testkit.TestKit, dom *domain.Domain, cascades, caller string) {
 		tk.MustExec("use test")
 		tk.MustExec(`CREATE TABLE crm_rd_150m (

--- a/pkg/planner/core/find_best_task_test.go
+++ b/pkg/planner/core/find_best_task_test.go
@@ -26,7 +26,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCostOverflow(t *testing.T) {
+func TestFindBestTaskSuite(t *testing.T) {
+	t.Run("TestCostOverflow", testCostOverflow)
+	t.Run("TestEnforcedProperty", testEnforcedProperty)
+	t.Run("TestHintCannotFitProperty", testHintCannotFitProperty)
+}
+
+func testCostOverflow(t *testing.T) {
 	ctx := coretestsdk.MockContext()
 	defer func() {
 		domain.GetDomain(ctx).StatsHandle().Close()
@@ -43,7 +49,7 @@ func TestCostOverflow(t *testing.T) {
 	require.False(t, task.Invalid())
 }
 
-func TestEnforcedProperty(t *testing.T) {
+func testEnforcedProperty(t *testing.T) {
 	ctx := coretestsdk.MockContext()
 	defer func() {
 		domain.GetDomain(ctx).StatsHandle().Close()
@@ -80,7 +86,7 @@ func TestEnforcedProperty(t *testing.T) {
 	require.False(t, task.Invalid())
 }
 
-func TestHintCannotFitProperty(t *testing.T) {
+func testHintCannotFitProperty(t *testing.T) {
 	ctx := coretestsdk.MockContext()
 	defer func() {
 		domain.GetDomain(ctx).StatsHandle().Close()

--- a/pkg/planner/core/hint_test.go
+++ b/pkg/planner/core/hint_test.go
@@ -28,172 +28,137 @@ import (
 )
 
 func TestHintSuite(t *testing.T) {
-	t.Run("TestSetVarTimestampHintsWorks", testSetVarTimestampHintsWorks)
-	t.Run("TestSetVarTimestampHintsWorksWithBindings", testSetVarTimestampHintsWorksWithBindings)
-	t.Run("TestSetVarInQueriesAndBindingsWorkTogether", testSetVarInQueriesAndBindingsWorkTogether)
-	t.Run("TestSetVarHintsWithExplain", testSetVarHintsWithExplain)
-	t.Run("TestWriteSlowLogHint", testWriteSlowLogHint)
-	t.Run("TestSetVarPartialOrderedIndexForTopN", testSetVarPartialOrderedIndexForTopN)
-}
-
-func testSetVarTimestampHintsWorks(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec(`use test`)
+		t.Run("TestSetVarTimestampHintsWorks", func(t *testing.T) {
+			testKit.MustExec(`set timestamp=default;`)
+			require.Equal(t, "42", testKit.MustQuery(`select /*+ set_var(timestamp=1) */ @@timestamp + 41;`).Rows()[0][0].(string))
+			firstts := testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string)
+			require.Eventually(t, func() bool {
+				return firstts < testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string)
+			}, time.Second, time.Microsecond*10)
 
-		// test that the timestamp continues to update (default behavior)
-		testKit.MustExec(`set timestamp=default;`)
-		require.Equal(t, "42", testKit.MustQuery(`select /*+ set_var(timestamp=1) */ @@timestamp + 41;`).Rows()[0][0].(string))
-		firstts := testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string)
-		require.Eventually(t, func() bool {
-			return firstts < testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string)
-		}, time.Second, time.Microsecond*10)
+			testKit.MustExec(`set timestamp=1745862208.446495;`)
+			require.Equal(t, "1745862208.446495", testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string))
+			require.Equal(t, "1", testKit.MustQuery(`select /*+ set_var(timestamp=1) */ @@timestamp;`).Rows()[0][0].(string))
+			require.Equal(t, "1745862208.446495", testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string))
+		})
 
-		// test that the set value is preserved
-		testKit.MustExec(`set timestamp=1745862208.446495;`)
-		require.Equal(t, "1745862208.446495", testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string))
-		require.Equal(t, "1", testKit.MustQuery(`select /*+ set_var(timestamp=1) */ @@timestamp;`).Rows()[0][0].(string))
-		require.Equal(t, "1745862208.446495", testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string))
-	})
-}
+		t.Run("TestSetVarTimestampHintsWorksWithBindings", func(t *testing.T) {
+			testKit.MustExec(`create session binding for select @@timestamp + 41 using select /*+ set_var(timestamp=1) */ @@timestamp + 41;`)
+			testKit.MustExec(`set timestamp=default;`)
+			require.Equal(t, "42", testKit.MustQuery(`select @@timestamp + 41;`).Rows()[0][0].(string))
+			testKit.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
+			firstts := testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string)
+			require.Eventually(t, func() bool {
+				return firstts < testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string)
+			}, time.Second, time.Microsecond*10)
 
-func testSetVarTimestampHintsWorksWithBindings(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
-		testKit.MustExec(`use test`)
-		testKit.MustExec(`create session binding for select @@timestamp + 41 using select /*+ set_var(timestamp=1) */ @@timestamp + 41;`)
+			testKit.MustExec(`set timestamp=1745862208.446495;`)
+			require.Equal(t, "1745862208.446495", testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string))
+			require.Equal(t, "42", testKit.MustQuery(`select @@timestamp + 41;`).Rows()[0][0].(string))
+			testKit.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
+			require.Equal(t, "1745862208.446495", testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string))
+		})
 
-		// test that bindings with hints correctly restore the default timestamp
-		testKit.MustExec(`set timestamp=default;`)
-		require.Equal(t, "42", testKit.MustQuery(`select @@timestamp + 41;`).Rows()[0][0].(string))
-		testKit.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
-		firstts := testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string)
-		require.Eventually(t, func() bool {
-			return firstts < testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string)
-		}, time.Second, time.Microsecond*10)
+		t.Run("TestSetVarInQueriesAndBindingsWorkTogether", func(t *testing.T) {
+			testKit.MustExec(`set @@max_execution_time=2000;`)
+			testKit.MustExec(`drop table if exists foo`)
+			testKit.MustExec(`create table foo (a int);`)
+			testKit.MustExec(`create session binding for select * from foo where a = 1 using select /*+ set_var(max_execution_time=1234) */ * from foo where a = 1;`)
+			testKit.MustExec(`select /*+ set_var(max_execution_time=2222) */ * from foo where a = 1;`)
+			testKit.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
+			testKit.MustQuery("select @@max_execution_time;").Check(testkit.Rows("2000"))
+		})
 
-		// test that bindings with hints correctly restore the previous non-default timestamp value
-		testKit.MustExec(`set timestamp=1745862208.446495;`)
-		require.Equal(t, "1745862208.446495", testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string))
-		require.Equal(t, "42", testKit.MustQuery(`select @@timestamp + 41;`).Rows()[0][0].(string))
-		testKit.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
-		require.Equal(t, "1745862208.446495", testKit.MustQuery(`select @@timestamp;`).Rows()[0][0].(string))
-	})
-}
+		t.Run("TestSetVarHintsWithExplain", func(t *testing.T) {
+			testKit.MustExec(`set @@max_execution_time=2000;`)
+			testKit.MustExec(`explain select /*+ set_var(max_execution_time=100) */ @@max_execution_time;`)
+			testKit.MustQuery("select @@max_execution_time;").Check(testkit.Rows("2000"))
 
-func testSetVarInQueriesAndBindingsWorkTogether(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
-		testKit.MustExec(`use test`)
-		testKit.MustExec(`set @@max_execution_time=2000;`)
-		testKit.MustExec(`create table foo (a int);`)
-		testKit.MustExec(`create session binding for select * from foo where a = 1 using select /*+ set_var(max_execution_time=1234) */ * from foo where a = 1;`)
-		testKit.MustExec(`select /*+ set_var(max_execution_time=2222) */ * from foo where a = 1;`)
-		testKit.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
-		testKit.MustQuery("select @@max_execution_time;").Check(testkit.Rows("2000"))
-	})
-}
+			testKit.MustExec(`drop table if exists t`)
+			testKit.MustExec(`create table t(a int);`)
+			testKit.MustExec(`create global binding for select * from t where a = 1 and sleep(0.1) using select /*+ SET_VAR(max_execution_time=500) */ * from t where a = 1 and sleep(0.1);`)
+			testKit.MustExec(`select * from t where a = 1 and sleep(0.1);`)
+			testKit.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
+			testKit.MustQuery("select @@max_execution_time;").Check(testkit.Rows("2000"))
 
-func testSetVarHintsWithExplain(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
-		testKit.MustExec(`use test`)
+			testKit.MustExec(`explain select * from t where a = 1 and sleep(0.1);`)
+			testKit.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
+			testKit.MustQuery("select @@max_execution_time;").Check(testkit.Rows("2000"))
+		})
 
-		testKit.MustExec(`set @@max_execution_time=2000;`)
-		testKit.MustExec(`explain select /*+ set_var(max_execution_time=100) */ @@max_execution_time;`)
-		testKit.MustQuery("select @@max_execution_time;").Check(testkit.Rows("2000"))
+		t.Run("TestWriteSlowLogHint", func(t *testing.T) {
+			testKit.MustExec(`drop table if exists t`)
+			testKit.MustExec(`create table t(a int);`)
+			testKit.MustExec(`select * from t where a = 1;`)
 
-		testKit.MustExec(`create table t(a int);`)
-		testKit.MustExec(`create global binding for select * from t where a = 1 and sleep(0.1) using select /*+ SET_VAR(max_execution_time=500) */ * from t where a = 1 and sleep(0.1);`)
-		testKit.MustExec(`select * from t where a = 1 and sleep(0.1);`)
-		testKit.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
-		testKit.MustQuery("select @@max_execution_time;").Check(testkit.Rows("2000"))
+			core, recorded := observer.New(zap.WarnLevel)
+			logger := zap.New(core)
+			prev := logutil.SlowQueryLogger
+			logutil.SlowQueryLogger = logger
+			defer func() { logutil.SlowQueryLogger = prev }()
 
-		testKit.MustExec(`explain select * from t where a = 1 and sleep(0.1);`)
-		testKit.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
-		testKit.MustQuery("select @@max_execution_time;").Check(testkit.Rows("2000"))
-	})
-}
+			sql := "select /*+ write_slow_log */ * from t where a = 1;"
+			checkWriteSlowLog := func(expectWrite bool) {
+				if !expectWrite {
+					require.Equal(t, 0, recorded.Len())
+				} else {
+					require.NotEqual(t, 0, recorded.Len())
+				}
 
-func testWriteSlowLogHint(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
-		testKit.MustExec(`use test`)
-		testKit.MustExec(`create table t(a int);`)
-		testKit.MustExec(`select * from t where a = 1;`)
-
-		core, recorded := observer.New(zap.WarnLevel)
-		logger := zap.New(core)
-		prev := logutil.SlowQueryLogger
-		logutil.SlowQueryLogger = logger
-		defer func() { logutil.SlowQueryLogger = prev }()
-
-		sql := "select /*+ write_slow_log */ * from t where a = 1;"
-		checkWriteSlowLog := func(expectWrite bool) {
-			if !expectWrite {
-				require.Equal(t, 0, recorded.Len())
-			} else {
-				require.NotEqual(t, 0, recorded.Len())
+				writeMsg := slices.ContainsFunc(recorded.All(), func(entry observer.LoggedEntry) bool {
+					if entry.Level == zap.WarnLevel && strings.Contains(entry.Message, sql) {
+						return true
+					}
+					return false
+				})
+				require.Equal(t, expectWrite, writeMsg)
 			}
 
-			writeMsg := slices.ContainsFunc(recorded.All(), func(entry observer.LoggedEntry) bool {
-				if entry.Level == zap.WarnLevel && strings.Contains(entry.Message, sql) {
-					return true
-				}
-				return false
-			})
-			require.Equal(t, expectWrite, writeMsg)
-		}
+			testKit.MustExec(`select * from t where a = 1;`)
+			checkWriteSlowLog(false)
 
-		testKit.MustExec(`select * from t where a = 1;`)
-		checkWriteSlowLog(false)
+			testKit.MustExec(sql)
+			checkWriteSlowLog(true)
+		})
 
-		testKit.MustExec(sql)
-		checkWriteSlowLog(true)
-	})
-}
+		t.Run("TestSetVarPartialOrderedIndexForTopN", func(t *testing.T) {
+			testKit.MustQuery(`select @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("DISABLE"))
 
-func testSetVarPartialOrderedIndexForTopN(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
-		testKit.MustExec(`use test`)
+			testKit.MustExec(`set @@tidb_opt_partial_ordered_index_for_topn = DISABLE`)
+			testKit.MustQuery(`select /*+ set_var(tidb_opt_partial_ordered_index_for_topn=COST) */ @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("COST"))
+			testKit.MustQuery(`select @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("DISABLE"))
 
-		// Test default value
-		testKit.MustQuery(`select @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("DISABLE"))
+			testKit.MustExec(`set @@tidb_opt_partial_ordered_index_for_topn = COST`)
+			testKit.MustQuery(`select /*+ set_var(tidb_opt_partial_ordered_index_for_topn=DISABLE) */ @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("DISABLE"))
+			testKit.MustQuery(`select @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("COST"))
 
-		// Test set_var hint changes the value during query execution
-		testKit.MustExec(`set @@tidb_opt_partial_ordered_index_for_topn = DISABLE`)
-		testKit.MustQuery(`select /*+ set_var(tidb_opt_partial_ordered_index_for_topn=COST) */ @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("COST"))
-		// Value should be restored after query
-		testKit.MustQuery(`select @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("DISABLE"))
+			testKit.MustExec(`drop table if exists t, t_multi`)
+			testKit.MustExec(`create table t(a int, b varchar(10), index idx_b(b(5)));`)
+			testKit.MustExec(`set @@tidb_opt_partial_ordered_index_for_topn = DISABLE`)
+			testKit.MustExec(`select /*+ set_var(tidb_opt_partial_ordered_index_for_topn=COST) */ * from t order by b limit 10;`)
+			testKit.MustQuery(`select @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("DISABLE"))
 
-		// Test set_var hint with OFF
-		testKit.MustExec(`set @@tidb_opt_partial_ordered_index_for_topn = COST`)
-		testKit.MustQuery(`select /*+ set_var(tidb_opt_partial_ordered_index_for_topn=DISABLE) */ @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("DISABLE"))
-		// Value should be restored after query
-		testKit.MustQuery(`select @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("COST"))
+			testKit.MustExec(`set @@tidb_opt_partial_ordered_index_for_topn = DISABLE`)
+			testKit.MustExec(`explain select /*+ set_var(tidb_opt_partial_ordered_index_for_topn=COST) */ * from t order by b limit 10;`)
+			testKit.MustQuery(`select @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("DISABLE"))
 
-		// Test set_var hint with multiple queries
-		testKit.MustExec(`create table t(a int, b varchar(10), index idx_b(b(5)));`)
-		testKit.MustExec(`set @@tidb_opt_partial_ordered_index_for_topn = DISABLE`)
-		testKit.MustExec(`select /*+ set_var(tidb_opt_partial_ordered_index_for_topn=COST) */ * from t order by b limit 10;`)
-		testKit.MustQuery(`select @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("DISABLE"))
-
-		// Test with EXPLAIN (should not change the value)
-		testKit.MustExec(`set @@tidb_opt_partial_ordered_index_for_topn = DISABLE`)
-		testKit.MustExec(`explain select /*+ set_var(tidb_opt_partial_ordered_index_for_topn=COST) */ * from t order by b limit 10;`)
-		testKit.MustQuery(`select @@tidb_opt_partial_ordered_index_for_topn`).Check(testkit.Rows("DISABLE"))
-
-		// Regression test: the partial-order prefix column must be resolved against
-		// the child schema even when the index's last column is a prefix column.
-		testKit.MustExec(`create table t_multi(a int, b varchar(30), c varchar(30), key idx_ab_prefix(a, b(15)))`)
-		testKit.MustExec(`insert into t_multi values
+			testKit.MustExec(`create table t_multi(a int, b varchar(30), c varchar(30), key idx_ab_prefix(a, b(15)))`)
+			testKit.MustExec(`insert into t_multi values
 			(1, 'alpha', 'first'),
 			(1, 'beta', 'second'),
 			(1, 'gamma', 'third'),
 			(2, 'alpha', 'fourth'),
 			(2, 'beta', 'fifth'),
 			(2, 'gamma', 'sixth')`)
-		testKit.MustExec(`set @@tidb_opt_partial_ordered_index_for_topn = COST`)
-		testKit.MustQuery(`select /*+ use_index(t_multi, idx_ab_prefix) */ * from t_multi order by a, b limit 3 offset 2`).
-			Check(testkit.Rows(
-				"1 gamma third",
-				"2 alpha fourth",
-				"2 beta fifth",
-			))
+			testKit.MustExec(`set @@tidb_opt_partial_ordered_index_for_topn = COST`)
+			testKit.MustQuery(`select /*+ use_index(t_multi, idx_ab_prefix) */ * from t_multi order by a, b limit 3 offset 2`).
+				Check(testkit.Rows(
+					"1 gamma third",
+					"2 alpha fourth",
+					"2 beta fifth",
+				))
+		})
 	})
 }

--- a/pkg/planner/core/hint_test.go
+++ b/pkg/planner/core/hint_test.go
@@ -27,7 +27,16 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-func TestSetVarTimestampHintsWorks(t *testing.T) {
+func TestHintSuite(t *testing.T) {
+	t.Run("TestSetVarTimestampHintsWorks", testSetVarTimestampHintsWorks)
+	t.Run("TestSetVarTimestampHintsWorksWithBindings", testSetVarTimestampHintsWorksWithBindings)
+	t.Run("TestSetVarInQueriesAndBindingsWorkTogether", testSetVarInQueriesAndBindingsWorkTogether)
+	t.Run("TestSetVarHintsWithExplain", testSetVarHintsWithExplain)
+	t.Run("TestWriteSlowLogHint", testWriteSlowLogHint)
+	t.Run("TestSetVarPartialOrderedIndexForTopN", testSetVarPartialOrderedIndexForTopN)
+}
+
+func testSetVarTimestampHintsWorks(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec(`use test`)
 
@@ -47,7 +56,7 @@ func TestSetVarTimestampHintsWorks(t *testing.T) {
 	})
 }
 
-func TestSetVarTimestampHintsWorksWithBindings(t *testing.T) {
+func testSetVarTimestampHintsWorksWithBindings(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec(`use test`)
 		testKit.MustExec(`create session binding for select @@timestamp + 41 using select /*+ set_var(timestamp=1) */ @@timestamp + 41;`)
@@ -70,7 +79,7 @@ func TestSetVarTimestampHintsWorksWithBindings(t *testing.T) {
 	})
 }
 
-func TestSetVarInQueriesAndBindingsWorkTogether(t *testing.T) {
+func testSetVarInQueriesAndBindingsWorkTogether(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec(`use test`)
 		testKit.MustExec(`set @@max_execution_time=2000;`)
@@ -82,7 +91,7 @@ func TestSetVarInQueriesAndBindingsWorkTogether(t *testing.T) {
 	})
 }
 
-func TestSetVarHintsWithExplain(t *testing.T) {
+func testSetVarHintsWithExplain(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec(`use test`)
 
@@ -102,7 +111,7 @@ func TestSetVarHintsWithExplain(t *testing.T) {
 	})
 }
 
-func TestWriteSlowLogHint(t *testing.T) {
+func testWriteSlowLogHint(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec(`use test`)
 		testKit.MustExec(`create table t(a int);`)
@@ -139,7 +148,7 @@ func TestWriteSlowLogHint(t *testing.T) {
 	})
 }
 
-func TestSetVarPartialOrderedIndexForTopN(t *testing.T) {
+func testSetVarPartialOrderedIndexForTopN(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec(`use test`)
 

--- a/pkg/planner/core/plan_cache_instance_test.go
+++ b/pkg/planner/core/plan_cache_instance_test.go
@@ -44,7 +44,15 @@ func _miss(t *testing.T, pc sessionctx.InstancePlanCache, testKey, statsHash int
 	require.False(t, ok)
 }
 
-func TestInstancePlanCacheBasic(t *testing.T) {
+func TestInstancePlanCacheSuite(t *testing.T) {
+	t.Run("TestInstancePlanCacheBasic", testInstancePlanCacheBasic)
+	t.Run("TestInstancePlanCacheWithMatchOpts", testInstancePlanCacheWithMatchOpts)
+	t.Run("TestInstancePlanCacheEvictAll", testInstancePlanCacheEvictAll)
+	t.Run("TestInstancePlanCacheConcurrentRead", testInstancePlanCacheConcurrentRead)
+	t.Run("TestInstancePlanCacheConcurrentWriteRead", testInstancePlanCacheConcurrentWriteRead)
+}
+
+func testInstancePlanCacheBasic(t *testing.T) {
 	sctx := coretestsdk.MockContext()
 	defer func() {
 		domain.GetDomain(sctx).StatsHandle().Close()
@@ -124,7 +132,7 @@ func TestInstancePlanCacheBasic(t *testing.T) {
 	require.Equal(t, numHeads, 0)
 }
 
-func TestInstancePlanCacheWithMatchOpts(t *testing.T) {
+func testInstancePlanCacheWithMatchOpts(t *testing.T) {
 	sctx := coretestsdk.MockContext()
 	defer func() {
 		domain.GetDomain(sctx).StatsHandle().Close()
@@ -188,7 +196,7 @@ func TestInstancePlanCacheWithMatchOpts(t *testing.T) {
 	_miss(t, pc, 1, 5)
 }
 
-func TestInstancePlanCacheEvictAll(t *testing.T) {
+func testInstancePlanCacheEvictAll(t *testing.T) {
 	sctx := coretestsdk.MockContext()
 	defer func() {
 		domain.GetDomain(sctx).StatsHandle().Close()
@@ -209,7 +217,7 @@ func TestInstancePlanCacheEvictAll(t *testing.T) {
 	require.Equal(t, pc.Size(), int64(0))
 }
 
-func TestInstancePlanCacheConcurrentRead(t *testing.T) {
+func testInstancePlanCacheConcurrentRead(t *testing.T) {
 	sctx := coretestsdk.MockContext()
 	defer func() {
 		domain.GetDomain(sctx).StatsHandle().Close()
@@ -246,7 +254,7 @@ func TestInstancePlanCacheConcurrentRead(t *testing.T) {
 	wg.Wait()
 }
 
-func TestInstancePlanCacheConcurrentWriteRead(t *testing.T) {
+func testInstancePlanCacheConcurrentWriteRead(t *testing.T) {
 	sctx := coretestsdk.MockContext()
 	defer func() {
 		domain.GetDomain(sctx).StatsHandle().Close()

--- a/pkg/planner/core/plan_cache_lru_test.go
+++ b/pkg/planner/core/plan_cache_lru_test.go
@@ -46,7 +46,17 @@ func randomPlanCacheValue(types []*types.FieldType) *PlanCacheValue {
 	}
 }
 
-func TestLRUPCPut(t *testing.T) {
+func TestLRUPlanCacheSuite(t *testing.T) {
+	t.Run("TestLRUPCPut", testLRUPCPut)
+	t.Run("TestLRUPCGet", testLRUPCGet)
+	t.Run("TestLRUPCDelete", testLRUPCDelete)
+	t.Run("TestLRUPCDeleteAll", testLRUPCDeleteAll)
+	t.Run("TestLRUPCSetCapacity", testLRUPCSetCapacity)
+	t.Run("TestLRUPlanCacheRegressionCases", testLRUPlanCacheRegressionCases)
+	t.Run("TestLRUPlanCacheMemoryUsage", testLRUPlanCacheMemoryUsage)
+}
+
+func testLRUPCPut(t *testing.T) {
 	// test initialize
 	mockCtx := coretestsdk.MockContext()
 	mockCtx.GetSessionVars().EnablePlanCacheForParamLimit = true
@@ -127,7 +137,7 @@ func TestLRUPCPut(t *testing.T) {
 	require.Nil(t, root)
 }
 
-func TestLRUPCGet(t *testing.T) {
+func testLRUPCGet(t *testing.T) {
 	mockCtx := coretestsdk.MockContext()
 	mockCtx.GetSessionVars().EnablePlanCacheForParamLimit = true
 	defer func() {
@@ -183,7 +193,7 @@ func TestLRUPCGet(t *testing.T) {
 	}
 }
 
-func TestLRUPCDelete(t *testing.T) {
+func testLRUPCDelete(t *testing.T) {
 	mockCtx := coretestsdk.MockContext()
 	mockCtx.GetSessionVars().EnablePlanCacheForParamLimit = true
 	defer func() {
@@ -221,7 +231,7 @@ func TestLRUPCDelete(t *testing.T) {
 	require.True(t, exists)
 }
 
-func TestLRUPCDeleteAll(t *testing.T) {
+func testLRUPCDeleteAll(t *testing.T) {
 	ctx := coretestsdk.MockContext()
 	lru := NewLRUPlanCache(3, 0, 0, ctx, false)
 	defer func() {
@@ -254,7 +264,7 @@ func TestLRUPCDeleteAll(t *testing.T) {
 	}
 }
 
-func TestLRUPCSetCapacity(t *testing.T) {
+func testLRUPCSetCapacity(t *testing.T) {
 	ctx := coretestsdk.MockContext()
 	lru := NewLRUPlanCache(5, 0, 0, ctx, false)
 	defer func() {
@@ -323,7 +333,7 @@ func TestLRUPCSetCapacity(t *testing.T) {
 	require.ErrorContains(t, err, "capacity of LRU cache should be at least 1")
 }
 
-func TestLRUPlanCacheRegressionCases(t *testing.T) {
+func testLRUPlanCacheRegressionCases(t *testing.T) {
 	t.Run("put-with-mem-guard", func(t *testing.T) {
 		ctx := coretestsdk.MockContext()
 		lru := NewLRUPlanCache(3, 0.1, 1, ctx, false)
@@ -370,7 +380,7 @@ func TestLRUPlanCacheRegressionCases(t *testing.T) {
 	})
 }
 
-func TestLRUPlanCacheMemoryUsage(t *testing.T) {
+func testLRUPlanCacheMemoryUsage(t *testing.T) {
 	pTypes := []*types.FieldType{types.NewFieldType(mysql.TypeFloat), types.NewFieldType(mysql.TypeDouble)}
 	ctx := coretestsdk.MockContext()
 	defer func() {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #49616, ref #55886, ref #56513

Problem Summary:

- planner test suites under `pkg/planner/core` and `pkg/planner/core/casetest/rule` had many small top-level tests that repeated wrapper setup and increased shard pressure
- some rule tests also repeated `RunTestUnderCascadesWithDomain` initialization and dataset setup even when the lifecycle could be shared

### What changed and how does it work?

- merged several planner test files into suite-style entry points with subtests while preserving the original testdata lookup keys
- merged `DerivedTopN` cases under one `RunTestUnderCascadesWithDomain` wrapper and shared dataset setup across both subtests
- merged `Outer2Inner` related tests under one wrapper and restored `collation_connection` explicitly for the special-case subtest
- updated planner rule notes with the suite-sizing guidance
- reduced `pkg/planner/core/casetest/rule` Bazel `shard_count` from `30` to `20`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

```bash
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/rule -run 'TestJoinReorderSuite|TestPredicatePushdownSuite|TestDerivedTopNSuite|TestEliminateProjectionSuite'
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/rule -run 'TestOuter2InnerSuite'
./tools/check/failpoint-go-test.sh pkg/planner/core -run 'TestHintSuite|TestFindBestTaskSuite|TestLRUPlanCacheSuite|TestInstancePlanCacheSuite'
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added dated guidance on consolidating planner rule casetests into suites, preserving explicit testdata lookup keys, and validating suites after refactors.

* **Tests**
  * Consolidated many standalone tests into suite-style entrypoints that run scenarios as subtests, unifying domain/setup and reducing repetition while keeping assertions unchanged.

* **Chores**
  * Reduced test shard count to improve test execution efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->