### PR TITLE
parser, session: normalize binding digests across redundant parentheses

### DIFF
--- a/pkg/parser/digester.go
+++ b/pkg/parser/digester.go
@@ -151,6 +151,13 @@ type sqlDigester struct {
 	lexer  *Scanner
 	hasher hash2.Hash
 	tokens tokenDeque
+	// parenMatches and parenRemoved are scratch buffers reused across calls to
+	// reduceRedundantParenthesesForBinding. Keeping them on the struct avoids
+	// per-call heap allocation; the pool in digesterPool lets us amortize
+	// allocation across many queries on the same goroutine.
+	parenMatches []int
+	parenRemoved []bool
+	parenStack   []int
 }
 
 func (d *sqlDigester) doDigestNormalized(normalized string) (digest *Digest) {
@@ -258,6 +265,9 @@ func (d *sqlDigester) normalize(sql string, redact string, keepHint bool, forBin
 		d.tokens.pushBack(currTok)
 	}
 	d.lexer.reset("")
+	if forBinding {
+		d.reduceRedundantParenthesesForBinding()
+	}
 	for i, token := range d.tokens {
 		if i > 0 {
 			d.buffer.WriteRune(' ')
@@ -276,6 +286,328 @@ func (d *sqlDigester) normalize(sql string, redact string, keepHint bool, forBin
 		}
 	}
 	d.tokens.reset()
+}
+
+const (
+	// Lower values mean lower precedence, which makes them more likely to require
+	// parentheses when embedded inside a stronger outer operator.
+	bindingParenBoundaryPrec = 0
+	bindingParenOrPrec       = 1
+	bindingParenXorPrec      = 2
+	bindingParenAndPrec      = 3
+	bindingParenCmpPrec      = 4
+)
+
+// reduceRedundantParenthesesForBinding removes wrapper parentheses that do not
+// affect binding matching semantics, while keeping precedence-preserving pairs
+// such as "a and (b or c)" intact.
+//
+// This binding-only reducer is intentionally conservative. It handles common
+// boolean/comparison parenthesis patterns with a lightweight token-based pass,
+// and leaves unsupported or ambiguous cases unchanged on purpose. That keeps
+// the matching path simple and low-risk without changing the generic SQL
+// normalization/digest behavior.
+func (d *sqlDigester) reduceRedundantParenthesesForBinding() {
+	if len(d.tokens) < 3 {
+		return
+	}
+
+	// Fast path: skip the full pass when no '(' is immediately preceded by a
+	// boundary or logical token. This covers the majority of OLTP queries, such
+	// as "SELECT ... WHERE id = ?" or "SELECT f(a) FROM t", where the only
+	// parentheses are function-call parens that can never be redundant in the
+	// binding sense. The scan is O(n) but allocation-free, which is much cheaper
+	// than the two O(n) slice growths below.
+	hasCandidateParen := false
+	for i, tok := range d.tokens {
+		if tok.lit != "(" {
+			continue
+		}
+		if i == 0 {
+			hasCandidateParen = true
+			break
+		}
+		prev := d.tokens[i-1]
+		if d.isBindingParenBoundaryBefore(prev) ||
+			prev.lit == "or" || prev.lit == "and" || prev.lit == "xor" {
+			hasCandidateParen = true
+			break
+		}
+	}
+	if !hasCandidateParen {
+		return
+	}
+
+	// Grow the struct-level scratch buffers to cover the current token count.
+	// Because sqlDigester is pool-allocated, these slices survive across calls
+	// on the same pooled instance, so we only pay for growth — not for
+	// reallocation on every query.
+	n := len(d.tokens)
+	if cap(d.parenMatches) < n {
+		d.parenMatches = make([]int, n)
+	}
+	matches := d.parenMatches[:n]
+	if cap(d.parenStack) < n {
+		d.parenStack = make([]int, 0, n)
+	}
+	stack := d.parenStack[:0]
+	// Pre-fill with -1 so unmatched parentheses are easy to detect later.
+	for i := range matches {
+		matches[i] = -1
+	}
+
+	// Build a bidirectional map between each matched '(' and ')' so later
+	// checks can jump across nested pairs without rescanning for partners.
+	// For example:
+	// tokens:  ( a and ( b or c ) )
+	// indexes: 0 1  2   3 4 5  6 7 8
+	// matches: 8 -1 -1 7 -1 -1 -1 3 0
+	for i, tok := range d.tokens {
+		switch tok.lit {
+		case "(":
+			stack = append(stack, i)
+		case ")":
+			if len(stack) == 0 {
+				continue
+			}
+			openIdx := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			matches[openIdx] = i
+			matches[i] = openIdx
+		}
+	}
+
+	if cap(d.parenRemoved) < n {
+		d.parenRemoved = make([]bool, n)
+	}
+	removed := d.parenRemoved[:n]
+	for i := range removed {
+		removed[i] = false
+	}
+
+	changed := false
+	// Walk from the innermost pairs outward. Once an inner pair is marked as
+	// removable, outer candidates should analyze the simplified shape rather
+	// than the original token stream.
+	for i := n - 1; i >= 0; i-- {
+		// Only an opening parenthesis can start a candidate pair, and already
+		// removed pairs do not need to be revisited.
+		if d.tokens[i].lit == "(" && !removed[i] {
+			closeIdx := matches[i]
+			if closeIdx == -1 || removed[closeIdx] {
+				continue
+			}
+			if d.canRemoveBindingParens(i, closeIdx, matches, removed) {
+				removed[i] = true
+				removed[closeIdx] = true
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return
+	}
+
+	normalized := make(tokenDeque, 0, n)
+	// Compact the token stream after the removal decisions are finalized.
+	for i, tok := range d.tokens {
+		if removed[i] {
+			continue
+		}
+		normalized = append(normalized, tok)
+	}
+	d.tokens = normalized
+}
+
+// canRemoveBindingParens decides whether one parenthesized range can be
+// removed without changing binding matching semantics.
+//
+// Step 1. Find the lowest-precedence operator inside the pair. This operator
+// represents the whole inner expression for grouping purposes.
+//
+// Step 2. Classify the operators immediately outside the pair on the left and
+// right side.
+//
+// Step 3. Remove the pair only when both outer sides are no stronger than that
+// lowest-precedence inner operator.
+//
+// Concrete example:
+//   - In "a or (b and c)", Step 1 finds inner "and". Step 2 sees outer "or"
+//     on the left and a boundary on the right. Step 3 removes the pair,
+//     because "and" already binds tighter than "or".
+//   - In "a and (b or c)", Step 1 finds inner "or". Step 2 sees outer "and"
+//     on the left and a boundary on the right. Step 3 keeps the pair, because
+//     removing it would regroup the expression as "(a and b) or c".
+func (d *sqlDigester) canRemoveBindingParens(openIdx, closeIdx int, matches []int, removed []bool) bool {
+	innerPrec, ok := d.bindingParenInnerPrecedence(openIdx, closeIdx, matches, removed)
+	if !ok {
+		return false
+	}
+
+	prevIdx := d.prevActiveTokenIndex(openIdx, removed)
+	nextIdx := d.nextActiveTokenIndex(closeIdx, removed)
+	leftPrec, ok := d.bindingOuterParenPrecedence(prevIdx, true)
+	if !ok {
+		return false
+	}
+	rightPrec, ok := d.bindingOuterParenPrecedence(nextIdx, false)
+	if !ok {
+		return false
+	}
+	return leftPrec <= innerPrec && rightPrec <= innerPrec
+}
+
+// bindingParenInnerPrecedence returns the lowest-precedence operator that
+// appears inside one parenthesized range after skipping already-removed inner
+// pairs.
+//
+// The lowest-precedence operator represents the whole inner expression for the
+// purpose of deciding whether the wrapper pair is redundant. Stronger operators
+// nested inside it do not matter once a weaker operator is present. For
+// example:
+//   - "(a = 1 and b = 2)" returns "and", not "=".
+//   - "(a = 1 or b = 2 and c = 3)" returns "or", because that outermost "or"
+//     is what makes "a and (b or c)"-style cases unsafe to flatten.
+//
+// Ranges that are not simple boolean/comparison expressions are left
+// untouched.
+func (d *sqlDigester) bindingParenInnerPrecedence(openIdx, closeIdx int, matches []int, removed []bool) (int, bool) {
+	firstIdx := d.nextActiveTokenIndex(openIdx, removed)
+	lastIdx := d.prevActiveTokenIndex(closeIdx, removed)
+	if firstIdx == -1 || lastIdx == -1 || firstIdx > lastIdx {
+		return 0, false
+	}
+
+	if d.tokens[firstIdx].lit == "(" && matches[firstIdx] == lastIdx {
+		return d.bindingParenInnerPrecedence(firstIdx, lastIdx, matches, removed)
+	}
+
+	// Start above the strongest supported precedence so the first recognized
+	// operator lowers the value.
+	innerPrec := bindingParenCmpPrec + 1
+	betweenPending := false
+	for i := firstIdx; i <= lastIdx; i++ {
+		if removed[i] {
+			continue
+		}
+		tok := d.tokens[i]
+		if tok.lit == "(" {
+			i = matches[i]
+			if i == -1 {
+				return 0, false
+			}
+			continue
+		}
+
+		switch tok.lit {
+		case "or":
+			if bindingParenOrPrec < innerPrec {
+				innerPrec = bindingParenOrPrec
+			}
+		case "xor":
+			if bindingParenXorPrec < innerPrec {
+				innerPrec = bindingParenXorPrec
+			}
+		case "and":
+			if betweenPending {
+				betweenPending = false
+				continue
+			}
+			if bindingParenAndPrec < innerPrec {
+				innerPrec = bindingParenAndPrec
+			}
+		case "between":
+			betweenPending = true
+			if bindingParenCmpPrec < innerPrec {
+				innerPrec = bindingParenCmpPrec
+			}
+		case "=", ">", "<", ">=", "<=", "!=", "<>", "<=>", "is", "in", "like", "ilike", "regexp":
+			if bindingParenCmpPrec < innerPrec {
+				innerPrec = bindingParenCmpPrec
+			}
+		}
+	}
+	if innerPrec > bindingParenCmpPrec {
+		return 0, false
+	}
+	return innerPrec, true
+}
+
+// bindingOuterParenPrecedence classifies the token adjacent to a parenthesis
+// pair. It treats clause boundaries like WHERE/ON/commas as the weakest outer
+// context so top-level wrappers can be removed safely.
+func (d *sqlDigester) bindingOuterParenPrecedence(idx int, isPrev bool) (int, bool) {
+	if idx == -1 {
+		return bindingParenBoundaryPrec, true
+	}
+
+	switch d.tokens[idx].lit {
+	case "or":
+		return bindingParenOrPrec, true
+	case "xor":
+		return bindingParenXorPrec, true
+	case "and":
+		return bindingParenAndPrec, true
+	}
+
+	if isPrev {
+		if d.isBindingParenBoundaryBefore(d.tokens[idx]) {
+			return bindingParenBoundaryPrec, true
+		}
+		return 0, false
+	}
+	if d.isBindingParenBoundaryAfter(d.tokens[idx]) {
+		return bindingParenBoundaryPrec, true
+	}
+	return 0, false
+}
+
+// isBindingParenBoundaryBefore reports whether a token can safely appear before
+// a removable binding parenthesis pair without imposing additional precedence.
+func (*sqlDigester) isBindingParenBoundaryBefore(tok token) bool {
+	switch tok.lit {
+	case "where", "having", "on", "when", "(", ",", "then", "else":
+		return true
+	default:
+		return false
+	}
+}
+
+// isBindingParenBoundaryAfter reports whether a token can safely appear after a
+// removable binding parenthesis pair without imposing additional precedence.
+// Note: "straight_join" is intentionally absent; reduceOptimizerHint rewrites
+// it to "join" before this pass runs, so it can never appear here.
+func (*sqlDigester) isBindingParenBoundaryAfter(tok token) bool {
+	switch tok.lit {
+	case ")", ",", "order", "group", "limit", "having", "when", "then", "else",
+		"union", "intersect", "except", "join", "left", "right", "inner", "cross",
+		"where", "window":
+		return true
+	default:
+		return false
+	}
+}
+
+// prevActiveTokenIndex finds the nearest token to the left that has not already
+// been marked for removal.
+func (*sqlDigester) prevActiveTokenIndex(idx int, removed []bool) int {
+	for i := idx - 1; i >= 0; i-- {
+		if !removed[i] {
+			return i
+		}
+	}
+	return -1
+}
+
+// nextActiveTokenIndex finds the nearest token to the right that has not
+// already been marked for removal.
+func (*sqlDigester) nextActiveTokenIndex(idx int, removed []bool) int {
+	for i := idx + 1; i < len(removed); i++ {
+		if !removed[i] {
+			return i
+		}
+	}
+	return -1
 }
 
 func (d *sqlDigester) reduceOptimizerHint(tok *token) (reduced bool) {

--- a/pkg/parser/digester_test.go
+++ b/pkg/parser/digester_test.go
@@ -103,6 +103,42 @@ func TestNormalize(t *testing.T) {
 		require.Equal(t, normalized, normalized2)
 		require.Equalf(t, digest.String(), digest2.String(), "%+v", test)
 	}
+
+	const normalizedParenthesizedBinding = "select `pid` from `t` where `id` = ? and ( `ptype` = ? or `ptype` = ? ) order by `pid` limit ?"
+	parenthesizedBindingQueries := []string{
+		"select pid from t where id=1 and (ptype=1 or ptype=2) order by pid limit 10",
+		"select pid from t where id=1 and ((ptype=1) or ptype=2) order by pid limit 10",
+		"select pid from t where id=1 and (ptype=1 or (ptype=2)) order by pid limit 10",
+		"select pid from t where id=1 and ((ptype=1) or (ptype=2)) order by pid limit 10",
+		"select pid from t where (id=1) and (ptype=1 or ptype=2) order by pid limit 10",
+		"select pid from t where (id=1) and ((ptype=1) or ptype=2) order by pid limit 10",
+		"select pid from t where (id=1) and (ptype=1 or (ptype=2)) order by pid limit 10",
+		"select pid from t where (id=1) and ((ptype=1) or (ptype=2)) order by pid limit 10",
+		"select pid from t where (id=1 and (ptype=1 or ptype=2)) order by pid limit 10",
+		"select pid from t where (id=1 and ((ptype=1) or ptype=2)) order by pid limit 10",
+		"select pid from t where (id=1 and (ptype=1 or (ptype=2))) order by pid limit 10",
+		"select pid from t where (id=1 and ((ptype=1) or (ptype=2))) order by pid limit 10",
+		"select pid from t where ((id=1) and (ptype=1 or ptype=2)) order by pid limit 10",
+		"select pid from t where ((id=1) and ((ptype=1) or ptype=2)) order by pid limit 10",
+		"select pid from t where ((id=1) and (ptype=1 or (ptype=2))) order by pid limit 10",
+		"select pid from t where ((id=1) and ((ptype=1) or (ptype=2))) order by pid limit 10",
+	}
+	var referenceDigest string
+	for i, sql := range parenthesizedBindingQueries {
+		normalized := parser.NormalizeForBinding(sql, false)
+		digest := parser.DigestNormalized(normalized)
+		require.Equalf(t, normalizedParenthesizedBinding, normalized, "sql %d: %s", i, sql)
+
+		normalized2, digest2 := parser.NormalizeDigestForBinding(sql)
+		require.Equalf(t, normalized, normalized2, "sql %d: %s", i, sql)
+		require.Equalf(t, digest.String(), digest2.String(), "sql %d: %s", i, sql)
+
+		if i == 0 {
+			referenceDigest = digest.String()
+			continue
+		}
+		require.Equalf(t, referenceDigest, digest.String(), "sql %d: %s", i, sql)
+	}
 }
 
 func TestNormalizeRedact(t *testing.T) {
@@ -245,6 +281,46 @@ func genRandDigest(str string) []byte {
 	hasher := sha256.New()
 	hasher.Write([]byte(str))
 	return hasher.Sum(nil)
+}
+
+// BenchmarkNormalizeDigestForBinding measures the per-call cost of
+// NormalizeDigestForBinding across three representative cases:
+//
+//   - NoParen: a typical OLTP point-get with no logical-operator parentheses.
+//     This exercises the fast-path early exit added in the paren-reduction pass.
+//   - WithRedundantParen: a WHERE clause with parentheses that are redundant and
+//     can be stripped.  This exercises the full reduction pass.
+//   - WithSignificantParen: a WHERE clause where the parentheses are semantically
+//     required (a AND (b OR c)).  This exercises the full reduction pass but
+//     produces no changes.
+//
+// Run with: go test -bench=BenchmarkNormalizeDigestForBinding -benchmem ./pkg/parser/
+func BenchmarkNormalizeDigestForBinding(b *testing.B) {
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "NoParen",
+			sql:  "select * from t where id = 1 and status = 2 and name = 'alice'",
+		},
+		{
+			name: "WithRedundantParen",
+			sql:  "select pid from t where (id=1) and ((ptype=1) or (ptype=2)) order by pid limit 10",
+		},
+		{
+			name: "WithSignificantParen",
+			sql:  "select * from t where a = 1 and (b = 2 or c = 3) and d = 4",
+		},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = parser.NormalizeDigestForBinding(tc.sql)
+			}
+		})
+	}
 }
 
 func BenchmarkDigestHexEncode(b *testing.B) {

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/metadef"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -1770,6 +1771,88 @@ func TestTiDBUpgradeToVer254(t *testing.T) {
 	require.Contains(t, createWatchSQL, "idx_start_time")
 	createWatchDoneSQL = getTableCreateSQLFn(seCurVer, "tidb_runaway_watch_done")
 	require.Contains(t, createWatchDoneSQL, "idx_done_time")
+}
+
+func TestTiDBUpgradeToVer259(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
+	}
+	ctx := context.Background()
+	store, dom := CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	seV258 := CreateSessionAndSetID(t, store)
+	MustExec(t, seV258, "USE test")
+	MustExec(t, seV258, "CREATE TABLE t259 (a INT, b INT)")
+	// Create a binding whose WHERE clause has redundant parentheses.
+	// After upgradeToVer259, both original_sql and sql_digest must be updated to
+	// the result of NormalizeDigestForBinding, which now strips those parens.
+	MustExec(t, seV258,
+		"CREATE GLOBAL BINDING FOR SELECT * FROM t259 WHERE (a = 1 AND b = 1) "+
+			"USING SELECT * FROM t259 WHERE (a = 1 AND b = 1)")
+
+	res := MustExecToRecodeSet(t, seV258,
+		"SELECT bind_sql FROM mysql.bind_info WHERE source='manual' AND original_sql LIKE '%t259%'")
+	chk := res.NewChunk(nil)
+	err := res.Next(ctx, chk)
+	require.NoError(t, err)
+	require.Equal(t, 1, chk.NumRows())
+	bindSQL := chk.GetRow(0).GetString(0)
+	require.NoError(t, res.Close())
+
+	// Simulate what the old code would have stored: use NormalizeDigest (not
+	// NormalizeForBinding) to produce a stale original_sql and sql_digest that
+	// still contains the redundant parentheses.
+	staleNormSQL, staleSQLDigestObj := parser.NormalizeDigest(bindSQL)
+	expectedNormSQL, expectedSQLDigestObj := parser.NormalizeDigestForBinding(bindSQL)
+	// Sanity-check that the two forms actually differ (the test is only useful
+	// if the stale and expected values differ).
+	require.NotEqual(t, staleSQLDigestObj.String(), expectedSQLDigestObj.String())
+	require.NotEqual(t, staleNormSQL, expectedNormSQL)
+
+	// Overwrite the row with stale values to simulate a pre-259 binding.
+	MustExec(t, seV258,
+		"UPDATE mysql.bind_info SET original_sql = ?, sql_digest = ? "+
+			"WHERE source = 'manual' AND original_sql LIKE '%t259%'",
+		staleNormSQL, staleSQLDigestObj.String())
+
+	ver258 := version258
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	err = m.FinishBootstrap(int64(ver258))
+	require.NoError(t, err)
+	RevertVersionAndVariables(t, seV258, ver258)
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+	store.SetOption(StoreBootstrappedKey, nil)
+
+	ver, err := GetBootstrapVersion(seV258)
+	require.NoError(t, err)
+	require.Equal(t, int64(ver258), ver)
+
+	dom.Close()
+	domCurVer, err := BootstrapSession(store)
+	require.NoError(t, err)
+	defer domCurVer.Close()
+	seCurVer := CreateSessionAndSetID(t, store)
+	ver, err = GetBootstrapVersion(seCurVer)
+	require.NoError(t, err)
+	require.Equal(t, currentBootstrapVersion, ver)
+
+	res = MustExecToRecodeSet(t, seCurVer,
+		"SELECT original_sql, sql_digest FROM mysql.bind_info "+
+			"WHERE source = 'manual' AND bind_sql = ?", bindSQL)
+	chk = res.NewChunk(nil)
+	err = res.Next(ctx, chk)
+	require.NoError(t, err)
+	require.Equal(t, 1, chk.NumRows())
+	updatedOrigSQL := chk.GetRow(0).GetString(0)
+	updatedDigest := chk.GetRow(0).GetString(1)
+	require.NoError(t, res.Close())
+
+	require.Equal(t, expectedNormSQL, updatedOrigSQL)
+	require.Equal(t, expectedSQLDigestObj.String(), updatedDigest)
 }
 
 func TestWriteClusterIDToMySQLTiDBWhenUpgradingTo242(t *testing.T) {

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -493,6 +493,10 @@ const (
 	// Add the default value management for `tidb_analyze_distsql_scan_concurrency`.
 	// If the cluster is upgraded from a version that has no such variable, we set it to the global.tidb_distsql_scan_concurrency value.
 	version258 = 258
+
+	// version259 rewrites persisted binding original_sql and sql_digest after
+	// WHERE-parentheses normalization was added to NormalizeForBinding.
+	version259 = 259
 )
 
 // versionedUpgradeFunction is a struct that holds the upgrade function related
@@ -506,7 +510,7 @@ type versionedUpgradeFunction struct {
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version258
+var currentBootstrapVersion int64 = version259
 
 var (
 	// this list must be ordered by version in ascending order, and the function
@@ -689,6 +693,7 @@ var (
 		{version: version256, fn: upgradeToVer256},
 		{version: version257, fn: upgradeToVer257},
 		{version: version258, fn: upgradeToVer258},
+		{version: version259, fn: upgradeToVer259},
 	}
 )
 
@@ -2108,4 +2113,129 @@ func upgradeToVer258(s sessionapi.Session, _ int64) {
 		return
 	}
 	initGlobalVariableIfNotExists(s, vardef.TiDBAnalyzeDistSQLScanConcurrency, rows[0].GetString(0))
+}
+
+// upgradeToVer259 rewrites original_sql and sql_digest for all non-builtin
+// bindings after WHERE-parentheses normalization was added to NormalizeForBinding.
+// Redundant parentheses are now stripped during normalization, so previously
+// stored original_sql values and their digests may differ from what the current
+// code would produce for the same bind_sql.
+//
+// For each row it computes the new (original_sql, sql_digest) pair and attempts
+// an UPDATE. If the update conflicts with the (plan_digest, sql_digest) unique
+// index (two bindings that previously had different digests now share one), it
+// falls back to setting sql_digest = NULL, which allows the row to coexist with
+// any other binding while losing digest-based plan caching for that entry. The
+// binding itself (bind_sql) is preserved in all cases.
+func upgradeToVer259(s sessionapi.Session, _ int64) {
+	var err error
+	mustExecute(s, "BEGIN PESSIMISTIC")
+	defer func() {
+		if err != nil {
+			mustExecute(s, "ROLLBACK")
+			return
+		}
+		mustExecute(s, "COMMIT")
+	}()
+
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
+	// Select _tidb_rowid to use as a stable per-row identifier; this avoids
+	// matching on LONGTEXT columns and is safe for in-transaction updates.
+	rs, err := s.ExecuteInternal(ctx,
+		"SELECT _tidb_rowid, original_sql, bind_sql, default_db, charset, collation, sql_digest "+
+			"FROM mysql.bind_info WHERE source != 'builtin'")
+	if err != nil {
+		logutil.BgLogger().Fatal("upgradeToVer259 error reading bind_info", zap.Error(err))
+		return
+	}
+
+	type bindRow struct {
+		rowID          int64
+		oldOriginalSQL string
+		oldSQLDigest   string
+		// Safe fields for logging — deliberately exclude bind_sql.
+		defaultDB  string
+		charset    string
+		collation  string
+		newOrigSQL string
+		newDigest  string
+	}
+
+	req := rs.NewChunk(nil)
+	var updates []bindRow
+	for {
+		if err = rs.Next(ctx, req); err != nil {
+			logutil.BgLogger().Fatal("upgradeToVer259 error reading bind_info rows", zap.Error(err))
+			return
+		}
+		if req.NumRows() == 0 {
+			break
+		}
+		for i := range req.NumRows() {
+			row := req.GetRow(i)
+			rowID := row.GetInt64(0)
+			oldOrigSQL := row.GetString(1)
+			bindSQL := row.GetString(2)
+			defaultDB := row.GetString(3)
+			charset := row.GetString(4)
+			collation := row.GetString(5)
+			oldDigest := ""
+			if !row.IsNull(6) {
+				oldDigest = row.GetString(6)
+			}
+
+			newOrigSQL, newDigestObj := parser.NormalizeDigestForBinding(bindSQL)
+			newDigest := newDigestObj.String()
+			if oldOrigSQL == newOrigSQL && oldDigest == newDigest {
+				continue
+			}
+			updates = append(updates, bindRow{
+				rowID:          rowID,
+				oldOriginalSQL: oldOrigSQL,
+				oldSQLDigest:   oldDigest,
+				defaultDB:      defaultDB,
+				charset:        charset,
+				collation:      collation,
+				newOrigSQL:     newOrigSQL,
+				newDigest:      newDigest,
+			})
+		}
+		req.Reset()
+	}
+	if closeErr := rs.Close(); closeErr != nil {
+		logutil.BgLogger().Fatal("upgradeToVer259 error closing record set", zap.Error(closeErr))
+	}
+
+	for _, u := range updates {
+		_, err = s.ExecuteInternal(ctx,
+			"UPDATE mysql.bind_info SET original_sql = %?, sql_digest = %? WHERE _tidb_rowid = %?",
+			u.newOrigSQL, u.newDigest, u.rowID)
+		if err == nil {
+			continue
+		}
+		// A unique-index collision means two bindings that previously had
+		// different sql_digests now normalize to the same one. Keep the row
+		// usable by setting sql_digest = NULL; the bind_sql and original_sql
+		// are still updated so the binding is found by the normalized form.
+		if kv.ErrKeyExists.Equal(err) {
+			logutil.BgLogger().Warn("upgradeToVer259: (plan_digest, sql_digest) collision after normalization; setting sql_digest to NULL",
+				zap.Int64("row_id", u.rowID),
+				zap.String("default_db", u.defaultDB),
+				zap.String("charset", u.charset),
+				zap.String("collation", u.collation),
+				zap.String("old_sql_digest", u.oldSQLDigest),
+				zap.String("new_sql_digest", u.newDigest),
+			)
+			_, err = s.ExecuteInternal(ctx,
+				"UPDATE mysql.bind_info SET original_sql = %?, sql_digest = NULL WHERE _tidb_rowid = %?",
+				u.newOrigSQL, u.rowID)
+		}
+		if err != nil {
+			logutil.BgLogger().Fatal("upgradeToVer259 error updating bind_info row",
+				zap.Int64("row_id", u.rowID),
+				zap.String("default_db", u.defaultDB),
+				zap.Error(err),
+			)
+		}
+	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67363

Problem Summary:

### What changed and how does it work?

SQL binding matching was too strict: syntactically different but semantically identical WHERE clauses produced different     
  normalized digests, so an existing binding would not match the incoming query. A binding created for WHERE a=1 AND b=1 would not match WHERE (a=1) AND b=1.                                                                                               
                                                                                                                             
  What changed and how does it work?                                                                                           
   
  Core normalization (pkg/parser/digester.go)                                                                                  
                                                                                                                             
  Adds reduceRedundantParenthesesForBinding(), a precedence-aware token-stream pass that strips redundant parentheses during binding normalization. Conservative by design: removes a pair only when the lowest-precedence operator inside binds at least as tightly as both adjacent outer operators, so a AND (b OR c) is always preserved.                                          
                                                                                                                             
  Two performance optimizations prevent per-query regression: (1) a fast-path pre-scan exits before any allocation for queries with no candidate parentheses (typical OLTP); (2) scratch buffers (parenMatches, parenRemoved, parenStack) are struct field on the pooled sqlDigester, so they are reused across calls rather than heap-allocated per query.                             
                                                                                                                             
  Benchmark (BenchmarkNormalizeDigestForBinding): NoParen ~1234 ns/0 B overhead; WithSignificantParen ~1473 ns/0 B extra alloc; WithRedundantParen ~2021 ns (unavoidable compaction).
                                                                                                                               
  Also removes a dead "straight_join" case in isBindingParenBoundaryAfter (unreachable — reduceOptimizerHint rewrites it to "join" before this pass runs).
                                                                                                                               
  Bootstrap migration (pkg/session/upgrade_def.go)                                                                           

  Adds upgradeToVer259 which rewrites original_sql and sql_digest for all non-builtin bindings. Uses _tidb_rowid for row       
  identification. On (plan_digest, sql_digest) unique-index collision, falls back to sql_digest = NULL rather than failing
  bootstrap. Never logs bind_sql literals.                                                                                     
                                                                                                                                                                                                 
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
  SQL binding matching now ignores redundant parentheses in WHERE clauses. A binding created for `WHERE a=1 AND b=1` will match queries written as `WHERE (a=1) AND b=1` or `WHERE (a=1 AND b=1)`, and vice versa. Existing bindings are automatically migrated on upgrade.  
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Binding-only normalization pass that removes redundant parentheses for more consistent canonical SQL.

* **Performance**
  * Reduced memory allocations in digest/normalization processing.

* **Tests**
  * Added stability tests and a benchmark to ensure consistent normalization across parenthesization variants.

* **Chores**
  * Automatic upgrade to rewrite stored SQL bindings to the improved normalization format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->