### PR TITLE
executor: use statement context for pre-analyze stats flush

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1418,7 +1418,7 @@ func (a *ExecStmt) buildExecutor() (exec.Executor, error) {
 
 	failpoint.Inject("assertTxnManagerAfterBuildExecutor", func() {
 		sessiontxn.RecordAssert(a.Ctx, "assertTxnManagerAfterBuildExecutor", true)
-		sessiontxn.AssertTxnManagerInfoSchema(b.ctx, b.is)
+		sessiontxn.AssertTxnManagerInfoSchema(b.sctx, b.is)
 	})
 
 	// ExecuteExec is not a real Executor, we only use it to build another Executor from a prepared statement.

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -419,7 +419,7 @@ func (a *ExecStmt) PointGet(ctx context.Context) (*recordSet, error) {
 	}
 
 	if executor == nil {
-		b := newExecutorBuilder(a.Ctx, a.InfoSchema, a.Ti)
+		b := newExecutorBuilder(ctx, a.Ctx, a.InfoSchema, a.Ti)
 		executor = b.build(a.Plan)
 		if b.err != nil {
 			return nil, b.err
@@ -678,7 +678,7 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		execStartTime = time.Now()
 	}
 
-	e, err := a.buildExecutor()
+	e, err := a.buildExecutor(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1371,7 +1371,7 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, lockErr error
 	a.resetPhaseDurations()
 
 	a.inheritContextFromExecuteStmt()
-	e, err := a.buildExecutor()
+	e, err := a.buildExecutor(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1397,20 +1397,20 @@ type pessimisticTxn interface {
 }
 
 // buildExecutor build an executor from plan, prepared statement may need additional procedure.
-func (a *ExecStmt) buildExecutor() (exec.Executor, error) {
+func (a *ExecStmt) buildExecutor(ctx context.Context) (exec.Executor, error) {
 	defer func(start time.Time) { a.phaseBuildDurations[0] += time.Since(start) }(time.Now())
-	ctx := a.Ctx
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	sctx := a.Ctx
+	stmtCtx := sctx.GetSessionVars().StmtCtx
 	if _, ok := a.Plan.(*plannercore.Execute); !ok {
 		if stmtCtx.Priority == mysql.NoPriority && a.LowerPriority {
 			stmtCtx.Priority = kv.PriorityLow
 		}
 	}
-	if _, ok := a.Plan.(*plannercore.Analyze); ok && ctx.GetSessionVars().InRestrictedSQL {
-		ctx.GetSessionVars().StmtCtx.Priority = kv.PriorityLow
+	if _, ok := a.Plan.(*plannercore.Analyze); ok && sctx.GetSessionVars().InRestrictedSQL {
+		sctx.GetSessionVars().StmtCtx.Priority = kv.PriorityLow
 	}
 
-	b := newExecutorBuilder(ctx, a.InfoSchema, a.Ti)
+	b := newExecutorBuilder(ctx, sctx, a.InfoSchema, a.Ti)
 	e := b.build(a.Plan)
 	if b.err != nil {
 		return nil, errors.Trace(b.err)
@@ -1428,7 +1428,7 @@ func (a *ExecStmt) buildExecutor() (exec.Executor, error) {
 			return nil, err
 		}
 		if executorExec.lowerPriority {
-			ctx.GetSessionVars().StmtCtx.Priority = kv.PriorityLow
+			sctx.GetSessionVars().StmtCtx.Priority = kv.PriorityLow
 		}
 		e = executorExec.stmtExec
 	}

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -97,6 +97,9 @@ func flushStatsDeltaForAnalyze(ctx context.Context, sctx sessionctx.Context, pla
 	if len(flushObjects) == 0 {
 		return nil
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	// HACK: Some tests register in-process TiDB domains but do not start TiDB RPC
 	// endpoints. Broadcasting FLUSH STATS_DELTA CLUSTER to those mock endpoints can

--- a/pkg/executor/analyze_col_sampling.go
+++ b/pkg/executor/analyze_col_sampling.go
@@ -431,7 +431,7 @@ func (e *AnalyzeColumnsExec) handleNDVForSpecialIndexes(ctx context.Context, ind
 			}
 		}
 	}()
-	tasks := e.buildSubIndexJobForSpecialIndex(indexInfos)
+	tasks := e.buildSubIndexJobForSpecialIndex(ctx, indexInfos)
 	taskCh := make(chan *analyzeTask, len(tasks))
 	pendingJobs := make(map[uint64]*statistics.AnalyzeJob, len(tasks))
 	for _, task := range tasks {
@@ -533,11 +533,11 @@ func (e *AnalyzeColumnsExec) subIndexWorkerForNDV(ctx context.Context, taskCh ch
 
 // buildSubIndexJobForSpecialIndex builds sub index pushed down task to calculate the NDV information for indexes containing virtual column.
 // This is because we cannot push the calculation of the virtual column down to the tikv side.
-func (e *AnalyzeColumnsExec) buildSubIndexJobForSpecialIndex(indexInfos []*model.IndexInfo) []*analyzeTask {
+func (e *AnalyzeColumnsExec) buildSubIndexJobForSpecialIndex(ctx context.Context, indexInfos []*model.IndexInfo) []*analyzeTask {
 	_, offset := timeutil.Zone(e.ctx.GetSessionVars().Location())
 	tasks := make([]*analyzeTask, 0, len(indexInfos))
 	sc := e.ctx.GetSessionVars().StmtCtx
-	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), e.ctx)
+	concurrency := adaptiveAnlayzeDistSQLConcurrency(ctx, e.ctx)
 	for _, indexInfo := range indexInfos {
 		base := baseAnalyzeExec{
 			ctx:         e.ctx,

--- a/pkg/executor/analyze_test.go
+++ b/pkg/executor/analyze_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/session"
@@ -212,6 +213,25 @@ func TestAnalyzeSaveResultErrorDoesNotHang(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("analyze hangs after save analyze result error")
 	}
+}
+
+func TestBuildAnalyzePreFlushUsesStatementContext(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_pre_analyze_flush_ctx(a int, b int, key idx_b(b))")
+	tk.MustExec("insert into t_pre_analyze_flush_ctx values (1, 1), (2, 2)")
+
+	stmtNodes, err := tk.Session().Parse(context.Background(), "analyze table t_pre_analyze_flush_ctx all columns")
+	require.NoError(t, err)
+	require.Len(t, stmtNodes, 1)
+	stmt, err := (&executor.Compiler{Ctx: tk.Session()}).Compile(context.Background(), stmtNodes[0])
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = executor.BuildExecutorForTest(ctx, stmt)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestAnalyzeKillDuringSaveDoesNotHang(t *testing.T) {

--- a/pkg/executor/analyze_utils_test.go
+++ b/pkg/executor/analyze_utils_test.go
@@ -60,3 +60,10 @@ func TestCanBroadcastToTiDBRPCForTestRejectsInvalidEndpoints(t *testing.T) {
 	// listener. Such targets must not take the broadcast path.
 	require.False(t, canBroadcastToTiDBRPCForTest(context.Background(), []string{"", ""}))
 }
+
+// BuildExecutorForTest builds stmt's executor tree. It is exported only for
+// external package tests that need to assert executor-build behavior.
+func BuildExecutorForTest(ctx context.Context, stmt *ExecStmt) error {
+	_, err := stmt.buildExecutor(ctx)
+	return err
+}

--- a/pkg/executor/benchmark_test.go
+++ b/pkg/executor/benchmark_test.go
@@ -67,7 +67,7 @@ func buildHashAggExecutor(ctx sessionctx.Context, src exec.Executor, schema *exp
 	plan.SetSchema(schema)
 	plan.Init(ctx.GetPlanCtx(), nil, 0)
 	plan.SetChildren(nil)
-	b := newExecutorBuilder(ctx, nil, nil)
+	b := newExecutorBuilder(context.Background(), ctx, nil, nil)
 	exec := b.build(plan)
 	hashAgg := exec.(*aggregate.HashAggExec)
 	hashAgg.SetChildren(0, src)
@@ -119,7 +119,7 @@ func buildStreamAggExecutor(ctx sessionctx.Context, srcExec exec.Executor, schem
 		plan = sg
 	}
 
-	b := newExecutorBuilder(ctx, nil, nil)
+	b := newExecutorBuilder(context.Background(), ctx, nil, nil)
 	return b.build(plan)
 }
 
@@ -352,7 +352,7 @@ func buildWindowExecutor(ctx sessionctx.Context, windowFunc string, funcs int, f
 		plan = win
 	}
 
-	b := newExecutorBuilder(ctx, nil, nil)
+	b := newExecutorBuilder(context.Background(), ctx, nil, nil)
 	exec := b.build(plan)
 	return exec
 }
@@ -1253,7 +1253,7 @@ func prepare4IndexInnerHashJoin(tc *IndexJoinTestCase, outerDS *testutil.MockDat
 		keyOff2IdxOff[i] = i
 	}
 
-	readerBuilder, err := newExecutorBuilder(tc.Ctx, nil, nil).
+	readerBuilder, err := newExecutorBuilder(context.Background(), tc.Ctx, nil, nil).
 		newDataReaderBuilder(&mockPhysicalIndexReader{e: innerDS})
 	if err != nil {
 		return nil, err
@@ -1328,7 +1328,7 @@ func prepare4IndexMergeJoin(tc *IndexJoinTestCase, outerDS *testutil.MockDataSou
 		outerCompareFuncs = append(outerCompareFuncs, expression.GetCmpFunction(nil, outerJoinKeys[i], outerJoinKeys[i]))
 	}
 
-	readerBuilder, err := newExecutorBuilder(tc.Ctx, nil, nil).
+	readerBuilder, err := newExecutorBuilder(context.Background(), tc.Ctx, nil, nil).
 		newDataReaderBuilder(&mockPhysicalIndexReader{e: innerDS})
 	if err != nil {
 		return nil, err

--- a/pkg/executor/brie.go
+++ b/pkg/executor/brie.go
@@ -234,7 +234,7 @@ func (bq *brieQueue) clearTask(sc *stmtctx.StatementContext) {
 }
 
 func (b *executorBuilder) parseTSString(ts string) (uint64, error) {
-	sc := stmtctx.NewStmtCtxWithTimeZone(b.ctx.GetSessionVars().Location())
+	sc := stmtctx.NewStmtCtxWithTimeZone(b.sctx.GetSessionVars().Location())
 	t, err := types.ParseTime(sc.TypeCtx(), ts, mysql.TypeTimestamp, types.MaxFsp)
 	if err != nil {
 		return 0, err
@@ -249,27 +249,27 @@ func (b *executorBuilder) parseTSString(ts string) (uint64, error) {
 func (b *executorBuilder) buildBRIE(s *ast.BRIEStmt, schema *expression.Schema) exec.Executor {
 	if s.Kind == ast.BRIEKindShowBackupMeta {
 		return execOnce(&showMetaExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, schema, 0),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, schema, 0),
 			showConfig:   buildShowMetadataConfigFrom(s),
 		})
 	}
 
 	if s.Kind == ast.BRIEKindShowQuery {
 		return execOnce(&showQueryExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, schema, 0),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, schema, 0),
 			targetID:     uint64(s.JobID),
 		})
 	}
 
 	if s.Kind == ast.BRIEKindCancelJob {
 		return &cancelJobExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, schema, 0),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, schema, 0),
 			targetID:     uint64(s.JobID),
 		}
 	}
 
 	e := &BRIEExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, schema, 0),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, schema, 0),
 		info: &brieTaskInfo{
 			kind: s.Kind,
 		},

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3083,7 +3083,7 @@ func (b *executorBuilder) buildAnalyzeIndexPushdown(task plannercore.AnalyzeInde
 	failpoint.Inject("injectAnalyzeSnapshot", func(val failpoint.Value) {
 		startTS = uint64(val.(int))
 	})
-	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.sctx)
+	concurrency := adaptiveAnlayzeDistSQLConcurrency(b.ctx, b.sctx)
 	base := baseAnalyzeExec{
 		ctx:         b.sctx,
 		tableID:     task.TableID,
@@ -3200,7 +3200,7 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 		PartitionName:    task.PartitionName,
 		SampleRateReason: sampleRateReason,
 	}
-	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.sctx)
+	concurrency := adaptiveAnlayzeDistSQLConcurrency(b.ctx, b.sctx)
 	base := baseAnalyzeExec{
 		ctx:         b.sctx,
 		tableID:     task.TableID,

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3173,7 +3173,7 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 	if opts[ast.AnalyzeOptNumSamples] == 0 {
 		*sampleRate = math.Float64frombits(opts[ast.AnalyzeOptSampleRate])
 		if *sampleRate < 0 {
-			*sampleRate, sampleRateReason = b.getAdjustedSampleRate(task)
+			*sampleRate, sampleRateReason = b.getAdjustedSampleRate(b.ctx, task)
 			if task.PartitionName != "" {
 				sc.AppendNote(errors.NewNoStackErrorf(
 					`Analyze use auto adjusted sample rate %f for table %s.%s's partition %s, reason to use this rate is "%s"`,
@@ -3255,7 +3255,7 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 // If we take n = 1e12, a 300*k sample still gives <= 0.66 bin size error with probability 0.99.
 // So if we don't consider the top-n values, we can keep the sample size at 300*256.
 // But we may take some top-n before building the histogram, so we increase the sample a little.
-func (b *executorBuilder) getAdjustedSampleRate(task plannercore.AnalyzeColumnsTask) (sampleRate float64, reason string) {
+func (b *executorBuilder) getAdjustedSampleRate(ctx context.Context, task plannercore.AnalyzeColumnsTask) (sampleRate float64, reason string) {
 	statsHandle := domain.GetDomain(b.sctx).StatsHandle()
 	defaultRate := 0.001
 	if statsHandle == nil {
@@ -3268,7 +3268,7 @@ func (b *executorBuilder) getAdjustedSampleRate(task plannercore.AnalyzeColumnsT
 	} else {
 		statsTbl = statsHandle.GetPhysicalTableStats(tid, task.TblInfo)
 	}
-	approxiCount, hasPD := b.getApproximateTableCountFromStorage(tid, task)
+	approxiCount, hasPD := b.getApproximateTableCountFromStorage(ctx, tid, task)
 	// If there's no stats meta and no pd, return the default rate.
 	if statsTbl == nil && !hasPD {
 		return defaultRate, fmt.Sprintf("TiDB cannot get the row count of the table, use the default-rate=%v", defaultRate)
@@ -3297,8 +3297,8 @@ func (b *executorBuilder) getAdjustedSampleRate(task plannercore.AnalyzeColumnsT
 	return sampleRate, fmt.Sprintf("use min(1, %v/%v) as the sample-rate=%v", config.DefRowsForSampleRate, statsTbl.RealtimeCount, sampleRate)
 }
 
-func (b *executorBuilder) getApproximateTableCountFromStorage(tid int64, task plannercore.AnalyzeColumnsTask) (float64, bool) {
-	return pdhelper.GlobalPDHelper.GetApproximateTableCountFromStorage(context.Background(), b.sctx, tid, task.DBName, task.TableName, task.PartitionName)
+func (b *executorBuilder) getApproximateTableCountFromStorage(ctx context.Context, tid int64, task plannercore.AnalyzeColumnsTask) (float64, bool) {
+	return pdhelper.GlobalPDHelper.GetApproximateTableCountFromStorage(ctx, b.sctx, tid, task.DBName, task.TableName, task.PartitionName)
 }
 
 func (b *executorBuilder) buildAnalyze(v *plannercore.Analyze) exec.Executor {

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -104,7 +104,7 @@ import (
 // executorBuilder builds an Executor from a Plan.
 // The InfoSchema must not change during execution.
 type executorBuilder struct {
-	ctx     sessionctx.Context
+	sctx    sessionctx.Context
 	is      infoschema.InfoSchema
 	err     error // err is set when there is error happened during Executor building process.
 	hasLock bool
@@ -146,13 +146,13 @@ type CTEStorages struct {
 	initErr error
 }
 
-func newExecutorBuilder(ctx sessionctx.Context, is infoschema.InfoSchema, ti *TelemetryInfo) *executorBuilder {
-	txnManager := sessiontxn.GetTxnManager(ctx)
+func newExecutorBuilder(sctx sessionctx.Context, is infoschema.InfoSchema, ti *TelemetryInfo) *executorBuilder {
+	txnManager := sessiontxn.GetTxnManager(sctx)
 	return &executorBuilder{
-		ctx:              ctx,
+		sctx:             sctx,
 		is:               is,
 		Ti:               ti,
-		isStaleness:      staleread.IsStmtStaleness(ctx),
+		isStaleness:      staleread.IsStmtStaleness(sctx),
 		txnScope:         txnManager.GetTxnScope(),
 		readReplicaScope: txnManager.GetReadReplicaScope(),
 	}
@@ -365,7 +365,7 @@ func (b *executorBuilder) build(p base.Plan) exec.Executor {
 func (b *executorBuilder) buildCancelDDLJobs(v *plannercore.CancelDDLJobs) exec.Executor {
 	e := &CancelDDLJobsExec{
 		CommandDDLJobsExec: &CommandDDLJobsExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 			jobIDs:       v.JobIDs,
 			execute:      ddl.CancelJobs,
 		},
@@ -376,7 +376,7 @@ func (b *executorBuilder) buildCancelDDLJobs(v *plannercore.CancelDDLJobs) exec.
 func (b *executorBuilder) buildPauseDDLJobs(v *plannercore.PauseDDLJobs) exec.Executor {
 	e := &PauseDDLJobsExec{
 		CommandDDLJobsExec: &CommandDDLJobsExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 			jobIDs:       v.JobIDs,
 			execute:      ddl.PauseJobs,
 		},
@@ -387,7 +387,7 @@ func (b *executorBuilder) buildPauseDDLJobs(v *plannercore.PauseDDLJobs) exec.Ex
 func (b *executorBuilder) buildResumeDDLJobs(v *plannercore.ResumeDDLJobs) exec.Executor {
 	e := &ResumeDDLJobsExec{
 		CommandDDLJobsExec: &CommandDDLJobsExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 			jobIDs:       v.JobIDs,
 			execute:      ddl.ResumeJobs,
 		},
@@ -397,7 +397,7 @@ func (b *executorBuilder) buildResumeDDLJobs(v *plannercore.ResumeDDLJobs) exec.
 
 func (b *executorBuilder) buildAlterDDLJob(v *plannercore.AlterDDLJob) exec.Executor {
 	e := &AlterDDLJobExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		jobID:        v.JobID,
 		AlterOpts:    v.Options,
 	}
@@ -406,7 +406,7 @@ func (b *executorBuilder) buildAlterDDLJob(v *plannercore.AlterDDLJob) exec.Exec
 
 func (b *executorBuilder) buildShowNextRowID(v *plannercore.ShowNextRowID) exec.Executor {
 	e := &ShowNextRowIDExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		tblName:      v.TableName,
 	}
 	return e
@@ -417,7 +417,7 @@ func (b *executorBuilder) buildShowDDL(v *plannercore.ShowDDL) exec.Executor {
 	// next will be called after transaction has been committed.
 	// We need the transaction to get Info.
 	e := &ShowDDLExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 	}
 
 	var err error
@@ -447,12 +447,12 @@ func (b *executorBuilder) buildShowDDL(v *plannercore.ShowDDL) exec.Executor {
 }
 
 func (b *executorBuilder) buildShowDDLJobs(v *physicalop.PhysicalShowDDLJobs) exec.Executor {
-	loc := b.ctx.GetSessionVars().Location()
+	loc := b.sctx.GetSessionVars().Location()
 	ddlJobRetriever := DDLJobRetriever{TZLoc: loc}
 	e := &ShowDDLJobsExec{
 		jobNumber:       int(v.JobNumber),
 		is:              b.is,
-		BaseExecutor:    exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor:    exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		DDLJobRetriever: ddlJobRetriever,
 	}
 	return e
@@ -460,7 +460,7 @@ func (b *executorBuilder) buildShowDDLJobs(v *physicalop.PhysicalShowDDLJobs) ex
 
 func (b *executorBuilder) buildShowDDLJobQueries(v *plannercore.ShowDDLJobQueries) exec.Executor {
 	e := &ShowDDLJobQueriesExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		jobIDs:       v.JobIDs,
 	}
 	return e
@@ -468,7 +468,7 @@ func (b *executorBuilder) buildShowDDLJobQueries(v *plannercore.ShowDDLJobQuerie
 
 func (b *executorBuilder) buildShowDDLJobQueriesWithRange(v *plannercore.ShowDDLJobQueriesWithRange) exec.Executor {
 	e := &ShowDDLJobQueriesWithRangeExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		offset:       v.Offset,
 		limit:        v.Limit,
 	}
@@ -477,7 +477,7 @@ func (b *executorBuilder) buildShowDDLJobQueriesWithRange(v *plannercore.ShowDDL
 
 func (b *executorBuilder) buildShowSlow(v *plannercore.ShowSlow) exec.Executor {
 	e := &ShowSlowExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		ShowSlow:     v.ShowSlow,
 	}
 	return e
@@ -548,9 +548,9 @@ func (b *executorBuilder) buildCheckTable(v *plannercore.CheckTable) exec.Execut
 			break
 		}
 	}
-	if b.ctx.GetSessionVars().FastCheckTable && canUseFastCheck {
+	if b.sctx.GetSessionVars().FastCheckTable && canUseFastCheck {
 		e := &FastCheckTableExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 			dbName:       v.DBName,
 			table:        v.Table,
 			indexInfos:   v.IndexInfos,
@@ -572,7 +572,7 @@ func (b *executorBuilder) buildCheckTable(v *plannercore.CheckTable) exec.Execut
 	}
 
 	e := &CheckTableExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		dbName:       v.DBName,
 		table:        v.Table,
 		indexInfos:   v.IndexInfos,
@@ -650,7 +650,7 @@ func (b *executorBuilder) buildRecoverIndex(v *plannercore.RecoverIndex) exec.Ex
 	}
 	cols := buildIdxColsConcatHandleCols(tblInfo, index.Meta(), hasGenedColOrPartialIndex)
 	e := &RecoverIndexExec{
-		BaseExecutor:                   exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor:                   exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		columns:                        cols,
 		containsGenedColOrPartialIndex: hasGenedColOrPartialIndex,
 		index:                          index,
@@ -717,7 +717,7 @@ func (b *executorBuilder) buildCleanupIndex(v *plannercore.CleanupIndex) exec.Ex
 		return nil
 	}
 	e := &CleanupIndexExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		columns:      buildIdxColsConcatHandleCols(tblInfo, index.Meta(), false),
 		index:        index,
 		table:        t,
@@ -738,7 +738,7 @@ func (b *executorBuilder) buildCheckIndexRange(v *plannercore.CheckIndexRange) e
 		return nil
 	}
 	e := &CheckIndexRangeExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		handleRanges: v.HandleRanges,
 		table:        tb.Meta(),
 		is:           b.is,
@@ -756,7 +756,7 @@ func (b *executorBuilder) buildCheckIndexRange(v *plannercore.CheckIndexRange) e
 
 func (b *executorBuilder) buildChecksumTable(v *plannercore.ChecksumTable) exec.Executor {
 	e := &ChecksumTableExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		tables:       make(map[int64]*checksumContext),
 		done:         false,
 	}
@@ -772,22 +772,22 @@ func (b *executorBuilder) buildChecksumTable(v *plannercore.ChecksumTable) exec.
 }
 
 func (b *executorBuilder) buildReloadExprPushdownBlacklist(_ *plannercore.ReloadExprPushdownBlacklist) exec.Executor {
-	base := exec.NewBaseExecutor(b.ctx, nil, 0)
+	base := exec.NewBaseExecutor(b.sctx, nil, 0)
 	return &ReloadExprPushdownBlacklistExec{base}
 }
 
 func (b *executorBuilder) buildReloadOptRuleBlacklist(_ *plannercore.ReloadOptRuleBlacklist) exec.Executor {
-	base := exec.NewBaseExecutor(b.ctx, nil, 0)
+	base := exec.NewBaseExecutor(b.sctx, nil, 0)
 	return &ReloadOptRuleBlacklistExec{BaseExecutor: base}
 }
 
 func (b *executorBuilder) buildAdminPlugins(v *plannercore.AdminPlugins) exec.Executor {
-	base := exec.NewBaseExecutor(b.ctx, nil, 0)
+	base := exec.NewBaseExecutor(b.sctx, nil, 0)
 	return &AdminPluginsExec{BaseExecutor: base, Action: v.Action, Plugins: v.Plugins}
 }
 
 func (b *executorBuilder) buildDeallocate(v *plannercore.Deallocate) exec.Executor {
-	base := exec.NewBaseExecutor(b.ctx, nil, v.ID())
+	base := exec.NewBaseExecutor(b.sctx, nil, v.ID())
 	base.SetInitCap(chunk.ZeroCapacity)
 	e := &DeallocateExec{
 		BaseExecutor: base,
@@ -809,7 +809,7 @@ func (b *executorBuilder) buildSelectLock(v *physicalop.PhysicalLock) exec.Execu
 	if b.err != nil {
 		return nil
 	}
-	if !b.ctx.GetSessionVars().PessimisticLockEligible() {
+	if !b.sctx.GetSessionVars().PessimisticLockEligible() {
 		// Locking of rows for update using SELECT FOR UPDATE only applies when autocommit
 		// is disabled (either by beginning transaction with START TRANSACTION or by setting
 		// autocommit to 0. If autocommit is enabled, the rows matching the specification are not locked.
@@ -819,7 +819,7 @@ func (b *executorBuilder) buildSelectLock(v *physicalop.PhysicalLock) exec.Execu
 	// If the `PhysicalLock` is not ignored by the above logic, set the `hasLock` flag.
 	b.hasLock = true
 	e := &SelectLockExec{
-		BaseExecutor:       exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), src),
+		BaseExecutor:       exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), src),
 		Lock:               v.Lock,
 		tblID2Handle:       v.TblID2Handle,
 		tblID2PhysTblIDCol: v.TblID2PhysTblIDCol,
@@ -846,8 +846,8 @@ func (b *executorBuilder) buildLimit(v *physicalop.PhysicalLimit) exec.Executor 
 	if b.err != nil {
 		return nil
 	}
-	n := int(min(v.Count, uint64(b.ctx.GetSessionVars().MaxChunkSize)))
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), childExec)
+	n := int(min(v.Count, uint64(b.sctx.GetSessionVars().MaxChunkSize)))
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), childExec)
 	base.SetInitCap(n)
 	e := &LimitExec{
 		BaseExecutor: base,
@@ -869,7 +869,7 @@ func (b *executorBuilder) buildLimit(v *physicalop.PhysicalLimit) exec.Executor 
 }
 
 func (b *executorBuilder) buildPrepare(v *plannercore.Prepare) exec.Executor {
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID())
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID())
 	base.SetInitCap(chunk.ZeroCapacity)
 	return &PrepareExec{
 		BaseExecutor: base,
@@ -880,7 +880,7 @@ func (b *executorBuilder) buildPrepare(v *plannercore.Prepare) exec.Executor {
 
 func (b *executorBuilder) buildExecute(v *plannercore.Execute) exec.Executor {
 	e := &ExecuteExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		is:           b.is,
 		name:         v.Name,
 		usingVars:    v.Params,
@@ -892,8 +892,8 @@ func (b *executorBuilder) buildExecute(v *plannercore.Execute) exec.Executor {
 	failpoint.Inject("assertExecutePrepareStatementStalenessOption", func(val failpoint.Value) {
 		vs := strings.Split(val.(string), "_")
 		assertTS, assertReadReplicaScope := vs[0], vs[1]
-		staleread.AssertStmtStaleness(b.ctx, true)
-		ts, err := sessiontxn.GetTxnManager(b.ctx).GetStmtReadTS()
+		staleread.AssertStmtStaleness(b.sctx, true)
+		ts, err := sessiontxn.GetTxnManager(b.sctx).GetStmtReadTS()
 		if err != nil {
 			panic(e)
 		}
@@ -909,7 +909,7 @@ func (b *executorBuilder) buildExecute(v *plannercore.Execute) exec.Executor {
 
 func (b *executorBuilder) buildShow(v *physicalop.PhysicalShow) exec.Executor {
 	e := &ShowExec{
-		BaseExecutor:          exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor:          exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		Tp:                    v.Tp,
 		CountWarningsOrErrors: v.CountWarningsOrErrors,
 		DBName:                ast.NewCIStr(v.DBName),
@@ -973,28 +973,28 @@ func (b *executorBuilder) buildSimple(v *plannercore.Simple) exec.Executor {
 		}
 	case *ast.CalibrateResourceStmt:
 		return &calibrateresource.Executor{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), 0),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), 0),
 			WorkloadType: s.Tp,
 			OptionList:   s.DynamicCalibrateResourceOptionList,
 		}
 	case *ast.AddQueryWatchStmt:
 		return &querywatch.AddExecutor{
-			BaseExecutor:         exec.NewBaseExecutor(b.ctx, v.Schema(), 0),
+			BaseExecutor:         exec.NewBaseExecutor(b.sctx, v.Schema(), 0),
 			QueryWatchOptionList: s.QueryWatchOptionList,
 		}
 	case *ast.ImportIntoActionStmt:
 		return &ImportIntoActionExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, 0),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, nil, 0),
 			tp:           s.Tp,
 			jobID:        s.JobID,
 		}
 	case *ast.CancelDistributionJobStmt:
 		return &CancelDistributionJobExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, 0),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, nil, 0),
 			jobID:        uint64(s.JobID),
 		}
 	}
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID())
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID())
 	base.SetInitCap(chunk.ZeroCapacity)
 	e := &SimpleExec{
 		BaseExecutor:    base,
@@ -1008,7 +1008,7 @@ func (b *executorBuilder) buildSimple(v *plannercore.Simple) exec.Executor {
 }
 
 func (b *executorBuilder) buildSet(v *plannercore.Set) exec.Executor {
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID())
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID())
 	base.SetInitCap(chunk.ZeroCapacity)
 	e := &SetExecutor{
 		BaseExecutor: base,
@@ -1019,7 +1019,7 @@ func (b *executorBuilder) buildSet(v *plannercore.Set) exec.Executor {
 
 func (b *executorBuilder) buildSetConfig(v *plannercore.SetConfig) exec.Executor {
 	return &SetConfigExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		p:            v,
 	}
 }
@@ -1038,7 +1038,7 @@ func (b *executorBuilder) buildInsert(v *physicalop.Insert) exec.Executor {
 	if selectExec != nil {
 		children = append(children, selectExec)
 	}
-	baseExec := exec.NewBaseExecutor(b.ctx, nil, v.ID(), children...)
+	baseExec := exec.NewBaseExecutor(b.sctx, nil, v.ID(), children...)
 	baseExec.SetInitCap(chunk.ZeroCapacity)
 
 	ivs := &InsertValues{
@@ -1058,7 +1058,7 @@ func (b *executorBuilder) buildInsert(v *physicalop.Insert) exec.Executor {
 		b.err = err
 		return nil
 	}
-	ivs.fkChecks, b.err = buildFKCheckExecs(b.ctx, ivs.Table, v.FKChecks)
+	ivs.fkChecks, b.err = buildFKCheckExecs(b.sctx, ivs.Table, v.FKChecks)
 	if b.err != nil {
 		return nil
 	}
@@ -1079,7 +1079,7 @@ func (b *executorBuilder) buildInsert(v *physicalop.Insert) exec.Executor {
 
 func (b *executorBuilder) buildImportInto(v *plannercore.ImportInto) exec.Executor {
 	// see planBuilder.buildImportInto for detail why we use the latest schema here.
-	latestIS := b.ctx.GetLatestInfoSchema().(infoschema.InfoSchema)
+	latestIS := b.sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	tbl, ok := latestIS.TableByID(context.Background(), v.Table.TableInfo.ID)
 	if !ok {
 		b.err = errors.Errorf("Can not get table %d", v.Table.TableInfo.ID)
@@ -1101,8 +1101,8 @@ func (b *executorBuilder) buildImportInto(v *plannercore.ImportInto) exec.Execut
 		}
 		children = append(children, selectExec)
 	}
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), children...)
-	executor, err := newImportIntoExec(base, selectExec, b.ctx, v, tbl)
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), children...)
+	executor, err := newImportIntoExec(base, selectExec, b.sctx, v, tbl)
 	if err != nil {
 		b.err = err
 		return nil
@@ -1122,8 +1122,8 @@ func (b *executorBuilder) buildLoadData(v *plannercore.LoadData) exec.Executor {
 		return nil
 	}
 
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID())
-	worker, err := NewLoadDataWorker(b.ctx, v, tbl)
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID())
+	worker, err := NewLoadDataWorker(b.sctx, v, tbl)
 	if err != nil {
 		b.err = err
 		return nil
@@ -1138,15 +1138,15 @@ func (b *executorBuilder) buildLoadData(v *plannercore.LoadData) exec.Executor {
 
 func (b *executorBuilder) buildLoadStats(v *plannercore.LoadStats) exec.Executor {
 	e := &LoadStatsExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, v.ID()),
-		info:         &LoadStatsInfo{v.Path, b.ctx},
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, nil, v.ID()),
+		info:         &LoadStatsInfo{v.Path, b.sctx},
 	}
 	return e
 }
 
 func (b *executorBuilder) buildLockStats(v *plannercore.LockStats) exec.Executor {
 	e := &lockstats.LockExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, nil, v.ID()),
 		Tables:       v.Tables,
 	}
 	return e
@@ -1154,7 +1154,7 @@ func (b *executorBuilder) buildLockStats(v *plannercore.LockStats) exec.Executor
 
 func (b *executorBuilder) buildUnlockStats(v *plannercore.UnlockStats) exec.Executor {
 	e := &lockstats.UnlockExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, nil, v.ID()),
 		Tables:       v.Tables,
 	}
 	return e
@@ -1163,14 +1163,14 @@ func (b *executorBuilder) buildUnlockStats(v *plannercore.UnlockStats) exec.Exec
 func (b *executorBuilder) buildPlanReplayer(v *plannercore.PlanReplayer) exec.Executor {
 	if v.Load {
 		e := &PlanReplayerLoadExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, v.ID()),
-			info:         &PlanReplayerLoadInfo{Path: v.File, Ctx: b.ctx},
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, nil, v.ID()),
+			info:         &PlanReplayerLoadInfo{Path: v.File, Ctx: b.sctx},
 		}
 		return e
 	}
 	if v.Capture {
 		e := &PlanReplayerExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, v.ID()),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, nil, v.ID()),
 			CaptureInfo: &PlanReplayerCaptureInfo{
 				SQLDigest:  v.SQLDigest,
 				PlanDigest: v.PlanDigest,
@@ -1180,7 +1180,7 @@ func (b *executorBuilder) buildPlanReplayer(v *plannercore.PlanReplayer) exec.Ex
 	}
 	if v.Remove {
 		e := &PlanReplayerExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, v.ID()),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, nil, v.ID()),
 			CaptureInfo: &PlanReplayerCaptureInfo{
 				SQLDigest:  v.SQLDigest,
 				PlanDigest: v.PlanDigest,
@@ -1191,11 +1191,11 @@ func (b *executorBuilder) buildPlanReplayer(v *plannercore.PlanReplayer) exec.Ex
 	}
 
 	e := &PlanReplayerExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		DumpInfo: &PlanReplayerDumpInfo{
 			Analyze:           v.Analyze,
 			Path:              v.File,
-			ctx:               b.ctx,
+			ctx:               b.sctx,
 			HistoricalStatsTS: v.HistoricalStatsTS,
 		},
 	}
@@ -1203,7 +1203,7 @@ func (b *executorBuilder) buildPlanReplayer(v *plannercore.PlanReplayer) exec.Ex
 		// Parse multiple SQL strings from StmtList
 		e.DumpInfo.ExecStmts = make([]ast.StmtNode, 0, len(v.StmtList))
 		for _, sqlStr := range v.StmtList {
-			node, err := b.ctx.GetRestrictedSQLExecutor().ParseWithParams(context.Background(), sqlStr)
+			node, err := b.sctx.GetRestrictedSQLExecutor().ParseWithParams(context.Background(), sqlStr)
 			if err != nil {
 				// If parsing fails, propagate the error immediately so the statement fails.
 				b.err = errors.Errorf("plan replayer: failed to parse SQL: %s, error: %v", sqlStr, err)
@@ -1214,7 +1214,7 @@ func (b *executorBuilder) buildPlanReplayer(v *plannercore.PlanReplayer) exec.Ex
 	} else if v.ExecStmt != nil {
 		e.DumpInfo.ExecStmts = []ast.StmtNode{v.ExecStmt}
 	} else {
-		e.BaseExecutor = exec.NewBaseExecutor(b.ctx, nil, v.ID())
+		e.BaseExecutor = exec.NewBaseExecutor(b.sctx, nil, v.ID())
 	}
 	return e
 }
@@ -1223,7 +1223,7 @@ func (b *executorBuilder) buildTraffic(traffic *plannercore.Traffic) exec.Execut
 	switch traffic.OpType {
 	case ast.TrafficOpCapture:
 		exec := &TrafficCaptureExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, traffic.Schema(), traffic.ID()),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, traffic.Schema(), traffic.ID()),
 			Args: map[string]string{
 				"output": traffic.Dir,
 			},
@@ -1241,7 +1241,7 @@ func (b *executorBuilder) buildTraffic(traffic *plannercore.Traffic) exec.Execut
 		return exec
 	case ast.TrafficOpReplay:
 		exec := &TrafficReplayExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, traffic.Schema(), traffic.ID()),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, traffic.Schema(), traffic.ID()),
 			Args: map[string]string{
 				"input": traffic.Dir,
 			},
@@ -1265,11 +1265,11 @@ func (b *executorBuilder) buildTraffic(traffic *plannercore.Traffic) exec.Execut
 		return exec
 	case ast.TrafficOpCancel:
 		return &TrafficCancelExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, traffic.Schema(), traffic.ID()),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, traffic.Schema(), traffic.ID()),
 		}
 	case ast.TrafficOpShow:
 		return &TrafficShowExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, traffic.Schema(), traffic.ID()),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, traffic.Schema(), traffic.ID()),
 		}
 	}
 	// impossible here
@@ -1285,7 +1285,7 @@ func (*executorBuilder) buildReplace(vals *InsertValues) exec.Executor {
 
 func (b *executorBuilder) buildGrant(grant *ast.GrantStmt) exec.Executor {
 	e := &GrantExec{
-		BaseExecutor:          exec.NewBaseExecutor(b.ctx, nil, 0),
+		BaseExecutor:          exec.NewBaseExecutor(b.sctx, nil, 0),
 		Privs:                 grant.Privs,
 		ObjectType:            grant.ObjectType,
 		Level:                 grant.Level,
@@ -1299,8 +1299,8 @@ func (b *executorBuilder) buildGrant(grant *ast.GrantStmt) exec.Executor {
 
 func (b *executorBuilder) buildRevoke(revoke *ast.RevokeStmt) exec.Executor {
 	e := &RevokeExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, 0),
-		ctx:          b.ctx,
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, nil, 0),
+		ctx:          b.sctx,
 		Privs:        revoke.Privs,
 		ObjectType:   revoke.ObjectType,
 		Level:        revoke.Level,
@@ -1395,11 +1395,11 @@ func (b *executorBuilder) buildDDL(v *plannercore.DDL) exec.Executor {
 	b.setTelemetryInfo(v)
 
 	e := &DDLExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
-		ddlExecutor:  domain.GetDomain(b.ctx).DDLExecutor(),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
+		ddlExecutor:  domain.GetDomain(b.sctx).DDLExecutor(),
 		stmt:         v.Statement,
 		is:           b.is,
-		tempTableDDL: temptable.GetTemporaryTableDDL(b.ctx),
+		tempTableDDL: temptable.GetTemporaryTableDDL(b.sctx),
 	}
 	return e
 }
@@ -1408,7 +1408,7 @@ func (b *executorBuilder) buildDDL(v *plannercore.DDL) exec.Executor {
 // at build().
 func (b *executorBuilder) buildTrace(v *plannercore.Trace) exec.Executor {
 	t := &TraceExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		stmtNode:     v.StmtNode,
 		resolveCtx:   v.ResolveCtx,
 		builder:      b,
@@ -1419,7 +1419,7 @@ func (b *executorBuilder) buildTrace(v *plannercore.Trace) exec.Executor {
 	}
 	if t.format == plannercore.TraceFormatLog && !t.optimizerTrace {
 		return &sortexec.SortExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), t),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), t),
 			ByItems: []*plannerutil.ByItems{
 				{Expr: &expression.Column{
 					Index:   0,
@@ -1435,12 +1435,12 @@ func (b *executorBuilder) buildTrace(v *plannercore.Trace) exec.Executor {
 // buildExplain builds a explain executor. `e.rows` collects final result to `ExplainExec`.
 func (b *executorBuilder) buildExplain(v *plannercore.Explain) exec.Executor {
 	explainExec := &ExplainExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		explain:      v,
 	}
 	if v.Analyze {
-		if b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl == nil {
-			b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStatsColl(nil)
+		if b.sctx.GetSessionVars().StmtCtx.RuntimeStatsColl == nil {
+			b.sctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStatsColl(nil)
 		}
 	}
 	// EXPLAIN FOR CONNECTION can render directly from the stored brief binary plan without
@@ -1460,7 +1460,7 @@ func (b *executorBuilder) buildSelectInto(v *plannercore.SelectInto) exec.Execut
 		return nil
 	}
 	return &SelectIntoExec{
-		BaseExecutor:   exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), child),
+		BaseExecutor:   exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), child),
 		intoOpt:        v.IntoOpt,
 		LineFieldsInfo: v.LineFieldsInfo,
 	}
@@ -1511,7 +1511,7 @@ func (b *executorBuilder) buildUnionScanFromReader(reader exec.Executor, v *phys
 		}
 		return x
 	}
-	us := &UnionScanExec{BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), reader)}
+	us := &UnionScanExec{BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), reader)}
 	// Get the handle column index of the below Plan.
 	us.handleCols = v.HandleCols
 	us.mutableRow = chunk.MutRowFromTypes(exec.RetTypes(us))
@@ -1528,7 +1528,7 @@ func (b *executorBuilder) buildUnionScanFromReader(reader exec.Executor, v *phys
 	}
 
 	startTS, err := b.getSnapshotTS()
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := b.sctx.GetSessionVars()
 	if err != nil {
 		b.err = err
 		return nil
@@ -1664,7 +1664,7 @@ func (us *UnionScanExec) handleCachedTable(b *executorBuilder, x bypassDataSourc
 		} else if loading {
 			return
 		} else if !b.inUpdateStmt && !b.inDeleteStmt && !b.inInsertStmt && !vars.StmtCtx.InExplainStmt {
-			store := b.ctx.GetStore()
+			store := b.sctx.GetStore()
 			cachedTable.UpdateLockForRead(context.Background(), store, startTS, leaseDuration)
 		}
 	}
@@ -1697,11 +1697,11 @@ func (b *executorBuilder) buildMergeJoin(v *physicalop.PhysicalMergeJoin) exec.E
 	}
 
 	e := &join.MergeJoinExec{
-		StmtCtx:      b.ctx.GetSessionVars().StmtCtx,
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), leftExec, rightExec),
+		StmtCtx:      b.sctx.GetSessionVars().StmtCtx,
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), leftExec, rightExec),
 		CompareFuncs: v.CompareFuncs,
 		Joiner: join.NewJoiner(
-			b.ctx,
+			b.sctx,
 			v.JoinType,
 			v.JoinType == base.RightOuterJoin,
 			defaultValues,
@@ -1808,7 +1808,7 @@ func (b *executorBuilder) buildHashJoinV2FromChildExecs(leftExec, rightExec exec
 	}
 
 	e := &join.HashJoinV2Exec{
-		BaseExecutor:          exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), leftExec, rightExec),
+		BaseExecutor:          exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), leftExec, rightExec),
 		ProbeSideTupleFetcher: &join.ProbeSideTupleFetcherV2{},
 		ProbeWorkers:          make([]*join.ProbeWorkerV2, v.Concurrency),
 		BuildWorkers:          make([]*join.BuildWorkerV2, v.Concurrency),
@@ -1817,7 +1817,7 @@ func (b *executorBuilder) buildHashJoinV2FromChildExecs(leftExec, rightExec exec
 		},
 		IsGA: physicalop.IsGAForHashJoinV2(v.JoinType, v.LeftJoinKeys, v.IsNullEQ, v.LeftNAJoinKeys),
 	}
-	e.HashJoinCtxV2.SessCtx = b.ctx
+	e.HashJoinCtxV2.SessCtx = b.sctx
 	e.HashJoinCtxV2.JoinType = v.JoinType
 	e.HashJoinCtxV2.Concurrency = v.Concurrency
 	e.HashJoinCtxV2.SetupPartitionInfo()
@@ -1954,7 +1954,7 @@ func (b *executorBuilder) buildHashJoinV2FromChildExecs(leftExec, rightExec exec
 }
 
 func (b *executorBuilder) buildHashJoin(v *physicalop.PhysicalHashJoin) exec.Executor {
-	if b.ctx.GetSessionVars().UseHashJoinV2 && joinversion.IsHashJoinV2Supported() && v.CanUseHashJoinV2() {
+	if b.sctx.GetSessionVars().UseHashJoinV2 && joinversion.IsHashJoinV2Supported() && v.CanUseHashJoinV2() {
 		return b.buildHashJoinV2(v)
 	}
 	leftExec := b.build(v.Children()[0])
@@ -1971,7 +1971,7 @@ func (b *executorBuilder) buildHashJoin(v *physicalop.PhysicalHashJoin) exec.Exe
 
 func (b *executorBuilder) buildHashJoinFromChildExecs(leftExec, rightExec exec.Executor, v *physicalop.PhysicalHashJoin) *join.HashJoinV1Exec {
 	e := &join.HashJoinV1Exec{
-		BaseExecutor:          exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), leftExec, rightExec),
+		BaseExecutor:          exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), leftExec, rightExec),
 		ProbeSideTupleFetcher: &join.ProbeSideTupleFetcherV1{},
 		ProbeWorkers:          make([]*join.ProbeWorkerV1, v.Concurrency),
 		BuildWorker:           &join.BuildWorkerV1{},
@@ -1980,7 +1980,7 @@ func (b *executorBuilder) buildHashJoinFromChildExecs(leftExec, rightExec exec.E
 			UseOuterToBuild: v.UseOuterToBuild,
 		},
 	}
-	e.HashJoinCtxV1.SessCtx = b.ctx
+	e.HashJoinCtxV1.SessCtx = b.sctx
 	e.HashJoinCtxV1.JoinType = v.JoinType
 	e.HashJoinCtxV1.Concurrency = v.Concurrency
 	e.HashJoinCtxV1.ChunkAllocPool = e.AllocPool
@@ -2058,7 +2058,7 @@ func (b *executorBuilder) buildHashJoinFromChildExecs(leftExec, rightExec exec.E
 	for i := range e.Concurrency {
 		e.ProbeWorkers[i] = &join.ProbeWorkerV1{
 			HashJoinCtx:      e.HashJoinCtxV1,
-			Joiner:           join.NewJoiner(b.ctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, lhsTypes, rhsTypes, childrenUsedSchema, isNAJoin),
+			Joiner:           join.NewJoiner(b.sctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, lhsTypes, rhsTypes, childrenUsedSchema, isNAJoin),
 			ProbeKeyColIdx:   probeKeyColIdx,
 			ProbeNAKeyColIdx: probeNAKeColIdx,
 		}
@@ -2127,9 +2127,9 @@ func (b *executorBuilder) buildHashAgg(v *physicalop.PhysicalHashAgg) exec.Execu
 }
 
 func (b *executorBuilder) buildHashAggFromChildExec(childExec exec.Executor, v *physicalop.PhysicalHashAgg) *aggregate.HashAggExec {
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := b.sctx.GetSessionVars()
 	e := &aggregate.HashAggExec{
-		BaseExecutor:    exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), childExec),
+		BaseExecutor:    exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), childExec),
 		Sc:              sessionVars.StmtCtx,
 		PartialAggFuncs: make([]aggfuncs.AggFunc, 0, len(v.AggFuncs)),
 		GroupByItems:    v.GroupByItems,
@@ -2170,7 +2170,7 @@ func (b *executorBuilder) buildHashAggFromChildExec(childExec exec.Executor, v *
 		e.IsUnparallelExec = true
 	}
 	partialOrdinal := 0
-	exprCtx := b.ctx.GetExprCtx()
+	exprCtx := b.sctx.GetExprCtx()
 	for i, aggDesc := range v.AggFuncs {
 		if e.IsUnparallelExec {
 			e.PartialAggFuncs = append(e.PartialAggFuncs, aggfuncs.Build(exprCtx, aggDesc, i))
@@ -2212,10 +2212,10 @@ func (b *executorBuilder) buildStreamAgg(v *physicalop.PhysicalStreamAgg) exec.E
 }
 
 func (b *executorBuilder) buildStreamAggFromChildExec(childExec exec.Executor, v *physicalop.PhysicalStreamAgg) *aggregate.StreamAggExec {
-	exprCtx := b.ctx.GetExprCtx()
+	exprCtx := b.sctx.GetExprCtx()
 	e := &aggregate.StreamAggExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), childExec),
-		GroupChecker: vecgroupchecker.NewVecGroupChecker(exprCtx.GetEvalCtx(), b.ctx.GetSessionVars().EnableVectorizedExpression, v.GroupByItems),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), childExec),
+		GroupChecker: vecgroupchecker.NewVecGroupChecker(exprCtx.GetEvalCtx(), b.sctx.GetSessionVars().EnableVectorizedExpression, v.GroupByItems),
 		AggFuncs:     make([]aggfuncs.AggFunc, 0, len(v.AggFuncs)),
 	}
 
@@ -2246,8 +2246,8 @@ func (b *executorBuilder) buildSelection(v *physicalop.PhysicalSelection) exec.E
 		return nil
 	}
 	e := &SelectionExec{
-		selectionExecutorContext: newSelectionExecutorContext(b.ctx),
-		BaseExecutorV2:           exec.NewBaseExecutorV2(b.ctx.GetSessionVars(), v.Schema(), v.ID(), childExec),
+		selectionExecutorContext: newSelectionExecutorContext(b.sctx),
+		BaseExecutorV2:           exec.NewBaseExecutorV2(b.sctx.GetSessionVars(), v.Schema(), v.ID(), childExec),
 		filters:                  v.Conditions,
 	}
 	return e
@@ -2268,15 +2268,15 @@ func (b *executorBuilder) buildExpand(v *physicalop.PhysicalExpand) exec.Executo
 		levelES = append(levelES, levelE)
 	}
 	e := &ExpandExec{
-		BaseExecutor:        exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), childExec),
-		numWorkers:          int64(b.ctx.GetSessionVars().ProjectionConcurrency()),
+		BaseExecutor:        exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), childExec),
+		numWorkers:          int64(b.sctx.GetSessionVars().ProjectionConcurrency()),
 		levelEvaluatorSuits: levelES,
 	}
 
 	// If the calculation row count for this Projection operator is smaller
 	// than a Chunk size, we turn back to the un-parallel Projection
 	// implementation to reduce the goroutine overhead.
-	if int64(v.StatsCount()) < int64(b.ctx.GetSessionVars().MaxChunkSize) {
+	if int64(v.StatsCount()) < int64(b.sctx.GetSessionVars().MaxChunkSize) {
 		e.numWorkers = 0
 	}
 
@@ -2298,9 +2298,9 @@ func (b *executorBuilder) buildProjection(v *physicalop.PhysicalProjection) exec
 
 func (b *executorBuilder) newProjectionExec(childExec exec.Executor, v *physicalop.PhysicalProjection) *ProjectionExec {
 	e := &ProjectionExec{
-		projectionExecutorContext: newProjectionExecutorContext(b.ctx),
-		BaseExecutorV2:            exec.NewBaseExecutorV2(b.ctx.GetSessionVars(), v.Schema(), v.ID(), childExec),
-		numWorkers:                int64(b.ctx.GetSessionVars().ProjectionConcurrency()),
+		projectionExecutorContext: newProjectionExecutorContext(b.sctx),
+		BaseExecutorV2:            exec.NewBaseExecutorV2(b.sctx.GetSessionVars(), v.Schema(), v.ID(), childExec),
+		numWorkers:                int64(b.sctx.GetSessionVars().ProjectionConcurrency()),
 		evaluatorSuit:             expression.NewEvaluatorSuite(v.Exprs, v.AvoidColumnEvaluator),
 		calculateNoDelay:          v.CalculateNoDelay,
 	}
@@ -2309,7 +2309,7 @@ func (b *executorBuilder) newProjectionExec(childExec exec.Executor, v *physical
 	// than a Chunk size, we turn back to the un-parallel Projection
 	// implementation to reduce the goroutine overhead.
 	// index join would use the same logic.
-	if int64(v.StatsCount()) < int64(b.ctx.GetSessionVars().MaxChunkSize) {
+	if int64(v.StatsCount()) < int64(b.sctx.GetSessionVars().MaxChunkSize) {
 		e.numWorkers = 0
 	}
 
@@ -2326,7 +2326,7 @@ func (b *executorBuilder) buildTableDual(v *physicalop.PhysicalTableDual) exec.E
 		b.err = errors.Errorf("buildTableDual failed, invalid row count for dual table: %v", v.RowCount)
 		return nil
 	}
-	base := exec.NewBaseExecutorV2(b.ctx.GetSessionVars(), v.Schema(), v.ID())
+	base := exec.NewBaseExecutorV2(b.sctx.GetSessionVars(), v.Schema(), v.ID())
 	base.SetInitCap(v.RowCount)
 	e := &TableDualExec{
 		BaseExecutorV2: base,
@@ -2342,7 +2342,7 @@ func (b *executorBuilder) getSnapshotTS() (ts uint64, err error) {
 		return b.dataReaderTS, nil
 	}
 
-	txnManager := sessiontxn.GetTxnManager(b.ctx)
+	txnManager := sessiontxn.GetTxnManager(b.sctx)
 	if b.inInsertStmt || b.inUpdateStmt || b.inDeleteStmt || b.inSelectLockStmt {
 		return txnManager.GetStmtForUpdateTS()
 	}
@@ -2355,7 +2355,7 @@ func (b *executorBuilder) getSnapshot() (kv.Snapshot, error) {
 	var snapshot kv.Snapshot
 	var err error
 
-	txnManager := sessiontxn.GetTxnManager(b.ctx)
+	txnManager := sessiontxn.GetTxnManager(b.sctx)
 	if b.inInsertStmt || b.inUpdateStmt || b.inDeleteStmt || b.inSelectLockStmt {
 		snapshot, err = txnManager.GetSnapshotWithStmtForUpdateTS()
 	} else {
@@ -2365,7 +2365,7 @@ func (b *executorBuilder) getSnapshot() (kv.Snapshot, error) {
 		return nil, err
 	}
 
-	InitSnapshotWithSessCtx(snapshot, b.ctx, &b.readReplicaScope)
+	InitSnapshotWithSessCtx(snapshot, b.sctx, &b.readReplicaScope)
 	return snapshot, nil
 }
 
@@ -2400,7 +2400,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 	switch v.DBName.L {
 	case metadef.MetricSchemaName.L:
 		return &MemTableReaderExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 			table:        v.Table,
 			retriever: &MetricRetriever{
 				table:     v.Table,
@@ -2411,7 +2411,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 		switch v.Table.Name.L {
 		case strings.ToLower(infoschema.TableClusterConfig):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &clusterConfigRetriever{
 					extractor: v.Extractor.(*plannercore.ClusterTableExtractor),
@@ -2419,7 +2419,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableClusterLoad):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &clusterServerInfoRetriever{
 					extractor:      v.Extractor.(*plannercore.ClusterTableExtractor),
@@ -2428,7 +2428,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableClusterHardware):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &clusterServerInfoRetriever{
 					extractor:      v.Extractor.(*plannercore.ClusterTableExtractor),
@@ -2437,7 +2437,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableClusterSystemInfo):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &clusterServerInfoRetriever{
 					extractor:      v.Extractor.(*plannercore.ClusterTableExtractor),
@@ -2446,7 +2446,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableClusterLog):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &clusterLogRetriever{
 					extractor: v.Extractor.(*plannercore.ClusterLogTableExtractor),
@@ -2454,7 +2454,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableTiDBHotRegionsHistory):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &hotRegionsHistoryRetriver{
 					extractor: v.Extractor.(*plannercore.HotRegionsHistoryTableExtractor),
@@ -2462,7 +2462,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableInspectionResult):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &inspectionResultRetriever{
 					extractor: v.Extractor.(*plannercore.InspectionResultTableExtractor),
@@ -2471,7 +2471,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableInspectionSummary):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &inspectionSummaryRetriever{
 					table:     v.Table,
@@ -2481,7 +2481,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableInspectionRules):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &inspectionRuleRetriever{
 					extractor: v.Extractor.(*plannercore.InspectionRuleTableExtractor),
@@ -2489,7 +2489,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableMetricSummary):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &MetricsSummaryRetriever{
 					table:     v.Table,
@@ -2499,7 +2499,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableMetricSummaryByLabel):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &MetricsSummaryByLabelRetriever{
 					table:     v.Table,
@@ -2509,7 +2509,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableTiKVRegionPeers):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &tikvRegionPeersRetriever{
 					extractor: v.Extractor.(*plannercore.TikvRegionPeersExtractor),
@@ -2565,9 +2565,9 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			strings.ToLower(infoschema.ClusterTableTiDBIndexUsage),
 			strings.ToLower(infoschema.TableKeyspaceMeta):
 			memTracker := memory.NewTracker(v.ID(), -1)
-			memTracker.AttachTo(b.ctx.GetSessionVars().StmtCtx.MemTracker)
+			memTracker.AttachTo(b.sctx.GetSessionVars().StmtCtx.MemTracker)
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &memtableRetriever{
 					table:      v.Table,
@@ -2579,7 +2579,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 		case strings.ToLower(infoschema.TableTiDBTrx),
 			strings.ToLower(infoschema.ClusterTableTiDBTrx):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &tidbTrxTableRetriever{
 					table:   v.Table,
@@ -2588,7 +2588,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableDataLockWaits):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &dataLockWaitsTableRetriever{
 					table:   v.Table,
@@ -2598,7 +2598,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 		case strings.ToLower(infoschema.TableDeadlocks),
 			strings.ToLower(infoschema.ClusterTableDeadlocks):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &deadlocksTableRetriever{
 					table:   v.Table,
@@ -2618,13 +2618,13 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 				extractor = v.Extractor.(*plannercore.StatementsSummaryExtractor)
 			}
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever:    buildStmtSummaryRetriever(v.Table, v.Columns, extractor),
 			}
 		case strings.ToLower(infoschema.TableColumns):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &hugeMemTableRetriever{
 					table:              v.Table,
@@ -2637,9 +2637,9 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 		case strings.ToLower(infoschema.TableSlowQuery), strings.ToLower(infoschema.ClusterTableSlowLog):
 			extractor := v.Extractor.(*plannercore.SlowQueryExtractor)
 			memTracker := memory.NewTracker(v.ID(), -1)
-			memTracker.AttachTo(b.ctx.GetSessionVars().StmtCtx.MemTracker)
+			memTracker.AttachTo(b.sctx.GetSessionVars().StmtCtx.MemTracker)
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &slowQueryRetriever{
 					table:      v.Table,
@@ -2651,7 +2651,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			}
 		case strings.ToLower(infoschema.TableStorageStats):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &tableStorageStatsRetriever{
 					table:      v.Table,
@@ -2660,10 +2660,10 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 				},
 			}
 		case strings.ToLower(infoschema.TableDDLJobs):
-			loc := b.ctx.GetSessionVars().Location()
+			loc := b.sctx.GetSessionVars().Location()
 			ddlJobRetriever := DDLJobRetriever{TZLoc: loc, extractor: v.Extractor}
 			return &DDLJobsReaderExec{
-				BaseExecutor:    exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor:    exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				is:              b.is,
 				DDLJobRetriever: ddlJobRetriever,
 			}
@@ -2671,7 +2671,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 			strings.ToLower(infoschema.TableTiFlashSegments),
 			strings.ToLower(infoschema.TableTiFlashIndexes):
 			return &MemTableReaderExec{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 				table:        v.Table,
 				retriever: &TiFlashSystemTableRetriever{
 					table:      v.Table,
@@ -2683,7 +2683,7 @@ func (b *executorBuilder) buildMemTable(v *physicalop.PhysicalMemTable) exec.Exe
 	}
 	tb, _ := b.is.TableByID(context.Background(), v.Table.ID)
 	return &TableScanExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		t:            tb,
 		columns:      v.Columns,
 	}
@@ -2695,7 +2695,7 @@ func (b *executorBuilder) buildSort(v *physicalop.PhysicalSort) exec.Executor {
 		return nil
 	}
 	sortExec := sortexec.SortExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), childExec),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), childExec),
 		ByItems:      v.ByItems,
 		ExecSchema:   v.Schema(),
 	}
@@ -2709,7 +2709,7 @@ func (b *executorBuilder) buildTopN(v *physicalop.PhysicalTopN) exec.Executor {
 		return nil
 	}
 	sortExec := sortexec.SortExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), childExec),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), childExec),
 		ByItems:      v.ByItems,
 		ExecSchema:   v.Schema(),
 	}
@@ -2717,7 +2717,7 @@ func (b *executorBuilder) buildTopN(v *physicalop.PhysicalTopN) exec.Executor {
 	t := &sortexec.TopNExec{
 		SortExec:    sortExec,
 		Limit:       &physicalop.PhysicalLimit{Count: v.Count, Offset: v.Offset},
-		Concurrency: b.ctx.GetSessionVars().Concurrency.ExecutorConcurrency,
+		Concurrency: b.sctx.GetSessionVars().Concurrency.ExecutorConcurrency,
 	}
 	columnIdxsUsedByChild, columnMissing := retrieveColumnIdxsUsedByChild(v.Schema(), v.Children()[0].Schema())
 	if columnIdxsUsedByChild != nil && columnMissing {
@@ -2780,12 +2780,12 @@ func (b *executorBuilder) buildApply(v *physicalop.PhysicalApply) exec.Executor 
 		outerExec, innerExec = rightChild, leftChild
 		outerFilter, innerFilter = v.RightConditions, v.LeftConditions
 	}
-	tupleJoiner := join.NewJoiner(b.ctx, v.JoinType, v.InnerChildIdx == 0,
+	tupleJoiner := join.NewJoiner(b.sctx, v.JoinType, v.InnerChildIdx == 0,
 		defaultValues, otherConditions, exec.RetTypes(leftChild), exec.RetTypes(rightChild), nil, false)
 
 	constructSerialExec := func() exec.Executor {
 		serialExec := &join.NestedLoopApplyExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), outerExec, innerExec),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), outerExec, innerExec),
 			InnerExec:    innerExec,
 			OuterExec:    outerExec,
 			OuterFilter:  outerFilter,
@@ -2793,7 +2793,7 @@ func (b *executorBuilder) buildApply(v *physicalop.PhysicalApply) exec.Executor 
 			Outer:        v.JoinType != base.InnerJoin,
 			Joiner:       tupleJoiner,
 			OuterSchema:  v.OuterSchema,
-			Sctx:         b.ctx,
+			Sctx:         b.sctx,
 			CanUseCache:  v.CanUseCache,
 		}
 		executor_metrics.ExecutorCounterNestedLoopApplyExec.Inc()
@@ -2821,14 +2821,14 @@ func (b *executorBuilder) buildApply(v *physicalop.PhysicalApply) exec.Executor 
 			innerExecs = append(innerExecs, clonedInnerExec)
 			corCols = append(corCols, corCol)
 			innerFilters = append(innerFilters, innerFilter.Clone())
-			joiners = append(joiners, join.NewJoiner(b.ctx, v.JoinType, v.InnerChildIdx == 0,
+			joiners = append(joiners, join.NewJoiner(b.sctx, v.JoinType, v.InnerChildIdx == 0,
 				defaultValues, otherConditions, exec.RetTypes(leftChild), exec.RetTypes(rightChild), nil, false))
 		}
 
 		allExecs := append([]exec.Executor{outerExec}, innerExecs...)
 
 		return &ParallelNestedLoopApplyExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), allExecs...),
+			BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), allExecs...),
 			innerExecs:   innerExecs,
 			outerExec:    outerExec,
 			outerFilter:  outerFilter,
@@ -2849,7 +2849,7 @@ func (b *executorBuilder) buildMaxOneRow(v *physicalop.PhysicalMaxOneRow) exec.E
 	if b.err != nil {
 		return nil
 	}
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), childExec)
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), childExec)
 	base.SetInitCap(2)
 	base.SetMaxChunkSize(2)
 	e := &MaxOneRowExec{BaseExecutor: base}
@@ -2865,8 +2865,8 @@ func (b *executorBuilder) buildUnionAll(v *physicalop.PhysicalUnionAll) exec.Exe
 		}
 	}
 	e := &unionexec.UnionExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), childExecs...),
-		Concurrency:  b.ctx.GetSessionVars().UnionConcurrency(),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), childExecs...),
+		Concurrency:  b.sctx.GetSessionVars().UnionConcurrency(),
 	}
 	return e
 }
@@ -2893,7 +2893,7 @@ func buildHandleColsForSplit(tbInfo *model.TableInfo) plannerutil.HandleCols {
 }
 
 func (b *executorBuilder) buildDistributeTable(v *plannercore.DistributeTable) exec.Executor {
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID())
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID())
 	base.SetInitCap(1)
 	base.SetMaxChunkSize(1)
 	return &DistributeTableExec{
@@ -2908,7 +2908,7 @@ func (b *executorBuilder) buildDistributeTable(v *plannercore.DistributeTable) e
 }
 
 func (b *executorBuilder) buildSplitRegion(v *plannercore.SplitRegion) exec.Executor {
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID())
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID())
 	base.SetInitCap(1)
 	base.SetMaxChunkSize(1)
 	if v.IndexInfo != nil {
@@ -2974,10 +2974,10 @@ func (b *executorBuilder) buildUpdate(v *physicalop.Update) exec.Executor {
 	if b.err != nil {
 		return nil
 	}
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), selExec)
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), selExec)
 	base.SetInitCap(chunk.ZeroCapacity)
 	var assignFlag []int
-	assignFlag, b.err = getAssignFlag(b.ctx, v, selExec.Schema().Len())
+	assignFlag, b.err = getAssignFlag(b.sctx, v, selExec.Schema().Len())
 	if b.err != nil {
 		return nil
 	}
@@ -2997,7 +2997,7 @@ func (b *executorBuilder) buildUpdate(v *physicalop.Update) exec.Executor {
 		assignFlag:                assignFlag,
 		IgnoreError:               v.IgnoreError,
 	}
-	updateExec.fkChecks, b.err = buildTblID2FKCheckExecs(b.ctx, tblID2table, v.FKChecks)
+	updateExec.fkChecks, b.err = buildTblID2FKCheckExecs(b.sctx, tblID2table, v.FKChecks)
 	if b.err != nil {
 		return nil
 	}
@@ -3041,7 +3041,7 @@ func (b *executorBuilder) buildDelete(v *physicalop.Delete) exec.Executor {
 	if b.err != nil {
 		return nil
 	}
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), selExec)
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), selExec)
 	base.SetInitCap(chunk.ZeroCapacity)
 	deleteExec := &DeleteExec{
 		BaseExecutor:   base,
@@ -3050,7 +3050,7 @@ func (b *executorBuilder) buildDelete(v *physicalop.Delete) exec.Executor {
 		tblColPosInfos: v.TblColPosInfos,
 		ignoreErr:      v.IgnoreErr,
 	}
-	deleteExec.fkChecks, b.err = buildTblID2FKCheckExecs(b.ctx, tblID2table, v.FKChecks)
+	deleteExec.fkChecks, b.err = buildTblID2FKCheckExecs(b.sctx, tblID2table, v.FKChecks)
 	if b.err != nil {
 		return nil
 	}
@@ -3063,14 +3063,14 @@ func (b *executorBuilder) buildDelete(v *physicalop.Delete) exec.Executor {
 
 func (b *executorBuilder) updateForUpdateTS() error {
 	// GetStmtForUpdateTS will auto update the for update ts if it is necessary
-	_, err := sessiontxn.GetTxnManager(b.ctx).GetStmtForUpdateTS()
+	_, err := sessiontxn.GetTxnManager(b.sctx).GetStmtForUpdateTS()
 	return err
 }
 
 func (b *executorBuilder) buildAnalyzeIndexPushdown(task plannercore.AnalyzeIndexTask, opts map[ast.AnalyzeOptionType]uint64, autoAnalyze string) *analyzeTask {
 	job := &statistics.AnalyzeJob{DBName: task.DBName, TableName: task.TableName, PartitionName: task.PartitionName, JobInfo: autoAnalyze + "analyze index " + task.IndexInfo.Name.O}
-	_, offset := timeutil.Zone(b.ctx.GetSessionVars().Location())
-	sc := b.ctx.GetSessionVars().StmtCtx
+	_, offset := timeutil.Zone(b.sctx.GetSessionVars().Location())
+	sc := b.sctx.GetSessionVars().StmtCtx
 	startTS, err := b.getSnapshotTS()
 	if err != nil {
 		b.err = err
@@ -3079,9 +3079,9 @@ func (b *executorBuilder) buildAnalyzeIndexPushdown(task plannercore.AnalyzeInde
 	failpoint.Inject("injectAnalyzeSnapshot", func(val failpoint.Value) {
 		startTS = uint64(val.(int))
 	})
-	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.ctx)
+	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.sctx)
 	base := baseAnalyzeExec{
-		ctx:         b.ctx,
+		ctx:         b.sctx,
 		tableID:     task.TableID,
 		concurrency: concurrency,
 		analyzePB: &tipb.AnalyzeReq{
@@ -3142,8 +3142,8 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 		}
 	}
 
-	_, offset := timeutil.Zone(b.ctx.GetSessionVars().Location())
-	sc := b.ctx.GetSessionVars().StmtCtx
+	_, offset := timeutil.Zone(b.sctx.GetSessionVars().Location())
+	sc := b.sctx.GetSessionVars().StmtCtx
 	startTS, err := b.getSnapshotTS()
 	if err != nil {
 		b.err = err
@@ -3152,7 +3152,7 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 	failpoint.Inject("injectAnalyzeSnapshot", func(val failpoint.Value) {
 		startTS = uint64(val.(int))
 	})
-	statsHandle := domain.GetDomain(b.ctx).StatsHandle()
+	statsHandle := domain.GetDomain(b.sctx).StatsHandle()
 	count, modifyCount, err := statsHandle.StatsMetaCountAndModifyCount(task.TableID.GetStatisticsID())
 	if err != nil {
 		b.err = err
@@ -3196,9 +3196,9 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 		PartitionName:    task.PartitionName,
 		SampleRateReason: sampleRateReason,
 	}
-	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.ctx)
+	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.sctx)
 	base := baseAnalyzeExec{
-		ctx:         b.ctx,
+		ctx:         b.sctx,
 		tableID:     task.TableID,
 		concurrency: concurrency,
 		analyzePB: &tipb.AnalyzeReq{
@@ -3235,7 +3235,7 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 			e.analyzePB.ColReq.PrimaryPrefixColumnIds = tables.PrimaryPrefixColumnIDs(task.TblInfo)
 		}
 	}
-	b.err = tables.SetPBColumnsDefaultValue(b.ctx.GetExprCtx(), e.analyzePB.ColReq.ColumnsInfo, task.ColsInfo)
+	b.err = tables.SetPBColumnsDefaultValue(b.sctx.GetExprCtx(), e.analyzePB.ColReq.ColumnsInfo, task.ColsInfo)
 	return &analyzeTask{taskType: colTask, colExec: e, job: job}
 }
 
@@ -3252,7 +3252,7 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 // So if we don't consider the top-n values, we can keep the sample size at 300*256.
 // But we may take some top-n before building the histogram, so we increase the sample a little.
 func (b *executorBuilder) getAdjustedSampleRate(task plannercore.AnalyzeColumnsTask) (sampleRate float64, reason string) {
-	statsHandle := domain.GetDomain(b.ctx).StatsHandle()
+	statsHandle := domain.GetDomain(b.sctx).StatsHandle()
 	defaultRate := 0.001
 	if statsHandle == nil {
 		return defaultRate, fmt.Sprintf("statsHandler is nil, use the default-rate=%v", defaultRate)
@@ -3294,13 +3294,13 @@ func (b *executorBuilder) getAdjustedSampleRate(task plannercore.AnalyzeColumnsT
 }
 
 func (b *executorBuilder) getApproximateTableCountFromStorage(tid int64, task plannercore.AnalyzeColumnsTask) (float64, bool) {
-	return pdhelper.GlobalPDHelper.GetApproximateTableCountFromStorage(context.Background(), b.ctx, tid, task.DBName, task.TableName, task.PartitionName)
+	return pdhelper.GlobalPDHelper.GetApproximateTableCountFromStorage(context.Background(), b.sctx, tid, task.DBName, task.TableName, task.PartitionName)
 }
 
 func (b *executorBuilder) buildAnalyze(v *plannercore.Analyze) exec.Executor {
-	gp := domain.GetDomain(b.ctx).StatsHandle().GPool()
+	gp := domain.GetDomain(b.sctx).StatsHandle().GPool()
 	e := &AnalyzeExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		tasks:        make([]*analyzeTask, 0, len(v.ColTasks)+len(v.IdxTasks)),
 		opts:         v.Opts,
 		OptionsMap:   v.OptionsMap,
@@ -3309,18 +3309,18 @@ func (b *executorBuilder) buildAnalyze(v *plannercore.Analyze) exec.Executor {
 		errExitCh:    make(chan struct{}),
 	}
 	autoAnalyze := ""
-	if b.ctx.GetSessionVars().InRestrictedSQL {
+	if b.sctx.GetSessionVars().InRestrictedSQL {
 		autoAnalyze = "auto "
 	}
 	// buildAnalyzeSamplingPushdown reads base count / modify_count from mysql.stats_meta
 	// while constructing column analyze tasks. Flush pending deltas first so the base
 	// values include pre-analyze changes and later delta dumps cannot double count them.
 	// TODO: Determine whether context.Background is appropriate here; if not, use the proper statement context.
-	if err := flushStatsDeltaForAnalyze(kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats), b.ctx, v); err != nil {
+	if err := flushStatsDeltaForAnalyze(kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats), b.sctx, v); err != nil {
 		b.err = err
 		return nil
 	}
-	exprCtx := b.ctx.GetExprCtx()
+	exprCtx := b.sctx.GetExprCtx()
 	for _, task := range v.ColTasks {
 		// ColumnInfos2ColumnsAndNames will use the `colInfos` to find the unique id for the column,
 		// so we need to make sure all the columns pass into it.
@@ -3575,7 +3575,7 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *physicalop.PhysicalIndexJoin) 
 	}
 
 	e := &join.IndexLookUpJoin{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), outerExec),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), outerExec),
 		OuterCtx: join.OuterCtx{
 			RowTypes:  outerTypes,
 			HashTypes: outerHashTypes,
@@ -3601,7 +3601,7 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *physicalop.PhysicalIndexJoin) 
 		colsFromChildren = colsFromChildren[:len(colsFromChildren)-1]
 	}
 	childrenUsedSchema := markChildrenUsedCols(colsFromChildren, v.Children()[0].Schema(), v.Children()[1].Schema())
-	e.Joiner = join.NewJoiner(b.ctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, leftTypes, rightTypes, childrenUsedSchema, false)
+	e.Joiner = join.NewJoiner(b.sctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, leftTypes, rightTypes, childrenUsedSchema, false)
 	outerKeyCols := make([]int, len(v.OuterJoinKeys))
 	for i := range v.OuterJoinKeys {
 		outerKeyCols[i] = v.OuterJoinKeys[i].Index
@@ -3704,7 +3704,7 @@ func (b *executorBuilder) buildIndexLookUpMergeJoin(v *physicalop.PhysicalIndexM
 	readerBuilder.indexJoinKeyUniqueIDs = innerKeyColUniqueIDs
 
 	e := &join.IndexLookUpMergeJoin{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), outerExec),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID(), outerExec),
 		OuterMergeCtx: join.OuterMergeCtx{
 			RowTypes:      outerTypes,
 			Filter:        outerFilter,
@@ -3738,7 +3738,7 @@ func (b *executorBuilder) buildIndexLookUpMergeJoin(v *physicalop.PhysicalIndexM
 	childrenUsedSchema := markChildrenUsedCols(colsFromChildren, v.Children()[0].Schema(), v.Children()[1].Schema())
 	joiners := make([]join.Joiner, e.Ctx().GetSessionVars().IndexLookupJoinConcurrency())
 	for i := range joiners {
-		joiners[i] = join.NewJoiner(b.ctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, leftTypes, rightTypes, childrenUsedSchema, false)
+		joiners[i] = join.NewJoiner(b.sctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, leftTypes, rightTypes, childrenUsedSchema, false)
 	}
 	e.Joiners = joiners
 	return e
@@ -3767,7 +3767,7 @@ func buildNoRangeTableReader(b *executorBuilder, v *physicalop.PhysicalTableRead
 	if v.StoreType == kv.TiFlash {
 		tablePlans = []base.PhysicalPlan{v.GetTablePlan()}
 	}
-	dagReq, err := builder.ConstructDAGReq(b.ctx, tablePlans, v.StoreType)
+	dagReq, err := builder.ConstructDAGReq(b.sctx, tablePlans, v.StoreType)
 	if err != nil {
 		return nil, err
 	}
@@ -3789,11 +3789,11 @@ func buildNoRangeTableReader(b *executorBuilder, v *physicalop.PhysicalTableRead
 	if err != nil {
 		return nil, err
 	}
-	paging := b.ctx.GetSessionVars().EnablePaging
+	paging := b.sctx.GetSessionVars().EnablePaging
 
 	e := &TableReaderExecutor{
-		BaseExecutorV2:             exec.NewBaseExecutorV2(b.ctx.GetSessionVars(), v.Schema(), v.ID()),
-		tableReaderExecutorContext: newTableReaderExecutorContext(b.ctx),
+		BaseExecutorV2:             exec.NewBaseExecutorV2(b.sctx.GetSessionVars(), v.Schema(), v.ID()),
+		tableReaderExecutorContext: newTableReaderExecutorContext(b.sctx),
 		indexUsageReporter:         b.buildIndexUsageReporter(v, true),
 		dagPB:                      dagReq,
 		startTS:                    startTS,
@@ -3816,11 +3816,11 @@ func buildNoRangeTableReader(b *executorBuilder, v *physicalop.PhysicalTableRead
 	}
 	e.buildVirtualColumnInfo()
 
-	if v.StoreType == kv.TiDB && b.ctx.GetSessionVars().User != nil {
+	if v.StoreType == kv.TiDB && b.sctx.GetSessionVars().User != nil {
 		// User info is used to do privilege check. It is only used in TiDB cluster memory table.
 		e.dagPB.User = &tipb.UserIdentity{
-			UserName: b.ctx.GetSessionVars().User.Username,
-			UserHost: b.ctx.GetSessionVars().User.Hostname,
+			UserName: b.sctx.GetSessionVars().User.Username,
+			UserHost: b.sctx.GetSessionVars().User.Hostname,
 		}
 	}
 
@@ -3843,11 +3843,11 @@ func (b *executorBuilder) buildMPPGather(v *physicalop.PhysicalTableReader) exec
 	}
 
 	gather := &MPPGather{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		is:           b.is,
 		originalPlan: v.GetTablePlan(),
 		startTS:      startTs,
-		mppQueryID:   kv.MPPQueryID{QueryTs: getMPPQueryTS(b.ctx), LocalQueryID: getMPPQueryID(b.ctx), ServerID: domain.GetDomain(b.ctx).ServerID()},
+		mppQueryID:   kv.MPPQueryID{QueryTs: getMPPQueryTS(b.sctx), LocalQueryID: getMPPQueryID(b.sctx), ServerID: domain.GetDomain(b.sctx).ServerID()},
 		memTracker:   memory.NewTracker(v.ID(), -1),
 
 		columns:                    []*model.ColumnInfo{},
@@ -3855,7 +3855,7 @@ func (b *executorBuilder) buildMPPGather(v *physicalop.PhysicalTableReader) exec
 		virtualColumnRetFieldTypes: []*types.FieldType{},
 	}
 
-	gather.memTracker.AttachTo(b.ctx.GetSessionVars().StmtCtx.MemTracker)
+	gather.memTracker.AttachTo(b.sctx.GetSessionVars().StmtCtx.MemTracker)
 
 	var hasVirtualCol bool
 	for _, col := range v.Schema().Columns {
@@ -3923,7 +3923,7 @@ func assertByItemsAreColumns(byItems []*plannerutil.ByItems) {
 // and then update it ranges from table scan plan.
 func (b *executorBuilder) buildTableReader(v *physicalop.PhysicalTableReader) exec.Executor {
 	failpoint.Inject("checkUseMPP", func(val failpoint.Value) {
-		if !b.ctx.GetSessionVars().InRestrictedSQL && val.(bool) != useMPPExecution(b.ctx, v) {
+		if !b.sctx.GetSessionVars().InRestrictedSQL && val.(bool) != useMPPExecution(b.sctx, v) {
 			if val.(bool) {
 				b.err = errors.New("expect mpp but not used")
 			} else {
@@ -3937,7 +3937,7 @@ func (b *executorBuilder) buildTableReader(v *physicalop.PhysicalTableReader) ex
 		v.SetSchema(v.GetTablePlan().Schema())
 	}
 
-	sctx := b.ctx.GetSessionVars().StmtCtx
+	sctx := b.sctx.GetSessionVars().StmtCtx
 	switch v.StoreType {
 	case kv.TiKV:
 		sctx.IsTiKV.Store(true)
@@ -3945,12 +3945,12 @@ func (b *executorBuilder) buildTableReader(v *physicalop.PhysicalTableReader) ex
 		sctx.IsTiFlash.Store(true)
 	}
 
-	useMPP := useMPPExecution(b.ctx, v)
+	useMPP := useMPPExecution(b.sctx, v)
 	useTiFlashBatchCop := v.ReadReqType == physicalop.BatchCop
 	useTiFlash := useMPP || useTiFlashBatchCop
 	if useTiFlash {
-		if _, isTiDBZoneLabelSet := config.GetGlobalConfig().Labels[placement.DCLabelKey]; b.ctx.GetSessionVars().TiFlashReplicaRead != tiflash.AllReplicas && !isTiDBZoneLabelSet {
-			b.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf("the variable tiflash_replica_read is ignored, because the entry TiDB[%s] does not set the zone attribute and tiflash_replica_read is '%s'", config.GetGlobalConfig().AdvertiseAddress, tiflash.GetTiFlashReplicaRead(b.ctx.GetSessionVars().TiFlashReplicaRead)))
+		if _, isTiDBZoneLabelSet := config.GetGlobalConfig().Labels[placement.DCLabelKey]; b.sctx.GetSessionVars().TiFlashReplicaRead != tiflash.AllReplicas && !isTiDBZoneLabelSet {
+			b.sctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf("the variable tiflash_replica_read is ignored, because the entry TiDB[%s] does not set the zone attribute and tiflash_replica_read is '%s'", config.GetGlobalConfig().AdvertiseAddress, tiflash.GetTiFlashReplicaRead(b.sctx.GetSessionVars().TiFlashReplicaRead)))
 		}
 	}
 	if useMPP {
@@ -3977,7 +3977,7 @@ func (b *executorBuilder) buildTableReader(v *physicalop.PhysicalTableReader) ex
 	ret.groupByColIdxs = ts.GroupByColIdxs
 	sctx.TableIDs = append(sctx.TableIDs, ts.Table.ID)
 
-	if !b.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
+	if !b.sctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
 		return ret
 	}
 	// When isPartition is set, it means the union rewriting is done, so a partition reader is preferred.
@@ -3992,7 +3992,7 @@ func (b *executorBuilder) buildTableReader(v *physicalop.PhysicalTableReader) ex
 
 	tmp, _ := b.is.TableByID(context.Background(), ts.Table.ID)
 	tbl := tmp.(table.PartitionedTable)
-	partitions, err := partitionPruning(b.ctx, tbl, v.PlanPartInfo)
+	partitions, err := partitionPruning(b.sctx, tbl, v.PlanPartInfo)
 	if err != nil {
 		b.err = err
 		return nil
@@ -4089,7 +4089,7 @@ func (builder *dataReaderBuilder) groupIndexJoinLookUpContentsByPartition(
 	}
 	contentsByPID := make(map[int64][]*join.IndexJoinLookUpContent, len(usedPartitions))
 	locateKey := make([]types.Datum, len(pt.Cols()))
-	exprCtx := builder.ctx.GetExprCtx()
+	exprCtx := builder.sctx.GetExprCtx()
 	for _, content := range lookUpContents {
 		for i, data := range content.Keys {
 			locateKey[keyColOffsets[i]] = data
@@ -4264,7 +4264,7 @@ func (builder *dataReaderBuilder) prunePartitionForInnerExecutor(tbl table.Table
 	locateKey := make([]types.Datum, len(partitionTbl.Cols()))
 	partitions := make(map[int64]table.PhysicalTable)
 	contentPos = make([]int64, len(lookUpContent))
-	exprCtx := builder.ctx.GetExprCtx()
+	exprCtx := builder.sctx.GetExprCtx()
 	for idx, content := range lookUpContent {
 		for i, data := range content.Keys {
 			locateKey[keyColOffsets[i]] = data
@@ -4297,7 +4297,7 @@ func (builder *dataReaderBuilder) prunePartitionForInnerExecutor(tbl table.Table
 }
 
 func buildNoRangeIndexReader(b *executorBuilder, v *physicalop.PhysicalIndexReader) (*IndexReaderExecutor, error) {
-	dagReq, err := builder.ConstructDAGReq(b.ctx, v.IndexPlans, kv.TiKV)
+	dagReq, err := builder.ConstructDAGReq(b.sctx, v.IndexPlans, kv.TiKV)
 	if err != nil {
 		return nil, err
 	}
@@ -4314,13 +4314,13 @@ func buildNoRangeIndexReader(b *executorBuilder, v *physicalop.PhysicalIndexRead
 	if err != nil {
 		return nil, err
 	}
-	paging := b.ctx.GetSessionVars().EnablePaging
+	paging := b.sctx.GetSessionVars().EnablePaging
 
-	b.ctx.GetSessionVars().StmtCtx.IsTiKV.Store(true)
+	b.sctx.GetSessionVars().StmtCtx.IsTiKV.Store(true)
 
 	e := &IndexReaderExecutor{
-		indexReaderExecutorContext: newIndexReaderExecutorContext(b.ctx),
-		BaseExecutorV2:             exec.NewBaseExecutorV2(b.ctx.GetSessionVars(), v.Schema(), v.ID()),
+		indexReaderExecutorContext: newIndexReaderExecutorContext(b.sctx),
+		BaseExecutorV2:             exec.NewBaseExecutorV2(b.sctx.GetSessionVars(), v.Schema(), v.ID()),
 		indexUsageReporter:         b.buildIndexUsageReporter(v, true),
 		dagPB:                      dagReq,
 		startTS:                    startTS,
@@ -4371,10 +4371,10 @@ func (b *executorBuilder) buildIndexReader(v *physicalop.PhysicalIndexReader) ex
 	}
 
 	ret.ranges = is.Ranges
-	sctx := b.ctx.GetSessionVars().StmtCtx
+	sctx := b.sctx.GetSessionVars().StmtCtx
 	sctx.IndexNames = append(sctx.IndexNames, is.Table.Name.O+":"+is.Index.Name.O)
 
-	if !b.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
+	if !b.sctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
 		return ret
 	}
 	// When isPartition is set, it means the union rewriting is done, so a partition reader is preferred.
@@ -4388,7 +4388,7 @@ func (b *executorBuilder) buildIndexReader(v *physicalop.PhysicalIndexReader) ex
 	}
 
 	if is.Index.Global {
-		ret.partitionIDMap, err = getPartitionIDsAfterPruning(b.ctx, ret.table.(table.PartitionedTable), v.PlanPartInfo)
+		ret.partitionIDMap, err = getPartitionIDsAfterPruning(b.sctx, ret.table.(table.PartitionedTable), v.PlanPartInfo)
 		if err != nil {
 			b.err = err
 			return nil
@@ -4398,7 +4398,7 @@ func (b *executorBuilder) buildIndexReader(v *physicalop.PhysicalIndexReader) ex
 
 	tmp, _ := b.is.TableByID(context.Background(), is.Table.ID)
 	tbl := tmp.(table.PartitionedTable)
-	partitions, err := partitionPruning(b.ctx, tbl, v.PlanPartInfo)
+	partitions, err := partitionPruning(b.sctx, tbl, v.PlanPartInfo)
 	if err != nil {
 		b.err = err
 		return nil
@@ -4408,7 +4408,7 @@ func (b *executorBuilder) buildIndexReader(v *physicalop.PhysicalIndexReader) ex
 }
 
 func buildTableReq(b *executorBuilder, schemaLen int, plans []base.PhysicalPlan) (dagReq *tipb.DAGRequest, val table.Table, err error) {
-	tableReq, err := builder.ConstructDAGReq(b.ctx, plans, kv.TiKV)
+	tableReq, err := builder.ConstructDAGReq(b.sctx, plans, kv.TiKV)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -4537,9 +4537,9 @@ func buildNoRangeIndexLookUpReader(b *executorBuilder, v *physicalop.PhysicalInd
 	var indexReq *tipb.DAGRequest
 	var err error
 	if v.IndexLookUpPushDown {
-		indexReq, err = buildIndexLookUpPushDownDAGReq(b.ctx, is.Index.Columns, handleLen, v.IndexPlans, v.IndexPlansUnNatureOrders)
+		indexReq, err = buildIndexLookUpPushDownDAGReq(b.sctx, is.Index.Columns, handleLen, v.IndexPlans, v.IndexPlansUnNatureOrders)
 	} else {
-		indexReq, err = buildIndexReq(b.ctx, is.Index.Columns, handleLen, v.IndexPlans)
+		indexReq, err = buildIndexReq(b.sctx, is.Index.Columns, handleLen, v.IndexPlans)
 	}
 	if err != nil {
 		return nil, err
@@ -4563,11 +4563,11 @@ func buildNoRangeIndexLookUpReader(b *executorBuilder, v *physicalop.PhysicalInd
 		return nil, err
 	}
 
-	b.ctx.GetSessionVars().StmtCtx.IsTiKV.Store(true)
+	b.sctx.GetSessionVars().StmtCtx.IsTiKV.Store(true)
 
 	e := &IndexLookUpExecutor{
-		indexLookUpExecutorContext: newIndexLookUpExecutorContext(b.ctx),
-		BaseExecutorV2:             exec.NewBaseExecutorV2(b.ctx.GetSessionVars(), v.Schema(), v.ID()),
+		indexLookUpExecutorContext: newIndexLookUpExecutorContext(b.sctx),
+		BaseExecutorV2:             exec.NewBaseExecutorV2(b.sctx.GetSessionVars(), v.Schema(), v.ID()),
 		indexUsageReporter:         b.buildIndexUsageReporter(v, true),
 		dagPB:                      indexReq,
 		startTS:                    startTS,
@@ -4635,11 +4635,11 @@ func (b *executorBuilder) buildIndexLookUpReader(v *physicalop.PhysicalIndexLook
 	ret.ranges = is.Ranges
 	executor_metrics.ExecutorCounterIndexLookUpExecutor.Inc()
 
-	sctx := b.ctx.GetSessionVars().StmtCtx
+	sctx := b.sctx.GetSessionVars().StmtCtx
 	sctx.IndexNames = append(sctx.IndexNames, is.Table.Name.O+":"+is.Index.Name.O)
 	sctx.TableIDs = append(sctx.TableIDs, ts.Table.ID)
 
-	if !b.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
+	if !b.sctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
 		return ret
 	}
 
@@ -4648,7 +4648,7 @@ func (b *executorBuilder) buildIndexLookUpReader(v *physicalop.PhysicalIndexLook
 	}
 
 	if is.Index.Global {
-		ret.partitionIDMap, err = getPartitionIDsAfterPruning(b.ctx, ret.table.(table.PartitionedTable), v.PlanPartInfo)
+		ret.partitionIDMap, err = getPartitionIDsAfterPruning(b.sctx, ret.table.(table.PartitionedTable), v.PlanPartInfo)
 		if err != nil {
 			b.err = err
 			return nil
@@ -4663,7 +4663,7 @@ func (b *executorBuilder) buildIndexLookUpReader(v *physicalop.PhysicalIndexLook
 
 	tmp, _ := b.is.TableByID(context.Background(), is.Table.ID)
 	tbl := tmp.(table.PartitionedTable)
-	partitions, err := partitionPruning(b.ctx, tbl, v.PlanPartInfo)
+	partitions, err := partitionPruning(b.sctx, tbl, v.PlanPartInfo)
 	if err != nil {
 		b.err = err
 		return nil
@@ -4688,7 +4688,7 @@ func buildNoRangeIndexMergeReader(b *executorBuilder, v *physicalop.PhysicalInde
 		var err error
 
 		if is, ok := v.PartialPlans[i][0].(*physicalop.PhysicalIndexScan); ok {
-			tempReq, err = buildIndexReq(b.ctx, is.Index.Columns, ts.HandleCols.NumCols(), v.PartialPlans[i])
+			tempReq, err = buildIndexReq(b.sctx, is.Index.Columns, ts.HandleCols.NumCols(), v.PartialPlans[i])
 			descs = append(descs, is.Desc)
 			indexes = append(indexes, is.Index)
 			if is.Index.Global {
@@ -4725,10 +4725,10 @@ func buildNoRangeIndexMergeReader(b *executorBuilder, v *physicalop.PhysicalInde
 		return nil, err
 	}
 
-	b.ctx.GetSessionVars().StmtCtx.IsTiKV.Store(true)
+	b.sctx.GetSessionVars().StmtCtx.IsTiKV.Store(true)
 
 	e := &IndexMergeReaderExecutor{
-		BaseExecutor:             exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor:             exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		indexUsageReporter:       b.buildIndexUsageReporter(v, true),
 		dagPBs:                   partialReqs,
 		startTS:                  startTS,
@@ -4781,7 +4781,7 @@ func buildIndexUsageReporter(ctx sessionctx.Context, plan tableStatsPreloader, l
 }
 
 func (b *executorBuilder) buildIndexUsageReporter(plan tableStatsPreloader, loadStats bool) (indexUsageReporter *exec.IndexUsageReporter) {
-	return buildIndexUsageReporter(b.ctx, plan, loadStats)
+	return buildIndexUsageReporter(b.sctx, plan, loadStats)
 }
 
 func (b *executorBuilder) buildIndexMergeReader(v *physicalop.PhysicalIndexMergeReader) exec.Executor {
@@ -4792,7 +4792,7 @@ func (b *executorBuilder) buildIndexMergeReader(v *physicalop.PhysicalIndexMerge
 		})
 	}
 	if len(v.TablePlans) == 0 {
-		if b.ctx.GetSessionVars().StmtCtx.InExplainStmt && !b.ctx.GetSessionVars().StmtCtx.InExplainAnalyzeStmt {
+		if b.sctx.GetSessionVars().StmtCtx.InExplainStmt && !b.sctx.GetSessionVars().StmtCtx.InExplainAnalyzeStmt {
 			// Plain EXPLAIN doesn't execute the target plan, allow displaying planner output here.
 			return nil
 		}
@@ -4812,7 +4812,7 @@ func (b *executorBuilder) buildIndexMergeReader(v *physicalop.PhysicalIndexMerge
 		return nil
 	}
 	ret.ranges = make([][]*ranger.Range, 0, len(v.PartialPlans))
-	sctx := b.ctx.GetSessionVars().StmtCtx
+	sctx := b.sctx.GetSessionVars().StmtCtx
 	hasGlobalIndex := false
 	for i := range v.PartialPlans {
 		if is, ok := v.PartialPlans[i][0].(*physicalop.PhysicalIndexScan); ok {
@@ -4835,7 +4835,7 @@ func (b *executorBuilder) buildIndexMergeReader(v *physicalop.PhysicalIndexMerge
 	sctx.TableIDs = append(sctx.TableIDs, ts.Table.ID)
 	executor_metrics.ExecutorCounterIndexMergeReaderExecutor.Inc()
 
-	if !b.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
+	if !b.sctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
 		return ret
 	}
 
@@ -4844,7 +4844,7 @@ func (b *executorBuilder) buildIndexMergeReader(v *physicalop.PhysicalIndexMerge
 	}
 
 	tmp, _ := b.is.TableByID(context.Background(), ts.Table.ID)
-	partitions, err := partitionPruning(b.ctx, tmp.(table.PartitionedTable), v.PlanPartInfo)
+	partitions, err := partitionPruning(b.sctx, tmp.(table.PartitionedTable), v.PlanPartInfo)
 	if err != nil {
 		b.err = err
 		return nil
@@ -4935,8 +4935,8 @@ func (builder *dataReaderBuilder) buildExecutorForIndexJoinInternal(ctx context.
 			return nil, err
 		}
 		exec := &SelectionExec{
-			selectionExecutorContext: newSelectionExecutorContext(builder.ctx),
-			BaseExecutorV2:           exec.NewBaseExecutorV2(builder.ctx.GetSessionVars(), v.Schema(), v.ID(), childExec),
+			selectionExecutorContext: newSelectionExecutorContext(builder.sctx),
+			BaseExecutorV2:           exec.NewBaseExecutorV2(builder.sctx.GetSessionVars(), v.Schema(), v.ID(), childExec),
 			filters:                  v.Conditions,
 		}
 		err = exec.open(ctx)
@@ -5018,7 +5018,7 @@ func (builder *dataReaderBuilder) buildHashJoinForIndexJoin(ctx context.Context,
 }
 
 func (builder *dataReaderBuilder) buildIndexJoinHashJoinExecFromChildExecs(childExecs []exec.Executor, v *physicalop.PhysicalHashJoin) (exec.Executor, error) {
-	if builder.ctx.GetSessionVars().UseHashJoinV2 && joinversion.IsHashJoinV2Supported() && v.CanUseHashJoinV2() {
+	if builder.sctx.GetSessionVars().UseHashJoinV2 && joinversion.IsHashJoinV2Supported() && v.CanUseHashJoinV2() {
 		joinExecV2 := builder.executorBuilder.buildHashJoinV2FromChildExecs(childExecs[0], childExecs[1], v)
 		if builder.executorBuilder.err != nil {
 			return nil, builder.executorBuilder.err
@@ -5117,7 +5117,7 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 		return nil, err
 	}
 	tbInfo := e.table.Meta()
-	if tbInfo.GetPartitionInfo() == nil || !builder.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
+	if tbInfo.GetPartitionInfo() == nil || !builder.sctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
 		if v.IsCommonHandle {
 			kvRanges, err := buildKvRangesForIndexJoin(e.dctx, e.rctx, getPhysicalTableID(e.table), -1, lookUpContents, indexRanges, keyOff2IdxOff, cwc, memTracker, interruptSignal)
 			if err != nil {
@@ -5251,7 +5251,7 @@ func (builder *dataReaderBuilder) buildTableReaderBase(ctx context.Context, e *T
 	}
 	e.kvRanges = kvReq.KeyRanges.AppendSelfTo(e.kvRanges)
 	e.resultHandler = &tableResultHandler{}
-	result, err := builder.SelectResult(ctx, builder.ctx.GetDistSQLCtx(), kvReq, exec.RetTypes(e), getPhysicalPlanIDs(e.plans), e.ID())
+	result, err := builder.SelectResult(ctx, builder.sctx.GetDistSQLCtx(), kvReq, exec.RetTypes(e), getPhysicalPlanIDs(e.plans), e.ID())
 	if err != nil {
 		return nil, err
 	}
@@ -5292,7 +5292,7 @@ func (builder *dataReaderBuilder) buildIndexReaderForIndexJoin(ctx context.Conte
 		return nil, err
 	}
 	tbInfo := e.table.Meta()
-	if tbInfo.GetPartitionInfo() == nil || !builder.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
+	if tbInfo.GetPartitionInfo() == nil || !builder.sctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
 		kvRanges, err := buildKvRangesForIndexJoin(e.dctx, e.rctx, e.physicalTableID, e.index.ID, lookUpContents, indexRanges, keyOff2IdxOff, cwc, memoryTracker, interruptSignal)
 		if err != nil {
 			return nil, err
@@ -5303,7 +5303,7 @@ func (builder *dataReaderBuilder) buildIndexReaderForIndexJoin(ctx context.Conte
 
 	is := v.IndexPlans[0].(*physicalop.PhysicalIndexScan)
 	if is.Index.Global {
-		e.partitionIDMap, err = getPartitionIDsAfterPruning(builder.ctx, e.table.(table.PartitionedTable), v.PlanPartInfo)
+		e.partitionIDMap, err = getPartitionIDsAfterPruning(builder.sctx, e.table.(table.PartitionedTable), v.PlanPartInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -5348,7 +5348,7 @@ func (builder *dataReaderBuilder) buildIndexLookUpReaderForIndexJoin(ctx context
 	}
 
 	tbInfo := e.table.Meta()
-	if tbInfo.GetPartitionInfo() == nil || !builder.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
+	if tbInfo.GetPartitionInfo() == nil || !builder.sctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
 		kvRange, err := buildKvRangesForIndexJoin(e.dctx, e.rctx, getPhysicalTableID(e.table), e.index.ID, lookUpContents, indexRanges, keyOff2IdxOff, cwc, memTracker, interruptSignal)
 		if err != nil {
 			return nil, err
@@ -5363,7 +5363,7 @@ func (builder *dataReaderBuilder) buildIndexLookUpReaderForIndexJoin(ctx context
 
 	is := v.IndexPlans[0].(*physicalop.PhysicalIndexScan)
 	if is.Index.Global {
-		e.partitionIDMap, err = getPartitionIDsAfterPruning(builder.ctx, e.table.(table.PartitionedTable), v.PlanPartInfo)
+		e.partitionIDMap, err = getPartitionIDsAfterPruning(builder.sctx, e.table.(table.PartitionedTable), v.PlanPartInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -5561,7 +5561,7 @@ func (b *executorBuilder) buildWindow(v *physicalop.PhysicalWindow) exec.Executo
 	if b.err != nil {
 		return nil
 	}
-	exec, err := windowexec.Build(b.ctx, v, childExec, false)
+	exec, err := windowexec.Build(b.sctx, v, childExec, false)
 	if err != nil {
 		b.err = err
 		return nil
@@ -5570,7 +5570,7 @@ func (b *executorBuilder) buildWindow(v *physicalop.PhysicalWindow) exec.Executo
 }
 
 func (b *executorBuilder) buildShuffle(v *physicalop.PhysicalShuffle) *ShuffleExec {
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID())
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID())
 	shuffle := &ShuffleExec{
 		BaseExecutor: base,
 		concurrency:  v.Concurrency,
@@ -5585,7 +5585,7 @@ func (b *executorBuilder) buildShuffle(v *physicalop.PhysicalShuffle) *ShuffleEx
 		}
 	case physicalop.PartitionRangeSplitterType:
 		for i, byItems := range v.ByItemArrays {
-			splitters[i] = buildPartitionRangeSplitter(b.ctx, shuffle.concurrency, byItems)
+			splitters[i] = buildPartitionRangeSplitter(b.sctx, shuffle.concurrency, byItems)
 		}
 	default:
 		panic("Not implemented. Should not reach here.")
@@ -5609,7 +5609,7 @@ func (b *executorBuilder) buildShuffle(v *physicalop.PhysicalShuffle) *ShuffleEx
 	for _, dataSource := range v.DataSources {
 		stub := physicalop.PhysicalShuffleReceiverStub{
 			DataSource: dataSource,
-		}.Init(b.ctx.GetPlanCtx(), dataSource.StatsInfo(), dataSource.QueryBlockOffset(), nil)
+		}.Init(b.sctx.GetPlanCtx(), dataSource.StatsInfo(), dataSource.QueryBlockOffset(), nil)
 		stub.SetSchema(dataSource.Schema())
 		stubs = append(stubs, stub)
 	}
@@ -5618,7 +5618,7 @@ func (b *executorBuilder) buildShuffle(v *physicalop.PhysicalShuffle) *ShuffleEx
 		receivers := make([]*shuffleReceiver, len(v.DataSources))
 		for j, dataSource := range v.DataSources {
 			receivers[j] = &shuffleReceiver{
-				BaseExecutor: exec.NewBaseExecutor(b.ctx, dataSource.Schema(), stubs[j].ID()),
+				BaseExecutor: exec.NewBaseExecutor(b.sctx, dataSource.Schema(), stubs[j].ID()),
 			}
 		}
 
@@ -5648,7 +5648,7 @@ func (*executorBuilder) buildShuffleReceiverStub(v *physicalop.PhysicalShuffleRe
 }
 
 func (b *executorBuilder) buildSQLBindExec(v *plannercore.SQLBindPlan) exec.Executor {
-	base := exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID())
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID())
 	base.SetInitCap(chunk.ZeroCapacity)
 
 	e := &SQLBindExec{
@@ -5727,7 +5727,7 @@ func (b *executorBuilder) buildBatchPointGet(plan *physicalop.BatchPointGetPlan)
 			b.inSelectLockStmt = false
 		}()
 	}
-	handles, isTableDual, err := plan.PrunePartitionsAndValues(b.ctx)
+	handles, isTableDual, err := plan.PrunePartitionsAndValues(b.sctx)
 	if err != nil {
 		b.err = err
 		return nil
@@ -5735,16 +5735,16 @@ func (b *executorBuilder) buildBatchPointGet(plan *physicalop.BatchPointGetPlan)
 	if isTableDual {
 		// No matching partitions
 		return &TableDualExec{
-			BaseExecutorV2: exec.NewBaseExecutorV2(b.ctx.GetSessionVars(), plan.Schema(), plan.ID()),
+			BaseExecutorV2: exec.NewBaseExecutorV2(b.sctx.GetSessionVars(), plan.Schema(), plan.ID()),
 			numDualRows:    0,
 		}
 	}
 
-	b.ctx.GetSessionVars().StmtCtx.IsTiKV.Store(true)
+	b.sctx.GetSessionVars().StmtCtx.IsTiKV.Store(true)
 
-	decoder := NewRowDecoder(b.ctx, plan.Schema(), plan.TblInfo)
+	decoder := NewRowDecoder(b.sctx, plan.Schema(), plan.TblInfo)
 	e := &BatchPointGetExec{
-		BaseExecutor:       exec.NewBaseExecutor(b.ctx, plan.Schema(), plan.ID()),
+		BaseExecutor:       exec.NewBaseExecutor(b.sctx, plan.Schema(), plan.ID()),
 		indexUsageReporter: b.buildIndexUsageReporter(plan, true),
 		tblInfo:            plan.TblInfo,
 		idxInfo:            plan.IndexInfo,
@@ -5776,7 +5776,7 @@ func (b *executorBuilder) buildBatchPointGet(plan *physicalop.BatchPointGetPlan)
 	}
 
 	if plan.IndexInfo != nil {
-		sctx := b.ctx.GetSessionVars().StmtCtx
+		sctx := b.sctx.GetSessionVars().StmtCtx
 		sctx.IndexNames = append(sctx.IndexNames, plan.TblInfo.Name.O+":"+plan.IndexInfo.Name.O)
 	}
 
@@ -5860,7 +5860,7 @@ func (builder *dataReaderBuilder) partitionPruning(tbl table.PartitionedTable, p
 		builder.once = &dataReaderBuilderOnce{}
 	}
 	builder.once.Do(func() {
-		condPruneResult, err := partitionPruning(builder.executorBuilder.ctx, tbl, planPartInfo)
+		condPruneResult, err := partitionPruning(builder.executorBuilder.sctx, tbl, planPartInfo)
 		builder.once.condPruneResult = condPruneResult
 		builder.once.err = err
 	})
@@ -5949,9 +5949,9 @@ func (b *executorBuilder) buildTableSample(v *physicalop.PhysicalTableSample) *T
 		b.err = err
 		return nil
 	}
-	b.ctx.GetSessionVars().StmtCtx.IsTiKV.Store(true)
+	b.sctx.GetSessionVars().StmtCtx.IsTiKV.Store(true)
 	e := &TableSampleExecutor{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		table:        v.TableInfo,
 		startTS:      startTS,
 	}
@@ -5965,7 +5965,7 @@ func (b *executorBuilder) buildTableSample(v *physicalop.PhysicalTableSample) *T
 		e.sampler = &emptySampler{}
 	} else if v.TableSampleInfo.AstNode.SampleMethod == ast.SampleMethodTypeTiDBRegion {
 		e.sampler = newTableRegionSampler(
-			b.ctx, v.TableInfo, startTS, v.PhysicalTableID, v.TableSampleInfo.Partitions, v.Schema(),
+			b.sctx, v.TableInfo, startTS, v.PhysicalTableID, v.TableSampleInfo.Partitions, v.Schema(),
 			v.TableSampleInfo.FullSchema, e.RetFieldTypes(), v.Desc)
 	}
 
@@ -6003,7 +6003,7 @@ func (b *executorBuilder) buildCTE(v *physicalop.PhysicalCTE) exec.Executor {
 	}
 
 	return &CTEExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		producer:     producer,
 	}
 }
@@ -6012,7 +6012,7 @@ func (b *executorBuilder) loadCTEStorages(storageID int) (*CTEStorages, error) {
 	var storages *CTEStorages
 	var ok bool
 	b.withStmtCtxLock(func() {
-		storageMap, castOK := b.ctx.GetSessionVars().StmtCtx.CTEStorageMap.(map[int]*CTEStorages)
+		storageMap, castOK := b.sctx.GetSessionVars().StmtCtx.CTEStorageMap.(map[int]*CTEStorages)
 		ok = castOK
 		if !castOK {
 			return
@@ -6029,7 +6029,7 @@ func (b *executorBuilder) loadOrStoreCTEStorages(storageID int) (*CTEStorages, e
 	var storages *CTEStorages
 	var ok bool
 	b.withStmtCtxLock(func() {
-		storageMap, castOK := b.ctx.GetSessionVars().StmtCtx.CTEStorageMap.(map[int]*CTEStorages)
+		storageMap, castOK := b.sctx.GetSessionVars().StmtCtx.CTEStorageMap.(map[int]*CTEStorages)
 		ok = castOK
 		if !castOK {
 			return
@@ -6059,7 +6059,7 @@ func (b *executorBuilder) buildCTEStorageProducer(v *physicalop.PhysicalCTE, sto
 	}
 
 	// Setup storages.
-	chkSize := b.ctx.GetSessionVars().MaxChunkSize
+	chkSize := b.sctx.GetSessionVars().MaxChunkSize
 	tps := seedExec.RetFieldTypes()
 	resTbl := cteutil.NewStorageRowContainer(tps, chkSize)
 	if err := resTbl.OpenAndRef(); err != nil {
@@ -6110,7 +6110,7 @@ func (b *executorBuilder) buildCTEStorageProducer(v *physicalop.PhysicalCTE, sto
 	}
 
 	producer := &cteProducer{
-		ctx:             b.ctx,
+		ctx:             b.sctx,
 		seedExec:        seedExec,
 		recursiveExec:   recursiveExec,
 		resTbl:          resTbl,
@@ -6146,7 +6146,7 @@ func (b *executorBuilder) buildCTETableReader(v *physicalop.PhysicalCTETable) ex
 		return nil
 	}
 	return &CTETableReaderExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		iterInTbl:    iterInTbl,
 		chkIdx:       0,
 	}
@@ -6165,7 +6165,7 @@ func (b *executorBuilder) validCanReadCacheTable(tbl *model.TableInfo) error {
 		return nil
 	}
 
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := b.sctx.GetSessionVars()
 
 	// Temporary table can't switch into cache table. so the following code will not cause confusion
 	if sessionVars.TxnCtx.IsStaleness || b.isStaleness {
@@ -6183,7 +6183,7 @@ func (b *executorBuilder) validCanReadTemporaryTable(tbl *model.TableInfo) error
 	// Some tools like dumpling use history read to dump all table's records and will be fail if we return an error.
 	// So we do not check SnapshotTS here
 
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := b.sctx.GetSessionVars()
 
 	if tbl.TempTableType == model.TempTableLocal && sessionVars.SnapshotTS != 0 {
 		return errors.New("can not read local temporary table when 'tidb_snapshot' is set")
@@ -6199,10 +6199,10 @@ func (b *executorBuilder) validCanReadTemporaryTable(tbl *model.TableInfo) error
 func (b *executorBuilder) getCacheTable(tblInfo *model.TableInfo, startTS uint64) kv.MemBuffer {
 	tbl, ok := b.is.TableByID(context.Background(), tblInfo.ID)
 	if !ok {
-		b.err = errors.Trace(infoschema.ErrTableNotExists.GenWithStackByArgs(b.ctx.GetSessionVars().CurrentDB, tblInfo.Name))
+		b.err = errors.Trace(infoschema.ErrTableNotExists.GenWithStackByArgs(b.sctx.GetSessionVars().CurrentDB, tblInfo.Name))
 		return nil
 	}
-	sessVars := b.ctx.GetSessionVars()
+	sessVars := b.sctx.GetSessionVars()
 	leaseDuration := time.Duration(vardef.TableCacheLease.Load()) * time.Second
 	cacheData, loading := tbl.(table.CachedTable).TryReadFromCache(startTS, leaseDuration)
 	if cacheData != nil {
@@ -6211,8 +6211,8 @@ func (b *executorBuilder) getCacheTable(tblInfo *model.TableInfo, startTS uint64
 	} else if loading {
 		return nil
 	}
-	if !b.ctx.GetSessionVars().StmtCtx.InExplainStmt && !b.inDeleteStmt && !b.inUpdateStmt {
-		tbl.(table.CachedTable).UpdateLockForRead(context.Background(), b.ctx.GetStore(), startTS, leaseDuration)
+	if !b.sctx.GetSessionVars().StmtCtx.InExplainStmt && !b.inDeleteStmt && !b.inUpdateStmt {
+		tbl.(table.CachedTable).UpdateLockForRead(context.Background(), b.sctx.GetStore(), startTS, leaseDuration)
 	}
 	return nil
 }
@@ -6223,7 +6223,7 @@ func (b *executorBuilder) buildCompactTable(v *plannercore.CompactTable) exec.Ex
 		return nil
 	}
 
-	store := b.ctx.GetStore()
+	store := b.sctx.GetStore()
 	tikvStore, ok := store.(tikv.Storage)
 	if !ok {
 		b.err = errors.New("compact tiflash replica can only run with tikv compatible storage")
@@ -6257,7 +6257,7 @@ func (b *executorBuilder) buildCompactTable(v *plannercore.CompactTable) exec.Ex
 	}
 
 	return &CompactTableTiFlashExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		tableInfo:    v.TableInfo,
 		partitionIDs: partitionIDs,
 		tikvStore:    tikvStore,
@@ -6265,12 +6265,12 @@ func (b *executorBuilder) buildCompactTable(v *plannercore.CompactTable) exec.Ex
 }
 
 func (b *executorBuilder) buildAdminShowBDRRole(v *plannercore.AdminShowBDRRole) exec.Executor {
-	return &AdminShowBDRRoleExec{BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID())}
+	return &AdminShowBDRRoleExec{BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID())}
 }
 
 func (b *executorBuilder) buildRecommendIndex(v *plannercore.RecommendIndexPlan) exec.Executor {
 	return &RecommendIndexExec{
-		BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
+		BaseExecutor: exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID()),
 		Action:       v.Action,
 		SQL:          v.SQL,
 		AdviseID:     v.AdviseID,
@@ -6279,6 +6279,6 @@ func (b *executorBuilder) buildRecommendIndex(v *plannercore.RecommendIndexPlan)
 }
 
 func (b *executorBuilder) buildWorkloadRepoCreate(_ *plannercore.WorkloadRepoCreate) exec.Executor {
-	base := exec.NewBaseExecutor(b.ctx, nil, 0)
+	base := exec.NewBaseExecutor(b.sctx, nil, 0)
 	return &WorkloadRepoCreateExec{base}
 }

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -104,6 +104,9 @@ import (
 // executorBuilder builds an Executor from a Plan.
 // The InfoSchema must not change during execution.
 type executorBuilder struct {
+	// ctx is the statement-scoped context.Context for executor build steps that
+	// can block before Executor.Open/Next receives the execution context.
+	ctx     context.Context
 	sctx    sessionctx.Context
 	is      infoschema.InfoSchema
 	err     error // err is set when there is error happened during Executor building process.
@@ -146,9 +149,10 @@ type CTEStorages struct {
 	initErr error
 }
 
-func newExecutorBuilder(sctx sessionctx.Context, is infoschema.InfoSchema, ti *TelemetryInfo) *executorBuilder {
+func newExecutorBuilder(ctx context.Context, sctx sessionctx.Context, is infoschema.InfoSchema, ti *TelemetryInfo) *executorBuilder {
 	txnManager := sessiontxn.GetTxnManager(sctx)
 	return &executorBuilder{
+		ctx:              ctx,
 		sctx:             sctx,
 		is:               is,
 		Ti:               ti,
@@ -177,7 +181,7 @@ type MockExecutorBuilder struct {
 // NewMockExecutorBuilderForTest is ONLY used in test.
 func NewMockExecutorBuilderForTest(ctx sessionctx.Context, is infoschema.InfoSchema, ti *TelemetryInfo) *MockExecutorBuilder {
 	return &MockExecutorBuilder{
-		executorBuilder: newExecutorBuilder(ctx, is, ti),
+		executorBuilder: newExecutorBuilder(context.Background(), ctx, is, ti),
 	}
 }
 
@@ -3315,8 +3319,8 @@ func (b *executorBuilder) buildAnalyze(v *plannercore.Analyze) exec.Executor {
 	// buildAnalyzeSamplingPushdown reads base count / modify_count from mysql.stats_meta
 	// while constructing column analyze tasks. Flush pending deltas first so the base
 	// values include pre-analyze changes and later delta dumps cannot double count them.
-	// TODO: Determine whether context.Background is appropriate here; if not, use the proper statement context.
-	if err := flushStatsDeltaForAnalyze(kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats), b.sctx, v); err != nil {
+	intest.Assert(b.ctx != nil, "missing statement context for analyze")
+	if err := flushStatsDeltaForAnalyze(kv.WithInternalSourceType(b.ctx, kv.InternalTxnStats), b.sctx, v); err != nil {
 		b.err = err
 		return nil
 	}

--- a/pkg/executor/builder_index_join_cleanup_test.go
+++ b/pkg/executor/builder_index_join_cleanup_test.go
@@ -81,7 +81,7 @@ func TestBuildExecutorForIndexJoinHashJoinErrorCleansChildren(t *testing.T) {
 	hashJoinPlan.SetSchema(expression.MergeSchema(lookupSchema, otherSchema))
 	hashJoinPlan.SetChildren(lookupMockPlan, otherMockPlan)
 
-	execBuilder := newExecutorBuilder(ctx, nil, nil)
+	execBuilder := newExecutorBuilder(context.Background(), ctx, nil, nil)
 	execBuilder.forDataReaderBuilder = true
 	execBuilder.dataReaderTS = 1
 	readerBuilder, err := execBuilder.newDataReaderBuilder(hashJoinPlan)
@@ -106,7 +106,7 @@ func TestBuildExecutorForIndexJoinHashJoinErrorCleansChildren(t *testing.T) {
 func TestBuildCTEStorageProducerCleansStoragesOnRecursiveBuildError(t *testing.T) {
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().StmtCtx.CTEStorageMap = map[int]*CTEStorages{}
-	builder := newExecutorBuilder(ctx, nil, nil)
+	builder := newExecutorBuilder(context.Background(), ctx, nil, nil)
 
 	stats := &property.StatsInfo{RowCount: 1}
 	schema := expression.NewSchema(&expression.Column{

--- a/pkg/executor/coprocessor.go
+++ b/pkg/executor/coprocessor.go
@@ -199,7 +199,7 @@ func (h *CoprocessorDAGHandler) buildDAGExecutor(ctx context.Context, req *copro
 	}
 	plan = core.InjectExtraProjection(plan)
 	// Build executor.
-	b := newExecutorBuilder(h.sctx, is, nil)
+	b := newExecutorBuilder(ctx, h.sctx, is, nil)
 	return b.build(plan), nil
 }
 

--- a/pkg/executor/executor_required_rows_test.go
+++ b/pkg/executor/executor_required_rows_test.go
@@ -741,7 +741,7 @@ func buildMergeJoinExec(ctx sessionctx.Context, joinType base.JoinType, innerSrc
 		j.CompareFuncs = append(j.CompareFuncs, expression.GetCmpFunction(ctx.GetExprCtx(), j.LeftJoinKeys[i], j.RightJoinKeys[i]))
 	}
 
-	b := newExecutorBuilder(ctx, nil, nil)
+	b := newExecutorBuilder(context.Background(), ctx, nil, nil)
 	return b.build(j)
 }
 

--- a/pkg/executor/foreign_key.go
+++ b/pkg/executor/foreign_key.go
@@ -794,7 +794,7 @@ func (fkc *FKCascadeExec) buildFKCascadePlan(ctx context.Context) (base.Plan, er
 	if stmtNode == nil {
 		return nil, errors.Errorf("generate foreign key cascade ast failed, %v", fkc.tp)
 	}
-	sctx := fkc.b.ctx
+	sctx := fkc.b.sctx
 	nodeW := resolve.NewNodeW(stmtNode)
 	err := plannercore.Preprocess(ctx, sctx, nodeW)
 	if err != nil {

--- a/pkg/executor/index_merge_reader.go
+++ b/pkg/executor/index_merge_reader.go
@@ -191,7 +191,7 @@ func (e *IndexMergeReaderExecutor) Open(_ context.Context) (err error) {
 		}
 		for i, idx := range e.indexes {
 			if idx != nil && idx.Global {
-				keyRange, _ := distsql.IndexRangesToKVRanges(e.ctx.GetDistSQLCtx(), e.table.Meta().ID, idx.ID, e.ranges[i])
+				keyRange, _ := distsql.IndexRangesToKVRanges(e.sctx.GetDistSQLCtx(), e.table.Meta().ID, idx.ID, e.ranges[i])
 				e.partitionKeyRanges[i] = [][]kv.KeyRange{keyRange.FirstPartitionRange()}
 			} else {
 				for _, pKeyRanges := range tmpPartitionKeyRanges {

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -56,14 +56,14 @@ func (b *executorBuilder) buildPointGet(p *physicalop.PointGetPlan) exec.Executo
 		return nil
 	}
 
-	isTableDual, err := p.PrunePartitions(b.ctx)
+	isTableDual, err := p.PrunePartitions(b.sctx)
 	if err != nil {
 		b.err = err
 		return nil
 	}
 	if isTableDual {
 		return &TableDualExec{
-			BaseExecutorV2: exec.NewBaseExecutorV2(b.ctx.GetSessionVars(), p.Schema(), p.ID()),
+			BaseExecutorV2: exec.NewBaseExecutorV2(b.sctx.GetSessionVars(), p.Schema(), p.ID()),
 			numDualRows:    0,
 			numReturned:    0,
 		}
@@ -76,10 +76,10 @@ func (b *executorBuilder) buildPointGet(p *physicalop.PointGetPlan) exec.Executo
 		}()
 	}
 
-	b.ctx.GetSessionVars().StmtCtx.IsTiKV.Store(true)
+	b.sctx.GetSessionVars().StmtCtx.IsTiKV.Store(true)
 
 	e := &PointGetExecutor{
-		BaseExecutor:       exec.NewBaseExecutor(b.ctx, p.Schema(), p.ID()),
+		BaseExecutor:       exec.NewBaseExecutor(b.sctx, p.Schema(), p.ID()),
 		indexUsageReporter: b.buildIndexUsageReporter(p, false),
 		txnScope:           b.txnScope,
 		readReplicaScope:   b.readReplicaScope,

--- a/pkg/executor/select.go
+++ b/pkg/executor/select.go
@@ -616,7 +616,7 @@ func init() {
 			return nil, err
 		}
 
-		e := newExecutorBuilder(sctx, is, nil)
+		e := newExecutorBuilder(ctx, sctx, is, nil)
 		executor := e.build(p)
 		if e.err != nil {
 			return nil, e.err

--- a/pkg/executor/traffic_test.go
+++ b/pkg/executor/traffic_test.go
@@ -405,7 +405,7 @@ func TestTrafficPrivilege(t *testing.T) {
 	defer server.Close()
 	ctx = fillCtxWithTiProxyAddr(ctx, []int{port})
 	mgr := &mockPrivManager{}
-	privilege.BindPrivilegeManager(suite.execBuilder.ctx, mgr)
+	privilege.BindPrivilegeManager(suite.execBuilder.sctx, mgr)
 
 	cancelTests := []struct {
 		privs []bool
@@ -508,7 +508,7 @@ func (suite *trafficTestSuite) build(ctx context.Context, sql string) exec.Execu
 }
 
 func (suite *trafficTestSuite) stmtCtx() *stmtctx.StatementContext {
-	return suite.execBuilder.ctx.GetSessionVars().StmtCtx
+	return suite.execBuilder.sctx.GetSessionVars().StmtCtx
 }
 
 type mockHTTPHandler struct {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68074

Problem Summary:
Pre-ANALYZE stats-delta flush used a detached context, so statement cancellation could be missed during executor build.

### What changed and how does it work?

Pass the statement context into `executorBuilder` and use it for context-sensitive ANALYZE build work:

- pre-ANALYZE `FLUSH STATS_DELTA` during executor build;
- adaptive analyze DistSQL concurrency lookups in `buildAnalyzeIndexPushdown`, `buildAnalyzeSamplingPushdown`, and special-index NDV sub-jobs;
- auto sample-rate approximate table count lookup through `getApproximateTableCountFromStorage`.

Added regression coverage for canceled statement contexts during executor build.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context propagation so cancellations/deadlines are respected and analyze pre-flush avoids unnecessary work when canceled.
* **Refactor**
  * Internal separation of statement-scoped and session-scoped contexts to ensure session settings and long-running operations behave consistently.
* **Tests**
  * Added/updated tests and benchmarks to validate cancellation behavior and the new context separation during executor construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
