### PR TITLE
*: limit failpoint directory enumeration to top level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,11 +343,11 @@ failpoint-disable: tools/bin/failpoint-ctl
 
 .PHONY: bazel-failpoint-enable
 bazel-failpoint-enable:
-	find $$PWD/ -mindepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable
+	find $$PWD/ -mindepth 1 -maxdepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable
 
 .PHONY: bazel-failpoint-disable
 bazel-failpoint-disable:
-	find $$PWD/ -mindepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable
+	find $$PWD/ -mindepth 1 -maxdepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable
 
 .PHONY: tools/bin/ut
 tools/bin/ut: tools/check/ut.go tools/check/longtests.go

--- a/Makefile.common
+++ b/Makefile.common
@@ -78,8 +78,8 @@ FILES_TIDB_TESTS := $$(find $$($(PACKAGE_DIRECTORIES_TIDB_TESTS)) -name "*.go" -
 UNCONVERT_PACKAGES_LIST := go list ./...| grep -vE "lightning/checkpoints|lightning/manual|lightning/common|tidb-binlog/proto/go-binlog"
 UNCONVERT_PACKAGES := $$($(UNCONVERT_PACKAGES_LIST))
 
-FAILPOINT_ENABLE  := find $$PWD/ -mindepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs tools/bin/failpoint-ctl enable
-FAILPOINT_DISABLE := find $$PWD/ -mindepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs tools/bin/failpoint-ctl disable
+FAILPOINT_ENABLE  := find $$PWD/ -mindepth 1 -maxdepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs tools/bin/failpoint-ctl enable
+FAILPOINT_DISABLE := find $$PWD/ -mindepth 1 -maxdepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs tools/bin/failpoint-ctl disable
 
 GITHASH := $(shell git rev-parse HEAD)
 GITBRANCH := $(shell git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #none

Problem Summary:

`make failpoint-enable` and its Bazel variant currently enumerate every nested directory under the repository root before invoking `failpoint-ctl`. Since `failpoint-ctl enable/disable <dir>` already walks the target directory recursively, the nested directory expansion is redundant and causes repeated traversal of the same subtrees.

### What changed and how does it work?

- add `-maxdepth 1` to the `find` commands used by `FAILPOINT_ENABLE` and `FAILPOINT_DISABLE`
- apply the same change to `bazel-failpoint-enable` and `bazel-failpoint-disable`
- keep the existing exclusion filter for `.git`, `.idea`, and `tools`

This keeps the behavior aligned with `failpoint-ctl`'s recursive traversal while avoiding duplicate directory arguments such as passing both `pkg/` and `pkg/planner/`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > - [x] The change only narrows Makefile directory enumeration and does not alter failpoint rewrite semantics.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized failpoint enable/disable build targets for improved performance by adjusting directory search scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->