### PR TITLE
planner: enforce exchange for MPP shared CTE readers

### DIFF
--- a/pkg/planner/core/casetest/enforcempp/enforce_mpp_test.go
+++ b/pkg/planner/core/casetest/enforcempp/enforce_mpp_test.go
@@ -575,8 +575,30 @@ func TestMPPSharedCTEScan(t *testing.T) {
 	tk.MustExec("drop table if exists s")
 	tk.MustExec("create table t(a int, b int, c int)")
 	tk.MustExec("create table s(a int, b int, c int)")
-	tk.MustExec("CREATE TABLE `part` (`P_PARTKEY` bigint NOT NULL, `P_NAME` varchar(55) NOT NULL, `P_MFGR` char(25) NOT NULL, `P_BRAND` char(10) NOT NULL, `P_TYPE` varchar(25) NOT NULL, `P_SIZE` bigint NOT NULL, `P_CONTAINER` char(10) NOT NULL, `P_RETAILPRICE` decimal(15,2) NOT NULL, `P_COMMENT` varchar(23) NOT NULL, PRIMARY KEY (`P_PARTKEY`) /*T![clustered_index] CLUSTERED */) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
-	tk.MustExec("CREATE TABLE `orders` (`O_ORDERKEY` bigint NOT NULL, `O_CUSTKEY` bigint NOT NULL, `O_ORDERSTATUS` char(1) NOT NULL, `O_TOTALPRICE` decimal(15,2) NOT NULL, `O_ORDERDATE` date NOT NULL, `O_ORDERPRIORITY` char(15) NOT NULL, `O_CLERK` char(15) NOT NULL, `O_SHIPPRIORITY` bigint NOT NULL, `O_COMMENT` varchar(79) NOT NULL, PRIMARY KEY (`O_ORDERKEY`) /*T![clustered_index] CLUSTERED */) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
+	tk.MustExec(`CREATE TABLE part (
+		P_PARTKEY bigint NOT NULL,
+		P_NAME varchar(55) NOT NULL,
+		P_MFGR char(25) NOT NULL,
+		P_BRAND char(10) NOT NULL,
+		P_TYPE varchar(25) NOT NULL,
+		P_SIZE bigint NOT NULL,
+		P_CONTAINER char(10) NOT NULL,
+		P_RETAILPRICE decimal(15,2) NOT NULL,
+		P_COMMENT varchar(23) NOT NULL,
+		PRIMARY KEY (P_PARTKEY) /*T![clustered_index] CLUSTERED */
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin`)
+	tk.MustExec(`CREATE TABLE orders (
+		O_ORDERKEY bigint NOT NULL,
+		O_CUSTKEY bigint NOT NULL,
+		O_ORDERSTATUS char(1) NOT NULL,
+		O_TOTALPRICE decimal(15,2) NOT NULL,
+		O_ORDERDATE date NOT NULL,
+		O_ORDERPRIORITY char(15) NOT NULL,
+		O_CLERK char(15) NOT NULL,
+		O_SHIPPRIORITY bigint NOT NULL,
+		O_COMMENT varchar(79) NOT NULL,
+		PRIMARY KEY (O_ORDERKEY) /*T![clustered_index] CLUSTERED */
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin`)
 	tk.MustExec("alter table t set tiflash replica 1")
 	tk.MustExec("alter table s set tiflash replica 1")
 	tk.MustExec("alter table part set tiflash replica 1")

--- a/pkg/planner/core/casetest/enforcempp/enforce_mpp_test.go
+++ b/pkg/planner/core/casetest/enforcempp/enforce_mpp_test.go
@@ -575,16 +575,18 @@ func TestMPPSharedCTEScan(t *testing.T) {
 	tk.MustExec("drop table if exists s")
 	tk.MustExec("create table t(a int, b int, c int)")
 	tk.MustExec("create table s(a int, b int, c int)")
+	tk.MustExec("CREATE TABLE `part` (`P_PARTKEY` bigint NOT NULL, `P_NAME` varchar(55) NOT NULL, `P_MFGR` char(25) NOT NULL, `P_BRAND` char(10) NOT NULL, `P_TYPE` varchar(25) NOT NULL, `P_SIZE` bigint NOT NULL, `P_CONTAINER` char(10) NOT NULL, `P_RETAILPRICE` decimal(15,2) NOT NULL, `P_COMMENT` varchar(23) NOT NULL, PRIMARY KEY (`P_PARTKEY`) /*T![clustered_index] CLUSTERED */) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
+	tk.MustExec("CREATE TABLE `orders` (`O_ORDERKEY` bigint NOT NULL, `O_CUSTKEY` bigint NOT NULL, `O_ORDERSTATUS` char(1) NOT NULL, `O_TOTALPRICE` decimal(15,2) NOT NULL, `O_ORDERDATE` date NOT NULL, `O_ORDERPRIORITY` char(15) NOT NULL, `O_CLERK` char(15) NOT NULL, `O_SHIPPRIORITY` bigint NOT NULL, `O_COMMENT` varchar(79) NOT NULL, PRIMARY KEY (`O_ORDERKEY`) /*T![clustered_index] CLUSTERED */) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
 	tk.MustExec("alter table t set tiflash replica 1")
 	tk.MustExec("alter table s set tiflash replica 1")
+	tk.MustExec("alter table part set tiflash replica 1")
+	tk.MustExec("alter table orders set tiflash replica 1")
 
-	tb := external.GetTableByName(t, tk, "test", "t")
-	err := domain.GetDomain(tk.Session()).DDLExecutor().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
-	require.NoError(t, err)
-
-	tb = external.GetTableByName(t, tk, "test", "s")
-	err = domain.GetDomain(tk.Session()).DDLExecutor().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
-	require.NoError(t, err)
+	for _, tableName := range []string{"t", "s", "part", "orders"} {
+		tb := external.GetTableByName(t, tk, "test", tableName)
+		err := domain.GetDomain(tk.Session()).DDLExecutor().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
+		require.NoError(t, err)
+	}
 
 	var input []string
 	var output []struct {
@@ -611,6 +613,39 @@ func TestMPPSharedCTEScan(t *testing.T) {
 		checkEnforceMPPPlanRows(t, res, output[i].Plan, tt)
 		require.Equal(t, output[i].Warn, testdata.ConvertSQLWarnToStrings(tk.Session().GetSessionVars().StmtCtx.GetWarnings()))
 	}
+
+	issue61242Plan := strings.Join(testdata.ConvertRowsToStrings(tk.MustQuery(`
+explain format = 'plan_tree' with cte1 as (
+  select
+    p_partkey,
+    substring(p_comment, 1, 20) as col0,
+    substring(p_comment, 18, 10) as col1,
+    substring(p_name, p_size % 10, 6) as col2
+  from part
+)
+select /* issue:61242 */
+  t3.col0,
+  t3.col1
+from (
+  select
+    t1.p_partkey as col0,
+    t1.col0 as col1
+  from cte1 t1
+  join cte1 t2 on t1.col0 = t2.col1
+) as t3
+join (
+  select
+    orders.o_orderkey as col0
+  from cte1 as t4
+  join orders on t4.col2 = substring(orders.o_comment, 1, 6)
+) as t5 on t3.col0 = t5.col0
+`).Rows()), "\n")
+	require.Contains(t, issue61242Plan, "Sequence mpp[tiflash]")
+	require.Contains(t, issue61242Plan, "CTE_0 mpp[tiflash]  Non-Recursive CTE Storage")
+	require.Contains(t, issue61242Plan, "CTEFullScan mpp[tiflash] CTE:cte1 AS t4 data:CTE_0")
+	require.NotContains(t, issue61242Plan, "CTEFullScan root")
+	require.NotContains(t, issue61242Plan, "CTE_0 root")
+	require.Empty(t, testdata.ConvertSQLWarnToStrings(tk.Session().GetSessionVars().StmtCtx.GetWarnings()))
 }
 
 func TestRollupMPP(t *testing.T) {

--- a/pkg/planner/core/operator/physicalop/physical_cte.go
+++ b/pkg/planner/core/operator/physicalop/physical_cte.go
@@ -269,10 +269,19 @@ func findBestTask4LogicalCTE(super base.LogicalPlan, prop *property.PhysicalProp
 	pcte := PhysicalCTE{SeedPlan: p.Cte.SeedPartPhysicalPlan, RecurPlan: p.Cte.RecursivePartPhysicalPlan, CTE: p.Cte, CteAsName: p.CteAsName, CteName: p.CteName}.Init(p.SCtx(), p.StatsInfo())
 	pcte.SetSchema(p.Schema())
 	if prop.IsFlashProp() && prop.CTEProducerStatus == property.AllCTECanMpp {
+		partitionTp := prop.MPPPartitionTp
+		partitionCols := prop.MPPPartitionCols
 		if prop.MPPPartitionTp != property.AnyType {
-			return base.InvalidTask, nil
+			if !prop.CanAddEnforcer {
+				return base.InvalidTask, nil
+			}
+			// The shared CTE storage/source itself is not tied to one consumer's
+			// distribution requirement. Build the reader as AnyType first and let
+			// the consumer-side enforcer add the required exchange above it.
+			partitionTp = property.AnyType
+			partitionCols = nil
 		}
-		t = NewMppTask(pcte, prop.MPPPartitionTp, prop.MPPPartitionCols, p.StatsInfo().HistColl, nil)
+		t = NewMppTask(pcte, partitionTp, partitionCols, p.StatsInfo().HistColl, nil)
 	} else {
 		rt := &RootTask{}
 		rt.SetPlan(pcte)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61242

Problem Summary:

MPP shared CTE readers can fall back to root execution when a parent MPP join requires a direct CTE reader to satisfy a broadcast or hash distribution property. The CTE reader path rejected non-Any MPP partition properties before the normal exchange enforcer could be applied.

### What changed and how does it work?

This PR keeps shared CTE readers as `AnyType` MPP tasks and lets the consumer-side enforcer add the required exchange above the CTE reader when the parent asks for `BroadcastType` or `HashType`.

The producer/storage side remains independent from individual consumers' distribution requirements, so different CTE readers can still be enforced differently by their parent operators.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that MPP shared CTE readers may fall back to root execution when a parent join requires an exchange on the CTE reader side.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Common Table Expression (CTE) execution in MPP mode to correctly handle partition requirements, preventing invalid query plan generation (issue 61242).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68387)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->