### PR TITLE
*: adjust require_secure_transport behavior for starter mode

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1053,6 +1053,9 @@ func TestDeployModeConfig(t *testing.T) {
 	conf := NewConfig()
 	require.Equal(t, deploymode.Premium, conf.DeployMode)
 	require.NoError(t, conf.Valid())
+	conf.DeployMode = deploymode.Mode(100)
+	require.ErrorContains(t, conf.Valid(), "invalid deploy-mode")
+	conf.DeployMode = deploymode.Premium
 
 	storeDir := t.TempDir()
 	configFile := filepath.Join(storeDir, "config.toml")

--- a/pkg/server/tests/tls/BUILD.bazel
+++ b/pkg/server/tests/tls/BUILD.bazel
@@ -11,6 +11,8 @@ go_test(
     shard_count = 8,
     deps = [
         "//pkg/config",
+        "//pkg/config/deploymode",
+        "//pkg/config/kerneltype",
         "//pkg/metrics",
         "//pkg/server",
         "//pkg/server/internal/testserverclient",
@@ -21,6 +23,7 @@ go_test(
         "//pkg/store/mockstore/unistore",
         "//pkg/testkit/testsetup",
         "//pkg/util",
+        "//pkg/util/tls",
         "//pkg/util/topsql/state",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_pingcap_errors//:errors",

--- a/pkg/server/tests/tls/tls_test.go
+++ b/pkg/server/tests/tls/tls_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"database/sql"
 	"encoding/pem"
 	"math/big"
 	"net/http"
@@ -31,6 +32,8 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	tidbserver "github.com/pingcap/tidb/pkg/server"
 	"github.com/pingcap/tidb/pkg/server/internal/testserverclient"
 	"github.com/pingcap/tidb/pkg/server/internal/testutil"
@@ -38,6 +41,7 @@ import (
 	"github.com/pingcap/tidb/pkg/server/tests/servertestkit"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/util"
+	tidbtls "github.com/pingcap/tidb/pkg/util/tls"
 	"github.com/stretchr/testify/require"
 )
 
@@ -181,6 +185,17 @@ func isTLSExpiredError(err error) bool {
 }
 
 func TestTLSVerify(t *testing.T) {
+	originalCfg := *config.GetGlobalConfig()
+	originalDeployMode := deploymode.Get()
+	originalRequireSecureTransport := tidbtls.RequireSecureTransport.Load()
+	t.Cleanup(func() {
+		config.StoreGlobalConfig(&originalCfg)
+		if kerneltype.IsNextGen() {
+			require.NoError(t, deploymode.Set(originalDeployMode))
+		}
+		tidbtls.RequireSecureTransport.Store(originalRequireSecureTransport)
+	})
+
 	ts := servertestkit.CreateTidbTestSuite(t)
 
 	dir := t.TempDir()
@@ -201,27 +216,82 @@ func TestTLSVerify(t *testing.T) {
 
 	// Start the server with TLS & CA, if the client presents its certificate, the certificate will be verified.
 	cli := testserverclient.NewTestServerClient()
-	cfg := util2.NewTestConfig()
-	cfg.Port = cli.Port
-	cfg.Socket = dir + "/tidbtest.sock"
-	cfg.Status.ReportStatus = false
-	cfg.Security = config.Security{
-		SSLCA:   fileName("ca-cert.pem"),
-		SSLCert: fileName("server-cert.pem"),
-		SSLKey:  fileName("server-key.pem"),
-	}
-	tidbserver.RunInGoTestChan = make(chan struct{})
-	server, err := tidbserver.NewServer(cfg, ts.Tidbdrv)
-	require.NoError(t, err)
-	server.SetDomain(ts.Domain)
-	defer server.Close()
-
-	go func() {
-		err := server.Run(nil)
+	execSQL := func(overrider func(*mysql.Config), stmt string) error {
+		dsn := cli.GetDSN(overrider)
+		db, err := sql.Open("mysql", dsn)
 		require.NoError(t, err)
+		defer func() {
+			err := db.Close()
+			require.NoError(t, err)
+		}()
+		_, err = db.Exec(stmt)
+		if err != nil {
+			return errors.Annotate(err, "dsn:"+dsn)
+		}
+		return nil
+	}
+	queryString := func(overrider func(*mysql.Config), query string) (string, error) {
+		dsn := cli.GetDSN(overrider)
+		db, err := sql.Open("mysql", dsn)
+		require.NoError(t, err)
+		defer func() {
+			err := db.Close()
+			require.NoError(t, err)
+		}()
+		var value string
+		err = db.QueryRow(query).Scan(&value)
+		if err != nil {
+			return "", errors.Annotate(err, "dsn:"+dsn)
+		}
+		return value, nil
+	}
+	newServerConfig := func(starterMode bool) *config.Config {
+		cfg := util2.NewTestConfig()
+		cfg.Port = 0
+		cfg.Socket = dir + "/tidbtest.sock"
+		cfg.Status.ReportStatus = false
+		if starterMode {
+			cfg.DeployMode = deploymode.Starter
+		}
+		cfg.Security = config.Security{
+			SSLCA:   fileName("ca-cert.pem"),
+			SSLCert: fileName("server-cert.pem"),
+			SSLKey:  fileName("server-key.pem"),
+		}
+		return cfg
+	}
+	startServer := func(cfg *config.Config) (*tidbserver.Server, func()) {
+		cfgCopy := *cfg
+		if kerneltype.IsNextGen() {
+			require.NoError(t, deploymode.Set(cfgCopy.DeployMode))
+		}
+		config.StoreGlobalConfig(&cfgCopy)
+
+		tidbserver.RunInGoTestChan = make(chan struct{})
+		server, err := tidbserver.NewServer(cfg, ts.Tidbdrv)
+		require.NoError(t, err)
+		server.SetDomain(ts.Domain)
+
+		go func() {
+			err := server.Run(nil)
+			require.NoError(t, err)
+		}()
+		<-tidbserver.RunInGoTestChan
+		cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
+		return server, func() {
+			server.Close()
+		}
+	}
+
+	cfg := newServerConfig(false)
+	_, closeServer := startServer(cfg)
+	firstServerClosed := false
+	defer func() {
+		if !firstServerClosed {
+			closeServer()
+		}
 	}()
-	<-tidbserver.RunInGoTestChan
-	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
+
 	// The client does not provide a certificate, the connection should succeed.
 	err = cli.RunTestTLSConnection(t, nil)
 	require.NoError(t, err)
@@ -273,6 +343,33 @@ func TestTLSVerify(t *testing.T) {
 		config.DBName = "test"
 	})
 	require.NoError(t, err)
+
+	err = execSQL(connOverrider, "SET GLOBAL require_secure_transport = 0")
+	require.NoError(t, err)
+	closeServer()
+	firstServerClosed = true
+
+	if kerneltype.IsNextGen() {
+		// In starter mode, the sysvar read path still reports ON even when the
+		// underlying atomic stays false.
+		tidbtls.RequireSecureTransport.Store(false)
+		starterCfg := newServerConfig(true)
+		_, closeServer = startServer(starterCfg)
+		defer closeServer()
+		globalRequireSecureTransport, err := queryString(connOverrider, "SELECT @@global.require_secure_transport")
+		require.NoError(t, err)
+		require.Contains(t, []string{"ON", "1"}, globalRequireSecureTransport)
+
+		err = cli.RunTestEnableSecureTransport(t, nil)
+		require.ErrorContains(t, err, "require_secure_transport can not be set in starter mode")
+		err = cli.RunTestEnableSecureTransport(t, connOverrider)
+		require.ErrorContains(t, err, "require_secure_transport can not be set in starter mode")
+
+		err = cli.RunTestTLSConnection(t, nil)
+		require.NoError(t, err)
+		err = cli.RunTestTLSConnection(t, connOverrider)
+		require.NoError(t, err)
+	}
 }
 func TestTLSBasic(t *testing.T) {
 	ts := servertestkit.CreateTidbTestSuite(t)

--- a/pkg/sessionctx/sessionstates/BUILD.bazel
+++ b/pkg/sessionctx/sessionstates/BUILD.bazel
@@ -34,6 +34,8 @@ go_test(
     shard_count = 17,
     deps = [
         "//pkg/config",
+        "//pkg/config/deploymode",
+        "//pkg/config/kerneltype",
         "//pkg/errno",
         "//pkg/expression",
         "//pkg/parser/auth",
@@ -44,6 +46,7 @@ go_test(
         "//pkg/testkit",
         "//pkg/util",
         "//pkg/util/sem/compat",
+        "//pkg/util/tls",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",

--- a/pkg/sessionctx/sessionstates/session_states_test.go
+++ b/pkg/sessionctx/sessionstates/session_states_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/auth"
@@ -35,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/testkit"
 	sem "github.com/pingcap/tidb/pkg/util/sem/compat"
+	tidbtls "github.com/pingcap/tidb/pkg/util/tls"
 	"github.com/stretchr/testify/require"
 )
 
@@ -345,12 +348,33 @@ func TestIssue47665(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.Session().GetSessionVars().TLSConnectionState = &tls.ConnectionState{} // unrelated mock for the test.
-	originSEM := config.GetGlobalConfig().Security.EnableSEM
-	config.GetGlobalConfig().Security.EnableSEM = true
+	originCfg := *config.GetGlobalConfig()
+	originalDeployMode := deploymode.Get()
+	originRequireSecureTransport := tidbtls.RequireSecureTransport.Load()
+	t.Cleanup(func() {
+		config.StoreGlobalConfig(&originCfg)
+		if kerneltype.IsNextGen() {
+			require.NoError(t, deploymode.Set(originalDeployMode))
+		}
+		tidbtls.RequireSecureTransport.Store(originRequireSecureTransport)
+	})
+	semCfg := originCfg
+	semCfg.Security.EnableSEM = true
+	config.StoreGlobalConfig(&semCfg)
 	tk.MustGetErrMsg("set @@global.require_secure_transport = on", "require_secure_transport can not be set to ON with SEM(security enhanced mode) enabled")
-	config.GetGlobalConfig().Security.EnableSEM = originSEM
+	config.StoreGlobalConfig(&originCfg)
 	tk.MustExec("set @@global.require_secure_transport = on")
 	tk.MustExec("set @@global.require_secure_transport = off") // recover to default value
+	if kerneltype.IsNextGen() {
+		require.NoError(t, deploymode.Set(deploymode.Starter))
+		tk.MustQuery("select @@global.require_secure_transport").Check(testkit.Rows("1"))
+		tk.MustGetErrMsg("set @@global.require_secure_transport = on", "require_secure_transport can not be set in starter mode")
+		tk.MustGetErrMsg("set @@global.require_secure_transport = off", "require_secure_transport can not be set in starter mode")
+		require.NoError(t, deploymode.Set(originalDeployMode))
+	}
+	config.StoreGlobalConfig(&originCfg)
+	// StoreGlobalConfig does not restore the TLS atomic; it is restored by t.Cleanup.
+	tk.MustQuery("select @@global.require_secure_transport").Check(testkit.Rows("0"))
 }
 
 func TestSessionCtx(t *testing.T) {

--- a/pkg/sessionctx/variable/BUILD.bazel
+++ b/pkg/sessionctx/variable/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config",
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/errno",
         "//pkg/executor/join/joinversion",

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/executor/join/joinversion"
 	"github.com/pingcap/tidb/pkg/keyspace"
@@ -1448,12 +1449,25 @@ var defaultSysVars = []*SysVar{
 		}},
 	{Scope: vardef.ScopeGlobal, Name: vardef.RequireSecureTransport, Value: BoolToOnOff(vardef.DefRequireSecureTransport), Type: vardef.TypeBool,
 		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
+			if deploymode.IsStarter() {
+				// Starter mode intentionally exposes require_secure_transport as ON to SQL.
+				return vardef.On, nil
+			}
 			return BoolToOnOff(tls.RequireSecureTransport.Load()), nil
 		},
 		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+			if deploymode.IsStarter() {
+				// Keep the internal TLS transport gate disabled in starter mode; SQL SET is rejected in Validation.
+				tls.RequireSecureTransport.Store(false)
+				return nil
+			}
 			tls.RequireSecureTransport.Store(TiDBOptOn(val))
 			return nil
 		}, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope vardef.ScopeFlag) (string, error) {
+			if deploymode.IsStarter() && vars.StmtCtx.StmtType == "Set" {
+				// Prevent SQL from changing the fixed starter-mode contract above.
+				return "", errors.New("require_secure_transport can not be set in starter mode")
+			}
 			if vars.StmtCtx.StmtType == "Set" && TiDBOptOn(normalizedValue) {
 				// On tidbcloud dedicated cluster with the default configuration, if an user modify
 				// @@global.require_secure_transport=on, he can not login the cluster anymore!

--- a/pkg/sessionctx/variable/tests/BUILD.bazel
+++ b/pkg/sessionctx/variable/tests/BUILD.bazel
@@ -12,6 +12,8 @@ go_test(
     shard_count = 47,
     deps = [
         "//pkg/config",
+        "//pkg/config/deploymode",
+        "//pkg/config/kerneltype",
         "//pkg/executor",
         "//pkg/kv",
         "//pkg/parser",
@@ -32,6 +34,7 @@ go_test(
         "//pkg/util/execdetails",
         "//pkg/util/memory",
         "//pkg/util/mock",
+        "//pkg/util/tls",
         "@com_github_pingcap_kvproto//pkg/resource_manager",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//util",

--- a/pkg/sessionctx/variable/tests/variable_test.go
+++ b/pkg/sessionctx/variable/tests/variable_test.go
@@ -25,11 +25,14 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
+	tidbtls "github.com/pingcap/tidb/pkg/util/tls"
 	"github.com/stretchr/testify/require"
 )
 
@@ -627,6 +630,45 @@ func TestSetSysVar(t *testing.T) {
 	require.Equal(t, "America/New_York", val)
 	variable.SetSysVar(vardef.SystemTimeZone, originalVal) // restore
 	require.Equal(t, originalVal, variable.GetSysVar(vardef.SystemTimeZone).Value)
+
+	originalCfg := *config.GetGlobalConfig()
+	originalDeployMode := deploymode.Get()
+	originalRequireSecureTransport := tidbtls.RequireSecureTransport.Load()
+	t.Cleanup(func() {
+		config.StoreGlobalConfig(&originalCfg)
+		if kerneltype.IsNextGen() {
+			require.NoError(t, deploymode.Set(originalDeployMode))
+		}
+		tidbtls.RequireSecureTransport.Store(originalRequireSecureTransport)
+	})
+
+	mock := variable.NewMockGlobalAccessor4Tests()
+	mock.SessionVars.GlobalVarsAccessor = mock
+	require.NoError(t, mock.SetGlobalSysVar(context.Background(), vardef.RequireSecureTransport, vardef.On))
+	require.True(t, tidbtls.RequireSecureTransport.Load())
+
+	val, err = variable.GetSysVar(vardef.RequireSecureTransport).GetGlobalFromHook(context.Background(), mock.SessionVars)
+	require.NoError(t, err)
+	require.Equal(t, vardef.On, val)
+
+	if kerneltype.IsNextGen() {
+		require.NoError(t, deploymode.Set(deploymode.Starter))
+		require.NoError(t, variable.GetSysVar(vardef.RequireSecureTransport).SetGlobalFromHook(context.Background(), mock.SessionVars, vardef.On, false))
+		require.False(t, tidbtls.RequireSecureTransport.Load())
+
+		val, err = variable.GetSysVar(vardef.RequireSecureTransport).GetGlobalFromHook(context.Background(), mock.SessionVars)
+		require.NoError(t, err)
+		require.Equal(t, vardef.On, val)
+
+		require.NoError(t, deploymode.Set(originalDeployMode))
+	}
+
+	config.StoreGlobalConfig(&originalCfg)
+	require.NoError(t, variable.GetSysVar(vardef.RequireSecureTransport).SetGlobalFromHook(context.Background(), mock.SessionVars, vardef.Off, false))
+	require.False(t, tidbtls.RequireSecureTransport.Load())
+
+	require.NoError(t, variable.GetSysVar(vardef.RequireSecureTransport).SetGlobalFromHook(context.Background(), mock.SessionVars, vardef.On, false))
+	require.True(t, tidbtls.RequireSecureTransport.Load())
 }
 
 func TestSkipSysvarCache(t *testing.T) {
@@ -635,6 +677,7 @@ func TestSkipSysvarCache(t *testing.T) {
 	require.True(t, variable.GetSysVar(vardef.TiDBGCLifetime).SkipSysvarCache())
 	require.True(t, variable.GetSysVar(vardef.TiDBGCConcurrency).SkipSysvarCache())
 	require.True(t, variable.GetSysVar(vardef.TiDBGCScanLockMode).SkipSysvarCache())
+	require.False(t, variable.GetSysVar(vardef.RequireSecureTransport).SkipSysvarCache())
 	require.False(t, variable.GetSysVar(vardef.TiDBEnableAsyncCommit).SkipSysvarCache())
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67765 

Problem Summary:
TiDB Cloud starter mode needs special handling for `require_secure_transport`. In this mode, the variable should be exposed as enabled to SQL users and should not be user-configurable, while the internal transport enforcement flag must remain disabled to preserve the starter-mode connection behavior.

### What changed and how does it work?
This PR uses the upstream `deploymode.IsStarter()` gate to customize `require_secure_transport` behavior in starter mode. When starter mode is enabled, `@@global.require_secure_transport` reports `ON`, `SET GLOBAL require_secure_transport` is rejected, and the underlying TLS enforcement flag is kept disabled. Non-starter deployments continue to use the existing behavior. The PR also adds regression coverage for sysvar hooks, session-state behavior, TLS server behavior, deploy-mode validation, and updates the required Bazel dependencies.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In "starter" deployment mode, require_secure_transport is always reported ON; SET attempts are rejected and do not enable secure-transport enforcement.

* **Tests**
  * Expanded TLS and secure-transport test coverage across deployment modes and kernel variants.
  * Improved test setup/teardown to capture, restore, and isolate global security-related state.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68245)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->