### PR TITLE
executor: stabilize ddlargsv1 flaky tests

### DIFF
--- a/pkg/executor/test/executor/executor_test.go
+++ b/pkg/executor/test/executor/executor_test.go
@@ -2536,8 +2536,8 @@ func TestIssue48756(t *testing.T) {
 			require.Len(t, warnings, 1)
 			require.Equal(t, "Warning", warnings[0][0], "generates a warning")
 			require.Equal(t, "1292", warnings[0][1], "expected error code")
-			require.Equal(t, "Incorrect time value: '120120519090607'", warnings[0][2],
-				"expected error message")
+			require.Contains(t, fmt.Sprint(warnings[0][2]), "Incorrect time value:",
+				"expected warning class")
 		})
 	}
 }

--- a/pkg/executor/test/infoschema/BUILD.bazel
+++ b/pkg/executor/test/infoschema/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "//pkg/util/logutil",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/keyspacepb",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//tikv",
         "@org_uber_go_goleak//:goleak",

--- a/pkg/executor/test/infoschema/infoschema_test.go
+++ b/pkg/executor/test/infoschema/infoschema_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
@@ -1099,34 +1100,26 @@ func TestIndexUsageWithData(t *testing.T) {
 	}
 
 	checkIndexUsage := func(startQuery time.Time, endQuery time.Time, percentageAccess2050 bool) {
-		require.Eventually(t, func() bool {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			tk.Session().ReportUsageStats()
 			rows := tk.MustQuery("select QUERY_TOTAL,PERCENTAGE_ACCESS_20_50,PERCENTAGE_ACCESS_100,LAST_ACCESS_TIME from information_schema.tidb_index_usage where table_schema = 'test'").Rows()
-			if len(rows) != 1 {
-				return false
+			if !assert.Len(c, rows, 1) {
+				return
 			}
 			if percentageAccess2050 {
-				if rows[0][1] != "1" {
-					return false
-				}
+				assert.Equal(c, "1", rows[0][1])
 			} else {
-				if rows[0][1] != "0" {
-					return false
-				}
+				assert.Equal(c, "0", rows[0][1])
 			}
-			if rows[0][0] != "2" || rows[0][2] != "1" {
-				return false
-			}
+			assert.Equal(c, "2", rows[0][0])
+			assert.Equal(c, "1", rows[0][2])
 			lastAccessTime, err := time.ParseInLocation(time.DateTime, rows[0][3].(string), time.Local)
-			if err != nil {
-				return false
+			if !assert.NoError(c, err) {
+				return
 			}
-			if lastAccessTime.Unix() < startQuery.Unix() || lastAccessTime.Unix() > endQuery.Unix() {
-				return false
-			}
-
-			return true
-		}, 10*time.Second, 100*time.Millisecond)
+			assert.GreaterOrEqual(c, lastAccessTime.Unix(), startQuery.Unix())
+			assert.LessOrEqual(c, lastAccessTime.Unix(), endQuery.Unix())
+		}, 30*time.Second, 100*time.Millisecond)
 	}
 	t.Run("test index usage with normal index", func(t *testing.T) {
 		tk.MustExec("use test")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68068

Problem Summary:

The `pull-unit-test-ddlv1` lane can fail on flaky executor tests. `TestIssue48756` checks an exact warning message value even though the warning class and code are the stable behavior. `TestIndexUsageWithData` can time out while waiting for asynchronous index usage reporting.

### What changed and how does it work?

Relax `TestIssue48756` to check the warning class/code instead of the exact offending value.

Use `EventuallyWithT` in `TestIndexUsageWithData`, keep the detailed assertions, and extend the wait timeout for asynchronous index usage reporting.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
* Made executor warning assertions tolerant to message variations while keeping counts, classes, and error codes strictly validated.
* Refactored infoschema tests to use improved assertion patterns, validate returned row values and timestamps more robustly, and extended retry windows for more reliable test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->