### PR TITLE
sessionctx/variable: add tidb_max_keys_read

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -2071,6 +2071,11 @@ error = '''
 Unknown background task name '%-.192s'
 '''
 
+["executor:8274"]
+error = '''
+tidb_max_keys_read limit exceeded
+'''
+
 ["expression:1139"]
 error = '''
 Got error '%-.64s' from regexp

--- a/pkg/distsql/context/context.go
+++ b/pkg/distsql/context/context.go
@@ -84,6 +84,10 @@ type DistSQLContext struct {
 	TiKVClientReadTimeout         uint64
 	MaxExecutionTime              uint64
 	MaxKeysRead                   uint64
+	// MaxKeysReadCounter, when non-nil, is the shared atomic accumulator used by
+	// copIterator to enforce a statement-wide max_keys_read budget across all
+	// coprocessor iterators belonging to the same statement. nil when MaxKeysRead == 0.
+	MaxKeysReadCounter *atomic.Uint64
 
 	ReplicaClosestReadThreshold int64
 	ConnectionID                uint64

--- a/pkg/distsql/context/context.go
+++ b/pkg/distsql/context/context.go
@@ -83,6 +83,7 @@ type DistSQLContext struct {
 	RUConsumptionReporter         resourcegroup.ConsumptionReporter
 	TiKVClientReadTimeout         uint64
 	MaxExecutionTime              uint64
+	MaxKeysRead                   uint64
 
 	ReplicaClosestReadThreshold int64
 	ConnectionID                uint64

--- a/pkg/distsql/context/context.go
+++ b/pkg/distsql/context/context.go
@@ -124,5 +124,8 @@ func (dctx *DistSQLContext) Detach() *DistSQLContext {
 	newCtx.KVVars = new(tikvstore.Variables)
 	*newCtx.KVVars = *dctx.KVVars
 	newCtx.KVVars.Killed = &newCtx.SQLKiller.Signal
+	if dctx.MaxKeysReadCounter != nil {
+		newCtx.MaxKeysReadCounter = new(atomic.Uint64)
+	}
 	return &newCtx
 }

--- a/pkg/distsql/context/context_test.go
+++ b/pkg/distsql/context/context_test.go
@@ -89,6 +89,7 @@ func TestContextDetach(t *testing.T) {
 		LoadBasedReplicaReadThreshold: time.Second,
 		TiKVClientReadTimeout:         1,
 		MaxExecutionTime:              1,
+		MaxKeysRead:                   1,
 
 		ReplicaClosestReadThreshold: 1,
 		ConnectionID:                1,

--- a/pkg/distsql/context/context_test.go
+++ b/pkg/distsql/context/context_test.go
@@ -90,6 +90,7 @@ func TestContextDetach(t *testing.T) {
 		TiKVClientReadTimeout:         1,
 		MaxExecutionTime:              1,
 		MaxKeysRead:                   1,
+		MaxKeysReadCounter:            new(atomic.Uint64),
 
 		ReplicaClosestReadThreshold: 1,
 		ConnectionID:                1,

--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -373,6 +373,7 @@ func (builder *RequestBuilder) SetFromSessionVars(dctx *distsqlctx.DistSQLContex
 	builder.Request.RunawayChecker = dctx.RunawayChecker
 	builder.Request.TiKVClientReadTimeout = dctx.TiKVClientReadTimeout
 	builder.Request.MaxExecutionTime = dctx.MaxExecutionTime
+	builder.Request.MaxKeysRead = dctx.MaxKeysRead
 	return builder
 }
 

--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -374,6 +374,7 @@ func (builder *RequestBuilder) SetFromSessionVars(dctx *distsqlctx.DistSQLContex
 	builder.Request.TiKVClientReadTimeout = dctx.TiKVClientReadTimeout
 	builder.Request.MaxExecutionTime = dctx.MaxExecutionTime
 	builder.Request.MaxKeysRead = dctx.MaxKeysRead
+	builder.Request.MaxKeysReadCounter = dctx.MaxKeysReadCounter
 	return builder
 }
 

--- a/pkg/distsql/select_result.go
+++ b/pkg/distsql/select_result.go
@@ -388,6 +388,18 @@ func (r *selectResult) fetchRespWithIntermediateResults(ctx context.Context, int
 		duration := time.Since(startTime)
 		r.fetchDuration += duration
 		if err != nil {
+			// On error paths with a non-nil resultSubset (e.g. ErrMaxKeysReadExceeded),
+			// still merge CopExecDetails so ProcessedKeys reaches StmtCtx.ExecDetails
+			// (feeds tidb_keys_examined and the slow query log). Skip
+			// updateCopRuntimeStats because r.selectResp is not unmarshaled on this
+			// path, so there are no ExecutionSummaries for per-operator stats.
+			if resultSubset != nil {
+				if hasStats, ok := resultSubset.(CopRuntimeStats); ok {
+					if copStats := hasStats.GetCopRuntimeStats(); copStats != nil {
+						r.ctx.ExecDetails.MergeCopExecDetails(&copStats.CopExecDetails, duration)
+					}
+				}
+			}
 			return errors.Trace(err)
 		}
 		if r.selectResp != nil {

--- a/pkg/errno/errcode.go
+++ b/pkg/errno/errcode.go
@@ -1171,6 +1171,7 @@ const (
 	ErrStorageClassInvalidSpec                  = 8271
 	ErrModifyColumnReferencedByPartialCondition = 8272
 	ErrCheckPartialIndexWithoutFastCheck        = 8273
+	ErrMaxKeysReadExceeded                      = 8274
 
 	// [8800, 8900) are reserved for a downstream fork
 

--- a/pkg/errno/errname.go
+++ b/pkg/errno/errname.go
@@ -1168,6 +1168,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrStorageClassInvalidSpec:                  mysql.Message("Invalid storage class: %s", nil),
 	ErrModifyColumnReferencedByPartialCondition: mysql.Message("Cannot drop, change or modify column '%s': it is referenced in partial index '%s'", nil),
 	ErrCheckPartialIndexWithoutFastCheck:        mysql.Message("Validation of partial indexes requires tidb_enable_fast_table_check=ON", nil),
+	ErrMaxKeysReadExceeded:                      mysql.Message("tidb_max_keys_read limit exceeded", nil),
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout:      mysql.Message("PD server timeout: %s", nil),

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1600,11 +1600,14 @@ func (a *ExecStmt) FinishExecuteStmt(txnTS uint64, err error, hasMoreResults boo
 	if execDetail.CommitDetail != nil && execDetail.CommitDetail.WriteSize > 0 {
 		a.Ctx.GetTxnWriteThroughputSLI().AddTxnWriteSize(execDetail.CommitDetail.WriteSize, execDetail.CommitDetail.WriteKeys)
 	}
-	if execDetail.ScanDetail != nil && sessVars.StmtCtx.AffectedRows() > 0 {
+	if execDetail.ScanDetail != nil {
 		processedKeys := atomic.LoadInt64(&execDetail.ScanDetail.ProcessedKeys)
 		if processedKeys > 0 {
-			// Only record the read keys in write statement which affect row more than 0.
-			a.Ctx.GetTxnWriteThroughputSLI().AddReadKeys(processedKeys)
+			if sessVars.StmtCtx.AffectedRows() > 0 {
+				// Only record the read keys in write statement which affect row more than 0.
+				a.Ctx.GetTxnWriteThroughputSLI().AddReadKeys(processedKeys)
+			}
+			sessVars.KeysExamined += uint64(processedKeys)
 		}
 	}
 	succ := err == nil

--- a/pkg/executor/executor_failpoint_test.go
+++ b/pkg/executor/executor_failpoint_test.go
@@ -628,12 +628,12 @@ func TestTxnWriteThroughputSLI(t *testing.T) {
 	mustExec("insert into t select b, a from t")
 	require.True(t, writeSLI.IsInvalid())
 	require.True(t, writeSLI.IsSmallTxn())
-	require.Equal(t, "invalid: true, affectRow: 2, writeSize: 58, readKeys: 0, writeKeys: 2, writeTime: 1s", tk.Session().GetTxnWriteThroughputSLI().String())
+	require.Equal(t, "invalid: true, affectRow: 2, writeSize: 58, readKeys: 2, writeKeys: 2, writeTime: 1s", tk.Session().GetTxnWriteThroughputSLI().String())
 	tk.Session().GetTxnWriteThroughputSLI().Reset()
 
 	// Test for delete
 	mustExec("delete from t")
-	require.Equal(t, "invalid: false, affectRow: 4, writeSize: 76, readKeys: 0, writeKeys: 4, writeTime: 1s", tk.Session().GetTxnWriteThroughputSLI().String())
+	require.Equal(t, "invalid: false, affectRow: 4, writeSize: 76, readKeys: 4, writeKeys: 4, writeTime: 1s", tk.Session().GetTxnWriteThroughputSLI().String())
 	tk.Session().GetTxnWriteThroughputSLI().Reset()
 
 	// Test insert not in small txn

--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -3060,6 +3060,8 @@ func (e *SimpleExec) executeFlush(ctx context.Context, s *ast.FlushStmt) error {
 				return err
 			}
 		}
+	case ast.FlushStatus:
+		e.Ctx().GetSessionVars().KeysExamined = 0
 	case ast.FlushClientErrorsSummary:
 		errno.FlushStats()
 	case ast.FlushStatsDelta:

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -648,6 +648,9 @@ type Request struct {
 	TiKVClientReadTimeout uint64
 	// MaxExecutionTime is the timeout of the whole query execution
 	MaxExecutionTime uint64
+	// MaxKeysRead is the global limit on storage engine keys examined across all
+	// coprocessor tasks for this request (0 = unlimited).
+	MaxKeysRead uint64
 
 	RunawayChecker resourcegroup.RunawayChecker
 

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -651,6 +651,10 @@ type Request struct {
 	// MaxKeysRead is the global limit on storage engine keys examined across all
 	// coprocessor tasks for this request (0 = unlimited).
 	MaxKeysRead uint64
+	// MaxKeysReadCounter, when non-nil, is the shared atomic accumulator used by
+	// copIterator to enforce a statement-wide max_keys_read budget across
+	// multiple coprocessor iterators belonging to the same statement.
+	MaxKeysReadCounter *atomic.Uint64
 
 	RunawayChecker resourcegroup.RunawayChecker
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -147,6 +147,7 @@ import (
 	"github.com/tikv/client-go/v2/trace"
 	"github.com/tikv/client-go/v2/txnkv/transaction"
 	tikvutil "github.com/tikv/client-go/v2/util"
+	gouberatomic "go.uber.org/atomic"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -3515,6 +3516,12 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 			TiKVClientReadTimeout:         vars.GetTiKVClientReadTimeout(),
 			MaxExecutionTime:              vars.GetMaxExecutionTime(),
 			MaxKeysRead:                   vars.GetMaxKeysRead(),
+			MaxKeysReadCounter: func() *gouberatomic.Uint64 {
+				if vars.GetMaxKeysRead() > 0 {
+					return new(gouberatomic.Uint64)
+				}
+				return nil
+			}(),
 
 			ReplicaClosestReadThreshold: vars.ReplicaClosestReadThreshold,
 			ConnectionID:                vars.ConnectionID,

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3514,6 +3514,7 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 			RUConsumptionReporter:         ruConsumptionReporter,
 			TiKVClientReadTimeout:         vars.GetTiKVClientReadTimeout(),
 			MaxExecutionTime:              vars.GetMaxExecutionTime(),
+			MaxKeysRead:                   vars.GetMaxKeysRead(),
 
 			ReplicaClosestReadThreshold: vars.ReplicaClosestReadThreshold,
 			ConnectionID:                vars.ConnectionID,

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3467,7 +3467,7 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 				ruConsumptionReporter = rgCtl
 			}
 		}
-		return &distsqlctx.DistSQLContext{
+		ret := &distsqlctx.DistSQLContext{
 			WarnHandler:     sc.WarnHandler,
 			InRestrictedSQL: sc.InRestrictedSQL,
 			Client:          s.GetClient(),
@@ -3516,12 +3516,6 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 			TiKVClientReadTimeout:         vars.GetTiKVClientReadTimeout(),
 			MaxExecutionTime:              vars.GetMaxExecutionTime(),
 			MaxKeysRead:                   vars.GetMaxKeysRead(),
-			MaxKeysReadCounter: func() *gouberatomic.Uint64 {
-				if vars.GetMaxKeysRead() > 0 {
-					return new(gouberatomic.Uint64)
-				}
-				return nil
-			}(),
 
 			ReplicaClosestReadThreshold: vars.ReplicaClosestReadThreshold,
 			ConnectionID:                vars.ConnectionID,
@@ -3529,6 +3523,10 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 
 			ExecDetails: &sc.SyncExecDetails,
 		}
+		if ret.MaxKeysRead > 0 {
+			ret.MaxKeysReadCounter = new(gouberatomic.Uint64)
+		}
+		return ret
 	})
 
 	// Check if the runaway checker is updated. This is to avoid that evaluating a non-correlated subquery

--- a/pkg/sessionctx/vardef/sysvar.go
+++ b/pkg/sessionctx/vardef/sysvar.go
@@ -308,6 +308,8 @@ const (
 	TxnIsolationOneShot = "tx_isolation_one_shot"
 	// MaxExecutionTime is the name of the 'max_execution_time' system variable.
 	MaxExecutionTime = "max_execution_time"
+	// TiDBMaxKeysRead is the name of the 'tidb_max_keys_read' system variable.
+	TiDBMaxKeysRead = "tidb_max_keys_read"
 	// TiKVClientReadTimeout is the name of the 'tikv_client_read_timeout' system variable.
 	TiKVClientReadTimeout = "tikv_client_read_timeout"
 	// TiDBLoadBindingTimeout is the name of the 'tidb_load_binding_timeout' system variable.

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1302,6 +1302,14 @@ type SessionVars struct {
 	// See https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_execution_time
 	MaxExecutionTime uint64
 
+	// MaxKeysRead is the maximum number of storage engine keys that a SELECT statement
+	// may examine. 0 means unlimited. Only applies to SELECT statements.
+	MaxKeysRead uint64
+
+	// KeysExamined is the cumulative number of storage engine keys examined across all
+	// statements (SELECT, UPDATE, DELETE, etc.) in this session. Reset by FLUSH STATUS.
+	KeysExamined uint64
+
 	// LoadBindingTimeout is the timeout for loading the bind info.
 	LoadBindingTimeout uint64
 
@@ -3730,6 +3738,15 @@ func (s *SessionVars) GetMaxExecutionTime() uint64 {
 // GetTiKVClientReadTimeout returns readonly kv request timeout, prefer query hint over session variable
 func (s *SessionVars) GetTiKVClientReadTimeout() uint64 {
 	return s.TiKVClientReadTimeout
+}
+
+// GetMaxKeysRead returns the max keys read limit for SELECT statements.
+// Returns 0 (unlimited) when not in a SELECT statement.
+func (s *SessionVars) GetMaxKeysRead() uint64 {
+	if !s.StmtCtx.InSelectStmt {
+		return 0
+	}
+	return s.MaxKeysRead
 }
 
 // SetDiskFullOpt sets the session variable DiskFullOpt

--- a/pkg/sessionctx/variable/setvar_affect.go
+++ b/pkg/sessionctx/variable/setvar_affect.go
@@ -144,6 +144,7 @@ var isHintUpdatableVerified = map[string]struct{}{
 	"cte_max_recursion_depth": {},
 	"sql_mode":                {},
 	"max_execution_time":      {},
+	"tidb_max_keys_read":      {},
 }
 
 func setHintUpdatable(vars []*SysVar) {

--- a/pkg/sessionctx/variable/statusvar.go
+++ b/pkg/sessionctx/variable/statusvar.go
@@ -129,7 +129,7 @@ var defaultStatus = map[string]*StatusVal{
 	"Ssl_version":     {vardef.ScopeGlobal | vardef.ScopeSession, ""},
 	"Performance_schema_session_connect_attrs_longest_seen": {vardef.ScopeGlobal, int64(0)},
 	"Performance_schema_session_connect_attrs_lost":         {vardef.ScopeGlobal, int64(0)},
-	"tidb_keys_examined":                                    {vardef.ScopeSession, uint64(0)},
+	"tidb_keys_examined": {vardef.ScopeSession, uint64(0)},
 }
 
 type defaultStatusStat struct {

--- a/pkg/sessionctx/variable/statusvar.go
+++ b/pkg/sessionctx/variable/statusvar.go
@@ -129,6 +129,7 @@ var defaultStatus = map[string]*StatusVal{
 	"Ssl_version":     {vardef.ScopeGlobal | vardef.ScopeSession, ""},
 	"Performance_schema_session_connect_attrs_longest_seen": {vardef.ScopeGlobal, int64(0)},
 	"Performance_schema_session_connect_attrs_lost":         {vardef.ScopeGlobal, int64(0)},
+	"tidb_keys_examined":                                    {vardef.ScopeSession, uint64(0)},
 }
 
 type defaultStatusStat struct {
@@ -150,12 +151,15 @@ func (s defaultStatusStat) Stats(vars *SessionVars) (map[string]any, error) {
 	statusVars["Performance_schema_session_connect_attrs_lost"] = vardef.ConnectAttrsLost.Load()
 
 	// `vars` may be nil in unit tests.
-	if vars != nil && vars.TLSConnectionState != nil {
-		statusVars["Ssl_cipher"] = tlsutil.CipherSuiteName(vars.TLSConnectionState.CipherSuite)
-		statusVars["Ssl_cipher_list"] = tlsSupportedCiphers
-		// tls.VerifyClientCertIfGiven == SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE
-		statusVars["Ssl_verify_mode"] = 0x01 | 0x04
-		statusVars["Ssl_version"] = tlsutil.VersionName(vars.TLSConnectionState.Version)
+	if vars != nil {
+		statusVars["tidb_keys_examined"] = vars.KeysExamined
+		if vars.TLSConnectionState != nil {
+			statusVars["Ssl_cipher"] = tlsutil.CipherSuiteName(vars.TLSConnectionState.CipherSuite)
+			statusVars["Ssl_cipher_list"] = tlsSupportedCiphers
+			// tls.VerifyClientCertIfGiven == SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE
+			statusVars["Ssl_verify_mode"] = 0x01 | 0x04
+			statusVars["Ssl_version"] = tlsutil.VersionName(vars.TLSConnectionState.Version)
+		}
 	}
 
 	return statusVars, nil

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1931,6 +1931,18 @@ var defaultSysVars = []*SysVar{
 		}},
 	{
 		Scope:                   vardef.ScopeGlobal | vardef.ScopeSession,
+		Name:                    vardef.TiDBMaxKeysRead,
+		Value:                   "0",
+		Type:                    vardef.TypeUnsigned,
+		MinValue:                0,
+		MaxValue:                math.MaxUint64,
+		IsHintUpdatableVerified: true,
+		SetSession: func(s *SessionVars, val string) error {
+			s.MaxKeysRead = TidbOptUint64(val, 0)
+			return nil
+		}},
+	{
+		Scope:                   vardef.ScopeGlobal | vardef.ScopeSession,
 		Name:                    vardef.TiKVClientReadTimeout,
 		Value:                   "0",
 		Type:                    vardef.TypeUnsigned,

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -135,6 +135,51 @@ func TestMaxExecutionTime(t *testing.T) {
 	require.Equal(t, uint64(99999), vars.MaxExecutionTime)
 }
 
+func TestTiDBMaxKeysRead(t *testing.T) {
+	sv := GetSysVar(vardef.TiDBMaxKeysRead)
+	require.NotNil(t, sv)
+	vars := NewSessionVars(nil)
+
+	// Negative values should be clipped to 0.
+	val, err := sv.Validate(vars, "-1", vardef.ScopeSession)
+	require.NoError(t, err)
+	require.Equal(t, "0", val)
+
+	// Zero is valid (unlimited).
+	val, err = sv.Validate(vars, "0", vardef.ScopeSession)
+	require.NoError(t, err)
+	require.Equal(t, "0", val)
+
+	// Positive values are accepted.
+	val, err = sv.Validate(vars, "1000", vardef.ScopeSession)
+	require.NoError(t, err)
+	require.Equal(t, "1000", val)
+
+	// SetSession sets MaxKeysRead.
+	require.Nil(t, sv.SetSessionFromHook(vars, "500"))
+	require.Equal(t, uint64(500), vars.MaxKeysRead)
+
+	// IsHintUpdatableVerified must be true.
+	require.True(t, sv.IsHintUpdatableVerified)
+}
+
+func TestGetMaxKeysRead(t *testing.T) {
+	vars := NewSessionVars(nil)
+	vars.MaxKeysRead = 100
+
+	// Outside SELECT statement: returns 0.
+	vars.StmtCtx.InSelectStmt = false
+	require.Equal(t, uint64(0), vars.GetMaxKeysRead())
+
+	// Inside SELECT statement: returns configured value.
+	vars.StmtCtx.InSelectStmt = true
+	require.Equal(t, uint64(100), vars.GetMaxKeysRead())
+
+	// Zero means unlimited regardless of context.
+	vars.MaxKeysRead = 0
+	require.Equal(t, uint64(0), vars.GetMaxKeysRead())
+}
+
 func TestTiFlashMaxBytes(t *testing.T) {
 	varNames := []string{vardef.TiDBMaxBytesBeforeTiFlashExternalJoin, vardef.TiDBMaxBytesBeforeTiFlashExternalGroupBy, vardef.TiDBMaxBytesBeforeTiFlashExternalSort}
 	for index, varName := range varNames {

--- a/pkg/store/copr/BUILD.bazel
+++ b/pkg/store/copr/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/store/driver/error",
         "//pkg/store/driver/options",
         "//pkg/util",
+        "//pkg/util/dbterror/exeerrors",
         "//pkg/util/execdetails",
         "//pkg/util/intest",
         "//pkg/util/logutil",

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -212,6 +212,7 @@ func (c *CopClient) BuildCopIterator(ctx context.Context, req *kv.Request, vars 
 		buildTaskElapsed: *buildOpt.elapsed,
 		runawayChecker:   req.RunawayChecker,
 		maxKeysRead:      req.MaxKeysRead,
+		keysRead:         pickKeysReadCounter(req),
 	}
 	// Pipelined-dml can flush locks when it is still reading.
 	// The coprocessor of the txn should not be blocked by itself.
@@ -1003,8 +1004,21 @@ type copIterator struct {
 	runawayChecker resourcegroup.RunawayChecker
 	stats          *copIteratorRuntimeStats
 
-	maxKeysRead uint64        // global limit from kv.Request (0 = unlimited)
-	keysRead    atomic.Uint64 // cumulative storage engine keys read across all completed tasks
+	maxKeysRead uint64          // global limit from kv.Request (0 = unlimited)
+	keysRead    *atomic2.Uint64 // cumulative storage engine keys read across all completed tasks; may be shared across copIterators in the same statement
+}
+
+// pickKeysReadCounter returns the counter used by a copIterator for cumulative
+// tracking of scanned keys. When the request carries a shared counter (set via
+// DistSQLContext.MaxKeysReadCounter), all coprocessor iterators in the same
+// statement accumulate into it so that max_keys_read is enforced as a
+// statement-wide budget rather than per-iterator. Falls back to a fresh
+// per-iterator counter for internal callers that don't plumb the shared one.
+func pickKeysReadCounter(req *kv.Request) *atomic2.Uint64 {
+	if req.MaxKeysReadCounter != nil {
+		return req.MaxKeysReadCounter
+	}
+	return new(atomic2.Uint64)
 }
 
 type liteCopIteratorWorker struct {
@@ -1036,8 +1050,8 @@ type copIteratorWorker struct {
 	storeBatchedFallbackNum *atomic.Uint64
 	stats                   *copIteratorRuntimeStats
 
-	maxKeysRead uint64         // global limit (0 = unlimited)
-	keysRead    *atomic.Uint64 // shared with copIterator for cumulative tracking
+	maxKeysRead uint64          // global limit (0 = unlimited)
+	keysRead    *atomic2.Uint64 // shared with copIterator for cumulative tracking
 }
 
 // copIteratorTaskSender sends tasks to taskCh then wait for the workers to exit.
@@ -1233,7 +1247,7 @@ func newCopIteratorWorker(it *copIterator, taskCh <-chan *copTask) *copIteratorW
 		storeBatchedFallbackNum: &it.storeBatchedFallbackNum,
 		stats:                   it.stats,
 		maxKeysRead:             it.maxKeysRead,
-		keysRead:                &it.keysRead,
+		keysRead:                it.keysRead,
 	}
 }
 

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1485,8 +1485,8 @@ func (it *copIterator) Next(ctx context.Context) (kv.ResultSubset, error) {
 	// updated remaining budget at handleTaskOnce dispatch via keysRead.Load().
 	if it.maxKeysRead > 0 {
 		if resp.detail != nil && resp.detail.ScanDetail != nil {
-			if scanned := uint64(resp.detail.ScanDetail.ProcessedKeys); scanned > 0 {
-				it.keysRead.Add(scanned)
+			if pk := resp.detail.ScanDetail.ProcessedKeys; pk > 0 {
+				it.keysRead.Add(uint64(pk))
 			}
 		}
 		if it.keysRead.Load() > it.maxKeysRead {

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -50,6 +50,7 @@ import (
 	derr "github.com/pingcap/tidb/pkg/store/driver/error"
 	"github.com/pingcap/tidb/pkg/store/driver/options"
 	util2 "github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/memory"
@@ -210,6 +211,7 @@ func (c *CopClient) BuildCopIterator(ctx context.Context, req *kv.Request, vars 
 		rpcCancel:        tikv.NewRPCanceller(),
 		buildTaskElapsed: *buildOpt.elapsed,
 		runawayChecker:   req.RunawayChecker,
+		maxKeysRead:      req.MaxKeysRead,
 	}
 	// Pipelined-dml can flush locks when it is still reading.
 	// The coprocessor of the txn should not be blocked by itself.
@@ -1000,6 +1002,9 @@ type copIterator struct {
 
 	runawayChecker resourcegroup.RunawayChecker
 	stats          *copIteratorRuntimeStats
+
+	maxKeysRead uint64        // global limit from kv.Request (0 = unlimited)
+	keysRead    atomic.Uint64 // cumulative storage engine keys read across all completed tasks
 }
 
 type liteCopIteratorWorker struct {
@@ -1030,6 +1035,9 @@ type copIteratorWorker struct {
 	storeBatchedNum         *atomic.Uint64
 	storeBatchedFallbackNum *atomic.Uint64
 	stats                   *copIteratorRuntimeStats
+
+	maxKeysRead uint64         // global limit (0 = unlimited)
+	keysRead    *atomic.Uint64 // shared with copIterator for cumulative tracking
 }
 
 // copIteratorTaskSender sends tasks to taskCh then wait for the workers to exit.
@@ -1224,6 +1232,8 @@ func newCopIteratorWorker(it *copIterator, taskCh <-chan *copTask) *copIteratorW
 		storeBatchedNum:         &it.storeBatchedNum,
 		storeBatchedFallbackNum: &it.storeBatchedFallbackNum,
 		stats:                   it.stats,
+		maxKeysRead:             it.maxKeysRead,
+		keysRead:                &it.keysRead,
 	}
 }
 
@@ -1455,6 +1465,26 @@ func (it *copIterator) Next(ctx context.Context) (kv.ResultSubset, error) {
 		return nil, errors.Trace(resp.err)
 	}
 
+	// Accumulate keys read and enforce the tidb_max_keys_read cap. Both the lite
+	// single-task path and the concurrent worker path funnel responses through
+	// here, so doing it here covers both uniformly. Sequential tasks pick up the
+	// updated remaining budget at handleTaskOnce dispatch via keysRead.Load().
+	if it.maxKeysRead > 0 {
+		if resp.detail != nil && resp.detail.ScanDetail != nil {
+			if scanned := uint64(resp.detail.ScanDetail.ProcessedKeys); scanned > 0 {
+				it.keysRead.Add(scanned)
+			}
+		}
+		if it.keysRead.Load() > it.maxKeysRead {
+			if atomic.CompareAndSwapUint32(&it.closed, 0, 1) {
+				close(it.finishCh)
+			}
+			// Return resp (non-nil) so the caller can still merge CopRuntimeStats
+			// into StmtCtx.ExecDetails, which flows into tidb_keys_examined.
+			return resp, exeerrors.ErrMaxKeysReadExceeded
+		}
+	}
+
 	err := it.store.CheckVisibility(it.req.StartTs)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1655,6 +1685,17 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 		task.pagingTaskIdx = atomic.AddUint32(worker.pagingTaskIdx, 1)
 	}
 
+	// All concurrent tasks get the full remaining budget; the cumulative check
+	// in Next() enforces the global limit.
+	var taskMaxKeysRead uint64
+	if worker.maxKeysRead > 0 {
+		scanned := worker.keysRead.Load()
+		if scanned >= worker.maxKeysRead {
+			return nil, exeerrors.ErrMaxKeysReadExceeded
+		}
+		taskMaxKeysRead = worker.maxKeysRead - scanned
+	}
+
 	copReq := coprocessor.Request{
 		Tp:              worker.req.Tp,
 		StartTs:         worker.req.StartTs,
@@ -1662,6 +1703,7 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 		Ranges:          task.ranges.ToPBRanges(),
 		SchemaVer:       worker.req.SchemaVar,
 		PagingSize:      task.pagingSize,
+		MaxKeysRead:     taskMaxKeysRead,
 		Tasks:           task.ToPBBatchTasks(),
 		ConnectionId:    worker.req.ConnID,
 		ConnectionAlias: worker.req.ConnAlias,

--- a/pkg/store/mockstore/unistore/cophandler/cop_handler.go
+++ b/pkg/store/mockstore/unistore/cophandler/cop_handler.go
@@ -632,11 +632,6 @@ func genRespWithMPPExec(chunks []tipb.Chunk, intermediateOutput []*tipb.Intermed
 	resp.ExecDetails = &kvrpcpb.ExecDetails{
 		TimeDetail: &kvrpcpb.TimeDetail{ProcessWallTimeMs: uint64(dur / time.Millisecond)},
 	}
-	// Sum rows scanned by leaf scan executors so TiDB-side features that rely on
-	// ScanDetail.ProcessedKeys (e.g. tidb_max_keys_read, tidb_keys_examined) have
-	// realistic numbers under unistore. Real TiKV populates this from its MVCC
-	// layer; unistore has no MVCC, so we approximate with the number of rows the
-	// scan executors pulled from storage.
 	var processedVersions uint64
 	for _, e := range mppExecs {
 		switch s := e.(type) {

--- a/pkg/store/mockstore/unistore/cophandler/cop_handler.go
+++ b/pkg/store/mockstore/unistore/cophandler/cop_handler.go
@@ -632,8 +632,23 @@ func genRespWithMPPExec(chunks []tipb.Chunk, intermediateOutput []*tipb.Intermed
 	resp.ExecDetails = &kvrpcpb.ExecDetails{
 		TimeDetail: &kvrpcpb.TimeDetail{ProcessWallTimeMs: uint64(dur / time.Millisecond)},
 	}
+	// Sum rows scanned by leaf scan executors so TiDB-side features that rely on
+	// ScanDetail.ProcessedKeys (e.g. tidb_max_keys_read, tidb_keys_examined) have
+	// realistic numbers under unistore. Real TiKV populates this from its MVCC
+	// layer; unistore has no MVCC, so we approximate with the number of rows the
+	// scan executors pulled from storage.
+	var processedVersions uint64
+	for _, e := range mppExecs {
+		switch s := e.(type) {
+		case *tableScanExec:
+			processedVersions += uint64(s.rowCnt)
+		case *indexScanExec:
+			processedVersions += uint64(s.rowCnt)
+		}
+	}
 	resp.ExecDetailsV2 = &kvrpcpb.ExecDetailsV2{
-		TimeDetail: resp.ExecDetails.TimeDetail,
+		TimeDetail:   resp.ExecDetails.TimeDetail,
+		ScanDetailV2: &kvrpcpb.ScanDetailV2{ProcessedVersions: processedVersions},
 	}
 	data, mErr := proto.Marshal(selResp)
 	if mErr != nil {

--- a/pkg/util/dbterror/exeerrors/errors.go
+++ b/pkg/util/dbterror/exeerrors/errors.go
@@ -103,4 +103,6 @@ var (
 	ErrLoadDataInvalidOperation       = dbterror.ClassExecutor.NewStd(mysql.ErrLoadDataInvalidOperation)
 	ErrLoadDataLocalUnsupportedOption = dbterror.ClassExecutor.NewStd(mysql.ErrLoadDataLocalUnsupportedOption)
 	ErrLoadDataPreCheckFailed         = dbterror.ClassExecutor.NewStd(mysql.ErrLoadDataPreCheckFailed)
+
+	ErrMaxKeysReadExceeded = dbterror.ClassExecutor.NewStd(mysql.ErrMaxKeysReadExceeded)
 )

--- a/tests/integrationtest/r/executor/max_keys_read.result
+++ b/tests/integrationtest/r/executor/max_keys_read.result
@@ -1,0 +1,74 @@
+select @@session.tidb_max_keys_read;
+@@session.tidb_max_keys_read
+0
+select @@global.tidb_max_keys_read;
+@@global.tidb_max_keys_read
+0
+set @@session.tidb_max_keys_read = 100;
+select @@session.tidb_max_keys_read;
+@@session.tidb_max_keys_read
+100
+set @@global.tidb_max_keys_read = 200;
+select @@global.tidb_max_keys_read;
+@@global.tidb_max_keys_read
+200
+select @@session.tidb_max_keys_read;
+@@session.tidb_max_keys_read
+100
+set @@session.tidb_max_keys_read = 0;
+select @@session.tidb_max_keys_read;
+@@session.tidb_max_keys_read
+0
+set @@global.tidb_max_keys_read = 0;
+select @@global.tidb_max_keys_read;
+@@global.tidb_max_keys_read
+0
+set @@session.tidb_max_keys_read = -1;
+select @@session.tidb_max_keys_read;
+@@session.tidb_max_keys_read
+0
+select /*+ SET_VAR(tidb_max_keys_read=999) */ @@tidb_max_keys_read;
+@@tidb_max_keys_read
+999
+select @@session.tidb_max_keys_read;
+@@session.tidb_max_keys_read
+0
+set @@session.tidb_max_keys_read = 50;
+select /*+ SET_VAR(tidb_max_keys_read=0) */ @@tidb_max_keys_read;
+@@tidb_max_keys_read
+0
+select @@session.tidb_max_keys_read;
+@@session.tidb_max_keys_read
+50
+set @@session.tidb_max_keys_read = 0;
+drop table if exists t_mrs;
+create table t_mrs (id int primary key auto_increment, val int);
+insert into t_mrs (val) values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
+insert into t_mrs (val) values (11),(12),(13),(14),(15),(16),(17),(18),(19),(20);
+set @@session.tidb_max_keys_read = 100;
+select count(*) from t_mrs;
+count(*)
+20
+select /*+ SET_VAR(tidb_max_keys_read=2) */ * from t_mrs;
+Error 8274 (HY000): tidb_max_keys_read limit exceeded
+set @@session.tidb_max_keys_read = 2;
+select /*+ SET_VAR(tidb_max_keys_read=0) */ count(*) from t_mrs;
+count(*)
+20
+set @@session.tidb_max_keys_read = 100;
+select /*+ SET_VAR(tidb_max_keys_read=5) */ * from t_mrs;
+Error 8274 (HY000): tidb_max_keys_read limit exceeded
+set @@session.tidb_max_keys_read = 1;
+insert into t_mrs (val) values (21);
+update t_mrs set val = val + 100 where id = 1;
+delete from t_mrs where id = 21;
+set @@session.tidb_max_keys_read = 0;
+select /*+ SET_VAR(tidb_max_keys_read=5) */ count(*) from t_mrs;
+Error 8274 (HY000): tidb_max_keys_read limit exceeded
+flush status;
+show status like 'tidb_keys_examined';
+Variable_name	Value
+tidb_keys_examined	0
+set @@session.tidb_max_keys_read = 0;
+set @@global.tidb_max_keys_read = 0;
+drop table t_mrs;

--- a/tests/integrationtest/r/executor/max_keys_read.result
+++ b/tests/integrationtest/r/executor/max_keys_read.result
@@ -59,8 +59,9 @@ set @@session.tidb_max_keys_read = 100;
 select /*+ SET_VAR(tidb_max_keys_read=5) */ * from t_mrs;
 Error 8274 (HY000): tidb_max_keys_read limit exceeded
 set @@session.tidb_max_keys_read = 1;
+update t_mrs set val = val + 1;
+update t_mrs set val = val - 1;
 insert into t_mrs (val) values (21);
-update t_mrs set val = val + 100 where id = 1;
 delete from t_mrs where id = 21;
 set @@session.tidb_max_keys_read = 0;
 select /*+ SET_VAR(tidb_max_keys_read=5) */ count(*) from t_mrs;

--- a/tests/integrationtest/r/executor/max_keys_read.result
+++ b/tests/integrationtest/r/executor/max_keys_read.result
@@ -42,9 +42,9 @@ select @@session.tidb_max_keys_read;
 50
 set @@session.tidb_max_keys_read = 0;
 drop table if exists t_mrs;
-create table t_mrs (id int primary key auto_increment, val int);
-insert into t_mrs (val) values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
-insert into t_mrs (val) values (11),(12),(13),(14),(15),(16),(17),(18),(19),(20);
+create table t_mrs (id int primary key auto_increment, val int, extra int);
+insert into t_mrs (val, extra) values (1, 100),(2, 100),(3, 100),(4, 100),(5, 100),(6, 100),(7, 100),(8, 100),(9, 100),(10, 100);
+insert into t_mrs (val, extra) values (11, 100),(12, 100),(13, 100),(14, 100),(15, 100),(16, 100),(17, 100),(18, 100),(19, 100),(20, 100);
 set @@session.tidb_max_keys_read = 100;
 select count(*) from t_mrs;
 count(*)
@@ -58,6 +58,12 @@ count(*)
 set @@session.tidb_max_keys_read = 100;
 select /*+ SET_VAR(tidb_max_keys_read=5) */ * from t_mrs;
 Error 8274 (HY000): tidb_max_keys_read limit exceeded
+create index idx_val on t_mrs (val);
+select /*+ SET_VAR(tidb_max_keys_read=25), USE_INDEX(t_mrs, idx_val) */ extra from t_mrs where val >= 1;
+Error 8274 (HY000): tidb_max_keys_read limit exceeded
+select /*+ SET_VAR(tidb_max_keys_read=50), USE_INDEX(t_mrs, idx_val) */ sum(extra) from t_mrs where val >= 1;
+sum(extra)
+2000
 set @@session.tidb_max_keys_read = 1;
 update t_mrs set val = val + 1;
 update t_mrs set val = val - 1;

--- a/tests/integrationtest/r/executor/max_keys_read.result
+++ b/tests/integrationtest/r/executor/max_keys_read.result
@@ -66,6 +66,19 @@ set @@session.tidb_max_keys_read = 0;
 select /*+ SET_VAR(tidb_max_keys_read=5) */ count(*) from t_mrs;
 Error 8274 (HY000): tidb_max_keys_read limit exceeded
 flush status;
+select count(*) from t_mrs;
+count(*)
+20
+show status like 'tidb_keys_examined';
+Variable_name	Value
+tidb_keys_examined	20
+select count(*) from t_mrs;
+count(*)
+20
+show status like 'tidb_keys_examined';
+Variable_name	Value
+tidb_keys_examined	40
+flush status;
 show status like 'tidb_keys_examined';
 Variable_name	Value
 tidb_keys_examined	0

--- a/tests/integrationtest/t/executor/max_keys_read.test
+++ b/tests/integrationtest/t/executor/max_keys_read.test
@@ -66,7 +66,12 @@ set @@session.tidb_max_keys_read = 0;
 -- error 8274
 select /*+ SET_VAR(tidb_max_keys_read=5) */ count(*) from t_mrs;
 
-# tidb_keys_examined is a session-scope status variable reset by FLUSH STATUS.
+# tidb_keys_examined accumulates examined keys across statements; FLUSH STATUS resets it.
+flush status;
+select count(*) from t_mrs;
+show status like 'tidb_keys_examined';
+select count(*) from t_mrs;
+show status like 'tidb_keys_examined';
 flush status;
 show status like 'tidb_keys_examined';
 

--- a/tests/integrationtest/t/executor/max_keys_read.test
+++ b/tests/integrationtest/t/executor/max_keys_read.test
@@ -34,9 +34,9 @@ select @@session.tidb_max_keys_read;
 set @@session.tidb_max_keys_read = 0;
 
 drop table if exists t_mrs;
-create table t_mrs (id int primary key auto_increment, val int);
-insert into t_mrs (val) values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
-insert into t_mrs (val) values (11),(12),(13),(14),(15),(16),(17),(18),(19),(20);
+create table t_mrs (id int primary key auto_increment, val int, extra int);
+insert into t_mrs (val, extra) values (1, 100),(2, 100),(3, 100),(4, 100),(5, 100),(6, 100),(7, 100),(8, 100),(9, 100),(10, 100);
+insert into t_mrs (val, extra) values (11, 100),(12, 100),(13, 100),(14, 100),(15, 100),(16, 100),(17, 100),(18, 100),(19, 100),(20, 100);
 
 # Under limit: 20 rows, limit=100 — succeeds.
 set @@session.tidb_max_keys_read = 100;
@@ -54,6 +54,23 @@ select /*+ SET_VAR(tidb_max_keys_read=0) */ count(*) from t_mrs;
 set @@session.tidb_max_keys_read = 100;
 -- error 8274
 select /*+ SET_VAR(tidb_max_keys_read=5) */ * from t_mrs;
+
+# IndexLookUp splits into two cop iterators (index side + table side).
+# tidb_max_keys_read must be a statement-wide budget, not per-iterator —
+# otherwise a regression in the shared-counter plumbing would let
+# IndexLookUp consume up to 2x the configured limit silently.
+create index idx_val on t_mrs (val);
+
+# Project `extra` (not covered by idx_val) so the plan must do a table lookup.
+# 20 rows total: index scan reads 20, table lookup reads 20 (= 40 total).
+# Shared-counter (correct): 40 > 25 → errors at 8274.
+# Per-iterator (regression): each side 20 < 25 → would pass silently.
+-- error 8274
+select /*+ SET_VAR(tidb_max_keys_read=25), USE_INDEX(t_mrs, idx_val) */ extra from t_mrs where val >= 1;
+
+# Sanity: limit comfortably above combined total — IndexLookUp succeeds.
+# sum(extra) forces a table lookup (count(*) / count(id) would be index-only).
+select /*+ SET_VAR(tidb_max_keys_read=50), USE_INDEX(t_mrs, idx_val) */ sum(extra) from t_mrs where val >= 1;
 
 # DML statements are exempt from tidb_max_keys_read.
 # Use a full-table UPDATE under limit=1 to prove exemption: if DML were

--- a/tests/integrationtest/t/executor/max_keys_read.test
+++ b/tests/integrationtest/t/executor/max_keys_read.test
@@ -1,0 +1,76 @@
+# tidb_max_keys_read — session variable and end-to-end cap enforcement.
+
+# Default value is 0 (unlimited).
+select @@session.tidb_max_keys_read;
+select @@global.tidb_max_keys_read;
+
+# Set session value.
+set @@session.tidb_max_keys_read = 100;
+select @@session.tidb_max_keys_read;
+
+# Global set does not affect already-open sessions.
+set @@global.tidb_max_keys_read = 200;
+select @@global.tidb_max_keys_read;
+select @@session.tidb_max_keys_read;
+
+# Reset to default.
+set @@session.tidb_max_keys_read = 0;
+select @@session.tidb_max_keys_read;
+set @@global.tidb_max_keys_read = 0;
+select @@global.tidb_max_keys_read;
+
+# Negative values clip to 0.
+set @@session.tidb_max_keys_read = -1;
+select @@session.tidb_max_keys_read;
+
+# SET_VAR hint only affects the hinted statement.
+select /*+ SET_VAR(tidb_max_keys_read=999) */ @@tidb_max_keys_read;
+select @@session.tidb_max_keys_read;
+
+# SET_VAR with 0 disables the limit for one statement.
+set @@session.tidb_max_keys_read = 50;
+select /*+ SET_VAR(tidb_max_keys_read=0) */ @@tidb_max_keys_read;
+select @@session.tidb_max_keys_read;
+set @@session.tidb_max_keys_read = 0;
+
+drop table if exists t_mrs;
+create table t_mrs (id int primary key auto_increment, val int);
+insert into t_mrs (val) values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
+insert into t_mrs (val) values (11),(12),(13),(14),(15),(16),(17),(18),(19),(20);
+
+# Under limit: 20 rows, limit=100 — succeeds.
+set @@session.tidb_max_keys_read = 100;
+select count(*) from t_mrs;
+
+# Hint override: limit=2 on 20-row scan — exceeds limit.
+-- error 8274
+select /*+ SET_VAR(tidb_max_keys_read=2) */ * from t_mrs;
+
+# Hint disables the session limit for one statement.
+set @@session.tidb_max_keys_read = 2;
+select /*+ SET_VAR(tidb_max_keys_read=0) */ count(*) from t_mrs;
+
+# Precedence: hint wins over session.
+set @@session.tidb_max_keys_read = 100;
+-- error 8274
+select /*+ SET_VAR(tidb_max_keys_read=5) */ * from t_mrs;
+
+# DML statements are not limited.
+set @@session.tidb_max_keys_read = 1;
+insert into t_mrs (val) values (21);
+update t_mrs set val = val + 100 where id = 1;
+delete from t_mrs where id = 21;
+set @@session.tidb_max_keys_read = 0;
+
+# Aggregation counts scanned keys, not result rows.
+-- error 8274
+select /*+ SET_VAR(tidb_max_keys_read=5) */ count(*) from t_mrs;
+
+# tidb_keys_examined is a session-scope status variable reset by FLUSH STATUS.
+flush status;
+show status like 'tidb_keys_examined';
+
+# Cleanup.
+set @@session.tidb_max_keys_read = 0;
+set @@global.tidb_max_keys_read = 0;
+drop table t_mrs;

--- a/tests/integrationtest/t/executor/max_keys_read.test
+++ b/tests/integrationtest/t/executor/max_keys_read.test
@@ -55,10 +55,13 @@ set @@session.tidb_max_keys_read = 100;
 -- error 8274
 select /*+ SET_VAR(tidb_max_keys_read=5) */ * from t_mrs;
 
-# DML statements are not limited.
+# DML statements are exempt from tidb_max_keys_read.
+# Use a full-table UPDATE under limit=1 to prove exemption: if DML were
+# subject to the cap it would fail after the first row read.
 set @@session.tidb_max_keys_read = 1;
+update t_mrs set val = val + 1;
+update t_mrs set val = val - 1;
 insert into t_mrs (val) values (21);
-update t_mrs set val = val + 100 where id = 1;
 delete from t_mrs where id = 21;
 set @@session.tidb_max_keys_read = 0;
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66925

spec: https://github.com/pingcap/tidb/pull/66926
tikv: https://github.com/tikv/tikv/pull/19518
kvproto: https://github.com/pingcap/kvproto/pull/1447

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tidb_max_keys_read (0 = unlimited) to cap keys examined by SELECTs; exceeding it returns Error 8274: "tidb_max_keys_read limit exceeded"
  * Added tidb_keys_examined session status and KeysExamined counter; FLUSH STATUS resets it
  * Per-statement SET_VAR hints can override the limit for a single statement; enforcement is statement-wide across coprocessor work; DML is exempt

* **Tests**
  * Added end-to-end integration tests covering sysvar behavior, hint precedence, enforcement, accounting, and reset semantics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->