### PR TITLE
*: improve Starter activation metadata and shutdown coordination

### DIFF
--- a/cmd/tidb-server/BUILD.bazel
+++ b/cmd/tidb-server/BUILD.bazel
@@ -108,7 +108,7 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":tidb-server_lib"],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/config",
         "//pkg/config/deploymode",

--- a/cmd/tidb-server/BUILD.bazel
+++ b/cmd/tidb-server/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/store/copr",
         "//pkg/store/driver",
         "//pkg/store/mockstore",
+        "//pkg/tidbmanager",
         "//pkg/util",
         "//pkg/util/cgmon",
         "//pkg/util/chunk",
@@ -107,7 +108,7 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":tidb-server_lib"],
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         "//pkg/config",
         "//pkg/config/deploymode",

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -153,6 +153,7 @@ const (
 	nmActivationTimeout = "activation-timeout"
 	nmMaxIdleSeconds    = "max-idle-seconds"
 	nmKeyspaceActivate  = "keyspace-activate"
+	nmStarterParams     = "starter-additional-params"
 )
 
 const (
@@ -228,6 +229,8 @@ var (
 	maxIdleSeconds    *uint
 	// Keyspace activate
 	keyspaceActivateMode *bool
+	// Starter additional params
+	starterAdditionalParams *string
 )
 
 func initFlagSet() *flag.FlagSet {
@@ -296,6 +299,7 @@ func initFlagSet() *flag.FlagSet {
 	activationTimeout = fset.Uint(nmActivationTimeout, 0, "max time in second allowed for tidb to activate from standby, 0 means no limit")
 	maxIdleSeconds = fset.Uint(nmMaxIdleSeconds, 0, "max idle seconds for a connection, 0 means no limit")
 	keyspaceActivateMode = flagBoolean(fset, nmKeyspaceActivate, false, "exit after activating the keyspace")
+	starterAdditionalParams = fset.String(nmStarterParams, "", "starter additional params in k=v,k=v format")
 
 	session.RegisterMockUpgradeFlag(fset)
 	// Ignore errors; CommandLine is set for ExitOnError.
@@ -345,7 +349,7 @@ func main() {
 
 	var standbyController server.StandbyController
 	if config.GetGlobalConfig().Standby.StandByMode {
-		mgrCli, err := createMgrClient()
+		mgrCli, err := createMgrClientForStarter()
 		terror.MustNil(err)
 		standbyController = standby.NewLoadKeyspaceController(mgrCli)
 	}
@@ -489,10 +493,7 @@ func exitAfterKeyspaceActivate(svr *server.Server, storage kv.Storage, dom *doma
 	if err := syncLog(); err != nil {
 		exitCode = exitCodeErr
 	}
-	if exitCode != exitCodeOK {
-		os.Exit(exitCode)
-	}
-	os.Exit(exitCodeOK)
+	os.Exit(exitCode)
 }
 
 func syncLog() error {
@@ -1267,7 +1268,68 @@ func closeStmtSummary() {
 	}
 }
 
-func createMgrClient() (tidbmanager.Client, error) {
+type starterParams struct {
+	managerNamespace string
+	podName          string
+	podIP            string
+	podNamespace     string
+}
+
+func parseStarterAdditionalParams(raw string) (starterParams, error) {
+	var params starterParams
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return params, nil
+	}
+
+	seen := make(map[string]struct{})
+	for _, item := range strings.Split(raw, ",") {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			return params, fmt.Errorf("starter additional params contains an empty item")
+		}
+
+		key, value, ok := strings.Cut(item, "=")
+		if !ok {
+			return params, fmt.Errorf("starter additional param %q must be in k=v format", item)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return params, fmt.Errorf("starter additional param %q has an empty key", item)
+		}
+		if value == "" {
+			return params, fmt.Errorf("starter additional param %q has an empty value", key)
+		}
+		if _, ok := seen[key]; ok {
+			return params, fmt.Errorf("starter additional param %q is duplicated", key)
+		}
+		seen[key] = struct{}{}
+
+		switch key {
+		case "manager-namespace":
+			params.managerNamespace = value
+		case "pod-name":
+			params.podName = value
+		case "pod-ip":
+			params.podIP = value
+		case "pod-namespace":
+			params.podNamespace = value
+		default:
+			return params, fmt.Errorf("unknown starter additional param %q", key)
+		}
+	}
+	return params, nil
+}
+
+func getStarterAdditionalParams() string {
+	if starterAdditionalParams == nil {
+		return ""
+	}
+	return *starterAdditionalParams
+}
+
+func createMgrClientForStarter() (tidbmanager.Client, error) {
 	if !deploymode.IsStarter() {
 		return nil, nil
 	}
@@ -1283,23 +1345,26 @@ func createMgrClient() (tidbmanager.Client, error) {
 		return nil, err
 	}
 
+	params, err := parseStarterAdditionalParams(getStarterAdditionalParams())
+	if err != nil {
+		return nil, err
+	}
+
 	managerAddr := cfg.Standby.ManagerAddr
 	if managerAddr == "" {
-		managerNs := os.Getenv(config.EnvManagerNs)
+		managerNs := params.managerNamespace
 		if managerNs == "" {
 			managerNs = config.DefaultManagerNamespace
 		}
 		managerAddr = fmt.Sprintf("manager-server.%s.svc:8000", managerNs)
 	}
 
-	podName := os.Getenv(config.EnvPodName)
-	podIP := os.Getenv(config.EnvPodIP)
-	namespace := os.Getenv(config.EnvNamespace)
+	podName := params.podName
+	podIP := params.podIP
+	namespace := params.podNamespace
 	if podName == "" || podIP == "" || namespace == "" {
-		return nil, fmt.Errorf("manager notifier requires pod identity envs: %s=%q, %s=%q, %s=%q",
-			config.EnvPodName, podName,
-			config.EnvPodIP, podIP,
-			config.EnvNamespace, namespace)
+		return nil, fmt.Errorf("manager notifier requires --starter-additional-params with pod-name, pod-ip and pod-namespace: pod-name=%q, pod-ip=%q, pod-namespace=%q",
+			podName, podIP, namespace)
 	}
 
 	return tidbmanager.NewClient(

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -152,6 +152,7 @@ const (
 	nmStandby           = "standby"
 	nmActivationTimeout = "activation-timeout"
 	nmMaxIdleSeconds    = "max-idle-seconds"
+	nmKeyspaceActivate  = "keyspace-activate"
 )
 
 const (
@@ -225,6 +226,8 @@ var (
 	standbyMode       *bool
 	activationTimeout *uint
 	maxIdleSeconds    *uint
+	// Keyspace activate
+	keyspaceActivateMode *bool
 )
 
 func initFlagSet() *flag.FlagSet {
@@ -292,6 +295,7 @@ func initFlagSet() *flag.FlagSet {
 	standbyMode = flagBoolean(fset, nmStandby, false, "start tidb-server as standby")
 	activationTimeout = fset.Uint(nmActivationTimeout, 0, "max time in second allowed for tidb to activate from standby, 0 means no limit")
 	maxIdleSeconds = fset.Uint(nmMaxIdleSeconds, 0, "max idle seconds for a connection, 0 means no limit")
+	keyspaceActivateMode = flagBoolean(fset, nmKeyspaceActivate, false, "exit after activating the keyspace")
 
 	session.RegisterMockUpgradeFlag(fset)
 	// Ignore errors; CommandLine is set for ExitOnError.
@@ -334,8 +338,8 @@ func main() {
 	if kerneltype.IsNextGen() && len(config.GetGlobalConfig().KeyspaceName) == 0 && !config.GetGlobalConfig().Standby.StandByMode {
 		fmt.Fprintln(os.Stderr, "invalid config: keyspace name or standby mode is required for nextgen TiDB")
 		os.Exit(0)
-	} else if kerneltype.IsClassic() && (len(config.GetGlobalConfig().KeyspaceName) > 0 || config.GetGlobalConfig().Standby.StandByMode) {
-		fmt.Fprintln(os.Stderr, "invalid config: keyspace name or standby mode is not supported for classic TiDB")
+	} else if kerneltype.IsClassic() && (len(config.GetGlobalConfig().KeyspaceName) > 0 || config.GetGlobalConfig().Standby.StandByMode || config.GetGlobalConfig().KeyspaceActivateMode) {
+		fmt.Fprintln(os.Stderr, "invalid config: keyspace name, standby mode or keyspace-activate mode is not supported for classic TiDB")
 		os.Exit(0)
 	}
 
@@ -437,6 +441,9 @@ func main() {
 		svr.StandbyController = standbyController
 		svr.StandbyController.OnServerCreated(svr)
 	}
+	if deploymode.IsStarter() && config.GetGlobalConfig().KeyspaceActivateMode {
+		exitAfterKeyspaceActivate(svr, storage, dom)
+	}
 
 	exited := make(chan struct{})
 	exitCode := exitCodeOK
@@ -469,6 +476,23 @@ func exitCodeForSignal(sig os.Signal) int {
 		return exitCodeInt
 	}
 	return exitCodeOK
+}
+
+func exitAfterKeyspaceActivate(svr *server.Server, storage kv.Storage, dom *domain.Domain) {
+	logutil.BgLogger().Info("keyspace activation completed, exiting")
+	exitCode := exitCodeOK
+	svr.Close()
+	resourcemanager.InstanceResourceManager.Stop()
+	cleanup(svr, storage, dom)
+	cpuprofile.StopCPUProfiler()
+	executor.Stop()
+	if err := syncLog(); err != nil {
+		exitCode = exitCodeErr
+	}
+	if exitCode != exitCodeOK {
+		os.Exit(exitCode)
+	}
+	os.Exit(exitCodeOK)
 }
 
 func syncLog() error {
@@ -848,6 +872,10 @@ func overrideConfig(cfg *config.Config, fset *flag.FlagSet) {
 
 	if actualFlags[nmMaxIdleSeconds] {
 		cfg.Standby.MaxIdleSeconds = *maxIdleSeconds
+	}
+
+	if actualFlags[nmKeyspaceActivate] {
+		cfg.KeyspaceActivateMode = *keyspaceActivateMode
 	}
 }
 

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -63,6 +63,7 @@ import (
 	"github.com/pingcap/tidb/pkg/store/copr"
 	"github.com/pingcap/tidb/pkg/store/driver"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
+	"github.com/pingcap/tidb/pkg/tidbmanager"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/cgmon"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -340,7 +341,9 @@ func main() {
 
 	var standbyController server.StandbyController
 	if config.GetGlobalConfig().Standby.StandByMode {
-		standbyController = standby.NewLoadKeyspaceController()
+		mgrCli, err := createMgrClient()
+		terror.MustNil(err)
+		standbyController = standby.NewLoadKeyspaceController(mgrCli)
 	}
 
 	var err error
@@ -1183,6 +1186,9 @@ func cleanup(svr *server.Server, storage kv.Storage, dom *domain.Domain) {
 	dom.StopAutoAnalyze()
 
 	drainClientWait := gracefulCloseConnectionsTimeout
+	if deploymode.IsStarter() && svr.GetForceShutdown() {
+		drainClientWait = 0
+	}
 
 	cancelClientWait := time.Second * 1
 	svr.DrainClients(drainClientWait, cancelClientWait)
@@ -1231,6 +1237,50 @@ func closeStmtSummary() {
 	if instanceCfg.StmtSummaryEnablePersistent {
 		stmtsummaryv2.Close()
 	}
+}
+
+func createMgrClient() (tidbmanager.Client, error) {
+	if !deploymode.IsStarter() {
+		return nil, nil
+	}
+
+	cfg := config.GetGlobalConfig()
+	if !cfg.Standby.EnableManagerNotifier {
+		return nil, nil
+	}
+
+	clusterSecurity := cfg.Security.ClusterSecurity()
+	tlsConfig, err := clusterSecurity.ToTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	managerAddr := cfg.Standby.ManagerAddr
+	if managerAddr == "" {
+		managerNs := os.Getenv(config.EnvManagerNs)
+		if managerNs == "" {
+			managerNs = config.DefaultManagerNamespace
+		}
+		managerAddr = fmt.Sprintf("manager-server.%s.svc:8000", managerNs)
+	}
+
+	podName := os.Getenv(config.EnvPodName)
+	podIP := os.Getenv(config.EnvPodIP)
+	namespace := os.Getenv(config.EnvNamespace)
+	if podName == "" || podIP == "" || namespace == "" {
+		return nil, fmt.Errorf("manager notifier requires pod identity envs: %s=%q, %s=%q, %s=%q",
+			config.EnvPodName, podName,
+			config.EnvPodIP, podIP,
+			config.EnvNamespace, namespace)
+	}
+
+	return tidbmanager.NewClient(
+		managerAddr,
+		tlsConfig,
+		podName,
+		podIP,
+		namespace,
+	), nil
 }
 
 func enablePyroscope() {

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -1335,7 +1335,7 @@ func createMgrClientForStarter() (tidbmanager.Client, error) {
 	}
 
 	cfg := config.GetGlobalConfig()
-	if !cfg.Standby.EnableManagerNotifier {
+	if !cfg.StarterParams.EnableManagerNotifier {
 		return nil, nil
 	}
 
@@ -1350,11 +1350,11 @@ func createMgrClientForStarter() (tidbmanager.Client, error) {
 		return nil, err
 	}
 
-	managerAddr := cfg.Standby.ManagerAddr
+	managerAddr := cfg.StarterParams.ManagerAddr
 	if managerAddr == "" {
 		managerNs := params.managerNamespace
 		if managerNs == "" {
-			managerNs = config.DefaultManagerNamespace
+			return nil, fmt.Errorf("manager notifier requires manager-addr config or manager-namespace in --starter-additional-params")
 		}
 		managerAddr = fmt.Sprintf("manager-server.%s.svc:8000", managerNs)
 	}

--- a/cmd/tidb-server/main_test.go
+++ b/cmd/tidb-server/main_test.go
@@ -75,17 +75,23 @@ func TestExitCodeForSignal(t *testing.T) {
 
 func TestOverrideConfigKeyspaceActivateMode(t *testing.T) {
 	originalArgs := os.Args
+	originalStarterAdditionalParams := starterAdditionalParams
 	os.Args = []string{"tidb-server"}
 	t.Cleanup(func() {
 		os.Args = originalArgs
+		starterAdditionalParams = originalStarterAdditionalParams
 	})
 
 	fset := initFlagSet()
-	require.NoError(t, fset.Parse([]string{"--keyspace-activate=true"}))
+	require.NoError(t, fset.Parse([]string{
+		"--keyspace-activate=true",
+		"--starter-additional-params=pod-name=pod-1,pod-ip=10.0.0.1,pod-namespace=ns-1",
+	}))
 
 	cfg := config.NewConfig()
 	overrideConfig(cfg, fset)
 	require.True(t, cfg.KeyspaceActivateMode)
+	require.Equal(t, "pod-name=pod-1,pod-ip=10.0.0.1,pod-namespace=ns-1", *starterAdditionalParams)
 }
 
 func TestSetGlobalVars(t *testing.T) {
@@ -193,19 +199,27 @@ func TestCreateMgrClientRequiresPodIdentityInStarter(t *testing.T) {
 		conf.Standby.ManagerAddr = "manager.example.com:8000"
 	})
 
-	t.Setenv(config.EnvPodName, "")
-	t.Setenv(config.EnvPodIP, "")
-	t.Setenv(config.EnvNamespace, "")
-	_, err := createMgrClient()
-	require.ErrorContains(t, err, "manager notifier requires pod identity envs")
-	require.ErrorContains(t, err, config.EnvPodName)
-	require.ErrorContains(t, err, config.EnvPodIP)
-	require.ErrorContains(t, err, config.EnvNamespace)
+	originalStarterAdditionalParams := starterAdditionalParams
+	t.Cleanup(func() {
+		starterAdditionalParams = originalStarterAdditionalParams
+	})
 
-	t.Setenv(config.EnvPodName, "pod-1")
-	t.Setenv(config.EnvPodIP, "10.0.0.1")
-	t.Setenv(config.EnvNamespace, "ns-1")
-	cli, err := createMgrClient()
+	_, err := createMgrClientForStarter()
+	require.ErrorContains(t, err, "manager notifier requires --starter-additional-params")
+
+	duplicatedParam := "pod-name=pod-1,pod-name=pod-2,pod-ip=10.0.0.1,pod-namespace=ns-1"
+	starterAdditionalParams = &duplicatedParam
+	_, err = createMgrClientForStarter()
+	require.ErrorContains(t, err, `starter additional param "pod-name" is duplicated`)
+
+	unknownParam := "pod-name=pod-1,pod-ip=10.0.0.1,pod-namespace=ns-1,unknown=value"
+	starterAdditionalParams = &unknownParam
+	_, err = createMgrClientForStarter()
+	require.ErrorContains(t, err, `unknown starter additional param "unknown"`)
+
+	validParams := "manager-namespace=manager-ns,pod-name=pod-1,pod-ip=10.0.0.1,pod-namespace=ns-1"
+	starterAdditionalParams = &validParams
+	cli, err := createMgrClientForStarter()
 	require.NoError(t, err)
 	require.NotNil(t, cli)
 }

--- a/cmd/tidb-server/main_test.go
+++ b/cmd/tidb-server/main_test.go
@@ -161,6 +161,40 @@ func TestInitDeployMode(t *testing.T) {
 	})
 }
 
+func TestCreateMgrClientRequiresPodIdentityInStarter(t *testing.T) {
+	if kerneltype.IsClassic() {
+		t.Skip("only for nextgen kernel")
+	}
+
+	restoreConfig := config.RestoreFunc()
+	t.Cleanup(restoreConfig)
+	originalMode := deploymode.Get()
+	t.Cleanup(func() {
+		require.NoError(t, deploymode.Set(originalMode))
+	})
+	require.NoError(t, deploymode.Set(deploymode.Starter))
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Standby.EnableManagerNotifier = true
+		conf.Standby.ManagerAddr = "manager.example.com:8000"
+	})
+
+	t.Setenv(config.EnvPodName, "")
+	t.Setenv(config.EnvPodIP, "")
+	t.Setenv(config.EnvNamespace, "")
+	_, err := createMgrClient()
+	require.ErrorContains(t, err, "manager notifier requires pod identity envs")
+	require.ErrorContains(t, err, config.EnvPodName)
+	require.ErrorContains(t, err, config.EnvPodIP)
+	require.ErrorContains(t, err, config.EnvNamespace)
+
+	t.Setenv(config.EnvPodName, "pod-1")
+	t.Setenv(config.EnvPodIP, "10.0.0.1")
+	t.Setenv(config.EnvNamespace, "ns-1")
+	cli, err := createMgrClient()
+	require.NoError(t, err)
+	require.NotNil(t, cli)
+}
+
 func TestSetVersionByConfigInNextGen(t *testing.T) {
 	if kerneltype.IsClassic() {
 		t.Skip("only for nextgen kernel")

--- a/cmd/tidb-server/main_test.go
+++ b/cmd/tidb-server/main_test.go
@@ -73,6 +73,21 @@ func TestExitCodeForSignal(t *testing.T) {
 	}
 }
 
+func TestOverrideConfigKeyspaceActivateMode(t *testing.T) {
+	originalArgs := os.Args
+	os.Args = []string{"tidb-server"}
+	t.Cleanup(func() {
+		os.Args = originalArgs
+	})
+
+	fset := initFlagSet()
+	require.NoError(t, fset.Parse([]string{"--keyspace-activate=true"}))
+
+	cfg := config.NewConfig()
+	overrideConfig(cfg, fset)
+	require.True(t, cfg.KeyspaceActivateMode)
+}
+
 func TestSetGlobalVars(t *testing.T) {
 	defer view.Stop()
 	require.Equal(t, "tikv,tiflash,tidb", variable.GetSysVar(vardef.TiDBIsolationReadEngines).Value)

--- a/cmd/tidb-server/main_test.go
+++ b/cmd/tidb-server/main_test.go
@@ -195,8 +195,8 @@ func TestCreateMgrClientRequiresPodIdentityInStarter(t *testing.T) {
 	})
 	require.NoError(t, deploymode.Set(deploymode.Starter))
 	config.UpdateGlobal(func(conf *config.Config) {
-		conf.Standby.EnableManagerNotifier = true
-		conf.Standby.ManagerAddr = "manager.example.com:8000"
+		conf.StarterParams.EnableManagerNotifier = true
+		conf.StarterParams.ManagerAddr = "manager.example.com:8000"
 	})
 
 	originalStarterAdditionalParams := starterAdditionalParams
@@ -216,6 +216,14 @@ func TestCreateMgrClientRequiresPodIdentityInStarter(t *testing.T) {
 	starterAdditionalParams = &unknownParam
 	_, err = createMgrClientForStarter()
 	require.ErrorContains(t, err, `unknown starter additional param "unknown"`)
+
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.StarterParams.ManagerAddr = ""
+	})
+	missingManagerNamespace := "pod-name=pod-1,pod-ip=10.0.0.1,pod-namespace=ns-1"
+	starterAdditionalParams = &missingManagerNamespace
+	_, err = createMgrClientForStarter()
+	require.ErrorContains(t, err, "manager notifier requires manager-addr config or manager-namespace in --starter-additional-params")
 
 	validParams := "manager-namespace=manager-ns,pod-name=pod-1,pod-ip=10.0.0.1,pod-namespace=ns-1"
 	starterAdditionalParams = &validParams

--- a/pkg/autoid_service/autoid.go
+++ b/pkg/autoid_service/autoid.go
@@ -388,6 +388,11 @@ func (s *Service) Close() {
 	}
 }
 
+// IsOwner returns whether this service is the current auto ID owner.
+func (s *Service) IsOwner() bool {
+	return s.leaderShip != nil && s.leaderShip.IsOwner()
+}
+
 // seekToFirstAutoIDSigned seeks to the next valid signed position.
 func seekToFirstAutoIDSigned(base, increment, offset int64) int64 {
 	nr := (base + increment - offset) / increment

--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -42,7 +42,7 @@ go_test(
     data = glob(["**"]),
     embed = [":config"],
     flaky = True,
-    shard_count = 32,
+    shard_count = 33,
     deps = [
         "//pkg/config/deploymode",
         "//pkg/config/kerneltype",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -127,14 +127,6 @@ const (
 	EnvSQLCert = "SQL_CERT"
 	// EnvSQLKey is the system env name for SQL key path.
 	EnvSQLKey = "SQL_KEY"
-	// EnvPodName is the system env name for pod name.
-	EnvPodName = "POD_NAME"
-	// EnvPodIP is the system env name for pod IP.
-	EnvPodIP = "POD_IP"
-	// EnvNamespace is the system env name for namespace.
-	EnvNamespace = "NAMESPACE"
-	// EnvManagerNs is the system env name for manager namespace.
-	EnvManagerNs = "MANAGER_NS"
 	// MaxTokenLimit is the max token limit value.
 	MaxTokenLimit  = 1024 * 1024
 	DefSchemaLease = 45 * time.Second
@@ -1586,6 +1578,9 @@ func (c *Config) Valid() error {
 	}
 	if c.KeyspaceActivateMode && c.DeployMode != deploymode.Starter {
 		return fmt.Errorf("keyspace-activate can only be configured for starter deploy mode")
+	}
+	if c.Standby.EnableManagerNotifier && c.DeployMode != deploymode.Starter {
+		return fmt.Errorf("standby.enable-manager-notifier can only be configured for starter deploy mode")
 	}
 	if c.DXFResourceLimit < MinDXFResourceLimit || c.DXFResourceLimit > MaxDXFResourceLimit {
 		return fmt.Errorf("dxf-resource-limit should be between %d and %d", MinDXFResourceLimit, MaxDXFResourceLimit)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -327,6 +327,8 @@ type Config struct {
 	// InitializeSQLFile is a file that will be executed after first bootstrap only.
 	// It can be used to set GLOBAL system variable values
 	InitializeSQLFile string `toml:"initialize-sql-file" json:"initialize-sql-file"`
+	// KeyspaceActivateMode indicates whether TiDB should exit after activating the keyspace.
+	KeyspaceActivateMode bool `toml:"keyspace-activate" json:"keyspace-activate"`
 	// Standby is the config for standby mode.
 	Standby Standby `toml:"standby" json:"standby"`
 
@@ -1578,6 +1580,12 @@ func (c *Config) Valid() error {
 	}
 	if !kerneltype.IsNextGen() && c.DeployMode != deploymode.Premium {
 		return fmt.Errorf("deploy-mode can only be configured for nextgen TiDB")
+	}
+	if c.Standby.StandByMode && c.KeyspaceActivateMode {
+		return fmt.Errorf("can't set standby and keyspace-activate mode at the same time")
+	}
+	if c.KeyspaceActivateMode && c.DeployMode != deploymode.Starter {
+		return fmt.Errorf("keyspace-activate can only be configured for starter deploy mode")
 	}
 	if c.DXFResourceLimit < MinDXFResourceLimit || c.DXFResourceLimit > MaxDXFResourceLimit {
 		return fmt.Errorf("dxf-resource-limit should be between %d and %d", MinDXFResourceLimit, MaxDXFResourceLimit)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -127,6 +127,14 @@ const (
 	EnvSQLCert = "SQL_CERT"
 	// EnvSQLKey is the system env name for SQL key path.
 	EnvSQLKey = "SQL_KEY"
+	// EnvPodName is the system env name for pod name.
+	EnvPodName = "POD_NAME"
+	// EnvPodIP is the system env name for pod IP.
+	EnvPodIP = "POD_IP"
+	// EnvNamespace is the system env name for namespace.
+	EnvNamespace = "NAMESPACE"
+	// EnvManagerNs is the system env name for manager namespace.
+	EnvManagerNs = "MANAGER_NS"
 	// MaxTokenLimit is the max token limit value.
 	MaxTokenLimit  = 1024 * 1024
 	DefSchemaLease = 45 * time.Second
@@ -137,6 +145,8 @@ const (
 	// DefMaxAllowedPacket is the default value of max_allowed_packet.
 	DefMaxAllowedPacket = 64 << 20
 	UnavailableIP       = "<nil>"
+	// DefaultManagerNamespace is the default namespace for TiDB manager in Starter deployments.
+	DefaultManagerNamespace = "tidb-admin"
 )
 
 // Valid config maps
@@ -1025,10 +1035,18 @@ type Standby struct {
 	MaxIdleSeconds uint `toml:"max-idle-seconds" json:"max-idle-seconds"`
 	// ActivationTimeout specifies the maximum allowed time for tidb to activate from standby mode.
 	ActivationTimeout uint `toml:"activation-timeout" json:"activation-timeout"`
+	// ExportID is the export identifier supplied by standby activation.
+	ExportID string `toml:"export-id" json:"export-id"`
 	// EnableZeroBackend is used to control the behavior of standby idle watcher.
 	// When it is enabled, the idle watcher will not wait for session migration
 	// and will not consider client interactive connections.
 	EnableZeroBackend bool `toml:"enable-zero-backend" json:"enable-zero-backend"`
+	// EnableManagerNotifier indicates whether standby shutdown should notify TiDB manager.
+	// It is only used in NextGen Starter deployments.
+	EnableManagerNotifier bool `toml:"enable-manager-notifier" json:"enable-manager-notifier"`
+	// ManagerAddr is the TiDB manager address used by the shutdown notifier.
+	// When empty and EnableManagerNotifier is true, the Starter path derives the default service address.
+	ManagerAddr string `toml:"manager-addr" json:"manager-addr"`
 }
 
 var defTiKVCfg = tikvcfg.DefaultConfig()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -322,7 +322,7 @@ type Config struct {
 	// Standby is the config for standby mode.
 	Standby Standby `toml:"standby" json:"standby"`
 	// StarterParams contains Starter-only extension parameters.
-	StarterParams StarterParams `toml:"starter" json:"starter"`
+	StarterParams StarterParams `toml:"starter-params" json:"starter-params"`
 
 	// The following items are deprecated. We need to keep them here temporarily
 	// to support the upgrade process. They can be removed in future.
@@ -1503,7 +1503,7 @@ func (c *Config) Load(confFile string) error {
 	if dxfResourceLimitDefined && c.DeployMode != deploymode.PremiumReserved {
 		return fmt.Errorf("dxf-resource-limit can only be configured when deploy-mode is premium_reserved")
 	}
-	if c.DeployMode == deploymode.Starter && !metaData.IsDefined("starter", "enable-zero-backend") {
+	if c.DeployMode == deploymode.Starter && !metaData.IsDefined("starter-params", "enable-zero-backend") {
 		c.StarterParams.EnableZeroBackend = true
 	}
 	if c.TokenLimit == 0 {
@@ -1584,7 +1584,7 @@ func (c *Config) Valid() error {
 		return fmt.Errorf("keyspace-activate can only be configured for starter deploy mode")
 	}
 	if c.StarterParams.EnableManagerNotifier && c.DeployMode != deploymode.Starter {
-		return fmt.Errorf("starter.enable-manager-notifier can only be configured for starter deploy mode")
+		return fmt.Errorf("starter-params.enable-manager-notifier can only be configured for starter deploy mode")
 	}
 	if c.DXFResourceLimit < MinDXFResourceLimit || c.DXFResourceLimit > MaxDXFResourceLimit {
 		return fmt.Errorf("dxf-resource-limit should be between %d and %d", MinDXFResourceLimit, MaxDXFResourceLimit)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,8 +137,6 @@ const (
 	// DefMaxAllowedPacket is the default value of max_allowed_packet.
 	DefMaxAllowedPacket = 64 << 20
 	UnavailableIP       = "<nil>"
-	// DefaultManagerNamespace is the default namespace for TiDB manager in Starter deployments.
-	DefaultManagerNamespace = "tidb-admin"
 )
 
 // Valid config maps
@@ -323,6 +321,8 @@ type Config struct {
 	KeyspaceActivateMode bool `toml:"keyspace-activate" json:"keyspace-activate"`
 	// Standby is the config for standby mode.
 	Standby Standby `toml:"standby" json:"standby"`
+	// StarterParams contains Starter-only extension parameters.
+	StarterParams StarterParams `toml:"starter" json:"starter"`
 
 	// The following items are deprecated. We need to keep them here temporarily
 	// to support the upgrade process. They can be removed in future.
@@ -1029,17 +1029,21 @@ type Standby struct {
 	MaxIdleSeconds uint `toml:"max-idle-seconds" json:"max-idle-seconds"`
 	// ActivationTimeout specifies the maximum allowed time for tidb to activate from standby mode.
 	ActivationTimeout uint `toml:"activation-timeout" json:"activation-timeout"`
+}
+
+// StarterParams contains Starter-only extension parameters.
+type StarterParams struct {
 	// ExportID is the export identifier supplied by standby activation.
 	ExportID string `toml:"export-id" json:"export-id"`
 	// EnableZeroBackend is used to control the behavior of standby idle watcher.
 	// When it is enabled, the idle watcher will not wait for session migration
 	// and will not consider client interactive connections.
 	EnableZeroBackend bool `toml:"enable-zero-backend" json:"enable-zero-backend"`
-	// EnableManagerNotifier indicates whether standby shutdown should notify TiDB manager.
+	// EnableManagerNotifier indicates whether Starter graceful shutdown should notify TiDB manager.
 	// It is only used in NextGen Starter deployments.
 	EnableManagerNotifier bool `toml:"enable-manager-notifier" json:"enable-manager-notifier"`
 	// ManagerAddr is the TiDB manager address used by the shutdown notifier.
-	// When empty and EnableManagerNotifier is true, the Starter path derives the default service address.
+	// When empty and EnableManagerNotifier is true, the Starter path derives the service address from starter additional params.
 	ManagerAddr string `toml:"manager-addr" json:"manager-addr"`
 }
 
@@ -1499,8 +1503,8 @@ func (c *Config) Load(confFile string) error {
 	if dxfResourceLimitDefined && c.DeployMode != deploymode.PremiumReserved {
 		return fmt.Errorf("dxf-resource-limit can only be configured when deploy-mode is premium_reserved")
 	}
-	if c.DeployMode == deploymode.Starter && !metaData.IsDefined("standby", "enable-zero-backend") {
-		c.Standby.EnableZeroBackend = true
+	if c.DeployMode == deploymode.Starter && !metaData.IsDefined("starter", "enable-zero-backend") {
+		c.StarterParams.EnableZeroBackend = true
 	}
 	if c.TokenLimit == 0 {
 		c.TokenLimit = 1000
@@ -1579,8 +1583,8 @@ func (c *Config) Valid() error {
 	if c.KeyspaceActivateMode && c.DeployMode != deploymode.Starter {
 		return fmt.Errorf("keyspace-activate can only be configured for starter deploy mode")
 	}
-	if c.Standby.EnableManagerNotifier && c.DeployMode != deploymode.Starter {
-		return fmt.Errorf("standby.enable-manager-notifier can only be configured for starter deploy mode")
+	if c.StarterParams.EnableManagerNotifier && c.DeployMode != deploymode.Starter {
+		return fmt.Errorf("starter.enable-manager-notifier can only be configured for starter deploy mode")
 	}
 	if c.DXFResourceLimit < MinDXFResourceLimit || c.DXFResourceLimit > MaxDXFResourceLimit {
 		return fmt.Errorf("dxf-resource-limit should be between %d and %d", MinDXFResourceLimit, MaxDXFResourceLimit)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1029,16 +1029,16 @@ type Standby struct {
 	MaxIdleSeconds uint `toml:"max-idle-seconds" json:"max-idle-seconds"`
 	// ActivationTimeout specifies the maximum allowed time for tidb to activate from standby mode.
 	ActivationTimeout uint `toml:"activation-timeout" json:"activation-timeout"`
+	// EnableZeroBackend is used to control the behavior of standby idle watcher.
+	// When it is enabled, the idle watcher will not wait for session migration
+	// and will not consider client interactive connections.
+	EnableZeroBackend bool `toml:"enable-zero-backend" json:"enable-zero-backend"`
 }
 
 // StarterParams contains Starter-only extension parameters.
 type StarterParams struct {
 	// ExportID is the export identifier supplied by standby activation.
 	ExportID string `toml:"export-id" json:"export-id"`
-	// EnableZeroBackend is used to control the behavior of standby idle watcher.
-	// When it is enabled, the idle watcher will not wait for session migration
-	// and will not consider client interactive connections.
-	EnableZeroBackend bool `toml:"enable-zero-backend" json:"enable-zero-backend"`
 	// EnableManagerNotifier indicates whether Starter graceful shutdown should notify TiDB manager.
 	// It is only used in NextGen Starter deployments.
 	EnableManagerNotifier bool `toml:"enable-manager-notifier" json:"enable-manager-notifier"`
@@ -1503,8 +1503,8 @@ func (c *Config) Load(confFile string) error {
 	if dxfResourceLimitDefined && c.DeployMode != deploymode.PremiumReserved {
 		return fmt.Errorf("dxf-resource-limit can only be configured when deploy-mode is premium_reserved")
 	}
-	if c.DeployMode == deploymode.Starter && !metaData.IsDefined("starter-params", "enable-zero-backend") {
-		c.StarterParams.EnableZeroBackend = true
+	if c.DeployMode == deploymode.Starter && !metaData.IsDefined("standby", "enable-zero-backend") {
+		c.Standby.EnableZeroBackend = true
 	}
 	if c.TokenLimit == 0 {
 		c.TokenLimit = 1000

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1121,7 +1121,7 @@ dxf-resource-limit = 101`), 0644))
 
 	conf = NewConfig()
 	conf.StarterParams.EnableManagerNotifier = true
-	require.ErrorContains(t, conf.Valid(), "starter.enable-manager-notifier can only be configured for starter deploy mode")
+	require.ErrorContains(t, conf.Valid(), "starter-params.enable-manager-notifier can only be configured for starter deploy mode")
 
 	require.NoError(t, os.WriteFile(configFile, []byte(`
 [standby]
@@ -1138,7 +1138,7 @@ max-idle-seconds = 60
 
 	require.NoError(t, os.WriteFile(configFile, []byte(`
 deploy-mode = "starter"
-[starter]
+[starter-params]
 enable-zero-backend = false
 `), 0644))
 	conf = NewConfig()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1119,6 +1119,10 @@ dxf-resource-limit = 101`), 0644))
 	require.True(t, conf.Standby.EnableZeroBackend)
 	require.NoError(t, conf.Valid())
 
+	conf = NewConfig()
+	conf.Standby.EnableManagerNotifier = true
+	require.ErrorContains(t, conf.Valid(), "standby.enable-manager-notifier can only be configured for starter deploy mode")
+
 	require.NoError(t, os.WriteFile(configFile, []byte(`
 deploy-mode = "starter"
 [standby]

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1211,6 +1211,24 @@ max-allowed-packet = %d`, packetSize)), 0644))
 	require.ErrorContains(t, conf.Load(configFile), `invalid deploy mode "unknown"`)
 }
 
+func TestKeyspaceActivateModeConfig(t *testing.T) {
+	if kerneltype.IsClassic() {
+		t.Skip("only for nextgen kernel")
+	}
+
+	conf := NewConfig()
+	conf.DeployMode = deploymode.Starter
+	conf.KeyspaceActivateMode = true
+	require.NoError(t, conf.Valid())
+
+	conf.Standby.StandByMode = true
+	require.ErrorContains(t, conf.Valid(), "can't set standby and keyspace-activate mode at the same time")
+
+	conf.Standby.StandByMode = false
+	conf.DeployMode = deploymode.Premium
+	require.ErrorContains(t, conf.Valid(), "keyspace-activate can only be configured for starter deploy mode")
+}
+
 func TestConflictInstanceConfig(t *testing.T) {
 	t.Cleanup(func() {
 		ConflictOptions = nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1116,7 +1116,7 @@ dxf-resource-limit = 101`), 0644))
 	conf = NewConfig()
 	require.NoError(t, conf.Load(configFile))
 	require.Equal(t, deploymode.Starter, conf.DeployMode)
-	require.True(t, conf.StarterParams.EnableZeroBackend)
+	require.True(t, conf.Standby.EnableZeroBackend)
 	require.NoError(t, conf.Valid())
 
 	conf = NewConfig()
@@ -1138,13 +1138,13 @@ max-idle-seconds = 60
 
 	require.NoError(t, os.WriteFile(configFile, []byte(`
 deploy-mode = "starter"
-[starter-params]
+[standby]
 enable-zero-backend = false
 `), 0644))
 	conf = NewConfig()
 	require.NoError(t, conf.Load(configFile))
 	require.Equal(t, deploymode.Starter, conf.DeployMode)
-	require.False(t, conf.StarterParams.EnableZeroBackend)
+	require.False(t, conf.Standby.EnableZeroBackend)
 	require.NoError(t, conf.Valid())
 
 	require.NoError(t, os.WriteFile(configFile, []byte(fmt.Sprintf(`deploy-mode = "starter"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1116,22 +1116,35 @@ dxf-resource-limit = 101`), 0644))
 	conf = NewConfig()
 	require.NoError(t, conf.Load(configFile))
 	require.Equal(t, deploymode.Starter, conf.DeployMode)
-	require.True(t, conf.Standby.EnableZeroBackend)
+	require.True(t, conf.StarterParams.EnableZeroBackend)
 	require.NoError(t, conf.Valid())
 
 	conf = NewConfig()
-	conf.Standby.EnableManagerNotifier = true
-	require.ErrorContains(t, conf.Valid(), "standby.enable-manager-notifier can only be configured for starter deploy mode")
+	conf.StarterParams.EnableManagerNotifier = true
+	require.ErrorContains(t, conf.Valid(), "starter.enable-manager-notifier can only be configured for starter deploy mode")
+
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+[standby]
+standby-mode = true
+activation-timeout = 30
+max-idle-seconds = 60
+`), 0644))
+	conf = NewConfig()
+	require.NoError(t, conf.Load(configFile))
+	require.True(t, conf.Standby.StandByMode)
+	require.Equal(t, uint(30), conf.Standby.ActivationTimeout)
+	require.Equal(t, uint(60), conf.Standby.MaxIdleSeconds)
+	require.NoError(t, conf.Valid())
 
 	require.NoError(t, os.WriteFile(configFile, []byte(`
 deploy-mode = "starter"
-[standby]
+[starter]
 enable-zero-backend = false
 `), 0644))
 	conf = NewConfig()
 	require.NoError(t, conf.Load(configFile))
 	require.Equal(t, deploymode.Starter, conf.DeployMode)
-	require.False(t, conf.Standby.EnableZeroBackend)
+	require.False(t, conf.StarterParams.EnableZeroBackend)
 	require.NoError(t, conf.Valid())
 
 	require.NoError(t, os.WriteFile(configFile, []byte(fmt.Sprintf(`deploy-mode = "starter"

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -231,6 +231,7 @@ go_test(
         "@com_github_tikv_client_go_v2//testutils",
         "@com_github_tikv_client_go_v2//tikv",
         "@com_github_tikv_client_go_v2//util",
+        "@org_uber_go_atomic//:atomic",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -402,14 +402,21 @@ func (cc *clientConn) Close() error {
 
 	cc.server.rwlock.Lock()
 	delete(cc.server.clients, cc.connectionID)
+	connections := len(cc.server.clients)
 	cc.server.rwlock.Unlock()
 	metrics.DDLClearTempIndexWrite(cc.connectionID)
-	return closeConn(cc)
+	return closeConn(cc, connections)
 }
 
 // closeConn is idempotent and thread-safe.
 // It will be called on the same `clientConn` more than once to avoid connection leak.
-func closeConn(cc *clientConn) error {
+func closeConn(cc *clientConn, connections int) error {
+	defer func() {
+		if deploymode.IsStarter() && connections == 0 && cc.server.zeroConnCond != nil && cc.server.StandbyController != nil {
+			cc.server.zeroConnCond.Broadcast()
+		}
+	}()
+
 	var err error
 	cc.closeOnce.Do(func() {
 		if cc.connectionID > 0 {
@@ -442,7 +449,7 @@ func closeConn(cc *clientConn) error {
 
 func (cc *clientConn) closeWithoutLock() error {
 	delete(cc.server.clients, cc.connectionID)
-	return closeConn(cc)
+	return closeConn(cc, len(cc.server.clients))
 }
 
 func (cc *clientConn) currentResourceGroupName() string {

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -402,21 +402,15 @@ func (cc *clientConn) Close() error {
 
 	cc.server.rwlock.Lock()
 	delete(cc.server.clients, cc.connectionID)
-	connections := len(cc.server.clients)
+	cc.server.notifyGracefulShutdownCondIfNeededLocked()
 	cc.server.rwlock.Unlock()
 	metrics.DDLClearTempIndexWrite(cc.connectionID)
-	return closeConn(cc, connections)
+	return closeConn(cc)
 }
 
 // closeConn is idempotent and thread-safe.
 // It will be called on the same `clientConn` more than once to avoid connection leak.
-func closeConn(cc *clientConn, connections int) error {
-	defer func() {
-		if deploymode.IsStarter() && connections == 0 && cc.server.zeroConnCond != nil && cc.server.StandbyController != nil {
-			cc.server.zeroConnCond.Broadcast()
-		}
-	}()
-
+func closeConn(cc *clientConn) error {
 	var err error
 	cc.closeOnce.Do(func() {
 		if cc.connectionID > 0 {
@@ -447,9 +441,11 @@ func closeConn(cc *clientConn, connections int) error {
 	return err
 }
 
+// closeWithoutLock removes cc from the server connection map. The caller must hold server.rwlock.
 func (cc *clientConn) closeWithoutLock() error {
 	delete(cc.server.clients, cc.connectionID)
-	return closeConn(cc, len(cc.server.clients))
+	cc.server.notifyGracefulShutdownCondIfNeededLocked()
+	return closeConn(cc)
 }
 
 func (cc *clientConn) currentResourceGroupName() string {

--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -2477,7 +2477,7 @@ func TestCloseConn(t *testing.T) {
 	for range numGoroutines {
 		go func() {
 			defer wg.Done()
-			err := closeConn(cc)
+			err := closeConn(cc, len(server.clients))
 			require.NoError(t, err)
 		}()
 	}

--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -2477,7 +2477,7 @@ func TestCloseConn(t *testing.T) {
 	for range numGoroutines {
 		go func() {
 			defer wg.Done()
-			err := closeConn(cc, len(server.clients))
+			err := closeConn(cc)
 			require.NoError(t, err)
 		}()
 	}

--- a/pkg/server/handler/BUILD.bazel
+++ b/pkg/server/handler/BUILD.bazel
@@ -1,8 +1,9 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "handler",
     srcs = [
+        "auto_id_owner_handler.go",
         "tikv_handler.go",
         "upgrade_handler.go",
         "util.go",
@@ -36,4 +37,13 @@ go_library(
         "@com_github_tikv_pd_client//opt",
         "@org_uber_go_zap//:zap",
     ],
+)
+
+go_test(
+    name = "handler_test",
+    timeout = "short",
+    srcs = ["auto_id_owner_handler_test.go"],
+    embed = [":handler"],
+    flaky = True,
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/server/handler/auto_id_owner_handler.go
+++ b/pkg/server/handler/auto_id_owner_handler.go
@@ -1,0 +1,49 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import "net/http"
+
+// AutoIDOwnerChecker is the server capability needed by AutoIDOwnerHandler.
+type AutoIDOwnerChecker interface {
+	Health() bool
+	IsAutoIDOwner() bool
+}
+
+// AutoIDOwnerHandler is the handler for checking whether this TiDB owns the auto ID service.
+type AutoIDOwnerHandler struct {
+	checker AutoIDOwnerChecker
+}
+
+type autoIDOwnerStatus struct {
+	IsOwner bool `json:"is_owner"`
+}
+
+// NewAutoIDOwnerHandler creates a new AutoIDOwnerHandler.
+func NewAutoIDOwnerHandler(checker AutoIDOwnerChecker) *AutoIDOwnerHandler {
+	return &AutoIDOwnerHandler{checker: checker}
+}
+
+// ServeHTTP checks whether this TiDB owns the auto ID service.
+func (h *AutoIDOwnerHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	if !h.checker.Health() {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	WriteData(w, autoIDOwnerStatus{
+		IsOwner: h.checker.IsAutoIDOwner(),
+	})
+}

--- a/pkg/server/handler/auto_id_owner_handler_test.go
+++ b/pkg/server/handler/auto_id_owner_handler_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAutoIDOwnerChecker struct {
+	healthy bool
+	owner   bool
+}
+
+func (c *fakeAutoIDOwnerChecker) Health() bool {
+	return c.healthy
+}
+
+func (c *fakeAutoIDOwnerChecker) IsAutoIDOwner() bool {
+	return c.owner
+}
+
+func TestAutoIDOwnerHandler(t *testing.T) {
+	checker := &fakeAutoIDOwnerChecker{healthy: true}
+	h := NewAutoIDOwnerHandler(checker)
+
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/owner_manager/auto_id_service", nil))
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.JSONEq(t, `{"is_owner": false}`, recorder.Body.String())
+
+	checker.owner = true
+	recorder = httptest.NewRecorder()
+	h.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/owner_manager/auto_id_service", nil))
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.JSONEq(t, `{"is_owner": true}`, recorder.Body.String())
+
+	checker.healthy = false
+	recorder = httptest.NewRecorder()
+	h.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/owner_manager/auto_id_service", nil))
+	require.Equal(t, http.StatusInternalServerError, recorder.Code)
+}

--- a/pkg/server/handler/tests/BUILD.bazel
+++ b/pkg/server/handler/tests/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 45,
+    shard_count = 46,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/server/handler/tests/BUILD.bazel
+++ b/pkg/server/handler/tests/BUILD.bazel
@@ -13,6 +13,7 @@ go_test(
     shard_count = 46,
     deps = [
         "//pkg/config",
+        "//pkg/config/deploymode",
         "//pkg/config/kerneltype",
         "//pkg/ddl",
         "//pkg/ddl/util",

--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -472,6 +472,17 @@ func TestDebugRoutes(t *testing.T) {
 	}
 }
 
+func TestAutoIDOwnerRouteNotRegisteredOutsideStarter(t *testing.T) {
+	ts := createBasicHTTPHandlerTestSuite()
+	ts.startServer(t)
+	defer ts.stopServer(t)
+
+	resp, err := ts.FetchStatus("/owner_manager/auto_id_service")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
 func TestFailpointHandler(t *testing.T) {
 	ts := createBasicHTTPHandlerTestSuite()
 

--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	ddlutil "github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -473,6 +474,10 @@ func TestDebugRoutes(t *testing.T) {
 }
 
 func TestAutoIDOwnerRouteNotRegisteredOutsideStarter(t *testing.T) {
+	if deploymode.IsStarter() {
+		t.Skip("auto-id owner route is registered in Starter mode")
+	}
+
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)

--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/deploymode"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	ddlutil "github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -473,19 +474,41 @@ func TestDebugRoutes(t *testing.T) {
 	}
 }
 
-func TestAutoIDOwnerRouteNotRegisteredOutsideStarter(t *testing.T) {
-	if deploymode.IsStarter() {
-		t.Skip("auto-id owner route is registered in Starter mode")
+func TestAutoIDOwnerRouteRegistration(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		originalMode := deploymode.Get()
+		require.NoError(t, deploymode.Set(deploymode.Premium))
+		defer func() {
+			require.NoError(t, deploymode.Set(originalMode))
+		}()
 	}
 
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
-	defer ts.stopServer(t)
-
 	resp, err := ts.FetchStatus("/owner_manager/auto_id_service")
 	require.NoError(t, err)
-	defer resp.Body.Close()
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	ts.stopServer(t)
+
+	// Starter deploy mode only exists for NextGen. In classic builds, deploymode.IsStarter()
+	// is always false, so only the non-Starter route-registration case applies.
+	if !kerneltype.IsNextGen() {
+		return
+	}
+
+	require.NoError(t, deploymode.Set(deploymode.Starter))
+	ts = createBasicHTTPHandlerTestSuite()
+	ts.startServer(t)
+	defer ts.stopServer(t)
+
+	resp, err = ts.FetchStatus("/owner_manager/auto_id_service")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.JSONEq(t, `{"is_owner": false}`, string(body))
 }
 
 func TestFailpointHandler(t *testing.T) {

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -684,8 +684,7 @@ type DetailStatus struct {
 	InitStatsPercentage float64 `json:"init_stats_percentage"`
 }
 
-// IsAutoIDServiceOwner is the response structure for checking if the auto ID service is the owner.
-type IsAutoIDServiceOwner struct {
+type autoIDServiceOwnerStatus struct {
 	IsOwner bool `json:"is_owner"`
 }
 
@@ -696,7 +695,7 @@ func (s *Server) handleCheckAutoIDOwner(w http.ResponseWriter, _ *http.Request) 
 		return
 	}
 
-	js, err := json.Marshal(IsAutoIDServiceOwner{
+	js, err := json.Marshal(autoIDServiceOwnerStatus{
 		IsOwner: s.IsAutoIDOwner(),
 	})
 	if err != nil {

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -44,6 +44,7 @@ import (
 	pb "github.com/pingcap/kvproto/pkg/autoid"
 	autoid "github.com/pingcap/tidb/pkg/autoid_service"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -281,6 +282,9 @@ func (s *Server) startHTTPServer() {
 
 	// HTTP path for upgrade operations.
 	router.Handle("/upgrade/{op}", handler.NewClusterUpgradeHandler(tikvHandlerTool.Store.(kv.Storage))).Name("upgrade operations")
+	if deploymode.IsStarter() {
+		router.HandleFunc("/owner_manager/auto_id_service", s.handleCheckAutoIDOwner).Name("isAutoIDServiceOwner")
+	}
 
 	// HTTP path for ingest configurations
 	router.Handle("/ingest/max-batch-split-ranges", tikvhandler.NewIngestConcurrencyHandler(
@@ -678,6 +682,30 @@ type Status struct {
 // DetailStatus is to show the detail status of TiDB. for example the init stats percentage.
 type DetailStatus struct {
 	InitStatsPercentage float64 `json:"init_stats_percentage"`
+}
+
+// IsAutoIDServiceOwner is the response structure for checking if the auto ID service is the owner.
+type IsAutoIDServiceOwner struct {
+	IsOwner bool `json:"is_owner"`
+}
+
+func (s *Server) handleCheckAutoIDOwner(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.health == nil || !s.health.Load() {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	js, err := json.Marshal(IsAutoIDServiceOwner{
+		IsOwner: s.IsAutoIDOwner(),
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		logutil.BgLogger().Warn("encode json failed", zap.Error(err))
+		return
+	}
+	_, err = w.Write(js)
+	terror.Log(errors.Trace(err))
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -283,7 +283,7 @@ func (s *Server) startHTTPServer() {
 	// HTTP path for upgrade operations.
 	router.Handle("/upgrade/{op}", handler.NewClusterUpgradeHandler(tikvHandlerTool.Store.(kv.Storage))).Name("upgrade operations")
 	if deploymode.IsStarter() {
-		router.HandleFunc("/owner_manager/auto_id_service", s.handleCheckAutoIDOwner).Name("isAutoIDServiceOwner")
+		router.Handle("/owner_manager/auto_id_service", handler.NewAutoIDOwnerHandler(s)).Name("isAutoIDServiceOwner")
 	}
 
 	// HTTP path for ingest configurations
@@ -682,29 +682,6 @@ type Status struct {
 // DetailStatus is to show the detail status of TiDB. for example the init stats percentage.
 type DetailStatus struct {
 	InitStatsPercentage float64 `json:"init_stats_percentage"`
-}
-
-type autoIDServiceOwnerStatus struct {
-	IsOwner bool `json:"is_owner"`
-}
-
-func (s *Server) handleCheckAutoIDOwner(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	if s.health == nil || !s.health.Load() {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	js, err := json.Marshal(autoIDServiceOwnerStatus{
-		IsOwner: s.IsAutoIDOwner(),
-	})
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		logutil.BgLogger().Warn("encode json failed", zap.Error(err))
-		return
-	}
-	_, err = w.Write(js)
-	terror.Log(errors.Trace(err))
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -641,8 +641,16 @@ func (s *Server) startShutdown() {
 		time.Sleep(waitTime)
 	}
 	if deploymode.IsStarter() && s.StandbyController != nil {
+		s.enterShutdownMode()
 		s.OnServerShutdown(s)
 	}
+}
+
+func (s *Server) enterShutdownMode() {
+	if s.inShutdownMode == nil {
+		s.inShutdownMode = uatomic.NewBool(false)
+	}
+	s.inShutdownMode.Store(true)
 }
 
 func (s *Server) closeListener() {
@@ -712,7 +720,7 @@ func (s *Server) Close() {
 	s.startShutdown()
 	s.rwlock.Lock() // // prevent new connections
 	defer s.rwlock.Unlock()
-	s.inShutdownMode.Store(true)
+	s.enterShutdownMode()
 	s.closeListener()
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -53,6 +53,7 @@ import (
 	"github.com/pingcap/log"
 	autoid "github.com/pingcap/tidb/pkg/autoid_service"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/executor/mppcoordmanager"
 	"github.com/pingcap/tidb/pkg/extension"
@@ -132,6 +133,8 @@ type Server struct {
 
 	rwlock  sync.RWMutex
 	clients map[uint64]*clientConn
+	// zeroConnCond is used by Starter graceful shutdown to wait until all connections are closed.
+	zeroConnCond *sync.Cond
 
 	normalClosedConnsMutex sync.Mutex
 	normalClosedConns      *kvcache.SimpleLRUCache
@@ -148,6 +151,7 @@ type Server struct {
 	grpcServer     *grpc.Server
 	inShutdownMode *uatomic.Bool
 	health         *uatomic.Bool
+	forceShutdown  *uatomic.Bool
 
 	sessionMapMutex     sync.Mutex
 	internalSessions    map[any]struct{}
@@ -155,6 +159,7 @@ type Server struct {
 	authTokenCancelFunc context.CancelFunc
 	wg                  sync.WaitGroup
 	printMDLLogTime     time.Time
+	needRequestMgrFree  *uatomic.Bool
 
 	StandbyController
 }
@@ -293,17 +298,20 @@ func (s *Server) newConn(conn net.Conn) *clientConn {
 // NewServer creates a new Server.
 func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 	s := &Server{
-		cfg:               cfg,
-		driver:            driver,
-		concurrentLimiter: util.NewTokenLimiter(cfg.TokenLimit),
-		clients:           make(map[uint64]*clientConn),
-		normalClosedConns: kvcache.NewSimpleLRUCache(normalClosedConnsCapacity, 0, 0),
-		userResource:      make(map[string]*userResourceLimits),
-		internalSessions:  make(map[any]struct{}, 100),
-		health:            uatomic.NewBool(false),
-		inShutdownMode:    uatomic.NewBool(false),
-		printMDLLogTime:   time.Now(),
+		cfg:                cfg,
+		driver:             driver,
+		concurrentLimiter:  util.NewTokenLimiter(cfg.TokenLimit),
+		clients:            make(map[uint64]*clientConn),
+		normalClosedConns:  kvcache.NewSimpleLRUCache(normalClosedConnsCapacity, 0, 0),
+		userResource:       make(map[string]*userResourceLimits),
+		internalSessions:   make(map[any]struct{}, 100),
+		health:             uatomic.NewBool(false),
+		inShutdownMode:     uatomic.NewBool(false),
+		forceShutdown:      uatomic.NewBool(false),
+		printMDLLogTime:    time.Now(),
+		needRequestMgrFree: uatomic.NewBool(false),
 	}
+	s.zeroConnCond = sync.NewCond(&s.rwlock)
 	s.capability = defaultCapability
 	setSystemTimeZoneVariable()
 
@@ -632,6 +640,9 @@ func (s *Server) startShutdown() {
 		logutil.BgLogger().Info("waiting for stray connections before starting shutdown process", zap.Duration("waitTime", waitTime))
 		time.Sleep(waitTime)
 	}
+	if deploymode.IsStarter() && s.StandbyController != nil {
+		s.OnServerShutdown(s)
+	}
 }
 
 func (s *Server) closeListener() {
@@ -654,14 +665,46 @@ func (s *Server) closeListener() {
 		s.grpcServer.Stop()
 		s.grpcServer = nil
 	}
-	if s.autoIDService != nil {
-		s.autoIDService.Close()
+	if !deploymode.IsStarter() || s.StandbyController == nil {
+		s.AutoIDServiceClose()
 	}
 	if s.authTokenCancelFunc != nil {
 		s.authTokenCancelFunc()
 	}
 	s.wg.Wait()
 	metrics.ServerEventCounter.WithLabelValues(metrics.ServerStop).Inc()
+}
+
+// SetForceShutdown sets the force shutdown flag.
+func (s *Server) SetForceShutdown() {
+	if s.forceShutdown == nil {
+		s.forceShutdown = uatomic.NewBool(false)
+	}
+	s.forceShutdown.Store(true)
+}
+
+// GetForceShutdown gets the force shutdown flag.
+func (s *Server) GetForceShutdown() bool {
+	if s.forceShutdown == nil {
+		return false
+	}
+	return s.forceShutdown.Load()
+}
+
+// SetNeedRequestMgrFree sets the need request manager free flag.
+func (s *Server) SetNeedRequestMgrFree() {
+	if s.needRequestMgrFree == nil {
+		s.needRequestMgrFree = uatomic.NewBool(false)
+	}
+	s.needRequestMgrFree.Store(true)
+}
+
+// GetNeedRequestMgrFree gets the need request manager free flag.
+func (s *Server) GetNeedRequestMgrFree() bool {
+	if s.needRequestMgrFree == nil {
+		return false
+	}
+	return s.needRequestMgrFree.Load()
 }
 
 // Close closes the server.
@@ -680,7 +723,7 @@ func (s *Server) registerConn(conn *clientConn) bool {
 	logger := logutil.BgLogger()
 	if s.inShutdownMode.Load() {
 		logger.Info("close connection directly when shutting down")
-		terror.Log(closeConn(conn))
+		terror.Log(closeConn(conn, len(s.clients)))
 		return false
 	}
 	s.clients[conn.connectionID] = conn
@@ -1275,4 +1318,28 @@ func (s *Server) GetStatusVars() map[uint64]map[string]string {
 // Health returns if the server is healthy (begin to shut down)
 func (s *Server) Health() bool {
 	return s.health.Load()
+}
+
+// AutoIDServiceClose closes the auto ID service.
+func (s *Server) AutoIDServiceClose() {
+	if s.autoIDService != nil {
+		s.autoIDService.Close()
+	}
+}
+
+// IsAutoIDOwner checks if the auto ID service is the owner.
+func (s *Server) IsAutoIDOwner() bool {
+	return s.autoIDService != nil && s.autoIDService.IsOwner()
+}
+
+// WaitZeroConn waits until all client connections are closed.
+func (s *Server) WaitZeroConn() {
+	if s.zeroConnCond == nil {
+		return
+	}
+	s.rwlock.Lock()
+	defer s.rwlock.Unlock()
+	for len(s.clients) > 0 {
+		s.zeroConnCond.Wait()
+	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -133,8 +133,8 @@ type Server struct {
 
 	rwlock  sync.RWMutex
 	clients map[uint64]*clientConn
-	// zeroConnCond is used by Starter graceful shutdown to wait until all connections are closed.
-	zeroConnCond *sync.Cond
+	// gracefulShutdownCond is used by Starter graceful shutdown to wait until all connections are closed.
+	gracefulShutdownCond *sync.Cond
 
 	normalClosedConnsMutex sync.Mutex
 	normalClosedConns      *kvcache.SimpleLRUCache
@@ -166,9 +166,16 @@ type Server struct {
 
 // NewTestServer creates a new Server for test.
 func NewTestServer(cfg *config.Config) *Server {
-	return &Server{
-		cfg: cfg,
+	s := &Server{
+		cfg:                cfg,
+		clients:            make(map[uint64]*clientConn),
+		health:             uatomic.NewBool(false),
+		inShutdownMode:     uatomic.NewBool(false),
+		forceShutdown:      uatomic.NewBool(false),
+		needRequestMgrFree: uatomic.NewBool(false),
 	}
+	s.gracefulShutdownCond = sync.NewCond(&s.rwlock)
+	return s
 }
 
 // Socket returns the server's socket file.
@@ -311,7 +318,7 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 		printMDLLogTime:    time.Now(),
 		needRequestMgrFree: uatomic.NewBool(false),
 	}
-	s.zeroConnCond = sync.NewCond(&s.rwlock)
+	s.gracefulShutdownCond = sync.NewCond(&s.rwlock)
 	s.capability = defaultCapability
 	setSystemTimeZoneVariable()
 
@@ -685,33 +692,21 @@ func (s *Server) closeListener() {
 
 // SetForceShutdown sets the force shutdown flag.
 func (s *Server) SetForceShutdown() {
-	if s.forceShutdown == nil {
-		s.forceShutdown = uatomic.NewBool(false)
-	}
 	s.forceShutdown.Store(true)
 }
 
 // GetForceShutdown gets the force shutdown flag.
 func (s *Server) GetForceShutdown() bool {
-	if s.forceShutdown == nil {
-		return false
-	}
 	return s.forceShutdown.Load()
 }
 
 // SetNeedRequestMgrFree sets the need request manager free flag.
 func (s *Server) SetNeedRequestMgrFree() {
-	if s.needRequestMgrFree == nil {
-		s.needRequestMgrFree = uatomic.NewBool(false)
-	}
 	s.needRequestMgrFree.Store(true)
 }
 
 // GetNeedRequestMgrFree gets the need request manager free flag.
 func (s *Server) GetNeedRequestMgrFree() bool {
-	if s.needRequestMgrFree == nil {
-		return false
-	}
 	return s.needRequestMgrFree.Load()
 }
 
@@ -731,11 +726,17 @@ func (s *Server) registerConn(conn *clientConn) bool {
 	logger := logutil.BgLogger()
 	if s.inShutdownMode.Load() {
 		logger.Info("close connection directly when shutting down")
-		terror.Log(closeConn(conn, len(s.clients)))
+		terror.Log(closeConn(conn))
 		return false
 	}
 	s.clients[conn.connectionID] = conn
 	return true
+}
+
+func (s *Server) notifyGracefulShutdownCondIfNeededLocked() {
+	if deploymode.IsStarter() && len(s.clients) == 0 && s.gracefulShutdownCond != nil && s.StandbyController != nil {
+		s.gracefulShutdownCond.Broadcast()
+	}
 }
 
 // onConn runs in its own goroutine, handles queries from this connection.
@@ -1102,8 +1103,8 @@ func (s *Server) KillSysProcesses() {
 func (s *Server) KillAllConnections() {
 	logutil.BgLogger().Info("kill all connections.", zap.String("category", "server"))
 
-	s.rwlock.RLock()
-	defer s.rwlock.RUnlock()
+	s.rwlock.Lock()
+	defer s.rwlock.Unlock()
 	for _, conn := range s.clients {
 		conn.setStatus(connStatusShutdown)
 		if err := conn.closeWithoutLock(); err != nil {
@@ -1342,12 +1343,12 @@ func (s *Server) IsAutoIDOwner() bool {
 
 // WaitZeroConn waits until all client connections are closed.
 func (s *Server) WaitZeroConn() {
-	if s.zeroConnCond == nil {
+	if s.gracefulShutdownCond == nil {
 		return
 	}
 	s.rwlock.Lock()
 	defer s.rwlock.Unlock()
 	for len(s.clients) > 0 {
-		s.zeroConnCond.Wait()
+		s.gracefulShutdownCond.Wait()
 	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -222,8 +222,9 @@ func TestServerShutdownFlags(t *testing.T) {
 }
 
 type mockStandbyController struct {
-	serverHealth bool
-	called       chan struct{}
+	serverHealth         bool
+	serverInShutdownMode bool
+	called               chan struct{}
 }
 
 func (c *mockStandbyController) WaitForActivate() {}
@@ -240,6 +241,7 @@ func (c *mockStandbyController) OnServerCreated(_ *Server) {}
 
 func (c *mockStandbyController) OnServerShutdown(svr *Server) {
 	c.serverHealth = svr.Health()
+	c.serverInShutdownMode = svr.inShutdownMode.Load()
 	close(c.called)
 }
 
@@ -256,12 +258,14 @@ func TestStartShutdownMarksUnhealthyBeforeStarterCallback(t *testing.T) {
 
 	svr := NewTestServer(util.NewTestConfig())
 	svr.health = uatomic.NewBool(true)
+	svr.inShutdownMode = uatomic.NewBool(false)
 	svr.StandbyController = &mockStandbyController{called: make(chan struct{})}
 
 	svr.startShutdown()
 
 	controller := svr.StandbyController.(*mockStandbyController)
 	require.False(t, controller.serverHealth)
+	require.True(t, controller.serverInShutdownMode)
 	select {
 	case <-controller.called:
 	default:

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -19,9 +19,12 @@ import (
 	"bytes"
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/config/deploymode"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/keyspace"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -36,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/replayer"
 	"github.com/stretchr/testify/require"
+	uatomic "go.uber.org/atomic"
 )
 
 type testStandbyController struct{}
@@ -51,6 +55,8 @@ func (*testStandbyController) Handler(*Server) (string, *http.ServeMux) {
 func (*testStandbyController) OnConnActive() {}
 
 func (*testStandbyController) OnServerCreated(*Server) {}
+
+func (*testStandbyController) OnServerShutdown(*Server) {}
 
 func TestIssue46197(t *testing.T) {
 	ctx := context.Background()
@@ -202,4 +208,78 @@ func TestSeverHealth(t *testing.T) {
 		// wait for server to be healthy
 	}
 	require.True(t, server.health.Load(), "server should be healthy")
+}
+
+func TestServerShutdownFlags(t *testing.T) {
+	svr := NewTestServer(util.NewTestConfig())
+	require.False(t, svr.GetForceShutdown())
+	require.False(t, svr.GetNeedRequestMgrFree())
+
+	svr.SetForceShutdown()
+	svr.SetNeedRequestMgrFree()
+	require.True(t, svr.GetForceShutdown())
+	require.True(t, svr.GetNeedRequestMgrFree())
+}
+
+type mockStandbyController struct {
+	serverHealth bool
+	called       chan struct{}
+}
+
+func (c *mockStandbyController) WaitForActivate() {}
+
+func (c *mockStandbyController) EndStandby(error) {}
+
+func (c *mockStandbyController) Handler(_ *Server) (string, *http.ServeMux) {
+	return "", nil
+}
+
+func (c *mockStandbyController) OnConnActive() {}
+
+func (c *mockStandbyController) OnServerCreated(_ *Server) {}
+
+func (c *mockStandbyController) OnServerShutdown(svr *Server) {
+	c.serverHealth = svr.Health()
+	close(c.called)
+}
+
+func TestStartShutdownMarksUnhealthyBeforeStarterCallback(t *testing.T) {
+	if kerneltype.IsClassic() {
+		t.Skip("only for nextgen kernel")
+	}
+
+	originalMode := deploymode.Get()
+	require.NoError(t, deploymode.Set(deploymode.Starter))
+	t.Cleanup(func() {
+		require.NoError(t, deploymode.Set(originalMode))
+	})
+
+	svr := NewTestServer(util.NewTestConfig())
+	svr.health = uatomic.NewBool(true)
+	svr.StandbyController = &mockStandbyController{called: make(chan struct{})}
+
+	svr.startShutdown()
+
+	controller := svr.StandbyController.(*mockStandbyController)
+	require.False(t, controller.serverHealth)
+	select {
+	case <-controller.called:
+	default:
+		require.Fail(t, "starter shutdown callback was not called")
+	}
+}
+
+func TestCheckAutoIDOwnerHandler(t *testing.T) {
+	svr := NewTestServer(util.NewTestConfig())
+	svr.health = uatomic.NewBool(true)
+
+	recorder := httptest.NewRecorder()
+	svr.handleCheckAutoIDOwner(recorder, httptest.NewRequest(http.MethodGet, "/owner_manager/auto_id_service", nil))
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.JSONEq(t, `{"is_owner": false}`, recorder.Body.String())
+
+	svr.health.Store(false)
+	recorder = httptest.NewRecorder()
+	svr.handleCheckAutoIDOwner(recorder, httptest.NewRequest(http.MethodGet, "/owner_manager/auto_id_service", nil))
+	require.Equal(t, http.StatusInternalServerError, recorder.Code)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -56,7 +56,7 @@ func (*testStandbyController) OnConnActive() {}
 
 func (*testStandbyController) OnServerCreated(*Server) {}
 
-func (*testStandbyController) OnServerShutdown(*Server) {}
+func (*testStandbyController) OnServerShutdown(StandbyShutdownServer) {}
 
 func TestIssue46197(t *testing.T) {
 	ctx := context.Background()
@@ -239,9 +239,10 @@ func (c *mockStandbyController) OnConnActive() {}
 
 func (c *mockStandbyController) OnServerCreated(_ *Server) {}
 
-func (c *mockStandbyController) OnServerShutdown(svr *Server) {
-	c.serverHealth = svr.Health()
-	c.serverInShutdownMode = svr.inShutdownMode.Load()
+func (c *mockStandbyController) OnServerShutdown(svr StandbyShutdownServer) {
+	server := svr.(*Server)
+	c.serverHealth = server.Health()
+	c.serverInShutdownMode = server.inShutdownMode.Load()
 	close(c.called)
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"path/filepath"
 	"testing"
 
@@ -272,19 +271,4 @@ func TestStartShutdownMarksUnhealthyBeforeStarterCallback(t *testing.T) {
 	default:
 		require.Fail(t, "starter shutdown callback was not called")
 	}
-}
-
-func TestCheckAutoIDOwnerHandler(t *testing.T) {
-	svr := NewTestServer(util.NewTestConfig())
-	svr.health = uatomic.NewBool(true)
-
-	recorder := httptest.NewRecorder()
-	svr.handleCheckAutoIDOwner(recorder, httptest.NewRequest(http.MethodGet, "/owner_manager/auto_id_service", nil))
-	require.Equal(t, http.StatusOK, recorder.Code)
-	require.JSONEq(t, `{"is_owner": false}`, recorder.Body.String())
-
-	svr.health.Store(false)
-	recorder = httptest.NewRecorder()
-	svr.handleCheckAutoIDOwner(recorder, httptest.NewRequest(http.MethodGet, "/owner_manager/auto_id_service", nil))
-	require.Equal(t, http.StatusInternalServerError, recorder.Code)
 }

--- a/pkg/server/standby.go
+++ b/pkg/server/standby.go
@@ -32,5 +32,16 @@ type StandbyController interface {
 	// OnServerCreated is called when the server is created.
 	OnServerCreated(svr *Server)
 	// OnServerShutdown is called when the server is going to shut down.
-	OnServerShutdown(svr *Server)
+	OnServerShutdown(svr StandbyShutdownServer)
+}
+
+// StandbyShutdownServer is the server capability used by standby shutdown control.
+type StandbyShutdownServer interface {
+	AutoIDServiceClose()
+	GetForceShutdown() bool
+	GetNeedRequestMgrFree() bool
+	IsAutoIDOwner() bool
+	SetForceShutdown()
+	SetNeedRequestMgrFree()
+	WaitZeroConn()
 }

--- a/pkg/server/standby.go
+++ b/pkg/server/standby.go
@@ -31,4 +31,6 @@ type StandbyController interface {
 	OnConnActive()
 	// OnServerCreated is called when the server is created.
 	OnServerCreated(svr *Server)
+	// OnServerShutdown is called when the server is going to shut down.
+	OnServerShutdown(svr *Server)
 }

--- a/pkg/server/tests/standby/standby_test.go
+++ b/pkg/server/tests/standby/standby_test.go
@@ -67,6 +67,9 @@ func (c *mockStandbyController) OnConnActive() {
 func (c *mockStandbyController) OnServerCreated(svr *server.Server) {
 }
 
+func (c *mockStandbyController) OnServerShutdown(svr *server.Server) {
+}
+
 func TestStandby(t *testing.T) {
 	standbyController := newMockStandbyController()
 	var svr *server.Server

--- a/pkg/server/tests/standby/standby_test.go
+++ b/pkg/server/tests/standby/standby_test.go
@@ -67,7 +67,7 @@ func (c *mockStandbyController) OnConnActive() {
 func (c *mockStandbyController) OnServerCreated(svr *server.Server) {
 }
 
-func (c *mockStandbyController) OnServerShutdown(svr *server.Server) {
+func (c *mockStandbyController) OnServerShutdown(svr server.StandbyShutdownServer) {
 }
 
 func TestStandby(t *testing.T) {

--- a/pkg/standby/BUILD.bazel
+++ b/pkg/standby/BUILD.bazel
@@ -27,7 +27,7 @@ go_test(
     srcs = ["standby_test.go"],
     embed = [":standby"],
     flaky = True,
-    shard_count = 5,
+    shard_count = 9,
     deps = [
         "//pkg/config",
         "//pkg/config/deploymode",

--- a/pkg/standby/BUILD.bazel
+++ b/pkg/standby/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "standby",
@@ -10,11 +10,29 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config",
+        "//pkg/config/deploymode",
         "//pkg/keyspace",
         "//pkg/parser/mysql",
         "//pkg/server",
+        "//pkg/tidbmanager",
         "//pkg/util/logutil",
         "//pkg/util/signal",
         "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "standby_test",
+    timeout = "short",
+    srcs = ["standby_test.go"],
+    embed = [":standby"],
+    flaky = True,
+    shard_count = 5,
+    deps = [
+        "//pkg/config",
+        "//pkg/config/deploymode",
+        "//pkg/config/kerneltype",
+        "//pkg/server",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/standby/BUILD.bazel
+++ b/pkg/standby/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/tidbmanager",
         "//pkg/util/logutil",
         "//pkg/util/signal",
+        "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/standby/idle_watcher.go
+++ b/pkg/standby/idle_watcher.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/server"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -82,6 +83,9 @@ func (c *LoadKeyspaceController) OnServerCreated(svr *server.Server) {
 				// And clientInteractiveCount don't need to be considered because session can be restored by gateway.
 				if config.GetGlobalConfig().Standby.EnableZeroBackend && (connCount == 0 || processCount == 0) && inTransCount == 0 {
 					SaveTidbNormalRestartInfo("connection idle for too long")
+					if deploymode.IsStarter() {
+						svr.SetNeedRequestMgrFree()
+					}
 					signal.TiDBExit(syscall.SIGTERM)
 				} else if (connCount == 0 || processCount == 0) && inTransCount == 0 && clientInteractiveCount == 0 {
 					SaveTidbNormalRestartInfo("connection idle for too long")

--- a/pkg/standby/idle_watcher.go
+++ b/pkg/standby/idle_watcher.go
@@ -81,7 +81,7 @@ func (c *LoadKeyspaceController) OnServerCreated(svr *server.Server) {
 
 				// if zero backend enabled. We shouldn't skip graceful shutdown to wait for session migration.
 				// And clientInteractiveCount don't need to be considered because session can be restored by gateway.
-				if deploymode.IsStarter() && config.GetGlobalConfig().StarterParams.EnableZeroBackend && (connCount == 0 || processCount == 0) && inTransCount == 0 {
+				if deploymode.IsStarter() && config.GetGlobalConfig().Standby.EnableZeroBackend && (connCount == 0 || processCount == 0) && inTransCount == 0 {
 					SaveTidbNormalRestartInfo("connection idle for too long")
 					svr.SetNeedRequestMgrFree()
 					signal.TiDBExit(syscall.SIGTERM)

--- a/pkg/standby/idle_watcher.go
+++ b/pkg/standby/idle_watcher.go
@@ -81,11 +81,9 @@ func (c *LoadKeyspaceController) OnServerCreated(svr *server.Server) {
 
 				// if zero backend enabled. We shouldn't skip graceful shutdown to wait for session migration.
 				// And clientInteractiveCount don't need to be considered because session can be restored by gateway.
-				if config.GetGlobalConfig().Standby.EnableZeroBackend && (connCount == 0 || processCount == 0) && inTransCount == 0 {
+				if deploymode.IsStarter() && config.GetGlobalConfig().StarterParams.EnableZeroBackend && (connCount == 0 || processCount == 0) && inTransCount == 0 {
 					SaveTidbNormalRestartInfo("connection idle for too long")
-					if deploymode.IsStarter() {
-						svr.SetNeedRequestMgrFree()
-					}
+					svr.SetNeedRequestMgrFree()
 					signal.TiDBExit(syscall.SIGTERM)
 				} else if (connCount == 0 || processCount == 0) && inTransCount == 0 && clientInteractiveCount == 0 {
 					SaveTidbNormalRestartInfo("connection idle for too long")

--- a/pkg/standby/standby.go
+++ b/pkg/standby/standby.go
@@ -23,22 +23,26 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/keyspace"
 	"github.com/pingcap/tidb/pkg/server"
+	"github.com/pingcap/tidb/pkg/tidbmanager"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/signal"
 	"go.uber.org/zap"
 )
 
 const (
-	standbyState   = "standby"
-	activatedState = "activated"
+	standbyState     = "standby"
+	activatedState   = "activated"
+	terminatingState = "terminating"
 
 	connNormalClosed         = "normal closed"
 	tidbNormalRestartLogPath = "/tmp/tidb-normal-restart.log"
@@ -49,6 +53,7 @@ const (
 // ActivateRequest is the request body for activating the tidb server.
 type ActivateRequest struct {
 	KeyspaceName   string `json:"keyspace_name"`
+	ExportID       string `json:"export_id"`
 	MaxIdleSeconds uint   `json:"max_idle_seconds"`
 
 	// analyze table
@@ -63,14 +68,20 @@ type LoadKeyspaceController struct {
 	serverStartCh  chan struct{}
 	startServerErr error
 	endOnce        sync.Once
+	mgrCli         tidbmanager.Client
 
 	lastActive int64
 }
 
 // NewLoadKeyspaceController creates a new StandbyController.
-func NewLoadKeyspaceController() *LoadKeyspaceController {
+func NewLoadKeyspaceController(mgrCli ...tidbmanager.Client) *LoadKeyspaceController {
+	var cli tidbmanager.Client
+	if len(mgrCli) > 0 {
+		cli = mgrCli[0]
+	}
 	return &LoadKeyspaceController{
 		serverStartCh: make(chan struct{}),
+		mgrCli:        cli,
 	}
 }
 
@@ -145,6 +156,11 @@ func loadTiDBNormalRestartInfoAndRemove() {
 	}
 }
 
+// LoadTiDBNormalRestartLog loads the tidb normal restart log file.
+func LoadTiDBNormalRestartLog() ([]byte, error) {
+	return os.ReadFile(tidbNormalRestartLogPath)
+}
+
 // SaveTidbNormalRestartInfo saves tidb normal restart info to file.
 func SaveTidbNormalRestartInfo(msg string) {
 	keyspaceName := keyspace.GetKeyspaceNameBySettings()
@@ -187,6 +203,14 @@ func (c *LoadKeyspaceController) Handler(svr *server.Server) (string, *http.Serv
 			state = activatedState
 			activateRequest = req
 			activateCh <- struct{}{}
+		case deploymode.IsStarter() && state == terminatingState:
+			mu.Unlock()
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, err := w.Write([]byte("server is going to shutdown"))
+			if err != nil {
+				logutil.BgLogger().Warn("failed to write response", zap.Error(err))
+			}
+			return
 		case svr != nil && !svr.Health():
 			mu.Unlock()
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -243,12 +267,88 @@ func (c *LoadKeyspaceController) Handler(svr *server.Server) (string, *http.Serv
 	})
 	// Terminate the tidb server by sending a request. For example, in a cloud environment, we may need to delete pod to free up resources.
 	mux.HandleFunc(httpPathPrefix+"exit", keyspaceValidateMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logutil.BgLogger().Info("receiving exit request")
+		gracefulStr, waitStr := r.URL.Query().Get("graceful"), r.URL.Query().Get("wait")
+		var graceful bool
+		if gracefulStr != "" {
+			var err error
+			graceful, err = strconv.ParseBool(gracefulStr)
+			if err != nil {
+				http.Error(w, "invalid graceful", http.StatusBadRequest)
+				return
+			}
+		}
+		var wait int64
+		if waitStr != "" {
+			var err error
+			wait, err = strconv.ParseInt(waitStr, 10, 64)
+			if err != nil || wait < 0 {
+				http.Error(w, "invalid wait", http.StatusBadRequest)
+				return
+			}
+		}
+		skipAutoIDOwnerStr := r.URL.Query().Get("skip_auto_id_owner")
+		var skipAutoIDOwner bool
+		if skipAutoIDOwnerStr != "" {
+			var err error
+			skipAutoIDOwner, err = strconv.ParseBool(skipAutoIDOwnerStr)
+			if err != nil {
+				http.Error(w, "invalid skip_auto_id_owner", http.StatusBadRequest)
+				return
+			}
+		}
+		needMgrFreeStr := r.URL.Query().Get("need_mgr_free")
+		var needMgrFree bool
+		if needMgrFreeStr != "" {
+			var err error
+			needMgrFree, err = strconv.ParseBool(needMgrFreeStr)
+			if err != nil {
+				http.Error(w, "invalid need_mgr_free", http.StatusBadRequest)
+				return
+			}
+		}
+		logutil.BgLogger().Info("receiving exit request",
+			zap.Bool("graceful", graceful),
+			zap.Int64("wait", wait),
+			zap.Bool("skip_auto_id_owner", skipAutoIDOwner),
+			zap.Bool("need_mgr_free", needMgrFree),
+		)
 		if svr != nil {
+			if deploymode.IsStarter() {
+				if skipAutoIDOwner && svr.IsAutoIDOwner() {
+					logutil.BgLogger().Info("auto id service is owner, skip exit")
+					w.WriteHeader(http.StatusNotModified)
+					_, err := w.Write([]byte("auto id service is owner"))
+					if err != nil {
+						logutil.BgLogger().Warn("failed to write response", zap.Error(err))
+					}
+					return
+				}
+				if !graceful {
+					svr.SetForceShutdown()
+					SaveTidbNormalRestartInfo("received force exit request")
+					w.WriteHeader(http.StatusOK)
+					// Consider the server is going to force shutdown, send a high priority signal to kill tidb.
+					signal.TiDBExit(syscall.SIGINT)
+					return
+				}
+				if wait > 0 {
+					_ = os.Setenv("GracefulCloseConnectionsTimeout", fmt.Sprintf("%ds", wait))
+				}
+				if !needMgrFree {
+					w.WriteHeader(http.StatusOK)
+					signal.TiDBExit(syscall.SIGINT)
+					return
+				}
+				svr.SetNeedRequestMgrFree()
+			}
 			SaveTidbNormalRestartInfo("received exit request")
 		}
 		w.WriteHeader(http.StatusOK)
-		// Consider the server is going to fore shutdown, send a high priority signal to kill tidb.
+		if deploymode.IsStarter() {
+			signal.TiDBExit(syscall.SIGTERM)
+			return
+		}
+		// Consider the server is going to force shutdown, send a high priority signal to kill tidb.
 		signal.TiDBExit(syscall.SIGINT)
 	})))
 	mux.HandleFunc(httpPathPrefix+"checkconn", func(w http.ResponseWriter, r *http.Request) {
@@ -293,9 +393,15 @@ func (c *LoadKeyspaceController) Handler(svr *server.Server) (string, *http.Serv
 func statusHandler(w http.ResponseWriter, r *http.Request) {
 	mu.RLock()
 	defer mu.RUnlock()
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
-	_, err := fmt.Fprintf(w, `{"state": "%s", "keyspace_name": "%s"}`, state, activateRequest.KeyspaceName)
+	w.WriteHeader(http.StatusOK)
+	var err error
+	if deploymode.IsStarter() && activateRequest.ExportID != "" {
+		_, err = fmt.Fprintf(w, `{"state": "%s", "keyspace_name": "%s", "export_id": "%s"}`,
+			state, activateRequest.KeyspaceName, activateRequest.ExportID)
+	} else {
+		_, err = fmt.Fprintf(w, `{"state": "%s", "keyspace_name": "%s"}`, state, activateRequest.KeyspaceName)
+	}
 	if err != nil {
 		logutil.BgLogger().Error("failed to write response", zap.Error(err))
 	}
@@ -353,6 +459,9 @@ func (c *LoadKeyspaceController) WaitForActivate() {
 
 	config.UpdateGlobal(func(c *config.Config) {
 		c.KeyspaceName = activateRequest.KeyspaceName
+		if deploymode.IsStarter() && activateRequest.ExportID != "" {
+			c.Standby.ExportID = activateRequest.ExportID
+		}
 		if activateRequest.MaxIdleSeconds > 0 {
 			c.Standby.MaxIdleSeconds = activateRequest.MaxIdleSeconds
 		}
@@ -387,4 +496,53 @@ func (c *LoadKeyspaceController) EndStandby(err error) {
 
 // OnServerShutdown is called when the server is going to shut down.
 func (c *LoadKeyspaceController) OnServerShutdown(svr *server.Server) {
+	if !deploymode.IsStarter() {
+		return
+	}
+
+	mu.Lock()
+	state = terminatingState
+	mu.Unlock()
+
+	// Give up auto ID ownership before waiting for TiProxy to migrate traffic.
+	svr.AutoIDServiceClose()
+
+	if c.mgrCli != nil && svr.GetNeedRequestMgrFree() {
+		exitReason, err := LoadTiDBNormalRestartLog()
+		if err != nil && !os.IsNotExist(err) {
+			exitReason = []byte(fmt.Sprintf("failed to load normal restart log: %v", err))
+			logutil.BgLogger().Warn("failed to load tidb normal restart log", zap.ByteString("exitReason", exitReason))
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), tidbmanager.DefaultTimeout)
+		defer cancel()
+		if err := c.mgrCli.Free(ctx, string(exitReason)); err != nil {
+			logutil.BgLogger().Info("failed to report free", zap.Error(err))
+		}
+	}
+
+	if svr.GetForceShutdown() {
+		return
+	}
+
+	maxWaitTime, err := time.ParseDuration(os.Getenv("GracefulCloseConnectionsTimeout"))
+	if err != nil {
+		logutil.BgLogger().Info("failed to parse GracefulCloseConnectionsTimeout env", zap.Error(err))
+		return
+	}
+	if maxWaitTime <= 0 {
+		return
+	}
+
+	logutil.BgLogger().Info("waiting for tiproxy to migrate and close all connections", zap.Duration("maxWaitTime", maxWaitTime))
+	done := make(chan struct{}, 1)
+	go func() {
+		svr.WaitZeroConn()
+		done <- struct{}{}
+	}()
+	select {
+	case <-time.After(maxWaitTime):
+		logutil.BgLogger().Info("tiproxy connection close timed out")
+	case <-done:
+		logutil.BgLogger().Info("tiproxy has closed all connections")
+	}
 }

--- a/pkg/standby/standby.go
+++ b/pkg/standby/standby.go
@@ -625,5 +625,5 @@ func (c *LoadKeyspaceController) reportManagerFree(exitReason string) {
 		}
 		return
 	}
-	logutil.BgLogger().Error("failed to report free after retries", zap.Error(lastErr))
+	logutil.BgLogger().Warn("failed to report free after retries", zap.Error(lastErr))
 }

--- a/pkg/standby/standby.go
+++ b/pkg/standby/standby.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -69,6 +70,7 @@ type LoadKeyspaceController struct {
 	startServerErr error
 	endOnce        sync.Once
 	mgrCli         tidbmanager.Client
+	closeConnWait  atomic.Int64
 
 	lastActive int64
 }
@@ -331,9 +333,7 @@ func (c *LoadKeyspaceController) Handler(svr *server.Server) (string, *http.Serv
 					signal.TiDBExit(syscall.SIGINT)
 					return
 				}
-				if wait > 0 {
-					_ = os.Setenv("GracefulCloseConnectionsTimeout", fmt.Sprintf("%ds", wait))
-				}
+				c.setCloseConnWait(wait)
 				if !needMgrFree {
 					w.WriteHeader(http.StatusOK)
 					signal.TiDBExit(syscall.SIGINT)
@@ -405,6 +405,18 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logutil.BgLogger().Error("failed to write response", zap.Error(err))
 	}
+}
+
+func (c *LoadKeyspaceController) setCloseConnWait(waitSeconds int64) {
+	if waitSeconds <= 0 {
+		c.closeConnWait.Store(0)
+		return
+	}
+	c.closeConnWait.Store(int64(time.Duration(waitSeconds) * time.Second))
+}
+
+func (c *LoadKeyspaceController) getCloseConnWait() time.Duration {
+	return time.Duration(c.closeConnWait.Load())
 }
 
 var httpServer *http.Server
@@ -524,11 +536,7 @@ func (c *LoadKeyspaceController) OnServerShutdown(svr *server.Server) {
 		return
 	}
 
-	maxWaitTime, err := time.ParseDuration(os.Getenv("GracefulCloseConnectionsTimeout"))
-	if err != nil {
-		logutil.BgLogger().Info("failed to parse GracefulCloseConnectionsTimeout env", zap.Error(err))
-		return
-	}
+	maxWaitTime := c.getCloseConnWait()
 	if maxWaitTime <= 0 {
 		return
 	}

--- a/pkg/standby/standby.go
+++ b/pkg/standby/standby.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -49,7 +50,16 @@ const (
 	tidbNormalRestartLogPath = "/tmp/tidb-normal-restart.log"
 
 	httpPathPrefix = "/tidb-pool/"
+
+	maxCloseConnWait = time.Hour
+
+	maxRepresentableCloseConnWaitSeconds = int64(1<<63-1) / int64(time.Second)
+
+	managerFreeMaxAttempts   = 3
+	managerFreeRetryInterval = 200 * time.Millisecond
 )
+
+var tidbExit = signal.TiDBExit
 
 // ActivateRequest is the request body for activating the tidb server.
 type ActivateRequest struct {
@@ -76,14 +86,11 @@ type LoadKeyspaceController struct {
 }
 
 // NewLoadKeyspaceController creates a new StandbyController.
-func NewLoadKeyspaceController(mgrCli ...tidbmanager.Client) *LoadKeyspaceController {
-	var cli tidbmanager.Client
-	if len(mgrCli) > 0 {
-		cli = mgrCli[0]
-	}
+// mgrCli can be nil when manager notification is disabled.
+func NewLoadKeyspaceController(mgrCli tidbmanager.Client) *LoadKeyspaceController {
 	return &LoadKeyspaceController{
 		serverStartCh: make(chan struct{}),
-		mgrCli:        cli,
+		mgrCli:        mgrCli,
 	}
 }
 
@@ -105,6 +112,27 @@ var activateCh = make(chan struct{}, 1)
 type KeyspaceMismatch struct {
 	Remote string `json:"remote"`
 	Local  string `json:"local"`
+}
+
+type statusResponse struct {
+	State        string `json:"state"`
+	KeyspaceName string `json:"keyspace_name"`
+	ExportID     string `json:"export_id,omitempty"`
+}
+
+type exitOptions struct {
+	graceful        bool
+	wait            time.Duration
+	skipAutoIDOwner bool
+	needMgrFree     bool
+}
+
+type invalidExitOptionError struct {
+	option string
+}
+
+func (e invalidExitOptionError) Error() string {
+	return "invalid " + e.option
 }
 
 func keyspaceValidateMiddleware(next http.Handler) http.HandlerFunc {
@@ -158,8 +186,7 @@ func loadTiDBNormalRestartInfoAndRemove() {
 	}
 }
 
-// LoadTiDBNormalRestartLog loads the tidb normal restart log file.
-func LoadTiDBNormalRestartLog() ([]byte, error) {
+func loadTiDBNormalRestartLog() ([]byte, error) {
 	return os.ReadFile(tidbNormalRestartLogPath)
 }
 
@@ -242,7 +269,7 @@ func (c *LoadKeyspaceController) Handler(svr *server.Server) (string, *http.Serv
 		case <-r.Context().Done(): // client closed connection.
 			go func() {
 				c.EndStandby(errors.New("client closed connection"))
-				signal.TiDBExit(syscall.SIGTERM)
+				tidbExit(syscall.SIGTERM)
 			}()
 		case <-timeout: // reach hardlimit timeout from config.
 			logutil.BgLogger().Warn("timeout waiting for activation")
@@ -253,7 +280,7 @@ func (c *LoadKeyspaceController) Handler(svr *server.Server) (string, *http.Serv
 			}
 			go func() {
 				c.EndStandby(errors.New("timeout waiting for activation"))
-				signal.TiDBExit(syscall.SIGTERM)
+				tidbExit(syscall.SIGTERM)
 			}()
 		case <-c.serverStartCh:
 			if c.startServerErr != nil {
@@ -269,54 +296,24 @@ func (c *LoadKeyspaceController) Handler(svr *server.Server) (string, *http.Serv
 	})
 	// Terminate the tidb server by sending a request. For example, in a cloud environment, we may need to delete pod to free up resources.
 	mux.HandleFunc(httpPathPrefix+"exit", keyspaceValidateMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gracefulStr, waitStr := r.URL.Query().Get("graceful"), r.URL.Query().Get("wait")
-		var graceful bool
-		if gracefulStr != "" {
-			var err error
-			graceful, err = strconv.ParseBool(gracefulStr)
-			if err != nil {
-				http.Error(w, "invalid graceful", http.StatusBadRequest)
-				return
-			}
-		}
-		var wait int64
-		if waitStr != "" {
-			var err error
-			wait, err = strconv.ParseInt(waitStr, 10, 64)
-			if err != nil || wait < 0 {
-				http.Error(w, "invalid wait", http.StatusBadRequest)
-				return
-			}
-		}
-		skipAutoIDOwnerStr := r.URL.Query().Get("skip_auto_id_owner")
-		var skipAutoIDOwner bool
-		if skipAutoIDOwnerStr != "" {
-			var err error
-			skipAutoIDOwner, err = strconv.ParseBool(skipAutoIDOwnerStr)
-			if err != nil {
-				http.Error(w, "invalid skip_auto_id_owner", http.StatusBadRequest)
-				return
-			}
-		}
-		needMgrFreeStr := r.URL.Query().Get("need_mgr_free")
-		var needMgrFree bool
-		if needMgrFreeStr != "" {
-			var err error
-			needMgrFree, err = strconv.ParseBool(needMgrFreeStr)
-			if err != nil {
-				http.Error(w, "invalid need_mgr_free", http.StatusBadRequest)
-				return
-			}
+		options, err := parseExitOptions(r.URL.Query())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 		logutil.BgLogger().Info("receiving exit request",
-			zap.Bool("graceful", graceful),
-			zap.Int64("wait", wait),
-			zap.Bool("skip_auto_id_owner", skipAutoIDOwner),
-			zap.Bool("need_mgr_free", needMgrFree),
+			zap.Bool("graceful", options.graceful),
+			zap.Duration("wait", options.wait),
+			zap.Bool("skip_auto_id_owner", options.skipAutoIDOwner),
+			zap.Bool("need_mgr_free", options.needMgrFree),
 		)
 		if svr != nil {
 			if deploymode.IsStarter() {
-				if skipAutoIDOwner && svr.IsAutoIDOwner() {
+				if options.needMgrFree && c.mgrCli == nil {
+					http.Error(w, "manager notifier is unavailable", http.StatusServiceUnavailable)
+					return
+				}
+				if options.skipAutoIDOwner && svr.IsAutoIDOwner() {
 					logutil.BgLogger().Info("auto id service is owner, skip exit")
 					w.WriteHeader(http.StatusNotModified)
 					_, err := w.Write([]byte("auto id service is owner"))
@@ -325,31 +322,28 @@ func (c *LoadKeyspaceController) Handler(svr *server.Server) (string, *http.Serv
 					}
 					return
 				}
-				if !graceful {
+				if !options.graceful {
 					svr.SetForceShutdown()
 					SaveTidbNormalRestartInfo("received force exit request")
 					w.WriteHeader(http.StatusOK)
 					// Consider the server is going to force shutdown, send a high priority signal to kill tidb.
-					signal.TiDBExit(syscall.SIGINT)
+					tidbExit(syscall.SIGINT)
 					return
 				}
-				c.setCloseConnWait(wait)
-				if !needMgrFree {
-					w.WriteHeader(http.StatusOK)
-					signal.TiDBExit(syscall.SIGINT)
-					return
+				c.setCloseConnWait(options.wait)
+				if options.needMgrFree {
+					svr.SetNeedRequestMgrFree()
 				}
-				svr.SetNeedRequestMgrFree()
 			}
 			SaveTidbNormalRestartInfo("received exit request")
 		}
 		w.WriteHeader(http.StatusOK)
 		if deploymode.IsStarter() {
-			signal.TiDBExit(syscall.SIGTERM)
+			tidbExit(syscall.SIGTERM)
 			return
 		}
 		// Consider the server is going to force shutdown, send a high priority signal to kill tidb.
-		signal.TiDBExit(syscall.SIGINT)
+		tidbExit(syscall.SIGINT)
 	})))
 	mux.HandleFunc(httpPathPrefix+"checkconn", func(w http.ResponseWriter, r *http.Request) {
 		keyspaceName, connID := r.URL.Query().Get("keyspace_name"), r.URL.Query().Get("conn_id")
@@ -390,29 +384,79 @@ func (c *LoadKeyspaceController) Handler(svr *server.Server) (string, *http.Serv
 	return httpPathPrefix, mux
 }
 
+func parseExitOptions(query url.Values) (exitOptions, error) {
+	graceful, err := parseExitBool(query.Get("graceful"), "graceful")
+	if err != nil {
+		return exitOptions{}, err
+	}
+	skipAutoIDOwner, err := parseExitBool(query.Get("skip_auto_id_owner"), "skip_auto_id_owner")
+	if err != nil {
+		return exitOptions{}, err
+	}
+	needMgrFree, err := parseExitBool(query.Get("need_mgr_free"), "need_mgr_free")
+	if err != nil {
+		return exitOptions{}, err
+	}
+	wait, err := parseExitWait(query.Get("wait"))
+	if err != nil {
+		return exitOptions{}, err
+	}
+	return exitOptions{
+		graceful:        graceful,
+		wait:            wait,
+		skipAutoIDOwner: skipAutoIDOwner,
+		needMgrFree:     needMgrFree,
+	}, nil
+}
+
+func parseExitBool(value, name string) (bool, error) {
+	if value == "" {
+		return false, nil
+	}
+	ret, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, invalidExitOptionError{option: name}
+	}
+	return ret, nil
+}
+
+func parseExitWait(value string) (time.Duration, error) {
+	if value == "" {
+		return 0, nil
+	}
+	waitSeconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || waitSeconds < 0 {
+		return 0, invalidExitOptionError{option: "wait"}
+	}
+	if waitSeconds == 0 {
+		return 0, nil
+	}
+	if waitSeconds > maxRepresentableCloseConnWaitSeconds || waitSeconds > int64(maxCloseConnWait/time.Second) {
+		return 0, invalidExitOptionError{option: "wait"}
+	}
+	return time.Duration(waitSeconds) * time.Second, nil
+}
+
 func statusHandler(w http.ResponseWriter, r *http.Request) {
 	mu.RLock()
 	defer mu.RUnlock()
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	var err error
-	if deploymode.IsStarter() && activateRequest.ExportID != "" {
-		_, err = fmt.Fprintf(w, `{"state": "%s", "keyspace_name": "%s", "export_id": "%s"}`,
-			state, activateRequest.KeyspaceName, activateRequest.ExportID)
-	} else {
-		_, err = fmt.Fprintf(w, `{"state": "%s", "keyspace_name": "%s"}`, state, activateRequest.KeyspaceName)
+	resp := statusResponse{
+		State:        state,
+		KeyspaceName: activateRequest.KeyspaceName,
 	}
+	if deploymode.IsStarter() && activateRequest.ExportID != "" {
+		resp.ExportID = activateRequest.ExportID
+	}
+	w.WriteHeader(http.StatusOK)
+	err := json.NewEncoder(w).Encode(resp)
 	if err != nil {
 		logutil.BgLogger().Error("failed to write response", zap.Error(err))
 	}
 }
 
-func (c *LoadKeyspaceController) setCloseConnWait(waitSeconds int64) {
-	if waitSeconds <= 0 {
-		c.closeConnWait.Store(0)
-		return
-	}
-	c.closeConnWait.Store(int64(time.Duration(waitSeconds) * time.Second))
+func (c *LoadKeyspaceController) setCloseConnWait(wait time.Duration) {
+	c.closeConnWait.Store(int64(wait))
 }
 
 func (c *LoadKeyspaceController) getCloseConnWait() time.Duration {
@@ -507,7 +551,7 @@ func (c *LoadKeyspaceController) EndStandby(err error) {
 }
 
 // OnServerShutdown is called when the server is going to shut down.
-func (c *LoadKeyspaceController) OnServerShutdown(svr *server.Server) {
+func (c *LoadKeyspaceController) OnServerShutdown(svr server.StandbyShutdownServer) {
 	if !deploymode.IsStarter() {
 		return
 	}
@@ -519,17 +563,13 @@ func (c *LoadKeyspaceController) OnServerShutdown(svr *server.Server) {
 	// Give up auto ID ownership before waiting for TiProxy to migrate traffic.
 	svr.AutoIDServiceClose()
 
-	if c.mgrCli != nil && svr.GetNeedRequestMgrFree() {
-		exitReason, err := LoadTiDBNormalRestartLog()
+	if svr.GetNeedRequestMgrFree() {
+		exitReason, err := loadTiDBNormalRestartLog()
 		if err != nil && !os.IsNotExist(err) {
 			exitReason = []byte(fmt.Sprintf("failed to load normal restart log: %v", err))
 			logutil.BgLogger().Warn("failed to load tidb normal restart log", zap.ByteString("exitReason", exitReason))
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), tidbmanager.DefaultTimeout)
-		defer cancel()
-		if err := c.mgrCli.Free(ctx, string(exitReason)); err != nil {
-			logutil.BgLogger().Info("failed to report free", zap.Error(err))
-		}
+		c.reportManagerFree(string(exitReason))
 	}
 
 	if svr.GetForceShutdown() {
@@ -553,4 +593,37 @@ func (c *LoadKeyspaceController) OnServerShutdown(svr *server.Server) {
 	case <-done:
 		logutil.BgLogger().Info("tiproxy has closed all connections")
 	}
+}
+
+func (c *LoadKeyspaceController) reportManagerFree(exitReason string) {
+	if c.mgrCli == nil {
+		logutil.BgLogger().Warn("manager notifier is unavailable")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), tidbmanager.DefaultTimeout)
+	defer cancel()
+	var lastErr error
+	for attempt := 1; attempt <= managerFreeMaxAttempts; attempt++ {
+		if err := c.mgrCli.Free(ctx, exitReason); err != nil {
+			lastErr = err
+			logutil.BgLogger().Warn("failed to report free",
+				zap.Int("attempt", attempt),
+				zap.Int("maxAttempts", managerFreeMaxAttempts),
+				zap.Error(err))
+			if attempt < managerFreeMaxAttempts {
+				select {
+				case <-ctx.Done():
+					logutil.BgLogger().Warn("manager free report timed out", zap.Error(ctx.Err()))
+					return
+				case <-time.After(managerFreeRetryInterval):
+				}
+			}
+			continue
+		}
+		if attempt > 1 {
+			logutil.BgLogger().Info("reported free after retry", zap.Int("attempt", attempt))
+		}
+		return
+	}
+	logutil.BgLogger().Error("failed to report free after retries", zap.Error(lastErr))
 }

--- a/pkg/standby/standby.go
+++ b/pkg/standby/standby.go
@@ -27,7 +27,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -38,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/pkg/tidbmanager"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/signal"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 )
 
@@ -51,9 +51,7 @@ const (
 
 	httpPathPrefix = "/tidb-pool/"
 
-	maxCloseConnWait = time.Hour
-
-	maxRepresentableCloseConnWaitSeconds = int64(1<<63-1) / int64(time.Second)
+	maxCloseConnWait = 24 * time.Hour
 
 	managerFreeMaxAttempts   = 3
 	managerFreeRetryInterval = 200 * time.Millisecond
@@ -80,7 +78,7 @@ type LoadKeyspaceController struct {
 	startServerErr error
 	endOnce        sync.Once
 	mgrCli         tidbmanager.Client
-	closeConnWait  atomic.Int64
+	closeConnWait  atomic.Duration
 
 	lastActive int64
 }
@@ -424,17 +422,18 @@ func parseExitWait(value string) (time.Duration, error) {
 	if value == "" {
 		return 0, nil
 	}
-	waitSeconds, err := strconv.ParseInt(value, 10, 64)
-	if err != nil || waitSeconds < 0 {
+	wait, err := time.ParseDuration(value)
+	if err != nil {
+		waitSeconds, parseErr := strconv.ParseInt(value, 10, 64)
+		if parseErr != nil || waitSeconds < 0 || waitSeconds > int64(maxCloseConnWait/time.Second) {
+			return 0, invalidExitOptionError{option: "wait"}
+		}
+		wait = time.Duration(waitSeconds) * time.Second
+	}
+	if wait < 0 || wait > maxCloseConnWait {
 		return 0, invalidExitOptionError{option: "wait"}
 	}
-	if waitSeconds == 0 {
-		return 0, nil
-	}
-	if waitSeconds > maxRepresentableCloseConnWaitSeconds || waitSeconds > int64(maxCloseConnWait/time.Second) {
-		return 0, invalidExitOptionError{option: "wait"}
-	}
-	return time.Duration(waitSeconds) * time.Second, nil
+	return wait, nil
 }
 
 func statusHandler(w http.ResponseWriter, r *http.Request) {
@@ -456,11 +455,11 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *LoadKeyspaceController) setCloseConnWait(wait time.Duration) {
-	c.closeConnWait.Store(int64(wait))
+	c.closeConnWait.Store(wait)
 }
 
 func (c *LoadKeyspaceController) getCloseConnWait() time.Duration {
-	return time.Duration(c.closeConnWait.Load())
+	return c.closeConnWait.Load()
 }
 
 var httpServer *http.Server
@@ -516,7 +515,7 @@ func (c *LoadKeyspaceController) WaitForActivate() {
 	config.UpdateGlobal(func(c *config.Config) {
 		c.KeyspaceName = activateRequest.KeyspaceName
 		if deploymode.IsStarter() && activateRequest.ExportID != "" {
-			c.Standby.ExportID = activateRequest.ExportID
+			c.StarterParams.ExportID = activateRequest.ExportID
 		}
 		if activateRequest.MaxIdleSeconds > 0 {
 			c.Standby.MaxIdleSeconds = activateRequest.MaxIdleSeconds

--- a/pkg/standby/standby.go
+++ b/pkg/standby/standby.go
@@ -51,7 +51,8 @@ const (
 
 	httpPathPrefix = "/tidb-pool/"
 
-	maxCloseConnWait = 24 * time.Hour
+	defaultCloseConnWait = 8 * time.Hour
+	maxCloseConnWait     = 24 * time.Hour
 
 	managerFreeMaxAttempts   = 3
 	managerFreeRetryInterval = 200 * time.Millisecond
@@ -328,6 +329,9 @@ func (c *LoadKeyspaceController) Handler(svr *server.Server) (string, *http.Serv
 					tidbExit(syscall.SIGINT)
 					return
 				}
+				if options.wait <= 0 {
+					options.wait = defaultCloseConnWait
+				}
 				c.setCloseConnWait(options.wait)
 				if options.needMgrFree {
 					svr.SetNeedRequestMgrFree()
@@ -602,10 +606,10 @@ func (c *LoadKeyspaceController) waitZeroConn(svr server.StandbyShutdownServer) 
 	}
 }
 
-func (c *LoadKeyspaceController) reportManagerFree(exitReason string) {
+func (c *LoadKeyspaceController) reportManagerFree(exitReason string) bool {
 	if c.mgrCli == nil {
 		logutil.BgLogger().Warn("manager notifier is unavailable")
-		return
+		return false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), tidbmanager.DefaultTimeout)
 	defer cancel()
@@ -620,8 +624,8 @@ func (c *LoadKeyspaceController) reportManagerFree(exitReason string) {
 			if attempt < managerFreeMaxAttempts {
 				select {
 				case <-ctx.Done():
-					logutil.BgLogger().Warn("manager free report timed out", zap.Error(ctx.Err()))
-					return
+					logutil.BgLogger().Error("manager free report timed out", zap.Error(ctx.Err()))
+					return false
 				case <-time.After(managerFreeRetryInterval):
 				}
 			}
@@ -630,7 +634,8 @@ func (c *LoadKeyspaceController) reportManagerFree(exitReason string) {
 		if attempt > 1 {
 			logutil.BgLogger().Info("reported free after retry", zap.Int("attempt", attempt))
 		}
-		return
+		return true
 	}
-	logutil.BgLogger().Warn("failed to report free after retries", zap.Error(lastErr))
+	logutil.BgLogger().Error("failed to report free after retries", zap.Error(lastErr))
+	return false
 }

--- a/pkg/standby/standby.go
+++ b/pkg/standby/standby.go
@@ -624,7 +624,7 @@ func (c *LoadKeyspaceController) reportManagerFree(exitReason string) bool {
 			if attempt < managerFreeMaxAttempts {
 				select {
 				case <-ctx.Done():
-					logutil.BgLogger().Error("manager free report timed out", zap.Error(ctx.Err()))
+					logutil.BgLogger().Warn("manager free report timed out", zap.Error(ctx.Err()))
 					return false
 				case <-time.After(managerFreeRetryInterval):
 				}
@@ -636,6 +636,6 @@ func (c *LoadKeyspaceController) reportManagerFree(exitReason string) bool {
 		}
 		return true
 	}
-	logutil.BgLogger().Error("failed to report free after retries", zap.Error(lastErr))
+	logutil.BgLogger().Warn("failed to report free after retries", zap.Error(lastErr))
 	return false
 }

--- a/pkg/standby/standby.go
+++ b/pkg/standby/standby.go
@@ -562,6 +562,14 @@ func (c *LoadKeyspaceController) OnServerShutdown(svr server.StandbyShutdownServ
 	// Give up auto ID ownership before waiting for TiProxy to migrate traffic.
 	svr.AutoIDServiceClose()
 
+	if svr.GetForceShutdown() {
+		return
+	}
+
+	if !c.waitZeroConn(svr) {
+		return
+	}
+
 	if svr.GetNeedRequestMgrFree() {
 		exitReason, err := loadTiDBNormalRestartLog()
 		if err != nil && !os.IsNotExist(err) {
@@ -570,14 +578,12 @@ func (c *LoadKeyspaceController) OnServerShutdown(svr server.StandbyShutdownServ
 		}
 		c.reportManagerFree(string(exitReason))
 	}
+}
 
-	if svr.GetForceShutdown() {
-		return
-	}
-
+func (c *LoadKeyspaceController) waitZeroConn(svr server.StandbyShutdownServer) bool {
 	maxWaitTime := c.getCloseConnWait()
 	if maxWaitTime <= 0 {
-		return
+		return true
 	}
 
 	logutil.BgLogger().Info("waiting for tiproxy to migrate and close all connections", zap.Duration("maxWaitTime", maxWaitTime))
@@ -589,8 +595,10 @@ func (c *LoadKeyspaceController) OnServerShutdown(svr server.StandbyShutdownServ
 	select {
 	case <-time.After(maxWaitTime):
 		logutil.BgLogger().Info("tiproxy connection close timed out")
+		return false
 	case <-done:
 		logutil.BgLogger().Info("tiproxy has closed all connections")
+		return true
 	}
 }
 

--- a/pkg/standby/standby_nextgen_test.go
+++ b/pkg/standby/standby_nextgen_test.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/deploymode"
@@ -32,11 +33,11 @@ import (
 func TestOnServerShutdownStarterReportsFree(t *testing.T) {
 	resetStandbyTestState(t)
 
+	originalMode := deploymode.Get()
 	require.NoError(t, deploymode.Set(deploymode.Starter))
 	t.Cleanup(func() {
-		require.NoError(t, deploymode.Set(deploymode.Premium))
+		require.NoError(t, deploymode.Set(originalMode))
 	})
-	t.Setenv("GracefulCloseConnectionsTimeout", "1ms")
 
 	require.NoError(t, os.WriteFile(tidbNormalRestartLogPath, []byte("keyspace-1:idle"), 0644))
 	t.Cleanup(func() {
@@ -58,9 +59,10 @@ func TestOnServerShutdownStarterReportsFree(t *testing.T) {
 func TestStatusReturnsExportIDForStarter(t *testing.T) {
 	resetStandbyTestState(t)
 
+	originalMode := deploymode.Get()
 	require.NoError(t, deploymode.Set(deploymode.Starter))
 	t.Cleanup(func() {
-		require.NoError(t, deploymode.Set(deploymode.Premium))
+		require.NoError(t, deploymode.Set(originalMode))
 	})
 
 	mu.Lock()
@@ -135,4 +137,11 @@ func TestExitRejectsInvalidQueryParams(t *testing.T) {
 			require.Equal(t, tt.want, recorder.Body.String())
 		})
 	}
+
+	t.Run("close connection wait is instance scoped", func(t *testing.T) {
+		controller.setCloseConnWait(3)
+		require.Equal(t, 3*time.Second, controller.getCloseConnWait())
+		controller.setCloseConnWait(0)
+		require.Zero(t, controller.getCloseConnWait())
+	})
 }

--- a/pkg/standby/standby_nextgen_test.go
+++ b/pkg/standby/standby_nextgen_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build nextgen
+
+package standby
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
+	"github.com/pingcap/tidb/pkg/server"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnServerShutdownStarterReportsFree(t *testing.T) {
+	resetStandbyTestState(t)
+
+	require.NoError(t, deploymode.Set(deploymode.Starter))
+	t.Cleanup(func() {
+		require.NoError(t, deploymode.Set(deploymode.Premium))
+	})
+	t.Setenv("GracefulCloseConnectionsTimeout", "1ms")
+
+	require.NoError(t, os.WriteFile(tidbNormalRestartLogPath, []byte("keyspace-1:idle"), 0644))
+	t.Cleanup(func() {
+		_ = os.Remove(tidbNormalRestartLogPath)
+	})
+
+	mgrCli := &mockManagerClient{}
+	controller := NewLoadKeyspaceController(mgrCli)
+	svr := server.NewTestServer(config.NewConfig())
+	svr.SetNeedRequestMgrFree()
+
+	controller.OnServerShutdown(svr)
+
+	require.True(t, mgrCli.called)
+	require.Equal(t, "keyspace-1:idle", mgrCli.gotReason)
+	require.Equal(t, terminatingState, state)
+}
+
+func TestStatusReturnsExportIDForStarter(t *testing.T) {
+	resetStandbyTestState(t)
+
+	require.NoError(t, deploymode.Set(deploymode.Starter))
+	t.Cleanup(func() {
+		require.NoError(t, deploymode.Set(deploymode.Premium))
+	})
+
+	mu.Lock()
+	activateRequest = ActivateRequest{
+		KeyspaceName: "ks1",
+		ExportID:     "export-1",
+	}
+	mu.Unlock()
+
+	recorder := httptest.NewRecorder()
+	statusHandler(recorder, httptest.NewRequest("GET", "/tidb-pool/status", nil))
+
+	require.JSONEq(t, `{"state": "standby", "keyspace_name": "ks1", "export_id": "export-1"}`, recorder.Body.String())
+}
+
+func TestExitRejectsInvalidQueryParams(t *testing.T) {
+	resetStandbyTestState(t)
+	restore := config.RestoreFunc()
+	t.Cleanup(restore)
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.KeyspaceName = "ks1"
+	})
+
+	controller := NewLoadKeyspaceController()
+	_, mux := controller.Handler(server.NewTestServer(config.NewConfig()))
+
+	tests := []struct {
+		name  string
+		query url.Values
+		want  string
+	}{
+		{
+			name: "invalid graceful",
+			query: url.Values{
+				"keyspace": {"ks1"},
+				"graceful": {"tru"},
+			},
+			want: "invalid graceful\n",
+		},
+		{
+			name: "invalid wait",
+			query: url.Values{
+				"keyspace": {"ks1"},
+				"wait":     {"-1"},
+			},
+			want: "invalid wait\n",
+		},
+		{
+			name: "invalid skip auto id owner",
+			query: url.Values{
+				"keyspace":           {"ks1"},
+				"skip_auto_id_owner": {"maybe"},
+			},
+			want: "invalid skip_auto_id_owner\n",
+		},
+		{
+			name: "invalid need manager free",
+			query: url.Values{
+				"keyspace":      {"ks1"},
+				"need_mgr_free": {"maybe"},
+			},
+			want: "invalid need_mgr_free\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			mux.ServeHTTP(recorder, httptest.NewRequest("GET", "/tidb-pool/exit?"+tt.query.Encode(), nil))
+
+			require.Equal(t, http.StatusBadRequest, recorder.Code)
+			require.Equal(t, tt.want, recorder.Body.String())
+		})
+	}
+}

--- a/pkg/standby/standby_nextgen_test.go
+++ b/pkg/standby/standby_nextgen_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -56,6 +57,26 @@ func TestOnServerShutdownStarterReportsFree(t *testing.T) {
 	require.Equal(t, terminatingState, state)
 }
 
+func TestOnServerShutdownStarterRetriesManagerFree(t *testing.T) {
+	resetStandbyTestState(t)
+
+	originalMode := deploymode.Get()
+	require.NoError(t, deploymode.Set(deploymode.Starter))
+	t.Cleanup(func() {
+		require.NoError(t, deploymode.Set(originalMode))
+	})
+
+	mgrCli := &mockManagerClient{failures: 2}
+	controller := NewLoadKeyspaceController(mgrCli)
+	svr := server.NewTestServer(config.NewConfig())
+	svr.SetNeedRequestMgrFree()
+
+	controller.OnServerShutdown(svr)
+
+	require.True(t, mgrCli.called)
+	require.Equal(t, 3, mgrCli.calls)
+}
+
 func TestStatusReturnsExportIDForStarter(t *testing.T) {
 	resetStandbyTestState(t)
 
@@ -68,14 +89,14 @@ func TestStatusReturnsExportIDForStarter(t *testing.T) {
 	mu.Lock()
 	activateRequest = ActivateRequest{
 		KeyspaceName: "ks1",
-		ExportID:     "export-1",
+		ExportID:     `export"\1`,
 	}
 	mu.Unlock()
 
 	recorder := httptest.NewRecorder()
 	statusHandler(recorder, httptest.NewRequest("GET", "/tidb-pool/status", nil))
 
-	require.JSONEq(t, `{"state": "standby", "keyspace_name": "ks1", "export_id": "export-1"}`, recorder.Body.String())
+	require.JSONEq(t, `{"state": "standby", "keyspace_name": "ks1", "export_id": "export\"\\1"}`, recorder.Body.String())
 }
 
 func TestExitRejectsInvalidQueryParams(t *testing.T) {
@@ -86,7 +107,7 @@ func TestExitRejectsInvalidQueryParams(t *testing.T) {
 		conf.KeyspaceName = "ks1"
 	})
 
-	controller := NewLoadKeyspaceController()
+	controller := NewLoadKeyspaceController(nil)
 	_, mux := controller.Handler(server.NewTestServer(config.NewConfig()))
 
 	tests := []struct {
@@ -103,10 +124,26 @@ func TestExitRejectsInvalidQueryParams(t *testing.T) {
 			want: "invalid graceful\n",
 		},
 		{
-			name: "invalid wait",
+			name: "negative wait",
 			query: url.Values{
 				"keyspace": {"ks1"},
 				"wait":     {"-1"},
+			},
+			want: "invalid wait\n",
+		},
+		{
+			name: "overflow wait",
+			query: url.Values{
+				"keyspace": {"ks1"},
+				"wait":     {"9223372036854775807"},
+			},
+			want: "invalid wait\n",
+		},
+		{
+			name: "too large wait",
+			query: url.Values{
+				"keyspace": {"ks1"},
+				"wait":     {"3601"},
 			},
 			want: "invalid wait\n",
 		},
@@ -139,9 +176,114 @@ func TestExitRejectsInvalidQueryParams(t *testing.T) {
 	}
 
 	t.Run("close connection wait is instance scoped", func(t *testing.T) {
-		controller.setCloseConnWait(3)
+		controller.setCloseConnWait(3 * time.Second)
 		require.Equal(t, 3*time.Second, controller.getCloseConnWait())
 		controller.setCloseConnWait(0)
 		require.Zero(t, controller.getCloseConnWait())
 	})
+}
+
+func TestExitGracefulUsesTermSignalWithoutManagerFree(t *testing.T) {
+	resetStandbyTestState(t)
+	t.Cleanup(func() {
+		_ = os.Remove(tidbNormalRestartLogPath)
+	})
+	restore := config.RestoreFunc()
+	t.Cleanup(restore)
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.KeyspaceName = "ks1"
+	})
+
+	originalMode := deploymode.Get()
+	require.NoError(t, deploymode.Set(deploymode.Starter))
+	t.Cleanup(func() {
+		require.NoError(t, deploymode.Set(originalMode))
+	})
+
+	var gotSig syscall.Signal
+	oldExit := tidbExit
+	tidbExit = func(sig syscall.Signal) {
+		gotSig = sig
+	}
+	t.Cleanup(func() {
+		tidbExit = oldExit
+	})
+
+	controller := NewLoadKeyspaceController(nil)
+	_, mux := controller.Handler(server.NewTestServer(config.NewConfig()))
+	query := url.Values{
+		"keyspace": {"ks1"},
+		"graceful": {"true"},
+	}
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/tidb-pool/exit?"+query.Encode(), nil))
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, syscall.SIGTERM, gotSig)
+}
+
+func TestExitRejectsManagerFreeWithoutNotifier(t *testing.T) {
+	resetStandbyTestState(t)
+	t.Cleanup(func() {
+		_ = os.Remove(tidbNormalRestartLogPath)
+	})
+	restore := config.RestoreFunc()
+	t.Cleanup(restore)
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.KeyspaceName = "ks1"
+	})
+
+	originalMode := deploymode.Get()
+	require.NoError(t, deploymode.Set(deploymode.Starter))
+	t.Cleanup(func() {
+		require.NoError(t, deploymode.Set(originalMode))
+	})
+
+	oldExit := tidbExit
+	tidbExit = func(syscall.Signal) {
+		require.Fail(t, "exit should not be dispatched")
+	}
+	t.Cleanup(func() {
+		tidbExit = oldExit
+	})
+
+	controller := NewLoadKeyspaceController(nil)
+	_, mux := controller.Handler(server.NewTestServer(config.NewConfig()))
+	query := url.Values{
+		"keyspace":      {"ks1"},
+		"graceful":      {"true"},
+		"need_mgr_free": {"true"},
+	}
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/tidb-pool/exit?"+query.Encode(), nil))
+
+	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	require.Equal(t, "manager notifier is unavailable\n", recorder.Body.String())
+}
+
+func TestParseExitWait(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "empty"},
+		{name: "zero", value: "0"},
+		{name: "max", value: "3600", want: time.Hour},
+		{name: "above max", value: "3601", wantErr: true},
+		{name: "overflow", value: "9223372036854775807", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseExitWait(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/pkg/standby/standby_nextgen_test.go
+++ b/pkg/standby/standby_nextgen_test.go
@@ -31,6 +31,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type blockingShutdownServer struct {
+	forceShutdown      bool
+	needRequestMgrFree bool
+	waitStarted        chan struct{}
+	waitDone           chan struct{}
+}
+
+func newBlockingShutdownServer() *blockingShutdownServer {
+	return &blockingShutdownServer{
+		needRequestMgrFree: true,
+		waitStarted:        make(chan struct{}),
+		waitDone:           make(chan struct{}),
+	}
+}
+
+func (s *blockingShutdownServer) AutoIDServiceClose() {}
+
+func (s *blockingShutdownServer) GetForceShutdown() bool {
+	return s.forceShutdown
+}
+
+func (s *blockingShutdownServer) GetNeedRequestMgrFree() bool {
+	return s.needRequestMgrFree
+}
+
+func (s *blockingShutdownServer) IsAutoIDOwner() bool {
+	return false
+}
+
+func (s *blockingShutdownServer) SetForceShutdown() {
+	s.forceShutdown = true
+}
+
+func (s *blockingShutdownServer) SetNeedRequestMgrFree() {
+	s.needRequestMgrFree = true
+}
+
+func (s *blockingShutdownServer) WaitZeroConn() {
+	close(s.waitStarted)
+	<-s.waitDone
+}
+
 func TestOnServerShutdownStarterReportsFree(t *testing.T) {
 	resetStandbyTestState(t)
 
@@ -55,6 +97,45 @@ func TestOnServerShutdownStarterReportsFree(t *testing.T) {
 	require.True(t, mgrCli.called)
 	require.Equal(t, "keyspace-1:idle", mgrCli.gotReason)
 	require.Equal(t, terminatingState, state)
+
+	t.Run("reports after zero connection wait succeeds", func(t *testing.T) {
+		mgrCli := &mockManagerClient{}
+		controller := NewLoadKeyspaceController(mgrCli)
+		controller.setCloseConnWait(time.Second)
+		svr := newBlockingShutdownServer()
+
+		done := make(chan struct{})
+		go func() {
+			controller.OnServerShutdown(svr)
+			close(done)
+		}()
+
+		select {
+		case <-svr.waitStarted:
+		case <-time.After(time.Second):
+			require.Fail(t, "wait zero connection was not called")
+		}
+		require.False(t, mgrCli.called)
+
+		close(svr.waitDone)
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			require.Fail(t, "shutdown did not finish")
+		}
+		require.True(t, mgrCli.called)
+	})
+
+	t.Run("does not report free after zero connection wait timeout", func(t *testing.T) {
+		mgrCli := &mockManagerClient{}
+		controller := NewLoadKeyspaceController(mgrCli)
+		controller.setCloseConnWait(10 * time.Millisecond)
+		svr := newBlockingShutdownServer()
+
+		controller.OnServerShutdown(svr)
+		require.False(t, mgrCli.called)
+		close(svr.waitDone)
+	})
 }
 
 func TestOnServerShutdownStarterRetriesManagerFree(t *testing.T) {

--- a/pkg/standby/standby_nextgen_test.go
+++ b/pkg/standby/standby_nextgen_test.go
@@ -143,7 +143,7 @@ func TestExitRejectsInvalidQueryParams(t *testing.T) {
 			name: "too large wait",
 			query: url.Values{
 				"keyspace": {"ks1"},
-				"wait":     {"3601"},
+				"wait":     {"24h1s"},
 			},
 			want: "invalid wait\n",
 		},
@@ -270,8 +270,11 @@ func TestParseExitWait(t *testing.T) {
 	}{
 		{name: "empty"},
 		{name: "zero", value: "0"},
-		{name: "max", value: "3600", want: time.Hour},
-		{name: "above max", value: "3601", wantErr: true},
+		{name: "zero duration", value: "0s"},
+		{name: "duration", value: "1h30m", want: time.Hour + 30*time.Minute},
+		{name: "legacy seconds", value: "3600", want: time.Hour},
+		{name: "max", value: "24h", want: 24 * time.Hour},
+		{name: "above max", value: "24h1s", wantErr: true},
 		{name: "overflow", value: "9223372036854775807", wantErr: true},
 	}
 

--- a/pkg/standby/standby_nextgen_test.go
+++ b/pkg/standby/standby_nextgen_test.go
@@ -156,6 +156,14 @@ func TestOnServerShutdownStarterRetriesManagerFree(t *testing.T) {
 
 	require.True(t, mgrCli.called)
 	require.Equal(t, 3, mgrCli.calls)
+
+	t.Run("returns false after exhausting retries", func(t *testing.T) {
+		mgrCli := &mockManagerClient{failures: managerFreeMaxAttempts}
+		controller := NewLoadKeyspaceController(mgrCli)
+
+		require.False(t, controller.reportManagerFree("manager free failed"))
+		require.Equal(t, managerFreeMaxAttempts, mgrCli.calls)
+	})
 }
 
 func TestStatusReturnsExportIDForStarter(t *testing.T) {
@@ -301,6 +309,7 @@ func TestExitGracefulUsesTermSignalWithoutManagerFree(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, recorder.Code)
 	require.Equal(t, syscall.SIGTERM, gotSig)
+	require.Equal(t, defaultCloseConnWait, controller.getCloseConnWait())
 }
 
 func TestExitRejectsManagerFreeWithoutNotifier(t *testing.T) {
@@ -328,18 +337,54 @@ func TestExitRejectsManagerFreeWithoutNotifier(t *testing.T) {
 		tidbExit = oldExit
 	})
 
-	controller := NewLoadKeyspaceController(nil)
-	_, mux := controller.Handler(server.NewTestServer(config.NewConfig()))
-	query := url.Values{
-		"keyspace":      {"ks1"},
-		"graceful":      {"true"},
-		"need_mgr_free": {"true"},
-	}
-	recorder := httptest.NewRecorder()
-	mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/tidb-pool/exit?"+query.Encode(), nil))
+	t.Run("uses default wait", func(t *testing.T) {
+		oldExit := tidbExit
+		var gotSig syscall.Signal
+		tidbExit = func(sig syscall.Signal) {
+			gotSig = sig
+		}
+		t.Cleanup(func() {
+			tidbExit = oldExit
+		})
 
-	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
-	require.Equal(t, "manager notifier is unavailable\n", recorder.Body.String())
+		for _, wait := range []string{"", "0", "0s"} {
+			gotSig = 0
+			controller := NewLoadKeyspaceController(&mockManagerClient{})
+			svr := server.NewTestServer(config.NewConfig())
+			_, mux := controller.Handler(svr)
+			query := url.Values{
+				"keyspace":      {"ks1"},
+				"graceful":      {"true"},
+				"need_mgr_free": {"true"},
+			}
+			if wait != "" {
+				query.Set("wait", wait)
+			}
+			recorder := httptest.NewRecorder()
+			mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/tidb-pool/exit?"+query.Encode(), nil))
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+			require.Equal(t, syscall.SIGTERM, gotSig)
+			require.True(t, svr.GetNeedRequestMgrFree())
+			require.Equal(t, defaultCloseConnWait, controller.getCloseConnWait())
+		}
+	})
+
+	t.Run("requires notifier", func(t *testing.T) {
+		controller := NewLoadKeyspaceController(nil)
+		_, mux := controller.Handler(server.NewTestServer(config.NewConfig()))
+		query := url.Values{
+			"keyspace":      {"ks1"},
+			"graceful":      {"true"},
+			"need_mgr_free": {"true"},
+			"wait":          {"1s"},
+		}
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/tidb-pool/exit?"+query.Encode(), nil))
+
+		require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+		require.Equal(t, "manager notifier is unavailable\n", recorder.Body.String())
+	})
 }
 
 func TestParseExitWait(t *testing.T) {

--- a/pkg/standby/standby_test.go
+++ b/pkg/standby/standby_test.go
@@ -16,6 +16,7 @@ package standby
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -28,12 +29,18 @@ import (
 
 type mockManagerClient struct {
 	called    bool
+	calls     int
+	failures  int
 	gotReason string
 }
 
 func (c *mockManagerClient) Free(_ context.Context, exitReason string) error {
 	c.called = true
+	c.calls++
 	c.gotReason = exitReason
+	if c.calls <= c.failures {
+		return errors.New("temporary error")
+	}
 	return nil
 }
 

--- a/pkg/standby/standby_test.go
+++ b/pkg/standby/standby_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standby
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/deploymode"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/pingcap/tidb/pkg/server"
+	"github.com/stretchr/testify/require"
+)
+
+type mockManagerClient struct {
+	called    bool
+	gotReason string
+}
+
+func (c *mockManagerClient) Free(_ context.Context, exitReason string) error {
+	c.called = true
+	c.gotReason = exitReason
+	return nil
+}
+
+func resetStandbyTestState(t *testing.T) {
+	t.Helper()
+	mu.Lock()
+	oldState := state
+	oldActivateRequest := activateRequest
+	state = standbyState
+	activateRequest = ActivateRequest{}
+	mu.Unlock()
+
+	t.Cleanup(func() {
+		mu.Lock()
+		state = oldState
+		activateRequest = oldActivateRequest
+		mu.Unlock()
+	})
+}
+
+func TestOnServerShutdownNoopOutsideStarter(t *testing.T) {
+	resetStandbyTestState(t)
+	if kerneltype.IsNextGen() {
+		original := deploymode.Get()
+		require.NoError(t, deploymode.Set(deploymode.Premium))
+		t.Cleanup(func() {
+			require.NoError(t, deploymode.Set(original))
+		})
+	}
+	require.False(t, deploymode.IsStarter())
+
+	mgrCli := &mockManagerClient{}
+	controller := NewLoadKeyspaceController(mgrCli)
+	svr := server.NewTestServer(config.NewConfig())
+	svr.SetNeedRequestMgrFree()
+
+	controller.OnServerShutdown(svr)
+
+	require.False(t, mgrCli.called)
+}
+
+func TestStatusDoesNotReturnExportIDOutsideStarter(t *testing.T) {
+	resetStandbyTestState(t)
+	if kerneltype.IsNextGen() {
+		original := deploymode.Get()
+		require.NoError(t, deploymode.Set(deploymode.Premium))
+		t.Cleanup(func() {
+			require.NoError(t, deploymode.Set(original))
+		})
+	}
+	require.False(t, deploymode.IsStarter())
+
+	mu.Lock()
+	activateRequest = ActivateRequest{
+		KeyspaceName: "ks1",
+		ExportID:     "export-1",
+	}
+	mu.Unlock()
+
+	recorder := httptest.NewRecorder()
+	statusHandler(recorder, httptest.NewRequest("GET", "/tidb-pool/status", nil))
+
+	require.JSONEq(t, `{"state": "standby", "keyspace_name": "ks1"}`, recorder.Body.String())
+}

--- a/pkg/tidbmanager/BUILD.bazel
+++ b/pkg/tidbmanager/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "tidbmanager",
+    srcs = ["tidbmanager.go"],
+    importpath = "github.com/pingcap/tidb/pkg/tidbmanager",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "tidbmanager_test",
+    timeout = "short",
+    srcs = ["tidbmanager_test.go"],
+    embed = [":tidbmanager"],
+    flaky = True,
+    shard_count = 3,
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/pkg/tidbmanager/tidbmanager.go
+++ b/pkg/tidbmanager/tidbmanager.go
@@ -1,0 +1,102 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tidbmanager
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	freeReqPath = "/api/tidb/free"
+
+	// DefaultTimeout is the default timeout for manager requests.
+	DefaultTimeout = 10 * time.Second
+)
+
+// Client is the client to communicate with the TiDB manager server.
+type Client interface {
+	// Free notifies the manager that the pod is ready to be reused.
+	Free(ctx context.Context, exitReason string) error
+}
+
+type client struct {
+	httpClient *http.Client
+
+	managerAddr string
+	podName     string
+	podIP       string
+	namespace   string
+}
+
+// NewClient creates a new manager client.
+func NewClient(addr string, tlsConfig *tls.Config, podName, podIP, namespace string) Client {
+	scheme := "http://"
+	transport := http.DefaultTransport
+	if tlsConfig != nil {
+		transport = &http.Transport{
+			TLSClientConfig:   tlsConfig,
+			ForceAttemptHTTP2: true,
+		}
+		scheme = "https://"
+	}
+
+	return &client{
+		httpClient: &http.Client{
+			Transport: transport,
+			Timeout:   DefaultTimeout,
+		},
+
+		managerAddr: scheme + strings.TrimRight(addr, "/"),
+		podName:     podName,
+		podIP:       podIP,
+		namespace:   namespace,
+	}
+}
+
+func (c *client) Free(ctx context.Context, exitReason string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.managerAddr+freeReqPath, nil)
+	if err != nil {
+		return fmt.Errorf("create request failed: %w", err)
+	}
+	query := req.URL.Query()
+	query.Set("pod_name", c.podName)
+	query.Set("pod_ip", c.podIP)
+	query.Set("ns", c.namespace)
+	query.Set("normal_restart_log", exitReason)
+	req.URL.RawQuery = query.Encode()
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("free request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errMsg, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("free response failed: %s, read body failed: %w, partial body: %s",
+				resp.Status, readErr, string(errMsg))
+		}
+		return fmt.Errorf("free response failed: %s, err: %s", resp.Status, string(errMsg))
+	}
+
+	return nil
+}

--- a/pkg/tidbmanager/tidbmanager_test.go
+++ b/pkg/tidbmanager/tidbmanager_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tidbmanager
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFree(t *testing.T) {
+	var gotPath string
+	var gotQuery url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
+		require.Equal(t, http.MethodPut, r.Method)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cli := NewClient(server.Listener.Addr().String(), nil, "pod-1", "10.0.0.1", "ns-1")
+	require.NoError(t, cli.Free(context.Background(), "idle restart"))
+	require.Equal(t, freeReqPath, gotPath)
+	require.Equal(t, "pod-1", gotQuery.Get("pod_name"))
+	require.Equal(t, "10.0.0.1", gotQuery.Get("pod_ip"))
+	require.Equal(t, "ns-1", gotQuery.Get("ns"))
+	require.Equal(t, "idle restart", gotQuery.Get("normal_restart_log"))
+}
+
+func TestFreeReturnsErrorOnNonOK(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("not ready"))
+	}))
+	defer server.Close()
+
+	cli := NewClient(server.Listener.Addr().String(), nil, "pod-1", "10.0.0.1", "ns-1")
+	err := cli.Free(context.Background(), "idle restart")
+	require.ErrorContains(t, err, "503 Service Unavailable")
+	require.ErrorContains(t, err, "not ready")
+}
+
+var errReadFailed = errors.New("read failed")
+
+type errorRoundTripper struct{}
+
+func (errorRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Status:     "503 Service Unavailable",
+		Body:       errReader{},
+		Request:    req,
+	}, nil
+}
+
+type errReader struct{}
+
+func (errReader) Read(_ []byte) (int, error) {
+	return 0, errReadFailed
+}
+
+func (errReader) Close() error {
+	return nil
+}
+
+func TestFreeReturnsBodyReadError(t *testing.T) {
+	cli := NewClient("manager.example.com", nil, "pod-1", "10.0.0.1", "ns-1").(*client)
+	cli.httpClient.Transport = errorRoundTripper{}
+
+	err := cli.Free(context.Background(), "idle restart")
+	require.ErrorContains(t, err, "503 Service Unavailable")
+	require.ErrorContains(t, err, "read body failed: read failed")
+	require.ErrorIs(t, err, errReadFailed)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67765 

Problem Summary:
NextGen Starter deployments can keep TiDB instances in a standby state and later activate them for a keyspace. The activation path needs to carry Starter-specific metadata, and the status path needs to expose enough information for external components to understand the instance assignment.  

And NextGen Starter deployments need a safer exit for pod recycling.

When a Starter TiDB pod is being recycled, TiDB needs to coordinate with TiDB manager and TiProxy, avoid shutting down the current auto-id service owner when requested, and give existing connections time to migrate away before the process exits. The existing flow does not provide these Starter-specific controls, which can cause unnecessary auto-id owner failover, missed manager free notifications, or premature shutdown during graceful recycle.

These behaviors should apply only to Starter deployments and must not affect Classic TiDB or non-Starter NextGen deployments.

### What changed and how does it work?
This PR adds Starter-only graceful shutdown handling.

The main changes are:

- Added Starter standby config for manager notification and activation metadata:
  - `standby.export-id`
  - `standby.enable-manager-notifier`
  - `standby.manager-addr`
- Added a TiDB manager client that can notify manager when a Starter TiDB pod is ready to be reused.
- Extended the standby exit API for Starter mode with:
  - `graceful`
  - `wait`
  - `skip_auto_id_owner`
  - `need_mgr_free`
- Added an auto-id owner check endpoint, `/owner_manager/auto_id_service`, registered only in Starter mode.
- Added server shutdown flags for Starter exit handling:
  - force shutdown skips normal client drain wait
  - manager-free flag controls whether TiDB reports free to TiDB manager
- Added Starter shutdown handling that:
  - marks the server as terminating
  - releases auto-id service ownership before waiting for connection migration
  - optionally reports free to TiDB manager
  - waits for all client connections to close, bounded by the requested wait time
- Added tests for Starter-only behavior and non-Starter isolation.

All new recycle/shutdown behavior is guarded by `deploymode.IsStarter()`, so Classic TiDB and non-Starter NextGen deployments keep their existing behavior.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standby mode: optional manager notifier, export ID support, starter-only status endpoint exposing AutoID ownership, and starter-aware exit/status behaviors.
  * Shutdown controls: force/graceful options, wait/skip flags, zero-connection wait, and optional manager “free” reporting.

* **Chores**
  * Kubernetes pod/namespace env keys and manager address defaults added.
  * Build/test updates and expanded test coverage for standby, shutdown, HTTP handlers, and manager interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->