### PR TITLE
importinto: require S3-like auth for nextgen import

### DIFF
--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -164,6 +164,21 @@ func TestNextGenS3ExternalID(t *testing.T) {
 		}
 	})
 
+	t.Run("SEM enabled, require explicit auth for S3 like store", func(t *testing.T) {
+		for i, fns := range semTestPatternFns {
+			t.Run(fmt.Sprint(i), func(t *testing.T) {
+				tk := testkit.NewTestKit(t, store)
+				fns[0](t, tk)
+				t.Cleanup(func() {
+					fns[1](t, tk)
+				})
+				for _, schema := range []string{"s3", "oss"} {
+					tk.MustMatchErrMsg(fmt.Sprintf("IMPORT INTO test.t FROM '%s://bucket'", schema), `(?i).*Feature 'IMPORT INTO .*without access key/secret access key or role ARN' is not supported when security enhanced mode is enabled`)
+				}
+			})
+		}
+	})
+
 	t.Run("SEM enabled, set external ID to keyspace name", func(t *testing.T) {
 		bak := config.GetGlobalKeyspaceName()
 		config.UpdateGlobal(func(conf *config.Config) {
@@ -189,7 +204,7 @@ func TestNextGenS3ExternalID(t *testing.T) {
 					panic("FAIL IT, AS WE CANNOT RUN IT HERE")
 				})
 				for _, schema := range []string{"s3", "oss"} {
-					err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM '%s://bucket'", schema))
+					err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM '%s://bucket?access-key=ak&secret-access-key=sk'", schema))
 					require.ErrorContains(t, err, "FAIL IT, AS WE CANNOT RUN IT HERE")
 				}
 			})
@@ -251,7 +266,7 @@ func testNextGenUnsupportedLocalSortAndOptions(t *testing.T, store kv.Storage, i
 	t.Run("local sort", func(t *testing.T) {
 		tk := testkit.NewTestKit(t, store)
 		initFn(t, tk)
-		err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket/*.csv'")
+		err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket/*.csv?access-key=ak&secret-access-key=sk'")
 		require.ErrorIs(t, err, plannererrors.ErrNotSupportedWithSem)
 		require.ErrorContains(t, err, "IMPORT INTO with local sort")
 	})
@@ -279,7 +294,7 @@ func testNextGenUnsupportedLocalSortAndOptions(t *testing.T, store kv.Storage, i
 			"checksum_table",
 			"record_errors",
 		} {
-			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv' with %s='1'", option))
+			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv?access-key=ak&secret-access-key=sk' with %s='1'", option))
 			require.ErrorIs(t, err, exeerrors.ErrLoadDataUnsupportedOption)
 			require.ErrorContains(t, err, option)
 		}
@@ -287,7 +302,7 @@ func testNextGenUnsupportedLocalSortAndOptions(t *testing.T, store kv.Storage, i
 			"__force_merge_step",
 			"__manual_recovery",
 		} {
-			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv' with %s", option))
+			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv?access-key=ak&secret-access-key=sk' with %s", option))
 			require.ErrorIs(t, err, exeerrors.ErrLoadDataUnsupportedOption)
 			require.ErrorContains(t, err, option)
 		}

--- a/pkg/objstore/parse.go
+++ b/pkg/objstore/parse.go
@@ -182,7 +182,7 @@ func ExtractQueryParameters(u *url.URL, options any) {
 			continue
 		}
 		param := params[0]
-		normalizedKey := strings.ToLower(strings.ReplaceAll(key, "_", "-"))
+		normalizedKey := NormalizeQueryParameterKey(key)
 		if f, ok := tagToField[normalizedKey]; ok {
 			field := o.Field(f.index)
 			switch f.kind {
@@ -200,6 +200,12 @@ func ExtractQueryParameters(u *url.URL, options any) {
 
 	// Clean up the URL finally.
 	u.RawQuery = ""
+}
+
+// NormalizeQueryParameterKey normalizes object storage URL query parameter keys
+// to match backend option tags.
+func NormalizeQueryParameterKey(key string) string {
+	return strings.ToLower(strings.ReplaceAll(key, "_", "-"))
 }
 
 // FormatBackendURL obtains the raw URL which can be used the reconstruct the

--- a/pkg/objstore/s3like/store.go
+++ b/pkg/objstore/s3like/store.go
@@ -45,6 +45,12 @@ import (
 var HardcodedChunkSize = 5 * 1024 * 1024
 
 const (
+	// S3AccessKey is the key for the access key used in S3 operations.
+	S3AccessKey = "access-key"
+	// S3SecretAccessKey is the key for the secret access key used in S3 operations.
+	S3SecretAccessKey = "secret-access-key"
+	// S3RoleARN is the key for the role ARN used in S3 operations.
+	S3RoleARN = "role-arn"
 	// S3ExternalID is the key for the external ID used in S3 operations.
 	S3ExternalID = "external-id"
 

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -6346,20 +6346,17 @@ func checkNextGenS3PathWithSem(u *url.URL) error {
 	hasAccessKey := false
 	hasSecretAccessKey := false
 	hasRoleARN := false
-	hasValue := func(values []string) bool {
-		return len(values) > 0 && values[0] != ""
-	}
-	for k, v := range values {
+	for k := range values {
 		normalizedK := objstore.NormalizeQueryParameterKey(k)
 		switch normalizedK {
 		case s3like.S3ExternalID:
 			return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO with explicit external ID")
 		case s3like.S3AccessKey:
-			hasAccessKey = hasAccessKey || hasValue(v)
+			hasAccessKey = hasAccessKey || values.Get(k) != ""
 		case s3like.S3SecretAccessKey:
-			hasSecretAccessKey = hasSecretAccessKey || hasValue(v)
+			hasSecretAccessKey = hasSecretAccessKey || values.Get(k) != ""
 		case s3like.S3RoleARN:
-			hasRoleARN = hasRoleARN || hasValue(v)
+			hasRoleARN = hasRoleARN || values.Get(k) != ""
 		}
 	}
 

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4680,15 +4680,9 @@ func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStm
 			return nil, exeerrors.ErrLoadDataInvalidURI.FastGenByArgs(ImportIntoDataSource, err.Error())
 		}
 		importFromServer = objstore.IsLocal(u)
-		// for SEM v2, they are checked by configured rules.
 		if semv1.IsEnabled() {
 			if importFromServer {
 				return nil, plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO from server disk")
-			}
-			if kerneltype.IsNextGen() && objstore.IsS3Like(u) {
-				if err := checkNextGenS3PathWithSem(u); err != nil {
-					return nil, err
-				}
 			}
 		}
 		// a nextgen cluster might be shared by multiple tenants, and they might
@@ -4696,6 +4690,9 @@ func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStm
 		// external ID can be used to restrict the access only to the current tenant.
 		// when SEM enabled, we need set it.
 		if kerneltype.IsNextGen() && sem.IsEnabled() && objstore.IsS3Like(u) {
+			if err := checkNextGenS3PathWithSem(u); err != nil {
+				return nil, err
+			}
 			values := u.Query()
 			values.Set(s3like.S3ExternalID, config.GetGlobalKeyspaceName())
 			u.RawQuery = values.Encode()
@@ -6342,15 +6339,32 @@ func checkAlterDDLJobOptValue(opt *AlterDDLJobOpt) error {
 	return nil
 }
 
-// for nextgen import-into with SEM, we disallow user to set S3 external ID explicitly,
-// and we will use the keyspace name as the S3 external ID.
+// For nextgen IMPORT INTO with SEM, require explicit S3 authentication and
+// disallow explicit S3 external ID. The keyspace name is used as the S3 external ID.
 func checkNextGenS3PathWithSem(u *url.URL) error {
 	values := u.Query()
-	for k := range values {
-		lowerK := strings.ToLower(k)
-		if lowerK == s3like.S3ExternalID {
+	hasAccessKey := false
+	hasSecretAccessKey := false
+	hasRoleARN := false
+	hasValue := func(values []string) bool {
+		return len(values) > 0 && values[0] != ""
+	}
+	for k, v := range values {
+		normalizedK := objstore.NormalizeQueryParameterKey(k)
+		switch normalizedK {
+		case s3like.S3ExternalID:
 			return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO with explicit external ID")
+		case s3like.S3AccessKey:
+			hasAccessKey = hasAccessKey || hasValue(v)
+		case s3like.S3SecretAccessKey:
+			hasSecretAccessKey = hasSecretAccessKey || hasValue(v)
+		case s3like.S3RoleARN:
+			hasRoleARN = hasRoleARN || hasValue(v)
 		}
+	}
+
+	if !hasRoleARN && !(hasAccessKey && hasSecretAccessKey) {
+		return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO from S3-like storage without access key/secret access key or role ARN")
 	}
 
 	return nil

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -1132,9 +1132,10 @@ func TestGetMaxWriteSpeedFromExpression(t *testing.T) {
 
 func TestProcessNextGenS3Path(t *testing.T) {
 	for _, str := range []string{
-		"S3://bucket?External-id=abc",
-		"oss://bucket?External-id=abc",
-		"oSS://bucket?External-id=abc",
+		"S3://bucket?External-id=abc&access-key=ak&secret-access-key=sk",
+		"s3://bucket?external_id=abc&access-key=ak&secret-access-key=sk",
+		"oss://bucket?External-id=abc&role-arn=arn",
+		"oSS://bucket?External-id=abc&access-key=ak&secret-access-key=sk",
 	} {
 		u, err := url.Parse(str)
 		require.NoError(t, err)
@@ -1144,13 +1145,31 @@ func TestProcessNextGenS3Path(t *testing.T) {
 	}
 
 	for _, str := range []string{
-		"s3://bucket",
-		"oss://bucket",
+		"s3://bucket?access-key=ak&secret-access-key=sk",
+		"s3://bucket?access_key=ak&secret_access_key=sk",
+		"oss://bucket?role-arn=arn",
+		"oss://bucket?role_arn=arn",
 	} {
 		u, err := url.Parse(str)
 		require.NoError(t, err)
 		err = checkNextGenS3PathWithSem(u)
 		require.NoError(t, err)
+	}
+
+	for _, str := range []string{
+		"s3://bucket",
+		"s3://bucket?access-key=&secret-access-key=",
+		"s3://bucket?access-key=ak",
+		"s3://bucket?secret-access-key=sk",
+		"s3://bucket?profile=dev",
+		"oss://bucket",
+		"oss://bucket?role-arn=",
+	} {
+		u, err := url.Parse(str)
+		require.NoError(t, err)
+		err = checkNextGenS3PathWithSem(u)
+		require.ErrorIs(t, err, plannererrors.ErrNotSupportedWithSem)
+		require.ErrorContains(t, err, "IMPORT INTO from S3-like storage without access key/secret access key or role ARN")
 	}
 }
 

--- a/pkg/util/sem/compat/BUILD.bazel
+++ b/pkg/util/sem/compat/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     embed = [":compat"],
     flaky = True,
     deps = [
+        "//pkg/config/kerneltype",
         "//pkg/objstore/s3like",
         "//pkg/parser/auth",
         "//pkg/parser/mysql",

--- a/pkg/util/sem/compat/sem_integration_test.go
+++ b/pkg/util/sem/compat/sem_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/objstore/s3like"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
@@ -51,6 +52,12 @@ func TestRestrictedSQL(t *testing.T) {
 		tk.MustContainErrMsg("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=abc'", "is not supported when security enhanced mode is enabled")
 
 		require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "semuser", Hostname: "localhost"}, nil, nil, nil))
+		if kerneltype.IsNextGen() {
+			tk.MustContainErrMsg("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=allowed'", "IMPORT INTO with explicit external ID")
+			tk.MustQuery("select * from test.t").Check(testkit.Rows())
+			return
+		}
+
 		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/importer/NewImportPlan", func(plan *plannercore.ImportInto) {
 			u, err := url.Parse(plan.Path)
 			require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68226

Problem Summary:

In NextGen security enhanced mode, `IMPORT INTO` accepted S3-like storage URIs without explicit user-provided credentials. That allowed the object-store client to fall back to TiDB node-role credentials, which weakens the expected boundary for user-specified import sources.

### What changed and how does it work?

This PR requires explicit authentication for S3-like `IMPORT INTO` sources when NextGen and SEM are enabled.

- Adds normalized object-store query parameter matching so both dash and underscore spellings are handled consistently.
- Defines shared S3-like query keys for access key, secret access key, and role ARN.
- Rejects S3-like import paths unless they provide either a non-empty access key/secret access key pair or a non-empty role ARN.
- Preserves the existing NextGen SEM behavior that rejects explicit external ID and injects the keyspace name as the external ID for allowed paths.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit tests:

- `./tools/check/failpoint-go-test.sh pkg/planner/core -tags=intest,deadlock,nextgen -run TestProcessNextGenS3Path -count=1`
- `./tools/check/failpoint-go-test.sh pkg/executor -tags=intest,deadlock,nextgen -run TestNextGenS3ExternalID -count=1`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
In NextGen security enhanced mode, IMPORT INTO from S3-like storage now requires access key/secret access key credentials or a role ARN.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IMPORT INTO now enforces S3-like credential requirements under Security Enhanced Mode: requests without proper credentials are rejected; explicit external IDs are disallowed.
  * Query-parameter formats for credentials (kebab/snake case) are handled consistently.

* **Tests**
  * Expanded test coverage for S3/OSS URL parsing and credential validation, including more error and no-error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->