### PR TITLE
planner: avoid NULLIF type leak from comparison rewrite

### DIFF
--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -2765,6 +2765,13 @@ func TestCompareBuiltin(t *testing.T) {
 	result = tk.MustQuery(`SELECT HEX(NULLIF("abc", 1));`)
 	result.Check(testkit.Rows("616263"))
 
+	tk.MustExec("drop table if exists t_nullif")
+	tk.MustExec("create table t_nullif (c6 mediumtext null, c10 enum('value1','value2','value3') null, c14 float(8,2) null, c15 double(12,4) null)")
+	tk.MustExec("insert into t_nullif values ('sample_jNu', 'value3', 43.51, 49.92)")
+	tk.MustQuery("select nullif(nullif(c10, c15), c15) from t_nullif").Check(testkit.Rows("value3"))
+	tk.MustQuery("select c6 as v from t_nullif union all select nullif(nullif(c10, c15), c15) from t_nullif").Sort().Check(testkit.Rows("sample_jNu", "value3"))
+	tk.MustQuery("with cte_995 as (select (select s164.c10 as subq_col from t_nullif as s164 order by s164.c10 asc limit 1) as col_1, nullif(nullif(pft41.c10, pft41.c15), pft41.c15) as col_3 from t_nullif as pft41) (select distinct variance(car26.c14) as col_1, car26.c6 as c6 from t_nullif as car26 group by car26.c6) union all select ueb82.col_1 as col_1, ueb82.col_3 as col_5 from cte_995 as ueb82").Sort().Check(testkit.Rows("0 sample_jNu", "value3 value3"))
+
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t(a date)")
 	result = tk.MustQuery("explain format = 'plan_tree' select a = a from t")

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -2771,6 +2771,10 @@ func TestCompareBuiltin(t *testing.T) {
 	tk.MustQuery("select nullif(nullif(c10, c15), c15) from t_nullif").Check(testkit.Rows("value3"))
 	tk.MustQuery("select c6 as v from t_nullif union all select nullif(nullif(c10, c15), c15) from t_nullif").Sort().Check(testkit.Rows("sample_jNu", "value3"))
 	tk.MustQuery("with cte_995 as (select (select s164.c10 as subq_col from t_nullif as s164 order by s164.c10 asc limit 1) as col_1, nullif(nullif(pft41.c10, pft41.c15), pft41.c15) as col_3 from t_nullif as pft41) (select distinct variance(car26.c14) as col_1, car26.c6 as c6 from t_nullif as car26 group by car26.c6) union all select ueb82.col_1 as col_1, ueb82.col_3 as col_5 from cte_995 as ueb82").Sort().Check(testkit.Rows("0 sample_jNu", "value3 value3"))
+	tk.MustExec("create table t_nullif_plan (u bigint unsigned not null)")
+	// The returned value branch should keep the original NULLIF argument type, not the comparison type.
+	plan := tk.MustQuery("explain format = 'brief' select nullif(u, 1) from t_nullif_plan").String()
+	require.NotContains(t, plan, "cast(test.t_nullif_plan.u")
 
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t(a date)")

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -2765,17 +2765,6 @@ func TestCompareBuiltin(t *testing.T) {
 	result = tk.MustQuery(`SELECT HEX(NULLIF("abc", 1));`)
 	result.Check(testkit.Rows("616263"))
 
-	tk.MustExec("drop table if exists t_nullif")
-	tk.MustExec("create table t_nullif (c6 mediumtext null, c10 enum('value1','value2','value3') null, c14 float(8,2) null, c15 double(12,4) null)")
-	tk.MustExec("insert into t_nullif values ('sample_jNu', 'value3', 43.51, 49.92)")
-	tk.MustQuery("select nullif(nullif(c10, c15), c15) from t_nullif").Check(testkit.Rows("value3"))
-	tk.MustQuery("select c6 as v from t_nullif union all select nullif(nullif(c10, c15), c15) from t_nullif").Sort().Check(testkit.Rows("sample_jNu", "value3"))
-	tk.MustQuery("with cte_995 as (select (select s164.c10 as subq_col from t_nullif as s164 order by s164.c10 asc limit 1) as col_1, nullif(nullif(pft41.c10, pft41.c15), pft41.c15) as col_3 from t_nullif as pft41) (select distinct variance(car26.c14) as col_1, car26.c6 as c6 from t_nullif as car26 group by car26.c6) union all select ueb82.col_1 as col_1, ueb82.col_3 as col_5 from cte_995 as ueb82").Sort().Check(testkit.Rows("0 sample_jNu", "value3 value3"))
-	tk.MustExec("create table t_nullif_plan (u bigint unsigned not null)")
-	// The returned value branch should keep the original NULLIF argument type, not the comparison type.
-	plan := tk.MustQuery("explain format = 'brief' select nullif(u, 1) from t_nullif_plan").String()
-	require.NotContains(t, plan, "cast(test.t_nullif_plan.u")
-
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t(a date)")
 	result = tk.MustQuery("explain format = 'plan_tree' select a = a from t")

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -2534,7 +2534,9 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 		stackLen := len(er.ctxStack)
 		param1 := er.ctxStack[stackLen-2]
 		param2 := er.ctxStack[stackLen-1]
-		// param1 = param2
+		// Build the comparison with cloned operands. The comparison branch may refine
+		// argument types or wrap casts, while NULLIF must still return the original
+		// first-argument semantics when the comparison is false.
 		funcCompare, err := er.constructBinaryOpFunction(param1.Clone(), param2.Clone(), ast.EQ)
 		if err != nil {
 			er.err = err

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -2541,6 +2541,8 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 			return true
 		}
 		// NULLIF returns the first argument when the comparison is false, otherwise NULL.
+		// Keep the NULL branch typed; the IF builtin infers its return type from both branches.
+		// A bare NULL type would make the result fall back to param1 and lose NULLIF's inferred metadata.
 		retTp := v.Type.DeepCopy()
 		retTp.DelFlag(mysql.NotNullFlag)
 		paramNull := &expression.Constant{

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -2540,18 +2540,13 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 			er.err = err
 			return true
 		}
-		// NULL
-		nullTp := types.NewFieldType(mysql.TypeNull)
-		flen, decimal := mysql.GetDefaultFieldLengthAndDecimal(mysql.TypeNull)
-		nullTp.SetFlen(flen)
-		nullTp.SetDecimal(decimal)
+		// NULLIF returns the first argument when the comparison is false, otherwise NULL.
+		retTp := v.Type.DeepCopy()
+		retTp.DelFlag(mysql.NotNullFlag)
 		paramNull := &expression.Constant{
 			Value:   types.NewDatum(nil),
-			RetType: nullTp,
+			RetType: retTp.Clone(),
 		}
-		// NULLIF returns the first argument when the comparison is false, otherwise NULL.
-		retTp := param1.GetType(er.sctx.GetEvalCtx()).Clone()
-		retTp.DelFlag(mysql.NotNullFlag)
 		funcIf, err := er.newFunction(ast.If, retTp, funcCompare, paramNull, param1)
 		if err != nil {
 			er.err = err

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -2541,15 +2541,22 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 			return true
 		}
 		// NULLIF returns the first argument when the comparison is false, otherwise NULL.
-		// Keep the NULL branch typed; the IF builtin infers its return type from both branches.
-		// A bare NULL type would make the result fall back to param1 and lose NULLIF's inferred metadata.
-		retTp := v.Type.DeepCopy()
+		// Keep the NULL branch as TypeNull so IF inherits the return type from the
+		// value branch instead of aggregating it with a typed NULL and rewriting metadata.
+		valueBranch := param1.Clone()
+		retTp := valueBranch.GetType(er.sctx.GetEvalCtx()).Clone()
 		retTp.DelFlag(mysql.NotNullFlag)
+		if !retTp.EvalType().IsStringKind() {
+			retTp.SetCharset(charset.CharsetBin)
+			retTp.SetCollate(charset.CollationBin)
+		}
+		valueBranch.GetType(er.sctx.GetEvalCtx()).SetCharset(retTp.GetCharset())
+		valueBranch.GetType(er.sctx.GetEvalCtx()).SetCollate(retTp.GetCollate())
 		paramNull := &expression.Constant{
 			Value:   types.NewDatum(nil),
-			RetType: retTp.Clone(),
+			RetType: types.NewFieldType(mysql.TypeNull),
 		}
-		funcIf, err := er.newFunction(ast.If, retTp, funcCompare, paramNull, param1)
+		funcIf, err := er.newFunction(ast.If, retTp, funcCompare, paramNull, valueBranch)
 		if err != nil {
 			er.err = err
 			return true

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -2535,7 +2535,7 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 		param1 := er.ctxStack[stackLen-2]
 		param2 := er.ctxStack[stackLen-1]
 		// param1 = param2
-		funcCompare, err := er.constructBinaryOpFunction(param1, param2, ast.EQ)
+		funcCompare, err := er.constructBinaryOpFunction(param1.Clone(), param2.Clone(), ast.EQ)
 		if err != nil {
 			er.err = err
 			return true
@@ -2549,8 +2549,10 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 			Value:   types.NewDatum(nil),
 			RetType: nullTp,
 		}
-		// if(param1 = param2, NULL, param1)
-		funcIf, err := er.newFunction(ast.If, v.Type.DeepCopy(), funcCompare, paramNull, param1)
+		// NULLIF returns the first argument when the comparison is false, otherwise NULL.
+		retTp := param1.GetType(er.sctx.GetEvalCtx()).Clone()
+		retTp.DelFlag(mysql.NotNullFlag)
+		funcIf, err := er.newFunction(ast.If, retTp, funcCompare, paramNull, param1)
 		if err != nil {
 			er.err = err
 			return true

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -2543,8 +2543,8 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 		// NULLIF returns the first argument when the comparison is false, otherwise NULL.
 		// Keep the NULL branch as TypeNull so IF inherits the return type from the
 		// value branch instead of aggregating it with a typed NULL and rewriting metadata.
-		valueBranch := param1.Clone()
-		retTp := valueBranch.GetType(er.sctx.GetEvalCtx()).Clone()
+		valueBranch := param1
+		retTp := valueBranch.GetType(er.sctx.GetEvalCtx())
 		retTp.DelFlag(mysql.NotNullFlag)
 		if !retTp.EvalType().IsStringKind() {
 			retTp.SetCharset(charset.CharsetBin)

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -2545,15 +2545,14 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 		// NULLIF returns the first argument when the comparison is false, otherwise NULL.
 		// Keep the NULL branch as TypeNull so IF inherits the return type from the
 		// value branch instead of aggregating it with a typed NULL and rewriting metadata.
-		valueBranch := param1
-		retTp := valueBranch.GetType(er.sctx.GetEvalCtx())
+		valueBranch := param1.Clone()
+		retTp := valueBranch.GetType(er.sctx.GetEvalCtx()).Clone()
 		retTp.DelFlag(mysql.NotNullFlag)
 		if !retTp.EvalType().IsStringKind() {
 			retTp.SetCharset(charset.CharsetBin)
 			retTp.SetCollate(charset.CollationBin)
 		}
-		valueBranch.GetType(er.sctx.GetEvalCtx()).SetCharset(retTp.GetCharset())
-		valueBranch.GetType(er.sctx.GetEvalCtx()).SetCollate(retTp.GetCollate())
+		setExprRetType(valueBranch, retTp.Clone())
 		paramNull := &expression.Constant{
 			Value:   types.NewDatum(nil),
 			RetType: types.NewFieldType(mysql.TypeNull),
@@ -2568,6 +2567,19 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func setExprRetType(expr expression.Expression, retTp *types.FieldType) {
+	switch x := expr.(type) {
+	case *expression.Column:
+		x.RetType = retTp
+	case *expression.CorrelatedColumn:
+		x.RetType = retTp
+	case *expression.Constant:
+		x.RetType = retTp
+	case *expression.ScalarFunction:
+		x.RetType = retTp
 	}
 }
 

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -205,6 +205,20 @@ ON base.c1 <=> base2.c1;`).Sort().Check(testkit.Rows(
 			"<nil> Bob <nil> <nil>"))
 	}
 
+	// issue-66322-nullif-type-leak
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("create table t_nullif (c6 mediumtext null, c10 enum('value1','value2','value3') null, c14 float(8,2) null, c15 double(12,4) null)")
+		tk.MustExec("insert into t_nullif values ('sample_jNu', 'value3', 43.51, 49.92)")
+		tk.MustQuery("select nullif(nullif(c10, c15), c15) from t_nullif").Check(testkit.Rows("value3"))
+		tk.MustQuery("select c6 as v from t_nullif union all select nullif(nullif(c10, c15), c15) from t_nullif").Sort().Check(testkit.Rows("sample_jNu", "value3"))
+		tk.MustQuery("with cte_995 as (select (select s164.c10 as subq_col from t_nullif as s164 order by s164.c10 asc limit 1) as col_1, nullif(nullif(pft41.c10, pft41.c15), pft41.c15) as col_3 from t_nullif as pft41) (select distinct variance(car26.c14) as col_1, car26.c6 as c6 from t_nullif as car26 group by car26.c6) union all select ueb82.col_1 as col_1, ueb82.col_3 as col_5 from cte_995 as ueb82").Sort().Check(testkit.Rows("0 sample_jNu", "value3 value3"))
+		tk.MustExec("create table t_nullif_plan (u bigint unsigned not null)")
+		// The returned value branch should keep the original NULLIF argument type, not the comparison type.
+		plan := tk.MustQuery("explain format = 'plan_tree' select nullif(u, 1) from t_nullif_plan").String()
+		require.NotContains(t, plan, "cast(test.t_nullif_plan.u")
+	}
+
 	// update-join-covering-index
 	{
 		tk := prepareSharedTestKit(t)

--- a/tests/integrationtest/r/executor/aggregate.result
+++ b/tests/integrationtest/r/executor/aggregate.result
@@ -2062,9 +2062,7 @@ delete from mysql.opt_rule_blacklist where name = "decorrelate";
 admin reload opt_rule_blacklist;
 select distinct avg(nullif(77.15, PI()));
 avg(nullif(77.15, PI()))
-77.1500000000000000000000000000000000
-Level	Code	Message
-Warning	1265	Data truncated for column '%s' at row %d
+77.150000
 drop table if exists t_a;
 CREATE TABLE `t_a` (
 `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'id',

--- a/tests/integrationtest/r/executor/aggregate.result
+++ b/tests/integrationtest/r/executor/aggregate.result
@@ -2060,6 +2060,12 @@ Projection	root		Column, Column, Column, Column
             └─TableFullScan	cop[tikv]	table:test	keep order:false
 delete from mysql.opt_rule_blacklist where name = "decorrelate";
 admin reload opt_rule_blacklist;
+select nullif(77.15, PI());
+nullif(77.15, PI())
+77.15
+select avg(nullif(77.15, PI()));
+avg(nullif(77.15, PI()))
+77.150000
 select distinct avg(nullif(77.15, PI()));
 avg(nullif(77.15, PI()))
 77.150000

--- a/tests/integrationtest/t/executor/aggregate.test
+++ b/tests/integrationtest/t/executor/aggregate.test
@@ -1073,6 +1073,8 @@ admin reload opt_rule_blacklist;
 
 # TestIssue61735AggregateTruncatedDecimal
 --enable_warnings
+select nullif(77.15, PI());
+select avg(nullif(77.15, PI()));
 select distinct avg(nullif(77.15, PI()));
 --disable_warnings
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/66322

Problem Summary:

`NULLIF(a, b)` is rewritten as `IF(a = b, NULL, a)`. The comparison branch may coerce or wrap the first argument for equality evaluation. Reusing the same expression object as the returned value branch can leak comparison-side type metadata into the `NULLIF` result, which may further affect `UNION` result metadata and values for nested `NULLIF` expressions.

### What changed and how does it work?

Clone the `NULLIF` comparison arguments before building the equality function, so comparison-side coercion cannot mutate the returned value expression.

Build the rewritten `IF` return type from the rewritten first argument type with `NotNull` cleared. This keeps the `IF` false branch aligned with `NULLIF` semantics and avoids adding comparison-side casts to the value returned when the comparison is false.

Add integration coverage for nested `NULLIF(enum, double)` and a `UNION ALL` shape matching the issue.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test details:

```text
./tools/check/failpoint-go-test.sh pkg/expression/integration_test -run TestCompareBuiltin -count=1
PASS
ok  	github.com/pingcap/tidb/pkg/expression/integration_test	3.104s

cd tests/integrationtest && ./run-tests.sh -r executor/aggregate
./t/executor/aggregate.test: ok! 891 test cases passed
Great, All tests passed
integrationtest passed!

cd tests/integrationtest && ./run-tests.sh -t executor/aggregate
./t/executor/aggregate.test: ok! 891 test cases passed
Great, All tests passed
integrationtest passed!

git -c core.fsmonitor=false diff --check
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a type metadata leak in NULLIF expression rewriting that could produce incorrect result metadata for nested NULLIF and UNION ALL queries.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * NULLIF now preserves the first argument’s type/precision, preventing incorrect type/precision results and removing a spurious truncation warning.

* **Tests**
  * Expanded integration tests to cover NULLIF across nullable types, nested NULLIF, UNION/CTE, aggregate/EXPLAIN cases, and added assertions for numeric formatting/aggregate outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->