### PR TITLE
types: pack Time into Datum.i to kill SetMysqlTime allocation

### DIFF
--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -95,12 +95,11 @@ func (d *Datum) Copy(dst *Datum) {
 		dst.b = make([]byte, len(d.b))
 		copy(dst.b, d.b)
 	}
-	switch dst.Kind() {
-	case KindMysqlDecimal:
+	// Time is stored inline in d.i, so the bitwise copy above already
+	// produced an independent value; no KindMysqlTime branch needed.
+	if dst.Kind() == KindMysqlDecimal {
 		d := *d.GetMysqlDecimal()
 		dst.SetMysqlDecimal(&d)
-	case KindMysqlTime:
-		dst.SetMysqlTime(d.GetMysqlTime())
 	}
 }
 
@@ -424,15 +423,18 @@ func (d *Datum) GetVectorFloat32() VectorFloat32 {
 	return v
 }
 
-// GetMysqlTime gets types.Time value
+// GetMysqlTime gets types.Time value. Time is a bit-packed CoreTime
+// (uint64) so it lives directly in d.i, avoiding the per-set heap
+// allocation that storing it via d.x (interface{}) would otherwise pay.
 func (d *Datum) GetMysqlTime() Time {
-	return d.x.(Time)
+	return Time{coreTime: CoreTime(uint64(d.i))}
 }
 
-// SetMysqlTime sets types.Time value
+// SetMysqlTime sets types.Time value. Keep the representation inside
+// d.i (8 bytes) rather than boxing through d.x; see GetMysqlTime.
 func (d *Datum) SetMysqlTime(b Time) {
 	d.k = KindMysqlTime
-	d.x = b
+	d.i = int64(uint64(b.coreTime))
 }
 
 // SetRaw sets raw value.

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -426,7 +426,11 @@ func (d *Datum) GetVectorFloat32() VectorFloat32 {
 // GetMysqlTime gets types.Time value. Time is a bit-packed CoreTime
 // (uint64) so it lives directly in d.i, avoiding the per-set heap
 // allocation that storing it via d.x (interface{}) would otherwise pay.
+// The intest assertion catches kind mismatches that the previous
+// `d.x.(Time)` implementation surfaced via panic but which this unchecked
+// reinterpret would otherwise silently return as bogus CoreTime bits.
 func (d *Datum) GetMysqlTime() Time {
+	intest.Assert(d.k == KindMysqlTime, "GetMysqlTime called on Datum of kind ", d.k)
 	return Time{coreTime: CoreTime(uint64(d.i))}
 }
 

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -441,6 +441,11 @@ func (d *Datum) SetMysqlTime(b Time) {
 	d.i = int64(uint64(b.coreTime))
 }
 
+// Compile-time guard: GetMysqlTime/SetMysqlTime assume Time fits in
+// d.i (8 bytes). If Time ever gains a field beyond coreTime, the
+// pack/unpack would silently drop data — break the build instead.
+var _ [8]byte = [unsafe.Sizeof(Time{})]byte{}
+
 // SetRaw sets raw value.
 func (d *Datum) SetRaw(b []byte) {
 	d.k = KindRaw
@@ -2241,6 +2246,10 @@ func (d *Datum) MarshalJSON() ([]byte, error) {
 	}
 	switch d.k {
 	case KindMysqlTime:
+		// Time is packed into d.i; emit it through jd.Time only so the
+		// JSON payload doesn't carry the same bits twice. UnmarshalJSON
+		// re-derives d.i from jd.Time via SetMysqlTime.
+		jd.I = 0
 		jd.Time = d.GetMysqlTime()
 	case KindMysqlDecimal:
 		jd.MyDecimal = d.GetMysqlDecimal()
@@ -2722,7 +2731,6 @@ func ChangeReverseResultByUpperLowerBound(
 
 const (
 	sizeOfEmptyDatum = int(unsafe.Sizeof(Datum{}))
-	sizeOfMysqlTime  = int(unsafe.Sizeof(ZeroTime))
 	sizeOfMyDecimal  = MyDecimalStructSize
 )
 
@@ -2746,7 +2754,7 @@ func (d Datum) EstimatedMemUsage() int64 {
 	case KindMysqlDecimal:
 		bytesConsumed += sizeOfMyDecimal
 	case KindMysqlTime:
-		bytesConsumed += sizeOfMysqlTime
+		// Time is packed inline in d.i, already counted in sizeOfEmptyDatum.
 	case KindVectorFloat32:
 		bytesConsumed += d.GetVectorFloat32().EstimatedMemUsage()
 	default:

--- a/pkg/types/datum_test.go
+++ b/pkg/types/datum_test.go
@@ -395,7 +395,9 @@ func TestEstimatedMemUsage(t *testing.T) {
 		NewBytesDatum(b),
 		NewDecimalDatum(newMyDecimal("1234.1234", t)),
 		NewMysqlEnumDatum(enum),
+		NewTimeDatum(NewTime(FromDate(2025, 1, 1, 0, 0, 0, 0), mysql.TypeDatetime, DefaultFsp)),
 	}
+	// Time packs into Datum.i, so KindMysqlTime adds no bytes beyond sizeOfEmptyDatum.
 	bytesConsumed := 10 * (len(datumArray)*sizeOfEmptyDatum +
 		sizeOfMyDecimal +
 		len(b)*2 +

--- a/pkg/types/datum_test.go
+++ b/pkg/types/datum_test.go
@@ -591,9 +591,13 @@ func TestMarshalDatum(t *testing.T) {
 			require.Nil(t, datum.x, msg)
 		}
 		require.Equal(t, reflect.TypeOf(tt.x), reflect.TypeOf(datum.x), msg)
+		// Time is packed into d.i, not stored via d.x, so verify its
+		// round-trip through the getter rather than via d.x.
+		if tt.k == KindMysqlTime {
+			require.Equal(t, 0, tt.GetMysqlTime().Compare(datum.GetMysqlTime()), msg)
+			continue
+		}
 		switch tt.x.(type) {
-		case Time:
-			require.Equal(t, 0, tt.x.(Time).Compare(datum.x.(Time)))
 		case *MyDecimal:
 			require.Equal(t, 0, tt.x.(*MyDecimal).Compare(datum.x.(*MyDecimal)))
 		default:
@@ -620,6 +624,35 @@ func BenchmarkCompareDatumByReflect(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		reflect.DeepEqual(vals, vals1)
+	}
+}
+
+// BenchmarkDatumSetMysqlTime asserts that SetMysqlTime is alloc-free.
+// Storing Time inline in d.i (rather than boxing through d.x any) means
+// every call should be 0 B/op / 0 allocs/op.
+func BenchmarkDatumSetMysqlTime(b *testing.B) {
+	t := NewTime(FromGoTime(time.Date(2018, 3, 8, 16, 1, 0, 315313000, time.UTC)), mysql.TypeTimestamp, 6)
+	var d Datum
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.SetMysqlTime(t)
+	}
+}
+
+// BenchmarkDatumCopy exercises Datum.Copy on a heterogeneous slice that
+// contains a Time datum. With Time in d.i, the KindMysqlTime branch of
+// Copy is gone and the per-copy allocation count drops by one vs. the
+// old interface-boxed representation.
+func BenchmarkDatumCopy(b *testing.B) {
+	src, _ := prepareCompareDatums()
+	dst := make([]Datum, len(src))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := range src {
+			src[j].Copy(&dst[j])
+		}
 	}
 }
 

--- a/pkg/util/rowcodec/common.go
+++ b/pkg/util/rowcodec/common.go
@@ -308,6 +308,12 @@ func appendDatumForChecksum(loc *time.Location, buf []byte, dat *data.Datum, typ
 	case mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeString, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob:
 		out = appendLengthValue(buf, dat.GetBytes())
 	case mysql.TypeTimestamp, mysql.TypeDatetime, mysql.TypeDate, mysql.TypeNewDate:
+		// GetMysqlTime reinterprets d.i as CoreTime without a kind check,
+		// so the defer-recover above cannot turn a mismatched-kind Datum
+		// into an error the way it does for the other boxed getters.
+		if dat.Kind() != data.KindMysqlTime {
+			return buf, errInvalidChecksumTyp
+		}
 		t := dat.GetMysqlTime()
 		if t.Type() == mysql.TypeTimestamp && loc != nil && loc != time.UTC {
 			err = t.ConvertTimeZone(loc, time.UTC)


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67976

Problem Summary:

`types.Time` is `struct{CoreTime}` where `CoreTime` is a `uint64` — exactly 8
bytes, the same size as `Datum.i`. Today it is stored through `Datum.x any`,
which boxes the value into an interface. Because Go stores non-pointer
interface payloads on the heap, every `SetMysqlTime` call allocates 8 bytes.

`SetMysqlDuration` already sidesteps the box by packing into `d.i`; this PR
does the same for Time. That removes one heap allocation per Time set and,
transitively, one heap allocation per `Datum.Copy` of a Time-valued Datum.

### What changed and how does it work?

- `SetMysqlTime(b Time)` now writes `d.i = int64(uint64(b.coreTime))`.
- `GetMysqlTime()` now returns `Time{coreTime: CoreTime(uint64(d.i))}`.
- `Datum.Copy` drops its `KindMysqlTime` branch: once Time lives in `d.i`,
  the existing bitwise `*dst = *d` already produces an independent value,
  so the extra `dst.SetMysqlTime(d.GetMysqlTime())` call (which itself
  allocated) is no longer needed.
- `TestMarshalDatum` previously asserted Time round-trip via `d.x.(Time)`;
  updated to use `GetMysqlTime().Compare` since the round-trip value no
  longer traverses `d.x`.
- Added `BenchmarkDatumSetMysqlTime` and `BenchmarkDatumCopy` to lock in the
  alloc guarantees.

On-wire and on-disk formats are unchanged. The Datum struct size is unchanged
(72 bytes); the size reduction is a separate change in #67977.

### Measurements

`benchstat`, linux/amd64, Intel i7-13700, `-count=5`:

| Benchmark | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `BenchmarkDatumSetMysqlTime` ns/op | 7.215 | 0.102 | **−98.6%** |
| `BenchmarkDatumSetMysqlTime` B/op | 8 | 0 | **−100%** |
| `BenchmarkDatumSetMysqlTime` allocs/op | 1 | 0 | **−100%** |
| `BenchmarkDatumCopy` ns/op | 46.14 | 36.88 | **−20%** |
| `BenchmarkDatumCopy` B/op | 64 | 53 | **−17%** |
| `BenchmarkDatumCopy` allocs/op | 3 | 2 | **−33%** |

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * More efficient inline storage and copy behavior for time values, reducing allocations and improving performance.

* **Bug Fixes**
  * Stricter kind validation for time handling to surface mismatches earlier and prevent misinterpretation.
  * JSON marshaling for time values normalized to avoid duplicated fields.

* **Tests**
  * Added benchmarks and updated tests to track allocation and copy performance for time operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->