### PR TITLE
pkg/ddl/tests/tiflash: stabilize flaky TestTiFlashBackoff

### DIFF
--- a/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
+++ b/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
@@ -759,35 +759,49 @@ func TestTiFlashBackoffer(t *testing.T) {
 func TestTiFlashBackoff(t *testing.T) {
 	s, teardown := createTiFlashContext(t)
 	defer teardown()
-	tk := testkit.NewTestKit(t, s.store)
+	se := session.CreateSessionAndSetID(t, s.store)
+	defer se.Close()
 
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists ddltiflash")
-	tk.MustExec("create table ddltiflash(z int)")
+	session.MustExec(t, se, "use test")
+	session.MustExec(t, se, "drop table if exists ddltiflash")
+	session.MustExec(t, se, "create table ddltiflash(z int)")
 
-	// Not available for all tables
+	// Hold the mocked TiFlash sync status unavailable while polling is paused so the
+	// backoff path is exercised without relying on failpoint instrumentation.
 	ddl.DisableTiFlashPoll(s.dom.DDL())
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/PollTiFlashReplicaStatusReplacePrevAvailableValue", `return(false)`))
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/PollTiFlashReplicaStatusReplaceCurAvailableValue", `return(false)`))
+	session.MustExec(t, se, "alter table ddltiflash set tiflash replica 1")
+	tb, err := s.dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("ddltiflash"))
+	require.NoError(t, err)
+	require.NotNil(t, tb)
+	s.tiflash.ResetSyncStatus(int(tb.Meta().ID), false)
 	ddl.EnableTiFlashPoll(s.dom.DDL())
-	tk.MustExec("alter table ddltiflash set tiflash replica 1")
 
 	// 1, 1.5, 2.25, 3.375, 5.5625
 	// (1), 1, 1, 2, 3, 5
 	time.Sleep(ddl.PollTiFlashInterval * 5)
-	tb, err := s.dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("ddltiflash"))
+	tb, err = s.dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("ddltiflash"))
 	require.NoError(t, err)
 	require.NotNil(t, tb)
 	require.False(t, tb.Meta().TiFlashReplica.Available)
 
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/PollTiFlashReplicaStatusReplacePrevAvailableValue"))
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/PollTiFlashReplicaStatusReplaceCurAvailableValue"))
-
-	time.Sleep(ddl.PollTiFlashInterval * 3)
-	tb, err = s.dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("ddltiflash"))
-	require.NoError(t, err)
-	require.NotNil(t, tb)
-	require.True(t, tb.Meta().TiFlashReplica.Available)
+	s.tiflash.ResetSyncStatus(int(tb.Meta().ID), true)
+	WaitTablesAvailableWithTableName(s.dom, t, 1, []string{}, "test", []string{"ddltiflash"}, ddl.PollTiFlashInterval*RoundToBeAvailable*10)
+	// Availability alone is not enough here: the poller keeps scheduling available
+	// tables for post-availability progress refreshes on later ticks. First prove one
+	// such refresh still happens after the table becomes available.
+	require.NoError(t, infosync.UpdateTiFlashProgressCache(tb.Meta().ID, 0))
+	require.Eventually(t, func() bool {
+		progress, isExist := infosync.GetTiFlashProgressFromCache(tb.Meta().ID)
+		return isExist && progress == 1
+	}, ddl.PollTiFlashInterval*RoundToBeAvailable*10, ddl.PollTiFlashInterval/2)
+	// Then stop future polling and prove no in-flight or later refresh can still
+	// reach the progress cache before teardown closes the mock status server.
+	ddl.DisableTiFlashPoll(s.dom.DDL())
+	require.NoError(t, infosync.UpdateTiFlashProgressCache(tb.Meta().ID, 0))
+	require.Never(t, func() bool {
+		progress, isExist := infosync.GetTiFlashProgressFromCache(tb.Meta().ID)
+		return isExist && progress == 1
+	}, ddl.PollTiFlashInterval*2, ddl.PollTiFlashInterval/5)
 }
 
 func TestAlterDatabaseBasic(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68044

Problem Summary:
Flaky test `TestTiFlashBackoff` in `pkg/ddl/tests/tiflash` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

`TestTiFlashBackoff` was a test teardown race: it returned after replica availability became true even though the TiFlash poller can still perform later available-table progress refreshes against the mock status server.

#### Fix

The added progress-cache witness is necessary to prove that post-availability polling both happened and then stopped before teardown, which closes the reviewer-reported quiescence gap without changing product code.

#### Verification

Spec:
- target: `pkg/ddl/tests/tiflash :: TestTiFlashBackoff`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/ddl/tests/tiflash -run '^TestTiFlashBackoff$' -count=1`
- `go test -json ./pkg/ddl/tests/tiflash -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved `TestTiFlashBackoff` test reliability by directly controlling TiFlash state and removing fragile mocking mechanisms. Enhanced validation to ensure TiFlash replica progress is properly refreshed when availability changes occur and polling is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->