### PR TITLE
planner, executor: fix ANALYZE TABLE panic when indexed generated column depends on skipped column

### DIFF
--- a/pkg/executor/test/analyzetest/BUILD.bazel
+++ b/pkg/executor/test/analyzetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 38,
+    shard_count = 39,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -2146,6 +2146,45 @@ func TestSkipStatsForGeneratedColumnsOnSkippedColumns(t *testing.T) {
 	require.True(t, tblStats.GetCol(tbl.Meta().Columns[3].ID).IsAnalyzed())
 }
 
+// TestAnalyzeIndexedGeneratedColumnOnSkippedColumn verifies that when we skip JSON columns,
+// a STORED generated column that depends on the skipped JSON column but has an index on it
+// can still be analyzed without panic. See https://github.com/pingcap/tidb/issues/67114.
+func TestAnalyzeIndexedGeneratedColumnOnSkippedColumn(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	// Create table matching the issue: JSON column + STORED generated column with index
+	tk.MustExec(`CREATE TABLE t (
+		j JSON NOT NULL,
+		email VARCHAR(255) GENERATED ALWAYS AS (JSON_EXTRACT(j, '$.email')) STORED,
+		INDEX idx_email (email)
+	)`)
+
+	// Explicitly skip JSON columns
+	tk.MustExec("set @@tidb_analyze_skip_column_types = 'json'")
+
+	// This should not panic with "index out of range [-1]"
+	tk.MustExec("ANALYZE TABLE t ALL COLUMNS")
+
+	// Also test ANALYZE TABLE ... INDEX
+	tk.MustExec("ANALYZE TABLE t INDEX idx_email")
+
+	h := dom.StatsHandle()
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tblStats := h.GetPhysicalTableStats(tbl.Meta().ID, tbl.Meta())
+	require.NotNil(t, tblStats)
+	require.True(t, tblStats.IsAnalyzed())
+
+	// JSON base column should be skipped
+	require.False(t, tblStats.GetCol(tbl.Meta().Columns[0].ID).IsAnalyzed())
+	// STORED generated column with index should be analyzed
+	require.True(t, tblStats.GetCol(tbl.Meta().Columns[1].ID).IsAnalyzed())
+	// Index on generated column should be analyzed
+	require.True(t, tblStats.GetIdx(tbl.Meta().Indices[0].ID).IsAnalyzed())
+}
+
 func TestDynamicExpandMustForceAllColumns(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -2572,8 +2572,12 @@ func (b *PlanBuilder) filterSkipColumnTypes(origin []*model.ColumnInfo, tbl *res
 			// Check if any dependency is in the skip list
 			for depName := range colInfo.Dependences {
 				if _, exists := skipColNameMap[depName]; exists {
-					skipCol = append(skipCol, colInfo)
-					shouldSkip = true
+					// If the generated column is required (e.g., part of an index),
+					// we must keep it to avoid index offset remapping failures.
+					if _, need := mustAnalyze[colInfo.ID]; !need {
+						skipCol = append(skipCol, colInfo)
+						shouldSkip = true
+					}
 					break
 				}
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #67114

Problem Summary:
`ANALYZE TABLE t ALL COLUMNS` panics with `runtime error: index out of range [-1]` when a table has a STORED generated column that depends on a skipped column (e.g., JSON) and the generated column has an index on it.

### What changed and how does it work?

In `filterSkipColumnTypes`, the second loop unconditionally filters out generated columns that depend on skipped columns, even if the generated column is in `mustAnalyze` (e.g., part of an index). This causes `allColumns` to become `false`, and `getModifiedIndexesInfoForAnalyze` returns offset `-1` for the missing column, which later causes an array index panic in `analyze_col_sampling.go`.

The fix adds a check: before skipping a generated column, verify whether it is in `mustAnalyze`. If it is required for index statistics, keep it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a panic that occurs when executing `ANALYZE TABLE ... ALL COLUMNS` on a table with an indexed generated column that depends on a skipped JSON column.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `ANALYZE` command handling for STORED generated columns. Generated columns are now correctly analyzed even when their dependency columns (such as JSON columns) are configured to be skipped from analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->