### PR TITLE
executor: stabilize variance partial merge

### DIFF
--- a/pkg/executor/aggfuncs/BUILD.bazel
+++ b/pkg/executor/aggfuncs/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "func_stddevsamp_test.go",
         "func_sum_test.go",
         "func_value_test.go",
+        "func_varpop_internal_test.go",
         "func_varpop_test.go",
         "func_varsamp_test.go",
         "main_test.go",

--- a/pkg/executor/aggfuncs/func_varpop.go
+++ b/pkg/executor/aggfuncs/func_varpop.go
@@ -94,8 +94,10 @@ func calculateMerge(srcCount, dstCount int64, srcSum, dstSum, srcVariance, dstVa
 	srcCountFloat64 := float64(srcCount)
 	dstCountFloat64 := float64(dstCount)
 
-	t := (srcCountFloat64/dstCountFloat64)*dstSum - srcSum
-	dstVariance += srcVariance + ((dstCountFloat64/srcCountFloat64)/(dstCountFloat64+srcCountFloat64))*t*t
+	srcMean := srcSum / srcCountFloat64
+	dstMean := dstSum / dstCountFloat64
+	meanDelta := dstMean - srcMean
+	dstVariance += srcVariance + meanDelta*meanDelta*srcCountFloat64*dstCountFloat64/(dstCountFloat64+srcCountFloat64)
 	return dstVariance
 }
 

--- a/pkg/executor/aggfuncs/func_varpop_internal_test.go
+++ b/pkg/executor/aggfuncs/func_varpop_internal_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggfuncs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateMergeKeepsIdenticalMeanVarianceZero(t *testing.T) {
+	const input = 110236466.0
+
+	variance := calculateMerge(1, 49, input, input*49, 0, 0)
+
+	require.Zero(t, variance)
+}

--- a/pkg/executor/test/issuetest/BUILD.bazel
+++ b/pkg/executor/test/issuetest/BUILD.bazel
@@ -5,6 +5,7 @@ go_test(
     timeout = "short",
     srcs = [
         "executor_issue_test.go",
+        "issue_67648_repro_test.go",
         "main_test.go",
     ],
     flaky = True,

--- a/pkg/executor/test/issuetest/issue_67648_repro_test.go
+++ b/pkg/executor/test/issuetest/issue_67648_repro_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issuetest_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+func TestIssue67648CurrentMasterRepro(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("drop database if exists database1")
+	tk.MustExec("create database database1")
+	tk.MustExec("use database1")
+	tk.MustExec("create table t2 (c0 blob not null)")
+	tk.MustExec("create table t3 (c0 blob not null)")
+	tk.MustExec("create definer = root@`%` view v1 as select `t2`.`c0` as `c0` from (`database1`.`t2`) join `database1`.`t3` where true")
+
+	for range 6 {
+		tk.MustExec("insert into database1.t2 (c0) values (0x313130323336343636)")
+	}
+	for _, sql := range []string{
+		"insert into database1.t3 (c0) values (0x31343234343732313935)",
+		"insert into database1.t3 (c0) values (0x2D3165353030)",
+		"insert into database1.t3 (c0) values (0x7E6267525E252866280929)",
+		"insert into database1.t3 (c0) values (0x2D31363934323832373739)",
+		"insert into database1.t3 (c0) values (0x302E39343539373532343435363137353935)",
+		"insert into database1.t3 (c0) values (0x2D3535373436363831)",
+		"insert into database1.t3 (c0) values (0x302E37333138313335313735323335393736)",
+		"insert into database1.t3 (c0) values (0x302E35373032313331323131393433393235)",
+	} {
+		tk.MustExec(sql)
+	}
+
+	issueQuery := "select variance(t2.c0) from v1,t2,t3"
+	checkVarianceAlwaysZero := func(name string, rounds int) {
+		for range rounds {
+			tk.MustQuery(issueQuery).Check(testkit.Rows("0"))
+			tk.MustQuery("show warnings").Check(testkit.Rows())
+		}
+		t.Logf("%s rounds=%d", name, rounds)
+	}
+
+	t.Logf("cast sample=%v warnings=%v",
+		tk.MustQuery("select hex(c0), cast(c0 as double), cast(c0 as decimal(65,0)) from t2 limit 1").Rows(),
+		tk.MustQuery("show warnings").Rows())
+	t.Logf("controls=%v warnings=%v",
+		tk.MustQuery("select count(t2.c0), sum(t2.c0), var_pop(t2.c0), variance(t2.c0), var_pop(cast(t2.c0 as double)), variance(cast(t2.c0 as double)), var_pop(cast(t2.c0 as decimal(65,0))), variance(cast(t2.c0 as decimal(65,0))) from v1,t2,t3").Rows(),
+		tk.MustQuery("show warnings").Rows())
+
+	for _, sql := range []string{
+		"explain " + issueQuery,
+		"explain select count(t2.c0), sum(t2.c0), var_pop(t2.c0), variance(t2.c0) from v1,t2,t3",
+	} {
+		t.Logf("%s rows=%v", sql, tk.MustQuery(sql).Rows())
+	}
+
+	tk.MustExec("set @@tidb_opt_agg_push_down=0")
+	tk.MustExec("set @@tidb_hashagg_partial_concurrency=default")
+	tk.MustExec("set @@tidb_hashagg_final_concurrency=default")
+	checkVarianceAlwaysZero("root_hashagg_default", 100)
+
+	tk.MustExec("set @@tidb_opt_agg_push_down=0")
+	tk.MustExec("set @@tidb_hashagg_partial_concurrency=1")
+	tk.MustExec("set @@tidb_hashagg_final_concurrency=1")
+	checkVarianceAlwaysZero("root_hashagg_serial", 20)
+
+	tk.MustExec("set @@tidb_opt_agg_push_down=1")
+	tk.MustExec("set @@tidb_hashagg_partial_concurrency=default")
+	tk.MustExec("set @@tidb_hashagg_final_concurrency=default")
+	checkVarianceAlwaysZero("agg_pushdown_default", 100)
+	t.Logf("agg_pushdown_plan=%v", tk.MustQuery("explain "+issueQuery).Rows())
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/67648

Problem Summary:

`VAR_POP` / `VARIANCE` may return a small non-zero residual for identical numeric inputs when root `HashAgg` merges partial variance states in different orders. The issue reproduces nondeterministically with parallel partial/final aggregation.

### What changed and how does it work?

Use the standard mean-delta M2 merge formula when combining two variance partial states:

```text
M2 = M2_a + M2_b + delta^2 * n_a * n_b / (n_a + n_b)
```

This avoids the numerically unstable correction form that could produce residual variance for identical means.

Add a focused unit test for `calculateMerge` and an issue regression covering default root hash aggregation, serial root hash aggregation, and aggregation pushdown mode.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test details:

```text
Worker-reported: ./tools/check/failpoint-go-test.sh pkg/executor/aggfuncs -run TestCalculateMergeKeepsIdenticalMeanVarianceZero -count=1 -v
Worker-reported: ./tools/check/failpoint-go-test.sh pkg/executor/test/issuetest -run TestIssue67648CurrentMasterRepro -count=1 -v
Leader-rerun: git -c core.fsmonitor=false diff --check
```

Leader local rerun note:

- Re-running the two Go test commands locally was blocked by environment noise: failpoint rewrite first touched unrelated `lightning/pkg/importer/get_pre_info.go`, and a later retry failed at link time with `No space left on device` under the local temp directory. The unrelated generated side effect was restored before commit.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix unstable VAR_POP and VARIANCE results when parallel aggregation merges identical-value partial states in different orders.
```
