### PR TITLE
executor, planner: port INSERT virtual-gencol perf improvement + regression fix to feature/fts  | tidb-test=release-fts-202602  tiflash=feature-fts tikv=feature-fts

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -341,6 +341,7 @@ go_test(
         "analyze_test.go",
         "analyze_utils_test.go",
         "batch_point_get_test.go",
+        "bench_gencol_test.go",
         "benchmark_test.go",
         "brie_test.go",
         "brie_utils_test.go",

--- a/pkg/executor/bench_gencol_test.go
+++ b/pkg/executor/bench_gencol_test.go
@@ -63,6 +63,31 @@ func BenchmarkInsertWideTableWithGC(b *testing.B) {
 	}
 }
 
+// BenchmarkInsertYCSBLike benchmarks INSERT into an 11-column table with no generated columns,
+// modeling the YCSB usertable schema (1 VARCHAR PK + 10 VARCHAR value fields).
+// This is the regression scenario from issue #68129: MutRowFromDatums is called
+// unconditionally even when gCols is empty, adding unnecessary allocation per row.
+func BenchmarkInsertYCSBLike(b *testing.B) {
+	store := testkit.CreateMockStore(b)
+	tk := testkit.NewTestKit(b, store)
+	tk.MustExec("use test")
+
+	defs := []string{"YCSB_KEY VARCHAR(255) PRIMARY KEY"}
+	vals := []string{"'user1000'"}
+	for i := 0; i < 10; i++ {
+		defs = append(defs, fmt.Sprintf("FIELD%d VARCHAR(100)", i))
+		vals = append(vals, fmt.Sprintf("'value%d'", i))
+	}
+	tk.MustExec("CREATE TABLE usertable (" + strings.Join(defs, ", ") + ")")
+
+	// Use INSERT IGNORE so repeated runs don't fail on the duplicate PK.
+	insertSQL := "INSERT IGNORE INTO usertable VALUES (" + strings.Join(vals, ", ") + ")"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tk.MustExec(insertSQL)
+	}
+}
+
 // BenchmarkInsertWideTableWithNonLiteralGC benchmarks INSERT into a table with 150 virtual
 // generated columns that reference a real column (GENERATED ALWAYS AS (LOWER(name)) VIRTUAL).
 // This exercises the non-constant GC path where each GC must read the base column value.

--- a/pkg/executor/bench_gencol_test.go
+++ b/pkg/executor/bench_gencol_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+// BenchmarkInsertWideTableNoGC is the baseline: 150-column table, no generated columns.
+func BenchmarkInsertWideTableNoGC(b *testing.B) {
+	store := testkit.CreateMockStore(b)
+	tk := testkit.NewTestKit(b, store)
+	tk.MustExec("use test")
+
+	cols := make([]string, 150)
+	vals := make([]string, 150)
+	for i := range cols {
+		cols[i] = fmt.Sprintf("c%d INT", i)
+		vals[i] = "1"
+	}
+	tk.MustExec("CREATE TABLE t_no_gc (" + strings.Join(cols, ", ") + ")")
+
+	insertSQL := "INSERT INTO t_no_gc VALUES (" + strings.Join(vals, ", ") + ")"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tk.MustExec(insertSQL)
+	}
+}
+
+// BenchmarkInsertWideTableWithGC benchmarks INSERT into a table with 150 virtual
+// generated columns (GENERATED ALWAYS AS (NULL) VIRTUAL) — the GTOC-8384 pattern.
+func BenchmarkInsertWideTableWithGC(b *testing.B) {
+	store := testkit.CreateMockStore(b)
+	tk := testkit.NewTestKit(b, store)
+	tk.MustExec("use test")
+
+	// 1 real base column + 150 virtual GCs.
+	defs := []string{"id INT"}
+	for i := 0; i < 150; i++ {
+		defs = append(defs, fmt.Sprintf("g%d INT GENERATED ALWAYS AS (NULL) VIRTUAL", i))
+	}
+	tk.MustExec("CREATE TABLE t_gc (" + strings.Join(defs, ", ") + ")")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tk.MustExec("INSERT INTO t_gc (id) VALUES (1)")
+	}
+}
+
+// BenchmarkInsertWideTableWithNonLiteralGC benchmarks INSERT into a table with 150 virtual
+// generated columns that reference a real column (GENERATED ALWAYS AS (LOWER(name)) VIRTUAL).
+// This exercises the non-constant GC path where each GC must read the base column value.
+func BenchmarkInsertWideTableWithNonLiteralGC(b *testing.B) {
+	store := testkit.CreateMockStore(b)
+	tk := testkit.NewTestKit(b, store)
+	tk.MustExec("use test")
+
+	// 1 real VARCHAR base column + 150 virtual GCs derived from it.
+	defs := []string{"name VARCHAR(30)"}
+	for i := 0; i < 150; i++ {
+		defs = append(defs, fmt.Sprintf("g%d VARCHAR(30) GENERATED ALWAYS AS (LOWER(name)) VIRTUAL", i))
+	}
+	tk.MustExec("CREATE TABLE t_gc_nonlit (" + strings.Join(defs, ", ") + ")")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tk.MustExec("INSERT INTO t_gc_nonlit (name) VALUES ('HelloWorld')")
+	}
+}

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -673,7 +673,7 @@ func (e *InsertValues) fillColValue(
 func (e *InsertValues) fillRow(ctx context.Context, row []types.Datum, hasValue []bool, rowIdx int) (
 	[]types.Datum, error,
 ) {
-	gCols := make([]*table.Column, 0)
+	var gCols []*table.Column
 	tCols := e.Table.Cols()
 	if e.hasExtraHandle {
 		col := &table.Column{}
@@ -710,6 +710,11 @@ func (e *InsertValues) fillRow(ctx context.Context, row []types.Datum, hasValue 
 		if err := checkRowForExchangePartition(e.Ctx(), row, tbl); err != nil {
 			return nil, err
 		}
+	}
+
+	// Fast path: no generated columns, nothing more to do.
+	if len(gCols) == 0 {
+		return row, nil
 	}
 
 	sctx := e.Ctx()

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -716,9 +716,13 @@ func (e *InsertValues) fillRow(ctx context.Context, row []types.Datum, hasValue 
 	evalCtx := sctx.GetExprCtx().GetEvalCtx()
 	sc := sctx.GetSessionVars().StmtCtx
 	warnCnt := int(sc.WarningCount())
+	// Build the MutRow once and update it in-place after each generated column is
+	// evaluated. Previously MutRowFromDatums was called inside the loop, causing a
+	// full row copy O(columns) allocation for every generated column — O(G*C) total.
+	mutRow := chunk.MutRowFromDatums(row)
 	for i, gCol := range gCols {
 		colIdx := gCol.ColumnInfo.Offset
-		val, err := e.GenExprs[i].Eval(evalCtx, chunk.MutRowFromDatums(row).ToRow())
+		val, err := e.GenExprs[i].Eval(evalCtx, mutRow.ToRow())
 		if err != nil && gCol.FieldType.IsArray() {
 			return nil, completeError(tbl, gCol.Offset, rowIdx, err)
 		}
@@ -740,6 +744,9 @@ func (e *InsertValues) fillRow(ctx context.Context, row []types.Datum, hasValue 
 		if err = gCol.HandleBadNull(sc.ErrCtx(), &row[colIdx], rowCntInLoadData); err != nil {
 			return nil, err
 		}
+		// Keep mutRow in sync so subsequent generated columns that reference
+		// already-computed generated columns see the updated value.
+		mutRow.SetDatum(colIdx, row[colIdx])
 	}
 	return row, nil
 }

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4171,12 +4171,19 @@ func (b *PlanBuilder) resolveGeneratedColumns(ctx context.Context, columns []*ta
 		}
 		colExpr := mockPlan.Schema().Columns[idx]
 
-		originalVal := b.allowBuildCastArray
-		b.allowBuildCastArray = true
-		expr, _, err := b.rewrite(ctx, column.GeneratedExpr.Clone(), mockPlan, nil, true)
-		b.allowBuildCastArray = originalVal
-		if err != nil {
-			return igc, err
+		var expr expression.Expression
+		// Fast path: pure value literals (e.g. GENERATED ALWAYS AS (NULL) VIRTUAL) contain no
+		// column references and need no rewriting. Skip the expensive Clone()+rewrite() for them.
+		if valExpr, ok := column.GeneratedExpr.Internal().(*driver.ValueExpr); ok {
+			expr = &expression.Constant{Value: valExpr.Datum, RetType: column.FieldType.Clone()}
+		} else {
+			originalVal := b.allowBuildCastArray
+			b.allowBuildCastArray = true
+			expr, _, err = b.rewrite(ctx, column.GeneratedExpr.Clone(), mockPlan, nil, true)
+			b.allowBuildCastArray = originalVal
+			if err != nil {
+				return igc, err
+			}
 		}
 
 		igc.Exprs = append(igc.Exprs, expr)

--- a/pkg/util/chunk/mutrow.go
+++ b/pkg/util/chunk/mutrow.go
@@ -302,18 +302,36 @@ func (mr MutRow) SetDatum(colIdx int, d types.Datum) {
 	if d.IsNull() {
 		return
 	}
+	// For all fixed-size types, col.data may be zero-length when the column was
+	// originally null-allocated (a varlen column with empty buffer). Grow the
+	// buffer to the required size before writing.
 	switch d.Kind() {
 	case types.KindInt64, types.KindUint64, types.KindFloat64:
+		if len(col.data) < 8 {
+			col.data = make([]byte, 8)
+		}
 		binary.LittleEndian.PutUint64(mr.c.columns[colIdx].data, d.GetUint64())
 	case types.KindFloat32:
+		if len(col.data) < 4 {
+			col.data = make([]byte, 4)
+		}
 		binary.LittleEndian.PutUint32(mr.c.columns[colIdx].data, math.Float32bits(d.GetFloat32()))
 	case types.KindString, types.KindBytes, types.KindBinaryLiteral:
 		setMutRowBytes(col, d.GetBytes())
 	case types.KindMysqlTime:
+		if len(col.data) < sizeTime {
+			col.data = make([]byte, sizeTime)
+		}
 		*(*types.Time)(unsafe.Pointer(&col.data[0])) = d.GetMysqlTime()
 	case types.KindMysqlDuration:
+		if len(col.data) < 8 {
+			col.data = make([]byte, 8)
+		}
 		*(*int64)(unsafe.Pointer(&col.data[0])) = int64(d.GetMysqlDuration().Duration)
 	case types.KindMysqlDecimal:
+		if len(col.data) < types.MyDecimalStructSize {
+			col.data = make([]byte, types.MyDecimalStructSize)
+		}
 		*(*types.MyDecimal)(unsafe.Pointer(&col.data[0])) = *d.GetMysqlDecimal()
 	case types.KindMysqlJSON:
 		setMutRowJSON(col, d.GetMysqlJSON())


### PR DESCRIPTION
## What problem does this PR solve?

Ports the INSERT performance improvement for tables with virtual generated columns and its regression fix from master to the `feature/fts` branch.

## Changes included

Cherry-picked 3 commits from 2 upstream PRs:

| Commit | Source PR | Description |
|--------|-----------|-------------|
| 775af768 | #67917 | executor, planner: improve INSERT performance for tables with many virtual generated columns |
| 4b0aa567 | #68187 | executor: fix INSERT regression for tables without generated columns (#68129) |
| 5c7332cb | #68187 | executor: add BenchmarkInsertYCSBLike to cover no-generated-column INSERT path |

## Related

- ref #67917
- ref #68187
- ref #68129

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized INSERT operations for tables with generated columns through reduced memory allocation.
  * Improved evaluation efficiency for literal expressions in generated column definitions.

* **Bug Fixes**
  * Fixed buffer allocation for fixed-size data types in row operations.

* **Tests**
  * Added comprehensive benchmarks for INSERT performance with wide tables and generated columns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68363)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->