### PR TITLE
Fix flaky test: stabilize flaky TestStatsStoreAndLoad

### DIFF
--- a/pkg/statistics/handle/handletest/statstest/stats_test.go
+++ b/pkg/statistics/handle/handletest/statstest/stats_test.go
@@ -17,6 +17,7 @@ package statstest
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/statistics"
 	statstestutil "github.com/pingcap/tidb/pkg/statistics/handle/ddl/testutil"
 	"github.com/pingcap/tidb/pkg/statistics/handle/internal"
@@ -306,22 +308,25 @@ func TestStatsCacheMemTracker(t *testing.T) {
 
 func TestStatsStoreAndLoad(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
-	testKit := testkit.NewTestKit(t, store)
-	testKit.MustExec("use test")
-	testKit.MustExec("create table t (c1 int, c2 int)")
+	se := session.CreateSessionAndSetID(t, store)
+	session.MustExec(t, se, "use test")
+	session.MustExec(t, se, "create table t (c1 int, c2 int)")
 	recordCount := 1000
+	vals := make([]string, 0, recordCount)
 	for i := range recordCount {
-		testKit.MustExec("insert into t values (?, ?)", i, i+1)
+		vals = append(vals, fmt.Sprintf("(%d, %d)", i, i+1))
 	}
-	testKit.MustExec("create index idx_t on t(c2)")
-	analyzehelper.TriggerPredicateColumnsCollection(t, testKit, store, "t", "c1")
+	session.MustExec(t, se, "insert into t values "+strings.Join(vals, ","))
+	session.MustExec(t, se, "create index idx_t on t(c2)")
+	session.MustExec(t, se, "select * from t where c1 = '1'")
+	require.NoError(t, dom.StatsHandle().DumpColStatsUsageToKV())
 	do := dom
 	is := do.InfoSchema()
 	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := tbl.Meta()
 
-	testKit.MustExec("analyze table t")
+	session.MustExec(t, se, "analyze table t")
 	statsTbl1 := do.StatsHandle().GetPhysicalTableStats(tableInfo.ID, tableInfo)
 
 	do.StatsHandle().Clear()

--- a/pkg/statistics/handle/handletest/statstest/stats_test.go
+++ b/pkg/statistics/handle/handletest/statstest/stats_test.go
@@ -309,6 +309,7 @@ func TestStatsCacheMemTracker(t *testing.T) {
 func TestStatsStoreAndLoad(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	se := session.CreateSessionAndSetID(t, store)
+	defer se.Close()
 	session.MustExec(t, se, "use test")
 	session.MustExec(t, se, "create table t (c1 int, c2 int)")
 	recordCount := 1000


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67901

Problem Summary:
Flaky test `TestStatsStoreAndLoad` in `pkg/statistics/handle/handletest/statstest` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TEST_ISSUE: `TestStatsStoreAndLoad` populated its fixture through a prepared `MustExec` loop, and the CI race detector flagged that prepared-exec path rather than any stats store/load bug.

#### Fix

Replacing the parameterized insert loop with one literal multi-row insert removes the racy prepared-statement path while preserving the exact fixture rows the stats assertions depend on.

#### Verification

Spec:
- target: `pkg/statistics/handle/handletest/statstest :: TestStatsStoreAndLoad`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/statistics/handle/handletest/statstest -run '^TestStatsStoreAndLoad$' -count=1`
- `go test -json ./pkg/statistics/handle/handletest/statstest -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reworked statistics tests to use a different session setup, load data in a single batched insert, remove an obsolete helper call, add an extra query, and include a new assertion ensuring stats-dump returns no error.
  
**Note:** No user-visible changes; this release updates internal tests only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/67932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->