### PR TITLE
planner: use typed NULL for outer join anti semi projection

### DIFF
--- a/pkg/planner/core/casetest/rule/rule_outer_to_semi_join_test.go
+++ b/pkg/planner/core/casetest/rule/rule_outer_to_semi_join_test.go
@@ -62,6 +62,29 @@ func TestOuterToSemiJoin(tt *testing.T) {
 			tk.MustQuery("EXPLAIN FORMAT='plan_tree' " + sql).Check(testkit.Rows(output[i].Plan...))
 			tk.MustQuery(sql).Check(testkit.Rows(output[i].Result...))
 		}
+
+		// issue:68112
+		tk.MustExec("drop table if exists t_outer, t_inner")
+		tk.MustExec("create table t_outer (id int not null)")
+		tk.MustExec(`create table t_inner (
+			id int not null,
+			d varchar(64) not null
+		)`)
+		tk.MustExec("insert into t_outer values (1), (3)")
+		tk.MustExec("insert into t_inner values (2, 'alpha')")
+		query := `select d
+			from (
+				(
+					select t_inner.d
+					from t_outer
+					left join t_inner on t_outer.id = t_inner.id
+					where t_inner.id is null
+				)
+				union all
+				select 'z'
+			) y
+			order by d`
+		tk.MustQuery(query).Check(testkit.Rows("<nil>", "<nil>", "z"))
 	})
 }
 

--- a/pkg/planner/core/rule/rule_outer_join_to_semi_join.go
+++ b/pkg/planner/core/rule/rule_outer_join_to_semi_join.go
@@ -385,6 +385,9 @@ func generateProjectForConvertAntiJoin(p *logicalop.LogicalJoin, innerSchSet *in
 	projExprs := make([]expression.Expression, 0, len(parentNodeSchema.Columns))
 	for _, c := range parentNodeSchema.Columns {
 		if innerSchSet.Has(int(c.UniqueID)) {
+			// Keep null-extended inner columns aligned with the parent schema type.
+			// NewNull() defaults to TINYINT, while the original column can have
+			// another type and must become nullable after the outer join rewrite.
 			retType := c.RetType.Clone()
 			retType.DelFlag(mysql.NotNullFlag)
 			projExprs = append(projExprs, expression.NewNullWithFieldType(retType))

--- a/pkg/planner/core/rule/rule_outer_join_to_semi_join.go
+++ b/pkg/planner/core/rule/rule_outer_join_to_semi_join.go
@@ -385,7 +385,9 @@ func generateProjectForConvertAntiJoin(p *logicalop.LogicalJoin, innerSchSet *in
 	projExprs := make([]expression.Expression, 0, len(parentNodeSchema.Columns))
 	for _, c := range parentNodeSchema.Columns {
 		if innerSchSet.Has(int(c.UniqueID)) {
-			projExprs = append(projExprs, expression.NewNull())
+			retType := c.RetType.Clone()
+			retType.DelFlag(mysql.NotNullFlag)
+			projExprs = append(projExprs, expression.NewNullWithFieldType(retType))
 		} else {
 			projExprs = append(projExprs, c.Clone())
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68112

Problem Summary:

`OuterJoinToSemiJoin` can rewrite a null-extended outer join into an anti semi join plus a projection. The projection used an untyped `NULL` constant for inner-side columns, so the expression type could be `TINYINT` while the output schema column was `VARCHAR`. A later `UNION ALL` and `ORDER BY` path can read the result as a variable-length column and panic with `index out of range`.

### What changed and how does it work?

Use a typed `NULL` constant when generating the projection for inner-side columns in the outer-join-to-anti-semi-join rewrite. The typed `NULL` clones the original output column type and clears the `NOT NULL` flag, keeping the projection expression type consistent with the schema while preserving null-extension semantics.

Add a regression test using the minimal reproduction from #68112. The test only checks the query result.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```bash
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/rule -run TestOuterToSemiJoin -count=1
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a panic when an outer join null-extends an inner-side string column and the result is processed by UNION ALL and ORDER BY.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Anti-join query rewrites now emit NULLs with the correct column type metadata, preventing generic-NULL typing issues.

* **Tests**
  * Added coverage for an outer-to-semi-join scenario involving derived-table and UNION ALL behavior, validating NULL results and final ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->