### PR TITLE
bindinfo: add a binding cache reload concurrency test

### DIFF
--- a/pkg/bindinfo/binding_operator_test.go
+++ b/pkg/bindinfo/binding_operator_test.go
@@ -139,10 +139,8 @@ func TestConcurrentBindingCacheReloadAndMatch(t *testing.T) {
 		}
 	})
 
-	for i, worker := range workers {
-		lookup := hotLookups[i%len(hotLookups)]
-		worker, lookup := worker, lookup
-		wg.Go(func() {
+	runMatchWorker := func(worker *testkit.TestKit, lookup hotBindingLookup) func() {
+		return func() {
 			<-start
 			matchCount := 0
 			for ctx.Err() == nil {
@@ -153,7 +151,12 @@ func TestConcurrentBindingCacheReloadAndMatch(t *testing.T) {
 				}
 				matchCount++
 			}
-		})
+		}
+	}
+
+	for i, worker := range workers {
+		lookup := hotLookups[i%len(hotLookups)]
+		wg.Go(runMatchWorker(worker, lookup))
 	}
 
 	close(start)

--- a/pkg/bindinfo/binding_operator_test.go
+++ b/pkg/bindinfo/binding_operator_test.go
@@ -17,6 +17,7 @@ package bindinfo_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -54,6 +55,112 @@ func TestBindingCache(t *testing.T) {
 	tk.MustExec("drop global binding for select * from t;")
 	require.Nil(t, dom.BindingHandle().LoadFromStorageToCache(false, false))
 	require.Equal(t, 1, len(dom.BindingHandle().GetAllBindings()))
+}
+
+// TestConcurrentBindingCacheReloadAndMatch mirrors the hot-binding repro:
+// keep a small set of digests hot while repeatedly reloading many bindings from storage.
+func TestConcurrentBindingCacheReloadAndMatch(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	const (
+		bindingCount = 24
+		hotCount     = 3
+		workerCount  = 8
+		testDuration = 20 * time.Second
+	)
+
+	type hotBindingLookup struct {
+		noDBDigest string
+		tableNames []*ast.TableName
+	}
+
+	parser4Test := parser.New()
+	hotLookups := make([]hotBindingLookup, 0, hotCount)
+	for i := 0; i < bindingCount; i++ {
+		tableName := fmt.Sprintf("binding_hot_%02d", i)
+		tk.MustExec(fmt.Sprintf("create table %s (a int, b int, key idx_a(a), key idx_b(b), key idx_ab(a, b))", tableName))
+
+		originSQL := fmt.Sprintf("select * from %s where a = 1 and b = 1", tableName)
+		bindSQL := fmt.Sprintf("select /*+ use_index(%s, idx_a) */ * from %s where a = 1 and b = 1", tableName, tableName)
+		tk.MustExec(fmt.Sprintf("create global binding for %s using %s", originSQL, bindSQL))
+
+		if i < hotCount {
+			stmt, err := parser4Test.ParseOneStmt(fmt.Sprintf("select * from test.%s where a = 1 and b = 1", tableName), "", "")
+			require.NoError(t, err)
+
+			_, noDBDigest := bindinfo.NormalizeStmtForBinding(stmt, "", true)
+			hotLookups = append(hotLookups, hotBindingLookup{
+				noDBDigest: noDBDigest,
+				tableNames: bindinfo.CollectTableNames(stmt),
+			})
+		}
+	}
+	require.Len(t, tk.MustQuery("show global bindings").Rows(), bindingCount)
+
+	bindHandle := dom.BindingHandle()
+	require.NoError(t, bindHandle.LoadFromStorageToCache(true, false))
+
+	workers := make([]*testkit.TestKit, 0, workerCount)
+	for i := 0; i < workerCount; i++ {
+		worker := testkit.NewTestKit(t, store)
+		worker.MustExec("use test")
+		lookup := hotLookups[i%len(hotLookups)]
+		binding, matched := bindHandle.MatchingBinding(worker.Session(), lookup.noDBDigest, lookup.tableNames)
+		require.True(t, matched)
+		require.NotNil(t, binding)
+		workers = append(workers, worker)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testDuration)
+	defer cancel()
+
+	var (
+		wg       sync.WaitGroup
+		errOnce  sync.Once
+		firstErr error
+	)
+	start := make(chan struct{})
+	setErr := func(err error) {
+		if err == nil {
+			return
+		}
+		errOnce.Do(func() {
+			firstErr = err
+			cancel()
+		})
+	}
+
+	wg.Go(func() {
+		<-start
+		for ctx.Err() == nil {
+			setErr(bindHandle.LoadFromStorageToCache(false, false))
+		}
+	})
+
+	for i, worker := range workers {
+		lookup := hotLookups[i%len(hotLookups)]
+		worker, lookup := worker, lookup
+		wg.Go(func() {
+			<-start
+			matchCount := 0
+			for ctx.Err() == nil {
+				binding, matched := bindHandle.MatchingBinding(worker.Session(), lookup.noDBDigest, lookup.tableNames)
+				if !matched || binding == nil {
+					setErr(fmt.Errorf("hot binding lookup missed after %d successful matches", matchCount))
+					return
+				}
+				matchCount++
+			}
+		})
+	}
+
+	close(start)
+	wg.Wait()
+
+	require.NoError(t, firstErr)
+	require.Len(t, tk.MustQuery("show global bindings").Rows(), bindingCount)
 }
 
 func TestBindingLastUpdateTime(t *testing.T) {

--- a/pkg/executor/windows/BUILD.bazel
+++ b/pkg/executor/windows/BUILD.bazel
@@ -34,7 +34,6 @@ go_test(
     flaky = True,
     shard_count = 7,
     deps = [
-        ":windows",
         "//pkg/parser/mysql",
         "//pkg/testkit",
     ],

--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -295,6 +295,7 @@ go_test(
         "//pkg/statistics/handle/ddl/testutil",
         "//pkg/store/mockstore",
         "//pkg/table",
+        "//pkg/table/tables",
         "//pkg/testkit",
         "//pkg/testkit/external",
         "//pkg/testkit/testdata",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68015

Problem Summary: bindinfo: add a binding cache reload concurrency test



### What changed and how does it work?


- Add a unit test in `pkg/bindinfo/binding_operator_test.go`.
- The test creates many global bindings, keeps a small hot subset under concurrent `MatchingBinding` calls, and repeatedly reloads bindings from storage for a fixed duration.
- This converts the standalone repro script into a repo-native regression test.
- Local verification was intentionally not run for this change.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added concurrency stress test for binding cache operations under simultaneous load.

* **Chores**
  * Updated build dependencies and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->