### PR TITLE
session: backfill tidb_ignore_inlist_plan_digest during upgrade

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -393,7 +393,7 @@ func TestCheckPrivilegeTableRowsCollateCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(227), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(228), session.CurrentBootstrapVersion)
 }
 
 func TestIsStatsTemporaryTable(t *testing.T) {

--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 12,
+    shard_count = 13,
     deps = [
         "//pkg/parser",
         "//pkg/planner",

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1271,6 +1271,12 @@ const (
 	// repairs the table schema.
 	version227 = 227
 
+	// version 228
+	// Backfill tidb_ignore_inlist_plan_digest for upgraded clusters where the row in
+	// mysql.global_variables was never materialized when the variable was introduced.
+	// Use the current sysvar default when the row is missing.
+	version228 = 228
+
 	// ...
 	// [version228, version238] is the version range reserved for patches of 8.5.x
 	// ...
@@ -1280,7 +1286,7 @@ const (
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version227
+var currentBootstrapVersion int64 = version228
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -1463,6 +1469,7 @@ var (
 		upgradeToVer225,
 		upgradeToVer226,
 		upgradeToVer227,
+		upgradeToVer228,
 	}
 )
 
@@ -3404,6 +3411,13 @@ func upgradeToVer227(s sessiontypes.Session, ver int64) {
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_pitr_id_map ADD COLUMN restore_id BIGINT NOT NULL DEFAULT 0", infoschema.ErrColumnExists)
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_pitr_id_map DROP PRIMARY KEY", dbterror.ErrCantDropFieldOrKey)
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_pitr_id_map ADD PRIMARY KEY(restore_id, restored_ts, upstream_cluster_id, segment_id)")
+}
+
+func upgradeToVer228(s sessiontypes.Session, ver int64) {
+	if ver >= version228 {
+		return
+	}
+	initGlobalVariableIfNotExists(s, variable.TiDBIgnoreInlistPlanDigest, variable.BoolToOnOff(variable.DefTiDBIgnoreInlistPlanDigest))
 }
 
 func getPrimaryKeyColsOrEmpty(s sessiontypes.Session, dbName, tableName string) []string {

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1278,7 +1278,7 @@ const (
 	version228 = 228
 
 	// ...
-	// [version228, version238] is the version range reserved for patches of 8.5.x
+	// [version229, version238] is the version range reserved for patches of 8.5.x
 	// ...
 	// next version should start with 239
 
@@ -3417,7 +3417,7 @@ func upgradeToVer228(s sessiontypes.Session, ver int64) {
 	if ver >= version228 {
 		return
 	}
-	initGlobalVariableIfNotExists(s, variable.TiDBIgnoreInlistPlanDigest, variable.BoolToOnOff(variable.DefTiDBIgnoreInlistPlanDigest))
+	initGlobalVariableIfNotExists(s, variable.TiDBIgnoreInlistPlanDigest, variable.Off)
 }
 
 func getPrimaryKeyColsOrEmpty(s sessiontypes.Session, dbName, tableName string) []string {

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -2745,6 +2745,74 @@ func TestUpgradeToVer227FixPITRIDMapSchemaWhenVer221Conflict(t *testing.T) {
 	requirePITRIDMapSchemaFixed(t, se2)
 }
 
+func TestUpgradeToVer228BackfillsIgnoreInlistPlanDigest(t *testing.T) {
+	ctx := context.Background()
+	store, dom := CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	ver227 := version227
+	seV227 := CreateSessionAndSetID(t, store)
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	err = m.FinishBootstrap(int64(ver227))
+	require.NoError(t, err)
+	revertVersionAndVariables(t, seV227, ver227)
+
+	// Simulate a cluster upgraded through the old path where the variable existed in code
+	// but its row was never backfilled into mysql.global_variables.
+	MustExec(t, seV227, fmt.Sprintf(
+		"delete from mysql.GLOBAL_VARIABLES where variable_name='%s'",
+		variable.TiDBIgnoreInlistPlanDigest,
+	))
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+	unsetStoreBootstrapped(store.UUID())
+
+	res := MustExecToRecodeSet(t, seV227, fmt.Sprintf(
+		"select * from mysql.GLOBAL_VARIABLES where variable_name='%s'",
+		variable.TiDBIgnoreInlistPlanDigest,
+	))
+	chk := res.NewChunk(nil)
+	err = res.Next(ctx, chk)
+	require.NoError(t, err)
+	require.Equal(t, 0, chk.NumRows())
+	require.NoError(t, res.Close())
+
+	dom.Close()
+	domCurVer, err := BootstrapSession(store)
+	require.NoError(t, err)
+	defer domCurVer.Close()
+
+	seCurVer := CreateSessionAndSetID(t, store)
+	ver, err := getBootstrapVersion(seCurVer)
+	require.NoError(t, err)
+	require.Equal(t, currentBootstrapVersion, ver)
+
+	res = MustExecToRecodeSet(t, seCurVer, fmt.Sprintf(
+		"select * from mysql.GLOBAL_VARIABLES where variable_name='%s'",
+		variable.TiDBIgnoreInlistPlanDigest,
+	))
+	chk = res.NewChunk(nil)
+	err = res.Next(ctx, chk)
+	require.NoError(t, err)
+	require.Equal(t, 1, chk.NumRows())
+	require.Equal(t, variable.BoolToOnOff(variable.DefTiDBIgnoreInlistPlanDigest), chk.GetRow(0).GetString(1))
+	require.NoError(t, res.Close())
+
+	res = MustExecToRecodeSet(t, seCurVer, "select @@global.tidb_ignore_inlist_plan_digest")
+	chk = res.NewChunk(nil)
+	err = res.Next(ctx, chk)
+	require.NoError(t, err)
+	require.Equal(t, 1, chk.NumRows())
+	if variable.DefTiDBIgnoreInlistPlanDigest {
+		require.Equal(t, int64(1), chk.GetRow(0).GetInt64(0))
+	} else {
+		require.Equal(t, int64(0), chk.GetRow(0).GetInt64(0))
+	}
+	require.NoError(t, res.Close())
+}
+
 func requirePITRIDMapSchemaFixed(t *testing.T, se sessiontypes.Session) {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -2797,7 +2797,7 @@ func TestUpgradeToVer228BackfillsIgnoreInlistPlanDigest(t *testing.T) {
 	err = res.Next(ctx, chk)
 	require.NoError(t, err)
 	require.Equal(t, 1, chk.NumRows())
-	require.Equal(t, variable.BoolToOnOff(variable.DefTiDBIgnoreInlistPlanDigest), chk.GetRow(0).GetString(1))
+	require.Equal(t, variable.Off, chk.GetRow(0).GetString(1))
 	require.NoError(t, res.Close())
 
 	res = MustExecToRecodeSet(t, seCurVer, "select @@global.tidb_ignore_inlist_plan_digest")
@@ -2805,11 +2805,7 @@ func TestUpgradeToVer228BackfillsIgnoreInlistPlanDigest(t *testing.T) {
 	err = res.Next(ctx, chk)
 	require.NoError(t, err)
 	require.Equal(t, 1, chk.NumRows())
-	if variable.DefTiDBIgnoreInlistPlanDigest {
-		require.Equal(t, int64(1), chk.GetRow(0).GetInt64(0))
-	} else {
-		require.Equal(t, int64(0), chk.GetRow(0).GetInt64(0))
-	}
+	require.Equal(t, int64(0), chk.GetRow(0).GetInt64(0))
 	require.NoError(t, res.Close())
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68136

Problem Summary: planner: backfill `tidb_ignore_inlist_plan_digest` into `mysql.global_variables` during upgrade when the row is missing

### What changed and how does it work?

Backfill `tidb_ignore_inlist_plan_digest` into `mysql.global_variables` during upgrade when the row is missing.

- add a new bootstrap upgrade step to insert the variable if it does not exist
- use the sysvar default value when backfilling
- add a regression test covering the missing-row upgrade path

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * A system configuration parameter is now automatically initialized during the bootstrap upgrade to ensure upgraded instances have the expected default.

* **Tests**
  * Added regression coverage for the 227→228 upgrade path validating the parameter is backfilled; updated an incremental system-table test to expect bootstrap version 228.

* **Chores**
  * Adjusted test/build configuration affecting test sharding and related test expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->