### PR TITLE
br/pkg/streamhelper: stabilize flaky TestStoreRemoved

### DIFF
--- a/br/pkg/streamhelper/subscription_test.go
+++ b/br/pkg/streamhelper/subscription_test.go
@@ -44,6 +44,22 @@ func waitPendingEvents(t *testing.T, sub *streamhelper.FlushSubscriber) {
 	}, 3*time.Second, 100*time.Millisecond)
 }
 
+func collectCheckpointSpans(t *testing.T, sub *streamhelper.FlushSubscriber, checkpoint uint64) *spans.ValueSortedFull {
+	t.Helper()
+	observed := spans.Sorted(spans.NewFullWith(spans.Full(), 1))
+	require.Eventually(t, func() bool {
+		for {
+			select {
+			case event := <-sub.Events():
+				observed.Merge(event)
+			default:
+				return observed.MinValue() == checkpoint
+			}
+		}
+	}, 3*time.Second, 100*time.Millisecond)
+	return observed
+}
+
 func TestSubBasic(t *testing.T) {
 	req := require.New(t)
 	ctx := context.Background()
@@ -169,12 +185,8 @@ func TestStoreRemoved(t *testing.T) {
 	sub.HandleErrors()
 	req.NoError(sub.PendingErrors())
 
-	waitPendingEvents(t, sub)
+	s := collectCheckpointSpans(t, sub, cp)
 	sub.Drop()
-	s := spans.Sorted(spans.NewFullWith(spans.Full(), 1))
-	for k := range sub.Events() {
-		s.Merge(k)
-	}
 
 	defer func() {
 		if t.Failed() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/52791

Problem Summary:
Flaky test `TestStoreRemoved` in `br/pkg/streamhelper` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

`TestStoreRemoved` was flaky because it used channel-idle timing (`waitPendingEvents`) as a proxy for delivery completion, so post-removal events could still be in flight when `Drop()` canceled them.

#### Fix

The test needed to wait for the semantic condition it actually cares about, namely that the subscriber has observed full-span coverage at the final post-removal checkpoint.

#### Verification

Spec:
- target: `br/pkg/streamhelper :: TestStoreRemoved`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./br/pkg/streamhelper -run '^TestStoreRemoved$' -count=1`
- `go test -json ./br/pkg/streamhelper -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #52791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test utility by consolidating span collection and synchronization logic into a reusable helper function, reducing code duplication and enhancing test maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->