### PR TITLE
planner: decrease the default value of `tidb_opt_range_max_size` to 8MB

### DIFF
--- a/pkg/executor/set_test.go
+++ b/pkg/executor/set_test.go
@@ -860,7 +860,7 @@ func TestSetVar(t *testing.T) {
 	tk.MustQuery("select @@session.tidb_opt_prefix_index_single_scan").Check(testkit.Rows("1"))
 
 	// test tidb_opt_range_max_size
-	tk.MustQuery("select @@tidb_opt_range_max_size").Check(testkit.Rows("67108864"))
+	tk.MustQuery("select @@tidb_opt_range_max_size").Check(testkit.Rows(strconv.FormatInt(vardef.DefTiDBOptRangeMaxSize, 10)))
 	tk.MustExec("set global tidb_opt_range_max_size = -1")
 	tk.MustQuery("show warnings").Check(testkit.RowsWithSep("|", "Warning|1292|Truncated incorrect tidb_opt_range_max_size value: '-1'"))
 	tk.MustQuery("select @@global.tidb_opt_range_max_size").Check(testkit.Rows("0"))

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1709,7 +1709,7 @@ const (
 	DefTiDBForeignKeyCheckInSharedLock           = false
 	DefTiDBOptAdvancedJoinHint                   = true
 	DefTiDBAnalyzePartitionConcurrency           = 2
-	DefTiDBOptRangeMaxSize                       = 64 * int64(size.MB) // 64 MB
+	DefTiDBOptRangeMaxSize                       = 8 * int64(size.MB)
 	DefTiDBCostModelVer                          = 2
 	DefTiDBServerMemoryLimitSessMinSize          = 128 << 20
 	DefTiDBMergePartitionStatsConcurrency        = 1

--- a/tests/integrationtest/r/sessionctx/setvar.result
+++ b/tests/integrationtest/r/sessionctx/setvar.result
@@ -1462,21 +1462,21 @@ select /*+ set_var(tidb_opt_range_max_size=0) */ @@tidb_opt_range_max_size;
 0
 select @@tidb_opt_range_max_size;
 @@tidb_opt_range_max_size
-67108864
+8388608
 set @@tidb_opt_range_max_size=default;
 select @@tidb_opt_range_max_size;
 @@tidb_opt_range_max_size
-67108864
+8388608
 select /*+ set_var(tidb_opt_range_max_size=1) */ @@tidb_opt_range_max_size;
 @@tidb_opt_range_max_size
 1
 select @@tidb_opt_range_max_size;
 @@tidb_opt_range_max_size
-67108864
+8388608
 set @@tidb_opt_range_max_size=default;
 select @@tidb_opt_range_max_size;
 @@tidb_opt_range_max_size
-67108864
+8388608
 select /*+ set_var(tidb_opt_advanced_join_hint=0) */ @@tidb_opt_advanced_join_hint;
 @@tidb_opt_advanced_join_hint
 0


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66203

Problem Summary:

The default value of `tidb_opt_range_max_size` (64MB) allows the optimizer to build an excessive number of access ranges from large in-lists (~200K ranges). This causes severe optimization latency (40s+ for a 30K-item NOT IN) and harmful execution behavior due to excessive seek operations on TiKV (#62499).

### What changed and how does it work?

Decreases the default value of `tidb_opt_range_max_size` from 64MB to 8MB (~24K ranges). At 64MB, the optimizer spends massive CPU time constructing and processing ranges that are counterproductive at execution time anyway. 8MB is generous enough for legitimate workloads while preventing pathological optimization and execution behavior. Users who need a higher limit can still `SET tidb_opt_range_max_size` explicitly.

Also fixes the existing default-value assertion in `set_test.go` to reference `vardef.DefTiDBOptRangeMaxSize` instead of a hardcoded constant, so future default changes don't require updating the test.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Change the default value of `tidb_opt_range_max_size` from `67108864` (64 MiB) to `8388608` (8 MiB) to avoid excessive optimization time and execution overhead caused by large in-lists.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Adjusted the default memory limit for range planning optimization (`tidb_opt_range_max_size`) from 64 MB to 8 MB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->