### PR TITLE
importinto: wait for TiCI indexes before finishing import | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature-fts tikv=feature-fts

### DIFF
--- a/pkg/dxf/importinto/proto.go
+++ b/pkg/dxf/importinto/proto.go
@@ -191,6 +191,8 @@ type PostProcessStepMeta struct {
 	TooManyConflictsFromIndex bool `json:"too-many-conflicts-from-index,omitempty"`
 	// MaxIDs of max all max-ids of subtasks in import step.
 	MaxIDs map[autoid.AllocatorType]int64
+	// TiCIIndexSummary records TiCI readiness warnings generated during post process.
+	TiCIIndexSummary *importer.TiCIIndexSummary `json:"tici-index-summary,omitempty"`
 }
 
 // SharedVars is the shared variables of all minimal tasks in a subtask.

--- a/pkg/dxf/importinto/scheduler.go
+++ b/pkg/dxf/importinto/scheduler.go
@@ -423,7 +423,7 @@ func (sch *importScheduler) OnNextSubtasksBatch(
 }
 
 // OnDone implements scheduler.Extension interface.
-func (sch *importScheduler) OnDone(ctx context.Context, _ storage.TaskHandle, task *proto.Task) error {
+func (sch *importScheduler) OnDone(ctx context.Context, taskHandle storage.TaskHandle, task *proto.Task) error {
 	logger := sch.GetLogger().With(zap.String("step", proto.Step2Str(task.Type, task.Step)))
 	logger.Info("task done", zap.Stringer("state", task.State), zap.Error(task.Error))
 	taskMeta := &TaskMeta{}
@@ -441,7 +441,35 @@ func (sch *importScheduler) OnDone(ctx context.Context, _ storage.TaskHandle, ta
 		}
 		return sch.failJob(ctx, task, taskMeta, logger, errMsg)
 	}
+	if err := mergeTiCIIndexSummaryFromPostProcess(ctx, taskHandle, task, taskMeta); err != nil {
+		return err
+	}
 	return sch.finishJob(ctx, logger, task, taskMeta)
+}
+
+func mergeTiCIIndexSummaryFromPostProcess(
+	_ context.Context,
+	taskHandle storage.TaskHandle,
+	task *proto.Task,
+	taskMeta *TaskMeta,
+) error {
+	if taskHandle == nil {
+		return nil
+	}
+	metas, err := taskHandle.GetPreviousSubtaskMetas(task.ID, proto.ImportStepPostProcess)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, bs := range metas {
+		var subtaskMeta PostProcessStepMeta
+		if err := json.Unmarshal(bs, &subtaskMeta); err != nil {
+			return errors.Trace(err)
+		}
+		if subtaskMeta.TiCIIndexSummary != nil {
+			taskMeta.Summary.TiCIIndexSummary = subtaskMeta.TiCIIndexSummary
+		}
+	}
+	return nil
 }
 
 // GetEligibleInstances implements scheduler.Extension interface.

--- a/pkg/dxf/importinto/scheduler_test.go
+++ b/pkg/dxf/importinto/scheduler_test.go
@@ -24,11 +24,36 @@ import (
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/scheduler"
+	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/execute"
 	"github.com/pingcap/tidb/pkg/executor/importer"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	drivererr "github.com/pingcap/tidb/pkg/store/driver/error"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
+
+type postProcessMetaTaskHandle struct {
+	metas [][]byte
+}
+
+func (h *postProcessMetaTaskHandle) GetPreviousSubtaskMetas(_ int64, step proto.Step) ([][]byte, error) {
+	if step != proto.ImportStepPostProcess {
+		return nil, nil
+	}
+	return h.metas, nil
+}
+
+func (*postProcessMetaTaskHandle) GetPreviousSubtaskSummary(int64, proto.Step) ([]*execute.SubtaskSummary, error) {
+	return nil, nil
+}
+
+func (*postProcessMetaTaskHandle) WithNewSession(func(sessionctx.Context) error) error {
+	return nil
+}
+
+func (*postProcessMetaTaskHandle) WithNewTxn(context.Context, func(sessionctx.Context) error) error {
+	return nil
+}
 
 type importIntoSuite struct {
 	suite.Suite
@@ -168,4 +193,29 @@ func TestIsImporting2TiKV(t *testing.T) {
 	require.False(t, ext.isImporting2TiKV(&proto.Task{TaskBase: proto.TaskBase{Step: proto.ImportStepPostProcess}}))
 	require.True(t, ext.isImporting2TiKV(&proto.Task{TaskBase: proto.TaskBase{Step: proto.ImportStepImport}}))
 	require.True(t, ext.isImporting2TiKV(&proto.Task{TaskBase: proto.TaskBase{Step: proto.ImportStepWriteAndIngest}}))
+}
+
+func TestMergeTiCIIndexSummaryFromPostProcess(t *testing.T) {
+	ticiSummary := &importer.TiCIIndexSummary{
+		Incomplete:      true,
+		TableID:         1,
+		IndexIDs:        []int64{101, 102},
+		ReadyIndexIDs:   []int64{101},
+		PendingIndexIDs: []int64{102},
+		ErrorIndexIDs:   []int64{102},
+		Reason:          "check-add-index-progress-failed",
+		ErrorMessage:    "tici unavailable",
+	}
+	postProcessMeta, err := json.Marshal(&PostProcessStepMeta{TiCIIndexSummary: ticiSummary})
+	require.NoError(t, err)
+
+	taskMeta := &TaskMeta{}
+	err = mergeTiCIIndexSummaryFromPostProcess(
+		context.Background(),
+		&postProcessMetaTaskHandle{metas: [][]byte{postProcessMeta}},
+		&proto.Task{TaskBase: proto.TaskBase{ID: 123}},
+		taskMeta,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ticiSummary, taskMeta.Summary.TiCIIndexSummary)
 }

--- a/pkg/dxf/importinto/subtask_executor.go
+++ b/pkg/dxf/importinto/subtask_executor.go
@@ -62,7 +62,7 @@ func newImportMinimalTaskExecutor0(t *importStepMinimalTask) MiniTaskExecutor {
 	}
 }
 
-const importIntoTiCIIndexReadyPollInterval = 2 * time.Second
+const importIntoTiCIIndexReadyPollInterval = 15 * time.Second
 
 var (
 	finishTiCIIndexUpload       = tici.FinishIndexUpload

--- a/pkg/dxf/importinto/subtask_executor.go
+++ b/pkg/dxf/importinto/subtask_executor.go
@@ -16,6 +16,9 @@ package importinto
 
 import (
 	"context"
+	goerrors "errors"
+	"sort"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -59,7 +62,13 @@ func newImportMinimalTaskExecutor0(t *importStepMinimalTask) MiniTaskExecutor {
 	}
 }
 
-var finishTiCIIndexUpload = tici.FinishIndexUpload
+const importIntoTiCIIndexReadyPollInterval = 2 * time.Second
+
+var (
+	finishTiCIIndexUpload       = tici.FinishIndexUpload
+	checkTiCIAddIndexProgress   = tici.CheckAddIndexProgress
+	waitTiCIIndexProgressPollFn = waitTiCIIndexProgressPoll
+)
 
 func (e *importMinimalTaskExecutor) Run(
 	ctx context.Context,
@@ -128,7 +137,24 @@ func (p *postProcessStepExecutor) postProcess(ctx context.Context, subtaskMeta *
 		return err
 	}
 
-	finishTiCIIndexUploadForPostProcess(ctx, p.store, p.taskID, p.taskMeta.JobID, plan, logger)
+	ticiIndexIDs, shouldWaitTiCIIndexReady, ticiSummary := finishTiCIIndexUploadForPostProcess(
+		ctx, p.store, p.taskID, p.taskMeta.JobID, plan, logger)
+	if ticiSummary != nil {
+		subtaskMeta.TiCIIndexSummary = ticiSummary
+	}
+	waitTiCIIndexReady := func() error {
+		if !shouldWaitTiCIIndexReady {
+			return nil
+		}
+		ticiSummary, err := waitTiCIIndexesReadyForPostProcess(ctx, p.store, p.taskID, plan.TableInfo.ID, ticiIndexIDs, logger)
+		if err != nil {
+			return err
+		}
+		if ticiSummary != nil {
+			subtaskMeta.TiCIIndexSummary = ticiSummary
+		}
+		return nil
+	}
 
 	localChecksum := verify.NewKVGroupChecksumForAdd()
 	for id, cksum := range subtaskMeta.Checksum {
@@ -150,7 +176,7 @@ func (p *postProcessStepExecutor) postProcess(ctx context.Context, subtaskMeta *
 		zap.Stringer("final", &finalChecksum))
 	if subtaskMeta.TooManyConflictsFromIndex {
 		callLog.Info("too many conflicts from index, skip verify checksum, as the checksum of deleted rows may be inaccurate")
-		return nil
+		return waitTiCIIndexReady()
 	}
 
 	ctx = util.WithInternalSourceType(ctx, kv.InternalDistTask)
@@ -160,7 +186,7 @@ func (p *postProcessStepExecutor) postProcess(ctx context.Context, subtaskMeta *
 			uint(plan.DistSQLScanConcurrency), bfWeight, resourcegroup.DefaultResourceGroupName)
 		defer mgr.Close()
 		checksumTableInfo := importer.TableInfoForRemoteChecksumValidation(plan)
-		return importer.VerifyChecksum(ctx, plan, finalChecksum, logger,
+		if err = importer.VerifyChecksum(ctx, plan, finalChecksum, logger,
 			func() (*local.RemoteChecksum, error) {
 				ctxWithLogger := logutil.WithLogger(ctx, logger)
 				return mgr.Checksum(ctxWithLogger, &checkpoints.TidbTableInfo{
@@ -169,10 +195,13 @@ func (p *postProcessStepExecutor) postProcess(ctx context.Context, subtaskMeta *
 					Core: checksumTableInfo,
 				})
 			},
-		)
+		); err != nil {
+			return err
+		}
+		return waitTiCIIndexReady()
 	}
 
-	return p.taskTbl.WithNewSession(func(se sessionctx.Context) error {
+	if err = p.taskTbl.WithNewSession(func(se sessionctx.Context) error {
 		err = importer.VerifyChecksum(ctx, plan, finalChecksum, logger,
 			func() (*local.RemoteChecksum, error) {
 				return importer.RemoteChecksumTableBySQL(ctx, se, plan, logger)
@@ -190,7 +219,10 @@ func (p *postProcessStepExecutor) postProcess(ctx context.Context, subtaskMeta *
 			}
 		}
 		return err
-	})
+	}); err != nil {
+		return err
+	}
+	return waitTiCIIndexReady()
 }
 
 func finishTiCIIndexUploadForPostProcess(
@@ -200,14 +232,14 @@ func finishTiCIIndexUploadForPostProcess(
 	jobID int64,
 	plan *importer.Plan,
 	logger *zap.Logger,
-) {
+) ([]int64, bool, *importer.TiCIIndexSummary) {
 	if plan == nil || plan.TableInfo == nil {
-		return
+		return nil, false, nil
 	}
 
 	ticiIndexIDs := tici.GetTiCIIndexIDs(plan.TableInfo)
 	if len(ticiIndexIDs) == 0 {
-		return
+		return nil, false, nil
 	}
 
 	tidbTaskID := ticiTaskIDForImportInto(jobID)
@@ -218,7 +250,14 @@ func finishTiCIIndexUploadForPostProcess(
 			zap.Int64s("tici-index-ids", ticiIndexIDs),
 			zap.Error(err),
 		)
-		return
+		return ticiIndexIDs, false, &importer.TiCIIndexSummary{
+			Incomplete:      true,
+			TableID:         plan.TableInfo.ID,
+			IndexIDs:        cloneSortedInt64s(ticiIndexIDs),
+			PendingIndexIDs: cloneSortedInt64s(ticiIndexIDs),
+			Reason:          "finish-index-upload-failed",
+			ErrorMessage:    err.Error(),
+		}
 	}
 
 	logger.Info(
@@ -226,4 +265,129 @@ func finishTiCIIndexUploadForPostProcess(
 		zap.Int64("task-id", taskID),
 		zap.Int64s("tici-index-ids", ticiIndexIDs),
 	)
+	return ticiIndexIDs, true, nil
+}
+
+func waitTiCIIndexesReadyForPostProcess(
+	ctx context.Context,
+	store kv.Storage,
+	taskID int64,
+	tableID int64,
+	ticiIndexIDs []int64,
+	logger *zap.Logger,
+) (*importer.TiCIIndexSummary, error) {
+	if len(ticiIndexIDs) == 0 {
+		return nil, nil
+	}
+
+	allIndexIDs := cloneSortedInt64s(ticiIndexIDs)
+	pending := make(map[int64]struct{}, len(allIndexIDs))
+	for _, indexID := range allIndexIDs {
+		pending[indexID] = struct{}{}
+	}
+	readyIndexIDs := make([]int64, 0, len(allIndexIDs))
+
+	logger.Info(
+		"start checking TiCI indexes readiness for post process",
+		zap.Int64("task-id", taskID),
+		zap.Int64("table-id", tableID),
+		zap.Int64s("tici-index-ids", allIndexIDs),
+	)
+
+	for len(pending) > 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		for _, indexID := range sortedPendingTiCIIndexIDs(pending) {
+			ready, err := checkTiCIAddIndexProgress(ctx, store, tableID, indexID)
+			if err != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return nil, ctxErr
+				}
+				if goerrors.Is(err, context.Canceled) || goerrors.Is(err, context.DeadlineExceeded) {
+					return nil, err
+				}
+				logger.Warn(
+					"failed to check TiCI index progress for post process",
+					zap.Int64("task-id", taskID),
+					zap.Int64("table-id", tableID),
+					zap.Int64("tici-index-id", indexID),
+					zap.Int64s("all-tici-index-ids", allIndexIDs),
+					zap.Error(err),
+				)
+				return &importer.TiCIIndexSummary{
+					Incomplete:      true,
+					TableID:         tableID,
+					IndexIDs:        allIndexIDs,
+					ReadyIndexIDs:   cloneSortedInt64s(readyIndexIDs),
+					PendingIndexIDs: sortedPendingTiCIIndexIDs(pending),
+					ErrorIndexIDs:   []int64{indexID},
+					Reason:          "check-add-index-progress-failed",
+					ErrorMessage:    err.Error(),
+				}, nil
+			}
+			if ready {
+				delete(pending, indexID)
+				readyIndexIDs = append(readyIndexIDs, indexID)
+				logger.Info(
+					"TiCI index is ready for post process",
+					zap.Int64("task-id", taskID),
+					zap.Int64("table-id", tableID),
+					zap.Int64("tici-index-id", indexID),
+				)
+			}
+		}
+		if len(pending) == 0 {
+			logger.Info(
+				"all TiCI indexes are ready for post process",
+				zap.Int64("task-id", taskID),
+				zap.Int64("table-id", tableID),
+				zap.Int64s("tici-index-ids", allIndexIDs),
+			)
+			return nil, nil
+		}
+		logger.Debug(
+			"waiting for TiCI indexes to be ready for post process",
+			zap.Int64("task-id", taskID),
+			zap.Int64("table-id", tableID),
+			zap.Int64s("pending-tici-index-ids", sortedPendingTiCIIndexIDs(pending)),
+		)
+		if err := waitTiCIIndexProgressPollFn(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
+func waitTiCIIndexProgressPoll(ctx context.Context) error {
+	timer := time.NewTimer(importIntoTiCIIndexReadyPollInterval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func cloneSortedInt64s(input []int64) []int64 {
+	if len(input) == 0 {
+		return nil
+	}
+	output := append([]int64(nil), input...)
+	sort.Slice(output, func(i, j int) bool {
+		return output[i] < output[j]
+	})
+	return output
+}
+
+func sortedPendingTiCIIndexIDs(pending map[int64]struct{}) []int64 {
+	indexIDs := make([]int64, 0, len(pending))
+	for indexID := range pending {
+		indexIDs = append(indexIDs, indexID)
+	}
+	sort.Slice(indexIDs, func(i, j int) bool {
+		return indexIDs[i] < indexIDs[j]
+	})
+	return indexIDs
 }

--- a/pkg/dxf/importinto/task_executor.go
+++ b/pkg/dxf/importinto/task_executor.go
@@ -829,7 +829,11 @@ func (p *postProcessStepExecutor) RunSubtask(ctx context.Context, subtask *proto
 	failpoint.Inject("waitBeforePostProcess", func() {
 		time.Sleep(5 * time.Second)
 	})
-	return p.postProcess(ctx, &stepMeta, logger)
+	if err = p.postProcess(ctx, &stepMeta, logger); err != nil {
+		return err
+	}
+	subtask.Meta, err = json.Marshal(&stepMeta)
+	return errors.Trace(err)
 }
 
 type importExecutor struct {

--- a/pkg/dxf/importinto/task_executor_test.go
+++ b/pkg/dxf/importinto/task_executor_test.go
@@ -16,6 +16,7 @@ package importinto
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -34,7 +35,6 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/types"
@@ -311,6 +311,7 @@ func TestFinishTiCIIndexUploadForPostProcess(t *testing.T) {
 		plan        *importer.Plan
 		finishErr   error
 		wantTaskIDs []string
+		wantWait    bool
 		wantWarn    bool
 		wantInfo    bool
 	}{
@@ -329,6 +330,7 @@ func TestFinishTiCIIndexUploadForPostProcess(t *testing.T) {
 			name:        "tici index finishes upload",
 			plan:        makePlan(true),
 			wantTaskIDs: []string{TaskKey(jobID)},
+			wantWait:    true,
 			wantInfo:    true,
 		},
 		{
@@ -350,9 +352,11 @@ func TestFinishTiCIIndexUploadForPostProcess(t *testing.T) {
 			core, recorded := observer.New(zap.DebugLevel)
 			logger := zap.New(core)
 
-			finishTiCIIndexUploadForPostProcess(context.Background(), nil, 123, jobID, tt.plan, logger)
+			gotIndexIDs, gotWait, gotSummary := finishTiCIIndexUploadForPostProcess(
+				context.Background(), nil, 123, jobID, tt.plan, logger)
 
 			require.Equal(t, tt.wantTaskIDs, gotTaskIDs)
+			require.Equal(t, tt.wantWait, gotWait)
 			warns := recorded.FilterMessage("failed to finish TiCI index upload for post process").All()
 			if tt.wantWarn {
 				require.Len(t, warns, 1)
@@ -360,8 +364,17 @@ func TestFinishTiCIIndexUploadForPostProcess(t *testing.T) {
 				require.Equal(t, int64(123), fields["task-id"])
 				require.Equal(t, []any{int64(101)}, fields["tici-index-ids"])
 				require.Equal(t, finishErr.Error(), fields["error"])
+				require.Equal(t, []int64{101}, gotIndexIDs)
+				require.NotNil(t, gotSummary)
+				require.True(t, gotSummary.Incomplete)
+				require.Equal(t, int64(1), gotSummary.TableID)
+				require.Equal(t, []int64{101}, gotSummary.IndexIDs)
+				require.Equal(t, []int64{101}, gotSummary.PendingIndexIDs)
+				require.Equal(t, "finish-index-upload-failed", gotSummary.Reason)
+				require.Equal(t, finishErr.Error(), gotSummary.ErrorMessage)
 			} else {
 				require.Empty(t, warns)
+				require.Nil(t, gotSummary)
 			}
 			infos := recorded.FilterMessage("finished TiCI index upload for post process").All()
 			if tt.wantInfo {
@@ -369,6 +382,7 @@ func TestFinishTiCIIndexUploadForPostProcess(t *testing.T) {
 				fields := infos[0].ContextMap()
 				require.Equal(t, int64(123), fields["task-id"])
 				require.Equal(t, []any{int64(101)}, fields["tici-index-ids"])
+				require.Equal(t, []int64{101}, gotIndexIDs)
 			} else {
 				require.Empty(t, infos)
 			}
@@ -376,13 +390,106 @@ func TestFinishTiCIIndexUploadForPostProcess(t *testing.T) {
 	}
 }
 
+func TestWaitTiCIIndexesReadyForPostProcess(t *testing.T) {
+	originCheckTiCIAddIndexProgress := checkTiCIAddIndexProgress
+	originWaitTiCIIndexProgressPollFn := waitTiCIIndexProgressPollFn
+	t.Cleanup(func() {
+		checkTiCIAddIndexProgress = originCheckTiCIAddIndexProgress
+		waitTiCIIndexProgressPollFn = originWaitTiCIIndexProgressPollFn
+	})
+
+	var gotIndexIDs []int64
+	readySeq := map[int64][]bool{
+		101: {false, true},
+		102: {true},
+	}
+	checkTiCIAddIndexProgress = func(_ context.Context, _ kv.Storage, tableID, indexID int64) (bool, error) {
+		require.Equal(t, int64(1), tableID)
+		gotIndexIDs = append(gotIndexIDs, indexID)
+		seq := readySeq[indexID]
+		require.NotEmpty(t, seq)
+		readySeq[indexID] = seq[1:]
+		return seq[0], nil
+	}
+	waitCount := 0
+	waitTiCIIndexProgressPollFn = func(context.Context) error {
+		waitCount++
+		return nil
+	}
+
+	summary, err := waitTiCIIndexesReadyForPostProcess(context.Background(), nil, 123, 1, []int64{102, 101}, zap.NewNop())
+	require.NoError(t, err)
+	require.Nil(t, summary)
+	require.Equal(t, []int64{101, 102, 101}, gotIndexIDs)
+	require.Equal(t, 1, waitCount)
+}
+
+func TestWaitTiCIIndexesReadyForPostProcessCheckError(t *testing.T) {
+	originCheckTiCIAddIndexProgress := checkTiCIAddIndexProgress
+	originWaitTiCIIndexProgressPollFn := waitTiCIIndexProgressPollFn
+	t.Cleanup(func() {
+		checkTiCIAddIndexProgress = originCheckTiCIAddIndexProgress
+		waitTiCIIndexProgressPollFn = originWaitTiCIIndexProgressPollFn
+	})
+
+	checkErr := errors.New("tici unavailable")
+	var gotIndexIDs []int64
+	checkTiCIAddIndexProgress = func(_ context.Context, _ kv.Storage, _ int64, indexID int64) (bool, error) {
+		gotIndexIDs = append(gotIndexIDs, indexID)
+		if indexID == 102 {
+			return false, checkErr
+		}
+		return true, nil
+	}
+	waitTiCIIndexProgressPollFn = func(context.Context) error {
+		require.FailNow(t, "should not wait after TiCI check error")
+		return nil
+	}
+
+	summary, err := waitTiCIIndexesReadyForPostProcess(context.Background(), nil, 123, 1, []int64{102, 101}, zap.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	require.True(t, summary.Incomplete)
+	require.Equal(t, int64(1), summary.TableID)
+	require.Equal(t, []int64{101, 102}, summary.IndexIDs)
+	require.Equal(t, []int64{101}, summary.ReadyIndexIDs)
+	require.Equal(t, []int64{102}, summary.PendingIndexIDs)
+	require.Equal(t, []int64{102}, summary.ErrorIndexIDs)
+	require.Equal(t, "check-add-index-progress-failed", summary.Reason)
+	require.Equal(t, checkErr.Error(), summary.ErrorMessage)
+	require.Equal(t, []int64{101, 102}, gotIndexIDs)
+}
+
+func TestWaitTiCIIndexesReadyForPostProcessContextCanceled(t *testing.T) {
+	originCheckTiCIAddIndexProgress := checkTiCIAddIndexProgress
+	t.Cleanup(func() {
+		checkTiCIAddIndexProgress = originCheckTiCIAddIndexProgress
+	})
+	checkTiCIAddIndexProgress = func(context.Context, kv.Storage, int64, int64) (bool, error) {
+		require.FailNow(t, "should not check TiCI progress after context is canceled")
+		return false, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	summary, err := waitTiCIIndexesReadyForPostProcess(ctx, nil, 123, 1, []int64{101}, zap.NewNop())
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, summary)
+}
+
 func TestPostProcessTiCIFinishFailureDoesNotAbort(t *testing.T) {
 	originFinishTiCIIndexUpload := finishTiCIIndexUpload
+	originCheckTiCIAddIndexProgress := checkTiCIAddIndexProgress
 	t.Cleanup(func() {
 		finishTiCIIndexUpload = originFinishTiCIIndexUpload
+		checkTiCIAddIndexProgress = originCheckTiCIAddIndexProgress
 	})
 	finishTiCIIndexUpload = func(_ context.Context, _ kv.Storage, _ string) error {
 		return errors.New("finish failed")
+	}
+	checkTiCIAddIndexProgress = func(context.Context, kv.Storage, int64, int64) (bool, error) {
+		require.FailNow(t, "should not check TiCI progress after FinishIndexUpload fails")
+		return false, nil
 	}
 
 	indexInfo := &model.IndexInfo{
@@ -412,23 +519,133 @@ func TestPostProcessTiCIFinishFailureDoesNotAbort(t *testing.T) {
 		logger: logger,
 	}
 
-	err := executor.postProcess(context.Background(), &PostProcessStepMeta{TooManyConflictsFromIndex: true}, logger)
+	stepMeta := &PostProcessStepMeta{TooManyConflictsFromIndex: true}
+	err := executor.postProcess(context.Background(), stepMeta, logger)
 	require.NoError(t, err)
 	require.Len(t, recorded.FilterMessage("failed to finish TiCI index upload for post process").All(), 1)
+	require.NotNil(t, stepMeta.TiCIIndexSummary)
+	require.True(t, stepMeta.TiCIIndexSummary.Incomplete)
+	require.Equal(t, "finish-index-upload-failed", stepMeta.TiCIIndexSummary.Reason)
 
 	ctrl := gomock.NewController(t)
 	taskTbl := frameworkmock.NewMockTaskTable(ctrl)
-	taskTbl.EXPECT().WithNewSession(gomock.Any()).AnyTimes().DoAndReturn(func(fn func(sessionctx.Context) error) error {
-		return fn(nil)
-	})
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/dxf/importinto/skipPostProcessAlterTableMode", "return(true)")
+	taskTbl.EXPECT().WithNewSession(gomock.Any()).AnyTimes().Return(nil)
 	core, recorded = observer.New(zap.DebugLevel)
 	logger = zap.New(core)
 	executor.taskTbl = taskTbl
 	executor.logger = logger
 	executor.taskMeta.Plan.Checksum = config.OpLevelOff
 
-	err = executor.postProcess(context.Background(), &PostProcessStepMeta{}, logger)
+	stepMeta = &PostProcessStepMeta{}
+	err = executor.postProcess(context.Background(), stepMeta, logger)
 	require.NoError(t, err)
 	require.Len(t, recorded.FilterMessage("failed to finish TiCI index upload for post process").All(), 1)
+	require.NotNil(t, stepMeta.TiCIIndexSummary)
+	require.True(t, stepMeta.TiCIIndexSummary.Incomplete)
+}
+
+func TestPostProcessWaitsTiCIIndexReadyAfterSkippedChecksum(t *testing.T) {
+	originFinishTiCIIndexUpload := finishTiCIIndexUpload
+	originCheckTiCIAddIndexProgress := checkTiCIAddIndexProgress
+	t.Cleanup(func() {
+		finishTiCIIndexUpload = originFinishTiCIIndexUpload
+		checkTiCIAddIndexProgress = originCheckTiCIAddIndexProgress
+	})
+	finishTiCIIndexUpload = func(context.Context, kv.Storage, string) error {
+		return nil
+	}
+	var checkedIndexIDs []int64
+	checkTiCIAddIndexProgress = func(_ context.Context, _ kv.Storage, tableID, indexID int64) (bool, error) {
+		require.Equal(t, int64(1), tableID)
+		checkedIndexIDs = append(checkedIndexIDs, indexID)
+		return true, nil
+	}
+
+	indexInfo := &model.IndexInfo{
+		ID:           101,
+		Name:         ast.NewCIStr("idx_fulltext"),
+		FullTextInfo: &model.FullTextIndexInfo{},
+		State:        model.StatePublic,
+	}
+	tableInfo := &model.TableInfo{
+		ID:         1,
+		Name:       ast.NewCIStr("t"),
+		PKIsHandle: true,
+		Indices:    []*model.IndexInfo{indexInfo},
+	}
+	executor := &postProcessStepExecutor{
+		taskID: 123,
+		taskMeta: &TaskMeta{
+			JobID: 456,
+			Plan: importer.Plan{
+				DBName:           "test",
+				TableInfo:        tableInfo,
+				DesiredTableInfo: tableInfo,
+			},
+		},
+		logger: zap.NewNop(),
+	}
+
+	stepMeta := &PostProcessStepMeta{TooManyConflictsFromIndex: true}
+	err := executor.postProcess(context.Background(), stepMeta, zap.NewNop())
+	require.NoError(t, err)
+	require.Equal(t, []int64{101}, checkedIndexIDs)
+	require.Nil(t, stepMeta.TiCIIndexSummary)
+}
+
+func TestPostProcessRunSubtaskPersistsTiCIIndexSummary(t *testing.T) {
+	originFinishTiCIIndexUpload := finishTiCIIndexUpload
+	originCheckTiCIAddIndexProgress := checkTiCIAddIndexProgress
+	t.Cleanup(func() {
+		finishTiCIIndexUpload = originFinishTiCIIndexUpload
+		checkTiCIAddIndexProgress = originCheckTiCIAddIndexProgress
+	})
+	finishErr := errors.New("finish failed")
+	finishTiCIIndexUpload = func(context.Context, kv.Storage, string) error {
+		return finishErr
+	}
+	checkTiCIAddIndexProgress = func(context.Context, kv.Storage, int64, int64) (bool, error) {
+		require.FailNow(t, "should not check TiCI progress after FinishIndexUpload fails")
+		return false, nil
+	}
+
+	indexInfo := &model.IndexInfo{
+		ID:           101,
+		Name:         ast.NewCIStr("idx_fulltext"),
+		FullTextInfo: &model.FullTextIndexInfo{},
+		State:        model.StatePublic,
+	}
+	tableInfo := &model.TableInfo{
+		ID:         1,
+		Name:       ast.NewCIStr("t"),
+		PKIsHandle: true,
+		Indices:    []*model.IndexInfo{indexInfo},
+	}
+	executor := &postProcessStepExecutor{
+		taskID: 123,
+		taskMeta: &TaskMeta{
+			JobID: 456,
+			Plan: importer.Plan{
+				DBName:           "test",
+				TableInfo:        tableInfo,
+				DesiredTableInfo: tableInfo,
+			},
+		},
+		logger: zap.NewNop(),
+	}
+	metaBytes, err := json.Marshal(&PostProcessStepMeta{TooManyConflictsFromIndex: true})
+	require.NoError(t, err)
+	subtask := &proto.Subtask{
+		SubtaskBase: proto.SubtaskBase{ID: 1},
+		Meta:        metaBytes,
+	}
+
+	require.NoError(t, executor.RunSubtask(context.Background(), subtask))
+	var got PostProcessStepMeta
+	require.NoError(t, json.Unmarshal(subtask.Meta, &got))
+	require.NotNil(t, got.TiCIIndexSummary)
+	require.True(t, got.TiCIIndexSummary.Incomplete)
+	require.Equal(t, []int64{101}, got.TiCIIndexSummary.PendingIndexIDs)
+	require.Equal(t, "finish-index-upload-failed", got.TiCIIndexSummary.Reason)
+	require.Equal(t, finishErr.Error(), got.TiCIIndexSummary.ErrorMessage)
 }

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -357,6 +357,27 @@ type Summary struct {
 	// cannot deduplicate during collecting its checksum, so we will skip later
 	// checksum step.
 	TooManyConflicts bool `json:"too-many-conflicts,omitempty"`
+
+	// TiCIIndexSummary records TiCI full-text index readiness warnings for
+	// IMPORT INTO. A finished import job can still have this field when TiKV
+	// import completed but TiCI full-text indexes are incomplete.
+	TiCIIndexSummary *TiCIIndexSummary `json:"tici-index-summary,omitempty"`
+}
+
+// TiCIIndexSummary records TiCI full-text index readiness status for IMPORT INTO.
+type TiCIIndexSummary struct {
+	Incomplete bool `json:"incomplete,omitempty"`
+
+	TableID  int64   `json:"table-id,omitempty"`
+	IndexIDs []int64 `json:"index-ids,omitempty"`
+
+	ReadyIndexIDs   []int64 `json:"ready-index-ids,omitempty"`
+	PendingIndexIDs []int64 `json:"pending-index-ids,omitempty"`
+	FailedIndexIDs  []int64 `json:"failed-index-ids,omitempty"`
+	ErrorIndexIDs   []int64 `json:"error-index-ids,omitempty"`
+
+	Reason       string `json:"reason,omitempty"`
+	ErrorMessage string `json:"error-message,omitempty"`
 }
 
 // LoadDataController load data controller.

--- a/pkg/executor/importer/job_test.go
+++ b/pkg/executor/importer/job_test.go
@@ -156,6 +156,37 @@ func TestJobHappyPath(t *testing.T) {
 	}
 }
 
+func TestJobSummaryTiCIIndexSummaryRoundTrip(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	ctx := context.Background()
+	conn := tk.Session().GetSQLExecutor()
+
+	jobID, err := importer.CreateJob(ctx, conn, "test", "t", 1,
+		"root", "", &importer.ImportParameters{}, 123)
+	require.NoError(t, err)
+	require.NoError(t, importer.StartJob(ctx, conn, jobID, importer.JobStepValidating))
+
+	summary := &importer.Summary{
+		ImportedRows: 100,
+		TiCIIndexSummary: &importer.TiCIIndexSummary{
+			Incomplete:      true,
+			TableID:         1,
+			IndexIDs:        []int64{101, 102},
+			ReadyIndexIDs:   []int64{101},
+			PendingIndexIDs: []int64{102},
+			ErrorIndexIDs:   []int64{102},
+			Reason:          "check-add-index-progress-failed",
+			ErrorMessage:    "tici unavailable",
+		},
+	}
+	require.NoError(t, importer.FinishJob(ctx, conn, jobID, summary))
+
+	jobInfo, err := importer.GetJob(ctx, conn, jobID, "root", true)
+	require.NoError(t, err)
+	require.Equal(t, summary, jobInfo.Summary)
+}
+
 func TestGetAndCancelJob(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -2459,6 +2459,9 @@ func FillOneImportJobInfo(result *chunk.Chunk, info *importer.JobInfo, runInfo *
 		if info.Summary.TooManyConflicts {
 			msgItems = append(msgItems, "Too many conflicted rows, checksum skipped.")
 		}
+		if msg := formatTiCIIndexResultMessage(info.Summary.TiCIIndexSummary); msg != "" {
+			msgItems = append(msgItems, msg)
+		}
 		result.AppendString(9, strings.Join(msgItems, " "))
 	} else {
 		result.AppendString(9, info.ErrorMessage)
@@ -2504,6 +2507,40 @@ func FillOneImportJobInfo(result *chunk.Chunk, info *importer.JobInfo, runInfo *
 	result.AppendString(18, runInfo.Percent())
 	result.AppendString(19, fmt.Sprintf("%s/s", units.BytesSize(float64(runInfo.Speed))))
 	result.AppendString(20, runInfo.ETA())
+}
+
+func formatTiCIIndexResultMessage(summary *importer.TiCIIndexSummary) string {
+	if summary == nil || !summary.Incomplete {
+		return ""
+	}
+	msgItems := []string{
+		"TiKV import completed, but TiCI full-text index is incomplete; rebuild the full-text index and clean TiCI metadata if needed.",
+	}
+	if summary.Reason != "" {
+		msgItems = append(msgItems, fmt.Sprintf("reason: %s.", summary.Reason))
+	}
+	if summary.TableID != 0 {
+		msgItems = append(msgItems, fmt.Sprintf("table ID: %d.", summary.TableID))
+	}
+	if len(summary.IndexIDs) > 0 {
+		msgItems = append(msgItems, fmt.Sprintf("index IDs: %v.", summary.IndexIDs))
+	}
+	if len(summary.ReadyIndexIDs) > 0 {
+		msgItems = append(msgItems, fmt.Sprintf("ready index IDs: %v.", summary.ReadyIndexIDs))
+	}
+	if len(summary.PendingIndexIDs) > 0 {
+		msgItems = append(msgItems, fmt.Sprintf("pending index IDs: %v.", summary.PendingIndexIDs))
+	}
+	if len(summary.FailedIndexIDs) > 0 {
+		msgItems = append(msgItems, fmt.Sprintf("failed index IDs: %v.", summary.FailedIndexIDs))
+	}
+	if len(summary.ErrorIndexIDs) > 0 {
+		msgItems = append(msgItems, fmt.Sprintf("error index IDs: %v.", summary.ErrorIndexIDs))
+	}
+	if summary.ErrorMessage != "" {
+		msgItems = append(msgItems, fmt.Sprintf("error: %s.", summary.ErrorMessage))
+	}
+	return strings.Join(msgItems, " ")
 }
 
 func handleImportJobInfo(

--- a/pkg/executor/show_test.go
+++ b/pkg/executor/show_test.go
@@ -15,6 +15,7 @@
 package executor_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -53,6 +54,7 @@ func TestFillOneImportJobInfo(t *testing.T) {
 
 	fmap := plannercore.ImportIntoFieldMap
 	rowCntIdx := fmap["ImportedRows"]
+	resultMsgIdx := fmap["ResultMessage"]
 	startIdx := fmap["StartTime"]
 	endIdx := fmap["EndTime"]
 
@@ -79,6 +81,46 @@ func TestFillOneImportJobInfo(t *testing.T) {
 	require.False(t, c.GetRow(2).IsNull(startIdx))
 	require.False(t, c.GetRow(2).IsNull(endIdx))
 
+	jobInfo.Summary = &importer.Summary{
+		ImportedRows: 123,
+		TiCIIndexSummary: &importer.TiCIIndexSummary{
+			Incomplete:      true,
+			TableID:         42,
+			IndexIDs:        []int64{101, 102},
+			ReadyIndexIDs:   []int64{101},
+			PendingIndexIDs: []int64{102},
+			ErrorIndexIDs:   []int64{102},
+			Reason:          "check-add-index-progress-failed",
+			ErrorMessage:    "tici unavailable",
+		},
+	}
+	executor.FillOneImportJobInfo(c, jobInfo, nil)
+	resultMsg := c.GetRow(3).GetString(resultMsgIdx)
+	for _, expected := range []string{
+		"TiKV import completed, but TiCI full-text index is incomplete",
+		"reason: check-add-index-progress-failed.",
+		"table ID: 42.",
+		"index IDs: [101 102].",
+		"ready index IDs: [101].",
+		"pending index IDs: [102].",
+		"error index IDs: [102].",
+		"error: tici unavailable.",
+	} {
+		require.True(t, strings.Contains(resultMsg, expected), resultMsg)
+	}
+
+	jobInfo.Summary.ConflictRowCnt = 2
+	jobInfo.Summary.TooManyConflicts = true
+	executor.FillOneImportJobInfo(c, jobInfo, nil)
+	resultMsg = c.GetRow(4).GetString(resultMsgIdx)
+	for _, expected := range []string{
+		"2 conflicted rows.",
+		"Too many conflicted rows, checksum skipped.",
+		"TiKV import completed, but TiCI full-text index is incomplete",
+	} {
+		require.True(t, strings.Contains(resultMsg, expected), resultMsg)
+	}
+
 	ri := &importinto.RuntimeInfo{
 		Processed: 10,
 		Total:     100000,
@@ -86,14 +128,14 @@ func TestFillOneImportJobInfo(t *testing.T) {
 	}
 	jobInfo.Summary = &importer.Summary{ImportedRows: 0}
 	executor.FillOneImportJobInfo(c, jobInfo, ri)
-	require.Equal(t, "10B", c.GetRow(3).GetString(fmap["CurStepProcessedSize"]))
-	require.Equal(t, "97.66KiB", c.GetRow(3).GetString(fmap["CurStepTotalSize"]))
-	require.Equal(t, "0", c.GetRow(3).GetString(fmap["CurStepProgressPct"]))
-	require.Equal(t, "13:53:15", c.GetRow(3).GetString(fmap["CurStepETA"]))
+	require.Equal(t, "10B", c.GetRow(5).GetString(fmap["CurStepProcessedSize"]))
+	require.Equal(t, "97.66KiB", c.GetRow(5).GetString(fmap["CurStepTotalSize"]))
+	require.Equal(t, "0", c.GetRow(5).GetString(fmap["CurStepProgressPct"]))
+	require.Equal(t, "13:53:15", c.GetRow(5).GetString(fmap["CurStepETA"]))
 
 	// runtime info have update time, so use it
 	executor.FillOneImportJobInfo(c, jobInfo, &importinto.RuntimeInfo{ImportRows: 0, UpdateTime: t2025})
-	require.EqualValues(t, t2025, c.GetRow(4).GetTime(14))
+	require.EqualValues(t, t2025, c.GetRow(6).GetTime(14))
 }
 
 func TestShow(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61759

Problem Summary:

`IMPORT INTO` finished after `FinishIndexUpload` without waiting for TiCI indexes to become ready.

### What changed and how does it work?

Wait for all TiCI indexes to be ready in post-process after checksum. If TiCI finish/check fails, keep TiKV import successful and expose a TiCI incomplete warning in job summary / `SHOW IMPORT JOBS`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test: verified `IMPORT INTO` with TiCI full-text index using the failpoint smoke flow.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
IMPORT INTO now waits for TiCI full-text indexes to become ready before reporting success.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IMPORT INTO job summaries now include TiCI full-text index readiness details and a summary field to record incomplete/ready/pending/failed index states.
  * Post-process now coordinates and optionally waits (polls) for TiCI index readiness so readiness info is recorded before job completion.
  * Job result messages now surface TiCI index status, reasons, and error details when readiness is incomplete.

* **Tests**
  * Added/expanded tests validating TiCI summary round-trips, polling behavior, and result-message generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68386)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->