### PR TITLE
grafana: render stacked nulls as zero

### DIFF
--- a/pkg/metrics/grafana/overview.json
+++ b/pkg/metrics/grafana/overview.json
@@ -3882,7 +3882,7 @@
           "lines": true,
           "linewidth": 0,
           "links": [],
-          "nullPointMode": "connected",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },
@@ -3981,7 +3981,7 @@
           "lines": true,
           "linewidth": 1,
           "links": [],
-          "nullPointMode": "connected",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -7494,7 +7494,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -7608,7 +7608,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -7707,7 +7707,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -7806,7 +7806,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -13253,7 +13253,7 @@
           "lines": false,
           "linewidth": 1,
           "links": [],
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -24098,7 +24098,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },
@@ -24228,7 +24228,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },
@@ -24583,7 +24583,7 @@
           },
           "lines": true,
           "linewidth": 0,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },

--- a/pkg/metrics/grafana/tidb_runtime.json
+++ b/pkg/metrics/grafana/tidb_runtime.json
@@ -96,7 +96,7 @@
           "linewidth": 1,
           "links": [],
           "maxPerRow": 3,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "percentage": false,
           "pluginVersion": "6.1.6",
           "pointradius": 5,

--- a/pkg/metrics/grafana/tidb_summary.json
+++ b/pkg/metrics/grafana/tidb_summary.json
@@ -148,7 +148,7 @@
                "lines": true,
                "linewidth": 1,
                "links": [ ],
-               "nullPointMode": "null",
+               "nullPointMode": "null as zero",
                "percentage": false,
                "pointradius": 5,
                "points": false,

--- a/pkg/metrics/nextgengrafana/overview.json
+++ b/pkg/metrics/nextgengrafana/overview.json
@@ -2333,7 +2333,7 @@
           "lines": true,
           "linewidth": 0,
           "links": [],
-          "nullPointMode": "connected",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },
@@ -2432,7 +2432,7 @@
           "lines": true,
           "linewidth": 1,
           "links": [],
-          "nullPointMode": "connected",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },

--- a/pkg/metrics/nextgengrafana/tidb_runtime_with_keyspace_name.json
+++ b/pkg/metrics/nextgengrafana/tidb_runtime_with_keyspace_name.json
@@ -96,7 +96,7 @@
           "linewidth": 1,
           "links": [],
           "maxPerRow": 3,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "percentage": false,
           "pluginVersion": "6.1.6",
           "pointradius": 5,

--- a/pkg/metrics/nextgengrafana/tidb_summary_with_keyspace_name.json
+++ b/pkg/metrics/nextgengrafana/tidb_summary_with_keyspace_name.json
@@ -148,7 +148,7 @@
                "lines": true,
                "linewidth": 1,
                "links": [ ],
-               "nullPointMode": "null",
+               "nullPointMode": "null as zero",
                "percentage": false,
                "pointradius": 5,
                "points": false,

--- a/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
+++ b/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
@@ -7574,7 +7574,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -7688,7 +7688,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -7787,7 +7787,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -7886,7 +7886,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -13156,7 +13156,7 @@
           "lines": false,
           "linewidth": 1,
           "links": [],
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -23822,7 +23822,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },
@@ -23952,7 +23952,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },
@@ -24307,7 +24307,7 @@
           },
           "lines": true,
           "linewidth": 0,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },

--- a/pkg/metrics/nextgengrafana/tidb_worker.json
+++ b/pkg/metrics/nextgengrafana/tidb_worker.json
@@ -7150,7 +7150,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -7264,7 +7264,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -7363,7 +7363,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -7462,7 +7462,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": false
           },
@@ -22713,7 +22713,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },
@@ -22843,7 +22843,7 @@
           },
           "lines": false,
           "linewidth": 1,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },
@@ -23198,7 +23198,7 @@
           },
           "lines": true,
           "linewidth": 0,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68230

Problem Summary:

Stacked Grafana graph panels can render misleading stacked areas when one series has null datapoints. For stacked panels, null values should be rendered as zero.

### What changed and how does it work?

Set `nullPointMode` to `"null as zero"` for stacked Grafana graph panels in TiDB dashboard JSON files.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test details:
- parsed changed dashboard JSON files
- verified every `stack: true` graph panel has `nullPointMode: "null as zero"`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix TiDB Grafana stacked panels to render null datapoints as zero.
```
