### PR TITLE
*: reduce Bazel failpoint and timeout flakes | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature-fts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -704,7 +704,7 @@ bazel_test: bazel-failpoint-enable bazel_prepare ## Run all tests using Bazel
 
 .PHONY: bazel_ci_test
 bazel_ci_test: bazel-failpoint-enable bazel_ci_simple_prepare
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc test $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=HOST_CPUS*0.9 --build_tests_only --test_keep_going=false \
+	bazel $(BAZEL_GLOBAL_CONFIG) test $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --build_tests_only --test_keep_going=false \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- //... -//cmd/... -//tests/graceshutdown/... \
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...

--- a/Makefile
+++ b/Makefile
@@ -702,6 +702,20 @@ bazel_test: bazel-failpoint-enable bazel_prepare ## Run all tests using Bazel
 		-- //... -//cmd/... -//tests/graceshutdown/... \
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
 
+.PHONY: bazel_ci_test
+bazel_ci_test: bazel-failpoint-enable bazel_ci_simple_prepare
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc test $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=HOST_CPUS*0.9 --build_tests_only --test_keep_going=false \
+		--define gotags=$(UNIT_TEST_TAGS) \
+		-- //... -//cmd/... -//tests/graceshutdown/... \
+		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
+
+.PHONY: bazel_ci_test_ddlargsv1
+bazel_ci_test_ddlargsv1: bazel-failpoint-enable bazel_ci_simple_prepare
+	bazel $(BAZEL_GLOBAL_CONFIG) test $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --build_tests_only --test_keep_going=false \
+		--define gotags=$(UNIT_TEST_TAGS),ddlargsv1 \
+		-- //... -//cmd/... -//tests/graceshutdown/... \
+		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
+
 .PHONY: bazel_coverage_test
 bazel_coverage_test: bazel-failpoint-enable bazel_ci_simple_prepare
 	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=35 --build_tests_only --test_keep_going=false \

--- a/Makefile
+++ b/Makefile
@@ -342,11 +342,11 @@ failpoint-disable: tools/bin/failpoint-ctl
 
 .PHONY: bazel_failpoint-enable
 bazel-failpoint-enable:
-	find $$PWD/ -mindepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable
+	find $$PWD/ -mindepth 1 -maxdepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable
 
 .PHONY: bazel_failpoint-disable
 bazel_failpoint-disable:
-	find $$PWD/ -mindepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable
+	find $$PWD/ -mindepth 1 -maxdepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable
 
 .PHONY: tools/bin/ut
 tools/bin/ut: tools/check/ut.go tools/check/longtests.go

--- a/Makefile.common
+++ b/Makefile.common
@@ -77,8 +77,8 @@ FILES_TIDB_TESTS := $$(find $$($(PACKAGE_DIRECTORIES_TIDB_TESTS)) -name "*.go")
 UNCONVERT_PACKAGES_LIST := go list ./...| grep -vE "lightning\/checkpoints|lightning\/manual|lightning\/common|tidb-binlog\/proto\/go-binlog"
 UNCONVERT_PACKAGES := $$($(UNCONVERT_PACKAGES_LIST))
 
-FAILPOINT_ENABLE  := find $$PWD/ -mindepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs tools/bin/failpoint-ctl enable
-FAILPOINT_DISABLE := find $$PWD/ -mindepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs tools/bin/failpoint-ctl disable
+FAILPOINT_ENABLE  := find $$PWD/ -mindepth 1 -maxdepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs tools/bin/failpoint-ctl enable
+FAILPOINT_DISABLE := find $$PWD/ -mindepth 1 -maxdepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs tools/bin/failpoint-ctl disable
 
 LDFLAGS += -X "github.com/pingcap/tidb/pkg/parser/mysql.TiDBReleaseVersion=$(shell git describe --tags --dirty --always)"
 LDFLAGS += -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBBuildTS=$(shell date -u '+%Y-%m-%d %H:%M:%S')"

--- a/br/pkg/checkpoint/BUILD.bazel
+++ b/br/pkg/checkpoint/BUILD.bazel
@@ -42,7 +42,7 @@ go_library(
 
 go_test(
     name = "checkpoint_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = ["checkpoint_test.go"],
     flaky = True,
     race = "on",

--- a/build/jenkins_collect_coverage.sh
+++ b/build/jenkins_collect_coverage.sh
@@ -20,7 +20,19 @@
 
 set -o pipefail
 
-bazel_collect
+coverage_report=./bazel-out/_coverage/_coverage_report.dat
+junit_report=./bazel.xml
+
+go install github.com/hawkingrei/bazel_collect@latest
 mkdir -p test_coverage
-cp ./bazel-out/_coverage/_coverage_report.dat ./coverage.dat
-mv bazel.xml test_coverage/bazel.xml
+if [ -f "${coverage_report}" ]; then
+    cp "${coverage_report}" ./coverage.dat
+else
+    : > ./coverage.dat
+    echo "warning: coverage report ${coverage_report} not found, created empty coverage.dat" >&2
+fi
+if [ -f "${junit_report}" ]; then
+    mv "${junit_report}" test_coverage/bazel.xml
+else
+    echo "warning: junit report ${junit_report} not found, skipping junit artifact collection" >&2
+fi

--- a/build/jenkins_unit_test.sh
+++ b/build/jenkins_unit_test.sh
@@ -20,11 +20,23 @@
 
 set -o pipefail
 
+coverage_report=./bazel-out/_coverage/_coverage_report.dat
+junit_report=./bazel.xml
+
+go install github.com/hawkingrei/bazel_collect@latest
 make bazel_coverage_test
 EXIT_STATUS=$?
 # collect the junit and coverage report
-bazel_collect
-cp ./bazel-out/_coverage/_coverage_report.dat ./coverage.dat
+if [ -f "${coverage_report}" ]; then
+    cp "${coverage_report}" ./coverage.dat
+else
+    : > ./coverage.dat
+    echo "warning: coverage report ${coverage_report} not found, created empty coverage.dat" >&2
+fi
 mkdir -p test_coverage
-mv bazel.xml test_coverage/bazel.xml
+if [ -f "${junit_report}" ]; then
+    mv "${junit_report}" test_coverage/bazel.xml
+else
+    echo "warning: junit report ${junit_report} not found, skipping junit artifact collection" >&2
+fi
 exit ${EXIT_STATUS}

--- a/build/jenkins_unit_test.sh
+++ b/build/jenkins_unit_test.sh
@@ -24,7 +24,7 @@ coverage_report=./bazel-out/_coverage/_coverage_report.dat
 junit_report=./bazel.xml
 
 go install github.com/hawkingrei/bazel_collect@latest
-make bazel_coverage_test
+make bazel_ci_test
 EXIT_STATUS=$?
 # collect the junit and coverage report
 if [ -f "${coverage_report}" ]; then

--- a/build/jenkins_unit_test_ddlargsv1.sh
+++ b/build/jenkins_unit_test_ddlargsv1.sh
@@ -20,11 +20,23 @@
 
 set -o pipefail
 
+coverage_report=./bazel-out/_coverage/_coverage_report.dat
+junit_report=./bazel.xml
+
+go install github.com/hawkingrei/bazel_collect@latest
 make bazel_coverage_test_ddlargsv1
 EXIT_STATUS=$?
 # collect the junit and coverage report
-bazel_collect
-cp ./bazel-out/_coverage/_coverage_report.dat ./coverage.dat
+if [ -f "${coverage_report}" ]; then
+    cp "${coverage_report}" ./coverage.dat
+else
+    : > ./coverage.dat
+    echo "warning: coverage report ${coverage_report} not found, created empty coverage.dat" >&2
+fi
 mkdir -p test_coverage
-mv bazel.xml test_coverage/bazel.xml
+if [ -f "${junit_report}" ]; then
+    mv "${junit_report}" test_coverage/bazel.xml
+else
+    echo "warning: junit report ${junit_report} not found, skipping junit artifact collection" >&2
+fi
 exit ${EXIT_STATUS}

--- a/build/jenkins_unit_test_ddlargsv1.sh
+++ b/build/jenkins_unit_test_ddlargsv1.sh
@@ -24,7 +24,7 @@ coverage_report=./bazel-out/_coverage/_coverage_report.dat
 junit_report=./bazel.xml
 
 go install github.com/hawkingrei/bazel_collect@latest
-make bazel_coverage_test_ddlargsv1
+make bazel_ci_test_ddlargsv1
 EXIT_STATUS=$?
 # collect the junit and coverage report
 if [ -f "${coverage_report}" ]; then

--- a/pkg/executor/test/memtest/BUILD.bazel
+++ b/pkg/executor/test/memtest/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "memtest_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "main_test.go",
         "mem_test.go",

--- a/pkg/executor/test/simpletest/BUILD.bazel
+++ b/pkg/executor/test/simpletest/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "simpletest_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "main_test.go",
         "simple_test.go",

--- a/pkg/resourcegroup/tests/BUILD.bazel
+++ b/pkg/resourcegroup/tests/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "tests_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = ["resource_group_test.go"],
     flaky = True,
     race = "on",

--- a/pkg/statistics/handle/syncload/BUILD.bazel
+++ b/pkg/statistics/handle/syncload/BUILD.bazel
@@ -33,7 +33,7 @@ go_library(
 
 go_test(
     name = "syncload_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = ["stats_syncload_test.go"],
     flaky = True,
     race = "on",

--- a/pkg/timer/BUILD.bazel
+++ b/pkg/timer/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "timer_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "main_test.go",
         "store_intergartion_test.go",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #63937, ref #67956

Problem Summary:

Bazel CI on `feature/fts` can fail because failpoint enablement enumerates too many directories, because some coverage test targets are still classified as `short` and hit the 150s CI timeout, or because Jenkins unit-test jobs still run Bazel coverage targets and depend on coverage artifacts.

### What changed and how does it work?

- Limit failpoint directory enumeration to top-level directories, matching #67990.
- Relax timeout classification from `short` to `moderate` for slow Bazel coverage test targets observed in recent CI failures.
- Stop treating missing coverage/junit artifacts as fatal in Jenkins coverage collection, matching #67634.
- Switch Jenkins unit-test jobs from Bazel coverage targets to Bazel test targets, matching #67982.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

- `git diff --check`
- `bash -n build/jenkins_unit_test.sh build/jenkins_unit_test_ddlargsv1.sh build/jenkins_collect_coverage.sh`
- `make -n bazel_ci_test`
- `make -n bazel_ci_test_ddlargsv1`
- Verified the updated failpoint directory enumeration only includes top-level directories locally.
- Checked recent `ghpr_unit_test` artifacts for timeout targets.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public CI test targets to run unit tests with alternate tag configurations (including a ddlargsv1 variant) for CI pipelines.

* **Chores**
  * Restricted failpoint enable/disable scanning to immediate subdirectories to reduce unnecessary traversal.
  * Increased test timeouts from short to moderate across multiple suites to accommodate longer runs.
  * Made CI artifact collection conditional: coverage and test reports are gathered only when present, with safe defaults and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
