### PR TITLE
planner: fix null-reject based FD not-null inference

### DIFF
--- a/pkg/planner/funcdep/extract_fd_test.go
+++ b/pkg/planner/funcdep/extract_fd_test.go
@@ -52,11 +52,13 @@ func TestFDSet_ExtractFD(t *testing.T) {
 	tk.MustExec("create table t2(m int key, n int, p int, unique(m,n))")
 	tk.MustExec("create table x1(a int not null primary key, b int not null, c int default null, d int not null, unique key I_b_c (b,c), unique key I_b_d (b,d))")
 	tk.MustExec("create table x2(a int not null primary key, b int not null, c int default null, d int not null, unique key I_b_c (b,c), unique key I_b_d (b,d))")
+	tk.MustExec("create table x3(a int not null primary key, b int not null, c int default null, d int not null, unique key I_b_c (b,c))")
 
 	tests := []struct {
 		sql  string
 		best string
 		fd   string
+		err  string
 	}{
 		{
 			sql:  "select a from t1",
@@ -213,6 +215,10 @@ func TestFDSet_ExtractFD(t *testing.T) {
 			best: "Apply{DataScan(t1)->DataScan(t2)->Projection->MaxOneRow}->Projection",
 			fd:   "{(1)-->(2-4,13), (2,3)~~>(1,4), (13)~~>(1)} >>> {}",
 		},
+		{
+			sql: "select a from x3 where c = 1 or d = 1 group by b, c",
+			err: "contains nonaggregated column 'test.x3.a'",
+		},
 	}
 
 	ctx := context.TODO()
@@ -233,6 +239,10 @@ func TestFDSet_ExtractFD(t *testing.T) {
 		builder, _ := plannercore.NewPlanBuilder().Init(tk.Session().GetPlanCtx(), is, hint.NewQBHintHandler(nil))
 		// extract FD to every OP
 		p, err := builder.Build(ctx, nodeW)
+		if tt.err != "" {
+			require.ErrorContains(t, err, tt.err, comment)
+			continue
+		}
 		require.NoError(t, err)
 		p, err = plannercore.LogicalOptimizeTest(ctx, builder.GetOptFlag(), p.(base.LogicalPlan))
 		require.NoError(t, err)

--- a/pkg/planner/util/funcdep_misc.go
+++ b/pkg/planner/util/funcdep_misc.go
@@ -41,8 +41,8 @@ func ExtractNotNullFromConds(conditions []expression.Expression, p base.LogicalP
 		if len(cols) == 0 {
 			continue
 		}
-		if IsNullRejected(p.SCtx(), p.Schema(), condition) {
-			for _, col := range cols {
+		for _, col := range cols {
+			if IsNullRejected(p.SCtx(), expression.NewSchema(col), condition) {
 				notnullColsUniqueIDs.Insert(int(col.UniqueID))
 			}
 		}

--- a/tests/integrationtest/r/executor/aggregate.result
+++ b/tests/integrationtest/r/executor/aggregate.result
@@ -1483,6 +1483,8 @@ select * from t group by b,c;
 Error 1055 (42000): Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'executor__aggregate.t.a' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
 select * from t where c = d group by b, c;
 a	b	c	d
+select /* issue:68026 */ a from t where c = 1 or d = 1 group by b, c;
+Error 1055 (42000): Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'executor__aggregate.t.a' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
 select t.*, x.* from t, x where t.a = x.a group by t.a;
 a	b	c	d	a	b	c	d
 select t.*, x.* from t, x where t.b = x.b and t.d = x.d group by t.b, t.d;

--- a/tests/integrationtest/t/executor/aggregate.test
+++ b/tests/integrationtest/t/executor/aggregate.test
@@ -784,6 +784,8 @@ select * from t group by b,d;
 --error 1055
 select * from t group by b,c;
 select * from t where c = d group by b, c;
+--error 1055
+select /* issue:68026 */ a from t where c = 1 or d = 1 group by b, c;
 select t.*, x.* from t, x where t.a = x.a group by t.a;
 select t.*, x.* from t, x where t.b = x.b and t.d = x.d group by t.b, t.d;
 select t.*, x.* from t, x where t.b = x.a group by t.b, t.d;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #68026

Problem Summary:

`ExtractNotNullFromConds` was using a whole-schema null-reject proof for each predicate and then
marking every referenced column as not null. For predicates like `c = 1 or d = 1`, the condition
is null-rejected for the output row, but that does not prove both `c` and `d` are individually not
null. That over-strengthened FD derivation and let ONLY_FULL_GROUP_BY accept invalid queries.

### What changed and how does it work?

- change `ExtractNotNullFromConds` to check null rejection per referenced column instead of once
  against the whole schema
- add a planner regression in `pkg/planner/funcdep/extract_fd_test.go`
- add an integration regression in `tests/integrationtest/t/executor/aggregate.test`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix ONLY_FULL_GROUP_BY false acceptance caused by over-aggressive not-null inference in FD extraction.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of `GROUP BY` clauses under `ONLY_FULL_GROUP_BY` SQL mode to properly reject queries selecting non-aggregated, non-grouped columns that lack functional dependency.
  * Enhanced null-rejection evaluation in functional dependency analysis for more accurate query constraint handling.

* **Tests**
  * Added test coverage for edge cases involving `GROUP BY` validation with complex `WHERE` predicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->