### PR TITLE
expression: fix BIT control function cast to string

### DIFF
--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -55,6 +55,7 @@ var (
 	_ builtinFunc = &builtinCastIntAsIntSig{}
 	_ builtinFunc = &builtinCastIntAsRealSig{}
 	_ builtinFunc = &builtinCastIntAsStringSig{}
+	_ builtinFunc = &builtinCastBitAsStringSig{}
 	_ builtinFunc = &builtinCastIntAsDecimalSig{}
 	_ builtinFunc = &builtinCastIntAsTimeSig{}
 	_ builtinFunc = &builtinCastIntAsDurationSig{}
@@ -315,6 +316,13 @@ func (c *castAsStringFunctionClass) getFunction(ctx BuildContext, args []Express
 	if ft := args[0].GetType(ctx.GetEvalCtx()); ft.Hybrid() {
 		castBitAsUnBinary := ft.GetType() == mysql.TypeBit && c.tp.GetCharset() != charset.CharsetBin
 		if !castBitAsUnBinary {
+			if ft.GetType() == mysql.TypeBit {
+				if _, ok := args[0].(*ScalarFunction); ok {
+					sig = &builtinCastBitAsStringSig{bf}
+					// This is not equivalent to CastIntAsString because BIT string casts preserve binary bytes.
+					return sig, nil
+				}
+			}
 			sig = &builtinCastStringAsStringSig{bf}
 			sig.setPbCode(tipb.ScalarFuncSig_CastStringAsString)
 			return sig, nil
@@ -1103,6 +1111,40 @@ func (b *builtinCastIntAsStringSig) evalString(ctx EvalContext, row chunk.Row) (
 		return res, false, err
 	}
 	return padZeroForBinaryType(res, b.tp, ctx)
+}
+
+type builtinCastBitAsStringSig struct {
+	baseBuiltinFunc
+	// NOTE: Any new fields added here must be thread-safe or immutable during execution,
+	// as this expression may be shared across sessions.
+	// If a field does not meet these requirements, set SafeToShareAcrossSession to false.
+}
+
+func (b *builtinCastBitAsStringSig) Clone() builtinFunc {
+	newSig := &builtinCastBitAsStringSig{}
+	newSig.cloneFrom(&b.baseBuiltinFunc)
+	return newSig
+}
+
+func (b *builtinCastBitAsStringSig) evalString(ctx EvalContext, row chunk.Row) (res string, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
+	if isNull || err != nil {
+		return res, isNull, err
+	}
+	res = bitIntToBinaryString(val, b.args[0].GetType(ctx))
+	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, typeCtx(ctx), false)
+	if err != nil {
+		return res, false, err
+	}
+	return padZeroForBinaryType(res, b.tp, ctx)
+}
+
+func bitIntToBinaryString(val int64, tp *types.FieldType) string {
+	byteSize := -1
+	if flen := tp.GetFlen(); flen > 0 && flen != types.UnspecifiedLength {
+		byteSize = (flen + 7) / 8
+	}
+	return types.NewBinaryLiteralFromUint(uint64(val), byteSize).ToString()
 }
 
 type builtinCastIntAsTimeSig struct {

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -694,6 +694,10 @@ func (*builtinCastIntAsStringSig) vectorized() bool {
 	return true
 }
 
+func (*builtinCastBitAsStringSig) vectorized() bool {
+	return true
+}
+
 func (b *builtinCastIntAsStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get()
@@ -738,6 +742,44 @@ func (b *builtinCastIntAsStringSig) vecEvalString(ctx EvalContext, input *chunk.
 		} else {
 			result.AppendString(str)
 		}
+	}
+	return nil
+}
+
+func (b *builtinCastBitAsStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get()
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
+		return err
+	}
+
+	tp := b.args[0].GetType(ctx)
+	result.ReserveString(n)
+	i64s := buf.Int64s()
+	for i := range n {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		str := bitIntToBinaryString(i64s[i], tp)
+		str, err = types.ProduceStrWithSpecifiedTp(str, b.tp, typeCtx(ctx), false)
+		if err != nil {
+			return err
+		}
+		var isNull bool
+		str, isNull, err = padZeroForBinaryType(str, b.tp, ctx)
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.AppendNull()
+			continue
+		}
+		result.AppendString(str)
 	}
 	return nil
 }

--- a/pkg/expression/builtin_threadsafe_generated.go
+++ b/pkg/expression/builtin_threadsafe_generated.go
@@ -335,6 +335,11 @@ func (s *builtinCaseWhenVectorFloat32Sig) SafeToShareAcrossSession() bool {
 }
 
 // SafeToShareAcrossSession implements BuiltinFunc.SafeToShareAcrossSession.
+func (s *builtinCastBitAsStringSig) SafeToShareAcrossSession() bool {
+	return safeToShareAcrossSession(&s.safeToShareAcrossSessionFlag, s.args)
+}
+
+// SafeToShareAcrossSession implements BuiltinFunc.SafeToShareAcrossSession.
 func (s *builtinCastDecimalAsDecimalSig) SafeToShareAcrossSession() bool {
 	return safeToShareAcrossSession(&s.safeToShareAcrossSessionFlag, s.args)
 }

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -4313,6 +4313,20 @@ func TestTiDBRowChecksumBuiltin(t *testing.T) {
 	tk.MustGetDBError("select tidb_row_checksum() from t where id > 0", expression.ErrNotSupportedYet)
 }
 
+func TestIssue66662(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table table1 (active bit, wider bit(10))")
+	tk.MustExec("insert into table1 values (1, 0b10101)")
+
+	for _, vectorized := range []string{"on", "off"} {
+		tk.MustExec("set @@tidb_enable_vectorized_expression=" + vectorized)
+		tk.MustQuery("select hex(cast(coalesce(active) as char)), is_ipv4(coalesce(active)), hex(cast(coalesce(wider) as char)) from table1").Check(testkit.Rows("01 0 0015"))
+		tk.MustQuery("select 1 as c0 from table1 as tom1 where coalesce(is_ipv4(coalesce(tom1.active)))").Check(testkit.Rows())
+	}
+}
+
 func TestIssue43527(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/66662

Problem Summary:

`IS_IPV4(COALESCE(bit_col))` can fail with an internal expression error:

```text
baseBuiltinFunc.evalString() should never be called
```

`COALESCE(bit_col)` keeps a `BIT` return field type, but its concrete control-function signature evaluates as integer. When a later string context casts it to binary string, TiDB picked the string-to-string cast signature and called `EvalString` / `VecEvalString` on the integer-evaluated control function.

### What changed and how does it work?

Add a narrow `builtinCastBitAsStringSig` path for scalar `BIT` expressions being cast to binary string.

The new signature evaluates the child through `EvalInt` / `VecEvalInt`, reconstructs the fixed-width `BinaryLiteral` string from the original `BIT` field length, and then applies the existing target string type handling. This keeps direct `BIT` column casting on the existing path and avoids treating a `BIT` binary string cast as a decimal integer string cast.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Manual test:

```sh
go test -tags=intest,deadlock ./pkg/expression/integration_test -run TestIssue66662 -count=1 -v
go test -tags=intest,deadlock ./.tmp/issue66662 -run TestIssue66662ReproAndControls -count=1 -v
go test -tags=intest,deadlock ./pkg/expression -run 'TestCoalesce|TestIsIPv4|TestCast' -count=1
git -c core.fsmonitor=false diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that `BIT` control-function results could fail with an internal expression error when they were used in string contexts such as `IS_IPV4(COALESCE(bit_col))`.
```
