### PR TITLE
statistics: stabilize TestNonLiteInitStatsWithTableIDs case

### DIFF
--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -391,6 +391,9 @@ func (h *Handle) initStatsHistogramsLite(ctx context.Context, sctx sessionctx.Co
 			break
 		}
 		h.initStatsHistograms4ChunkLite(cache, iter)
+		// The same table may continue in the next chunk. Drain LFU async admission/rejection
+		// before the next chunk reads or mutates it again.
+		cache.WaitForAsyncUpdates()
 	}
 	return nil
 }
@@ -424,6 +427,9 @@ func (h *Handle) initStatsHistogramsByPagingWithSCtx(sctx sessionctx.Context, is
 			break
 		}
 		h.initStatsHistograms4Chunk(is, cache, iter, isFullCache(cache, totalMemory))
+		// The same table may continue in the next chunk. Drain LFU async admission/rejection
+		// before the next chunk reads or mutates it again.
+		cache.WaitForAsyncUpdates()
 	}
 	return nil
 }
@@ -651,6 +657,9 @@ func (h *Handle) initStatsTopNByPagingWithSCtx(sctx sessionctx.Context, cache st
 			break
 		}
 		h.initStatsTopN4Chunk(cache, iter, totalMemory, tablesWithBuckets)
+		// The same table may continue in the next chunk. Drain LFU async admission/rejection
+		// before the next chunk reads or mutates it again.
+		cache.WaitForAsyncUpdates()
 	}
 	return nil
 }
@@ -780,6 +789,9 @@ func (h *Handle) initStatsBucketsByPagingWithSCtx(sctx sessionctx.Context, cache
 			break
 		}
 		h.initStatsBuckets4Chunk(cache, iter)
+		// The same table may continue in the next chunk. Drain LFU async admission/rejection
+		// before the next chunk reads or mutates it again.
+		cache.WaitForAsyncUpdates()
 	}
 	return nil
 }
@@ -843,6 +855,9 @@ func (h *Handle) initStatsLiteWithSession(ctx context.Context, sctx sessionctx.C
 	if err != nil {
 		return errors.Trace(err)
 	}
+	// Required: initStatsMeta adds new tables without an internal wait; histogram loading
+	// reads them immediately.
+	cache.WaitForAsyncUpdates()
 	statslogutil.StatsLogger().Info("Complete loading the stats meta in the lite mode", zap.Duration("duration", time.Since(start)))
 	start = time.Now()
 	err = h.initStatsHistogramsLite(ctx, sctx, cache, tableIDs...)
@@ -861,6 +876,8 @@ func (h *Handle) initStatsLiteWithSession(ctx context.Context, sctx sessionctx.C
 			intest.Assert(table != nil, "table should not be nil")
 			h.Put(table.PhysicalID, table)
 		}
+		// Targeted refresh publishes refreshed tables to global LFU; make async admissions visible before returning.
+		h.StatsCache.WaitForAsyncUpdates()
 		// Do not forget to close the new cache. Otherwise it would cause the goroutine leak issue.
 		cache.Close()
 	}
@@ -907,6 +924,9 @@ func (h *Handle) initStatsWithSession(ctx context.Context, sctx sessionctx.Conte
 	if err != nil {
 		return errors.Trace(err)
 	}
+	// Required: initStatsMeta adds new tables without an internal wait; histogram loading
+	// reads them immediately.
+	cache.WaitForAsyncUpdates()
 	statslogutil.StatsLogger().Info("Complete loading the stats meta", zap.Duration("duration", time.Since(start)))
 	initstats.InitStatsPercentage.Store(initStatsPercentageInterval)
 
@@ -932,6 +952,8 @@ func (h *Handle) initStatsWithSession(ctx context.Context, sctx sessionctx.Conte
 	if err != nil {
 		return errors.Trace(err)
 	}
+	// CalcPreScalar writes tables back; drain before replacing/publishing the cache.
+	cache.WaitForAsyncUpdates()
 	statslogutil.StatsLogger().Info("Complete loading the bucket", zap.Duration("duration", time.Since(start)))
 
 	// If tableIDs is empty, it means we load all the tables' stats.
@@ -944,6 +966,8 @@ func (h *Handle) initStatsWithSession(ctx context.Context, sctx sessionctx.Conte
 			intest.Assert(table != nil, "table should not be nil")
 			h.Put(table.PhysicalID, table)
 		}
+		// Targeted refresh publishes refreshed tables to global LFU; make async admissions visible before returning.
+		h.StatsCache.WaitForAsyncUpdates()
 		// Do not forget to close the new cache. Otherwise it would cause the goroutine leak issue.
 		cache.Close()
 	}

--- a/pkg/statistics/handle/cache/internal/inner.go
+++ b/pkg/statistics/handle/cache/internal/inner.go
@@ -43,4 +43,8 @@ type StatsCacheInner interface {
 	Close()
 	// TriggerEvict triggers the cache to evict some items
 	TriggerEvict()
+	// WaitForAsyncUpdates blocks until buffered asynchronous cache writes are visible to later Get calls.
+	// Use it after adding new items when following reads depend on them. LFU/Ristretto admits
+	// non-resident items asynchronously; init stats calls this between load phases/chunks.
+	WaitForAsyncUpdates()
 }

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -29,7 +29,12 @@ import (
 	"go.uber.org/zap"
 )
 
-// LFU is a LFU based on the ristretto.Cache
+// LFU is a LFU based on the ristretto.Cache.
+//
+// NOTE: In Ristretto, updates to keys already resident in the primary store become visible
+// immediately, but keys not currently resident go through a buffered admission path and are
+// applied by a background worker. So a successful Set does not guarantee immediate Get
+// visibility for a non-resident key.
 type LFU struct {
 	cache *ristretto.Cache
 	// This is a secondary cache layer used to store all tables,
@@ -87,7 +92,27 @@ func adjustMemCost(totalMemCost int64) (result int64, err error) {
 	return totalMemCost, nil
 }
 
-// Get implements statsCacheInner
+// Get reads the primary Ristretto cache first and falls back to resultKeySet.
+//
+// NOTE: We keep this order to preserve Ristretto's admission/frequency behavior.
+// That means a resident primary-cache entry wins even if resultKeySet has already been updated to
+// a newer table snapshot; until the buffered Ristretto write catches up, Get can still observe
+// that older snapshot. We are aware of this stale-read window, but it is very rare in practice, so
+// we currently document it instead of changing the read order and taking on different concurrency
+// trade-offs.
+//
+// Extreme example (the old flaky pattern from TestNonLiteInitStatsWithTableIDs):
+//  1. InitStats(tbl1) publishes tbl1 to resultKeySet, but the new primary-cache entry is still in
+//     Ristretto's buffered admission path.
+//  2. A later targeted InitStats call that includes tbl1 again reads tbl1 from resultKeySet,
+//     fills in more index state, and republishes a newer tbl1 snapshot there.
+//  3. The older tbl1 can still reach Ristretto first, so topn/buckets sees that resident older
+//     snapshot, misses the index entry, and Put() can write that stale tbl1 back into the main
+//     cache.
+//
+// For phase-by-phase or chunk-by-chunk cache construction, callers that read after writes should
+// drain buffered Ristretto updates before the next dependent read. InitStats does this between load
+// phases and chunks so a temporary LFU cache cannot carry an older table snapshot into later loading.
 func (s *LFU) Get(tid int64) (*statistics.Table, bool) {
 	result, ok := s.cache.Get(tid)
 	if !ok {
@@ -96,7 +121,10 @@ func (s *LFU) Get(tid int64) (*statistics.Table, bool) {
 	return result.(*statistics.Table), ok
 }
 
-// Put implements statsCacheInner
+// Put publishes to resultKeySet first, then hands the item to Ristretto.
+//
+// Resident-key updates become visible there immediately; non-resident keys still go through the
+// buffered admission path.
 func (s *LFU) Put(tblID int64, tbl *statistics.Table) bool {
 	cost := tbl.MemoryUsage().TotalTrackingMemUsage()
 	s.resultKeySet.AddKeyValue(tblID, tbl)

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -111,8 +111,8 @@ func adjustMemCost(totalMemCost int64) (result int64, err error) {
 //     cache.
 //
 // For phase-by-phase or chunk-by-chunk cache construction, callers that read after writes should
-// drain buffered Ristretto updates before the next dependent read. InitStats does this between load
-// phases and chunks so a temporary LFU cache cannot carry an older table snapshot into later loading.
+// call WaitForAsyncUpdates before the next dependent read. InitStats does this between load phases
+// and chunks so a temporary LFU cache cannot carry an older table snapshot into later loading.
 func (s *LFU) Get(tid int64) (*statistics.Table, bool) {
 	result, ok := s.cache.Get(tid)
 	if !ok {
@@ -249,9 +249,9 @@ func (s *LFU) SetCapacity(maxCost int64) {
 	metrics.CostGauge.Set(float64(s.Cost()))
 }
 
-// wait blocks until all buffered writes have been applied. This ensures a call to Set()
-// will be visible to future calls to Get(). it is only used for test.
-func (s *LFU) wait() {
+// WaitForAsyncUpdates blocks until all buffered writes have been applied. This ensures a call to
+// Put is visible to future calls to Get.
+func (s *LFU) WaitForAsyncUpdates() {
 	s.cache.Wait()
 }
 

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
@@ -36,12 +36,12 @@ func TestLFUPutGetDel(t *testing.T) {
 	mockTable := testutil.NewMockStatisticsTable(1, 1, true, false, false)
 	mockTableID := int64(1)
 	lfu.Put(mockTableID, mockTable)
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	lfu.Del(mockTableID)
 	v, ok := lfu.Get(mockTableID)
 	require.False(t, ok)
 	require.Nil(t, v)
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
 	require.Equal(t, 0, len(lfu.Values()))
 }
@@ -58,15 +58,15 @@ func TestLFUFreshMemUsage(t *testing.T) {
 	lfu.Put(int64(1), t1)
 	lfu.Put(int64(2), t2)
 	lfu.Put(int64(3), t3)
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, lfu.Cost(), 6*mockCMSMemoryUsage+6*mockCMSMemoryUsage)
 	t4 := testutil.NewMockStatisticsTable(2, 1, true, false, false)
 	lfu.Put(int64(1), t4)
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, lfu.Cost(), 7*mockCMSMemoryUsage+6*mockCMSMemoryUsage)
 	t5 := testutil.NewMockStatisticsTable(2, 2, true, false, false)
 	lfu.Put(int64(1), t5)
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, lfu.Cost(), 7*mockCMSMemoryUsage+7*mockCMSMemoryUsage)
 
 	t6 := testutil.NewMockStatisticsTable(1, 2, true, false, false)
@@ -76,7 +76,7 @@ func TestLFUFreshMemUsage(t *testing.T) {
 	t7 := testutil.NewMockStatisticsTable(1, 1, true, false, false)
 	lfu.Put(int64(1), t7)
 	require.Equal(t, lfu.Cost(), 6*mockCMSMemoryUsage+6*mockCMSMemoryUsage)
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
 }
 
@@ -88,7 +88,7 @@ func TestLFUPutTooBig(t *testing.T) {
 	lfu.Put(int64(1), mockTable)
 	_, ok := lfu.Get(int64(1))
 	require.True(t, ok)
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
 }
 
@@ -102,14 +102,14 @@ func TestCacheLen(t *testing.T) {
 	t2 := testutil.NewMockStatisticsTable(1, 1, true, false, false)
 	// put t2, t1 should be evicted 2 items and still exists in the list
 	lfu.Put(int64(2), t2)
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, lfu.Len(), 2)
 	require.Equal(t, uint64(8), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
 
 	// put t3, t1/t2 should be evicted all items. but t1/t2 still exists in the list
 	t3 := testutil.NewMockStatisticsTable(2, 1, true, false, false)
 	lfu.Put(int64(3), t3)
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, lfu.Len(), 3)
 	require.Equal(t, uint64(12), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
 }
@@ -133,7 +133,7 @@ func TestLFUCachePutGetWithManyConcurrency(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, lfu.Len(), 1000)
 	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
 	require.Equal(t, 1000, len(lfu.Values()))
@@ -164,7 +164,7 @@ func TestLFUCachePutGetWithManyConcurrency2(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
 	require.Equal(t, 1000, len(lfu.Values()))
 }
@@ -202,7 +202,7 @@ func TestLFUCachePutGetWithManyConcurrencyAndSmallConcurrency(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	v, ok := lfu.Get(rand.Int63n(50))
 	require.True(t, ok)
 	v.ForEachColumnImmutable(func(_ int64, c *statistics.Column) bool {
@@ -245,14 +245,14 @@ func TestLFUReject(t *testing.T) {
 	t1 := testutil.NewMockStatisticsTable(2, 1, true, false, false)
 	require.Equal(t, 2*mockCMSMemoryUsage+mockCMSMemoryUsage, t1.MemoryUsage().TotalTrackingMemUsage())
 	lfu.Put(1, t1)
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, lfu.Cost(), 2*mockCMSMemoryUsage+mockCMSMemoryUsage)
 
 	lfu.SetCapacity(2*mockCMSMemoryUsage + mockCMSMemoryUsage - 1)
 
 	t2 := testutil.NewMockStatisticsTable(2, 1, true, false, false)
 	require.True(t, lfu.Put(2, t2))
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	time.Sleep(3 * time.Second)
 	require.Equal(t, int64(0), lfu.Cost())
 	require.Len(t, lfu.Values(), 2)
@@ -275,7 +275,7 @@ func TestMemoryControl(t *testing.T) {
 	t1 := testutil.NewMockStatisticsTable(2, 1, true, false, false)
 	require.Equal(t, 2*mockCMSMemoryUsage+mockCMSMemoryUsage, t1.MemoryUsage().TotalTrackingMemUsage())
 	lfu.Put(1, t1)
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 
 	for i := 2; i <= 1000; i++ {
 		t1 := testutil.NewMockStatisticsTable(2, 1, true, false, false)
@@ -286,19 +286,19 @@ func TestMemoryControl(t *testing.T) {
 
 	for i := 1000; i > 990; i-- {
 		lfu.SetCapacity(int64(i-1) * (2*mockCMSMemoryUsage + mockCMSMemoryUsage))
-		lfu.wait()
+		lfu.WaitForAsyncUpdates()
 		require.Equal(t, int64(i-1)*(2*mockCMSMemoryUsage+mockCMSMemoryUsage), lfu.Cost())
 	}
 	for i := 990; i > 100; i = i - 100 {
 		lfu.SetCapacity(int64(i-1) * (2*mockCMSMemoryUsage + mockCMSMemoryUsage))
-		lfu.wait()
+		lfu.WaitForAsyncUpdates()
 		require.Equal(t, int64(i-1)*(2*mockCMSMemoryUsage+mockCMSMemoryUsage), lfu.Cost())
 	}
 	lfu.SetCapacity(int64(10) * (2*mockCMSMemoryUsage + mockCMSMemoryUsage))
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, int64(10)*(2*mockCMSMemoryUsage+mockCMSMemoryUsage), lfu.Cost())
 	lfu.SetCapacity(0)
-	lfu.wait()
+	lfu.WaitForAsyncUpdates()
 	require.Equal(t, int64(10)*(2*mockCMSMemoryUsage+mockCMSMemoryUsage), lfu.Cost())
 }
 

--- a/pkg/statistics/handle/cache/internal/mapcache/map_cache.go
+++ b/pkg/statistics/handle/cache/internal/mapcache/map_cache.go
@@ -134,3 +134,6 @@ func (*MapCache) Close() {}
 
 // TriggerEvict implements statsCacheInner
 func (*MapCache) TriggerEvict() {}
+
+// WaitForAsyncUpdates implements statsCacheInner.
+func (*MapCache) WaitForAsyncUpdates() {}

--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -337,6 +337,11 @@ func (s *StatsCacheImpl) TriggerEvict() {
 	s.Load().TriggerEvict()
 }
 
+// WaitForAsyncUpdates blocks until buffered asynchronous cache writes are visible to later Get calls.
+func (s *StatsCacheImpl) WaitForAsyncUpdates() {
+	s.Load().WaitForAsyncUpdates()
+}
+
 // MaxTableStatsVersion returns the version of the current cache, which is defined as
 // the max table stats version the cache has in its lifecycle.
 func (s *StatsCacheImpl) MaxTableStatsVersion() uint64 {

--- a/pkg/statistics/handle/cache/statscache_test.go
+++ b/pkg/statistics/handle/cache/statscache_test.go
@@ -196,3 +196,7 @@ func (*mockStatsCacheInner) Close() {
 func (*mockStatsCacheInner) TriggerEvict() {
 	panic("not implemented")
 }
+
+func (*mockStatsCacheInner) WaitForAsyncUpdates() {
+	panic("not implemented")
+}

--- a/pkg/statistics/handle/cache/statscacheinner.go
+++ b/pkg/statistics/handle/cache/statscacheinner.go
@@ -190,3 +190,8 @@ func (sc *StatsCache) Update(tables []*statistics.Table, deletedIDs []int64, ski
 func (sc *StatsCache) TriggerEvict() {
 	sc.c.TriggerEvict()
 }
+
+// WaitForAsyncUpdates blocks until buffered asynchronous cache writes are visible to later Get calls.
+func (sc *StatsCache) WaitForAsyncUpdates() {
+	sc.c.WaitForAsyncUpdates()
+}

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -263,6 +263,11 @@ type StatsCache interface {
 
 	// TriggerEvict triggers the cache to evict some items
 	TriggerEvict()
+
+	// WaitForAsyncUpdates blocks until buffered asynchronous cache writes are visible to later Get calls.
+	// Use it after adding new items when following reads depend on them. LFU/Ristretto admits
+	// non-resident items asynchronously; init stats calls this between load phases/chunks.
+	WaitForAsyncUpdates()
 }
 
 // StatsLockTable is the table info of which will be locked.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67176

Problem Summary:

The LFU stats cache is backed by Ristretto. New/non-resident entries are admitted asynchronously, but init stats builds a fresh stats cache in phases/chunks and later phases may read entries written by earlier phases/chunks. Without draining the async path at the required boundaries, init stats can observe missing or stale table snapshots.

### What changed and how does it work?

- Added `WaitForAsyncUpdates` to the stats-cache interfaces and implementations.
  - LFU delegates to Ristretto `Wait()`.
  - Map cache implements it as a no-op.
- Used the wait in init stats only where later reads or publishing depend on newly written entries:
  - after stats meta loading, before histogram loading reads the newly added tables;
  - after each histogram/TopN/bucket chunk, because one table's rows can span chunks;
  - after `CalcPreScalar` writes tables back, before replacing/publishing the cache;
  - after targeted refresh publishes refreshed tables to the global stats cache.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test ([Benchmark Test](https://github.com/pingcap/tidb/pull/67971#issuecomment-4353043806))
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
