### PR TITLE
pkg/importsdk: skip real size estimation by default

### DIFF
--- a/pkg/executor/windows/BUILD.bazel
+++ b/pkg/executor/windows/BUILD.bazel
@@ -34,7 +34,6 @@ go_test(
     flaky = True,
     shard_count = 7,
     deps = [
-        ":windows",
         "//pkg/parser/mysql",
         "//pkg/testkit",
     ],

--- a/pkg/importsdk/config.go
+++ b/pkg/importsdk/config.go
@@ -51,8 +51,8 @@ func defaultSDKConfig() *SDKConfig {
 		charset:          "auto",
 		csvConfig:        defaultCfg.Mydumper.CSV,
 		dataCharacterSet: defaultCfg.Mydumper.DataCharacterSet,
-		// Estimate the real size (uncompressed / row-oriented) for compressed/parquet data files by default.
-		estimateRealSize: true,
+		// Skip real-size estimation by default to keep SDK initialization fast for many large compressed files.
+		estimateRealSize: false,
 	}
 }
 

--- a/pkg/importsdk/config_test.go
+++ b/pkg/importsdk/config_test.go
@@ -29,7 +29,7 @@ func TestDefaultSDKConfig(t *testing.T) {
 	require.Equal(t, config.GetDefaultFilter(), cfg.filter)
 	require.Equal(t, log.L(), cfg.logger)
 	require.Equal(t, "auto", cfg.charset)
-	require.True(t, cfg.estimateRealSize)
+	require.False(t, cfg.estimateRealSize)
 }
 
 func TestSDKOptions(t *testing.T) {
@@ -73,8 +73,8 @@ func TestSDKOptions(t *testing.T) {
 	require.Equal(t, 100, *cfg.maxScanFiles)
 
 	// Test WithEstimateRealSize
-	WithEstimateRealSize(false)(cfg)
-	require.False(t, cfg.estimateRealSize)
+	WithEstimateRealSize(true)(cfg)
+	require.True(t, cfg.estimateRealSize)
 
 	// Test WithSkipInvalidFiles
 	WithSkipInvalidFiles(true)(cfg)

--- a/pkg/importsdk/file_scanner.go
+++ b/pkg/importsdk/file_scanner.go
@@ -345,6 +345,9 @@ func (s *fileScanner) estimateParquetSourceSize(ctx context.Context, files []myd
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
+		if rowCount == 0 {
+			continue
+		}
 		sampledStorageSize += file.FileMeta.FileSize
 		sampledSourceSize += float64(rowCount) * rowSize
 	}

--- a/pkg/importsdk/file_scanner.go
+++ b/pkg/importsdk/file_scanner.go
@@ -56,7 +56,10 @@ type fileScanner struct {
 	config             *SDKConfig
 }
 
-const redactedInvalidSourcePath = "<redacted-invalid-source>"
+const (
+	redactedInvalidSourcePath        = "<redacted-invalid-source>"
+	maxEstimateSourceSizeSampleFiles = 3
+)
 
 // NewFileScanner creates a new FileScanner
 func NewFileScanner(ctx context.Context, sourcePath string, db *sql.DB, cfg *SDKConfig) (FileScanner, error) {
@@ -219,7 +222,15 @@ func (s *fileScanner) EstimateImportDataSize(ctx context.Context) (*ImportDataSi
 	}
 	for _, dbMeta := range dbMetas {
 		for _, tblMeta := range dbMeta.Tables {
-			singleReplicaSize, err := s.estimateOneTableSize(ctx, tblMeta)
+			sourceSize, err := s.estimateTableSourceSize(ctx, tblMeta)
+			if err != nil {
+				if s.config.skipInvalidFiles {
+					s.logger.Warn("skipping table during source size estimation", zap.String("database", dbMeta.Name), zap.String("table", tblMeta.Name), zap.Error(err))
+					continue
+				}
+				return nil, err
+			}
+			singleReplicaSize, err := s.estimateOneTableSize(ctx, tblMeta, sourceSize)
 			if err != nil {
 				if s.config.skipInvalidFiles {
 					s.logger.Warn("skipping table during size estimation", zap.String("database", dbMeta.Name), zap.String("table", tblMeta.Name), zap.Error(err))
@@ -230,7 +241,7 @@ func (s *fileScanner) EstimateImportDataSize(ctx context.Context) (*ImportDataSi
 			tableEstimate := TableDataSizeEstimate{
 				Database:   dbMeta.Name,
 				Table:      tblMeta.Name,
-				SourceSize: tblMeta.TotalSize,
+				SourceSize: sourceSize,
 				TiKVSize:   singleReplicaSize,
 			}
 			result.Tables = append(result.Tables, tableEstimate)
@@ -239,6 +250,124 @@ func (s *fileScanner) EstimateImportDataSize(ctx context.Context) (*ImportDataSi
 		}
 	}
 	return result, nil
+}
+
+func (s *fileScanner) estimateTableSourceSize(ctx context.Context, tblMeta *mydump.MDTableMeta) (int64, error) {
+	var (
+		sourceSize      int64
+		compressedFiles []mydump.FileInfo
+		parquetFiles    []mydump.FileInfo
+	)
+	for _, file := range tblMeta.DataFiles {
+		switch file.FileMeta.Type {
+		case mydump.SourceTypeCSV, mydump.SourceTypeSQL:
+			if file.FileMeta.Compression == mydump.CompressionNone {
+				sourceSize += file.FileMeta.FileSize
+			} else {
+				compressedFiles = append(compressedFiles, file)
+			}
+		case mydump.SourceTypeParquet:
+			parquetFiles = append(parquetFiles, file)
+		default:
+			return 0, errors.Errorf("unsupported source format %v", file.FileMeta.Type)
+		}
+	}
+
+	compressedSourceSize, err := s.estimateCompressedSourceSize(ctx, compressedFiles)
+	if err != nil {
+		return 0, err
+	}
+	parquetSourceSize, err := s.estimateParquetSourceSize(ctx, parquetFiles)
+	if err != nil {
+		return 0, err
+	}
+	return sourceSize + compressedSourceSize + parquetSourceSize, nil
+}
+
+func storageSize(files []mydump.FileInfo) int64 {
+	var total int64
+	for _, file := range files {
+		total += file.FileMeta.FileSize
+	}
+	return total
+}
+
+func (s *fileScanner) estimateCompressedSourceSize(ctx context.Context, files []mydump.FileInfo) (int64, error) {
+	totalStorageSize := storageSize(files)
+	if len(files) == 0 || totalStorageSize == 0 {
+		return totalStorageSize, nil
+	}
+
+	sampleCandidates := make([]mydump.FileInfo, 0, len(files))
+	for _, file := range files {
+		if file.FileMeta.FileSize > 0 {
+			sampleCandidates = append(sampleCandidates, file)
+		}
+	}
+
+	var (
+		sampledStorageSize int64
+		weightedRatio      float64
+	)
+	for _, file := range pickSampleFiles(sampleCandidates, maxEstimateSourceSizeSampleFiles) {
+		ratio, err := mydump.SampleFileCompressRatio(ctx, file.FileMeta, s.store)
+		if err != nil {
+			return 0, errors.Trace(err)
+		}
+		sampledStorageSize += file.FileMeta.FileSize
+		weightedRatio += ratio * float64(file.FileMeta.FileSize)
+	}
+	if sampledStorageSize == 0 {
+		return totalStorageSize, nil
+	}
+	return int64(float64(totalStorageSize) * weightedRatio / float64(sampledStorageSize)), nil
+}
+
+func (s *fileScanner) estimateParquetSourceSize(ctx context.Context, files []mydump.FileInfo) (int64, error) {
+	totalStorageSize := storageSize(files)
+	if len(files) == 0 || totalStorageSize == 0 {
+		return totalStorageSize, nil
+	}
+
+	sampleCandidates := make([]mydump.FileInfo, 0, len(files))
+	for _, file := range files {
+		if file.FileMeta.FileSize > 0 {
+			sampleCandidates = append(sampleCandidates, file)
+		}
+	}
+
+	var (
+		sampledStorageSize int64
+		sampledSourceSize  float64
+	)
+	for _, file := range pickSampleFiles(sampleCandidates, maxEstimateSourceSizeSampleFiles) {
+		rowCount, rowSize, err := mydump.SampleStatisticsFromParquet(ctx, file.FileMeta.Path, s.store)
+		if err != nil {
+			return 0, errors.Trace(err)
+		}
+		sampledStorageSize += file.FileMeta.FileSize
+		sampledSourceSize += float64(rowCount) * rowSize
+	}
+	if sampledStorageSize == 0 || sampledSourceSize == 0 {
+		return totalStorageSize, nil
+	}
+	return int64(float64(totalStorageSize) * sampledSourceSize / float64(sampledStorageSize)), nil
+}
+
+func pickSampleFiles(files []mydump.FileInfo, maxCount int) []mydump.FileInfo {
+	if maxCount <= 0 || len(files) <= maxCount {
+		return files
+	}
+	if maxCount == 1 {
+		return files[:1]
+	}
+	samples := make([]mydump.FileInfo, 0, maxCount)
+	lastFileIdx := len(files) - 1
+	lastSampleIdx := maxCount - 1
+	for i := range maxCount {
+		samples = append(samples, files[i*lastFileIdx/lastSampleIdx])
+	}
+	return samples
 }
 
 func (s *fileScanner) Close() error {
@@ -309,6 +438,7 @@ func createDataFileMeta(file mydump.FileInfo) DataFileMeta {
 func (s *fileScanner) estimateOneTableSize(
 	ctx context.Context,
 	tblMeta *mydump.MDTableMeta,
+	sourceSize int64,
 ) (int64, error) {
 	if len(tblMeta.DataFiles) == 0 {
 		return 0, nil
@@ -349,9 +479,9 @@ func (s *fileScanner) estimateOneTableSize(
 		return 0, nil
 	}
 	if sampledSize.SourceSize <= 0 || sampledSize.TotalKVSize() <= 0 {
-		return tblMeta.TotalSize, nil
+		return sourceSize, nil
 	}
-	return int64(float64(tblMeta.TotalSize) * float64(sampledSize.TotalKVSize()) / float64(sampledSize.SourceSize)), nil
+	return int64(float64(sourceSize) * float64(sampledSize.TotalKVSize()) / float64(sampledSize.SourceSize)), nil
 }
 
 func (s *fileScanner) buildEstimateSampleConfig(format string) *execimporter.KVSizeSampleConfig {

--- a/pkg/importsdk/file_scanner_test.go
+++ b/pkg/importsdk/file_scanner_test.go
@@ -320,6 +320,47 @@ func TestFileScanner(t *testing.T) {
 		require.Positive(t, tableEstimates["with_csv"].TiKVSize)
 	})
 
+	t.Run("EstimateImportDataSizeCompressedCSV", func(t *testing.T) {
+		estimateDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(estimateDir, "db1-schema-create.sql"), []byte("CREATE DATABASE db1;"), 0o644))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(estimateDir, "db1.compressed_csv-schema.sql"),
+			[]byte("CREATE TABLE db1.compressed_csv (id INT PRIMARY KEY, v VARCHAR(255), KEY idx_v (v));"),
+			0o644,
+		))
+
+		var rawData strings.Builder
+		for i := 1; i <= 200; i++ {
+			_, err := fmt.Fprintf(&rawData, "%d,%s\n", i, strings.Repeat("a", 128))
+			require.NoError(t, err)
+		}
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, err := gz.Write([]byte(rawData.String()))
+		require.NoError(t, err)
+		require.NoError(t, gz.Close())
+		compressedSize := int64(buf.Len())
+		require.NoError(t, os.WriteFile(filepath.Join(estimateDir, "db1.compressed_csv.001.csv.gz"), buf.Bytes(), 0o644))
+
+		estimateScanner, err := NewFileScanner(ctx, "file://"+estimateDir, db, defaultSDKConfig())
+		require.NoError(t, err)
+		defer estimateScanner.Close()
+
+		metas, err := estimateScanner.GetTableMetas(ctx)
+		require.NoError(t, err)
+		require.Len(t, metas, 1)
+		require.Equal(t, compressedSize, metas[0].TotalSize)
+
+		estimate, err := estimateScanner.EstimateImportDataSize(ctx)
+		require.NoError(t, err)
+		require.Len(t, estimate.Tables, 1)
+		require.Equal(t, "compressed_csv", estimate.Tables[0].Table)
+		require.Greater(t, estimate.Tables[0].SourceSize, compressedSize)
+		require.Positive(t, estimate.Tables[0].TiKVSize)
+		require.Equal(t, estimate.Tables[0].SourceSize, estimate.TotalSourceSize)
+		require.Equal(t, estimate.Tables[0].TiKVSize, estimate.TotalTiKVSize)
+	})
+
 	t.Run("EstimateImportDataSizeSkipInvalidFiles", func(t *testing.T) {
 		estimateDir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(estimateDir, "db1-schema-create.sql"), []byte("CREATE DATABASE db1;"), 0o644))
@@ -425,14 +466,16 @@ func TestFileScannerWithEstimateRealSize(t *testing.T) {
 	metas1, err := scanner1.GetTableMetas(ctx)
 	require.NoError(t, err)
 	require.Len(t, metas1, 1)
-	require.Greater(t, metas1[0].TotalSize, compressedSize)
+	require.Equal(t, compressedSize, metas1[0].TotalSize)
+	require.Len(t, metas1[0].DataFiles, 1)
+	require.Equal(t, compressedSize, metas1[0].DataFiles[0].Size)
 
 	db2, _, err := sqlmock.New()
 	require.NoError(t, err)
 	defer db2.Close()
 
 	cfg2 := defaultSDKConfig()
-	WithEstimateRealSize(false)(cfg2)
+	WithEstimateRealSize(true)(cfg2)
 	scanner2, err := NewFileScanner(ctx, "file://"+tmpDir, db2, cfg2)
 	require.NoError(t, err)
 	defer scanner2.Close()
@@ -440,9 +483,7 @@ func TestFileScannerWithEstimateRealSize(t *testing.T) {
 	metas2, err := scanner2.GetTableMetas(ctx)
 	require.NoError(t, err)
 	require.Len(t, metas2, 1)
-	require.Equal(t, compressedSize, metas2[0].TotalSize)
-	require.Len(t, metas2[0].DataFiles, 1)
-	require.Equal(t, compressedSize, metas2[0].DataFiles[0].Size)
+	require.Greater(t, metas2[0].TotalSize, compressedSize)
 }
 
 func TestFileScannerWithSkipInvalidFiles(t *testing.T) {

--- a/pkg/importsdk/model.go
+++ b/pkg/importsdk/model.go
@@ -23,17 +23,22 @@ import (
 
 // TableMeta contains metadata for a table to be imported
 type TableMeta struct {
-	Database     string
-	Table        string
-	DataFiles    []DataFileMeta
-	TotalSize    int64  // In bytes
+	Database  string
+	Table     string
+	DataFiles []DataFileMeta
+	// TotalSize is the sum of DataFiles.Size in bytes.
+	// By default, Size is the storage-reported file size. With WithEstimateRealSize(true),
+	// compressed and parquet files use estimated uncompressed/row-oriented size instead.
+	TotalSize    int64
 	WildcardPath string // Wildcard pattern that matches only this table's data files
 	SchemaFile   string // Path to the table schema file, if available
 }
 
 // DataFileMeta contains metadata for a data file
 type DataFileMeta struct {
-	Path        string
+	Path string
+	// Size is the storage-reported file size by default. With WithEstimateRealSize(true),
+	// compressed and parquet files use estimated uncompressed/row-oriented size instead.
 	Size        int64
 	Format      mydump.SourceType
 	Compression mydump.Compression


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #66081, ref #67240

Problem Summary:

Import SDK currently estimates the real size of compressed and parquet source files during scanner initialization by default. When there are many large compressed files, this makes the main SDK path slow even when callers only need schema/table metadata or import SQL generation.

### What changed and how does it work?

- Default `SDKConfig.estimateRealSize` to `false`, so Import SDK initialization skips expensive real-size estimation by default.
- Keep `WithEstimateRealSize(true)` as an opt-in compatibility path for callers that need `GetTotalSize`, `TableMeta.TotalSize`, or `DataFileMeta.Size` to represent estimated uncompressed / row-oriented source size.
- Make `EstimateImportDataSize` estimate logical source size on demand without depending on loader initialization's `tblMeta.TotalSize`:
  - uncompressed CSV/SQL files use storage-reported `FileSize` directly;
  - compressed CSV/SQL files sample at most a bounded number of files to estimate a weighted compression ratio and scale by total storage size;
  - parquet files sample at most a bounded number of files to estimate row-oriented size and scale by total storage size;
  - KV-size estimation continues to use the existing bounded KV sampling logic.
- Update Import SDK size field comments to document the default storage-size semantics and the `WithEstimateRealSize(true)` opt-in behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual / local validation:

```sh
go test ./pkg/importsdk -run 'Test(DefaultSDKConfig|SDKOptions|CreateDataFileMeta|ProcessDataFiles|FileScanner|FileScannerWithEstimateRealSize|GenerateWildcardPath|SQLGenerator|Model|Pattern)'
go test ./pkg/importsdk -run 'TestFileScanner/EstimateImportDataSizeCompressedCSV' -count=10
bazel build --remote_cache=https://cache.hawkingrei.com/bazelcache --noremote_upload_local_results //pkg/importsdk:importsdk --//build:with_nogo_flag=true
make bazel_prepare
make bazel_lint
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

`GetTotalSize`, `TableMeta.TotalSize`, and `DataFileMeta.Size` now report storage-reported file size by default for compressed/parquet data files. Callers that require estimated uncompressed / row-oriented source size should opt in with `WithEstimateRealSize(true)` or use `EstimateImportDataSize` for import-size estimation.

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve Import SDK initialization performance by skipping compressed and parquet real-size estimation by default. Use `WithEstimateRealSize(true)` to opt in to the previous metadata size behavior, or call `EstimateImportDataSize` for bounded import-size estimation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added table-level source-size estimation for imports (CSV, compressed CSV, SQL, Parquet) using sampled/weighted heuristics.

* **Changes**
  * SDK default: real-size estimation is now disabled by default; storage-reported file sizes are used unless enabled.
  * Import sizing now uses computed source sizes and can skip or warn on invalid file estimates.

* **Tests**
  * Updated and added tests for compressed CSV handling and new default behavior.

* **Documentation**
  * Clarified file-size field semantics when real-size estimation is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->