### PR TITLE
ddl: use real start ts for recover table snapshot

### DIFF
--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -1331,9 +1331,9 @@ var (
 	RunInGoTest bool
 )
 
-// GetRecoverTableSnapshotTS returns the snapshot timestamp for reconstructing
-// table metadata from a finished drop/truncate table job.
-func GetRecoverTableSnapshotTS(job *model.Job) uint64 {
+// GetRecoverSnapshotTS returns the snapshot timestamp for reconstructing
+// metadata from a finished drop/truncate table or drop schema job.
+func GetRecoverSnapshotTS(job *model.Job) uint64 {
 	if job.RealStartTS != 0 {
 		return job.RealStartTS
 	}
@@ -1347,7 +1347,7 @@ func GetDropOrTruncateTableInfoFromJobsByStore(jobs []*model.Job, gcSafePoint ui
 			continue
 		}
 
-		snapshotTS := GetRecoverTableSnapshotTS(job)
+		snapshotTS := GetRecoverSnapshotTS(job)
 		// Check GC safe point for getting snapshot infoSchema.
 		err := gcutil.ValidateSnapshotWithGCSafePoint(snapshotTS, gcSafePoint)
 		if err != nil {

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -1331,19 +1331,30 @@ var (
 	RunInGoTest bool
 )
 
+// GetRecoverTableSnapshotTS returns the snapshot timestamp for reconstructing
+// table metadata from a finished drop/truncate table job.
+func GetRecoverTableSnapshotTS(job *model.Job) uint64 {
+	if job.RealStartTS != 0 {
+		return job.RealStartTS
+	}
+	return job.StartTS
+}
+
 // GetDropOrTruncateTableInfoFromJobsByStore implements GetDropOrTruncateTableInfoFromJobs
 func GetDropOrTruncateTableInfoFromJobsByStore(jobs []*model.Job, gcSafePoint uint64, getTable func(uint64, int64, int64) (*model.TableInfo, error), fn func(*model.Job, *model.TableInfo) (bool, error)) (bool, error) {
 	for _, job := range jobs {
-		// Check GC safe point for getting snapshot infoSchema.
-		err := gcutil.ValidateSnapshotWithGCSafePoint(job.StartTS, gcSafePoint)
-		if err != nil {
-			return false, err
-		}
 		if job.Type != model.ActionDropTable && job.Type != model.ActionTruncateTable {
 			continue
 		}
 
-		tbl, err := getTable(job.StartTS, job.SchemaID, job.TableID)
+		snapshotTS := GetRecoverTableSnapshotTS(job)
+		// Check GC safe point for getting snapshot infoSchema.
+		err := gcutil.ValidateSnapshotWithGCSafePoint(snapshotTS, gcSafePoint)
+		if err != nil {
+			return false, err
+		}
+
+		tbl, err := getTable(snapshotTS, job.SchemaID, job.TableID)
 		if err != nil {
 			if meta.ErrDBNotExists.Equal(err) {
 				// The dropped/truncated DDL maybe execute failed that caused by the parallel DDL execution,

--- a/pkg/ddl/tests/serial/BUILD.bazel
+++ b/pkg/ddl/tests/serial/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "serial_test.go",
     ],
     flaky = True,
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/ddl/tests/serial/BUILD.bazel
+++ b/pkg/ddl/tests/serial/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "serial_test.go",
     ],
     flaky = True,
-    shard_count = 21,
+    shard_count = 22,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/ddl/tests/serial/serial_test.go
+++ b/pkg/ddl/tests/serial/serial_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -641,6 +642,121 @@ func TestRecoverTableByJobID(t *testing.T) {
 	gcEnable, err := gcutil.CheckGCEnable(tk.Session())
 	require.NoError(t, err)
 	require.Equal(t, false, gcEnable)
+}
+
+func TestRecoverTableUsesRealStartTSForQueuedDropTable(t *testing.T) {
+	store := createMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create database if not exists test_recover")
+	tk.MustExec("use test_recover")
+	tk.MustExec("drop table if exists t_recover_snapshot")
+	tk.MustExec("create table t_recover_snapshot (id int primary key, col_a int, col_b int)")
+	tk.MustExec("insert into t_recover_snapshot values (1, 11, 21)")
+
+	defer func(originGC bool) {
+		if originGC {
+			util.EmulatorGCEnable()
+		} else {
+			util.EmulatorGCDisable()
+		}
+	}(util.IsEmulatorGCEnable())
+	util.EmulatorGCDisable()
+
+	var pauseSchedule atomic.Bool
+	waitSchCh := make(chan struct{})
+	var closeSchedule sync.Once
+	releaseSchedule := func() {
+		pauseSchedule.Store(false)
+		closeSchedule.Do(func() { close(waitSchCh) })
+	}
+	t.Cleanup(releaseSchedule)
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeLoadAndDeliverJobs", func() {
+		if pauseSchedule.Load() {
+			<-waitSchCh
+		}
+	})
+	pauseSchedule.Store(true)
+
+	submittedCh := make(chan struct{}, 2)
+	submitGate := make(chan struct{})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/waitJobSubmitted", func() {
+		submittedCh <- struct{}{}
+		<-submitGate
+	})
+	waitSubmitted := func() {
+		select {
+		case <-submittedCh:
+			submitGate <- struct{}{}
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "DDL job was not submitted")
+		}
+	}
+
+	// Two independent sessions are needed so the drop-table job can be queued
+	// after drop-column is submitted but before drop-column has changed metadata.
+	tkAlter := testkit.NewTestKit(t, store)
+	tkAlter.MustExec("use test_recover")
+	alterDoneCh := make(chan error, 1)
+	go func() {
+		_, err := tkAlter.Exec("alter table t_recover_snapshot drop column col_a")
+		alterDoneCh <- err
+	}()
+	waitSubmitted()
+
+	tkDrop := testkit.NewTestKit(t, store)
+	tkDrop.MustExec("use test_recover")
+	dropDoneCh := make(chan error, 1)
+	go func() {
+		_, err := tkDrop.Exec("drop table t_recover_snapshot")
+		dropDoneCh <- err
+	}()
+	waitSubmitted()
+
+	testfailpoint.Disable(t, "github.com/pingcap/tidb/pkg/ddl/waitJobSubmitted")
+	releaseSchedule()
+	require.NoError(t, <-alterDoneCh)
+	require.NoError(t, <-dropDoneCh)
+
+	getHistoryJobID := func(jobType string) int64 {
+		rows := tk.MustQuery(fmt.Sprintf(
+			"admin show ddl jobs where db_name = 'test_recover' and table_name = 't_recover_snapshot' and job_type = '%s'",
+			jobType,
+		)).Rows()
+		require.NotEmpty(t, rows)
+		jobID, err := strconv.ParseInt(rows[0][0].(string), 10, 64)
+		require.NoError(t, err)
+		return jobID
+	}
+
+	dropJobID := getHistoryJobID("drop table")
+	dropJob, err := ddl.GetHistoryJobByID(tk.Session(), dropJobID)
+	require.NoError(t, err)
+	require.NotNil(t, dropJob)
+	require.Greater(t, dropJob.RealStartTS, dropJob.StartTS)
+
+	gcTimeFormat := "20060102-15:04:05 -0700 MST"
+	timeBeforeDrop := time.Now().Add(-48 * time.Hour).Format(gcTimeFormat)
+	safePointSQL := `INSERT HIGH_PRIORITY INTO mysql.tidb VALUES ('tikv_gc_safe_point', '%[1]s', '')
+			       ON DUPLICATE KEY
+			       UPDATE variable_value = '%[1]s'`
+	tk.MustExec("delete from mysql.tidb where variable_name in ('tikv_gc_safe_point','tikv_gc_enable')")
+	tk.MustExec(fmt.Sprintf(safePointSQL, timeBeforeDrop))
+	require.NoError(t, gcutil.EnableGC(tk.Session()))
+
+	tk.MustExec(fmt.Sprintf("recover table by job %d", dropJobID))
+	tk.MustQuery("select column_name from information_schema.columns where table_schema = 'test_recover' and table_name = 't_recover_snapshot' order by ordinal_position").Check(testkit.Rows("id", "col_b"))
+	tk.MustQuery("select id, col_b from t_recover_snapshot").Check(testkit.Rows("1 21"))
+
+	recoverJobID := getHistoryJobID("recover table")
+	recoverJob, err := ddl.GetHistoryJobByID(tk.Session(), recoverJobID)
+	require.NoError(t, err)
+	require.NotNil(t, recoverJob)
+	require.NotNil(t, recoverJob.BinlogInfo.TableInfo)
+	colNames := make([]string, 0, len(recoverJob.BinlogInfo.TableInfo.Columns))
+	for _, col := range recoverJob.BinlogInfo.TableInfo.Columns {
+		colNames = append(colNames, col.Name.L)
+	}
+	require.Equal(t, []string{"id", "col_b"}, colNames)
 }
 
 func TestRecoverTableByJobIDFail(t *testing.T) {

--- a/pkg/ddl/tests/serial/serial_test.go
+++ b/pkg/ddl/tests/serial/serial_test.go
@@ -759,6 +759,98 @@ func TestRecoverTableUsesRealStartTSForQueuedDropTable(t *testing.T) {
 	require.Equal(t, []string{"id", "col_b"}, colNames)
 }
 
+func TestFlashbackDatabaseUsesRealStartTSForQueuedDropSchema(t *testing.T) {
+	store := createMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("drop database if exists test_recover_schema_snapshot")
+	tk.MustExec("create database test_recover_schema_snapshot")
+	tk.MustExec("create table test_recover_schema_snapshot.t (id int primary key, col_a int, col_b int)")
+	tk.MustExec("insert into test_recover_schema_snapshot.t values (1, 11, 21)")
+
+	defer func(originGC bool) {
+		if originGC {
+			util.EmulatorGCEnable()
+		} else {
+			util.EmulatorGCDisable()
+		}
+	}(util.IsEmulatorGCEnable())
+	util.EmulatorGCDisable()
+
+	var pauseSchedule atomic.Bool
+	waitSchCh := make(chan struct{})
+	var closeSchedule sync.Once
+	releaseSchedule := func() {
+		pauseSchedule.Store(false)
+		closeSchedule.Do(func() { close(waitSchCh) })
+	}
+	t.Cleanup(releaseSchedule)
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeLoadAndDeliverJobs", func() {
+		if pauseSchedule.Load() {
+			<-waitSchCh
+		}
+	})
+	pauseSchedule.Store(true)
+
+	submittedCh := make(chan struct{}, 2)
+	submitGate := make(chan struct{})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/waitJobSubmitted", func() {
+		submittedCh <- struct{}{}
+		<-submitGate
+	})
+	waitSubmitted := func() {
+		select {
+		case <-submittedCh:
+			submitGate <- struct{}{}
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "DDL job was not submitted")
+		}
+	}
+
+	tkAlter := testkit.NewTestKit(t, store)
+	tkAlter.MustExec("use test_recover_schema_snapshot")
+	alterDoneCh := make(chan error, 1)
+	go func() {
+		_, err := tkAlter.Exec("alter table t drop column col_a")
+		alterDoneCh <- err
+	}()
+	waitSubmitted()
+
+	tkDrop := testkit.NewTestKit(t, store)
+	dropDoneCh := make(chan error, 1)
+	go func() {
+		_, err := tkDrop.Exec("drop database test_recover_schema_snapshot")
+		dropDoneCh <- err
+	}()
+	waitSubmitted()
+
+	testfailpoint.Disable(t, "github.com/pingcap/tidb/pkg/ddl/waitJobSubmitted")
+	releaseSchedule()
+	require.NoError(t, <-alterDoneCh)
+	require.NoError(t, <-dropDoneCh)
+
+	rows := tk.MustQuery("admin show ddl jobs where db_name = 'test_recover_schema_snapshot' and job_type = 'drop schema'").Rows()
+	require.NotEmpty(t, rows)
+	dropJobID, err := strconv.ParseInt(rows[0][0].(string), 10, 64)
+	require.NoError(t, err)
+	dropJob, err := ddl.GetHistoryJobByID(tk.Session(), dropJobID)
+	require.NoError(t, err)
+	require.NotNil(t, dropJob)
+	require.Greater(t, dropJob.RealStartTS, dropJob.StartTS)
+
+	gcTimeFormat := "20060102-15:04:05 -0700 MST"
+	timeBeforeDrop := time.Now().Add(-48 * time.Hour).Format(gcTimeFormat)
+	safePointSQL := `INSERT HIGH_PRIORITY INTO mysql.tidb VALUES ('tikv_gc_safe_point', '%[1]s', '')
+			       ON DUPLICATE KEY
+			       UPDATE variable_value = '%[1]s'`
+	tk.MustExec("delete from mysql.tidb where variable_name in ('tikv_gc_safe_point','tikv_gc_enable')")
+	tk.MustExec(fmt.Sprintf(safePointSQL, timeBeforeDrop))
+	require.NoError(t, gcutil.EnableGC(tk.Session()))
+
+	tk.MustExec("flashback database test_recover_schema_snapshot")
+	tk.MustQuery("select column_name from information_schema.columns where table_schema = 'test_recover_schema_snapshot' and table_name = 't' order by ordinal_position").Check(testkit.Rows("id", "col_b"))
+	tk.MustQuery("select id, col_b from test_recover_schema_snapshot.t").Check(testkit.Rows("1 21"))
+}
+
 func TestRecoverTableByJobIDFail(t *testing.T) {
 	store := createMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/ddl.go
+++ b/pkg/executor/ddl.go
@@ -449,7 +449,7 @@ func (e *DDLExec) executeRecoverTable(s *ast.RecoverTableStmt) error {
 		return infoschema.ErrTableExists.GenWithStack("Table '%-.192s' already been recover to '%-.192s', can't be recover repeatedly", tblInfo.Name.O, tbl.Meta().Name.O)
 	}
 
-	snapshotTS := ddl.GetRecoverTableSnapshotTS(job)
+	snapshotTS := ddl.GetRecoverSnapshotTS(job)
 	m := domain.GetDomain(e.Ctx()).GetSnapshotMeta(snapshotTS)
 	autoIDs, err := m.GetAutoIDAccessors(job.SchemaID, job.TableID).Get()
 	if err != nil {
@@ -488,7 +488,7 @@ func (e *DDLExec) getRecoverTableByJobID(s *ast.RecoverTableStmt, dom *domain.Do
 		return nil, nil, errors.Errorf("Job %v type is %v, not dropped/truncated table", job.ID, job.Type)
 	}
 
-	snapshotTS := ddl.GetRecoverTableSnapshotTS(job)
+	snapshotTS := ddl.GetRecoverSnapshotTS(job)
 	// Check GC safe point for getting snapshot infoSchema.
 	err = gcutil.ValidateSnapshot(e.Ctx(), snapshotTS)
 	if err != nil {
@@ -615,7 +615,7 @@ func (e *DDLExec) executeFlashbackTable(s *ast.FlashBackTableStmt) error {
 		return infoschema.ErrTableExists.GenWithStack("Table '%-.192s' already been flashback to '%-.192s', can't be flashback repeatedly", s.Table.Name.O, tbl.Meta().Name.O)
 	}
 
-	snapshotTS := ddl.GetRecoverTableSnapshotTS(job)
+	snapshotTS := ddl.GetRecoverSnapshotTS(job)
 	m := domain.GetDomain(e.Ctx()).GetSnapshotMeta(snapshotTS)
 	autoIDs, err := m.GetAutoIDAccessors(job.SchemaID, job.TableID).Get()
 	if err != nil {
@@ -675,15 +675,17 @@ func (e *DDLExec) getRecoverDBByName(schemaName ast.CIStr) (recoverSchemaInfo *m
 	dom := domain.GetDomain(e.Ctx())
 	fn := func(jobs []*model.Job) (bool, error) {
 		for _, job := range jobs {
-			// Check GC safe point for getting snapshot infoSchema.
-			err = gcutil.ValidateSnapshotWithGCSafePoint(job.StartTS, gcSafePoint)
-			if err != nil {
-				return false, err
-			}
 			if job.Type != model.ActionDropSchema {
 				continue
 			}
-			snapMeta := dom.GetSnapshotMeta(job.StartTS)
+
+			snapshotTS := ddl.GetRecoverSnapshotTS(job)
+			// Check GC safe point for getting snapshot infoSchema.
+			err = gcutil.ValidateSnapshotWithGCSafePoint(snapshotTS, gcSafePoint)
+			if err != nil {
+				return false, err
+			}
+			snapMeta := dom.GetSnapshotMeta(snapshotTS)
 			schemaInfo, err := snapMeta.GetDatabase(job.SchemaID)
 			if err != nil {
 				return false, err
@@ -701,7 +703,7 @@ func (e *DDLExec) getRecoverDBByName(schemaName ast.CIStr) (recoverSchemaInfo *m
 				DBInfo:              schemaInfo,
 				LoadTablesOnExecute: true,
 				DropJobID:           job.ID,
-				SnapshotTS:          job.StartTS,
+				SnapshotTS:          snapshotTS,
 				OldSchemaName:       schemaName,
 			}
 			return true, nil

--- a/pkg/executor/ddl.go
+++ b/pkg/executor/ddl.go
@@ -449,7 +449,8 @@ func (e *DDLExec) executeRecoverTable(s *ast.RecoverTableStmt) error {
 		return infoschema.ErrTableExists.GenWithStack("Table '%-.192s' already been recover to '%-.192s', can't be recover repeatedly", tblInfo.Name.O, tbl.Meta().Name.O)
 	}
 
-	m := domain.GetDomain(e.Ctx()).GetSnapshotMeta(job.StartTS)
+	snapshotTS := ddl.GetRecoverTableSnapshotTS(job)
+	m := domain.GetDomain(e.Ctx()).GetSnapshotMeta(snapshotTS)
 	autoIDs, err := m.GetAutoIDAccessors(job.SchemaID, job.TableID).Get()
 	if err != nil {
 		return err
@@ -459,7 +460,7 @@ func (e *DDLExec) executeRecoverTable(s *ast.RecoverTableStmt) error {
 		SchemaID:      job.SchemaID,
 		TableInfo:     tblInfo,
 		DropJobID:     job.ID,
-		SnapshotTS:    job.StartTS,
+		SnapshotTS:    snapshotTS,
 		AutoIDs:       autoIDs,
 		OldSchemaName: job.SchemaName,
 		OldTableName:  tblInfo.Name.L,
@@ -487,14 +488,15 @@ func (e *DDLExec) getRecoverTableByJobID(s *ast.RecoverTableStmt, dom *domain.Do
 		return nil, nil, errors.Errorf("Job %v type is %v, not dropped/truncated table", job.ID, job.Type)
 	}
 
+	snapshotTS := ddl.GetRecoverTableSnapshotTS(job)
 	// Check GC safe point for getting snapshot infoSchema.
-	err = gcutil.ValidateSnapshot(e.Ctx(), job.StartTS)
+	err = gcutil.ValidateSnapshot(e.Ctx(), snapshotTS)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Get the snapshot infoSchema before drop table.
-	snapInfo, err := dom.GetSnapshotInfoSchema(job.StartTS)
+	snapInfo, err := dom.GetSnapshotInfoSchema(snapshotTS)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -514,7 +516,7 @@ func (e *DDLExec) getRecoverTableByJobID(s *ast.RecoverTableStmt, dom *domain.Do
 }
 
 // GetDropOrTruncateTableInfoFromJobs gets the dropped/truncated table information from DDL jobs,
-// it will use the `start_ts` of DDL job as snapshot to get the dropped/truncated table information.
+// it will use the recover snapshot of DDL job to get the dropped/truncated table information.
 func GetDropOrTruncateTableInfoFromJobs(jobs []*model.Job, gcSafePoint uint64, dom *domain.Domain, fn func(*model.Job, *model.TableInfo) (bool, error)) (bool, error) {
 	getTable := func(startTS uint64, schemaID int64, tableID int64) (*model.TableInfo, error) {
 		snapMeta := dom.GetSnapshotMeta(startTS)
@@ -613,7 +615,8 @@ func (e *DDLExec) executeFlashbackTable(s *ast.FlashBackTableStmt) error {
 		return infoschema.ErrTableExists.GenWithStack("Table '%-.192s' already been flashback to '%-.192s', can't be flashback repeatedly", s.Table.Name.O, tbl.Meta().Name.O)
 	}
 
-	m := domain.GetDomain(e.Ctx()).GetSnapshotMeta(job.StartTS)
+	snapshotTS := ddl.GetRecoverTableSnapshotTS(job)
+	m := domain.GetDomain(e.Ctx()).GetSnapshotMeta(snapshotTS)
 	autoIDs, err := m.GetAutoIDAccessors(job.SchemaID, job.TableID).Get()
 	if err != nil {
 		return err
@@ -623,7 +626,7 @@ func (e *DDLExec) executeFlashbackTable(s *ast.FlashBackTableStmt) error {
 		SchemaID:      job.SchemaID,
 		TableInfo:     tblInfo,
 		DropJobID:     job.ID,
-		SnapshotTS:    job.StartTS,
+		SnapshotTS:    snapshotTS,
 		AutoIDs:       autoIDs,
 		OldSchemaName: job.SchemaName,
 		OldTableName:  s.Table.Name.L,


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68222

Problem Summary:

`RECOVER TABLE` and `FLASHBACK TABLE` reconstruct dropped/truncated table metadata from the drop/truncate DDL history job. Before this PR, TiDB used the job's `StartTS` as the snapshot timestamp.

However, `StartTS` is assigned when the DDL job is inserted into `mysql.tidb_ddl_job`, not when the job actually starts running. If a `DROP TABLE` job is queued while an earlier DDL on the same table is still pending, the drop-table job's `StartTS` may point to stale table metadata.

For example:

1. `CREATE TABLE t (id INT PRIMARY KEY, col_a INT, col_b INT)`.
2. Queue `ALTER TABLE t DROP COLUMN col_a`.
3. Queue `DROP TABLE t` before the drop-column job finishes.
4. The drop-column job finishes first, then the drop-table job runs.
5. `RECOVER TABLE t` may reconstruct metadata from the drop-table job's `StartTS`, where `col_a` still existed.

As a result, the recovered table metadata and the recover-table history job's `BinlogInfo.TableInfo` may contain stale columns that were no longer part of the table when it was actually dropped.

### What changed and how does it work?

This PR introduces `ddl.GetRecoverTableSnapshotTS(job)` for reconstructing dropped/truncated table metadata:

- Use `job.RealStartTS` if it is available.
- Fall back to `job.StartTS` for compatibility with older history jobs where `RealStartTS` may be zero.

`RealStartTS` is set when the DDL worker actually starts running the job, so it represents the schema state immediately before the drop/truncate job begins changing the table metadata. This is the correct snapshot for recovering the table definition.

The new snapshot selection is used by:

- `RECOVER TABLE BY JOB ...`
- `RECOVER TABLE <table_name>`
- `FLASHBACK TABLE ...`
- shared history-job scanning for dropped/truncated table metadata

The GC safe point validation is also applied only after filtering to drop/truncate table jobs, so unrelated history jobs are not validated with recover-table snapshot semantics.

A regression test is added to make the stale snapshot case deterministic with DDL failpoints:

1. Pause DDL scheduling before jobs are loaded and delivered.
2. Submit `ALTER TABLE ... DROP COLUMN col_a` and wait until it is queued.
3. Submit `DROP TABLE ...` and wait until it is queued.
4. Release DDL scheduling so the drop-column job finishes before the drop-table job starts.
5. Recover the table by the drop-table job ID.
6. Assert the recovered table and the recover-table history job's `BinlogInfo.TableInfo.Columns` do not contain `col_a`.

`make bazel_prepare` was run because this PR adds a new top-level Go test function in an existing `*_test.go` file.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `GOSUMDB=sum.golang.org GOPATH=/Users/xiaoli/go ./tools/check/failpoint-go-test.sh pkg/ddl/tests/serial -run TestRecoverTableUsesRealStartTSForQueuedDropTable -count=1`
  - `GOSUMDB=sum.golang.org GOPATH=/Users/xiaoli/go make bazel_prepare`
  - `GOSUMDB=sum.golang.org GOPATH=/Users/xiaoli/go make lint`
  - `git diff --check`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that RECOVER TABLE and FLASHBACK TABLE might restore stale table metadata when a drop or truncate table job was queued before preceding table DDL changes finished.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table and database recovery operations to use the correct snapshot timestamp when drop or truncate operations are queued behind other DDL commands.

* **Tests**
  * Added regression tests validating recovery and flashback operations with queued DDL jobs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68229)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->