### PR TITLE
*: refine exit code handling

### DIFF
--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/grafana/pyroscope-go"
@@ -143,6 +144,12 @@ const (
 	nmStandby           = "standby"
 	nmActivationTimeout = "activation-timeout"
 	nmMaxIdleSeconds    = "max-idle-seconds"
+)
+
+const (
+	exitCodeOK  = 0
+	exitCodeErr = 1
+	exitCodeInt = 128 + int(syscall.SIGINT)
 )
 
 var (
@@ -403,31 +410,50 @@ func main() {
 	}
 
 	exited := make(chan struct{})
-	signal.SetupSignalHandler(func() {
+	exitCode := exitCodeOK
+	signal.SetupSignalHandler(func(sig os.Signal) {
 		svr.Close()
 		resourcemanager.InstanceResourceManager.Stop()
 		cleanup(svr, storage, dom)
 		cpuprofile.StopCPUProfiler()
 		executor.Stop()
+		exitCode = exitCodeForSignal(sig)
 		close(exited)
 	})
 	topsql.SetupTopProfiling(keyspace.GetKeyspaceNameBytesBySettings(), svr, dom)
 	terror.MustNil(svr.Run(dom))
 	<-exited
-	syncLog()
+	if err := syncLog(); err != nil {
+		// Log sync failure means shutdown did not finish cleanly, so keep
+		// reporting it as a generic non-zero exit instead of a successful exit.
+		exitCode = exitCodeErr
+	}
+	if exitCode != exitCodeOK {
+		os.Exit(exitCode)
+	}
 }
 
-func syncLog() {
+func exitCodeForSignal(sig os.Signal) int {
+	// Standby force shutdown uses SIGINT. Return 128+SIGINT so deployment scripts
+	// can identify this force-shutdown path.
+	if sig == syscall.SIGINT {
+		return exitCodeInt
+	}
+	return exitCodeOK
+}
+
+func syncLog() error {
 	if err := log.Sync(); err != nil {
 		// Don't complain about /dev/stdout as Fsync will return EINVAL.
 		if pathErr, ok := err.(*fs.PathError); ok {
 			if pathErr.Path == "/dev/stdout" {
-				os.Exit(0)
+				return nil
 			}
 		}
 		fmt.Fprintln(os.Stderr, "sync log err:", err)
-		os.Exit(1)
+		return err
 	}
+	return nil
 }
 
 func checkTempStorageQuota() error {

--- a/cmd/tidb-server/main_test.go
+++ b/cmd/tidb-server/main_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"os"
+	"syscall"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/config"
@@ -48,6 +49,26 @@ func TestMain(m *testing.M) {
 func TestRunMain(t *testing.T) {
 	if isCoverageServer == "1" {
 		main()
+	}
+}
+
+func TestExitCodeForSignal(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  os.Signal
+		want int
+	}{
+		{name: "SIGINT", sig: syscall.SIGINT, want: exitCodeInt},
+		{name: "SIGTERM", sig: syscall.SIGTERM, want: exitCodeOK},
+		{name: "SIGHUP", sig: syscall.SIGHUP, want: exitCodeOK},
+		{name: "SIGQUIT", sig: syscall.SIGQUIT, want: exitCodeOK},
+		{name: "nil", sig: nil, want: exitCodeOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, exitCodeForSignal(tt.sig))
+		})
 	}
 }
 

--- a/pkg/util/signal/exit.go
+++ b/pkg/util/signal/exit.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
+
 package signal
 
 import (

--- a/pkg/util/signal/signal_posix.go
+++ b/pkg/util/signal/signal_posix.go
@@ -71,7 +71,7 @@ func SetupUSR1Handler() {
 }
 
 // SetupSignalHandler setup signal handler for TiDB Server
-func SetupSignalHandler(shutdownFunc func()) {
+func SetupSignalHandler(shutdownFunc func(sig os.Signal)) {
 	closeSignalChan := make(chan os.Signal, 1)
 	signal.Notify(closeSignalChan,
 		syscall.SIGHUP,
@@ -82,6 +82,6 @@ func SetupSignalHandler(shutdownFunc func()) {
 	go func() {
 		sig := <-closeSignalChan
 		logutil.BgLogger().Info("got signal to exit", zap.Stringer("signal", sig))
-		shutdownFunc()
+		shutdownFunc(sig)
 	}()
 }

--- a/pkg/util/signal/signal_wasm.go
+++ b/pkg/util/signal/signal_wasm.go
@@ -14,9 +14,11 @@
 
 package signal
 
+import "os"
+
 // SetupUSR1Handler sets up a signal handler for SIGUSR1.
 func SetupUSR1Handler() {}
 
-// SetupSignalHandler setup signal handler for TiDB Server
-func SetupSignalHandler(shutdownFunc func(bool)) {
+// SetupSignalHandler is a no-op on WASM and never invokes shutdownFunc.
+func SetupSignalHandler(shutdownFunc func(sig os.Signal)) {
 }

--- a/pkg/util/signal/signal_windows.go
+++ b/pkg/util/signal/signal_windows.go
@@ -28,7 +28,7 @@ import (
 func SetupUSR1Handler() {}
 
 // SetupSignalHandler setup signal handler for TiDB Server
-func SetupSignalHandler(shutdownFunc func()) {
+func SetupSignalHandler(shutdownFunc func(sig os.Signal)) {
 	//todo deal with dump goroutine stack on windows
 	closeSignalChan := make(chan os.Signal, 1)
 	signal.Notify(closeSignalChan,
@@ -40,6 +40,16 @@ func SetupSignalHandler(shutdownFunc func()) {
 	go func() {
 		sig := <-closeSignalChan
 		logutil.BgLogger().Info("got signal to exit", zap.Stringer("signal", sig))
-		shutdownFunc()
+		shutdownFunc(sig)
 	}()
+}
+
+// TiDBExit sends a signal to the current process.
+func TiDBExit(sig syscall.Signal) {
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		return
+	}
+	// Best effort; Windows does not support POSIX signal shutdown semantics.
+	_ = p.Signal(sig)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67765 

Problem Summary:

TiDB handles shutdown signals itself in order to perform graceful shutdown. As a result, when TiDB receives SIGINT, the process can finish cleanup and exit with code 0, which makes an interrupted shutdown indistinguishable from a normal successful exit for scripts, supervisors, or operators checking the process exit status.

SIGINT is conventionally reported as exit code 130 (`128 + SIGINT`). TiDB should preserve this convention after graceful shutdown, while keeping SIGTERM/SIGHUP/SIGQUIT successful graceful shutdown behavior unchanged.

### What changed and how does it work?

This PR passes the received signal into the TiDB shutdown callback. During shutdown, `tidb-server` records the intended exit code and sets it to 130 when the received signal is SIGINT. Other shutdown signals continue to use the normal successful exit path if cleanup succeeds.

This PR also changes `syncLog()` to return an error instead of calling `os.Exit()` internally, so the final exit code is decided in one place in `main()`. If log sync fails, TiDB exits with code 1; otherwise, SIGINT exits with 130 and normal graceful shutdown exits with 0.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Shutdown flow now tracks and uses explicit exit codes for signals and ensures logs are flushed before terminating.
* **Bug Fixes**
  * Log-sync failures on stdout are treated as non-fatal; other sync errors are reported and can affect the process exit code.
* **Chores**
  * Signal handling behavior unified and clarified across platforms, including explicit no-op handling where applicable and a best-effort exit helper.
* **Tests**
  * Added unit tests validating exit-code mapping for various signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->