### PR TITLE
*: add TLS config and cert reload for starter mode

### DIFF
--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -127,6 +127,12 @@ const (
 	nmRepairMode       = "repair-mode"
 	nmRepairList       = "repair-list"
 	nmTempDir          = "temp-dir"
+	nmClusterCa        = "cluster-ca"
+	nmClusterCert      = "cluster-cert"
+	nmClusterKey       = "cluster-key"
+	nmSQLCA            = "sql-ca"
+	nmSQLCert          = "sql-cert"
+	nmSQLKey           = "sql-key"
 
 	nmRedact = "redact"
 
@@ -177,6 +183,12 @@ var (
 	repairMode       *bool
 	repairList       *string
 	tempDir          *string
+	clusterCA        *string
+	clusterCert      *string
+	clusterKey       *string
+	sqlCA            *string
+	sqlCert          *string
+	sqlKey           *string
 
 	// Log
 	logLevel     *string
@@ -238,6 +250,12 @@ func initFlagSet() *flag.FlagSet {
 	repairMode = flagBoolean(fset, nmRepairMode, false, "enable admin repair mode")
 	repairList = fset.String(nmRepairList, "", "admin repair table list")
 	tempDir = fset.String(nmTempDir, config.DefTempDir, "tidb temporary directory")
+	clusterCA = fset.String(nmClusterCa, "", "cluster CA file path")
+	clusterCert = fset.String(nmClusterCert, "", "cluster cert file path")
+	clusterKey = fset.String(nmClusterKey, "", "cluster key file path")
+	sqlCA = fset.String(nmSQLCA, "", "SQL CA file path")
+	sqlCert = fset.String(nmSQLCert, "", "SQL cert file path")
+	sqlKey = fset.String(nmSQLKey, "", "SQL key file path")
 
 	// Log
 	logLevel = fset.String(nmLogLevel, "info", "log level: info, debug, warn, error, fatal")
@@ -682,6 +700,49 @@ func overrideConfig(cfg *config.Config, fset *flag.FlagSet) {
 	}
 	if actualFlags[nmTempDir] {
 		cfg.TempDir = *tempDir
+	}
+	if cfg.DeployMode == deploymode.Starter {
+		clusterTLSOverridden := actualFlags[nmClusterCa] || actualFlags[nmClusterCert] || actualFlags[nmClusterKey]
+		if actualFlags[nmClusterCa] {
+			cfg.Security.ClusterSSLCA = *clusterCA
+		}
+		if actualFlags[nmClusterCert] {
+			cfg.Security.ClusterSSLCert = *clusterCert
+		}
+		if actualFlags[nmClusterKey] {
+			cfg.Security.ClusterSSLKey = *clusterKey
+		}
+		if clusterTLSOverridden {
+			if actualFlags[nmClusterCert] != actualFlags[nmClusterKey] {
+				err = fmt.Errorf("cluster-cert and cluster-key must be set together")
+				terror.MustNil(err)
+			}
+			if cfg.Security.ClusterSSLCA != "" && (cfg.Security.ClusterSSLCert == "" || cfg.Security.ClusterSSLKey == "") {
+				err = fmt.Errorf("cluster-ca requires both cluster-cert and cluster-key")
+				terror.MustNil(err)
+			}
+		}
+
+		sqlTLSOverridden := actualFlags[nmSQLCA] || actualFlags[nmSQLCert] || actualFlags[nmSQLKey]
+		if actualFlags[nmSQLCA] {
+			cfg.Security.SSLCA = *sqlCA
+		}
+		if actualFlags[nmSQLCert] {
+			cfg.Security.SSLCert = *sqlCert
+		}
+		if actualFlags[nmSQLKey] {
+			cfg.Security.SSLKey = *sqlKey
+		}
+		if sqlTLSOverridden {
+			if actualFlags[nmSQLCert] != actualFlags[nmSQLKey] {
+				err = fmt.Errorf("sql-cert and sql-key must be set together")
+				terror.MustNil(err)
+			}
+			if cfg.Security.SSLCA != "" && (cfg.Security.SSLCert == "" || cfg.Security.SSLKey == "") {
+				err = fmt.Errorf("sql-ca requires both sql-cert and sql-key")
+				terror.MustNil(err)
+			}
+		}
 	}
 
 	// Log

--- a/cmd/tidb-server/main_test.go
+++ b/cmd/tidb-server/main_test.go
@@ -132,6 +132,33 @@ func TestInitDeployMode(t *testing.T) {
 
 	cfg.DeployMode = deploymode.Mode(100)
 	require.ErrorContains(t, initDeployMode(cfg), "invalid deploy mode")
+
+	t.Run("starter TLS flags can override cert and key only", func(t *testing.T) {
+		fset := initFlagSet()
+		require.NoError(t, fset.Parse([]string{
+			"--cluster-cert=/tmp/flag-cluster-cert.pem",
+			"--cluster-key=/tmp/flag-cluster-key.pem",
+			"--sql-cert=/tmp/flag-sql-cert.pem",
+			"--sql-key=/tmp/flag-sql-key.pem",
+		}))
+
+		cfg := config.NewConfig()
+		cfg.DeployMode = deploymode.Starter
+		cfg.Security.ClusterSSLCA = "/tmp/config-cluster-ca.pem"
+		cfg.Security.ClusterSSLCert = "/tmp/config-cluster-cert.pem"
+		cfg.Security.ClusterSSLKey = "/tmp/config-cluster-key.pem"
+		cfg.Security.SSLCA = "/tmp/config-sql-ca.pem"
+		cfg.Security.SSLCert = "/tmp/config-sql-cert.pem"
+		cfg.Security.SSLKey = "/tmp/config-sql-key.pem"
+
+		overrideConfig(cfg, fset)
+		require.Equal(t, "/tmp/config-cluster-ca.pem", cfg.Security.ClusterSSLCA)
+		require.Equal(t, "/tmp/flag-cluster-cert.pem", cfg.Security.ClusterSSLCert)
+		require.Equal(t, "/tmp/flag-cluster-key.pem", cfg.Security.ClusterSSLKey)
+		require.Equal(t, "/tmp/config-sql-ca.pem", cfg.Security.SSLCA)
+		require.Equal(t, "/tmp/flag-sql-cert.pem", cfg.Security.SSLCert)
+		require.Equal(t, "/tmp/flag-sql-key.pem", cfg.Security.SSLKey)
+	})
 }
 
 func TestSetVersionByConfigInNextGen(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,6 +115,18 @@ const (
 	DefAuthTokenRefreshInterval = time.Hour
 	// EnvVarKeyspaceName is the system env name for keyspace name.
 	EnvVarKeyspaceName = "KEYSPACE_NAME"
+	// EnvClusterCA is the system env name for cluster CA path.
+	EnvClusterCA = "CLUSTER_CA"
+	// EnvClusterCert is the system env name for cluster cert path.
+	EnvClusterCert = "CLUSTER_CERT"
+	// EnvClusterKey is the system env name for cluster key path.
+	EnvClusterKey = "CLUSTER_KEY"
+	// EnvSQLCA is the system env name for SQL CA path.
+	EnvSQLCA = "SQL_CA"
+	// EnvSQLCert is the system env name for SQL cert path.
+	EnvSQLCert = "SQL_CERT"
+	// EnvSQLKey is the system env name for SQL key path.
+	EnvSQLKey = "SQL_KEY"
 	// MaxTokenLimit is the max token limit value.
 	MaxTokenLimit  = 1024 * 1024
 	DefSchemaLease = 45 * time.Second
@@ -1363,11 +1375,75 @@ func InitializeConfig(confPath string, configCheck, configStrict bool, enforceCm
 		fmt.Fprintln(os.Stderr, "invalid config", err)
 		os.Exit(1)
 	}
+	if err := cfg.AdjustStarterConfig(cfg.DeployMode == deploymode.Starter); err != nil {
+		fmt.Fprintln(os.Stderr, "invalid security env vars", err)
+		os.Exit(1)
+	}
 	if configCheck {
 		fmt.Println("config check successful")
 		os.Exit(0)
 	}
 	StoreGlobalConfig(cfg)
+}
+
+// AdjustStarterConfig applies starter-only security overrides.
+func (c *Config) AdjustStarterConfig(isStarter bool) error {
+	if !isStarter {
+		return nil
+	}
+	return c.adjustSecurityConfig()
+}
+
+func (c *Config) adjustSecurityConfig() error {
+	clusterCAPath := os.Getenv(EnvClusterCA)
+	clusterCertPath := os.Getenv(EnvClusterCert)
+	clusterKeyPath := os.Getenv(EnvClusterKey)
+	clusterCAOverridden := len(clusterCAPath) > 0
+	clusterCertOverridden := len(clusterCertPath) > 0
+	clusterKeyOverridden := len(clusterKeyPath) > 0
+	if len(clusterCAPath) > 0 {
+		c.Security.ClusterSSLCA = clusterCAPath
+	}
+	if len(clusterCertPath) > 0 {
+		c.Security.ClusterSSLCert = clusterCertPath
+	}
+	if len(clusterKeyPath) > 0 {
+		c.Security.ClusterSSLKey = clusterKeyPath
+	}
+	if clusterCAOverridden || clusterCertOverridden || clusterKeyOverridden {
+		if clusterCertOverridden != clusterKeyOverridden {
+			return errors.New("CLUSTER_CERT and CLUSTER_KEY must be set together")
+		}
+		if len(c.Security.ClusterSSLCA) > 0 && (len(c.Security.ClusterSSLCert) == 0 || len(c.Security.ClusterSSLKey) == 0) {
+			return errors.New("both CLUSTER_CERT and CLUSTER_KEY must be set when CLUSTER_CA is set")
+		}
+	}
+
+	sqlCAPath := os.Getenv(EnvSQLCA)
+	sqlCertPath := os.Getenv(EnvSQLCert)
+	sqlKeyPath := os.Getenv(EnvSQLKey)
+	sqlCAOverridden := len(sqlCAPath) > 0
+	sqlCertOverridden := len(sqlCertPath) > 0
+	sqlKeyOverridden := len(sqlKeyPath) > 0
+	if len(sqlCAPath) > 0 {
+		c.Security.SSLCA = sqlCAPath
+	}
+	if len(sqlCertPath) > 0 {
+		c.Security.SSLCert = sqlCertPath
+	}
+	if len(sqlKeyPath) > 0 {
+		c.Security.SSLKey = sqlKeyPath
+	}
+	if sqlCAOverridden || sqlCertOverridden || sqlKeyOverridden {
+		if sqlCertOverridden != sqlKeyOverridden {
+			return errors.New("SQL_CERT and SQL_KEY must be set together")
+		}
+		if len(c.Security.SSLCA) > 0 && (len(c.Security.SSLCert) == 0 || len(c.Security.SSLKey) == 0) {
+			return errors.New("both SQL_CERT and SQL_KEY must be set when SQL_CA is set")
+		}
+	}
+
+	return nil
 }
 
 // RemovedVariableCheck checks if the config file contains any items

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1162,6 +1162,50 @@ max-allowed-packet = %d`, packetSize)), 0644))
 	StoreGlobalConfig(conf)
 	require.Equal(t, uint64(DefMaxAllowedPacket), GetMaxAllowedPacket())
 
+	t.Run("adjust starter config with full TLS env", func(t *testing.T) {
+		conf := NewConfig()
+		t.Setenv(EnvClusterCA, "/tmp/cluster-ca.pem")
+		t.Setenv(EnvClusterCert, "/tmp/cluster-cert.pem")
+		t.Setenv(EnvClusterKey, "/tmp/cluster-key.pem")
+		t.Setenv(EnvSQLCA, "/tmp/sql-ca.pem")
+		t.Setenv(EnvSQLCert, "/tmp/sql-cert.pem")
+		t.Setenv(EnvSQLKey, "/tmp/sql-key.pem")
+		require.NoError(t, conf.AdjustStarterConfig(true))
+		require.Equal(t, "/tmp/cluster-ca.pem", conf.Security.ClusterSSLCA)
+		require.Equal(t, "/tmp/cluster-cert.pem", conf.Security.ClusterSSLCert)
+		require.Equal(t, "/tmp/cluster-key.pem", conf.Security.ClusterSSLKey)
+		require.Equal(t, "/tmp/sql-ca.pem", conf.Security.SSLCA)
+		require.Equal(t, "/tmp/sql-cert.pem", conf.Security.SSLCert)
+		require.Equal(t, "/tmp/sql-key.pem", conf.Security.SSLKey)
+	})
+
+	t.Run("adjust starter config keeps CA when env overrides cert and key", func(t *testing.T) {
+		conf := NewConfig()
+		conf.Security.ClusterSSLCA = "/tmp/config-cluster-ca.pem"
+		conf.Security.ClusterSSLCert = "/tmp/config-cluster-cert.pem"
+		conf.Security.ClusterSSLKey = "/tmp/config-cluster-key.pem"
+		conf.Security.SSLCA = "/tmp/config-sql-ca.pem"
+		conf.Security.SSLCert = "/tmp/config-sql-cert.pem"
+		conf.Security.SSLKey = "/tmp/config-sql-key.pem"
+		t.Setenv(EnvClusterCert, "/tmp/env-cluster-cert.pem")
+		t.Setenv(EnvClusterKey, "/tmp/env-cluster-key.pem")
+		t.Setenv(EnvSQLCert, "/tmp/env-sql-cert.pem")
+		t.Setenv(EnvSQLKey, "/tmp/env-sql-key.pem")
+		require.NoError(t, conf.AdjustStarterConfig(true))
+		require.Equal(t, "/tmp/config-cluster-ca.pem", conf.Security.ClusterSSLCA)
+		require.Equal(t, "/tmp/env-cluster-cert.pem", conf.Security.ClusterSSLCert)
+		require.Equal(t, "/tmp/env-cluster-key.pem", conf.Security.ClusterSSLKey)
+		require.Equal(t, "/tmp/config-sql-ca.pem", conf.Security.SSLCA)
+		require.Equal(t, "/tmp/env-sql-cert.pem", conf.Security.SSLCert)
+		require.Equal(t, "/tmp/env-sql-key.pem", conf.Security.SSLKey)
+	})
+
+	t.Run("adjust starter config rejects incomplete TLS env", func(t *testing.T) {
+		conf := NewConfig()
+		t.Setenv(EnvClusterCert, "/tmp/env-cluster-cert.pem")
+		require.ErrorContains(t, conf.AdjustStarterConfig(true), "CLUSTER_CERT and CLUSTER_KEY must be set together")
+	})
+
 	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "unknown"`), 0644))
 	conf = NewConfig()
 	require.ErrorContains(t, conf.Load(configFile), `invalid deploy mode "unknown"`)

--- a/pkg/server/stat.go
+++ b/pkg/server/stat.go
@@ -53,7 +53,21 @@ func (s *Server) Stats(_ *variable.SessionVars) (map[string]any, error) {
 
 	tlsConfig := s.GetTLSConfig()
 	if tlsConfig != nil {
-		if len(tlsConfig.Certificates) == 1 {
+		if tlsConfig.GetCertificate != nil {
+			certs, err := tlsConfig.GetCertificate(nil)
+			if err != nil {
+				logutil.BgLogger().Warn("Failed to get TLS certificates while acquiring server status", zap.Error(err))
+			}
+			if certs != nil && len(certs.Certificate) > 0 {
+				pc, err := x509.ParseCertificate(certs.Certificate[0])
+				if err != nil {
+					logutil.BgLogger().Warn("Failed to parse TLS certificates to get server status", zap.Error(err))
+				} else {
+					m[serverNotAfter] = pc.NotAfter.Format("Jan _2 15:04:05 2006 MST")
+					m[serverNotBefore] = pc.NotBefore.Format("Jan _2 15:04:05 2006 MST")
+				}
+			}
+		} else if len(tlsConfig.Certificates) == 1 {
 			pc, err := x509.ParseCertificate(tlsConfig.Certificates[0].Certificate[0])
 			if err != nil {
 				logutil.BgLogger().Error("Failed to parse TLS certficates to get server status", zap.Error(err))

--- a/pkg/server/tests/tls/tls_test.go
+++ b/pkg/server/tests/tls/tls_test.go
@@ -558,7 +558,9 @@ func TestReloadTLS(t *testing.T) {
 
 	// try reload a valid cert.
 	tlsCfg := server.GetTLSConfig()
-	cert, err := x509.ParseCertificate(tlsCfg.Certificates[0].Certificate[0])
+	tlsCert, err := tlsCfg.GetCertificate(nil)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(tlsCert.Certificate[0])
 	require.NoError(t, err)
 	oldExpireTime := cert.NotAfter
 	_, _, err = generateCert(1, "tidb-server", caCert, caKey, "/tmp/server-key-reload2.pem", "/tmp/server-cert-reload2.pem", func(c *x509.Certificate) {
@@ -582,7 +584,9 @@ func TestReloadTLS(t *testing.T) {
 	require.NoError(t, err)
 
 	tlsCfg = server.GetTLSConfig()
-	cert, err = x509.ParseCertificate(tlsCfg.Certificates[0].Certificate[0])
+	tlsCert, err = tlsCfg.GetCertificate(nil)
+	require.NoError(t, err)
+	cert, err = x509.ParseCertificate(tlsCert.Certificate[0])
 	require.NoError(t, err)
 	newExpireTime := cert.NotAfter
 	require.True(t, newExpireTime.After(oldExpireTime))

--- a/pkg/util/misc.go
+++ b/pkg/util/misc.go
@@ -35,6 +35,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -399,13 +400,14 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool, rsaKeySize int) (tl
 		}
 	}
 
-	var tlsCert tls.Certificate
-	tlsCert, err = tls.LoadX509KeyPair(cert, key)
+	certs, err := tls.LoadX509KeyPair(cert, key)
 	if err != nil {
 		logutil.BgLogger().Warn("load x509 failed", zap.Error(err))
 		err = errors.Trace(err)
 		return
 	}
+	cs := &atomic.Pointer[tls.Certificate]{}
+	cs.Store(&certs)
 
 	requireTLS := tlsutil.RequireSecureTransport.Load()
 
@@ -467,11 +469,23 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool, rsaKeySize int) (tl
 
 	/* #nosec G402 */
 	tlsConfig = &tls.Config{
-		Certificates: []tls.Certificate{tlsCert},
 		ClientCAs:    certPool,
 		ClientAuth:   clientAuthPolicy,
 		MinVersion:   minTLSVersion,
 		CipherSuites: cipherSuites,
+	}
+	tlsConfig.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		certs, err := tls.LoadX509KeyPair(cert, key)
+		if err != nil {
+			logutil.BgLogger().Warn("could not load server certificate, using the old one", zap.Error(err))
+			if old := cs.Load(); old != nil {
+				return old, nil
+			}
+			return nil, nil
+		}
+		newCerts := &certs
+		cs.Store(newCerts)
+		return newCerts, nil
 	}
 	return
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67765 

Problem Summary:
Starter-mode deployments in TiDB Cloud need special TLS/bootstrap handling for mTLS. These behaviors should only apply in starter mode and must not affect non-starter deployments.
### What changed and how does it work?
This PR adds starter-only overrides for cluster and SQL TLS settings from CLI flags and environment variables. The overrides are applied only when the loaded config uses starter deploy mode, and cert/key pairs are validated before startup continues. It also makes server TLS certificate loading dynamic via GetCertificate, so certificate reloads and status reporting reflect the current certificate files.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flags and environment variables to supply cluster and SQL TLS materials in starter mode.
  * Dynamic TLS certificate reloading with server status exposing SSL not-before/not-after.

* **Improvements**
  * Starter-mode loads TLS paths from flags/env, validates cert/key pairings, and persists adjusted config at startup.

* **Tests**
  * TLS tests updated to validate runtime certificate selection, reload behavior, and starter TLS handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68294)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->