### PR TITLE
pkg/planner: remove redundant visited table state in stats usage collector

### DIFF
--- a/pkg/planner/core/rule/collect_column_stats_usage.go
+++ b/pkg/planner/core/rule/collect_column_stats_usage.go
@@ -45,14 +45,9 @@ type columnStatsUsageCollector struct {
 	// cols is used to store columns collected from expressions and saves some allocation.
 	cols []*expression.Column
 
-	// visitedPhysTblIDs all ds.PhysicalTableID that have been visited.
-	// It's always collected, even collectHistNeededColumns is not set.
+	// visitedPhysTblIDs is always collected for stats-load logic and reused by plan replayer capture.
+	// NOTE: it currently stores table meta IDs (DataSource.TableInfo.ID), not ds.PhysicalTableID.
 	visitedPhysTblIDs *intset.FastIntSet
-
-	// collectVisitedTable indicates whether to collect visited table
-	collectVisitedTable bool
-	// visitedtbls indicates the visited table
-	visitedtbls map[int64]struct{}
 
 	// tblID2PartitionIDs is used for tables with static pruning mode.
 	// Note that we've no longer suggested to use static pruning mode.
@@ -67,7 +62,7 @@ type columnStatsUsageCollector struct {
 	colSet map[int64]struct{}
 }
 
-func newColumnStatsUsageCollector(enabledPlanCapture bool, collectIndexPruningCols bool) *columnStatsUsageCollector {
+func newColumnStatsUsageCollector(collectIndexPruningCols bool) *columnStatsUsageCollector {
 	set := intset.NewFastIntSet()
 	collector := &columnStatsUsageCollector{
 		// Pre-allocate a slice to reduce allocation, 8 doesn't have special meaning.
@@ -77,10 +72,6 @@ func newColumnStatsUsageCollector(enabledPlanCapture bool, collectIndexPruningCo
 	}
 	collector.predicateCols = make(map[model.TableItemID]bool)
 	collector.colMap = make(map[int64]map[model.TableItemID]struct{})
-	if enabledPlanCapture {
-		collector.collectVisitedTable = true
-		collector.visitedtbls = map[int64]struct{}{}
-	}
 	if collectIndexPruningCols {
 		collector.interestingColsByDS = make(map[*logicalop.DataSource][]*expression.Column)
 		collector.colSet = make(map[int64]struct{})
@@ -145,9 +136,6 @@ func (c *columnStatsUsageCollector) collectPredicateColumnsForDataSource(askedCo
 	// For partition tables, no matter whether it is static or dynamic pruning mode, we use table ID rather than partition ID to
 	// set TableColumnID.TableID. In this way, we keep the set of predicate columns consistent between different partitions and global table.
 	tblID := ds.TableInfo.ID
-	if c.collectVisitedTable {
-		c.visitedtbls[tblID] = struct{}{}
-	}
 	c.visitedPhysTblIDs.Insert(int(tblID))
 	if tblID != ds.PhysicalTableID {
 		c.tblID2PartitionIDs[tblID] = append(c.tblID2PartitionIDs[tblID], ds.PhysicalTableID)
@@ -442,10 +430,15 @@ func CollectColumnStatsUsage(lp base.LogicalPlan) (
 	threshold := lp.SCtx().GetSessionVars().OptIndexPruneThreshold
 	collectIndexPruningCols := threshold >= 0
 
-	collector := newColumnStatsUsageCollector(lp.SCtx().GetSessionVars().IsPlanReplayerCaptureEnabled(), collectIndexPruningCols)
+	enablePlanCapture := lp.SCtx().GetSessionVars().IsPlanReplayerCaptureEnabled()
+	collector := newColumnStatsUsageCollector(collectIndexPruningCols)
 	collector.collectFromPlan(nil, lp, nil, nil)
-	if collector.collectVisitedTable {
-		recordTableRuntimeStats(lp.SCtx(), collector.visitedtbls)
+	if enablePlanCapture {
+		visitedTbls := make(map[int64]struct{}, collector.visitedPhysTblIDs.Len())
+		collector.visitedPhysTblIDs.ForEach(func(tblID int) {
+			visitedTbls[int64(tblID)] = struct{}{}
+		})
+		recordTableRuntimeStats(lp.SCtx(), visitedTbls)
 	}
 
 	// Populate DataSource field with the collected interesting columns (if index pruning is enabled)

--- a/pkg/planner/core/rule/collect_column_stats_usage.go
+++ b/pkg/planner/core/rule/collect_column_stats_usage.go
@@ -45,9 +45,9 @@ type columnStatsUsageCollector struct {
 	// cols is used to store columns collected from expressions and saves some allocation.
 	cols []*expression.Column
 
-	// visitedTblLogicalIDs is always collected for stats-load logic and reused by plan replayer capture.
-	// NOTE: it currently stores logical table ID (DataSource.TableInfo.ID), not ds.PhysicalTableID.
-	visitedTblLogicalIDs *intset.FastIntSet
+	// visitedLogicalTblIDs is always collected for stats-load logic and reused by plan replayer capture.
+	// it currently stores logical table ID (DataSource.TableInfo.ID), not ds.PhysicalTableID.
+	visitedLogicalTblIDs *intset.FastIntSet
 	// tblID2PartitionIDs is used for tables with static pruning mode.
 	// Note that we've no longer suggested to use static pruning mode.
 	tblID2PartitionIDs map[int64][]int64
@@ -66,7 +66,7 @@ func newColumnStatsUsageCollector(collectIndexPruningCols bool) *columnStatsUsag
 	collector := &columnStatsUsageCollector{
 		// Pre-allocate a slice to reduce allocation, 8 doesn't have special meaning.
 		cols:                 make([]*expression.Column, 0, 8),
-		visitedTblLogicalIDs: &set,
+		visitedLogicalTblIDs: &set,
 		tblID2PartitionIDs:   make(map[int64][]int64),
 	}
 	collector.predicateCols = make(map[model.TableItemID]bool)
@@ -135,7 +135,7 @@ func (c *columnStatsUsageCollector) collectPredicateColumnsForDataSource(askedCo
 	// For partition tables, no matter whether it is static or dynamic pruning mode, we use table ID rather than partition ID to
 	// set TableColumnID.TableID. In this way, we keep the set of predicate columns consistent between different partitions and global table.
 	tblID := ds.TableInfo.ID
-	c.visitedTblLogicalIDs.Insert(int(tblID))
+	c.visitedLogicalTblIDs.Insert(int(tblID))
 	if tblID != ds.PhysicalTableID {
 		c.tblID2PartitionIDs[tblID] = append(c.tblID2PartitionIDs[tblID], ds.PhysicalTableID)
 	}
@@ -415,7 +415,7 @@ func (c *columnStatsUsageCollector) collectFromPlan(askedColGroups [][]*expressi
 // predicate indicates whether to collect predicate columns and histNeeded indicates whether to collect histogram-needed columns.
 // The predicate columns are always collected while the histNeeded columns are depending on whether we use sync load.
 // First return value: predicate columns
-// Second return value: visited table IDs. For partitioned tables, we only record logical table IDs;
+// Second return value: visited logical table IDs. For partitioned tables, we only record logical table IDs;
 // each partition's physical table ID is recorded in tblID2PartitionIDs.
 // Third return value: the visited partition IDs. Used for static partition pruning.
 // Forth return value: the number of operators in the logical plan.
@@ -434,8 +434,8 @@ func CollectColumnStatsUsage(lp base.LogicalPlan) (
 	collector := newColumnStatsUsageCollector(collectIndexPruningCols)
 	collector.collectFromPlan(nil, lp, nil, nil)
 	if enablePlanCapture {
-		visitedTbls := make(map[int64]struct{}, collector.visitedTblLogicalIDs.Len())
-		collector.visitedTblLogicalIDs.ForEach(func(tblID int) {
+		visitedTbls := make(map[int64]struct{}, collector.visitedLogicalTblIDs.Len())
+		collector.visitedLogicalTblIDs.ForEach(func(tblID int) {
 			visitedTbls[int64(tblID)] = struct{}{}
 		})
 		recordTableRuntimeStats(lp.SCtx(), visitedTbls)
@@ -448,5 +448,5 @@ func CollectColumnStatsUsage(lp base.LogicalPlan) (
 		}
 	}
 
-	return collector.predicateCols, collector.visitedTblLogicalIDs, collector.tblID2PartitionIDs, collector.operatorNum
+	return collector.predicateCols, collector.visitedLogicalTblIDs, collector.tblID2PartitionIDs, collector.operatorNum
 }

--- a/pkg/planner/core/rule/collect_column_stats_usage.go
+++ b/pkg/planner/core/rule/collect_column_stats_usage.go
@@ -45,10 +45,9 @@ type columnStatsUsageCollector struct {
 	// cols is used to store columns collected from expressions and saves some allocation.
 	cols []*expression.Column
 
-	// visitedPhysTblIDs is always collected for stats-load logic and reused by plan replayer capture.
-	// NOTE: it currently stores table meta IDs (DataSource.TableInfo.ID), not ds.PhysicalTableID.
-	visitedPhysTblIDs *intset.FastIntSet
-
+	// visitedTblLogicalIDs is always collected for stats-load logic and reused by plan replayer capture.
+	// NOTE: it currently stores logical table ID (DataSource.TableInfo.ID), not ds.PhysicalTableID.
+	visitedTblLogicalIDs *intset.FastIntSet
 	// tblID2PartitionIDs is used for tables with static pruning mode.
 	// Note that we've no longer suggested to use static pruning mode.
 	tblID2PartitionIDs map[int64][]int64
@@ -66,9 +65,9 @@ func newColumnStatsUsageCollector(collectIndexPruningCols bool) *columnStatsUsag
 	set := intset.NewFastIntSet()
 	collector := &columnStatsUsageCollector{
 		// Pre-allocate a slice to reduce allocation, 8 doesn't have special meaning.
-		cols:               make([]*expression.Column, 0, 8),
-		visitedPhysTblIDs:  &set,
-		tblID2PartitionIDs: make(map[int64][]int64),
+		cols:                 make([]*expression.Column, 0, 8),
+		visitedTblLogicalIDs: &set,
+		tblID2PartitionIDs:   make(map[int64][]int64),
 	}
 	collector.predicateCols = make(map[model.TableItemID]bool)
 	collector.colMap = make(map[int64]map[model.TableItemID]struct{})
@@ -136,7 +135,7 @@ func (c *columnStatsUsageCollector) collectPredicateColumnsForDataSource(askedCo
 	// For partition tables, no matter whether it is static or dynamic pruning mode, we use table ID rather than partition ID to
 	// set TableColumnID.TableID. In this way, we keep the set of predicate columns consistent between different partitions and global table.
 	tblID := ds.TableInfo.ID
-	c.visitedPhysTblIDs.Insert(int(tblID))
+	c.visitedTblLogicalIDs.Insert(int(tblID))
 	if tblID != ds.PhysicalTableID {
 		c.tblID2PartitionIDs[tblID] = append(c.tblID2PartitionIDs[tblID], ds.PhysicalTableID)
 	}
@@ -416,7 +415,8 @@ func (c *columnStatsUsageCollector) collectFromPlan(askedColGroups [][]*expressi
 // predicate indicates whether to collect predicate columns and histNeeded indicates whether to collect histogram-needed columns.
 // The predicate columns are always collected while the histNeeded columns are depending on whether we use sync load.
 // First return value: predicate columns
-// Second return value: the visited table IDs(For partition table, we only record its global meta ID. The meta ID of each partition will be recorded in tblID2PartitionIDs)
+// Second return value: visited table IDs. For partitioned tables, we only record logical table IDs;
+// each partition's physical table ID is recorded in tblID2PartitionIDs.
 // Third return value: the visited partition IDs. Used for static partition pruning.
 // Forth return value: the number of operators in the logical plan.
 // TODO: remove the third return value when the static partition pruning is totally deprecated.
@@ -434,8 +434,8 @@ func CollectColumnStatsUsage(lp base.LogicalPlan) (
 	collector := newColumnStatsUsageCollector(collectIndexPruningCols)
 	collector.collectFromPlan(nil, lp, nil, nil)
 	if enablePlanCapture {
-		visitedTbls := make(map[int64]struct{}, collector.visitedPhysTblIDs.Len())
-		collector.visitedPhysTblIDs.ForEach(func(tblID int) {
+		visitedTbls := make(map[int64]struct{}, collector.visitedTblLogicalIDs.Len())
+		collector.visitedTblLogicalIDs.ForEach(func(tblID int) {
 			visitedTbls[int64(tblID)] = struct{}{}
 		})
 		recordTableRuntimeStats(lp.SCtx(), visitedTbls)
@@ -448,5 +448,5 @@ func CollectColumnStatsUsage(lp base.LogicalPlan) (
 		}
 	}
 
-	return collector.predicateCols, collector.visitedPhysTblIDs, collector.tblID2PartitionIDs, collector.operatorNum
+	return collector.predicateCols, collector.visitedTblLogicalIDs, collector.tblID2PartitionIDs, collector.operatorNum
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67912

Problem Summary:
`collect_column_stats_usage` maintained redundant visited-table states for plan replayer capture.

### What changed and how does it work?

- Removed redundant `collectVisitedTable` and `visitedtbls` from the collector.
- Reused `visitedPhysTblIDs` for plan replayer table-stats recording.
- Clarified comments: `visitedPhysTblIDs` currently stores table meta IDs (`DataSource.TableInfo.ID`), not `DataSource.PhysicalTableID`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit tests:
- `./tools/check/failpoint-go-test.sh pkg/planner/core/rule -run 'TestSkipSystemTables|TestCollectPredicateColumns|TestCollectHistNeededColumns'`
- `./tools/check/failpoint-go-test.sh pkg/planner/core -run TestPlanReplayerCaptureRecordJsonStats`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal table-statistics tracking and plan-capture handling to reduce conditional state and streamline control flow.
  * Index-pruning column collection remains conditional; public interfaces and function signatures are unchanged.
  * Expected benefits: clearer code paths, easier maintenance, and potential reliability/performance improvements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68166)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68166)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
