### PR TITLE
pkg/resourcegroup/tests: stabilize runaway watch assertion

### DIFF
--- a/pkg/resourcegroup/tests/resource_group_test.go
+++ b/pkg/resourcegroup/tests/resource_group_test.go
@@ -386,8 +386,10 @@ func TestResourceGroupRunaway(t *testing.T) {
 	tk.EventuallyMustQueryAndCheck("select SQL_NO_CACHE resource_group_name, sample_sql, match_type from mysql.tidb_runaway_queries", nil,
 		testkit.Rows("rg2 select /*+ resource_group(rg2) */ * from t identify",
 			"rg2 select /*+ resource_group(rg2) */ * from t watch"), maxWaitDuration, tryInterval)
-	tk.MustQuery("select SQL_NO_CACHE resource_group_name, watch_text from mysql.tidb_runaway_watch").
-		Check(testkit.Rows("rg2 select /*+ resource_group(rg2) */ * from t"))
+	// Watch records are flushed asynchronously; under loaded CI the watch row may not be
+	// visible immediately after the query returns.
+	tk.EventuallyMustQueryAndCheck("select SQL_NO_CACHE resource_group_name, watch_text from mysql.tidb_runaway_watch", nil,
+		testkit.Rows("rg2 select /*+ resource_group(rg2) */ * from t"), maxWaitDuration, tryInterval)
 	// wait for the runaway watch to be cleaned up
 	tk.EventuallyMustQueryAndCheck("select SQL_NO_CACHE resource_group_name, watch_text from mysql.tidb_runaway_watch", nil, testkit.Rows(), maxWaitDuration, tryInterval)
 	err = tk.QueryToErr("select /*+ resource_group(rg2) */ * from t")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66977

Problem Summary:

`TestResourceGroupRunaway` asserts rows in `mysql.tidb_runaway_watch`. The watch records are flushed asynchronously, and on loaded CI workers the expected watch row may not be visible immediately after the runaway query returns, causing occasional empty reads.

### What changed and how does it work?

- Switch the immediate `MustQuery(...tidb_runaway_watch).Check(...)` to `EventuallyMustQueryAndCheck(...)` to wait until the watch row becomes visible.
- Keep the existing "eventually cleaned up" assertion to ensure the watch row is removed in a bounded time.

### Check List

 Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
 > - [ ] No code

### Release note

```release-note
None
```
