### PR TITLE
expression: avoid mutating shared columns in case results

### DIFF
--- a/pkg/executor/test/issuetest/BUILD.bazel
+++ b/pkg/executor/test/issuetest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/autoid_service",
         "//pkg/config",

--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -793,3 +793,23 @@ func TestIssue60926(t *testing.T) {
 	tk.MustQuery("select * from t1 join (select col0, sum(col1) from t2 group by col0) as r on t1.col0 = r.col0;")
 	require.True(t, join.IsChildCloseCalledForTest.Load())
 }
+
+func TestCaseWhenBinaryResultDoesNotMutateSharedColumns(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists issue_67375_t0, issue_67375_t1")
+	tk.MustExec("create table issue_67375_t0(c0 text, c1 blob, c2 text as (cast(c1 or c1 regexp c0 as binary)))")
+	tk.MustExec("create table issue_67375_t1 like issue_67375_t0")
+	tk.MustExec("insert into issue_67375_t0(c0, c1) values ('', '1')")
+	tk.MustExec("insert into issue_67375_t1(c0) values (' ')")
+
+	issueFilter := "(case 1 when (case 0 when 0 then t1.c0 when 0 then t1.c1 end) then t1.c0 else t0.c2 end) not like 0"
+
+	// Issue #67375: direct comparison is true under the column collation. Embedding
+	// the same column in a binary CASE result must not mutate this shared comparison.
+	tk.MustQuery("select t1.c0 <= t0.c0, not (t1.c0 <= t0.c0) from issue_67375_t1 t1 join issue_67375_t0 t0 on t1.c0 <= t0.c0").Check(testkit.Rows("1 0"))
+	tk.MustQuery("select sum(t1.c0 <= t0.c0), sum(not (t1.c0 <= t0.c0)) from issue_67375_t1 t1 join issue_67375_t0 t0 on t1.c0 <= t0.c0 where " + issueFilter).Check(testkit.Rows("1 0"))
+	tk.MustQuery("select count(case when not (t1.c0 <= t0.c0) then 1 end) from issue_67375_t1 t1 join issue_67375_t0 t0 on t1.c0 <= t0.c0 where " + issueFilter).Check(testkit.Rows("0"))
+}

--- a/pkg/expression/builtin_control.go
+++ b/pkg/expression/builtin_control.go
@@ -343,6 +343,10 @@ func (c *caseWhenFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		if args[i], err = wrapWithIsTrue(ctx, true, args[i], false); err != nil {
 			return nil, err
 		}
+		// CASE string arms need the final CASE charset/collation before the
+		// signature is built. newBaseBuiltinFuncWithFieldTypes only casts by
+		// EvalType for string arguments, so an already-string arm can otherwise
+		// keep a different collation from the CASE result.
 		if tp == types.ETString {
 			args[i+1] = wrapCaseWhenStringResult(ctx, args[i+1], fieldTp)
 		}
@@ -395,13 +399,16 @@ func (c *caseWhenFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	return sig, nil
 }
 
+// wrapCaseWhenStringResult coerces one CASE result arm to the final CASE string
+// type without changing the original expression. Result arms can be reused by
+// other predicates, so mutating a shared Column's FieldType here would also
+// change those predicates' comparison collation.
 func wrapCaseWhenStringResult(ctx BuildContext, arg Expression, targetTp *types.FieldType) Expression {
 	arg = WrapWithCastAsString(ctx, arg)
 	argTp := arg.GetType(ctx.GetEvalCtx())
 	if argTp.GetCharset() == targetTp.GetCharset() && argTp.GetCollate() == targetTp.GetCollate() {
 		return arg
 	}
-	// Cast only the CASE result arm copy so shared column expressions keep their own collation.
 	return BuildCastFunction(ctx, arg, targetTp.Clone())
 }
 

--- a/pkg/expression/builtin_control.go
+++ b/pkg/expression/builtin_control.go
@@ -343,9 +343,15 @@ func (c *caseWhenFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		if args[i], err = wrapWithIsTrue(ctx, true, args[i], false); err != nil {
 			return nil, err
 		}
+		if tp == types.ETString {
+			args[i+1] = wrapCaseWhenStringResult(ctx, args[i+1], fieldTp)
+		}
 		argTps = append(argTps, args[i].GetType(ctx.GetEvalCtx()), fieldTp.Clone())
 	}
 	if l%2 == 1 {
+		if tp == types.ETString {
+			args[l-1] = wrapCaseWhenStringResult(ctx, args[l-1], fieldTp)
+		}
 		argTps = append(argTps, fieldTp.Clone())
 	}
 	bf, err := newBaseBuiltinFuncWithFieldTypes(ctx, c.funcName, args, tp, argTps...)
@@ -387,6 +393,16 @@ func (c *caseWhenFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		return nil, errors.Errorf("%s is not supported for CASE WHEN", tp)
 	}
 	return sig, nil
+}
+
+func wrapCaseWhenStringResult(ctx BuildContext, arg Expression, targetTp *types.FieldType) Expression {
+	arg = WrapWithCastAsString(ctx, arg)
+	argTp := arg.GetType(ctx.GetEvalCtx())
+	if argTp.GetCharset() == targetTp.GetCharset() && argTp.GetCollate() == targetTp.GetCollate() {
+		return arg
+	}
+	// Cast only the CASE result arm copy so shared column expressions keep their own collation.
+	return BuildCastFunction(ctx, arg, targetTp.Clone())
 }
 
 type builtinCaseWhenIntSig struct {

--- a/pkg/expression/builtin_control.go
+++ b/pkg/expression/builtin_control.go
@@ -344,9 +344,8 @@ func (c *caseWhenFunctionClass) getFunction(ctx BuildContext, args []Expression)
 			return nil, err
 		}
 		// CASE string arms need the final CASE charset/collation before the
-		// signature is built. newBaseBuiltinFuncWithFieldTypes only casts by
-		// EvalType for string arguments, so an already-string arm can otherwise
-		// keep a different collation from the CASE result.
+		// signature is built. See wrapCaseWhenStringResult for why the normal
+		// string argument wrapping is not enough here.
 		if tp == types.ETString {
 			args[i+1] = wrapCaseWhenStringResult(ctx, args[i+1], fieldTp)
 		}
@@ -400,9 +399,14 @@ func (c *caseWhenFunctionClass) getFunction(ctx BuildContext, args []Expression)
 }
 
 // wrapCaseWhenStringResult coerces one CASE result arm to the final CASE string
-// type without changing the original expression. Result arms can be reused by
-// other predicates, so mutating a shared Column's FieldType here would also
-// change those predicates' comparison collation.
+// type without changing the original expression. This is needed because an
+// already-string arm can otherwise keep its own collation even when another arm
+// makes the final CASE result binary.
+//
+// Do not update the arm's FieldType in place: the same Column expression can
+// also be referenced by predicates outside this CASE. If this CASE changes that
+// Column to binary, those predicates will see binary collation too. Build a
+// cast around this CASE arm copy instead.
 func wrapCaseWhenStringResult(ctx BuildContext, arg Expression, targetTp *types.FieldType) Expression {
 	arg = WrapWithCastAsString(ctx, arg)
 	argTp := arg.GetType(ctx.GetEvalCtx())

--- a/pkg/expression/builtin_control_test.go
+++ b/pkg/expression/builtin_control_test.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/charset"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/testkit/testutil"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -56,6 +58,25 @@ func TestCaseWhen(t *testing.T) {
 	require.NoError(t, err)
 	_, err = evalBuiltinFunc(f, ctx, chunk.Row{})
 	require.Error(t, err)
+
+	textCol := &Column{
+		RetType: types.NewFieldTypeBuilder().SetType(mysql.TypeString).SetCharset(charset.CharsetUTF8MB4).SetCollate(charset.CollationUTF8MB4).BuildP(),
+	}
+	binaryCol := &Column{
+		RetType: types.NewFieldTypeBuilder().SetType(mysql.TypeBlob).SetCharset(charset.CharsetBin).SetCollate(charset.CollationBin).BuildP(),
+	}
+	caseExpr, err := newFunctionForTest(ctx, ast.Case, NewOne(), textCol, binaryCol)
+	require.NoError(t, err)
+	args := caseExpr.(*ScalarFunction).GetArgs()
+	require.Equal(t, charset.CharsetUTF8MB4, textCol.GetType(ctx.GetEvalCtx()).GetCharset())
+	require.Equal(t, charset.CollationUTF8MB4, textCol.GetType(ctx.GetEvalCtx()).GetCollate())
+	require.NotSame(t, textCol, args[1])
+	textResultCast, ok := args[1].(*ScalarFunction)
+	require.True(t, ok)
+	require.Equal(t, ast.Cast, textResultCast.FuncName.L)
+	require.Same(t, textCol, textResultCast.GetArgs()[0])
+	require.Equal(t, charset.CharsetBin, textResultCast.GetType(ctx.GetEvalCtx()).GetCharset())
+	require.Equal(t, charset.CollationBin, textResultCast.GetType(ctx.GetEvalCtx()).GetCollate())
 }
 
 func TestIf(t *testing.T) {

--- a/pkg/planner/core/casetest/rule/testdata/outer2inner_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/outer2inner_out.json
@@ -632,7 +632,7 @@
           "├─TableReader(Build) root  data:TableFullScan",
           "│ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
           "└─Projection(Probe) root  1->Column",
-          "  └─HashJoin root  CARTESIAN inner join, other cond:le(1, cast(case(istrue_with_null(cast(case(istrue_with_null(cast(test.t1.c_jbb, double BINARY)), from_binary(inet6_aton(test.t1.c_foveoe)), test.t1.c_cz), double BINARY)), \"1\", case(istrue_with_null(cast(test.t1.c_jbb, double BINARY)), from_binary(inet6_aton(test.t1.c_foveoe)), test.t1.c_cz)), double BINARY))",
+          "  └─HashJoin root  CARTESIAN inner join, other cond:le(1, cast(case(istrue_with_null(cast(case(istrue_with_null(cast(test.t1.c_jbb, double BINARY)), cast(from_binary(inet6_aton(test.t1.c_foveoe)), text BINARY CHARACTER SET utf8mb4 COLLATE utf8mb4_bin), test.t1.c_cz), double BINARY)), \"1\", case(istrue_with_null(cast(test.t1.c_jbb, double BINARY)), cast(from_binary(inet6_aton(test.t1.c_foveoe)), text BINARY CHARACTER SET utf8mb4 COLLATE utf8mb4_bin), test.t1.c_cz)), double BINARY))",
           "    ├─TableReader(Build) root  data:TableFullScan",
           "    │ └─TableFullScan cop[tikv] table:ref_0 keep order:false, stats:pseudo",
           "    └─HashJoin(Probe) root  CARTESIAN right outer join, left side:TableReader, right cond:ne(test.t2.c_g7eofzlxn, 1)",

--- a/pkg/planner/core/casetest/rule/testdata/outer2inner_xut.json
+++ b/pkg/planner/core/casetest/rule/testdata/outer2inner_xut.json
@@ -632,7 +632,7 @@
           "├─TableReader(Build) root  data:TableFullScan",
           "│ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
           "└─Projection(Probe) root  1->Column",
-          "  └─HashJoin root  CARTESIAN inner join, other cond:le(1, cast(case(istrue_with_null(cast(case(istrue_with_null(cast(test.t1.c_jbb, double BINARY)), from_binary(inet6_aton(test.t1.c_foveoe)), test.t1.c_cz), double BINARY)), \"1\", case(istrue_with_null(cast(test.t1.c_jbb, double BINARY)), from_binary(inet6_aton(test.t1.c_foveoe)), test.t1.c_cz)), double BINARY))",
+          "  └─HashJoin root  CARTESIAN inner join, other cond:le(1, cast(case(istrue_with_null(cast(case(istrue_with_null(cast(test.t1.c_jbb, double BINARY)), cast(from_binary(inet6_aton(test.t1.c_foveoe)), text BINARY CHARACTER SET utf8mb4 COLLATE utf8mb4_bin), test.t1.c_cz), double BINARY)), \"1\", case(istrue_with_null(cast(test.t1.c_jbb, double BINARY)), cast(from_binary(inet6_aton(test.t1.c_foveoe)), text BINARY CHARACTER SET utf8mb4 COLLATE utf8mb4_bin), test.t1.c_cz)), double BINARY))",
           "    ├─TableReader(Build) root  data:TableFullScan",
           "    │ └─TableFullScan cop[tikv] table:ref_0 keep order:false, stats:pseudo",
           "    └─HashJoin(Probe) root  CARTESIAN right outer join, left side:TableReader, right cond:ne(test.t2.c_g7eofzlxn, 1)",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67375

Related Issue: ref https://github.com/pingcap/tidb/issues/64822

Problem Summary:

A `CASE` expression with a binary string result could reuse a non-binary string column expression as one of its result arms. The binary `CASE` context could mutate shared column expression metadata, so the same column used by the `JOIN` comparison was compared with the wrong collation and made a logically contradictory aggregate return a non-zero count.

### What changed and how does it work?

This PR wraps `CASE` string result arms as expression copies with the resolved `CASE` charset and collation before building the builtin signature. The cast is applied only to `CASE` result arm copies, so shared column expressions keep their original charset and collation when they are also used elsewhere, such as in `JOIN` predicates.

The change intentionally avoids the global `ETString` implicit-cast path.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that a binary CASE result could mutate shared column expression metadata and produce wrong results.
```

### Tests

- `./tools/check/failpoint-go-test.sh pkg/expression -run TestCaseWhen -count=1`
- `./tools/check/failpoint-go-test.sh pkg/executor/test/issuetest -run TestCaseWhenBinaryResultDoesNotMutateSharedColumns -count=1`
- `make bazel_prepare`
- `make lint`
- `git diff --check -- pkg/expression/builtin_control.go pkg/expression/builtin_control_test.go pkg/executor/test/issuetest/executor_issue_test.go pkg/executor/test/issuetest/BUILD.bazel`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CASE WHEN with mixed binary/text results no longer alters shared-column comparisons, restoring correct query semantics.

* **Tests**
  * Added a regression test for CASE WHEN binary/text behavior.
  * Updated expected query plan outputs to match corrected type/collation handling.

* **Chores**
  * Adjusted test sharding configuration for the executor test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
