### PR TITLE
executor: deduplicate prepared time warnings

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -552,6 +552,9 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 	defer func() {
 		r := recover()
 		if r == nil {
+			if err == nil && a.isPreparedStmt && a.Ctx.GetSessionVars().EnablePreparedPlanCache {
+				deduplicatePreparedPlanCacheTruncatedWrongValueWarnings(a.Ctx.GetSessionVars().StmtCtx)
+			}
 			if a.retryCount > 0 {
 				metrics.StatementPessimisticRetryCount.Observe(float64(a.retryCount))
 			}
@@ -741,6 +744,39 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		txnStartTS: txnStartTS,
 		traceID:    traceID,
 	}, nil
+}
+
+func deduplicatePreparedPlanCacheTruncatedWrongValueWarnings(stmtCtx *stmtctx.StatementContext) {
+	warnings := stmtCtx.GetWarnings()
+	if len(warnings) <= 1 {
+		return
+	}
+
+	deduplicated := make([]stmtctx.SQLWarn, 0, len(warnings))
+	seenTruncatedWrongValue := make(map[string]struct{})
+	for _, warning := range warnings {
+		terr, ok := errors.Cause(warning.Err).(*terror.Error)
+		if warning.Level != "Warning" || !ok {
+			deduplicated = append(deduplicated, warning)
+			continue
+		}
+		sqlErr := terror.ToSQLError(terr)
+		if sqlErr.Code != mysql.ErrTruncatedWrongValue ||
+			!strings.HasPrefix(sqlErr.Message, "Truncated incorrect time value") {
+			deduplicated = append(deduplicated, warning)
+			continue
+		}
+
+		key := sqlErr.Message
+		if _, ok := seenTruncatedWrongValue[key]; ok {
+			continue
+		}
+		seenTruncatedWrongValue[key] = struct{}{}
+		deduplicated = append(deduplicated, warning)
+	}
+	if len(deduplicated) != len(warnings) {
+		stmtCtx.SetWarnings(deduplicated)
+	}
 }
 
 func (a *ExecStmt) inheritContextFromExecuteStmt() {

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -553,6 +553,9 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		r := recover()
 		if r == nil {
 			if err == nil && a.isPreparedStmt && a.Ctx.GetSessionVars().EnablePreparedPlanCache {
+				// Prepared plan-cache execution can append the same invalid TIME conversion
+				// warning through repeated plan/build/metadata paths; keep the first
+				// semantic warning while preserving distinct warning messages.
 				deduplicatePreparedPlanCacheTruncatedWrongValueWarnings(a.Ctx.GetSessionVars().StmtCtx)
 			}
 			if a.retryCount > 0 {

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -552,12 +552,6 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 	defer func() {
 		r := recover()
 		if r == nil {
-			if err == nil && a.isPreparedStmt && a.Ctx.GetSessionVars().EnablePreparedPlanCache {
-				// Prepared plan-cache execution can append the same invalid TIME conversion
-				// warning through repeated plan/build/metadata paths; keep the first
-				// semantic warning while preserving distinct warning messages.
-				deduplicatePreparedPlanCacheTruncatedWrongValueWarnings(a.Ctx.GetSessionVars().StmtCtx)
-			}
 			if a.retryCount > 0 {
 				metrics.StatementPessimisticRetryCount.Observe(float64(a.retryCount))
 			}
@@ -652,6 +646,9 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 
 	// must set plan according to the `Execute` plan before getting planDigest
 	a.inheritContextFromExecuteStmt()
+	if a.isPreparedStmt && sctx.GetSessionVars().EnablePreparedPlanCache {
+		sctx.GetSessionVars().StmtCtx.SetDeduplicateTruncatedWrongValueWarnings(true)
+	}
 	var rm *runaway.Manager
 	dom := domain.GetDomain(sctx)
 	if dom != nil {
@@ -747,39 +744,6 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		txnStartTS: txnStartTS,
 		traceID:    traceID,
 	}, nil
-}
-
-func deduplicatePreparedPlanCacheTruncatedWrongValueWarnings(stmtCtx *stmtctx.StatementContext) {
-	warnings := stmtCtx.GetWarnings()
-	if len(warnings) <= 1 {
-		return
-	}
-
-	deduplicated := make([]stmtctx.SQLWarn, 0, len(warnings))
-	seenTruncatedWrongValue := make(map[string]struct{})
-	for _, warning := range warnings {
-		terr, ok := errors.Cause(warning.Err).(*terror.Error)
-		if warning.Level != "Warning" || !ok {
-			deduplicated = append(deduplicated, warning)
-			continue
-		}
-		sqlErr := terror.ToSQLError(terr)
-		if sqlErr.Code != mysql.ErrTruncatedWrongValue ||
-			!strings.HasPrefix(sqlErr.Message, "Truncated incorrect time value") {
-			deduplicated = append(deduplicated, warning)
-			continue
-		}
-
-		key := sqlErr.Message
-		if _, ok := seenTruncatedWrongValue[key]; ok {
-			continue
-		}
-		seenTruncatedWrongValue[key] = struct{}{}
-		deduplicated = append(deduplicated, warning)
-	}
-	if len(deduplicated) != len(warnings) {
-		stmtCtx.SetWarnings(deduplicated)
-	}
 }
 
 func (a *ExecStmt) inheritContextFromExecuteStmt() {

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -646,9 +646,6 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 
 	// must set plan according to the `Execute` plan before getting planDigest
 	a.inheritContextFromExecuteStmt()
-	if a.isPreparedStmt && sctx.GetSessionVars().EnablePreparedPlanCache {
-		sctx.GetSessionVars().StmtCtx.SetDeduplicateTruncatedWrongValueWarnings(true)
-	}
 	var rm *runaway.Manager
 	dom := domain.GetDomain(sctx)
 	if dom != nil {

--- a/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
@@ -279,6 +279,7 @@ func TestPreparedPlanCacheWarningRegressions(t *testing.T) {
 	runPreparedPlanCacheLimitWarning(t, tk)
 	runPreparedPlanCacheTypeConversionWarning(t, tk)
 	runPreparedPlanCacheIndexRangeTypeWarning(t, tk)
+	runPreparedPlanCacheTimeParamWarning(t, tk)
 	runPreparedPlanCacheConvFunction(t, tk)
 	runPreparedPlanCacheForUpdateInTxn(t, tk)
 }
@@ -622,6 +623,25 @@ func runPreparedPlanCacheIndexRangeTypeWarning(t *testing.T, tk *testkit.TestKit
 
 	tk.MustExec("execute st using @a1")
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 skip prepared plan-cache: '1.1' may be converted to INT"))
+	tk.MustExec("deallocate prepare st")
+}
+
+func runPreparedPlanCacheTimeParamWarning(t *testing.T, tk *testkit.TestKit) {
+	tk.MustExec("use test")
+	tableName := "t_time_param_warning"
+	tk.MustExec(fmt.Sprintf("drop table if exists %s", tableName))
+	tk.MustExec(fmt.Sprintf("create table %s (c time(6))", tableName))
+	tk.MustExec(fmt.Sprintf("insert into %s values ('02:59:59.000000')", tableName))
+	tk.MustExec(fmt.Sprintf("prepare st from 'select c from %s where c in (?, ?)'", tableName))
+	tk.MustExec("set @a='NULL', @b='02:59:59.000000'")
+
+	tk.MustQuery("execute st using @a, @b").Check(testkit.Rows("02:59:59.000000"))
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1292 Truncated incorrect time value: 'NULL'"))
+
+	tk.MustExec(fmt.Sprintf("prepare st_eq from 'select c from %s where c = ?'", tableName))
+	tk.MustQuery("execute st_eq using @a").Check(testkit.Rows())
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1292 Truncated incorrect time value: 'NULL'"))
+	tk.MustExec("deallocate prepare st_eq")
 	tk.MustExec("deallocate prepare st")
 }
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2457,6 +2457,9 @@ func (s *session) executeStmtImpl(ctx context.Context, stmtNode ast.StmtNode) (s
 	}
 
 	if execStmt, ok := stmtNode.(*ast.ExecuteStmt); ok {
+		if sessVars.EnablePreparedPlanCache {
+			sessVars.StmtCtx.SetDeduplicateTruncatedWrongValueWarnings(true)
+		}
 		if binParam, ok := execStmt.BinaryArgs.([]param.BinaryParam); ok {
 			args, err := expression.ExecBinaryParam(s.GetSessionVars().StmtCtx.TypeCtx(), binParam)
 			if err != nil {

--- a/pkg/sessionctx/stmtctx/BUILD.bazel
+++ b/pkg/sessionctx/stmtctx/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/nocopy",
         "//pkg/util/topsql/stmtstats",
         "//pkg/util/tracing",
+        "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@org_golang_x_sync//singleflight",
         "@org_uber_go_atomic//:atomic",

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -27,6 +27,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	distsqlctx "github.com/pingcap/tidb/pkg/distsql/context"
 	"github.com/pingcap/tidb/pkg/errctx"
@@ -68,6 +69,16 @@ func AllocateTaskID() uint64 {
 
 // SQLWarn relates a sql warning and it's level.
 type SQLWarn = contextutil.SQLWarn
+
+type warningDedupKey struct {
+	code    uint16
+	message string
+}
+
+type sqlWarningForDedup interface {
+	Code() errors.ErrCode
+	GetMsg() string
+}
 
 // LogicalPlanBuildState stores the statement-scoped planner state that is mutated while
 // building a logical plan from AST.
@@ -305,6 +316,8 @@ type StatementContext struct {
 	// extraWarnings would not be printed through SHOW WARNINGS, but we want to always output them through the slow
 	// log to help diagnostics, so we store them here separately.
 	ExtraWarnHandler contextutil.WarnHandlerExt
+
+	deduplicateTruncatedWrongValueWarnings bool
 
 	execdetails.SyncExecDetails
 
@@ -1134,14 +1147,76 @@ func (sc *StatementContext) SetWarnings(warns []SQLWarn) {
 	sc.WarnHandler.SetWarnings(warns)
 }
 
+// SetDeduplicateTruncatedWrongValueWarnings controls whether duplicated
+// ErrTruncatedWrongValue warnings with the same message are ignored when they
+// are appended. This should only be enabled for narrow paths where duplicate
+// conversion diagnostics come from repeated planning/building work rather than
+// distinct input rows.
+func (sc *StatementContext) SetDeduplicateTruncatedWrongValueWarnings(deduplicate bool) {
+	sc.deduplicateTruncatedWrongValueWarnings = deduplicate
+}
+
 // AppendWarning appends a warning with level 'Warning'.
 func (sc *StatementContext) AppendWarning(warn error) {
+	if sc.shouldSkipDuplicatedWarning(contextutil.WarnLevelWarning, warn, nil) {
+		return
+	}
 	sc.WarnHandler.AppendWarning(warn)
 }
 
 // AppendWarnings appends some warnings.
 func (sc *StatementContext) AppendWarnings(warns []SQLWarn) {
+	if sc.deduplicateTruncatedWrongValueWarnings {
+		warnings := sc.WarnHandler.CopyWarnings(nil)
+		deduplicated := make([]SQLWarn, 0, len(warns))
+		for _, warn := range warns {
+			if duplicatedTruncatedWrongValueWarning(warn.Level, warn.Err, warnings, deduplicated) {
+				continue
+			}
+			deduplicated = append(deduplicated, warn)
+		}
+		warns = deduplicated
+	}
 	sc.WarnHandler.AppendWarnings(warns)
+}
+
+func (sc *StatementContext) shouldSkipDuplicatedWarning(level string, warn error, pending []SQLWarn) bool {
+	if !sc.deduplicateTruncatedWrongValueWarnings {
+		return false
+	}
+	return duplicatedTruncatedWrongValueWarning(level, warn, sc.WarnHandler.CopyWarnings(nil), pending)
+}
+
+func duplicatedTruncatedWrongValueWarning(level string, warn error, warnings []SQLWarn, pending []SQLWarn) bool {
+	key, ok := truncatedWrongValueWarningKey(level, warn)
+	if !ok {
+		return false
+	}
+	for _, warning := range warnings {
+		if existingKey, ok := truncatedWrongValueWarningKey(warning.Level, warning.Err); ok && existingKey == key {
+			return true
+		}
+	}
+	for _, warning := range pending {
+		if existingKey, ok := truncatedWrongValueWarningKey(warning.Level, warning.Err); ok && existingKey == key {
+			return true
+		}
+	}
+	return false
+}
+
+func truncatedWrongValueWarningKey(level string, warn error) (warningDedupKey, bool) {
+	if level != contextutil.WarnLevelWarning {
+		return warningDedupKey{}, false
+	}
+	sqlWarn, ok := errors.Cause(warn).(sqlWarningForDedup)
+	if !ok {
+		return warningDedupKey{}, false
+	}
+	if uint16(sqlWarn.Code()) != mysql.ErrTruncatedWrongValue {
+		return warningDedupKey{}, false
+	}
+	return warningDedupKey{code: mysql.ErrTruncatedWrongValue, message: sqlWarn.GetMsg()}, true
 }
 
 // AppendNote appends a warning with level 'Note'.

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -317,7 +317,7 @@ type StatementContext struct {
 	// log to help diagnostics, so we store them here separately.
 	ExtraWarnHandler contextutil.WarnHandlerExt
 
-	deduplicateTruncatedWrongValueWarnings bool
+	deduplicatedTruncatedWrongValueWarnings map[warningDedupKey]struct{}
 
 	execdetails.SyncExecDetails
 
@@ -1145,6 +1145,7 @@ func (sc *StatementContext) NumErrorWarnings() (ec uint16, wc int) {
 // SetWarnings sets warnings.
 func (sc *StatementContext) SetWarnings(warns []SQLWarn) {
 	sc.WarnHandler.SetWarnings(warns)
+	sc.rebuildDeduplicatedTruncatedWrongValueWarnings()
 }
 
 // SetDeduplicateTruncatedWrongValueWarnings controls whether duplicated
@@ -1153,12 +1154,19 @@ func (sc *StatementContext) SetWarnings(warns []SQLWarn) {
 // conversion diagnostics come from repeated planning/building work rather than
 // distinct input rows.
 func (sc *StatementContext) SetDeduplicateTruncatedWrongValueWarnings(deduplicate bool) {
-	sc.deduplicateTruncatedWrongValueWarnings = deduplicate
+	if !deduplicate {
+		sc.deduplicatedTruncatedWrongValueWarnings = nil
+		return
+	}
+	if sc.deduplicatedTruncatedWrongValueWarnings == nil {
+		sc.deduplicatedTruncatedWrongValueWarnings = make(map[warningDedupKey]struct{})
+	}
+	sc.rebuildDeduplicatedTruncatedWrongValueWarnings()
 }
 
 // AppendWarning appends a warning with level 'Warning'.
 func (sc *StatementContext) AppendWarning(warn error) {
-	if sc.shouldSkipDuplicatedWarning(contextutil.WarnLevelWarning, warn, nil) {
+	if sc.skipOrRecordTruncatedWrongValueWarning(contextutil.WarnLevelWarning, warn) {
 		return
 	}
 	sc.WarnHandler.AppendWarning(warn)
@@ -1166,11 +1174,10 @@ func (sc *StatementContext) AppendWarning(warn error) {
 
 // AppendWarnings appends some warnings.
 func (sc *StatementContext) AppendWarnings(warns []SQLWarn) {
-	if sc.deduplicateTruncatedWrongValueWarnings {
-		warnings := sc.WarnHandler.CopyWarnings(nil)
+	if sc.deduplicatedTruncatedWrongValueWarnings != nil {
 		deduplicated := make([]SQLWarn, 0, len(warns))
 		for _, warn := range warns {
-			if duplicatedTruncatedWrongValueWarning(warn.Level, warn.Err, warnings, deduplicated) {
+			if sc.skipOrRecordTruncatedWrongValueWarning(warn.Level, warn.Err) {
 				continue
 			}
 			deduplicated = append(deduplicated, warn)
@@ -1180,29 +1187,31 @@ func (sc *StatementContext) AppendWarnings(warns []SQLWarn) {
 	sc.WarnHandler.AppendWarnings(warns)
 }
 
-func (sc *StatementContext) shouldSkipDuplicatedWarning(level string, warn error, pending []SQLWarn) bool {
-	if !sc.deduplicateTruncatedWrongValueWarnings {
+func (sc *StatementContext) skipOrRecordTruncatedWrongValueWarning(level string, warn error) bool {
+	if sc.deduplicatedTruncatedWrongValueWarnings == nil {
 		return false
 	}
-	return duplicatedTruncatedWrongValueWarning(level, warn, sc.WarnHandler.CopyWarnings(nil), pending)
-}
-
-func duplicatedTruncatedWrongValueWarning(level string, warn error, warnings []SQLWarn, pending []SQLWarn) bool {
 	key, ok := truncatedWrongValueWarningKey(level, warn)
 	if !ok {
 		return false
 	}
-	for _, warning := range warnings {
-		if existingKey, ok := truncatedWrongValueWarningKey(warning.Level, warning.Err); ok && existingKey == key {
-			return true
-		}
+	if _, ok := sc.deduplicatedTruncatedWrongValueWarnings[key]; ok {
+		return true
 	}
-	for _, warning := range pending {
-		if existingKey, ok := truncatedWrongValueWarningKey(warning.Level, warning.Err); ok && existingKey == key {
-			return true
-		}
-	}
+	sc.deduplicatedTruncatedWrongValueWarnings[key] = struct{}{}
 	return false
+}
+
+func (sc *StatementContext) rebuildDeduplicatedTruncatedWrongValueWarnings() {
+	if sc.deduplicatedTruncatedWrongValueWarnings == nil {
+		return
+	}
+	clear(sc.deduplicatedTruncatedWrongValueWarnings)
+	for _, warning := range sc.WarnHandler.CopyWarnings(nil) {
+		if key, ok := truncatedWrongValueWarningKey(warning.Level, warning.Err); ok {
+			sc.deduplicatedTruncatedWrongValueWarnings[key] = struct{}{}
+		}
+	}
 }
 
 func truncatedWrongValueWarningKey(level string, warn error) (warningDedupKey, bool) {
@@ -1277,6 +1286,7 @@ func (sc *StatementContext) ResetForRetry() {
 	sc.TaskID = AllocateTaskID()
 	sc.WarnHandler.TruncateWarnings(0)
 	sc.ExtraWarnHandler.TruncateWarnings(0)
+	sc.rebuildDeduplicatedTruncatedWrongValueWarnings()
 
 	// `TaskID` is reset, we'll need to reset distSQLCtx
 	sc.distSQLCtxCache.init = sync.Once{}

--- a/pkg/sessionctx/stmtctx/stmtctx_test.go
+++ b/pkg/sessionctx/stmtctx/stmtctx_test.go
@@ -444,6 +444,7 @@ func TestNewStmtCtx(t *testing.T) {
 	truncatedDateWarn := types.ErrTruncatedWrongVal.FastGenByArgs("date", "NULL")
 	sc.AppendWarning(truncatedTimeWarn)
 	sc.AppendWarning(errors.NewNoStackError("regular warning"))
+	sc.AppendWarning(types.ErrTruncatedWrongVal.FastGenByArgs("DECIMAL", "1.2"))
 	sc.AppendWarning(types.ErrTruncatedWrongVal.FastGenByArgs("datetime", "NULL"))
 	sc.AppendWarning(types.ErrTruncatedWrongVal.FastGenByArgs("time", "NULL"))
 	sc.AppendWarnings([]stmtctx.SQLWarn{
@@ -452,11 +453,12 @@ func TestNewStmtCtx(t *testing.T) {
 		{Level: contextutil.WarnLevelWarning, Err: truncatedDateWarn},
 	})
 	warnings = sc.GetWarnings()
-	require.Equal(t, 4, len(warnings))
+	require.Equal(t, 5, len(warnings))
 	require.EqualError(t, warnings[0].Err, "[types:1292]Truncated incorrect time value: 'NULL'")
 	require.EqualError(t, warnings[1].Err, "regular warning")
-	require.EqualError(t, warnings[2].Err, "[types:1292]Truncated incorrect datetime value: 'NULL'")
-	require.EqualError(t, warnings[3].Err, "[types:1292]Truncated incorrect date value: 'NULL'")
+	require.EqualError(t, warnings[2].Err, "[types:1292]Truncated incorrect DECIMAL value: '1.2'")
+	require.EqualError(t, warnings[3].Err, "[types:1292]Truncated incorrect datetime value: 'NULL'")
+	require.EqualError(t, warnings[4].Err, "[types:1292]Truncated incorrect date value: 'NULL'")
 }
 
 func TestSetStmtCtxTimeZone(t *testing.T) {

--- a/pkg/sessionctx/stmtctx/stmtctx_test.go
+++ b/pkg/sessionctx/stmtctx/stmtctx_test.go
@@ -437,6 +437,26 @@ func TestNewStmtCtx(t *testing.T) {
 	require.Equal(t, 1, len(warnings))
 	require.Equal(t, contextutil.WarnLevelWarning, warnings[0].Level)
 	require.Equal(t, "err2", warnings[0].Err.Error())
+
+	sc = stmtctx.NewStmtCtx()
+	sc.SetDeduplicateTruncatedWrongValueWarnings(true)
+	truncatedTimeWarn := types.ErrTruncatedWrongVal.FastGenByArgs("time", "NULL")
+	truncatedDateWarn := types.ErrTruncatedWrongVal.FastGenByArgs("date", "NULL")
+	sc.AppendWarning(truncatedTimeWarn)
+	sc.AppendWarning(errors.NewNoStackError("regular warning"))
+	sc.AppendWarning(types.ErrTruncatedWrongVal.FastGenByArgs("datetime", "NULL"))
+	sc.AppendWarning(types.ErrTruncatedWrongVal.FastGenByArgs("time", "NULL"))
+	sc.AppendWarnings([]stmtctx.SQLWarn{
+		{Level: contextutil.WarnLevelWarning, Err: truncatedDateWarn},
+		{Level: contextutil.WarnLevelWarning, Err: truncatedTimeWarn},
+		{Level: contextutil.WarnLevelWarning, Err: truncatedDateWarn},
+	})
+	warnings = sc.GetWarnings()
+	require.Equal(t, 4, len(warnings))
+	require.EqualError(t, warnings[0].Err, "[types:1292]Truncated incorrect time value: 'NULL'")
+	require.EqualError(t, warnings[1].Err, "regular warning")
+	require.EqualError(t, warnings[2].Err, "[types:1292]Truncated incorrect datetime value: 'NULL'")
+	require.EqualError(t, warnings[3].Err, "[types:1292]Truncated incorrect date value: 'NULL'")
 }
 
 func TestSetStmtCtxTimeZone(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/66533

Problem Summary:

Prepared statement execution with prepared plan cache can append the same `Truncated incorrect time value` warning multiple times when a `TIME` comparison evaluates an invalid parameter value during planning, executor building, and plan metadata formatting. The reported case returns the correct row, but `SHOW WARNINGS` contains many duplicate `1292` warnings for the same invalid parameter.

### What changed and how does it work?

This PR deduplicates identical `Truncated incorrect time value` warnings for prepared statements when prepared plan cache is enabled. The deduplication keeps the first warning for each distinct warning message and preserves unrelated warnings.

It also adds regression coverage for:

- `TIME IN (?, ?)` with one invalid string parameter and one valid `TIME` value.
- `TIME = ?` with an invalid string parameter.

Both cases now emit one semantic `1292` warning instead of repeated duplicates.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix duplicate warnings for prepared statement execution with invalid TIME parameters and prepared plan cache enabled.
```

### Tests

```text
go test -tags=intest ./pkg/planner/core/casetest/plancache -run TestPreparedPlanCacheWarningRegressions -count=1
git diff --check
GOPROXY=https://proxy.golang.org,direct make bazel_prepare
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate warnings for truncated value errors in prepared statements with plan cache enabled.

* **Tests**
  * Added regression test for TIME parameter warnings in prepared statement caching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->