### PR TITLE
[WIP] parser, bindinfo: normalize binding redundant parentheses

### DIFF
--- a/pkg/bindinfo/binding_operator_test.go
+++ b/pkg/bindinfo/binding_operator_test.go
@@ -828,14 +828,45 @@ func TestNormalizeStmtForBinding(t *testing.T) {
 		{"select 1 from b where (x,y) in ((1, 3), ('3', 1), (2, 3))", "select ? from `b` where row ( `x` , `y` ) in ( ... )", "ab6c607d118c24030807f8d1c7c846ec23e3b752fd88ed763bb8e26fbfa56a83"},
 		{"select 1 from b where (x,y) in ((1, 3), ('3', 1), (2, 3),('x', 'y'))", "select ? from `b` where row ( `x` , `y` ) in ( ... )", "ab6c607d118c24030807f8d1c7c846ec23e3b752fd88ed763bb8e26fbfa56a83"},
 		{"select 1 from b where (x,y) in ((1, 3), ('3', 1), (2, 3),('x', 'y'),('x', 'y'))", "select ? from `b` where row ( `x` , `y` ) in ( ... )", "ab6c607d118c24030807f8d1c7c846ec23e3b752fd88ed763bb8e26fbfa56a83"},
-		{"select 1 from b where (x) in ((1), ('3'), (2),('x'),('x'))", "select ? from `b` where ( `x` ) in ( ( ... ) )", "03e6e1eb3d76b69363922ff269284b359ca73351001ba0e82d3221c740a6a14c"},
-		{"select 1 from b where (x) in ((1), ('3'), (2),('x'))", "select ? from `b` where ( `x` ) in ( ( ... ) )", "03e6e1eb3d76b69363922ff269284b359ca73351001ba0e82d3221c740a6a14c"},
+		{"select 1 from b where (x) in ((1), ('3'), (2),('x'),('x'))", "select ? from `b` where `x` in ( ... )", "695a1f42dbae3cae4a5d475d7a9d67955aed6d9790c1ffa20106d80f79b33dc0"},
+		{"select 1 from b where (x) in ((1), ('3'), (2),('x'))", "select ? from `b` where `x` in ( ... )", "695a1f42dbae3cae4a5d475d7a9d67955aed6d9790c1ffa20106d80f79b33dc0"},
 	}
 	for _, test := range tests {
 		stmt, _, _ := utilNormalizeWithDefaultDB(t, test.sql)
 		n, digest := bindinfo.NormalizeStmtForBinding(stmt, "", true)
 		require.Equalf(t, test.normalized, n, "sql: %s", test.sql)
 		require.Equalf(t, test.digest, digest, "sql: %s", test.sql)
+	}
+
+	parenthesesTests := []struct {
+		sql        string
+		normalized string
+	}{
+		{
+			"select 1 from b where abs((x + 1)) = 2",
+			"select ? from `b` where `abs` ( `x` + ? ) = ?",
+		},
+		{
+			"select 1 from b where (x + 1) * y = 2",
+			"select ? from `b` where ( `x` + ? ) * `y` = ?",
+		},
+		{
+			"select 1 from b where x = 1 and (y = 1 or y = 2)",
+			"select ? from `b` where `x` = ? and ( `y` = ? or `y` = ? )",
+		},
+		{
+			"select 1 from b where not (x = 1)",
+			"select ? from `b` where not ( `x` = ? )",
+		},
+		{
+			"select 1 from b where (not x) = 1",
+			"select ? from `b` where ( not `x` ) = ?",
+		},
+	}
+	for _, test := range parenthesesTests {
+		stmt, _, _ := utilNormalizeWithDefaultDB(t, test.sql)
+		n, _ := bindinfo.NormalizeStmtForBinding(stmt, "", true)
+		require.Equalf(t, test.normalized, n, "sql: %s", test.sql)
 	}
 }
 

--- a/pkg/bindinfo/binding_operator_test.go
+++ b/pkg/bindinfo/binding_operator_test.go
@@ -862,6 +862,22 @@ func TestNormalizeStmtForBinding(t *testing.T) {
 			"select 1 from b where (not x) = 1",
 			"select ? from `b` where ( not `x` ) = ?",
 		},
+		{
+			"select 1 from b where (x + y) ^ z = 1",
+			"select ? from `b` where ( `x` + `y` ) ^ `z` = ?",
+		},
+		{
+			"select 1 from b where (x * y) ^ z = 1",
+			"select ? from `b` where ( `x` * `y` ) ^ `z` = ?",
+		},
+		{
+			"select 1 from b where x + (y ^ z) = 1",
+			"select ? from `b` where `x` + `y` ^ `z` = ?",
+		},
+		{
+			"select 1 from b where -(x + (y + z)) = 1",
+			"select ? from `b` where - ( `x` + `y` + `z` ) = ?",
+		},
 	}
 	for _, test := range parenthesesTests {
 		stmt, _, _ := utilNormalizeWithDefaultDB(t, test.sql)

--- a/pkg/bindinfo/tests/bind_test.go
+++ b/pkg/bindinfo/tests/bind_test.go
@@ -479,7 +479,7 @@ func TestSimplifiedCreateBinding(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec(`use test`)
-	tk.MustExec(`create table t (a int, b int, key(a))`)
+	tk.MustExec(`create table t (a int, b int, key(a), key(b))`)
 
 	check := func(scope, sql, binding string) {
 		r := tk.MustQuery(fmt.Sprintf("show %s bindings", scope)).Rows()
@@ -505,6 +505,12 @@ func TestSimplifiedCreateBinding(t *testing.T) {
 	tk.MustQuery(`select * from t where (a = 1) and b = 1`).Check(testkit.Rows())
 	tk.MustQuery(`select @@last_plan_from_binding`).Check(testkit.Rows("1"))
 	tk.MustExec(`drop global binding for select * from t where a = 1 and b = 1`)
+
+	tk.MustExec(`create binding for select * from t where abs((a + 1)) = 2 and (b = 1) using select /*+ use_index(t, b) */ * from t where abs((a + 1)) = 2 and (b = 1)`)
+	check("", "select * from `test` . `t` where `abs` ( `a` + ? ) = ? and `b` = ?", "SELECT /*+ use_index(`t` `b`)*/ * FROM `test`.`t` WHERE abs(`a` + 1) = 2 AND `b` = 1")
+	tk.MustQuery(`select * from t where abs(a + 1) = 2 and b = 1`)
+	tk.MustQuery(`select @@last_plan_from_binding`).Check(testkit.Rows("1"))
+	tk.MustExec(`drop binding for select * from t where abs(a + 1) = 2 and b = 1`)
 }
 
 func TestDropBindBySQLDigest(t *testing.T) {

--- a/pkg/bindinfo/tests/bind_test.go
+++ b/pkg/bindinfo/tests/bind_test.go
@@ -500,6 +500,11 @@ func TestSimplifiedCreateBinding(t *testing.T) {
 	tk.MustExec(`create global binding using select /*+ use_index(t, a) */ * from t where a in (1,2,3)`)
 	check("global", "select * from `test` . `t` where `a` in ( ... )", "SELECT /*+ use_index(`t` `a`)*/ * FROM `test`.`t` WHERE `a` IN (1,2,3)")
 	tk.MustExec(`drop global binding for select * from t where a in (1,2,3)`)
+
+	tk.MustExec(`create global binding using select /*+ use_index(t, a) */ * from t where a = 1 and b = 1`)
+	tk.MustQuery(`select * from t where (a = 1) and b = 1`).Check(testkit.Rows())
+	tk.MustQuery(`select @@last_plan_from_binding`).Check(testkit.Rows("1"))
+	tk.MustExec(`drop global binding for select * from t where a = 1 and b = 1`)
 }
 
 func TestDropBindBySQLDigest(t *testing.T) {

--- a/pkg/parser/ast/expressions.go
+++ b/pkg/parser/ast/expressions.go
@@ -1025,9 +1025,13 @@ func (n *ParenthesesExpr) Restore(ctx *format.RestoreCtx) error {
 		return nil
 	}
 	ctx.WritePlain("(")
+	inUnaryOperation, parentOp, parentSide := ctx.InUnaryOperation, ctx.ParentBinaryOp, ctx.ParentBinarySide
+	ctx.InUnaryOperation, ctx.ParentBinaryOp, ctx.ParentBinarySide = false, 0, 0
 	if err := n.Expr.Restore(ctx); err != nil {
+		ctx.InUnaryOperation, ctx.ParentBinaryOp, ctx.ParentBinarySide = inUnaryOperation, parentOp, parentSide
 		return errors.Annotate(err, "An error occurred when restore ParenthesesExpr.Expr")
 	}
+	ctx.InUnaryOperation, ctx.ParentBinaryOp, ctx.ParentBinarySide = inUnaryOperation, parentOp, parentSide
 	ctx.WritePlain(")")
 	return nil
 }
@@ -1107,15 +1111,15 @@ func restoreBinaryPrecedence(op opcode.Op) int {
 		return 4
 	case opcode.Or:
 		return 5
-	case opcode.Xor:
-		return 6
 	case opcode.And:
-		return 7
+		return 6
 	case opcode.LeftShift, opcode.RightShift:
-		return 8
+		return 7
 	case opcode.Plus, opcode.Minus:
-		return 9
+		return 8
 	case opcode.Mul, opcode.Div, opcode.IntDiv, opcode.Mod:
+		return 9
+	case opcode.Xor:
 		return 10
 	default:
 		return 0

--- a/pkg/parser/ast/expressions.go
+++ b/pkg/parser/ast/expressions.go
@@ -183,15 +183,22 @@ func (n *BinaryOperationExpr) Restore(ctx *format.RestoreCtx) error {
 		ctx.WritePlain("(")
 		ctx.Flags |= format.RestoreBracketAroundBetweenExpr
 	}
+	parentOp, parentSide := ctx.ParentBinaryOp, ctx.ParentBinarySide
+	ctx.ParentBinaryOp, ctx.ParentBinarySide = int(n.Op), binaryOpLeftSide
 	if err := n.L.Restore(ctx); err != nil {
+		ctx.ParentBinaryOp, ctx.ParentBinarySide = parentOp, parentSide
 		return errors.Annotate(err, "An error occurred when restore BinaryOperationExpr.L")
 	}
+	ctx.ParentBinaryOp, ctx.ParentBinarySide = parentOp, parentSide
 	if err := restoreBinaryOpWithSpacesAround(ctx, n.Op); err != nil {
 		return errors.Annotate(err, "An error occurred when restore BinaryOperationExpr.Op")
 	}
+	ctx.ParentBinaryOp, ctx.ParentBinarySide = int(n.Op), binaryOpRightSide
 	if err := n.R.Restore(ctx); err != nil {
+		ctx.ParentBinaryOp, ctx.ParentBinarySide = parentOp, parentSide
 		return errors.Annotate(err, "An error occurred when restore BinaryOperationExpr.R")
 	}
+	ctx.ParentBinaryOp, ctx.ParentBinarySide = parentOp, parentSide
 	if ctx.Flags.HasRestoreBracketAroundBinaryOperation() {
 		ctx.WritePlain(")")
 		ctx.Flags = originalFlags
@@ -1011,6 +1018,12 @@ type ParenthesesExpr struct {
 
 // Restore implements Node interface.
 func (n *ParenthesesExpr) Restore(ctx *format.RestoreCtx) error {
+	if ctx.Flags.HasRestoreSkipRedundantParentheses() && canRestoreWithoutParentheses(ctx, n.Expr) {
+		if err := n.Expr.Restore(ctx); err != nil {
+			return errors.Annotate(err, "An error occurred when restore ParenthesesExpr.Expr")
+		}
+		return nil
+	}
 	ctx.WritePlain("(")
 	if err := n.Expr.Restore(ctx); err != nil {
 		return errors.Annotate(err, "An error occurred when restore ParenthesesExpr.Expr")
@@ -1041,6 +1054,84 @@ func (n *ParenthesesExpr) Accept(v Visitor) (Node, bool) {
 		n.Expr = node.(ExprNode)
 	}
 	return v.Leave(n)
+}
+
+const (
+	binaryOpLeftSide = iota + 1
+	binaryOpRightSide
+)
+
+func canRestoreWithoutParentheses(ctx *format.RestoreCtx, expr ExprNode) bool {
+	if ctx.InUnaryOperation {
+		return false
+	}
+	child, ok := expr.(*BinaryOperationExpr)
+	if !ok {
+		if _, ok := expr.(*UnaryOperationExpr); ok && ctx.ParentBinaryOp != 0 {
+			return false
+		}
+		return true
+	}
+	parentOp := opcode.Op(ctx.ParentBinaryOp)
+	if parentOp == 0 {
+		return true
+	}
+	return canRestoreBinaryChildWithoutParentheses(parentOp, child.Op, ctx.ParentBinarySide)
+}
+
+func canRestoreBinaryChildWithoutParentheses(parentOp, childOp opcode.Op, side int) bool {
+	parentPrecedence := restoreBinaryPrecedence(parentOp)
+	childPrecedence := restoreBinaryPrecedence(childOp)
+	if parentPrecedence == 0 || childPrecedence == 0 {
+		return false
+	}
+	if childPrecedence > parentPrecedence {
+		return true
+	}
+	if childPrecedence < parentPrecedence {
+		return false
+	}
+	return side == binaryOpLeftSide || isAssociativeRestoreOp(parentOp, childOp)
+}
+
+func restoreBinaryPrecedence(op opcode.Op) int {
+	switch op {
+	case opcode.LogicOr:
+		return 1
+	case opcode.LogicXor:
+		return 2
+	case opcode.LogicAnd:
+		return 3
+	case opcode.EQ, opcode.NE, opcode.NullEQ, opcode.LT, opcode.LE, opcode.GT, opcode.GE,
+		opcode.In, opcode.Like, opcode.Regexp, opcode.IsNull, opcode.IsTruth, opcode.IsFalsity:
+		return 4
+	case opcode.Or:
+		return 5
+	case opcode.Xor:
+		return 6
+	case opcode.And:
+		return 7
+	case opcode.LeftShift, opcode.RightShift:
+		return 8
+	case opcode.Plus, opcode.Minus:
+		return 9
+	case opcode.Mul, opcode.Div, opcode.IntDiv, opcode.Mod:
+		return 10
+	default:
+		return 0
+	}
+}
+
+func isAssociativeRestoreOp(parentOp, childOp opcode.Op) bool {
+	if parentOp != childOp {
+		return false
+	}
+	switch parentOp {
+	case opcode.LogicAnd, opcode.LogicOr, opcode.Plus, opcode.Mul, opcode.And, opcode.Or, opcode.Xor:
+		return true
+	default:
+		return false
+	}
 }
 
 // PositionExpr is the expression for order by and group by position.
@@ -1208,9 +1299,13 @@ func (n *UnaryOperationExpr) Restore(ctx *format.RestoreCtx) error {
 	if err := n.Op.Restore(ctx); err != nil {
 		return errors.Trace(err)
 	}
+	inUnaryOperation := ctx.InUnaryOperation
+	ctx.InUnaryOperation = true
 	if err := n.V.Restore(ctx); err != nil {
+		ctx.InUnaryOperation = inUnaryOperation
 		return errors.Trace(err)
 	}
+	ctx.InUnaryOperation = inUnaryOperation
 	return nil
 }
 

--- a/pkg/parser/digester.go
+++ b/pkg/parser/digester.go
@@ -162,7 +162,7 @@ func (d *sqlDigester) doDigestNormalized(normalized string) (digest *Digest) {
 }
 
 func (d *sqlDigester) doDigest(sql string) (digest *Digest) {
-	d.normalize(sql, errors.RedactLogEnable, false, false, false)
+	d.normalize(sql, errors.RedactLogEnable, false, false, false, false)
 	d.hasher.Write(d.buffer.Bytes())
 	d.buffer.Reset()
 	digest = NewDigest(d.hasher.Sum(nil))
@@ -171,21 +171,21 @@ func (d *sqlDigester) doDigest(sql string) (digest *Digest) {
 }
 
 func (d *sqlDigester) doNormalize(sql string, redact string, keepHint bool) (result string) {
-	d.normalize(sql, redact, keepHint, false, false)
+	d.normalize(sql, redact, keepHint, false, false, false)
 	result = d.buffer.String()
 	d.buffer.Reset()
 	return
 }
 
 func (d *sqlDigester) doNormalizeForBinding(sql string, keepHint bool, forPlanReplayerReload bool) (result string) {
-	d.normalize(sql, errors.RedactLogEnable, keepHint, true, forPlanReplayerReload)
+	d.normalize(sql, errors.RedactLogEnable, keepHint, true, forPlanReplayerReload, true)
 	result = d.buffer.String()
 	d.buffer.Reset()
 	return
 }
 
 func (d *sqlDigester) doNormalizeDigest(sql string) (normalized string, digest *Digest) {
-	d.normalize(sql, errors.RedactLogEnable, false, false, false)
+	d.normalize(sql, errors.RedactLogEnable, false, false, false, false)
 	normalized = d.buffer.String()
 	d.hasher.Write(d.buffer.Bytes())
 	d.buffer.Reset()
@@ -195,7 +195,7 @@ func (d *sqlDigester) doNormalizeDigest(sql string) (normalized string, digest *
 }
 
 func (d *sqlDigester) doNormalizeDigestForBinding(sql string) (normalized string, digest *Digest) {
-	d.normalize(sql, errors.RedactLogEnable, false, true, false)
+	d.normalize(sql, errors.RedactLogEnable, false, true, false, true)
 	normalized = d.buffer.String()
 	d.hasher.Write(d.buffer.Bytes())
 	d.buffer.Reset()
@@ -213,7 +213,7 @@ const (
 	genericSymbolList = -2
 )
 
-func (d *sqlDigester) normalize(sql string, redact string, keepHint bool, forBinding bool, forPlanReplayerReload bool) {
+func (d *sqlDigester) normalize(sql string, redact string, keepHint bool, forBinding bool, forPlanReplayerReload bool, removeRedundantExprParen bool) {
 	d.lexer.reset(sql)
 	d.lexer.setKeepHint(keepHint)
 	for {
@@ -258,6 +258,9 @@ func (d *sqlDigester) normalize(sql string, redact string, keepHint bool, forBin
 		d.tokens.pushBack(currTok)
 	}
 	d.lexer.reset("")
+	if removeRedundantExprParen {
+		d.reduceRedundantParenthesesForBinding()
+	}
 	for i, token := range d.tokens {
 		if i > 0 {
 			d.buffer.WriteRune(' ')
@@ -503,6 +506,176 @@ func (d *sqlDigester) reduceInRowListWithSingleLiteral(currTok *token) {
 		d.tokens.pushBack(token{genericSymbolList, "..."})
 		return
 	}
+}
+
+func (d *sqlDigester) reduceRedundantParenthesesForBinding() {
+	if !d.hasParentheses() {
+		return
+	}
+	for {
+		changed := false
+		for i := 0; i < len(d.tokens); i++ {
+			if d.tokens[i].lit != "(" {
+				continue
+			}
+			if d.isParenKeptByKeyword(i) {
+				continue
+			}
+			end := d.findMatchingRightParen(i)
+			if end < 0 {
+				continue
+			}
+			if d.canRemoveBindingParentheses(i, end) {
+				d.removeTokenPair(i, end)
+				changed = true
+				break
+			}
+		}
+		if !changed {
+			return
+		}
+	}
+}
+
+func (d *sqlDigester) hasParentheses() bool {
+	for _, tok := range d.tokens {
+		if tok.lit == "(" || tok.lit == ")" {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *sqlDigester) findMatchingRightParen(left int) int {
+	depth := 0
+	for i := left; i < len(d.tokens); i++ {
+		switch d.tokens[i].lit {
+		case "(":
+			depth++
+		case ")":
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func (d *sqlDigester) canRemoveBindingParentheses(left, right int) bool {
+	if right-left <= 1 {
+		return false
+	}
+	if d.isSimpleBindingExpr(left, right) {
+		return true
+	}
+	return d.isWholeBooleanClause(left, right)
+}
+
+func (d *sqlDigester) isSimpleBindingExpr(left, right int) bool {
+	depth := 0
+	hasCompare := false
+	for i := left + 1; i < right; i++ {
+		tok := d.tokens[i]
+		switch tok.lit {
+		case "(":
+			depth++
+		case ")":
+			depth--
+		default:
+			if depth == 0 && tok.lit == "," {
+				return false
+			}
+			if depth == 0 && d.isLogicalOp(tok) {
+				return false
+			}
+			if depth == 0 && d.isComparisonOp(tok) {
+				hasCompare = true
+			}
+		}
+	}
+	return hasCompare
+}
+
+func (d *sqlDigester) isWholeBooleanClause(left, right int) bool {
+	if !d.hasTopLevelLogicalOp(left, right) {
+		return false
+	}
+	return d.isBooleanClauseStart(left) && d.isBooleanClauseEnd(right)
+}
+
+func (d *sqlDigester) hasTopLevelLogicalOp(left, right int) bool {
+	depth := 0
+	for i := left + 1; i < right; i++ {
+		tok := d.tokens[i]
+		switch tok.lit {
+		case "(":
+			depth++
+		case ")":
+			depth--
+		default:
+			if depth == 0 && d.isLogicalOp(tok) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (d *sqlDigester) isBooleanClauseStart(left int) bool {
+	if left == 0 {
+		return true
+	}
+	prev := d.tokens[left-1].lit
+	return prev == "where" || prev == "having" || prev == "on" || prev == "("
+}
+
+func (d *sqlDigester) isBooleanClauseEnd(right int) bool {
+	if right == len(d.tokens)-1 {
+		return true
+	}
+	next := d.tokens[right+1].lit
+	switch next {
+	case "order", "group", "limit", "offset", "having", "window", "union", "except", "intersect", ")":
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *sqlDigester) isParenKeptByKeyword(left int) bool {
+	if left == 0 {
+		return false
+	}
+	prev := d.tokens[left-1]
+	if d.isLogicalOp(prev) {
+		return false
+	}
+	switch prev.lit {
+	case "where", "having", "on", "and", "or", "xor", "(":
+		return false
+	default:
+		return true
+	}
+}
+
+func (*sqlDigester) isLogicalOp(tok token) bool {
+	return tok.lit == "and" || tok.lit == "&&" || tok.lit == "or" || tok.lit == "||" || tok.lit == "xor"
+}
+
+func (*sqlDigester) isComparisonOp(tok token) bool {
+	switch tok.lit {
+	case "=", "<", ">", "<=", ">=", "!=", "<>", "<=>", "is", "like", "regexp":
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *sqlDigester) removeTokenPair(left, right int) {
+	copy(d.tokens[left:], d.tokens[left+1:right])
+	copy(d.tokens[right-1:], d.tokens[right+1:])
+	d.tokens = d.tokens[:len(d.tokens)-2]
 }
 
 func (d *sqlDigester) isPrefixByUnary(currTok int) (isUnary bool) {

--- a/pkg/parser/digester.go
+++ b/pkg/parser/digester.go
@@ -673,6 +673,8 @@ func (*sqlDigester) isComparisonOp(tok token) bool {
 }
 
 func (d *sqlDigester) removeTokenPair(left, right int) {
+	// Drop both parentheses from d.tokens by shifting the enclosed tokens over
+	// the left paren, then shifting the trailing tokens over the right paren.
 	copy(d.tokens[left:], d.tokens[left+1:right])
 	copy(d.tokens[right-1:], d.tokens[right+1:])
 	d.tokens = d.tokens[:len(d.tokens)-2]

--- a/pkg/parser/digester_test.go
+++ b/pkg/parser/digester_test.go
@@ -93,6 +93,10 @@ func TestNormalize(t *testing.T) {
 		{"select * from t where (a, b) in ((1, 1), (2, 2))", "select * from `t` where ( `a` , `b` ) in ( ( ... ) )"},
 		{"select * from t where a in(1, 2)", "select * from `t` where `a` in ( ... )"},
 		{"select * from t where a in(1, 2, 3)", "select * from `t` where `a` in ( ... )"},
+		{"select * from t where (a = 1) and b = 1", "select * from `t` where `a` = ? and `b` = ?"},
+		{"select * from t where a = 1 and (b = 1 or b = 2)", "select * from `t` where `a` = ? and ( `b` = ? or `b` = ? )"},
+		{"select * from t where not (a = 1)", "select * from `t` where not ( `a` = ? )"},
+		{"select pid from t where ((id = 1) and ((ptype = 1) or (ptype = 2))) order by pid limit 10", "select `pid` from `t` where `id` = ? and ( `ptype` = ? or `ptype` = ? ) order by `pid` limit ?"},
 	}
 	for _, test := range tests_for_binding_specific_rules {
 		normalized := parser.NormalizeForBinding(test.input, false)
@@ -102,6 +106,20 @@ func TestNormalize(t *testing.T) {
 		normalized2, digest2 := parser.NormalizeDigestForBinding(test.input)
 		require.Equal(t, normalized, normalized2)
 		require.Equalf(t, digest.String(), digest2.String(), "%+v", test)
+	}
+
+	bindingDigestCases := []string{
+		"select pid from t where id=1 and (ptype=1 or ptype=2) order by pid limit 10",
+		"select pid from t where id=1 and ((ptype=1) or ptype=2) order by pid limit 10",
+		"select pid from t where id=1 and (ptype=1 or (ptype=2)) order by pid limit 10",
+		"select pid from t where (id=1 and ((ptype=1) or (ptype=2))) order by pid limit 10",
+		"select pid from t where ((id=1) and (ptype=1 or (ptype=2))) order by pid limit 10",
+	}
+	normalized, digest := parser.NormalizeDigestForBinding(bindingDigestCases[0])
+	for _, input := range bindingDigestCases[1:] {
+		normalized2, digest2 := parser.NormalizeDigestForBinding(input)
+		require.Equalf(t, normalized, normalized2, "sql: %s", input)
+		require.Equalf(t, digest.String(), digest2.String(), "sql: %s", input)
 	}
 }
 

--- a/pkg/parser/format/format.go
+++ b/pkg/parser/format/format.go
@@ -242,6 +242,7 @@ const (
 	RestoreForNonPrepPlanCache
 
 	RestoreBracketAroundBetweenExpr
+	RestoreSkipRedundantParentheses
 )
 
 const (
@@ -332,6 +333,12 @@ func (rf RestoreFlags) HasRestoreBracketAroundBetweenExpr() bool {
 	return rf.has(RestoreBracketAroundBetweenExpr)
 }
 
+// HasRestoreSkipRedundantParentheses returns a boolean indicating whether
+// `rf` has `RestoreSkipRedundantParentheses` flag.
+func (rf RestoreFlags) HasRestoreSkipRedundantParentheses() bool {
+	return rf.has(RestoreSkipRedundantParentheses)
+}
+
 // HasStringWithoutCharset returns a boolean indicating whether `rf` has `RestoreStringWithoutCharset` flag.
 func (rf RestoreFlags) HasStringWithoutCharset() bool {
 	return rf.has(RestoreStringWithoutCharset)
@@ -366,9 +373,12 @@ type RestoreWriter interface {
 
 // RestoreCtx is `Restore` context to hold flags and writer.
 type RestoreCtx struct {
-	Flags     RestoreFlags
-	In        RestoreWriter
-	DefaultDB string
+	Flags            RestoreFlags
+	In               RestoreWriter
+	DefaultDB        string
+	ParentBinaryOp   int
+	ParentBinarySide int
+	InUnaryOperation bool
 	CTERestorer
 }
 

--- a/pkg/util/parser/ast.go
+++ b/pkg/util/parser/ast.go
@@ -124,6 +124,7 @@ func SimpleCases(node ast.StmtNode, defaultDB, origin string) (s string, ok bool
 // 3. RestoreStringWithoutCharset specifies to not print charset before string;
 // 4. RestoreNameBackQuotes specifies to use back quotes to surround the name;
 const defaultRestoreFlag = format.RestoreStringSingleQuotes | format.RestoreSpacesAroundBinaryOperation | format.RestoreStringWithoutCharset | format.RestoreNameBackQuotes
+const bindingRestoreFlag = defaultRestoreFlag | format.RestoreSkipRedundantParentheses
 
 // RestoreWithDefaultDB returns restore strings for StmtNode with defaultDB
 // This function is customized for SQL bind usage.
@@ -132,7 +133,7 @@ func RestoreWithDefaultDB(node ast.StmtNode, defaultDB, origin string) string {
 		return s
 	}
 	var sb strings.Builder
-	ctx := format.NewRestoreCtx(defaultRestoreFlag, &sb)
+	ctx := format.NewRestoreCtx(bindingRestoreFlag, &sb)
 	ctx.DefaultDB = defaultDB
 	if err := node.Restore(ctx); err != nil {
 		logutil.BgLogger().Debug("restore SQL failed", zap.String("category", "sql-bind"), zap.Error(err))
@@ -145,7 +146,7 @@ func RestoreWithDefaultDB(node ast.StmtNode, defaultDB, origin string) string {
 // This function is customized for universal SQL binding.
 func RestoreWithoutDB(node ast.StmtNode) string {
 	var sb strings.Builder
-	ctx := format.NewRestoreCtx(defaultRestoreFlag|format.RestoreWithoutSchemaName, &sb)
+	ctx := format.NewRestoreCtx(bindingRestoreFlag|format.RestoreWithoutSchemaName, &sb)
 	if err := node.Restore(ctx); err != nil {
 		logutil.BgLogger().Debug("restore SQL failed", zap.String("category", "sql-bind"), zap.Error(err))
 		return ""


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67363

Problem Summary:

Bindings can miss semantically identical SQL when redundant parentheses appear in predicates or scalar function arguments.

This PR supersedes #68356 and #68359 by stacking both approaches into one final version:

- token-level binding normalization for `parser.NormalizeForBinding` / `NormalizeDigestForBinding`;
- AST restore normalization for SQL binding creation and lookup paths.

### What changed and how does it work?

The final version keeps the scope binding-only:

- Add a binding-only token normalization pass to remove redundant expression parentheses from parser binding digests.
- Add `RestoreSkipRedundantParentheses` for AST restore.
- Track parent binary operator context while restoring expressions and remove parentheses only when precedence/associativity makes it safe.
- Use the AST restore flag only in binding restore helpers.
- Preserve necessary parentheses for cases such as arithmetic precedence, mixed boolean precedence, and unary expressions.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```sh
cd pkg/parser && go test -run TestNormalize -tags=intest,deadlock
./tools/check/failpoint-go-test.sh pkg/bindinfo -run TestNormalizeStmtForBinding
./tools/check/failpoint-go-test.sh pkg/bindinfo/tests -run TestSimplifiedCreateBinding
make lint
git diff --check master..HEAD
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve SQL binding matching by ignoring redundant expression parentheses during binding normalization.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalization for bindings now consistently removes redundant parentheses across many expression forms, producing stable normalized SQL and binding digests.

* **Tests**
  * Expanded test coverage for normalization and binding behavior, including redundant-parentheses cases, arithmetic/unary/function expressions, boolean logic, and end-to-end binding plan checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68361)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->