### PR TITLE
test: cover materialized view log on generated column

### DIFF
--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -876,3 +876,26 @@ func TestPurgeMaterializedViewLogInternalSQLStartWithNoNextSetsNextTimeNull(t *t
 		mlogID,
 	)).Check(testkit.Rows("automatically"))
 }
+
+func TestCreateMaterializedViewLogAllowsGeneratedColumns(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("CREATE TABLE t_gen (" +
+		"id BIGINT NOT NULL PRIMARY KEY," +
+		"base BIGINT NOT NULL," +
+		"gv BIGINT AS (base + 1) VIRTUAL," +
+		"gs BIGINT AS (base + 2) STORED" +
+		")")
+	tk.MustExec("CREATE MATERIALIZED VIEW LOG ON t_gen (id, gv, gs)")
+
+	tk.MustQuery("select column_name from information_schema.columns where table_schema='test' and table_name='$mlog$t_gen' order by ordinal_position").
+		Check(testkit.Rows("id", "gv", "gs", "_MLOG$_DML_TYPE", "_MLOG$_OLD_NEW"))
+
+	is := dom.InfoSchema()
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_gen"))
+	require.NoError(t, err)
+	require.NotNil(t, mlogTable.Meta().MaterializedViewLog)
+	require.Equal(t, []pmodel.CIStr{pmodel.NewCIStr("id"), pmodel.NewCIStr("gv"), pmodel.NewCIStr("gs")}, mlogTable.Meta().MaterializedViewLog.Columns)
+}

--- a/pkg/executor/test/writetest/mview_log_write_test.go
+++ b/pkg/executor/test/writetest/mview_log_write_test.go
@@ -1153,14 +1153,8 @@ func TestMLogAlterDropTrackedGeneratedColumnCurrentBehavior(t *testing.T) {
 		t.Run(ca.name, func(t *testing.T) {
 			tk.MustExec("create table " + ca.table + " (id int primary key, base int, g int as (base + 1) " + ca.kind + ")")
 			tk.MustExec("create materialized view log on " + ca.table + " (id, g)")
-			tk.MustExec("alter table " + ca.table + " drop column g")
-
-			err := tk.ExecToErr("insert into " + ca.table + " values (1, 10)")
-			require.ErrorContains(t, err, "wrap table with mlog: base column g not found")
-			err = tk.ExecToErr("update " + ca.table + " set base=11 where id=1")
-			require.ErrorContains(t, err, "wrap table with mlog: base column g not found")
-			err = tk.ExecToErr("delete from " + ca.table + " where id=1")
-			require.ErrorContains(t, err, "wrap table with mlog: base column g not found")
+			err := tk.ExecToErr("alter table " + ca.table + " drop column g")
+			require.ErrorContains(t, err, "referenced by materialized view log")
 		})
 	}
 }
@@ -1205,10 +1199,8 @@ func TestMLogAlterRenameTrackedGeneratedColumnCurrentBehavior(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (id int primary key, base int, g int as (base + 1) virtual)")
 	tk.MustExec("create materialized view log on t (id, g)")
-	tk.MustExec("alter table t rename column g to g2")
-
-	err := tk.ExecToErr("insert into t (id, base) values (1, 10)")
-	require.ErrorContains(t, err, "wrap table with mlog: base column g not found")
+	err := tk.ExecToErr("alter table t rename column g to g2")
+	require.ErrorContains(t, err, "referenced by materialized view log")
 }
 
 func TestMLogAutoIncrement(t *testing.T) {

--- a/pkg/executor/test/writetest/mview_log_write_test.go
+++ b/pkg/executor/test/writetest/mview_log_write_test.go
@@ -145,6 +145,24 @@ func TestMLogInsert(t *testing.T) {
 	))
 }
 
+func TestMLogInsertGeneratedColumn(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_gen (" +
+		"id bigint primary key," +
+		"base int not null," +
+		"gv int as (base + 1) virtual," +
+		"gs int as (base + 2) stored" +
+		")")
+	tk.MustExec("create materialized view log on t_gen (id, gv, gs)")
+
+	tk.MustExec("insert into t_gen(id, base) values (1, 10), (2, 20)")
+	tk.MustQuery("select id, gv, gs, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t_gen` order by id").
+		Check(testkit.Rows("1 11 12 I 1", "2 21 22 I 1"))
+}
+
 func TestMLogInsertSelect(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -1059,6 +1077,138 @@ func TestMLogVirtualGeneratedColumn(t *testing.T) {
 		"1 10 30 U -1",
 		"1 11 31 U 1",
 	))
+}
+
+func TestMLogUpdateTrackedGeneratedColumnOnly(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	cases := []struct {
+		name  string
+		table string
+		mlog  string
+		kind  string
+	}{
+		{name: "stored", table: "t_stored", mlog: "`$mlog$t_stored`", kind: "stored"},
+		{name: "virtual", table: "t_virtual", mlog: "`$mlog$t_virtual`", kind: "virtual"},
+	}
+	for _, ca := range cases {
+		t.Run(ca.name, func(t *testing.T) {
+			tk.MustExec("create table " + ca.table + " (a int primary key, b int, c int, d int as (b+c) " + ca.kind + ")")
+			tk.MustExec("create materialized view log on " + ca.table + " (a, d)")
+
+			tk.MustExec("insert into " + ca.table + " (a, b, c) values (1, 10, 20)")
+			execAsMViewMaintenance(tk, "delete from "+ca.mlog)
+			tk.MustExec("update " + ca.table + " set b=11 where a=1")
+
+			tk.MustQuery(
+				"select a, d, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from " + ca.mlog,
+			).Sort().Check(testkit.Rows(
+				"1 30 U -1",
+				"1 31 U 1",
+			))
+		})
+	}
+}
+
+func TestMLogAlterAddGeneratedColumn(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t (id int primary key, tracked int)")
+	tk.MustExec("create materialized view log on t (id, tracked)")
+
+	tk.MustExec("alter table t add column gv int as (tracked + 1) virtual")
+	err := tk.ExecToErr("alter table t add column gs int as (tracked + 2) stored")
+	require.ErrorContains(t, err, "Adding generated stored column through ALTER TABLE")
+
+	tk.MustExec("insert into t (id, tracked) values (1, 10)")
+	tk.MustQuery("select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`").
+		Check(testkit.Rows("1 10 I 1"))
+	tk.MustQuery("select id, tracked, gv from t").Check(testkit.Rows("1 10 11"))
+
+	execAsMViewMaintenance(tk, "delete from `$mlog$t`")
+	tk.MustExec("update t set tracked=20 where id=1")
+	tk.MustQuery("select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`").Sort().
+		Check(testkit.Rows("1 10 U -1", "1 20 U 1"))
+	tk.MustQuery("select id, tracked, gv from t").Check(testkit.Rows("1 20 21"))
+}
+
+func TestMLogAlterDropTrackedGeneratedColumnCurrentBehavior(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	cases := []struct {
+		name  string
+		table string
+		kind  string
+	}{
+		{name: "stored", table: "t_drop_stored", kind: "stored"},
+		{name: "virtual", table: "t_drop_virtual", kind: "virtual"},
+	}
+	for _, ca := range cases {
+		t.Run(ca.name, func(t *testing.T) {
+			tk.MustExec("create table " + ca.table + " (id int primary key, base int, g int as (base + 1) " + ca.kind + ")")
+			tk.MustExec("create materialized view log on " + ca.table + " (id, g)")
+			tk.MustExec("alter table " + ca.table + " drop column g")
+
+			err := tk.ExecToErr("insert into " + ca.table + " values (1, 10)")
+			require.ErrorContains(t, err, "wrap table with mlog: base column g not found")
+			err = tk.ExecToErr("update " + ca.table + " set base=11 where id=1")
+			require.ErrorContains(t, err, "wrap table with mlog: base column g not found")
+			err = tk.ExecToErr("delete from " + ca.table + " where id=1")
+			require.ErrorContains(t, err, "wrap table with mlog: base column g not found")
+		})
+	}
+}
+
+func TestMLogAlterGeneratedColumnConstraints(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (id int primary key, base int, gv int as (base + 1) virtual, gs int as (base + 2) stored)")
+	tk.MustExec("create materialized view log on t (id, gv, gs)")
+
+	err := tk.ExecToErr("alter table t rename column base to base2")
+	require.ErrorContains(t, err, "generated column dependency")
+	err = tk.ExecToErr("alter table t modify column base bigint")
+	require.ErrorContains(t, err, "generated column dependency")
+	err = tk.ExecToErr("alter table t modify column gv bigint")
+	require.ErrorContains(t, err, "Changing the STORED status")
+}
+
+func TestMLogAlterModifyTrackedVirtualGeneratedColumn(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t (id int primary key, base int, g int as (base + 1) virtual)")
+	tk.MustExec("create materialized view log on t (id, g)")
+	tk.MustExec("alter table t modify column g int as (base + 2) virtual")
+
+	tk.MustExec("insert into t (id, base) values (1, 10)")
+	tk.MustQuery("select id, g, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`").
+		Check(testkit.Rows("1 12 I 1"))
+
+	execAsMViewMaintenance(tk, "delete from `$mlog$t`")
+	tk.MustExec("update t set base=20 where id=1")
+	tk.MustQuery("select id, g, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`").Sort().
+		Check(testkit.Rows("1 12 U -1", "1 22 U 1"))
+}
+
+func TestMLogAlterRenameTrackedGeneratedColumnCurrentBehavior(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (id int primary key, base int, g int as (base + 1) virtual)")
+	tk.MustExec("create materialized view log on t (id, g)")
+	tk.MustExec("alter table t rename column g to g2")
+
+	err := tk.ExecToErr("insert into t (id, base) values (1, 10)")
+	require.ErrorContains(t, err, "wrap table with mlog: base column g not found")
 }
 
 func TestMLogAutoIncrement(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #66757

Problem Summary: Add coverage for materialized view logs that track generated columns. The current behavior is to allow generated columns in the MLog column list; this PR documents that behavior with DDL and write-path tests instead of forbidding it.

The coverage now includes both virtual and stored generated columns, updates where only the generated column is tracked, and ALTER TABLE behavior around adding, dropping, renaming, and modifying generated columns after an MLog is created.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Ran:

- `go test -count=1 -tags intest ./pkg/executor/test/ddl -run TestCreateMaterializedViewLogAllowsGeneratedColumns`
- `go test -count=1 -tags intest ./pkg/executor/test/writetest -run 'TestMLog.*GeneratedColumn'`
- `go test -tags intest ./pkg/executor/test/writetest -run 'TestMLog(InsertGeneratedColumn|UpdateTrackedGeneratedColumnOnly|Alter(AddGeneratedColumn|DropTrackedGeneratedColumnCurrentBehavior|GeneratedColumnConstraints|ModifyTrackedVirtualGeneratedColumn|RenameTrackedGeneratedColumnCurrentBehavior))'`
- `git diff --check`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for materialized view logs with generated columns, including creating logs that include both virtual and stored generated columns.
  * Added insert/update validations to confirm computed generated values are captured correctly in log records, including DML metadata.
  * Added alter/rename/drop scenarios to verify expected behaviors and error handling when generated-column dependencies change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->