### PR TITLE
importinto: simplify TiCI full-text import flow | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature-fts tici=master-232c4fd

### DIFF
--- a/pkg/dxf/importinto/BUILD.bazel
+++ b/pkg/dxf/importinto/BUILD.bazel
@@ -118,6 +118,7 @@ go_test(
         "//pkg/ddl",
         "//pkg/domain/serverinfo",
         "//pkg/dxf/framework/handle",
+        "//pkg/dxf/framework/mock",
         "//pkg/dxf/framework/planner",
         "//pkg/dxf/framework/proto",
         "//pkg/dxf/framework/scheduler",

--- a/pkg/dxf/importinto/BUILD.bazel
+++ b/pkg/dxf/importinto/BUILD.bazel
@@ -111,7 +111,7 @@ go_test(
     ],
     embed = [":importinto"],
     flaky = True,
-    shard_count = 25,
+    shard_count = 27,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/dxf/importinto/subtask_executor.go
+++ b/pkg/dxf/importinto/subtask_executor.go
@@ -60,6 +60,8 @@ func newImportMinimalTaskExecutor0(t *importStepMinimalTask) MiniTaskExecutor {
 	}
 }
 
+var finishTiCIIndexUpload = tici.FinishIndexUpload
+
 func (e *importMinimalTaskExecutor) Run(
 	ctx context.Context,
 	dataWriter, indexWriter backend.EngineWriter,
@@ -127,37 +129,7 @@ func (p *postProcessStepExecutor) postProcess(ctx context.Context, subtaskMeta *
 		return err
 	}
 
-	// Call Backend.PostProcess to finish TiCI index upload if needed.
-	// This should be called after all engines are imported.
-	// We need to recreate TableImporter here because post process step executor is different
-	// from import step executor. The same tidbTaskID will ensure we get the same TiCI job ID.
-	tableImporter, err := getTableImporter(ctx, p.taskID, p.taskMeta, p.store, logger)
-	if err != nil {
-		logger.Warn("failed to get table importer for post process", zap.Error(err))
-		// Continue with other post process steps even if we can't get table importer
-	} else {
-		defer func() {
-			if closeErr := tableImporter.Close(); closeErr != nil {
-				logger.Warn("failed to close table importer", zap.Error(closeErr))
-			}
-		}()
-		backend := tableImporter.Backend()
-		if backend != nil {
-			// Re-initialize TiCI writer group with the same taskID to get the same ticiJobID
-			taskIDStr := strconv.FormatInt(p.taskID, 10)
-			// The newIndexIDs is not critical here as we only need to get the ticiJobID by taskID.
-			// Now we collect all the tici indexIDs because `InitTiCIWriterGroup` require a non-empty indexIDs.
-			newIndexIDs := tici.GetTiCIIndexIDs(plan.TableInfo)
-			if err := backend.InitTiCIWriterGroup(ctx, plan.TableInfo, plan.DBName, taskIDStr, newIndexIDs); err != nil {
-				logger.Warn("failed to init TiCI writer group for post process", zap.Error(err))
-				// Continue with other post process steps even if we can't init TiCI writer group
-			} else {
-				if err := backend.PostProcess(ctx); err != nil {
-					return errors.Annotate(err, "backend post process failed")
-				}
-			}
-		}
-	}
+	finishTiCIIndexUploadForPostProcess(ctx, p.store, p.taskID, plan, logger)
 
 	localChecksum := verify.NewKVGroupChecksumForAdd()
 	for id, cksum := range subtaskMeta.Checksum {
@@ -220,4 +192,38 @@ func (p *postProcessStepExecutor) postProcess(ctx context.Context, subtaskMeta *
 		}
 		return err
 	})
+}
+
+func finishTiCIIndexUploadForPostProcess(
+	ctx context.Context,
+	store kv.Storage,
+	taskID int64,
+	plan *importer.Plan,
+	logger *zap.Logger,
+) {
+	if plan == nil || plan.TableInfo == nil {
+		return
+	}
+
+	ticiIndexIDs := tici.GetTiCIIndexIDs(plan.TableInfo)
+	if len(ticiIndexIDs) == 0 {
+		return
+	}
+
+	taskIDStr := strconv.FormatInt(taskID, 10)
+	if err := finishTiCIIndexUpload(ctx, store, taskIDStr); err != nil {
+		logger.Warn(
+			"failed to finish TiCI index upload for post process",
+			zap.Int64("task-id", taskID),
+			zap.Int64s("tici-index-ids", ticiIndexIDs),
+			zap.Error(err),
+		)
+		return
+	}
+
+	logger.Info(
+		"finished TiCI index upload for post process",
+		zap.Int64("task-id", taskID),
+		zap.Int64s("tici-index-ids", ticiIndexIDs),
+	)
 }

--- a/pkg/dxf/importinto/task_executor_test.go
+++ b/pkg/dxf/importinto/task_executor_test.go
@@ -20,15 +20,20 @@ import (
 	"strconv"
 	"testing"
 
+	frameworkmock "github.com/pingcap/tidb/pkg/dxf/framework/mock"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor"
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/ingestor/engineapi"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/lightning/backend/external"
+	"github.com/pingcap/tidb/pkg/lightning/config"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -278,6 +283,7 @@ func TestPostProcessTiCIFinishFailureDoesNotAbort(t *testing.T) {
 		ID:           101,
 		Name:         ast.NewCIStr("idx_fulltext"),
 		FullTextInfo: &model.FullTextIndexInfo{},
+		State:        model.StatePublic,
 	}
 	tableInfo := &model.TableInfo{
 		ID:         1,
@@ -300,6 +306,22 @@ func TestPostProcessTiCIFinishFailureDoesNotAbort(t *testing.T) {
 	}
 
 	err := executor.postProcess(context.Background(), &PostProcessStepMeta{TooManyConflictsFromIndex: true}, logger)
+	require.NoError(t, err)
+	require.Len(t, recorded.FilterMessage("failed to finish TiCI index upload for post process").All(), 1)
+
+	ctrl := gomock.NewController(t)
+	taskTbl := frameworkmock.NewMockTaskTable(ctrl)
+	taskTbl.EXPECT().WithNewSession(gomock.Any()).AnyTimes().DoAndReturn(func(fn func(sessionctx.Context) error) error {
+		return fn(nil)
+	})
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/dxf/importinto/skipPostProcessAlterTableMode", "return(true)")
+	core, recorded = observer.New(zap.DebugLevel)
+	logger = zap.New(core)
+	executor.taskTbl = taskTbl
+	executor.logger = logger
+	executor.taskMeta.Plan.Checksum = config.OpLevelOff
+
+	err = executor.postProcess(context.Background(), &PostProcessStepMeta{}, logger)
 	require.NoError(t, err)
 	require.Len(t, recorded.FilterMessage("failed to finish TiCI index upload for post process").All(), 1)
 }

--- a/pkg/dxf/importinto/task_executor_test.go
+++ b/pkg/dxf/importinto/task_executor_test.go
@@ -16,6 +16,7 @@ package importinto
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"testing"
 
@@ -164,4 +165,141 @@ func TestDecideTiCIWriteEnabled(t *testing.T) {
 		fields := entries[0].ContextMap()
 		require.Equal(t, false, fields["tici-write-enabled"])
 	})
+}
+
+func TestFinishTiCIIndexUploadForPostProcess(t *testing.T) {
+	originFinishTiCIIndexUpload := finishTiCIIndexUpload
+	t.Cleanup(func() {
+		finishTiCIIndexUpload = originFinishTiCIIndexUpload
+	})
+
+	makePlan := func(withTiCI bool) *importer.Plan {
+		indexInfo := &model.IndexInfo{
+			ID:   101,
+			Name: ast.NewCIStr("idx_fulltext"),
+		}
+		if withTiCI {
+			indexInfo.FullTextInfo = &model.FullTextIndexInfo{}
+		}
+		tableInfo := &model.TableInfo{
+			ID:         1,
+			Name:       ast.NewCIStr("t"),
+			PKIsHandle: true,
+			Indices:    []*model.IndexInfo{indexInfo},
+		}
+		return &importer.Plan{
+			DBName:           "test",
+			TableInfo:        tableInfo,
+			DesiredTableInfo: tableInfo,
+		}
+	}
+
+	finishErr := errors.New("finish failed")
+	tests := []struct {
+		name        string
+		plan        *importer.Plan
+		finishErr   error
+		wantTaskIDs []string
+		wantWarn    bool
+		wantInfo    bool
+	}{
+		{
+			name: "nil plan skips finish",
+		},
+		{
+			name: "nil table info skips finish",
+			plan: &importer.Plan{},
+		},
+		{
+			name: "no tici index skips finish",
+			plan: makePlan(false),
+		},
+		{
+			name:        "tici index finishes upload",
+			plan:        makePlan(true),
+			wantTaskIDs: []string{"123"},
+			wantInfo:    true,
+		},
+		{
+			name:        "finish failure only warns",
+			plan:        makePlan(true),
+			finishErr:   finishErr,
+			wantTaskIDs: []string{"123"},
+			wantWarn:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotTaskIDs []string
+			finishTiCIIndexUpload = func(_ context.Context, _ kv.Storage, taskID string) error {
+				gotTaskIDs = append(gotTaskIDs, taskID)
+				return tt.finishErr
+			}
+			core, recorded := observer.New(zap.DebugLevel)
+			logger := zap.New(core)
+
+			finishTiCIIndexUploadForPostProcess(context.Background(), nil, 123, tt.plan, logger)
+
+			require.Equal(t, tt.wantTaskIDs, gotTaskIDs)
+			warns := recorded.FilterMessage("failed to finish TiCI index upload for post process").All()
+			if tt.wantWarn {
+				require.Len(t, warns, 1)
+				fields := warns[0].ContextMap()
+				require.Equal(t, int64(123), fields["task-id"])
+				require.Equal(t, []any{int64(101)}, fields["tici-index-ids"])
+				require.Equal(t, finishErr.Error(), fields["error"])
+			} else {
+				require.Empty(t, warns)
+			}
+			infos := recorded.FilterMessage("finished TiCI index upload for post process").All()
+			if tt.wantInfo {
+				require.Len(t, infos, 1)
+				fields := infos[0].ContextMap()
+				require.Equal(t, int64(123), fields["task-id"])
+				require.Equal(t, []any{int64(101)}, fields["tici-index-ids"])
+			} else {
+				require.Empty(t, infos)
+			}
+		})
+	}
+}
+
+func TestPostProcessTiCIFinishFailureDoesNotAbort(t *testing.T) {
+	originFinishTiCIIndexUpload := finishTiCIIndexUpload
+	t.Cleanup(func() {
+		finishTiCIIndexUpload = originFinishTiCIIndexUpload
+	})
+	finishTiCIIndexUpload = func(_ context.Context, _ kv.Storage, _ string) error {
+		return errors.New("finish failed")
+	}
+
+	indexInfo := &model.IndexInfo{
+		ID:           101,
+		Name:         ast.NewCIStr("idx_fulltext"),
+		FullTextInfo: &model.FullTextIndexInfo{},
+	}
+	tableInfo := &model.TableInfo{
+		ID:         1,
+		Name:       ast.NewCIStr("t"),
+		PKIsHandle: true,
+		Indices:    []*model.IndexInfo{indexInfo},
+	}
+	core, recorded := observer.New(zap.DebugLevel)
+	logger := zap.New(core)
+	executor := &postProcessStepExecutor{
+		taskID: 123,
+		taskMeta: &TaskMeta{
+			Plan: importer.Plan{
+				DBName:           "test",
+				TableInfo:        tableInfo,
+				DesiredTableInfo: tableInfo,
+			},
+		},
+		logger: logger,
+	}
+
+	err := executor.postProcess(context.Background(), &PostProcessStepMeta{TooManyConflictsFromIndex: true}, logger)
+	require.NoError(t, err)
+	require.Len(t, recorded.FilterMessage("failed to finish TiCI index upload for post process").All(), 1)
 }

--- a/pkg/executor/importer/BUILD.bazel
+++ b/pkg/executor/importer/BUILD.bazel
@@ -116,7 +116,7 @@ go_test(
     embed = [":importer"],
     flaky = True,
     race = "on",
-    shard_count = 34,
+    shard_count = 35,
     deps = [
         "//br/pkg/mock",
         "//br/pkg/streamhelper",

--- a/pkg/executor/importer/kv_encode.go
+++ b/pkg/executor/importer/kv_encode.go
@@ -59,7 +59,9 @@ func NewTableKVEncoderForDupResolve(
 	ctrl *LoadDataController,
 ) (*TableKVEncoder, error) {
 	mappings, _ := ctrl.tableVisCols2FieldMappings()
-	return newTableKVEncoderInner(config, ctrl, mappings, ctrl.Table.VisibleCols())
+	dupResolveConfig := *config
+	dupResolveConfig.SkipTiCIIndexKVs = true
+	return newTableKVEncoderInner(&dupResolveConfig, ctrl, mappings, ctrl.Table.VisibleCols())
 }
 
 func newTableKVEncoderInner(

--- a/pkg/executor/importer/kv_encode_test.go
+++ b/pkg/executor/importer/kv_encode_test.go
@@ -20,8 +20,12 @@ import (
 
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/lightning/backend/encode"
+	lkv "github.com/pingcap/tidb/pkg/lightning/backend/kv"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/session"
+	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/types"
@@ -84,4 +88,103 @@ func TestKVEncoderForDupResolve(t *testing.T) {
 		})
 		require.Greater(t, handleLargerThanOneCount, 1)
 	})
+}
+
+func TestTableKVEncoderEmitsFullTextIndexKVs(t *testing.T) {
+	colID := &model.ColumnInfo{ID: 1, Name: ast.NewCIStr("id"), State: model.StatePublic, Offset: 0, FieldType: *types.NewFieldType(mysql.TypeLonglong)}
+	colBody := &model.ColumnInfo{ID: 2, Name: ast.NewCIStr("body"), State: model.StatePublic, Offset: 1, FieldType: *types.NewFieldType(mysql.TypeVarchar)}
+	normalIdx := &model.IndexInfo{
+		ID:      2,
+		Name:    ast.NewCIStr("idx_body"),
+		State:   model.StatePublic,
+		Columns: []*model.IndexColumn{{Name: ast.NewCIStr("body"), Offset: 1, Length: types.UnspecifiedLength}},
+	}
+	fullTextIdx := &model.IndexInfo{
+		ID:      3,
+		Name:    ast.NewCIStr("idx_fulltext"),
+		State:   model.StatePublic,
+		Columns: []*model.IndexColumn{{Name: ast.NewCIStr("body"), Offset: 1, Length: types.UnspecifiedLength}},
+		FullTextInfo: &model.FullTextIndexInfo{
+			ParserType: model.FullTextParserTypeStandardV1,
+		},
+	}
+	hybridIdx := &model.IndexInfo{
+		ID:      4,
+		Name:    ast.NewCIStr("idx_hybrid"),
+		State:   model.StatePublic,
+		Columns: []*model.IndexColumn{{Name: ast.NewCIStr("body"), Offset: 1, Length: types.UnspecifiedLength}},
+		HybridInfo: &model.HybridIndexInfo{
+			Sharding: &model.HybridShardingSpec{
+				Columns: []*model.IndexColumn{{Name: ast.NewCIStr("body"), Offset: 1, Length: types.UnspecifiedLength}},
+			},
+		},
+	}
+	tblInfo := &model.TableInfo{
+		ID:      11,
+		Name:    ast.NewCIStr("t"),
+		State:   model.StatePublic,
+		Columns: []*model.ColumnInfo{colID, colBody},
+		Indices: []*model.IndexInfo{normalIdx, fullTextIdx, hybridIdx},
+	}
+	tbl, err := tables.TableFromMeta(lkv.NewPanickingAllocators(tblInfo.SepAutoInc()), tblInfo)
+	require.NoError(t, err)
+
+	fieldMappings := make([]*importer.FieldMapping, 0, len(tbl.VisibleCols()))
+	for _, col := range tbl.VisibleCols() {
+		fieldMappings = append(fieldMappings, &importer.FieldMapping{Column: col})
+	}
+	collectPairInfo := func(t *testing.T, pairs *lkv.Pairs) (map[int64]struct{}, bool) {
+		t.Helper()
+		seenIndexIDs := make(map[int64]struct{})
+		var seenRecord bool
+		for _, pair := range pairs.Pairs {
+			_, indexID, isRecordKey, err := tablecodec.DecodeKeyHead(pair.Key)
+			require.NoError(t, err)
+			if isRecordKey {
+				seenRecord = true
+				continue
+			}
+			seenIndexIDs[indexID] = struct{}{}
+		}
+		return seenIndexIDs, seenRecord
+	}
+	newController := func() *importer.LoadDataController {
+		return &importer.LoadDataController{
+			ASTArgs:       &importer.ASTArgs{},
+			Plan:          &importer.Plan{},
+			Table:         tbl,
+			InsertColumns: tbl.VisibleCols(),
+			FieldMappings: fieldMappings,
+		}
+	}
+
+	encoder, err := importer.NewTableKVEncoder(
+		&encode.EncodingConfig{Table: tbl},
+		newController(),
+	)
+	require.NoError(t, err)
+
+	pairs, err := encoder.Encode([]types.Datum{types.NewIntDatum(1), types.NewStringDatum("doc")}, 100)
+	require.NoError(t, err)
+
+	seenIndexIDs, seenRecord := collectPairInfo(t, pairs)
+	require.True(t, seenRecord)
+	require.Contains(t, seenIndexIDs, normalIdx.ID)
+	require.Contains(t, seenIndexIDs, fullTextIdx.ID)
+	require.NotContains(t, seenIndexIDs, hybridIdx.ID)
+
+	dupResolveEncoder, err := importer.NewTableKVEncoderForDupResolve(
+		&encode.EncodingConfig{Table: tbl},
+		newController(),
+	)
+	require.NoError(t, err)
+
+	dupResolvePairs, err := dupResolveEncoder.Encode([]types.Datum{types.NewIntDatum(2), types.NewStringDatum("doc")}, 200)
+	require.NoError(t, err)
+
+	seenIndexIDs, seenRecord = collectPairInfo(t, dupResolvePairs)
+	require.True(t, seenRecord)
+	require.Contains(t, seenIndexIDs, normalIdx.ID)
+	require.NotContains(t, seenIndexIDs, fullTextIdx.ID)
+	require.NotContains(t, seenIndexIDs, hybridIdx.ID)
 }

--- a/pkg/lightning/backend/encode/encode.go
+++ b/pkg/lightning/backend/encode/encode.go
@@ -34,6 +34,8 @@ type EncodingConfig struct {
 	// when encoding.
 	// default false, in this case we will do sharding automatically if needed.
 	UseIdentityAutoRowID bool
+	// SkipTiCIIndexKVs controls whether to skip TiCI index KV encoding.
+	SkipTiCIIndexKVs bool
 }
 
 // EncodingBuilder consists of operations to handle encoding backend row data formats from source.

--- a/pkg/lightning/backend/kv/base.go
+++ b/pkg/lightning/backend/kv/base.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/table"
+	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
@@ -131,6 +132,8 @@ type BaseKVEncoder struct {
 
 	logger      *zap.Logger
 	recordCache []types.Datum
+
+	skipTiCIIndexKVs bool
 }
 
 // NewBaseKVEncoder creates a new BaseKVEncoder.
@@ -172,13 +175,14 @@ func NewBaseKVEncoder(config *encode.EncodingConfig) (*BaseKVEncoder, error) {
 		return nil, errors.Annotate(err, "failed to parse generated column expressions")
 	}
 	return &BaseKVEncoder{
-		GenCols:         genCols,
-		SessionCtx:      se,
-		table:           config.Table,
-		Columns:         cols,
-		AutoRandomColID: autoRandomColID,
-		AutoIDFn:        autoIDFn,
-		logger:          config.Logger.Logger,
+		GenCols:          genCols,
+		SessionCtx:       se,
+		table:            config.Table,
+		Columns:          cols,
+		AutoRandomColID:  autoRandomColID,
+		AutoIDFn:         autoIDFn,
+		logger:           config.Logger.Logger,
+		skipTiCIIndexKVs: config.SkipTiCIIndexKVs,
 	}, nil
 }
 
@@ -192,9 +196,20 @@ func (e *BaseKVEncoder) GetOrCreateRecord() []types.Datum {
 
 // Record2KV converts a row into a KV pair.
 func (e *BaseKVEncoder) Record2KV(record, originalRow []types.Datum, rowID int64) (*Pairs, error) {
-	_, err := e.AddRecord(record)
+	recordID, err := e.AddRecord(record)
 	if err != nil {
 		e.logger.Error("kv encode failed",
+			zap.Array("originalRow", RowArrayMarshaller(originalRow)),
+			zap.Array("convertedRow", RowArrayMarshaller(record)),
+			log.ShortError(err),
+		)
+		return nil, errors.Trace(err)
+	}
+	if !e.skipTiCIIndexKVs {
+		err = e.addFullTextIndexKVs(recordID, record)
+	}
+	if err != nil {
+		e.logger.Error("fulltext index kv encode failed",
 			zap.Array("originalRow", RowArrayMarshaller(originalRow)),
 			zap.Array("convertedRow", RowArrayMarshaller(record)),
 			log.ShortError(err),
@@ -208,6 +223,48 @@ func (e *BaseKVEncoder) Record2KV(record, originalRow []types.Datum, rowID int64
 	}
 	e.recordCache = record[:0]
 	return kvPairs, nil
+}
+
+func (e *BaseKVEncoder) addFullTextIndexKVs(recordID kv.Handle, record []types.Datum) error {
+	var indexVals []types.Datum
+	for _, idx := range e.table.Indices() {
+		idxInfo := idx.Meta()
+		if !shouldEncodeTiCIIndex(idxInfo) {
+			continue
+		}
+		if !tables.IsIndexWritable(idx) {
+			continue
+		}
+		meetPartialCondition, err := idx.MeetPartialCondition(record)
+		if err != nil {
+			return err
+		}
+		if !meetPartialCondition {
+			continue
+		}
+		indexVals, err = idx.FetchValues(record, indexVals)
+		if err != nil {
+			return err
+		}
+		restoredData := tables.TryGetHandleRestoredDataWrapper(e.table.Meta(), record, nil, idxInfo)
+		if _, err = idx.Create(
+			e.SessionCtx.GetTableCtx(),
+			e.SessionCtx.Txn(),
+			indexVals,
+			recordID,
+			restoredData,
+			table.DupKeyCheckSkip,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func shouldEncodeTiCIIndex(idxInfo *model.IndexInfo) bool {
+	// Hybrid indexes also use TiCI, but their Import Into encode behavior is
+	// validated separately before being enabled here.
+	return idxInfo.FullTextInfo != nil
 }
 
 // AddRecord adds a record into encoder


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61759

Problem Summary:

`IMPORT INTO` still has redundant TiCI full-text post-process setup, and the encode path needs to emit full-text TiCI index KVs.

### What changed and how does it work?

- Finish TiCI index upload directly in Import Into post-process without rebuilding importer/backend/writer group.
- Encode full-text TiCI index KVs during Import Into KV encoding.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Safer post-process index upload completion with clearer logs and non-fatal handling of upload failures.
  * Full-text index KV encoding integrated into the record import path (optional).
* **New Feature**
  * Added config flag to optionally skip full-text index KV encoding.
* **Tests**
  * New unit tests covering full-text KV emission and post-process finish/error handling.
* **Chores**
  * Increased test sharding for faster parallel test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->