### PR TITLE
Test: stabilize flaky TestGlobalMemoryControlForPrepareAnalyze

### DIFF
--- a/pkg/executor/test/analyzetest/memorycontrol/BUILD.bazel
+++ b/pkg/executor/test/analyzetest/memorycontrol/BUILD.bazel
@@ -22,6 +22,8 @@ go_test(
         "//pkg/statistics/handle/ddl/testutil",
         "//pkg/testkit",
         "//pkg/util/intest",
+        "//pkg/util/memory",
+        "//pkg/util/servermemorylimit",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",

--- a/pkg/executor/test/analyzetest/memorycontrol/BUILD.bazel
+++ b/pkg/executor/test/analyzetest/memorycontrol/BUILD.bazel
@@ -22,7 +22,6 @@ go_test(
         "//pkg/statistics/handle/ddl/testutil",
         "//pkg/testkit",
         "//pkg/util/intest",
-        "//pkg/util/memory",
         "//pkg/util/servermemorylimit",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",

--- a/pkg/executor/test/analyzetest/memorycontrol/memory_control_test.go
+++ b/pkg/executor/test/analyzetest/memorycontrol/memory_control_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/pkg/statistics/handle/ddl/testutil"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util/intest"
-	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/servermemorylimit"
 	"github.com/stretchr/testify/require"
 )
@@ -143,41 +142,7 @@ func TestGlobalMemoryControlForPrepareAnalyze(t *testing.T) {
 	tk0.MustExec("set global tidb_server_memory_limit = 512MB")
 	_, err0 := tk0.Exec(sqlPrepare)
 	require.NoError(t, err0)
-	var err1 error
-	if intest.InTest {
-		_, err1 = tk0.Exec(sqlExecute)
-	} else {
-		lastStmtTime := tk0.Session().ShowProcess().Time
-		errCh := make(chan error, 1)
-		go func() {
-			_, err := tk0.Exec(sqlExecute)
-			errCh <- err
-		}()
-		require.Eventually(t, func() bool {
-			processInfo, ok := sm.GetProcessInfo(tk0.Session().GetSessionVars().ConnectionID)
-			return ok &&
-				processInfo.MemTracker != nil &&
-				!processInfo.Time.Equal(lastStmtTime) &&
-				processInfo.MemTracker.BytesConsumed() > 64<<20
-		}, 5*time.Second, 10*time.Millisecond)
-
-		pressure := make([][]byte, 32)
-		for i := range pressure {
-			pressure[i] = make([]byte, 8<<20)
-			pressure[i][0] = byte(i)
-		}
-		memory.ForceReadMemStats()
-		require.Eventually(t, func() bool {
-			return servermemorylimit.SessionKillTotal.Load() > baseKillTotal
-		}, 5*time.Second, 50*time.Millisecond)
-
-		select {
-		case err1 = <-errCh:
-		case <-time.After(5 * time.Second):
-			t.Fatal("prepared analyze did not finish after server memory controller kill")
-		}
-		pressure[0][0] = 0
-	}
+	_, err1 := tk0.Exec(sqlExecute)
 	// Killed and the WarnMsg is WarnMsgSuffixForInstance instead of WarnMsgSuffixForSingleQuery
 	require.Error(t, err1)
 	require.True(t, strings.Contains(err1.Error(), "Your query has been cancelled due to exceeding the allowed memory limit for the tidb-server instance and this query is currently using the most memory. Please try narrowing your query scope or increase the tidb_server_memory_limit and try again."), err1.Error())

--- a/pkg/executor/test/analyzetest/memorycontrol/memory_control_test.go
+++ b/pkg/executor/test/analyzetest/memorycontrol/memory_control_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/pingcap/tidb/pkg/statistics/handle/ddl/testutil"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util/intest"
+	"github.com/pingcap/tidb/pkg/util/memory"
+	"github.com/pingcap/tidb/pkg/util/servermemorylimit"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,6 +82,7 @@ func TestGlobalMemoryControlForAnalyze(t *testing.T) {
 	tk0.MustExec("set global tidb_server_memory_limit_sess_min_size = 128")
 
 	sm := newLiveSessionManager(dom, tk0.Session())
+	tk0.Session().SetSessionManager(sm)
 	dom.ServerMemoryLimitHandle().SetSessionManager(sm)
 	go dom.ServerMemoryLimitHandle().Run()
 
@@ -103,21 +106,23 @@ func TestGlobalMemoryControlForAnalyze(t *testing.T) {
 func TestGlobalMemoryControlForPrepareAnalyze(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 
-	tk0 := testkit.NewTestKit(t, store)
+	tk0 := testkit.NewTestKitWithSession(t, store, testkit.NewSession(t, store))
+	tk0.MustExec("select 3")
 	tk0.MustExec("set global tidb_mem_oom_action = 'cancel'")
-	tk0.MustExec("set global tidb_mem_quota_query = 209715200 ") // 200MB
+	tk0.MustExec("set global tidb_mem_quota_query = 209715200") // 200MB
 	tk0.MustExec("set global tidb_server_memory_limit = 5GB")
 	tk0.MustExec("set global tidb_server_memory_limit_sess_min_size = 128")
 
 	sm := newLiveSessionManager(dom, tk0.Session())
+	tk0.Session().SetSessionManager(sm)
 	dom.ServerMemoryLimitHandle().SetSessionManager(sm)
 	go dom.ServerMemoryLimitHandle().Run()
 
 	tk0.MustExec("use test")
-	tk0.MustExec("create table t(a int)")
-	tk0.MustExec("insert into t select 1")
+	tk0.MustExec("create table t(a int, b varchar(2048), c varchar(2048), d varchar(2048), e varchar(2048), f varchar(2048), g varchar(2048), h varchar(2048))")
+	tk0.MustExec("insert into t values (1, repeat('x', 2048), repeat('x', 2048), repeat('x', 2048), repeat('x', 2048), repeat('x', 2048), repeat('x', 2048), repeat('x', 2048))")
 	for i := 1; i <= 8; i++ {
-		tk0.MustExec("insert into t select * from t") // 256 Lines
+		tk0.MustExec("insert into t select * from t")
 	}
 	sqlPrepare := "prepare stmt from 'analyze table t with 1.0 samplerate';"
 	sqlExecute := "execute stmt;"                                                                                     // Need about 100MB
@@ -128,16 +133,65 @@ func TestGlobalMemoryControlForPrepareAnalyze(t *testing.T) {
 	tk0.MustExec(sqlPrepare)
 	tk0.MustExec(sqlExecute)
 	runtime.GC()
+	require.Eventually(t, func() bool {
+		runtime.GC()
+		return tk0.Session().GetSessionVars().MemTracker.BytesConsumed() == 0 &&
+			tk0.Session().GetSessionVars().SQLKiller.GetKillSignal() == 0
+	}, time.Second, 10*time.Millisecond)
+	baseKillTotal := servermemorylimit.SessionKillTotal.Load()
 	// killed by tidb_server_memory_limit
 	tk0.MustExec("set global tidb_server_memory_limit = 512MB")
 	_, err0 := tk0.Exec(sqlPrepare)
 	require.NoError(t, err0)
-	_, err1 := tk0.Exec(sqlExecute)
+	var err1 error
+	if intest.InTest {
+		_, err1 = tk0.Exec(sqlExecute)
+	} else {
+		lastStmtTime := tk0.Session().ShowProcess().Time
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := tk0.Exec(sqlExecute)
+			errCh <- err
+		}()
+		require.Eventually(t, func() bool {
+			processInfo, ok := sm.GetProcessInfo(tk0.Session().GetSessionVars().ConnectionID)
+			return ok &&
+				processInfo.MemTracker != nil &&
+				!processInfo.Time.Equal(lastStmtTime) &&
+				processInfo.MemTracker.BytesConsumed() > 64<<20
+		}, 5*time.Second, 10*time.Millisecond)
+
+		pressure := make([][]byte, 32)
+		for i := range pressure {
+			pressure[i] = make([]byte, 8<<20)
+			pressure[i][0] = byte(i)
+		}
+		memory.ForceReadMemStats()
+		require.Eventually(t, func() bool {
+			return servermemorylimit.SessionKillTotal.Load() > baseKillTotal
+		}, 5*time.Second, 50*time.Millisecond)
+
+		select {
+		case err1 = <-errCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("prepared analyze did not finish after server memory controller kill")
+		}
+		pressure[0][0] = 0
+	}
 	// Killed and the WarnMsg is WarnMsgSuffixForInstance instead of WarnMsgSuffixForSingleQuery
+	require.Error(t, err1)
 	require.True(t, strings.Contains(err1.Error(), "Your query has been cancelled due to exceeding the allowed memory limit for the tidb-server instance and this query is currently using the most memory. Please try narrowing your query scope or increase the tidb_server_memory_limit and try again."), err1.Error())
+	require.Greater(t, servermemorylimit.SessionKillTotal.Load(), baseKillTotal)
 	runtime.GC()
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/util/memory/ReadMemStats"))
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockAnalyzeMergeWorkerSlowConsume"))
+	tk0.MustExec("set global tidb_server_memory_limit = 5GB")
+	require.Eventually(t, func() bool {
+		runtime.GC()
+		return !servermemorylimit.IsKilling.Load() &&
+			tk0.Session().GetSessionVars().MemTracker.BytesConsumed() == 0 &&
+			tk0.Session().GetSessionVars().SQLKiller.GetKillSignal() == 0
+	}, time.Second, 10*time.Millisecond)
 	tk0.MustExec(sqlPrepare)
 	tk0.MustExec(sqlExecute)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68012

Problem Summary:
Flaky test `TestGlobalMemoryControlForPrepareAnalyze` in `pkg/executor/test/analyzetest/memorycontrol` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TEST_ISSUE in `TestGlobalMemoryControlForPrepareAnalyze`: the non-`intest` gate could satisfy itself from stale session `MaxConsumed` history before the second prepared `execute stmt` had actually started, so heap pressure was not guaranteed to target the intended active same-session analyze.

#### Fix

The added idle-baseline wait plus fresh process-time-and-live-bytes gate is the minimal test-only change that closes the reviewer’s stale-gate race without weakening the original same-session kill-and-recover contract.

#### Verification

Spec:
- target: `pkg/executor/test/analyzetest/memorycontrol :: TestGlobalMemoryControlForPrepareAnalyze`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/executor/test/analyzetest/memorycontrol -run '^TestGlobalMemoryControlForPrepareAnalyze$' -count=1`
- `go test -json ./pkg/executor/test/analyzetest/memorycontrol -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened memory-control tests: use explicit test sessions, wire session managers directly, enlarge schema and payloads, run async execute with polling and forced GC, and add state-driven validation of memory usage, kill signals, and recovery resets.
* **Chores**
  * Updated test dependencies to support enhanced memory- and server-limit testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->