### PR TITLE
planner: handle projection between join groups

### DIFF
--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -433,6 +433,7 @@ func (sf *ScalarFunction) Decorrelate(schema *Schema) Expression {
 	for i, arg := range sf.GetArgs() {
 		sf.GetArgs()[i] = arg.Decorrelate(schema)
 	}
+	sf.CleanHashCode()
 	return sf
 }
 
@@ -573,6 +574,13 @@ func (sf *ScalarFunction) CanonicalHashCode() []byte {
 	}
 	simpleCanonicalizedHashCode(sf)
 	return sf.canonicalhashcode
+}
+
+// CleanHashCode cleans the cached hashcode and canonical hashcode.
+// It should be called after the function is mutated in-place.
+func (sf *ScalarFunction) CleanHashCode() {
+	sf.hashcode = sf.hashcode[:0]
+	sf.canonicalhashcode = sf.canonicalhashcode[:0]
 }
 
 // ExpressionsSemanticEqual is used to judge whether two expression tree is semantic equivalent.
@@ -727,6 +735,7 @@ func (sf *ScalarFunction) Equals(other any) bool {
 // ReHashCode is used after we change the argument in place.
 func ReHashCode(sf *ScalarFunction) {
 	sf.hashcode = sf.hashcode[:0]
+	sf.canonicalhashcode = sf.canonicalhashcode[:0]
 	sf.hashcode = append(sf.hashcode, scalarFunctionFlag)
 	sf.hashcode = codec.EncodeCompactBytes(sf.hashcode, hack.Slice(sf.FuncName.L))
 	for _, arg := range sf.GetArgs() {
@@ -804,8 +813,7 @@ func (sf *ScalarFunction) RemapColumn(m map[int64]*Column) (Expression, error) {
 		}
 		newSf.GetArgs()[i] = newArg
 	}
-	// clear hash code
-	newSf.hashcode = nil
+	newSf.CleanHashCode()
 	return newSf, nil
 }
 

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -440,6 +440,7 @@ func SetExprColumnInOperand(expr Expression) Expression {
 		for i, arg := range args {
 			args[i] = SetExprColumnInOperand(arg)
 		}
+		v.CleanHashCode()
 	}
 	return expr
 }
@@ -505,7 +506,9 @@ func ColumnSubstituteImpl(ctx BuildContext, expr Expression, schema *Schema, new
 				} else {
 					// for grouping function recreation, use clone (meta included) instead of newFunction
 					e = v.Clone()
-					e.(*ScalarFunction).Function.getArgs()[0] = newArg
+					sf := e.(*ScalarFunction)
+					sf.Function.getArgs()[0] = newArg
+					sf.CleanHashCode()
 				}
 				e.SetCoercibility(v.Coercibility())
 				e.GetType(ctx.GetEvalCtx()).SetFlag(flag)
@@ -687,7 +690,9 @@ func SubstituteCorCol2Constant(ctx BuildContext, expr Expression) (Expression, e
 			newSf = BuildCastFunction(ctx, newArgs[0], x.RetType)
 		} else if x.FuncName.L == ast.Grouping {
 			newSf = x.Clone()
-			newSf.(*ScalarFunction).GetArgs()[0] = newArgs[0]
+			sf := newSf.(*ScalarFunction)
+			sf.GetArgs()[0] = newArgs[0]
+			sf.CleanHashCode()
 		} else {
 			newSf, err = NewFunction(ctx, x.FuncName.L, x.GetType(ctx.GetEvalCtx()), newArgs...)
 		}

--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "rule_join_reorder.go",
         "rule_join_reorder_dp.go",
         "rule_join_reorder_greedy.go",
+        "rule_join_reorder_projection_inline.go",
         "rule_max_min_eliminate.go",
         "rule_outer_to_inner_join.go",
         "rule_partition_processor.go",

--- a/pkg/planner/core/operator/logicalop/logical_cte.go
+++ b/pkg/planner/core/operator/logicalop/logical_cte.go
@@ -210,7 +210,7 @@ func (p *LogicalCTE) DeriveStats(_ []*property.StatsInfo, selfSchema *expression
 	}
 	if p.Cte.RecursivePartLogicalPlan != nil {
 		if p.Cte.RecursivePartPhysicalPlan == nil {
-			_, p.Cte.RecursivePartPhysicalPlan, _, err = utilfuncp.DoOptimize(context.TODO(), p.SCtx(), p.Cte.OptFlag, p.Cte.RecursivePartLogicalPlan)
+			p.Cte.RecursivePartLogicalPlan, p.Cte.RecursivePartPhysicalPlan, _, err = utilfuncp.DoOptimize(context.TODO(), p.SCtx(), p.Cte.OptFlag, p.Cte.RecursivePartLogicalPlan)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -26,7 +26,9 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace"
+	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 	h "github.com/pingcap/tidb/pkg/util/hint"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 	"github.com/pingcap/tidb/pkg/util/tracing"
 )
@@ -38,15 +40,41 @@ import (
 // For example: "InnerJoin(InnerJoin(a, b), LeftJoin(c, d))"
 // results in a join group {a, b, c, d}.
 func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
+	return extractJoinGroupImpl(p)
+}
+
+// extractJoinGroupImpl is the internal implementation of extractJoinGroup.
+//
+// When enabled, it can look through a single safe Projection on top of a Join.
+// The derived output columns are tracked in colExprMap and substituted back into
+// join predicates before the join graph is built.
+func extractJoinGroupImpl(p base.LogicalPlan) *joinGroupResult {
 	joinMethodHintInfo := make(map[int]*joinMethodHint)
 	var (
-		group             []base.LogicalPlan
-		joinOrderHintInfo []*h.PlanHints
-		eqEdges           []*expression.ScalarFunction
-		otherConds        []expression.Expression
-		joinTypes         []*joinTypeWithExtMsg
-		hasOuterJoin      bool
+		group              []base.LogicalPlan
+		joinOrderHintInfo  []*h.PlanHints
+		eqEdges            []*expression.ScalarFunction
+		otherConds         []expression.Expression
+		joinTypes          []*joinTypeWithExtMsg
+		nullExtendedCols   []*expression.Column
+		nullExtendedColSet = make(map[int64]struct{})
+		hasOuterJoin       bool
 	)
+	appendNullExtendedCols := func(schema *expression.Schema) {
+		if schema == nil {
+			return
+		}
+		for _, col := range schema.Columns {
+			if col == nil {
+				continue
+			}
+			if _, ok := nullExtendedColSet[col.UniqueID]; ok {
+				continue
+			}
+			nullExtendedColSet[col.UniqueID] = struct{}{}
+			nullExtendedCols = append(nullExtendedCols, col)
+		}
+	}
 
 	// Check if the current plan is a Selection. If its child is a join, add the selection conditions
 	// to otherConds and continue extracting the join group from the child.
@@ -54,12 +82,22 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 	// For volatile or side-effect expressions, moving them can change evaluation times/orders
 	// thus may change query results, so we skip reordering through Selection in such cases.
 	if selection, isSelection := p.(*logicalop.LogicalSelection); isSelection && p.SCtx().GetSessionVars().TiDBOptJoinReorderThroughSel &&
-		!slices.ContainsFunc(selection.Conditions, expression.IsMutableEffectsExpr) {
+		!slices.ContainsFunc(selection.Conditions, func(expr expression.Expression) bool {
+			return expression.IsMutableEffectsExpr(expr) || expression.CheckNonDeterministic(expr)
+		}) {
 		child := selection.Children()[0]
 		if _, isChildJoin := child.(*logicalop.LogicalJoin); isChildJoin {
-			childResult := extractJoinGroup(child)
-			childResult.otherConds = append(childResult.otherConds, selection.Conditions...)
+			childResult := extractJoinGroupImpl(child)
+			selectionConds := selection.Conditions
+			if len(childResult.colExprMap) > 0 {
+				selectionConds = substituteColsInExprs(selectionConds, childResult.colExprMap)
+			}
+			childResult.otherConds = append(childResult.otherConds, selectionConds...)
 			return childResult
+		}
+	} else if proj, isProj := p.(*logicalop.LogicalProjection); isProj && p.SCtx().GetSessionVars().TiDBOptJoinReorderThroughProj {
+		if result, handled := tryInlineProjectionForJoinGroup(p, proj); handled {
+			return result
 		}
 	}
 
@@ -110,35 +148,17 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 			rightHasHint = true
 		}
 	}
+	var colExprMap map[int64]expression.Expression
 	hasOuterJoin = hasOuterJoin || (join.JoinType != logicalop.InnerJoin)
 	// If the left child has the hint, it means there are some join method hints want to specify the join method based on the left child.
 	// For example: `select .. from t1 join t2 join (select .. from t3 join t4) t5 where ..;` If there are some join method hints related to `t5`, we can't split `t5` into `t3` and `t4`.
 	// So we don't need to split the left child part. The right child part is the same.
 	if join.JoinType != logicalop.RightOuterJoin && !leftHasHint {
-		lhsJoinGroupResult := extractJoinGroup(join.Children()[0])
-		lhsGroup, lhsEqualConds, lhsOtherConds, lhsJoinTypes, lhsJoinOrderHintInfo, lhsJoinMethodHintInfo, lhsHasOuterJoin := lhsJoinGroupResult.group, lhsJoinGroupResult.eqEdges, lhsJoinGroupResult.otherConds, lhsJoinGroupResult.joinTypes, lhsJoinGroupResult.joinOrderHintInfo, lhsJoinGroupResult.joinMethodHintInfo, lhsJoinGroupResult.hasOuterJoin
-		noExpand := false
+		lhsJoinGroupResult := extractJoinGroupImpl(join.Children()[0])
+		lhsGroup, lhsEqualConds, lhsOtherConds, lhsJoinTypes, lhsJoinOrderHintInfo, lhsJoinMethodHintInfo, lhsHasOuterJoin, lhsColExprMap := lhsJoinGroupResult.group, lhsJoinGroupResult.eqEdges, lhsJoinGroupResult.otherConds, lhsJoinGroupResult.joinTypes, lhsJoinGroupResult.joinOrderHintInfo, lhsJoinGroupResult.joinMethodHintInfo, lhsJoinGroupResult.hasOuterJoin, lhsJoinGroupResult.colExprMap
 		// If the filters of the outer join is related with multiple leaves of the outer join side. We don't reorder it for now.
-		if join.JoinType == logicalop.LeftOuterJoin {
-			extractedCols := make([]*expression.Column, 0, 8)
-			extractedCols = expression.ExtractColumnsFromExpressions(extractedCols, join.OtherConditions, nil)
-			extractedCols = expression.ExtractColumnsFromExpressions(extractedCols, join.LeftConditions, nil)
-			extractedCols = expression.ExtractColumnsFromExpressions(extractedCols, expression.ScalarFuncs2Exprs(join.EqualConditions), nil)
-			affectedGroups := 0
-			for i := range lhsGroup {
-				for _, col := range extractedCols {
-					if lhsGroup[i].Schema().Contains(col) {
-						affectedGroups++
-						break
-					}
-				}
-				if affectedGroups > 1 {
-					noExpand = true
-					break
-				}
-			}
-		}
-		if noExpand {
+		if join.JoinType == logicalop.LeftOuterJoin &&
+			outerJoinSideFiltersTouchMultipleLeaves(join, lhsGroup, lhsColExprMap, true) {
 			return &joinGroupResult{
 				group:              []base.LogicalPlan{p},
 				basicJoinGroupInfo: &basicJoinGroupInfo{},
@@ -149,40 +169,23 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 		otherConds = append(otherConds, lhsOtherConds...)
 		joinTypes = append(joinTypes, lhsJoinTypes...)
 		joinOrderHintInfo = append(joinOrderHintInfo, lhsJoinOrderHintInfo...)
+		appendNullExtendedCols(lhsJoinGroupResult.nullExtendedCols)
 		for ID, joinMethodHint := range lhsJoinMethodHintInfo {
 			joinMethodHintInfo[ID] = joinMethodHint
 		}
 		hasOuterJoin = hasOuterJoin || lhsHasOuterJoin
+		colExprMap = mergeColExprMap(colExprMap, lhsColExprMap)
 	} else {
 		group = append(group, join.Children()[0])
 	}
 
 	// You can see the comments in the upside part which we try to split the left child part. It's the same here.
 	if join.JoinType != logicalop.LeftOuterJoin && !rightHasHint {
-		rhsJoinGroupResult := extractJoinGroup(join.Children()[1])
-		rhsGroup, rhsEqualConds, rhsOtherConds, rhsJoinTypes, rhsJoinOrderHintInfo, rhsJoinMethodHintInfo, rhsHasOuterJoin := rhsJoinGroupResult.group, rhsJoinGroupResult.eqEdges, rhsJoinGroupResult.otherConds, rhsJoinGroupResult.joinTypes, rhsJoinGroupResult.joinOrderHintInfo, rhsJoinGroupResult.joinMethodHintInfo, rhsJoinGroupResult.hasOuterJoin
-		noExpand := false
+		rhsJoinGroupResult := extractJoinGroupImpl(join.Children()[1])
+		rhsGroup, rhsEqualConds, rhsOtherConds, rhsJoinTypes, rhsJoinOrderHintInfo, rhsJoinMethodHintInfo, rhsHasOuterJoin, rhsColExprMap := rhsJoinGroupResult.group, rhsJoinGroupResult.eqEdges, rhsJoinGroupResult.otherConds, rhsJoinGroupResult.joinTypes, rhsJoinGroupResult.joinOrderHintInfo, rhsJoinGroupResult.joinMethodHintInfo, rhsJoinGroupResult.hasOuterJoin, rhsJoinGroupResult.colExprMap
 		// If the filters of the outer join is related with multiple leaves of the outer join side. We don't reorder it for now.
-		if join.JoinType == logicalop.RightOuterJoin {
-			extractedCols := make([]*expression.Column, 0, 8)
-			extractedCols = expression.ExtractColumnsFromExpressions(extractedCols, join.OtherConditions, nil)
-			extractedCols = expression.ExtractColumnsFromExpressions(extractedCols, join.RightConditions, nil)
-			extractedCols = expression.ExtractColumnsFromExpressions(extractedCols, expression.ScalarFuncs2Exprs(join.EqualConditions), nil)
-			affectedGroups := 0
-			for i := range rhsGroup {
-				for _, col := range extractedCols {
-					if rhsGroup[i].Schema().Contains(col) {
-						affectedGroups++
-						break
-					}
-				}
-				if affectedGroups > 1 {
-					noExpand = true
-					break
-				}
-			}
-		}
-		if noExpand {
+		if join.JoinType == logicalop.RightOuterJoin &&
+			outerJoinSideFiltersTouchMultipleLeaves(join, rhsGroup, rhsColExprMap, false) {
 			return &joinGroupResult{
 				group:              []base.LogicalPlan{p},
 				basicJoinGroupInfo: &basicJoinGroupInfo{},
@@ -193,12 +196,21 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 		otherConds = append(otherConds, rhsOtherConds...)
 		joinTypes = append(joinTypes, rhsJoinTypes...)
 		joinOrderHintInfo = append(joinOrderHintInfo, rhsJoinOrderHintInfo...)
+		appendNullExtendedCols(rhsJoinGroupResult.nullExtendedCols)
 		for ID, joinMethodHint := range rhsJoinMethodHintInfo {
 			joinMethodHintInfo[ID] = joinMethodHint
 		}
 		hasOuterJoin = hasOuterJoin || rhsHasOuterJoin
+		colExprMap = mergeColExprMap(colExprMap, rhsColExprMap)
 	} else {
 		group = append(group, join.Children()[1])
+	}
+
+	switch join.JoinType {
+	case logicalop.LeftOuterJoin:
+		appendNullExtendedCols(join.Children()[1].Schema())
+	case logicalop.RightOuterJoin:
+		appendNullExtendedCols(join.Children()[0].Schema())
 	}
 
 	eqEdges = append(eqEdges, join.EqualConditions...)
@@ -221,6 +233,21 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 		}
 		otherConds = append(otherConds, tmpOtherConds...)
 	}
+
+	if len(colExprMap) > 0 {
+		eqEdges = substituteColsInEqEdges(eqEdges, colExprMap)
+		otherConds = substituteColsInExprs(otherConds, colExprMap)
+		for _, joinType := range joinTypes {
+			if joinType.outerBindCondition != nil {
+				joinType.outerBindCondition = substituteColsInExprs(joinType.outerBindCondition, colExprMap)
+			}
+		}
+	}
+
+	var nullExtendedSchema *expression.Schema
+	if len(nullExtendedCols) > 0 {
+		nullExtendedSchema = expression.NewSchema(nullExtendedCols...)
+	}
 	return &joinGroupResult{
 		group:             group,
 		hasOuterJoin:      hasOuterJoin,
@@ -229,8 +256,10 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 			eqEdges:            eqEdges,
 			otherConds:         otherConds,
 			joinTypes:          joinTypes,
+			nullExtendedCols:   nullExtendedSchema,
 			joinMethodHintInfo: joinMethodHintInfo,
 		},
+		colExprMap: colExprMap,
 	}
 }
 
@@ -277,7 +306,20 @@ func (s *JoinReOrderSolver) optimizeRecursive(ctx base.PlanContext, p base.Logic
 					return nil, err
 				}
 			}
+			origJoinRoot := p
 			originalSchema := p.Schema()
+			fallbackOnErr := func(err error) (base.LogicalPlan, error) {
+				if ctx.GetSessionVars().TiDBOptJoinReorderThroughProj {
+					// Through-projection join reorder is best-effort. If the
+					// projected join graph cannot be restored safely, retry with
+					// projections treated as ordinary join-group leaves.
+					saved := ctx.GetSessionVars().TiDBOptJoinReorderThroughProj
+					ctx.GetSessionVars().TiDBOptJoinReorderThroughProj = false
+					defer func() { ctx.GetSessionVars().TiDBOptJoinReorderThroughProj = saved }()
+					return s.optimizeRecursive(ctx, origJoinRoot, tracer)
+				}
+				return nil, err
+			}
 
 			// Not support outer join reorder when using the DP algorithm
 			isSupportDP := true
@@ -329,27 +371,11 @@ func (s *JoinReOrderSolver) optimizeRecursive(ctx base.PlanContext, p base.Logic
 				p, err = dpSolver.solve(curJoinGroup, tracer)
 			}
 			if err != nil {
-				return nil, err
+				return fallbackOnErr(err)
 			}
-			schemaChanged := false
-			if len(p.Schema().Columns) != len(originalSchema.Columns) {
-				schemaChanged = true
-			} else {
-				for i, col := range p.Schema().Columns {
-					if !col.EqualColumn(originalSchema.Columns[i]) {
-						schemaChanged = true
-						break
-					}
-				}
-			}
-			if schemaChanged {
-				proj := logicalop.LogicalProjection{
-					Exprs: expression.Column2Exprs(originalSchema.Columns),
-				}.Init(p.SCtx(), p.QueryBlockOffset())
-				// Clone the schema here, because the schema may be changed by column pruning rules.
-				proj.SetSchema(originalSchema.Clone())
-				proj.SetChildren(p)
-				p = proj
+			p, err = restoreSchemaIfChanged(p, originalSchema, result.colExprMap)
+			if err != nil {
+				return fallbackOnErr(err)
 			}
 			return p, nil
 		}
@@ -367,6 +393,56 @@ func (s *JoinReOrderSolver) optimizeRecursive(ctx base.PlanContext, p base.Logic
 	}
 	p.SetChildren(newChildren...)
 	return p, nil
+}
+
+// restoreSchemaIfChanged restores the original join-root schema after join reorder.
+//
+// Join reorder may inject projections to materialize expression join keys, which
+// can change the current output schema. When projection inlining is active,
+// colExprMap records how to rebuild derived output columns.
+func restoreSchemaIfChanged(
+	p base.LogicalPlan,
+	originalSchema *expression.Schema,
+	colExprMap map[int64]expression.Expression,
+) (base.LogicalPlan, error) {
+	if p == nil || originalSchema == nil {
+		return p, nil
+	}
+
+	schemaChanged := false
+	if len(p.Schema().Columns) != len(originalSchema.Columns) {
+		schemaChanged = true
+	} else {
+		for i, col := range p.Schema().Columns {
+			if !col.EqualColumn(originalSchema.Columns[i]) {
+				schemaChanged = true
+				break
+			}
+		}
+	}
+	if !schemaChanged {
+		return p, nil
+	}
+
+	exprs := expression.Column2Exprs(originalSchema.Columns)
+	if len(colExprMap) > 0 {
+		for i, col := range originalSchema.Columns {
+			if expr, ok := colExprMap[col.UniqueID]; ok {
+				exprs[i] = expr
+				continue
+			}
+			if !p.Schema().Contains(col) {
+				return nil, plannererrors.ErrInternal.GenWithStack("join reorder: schema restore mapping missing after projection inlining")
+			}
+		}
+	}
+	proj := logicalop.LogicalProjection{
+		Exprs: exprs,
+	}.Init(p.SCtx(), p.QueryBlockOffset())
+	// Clone the schema here, because the schema may be changed by column pruning rules.
+	proj.SetSchema(originalSchema.Clone())
+	proj.SetChildren(p)
+	return proj, nil
 }
 
 // checkAndGenerateLeadingHint used to check and generate the valid leading hint.
@@ -406,6 +482,9 @@ type basicJoinGroupInfo struct {
 	eqEdges    []*expression.ScalarFunction
 	otherConds []expression.Expression
 	joinTypes  []*joinTypeWithExtMsg
+	// nullExtendedCols records columns that may become NULL due to outer joins
+	// in this join group.
+	nullExtendedCols *expression.Schema
 	// `joinMethodHintInfo` is used to map the sub-plan's ID to the join method hint.
 	// The sub-plan will join the join reorder process to build the new plan.
 	// So after we have finished the join reorder process, we can reset the join method hint based on the sub-plan's ID.
@@ -417,6 +496,9 @@ type joinGroupResult struct {
 	hasOuterJoin      bool
 	joinOrderHintInfo []*h.PlanHints
 	*basicJoinGroupInfo
+	// colExprMap maps projection output column UniqueID to the expression
+	// that computes it, after inlining a safe Projection over a Join.
+	colExprMap map[int64]expression.Expression
 }
 
 // nolint:structcheck
@@ -425,6 +507,19 @@ type baseSingleGroupJoinOrderSolver struct {
 	curJoinGroup     []*jrNode
 	leadingJoinGroup base.LogicalPlan
 	*basicJoinGroupInfo
+}
+
+func mergeColExprMap(dst, src map[int64]expression.Expression) map[int64]expression.Expression {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = make(map[int64]expression.Expression, len(src))
+	}
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }
 
 func (s *baseSingleGroupJoinOrderSolver) generateLeadingJoinGroup(curJoinGroup []base.LogicalPlan, hintInfo *h.PlanHints, hasOuterJoin bool, opt *optimizetrace.LogicalOptimizeOp) (bool, []base.LogicalPlan) {
@@ -529,50 +624,99 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 	joinType = &joinTypeWithExtMsg{JoinType: logicalop.InnerJoin}
 	leftNode, rightNode = leftPlan, rightPlan
 	for idx, edge := range s.eqEdges {
-		lCol := edge.GetArgs()[0].(*expression.Column)
-		rCol := edge.GetArgs()[1].(*expression.Column)
-		if leftPlan.Schema().Contains(lCol) && rightPlan.Schema().Contains(rCol) {
-			joinType = s.joinTypes[idx]
-			usedEdges = append(usedEdges, edge)
-		} else if rightPlan.Schema().Contains(lCol) && leftPlan.Schema().Contains(rCol) {
-			joinType = s.joinTypes[idx]
-			if joinType.JoinType != logicalop.InnerJoin {
-				rightNode, leftNode = leftPlan, rightPlan
-				usedEdges = append(usedEdges, edge)
-			} else {
-				funcName := edge.FuncName.L
-				newSf := expression.NewFunctionInternal(s.ctx.GetExprCtx(), funcName, edge.GetStaticType(), rCol, lCol).(*expression.ScalarFunction)
-
-				// after creating the new EQCondition function, the 2 args might not be column anymore, for example `sf=sf(cast(col))`,
-				// which breaks the assumption that join eq keys must be `col=col`, to handle this, inject 2 projections.
-				_, isCol0 := newSf.GetArgs()[0].(*expression.Column)
-				_, isCol1 := newSf.GetArgs()[1].(*expression.Column)
-				if !isCol0 || !isCol1 {
-					if !isCol0 {
-						leftPlan, rCol = s.injectExpr(leftPlan, newSf.GetArgs()[0])
-					}
-					if !isCol1 {
-						rightPlan, lCol = s.injectExpr(rightPlan, newSf.GetArgs()[1])
-					}
-					leftNode, rightNode = leftPlan, rightPlan
-					newSf = expression.NewFunctionInternal(s.ctx.GetExprCtx(), funcName, edge.GetStaticType(),
-						rCol, lCol).(*expression.ScalarFunction)
-				}
-				usedEdges = append(usedEdges, newSf)
-			}
+		lArg, rArg, lCols, rCols, ok := getEqEdgeArgsAndCols(edge)
+		if !ok {
+			continue
 		}
+		intest.Assert(len(lCols) > 0 && len(rCols) > 0)
+		if len(lCols) == 0 || len(rCols) == 0 {
+			continue
+		}
+
+		lExpr, rExpr, swapped, ok := alignJoinEdgeArgs(lArg, rArg, leftPlan.Schema(), rightPlan.Schema())
+		if !ok {
+			continue
+		}
+
+		joinType = s.joinTypes[idx]
+		if !swapped {
+			newEdge := s.buildJoinEdge(edge, lExpr, rExpr, &leftPlan, &rightPlan)
+			leftNode, rightNode = leftPlan, rightPlan
+			usedEdges = append(usedEdges, newEdge)
+			continue
+		}
+
+		if joinType.JoinType != logicalop.InnerJoin {
+			newEdge := s.buildJoinEdge(edge, lArg, rArg, &rightPlan, &leftPlan)
+			leftNode, rightNode = rightPlan, leftPlan
+			usedEdges = append(usedEdges, newEdge)
+			continue
+		}
+
+		newEdge := s.buildJoinEdge(edge, lExpr, rExpr, &leftPlan, &rightPlan)
+		leftNode, rightNode = leftPlan, rightPlan
+		usedEdges = append(usedEdges, newEdge)
 	}
 	return
 }
 
-func (*baseSingleGroupJoinOrderSolver) injectExpr(p base.LogicalPlan, expr expression.Expression) (base.LogicalPlan, *expression.Column) {
+func (s *baseSingleGroupJoinOrderSolver) buildJoinEdge(
+	originalEdge *expression.ScalarFunction,
+	lExpr, rExpr expression.Expression,
+	leftPlan, rightPlan *base.LogicalPlan,
+) *expression.ScalarFunction {
+	funcName := originalEdge.FuncName.L
+
+	lCol, lIsCol := lExpr.(*expression.Column)
+	rCol, rIsCol := rExpr.(*expression.Column)
+	if lIsCol && rIsCol {
+		return expression.NewFunctionInternal(s.ctx.GetExprCtx(), funcName, originalEdge.GetStaticType(), lCol, rCol).(*expression.ScalarFunction)
+	}
+
+	if !lIsCol {
+		*leftPlan, lCol = s.injectExpr(*leftPlan, lExpr)
+	}
+	if !rIsCol {
+		*rightPlan, rCol = s.injectExpr(*rightPlan, rExpr)
+	}
+	return expression.NewFunctionInternal(s.ctx.GetExprCtx(), funcName, originalEdge.GetStaticType(), lCol, rCol).(*expression.ScalarFunction)
+}
+
+func canReuseInjectedJoinExpr(expr expression.Expression) bool {
+	return !expression.IsMutableEffectsExpr(expr) && !expression.CheckNonDeterministic(expr)
+}
+
+func (s *baseSingleGroupJoinOrderSolver) injectExpr(p base.LogicalPlan, expr expression.Expression) (base.LogicalPlan, *expression.Column) {
+	originalPlanID := p.ID()
 	proj, ok := p.(*logicalop.LogicalProjection)
 	if !ok {
-		proj = logicalop.LogicalProjection{Exprs: cols2Exprs(p.Schema().Columns)}.Init(p.SCtx(), p.QueryBlockOffset())
+		proj = logicalop.LogicalProjection{Exprs: expression.Column2Exprs(p.Schema().Columns)}.Init(p.SCtx(), p.QueryBlockOffset())
 		proj.SetSchema(p.Schema().Clone())
 		proj.SetChildren(p)
+		s.propagateJoinMethodHint(originalPlanID, proj.ID())
+	}
+
+	substituted := expression.ColumnSubstitute(proj.SCtx().GetExprCtx(), expr, proj.Schema(), proj.Exprs)
+	if canReuseInjectedJoinExpr(substituted) {
+		for i, e := range proj.Exprs {
+			if expression.ExpressionsSemanticEqual(e, substituted) {
+				return proj, proj.Schema().Columns[i]
+			}
+		}
 	}
 	return proj, proj.AppendExpr(expr)
+}
+
+func (s *baseSingleGroupJoinOrderSolver) propagateJoinMethodHint(oldPlanID, newPlanID int) {
+	if s == nil || oldPlanID == newPlanID || len(s.joinMethodHintInfo) == 0 {
+		return
+	}
+	if _, exists := s.joinMethodHintInfo[newPlanID]; exists {
+		return
+	}
+	if hintInfo, ok := s.joinMethodHintInfo[oldPlanID]; ok {
+		s.joinMethodHintInfo[newPlanID] = hintInfo
+	}
 }
 
 // makeJoin build join tree for the nodes which have equal conditions to connect them.

--- a/pkg/planner/core/rule_join_reorder_dp.go
+++ b/pkg/planner/core/rule_join_reorder_dp.go
@@ -18,11 +18,11 @@ import (
 	"math/bits"
 
 	"github.com/pingcap/tidb/pkg/expression"
-	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace"
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
+	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
 type joinReorderDPSolver struct {
@@ -68,15 +68,26 @@ func (s *joinReorderDPSolver) solve(joinGroup []base.LogicalPlan, tracer *joinRe
 	// Build Graph for join group
 	for _, cond := range eqConds {
 		sf := cond.(*expression.ScalarFunction)
-		lCol := sf.GetArgs()[0].(*expression.Column)
-		rCol := sf.GetArgs()[1].(*expression.Column)
-		lIdx, err := findNodeIndexInGroup(joinGroup, lCol)
+		lArg := sf.GetArgs()[0]
+		rArg := sf.GetArgs()[1]
+		lCols := expression.ExtractColumns(lArg)
+		rCols := expression.ExtractColumns(rArg)
+		intest.Assert(len(lCols) > 0 && len(rCols) > 0)
+		if len(lCols) == 0 || len(rCols) == 0 {
+			return nil, plannererrors.ErrInternal.GenWithStack("join reorder dp: eq edge has empty column list")
+		}
+
+		lIdx, err := findNodeIndexForColumns(joinGroup, lCols)
 		if err != nil {
 			return nil, err
 		}
-		rIdx, err := findNodeIndexInGroup(joinGroup, rCol)
+		rIdx, err := findNodeIndexForColumns(joinGroup, rCols)
 		if err != nil {
 			return nil, err
+		}
+		intest.Assert(lIdx != rIdx)
+		if lIdx == rIdx {
+			return nil, plannererrors.ErrInternal.GenWithStack("join reorder dp: eq edge doesn't connect two join-group nodes")
 		}
 		addEqEdge(lIdx, rIdx, sf)
 	}
@@ -252,16 +263,15 @@ func (*joinReorderDPSolver) nodesAreConnected(leftMask, rightMask uint, oldPos2N
 }
 
 func (s *joinReorderDPSolver) newJoinWithEdge(leftPlan, rightPlan base.LogicalPlan, edges []joinGroupEqEdge, otherConds []expression.Expression, opt *optimizetrace.LogicalOptimizeOp) (base.LogicalPlan, error) {
-	var eqConds []*expression.ScalarFunction
+	eqConds := make([]*expression.ScalarFunction, 0, len(edges))
 	for _, edge := range edges {
-		lCol := edge.edge.GetArgs()[0].(*expression.Column)
-		rCol := edge.edge.GetArgs()[1].(*expression.Column)
-		if leftPlan.Schema().Contains(lCol) {
-			eqConds = append(eqConds, edge.edge)
-		} else {
-			newSf := expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.edge.GetStaticType(), rCol, lCol).(*expression.ScalarFunction)
-			eqConds = append(eqConds, newSf)
+		lArg := edge.edge.GetArgs()[0]
+		rArg := edge.edge.GetArgs()[1]
+		lExpr, rExpr, _, ok := alignJoinEdgeArgs(lArg, rArg, leftPlan.Schema(), rightPlan.Schema())
+		if !ok {
+			return nil, plannererrors.ErrInternal.GenWithStack("join reorder dp: eq edge doesn't connect left/right plans")
 		}
+		eqConds = append(eqConds, s.buildJoinEdge(edge.edge, lExpr, rExpr, &leftPlan, &rightPlan))
 	}
 	join := s.newJoin(leftPlan, rightPlan, eqConds, otherConds, nil, nil, logicalop.InnerJoin, opt)
 	_, err := join.RecursiveDeriveStats(nil)
@@ -299,4 +309,25 @@ func findNodeIndexInGroup(group []base.LogicalPlan, col *expression.Column) (int
 		}
 	}
 	return -1, plannererrors.ErrUnknownColumn.GenWithStackByArgs(col, "JOIN REORDER RULE")
+}
+
+func findNodeIndexForColumns(group []base.LogicalPlan, cols []*expression.Column) (int, error) {
+	if len(cols) == 0 {
+		return -1, plannererrors.ErrUnknownColumn.GenWithStackByArgs("empty column list", "JOIN REORDER RULE")
+	}
+
+	firstIdx, err := findNodeIndexInGroup(group, cols[0])
+	if err != nil {
+		return -1, err
+	}
+	for _, col := range cols[1:] {
+		idx, err := findNodeIndexInGroup(group, col)
+		if err != nil {
+			return -1, err
+		}
+		if idx != firstIdx {
+			return -1, plannererrors.ErrUnknownColumn.GenWithStackByArgs(col, "JOIN REORDER RULE: columns span multiple nodes")
+		}
+	}
+	return firstIdx, nil
 }

--- a/pkg/planner/core/rule_join_reorder_dp_test.go
+++ b/pkg/planner/core/rule_join_reorder_dp_test.go
@@ -238,3 +238,276 @@ func TestDPReorderAllCartesian(t *testing.T) {
 	expected := "MockJoin{MockJoin{a, b}, MockJoin{c, d}}"
 	require.Equal(t, expected, planToString(result))
 }
+
+func TestInjectedJoinExprMaterializationSafety(t *testing.T) {
+	ctx := MockContext()
+	defer func() {
+		domain.GetDomain(ctx).StatsHandle().Close()
+	}()
+	ctx.GetSessionVars().PlanID.Store(-1)
+
+	makeRandPlusCol := func(col *expression.Column) expression.Expression {
+		randExpr := expression.NewFunctionInternal(ctx, ast.Rand, types.NewFieldType(mysql.TypeDouble))
+		return expression.NewFunctionInternal(ctx, ast.Plus, types.NewFieldType(mysql.TypeDouble), randExpr, col)
+	}
+
+	t.Run("repeated rand expressions are not reused", func(t *testing.T) {
+		solver := &baseSingleGroupJoinOrderSolver{
+			ctx:                ctx,
+			basicJoinGroupInfo: &basicJoinGroupInfo{},
+		}
+		plan := newDataSource(ctx, "t", 1)
+		baseCol := plan.Schema().Columns[0]
+
+		expr1 := makeRandPlusCol(baseCol)
+		expr2 := makeRandPlusCol(baseCol)
+		require.True(t, expression.ExpressionsSemanticEqual(expr1, expr2))
+
+		plan, injected1 := solver.injectExpr(plan, expr1)
+		plan, injected2 := solver.injectExpr(plan, expr2)
+
+		proj, ok := plan.(*logicalop.LogicalProjection)
+		require.True(t, ok)
+		require.Len(t, proj.Exprs, 3)
+		require.NotEqual(t, injected1.UniqueID, injected2.UniqueID)
+	})
+
+	t.Run("existing projection append keeps expression in child space", func(t *testing.T) {
+		solver := &baseSingleGroupJoinOrderSolver{
+			ctx:                ctx,
+			basicJoinGroupInfo: &basicJoinGroupInfo{},
+		}
+		plan := newDataSource(ctx, "p", 1)
+		baseCol := plan.Schema().Columns[0]
+
+		proj := logicalop.LogicalProjection{Exprs: expression.Column2Exprs(plan.Schema().Columns)}.Init(ctx, 0)
+		proj.SetSchema(plan.Schema().Clone())
+		proj.SetChildren(plan)
+
+		derivedExpr := expression.NewFunctionInternal(ctx, ast.Plus, types.NewFieldType(mysql.TypeLonglong), baseCol, expression.NewOne())
+		derivedCol := proj.AppendExpr(derivedExpr)
+
+		exprUsingProjOutput := expression.NewFunctionInternal(ctx, ast.Plus, types.NewFieldType(mysql.TypeLonglong), derivedCol, expression.NewOne())
+		newPlan, injectedCol := solver.injectExpr(proj, exprUsingProjOutput)
+
+		newProj, ok := newPlan.(*logicalop.LogicalProjection)
+		require.True(t, ok)
+		require.NotNil(t, injectedCol)
+		require.Len(t, newProj.Exprs, 3)
+
+		appendedExpr := newProj.Exprs[2]
+		expectedExpr := expression.NewFunctionInternal(
+			ctx,
+			ast.Plus,
+			types.NewFieldType(mysql.TypeLonglong),
+			derivedExpr,
+			expression.NewOne(),
+		)
+		require.True(t, expression.ExpressionsSemanticEqual(appendedExpr, expectedExpr))
+
+		appendedCols := expression.ExtractColumns(appendedExpr)
+		require.Len(t, appendedCols, 1)
+		require.Equal(t, baseCol.UniqueID, appendedCols[0].UniqueID)
+	})
+}
+
+func TestSubstituteColsInExprPreservesInOperand(t *testing.T) {
+	ctx := MockContext()
+	defer func() {
+		domain.GetDomain(ctx).StatsHandle().Close()
+	}()
+
+	baseCol := &expression.Column{
+		UniqueID: ctx.GetSessionVars().AllocPlanColumnID(),
+		RetType:  types.NewFieldType(mysql.TypeLonglong),
+	}
+	projectedCol := &expression.Column{
+		UniqueID:  ctx.GetSessionVars().AllocPlanColumnID(),
+		RetType:   types.NewFieldType(mysql.TypeLonglong),
+		InOperand: true,
+	}
+	rhsCol := &expression.Column{
+		UniqueID: ctx.GetSessionVars().AllocPlanColumnID(),
+		RetType:  types.NewFieldType(mysql.TypeLonglong),
+	}
+	eqCond := expression.NewFunctionInternal(ctx, ast.EQ, types.NewFieldType(mysql.TypeTiny), projectedCol, rhsCol)
+	require.True(t, expression.IsEQCondFromIn(eqCond))
+
+	substituted := substituteColsInExpr(eqCond, map[int64]expression.Expression{
+		projectedCol.UniqueID: baseCol,
+	})
+	require.True(t, expression.IsEQCondFromIn(substituted))
+	require.False(t, baseCol.InOperand)
+
+	substitutedArg := substituted.(*expression.ScalarFunction).GetArgs()[0].(*expression.Column)
+	require.Equal(t, baseCol.UniqueID, substitutedArg.UniqueID)
+	require.True(t, substitutedArg.InOperand)
+
+	mappedExpr := expression.NewFunctionInternal(ctx, ast.Plus, types.NewFieldType(mysql.TypeLonglong), baseCol, expression.NewOne())
+	colExprMap := map[int64]expression.Expression{
+		projectedCol.UniqueID: mappedExpr,
+	}
+
+	substitutedFromIn := substituteColsInExpr(eqCond, colExprMap)
+	require.True(t, expression.IsEQCondFromIn(substitutedFromIn))
+	require.False(t, expression.ExtractColumns(mappedExpr)[0].InOperand)
+
+	normalProjectedCol := projectedCol.Clone().(*expression.Column)
+	normalProjectedCol.InOperand = false
+	normalEqCond := expression.NewFunctionInternal(ctx, ast.EQ, types.NewFieldType(mysql.TypeTiny), normalProjectedCol, rhsCol)
+	normalSubstituted := substituteColsInExpr(normalEqCond, colExprMap)
+	require.False(t, expression.IsEQCondFromIn(normalSubstituted))
+}
+
+func TestJoinReorderProjectionInlineSafety(t *testing.T) {
+	ctx := MockContext()
+	defer func() {
+		domain.GetDomain(ctx).StatsHandle().Close()
+	}()
+	ctx.GetSessionVars().PlanID.Store(-1)
+
+	newJoin := func(joinType logicalop.JoinType, left, right base.LogicalPlan) *logicalop.LogicalJoin {
+		join := logicalop.LogicalJoin{JoinType: joinType}.Init(ctx, 0)
+		join.SetSchema(expression.MergeSchema(left.Schema(), right.Schema()))
+		join.SetChildren(left, right)
+		return join
+	}
+
+	newProjection := func(child base.LogicalPlan, exprs ...expression.Expression) *logicalop.LogicalProjection {
+		proj := logicalop.LogicalProjection{Exprs: exprs}.Init(ctx, 0)
+		schema := expression.NewSchema()
+		for _, expr := range exprs {
+			col := &expression.Column{
+				UniqueID: ctx.GetSessionVars().AllocPlanColumnID(),
+				RetType:  expr.GetType(ctx.GetExprCtx().GetEvalCtx()).Clone(),
+			}
+			col.SetCoercibility(expr.Coercibility())
+			col.SetRepertoire(expr.Repertoire())
+			schema.Append(col)
+		}
+		proj.SetSchema(schema)
+		proj.SetChildren(child)
+		return proj
+	}
+
+	t.Run("selection rejects non-deterministic predicates", func(t *testing.T) {
+		left := newDataSource(ctx, "sel_l", 10)
+		right := newDataSource(ctx, "sel_r", 10)
+		join := newJoin(logicalop.InnerJoin, left, right)
+
+		old := ctx.GetSessionVars().TiDBOptJoinReorderThroughSel
+		ctx.GetSessionVars().TiDBOptJoinReorderThroughSel = true
+		t.Cleanup(func() {
+			ctx.GetSessionVars().TiDBOptJoinReorderThroughSel = old
+		})
+
+		foundRows := expression.NewFunctionInternal(ctx, ast.FoundRows, types.NewFieldType(mysql.TypeLonglong))
+		pred := expression.NewFunctionInternal(ctx, ast.EQ, types.NewFieldType(mysql.TypeTiny), foundRows, expression.NewOne())
+		sel := logicalop.LogicalSelection{Conditions: []expression.Expression{pred}}.Init(ctx, 0)
+		sel.SetChildren(join)
+
+		result := extractJoinGroup(sel)
+		require.Len(t, result.group, 1)
+		require.Same(t, sel, result.group[0])
+	})
+
+	t.Run("projection rejects non-deterministic expressions", func(t *testing.T) {
+		left := newDataSource(ctx, "basic_l", 10)
+		right := newDataSource(ctx, "basic_r", 10)
+		join := newJoin(logicalop.InnerJoin, left, right)
+
+		foundRows := expression.NewFunctionInternal(ctx, ast.FoundRows, types.NewFieldType(mysql.TypeLonglong))
+		expr := expression.NewFunctionInternal(
+			ctx,
+			ast.Plus,
+			types.NewFieldType(mysql.TypeLonglong),
+			left.Schema().Columns[0],
+			foundRows,
+		)
+		proj := newProjection(join, expr)
+		require.False(t, canInlineProjectionBasic(proj))
+	})
+
+	t.Run("projection rejects cross-leaf expressions", func(t *testing.T) {
+		left := newDataSource(ctx, "cross_l", 10)
+		right := newDataSource(ctx, "cross_r", 10)
+		join := newJoin(logicalop.InnerJoin, left, right)
+
+		expr := expression.NewFunctionInternal(
+			ctx,
+			ast.Plus,
+			types.NewFieldType(mysql.TypeLonglong),
+			left.Schema().Columns[0],
+			right.Schema().Columns[0],
+		)
+		proj := newProjection(join, expr)
+		require.True(t, canInlineProjectionBasic(proj))
+		require.False(t, canInlineProjection(proj, &joinGroupResult{
+			group:              []base.LogicalPlan{left, right},
+			basicJoinGroupInfo: &basicJoinGroupInfo{},
+		}))
+	})
+
+	t.Run("projection rejects null-extended expressions", func(t *testing.T) {
+		left := newDataSource(ctx, "outer_l", 10)
+		right := newDataSource(ctx, "outer_r", 10)
+		join := newJoin(logicalop.LeftOuterJoin, left, right)
+
+		expr := expression.NewFunctionInternal(
+			ctx,
+			ast.Plus,
+			types.NewFieldType(mysql.TypeLonglong),
+			right.Schema().Columns[0],
+			expression.NewOne(),
+		)
+		proj := newProjection(join, expr)
+		require.True(t, canInlineProjectionBasic(proj))
+		require.False(t, canInlineProjection(proj, &joinGroupResult{
+			group: []base.LogicalPlan{left, right},
+			basicJoinGroupInfo: &basicJoinGroupInfo{
+				nullExtendedCols: expression.NewSchema(right.Schema().Columns...),
+			},
+		}))
+	})
+
+	t.Run("safe single-leaf projection is inlined", func(t *testing.T) {
+		left := newDataSource(ctx, "inline_l", 10)
+		right := newDataSource(ctx, "inline_r", 10)
+		join := newJoin(logicalop.InnerJoin, left, right)
+
+		expr := expression.NewFunctionInternal(
+			ctx,
+			ast.Plus,
+			types.NewFieldType(mysql.TypeLonglong),
+			left.Schema().Columns[0],
+			expression.NewOne(),
+		)
+		proj := newProjection(join, expr)
+
+		result, handled := tryInlineProjectionForJoinGroup(proj, proj)
+		require.True(t, handled)
+		require.Len(t, result.group, 2)
+		require.Contains(t, result.colExprMap, proj.Schema().Columns[0].UniqueID)
+		require.True(t, expression.ExpressionsSemanticEqual(result.colExprMap[proj.Schema().Columns[0].UniqueID], expr))
+	})
+
+	t.Run("unsafe cross-leaf projection remains atomic", func(t *testing.T) {
+		left := newDataSource(ctx, "atomic_l", 10)
+		right := newDataSource(ctx, "atomic_r", 10)
+		join := newJoin(logicalop.InnerJoin, left, right)
+
+		expr := expression.NewFunctionInternal(
+			ctx,
+			ast.Plus,
+			types.NewFieldType(mysql.TypeLonglong),
+			left.Schema().Columns[0],
+			right.Schema().Columns[0],
+		)
+		proj := newProjection(join, expr)
+
+		result, handled := tryInlineProjectionForJoinGroup(proj, proj)
+		require.True(t, handled)
+		require.Len(t, result.group, 1)
+		require.Same(t, proj, result.group[0])
+	})
+}

--- a/pkg/planner/core/rule_join_reorder_projection_inline.go
+++ b/pkg/planner/core/rule_join_reorder_projection_inline.go
@@ -1,0 +1,312 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/planner/core/base"
+	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
+)
+
+// tryInlineProjectionForJoinGroup tries to extract the join group through a Projection on top of a Join.
+//
+// It returns (result, true) when the Projection node is handled:
+//   - inlined successfully, or
+//   - determined unsafe to inline and kept as an atomic leaf.
+//
+// It returns (nil, false) when the caller should continue with normal extractJoinGroupImpl logic.
+func tryInlineProjectionForJoinGroup(p base.LogicalPlan, proj *logicalop.LogicalProjection) (*joinGroupResult, bool) {
+	child := proj.Children()[0]
+	if _, isJoin := child.(*logicalop.LogicalJoin); !isJoin {
+		return nil, false
+	}
+
+	if !canInlineProjectionBasic(proj) {
+		return nil, false
+	}
+
+	childResult := extractJoinGroupImpl(child)
+	if !canInlineProjection(proj, childResult) {
+		return &joinGroupResult{
+			group:              []base.LogicalPlan{p},
+			basicJoinGroupInfo: &basicJoinGroupInfo{},
+		}, true
+	}
+
+	childResult.colExprMap = buildColExprMapForProjection(proj, childResult.colExprMap)
+	return childResult, true
+}
+
+func buildColExprMapForProjection(
+	proj *logicalop.LogicalProjection,
+	childColExprMap map[int64]expression.Expression,
+) map[int64]expression.Expression {
+	colExprMap := make(map[int64]expression.Expression, len(proj.Schema().Columns)+len(childColExprMap))
+	for i, outCol := range proj.Schema().Columns {
+		expr := proj.Exprs[i]
+		if len(childColExprMap) > 0 {
+			expr = substituteColsInExpr(expr, childColExprMap)
+		}
+		if colExpr, isCol := expr.(*expression.Column); isCol && colExpr.UniqueID == outCol.UniqueID {
+			continue
+		}
+		colExprMap[outCol.UniqueID] = expr
+	}
+
+	for k, v := range childColExprMap {
+		if _, exists := colExprMap[k]; !exists {
+			colExprMap[k] = v
+		}
+	}
+	return colExprMap
+}
+
+func isInlineableProjectionExpr(expr expression.Expression) bool {
+	switch x := expr.(type) {
+	case *expression.Column:
+		return true
+	case *expression.ScalarFunction:
+		for _, arg := range x.GetArgs() {
+			if !isInlineableProjectionExpr(arg) {
+				return false
+			}
+		}
+		return true
+	case *expression.Constant:
+		return x.DeferredExpr == nil
+	default:
+		return false
+	}
+}
+
+func canInlineProjectionBasic(proj *logicalop.LogicalProjection) bool {
+	if proj.Proj4Expand {
+		return false
+	}
+
+	for _, expr := range proj.Exprs {
+		if len(expression.ExtractColumns(expr)) == 0 {
+			return false
+		}
+		if !isInlineableProjectionExpr(expr) {
+			return false
+		}
+		if expression.IsMutableEffectsExpr(expr) || expression.CheckNonDeterministic(expr) || expr.IsCorrelated() {
+			return false
+		}
+	}
+	return true
+}
+
+func canInlineProjection(proj *logicalop.LogicalProjection, childResult *joinGroupResult) bool {
+	if childResult == nil {
+		return false
+	}
+
+	leafByColID := make(map[int64]int)
+	for leafIdx, leaf := range childResult.group {
+		for _, col := range leaf.Schema().Columns {
+			if prev, ok := leafByColID[col.UniqueID]; ok && prev != leafIdx {
+				return false
+			}
+			leafByColID[col.UniqueID] = leafIdx
+		}
+	}
+
+	for _, expr := range proj.Exprs {
+		checkExpr := expr
+		if len(childResult.colExprMap) > 0 {
+			checkExpr = substituteColsInExpr(checkExpr, childResult.colExprMap)
+		}
+		if childResult.nullExtendedCols != nil && expression.ExprReferenceSchema(checkExpr, childResult.nullExtendedCols) {
+			// Values from a null-extended side are produced by the outer join itself, so
+			// treating them as ordinary leaf-local expressions can change SQL semantics.
+			return false
+		}
+
+		cols := expression.ExtractColumns(checkExpr)
+		if len(cols) == 0 {
+			return false
+		}
+
+		leafIdx := -1
+		for _, col := range cols {
+			idx, ok := leafByColID[col.UniqueID]
+			if !ok {
+				return false
+			}
+			if leafIdx == -1 {
+				leafIdx = idx
+				continue
+			}
+			if idx != leafIdx {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+type exprReplacer func(expr expression.Expression) (newExpr expression.Expression, replaced bool)
+
+func rewriteExprTree(expr expression.Expression, replace exprReplacer) expression.Expression {
+	if expr == nil {
+		return nil
+	}
+
+	if replace != nil {
+		if newExpr, replaced := replace(expr); replaced {
+			if newExpr == nil {
+				return nil
+			}
+			if newExpr != expr {
+				return rewriteExprTree(newExpr, replace)
+			}
+		}
+	}
+
+	sf, ok := expr.(*expression.ScalarFunction)
+	if !ok {
+		return expr
+	}
+
+	oldArgs := sf.GetArgs()
+	var newArgs []expression.Expression
+	for i, arg := range oldArgs {
+		rewrittenArg := rewriteExprTree(arg, replace)
+		if newArgs == nil {
+			if rewrittenArg == arg {
+				continue
+			}
+			newArgs = make([]expression.Expression, len(oldArgs))
+			copy(newArgs, oldArgs[:i])
+		}
+		newArgs[i] = rewrittenArg
+	}
+	if newArgs == nil {
+		return sf
+	}
+
+	newSf := sf.Clone().(*expression.ScalarFunction)
+	args := newSf.GetArgs()
+	for i := range args {
+		args[i] = newArgs[i]
+	}
+	newSf.CleanHashCode()
+	return newSf
+}
+
+func substituteColsInEqEdges(edges []*expression.ScalarFunction, colExprMap map[int64]expression.Expression) []*expression.ScalarFunction {
+	result := make([]*expression.ScalarFunction, 0, len(edges))
+	for _, edge := range edges {
+		// substituteColsInExpr only rewrites columns inside the edge, so the
+		// top-level equality function must remain a scalar function.
+		result = append(result, substituteColsInExpr(edge, colExprMap).(*expression.ScalarFunction))
+	}
+	return result
+}
+
+func substituteColsInExprs(exprs []expression.Expression, colExprMap map[int64]expression.Expression) []expression.Expression {
+	result := make([]expression.Expression, 0, len(exprs))
+	for _, expr := range exprs {
+		result = append(result, substituteColsInExpr(expr, colExprMap))
+	}
+	return result
+}
+
+func substituteColsInExpr(expr expression.Expression, colExprMap map[int64]expression.Expression) expression.Expression {
+	if len(colExprMap) == 0 {
+		return expr
+	}
+	return rewriteExprTree(expr, func(e expression.Expression) (expression.Expression, bool) {
+		col, ok := e.(*expression.Column)
+		if !ok {
+			return e, false
+		}
+		if defExpr, ok := colExprMap[col.UniqueID]; ok {
+			if col.InOperand {
+				return expression.SetExprColumnInOperand(defExpr.Clone()), true
+			}
+			return defExpr, true
+		}
+		return e, false
+	})
+}
+
+func outerJoinSideFiltersTouchMultipleLeaves(
+	join *logicalop.LogicalJoin,
+	outerGroup []base.LogicalPlan,
+	outerColExprMap map[int64]expression.Expression,
+	outerIsLeft bool,
+) bool {
+	checkOtherConds := join.OtherConditions
+	checkSideConds := join.RightConditions
+	if outerIsLeft {
+		checkSideConds = join.LeftConditions
+	}
+	checkEQConds := expression.ScalarFuncs2Exprs(join.EqualConditions)
+
+	if len(outerColExprMap) > 0 {
+		checkOtherConds = substituteColsInExprs(checkOtherConds, outerColExprMap)
+		checkSideConds = substituteColsInExprs(checkSideConds, outerColExprMap)
+		checkEQConds = substituteColsInExprs(checkEQConds, outerColExprMap)
+	}
+
+	extractedCols := make([]*expression.Column, 0, 8)
+	extractedCols = expression.ExtractColumnsFromExpressions(extractedCols, checkOtherConds, nil)
+	extractedCols = expression.ExtractColumnsFromExpressions(extractedCols, checkSideConds, nil)
+	extractedCols = expression.ExtractColumnsFromExpressions(extractedCols, checkEQConds, nil)
+
+	affectedGroups := 0
+	for _, outerLeaf := range outerGroup {
+		for _, col := range extractedCols {
+			if outerLeaf.Schema().Contains(col) {
+				affectedGroups++
+				break
+			}
+		}
+		if affectedGroups > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func getEqEdgeArgsAndCols(edge *expression.ScalarFunction) (lArg, rArg expression.Expression, lCols, rCols []*expression.Column, ok bool) {
+	if edge == nil {
+		return nil, nil, nil, nil, false
+	}
+	args := edge.GetArgs()
+	if len(args) != 2 {
+		return nil, nil, nil, nil, false
+	}
+	lArg, rArg = args[0], args[1]
+	lCols = expression.ExtractColumns(lArg)
+	rCols = expression.ExtractColumns(rArg)
+	return lArg, rArg, lCols, rCols, true
+}
+
+func alignJoinEdgeArgs(
+	lArg, rArg expression.Expression,
+	leftSchema, rightSchema *expression.Schema,
+) (lExpr, rExpr expression.Expression, swapped, ok bool) {
+	if expression.ExprFromSchema(lArg, leftSchema) && expression.ExprFromSchema(rArg, rightSchema) {
+		return lArg, rArg, false, true
+	}
+	if expression.ExprFromSchema(lArg, rightSchema) && expression.ExprFromSchema(rArg, leftSchema) {
+		return rArg, lArg, true, true
+	}
+	return nil, nil, false, false
+}

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1178,6 +1178,9 @@ type SessionVars struct {
 	// TiDBOptEnableAdvancedJoinReorder controls whether to use the advanced join reorder framework.
 	TiDBOptEnableAdvancedJoinReorder bool
 
+	// TiDBOptJoinReorderThroughProj enables join reorder to look through projections.
+	TiDBOptJoinReorderThroughProj bool
+
 	// TiDBOptJoinReorderThroughSel enables pushing selection conditions down to
 	// reordered join trees when applicable.
 	TiDBOptJoinReorderThroughSel bool
@@ -2234,6 +2237,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		IndexJoinCostFactor:           DefOptIndexJoinCostFactor,
 		CommandValue:                  uint32(mysql.ComSleep),
 		TiDBOptJoinReorderThreshold:   DefTiDBOptJoinReorderThreshold,
+		TiDBOptJoinReorderThroughProj: DefTiDBOptJoinReorderThroughProj,
 		TiDBOptJoinReorderThroughSel:  DefTiDBOptJoinReorderThroughSel,
 		SlowQueryFile:                 config.GetGlobalConfig().Log.SlowQueryFile,
 		WaitSplitRegionFinish:         DefTiDBWaitSplitRegionFinish,

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2415,6 +2415,10 @@ var defaultSysVars = []*SysVar{
 		s.TiDBOptEnableAdvancedJoinReorder = TiDBOptOn(val)
 		return nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBOptJoinReorderThroughProj, Value: BoolToOnOff(DefTiDBOptJoinReorderThroughProj), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.TiDBOptJoinReorderThroughProj = TiDBOptOn(val)
+		return nil
+	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBOptJoinReorderThroughSel, Value: BoolToOnOff(DefTiDBOptJoinReorderThroughSel), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
 		s.TiDBOptJoinReorderThroughSel = TiDBOptOn(val)
 		return nil

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -614,6 +614,10 @@ const (
 	// TiDBOptEnableAdvancedJoinReorder controls whether to use the advanced join reorder framework.
 	TiDBOptEnableAdvancedJoinReorder = "tidb_opt_enable_advanced_join_reorder"
 
+	// TiDBOptJoinReorderThroughProj enables join reorder to look through projection operators
+	// when extracting join groups.
+	TiDBOptJoinReorderThroughProj = "tidb_opt_join_reorder_through_proj"
+
 	// TiDBOptJoinReorderThroughSel indicates whether join reorder considers
 	// joins through selection, allowing more flexible join ordering.
 	TiDBOptJoinReorderThroughSel = "tidb_opt_join_reorder_through_sel"
@@ -1428,6 +1432,7 @@ const (
 	DefEnableVectorizedExpression           = true
 	DefTiDBOptJoinReorderThreshold          = 0
 	DefTiDBOptEnableAdvancedJoinReorder     = true
+	DefTiDBOptJoinReorderThroughProj        = false
 	DefTiDBOptJoinReorderThroughSel         = false
 	DefTiDBDDLSlowOprThreshold              = 300
 	DefTiDBUseFastAnalyze                   = false

--- a/tests/integrationtest/r/planner/core/cbo.result
+++ b/tests/integrationtest/r/planner/core/cbo.result
@@ -66,16 +66,16 @@ create table t2(a int, b int);
 insert into t1 values (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 4), (5, 5, 5);
 insert into t2 values (2, 22), (3, 33), (5, 55), (233, 2), (333, 3), (3434, 5);
 analyze table t1, t2 all columns;
-explain analyze select t1.a, t1.b, sum(t1.c) from t1 join t2 on t1.a = t2.b where t1.a > 1;
+explain analyze format='brief' select t1.a, t1.b, sum(t1.c) from t1 join t2 on t1.a = t2.b where t1.a > 1;
 id	estRows	actRows	task	access object	execution info	operator info	memory	disk
-Projection_9	1.00	1	root	NULL	time:<num>, loops:<num>, RU:<num>, Concurrency:OFF	planner__core__cbo.t1.a, planner__core__cbo.t1.b, Column#8	<num>	N/A
-└─StreamAgg_11	1.00	1	root	NULL	time:<num>, loops:<num>	funcs:sum(Column#16)->Column#8, funcs:firstrow(Column#17)->planner__core__cbo.t1.a, funcs:firstrow(Column#18)->planner__core__cbo.t1.b	<num>	N/A
-  └─Projection_53	4.00	3	root	NULL	time:<num>, loops:<num>, Concurrency:OFF	cast(planner__core__cbo.t1.c, decimal(10,0) BINARY)->Column#16, planner__core__cbo.t1.a->Column#17, planner__core__cbo.t1.b->Column#18	<num>	N/A
-    └─HashJoin_51	4.00	3	root	NULL	time:<num>, loops:<num>, build_hash_table:{total:<num>, fetch:<num>, build:<num>}, probe:{concurrency:<num>, total:<num>, max:<num>, probe:<num>, fetch and wait:<num>}	inner join, equal:[eq(planner__core__cbo.t1.a, planner__core__cbo.t2.b)]	<num>	<num>
-      ├─TableReader_30(Build)	6.00	6	root	NULL	time.*loops.*cop_task.*	data:Selection_29	<num>	N/A
-      │ └─Selection_29	6.00	6	cop[tikv]	NULL	tikv_task:{time:<num>, loops:<num>}	gt(planner__core__cbo.t2.b, 1), not(isnull(planner__core__cbo.t2.b))	N/A	N/A
-      │   └─TableFullScan_28	6.00	6	cop[tikv]	table:t2	tikv_task:{time:<num>, loops:<num>}	keep order:false	N/A	N/A
-      └─TableReader_33(Probe)	4.00	4	root	NULL	time.*loops.*cop_task.*	data:Selection_32	<num>	N/A
-        └─Selection_32	4.00	4	cop[tikv]	NULL	tikv_task:{time:<num>, loops:<num>}	gt(planner__core__cbo.t1.a, 1), not(isnull(planner__core__cbo.t1.a))	N/A	N/A
-          └─TableFullScan_31	5.00	5	cop[tikv]	table:t1	tikv_task:{time:<num>, loops:<num>}	keep order:false	N/A	N/A
+Projection	1.00	1	root	NULL	time:<num>, loops:<num>, RU:<num>, Concurrency:OFF	planner__core__cbo.t1.a, planner__core__cbo.t1.b, Column#8	<num>	N/A
+└─StreamAgg	1.00	1	root	NULL	time:<num>, loops:<num>	funcs:sum(Column#16)->Column#8, funcs:firstrow(Column#17)->planner__core__cbo.t1.a, funcs:firstrow(Column#18)->planner__core__cbo.t1.b	<num>	N/A
+  └─Projection	4.00	3	root	NULL	time:<num>, loops:<num>, Concurrency:OFF	cast(planner__core__cbo.t1.c, decimal(10,0) BINARY)->Column#16, planner__core__cbo.t1.a->Column#17, planner__core__cbo.t1.b->Column#18	<num>	N/A
+    └─HashJoin	4.00	3	root	NULL	time:<num>, loops:<num>, build_hash_table:{total:<num>, fetch:<num>, build:<num>}, probe:{concurrency:<num>, total:<num>, max:<num>, probe:<num>, fetch and wait:<num>}	inner join, equal:[eq(planner__core__cbo.t1.a, planner__core__cbo.t2.b)]	<num>	<num>
+      ├─TableReader(Build)	6.00	6	root	NULL	time.*loops.*cop_task.*	data:Selection	<num>	N/A
+      │ └─Selection	6.00	6	cop[tikv]	NULL	tikv_task:{time:<num>, loops:<num>}	gt(planner__core__cbo.t2.b, 1), not(isnull(planner__core__cbo.t2.b))	N/A	N/A
+      │   └─TableFullScan	6.00	6	cop[tikv]	table:t2	tikv_task:{time:<num>, loops:<num>}	keep order:false	N/A	N/A
+      └─TableReader(Probe)	4.00	4	root	NULL	time.*loops.*cop_task.*	data:Selection	<num>	N/A
+        └─Selection	4.00	4	cop[tikv]	NULL	tikv_task:{time:<num>, loops:<num>}	gt(planner__core__cbo.t1.a, 1), not(isnull(planner__core__cbo.t1.a))	N/A	N/A
+          └─TableFullScan	5.00	5	cop[tikv]	table:t1	tikv_task:{time:<num>, loops:<num>}	keep order:false	N/A	N/A
 set sql_mode=default;

--- a/tests/integrationtest/r/planner/core/join_reorder_through_projection.result
+++ b/tests/integrationtest/r/planner/core/join_reorder_through_projection.result
@@ -1,0 +1,2368 @@
+drop table if exists t1, t2, t3, t4, t5;
+create table t1(a int, b int, c varchar(32), primary key (a), key(b));
+create table t2(a int, b int, c varchar(32), primary key (a), key(b));
+create table t3(a int, b int, c varchar(32), primary key (a), key(b));
+create table t4(a int, b int, c varchar(32), primary key (a), key(b));
+create table t5(a int, b int, c varchar(32), primary key (a), key(b));
+insert into t1 values(1, 10, 'a1'), (2, 20, 'a2'), (3, 30, 'a3'), (4, 200, 'a4');
+insert into t2 values(1, 100, 'b1'), (2, 200, 'b2'), (3, 300, 'b3');
+insert into t3 values(1, 1000, 'c1'), (2, 2000, 'c2'), (3, 3000, 'c3');
+insert into t4 values(1, 10000, 'd1'), (2, 20000, 'd2'), (3, 30000, 'd3');
+insert into t5 values(1, 10, 'e1'), (2, 20, 'e2'), (3, 30, 'e3'), (4, 40, 'e4');
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.doubled_b, dt.shifted_b from t1,
+(select t2.a as a2, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10, plus(planner__core__join_reorder_through_projection.t3.b, 100)->Column#11
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.doubled_b, dt.shifted_b from t1,
+(select t2.a as a2, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2
+order by 1;
+a	doubled_b	shifted_b
+1	200	1100
+2	400	2100
+3	600	3100
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.doubled_b, dt.shifted_b from t1,
+(select t2.a as a2, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10, plus(planner__core__join_reorder_through_projection.t3.b, 100)->Column#11
+└─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.doubled_b, dt.shifted_b from t1,
+(select t2.a as a2, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2
+order by 1;
+a	doubled_b	shifted_b
+1	200	1100
+2	400	2100
+3	600	3100
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' with joined_cte as (
+select t2.a as cte_a, t2.b * 2 as doubled_b
+from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.doubled_b from t1 join joined_cte cte on t1.a = cte.cte_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#19
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+with joined_cte as (
+select t2.a as cte_a, t2.b * 2 as doubled_b
+from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.doubled_b from t1 join joined_cte cte on t1.a = cte.cte_a
+order by 1;
+a	cte_a	doubled_b
+1	1	200
+2	2	400
+3	3	600
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' with joined_cte as (
+select t2.a as cte_a, t2.b * 2 as doubled_b
+from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.doubled_b from t1 join joined_cte cte on t1.a = cte.cte_a;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#19
+└─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+with joined_cte as (
+select t2.a as cte_a, t2.b * 2 as doubled_b
+from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.doubled_b from t1 join joined_cte cte on t1.a = cte.cte_a
+order by 1;
+a	cte_a	doubled_b
+1	1	200
+2	2	400
+3	3	600
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.* from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10, plus(planner__core__join_reorder_through_projection.t3.b, 100)->Column#11
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.* from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+a	key_a	doubled_b	shifted_b
+1	1	200	1100
+2	2	400	2100
+3	3	600	3100
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.* from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10, plus(planner__core__join_reorder_through_projection.t3.b, 100)->Column#11
+└─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.* from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+a	key_a	doubled_b	shifted_b
+1	1	200	1100
+2	2	400	2100
+3	3	600	3100
+set tidb_opt_enable_non_eval_scalar_subquery = on;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.subq_cnt from t1 join (
+select t2.a as a2, (select count(*) from t4) as subq_cnt
+from t2 join t3 on t2.a = t3.a
+) dt on t1.a = dt.a2;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root	NULL	inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root	NULL	planner__core__join_reorder_through_projection.t2.a, <nil>->Column#24
+│ └─MergeJoin	12500.00	root	NULL	inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root	NULL	data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root	NULL	data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root	NULL	data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+ScalarSubQuery	N/A	root	NULL	Output: ScalarQueryCol#<id>
+└─MaxOneRow	1.00	root	NULL	NULL
+  └─HashAgg	1.00	root	NULL	funcs:count(Column#18)->Column#16
+    └─IndexReader	1.00	root	NULL	index:HashAgg
+      └─HashAgg	1.00	cop[tikv]	NULL	funcs:count(1)->Column#18
+        └─IndexFullScan	10000.00	cop[tikv]	table:t4, index:b(b)	keep order:false, stats:pseudo
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.subq_cnt from t1 join (
+select t2.a as a2, (select count(*) from t4) as subq_cnt
+from t2 join t3 on t2.a = t3.a
+) dt on t1.a = dt.a2;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root	NULL	inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root	NULL	planner__core__join_reorder_through_projection.t2.a, <nil>->Column#24
+│ └─MergeJoin	12500.00	root	NULL	inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root	NULL	data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root	NULL	data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root	NULL	data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+ScalarSubQuery	N/A	root	NULL	Output: ScalarQueryCol#<id>
+└─MaxOneRow	1.00	root	NULL	NULL
+  └─HashAgg	1.00	root	NULL	funcs:count(Column#18)->Column#16
+    └─IndexReader	1.00	root	NULL	index:HashAgg
+      └─HashAgg	1.00	cop[tikv]	NULL	funcs:count(1)->Column#18
+        └─IndexFullScan	10000.00	cop[tikv]	table:t4, index:b(b)	keep order:false, stats:pseudo
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.subq_cnt from t1 join (
+select t2.a as a2, ifnull((select count(*) from t4), 0) as subq_cnt
+from t2 join t3 on t2.a = t3.a
+) dt on t1.a = dt.a2;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root	NULL	inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root	NULL	planner__core__join_reorder_through_projection.t2.a, ifnull(<nil>, 0)->Column#24
+│ └─MergeJoin	12500.00	root	NULL	inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root	NULL	data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root	NULL	data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root	NULL	data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+ScalarSubQuery	N/A	root	NULL	Output: ScalarQueryCol#<id>
+└─MaxOneRow	1.00	root	NULL	NULL
+  └─HashAgg	1.00	root	NULL	funcs:count(Column#18)->Column#16
+    └─IndexReader	1.00	root	NULL	index:HashAgg
+      └─HashAgg	1.00	cop[tikv]	NULL	funcs:count(1)->Column#18
+        └─IndexFullScan	10000.00	cop[tikv]	table:t4, index:b(b)	keep order:false, stats:pseudo
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.subq_cnt from t1 join (
+select t2.a as a2, ifnull((select count(*) from t4), 0) as subq_cnt
+from t2 join t3 on t2.a = t3.a
+) dt on t1.a = dt.a2;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root	NULL	inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root	NULL	planner__core__join_reorder_through_projection.t2.a, ifnull(<nil>, 0)->Column#24
+│ └─MergeJoin	12500.00	root	NULL	inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root	NULL	data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root	NULL	data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root	NULL	data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+ScalarSubQuery	N/A	root	NULL	Output: ScalarQueryCol#<id>
+└─MaxOneRow	1.00	root	NULL	NULL
+  └─HashAgg	1.00	root	NULL	funcs:count(Column#18)->Column#16
+    └─IndexReader	1.00	root	NULL	index:HashAgg
+      └─HashAgg	1.00	cop[tikv]	NULL	funcs:count(1)->Column#18
+        └─IndexFullScan	10000.00	cop[tikv]	table:t4, index:b(b)	keep order:false, stats:pseudo
+set tidb_opt_enable_non_eval_scalar_subquery = off;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.key_a, dt.sum_b from t1 join (
+select t2.a as key_a, sum(t3.b) as sum_b
+from t2 join t3 on t2.a = t3.a
+group by t2.a with rollup
+) dt on t1.a = dt.key_a;
+id	estRows	task	access object	operator info
+Projection	8000.00	root		planner__core__join_reorder_through_projection.t1.a, Column#10, Column#12
+└─HashJoin	8000.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.a, Column#10)]
+  ├─IndexReader(Build)	10000.00	root		index:IndexFullScan
+  │ └─IndexFullScan	10000.00	cop[tikv]	table:t1, index:b(b)	keep order:false, stats:pseudo
+  └─HashAgg(Probe)	6400.00	root		group by:Column#21, Column#22, funcs:sum(Column#20)->Column#12, funcs:firstrow(Column#21)->Column#10
+    └─Projection	10000.00	root		cast(planner__core__join_reorder_through_projection.t3.b, decimal(10,0) BINARY)->Column#20, Column#10->Column#21, gid->Column#22
+      └─Selection	10000.00	root		not(isnull(Column#10))
+        └─Expand	12500.00	root		level-projection:[planner__core__join_reorder_through_projection.t3.b, <nil>->Column#10, 0->gid],[planner__core__join_reorder_through_projection.t3.b, Column#10, 1->gid]; schema: [planner__core__join_reorder_through_projection.t3.b,Column#10,gid]
+          └─Projection	12500.00	root		planner__core__join_reorder_through_projection.t3.b, planner__core__join_reorder_through_projection.t2.a->Column#10
+            └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+              ├─TableReader(Build)	10000.00	root		data:TableFullScan
+              │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+              └─TableReader(Probe)	10000.00	root		data:TableFullScan
+                └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.key_a, dt.sum_b from t1 join (
+select t2.a as key_a, sum(t3.b) as sum_b
+from t2 join t3 on t2.a = t3.a
+group by t2.a with rollup
+) dt on t1.a = dt.key_a;
+id	estRows	task	access object	operator info
+Projection	8000.00	root		planner__core__join_reorder_through_projection.t1.a, Column#10, Column#12
+└─HashJoin	8000.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.a, Column#10)]
+  ├─IndexReader(Build)	10000.00	root		index:IndexFullScan
+  │ └─IndexFullScan	10000.00	cop[tikv]	table:t1, index:b(b)	keep order:false, stats:pseudo
+  └─HashAgg(Probe)	6400.00	root		group by:Column#21, Column#22, funcs:sum(Column#20)->Column#12, funcs:firstrow(Column#21)->Column#10
+    └─Projection	10000.00	root		cast(planner__core__join_reorder_through_projection.t3.b, decimal(10,0) BINARY)->Column#20, Column#10->Column#21, gid->Column#22
+      └─Selection	10000.00	root		not(isnull(Column#10))
+        └─Expand	12500.00	root		level-projection:[planner__core__join_reorder_through_projection.t3.b, <nil>->Column#10, 0->gid],[planner__core__join_reorder_through_projection.t3.b, Column#10, 1->gid]; schema: [planner__core__join_reorder_through_projection.t3.b,Column#10,gid]
+          └─Projection	12500.00	root		planner__core__join_reorder_through_projection.t3.b, planner__core__join_reorder_through_projection.t2.a->Column#10
+            └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+              ├─TableReader(Build)	10000.00	root		data:TableFullScan
+              │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+              └─TableReader(Probe)	10000.00	root		data:TableFullScan
+                └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.const_one from t1 join (
+select t2.a as a2, 1 as const_one
+from t2 join t3 on t2.a = t3.a
+) dt on t1.a = dt.a2;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, 1->Column#10
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.const_one from t1 join (
+select t2.a as a2, 1 as const_one
+from t2 join t3 on t2.a = t3.a
+) dt on t1.a = dt.a2;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, 1->Column#10
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+drop table if exists jt_mp, jt_ms, jt_ch, jt_ab;
+create table jt_mp(
+id int primary key,
+ms_id int,
+user_id int,
+site_code int,
+pay_receive_id int,
+payline_id int,
+key(user_id, site_code),
+key(ms_id),
+key(pay_receive_id, payline_id)
+);
+create table jt_ms(id int primary key, note varchar(10));
+create table jt_ch(channel_id int, pay_kind int, key(channel_id, pay_kind));
+create table jt_ab(user_id int, site_code int, regpkgid int, key(user_id, site_code));
+insert into jt_mp values (1, 1, 10, 1, 100, 2), (2, 2, 20, 1, 200, 3);
+insert into jt_ms values (1, 'm1'), (2, 'm2');
+insert into jt_ch values (100, 200), (200, 300);
+insert into jt_ab values (10, 1, 1), (20, 1, 2);
+analyze table jt_mp, jt_ms, jt_ch, jt_ab;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select /*+ leading(ab) */ mp.id, ms.note
+from jt_mp mp
+left join jt_ms ms
+on mp.ms_id = ms.id
+left join jt_ch ch
+on mp.pay_receive_id = ch.channel_id
+and mp.payline_id * 100 = ch.pay_kind
+left join jt_ab ab
+on ab.user_id = mp.user_id
+and ab.site_code = mp.site_code
+where ab.regpkgid = 1;
+id	estRows	task	access object	operator info
+HashJoin	1.00	root		left outer join, equal:[eq(planner__core__join_reorder_through_projection.jt_mp.pay_receive_id, planner__core__join_reorder_through_projection.jt_ch.channel_id) eq(Column#16, planner__core__join_reorder_through_projection.jt_ch.pay_kind)]
+├─HashJoin(Build)	1.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.jt_ab.user_id, planner__core__join_reorder_through_projection.jt_mp.user_id) eq(planner__core__join_reorder_through_projection.jt_ab.site_code, planner__core__join_reorder_through_projection.jt_mp.site_code)]
+│ ├─TableReader(Build)	1.00	root		data:Selection
+│ │ └─Selection	1.00	cop[tikv]		eq(planner__core__join_reorder_through_projection.jt_ab.regpkgid, 1), not(isnull(planner__core__join_reorder_through_projection.jt_ab.site_code)), not(isnull(planner__core__join_reorder_through_projection.jt_ab.user_id))
+│ │   └─TableFullScan	2.00	cop[tikv]	table:ab	keep order:false
+│ └─Projection(Probe)	2.00	root		planner__core__join_reorder_through_projection.jt_mp.id, planner__core__join_reorder_through_projection.jt_mp.user_id, planner__core__join_reorder_through_projection.jt_mp.site_code, planner__core__join_reorder_through_projection.jt_mp.pay_receive_id, planner__core__join_reorder_through_projection.jt_ms.note, mul(planner__core__join_reorder_through_projection.jt_mp.payline_id, 100)->Column#16
+│   └─HashJoin	2.00	root		left outer join, equal:[eq(planner__core__join_reorder_through_projection.jt_mp.ms_id, planner__core__join_reorder_through_projection.jt_ms.id)]
+│     ├─TableReader(Build)	2.00	root		data:TableFullScan
+│     │ └─TableFullScan	2.00	cop[tikv]	table:ms	keep order:false
+│     └─TableReader(Probe)	2.00	root		data:Selection
+│       └─Selection	2.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.jt_mp.site_code)), not(isnull(planner__core__join_reorder_through_projection.jt_mp.user_id))
+│         └─TableFullScan	2.00	cop[tikv]	table:mp	keep order:false
+└─IndexReader(Probe)	2.00	root		index:IndexFullScan
+  └─IndexFullScan	2.00	cop[tikv]	table:ch, index:channel_id(channel_id, pay_kind)	keep order:false
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select /*+ leading(ab) */ mp.id, ms.note
+from jt_mp mp
+left join jt_ms ms
+on mp.ms_id = ms.id
+left join jt_ch ch
+on mp.pay_receive_id = ch.channel_id
+and mp.payline_id * 100 = ch.pay_kind
+left join jt_ab ab
+on ab.user_id = mp.user_id
+and ab.site_code = mp.site_code
+where ab.regpkgid = 1;
+id	estRows	task	access object	operator info
+HashJoin	1.00	root		left outer join, equal:[eq(planner__core__join_reorder_through_projection.jt_mp.pay_receive_id, planner__core__join_reorder_through_projection.jt_ch.channel_id) eq(Column#16, planner__core__join_reorder_through_projection.jt_ch.pay_kind)]
+├─HashJoin(Build)	1.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.jt_ab.user_id, planner__core__join_reorder_through_projection.jt_mp.user_id) eq(planner__core__join_reorder_through_projection.jt_ab.site_code, planner__core__join_reorder_through_projection.jt_mp.site_code)]
+│ ├─TableReader(Build)	1.00	root		data:Selection
+│ │ └─Selection	1.00	cop[tikv]		eq(planner__core__join_reorder_through_projection.jt_ab.regpkgid, 1), not(isnull(planner__core__join_reorder_through_projection.jt_ab.site_code)), not(isnull(planner__core__join_reorder_through_projection.jt_ab.user_id))
+│ │   └─TableFullScan	2.00	cop[tikv]	table:ab	keep order:false
+│ └─Projection(Probe)	2.00	root		planner__core__join_reorder_through_projection.jt_mp.id, planner__core__join_reorder_through_projection.jt_mp.user_id, planner__core__join_reorder_through_projection.jt_mp.site_code, planner__core__join_reorder_through_projection.jt_mp.pay_receive_id, planner__core__join_reorder_through_projection.jt_ms.note, mul(planner__core__join_reorder_through_projection.jt_mp.payline_id, 100)->Column#16
+│   └─HashJoin	2.00	root		left outer join, equal:[eq(planner__core__join_reorder_through_projection.jt_mp.ms_id, planner__core__join_reorder_through_projection.jt_ms.id)]
+│     ├─TableReader(Build)	2.00	root		data:TableFullScan
+│     │ └─TableFullScan	2.00	cop[tikv]	table:ms	keep order:false
+│     └─TableReader(Probe)	2.00	root		data:Selection
+│       └─Selection	2.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.jt_mp.site_code)), not(isnull(planner__core__join_reorder_through_projection.jt_mp.user_id))
+│         └─TableFullScan	2.00	cop[tikv]	table:mp	keep order:false
+└─IndexReader(Probe)	2.00	root		index:IndexFullScan
+  └─IndexFullScan	2.00	cop[tikv]	table:ch, index:channel_id(channel_id, pay_kind)	keep order:false
+set tidb_opt_join_reorder_through_proj = on;
+set tidb_opt_join_reorder_threshold = 3;
+select count(*) from (
+select t2.a as a2, t2.b * 2 as doubled_b
+from t2 join t3 on t2.a = t3.a
+) dt join t1 on dt.a2 = t1.a and dt.doubled_b > 300;
+count(*)
+2
+set tidb_opt_join_reorder_threshold = 0;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' with
+cte1 as (select a, b * 2 as doubled_b from t2),
+cte2 as (select t3.a, t3.b + 100 as shifted_b, cte1.doubled_b from t3 join cte1 on t3.a = cte1.a)
+select t1.a, cte2.* from t1 join cte2 on t1.b = cte2.doubled_b;
+id	estRows	task	access object	operator info
+HashJoin	12500.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.b, Column#29)]
+├─Projection(Build)	10000.00	root		planner__core__join_reorder_through_projection.t3.a, plus(planner__core__join_reorder_through_projection.t3.b, 100)->Column#30, Column#29
+│ └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t3.a, right key:planner__core__join_reorder_through_projection.t2.a
+│   ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#29
+│   │ └─TableReader	8000.00	root		data:Selection
+│   │   └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2)))
+│   │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+└─IndexReader(Probe)	9990.00	root		index:IndexFullScan
+  └─IndexFullScan	9990.00	cop[tikv]	table:t1, index:b(b)	keep order:false, stats:pseudo
+with
+cte1 as (select a, b * 2 as doubled_b from t2),
+cte2 as (select t3.a, t3.b + 100 as shifted_b, cte1.doubled_b from t3 join cte1 on t3.a = cte1.a)
+select t1.a, cte2.* from t1 join cte2 on t1.b = cte2.doubled_b
+order by 1;
+a	a	shifted_b	doubled_b
+4	1	1100	200
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' with
+cte1 as (select a, b * 2 as doubled_b from t2),
+cte2 as (select t3.a, t3.b + 100 as shifted_b, cte1.doubled_b from t3 join cte1 on t3.a = cte1.a)
+select t1.a, cte2.* from t1 join cte2 on t1.b = cte2.doubled_b;
+id	estRows	task	access object	operator info
+Projection	12500.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t3.a, plus(planner__core__join_reorder_through_projection.t3.b, 100)->Column#30, Column#29
+└─HashJoin	12500.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t3.a)]
+  ├─HashJoin(Build)	10000.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.b, Column#29)]
+  │ ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#29
+  │ │ └─IndexReader	8000.00	root		index:Selection
+  │ │   └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2)))
+  │ │     └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:b(b)	keep order:false, stats:pseudo
+  │ └─IndexReader(Probe)	9990.00	root		index:IndexFullScan
+  │   └─IndexFullScan	9990.00	cop[tikv]	table:t1, index:b(b)	keep order:false, stats:pseudo
+  └─IndexReader(Probe)	10000.00	root		index:IndexFullScan
+    └─IndexFullScan	10000.00	cop[tikv]	table:t3, index:b(b)	keep order:false, stats:pseudo
+with
+cte1 as (select a, b * 2 as doubled_b from t2),
+cte2 as (select t3.a, t3.b + 100 as shifted_b, cte1.doubled_b from t3 join cte1 on t3.a = cte1.a)
+select t1.a, cte2.* from t1 join cte2 on t1.b = cte2.doubled_b
+order by 1;
+a	a	shifted_b	doubled_b
+4	1	1100	200
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, v.* from t1,
+(select t2.a as va, t2.b * 2 as vb, t3.b as vb2 from t2, t3 where t2.a = t3.a) v
+where t1.a = v.va;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10, planner__core__join_reorder_through_projection.t3.b
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, v.* from t1,
+(select t2.a as va, t2.b * 2 as vb, t3.b as vb2 from t2, t3 where t2.a = t3.a) v
+where t1.a = v.va
+order by 1;
+a	va	vb	vb2
+1	1	200	1000
+2	2	400	2000
+3	3	600	3000
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, v.* from t1,
+(select t2.a as va, t2.b * 2 as vb, t3.b as vb2 from t2, t3 where t2.a = t3.a) v
+where t1.a = v.va;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10, planner__core__join_reorder_through_projection.t3.b
+└─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, v.* from t1,
+(select t2.a as va, t2.b * 2 as vb, t3.b as vb2 from t2, t3 where t2.a = t3.a) v
+where t1.a = v.va
+order by 1;
+a	va	vb	vb2
+1	1	200	1000
+2	2	400	2000
+3	3	600	3000
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.* from t1,
+(select t2.a as key_a, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, upper(planner__core__join_reorder_through_projection.t2.c)->Column#10
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.* from t1,
+(select t2.a as key_a, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+a	key_a	upper_c
+1	1	B1
+2	2	B2
+3	3	B3
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.* from t1,
+(select t2.a as key_a, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a, upper(planner__core__join_reorder_through_projection.t2.c)->Column#10
+└─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.* from t1,
+(select t2.a as key_a, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+a	key_a	upper_c
+1	1	B1
+2	2	B2
+3	3	B3
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt.*, t5.a as t5_a from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		left outer join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a
+├─TableReader(Build)	10000.00	root		data:TableFullScan
+│ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+└─Projection(Probe)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#7
+  └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+select dt.*, t5.a as t5_a from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a
+order by 1;
+key_a	doubled_b	t5_a
+1	200	1
+2	400	2
+3	600	3
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt.*, t5.a as t5_a from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#7, planner__core__join_reorder_through_projection.t5.a
+└─MergeJoin	15625.00	root		left outer join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+select dt.*, t5.a as t5_a from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a
+order by 1;
+key_a	doubled_b	t5_a
+1	200	1
+2	400	2
+3	600	3
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.* from t1
+left join (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+on t1.a = dt.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		left outer join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.* from t1
+left join (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+on t1.a = dt.key_a
+order by 1;
+a	key_a	doubled_b
+1	1	200
+2	2	400
+3	3	600
+4	NULL	NULL
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.* from t1
+left join (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+on t1.a = dt.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		left outer join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.* from t1
+left join (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+on t1.a = dt.key_a
+order by 1;
+a	key_a	doubled_b
+1	1	200
+2	2	400
+3	3	600
+4	NULL	NULL
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt.*, t5.a as t5_a from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a and dt.doubled_b > 100;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		left outer join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a, left cond:gt(Column#7, 100)
+├─TableReader(Build)	10000.00	root		data:TableFullScan
+│ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+└─Projection(Probe)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#7
+  └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+select dt.*, t5.a as t5_a from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a and dt.doubled_b > 100
+order by 1;
+key_a	doubled_b	t5_a
+1	200	1
+2	400	2
+3	600	3
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt.*, t5.a as t5_a from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a and dt.doubled_b > 100;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#7, planner__core__join_reorder_through_projection.t5.a
+└─MergeJoin	15625.00	root		left outer join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a, left cond:gt(mul(planner__core__join_reorder_through_projection.t2.b, 2), 100)
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+select dt.*, t5.a as t5_a from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a and dt.doubled_b > 100
+order by 1;
+key_a	doubled_b	t5_a
+1	200	1
+2	400	2
+3	600	3
+drop table if exists oj_t2, oj_t3, oj_t5;
+create table oj_t2(a int, b int, primary key (a));
+create table oj_t3(a int, b int, primary key (a));
+create table oj_t5(a int, b int, primary key (a));
+insert into oj_t2 values
+(1, 10), (2, 20), (3, 30), (4, 40), (5, 50),
+(6, 60), (7, 70), (8, 80), (9, 90), (10, 100);
+insert into oj_t3 values
+(1, 10), (2, 100), (3, 10), (4, 10), (5, 10),
+(6, 10), (7, 10), (8, 10), (9, 10), (10, 10);
+insert into oj_t5 values (1, 1000), (2, 2000);
+analyze table oj_t2, oj_t3, oj_t5;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt.key_a, ifnull(oj_t5.b, -1) as t5_b from
+(select oj_t2.a as key_a, oj_t2.b * 2 as doubled_b, oj_t3.b + 100 as shifted_b
+from oj_t2 join oj_t3 on oj_t2.a = oj_t3.a) dt
+left join oj_t5 on dt.key_a = oj_t5.a and dt.doubled_b > 0 and dt.shifted_b > 150
+order by dt.key_a;
+id	estRows	task	access object	operator info
+Projection	10.00	root		planner__core__join_reorder_through_projection.oj_t2.a, ifnull(planner__core__join_reorder_through_projection.oj_t5.b, -1)->Column#9
+└─MergeJoin	10.00	root		left outer join, left key:planner__core__join_reorder_through_projection.oj_t2.a, right key:planner__core__join_reorder_through_projection.oj_t5.a, left cond:gt(Column#5, 0), gt(Column#6, 150)
+  ├─TableReader(Build)	2.00	root		data:TableFullScan
+  │ └─TableFullScan	2.00	cop[tikv]	table:oj_t5	keep order:true
+  └─Projection(Probe)	10.00	root		planner__core__join_reorder_through_projection.oj_t2.a, mul(planner__core__join_reorder_through_projection.oj_t2.b, 2)->Column#5, plus(planner__core__join_reorder_through_projection.oj_t3.b, 100)->Column#6
+    └─MergeJoin	10.00	root		inner join, left key:planner__core__join_reorder_through_projection.oj_t2.a, right key:planner__core__join_reorder_through_projection.oj_t3.a
+      ├─TableReader(Build)	10.00	root		data:TableFullScan
+      │ └─TableFullScan	10.00	cop[tikv]	table:oj_t3	keep order:true
+      └─TableReader(Probe)	10.00	root		data:TableFullScan
+        └─TableFullScan	10.00	cop[tikv]	table:oj_t2	keep order:true
+select dt.key_a, ifnull(oj_t5.b, -1) as t5_b from
+(select oj_t2.a as key_a, oj_t2.b * 2 as doubled_b, oj_t3.b + 100 as shifted_b
+from oj_t2 join oj_t3 on oj_t2.a = oj_t3.a) dt
+left join oj_t5 on dt.key_a = oj_t5.a and dt.doubled_b > 0 and dt.shifted_b > 150
+order by dt.key_a;
+key_a	t5_b
+1	-1
+2	2000
+3	-1
+4	-1
+5	-1
+6	-1
+7	-1
+8	-1
+9	-1
+10	-1
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt.key_a, ifnull(oj_t5.b, -1) as t5_b from
+(select oj_t2.a as key_a, oj_t2.b * 2 as doubled_b, oj_t3.b + 100 as shifted_b
+from oj_t2 join oj_t3 on oj_t2.a = oj_t3.a) dt
+left join oj_t5 on dt.key_a = oj_t5.a and dt.doubled_b > 0 and dt.shifted_b > 150
+order by dt.key_a;
+id	estRows	task	access object	operator info
+Projection	10.00	root		planner__core__join_reorder_through_projection.oj_t2.a, ifnull(planner__core__join_reorder_through_projection.oj_t5.b, -1)->Column#9
+└─MergeJoin	10.00	root		left outer join, left key:planner__core__join_reorder_through_projection.oj_t2.a, right key:planner__core__join_reorder_through_projection.oj_t5.a, left cond:gt(Column#5, 0), gt(Column#6, 150)
+  ├─TableReader(Build)	2.00	root		data:TableFullScan
+  │ └─TableFullScan	2.00	cop[tikv]	table:oj_t5	keep order:true
+  └─Projection(Probe)	10.00	root		planner__core__join_reorder_through_projection.oj_t2.a, mul(planner__core__join_reorder_through_projection.oj_t2.b, 2)->Column#5, plus(planner__core__join_reorder_through_projection.oj_t3.b, 100)->Column#6
+    └─MergeJoin	10.00	root		inner join, left key:planner__core__join_reorder_through_projection.oj_t2.a, right key:planner__core__join_reorder_through_projection.oj_t3.a
+      ├─TableReader(Build)	10.00	root		data:TableFullScan
+      │ └─TableFullScan	10.00	cop[tikv]	table:oj_t3	keep order:true
+      └─TableReader(Probe)	10.00	root		data:TableFullScan
+        └─TableFullScan	10.00	cop[tikv]	table:oj_t2	keep order:true
+select dt.key_a, ifnull(oj_t5.b, -1) as t5_b from
+(select oj_t2.a as key_a, oj_t2.b * 2 as doubled_b, oj_t3.b + 100 as shifted_b
+from oj_t2 join oj_t3 on oj_t2.a = oj_t3.a) dt
+left join oj_t5 on dt.key_a = oj_t5.a and dt.doubled_b > 0 and dt.shifted_b > 150
+order by dt.key_a;
+key_a	t5_b
+1	-1
+2	2000
+3	-1
+4	-1
+5	-1
+6	-1
+7	-1
+8	-1
+9	-1
+10	-1
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt.key_a, ifnull(oj_t5.b, -1) as t5_b from
+(select oj_t2.a as key_a, oj_t2.b * 2 as doubled_b
+from oj_t2 join oj_t3 on oj_t2.a = oj_t3.a) dt
+left join oj_t5 on dt.doubled_b = oj_t5.b
+order by dt.key_a;
+id	estRows	task	access object	operator info
+Sort	10.00	root		planner__core__join_reorder_through_projection.oj_t2.a
+└─Projection	10.00	root		planner__core__join_reorder_through_projection.oj_t2.a, ifnull(planner__core__join_reorder_through_projection.oj_t5.b, -1)->Column#8
+  └─HashJoin	10.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.oj_t2.a, planner__core__join_reorder_through_projection.oj_t3.a)]
+    ├─TableReader(Build)	10.00	root		data:TableFullScan
+    │ └─TableFullScan	10.00	cop[tikv]	table:oj_t3	keep order:false
+    └─HashJoin(Probe)	10.00	root		left outer join, equal:[eq(Column#10, planner__core__join_reorder_through_projection.oj_t5.b)]
+      ├─TableReader(Build)	2.00	root		data:Selection
+      │ └─Selection	2.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.oj_t5.b))
+      │   └─TableFullScan	2.00	cop[tikv]	table:oj_t5	keep order:false
+      └─Projection(Probe)	10.00	root		planner__core__join_reorder_through_projection.oj_t2.a, mul(planner__core__join_reorder_through_projection.oj_t2.b, 2)->Column#10
+        └─TableReader	10.00	root		data:TableFullScan
+          └─TableFullScan	10.00	cop[tikv]	table:oj_t2	keep order:false
+select dt.key_a, ifnull(oj_t5.b, -1) as t5_b from
+(select oj_t2.a as key_a, oj_t2.b * 2 as doubled_b
+from oj_t2 join oj_t3 on oj_t2.a = oj_t3.a) dt
+left join oj_t5 on dt.doubled_b = oj_t5.b
+order by dt.key_a;
+key_a	t5_b
+1	-1
+2	-1
+3	-1
+4	-1
+5	-1
+6	-1
+7	-1
+8	-1
+9	-1
+10	-1
+drop table oj_t2, oj_t3, oj_t5;
+drop table if exists ne_t1, ne_t2, ne_t3;
+create table ne_t1(a int, b int, primary key (a));
+create table ne_t2(a int, b int, primary key (a));
+create table ne_t3(a int, b int, primary key (a));
+insert into ne_t1 values (1, 0), (2, 200), (3, 300);
+insert into ne_t2 values (1, 10), (2, 20), (3, 30);
+insert into ne_t3 values (2, 200), (3, 300);
+analyze table ne_t1, ne_t2, ne_t3;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select ne_t1.a, dt.key_a, dt.coalesced_b from ne_t1 join
+(select ne_t2.a as key_a, coalesce(ne_t3.b, 0) as coalesced_b
+from ne_t2 left join ne_t3 on ne_t2.a = ne_t3.a) dt
+on ne_t1.b = dt.coalesced_b;
+id	estRows	task	access object	operator info
+HashJoin	3.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.ne_t1.b, Column#7)]
+├─Projection(Build)	3.00	root		planner__core__join_reorder_through_projection.ne_t2.a, coalesce(planner__core__join_reorder_through_projection.ne_t3.b, 0)->Column#7
+│ └─MergeJoin	3.00	root		left outer join, left key:planner__core__join_reorder_through_projection.ne_t2.a, right key:planner__core__join_reorder_through_projection.ne_t3.a
+│   ├─TableReader(Build)	2.00	root		data:TableFullScan
+│   │ └─TableFullScan	2.00	cop[tikv]	table:ne_t3	keep order:true
+│   └─TableReader(Probe)	3.00	root		data:TableFullScan
+│     └─TableFullScan	3.00	cop[tikv]	table:ne_t2	keep order:true
+└─TableReader(Probe)	3.00	root		data:Selection
+  └─Selection	3.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.ne_t1.b))
+    └─TableFullScan	3.00	cop[tikv]	table:ne_t1	keep order:false
+select ne_t1.a, dt.key_a, dt.coalesced_b from ne_t1 join
+(select ne_t2.a as key_a, coalesce(ne_t3.b, 0) as coalesced_b
+from ne_t2 left join ne_t3 on ne_t2.a = ne_t3.a) dt
+on ne_t1.b = dt.coalesced_b
+order by 1;
+a	key_a	coalesced_b
+1	1	0
+2	2	200
+3	3	300
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select ne_t1.a, dt.key_a, dt.coalesced_b from ne_t1 join
+(select ne_t2.a as key_a, coalesce(ne_t3.b, 0) as coalesced_b
+from ne_t2 left join ne_t3 on ne_t2.a = ne_t3.a) dt
+on ne_t1.b = dt.coalesced_b;
+id	estRows	task	access object	operator info
+HashJoin	3.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.ne_t1.b, Column#7)]
+├─Projection(Build)	3.00	root		planner__core__join_reorder_through_projection.ne_t2.a, coalesce(planner__core__join_reorder_through_projection.ne_t3.b, 0)->Column#7
+│ └─MergeJoin	3.00	root		left outer join, left key:planner__core__join_reorder_through_projection.ne_t2.a, right key:planner__core__join_reorder_through_projection.ne_t3.a
+│   ├─TableReader(Build)	2.00	root		data:TableFullScan
+│   │ └─TableFullScan	2.00	cop[tikv]	table:ne_t3	keep order:true
+│   └─TableReader(Probe)	3.00	root		data:TableFullScan
+│     └─TableFullScan	3.00	cop[tikv]	table:ne_t2	keep order:true
+└─TableReader(Probe)	3.00	root		data:Selection
+  └─Selection	3.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.ne_t1.b))
+    └─TableFullScan	3.00	cop[tikv]	table:ne_t1	keep order:false
+select ne_t1.a, dt.key_a, dt.coalesced_b from ne_t1 join
+(select ne_t2.a as key_a, coalesce(ne_t3.b, 0) as coalesced_b
+from ne_t2 left join ne_t3 on ne_t2.a = ne_t3.a) dt
+on ne_t1.b = dt.coalesced_b
+order by 1;
+a	key_a	coalesced_b
+1	1	0
+2	2	200
+3	3	300
+drop table ne_t1, ne_t2, ne_t3;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt1.*, dt2.* from
+(select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3;
+id	estRows	task	access object	operator info
+MergeJoin	19531.25	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t3.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t3.a, mul(planner__core__join_reorder_through_projection.t3.b, 2)->Column#14
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t3.a, right key:planner__core__join_reorder_through_projection.t4.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+└─Projection(Probe)	12500.00	root		planner__core__join_reorder_through_projection.t1.a, mul(planner__core__join_reorder_through_projection.t1.b, 2)->Column#7
+  └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select dt1.*, dt2.* from
+(select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3
+order by 1;
+a1	doubled1	a3	doubled3
+1	20	1	2000
+2	40	2	4000
+3	60	3	6000
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt1.*, dt2.* from
+(select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3;
+id	estRows	task	access object	operator info
+Projection	19531.25	root		planner__core__join_reorder_through_projection.t1.a, mul(planner__core__join_reorder_through_projection.t1.b, 2)->Column#7, planner__core__join_reorder_through_projection.t3.a, mul(planner__core__join_reorder_through_projection.t3.b, 2)->Column#14
+└─MergeJoin	19531.25	root		inner join, left key:planner__core__join_reorder_through_projection.t3.a, right key:planner__core__join_reorder_through_projection.t4.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+      ├─TableReader(Build)	10000.00	root		data:TableFullScan
+      │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+      └─TableReader(Probe)	10000.00	root		data:TableFullScan
+        └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select dt1.*, dt2.* from
+(select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3
+order by 1;
+a1	doubled1	a3	doubled3
+1	20	1	2000
+2	40	2	4000
+3	60	3	6000
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt1.*, dt2.* from
+(select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled3;
+id	estRows	task	access object	operator info
+HashJoin	15625.00	root		inner join, equal:[eq(Column#7, Column#14)]
+├─Projection(Build)	10000.00	root		planner__core__join_reorder_through_projection.t3.a, mul(planner__core__join_reorder_through_projection.t3.b, 2)->Column#14
+│ └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t3.a, right key:planner__core__join_reorder_through_projection.t4.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	8000.00	root		data:Selection
+│     └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t3.b, 2)))
+│       └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+└─Projection(Probe)	10000.00	root		planner__core__join_reorder_through_projection.t1.a, mul(planner__core__join_reorder_through_projection.t1.b, 2)->Column#7
+  └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─TableReader(Probe)	8000.00	root		data:Selection
+      └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t1.b, 2)))
+        └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select dt1.*, dt2.* from
+(select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled3
+order by 1;
+a1	doubled1	a3	doubled3
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt1.*, dt2.* from
+(select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled3;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, mul(planner__core__join_reorder_through_projection.t1.b, 2)->Column#7, planner__core__join_reorder_through_projection.t3.a, mul(planner__core__join_reorder_through_projection.t3.b, 2)->Column#14
+└─HashJoin	15625.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t3.a, planner__core__join_reorder_through_projection.t4.a)]
+  ├─IndexReader(Build)	10000.00	root		index:IndexFullScan
+  │ └─IndexFullScan	10000.00	cop[tikv]	table:t4, index:b(b)	keep order:false, stats:pseudo
+  └─HashJoin(Probe)	12500.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a)]
+    ├─IndexReader(Build)	10000.00	root		index:IndexFullScan
+    │ └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:b(b)	keep order:false, stats:pseudo
+    └─HashJoin(Probe)	10000.00	root		inner join, equal:[eq(Column#17, Column#18)]
+      ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t3.a, planner__core__join_reorder_through_projection.t3.b, mul(planner__core__join_reorder_through_projection.t3.b, 2)->Column#18
+      │ └─IndexReader	8000.00	root		index:Selection
+      │   └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t3.b, 2)))
+      │     └─IndexFullScan	10000.00	cop[tikv]	table:t3, index:b(b)	keep order:false, stats:pseudo
+      └─Projection(Probe)	8000.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t1.b, mul(planner__core__join_reorder_through_projection.t1.b, 2)->Column#17
+        └─IndexReader	8000.00	root		index:Selection
+          └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t1.b, 2)))
+            └─IndexFullScan	10000.00	cop[tikv]	table:t1, index:b(b)	keep order:false, stats:pseudo
+select dt1.*, dt2.* from
+(select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled3
+order by 1;
+a1	doubled1	a3	doubled3
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select outer_t.a, dt2.* from t1 outer_t,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	19531.25	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	15625.00	root		planner__core__join_reorder_through_projection.t2.a, plus(Column#10, 10)->Column#14
+│ └─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t4.a, right key:planner__core__join_reorder_through_projection.t2.a
+│   ├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10
+│   │ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   │   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   │   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│   │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:outer_t	keep order:true, stats:pseudo
+select outer_t.a, dt2.* from t1 outer_t,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a
+order by 1;
+a	key_a	adjusted
+1	1	210
+2	2	410
+3	3	610
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select outer_t.a, dt2.* from t1 outer_t,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a;
+id	estRows	task	access object	operator info
+Projection	19531.25	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a, plus(mul(planner__core__join_reorder_through_projection.t2.b, 2), 10)->Column#14
+└─MergeJoin	19531.25	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t4.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+      ├─TableReader(Build)	10000.00	root		data:TableFullScan
+      │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+      └─TableReader(Probe)	10000.00	root		data:TableFullScan
+        └─TableFullScan	10000.00	cop[tikv]	table:outer_t	keep order:true, stats:pseudo
+select outer_t.a, dt2.* from t1 outer_t,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a
+order by 1;
+a	key_a	adjusted
+1	1	210
+2	2	410
+3	3	610
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select outer_t.a, dt2.* from t1 outer_t,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where outer_t.b = dt2.adjusted;
+id	estRows	task	access object	operator info
+HashJoin	15625.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.b, Column#14)]
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(Column#10, 10)->Column#14
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t4.a, right key:planner__core__join_reorder_through_projection.t2.a
+│   ├─Projection(Build)	10000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10
+│   │ └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   │   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   │   └─TableReader(Probe)	8000.00	root		data:Selection
+│   │     └─Selection	8000.00	cop[tikv]		not(isnull(plus(mul(planner__core__join_reorder_through_projection.t2.b, 2), 10)))
+│   │       └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+└─IndexReader(Probe)	9990.00	root		index:IndexFullScan
+  └─IndexFullScan	9990.00	cop[tikv]	table:outer_t, index:b(b)	keep order:false, stats:pseudo
+select outer_t.a, dt2.* from t1 outer_t,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where outer_t.b = dt2.adjusted
+order by 1;
+a	key_a	adjusted
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select outer_t.a, dt2.* from t1 outer_t,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where outer_t.b = dt2.adjusted;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a, plus(mul(planner__core__join_reorder_through_projection.t2.b, 2), 10)->Column#14
+└─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t4.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─IndexHashJoin(Probe)	10000.00	root		inner join, inner:IndexReader, outer key:Column#18, inner key:planner__core__join_reorder_through_projection.t1.b, equal cond:eq(Column#18, planner__core__join_reorder_through_projection.t1.b)
+      ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t2.b, plus(mul(planner__core__join_reorder_through_projection.t2.b, 2), 10)->Column#18
+      │ └─TableReader	8000.00	root		data:Selection
+      │   └─Selection	8000.00	cop[tikv]		not(isnull(plus(mul(planner__core__join_reorder_through_projection.t2.b, 2), 10)))
+      │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+      └─IndexReader(Probe)	10000.00	root		index:Selection
+        └─Selection	10000.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+          └─IndexRangeScan	10010.01	cop[tikv]	table:outer_t, index:b(b)	range: decided by [eq(planner__core__join_reorder_through_projection.t1.b, Column#18)], keep order:false, stats:pseudo
+select outer_t.a, dt2.* from t1 outer_t,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where outer_t.b = dt2.adjusted
+order by 1;
+a	key_a	adjusted
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.a2, dt.cross_table_sum from t1,
+(select t2.a as a2, t2.b + t3.b as cross_table_sum, rand() as unsafe_expr
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#10
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.a2, dt.cross_table_sum from t1,
+(select t2.a as a2, t2.b + t3.b as cross_table_sum, rand() as unsafe_expr
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#10
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.a2, dt.val from t1,
+(select t2.a as a2, @v := t2.b as val from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, setvar(v, planner__core__join_reorder_through_projection.t2.b)->Column#10
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.a2, dt.val from t1,
+(select t2.a as a2, @v := t2.b as val from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, setvar(v, planner__core__join_reorder_through_projection.t2.b)->Column#10
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+drop table if exists expr_small, expr_medium, expr_large;
+create table expr_small(a int, b int, primary key (a), key(b));
+create table expr_medium(a int, b int, primary key (a), key(b));
+create table expr_large(a int, b int, primary key (a), key(b));
+insert into expr_small values(11, 10), (21, 20);
+insert into expr_medium values(1, 10), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60);
+insert into expr_large values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10);
+insert into expr_large values(11, 11), (12, 12), (13, 13), (14, 14), (15, 15), (16, 16), (17, 17), (18, 18), (19, 19), (20, 20);
+analyze table expr_small, expr_medium, expr_large;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select s.*, dt.* from expr_small s,
+(select m.a as key_a, m.b + 1 as expr_key, l.b as lb from expr_medium m join expr_large l on m.a = l.a) dt
+where s.a = dt.expr_key;
+id	estRows	task	access object	operator info
+HashJoin	2.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.expr_small.a, Column#7)]
+├─TableReader(Build)	2.00	root		data:TableFullScan
+│ └─TableFullScan	2.00	cop[tikv]	table:s	keep order:false
+└─Projection(Probe)	4.80	root		planner__core__join_reorder_through_projection.expr_medium.a, plus(planner__core__join_reorder_through_projection.expr_medium.b, 1)->Column#7, planner__core__join_reorder_through_projection.expr_large.b
+  └─MergeJoin	4.80	root		inner join, left key:planner__core__join_reorder_through_projection.expr_medium.a, right key:planner__core__join_reorder_through_projection.expr_large.a
+    ├─TableReader(Build)	20.00	root		data:TableFullScan
+    │ └─TableFullScan	20.00	cop[tikv]	table:l	keep order:true
+    └─TableReader(Probe)	4.80	root		data:Selection
+      └─Selection	4.80	cop[tikv]		not(isnull(plus(planner__core__join_reorder_through_projection.expr_medium.b, 1)))
+        └─TableFullScan	6.00	cop[tikv]	table:m	keep order:true
+select s.*, dt.* from expr_small s,
+(select m.a as key_a, m.b + 1 as expr_key, l.b as lb from expr_medium m join expr_large l on m.a = l.a) dt
+where s.a = dt.expr_key
+order by 1;
+a	b	key_a	expr_key	lb
+11	10	1	11	1
+21	20	2	21	2
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select s.*, dt.* from expr_small s,
+(select m.a as key_a, m.b + 1 as expr_key, l.b as lb from expr_medium m join expr_large l on m.a = l.a) dt
+where s.a = dt.expr_key;
+id	estRows	task	access object	operator info
+Projection	2.00	root		planner__core__join_reorder_through_projection.expr_small.a, planner__core__join_reorder_through_projection.expr_small.b, planner__core__join_reorder_through_projection.expr_medium.a, plus(planner__core__join_reorder_through_projection.expr_medium.b, 1)->Column#7, planner__core__join_reorder_through_projection.expr_large.b
+└─MergeJoin	2.00	root		inner join, left key:planner__core__join_reorder_through_projection.expr_medium.a, right key:planner__core__join_reorder_through_projection.expr_large.a
+  ├─TableReader(Build)	20.00	root		data:TableFullScan
+  │ └─TableFullScan	20.00	cop[tikv]	table:l	keep order:true
+  └─IndexJoin(Probe)	2.00	root		inner join, inner:TableReader, outer key:Column#9, inner key:planner__core__join_reorder_through_projection.expr_small.a, equal cond:eq(Column#9, planner__core__join_reorder_through_projection.expr_small.a)
+    ├─Projection(Build)	4.80	root		planner__core__join_reorder_through_projection.expr_medium.a, planner__core__join_reorder_through_projection.expr_medium.b, plus(planner__core__join_reorder_through_projection.expr_medium.b, 1)->Column#9
+    │ └─TableReader	4.80	root		data:Selection
+    │   └─Selection	4.80	cop[tikv]		not(isnull(plus(planner__core__join_reorder_through_projection.expr_medium.b, 1)))
+    │     └─TableFullScan	6.00	cop[tikv]	table:m	keep order:true
+    └─TableReader(Probe)	2.00	root		data:TableRangeScan
+      └─TableRangeScan	2.00	cop[tikv]	table:s	range: decided by [Column#9], keep order:false
+select s.*, dt.* from expr_small s,
+(select m.a as key_a, m.b + 1 as expr_key, l.b as lb from expr_medium m join expr_large l on m.a = l.a) dt
+where s.a = dt.expr_key
+order by 1;
+a	b	key_a	expr_key	lb
+11	10	1	11	1
+21	20	2	21	2
+drop table expr_small, expr_medium, expr_large;
+drop table if exists t_int_small, t_double_medium, t_int_large;
+create table t_int_small(a int, b int, primary key (a), key(b));
+create table t_double_medium(a double, b double, key(a));
+create table t_int_large(a int, b int, primary key (a), key(b));
+insert into t_int_small values(1, 10), (2, 20);
+insert into t_double_medium values(1.0, 100.0), (2.0, 200.0), (3.0, 300.0), (4.0, 400.0), (5.0, 500.0), (6.0, 600.0);
+insert into t_int_large values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10);
+insert into t_int_large values(11, 11), (12, 12), (13, 13), (14, 14), (15, 15), (16, 16), (17, 17), (18, 18), (19, 19), (20, 20);
+analyze table t_int_small, t_double_medium, t_int_large;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select s.*, dt.* from t_int_small s,
+(select l.a as key_a, l.b * 2 as doubled_b, m.b as mb
+from t_int_large l join t_double_medium m on cast(l.a as double) = m.a) dt
+where s.a = dt.key_a;
+id	estRows	task	access object	operator info
+HashJoin	2.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t_int_small.a, planner__core__join_reorder_through_projection.t_int_large.a)]
+├─TableReader(Build)	2.00	root		data:TableFullScan
+│ └─TableFullScan	2.00	cop[tikv]	table:s	keep order:false
+└─Projection(Probe)	6.00	root		planner__core__join_reorder_through_projection.t_int_large.a, mul(planner__core__join_reorder_through_projection.t_int_large.b, 2)->Column#8, planner__core__join_reorder_through_projection.t_double_medium.b
+  └─Projection	6.00	root		planner__core__join_reorder_through_projection.t_int_large.a, planner__core__join_reorder_through_projection.t_int_large.b, planner__core__join_reorder_through_projection.t_double_medium.b
+    └─HashJoin	6.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t_double_medium.a, Column#9)]
+      ├─TableReader(Build)	6.00	root		data:TableFullScan
+      │ └─TableFullScan	6.00	cop[tikv]	table:m	keep order:false
+      └─Projection(Probe)	20.00	root		planner__core__join_reorder_through_projection.t_int_large.a, planner__core__join_reorder_through_projection.t_int_large.b, cast(planner__core__join_reorder_through_projection.t_int_large.a, double BINARY)->Column#9
+        └─TableReader	20.00	root		data:TableFullScan
+          └─TableFullScan	20.00	cop[tikv]	table:l	keep order:false
+select s.*, dt.* from t_int_small s,
+(select l.a as key_a, l.b * 2 as doubled_b, m.b as mb
+from t_int_large l join t_double_medium m on cast(l.a as double) = m.a) dt
+where s.a = dt.key_a
+order by 1;
+a	b	key_a	doubled_b	mb
+1	10	1	2	100
+2	20	2	4	200
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select s.*, dt.* from t_int_small s,
+(select l.a as key_a, l.b * 2 as doubled_b, m.b as mb
+from t_int_large l join t_double_medium m on cast(l.a as double) = m.a) dt
+where s.a = dt.key_a;
+id	estRows	task	access object	operator info
+Projection	2.00	root		planner__core__join_reorder_through_projection.t_int_small.a, planner__core__join_reorder_through_projection.t_int_small.b, planner__core__join_reorder_through_projection.t_int_large.a, mul(planner__core__join_reorder_through_projection.t_int_large.b, 2)->Column#8, planner__core__join_reorder_through_projection.t_double_medium.b
+└─HashJoin	2.00	root		inner join, equal:[eq(Column#9, planner__core__join_reorder_through_projection.t_double_medium.a)]
+  ├─MergeJoin(Build)	2.00	root		inner join, left key:planner__core__join_reorder_through_projection.t_int_small.a, right key:planner__core__join_reorder_through_projection.t_int_large.a
+  │ ├─Projection(Build)	20.00	root		planner__core__join_reorder_through_projection.t_int_large.a, planner__core__join_reorder_through_projection.t_int_large.b, cast(planner__core__join_reorder_through_projection.t_int_large.a, double BINARY)->Column#9
+  │ │ └─TableReader	20.00	root		data:TableFullScan
+  │ │   └─TableFullScan	20.00	cop[tikv]	table:l	keep order:true
+  │ └─TableReader(Probe)	2.00	root		data:TableFullScan
+  │   └─TableFullScan	2.00	cop[tikv]	table:s	keep order:true
+  └─TableReader(Probe)	6.00	root		data:TableFullScan
+    └─TableFullScan	6.00	cop[tikv]	table:m	keep order:false
+select s.*, dt.* from t_int_small s,
+(select l.a as key_a, l.b * 2 as doubled_b, m.b as mb
+from t_int_large l join t_double_medium m on cast(l.a as double) = m.a) dt
+where s.a = dt.key_a
+order by 1;
+a	b	key_a	doubled_b	mb
+1	10	1	2	100
+2	20	2	4	200
+drop table t_int_small, t_double_medium, t_int_large;
+set tidb_opt_join_reorder_threshold = 10;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.key_a, dt.doubled_b from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a;
+id	estRows	task	access object	operator info
+MergeJoin	19531.25	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a
+├─TableReader(Build)	10000.00	root		data:TableFullScan
+│ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+└─MergeJoin(Probe)	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+  ├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#13
+  │ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  │   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  │   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+  │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+  └─TableReader(Probe)	10000.00	root		data:TableFullScan
+    └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.key_a, dt.doubled_b from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a
+order by 1;
+a	key_a	doubled_b
+1	1	200
+2	2	400
+3	3	600
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.key_a, dt.doubled_b from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a;
+id	estRows	task	access object	operator info
+Projection	19531.25	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#13
+└─MergeJoin	19531.25	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+      ├─TableReader(Build)	10000.00	root		data:TableFullScan
+      │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+      └─TableReader(Probe)	10000.00	root		data:TableFullScan
+        └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.key_a, dt.doubled_b from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a
+order by 1;
+a	key_a	doubled_b
+1	1	200
+2	2	400
+3	3	600
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.key_a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a;
+id	estRows	task	access object	operator info
+HashJoin	15625.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t5.a)]
+├─IndexReader(Build)	10000.00	root		index:IndexFullScan
+│ └─IndexFullScan	10000.00	cop[tikv]	table:t5, index:b(b)	keep order:false, stats:pseudo
+└─HashJoin(Probe)	12500.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.b, Column#13)]
+  ├─Projection(Build)	10000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#13
+  │ └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  │   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  │   └─TableReader(Probe)	8000.00	root		data:Selection
+  │     └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2)))
+  │       └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+  └─IndexReader(Probe)	9990.00	root		index:IndexFullScan
+    └─IndexFullScan	9990.00	cop[tikv]	table:t1, index:b(b)	keep order:false, stats:pseudo
+select t1.a, dt.key_a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a
+order by 1;
+a	key_a
+4	1
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.key_a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a
+├─TableReader(Build)	10000.00	root		data:TableFullScan
+│ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+└─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  └─IndexHashJoin(Probe)	10000.00	root		inner join, inner:IndexReader, outer key:Column#15, inner key:planner__core__join_reorder_through_projection.t1.b, equal cond:eq(Column#15, planner__core__join_reorder_through_projection.t1.b)
+    ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#15
+    │ └─TableReader	8000.00	root		data:Selection
+    │   └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2)))
+    │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─IndexReader(Probe)	10000.00	root		index:Selection
+      └─Selection	10000.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+        └─IndexRangeScan	10010.01	cop[tikv]	table:t1, index:b(b)	range: decided by [eq(planner__core__join_reorder_through_projection.t1.b, Column#15)], keep order:false, stats:pseudo
+select t1.a, dt.key_a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a
+order by 1;
+a	key_a
+4	1
+set tidb_opt_join_reorder_threshold = 10;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c and dt.key_a = t5.a;
+id	estRows	task	access object	operator info
+HashJoin	14062.50	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t5.a)]
+├─IndexReader(Build)	10000.00	root		index:IndexFullScan
+│ └─IndexFullScan	10000.00	cop[tikv]	table:t5, index:b(b)	keep order:false, stats:pseudo
+└─HashJoin(Probe)	11250.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.b, Column#13) eq(planner__core__join_reorder_through_projection.t1.c, Column#14)]
+  ├─Projection(Build)	10000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#13, upper(planner__core__join_reorder_through_projection.t2.c)->Column#14
+  │ └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  │   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  │   └─TableReader(Probe)	8000.00	root		data:Selection
+  │     └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2))), not(isnull(upper(planner__core__join_reorder_through_projection.t2.c)))
+  │       └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+  └─TableReader(Probe)	9980.01	root		data:Selection
+    └─Selection	9980.01	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b)), not(isnull(planner__core__join_reorder_through_projection.t1.c))
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+select t1.a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c and dt.key_a = t5.a
+order by 1;
+a
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c and dt.key_a = t5.a;
+id	estRows	task	access object	operator info
+MergeJoin	14062.50	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a
+├─TableReader(Build)	10000.00	root		data:TableFullScan
+│ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+└─MergeJoin(Probe)	11250.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  └─IndexHashJoin(Probe)	9000.00	root		inner join, inner:IndexLookUp, outer key:Column#17, inner key:planner__core__join_reorder_through_projection.t1.b, equal cond:eq(Column#17, planner__core__join_reorder_through_projection.t1.b), eq(Column#18, planner__core__join_reorder_through_projection.t1.c)
+    ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#17, upper(planner__core__join_reorder_through_projection.t2.c)->Column#18
+    │ └─TableReader	8000.00	root		data:Selection
+    │   └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2))), not(isnull(upper(planner__core__join_reorder_through_projection.t2.c)))
+    │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─IndexLookUp(Probe)	9000.00	root		
+      ├─Selection(Build)	9009.01	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+      │ └─IndexRangeScan	9018.03	cop[tikv]	table:t1, index:b(b)	range: decided by [eq(planner__core__join_reorder_through_projection.t1.b, Column#17)], keep order:false, stats:pseudo
+      └─Selection(Probe)	9000.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.c))
+        └─TableRowIDScan	9009.01	cop[tikv]	table:t1	keep order:false, stats:pseudo
+select t1.a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c and dt.key_a = t5.a
+order by 1;
+a
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.key_a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a and dt.doubled_b > 100;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a
+├─TableReader(Build)	10000.00	root		data:TableFullScan
+│ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+└─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+  ├─MergeJoin(Build)	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  │ ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  │ └─TableReader(Probe)	8000.00	root		data:Selection
+  │   └─Selection	8000.00	cop[tikv]		gt(mul(planner__core__join_reorder_through_projection.t2.b, 2), 100)
+  │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+  └─TableReader(Probe)	10000.00	root		data:TableFullScan
+    └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.key_a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a and dt.doubled_b > 100
+order by 1;
+a	key_a
+1	1
+2	2
+3	3
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.key_a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a and dt.doubled_b > 100;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a
+├─TableReader(Build)	10000.00	root		data:TableFullScan
+│ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+└─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+    ├─TableReader(Build)	8000.00	root		data:Selection
+    │ └─Selection	8000.00	cop[tikv]		gt(mul(planner__core__join_reorder_through_projection.t2.b, 2), 100)
+    │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.key_a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a and dt.doubled_b > 100
+order by 1;
+a	key_a
+1	1
+2	2
+3	3
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt2.key_a from t1, t5,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted and dt2.key_a = t5.a;
+id	estRows	task	access object	operator info
+HashJoin	19531.25	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t5.a)]
+├─IndexReader(Build)	10000.00	root		index:IndexFullScan
+│ └─IndexFullScan	10000.00	cop[tikv]	table:t5, index:b(b)	keep order:false, stats:pseudo
+└─HashJoin(Probe)	15625.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.b, Column#17)]
+  ├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(Column#13, 10)->Column#17
+  │ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t4.a
+  │   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │   │ └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+  │   └─Projection(Probe)	10000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#13
+  │     └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  │       ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │       │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  │       └─TableReader(Probe)	8000.00	root		data:Selection
+  │         └─Selection	8000.00	cop[tikv]		not(isnull(plus(mul(planner__core__join_reorder_through_projection.t2.b, 2), 10)))
+  │           └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+  └─IndexReader(Probe)	9990.00	root		index:IndexFullScan
+    └─IndexFullScan	9990.00	cop[tikv]	table:t1, index:b(b)	keep order:false, stats:pseudo
+select t1.a, dt2.key_a from t1, t5,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted and dt2.key_a = t5.a
+order by 1;
+a	key_a
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt2.key_a from t1, t5,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted and dt2.key_a = t5.a;
+id	estRows	task	access object	operator info
+MergeJoin	19531.25	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a
+├─TableReader(Build)	10000.00	root		data:TableFullScan
+│ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+└─MergeJoin(Probe)	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t4.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─IndexHashJoin(Probe)	10000.00	root		inner join, inner:IndexReader, outer key:Column#21, inner key:planner__core__join_reorder_through_projection.t1.b, equal cond:eq(Column#21, planner__core__join_reorder_through_projection.t1.b)
+      ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t2.a, plus(mul(planner__core__join_reorder_through_projection.t2.b, 2), 10)->Column#21
+      │ └─TableReader	8000.00	root		data:Selection
+      │   └─Selection	8000.00	cop[tikv]		not(isnull(plus(mul(planner__core__join_reorder_through_projection.t2.b, 2), 10)))
+      │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+      └─IndexReader(Probe)	10000.00	root		index:Selection
+        └─Selection	10000.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+          └─IndexRangeScan	10010.01	cop[tikv]	table:t1, index:b(b)	range: decided by [eq(planner__core__join_reorder_through_projection.t1.b, Column#21)], keep order:false, stats:pseudo
+select t1.a, dt2.key_a from t1, t5,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted and dt2.key_a = t5.a
+order by 1;
+a	key_a
+set tidb_opt_join_reorder_threshold = 0;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.key_a, dt.doubled_b from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.doubled_b > 100;
+id	estRows	task	access object	operator info
+MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	10000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10
+│ └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	8000.00	root		data:Selection
+│     └─Selection	8000.00	cop[tikv]		gt(mul(planner__core__join_reorder_through_projection.t2.b, 2), 100)
+│       └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.key_a, dt.doubled_b from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.doubled_b > 100
+order by 1;
+a	key_a	doubled_b
+1	1	200
+2	2	400
+3	3	600
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.key_a, dt.doubled_b from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.doubled_b > 100;
+id	estRows	task	access object	operator info
+Projection	12500.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10
+└─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t1.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+    └─TableReader(Probe)	8000.00	root		data:Selection
+      └─Selection	8000.00	cop[tikv]		gt(mul(planner__core__join_reorder_through_projection.t2.b, 2), 100)
+        └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+select t1.a, dt.key_a, dt.doubled_b from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.doubled_b > 100
+order by 1;
+a	key_a	doubled_b
+1	1	200
+2	2	400
+3	3	600
+set tidb_opt_join_reorder_through_sel = on;
+set tidb_opt_join_reorder_threshold = 63;
+explain format = 'brief' select t1.a, dt.key_a, dt.doubled_b from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.doubled_b > 100;
+id	estRows	task	access object	operator info
+Projection	12500.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10
+└─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+    ├─TableReader(Build)	8000.00	root		data:Selection
+    │ └─Selection	8000.00	cop[tikv]		gt(mul(planner__core__join_reorder_through_projection.t2.b, 2), 100)
+    │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.key_a, dt.doubled_b from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.doubled_b > 100
+order by 1;
+a	key_a	doubled_b
+1	1	200
+2	2	400
+3	3	600
+set tidb_opt_join_reorder_threshold = 0;
+set tidb_opt_join_reorder_through_sel = off;
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.*, dt.* from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b;
+id	estRows	task	access object	operator info
+HashJoin	12500.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.b, Column#10)]
+├─Projection(Build)	10000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10
+│ └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	8000.00	root		data:Selection
+│     └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2)))
+│       └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	9990.00	root		data:Selection
+  └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+    └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+select t1.*, dt.* from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b
+order by 1;
+a	b	c	key_a	doubled_b
+4	200	a4	1	200
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.*, dt.* from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b;
+id	estRows	task	access object	operator info
+Projection	12500.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t1.b, planner__core__join_reorder_through_projection.t1.c, planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10
+└─HashJoin	12500.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t3.a)]
+  ├─IndexReader(Build)	10000.00	root		index:IndexFullScan
+  │ └─IndexFullScan	10000.00	cop[tikv]	table:t3, index:b(b)	keep order:false, stats:pseudo
+  └─HashJoin(Probe)	10000.00	root		inner join, equal:[eq(Column#12, planner__core__join_reorder_through_projection.t1.b)]
+    ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t2.b, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#12
+    │ └─IndexReader	8000.00	root		index:Selection
+    │   └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2)))
+    │     └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:b(b)	keep order:false, stats:pseudo
+    └─TableReader(Probe)	9990.00	root		data:Selection
+      └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+        └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+select t1.*, dt.* from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b
+order by 1;
+a	b	c	key_a	doubled_b
+4	200	a4	1	200
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.*, dt.* from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c
+from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c;
+id	estRows	task	access object	operator info
+HashJoin	12500.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.b, Column#10) eq(planner__core__join_reorder_through_projection.t1.c, Column#11)]
+├─Projection(Build)	10000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10, upper(planner__core__join_reorder_through_projection.t2.c)->Column#11
+│ └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	8000.00	root		data:Selection
+│     └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2))), not(isnull(upper(planner__core__join_reorder_through_projection.t2.c)))
+│       └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	9980.01	root		data:Selection
+  └─Selection	9980.01	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b)), not(isnull(planner__core__join_reorder_through_projection.t1.c))
+    └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+select t1.*, dt.* from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c
+from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c
+order by 1;
+a	b	c	key_a	doubled_b	upper_c
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.*, dt.* from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c
+from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c;
+id	estRows	task	access object	operator info
+Projection	12500.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t1.b, planner__core__join_reorder_through_projection.t1.c, planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10, upper(planner__core__join_reorder_through_projection.t2.c)->Column#11
+└─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+  └─IndexHashJoin(Probe)	10000.00	root		inner join, inner:IndexLookUp, outer key:Column#14, inner key:planner__core__join_reorder_through_projection.t1.b, equal cond:eq(Column#14, planner__core__join_reorder_through_projection.t1.b), eq(Column#15, planner__core__join_reorder_through_projection.t1.c)
+    ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t2.c, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#14, upper(planner__core__join_reorder_through_projection.t2.c)->Column#15
+    │ └─TableReader	8000.00	root		data:Selection
+    │   └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2))), not(isnull(upper(planner__core__join_reorder_through_projection.t2.c)))
+    │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─IndexLookUp(Probe)	10000.00	root		
+      ├─Selection(Build)	10010.01	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+      │ └─IndexRangeScan	10020.03	cop[tikv]	table:t1, index:b(b)	range: decided by [eq(planner__core__join_reorder_through_projection.t1.b, Column#14)], keep order:false, stats:pseudo
+      └─Selection(Probe)	10000.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.c))
+        └─TableRowIDScan	10010.01	cop[tikv]	table:t1	keep order:false, stats:pseudo
+select t1.*, dt.* from t1,
+(select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c
+from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c
+order by 1;
+a	b	c	key_a	doubled_b	upper_c
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.*, dt.*, t5.a as t5_a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t1.b, planner__core__join_reorder_through_projection.t1.c, planner__core__join_reorder_through_projection.t2.a, Column#13, planner__core__join_reorder_through_projection.t5.a
+└─Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t1.b, planner__core__join_reorder_through_projection.t1.c, planner__core__join_reorder_through_projection.t5.a, planner__core__join_reorder_through_projection.t2.a, Column#13
+  └─HashJoin	15625.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t5.a)]
+    ├─IndexReader(Build)	10000.00	root		index:IndexFullScan
+    │ └─IndexFullScan	10000.00	cop[tikv]	table:t5, index:b(b)	keep order:false, stats:pseudo
+    └─HashJoin(Probe)	12500.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.b, Column#13)]
+      ├─Projection(Build)	10000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#13
+      │ └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+      │   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+      │   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+      │   └─TableReader(Probe)	8000.00	root		data:Selection
+      │     └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2)))
+      │       └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+      └─TableReader(Probe)	9990.00	root		data:Selection
+        └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+          └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+select t1.*, dt.*, t5.a as t5_a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a
+order by 1;
+a	b	c	key_a	doubled_b	t5_a
+4	200	a4	1	200	1
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.*, dt.*, t5.a as t5_a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t1.b, planner__core__join_reorder_through_projection.t1.c, planner__core__join_reorder_through_projection.t2.a, Column#13, planner__core__join_reorder_through_projection.t5.a
+└─Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t1.b, planner__core__join_reorder_through_projection.t1.c, planner__core__join_reorder_through_projection.t5.a, planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#13
+  └─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a
+      ├─TableReader(Build)	10000.00	root		data:TableFullScan
+      │ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+      └─IndexHashJoin(Probe)	10000.00	root		inner join, inner:IndexLookUp, outer key:Column#15, inner key:planner__core__join_reorder_through_projection.t1.b, equal cond:eq(Column#15, planner__core__join_reorder_through_projection.t1.b)
+        ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t2.b, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#15
+        │ └─TableReader	8000.00	root		data:Selection
+        │   └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2)))
+        │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+        └─IndexLookUp(Probe)	10000.00	root		
+          ├─Selection(Build)	10000.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+          │ └─IndexRangeScan	10010.01	cop[tikv]	table:t1, index:b(b)	range: decided by [eq(planner__core__join_reorder_through_projection.t1.b, Column#15)], keep order:false, stats:pseudo
+          └─TableRowIDScan(Probe)	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+select t1.*, dt.*, t5.a as t5_a from t1, t5,
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a
+order by 1;
+a	b	c	key_a	doubled_b	t5_a
+4	200	a4	1	200	1
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.*, dt2.* from t1,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted;
+id	estRows	task	access object	operator info
+HashJoin	15625.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.b, Column#14)]
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(Column#10, 10)->Column#14
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t4.a, right key:planner__core__join_reorder_through_projection.t2.a
+│   ├─Projection(Build)	10000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#10
+│   │ └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   │   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   │   └─TableReader(Probe)	8000.00	root		data:Selection
+│   │     └─Selection	8000.00	cop[tikv]		not(isnull(plus(mul(planner__core__join_reorder_through_projection.t2.b, 2), 10)))
+│   │       └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+└─TableReader(Probe)	9990.00	root		data:Selection
+  └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+    └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+select t1.*, dt2.* from t1,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted
+order by 1;
+a	b	c	key_a	adjusted
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.*, dt2.* from t1,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t1.b, planner__core__join_reorder_through_projection.t1.c, planner__core__join_reorder_through_projection.t2.a, plus(mul(planner__core__join_reorder_through_projection.t2.b, 2), 10)->Column#14
+└─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t4.a
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+  └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─IndexHashJoin(Probe)	10000.00	root		inner join, inner:IndexLookUp, outer key:Column#18, inner key:planner__core__join_reorder_through_projection.t1.b, equal cond:eq(Column#18, planner__core__join_reorder_through_projection.t1.b)
+      ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t2.b, plus(mul(planner__core__join_reorder_through_projection.t2.b, 2), 10)->Column#18
+      │ └─TableReader	8000.00	root		data:Selection
+      │   └─Selection	8000.00	cop[tikv]		not(isnull(plus(mul(planner__core__join_reorder_through_projection.t2.b, 2), 10)))
+      │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+      └─IndexLookUp(Probe)	10000.00	root		
+        ├─Selection(Build)	10000.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+        │ └─IndexRangeScan	10010.01	cop[tikv]	table:t1, index:b(b)	range: decided by [eq(planner__core__join_reorder_through_projection.t1.b, Column#18)], keep order:false, stats:pseudo
+        └─TableRowIDScan(Probe)	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+select t1.*, dt2.* from t1,
+(select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+(select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted
+order by 1;
+a	b	c	key_a	adjusted
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt1.*, dt2.* from
+(select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b * 2 as doubled2 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled2;
+id	estRows	task	access object	operator info
+HashJoin	15625.00	root		inner join, equal:[eq(Column#7, Column#14)]
+├─Projection(Build)	10000.00	root		planner__core__join_reorder_through_projection.t3.a, mul(planner__core__join_reorder_through_projection.t3.b, 2)->Column#14
+│ └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t3.a, right key:planner__core__join_reorder_through_projection.t4.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	8000.00	root		data:Selection
+│     └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t3.b, 2)))
+│       └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+└─Projection(Probe)	10000.00	root		planner__core__join_reorder_through_projection.t1.a, mul(planner__core__join_reorder_through_projection.t1.b, 2)->Column#7
+  └─MergeJoin	10000.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─TableReader(Probe)	8000.00	root		data:Selection
+      └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t1.b, 2)))
+        └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select dt1.*, dt2.* from
+(select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b * 2 as doubled2 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled2
+order by 1;
+a1	doubled1	a3	doubled2
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt1.*, dt2.* from
+(select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b * 2 as doubled2 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled2;
+id	estRows	task	access object	operator info
+Projection	15625.00	root		planner__core__join_reorder_through_projection.t1.a, mul(planner__core__join_reorder_through_projection.t1.b, 2)->Column#7, planner__core__join_reorder_through_projection.t3.a, mul(planner__core__join_reorder_through_projection.t3.b, 2)->Column#14
+└─HashJoin	15625.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t3.a, planner__core__join_reorder_through_projection.t4.a)]
+  ├─IndexReader(Build)	10000.00	root		index:IndexFullScan
+  │ └─IndexFullScan	10000.00	cop[tikv]	table:t4, index:b(b)	keep order:false, stats:pseudo
+  └─HashJoin(Probe)	12500.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a)]
+    ├─IndexReader(Build)	10000.00	root		index:IndexFullScan
+    │ └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:b(b)	keep order:false, stats:pseudo
+    └─HashJoin(Probe)	10000.00	root		inner join, equal:[eq(Column#17, Column#18)]
+      ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t3.a, planner__core__join_reorder_through_projection.t3.b, mul(planner__core__join_reorder_through_projection.t3.b, 2)->Column#18
+      │ └─IndexReader	8000.00	root		index:Selection
+      │   └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t3.b, 2)))
+      │     └─IndexFullScan	10000.00	cop[tikv]	table:t3, index:b(b)	keep order:false, stats:pseudo
+      └─Projection(Probe)	8000.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t1.b, mul(planner__core__join_reorder_through_projection.t1.b, 2)->Column#17
+        └─IndexReader	8000.00	root		index:Selection
+          └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t1.b, 2)))
+            └─IndexFullScan	10000.00	cop[tikv]	table:t1, index:b(b)	keep order:false, stats:pseudo
+select dt1.*, dt2.* from
+(select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b * 2 as doubled2 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled2
+order by 1;
+a1	doubled1	a3	doubled2
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.* from t1,
+(select t2.a as key_a, t2.b + t3.b as cross_sum, t2.b * t3.b as cross_product
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#10, mul(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#11
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.* from t1,
+(select t2.a as key_a, t2.b + t3.b as cross_sum, t2.b * t3.b as cross_product
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+a	key_a	cross_sum	cross_product
+1	1	1100	100000
+2	2	2200	400000
+3	3	3300	900000
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.* from t1,
+(select t2.a as key_a, t2.b + t3.b as cross_sum, t2.b * t3.b as cross_product
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#10, mul(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#11
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.* from t1,
+(select t2.a as key_a, t2.b + t3.b as cross_sum, t2.b * t3.b as cross_product
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+a	key_a	cross_sum	cross_product
+1	1	1100	100000
+2	2	2200	400000
+3	3	3300	900000
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.* from t1,
+(select t2.a as key_a,
+concat(t2.c, '-', t3.c) as combined_c,
+greatest(t2.b, t3.b) as max_b,
+least(t2.b, t3.b) as min_b
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, concat(planner__core__join_reorder_through_projection.t2.c, -, planner__core__join_reorder_through_projection.t3.c)->Column#10, greatest(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#11, least(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#12
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.* from t1,
+(select t2.a as key_a,
+concat(t2.c, '-', t3.c) as combined_c,
+greatest(t2.b, t3.b) as max_b,
+least(t2.b, t3.b) as min_b
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+a	key_a	combined_c	max_b	min_b
+1	1	b1-c1	1000	100
+2	2	b2-c2	2000	200
+3	3	b3-c3	3000	300
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.* from t1,
+(select t2.a as key_a,
+concat(t2.c, '-', t3.c) as combined_c,
+greatest(t2.b, t3.b) as max_b,
+least(t2.b, t3.b) as min_b
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, concat(planner__core__join_reorder_through_projection.t2.c, -, planner__core__join_reorder_through_projection.t3.c)->Column#10, greatest(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#11, least(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#12
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select t1.a, dt.* from t1,
+(select t2.a as key_a,
+concat(t2.c, '-', t3.c) as combined_c,
+greatest(t2.b, t3.b) as max_b,
+least(t2.b, t3.b) as min_b
+from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+a	key_a	combined_c	max_b	min_b
+1	1	b1-c1	1000	100
+2	2	b2-c2	2000	200
+3	3	b3-c3	3000	300
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' with joined_cte as (
+select t2.a as cte_a, t2.b + t3.b as sum_b
+from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.sum_b from t1 join joined_cte cte on t1.a = cte.cte_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#19
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+with joined_cte as (
+select t2.a as cte_a, t2.b + t3.b as sum_b
+from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.sum_b from t1 join joined_cte cte on t1.a = cte.cte_a
+order by 1;
+a	cte_a	sum_b
+1	1	1100
+2	2	2200
+3	3	3300
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' with joined_cte as (
+select t2.a as cte_a, t2.b + t3.b as sum_b
+from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.sum_b from t1 join joined_cte cte on t1.a = cte.cte_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#19
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+with joined_cte as (
+select t2.a as cte_a, t2.b + t3.b as sum_b
+from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.sum_b from t1 join joined_cte cte on t1.a = cte.cte_a
+order by 1;
+a	cte_a	sum_b
+1	1	1100
+2	2	2200
+3	3	3300
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt.*, t5.a as t5_a from
+(select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		left outer join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a
+├─TableReader(Build)	10000.00	root		data:TableFullScan
+│ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+└─Projection(Probe)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#7
+  └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+select dt.*, t5.a as t5_a from
+(select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a
+order by 1;
+key_a	sum_b	t5_a
+1	1100	1
+2	2200	2
+3	3300	3
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt.*, t5.a as t5_a from
+(select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		left outer join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t5.a
+├─TableReader(Build)	10000.00	root		data:TableFullScan
+│ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+└─Projection(Probe)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#7
+  └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+select dt.*, t5.a as t5_a from
+(select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a
+order by 1;
+key_a	sum_b	t5_a
+1	1100	1
+2	2200	2
+3	3300	3
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t5.a as t5_a, dt.* from t5
+right join (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+on t5.a = dt.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		right outer join, left key:planner__core__join_reorder_through_projection.t5.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─TableReader(Build)	10000.00	root		data:TableFullScan
+│ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+└─Projection(Probe)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#10
+  └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+select t5.a as t5_a, dt.* from t5
+right join (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+on t5.a = dt.key_a
+order by 1;
+t5_a	key_a	sum_b
+1	1	1100
+2	2	2200
+3	3	3300
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t5.a as t5_a, dt.* from t5
+right join (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+on t5.a = dt.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	15625.00	root		right outer join, left key:planner__core__join_reorder_through_projection.t5.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─TableReader(Build)	10000.00	root		data:TableFullScan
+│ └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:true, stats:pseudo
+└─Projection(Probe)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#10
+  └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+select t5.a as t5_a, dt.* from t5
+right join (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+on t5.a = dt.key_a
+order by 1;
+t5_a	key_a	sum_b
+1	1	1100
+2	2	2200
+3	3	3300
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt1.*, dt2.* from
+(select t1.a as a1, t1.b + t2.b as sum1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b + t4.b as sum3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3;
+id	estRows	task	access object	operator info
+MergeJoin	19531.25	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t3.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t3.a, plus(planner__core__join_reorder_through_projection.t3.b, planner__core__join_reorder_through_projection.t4.b)->Column#14
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t3.a, right key:planner__core__join_reorder_through_projection.t4.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+└─Projection(Probe)	12500.00	root		planner__core__join_reorder_through_projection.t1.a, plus(planner__core__join_reorder_through_projection.t1.b, planner__core__join_reorder_through_projection.t2.b)->Column#7
+  └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select dt1.*, dt2.* from
+(select t1.a as a1, t1.b + t2.b as sum1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b + t4.b as sum3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3
+order by 1;
+a1	sum1	a3	sum3
+1	110	1	11000
+2	220	2	22000
+3	330	3	33000
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt1.*, dt2.* from
+(select t1.a as a1, t1.b + t2.b as sum1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b + t4.b as sum3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3;
+id	estRows	task	access object	operator info
+MergeJoin	19531.25	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t3.a
+├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t3.a, plus(planner__core__join_reorder_through_projection.t3.b, planner__core__join_reorder_through_projection.t4.b)->Column#14
+│ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t3.a, right key:planner__core__join_reorder_through_projection.t4.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+│   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+└─Projection(Probe)	12500.00	root		planner__core__join_reorder_through_projection.t1.a, plus(planner__core__join_reorder_through_projection.t1.b, planner__core__join_reorder_through_projection.t2.b)->Column#7
+  └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+    ├─TableReader(Build)	10000.00	root		data:TableFullScan
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    └─TableReader(Probe)	10000.00	root		data:TableFullScan
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+select dt1.*, dt2.* from
+(select t1.a as a1, t1.b + t2.b as sum1 from t1 join t2 on t1.a = t2.a) dt1,
+(select t3.a as a3, t3.b + t4.b as sum3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3
+order by 1;
+a1	sum1	a3	sum3
+1	110	1	11000
+2	220	2	22000
+3	330	3	33000
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select outer_t.a, dt2.* from t1 outer_t,
+(select dt1.key_a, dt1.sum_b + t4.b as final_sum from
+(select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	19531.25	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	15625.00	root		planner__core__join_reorder_through_projection.t2.a, plus(Column#10, planner__core__join_reorder_through_projection.t4.b)->Column#14
+│ └─Projection	15625.00	root		planner__core__join_reorder_through_projection.t2.a, Column#10, planner__core__join_reorder_through_projection.t4.b
+│   └─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t4.a, right key:planner__core__join_reorder_through_projection.t2.a
+│     ├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#10
+│     │ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│     │   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│     │   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│     │   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│     └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│       └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:outer_t	keep order:true, stats:pseudo
+select outer_t.a, dt2.* from t1 outer_t,
+(select dt1.key_a, dt1.sum_b + t4.b as final_sum from
+(select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a
+order by 1;
+a	key_a	final_sum
+1	1	11100
+2	2	22200
+3	3	33300
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select outer_t.a, dt2.* from t1 outer_t,
+(select dt1.key_a, dt1.sum_b + t4.b as final_sum from
+(select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a;
+id	estRows	task	access object	operator info
+MergeJoin	19531.25	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a
+├─Projection(Build)	15625.00	root		planner__core__join_reorder_through_projection.t2.a, plus(Column#10, planner__core__join_reorder_through_projection.t4.b)->Column#14
+│ └─Projection	15625.00	root		planner__core__join_reorder_through_projection.t2.a, Column#10, planner__core__join_reorder_through_projection.t4.b
+│   └─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t4.a, right key:planner__core__join_reorder_through_projection.t2.a
+│     ├─Projection(Build)	12500.00	root		planner__core__join_reorder_through_projection.t2.a, plus(planner__core__join_reorder_through_projection.t2.b, planner__core__join_reorder_through_projection.t3.b)->Column#10
+│     │ └─MergeJoin	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t2.a, right key:planner__core__join_reorder_through_projection.t3.a
+│     │   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│     │   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│     │   └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│     │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│     └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│       └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:outer_t	keep order:true, stats:pseudo
+select outer_t.a, dt2.* from t1 outer_t,
+(select dt1.key_a, dt1.sum_b + t4.b as final_sum from
+(select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt1
+join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a
+order by 1;
+a	key_a	final_sum
+1	1	11100
+2	2	22200
+3	3	33300
+drop table if exists t1, t2, t3, t4;
+create table t1(a int, b int, primary key (a));
+create table t2(a int, b int, primary key (a));
+create table t3(a int, b int, primary key (a));
+create table t4(a int, b int, primary key (a));
+insert into t1 values(1, 10), (2, 20), (3, 30);
+insert into t2 values(1, 100), (2, 200), (3, 300);
+insert into t3 values(1, 1000), (2, 2000), (3, 3000);
+insert into t4 values(101, 1), (120, 2), (230, 3);
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t4.a, tt.plus from t4,
+(select t.a + t.b as plus, t3.a as t3_a from (
+select t1.a as a, t2.b as b from t1, t2 where t1.a = t2.a
+) t
+join t3 on t.a = t3.a) tt
+where t4.a = tt.plus;
+id	estRows	task	access object	operator info
+HashJoin	19531.25	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t4.a, Column#9)]
+├─Projection(Build)	15625.00	root		plus(planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.b)->Column#9
+│ └─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a, other cond:not(isnull(plus(planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.b)))
+│     ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│     │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│     └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│       └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:false, stats:pseudo
+select t4.a, tt.plus from t4,
+(select t.a + t.b as plus, t3.a as t3_a from (
+select t1.a as a, t2.b as b from t1, t2 where t1.a = t2.a
+) t
+join t3 on t.a = t3.a) tt
+where t4.a = tt.plus order by t4.a;
+a	plus
+101	101
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t4.a, tt.plus from t4,
+(select t.a + t.b as plus, t3.a as t3_a from (
+select t1.a as a, t2.b as b from t1, t2 where t1.a = t2.a
+) t
+join t3 on t.a = t3.a) tt
+where t4.a = tt.plus;
+id	estRows	task	access object	operator info
+HashJoin	19531.25	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t4.a, Column#9)]
+├─Projection(Build)	15625.00	root		plus(planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.b)->Column#9
+│ └─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a, other cond:not(isnull(plus(planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.b)))
+│     ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│     │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│     └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│       └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:false, stats:pseudo
+select t4.a, tt.plus from t4,
+(select t.a + t.b as plus, t3.a as t3_a from (
+select t1.a as a, t2.b as b from t1, t2 where t1.a = t2.a
+) t
+join t3 on t.a = t3.a) tt
+where t4.a = tt.plus order by t4.a;
+a	plus
+101	101
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t4.a, dt2.combined from t4,
+(select dt1.val_a + dt1.val_b as combined, t3.a as t3_a from (
+select t1.a as val_a, t2.b as val_b from t1 join t2 on t1.a = t2.a
+) dt1
+join t3 on dt1.val_a = t3.a) dt2
+where t4.a = dt2.combined;
+id	estRows	task	access object	operator info
+HashJoin	19531.25	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t4.a, Column#9)]
+├─Projection(Build)	15625.00	root		plus(planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.b)->Column#9
+│ └─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a, other cond:not(isnull(plus(planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.b)))
+│     ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│     │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│     └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│       └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:false, stats:pseudo
+select t4.a, dt2.combined from t4,
+(select dt1.val_a + dt1.val_b as combined, t3.a as t3_a from (
+select t1.a as val_a, t2.b as val_b from t1 join t2 on t1.a = t2.a
+) dt1
+join t3 on dt1.val_a = t3.a) dt2
+where t4.a = dt2.combined order by t4.a;
+a	combined
+101	101
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t4.a, dt2.combined from t4,
+(select dt1.val_a + dt1.val_b as combined, t3.a as t3_a from (
+select t1.a as val_a, t2.b as val_b from t1 join t2 on t1.a = t2.a
+) dt1
+join t3 on dt1.val_a = t3.a) dt2
+where t4.a = dt2.combined;
+id	estRows	task	access object	operator info
+HashJoin	19531.25	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t4.a, Column#9)]
+├─Projection(Build)	15625.00	root		plus(planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.b)->Column#9
+│ └─MergeJoin	15625.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t3.a
+│   ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│   │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:true, stats:pseudo
+│   └─MergeJoin(Probe)	12500.00	root		inner join, left key:planner__core__join_reorder_through_projection.t1.a, right key:planner__core__join_reorder_through_projection.t2.a, other cond:not(isnull(plus(planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.b)))
+│     ├─TableReader(Build)	10000.00	root		data:TableFullScan
+│     │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│     └─TableReader(Probe)	10000.00	root		data:TableFullScan
+│       └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+└─TableReader(Probe)	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:false, stats:pseudo
+select t4.a, dt2.combined from t4,
+(select dt1.val_a + dt1.val_b as combined, t3.a as t3_a from (
+select t1.a as val_a, t2.b as val_b from t1 join t2 on t1.a = t2.a
+) dt1
+join t3 on dt1.val_a = t3.a) dt2
+where t4.a = dt2.combined order by t4.a;
+a	combined
+101	101
+set tidb_opt_join_reorder_through_proj = on;
+set tidb_opt_join_reorder_threshold = 0;
+set tidb_opt_advanced_join_hint = on;
+explain format = 'brief' select t1.a, dt.a2 from t1 join (
+select t2.a as a2, t2.b * 2 as doubled_b, t3.a as a3
+from t2 join t3 on t2.a = t3.a
+) dt on t1.b = dt.doubled_b;
+id	estRows	task	access object	operator info
+Projection	12500.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a
+└─HashJoin	12500.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t3.a)]
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+  └─HashJoin(Probe)	10000.00	root		inner join, equal:[eq(Column#9, planner__core__join_reorder_through_projection.t1.b)]
+    ├─Projection(Build)	8000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#9
+    │ └─TableReader	8000.00	root		data:Selection
+    │   └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2)))
+    │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+    └─TableReader(Probe)	9990.00	root		data:Selection
+      └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+        └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+explain format = 'brief' select t1.a, dt.a2 from t1 join (
+select /*+ merge_join(t2) */ t2.a as a2, t2.b * 2 as doubled_b, t3.a as a3
+from t2 join t3 on t2.a = t3.a
+) dt on t1.b = dt.doubled_b;
+id	estRows	task	access object	operator info
+Projection	12500.00	root		planner__core__join_reorder_through_projection.t1.a, planner__core__join_reorder_through_projection.t2.a
+└─HashJoin	12500.00	root		inner join, equal:[eq(planner__core__join_reorder_through_projection.t2.a, planner__core__join_reorder_through_projection.t3.a)]
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+  └─MergeJoin(Probe)	10000.00	root		inner join, left key:Column#9, right key:planner__core__join_reorder_through_projection.t1.b
+    ├─Sort(Build)	9990.00	root		planner__core__join_reorder_through_projection.t1.b
+    │ └─TableReader	9990.00	root		data:Selection
+    │   └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__join_reorder_through_projection.t1.b))
+    │     └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+    └─Sort(Probe)	8000.00	root		Column#9
+      └─Projection	8000.00	root		planner__core__join_reorder_through_projection.t2.a, mul(planner__core__join_reorder_through_projection.t2.b, 2)->Column#9
+        └─TableReader	8000.00	root		data:Selection
+          └─Selection	8000.00	cop[tikv]		not(isnull(mul(planner__core__join_reorder_through_projection.t2.b, 2)))
+            └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+set tidb_opt_join_reorder_through_proj = off;
+drop table if exists t1, t2, t3, t4, t5;

--- a/tests/integrationtest/t/planner/core/cbo.test
+++ b/tests/integrationtest/t/planner/core/cbo.test
@@ -60,5 +60,5 @@ insert into t1 values (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 4), (5, 5, 5);
 insert into t2 values (2, 22), (3, 33), (5, 55), (233, 2), (333, 3), (3434, 5);
 analyze table t1, t2 all columns;
 --replace_regex /:[ ]?[.0-9]+[nµms]*/:<num>/ /time.*loops.*cop_task.*/time.*loops.*cop_task.*/ /, scan_detail: {.*}// /[.0-9]+ ((KB)|(Bytes))/<num>/
-explain analyze select t1.a, t1.b, sum(t1.c) from t1 join t2 on t1.a = t2.b where t1.a > 1;
+explain analyze format='brief' select t1.a, t1.b, sum(t1.c) from t1 join t2 on t1.a = t2.b where t1.a > 1;
 set sql_mode=default;

--- a/tests/integrationtest/t/planner/core/join_reorder_through_projection.test
+++ b/tests/integrationtest/t/planner/core/join_reorder_through_projection.test
@@ -1,0 +1,1599 @@
+# Test join reorder through projection
+# Tests for join reorder optimization when projection operators contain expressions
+#
+# Overview:
+# The tidb_opt_join_reorder_through_proj session variable controls whether
+# the join reorder algorithm can "look through" projection operators to find more
+# reorderable join nodes. When a projection contains expressions (e.g., t2.b + t3.b),
+# it creates "derived columns" that hide the underlying join structure from the
+# join reorder algorithm.
+#
+# This optimization:
+# 1. Inlines safe projections during join group extraction
+# 2. Maintains a column-to-expression mapping (colExprMap) for derived columns
+# 3. Substitutes derived column references in join conditions with their original expressions
+# 4. Restores the output schema after reordering by adding a projection if needed
+#
+# Safety conditions for inline:
+# - No non-deterministic functions (rand, uuid, etc.)
+# - No side effects (setvar, sleep, etc.)
+# - No correlated columns
+# - No cross-table expressions in single projection expression
+# - Single-table string expressions are supported (collation safe)
+# - Only Column/ScalarFunction/Constant nodes are supported inside expression trees;
+#   other Expression implementations (e.g. ScalarSubQueryExpr) are NOT inlined (deny by default).
+# - Each projection expression must reference at least one column; constant-only expressions
+#   (including deterministic "pure functions") are not inlined.
+
+# =============================================================================
+# Setup test tables
+# =============================================================================
+drop table if exists t1, t2, t3, t4, t5;
+create table t1(a int, b int, c varchar(32), primary key (a), key(b));
+create table t2(a int, b int, c varchar(32), primary key (a), key(b));
+create table t3(a int, b int, c varchar(32), primary key (a), key(b));
+create table t4(a int, b int, c varchar(32), primary key (a), key(b));
+create table t5(a int, b int, c varchar(32), primary key (a), key(b));
+
+insert into t1 values(1, 10, 'a1'), (2, 20, 'a2'), (3, 30, 'a3'), (4, 200, 'a4');
+insert into t2 values(1, 100, 'b1'), (2, 200, 'b2'), (3, 300, 'b3');
+insert into t3 values(1, 1000, 'c1'), (2, 2000, 'c2'), (3, 3000, 'c3');
+insert into t4 values(1, 10000, 'd1'), (2, 20000, 'd2'), (3, 30000, 'd3');
+insert into t5 values(1, 10, 'e1'), (2, 20, 'e2'), (3, 30, 'e3'), (4, 40, 'e4');
+
+# release-8.5 only has the legacy join reorder implementation.
+
+# =============================================================================
+# Basic Single-Table Expressions (Can Inline)
+# =============================================================================
+# Query: t1 JOIN (t2 JOIN t3 with single-table expressions in SELECT)
+# The projection uses expressions that only reference ONE table each.
+#
+# EXPECTED BEHAVIOR:
+# - OFF: Join group is {t1} and {Projection(t2 JOIN t3)}. The projection blocks
+#   join reorder from seeing t2 and t3 as separate relations.
+# - ON: Projection is inlined because expressions only reference single tables:
+#   - t2.b * 2 (only references t2)
+#   - t3.b + 100 (only references t3)
+#   Join group becomes {t1, t2, t3}. Join conditions using derived columns are
+#   substituted to use base columns.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.doubled_b, dt.shifted_b from t1,
+  (select t2.a as a2, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2;
+
+select t1.a, dt.doubled_b, dt.shifted_b from t1,
+  (select t2.a as a2, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.doubled_b, dt.shifted_b from t1,
+  (select t2.a as a2, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2;
+
+select t1.a, dt.doubled_b, dt.shifted_b from t1,
+  (select t2.a as a2, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2
+order by 1;
+
+
+# =============================================================================
+# CTE (Common Table Expression) with Single-Table Expression (Can Inline)
+# =============================================================================
+# Query: t1 JOIN (CTE containing t2 JOIN t3 with single-table expression)
+# The CTE uses t2.b * 2 which only references t2 (single-table, can inline).
+#
+# EXPECTED BEHAVIOR:
+# - CTE is inlined (non-recursive CTE), so it behaves like a derived table.
+# - The projection over the join inside CTE is processed for inlining.
+# - Since t2.b * 2 only references t2, it CAN be inlined.
+#
+# NOTE: TiDB inlines simple CTEs, so this test behaves similarly to derived tables.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' with joined_cte as (
+  select t2.a as cte_a, t2.b * 2 as doubled_b
+  from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.doubled_b from t1 join joined_cte cte on t1.a = cte.cte_a;
+
+with joined_cte as (
+  select t2.a as cte_a, t2.b * 2 as doubled_b
+  from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.doubled_b from t1 join joined_cte cte on t1.a = cte.cte_a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' with joined_cte as (
+  select t2.a as cte_a, t2.b * 2 as doubled_b
+  from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.doubled_b from t1 join joined_cte cte on t1.a = cte.cte_a;
+
+with joined_cte as (
+  select t2.a as cte_a, t2.b * 2 as doubled_b
+  from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.doubled_b from t1 join joined_cte cte on t1.a = cte.cte_a
+order by 1;
+
+# Nested Projection over Join - Key Test Case
+# Query: t1 JOIN (Projection over (t2 JOIN t3))
+# This test specifically validates that projections OVER JOIN nodes can be inlined.
+# Previous test had projection over DataSource which is treated as atomic unit.
+#
+# STRUCTURE:
+# - Inner: t2 JOIN t3 ON t2.a = t3.a (produces base join)
+# - Middle: Projection over this join with single-table expressions
+# - Outer: t1 joins with the projected result
+#
+# EXPECTED BEHAVIOR:
+# - OFF: Join group = {t1, Projection(t2 JOIN t3)}, projection blocks visibility
+# - ON: Projection is inlined, join group = {t1, t2, t3}
+#   The projection moves to the top level, and join conditions are substituted
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.* from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+
+select t1.a, dt.* from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.* from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+
+select t1.a, dt.* from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b, t3.b + 100 as shifted_b
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+
+# =============================================================================
+# Unsupported Expression Types in Projection (Should NOT Inline)
+# =============================================================================
+# Scalar subqueries in the projection list are represented as ScalarSubQueryExpr (not ScalarFunction).
+# We conservatively do NOT inline such projections.
+set tidb_opt_enable_non_eval_scalar_subquery = on;
+set tidb_opt_join_reorder_through_proj = off;
+--replace_regex /ScalarQueryCol#[0-9]+/ScalarQueryCol#<id>/
+explain format = 'brief' select t1.a, dt.subq_cnt from t1 join (
+  select t2.a as a2, (select count(*) from t4) as subq_cnt
+  from t2 join t3 on t2.a = t3.a
+) dt on t1.a = dt.a2;
+
+set tidb_opt_join_reorder_through_proj = on;
+--replace_regex /ScalarQueryCol#[0-9]+/ScalarQueryCol#<id>/
+explain format = 'brief' select t1.a, dt.subq_cnt from t1 join (
+  select t2.a as a2, (select count(*) from t4) as subq_cnt
+  from t2 join t3 on t2.a = t3.a
+) dt on t1.a = dt.a2;
+
+# Scalar subqueries can also appear as arguments of ScalarFunction in projection expressions.
+# The subquery argument is still a ScalarSubQueryExpr and should prevent inlining.
+set tidb_opt_join_reorder_through_proj = off;
+--replace_regex /ScalarQueryCol#[0-9]+/ScalarQueryCol#<id>/
+explain format = 'brief' select t1.a, dt.subq_cnt from t1 join (
+  select t2.a as a2, ifnull((select count(*) from t4), 0) as subq_cnt
+  from t2 join t3 on t2.a = t3.a
+) dt on t1.a = dt.a2;
+
+set tidb_opt_join_reorder_through_proj = on;
+--replace_regex /ScalarQueryCol#[0-9]+/ScalarQueryCol#<id>/
+explain format = 'brief' select t1.a, dt.subq_cnt from t1 join (
+  select t2.a as a2, ifnull((select count(*) from t4), 0) as subq_cnt
+  from t2 join t3 on t2.a = t3.a
+) dt on t1.a = dt.a2;
+set tidb_opt_enable_non_eval_scalar_subquery = off;
+
+# Proj4Expand projection must not be inlined.
+# GROUP BY ... WITH ROLLUP introduces Expand + Proj4Expand over the join.
+# ON/OFF should keep the same shape for the derived table side.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.key_a, dt.sum_b from t1 join (
+  select t2.a as key_a, sum(t3.b) as sum_b
+  from t2 join t3 on t2.a = t3.a
+  group by t2.a with rollup
+) dt on t1.a = dt.key_a;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.key_a, dt.sum_b from t1 join (
+  select t2.a as key_a, sum(t3.b) as sum_b
+  from t2 join t3 on t2.a = t3.a
+  group by t2.a with rollup
+) dt on t1.a = dt.key_a;
+
+# Constant-only projection expression must not be inlined.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.const_one from t1 join (
+  select t2.a as a2, 1 as const_one
+  from t2 join t3 on t2.a = t3.a
+) dt on t1.a = dt.a2;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.const_one from t1 join (
+  select t2.a as a2, 1 as const_one
+  from t2 join t3 on t2.a = t3.a
+) dt on t1.a = dt.a2;
+
+# =============================================================================
+# Current Limitation: Injected Projection Carries Null-Extended Pass-Through Columns
+# =============================================================================
+# This reproduces the legacy-path limitation discussed in the code comments around
+# canInlineProjection().
+#
+# Query shape:
+# - mp LEFT JOIN ms first, so `ms.note` is from the null-extended side.
+# - Then `mp` joins `ch` on `mp.payline_id * 100 = ch.pay_kind`.
+# - The expression join key forces updateEQCond() to inject a Projection on top of
+#   the whole `(mp LEFT JOIN ms)` left child.
+# - That injected Projection forwards `ms.note` together with mp columns and the
+#   derived join key `mp.payline_id * 100`.
+#
+# `ms.note` is only a pure pass-through column, but today the through-proj safety
+# check rejects the entire Projection as soon as any expression references
+# nullExtendedCols. As a result, turning tidb_opt_join_reorder_through_proj ON does
+# not inline this Projection, and `leading(ab)` can only start from the whole
+# projected subtree instead of from bare `mp`.
+drop table if exists jt_mp, jt_ms, jt_ch, jt_ab;
+create table jt_mp(
+  id int primary key,
+  ms_id int,
+  user_id int,
+  site_code int,
+  pay_receive_id int,
+  payline_id int,
+  key(user_id, site_code),
+  key(ms_id),
+  key(pay_receive_id, payline_id)
+);
+create table jt_ms(id int primary key, note varchar(10));
+create table jt_ch(channel_id int, pay_kind int, key(channel_id, pay_kind));
+create table jt_ab(user_id int, site_code int, regpkgid int, key(user_id, site_code));
+
+insert into jt_mp values (1, 1, 10, 1, 100, 2), (2, 2, 20, 1, 200, 3);
+insert into jt_ms values (1, 'm1'), (2, 'm2');
+insert into jt_ch values (100, 200), (200, 300);
+insert into jt_ab values (10, 1, 1), (20, 1, 2);
+analyze table jt_mp, jt_ms, jt_ch, jt_ab;
+
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select /*+ leading(ab) */ mp.id, ms.note
+from jt_mp mp
+left join jt_ms ms
+  on mp.ms_id = ms.id
+left join jt_ch ch
+  on mp.pay_receive_id = ch.channel_id
+ and mp.payline_id * 100 = ch.pay_kind
+left join jt_ab ab
+  on ab.user_id = mp.user_id
+ and ab.site_code = mp.site_code
+where ab.regpkgid = 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select /*+ leading(ab) */ mp.id, ms.note
+from jt_mp mp
+left join jt_ms ms
+  on mp.ms_id = ms.id
+left join jt_ch ch
+  on mp.pay_receive_id = ch.channel_id
+ and mp.payline_id * 100 = ch.pay_kind
+left join jt_ab ab
+  on ab.user_id = mp.user_id
+ and ab.site_code = mp.site_code
+where ab.regpkgid = 1;
+
+# =============================================================================
+# DP Reorder: Preserve Single-Node Predicates After Projection Inlining
+# =============================================================================
+# After projection inlining, join conditions can become single-table predicates.
+# DP join reorder must not drop them.
+set tidb_opt_join_reorder_through_proj = on;
+set tidb_opt_join_reorder_threshold = 3;
+
+# Single-node predicate after substitution: dt.doubled_b > 300 -> (t2.b * 2) > 300
+select count(*) from (
+  select t2.a as a2, t2.b * 2 as doubled_b
+  from t2 join t3 on t2.a = t3.a
+) dt join t1 on dt.a2 = t1.a and dt.doubled_b > 300;
+
+set tidb_opt_join_reorder_threshold = 0;
+
+# Multi-level CTE with Projection over Join
+# This tests multi-level colExprMap propagation where EACH level has projection over join.
+#
+# STRUCTURE:
+# - cte1: Projection over t2 (simple single-table projection, b*2)
+# - cte2: Projection over (t3 JOIN cte1), computes shifted_b from t3 and also keeps cte1's doubled_b
+# - Outer: t1 JOIN cte2 on t1.b = cte2.doubled_b
+#
+# EXPECTED BEHAVIOR:
+# - cte1's colExprMap: doubled_b -> (t2.b * 2)
+# - cte2's colExprMap: shifted_b -> (t3.b + 100), and passes through cte1's mappings
+# - After inlining, t1.b = cte2.doubled_b becomes t1.b = (t2.b * 2)
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' with
+  cte1 as (select a, b * 2 as doubled_b from t2),
+  cte2 as (select t3.a, t3.b + 100 as shifted_b, cte1.doubled_b from t3 join cte1 on t3.a = cte1.a)
+select t1.a, cte2.* from t1 join cte2 on t1.b = cte2.doubled_b;
+
+with
+  cte1 as (select a, b * 2 as doubled_b from t2),
+  cte2 as (select t3.a, t3.b + 100 as shifted_b, cte1.doubled_b from t3 join cte1 on t3.a = cte1.a)
+select t1.a, cte2.* from t1 join cte2 on t1.b = cte2.doubled_b
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' with
+  cte1 as (select a, b * 2 as doubled_b from t2),
+  cte2 as (select t3.a, t3.b + 100 as shifted_b, cte1.doubled_b from t3 join cte1 on t3.a = cte1.a)
+select t1.a, cte2.* from t1 join cte2 on t1.b = cte2.doubled_b;
+
+with
+  cte1 as (select a, b * 2 as doubled_b from t2),
+  cte2 as (select t3.a, t3.b + 100 as shifted_b, cte1.doubled_b from t3 join cte1 on t3.a = cte1.a)
+select t1.a, cte2.* from t1 join cte2 on t1.b = cte2.doubled_b
+order by 1;
+
+# =============================================================================
+# View/Derived Table with Single-Table Expression
+# =============================================================================
+# Query: t1 JOIN (t2 JOIN t3 with t2.b * 2 expression)
+#
+# EXPECTED BEHAVIOR:
+# - The expression (t2.b * 2) only references t2, NOT a cross-table expression.
+# - The projection should be INLINED when ON.
+#
+# NOTE: If plans differ between OFF and ON, it confirms inlining is working.
+# Look for structural differences like projection position in the plan tree.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, v.* from t1,
+  (select t2.a as va, t2.b * 2 as vb, t3.b as vb2 from t2, t3 where t2.a = t3.a) v
+where t1.a = v.va;
+
+select t1.a, v.* from t1,
+  (select t2.a as va, t2.b * 2 as vb, t3.b as vb2 from t2, t3 where t2.a = t3.a) v
+where t1.a = v.va
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, v.* from t1,
+  (select t2.a as va, t2.b * 2 as vb, t3.b as vb2 from t2, t3 where t2.a = t3.a) v
+where t1.a = v.va;
+
+select t1.a, v.* from t1,
+  (select t2.a as va, t2.b * 2 as vb, t3.b as vb2 from t2, t3 where t2.a = t3.a) v
+where t1.a = v.va
+order by 1;
+
+# =============================================================================
+# Single-Table String Expression (Can Inline - Collation Safe)
+# =============================================================================
+# Query: t1 JOIN (t2 JOIN t3) with UPPER(t2.c) computed expression
+# Tests that single-table string expressions can be safely inlined.
+# From first principles, the collation context is preserved because:
+# 1. The expression's collation is determined by its source columns
+# 2. Join reordering doesn't change which columns participate in the expression
+# 3. The expression is evaluated in the same context after inlining
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.* from t1,
+  (select t2.a as key_a, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+
+select t1.a, dt.* from t1,
+  (select t2.a as key_a, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.* from t1,
+  (select t2.a as key_a, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+
+select t1.a, dt.* from t1,
+  (select t2.a as key_a, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+
+# =============================================================================
+# LEFT JOIN with Single-Table Expressions (Can Inline)
+# =============================================================================
+# These tests verify correct handling of outer joins where projection inlining
+# uses SINGLE-TABLE expressions that CAN be inlined.
+
+# LEFT JOIN - projection with single-table expression on OUTER (left) side
+# Query: (Projection(t2 JOIN t3)) LEFT JOIN t5
+# The projection uses t2.b * 2 which only references t2 (single-table, can inline)
+#
+# EXPECTED BEHAVIOR:
+# - The derived table (dt) is on the OUTER side of the LEFT JOIN.
+# - The expression (t2.b * 2) only references t2, so projection CAN be inlined.
+# - When ON, the join group should include {t2, t3, t5} for potential reordering.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt.*, t5.a as t5_a from
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a;
+
+select dt.*, t5.a as t5_a from
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt.*, t5.a as t5_a from
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a;
+
+select dt.*, t5.a as t5_a from
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a
+order by 1;
+
+# LEFT JOIN - projection with single-table expression on INNER (right) side
+# Query: t1 LEFT JOIN (Projection(t2 JOIN t3))
+#
+# EXPECTED BEHAVIOR:
+# - The derived table (dt) is on the INNER side of the LEFT JOIN.
+# - Current implementation: extractJoinGroupImpl doesn't recurse into inner side
+#   for LeftOuterJoin, so this projection is naturally NOT inlined even with
+#   single-table expressions.
+#
+# RESULT: Plans should be identical for both OFF and ON.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.* from t1
+left join (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+on t1.a = dt.key_a;
+
+select t1.a, dt.* from t1
+left join (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+on t1.a = dt.key_a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.* from t1
+left join (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+on t1.a = dt.key_a;
+
+select t1.a, dt.* from t1
+left join (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+on t1.a = dt.key_a
+order by 1;
+
+# LEFT JOIN with single-table derived column in OuterBindCondition
+# Query: (Projection(t2 JOIN t3)) LEFT JOIN t5 ON dt.key_a = t5.a AND dt.doubled_b > 100
+# The condition dt.doubled_b > 100 references a single-table derived column.
+#
+# EXPECTED BEHAVIOR:
+# - The expression (t2.b * 2) only references t2, so it CAN be inlined.
+# - When projection is inlined, this condition is SUBSTITUTED:
+#   dt.doubled_b > 100 -> (t2.b * 2) > 100
+# - This tests the outerBindCondition substitution in extractJoinGroupImpl.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt.*, t5.a as t5_a from
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a and dt.doubled_b > 100;
+
+select dt.*, t5.a as t5_a from
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a and dt.doubled_b > 100
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt.*, t5.a as t5_a from
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a and dt.doubled_b > 100;
+
+select dt.*, t5.a as t5_a from
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a and dt.doubled_b > 100
+order by 1;
+
+# LEFT JOIN with multi-leaf derived columns in OuterBindCondition (Should NOT Expand)
+# Query: (Projection(t2 JOIN t3)) LEFT JOIN t5
+#   ON dt.key_a = t5.a AND dt.doubled_b > 0 AND dt.shifted_b > 150
+#
+# The outer-join filters reference derived columns from DIFFERENT leaves:
+# - dt.doubled_b -> t2.b * 2 (from t2)
+# - dt.shifted_b -> t3.b + 100 (from t3)
+#
+# If join reorder incorrectly expands the outer join into the join group and chooses
+# to build (t2 LEFT JOIN t5) JOIN t3, the t3-dependent filter could be lost because
+# t3 is not available when constructing the outer join.
+drop table if exists oj_t2, oj_t3, oj_t5;
+create table oj_t2(a int, b int, primary key (a));
+create table oj_t3(a int, b int, primary key (a));
+create table oj_t5(a int, b int, primary key (a));
+
+insert into oj_t2 values
+  (1, 10), (2, 20), (3, 30), (4, 40), (5, 50),
+  (6, 60), (7, 70), (8, 80), (9, 90), (10, 100);
+insert into oj_t3 values
+  (1, 10), (2, 100), (3, 10), (4, 10), (5, 10),
+  (6, 10), (7, 10), (8, 10), (9, 10), (10, 10);
+insert into oj_t5 values (1, 1000), (2, 2000);
+analyze table oj_t2, oj_t3, oj_t5;
+
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt.key_a, ifnull(oj_t5.b, -1) as t5_b from
+  (select oj_t2.a as key_a, oj_t2.b * 2 as doubled_b, oj_t3.b + 100 as shifted_b
+   from oj_t2 join oj_t3 on oj_t2.a = oj_t3.a) dt
+left join oj_t5 on dt.key_a = oj_t5.a and dt.doubled_b > 0 and dt.shifted_b > 150
+order by dt.key_a;
+
+select dt.key_a, ifnull(oj_t5.b, -1) as t5_b from
+  (select oj_t2.a as key_a, oj_t2.b * 2 as doubled_b, oj_t3.b + 100 as shifted_b
+   from oj_t2 join oj_t3 on oj_t2.a = oj_t3.a) dt
+left join oj_t5 on dt.key_a = oj_t5.a and dt.doubled_b > 0 and dt.shifted_b > 150
+order by dt.key_a;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt.key_a, ifnull(oj_t5.b, -1) as t5_b from
+  (select oj_t2.a as key_a, oj_t2.b * 2 as doubled_b, oj_t3.b + 100 as shifted_b
+   from oj_t2 join oj_t3 on oj_t2.a = oj_t3.a) dt
+left join oj_t5 on dt.key_a = oj_t5.a and dt.doubled_b > 0 and dt.shifted_b > 150
+order by dt.key_a;
+
+select dt.key_a, ifnull(oj_t5.b, -1) as t5_b from
+  (select oj_t2.a as key_a, oj_t2.b * 2 as doubled_b, oj_t3.b + 100 as shifted_b
+   from oj_t2 join oj_t3 on oj_t2.a = oj_t3.a) dt
+left join oj_t5 on dt.key_a = oj_t5.a and dt.doubled_b > 0 and dt.shifted_b > 150
+order by dt.key_a;
+
+# Repro Case: Outer Join + Reversed Edge + Expression Join Key
+# This case exercises the checkConnection() branch where:
+# - A LeftOuterJoin edge is found in reverse direction (current join tree starts from the INNER side)
+# - The outer-side join key is a scalar expression after projection inlining
+# - buildJoinEdge() must inject a projection to materialize the expression join key
+#
+# Without correct leftNode/rightNode update after injectExpr(), this can produce an invalid plan
+# (join condition columns not found in join children schema).
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt.key_a, ifnull(oj_t5.b, -1) as t5_b from
+  (select oj_t2.a as key_a, oj_t2.b * 2 as doubled_b
+   from oj_t2 join oj_t3 on oj_t2.a = oj_t3.a) dt
+left join oj_t5 on dt.doubled_b = oj_t5.b
+order by dt.key_a;
+
+select dt.key_a, ifnull(oj_t5.b, -1) as t5_b from
+  (select oj_t2.a as key_a, oj_t2.b * 2 as doubled_b
+   from oj_t2 join oj_t3 on oj_t2.a = oj_t3.a) dt
+left join oj_t5 on dt.doubled_b = oj_t5.b
+order by dt.key_a;
+
+drop table oj_t2, oj_t3, oj_t5;
+
+# LEFT JOIN with single-leaf expression on the NULL-extended side (Should NOT Inline)
+# Query: ne_t1 JOIN (Projection(ne_t2 LEFT JOIN ne_t3))
+# The expression COALESCE(ne_t3.b, 0) only references ne_t3, but ne_t3 is the
+# NULL-extended side of the LEFT JOIN. Inlining this projection would let later
+# join reorder treat the derived column as a normal connector and can change
+# outer-join semantics.
+drop table if exists ne_t1, ne_t2, ne_t3;
+create table ne_t1(a int, b int, primary key (a));
+create table ne_t2(a int, b int, primary key (a));
+create table ne_t3(a int, b int, primary key (a));
+
+insert into ne_t1 values (1, 0), (2, 200), (3, 300);
+insert into ne_t2 values (1, 10), (2, 20), (3, 30);
+insert into ne_t3 values (2, 200), (3, 300);
+analyze table ne_t1, ne_t2, ne_t3;
+
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select ne_t1.a, dt.key_a, dt.coalesced_b from ne_t1 join
+  (select ne_t2.a as key_a, coalesce(ne_t3.b, 0) as coalesced_b
+   from ne_t2 left join ne_t3 on ne_t2.a = ne_t3.a) dt
+on ne_t1.b = dt.coalesced_b;
+
+select ne_t1.a, dt.key_a, dt.coalesced_b from ne_t1 join
+  (select ne_t2.a as key_a, coalesce(ne_t3.b, 0) as coalesced_b
+   from ne_t2 left join ne_t3 on ne_t2.a = ne_t3.a) dt
+on ne_t1.b = dt.coalesced_b
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select ne_t1.a, dt.key_a, dt.coalesced_b from ne_t1 join
+  (select ne_t2.a as key_a, coalesce(ne_t3.b, 0) as coalesced_b
+   from ne_t2 left join ne_t3 on ne_t2.a = ne_t3.a) dt
+on ne_t1.b = dt.coalesced_b;
+
+select ne_t1.a, dt.key_a, dt.coalesced_b from ne_t1 join
+  (select ne_t2.a as key_a, coalesce(ne_t3.b, 0) as coalesced_b
+   from ne_t2 left join ne_t3 on ne_t2.a = ne_t3.a) dt
+on ne_t1.b = dt.coalesced_b
+order by 1;
+
+drop table ne_t1, ne_t2, ne_t3;
+
+# Note: RIGHT JOIN tests are omitted as they mirror LEFT JOIN behavior.
+# The key difference is which side is OUTER vs INNER, but the projection
+# inlining logic is symmetric.
+
+# =============================================================================
+# Multiple Derived Tables with Single-Table Expressions (Can Inline)
+# =============================================================================
+# Query: (Projection(t1 JOIN t2)) INNER JOIN (Projection(t3 JOIN t4))
+# Each projection uses single-table expressions that CAN be inlined.
+#
+# EXPECTED BEHAVIOR:
+# - Two separate derived tables, each containing an inner join with single-table expressions.
+# - Each projection is evaluated independently for inlining.
+# - If both are inlined, join group becomes {t1, t2, t3, t4}.
+# - The join condition dt1.a1 = dt2.a3 becomes t1.a = t3.a after substitution.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3;
+
+select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3;
+
+select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3
+order by 1;
+
+# Join on computed columns (dt1.doubled1 = dt2.doubled3)
+# Tests colExprMap substitution for computed column join keys between two derived tables
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled3;
+
+select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled3
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled3;
+
+select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b * 2 as doubled3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled3
+order by 1;
+
+# =============================================================================
+# Deeply Nested Derived Tables with Single-Table Expressions (Can Inline)
+# =============================================================================
+# Query: t1 JOIN (Projection(dt1 JOIN t4)) where dt1 = (Projection(t2 JOIN t3))
+# Each projection uses single-table expressions that CAN be inlined.
+#
+# EXPECTED BEHAVIOR:
+# - Three levels of nesting: t1 -> dt2 -> dt1 -> (t2, t3)
+# - Each level has a projection with single-table expressions:
+#   - dt1: t2.b * 2 as doubled_b (only references t2)
+#   - dt2: dt1.doubled_b + 10 as adjusted (references dt1 column, which expands to t2.b * 2)
+# - Multi-level colExprMap propagation:
+#   1. dt1's colExprMap: doubled_b -> (t2.b * 2)
+#   2. dt2's colExprMap: adjusted -> (dt1.doubled_b + 10) -> ((t2.b * 2) + 10)
+#
+# This is a KEY test for bottom-up colExprMap propagation correctness.
+# If working correctly, join group should include {t1, t2, t3, t4}.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select outer_t.a, dt2.* from t1 outer_t,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a;
+
+select outer_t.a, dt2.* from t1 outer_t,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select outer_t.a, dt2.* from t1 outer_t,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a;
+
+select outer_t.a, dt2.* from t1 outer_t,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a
+order by 1;
+
+# Join on nested computed column (outer_t.b = dt2.adjusted)
+# Tests multi-level colExprMap substitution: adjusted = doubled_b + 10 = (t2.b * 2) + 10
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select outer_t.a, dt2.* from t1 outer_t,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where outer_t.b = dt2.adjusted;
+
+select outer_t.a, dt2.* from t1 outer_t,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where outer_t.b = dt2.adjusted
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select outer_t.a, dt2.* from t1 outer_t,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where outer_t.b = dt2.adjusted;
+
+select outer_t.a, dt2.* from t1 outer_t,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where outer_t.b = dt2.adjusted
+order by 1;
+
+# =============================================================================
+# Non-Deterministic Functions (Safety Check)
+# =============================================================================
+# Query: t1 JOIN (Projection with rand() function over t2 JOIN t3)
+#
+# EXPECTED BEHAVIOR:
+# - The projection contains rand() which is NON-DETERMINISTIC.
+# - canInlineProjection() checks expression.CheckNonDeterministic() and returns FALSE.
+# - Projection should NOT be inlined regardless of the session variable.
+# - Plans should be IDENTICAL for both OFF and ON.
+#
+# WHY BLOCK NON-DETERMINISTIC:
+# If we inline and reorder, the number of times rand() is called could change,
+# or it could be computed at a different point in the query execution,
+# producing different and incorrect results.
+#
+# NOTE: The SELECT doesn't reference unsafe_expr, but its presence in the
+# projection still blocks inlining for the entire projection.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.a2, dt.cross_table_sum from t1,
+  (select t2.a as a2, t2.b + t3.b as cross_table_sum, rand() as unsafe_expr
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.a2, dt.cross_table_sum from t1,
+  (select t2.a as a2, t2.b + t3.b as cross_table_sum, rand() as unsafe_expr
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2;
+
+# =============================================================================
+# Side Effects (setvar) - Should Block Inline
+# =============================================================================
+# Query: Projection contains @var := expr which has side effects
+#
+# EXPECTED BEHAVIOR:
+# - expression.ExprsHasSideEffects() returns true for setvar
+# - Projection should NOT be inlined
+# - Plans should be identical for OFF and ON
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.a2, dt.val from t1,
+  (select t2.a as a2, @v := t2.b as val from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.a2, dt.val from t1,
+  (select t2.a as a2, @v := t2.b as val from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.a2;
+
+# Note: Single-table expression test is covered by earlier "Basic Single-Table Expressions"
+# test case, so this duplicate section is removed.
+
+# =============================================================================
+# Expression Join Key in Derived Table (Projection over Join)
+# =============================================================================
+# This test structures the query so that the expression join key (m.b + 1)
+# is computed in a derived table that contains a join. This ensures the
+# Projection is OVER a Join node, truly blocking the join group.
+#
+# STRUCTURE:
+# - dt: Projection over (expr_medium JOIN expr_large), with expression m.b+1
+# - Outer: expr_small JOIN dt ON s.a = dt.expr_key
+#
+# EXPECTED BEHAVIOR:
+# - OFF: Join group = {s, Projection(m JOIN l)}, projection blocks visibility
+# - ON: Projection is inlined, join group = {s, m, l}, join order may change
+#
+# Setup: Create tables with different row counts to influence join order
+drop table if exists expr_small, expr_medium, expr_large;
+create table expr_small(a int, b int, primary key (a), key(b));
+create table expr_medium(a int, b int, primary key (a), key(b));
+create table expr_large(a int, b int, primary key (a), key(b));
+
+# Different row counts: small (2), medium (6), large (20)
+insert into expr_small values(11, 10), (21, 20);
+insert into expr_medium values(1, 10), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60);
+insert into expr_large values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10);
+insert into expr_large values(11, 11), (12, 12), (13, 13), (14, 14), (15, 15), (16, 16), (17, 17), (18, 18), (19, 19), (20, 20);
+
+analyze table expr_small, expr_medium, expr_large;
+
+# Query: outer table joins with derived table that has expression join key
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select s.*, dt.* from expr_small s,
+  (select m.a as key_a, m.b + 1 as expr_key, l.b as lb from expr_medium m join expr_large l on m.a = l.a) dt
+where s.a = dt.expr_key;
+
+select s.*, dt.* from expr_small s,
+  (select m.a as key_a, m.b + 1 as expr_key, l.b as lb from expr_medium m join expr_large l on m.a = l.a) dt
+where s.a = dt.expr_key
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select s.*, dt.* from expr_small s,
+  (select m.a as key_a, m.b + 1 as expr_key, l.b as lb from expr_medium m join expr_large l on m.a = l.a) dt
+where s.a = dt.expr_key;
+
+select s.*, dt.* from expr_small s,
+  (select m.a as key_a, m.b + 1 as expr_key, l.b as lb from expr_medium m join expr_large l on m.a = l.a) dt
+where s.a = dt.expr_key
+order by 1;
+
+drop table expr_small, expr_medium, expr_large;
+
+# =============================================================================
+# Type Coercion in Derived Table with Join (INT vs DOUBLE)
+# =============================================================================
+# This test structures the query so that type coercion (CAST int to double)
+# happens in a derived table that contains a join. The outer table then joins
+# with this derived table using the casted column.
+#
+# STRUCTURE:
+# - dt: Projection over (t_int_large JOIN t_double_medium), with cast expression
+# - Outer: t_int_small JOIN dt
+#
+# This ensures the CAST Projection is OVER a Join, allowing inline to have effect.
+drop table if exists t_int_small, t_double_medium, t_int_large;
+create table t_int_small(a int, b int, primary key (a), key(b));
+create table t_double_medium(a double, b double, key(a));
+create table t_int_large(a int, b int, primary key (a), key(b));
+
+# Different row counts: small (2), medium (6), large (20)
+insert into t_int_small values(1, 10), (2, 20);
+insert into t_double_medium values(1.0, 100.0), (2.0, 200.0), (3.0, 300.0), (4.0, 400.0), (5.0, 500.0), (6.0, 600.0);
+insert into t_int_large values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10);
+insert into t_int_large values(11, 11), (12, 12), (13, 13), (14, 14), (15, 15), (16, 16), (17, 17), (18, 18), (19, 19), (20, 20);
+
+analyze table t_int_small, t_double_medium, t_int_large;
+
+# Query: outer table joins with derived table that has cast expression
+# The derived table contains a join between int and double columns,
+# producing a projection with CAST to match types
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select s.*, dt.* from t_int_small s,
+  (select l.a as key_a, l.b * 2 as doubled_b, m.b as mb
+   from t_int_large l join t_double_medium m on cast(l.a as double) = m.a) dt
+where s.a = dt.key_a;
+
+select s.*, dt.* from t_int_small s,
+  (select l.a as key_a, l.b * 2 as doubled_b, m.b as mb
+   from t_int_large l join t_double_medium m on cast(l.a as double) = m.a) dt
+where s.a = dt.key_a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select s.*, dt.* from t_int_small s,
+  (select l.a as key_a, l.b * 2 as doubled_b, m.b as mb
+   from t_int_large l join t_double_medium m on cast(l.a as double) = m.a) dt
+where s.a = dt.key_a;
+
+select s.*, dt.* from t_int_small s,
+  (select l.a as key_a, l.b * 2 as doubled_b, m.b as mb
+   from t_int_large l join t_double_medium m on cast(l.a as double) = m.a) dt
+where s.a = dt.key_a
+order by 1;
+
+drop table t_int_small, t_double_medium, t_int_large;
+
+# NOTE: Pure Column Pass-through Projection test removed.
+# Such projections are eliminated by ProjectionEliminator before join reorder,
+# so there's no projection to inline. Testing this case is redundant.
+
+# =============================================================================
+# DP Solver Path - Many Inner Joins
+# =============================================================================
+# Query: 5 tables with inner joins - triggers DP solver when threshold is not exceeded
+# Tests findNodeIndexInGroupWithSubstitution in rule_join_reorder_dp.go
+set tidb_opt_join_reorder_threshold = 10;
+
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.key_a, dt.doubled_b from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a;
+
+select t1.a, dt.key_a, dt.doubled_b from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.key_a, dt.doubled_b from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a;
+
+select t1.a, dt.key_a, dt.doubled_b from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a
+order by 1;
+
+# DP Solver with computed column as join key
+# This test SPECIFICALLY uses a computed column (doubled_b = t2.b * 2) as the join key
+# between the outer table and derived table. After colExprMap substitution:
+#   t1.b = dt.doubled_b -> t1.b = (t2.b * 2)
+# The EQ condition's right side changes from Column to ScalarFunction.
+# This tests whether DP phase (rule_join_reorder_dp.go L69-70) correctly handles
+# the substituted expression.
+#
+# POTENTIAL ISSUE: If DP phase directly type-asserts sf.GetArgs()[1].(*Column),
+# it would panic because after substitution the argument is ScalarFunction not Column.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.key_a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a;
+
+select t1.a, dt.key_a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.key_a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a;
+
+select t1.a, dt.key_a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a
+order by 1;
+
+set tidb_opt_join_reorder_threshold = 10;
+
+# DP Solver with multiple computed columns as join keys
+# Tests multiple substituted expressions in single query
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c and dt.key_a = t5.a;
+
+select t1.a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c and dt.key_a = t5.a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c and dt.key_a = t5.a;
+
+select t1.a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c and dt.key_a = t5.a
+order by 1;
+
+# DP Solver with computed column in filter (otherConds)
+# Tests substitution in non-equality conditions during DP graph building
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.key_a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a and dt.doubled_b > 100;
+
+select t1.a, dt.key_a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a and dt.doubled_b > 100
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.key_a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a and dt.doubled_b > 100;
+
+select t1.a, dt.key_a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.key_a = t5.a and dt.doubled_b > 100
+order by 1;
+
+# DP Solver with nested computed expression
+# Tests multi-level colExprMap substitution in DP phase
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt2.key_a from t1, t5,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted and dt2.key_a = t5.a;
+
+select t1.a, dt2.key_a from t1, t5,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted and dt2.key_a = t5.a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt2.key_a from t1, t5,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted and dt2.key_a = t5.a;
+
+select t1.a, dt2.key_a from t1, t5,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted and dt2.key_a = t5.a
+order by 1;
+
+set tidb_opt_join_reorder_threshold = 0;
+
+# =============================================================================
+# Derived Column in WHERE Filter (colExprMap Substitution)
+# =============================================================================
+# Query: WHERE clause references the derived column dt.doubled_b
+# Tests substituteColsInExprs for otherConds
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.key_a, dt.doubled_b from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.doubled_b > 100;
+
+select t1.a, dt.key_a, dt.doubled_b from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.doubled_b > 100
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.key_a, dt.doubled_b from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.doubled_b > 100;
+
+select t1.a, dt.key_a, dt.doubled_b from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.doubled_b > 100
+order by 1;
+
+# The same derived-column filter should also work when Selection is extracted
+# into the join group first. This specifically exercises:
+# Selection -> JoinGroup extraction + colExprMap substitution for otherConds.
+set tidb_opt_join_reorder_through_sel = on;
+set tidb_opt_join_reorder_threshold = 63;
+explain format = 'brief' select t1.a, dt.key_a, dt.doubled_b from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.doubled_b > 100;
+
+select t1.a, dt.key_a, dt.doubled_b from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a and dt.doubled_b > 100
+order by 1;
+
+set tidb_opt_join_reorder_threshold = 0;
+set tidb_opt_join_reorder_through_sel = off;
+
+# =============================================================================
+# Computed Expressions in JOIN Conditions (colExprMap Substitution Test)
+# =============================================================================
+# The following tests verify that computed columns from projections can be
+# correctly used in JOIN conditions, requiring proper colExprMap substitution.
+
+# Computed expression in INNER JOIN condition
+# Query: t1 JOIN (Projection(t2 JOIN t3)) ON t1.b = dt.doubled_b
+# The JOIN condition references dt.doubled_b which is a computed column (t2.b * 2)
+#
+# EXPECTED BEHAVIOR:
+# - OFF: Projection blocks join reorder
+# - ON: Projection is inlined, and the condition "t1.b = dt.doubled_b" is substituted
+#   to "t1.b = (t2.b * 2)". This tests colExprMap substitution in eqCond.
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.*, dt.* from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b;
+
+select t1.*, dt.* from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.*, dt.* from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b;
+
+select t1.*, dt.* from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b
+order by 1;
+
+# Multiple computed expressions in JOIN conditions
+# Query: t1 JOIN dt ON t1.b = dt.doubled_b AND t1.c = dt.upper_c
+# Both join conditions use computed columns
+#
+# EXPECTED BEHAVIOR:
+# - Both conditions should be substituted:
+#   t1.b = dt.doubled_b -> t1.b = (t2.b * 2)
+#   t1.c = dt.upper_c -> t1.c = upper(t2.c)
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.*, dt.* from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c;
+
+select t1.*, dt.* from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.*, dt.* from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c;
+
+select t1.*, dt.* from t1,
+  (select t2.a as key_a, t2.b * 2 as doubled_b, upper(t2.c) as upper_c
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and t1.c = dt.upper_c
+order by 1;
+
+# Computed expression in multi-table join condition
+# Query: t1 JOIN dt ON t1.b = dt.doubled_b, and dt JOIN t5 ON dt.key_a = t5.a
+# Tests computed column join in a 3-table scenario
+#
+# EXPECTED BEHAVIOR:
+# - Join group should include {t1, t2, t3, t5}
+# - Condition "t1.b = dt.doubled_b" is substituted to "t1.b = (t2.b * 2)"
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.*, dt.*, t5.a as t5_a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a;
+
+select t1.*, dt.*, t5.a as t5_a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.*, dt.*, t5.a as t5_a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a;
+
+select t1.*, dt.*, t5.a as t5_a from t1, t5,
+  (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt
+where t1.b = dt.doubled_b and dt.key_a = t5.a
+order by 1;
+
+# Nested computed expression in JOIN condition
+# Query: Outer query joins with dt on a column that is computed from inner dt1
+# Tests multi-level colExprMap substitution in join conditions
+#
+# EXPECTED BEHAVIOR:
+# - dt2.adjusted is computed from dt1.doubled_b which is t2.b * 2
+# - Final substitution: t1.b = (t2.b * 2) + 10
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.*, dt2.* from t1,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted;
+
+select t1.*, dt2.* from t1,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.*, dt2.* from t1,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted;
+
+select t1.*, dt2.* from t1,
+  (select dt1.key_a, dt1.doubled_b + 10 as adjusted from
+    (select t2.a as key_a, t2.b * 2 as doubled_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where t1.b = dt2.adjusted
+order by 1;
+
+# Computed expression between two derived tables
+# Query: dt1 JOIN dt2 ON dt1.doubled1 = dt2.doubled2
+# Both sides use computed columns in the join condition
+#
+# EXPECTED BEHAVIOR:
+# - Condition "dt1.doubled1 = dt2.doubled2" is substituted to "(t1.b * 2) = (t3.b * 2)"
+# - Join group should include {t1, t2, t3, t4}
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b * 2 as doubled2 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled2;
+
+select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b * 2 as doubled2 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled2
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b * 2 as doubled2 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled2;
+
+select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b * 2 as doubled1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b * 2 as doubled2 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.doubled1 = dt2.doubled2
+order by 1;
+
+
+# ###########################################################################
+# CROSS-TABLE EXPRESSIONS - CANNOT INLINE
+# ###########################################################################
+# The following tests demonstrate cases where projection CANNOT be inlined
+# because expressions reference columns from MULTIPLE base tables.
+#
+# WHY BLOCK CROSS-TABLE: If we inline a projection with (t2.b + t3.b), this
+# expression can only be computed AFTER t2 and t3 are already joined. If the
+# reordering separates t2 and t3 to different branches, the expression becomes
+# invalid. So we conservatively block such projections.
+#
+# ALL TESTS BELOW: Plans should be IDENTICAL for both OFF and ON modes.
+
+# Cross-Table Arithmetic Expression
+# Expression: t2.b + t3.b (references BOTH t2 and t3)
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.* from t1,
+  (select t2.a as key_a, t2.b + t3.b as cross_sum, t2.b * t3.b as cross_product
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+
+select t1.a, dt.* from t1,
+  (select t2.a as key_a, t2.b + t3.b as cross_sum, t2.b * t3.b as cross_product
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.* from t1,
+  (select t2.a as key_a, t2.b + t3.b as cross_sum, t2.b * t3.b as cross_product
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+
+select t1.a, dt.* from t1,
+  (select t2.a as key_a, t2.b + t3.b as cross_sum, t2.b * t3.b as cross_product
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+
+# Cross-Table String/Function Expression
+# Expressions: concat(t2.c, '-', t3.c), greatest(t2.b, t3.b), least(t2.b, t3.b)
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t1.a, dt.* from t1,
+  (select t2.a as key_a,
+          concat(t2.c, '-', t3.c) as combined_c,
+          greatest(t2.b, t3.b) as max_b,
+          least(t2.b, t3.b) as min_b
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+
+select t1.a, dt.* from t1,
+  (select t2.a as key_a,
+          concat(t2.c, '-', t3.c) as combined_c,
+          greatest(t2.b, t3.b) as max_b,
+          least(t2.b, t3.b) as min_b
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t1.a, dt.* from t1,
+  (select t2.a as key_a,
+          concat(t2.c, '-', t3.c) as combined_c,
+          greatest(t2.b, t3.b) as max_b,
+          least(t2.b, t3.b) as min_b
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a;
+
+select t1.a, dt.* from t1,
+  (select t2.a as key_a,
+          concat(t2.c, '-', t3.c) as combined_c,
+          greatest(t2.b, t3.b) as max_b,
+          least(t2.b, t3.b) as min_b
+   from t2 join t3 on t2.a = t3.a) dt
+where t1.a = dt.key_a
+order by 1;
+
+# Cross-Table CTE Expression
+# Expression: t2.b + t3.b in CTE
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' with joined_cte as (
+  select t2.a as cte_a, t2.b + t3.b as sum_b
+  from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.sum_b from t1 join joined_cte cte on t1.a = cte.cte_a;
+
+with joined_cte as (
+  select t2.a as cte_a, t2.b + t3.b as sum_b
+  from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.sum_b from t1 join joined_cte cte on t1.a = cte.cte_a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' with joined_cte as (
+  select t2.a as cte_a, t2.b + t3.b as sum_b
+  from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.sum_b from t1 join joined_cte cte on t1.a = cte.cte_a;
+
+with joined_cte as (
+  select t2.a as cte_a, t2.b + t3.b as sum_b
+  from t2 join t3 on t2.a = t3.a
+)
+select t1.a, cte.cte_a, cte.sum_b from t1 join joined_cte cte on t1.a = cte.cte_a
+order by 1;
+
+# Cross-Table LEFT JOIN Expression
+# Expression: t2.b + t3.b in LEFT JOIN outer side
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt.*, t5.a as t5_a from
+  (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a;
+
+select dt.*, t5.a as t5_a from
+  (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt.*, t5.a as t5_a from
+  (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a;
+
+select dt.*, t5.a as t5_a from
+  (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+left join t5 on dt.key_a = t5.a
+order by 1;
+
+# Cross-Table RIGHT JOIN Expression
+# Expression: t2.b + t3.b in RIGHT JOIN outer side
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t5.a as t5_a, dt.* from t5
+right join (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+on t5.a = dt.key_a;
+
+select t5.a as t5_a, dt.* from t5
+right join (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+on t5.a = dt.key_a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t5.a as t5_a, dt.* from t5
+right join (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+on t5.a = dt.key_a;
+
+select t5.a as t5_a, dt.* from t5
+right join (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt
+on t5.a = dt.key_a
+order by 1;
+
+# Cross-Table Multiple Derived Tables
+# Expressions: t1.b + t2.b, t3.b + t4.b
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b + t2.b as sum1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b + t4.b as sum3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3;
+
+select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b + t2.b as sum1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b + t4.b as sum3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b + t2.b as sum1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b + t4.b as sum3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3;
+
+select dt1.*, dt2.* from
+  (select t1.a as a1, t1.b + t2.b as sum1 from t1 join t2 on t1.a = t2.a) dt1,
+  (select t3.a as a3, t3.b + t4.b as sum3 from t3 join t4 on t3.a = t4.a) dt2
+where dt1.a1 = dt2.a3
+order by 1;
+
+# Cross-Table Deeply Nested Expression
+# Expressions: t2.b + t3.b in nested derived tables
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select outer_t.a, dt2.* from t1 outer_t,
+  (select dt1.key_a, dt1.sum_b + t4.b as final_sum from
+    (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a;
+
+select outer_t.a, dt2.* from t1 outer_t,
+  (select dt1.key_a, dt1.sum_b + t4.b as final_sum from
+    (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a
+order by 1;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select outer_t.a, dt2.* from t1 outer_t,
+  (select dt1.key_a, dt1.sum_b + t4.b as final_sum from
+    (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a;
+
+select outer_t.a, dt2.* from t1 outer_t,
+  (select dt1.key_a, dt1.sum_b + t4.b as final_sum from
+    (select t2.a as key_a, t2.b + t3.b as sum_b from t2 join t3 on t2.a = t3.a) dt1
+   join t4 on dt1.key_a = t4.a) dt2
+where outer_t.a = dt2.key_a
+order by 1;
+
+# =============================================================================
+# Derived Column Aliasing - Cross-Leaf Expression Detection
+# =============================================================================
+# This section verifies canInlineProjection rejects cross-leaf expressions even when
+# columns are re-aliased through derived tables.
+#
+# Example: SELECT t.a + t.b FROM (SELECT t1.a, t2.b FROM t1, t2) t
+# Here, the expression text looks like it only references one derived table "t",
+# but t.a and t.b originate from different join-group leaves (t1 and t2).
+#
+# The inlining safety check reasons about join-group leaves via column UniqueIDs and
+# leaf schema membership (not by alias/table name prefixes), so it should correctly
+# detect the cross-leaf dependency and refuse to inline the Projection.
+
+# Recreate test tables
+drop table if exists t1, t2, t3, t4;
+create table t1(a int, b int, primary key (a));
+create table t2(a int, b int, primary key (a));
+create table t3(a int, b int, primary key (a));
+create table t4(a int, b int, primary key (a));
+
+insert into t1 values(1, 10), (2, 20), (3, 30);
+insert into t2 values(1, 100), (2, 200), (3, 300);
+insert into t3 values(1, 1000), (2, 2000), (3, 3000);
+insert into t4 values(101, 1), (120, 2), (230, 3);
+
+# Alias-derived columns (shallow): Expression (t.a + t.b) appears to reference single table "t",
+# but t.a comes from t1 and t.b comes from t2.
+# This is a cross-table expression that should NOT be inlined.
+#
+# STRUCTURE:
+# - Inner: (t1 JOIN t2) produces columns aliased as t.a (from t1.a) and t.b (from t2.b)
+# - Middle: Projection computes t.a + t.b as 'plus', JOIN t3
+# - Outer: t4 joins using t4.a = tt.plus (the derived column)
+#
+# The key point: 'plus' is computed from t.a + t.b where t.a and t.b appear to be
+# from the same table 't', but actually originate from different base tables (t1, t2).
+# Even though both columns are re-aliased under the same derived-table prefix "t",
+# the inlining logic should still treat this as a cross-leaf expression.
+
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t4.a, tt.plus from t4,
+  (select t.a + t.b as plus, t3.a as t3_a from (
+    select t1.a as a, t2.b as b from t1, t2 where t1.a = t2.a
+  ) t
+  join t3 on t.a = t3.a) tt
+where t4.a = tt.plus;
+
+select t4.a, tt.plus from t4,
+  (select t.a + t.b as plus, t3.a as t3_a from (
+    select t1.a as a, t2.b as b from t1, t2 where t1.a = t2.a
+  ) t
+  join t3 on t.a = t3.a) tt
+where t4.a = tt.plus order by t4.a;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t4.a, tt.plus from t4,
+  (select t.a + t.b as plus, t3.a as t3_a from (
+    select t1.a as a, t2.b as b from t1, t2 where t1.a = t2.a
+  ) t
+  join t3 on t.a = t3.a) tt
+where t4.a = tt.plus;
+
+select t4.a, tt.plus from t4,
+  (select t.a + t.b as plus, t3.a as t3_a from (
+    select t1.a as a, t2.b as b from t1, t2 where t1.a = t2.a
+  ) t
+  join t3 on t.a = t3.a) tt
+where t4.a = tt.plus order by t4.a;
+
+# Alias-derived columns (deep): More deeply nested alias case
+# dt2.combined references dt1.val_a and dt1.val_b, which come from t1.a and t2.b
+# Outer t4 joins on t4.a = dt2.combined
+
+set tidb_opt_join_reorder_through_proj = off;
+explain format = 'brief' select t4.a, dt2.combined from t4,
+  (select dt1.val_a + dt1.val_b as combined, t3.a as t3_a from (
+    select t1.a as val_a, t2.b as val_b from t1 join t2 on t1.a = t2.a
+  ) dt1
+  join t3 on dt1.val_a = t3.a) dt2
+where t4.a = dt2.combined;
+
+select t4.a, dt2.combined from t4,
+  (select dt1.val_a + dt1.val_b as combined, t3.a as t3_a from (
+    select t1.a as val_a, t2.b as val_b from t1 join t2 on t1.a = t2.a
+  ) dt1
+  join t3 on dt1.val_a = t3.a) dt2
+where t4.a = dt2.combined order by t4.a;
+
+set tidb_opt_join_reorder_through_proj = on;
+explain format = 'brief' select t4.a, dt2.combined from t4,
+  (select dt1.val_a + dt1.val_b as combined, t3.a as t3_a from (
+    select t1.a as val_a, t2.b as val_b from t1 join t2 on t1.a = t2.a
+  ) dt1
+  join t3 on dt1.val_a = t3.a) dt2
+where t4.a = dt2.combined;
+
+select t4.a, dt2.combined from t4,
+  (select dt1.val_a + dt1.val_b as combined, t3.a as t3_a from (
+    select t1.a as val_a, t2.b as val_b from t1 join t2 on t1.a = t2.a
+  ) dt1
+  join t3 on dt1.val_a = t3.a) dt2
+where t4.a = dt2.combined order by t4.a;
+
+# =============================================================================
+# Hint Compatibility (Join Method)
+# =============================================================================
+# The join reorder process may inject extra projections to materialize expressions
+# (e.g. t2.b * 2) as columns. This must not break hint matching.
+#
+# LEADING-specific cases depend on the master-only leading hint refactor
+# (#63881/#66087) and are intentionally omitted from this release-8.5 backport.
+# Join method hints should still take effect even if the join side is wrapped by
+# an injected projection.
+
+set tidb_opt_join_reorder_through_proj = on;
+set tidb_opt_join_reorder_threshold = 0;
+set tidb_opt_advanced_join_hint = on;
+
+# Baseline: greedy reorder prefers joining t1 with t2 first (t1.b = t2.b * 2 is selective)
+explain format = 'brief' select t1.a, dt.a2 from t1 join (
+  select t2.a as a2, t2.b * 2 as doubled_b, t3.a as a3
+  from t2 join t3 on t2.a = t3.a
+) dt on t1.b = dt.doubled_b;
+
+# MERGE_JOIN(t2): hint should still be applied even if t2 is wrapped by an injected projection
+explain format = 'brief' select t1.a, dt.a2 from t1 join (
+  select /*+ merge_join(t2) */ t2.a as a2, t2.b * 2 as doubled_b, t3.a as a3
+  from t2 join t3 on t2.a = t3.a
+) dt on t1.b = dt.doubled_b;
+
+# =============================================================================
+# Cleanup
+# =============================================================================
+set tidb_opt_join_reorder_through_proj = off;
+drop table if exists t1, t2, t3, t4, t5;


### PR DESCRIPTION
Backport projection-aware join reorder from a64f198a6e with release-8.5 adaptations.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

cherry-pick from https://github.com/pingcap/tidb/pull/65367

Issue Number: close https://github.com/pingcap/tidb/issues/50229

Problem Summary:
handle the projection between the join group

### What changed and how does it work?
https://docs.google.com/document/d/1x5QDc0i9ks9Jy-I2f_3_lsz3oqu1lFbcb-1h3zAD6a4

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Planner can look through and inline safe projections into join reordering, controllable by a new session/system toggle (off by default).
* **Bug Fixes**
  * Expression hash caches now clear and rebuild correctly after in-place expression updates.
  * Recursive CTE optimization now produces stats from the optimized recursive part.
* **Tests**
  * Added unit and integration tests for projection inlining safety, non-determinism, null-extension, and join-edge cases.
* **Other**
  * EXPLAIN/EXPLAIN ANALYZE now supports a briefer plan output format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->