### PR TITLE
server: listen on MySQL port before stats initialization

### DIFF
--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -411,10 +411,9 @@ func main() {
 	repository.SetupRepository(dom)
 	svr := createServer(storage, dom)
 	if standbyController != nil {
-		standbyController.EndStandby(nil)
-
 		svr.StandbyController = standbyController
 		svr.StandbyController.OnServerCreated(svr)
+		standbyController.EndStandby(nil)
 	}
 
 	exited := make(chan struct{})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -345,6 +345,10 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 		s.capability |= mysql.ClientSSL
 	}
 	variable.RegisterStatistics(s)
+
+	if err := s.initTiDBListener(); err != nil {
+		return nil, err
+	}
 	return s, nil
 }
 
@@ -486,11 +490,6 @@ func (s *Server) Run(dom *domain.Domain) error {
 	// If error should be reported and exit the server it can be sent on this
 	// channel. Otherwise, end with sending a nil error to signal "done"
 	errChan := make(chan error, 2)
-	err := s.initTiDBListener()
-	if err != nil {
-		log.Error("failed to create the server", zap.Error(err), zap.Stack("stack"))
-		return err
-	}
 	// Register error API is not thread-safe, the caller MUST NOT register errors after initialization.
 	// To prevent misuse, set a flag to indicate that register new error will panic immediately.
 	// For regression of issue like https://github.com/pingcap/tidb/issues/28190
@@ -501,7 +500,7 @@ func (s *Server) Run(dom *domain.Domain) error {
 		close(RunInGoTestChan)
 	}
 	s.health.Store(true)
-	err = <-errChan
+	err := <-errChan
 	if err != nil {
 		return err
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"net"
 	"path/filepath"
 	"testing"
 
@@ -141,6 +142,10 @@ func TestSeverHealth(t *testing.T) {
 	cfg.Status.ReportStatus = false
 	server, err := NewServer(cfg, tidbdrv)
 	require.NoError(t, err)
+	require.NotNil(t, server.listener, "server should initialize the listener before Run")
+	conflict, err := net.Listen("tcp", server.ListenAddr().String())
+	require.Error(t, err)
+	require.Nil(t, conflict)
 	require.False(t, server.health.Load(), "server should not be healthy")
 	go func() {
 		err = server.Run(nil)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68353

Problem Summary:

When TiDB starts in standby mode, or when forced stats initialization is enabled, the MySQL listener is initialized late in `Server.Run`. The activation caller can be notified before the MySQL port is actually listening, which can make clients see connection refused during startup.

### What changed and how does it work?

Move MySQL listener initialization into `NewServer`, so the port is bound as soon as the server object is created. In standby startup, attach the standby controller and start `OnServerCreated` before notifying activation completion with `EndStandby(nil)`.

The regression test extends `TestSeverHealth` to verify that the listener is already bound before `Run` is called.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/server -run TestSeverHealth -count=1`
  - `go test -run TestStandby -tags=intest,deadlock ./pkg/server/tests/standby`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized server initialization sequence by moving listener setup earlier in the startup process.
  * Improved server startup reliability in standby mode through reordered initialization steps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68339)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
