### PR TITLE
fix(br): duplicated "the" in checkpoint mismatch error message

### DIFF
--- a/br/pkg/restore/snap_client/client.go
+++ b/br/pkg/restore/snap_client/client.go
@@ -502,7 +502,7 @@ func (rc *SnapClient) InitCheckpoint(
 			return checkpointSetWithTableID, nil, 0, errors.Errorf(
 				"The hash of the current snapshot restore does not match that recorded in checkpoint. "+
 					"Please don't use the checkpoint, "+
-					"or use the the same restore command. checkpoint manager: %v",
+					"or use the same restore command. checkpoint manager: %v",
 				snapshotCheckpointMetaManager)
 		}
 


### PR DESCRIPTION
One-line typo fix in `br/pkg/restore/snap_client/client.go`: error string "or use the the same restore command. checkpoint manager: %v" → "or use the same restore command. checkpoint manager: %v". No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a grammatical error in checkpoint error messaging for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68380)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->