### PR TITLE
executor: add stream window execution helpers

### DIFF
--- a/docs/agents/architecture-index.md
+++ b/docs/agents/architecture-index.md
@@ -85,6 +85,7 @@ Hard requirements remain in the repository root `AGENTS.md`.
 - Store/KV/DistSQL -> Executor for distributed execution behavior.
 
 ## Notes and Runbooks
+- Executor notes: `docs/agents/executor/stream_window_notes.md`
 - Planner notes: `docs/agents/planner/rule/rule_ai_notes.md`
 - Notes guide: `docs/agents/notes-guide.md`
 - Testing runbook: `docs/agents/testing-flow.md`

--- a/docs/agents/executor/stream_window_notes.md
+++ b/docs/agents/executor/stream_window_notes.md
@@ -1,0 +1,33 @@
+# Stream Window Executor Notes
+
+## 2026-04-29: Executor slice for ordered-input window work
+
+Context:
+- Issue: https://github.com/pingcap/tidb/issues/67989
+- Demo PR: https://github.com/pingcap/tidb/pull/67696
+- This slice only extracts executor-side building blocks. Planner admission,
+  physical plan enumeration, and plan goldens should be reviewed separately.
+
+Executor boundary:
+- `StreamWindowExec` is a thin wrapper over `PipelinedWindowExec`.
+- The executor does not prove ordering by itself. Its caller must only choose it
+  when the child already satisfies the required `PARTITION BY` / `ORDER BY`
+  property.
+- `PipelinedWindowExec.OpenSelf()` exists for builder paths that already opened
+  children while constructing nested executors, such as index-join inner reader
+  construction. It resets only this executor's state.
+
+Partition pruning boundary:
+- `PartitionTopNWindowExec` is a local executor helper for
+  `row_number() <= K` style stream-window pruning.
+- It consumes ordered child rows, emits at most `K` rows per partition, and
+  materializes the `row_number` result column for emitted rows.
+- It is not a general `rank()` / `dense_rank()` pruning primitive. Tie-aware
+  rank functions need a different boundary because they cannot be reduced to a
+  hard row count per partition.
+
+Testing notes:
+- Cross-chunk coverage is required. A test that keeps each partition inside one
+  chunk can miss bugs where row numbers reset at chunk boundaries.
+- Direct executor tests are useful for this slice because planner enumeration is
+  intentionally left out of the PR.

--- a/pkg/executor/internal/vecgroupchecker/vec_group_checker.go
+++ b/pkg/executor/internal/vecgroupchecker/vec_group_checker.go
@@ -560,6 +560,16 @@ func (e *VecGroupChecker) Reset() {
 	}
 }
 
+// ResetForNewExecution resets both current-chunk state and previous-chunk state.
+func (e *VecGroupChecker) ResetForNewExecution() {
+	e.Reset()
+	e.nextGroupID = 0
+	e.groupCount = 0
+	if e.lastGroupKeyOfPrevChk != nil {
+		e.lastGroupKeyOfPrevChk = e.lastGroupKeyOfPrevChk[:0]
+	}
+}
+
 // GroupCount returns the number of groups.
 func (e *VecGroupChecker) GroupCount() int {
 	return e.groupCount

--- a/pkg/executor/internal/vecgroupchecker/vec_group_checker.go
+++ b/pkg/executor/internal/vecgroupchecker/vec_group_checker.go
@@ -537,7 +537,10 @@ func (e *VecGroupChecker) IsExhausted() bool {
 	return e.nextGroupID >= e.groupCount
 }
 
-// Reset resets the group checker.
+// Reset resets current-chunk state.
+// It intentionally keeps lastGroupKeyOfPrevChk because SplitIntoGroups calls
+// Reset before every input chunk and still needs the previous chunk key to
+// detect a group that spans chunk boundaries.
 func (e *VecGroupChecker) Reset() {
 	if e.groupOffset != nil {
 		e.groupOffset = e.groupOffset[:0]
@@ -560,7 +563,10 @@ func (e *VecGroupChecker) Reset() {
 	}
 }
 
-// ResetForNewExecution resets both current-chunk state and previous-chunk state.
+// ResetForNewExecution resets all state for a new logical input stream.
+// Unlike Reset, it also clears lastGroupKeyOfPrevChk so a reused executor will
+// not treat the first chunk of the new execution as a continuation of the last
+// chunk from the previous execution.
 func (e *VecGroupChecker) ResetForNewExecution() {
 	e.Reset()
 	e.nextGroupID = 0

--- a/pkg/executor/internal/vecgroupchecker/vec_group_checker_test.go
+++ b/pkg/executor/internal/vecgroupchecker/vec_group_checker_test.go
@@ -267,6 +267,16 @@ func TestVecGroupChecker(t *testing.T) {
 	require.Equal(t, b, 0)
 	require.Equal(t, e, 3)
 	require.True(t, groupChecker.IsExhausted())
+
+	groupChecker.Reset()
+	isFirstGroupSameAsPrev, err := groupChecker.SplitIntoGroups(chk)
+	require.NoError(t, err)
+	require.True(t, isFirstGroupSameAsPrev)
+
+	groupChecker.ResetForNewExecution()
+	isFirstGroupSameAsPrev, err = groupChecker.SplitIntoGroups(chk)
+	require.NoError(t, err)
+	require.False(t, isFirstGroupSameAsPrev)
 }
 
 func TestIssue53867(t *testing.T) {

--- a/pkg/executor/windows/BUILD.bazel
+++ b/pkg/executor/windows/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "windows",
     srcs = [
         "builder.go",
+        "partition_topn_window.go",
         "pipelined_window.go",
         "window.go",
     ],
@@ -28,13 +29,21 @@ go_test(
     name = "windows_test",
     timeout = "short",
     srcs = [
+        "partition_topn_window_test.go",
         "window_executor_test.go",
         "window_sql_test.go",
     ],
+    embed = [":windows"],
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
+        "//pkg/executor/internal/exec",
+        "//pkg/executor/internal/testutil",
+        "//pkg/expression",
         "//pkg/parser/mysql",
         "//pkg/testkit",
+        "//pkg/types",
+        "//pkg/util/mock",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/executor/windows/builder.go
+++ b/pkg/executor/windows/builder.go
@@ -15,6 +15,7 @@
 package windows
 
 import (
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/executor/aggfuncs"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/executor/internal/vecgroupchecker"
@@ -25,6 +26,44 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 )
+
+// BuildStream constructs the executor for a stream window physical plan.
+// The caller is responsible for ensuring the child already provides the
+// required partition/order property.
+func BuildStream(sctx sessionctx.Context, v *physicalop.PhysicalWindow, childExec exec.Executor) (exec.Executor, error) {
+	windowExec, err := Build(sctx, v, childExec, true)
+	if err != nil {
+		return nil, err
+	}
+	pipelinedExec, ok := windowExec.(*PipelinedWindowExec)
+	if !ok {
+		return nil, errors.New("stream window must be built with pipelined window executor")
+	}
+	return &StreamWindowExec{PipelinedWindowExec: pipelinedExec}, nil
+}
+
+// BuildPartitionTopN constructs the executor-side pruning helper for
+// row_number stream windows with a per-partition upper bound.
+func BuildPartitionTopN(
+	sctx sessionctx.Context,
+	schema *expression.Schema,
+	id int,
+	childExec exec.Executor,
+	partitionBy []expression.Expression,
+	resultColIdx int,
+	limitCount uint64,
+) *PartitionTopNWindowExec {
+	return &PartitionTopNWindowExec{
+		BaseExecutor: exec.NewBaseExecutor(sctx, schema, id, childExec),
+		groupChecker: vecgroupchecker.NewVecGroupChecker(
+			sctx.GetExprCtx().GetEvalCtx(),
+			sctx.GetSessionVars().EnableVectorizedExpression,
+			partitionBy,
+		),
+		limitCount:   limitCount,
+		resultColIdx: resultColIdx,
+	}
+}
 
 // Build constructs the concrete executor for a window physical plan.
 func Build(sctx sessionctx.Context, v *physicalop.PhysicalWindow, childExec exec.Executor, forcePipelined bool) (exec.Executor, error) {

--- a/pkg/executor/windows/partition_topn_window.go
+++ b/pkg/executor/windows/partition_topn_window.go
@@ -35,6 +35,8 @@ type PartitionTopNWindowExec struct {
 	limitCount   uint64
 	resultColIdx int
 
+	// groupStart and groupEnd delimit the current group inside childResult as a
+	// half-open row range [groupStart, groupEnd).
 	groupStart int
 	groupEnd   int
 	// groupRank is the current row_number value within the partition. It keeps

--- a/pkg/executor/windows/partition_topn_window.go
+++ b/pkg/executor/windows/partition_topn_window.go
@@ -1,0 +1,132 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package windows
+
+import (
+	"context"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/executor/internal/exec"
+	"github.com/pingcap/tidb/pkg/executor/internal/vecgroupchecker"
+	"github.com/pingcap/tidb/pkg/util/chunk"
+)
+
+// PartitionTopNWindowExec fuses a row_number stream window with an upper-bound
+// filter and only produces the first K rows of each partition.
+type PartitionTopNWindowExec struct {
+	exec.BaseExecutor
+
+	groupChecker *vecgroupchecker.VecGroupChecker
+	childResult  *chunk.Chunk
+
+	limitCount   uint64
+	resultColIdx int
+
+	groupStart int
+	groupEnd   int
+	groupRank  uint64
+	exhausted  bool
+
+	resumeLastPartition bool
+}
+
+// Open implements the Executor Open interface.
+func (e *PartitionTopNWindowExec) Open(ctx context.Context) error {
+	if err := e.BaseExecutor.Open(ctx); err != nil {
+		return err
+	}
+	return e.OpenSelf()
+}
+
+// OpenSelf initializes the executor state without opening children.
+func (e *PartitionTopNWindowExec) OpenSelf() error {
+	e.childResult = nil
+	e.groupStart = 0
+	e.groupEnd = 0
+	e.groupRank = 0
+	e.exhausted = false
+	e.resumeLastPartition = false
+	return nil
+}
+
+// Close implements the Executor Close interface.
+func (e *PartitionTopNWindowExec) Close() error {
+	return errors.Trace(e.BaseExecutor.Close())
+}
+
+// Next implements the Executor Next interface.
+func (e *PartitionTopNWindowExec) Next(ctx context.Context, req *chunk.Chunk) error {
+	req.Reset()
+	if e.limitCount == 0 {
+		return nil
+	}
+	for !req.IsFull() {
+		if e.groupStart >= e.groupEnd {
+			drained, err := e.loadNextGroup(ctx)
+			if err != nil {
+				return err
+			}
+			if drained {
+				return nil
+			}
+		}
+		if e.groupRank >= e.limitCount {
+			e.groupStart = e.groupEnd
+			continue
+		}
+		row := e.childResult.GetRow(e.groupStart)
+		e.groupStart++
+		e.groupRank++
+		req.AppendPartialRow(0, row)
+		req.AppendInt64(e.resultColIdx, int64(e.groupRank))
+	}
+	return nil
+}
+
+func (e *PartitionTopNWindowExec) loadNextGroup(ctx context.Context) (bool, error) {
+	for {
+		if e.exhausted {
+			return true, nil
+		}
+		if e.groupChecker.IsExhausted() {
+			childResult := exec.TryNewCacheChunk(e.Children(0))
+			if err := exec.Next(ctx, e.Children(0), childResult); err != nil {
+				return false, errors.Trace(err)
+			}
+			if childResult.NumRows() == 0 {
+				e.exhausted = true
+				return true, nil
+			}
+			e.childResult = childResult
+			samePartition, err := e.groupChecker.SplitIntoGroups(childResult)
+			if err != nil {
+				return false, errors.Trace(err)
+			}
+			e.resumeLastPartition = samePartition
+		}
+		begin, end := e.groupChecker.GetNextGroup()
+		if begin == end {
+			continue
+		}
+		e.groupStart = begin
+		e.groupEnd = end
+		if e.resumeLastPartition {
+			e.resumeLastPartition = false
+		} else {
+			e.groupRank = 0
+		}
+		return false, nil
+	}
+}

--- a/pkg/executor/windows/partition_topn_window.go
+++ b/pkg/executor/windows/partition_topn_window.go
@@ -31,13 +31,16 @@ type PartitionTopNWindowExec struct {
 	groupChecker *vecgroupchecker.VecGroupChecker
 	childResult  *chunk.Chunk
 
+	// limitCount is the per-partition upper bound from row_number() <= K.
 	limitCount   uint64
 	resultColIdx int
 
 	groupStart int
 	groupEnd   int
-	groupRank  uint64
-	exhausted  bool
+	// groupRank is the current row_number value within the partition. It keeps
+	// increasing across child chunks when one partition spans multiple chunks.
+	groupRank uint64
+	exhausted bool
 
 	resumeLastPartition bool
 }

--- a/pkg/executor/windows/partition_topn_window.go
+++ b/pkg/executor/windows/partition_topn_window.go
@@ -58,6 +58,7 @@ func (e *PartitionTopNWindowExec) Open(ctx context.Context) error {
 // OpenSelf initializes the executor state without opening children.
 func (e *PartitionTopNWindowExec) OpenSelf() error {
 	e.childResult = nil
+	e.groupChecker.ResetForNewExecution()
 	e.groupStart = 0
 	e.groupEnd = 0
 	e.groupRank = 0

--- a/pkg/executor/windows/partition_topn_window.go
+++ b/pkg/executor/windows/partition_topn_window.go
@@ -58,6 +58,9 @@ func (e *PartitionTopNWindowExec) Open(ctx context.Context) error {
 // OpenSelf initializes the executor state without opening children.
 func (e *PartitionTopNWindowExec) OpenSelf() error {
 	e.childResult = nil
+	// OpenSelf may run again on a reused executor instance. Drop cross-chunk
+	// partition state here so the first chunk of this execution starts a fresh
+	// row_number sequence instead of continuing the previous execution.
 	e.groupChecker.ResetForNewExecution()
 	e.groupStart = 0
 	e.groupEnd = 0

--- a/pkg/executor/windows/partition_topn_window_test.go
+++ b/pkg/executor/windows/partition_topn_window_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package windows
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/executor/internal/exec"
+	"github.com/pingcap/tidb/pkg/executor/internal/testutil"
+	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitionTopNWindowExecAcrossChunks(t *testing.T) {
+	ctx := mock.NewContext()
+	ctx.GetSessionVars().InitChunkSize = 2
+	ctx.GetSessionVars().MaxChunkSize = 2
+
+	intTp := types.NewFieldType(mysql.TypeLonglong)
+	partitionCol := &expression.Column{Index: 0, RetType: intTp}
+	valueCol := &expression.Column{Index: 1, RetType: intTp}
+	rowNumberCol := &expression.Column{Index: 2, RetType: intTp}
+	childSchema := expression.NewSchema(partitionCol, valueCol)
+	resultSchema := expression.NewSchema(partitionCol, valueCol, rowNumberCol)
+	childExec := testutil.BuildMockDataSource(testutil.MockDataSourceParameters{
+		Ctx:        ctx,
+		DataSchema: childSchema,
+		Rows:       6,
+		Ndvs:       []int{-2, -2},
+		Datums: [][]any{
+			{int64(1), int64(1), int64(1), int64(2), int64(2), int64(3)},
+			{int64(10), int64(11), int64(12), int64(20), int64(21), int64(30)},
+		},
+	})
+	childExec.PrepareChunks()
+	windowExec := BuildPartitionTopN(
+		ctx,
+		resultSchema,
+		1,
+		childExec,
+		[]expression.Expression{partitionCol},
+		2,
+		2,
+	)
+
+	require.NoError(t, windowExec.Open(context.Background()))
+	defer func() {
+		require.NoError(t, windowExec.Close())
+	}()
+
+	rows := drainPartitionTopNRows(t, windowExec)
+	require.Equal(t, [][]int64{
+		{1, 10, 1},
+		{1, 11, 2},
+		{2, 20, 1},
+		{2, 21, 2},
+		{3, 30, 1},
+	}, rows)
+}
+
+func drainPartitionTopNRows(t *testing.T, executor exec.Executor) [][]int64 {
+	rows := make([][]int64, 0)
+	for {
+		chk := executor.NewChunk()
+		require.NoError(t, exec.Next(context.Background(), executor, chk))
+		if chk.NumRows() == 0 {
+			return rows
+		}
+		for i := range chk.NumRows() {
+			row := chk.GetRow(i)
+			rows = append(rows, []int64{
+				row.GetInt64(0),
+				row.GetInt64(1),
+				row.GetInt64(2),
+			})
+		}
+	}
+}

--- a/pkg/executor/windows/partition_topn_window_test.go
+++ b/pkg/executor/windows/partition_topn_window_test.go
@@ -23,14 +23,70 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPartitionTopNWindowExecAcrossChunks(t *testing.T) {
+	_, windowExec := buildPartitionTopNWindowExecForTest(
+		2,
+		[][]any{
+			{int64(1), int64(1), int64(1), int64(2), int64(2), int64(3)},
+			{int64(10), int64(11), int64(12), int64(20), int64(21), int64(30)},
+		},
+		2,
+	)
+	require.NoError(t, windowExec.Open(context.Background()))
+	rows := drainPartitionTopNRows(t, windowExec)
+	require.NoError(t, windowExec.Close())
+	require.Equal(t, [][]int64{
+		{1, 10, 1},
+		{1, 11, 2},
+		{2, 20, 1},
+		{2, 21, 2},
+		{3, 30, 1},
+	}, rows)
+
+	childExec, windowExec := buildPartitionTopNWindowExecForTest(
+		4,
+		[][]any{
+			{int64(1), int64(1), int64(2), int64(2)},
+			{int64(10), int64(11), int64(20), int64(21)},
+		},
+		2,
+	)
+	require.NoError(t, windowExec.Open(context.Background()))
+	req := chunk.NewChunkWithCapacity(exec.RetTypes(windowExec), 1)
+	require.NoError(t, exec.Next(context.Background(), windowExec, req))
+	require.Equal(t, 1, req.NumRows())
+	require.Equal(t, []int64{1, 10, 1}, []int64{
+		req.GetRow(0).GetInt64(0),
+		req.GetRow(0).GetInt64(1),
+		req.GetRow(0).GetInt64(2),
+	})
+	require.NoError(t, windowExec.Close())
+
+	childExec.PrepareChunks()
+	require.NoError(t, windowExec.Open(context.Background()))
+	rows = drainPartitionTopNRows(t, windowExec)
+	require.NoError(t, windowExec.Close())
+	require.Equal(t, [][]int64{
+		{1, 10, 1},
+		{1, 11, 2},
+		{2, 20, 1},
+		{2, 21, 2},
+	}, rows)
+}
+
+func buildPartitionTopNWindowExecForTest(
+	maxChunkSize int,
+	datums [][]any,
+	limitCount uint64,
+) (*testutil.MockDataSource, *PartitionTopNWindowExec) {
 	ctx := mock.NewContext()
-	ctx.GetSessionVars().InitChunkSize = 2
-	ctx.GetSessionVars().MaxChunkSize = 2
+	ctx.GetSessionVars().InitChunkSize = maxChunkSize
+	ctx.GetSessionVars().MaxChunkSize = maxChunkSize
 
 	intTp := types.NewFieldType(mysql.TypeLonglong)
 	partitionCol := &expression.Column{Index: 0, RetType: intTp}
@@ -41,37 +97,20 @@ func TestPartitionTopNWindowExecAcrossChunks(t *testing.T) {
 	childExec := testutil.BuildMockDataSource(testutil.MockDataSourceParameters{
 		Ctx:        ctx,
 		DataSchema: childSchema,
-		Rows:       6,
+		Rows:       len(datums[0]),
 		Ndvs:       []int{-2, -2},
-		Datums: [][]any{
-			{int64(1), int64(1), int64(1), int64(2), int64(2), int64(3)},
-			{int64(10), int64(11), int64(12), int64(20), int64(21), int64(30)},
-		},
+		Datums:     datums,
 	})
 	childExec.PrepareChunks()
-	windowExec := BuildPartitionTopN(
+	return childExec, BuildPartitionTopN(
 		ctx,
 		resultSchema,
 		1,
 		childExec,
 		[]expression.Expression{partitionCol},
 		2,
-		2,
+		limitCount,
 	)
-
-	require.NoError(t, windowExec.Open(context.Background()))
-	defer func() {
-		require.NoError(t, windowExec.Close())
-	}()
-
-	rows := drainPartitionTopNRows(t, windowExec)
-	require.Equal(t, [][]int64{
-		{1, 10, 1},
-		{1, 11, 2},
-		{2, 20, 1},
-		{2, 21, 2},
-		{3, 30, 1},
-	}, rows)
 }
 
 func drainPartitionTopNRows(t *testing.T, executor exec.Executor) [][]int64 {

--- a/pkg/executor/windows/pipelined_window.go
+++ b/pkg/executor/windows/pipelined_window.go
@@ -77,6 +77,13 @@ type PipelinedWindowExec struct {
 	initializedSlidingWindow bool
 }
 
+// StreamWindowExec is the executor for stream window functions.
+// It reuses the pipelined window implementation and should only be selected
+// when the planner has already guaranteed the required partition/order property.
+type StreamWindowExec struct {
+	*PipelinedWindowExec
+}
+
 // Close implements the Executor Close interface.
 func (e *PipelinedWindowExec) Close() error {
 	return errors.Trace(e.BaseExecutor.Close())
@@ -84,11 +91,19 @@ func (e *PipelinedWindowExec) Close() error {
 
 // Open implements the Executor Open interface
 func (e *PipelinedWindowExec) Open(ctx context.Context) (err error) {
+	if err := e.BaseExecutor.Open(ctx); err != nil {
+		return err
+	}
+	return e.OpenSelf()
+}
+
+// OpenSelf initializes the executor state without opening children.
+func (e *PipelinedWindowExec) OpenSelf() error {
 	e.done, e.newPartition, e.whole, e.initializedSlidingWindow = false, false, false, false
 	e.dataIdx, e.curRowIdx, e.dropped, e.rowToConsume, e.accumulated = 0, 0, 0, 0, 0
 	e.lastStartRow, e.lastEndRow, e.stagedStartRow, e.stagedEndRow, e.rowStart, e.rowCnt = 0, 0, 0, 0, 0, 0
 	e.rows, e.data = make([]chunk.Row, 0), make([]dataInfo, 0)
-	return e.BaseExecutor.Open(ctx)
+	return nil
 }
 
 func (e *PipelinedWindowExec) firstResultChunkNotReady() bool {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67989

Problem Summary:

This PR splits the executor-side stream-window building blocks out of the demo PR #67696 so they can be reviewed independently from planner enumeration and plan golden changes.

### What changed and how does it work?

- Add `StreamWindowExec` as a thin wrapper over the existing pipelined window executor.
- Add `PipelinedWindowExec.OpenSelf()` so builder paths that already opened children can initialize only the window executor state.
- Add `PartitionTopNWindowExec`, an executor-side helper for `row_number() <= K` stream-window pruning that emits at most `K` rows per partition and materializes the `row_number` column.
- Add direct executor coverage for cross-chunk partition handling.
- Add agent notes documenting the executor-only boundary and the follow-up planner split.

This PR intentionally does not add planner admission rules, physical stream-window enumeration, or plan goldens. Those should be reviewed in a follow-up PR.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partitioned Top‑N window processing
  * Stream‑window executor for pipelined window execution

* **Fixes / Reliability**
  * Improved group‑boundary handling and reset semantics across chunk boundaries and repeated executions
  * Explicit reset behavior to allow safe executor reuse

* **Documentation**
  * Added executor notes on stream‑window behavior, pruning limits, and testing guidance

* **Tests**
  * New unit tests validating partitioned Top‑N behavior across chunk boundaries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->