### PR TITLE
executor: fix INSERT regression for tables without generated columns

### DIFF
--- a/pkg/executor/bench_gencol_test.go
+++ b/pkg/executor/bench_gencol_test.go
@@ -63,6 +63,31 @@ func BenchmarkInsertWideTableWithGC(b *testing.B) {
 	}
 }
 
+// BenchmarkInsertYCSBLike benchmarks INSERT into an 11-column table with no generated columns,
+// modeling the YCSB usertable schema (1 VARCHAR PK + 10 VARCHAR value fields).
+// This is the regression scenario from issue #68129: MutRowFromDatums is called
+// unconditionally even when gCols is empty, adding unnecessary allocation per row.
+func BenchmarkInsertYCSBLike(b *testing.B) {
+	store := testkit.CreateMockStore(b)
+	tk := testkit.NewTestKit(b, store)
+	tk.MustExec("use test")
+
+	defs := []string{"YCSB_KEY VARCHAR(255) PRIMARY KEY"}
+	vals := []string{"'user1000'"}
+	for i := 0; i < 10; i++ {
+		defs = append(defs, fmt.Sprintf("FIELD%d VARCHAR(100)", i))
+		vals = append(vals, fmt.Sprintf("'value%d'", i))
+	}
+	tk.MustExec("CREATE TABLE usertable (" + strings.Join(defs, ", ") + ")")
+
+	// Use INSERT IGNORE so repeated runs don't fail on the duplicate PK.
+	insertSQL := "INSERT IGNORE INTO usertable VALUES (" + strings.Join(vals, ", ") + ")"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tk.MustExec(insertSQL)
+	}
+}
+
 // BenchmarkInsertWideTableWithNonLiteralGC benchmarks INSERT into a table with 150 virtual
 // generated columns that reference a real column (GENERATED ALWAYS AS (LOWER(name)) VIRTUAL).
 // This exercises the non-constant GC path where each GC must read the base column value.

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -673,7 +673,7 @@ func (e *InsertValues) fillColValue(
 func (e *InsertValues) fillRow(ctx context.Context, row []types.Datum, hasValue []bool, rowIdx int) (
 	[]types.Datum, error,
 ) {
-	gCols := make([]*table.Column, 0)
+	var gCols []*table.Column
 	tCols := e.Table.Cols()
 	if e.hasExtraHandle {
 		col := &table.Column{}
@@ -710,6 +710,11 @@ func (e *InsertValues) fillRow(ctx context.Context, row []types.Datum, hasValue 
 		if err := checkRowForExchangePartition(e.Ctx(), row, tbl); err != nil {
 			return nil, err
 		}
+	}
+
+	// Fast path: no generated columns, nothing more to do.
+	if len(gCols) == 0 {
+		return row, nil
 	}
 
 	sctx := e.Ctx()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68129

Problem Summary:

PR #67917 introduced a performance regression in `INSERT` statements. In `fillRow()` inside `insert_common.go`, the code unconditionally calls `MutRowFromDatums(row)` — which allocates a `Chunk` plus N `*Column` objects — even when the table has **zero** virtual generated columns (`gCols` is empty). This causes unnecessary heap allocations on every single inserted row, increasing GC pressure and reducing throughput.

For YCSB Workload A (mixed read/write) against an 11-column table with no generated columns (the typical `usertable` schema), this regression measured at **−23.8% OPS** compared to the pre-PR baseline.

### What changed and how does it work?

Two minimal changes in `pkg/executor/insert_common.go`:

1. **Lazy slice initialization**: Changed `gCols := make([]*table.Column, 0)` to `var gCols []*table.Column`, avoiding an unnecessary heap allocation of an empty slice header on every call.

2. **Early return when no generated columns**: Added a fast path immediately before the `MutRowFromDatums` call:
   ```go
   if len(gCols) == 0 {
       return row, nil
   }
   ```
   When `gCols` is empty (the common case for tables without virtual generated columns), we skip `MutRowFromDatums` entirely and return the row directly.

These changes restore pre-regression performance for the common case while leaving the generated-column path fully intact.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test (added `BenchmarkInsertYCSBLike` in `pkg/executor/bench_gencol_test.go`)
- [ ] Integration test
- [x] Manual test (go-ycsb Workload A benchmark, 3-way comparison)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

**Benchmark results** (go-ycsb Workload A, 8 threads, 30 s, `tidb-server --store=unistore`):

| Binary | OPS | vs Baseline |
|--------|-----|-------------|
| Baseline (f2ebab013, before #67917) | 19,143 | — |
| Regressed (35e8e043, after #67917) | 14,591 | **−23.8%** |
| Fixed (35e8e043 + this PR) | 18,990 | **−0.8%** (within noise) |

Side effects:

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation:

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a performance regression in INSERT statements introduced by #67917: skip MutRowFromDatums allocation when a table has no virtual generated columns, restoring ~24% OPS throughput for workloads on plain tables.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced work and allocations during INSERT when no generated columns exist by adding a fast-path that skips generated-column evaluation, improving insert performance.
* **Tests**
  * Added a YCSB-like benchmark to measure INSERT performance on wide tables and track regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68187)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->