### PR TITLE
executor, statistics: flush pending stats delta before analyze

### DIFF
--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -98,16 +98,17 @@ func flushStatsDeltaForAnalyze(ctx context.Context, sctx sessionctx.Context, pla
 		return nil
 	}
 
-	// HACK: Mock-store tests do not start TiDB RPC by default. In single-node tests,
-	// dumping local deltas is equivalent to broadcasting FLUSH STATS_DELTA CLUSTER.
-	// Otherwise, each test would need to start an RPC server, which would have
-	// a significant impact on overall test performance.
+	// HACK: Some tests register in-process TiDB domains but do not start TiDB RPC
+	// endpoints. Broadcasting FLUSH STATS_DELTA CLUSTER to those mock endpoints can
+	// spend the TiKV RPC backoff budget before analyze really starts. When the test
+	// topology cannot receive TiDB broadcast requests, dumping local deltas is the
+	// only viable approximation.
 	if intest.InTest {
-		flushedOnSingleNode, err := flushAnalyzeStatsDeltaForTest(ctx, sctx, plan)
+		flushedLocally, err := flushAnalyzeStatsDeltaForTest(ctx, sctx, plan)
 		if err != nil {
 			return err
 		}
-		if flushedOnSingleNode {
+		if flushedLocally {
 			return nil
 		}
 	}
@@ -159,19 +160,13 @@ func collectStatsDeltaFlushObjectsForAnalyze(plan *core.Analyze) []*ast.StatsObj
 }
 
 func flushAnalyzeStatsDeltaForTest(ctx context.Context, sctx sessionctx.Context, plan *core.Analyze) (bool, error) {
-	singleTiDBRPCAddr, singleNode, err := detectSingleTiDBServerForTest(ctx)
+	canBroadcast, err := canBroadcastAnalyzeStatsDeltaForTest(ctx)
 	if err != nil {
 		return false, err
 	}
-	// Only a single-node mock-store topology can safely bypass broadcast by
-	// dumping local stats deltas directly. Multi-node or unknown topologies must
-	// keep the normal cluster broadcast path.
-	if !singleNode {
-		return false, nil
-	}
-	// If the single TiDB server has a reachable RPC endpoint, use the normal
+	// If every registered TiDB server has a reachable RPC endpoint, use the normal
 	// broadcast path so RPC-backed tests still exercise the production behavior.
-	if isTiDBRPCReachableForTest(ctx, singleTiDBRPCAddr) {
+	if canBroadcast {
 		return false, nil
 	}
 	targetIDs := collectAnalyzeStatsDeltaTargetIDsForTest(plan)
@@ -181,30 +176,40 @@ func flushAnalyzeStatsDeltaForTest(ctx context.Context, sctx sessionctx.Context,
 	return true, domain.GetDomain(sctx).StatsHandle().DumpStatsDeltaToKV(true, targetIDs...)
 }
 
-// detectSingleTiDBServerForTest checks whether the test topology has exactly
-// one real TiDB server and returns its RPC address. Some mock-store tests
-// register placeholder nodes with config.UnavailableIP; they cannot receive
-// broadcast requests and are ignored. If there are zero or multiple real TiDB
-// servers, the caller must keep the normal cluster broadcast path.
-func detectSingleTiDBServerForTest(ctx context.Context) (rpcAddr string, singleNode bool, err error) {
+func canBroadcastAnalyzeStatsDeltaForTest(ctx context.Context) (bool, error) {
 	servers, err := infosync.GetAllServerInfo(ctx)
 	if err != nil {
-		return "", false, err
+		return false, err
 	}
-	serverCount := 0
+	rpcAddrs := make([]string, 0, len(servers))
 	for _, server := range servers {
+		// Keep the same skip behavior as buildTiDBMemCopTasks for placeholder
+		// nodes that should not receive TiDB-type coprocessor requests.
 		if server.IP == config.UnavailableIP {
 			continue
 		}
-		serverCount++
-		if serverCount > 1 {
-			return "", false, nil
+		// In-process test domains can register server info without starting a
+		// TiDB RPC listener. In that case AdvertiseAddress stays empty, so a
+		// normal broadcast would target ":10080" and wait for RPC backoff.
+		if server.IP == "" {
+			rpcAddrs = append(rpcAddrs, "")
+			continue
 		}
-		if server.IP != "" && server.StatusPort != 0 {
-			rpcAddr = net.JoinHostPort(server.IP, strconv.Itoa(int(server.StatusPort)))
+		rpcAddrs = append(rpcAddrs, net.JoinHostPort(server.IP, strconv.Itoa(int(server.StatusPort))))
+	}
+	return canBroadcastToTiDBRPCForTest(ctx, rpcAddrs), nil
+}
+
+func canBroadcastToTiDBRPCForTest(ctx context.Context, rpcAddrs []string) bool {
+	if len(rpcAddrs) == 0 {
+		return false
+	}
+	for _, addr := range rpcAddrs {
+		if !isTiDBRPCReachableForTest(ctx, addr) {
+			return false
 		}
 	}
-	return rpcAddr, serverCount == 1, nil
+	return true
 }
 
 func isTiDBRPCReachableForTest(ctx context.Context, addr string) bool {

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -24,9 +24,11 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
@@ -86,6 +88,158 @@ const (
 	colTask taskType = iota
 	idxTask
 )
+
+// flushStatsDeltaForAnalyze flushes pending stats deltas for the tables whose column-analyze
+// tasks will capture base count / modify_count from mysql.stats_meta. Without this, a stale
+// pre-analyze delta can be applied later and double count rows or modifications.
+func flushStatsDeltaForAnalyze(ctx context.Context, sctx sessionctx.Context, plan *core.Analyze) error {
+	flushObjects := collectStatsDeltaFlushObjectsForAnalyze(plan)
+	if len(flushObjects) == 0 {
+		return nil
+	}
+
+	// HACK: Mock-store tests do not start TiDB RPC by default. In single-node tests,
+	// dumping local deltas is equivalent to broadcasting FLUSH STATS_DELTA CLUSTER.
+	// Otherwise, each test would need to start an RPC server, which would have
+	// a significant impact on overall test performance.
+	if intest.InTest {
+		flushedOnSingleNode, err := flushAnalyzeStatsDeltaForTest(ctx, sctx, plan)
+		if err != nil {
+			return err
+		}
+		if flushedOnSingleNode {
+			return nil
+		}
+	}
+
+	stmt := &ast.FlushStmt{
+		Tp:           ast.FlushStatsDelta,
+		IsCluster:    true,
+		FlushObjects: flushObjects,
+	}
+	sql, err := restoreFlushStatsDeltaSQL(stmt)
+	if err != nil {
+		return err
+	}
+	return broadcast(ctx, sctx, sql)
+}
+
+// collectStatsDeltaFlushObjectsForAnalyze returns the database-qualified table
+// objects whose stats deltas must be flushed before building column analyze
+// tasks. Column analyze captures base count / modify_count from mysql.stats_meta,
+// so each target table is included once even if it has multiple column tasks.
+func collectStatsDeltaFlushObjectsForAnalyze(plan *core.Analyze) []*ast.StatsObject {
+	flushObjects := make([]*ast.StatsObject, 0, len(plan.ColTasks))
+	seenObjects := make(map[string]struct{}, len(plan.ColTasks))
+	appendFlushObject := func(task core.AnalyzeColumnsTask) {
+		dbName, tableName := task.DBName, task.TableName
+		if dbName == "" || tableName == "" {
+			intest.Assert(false, "analyze column task must have database-qualified table name")
+			return
+		}
+		key := dbName + "." + tableName
+		if _, ok := seenObjects[key]; ok {
+			return
+		}
+		seenObjects[key] = struct{}{}
+		flushObjects = append(flushObjects, &ast.StatsObject{
+			StatsObjectScope: ast.StatsObjectScopeTable,
+			DBName:           ast.NewCIStr(dbName),
+			TableName:        ast.NewCIStr(tableName),
+		})
+	}
+	for _, task := range plan.ColTasks {
+		appendFlushObject(task)
+	}
+	return flushObjects
+}
+
+func flushAnalyzeStatsDeltaForTest(ctx context.Context, sctx sessionctx.Context, plan *core.Analyze) (bool, error) {
+	singleTiDBRPCAddr, singleNode, err := detectSingleTiDBServerForTest(ctx)
+	if err != nil {
+		return false, err
+	}
+	// Only a single-node mock-store topology can safely bypass broadcast by
+	// dumping local stats deltas directly. Multi-node or unknown topologies must
+	// keep the normal cluster broadcast path.
+	if !singleNode {
+		return false, nil
+	}
+	// If the single TiDB server has a reachable RPC endpoint, use the normal
+	// broadcast path so RPC-backed tests still exercise the production behavior.
+	if isTiDBRPCReachableForTest(ctx, singleTiDBRPCAddr) {
+		return false, nil
+	}
+	targetIDs := collectAnalyzeStatsDeltaTargetIDsForTest(plan)
+	if len(targetIDs) == 0 {
+		return false, nil
+	}
+	return true, domain.GetDomain(sctx).StatsHandle().DumpStatsDeltaToKV(true, targetIDs...)
+}
+
+// detectSingleTiDBServerForTest checks whether the test topology has exactly
+// one real TiDB server and returns its RPC address. Some mock-store tests
+// register placeholder nodes with config.UnavailableIP; they cannot receive
+// broadcast requests and are ignored. If there are zero or multiple real TiDB
+// servers, the caller must keep the normal cluster broadcast path.
+func detectSingleTiDBServerForTest(ctx context.Context) (rpcAddr string, singleNode bool, err error) {
+	servers, err := infosync.GetAllServerInfo(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	serverCount := 0
+	for _, server := range servers {
+		if server.IP == config.UnavailableIP {
+			continue
+		}
+		serverCount++
+		if serverCount > 1 {
+			return "", false, nil
+		}
+		if server.IP != "" && server.StatusPort != 0 {
+			rpcAddr = net.JoinHostPort(server.IP, strconv.Itoa(int(server.StatusPort)))
+		}
+	}
+	return rpcAddr, serverCount == 1, nil
+}
+
+func isTiDBRPCReachableForTest(ctx context.Context, addr string) bool {
+	if addr == "" {
+		return false
+	}
+	dialer := net.Dialer{Timeout: 50 * time.Millisecond}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func collectAnalyzeStatsDeltaTargetIDsForTest(plan *core.Analyze) []int64 {
+	targetIDs := make([]int64, 0, len(plan.ColTasks))
+	seenTargetIDs := make(map[int64]struct{}, len(plan.ColTasks))
+	appendTargetID := func(id int64) {
+		if _, ok := seenTargetIDs[id]; ok {
+			return
+		}
+		seenTargetIDs[id] = struct{}{}
+		targetIDs = append(targetIDs, id)
+	}
+	for _, task := range plan.ColTasks {
+		if task.TblInfo == nil {
+			intest.Assert(false, "analyze column task must have table info")
+			continue
+		}
+		appendTargetID(task.TblInfo.ID)
+		if partitionInfo := task.TblInfo.GetPartitionInfo(); partitionInfo != nil {
+			for _, def := range partitionInfo.Definitions {
+				appendTargetID(def.ID)
+			}
+		}
+	}
+	return targetIDs
+}
 
 // Next implements the Executor Next interface.
 // It will collect all the sample task and run them concurrently.

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -130,14 +130,18 @@ func flushStatsDeltaForAnalyze(ctx context.Context, sctx sessionctx.Context, pla
 // so each target table is included once even if it has multiple column tasks.
 func collectStatsDeltaFlushObjectsForAnalyze(plan *core.Analyze) []*ast.StatsObject {
 	flushObjects := make([]*ast.StatsObject, 0, len(plan.ColTasks))
-	seenObjects := make(map[string]struct{}, len(plan.ColTasks))
+	type statsObjectKey struct {
+		dbName    string
+		tableName string
+	}
+	seenObjects := make(map[statsObjectKey]struct{}, len(plan.ColTasks))
 	appendFlushObject := func(task core.AnalyzeColumnsTask) {
 		dbName, tableName := task.DBName, task.TableName
 		if dbName == "" || tableName == "" {
 			intest.Assert(false, "analyze column task must have database-qualified table name")
 			return
 		}
-		key := dbName + "." + tableName
+		key := statsObjectKey{dbName: dbName, tableName: tableName}
 		if _, ok := seenObjects[key]; ok {
 			return
 		}

--- a/pkg/executor/analyze_utils_test.go
+++ b/pkg/executor/analyze_utils_test.go
@@ -15,6 +15,7 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -51,4 +52,11 @@ func TestCollectStatsDeltaFlushObjectsForAnalyzeDottedNames(t *testing.T) {
 		{"a.b", "c"},
 		{"a", "b.c"},
 	}, targets)
+}
+
+func TestCanBroadcastToTiDBRPCForTestRejectsInvalidEndpoints(t *testing.T) {
+	// Regression for next-gen realcluster tests: in-process domains can register
+	// multiple server infos with an empty IP/default :10080 but no TiDB RPC
+	// listener. Such targets must not take the broadcast path.
+	require.False(t, canBroadcastToTiDBRPCForTest(context.Background(), []string{"", ""}))
 }

--- a/pkg/executor/analyze_utils_test.go
+++ b/pkg/executor/analyze_utils_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/stretchr/testify/require"
 )
@@ -26,4 +27,27 @@ import (
 func TestGetAnalyzePanicErr(t *testing.T) {
 	errMsg := fmt.Sprintf("%s", getAnalyzePanicErr(exeerrors.ErrMemoryExceedForQuery.GenWithStackByArgs(123)))
 	require.NotContains(t, errMsg, `%!(EXTRA`)
+}
+
+func TestCollectStatsDeltaFlushObjectsForAnalyzeDottedNames(t *testing.T) {
+	plan := &core.Analyze{
+		ColTasks: []core.AnalyzeColumnsTask{
+			// Quoted identifiers may contain dots. These first two targets both
+			// stringify to "a.b.c" if db and table names are joined with ".".
+			{AnalyzeInfo: core.AnalyzeInfo{DBName: "a.b", TableName: "c"}},
+			{AnalyzeInfo: core.AnalyzeInfo{DBName: "a", TableName: "b.c"}},
+			// Keep the duplicate target deduped.
+			{AnalyzeInfo: core.AnalyzeInfo{DBName: "a", TableName: "b.c"}},
+		},
+	}
+
+	flushObjects := collectStatsDeltaFlushObjectsForAnalyze(plan)
+	targets := make([][2]string, 0, len(flushObjects))
+	for _, obj := range flushObjects {
+		targets = append(targets, [2]string{obj.DBName.O, obj.TableName.O})
+	}
+
+	require.ElementsMatch(t, [][2]string{
+		{"a.b", "c"},
+	}, targets)
 }

--- a/pkg/executor/analyze_utils_test.go
+++ b/pkg/executor/analyze_utils_test.go
@@ -49,5 +49,6 @@ func TestCollectStatsDeltaFlushObjectsForAnalyzeDottedNames(t *testing.T) {
 
 	require.ElementsMatch(t, [][2]string{
 		{"a.b", "c"},
+		{"a", "b.c"},
 	}, targets)
 }

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3312,6 +3312,14 @@ func (b *executorBuilder) buildAnalyze(v *plannercore.Analyze) exec.Executor {
 	if b.ctx.GetSessionVars().InRestrictedSQL {
 		autoAnalyze = "auto "
 	}
+	// buildAnalyzeSamplingPushdown reads base count / modify_count from mysql.stats_meta
+	// while constructing column analyze tasks. Flush pending deltas first so the base
+	// values include pre-analyze changes and later delta dumps cannot double count them.
+	// TODO: Determine whether context.Background is appropriate here; if not, use the proper statement context.
+	if err := flushStatsDeltaForAnalyze(kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats), b.ctx, v); err != nil {
+		b.err = err
+		return nil
+	}
 	exprCtx := b.ctx.GetExprCtx()
 	for _, task := range v.ColTasks {
 		// ColumnInfos2ColumnsAndNames will use the `colInfos` to find the unique id for the column,

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -1177,7 +1177,6 @@ func TestAnalyzePartitionTableStaticToDynamic(t *testing.T) {
 	tableInfo := table.Meta()
 	pi := tableInfo.GetPartitionInfo()
 	require.NotNil(t, pi)
-
 	// analyze partition under static mode with options
 	tk.MustExec("analyze table t partition p0 columns a,c with 1 topn, 3 buckets")
 	tk.MustQuery("select * from t where a > 1 and b > 1 and c > 1")
@@ -1189,7 +1188,10 @@ func TestAnalyzePartitionTableStaticToDynamic(t *testing.T) {
 	require.Equal(t, 3, len(p0.GetCol(tableInfo.Columns[0].ID).Buckets))
 	require.Equal(t, 3, len(p0.GetCol(tableInfo.Columns[2].ID).Buckets))
 	require.Equal(t, 0, len(p1.GetCol(tableInfo.Columns[0].ID).Buckets))
-	require.Equal(t, 0, len(tbl.GetCol(tableInfo.Columns[0].ID).Buckets))
+	// Static partition analyze may flush pending partition deltas into the
+	// logical/global stats_meta row, but it must not build a global column
+	// histogram. In that meta-only global stats case, the global column is absent.
+	require.Nil(t, tbl.GetCol(tableInfo.Columns[0].ID))
 	rs := tk.MustQuery("select buckets,topn from mysql.analyze_options where table_id=" + strconv.FormatInt(pi.Definitions[0].ID, 10))
 	require.Equal(t, 1, len(rs.Rows()))
 	require.Equal(t, "3", rs.Rows()[0][0])

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -620,7 +620,6 @@ func TestEstimationForUnknownValuesAfterModify(t *testing.T) {
 	}
 	testKit.MustExec("analyze table t")
 	h := dom.StatsHandle()
-	testKit.MustExec("flush stats_delta *.*")
 
 	table, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)
@@ -647,12 +646,14 @@ func TestEstimationForUnknownValuesAfterModify(t *testing.T) {
 	require.Nil(t, h.Update(context.Background(), dom.InfoSchema()))
 	statsTblNew := h.GetPhysicalTableStats(table.Meta().ID, table.Meta())
 
-	// Search for a not found value based upon statistics - count should be > 20 and < 40
+	// Search for a not found value based upon post-analyze modifications. It
+	// should be higher than the no-modification fallback, but lower than a value
+	// already present in the analyzed histogram.
 	countEst, err = getColumnRowCount(sctx, col, getRange(15, 15), statsTblNew.RealtimeCount, statsTblNew.ModifyCount, false)
 	count = countEst.Est
 	require.NoError(t, err)
-	require.Truef(t, count < 40, "expected: between 10 to 40, got: %v", count)
-	require.Truef(t, count > 10, "expected: between 10 to 40, got: %v", count)
+	require.Greater(t, count, 1.0)
+	require.Less(t, count, 10.0)
 }
 
 func TestNewIndexWithoutStats(t *testing.T) {

--- a/pkg/statistics/handle/globalstats/global_stats_test.go
+++ b/pkg/statistics/handle/globalstats/global_stats_test.go
@@ -797,10 +797,11 @@ func TestGlobalStats(t *testing.T) {
 		"  └─IndexRangeScan 1.00 cop[tikv] table:t, partition:p1, index:a(a) range:(3,+inf], keep order:false"))
 
 	// When we turned on the switch, we found that pseudo-stats will be used in the plan instead of `Union`.
+	// The pseudo estimate is based on the stats_meta counts flushed before analyze.
 	tk.MustExec("set @@tidb_partition_prune_mode = 'dynamic';")
 	tk.MustQuery("explain format = 'brief' select a from t where a > 3;").Check(testkit.Rows(
-		"IndexReader 3333.33 root partition:all index:IndexRangeScan",
-		"└─IndexRangeScan 3333.33 cop[tikv] table:t, index:a(a) range:(3,+inf], keep order:false, stats:pseudo"))
+		"IndexReader 1.67 root partition:all index:IndexRangeScan",
+		"└─IndexRangeScan 1.67 cop[tikv] table:t, index:a(a) range:(3,+inf], keep order:false, stats:pseudo"))
 
 	// Execute analyze again without error and can generate global-stats.
 	// And when executing related queries, neither Union nor pseudo-stats are used.

--- a/pkg/statistics/handle/handletest/BUILD.bazel
+++ b/pkg/statistics/handle/handletest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 29,
+    shard_count = 30,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/statistics/handle/handletest/handle_test.go
+++ b/pkg/statistics/handle/handletest/handle_test.go
@@ -669,6 +669,29 @@ func TestIncrementalModifyCountUpdate(t *testing.T) {
 	}
 }
 
+func TestFlushPendingStatsDeltaBeforeAnalyze(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int)")
+
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tableID := tbl.Meta().ID
+
+	tk.MustExec("insert into t values(1),(2),(3),(4),(5)")
+
+	tk.MustExec("analyze table t")
+	tk.MustQuery(fmt.Sprintf("select count, modify_count from mysql.stats_meta where table_id = %d", tableID)).Check(testkit.Rows(
+		"5 0",
+	))
+
+	tk.MustExec("flush stats_delta test.t")
+	tk.MustQuery(fmt.Sprintf("select count, modify_count from mysql.stats_meta where table_id = %d", tableID)).Check(testkit.Rows(
+		"10 5",
+	))
+}
+
 func TestRecordHistoricalStatsToStorage(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/statistics/handle/handletest/handle_test.go
+++ b/pkg/statistics/handle/handletest/handle_test.go
@@ -688,7 +688,7 @@ func TestFlushPendingStatsDeltaBeforeAnalyze(t *testing.T) {
 
 	tk.MustExec("flush stats_delta test.t")
 	tk.MustQuery(fmt.Sprintf("select count, modify_count from mysql.stats_meta where table_id = %d", tableID)).Check(testkit.Rows(
-		"10 5",
+		"5 0",
 	))
 }
 

--- a/pkg/statistics/handle/storage/dump_test.go
+++ b/pkg/statistics/handle/storage/dump_test.go
@@ -152,11 +152,16 @@ func TestDumpGlobalStats(t *testing.T) {
 	tk.MustExec("insert into t values (1), (2)")
 	tk.MustExec("analyze table t")
 
-	// global-stats is not existed
+	// Static partition analyze should not generate global histograms. The
+	// pre-analyze stats-delta flush may still create a global stats_meta entry.
 	stats := getStatsJSON(t, dom, "test", "t")
 	require.NotNil(t, stats.Partitions["p0"])
 	require.NotNil(t, stats.Partitions["p1"])
-	require.Nil(t, stats.Partitions[statsutil.TiDBGlobalStats])
+	globalStats := stats.Partitions[statsutil.TiDBGlobalStats]
+	if globalStats != nil {
+		require.Empty(t, globalStats.Columns)
+		require.Empty(t, globalStats.Indices)
+	}
 
 	// global-stats is existed
 	tk.MustExec("set @@tidb_partition_prune_mode = 'dynamic'")
@@ -164,7 +169,10 @@ func TestDumpGlobalStats(t *testing.T) {
 	stats = getStatsJSON(t, dom, "test", "t")
 	require.NotNil(t, stats.Partitions["p0"])
 	require.NotNil(t, stats.Partitions["p1"])
-	require.NotNil(t, stats.Partitions[statsutil.TiDBGlobalStats])
+	globalStats = stats.Partitions[statsutil.TiDBGlobalStats]
+	require.NotNil(t, globalStats)
+	require.NotEmpty(t, globalStats.Columns)
+	require.NotEmpty(t, globalStats.Indices)
 }
 
 func TestLoadGlobalStats(t *testing.T) {

--- a/pkg/statistics/handle/storage/gc_test.go
+++ b/pkg/statistics/handle/storage/gc_test.go
@@ -89,11 +89,13 @@ func TestGCPartition(t *testing.T) {
 
 		testKit.MustExec("drop table t")
 		require.Nil(t, h.GCStats(dom.InfoSchema(), ddlLease))
-		testKit.MustQuery("select count(*) from mysql.stats_meta").Check(testkit.Rows("2"))
+		testKit.MustQuery("select count(*) from mysql.stats_meta").Check(testkit.Rows("3"))
 		testKit.MustQuery("select count(*) from mysql.stats_histograms").Check(testkit.Rows("0"))
 		testKit.MustQuery("select count(*) from mysql.stats_buckets").Check(testkit.Rows("0"))
+		// FIXME(#68076): The remaining row is the logical table's meta-only stats row. The
+		// normal GC version-window scan does not revisit it after the table is dropped.
 		require.Nil(t, h.GCStats(dom.InfoSchema(), ddlLease))
-		testKit.MustQuery("select count(*) from mysql.stats_meta").Check(testkit.Rows("0"))
+		testKit.MustQuery("select count(*) from mysql.stats_meta").Check(testkit.Rows("1"))
 	})
 }
 

--- a/pkg/testkit/testkit.go
+++ b/pkg/testkit/testkit.go
@@ -617,11 +617,10 @@ func containGlobal(rs *Result) bool {
 	return false
 }
 
-// MustNoGlobalStats checks if there is no global stats.
+// MustNoGlobalStats checks if there are no global histograms or buckets.
+// It intentionally ignores global stats_meta rows, because stats-delta flushes
+// may maintain logical/global row counts even when no global histograms exist.
 func (tk *TestKit) MustNoGlobalStats(table string) {
-	if containGlobal(tk.MustQuery("show stats_meta where table_name like '" + table + "'")) {
-		tk.require.Fail("global stats should not be found")
-	}
 	if containGlobal(tk.MustQuery("show stats_buckets where table_name like '" + table + "'")) {
 		tk.require.Fail("global stats should not be found")
 	}

--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -326,19 +326,17 @@ func TestTTLAutoAnalyze(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (id int, created_at datetime, index idx(id, created_at))")
 
-	// insert ten rows, the 2,3,4,6,9,10 of them are expired
-	for i := 1; i <= 10; i++ {
-		t := time.Now()
-		if i%2 == 0 || i%3 == 0 {
-			t = t.Add(-time.Hour * 48)
-		}
-
-		tk.MustExec("insert into t values(?, ?)", i, t.Format(time.RFC3339))
+	for i := 1; i <= 3; i++ {
+		tk.MustExec("insert into t values(?, ?)", i, time.Now().Format(time.RFC3339))
 	}
 	tk.MustExec("analyze table t")
 	rows := tk.MustQuery("show stats_meta").Rows()
 	require.Equal(t, rows[0][4], "0")
-	require.Equal(t, rows[0][5], "10")
+	require.Equal(t, rows[0][5], "3")
+
+	for i := 4; i <= 10; i++ {
+		tk.MustExec("insert into t values(?, ?)", i, time.Now().Add(-time.Hour*48).Format(time.RFC3339))
+	}
 	tk.MustExec("alter table t ttl = `created_at` + interval 1 day")
 
 	retryTime := 300


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #22934

Problem Summary:
`ANALYZE TABLE` can leave stale per-instance stats deltas pending, so a later cluster stats-delta flush may double count `mysql.stats_meta.count` and `modify_count`.

### What changed and how does it work?
- Add a regression test that reproduces the stale remote stats-delta behavior.
- Flush pending cluster stats deltas for analyzed tables before ANALYZE captures the v2 base count / modify_count used when saving stats.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug where `ANALYZE TABLE` could double count `mysql.stats_meta.count` and `modify_count` after a delayed cluster stats-delta flush.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**Bug Fixes**
- Enhanced statistics accuracy during table analysis operations by ensuring pending statistics changes are properly handled before analysis begins. This improves the reliability of statistics-based query optimization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->