### PR TITLE
pkg/planner/core/casetest/planstats: stabilize flaky TestPreparedPlanCacheInvalidatedAfterSyncLoadTimeoutFallback

### DIFF
--- a/pkg/planner/core/casetest/planstats/plan_stats_test.go
+++ b/pkg/planner/core/casetest/planstats/plan_stats_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/statistics"
-	"github.com/pingcap/tidb/pkg/statistics/asyncload"
 	"github.com/pingcap/tidb/pkg/statistics/handle/ddl/testutil"
 	"github.com/pingcap/tidb/pkg/statistics/handle/types"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -416,7 +415,7 @@ func TestPreparedPlanCacheInvalidatedAfterSyncLoadTimeoutFallback(t *testing.T) 
 	})
 
 	store, dom := testkit.CreateMockStoreAndDomain(t)
-	tk := testkit.NewTestKit(t, store)
+	tk := testkit.NewTestKitWithSession(t, store, testkit.NewSession(t, store))
 	tk.MustExec("use test")
 	originalPseudoTimeout := tk.MustQuery("select @@tidb_stats_load_pseudo_timeout").Rows()[0][0].(string)
 	defer func() {
@@ -452,23 +451,15 @@ func TestPreparedPlanCacheInvalidatedAfterSyncLoadTimeoutFallback(t *testing.T) 
 	tk.MustExec("prepare st from 'select * from t where b > ?'")
 	tk.MustExec("set @p = 2")
 	tk.MustExec("execute st using @p")
+	require.True(t, tk.Session().GetSessionVars().StmtCtx.IsSyncStatsFailed)
+	require.NotZero(t, tk.Session().GetSessionVars().StmtCtx.WarningCount())
+	require.Equal(t, 0, tk.Session().GetSessionPlanCache().Size())
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
-
-	// Wait for the async histogram load item corresponding to column b to be marked
-	// as sync-load failed, which confirms the sync-load path timed out and fell back
-	// to async loading for this full-load stats item.
-	require.Eventually(t, func() bool {
-		for _, item := range asyncload.AsyncLoadHistogramNeededItems.AllItems() {
-			if item.TableID == tblInfo.ID && item.ID == colBID && !item.IsIndex && item.FullLoad && item.IsSyncLoadFailed {
-				return true
-			}
-		}
-		return false
-	}, 5*time.Second, 100*time.Millisecond)
 
 	tk.MustExec("execute st using @p")
-	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	require.True(t, tk.Session().GetSessionVars().StmtCtx.IsSyncStatsFailed)
 	require.Equal(t, 0, tk.Session().GetSessionPlanCache().Size())
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 
 	require.NoError(t, dom.StatsHandle().LoadNeededHistograms(dom.InfoSchema()))
 	statsTbl = dom.StatsHandle().GetPhysicalTableStats(tblInfo.ID, tblInfo)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67629

Problem Summary:
Flaky test `TestPreparedPlanCacheInvalidatedAfterSyncLoadTimeoutFallback` in `pkg/planner/core/casetest/planstats` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The flaky came from a test-only timing assumption: it polled the shared async-load registry instead of asserting the executed statement’s own sync-load-fallback state.

#### Fix

The change is necessary to preserve the original cache-invalidation intent while removing a transient global observation point and making the exact no-tag runtime gate executable.

#### Verification

Spec:
- target: `pkg/planner/core/casetest/planstats :: TestPreparedPlanCacheInvalidatedAfterSyncLoadTimeoutFallback`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/planner/core/casetest/planstats -run '^TestPreparedPlanCacheInvalidatedAfterSyncLoadTimeoutFallback$' -count=1`
- `go test -json ./pkg/planner/core/casetest/planstats -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure for prepared plan cache sync-load failure validation to improve assertion accuracy and test maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->