### PR TITLE
config, dxf: backport deploy-mode and dxf-resource-limit to release-nextgen-202603

### DIFF
--- a/cmd/tidb-server/BUILD.bazel
+++ b/cmd/tidb-server/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/bindinfo",
         "//pkg/config",
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/ddl",
         "//pkg/domain",
@@ -106,9 +107,10 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":tidb-server_lib"],
     flaky = True,
-    shard_count = 7,
+    shard_count = 6,
     deps = [
         "//pkg/config",
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/parser/mysql",
         "//pkg/sessionctx/vardef",

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/bindinfo"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
@@ -277,6 +278,10 @@ func initFlagSet() *flag.FlagSet {
 	return fset
 }
 
+func initDeployMode(cfg *config.Config) error {
+	return deploymode.Set(cfg.DeployMode)
+}
+
 func main() {
 	fset := initFlagSet()
 	if args := fset.Args(); len(args) != 0 {
@@ -290,6 +295,9 @@ func main() {
 		}
 	}
 	config.InitializeConfig(*configPath, *configCheck, *configStrict, overrideConfig, fset)
+	if kerneltype.IsNextGen() {
+		terror.MustNil(initDeployMode(config.GetGlobalConfig()))
+	}
 	if *version {
 		mustInitVersions()
 		fmt.Println(printer.GetTiDBInfo())

--- a/cmd/tidb-server/main_test.go
+++ b/cmd/tidb-server/main_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
@@ -91,6 +92,25 @@ func TestSetGlobalVars(t *testing.T) {
 	if hostname, err := os.Hostname(); err == nil {
 		require.Equal(t, variable.GetSysVar(vardef.Hostname).Value, hostname)
 	}
+}
+
+func TestInitDeployMode(t *testing.T) {
+	if kerneltype.IsClassic() {
+		t.Skip("only for nextgen kernel")
+	}
+
+	original := deploymode.Get()
+	t.Cleanup(func() {
+		require.NoError(t, deploymode.Set(original))
+	})
+
+	cfg := config.NewConfig()
+	cfg.DeployMode = deploymode.PremiumReserved
+	require.NoError(t, initDeployMode(cfg))
+	require.Equal(t, deploymode.PremiumReserved, deploymode.Get())
+
+	cfg.DeployMode = deploymode.Mode(100)
+	require.ErrorContains(t, initDeployMode(cfg), "invalid deploy mode")
 }
 
 func TestSetVersionByConfigInNextGen(t *testing.T) {

--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/config",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/parser/terror",
         "//pkg/util/intest",
@@ -41,8 +42,9 @@ go_test(
     data = glob(["**"]),
     embed = [":config"],
     flaky = True,
-    shard_count = 31,
+    shard_count = 32,
     deps = [
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/testkit/testsetup",
         "//pkg/util/logutil",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/errors"
 	zaplog "github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/util/intest"
@@ -199,6 +200,7 @@ type Config struct {
 	VersionComment             string                  `toml:"version-comment" json:"version-comment"`
 	TiDBEdition                string                  `toml:"tidb-edition" json:"tidb-edition"`
 	TiDBReleaseVersion         string                  `toml:"tidb-release-version" json:"tidb-release-version"`
+	DeployMode                 deploymode.Mode         `toml:"deploy-mode" json:"deploy-mode"`
 	KeyspaceName               string                  `toml:"keyspace-name" json:"keyspace-name"`
 	TiKVWorkerURL              string                  `toml:"tikv-worker-url" json:"tikv-worker-url"`
 	Log                        Log                     `toml:"log" json:"log"`
@@ -1038,6 +1040,7 @@ var defaultConf = Config{
 	TiDBEdition:                  "",
 	VersionComment:               "",
 	TiDBReleaseVersion:           "",
+	DeployMode:                   deploymode.Premium,
 	RUV2:                         DefaultRUV2Config(),
 	Log: Log{
 		Level:               "info",
@@ -1379,6 +1382,9 @@ func (c *Config) Load(confFile string) error {
 	if err != nil {
 		return err
 	}
+	if !kerneltype.IsNextGen() && metaData.IsDefined("deploy-mode") {
+		return fmt.Errorf("deploy-mode can only be configured for nextgen TiDB")
+	}
 	if c.TokenLimit == 0 {
 		c.TokenLimit = 1000
 	} else if c.TokenLimit > MaxTokenLimit {
@@ -1443,6 +1449,12 @@ func (c *Config) Valid() error {
 	}
 	if !c.Store.Valid() {
 		return fmt.Errorf("invalid store=%s, valid storages=%v", c.Store, StoreTypeList())
+	}
+	if !c.DeployMode.Valid() {
+		return fmt.Errorf("invalid deploy-mode=%s, valid deploy modes=%v", c.DeployMode, deploymode.ModeList())
+	}
+	if !kerneltype.IsNextGen() && c.DeployMode != deploymode.Premium {
+		return fmt.Errorf("deploy-mode can only be configured for nextgen TiDB")
 	}
 	if c.Store == StoreTypeMockTiKV && !c.Instance.TiDBEnableDDL.Load() {
 		return fmt.Errorf("can't disable DDL on mocktikv")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,6 +97,14 @@ const (
 	DefExpensiveTxnTimeThreshold = 600
 	// DefMemoryUsageAlarmRatio is the threshold triggering an alarm which the memory usage of tidb-server instance exceeds.
 	DefMemoryUsageAlarmRatio = 0.8
+	// DefDXFResourceLimit is the default resource percentage available for DXF.
+	DefDXFResourceLimit = 100
+	// MinDXFResourceLimit is the minimum resource percentage available for DXF.
+	// Keep it at 10 while mysql.dist_framework_meta.cpu_count changes from total
+	// node CPU to usable DXF CPU, so the stored value stays non-zero.
+	MinDXFResourceLimit = 10
+	// MaxDXFResourceLimit is the maximum resource percentage available for DXF.
+	MaxDXFResourceLimit = 100
 	// DefTempDir is the default temporary directory path for TiDB.
 	DefTempDir = "/tmp/tidb"
 	// DefPluginAuditLogBufferSize is the default buffer size for plugin audit log.
@@ -201,6 +209,7 @@ type Config struct {
 	TiDBEdition                string                  `toml:"tidb-edition" json:"tidb-edition"`
 	TiDBReleaseVersion         string                  `toml:"tidb-release-version" json:"tidb-release-version"`
 	DeployMode                 deploymode.Mode         `toml:"deploy-mode" json:"deploy-mode"`
+	DXFResourceLimit           int                     `toml:"dxf-resource-limit" json:"dxf-resource-limit"`
 	KeyspaceName               string                  `toml:"keyspace-name" json:"keyspace-name"`
 	TiKVWorkerURL              string                  `toml:"tikv-worker-url" json:"tikv-worker-url"`
 	Log                        Log                     `toml:"log" json:"log"`
@@ -1041,6 +1050,7 @@ var defaultConf = Config{
 	VersionComment:               "",
 	TiDBReleaseVersion:           "",
 	DeployMode:                   deploymode.Premium,
+	DXFResourceLimit:             DefDXFResourceLimit,
 	RUV2:                         DefaultRUV2Config(),
 	Log: Log{
 		Level:               "info",
@@ -1385,6 +1395,13 @@ func (c *Config) Load(confFile string) error {
 	if !kerneltype.IsNextGen() && metaData.IsDefined("deploy-mode") {
 		return fmt.Errorf("deploy-mode can only be configured for nextgen TiDB")
 	}
+	dxfResourceLimitDefined := metaData.IsDefined("dxf-resource-limit")
+	if !dxfResourceLimitDefined && c.DXFResourceLimit == 0 {
+		c.DXFResourceLimit = DefDXFResourceLimit
+	}
+	if dxfResourceLimitDefined && c.DeployMode != deploymode.PremiumReserved {
+		return fmt.Errorf("dxf-resource-limit can only be configured when deploy-mode is premium_reserved")
+	}
 	if c.TokenLimit == 0 {
 		c.TokenLimit = 1000
 	} else if c.TokenLimit > MaxTokenLimit {
@@ -1455,6 +1472,12 @@ func (c *Config) Valid() error {
 	}
 	if !kerneltype.IsNextGen() && c.DeployMode != deploymode.Premium {
 		return fmt.Errorf("deploy-mode can only be configured for nextgen TiDB")
+	}
+	if c.DXFResourceLimit < MinDXFResourceLimit || c.DXFResourceLimit > MaxDXFResourceLimit {
+		return fmt.Errorf("dxf-resource-limit should be between %d and %d", MinDXFResourceLimit, MaxDXFResourceLimit)
+	}
+	if c.DXFResourceLimit != DefDXFResourceLimit && c.DeployMode != deploymode.PremiumReserved {
+		return fmt.Errorf("dxf-resource-limit can only be configured when deploy-mode is premium_reserved")
 	}
 	if c.Store == StoreTypeMockTiKV && !c.Instance.TiDBEnableDDL.Load() {
 		return fmt.Errorf("can't disable DDL on mocktikv")

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -16,6 +16,10 @@ store = "unistore"
 # startup and cannot be changed after it is set.
 deploy-mode = "premium"
 
+# Limits the local TiDB resources available to DXF tasks, [10, 100].
+# This can only be configured when deploy-mode is "premium_reserved".
+# dxf-resource-limit = 100
+
 # TiDB storage path.
 path = "/tmp/tidb"
 

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -12,6 +12,10 @@ port = 4000
 # Registered store name, [tikv, mocktikv, unistore]
 store = "unistore"
 
+# Deployment mode, [premium, premium_reserved, starter]. It is initialized during
+# startup and cannot be changed after it is set.
+deploy-mode = "premium"
+
 # TiDB storage path.
 path = "/tmp/tidb"
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/errors"
 	zaplog "github.com/pingcap/log"
 	meter_config "github.com/pingcap/metering_sdk/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/stretchr/testify/require"
@@ -1046,6 +1047,43 @@ func TestTxnTotalSizeLimitValid(t *testing.T) {
 		conf.Performance.TxnTotalSizeLimit = tt.limit
 		require.Equal(t, tt.valid, conf.Valid() == nil)
 	}
+}
+
+func TestDeployModeConfig(t *testing.T) {
+	conf := NewConfig()
+	require.Equal(t, deploymode.Premium, conf.DeployMode)
+	require.NoError(t, conf.Valid())
+
+	storeDir := t.TempDir()
+	configFile := filepath.Join(storeDir, "config.toml")
+
+	if kerneltype.IsClassic() {
+		require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "premium"`), 0644))
+		conf = NewConfig()
+		require.ErrorContains(t, conf.Load(configFile), "deploy-mode can only be configured for nextgen TiDB")
+
+		conf = NewConfig()
+		conf.DeployMode = deploymode.PremiumReserved
+		require.ErrorContains(t, conf.Valid(), "deploy-mode can only be configured for nextgen TiDB")
+		return
+	}
+
+	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "premium_reserved"`), 0644))
+
+	conf = NewConfig()
+	require.NoError(t, conf.Load(configFile))
+	require.Equal(t, deploymode.PremiumReserved, conf.DeployMode)
+	require.NoError(t, conf.Valid())
+
+	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "starter"`), 0644))
+	conf = NewConfig()
+	require.NoError(t, conf.Load(configFile))
+	require.Equal(t, deploymode.Starter, conf.DeployMode)
+	require.NoError(t, conf.Valid())
+
+	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "unknown"`), 0644))
+	conf = NewConfig()
+	require.ErrorContains(t, conf.Load(configFile), `invalid deploy mode "unknown"`)
 }
 
 func TestConflictInstanceConfig(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1052,12 +1052,17 @@ func TestTxnTotalSizeLimitValid(t *testing.T) {
 func TestDeployModeConfig(t *testing.T) {
 	conf := NewConfig()
 	require.Equal(t, deploymode.Premium, conf.DeployMode)
+	require.Equal(t, DefDXFResourceLimit, conf.DXFResourceLimit)
 	require.NoError(t, conf.Valid())
 
 	storeDir := t.TempDir()
 	configFile := filepath.Join(storeDir, "config.toml")
 
 	if kerneltype.IsClassic() {
+		require.NoError(t, os.WriteFile(configFile, []byte(`dxf-resource-limit = 30`), 0644))
+		conf = NewConfig()
+		require.ErrorContains(t, conf.Load(configFile), "dxf-resource-limit can only be configured when deploy-mode is premium_reserved")
+
 		require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "premium"`), 0644))
 		conf = NewConfig()
 		require.ErrorContains(t, conf.Load(configFile), "deploy-mode can only be configured for nextgen TiDB")
@@ -1073,7 +1078,33 @@ func TestDeployModeConfig(t *testing.T) {
 	conf = NewConfig()
 	require.NoError(t, conf.Load(configFile))
 	require.Equal(t, deploymode.PremiumReserved, conf.DeployMode)
+	require.Equal(t, DefDXFResourceLimit, conf.DXFResourceLimit)
 	require.NoError(t, conf.Valid())
+
+	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "premium_reserved"
+dxf-resource-limit = 30`), 0644))
+	conf = NewConfig()
+	require.NoError(t, conf.Load(configFile))
+	require.Equal(t, deploymode.PremiumReserved, conf.DeployMode)
+	require.Equal(t, 30, conf.DXFResourceLimit)
+	require.NoError(t, conf.Valid())
+
+	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "premium"
+dxf-resource-limit = 100`), 0644))
+	conf = NewConfig()
+	require.ErrorContains(t, conf.Load(configFile), "dxf-resource-limit can only be configured when deploy-mode is premium_reserved")
+
+	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "premium_reserved"
+dxf-resource-limit = 9`), 0644))
+	conf = NewConfig()
+	require.NoError(t, conf.Load(configFile))
+	require.ErrorContains(t, conf.Valid(), "dxf-resource-limit should be between 10 and 100")
+
+	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "premium_reserved"
+dxf-resource-limit = 101`), 0644))
+	conf = NewConfig()
+	require.NoError(t, conf.Load(configFile))
+	require.ErrorContains(t, conf.Valid(), "dxf-resource-limit should be between 10 and 100")
 
 	require.NoError(t, os.WriteFile(configFile, []byte(`deploy-mode = "starter"`), 0644))
 	conf = NewConfig()

--- a/pkg/config/deploymode/BUILD.bazel
+++ b/pkg/config/deploymode/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "deploymode",
+    srcs = [
+        "doc.go",
+        "mode.go",
+    ],
+    importpath = "github.com/pingcap/tidb/pkg/config/deploymode",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/config/kerneltype"],
+)
+
+go_test(
+    name = "deploymode_test",
+    timeout = "short",
+    srcs = ["mode_test.go"],
+    embed = [":deploymode"],
+    flaky = True,
+    shard_count = 3,
+    deps = [
+        "//pkg/config/kerneltype",
+        "@com_github_burntsushi_toml//:toml",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/config/deploymode/doc.go
+++ b/pkg/config/deploymode/doc.go
@@ -1,0 +1,40 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package deploymode stores the process-wide deployment mode for TiDB X
+// (NextGen) deployments.
+//
+// TiDB X Premium Reserved keeps the Premium product capability set, but uses a
+// fixed-resource deployment shape instead of the standard Premium elastic shape.
+// The resource scope is decided when the cluster starts. TiDB-worker,
+// TiKV-worker, and coprocessor-worker are not scaled on demand, so background
+// tasks must not assume that additional worker resources will be created
+// automatically when task demand increases.
+//
+// Premium Reserved adapts Premium behavior to that fixed-resource shape by
+// avoiding TiKV-worker and coprocessor-worker deployment, and by merging TiDB
+// and TiDB-worker behavior. User traffic and distributed task execution run
+// directly on TiDB nodes, and they all run on the SYSTEM keyspace.
+//
+// Starter is a deployment mode for supporting a large number of small tenants.
+//
+// Deploy mode is initialized during TiDB startup and cannot be changed after it
+// is set. It is stored in TiDB component config, which can make the deploy mode
+// inconsistent across TiDB instances if different instances are started with
+// different config values. The tradeoff is intentional: keeping deploy mode in
+// TiDB config avoids changing other components and avoids maintaining separate
+// binaries. Premium Reserved is mainly used in cloud deployments, where all TiDB
+// instances in one group are started with the same config, so the consistency
+// risk is acceptable.
+package deploymode

--- a/pkg/config/deploymode/mode.go
+++ b/pkg/config/deploymode/mode.go
@@ -1,0 +1,155 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploymode
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync/atomic"
+
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
+)
+
+const (
+	premiumName         = "premium"
+	premiumReservedName = "premium_reserved"
+	starterName         = "starter"
+)
+
+// Mode is the deployment mode of the TiDB instance. It is only allowed when
+// kerneltype.IsNextGen returns true.
+type Mode int32
+
+const (
+	// Premium is the default deployment mode.
+	Premium Mode = iota
+	// PremiumReserved is the reserved premium deployment mode. In Premium Reserved,
+	// resources are fixed when the cluster starts. TiDB-worker, TiKV-worker, and
+	// coprocessor-worker are not scaled on demand.
+	PremiumReserved
+	// Starter is for deployments that support a large number of small tenants.
+	Starter
+)
+
+var currentMode atomic.Int32
+
+// Get returns the current deployment mode.
+func Get() Mode {
+	return Mode(currentMode.Load())
+}
+
+// IsPremiumReserved returns true if the current deployment mode is PremiumReserved.
+func IsPremiumReserved() bool {
+	return kerneltype.IsNextGen() && Get() == PremiumReserved
+}
+
+// IsStarter returns true if the current deployment mode is Starter.
+func IsStarter() bool {
+	return kerneltype.IsNextGen() && Get() == Starter
+}
+
+// Set sets the current deployment mode during TiDB startup.
+//
+// The deployment mode cannot be changed after it is set.
+func Set(mode Mode) error {
+	if !kerneltype.IsNextGen() {
+		return fmt.Errorf("deploy mode can only be set for nextgen TiDB")
+	}
+	if !mode.Valid() {
+		return fmt.Errorf("invalid deploy mode %d", mode)
+	}
+	currentMode.Store(int32(mode))
+	return nil
+}
+
+// Parse returns the deployment mode for the given string.
+func Parse(s string) (Mode, error) {
+	switch strings.ToLower(s) {
+	case premiumName:
+		return Premium, nil
+	case premiumReservedName:
+		return PremiumReserved, nil
+	case starterName:
+		return Starter, nil
+	default:
+		return Premium, fmt.Errorf("invalid deploy mode %q", s)
+	}
+}
+
+// String returns the string representation of the deployment mode.
+func (m Mode) String() string {
+	switch m {
+	case Premium:
+		return premiumName
+	case PremiumReserved:
+		return premiumReservedName
+	case Starter:
+		return starterName
+	default:
+		return fmt.Sprintf("unknown(%d)", m)
+	}
+}
+
+// Valid returns true if the deployment mode is valid.
+func (m Mode) Valid() bool {
+	switch m {
+	case Premium, PremiumReserved, Starter:
+		return true
+	default:
+		return false
+	}
+}
+
+// ModeList returns all valid deployment modes.
+func ModeList() []Mode {
+	return []Mode{Premium, PremiumReserved, Starter}
+}
+
+// MarshalJSON implements json.Marshaler.
+func (m Mode) MarshalJSON() ([]byte, error) {
+	if !m.Valid() {
+		return nil, fmt.Errorf("invalid deploy mode %d", m)
+	}
+	return json.Marshal(m.String())
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (m *Mode) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	mode, err := Parse(s)
+	if err != nil {
+		return err
+	}
+	*m = mode
+	return nil
+}
+
+// UnmarshalTOML implements toml.Unmarshaler.
+func (m *Mode) UnmarshalTOML(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("invalid deploy mode %v", v)
+	}
+	mode, err := Parse(s)
+	if err != nil {
+		return err
+	}
+	*m = mode
+	return nil
+}

--- a/pkg/config/deploymode/mode_test.go
+++ b/pkg/config/deploymode/mode_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploymode
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModeJSON(t *testing.T) {
+	data, err := json.Marshal(PremiumReserved)
+	require.NoError(t, err)
+	require.Equal(t, `"premium_reserved"`, string(data))
+
+	data, err = json.Marshal(Starter)
+	require.NoError(t, err)
+	require.Equal(t, `"starter"`, string(data))
+
+	var mode Mode
+	require.NoError(t, json.Unmarshal([]byte(`"premium"`), &mode))
+	require.Equal(t, Premium, mode)
+
+	require.NoError(t, json.Unmarshal([]byte(`"premium_reserved"`), &mode))
+	require.Equal(t, PremiumReserved, mode)
+
+	require.NoError(t, json.Unmarshal([]byte(`"Premium_Reserved"`), &mode))
+	require.Equal(t, PremiumReserved, mode)
+
+	require.NoError(t, json.Unmarshal([]byte(`"Starter"`), &mode))
+	require.Equal(t, Starter, mode)
+
+	require.ErrorContains(t, json.Unmarshal([]byte(`"unknown"`), &mode), `invalid deploy mode "unknown"`)
+	require.Error(t, json.Unmarshal([]byte(`1`), &mode))
+}
+
+func TestModeTOML(t *testing.T) {
+	var cfg struct {
+		Mode Mode `toml:"deploy-mode"`
+	}
+
+	_, err := toml.Decode(`deploy-mode = "premium_reserved"`, &cfg)
+	require.NoError(t, err)
+	require.Equal(t, PremiumReserved, cfg.Mode)
+
+	_, err = toml.Decode(`deploy-mode = "Premium"`, &cfg)
+	require.NoError(t, err)
+	require.Equal(t, Premium, cfg.Mode)
+
+	_, err = toml.Decode(`deploy-mode = "Starter"`, &cfg)
+	require.NoError(t, err)
+	require.Equal(t, Starter, cfg.Mode)
+}
+
+func TestCurrentMode(t *testing.T) {
+	original := Get()
+	t.Cleanup(func() {
+		currentMode.Store(int32(original))
+	})
+
+	if !kerneltype.IsNextGen() {
+		require.Equal(t, Premium, Get())
+		currentMode.Store(int32(PremiumReserved))
+		require.False(t, IsPremiumReserved())
+		currentMode.Store(int32(Starter))
+		require.False(t, IsStarter())
+		require.ErrorContains(t, Set(PremiumReserved), "deploy mode can only be set for nextgen TiDB")
+		return
+	}
+
+	require.Equal(t, Premium, Get())
+	require.False(t, IsPremiumReserved())
+	require.False(t, IsStarter())
+	require.NoError(t, Set(PremiumReserved))
+	require.Equal(t, PremiumReserved, Get())
+	require.True(t, IsPremiumReserved())
+	require.False(t, IsStarter())
+	require.NoError(t, Set(Starter))
+	require.Equal(t, Starter, Get())
+	require.False(t, IsPremiumReserved())
+	require.True(t, IsStarter())
+	require.ErrorContains(t, Set(Mode(100)), "invalid deploy mode")
+}

--- a/pkg/ddl/backfilling_dist_scheduler.go
+++ b/pkg/ddl/backfilling_dist_scheduler.go
@@ -774,7 +774,7 @@ func getRangeSplitter(
 			logger.Warn("fail to get region split keys and size", zap.Error(err))
 		}
 	}
-	nodeRc := handle.GetNodeResource()
+	nodeRc := diststorage.GetNodeResource()
 	rangeSize, rangeKeys := external.CalRangeSize(nodeRc.TotalMem/int64(nodeRc.TotalCPU), regionSplitSize, regionSplitKeys)
 	logutil.DDLIngestLogger().Info("split kv range with split size and keys",
 		zap.Int64("region-split-size", regionSplitSize),

--- a/pkg/domain/BUILD.bazel
+++ b/pkg/domain/BUILD.bazel
@@ -36,7 +36,6 @@ go_library(
         "//pkg/domain/infosync",
         "//pkg/domain/metrics",
         "//pkg/domain/sqlsvrapi",
-        "//pkg/dxf/framework/handle",
         "//pkg/dxf/framework/metering",
         "//pkg/dxf/framework/proto",
         "//pkg/dxf/framework/scheduler",

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -50,7 +50,6 @@ import (
 	"github.com/pingcap/tidb/pkg/domain/globalconfigsync"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/domain/sqlsvrapi"
-	disthandle "github.com/pingcap/tidb/pkg/dxf/framework/handle"
 	"github.com/pingcap/tidb/pkg/dxf/framework/metering"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/scheduler"
@@ -1127,7 +1126,7 @@ func (do *Domain) InitDistTaskLoop() error {
 	if err != nil {
 		return err
 	}
-	disthandle.SetNodeResource(nodeRes)
+	storage.SetNodeResource(nodeRes)
 	executorManager, err := taskexecutor.NewManager(managerCtx, do.store, serverID, taskManager, nodeRes)
 	if err != nil {
 		return err
@@ -1175,11 +1174,16 @@ func calculateNodeResource() (*proto.NodeResource, error) {
 	} else {
 		totalDisk = sz.Capacity
 	}
+	nodeRes := proto.NewNodeResource(totalCPU, int64(totalMem), totalDisk)
+	dxfNodeRes := nodeRes.LimitDXFResource(cfg.DXFResourceLimit)
 	logger.Info("initialize node resource",
 		zap.Int("total-cpu", totalCPU),
 		zap.String("total-mem", units.BytesSize(float64(totalMem))),
+		zap.Int("dxf-resource-limit", cfg.DXFResourceLimit),
+		zap.Int("dxf-usable-cpu", dxfNodeRes.TotalCPU),
+		zap.String("dxf-usable-mem", units.BytesSize(float64(dxfNodeRes.TotalMem))),
 		zap.String("total-disk", units.BytesSize(float64(totalDisk))))
-	return proto.NewNodeResource(totalCPU, int64(totalMem), totalDisk), nil
+	return dxfNodeRes, nil
 }
 
 func (do *Domain) distTaskFrameworkLoop(ctx context.Context, taskManager *storage.TaskManager, executorManager *taskexecutor.Manager, serverID string, nodeRes *proto.NodeResource) {

--- a/pkg/dxf/framework/handle/BUILD.bazel
+++ b/pkg/dxf/framework/handle/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//pkg/sessionctx",
         "//pkg/sessionctx/vardef",
         "//pkg/util/backoff",
-        "//pkg/util/cpu",
         "//pkg/util/disttask",
         "//pkg/util/logutil",
         "//pkg/util/sem/compat",
@@ -35,7 +34,6 @@ go_library(
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_tikv_client_go_v2//util",
-        "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",
     ],
 )
@@ -56,6 +54,7 @@ go_test(
         "//pkg/dxf/framework/proto",
         "//pkg/dxf/framework/schstatus",
         "//pkg/dxf/framework/storage",
+        "//pkg/dxf/framework/testutil",
         "//pkg/kv",
         "//pkg/meta",
         "//pkg/sessionctx",

--- a/pkg/dxf/framework/handle/handle.go
+++ b/pkg/dxf/framework/handle/handle.go
@@ -46,7 +46,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/sem/compat"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/tikv/client-go/v2/util"
-	"go.uber.org/atomic"
 	"go.uber.org/zap"
 )
 
@@ -292,18 +291,6 @@ func RunWithRetry(
 	return lastErr
 }
 
-var nodeResource atomic.Pointer[proto.NodeResource]
-
-// GetNodeResource gets the node resource.
-func GetNodeResource() *proto.NodeResource {
-	return nodeResource.Load()
-}
-
-// SetNodeResource gets the node resource.
-func SetNodeResource(rc *proto.NodeResource) {
-	nodeResource.Store(rc)
-}
-
 // GetDefaultRegionSplitConfig gets the default region split size and keys.
 func GetDefaultRegionSplitConfig() (splitSize, splitKeys int64) {
 	if kerneltype.IsNextGen() {
@@ -472,10 +459,4 @@ func SendRowAndSizeMeterData(ctx context.Context, task *proto.Task, rows int64,
 	}
 	failpoint.InjectCall("afterSendRowAndSizeMeterData", item)
 	return nil
-}
-
-func init() {
-	// domain will init this var at runtime, we store it here for test, as some
-	// test might not start domain.
-	nodeResource.Store(proto.NewNodeResource(8, 16*units.GiB, 100*units.GiB))
 }

--- a/pkg/dxf/framework/handle/status.go
+++ b/pkg/dxf/framework/handle/status.go
@@ -27,11 +27,11 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/tidbvar"
 	"github.com/pingcap/tidb/pkg/sessionctx"
-	"github.com/pingcap/tidb/pkg/util/cpu"
 	disttaskutil "github.com/pingcap/tidb/pkg/util/disttask"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/tikv/client-go/v2/util"
+	"go.uber.org/zap"
 )
 
 // GetScheduleStatus returns the schedule status.
@@ -115,8 +115,9 @@ func GetNodesInfo(ctx context.Context, manager *storage.TaskManager) (nodeCount 
 	if len(nodes) == 0 {
 		// shouldn't happen normally as every node will register itself to the meta
 		// table.
-		logutil.BgLogger().Warn("no managed nodes found, use local node CPU count instead")
-		cpuCount = cpu.GetCPUCount()
+		cpuCount = storage.GetDXFCPUCount()
+		logutil.BgLogger().Warn("no managed nodes found, use local usable CPU count instead",
+			zap.Int("usableCPUCount", cpuCount))
 	} else {
 		cpuCount = nodes[0].CPUCount
 	}

--- a/pkg/dxf/framework/handle/status_testkit_test.go
+++ b/pkg/dxf/framework/handle/status_testkit_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/schstatus"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
+	"github.com/pingcap/tidb/pkg/dxf/framework/testutil"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/sessionctx"
@@ -59,7 +60,7 @@ func TestGetScheduleStatus(t *testing.T) {
 
 func TestNodeInfoAndBusyNodes(t *testing.T) {
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/domain/MockDisableDistTask", "return(true)")
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", "return(16)")
+	testutil.MockNodeResource(t, 16)
 	store := testkit.CreateMockStore(t)
 	gtk := testkit.NewTestKit(t, store)
 	pool := pools.NewResourcePool(func() (pools.Resource, error) {

--- a/pkg/dxf/framework/integrationtests/framework_test.go
+++ b/pkg/dxf/framework/integrationtests/framework_test.go
@@ -361,6 +361,9 @@ func TestMaxRuntimeSlots(t *testing.T) {
 		},
 	)
 	scope := handle.GetTargetScope()
+	cpuCount, err := c.TaskMgr.GetCPUCountOfNode(c.Ctx)
+	require.NoError(t, err)
+	require.Equal(t, 16, cpuCount)
 	task := testutil.SubmitAndWaitTask(c.Ctx, t, "key1", scope, 16)
 	require.Equal(t, proto.TaskStateSucceed, task.State)
 	require.EqualValues(t, 2, callCount.Load())

--- a/pkg/dxf/framework/proto/node.go
+++ b/pkg/dxf/framework/proto/node.go
@@ -14,7 +14,11 @@
 
 package proto
 
-import "github.com/docker/go-units"
+import (
+	"math"
+
+	"github.com/docker/go-units"
+)
 
 // ManagedNode is a TiDB node that is managed by the framework.
 type ManagedNode struct {
@@ -41,6 +45,32 @@ func NewNodeResource(totalCPU int, totalMem int64, totalDisk uint64) *NodeResour
 		TotalMem:  totalMem,
 		TotalDisk: totalDisk,
 	}
+}
+
+// LimitDXFResource returns the resource available to DXF under the given percentage limit.
+func (nr *NodeResource) LimitDXFResource(limit int) *NodeResource {
+	usableCPU := getLimitedDXFCPU(nr.TotalCPU, limit)
+	if usableCPU == nr.TotalCPU || nr.TotalCPU <= 0 {
+		return NewNodeResource(nr.TotalCPU, nr.TotalMem, nr.TotalDisk)
+	}
+	usableMem := int64(float64(usableCPU) / float64(nr.TotalCPU) * float64(nr.TotalMem))
+	// this feature is for premium based cluster, in which we are only support
+	// global sort, there is no local disk. so we leave the disk as is.
+	return NewNodeResource(usableCPU, usableMem, nr.TotalDisk)
+}
+
+// getLimitedDXFCPU returns the CPU slots available to DXF under the given percentage limit.
+func getLimitedDXFCPU(totalCPU int, limit int) int {
+	if totalCPU <= 0 || limit >= 100 {
+		return totalCPU
+	}
+	// use CEIL might cause the real limit to be higher than the given limit.
+	// as DXF use slots or CPU cores as the unit of resource, that's acceptable.
+	usableCPU := int(math.Ceil(float64(totalCPU) * float64(limit) / 100))
+	if usableCPU < 1 {
+		return 1
+	}
+	return min(usableCPU, totalCPU)
 }
 
 // NodeResourceForTest is only used for test.

--- a/pkg/dxf/framework/proto/task_test.go
+++ b/pkg/dxf/framework/proto/task_test.go
@@ -87,4 +87,19 @@ func TestTaskBaseGetRuntimeSlots(t *testing.T) {
 	require.Equal(t, 2, task.GetRuntimeSlots())
 	task.Step = StepTwo
 	require.Equal(t, 4, task.GetRuntimeSlots())
+
+	resource := NewNodeResource(16, 1600, 100)
+	limited := resource.LimitDXFResource(30)
+	require.Equal(t, 5, limited.TotalCPU)
+	require.Equal(t, int64(500), limited.TotalMem)
+	require.Equal(t, resource.TotalDisk, limited.TotalDisk)
+
+	full := resource.LimitDXFResource(100)
+	require.Equal(t, 16, full.TotalCPU)
+	require.Equal(t, int64(1600), full.TotalMem)
+	require.Equal(t, resource.TotalDisk, full.TotalDisk)
+
+	small := NewNodeResource(2, 200, 100).LimitDXFResource(10)
+	require.Equal(t, 1, small.TotalCPU)
+	require.Equal(t, int64(100), small.TotalMem)
 }

--- a/pkg/dxf/framework/storage/BUILD.bazel
+++ b/pkg/dxf/framework/storage/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//pkg/sessionctx/vardef",
         "//pkg/util",
         "//pkg/util/chunk",
-        "//pkg/util/cpu",
         "//pkg/util/hack",
         "//pkg/util/injectfailpoint",
         "//pkg/util/logutil",

--- a/pkg/dxf/framework/storage/nodes.go
+++ b/pkg/dxf/framework/storage/nodes.go
@@ -18,17 +18,38 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 
+	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/schstatus"
 	"github.com/pingcap/tidb/pkg/sessionctx"
-	"github.com/pingcap/tidb/pkg/util/cpu"
 	"github.com/pingcap/tidb/pkg/util/injectfailpoint"
 	"github.com/pingcap/tidb/pkg/util/sqlescape"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/pingcap/tidb/pkg/util/tracing"
 )
+
+var nodeResource atomic.Pointer[proto.NodeResource]
+
+// GetNodeResource gets the node resource.
+func GetNodeResource() *proto.NodeResource {
+	return nodeResource.Load()
+}
+
+// SetNodeResource sets the node resource.
+func SetNodeResource(rc *proto.NodeResource) {
+	nodeResource.Store(rc)
+}
+
+// GetDXFCPUCount returns the cpu count usable to DXF.
+func GetDXFCPUCount() int {
+	if rc := GetNodeResource(); rc != nil {
+		return rc.TotalCPU
+	}
+	return 0
+}
 
 // InitMeta insert the manager information into dist_framework_meta.
 func (mgr *TaskManager) InitMeta(ctx context.Context, tidbID string, role string) error {
@@ -43,7 +64,7 @@ func (*TaskManager) InitMetaSession(ctx context.Context, se sessionctx.Context, 
 	if err := injectfailpoint.DXFRandomErrorWithOnePercent(); err != nil {
 		return err
 	}
-	cpuCount := cpu.GetCPUCount()
+	cpuCount := GetDXFCPUCount()
 	_, err := sqlexec.ExecSQL(ctx, se.GetSQLExecutor(), `
 		insert into mysql.dist_framework_meta(host, role, cpu_count, keyspace_id)
 		values (%?, %?, %?, -1)
@@ -61,7 +82,7 @@ func (mgr *TaskManager) RecoverMeta(ctx context.Context, execID string, role str
 	if err := injectfailpoint.DXFRandomErrorWithOnePercent(); err != nil {
 		return err
 	}
-	cpuCount := cpu.GetCPUCount()
+	cpuCount := GetDXFCPUCount()
 	_, err := mgr.ExecuteSQLWithNewSession(ctx, `
 		insert into mysql.dist_framework_meta(host, role, cpu_count, keyspace_id)
 		values (%?, %?, %?, -1)
@@ -215,7 +236,7 @@ func (mgr *TaskManager) getCPUCountOfNodeByRole(
 	ctx context.Context,
 	se sessionctx.Context,
 	role string,
-	arbitarary bool,
+	arbitrary bool,
 ) (int, error) {
 	nodes, err := mgr.getAllNodesWithSession(ctx, se)
 	if err != nil {
@@ -226,7 +247,7 @@ func (mgr *TaskManager) getCPUCountOfNodeByRole(
 	}
 	var cpuCount int
 	for _, n := range nodes {
-		if !arbitarary && n.Role != role {
+		if !arbitrary && n.Role != role {
 			continue
 		}
 		if n.CPUCount > 0 {
@@ -238,4 +259,9 @@ func (mgr *TaskManager) getCPUCountOfNodeByRole(
 		return 0, errors.New("no managed node have enough resource for dist task")
 	}
 	return cpuCount, nil
+}
+
+func init() {
+	// domain initializes this at runtime. Keep a default for tests that don't start domain.
+	nodeResource.Store(proto.NewNodeResource(8, 16*units.GiB, 100*units.GiB))
 }

--- a/pkg/dxf/framework/storage/table_test.go
+++ b/pkg/dxf/framework/storage/table_test.go
@@ -800,18 +800,22 @@ func TestGetSubtaskCntByStates(t *testing.T) {
 
 func TestDistFrameworkMeta(t *testing.T) {
 	_, sm, ctx := testutil.InitTableTest(t)
+	originNodeResource := storage.GetNodeResource()
+	t.Cleanup(func() {
+		storage.SetNodeResource(originNodeResource)
+	})
 
 	// when no node
 	_, err := sm.GetCPUCountOfNode(ctx)
 	require.ErrorContains(t, err, "no managed nodes")
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", "return(0)")
+	storage.SetNodeResource(proto.NewNodeResource(0, 0, 0))
 	require.NoError(t, sm.InitMeta(ctx, ":4000", "background"))
 	_, err = sm.GetCPUCountOfNode(ctx)
 	require.ErrorContains(t, err, "no managed node have enough resource")
 
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", "return(100)")
+	storage.SetNodeResource(proto.NewNodeResource(100, 100, 100))
 	require.NoError(t, sm.InitMeta(ctx, ":4000", "background"))
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", "return(8)")
+	storage.SetNodeResource(proto.NewNodeResource(8, 8, 100))
 	require.NoError(t, sm.InitMeta(ctx, ":4001", ""))
 	require.NoError(t, sm.InitMeta(ctx, ":4002", "background"))
 	nodes, err := sm.GetAllNodes(ctx)
@@ -822,7 +826,7 @@ func TestDistFrameworkMeta(t *testing.T) {
 		{ID: ":4002", Role: "background", CPUCount: 8},
 	}, nodes)
 
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", "return(100)")
+	storage.SetNodeResource(proto.NewNodeResource(100, 100, 100))
 	require.NoError(t, sm.InitMeta(ctx, ":4002", ""))
 	require.NoError(t, sm.InitMeta(ctx, ":4003", "background"))
 
@@ -883,10 +887,10 @@ func TestDistFrameworkMeta(t *testing.T) {
 		{ID: ":4002", Role: "background", CPUCount: 100},
 	}, nodes)
 
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", "return(100)")
+	storage.SetNodeResource(proto.NewNodeResource(100, 100, 100))
 	require.NoError(t, sm.InitMeta(ctx, ":4000", "background"))
 	require.NoError(t, sm.InitMeta(ctx, ":4001", "background"))
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", "return(8)")
+	storage.SetNodeResource(proto.NewNodeResource(8, 8, 100))
 	require.NoError(t, sm.InitMeta(ctx, ":4002", ""))
 	require.NoError(t, sm.InitMeta(ctx, ":4003", ""))
 	cpuCount, err = sm.GetCPUCountOfNode(ctx)
@@ -898,6 +902,31 @@ func TestDistFrameworkMeta(t *testing.T) {
 	cpuCount, err = sm.GetCPUCountOfNodeByRole(ctx, "background")
 	require.NoError(t, err)
 	require.Equal(t, 100, cpuCount)
+
+	storage.SetNodeResource(proto.NewNodeResource(5, 5, 100))
+	require.NoError(t, sm.InitMeta(ctx, ":4004", "background"))
+	nodes, err = sm.GetAllNodes(ctx)
+	require.NoError(t, err)
+	var limitedNode proto.ManagedNode
+	for _, n := range nodes {
+		if n.ID == ":4004" {
+			limitedNode = n
+			break
+		}
+	}
+	require.Equal(t, proto.ManagedNode{ID: ":4004", Role: "background", CPUCount: 5}, limitedNode)
+
+	storage.SetNodeResource(proto.NewNodeResource(1, 1, 100))
+	require.NoError(t, sm.RecoverMeta(ctx, ":4004", ""))
+	nodes, err = sm.GetAllNodes(ctx)
+	require.NoError(t, err)
+	for _, n := range nodes {
+		if n.ID == ":4004" {
+			limitedNode = n
+			break
+		}
+	}
+	require.Equal(t, proto.ManagedNode{ID: ":4004", Role: "background", CPUCount: 1}, limitedNode)
 }
 
 func TestSubtaskHistoryTable(t *testing.T) {

--- a/pkg/dxf/framework/testutil/context.go
+++ b/pkg/dxf/framework/testutil/context.go
@@ -111,6 +111,11 @@ func (c *TestDXFContext) init(nodeNum, cpuCount int, reduceCheckInterval bool) {
 	}
 	// all nodes are isometric
 	c.mockCPUNum = cpuCount
+	originNodeResource := storage.GetNodeResource()
+	storage.SetNodeResource(proto.NewNodeResource(cpuCount, 32*units.GB, 100*units.GB))
+	c.T.Cleanup(func() {
+		storage.SetNodeResource(originNodeResource)
+	})
 	term := fmt.Sprintf("return(%d)", cpuCount)
 	testfailpoint.Enable(c.T, "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", term)
 	testfailpoint.Enable(c.T, "github.com/pingcap/tidb/pkg/domain/MockDisableDistTask", "return(true)")

--- a/pkg/dxf/framework/testutil/table_util.go
+++ b/pkg/dxf/framework/testutil/table_util.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/ngaut/pools"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
@@ -251,4 +252,14 @@ func PrintSubtaskInfo(ctx context.Context, mgr *storage.TaskManager, taskID int6
 	for _, r := range rs {
 		logutil.BgLogger().Info(fmt.Sprintf("subTask: %v\n", storage.Row2SubTask(r)))
 	}
+}
+
+// MockNodeResource mock node resource.
+func MockNodeResource(t *testing.T, cpu int) {
+	t.Helper()
+	originNodeResource := storage.GetNodeResource()
+	t.Cleanup(func() {
+		storage.SetNodeResource(originNodeResource)
+	})
+	storage.SetNodeResource(proto.NewNodeResource(cpu, int64(cpu)*2*units.GiB, 100*units.GiB))
 }

--- a/pkg/dxf/importinto/planner.go
+++ b/pkg/dxf/importinto/planner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/pkg/dxf/framework/handle"
 	"github.com/pingcap/tidb/pkg/dxf/framework/planner"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
+	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	tidbkv "github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/lightning/backend/external"
@@ -700,7 +701,7 @@ func getRangeSplitter(
 	defRegionSplitSize, defRegionSplitKeys := handle.GetDefaultRegionSplitConfig()
 	regionSplitSize = max(regionSplitSize, defRegionSplitSize)
 	regionSplitKeys = max(regionSplitKeys, defRegionSplitKeys)
-	nodeRc := handle.GetNodeResource()
+	nodeRc := storage.GetNodeResource()
 	rangeSize, rangeKeys := external.CalRangeSize(nodeRc.TotalMem/int64(nodeRc.TotalCPU), regionSplitSize, regionSplitKeys)
 	logutil.Logger(ctx).Info("split kv range with split size and keys",
 		zap.Int64("region-split-size", regionSplitSize),

--- a/pkg/executor/importer/BUILD.bazel
+++ b/pkg/executor/importer/BUILD.bazel
@@ -126,6 +126,7 @@ go_test(
         "//pkg/ddl",
         "//pkg/dxf/framework/handle",
         "//pkg/dxf/framework/proto",
+        "//pkg/dxf/framework/storage",
         "//pkg/dxf/framework/taskexecutor/execute",
         "//pkg/dxf/framework/testutil",
         "//pkg/expression",

--- a/pkg/executor/importer/importer_testkit_test.go
+++ b/pkg/executor/importer/importer_testkit_test.go
@@ -29,6 +29,8 @@ import (
 	tidb "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/dxf/framework/handle"
+	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
+	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/dxf/framework/testutil"
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/expression"
@@ -177,9 +179,13 @@ func TestGetTargetNodeCpuCnt(t *testing.T) {
 	}
 	store, tm, ctx := testutil.InitTableTest(t)
 	tk := testkit.NewTestKit(t, store)
+	originNodeResource := storage.GetNodeResource()
+	t.Cleanup(func() {
+		storage.SetNodeResource(originNodeResource)
+	})
 
 	tk.MustExec("set @@global.tidb_enable_dist_task = off;")
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", "return(16)")
+	storage.SetNodeResource(proto.NewNodeResource(16, 16*units.GiB, 100*units.GiB))
 	require.NoError(t, tm.InitMeta(ctx, "tidb1", ""))
 
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", "return(8)")

--- a/pkg/executor/test/memtest/BUILD.bazel
+++ b/pkg/executor/test/memtest/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "memtest_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "main_test.go",
         "mem_test.go",

--- a/pkg/util/memory/BUILD.bazel
+++ b/pkg/util/memory/BUILD.bazel
@@ -35,7 +35,7 @@ go_library(
 
 go_test(
     name = "memory_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "arbitrator_test.go",
         "bench_test.go",

--- a/pkg/util/printer/BUILD.bazel
+++ b/pkg/util/printer/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config",
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/parser/mysql",
         "//pkg/util/israce",
@@ -26,6 +27,7 @@ go_test(
     embed = [":printer"],
     flaky = True,
     deps = [
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/parser/mysql",
         "//pkg/testkit/testsetup",

--- a/pkg/util/printer/printer.go
+++ b/pkg/util/printer/printer.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/util/israce"
@@ -65,6 +66,9 @@ func PrintTiDBInfo() {
 	}
 	if componentVersion != "" {
 		fields = append(fields, zap.String("TiDB Component Version", componentVersion))
+	}
+	if kerneltype.IsNextGen() {
+		fields = append(fields, zap.Stringer("Deploy Mode", deploymode.Get()))
 	}
 	fields = append(fields, zap.String("Kernel Type", kerneltype.Name()))
 	if versioninfo.TiDBEnterpriseExtensionGitHash != "" {

--- a/pkg/util/printer/printer_test.go
+++ b/pkg/util/printer/printer_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/stretchr/testify/require"
@@ -87,8 +88,11 @@ func TestPrintTiDBInfo(t *testing.T) {
 	fields := entries[0].ContextMap()
 	if kerneltype.IsNextGen() {
 		require.Equal(t, mysql.NormalizeTiDBReleaseVersionForNextGen(mysql.TiDBReleaseVersion), fields["TiDB Component Version"])
+		require.Equal(t, deploymode.Get().String(), fields["Deploy Mode"])
 	} else {
 		_, ok := fields["TiDB Component Version"]
+		require.False(t, ok)
+		_, ok = fields["Deploy Mode"]
 		require.False(t, ok)
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #68181

Problem Summary:

`upstream/release-nextgen-202603` is missing the following NextGen changes already merged to `master`:
- `config: add nextgen deploy mode config` (#68178)
- `dxf: add DXF resource limit config` (#68251)

### What changed and how does it work?

This PR cherry-picks the two upstream merge commits in order:
1. `2cf1f9ccd2a96f720b02e6167e9b881c6880799b` (PR #68178)
2. `5634bd67e94ae757089701e54dc9bfe4ea68f9c9` (PR #68251)

Key effects:
- adds NextGen `deploy-mode` support (`premium`, `premium_reserved`, `starter`) and config validation
- adds `dxf-resource-limit` (10-100, default 100) for `premium_reserved`
- limits DXF runtime resource calculation and persists usable CPU in dist framework metadata
- includes required Bazel metadata regeneration for this branch (`cmd/tidb-server/BUILD.bazel` shard count update)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `make bazel_prepare`
  - `go test -run 'TestDeployModeConfig|TestConfig$|TestConfigExample|TestGetJSONConfig' -count=1 -tags=intest,deadlock ./pkg/config`
  - `go test -run 'TestDeployModeConfig|TestConfig$|TestConfigExample|TestGetJSONConfig' -count=1 -tags=intest,deadlock,nextgen ./pkg/config`
  - `go test -run 'TestModeJSON|TestModeTOML|TestCurrentMode' -count=1 -tags=intest,deadlock ./pkg/config/deploymode`
  - `go test -run 'TestModeJSON|TestModeTOML|TestCurrentMode' -count=1 -tags=intest,deadlock,nextgen ./pkg/config/deploymode`
  - `./tools/check/failpoint-go-test.sh cmd/tidb-server -run TestInitDeployMode -count=1 -tags=intest,deadlock,nextgen`
  - `go test -run TestPrintTiDBInfo -count=1 -tags=intest,deadlock ./pkg/util/printer`
  - `go test -run TestPrintTiDBInfo -count=1 -tags=intest,deadlock,nextgen ./pkg/util/printer`
  - `go test -run TestTaskBaseGetRuntimeSlots -count=1 -tags=intest,deadlock ./pkg/dxf/framework/proto`
  - `./tools/check/failpoint-go-test.sh pkg/dxf/framework/storage -run TestDistFrameworkMeta -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/dxf/framework/handle -run TestNodeInfoAndBusyNodes -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/dxf/framework/integrationtests -run TestMaxRuntimeSlots -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/executor/importer -run TestGetTargetNodeCpuCnt -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/domain -run '^$' -count=1 -tags=intest,deadlock,nextgen`
  - `make lint`
  - `git diff --check upstream/release-nextgen-202603...HEAD`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Add NextGen `deploy-mode` support and `dxf-resource-limit` configuration to control DXF local resource usage for premium_reserved deployments.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deployment mode configuration system for TiDB with three modes: Premium, PremiumReserved, and Starter (nextgen kernel only).
  * Added DXF resource limit configuration to control resource allocation for distributed task execution.
  * Deploy mode is now displayed in server startup information.

* **Configuration**
  * New `[deploy-mode]` and `dxf-resource-limit` configuration options in TOML files with validation constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->