### PR TITLE
pkg/ddl/tests/tiflash: stabilize flaky TestTiFlashFailureProgressAfterAvailable

### DIFF
--- a/pkg/ddl/tests/tiflash/BUILD.bazel
+++ b/pkg/ddl/tests/tiflash/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "//pkg/testkit/testsetup",
         "//pkg/types",
         "//pkg/util",
+        "//pkg/util/intest",
         "//pkg/util/sqlkiller",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/metapb",

--- a/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
+++ b/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
@@ -106,10 +106,12 @@ func createTiFlashContext(t *testing.T) (*tiflashContext, func()) {
 	s.dom.SetStatsUpdating(true)
 
 	tearDown := func() {
-		s.tiflash.Lock()
-		s.tiflash.StatusServer.Close()
-		s.tiflash.Unlock()
 		s.dom.Close()
+		s.tiflash.Lock()
+		if s.tiflash.StatusServer != nil {
+			s.tiflash.StatusServer.Close()
+		}
+		s.tiflash.Unlock()
 		require.NoError(t, s.store.Close())
 		ddl.PollTiFlashInterval = 2 * time.Second
 	}

--- a/pkg/ddl/tests/tiflash/main_test.go
+++ b/pkg/ddl/tests/tiflash/main_test.go
@@ -25,10 +25,15 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/testkit/testsetup"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
+	intest.InTest = true
+	intest.EnableAssert = true
+	intest.EnableInternalCheck = true
+
 	testsetup.SetupForCommonTest()
 
 	config.UpdateGlobal(func(conf *config.Config) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68100

Problem Summary:
Flaky test `TestTiFlashFailureProgressAfterAvailable` in `pkg/ddl/tests/tiflash` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The flaky came from test fixture teardown closing the mock TiFlash HTTP status server before the domain had fully stopped its background TiFlash polling routine, leaving a race that could panic with `connect: connection refused`.

#### Fix

Reordering teardown to `dom.Close()` before `StatusServer.Close()` removes the proven race window without weakening the test, and package-local `intest` setup is required so the runtime-mandated plain `go test -json` command can run this package at all.

#### Verification

Spec:
- target: `pkg/ddl/tests/tiflash :: TestTiFlashFailureProgressAfterAvailable`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/ddl/tests/tiflash -run '^TestTiFlashFailureProgressAfterAvailable$' -count=1`
- `go test -json ./pkg/ddl/tests/tiflash -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved TiFlash test teardown for greater stability by reordering shutdown steps and adding safety checks to prevent nil-related shutdown errors.
  * Strengthened the test harness: enabled in-test mode, assertions, and internal checks to catch issues earlier and improve reliability.
  * Updated test build configuration to include the in-test utilities dependency so the enhanced test behavior runs consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->