### PR TITLE
gctuner: make TestGlobalMemoryTuner resilient to background GC

### DIFF
--- a/pkg/util/gctuner/memory_limit_tuner_test.go
+++ b/pkg/util/gctuner/memory_limit_tuner_test.go
@@ -107,7 +107,6 @@ func TestGlobalMemoryTuner(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return GlobalMemoryLimitTuner.calcMemoryLimit(fallbackPercentage) == debug.SetMemoryLimit(-1)
 	}, 5*time.Second, 100*time.Millisecond)
-	gcNum = getNowGCNum()
 	memoryLimitGCTotal := memory.MemoryLimitGCTotal.Load()
 	memory100mb := allocator.alloc(100 << 20)
 	// This window used to assert "no GC at all" via NumGC, but that is inherently
@@ -117,9 +116,9 @@ func TestGlobalMemoryTuner(t *testing.T) {
 	// What we really need to assert is: while MemoryLimit is in fallback mode,
 	// allocating more memory should not immediately cause an extra *memory-limit*
 	// GC/adjust cycle.
-	require.Eventually(t, func() bool {
-		return memoryLimitGCTotal == memory.MemoryLimitGCTotal.Load()
-	}, 5*time.Second, 100*time.Millisecond)
+	require.Never(t, func() bool {
+		return memoryLimitGCTotal != memory.MemoryLimitGCTotal.Load()
+	}, 500*time.Millisecond, 100*time.Millisecond)
 
 	allocator.free(memory210mb)
 	allocator.free(memory100mb)

--- a/pkg/util/gctuner/memory_limit_tuner_test.go
+++ b/pkg/util/gctuner/memory_limit_tuner_test.go
@@ -108,10 +108,18 @@ func TestGlobalMemoryTuner(t *testing.T) {
 		return GlobalMemoryLimitTuner.calcMemoryLimit(fallbackPercentage) == debug.SetMemoryLimit(-1)
 	}, 5*time.Second, 100*time.Millisecond)
 	gcNum = getNowGCNum()
+	memoryLimitGCTotal := memory.MemoryLimitGCTotal.Load()
 	memory100mb := allocator.alloc(100 << 20)
+	// This window used to assert "no GC at all" via NumGC, but that is inherently
+	// timing-sensitive: unrelated background GCs (or test harness GCs) can happen
+	// here without violating the intent of this test.
+	//
+	// What we really need to assert is: while MemoryLimit is in fallback mode,
+	// allocating more memory should not immediately cause an extra *memory-limit*
+	// GC/adjust cycle.
 	require.Eventually(t, func() bool {
-		return gcNum == getNowGCNum()
-	}, 5*time.Second, 100*time.Millisecond) // No GC
+		return memoryLimitGCTotal == memory.MemoryLimitGCTotal.Load()
+	}, 5*time.Second, 100*time.Millisecond)
 
 	allocator.free(memory210mb)
 	allocator.free(memory100mb)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67174

`TestGlobalMemoryTuner` in `pkg/util/gctuner` re-flaked after #67377.

The failure is a timing issue in the test itself:

- The test has a window that asserts "no GC at all" by requiring `MemStats.NumGC` to stay unchanged.
- In CI, an unrelated/background GC can occur in that window.
- Once `NumGC` increments between `gcNum = getNowGCNum()` and the first poll, the condition can never become true again, so `require.Eventually` fails with "Condition never satisfied".

This is why the flaky can recur even if the memory-limit tuner logic is correct.

Why the previous fix (#67377) was incomplete:

- #67377 improved observability of GC-driven state transitions by calling `runtime.GC()` inside several polling loops.
- However, it did not address the later "No GC" assertion window, which is inherently unstable under concurrent/background GC activity.

### What changed and how does it work?

This PR makes the test assert the intended invariant instead of asserting "no GC" globally:

- Replace the brittle `NumGC`-based check with a check that `memory.MemoryLimitGCTotal` does not increase during the fallback-memory-limit window.

Rationale:

- The intent of that section is to ensure that while MemoryLimit is temporarily raised to fallback (to avoid frequent GC), allocating a bit more memory should not immediately trigger another memory-limit GC/adjust cycle.
- Background GC is allowed and should not fail the test.

### Timing-only precise repro (deterministic)

A deterministic reproduction can be achieved by forcing a GC to land immediately after the test captures `gcNum` and before it evaluates the "No GC" condition.

One simple timing-only method is:

1. Add a local-only delay right after `gcNum = getNowGCNum()` (so the window is large enough).
2. In another goroutine, call `runtime.GC()` during that delay.

With that timing-only interleaving, the original assertion becomes impossible to satisfy, reproducing the same CI signature.

### Check List

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved tests around memory-management fallback: capture a snapshot of the memory-limit metric before a controlled allocation and continuously assert it does not change during the allocation window (replacing a previous GC-count-based check). This makes validation across allocation scenarios more reliable and increases overall test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->