### PR TITLE
executor: move mlog purge delete out of pessimistic txn

### DIFF
--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1548,7 +1548,6 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 	safePurgeTSO := uint64(0)
 	lockedLastPurgedTSO := uint64(0)
 	lockedLastPurgedTSOReady := false
-	deleteLoopCompleted := false
 	purgeJobID := uint64(0)
 	purgeHistRunningInserted := false
 	defer func() {
@@ -1789,17 +1788,9 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 				return finalizeFailure(batchErr)
 			}
 			if batchPurgeRows < batchSize {
-				deleteLoopCompleted = true
 				break
 			}
 		}
-	} else {
-		deleteLoopCompleted = true
-	}
-
-	if !deleteLoopCompleted {
-		_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
-		return finalizeFailure(errors.New("purge materialized view log: delete loop did not complete"))
 	}
 
 	nextTime, shouldUpdateNextTime, err := deriveRuntimeMaterializedScheduleNextTime(

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -262,8 +262,8 @@ func startMVTaskMonitor(
 					zap.Error(err),
 				)
 			} else if requested {
-				failpoint.InjectCall("mvTaskMonitorCancelRequested", monitorName)
 				taskCancelController.requestManualCancelByRequester(requester)
+				failpoint.InjectCall("mvTaskMonitorCancelRequested", monitorName)
 				return
 			}
 

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1550,6 +1550,8 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 	lockedLastPurgedTSOReady := false
 	purgeJobID := uint64(0)
 	purgeHistRunningInserted := false
+	txnStarted := false
+	txnFinished := false
 	defer func() {
 		if r := recover(); r != nil {
 			err = util.GetRecoverError(r)
@@ -1641,9 +1643,20 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 	defer func() {
 		stopTaskMonitor()
 	}()
+	defer func() {
+		if !txnStarted || txnFinished {
+			return
+		}
+		_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
+		txnFinished = true
+	}()
 
 	finalizeFailure := func(purgeErr error) error {
 		purgeFailedReason, finalErr := taskCancelController.normalizeTaskFailure(purgeErr)
+		if txnStarted && !txnFinished {
+			_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
+			txnFinished = true
+		}
 		if !purgeHistRunningInserted {
 			return errors.Trace(finalErr)
 		}
@@ -1698,10 +1711,10 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 	if _, err = sqlExec.ExecuteInternal(kctx, "BEGIN PESSIMISTIC"); err != nil {
 		return errors.Trace(err)
 	}
+	txnStarted = true
 
 	lastPurgedTSO, hasLastPurgedTSO, err := acquireMaterializedViewLogPurgeLock(kctx, sqlExec, schemaName, s.Table.Name, mlogID)
 	if err != nil {
-		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
 		return err
 	}
 	lockedLastPurgedTSO = lastPurgedTSO
@@ -1709,7 +1722,6 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 
 	txn, err := purgeSctx.Txn(true)
 	if err != nil {
-		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
 		return errors.Trace(err)
 	}
 	purgeStartTS := txn.StartTS()
@@ -1726,7 +1738,6 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		purgeMethod,
 		histTime(purgeStart),
 	); err != nil {
-		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
 		return errors.Trace(err)
 	}
 	purgeHistRunningInserted = true
@@ -1746,14 +1757,12 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		},
 	)
 	if err != nil {
-		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
 		return finalizeFailure(err)
 	}
 	failpoint.Inject("pausePurgeMaterializedViewLogAfterInsertPurgeHistRunning", func() {})
 
 	publicMVIDs, buildingMVIDs, err := collectDependentMViewIDsForMLogPurge(kctx, sqlExec, baseTableMeta, mlogID)
 	if err != nil {
-		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
 		return finalizeFailure(err)
 	}
 	safePurgeTSO, err = calcMaterializedViewLogSafePurgeTSO(
@@ -1766,7 +1775,6 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		buildingMVIDs,
 	)
 	if err != nil {
-		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
 		return finalizeFailure(err)
 	}
 	skipDeleteByCheckpoint := lockedLastPurgedTSOReady && lockedLastPurgedTSO >= safePurgeTSO
@@ -1784,7 +1792,6 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 			totalPurgeRows += batchPurgeRows
 			failpoint.Inject("pausePurgeMaterializedViewLogAfterDeleteBatch", func() {})
 			if batchErr != nil {
-				_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
 				return finalizeFailure(batchErr)
 			}
 			if batchPurgeRows < batchSize {
@@ -1806,7 +1813,6 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		},
 	)
 	if err != nil {
-		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
 		return finalizeFailure(err)
 	}
 	var lastPurgedTSOToPersist *uint64
@@ -1821,12 +1827,12 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		nextTime,
 		shouldUpdateNextTime,
 	); err != nil {
-		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
 		return finalizeFailure(err)
 	}
 	if _, err = sqlExec.ExecuteInternal(kctx, "COMMIT"); err != nil {
 		return finalizeFailure(err)
 	}
+	txnFinished = true
 
 	if err := finalizeSuccess(); err != nil {
 		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1545,10 +1545,10 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		batchSize = int64(variable.DefTiDBMLogPurgeBatchSize)
 	}
 	totalPurgeRows := int64(0)
-	safePurgeTSOReady := false
 	safePurgeTSO := uint64(0)
 	lockedLastPurgedTSO := uint64(0)
 	lockedLastPurgedTSOReady := false
+	deleteLoopCompleted := false
 	purgeJobID := uint64(0)
 	purgeHistRunningInserted := false
 	defer func() {
@@ -1598,6 +1598,30 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		targetMaintainIsolationReadEngines,
 	)
 	sqlExec := purgeSctx.GetSQLExecutor()
+
+	deleteSctx, err := e.GetSysSession()
+	if err != nil {
+		return err
+	}
+	defer e.ReleaseSysSession(releaseCtx, deleteSctx)
+	deleteSessVars := deleteSctx.GetSessionVars()
+	restoreDeleteMaintenanceVars, err := applyMVMaintenanceSessionVars(
+		deleteSessVars,
+		targetMaintainMemQuota,
+		targetMaintainIsolationReadEngines,
+		isInternalSQL,
+	)
+	if err != nil {
+		return err
+	}
+	defer restoreDeleteMaintenanceVars()
+	failpoint.InjectCall("mvMaintainMemQuotaAppliedOnPurgeDeleteSession", deleteSessVars.MemQuotaQuery, targetMaintainMemQuota)
+	failpoint.InjectCall(
+		"mvMaintainIsolationReadEnginesAppliedOnPurgeDeleteSession",
+		variable.GetIsolationReadEnginesString(deleteSessVars),
+		targetMaintainIsolationReadEngines,
+	)
+	deleteSQLExec := deleteSctx.GetSQLExecutor()
 
 	histSctx, err := e.GetSysSession()
 	if err != nil {
@@ -1672,172 +1696,175 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		}
 	})
 
-	for {
-		if _, err = sqlExec.ExecuteInternal(kctx, "BEGIN PESSIMISTIC"); err != nil {
-			return errors.Trace(err)
-		}
+	if _, err = sqlExec.ExecuteInternal(kctx, "BEGIN PESSIMISTIC"); err != nil {
+		return errors.Trace(err)
+	}
 
-		lastPurgedTSO, hasLastPurgedTSO, err := acquireMaterializedViewLogPurgeLock(kctx, sqlExec, schemaName, s.Table.Name, mlogID)
-		if err != nil {
-			_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
-			if isMLogPurgeLockConflict(err) && totalPurgeRows > 0 {
-				if histErr := finalizeSuccess(); histErr != nil {
-					e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
-						errors.Annotate(histErr, "purge materialized view log: purge committed but failed to finalize purge history"),
-					)
-				}
-				applyMVRefreshStmtResult(
-					e.Ctx().GetSessionVars().StmtCtx,
-					newMVRefreshStmtResultFromWriteCounts(0, 0, totalPurgeRows),
-				)
-				e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf(
-					"purge materialized view log on %s.%s stopped before deleting all eligible rows due to lock conflict after deleting %d rows; please retry later",
-					schemaName.O,
-					s.Table.Name.O,
-					totalPurgeRows,
-				))
-				return nil
-			}
-			return err
-		}
+	lastPurgedTSO, hasLastPurgedTSO, err := acquireMaterializedViewLogPurgeLock(kctx, sqlExec, schemaName, s.Table.Name, mlogID)
+	if err != nil {
+		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
+		return err
+	}
+	lockedLastPurgedTSO = lastPurgedTSO
+	lockedLastPurgedTSOReady = hasLastPurgedTSO
 
-		var batchErr error
-		batchPurgeRows := int64(0)
+	txn, err := purgeSctx.Txn(true)
+	if err != nil {
+		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
+		return errors.Trace(err)
+	}
+	purgeStartTS := txn.StartTS()
+	safePurgeTSO = purgeStartTS
 
-		// Calculate safe purge tso once at the first successful lock acquisition.
-		if !safePurgeTSOReady {
-			lockedLastPurgedTSO = lastPurgedTSO
-			lockedLastPurgedTSOReady = hasLastPurgedTSO
+	purgeJobID = purgeStartTS
+	if err := insertMLogPurgeHistRunning(
+		kctx,
+		histSQLExec,
+		purgeJobID,
+		mlogID,
+		schemaName.O,
+		baseTableMeta.Name.O,
+		purgeMethod,
+		histTime(purgeStart),
+	); err != nil {
+		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
+		return errors.Trace(err)
+	}
+	purgeHistRunningInserted = true
+	stopTaskMonitor, err = startMVTaskMonitor(
+		kctx,
+		e.GetSysSession,
+		func(sctx sessionctx.Context) {
+			e.ReleaseSysSession(releaseCtx, sctx)
+		},
+		taskCancelController,
+		fmt.Sprintf("mlog-purge-%d", purgeJobID),
+		func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) (bool, string, error) {
+			return readPurgeHistCancelRequest(watchCtx, watchSQLExec, purgeJobID, mlogID)
+		},
+		func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) error {
+			return updatePurgeHistHeartbeat(watchCtx, watchSQLExec, purgeJobID, mlogID)
+		},
+	)
+	if err != nil {
+		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
+		return finalizeFailure(err)
+	}
+	failpoint.Inject("pausePurgeMaterializedViewLogAfterInsertPurgeHistRunning", func() {})
 
-			txn, err := purgeSctx.Txn(true)
-			if err != nil {
-				_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
-				return errors.Trace(err)
-			}
-			purgeStartTS := txn.StartTS()
-			safePurgeTSO = purgeStartTS
-
-			if !purgeHistRunningInserted {
-				purgeJobID = purgeStartTS
-				if err := insertMLogPurgeHistRunning(
-					kctx,
-					histSQLExec,
-					purgeJobID,
-					mlogID,
-					schemaName.O,
-					baseTableMeta.Name.O,
-					purgeMethod,
-					histTime(purgeStart),
-				); err != nil {
-					_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
-					return errors.Trace(err)
-				}
-				purgeHistRunningInserted = true
-				stopTaskMonitor, err = startMVTaskMonitor(
-					kctx,
-					e.GetSysSession,
-					func(sctx sessionctx.Context) {
-						e.ReleaseSysSession(releaseCtx, sctx)
-					},
-					taskCancelController,
-					fmt.Sprintf("mlog-purge-%d", purgeJobID),
-					func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) (bool, string, error) {
-						return readPurgeHistCancelRequest(watchCtx, watchSQLExec, purgeJobID, mlogID)
-					},
-					func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) error {
-						return updatePurgeHistHeartbeat(watchCtx, watchSQLExec, purgeJobID, mlogID)
-					},
-				)
-				if err != nil {
-					_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
-					return finalizeFailure(err)
-				}
-				failpoint.Inject("pausePurgeMaterializedViewLogAfterInsertPurgeHistRunning", func() {})
-			}
-
-			// Collect all dependent MV IDs (Public + in-building CREATE MATERIALIZED VIEW jobs).
-			publicMVIDs, buildingMVIDs, collectErr := collectDependentMViewIDsForMLogPurge(kctx, sqlExec, baseTableMeta, mlogID)
-			if collectErr != nil {
-				batchErr = collectErr
-			} else {
-				// If there are no dependent MVs, it is safe to purge up to the start tso of this transaction.
-				safePurgeTSO, batchErr = calcMaterializedViewLogSafePurgeTSO(
-					kctx,
-					sqlExec,
-					schemaName.O,
-					s.Table.Name.O,
-					purgeStartTS,
-					publicMVIDs,
-					buildingMVIDs,
-				)
-			}
-			safePurgeTSOReady = true
-		}
-
-		skipDeleteByCheckpoint := batchErr == nil && lockedLastPurgedTSOReady && lockedLastPurgedTSO >= safePurgeTSO
-		if batchErr == nil && !skipDeleteByCheckpoint && safePurgeTSO > 0 {
-			batchPurgeRows, batchErr = purgeMaterializedViewLogData(
+	publicMVIDs, buildingMVIDs, err := collectDependentMViewIDsForMLogPurge(kctx, sqlExec, baseTableMeta, mlogID)
+	if err != nil {
+		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
+		return finalizeFailure(err)
+	}
+	safePurgeTSO, err = calcMaterializedViewLogSafePurgeTSO(
+		kctx,
+		sqlExec,
+		schemaName.O,
+		s.Table.Name.O,
+		purgeStartTS,
+		publicMVIDs,
+		buildingMVIDs,
+	)
+	if err != nil {
+		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
+		return finalizeFailure(err)
+	}
+	skipDeleteByCheckpoint := lockedLastPurgedTSOReady && lockedLastPurgedTSO >= safePurgeTSO
+	if !skipDeleteByCheckpoint && safePurgeTSO > 0 {
+		for {
+			batchPurgeRows, batchErr := purgeMaterializedViewLogData(
 				kctx,
-				sqlExec,
-				purgeSctx.GetSessionVars(),
+				deleteSQLExec,
+				deleteSessVars,
 				schemaName.O,
 				mlogName.O,
 				safePurgeTSO,
 				batchSize,
 			)
-		}
-		if batchErr == nil && batchPurgeRows < batchSize {
-			nextTime, shouldUpdateNextTime, deriveErr := deriveRuntimeMaterializedScheduleNextTime(
-				kctx,
-				scheduleEvalSctx,
-				purgeSctx,
-				mlogInfo.PurgeStartWith,
-				mlogInfo.PurgeNext,
-				isInternalSQL,
-				mlogInfo.DefinitionSQLMode,
-				func() {
-					logRuntimeMaterializedViewLogPurgeNextTimeUpdateNull(schemaName.O, mlogName.O, mlogInfo.PurgeNext)
-				},
-			)
-			if deriveErr != nil {
-				batchErr = deriveErr
-			} else {
-				var lastPurgedTSOToPersist *uint64
-				if !skipDeleteByCheckpoint {
-					lastPurgedTSOToPersist = &safePurgeTSO
+			totalPurgeRows += batchPurgeRows
+			if batchErr != nil {
+				_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
+				if totalPurgeRows > 0 {
+					if histErr := finalizeSuccess(); histErr != nil {
+						e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
+							errors.Annotate(histErr, "purge materialized view log: deleted rows but failed to finalize purge history"),
+						)
+					}
+					applyMVRefreshStmtResult(
+						e.Ctx().GetSessionVars().StmtCtx,
+						newMVRefreshStmtResultFromWriteCounts(0, 0, totalPurgeRows),
+					)
+					e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf(
+						"purge materialized view log on %s.%s stopped after deleting %d rows due to error: %v; LAST_PURGED_TSO and NEXT_TIME were not advanced, please retry later",
+						schemaName.O,
+						s.Table.Name.O,
+						totalPurgeRows,
+						batchErr,
+					))
+					return nil
 				}
-				batchErr = updateMaterializedViewLogPurgeInfoOnSuccess(
-					kctx,
-					sqlExec,
-					mlogID,
-					lastPurgedTSOToPersist,
-					nextTime,
-					shouldUpdateNextTime,
-				)
+				return finalizeFailure(batchErr)
+			}
+			if batchPurgeRows < batchSize {
+				deleteLoopCompleted = true
+				break
 			}
 		}
-		if batchErr != nil {
-			_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
-			return finalizeFailure(batchErr)
-		}
-		if _, err = sqlExec.ExecuteInternal(kctx, "COMMIT"); err != nil {
-			return finalizeFailure(err)
-		}
-
-		totalPurgeRows += batchPurgeRows
-		if batchPurgeRows < batchSize {
-			if err := finalizeSuccess(); err != nil {
-				e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
-					errors.Annotate(err, "purge materialized view log: purge committed but failed to finalize purge history"),
-				)
-			}
-			applyMVRefreshStmtResult(
-				e.Ctx().GetSessionVars().StmtCtx,
-				newMVRefreshStmtResultFromWriteCounts(0, 0, totalPurgeRows),
-			)
-			return nil
-		}
+	} else {
+		deleteLoopCompleted = true
 	}
+
+	if !deleteLoopCompleted {
+		_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
+		return finalizeFailure(errors.New("purge materialized view log: delete loop did not complete"))
+	}
+
+	nextTime, shouldUpdateNextTime, err := deriveRuntimeMaterializedScheduleNextTime(
+		kctx,
+		scheduleEvalSctx,
+		purgeSctx,
+		mlogInfo.PurgeStartWith,
+		mlogInfo.PurgeNext,
+		isInternalSQL,
+		mlogInfo.DefinitionSQLMode,
+		func() {
+			logRuntimeMaterializedViewLogPurgeNextTimeUpdateNull(schemaName.O, mlogName.O, mlogInfo.PurgeNext)
+		},
+	)
+	if err != nil {
+		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
+		return finalizeFailure(err)
+	}
+	var lastPurgedTSOToPersist *uint64
+	if !skipDeleteByCheckpoint {
+		lastPurgedTSOToPersist = &safePurgeTSO
+	}
+	if err = updateMaterializedViewLogPurgeInfoOnSuccess(
+		kctx,
+		sqlExec,
+		mlogID,
+		lastPurgedTSOToPersist,
+		nextTime,
+		shouldUpdateNextTime,
+	); err != nil {
+		_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
+		return finalizeFailure(err)
+	}
+	if _, err = sqlExec.ExecuteInternal(kctx, "COMMIT"); err != nil {
+		return finalizeFailure(err)
+	}
+
+	if err := finalizeSuccess(); err != nil {
+		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
+			errors.Annotate(err, "purge materialized view log: purge committed but failed to finalize purge history"),
+		)
+	}
+	applyMVRefreshStmtResult(
+		e.Ctx().GetSessionVars().StmtCtx,
+		newMVRefreshStmtResultFromWriteCounts(0, 0, totalPurgeRows),
+	)
+	return nil
 }
 
 func calcMaterializedViewLogSafePurgeTSO(
@@ -2029,10 +2056,6 @@ func acquireMaterializedViewLogPurgeLock(
 	return rows[0].GetUint64(0), true, nil
 }
 
-func isMLogPurgeLockConflict(err error) bool {
-	return err != nil && errors.ErrorEqual(err, errMLogPurgeLockConflict)
-}
-
 func collectDependentMViewIDsForMLogPurge(
 	kctx context.Context,
 	sqlExec sqlexec.SQLExecutor,
@@ -2095,7 +2118,6 @@ func purgeMaterializedViewLogData(
 			failpoint.Return(int64(0), errors.New("mock purge mlog delete error"))
 		}
 	})
-
 	failpoint.Inject("mockPurgeMaterializedViewLogDeleteRows", func(val failpoint.Value) {
 		switch v := val.(type) {
 		case int:

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1783,27 +1783,9 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 				batchSize,
 			)
 			totalPurgeRows += batchPurgeRows
+			failpoint.Inject("pausePurgeMaterializedViewLogAfterDeleteBatch", func() {})
 			if batchErr != nil {
 				_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
-				if totalPurgeRows > 0 {
-					if histErr := finalizeSuccess(); histErr != nil {
-						e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
-							errors.Annotate(histErr, "purge materialized view log: deleted rows but failed to finalize purge history"),
-						)
-					}
-					applyMVRefreshStmtResult(
-						e.Ctx().GetSessionVars().StmtCtx,
-						newMVRefreshStmtResultFromWriteCounts(0, 0, totalPurgeRows),
-					)
-					e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf(
-						"purge materialized view log on %s.%s stopped after deleting %d rows due to error: %v; LAST_PURGED_TSO and NEXT_TIME were not advanced, please retry later",
-						schemaName.O,
-						s.Table.Name.O,
-						totalPurgeRows,
-						batchErr,
-					))
-					return nil
-				}
 				return finalizeFailure(batchErr)
 			}
 			if batchPurgeRows < batchSize {

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -262,6 +262,7 @@ func startMVTaskMonitor(
 					zap.Error(err),
 				)
 			} else if requested {
+				failpoint.InjectCall("mvTaskMonitorCancelRequested", monitorName)
 				taskCancelController.requestManualCancelByRequester(requester)
 				return
 			}

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -1444,6 +1444,25 @@ func TestPurgeMaterializedViewLogManualCancelAfterPartialSuccess(t *testing.T) {
 		return fmt.Sprint(rows[0][0]) == "1"
 	}, 10*time.Second, 100*time.Millisecond)
 
+	purgeJobID := fmt.Sprint(tkObserver.MustQuery(fmt.Sprintf(
+		"select PURGE_JOB_ID from mysql.tidb_mlog_purge_hist where MLOG_ID = %d and PURGE_STATUS = 'running' limit 1",
+		mlogID,
+	)).Rows()[0][0])
+	cancelObservedCh := make(chan struct{}, 1)
+	cancelObservedFailpoint := "github.com/pingcap/tidb/pkg/executor/mvTaskMonitorCancelRequested"
+	expectedMonitorName := fmt.Sprintf("mlog-purge-%s", purgeJobID)
+	require.NoError(t, failpoint.EnableCall(cancelObservedFailpoint, func(monitorName string) {
+		if monitorName == expectedMonitorName {
+			select {
+			case cancelObservedCh <- struct{}{}:
+			default:
+			}
+		}
+	}))
+	defer func() {
+		require.NoError(t, failpoint.Disable(cancelObservedFailpoint))
+	}()
+
 	requester := "'partial_cancel_req'@'stage-d'"
 	tkObserver.MustExec(
 		`UPDATE mysql.tidb_mlog_purge_hist
@@ -1455,6 +1474,12 @@ WHERE MLOG_ID = ?
 		requester,
 		mlogID,
 	)
+
+	select {
+	case <-cancelObservedCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for purge task monitor to observe manual cancel request")
+	}
 
 	require.NoError(t, failpoint.Disable(pauseFailpoint))
 	paused = false

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -1356,32 +1356,39 @@ func TestPurgeMaterializedViewLogFinalizeFailureUsesWithoutCancel(t *testing.T) 
 		Check(testkit.Rows("failed 1 1"))
 }
 
-func TestPurgeMaterializedViewLogLockConflictAfterPartialSuccess(t *testing.T) {
+func TestPurgeMaterializedViewLogDeleteErrorAfterPartialSuccess(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
-	tk.MustExec("create table t_purge_partial_conflict (id int primary key, v int)")
-	tk.MustExec("create materialized view log on t_purge_partial_conflict (id, v) purge next date_add(now(), interval 1 hour)")
-	tk.MustExec("insert into t_purge_partial_conflict values (1, 10), (2, 20), (3, 30)")
+	tk.MustExec("create table t_purge_partial_delete_err (id int primary key, v int)")
+	tk.MustExec("create materialized view log on t_purge_partial_delete_err (id, v) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("insert into t_purge_partial_delete_err values (1, 10), (2, 20), (3, 30)")
 
 	is := dom.InfoSchema()
-	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_partial_conflict"))
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_partial_delete_err"))
 	require.NoError(t, err)
 	mlogID := mlogTable.Meta().ID
 
 	tk.MustExec("set @@session.tidb_mlog_purge_batch_size = 1")
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockPurgeMaterializedViewLogLockConflict", "1*return(false)->return(true)"))
+	beforeNextTime := fmt.Sprint(tk.MustQuery(fmt.Sprintf("select NEXT_TIME from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).Rows()[0][0])
+	beforeLastPurgedTSO := tk.MustQuery(fmt.Sprintf("select LAST_PURGED_TSO is null from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID))
+	beforeLastPurgedTSO.Check(testkit.Rows("1"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockPurgeMaterializedViewLogDeleteErr", "1*return(false)->return(true)"))
 	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockPurgeMaterializedViewLogLockConflict"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockPurgeMaterializedViewLogDeleteErr"))
 	}()
 
-	tk.MustExec("purge materialized view log on t_purge_partial_conflict")
-	tk.MustQuery("show warnings").CheckContain("lock conflict after deleting 1 rows")
+	tk.MustExec("purge materialized view log on t_purge_partial_delete_err")
+	require.Equal(t, uint64(1), tk.Session().AffectedRows())
+	tk.CheckLastMessage("Rows inserted: 0  Updated: 0  Deleted: 1")
+	tk.MustQuery("show warnings").CheckContain("stopped after deleting 1 rows due to error: mock purge mlog delete error")
 
-	tk.MustQuery("select count(*) from `$mlog$t_purge_partial_conflict`").Check(testkit.Rows("2"))
+	tk.MustQuery("select count(*) from `$mlog$t_purge_partial_delete_err`").Check(testkit.Rows("2"))
 	tk.MustQuery(fmt.Sprintf("select PURGE_STATUS, PURGE_ROWS from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1", mlogID)).
 		Check(testkit.Rows("success 1"))
+	tk.MustQuery(fmt.Sprintf("select LAST_PURGED_TSO is null, NEXT_TIME from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).
+		Check(testkit.Rows("1 " + beforeNextTime))
 }
 
 func TestPurgeMaterializedViewLogMissingPublicMViewRefreshRow(t *testing.T) {

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -1379,15 +1379,96 @@ func TestPurgeMaterializedViewLogDeleteErrorAfterPartialSuccess(t *testing.T) {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockPurgeMaterializedViewLogDeleteErr"))
 	}()
 
-	tk.MustExec("purge materialized view log on t_purge_partial_delete_err")
-	require.Equal(t, uint64(1), tk.Session().AffectedRows())
-	tk.CheckLastMessage("Rows inserted: 0  Updated: 0  Deleted: 1")
-	tk.MustQuery("show warnings").CheckContain("stopped after deleting 1 rows due to error: mock purge mlog delete error")
+	err = tk.ExecToErr("purge materialized view log on t_purge_partial_delete_err")
+	require.ErrorContains(t, err, "mock purge mlog delete error")
 
 	tk.MustQuery("select count(*) from `$mlog$t_purge_partial_delete_err`").Check(testkit.Rows("2"))
-	tk.MustQuery(fmt.Sprintf("select PURGE_STATUS, PURGE_ROWS from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1", mlogID)).
-		Check(testkit.Rows("success 1"))
+	tk.MustQuery(fmt.Sprintf("select PURGE_STATUS, PURGE_ROWS, PURGE_FAILED_REASON like '%%mock purge mlog delete error%%' from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1", mlogID)).
+		Check(testkit.Rows("failed 1 1"))
 	tk.MustQuery(fmt.Sprintf("select LAST_PURGED_TSO is null, NEXT_TIME from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).
+		Check(testkit.Rows("1 " + beforeNextTime))
+}
+
+func TestPurgeMaterializedViewLogManualCancelAfterPartialSuccess(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tkObserver := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tkObserver.MustExec("use test")
+
+	tk.MustExec("create table t_purge_partial_delete_cancel (id int primary key, v int)")
+	tk.MustExec("create materialized view log on t_purge_partial_delete_cancel (id, v) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("insert into t_purge_partial_delete_cancel values (1, 10), (2, 20), (3, 30)")
+
+	is := dom.InfoSchema()
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_partial_delete_cancel"))
+	require.NoError(t, err)
+	mlogID := mlogTable.Meta().ID
+
+	beforeNextTime := fmt.Sprint(tk.MustQuery(fmt.Sprintf("select NEXT_TIME from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).Rows()[0][0])
+	tk.MustExec("set @@session.tidb_mlog_purge_batch_size = 1")
+
+	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskMonitorPollInterval"
+	require.NoError(t, failpoint.Enable(pollIntervalFailpoint, "return(50)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable(pollIntervalFailpoint))
+	}()
+
+	pauseFailpoint := "github.com/pingcap/tidb/pkg/executor/pausePurgeMaterializedViewLogAfterDeleteBatch"
+	require.NoError(t, failpoint.Enable(pauseFailpoint, "pause"))
+	paused := true
+	defer func() {
+		if paused {
+			require.NoError(t, failpoint.Disable(pauseFailpoint))
+		}
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		tkPurge := testkit.NewTestKit(t, store)
+		tkPurge.MustExec("use test")
+		tkPurge.MustExec("set @@session.tidb_mlog_purge_batch_size = 1")
+		errCh <- tkPurge.ExecToErr("purge materialized view log on t_purge_partial_delete_cancel")
+	}()
+
+	require.Eventually(t, func() bool {
+		rows := tkObserver.MustQuery("select count(*) from `$mlog$t_purge_partial_delete_cancel`").Rows()
+		return fmt.Sprint(rows[0][0]) == "2"
+	}, 10*time.Second, 100*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		rows := tkObserver.MustQuery(fmt.Sprintf(
+			"select count(*) from mysql.tidb_mlog_purge_hist where MLOG_ID = %d and PURGE_STATUS = 'running'",
+			mlogID,
+		)).Rows()
+		return fmt.Sprint(rows[0][0]) == "1"
+	}, 10*time.Second, 100*time.Millisecond)
+
+	requester := "'partial_cancel_req'@'stage-d'"
+	tkObserver.MustExec(
+		`UPDATE mysql.tidb_mlog_purge_hist
+SET CANCEL_REQUESTED_AT = NOW(6),
+	CANCEL_REQUESTED_BY = ?
+WHERE MLOG_ID = ?
+  AND PURGE_STATUS = 'running'
+  AND CANCEL_REQUESTED_AT IS NULL`,
+		requester,
+		mlogID,
+	)
+
+	require.NoError(t, failpoint.Disable(pauseFailpoint))
+	paused = false
+
+	err = <-errCh
+	require.Error(t, err)
+	require.ErrorContains(t, err, "materialized view task canceled manually")
+
+	tkObserver.MustQuery("select count(*) from `$mlog$t_purge_partial_delete_cancel`").Check(testkit.Rows("2"))
+	tkObserver.MustQuery(fmt.Sprintf(
+		"select PURGE_STATUS, PURGE_ROWS, PURGE_FAILED_REASON from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1",
+		mlogID,
+	)).Check(testkit.Rows("failed 1 cancelled manually by " + requester))
+	tkObserver.MustQuery(fmt.Sprintf("select LAST_PURGED_TSO is null, NEXT_TIME from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).
 		Check(testkit.Rows("1 " + beforeNextTime))
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Purge now uses a single lock-acquire flow, improves transaction safety, reliably rolls back on partial-delete failures, records failed purge entries, preserves scheduled timing/progress markers, and reports accurate affected-row counts.
  * Manual cancellation during purge is detected and recorded with a cancel reason; partial progress is not committed.

* **Tests**
  * Added tests covering partial-progress delete errors and manual-cancel purge flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68248)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->