### PR TITLE
Revert "planner: switch to RWLock to improve binding cache performance (#65570)"

### DIFF
--- a/pkg/bindinfo/binding_cache.go
+++ b/pkg/bindinfo/binding_cache.go
@@ -291,7 +291,7 @@ type BindingCache interface {
 // The key of the LRU cache is original sql, the value is a slice of Bindings.
 // Note: The bindingCache should be accessed with lock.
 type bindingCache struct {
-	lock        sync.RWMutex
+	lock        sync.Mutex
 	cache       *kvcache.SimpleLRUCache
 	memCapacity int64
 	memTracker  *memory.Tracker // track memory usage.
@@ -379,8 +379,8 @@ func (c *bindingCache) delete(key bindingCacheKey) bool {
 // The return value is not read-only, but it shouldn't be changed in the caller functions.
 // The function is thread-safe.
 func (c *bindingCache) GetBinding(sqlDigest string) Bindings {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.get(bindingCacheKey(sqlDigest))
 }
 
@@ -388,8 +388,8 @@ func (c *bindingCache) GetBinding(sqlDigest string) Bindings {
 // The return value is not read-only, but it shouldn't be changed in the caller functions.
 // The function is thread-safe.
 func (c *bindingCache) GetAllBindings() Bindings {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	values := c.cache.Values()
 	bindings := make(Bindings, 0, len(values))
 	for _, vals := range values {
@@ -428,16 +428,16 @@ func (c *bindingCache) SetMemCapacity(capacity int64) {
 // GetMemUsage get the memory Usage for the cache.
 // The function is thread-safe.
 func (c *bindingCache) GetMemUsage() int64 {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.memTracker.BytesConsumed()
 }
 
 // GetMemCapacity get the memory capacity for the cache.
 // The function is thread-safe.
 func (c *bindingCache) GetMemCapacity() int64 {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.memCapacity
 }
 
@@ -463,7 +463,7 @@ func (c *bindingCache) CopyBindingCache() (BindingCache, error) {
 }
 
 func (c *bindingCache) Size() int {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.cache.Size()
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68015

Problem Summary: Revert "planner: switch to RWLock to improve binding cache performance (#65570)"

### What changed and how does it work?

The underlying binding cache structure in v8.5.6 is not thread-safe, so this optimization might cause a corrupted LRU cache and eventually cause TiDB OOM.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal synchronization mechanism for improved performance in binding cache operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->