### PR TITLE
session: backfill tidb_ignore_inlist_plan_digest during upgrade

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -393,7 +393,7 @@ func TestCheckPrivilegeTableRowsCollateCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(258), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(259), session.CurrentBootstrapVersion)
 }
 
 func TestIsStatsTemporaryTable(t *testing.T) {

--- a/pkg/session/BUILD.bazel
+++ b/pkg/session/BUILD.bazel
@@ -160,6 +160,7 @@ go_test(
         "main_test.go",
         "session_test.go",
         "tidb_test.go",
+        "upgrade_backfill_test.go",
         "upgrade_test.go",
     ],
     embed = [":session"],

--- a/pkg/session/upgrade_backfill_test.go
+++ b/pkg/session/upgrade_backfill_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeToVer259BackfillsIgnoreInlistPlanDigest(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
+	}
+
+	ctx := context.Background()
+	store, dom := CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	ver258 := version258
+	seV258 := CreateSessionAndSetID(t, store)
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	err = m.FinishBootstrap(int64(ver258))
+	require.NoError(t, err)
+	RevertVersionAndVariables(t, seV258, ver258)
+
+	// Simulate a cluster upgraded through the old path where the variable existed in code
+	// but its row was never backfilled into mysql.global_variables.
+	MustExec(t, seV258, fmt.Sprintf(
+		"delete from mysql.GLOBAL_VARIABLES where variable_name='%s'",
+		vardef.TiDBIgnoreInlistPlanDigest,
+	))
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+	store.SetOption(StoreBootstrappedKey, nil)
+
+	res := MustExecToRecodeSet(t, seV258, fmt.Sprintf(
+		"select * from mysql.GLOBAL_VARIABLES where variable_name='%s'",
+		vardef.TiDBIgnoreInlistPlanDigest,
+	))
+	chk := res.NewChunk(nil)
+	require.NoError(t, res.Next(ctx, chk))
+	require.Equal(t, 0, chk.NumRows())
+	require.NoError(t, res.Close())
+
+	dom.Close()
+	domCurVer, err := BootstrapSession(store)
+	require.NoError(t, err)
+	defer domCurVer.Close()
+
+	seCurVer := CreateSessionAndSetID(t, store)
+	ver, err := GetBootstrapVersion(seCurVer)
+	require.NoError(t, err)
+	require.Equal(t, currentBootstrapVersion, ver)
+
+	res = MustExecToRecodeSet(t, seCurVer, fmt.Sprintf(
+		"select * from mysql.GLOBAL_VARIABLES where variable_name='%s'",
+		vardef.TiDBIgnoreInlistPlanDigest,
+	))
+	chk = res.NewChunk(nil)
+	require.NoError(t, res.Next(ctx, chk))
+	require.Equal(t, 1, chk.NumRows())
+	require.Equal(t, "OFF", chk.GetRow(0).GetString(1))
+	require.NoError(t, res.Close())
+
+	res = MustExecToRecodeSet(t, seCurVer, "select @@global.tidb_ignore_inlist_plan_digest")
+	chk = res.NewChunk(nil)
+	require.NoError(t, res.Next(ctx, chk))
+	require.Equal(t, 1, chk.NumRows())
+	require.Equal(t, int64(0), chk.GetRow(0).GetInt64(0))
+	require.NoError(t, res.Close())
+}

--- a/pkg/session/upgrade_backfill_test.go
+++ b/pkg/session/upgrade_backfill_test.go
@@ -79,13 +79,17 @@ func TestUpgradeToVer259BackfillsIgnoreInlistPlanDigest(t *testing.T) {
 	chk = res.NewChunk(nil)
 	require.NoError(t, res.Next(ctx, chk))
 	require.Equal(t, 1, chk.NumRows())
-	require.Equal(t, "OFF", chk.GetRow(0).GetString(1))
+	require.Equal(t, variable.BoolToOnOff(vardef.DefTiDBIgnoreInlistPlanDigest), chk.GetRow(0).GetString(1))
 	require.NoError(t, res.Close())
 
 	res = MustExecToRecodeSet(t, seCurVer, "select @@global.tidb_ignore_inlist_plan_digest")
 	chk = res.NewChunk(nil)
 	require.NoError(t, res.Next(ctx, chk))
 	require.Equal(t, 1, chk.NumRows())
-	require.Equal(t, int64(0), chk.GetRow(0).GetInt64(0))
+	if vardef.DefTiDBIgnoreInlistPlanDigest {
+		require.Equal(t, int64(1), chk.GetRow(0).GetInt64(0))
+	} else {
+		require.Equal(t, int64(0), chk.GetRow(0).GetInt64(0))
+	}
 	require.NoError(t, res.Close())
 }

--- a/pkg/session/upgrade_backfill_test.go
+++ b/pkg/session/upgrade_backfill_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/session/upgrade_backfill_test.go
+++ b/pkg/session/upgrade_backfill_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
-	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,17 +79,13 @@ func TestUpgradeToVer259BackfillsIgnoreInlistPlanDigest(t *testing.T) {
 	chk = res.NewChunk(nil)
 	require.NoError(t, res.Next(ctx, chk))
 	require.Equal(t, 1, chk.NumRows())
-	require.Equal(t, variable.BoolToOnOff(vardef.DefTiDBIgnoreInlistPlanDigest), chk.GetRow(0).GetString(1))
+	require.Equal(t, "OFF", chk.GetRow(0).GetString(1))
 	require.NoError(t, res.Close())
 
 	res = MustExecToRecodeSet(t, seCurVer, "select @@global.tidb_ignore_inlist_plan_digest")
 	chk = res.NewChunk(nil)
 	require.NoError(t, res.Next(ctx, chk))
 	require.Equal(t, 1, chk.NumRows())
-	if vardef.DefTiDBIgnoreInlistPlanDigest {
-		require.Equal(t, int64(1), chk.GetRow(0).GetInt64(0))
-	} else {
-		require.Equal(t, int64(0), chk.GetRow(0).GetInt64(0))
-	}
+	require.Equal(t, int64(0), chk.GetRow(0).GetInt64(0))
 	require.NoError(t, res.Close())
 }

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -2118,5 +2118,5 @@ func upgradeToVer258(s sessionapi.Session, _ int64) {
 }
 
 func upgradeToVer259(s sessionapi.Session, _ int64) {
-	initGlobalVariableIfNotExists(s, vardef.TiDBIgnoreInlistPlanDigest, variable.BoolToOnOff(vardef.DefTiDBIgnoreInlistPlanDigest))
+	initGlobalVariableIfNotExists(s, vardef.TiDBIgnoreInlistPlanDigest, vardef.Off)
 }

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -497,7 +497,7 @@ const (
 	// version259
 	// Backfill tidb_ignore_inlist_plan_digest for upgraded clusters where the row in
 	// mysql.global_variables was never materialized when the variable was introduced.
-	// Preserve the pre-v8.5.6 behavior by persisting OFF when the row is missing.
+	// Use the current sysvar default when the row is missing.
 	version259 = 259
 )
 
@@ -2118,5 +2118,5 @@ func upgradeToVer258(s sessionapi.Session, _ int64) {
 }
 
 func upgradeToVer259(s sessionapi.Session, _ int64) {
-	initGlobalVariableIfNotExists(s, vardef.TiDBIgnoreInlistPlanDigest, vardef.Off)
+	initGlobalVariableIfNotExists(s, vardef.TiDBIgnoreInlistPlanDigest, variable.BoolToOnOff(vardef.DefTiDBIgnoreInlistPlanDigest))
 }

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -493,6 +493,12 @@ const (
 	// Add the default value management for `tidb_analyze_distsql_scan_concurrency`.
 	// If the cluster is upgraded from a version that has no such variable, we set it to the global.tidb_distsql_scan_concurrency value.
 	version258 = 258
+
+	// version259
+	// Backfill tidb_ignore_inlist_plan_digest for upgraded clusters where the row in
+	// mysql.global_variables was never materialized when the variable was introduced.
+	// Preserve the pre-v8.5.6 behavior by persisting OFF when the row is missing.
+	version259 = 259
 )
 
 // versionedUpgradeFunction is a struct that holds the upgrade function related
@@ -506,7 +512,7 @@ type versionedUpgradeFunction struct {
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version258
+var currentBootstrapVersion int64 = version259
 
 var (
 	// this list must be ordered by version in ascending order, and the function
@@ -689,6 +695,7 @@ var (
 		{version: version256, fn: upgradeToVer256},
 		{version: version257, fn: upgradeToVer257},
 		{version: version258, fn: upgradeToVer258},
+		{version: version259, fn: upgradeToVer259},
 	}
 )
 
@@ -2108,4 +2115,8 @@ func upgradeToVer258(s sessionapi.Session, _ int64) {
 		return
 	}
 	initGlobalVariableIfNotExists(s, vardef.TiDBAnalyzeDistSQLScanConcurrency, rows[0].GetString(0))
+}
+
+func upgradeToVer259(s sessionapi.Session, _ int64) {
+	initGlobalVariableIfNotExists(s, vardef.TiDBIgnoreInlistPlanDigest, vardef.Off)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68136

Problem Summary: planner: backfill `tidb_ignore_inlist_plan_digest` into `mysql.global_variables` during upgrade when the row is missing

### What changed and how does it work?

Backfill `tidb_ignore_inlist_plan_digest` into `mysql.global_variables` during upgrade when the row is missing.

- add a new bootstrap upgrade step to insert the variable if it does not exist
- use the sysvar default value when backfilling
- add a regression test covering the missing-row upgrade path

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the tidb_ignore_inlist_plan_digest system variable is backfilled during upgrades so it is present and evaluates to the expected value after upgrading.

* **Tests**
  * Add a regression test validating system-variable initialization across upgrade paths and update test expectations to the new bootstrap version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->