### PR TITLE
planner: fix inconsistent plans for user variables with different casing (#66340)

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -312,6 +312,17 @@ func TestJoinReorderWithAddSelection(t *testing.T) {
 		`      └─TableFullScan 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo`))
 }
 
+func TestIssue66339(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec("create table t(a int, key(a))")
+	tk.MustExec("set @a=1")
+	tk.MustHavePlan("select a from t where a=@a", "IndexRangeScan")
+	tk.MustExec("set @A=1")
+	tk.MustHavePlan("select a from t where a=@A", "IndexRangeScan")
+}
+
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -438,14 +438,19 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 	case *ast.AnalyzeTableStmt:
 		p.flag |= inAnalyze
 	case *ast.VariableExpr:
+		// Use lowercase for consistency with how user variables are stored (session.go) and
+		// looked up in convertReadonlyVarToConst (builtin_other.go), which uses the lowercased
+		// name from the GetVar expression. Otherwise @customerId vs @customerid would have
+		// different plans: only the latter would be converted to constant for index range.
+		nameLower := strings.ToLower(node.Name)
 		if node.Value != nil {
-			p.varsMutable[node.Name] = struct{}{}
-			delete(p.varsReadonly, node.Name)
+			p.varsMutable[nameLower] = struct{}{}
+			delete(p.varsReadonly, nameLower)
 		} else if p.stmtTp == TypeSelect {
 			// Only check the variable in select statement.
-			_, ok := p.varsMutable[node.Name]
+			_, ok := p.varsMutable[nameLower]
 			if !ok {
-				p.varsReadonly[node.Name] = struct{}{}
+				p.varsReadonly[nameLower] = struct{}{}
 			}
 		}
 	default:


### PR DESCRIPTION
This is a manual cherry-pick of #66340 and replaces the broken automated cherry-pick in #67959.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66339

Problem Summary: planner: fix inconsistent plans for user variables with different casing

### What changed and how does it work?

Root cause:
`varsReadonly` / `varsMutable` in preprocess used the original variable name, while the readonly lookup uses the lowercased name from `GetVar`. Mixed-case user variables therefore missed readonly-to-constant conversion and could get different plans.

Fix:
Use `strings.ToLower(node.Name)` when populating `varsReadonly` and `varsMutable`, and add a regression test to verify both `@a` and `@A` use `IndexRangeScan`.

Note:
The automated cherry-pick PR #67959 contains unresolved conflict markers in `planner_issue_test.go`, so this PR carries the same hotfix as a clean manual cherry-pick for `release-8.5`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed session variable handling to be case-insensitive. Variables with different letter casings (e.g., `@customerId` vs `@customerid`) are now consistently treated as the same variable during query planning, ensuring uniform execution behavior.

* **Tests**
  * Added test coverage for case-insensitive session variable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->