### PR TITLE
parser: fix stats object dedup for dotted names

### DIFF
--- a/pkg/parser/ast/stats.go
+++ b/pkg/parser/ast/stats.go
@@ -434,8 +434,13 @@ func dedupStatsObjects(objects []*StatsObject) []*StatsObject {
 		return objects
 	}
 
+	type tableKey struct {
+		dbName    string
+		tableName string
+	}
+
 	dbSeen := make(map[string]struct{})
-	tableSeen := make(map[string]struct{})
+	tableSeen := make(map[tableKey]struct{})
 	result := make([]*StatsObject, 0, len(objects))
 
 	for _, obj := range objects {
@@ -456,7 +461,7 @@ func dedupStatsObjects(objects []*StatsObject) []*StatsObject {
 				if existing.StatsObjectScope == StatsObjectScopeTable {
 					existingDBKey := existing.DBName.L
 					if existingDBKey != "" && existingDBKey == dbKey {
-						tblKey := existingDBKey + "." + existing.TableName.L
+						tblKey := tableKey{dbName: existingDBKey, tableName: existing.TableName.L}
 						delete(tableSeen, tblKey)
 						continue
 					}
@@ -471,7 +476,7 @@ func dedupStatsObjects(objects []*StatsObject) []*StatsObject {
 					continue
 				}
 			}
-			tblKey := dbKey + "." + obj.TableName.L
+			tblKey := tableKey{dbName: dbKey, tableName: obj.TableName.L}
 			if _, exists := tableSeen[tblKey]; exists {
 				continue
 			}

--- a/pkg/parser/ast/stats_test.go
+++ b/pkg/parser/ast/stats_test.go
@@ -182,6 +182,11 @@ func TestFlushStatsDeltaScoped(t *testing.T) {
 			sql:  "FLUSH STATS_DELTA db1.t1, db1.T1, db2.t1",
 			want: "FLUSH STATS_DELTA `db1`.`t1`, `db2`.`t1`",
 		},
+		{
+			name: "quoted dotted names are distinct",
+			sql:  "FLUSH STATS_DELTA `a.b`.`c`, `a`.`b.c`",
+			want: "FLUSH STATS_DELTA `a.b`.`c`, `a`.`b.c`",
+		},
 	}
 	for _, test := range dedupTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -227,6 +232,11 @@ func TestRefreshStatsStmtDedup(t *testing.T) {
 			name: "database duplicates case insensitive",
 			sql:  "REFRESH STATS db1.*, DB1.*, db2.t1",
 			want: "REFRESH STATS `db1`.*, `db2`.`t1`",
+		},
+		{
+			name: "quoted dotted names are distinct",
+			sql:  "REFRESH STATS `a.b`.`c`, `a`.`b.c`",
+			want: "REFRESH STATS `a.b`.`c`, `a`.`b.c`",
 		},
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

Scoped statistics targets are deduplicated with a string key built as `dbName + "." + tableName`. Quoted identifiers can contain dots, so distinct table targets such as `` `a.b`.`c` `` and `` `a`.`b.c` `` collapse to the same key. For `FLUSH STATS_DELTA`, this can skip one target and also skip its privilege check.

### What changed and how does it work?

Use a structured table key `{dbName, tableName}` when deduplicating stats objects instead of concatenating the names with `.`.

The helper is shared by `FLUSH STATS_DELTA` and `REFRESH STATS`, so the regression tests cover both statements.

### Check List

Tests

- [x] Unit test

Side effects

- [x] No side effects

### Release note

```release-note
None
```

### Verification

```sh
cd pkg/parser && GOTOOLCHAIN=auto go test ./ast -run '^(TestFlushStatsDeltaScoped|TestRefreshStatsStmtDedup)$' -count=1 -v
cd pkg/parser && GOTOOLCHAIN=auto go test . -run '^(TestDBAStmt|TestKeywordsLength)$' -count=1
```
