### PR TITLE
test: stabilize flaky TestAnalyzeHighestPriorityTablesWithFailedAnalysis

### DIFF
--- a/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "//pkg/statistics/handle/util",
         "//pkg/testkit",
         "//pkg/testkit/testsetup",
+        "//pkg/util/intest",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
     ],

--- a/pkg/statistics/handle/autoanalyze/refresher/main_test.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/main_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/testkit/testsetup"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"go.uber.org/goleak"
 )
 
@@ -29,6 +30,9 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/client/pkg/v3/logutil.(*MergeLogger).outputLoop"),
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
 	}
+	intest.InTest = true
+	intest.EnableAssert = true
+	intest.EnableInternalCheck = true
 	testsetup.SetupForCommonTest()
 	goleak.VerifyTestMain(m, opts...)
 }

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
@@ -530,7 +530,7 @@ func TestAnalyzeHighestPriorityTablesWithFailedAnalysis(t *testing.T) {
 	tk.MustExec("set global tidb_auto_analyze_concurrency=2")
 	tk.MustExec("create table t1 (a int, b int, index idx(a)) partition by range (a) (partition p0 values less than (2), partition p1 values less than (4))")
 	testutil.HandleNextDDLEventWithTxn(handle)
-	tk.MustExec("create table t2 (a int, b int, index idx(a)) partition by range (a) (partition p0 values less than (2), partition p1 values less than (4))")
+	tk.MustExec("create table t2 (a int, b int, index idx(a))")
 	testutil.HandleNextDDLEventWithTxn(handle)
 	tk.MustExec("analyze table t2")
 	tk.MustExec("flush stats_delta *.*")
@@ -564,8 +564,7 @@ func TestAnalyzeHighestPriorityTablesWithFailedAnalysis(t *testing.T) {
 	// t2 is analyzed.
 	tbl2, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t2"))
 	require.NoError(t, err)
-	pid2 := tbl2.Meta().GetPartitionInfo().Definitions[0].ID
-	tblStats2 := handle.GetPhysicalTableStats(pid2, tbl2.Meta())
+	tblStats2 := handle.GetPhysicalTableStats(tbl2.Meta().ID, tbl2.Meta())
 	require.False(t, tblStats2.Pseudo)
 	require.Equal(t, int64(0), tblStats2.ModifyCount)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68123

Problem Summary:
Flaky test `TestAnalyzeHighestPriorityTablesWithFailedAnalysis` in `pkg/statistics/handle/autoanalyze/refresher` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The flaky root cause remains a TEST_ISSUE where the case accidentally used partitioned `t2` and entered an unrelated dynamic-partition analyze race, while this address round fixes only the missing Bazel direct dep for the staged `intest` import.

#### Fix

Adding `//pkg/util/intest` to `refresher_test` is necessary because `main_test.go` now imports `github.com/pingcap/tidb/pkg/util/intest` directly and Bazel strict-deps must reflect that import explicitly.

#### Verification

Spec:
- target: `pkg/statistics/handle/autoanalyze/refresher :: TestAnalyzeHighestPriorityTablesWithFailedAnalysis`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
Required flaky gate passed.
Affected scope regression gate passed.
Build safety gate passed.
Intent guard gate passed.

Gate checklist:
- Required flaky gate: PASS
- Affected scope regression gate: PASS
- Build safety gate: PASS
- Intent guard gate: PASS
- Repo-wide advisory gate: SKIPPED
- Feedback specific gate: SKIPPED

Commands:
- `go test -json ./pkg/statistics/handle/autoanalyze/refresher -run '^TestAnalyzeHighestPriorityTablesWithFailedAnalysis$' -count=1`
- `go test -json ./pkg/statistics/handle/autoanalyze/refresher -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure and initialization procedures for improved validation during test execution.

**Note:** This release contains internal test improvements with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->