### PR TITLE
*: harden generated Bazel artifact workflow

### DIFF
--- a/.github/workflows/check-bazel-prepare.yml
+++ b/.github/workflows/check-bazel-prepare.yml
@@ -1,0 +1,42 @@
+name: Check Bazel Prepare
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-bazel-prepare-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check Bazel Prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.25
+          cache: false
+      - name: Set up Bazelisk
+        uses: bazel-contrib/setup-bazel@0.16.0
+        with:
+          bazelisk-cache: false
+          repository-cache: false
+          external-cache: false
+      - name: Check Bazel Prepare
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Avoid the TiDB CI path that assumes Jenkins-owned temp directories.
+          unset CI
+          make check-bazel-prepare

--- a/.github/workflows/generate-bazel-files.yml
+++ b/.github/workflows/generate-bazel-files.yml
@@ -42,7 +42,16 @@ jobs:
           sed -i '/ats.apps.svc/d' DEPS.bzl
           sed -i '/bazel-cache/d' WORKSPACE
           sed -i '/ats.apps.svc/d' WORKSPACE
-          make bazel_prepare
+          bazel run //:gazelle
+          bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro DEPS.bzl%go_deps -build_file_proto_mode=disable -prune
+          bazel run \
+            --run_under="cd ${PWD} && " \
+            //tools/tazel:tazel
+
+          tmp_out="$(mktemp -d -t tidbbzl.XXXXXX)"
+          trap 'rm -rf "${tmp_out}"' EXIT
+          bazel run //cmd/mirror -- --mirror > "${tmp_out}/DEPS.bzl"
+          cp "${tmp_out}/DEPS.bzl" DEPS.bzl
       - name: Restore non-generated files
         shell: bash
         run: |
@@ -62,10 +71,16 @@ jobs:
             fi
 
             case "${path}" in
+              build/BUILD.bazel|build/*/BUILD.bazel)
+                ;;
+              WORKSPACE|WORKSPACE.bazel|build|build/*)
+                echo "Unsafe generated file path: ${path}" >&2
+                exit 1
+                ;;
               DEPS.bzl|*.bazel|*.bzl)
                 ;;
               *)
-                echo "Unexpected file changed by bazel_prepare: ${path}" >&2
+                echo "Unexpected generated file path: ${path}" >&2
                 exit 1
                 ;;
             esac

--- a/.github/workflows/update-bazel-files.yml
+++ b/.github/workflows/update-bazel-files.yml
@@ -59,10 +59,9 @@ jobs:
 
           if [[ "${head_repo}" != "${REPOSITORY}" ]]; then
             echo "same_repo=false" >> "${GITHUB_OUTPUT}"
-            exit 0
+          else
+            echo "same_repo=true" >> "${GITHUB_OUTPUT}"
           fi
-
-          echo "same_repo=true" >> "${GITHUB_OUTPUT}"
 
           if [[ "${pr_head_sha}" != "${RUN_HEAD_SHA}" ]]; then
             echo "stale=true" >> "${GITHUB_OUTPUT}"
@@ -75,6 +74,42 @@ jobs:
         shell: bash
         run: |
           echo "Skip stale bazel update for PR #${{ steps.pr.outputs.pr_number }}."
+      - name: Download Fork Bazel Files Artifact
+        if: steps.pr.outputs.same_repo != 'true' && steps.pr.outputs.stale != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: bazel-files
+          path: bazel-artifact
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - name: Report fork PR Bazel changes
+        if: steps.pr.outputs.same_repo != 'true' && steps.pr.outputs.stale != 'true'
+        shell: bash
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          patch_path="${PWD}/bazel-artifact/bazel.patch"
+          if [[ ! -f "${patch_path}" ]]; then
+            echo "Missing bazel.patch artifact for fork PR #${PR_NUMBER}." >&2
+            exit 1
+          fi
+
+          if [[ ! -s "${patch_path}" ]]; then
+            echo "No generated Bazel changes for fork PR #${PR_NUMBER}."
+            exit 0
+          fi
+
+          {
+            echo "Generated Bazel changes cannot be committed automatically for fork PR #${PR_NUMBER}."
+            echo "Run: gh run download ${RUN_ID} --repo ${REPOSITORY} --name bazel-files --dir bazel-artifact && git apply bazel-artifact/bazel.patch"
+          } | tee -a "${GITHUB_STEP_SUMMARY}"
+
+          exit 1
       - name: Checkout PR branch
         if: steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.stale != 'true'
         uses: actions/checkout@v6
@@ -101,7 +136,7 @@ jobs:
           set -euo pipefail
 
           patch_path="${PWD}/bazel-artifact/bazel.patch"
-          summary="$(git apply --summary "${patch_path}")"
+          summary="$(git -C pr apply --summary "${patch_path}")"
 
           while IFS= read -r line; do
             case "${line}" in
@@ -126,6 +161,12 @@ jobs:
                 echo "Unexpected patch path: ${path}" >&2
                 exit 1
                 ;;
+              build/BUILD.bazel|build/*/BUILD.bazel)
+                ;;
+              WORKSPACE|WORKSPACE.bazel|build|build/*)
+                echo "Unsafe patch path: ${path}" >&2
+                exit 1
+                ;;
               DEPS.bzl|*.bazel|*.bzl)
                 ;;
               *)
@@ -139,7 +180,7 @@ jobs:
               exit 1
             fi
             seen_paths["${path}"]=1
-          done < <(git apply --numstat -z "${patch_path}")
+          done < <(git -C pr apply --numstat -z "${patch_path}")
 
           git -C pr apply --check --index "${patch_path}"
           git -C pr apply --index "${patch_path}"


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68199

Problem Summary:

The generated Bazel files workflow can produce and later consume a generated patch artifact. The consumer workflow is privileged enough to commit generated files back to same-repo PR branches, so the generated artifact should have a narrow path boundary and should not carry high-risk workspace or build directory changes. Fork PRs also need an explicit signal when generated Bazel changes exist, because the base repository workflow cannot safely commit back to fork branches.

### What changed and how does it work?

This PR tightens the generated Bazel artifact path contract:

- Expand the `make bazel_prepare` call in `Generate Bazel Files` into the concrete Bazel commands used by the workflow.
- Reject generated changes to `WORKSPACE`, `WORKSPACE.bazel`, and non-`BUILD.bazel` files under `build/`.
- Keep `build/**/BUILD.bazel` allowed so Bazel metadata generated under `build/` can still be committed automatically.
- Recheck the same unsafe paths in `Update Bazel Files` before applying a downloaded artifact.
- Make `Update Bazel Files` validate fork PR artifacts. If a fork PR has a non-empty generated patch, the job fails with commands for applying the artifact manually instead of silently skipping.
- Run `check-bazel-prepare` before `bazel-failpoint-enable` in `bazel_ci_test*` targets.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

```bash
ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/generate-bazel-files.yml .github/workflows/update-bazel-files.yml
git -c core.fsmonitor=false diff --check
make -n bazel_ci_test
make -n bazel_ci_test_ddlargsv1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened validation of generated build outputs with stricter path restrictions and clearer error messages.
  * Improved handling of pull requests from forks by providing manual patch-application instructions when needed.
  * Added an automated preflight check workflow to verify build-preparation steps run and report failures early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->