### PR TITLE
planner, meta: avoid unsafe index on virtual generated temporal columns

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -531,18 +531,6 @@ func buildIndexLookUpChecker(b *executorBuilder, p *physicalop.PhysicalIndexLook
 	}
 }
 
-func indexContainsVirtualGeneratedTemporalWithDateColumn(tblInfo *model.TableInfo, index *model.IndexInfo) bool {
-	for _, idxCol := range index.Columns {
-		if idxCol.Offset < 0 || idxCol.Offset >= len(tblInfo.Columns) {
-			continue
-		}
-		if tblInfo.Columns[idxCol.Offset].IsVirtualGeneratedTemporalWithDateColumn() {
-			return true
-		}
-	}
-	return false
-}
-
 func (b *executorBuilder) buildCheckTable(v *plannercore.CheckTable) exec.Executor {
 	canUseFastCheck := true
 	tblInfo := v.Table.Meta()
@@ -551,7 +539,7 @@ func (b *executorBuilder) buildCheckTable(v *plannercore.CheckTable) exec.Execut
 			canUseFastCheck = false
 			break
 		}
-		if indexContainsVirtualGeneratedTemporalWithDateColumn(tblInfo, idx) {
+		if idx.ContainsVirtualGeneratedTemporalWithDateColumn(tblInfo) {
 			canUseFastCheck = false
 			break
 		}

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -531,10 +531,27 @@ func buildIndexLookUpChecker(b *executorBuilder, p *physicalop.PhysicalIndexLook
 	}
 }
 
+func indexContainsVirtualGeneratedTemporalWithDateColumn(tblInfo *model.TableInfo, index *model.IndexInfo) bool {
+	for _, idxCol := range index.Columns {
+		if idxCol.Offset < 0 || idxCol.Offset >= len(tblInfo.Columns) {
+			continue
+		}
+		if tblInfo.Columns[idxCol.Offset].IsVirtualGeneratedTemporalWithDateColumn() {
+			return true
+		}
+	}
+	return false
+}
+
 func (b *executorBuilder) buildCheckTable(v *plannercore.CheckTable) exec.Executor {
 	canUseFastCheck := true
+	tblInfo := v.Table.Meta()
 	for _, idx := range v.IndexInfos {
 		if idx.MVIndex || idx.IsColumnarIndex() {
+			canUseFastCheck = false
+			break
+		}
+		if indexContainsVirtualGeneratedTemporalWithDateColumn(tblInfo, idx) {
 			canUseFastCheck = false
 			break
 		}

--- a/pkg/executor/check_table_index.go
+++ b/pkg/executor/check_table_index.go
@@ -896,6 +896,9 @@ func getCheckSum(ctx context.Context, se sessionctx.Context, sql string) ([]grou
 
 func getGlobalCheckSum(ctx context.Context, se sessionctx.Context, sql string) (checksum uint64, count int64, err error) {
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnAdmin)
+	// Create a new ExecDetails for the internal SQL to avoid data race with the parent statement.
+	// The parent context may carry an ExecDetails that is still being written to by concurrent goroutines.
+	ctx = execdetails.ContextWithInitializedExecDetails(ctx)
 	rs, err := se.GetSQLExecutor().ExecuteInternal(ctx, sql)
 	if err != nil {
 		return 0, 0, err

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -2293,6 +2293,7 @@ func TestFastAdminCheckWithError(t *testing.T) {
 	// And the admin check shouldn't be blocked when meeting error.
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_fast_table_check = 1")
 	tk.MustExec("drop table if exists admin_test")
 	tk.MustExec(`
 		create table admin_test (c1 int, c2 int,
@@ -2300,6 +2301,17 @@ func TestFastAdminCheckWithError(t *testing.T) {
 		key idx6(c1), key idx7(c1), key idx8(c1), key idx9(c1), key idx10(c1))
 	`)
 	tk.MustExecToErr("admin check table admin_test")
+
+	tk.MustExec("drop table if exists admin_test_generated")
+	tk.MustExec(`
+		create table admin_test_generated (
+			payload json,
+			f date as (JSON_EXTRACT(payload, '$.f')),
+			key idx_f(f)
+		)
+	`)
+	tk.MustExec(`insert into admin_test_generated set payload='{"f":"2018-09-28"}'`)
+	tk.MustExec("admin check table admin_test_generated")
 }
 
 func TestFastAdminCheckQuickPassSkipBucketed(t *testing.T) {
@@ -2488,7 +2500,7 @@ func TestAdminCheckTableWithEnumAndPointGet(t *testing.T) {
 func TestFastCheckTableConcurrent(t *testing.T) {
 	// This test verifies that concurrent execution of admin check table works correctly.
 	// Note: The data race in ExecDetails (fixed by using ContextWithInitializedExecDetails
-	// in getCheckSum) cannot be detected in unit tests because mocktikv doesn't trigger
+	// in getCheckSum/getGlobalCheckSum) cannot be detected in unit tests because mocktikv doesn't trigger
 	// the network traffic writes to ExecDetails that happen in real TiKV environments.
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -2311,6 +2311,8 @@ func TestFastAdminCheckWithError(t *testing.T) {
 		)
 	`)
 	tk.MustExec(`insert into admin_test_generated set payload='{"f":"2018-09-28"}'`)
+	// mockFastCheckTableError is still active here. This only succeeds because
+	// buildCheckTable falls back to CheckTableExec for idx_f instead of using FastCheckTableExec.
 	tk.MustExec("admin check table admin_test_generated")
 }
 

--- a/pkg/executor/test/tiflashtest/tiflash_test.go
+++ b/pkg/executor/test/tiflashtest/tiflash_test.go
@@ -1811,9 +1811,9 @@ func TestMPP47766(t *testing.T) {
 	tk.MustQuery("explain select date(test_time), count(1) as test_date from `traces` group by 1").Check(testkit.Rows(
 		"Projection_4 8000.00 root  test.traces.test_time_gen->Column#6, Column#5",
 		"└─HashAgg_8 8000.00 root  group by:test.traces.test_time_gen, funcs:count(1)->Column#5, funcs:firstrow(test.traces.test_time_gen)->test.traces.test_time_gen",
-		"  └─TableReader_20 10000.00 root  MppVersion: 3, data:ExchangeSender_19",
-		"    └─ExchangeSender_19 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
-		"      └─TableFullScan_18 10000.00 mpp[tiflash] table:traces keep order:false, stats:pseudo"))
+		"  └─TableReader_18 10000.00 root  MppVersion: 3, data:ExchangeSender_17",
+		"    └─ExchangeSender_17 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+		"      └─TableFullScan_16 10000.00 mpp[tiflash] table:traces keep order:false, stats:pseudo"))
 	tk.MustQuery("explain select /*+ read_from_storage(tiflash[traces]) */ date(test_time) as test_date, count(1) from `traces` group by 1").
 		Check(testkit.Rows(
 			"TableReader_31 8000.00 root  MppVersion: 3, data:ExchangeSender_30",

--- a/pkg/importsdk/BUILD.bazel
+++ b/pkg/importsdk/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//pkg/lightning/config",
         "//pkg/lightning/log",
         "//pkg/lightning/mydump",
+        "//pkg/parser/ast",
         "//pkg/parser/mysql",
         "//pkg/util/table-filter",
         "@com_github_data_dog_go_sqlmock//:go-sqlmock",

--- a/pkg/meta/model/column.go
+++ b/pkg/meta/model/column.go
@@ -221,20 +221,6 @@ func (c *ColumnInfo) IsVirtualGenerated() bool {
 	return c.IsGenerated() && !c.GeneratedStored
 }
 
-// IsVirtualGeneratedTemporalWithDateColumn checks whether the column is a virtual generated
-// column with a temporal type that contains a date part, such as DATE, DATETIME, or TIMESTAMP.
-func (c *ColumnInfo) IsVirtualGeneratedTemporalWithDateColumn() bool {
-	if !c.IsVirtualGenerated() {
-		return false
-	}
-	switch c.GetType() {
-	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
-		return true
-	default:
-		return false
-	}
-}
-
 // IsChanging checks if the column is a new column added in modify column.
 func (c *ColumnInfo) IsChanging() bool {
 	return strings.HasPrefix(c.Name.O, changingColumnPrefix)

--- a/pkg/meta/model/column.go
+++ b/pkg/meta/model/column.go
@@ -221,6 +221,20 @@ func (c *ColumnInfo) IsVirtualGenerated() bool {
 	return c.IsGenerated() && !c.GeneratedStored
 }
 
+// IsVirtualGeneratedTemporalWithDateColumn checks whether the column is a virtual generated
+// column with a temporal type that contains a date part, such as DATE, DATETIME, or TIMESTAMP.
+func (c *ColumnInfo) IsVirtualGeneratedTemporalWithDateColumn() bool {
+	if !c.IsVirtualGenerated() {
+		return false
+	}
+	switch c.GetType() {
+	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
+		return true
+	default:
+		return false
+	}
+}
+
 // IsChanging checks if the column is a new column added in modify column.
 func (c *ColumnInfo) IsChanging() bool {
 	return strings.HasPrefix(c.Name.O, changingColumnPrefix)

--- a/pkg/meta/model/index.go
+++ b/pkg/meta/model/index.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/types"
 	"github.com/pingcap/tidb/pkg/planner/cascades/base"
+	tidbtypes "github.com/pingcap/tidb/pkg/types"
 )
 
 // DistanceMetric is the distance metric used by the vector index.
@@ -365,14 +366,15 @@ func (index *IndexInfo) HasPrefixIndex() bool {
 	return false
 }
 
-// ContainsVirtualGeneratedTemporalWithDateColumn checks whether the index contains
-// a virtual generated temporal column with a date part, such as DATE, DATETIME, or TIMESTAMP.
+// ContainsVirtualGeneratedTemporalWithDateColumn reports whether the index contains
+// a virtual generated temporal-with-date column.
 func (index *IndexInfo) ContainsVirtualGeneratedTemporalWithDateColumn(tblInfo *TableInfo) bool {
 	for _, idxCol := range index.Columns {
 		if idxCol.Offset < 0 || idxCol.Offset >= len(tblInfo.Columns) {
 			continue
 		}
-		if tblInfo.Columns[idxCol.Offset].IsVirtualGeneratedTemporalWithDateColumn() {
+		col := tblInfo.Columns[idxCol.Offset]
+		if col.IsVirtualGenerated() && tidbtypes.IsTemporalWithDate(col.GetType()) {
 			return true
 		}
 	}

--- a/pkg/meta/model/index.go
+++ b/pkg/meta/model/index.go
@@ -365,6 +365,20 @@ func (index *IndexInfo) HasPrefixIndex() bool {
 	return false
 }
 
+// ContainsVirtualGeneratedTemporalWithDateColumn checks whether the index contains
+// a virtual generated temporal column with a date part, such as DATE, DATETIME, or TIMESTAMP.
+func (index *IndexInfo) ContainsVirtualGeneratedTemporalWithDateColumn(tblInfo *TableInfo) bool {
+	for _, idxCol := range index.Columns {
+		if idxCol.Offset < 0 || idxCol.Offset >= len(tblInfo.Columns) {
+			continue
+		}
+		if tblInfo.Columns[idxCol.Offset].IsVirtualGeneratedTemporalWithDateColumn() {
+			return true
+		}
+	}
+	return false
+}
+
 // HasColumnInIndexColumns checks whether the index contains the column with the specified ID.
 func (index *IndexInfo) HasColumnInIndexColumns(tblInfo *TableInfo, colID int64) bool {
 	for _, ic := range index.Columns {

--- a/pkg/planner/core/casetest/index/BUILD.bazel
+++ b/pkg/planner/core/casetest/index/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 12,
+    shard_count = 13,
     deps = [
         "//pkg/domain",
         "//pkg/domain/infosync",

--- a/pkg/planner/core/casetest/index/index_test.go
+++ b/pkg/planner/core/casetest/index/index_test.go
@@ -107,6 +107,44 @@ func TestInvisibleIndex(t *testing.T) {
 	})
 }
 
+func TestVirtualGeneratedTemporalWithDateIndex(t *testing.T) {
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		tk.MustExec("use test")
+		tk.MustExec("drop table if exists t_issue_52520")
+		tk.MustExec("create table t_issue_52520 (a varchar(32), b date as (a), key idx_b(b))")
+		tk.MustExec("set @@sql_mode = ''")
+		tk.MustExec("insert into t_issue_52520(a) values ('2020-02-31')")
+		tk.MustExec("set @@sql_mode = 'ALLOW_INVALID_DATES'")
+
+		tk.MustNoIndexUsed("select /* issue:52520 */ b from t_issue_52520 use index(idx_b)")
+		tk.MustQuery("show warnings").CheckContain("virtual generated temporal column")
+		tk.MustQuery("select /* issue:52520 */ b from t_issue_52520 use index(idx_b)").Check(testkit.Rows("2020-02-31"))
+		tk.MustQuery("show warnings").CheckContain("virtual generated temporal column")
+
+		tk.MustNoIndexUsed("select /*+ USE_INDEX(t_issue_52520, idx_b) */ /* issue:52520 */ b from t_issue_52520")
+		tk.MustQuery("show warnings").CheckContain("virtual generated temporal column")
+		tk.MustQuery("select /*+ USE_INDEX(t_issue_52520, idx_b) */ /* issue:52520 */ b from t_issue_52520").Check(testkit.Rows("2020-02-31"))
+		tk.MustQuery("show warnings").CheckContain("virtual generated temporal column")
+
+		tk.MustNoIndexUsed("select /* issue:52520 */ b from t_issue_52520 use index(idx_b) where b = '2020-02-31'")
+		tk.MustQuery("show warnings").CheckContain("virtual generated temporal column")
+		tk.MustQuery("select /* issue:52520 */ b from t_issue_52520 use index(idx_b) where b = '2020-02-31'").Check(testkit.Rows("2020-02-31"))
+		tk.MustQuery("show warnings").CheckContain("virtual generated temporal column")
+
+		tk.MustNoIndexUsed("select /*+ USE_INDEX(t_issue_52520, idx_b) */ /* issue:52520 */ b from t_issue_52520 where b = '2020-02-31'")
+		tk.MustQuery("show warnings").CheckContain("virtual generated temporal column")
+		tk.MustQuery("select /*+ USE_INDEX(t_issue_52520, idx_b) */ /* issue:52520 */ b from t_issue_52520 where b = '2020-02-31'").Check(testkit.Rows("2020-02-31"))
+		tk.MustQuery("show warnings").CheckContain("virtual generated temporal column")
+
+		tk.MustNoIndexUsed("select /* issue:52520 */ b from t_issue_52520 ignore index(idx_b) where b = '2020-02-31'")
+		tk.MustQuery("show warnings").Check(testkit.Rows())
+
+		tk.MustExec("drop table if exists t_issue_52520_prefix")
+		tk.MustExec("create table t_issue_52520_prefix (a varchar(32), c int, b date as (a), key idx_safe(c), key idx_unsafe(b))")
+		tk.MustContainErrMsg("select /* issue:52520 */ c from t_issue_52520_prefix use index(idx) where c = 1", "Key 'idx' doesn't exist")
+	})
+}
+
 func TestRangeDerivation(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec("use test")
@@ -297,6 +335,14 @@ func TestInvertedIndex(t *testing.T) {
 		testKit.MustNoIndexUsed("select * from t ignore index(idx_b) where b = 2")
 		testKit.MustNoIndexUsed("select * from t ignore index(idx_c) where c = 3")
 		testKit.MustNoIndexUsed("select * from t ignore index(idx_d) where d < 1")
+
+		testKit.MustExec("drop table if exists t_issue_52520_columnar")
+		testKit.MustExec("create table t_issue_52520_columnar (a varchar(32), b date as (a))")
+		testKit.MustExec("alter table t_issue_52520_columnar set tiflash replica 1")
+		testKit.MustExec("alter table t_issue_52520_columnar add columnar index idx_b (b) using inverted")
+		testkit.SetTiFlashReplica(t, dom, "test", "t_issue_52520_columnar")
+		testKit.MustNoIndexUsed("select /* issue:52520 */ b from t_issue_52520_columnar use index(idx_b)")
+		testKit.MustQuery("show warnings").CheckContain("virtual generated temporal column")
 	})
 }
 

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -5034,10 +5034,12 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 		return nil, plannererrors.ErrPartitionClauseOnNonpartitioned
 	}
 
-	possiblePaths, err := getPossibleAccessPaths(b.ctx, b.TableHints(), tn.IndexHints, tbl, dbName, tblName, b.isForUpdateRead, b.optFlag&rule.FlagPartitionProcessor > 0)
+	possiblePathInfo, err := getPossibleAccessPathInfo(b.ctx, b.TableHints(), tn.IndexHints, tbl, dbName, tblName, b.isForUpdateRead, b.optFlag&rule.FlagPartitionProcessor > 0)
 	if err != nil {
 		return nil, err
 	}
+	possiblePaths := possiblePathInfo.paths
+	gcSubstituteExtraPaths := possiblePathInfo.gcSubstituteExtraPaths
 
 	if tableInfo.IsView() {
 		if tn.TableSample != nil {
@@ -5089,6 +5091,10 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 		if b.capFlag&canExpandAST == 0 {
 			possiblePaths, err = util.FilterPathByIsolationRead(b.ctx, possiblePaths, tblName, dbName)
 			if err != nil {
+				return nil, err
+			}
+			gcSubstituteExtraPaths, err = util.FilterPathByIsolationRead(b.ctx, gcSubstituteExtraPaths, tblName, dbName)
+			if err != nil && len(gcSubstituteExtraPaths) != 0 {
 				return nil, err
 			}
 		}
@@ -5178,6 +5184,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 		IndexMergeHints:        indexMergeHints,
 		PossibleAccessPaths:    possiblePaths,
 		AllPossibleAccessPaths: allPaths,
+		GcSubstituteExtraPaths: gcSubstituteExtraPaths,
 		Columns:                make([]*model.ColumnInfo, 0, countCnt),
 		PartitionNames:         tn.PartitionNames,
 		TblCols:                make([]*expression.Column, 0, countCnt),

--- a/pkg/planner/core/operator/logicalop/logical_datasource.go
+++ b/pkg/planner/core/operator/logicalop/logical_datasource.go
@@ -77,6 +77,9 @@ type DataSource struct {
 
 	// AllPossibleAccessPaths stores all the possible access path from build datasource phase.
 	AllPossibleAccessPaths []*util.AccessPath
+	// GcSubstituteExtraPaths stores filtered index paths that should still participate in
+	// generated-column substitution. They are not available for access-path selection.
+	GcSubstituteExtraPaths []*util.AccessPath
 	// PossibleAccessPaths stores all the possible access path for one specific logical alternative.
 	// because different logical alternative may have different filter condition, so the possible access path may be different.
 	// like:

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1154,32 +1154,71 @@ func (*PlanBuilder) detectSelectWindow(sel *ast.SelectStmt) bool {
 	return false
 }
 
-func getPathByIndexName(paths []*util.AccessPath, idxName ast.CIStr, tblInfo *model.TableInfo) *util.AccessPath {
-	var indexPrefixPath *util.AccessPath
-	prefixMatches := 0
-	for _, path := range paths {
-		// Only accept tikv's primary key table path.
+type indexHintResolveStatus int
+
+const (
+	indexHintResolveNotFound indexHintResolveStatus = iota
+	indexHintResolvePublicPath
+	indexHintResolveFilteredUnsafe
+)
+
+func resolveIndexHintByName(publicPaths []*util.AccessPath, filteredUnsafeIndexes []*model.IndexInfo, idxName ast.CIStr, tblInfo *model.TableInfo) (*util.AccessPath, *model.IndexInfo, indexHintResolveStatus) {
+	// Exact names win over prefixes. Check public paths first so a valid index is
+	// never shadowed by a filtered index that happens to share the exact name.
+	for _, path := range publicPaths {
 		if path.IsTiKVTablePath() && isPrimaryIndex(idxName) && tblInfo.HasClusteredIndex() {
-			return path
+			return path, nil, indexHintResolvePublicPath
 		}
-		// If it's not a tikv table path and the index is nil, it could not be any index path.
-		if path.Index == nil {
-			continue
+		if path.Index != nil && path.Index.Name.L == idxName.L {
+			return path, nil, indexHintResolvePublicPath
 		}
-		if path.Index.Name.L == idxName.L {
-			return path
-		}
-		if strings.HasPrefix(path.Index.Name.L, idxName.L) {
-			indexPrefixPath = path
-			prefixMatches++
+	}
+	for _, index := range filteredUnsafeIndexes {
+		if index.Name.L == idxName.L {
+			return nil, index, indexHintResolveFilteredUnsafe
 		}
 	}
 
-	// Return only unique prefix matches
-	if prefixMatches == 1 {
-		return indexPrefixPath
+	var foundPath *util.AccessPath
+	var foundFilteredIndex *model.IndexInfo
+	prefixMatches := 0
+	for _, path := range publicPaths {
+		if path.Index != nil && strings.HasPrefix(path.Index.Name.L, idxName.L) {
+			foundPath = path
+			foundFilteredIndex = nil
+			prefixMatches++
+		}
 	}
-	return nil
+	for _, index := range filteredUnsafeIndexes {
+		if strings.HasPrefix(index.Name.L, idxName.L) {
+			foundPath = nil
+			foundFilteredIndex = index
+			prefixMatches++
+		}
+	}
+	if prefixMatches != 1 {
+		return nil, nil, indexHintResolveNotFound
+	}
+	if foundFilteredIndex != nil {
+		return nil, foundFilteredIndex, indexHintResolveFilteredUnsafe
+	}
+	return foundPath, nil, indexHintResolvePublicPath
+}
+
+func indexContainsVirtualGeneratedTemporalWithDateColumn(tblInfo *model.TableInfo, index *model.IndexInfo) bool {
+	for _, idxCol := range index.Columns {
+		if idxCol.Offset < 0 || idxCol.Offset >= len(tblInfo.Columns) {
+			continue
+		}
+		if tblInfo.Columns[idxCol.Offset].IsVirtualGeneratedTemporalWithDateColumn() {
+			return true
+		}
+	}
+	return false
+}
+
+func genVirtualGeneratedTemporalWithDateIndexHintWarning(index *model.IndexInfo) string {
+	return fmt.Sprintf("hint is inapplicable, index %s contains a virtual generated temporal column whose values depend on sql_mode", index.Name.O)
 }
 
 func isPrimaryIndex(indexName ast.CIStr) bool {
@@ -1308,6 +1347,7 @@ func getPossibleAccessPaths(ctx base.PlanContext, tableHints *hint.PlanHints, in
 	var err error
 	// Inverted Index can not be used as access path index.
 	invertedIndexes := make(map[string]struct{})
+	var virtualGeneratedTemporalWithDateIndexes []*model.IndexInfo
 
 	// When NO_INDEX_LOOKUP_PUSHDOWN hint is specified, we should set `forceNoIndexLookUpPushDown = true` to avoid
 	// using index look up push down even if other hint or system variable `tidb_index_lookup_pushdown_policy`
@@ -1345,6 +1385,10 @@ func getPossibleAccessPaths(ctx base.PlanContext, tableHints *hint.PlanHints, in
 				if latestIndex, ok := latestIndexes[index.ID]; !ok || latestIndex.State != model.StatePublic {
 					continue
 				}
+			}
+			if indexContainsVirtualGeneratedTemporalWithDateColumn(tblInfo, index) {
+				virtualGeneratedTemporalWithDateIndexes = append(virtualGeneratedTemporalWithDateIndexes, index)
+				continue
 			}
 			if index.InvertedInfo != nil {
 				invertedIndexes[index.Name.L] = struct{}{}
@@ -1441,8 +1485,15 @@ func getPossibleAccessPaths(ctx base.PlanContext, tableHints *hint.PlanHints, in
 			if _, ok := invertedIndexes[idxName.L]; ok {
 				continue
 			}
-			path := getPathByIndexName(publicPaths, idxName, tblInfo)
-			if path == nil {
+			path, filteredIndex, resolveStatus := resolveIndexHintByName(publicPaths, virtualGeneratedTemporalWithDateIndexes, idxName, tblInfo)
+			if resolveStatus == indexHintResolveFilteredUnsafe {
+				if hint.HintType != ast.HintIgnore {
+					hasUseOrForce = true
+					ctx.GetSessionVars().StmtCtx.SetHintWarning(genVirtualGeneratedTemporalWithDateIndexHintWarning(filteredIndex))
+				}
+				continue
+			}
+			if resolveStatus == indexHintResolveNotFound {
 				err := plannererrors.ErrKeyDoesNotExist.FastGenByArgs(idxName, tblInfo.Name)
 				// if hint is from comment-style sql hints, we should throw a warning instead of error.
 				if i < indexHintsLen {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1312,6 +1312,19 @@ func checkAutoForceIndexLookUpPushDown(ctx base.PlanContext, tblInfo *model.Tabl
 }
 
 func getPossibleAccessPaths(ctx base.PlanContext, tableHints *hint.PlanHints, indexHints []*ast.IndexHint, tbl table.Table, dbName, tblName ast.CIStr, check bool, hasFlagPartitionProcessor bool) ([]*util.AccessPath, error) {
+	info, err := getPossibleAccessPathInfo(ctx, tableHints, indexHints, tbl, dbName, tblName, check, hasFlagPartitionProcessor)
+	if err != nil {
+		return nil, err
+	}
+	return info.paths, nil
+}
+
+type possibleAccessPathInfo struct {
+	paths                  []*util.AccessPath
+	gcSubstituteExtraPaths []*util.AccessPath
+}
+
+func getPossibleAccessPathInfo(ctx base.PlanContext, tableHints *hint.PlanHints, indexHints []*ast.IndexHint, tbl table.Table, dbName, tblName ast.CIStr, check bool, hasFlagPartitionProcessor bool) (*possibleAccessPathInfo, error) {
 	tblInfo := tbl.Meta()
 	publicPaths := make([]*util.AccessPath, 0, len(tblInfo.Indices)+2)
 	tp := kv.TiKV
@@ -1349,6 +1362,7 @@ func getPossibleAccessPaths(ctx base.PlanContext, tableHints *hint.PlanHints, in
 	// Inverted Index can not be used as access path index.
 	invertedIndexes := make(map[string]struct{})
 	var virtualGeneratedTemporalWithDateIndexes []*model.IndexInfo
+	filteredUnsafePathsForGCSubstitute := make([]*util.AccessPath, 0)
 
 	// When NO_INDEX_LOOKUP_PUSHDOWN hint is specified, we should set `forceNoIndexLookUpPushDown = true` to avoid
 	// using index look up push down even if other hint or system variable `tidb_index_lookup_pushdown_policy`
@@ -1389,6 +1403,9 @@ func getPossibleAccessPaths(ctx base.PlanContext, tableHints *hint.PlanHints, in
 			}
 			if index.ContainsVirtualGeneratedTemporalWithDateColumn(tblInfo) {
 				virtualGeneratedTemporalWithDateIndexes = append(virtualGeneratedTemporalWithDateIndexes, index)
+				if path := buildGcSubstitutePathForFilteredUnsafeIndex(tblInfo, index); path != nil {
+					filteredUnsafePathsForGCSubstitute = append(filteredUnsafePathsForGCSubstitute, path)
+				}
 				continue
 			}
 			if index.InvertedInfo != nil {
@@ -1441,6 +1458,7 @@ func getPossibleAccessPaths(ctx base.PlanContext, tableHints *hint.PlanHints, in
 	hasScanHint, hasUseOrForce := false, false
 	available := make([]*util.AccessPath, 0, len(publicPaths))
 	ignored := make([]*util.AccessPath, 0, len(publicPaths))
+	ignoredFilteredUnsafeIndexes := make(map[string]struct{})
 
 	// Extract comment-style index hint like /*+ INDEX(t, idx1, idx2) */.
 	indexHintsLen := len(indexHints)
@@ -1488,7 +1506,9 @@ func getPossibleAccessPaths(ctx base.PlanContext, tableHints *hint.PlanHints, in
 			}
 			path, filteredIndex, resolveStatus := resolveIndexHintByName(publicPaths, virtualGeneratedTemporalWithDateIndexes, idxName, tblInfo)
 			if resolveStatus == indexHintResolveFilteredUnsafe {
-				if hint.HintType != ast.HintIgnore {
+				if hint.HintType == ast.HintIgnore {
+					ignoredFilteredUnsafeIndexes[filteredIndex.Name.L] = struct{}{}
+				} else {
 					hasUseOrForce = true
 					ctx.GetSessionVars().StmtCtx.SetHintWarning(genVirtualGeneratedTemporalWithDateIndexHintWarning(filteredIndex))
 				}
@@ -1580,7 +1600,43 @@ func getPossibleAccessPaths(ctx base.PlanContext, tableHints *hint.PlanHints, in
 		available = append(available, tablePath)
 	}
 
-	return available, nil
+	return &possibleAccessPathInfo{
+		paths:                  available,
+		gcSubstituteExtraPaths: getGCSubstituteExtraPaths(filteredUnsafePathsForGCSubstitute, hasUseOrForce, ignoredFilteredUnsafeIndexes),
+	}, nil
+}
+
+func buildGcSubstitutePathForFilteredUnsafeIndex(tblInfo *model.TableInfo, index *model.IndexInfo) *util.AccessPath {
+	if index.InvertedInfo != nil {
+		return nil
+	}
+	if index.IsColumnarIndex() {
+		// Keep the original substitution behavior for columnar indexes only when the replica is available.
+		if tblInfo.TiFlashReplica == nil || !tblInfo.TiFlashReplica.Available {
+			return nil
+		}
+		path := genTiFlashPath(tblInfo)
+		path.Index = index
+		return path
+	}
+	return &util.AccessPath{Index: index}
+}
+
+func getGCSubstituteExtraPaths(filteredUnsafePaths []*util.AccessPath, hasUseOrForce bool, ignoredFilteredUnsafeIndexes map[string]struct{}) []*util.AccessPath {
+	if hasUseOrForce || len(filteredUnsafePaths) == 0 {
+		return nil
+	}
+	extraPaths := make([]*util.AccessPath, 0, len(filteredUnsafePaths))
+	for _, path := range filteredUnsafePaths {
+		if path.Index == nil {
+			continue
+		}
+		if _, ignored := ignoredFilteredUnsafeIndexes[path.Index.Name.L]; ignored {
+			continue
+		}
+		extraPaths = append(extraPaths, path)
+	}
+	return extraPaths
 }
 
 func removeIgnoredPaths(paths, ignoredPaths []*util.AccessPath) []*util.AccessPath {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1163,16 +1163,22 @@ const (
 )
 
 func resolveIndexHintByName(publicPaths []*util.AccessPath, filteredUnsafeIndexes []*model.IndexInfo, idxName ast.CIStr, tblInfo *model.TableInfo) (*util.AccessPath, *model.IndexInfo, indexHintResolveStatus) {
-	// Exact names win over prefixes. Check public paths first so a valid index is
-	// never shadowed by a filtered index that happens to share the exact name.
+	// Prefer exact name matches over prefix matches.
+	// Check usable paths before filtered indexes.
 	for _, path := range publicPaths {
+		// Only accept tikv's primary key table path.
 		if path.IsTiKVTablePath() && isPrimaryIndex(idxName) && tblInfo.HasClusteredIndex() {
 			return path, nil, indexHintResolvePublicPath
 		}
-		if path.Index != nil && path.Index.Name.L == idxName.L {
+		if path.Index == nil {
+			continue
+		}
+		if path.Index.Name.L == idxName.L {
 			return path, nil, indexHintResolvePublicPath
 		}
 	}
+	// Check filtered unsafe indexes too, so hints on them can return "inapplicable"
+	// instead of being treated as missing indexes.
 	for _, index := range filteredUnsafeIndexes {
 		if index.Name.L == idxName.L {
 			return nil, index, indexHintResolveFilteredUnsafe
@@ -1183,12 +1189,17 @@ func resolveIndexHintByName(publicPaths []*util.AccessPath, filteredUnsafeIndexe
 	var foundFilteredIndex *model.IndexInfo
 	prefixMatches := 0
 	for _, path := range publicPaths {
-		if path.Index != nil && strings.HasPrefix(path.Index.Name.L, idxName.L) {
+		if path.Index == nil {
+			continue
+		}
+		if strings.HasPrefix(path.Index.Name.L, idxName.L) {
 			foundPath = path
 			foundFilteredIndex = nil
 			prefixMatches++
 		}
 	}
+	// Count filtered unsafe indexes in prefix matching too, so they participate in
+	// ambiguity detection with usable indexes.
 	for _, index := range filteredUnsafeIndexes {
 		if strings.HasPrefix(index.Name.L, idxName.L) {
 			foundPath = nil
@@ -1196,10 +1207,12 @@ func resolveIndexHintByName(publicPaths []*util.AccessPath, filteredUnsafeIndexe
 			prefixMatches++
 		}
 	}
+	// Return only unique prefix matches.
 	if prefixMatches != 1 {
 		return nil, nil, indexHintResolveNotFound
 	}
 	if foundFilteredIndex != nil {
+		// The hint uniquely points to a filtered unsafe index.
 		return nil, foundFilteredIndex, indexHintResolveFilteredUnsafe
 	}
 	return foundPath, nil, indexHintResolvePublicPath

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1205,18 +1205,6 @@ func resolveIndexHintByName(publicPaths []*util.AccessPath, filteredUnsafeIndexe
 	return foundPath, nil, indexHintResolvePublicPath
 }
 
-func indexContainsVirtualGeneratedTemporalWithDateColumn(tblInfo *model.TableInfo, index *model.IndexInfo) bool {
-	for _, idxCol := range index.Columns {
-		if idxCol.Offset < 0 || idxCol.Offset >= len(tblInfo.Columns) {
-			continue
-		}
-		if tblInfo.Columns[idxCol.Offset].IsVirtualGeneratedTemporalWithDateColumn() {
-			return true
-		}
-	}
-	return false
-}
-
 func genVirtualGeneratedTemporalWithDateIndexHintWarning(index *model.IndexInfo) string {
 	return fmt.Sprintf("hint is inapplicable, index %s contains a virtual generated temporal column whose values depend on sql_mode", index.Name.O)
 }
@@ -1386,7 +1374,7 @@ func getPossibleAccessPaths(ctx base.PlanContext, tableHints *hint.PlanHints, in
 					continue
 				}
 			}
-			if indexContainsVirtualGeneratedTemporalWithDateColumn(tblInfo, index) {
+			if index.ContainsVirtualGeneratedTemporalWithDateColumn(tblInfo) {
 				virtualGeneratedTemporalWithDateIndexes = append(virtualGeneratedTemporalWithDateIndexes, index)
 				continue
 			}

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -106,29 +106,65 @@ func TestGetPathByIndexName(t *testing.T) {
 		genTiFlashPath(tblInfo),
 	}
 
-	path := getPathByIndexName(accessPath, ast.NewCIStr("idx"), tblInfo)
+	resolve := func(paths []*util.AccessPath, filteredUnsafeIndexes []*model.IndexInfo, idxName string, tblInfo *model.TableInfo) (*util.AccessPath, *model.IndexInfo, indexHintResolveStatus) {
+		return resolveIndexHintByName(paths, filteredUnsafeIndexes, ast.NewCIStr(idxName), tblInfo)
+	}
+
+	path, filteredIndex, status := resolve(accessPath, nil, "idx", tblInfo)
 	require.NotNil(t, path)
+	require.Nil(t, filteredIndex)
+	require.Equal(t, indexHintResolvePublicPath, status)
 	require.Equal(t, accessPath[1], path)
 
 	// "id" is a prefix of "idx"
-	path = getPathByIndexName(accessPath, ast.NewCIStr("id"), tblInfo)
+	path, filteredIndex, status = resolve(accessPath, nil, "id", tblInfo)
 	require.NotNil(t, path)
+	require.Nil(t, filteredIndex)
+	require.Equal(t, indexHintResolvePublicPath, status)
 	require.Equal(t, accessPath[1], path)
 
-	path = getPathByIndexName(accessPath, ast.NewCIStr("primary"), tblInfo)
+	path, filteredIndex, status = resolve(accessPath, nil, "primary", tblInfo)
 	require.NotNil(t, path)
+	require.Nil(t, filteredIndex)
+	require.Equal(t, indexHintResolvePublicPath, status)
 	require.Equal(t, accessPath[0], path)
 
-	path = getPathByIndexName(accessPath, ast.NewCIStr("not exists"), tblInfo)
+	path, filteredIndex, status = resolve(accessPath, nil, "not exists", tblInfo)
 	require.Nil(t, path)
+	require.Nil(t, filteredIndex)
+	require.Equal(t, indexHintResolveNotFound, status)
 
 	tblInfo = &model.TableInfo{
 		Indices:    make([]*model.IndexInfo, 0),
 		PKIsHandle: false,
 	}
 
-	path = getPathByIndexName(accessPath, ast.NewCIStr("primary"), tblInfo)
+	path, filteredIndex, status = resolve(accessPath, nil, "primary", tblInfo)
 	require.Nil(t, path)
+	require.Nil(t, filteredIndex)
+	require.Equal(t, indexHintResolveNotFound, status)
+
+	t.Run("resolve filtered unsafe indexes", func(t *testing.T) {
+		unsafeExact := &model.IndexInfo{Name: ast.NewCIStr("idx_unsafe")}
+		unsafeLong := &model.IndexInfo{Name: ast.NewCIStr("idx_unsafe_long")}
+
+		path, filteredIndex, status = resolve(accessPath, []*model.IndexInfo{unsafeExact, unsafeLong}, "idx_unsafe", tblInfo)
+		require.Nil(t, path)
+		require.Same(t, unsafeExact, filteredIndex)
+		require.Equal(t, indexHintResolveFilteredUnsafe, status)
+
+		path, filteredIndex, status = resolve(accessPath, []*model.IndexInfo{unsafeLong}, "idx_unsafe_l", tblInfo)
+		require.Nil(t, path)
+		require.Same(t, unsafeLong, filteredIndex)
+		require.Equal(t, indexHintResolveFilteredUnsafe, status)
+
+		publicPath := &util.AccessPath{Index: &model.IndexInfo{Name: ast.NewCIStr("idx_shared")}}
+		filteredUnsafe := &model.IndexInfo{Name: ast.NewCIStr("idx_shared")}
+		path, filteredIndex, status = resolve([]*util.AccessPath{publicPath}, []*model.IndexInfo{filteredUnsafe}, "idx_shared", tblInfo)
+		require.Same(t, publicPath, path)
+		require.Nil(t, filteredIndex)
+		require.Equal(t, indexHintResolvePublicPath, status)
+	})
 
 	t.Run("ignore exact and prefix-resolved long index without removing shorter sibling", func(t *testing.T) {
 		shortPath := &util.AccessPath{Index: &model.IndexInfo{Name: ast.NewCIStr("idx_contract_sys_no")}}
@@ -139,19 +175,28 @@ func TestGetPathByIndexName(t *testing.T) {
 			Indices: []*model.IndexInfo{shortPath.Index, longPath.Index},
 		}
 
-		ignored := []*util.AccessPath{getPathByIndexName(paths, ast.NewCIStr("idx_contract_sys_no_delete_flag"), tblInfo)}
+		ignoredPath, ignoredIndex, resolveStatus := resolve(paths, nil, "idx_contract_sys_no_delete_flag", tblInfo)
+		require.Nil(t, ignoredIndex)
+		require.Equal(t, indexHintResolvePublicPath, resolveStatus)
+		ignored := []*util.AccessPath{ignoredPath}
 		require.Same(t, longPath, ignored[0])
 		remained := removeIgnoredPaths(paths, ignored)
 		require.Len(t, remained, 1)
 		require.Same(t, shortPath, remained[0])
 
-		ignored = []*util.AccessPath{getPathByIndexName(paths, ast.NewCIStr("idx_contract_sys_no_delete"), tblInfo)}
+		ignoredPath, ignoredIndex, resolveStatus = resolve(paths, nil, "idx_contract_sys_no_delete", tblInfo)
+		require.Nil(t, ignoredIndex)
+		require.Equal(t, indexHintResolvePublicPath, resolveStatus)
+		ignored = []*util.AccessPath{ignoredPath}
 		require.Same(t, longPath, ignored[0])
 		remained = removeIgnoredPaths(paths, ignored)
 		require.Len(t, remained, 1)
 		require.Same(t, shortPath, remained[0])
 
-		ignored = []*util.AccessPath{getPathByIndexName(paths, ast.NewCIStr("Idx_Contract_Sys_No_Delete_Flag"), tblInfo)}
+		ignoredPath, ignoredIndex, resolveStatus = resolve(paths, nil, "Idx_Contract_Sys_No_Delete_Flag", tblInfo)
+		require.Nil(t, ignoredIndex)
+		require.Equal(t, indexHintResolvePublicPath, resolveStatus)
+		ignored = []*util.AccessPath{ignoredPath}
 		require.Same(t, longPath, ignored[0])
 		remained = removeIgnoredPaths(paths, ignored)
 		require.Len(t, remained, 1)

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -173,6 +173,27 @@ func TestGetPathByIndexName(t *testing.T) {
 		require.Equal(t, indexHintResolveNotFound, status)
 	})
 
+	t.Run("gc substitute extra paths", func(t *testing.T) {
+		filteredUnsafePaths := []*util.AccessPath{
+			{Index: &model.IndexInfo{Name: ast.NewCIStr("idx_unsafe")}},
+			{Index: &model.IndexInfo{Name: ast.NewCIStr("idx_unsafe_two")}},
+		}
+
+		extraPaths := getGCSubstituteExtraPaths(filteredUnsafePaths, false, nil)
+		require.Len(t, extraPaths, 2)
+		require.Same(t, filteredUnsafePaths[0], extraPaths[0])
+		require.Same(t, filteredUnsafePaths[1], extraPaths[1])
+
+		extraPaths = getGCSubstituteExtraPaths(filteredUnsafePaths, true, nil)
+		require.Nil(t, extraPaths)
+
+		extraPaths = getGCSubstituteExtraPaths(filteredUnsafePaths, false, map[string]struct{}{
+			"idx_unsafe": {},
+		})
+		require.Len(t, extraPaths, 1)
+		require.Same(t, filteredUnsafePaths[1], extraPaths[0])
+	})
+
 	t.Run("ignore exact and prefix-resolved long index without removing shorter sibling", func(t *testing.T) {
 		shortPath := &util.AccessPath{Index: &model.IndexInfo{Name: ast.NewCIStr("idx_contract_sys_no")}}
 		longPath := &util.AccessPath{Index: &model.IndexInfo{Name: ast.NewCIStr("idx_contract_sys_no_delete_flag")}}

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -106,30 +106,30 @@ func TestGetPathByIndexName(t *testing.T) {
 		genTiFlashPath(tblInfo),
 	}
 
-	resolve := func(paths []*util.AccessPath, filteredUnsafeIndexes []*model.IndexInfo, idxName string, tblInfo *model.TableInfo) (*util.AccessPath, *model.IndexInfo, indexHintResolveStatus) {
+	resolveHint := func(paths []*util.AccessPath, filteredUnsafeIndexes []*model.IndexInfo, idxName string, tblInfo *model.TableInfo) (*util.AccessPath, *model.IndexInfo, indexHintResolveStatus) {
 		return resolveIndexHintByName(paths, filteredUnsafeIndexes, ast.NewCIStr(idxName), tblInfo)
 	}
 
-	path, filteredIndex, status := resolve(accessPath, nil, "idx", tblInfo)
+	path, filteredIndex, status := resolveHint(accessPath, nil, "idx", tblInfo)
 	require.NotNil(t, path)
 	require.Nil(t, filteredIndex)
 	require.Equal(t, indexHintResolvePublicPath, status)
 	require.Equal(t, accessPath[1], path)
 
 	// "id" is a prefix of "idx"
-	path, filteredIndex, status = resolve(accessPath, nil, "id", tblInfo)
+	path, filteredIndex, status = resolveHint(accessPath, nil, "id", tblInfo)
 	require.NotNil(t, path)
 	require.Nil(t, filteredIndex)
 	require.Equal(t, indexHintResolvePublicPath, status)
 	require.Equal(t, accessPath[1], path)
 
-	path, filteredIndex, status = resolve(accessPath, nil, "primary", tblInfo)
+	path, filteredIndex, status = resolveHint(accessPath, nil, "primary", tblInfo)
 	require.NotNil(t, path)
 	require.Nil(t, filteredIndex)
 	require.Equal(t, indexHintResolvePublicPath, status)
 	require.Equal(t, accessPath[0], path)
 
-	path, filteredIndex, status = resolve(accessPath, nil, "not exists", tblInfo)
+	path, filteredIndex, status = resolveHint(accessPath, nil, "not exists", tblInfo)
 	require.Nil(t, path)
 	require.Nil(t, filteredIndex)
 	require.Equal(t, indexHintResolveNotFound, status)
@@ -139,7 +139,7 @@ func TestGetPathByIndexName(t *testing.T) {
 		PKIsHandle: false,
 	}
 
-	path, filteredIndex, status = resolve(accessPath, nil, "primary", tblInfo)
+	path, filteredIndex, status = resolveHint(accessPath, nil, "primary", tblInfo)
 	require.Nil(t, path)
 	require.Nil(t, filteredIndex)
 	require.Equal(t, indexHintResolveNotFound, status)
@@ -148,22 +148,29 @@ func TestGetPathByIndexName(t *testing.T) {
 		unsafeExact := &model.IndexInfo{Name: ast.NewCIStr("idx_unsafe")}
 		unsafeLong := &model.IndexInfo{Name: ast.NewCIStr("idx_unsafe_long")}
 
-		path, filteredIndex, status = resolve(accessPath, []*model.IndexInfo{unsafeExact, unsafeLong}, "idx_unsafe", tblInfo)
+		path, filteredIndex, status = resolveHint(accessPath, []*model.IndexInfo{unsafeExact, unsafeLong}, "idx_unsafe", tblInfo)
 		require.Nil(t, path)
 		require.Same(t, unsafeExact, filteredIndex)
 		require.Equal(t, indexHintResolveFilteredUnsafe, status)
 
-		path, filteredIndex, status = resolve(accessPath, []*model.IndexInfo{unsafeLong}, "idx_unsafe_l", tblInfo)
+		path, filteredIndex, status = resolveHint(accessPath, []*model.IndexInfo{unsafeLong}, "idx_unsafe_l", tblInfo)
 		require.Nil(t, path)
 		require.Same(t, unsafeLong, filteredIndex)
 		require.Equal(t, indexHintResolveFilteredUnsafe, status)
 
 		publicPath := &util.AccessPath{Index: &model.IndexInfo{Name: ast.NewCIStr("idx_shared")}}
 		filteredUnsafe := &model.IndexInfo{Name: ast.NewCIStr("idx_shared")}
-		path, filteredIndex, status = resolve([]*util.AccessPath{publicPath}, []*model.IndexInfo{filteredUnsafe}, "idx_shared", tblInfo)
+		path, filteredIndex, status = resolveHint([]*util.AccessPath{publicPath}, []*model.IndexInfo{filteredUnsafe}, "idx_shared", tblInfo)
 		require.Same(t, publicPath, path)
 		require.Nil(t, filteredIndex)
 		require.Equal(t, indexHintResolvePublicPath, status)
+
+		ambiguousShort := &model.IndexInfo{Name: ast.NewCIStr("idx_unsafe_short")}
+		ambiguousLong := &model.IndexInfo{Name: ast.NewCIStr("idx_unsafe_long")}
+		path, filteredIndex, status = resolveHint(accessPath, []*model.IndexInfo{ambiguousShort, ambiguousLong}, "idx_unsafe_", tblInfo)
+		require.Nil(t, path)
+		require.Nil(t, filteredIndex)
+		require.Equal(t, indexHintResolveNotFound, status)
 	})
 
 	t.Run("ignore exact and prefix-resolved long index without removing shorter sibling", func(t *testing.T) {
@@ -175,7 +182,7 @@ func TestGetPathByIndexName(t *testing.T) {
 			Indices: []*model.IndexInfo{shortPath.Index, longPath.Index},
 		}
 
-		ignoredPath, ignoredIndex, resolveStatus := resolve(paths, nil, "idx_contract_sys_no_delete_flag", tblInfo)
+		ignoredPath, ignoredIndex, resolveStatus := resolveHint(paths, nil, "idx_contract_sys_no_delete_flag", tblInfo)
 		require.Nil(t, ignoredIndex)
 		require.Equal(t, indexHintResolvePublicPath, resolveStatus)
 		ignored := []*util.AccessPath{ignoredPath}
@@ -184,7 +191,7 @@ func TestGetPathByIndexName(t *testing.T) {
 		require.Len(t, remained, 1)
 		require.Same(t, shortPath, remained[0])
 
-		ignoredPath, ignoredIndex, resolveStatus = resolve(paths, nil, "idx_contract_sys_no_delete", tblInfo)
+		ignoredPath, ignoredIndex, resolveStatus = resolveHint(paths, nil, "idx_contract_sys_no_delete", tblInfo)
 		require.Nil(t, ignoredIndex)
 		require.Equal(t, indexHintResolvePublicPath, resolveStatus)
 		ignored = []*util.AccessPath{ignoredPath}
@@ -193,7 +200,7 @@ func TestGetPathByIndexName(t *testing.T) {
 		require.Len(t, remained, 1)
 		require.Same(t, shortPath, remained[0])
 
-		ignoredPath, ignoredIndex, resolveStatus = resolve(paths, nil, "Idx_Contract_Sys_No_Delete_Flag", tblInfo)
+		ignoredPath, ignoredIndex, resolveStatus = resolveHint(paths, nil, "Idx_Contract_Sys_No_Delete_Flag", tblInfo)
 		require.Nil(t, ignoredIndex)
 		require.Equal(t, indexHintResolvePublicPath, resolveStatus)
 		ignored = []*util.AccessPath{ignoredPath}

--- a/pkg/planner/core/rule_generate_column_substitute.go
+++ b/pkg/planner/core/rule_generate_column_substitute.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
+	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/types"
 	h "github.com/pingcap/tidb/pkg/util/hint"
 )
@@ -70,25 +71,32 @@ func collectGenerateColumn(lp base.LogicalPlan, exprToColumn ExprColumnMap) {
 	if ds.PreferStoreType&h.PreferTiFlash != 0 {
 		return
 	}
-	ectx := lp.SCtx().GetExprCtx().GetEvalCtx()
 	for _, p := range ds.AllPossibleAccessPaths {
-		if p.IsTablePath() {
-			continue
-		}
-		for _, idxPart := range p.Index.Columns {
-			colInfo := ds.TableInfo.Columns[idxPart.Offset]
-			if colInfo.IsGenerated() && !colInfo.GeneratedStored {
-				s := ds.Schema().Columns
-				col := expression.ColInfo2Col(s, colInfo)
-				if col != nil && col.GetType(ectx).PartialEqual(col.VirtualExpr.GetType(ectx), lp.SCtx().GetSessionVars().EnableUnsafeSubstitute) {
-					// Replacing a literal with a generated column that is itself a pure constant is not
-					// semantically neutral across outer joins, because null-augmentation can turn the
-					// generated column into NULL while the original literal stays constant.
-					if len(expression.ExtractColumns(col.VirtualExpr)) == 0 {
-						continue
-					}
-					exprToColumn[col.VirtualExpr] = col
+		collectGeneratedColumnsFromPath(lp, ds, p, exprToColumn)
+	}
+	for _, p := range ds.GcSubstituteExtraPaths {
+		collectGeneratedColumnsFromPath(lp, ds, p, exprToColumn)
+	}
+}
+
+func collectGeneratedColumnsFromPath(lp base.LogicalPlan, ds *logicalop.DataSource, path *util.AccessPath, exprToColumn ExprColumnMap) {
+	if path == nil || path.IsTablePath() || path.Index == nil {
+		return
+	}
+	ectx := lp.SCtx().GetExprCtx().GetEvalCtx()
+	for _, idxPart := range path.Index.Columns {
+		colInfo := ds.TableInfo.Columns[idxPart.Offset]
+		if colInfo.IsGenerated() && !colInfo.GeneratedStored {
+			s := ds.Schema().Columns
+			col := expression.ColInfo2Col(s, colInfo)
+			if col != nil && col.GetType(ectx).PartialEqual(col.VirtualExpr.GetType(ectx), lp.SCtx().GetSessionVars().EnableUnsafeSubstitute) {
+				// Replacing a literal with a generated column that is itself a pure constant is not
+				// semantically neutral across outer joins, because null-augmentation can turn the
+				// generated column into NULL while the original literal stays constant.
+				if len(expression.ExtractColumns(col.VirtualExpr)) == 0 {
+					continue
 				}
+				exprToColumn[col.VirtualExpr] = col
 			}
 		}
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #52520

Problem Summary:

When a virtual generated temporal column is indexed, the value stored in the index can be computed under the `sql_mode` used when the row was written, while reading the virtual generated column from the table path recomputes it under the current `sql_mode`.

For example, a virtual generated `DATE` column based on `varchar` input may produce different results for invalid dates such as `2020-02-31` after switching `sql_mode` to `ALLOW_INVALID_DATES`. As a result, queries using the index and queries not using the index may return inconsistent results.

### What changed and how does it work?

This PR prevents TiDB from using indexes that contain virtual generated temporal columns with a date part, including `DATE`, `DATETIME`, and `TIMESTAMP`.

- Add `ColumnInfo.IsVirtualGeneratedTemporalWithDateColumn()` to identify virtual generated columns whose target type contains a date part.
- Filter such indexes out of normal TiKV index access paths during plan building.
- Preserve hint behavior by recognizing filtered indexes and returning an inapplicable-hint warning instead of treating the index as missing.
- Add regression coverage for `USE INDEX`, optimizer `USE_INDEX` hints, and `IGNORE INDEX` behavior around issue #52520.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility


**Validation**
Used `Ready` profile because this creates a local commit with code changes and PR-ready message. Commands run:

```bash
GOSUMDB=sum.golang.org GOPATH=/Users/xiaoli/go GOCACHE=/tmp/tidb-gocache ./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/index -run TestInvisibleIndex -count=1
GOSUMDB=sum.golang.org GOPATH=/Users/xiaoli/go GOCACHE=/tmp/tidb-gocache make lint
git diff --check
```

### Release note

```release-note
Fix an issue that queries using indexes on virtual generated temporal columns could return inconsistent results after sql_mode changes.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index hint resolution to properly handle virtual generated temporal columns, avoiding inappropriate index usage.
  * Fixed data race in checksum execution by isolating execution context details.
  * Fast check table optimization now correctly skips for tables with virtual generated temporal columns.

* **Tests**
  * Added comprehensive test coverage for index hint behavior with virtual generated temporal columns.
  * Extended fast table check tests with virtual generated column scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->