### PR TITLE
planner: avoid dotted schema table key collisions | tidb-test=pr/2758

### DIFF
--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -71,6 +71,7 @@ go_library(
         "rule_topn_push_down.go",
         "runtime_filter_generator.go",
         "scalar_subq_expression.go",
+        "schema_table_key.go",
         "show_predicate_extractor.go",
         "stats.go",
         "stringer.go",

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -165,6 +165,8 @@ func TestPlannerIssueRegressions(t *testing.T) {
 		tk.MustQuery("select t2.id from `a`.`b.c` as t1, `a.b`.`c` as t2 for update of `a.b`.`c`").
 			Check(testkit.Rows("2"))
 		tk.MustQuery("show warnings").CheckContain("Use the alias 't2'")
+		tk.MustContainErrMsg("select * from `a`.`b.c`, `A`.`B.C`",
+			"[planner:1066]Not unique table/alias: 'a.b.c'")
 
 		tk.MustExec("create database `v`")
 		tk.MustExec("create database `v.b`")

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -147,6 +147,37 @@ func TestPlannerIssueRegressions(t *testing.T) {
 		tk.MustQuery("select * from v")
 	}
 
+	// issue-68164-dotted-schema-table-keys
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("drop database if exists `a`")
+		tk.MustExec("drop database if exists `a.b`")
+		tk.MustExec("drop database if exists `v`")
+		tk.MustExec("drop database if exists `v.b`")
+		tk.MustExec("create database `a`")
+		tk.MustExec("create database `a.b`")
+		tk.MustExec("create table `a`.`b.c` (id int primary key)")
+		tk.MustExec("create table `a.b`.`c` (id int primary key)")
+		tk.MustExec("insert into `a`.`b.c` values (1)")
+		tk.MustExec("insert into `a.b`.`c` values (2)")
+		tk.MustQuery("select * from `a`.`b.c`, `a.b`.`c` for update of `a.b`.`c`").
+			Check(testkit.Rows("1 2"))
+		tk.MustQuery("select t2.id from `a`.`b.c` as t1, `a.b`.`c` as t2 for update of `a.b`.`c`").
+			Check(testkit.Rows("2"))
+		tk.MustQuery("show warnings").CheckContain("Use the alias 't2'")
+
+		tk.MustExec("create database `v`")
+		tk.MustExec("create database `v.b`")
+		tk.MustExec("create view `v`.`b.c` as select 1 as id")
+		tk.MustExec("create view `v.b`.`c` as select * from `v`.`b.c`")
+		tk.MustQuery("select * from `v.b`.`c`").Check(testkit.Rows("1"))
+
+		tk.MustExec("drop database `a`")
+		tk.MustExec("drop database `a.b`")
+		tk.MustExec("drop database `v`")
+		tk.MustExec("drop database `v.b`")
+	}
+
 	// index-merge-with-generated-column
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -166,7 +166,7 @@ func TestPlannerIssueRegressions(t *testing.T) {
 			Check(testkit.Rows("2"))
 		tk.MustQuery("show warnings").CheckContain("Use the alias 't2'")
 		tk.MustContainErrMsg("select * from `a`.`b.c`, `A`.`B.C`",
-			"[planner:1066]Not unique table/alias: 'a.b.c'")
+			"[planner:1066]Not unique table/alias: 'B.C'")
 
 		tk.MustExec("create database `v`")
 		tk.MustExec("create database `v.b`")

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -5480,7 +5480,7 @@ func (b *PlanBuilder) buildMemTable(_ context.Context, dbName ast.CIStr, tableIn
 
 // checkRecursiveView checks whether this view is recursively defined.
 func (b *PlanBuilder) checkRecursiveView(dbName ast.CIStr, tableName ast.CIStr) (func(), error) {
-	viewFullName := schemaTableKey{schema: dbName.L, table: tableName.L}
+	viewFullName := newSchemaTableKey(dbName, tableName)
 	if b.buildingViewStack == nil {
 		b.buildingViewStack = make(map[schemaTableKey]struct{})
 	}

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -5480,20 +5480,20 @@ func (b *PlanBuilder) buildMemTable(_ context.Context, dbName ast.CIStr, tableIn
 
 // checkRecursiveView checks whether this view is recursively defined.
 func (b *PlanBuilder) checkRecursiveView(dbName ast.CIStr, tableName ast.CIStr) (func(), error) {
-	viewFullName := dbName.L + "." + tableName.L
+	viewFullName := schemaTableKey{schema: dbName.L, table: tableName.L}
 	if b.buildingViewStack == nil {
-		b.buildingViewStack = set.NewStringSet()
+		b.buildingViewStack = make(map[schemaTableKey]struct{})
 	}
 	// If this view has already been on the building stack, it means
 	// this view contains a recursive definition.
-	if b.buildingViewStack.Exist(viewFullName) {
+	if _, ok := b.buildingViewStack[viewFullName]; ok {
 		return nil, plannererrors.ErrViewRecursive.GenWithStackByArgs(dbName.O, tableName.O)
 	}
 	// If the view is being renamed, we return the mysql compatible error message.
 	if b.capFlag&renameView != 0 && viewFullName == b.renamingViewName {
 		return nil, plannererrors.ErrNoSuchTable.GenWithStackByArgs(dbName.O, tableName.O)
 	}
-	b.buildingViewStack.Insert(viewFullName)
+	b.buildingViewStack[viewFullName] = struct{}{}
 	return func() { delete(b.buildingViewStack, viewFullName) }, nil
 }
 

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -82,7 +82,6 @@ import (
 	semv1 "github.com/pingcap/tidb/pkg/util/sem"
 	sem "github.com/pingcap/tidb/pkg/util/sem/compat"
 	semv2 "github.com/pingcap/tidb/pkg/util/sem/v2"
-	"github.com/pingcap/tidb/pkg/util/set"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/tikv/client-go/v2/oracle"
 	"go.uber.org/zap"
@@ -260,12 +259,12 @@ type PlanBuilder struct {
 	// SelectLock need this information to locate the lock on partitions.
 	partitionedTable []table.PartitionedTable
 	// buildingViewStack is used to check whether there is a recursive view.
-	buildingViewStack set.StringSet
+	buildingViewStack map[schemaTableKey]struct{}
 	// ignoreTruncateErrForViewPredicateFolding narrows truncate relaxation to
 	// constant predicate folding while expanding a view.
 	ignoreTruncateErrForViewPredicateFolding bool
 	// renamingViewName is the name of the view which is being renamed.
-	renamingViewName string
+	renamingViewName schemaTableKey
 	// isCreateView indicates whether the query is create view.
 	isCreateView bool
 
@@ -5396,7 +5395,7 @@ func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (base.Plan
 		}
 		b.isCreateView = true
 		b.capFlag |= canExpandAST | renameView
-		b.renamingViewName = v.ViewName.Schema.L + "." + v.ViewName.Name.L
+		b.renamingViewName = schemaTableKey{schema: v.ViewName.Schema.L, table: v.ViewName.Name.L}
 		defer func() {
 			b.capFlag &= ^canExpandAST
 			b.capFlag &= ^renameView

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5395,7 +5395,7 @@ func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (base.Plan
 		}
 		b.isCreateView = true
 		b.capFlag |= canExpandAST | renameView
-		b.renamingViewName = schemaTableKey{schema: v.ViewName.Schema.L, table: v.ViewName.Name.L}
+		b.renamingViewName = newSchemaTableKey(v.ViewName.Schema, v.ViewName.Name)
 		defer func() {
 			b.capFlag &= ^canExpandAST
 			b.capFlag &= ^renameView

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -130,7 +130,7 @@ func Preprocess(ctx context.Context, sctx sessionctx.Context, node *resolve.Node
 	v := preprocessor{
 		ctx:                ctx,
 		sctx:               sctx,
-		tableAliasInJoin:   make([]map[string]any, 0),
+		tableAliasInJoin:   make([]map[tableAliasKey]any, 0),
 		preprocessWith:     &preprocessWith{cteCanUsed: make([]string, 0), cteBeforeOffset: make([]int, 0)},
 		lockSelectCtxStack: make([]lockSelectCtx, 0),
 		staleReadProcessor: staleread.NewStaleReadProcessor(ctx, sctx),
@@ -236,7 +236,7 @@ type preprocessor struct {
 
 	// tableAliasInJoin is a stack that keeps the table alias names for joins.
 	// len(tableAliasInJoin) may bigger than 1 because the left/right child of join may be subquery that contains `JOIN`
-	tableAliasInJoin []map[string]any
+	tableAliasInJoin []map[tableAliasKey]any
 	preprocessWith   *preprocessWith
 
 	// lockSelectCtxStack tracks lock-clause resolution state for each SELECT. Each level keeps both
@@ -1138,7 +1138,7 @@ func (p *preprocessor) checkDropTableNames(tables []*ast.TableName) {
 
 func (p *preprocessor) checkNonUniqTableAlias(stmt *ast.Join) {
 	if p.flag&parentIsJoin == 0 {
-		p.tableAliasInJoin = append(p.tableAliasInJoin, make(map[string]any))
+		p.tableAliasInJoin = append(p.tableAliasInJoin, make(map[tableAliasKey]any))
 	}
 	tableAliases := p.tableAliasInJoin[len(p.tableAliasInJoin)-1]
 	isOracleMode := p.sctx.GetSessionVars().SQLMode&mysql.ModeOracle != 0
@@ -1155,23 +1155,26 @@ func (p *preprocessor) checkNonUniqTableAlias(stmt *ast.Join) {
 	p.flag |= parentIsJoin
 }
 
-func isTableAliasDuplicate(node ast.ResultSetNode, tableAliases map[string]any) error {
+func isTableAliasDuplicate(node ast.ResultSetNode, tableAliases map[tableAliasKey]any) error {
 	if ts, ok := node.(*ast.TableSource); ok {
 		tabName := ts.AsName
+		key := tableAliasKey{name: tabName.L}
 		if tabName.L == "" {
 			if tableNode, ok := ts.Source.(*ast.TableName); ok {
 				if tableNode.Schema.L != "" {
-					tabName = ast.NewCIStr(fmt.Sprintf("%s.%s", tableNode.Schema.L, tableNode.Name.L))
+					tabName = ast.NewCIStr(fmt.Sprintf("%s.%s", tableNode.Schema.O, tableNode.Name.O))
+					key = tableAliasKey{schema: tableNode.Schema.L, name: tableNode.Name.L, qualified: true}
 				} else {
 					tabName = tableNode.Name
+					key = tableAliasKey{name: tableNode.Name.L}
 				}
 			}
 		}
-		_, exists := tableAliases[tabName.L]
+		_, exists := tableAliases[key]
 		if len(tabName.L) != 0 && exists {
 			return plannererrors.ErrNonUniqTable.GenWithStackByArgs(tabName)
 		}
-		tableAliases[tabName.L] = nil
+		tableAliases[key] = nil
 	}
 	return nil
 }
@@ -1833,7 +1836,7 @@ type lockSelectCtx struct {
 	// clause. They skip handleTableName because they are resolved later against the FROM clause.
 	lockClauseTables map[*ast.TableName]struct{}
 	aliasMap         map[string]lockRef
-	qualifiedMap     map[string]lockRef
+	qualifiedMap     map[schemaTableKey]lockRef
 	// orderedRefs preserves the left-to-right FROM order for unqualified OF fallback.
 	// For example, `FROM db1.t, db2.t` records `db1.t` before `db2.t`, so fallback resolution for `FOR UPDATE OF t` will try `db1.t` first.
 	// When both aliased and unaliased entries share the same base name, checkLockClauseTables first
@@ -1850,7 +1853,7 @@ func newLockSelectCtx(lockTables []*ast.TableName) lockSelectCtx {
 	return lockSelectCtx{
 		lockClauseTables: lockClauseTables,
 		aliasMap:         make(map[string]lockRef),
-		qualifiedMap:     make(map[string]lockRef),
+		qualifiedMap:     make(map[schemaTableKey]lockRef),
 		orderedRefs:      make([]lockRef, 0),
 	}
 }
@@ -1864,7 +1867,7 @@ func (c *lockSelectCtx) collect(tableName *ast.TableName, asName ast.CIStr) {
 		c.aliasMap[asName.L] = ref
 	}
 	if tableName.Schema.L != "" {
-		qualifiedKey := tableName.Schema.L + "." + tableName.Name.L
+		qualifiedKey := schemaTableKey{schema: tableName.Schema.L, table: tableName.Name.L}
 		// Prefer an exact unaliased `schema.table` entry. If only aliased references exist in FROM,
 		// keep one as the backward-compatibility fallback for `OF schema.table`.
 		if asName.L == "" || c.qualifiedMap[qualifiedKey].table == nil {
@@ -1872,7 +1875,7 @@ func (c *lockSelectCtx) collect(tableName *ast.TableName, asName ast.CIStr) {
 		}
 		if asName.L != "" {
 			// Keep backward compatibility for `OF schema.table` while also supporting `OF schema.alias`.
-			c.qualifiedMap[tableName.Schema.L+"."+asName.L] = ref
+			c.qualifiedMap[schemaTableKey{schema: tableName.Schema.L, table: asName.L}] = ref
 		}
 	}
 	c.orderedRefs = append(c.orderedRefs, ref)
@@ -1919,8 +1922,7 @@ func (p *preprocessor) checkLockClauseTables(stmt *ast.SelectStmt, lockCtx *lock
 		var matchedByAlias bool
 
 		if ref.Schema.L != "" {
-			name = ref.Schema.L + "." + ref.Name.L
-			matched = lockCtx.qualifiedMap[name]
+			matched = lockCtx.qualifiedMap[schemaTableKey{schema: ref.Schema.L, table: ref.Name.L}]
 			matchedByAlias = matched.alias.L != "" && ref.Name.L == matched.alias.L
 			if matchedByAlias {
 				ref.IsAlias = true

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -1158,15 +1158,15 @@ func (p *preprocessor) checkNonUniqTableAlias(stmt *ast.Join) {
 func isTableAliasDuplicate(node ast.ResultSetNode, tableAliases map[tableAliasKey]any) error {
 	if ts, ok := node.(*ast.TableSource); ok {
 		tabName := ts.AsName
-		key := tableAliasKey{name: tabName.L}
+		key := newTableAliasKey(tabName)
 		if tabName.L == "" {
 			if tableNode, ok := ts.Source.(*ast.TableName); ok {
 				if tableNode.Schema.L != "" {
-					key = tableAliasKey{schema: tableNode.Schema.L, name: tableNode.Name.L, qualified: true}
-					tabName = ast.NewCIStr(fmt.Sprintf("%s.%s", key.schema, key.name))
+					key = newQualifiedTableAliasKey(tableNode.Schema, tableNode.Name)
+					tabName = key.displayName()
 				} else {
 					tabName = tableNode.Name
-					key = tableAliasKey{name: tableNode.Name.L}
+					key = newTableAliasKey(tableNode.Name)
 				}
 			}
 		}
@@ -1867,7 +1867,7 @@ func (c *lockSelectCtx) collect(tableName *ast.TableName, asName ast.CIStr) {
 		c.aliasMap[asName.L] = ref
 	}
 	if tableName.Schema.L != "" {
-		qualifiedKey := schemaTableKey{schema: tableName.Schema.L, table: tableName.Name.L}
+		qualifiedKey := newSchemaTableKey(tableName.Schema, tableName.Name)
 		// Prefer an exact unaliased `schema.table` entry. If only aliased references exist in FROM,
 		// keep one as the backward-compatibility fallback for `OF schema.table`.
 		if asName.L == "" || c.qualifiedMap[qualifiedKey].table == nil {
@@ -1875,7 +1875,7 @@ func (c *lockSelectCtx) collect(tableName *ast.TableName, asName ast.CIStr) {
 		}
 		if asName.L != "" {
 			// Keep backward compatibility for `OF schema.table` while also supporting `OF schema.alias`.
-			c.qualifiedMap[schemaTableKey{schema: tableName.Schema.L, table: asName.L}] = ref
+			c.qualifiedMap[newSchemaTableKey(tableName.Schema, asName)] = ref
 		}
 	}
 	c.orderedRefs = append(c.orderedRefs, ref)
@@ -1922,7 +1922,7 @@ func (p *preprocessor) checkLockClauseTables(stmt *ast.SelectStmt, lockCtx *lock
 		var matchedByAlias bool
 
 		if ref.Schema.L != "" {
-			matched = lockCtx.qualifiedMap[schemaTableKey{schema: ref.Schema.L, table: ref.Name.L}]
+			matched = lockCtx.qualifiedMap[newSchemaTableKey(ref.Schema, ref.Name)]
 			matchedByAlias = matched.alias.L != "" && ref.Name.L == matched.alias.L
 			if matchedByAlias {
 				ref.IsAlias = true

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -1162,8 +1162,8 @@ func isTableAliasDuplicate(node ast.ResultSetNode, tableAliases map[tableAliasKe
 		if tabName.L == "" {
 			if tableNode, ok := ts.Source.(*ast.TableName); ok {
 				if tableNode.Schema.L != "" {
-					tabName = ast.NewCIStr(fmt.Sprintf("%s.%s", tableNode.Schema.O, tableNode.Name.O))
 					key = tableAliasKey{schema: tableNode.Schema.L, name: tableNode.Name.L, qualified: true}
+					tabName = ast.NewCIStr(fmt.Sprintf("%s.%s", key.schema, key.name))
 				} else {
 					tabName = tableNode.Name
 					key = tableAliasKey{name: tableNode.Name.L}

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -130,7 +130,7 @@ func Preprocess(ctx context.Context, sctx sessionctx.Context, node *resolve.Node
 	v := preprocessor{
 		ctx:                ctx,
 		sctx:               sctx,
-		tableAliasInJoin:   make([]map[tableAliasKey]any, 0),
+		tableAliasInJoin:   make([]map[tableAliasKey]string, 0),
 		preprocessWith:     &preprocessWith{cteCanUsed: make([]string, 0), cteBeforeOffset: make([]int, 0)},
 		lockSelectCtxStack: make([]lockSelectCtx, 0),
 		staleReadProcessor: staleread.NewStaleReadProcessor(ctx, sctx),
@@ -236,7 +236,7 @@ type preprocessor struct {
 
 	// tableAliasInJoin is a stack that keeps the table alias names for joins.
 	// len(tableAliasInJoin) may bigger than 1 because the left/right child of join may be subquery that contains `JOIN`
-	tableAliasInJoin []map[tableAliasKey]any
+	tableAliasInJoin []map[tableAliasKey]string
 	preprocessWith   *preprocessWith
 
 	// lockSelectCtxStack tracks lock-clause resolution state for each SELECT. Each level keeps both
@@ -1138,7 +1138,7 @@ func (p *preprocessor) checkDropTableNames(tables []*ast.TableName) {
 
 func (p *preprocessor) checkNonUniqTableAlias(stmt *ast.Join) {
 	if p.flag&parentIsJoin == 0 {
-		p.tableAliasInJoin = append(p.tableAliasInJoin, make(map[tableAliasKey]any))
+		p.tableAliasInJoin = append(p.tableAliasInJoin, make(map[tableAliasKey]string))
 	}
 	tableAliases := p.tableAliasInJoin[len(p.tableAliasInJoin)-1]
 	isOracleMode := p.sctx.GetSessionVars().SQLMode&mysql.ModeOracle != 0
@@ -1155,7 +1155,7 @@ func (p *preprocessor) checkNonUniqTableAlias(stmt *ast.Join) {
 	p.flag |= parentIsJoin
 }
 
-func isTableAliasDuplicate(node ast.ResultSetNode, tableAliases map[tableAliasKey]any) error {
+func isTableAliasDuplicate(node ast.ResultSetNode, tableAliases map[tableAliasKey]string) error {
 	if ts, ok := node.(*ast.TableSource); ok {
 		tabName := ts.AsName
 		key := newTableAliasKey(tabName)
@@ -1163,18 +1163,21 @@ func isTableAliasDuplicate(node ast.ResultSetNode, tableAliases map[tableAliasKe
 			if tableNode, ok := ts.Source.(*ast.TableName); ok {
 				if tableNode.Schema.L != "" {
 					key = newQualifiedTableAliasKey(tableNode.Schema, tableNode.Name)
-					tabName = key.displayName()
+					tabName = tableNode.Name
 				} else {
 					tabName = tableNode.Name
 					key = newTableAliasKey(tableNode.Name)
 				}
 			}
 		}
-		_, exists := tableAliases[key]
+		existingName, exists := tableAliases[key]
 		if len(tabName.L) != 0 && exists {
-			return plannererrors.ErrNonUniqTable.GenWithStackByArgs(tabName)
+			if existingName == "" {
+				existingName = tabName.O
+			}
+			return plannererrors.ErrNonUniqTable.GenWithStackByArgs(existingName)
 		}
-		tableAliases[key] = nil
+		tableAliases[key] = tabName.O
 	}
 	return nil
 }

--- a/pkg/planner/core/schema_table_key.go
+++ b/pkg/planner/core/schema_table_key.go
@@ -1,0 +1,26 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+type schemaTableKey struct {
+	schema string
+	table  string
+}
+
+type tableAliasKey struct {
+	schema    string
+	name      string
+	qualified bool
+}

--- a/pkg/planner/core/schema_table_key.go
+++ b/pkg/planner/core/schema_table_key.go
@@ -14,13 +14,36 @@
 
 package core
 
+import "github.com/pingcap/tidb/pkg/parser/ast"
+
+// These keys represent SQL identifier identity. Keep all matching keys and
+// key-derived diagnostics on the normalized CIStr.L fields.
 type schemaTableKey struct {
 	schema string
 	table  string
+}
+
+func newSchemaTableKey(schema, table ast.CIStr) schemaTableKey {
+	return schemaTableKey{schema: schema.L, table: table.L}
 }
 
 type tableAliasKey struct {
 	schema    string
 	name      string
 	qualified bool
+}
+
+func newTableAliasKey(name ast.CIStr) tableAliasKey {
+	return tableAliasKey{name: name.L}
+}
+
+func newQualifiedTableAliasKey(schema, name ast.CIStr) tableAliasKey {
+	return tableAliasKey{schema: schema.L, name: name.L, qualified: true}
+}
+
+func (k tableAliasKey) displayName() ast.CIStr {
+	if k.qualified {
+		return ast.NewCIStr(k.schema + "." + k.name)
+	}
+	return ast.NewCIStr(k.name)
 }

--- a/pkg/planner/core/schema_table_key.go
+++ b/pkg/planner/core/schema_table_key.go
@@ -40,10 +40,3 @@ func newTableAliasKey(name ast.CIStr) tableAliasKey {
 func newQualifiedTableAliasKey(schema, name ast.CIStr) tableAliasKey {
 	return tableAliasKey{schema: schema.L, name: name.L, qualified: true}
 }
-
-func (k tableAliasKey) displayName() ast.CIStr {
-	if k.qualified {
-		return ast.NewCIStr(k.schema + "." + k.name)
-	}
-	return ast.NewCIStr(k.name)
-}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68164

Problem Summary:

Quoted identifiers can contain dots, so `` `a`.`b.c` `` and `` `a.b`.`c` `` are two different tables:

- `` `a`.`b.c` ``: schema = `a`, table = `b.c`
- `` `a.b`.`c` ``: schema = `a.b`, table = `c`

Some planner paths used `schema + "." + table` as an internal semantic key. Both tables collapse to the same string key `a.b.c`, which can make TiDB misidentify view recursion, report table-not-found in create-view rename paths, or bind `FOR UPDATE OF` to the wrong table.

### What changed and how does it work?

This PR replaces the affected string-concatenated schema/table keys with structured keys.

Changed paths:

- Use `schemaTableKey{schema, table}` for view recursion tracking.
- Use `schemaTableKey{schema, table}` for create-view rename matching.
- Use structured keys for `SELECT ... FOR UPDATE OF` qualified table matching.
- Use `tableAliasKey` for join table alias duplicate checks so qualified table names with dotted identifiers do not collide.
- Add an issue regression case covering `` `a`.`b.c` `` and `` `a.b`.`c` ``.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Executed:

```sh
go test -tags=intest ./pkg/planner/core/issuetest -run TestPlannerIssueRegressions -count=1
go test -tags=intest ./pkg/planner/core -run 'TestPreprocessCTE|TestPointGetWithSelectLock|TestSelectView' -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a planner issue where quoted schema or table identifiers containing dots could be misidentified as the same schema/table key.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test covering dotted schema/table identifiers, FOR UPDATE behavior, alias handling and the “not unique table/alias” error.

* **Chores**
  * Internal identifier handling improved to better recognize and disambiguate schema-qualified and dotted names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
