### PR TITLE
[WIP] ddl, table: skip pre-check SELECT for widening modify-column changes

### DIFF
--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -811,6 +811,7 @@ func checkModifyColumnData(
 	oldCol, changingCol *model.ColumnInfo,
 	checkValueRange bool,
 ) (checked bool, err error) {
+	failpoint.InjectCall("checkModifyColumnDataEntry", oldCol.Name.L)
 	// Get sessionctx from context resource pool.
 	var sctx sessionctx.Context
 	sctx, err = w.sessPool.Get()
@@ -1199,15 +1200,23 @@ func (w *worker) doModifyColumnIndexReorg(
 		failpoint.InjectCall("modifyColumnTypeWithData", job, args)
 		job.FillArgs(args)
 	case model.StateDeleteOnly:
-		checked, err := checkModifyColumnData(
-			jobCtx.stepCtx, w,
-			dbInfo.Name, tblInfo.Name,
-			oldCol, args.Column, true)
-		if err != nil {
-			if checked {
-				job.State = model.JobStateRollingback
+		// Skip the pre-check SELECT for char/varchar flen widening: the
+		// ModifyTypeIndexReorg path is only reachable via isCharChange in
+		// getModifyColumnType, so this is the one case where no existing
+		// row can violate. NULL -> NOT NULL is caught by the NotNullFlag
+		// guard in castIndexValuesToChangingTypes during reorg.
+		widensFlen := isCharChange(oldCol, args.Column) && args.Column.GetFlen() >= oldCol.GetFlen()
+		if !widensFlen {
+			checked, err := checkModifyColumnData(
+				jobCtx.stepCtx, w,
+				dbInfo.Name, tblInfo.Name,
+				oldCol, args.Column, true)
+			if err != nil {
+				if checked {
+					job.State = model.JobStateRollingback
+				}
+				return ver, errors.Trace(err)
 			}
-			return ver, errors.Trace(err)
 		}
 
 		// delete only -> write only

--- a/pkg/ddl/modify_column_test.go
+++ b/pkg/ddl/modify_column_test.go
@@ -683,6 +683,52 @@ func TestModifyColumnWithSkipReorg(t *testing.T) {
 	require.Equal(t, model.ModifyTypeNoReorgWithCheck, gotTp)
 }
 
+// TestModifyColumnIndexReorgPrecheck exercises the pre-check gating added in
+// doModifyColumnIndexReorg's StateDeleteOnly branch: char/varchar flen
+// widening skips the pre-check, narrowing still runs it, and a reorg-phase
+// failure rolls back cleanly.
+func TestModifyColumnIndexReorgPrecheck(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	precheckCalls := 0
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkModifyColumnDataEntry", func(string) {
+		precheckCalls++
+	})
+
+	// Widening: char(20) -> varchar(30) on an indexed column skips the
+	// pre-check and the ALTER succeeds.
+	tk.MustExec("create table t1 (a char(20) collate utf8mb4_bin, key i1(a))")
+	tk.MustExec("insert into t1 values ('short')")
+	tk.MustExec("alter table t1 modify column a varchar(30) collate utf8mb4_bin")
+	require.Zero(t, precheckCalls)
+	require.Equal(t, mysql.TypeVarchar, external.GetModifyColumn(t, tk, "test", "t1", "a", false).FieldType.GetType())
+
+	// Narrowing: char(20) -> varchar(10) with a 15-byte row. Pre-check runs
+	// and catches the violation.
+	tk.MustExec("create table t2 (a char(20) collate utf8mb4_bin, key i1(a))")
+	tk.MustExec("insert into t2 values ('abcdefghijklmno')")
+	tk.MustGetErrMsg(
+		"alter table t2 modify column a varchar(10) collate utf8mb4_bin",
+		"[types:1265]Data truncated for column 'a', value is 'abcdefghijklmno'",
+	)
+	require.Equal(t, 1, precheckCalls)
+
+	// Reorg-phase failure (errorMockPanic -> ErrReorgPanic) rolls back
+	// cleanly. Cap the retry count so the panic loop terminates quickly.
+	tk.MustExec("set @@global.tidb_ddl_error_count_limit = 3")
+	defer tk.MustExec("set @@global.tidb_ddl_error_count_limit = default")
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/errorMockPanic", "return(true)")
+	tk.MustExec("create table t3 (a char(20) collate utf8mb4_bin, key i1(a))")
+	tk.MustExec("insert into t3 values ('short')")
+	require.Error(t, tk.ExecToErr("alter table t3 modify column a varchar(30) collate utf8mb4_bin"))
+	col := external.GetModifyColumn(t, tk, "test", "t3", "a", false)
+	require.Equal(t, mysql.TypeString, col.FieldType.GetType())
+	require.Equal(t, 20, col.FieldType.GetFlen())
+	tk.MustExec("admin check table t3")
+}
+
 func TestGetModifyColumnType(t *testing.T) {
 	type testCase struct {
 		beforeType string

--- a/pkg/table/tables/index.go
+++ b/pkg/table/tables/index.go
@@ -137,6 +137,11 @@ func (c *index) castIndexValuesToChangingTypes(indexedValues []types.Datum) erro
 		if err != nil {
 			return err
 		}
+		// Strict cast passes NULL through; reject it here when the new type
+		// carries NotNullFlag so reorg surfaces existing NULL rows.
+		if indexedValues[i].IsNull() && mysql.HasNotNullFlag(tblCol.ChangingFieldType.GetFlag()) {
+			return table.ErrColumnCantNull.FastGenByArgs(tblCol.Name)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #68013

Problem Summary:

`ALTER TABLE ... MODIFY COLUMN` on the `ModifyTypeIndexReorg` path runs a synchronous pre-check SELECT in `StateDeleteOnly` that has no timeout, pins the cluster GC safepoint for its whole duration, blocks subsequent DDL on the same table, and is invisible to `SHOW PROCESSLIST`. For widening changes (for example `char(60) -> varchar(70)`) this scan is pure overhead — no existing row can violate.

### What changed and how does it work?

`ModifyTypeIndexReorg` is only reachable via `isCharChange` in `getModifyColumnType`. Gate the pre-check SELECT in `doModifyColumnIndexReorg`'s `StateDeleteOnly` branch on `isCharChange(oldCol, newCol) && newCol.GetFlen() >= oldCol.GetFlen()`; skip it for widening, keep it otherwise.

Add a NULL guard in `castIndexValuesToChangingTypes` right after the strict cast: `Datum.ConvertTo` passes NULL through, so when the new type carries `NotNullFlag` the guard rejects existing NULL rows during reorg. This keeps `NULL -> NOT NULL` safe on the widening skip path.

Add a `checkModifyColumnDataEntry` failpoint at the top of `checkModifyColumnData` so tests can observe whether the pre-check was reached.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Three unit tests cover: widening skip (pre-check not entered), narrowing with an oversized row (pre-check catches), and reorg-phase rollback via `errorMockPanic`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Speed up `ALTER TABLE ... MODIFY COLUMN` jobs that only widen a char/varchar column on a column with a secondary index, by skipping the previously-required pre-check SELECT. Eliminates a multi-minute GC safepoint pin on large tables.
```

