### PR TITLE
*: add server_failpoint make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,8 +257,7 @@ else
 endif
 
 .PHONY: server_failpoint
-server_failpoint: ## Build TiDB server binary with failpoints enabled
-server_failpoint: failpoint-enable
+server_failpoint: failpoint-enable ## Build TiDB server binary with failpoints enabled
 	$(SERVER_BUILD_CMD) || { $(FAILPOINT_DISABLE); exit 1; }
 	@$(FAILPOINT_DISABLE)
 

--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,11 @@ else
 	CGO_ENABLED=1 $(GOBUILD) -gcflags="all=-N -l" $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o '$(TARGET)' ./cmd/tidb-server
 endif
 
+.PHONY: server_failpoint
+server_failpoint: failpoint-enable
+	$(SERVER_BUILD_CMD) || { $(FAILPOINT_DISABLE); exit 1; }
+	$(FAILPOINT_DISABLE)
+
 .PHONY: init-submodule
 init-submodule:
 	git submodule init && git submodule update --force

--- a/Makefile
+++ b/Makefile
@@ -257,9 +257,10 @@ else
 endif
 
 .PHONY: server_failpoint
+server_failpoint: ## Build TiDB server binary with failpoints enabled
 server_failpoint: failpoint-enable
 	$(SERVER_BUILD_CMD) || { $(FAILPOINT_DISABLE); exit 1; }
-	$(FAILPOINT_DISABLE)
+	@$(FAILPOINT_DISABLE)
 
 .PHONY: init-submodule
 init-submodule:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68241

Problem Summary:

There is no dedicated Makefile target for building a TiDB server binary with failpoint rewriting enabled.

### What changed and how does it work?

This PR adds a `server_failpoint` Makefile target. The target depends on `failpoint-enable`, reuses the existing `SERVER_BUILD_CMD`, and disables failpoints after the build. If the server build fails, it still disables failpoints before exiting.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - `make -n server_failpoint`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a build target to produce server builds with failpoints enabled for improved testing and debugging; the process now guarantees cleanup of failpoint state whether the build succeeds or fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->