### PR TITLE
pkg/dxf: reduce noisy expected-flow logs

### DIFF
--- a/pkg/dxf/framework/handle/handle.go
+++ b/pkg/dxf/framework/handle/handle.go
@@ -160,7 +160,7 @@ func WaitTaskDoneOrPaused(ctx context.Context, id int64) error {
 		logger.Error("task reverted", zap.Error(found.Error))
 		return found.Error
 	case proto.TaskStatePaused:
-		logger.Error("task paused")
+		logger.Info("task paused")
 		return nil
 	case proto.TaskStateFailed:
 		return errors.Errorf("task stopped with state %s, err %v", found.State, found.Error)

--- a/pkg/dxf/framework/scheduler/scheduler.go
+++ b/pkg/dxf/framework/scheduler/scheduler.go
@@ -201,7 +201,7 @@ func (s *BaseScheduler) scheduleTask() {
 				s.logger.Debug("task not found, might be reverted/succeed/failed")
 				return
 			}
-			s.sampleLogger.Error("refresh task failed", zap.Error(err))
+			s.sampleLogger.Warn("refresh task failed", zap.Error(err))
 			continue
 		}
 		failpoint.InjectCall("afterRefreshTask", s.GetTask())

--- a/pkg/dxf/framework/taskexecutor/manager.go
+++ b/pkg/dxf/framework/taskexecutor/manager.go
@@ -394,7 +394,7 @@ func (m *Manager) failSubtask(err error, taskID int64, taskExecutor TaskExecutor
 	// TODO we want to define err of taskexecutor.Init as fatal, but add-index have
 	// some code in Init that need retry, remove it after it's decoupled.
 	if taskExecutor != nil && taskExecutor.IsRetryableError(err) {
-		m.logger.Error("met retryable err", zap.Error(err))
+		m.logger.Warn("met retryable err", zap.Error(err))
 		return
 	}
 	err1 := m.runWithRetry(func() error {

--- a/pkg/dxf/framework/taskexecutor/task_executor.go
+++ b/pkg/dxf/framework/taskexecutor/task_executor.go
@@ -171,7 +171,7 @@ func (e *BaseTaskExecutor) checkBalanceSubtask(ctx context.Context, subtaskCtxCa
 		subtasks, err := e.taskTable.GetSubtasksByExecIDAndStepAndStates(ctx, e.execID, task.ID, task.Step,
 			proto.SubtaskStateRunning)
 		if err != nil {
-			e.logger.Error("get subtasks failed", zap.Error(err))
+			e.logger.Warn("get subtasks failed", zap.Error(err))
 			continue
 		}
 		if len(subtasks) == 0 {
@@ -308,7 +308,7 @@ func (e *BaseTaskExecutor) Run() {
 			if goerrors.Is(err, storage.ErrTaskNotFound) {
 				return
 			}
-			e.sampleLogger.Error("refresh task failed", zap.Error(err))
+			e.sampleLogger.Warn("refresh task failed", zap.Error(err))
 			continue
 		}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67631

Problem Summary:

DXF has several expected or retryable task-flow paths that currently emit error-level logs. These paths can be noisy in hot loops and can make normal retry, pause, and balance handling look like actionable failures.

### What changed and how does it work?

This PR downgrades non-terminal DXF framework logs from error level to info or warn level:

- logs paused task completion as info instead of error.
- logs retryable task executor initialization errors as warn instead of error.
- logs transient scheduler/task-executor task refresh and balance-subtask lookup failures as warn instead of error.

Terminal task/subtask failures still keep their existing error-level logs.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test and lint commands:

```bash
./tools/check/failpoint-go-test.sh pkg/dxf/framework/handle -run TestHandle -count=1
./tools/check/failpoint-go-test.sh pkg/dxf/framework/scheduler -run 'TestSchedulerRefreshTask|TestSchedulerNotAllocateSlots|TestManagerSchedulerNotAllocateSlots' -count=1
./tools/check/failpoint-go-test.sh pkg/dxf/framework/taskexecutor -run 'TestManageTaskExecutor|TestTaskExecutorRun|TestCheckBalanceSubtask' -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging severity levels across task scheduling and execution operations to provide more accurate classification of system events and improve observability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68342)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->