### PR TITLE
pkg/ddl/tests/tiflash: stabilize flaky TestTiFlashTruncateTable

### DIFF
--- a/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
+++ b/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
@@ -106,10 +106,12 @@ func createTiFlashContext(t *testing.T) (*tiflashContext, func()) {
 	s.dom.SetStatsUpdating(true)
 
 	tearDown := func() {
-		s.tiflash.Lock()
-		s.tiflash.StatusServer.Close()
-		s.tiflash.Unlock()
 		s.dom.Close()
+		s.tiflash.Lock()
+		if s.tiflash.StatusServer != nil {
+			s.tiflash.StatusServer.Close()
+		}
+		s.tiflash.Unlock()
 		require.NoError(t, s.store.Close())
 		ddl.PollTiFlashInterval = 2 * time.Second
 	}

--- a/pkg/ddl/tests/tiflash/main_test.go
+++ b/pkg/ddl/tests/tiflash/main_test.go
@@ -25,10 +25,15 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/testkit/testsetup"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
+	intest.InTest = true
+	intest.EnableAssert = true
+	intest.EnableInternalCheck = true
+
 	testsetup.SetupForCommonTest()
 
 	config.UpdateGlobal(func(conf *config.Config) {

--- a/pkg/ddl/tests/tiflash/main_test.go
+++ b/pkg/ddl/tests/tiflash/main_test.go
@@ -25,15 +25,10 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/testkit/testsetup"
-	"github.com/pingcap/tidb/pkg/util/intest"
 	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
-	intest.InTest = true
-	intest.EnableAssert = true
-	intest.EnableInternalCheck = true
-
 	testsetup.SetupForCommonTest()
 
 	config.UpdateGlobal(func(conf *config.Config) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68043

Problem Summary:
Flaky test `TestTiFlashTruncateTable` in `pkg/ddl/tests/tiflash` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The TiFlash test teardown closed the mock status server before closing the domain, so the domain’s background TiFlash polling could still access the already closed mock server after TestTiFlashTruncateTable finished.

#### Fix

Close the domain before closing the mock TiFlash server, so the polling goroutine exits first. Also guard StatusServer.Close() with a nil check to avoid teardown panics when the mock server is unavailable.
#### Verification

Spec:
- target: `pkg/ddl/tests/tiflash :: TestTiFlashTruncateTable`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/ddl/tests/tiflash -run '^TestTiFlashTruncateTable$' -count=1`
- `go test -json ./pkg/ddl/tests/tiflash -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68043

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced TiFlash test cleanup procedures to prevent potential issues during teardown.
  * Improved test harness initialization for better stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->