### PR TITLE
importer, mydump: fix parquet timestamp logical type import

### DIFF
--- a/pkg/dxf/importinto/subtask_executor.go
+++ b/pkg/dxf/importinto/subtask_executor.go
@@ -70,7 +70,7 @@ func (e *importMinimalTaskExecutor) Run(
 
 	chunk := e.mTtask.Chunk
 	chunk.ParquetMeta = mydump.ParquetFileMeta{
-		Loc: sharedVars.TableImporter.Location,
+		Loc: sharedVars.TableImporter.ParquetLocation(),
 	}
 
 	checksum := verify.NewKVGroupChecksumWithKeyspace(sharedVars.TableImporter.GetKeySpace())

--- a/pkg/executor/importer/BUILD.bazel
+++ b/pkg/executor/importer/BUILD.bazel
@@ -81,6 +81,7 @@ go_library(
         "//pkg/util/sqlkiller",
         "//pkg/util/stringutil",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "@com_github_docker_go_units//:go-units",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
@@ -116,7 +117,7 @@ go_test(
     embed = [":importer"],
     flaky = True,
     race = "on",
-    shard_count = 38,
+    shard_count = 39,
     deps = [
         "//br/pkg/mock",
         "//br/pkg/streamhelper",

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -705,10 +705,10 @@ func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs, option
 	logger := log.L().With(zap.String("table", fullTableName))
 	loc := time.UTC
 	// historically, we store *time.Location in Plan, but *time.Location cannot
-	// be marshaled into JSON, we now only store location name in Plan, and load
-	// location when creating controller. Old task metadata has no LocationID, so
-	// use UTC as the compatibility fallback before the location is passed to
-	// parquet parsing.
+	// be marshaled into JSON. New task metadata stores a timezone specifier
+	// string (IANA name or offset form), and resolves it when creating the
+	// controller. Old task metadata has no LocationID, so use UTC as the
+	// compatibility fallback before the location is passed to parquet parsing.
 	// see sparkRebaseTimeZoneID too.
 	if plan.LocationID != "" {
 		location, err := loadLocationFromID(plan.LocationID)

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -74,6 +75,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/naming"
 	sem "github.com/pingcap/tidb/pkg/util/sem/compat"
 	"github.com/pingcap/tidb/pkg/util/stringutil"
+	"github.com/pingcap/tidb/pkg/util/timeutil"
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -452,6 +454,30 @@ func getImportantSysVars(sctx sessionctx.Context) map[string]string {
 	return res
 }
 
+func getLocationID(sctx sessionctx.Context) string {
+	sessionVars := sctx.GetSessionVars()
+	if timeZone, ok := sessionVars.GetSystemVar(vardef.TimeZone); ok && !strings.EqualFold(timeZone, "SYSTEM") {
+		return timeZone
+	}
+	location := sessionVars.Location()
+	if locationID := location.String(); locationID != "" {
+		return locationID
+	}
+	_, offset := time.Now().In(location).Zone()
+	return formatTimeZoneOffset(offset)
+}
+
+func formatTimeZoneOffset(offset int) string {
+	sign := '+'
+	if offset < 0 {
+		sign = '-'
+		offset = -offset
+	}
+	hours := offset / int(time.Hour/time.Second)
+	minutes := offset % int(time.Hour/time.Second) / int(time.Minute/time.Second)
+	return fmt.Sprintf("%c%02d:%02d", sign, hours, minutes)
+}
+
 // NewPlanFromLoadDataPlan creates a import plan from LOAD DATA.
 func NewPlanFromLoadDataPlan(userSctx sessionctx.Context, plan *plannercore.LoadData) (*Plan, error) {
 	fullTableName := common.UniqueTable(plan.Table.Schema.L, plan.Table.Name.L)
@@ -526,7 +552,6 @@ func NewImportPlan(ctx context.Context, userSctx sessionctx.Context, plan *plann
 	restrictive := userSctx.GetSessionVars().SQLMode.HasStrictMode()
 	lineFieldsInfo := newDefaultLineFieldsInfo()
 
-	location := userSctx.GetSessionVars().Location()
 	p := &Plan{
 		TableInfo:        tbl.Meta(),
 		DesiredTableInfo: tbl.Meta(),
@@ -539,7 +564,7 @@ func NewImportPlan(ctx context.Context, userSctx sessionctx.Context, plan *plann
 		FieldNullDef:   defaultFieldNullDef,
 		LineFieldsInfo: lineFieldsInfo,
 
-		LocationID:       location.String(),
+		LocationID:       getLocationID(userSctx),
 		SQLMode:          userSctx.GetSessionVars().SQLMode,
 		ImportantSysVars: getImportantSysVars(userSctx),
 
@@ -623,6 +648,57 @@ func WithLogger(logger *zap.Logger) Option {
 	}
 }
 
+func loadLocationFromID(locationID string) (*time.Location, error) {
+	location, err := timeutil.ParseTimeZone(locationID)
+	if err == nil {
+		return location, nil
+	}
+	if location, ok := parseUTCFixedZone(locationID); ok {
+		return location, nil
+	}
+	return nil, err
+}
+
+func parseUTCFixedZone(locationID string) (*time.Location, bool) {
+	if !strings.HasPrefix(locationID, "UTC+") && !strings.HasPrefix(locationID, "UTC-") {
+		return nil, false
+	}
+
+	sign := locationID[len("UTC")]
+	parts := strings.Split(locationID[len("UTC")+1:], ":")
+	if len(parts) == 0 || len(parts) > 2 || parts[0] == "" {
+		return nil, false
+	}
+	hours, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, false
+	}
+	minutes := 0
+	if len(parts) == 2 {
+		if len(parts[1]) != 2 {
+			return nil, false
+		}
+		minutes, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return nil, false
+		}
+	}
+	if hours < 0 || minutes < 0 || minutes >= 60 {
+		return nil, false
+	}
+
+	offset := hours*int(time.Hour/time.Second) + minutes*int(time.Minute/time.Second)
+	if sign == '-' {
+		if offset > int((12*time.Hour+59*time.Minute)/time.Second) {
+			return nil, false
+		}
+		offset = -offset
+	} else if offset > int((14*time.Hour)/time.Second) {
+		return nil, false
+	}
+	return time.FixedZone(locationID, offset), true
+}
+
 // NewLoadDataController create new controller.
 func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs, options ...Option) (*LoadDataController, error) {
 	fullTableName := tbl.Meta().Name.String()
@@ -635,7 +711,7 @@ func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs, option
 	// both will be taken as UTC when used to parse parquet files.
 	// see sparkRebaseTimeZoneID too.
 	if plan.LocationID != "" {
-		location, err := time.LoadLocation(plan.LocationID)
+		location, err := loadLocationFromID(plan.LocationID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid location %s", plan.LocationID)
 		}

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -453,27 +453,6 @@ func getImportantSysVars(sctx sessionctx.Context) map[string]string {
 	return res
 }
 
-func getLocationID(sctx sessionctx.Context) string {
-	location := sctx.GetSessionVars().Location()
-	if locationID := location.String(); locationID != "" {
-		return locationID
-	}
-	// time_zone also can be set by "set time_zone='+08:00'"
-	_, offset := time.Now().In(location).Zone()
-	return formatTimeZoneOffset(offset)
-}
-
-func formatTimeZoneOffset(offset int) string {
-	sign := '+'
-	if offset < 0 {
-		sign = '-'
-		offset = -offset
-	}
-	hours := offset / int(time.Hour/time.Second)
-	minutes := offset % int(time.Hour/time.Second) / int(time.Minute/time.Second)
-	return fmt.Sprintf("%c%02d:%02d", sign, hours, minutes)
-}
-
 // NewPlanFromLoadDataPlan creates a import plan from LOAD DATA.
 func NewPlanFromLoadDataPlan(userSctx sessionctx.Context, plan *plannercore.LoadData) (*Plan, error) {
 	fullTableName := common.UniqueTable(plan.Table.Schema.L, plan.Table.Name.L)
@@ -547,7 +526,10 @@ func NewImportPlan(ctx context.Context, userSctx sessionctx.Context, plan *plann
 	}
 	restrictive := userSctx.GetSessionVars().SQLMode.HasStrictMode()
 	lineFieldsInfo := newDefaultLineFieldsInfo()
-
+	// TiDB doesn't support setting zones like UTC+8, it should be parsable by
+	// ParseTimeZone, i.e. in IANA format like Asia/Shanghai, or in offset form
+	// like +08:00.
+	location := userSctx.GetSessionVars().Location()
 	p := &Plan{
 		TableInfo:        tbl.Meta(),
 		DesiredTableInfo: tbl.Meta(),
@@ -560,7 +542,7 @@ func NewImportPlan(ctx context.Context, userSctx sessionctx.Context, plan *plann
 		FieldNullDef:   defaultFieldNullDef,
 		LineFieldsInfo: lineFieldsInfo,
 
-		LocationID:       getLocationID(userSctx),
+		LocationID:       timeutil.ZoneName(location),
 		SQLMode:          userSctx.GetSessionVars().SQLMode,
 		ImportantSysVars: getImportantSysVars(userSctx),
 

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -455,14 +454,11 @@ func getImportantSysVars(sctx sessionctx.Context) map[string]string {
 }
 
 func getLocationID(sctx sessionctx.Context) string {
-	sessionVars := sctx.GetSessionVars()
-	if timeZone, ok := sessionVars.GetSystemVar(vardef.TimeZone); ok && !strings.EqualFold(timeZone, "SYSTEM") {
-		return timeZone
-	}
-	location := sessionVars.Location()
+	location := sctx.GetSessionVars().Location()
 	if locationID := location.String(); locationID != "" {
 		return locationID
 	}
+	// time_zone also can be set by "set time_zone='+08:00'"
 	_, offset := time.Now().In(location).Zone()
 	return formatTimeZoneOffset(offset)
 }
@@ -648,57 +644,6 @@ func WithLogger(logger *zap.Logger) Option {
 	}
 }
 
-func loadLocationFromID(locationID string) (*time.Location, error) {
-	location, err := timeutil.ParseTimeZone(locationID)
-	if err == nil {
-		return location, nil
-	}
-	if location, ok := parseUTCFixedZone(locationID); ok {
-		return location, nil
-	}
-	return nil, err
-}
-
-func parseUTCFixedZone(locationID string) (*time.Location, bool) {
-	if !strings.HasPrefix(locationID, "UTC+") && !strings.HasPrefix(locationID, "UTC-") {
-		return nil, false
-	}
-
-	sign := locationID[len("UTC")]
-	parts := strings.Split(locationID[len("UTC")+1:], ":")
-	if len(parts) == 0 || len(parts) > 2 || parts[0] == "" {
-		return nil, false
-	}
-	hours, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return nil, false
-	}
-	minutes := 0
-	if len(parts) == 2 {
-		if len(parts[1]) != 2 {
-			return nil, false
-		}
-		minutes, err = strconv.Atoi(parts[1])
-		if err != nil {
-			return nil, false
-		}
-	}
-	if hours < 0 || minutes < 0 || minutes >= 60 {
-		return nil, false
-	}
-
-	offset := hours*int(time.Hour/time.Second) + minutes*int(time.Minute/time.Second)
-	if sign == '-' {
-		if offset > int((12*time.Hour+59*time.Minute)/time.Second) {
-			return nil, false
-		}
-		offset = -offset
-	} else if offset > int((14*time.Hour)/time.Second) {
-		return nil, false
-	}
-	return time.FixedZone(locationID, offset), true
-}
-
 // NewLoadDataController create new controller.
 func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs, options ...Option) (*LoadDataController, error) {
 	fullTableName := tbl.Meta().Name.String()
@@ -711,7 +656,7 @@ func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs, option
 	// compatibility fallback before the location is passed to parquet parsing.
 	// see sparkRebaseTimeZoneID too.
 	if plan.LocationID != "" {
-		location, err := loadLocationFromID(plan.LocationID)
+		location, err := timeutil.ParseTimeZone(plan.LocationID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid location %s", plan.LocationID)
 		}

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -423,7 +423,7 @@ type LoadDataController struct {
 	// - "...(a,b) set b=100" will set b=100 in mysql, but in tidb the set is ignored.
 	// - ref columns in set clause is allowed in mysql, but not in tidb
 	InsertColumns []*table.Column
-	Location      *time.Location
+	location      *time.Location
 	logger        *zap.Logger
 	dataStore     storeapi.Storage
 	dataFiles     []*mydump.SourceFileMeta
@@ -706,9 +706,9 @@ func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs, option
 	var loc *time.Location
 	// historically, we store *time.Location in Plan, but *time.Location cannot
 	// be marshaled into JSON, we now only store location name in Plan, and load
-	// location when creating controller, for those old plans, we keep the Location
-	// nil. it's semantically the same as the old incorrectly marshaled Location,
-	// both will be taken as UTC when used to parse parquet files.
+	// location when creating controller. For old plans without LocationID, keep
+	// the controller location nil so parquet parsing uses its existing nil-location
+	// fallback, timeutil.SystemLocation().
 	// see sparkRebaseTimeZoneID too.
 	if plan.LocationID != "" {
 		location, err := loadLocationFromID(plan.LocationID)
@@ -721,7 +721,7 @@ func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs, option
 		Plan:            plan,
 		ASTArgs:         astArgs,
 		Table:           tbl,
-		Location:        loc,
+		location:        loc,
 		logger:          logger,
 		ExecuteNodesCnt: 1,
 	}
@@ -738,6 +738,12 @@ func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs, option
 		return nil, err
 	}
 	return c, nil
+}
+
+// ParquetLocation returns the timezone used to interpret parquet temporal values.
+// Callers should treat the returned location as read-only controller state.
+func (e *LoadDataController) ParquetLocation() *time.Location {
+	return e.location
 }
 
 // InitTiKVConfigs initializes some TiKV related configs.
@@ -1567,7 +1573,7 @@ func (e *LoadDataController) InitDataFiles(ctx context.Context) error {
 			FileSize:    size,
 			Compression: compressTp,
 			Type:        sourceType,
-			ParquetMeta: mydump.ParquetFileMeta{Loc: e.Location},
+			ParquetMeta: mydump.ParquetFileMeta{Loc: e.location},
 		}
 		fileMeta.RealSize = mydump.EstimateRealSizeForFile(ctx, fileMeta, s)
 		fileMeta.RealSize = int64(float64(fileMeta.RealSize) * compressionRatio)
@@ -1624,7 +1630,7 @@ func (e *LoadDataController) InitDataFiles(ctx context.Context) error {
 					FileSize:    size,
 					Compression: compressTp,
 					Type:        sourceType,
-					ParquetMeta: mydump.ParquetFileMeta{Loc: e.Location},
+					ParquetMeta: mydump.ParquetFileMeta{Loc: e.location},
 				}
 				fileMeta.RealSize = int64(ce.estimate(ctx, fileMeta, s) * float64(fileMeta.FileSize))
 				fileMeta.RealSize = int64(float64(fileMeta.RealSize) * sizeExpansionRatio)

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -275,9 +275,9 @@ type Plan struct {
 	// ref https://dev.mysql.com/doc/refman/8.0/en/load-data.html#load-data-column-assignments
 	Restrictive bool
 
-	// Location is used to convert time type for parquet, see
+	// LocationID is used to convert time type for parquet, see
 	// https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#timestamp
-	Location *time.Location
+	LocationID string
 
 	SQLMode mysql.SQLMode
 	// Charset is the charset of the data file when file is CSV or TSV.
@@ -421,10 +421,10 @@ type LoadDataController struct {
 	// - "...(a,b) set b=100" will set b=100 in mysql, but in tidb the set is ignored.
 	// - ref columns in set clause is allowed in mysql, but not in tidb
 	InsertColumns []*table.Column
-
-	logger    *zap.Logger
-	dataStore storeapi.Storage
-	dataFiles []*mydump.SourceFileMeta
+	Location      *time.Location
+	logger        *zap.Logger
+	dataStore     storeapi.Storage
+	dataFiles     []*mydump.SourceFileMeta
 	// exported for testing.
 	TotalRealSize int64
 	// globalSortStore is used to store sorted data when using global sort.
@@ -526,6 +526,7 @@ func NewImportPlan(ctx context.Context, userSctx sessionctx.Context, plan *plann
 	restrictive := userSctx.GetSessionVars().SQLMode.HasStrictMode()
 	lineFieldsInfo := newDefaultLineFieldsInfo()
 
+	location := userSctx.GetSessionVars().Location()
 	p := &Plan{
 		TableInfo:        tbl.Meta(),
 		DesiredTableInfo: tbl.Meta(),
@@ -538,7 +539,7 @@ func NewImportPlan(ctx context.Context, userSctx sessionctx.Context, plan *plann
 		FieldNullDef:   defaultFieldNullDef,
 		LineFieldsInfo: lineFieldsInfo,
 
-		Location:         userSctx.GetSessionVars().Location(),
+		LocationID:       location.String(),
 		SQLMode:          userSctx.GetSessionVars().SQLMode,
 		ImportantSysVars: getImportantSysVars(userSctx),
 
@@ -626,10 +627,25 @@ func WithLogger(logger *zap.Logger) Option {
 func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs, options ...Option) (*LoadDataController, error) {
 	fullTableName := tbl.Meta().Name.String()
 	logger := log.L().With(zap.String("table", fullTableName))
+	var loc *time.Location
+	// historically, we store *time.Location in Plan, but *time.Location cannot
+	// be marshaled into JSON, we now only store location name in Plan, and load
+	// location when creating controller, for those old plans, we keep the Location
+	// nil. it's semantically the same as the old incorrectly marshaled Location,
+	// both will be taken as UTC when used to parse parquet files.
+	// see sparkRebaseTimeZoneID too.
+	if plan.LocationID != "" {
+		location, err := time.LoadLocation(plan.LocationID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid location %s", plan.LocationID)
+		}
+		loc = location
+	}
 	c := &LoadDataController{
 		Plan:            plan,
 		ASTArgs:         astArgs,
 		Table:           tbl,
+		Location:        loc,
 		logger:          logger,
 		ExecuteNodesCnt: 1,
 	}
@@ -1475,6 +1491,7 @@ func (e *LoadDataController) InitDataFiles(ctx context.Context) error {
 			FileSize:    size,
 			Compression: compressTp,
 			Type:        sourceType,
+			ParquetMeta: mydump.ParquetFileMeta{Loc: e.Location},
 		}
 		fileMeta.RealSize = mydump.EstimateRealSizeForFile(ctx, fileMeta, s)
 		fileMeta.RealSize = int64(float64(fileMeta.RealSize) * compressionRatio)
@@ -1531,6 +1548,7 @@ func (e *LoadDataController) InitDataFiles(ctx context.Context) error {
 					FileSize:    size,
 					Compression: compressTp,
 					Type:        sourceType,
+					ParquetMeta: mydump.ParquetFileMeta{Loc: e.Location},
 				}
 				fileMeta.RealSize = int64(ce.estimate(ctx, fileMeta, s) * float64(fileMeta.FileSize))
 				fileMeta.RealSize = int64(float64(fileMeta.RealSize) * sizeExpansionRatio)

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -703,12 +703,12 @@ func parseUTCFixedZone(locationID string) (*time.Location, bool) {
 func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs, options ...Option) (*LoadDataController, error) {
 	fullTableName := tbl.Meta().Name.String()
 	logger := log.L().With(zap.String("table", fullTableName))
-	var loc *time.Location
+	loc := time.UTC
 	// historically, we store *time.Location in Plan, but *time.Location cannot
 	// be marshaled into JSON, we now only store location name in Plan, and load
-	// location when creating controller. For old plans without LocationID, keep
-	// the controller location nil so parquet parsing uses its existing nil-location
-	// fallback, timeutil.SystemLocation().
+	// location when creating controller. Old task metadata has no LocationID, so
+	// use UTC as the compatibility fallback before the location is passed to
+	// parquet parsing.
 	// see sparkRebaseTimeZoneID too.
 	if plan.LocationID != "" {
 		location, err := loadLocationFromID(plan.LocationID)

--- a/pkg/executor/importer/import_test.go
+++ b/pkg/executor/importer/import_test.go
@@ -30,15 +30,19 @@ import (
 	"github.com/docker/go-units"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/expression"
 	tidbkv "github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/lightning/config"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
+	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
@@ -48,6 +52,14 @@ import (
 	tikvutil "github.com/tikv/client-go/v2/util"
 	"go.uber.org/zap"
 )
+
+type keyspaceOnlyStore struct {
+	tidbkv.Storage
+}
+
+func (keyspaceOnlyStore) GetKeyspace() string {
+	return ""
+}
 
 func TestInitDefaultOptions(t *testing.T) {
 	plan := &Plan{
@@ -361,6 +373,53 @@ func TestGetLocalBackendCfg(t *testing.T) {
 	cfg = c.getLocalBackendCfg("", "http://1.1.1.1:1234", "/tmp")
 	require.Greater(t, cfg.RaftKV2SwitchModeDuration, time.Duration(0))
 	require.Equal(t, config.DefaultSwitchTiKVModeInterval, cfg.RaftKV2SwitchModeDuration)
+
+	t.Run("import_plan_parquet_location", func(t *testing.T) {
+		ctx := context.Background()
+		sctx := mock.NewContext()
+		sctx.Store = keyspaceOnlyStore{}
+		asiaShanghai, err := time.LoadLocation("Asia/Shanghai")
+		require.NoError(t, err)
+		sctx.GetSessionVars().TimeZone = asiaShanghai
+		sctx.GetSessionVars().StmtCtx.SetTimeZone(asiaShanghai)
+
+		node, err := parser.New().ParseOneStmt("create table t(a timestamp)", "", "")
+		require.NoError(t, err)
+		tblInfo, err := ddl.MockTableInfo(sctx, node.(*ast.CreateTableStmt), 1)
+		require.NoError(t, err)
+		tblInfo.State = model.StatePublic
+		table := tables.MockTableFromMeta(tblInfo)
+
+		fileName := filepath.Join(t.TempDir(), "data.parquet")
+		require.NoError(t, os.WriteFile(fileName, nil, 0o644))
+		format := DataFormatParquet
+		plan, err := NewImportPlan(ctx, sctx, plannercore.ImportInto{
+			Path:   fileName,
+			Format: &format,
+			Table: &resolve.TableNameW{
+				TableName: &ast.TableName{
+					Schema: ast.NewCIStr("test"),
+					Name:   ast.NewCIStr("t"),
+				},
+				DBInfo: &model.DBInfo{
+					Name: ast.NewCIStr("test"),
+					ID:   1,
+				},
+			},
+		}.Init(sctx.GetPlanCtx()), table)
+		require.NoError(t, err)
+		require.Equal(t, "Asia/Shanghai", plan.LocationID)
+
+		controller, err := NewLoadDataController(plan, table, &ASTArgs{})
+		require.NoError(t, err)
+		require.NotNil(t, controller.Location)
+		require.Equal(t, "Asia/Shanghai", controller.Location.String())
+
+		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/importer/skipEstimateCompressionForParquet", "return(true)")
+		require.NoError(t, controller.InitDataFiles(ctx))
+		require.Len(t, controller.dataFiles, 1)
+		require.Same(t, controller.Location, controller.dataFiles[0].ParquetMeta.Loc)
+	})
 }
 
 func TestInitCompressedFiles(t *testing.T) {

--- a/pkg/executor/importer/import_test.go
+++ b/pkg/executor/importer/import_test.go
@@ -373,42 +373,45 @@ func TestGetLocalBackendCfg(t *testing.T) {
 	cfg = c.getLocalBackendCfg("", "http://1.1.1.1:1234", "/tmp")
 	require.Greater(t, cfg.RaftKV2SwitchModeDuration, time.Duration(0))
 	require.Equal(t, config.DefaultSwitchTiKVModeInterval, cfg.RaftKV2SwitchModeDuration)
+}
 
-	ctx := context.Background()
-	newParquetPlanAndController := func(t *testing.T, sctx *mock.Context) (*Plan, *LoadDataController) {
-		t.Helper()
-		sctx.Store = keyspaceOnlyStore{}
+func newParquetPlanAndControllerForTest(ctx context.Context, t *testing.T, sctx *mock.Context) (*Plan, *LoadDataController) {
+	t.Helper()
+	sctx.Store = keyspaceOnlyStore{}
 
-		node, err := parser.New().ParseOneStmt("create table t(a timestamp)", "", "")
-		require.NoError(t, err)
-		tblInfo, err := ddl.MockTableInfo(sctx, node.(*ast.CreateTableStmt), 1)
-		require.NoError(t, err)
-		tblInfo.State = model.StatePublic
-		table := tables.MockTableFromMeta(tblInfo)
+	node, err := parser.New().ParseOneStmt("create table t(a timestamp)", "", "")
+	require.NoError(t, err)
+	tblInfo, err := ddl.MockTableInfo(sctx, node.(*ast.CreateTableStmt), 1)
+	require.NoError(t, err)
+	tblInfo.State = model.StatePublic
+	table := tables.MockTableFromMeta(tblInfo)
 
-		fileName := filepath.Join(t.TempDir(), "data.parquet")
-		require.NoError(t, os.WriteFile(fileName, nil, 0o644))
-		format := DataFormatParquet
-		plan, err := NewImportPlan(ctx, sctx, plannercore.ImportInto{
-			Path:   fileName,
-			Format: &format,
-			Table: &resolve.TableNameW{
-				TableName: &ast.TableName{
-					Schema: ast.NewCIStr("test"),
-					Name:   ast.NewCIStr("t"),
-				},
-				DBInfo: &model.DBInfo{
-					Name: ast.NewCIStr("test"),
-					ID:   1,
-				},
+	fileName := filepath.Join(t.TempDir(), "data.parquet")
+	require.NoError(t, os.WriteFile(fileName, nil, 0o644))
+	format := DataFormatParquet
+	plan, err := NewImportPlan(ctx, sctx, plannercore.ImportInto{
+		Path:   fileName,
+		Format: &format,
+		Table: &resolve.TableNameW{
+			TableName: &ast.TableName{
+				Schema: ast.NewCIStr("test"),
+				Name:   ast.NewCIStr("t"),
 			},
-		}.Init(sctx.GetPlanCtx()), table)
-		require.NoError(t, err)
+			DBInfo: &model.DBInfo{
+				Name: ast.NewCIStr("test"),
+				ID:   1,
+			},
+		},
+	}.Init(sctx.GetPlanCtx()), table)
+	require.NoError(t, err)
 
-		controller, err := NewLoadDataController(plan, table, &ASTArgs{})
-		require.NoError(t, err)
-		return plan, controller
-	}
+	controller, err := NewLoadDataController(plan, table, &ASTArgs{})
+	require.NoError(t, err)
+	return plan, controller
+}
+
+func TestImportPlanParquetLocation(t *testing.T) {
+	ctx := context.Background()
 
 	t.Run("import_plan_parquet_location", func(t *testing.T) {
 		sctx := mock.NewContext()
@@ -417,31 +420,31 @@ func TestGetLocalBackendCfg(t *testing.T) {
 		sctx.GetSessionVars().TimeZone = asiaShanghai
 		sctx.GetSessionVars().StmtCtx.SetTimeZone(asiaShanghai)
 
-		plan, controller := newParquetPlanAndController(t, sctx)
+		plan, controller := newParquetPlanAndControllerForTest(ctx, t, sctx)
 		require.Equal(t, "Asia/Shanghai", plan.LocationID)
-		require.NotNil(t, controller.Location)
-		require.Equal(t, "Asia/Shanghai", controller.Location.String())
+		require.NotNil(t, controller.ParquetLocation())
+		require.Equal(t, "Asia/Shanghai", controller.ParquetLocation().String())
 
 		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/importer/skipEstimateCompressionForParquet", "return(true)")
 		require.NoError(t, controller.InitDataFiles(ctx))
 		require.Len(t, controller.dataFiles, 1)
-		require.Same(t, controller.Location, controller.dataFiles[0].ParquetMeta.Loc)
+		require.Same(t, controller.ParquetLocation(), controller.dataFiles[0].ParquetMeta.Loc)
 	})
 
 	t.Run("import_plan_parquet_fixed_offset_location", func(t *testing.T) {
 		sctx := mock.NewContext()
 		require.NoError(t, sctx.GetSessionVars().SetSystemVar(vardef.TimeZone, "+08:00"))
 
-		plan, controller := newParquetPlanAndController(t, sctx)
+		plan, controller := newParquetPlanAndControllerForTest(ctx, t, sctx)
 		require.Equal(t, "+08:00", plan.LocationID)
-		require.NotNil(t, controller.Location)
-		_, offset := time.Now().In(controller.Location).Zone()
+		require.NotNil(t, controller.ParquetLocation())
+		_, offset := time.Now().In(controller.ParquetLocation()).Zone()
 		require.Equal(t, 8*3600, offset)
 
 		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/importer/skipEstimateCompressionForParquet", "return(true)")
 		require.NoError(t, controller.InitDataFiles(ctx))
 		require.Len(t, controller.dataFiles, 1)
-		require.Same(t, controller.Location, controller.dataFiles[0].ParquetMeta.Loc)
+		require.Same(t, controller.ParquetLocation(), controller.dataFiles[0].ParquetMeta.Loc)
 	})
 
 	t.Run("import_plan_parquet_named_fixed_zone_location", func(t *testing.T) {
@@ -450,10 +453,10 @@ func TestGetLocalBackendCfg(t *testing.T) {
 		sctx.GetSessionVars().TimeZone = loc
 		sctx.GetSessionVars().StmtCtx.SetTimeZone(loc)
 
-		plan, controller := newParquetPlanAndController(t, sctx)
+		plan, controller := newParquetPlanAndControllerForTest(ctx, t, sctx)
 		require.Equal(t, "UTC+8", plan.LocationID)
-		require.NotNil(t, controller.Location)
-		_, offset := time.Now().In(controller.Location).Zone()
+		require.NotNil(t, controller.ParquetLocation())
+		_, offset := time.Now().In(controller.ParquetLocation()).Zone()
 		require.Equal(t, 8*3600, offset)
 	})
 
@@ -463,10 +466,10 @@ func TestGetLocalBackendCfg(t *testing.T) {
 		sctx.GetSessionVars().TimeZone = loc
 		sctx.GetSessionVars().StmtCtx.SetTimeZone(loc)
 
-		plan, controller := newParquetPlanAndController(t, sctx)
+		plan, controller := newParquetPlanAndControllerForTest(ctx, t, sctx)
 		require.Equal(t, "-06:00", plan.LocationID)
-		require.NotNil(t, controller.Location)
-		_, offset := time.Now().In(controller.Location).Zone()
+		require.NotNil(t, controller.ParquetLocation())
+		_, offset := time.Now().In(controller.ParquetLocation()).Zone()
 		require.Equal(t, -6*3600, offset)
 	})
 }

--- a/pkg/executor/importer/import_test.go
+++ b/pkg/executor/importer/import_test.go
@@ -416,6 +416,7 @@ func TestImportPlanParquetLocation(t *testing.T) {
 
 	t.Run("import_plan_parquet_location", func(t *testing.T) {
 		sctx := mock.NewContext()
+		defer sctx.Close()
 		asiaShanghai, err := time.LoadLocation("Asia/Shanghai")
 		require.NoError(t, err)
 		sctx.GetSessionVars().TimeZone = asiaShanghai
@@ -434,6 +435,7 @@ func TestImportPlanParquetLocation(t *testing.T) {
 
 	t.Run("import_plan_parquet_fixed_offset_location", func(t *testing.T) {
 		sctx := mock.NewContext()
+		defer sctx.Close()
 		require.NoError(t, sctx.GetSessionVars().SetSystemVar(vardef.TimeZone, "+08:00"))
 
 		plan, controller := newParquetPlanAndControllerForTest(ctx, t, sctx)
@@ -450,6 +452,7 @@ func TestImportPlanParquetLocation(t *testing.T) {
 
 	t.Run("import_plan_parquet_named_fixed_zone_location", func(t *testing.T) {
 		sctx := mock.NewContext()
+		defer sctx.Close()
 		loc := time.FixedZone("UTC+8", 8*3600)
 		sctx.GetSessionVars().TimeZone = loc
 		sctx.GetSessionVars().StmtCtx.SetTimeZone(loc)
@@ -463,6 +466,7 @@ func TestImportPlanParquetLocation(t *testing.T) {
 
 	t.Run("import_plan_parquet_unnamed_fixed_zone_location", func(t *testing.T) {
 		sctx := mock.NewContext()
+		defer sctx.Close()
 		loc := time.FixedZone("", -6*3600)
 		sctx.GetSessionVars().TimeZone = loc
 		sctx.GetSessionVars().StmtCtx.SetTimeZone(loc)
@@ -476,6 +480,7 @@ func TestImportPlanParquetLocation(t *testing.T) {
 
 	t.Run("legacy_import_task_meta_without_location_id_uses_utc", func(t *testing.T) {
 		sctx := mock.NewContext()
+		defer sctx.Close()
 		asiaShanghai, err := time.LoadLocation("Asia/Shanghai")
 		require.NoError(t, err)
 		sctx.GetSessionVars().TimeZone = asiaShanghai

--- a/pkg/executor/importer/import_test.go
+++ b/pkg/executor/importer/import_test.go
@@ -374,14 +374,10 @@ func TestGetLocalBackendCfg(t *testing.T) {
 	require.Greater(t, cfg.RaftKV2SwitchModeDuration, time.Duration(0))
 	require.Equal(t, config.DefaultSwitchTiKVModeInterval, cfg.RaftKV2SwitchModeDuration)
 
-	t.Run("import_plan_parquet_location", func(t *testing.T) {
-		ctx := context.Background()
-		sctx := mock.NewContext()
+	ctx := context.Background()
+	newParquetPlanAndController := func(t *testing.T, sctx *mock.Context) (*Plan, *LoadDataController) {
+		t.Helper()
 		sctx.Store = keyspaceOnlyStore{}
-		asiaShanghai, err := time.LoadLocation("Asia/Shanghai")
-		require.NoError(t, err)
-		sctx.GetSessionVars().TimeZone = asiaShanghai
-		sctx.GetSessionVars().StmtCtx.SetTimeZone(asiaShanghai)
 
 		node, err := parser.New().ParseOneStmt("create table t(a timestamp)", "", "")
 		require.NoError(t, err)
@@ -408,10 +404,21 @@ func TestGetLocalBackendCfg(t *testing.T) {
 			},
 		}.Init(sctx.GetPlanCtx()), table)
 		require.NoError(t, err)
-		require.Equal(t, "Asia/Shanghai", plan.LocationID)
 
 		controller, err := NewLoadDataController(plan, table, &ASTArgs{})
 		require.NoError(t, err)
+		return plan, controller
+	}
+
+	t.Run("import_plan_parquet_location", func(t *testing.T) {
+		sctx := mock.NewContext()
+		asiaShanghai, err := time.LoadLocation("Asia/Shanghai")
+		require.NoError(t, err)
+		sctx.GetSessionVars().TimeZone = asiaShanghai
+		sctx.GetSessionVars().StmtCtx.SetTimeZone(asiaShanghai)
+
+		plan, controller := newParquetPlanAndController(t, sctx)
+		require.Equal(t, "Asia/Shanghai", plan.LocationID)
 		require.NotNil(t, controller.Location)
 		require.Equal(t, "Asia/Shanghai", controller.Location.String())
 
@@ -419,6 +426,48 @@ func TestGetLocalBackendCfg(t *testing.T) {
 		require.NoError(t, controller.InitDataFiles(ctx))
 		require.Len(t, controller.dataFiles, 1)
 		require.Same(t, controller.Location, controller.dataFiles[0].ParquetMeta.Loc)
+	})
+
+	t.Run("import_plan_parquet_fixed_offset_location", func(t *testing.T) {
+		sctx := mock.NewContext()
+		require.NoError(t, sctx.GetSessionVars().SetSystemVar(vardef.TimeZone, "+08:00"))
+
+		plan, controller := newParquetPlanAndController(t, sctx)
+		require.Equal(t, "+08:00", plan.LocationID)
+		require.NotNil(t, controller.Location)
+		_, offset := time.Now().In(controller.Location).Zone()
+		require.Equal(t, 8*3600, offset)
+
+		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/importer/skipEstimateCompressionForParquet", "return(true)")
+		require.NoError(t, controller.InitDataFiles(ctx))
+		require.Len(t, controller.dataFiles, 1)
+		require.Same(t, controller.Location, controller.dataFiles[0].ParquetMeta.Loc)
+	})
+
+	t.Run("import_plan_parquet_named_fixed_zone_location", func(t *testing.T) {
+		sctx := mock.NewContext()
+		loc := time.FixedZone("UTC+8", 8*3600)
+		sctx.GetSessionVars().TimeZone = loc
+		sctx.GetSessionVars().StmtCtx.SetTimeZone(loc)
+
+		plan, controller := newParquetPlanAndController(t, sctx)
+		require.Equal(t, "UTC+8", plan.LocationID)
+		require.NotNil(t, controller.Location)
+		_, offset := time.Now().In(controller.Location).Zone()
+		require.Equal(t, 8*3600, offset)
+	})
+
+	t.Run("import_plan_parquet_unnamed_fixed_zone_location", func(t *testing.T) {
+		sctx := mock.NewContext()
+		loc := time.FixedZone("", -6*3600)
+		sctx.GetSessionVars().TimeZone = loc
+		sctx.GetSessionVars().StmtCtx.SetTimeZone(loc)
+
+		plan, controller := newParquetPlanAndController(t, sctx)
+		require.Equal(t, "-06:00", plan.LocationID)
+		require.NotNil(t, controller.Location)
+		_, offset := time.Now().In(controller.Location).Zone()
+		require.Equal(t, -6*3600, offset)
 	})
 }
 

--- a/pkg/executor/importer/import_test.go
+++ b/pkg/executor/importer/import_test.go
@@ -16,6 +16,7 @@ package importer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -471,6 +472,45 @@ func TestImportPlanParquetLocation(t *testing.T) {
 		require.NotNil(t, controller.ParquetLocation())
 		_, offset := time.Now().In(controller.ParquetLocation()).Zone()
 		require.Equal(t, -6*3600, offset)
+	})
+
+	t.Run("legacy_import_task_meta_without_location_id_uses_utc", func(t *testing.T) {
+		sctx := mock.NewContext()
+		asiaShanghai, err := time.LoadLocation("Asia/Shanghai")
+		require.NoError(t, err)
+		sctx.GetSessionVars().TimeZone = asiaShanghai
+		sctx.GetSessionVars().StmtCtx.SetTimeZone(asiaShanghai)
+
+		plan, controller := newParquetPlanAndControllerForTest(ctx, t, sctx)
+		taskMetaBytes, err := json.Marshal(struct {
+			Plan *Plan
+		}{
+			Plan: plan,
+		})
+		require.NoError(t, err)
+
+		var taskMeta map[string]any
+		require.NoError(t, json.Unmarshal(taskMetaBytes, &taskMeta))
+		planMeta, ok := taskMeta["Plan"].(map[string]any)
+		require.True(t, ok)
+		delete(planMeta, "LocationID")
+		legacyTaskMetaBytes, err := json.Marshal(taskMeta)
+		require.NoError(t, err)
+
+		var legacyTaskMeta struct {
+			Plan Plan
+		}
+		require.NoError(t, json.Unmarshal(legacyTaskMetaBytes, &legacyTaskMeta))
+		require.Empty(t, legacyTaskMeta.Plan.LocationID)
+
+		legacyController, err := NewLoadDataController(&legacyTaskMeta.Plan, controller.Table, &ASTArgs{})
+		require.NoError(t, err)
+		require.Same(t, time.UTC, legacyController.ParquetLocation())
+
+		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/importer/skipEstimateCompressionForParquet", "return(true)")
+		require.NoError(t, legacyController.InitDataFiles(ctx))
+		require.Len(t, legacyController.dataFiles, 1)
+		require.Same(t, time.UTC, legacyController.dataFiles[0].ParquetMeta.Loc)
 	})
 }
 

--- a/pkg/executor/importer/import_test.go
+++ b/pkg/executor/importer/import_test.go
@@ -376,7 +376,7 @@ func TestGetLocalBackendCfg(t *testing.T) {
 	require.Equal(t, config.DefaultSwitchTiKVModeInterval, cfg.RaftKV2SwitchModeDuration)
 }
 
-func newParquetPlanAndControllerForTest(ctx context.Context, t *testing.T, sctx *mock.Context) (*Plan, *LoadDataController) {
+func newParquetPlanAndControllerForTest(ctx context.Context, t *testing.T, sctx *mock.Context) (*Plan, *LoadDataController, error) {
 	t.Helper()
 	sctx.Store = keyspaceOnlyStore{}
 
@@ -407,8 +407,7 @@ func newParquetPlanAndControllerForTest(ctx context.Context, t *testing.T, sctx 
 	require.NoError(t, err)
 
 	controller, err := NewLoadDataController(plan, table, &ASTArgs{})
-	require.NoError(t, err)
-	return plan, controller
+	return plan, controller, err
 }
 
 func TestImportPlanParquetLocation(t *testing.T) {
@@ -422,7 +421,8 @@ func TestImportPlanParquetLocation(t *testing.T) {
 		sctx.GetSessionVars().TimeZone = asiaShanghai
 		sctx.GetSessionVars().StmtCtx.SetTimeZone(asiaShanghai)
 
-		plan, controller := newParquetPlanAndControllerForTest(ctx, t, sctx)
+		plan, controller, err := newParquetPlanAndControllerForTest(ctx, t, sctx)
+		require.NoError(t, err)
 		require.Equal(t, "Asia/Shanghai", plan.LocationID)
 		require.NotNil(t, controller.ParquetLocation())
 		require.Equal(t, "Asia/Shanghai", controller.ParquetLocation().String())
@@ -438,7 +438,8 @@ func TestImportPlanParquetLocation(t *testing.T) {
 		defer sctx.Close()
 		require.NoError(t, sctx.GetSessionVars().SetSystemVar(vardef.TimeZone, "+08:00"))
 
-		plan, controller := newParquetPlanAndControllerForTest(ctx, t, sctx)
+		plan, controller, err := newParquetPlanAndControllerForTest(ctx, t, sctx)
+		require.NoError(t, err)
 		require.Equal(t, "+08:00", plan.LocationID)
 		require.NotNil(t, controller.ParquetLocation())
 		_, offset := time.Now().In(controller.ParquetLocation()).Zone()
@@ -450,18 +451,17 @@ func TestImportPlanParquetLocation(t *testing.T) {
 		require.Same(t, controller.ParquetLocation(), controller.dataFiles[0].ParquetMeta.Loc)
 	})
 
-	t.Run("import_plan_parquet_named_fixed_zone_location", func(t *testing.T) {
+	t.Run("import_plan_parquet_named_fixed_zone_location_is_rejected", func(t *testing.T) {
 		sctx := mock.NewContext()
 		defer sctx.Close()
 		loc := time.FixedZone("UTC+8", 8*3600)
 		sctx.GetSessionVars().TimeZone = loc
 		sctx.GetSessionVars().StmtCtx.SetTimeZone(loc)
 
-		plan, controller := newParquetPlanAndControllerForTest(ctx, t, sctx)
+		plan, controller, err := newParquetPlanAndControllerForTest(ctx, t, sctx)
 		require.Equal(t, "UTC+8", plan.LocationID)
-		require.NotNil(t, controller.ParquetLocation())
-		_, offset := time.Now().In(controller.ParquetLocation()).Zone()
-		require.Equal(t, 8*3600, offset)
+		require.Nil(t, controller)
+		require.ErrorContains(t, err, "invalid location UTC+8")
 	})
 
 	t.Run("import_plan_parquet_unnamed_fixed_zone_location", func(t *testing.T) {
@@ -471,7 +471,8 @@ func TestImportPlanParquetLocation(t *testing.T) {
 		sctx.GetSessionVars().TimeZone = loc
 		sctx.GetSessionVars().StmtCtx.SetTimeZone(loc)
 
-		plan, controller := newParquetPlanAndControllerForTest(ctx, t, sctx)
+		plan, controller, err := newParquetPlanAndControllerForTest(ctx, t, sctx)
+		require.NoError(t, err)
 		require.Equal(t, "-06:00", plan.LocationID)
 		require.NotNil(t, controller.ParquetLocation())
 		_, offset := time.Now().In(controller.ParquetLocation()).Zone()
@@ -486,7 +487,8 @@ func TestImportPlanParquetLocation(t *testing.T) {
 		sctx.GetSessionVars().TimeZone = asiaShanghai
 		sctx.GetSessionVars().StmtCtx.SetTimeZone(asiaShanghai)
 
-		plan, controller := newParquetPlanAndControllerForTest(ctx, t, sctx)
+		plan, controller, err := newParquetPlanAndControllerForTest(ctx, t, sctx)
+		require.NoError(t, err)
 		taskMetaBytes, err := json.Marshal(struct {
 			Plan *Plan
 		}{

--- a/pkg/lightning/mydump/parquet_parser.go
+++ b/pkg/lightning/mydump/parquet_parser.go
@@ -655,7 +655,15 @@ func NewParquetParser(
 					return nil, errors.Errorf("unsupported timestamp time unit %d", t.TimeUnit())
 				}
 				colTypes[i].IsAdjustedToUTC = t.IsAdjustedToUTC()
-			} else if t, ok := logicalType.(*schema.TimeLogicalType); ok {
+			} else if t, ok := logicalType.(schema.TimeLogicalType); ok {
+				// TimeLogicalType.ToConvertedType() returns none when
+				// IsAdjustedToUTC=false, so preserve the logical time unit here.
+				switch t.TimeUnit() {
+				case schema.TimeUnitMillis:
+					colTypes[i].converted = schema.ConvertedTypes.TimeMillis
+				case schema.TimeUnitMicros:
+					colTypes[i].converted = schema.ConvertedTypes.TimeMicros
+				}
 				colTypes[i].IsAdjustedToUTC = t.IsAdjustedToUTC()
 			} else {
 				colTypes[i].IsAdjustedToUTC = true

--- a/pkg/lightning/mydump/parquet_parser.go
+++ b/pkg/lightning/mydump/parquet_parser.go
@@ -643,6 +643,9 @@ func NewParquetParser(
 		if logicalType.IsValid() {
 			colTypes[i].converted, colTypes[i].decimalMeta = logicalType.ToConvertedType()
 			if t, ok := logicalType.(schema.TimestampLogicalType); ok {
+				// TimestampLogicalType.ToConvertedType() might return none when
+				// IsAdjustedToUTC=false, and not from force convert, so we have
+				// to check again here.
 				switch t.TimeUnit() {
 				case schema.TimeUnitMillis:
 					colTypes[i].converted = schema.ConvertedTypes.TimestampMillis

--- a/pkg/lightning/mydump/parquet_parser.go
+++ b/pkg/lightning/mydump/parquet_parser.go
@@ -213,7 +213,12 @@ type convertedType struct {
 	converted   schema.ConvertedType
 	decimalMeta schema.DecimalMetadata
 
-	// See https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#temporal-types
+	// See https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#temporal-types.
+	//
+	// true  => epoch value has instant semantics (normalized to UTC), so convert to parser location first.
+	// false => epoch value has local semantics, so keep the "as-if UTC" wall clock unchanged.
+	//
+	// NOTE: types.FromGoTime stores only wall-clock fields and drops location metadata.
 	IsAdjustedToUTC bool
 
 	// sparkRebaseMicros is non-empty when the file footer says the column was
@@ -637,7 +642,17 @@ func NewParquetParser(
 		logicalType := desc.LogicalType()
 		if logicalType.IsValid() {
 			colTypes[i].converted, colTypes[i].decimalMeta = logicalType.ToConvertedType()
-			if t, ok := logicalType.(*schema.TimeLogicalType); ok {
+			if t, ok := logicalType.(schema.TimestampLogicalType); ok {
+				switch t.TimeUnit() {
+				case schema.TimeUnitMillis:
+					colTypes[i].converted = schema.ConvertedTypes.TimestampMillis
+				case schema.TimeUnitMicros:
+					colTypes[i].converted = schema.ConvertedTypes.TimestampMicros
+				default:
+					return nil, errors.Errorf("unsupported timestamp time unit %d", t.TimeUnit())
+				}
+				colTypes[i].IsAdjustedToUTC = t.IsAdjustedToUTC()
+			} else if t, ok := logicalType.(*schema.TimeLogicalType); ok {
 				colTypes[i].IsAdjustedToUTC = t.IsAdjustedToUTC()
 			} else {
 				colTypes[i].IsAdjustedToUTC = true

--- a/pkg/lightning/mydump/parquet_parser_test.go
+++ b/pkg/lightning/mydump/parquet_parser_test.go
@@ -404,6 +404,55 @@ func TestParquetVariousTypes(t *testing.T) {
 		}
 	})
 
+	t.Run("logical_time_local_semantics", func(t *testing.T) {
+		asiaShanghai, err := time.LoadLocation("Asia/Shanghai")
+		require.NoError(t, err)
+
+		const timeMillis = int32(123456)
+		const timeMicros = int64(123456789)
+		pc := []ParquetColumn{
+			{
+				Name:    "time_millis_local",
+				Type:    parquet.Types.Int32,
+				Logical: schema.NewTimeLogicalType(false, schema.TimeUnitMillis),
+				Gen: func(_ int) (any, []int16) {
+					return []int32{timeMillis}, []int16{1}
+				},
+			},
+			{
+				Name:    "time_micros_local",
+				Type:    parquet.Types.Int64,
+				Logical: schema.NewTimeLogicalType(false, schema.TimeUnitMicros),
+				Gen: func(_ int) (any, []int16) {
+					return []int64{timeMicros}, []int16{1}
+				},
+			},
+		}
+
+		dir := t.TempDir()
+		name := "logical-time-local.parquet"
+		require.NoError(t, WriteParquetFile(dir, name, pc, 1))
+
+		reader := newParquetParserForTest(context.Background(), t, dir, name, ParquetFileMeta{Loc: asiaShanghai})
+		require.Equal(t, schema.ConvertedTypes.TimeMillis, reader.colTypes[0].converted)
+		require.Equal(t, schema.ConvertedTypes.TimeMicros, reader.colTypes[1].converted)
+		require.False(t, reader.colTypes[0].IsAdjustedToUTC)
+		require.False(t, reader.colTypes[1].IsAdjustedToUTC)
+
+		require.NoError(t, reader.ReadRow())
+		row := reader.lastRow.Row
+		require.Len(t, row, 2)
+		expected := []time.Time{
+			time.Date(1970, 1, 1, 0, 2, 3, 456000000, time.UTC),
+			time.Date(1970, 1, 1, 0, 2, 3, 456789000, time.UTC),
+		}
+		for i, want := range expected {
+			got, err := row[i].GetMysqlTime().GoTime(time.UTC)
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		}
+	})
+
 	t.Run("unsupported_logical_timestamp_nanos", func(t *testing.T) {
 		pc := []ParquetColumn{
 			{

--- a/pkg/lightning/mydump/parquet_parser_test.go
+++ b/pkg/lightning/mydump/parquet_parser_test.go
@@ -77,6 +77,101 @@ func newInt96FromUnixNanos(nanoseconds int64) parquet.Int96 {
 	return parquet.Int96(b)
 }
 
+type parquetLogicalColumn struct {
+	Name    string
+	Type    parquet.Type
+	Logical schema.LogicalType
+	TypeLen int
+	Gen     func(numRows int) (any, []int16)
+}
+
+func writeParquetLogicalFile(
+	t *testing.T,
+	path string,
+	fileName string,
+	pcolumns []parquetLogicalColumn,
+	rows int,
+	addOpts ...any,
+) {
+	t.Helper()
+
+	fields := make([]schema.Node, len(pcolumns))
+	opts := make([]parquet.WriterProperty, 0, len(pcolumns)*2)
+	for i, pc := range pcolumns {
+		typeLen := -1
+		if pc.TypeLen > 0 {
+			typeLen = pc.TypeLen
+		}
+		field, err := schema.NewPrimitiveNodeLogical(
+			pc.Name,
+			parquet.Repetitions.Optional,
+			pc.Logical,
+			pc.Type,
+			typeLen,
+			-1,
+		)
+		require.NoError(t, err)
+		fields[i] = field
+		opts = append(opts, parquet.WithDictionaryFor(pc.Name, true))
+		opts = append(opts, parquet.WithCompressionFor(pc.Name, compress.Codecs.Snappy))
+	}
+
+	var writerOpts []file.WriteOption
+	for _, opt := range addOpts {
+		switch v := opt.(type) {
+		case parquet.WriterProperty:
+			opts = append(opts, v)
+		case file.WriteOption:
+			writerOpts = append(writerOpts, v)
+		default:
+			require.Failf(t, "unsupported parquet writer option", "type %T", opt)
+		}
+	}
+	props := parquet.NewWriterProperties(opts...)
+	writerOpts = append(writerOpts, file.WithWriterProps(props))
+
+	node, err := schema.NewGroupNode("schema", parquet.Repetitions.Required, fields, -1)
+	require.NoError(t, err)
+
+	s, err := getStore(path)
+	require.NoError(t, err)
+	writer, err := s.Create(context.Background(), fileName, nil)
+	require.NoError(t, err)
+	wrapper := &writeWrapper{Writer: writer}
+
+	pw := file.NewParquetWriter(wrapper, node, writerOpts...)
+	defer func() {
+		require.NoError(t, pw.Close())
+	}()
+
+	colData := make([]parquetColumnData, 0, len(pcolumns))
+	for _, pc := range pcolumns {
+		vals, defLevels := pc.Gen(rows)
+		colData = append(colData, parquetColumnData{vals: vals, defLevels: defLevels})
+	}
+
+	rowGroupLen := int(props.MaxRowGroupLength())
+	if rowGroupLen <= 0 {
+		rowGroupLen = rows
+	}
+	for rowStart := 0; rowStart < rows; rowStart += rowGroupLen {
+		rowEnd := min(rows, rowStart+rowGroupLen)
+		rgw := pw.AppendRowGroup()
+
+		for colIdx := range pcolumns {
+			cw, err := rgw.NextColumn()
+			require.NoError(t, err)
+
+			rowVals, rowDefLevels, err := sliceColumnData(colData[colIdx], rowStart, rowEnd)
+			require.NoError(t, err)
+			require.NoError(t, writeParquetColumnBatch(cw, rowVals, rowDefLevels))
+			require.NoError(t, cw.Close())
+		}
+
+		require.NoError(t, rgw.Close())
+	}
+}
+
 func TestParquetParser(t *testing.T) {
 	pc := []ParquetColumn{
 		{
@@ -331,6 +426,102 @@ func TestParquetVariousTypes(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, expectedDatum, row[i])
 		}
+	})
+
+	t.Run("logical_timestamp_adjustment", func(t *testing.T) {
+		asiaShanghai, err := time.LoadLocation("Asia/Shanghai")
+		require.NoError(t, err)
+
+		const timestampMillis = int64(1603963672356)
+		const timestampMicros = int64(1603963672356956)
+		pc := []parquetLogicalColumn{
+			{
+				Name:    "timestamp_millis_instant",
+				Type:    parquet.Types.Int64,
+				Logical: schema.NewTimestampLogicalType(true, schema.TimeUnitMillis),
+				Gen: func(_ int) (any, []int16) {
+					return []int64{timestampMillis}, []int16{1}
+				},
+			},
+			{
+				Name:    "timestamp_micros_instant",
+				Type:    parquet.Types.Int64,
+				Logical: schema.NewTimestampLogicalType(true, schema.TimeUnitMicros),
+				Gen: func(_ int) (any, []int16) {
+					return []int64{timestampMicros}, []int16{1}
+				},
+			},
+			{
+				Name:    "timestamp_millis_local",
+				Type:    parquet.Types.Int64,
+				Logical: schema.NewTimestampLogicalType(false, schema.TimeUnitMillis),
+				Gen: func(_ int) (any, []int16) {
+					return []int64{timestampMillis}, []int16{1}
+				},
+			},
+			{
+				Name:    "timestamp_micros_local",
+				Type:    parquet.Types.Int64,
+				Logical: schema.NewTimestampLogicalType(false, schema.TimeUnitMicros),
+				Gen: func(_ int) (any, []int16) {
+					return []int64{timestampMicros}, []int16{1}
+				},
+			},
+		}
+
+		dir := t.TempDir()
+		name := "logical-timestamps.parquet"
+		writeParquetLogicalFile(t, dir, name, pc, 1)
+
+		reader := newParquetParserForTest(context.Background(), t, dir, name, ParquetFileMeta{Loc: asiaShanghai})
+		require.Equal(t, schema.ConvertedTypes.TimestampMillis, reader.colTypes[0].converted)
+		require.Equal(t, schema.ConvertedTypes.TimestampMicros, reader.colTypes[1].converted)
+		require.Equal(t, schema.ConvertedTypes.TimestampMillis, reader.colTypes[2].converted)
+		require.Equal(t, schema.ConvertedTypes.TimestampMicros, reader.colTypes[3].converted)
+		require.True(t, reader.colTypes[0].IsAdjustedToUTC)
+		require.True(t, reader.colTypes[1].IsAdjustedToUTC)
+		require.False(t, reader.colTypes[2].IsAdjustedToUTC)
+		require.False(t, reader.colTypes[3].IsAdjustedToUTC)
+
+		require.NoError(t, reader.ReadRow())
+		row := reader.lastRow.Row
+		require.Len(t, row, 4)
+		expected := []time.Time{
+			time.Date(2020, 10, 29, 17, 27, 52, 356000000, time.UTC),
+			time.Date(2020, 10, 29, 17, 27, 52, 356956000, time.UTC),
+			time.Date(2020, 10, 29, 9, 27, 52, 356000000, time.UTC),
+			time.Date(2020, 10, 29, 9, 27, 52, 356956000, time.UTC),
+		}
+		for i, want := range expected {
+			got, err := row[i].GetMysqlTime().GoTime(time.UTC)
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		}
+	})
+
+	t.Run("unsupported_logical_timestamp_nanos", func(t *testing.T) {
+		pc := []parquetLogicalColumn{
+			{
+				Name:    "timestamp_nanos",
+				Type:    parquet.Types.Int64,
+				Logical: schema.NewTimestampLogicalType(false, schema.TimeUnitNanos),
+				Gen: func(_ int) (any, []int16) {
+					return []int64{1603963672356956000}, []int16{1}
+				},
+			},
+		}
+
+		dir := t.TempDir()
+		name := "logical-timestamp-nanos.parquet"
+		writeParquetLogicalFile(t, dir, name, pc, 1)
+
+		store, err := objstore.NewLocalStorage(dir)
+		require.NoError(t, err)
+		r, err := store.Open(context.Background(), name, nil)
+		require.NoError(t, err)
+		parser, err := NewParquetParser(context.Background(), store, r, name, ParquetFileMeta{Loc: time.UTC})
+		require.ErrorContains(t, err, "unsupported timestamp time unit")
+		require.Nil(t, parser)
 	})
 
 	t.Run("int96_rounds_sub_microsecond_precision", func(t *testing.T) {

--- a/pkg/lightning/mydump/parquet_parser_test.go
+++ b/pkg/lightning/mydump/parquet_parser_test.go
@@ -77,101 +77,6 @@ func newInt96FromUnixNanos(nanoseconds int64) parquet.Int96 {
 	return parquet.Int96(b)
 }
 
-type parquetLogicalColumn struct {
-	Name    string
-	Type    parquet.Type
-	Logical schema.LogicalType
-	TypeLen int
-	Gen     func(numRows int) (any, []int16)
-}
-
-func writeParquetLogicalFile(
-	t *testing.T,
-	path string,
-	fileName string,
-	pcolumns []parquetLogicalColumn,
-	rows int,
-	addOpts ...any,
-) {
-	t.Helper()
-
-	fields := make([]schema.Node, len(pcolumns))
-	opts := make([]parquet.WriterProperty, 0, len(pcolumns)*2)
-	for i, pc := range pcolumns {
-		typeLen := -1
-		if pc.TypeLen > 0 {
-			typeLen = pc.TypeLen
-		}
-		field, err := schema.NewPrimitiveNodeLogical(
-			pc.Name,
-			parquet.Repetitions.Optional,
-			pc.Logical,
-			pc.Type,
-			typeLen,
-			-1,
-		)
-		require.NoError(t, err)
-		fields[i] = field
-		opts = append(opts, parquet.WithDictionaryFor(pc.Name, true))
-		opts = append(opts, parquet.WithCompressionFor(pc.Name, compress.Codecs.Snappy))
-	}
-
-	var writerOpts []file.WriteOption
-	for _, opt := range addOpts {
-		switch v := opt.(type) {
-		case parquet.WriterProperty:
-			opts = append(opts, v)
-		case file.WriteOption:
-			writerOpts = append(writerOpts, v)
-		default:
-			require.Failf(t, "unsupported parquet writer option", "type %T", opt)
-		}
-	}
-	props := parquet.NewWriterProperties(opts...)
-	writerOpts = append(writerOpts, file.WithWriterProps(props))
-
-	node, err := schema.NewGroupNode("schema", parquet.Repetitions.Required, fields, -1)
-	require.NoError(t, err)
-
-	s, err := getStore(path)
-	require.NoError(t, err)
-	writer, err := s.Create(context.Background(), fileName, nil)
-	require.NoError(t, err)
-	wrapper := &writeWrapper{Writer: writer}
-
-	pw := file.NewParquetWriter(wrapper, node, writerOpts...)
-	defer func() {
-		require.NoError(t, pw.Close())
-	}()
-
-	colData := make([]parquetColumnData, 0, len(pcolumns))
-	for _, pc := range pcolumns {
-		vals, defLevels := pc.Gen(rows)
-		colData = append(colData, parquetColumnData{vals: vals, defLevels: defLevels})
-	}
-
-	rowGroupLen := int(props.MaxRowGroupLength())
-	if rowGroupLen <= 0 {
-		rowGroupLen = rows
-	}
-	for rowStart := 0; rowStart < rows; rowStart += rowGroupLen {
-		rowEnd := min(rows, rowStart+rowGroupLen)
-		rgw := pw.AppendRowGroup()
-
-		for colIdx := range pcolumns {
-			cw, err := rgw.NextColumn()
-			require.NoError(t, err)
-
-			rowVals, rowDefLevels, err := sliceColumnData(colData[colIdx], rowStart, rowEnd)
-			require.NoError(t, err)
-			require.NoError(t, writeParquetColumnBatch(cw, rowVals, rowDefLevels))
-			require.NoError(t, cw.Close())
-		}
-
-		require.NoError(t, rgw.Close())
-	}
-}
-
 func TestParquetParser(t *testing.T) {
 	pc := []ParquetColumn{
 		{
@@ -434,7 +339,7 @@ func TestParquetVariousTypes(t *testing.T) {
 
 		const timestampMillis = int64(1603963672356)
 		const timestampMicros = int64(1603963672356956)
-		pc := []parquetLogicalColumn{
+		pc := []ParquetColumn{
 			{
 				Name:    "timestamp_millis_instant",
 				Type:    parquet.Types.Int64,
@@ -471,7 +376,7 @@ func TestParquetVariousTypes(t *testing.T) {
 
 		dir := t.TempDir()
 		name := "logical-timestamps.parquet"
-		writeParquetLogicalFile(t, dir, name, pc, 1)
+		require.NoError(t, WriteParquetFile(dir, name, pc, 1))
 
 		reader := newParquetParserForTest(context.Background(), t, dir, name, ParquetFileMeta{Loc: asiaShanghai})
 		require.Equal(t, schema.ConvertedTypes.TimestampMillis, reader.colTypes[0].converted)
@@ -500,7 +405,7 @@ func TestParquetVariousTypes(t *testing.T) {
 	})
 
 	t.Run("unsupported_logical_timestamp_nanos", func(t *testing.T) {
-		pc := []parquetLogicalColumn{
+		pc := []ParquetColumn{
 			{
 				Name:    "timestamp_nanos",
 				Type:    parquet.Types.Int64,
@@ -513,7 +418,7 @@ func TestParquetVariousTypes(t *testing.T) {
 
 		dir := t.TempDir()
 		name := "logical-timestamp-nanos.parquet"
-		writeParquetLogicalFile(t, dir, name, pc, 1)
+		require.NoError(t, WriteParquetFile(dir, name, pc, 1))
 
 		store, err := objstore.NewLocalStorage(dir)
 		require.NoError(t, err)

--- a/pkg/lightning/mydump/parquet_type_converter.go
+++ b/pkg/lightning/mydump/parquet_type_converter.go
@@ -185,6 +185,10 @@ func getBoolDataSetter(val bool, d *types.Datum) error {
 }
 
 func getInt32Setter(converted *convertedType, loc *time.Location) setter[int32] {
+	// For parquet TIME/TIMESTAMP epoch values:
+	// - IsAdjustedToUTC=true: interpret as UTC instant, then render in parser location.
+	// - IsAdjustedToUTC=false: keep as local-semantics wall clock ("as-if UTC"), no loc conversion.
+	// See convertedType.IsAdjustedToUTC for details about why this is required.
 	switch converted.converted {
 	case schema.ConvertedTypes.Decimal:
 		return func(val int32, d *types.Datum) error {

--- a/pkg/lightning/mydump/parquet_writer.go
+++ b/pkg/lightning/mydump/parquet_writer.go
@@ -122,6 +122,7 @@ type ParquetColumn struct {
 	Name      string
 	Type      parquet.Type
 	Converted schema.ConvertedType
+	Logical   schema.LogicalType
 	TypeLen   int
 	Precision int
 	Scale     int
@@ -171,13 +172,26 @@ func WriteParquetFile(path, fileName string, pcolumns []ParquetColumn, rows int,
 		if pc.TypeLen > 0 {
 			typeLen = pc.TypeLen
 		}
-		field, err := schema.NewPrimitiveNodeConverted(
-			pc.Name,
-			parquet.Repetitions.Optional,
-			pc.Type, pc.Converted,
-			typeLen, pc.Precision, pc.Scale,
-			-1,
-		)
+		var field schema.Node
+		var err error
+		if pc.Logical != nil {
+			field, err = schema.NewPrimitiveNodeLogical(
+				pc.Name,
+				parquet.Repetitions.Optional,
+				pc.Logical,
+				pc.Type,
+				typeLen,
+				-1,
+			)
+		} else {
+			field, err = schema.NewPrimitiveNodeConverted(
+				pc.Name,
+				parquet.Repetitions.Optional,
+				pc.Type, pc.Converted,
+				typeLen, pc.Precision, pc.Scale,
+				-1,
+			)
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/util/timeutil/time_zone.go
+++ b/pkg/util/timeutil/time_zone.go
@@ -198,6 +198,26 @@ func Zone(loc *time.Location) (string, int64) {
 	return name, int64(offset)
 }
 
+// ZoneName return the zone name of the location. If the name is empty, it will
+// return the offset in format like "+08:00" or "-06:00".
+// Note: the input loc cannot be a Location constructed by time.FixedZone with
+// any name, otherwise the name will be returned directly, and might be
+// un-parsable by ParseTimeZone
+func ZoneName(loc *time.Location) string {
+	name, offset := Zone(loc)
+	if name != "" {
+		return name
+	}
+	sign := '+'
+	if offset < 0 {
+		sign = '-'
+		offset = -offset
+	}
+	hours := offset / int64(time.Hour/time.Second)
+	minutes := offset % int64(time.Hour/time.Second) / int64(time.Minute/time.Second)
+	return fmt.Sprintf("%c%02d:%02d", sign, hours, minutes)
+}
+
 // ConstructTimeZone constructs timezone by name first. When the timezone name
 // is set, the daylight saving problem must be considered. Otherwise the
 // timezone offset in seconds east of UTC is used to constructed the timezone.

--- a/pkg/util/timeutil/time_zone_test.go
+++ b/pkg/util/timeutil/time_zone_test.go
@@ -133,6 +133,46 @@ func TestParseTimeZone(t *testing.T) {
 	}
 }
 
+func TestZoneName(t *testing.T) {
+	cases := []struct {
+		name     string
+		loc      *time.Location
+		expected string
+	}{
+		{
+			name:     "iana timezone",
+			loc:      time.UTC,
+			expected: "UTC",
+		},
+		{
+			name:     "unnamed positive fixed zone",
+			loc:      time.FixedZone("", int((8*time.Hour + 30*time.Minute).Seconds())),
+			expected: "+08:30",
+		},
+		{
+			name:     "unnamed negative fixed zone",
+			loc:      time.FixedZone("", -int((6*time.Hour + 15*time.Minute).Seconds())),
+			expected: "-06:15",
+		},
+		{
+			name:     "unnamed zero fixed zone",
+			loc:      time.FixedZone("", 0),
+			expected: "+00:00",
+		},
+		{
+			name:     "named fixed zone",
+			loc:      time.FixedZone("UTC+8", int((8 * time.Hour).Seconds())),
+			expected: "UTC+8",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.expected, ZoneName(c.loc))
+		})
+	}
+}
+
 func TestConstructTimeZone(t *testing.T) {
 	secondsEastOfUTC := int((8 * time.Hour).Seconds())
 	loc, err := ConstructTimeZone("", secondsEastOfUTC)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68139, ref #68069

Problem Summary:

TiDB's Parquet import path did not consistently preserve Parquet logical timestamp semantics.
For `TIMESTAMP(isAdjustedToUTC=false)` logical annotations, Arrow reports the converted type as `None`, so TiDB could classify the column as a plain `INT64` instead of `TIMESTAMP_MILLIS` or `TIMESTAMP_MICROS`.

The import task plan also stored a `*time.Location` directly. That value is not meaningfully JSON serializable, so distributed/asynchronous `IMPORT INTO` execution could lose the session time zone needed for Parquet timestamp conversion.

### What changed and how does it work?

This PR stores the import plan location as a location ID string and reloads it when creating the load-data controller. The controller then passes the resolved location through `ParquetFileMeta` so Parquet timestamp parsing uses the session/import location.

The Parquet parser now detects `schema.TimestampLogicalType` directly. For millisecond and microsecond logical timestamps it maps the physical `INT64` column to the corresponding timestamp converted type and preserves `IsAdjustedToUTC`; unsupported nanosecond timestamp logical types now return an explicit error instead of being silently treated as ordinary integers.

The tests add Parquet files with real logical timestamp annotations and cover both UTC-adjusted instant semantics and local wall-clock semantics. They also cover import-plan location serialization/propagation into Parquet file metadata.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit tests and checks run:

```bash
make bazel_prepare
./tools/check/failpoint-go-test.sh pkg/lightning/mydump -run 'TestParquetVariousTypes/(logical_timestamp_adjustment|unsupported_logical_timestamp_nanos)' -count=1
./tools/check/failpoint-go-test.sh pkg/executor/importer -run 'Test(GetLocalBackendCfg|ImportPlanParquetLocation)' -count=1
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix incorrect Parquet timestamp import semantics for logical timestamp columns and preserve the session time zone during Parquet import task execution.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Parquet timezone handling so invalid or unsupported timestamp/time units error clearly and timestamps convert consistently.

* **Enhancements**
  * Import flow now records and exposes precise Parquet timezone identifiers, defaulting to UTC for legacy/empty data; import assigns resolved timezone to parsed files.
  * Test writer supports Parquet logical types for more accurate test schemas.

* **Tests**
  * Added tests covering timezone propagation, fixed/offset zones, and timestamp/time logical-type semantics.

* **Documentation**
  * Clarified comments on Parquet timestamp adjustment semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


