### PR TITLE
planner: eliminate inner distinct aggregation for correlated IN Apply

### DIFF
--- a/pkg/planner/core/casetest/rule/BUILD.bazel
+++ b/pkg/planner/core/casetest/rule/BUILD.bazel
@@ -21,7 +21,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 23,
+    shard_count = 24,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/core/casetest/rule/rule_correlate_test.go
+++ b/pkg/planner/core/casetest/rule/rule_correlate_test.go
@@ -94,6 +94,47 @@ func TestCorrelateAlternativeChoosesApply(t *testing.T) {
 	tk.MustQuery(sql).Check(testkit.Rows("1 1"))
 }
 
+func TestCorrelatedInApplyEliminatesDistinct(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists international_contractors, members, member_employments")
+	tk.MustExec("create table international_contractors (member_id int not null, company_id bigint not null, key(company_id), key(member_id))")
+	tk.MustExec("create table members (id int not null, primary key(id))")
+	tk.MustExec("create table member_employments (member_id int not null, worker_type varchar(20), country_code varchar(8), start_date date, end_date date, key(member_id, worker_type, start_date, end_date))")
+	tk.MustExec("insert into international_contractors values (1, 1), (2, 1), (3, 1)")
+	tk.MustExec("insert into members values (1), (2), (3)")
+	tk.MustExec("insert into member_employments values " +
+		"(1, 'Contractor', 'CA', '2025-01-01', null)," +
+		"(1, 'Contractor', 'CA', '2025-01-02', null)," +
+		"(2, 'Contractor', 'GB', '2025-01-01', '2026-02-01')," +
+		"(3, 'Employee', 'US', '2025-01-01', null)")
+
+	sql := `select count(1)
+from international_contractors ic
+join members m on m.id = ic.member_id
+where m.id in (
+	select distinct inner_members.id
+	from members inner_members
+	join member_employments me on me.member_id = inner_members.id
+	where me.start_date <= '2026-01-05'
+	  and (me.end_date is null or me.end_date >= '2026-01-05')
+	  and me.worker_type = 'Contractor'
+	  and me.country_code != 'US'
+	  and me.member_id = m.id
+)
+and ic.company_id = 1`
+
+	tk.MustExec("set tidb_opt_enable_alternative_logical_plans = ON")
+	rows := tk.MustQuery("explain format = 'brief' " + sql).Rows()
+	require.True(t, explainContains(rows, "Apply"),
+		"with alternative plans, expected Apply in plan:\n%s", joinExplainRows(rows))
+	require.False(t, explainHasDistinctLikeAgg(rows),
+		"expected correlated IN apply to eliminate inner distinct agg:\n%s", joinExplainRows(rows))
+	tk.MustQuery(sql).Check(testkit.Rows("2"))
+}
+
 func TestCorrelate(tt *testing.T) {
 	testkit.RunTestUnderCascades(tt, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
 		tk.MustExec("use test")
@@ -146,6 +187,19 @@ func joinExplainRows(rows [][]any) string {
 		sb.WriteByte('\n')
 	}
 	return sb.String()
+}
+
+func explainHasDistinctLikeAgg(rows [][]any) bool {
+	for _, row := range rows {
+		if len(row) < 5 {
+			continue
+		}
+		info := fmt.Sprintf("%v", row[4])
+		if strings.Contains(info, "group by:") && strings.Contains(info, "firstrow(") {
+			return true
+		}
+	}
+	return false
 }
 
 // TestCorrelateParallelApply verifies that when the correlate alternative round

--- a/pkg/planner/core/casetest/rule/rule_correlate_test.go
+++ b/pkg/planner/core/casetest/rule/rule_correlate_test.go
@@ -127,11 +127,27 @@ where m.id in (
 and ic.company_id = 1`
 
 	tk.MustExec("set tidb_opt_enable_alternative_logical_plans = ON")
+	tk.MustExec(`delete from mysql.opt_rule_blacklist where name = "aggregation_eliminate"`)
+	tk.MustExec("admin reload opt_rule_blacklist")
+	defer func() {
+		tk.MustExec(`delete from mysql.opt_rule_blacklist where name = "aggregation_eliminate"`)
+		tk.MustExec("admin reload opt_rule_blacklist")
+	}()
+	tk.MustExec(`insert into mysql.opt_rule_blacklist values ("aggregation_eliminate")`)
+	tk.MustExec("admin reload opt_rule_blacklist")
 	rows := tk.MustQuery("explain format = 'brief' " + sql).Rows()
 	require.True(t, explainContains(rows, "Apply"),
-		"with alternative plans, expected Apply in plan:\n%s", joinExplainRows(rows))
+		"with aggregation_eliminate disabled, expected Apply in plan:\n%s", joinExplainRows(rows))
+	require.True(t, explainHasDistinctLikeAgg(rows),
+		"with aggregation_eliminate disabled, expected inner distinct agg in Apply plan:\n%s", joinExplainRows(rows))
+
+	tk.MustExec(`delete from mysql.opt_rule_blacklist where name = "aggregation_eliminate"`)
+	tk.MustExec("admin reload opt_rule_blacklist")
+	rows = tk.MustQuery("explain format = 'brief' " + sql).Rows()
+	require.True(t, explainContains(rows, "Apply"),
+		"with aggregation_eliminate enabled, expected Apply in plan:\n%s", joinExplainRows(rows))
 	require.False(t, explainHasDistinctLikeAgg(rows),
-		"expected correlated IN apply to eliminate inner distinct agg:\n%s", joinExplainRows(rows))
+		"with aggregation_eliminate enabled, expected correlated IN apply to eliminate inner distinct agg:\n%s", joinExplainRows(rows))
 	tk.MustQuery(sql).Check(testkit.Rows("2"))
 }
 

--- a/pkg/planner/core/rule_aggregation_elimination.go
+++ b/pkg/planner/core/rule_aggregation_elimination.go
@@ -123,6 +123,26 @@ func (*aggregationEliminateChecker) tryToEliminateDistinct(agg *logicalop.Logica
 	}
 }
 
+// canEliminateSemiJoinInnerDistinct reports whether agg is a duplicate-elimination
+// aggregation that can be removed from the inner side of a semi-style Apply.
+//
+// For semi/anti-semi Apply, the outer row only depends on whether any inner row
+// exists (plus NULL tracking handled by the joiner). A top-level DISTINCT/GROUP BY
+// implemented as first_row aggregations does not change that existence result, so it
+// only delays the Limit-1 short-circuit path. We keep LIMIT-sensitive plans intact,
+// because removing DISTINCT below a LIMIT can change which values survive.
+func (*aggregationEliminateChecker) canEliminateSemiJoinInnerDistinct(agg *logicalop.LogicalAggregation) bool {
+	if agg == nil || len(agg.GroupByItems) == 0 || len(agg.Children()) != 1 || hasLimit(agg.Children()[0]) {
+		return false
+	}
+	for _, aggFunc := range agg.AggFuncs {
+		if aggFunc.Name != ast.AggFuncFirstRow || aggFunc.HasDistinct || len(aggFunc.OrderByItems) > 0 || len(aggFunc.Args) != 1 {
+			return false
+		}
+	}
+	return true
+}
+
 // CheckCanConvertAggToProj check whether a special old aggregation (which has already been pushed down) to projection.
 // link: issue#44795
 func CheckCanConvertAggToProj(agg *logicalop.LogicalAggregation) bool {
@@ -245,6 +265,13 @@ func (a *AggregationEliminator) Optimize(ctx context.Context, p base.LogicalPlan
 		newChildren = append(newChildren, newChild)
 	}
 	p.SetChildren(newChildren...)
+	if apply, ok := p.(*logicalop.LogicalApply); ok && apply.JoinType.IsSemiJoin() {
+		agg, ok := apply.Children()[1].(*logicalop.LogicalAggregation)
+		if ok && a.canEliminateSemiJoinInnerDistinct(agg) {
+			apply.SetChildren(apply.Children()[0], agg.Children()[0])
+			return apply, true, nil
+		}
+	}
 	agg, ok := p.(*logicalop.LogicalAggregation)
 	if !ok {
 		return p, planChanged, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67854

Problem Summary:

When a correlated `IN` subquery is preserved as a semi-style `Apply`, the alternative logical plan path can still keep an inner duplicate-elimination aggregation. That extra aggregation blocks the `Limit 1` short-circuit on the inner side, so fast failover still waits for the aggregation to finish.

### What changed and how does it work?

This change extends `aggregation_eliminate` to remove duplicate-elimination aggregations from the inner child of semi-style `LogicalApply` plans when the aggregation is only implementing `DISTINCT`/`GROUP BY` semantics.

The elimination is intentionally narrow:

- only semi-style `Apply` joins are considered
- the inner aggregation must be a pure duplicate-elimination shape (`GROUP BY` with `first_row(...)` outputs only)
- plans with a `LIMIT` below the aggregation are kept intact to avoid changing semantics

A regression test covers a correlated `IN (SELECT DISTINCT ...)` query and verifies that the optimized plan still keeps `Apply` but no longer contains the distinct-like aggregation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved optimizer to remove redundant DISTINCT aggregations inside correlated semi-join subqueries, reducing work for affected queries.

* **Tests**
  * Added coverage verifying correlated-subquery DISTINCT elimination behavior and plan shapes.
  * Adjusted test parallelization to better distribute test shards.

* **Chores**
  * Updated test shard count configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->