### PR TITLE
parser: fix stats object dedup for dotted names

### DIFF
--- a/pkg/parser/ast/stats.go
+++ b/pkg/parser/ast/stats.go
@@ -434,8 +434,13 @@ func dedupStatsObjects(objects []*StatsObject) []*StatsObject {
 		return objects
 	}
 
+	type tableKey struct {
+		dbName    string
+		tableName string
+	}
+
 	dbSeen := make(map[string]struct{})
-	tableSeen := make(map[string]struct{})
+	tableSeen := make(map[tableKey]struct{})
 	result := make([]*StatsObject, 0, len(objects))
 
 	for _, obj := range objects {
@@ -456,7 +461,7 @@ func dedupStatsObjects(objects []*StatsObject) []*StatsObject {
 				if existing.StatsObjectScope == StatsObjectScopeTable {
 					existingDBKey := existing.DBName.L
 					if existingDBKey != "" && existingDBKey == dbKey {
-						tblKey := existingDBKey + "." + existing.TableName.L
+						tblKey := tableKey{dbName: existingDBKey, tableName: existing.TableName.L}
 						delete(tableSeen, tblKey)
 						continue
 					}
@@ -471,7 +476,7 @@ func dedupStatsObjects(objects []*StatsObject) []*StatsObject {
 					continue
 				}
 			}
-			tblKey := dbKey + "." + obj.TableName.L
+			tblKey := tableKey{dbName: dbKey, tableName: obj.TableName.L}
 			if _, exists := tableSeen[tblKey]; exists {
 				continue
 			}

--- a/pkg/parser/ast/stats_test.go
+++ b/pkg/parser/ast/stats_test.go
@@ -182,6 +182,11 @@ func TestFlushStatsDeltaScoped(t *testing.T) {
 			sql:  "FLUSH STATS_DELTA db1.t1, db1.T1, db2.t1",
 			want: "FLUSH STATS_DELTA `db1`.`t1`, `db2`.`t1`",
 		},
+		{
+			name: "quoted dotted names are distinct",
+			sql:  "FLUSH STATS_DELTA `a.b`.`c`, `a`.`b.c`",
+			want: "FLUSH STATS_DELTA `a.b`.`c`, `a`.`b.c`",
+		},
 	}
 	for _, test := range dedupTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -227,6 +232,11 @@ func TestRefreshStatsStmtDedup(t *testing.T) {
 			name: "database duplicates case insensitive",
 			sql:  "REFRESH STATS db1.*, DB1.*, db2.t1",
 			want: "REFRESH STATS `db1`.*, `db2`.`t1`",
+		},
+		{
+			name: "quoted dotted names are distinct",
+			sql:  "REFRESH STATS `a.b`.`c`, `a`.`b.c`",
+			want: "REFRESH STATS `a.b`.`c`, `a`.`b.c`",
 		},
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #22934

Problem Summary:

Scoped stats targets are deduplicated with a string key built as `dbName + "." + tableName`.
Quoted identifiers can contain dots, so distinct targets like `` `a.b`.`c` `` and `` `a`.`b.c` `` collide and one target is dropped.

### What changed and how does it work?

Use a structured `{dbName, tableName}` key when deduplicating table-scoped stats objects instead of concatenating names with `"."`.
Add regression tests for both `FLUSH STATS_DELTA` and `REFRESH STATS`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  `./tools/check/failpoint-go-test.sh pkg/parser/ast -run '^(TestFlushStatsDeltaScoped|TestRefreshStatsStmtDedup)$' -count=1`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deduplication logic for quoted identifiers in `FLUSH STATS_DELTA` and `REFRESH STATS` statements to properly distinguish between different dotted name formats.

* **Tests**
  * Added test coverage for quoted dotted names in stats operations to ensure correct handling of distinct targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->