### PR TITLE
localbackend: add write timeout handling for object store region jobs

### DIFF
--- a/lightning/tests/lightning_write_timeout/run.sh
+++ b/lightning/tests/lightning_write_timeout/run.sh
@@ -42,7 +42,7 @@ for i in {1..200000}; do
 done
 set -x
 
-export GO_FAILPOINTS="github.com/pingcap/tidb/pkg/lightning/backend/local/shortWaitNTimeout=100*return(1)" 
+export GO_FAILPOINTS="github.com/pingcap/tidb/pkg/lightning/backend/local/shortWaitNTimeout=5*return(1000)"
 
 run_lightning --backend local -d "$TEST_DIR/data" --config "$CUR/config.toml"
 check_lightning_log_contains 'experiencing a wait timeout while writing to TiKV'

--- a/lightning/tests/lightning_write_timeout/run.sh
+++ b/lightning/tests/lightning_write_timeout/run.sh
@@ -45,4 +45,4 @@ set -x
 export GO_FAILPOINTS="github.com/pingcap/tidb/pkg/lightning/backend/local/shortWaitNTimeout=100*return(1)" 
 
 run_lightning --backend local -d "$TEST_DIR/data" --config "$CUR/config.toml"
-check_lightning_log_contains 'Experiencing a wait timeout while writing to TiKV'
+check_lightning_log_contains 'experiencing a wait timeout while writing to TiKV'

--- a/lightning/tests/lightning_write_timeout/run.sh
+++ b/lightning/tests/lightning_write_timeout/run.sh
@@ -45,4 +45,4 @@ set -x
 export GO_FAILPOINTS="github.com/pingcap/tidb/pkg/lightning/backend/local/shortWaitNTimeout=100*return(1)" 
 
 run_lightning --backend local -d "$TEST_DIR/data" --config "$CUR/config.toml"
-check_lightning_log_contains 'Experiencing a wait timeout while writing to tikv'
+check_lightning_log_contains 'Experiencing a wait timeout while writing to TiKV'

--- a/pkg/lightning/backend/local/job_worker.go
+++ b/pkg/lightning/backend/local/job_worker.go
@@ -16,6 +16,7 @@ package local
 
 import (
 	"context"
+	goerrors "errors"
 	"io"
 	"strings"
 	"sync"
@@ -323,7 +324,25 @@ func (*objStoreRegionJobWorker) preRunJob(_ context.Context, _ *regionJob) error
 }
 
 // we don't need to limit write speed as we write to tikv-worker.
-func (w *objStoreRegionJobWorker) write(ctx context.Context, job *regionJob) (*tikvWriteResult, error) {
+func (w *objStoreRegionJobWorker) write(ctx context.Context, job *regionJob) (ret *tikvWriteResult, err error) {
+	var cancel context.CancelFunc
+	timeout := 15 * time.Minute
+	ctx, cancel = context.WithTimeoutCause(ctx, timeout, common.ErrWriteTooSlow)
+	defer cancel()
+
+	wctx := ctx
+	defer func() {
+		if err == nil {
+			return
+		}
+		if errors.Cause(err) == context.DeadlineExceeded {
+			if cause := context.Cause(wctx); goerrors.Is(cause, common.ErrWriteTooSlow) {
+				tidblogutil.Logger(ctx).Info("experiencing a wait timeout while writing to tikv-worker")
+				err = errors.Trace(cause)
+			}
+		}
+	}()
+
 	firstKey, _, err := job.ingestData.GetFirstAndLastKey(job.keyRange.Start, job.keyRange.End)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/pkg/lightning/backend/local/job_worker.go
+++ b/pkg/lightning/backend/local/job_worker.go
@@ -277,7 +277,8 @@ func (w *regionJobBaseWorker) writeWithTimeout(
 
 	wcancel := func() {}
 	failpoint.Inject("shortWaitNTimeout", func(val failpoint.Value) {
-		innerTimeout := time.Duration(val.(int)) * time.Millisecond
+		ms := val.(int)
+		innerTimeout := time.Duration(ms) * time.Millisecond
 		tidblogutil.Logger(ctx).Info("Injecting a timeout to write context.")
 		ctx, wcancel = context.WithTimeoutCause(ctx, innerTimeout, common.ErrWriteTooSlow)
 	})

--- a/pkg/lightning/backend/local/job_worker.go
+++ b/pkg/lightning/backend/local/job_worker.go
@@ -198,7 +198,7 @@ func (w *regionJobBaseWorker) runJob(ctx context.Context, job *regionJob) error 
 				job.convertStageTo(needRescan)
 				return nil
 			}
-			res, err := w.writeFn(ctx, job)
+			res, err := w.writeWithTimeout(ctx, job)
 			err = injectfailpoint.DXFRandomErrorWithOnePercentWrapper(err)
 			if err != nil {
 				if !w.isRetryableImportTiKVError(err) {
@@ -267,6 +267,27 @@ func (w *regionJobBaseWorker) runJob(ctx context.Context, job *regionJob) error 
 	}
 }
 
+func (w *regionJobBaseWorker) writeWithTimeout(
+	ctx context.Context,
+	job *regionJob,
+) (ret *tikvWriteResult, err error) {
+	timeout := 15 * time.Minute
+	ctx, cancel := context.WithTimeoutCause(ctx, timeout, common.ErrWriteTooSlow)
+	defer cancel()
+
+	ret, err = w.writeFn(ctx, job)
+	if err == nil {
+		return ret, nil
+	}
+	if errors.Cause(err) == context.DeadlineExceeded {
+		if cause := context.Cause(ctx); goerrors.Is(cause, common.ErrWriteTooSlow) {
+			tidblogutil.Logger(ctx).Info("experiencing a wait timeout while writing to TiKV")
+			err = errors.Trace(cause)
+		}
+	}
+	return ret, err
+}
+
 func (*regionJobBaseWorker) isRetryableImportTiKVError(err error) bool {
 	err = errors.Cause(err)
 	// io.EOF is not retryable in normal case
@@ -324,25 +345,7 @@ func (*objStoreRegionJobWorker) preRunJob(_ context.Context, _ *regionJob) error
 }
 
 // we don't need to limit write speed as we write to tikv-worker.
-func (w *objStoreRegionJobWorker) write(ctx context.Context, job *regionJob) (ret *tikvWriteResult, err error) {
-	var cancel context.CancelFunc
-	timeout := 15 * time.Minute
-	ctx, cancel = context.WithTimeoutCause(ctx, timeout, common.ErrWriteTooSlow)
-	defer cancel()
-
-	wctx := ctx
-	defer func() {
-		if err == nil {
-			return
-		}
-		if errors.Cause(err) == context.DeadlineExceeded {
-			if cause := context.Cause(wctx); goerrors.Is(cause, common.ErrWriteTooSlow) {
-				tidblogutil.Logger(ctx).Info("experiencing a wait timeout while writing to tikv-worker")
-				err = errors.Trace(cause)
-			}
-		}
-	}()
-
+func (w *objStoreRegionJobWorker) write(ctx context.Context, job *regionJob) (*tikvWriteResult, error) {
 	firstKey, _, err := job.ingestData.GetFirstAndLastKey(job.keyRange.Start, job.keyRange.End)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/pkg/lightning/backend/local/job_worker.go
+++ b/pkg/lightning/backend/local/job_worker.go
@@ -282,7 +282,7 @@ func (w *regionJobBaseWorker) writeWithTimeout(
 	failpoint.Inject("shortWaitNTimeout", func(val failpoint.Value) {
 		ms := val.(int)
 		innerTimeout := time.Duration(ms) * time.Millisecond
-		tidblogutil.Logger(ctx).Info("Injecting a timeout to write context.")
+		tidblogutil.Logger(ctx).Info("injecting a timeout to write context.")
 		ctx, wcancel = context.WithTimeoutCause(ctx, innerTimeout, common.ErrWriteTooSlow)
 	})
 	defer wcancel()
@@ -293,7 +293,7 @@ func (w *regionJobBaseWorker) writeWithTimeout(
 	}
 	if errors.Cause(err) == context.DeadlineExceeded {
 		if cause := context.Cause(ctx); goerrors.Is(cause, common.ErrWriteTooSlow) {
-			tidblogutil.Logger(ctx).Info("Experiencing a wait timeout while writing to TiKV")
+			tidblogutil.Logger(ctx).Info("experiencing a wait timeout while writing to TiKV")
 			err = errors.Trace(cause)
 		}
 	}

--- a/pkg/lightning/backend/local/job_worker.go
+++ b/pkg/lightning/backend/local/job_worker.go
@@ -271,6 +271,9 @@ func (w *regionJobBaseWorker) writeWithTimeout(
 	ctx context.Context,
 	job *regionJob,
 ) (ret *tikvWriteResult, err error) {
+	// set a timeout for the write operation, if it takes too long, we will
+	// return with common.ErrWriteTooSlow and let caller retry the whole job
+	// instead of being stuck forever.
 	timeout := 15 * time.Minute
 	ctx, cancel := context.WithTimeoutCause(ctx, timeout, common.ErrWriteTooSlow)
 	defer cancel()

--- a/pkg/lightning/backend/local/job_worker.go
+++ b/pkg/lightning/backend/local/job_worker.go
@@ -275,17 +275,12 @@ func (w *regionJobBaseWorker) writeWithTimeout(
 	// return with common.ErrWriteTooSlow and let caller retry the whole job
 	// instead of being stuck forever.
 	timeout := 15 * time.Minute
-	ctx, cancel := context.WithTimeoutCause(ctx, timeout, common.ErrWriteTooSlow)
-	defer cancel()
-
-	wcancel := func() {}
 	failpoint.Inject("shortWaitNTimeout", func(val failpoint.Value) {
 		ms := val.(int)
-		innerTimeout := time.Duration(ms) * time.Millisecond
-		tidblogutil.Logger(ctx).Info("injecting a timeout to write context.")
-		ctx, wcancel = context.WithTimeoutCause(ctx, innerTimeout, common.ErrWriteTooSlow)
+		timeout = time.Duration(ms) * time.Millisecond
 	})
-	defer wcancel()
+	ctx, cancel := context.WithTimeoutCause(ctx, timeout, common.ErrWriteTooSlow)
+	defer cancel()
 
 	ret, err = w.writeFn(ctx, job)
 	if err == nil {

--- a/pkg/lightning/backend/local/job_worker.go
+++ b/pkg/lightning/backend/local/job_worker.go
@@ -275,13 +275,21 @@ func (w *regionJobBaseWorker) writeWithTimeout(
 	ctx, cancel := context.WithTimeoutCause(ctx, timeout, common.ErrWriteTooSlow)
 	defer cancel()
 
+	wcancel := func() {}
+	failpoint.Inject("shortWaitNTimeout", func(val failpoint.Value) {
+		innerTimeout := time.Duration(val.(int)) * time.Millisecond
+		tidblogutil.Logger(ctx).Info("Injecting a timeout to write context.")
+		ctx, wcancel = context.WithTimeoutCause(ctx, innerTimeout, common.ErrWriteTooSlow)
+	})
+	defer wcancel()
+
 	ret, err = w.writeFn(ctx, job)
 	if err == nil {
 		return ret, nil
 	}
 	if errors.Cause(err) == context.DeadlineExceeded {
 		if cause := context.Cause(ctx); goerrors.Is(cause, common.ErrWriteTooSlow) {
-			tidblogutil.Logger(ctx).Info("experiencing a wait timeout while writing to TiKV")
+			tidblogutil.Logger(ctx).Info("Experiencing a wait timeout while writing to TiKV")
 			err = errors.Trace(cause)
 		}
 	}

--- a/pkg/lightning/backend/local/job_worker_test.go
+++ b/pkg/lightning/backend/local/job_worker_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ingestor/errdef"
 	"github.com/pingcap/tidb/pkg/ingestor/ingestcli"
 	ingestclimock "github.com/pingcap/tidb/pkg/ingestor/ingestcli/mock"
+	"github.com/pingcap/tidb/pkg/lightning/common"
 	"github.com/pingcap/tidb/pkg/resourcemanager/pool/workerpool"
 	rcmgrutil "github.com/pingcap/tidb/pkg/resourcemanager/util"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
@@ -301,6 +302,21 @@ func TestCloudRegionJobWorker(t *testing.T) {
 		mockIngestCli.EXPECT().WriteClient(gomock.Any(), gomock.Any()).Return(nil, errors.New("mock error"))
 		writeRes, err := cloudW.write(context.Background(), job)
 		require.ErrorContains(t, err, "mock error")
+		require.Nil(t, writeRes)
+		require.True(t, ctrl.Satisfied())
+	})
+
+	t.Run("timeout while creating ingest client should return retryable error", func(t *testing.T) {
+		job := &regionJob{
+			keyRange:   engineapi.Range{Start: []byte("a"), End: []byte("z")},
+			stage:      regionScanned,
+			ingestData: mockIngestData{{[]byte("a"), []byte("a")}},
+		}
+		mockIngestCli.EXPECT().WriteClient(gomock.Any(), gomock.Any()).Return(nil, context.DeadlineExceeded)
+		ctx, cancel := context.WithTimeoutCause(context.Background(), 0, common.ErrWriteTooSlow)
+		defer cancel()
+		writeRes, err := cloudW.write(ctx, job)
+		require.ErrorIs(t, err, common.ErrWriteTooSlow)
 		require.Nil(t, writeRes)
 		require.True(t, ctrl.Satisfied())
 	})

--- a/pkg/lightning/backend/local/job_worker_test.go
+++ b/pkg/lightning/backend/local/job_worker_test.go
@@ -306,18 +306,22 @@ func TestCloudRegionJobWorker(t *testing.T) {
 		require.True(t, ctrl.Satisfied())
 	})
 
-	t.Run("timeout while creating ingest client should return retryable error", func(t *testing.T) {
+	t.Run("timeout while creating ingest client should be handled by runJob wrapper", func(t *testing.T) {
 		job := &regionJob{
 			keyRange:   engineapi.Range{Start: []byte("a"), End: []byte("z")},
 			stage:      regionScanned,
 			ingestData: mockIngestData{{[]byte("a"), []byte("a")}},
+			region: &split.RegionInfo{Region: &metapb.Region{
+				Id: 1, Peers: []*metapb.Peer{{StoreId: 1}},
+			}, Leader: &metapb.Peer{StoreId: 1}},
 		}
 		mockIngestCli.EXPECT().WriteClient(gomock.Any(), gomock.Any()).Return(nil, context.DeadlineExceeded)
 		ctx, cancel := context.WithTimeoutCause(context.Background(), 0, common.ErrWriteTooSlow)
 		defer cancel()
-		writeRes, err := cloudW.write(ctx, job)
-		require.ErrorIs(t, err, common.ErrWriteTooSlow)
-		require.Nil(t, writeRes)
+		err := cloudW.runJob(ctx, job)
+		require.NoError(t, err)
+		require.Equal(t, needRescan, job.stage)
+		require.ErrorIs(t, job.lastRetryableErr, common.ErrWriteTooSlow)
 		require.True(t, ctrl.Satisfied())
 	})
 

--- a/pkg/lightning/backend/local/region_job.go
+++ b/pkg/lightning/backend/local/region_job.go
@@ -339,34 +339,6 @@ func (local *Backend) doWrite(ctx context.Context, j *regionJob) (ret *tikvWrite
 		failpoint.Return(front.write.result, err)
 	})
 
-	var cancel context.CancelFunc
-	// set a timeout for the write operation, if it takes too long, we will return with common.ErrWriteTooSlow and let caller retry the whole job instead of being stuck forever.
-	timeout := 15 * time.Minute
-	ctx, cancel = context.WithTimeoutCause(ctx, timeout, common.ErrWriteTooSlow)
-	defer cancel()
-
-	// A defer function to handle all DeadlineExceeded errors that may occur
-	// during the write operation using this context with 15 minutes timeout.
-	// When the error is "context deadline exceeded", we will check if the cause
-	// is common.ErrWriteTooSlow and return the common.ErrWriteTooSlow instead so
-	// our caller would be able to retry this doWrite operation. By doing this
-	// defer we are hoping to handle all DeadlineExceeded error during this
-	// write, either from gRPC stream or write limiter WaitN operation.
-	wctx := ctx
-	defer func() {
-		if err == nil {
-			return
-		}
-		if errors.Cause(err) == context.DeadlineExceeded {
-			if cause := context.Cause(wctx); goerrors.Is(cause, common.ErrWriteTooSlow) {
-				tidblogutil.Logger(ctx).Info("Experiencing a wait timeout while writing to tikv",
-					zap.Int("store-write-bwlimit", local.BackendConfig.StoreWriteBWLimit),
-					zap.Int("limit-size", local.writeLimiter.Limit()))
-				err = errors.Trace(cause) // return the common.ErrWriteTooSlow instead to let caller retry it
-			}
-		}
-	}()
-
 	apiVersion := local.tikvCodec.GetAPIVersion()
 	clientFactory := local.importClientFactory
 	kvBatchSize := local.KVWriteBatchSize
@@ -486,6 +458,7 @@ func (local *Backend) doWrite(ctx context.Context, j *regionJob) (ret *tikvWrite
 	}
 
 	// preparation work for the write timeout fault injection, only enabled if the following failpoint is enabled
+	wctx := ctx
 	wcancel := func() {}
 	failpoint.Inject("shortWaitNTimeout", func(val failpoint.Value) {
 		var innerTimeout time.Duration

--- a/pkg/lightning/backend/local/region_job.go
+++ b/pkg/lightning/backend/local/region_job.go
@@ -457,20 +457,6 @@ func (local *Backend) doWrite(ctx context.Context, j *regionJob) (ret *tikvWrite
 		regionMaxSize = j.regionSplitSize * 4 / 3
 	}
 
-	// preparation work for the write timeout fault injection, only enabled if the following failpoint is enabled
-	wctx := ctx
-	wcancel := func() {}
-	failpoint.Inject("shortWaitNTimeout", func(val failpoint.Value) {
-		var innerTimeout time.Duration
-		// GO_FAILPOINTS action supplies the duration in
-		ms, _ := val.(int)
-		innerTimeout = time.Duration(ms) * time.Millisecond
-		tidblogutil.Logger(ctx).Info("Injecting a timeout to write context.")
-		wctx, wcancel = context.WithTimeoutCause(
-			ctx, innerTimeout, common.ErrWriteTooSlow)
-	})
-	defer wcancel()
-
 	flushKVs := func() error {
 		req.Chunk.(*sst.WriteRequest_Batch).Batch.Pairs = pairs[:count]
 		preparedMsg := &grpc.PreparedMsg{}
@@ -483,7 +469,7 @@ func (local *Backend) doWrite(ctx context.Context, j *regionJob) (ret *tikvWrite
 		for i := range clients {
 			// original ctx would be used when failpoint is not enabled
 			// that new context would be used when failpoint is enabled
-			err := writeLimiter.WaitN(wctx, allPeers[i].StoreId, int(size))
+			err := writeLimiter.WaitN(ctx, allPeers[i].StoreId, int(size))
 			if err != nil {
 				// We expect to encounter two types of errors here:
 				// 1. context.DeadlineExceeded — occurs when the calculated delay is
@@ -493,13 +479,8 @@ func (local *Backend) doWrite(ctx context.Context, j *regionJob) (ret *tikvWrite
 				//    path triggered when the delay already exceeds the remaining
 				//    time for context before sleeping.
 				//
-				// Unfortunately, we cannot precisely control when the context will
-				// expire, so both scenarios are valid and expected.
-				// Fortunately, the "rate: Wait" error is already treated as
-				// retryable, so we only need to explicitly handle
-				// context.DeadlineExceeded here.
-				// We rely on the defer function at the top of doWrite to handle it
-				// for us in general.
+				// "rate: Wait" error is already treated as retryable,
+				// writeWithTimeout will handle the context.DeadlineExceeded.
 				return errors.Trace(err)
 			}
 			if err := clients[i].SendMsg(preparedMsg); err != nil {

--- a/pkg/lightning/backend/local/region_job.go
+++ b/pkg/lightning/backend/local/region_job.go
@@ -465,7 +465,11 @@ func (local *Backend) doWrite(ctx context.Context, j *regionJob) (ret *tikvWrite
 		if err := preparedMsg.Encode(clients[0], req); err != nil {
 			return err
 		}
-
+		failpoint.Inject("shortWaitNTimeout", func(val failpoint.Value) {
+			// add 20 to make sure the ctx is timed out.
+			ms := val.(int) + 20
+			time.Sleep(time.Duration(ms) * time.Millisecond)
+		})
 		for i := range clients {
 			// original ctx would be used when failpoint is not enabled
 			// that new context would be used when failpoint is enabled


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

Object store imports use the object store region job worker, which can time out while creating or using the TiKV write client. The write timeout handling was tied to `Backend.doWrite`, so object store region jobs did not get the same `common.ErrWriteTooSlow` retry behavior before `runJob` classified write errors.

### What changed and how does it work?

Move the 15-minute write timeout wrapper to `regionJobBaseWorker.writeWithTimeout`, so both local backend writes and object store region job worker writes are wrapped before `runJob` classifies retryable write errors. If the context deadline is caused by `common.ErrWriteTooSlow`, return that error so the job is marked retryable and can be rescanned/retried.

Remove the duplicate timeout wrapper from `Backend.doWrite` and keep the existing short write-timeout failpoint setup. This keeps the timeout behavior in the common region job execution path instead of only in the local backend write implementation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/lightning/backend/local -run 'Test(CloudRegionJobWorker|RegionJobBaseWorker)$' -count=1`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve TiDB Lightning object store region job retry handling when writes to TiKV exceed the write timeout.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TiKV write timeout handling to better detect, log, and trace slow writes while preserving retry behavior; added an opt-in path to simulate shorter per-write timeouts.

* **Tests**
  * Added/updated tests for write-timeout and retry scenarios, including a client-creation timeout case.
  * Updated log assertion to expect “TiKV” capitalization in timeout messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->