### PR TITLE
types, tablecodec, codec: [DNM] add benchmark baseline for Datum refactor

### DIFF
--- a/pkg/tablecodec/bench_test.go
+++ b/pkg/tablecodec/bench_test.go
@@ -25,12 +25,14 @@ import (
 )
 
 func BenchmarkEncodeRowKeyWithHandle(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		EncodeRowKeyWithHandle(100, kv.IntHandle(100))
 	}
 }
 
 func BenchmarkEncodeEndKey(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		EncodeRowKeyWithHandle(100, kv.IntHandle(100))
 		EncodeRowKeyWithHandle(100, kv.IntHandle(101))
@@ -42,6 +44,7 @@ func BenchmarkEncodeEndKey(b *testing.B) {
 // BenchmarkEncodeEndKey-4		20000000	        97.2 ns/op
 // BenchmarkEncodeRowKeyWithPrefixNex-4	10000000	       121 ns/op
 func BenchmarkEncodeRowKeyWithPrefixNex(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		sk := EncodeRowKeyWithHandle(100, kv.IntHandle(100))
 		sk.PrefixNext()
@@ -50,6 +53,7 @@ func BenchmarkEncodeRowKeyWithPrefixNex(b *testing.B) {
 
 func BenchmarkDecodeRowKey(b *testing.B) {
 	rowKey := EncodeRowKeyWithHandle(100, kv.IntHandle(100))
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_, err := DecodeRowKey(rowKey)
 		if err != nil {
@@ -63,6 +67,7 @@ func BenchmarkDecodeIndexKeyIntHandle(b *testing.B) {
 	// When handle values greater than 255, it will have a memory alloc.
 	idxVal = append(idxVal, EncodeHandleInUniqueIndexValue(kv.IntHandle(256), false)...)
 
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		DecodeHandleInIndexValue(idxVal)
 	}
@@ -80,6 +85,7 @@ func BenchmarkDecodeIndexKeyCommonHandle(b *testing.B) {
 	h, _ := kv.NewCommonHandle(encoded)
 	idxVal = encodeCommonHandle(idxVal, h)
 
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		DecodeHandleInIndexValue(idxVal)
 	}

--- a/pkg/tablecodec/tablecodec_test.go
+++ b/pkg/tablecodec/tablecodec_test.go
@@ -565,6 +565,7 @@ func BenchmarkEncodeValue(b *testing.B) {
 	row[4] = types.NewDatum(types.Set{Name: "a", Value: 0})
 	row[5] = types.NewDatum(types.BinaryLiteral{100})
 	row[6] = types.NewFloat32Datum(1.5)
+	b.ReportAllocs()
 	b.ResetTimer()
 	encodedCol := make([]byte, 0, 16)
 	for i := 0; i < b.N; i++ {

--- a/pkg/types/datum_test.go
+++ b/pkg/types/datum_test.go
@@ -604,6 +604,7 @@ func TestMarshalDatum(t *testing.T) {
 
 func BenchmarkCompareDatum(b *testing.B) {
 	vals, vals1 := prepareCompareDatums()
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j, v := range vals {
@@ -615,11 +616,57 @@ func BenchmarkCompareDatum(b *testing.B) {
 	}
 }
 
+// BenchmarkCompareDatumCollation compares collated string datums. Unlike
+// BenchmarkCompareDatum, the datums carry a non-empty collation and the
+// compare path dispatches through the named collator instead of the binary
+// shortcut, so it exercises Datum.Collation() on the hot path.
+func BenchmarkCompareDatumCollation(b *testing.B) {
+	d1 := NewCollationStringDatum("abcdefghij", charset.CollationUTF8MB4)
+	d2 := NewCollationStringDatum("abcdefghik", charset.CollationUTF8MB4)
+	coll := collate.GetCollator(charset.CollationUTF8MB4)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := d1.Compare(DefaultStmtNoWarningContext, &d2, coll); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkCompareDatumByReflect(b *testing.B) {
 	vals, vals1 := prepareCompareDatums()
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		reflect.DeepEqual(vals, vals1)
+	}
+}
+
+// BenchmarkDatumCopy exercises Datum.Copy on a heterogeneous slice. This
+// is the most direct measurement of Datum struct size: every byte saved
+// from the struct shows up in B/op here.
+func BenchmarkDatumCopy(b *testing.B) {
+	src, _ := prepareCompareDatums()
+	dst := make([]Datum, len(src))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := range src {
+			src[j].Copy(&dst[j])
+		}
+	}
+}
+
+// BenchmarkDatumSetMysqlTime locks in the allocation cost of SetMysqlTime.
+// Today Time is boxed via d.x (any), which heap-allocates the uint64-sized
+// value. After packing Time into d.i this should drop to 0 allocs/op.
+func BenchmarkDatumSetMysqlTime(b *testing.B) {
+	t := NewTime(FromGoTime(time.Date(2018, 3, 8, 16, 1, 0, 315313000, time.UTC)), mysql.TypeTimestamp, 6)
+	var d Datum
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.SetMysqlTime(t)
 	}
 }
 
@@ -746,6 +793,7 @@ func BenchmarkDatumsToString(b *testing.B) {
 		MinNotNullDatum(),
 		MaxValueDatum(),
 	}
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := DatumsToString(datums, true)
@@ -759,6 +807,7 @@ func BenchmarkDatumsToStringStr(b *testing.B) {
 	datums := []Datum{
 		NewStringDatum(strings.Repeat("1", 512)),
 	}
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := DatumsToString(datums, true)
@@ -772,6 +821,7 @@ func BenchmarkDatumsToStringLongStr(b *testing.B) {
 	datums := []Datum{
 		NewStringDatum(strings.Repeat("1", 1024*10)), // 10KB
 	}
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := DatumsToString(datums, true)
@@ -784,6 +834,7 @@ func BenchmarkDatumsToStringLongStr(b *testing.B) {
 func BenchmarkDatumTruncatedStringify(b *testing.B) {
 	d1 := NewStringDatum(strings.Repeat("1", 128))
 	d2 := NewIntDatum(2)
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = d1.TruncatedStringify()

--- a/pkg/util/codec/bench_test.go
+++ b/pkg/util/codec/bench_test.go
@@ -38,6 +38,7 @@ func composeEncodedData(size int) []byte {
 func BenchmarkDecodeWithSize(b *testing.B) {
 	b.StopTimer()
 	bs := composeEncodedData(valueCnt)
+	b.ReportAllocs()
 	b.StartTimer()
 	for range b.N {
 		_, err := Decode(bs, valueCnt)
@@ -50,6 +51,7 @@ func BenchmarkDecodeWithSize(b *testing.B) {
 func BenchmarkDecodeWithOutSize(b *testing.B) {
 	b.StopTimer()
 	bs := composeEncodedData(valueCnt)
+	b.ReportAllocs()
 	b.StartTimer()
 	for range b.N {
 		_, err := Decode(bs, 1)
@@ -60,6 +62,7 @@ func BenchmarkDecodeWithOutSize(b *testing.B) {
 }
 
 func BenchmarkEncodeIntWithSize(b *testing.B) {
+	b.ReportAllocs()
 	for range b.N {
 		data := make([]byte, 0, 8)
 		EncodeInt(data, 10)
@@ -67,6 +70,7 @@ func BenchmarkEncodeIntWithSize(b *testing.B) {
 }
 
 func BenchmarkEncodeIntWithOutSize(b *testing.B) {
+	b.ReportAllocs()
 	for range b.N {
 		EncodeInt(nil, 10)
 	}
@@ -80,6 +84,7 @@ func BenchmarkDecodeDecimal(b *testing.B) {
 	}
 	precision, frac := dec.PrecisionAndFrac()
 	raw, _ := EncodeDecimal([]byte{}, dec, precision, frac)
+	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
 		_, _, _, _, err := DecodeDecimal(raw)
@@ -96,6 +101,7 @@ func BenchmarkDecodeOneToChunk(b *testing.B) {
 	raw = append(raw, bytesFlag)
 	raw = EncodeBytes(raw, str.GetBytes())
 	intType := types.NewFieldType(mysql.TypeLonglong)
+	b.ReportAllocs()
 	b.ResetTimer()
 	decoder := NewDecoder(chunk.New([]*types.FieldType{intType}, 32, 32), nil)
 	for range b.N {


### PR DESCRIPTION
Turn on b.ReportAllocs() across Datum-related benchmarks so benchstat can diff B/op and allocs/op against upcoming struct-size changes. Add three new targeted benches in pkg/types:

- BenchmarkDatumCopy: tightest signal on Datum struct size (heterogeneous slice copied per iteration).
- BenchmarkDatumSetMysqlTime: locks in the current 1 alloc / 8 B per call caused by boxing Time through d.x; will drop to 0 allocs once Time packs into d.i.
- BenchmarkCompareDatumCollation: exercises the named-collator compare path, which the existing BenchmarkCompareDatum skips by using the binary collator.

Behavior-only change in benchmarks; no production code touched.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67976

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
