### PR TITLE
*: add likidu to critical approver aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,12 +10,15 @@ aliases:
   sig-critical-approvers-tidb-server:
     - yudongusa
     - terry1purcell
+    - likidu
   sig-critical-approvers-tidb-lightning:
     - yudongusa
     - terry1purcell
+    - likidu
   sig-critical-approvers-parser:
     - yudongusa
     - terry1purcell
+    - likidu
   sig-critical-approvers-dep:
     - bb7133
     - cfzjywxk

--- a/pkg/executor/windows/BUILD.bazel
+++ b/pkg/executor/windows/BUILD.bazel
@@ -34,7 +34,6 @@ go_test(
     flaky = True,
     shard_count = 7,
     deps = [
-        ":windows",
         "//pkg/parser/mysql",
         "//pkg/testkit",
     ],

--- a/pkg/executor/windows/BUILD.bazel
+++ b/pkg/executor/windows/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     flaky = True,
     shard_count = 7,
     deps = [
+        ":windows",
         "//pkg/parser/mysql",
         "//pkg/testkit",
     ],


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68034

Problem Summary:

Follow-up to #67380 under the same OWNERS_ALIASES update thread: preserve the existing `BenMeadowcroft` -> `terry1purcell` replacement on `master`, and additionally add `likidu` to the same critical approver aliases.

### What changed and how does it work?

- adds `likidu` to `sig-critical-approvers-tidb-server`
- adds `likidu` to `sig-critical-approvers-tidb-lightning`
- adds `likidu` to `sig-critical-approvers-parser`
- keeps the current `terry1purcell` entries introduced by #67380

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
