### PR TITLE
*: replace BenMeadowcroft with likidu in OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,13 +2,13 @@
 aliases:
   sig-critical-approvers-tidb-server:
     - yudongusa
-    - BenMeadowcroft
+    - likidu
   sig-critical-approvers-tidb-lightning:
     - yudongusa
-    - BenMeadowcroft
+    - likidu
   sig-critical-approvers-parser:
     - yudongusa
-    - BenMeadowcroft
+    - likidu
   sig-approvers-autoid-service: # approvers for auto-id service
     - bb7133
     - tiancaiamao


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what\x27s changed
2. *: what\x27s changed

-->

### What problem does this PR solve?

Issue Number: ref #68034

Problem Summary:
- Replace `BenMeadowcroft` with `likidu` in `OWNERS_ALIASES` for `sig-critical-approvers-*` aliases on `release-7.1`.

### What is changed and how it works?

- Update `OWNERS_ALIASES` entries.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated approver assignments for critical components to reflect current team structure across project governance areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->