### PR TITLE
pkg/ddl/tests/tiflash: stabilize flaky TestTiFlashProgressAfterAvailable

### DIFF
--- a/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
+++ b/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
@@ -106,10 +106,12 @@ func createTiFlashContext(t *testing.T) (*tiflashContext, func()) {
 	s.dom.SetStatsUpdating(true)
 
 	tearDown := func() {
-		s.tiflash.Lock()
-		s.tiflash.StatusServer.Close()
-		s.tiflash.Unlock()
 		s.dom.Close()
+		s.tiflash.Lock()
+		if s.tiflash.StatusServer != nil {
+			s.tiflash.StatusServer.Close()
+		}
+		s.tiflash.Unlock()
 		require.NoError(t, s.store.Close())
 		ddl.PollTiFlashInterval = 2 * time.Second
 	}
@@ -1144,12 +1146,13 @@ func TestTiFlashFailureProgressAfterAvailable(t *testing.T) {
 func TestTiFlashProgressAfterAvailable(t *testing.T) {
 	s, teardown := createTiFlashContext(t)
 	defer teardown()
-	tk := testkit.NewTestKit(t, s.store)
+	se := session.CreateSessionAndSetID(t, s.store)
+	defer se.Close()
 
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists ddltiflash")
-	tk.MustExec("create table ddltiflash(z int)")
-	tk.MustExec("alter table ddltiflash set tiflash replica 1")
+	session.MustExec(t, se, "use test")
+	session.MustExec(t, se, "drop table if exists ddltiflash")
+	session.MustExec(t, se, "create table ddltiflash(z int)")
+	session.MustExec(t, se, "alter table ddltiflash set tiflash replica 1")
 	time.Sleep(ddl.PollTiFlashInterval * RoundToBeAvailable * 3)
 	CheckTableAvailable(s.dom, t, 1, []string{})
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67420

Problem Summary:
Flaky test `TestTiFlashProgressAfterAvailable` in `pkg/ddl/tests/tiflash` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

the original flaky is still a teardown race where the mock TiFlash status endpoint could be closed before the DDL poller stopped, and this round’s finding was that removing the close entirely fixed the panic but leaked the mock server goroutines.

#### Fix

the necessary patch restores mock-server teardown after `Domain.Close()` drains the DDL background loops, preserving the earlier `session.CreateSessionAndSetID` validation-compatibility fix for `TestTiFlashProgressAfterAvailable`.

#### Verification

Spec:
- target: `pkg/ddl/tests/tiflash :: TestTiFlashProgressAfterAvailable`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- scope debt present: yes

Gate checklist:
- Required flaky gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/ddl/tests/tiflash -run '^TestTiFlashProgressAfterAvailable$' -count=1`
- `go test -json ./pkg/ddl/tests/tiflash -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown sequence to prevent potential nil pointer issues during teardown.

* **Tests**
  * Enhanced test implementation for improved reliability and proper resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->