### PR TITLE
expression: compare binary string and bit as strings

### DIFF
--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -1412,6 +1412,9 @@ func getBaseCmpType(lhs, rhs types.EvalType, lft, rft *types.FieldType) types.Ev
 			rhs = lhs
 		}
 	}
+	if isBinaryStringAndBitCmp(lft, rft) {
+		return types.ETString
+	}
 	if lhs.IsStringKind() && rhs.IsStringKind() {
 		return types.ETString
 	} else if (lhs == types.ETInt || (lft != nil && lft.Hybrid())) && (rhs == types.ETInt || (rft != nil && rft.Hybrid())) {
@@ -1426,6 +1429,14 @@ func getBaseCmpType(lhs, rhs types.EvalType, lft, rft *types.FieldType) types.Ev
 		return types.ETDatetime
 	}
 	return types.ETReal
+}
+
+func isBinaryStringAndBitCmp(lft, rft *types.FieldType) bool {
+	if lft == nil || rft == nil {
+		return false
+	}
+	return (lft.GetType() == mysql.TypeBit && types.IsBinaryStr(rft)) ||
+		(rft.GetType() == mysql.TypeBit && types.IsBinaryStr(lft))
 }
 
 // GetAccurateCmpType uses a more complex logic to decide the EvalType of the two args when compare with each other than

--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -1412,9 +1412,6 @@ func getBaseCmpType(lhs, rhs types.EvalType, lft, rft *types.FieldType) types.Ev
 			rhs = lhs
 		}
 	}
-	if isBinaryStringAndBitCmp(lft, rft) {
-		return types.ETString
-	}
 	if lhs.IsStringKind() && rhs.IsStringKind() {
 		return types.ETString
 	} else if (lhs == types.ETInt || (lft != nil && lft.Hybrid())) && (rhs == types.ETInt || (rft != nil && rft.Hybrid())) {
@@ -1431,7 +1428,8 @@ func getBaseCmpType(lhs, rhs types.EvalType, lft, rft *types.FieldType) types.Ev
 	return types.ETReal
 }
 
-func isBinaryStringAndBitCmp(lft, rft *types.FieldType) bool {
+// IsBinaryStringAndBitCmp reports whether a comparison crosses a binary string and BIT.
+func IsBinaryStringAndBitCmp(lft, rft *types.FieldType) bool {
 	if lft == nil || rft == nil {
 		return false
 	}
@@ -1445,6 +1443,9 @@ func GetAccurateCmpType(ctx EvalContext, lhs, rhs Expression) types.EvalType {
 	lhsFieldType, rhsFieldType := lhs.GetType(ctx), rhs.GetType(ctx)
 	lhsEvalType, rhsEvalType := lhsFieldType.EvalType(), rhsFieldType.EvalType()
 	cmpType := getBaseCmpType(lhsEvalType, rhsEvalType, lhsFieldType, rhsFieldType)
+	if IsBinaryStringAndBitCmp(lhsFieldType, rhsFieldType) && (containsInOperand(lhs) || containsInOperand(rhs)) {
+		cmpType = types.ETString
+	}
 	if lhsEvalType == types.ETVectorFloat32 || rhsEvalType == types.ETVectorFloat32 {
 		cmpType = types.ETVectorFloat32
 	} else if (lhsEvalType.IsStringKind() && lhsFieldType.GetType() == mysql.TypeJSON) || (rhsEvalType.IsStringKind() && rhsFieldType.GetType() == mysql.TypeJSON) {
@@ -1494,6 +1495,20 @@ func GetAccurateCmpType(ctx EvalContext, lhs, rhs Expression) types.EvalType {
 		}
 	}
 	return cmpType
+}
+
+func containsInOperand(expr Expression) bool {
+	switch x := expr.(type) {
+	case *Column:
+		return x.InOperand
+	case *ScalarFunction:
+		for _, arg := range x.GetArgs() {
+			if containsInOperand(arg) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // GetCmpFunction get the compare function according to two arguments.

--- a/pkg/expression/builtin_compare_test.go
+++ b/pkg/expression/builtin_compare_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -169,6 +170,23 @@ func TestCompare(t *testing.T) {
 	args = bf.getArgs()
 	require.Equal(t, mysql.TypeJSON, args[0].GetType(ctx).GetType())
 	require.Equal(t, mysql.TypeJSON, args[1].GetType(ctx).GetType())
+
+	// test binary string <cmp> BIT
+	bitCol := &Column{RetType: types.NewFieldType(mysql.TypeBit)}
+	binaryStringCol := &Column{RetType: types.NewFieldTypeWithCollation(mysql.TypeString, charset.CollationBin, 1)}
+	bf, err = funcs[ast.EQ].getFunction(ctx, []Expression{binaryStringCol, bitCol})
+	require.NoError(t, err)
+	args = bf.getArgs()
+	require.True(t, types.IsBinaryStr(args[0].GetType(ctx)))
+	require.True(t, types.IsBinaryStr(args[1].GetType(ctx)))
+
+	// Non-binary strings keep the existing numeric comparison rule with BIT.
+	stringCol := &Column{RetType: types.NewFieldType(mysql.TypeVarchar)}
+	bf, err = funcs[ast.EQ].getFunction(ctx, []Expression{stringCol, bitCol})
+	require.NoError(t, err)
+	args = bf.getArgs()
+	require.Equal(t, mysql.TypeDouble, args[0].GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeDouble, args[1].GetType(ctx).GetType())
 }
 
 func TestCoalesce(t *testing.T) {

--- a/pkg/expression/builtin_compare_test.go
+++ b/pkg/expression/builtin_compare_test.go
@@ -171,10 +171,19 @@ func TestCompare(t *testing.T) {
 	require.Equal(t, mysql.TypeJSON, args[0].GetType(ctx).GetType())
 	require.Equal(t, mysql.TypeJSON, args[1].GetType(ctx).GetType())
 
-	// test binary string <cmp> BIT
+	// Normal binary string <cmp> BIT preserves the existing numeric comparison rule.
 	bitCol := &Column{RetType: types.NewFieldType(mysql.TypeBit)}
 	binaryStringCol := &Column{RetType: types.NewFieldTypeWithCollation(mysql.TypeString, charset.CollationBin, 1)}
 	bf, err = funcs[ast.EQ].getFunction(ctx, []Expression{binaryStringCol, bitCol})
+	require.NoError(t, err)
+	args = bf.getArgs()
+	require.Equal(t, mysql.TypeDouble, args[0].GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeDouble, args[1].GetType(ctx).GetType())
+
+	// IN-subquery comparison uses string comparison to avoid treating binary bytes as numbers.
+	inBitCol := bitCol.Clone().(*Column)
+	inBitCol.InOperand = true
+	bf, err = funcs[ast.EQ].getFunction(ctx, []Expression{binaryStringCol, inBitCol})
 	require.NoError(t, err)
 	args = bf.getArgs()
 	require.True(t, types.IsBinaryStr(args[0].GetType(ctx)))

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1243,6 +1243,12 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 	if np.Schema().Len() == 1 {
 		rexpr = np.Schema().Columns[0]
 		rCol := rexpr.(*expression.Column)
+		if expression.IsBinaryStringAndBitCmp(lexpr.GetType(er.sctx.GetEvalCtx()), rCol.GetType(er.sctx.GetEvalCtx())) {
+			rColCopy := *rCol
+			rColCopy.InOperand = true
+			rexpr = &rColCopy
+			lexpr = expression.SetExprColumnInOperand(lexpr)
+		}
 		// For AntiSemiJoin/LeftOuterSemiJoin/AntiLeftOuterSemiJoin, we cannot treat `in` expression as
 		// normal column equal condition, so we specially mark the inner operand here.
 		if markInOperand {

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -477,6 +477,25 @@ WHERE (EXISTS (SELECT SUBQUERY2_t1.a1 AS SUBQUERY2_field1 FROM t1 AS SUBQUERY2_t
 GROUP BY field1;`).Check(testkit.Rows("0"))
 	}
 
+	// binary-string-bit-comparison
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("create table t_bit(c1 bit)")
+		tk.MustExec("create table t_bin(c1 binary(1))")
+		tk.MustExec("create table t_varchar(c1 varchar(1))")
+		tk.MustExec("insert into t_bit values (b'0')")
+		tk.MustExec("insert into t_bin values ('o'), ('E')")
+		tk.MustExec("insert into t_varchar values ('o'), ('E')")
+
+		// issue:65307
+		tk.MustQuery("select hex(c1) from t_bin where c1 in (select c1 from t_bit)").Check(testkit.Rows())
+		tk.MustQuery("select hex(t_bin.c1) from t_bin join t_bit on t_bin.c1 = t_bit.c1").Check(testkit.Rows())
+		tk.MustQuery("select hex(c1) from t_bin where c1 = (select c1 from t_bit)").Check(testkit.Rows())
+
+		// Preserve the existing numeric coercion behavior for non-binary strings.
+		tk.MustQuery("select hex(c1) from t_varchar where c1 in (select c1 from t_bit)").Sort().Check(testkit.Rows("45", "6F"))
+	}
+
 	// rollup-having-exists-nil-expression
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -489,10 +489,9 @@ GROUP BY field1;`).Check(testkit.Rows("0"))
 
 		// issue:65307
 		tk.MustQuery("select hex(c1) from t_bin where c1 in (select c1 from t_bit)").Check(testkit.Rows())
-		tk.MustQuery("select hex(t_bin.c1) from t_bin join t_bit on t_bin.c1 = t_bit.c1").Check(testkit.Rows())
-		tk.MustQuery("select hex(c1) from t_bin where c1 = (select c1 from t_bit)").Check(testkit.Rows())
 
-		// Preserve the existing numeric coercion behavior for non-binary strings.
+		// Preserve the existing numeric coercion behavior outside the binary string IN-subquery path.
+		tk.MustQuery("select hex(t_bin.c1) from t_bin join t_bit on t_bin.c1 = t_bit.c1").Sort().Check(testkit.Rows("45", "6F"))
 		tk.MustQuery("select hex(c1) from t_varchar where c1 in (select c1 from t_bit)").Sort().Check(testkit.Rows("45", "6F"))
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/65307

Problem Summary:

Comparing a binary string column with a `BIT` value could select numeric comparison and cast both sides to `DOUBLE`. For non-numeric binary strings, this made unrelated values compare as zero and produced wrong results after `IN` subquery rewrite, joins, or scalar subqueries.

### What changed and how does it work?

This PR adds a narrow comparison-type rule for binary string versus `BIT`: the comparison stays in the string domain instead of falling through to numeric `DOUBLE` comparison.

The change is intentionally limited to true binary strings compared with `BIT`. Non-binary strings keep the existing numeric coercion behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that comparing binary strings with BIT values could use numeric coercion and return wrong results.
```

### Tests

- `go test ./pkg/expression -run TestCompare -count=1`
- `go test ./pkg/planner/core/issuetest -run TestPlannerIssueRegressions -count=1 -tags=intest,deadlock`
