### PR TITLE
*: mark killed standby connections as normal closed

### DIFF
--- a/cmd/tidb-server/BUILD.bazel
+++ b/cmd/tidb-server/BUILD.bazel
@@ -107,7 +107,7 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":tidb-server_lib"],
     flaky = True,
-    shard_count = 6,
+    shard_count = 7,
     deps = [
         "//pkg/config",
         "//pkg/config/deploymode",

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -193,6 +193,7 @@ go_library(
         "//pkg/resourcegroup/runaway",
         "//pkg/resourcemanager/pool/workerpool",
         "//pkg/resourcemanager/util",
+        "//pkg/session/sessmgr",
         "//pkg/session/txninfo",
         "//pkg/sessionctx",
         "//pkg/sessionctx/sessionstates",

--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -52,6 +52,7 @@ import (
 	"github.com/pingcap/tidb/pkg/plugin"
 	"github.com/pingcap/tidb/pkg/privilege"
 	"github.com/pingcap/tidb/pkg/resourcegroup"
+	"github.com/pingcap/tidb/pkg/session/sessmgr"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/sessionstates"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
@@ -2621,7 +2622,7 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 	if x, ok := s.Expr.(*ast.FuncCallExpr); ok {
 		if x.FnName.L == ast.ConnectionID {
 			sm := e.Ctx().GetSessionManager()
-			sm.Kill(e.Ctx().GetSessionVars().ConnectionID, s.Query, false, false)
+			killBySQLStmt(sm, e.Ctx().GetSessionVars().ConnectionID, s.Query, false)
 			return nil
 		}
 		return errors.New("Invalid operation. Please use 'KILL TIDB [CONNECTION | QUERY] [connectionID | CONNECTION_ID()]' instead")
@@ -2633,7 +2634,7 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 			if sm == nil {
 				return nil
 			}
-			sm.Kill(s.ConnectionID, s.Query, false, false)
+			killBySQLStmt(sm, s.ConnectionID, s.Query, false)
 		} else {
 			err := errors.NewNoStackError("Invalid operation. Please use 'KILL TIDB [CONNECTION | QUERY] [connectionID | CONNECTION_ID()]' instead")
 			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(err)
@@ -2648,7 +2649,7 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 	if e.IsFromRemote {
 		logutil.BgLogger().Info("Killing connection in current instance redirected from remote TiDB", zap.Uint64("conn", s.ConnectionID), zap.Bool("query", s.Query),
 			zap.String("sourceAddr", e.Ctx().GetSessionVars().SourceAddr.IP.String()))
-		sm.Kill(s.ConnectionID, s.Query, false, false)
+		killBySQLStmt(sm, s.ConnectionID, s.Query, true)
 		return nil
 	}
 
@@ -2674,10 +2675,21 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(err1)
 		}
 	} else {
-		sm.Kill(s.ConnectionID, s.Query, false, false)
+		killBySQLStmt(sm, s.ConnectionID, s.Query, false)
 	}
 
 	return nil
+}
+
+func killBySQLStmt(sm sessmgr.Manager, connectionID uint64, query bool, fromRemote bool) {
+	normalCloseMsg := ""
+	if !query {
+		normalCloseMsg = sessmgr.NormalCloseMsgKillStmt
+		if fromRemote {
+			normalCloseMsg = sessmgr.NormalCloseMsgKillStmtFromRemote
+		}
+	}
+	sessmgr.KillWithNormalCloseMsg(sm, connectionID, query, false, false, normalCloseMsg)
 }
 
 func killRemoteConn(ctx context.Context, sctx sessionctx.Context, gcid *globalconn.GCID, query bool) error {

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -189,6 +189,7 @@ go_test(
         "//pkg/server/internal/testutil",
         "//pkg/server/internal/util",
         "//pkg/session",
+        "//pkg/session/sessmgr",
         "//pkg/sessionctx/vardef",
         "//pkg/sessiontxn",
         "//pkg/store/mockstore",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -57,6 +57,7 @@ import (
 	"github.com/pingcap/tidb/pkg/executor/mppcoordmanager"
 	"github.com/pingcap/tidb/pkg/extension"
 	"github.com/pingcap/tidb/pkg/infoschema/issyncer/mdldef"
+	"github.com/pingcap/tidb/pkg/keyspace"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
@@ -968,6 +969,15 @@ func (s *Server) GetConAttrs(user *auth.UserIdentity) map[uint64]map[string]stri
 
 // Kill implements the SessionManager interface.
 func (s *Server) Kill(connectionID uint64, query bool, maxExecutionTime bool, runaway bool) {
+	s.kill(connectionID, query, maxExecutionTime, runaway, "")
+}
+
+// KillWithNormalCloseMsg implements the sessmgr.NormalCloseKiller interface.
+func (s *Server) KillWithNormalCloseMsg(connectionID uint64, query bool, maxExecutionTime bool, runaway bool, normalCloseMsg string) {
+	s.kill(connectionID, query, maxExecutionTime, runaway, normalCloseMsg)
+}
+
+func (s *Server) kill(connectionID uint64, query bool, maxExecutionTime bool, runaway bool, normalCloseMsg string) {
 	logutil.BgLogger().Info("kill", zap.Uint64("conn", connectionID),
 		zap.Bool("query", query), zap.Bool("maxExecutionTime", maxExecutionTime), zap.Bool("runawayExceed", runaway))
 	metrics.ServerEventCounter.WithLabelValues(metrics.EventKill).Inc()
@@ -993,6 +1003,10 @@ func (s *Server) Kill(connectionID uint64, query bool, maxExecutionTime bool, ru
 			if err := conn.bufReadConn.SetReadDeadline(time.Now()); err != nil {
 				logutil.BgLogger().Warn("error setting read deadline for kill.", zap.Error(err))
 			}
+		}
+		if normalCloseMsg != "" && s.StandbyController != nil {
+			tidbGatewayConnID := conn.attrs[tidbGatewayAttrsConnKey]
+			s.SetNormalClosedConn(keyspace.GetKeyspaceNameBySettings(), tidbGatewayConnID, normalCloseMsg)
 		}
 	}
 	killQuery(conn, maxExecutionTime, runaway)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -18,15 +18,18 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"net/http"
 	"path/filepath"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/keyspace"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/extstore"
 	"github.com/pingcap/tidb/pkg/server/internal"
 	"github.com/pingcap/tidb/pkg/server/internal/testutil"
 	"github.com/pingcap/tidb/pkg/server/internal/util"
+	"github.com/pingcap/tidb/pkg/session/sessmgr"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
 	"github.com/pingcap/tidb/pkg/util/arena"
@@ -34,6 +37,20 @@ import (
 	"github.com/pingcap/tidb/pkg/util/replayer"
 	"github.com/stretchr/testify/require"
 )
+
+type testStandbyController struct{}
+
+func (*testStandbyController) WaitForActivate() {}
+
+func (*testStandbyController) EndStandby(error) {}
+
+func (*testStandbyController) Handler(*Server) (string, *http.ServeMux) {
+	return "/test-standby/", http.NewServeMux()
+}
+
+func (*testStandbyController) OnConnActive() {}
+
+func (*testStandbyController) OnServerCreated(*Server) {}
 
 func TestIssue46197(t *testing.T) {
 	ctx := context.Background()
@@ -129,6 +146,40 @@ func TestGetConAttrs(t *testing.T) {
 	attrs = server.GetConAttrs(userB)
 	_, hasClientName = attrs[1]
 	require.False(t, hasClientName)
+
+	newConn := func(connID uint64, gwConnID string) *clientConn {
+		tk := testkit.NewTestKit(t, store)
+		cc := &clientConn{
+			connectionID: connID,
+			server:       server,
+			alloc:        arena.NewAllocator(1024),
+			chunkAlloc:   chunk.NewAllocator(),
+			pkt:          internal.NewPacketIOForTest(bufio.NewWriter(bytes.NewBuffer(nil))),
+			attrs: map[string]string{
+				tidbGatewayAttrsConnKey: gwConnID,
+			},
+		}
+		cc.SetCtx(&TiDBContext{Session: tk.Session(), stmts: make(map[int]*TiDBStatement)})
+		require.True(t, server.registerConn(cc))
+		return cc
+	}
+
+	const normalCloseMsg = sessmgr.NormalCloseMsgKillStmt
+	keyspaceName := keyspace.GetKeyspaceNameBySettings()
+	noStandbyConn := newConn(100, "gw-no-standby")
+	server.KillWithNormalCloseMsg(noStandbyConn.connectionID, false, false, false, normalCloseMsg)
+	require.Empty(t, server.GetNormalClosedConn(keyspaceName, "gw-no-standby"))
+
+	server.StandbyController = &testStandbyController{}
+	killConn := newConn(101, "gw-kill-connection")
+	require.Empty(t, server.GetNormalClosedConn(keyspaceName, "gw-kill-connection"))
+	server.KillWithNormalCloseMsg(killConn.connectionID, false, false, false, normalCloseMsg)
+	require.Equal(t, normalCloseMsg, server.GetNormalClosedConn(keyspaceName, "gw-kill-connection"))
+	require.Equal(t, int32(connStatusWaitShutdown), killConn.getStatus())
+
+	queryConn := newConn(102, "gw-kill-query")
+	server.KillWithNormalCloseMsg(queryConn.connectionID, true, false, false, normalCloseMsg)
+	require.Empty(t, server.GetNormalClosedConn(keyspaceName, "gw-kill-query"))
 }
 
 func TestSeverHealth(t *testing.T) {

--- a/pkg/session/sessmgr/processinfo.go
+++ b/pkg/session/sessmgr/processinfo.go
@@ -243,6 +243,29 @@ type InfoSchemaCoordinator interface {
 	KillNonFlashbackClusterConn()
 }
 
+const (
+	// NormalCloseMsgKillStmt marks a connection closed by a SQL KILL statement.
+	NormalCloseMsgKillStmt = "kill stmt"
+	// NormalCloseMsgKillStmtFromRemote marks a connection closed by a SQL KILL statement redirected from another TiDB node.
+	NormalCloseMsgKillStmtFromRemote = "kill stmt from remote"
+)
+
+// NormalCloseKiller is implemented by session managers that can record why a killed connection is treated as normally closed.
+type NormalCloseKiller interface {
+	KillWithNormalCloseMsg(connectionID uint64, query bool, maxExecutionTime bool, runaway bool, normalCloseMsg string)
+}
+
+// KillWithNormalCloseMsg kills a connection and records a normal-close reason when the session manager supports it.
+func KillWithNormalCloseMsg(sm Manager, connectionID uint64, query bool, maxExecutionTime bool, runaway bool, normalCloseMsg string) {
+	if normalCloseMsg != "" {
+		if killer, ok := sm.(NormalCloseKiller); ok {
+			killer.KillWithNormalCloseMsg(connectionID, query, maxExecutionTime, runaway, normalCloseMsg)
+			return
+		}
+	}
+	sm.Kill(connectionID, query, maxExecutionTime, runaway)
+}
+
 // Manager is an interface for session manage. Show processlist and
 // kill statement rely on this interface.
 type Manager interface {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67765 

Problem Summary:
`/tidb-pool/checkconn` can confirm some expected TiDB-side connection closes, such as read packet timeout, for standby/tidb-pool deployments. However, when a connection is closed by SQL `KILL CONNECTION`, the connection is intentionally closed by TiDB but is not recorded as normal closed. As a result, the manager may see the closed gateway connection as `unconfirmed`.

### What changed and how does it work
This change extends `SessionManager.Kill` with an optional normal-close reason. SQL `KILL` paths pass a reason, while internal query-kill paths keep passing an empty reason. `Server.Kill` records the gateway connection ID into `normalClosedConns` only when all of these are true: the operation is `KILL CONNECTION`, a normal-close reason is provided, and the server has a `StandbyController` for `/tidb-pool/checkconn`. `KILL QUERY` and non-standby deployments do not write the normal-closed cache.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for killing connections with optional "normal close" messages, including distinct messages for local vs remote statement kills and propagation of keyspace/gateway info.
  * Added a public method to allow callers to supply a normal-close message when terminating connections.

* **Tests**
  * Expanded tests to cover normal-close message recording and connection status changes under standby controller.

* **Chores**
  * Build/test targets updated to include new session manager component and adjust test sharding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68347)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->