### PR TITLE
planner: preserve UnionScan child rewrite for NULL predicates

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -819,6 +819,28 @@ ORDER BY field1`).Check(testkit.Rows())
 			"2 3 1,2",
 		))
 	}
+
+	// issue-67967-unionscan-should-eliminate-tabledual-for-null-comparison
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("create table t_issue_67967 (id bigint not null primary key auto_increment, delete_flag tinyint default null)")
+
+		for _, sql := range []string{
+			"begin",
+			"insert into t_issue_67967(delete_flag) values (null)",
+		} {
+			tk.MustExec(sql)
+		}
+		tk.MustQuery("explain format='brief' select 1 from t_issue_67967 use index() where delete_flag = null").Check(testkit.Rows(
+			"Projection 0.00 root  1->Column#4",
+			"└─TableDual 0.00 root  rows:0",
+		))
+		tk.MustQuery("explain format='brief' select 1 from t_issue_67967 where delete_flag = null").Check(testkit.Rows(
+			"Projection 0.00 root  1->Column#4",
+			"└─TableDual 0.00 root  rows:0",
+		))
+		tk.MustExec("rollback")
+	}
 }
 
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {

--- a/pkg/planner/core/operator/logicalop/logical_union_scan.go
+++ b/pkg/planner/core/operator/logicalop/logical_union_scan.go
@@ -70,10 +70,14 @@ func (p *LogicalUnionScan) PredicatePushDown(predicates []expression.Expression)
 		}
 	}
 	predicates = predicatesWithoutVCol
-	retainedPredicates, _, err := p.Children()[0].PredicatePushDown(predicates)
+	retainedPredicates, child, err := p.Children()[0].PredicatePushDown(predicates)
 	if err != nil {
 		return nil, nil, err
 	}
+	if _, ok := child.(*LogicalTableDual); ok {
+		return nil, child, nil
+	}
+	p.SetChild(0, child)
 	p.Conditions = make([]expression.Expression, 0, len(predicates))
 	p.Conditions = append(p.Conditions, predicates...)
 	// The conditions in UnionScan is only used for added rows, so parent Selection should not be removed.

--- a/pkg/planner/core/tests/prepare/prepare_test.go
+++ b/pkg/planner/core/tests/prepare/prepare_test.go
@@ -752,8 +752,10 @@ func TestPlanCacheUnionScan(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("drop table if exists t2")
+	tk.MustExec("drop table if exists t3")
 	tk.MustExec("create table t1(a int not null)")
 	tk.MustExec("create table t2(a int not null)")
+	tk.MustExec("create table t3(a int)")
 	tk.MustExec("prepare stmt1 from 'select * from t1 where a > ?'")
 	tk.MustExec("set @p0 = 0")
 	tk.MustQuery("execute stmt1 using @p0").Check(testkit.Rows())
@@ -834,6 +836,37 @@ func TestPlanCacheUnionScan(t *testing.T) {
 	require.NoError(t, err)
 	cnt = pb.GetCounter().GetValue()
 	require.Equal(t, float64(6), cnt)
+
+	tk.MustExec("prepare stmt3 from 'select 1 from t3 where a = null'")
+	tk.MustQuery("execute stmt3").Check(testkit.Rows())
+	tk.MustExec("begin")
+	tk.MustQuery("execute stmt3").Check(testkit.Rows())
+	require.Equal(t, float64(6), cnt) // can't reuse the plan created outside the txn
+	tk.MustQuery("execute stmt3").Check(testkit.Rows())
+	err = counter.Write(pb)
+	require.NoError(t, err)
+	cnt = pb.GetCounter().GetValue()
+	require.Equal(t, float64(7), cnt)
+	tk.MustExec("insert into t3 values(null)")
+	// Cached plan is invalid now, it is not chosen and removed. The result must still be empty.
+	tk.MustQuery("execute stmt3").Check(testkit.Rows())
+	err = counter.Write(pb)
+	require.NoError(t, err)
+	cnt = pb.GetCounter().GetValue()
+	require.Equal(t, float64(7), cnt)
+	// Cached plan is reused and must still keep the result empty.
+	tk.MustQuery("execute stmt3").Check(testkit.Rows())
+	err = counter.Write(pb)
+	require.NoError(t, err)
+	cnt = pb.GetCounter().GetValue()
+	require.Equal(t, float64(8), cnt)
+	tk.MustExec("rollback")
+	// Though the cached plan was built in a transaction, it does not impact correctness, so it is reused.
+	tk.MustQuery("execute stmt3").Check(testkit.Rows())
+	err = counter.Write(pb)
+	require.NoError(t, err)
+	cnt = pb.GetCounter().GetValue()
+	require.Equal(t, float64(9), cnt)
 }
 
 func TestPlanCacheSwitchDB(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67967

Problem Summary:

`delete_flag = NULL` is always false, so the optimizer should preserve the
`TableDual` rewrite even when the query runs inside a transaction and goes
through `UnionScan` predicate pushdown.

After `#59199`, `DataSource.PredicatePushDown()` can already turn this predicate
into `TableDual`, but `LogicalUnionScan.PredicatePushDown()` dropped the child
plan returned from its child. That kept the original scan child and regressed
the issue case to a full table scan.

### What changed and how does it work?

- Keep the child plan returned from `LogicalUnionScan.PredicatePushDown()`.
- If the rewritten child is already `TableDual`, return it directly instead of
  keeping a redundant `UnionScan`.
- Add a regression test for the transaction + `col = NULL` case, covering both
  `USE INDEX()` and the no-hint variant from the issue report.
- Extend the prepared-plan-cache test to verify the transaction path still keeps
  the result empty and remains cache-safe.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queries with NULL comparisons involving union-scan logic now produce stable, correct execution plans and no longer lead to incorrect plan reuse or unexpected empty results across transactional boundaries.

* **Tests**
  * Added regression and plan-cache tests validating correct plan generation, proper cache invalidation and safe reuse for NULL-comparison scenarios, including behavior across transactions, rollbacks, and prepared/executed statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->