### PR TITLE
chore: typo sweep in design docs (enviroment, seperate, neccessary)

### DIFF
--- a/docs/design/2022-07-03-block-storage-snapshot-based-backup-restore.md
+++ b/docs/design/2022-07-03-block-storage-snapshot-based-backup-restore.md
@@ -1067,7 +1067,7 @@ All block issues had been identified. However some part of design may need some 
 
 * On-premise backup and restore
 
-4. setup a enviroment with LVM disk
+4. setup an environment with LVM disk
 
   1. prepare a lvm snapshot script
 

--- a/docs/design/2022-11-23-batch-cop.md
+++ b/docs/design/2022-11-23-batch-cop.md
@@ -145,5 +145,5 @@ All the request handling could be scheduled to the read pool at the same time,
 so before finishing something like `join_all` would be needed to wait for all the results of 
 different tasks. If any error is returned, do fill in the error fields in the `Response`.
 
-For the execution tracking, creating seperate trackers for the requests, all the execution details would be returned
+For the execution tracking, creating separate trackers for the requests, all the execution details would be returned
 to the client.

--- a/docs/design/2025-11-05-active-active.md
+++ b/docs/design/2025-11-05-active-active.md
@@ -924,7 +924,7 @@ To guarantee Cross-Table Transaction Atomicity, it is mandatory that all tables 
 - Performance Limits: Due to the single-node centralized scheduling bottleneck, the maximum throughput for a single changefeed enabling this feature is wide table 100MiB/s and narrow table 30MiB/s, supporting a maximum of 10K tables.
 - Conflict Constraint: It is not supported to configure multiple changefeeds with this feature enabled to synchronize the same table into the same downstream cluster.
 - Feature Gaps: This initial design does not support Syncpoint or Redo log functionalities.
-  - Since we already guarantee cross table transaction atomacity, Redo log is not neccessary.
+  - Since we already guarantee cross table transaction atomacity, Redo log is not necessary.
   - SyncPoint is not possible to create an identical consistent view between two clusters in active-active setup.
 
 


### PR DESCRIPTION
Three typo fixes across design documents:

- `docs/design/2022-07-03-block-storage-snapshot-based-backup-restore.md:1070` — `setup a enviroment` -> `setup an environment`
- `docs/design/2022-11-23-batch-cop.md:148` — `creating seperate trackers` -> `creating separate trackers`
- `docs/design/2025-11-05-active-active.md:927` — `Redo log is not neccessary` -> `Redo log is not necessary`

No functional change.

Issue Number: close #68008