### PR TITLE
expression: fix INET_ATON invalid row evaluation

### DIFF
--- a/pkg/expression/builtin_miscellaneous.go
+++ b/pkg/expression/builtin_miscellaneous.go
@@ -602,7 +602,7 @@ func (b *builtinInetAtonSig) evalInt(ctx EvalContext, row chunk.Row) (int64, boo
 	}
 	// ip address should not end with '.'.
 	if len(val) == 0 || val[len(val)-1] == '.' {
-		return 0, false, errWrongValueForType.GenWithStackByArgs("string", val, "inet_aton")
+		return 0, true, nil
 	}
 
 	var (
@@ -614,17 +614,17 @@ func (b *builtinInetAtonSig) evalInt(ctx EvalContext, row chunk.Row) (int64, boo
 			digit := uint64(c - '0')
 			byteResult = byteResult*10 + digit
 			if byteResult > 255 {
-				return 0, false, errWrongValueForType.GenWithStackByArgs("string", val, "inet_aton")
+				return 0, true, nil
 			}
 		} else if c == '.' {
 			dotCount++
 			if dotCount > 3 {
-				return 0, false, errWrongValueForType.GenWithStackByArgs("string", val, "inet_aton")
+				return 0, true, nil
 			}
 			result = (result << 8) + byteResult
 			byteResult = 0
 		} else {
-			return 0, false, errWrongValueForType.GenWithStackByArgs("string", val, "inet_aton")
+			return 0, true, nil
 		}
 	}
 	// 127 		-> 0.0.0.127

--- a/pkg/expression/builtin_miscellaneous_test.go
+++ b/pkg/expression/builtin_miscellaneous_test.go
@@ -50,6 +50,7 @@ func TestInetAton(t *testing.T) {
 		{"127.2.1", 2130837505},
 		{"123.2.1.", nil},
 		{"127.0.0.1.1", nil},
+		{0.8949238218722565, nil},
 	}
 
 	dtbl := tblToDtbl(tbl)
@@ -58,12 +59,8 @@ func TestInetAton(t *testing.T) {
 		f, err := fc.getFunction(ctx, datumsToConstants(tt["Input"]))
 		require.NoError(t, err)
 		d, err := evalBuiltinFunc(f, ctx, chunk.Row{})
-		if tt["Expected"][0].IsNull() && !tt["Input"][0].IsNull() {
-			require.True(t, terror.ErrorEqual(err, errWrongValueForType))
-		} else {
-			require.NoError(t, err)
-			testutil.DatumEqual(t, tt["Expected"][0], d)
-		}
+		require.NoError(t, err)
+		testutil.DatumEqual(t, tt["Expected"][0], d)
 	}
 }
 

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -4441,6 +4441,18 @@ func TestIssue55886(t *testing.T) {
 	tk.MustQuery("with cte_0 AS (select 1 as c1, case when ref_0.c_jbb then inet6_aton(ref_0.c_foveoe) else ref_4.c_cz end as c5 from t1 as ref_0 join " +
 		" (t1 as ref_4 right outer join t2 as ref_5 on ref_5.c_g7eofzlxn != 1)), cte_4 as (select 1 as c1 from t2) select ref_34.c1 as c5 from" +
 		" cte_0 as ref_34 where exists (select 1 from cte_4 as ref_35 where ref_34.c1 <= case when ref_34.c5 then cast(1 as char) else ref_34.c5 end);")
+
+	// issue #65324: row-based evaluation must match vectorized/direct INET_ATON semantics.
+	tk.MustExec("create table t65324(c0 double)")
+	tk.MustExec("replace into t65324(c0) values (-1.930236983e9)")
+	tk.MustExec("create view v65324(c4) as select t65324.c0 < bit_count(inet_aton(0.8949238218722565)) from t65324")
+	tk.MustExec("prepare stmt65324 from 'select v65324.c4 and ? from v65324'")
+	defer tk.MustExec("deallocate prepare stmt65324")
+
+	tk.MustExec("set @a = 'a'")
+	tk.MustQuery("execute stmt65324 using @a").Check(testkit.Rows("0"))
+	tk.MustExec("set @a = true")
+	tk.MustQuery("execute stmt65324 using @a").Check(testkit.Rows("<nil>"))
 }
 
 func TestIssue57608(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/65324

Problem Summary:

`INET_ATON(0.8949238218722565)` can raise `errWrongValueForType` only on the row-based evaluation path. This makes a prepared query through a view fail even though the direct/vectorized `INET_ATON` behavior treats invalid IPv4 input as SQL `NULL`.

### What changed and how does it work?

This PR makes row-based `INET_ATON` invalid-input handling match the existing vectorized behavior:

- empty input, trailing dots, invalid octet values, too many dots, and non-digit characters return SQL `NULL` instead of `errWrongValueForType`
- `TestInetAton` now covers invalid row-path inputs as `NULL` without an error, including the issue value `0.8949238218722565`
- `TestIssue55886` includes a prepared-view regression for https://github.com/pingcap/tidb/issues/65324

The change is intentionally limited to `builtinInetAtonSig.evalInt` and focused regression coverage. It does not change PREPARE semantics, view expansion, global string/numeric conversion, or warning policy.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Tests

```bash
./tools/check/failpoint-go-test.sh pkg/expression -run TestInetAton -count=1
./tools/check/failpoint-go-test.sh pkg/expression/integration_test -run TestIssue55886 -count=1 -v
git -c core.fsmonitor=false diff --check
make lint
```

### Release note

```release-note
Fix an issue that `INET_ATON()` could return an error instead of `NULL` for invalid IPv4 input on the row-based evaluation path.
```
