### PR TITLE
owners: add Terry to critical parser approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,6 +10,7 @@ aliases:
   sig-critical-approvers-parser:
     - yudongusa
     - likidu
+    - terry1purcell
   sig-approvers-autoid-service:
     - bb7133
     - tiancaiamao


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary:

Add Terry to the critical parser approver alias.

### What changed and how does it work?

Add `terry1purcell` to `sig-critical-approvers-parser` in `OWNERS_ALIASES`.

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.

Manual test:

- Parsed `OWNERS_ALIASES` as YAML.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated team member approver permissions configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68350)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->