### PR TITLE
planner, statistics: skip internal column IDs in async stats load queue (#67767)

### DIFF
--- a/pkg/planner/core/collect_column_stats_usage.go
+++ b/pkg/planner/core/collect_column_stats_usage.go
@@ -139,6 +139,11 @@ func (c *columnStatsUsageCollector) collectPredicateColumnsForDataSource(ds *log
 		c.tblID2PartitionIDs[tblID] = append(c.tblID2PartitionIDs[tblID], ds.PhysicalTableID)
 	}
 	for _, col := range ds.Schema().Columns {
+		// Internal pseudo columns (for example, _tidb_rowid with ID -1) don't have persisted stats.
+		// Skip them when collecting predicate/histogram-needed columns.
+		if col.ID <= 0 {
+			continue
+		}
 		tblColID := model.TableItemID{TableID: tblID, ID: col.ID, IsIndex: false}
 		c.colMap[col.UniqueID] = map[model.TableItemID]struct{}{tblColID: {}}
 	}

--- a/pkg/planner/core/collect_column_stats_usage_test.go
+++ b/pkg/planner/core/collect_column_stats_usage_test.go
@@ -359,6 +359,10 @@ func TestCollectHistNeededColumns(t *testing.T) {
 			res: []string{"t.a full", "t.b full"},
 		},
 		{
+			sql: "select * from t3 where _tidb_rowid > 1",
+			res: []string{},
+		},
+		{
 			sql: "select b, count(a) from t where b > 1 group by b having count(a) > 2",
 			res: []string{"t.a meta", "t.b full"},
 		},

--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 12,
+    shard_count = 13,
     deps = [
         "//pkg/parser",
         "//pkg/planner",

--- a/pkg/statistics/column.go
+++ b/pkg/statistics/column.go
@@ -155,10 +155,11 @@ func ColumnStatsIsInvalid(colStats *Column, sctx planctx.PlanContext, histColl *
 	}
 	if sctx != nil {
 		stmtctx := sctx.GetSessionVars().StmtCtx
+		// Internal pseudo columns (eg: _tidb_rowid with ID -1) don't have persisted column stats.
+		isNonInternalColumnID := cid > 0
 		if (colStats == nil || !colStats.IsStatsInitialized() || colStats.IsLoadNeeded()) &&
 			stmtctx != nil &&
-			// Internal pseudo columns (for example, _tidb_rowid with ID -1) don't have persisted column stats.
-			cid > 0 &&
+			isNonInternalColumnID &&
 			!histColl.CanNotTriggerLoad {
 			asyncload.AsyncLoadHistogramNeededItems.Insert(model.TableItemID{
 				TableID:          histColl.PhysicalID,

--- a/pkg/statistics/column.go
+++ b/pkg/statistics/column.go
@@ -157,6 +157,8 @@ func ColumnStatsIsInvalid(colStats *Column, sctx planctx.PlanContext, histColl *
 		stmtctx := sctx.GetSessionVars().StmtCtx
 		if (colStats == nil || !colStats.IsStatsInitialized() || colStats.IsLoadNeeded()) &&
 			stmtctx != nil &&
+			// Internal pseudo columns (for example, _tidb_rowid with ID -1) don't have persisted column stats.
+			cid > 0 &&
 			!histColl.CanNotTriggerLoad {
 			asyncload.AsyncLoadHistogramNeededItems.Insert(model.TableItemID{
 				TableID:          histColl.PhysicalID,

--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -59,7 +59,7 @@ go_test(
         "stats_read_writer_test.go",
     ],
     flaky = True,
-    shard_count = 31,
+    shard_count = 28,
     deps = [
         ":storage",
         "//pkg/domain",

--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -59,7 +59,7 @@ go_test(
         "stats_read_writer_test.go",
     ],
     flaky = True,
-    shard_count = 28,
+    shard_count = 31,
     deps = [
         ":storage",
         "//pkg/domain",

--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -59,7 +59,7 @@ go_test(
         "stats_read_writer_test.go",
     ],
     flaky = True,
-    shard_count = 28,
+    shard_count = 30,
     deps = [
         ":storage",
         "//pkg/domain",
@@ -68,6 +68,7 @@ go_test(
         "//pkg/planner/cardinality",
         "//pkg/sessionctx/variable",
         "//pkg/statistics",
+        "//pkg/statistics/asyncload",
         "//pkg/statistics/handle/ddl/testutil",
         "//pkg/statistics/handle/internal",
         "//pkg/statistics/handle/types",

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -667,6 +667,13 @@ func CleanFakeItemsForShowHistInFlights(statsCache statstypes.StatsCache) int {
 }
 
 func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.StatsHandle, col model.TableItemID, loadFMSketch bool, fullLoad bool) (err error) {
+	// Internal pseudo columns (for example, _tidb_rowid with ID -1) do not have corresponding column metadata/stats.
+	// Skip them defensively in case they leak into the async-load queue.
+	// We need to remove it from the queue explicitly in release-8.5 path.
+	if col.ID <= 0 {
+		asyncload.AsyncLoadHistogramNeededItems.Delete(col)
+		return nil
+	}
 	statsTbl, ok := statsHandle.Get(col.TableID)
 	if !ok {
 		// This could happen when the table is dropped after the async load is triggered.

--- a/pkg/statistics/handle/storage/read_test.go
+++ b/pkg/statistics/handle/storage/read_test.go
@@ -134,7 +134,7 @@ func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
 	tk.MustExec("create table t(a int, b int)")
 	tk.MustExec("insert into t value(1,1), (2,2);")
 	h := dom.StatsHandle()
-	tk.MustExec("flush stats_delta")
+	tk.MustExec("flush stats_delta *.*")
 	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
 	tk.MustExec("analyze table t")
 	tk.MustExec("set tidb_opt_objective='determinate';")

--- a/pkg/statistics/handle/storage/read_test.go
+++ b/pkg/statistics/handle/storage/read_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/meta/model"
-	"github.com/pingcap/tidb/pkg/parser/ast"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/planner/cardinality"
 	"github.com/pingcap/tidb/pkg/statistics"
@@ -119,7 +118,9 @@ func TestColumnStatsIsInvalidSkipsInternalColumnID(t *testing.T) {
 	statistics.ColumnStatsIsInvalid(nil, tk.Session().GetPlanCtx(), histColl, -1)
 
 	items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
-	require.Len(t, items, 0)
+	for _, item := range items {
+		require.False(t, !item.IsIndex && item.TableID == histColl.PhysicalID && item.ID <= 0)
+	}
 }
 
 func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
@@ -134,12 +135,10 @@ func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
 	tk.MustExec("create table t(a int, b int)")
 	tk.MustExec("insert into t value(1,1), (2,2);")
 	h := dom.StatsHandle()
-	tk.MustExec("flush stats_delta *.*")
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
 	tk.MustExec("analyze table t")
 	tk.MustQuery("select * from t where a = 2 and b = 2 and _tidb_rowid > 0;").Check(testkit.Rows("2 2"))
 
-	table, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	table, err := dom.InfoSchema().TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := table.Meta()
 	colAID := tableInfo.Columns[0].ID
@@ -182,7 +181,7 @@ func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
 	asyncload.AsyncLoadHistogramNeededItems.Insert(internalColumnItem, true)
 
 	require.NotPanics(t, func() {
-		err = storage.LoadNeededHistograms(nil, dom.InfoSchema(), h)
+		err = storage.LoadNeededHistograms(nil, dom.InfoSchema(), h, false)
 		require.NoError(t, err)
 	})
 	require.NotContains(t, asyncload.AsyncLoadHistogramNeededItems.AllItems(), model.StatsLoadItem{

--- a/pkg/statistics/handle/storage/read_test.go
+++ b/pkg/statistics/handle/storage/read_test.go
@@ -137,20 +137,22 @@ func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
 	tableInfo := table.Meta()
 	h := dom.StatsHandle()
 	// Make sure this table exists in stats cache so the old path would touch session context.
-	h.GetPhysicalTableStats(tableInfo.ID, tableInfo)
+	statsTbl := h.GetPhysicalTableStats(tableInfo.ID, tableInfo)
+	require.NotNil(t, statsTbl)
+	require.Equal(t, tableInfo.ID, statsTbl.PhysicalID)
 
-	rowIDItem := model.TableItemID{
+	internalColumnItem := model.TableItemID{
 		TableID: tableInfo.ID,
 		ID:      -1,
 	}
-	asyncload.AsyncLoadHistogramNeededItems.Insert(rowIDItem, true)
+	asyncload.AsyncLoadHistogramNeededItems.Insert(internalColumnItem, true)
 
 	require.NotPanics(t, func() {
 		err = storage.LoadNeededHistograms(nil, dom.InfoSchema(), h)
 		require.NoError(t, err)
 	})
 	require.NotContains(t, asyncload.AsyncLoadHistogramNeededItems.AllItems(), model.StatsLoadItem{
-		TableItemID: rowIDItem,
+		TableItemID: internalColumnItem,
 		FullLoad:    true,
 	})
 }

--- a/pkg/statistics/handle/storage/read_test.go
+++ b/pkg/statistics/handle/storage/read_test.go
@@ -137,7 +137,6 @@ func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
 	tk.MustExec("flush stats_delta *.*")
 	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
 	tk.MustExec("analyze table t")
-	tk.MustExec("set tidb_opt_objective='determinate';")
 	tk.MustQuery("select * from t where a = 2 and b = 2 and _tidb_rowid > 0;").Check(testkit.Rows("2 2"))
 
 	table, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))

--- a/pkg/statistics/handle/storage/read_test.go
+++ b/pkg/statistics/handle/storage/read_test.go
@@ -128,15 +128,50 @@ func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
 
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set @@tidb_stats_load_sync_wait = 0")
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
-	tk.MustExec("create table t(a int)")
+	tk.MustExec("create table t(a int, b int)")
+	tk.MustExec("insert into t value(1,1), (2,2);")
+	h := dom.StatsHandle()
+	tk.MustExec("flush stats_delta")
+	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	tk.MustExec("analyze table t")
+	tk.MustExec("set tidb_opt_objective='determinate';")
+	tk.MustQuery("select * from t where a = 2 and b = 2 and _tidb_rowid > 0;").Check(testkit.Rows("2 2"))
 
 	table, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := table.Meta()
-	h := dom.StatsHandle()
-	// Make sure this table exists in stats cache so the old path would touch session context.
+	colAID := tableInfo.Columns[0].ID
+	colBID := tableInfo.Columns[1].ID
+	// 1. query-triggered async loading should enqueue only real columns (a, b) and should never enqueue the internal pseudo column _tidb_rowid (ID=-1).
+	require.Eventually(t, func() bool {
+		items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
+		hasA, hasB := false, false
+		for _, item := range items {
+			if item.TableID != tableInfo.ID || item.IsIndex {
+				continue
+			}
+			// if column _tidb_rowid (ID=-1) should never enqueue,
+			if item.ID <= 0 {
+				return false
+			}
+			if item.ID == colAID {
+				hasA = true
+			}
+			if item.ID == colBID {
+				hasB = true
+			}
+		}
+		return hasA && hasB
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Clear query-triggered items so this test can isolate the nil-sctx internal-column path.
+	clearAsyncLoadHistogramNeededItems()
+
+	// 2. even if an internal pseudo column item (ID=-1) is inserted into the queue by mistake,
+	// LoadNeededHistograms should skip it safely and remove it without panic.
 	statsTbl := h.GetPhysicalTableStats(tableInfo.ID, tableInfo)
 	require.NotNil(t, statsTbl)
 	require.Equal(t, tableInfo.ID, statsTbl.PhysicalID)

--- a/pkg/statistics/handle/storage/read_test.go
+++ b/pkg/statistics/handle/storage/read_test.go
@@ -17,10 +17,15 @@ package storage_test
 import (
 	"context"
 	"testing"
+	"time"
 
-	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/planner/cardinality"
 	"github.com/pingcap/tidb/pkg/statistics"
+	"github.com/pingcap/tidb/pkg/statistics/asyncload"
+	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/stretchr/testify/require"
@@ -43,7 +48,7 @@ func TestLoadStats(t *testing.T) {
 	testKit.MustExec("analyze table t")
 
 	is := dom.InfoSchema()
-	tbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
+	tbl, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := tbl.Meta()
 	colAID := tableInfo.Columns[0].ID
@@ -99,4 +104,59 @@ func TestLoadStats(t *testing.T) {
 	topN := idx.TopN
 	require.Greater(t, float64(cms.TotalCount()+topN.TotalCount())+hg.TotalRowCount(), float64(0))
 	require.True(t, idx.IsFullLoad())
+}
+
+func TestColumnStatsIsInvalidSkipsInternalColumnID(t *testing.T) {
+	clearAsyncLoadHistogramNeededItems()
+	t.Cleanup(clearAsyncLoadHistogramNeededItems)
+
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	histColl := &statistics.HistColl{
+		PhysicalID: 1,
+	}
+	statistics.ColumnStatsIsInvalid(nil, tk.Session().GetPlanCtx(), histColl, -1)
+
+	items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
+	require.Len(t, items, 0)
+}
+
+func TestLoadNeededHistogramsSkipsInternalColumnID(t *testing.T) {
+	clearAsyncLoadHistogramNeededItems()
+	t.Cleanup(clearAsyncLoadHistogramNeededItems)
+
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int)")
+
+	table, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tableInfo := table.Meta()
+	h := dom.StatsHandle()
+	// Make sure this table exists in stats cache so the old path would touch session context.
+	h.GetPhysicalTableStats(tableInfo.ID, tableInfo)
+
+	rowIDItem := model.TableItemID{
+		TableID: tableInfo.ID,
+		ID:      -1,
+	}
+	asyncload.AsyncLoadHistogramNeededItems.Insert(rowIDItem, true)
+
+	require.NotPanics(t, func() {
+		err = storage.LoadNeededHistograms(nil, dom.InfoSchema(), h)
+		require.NoError(t, err)
+	})
+	require.NotContains(t, asyncload.AsyncLoadHistogramNeededItems.AllItems(), model.StatsLoadItem{
+		TableItemID: rowIDItem,
+		FullLoad:    true,
+	})
+}
+
+func clearAsyncLoadHistogramNeededItems() {
+	for _, item := range asyncload.AsyncLoadHistogramNeededItems.AllItems() {
+		asyncload.AsyncLoadHistogramNeededItems.Delete(item.TableItemID)
+	}
 }


### PR DESCRIPTION
This is a manual backport of #67767

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64504

Problem Summary:
`_tidb_rowid` uses an internal column ID (`-1`) and does not have persisted column histogram metadata. Under async stats loading, this internal ID could be inserted into the needed-items queue, and the load path later emitted noisy logs such as `columnID=-1`.

### What changed and how does it work?
- Added source filtering for internal column IDs in `statistics.ColumnStatsIsInvalid` so `cid <= 0` is not inserted into `AsyncLoadHistogramNeededItems`.
- Added defensive filtering in `loadNeededColumnHistograms` to skip `col.ID <= 0` early, while still deleting the queue item via `defer`.
- Added planner-side source filtering in `CollectColumnStatsUsage` to skip pseudo/internal columns (`col.ID <= 0`) when collecting predicate/histogram-needed columns.
- Added regression tests:
  - `TestColumnStatsIsInvalidSkipsInternalColumnID`
  - `TestLoadNeededHistogramsSkipsInternalColumnID`
  - Added `_tidb_rowid` case in `TestCollectHistNeededColumns` to assert no stats-load columns are collected.
- Ran `make bazel_lint_changed`, which updated `pkg/statistics/handle/storage/BUILD.bazel` shard count.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:
- `make failpoint-enable && (cd pkg/statistics/handle/storage && go test -run 'TestColumnStatsIsInvalidSkipsInternalColumnID|TestLoadNeededHistogramsSkipsInternalColumnID' -tags=intest,deadlock) && make failpoint-disable`
- `make failpoint-enable && (cd pkg/statistics/handle/storage && go test -run 'TestLoadStats|TestLoadNonExistentIndexStats|TestColumnStatsIsInvalidSkipsInternalColumnID|TestLoadNeededHistogramsSkipsInternalColumnID' -tags=intest,deadlock) && make failpoint-disable`
- `make failpoint-enable && (cd pkg/planner/core/rule && go test -run 'TestCollectHistNeededColumns' -tags=intest,deadlock) && make failpoint-disable`
- `make bazel_lint_changed`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of internal pseudo columns in statistics collection and histogram loading to avoid unnecessary queuing and processing.

* **Tests**
  * Added tests to verify async histogram-loading skips and cleans up internal pseudo-column items safely.

* **Chores**
  * Adjusted test shard counts and test target configuration for storage/statistics tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
