### PR TITLE
config: add nextgen deploy mode config

### DIFF
--- a/cmd/tidb-server/BUILD.bazel
+++ b/cmd/tidb-server/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/bindinfo",
         "//pkg/config",
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/ddl",
         "//pkg/domain",
@@ -106,9 +107,10 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":tidb-server_lib"],
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/config",
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/parser/mysql",
         "//pkg/sessionctx/vardef",

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -295,7 +295,9 @@ func main() {
 		}
 	}
 	config.InitializeConfig(*configPath, *configCheck, *configStrict, overrideConfig, fset)
-	terror.MustNil(initDeployMode(config.GetGlobalConfig()))
+	if kerneltype.IsNextGen() {
+		terror.MustNil(initDeployMode(config.GetGlobalConfig()))
+	}
 	if *version {
 		mustInitVersions()
 		fmt.Println(printer.GetTiDBInfo())

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/bindinfo"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
@@ -277,6 +278,10 @@ func initFlagSet() *flag.FlagSet {
 	return fset
 }
 
+func initDeployMode(cfg *config.Config) error {
+	return deploymode.Set(cfg.DeployMode)
+}
+
 func main() {
 	fset := initFlagSet()
 	if args := fset.Args(); len(args) != 0 {
@@ -290,6 +295,7 @@ func main() {
 		}
 	}
 	config.InitializeConfig(*configPath, *configCheck, *configStrict, overrideConfig, fset)
+	terror.MustNil(initDeployMode(config.GetGlobalConfig()))
 	if *version {
 		mustInitVersions()
 		fmt.Println(printer.GetTiDBInfo())

--- a/cmd/tidb-server/main_test.go
+++ b/cmd/tidb-server/main_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
@@ -91,6 +92,21 @@ func TestSetGlobalVars(t *testing.T) {
 	if hostname, err := os.Hostname(); err == nil {
 		require.Equal(t, variable.GetSysVar(vardef.Hostname).Value, hostname)
 	}
+}
+
+func TestInitDeployMode(t *testing.T) {
+	original := deploymode.Get()
+	t.Cleanup(func() {
+		require.NoError(t, deploymode.Set(original))
+	})
+
+	cfg := config.NewConfig()
+	cfg.DeployMode = deploymode.PremiumReserved
+	require.NoError(t, initDeployMode(cfg))
+	require.Equal(t, deploymode.PremiumReserved, deploymode.Get())
+
+	cfg.DeployMode = deploymode.Mode(100)
+	require.ErrorContains(t, initDeployMode(cfg), "invalid deploy mode")
 }
 
 func TestSetVersionByConfigInNextGen(t *testing.T) {

--- a/cmd/tidb-server/main_test.go
+++ b/cmd/tidb-server/main_test.go
@@ -95,6 +95,10 @@ func TestSetGlobalVars(t *testing.T) {
 }
 
 func TestInitDeployMode(t *testing.T) {
+	if kerneltype.IsClassic() {
+		t.Skip("only for nextgen kernel")
+	}
+
 	original := deploymode.Get()
 	t.Cleanup(func() {
 		require.NoError(t, deploymode.Set(original))

--- a/cmd/tidb-server/main_test.go
+++ b/cmd/tidb-server/main_test.go
@@ -99,15 +99,9 @@ func TestInitDeployMode(t *testing.T) {
 		t.Skip("only for nextgen kernel")
 	}
 
-	original := deploymode.Get()
-	t.Cleanup(func() {
-		require.NoError(t, deploymode.Set(original))
-	})
-
 	cfg := config.NewConfig()
-	cfg.DeployMode = deploymode.PremiumReserved
 	require.NoError(t, initDeployMode(cfg))
-	require.Equal(t, deploymode.PremiumReserved, deploymode.Get())
+	require.Equal(t, deploymode.Premium, deploymode.Get())
 
 	cfg.DeployMode = deploymode.Mode(100)
 	require.ErrorContains(t, initDeployMode(cfg), "invalid deploy mode")

--- a/cmd/tidb-server/main_test.go
+++ b/cmd/tidb-server/main_test.go
@@ -99,9 +99,15 @@ func TestInitDeployMode(t *testing.T) {
 		t.Skip("only for nextgen kernel")
 	}
 
+	original := deploymode.Get()
+	t.Cleanup(func() {
+		require.NoError(t, deploymode.Set(original))
+	})
+
 	cfg := config.NewConfig()
+	cfg.DeployMode = deploymode.PremiumReserved
 	require.NoError(t, initDeployMode(cfg))
-	require.Equal(t, deploymode.Premium, deploymode.Get())
+	require.Equal(t, deploymode.PremiumReserved, deploymode.Get())
 
 	cfg.DeployMode = deploymode.Mode(100)
 	require.ErrorContains(t, initDeployMode(cfg), "invalid deploy mode")

--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/config",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/parser/terror",
         "//pkg/util/intest",
@@ -41,8 +42,9 @@ go_test(
     data = glob(["**"]),
     embed = [":config"],
     flaky = True,
-    shard_count = 31,
+    shard_count = 32,
     deps = [
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/testkit/testsetup",
         "//pkg/util/logutil",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1382,6 +1382,9 @@ func (c *Config) Load(confFile string) error {
 	if err != nil {
 		return err
 	}
+	if !kerneltype.IsNextGen() && metaData.IsDefined("deploy-mode") {
+		return fmt.Errorf("deploy-mode can only be configured for nextgen TiDB")
+	}
 	if c.TokenLimit == 0 {
 		c.TokenLimit = 1000
 	} else if c.TokenLimit > MaxTokenLimit {
@@ -1449,6 +1452,9 @@ func (c *Config) Valid() error {
 	}
 	if !c.DeployMode.Valid() {
 		return fmt.Errorf("invalid deploy-mode=%s, valid deploy modes=%v", c.DeployMode, deploymode.ModeList())
+	}
+	if !kerneltype.IsNextGen() && c.DeployMode != deploymode.Premium {
+		return fmt.Errorf("deploy-mode can only be configured for nextgen TiDB")
 	}
 	if c.Store == StoreTypeMockTiKV && !c.Instance.TiDBEnableDDL.Load() {
 		return fmt.Errorf("can't disable DDL on mocktikv")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/errors"
 	zaplog "github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/util/intest"
@@ -199,6 +200,7 @@ type Config struct {
 	VersionComment             string                  `toml:"version-comment" json:"version-comment"`
 	TiDBEdition                string                  `toml:"tidb-edition" json:"tidb-edition"`
 	TiDBReleaseVersion         string                  `toml:"tidb-release-version" json:"tidb-release-version"`
+	DeployMode                 deploymode.Mode         `toml:"deploy-mode" json:"deploy-mode"`
 	KeyspaceName               string                  `toml:"keyspace-name" json:"keyspace-name"`
 	TiKVWorkerURL              string                  `toml:"tikv-worker-url" json:"tikv-worker-url"`
 	Log                        Log                     `toml:"log" json:"log"`
@@ -1038,6 +1040,7 @@ var defaultConf = Config{
 	TiDBEdition:                  "",
 	VersionComment:               "",
 	TiDBReleaseVersion:           "",
+	DeployMode:                   deploymode.Premium,
 	RUV2:                         DefaultRUV2Config(),
 	Log: Log{
 		Level:               "info",
@@ -1443,6 +1446,9 @@ func (c *Config) Valid() error {
 	}
 	if !c.Store.Valid() {
 		return fmt.Errorf("invalid store=%s, valid storages=%v", c.Store, StoreTypeList())
+	}
+	if !c.DeployMode.Valid() {
+		return fmt.Errorf("invalid deploy-mode=%s, valid deploy modes=%v", c.DeployMode, deploymode.ModeList())
 	}
 	if c.Store == StoreTypeMockTiKV && !c.Instance.TiDBEnableDDL.Load() {
 		return fmt.Errorf("can't disable DDL on mocktikv")

--- a/pkg/config/config.toml.example
+++ b/pkg/config/config.toml.example
@@ -12,6 +12,10 @@ port = 4000
 # Registered store name, [tikv, mocktikv, unistore]
 store = "unistore"
 
+# Deployment mode, [premium, premium_reserved]. It is initialized on startup
+# and cannot be changed at runtime.
+deploy-mode = "premium"
+
 # TiDB storage path.
 path = "/tmp/tidb"
 

--- a/pkg/config/config.toml.example
+++ b/pkg/config/config.toml.example
@@ -12,10 +12,6 @@ port = 4000
 # Registered store name, [tikv, mocktikv, unistore]
 store = "unistore"
 
-# Deployment mode, [premium, premium_reserved]. It is initialized on startup
-# and cannot be changed at runtime.
-deploy-mode = "premium"
-
 # TiDB storage path.
 path = "/tmp/tidb"
 

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -12,6 +12,10 @@ port = 4000
 # Registered store name, [tikv, mocktikv, unistore]
 store = "unistore"
 
+# Deployment mode, [premium, premium_reserved]. It is initialized on startup
+# and cannot be changed at runtime.
+deploy-mode = "premium"
+
 # TiDB storage path.
 path = "/tmp/tidb"
 

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -12,8 +12,8 @@ port = 4000
 # Registered store name, [tikv, mocktikv, unistore]
 store = "unistore"
 
-# Deployment mode, [premium, premium_reserved, starter]. It is initialized on startup
-# and cannot be changed at runtime.
+# Deployment mode, [premium, premium_reserved, starter]. It is initialized during
+# startup and cannot be changed after it is set.
 deploy-mode = "premium"
 
 # TiDB storage path.

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -12,7 +12,7 @@ port = 4000
 # Registered store name, [tikv, mocktikv, unistore]
 store = "unistore"
 
-# Deployment mode, [premium, premium_reserved]. It is initialized on startup
+# Deployment mode, [premium, premium_reserved, starter]. It is initialized on startup
 # and cannot be changed at runtime.
 deploy-mode = "premium"
 

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -12,8 +12,8 @@ port = 4000
 # Registered store name, [tikv, mocktikv, unistore]
 store = "unistore"
 
-# Deployment mode, [premium, premium_reserved, starter]. It is initialized during
-# startup and cannot be changed after it is set.
+# Deployment mode, [premium, premium_reserved, starter]. It is initialized on startup
+# and cannot be changed at runtime.
 deploy-mode = "premium"
 
 # TiDB storage path.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/errors"
 	zaplog "github.com/pingcap/log"
 	meter_config "github.com/pingcap/metering_sdk/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/stretchr/testify/require"
@@ -1046,6 +1047,25 @@ func TestTxnTotalSizeLimitValid(t *testing.T) {
 		conf.Performance.TxnTotalSizeLimit = tt.limit
 		require.Equal(t, tt.valid, conf.Valid() == nil)
 	}
+}
+
+func TestDeployModeConfig(t *testing.T) {
+	conf := NewConfig()
+	require.Equal(t, deploymode.Premium, conf.DeployMode)
+	require.NoError(t, conf.Valid())
+
+	storeDir := t.TempDir()
+	configFile := filepath.Join(storeDir, "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "premium_reserved"`), 0644))
+
+	conf = NewConfig()
+	require.NoError(t, conf.Load(configFile))
+	require.Equal(t, deploymode.PremiumReserved, conf.DeployMode)
+	require.NoError(t, conf.Valid())
+
+	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "unknown"`), 0644))
+	conf = NewConfig()
+	require.ErrorContains(t, conf.Load(configFile), `invalid deploy mode "unknown"`)
 }
 
 func TestConflictInstanceConfig(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1056,6 +1056,18 @@ func TestDeployModeConfig(t *testing.T) {
 
 	storeDir := t.TempDir()
 	configFile := filepath.Join(storeDir, "config.toml")
+
+	if kerneltype.IsClassic() {
+		require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "premium"`), 0644))
+		conf = NewConfig()
+		require.ErrorContains(t, conf.Load(configFile), "deploy-mode can only be configured for nextgen TiDB")
+
+		conf = NewConfig()
+		conf.DeployMode = deploymode.PremiumReserved
+		require.ErrorContains(t, conf.Valid(), "deploy-mode can only be configured for nextgen TiDB")
+		return
+	}
+
 	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "premium_reserved"`), 0644))
 
 	conf = NewConfig()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1075,6 +1075,12 @@ func TestDeployModeConfig(t *testing.T) {
 	require.Equal(t, deploymode.PremiumReserved, conf.DeployMode)
 	require.NoError(t, conf.Valid())
 
+	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "starter"`), 0644))
+	conf = NewConfig()
+	require.NoError(t, conf.Load(configFile))
+	require.Equal(t, deploymode.Starter, conf.DeployMode)
+	require.NoError(t, conf.Valid())
+
 	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "unknown"`), 0644))
 	conf = NewConfig()
 	require.ErrorContains(t, conf.Load(configFile), `invalid deploy mode "unknown"`)

--- a/pkg/config/deploymode/BUILD.bazel
+++ b/pkg/config/deploymode/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["mode.go"],
     importpath = "github.com/pingcap/tidb/pkg/config/deploymode",
     visibility = ["//visibility:public"],
+    deps = ["//pkg/config/kerneltype"],
 )
 
 go_test(
@@ -15,6 +16,7 @@ go_test(
     flaky = True,
     shard_count = 3,
     deps = [
+        "//pkg/config/kerneltype",
         "@com_github_burntsushi_toml//:toml",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/config/deploymode/BUILD.bazel
+++ b/pkg/config/deploymode/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "deploymode",
+    srcs = ["mode.go"],
+    importpath = "github.com/pingcap/tidb/pkg/config/deploymode",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "deploymode_test",
+    timeout = "short",
+    srcs = ["mode_test.go"],
+    embed = [":deploymode"],
+    flaky = True,
+    shard_count = 3,
+    deps = [
+        "@com_github_burntsushi_toml//:toml",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/config/deploymode/BUILD.bazel
+++ b/pkg/config/deploymode/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "deploymode",
-    srcs = ["mode.go"],
+    srcs = [
+        "doc.go",
+        "mode.go",
+    ],
     importpath = "github.com/pingcap/tidb/pkg/config/deploymode",
     visibility = ["//visibility:public"],
     deps = ["//pkg/config/kerneltype"],

--- a/pkg/config/deploymode/doc.go
+++ b/pkg/config/deploymode/doc.go
@@ -26,4 +26,12 @@
 // avoiding TiKV-worker and coprocessor-worker deployment, and by merging TiDB
 // and TiDB-worker behavior. User traffic and distributed task execution run
 // directly on TiDB nodes, and they all run on the SYSTEM keyspace.
+//
+// Deploy mode is stored in TiDB component config. This can make the deploy mode
+// inconsistent across TiDB instances if different instances are started with
+// different config values. The tradeoff is intentional: keeping deploy mode in
+// TiDB config avoids changing other components and avoids maintaining separate
+// binaries. Premium Reserved is mainly used in cloud deployments, where all TiDB
+// instances in one group are started with the same config, so the consistency
+// risk is acceptable.
 package deploymode

--- a/pkg/config/deploymode/doc.go
+++ b/pkg/config/deploymode/doc.go
@@ -1,0 +1,29 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package deploymode stores the process-wide deployment mode for TiDB X
+// (NextGen) deployments.
+//
+// TiDB X Premium Reserved keeps the Premium product capability set, but uses a
+// fixed-resource deployment shape instead of the standard Premium elastic shape.
+// The resource scope is decided when the cluster starts. TiDB-worker,
+// TiKV-worker, and coprocessor-worker are not scaled on demand, so background
+// tasks must not assume that additional worker resources will be created
+// automatically when task demand increases.
+//
+// Premium Reserved adapts Premium behavior to that fixed-resource shape by
+// avoiding TiKV-worker and coprocessor-worker deployment, and by merging TiDB
+// and TiDB-worker behavior. User traffic and distributed task execution run
+// directly on TiDB nodes, and they all run on the SYSTEM keyspace.
+package deploymode

--- a/pkg/config/deploymode/doc.go
+++ b/pkg/config/deploymode/doc.go
@@ -29,7 +29,8 @@
 //
 // Starter is a deployment mode for supporting a large number of small tenants.
 //
-// Deploy mode is stored in TiDB component config. This can make the deploy mode
+// Deploy mode is initialized during TiDB startup and cannot be changed after it
+// is set. It is stored in TiDB component config, which can make the deploy mode
 // inconsistent across TiDB instances if different instances are started with
 // different config values. The tradeoff is intentional: keeping deploy mode in
 // TiDB config avoids changing other components and avoids maintaining separate

--- a/pkg/config/deploymode/doc.go
+++ b/pkg/config/deploymode/doc.go
@@ -27,6 +27,8 @@
 // and TiDB-worker behavior. User traffic and distributed task execution run
 // directly on TiDB nodes, and they all run on the SYSTEM keyspace.
 //
+// Starter is a deployment mode for supporting a large number of small tenants.
+//
 // Deploy mode is stored in TiDB component config. This can make the deploy mode
 // inconsistent across TiDB instances if different instances are started with
 // different config values. The tradeoff is intentional: keeping deploy mode in

--- a/pkg/config/deploymode/doc.go
+++ b/pkg/config/deploymode/doc.go
@@ -29,8 +29,7 @@
 //
 // Starter is a deployment mode for supporting a large number of small tenants.
 //
-// Deploy mode is initialized during TiDB startup and cannot be changed after it
-// is set. It is stored in TiDB component config, which can make the deploy mode
+// Deploy mode is stored in TiDB component config. This can make the deploy mode
 // inconsistent across TiDB instances if different instances are started with
 // different config values. The tradeoff is intentional: keeping deploy mode in
 // TiDB config avoids changing other components and avoids maintaining separate

--- a/pkg/config/deploymode/mode.go
+++ b/pkg/config/deploymode/mode.go
@@ -18,6 +18,7 @@ package deploymode
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync/atomic"
 
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
@@ -35,7 +36,9 @@ type Mode int32
 const (
 	// Premium is the default deployment mode.
 	Premium Mode = iota
-	// PremiumReserved is the reserved premium deployment mode.
+	// PremiumReserved is the reserved premium deployment mode. In Premium Reserved,
+	// resources are fixed when the cluster starts. TiDB-worker, TiKV-worker, and
+	// coprocessor-worker are not scaled on demand.
 	PremiumReserved
 )
 
@@ -44,6 +47,11 @@ var currentMode atomic.Int32
 // Get returns the current deployment mode.
 func Get() Mode {
 	return Mode(currentMode.Load())
+}
+
+// IsPremiumReserved returns true if the current deployment mode is PremiumReserved.
+func IsPremiumReserved() bool {
+	return kerneltype.IsNextGen() && Get() == PremiumReserved
 }
 
 // Set updates the current deployment mode.
@@ -63,7 +71,7 @@ func Set(mode Mode) error {
 
 // Parse returns the deployment mode for the given string.
 func Parse(s string) (Mode, error) {
-	switch s {
+	switch strings.ToLower(s) {
 	case premiumName:
 		return Premium, nil
 	case premiumReservedName:

--- a/pkg/config/deploymode/mode.go
+++ b/pkg/config/deploymode/mode.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package deploymode stores the process-wide TiDB deployment mode.
 package deploymode
 
 import (

--- a/pkg/config/deploymode/mode.go
+++ b/pkg/config/deploymode/mode.go
@@ -1,0 +1,135 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package deploymode stores the process-wide TiDB deployment mode.
+package deploymode
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+)
+
+const (
+	premiumName         = "premium"
+	premiumReservedName = "premium_reserved"
+)
+
+// Mode is the deployment mode of the TiDB instance.
+type Mode int32
+
+const (
+	// Premium is the default deployment mode.
+	Premium Mode = iota
+	// PremiumReserved is the reserved premium deployment mode.
+	PremiumReserved
+)
+
+var currentMode atomic.Int32
+
+// Get returns the current deployment mode.
+func Get() Mode {
+	return Mode(currentMode.Load())
+}
+
+// Set updates the current deployment mode.
+//
+// The deployment mode is initialized during TiDB startup and should not be
+// changed during runtime.
+func Set(mode Mode) error {
+	if !mode.Valid() {
+		return fmt.Errorf("invalid deploy mode %d", mode)
+	}
+	currentMode.Store(int32(mode))
+	return nil
+}
+
+// Parse returns the deployment mode for the given string.
+func Parse(s string) (Mode, error) {
+	switch s {
+	case premiumName:
+		return Premium, nil
+	case premiumReservedName:
+		return PremiumReserved, nil
+	default:
+		return Premium, fmt.Errorf("invalid deploy mode %q", s)
+	}
+}
+
+// String returns the string representation of the deployment mode.
+func (m Mode) String() string {
+	switch m {
+	case Premium:
+		return premiumName
+	case PremiumReserved:
+		return premiumReservedName
+	default:
+		return fmt.Sprintf("unknown(%d)", m)
+	}
+}
+
+// Valid returns true if the deployment mode is valid.
+func (m Mode) Valid() bool {
+	switch m {
+	case Premium, PremiumReserved:
+		return true
+	default:
+		return false
+	}
+}
+
+// ModeList returns all valid deployment modes.
+func ModeList() []Mode {
+	return []Mode{Premium, PremiumReserved}
+}
+
+// MarshalJSON implements json.Marshaler.
+func (m Mode) MarshalJSON() ([]byte, error) {
+	if !m.Valid() {
+		return nil, fmt.Errorf("invalid deploy mode %d", m)
+	}
+	return json.Marshal(m.String())
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (m *Mode) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	mode, err := Parse(s)
+	if err != nil {
+		return err
+	}
+	*m = mode
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (m Mode) MarshalText() ([]byte, error) {
+	if !m.Valid() {
+		return nil, fmt.Errorf("invalid deploy mode %d", m)
+	}
+	return []byte(m.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (m *Mode) UnmarshalText(text []byte) error {
+	mode, err := Parse(string(text))
+	if err != nil {
+		return err
+	}
+	*m = mode
+	return nil
+}

--- a/pkg/config/deploymode/mode.go
+++ b/pkg/config/deploymode/mode.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync/atomic"
+
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 )
 
 const (
@@ -26,7 +28,8 @@ const (
 	premiumReservedName = "premium_reserved"
 )
 
-// Mode is the deployment mode of the TiDB instance.
+// Mode is the deployment mode of the TiDB instance. It is only allowed when
+// kerneltype.IsNextGen returns true.
 type Mode int32
 
 const (
@@ -48,6 +51,9 @@ func Get() Mode {
 // The deployment mode is initialized during TiDB startup and should not be
 // changed during runtime.
 func Set(mode Mode) error {
+	if !kerneltype.IsNextGen() {
+		return fmt.Errorf("deploy mode can only be set for nextgen TiDB")
+	}
 	if !mode.Valid() {
 		return fmt.Errorf("invalid deploy mode %d", mode)
 	}
@@ -116,17 +122,13 @@ func (m *Mode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalText implements encoding.TextMarshaler.
-func (m Mode) MarshalText() ([]byte, error) {
-	if !m.Valid() {
-		return nil, fmt.Errorf("invalid deploy mode %d", m)
+// UnmarshalTOML implements toml.Unmarshaler.
+func (m *Mode) UnmarshalTOML(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("invalid deploy mode %v", v)
 	}
-	return []byte(m.String()), nil
-}
-
-// UnmarshalText implements encoding.TextUnmarshaler.
-func (m *Mode) UnmarshalText(text []byte) error {
-	mode, err := Parse(string(text))
+	mode, err := Parse(s)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/deploymode/mode.go
+++ b/pkg/config/deploymode/mode.go
@@ -26,6 +26,7 @@ import (
 const (
 	premiumName         = "premium"
 	premiumReservedName = "premium_reserved"
+	starterName         = "starter"
 )
 
 // Mode is the deployment mode of the TiDB instance. It is only allowed when
@@ -39,6 +40,8 @@ const (
 	// resources are fixed when the cluster starts. TiDB-worker, TiKV-worker, and
 	// coprocessor-worker are not scaled on demand.
 	PremiumReserved
+	// Starter is for deployments that support a large number of small tenants.
+	Starter
 )
 
 var currentMode atomic.Int32
@@ -51,6 +54,11 @@ func Get() Mode {
 // IsPremiumReserved returns true if the current deployment mode is PremiumReserved.
 func IsPremiumReserved() bool {
 	return kerneltype.IsNextGen() && Get() == PremiumReserved
+}
+
+// IsStarter returns true if the current deployment mode is Starter.
+func IsStarter() bool {
+	return kerneltype.IsNextGen() && Get() == Starter
 }
 
 // Set updates the current deployment mode.
@@ -75,6 +83,8 @@ func Parse(s string) (Mode, error) {
 		return Premium, nil
 	case premiumReservedName:
 		return PremiumReserved, nil
+	case starterName:
+		return Starter, nil
 	default:
 		return Premium, fmt.Errorf("invalid deploy mode %q", s)
 	}
@@ -87,6 +97,8 @@ func (m Mode) String() string {
 		return premiumName
 	case PremiumReserved:
 		return premiumReservedName
+	case Starter:
+		return starterName
 	default:
 		return fmt.Sprintf("unknown(%d)", m)
 	}
@@ -95,7 +107,7 @@ func (m Mode) String() string {
 // Valid returns true if the deployment mode is valid.
 func (m Mode) Valid() bool {
 	switch m {
-	case Premium, PremiumReserved:
+	case Premium, PremiumReserved, Starter:
 		return true
 	default:
 		return false
@@ -104,7 +116,7 @@ func (m Mode) Valid() bool {
 
 // ModeList returns all valid deployment modes.
 func ModeList() []Mode {
-	return []Mode{Premium, PremiumReserved}
+	return []Mode{Premium, PremiumReserved, Starter}
 }
 
 // MarshalJSON implements json.Marshaler.

--- a/pkg/config/deploymode/mode.go
+++ b/pkg/config/deploymode/mode.go
@@ -29,6 +29,8 @@ const (
 	starterName         = "starter"
 )
 
+const unsetMode int32 = -1
+
 // Mode is the deployment mode of the TiDB instance. It is only allowed when
 // kerneltype.IsNextGen returns true.
 type Mode int32
@@ -46,9 +48,17 @@ const (
 
 var currentMode atomic.Int32
 
+func init() {
+	currentMode.Store(unsetMode)
+}
+
 // Get returns the current deployment mode.
 func Get() Mode {
-	return Mode(currentMode.Load())
+	mode := currentMode.Load()
+	if mode == unsetMode {
+		return Premium
+	}
+	return Mode(mode)
 }
 
 // IsPremiumReserved returns true if the current deployment mode is PremiumReserved.
@@ -61,10 +71,10 @@ func IsStarter() bool {
 	return kerneltype.IsNextGen() && Get() == Starter
 }
 
-// Set updates the current deployment mode.
+// Set initializes the current deployment mode.
 //
-// The deployment mode is initialized during TiDB startup and should not be
-// changed during runtime.
+// The deployment mode is initialized during TiDB startup and cannot be changed
+// after it is set.
 func Set(mode Mode) error {
 	if !kerneltype.IsNextGen() {
 		return fmt.Errorf("deploy mode can only be set for nextgen TiDB")
@@ -72,8 +82,18 @@ func Set(mode Mode) error {
 	if !mode.Valid() {
 		return fmt.Errorf("invalid deploy mode %d", mode)
 	}
-	currentMode.Store(int32(mode))
-	return nil
+	for {
+		current := currentMode.Load()
+		if current != unsetMode {
+			if Mode(current) == mode {
+				return nil
+			}
+			return fmt.Errorf("deploy mode cannot be changed after it is set")
+		}
+		if currentMode.CompareAndSwap(unsetMode, int32(mode)) {
+			return nil
+		}
+	}
 }
 
 // Parse returns the deployment mode for the given string.

--- a/pkg/config/deploymode/mode.go
+++ b/pkg/config/deploymode/mode.go
@@ -61,10 +61,9 @@ func IsStarter() bool {
 	return kerneltype.IsNextGen() && Get() == Starter
 }
 
-// Set updates the current deployment mode.
+// Set sets the current deployment mode during TiDB startup.
 //
-// The deployment mode is initialized during TiDB startup and should not be
-// changed during runtime.
+// The deployment mode cannot be changed after it is set.
 func Set(mode Mode) error {
 	if !kerneltype.IsNextGen() {
 		return fmt.Errorf("deploy mode can only be set for nextgen TiDB")

--- a/pkg/config/deploymode/mode.go
+++ b/pkg/config/deploymode/mode.go
@@ -29,8 +29,6 @@ const (
 	starterName         = "starter"
 )
 
-const unsetMode int32 = -1
-
 // Mode is the deployment mode of the TiDB instance. It is only allowed when
 // kerneltype.IsNextGen returns true.
 type Mode int32
@@ -48,17 +46,9 @@ const (
 
 var currentMode atomic.Int32
 
-func init() {
-	currentMode.Store(unsetMode)
-}
-
 // Get returns the current deployment mode.
 func Get() Mode {
-	mode := currentMode.Load()
-	if mode == unsetMode {
-		return Premium
-	}
-	return Mode(mode)
+	return Mode(currentMode.Load())
 }
 
 // IsPremiumReserved returns true if the current deployment mode is PremiumReserved.
@@ -71,10 +61,10 @@ func IsStarter() bool {
 	return kerneltype.IsNextGen() && Get() == Starter
 }
 
-// Set initializes the current deployment mode.
+// Set updates the current deployment mode.
 //
-// The deployment mode is initialized during TiDB startup and cannot be changed
-// after it is set.
+// The deployment mode is initialized during TiDB startup and should not be
+// changed during runtime.
 func Set(mode Mode) error {
 	if !kerneltype.IsNextGen() {
 		return fmt.Errorf("deploy mode can only be set for nextgen TiDB")
@@ -82,18 +72,8 @@ func Set(mode Mode) error {
 	if !mode.Valid() {
 		return fmt.Errorf("invalid deploy mode %d", mode)
 	}
-	for {
-		current := currentMode.Load()
-		if current != unsetMode {
-			if Mode(current) == mode {
-				return nil
-			}
-			return fmt.Errorf("deploy mode cannot be changed after it is set")
-		}
-		if currentMode.CompareAndSwap(unsetMode, int32(mode)) {
-			return nil
-		}
-	}
+	currentMode.Store(int32(mode))
+	return nil
 }
 
 // Parse returns the deployment mode for the given string.

--- a/pkg/config/deploymode/mode_test.go
+++ b/pkg/config/deploymode/mode_test.go
@@ -35,6 +35,9 @@ func TestModeJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(`"premium_reserved"`), &mode))
 	require.Equal(t, PremiumReserved, mode)
 
+	require.NoError(t, json.Unmarshal([]byte(`"Premium_Reserved"`), &mode))
+	require.Equal(t, PremiumReserved, mode)
+
 	require.ErrorContains(t, json.Unmarshal([]byte(`"unknown"`), &mode), `invalid deploy mode "unknown"`)
 	require.Error(t, json.Unmarshal([]byte(`1`), &mode))
 }
@@ -47,23 +50,30 @@ func TestModeTOML(t *testing.T) {
 	_, err := toml.Decode(`deploy-mode = "premium_reserved"`, &cfg)
 	require.NoError(t, err)
 	require.Equal(t, PremiumReserved, cfg.Mode)
+
+	_, err = toml.Decode(`deploy-mode = "Premium"`, &cfg)
+	require.NoError(t, err)
+	require.Equal(t, Premium, cfg.Mode)
 }
 
 func TestCurrentMode(t *testing.T) {
+	original := Get()
+	t.Cleanup(func() {
+		currentMode.Store(int32(original))
+	})
+
 	if !kerneltype.IsNextGen() {
 		require.Equal(t, Premium, Get())
+		currentMode.Store(int32(PremiumReserved))
+		require.False(t, IsPremiumReserved())
 		require.ErrorContains(t, Set(PremiumReserved), "deploy mode can only be set for nextgen TiDB")
-		require.Equal(t, Premium, Get())
 		return
 	}
 
-	original := Get()
-	t.Cleanup(func() {
-		require.NoError(t, Set(original))
-	})
-
 	require.Equal(t, Premium, Get())
+	require.False(t, IsPremiumReserved())
 	require.NoError(t, Set(PremiumReserved))
 	require.Equal(t, PremiumReserved, Get())
+	require.True(t, IsPremiumReserved())
 	require.ErrorContains(t, Set(Mode(100)), "invalid deploy mode")
 }

--- a/pkg/config/deploymode/mode_test.go
+++ b/pkg/config/deploymode/mode_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploymode
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModeJSON(t *testing.T) {
+	data, err := json.Marshal(PremiumReserved)
+	require.NoError(t, err)
+	require.Equal(t, `"premium_reserved"`, string(data))
+
+	var mode Mode
+	require.NoError(t, json.Unmarshal([]byte(`"premium"`), &mode))
+	require.Equal(t, Premium, mode)
+
+	require.NoError(t, json.Unmarshal([]byte(`"premium_reserved"`), &mode))
+	require.Equal(t, PremiumReserved, mode)
+
+	require.ErrorContains(t, json.Unmarshal([]byte(`"unknown"`), &mode), `invalid deploy mode "unknown"`)
+	require.Error(t, json.Unmarshal([]byte(`1`), &mode))
+}
+
+func TestModeText(t *testing.T) {
+	var cfg struct {
+		Mode Mode `toml:"deploy-mode"`
+	}
+
+	_, err := toml.Decode(`deploy-mode = "premium_reserved"`, &cfg)
+	require.NoError(t, err)
+	require.Equal(t, PremiumReserved, cfg.Mode)
+
+	text, err := Premium.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "premium", string(text))
+}
+
+func TestCurrentMode(t *testing.T) {
+	original := Get()
+	t.Cleanup(func() {
+		require.NoError(t, Set(original))
+	})
+
+	require.Equal(t, Premium, Get())
+	require.NoError(t, Set(PremiumReserved))
+	require.Equal(t, PremiumReserved, Get())
+	require.ErrorContains(t, Set(Mode(100)), "invalid deploy mode")
+}

--- a/pkg/config/deploymode/mode_test.go
+++ b/pkg/config/deploymode/mode_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,7 +39,7 @@ func TestModeJSON(t *testing.T) {
 	require.Error(t, json.Unmarshal([]byte(`1`), &mode))
 }
 
-func TestModeText(t *testing.T) {
+func TestModeTOML(t *testing.T) {
 	var cfg struct {
 		Mode Mode `toml:"deploy-mode"`
 	}
@@ -46,13 +47,16 @@ func TestModeText(t *testing.T) {
 	_, err := toml.Decode(`deploy-mode = "premium_reserved"`, &cfg)
 	require.NoError(t, err)
 	require.Equal(t, PremiumReserved, cfg.Mode)
-
-	text, err := Premium.MarshalText()
-	require.NoError(t, err)
-	require.Equal(t, "premium", string(text))
 }
 
 func TestCurrentMode(t *testing.T) {
+	if !kerneltype.IsNextGen() {
+		require.Equal(t, Premium, Get())
+		require.ErrorContains(t, Set(PremiumReserved), "deploy mode can only be set for nextgen TiDB")
+		require.Equal(t, Premium, Get())
+		return
+	}
+
 	original := Get()
 	t.Cleanup(func() {
 		require.NoError(t, Set(original))

--- a/pkg/config/deploymode/mode_test.go
+++ b/pkg/config/deploymode/mode_test.go
@@ -68,9 +68,9 @@ func TestModeTOML(t *testing.T) {
 }
 
 func TestCurrentMode(t *testing.T) {
-	original := currentMode.Load()
+	original := Get()
 	t.Cleanup(func() {
-		currentMode.Store(original)
+		currentMode.Store(int32(original))
 	})
 
 	if !kerneltype.IsNextGen() {
@@ -90,10 +90,9 @@ func TestCurrentMode(t *testing.T) {
 	require.Equal(t, PremiumReserved, Get())
 	require.True(t, IsPremiumReserved())
 	require.False(t, IsStarter())
-	require.NoError(t, Set(PremiumReserved))
-	require.ErrorContains(t, Set(Starter), "deploy mode cannot be changed after it is set")
-	require.Equal(t, PremiumReserved, Get())
-	require.True(t, IsPremiumReserved())
-	require.False(t, IsStarter())
+	require.NoError(t, Set(Starter))
+	require.Equal(t, Starter, Get())
+	require.False(t, IsPremiumReserved())
+	require.True(t, IsStarter())
 	require.ErrorContains(t, Set(Mode(100)), "invalid deploy mode")
 }

--- a/pkg/config/deploymode/mode_test.go
+++ b/pkg/config/deploymode/mode_test.go
@@ -28,6 +28,10 @@ func TestModeJSON(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, `"premium_reserved"`, string(data))
 
+	data, err = json.Marshal(Starter)
+	require.NoError(t, err)
+	require.Equal(t, `"starter"`, string(data))
+
 	var mode Mode
 	require.NoError(t, json.Unmarshal([]byte(`"premium"`), &mode))
 	require.Equal(t, Premium, mode)
@@ -37,6 +41,9 @@ func TestModeJSON(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal([]byte(`"Premium_Reserved"`), &mode))
 	require.Equal(t, PremiumReserved, mode)
+
+	require.NoError(t, json.Unmarshal([]byte(`"Starter"`), &mode))
+	require.Equal(t, Starter, mode)
 
 	require.ErrorContains(t, json.Unmarshal([]byte(`"unknown"`), &mode), `invalid deploy mode "unknown"`)
 	require.Error(t, json.Unmarshal([]byte(`1`), &mode))
@@ -54,6 +61,10 @@ func TestModeTOML(t *testing.T) {
 	_, err = toml.Decode(`deploy-mode = "Premium"`, &cfg)
 	require.NoError(t, err)
 	require.Equal(t, Premium, cfg.Mode)
+
+	_, err = toml.Decode(`deploy-mode = "Starter"`, &cfg)
+	require.NoError(t, err)
+	require.Equal(t, Starter, cfg.Mode)
 }
 
 func TestCurrentMode(t *testing.T) {
@@ -66,14 +77,22 @@ func TestCurrentMode(t *testing.T) {
 		require.Equal(t, Premium, Get())
 		currentMode.Store(int32(PremiumReserved))
 		require.False(t, IsPremiumReserved())
+		currentMode.Store(int32(Starter))
+		require.False(t, IsStarter())
 		require.ErrorContains(t, Set(PremiumReserved), "deploy mode can only be set for nextgen TiDB")
 		return
 	}
 
 	require.Equal(t, Premium, Get())
 	require.False(t, IsPremiumReserved())
+	require.False(t, IsStarter())
 	require.NoError(t, Set(PremiumReserved))
 	require.Equal(t, PremiumReserved, Get())
 	require.True(t, IsPremiumReserved())
+	require.False(t, IsStarter())
+	require.NoError(t, Set(Starter))
+	require.Equal(t, Starter, Get())
+	require.False(t, IsPremiumReserved())
+	require.True(t, IsStarter())
 	require.ErrorContains(t, Set(Mode(100)), "invalid deploy mode")
 }

--- a/pkg/config/deploymode/mode_test.go
+++ b/pkg/config/deploymode/mode_test.go
@@ -68,9 +68,9 @@ func TestModeTOML(t *testing.T) {
 }
 
 func TestCurrentMode(t *testing.T) {
-	original := Get()
+	original := currentMode.Load()
 	t.Cleanup(func() {
-		currentMode.Store(int32(original))
+		currentMode.Store(original)
 	})
 
 	if !kerneltype.IsNextGen() {
@@ -90,9 +90,10 @@ func TestCurrentMode(t *testing.T) {
 	require.Equal(t, PremiumReserved, Get())
 	require.True(t, IsPremiumReserved())
 	require.False(t, IsStarter())
-	require.NoError(t, Set(Starter))
-	require.Equal(t, Starter, Get())
-	require.False(t, IsPremiumReserved())
-	require.True(t, IsStarter())
+	require.NoError(t, Set(PremiumReserved))
+	require.ErrorContains(t, Set(Starter), "deploy mode cannot be changed after it is set")
+	require.Equal(t, PremiumReserved, Get())
+	require.True(t, IsPremiumReserved())
+	require.False(t, IsStarter())
 	require.ErrorContains(t, Set(Mode(100)), "invalid deploy mode")
 }

--- a/pkg/util/printer/BUILD.bazel
+++ b/pkg/util/printer/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config",
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/parser/mysql",
         "//pkg/util/israce",
@@ -26,6 +27,7 @@ go_test(
     embed = [":printer"],
     flaky = True,
     deps = [
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/parser/mysql",
         "//pkg/testkit/testsetup",

--- a/pkg/util/printer/printer.go
+++ b/pkg/util/printer/printer.go
@@ -68,7 +68,7 @@ func PrintTiDBInfo() {
 		fields = append(fields, zap.String("TiDB Component Version", componentVersion))
 	}
 	if kerneltype.IsNextGen() {
-		fields = append(fields, zap.String("Deploy Mode", deploymode.Get().String()))
+		fields = append(fields, zap.Stringer("Deploy Mode", deploymode.Get()))
 	}
 	fields = append(fields, zap.String("Kernel Type", kerneltype.Name()))
 	if versioninfo.TiDBEnterpriseExtensionGitHash != "" {

--- a/pkg/util/printer/printer.go
+++ b/pkg/util/printer/printer.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/util/israce"
@@ -65,6 +66,9 @@ func PrintTiDBInfo() {
 	}
 	if componentVersion != "" {
 		fields = append(fields, zap.String("TiDB Component Version", componentVersion))
+	}
+	if kerneltype.IsNextGen() {
+		fields = append(fields, zap.String("Deploy Mode", deploymode.Get().String()))
 	}
 	fields = append(fields, zap.String("Kernel Type", kerneltype.Name()))
 	if versioninfo.TiDBEnterpriseExtensionGitHash != "" {

--- a/pkg/util/printer/printer_test.go
+++ b/pkg/util/printer/printer_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/stretchr/testify/require"
@@ -87,8 +88,11 @@ func TestPrintTiDBInfo(t *testing.T) {
 	fields := entries[0].ContextMap()
 	if kerneltype.IsNextGen() {
 		require.Equal(t, mysql.NormalizeTiDBReleaseVersionForNextGen(mysql.TiDBReleaseVersion), fields["TiDB Component Version"])
+		require.Equal(t, deploymode.Get().String(), fields["Deploy Mode"])
 	} else {
 		_, ok := fields["TiDB Component Version"]
+		require.False(t, ok)
+		_, ok = fields["Deploy Mode"]
 		require.False(t, ok)
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68181, ref #67765

Problem Summary:

NextGen TiDB needs a process-wide deploy mode setting so startup-time components can distinguish the default `premium` mode from specialized shapes such as `premium_reserved` and `starter`. `premium_reserved` represents a fixed-resource deployment where resources are allocated when the cluster starts and TiDB-worker, TiKV-worker, and coprocessor-worker are not scaled on demand. `starter` is for supporting a large number of small tenants.

### What changed and how does it work?

This PR adds `pkg/config/deploymode` with an `iota`-based `Mode` enum and process-wide helpers. Supported values are `premium`, `premium_reserved`, and `starter`; parsing is case-insensitive, JSON marshals/unmarshals as strings, and TOML config loading accepts string values through `UnmarshalTOML`.

The package exposes `Get`, `Set`, `IsPremiumReserved`, and `IsStarter`. `Set` rejects calls outside NextGen builds. `IsPremiumReserved` and `IsStarter` return true only when `kerneltype.IsNextGen()` is true and the current mode matches the helper.

`config.Config` now carries `DeployMode`, defaulting to `premium`. The config item is only configurable for NextGen builds: classic builds reject explicit `deploy-mode` config values and reject non-default programmatic values during config validation. TiDB startup initializes the deploymode package global from the loaded global config only when `kerneltype.IsNextGen()` is true.

`PrintTiDBInfo` now includes the current deploy mode in the startup log fields for NextGen builds only.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - `make bazel_prepare`
  - `make lint`
  - `git diff --check`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deploy-mode setting for nextgen kernels with Premium, Premium Reserved, and Starter options.
  * Deploy mode is set during startup and cannot be changed at runtime.
  * Deploy mode is included in TiDB information output.

* **Documentation**
  * Example configuration and package docs updated to describe deploy-mode semantics and allowed values.

* **Tests**
  * New unit tests validate deploy-mode parsing, validation, initialization, and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->