### PR TITLE
*: support zero-backend and token intervals for starter mode

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1402,6 +1402,9 @@ func (c *Config) Load(confFile string) error {
 	if dxfResourceLimitDefined && c.DeployMode != deploymode.PremiumReserved {
 		return fmt.Errorf("dxf-resource-limit can only be configured when deploy-mode is premium_reserved")
 	}
+	if c.DeployMode == deploymode.Starter && !metaData.IsDefined("standby", "enable-zero-backend") {
+		c.Standby.EnableZeroBackend = true
+	}
 	if c.TokenLimit == 0 {
 		c.TokenLimit = 1000
 	} else if c.TokenLimit > MaxTokenLimit {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1113,6 +1113,18 @@ dxf-resource-limit = 101`), 0644))
 	conf = NewConfig()
 	require.NoError(t, conf.Load(configFile))
 	require.Equal(t, deploymode.Starter, conf.DeployMode)
+	require.True(t, conf.Standby.EnableZeroBackend)
+	require.NoError(t, conf.Valid())
+
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+deploy-mode = "starter"
+[standby]
+enable-zero-backend = false
+`), 0644))
+	conf = NewConfig()
+	require.NoError(t, conf.Load(configFile))
+	require.Equal(t, deploymode.Starter, conf.DeployMode)
+	require.False(t, conf.Standby.EnableZeroBackend)
 	require.NoError(t, conf.Valid())
 
 	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "unknown"`), 0644))

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2508,7 +2508,7 @@ func (do *Domain) LoadSigningCertLoop(signingCert, signingKey string) {
 
 		for {
 			select {
-			case <-time.After(sessionstates.LoadCertInterval):
+			case <-time.After(sessionstates.GetLoadCertInterval()):
 				sessionstates.ReloadSigningCert()
 			case <-do.exit:
 				return

--- a/pkg/sessionctx/sessionstates/BUILD.bazel
+++ b/pkg/sessionctx/sessionstates/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/sessionctx/sessionstates",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config/deploymode",
         "//pkg/errno",
         "//pkg/meta/model",
         "//pkg/parser/types",
@@ -31,7 +32,7 @@ go_test(
     ],
     embed = [":sessionstates"],
     flaky = True,
-    shard_count = 17,
+    shard_count = 18,
     deps = [
         "//pkg/config",
         "//pkg/config/deploymode",

--- a/pkg/sessionctx/sessionstates/session_token.go
+++ b/pkg/sessionctx/sessionstates/session_token.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
 )
@@ -51,8 +52,13 @@ import (
 const (
 	// A token needs a lifetime to avoid brute force attack.
 	tokenLifetime = time.Minute
+	// Starter uses a longer lifetime because session migration can span a longer
+	// idle window in zero-backend deployments.
+	starterTokenLifetime = 8 * time.Hour
 	// LoadCertInterval is the interval of reloading the certificate. The certificate should be rotated periodically.
 	LoadCertInterval = 10 * time.Minute
+	// starterLoadCertInterval is the certificate reload interval for Starter.
+	starterLoadCertInterval = 24 * time.Hour
 	// After a certificate is replaced, it's still valid for oldCertValidTime.
 	// oldCertValidTime must be a little longer than LoadCertInterval, because the previous server may
 	// sign with the old cert but the new server checks with the new cert.
@@ -63,7 +69,31 @@ const (
 	// - server B reloads the same new cert again at 00:10:01, and it has 3 certs now.
 	// - server B receives the token at 00:10:02, so the old cert should be valid for more than 10m after replacement.
 	oldCertValidTime = 15 * time.Minute
+	// starterOldCertValidTime is the old certificate grace period for Starter.
+	starterOldCertValidTime = 36 * time.Hour
 )
+
+func currentTokenLifetime() time.Duration {
+	if deploymode.IsStarter() {
+		return starterTokenLifetime
+	}
+	return tokenLifetime
+}
+
+// GetLoadCertInterval returns the current interval for reloading session-token signing certificates.
+func GetLoadCertInterval() time.Duration {
+	if deploymode.IsStarter() {
+		return starterLoadCertInterval
+	}
+	return LoadCertInterval
+}
+
+func currentOldCertValidTime() time.Duration {
+	if deploymode.IsStarter() {
+		return starterOldCertValidTime
+	}
+	return oldCertValidTime
+}
 
 // SessionToken represents the token used to authenticate with the new server.
 type SessionToken struct {
@@ -79,7 +109,7 @@ func CreateSessionToken(username string) (*SessionToken, error) {
 	token := &SessionToken{
 		Username:   username,
 		SignTime:   now,
-		ExpireTime: now.Add(tokenLifetime),
+		ExpireTime: now.Add(currentTokenLifetime()),
 	}
 	tokenBytes, err := json.Marshal(token)
 	if err != nil {
@@ -114,7 +144,7 @@ func ValidateSessionToken(tokenBytes []byte, username string) (err error) {
 	// However, we need to be tolerant of these problems:
 	// - The `tokenLifetime` may change between TiDB versions, so we can't check `token.SignTime.Add(tokenLifetime).Equal(token.ExpireTime)`
 	// - There may exist time bias between TiDB instances, so we can't check `now.After(token.SignTime)`
-	if token.SignTime.Add(tokenLifetime).Before(now) {
+	if token.SignTime.Add(currentTokenLifetime()).Before(now) {
 		return ErrCannotMigrateSession.GenWithStackByArgs("token lifetime is too long", token.SignTime.String())
 	}
 	if !strings.EqualFold(username, token.Username) {
@@ -222,7 +252,7 @@ func (sc *signingCert) loadCert() error {
 	newCerts = append(newCerts, &certInfo{
 		cert:       cert,
 		privKey:    tlsCert.PrivateKey,
-		expireTime: now.Add(LoadCertInterval + oldCertValidTime),
+		expireTime: now.Add(GetLoadCertInterval() + currentOldCertValidTime()),
 	})
 	for i := range sc.certs {
 		// Discard the certs that are already expired.

--- a/pkg/sessionctx/sessionstates/session_token_test.go
+++ b/pkg/sessionctx/sessionstates/session_token_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/stretchr/testify/require"
 )
@@ -156,6 +158,37 @@ func TestVerifyToken(t *testing.T) {
 	require.NoError(t, err)
 	err = ValidateSessionToken(tokenBytes2, "test_user")
 	require.ErrorContains(t, err, "verification error")
+}
+
+func TestStarterSessionTokenLifetime(t *testing.T) {
+	if !kerneltype.IsNextGen() {
+		t.Skip("starter deploy mode is only available for nextgen TiDB")
+	}
+
+	original := deploymode.Get()
+	require.NoError(t, deploymode.Set(deploymode.Starter))
+	t.Cleanup(func() {
+		require.NoError(t, deploymode.Set(original))
+	})
+
+	require.Equal(t, starterTokenLifetime, currentTokenLifetime())
+	require.Equal(t, starterLoadCertInterval, GetLoadCertInterval())
+	require.Equal(t, starterOldCertValidTime, currentOldCertValidTime())
+
+	SetupSigningCertForTest(t)
+	_, tokenBytes := createNewToken(t, "test_user")
+
+	timeOffset := uint64(tokenLifetime + time.Minute)
+	require.NoError(t, failpoint.Enable(mockNowOffset, fmt.Sprintf(`return(%d)`, timeOffset)))
+	err := ValidateSessionToken(tokenBytes, "test_user")
+	require.NoError(t, failpoint.Disable(mockNowOffset))
+	require.NoError(t, err)
+
+	timeOffset = uint64(starterTokenLifetime + time.Minute)
+	require.NoError(t, failpoint.Enable(mockNowOffset, fmt.Sprintf(`return(%d)`, timeOffset)))
+	err = ValidateSessionToken(tokenBytes, "test_user")
+	require.NoError(t, failpoint.Disable(mockNowOffset))
+	require.ErrorContains(t, err, "token expired")
 }
 
 func TestCertExpire(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67765 

Problem Summary:
Starter deployment mode needs different defaults for zero-backend deployments
and longer session token/certificate intervals. The zero-backend default should
only apply to Starter mode, and the longer token/certificate intervals should
not change the behavior of other deployment modes.

### What changed and how does it work?
This PR adds Starter-specific handling guarded by deploymode.IsStarter().

When deploy-mode is starter, standby zero-backend is enabled by default if it is
not explicitly configured. If users explicitly set standby.enable-zero-backend,
that value is preserved.

For session migration, Starter mode uses longer session token lifetime, signing
certificate reload interval, and old certificate validity time. Other deployment
modes continue to use the existing intervals.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Starter deploy mode now automatically enables zero-backend support and implements optimized token lifecycle management with adjusted session duration and certificate refresh intervals.

* **Tests**
  * Added test coverage validating Starter mode token behavior and configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68313)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->