### PR TITLE
ranger: reduce point conversion overhead

### DIFF
--- a/cmd/tidb-server/BUILD.bazel
+++ b/cmd/tidb-server/BUILD.bazel
@@ -107,7 +107,7 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":tidb-server_lib"],
     flaky = True,
-    shard_count = 6,
+    shard_count = 7,
     deps = [
         "//pkg/config",
         "//pkg/config/deploymode",

--- a/pkg/util/ranger/bench_test.go
+++ b/pkg/util/ranger/bench_test.go
@@ -16,6 +16,8 @@ package ranger_test
 
 import (
 	"context"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/expression"
@@ -27,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/benchdaily"
 	"github.com/pingcap/tidb/pkg/util/ranger"
 	"github.com/stretchr/testify/require"
@@ -137,6 +140,125 @@ WHERE
 		require.NoError(b, err)
 	}
 	b.StopTimer()
+}
+
+func BenchmarkDetachCondAndBuildRangeForIndexLeadingLongIN(b *testing.B) {
+	sctx, selection, dataSource := buildBenchmarkSelection(b, `
+CREATE TABLE t (
+    org_id bigint(20) NOT NULL,
+    flag tinyint(1) NOT NULL,
+    end_time bigint(20) NOT NULL,
+    KEY idx (org_id, flag, end_time)
+)`, "SELECT * FROM test.t WHERE org_id IN ("+makeBenchmarkIntList(512)+") AND flag = 0 AND end_time < 1437233819011")
+	conds := benchmarkConditions(sctx, selection)
+	cols, lengths := plannerutil.IndexInfo2PrefixCols(dataSource.TableInfo.Columns, selection.Schema().Columns, dataSource.TableInfo.Indices[0])
+	require.NotNil(b, cols)
+
+	b.ResetTimer()
+	pctx := sctx.GetPlanCtx()
+	var rangeCount int
+	var rangeBytes int64
+	for range b.N {
+		res, err := ranger.DetachCondAndBuildRangeForIndex(pctx.GetRangerCtx(), conds, cols, lengths, 0)
+		require.NoError(b, err)
+		rangeCount = len(res.Ranges)
+		rangeBytes = res.Ranges.MemUsage()
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(rangeCount), "ranges/op")
+	b.ReportMetric(float64(rangeBytes), "range-bytes/op")
+}
+
+func BenchmarkBuildColumnRangeLongIN(b *testing.B) {
+	sctx, selection, dataSource := buildBenchmarkSelection(b, `
+CREATE TABLE t (
+    org_id bigint(20) NOT NULL,
+    payload bigint(20) NOT NULL,
+    KEY idx (payload)
+)`, "SELECT * FROM test.t WHERE org_id IN ("+makeBenchmarkIntList(512)+")")
+	conds := benchmarkConditions(sctx, selection)
+	tp := &dataSource.TableInfo.Columns[0].FieldType
+
+	b.ResetTimer()
+	rctx := sctx.GetPlanCtx().GetRangerCtx()
+	var rangeCount int
+	var rangeBytes int64
+	for range b.N {
+		ranges, _, _, err := ranger.BuildColumnRange(conds, rctx, tp, types.UnspecifiedLength, 0)
+		require.NoError(b, err)
+		rangeCount = len(ranges)
+		rangeBytes = ranges.MemUsage()
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(rangeCount), "ranges/op")
+	b.ReportMetric(float64(rangeBytes), "range-bytes/op")
+}
+
+func buildBenchmarkSelection(b *testing.B, createTable, query string) (sessionctx.Context, *logicalop.LogicalSelection, *logicalop.DataSource) {
+	store := testkit.CreateMockStore(b)
+	testKit := testkit.NewTestKit(b, store)
+	testKit.MustExec("USE test")
+	testKit.MustExec("DROP TABLE IF EXISTS t")
+	testKit.MustExec(createTable)
+	sctx := testKit.Session().(sessionctx.Context)
+	stmts, err := session.Parse(sctx, query)
+	require.NoError(b, err)
+	require.Len(b, stmts, 1)
+	ret := &plannercore.PreprocessorReturn{}
+	nodeW := resolve.NewNodeW(stmts[0])
+	err = plannercore.Preprocess(context.Background(), sctx, nodeW, plannercore.WithPreprocessorReturn(ret))
+	require.NoError(b, err)
+	p, err := plannercore.BuildLogicalPlanForTest(context.Background(), sctx, nodeW, ret.InfoSchema)
+	require.NoError(b, err)
+	plan := p.(base.LogicalPlan)
+	selection := findBenchmarkSelection(plan)
+	require.NotNil(b, selection)
+	dataSource := findBenchmarkDataSource(selection)
+	require.NotNil(b, dataSource)
+	return sctx, selection, dataSource
+}
+
+func benchmarkConditions(sctx sessionctx.Context, selection *logicalop.LogicalSelection) []expression.Expression {
+	conds := make([]expression.Expression, len(selection.Conditions))
+	for i, cond := range selection.Conditions {
+		conds[i] = expression.PushDownNot(sctx.GetExprCtx(), cond)
+	}
+	return conds
+}
+
+func findBenchmarkSelection(plan base.LogicalPlan) *logicalop.LogicalSelection {
+	if selection, ok := plan.(*logicalop.LogicalSelection); ok {
+		return selection
+	}
+	for _, child := range plan.Children() {
+		if selection := findBenchmarkSelection(child); selection != nil {
+			return selection
+		}
+	}
+	return nil
+}
+
+func findBenchmarkDataSource(plan base.LogicalPlan) *logicalop.DataSource {
+	if dataSource, ok := plan.(*logicalop.DataSource); ok {
+		return dataSource
+	}
+	for _, child := range plan.Children() {
+		if dataSource := findBenchmarkDataSource(child); dataSource != nil {
+			return dataSource
+		}
+	}
+	return nil
+}
+
+func makeBenchmarkIntList(n int) string {
+	var buf strings.Builder
+	for i := range n {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(strconv.Itoa(i + 1))
+	}
+	return buf.String()
 }
 
 func TestBenchDaily(t *testing.T) {

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -71,14 +71,6 @@ func (rp *point) String() string {
 	return fmt.Sprintf("%v%s", val, symbol)
 }
 
-func (rp *point) Clone(value types.Datum) *point {
-	return &point{
-		value: value,
-		excl:  rp.excl,
-		start: rp.start,
-	}
-}
-
 func rangePointCmp(tc types.Context, a, b *point, collator collate.Collator) (int, error) {
 	if a.value.Kind() == types.KindMysqlEnum && b.value.Kind() == types.KindMysqlEnum {
 		return rangePointEnumCmp(a, b)

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -107,7 +107,7 @@ func rangePointEqualValueCmp(a, b *point) int {
 	return 0
 }
 
-func pointsConvertToSortKey(sctx *rangerctx.RangerContext, inputPs []*point, newTp *types.FieldType) ([]*point, error) {
+func convertPointsToSortKeyInPlace(sctx *rangerctx.RangerContext, points []*point, newTp *types.FieldType) error {
 	// Only handle normal string type here.
 	// Currently, set won't be pushed down and it shouldn't reach here in theory.
 	// For enum, we have separate logic for it, like handleEnumFromBinOp(). For now, it only supports point range,
@@ -115,31 +115,27 @@ func pointsConvertToSortKey(sctx *rangerctx.RangerContext, inputPs []*point, new
 	if newTp.EvalType() != types.ETString ||
 		newTp.GetType() == mysql.TypeEnum ||
 		newTp.GetType() == mysql.TypeSet {
-		return inputPs, nil
+		return nil
 	}
-	ps := make([]*point, 0, len(inputPs))
-	for _, p := range inputPs {
-		np, err := pointConvertToSortKey(sctx, p, newTp, true)
-		if err != nil {
-			return nil, err
+	for _, p := range points {
+		if err := convertPointToSortKeyInPlace(sctx, p, newTp, true); err != nil {
+			return err
 		}
-		ps = append(ps, np)
 	}
-	return ps, nil
+	return nil
 }
 
-func pointConvertToSortKey(
+func convertPointToSortKeyInPlace(
 	sctx *rangerctx.RangerContext,
-	inputP *point,
+	p *point,
 	newTp *types.FieldType,
 	trimTrailingSpace bool,
-) (*point, error) {
-	p, err := convertPoint(sctx, inputP, newTp)
-	if err != nil {
-		return nil, err
+) error {
+	if err := convertPointInPlace(sctx, p, newTp); err != nil {
+		return err
 	}
 	if p.value.Kind() != types.KindString || newTp.GetCollate() == charset.CollationBin || !collate.NewCollationEnabled() {
-		return p, nil
+		return nil
 	}
 	sortKey := p.value.GetBytes()
 	if !trimTrailingSpace {
@@ -148,7 +144,8 @@ func pointConvertToSortKey(
 		sortKey = collate.GetCollator(newTp.GetCollate()).Key(string(hack.String(sortKey)))
 	}
 
-	return &point{value: types.NewBytesDatum(sortKey), excl: p.excl, start: p.start}, nil
+	p.value = types.NewBytesDatum(sortKey)
+	return nil
 }
 
 /*
@@ -433,8 +430,7 @@ func (r *builder) buildFromBinOp(
 	}
 	cutPrefixForPoints(res, prefixLen, ft)
 	if convertToSortKey {
-		res, err = pointsConvertToSortKey(r.sctx, res, newTp)
-		if err != nil {
+		if err = convertPointsToSortKeyInPlace(r.sctx, res, newTp); err != nil {
 			r.err = err
 			return getFullRange()
 		}
@@ -710,10 +706,8 @@ func (r *builder) buildFromIn(
 	}
 	rangePoints = rangePoints[:curPos]
 	cutPrefixForPoints(rangePoints, prefixLen, ft)
-	var err error
 	if convertToSortKey {
-		rangePoints, err = pointsConvertToSortKey(r.sctx, rangePoints, newTp)
-		if err != nil {
+		if err := convertPointsToSortKeyInPlace(r.sctx, rangePoints, newTp); err != nil {
 			r.err = err
 			return getFullRange(), false
 		}
@@ -748,8 +742,7 @@ func (r *builder) newBuildFromPatternLike(
 		endPoint := &point{value: types.NewStringDatum("")}
 		res := []*point{startPoint, endPoint}
 		if convertToSortKey {
-			res, err = pointsConvertToSortKey(r.sctx, res, newTp)
-			if err != nil {
+			if err := convertPointsToSortKeyInPlace(r.sctx, res, newTp); err != nil {
 				r.err = err
 				return getFullRange()
 			}
@@ -807,8 +800,7 @@ func (r *builder) newBuildFromPatternLike(
 		res := []*point{startPoint, endPoint}
 		cutPrefixForPoints(res, prefixLen, tpOfPattern)
 		if convertToSortKey {
-			res, err = pointsConvertToSortKey(r.sctx, res, newTp)
-			if err != nil {
+			if err := convertPointsToSortKeyInPlace(r.sctx, res, newTp); err != nil {
 				r.err = err
 				return getFullRange()
 			}
@@ -828,9 +820,9 @@ func (r *builder) newBuildFromPatternLike(
 
 	// non-exceptional return case 4-2: build a range for the wildcard
 	// the end_key is sortKey(start_value) + 1
-	originalStartPoint := &point{start: true, excl: exclude}
+	originalStartPoint := point{start: true, excl: exclude}
 	originalStartPoint.value.SetBytesAsString(lowValue, tpOfPattern.GetCollate(), uint32(tpOfPattern.GetFlen()))
-	cutPrefixForPoints([]*point{originalStartPoint}, prefixLen, tpOfPattern)
+	cutPrefixForPoints([]*point{&originalStartPoint}, prefixLen, tpOfPattern)
 
 	// If we don't trim the trailing spaces, which means using KeyWithoutTrimRightSpace() instead of Key(), we can build
 	// a smaller range for better performance, e.g., LIKE '  %'.
@@ -839,13 +831,13 @@ func (r *builder) newBuildFromPatternLike(
 	// column, the start key should be 'abd' instead of 'abc ', but the end key can be 'abc!'. ( ' ' is 32 and '!' is 33
 	// in ASCII)
 	shouldTrimTrailingSpace := collate.IsPadSpaceCollation(collation)
-	startPoint, err := pointConvertToSortKey(r.sctx, originalStartPoint, newTp, shouldTrimTrailingSpace)
-	if err != nil {
+	startPoint := originalStartPoint
+	if err := convertPointToSortKeyInPlace(r.sctx, &startPoint, newTp, shouldTrimTrailingSpace); err != nil {
 		r.err = errors.Trace(err)
 		return getFullRange()
 	}
-	sortKeyPointWithoutTrim, err := pointConvertToSortKey(r.sctx, originalStartPoint, newTp, false)
-	if err != nil {
+	sortKeyPointWithoutTrim := originalStartPoint
+	if err := convertPointToSortKeyInPlace(r.sctx, &sortKeyPointWithoutTrim, newTp, false); err != nil {
 		r.err = errors.Trace(err)
 		return getFullRange()
 	}
@@ -865,7 +857,7 @@ func (r *builder) newBuildFromPatternLike(
 			endPoint.value = types.MaxValueDatum()
 		}
 	}
-	return []*point{startPoint, endPoint}
+	return []*point{&startPoint, endPoint}
 }
 
 func (r *builder) buildFromNot(
@@ -921,9 +913,7 @@ func (r *builder) buildFromNot(
 		retRangePoints = append(retRangePoints, &point{value: types.MaxValueDatum()})
 		cutPrefixForPoints(retRangePoints, prefixLen, expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()))
 		if convertToSortKey {
-			var err error
-			retRangePoints, err = pointsConvertToSortKey(r.sctx, retRangePoints, newTp)
-			if err != nil {
+			if err := convertPointsToSortKeyInPlace(r.sctx, retRangePoints, newTp); err != nil {
 				r.err = err
 				return getFullRange()
 			}

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -221,36 +221,36 @@ func convertPoint(sctx *rangerctx.RangerContext, point *point, newTp *types.Fiel
 	if err != nil {
 		return point, errors.Trace(err)
 	}
-	npoint := point.Clone(casted)
+	point.value = casted
 	if valCmpCasted == 0 {
-		return npoint, nil
+		return point, nil
 	}
-	if npoint.start {
-		if npoint.excl {
+	if point.start {
+		if point.excl {
 			if valCmpCasted < 0 {
 				// e.g. "a > 1.9" convert to "a >= 2".
-				npoint.excl = false
+				point.excl = false
 			}
 		} else {
 			if valCmpCasted > 0 {
 				// e.g. "a >= 1.1 convert to "a > 1"
-				npoint.excl = true
+				point.excl = true
 			}
 		}
 	} else {
-		if npoint.excl {
+		if point.excl {
 			if valCmpCasted > 0 {
 				// e.g. "a < 1.1" convert to "a <= 1"
-				npoint.excl = false
+				point.excl = false
 			}
 		} else {
 			if valCmpCasted < 0 {
 				// e.g. "a <= 1.9" convert to "a < 2"
-				npoint.excl = true
+				point.excl = true
 			}
 		}
 	}
-	return npoint, nil
+	return point, nil
 }
 
 func getRangesTotalDatumSize(ranges Ranges) (sum int64) {

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -60,9 +60,9 @@ func validInterval(ec errctx.Context, loc *time.Location, low, high *point) (boo
 	return bytes.Compare(l, r) < 0, nil
 }
 
-// convertPoints does some preprocessing on rangePoints to make them ready to build ranges. Preprocessing includes converting
-// points to the specified type, validating intervals and skipping impossible intervals.
-func convertPoints(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *types.FieldType, skipNull bool, tableRange bool) ([]*point, error) {
+// convertPointsInPlace does some preprocessing on rangePoints to make them ready to build ranges. It converts
+// points to the specified type in place, validates intervals, and compacts valid intervals to the front of rangePoints.
+func convertPointsInPlace(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *types.FieldType, skipNull bool, tableRange bool) ([]*point, error) {
 	i := 0
 	numPoints := len(rangePoints)
 	var minValueDatum, maxValueDatum types.Datum
@@ -78,8 +78,8 @@ func convertPoints(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 		}
 	}
 	for j := 0; j < numPoints; j += 2 {
-		startPoint, err := convertPoint(sctx, rangePoints[j], newTp)
-		if err != nil {
+		startPoint := rangePoints[j]
+		if err := convertPointInPlace(sctx, startPoint, newTp); err != nil {
 			return nil, errors.Trace(err)
 		}
 		if tableRange {
@@ -90,8 +90,8 @@ func convertPoints(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 				startPoint.value = minValueDatum
 			}
 		}
-		endPoint, err := convertPoint(sctx, rangePoints[j+1], newTp)
-		if err != nil {
+		endPoint := rangePoints[j+1]
+		if err := convertPointInPlace(sctx, endPoint, newTp); err != nil {
 			return nil, errors.Trace(err)
 		}
 		if tableRange {
@@ -127,12 +127,12 @@ func estimateMemUsageForPoints2Ranges(rangePoints []*point) int64 {
 // rangeMaxSize is the max memory limit for ranges. O indicates no memory limit.
 // If the second return value is true, it means that the estimated memory usage of ranges exceeds rangeMaxSize and it falls back to full range.
 func points2Ranges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *types.FieldType, rangeMaxSize int64) (Ranges, bool, error) {
-	convertedPoints, err := convertPoints(sctx, rangePoints, newTp, mysql.HasNotNullFlag(newTp.GetFlag()), false)
+	rangePoints, err := convertPointsInPlace(sctx, rangePoints, newTp, mysql.HasNotNullFlag(newTp.GetFlag()), false)
 	if err != nil {
 		return nil, false, errors.Trace(err)
 	}
 	// Estimate whether rangeMaxSize will be exceeded first before converting points to ranges.
-	if rangeMaxSize > 0 && estimateMemUsageForPoints2Ranges(convertedPoints) > rangeMaxSize {
+	if rangeMaxSize > 0 && estimateMemUsageForPoints2Ranges(rangePoints) > rangeMaxSize {
 		var fullRange Ranges
 		if mysql.HasNotNullFlag(newTp.GetFlag()) {
 			fullRange = FullNotNullRange()
@@ -141,7 +141,7 @@ func points2Ranges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 		}
 		return fullRange, true, nil
 	}
-	rangeCount := len(convertedPoints) / 2
+	rangeCount := len(rangePoints) / 2
 	// Keep emitted ranges and their single-column backing slices in batch
 	// storage to avoid per-range heap allocations on long-IN workloads.
 	ranges := make(Ranges, rangeCount)
@@ -151,7 +151,7 @@ func points2Ranges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 	collatorBuf := make([]collate.Collator, rangeCount)
 	rangeCollator := collate.GetCollator(newTp.GetCollate())
 	for i := range rangeCount {
-		startPoint, endPoint := convertedPoints[i*2], convertedPoints[i*2+1]
+		startPoint, endPoint := rangePoints[i*2], rangePoints[i*2+1]
 		// Batch-allocate the backing arrays, but clamp each slice to len==cap.
 		// Some callers append tail datums to an emitted range later, and that append
 		// must not overwrite the neighboring ranges that share the same buffer.
@@ -174,15 +174,15 @@ func points2Ranges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 	return ranges, false, nil
 }
 
-func convertPoint(sctx *rangerctx.RangerContext, point *point, newTp *types.FieldType) (*point, error) {
-	switch point.value.Kind() {
+func convertPointInPlace(sctx *rangerctx.RangerContext, p *point, newTp *types.FieldType) error {
+	switch p.value.Kind() {
 	case types.KindMaxValue, types.KindMinNotNull:
-		return point, nil
+		return nil
 	}
-	casted, err := point.value.ConvertTo(sctx.TypeCtx, newTp)
+	casted, err := p.value.ConvertTo(sctx.TypeCtx, newTp)
 	if err != nil {
 		// skip plan cache in this case for safety.
-		sctx.SetSkipPlanCache(fmt.Sprintf("%s when converting %v", err.Error(), point.value))
+		sctx.SetSkipPlanCache(fmt.Sprintf("%s when converting %v", err.Error(), p.value))
 
 		//revive:disable:empty-block
 		if newTp.GetType() == mysql.TypeYear && terror.ErrorEqual(err, types.ErrWarnDataOutOfRange) {
@@ -194,16 +194,16 @@ func convertPoint(sctx *rangerctx.RangerContext, point *point, newTp *types.Fiel
 			// A trimmed valid boundary point value would be returned then. Accordingly, the `excl` of the point
 			// would be adjusted. Impossible ranges would be skipped by the `validInterval` call later.
 			// tests in TestIndexRange/TestIndexRangeForDecimal
-		} else if point.value.Kind() == types.KindMysqlTime && newTp.GetType() == mysql.TypeTimestamp && terror.ErrorEqual(err, types.ErrWrongValue) {
+		} else if p.value.Kind() == types.KindMysqlTime && newTp.GetType() == mysql.TypeTimestamp && terror.ErrorEqual(err, types.ErrWrongValue) {
 			// See issue #28424: query failed after add index
 			// Ignore conversion from Date[Time] to Timestamp since it must be either out of range or impossible date, which will not match a point select
 		} else if newTp.GetType() == mysql.TypeEnum && terror.ErrorEqual(err, types.ErrTruncated) {
 			// Ignore the types.ErrorTruncated when we convert TypeEnum values.
 			// We should cover Enum upper overflow, and convert to the biggest value.
-			if point.value.GetInt64() > 0 {
+			if p.value.GetInt64() > 0 {
 				upperEnum, err := types.ParseEnumValue(newTp.GetElems(), uint64(len(newTp.GetElems())))
 				if err != nil {
-					return nil, err
+					return err
 				}
 				casted.SetMysqlEnum(upperEnum, newTp.GetCollate())
 			}
@@ -211,46 +211,46 @@ func convertPoint(sctx *rangerctx.RangerContext, point *point, newTp *types.Fiel
 			// The invalid string can be produced by changing datum's underlying bytes directly.
 			// For example, newBuildFromPatternLike calculates the end point by adding 1 to bytes.
 			// We need to skip these invalid strings.
-			return point, nil
+			return nil
 		} else {
-			return point, errors.Trace(err)
+			return errors.Trace(err)
 		}
 		//revive:enable:empty-block
 	}
-	valCmpCasted, err := point.value.Compare(sctx.TypeCtx, &casted, collate.GetCollator(newTp.GetCollate()))
+	valCmpCasted, err := p.value.Compare(sctx.TypeCtx, &casted, collate.GetCollator(newTp.GetCollate()))
 	if err != nil {
-		return point, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	point.value = casted
+	p.value = casted
 	if valCmpCasted == 0 {
-		return point, nil
+		return nil
 	}
-	if point.start {
-		if point.excl {
+	if p.start {
+		if p.excl {
 			if valCmpCasted < 0 {
 				// e.g. "a > 1.9" convert to "a >= 2".
-				point.excl = false
+				p.excl = false
 			}
 		} else {
 			if valCmpCasted > 0 {
 				// e.g. "a >= 1.1 convert to "a > 1"
-				point.excl = true
+				p.excl = true
 			}
 		}
 	} else {
-		if point.excl {
+		if p.excl {
 			if valCmpCasted > 0 {
 				// e.g. "a < 1.1" convert to "a <= 1"
-				point.excl = false
+				p.excl = false
 			}
 		} else {
 			if valCmpCasted < 0 {
 				// e.g. "a <= 1.9" convert to "a < 2"
-				point.excl = true
+				p.excl = true
 			}
 		}
 	}
-	return point, nil
+	return nil
 }
 
 func getRangesTotalDatumSize(ranges Ranges) (sum int64) {
@@ -292,12 +292,12 @@ func estimateMemUsageForAppendPoints2Ranges(origin Ranges, rangePoints []*point)
 // rangeMaxSize and the function rejects appending points to ranges.
 func appendPoints2Ranges(sctx *rangerctx.RangerContext, origin Ranges, rangePoints []*point,
 	newTp *types.FieldType, rangeMaxSize int64) (Ranges, bool, error) {
-	convertedPoints, err := convertPoints(sctx, rangePoints, newTp, false, false)
+	rangePoints, err := convertPointsInPlace(sctx, rangePoints, newTp, false, false)
 	if err != nil {
 		return nil, false, errors.Trace(err)
 	}
 	// Estimate whether rangeMaxSize will be exceeded first before appending points to ranges.
-	if rangeMaxSize > 0 && estimateMemUsageForAppendPoints2Ranges(origin, convertedPoints) > rangeMaxSize {
+	if rangeMaxSize > 0 && estimateMemUsageForAppendPoints2Ranges(origin, rangePoints) > rangeMaxSize {
 		return origin, true, nil
 	}
 	var newIndexRanges Ranges
@@ -306,7 +306,7 @@ func appendPoints2Ranges(sctx *rangerctx.RangerContext, origin Ranges, rangePoin
 		if !oRange.IsPoint(sctx) {
 			newIndexRanges = append(newIndexRanges, oRange)
 		} else {
-			newRanges, err := appendPoints2IndexRange(oRange, convertedPoints, newTp)
+			newRanges, err := appendPoints2IndexRange(oRange, rangePoints, newTp)
 			if err != nil {
 				return nil, false, errors.Trace(err)
 			}
@@ -463,16 +463,16 @@ func AppendRanges2PointRanges(pointRanges Ranges, ranges Ranges, rangeMaxSize in
 // rangeMaxSize is the max memory limit for ranges. O indicates no memory limit.
 // If the second return value is true, it means that the estimated memory usage of ranges exceeds rangeMaxSize and it falls back to full range.
 func points2TableRanges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *types.FieldType, rangeMaxSize int64) (Ranges, bool, error) {
-	convertedPoints, err := convertPoints(sctx, rangePoints, newTp, true, true)
+	rangePoints, err := convertPointsInPlace(sctx, rangePoints, newTp, true, true)
 	if err != nil {
 		return nil, false, errors.Trace(err)
 	}
-	if rangeMaxSize > 0 && estimateMemUsageForPoints2Ranges(convertedPoints) > rangeMaxSize {
+	if rangeMaxSize > 0 && estimateMemUsageForPoints2Ranges(rangePoints) > rangeMaxSize {
 		return FullIntRange(mysql.HasUnsignedFlag(newTp.GetFlag())), true, nil
 	}
-	ranges := make(Ranges, 0, len(convertedPoints)/2)
-	for i := 0; i < len(convertedPoints); i += 2 {
-		startPoint, endPoint := convertedPoints[i], convertedPoints[i+1]
+	ranges := make(Ranges, 0, len(rangePoints)/2)
+	for i := 0; i < len(rangePoints); i += 2 {
+		startPoint, endPoint := rangePoints[i], rangePoints[i+1]
 		ran := &Range{
 			LowVal:      []types.Datum{startPoint.value},
 			LowExclude:  startPoint.excl,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67756

Problem Summary:

This is a follow-up optimization under the large `IN`-list ranger performance work tracked by #67756.

A TiDB CPU profile shows non-trivial optimizer CPU time in ranger range construction for long `IN` list workloads. The hot path includes `DetachCondAndBuildRangeForIndex`, `points2Ranges`, `convertPoints`, `convertPoint`, and `buildFromIn`.

One specific source of overhead is that `convertPoint` used to clone each `point` before replacing the converted datum and adjusting the inclusive/exclusive boundary. In the profile, `(*point).Clone` accounts for a large cumulative cost under `convertPoint`.

The existing benchmark shape was also too narrow. It covered a long `IN` list on a later composite-index column, but did not directly cover leading-index-column long `IN` or single-column `BuildColumnRange` long `IN` workloads.

### What changed and how does it work?

This PR makes ranger point conversion consistently use in-place mutation and adds benchmarks for the missing long-`IN` shapes.

Changes:

- Add `BenchmarkDetachCondAndBuildRangeForIndexLeadingLongIN`.
- Add `BenchmarkBuildColumnRangeLongIN`.
- Report `ranges/op` and `range-bytes/op` in the new benchmarks to verify that range shape and logical range memory footprint do not change.
- Replace the old clone-returning `convertPoint` path with `convertPointInPlace`.
- Rename and adjust the callers around `convertPointsInPlace`, `convertPointsToSortKeyInPlace`, and `convertPointToSortKeyInPlace` so their names match the actual mutation semantics.
- Keep the LIKE wildcard path explicit where both trimmed and untrimmed sort-key variants are needed.

Why removing `(*point).Clone` is safe:

1. `point` is an unexported temporary boundary object inside `pkg/util/ranger`. The conversion helpers do not receive shared `Range` objects or plan-cache state. They receive point objects produced during the current range-building pass.
2. The old `convertPoint` cloned a point only to store the converted datum and adjusted `excl` flag, then returned that point to the caller. The caller immediately used the returned point as the normalized boundary. The original unconverted boundary was not used again for range materialization after conversion.
3. `convertPoints` already behaved as a destructive preprocessing step at the slice level: it validated intervals and compacted valid point pairs to the front of the same `rangePoints` slice. Mutating each private point in place is consistent with that existing lifecycle.
4. Other ranger preprocessing already mutates point objects in place. For example, `cutPrefixForPoints` updates `point.value` and `point.excl` directly before later range construction. This PR makes type conversion and sort-key conversion follow the same ownership model.
5. The final `Range` objects are materialized after conversion from the normalized point values and exclusion flags. The generated range count and logical range memory footprint are unchanged in the new benchmarks (`ranges/op` and `range-bytes/op` remain the same).
6. The error paths keep the previous behavior. For invalid character strings, the helper still returns without replacing the datum, matching the old path that returned the original point. For other conversion errors, the same error is propagated.
7. The only path that still needs two versions of a point is LIKE wildcard range building, where TiDB needs both trimmed and untrimmed sort keys. This PR copies the small `point` value before calling the in-place helper for those two variants, preserving the old behavior without relying on hidden cloning inside the helper.

Benchmark results against current `origin/master`:

Command:

```sh
go test -run '^$' -bench '^Benchmark(DetachCondAndBuildRangeForIndex|DetachCondAndBuildRangeForIndexLeadingLongIN|BuildColumnRangeLongIN)$' -benchmem -count=8 ./pkg/util/ranger
```

Comparison: current `origin/master` plus the same benchmark-only changes vs this PR.

```text
BenchmarkDetachCondAndBuildRangeForIndex-32
  sec/op:    100.38us -> 80.97us  (-19.33%)
  B/op:      490.0Ki  -> 410.3Ki  (-16.27%)
  allocs/op: 2.217k   -> 1.199k   (-45.93%)

BenchmarkDetachCondAndBuildRangeForIndexLeadingLongIN-32
  sec/op:    264.7us  -> 226.2us  (-14.55%)
  B/op:      1154.9Ki -> 994.1Ki  (-13.93%)
  allocs/op: 6.820k   -> 4.762k   (-30.18%)
  ranges/op: unchanged at 512
  range-bytes/op: unchanged at 280Ki

BenchmarkBuildColumnRangeLongIN-32
  sec/op:    88.54us -> 69.53us  (-21.48%)
  B/op:      329.2Ki -> 249.1Ki  (-24.33%)
  allocs/op: 2.062k  -> 1.037k   (-49.71%)
  ranges/op: unchanged at 512
  range-bytes/op: unchanged at 120Ki

geomean:
  sec/op:    -18.50%
  B/op:      -18.30%
  allocs/op: -42.52%
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test and benchmark commands:

```sh
go test -run 'TestRangeFallbackForDetachCondAndBuildRangeForIndex|TestRangeFallbackForBuildColumnRange' -tags=intest,deadlock ./pkg/util/ranger
go test -run '^$' -tags=intest,deadlock ./pkg/util/ranger
go test -run '^TestSelectWhereInvalidDSTTime$' -tags=intest,deadlock ./pkg/executor/test/simpletest
go test -tags=intest,deadlock ./pkg/util/ranger
git diff --check
tools/bin/revive -formatter friendly -config tools/check/revive.toml ./pkg/util/ranger/...
make lint FILES_TIDB_TESTS='./pkg/util/ranger/...'
go test -run '^$' -bench '^Benchmark(DetachCondAndBuildRangeForIndex|DetachCondAndBuildRangeForIndexLeadingLongIN|BuildColumnRangeLongIN)$' -benchmem -count=8 ./pkg/util/ranger
```

`make lint` without `FILES_TIDB_TESTS` was also attempted, but it currently fails on existing repo-wide revive/VCS issues outside `pkg/util/ranger`, including `error obtaining VCS status: exit status 128` and revive reports under paths such as `br/pkg/...` and `pkg/parser/ast/...`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Reduce CPU and allocation overhead when the optimizer builds ranges for long IN-list predicates.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new benchmark cases to measure ranger range-building and column-range performance.

* **Refactor**
  * Optimized range-point conversion to operate in place, reducing allocations and memory usage.

* **Chores**
  * Adjusted test shard configuration for the server test target.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68247)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->