### PR TITLE
*: make max_allowed_packet config-owned in starter mode

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -118,7 +118,13 @@ const (
 	// MaxTokenLimit is the max token limit value.
 	MaxTokenLimit  = 1024 * 1024
 	DefSchemaLease = 45 * time.Second
-	UnavailableIP  = "<nil>"
+	// max_allowed_packet must be in [1024, 1073741824] and a multiple of 1024.
+	maxAllowedPacketUnit  = 1024
+	minMaxAllowedPacket   = maxAllowedPacketUnit
+	maxOfMaxAllowedPacket = 1 << 30
+	// DefMaxAllowedPacket is the default value of max_allowed_packet.
+	DefMaxAllowedPacket = 64 << 20
+	UnavailableIP       = "<nil>"
 )
 
 // Valid config maps
@@ -198,8 +204,10 @@ type Config struct {
 	Lease            string    `toml:"lease" json:"lease"`
 	SplitTable       bool      `toml:"split-table" json:"split-table"`
 	TokenLimit       uint      `toml:"token-limit" json:"token-limit"`
-	TempDir          string    `toml:"temp-dir" json:"temp-dir"`
-	TempStoragePath  string    `toml:"tmp-storage-path" json:"tmp-storage-path"`
+	// MaxAllowedPacket is the configured default for max_allowed_packet in starter deployment mode.
+	MaxAllowedPacket uint64 `toml:"max-allowed-packet" json:"max-allowed-packet"`
+	TempDir          string `toml:"temp-dir" json:"temp-dir"`
+	TempStoragePath  string `toml:"tmp-storage-path" json:"tmp-storage-path"`
 	// TempStorageQuota describe the temporary storage Quota during query exector when TiDBEnableTmpStorageOnOOM is enabled
 	// If the quota exceed the capacity of the TempStoragePath, the tidb-server would exit with fatal error
 	TempStorageQuota           int64                   `toml:"tmp-storage-quota" json:"tmp-storage-quota"` // Bytes
@@ -1024,6 +1032,7 @@ var defaultConf = Config{
 	SplitTable:                   true,
 	Lease:                        DefSchemaLease.String(),
 	TokenLimit:                   1000,
+	MaxAllowedPacket:             DefMaxAllowedPacket,
 	OOMUseTmpStorage:             true,
 	TempDir:                      DefTempDir,
 	TempStorageQuota:             -1,
@@ -1482,6 +1491,9 @@ func (c *Config) Valid() error {
 	if c.DXFResourceLimit != DefDXFResourceLimit && c.DeployMode != deploymode.PremiumReserved {
 		return fmt.Errorf("dxf-resource-limit can only be configured when deploy-mode is premium_reserved")
 	}
+	if c.DeployMode == deploymode.Starter && !validMaxAllowedPacket(c.MaxAllowedPacket) {
+		return fmt.Errorf("max-allowed-packet should be [%d, %d] and a multiple of %d", minMaxAllowedPacket, maxOfMaxAllowedPacket, maxAllowedPacketUnit)
+	}
 	if c.Store == StoreTypeMockTiKV && !c.Instance.TiDBEnableDDL.Load() {
 		return fmt.Errorf("can't disable DDL on mocktikv")
 	}
@@ -1726,4 +1738,19 @@ func ContainHiddenConfig(s string) bool {
 // from config file or command line.
 func GetGlobalKeyspaceName() string {
 	return GetGlobalConfig().KeyspaceName
+}
+
+// GetMaxAllowedPacket returns the max_allowed_packet value used to initialize sessions.
+// The config value is honored only for starter deployment mode.
+func GetMaxAllowedPacket() uint64 {
+	if deploymode.IsStarter() {
+		if v := GetGlobalConfig().MaxAllowedPacket; validMaxAllowedPacket(v) {
+			return v
+		}
+	}
+	return DefMaxAllowedPacket
+}
+
+func validMaxAllowedPacket(v uint64) bool {
+	return v >= minMaxAllowedPacket && v <= maxOfMaxAllowedPacket && v%maxAllowedPacketUnit == 0
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1057,6 +1057,9 @@ func TestDeployModeConfig(t *testing.T) {
 	conf.DeployMode = deploymode.Mode(100)
 	require.ErrorContains(t, conf.Valid(), "invalid deploy-mode")
 	conf.DeployMode = deploymode.Premium
+	conf.MaxAllowedPacket = 0
+	require.NoError(t, conf.Valid())
+	conf.MaxAllowedPacket = DefMaxAllowedPacket
 
 	storeDir := t.TempDir()
 	configFile := filepath.Join(storeDir, "config.toml")
@@ -1126,6 +1129,38 @@ enable-zero-backend = false
 	require.Equal(t, deploymode.Starter, conf.DeployMode)
 	require.False(t, conf.Standby.EnableZeroBackend)
 	require.NoError(t, conf.Valid())
+
+	require.NoError(t, os.WriteFile(configFile, []byte(fmt.Sprintf(`deploy-mode = "starter"
+max-allowed-packet = %d`, minMaxAllowedPacket)), 0644))
+	conf = NewConfig()
+	require.NoError(t, conf.Load(configFile))
+	require.Equal(t, deploymode.Starter, conf.DeployMode)
+	require.Equal(t, uint64(minMaxAllowedPacket), conf.MaxAllowedPacket)
+	require.NoError(t, conf.Valid())
+
+	maxAllowedPacketErr := fmt.Sprintf("max-allowed-packet should be [%d, %d] and a multiple of %d", minMaxAllowedPacket, maxOfMaxAllowedPacket, maxAllowedPacketUnit)
+	for _, packetSize := range []uint64{0, minMaxAllowedPacket - 1, minMaxAllowedPacket + 1, maxOfMaxAllowedPacket + 1} {
+		require.NoError(t, os.WriteFile(configFile, []byte(fmt.Sprintf(`deploy-mode = "starter"
+max-allowed-packet = %d`, packetSize)), 0644))
+		conf = NewConfig()
+		require.NoError(t, conf.Load(configFile))
+		require.ErrorContains(t, conf.Valid(), maxAllowedPacketErr)
+	}
+
+	originDeployMode := deploymode.Get()
+	originGlobalConfig := GetGlobalConfig()
+	t.Cleanup(func() {
+		StoreGlobalConfig(originGlobalConfig)
+		require.NoError(t, deploymode.Set(originDeployMode))
+	})
+	require.NoError(t, deploymode.Set(deploymode.Starter))
+	conf = NewConfig()
+	conf.MaxAllowedPacket = minMaxAllowedPacket
+	StoreGlobalConfig(conf)
+	require.Equal(t, uint64(minMaxAllowedPacket), GetMaxAllowedPacket())
+	conf.MaxAllowedPacket = 0
+	StoreGlobalConfig(conf)
+	require.Equal(t, uint64(DefMaxAllowedPacket), GetMaxAllowedPacket())
 
 	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "unknown"`), 0644))
 	conf = NewConfig()

--- a/pkg/domain/BUILD.bazel
+++ b/pkg/domain/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//br/pkg/streamhelper/daemon",
         "//pkg/bindinfo",
         "//pkg/config",
+        "//pkg/config/deploymode",
         "//pkg/ddl",
         "//pkg/ddl/notifier",
         "//pkg/ddl/placement",

--- a/pkg/domain/sysvar_cache.go
+++ b/pkg/domain/sysvar_cache.go
@@ -18,7 +18,10 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"strconv"
 
+	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
@@ -100,6 +103,12 @@ func (*Domain) fetchTableValues(sctx sessionctx.Context) (map[string]string, err
 	return tableContents, nil
 }
 
+func (*Domain) overrideSysVarWithConfig(tableContent map[string]string) {
+	if _, exist := tableContent[vardef.MaxAllowedPacket]; exist {
+		tableContent[vardef.MaxAllowedPacket] = strconv.FormatUint(config.GetMaxAllowedPacket(), 10)
+	}
+}
+
 // rebuildSysVarCache rebuilds the sysvar cache both globally and for session vars.
 // It needs to be called when sysvars are added or removed.
 func (do *Domain) rebuildSysVarCache(ctx sessionctx.Context) error {
@@ -120,6 +129,10 @@ func (do *Domain) rebuildSysVarCache(ctx sessionctx.Context) error {
 	tableContents, err := do.fetchTableValues(ctx)
 	if err != nil {
 		return err
+	}
+
+	if deploymode.IsStarter() {
+		do.overrideSysVarWithConfig(tableContents)
 	}
 
 	for _, sv := range variable.GetSysVars() {

--- a/pkg/executor/test/showtest/show_test.go
+++ b/pkg/executor/test/showtest/show_test.go
@@ -17,12 +17,14 @@ package showtest
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/pingcap/failpoint"
 	_ "github.com/pingcap/tidb/pkg/autoid_service"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -1110,7 +1112,7 @@ func TestShowLimitReturnRow(t *testing.T) {
 		"gbk Chinese Internal Code Specification gbk_chinese_ci 2"))
 
 	tk.MustQuery("Show Variables where variable_name ='max_allowed_packet'").Check(testkit.RowsWithSep("|", ""+
-		"max_allowed_packet 67108864"))
+		"max_allowed_packet "+strconv.FormatUint(config.GetMaxAllowedPacket(), 10)))
 
 	result = tk.MustQuery("SHOW status where variable_name ='server_id'")
 	rows = result.Rows()

--- a/pkg/expression/main_test.go
+++ b/pkg/expression/main_test.go
@@ -15,6 +15,7 @@
 package expression
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -69,7 +70,7 @@ func createContext(t testing.TB) *mock.Context {
 	ctx.ResetSessionAndStmtTimeZone(tz)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true))
-	require.NoError(t, ctx.GetSessionVars().SetSystemVar("max_allowed_packet", "67108864"))
+	require.NoError(t, ctx.GetSessionVars().SetSystemVar("max_allowed_packet", strconv.FormatUint(config.GetMaxAllowedPacket(), 10)))
 	ctx.GetSessionVars().PlanColumnID.Store(0)
 	return ctx
 }

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     deps = [
         "//pkg/autoid_service",
         "//pkg/config",
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/domain",
         "//pkg/domain/infosync",
@@ -164,6 +165,8 @@ go_test(
     shard_count = 50,
     deps = [
         "//pkg/config",
+        "//pkg/config/deploymode",
+        "//pkg/config/kerneltype",
         "//pkg/domain",
         "//pkg/domain/infosync",
         "//pkg/expression",

--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/extension"
 	"github.com/pingcap/tidb/pkg/metrics"
@@ -1900,6 +1902,38 @@ func TestMaxAllowedPacket(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("SELECT length('%s') as len;", strings.Repeat("b", 488)), string(readBytes))
 	require.Equal(t, uint8(2), pkt.Sequence())
+
+	if kerneltype.IsNextGen() {
+		originalMode := deploymode.Get()
+		originalMaxAllowedPacket := config.GetGlobalConfig().MaxAllowedPacket
+		t.Cleanup(func() {
+			require.NoError(t, deploymode.Set(originalMode))
+			config.UpdateGlobal(func(c *config.Config) {
+				c.MaxAllowedPacket = originalMaxAllowedPacket
+			})
+		})
+
+		require.NoError(t, deploymode.Set(deploymode.Starter))
+		config.UpdateGlobal(func(c *config.Config) {
+			c.MaxAllowedPacket = maxAllowedPacket
+		})
+
+		store := testkit.CreateMockStore(t)
+		tc, err := NewTiDBDriver(store).OpenCtx(1, 0, mysql.DefaultCollationID, "", nil, nil)
+		require.NoError(t, err)
+		require.False(t, tc.GetSessionVars().CommonGlobalLoaded)
+		require.Equal(t, uint64(maxAllowedPacket), tc.GetSessionVars().MaxAllowedPacket)
+
+		inBuffer.Reset()
+		bytes = append([]byte{0x00, 0x08, 0x00, 0x00}, strings.Repeat("a", 2048)...)
+		_, err = inBuffer.Write(bytes)
+		require.NoError(t, err)
+		brc = serverutil.NewBufferedReadConn(&testutil.BytesConn{Buffer: inBuffer})
+		cc := &clientConn{pkt: internal.NewPacketIO(brc)}
+		cc.SetCtx(tc)
+		_, err = cc.readPacket()
+		require.ErrorContains(t, err, "Got a packet bigger than 'max_allowed_packet' bytes")
+	}
 }
 
 func TestOkEof(t *testing.T) {

--- a/pkg/server/driver_tidb.go
+++ b/pkg/server/driver_tidb.go
@@ -18,9 +18,12 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/extension"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -35,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/sessionstates"
+	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
@@ -250,6 +254,12 @@ func (qd *TiDBDriver) OpenCtx(connID uint64, capability uint32, collation uint8,
 	}
 	se.SetClientCapability(capability)
 	se.SetConnectionID(connID)
+	if deploymode.IsStarter() {
+		err = se.GetSessionVars().SetSystemVar(vardef.MaxAllowedPacket, strconv.FormatUint(config.GetMaxAllowedPacket(), 10))
+		if err != nil {
+			return nil, err
+		}
+	}
 	tc := &TiDBContext{
 		Session: se,
 		stmts:   make(map[int]*TiDBStatement),

--- a/pkg/server/internal/BUILD.bazel
+++ b/pkg/server/internal/BUILD.bazel
@@ -6,12 +6,12 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/server/internal",
     visibility = ["//pkg/server:__subpackages__"],
     deps = [
+        "//pkg/config",
         "//pkg/parser/mysql",
         "//pkg/parser/terror",
         "//pkg/server/err",
         "//pkg/server/internal/util",
         "//pkg/server/metrics",
-        "//pkg/sessionctx/vardef",
         "@com_github_klauspost_compress//zstd",
         "@com_github_pingcap_errors//:errors",
     ],

--- a/pkg/server/internal/packetio.go
+++ b/pkg/server/internal/packetio.go
@@ -44,12 +44,12 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	server_err "github.com/pingcap/tidb/pkg/server/err"
 	"github.com/pingcap/tidb/pkg/server/internal/util"
 	server_metrics "github.com/pingcap/tidb/pkg/server/metrics"
-	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 )
 
 const defaultWriterSize = 16 * 1024
@@ -76,7 +76,7 @@ type PacketIO struct {
 func NewPacketIO(bufReadConn *util.BufferedReadConn) *PacketIO {
 	p := &PacketIO{sequence: 0, compressionAlgorithm: mysql.CompressionNone, compressedSequence: 0, zstdLevel: 3}
 	p.SetBufferedReadConn(bufReadConn)
-	p.SetMaxAllowedPacket(vardef.DefMaxAllowedPacket)
+	p.SetMaxAllowedPacket(config.GetMaxAllowedPacket())
 	return p
 }
 

--- a/pkg/server/rpc_server.go
+++ b/pkg/server/rpc_server.go
@@ -241,7 +241,7 @@ func (s *rpcServer) createSession() (sessionapi.Session, error) {
 		action := &memory.PanicOnExceed{Killer: &vars.SQLKiller}
 		vars.MemTracker.SetActionOnExceed(action)
 	}
-	if err = vars.SetSystemVar(vardef.MaxAllowedPacket, strconv.FormatUint(vardef.DefMaxAllowedPacket, 10)); err != nil {
+	if err = vars.SetSystemVar(vardef.MaxAllowedPacket, strconv.FormatUint(config.GetMaxAllowedPacket(), 10)); err != nil {
 		return nil, err
 	}
 	se.SetExtensions(extensions.NewSessionExtensions())

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1335,7 +1335,7 @@ func getSessionFactoryInternal(store kv.Storage, createSessFn func(store kv.Stor
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		err = se.sessionVars.SetSystemVar(vardef.MaxAllowedPacket, strconv.FormatUint(vardef.DefMaxAllowedPacket, 10))
+		err = se.sessionVars.SetSystemVar(vardef.MaxAllowedPacket, strconv.FormatUint(config.GetMaxAllowedPacket(), 10))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -4860,7 +4860,7 @@ func (s *session) loadCommonGlobalVariablesIfNeeded() error {
 	if s.Value(sessionctx.Initing) != nil {
 		// When running bootstrap or upgrade, we should not access global storage.
 		// But we need to init max_allowed_packet to use concat function during bootstrap or upgrade.
-		err := vars.SetSystemVar(vardef.MaxAllowedPacket, strconv.FormatUint(vardef.DefMaxAllowedPacket, 10))
+		err := vars.SetSystemVar(vardef.MaxAllowedPacket, strconv.FormatUint(config.GetMaxAllowedPacket(), 10))
 		if err != nil {
 			logutil.BgLogger().Error("set system variable max_allowed_packet error", zap.Error(err))
 		}

--- a/pkg/session/test/vars/BUILD.bazel
+++ b/pkg/session/test/vars/BUILD.bazel
@@ -11,6 +11,8 @@ go_test(
     shard_count = 11,
     deps = [
         "//pkg/config",
+        "//pkg/config/deploymode",
+        "//pkg/config/kerneltype",
         "//pkg/domain",
         "//pkg/kv",
         "//pkg/parser/terror",

--- a/pkg/session/test/vars/vars_test.go
+++ b/pkg/session/test/vars/vars_test.go
@@ -22,6 +22,9 @@ import (
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/domain"
 	tikv "github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/terror"
@@ -267,14 +270,23 @@ func TestTimeZone(t *testing.T) {
 }
 
 func TestGlobalVarAccessor(t *testing.T) {
+	originalMode := deploymode.Get()
+	if kerneltype.IsNextGen() {
+		require.NoError(t, deploymode.Set(deploymode.Premium))
+		t.Cleanup(func() {
+			require.NoError(t, deploymode.Set(originalMode))
+		})
+	}
+
 	varName := "max_allowed_packet"
-	varValue := strconv.FormatUint(vardef.DefMaxAllowedPacket, 10) // This is the default value for max_allowed_packet
+	varValue := strconv.FormatUint(config.GetMaxAllowedPacket(), 10) // This is the default value for max_allowed_packet
 
 	// The value of max_allowed_packet should be a multiple of 1024,
 	// so the setting of varValue1 and varValue2 would be truncated to varValue0
 	varValue0 := "4194304"
 	varValue1 := "4194305"
 	varValue2 := "4194306"
+	configuredMaxAllowedPacket := uint64(8 << 20)
 
 	store := testkit.CreateMockStore(t)
 
@@ -314,6 +326,55 @@ func TestGlobalVarAccessor(t *testing.T) {
 	v, err = se.GetGlobalSysVar(varName)
 	require.NoError(t, err)
 	require.Equal(t, varValue0, v)
+
+	t.Run("non-starter ignores max_allowed_packet from config", func(t *testing.T) {
+		originalMaxAllowedPacket := config.GetGlobalConfig().MaxAllowedPacket
+		t.Cleanup(func() {
+			config.UpdateGlobal(func(c *config.Config) {
+				c.MaxAllowedPacket = originalMaxAllowedPacket
+			})
+		})
+		config.UpdateGlobal(func(c *config.Config) {
+			c.MaxAllowedPacket = configuredMaxAllowedPacket
+		})
+		nonStarterStore := testkit.CreateMockStore(t)
+		nonStarterTk := testkit.NewTestKit(t, nonStarterStore)
+		nonStarterTk.MustExec("use test")
+		nonStarterSe := nonStarterTk.Session().(variable.GlobalVarAccessor)
+		v, err := nonStarterSe.GetGlobalSysVar(varName)
+		require.NoError(t, err)
+		require.Equal(t, strconv.FormatUint(vardef.DefMaxAllowedPacket, 10), v)
+		nonStarterTk.MustExec("set @@global.max_allowed_packet = 4194304")
+		nonStarterTk.MustQuery("select @@global.max_allowed_packet").Check(testkit.Rows("4194304"))
+	})
+
+	t.Run("starter uses max_allowed_packet from config", func(t *testing.T) {
+		if kerneltype.IsClassic() {
+			t.Skip("starter deploy mode is only available in nextgen")
+		}
+		originalMaxAllowedPacket := config.GetGlobalConfig().MaxAllowedPacket
+		t.Cleanup(func() {
+			config.UpdateGlobal(func(c *config.Config) {
+				c.MaxAllowedPacket = originalMaxAllowedPacket
+			})
+			require.NoError(t, deploymode.Set(deploymode.Premium))
+		})
+		require.NoError(t, deploymode.Set(deploymode.Starter))
+		config.UpdateGlobal(func(c *config.Config) {
+			c.MaxAllowedPacket = configuredMaxAllowedPacket
+		})
+		starterStore := testkit.CreateMockStore(t)
+		starterTk := testkit.NewTestKit(t, starterStore)
+		starterTk.MustExec("use test")
+		starterSe := starterTk.Session().(variable.GlobalVarAccessor)
+		v, err := starterSe.GetGlobalSysVar(varName)
+		require.NoError(t, err)
+		require.Equal(t, strconv.FormatUint(configuredMaxAllowedPacket, 10), v)
+		starterTk.MustContainErrMsg(
+			"set @@global.max_allowed_packet = 4194304",
+			"SET GLOBAL max_allowed_packet is not supported in starter deployment mode",
+		)
+	})
 
 	// For issue 10955, make sure the new session load `max_execution_time` into sessionVars.
 	tk1.MustExec("set @@global.max_execution_time = 100")

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1645,7 +1645,7 @@ const (
 	DefTiDBOptExplainEvaledSubquery                   = false
 	DefTiDBReadStaleness                              = 0
 	DefTiDBGCMaxWaitTime                              = 24 * 60 * 60
-	DefMaxAllowedPacket                        uint64 = 67108864
+	DefMaxAllowedPacket                        uint64 = config.DefMaxAllowedPacket
 	DefTiDBEnableBatchDML                             = false
 	DefTiDBMemQuotaQuery                              = memory.DefMemQuotaQuery // 1GB
 	DefTiDBStatsCacheMemQuota                         = 0

--- a/pkg/sessionctx/variable/error.go
+++ b/pkg/sessionctx/variable/error.go
@@ -38,6 +38,7 @@ var (
 	errGlobalVariable              = dbterror.ClassVariable.NewStd(mysql.ErrGlobalVariable)
 	errLocalVariable               = dbterror.ClassVariable.NewStd(mysql.ErrLocalVariable)
 	errValueNotSupportedWhen       = dbterror.ClassVariable.NewStdErr(mysql.ErrNotSupportedYet, pmysql.Message("%s = OFF is not supported when %s = ON", nil))
+	errSetGlobalMaxAllowedPacket   = dbterror.ClassVariable.NewStdErr(mysql.ErrNotSupportedYet, pmysql.Message("SET GLOBAL max_allowed_packet is not supported in starter deployment mode", nil))
 	ErrNotSupportedInNextGen       = dbterror.ClassVariable.NewStdErr(mysql.ErrNotSupportedYet, pmysql.Message("%s is not supported in the next generation of TiDB", nil))
 	ErrNotValidPassword            = dbterror.ClassExecutor.NewStd(mysql.ErrNotValidPassword)
 	// ErrFunctionsNoopImpl is an error to say the behavior is protected by the tidb_enable_noop_functions sysvar.

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2150,9 +2150,14 @@ var defaultSysVars = []*SysVar{
 	}},
 	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.MaxAllowedPacket, Value: strconv.FormatUint(vardef.DefMaxAllowedPacket, 10), Type: vardef.TypeUnsigned, MinValue: 1024, MaxValue: vardef.MaxOfMaxAllowedPacket,
 		Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope vardef.ScopeFlag) (string, error) {
-			if vars.StmtCtx.StmtType == "Set" && scope == vardef.ScopeSession {
-				err := ErrReadOnly.GenWithStackByArgs("SESSION", vardef.MaxAllowedPacket, "GLOBAL")
-				return normalizedValue, err
+			if vars.StmtCtx.StmtType == "Set" {
+				if scope == vardef.ScopeSession {
+					err := ErrReadOnly.GenWithStackByArgs("SESSION", vardef.MaxAllowedPacket, "GLOBAL")
+					return normalizedValue, err
+				}
+				if scope == vardef.ScopeGlobal && deploymode.IsStarter() {
+					return normalizedValue, errSetGlobalMaxAllowedPacket.GenWithStackByArgs()
+				}
 			}
 			// Truncate the value of max_allowed_packet to be a multiple of 1024,
 			// nonmultiples are rounded down to the nearest multiple.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67765 

Problem Summary:
Starter deployments need a deployment-controlled `max_allowed_packet` limit. Before this change, TiDB only handled `max_allowed_packet` through the regular global sysvar/default path, so packet I/O and different session initialization paths could not consistently use a starter-specific value. Users could also change the value through `SET GLOBAL`, which is not desired for starter mode.

### What changed and how does it work
This PR adds a starter-mode configuration path for `max_allowed_packet`. A new deployment-mode-aware `config.GetMaxAllowedPacket()` helper returns the validated configured value in starter mode and preserves the existing default behavior in non-starter mode.

The helper is used when initializing packet I/O, normal client sessions, internal sessions, RPC sessions, bootstrap/upgrade sessions, and the sysvar cache, making the effective value consistent in starter mode. `SET GLOBAL max_allowed_packet` is rejected in starter mode because the value is deployment-controlled, while non-starter behavior remains unchanged.


In starter mode, `SET GLOBAL max_allowed_packet` is rejected with a clear unsupported error because the value is controlled by deployment configuration. In non-starter mode, the existing sysvar behavior is preserved.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable `max-allowed-packet` setting in starter deployment mode. Users can now set custom maximum allowed packet sizes via configuration (TOML/JSON).

* **Bug Fixes**
  * Fixed system variable initialization to respect configured `max-allowed-packet` values instead of hardcoded defaults across sessions and internal operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68314)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->