### PR TITLE
ddl: relax constraints on columns referenced by generated columns

### DIFF
--- a/pkg/ddl/db_integration_test.go
+++ b/pkg/ddl/db_integration_test.go
@@ -3147,3 +3147,74 @@ func TestCreateIndexWithChangeMaxIndexLength(t *testing.T) {
 	tk.MustExec("create table t(id int, a json DEFAULT NULL, b varchar(2) DEFAULT NULL);")
 	tk.MustGetErrMsg("CREATE INDEX idx_test on t ((cast(a as char(2000) array)),b);", "[ddl:1071]Specified key was too long (2000 bytes); max key length is 1000 bytes")
 }
+
+// TestModifyColumnWithGeneratedColumnNoReorg tests that column modifications which do NOT
+// require data reorganization are allowed even when the column is a dependency of a generated
+// column or expression index. Modifications that DO require reorganization remain blocked.
+// See https://github.com/pingcap/tidb/issues/43455
+func TestModifyColumnWithGeneratedColumnNoReorg(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	// Case 1: collation change + virtual generated column → success
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1(a char, b varchar(10), c varchar(20) as (concat(a, b)), index idx(c)) charset utf8mb4 collate utf8mb4_bin")
+	tk.MustExec("alter table t1 modify column a char character set utf8mb4 collate utf8mb4_unicode_ci")
+
+	// Case 2: collation change + stored generated column → success
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t2(a varchar(20), b varchar(20) as (concat(a, 'suffix')) stored, index idx(b)) charset utf8mb4 collate utf8mb4_bin")
+	tk.MustExec("alter table t2 modify column a varchar(20) character set utf8mb4 collate utf8mb4_unicode_ci")
+
+	// Case 3: collation change + expression index → success
+	tk.MustExec("drop table if exists t3")
+	tk.MustExec("create table t3(a char(20), index idx((lower(a)))) charset utf8mb4 collate utf8mb4_bin")
+	tk.MustExec("alter table t3 modify column a char(20) character set utf8mb4 collate utf8mb4_unicode_ci")
+
+	// Case 4: default value change + generated column → success
+	tk.MustExec("drop table if exists t4")
+	tk.MustExec("create table t4(a int, b int as (a+1))")
+	tk.MustExec("alter table t4 modify column a int default 42")
+
+	// Case 5: INT -> BIGINT + generated column → success
+	tk.MustExec("drop table if exists t5")
+	tk.MustExec("create table t5(a int, b int as (abs(a)) virtual)")
+	tk.MustExec("alter table t5 modify column a bigint")
+
+	// Case 6: VARCHAR(10) -> VARCHAR(20) + generated column → success
+	tk.MustExec("drop table if exists t6")
+	tk.MustExec("create table t6(a varchar(10), b varchar(20) as (concat(a, 'x')))")
+	tk.MustExec("alter table t6 modify column a varchar(20)")
+
+	// Case 7: INT -> MEDIUMINT + generated column → error (reorg needed)
+	tk.MustExec("drop table if exists t7")
+	tk.MustExec("create table t7(a int, b int as (abs(a)) virtual)")
+	tk.MustGetErrCode("alter table t7 modify column a mediumint", errno.ErrUnsupportedDDLOperation)
+
+	// Case 8: VARCHAR(10) -> VARCHAR(5) + generated column → error (reorg needed)
+	tk.MustExec("drop table if exists t8")
+	tk.MustExec("create table t8(a varchar(10), b varchar(20) as (concat(a, 'x')))")
+	tk.MustGetErrCode("alter table t8 modify column a varchar(5)", errno.ErrUnsupportedDDLOperation)
+
+	// Case 9: rename + generated column → error (always blocked)
+	tk.MustExec("drop table if exists t9")
+	tk.MustExec("create table t9(a int, b int as (a+1))")
+	tk.MustGetErrCode("alter table t9 change column a anew int", errno.ErrDependentByGeneratedColumn)
+
+	// Case 10: modify stored generated column itself, expression unchanged → allowed
+	// (checkModifyGeneratedColumn permits this when expression is unchanged and no index)
+	tk.MustExec("drop table if exists t10")
+	tk.MustExec("create table t10(a int, b int as (a+1) stored)")
+	tk.MustExec("alter table t10 modify column b bigint")
+
+	// Case 10b: modify generated column expression (stored) → error
+	tk.MustExec("drop table if exists t10b")
+	tk.MustExec("create table t10b(a int, b int as (a+1) stored)")
+	tk.MustGetErrCode("alter table t10b modify column b bigint as (a+2) stored", errno.ErrUnsupportedOnGeneratedColumn)
+
+	// Case 11: expression index + reorg-needed type change → error
+	tk.MustExec("drop table if exists t11")
+	tk.MustExec("create table t11(a int, index idx((a+1)))")
+	tk.MustGetErrCode("alter table t11 modify column a varchar(20)", errno.ErrUnsupportedDDLOperation)
+}

--- a/pkg/ddl/db_integration_test.go
+++ b/pkg/ddl/db_integration_test.go
@@ -3149,43 +3149,50 @@ func TestCreateIndexWithChangeMaxIndexLength(t *testing.T) {
 }
 
 // TestModifyColumnWithGeneratedColumnNoReorg tests that column modifications which do NOT
-// require data reorganization are allowed even when the column is a dependency of a generated
-// column or expression index. Modifications that DO require reorganization remain blocked.
-// See https://github.com/pingcap/tidb/issues/43455
+// require data reorganization are allowed for generated column dependencies only when they
+// cannot change existing dependent expression results. Modifications that DO require
+// reorganization remain blocked. See https://github.com/pingcap/tidb/issues/43455
 func TestModifyColumnWithGeneratedColumnNoReorg(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
-	// Case 1: collation change + virtual generated column → success
+	// Case 1: original issue 43455, collation change + concat virtual generated column → success
 	tk.MustExec("drop table if exists t1")
-	tk.MustExec("create table t1(a char, b varchar(10), c varchar(20) as (concat(a, b)), index idx(c)) charset utf8mb4 collate utf8mb4_bin")
+	tk.MustExec("create table t1(a char, b varchar(10), c varchar(20) as (concat(a, b)), d varchar(20) as (concat(b, 'À')) stored, index idx(c), unique key (d)) charset utf8mb4 collate utf8mb4_bin")
 	tk.MustExec("alter table t1 modify column a char character set utf8mb4 collate utf8mb4_unicode_ci")
+	tk.MustExec("insert into t1(a, b) values ('a', 'abc'), ('A', 'ABC')")
+	tk.MustQuery("select a, b, c, d from t1 where a = 'a' order by b").Check(testkit.Rows("A ABC AABC ABCÀ", "a abc aabc abcÀ"))
 
-	// Case 2: collation change + stored generated column → success
+	// Case 2: collation change + stored generated column with byte-preserving concat → success
 	tk.MustExec("drop table if exists t2")
 	tk.MustExec("create table t2(a varchar(20), b varchar(20) as (concat(a, 'suffix')) stored, index idx(b)) charset utf8mb4 collate utf8mb4_bin")
 	tk.MustExec("alter table t2 modify column a varchar(20) character set utf8mb4 collate utf8mb4_unicode_ci")
 
-	// Case 3: collation change + expression index → success
+	// Case 3: collation change + collation-sensitive expression index → error
 	tk.MustExec("drop table if exists t3")
 	tk.MustExec("create table t3(a char(20), index idx((lower(a)))) charset utf8mb4 collate utf8mb4_bin")
-	tk.MustExec("alter table t3 modify column a char(20) character set utf8mb4 collate utf8mb4_unicode_ci")
+	tk.MustGetErrCode("alter table t3 modify column a char(20) character set utf8mb4 collate utf8mb4_unicode_ci", errno.ErrUnsupportedDDLOperation)
+
+	// Case 3b: collation change + collation-sensitive stored generated column → error
+	tk.MustExec("drop table if exists t3b")
+	tk.MustExec("create table t3b(a varchar(20), b bool as (a = 'A') stored, index idx(b)) charset utf8mb4 collate utf8mb4_bin")
+	tk.MustGetErrCode("alter table t3b modify column a varchar(20) character set utf8mb4 collate utf8mb4_unicode_ci", errno.ErrUnsupportedDDLOperation)
 
 	// Case 4: default value change + generated column → success
 	tk.MustExec("drop table if exists t4")
 	tk.MustExec("create table t4(a int, b int as (a+1))")
 	tk.MustExec("alter table t4 modify column a int default 42")
 
-	// Case 5: INT -> BIGINT + generated column → success
+	// Case 5: INT -> BIGINT + generated column → error (outside the narrow allow list)
 	tk.MustExec("drop table if exists t5")
 	tk.MustExec("create table t5(a int, b int as (abs(a)) virtual)")
-	tk.MustExec("alter table t5 modify column a bigint")
+	tk.MustGetErrCode("alter table t5 modify column a bigint", errno.ErrUnsupportedDDLOperation)
 
-	// Case 6: VARCHAR(10) -> VARCHAR(20) + generated column → success
+	// Case 6: VARCHAR(10) -> VARCHAR(20) + generated column → error (outside the narrow allow list)
 	tk.MustExec("drop table if exists t6")
 	tk.MustExec("create table t6(a varchar(10), b varchar(20) as (concat(a, 'x')))")
-	tk.MustExec("alter table t6 modify column a varchar(20)")
+	tk.MustGetErrCode("alter table t6 modify column a varchar(20)", errno.ErrUnsupportedDDLOperation)
 
 	// Case 7: INT -> MEDIUMINT + generated column → error (reorg needed)
 	tk.MustExec("drop table if exists t7")

--- a/pkg/ddl/db_integration_test.go
+++ b/pkg/ddl/db_integration_test.go
@@ -3163,11 +3163,15 @@ func TestModifyColumnWithGeneratedColumnNoReorg(t *testing.T) {
 	tk.MustExec("alter table t1 modify column a char character set utf8mb4 collate utf8mb4_unicode_ci")
 	tk.MustExec("insert into t1(a, b) values ('a', 'abc'), ('A', 'ABC')")
 	tk.MustQuery("select a, b, c, d from t1 where a = 'a' order by b").Check(testkit.Rows("A ABC AABC ABCÀ", "a abc aabc abcÀ"))
+	tk.MustExec("admin check table t1")
 
 	// Case 2: collation change + stored generated column with byte-preserving concat → success
 	tk.MustExec("drop table if exists t2")
 	tk.MustExec("create table t2(a varchar(20), b varchar(20) as (concat(a, 'suffix')) stored, index idx(b)) charset utf8mb4 collate utf8mb4_bin")
 	tk.MustExec("alter table t2 modify column a varchar(20) character set utf8mb4 collate utf8mb4_unicode_ci")
+	tk.MustExec("insert into t2(a) values ('test')")
+	tk.MustQuery("select a, b from t2").Check(testkit.Rows("test testsuffix"))
+	tk.MustExec("admin check table t2")
 
 	// Case 3: collation change + collation-sensitive expression index → error
 	tk.MustExec("drop table if exists t3")
@@ -3183,6 +3187,9 @@ func TestModifyColumnWithGeneratedColumnNoReorg(t *testing.T) {
 	tk.MustExec("drop table if exists t4")
 	tk.MustExec("create table t4(a int, b int as (a+1))")
 	tk.MustExec("alter table t4 modify column a int default 42")
+	tk.MustExec("insert into t4(a) values (1)")
+	tk.MustQuery("select a, b from t4").Check(testkit.Rows("1 2"))
+	tk.MustExec("admin check table t4")
 
 	// Case 5: INT -> BIGINT + generated column → error (outside the narrow allow list)
 	tk.MustExec("drop table if exists t5")

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -2108,7 +2108,9 @@ func needCheckGeneratedColumnDependencyForNoReorg(tblInfo *model.TableInfo, oldC
 
 	// The normal generated-column restriction is only relevant when another generated
 	// column or expression index depends on the modified column.
-
+	if ok, _, _ := hasDependentByGeneratedColumn(tblInfo, oldCol.Name); !ok {
+		return false
+	}
 	// Metadata-only changes do not change existing row values or generated expression results.
 	if oldCol.FieldType.Equal(&newCol.FieldType) {
 		return false

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -1852,8 +1852,6 @@ func GetModifiableColumnJob(
 	if newColName.L == model.ExtraHandleName.L {
 		return nil, dbterror.ErrWrongColumnName.GenWithStackByArgs(newColName.L)
 	}
-	errG := checkModifyColumnWithGeneratedColumnsConstraint(t.Cols(), originalColName)
-
 	// If we want to rename the column name, we need to check whether it already exists.
 	if newColName.L != originalColName.L {
 		c := table.FindCol(t.Cols(), newColName.L)
@@ -1863,8 +1861,8 @@ func GetModifiableColumnJob(
 
 		// And also check the generated columns dependency, if some generated columns
 		// depend on this column, we can't rename the column name.
-		if errG != nil {
-			return nil, errors.Trace(errG)
+		if err := checkModifyColumnWithGeneratedColumnsConstraint(t.Cols(), originalColName); err != nil {
+			return nil, errors.Trace(err)
 		}
 	}
 
@@ -1972,11 +1970,10 @@ func GetModifiableColumnJob(
 	if err = checkModifyGeneratedColumn(sctx, schema.Name, t, col, newCol, specNewColumn, spec.Position); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if errG != nil {
-		// According to issue https://github.com/pingcap/tidb/issues/24321,
-		// changing the type of a column involving generating a column is prohibited.
-		return nil, dbterror.ErrUnsupportedOnGeneratedColumn.GenWithStackByArgs(errG.Error())
-	}
+	// NOTE: We no longer unconditionally block all modifications of columns with generated
+	// column dependencies. Instead, we rely on `isGeneratedRelatedColumn` (called above
+	// when mayNeedChangeColData is true) to block only modifications that require data
+	// reorganization. See https://github.com/pingcap/tidb/issues/43455
 
 	if t.Meta().TTLInfo != nil {
 		// the column referenced by TTL should be a time type

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -1919,7 +1919,9 @@ func GetModifiableColumnJob(
 		return nil, errors.Trace(err)
 	}
 	mayNeedChangeColData := !noReorgDataStrict(t.Meta(), col.ColumnInfo, newCol.ColumnInfo)
-	if mayNeedChangeColData {
+	shouldCheckGeneratedColumnDependency := mayNeedChangeColData ||
+		needCheckGeneratedColumnDependencyForNoReorg(t.Meta(), col.ColumnInfo, newCol.ColumnInfo)
+	if shouldCheckGeneratedColumnDependency {
 		if err = isGeneratedRelatedColumn(t.Meta(), newCol.ColumnInfo, col.ColumnInfo); err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1970,10 +1972,8 @@ func GetModifiableColumnJob(
 	if err = checkModifyGeneratedColumn(sctx, schema.Name, t, col, newCol, specNewColumn, spec.Position); err != nil {
 		return nil, errors.Trace(err)
 	}
-	// NOTE: We no longer unconditionally block all modifications of columns with generated
-	// column dependencies. Instead, we rely on `isGeneratedRelatedColumn` (called above
-	// when mayNeedChangeColData is true) to block only modifications that require data
-	// reorganization. See https://github.com/pingcap/tidb/issues/43455
+	// NOTE: We only relax the generated dependency check for metadata-only changes
+	// and the narrow no-reorg collation-only path needed by issue 43455.
 
 	if t.Meta().TTLInfo != nil {
 		// the column referenced by TTL should be a time type
@@ -2096,6 +2096,63 @@ func noReorgDataStrict(tblInfo *model.TableInfo, oldCol, newCol *model.ColumnInf
 		// conversion between float and double needs reorganization, see issue #31372
 	}
 
+	return false
+}
+
+func needCheckGeneratedColumnDependencyForNoReorg(tblInfo *model.TableInfo, oldCol, newCol *model.ColumnInfo) bool {
+	// The normal generated-column restriction is only relevant when another generated
+	// column or expression index depends on the modified column.
+	if ok, _, _ := hasDependentByGeneratedColumn(tblInfo, oldCol.Name); !ok {
+		return false
+	}
+
+	// Metadata-only changes do not change existing row values or generated expression results.
+	if oldCol.FieldType.Equal(&newCol.FieldType) {
+		return false
+	}
+
+	// Issue 43455 needs this narrow collation-only path. The base column bytes stay the
+	// same, so we only skip the dependency check when every dependent expression is known
+	// to preserve its result bytes under the new collation.
+	if isCharChange(oldCol, newCol) && oldCol.GetCharset() == newCol.GetCharset() &&
+		!collate.CompatibleCollate(oldCol.GetCollate(), newCol.GetCollate()) &&
+		allDependentGeneratedExprsPreserveStringResultBytes(tblInfo, oldCol.Name) {
+		return false
+	}
+
+	return true
+}
+
+func allDependentGeneratedExprsPreserveStringResultBytes(tblInfo *model.TableInfo, oldColName ast.CIStr) bool {
+	for _, col := range tblInfo.Columns {
+		if _, ok := col.Dependences[oldColName.L]; !ok {
+			continue
+		}
+		expr, err := generatedexpr.ParseExpression(col.GeneratedExprString)
+		if err != nil || !generatedExprPreservesStringResultBytes(expr) {
+			return false
+		}
+	}
+	return true
+}
+
+func generatedExprPreservesStringResultBytes(expr ast.ExprNode) bool {
+	switch x := expr.(type) {
+	case *ast.ParenthesesExpr:
+		return generatedExprPreservesStringResultBytes(x.Expr)
+	case *ast.ColumnNameExpr, ast.ValueExpr:
+		return true
+	case *ast.FuncCallExpr:
+		if x.FnName.L != ast.Concat {
+			return false
+		}
+		for _, arg := range x.Args {
+			if !generatedExprPreservesStringResultBytes(arg) {
+				return false
+			}
+		}
+		return true
+	}
 	return false
 }
 

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -2100,11 +2100,14 @@ func noReorgDataStrict(tblInfo *model.TableInfo, oldCol, newCol *model.ColumnInf
 }
 
 func needCheckGeneratedColumnDependencyForNoReorg(tblInfo *model.TableInfo, oldCol, newCol *model.ColumnInfo) bool {
-	// The normal generated-column restriction is only relevant when another generated
-	// column or expression index depends on the modified column.
-	if ok, _, _ := hasDependentByGeneratedColumn(tblInfo, oldCol.Name); !ok {
+	// When modifying a generated column itself, leave it to checkModifyGeneratedColumn
+	// instead of the dependency check for base columns.
+	if oldCol.IsGenerated() {
 		return false
 	}
+
+	// The normal generated-column restriction is only relevant when another generated
+	// column or expression index depends on the modified column.
 
 	// Metadata-only changes do not change existing row values or generated expression results.
 	if oldCol.FieldType.Equal(&newCol.FieldType) {

--- a/tests/integrationtest/r/ddl/column_change.result
+++ b/tests/integrationtest/r/ddl/column_change.result
@@ -9,4 +9,10 @@ Error 3108 (HY000): Column 'a' has a generated column dependency.
 drop table if exists t2;
 create table t2(id int, a int, b int generated always as (abs(a)) virtual);
 alter table t2 modify column a bigint;
-Error 3106 (HY000): '[ddl:3108]Column 'a' has a generated column dependency.' is not supported for generated columns.
+DESC t2;
+Field	Type	Null	Key	Default	Extra
+id	int	YES		NULL	
+a	bigint	YES		NULL	
+b	int	YES		NULL	VIRTUAL GENERATED
+alter table t2 modify column a varchar(20);
+Error 8200 (HY000): Unsupported modify column: oldCol is a dependent column 'a' for generated column

--- a/tests/integrationtest/r/ddl/column_change.result
+++ b/tests/integrationtest/r/ddl/column_change.result
@@ -9,10 +9,6 @@ Error 3108 (HY000): Column 'a' has a generated column dependency.
 drop table if exists t2;
 create table t2(id int, a int, b int generated always as (abs(a)) virtual);
 alter table t2 modify column a bigint;
-DESC t2;
-Field	Type	Null	Key	Default	Extra
-id	int	YES		NULL	
-a	bigint	YES		NULL	
-b	int	YES		NULL	VIRTUAL GENERATED
+Error 8200 (HY000): Unsupported modify column: oldCol is a dependent column 'a' for generated column
 alter table t2 modify column a varchar(20);
 Error 8200 (HY000): Unsupported modify column: oldCol is a dependent column 'a' for generated column

--- a/tests/integrationtest/r/ddl/column_change.result
+++ b/tests/integrationtest/r/ddl/column_change.result
@@ -12,3 +12,17 @@ alter table t2 modify column a bigint;
 Error 8200 (HY000): Unsupported modify column: oldCol is a dependent column 'a' for generated column
 alter table t2 modify column a varchar(20);
 Error 8200 (HY000): Unsupported modify column: oldCol is a dependent column 'a' for generated column
+drop table if exists t3;
+create table t3(a int default 1, b int generated always as (a+1) virtual);
+alter table t3 modify column a int default 2;
+insert into t3(a) values (10);
+select * from t3;
+a	b
+10	11
+drop table if exists t4;
+create table t4(a char collate utf8mb4_bin, b varchar(10), c varchar(20) as (concat(a, b))) charset utf8mb4 collate utf8mb4_bin;
+alter table t4 modify column a char character set utf8mb4 collate utf8mb4_unicode_ci;
+insert into t4(a, b) values ('x', 'y');
+select a, b, c from t4;
+a	b	c
+x	y	xy

--- a/tests/integrationtest/t/ddl/column_change.test
+++ b/tests/integrationtest/t/ddl/column_change.test
@@ -10,10 +10,15 @@ create table t (a int, b int as (a+3));
 -- error 3108
 alter table t change a c int not null;
 
-# TestIssue24321
-# Note, the result is not the same with MySQL, since the limitation of the current modify column implementation.
+# TestIssue24321 / TestIssue43455
+# Modifications that do not require data reorganization are allowed even if the column
+# has a generated column dependency. See https://github.com/pingcap/tidb/issues/43455
 drop table if exists t2;
 create table t2(id int, a int, b int generated always as (abs(a)) virtual);
--- error 3106
+# INT -> BIGINT does not need reorg, so it is allowed now.
 alter table t2 modify column a bigint;
+DESC t2;
+# Changes that need reorg are still prohibited.
+-- error 8200
+alter table t2 modify column a varchar(20);
 

--- a/tests/integrationtest/t/ddl/column_change.test
+++ b/tests/integrationtest/t/ddl/column_change.test
@@ -11,14 +11,12 @@ create table t (a int, b int as (a+3));
 alter table t change a c int not null;
 
 # TestIssue24321 / TestIssue43455
-# Modifications that do not require data reorganization are allowed even if the column
-# has a generated column dependency. See https://github.com/pingcap/tidb/issues/43455
+# Only metadata-only and safe collation-only changes are allowed for a column with
+# generated column dependencies. See https://github.com/pingcap/tidb/issues/43455
 drop table if exists t2;
 create table t2(id int, a int, b int generated always as (abs(a)) virtual);
-# INT -> BIGINT does not need reorg, so it is allowed now.
+-- error 8200
 alter table t2 modify column a bigint;
-DESC t2;
 # Changes that need reorg are still prohibited.
 -- error 8200
 alter table t2 modify column a varchar(20);
-

--- a/tests/integrationtest/t/ddl/column_change.test
+++ b/tests/integrationtest/t/ddl/column_change.test
@@ -20,3 +20,17 @@ alter table t2 modify column a bigint;
 # Changes that need reorg are still prohibited.
 -- error 8200
 alter table t2 modify column a varchar(20);
+
+# Positive case: metadata-only change should succeed.
+drop table if exists t3;
+create table t3(a int default 1, b int generated always as (a+1) virtual);
+alter table t3 modify column a int default 2;
+insert into t3(a) values (10);
+select * from t3;
+
+# Positive case: safe collation-only change should succeed.
+drop table if exists t4;
+create table t4(a char collate utf8mb4_bin, b varchar(10), c varchar(20) as (concat(a, b))) charset utf8mb4 collate utf8mb4_bin;
+alter table t4 modify column a char character set utf8mb4 collate utf8mb4_unicode_ci;
+insert into t4(a, b) values ('x', 'y');
+select a, b, c from t4;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43455

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed validation for modifying columns referenced by generated columns: metadata-only changes (e.g., default-only), certain collation-only changes that preserve byte semantics, and safe non-reorg widenings are now permitted. Changes requiring data reorganization or altering a generated column’s expression remain blocked and return appropriate errors (including error 8200 where applicable). Minor stored-generated-column type tweaks allowed when the generated expression is unchanged.

* **Tests**
  * Added and updated integration tests covering these allowed and disallowed ALTER TABLE MODIFY COLUMN scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->