### PR TITLE
expression: fix group_concat collation inference for non-binary inputs

### DIFF
--- a/pkg/expression/aggregation/BUILD.bazel
+++ b/pkg/expression/aggregation/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//pkg/expression",
         "//pkg/kv",
         "//pkg/parser/ast",
+        "//pkg/parser/charset",
         "//pkg/parser/mysql",
         "//pkg/planner/cascades/base",
         "//pkg/planner/util",

--- a/pkg/expression/aggregation/base_func.go
+++ b/pkg/expression/aggregation/base_func.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
-	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/cascades/base"
 	"github.com/pingcap/tidb/pkg/types"
@@ -300,14 +299,12 @@ func (a *baseFuncDesc) typeInfer4Avg(ctx expression.EvalContext) {
 
 func (a *baseFuncDesc) typeInfer4GroupConcat(ctx expression.BuildContext) error {
 	a.RetTp = types.NewFieldType(mysql.TypeVarString)
-	retCharset, retCollate := charset.GetDefaultCharsetAndCollate()
 	ec, err := expression.CheckAndDeriveCollationFromExprs(ctx, ast.AggFuncGroupConcat, types.ETString, a.Args...)
 	if err != nil {
 		return err
 	}
-	retCharset, retCollate = ec.Charset, ec.Collation
-	a.RetTp.SetCharset(retCharset)
-	a.RetTp.SetCollate(retCollate)
+	a.RetTp.SetCharset(ec.Charset)
+	a.RetTp.SetCollate(ec.Collation)
 
 	a.RetTp.SetFlen(mysql.MaxBlobWidth)
 	a.RetTp.SetDecimal(0)

--- a/pkg/expression/aggregation/base_func.go
+++ b/pkg/expression/aggregation/base_func.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/cascades/base"
 	"github.com/pingcap/tidb/pkg/types"
@@ -302,6 +303,24 @@ func (a *baseFuncDesc) typeInfer4GroupConcat(ctx expression.BuildContext) error 
 	ec, err := expression.CheckAndDeriveCollationFromExprs(ctx, ast.AggFuncGroupConcat, types.ETString, a.Args...)
 	if err != nil {
 		return err
+	}
+	if ec.Charset == "" || ec.Collation == "" {
+		connCharset, connCollation := ctx.GetCharsetInfo()
+		if connCharset == "" || connCollation == "" {
+			connCharset, connCollation = charset.GetDefaultCharsetAndCollate()
+		}
+		if ec.Charset == "" {
+			ec.Charset = connCharset
+		}
+		if ec.Collation == "" {
+			if ec.Charset == connCharset {
+				ec.Collation = connCollation
+			} else if coll, err := charset.GetDefaultCollation(ec.Charset); err == nil {
+				ec.Collation = coll
+			} else {
+				ec.Collation = connCollation
+			}
+		}
 	}
 	a.RetTp.SetCharset(ec.Charset)
 	a.RetTp.SetCollate(ec.Collation)

--- a/pkg/expression/aggregation/base_func.go
+++ b/pkg/expression/aggregation/base_func.go
@@ -137,7 +137,7 @@ func (a *baseFuncDesc) TypeInfer(ctx expression.BuildContext) error {
 	case ast.AggFuncAvg:
 		a.typeInfer4Avg(ctx.GetEvalCtx())
 	case ast.AggFuncGroupConcat:
-		a.typeInfer4GroupConcat(ctx)
+		return a.typeInfer4GroupConcat(ctx)
 	case ast.AggFuncMax, ast.AggFuncMin, ast.AggFuncFirstRow,
 		ast.WindowFuncFirstValue, ast.WindowFuncLastValue, ast.WindowFuncNthValue:
 		a.typeInfer4MaxMin(ctx)
@@ -298,11 +298,16 @@ func (a *baseFuncDesc) typeInfer4Avg(ctx expression.EvalContext) {
 	types.SetBinChsClnFlag(a.RetTp)
 }
 
-func (a *baseFuncDesc) typeInfer4GroupConcat(ctx expression.BuildContext) {
+func (a *baseFuncDesc) typeInfer4GroupConcat(ctx expression.BuildContext) error {
 	a.RetTp = types.NewFieldType(mysql.TypeVarString)
-	charset, collate := charset.GetDefaultCharsetAndCollate()
-	a.RetTp.SetCharset(charset)
-	a.RetTp.SetCollate(collate)
+	retCharset, retCollate := charset.GetDefaultCharsetAndCollate()
+	ec, err := expression.CheckAndDeriveCollationFromExprs(ctx, ast.AggFuncGroupConcat, types.ETString, a.Args...)
+	if err != nil {
+		return err
+	}
+	retCharset, retCollate = ec.Charset, ec.Collation
+	a.RetTp.SetCharset(retCharset)
+	a.RetTp.SetCollate(retCollate)
 
 	a.RetTp.SetFlen(mysql.MaxBlobWidth)
 	a.RetTp.SetDecimal(0)
@@ -312,6 +317,7 @@ func (a *baseFuncDesc) typeInfer4GroupConcat(ctx expression.BuildContext) {
 			a.Args[i] = expression.BuildCastFunction(ctx, a.Args[i], tp)
 		}
 	}
+	return nil
 }
 
 func (a *baseFuncDesc) typeInfer4MaxMin(ctx expression.BuildContext) {

--- a/pkg/expression/aggregation/base_func_test.go
+++ b/pkg/expression/aggregation/base_func_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/mock"
@@ -72,6 +73,32 @@ func TestBaseFunc_InferAggRetType(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, dataType, desc.RetTp)
 		}
+	}
+
+	// GROUP_CONCAT should keep the non-binary collation from its non-binary inputs.
+	{
+		colType := types.NewFieldType(mysql.TypeVarString)
+		colType.SetCharset(charset.CharsetUTF8MB4)
+		colType.SetCollate("utf8mb4_0900_ai_ci")
+		colType.DelFlag(mysql.BinaryFlag)
+		col := &expression.Column{
+			UniqueID: 1,
+			RetType:  colType,
+		}
+
+		sepType := types.NewFieldType(mysql.TypeVarString)
+		sepType.SetCharset(charset.CharsetUTF8MB4)
+		sepType.SetCollate("utf8mb4_0900_ai_ci")
+		sepType.DelFlag(mysql.BinaryFlag)
+		sep := &expression.Constant{
+			Value:   types.NewStringDatum(" "),
+			RetType: sepType,
+		}
+
+		desc, err := newBaseFuncDesc(ctx, ast.AggFuncGroupConcat, []expression.Expression{col, sep})
+		require.NoError(t, err)
+		require.Equal(t, charset.CharsetUTF8MB4, desc.RetTp.GetCharset())
+		require.Equal(t, "utf8mb4_0900_ai_ci", desc.RetTp.GetCollate())
 	}
 }
 

--- a/pkg/expression/aggregation/base_func_test.go
+++ b/pkg/expression/aggregation/base_func_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
@@ -96,6 +97,51 @@ func TestBaseFunc_InferAggRetType(t *testing.T) {
 		}
 
 		desc, err := newBaseFuncDesc(ctx, ast.AggFuncGroupConcat, []expression.Expression{col, sep})
+		require.NoError(t, err)
+		require.Equal(t, charset.CharsetUTF8MB4, desc.RetTp.GetCharset())
+		require.Equal(t, "utf8mb4_0900_ai_ci", desc.RetTp.GetCollate())
+	}
+
+	// GROUP_CONCAT should fall back to connection collation when separator literal has empty charset/collation metadata.
+	{
+		require.NoError(t, ctx.GetSessionVars().SetSystemVar(vardef.CharacterSetConnection, charset.CharsetUTF8MB4))
+		require.NoError(t, ctx.GetSessionVars().SetSystemVar(vardef.CollationConnection, charset.CollationUTF8MB4))
+
+		col := &expression.Column{
+			UniqueID: 2,
+			RetType:  types.NewFieldType(mysql.TypeLonglong),
+		}
+
+		emptySepType := types.NewFieldType(mysql.TypeVarString)
+		emptySep := &expression.Constant{
+			Value:   types.NewStringDatum(","),
+			RetType: emptySepType,
+		}
+
+		desc, err := newBaseFuncDesc(ctx, ast.AggFuncGroupConcat, []expression.Expression{col, emptySep})
+		require.NoError(t, err)
+		require.Equal(t, charset.CharsetUTF8MB4, desc.RetTp.GetCharset())
+		require.Equal(t, charset.CollationUTF8MB4, desc.RetTp.GetCollate())
+	}
+
+	// GROUP_CONCAT should still keep a non-binary input collation even when separator metadata is empty.
+	{
+		colType := types.NewFieldType(mysql.TypeVarString)
+		colType.SetCharset(charset.CharsetUTF8MB4)
+		colType.SetCollate("utf8mb4_0900_ai_ci")
+		colType.DelFlag(mysql.BinaryFlag)
+		col := &expression.Column{
+			UniqueID: 3,
+			RetType:  colType,
+		}
+
+		emptySepType := types.NewFieldType(mysql.TypeVarString)
+		emptySep := &expression.Constant{
+			Value:   types.NewStringDatum("|"),
+			RetType: emptySepType,
+		}
+
+		desc, err := newBaseFuncDesc(ctx, ast.AggFuncGroupConcat, []expression.Expression{col, emptySep})
 		require.NoError(t, err)
 		require.Equal(t, charset.CharsetUTF8MB4, desc.RetTp.GetCharset())
 		require.Equal(t, "utf8mb4_0900_ai_ci", desc.RetTp.GetCollate())

--- a/pkg/parser/ast/functions.go
+++ b/pkg/parser/ast/functions.go
@@ -893,7 +893,11 @@ func (n *AggregateFuncExpr) Restore(ctx *format.RestoreCtx) error {
 			}
 		}
 		ctx.WriteKeyWord(" SEPARATOR ")
-		if err := n.Args[len(n.Args)-1].Restore(ctx); err != nil {
+		// The parser grammar only accepts `SEPARATOR stringLit` without charset introducer.
+		// Keep the literal text restorable even when separator carries charset/collation metadata.
+		separatorCtx := *ctx
+		separatorCtx.Flags |= format.RestoreStringWithoutCharset
+		if err := n.Args[len(n.Args)-1].Restore(&separatorCtx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore AggregateFuncExpr.Args SEPARATOR")
 		}
 	default:

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -9189,11 +9189,11 @@ SumExpr:
 
 OptGConcatSeparator:
 	{
-		$$ = ast.NewValueExpr(",", "", "")
+		$$ = ast.NewValueExpr(",", parser.charset, parser.collation)
 	}
 |	"SEPARATOR" stringLit
 	{
-		$$ = ast.NewValueExpr($2, "", "")
+		$$ = ast.NewValueExpr($2, parser.charset, parser.collation)
 	}
 
 FunctionCallGeneric:

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -4374,6 +4374,55 @@ func TestErrorMsg(t *testing.T) {
 	require.EqualError(t, err, "[ddl:1273]Unknown collation: 'some_unknown_collation'")
 }
 
+func TestGroupConcatSeparatorCharsetCollation(t *testing.T) {
+	p := parser.New()
+	testCases := []struct {
+		sql     string
+		charset string
+		collate string
+		sep     string
+	}{
+		{
+			sql:     "select group_concat('x')",
+			charset: charset.CharsetLatin1,
+			collate: charset.CollationLatin1,
+			sep:     ",",
+		},
+		{
+			sql:     "select group_concat('x' separator ';')",
+			charset: charset.CharsetLatin1,
+			collate: charset.CollationLatin1,
+			sep:     ";",
+		},
+		{
+			sql:     "select group_concat('x')",
+			charset: mysql.DefaultCharset,
+			collate: mysql.DefaultCollationName,
+			sep:     ",",
+		},
+	}
+
+	for _, tc := range testCases {
+		stmt, err := p.ParseOneStmt(tc.sql, tc.charset, tc.collate)
+		require.NoError(t, err)
+
+		sel, ok := stmt.(*ast.SelectStmt)
+		require.True(t, ok)
+		require.Len(t, sel.Fields.Fields, 1)
+
+		agg, ok := sel.Fields.Fields[0].Expr.(*ast.AggregateFuncExpr)
+		require.True(t, ok)
+		require.Equal(t, ast.AggFuncGroupConcat, agg.F)
+		require.GreaterOrEqual(t, len(agg.Args), 2)
+
+		separator, ok := agg.Args[len(agg.Args)-1].(ast.ValueExpr)
+		require.True(t, ok)
+		require.Equal(t, tc.sep, separator.GetString())
+		require.Equal(t, tc.charset, separator.GetType().GetCharset())
+		require.Equal(t, tc.collate, separator.GetType().GetCollate())
+	}
+}
+
 func TestOptimizerHints(t *testing.T) {
 	p := parser.New()
 	// Test USE_INDEX

--- a/tests/integrationtest/r/expression/issues.result
+++ b/tests/integrationtest/r/expression/issues.result
@@ -3426,3 +3426,38 @@ set @@tidb_enable_no_backslash_escapes_in_like = default;
 drop view v_nbe_like;
 drop view v_nbe_like_escape;
 drop table t_no_backslash_escapes;
+drop table if exists t_gc;
+create table t_gc (
+id int primary key,
+first_name varchar(20) collate utf8mb4_0900_ai_ci,
+last_name varchar(20) collate utf8mb4_0900_ai_ci,
+marker varchar(20) collate utf8mb4_0900_ai_ci
+) collate = utf8mb4_0900_ai_ci;
+insert into t_gc values
+(1, 'Billy', 'Alpha', 'm1'),
+(2, 'billy', 'Beta', 'm2'),
+(3, 'Human', 'Gamma', 'm3');
+select count(*) from t_gc where first_name like 'billy';
+count(*)
+2
+select count(*) from (
+select id from t_gc
+group by id
+having concat(' ', min(first_name), ' ', min(last_name), ' ', min(marker)) like '%billy%'
+) s;
+count(*)
+2
+select count(*) from (
+select id from t_gc
+group by id
+having group_concat(' ', first_name, ' ', last_name, ' ', marker) like '%billy%'
+) s;
+count(*)
+2
+select
+collation(concat(' ', min(first_name), ' ', min(last_name), ' ', min(marker))) as concat_collation,
+collation(group_concat(' ', first_name, ' ', last_name, ' ', marker)) as group_concat_collation
+from t_gc;
+concat_collation	group_concat_collation
+utf8mb4_0900_ai_ci	utf8mb4_0900_ai_ci
+drop table if exists t_gc;

--- a/tests/integrationtest/t/expression/issues.test
+++ b/tests/integrationtest/t/expression/issues.test
@@ -2311,3 +2311,32 @@ set @@tidb_enable_no_backslash_escapes_in_like = default;
 drop view v_nbe_like;
 drop view v_nbe_like_escape;
 drop table t_no_backslash_escapes;
+
+# TestIssue68360
+drop table if exists t_gc;
+create table t_gc (
+  id int primary key,
+  first_name varchar(20) collate utf8mb4_0900_ai_ci,
+  last_name varchar(20) collate utf8mb4_0900_ai_ci,
+  marker varchar(20) collate utf8mb4_0900_ai_ci
+) collate = utf8mb4_0900_ai_ci;
+insert into t_gc values
+  (1, 'Billy', 'Alpha', 'm1'),
+  (2, 'billy', 'Beta', 'm2'),
+  (3, 'Human', 'Gamma', 'm3');
+select count(*) from t_gc where first_name like 'billy';
+select count(*) from (
+  select id from t_gc
+  group by id
+  having concat(' ', min(first_name), ' ', min(last_name), ' ', min(marker)) like '%billy%'
+) s;
+select count(*) from (
+  select id from t_gc
+  group by id
+  having group_concat(' ', first_name, ' ', last_name, ' ', marker) like '%billy%'
+) s;
+select
+  collation(concat(' ', min(first_name), ' ', min(last_name), ' ', min(marker))) as concat_collation,
+  collation(group_concat(' ', first_name, ' ', last_name, ' ', marker)) as group_concat_collation
+from t_gc;
+drop table if exists t_gc;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68360

`GROUP_CONCAT` had two compatibility gaps:

- Issue #68360: for non-binary utf8mb4 inputs, `GROUP_CONCAT` could end up with `utf8mb4_bin`, making `HAVING ... LIKE` case-sensitive unexpectedly.
- Additional gap found while validating behavior against MySQL: default `GROUP_CONCAT` separator could be created with empty charset/collation metadata in parser AST, which can trigger `Error 1267` (illegal collation mix) in latin1 sessions.

### What changed and how does it work?

Diff vs `master` contains 9 files, and this PR changes exactly these areas:

1. `pkg/expression/aggregation/base_func.go`
- `typeInfer4GroupConcat` now derives the return collation from arguments using `CheckAndDeriveCollationFromExprs(...)`.
- Added fallback for empty derived charset/collation: use session charset/collation and charset default collation when needed.
- `TypeInfer` now returns `GROUP_CONCAT` type-inference errors directly.

2. `pkg/expression/aggregation/base_func_test.go`
- Added regression coverage for:
  - preserving non-binary input collation,
  - fallback behavior when separator metadata is empty.

3. `pkg/expression/aggregation/BUILD.bazel`
- Added parser charset dependency required by new collation fallback logic.

4. `pkg/parser/parser.y` and regenerated `pkg/parser/parser.go`
- `OptGConcatSeparator` now builds separator `ValueExpr` with parser session charset/collation instead of empty metadata.

5. `pkg/parser/ast/functions.go`
- `AggregateFuncExpr.Restore` for `GROUP_CONCAT ... SEPARATOR` now restores separator as a plain string literal (no charset introducer), keeping restore output parseable with current grammar (`SEPARATOR stringLit`).

6. `pkg/parser/parser_test.go`
- Added parser regression test `TestGroupConcatSeparatorCharsetCollation`.

7. `tests/integrationtest/t/expression/issues.test`
   `tests/integrationtest/r/expression/issues.result`
- Added #68360 regression SQL and expected results.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual verification summary:

- Built patched TiDB and ran local unistore.
- Compared with local MySQL using the same SQL matrix:
  - default utf8mb4 session
  - `SET NAMES latin1`
  - `SET NAMES latin1 COLLATE latin1_bin`
- Verified patched TiDB no longer hits the latin1 collation-mix error for the repro query and aligns with MySQL outcomes for checked queries.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix GROUP_CONCAT collation handling by deriving result collation from arguments and ensuring parser-generated separator literals carry session charset/collation metadata, avoiding MySQL-compatibility collation mismatches.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GROUP_CONCAT now correctly derives and preserves character set and collation from its inputs (with fallback to connection/default) and consistently emits the separator literal with its charset/collation.

* **Tests**
  * Added unit and integration tests validating GROUP_CONCAT charset/collation inference, separator handling, fallback behavior, and related query outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68362)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->