### PR TITLE
server, session: interrupt autocommit DML after disconnect

### DIFF
--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -2112,9 +2112,11 @@ func (cc *clientConn) setSQLKillerConnectionAlive() func() {
 
 func (cc *clientConn) monitorConnectionAlive(isAlive func() bool, stop <-chan struct{}) {
 	checkInterval := time.Second
-	if intest.InTest {
-		checkInterval = time.Millisecond
-	}
+	failpoint.Inject("mockConnectionAliveMonitorInterval", func(val failpoint.Value) {
+		if interval, ok := val.(int); ok {
+			checkInterval = time.Duration(interval) * time.Millisecond
+		}
+	})
 	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
 	for {

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -2090,27 +2090,37 @@ func setResourceGroupTaggerForMultiStmtPrefetch(snapshot kv.Snapshot, sqls strin
 	}
 }
 
+// setSQLKillerConnectionAlive installs a connection-liveness probe on the
+// session SQLKiller and starts a background monitor for the current statement.
+// The returned cleanup is idempotent and must be called when the statement is
+// done to stop the monitor and clear the probe.
 func (cc *clientConn) setSQLKillerConnectionAlive() func() {
 	fn := func() bool {
 		if cc.bufReadConn != nil {
+			// IsAlive returns 0 only when the connection is known dead. Treat
+			// unknown states as alive so we do not interrupt queries
+			// conservatively when the liveness check itself cannot run.
 			return cc.bufReadConn.IsAlive() != 0
 		}
 		return true
 	}
 	cc.ctx.GetSessionVars().SQLKiller.IsConnectionAlive.Store(&fn)
 	stopMonitor := make(chan struct{})
-	go cc.monitorConnectionAlive(fn, stopMonitor)
+	doneMonitor := make(chan struct{})
+	go cc.monitorConnectionAlive(fn, stopMonitor, doneMonitor)
 
 	var clearOnce sync.Once
 	return func() {
 		clearOnce.Do(func() {
 			close(stopMonitor)
+			<-doneMonitor
 			cc.ctx.GetSessionVars().SQLKiller.IsConnectionAlive.Store(nil)
 		})
 	}
 }
 
-func (cc *clientConn) monitorConnectionAlive(isAlive func() bool, stop <-chan struct{}) {
+func (cc *clientConn) monitorConnectionAlive(isAlive func() bool, stop <-chan struct{}, done chan<- struct{}) {
+	defer close(done)
 	checkInterval := time.Second
 	failpoint.Inject("mockConnectionAliveMonitorInterval", func(val failpoint.Value) {
 		if interval, ok := val.(int); ok {
@@ -2123,6 +2133,11 @@ func (cc *clientConn) monitorConnectionAlive(isAlive func() bool, stop <-chan st
 		select {
 		case <-ticker.C:
 			if !isAlive() {
+				select {
+				case <-stop:
+					return
+				default:
+				}
 				cc.ctx.GetSessionVars().SQLKiller.SendKillSignal(sqlkiller.QueryInterrupted)
 				cc.cancelDispatch()
 				return
@@ -2187,6 +2202,7 @@ func (cc *clientConn) handleStmt(
 	monitoringConnectionAlive := shouldMonitorConnectionAliveDuringExecute(stmt, cc.ctx.GetSessionVars())
 	if monitoringConnectionAlive {
 		clearConnectionAlive = cc.setSQLKillerConnectionAlive()
+		defer clearConnectionAlive()
 	}
 	rs, err := cc.ctx.ExecuteStmt(ctx, stmt)
 	if rs == nil || err != nil {
@@ -2224,6 +2240,7 @@ func (cc *clientConn) handleStmt(
 		}
 		if !monitoringConnectionAlive {
 			clearConnectionAlive = cc.setSQLKillerConnectionAlive()
+			defer clearConnectionAlive()
 		}
 		cc.ctx.GetSessionVars().SQLKiller.SetFinishFunc(
 			func() {
@@ -2233,7 +2250,6 @@ func (cc *clientConn) handleStmt(
 		cc.ctx.GetSessionVars().SQLKiller.InWriteResultSet.Store(true)
 		defer cc.ctx.GetSessionVars().SQLKiller.InWriteResultSet.Store(false)
 		defer cc.ctx.GetSessionVars().SQLKiller.ClearFinishFunc()
-		defer clearConnectionAlive()
 		if retryable, err := cc.writeResultSet(ctx, rs, false, status, 0); err != nil {
 			return retryable, err
 		}

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -2141,6 +2141,9 @@ func (cc *clientConn) cancelDispatch() {
 }
 
 func shouldMonitorConnectionAliveDuringExecute(stmt ast.StmtNode, sessVars *variable.SessionVars) bool {
+	if !sessVars.IsAutocommit() || sessVars.InTxn() {
+		return false
+	}
 	if executeStmt, ok := stmt.(*ast.ExecuteStmt); ok {
 		prepared, err := plannercore.GetPreparedStmt(executeStmt, sessVars)
 		if err != nil || prepared.PreparedAst == nil {

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -107,6 +107,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	tlsutil "github.com/pingcap/tidb/pkg/util/tls"
 	"github.com/pingcap/tidb/pkg/util/topsql"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
@@ -2089,6 +2090,72 @@ func setResourceGroupTaggerForMultiStmtPrefetch(snapshot kv.Snapshot, sqls strin
 	}
 }
 
+func (cc *clientConn) setSQLKillerConnectionAlive() func() {
+	fn := func() bool {
+		if cc.bufReadConn != nil {
+			return cc.bufReadConn.IsAlive() != 0
+		}
+		return true
+	}
+	cc.ctx.GetSessionVars().SQLKiller.IsConnectionAlive.Store(&fn)
+	stopMonitor := make(chan struct{})
+	go cc.monitorConnectionAlive(fn, stopMonitor)
+
+	var clearOnce sync.Once
+	return func() {
+		clearOnce.Do(func() {
+			close(stopMonitor)
+			cc.ctx.GetSessionVars().SQLKiller.IsConnectionAlive.Store(nil)
+		})
+	}
+}
+
+func (cc *clientConn) monitorConnectionAlive(isAlive func() bool, stop <-chan struct{}) {
+	checkInterval := time.Second
+	if intest.InTest {
+		checkInterval = time.Millisecond
+	}
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if !isAlive() {
+				cc.ctx.GetSessionVars().SQLKiller.SendKillSignal(sqlkiller.QueryInterrupted)
+				cc.cancelDispatch()
+				return
+			}
+		case <-stop:
+			return
+		}
+	}
+}
+
+func (cc *clientConn) cancelDispatch() {
+	cc.mu.RLock()
+	cancelFunc := cc.mu.cancelFunc
+	cc.mu.RUnlock()
+	if cancelFunc != nil {
+		cancelFunc()
+	}
+}
+
+func shouldMonitorConnectionAliveDuringExecute(stmt ast.StmtNode, sessVars *variable.SessionVars) bool {
+	if executeStmt, ok := stmt.(*ast.ExecuteStmt); ok {
+		prepared, err := plannercore.GetPreparedStmt(executeStmt, sessVars)
+		if err != nil || prepared.PreparedAst == nil {
+			return false
+		}
+		stmt = prepared.PreparedAst.Stmt
+	}
+	switch stmt.(type) {
+	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt:
+		return true
+	default:
+		return false
+	}
+}
+
 // The first return value indicates whether the call of handleStmt has no side effect and can be retried.
 // Currently, the first return value is used to fall back to TiKV when TiFlash is down.
 func (cc *clientConn) handleStmt(
@@ -2111,7 +2178,15 @@ func (cc *clientConn) handleStmt(
 		}
 	}
 
+	clearConnectionAlive := func() {}
+	monitoringConnectionAlive := shouldMonitorConnectionAliveDuringExecute(stmt, cc.ctx.GetSessionVars())
+	if monitoringConnectionAlive {
+		clearConnectionAlive = cc.setSQLKillerConnectionAlive()
+	}
 	rs, err := cc.ctx.ExecuteStmt(ctx, stmt)
+	if rs == nil || err != nil {
+		clearConnectionAlive()
+	}
 	reg.End()
 	// - If rs is not nil, the statement tracker detachment from session tracker
 	//   is done in the `rs.Close` in most cases.
@@ -2142,22 +2217,18 @@ func (cc *clientConn) handleStmt(
 		if cc.getStatus() == connStatusShutdown {
 			return false, exeerrors.ErrQueryInterrupted
 		}
+		if !monitoringConnectionAlive {
+			clearConnectionAlive = cc.setSQLKillerConnectionAlive()
+		}
 		cc.ctx.GetSessionVars().SQLKiller.SetFinishFunc(
 			func() {
 				//nolint: errcheck
 				rs.Finish()
 			})
-		fn := func() bool {
-			if cc.bufReadConn != nil {
-				return cc.bufReadConn.IsAlive() != 0
-			}
-			return true
-		}
-		cc.ctx.GetSessionVars().SQLKiller.IsConnectionAlive.Store(&fn)
 		cc.ctx.GetSessionVars().SQLKiller.InWriteResultSet.Store(true)
 		defer cc.ctx.GetSessionVars().SQLKiller.InWriteResultSet.Store(false)
 		defer cc.ctx.GetSessionVars().SQLKiller.ClearFinishFunc()
-		defer cc.ctx.GetSessionVars().SQLKiller.IsConnectionAlive.Store(nil)
+		defer clearConnectionAlive()
 		if retryable, err := cc.writeResultSet(ctx, rs, false, status, 0); err != nil {
 			return retryable, err
 		}

--- a/pkg/server/conn_stmt.go
+++ b/pkg/server/conn_stmt.go
@@ -233,15 +233,6 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 func (cc *clientConn) executePlanCacheStmt(ctx context.Context, stmt any, args []param.BinaryParam, useCursor bool) (err error) {
 	ctx = execdetails.ContextWithInitializedExecDetails(ctx)
 
-	fn := func() bool {
-		if cc.bufReadConn != nil {
-			return cc.bufReadConn.IsAlive() != 0
-		}
-		return true
-	}
-	cc.ctx.GetSessionVars().SQLKiller.IsConnectionAlive.Store(&fn)
-	defer cc.ctx.GetSessionVars().SQLKiller.IsConnectionAlive.Store(nil)
-
 	//nolint:forcetypeassert
 	retryable, err := cc.executePreparedStmtAndWriteResult(ctx, stmt.(PreparedStatement), args, useCursor)
 	if err != nil {
@@ -319,9 +310,24 @@ func (cc *clientConn) executePreparedStmtAndWriteResult(ctx context.Context, stm
 		sql = planCacheStmt.StmtText
 	}
 	execStmt.SetText(charset.EncodingUTF8Impl, sql)
+	clearConnectionAlive := func() {}
+	monitoringConnectionAlive := false
+	if planCacheStmt != nil && planCacheStmt.PreparedAst != nil {
+		monitoringConnectionAlive = shouldMonitorConnectionAliveDuringExecute(planCacheStmt.PreparedAst.Stmt, vars)
+		if monitoringConnectionAlive {
+			clearConnectionAlive = cc.setSQLKillerConnectionAlive()
+		}
+	}
 	rs, err := (&cc.ctx).ExecuteStmt(ctx, execStmt)
+	if rs == nil || err != nil {
+		clearConnectionAlive()
+	}
 	var lazy bool
 	if rs != nil {
+		if !monitoringConnectionAlive {
+			clearConnectionAlive = cc.setSQLKillerConnectionAlive()
+		}
+		defer clearConnectionAlive()
 		defer func() {
 			if !lazy {
 				rs.Close()

--- a/pkg/server/conn_stmt.go
+++ b/pkg/server/conn_stmt.go
@@ -316,6 +316,7 @@ func (cc *clientConn) executePreparedStmtAndWriteResult(ctx context.Context, stm
 		monitoringConnectionAlive = shouldMonitorConnectionAliveDuringExecute(planCacheStmt.PreparedAst.Stmt, vars)
 		if monitoringConnectionAlive {
 			clearConnectionAlive = cc.setSQLKillerConnectionAlive()
+			defer clearConnectionAlive()
 		}
 	}
 	rs, err := (&cc.ctx).ExecuteStmt(ctx, execStmt)
@@ -326,8 +327,8 @@ func (cc *clientConn) executePreparedStmtAndWriteResult(ctx context.Context, stm
 	if rs != nil {
 		if !monitoringConnectionAlive {
 			clearConnectionAlive = cc.setSQLKillerConnectionAlive()
+			defer clearConnectionAlive()
 		}
-		defer clearConnectionAlive()
 		defer func() {
 			if !lazy {
 				rs.Close()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1017,13 +1017,7 @@ func killQuery(conn *clientConn, maxExecutionTime, runaway bool) {
 	} else {
 		sessVars.SQLKiller.SendKillSignal(sqlkiller.QueryInterrupted)
 	}
-	conn.mu.RLock()
-	cancelFunc := conn.mu.cancelFunc
-	conn.mu.RUnlock()
-
-	if cancelFunc != nil {
-		cancelFunc()
-	}
+	conn.cancelDispatch()
 	sessVars.SQLKiller.FinishResultSet()
 }
 

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3513,35 +3513,32 @@ func TestClientDisconnectKillsAutocommitInsert(t *testing.T) {
 		if prepared {
 			name = "prepared"
 		}
-		t.Run(name, func(t *testing.T) {
-			ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
-				tableName := "issue57531_insert_" + name
-				dbt.MustExec("drop table if exists " + tableName)
-				dbt.MustExec("create table " + tableName + " (a int primary key, b int)")
-				runClientDisconnectAutocommitInsert(t, dbt, tableName, fmt.Sprintf("insert into %s values (1, sleep(300))", tableName), prepared)
+		for _, insertCase := range []struct {
+			name     string
+			buildSQL func(tableName string) string
+		}{
+			{
+				name: "single_row",
+				buildSQL: func(tableName string) string {
+					return fmt.Sprintf("insert into %s values (1, sleep(300))", tableName)
+				},
+			},
+			{
+				name: "multi_rows",
+				buildSQL: func(tableName string) string {
+					return fmt.Sprintf("insert into %s values (1, 1), (2, sleep(300)), (3, 3), (4, 4), (5, 5)", tableName)
+				},
+			},
+		} {
+			t.Run(name+"/"+insertCase.name, func(t *testing.T) {
+				ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
+					tableName := "issue57531_insert_" + name + "_" + insertCase.name
+					dbt.MustExec("drop table if exists " + tableName)
+					dbt.MustExec("create table " + tableName + " (a int primary key, b int)")
+					runClientDisconnectAutocommitInsert(t, dbt, tableName, insertCase.buildSQL(tableName), prepared)
+				})
 			})
-		})
-	}
-}
-
-func TestClientDisconnectCancelsAutocommitInsertPrewrite(t *testing.T) {
-	ts := servertestkit.CreateTidbTestSuite(t)
-	enableFastConnectionAliveMonitor(t)
-
-	for _, prepared := range []bool{false, true} {
-		name := "query"
-		if prepared {
-			name = "prepared"
 		}
-		t.Run(name, func(t *testing.T) {
-			ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
-				tableName := "issue57531_prewrite_" + name
-				dbt.MustExec("drop table if exists " + tableName)
-				dbt.MustExec("create table " + tableName + " (a int primary key, b int)")
-				testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/store/mockstore/unistore/rpcPrewriteResult", `return("notLeader")`)
-				runClientDisconnectAutocommitInsert(t, dbt, tableName, fmt.Sprintf("insert into %s values (1, 1)", tableName), prepared)
-			})
-		})
 	}
 }
 

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3459,22 +3459,12 @@ func TestIssue57531(t *testing.T) {
 	var rsCnt int
 	for i := range 2 {
 		ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
-			var conn *sql.Conn
-			var netConn net.Conn
-			conn, _ = dbt.GetDB().Conn(context.Background())
-
-			// get the TCP connection
-			conn.Raw(func(driverConn any) error {
-				v := reflect.ValueOf(driverConn)
-				if v.Kind() == reflect.Ptr {
-					v = v.Elem()
-				}
-				f := v.FieldByName("netConn")
-				if f.IsValid() && f.Type().Implements(reflect.TypeOf((*net.Conn)(nil)).Elem()) {
-					netConn = *(*net.Conn)(unsafe.Pointer(f.UnsafeAddr()))
-				}
-				return nil
-			})
+			conn, err := dbt.GetDB().Conn(context.Background())
+			require.NoError(t, err)
+			defer func() {
+				_ = conn.Close()
+			}()
+			netConn := getRawNetConn(t, conn)
 
 			// execute `select sleep(300)`
 			go func() {
@@ -3512,6 +3502,132 @@ func TestIssue57531(t *testing.T) {
 			}, 5*time.Second, 50*time.Millisecond)
 		})
 	}
+}
+
+func TestClientDisconnectKillsAutocommitInsert(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+
+	ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
+		dbt.MustExec("drop table if exists issue57531_insert")
+		dbt.MustExec("create table issue57531_insert (a int primary key, b int)")
+
+		conn, err := dbt.GetDB().Conn(context.Background())
+		require.NoError(t, err)
+		defer func() {
+			_ = conn.Close()
+		}()
+		netConn := getRawNetConn(t, conn)
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := conn.ExecContext(context.Background(), "insert into issue57531_insert values (1, sleep(300))")
+			done <- err
+		}()
+
+		require.Eventually(t, func() bool {
+			return processlistCountByInfo(t, dbt, "insert into issue57531_insert%") == 1
+		}, 5*time.Second, 50*time.Millisecond)
+
+		require.NoError(t, netConn.Close())
+
+		var execErr error
+		require.Eventually(t, func() bool {
+			select {
+			case execErr = <-done:
+				return true
+			default:
+				return false
+			}
+		}, 5*time.Second, 50*time.Millisecond)
+		require.Error(t, execErr)
+
+		require.Eventually(t, func() bool {
+			return processlistCountByInfo(t, dbt, "insert into issue57531_insert%") == 0
+		}, 5*time.Second, 50*time.Millisecond)
+
+		var cnt int
+		err = dbt.GetDB().QueryRowContext(context.Background(), "select count(*) from issue57531_insert").Scan(&cnt)
+		require.NoError(t, err)
+		require.Equal(t, 0, cnt)
+	})
+}
+
+func TestClientDisconnectCancelsAutocommitInsertPrewrite(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+
+	ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
+		dbt.MustExec("drop table if exists issue57531_prewrite")
+		dbt.MustExec("create table issue57531_prewrite (a int primary key, b int)")
+		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/store/mockstore/unistore/rpcPrewriteResult", `return("notLeader")`)
+
+		conn, err := dbt.GetDB().Conn(context.Background())
+		require.NoError(t, err)
+		defer func() {
+			_ = conn.Close()
+		}()
+		netConn := getRawNetConn(t, conn)
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := conn.ExecContext(context.Background(), "insert into issue57531_prewrite values (1, 1)")
+			done <- err
+		}()
+
+		require.Eventually(t, func() bool {
+			return processlistCountByInfo(t, dbt, "insert into issue57531_prewrite%") == 1
+		}, 5*time.Second, 50*time.Millisecond)
+
+		require.NoError(t, netConn.Close())
+
+		var execErr error
+		require.Eventually(t, func() bool {
+			select {
+			case execErr = <-done:
+				return true
+			default:
+				return false
+			}
+		}, 5*time.Second, 50*time.Millisecond)
+		require.Error(t, execErr)
+
+		require.Eventually(t, func() bool {
+			return processlistCountByInfo(t, dbt, "insert into issue57531_prewrite%") == 0
+		}, 5*time.Second, 50*time.Millisecond)
+
+		var cnt int
+		err = dbt.GetDB().QueryRowContext(context.Background(), "select count(*) from issue57531_prewrite").Scan(&cnt)
+		require.NoError(t, err)
+		require.Equal(t, 0, cnt)
+	})
+}
+
+func getRawNetConn(t *testing.T, conn *sql.Conn) net.Conn {
+	var netConn net.Conn
+	err := conn.Raw(func(driverConn any) error {
+		v := reflect.ValueOf(driverConn)
+		if v.Kind() == reflect.Ptr {
+			v = v.Elem()
+		}
+		f := v.FieldByName("netConn")
+		if f.IsValid() && f.Type().Implements(reflect.TypeOf((*net.Conn)(nil)).Elem()) {
+			netConn = *(*net.Conn)(unsafe.Pointer(f.UnsafeAddr()))
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, netConn)
+	return netConn
+}
+
+func processlistCountByInfo(t *testing.T, dbt *testkit.DBTestKit, pattern string) int {
+	var cnt int
+	err := dbt.GetDB().QueryRowContext(
+		context.Background(),
+		"select count(*) from information_schema.processlist where info like ?",
+		pattern,
+	).Scan(&cnt)
+	require.NoError(t, err)
+	return cnt
 }
 
 func TestCloseConnForUndeterminedError(t *testing.T) {

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3508,99 +3508,100 @@ func TestClientDisconnectKillsAutocommitInsert(t *testing.T) {
 	ts := servertestkit.CreateTidbTestSuite(t)
 	enableFastConnectionAliveMonitor(t)
 
-	ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
-		dbt.MustExec("drop table if exists issue57531_insert")
-		dbt.MustExec("create table issue57531_insert (a int primary key, b int)")
-
-		conn, err := dbt.GetDB().Conn(context.Background())
-		require.NoError(t, err)
-		defer func() {
-			_ = conn.Close()
-		}()
-		netConn := getRawNetConn(t, conn)
-
-		done := make(chan error, 1)
-		go func() {
-			_, err := conn.ExecContext(context.Background(), "insert into issue57531_insert values (1, sleep(300))")
-			done <- err
-		}()
-
-		require.Eventually(t, func() bool {
-			return processlistCountByInfo(t, dbt, "insert into issue57531_insert%") == 1
-		}, 5*time.Second, 50*time.Millisecond)
-
-		require.NoError(t, netConn.Close())
-
-		var execErr error
-		require.Eventually(t, func() bool {
-			select {
-			case execErr = <-done:
-				return true
-			default:
-				return false
-			}
-		}, 5*time.Second, 50*time.Millisecond)
-		require.Error(t, execErr)
-
-		require.Eventually(t, func() bool {
-			return processlistCountByInfo(t, dbt, "insert into issue57531_insert%") == 0
-		}, 5*time.Second, 50*time.Millisecond)
-
-		var cnt int
-		err = dbt.GetDB().QueryRowContext(context.Background(), "select count(*) from issue57531_insert").Scan(&cnt)
-		require.NoError(t, err)
-		require.Equal(t, 0, cnt)
-	})
+	for _, prepared := range []bool{false, true} {
+		name := "query"
+		if prepared {
+			name = "prepared"
+		}
+		t.Run(name, func(t *testing.T) {
+			ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
+				tableName := "issue57531_insert_" + name
+				dbt.MustExec("drop table if exists " + tableName)
+				dbt.MustExec("create table " + tableName + " (a int primary key, b int)")
+				runClientDisconnectAutocommitInsert(t, dbt, tableName, fmt.Sprintf("insert into %s values (1, sleep(300))", tableName), prepared)
+			})
+		})
+	}
 }
 
 func TestClientDisconnectCancelsAutocommitInsertPrewrite(t *testing.T) {
 	ts := servertestkit.CreateTidbTestSuite(t)
 	enableFastConnectionAliveMonitor(t)
 
-	ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
-		dbt.MustExec("drop table if exists issue57531_prewrite")
-		dbt.MustExec("create table issue57531_prewrite (a int primary key, b int)")
-		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/store/mockstore/unistore/rpcPrewriteResult", `return("notLeader")`)
+	for _, prepared := range []bool{false, true} {
+		name := "query"
+		if prepared {
+			name = "prepared"
+		}
+		t.Run(name, func(t *testing.T) {
+			ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
+				tableName := "issue57531_prewrite_" + name
+				dbt.MustExec("drop table if exists " + tableName)
+				dbt.MustExec("create table " + tableName + " (a int primary key, b int)")
+				testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/store/mockstore/unistore/rpcPrewriteResult", `return("notLeader")`)
+				runClientDisconnectAutocommitInsert(t, dbt, tableName, fmt.Sprintf("insert into %s values (1, 1)", tableName), prepared)
+			})
+		})
+	}
+}
 
-		conn, err := dbt.GetDB().Conn(context.Background())
+func runClientDisconnectAutocommitInsert(t *testing.T, dbt *testkit.DBTestKit, tableName, insertSQL string, prepared bool) {
+	conn, err := dbt.GetDB().Conn(context.Background())
+	require.NoError(t, err)
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	var stmt *sql.Stmt
+	if prepared {
+		stmt, err = conn.PrepareContext(context.Background(), insertSQL)
 		require.NoError(t, err)
 		defer func() {
-			_ = conn.Close()
+			_ = stmt.Close()
 		}()
-		netConn := getRawNetConn(t, conn)
+	}
+	netConn := getRawNetConn(t, conn)
 
-		done := make(chan error, 1)
-		go func() {
-			_, err := conn.ExecContext(context.Background(), "insert into issue57531_prewrite values (1, 1)")
-			done <- err
-		}()
-
-		require.Eventually(t, func() bool {
-			return processlistCountByInfo(t, dbt, "insert into issue57531_prewrite%") == 1
-		}, 5*time.Second, 50*time.Millisecond)
-
-		require.NoError(t, netConn.Close())
-
+	done := make(chan error, 1)
+	go func() {
 		var execErr error
-		require.Eventually(t, func() bool {
-			select {
-			case execErr = <-done:
-				return true
-			default:
-				return false
-			}
-		}, 5*time.Second, 50*time.Millisecond)
-		require.Error(t, execErr)
+		if prepared {
+			_, execErr = stmt.ExecContext(context.Background())
+		} else {
+			_, execErr = conn.ExecContext(context.Background(), insertSQL)
+		}
+		done <- execErr
+	}()
 
-		require.Eventually(t, func() bool {
-			return processlistCountByInfo(t, dbt, "insert into issue57531_prewrite%") == 0
-		}, 5*time.Second, 50*time.Millisecond)
+	pattern := fmt.Sprintf("insert into %s%%", tableName)
+	require.Eventually(t, func() bool {
+		return processlistCountByInfo(t, dbt, pattern) == 1
+	}, 5*time.Second, 50*time.Millisecond)
+	processID, ok := processlistIDByInfo(t, dbt, pattern)
+	require.True(t, ok)
+	cleanupProcessByID(t, dbt.GetDB(), processID)
 
-		var cnt int
-		err = dbt.GetDB().QueryRowContext(context.Background(), "select count(*) from issue57531_prewrite").Scan(&cnt)
-		require.NoError(t, err)
-		require.Equal(t, 0, cnt)
-	})
+	require.NoError(t, netConn.Close())
+
+	var execErr error
+	require.Eventually(t, func() bool {
+		select {
+		case execErr = <-done:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 50*time.Millisecond)
+	require.Error(t, execErr)
+
+	require.Eventually(t, func() bool {
+		return processlistCountByInfo(t, dbt, pattern) == 0
+	}, 5*time.Second, 50*time.Millisecond)
+
+	var cnt int
+	err = dbt.GetDB().QueryRowContext(context.Background(), "select count(*) from "+tableName).Scan(&cnt)
+	require.NoError(t, err)
+	require.Equal(t, 0, cnt)
 }
 
 func enableFastConnectionAliveMonitor(t *testing.T) {
@@ -3640,6 +3641,46 @@ func processlistCountByInfo(t *testing.T, dbt *testkit.DBTestKit, pattern string
 	).Scan(&cnt)
 	require.NoError(t, err)
 	return cnt
+}
+
+func processlistIDByInfo(t *testing.T, dbt *testkit.DBTestKit, pattern string) (uint64, bool) {
+	var id uint64
+	err := dbt.GetDB().QueryRowContext(
+		context.Background(),
+		"select id from information_schema.processlist where info like ? limit 1",
+		pattern,
+	).Scan(&id)
+	if err == sql.ErrNoRows {
+		return 0, false
+	}
+	require.NoError(t, err)
+	return id, true
+}
+
+func cleanupProcessByID(t *testing.T, db *sql.DB, processID uint64) {
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		var cnt int
+		err = conn.QueryRowContext(
+			ctx,
+			"select count(*) from information_schema.processlist where id = ?",
+			processID,
+		).Scan(&cnt)
+		if err != nil || cnt == 0 {
+			return
+		}
+		_, _ = conn.ExecContext(ctx, fmt.Sprintf("kill query %d", processID))
+	})
 }
 
 func TestCloseConnForUndeterminedError(t *testing.T) {

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3506,6 +3506,7 @@ func TestIssue57531(t *testing.T) {
 
 func TestClientDisconnectKillsAutocommitInsert(t *testing.T) {
 	ts := servertestkit.CreateTidbTestSuite(t)
+	enableFastConnectionAliveMonitor(t)
 
 	ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("drop table if exists issue57531_insert")
@@ -3554,6 +3555,7 @@ func TestClientDisconnectKillsAutocommitInsert(t *testing.T) {
 
 func TestClientDisconnectCancelsAutocommitInsertPrewrite(t *testing.T) {
 	ts := servertestkit.CreateTidbTestSuite(t)
+	enableFastConnectionAliveMonitor(t)
 
 	ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("drop table if exists issue57531_prewrite")
@@ -3598,6 +3600,16 @@ func TestClientDisconnectCancelsAutocommitInsertPrewrite(t *testing.T) {
 		err = dbt.GetDB().QueryRowContext(context.Background(), "select count(*) from issue57531_prewrite").Scan(&cnt)
 		require.NoError(t, err)
 		require.Equal(t, 0, cnt)
+	})
+}
+
+func enableFastConnectionAliveMonitor(t *testing.T) {
+	require.NoError(t, failpoint.Enable(
+		"github.com/pingcap/tidb/pkg/server/mockConnectionAliveMonitorInterval",
+		`return(1)`,
+	))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/server/mockConnectionAliveMonitorInterval"))
 	})
 }
 

--- a/pkg/session/tidb.go
+++ b/pkg/session/tidb.go
@@ -275,6 +275,9 @@ func isLoadDataLocal(sql sqlexec.Statement) bool {
 }
 
 func shouldCheckConnectionAliveBeforeCommit(sessVars *variable.SessionVars, sql sqlexec.Statement) bool {
+	if !sessVars.IsAutocommit() || sessVars.InTxn() {
+		return false
+	}
 	stmt, err := resolvePreparedStmt(sql.GetStmtNode(), sessVars)
 	if err != nil || stmt == nil {
 		return false

--- a/pkg/session/tidb.go
+++ b/pkg/session/tidb.go
@@ -220,7 +220,12 @@ func finishStmt(ctx context.Context, se *session, meetsErr error, sql sqlexec.St
 			failpoint.Return(errors.New("occur an error after finishStmt"))
 		}
 	})
-	if !sql.IsReadOnly(sessVars) {
+	readOnly := sql.IsReadOnly(sessVars)
+	if !readOnly && meetsErr == nil && shouldCheckConnectionAliveBeforeCommit(sessVars, sql) {
+		sessVars.SQLKiller.CheckConnectionAlive()
+		meetsErr = sessVars.SQLKiller.HandleSignal()
+	}
+	if !readOnly {
 		if meetsErr == nil && sessVars.TxnCtx.CouldRetry {
 			// Add only retry-safe write statements to StmtHistory.
 			// LOAD DATA LOCAL INFILE uses a one-shot client file stream via
@@ -267,6 +272,19 @@ func isLoadDataLocal(sql sqlexec.Statement) bool {
 		return s.FileLocRef == ast.FileLocClient
 	}
 	return false
+}
+
+func shouldCheckConnectionAliveBeforeCommit(sessVars *variable.SessionVars, sql sqlexec.Statement) bool {
+	stmt, err := resolvePreparedStmt(sql.GetStmtNode(), sessVars)
+	if err != nil || stmt == nil {
+		return false
+	}
+	switch stmt.(type) {
+	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt:
+		return true
+	default:
+		return false
+	}
 }
 
 func autoCommitAfterStmt(ctx context.Context, se *session, meetsErr error, sql sqlexec.Statement) error {

--- a/pkg/util/sqlkiller/sqlkiller.go
+++ b/pkg/util/sqlkiller/sqlkiller.go
@@ -220,7 +220,7 @@ func (killer *SQLKiller) HandleSignal() error {
 		} else if now.Sub(*lastCheckTime) > checkConnectionAliveDur {
 			killer.lastCheckTime.Store(&now)
 			if !(*fn)() {
-				atomic.CompareAndSwapUint32(&killer.Signal, 0, QueryInterrupted)
+				killer.sendKillSignal(QueryInterrupted)
 			}
 		}
 	}
@@ -238,7 +238,7 @@ func (killer *SQLKiller) HandleSignal() error {
 func (killer *SQLKiller) CheckConnectionAlive() {
 	fn := killer.IsConnectionAlive.Load()
 	if fn != nil && !(*fn)() {
-		atomic.CompareAndSwapUint32(&killer.Signal, 0, QueryInterrupted)
+		killer.sendKillSignal(QueryInterrupted)
 	}
 }
 

--- a/pkg/util/sqlkiller/sqlkiller.go
+++ b/pkg/util/sqlkiller/sqlkiller.go
@@ -234,6 +234,14 @@ func (killer *SQLKiller) HandleSignal() error {
 	return err
 }
 
+// CheckConnectionAlive checks whether the connection is alive immediately.
+func (killer *SQLKiller) CheckConnectionAlive() {
+	fn := killer.IsConnectionAlive.Load()
+	if fn != nil && !(*fn)() {
+		atomic.CompareAndSwapUint32(&killer.Signal, 0, QueryInterrupted)
+	}
+}
+
 // Reset resets the SqlKiller.
 func (killer *SQLKiller) Reset() {
 	if atomic.LoadUint32(&killer.Signal) != 0 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68236

Problem Summary:

Autocommit write statements such as `INSERT` do not write a result set, so the connection-liveness check added for the result-set path does not cover the whole statement lifecycle. If the client disconnects after TiDB has read the request packet, the statement can keep running until expression evaluation, commit, prewrite, or retry/backoff finishes naturally.

### What changed and how does it work?

- Install a SQLKiller connection-liveness callback while executing `INSERT`, `UPDATE`, and `DELETE`, including text protocol `EXECUTE` and binary prepared execution.
- Start a lightweight connection monitor for those write statements. When the underlying TCP connection is gone, it sends `QueryInterrupted` and cancels the current dispatch context, so prewrite/backoff can exit promptly.
- Keep the existing result-set liveness behavior for queries that return rows.
- Check connection liveness immediately before committing `INSERT` / `UPDATE` / `DELETE`, so a disconnect observed after execution but before commit is converted into an interrupt.
- Reuse the dispatch-context cancellation helper for `KILL QUERY`.
- Add regressions for autocommit `INSERT` disconnect before commit and during prewrite/backoff.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validated locally:

```bash
GOTOOLCHAIN=go1.25.9 GOFLAGS=-mod=mod ./tools/check/failpoint-go-test.sh pkg/server/tests/commontest -run 'Test(ClientDisconnectKillsAutocommitInsert|ClientDisconnectCancelsAutocommitInsertPrewrite|Issue57531)$' -count=1
GOTOOLCHAIN=go1.25.9 GOFLAGS=-mod=mod ./tools/check/failpoint-go-test.sh pkg/session -run '^$' -count=1
GOTOOLCHAIN=go1.25.9 GOFLAGS=-mod=mod go test ./pkg/util/sqlkiller -run '^$' -count=1
GOFLAGS=-mod=mod make lint
make bazel_ci_simple_prepare
git diff --check
```

`make bazel_prepare` was also attempted, but the current checkout's `go.mod` contains a local replacement `github.com/pingcap/tidb/pkg/parser => ./pkg/parser`, and Gazelle failed with:

```text
gazelle: go_repository does not support file path replacements for github.com/pingcap/tidb/pkg/parser -> ./pkg/parser
```

`make bazel_ci_simple_prepare` passed and did not generate additional Bazel diffs.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

No expected performance regression. The extra monitor is scoped to `INSERT` / `UPDATE` / `DELETE` execution while the statement is active. It checks once per second in normal builds and exits when the statement finishes.

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that autocommit write statements might not be interrupted promptly after the client disconnects.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Targeted in-execution liveness monitoring for autocommit writes and an added pre-commit liveness check for write statements.

* **Bug Fixes**
  * More reliable and faster cancellation/cleanup when clients disconnect, including server-side dispatch cancellation and unified kill-signal handling.

* **Tests**
  * New tests and helpers validating client disconnect behavior during autocommit writes (prepared and non-prepared) and processlist/connection checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68237)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->