### PR TITLE
executor: avoid shared FK lock on written keys

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1281,6 +1281,11 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e exec.Executor) (e
 
 		// acquire xlocks
 		keys = txnCtx.CollectUnchangedKeysForXLock(keys)
+		sharedKeys := txnCtx.CollectUnchangedKeysForSLock(nil)
+		keys, sharedKeys, err = moveWrittenSharedLockKeysToExclusive(ctx, txn, keys, sharedKeys)
+		if err != nil {
+			return err
+		}
 		if ex, err := tryLockKeys(e, keys, false); err != nil {
 			return err
 		} else if ex != nil {
@@ -1289,9 +1294,8 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e exec.Executor) (e
 		}
 
 		// acquire slocks
-		keys = txnCtx.CollectUnchangedKeysForSLock(keys[:0])
 		startLock := time.Now()
-		if ex, err := tryLockKeys(e, keys, true); err != nil {
+		if ex, err := tryLockKeys(e, sharedKeys, true); err != nil {
 			return err
 		} else if ex != nil {
 			e = ex
@@ -1301,6 +1305,52 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e exec.Executor) (e
 
 		return nil
 	}
+}
+
+func moveWrittenSharedLockKeysToExclusive(
+	ctx context.Context,
+	txn kv.Transaction,
+	exclusiveKeys []kv.Key,
+	sharedKeys []kv.Key,
+) (finalExclusiveKeys []kv.Key, finalSharedKeys []kv.Key, err error) {
+	if len(sharedKeys) == 0 {
+		return exclusiveKeys, sharedKeys, nil
+	}
+
+	exclusiveKeySet := make(map[string]struct{}, len(exclusiveKeys))
+	for _, key := range exclusiveKeys {
+		exclusiveKeySet[string(key)] = struct{}{}
+	}
+
+	memBuffer := txn.GetMemBuffer()
+	memBuffer.RLock()
+	defer memBuffer.RUnlock()
+
+	// sharedKeys is collected locally for this lock phase, so reuse its buffer
+	// for the filtered shared-only result.
+	sharedOnlyKeys := sharedKeys[:0]
+	for _, key := range sharedKeys {
+		if _, ok := exclusiveKeySet[string(key)]; ok {
+			continue
+		}
+
+		// A key written by this transaction must not be protected only by a
+		// shared pessimistic lock, otherwise commit prewrite would put over
+		// its own shared pessimistic lock.
+		_, err := memBuffer.GetLocal(ctx, key)
+		if err == nil {
+			exclusiveKeys = append(exclusiveKeys, key)
+			exclusiveKeySet[string(key)] = struct{}{}
+			continue
+		}
+		if !kv.ErrNotExist.Equal(err) {
+			return nil, nil, err
+		}
+
+		sharedOnlyKeys = append(sharedOnlyKeys, key)
+	}
+
+	return exclusiveKeys, sharedOnlyKeys, nil
 }
 
 // updateFKCheckLockStats updates the Lock stats of FK check executors after the deferred

--- a/pkg/executor/adapter_internal_test.go
+++ b/pkg/executor/adapter_internal_test.go
@@ -17,12 +17,14 @@ package executor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/pingcap/kvproto/pkg/meta_storagepb"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
@@ -42,6 +44,34 @@ import (
 type stmtStatsTestContext struct {
 	*mock.Context
 	stmtStats *stmtstats.StatementStats
+}
+
+type sharedLockMemBufferForTest struct {
+	kv.MemBuffer
+	getLocal func(key []byte) ([]byte, error)
+	rLocks   int
+	rUnlocks int
+}
+
+func (m *sharedLockMemBufferForTest) GetLocal(_ context.Context, key []byte) ([]byte, error) {
+	return m.getLocal(key)
+}
+
+func (m *sharedLockMemBufferForTest) RLock() {
+	m.rLocks++
+}
+
+func (m *sharedLockMemBufferForTest) RUnlock() {
+	m.rUnlocks++
+}
+
+type sharedLockTxnForTest struct {
+	kv.Transaction
+	memBuffer kv.MemBuffer
+}
+
+func (t *sharedLockTxnForTest) GetMemBuffer() kv.MemBuffer {
+	return t.memBuffer
 }
 
 func (c *stmtStatsTestContext) GetStmtStats() *stmtstats.StatementStats {
@@ -97,6 +127,92 @@ func ruKeyForStmt(t *testing.T, stmt *ExecStmt) stmtstats.RUKey {
 		User:       stmt.Ctx.GetSessionVars().User.String(),
 		SQLDigest:  stmtstats.BinaryDigest(sqlDigest),
 		PlanDigest: stmtstats.BinaryDigest(planDigest),
+	}
+}
+
+func TestMoveWrittenSharedLockKeysToExclusive(t *testing.T) {
+	injectedErr := errors.New("injected get local error")
+
+	tests := []struct {
+		name              string
+		exclusiveKeys     []kv.Key
+		sharedKeys        []kv.Key
+		writtenKeys       map[string]struct{}
+		getLocalErrors    map[string]error
+		wantExclusiveKeys []kv.Key
+		wantSharedKeys    []kv.Key
+		wantErr           error
+	}{
+		{
+			name:              "no shared keys",
+			exclusiveKeys:     []kv.Key{kv.Key("exclusive")},
+			wantExclusiveKeys: []kv.Key{kv.Key("exclusive")},
+		},
+		{
+			name:          "deduplicate exclusive and promote written keys",
+			exclusiveKeys: []kv.Key{kv.Key("exclusive")},
+			sharedKeys: []kv.Key{
+				kv.Key("exclusive"),
+				kv.Key("written"),
+				kv.Key("shared"),
+			},
+			writtenKeys: map[string]struct{}{
+				"written": {},
+			},
+			wantExclusiveKeys: []kv.Key{kv.Key("exclusive"), kv.Key("written")},
+			wantSharedKeys:    []kv.Key{kv.Key("shared")},
+		},
+		{
+			name: "propagate get local error",
+			sharedKeys: []kv.Key{
+				kv.Key("bad"),
+			},
+			getLocalErrors: map[string]error{
+				"bad": injectedErr,
+			},
+			wantErr: injectedErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			memBuffer := &sharedLockMemBufferForTest{
+				getLocal: func(key []byte) ([]byte, error) {
+					if err, ok := tt.getLocalErrors[string(key)]; ok {
+						return nil, err
+					}
+					if _, ok := tt.writtenKeys[string(key)]; ok {
+						return []byte("value"), nil
+					}
+					return nil, kv.ErrNotExist
+				},
+			}
+			txn := &sharedLockTxnForTest{memBuffer: memBuffer}
+
+			exclusiveKeys, sharedKeys, err := moveWrittenSharedLockKeysToExclusive(
+				context.Background(),
+				txn,
+				tt.exclusiveKeys,
+				tt.sharedKeys,
+			)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Nil(t, exclusiveKeys)
+				require.Nil(t, sharedKeys)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantExclusiveKeys, exclusiveKeys)
+				require.Equal(t, tt.wantSharedKeys, sharedKeys)
+			}
+			if len(tt.sharedKeys) > 0 {
+				require.Equal(t, 1, memBuffer.rLocks)
+				require.Equal(t, 1, memBuffer.rUnlocks)
+			} else {
+				require.Zero(t, memBuffer.rLocks)
+				require.Zero(t, memBuffer.rUnlocks)
+			}
+		})
 	}
 }
 

--- a/tests/realtikvtest/txntest/shared_lock_test.go
+++ b/tests/realtikvtest/txntest/shared_lock_test.go
@@ -250,6 +250,46 @@ func TestSharedLockChildTableConflict(t *testing.T) {
 	tk1.MustExec("admin check table child")
 }
 
+func TestSharedLockCascadeUpdateExplicitPessimisticTxn(t *testing.T) {
+	if !*realtikvtest.WithRealTiKV {
+		t.Skip("requires real TiKV")
+	}
+	if kerneltype.IsNextGen() {
+		t.Skip("does not support shared lock in next-gen TiKV")
+	}
+
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+
+	for _, constraintCheckInPlace := range []string{"ON", "OFF"} {
+		t.Run("constraint_check_in_place_pessimistic_"+constraintCheckInPlace, func(t *testing.T) {
+			tk := testkit.NewTestKit(t, store)
+			tk.MustExec("use test")
+			tk.MustExec("set @@global.tidb_enable_foreign_key=1")
+			defer tk.MustExec("set @@global.tidb_enable_foreign_key=default")
+			tk.MustExec("set @@foreign_key_checks=1")
+			tk.MustExec("set @@tidb_foreign_key_check_in_shared_lock=ON")
+			tk.MustExec("set @@tidb_constraint_check_in_place_pessimistic=" + constraintCheckInPlace)
+
+			tk.MustExec("drop table if exists c, p")
+			tk.MustExec("create table p(id int primary key)")
+			tk.MustExec("create table c(pid int, foreign key(pid) references p(id) on delete cascade on update cascade)")
+			tk.MustExec("insert into p values (1)")
+			tk.MustExec("insert into c values (1)")
+
+			tk.MustExec("begin pessimistic")
+			tk.MustExec("update p set id = 2 where id = 1")
+			tk.MustQuery("select pid from c").Check(testkit.Rows("2"))
+			tk.MustExec("commit")
+
+			tk.MustQuery("select pid from c").Check(testkit.Rows("2"))
+			tk.MustExec("delete from p where id = 2")
+			tk.MustQuery("select count(*) from c").Check(testkit.Rows("0"))
+			tk.MustExec("admin check table p")
+			tk.MustExec("admin check table c")
+		})
+	}
+}
+
 func TestSharedLockLockView(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68133

Problem Summary:

When `tidb_foreign_key_check_in_shared_lock` is enabled, an FK cascade update can collect the same key as both a pending write and an FK shared-lock key. If pessimistic lazy constraint checking makes `KeysNeedToLock()` skip that written key, TiDB sends a shared-lock RPC for it. Commit then prewrites a normal mutation over its own shared pessimistic lock and TiKV rejects it with `use Op::SharedLock to prewrite on a shared lock`.

### What changed and how does it work?

Before acquiring FK shared locks, TiDB now checks the shared-lock candidates against the transaction mem buffer. If a shared-lock candidate already has a local write, it is moved to the exclusive-lock phase and removed from the shared-lock phase.

This keeps the lock mode consistent with the later prewrite: keys written by the transaction are protected by exclusive pessimistic locks, while read-only FK check keys still use shared locks.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

### Release note

```release-note
Fix an issue that FK cascade updates in pessimistic transactions could fail with `use Op::SharedLock to prewrite on a shared lock`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined pessimistic foreign-key locking: shared-lock candidates written in the same transaction are promoted to exclusive locks and acquired in a two-phase flow, preserving prior behavior when no shared keys or flags are present.

* **Tests**
  * Added end-to-end test validating UPDATE/DELETE CASCADE under explicit pessimistic transactions with shared-lock checks.
  * Added unit test covering classification/promotion of shared vs. written keys, deduplication, error propagation, and lock acquisition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

