### PR TITLE
parser, bindinfo: relax binding match for redundant parentheses

### DIFF
--- a/pkg/bindinfo/tests/bind_test.go
+++ b/pkg/bindinfo/tests/bind_test.go
@@ -500,6 +500,11 @@ func TestSimplifiedCreateBinding(t *testing.T) {
 	tk.MustExec(`create global binding using select /*+ use_index(t, a) */ * from t where a in (1,2,3)`)
 	check("global", "select * from `test` . `t` where `a` in ( ... )", "SELECT /*+ use_index(`t` `a`)*/ * FROM `test`.`t` WHERE `a` IN (1,2,3)")
 	tk.MustExec(`drop global binding for select * from t where a in (1,2,3)`)
+
+	tk.MustExec(`create global binding using select /*+ use_index(t, a) */ * from t where a = 1 and b = 1`)
+	tk.MustQuery(`select * from t where (a = 1) and b = 1`).Check(testkit.Rows())
+	tk.MustQuery(`select @@last_plan_from_binding`).Check(testkit.Rows("1"))
+	tk.MustExec(`drop global binding for select * from t where a = 1 and b = 1`)
 }
 
 func TestDropBindBySQLDigest(t *testing.T) {

--- a/pkg/parser/digester.go
+++ b/pkg/parser/digester.go
@@ -162,7 +162,7 @@ func (d *sqlDigester) doDigestNormalized(normalized string) (digest *Digest) {
 }
 
 func (d *sqlDigester) doDigest(sql string) (digest *Digest) {
-	d.normalize(sql, errors.RedactLogEnable, false, false, false)
+	d.normalize(sql, errors.RedactLogEnable, false, false, false, false)
 	d.hasher.Write(d.buffer.Bytes())
 	d.buffer.Reset()
 	digest = NewDigest(d.hasher.Sum(nil))
@@ -171,21 +171,21 @@ func (d *sqlDigester) doDigest(sql string) (digest *Digest) {
 }
 
 func (d *sqlDigester) doNormalize(sql string, redact string, keepHint bool) (result string) {
-	d.normalize(sql, redact, keepHint, false, false)
+	d.normalize(sql, redact, keepHint, false, false, false)
 	result = d.buffer.String()
 	d.buffer.Reset()
 	return
 }
 
 func (d *sqlDigester) doNormalizeForBinding(sql string, keepHint bool, forPlanReplayerReload bool) (result string) {
-	d.normalize(sql, errors.RedactLogEnable, keepHint, true, forPlanReplayerReload)
+	d.normalize(sql, errors.RedactLogEnable, keepHint, true, forPlanReplayerReload, true)
 	result = d.buffer.String()
 	d.buffer.Reset()
 	return
 }
 
 func (d *sqlDigester) doNormalizeDigest(sql string) (normalized string, digest *Digest) {
-	d.normalize(sql, errors.RedactLogEnable, false, false, false)
+	d.normalize(sql, errors.RedactLogEnable, false, false, false, false)
 	normalized = d.buffer.String()
 	d.hasher.Write(d.buffer.Bytes())
 	d.buffer.Reset()
@@ -195,7 +195,7 @@ func (d *sqlDigester) doNormalizeDigest(sql string) (normalized string, digest *
 }
 
 func (d *sqlDigester) doNormalizeDigestForBinding(sql string) (normalized string, digest *Digest) {
-	d.normalize(sql, errors.RedactLogEnable, false, true, false)
+	d.normalize(sql, errors.RedactLogEnable, false, true, false, true)
 	normalized = d.buffer.String()
 	d.hasher.Write(d.buffer.Bytes())
 	d.buffer.Reset()
@@ -213,7 +213,7 @@ const (
 	genericSymbolList = -2
 )
 
-func (d *sqlDigester) normalize(sql string, redact string, keepHint bool, forBinding bool, forPlanReplayerReload bool) {
+func (d *sqlDigester) normalize(sql string, redact string, keepHint bool, forBinding bool, forPlanReplayerReload bool, removeRedundantExprParen bool) {
 	d.lexer.reset(sql)
 	d.lexer.setKeepHint(keepHint)
 	for {
@@ -258,6 +258,9 @@ func (d *sqlDigester) normalize(sql string, redact string, keepHint bool, forBin
 		d.tokens.pushBack(currTok)
 	}
 	d.lexer.reset("")
+	if removeRedundantExprParen {
+		d.reduceRedundantParenthesesForBinding()
+	}
 	for i, token := range d.tokens {
 		if i > 0 {
 			d.buffer.WriteRune(' ')
@@ -503,6 +506,176 @@ func (d *sqlDigester) reduceInRowListWithSingleLiteral(currTok *token) {
 		d.tokens.pushBack(token{genericSymbolList, "..."})
 		return
 	}
+}
+
+func (d *sqlDigester) reduceRedundantParenthesesForBinding() {
+	if !d.hasParentheses() {
+		return
+	}
+	for {
+		changed := false
+		for i := 0; i < len(d.tokens); i++ {
+			if d.tokens[i].lit != "(" {
+				continue
+			}
+			if d.isParenKeptByKeyword(i) {
+				continue
+			}
+			end := d.findMatchingRightParen(i)
+			if end < 0 {
+				continue
+			}
+			if d.canRemoveBindingParentheses(i, end) {
+				d.removeTokenPair(i, end)
+				changed = true
+				break
+			}
+		}
+		if !changed {
+			return
+		}
+	}
+}
+
+func (d *sqlDigester) hasParentheses() bool {
+	for _, tok := range d.tokens {
+		if tok.lit == "(" || tok.lit == ")" {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *sqlDigester) findMatchingRightParen(left int) int {
+	depth := 0
+	for i := left; i < len(d.tokens); i++ {
+		switch d.tokens[i].lit {
+		case "(":
+			depth++
+		case ")":
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func (d *sqlDigester) canRemoveBindingParentheses(left, right int) bool {
+	if right-left <= 1 {
+		return false
+	}
+	if d.isSimpleBindingExpr(left, right) {
+		return true
+	}
+	return d.isWholeBooleanClause(left, right)
+}
+
+func (d *sqlDigester) isSimpleBindingExpr(left, right int) bool {
+	depth := 0
+	hasCompare := false
+	for i := left + 1; i < right; i++ {
+		tok := d.tokens[i]
+		switch tok.lit {
+		case "(":
+			depth++
+		case ")":
+			depth--
+		default:
+			if depth == 0 && tok.lit == "," {
+				return false
+			}
+			if depth == 0 && d.isLogicalOp(tok) {
+				return false
+			}
+			if depth == 0 && d.isComparisonOp(tok) {
+				hasCompare = true
+			}
+		}
+	}
+	return hasCompare
+}
+
+func (d *sqlDigester) isWholeBooleanClause(left, right int) bool {
+	if !d.hasTopLevelLogicalOp(left, right) {
+		return false
+	}
+	return d.isBooleanClauseStart(left) && d.isBooleanClauseEnd(right)
+}
+
+func (d *sqlDigester) hasTopLevelLogicalOp(left, right int) bool {
+	depth := 0
+	for i := left + 1; i < right; i++ {
+		tok := d.tokens[i]
+		switch tok.lit {
+		case "(":
+			depth++
+		case ")":
+			depth--
+		default:
+			if depth == 0 && d.isLogicalOp(tok) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (d *sqlDigester) isBooleanClauseStart(left int) bool {
+	if left == 0 {
+		return true
+	}
+	prev := d.tokens[left-1].lit
+	return prev == "where" || prev == "having" || prev == "on" || prev == "("
+}
+
+func (d *sqlDigester) isBooleanClauseEnd(right int) bool {
+	if right == len(d.tokens)-1 {
+		return true
+	}
+	next := d.tokens[right+1].lit
+	switch next {
+	case "order", "group", "limit", "offset", "having", "window", "union", "except", "intersect", ")":
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *sqlDigester) isParenKeptByKeyword(left int) bool {
+	if left == 0 {
+		return false
+	}
+	prev := d.tokens[left-1]
+	if d.isLogicalOp(prev) {
+		return false
+	}
+	switch prev.lit {
+	case "where", "having", "on", "and", "or", "xor", "(":
+		return false
+	default:
+		return true
+	}
+}
+
+func (*sqlDigester) isLogicalOp(tok token) bool {
+	return tok.lit == "and" || tok.lit == "&&" || tok.lit == "or" || tok.lit == "||" || tok.lit == "xor"
+}
+
+func (*sqlDigester) isComparisonOp(tok token) bool {
+	switch tok.lit {
+	case "=", "<", ">", "<=", ">=", "!=", "<>", "<=>", "is", "like", "regexp":
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *sqlDigester) removeTokenPair(left, right int) {
+	copy(d.tokens[left:], d.tokens[left+1:right])
+	copy(d.tokens[right-1:], d.tokens[right+1:])
+	d.tokens = d.tokens[:len(d.tokens)-2]
 }
 
 func (d *sqlDigester) isPrefixByUnary(currTok int) (isUnary bool) {

--- a/pkg/parser/digester_test.go
+++ b/pkg/parser/digester_test.go
@@ -93,6 +93,10 @@ func TestNormalize(t *testing.T) {
 		{"select * from t where (a, b) in ((1, 1), (2, 2))", "select * from `t` where ( `a` , `b` ) in ( ( ... ) )"},
 		{"select * from t where a in(1, 2)", "select * from `t` where `a` in ( ... )"},
 		{"select * from t where a in(1, 2, 3)", "select * from `t` where `a` in ( ... )"},
+		{"select * from t where (a = 1) and b = 1", "select * from `t` where `a` = ? and `b` = ?"},
+		{"select * from t where a = 1 and (b = 1 or b = 2)", "select * from `t` where `a` = ? and ( `b` = ? or `b` = ? )"},
+		{"select * from t where not (a = 1)", "select * from `t` where not ( `a` = ? )"},
+		{"select pid from t where ((id = 1) and ((ptype = 1) or (ptype = 2))) order by pid limit 10", "select `pid` from `t` where `id` = ? and ( `ptype` = ? or `ptype` = ? ) order by `pid` limit ?"},
 	}
 	for _, test := range tests_for_binding_specific_rules {
 		normalized := parser.NormalizeForBinding(test.input, false)
@@ -102,6 +106,20 @@ func TestNormalize(t *testing.T) {
 		normalized2, digest2 := parser.NormalizeDigestForBinding(test.input)
 		require.Equal(t, normalized, normalized2)
 		require.Equalf(t, digest.String(), digest2.String(), "%+v", test)
+	}
+
+	bindingDigestCases := []string{
+		"select pid from t where id=1 and (ptype=1 or ptype=2) order by pid limit 10",
+		"select pid from t where id=1 and ((ptype=1) or ptype=2) order by pid limit 10",
+		"select pid from t where id=1 and (ptype=1 or (ptype=2)) order by pid limit 10",
+		"select pid from t where (id=1 and ((ptype=1) or (ptype=2))) order by pid limit 10",
+		"select pid from t where ((id=1) and (ptype=1 or (ptype=2))) order by pid limit 10",
+	}
+	normalized, digest := parser.NormalizeDigestForBinding(bindingDigestCases[0])
+	for _, input := range bindingDigestCases[1:] {
+		normalized2, digest2 := parser.NormalizeDigestForBinding(input)
+		require.Equalf(t, normalized, normalized2, "sql: %s", input)
+		require.Equalf(t, digest.String(), digest2.String(), "sql: %s", input)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67363

Problem Summary:

SQL binding matching is currently sensitive to redundant parentheses in predicates. For example, a binding created for `where a = 1 and b = 1` does not match `where (a = 1) and b = 1`, even though the predicates are equivalent for binding matching.

### What changed and how does it work?

This PR adds a narrow binding-only normalization step after the existing SQL digester token normalization.

The new step removes redundant parentheses only in simple predicate forms that are safe for binding matching, such as:

- parenthesized simple comparison predicates, for example `(a = 1)`
- an outer pair around a whole boolean clause in `WHERE`, `ON`, or `HAVING`

It intentionally keeps semantically significant parentheses, such as `a and (b or c)`, and avoids changing parser restore behavior or stored binding upgrade logic.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
SQL binding matching now ignores redundant parentheses in simple predicates.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL binding matching to correctly handle queries with redundant parentheses in WHERE conditions and boolean expressions.
  * Bindings now consistently apply to semantically equivalent queries regardless of how parentheses are used or formatted.

* **Tests**
  * Added comprehensive test coverage for binding normalization with extra parenthesization in complex conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68356)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->