### PR TITLE
planner: avoid pushing TopN to probe side for virtual columns

### DIFF
--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -1941,6 +1941,22 @@ func TestVirtualExprPushDown(t *testing.T) {
 		require.NotEmpty(t, plan)
 		tk.MustQuery("select g from t_force_idx force index (idx_exp_i) where (i + 1) >= 1 order by g limit 1;").Check(testkit.Rows("2"))
 
+		tk.MustExec("drop table if exists t_bug")
+		tk.MustExec(`create table t_bug (
+			id bigint primary key auto_increment,
+			s varchar(20),
+			g varchar(20) generated always as (lower(s)) virtual,
+			key idx_exp_lower ((lower(s)))
+		)`)
+		tk.MustExec("insert into t_bug(s) values ('B'),('a')")
+		tk.MustQuery("explain format='plan_tree' select /* issue:67981 */ * from t_bug force index (idx_exp_lower) where lower(s) >= 'a' order by g limit 1;").Check(testkit.Rows(
+			"Projection root  test.t_bug.id, test.t_bug.s, test.t_bug.g",
+			"└─TopN root  test.t_bug.g, offset:0, count:1",
+			"  └─IndexLookUp root  ",
+			"    ├─IndexRangeScan(Build) cop[tikv] table:t_bug, index:idx_exp_lower(lower(`s`)) range:[\"a\",+inf], keep order:false, stats:pseudo",
+			"    └─TableRowIDScan(Probe) cop[tikv] table:t_bug keep order:false, stats:pseudo"))
+		tk.MustQuery("select /* issue:67981 */ * from t_bug force index (idx_exp_lower) where lower(s) >= 'a' order by g limit 1;").Check(testkit.Rows("2 a a"))
+
 		tk.MustExec("set @@tidb_allow_mpp=1; set @@tidb_enforce_mpp=1")
 		tk.MustExec("set @@tidb_isolation_read_engines = 'tiflash'")
 		is := dom.InfoSchema()

--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -1946,6 +1946,7 @@ func TestVirtualExprPushDown(t *testing.T) {
 			id bigint primary key auto_increment,
 			s varchar(20),
 			g varchar(20) generated always as (lower(s)) virtual,
+			key(g),
 			key idx_exp_lower ((lower(s)))
 		)`)
 		tk.MustExec("insert into t_bug(s) values ('B'),('a')")
@@ -1956,6 +1957,13 @@ func TestVirtualExprPushDown(t *testing.T) {
 			"    ├─IndexRangeScan(Build) cop[tikv] table:t_bug, index:idx_exp_lower(lower(`s`)) range:[\"a\",+inf], keep order:false, stats:pseudo",
 			"    └─TableRowIDScan(Probe) cop[tikv] table:t_bug keep order:false, stats:pseudo"))
 		tk.MustQuery("select /* issue:67981 */ * from t_bug force index (idx_exp_lower) where lower(s) >= 'a' order by g limit 1;").Check(testkit.Rows("2 a a"))
+		tk.MustQuery("explain format='plan_tree' select /* issue:67981 */ * from t_bug force index (g) where lower(s) >= 'a' order by g limit 1;").Check(testkit.Rows(
+			"Projection root  test.t_bug.id, test.t_bug.s, test.t_bug.g",
+			"└─IndexLookUp root  limit embedded(offset:0, count:1)",
+			"  ├─Limit(Build) cop[tikv]  offset:0, count:1",
+			"  │ └─IndexRangeScan cop[tikv] table:t_bug, index:g(g) range:[\"a\",+inf], keep order:true, stats:pseudo",
+			"  └─TableRowIDScan(Probe) cop[tikv] table:t_bug keep order:false, stats:pseudo"))
+		tk.MustQuery("select /* issue:67981 */ * from t_bug force index (g) where lower(s) >= 'a' order by g limit 1;").Check(testkit.Rows("2 a a"))
 
 		tk.MustExec("set @@tidb_allow_mpp=1; set @@tidb_enforce_mpp=1")
 		tk.MustExec("set @@tidb_isolation_read_engines = 'tiflash'")

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1298,6 +1298,17 @@ func attach2Task4PhysicalTopN(pp base.PhysicalPlan, tasks ...base.Task) base.Tas
 				}
 				return attachPlan2Task(p, rootTask)
 			}
+			if containVirtualColumn(p, copTask.TablePlan.Schema().Columns) {
+				// Keep TopN at root when it would be pushed to the table/probe side of an
+				// IndexLookUp on a virtual generated column. The build/index side may not
+				// preserve the global order in this case, so a probe-side partial TopN can
+				// stop too early and return wrong rows.
+				rootTask := t.ConvertToRootTask(p.SCtx())
+				if len(p.GetPartitionBy()) > 0 {
+					return t
+				}
+				return attachPlan2Task(p, rootTask)
+			}
 			pushedDownTopN, newGlobalTopN = getPushedDownTopN(p, copTask.TablePlan, copTask.GetStoreType())
 			copTask.TablePlan = pushedDownTopN
 			if newGlobalTopN != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67981

Problem Summary:

`TopN` could be incorrectly pushed to the `IndexLookUp` probe side when `ORDER BY`
references a virtual generated column backed by an expression index. In that
shape, the probe-side partial `TopN` may stop too early and return wrong rows.

### What changed and how does it work?

This change keeps `TopN` at the root when an `IndexLookUp` would otherwise push
it to the table/probe side and the `ORDER BY` items reference a virtual
generated column from the table-side schema.

It also adds a regression test for issue `#67981` that checks the full
`plan_tree` output and verifies the query result.

Tests:

- `./tools/check/failpoint-go-test.sh pkg/planner/core -run TestVirtualExprPushDown -count=1`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix incorrect results caused by pushing TopN to the IndexLookUp probe side when
ordering by a virtual generated column backed by an expression index.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect results and ordering when TOP N is combined with virtual generated columns and index-lookups; queries now return correct rows and preserve global ordering.

* **Tests**
  * Added regression tests that verify forced-index plans and LIMIT behavior with virtual generated columns, ensuring correct access paths and returned rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->