### PR TITLE
*: update pingcap/errors for verbose stack formatting

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -6478,13 +6478,13 @@ def go_deps():
         name = "com_github_pingcap_errors",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/pingcap/errors",
-        sha256 = "e90414b6322256cb88c6c39569070e23c074a95a803df4d2cedb10136e1d121c",
-        strip_prefix = "github.com/pingcap/errors@v0.11.5-0.20260310054046-9c8b3586e4b2",
+        sha256 = "8843ed815adc22e020095250e3d0ac3e2ffd974260dbb58c050491bb3ba2f926",
+        strip_prefix = "github.com/pingcap/errors@v0.11.5-0.20260508054701-306e305bcf41",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/errors/com_github_pingcap_errors-v0.11.5-0.20260310054046-9c8b3586e4b2.zip",
-            "http://ats.apps.svc/gomod/github.com/pingcap/errors/com_github_pingcap_errors-v0.11.5-0.20260310054046-9c8b3586e4b2.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/pingcap/errors/com_github_pingcap_errors-v0.11.5-0.20260310054046-9c8b3586e4b2.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/errors/com_github_pingcap_errors-v0.11.5-0.20260310054046-9c8b3586e4b2.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/errors/com_github_pingcap_errors-v0.11.5-0.20260508054701-306e305bcf41.zip",
+            "http://ats.apps.svc/gomod/github.com/pingcap/errors/com_github_pingcap_errors-v0.11.5-0.20260508054701-306e305bcf41.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/pingcap/errors/com_github_pingcap_errors-v0.11.5-0.20260508054701-306e305bcf41.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/errors/com_github_pingcap_errors-v0.11.5-0.20260508054701-306e305bcf41.zip",
         ],
     )
     go_repository(

--- a/cmd/tidb-server/BUILD.bazel
+++ b/cmd/tidb-server/BUILD.bazel
@@ -106,7 +106,7 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":tidb-server_lib"],
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pingcap/badger v1.5.1-0.20241015064302-38533b6cbf8d
-	github.com/pingcap/errors v0.11.5-0.20260310054046-9c8b3586e4b2
+	github.com/pingcap/errors v0.11.5-0.20260508054701-306e305bcf41
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/fn v1.0.0
 	github.com/pingcap/kvproto v0.0.0-20260414083400-4388bfaaedab
@@ -352,7 +352,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.29.11 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -719,8 +719,8 @@ github.com/pingcap/badger v1.5.1-0.20241015064302-38533b6cbf8d/go.mod h1:KiO2zum
 github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/pingcap/errors v0.11.5-0.20260310054046-9c8b3586e4b2 h1:cLgCk5mwDG9lDH+dPK8TmEliTjyGJwwKN0qevWAl8IY=
-github.com/pingcap/errors v0.11.5-0.20260310054046-9c8b3586e4b2/go.mod h1:ktAJCA9lxrHHjVyVl2pKJFvzBnq2eZbb+CUOjBRPlXo=
+github.com/pingcap/errors v0.11.5-0.20260508054701-306e305bcf41 h1:4ap5NsAa5AgJBom0lRKH4j+MI1m7E+zKNIE7LZ+n7XE=
+github.com/pingcap/errors v0.11.5-0.20260508054701-306e305bcf41/go.mod h1:ktAJCA9lxrHHjVyVl2pKJFvzBnq2eZbb+CUOjBRPlXo=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/fn v1.0.0 h1:CyA6AxcOZkQh52wIqYlAmaVmF6EvrcqFywP463pjA8g=

--- a/pkg/util/signal/BUILD.bazel
+++ b/pkg/util/signal/BUILD.bazel
@@ -10,45 +10,81 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/pkg/util/signal",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_pingcap_log//:log",
-        "@org_uber_go_zap//:zap",
-    ] + select({
+    deps = select({
         "@io_bazel_rules_go//go/platform:aix": [
             "//pkg/util/logutil",
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
         ],
         "@io_bazel_rules_go//go/platform:android": [
             "//pkg/util/logutil",
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "//pkg/util/logutil",
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly": [
             "//pkg/util/logutil",
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
             "//pkg/util/logutil",
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
         ],
         "@io_bazel_rules_go//go/platform:illumos": [
             "//pkg/util/logutil",
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
         ],
         "@io_bazel_rules_go//go/platform:ios": [
             "//pkg/util/logutil",
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
+        ],
+        "@io_bazel_rules_go//go/platform:js": [
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/util/logutil",
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//pkg/util/logutil",
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
         ],
         "@io_bazel_rules_go//go/platform:openbsd": [
             "//pkg/util/logutil",
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
+        ],
+        "@io_bazel_rules_go//go/platform:osx": [
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
+        ],
+        "@io_bazel_rules_go//go/platform:qnx": [
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
         ],
         "@io_bazel_rules_go//go/platform:solaris": [
             "//pkg/util/logutil",
+            "@com_github_pingcap_log//:log",
+            "@org_uber_go_zap//:zap",
         ],
         "@io_bazel_rules_go//go/platform:windows": [
             "//pkg/util/logutil",
+            "@org_uber_go_zap//:zap",
         ],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68220

Problem Summary:

TiDB still depends on a `github.com/pingcap/errors` revision from before https://github.com/pingcap/errors/pull/83. For named errors that wrap a cause that already has a stack, zap can miss verbose stack output because the bare `*errors.Error` did not implement `fmt.Formatter`.

### What changed and how does it work?

- Update `github.com/pingcap/errors` to `v0.11.5-0.20260508054701-306e305bcf41`, which includes https://github.com/pingcap/errors/pull/83.
- Refresh `go.sum` and Bazel dependency metadata for the updated module.
- Keep `gopkg.in/natefinch/lumberjack.v2` as a direct dependency because TiDB imports it directly under `pkg/extension/enterprise/audit`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```golang
func TestAAA(t *testing.T) {
	inErr := errors.New("this is in error")
	err := common.ErrCreatePDClient.Wrap(inErr).GenWithStackByArgs()
	logutil.ErrVerboseLogger().Info("log error", zap.Error(err))
}
```
new
```
[2026/05/08 15:13:20.608 +08:00] [INFO] [local_test.go:2895] ["log error"] [error="[Lightning:PD:ErrCreatePDClient]create pd client error: this is in error"] [errorVerbose="this is in error\ngithub.com/pingcap/tidb/pkg/lightning/backend/local.TestAAA\n\t/Users/jujiajia/code/pingcap/tidb/pkg/lightning/backend/local/local_test.go:2893\ntesting.tRunner\n\t/Users/jujiajia/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/testing/testing.go:1934\nruntime.goexit\n\t/Users/jujiajia/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268\n[Lightning:PD:ErrCreatePDClient]create pd client error"]
```
old
```
[2026/05/08 15:12:12.519 +08:00] [INFO] [local_test.go:2895] ["log error"] [error="[Lightning:PD:ErrCreatePDClient]create pd client error: this is in error"]
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test commands:

- `make bazel_prepare`
- `make lint`
- `go list -m github.com/pingcap/errors`
- `go test -count=1 github.com/pingcap/errors -run '^TestWrappedNamedError(GenWithStackByArgsFormatsCauseStack|FormatsStacklessCause)$'`
- `go test -count=1 ./pkg/util/signal`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed an issue that named errors could miss verbose stack output in logs.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to latest versions.
  * Optimized build configuration for improved test execution.
  * Refactored internal build system dependencies for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->