### PR TITLE
session: route LOAD DATA LOCAL to the pessimistic txn provider

### DIFF
--- a/pkg/executor/test/loaddatatest/BUILD.bazel
+++ b/pkg/executor/test/loaddatatest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 14,
+    shard_count = 15,
     deps = [
         "//pkg/config",
         "//pkg/executor",

--- a/pkg/executor/test/loaddatatest/load_data_test.go
+++ b/pkg/executor/test/loaddatatest/load_data_test.go
@@ -624,12 +624,6 @@ func (p *loadDataIsPessimisticProbe) Read(b []byte) (int, error) {
 
 func (p *loadDataIsPessimisticProbe) Close() error { return p.inner.Close() }
 
-// TestLoadDataLocalUsesPessimisticTxn asserts that LOAD DATA LOCAL INFILE runs
-// on the pessimistic txn provider, even under default session config
-// (tidb_txn_mode=PESSIMISTIC + autocommit=ON, which otherwise lets
-// decideTxnMode fall through to the optimistic provider). Running on the
-// optimistic provider is what enables the session-level retry path that
-// produced the "drain connection failed in load data" symptom in production.
 func TestLoadDataLocalUsesPessimisticTxn(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/loaddatatest/load_data_test.go
+++ b/pkg/executor/test/loaddatatest/load_data_test.go
@@ -603,3 +603,58 @@ func TestLoadDataLowPrioritySetsKVLowPriority(t *testing.T) {
 	tk.MustQuery("select * from load_data_low_prio").Check(testkit.Rows("1 10"))
 	require.NoError(t, reader.Close())
 }
+
+// loadDataIsPessimisticProbe wraps the file reader and snapshots
+// TxnCtx.IsPessimistic the first time LOAD DATA reads a byte. This lets the
+// test observe which txn provider LOAD DATA actually executes on (the
+// auto-committed case in particular).
+type loadDataIsPessimisticProbe struct {
+	inner         io.ReadCloser
+	sess          sessionctx.Context
+	once          sync.Once
+	isPessimistic atomic.Bool
+}
+
+func (p *loadDataIsPessimisticProbe) Read(b []byte) (int, error) {
+	p.once.Do(func() {
+		p.isPessimistic.Store(p.sess.GetSessionVars().TxnCtx.IsPessimistic)
+	})
+	return p.inner.Read(b)
+}
+
+func (p *loadDataIsPessimisticProbe) Close() error { return p.inner.Close() }
+
+// TestLoadDataLocalUsesPessimisticTxn asserts that LOAD DATA LOCAL INFILE runs
+// on the pessimistic txn provider, even under default session config
+// (tidb_txn_mode=PESSIMISTIC + autocommit=ON, which otherwise lets
+// decideTxnMode fall through to the optimistic provider). Running on the
+// optimistic provider is what enables the session-level retry path that
+// produced the "drain connection failed in load data" symptom in production.
+func TestLoadDataLocalUsesPessimisticTxn(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table load_data_pessimistic (a int, b int)")
+	ctx := tk.Session().(sessionctx.Context)
+
+	// Sanity: confirm we are exercising the default config that would
+	// otherwise route us onto the optimistic provider.
+	tk.MustQuery("select @@tidb_txn_mode").Check(testkit.Rows("pessimistic"))
+	tk.MustQuery("select @@autocommit").Check(testkit.Rows("1"))
+
+	probe := &loadDataIsPessimisticProbe{
+		inner: mydump.NewStringReader("1,2\n3,4\n"),
+		sess:  ctx,
+	}
+	readerBuilder := executor.LoadDataReaderBuilder{
+		Build: func(_ string) (io.ReadCloser, error) { return probe, nil },
+		Wg:    &sync.WaitGroup{},
+	}
+	ctx.SetValue(executor.LoadDataReaderBuilderKey, readerBuilder)
+
+	tk.MustExec("load data local infile '/tmp/x.csv' into table load_data_pessimistic fields terminated by ','")
+
+	require.True(t, probe.isPessimistic.Load(),
+		"LOAD DATA LOCAL must run on the pessimistic provider so the session-level optimistic retry path is short-circuited; otherwise a retryable commit error (kv:8022) would trigger LoadDataReaderBuilder.Build again and surface as 'drain connection failed in load data'")
+}
+

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4923,17 +4923,9 @@ func (s *session) decideTxnMode(stmt ast.StmtNode) string {
 		return s.sessionVars.TxnMode
 	}
 
-	// LOAD DATA LOCAL streams the file from the client as one-shot data: once
-	// the client has sent the terminating empty packet, the protocol gives the
-	// server no way to ask for the file again. Running such a statement on the
-	// optimistic provider would let the session-level retry path
-	// (doCommitWithRetry -> s.retry) re-execute it on a retryable commit
-	// error, which calls the reader builder again and asks the
-	// already-finished client to re-send the file. The result is an EOF that
-	// surfaces as "drain connection failed in load data" and masks the real
-	// commit error. Force LOAD DATA LOCAL onto the pessimistic provider so the
-	// retry guard at doCommitWithRetry short-circuits and the original commit
-	// error is delivered to the client unchanged.
+	// LOAD DATA LOCAL is a one-shot client stream; the optimistic session
+	// retry path cannot replay it, so route it onto the pessimistic provider
+	// to bypass that retry.
 	if _, ok := stmt.(*ast.LoadDataStmt); ok {
 		return ast.Pessimistic
 	}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4923,6 +4923,21 @@ func (s *session) decideTxnMode(stmt ast.StmtNode) string {
 		return s.sessionVars.TxnMode
 	}
 
+	// LOAD DATA LOCAL streams the file from the client as one-shot data: once
+	// the client has sent the terminating empty packet, the protocol gives the
+	// server no way to ask for the file again. Running such a statement on the
+	// optimistic provider would let the session-level retry path
+	// (doCommitWithRetry -> s.retry) re-execute it on a retryable commit
+	// error, which calls the reader builder again and asks the
+	// already-finished client to re-send the file. The result is an EOF that
+	// surfaces as "drain connection failed in load data" and masks the real
+	// commit error. Force LOAD DATA LOCAL onto the pessimistic provider so the
+	// retry guard at doCommitWithRetry short-circuits and the original commit
+	// error is delivered to the client unchanged.
+	if _, ok := stmt.(*ast.LoadDataStmt); ok {
+		return ast.Pessimistic
+	}
+
 	if stmt != nil && s.shouldUsePessimisticAutoCommit(stmt) {
 		return ast.Pessimistic
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68316

Problem Summary:

LOAD DATA LOCAL streams the file from the client as one-shot data. Once the client has sent the terminating empty packet, the MySQL protocol gives the server no way to request the file again.

`decideTxnMode` (`pkg/session/session.go:4910`) chooses the txn provider for an auto-committed statement. The fall-through path returns `ast.Optimistic` unless `shouldUsePessimisticAutoCommit(stmt)` is true, and that function ultimately delegates to `isDMLStatement`, which **intentionally excludes LOAD DATA and IMPORT** (`session.go:4984`):

```go
// Only these DML statements should use pessimistic-auto-commit
// Note: LOAD DATA and IMPORT are intentionally excluded
switch actualStmt.(type) {
case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt:
    return true
default:
    return false
}
```

The combined effect:

| TiDB build | `pessimistic-auto-commit` default | autocommit `INSERT/UPDATE/DELETE` | autocommit **`LOAD DATA`** |
|---|---|---|---|
| Classic | `false` | optimistic | optimistic |
| Nextgen | `true` | pessimistic | **optimistic** (excluded by `isDMLStatement`) |

Running on the optimistic provider exposes LOAD DATA to the session-level retry path in `doCommitWithRetry -> s.retry`. When commit hits a retryable error such as `kv:8022 TxnLockNotFound`, the retry path re-executes the statement and calls `LoadDataReaderBuilder.Build` a second time. The new `Build` asks the already-finished client to re-send the file; the read returns `EOF` and surfaces as:

```
[ERROR] [conn.go:2144] "drain connection failed in load data" [error=EOF]
```

masking the real commit error from the user.

### What changed and how does it work?

Carve LOAD DATA LOCAL out of the optimistic-by-default rule in `decideTxnMode`, alongside the existing `pessimistic-auto-commit` carve-out:

```go
if _, ok := stmt.(*ast.LoadDataStmt); ok {
    return ast.Pessimistic
}
```

Placing the carve-out in `decideTxnMode` rather than `isDMLStatement` is deliberate: it forces LOAD DATA onto the pessimistic provider regardless of `pessimistic-auto-commit`, so the fix covers both classic builds (where `pessimistic-auto-commit=false` would otherwise still route LOAD DATA to optimistic) and nextgen builds. The retry guard at `doCommitWithRetry` (`session.go:873`) short-circuits on pessimistic txns, so the original commit error reaches the client unchanged and the user can decide how to re-run the LOAD DATA.

This mirrors the design intent of the existing `!s.sessionVars.BatchInsert` guard at `session.go:873`, which was added to prevent the same class of "re-execute a non-replayable statement" hazard for the `BatchInsert` path.

A regression test (`TestLoadDataLocalUsesPessimisticTxn`) observes `TxnCtx.IsPessimistic` during the LOAD DATA file read. Verified fail-before / pass-after on stock master.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix LOAD DATA LOCAL INFILE silently entering the optimistic session-retry
path on retryable commit errors (e.g. kv:8022 TxnLockNotFound) and masking
the real error as "drain connection failed in load data". LOAD DATA LOCAL
now runs on the pessimistic provider, so the underlying commit error is
delivered to the client directly.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LOAD DATA LOCAL INFILE now consistently uses pessimistic transactions.

* **Tests**
  * Added a test to verify LOAD DATA transaction behavior.

* **Chores**
  * Updated test shard configuration to adjust parallel test shards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68317)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->