### PR TITLE
dxf/importinto: align TiCI pre-split task ID | tidb-test=13ccf8de48e8db2290ff884598444d0508606bbf tiflash=feature-fts tikv=feature-fts

### DIFF
--- a/pkg/dxf/importinto/planner.go
+++ b/pkg/dxf/importinto/planner.go
@@ -552,7 +552,7 @@ func triggerTiCIPreSplitForImportInto(
 	timeoutCtx, cancel := context.WithTimeout(ctx, ticiPreSplitRequestTimeout)
 	defer cancel()
 
-	req, err := buildTiCIPreSplitImportShardsRequestForImportInto(timeoutCtx, planCtx, p, store, kvMetaGroups)
+	req, err := buildTiCIPreSplitImportShardsRequestForImportInto(timeoutCtx, p, store, kvMetaGroups)
 	if err != nil {
 		return err
 	}
@@ -607,7 +607,6 @@ func collectTiCIPreSplitImportKVMetaGroups(
 
 func buildTiCIPreSplitImportShardsRequestForImportInto(
 	ctx context.Context,
-	planCtx planner.PlanCtx,
 	p *LogicalPlan,
 	store storeapi.Storage,
 	kvMetaGroups []ticiPreSplitImportKVMetaGroup,
@@ -628,7 +627,7 @@ func buildTiCIPreSplitImportShardsRequestForImportInto(
 	}
 	dataFileCount, statFileCount := countUniqueFilesForTiCIPreSplitImportRequest(kvMetas)
 	req := &tici.PreSplitImportShardsRequest{
-		TidbTaskId:    strconv.FormatInt(planCtx.TaskID, 10),
+		TidbTaskId:    ticiTaskIDForImportInto(p.JobID),
 		TableId:       p.Plan.TableInfo.ID,
 		IndexIds:      indexIDs,
 		DataFileCount: dataFileCount,

--- a/pkg/dxf/importinto/planner_test.go
+++ b/pkg/dxf/importinto/planner_test.go
@@ -359,8 +359,7 @@ func TestBuildTiCIPreSplitImportShardsRequestForImportInto(t *testing.T) {
 
 	req, err := buildTiCIPreSplitImportShardsRequestForImportInto(
 		context.Background(),
-		planner.PlanCtx{TaskID: 123},
-		&LogicalPlan{Plan: importer.Plan{
+		&LogicalPlan{JobID: 123, Plan: importer.Plan{
 			TableInfo: &model.TableInfo{ID: 456},
 		}},
 		nil,
@@ -383,7 +382,7 @@ func TestBuildTiCIPreSplitImportShardsRequestForImportInto(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	require.Equal(t, "123", req.TidbTaskId)
+	require.Equal(t, TaskKey(123), req.TidbTaskId)
 	require.Equal(t, int64(456), req.TableId)
 	require.Equal(t, []int64{10, 20}, req.IndexIds)
 	require.Zero(t, req.ScanSnapshotTs)
@@ -411,7 +410,7 @@ func TestTriggerTiCIPreSplitForImportInto(t *testing.T) {
 	err := triggerTiCIPreSplitForImportInto(
 		context.Background(),
 		planner.PlanCtx{TaskID: 101},
-		&LogicalPlan{Plan: importer.Plan{
+		&LogicalPlan{JobID: 101, Plan: importer.Plan{
 			DBName: "test",
 			TableInfo: &model.TableInfo{
 				ID:   202,
@@ -435,7 +434,7 @@ func TestTriggerTiCIPreSplitForImportInto(t *testing.T) {
 	require.NotEmpty(t, raw)
 	var req tici.PreSplitImportShardsRequest
 	require.NoError(t, json.Unmarshal(raw, &req))
-	require.Equal(t, "101", req.TidbTaskId)
+	require.Equal(t, TaskKey(101), req.TidbTaskId)
 	require.Equal(t, int64(202), req.TableId)
 	require.Equal(t, []int64{2}, req.IndexIds)
 	require.Zero(t, req.ScanSnapshotTs)
@@ -526,7 +525,7 @@ func TestGenerateWriteIngestSpecsTiCIPreSplitBestEffort(t *testing.T) {
 		},
 		ThreadCnt: 1,
 		Store:     taskStore,
-	}, &LogicalPlan{Plan: importer.Plan{
+	}, &LogicalPlan{JobID: 909, Plan: importer.Plan{
 		DBName:          "test",
 		CloudStorageURI: "local://" + filepath.ToSlash(sortDir),
 		TableInfo: &model.TableInfo{
@@ -544,7 +543,7 @@ func TestGenerateWriteIngestSpecsTiCIPreSplitBestEffort(t *testing.T) {
 	require.NotEmpty(t, raw)
 	var req tici.PreSplitImportShardsRequest
 	require.NoError(t, json.Unmarshal(raw, &req))
-	require.Equal(t, "909", req.TidbTaskId)
+	require.Equal(t, TaskKey(909), req.TidbTaskId)
 	require.Equal(t, int64(808), req.TableId)
 	require.Equal(t, []int64{2}, req.IndexIds)
 	require.Zero(t, req.ScanSnapshotTs)
@@ -603,7 +602,7 @@ func TestGenerateWriteIngestSpecsTiCIPreSplitUsesMergedMeta(t *testing.T) {
 		},
 		ThreadCnt: 1,
 		Store:     taskStore,
-	}, &LogicalPlan{Plan: importer.Plan{
+	}, &LogicalPlan{JobID: 910, Plan: importer.Plan{
 		DBName:          "test",
 		CloudStorageURI: "local://" + filepath.ToSlash(sortDir),
 		ForceMergeStep:  true,
@@ -621,7 +620,7 @@ func TestGenerateWriteIngestSpecsTiCIPreSplitUsesMergedMeta(t *testing.T) {
 	require.NotEmpty(t, raw)
 	var req tici.PreSplitImportShardsRequest
 	require.NoError(t, json.Unmarshal(raw, &req))
-	require.Equal(t, "910", req.TidbTaskId)
+	require.Equal(t, TaskKey(910), req.TidbTaskId)
 	require.Equal(t, []int64{2}, req.IndexIds)
 	require.Equal(t, mergedIndexMeta.StartKey, req.StartKey)
 	require.Equal(t, mergedIndexMeta.EndKey, req.EndKey)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #63937


Problem Summary:

TiDB used different TiCI `tidb_task_id` values for the same IMPORT INTO job. The TiCI upload path used the IMPORT INTO task key, while `PreSplitImportShards` used the raw DXF task ID, so TiCI could create a duplicate empty import job and report pending progress from it.

### What changed and how does it work?

`PreSplitImportShardsRequest` now derives `TidbTaskId` through `ticiTaskIDForImportInto(p.JobID)`, matching the TiCI upload and finish paths. The pre-split request tests now carry the IMPORT job ID and assert the shared `TaskKey(jobID)` value.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test:

```sh
make failpoint-enable && (
  pushd pkg/dxf/importinto
  go test -run 'TestBuildTiCIPreSplitImportShardsRequestForImportInto|TestTriggerTiCIPreSplitForImportInto|TestGenerateWriteIngestSpecsTiCIPreSplitBestEffort|TestGenerateWriteIngestSpecsTiCIPreSplitUsesMergedMeta|TestTiCITaskIDForImportIntoUsesTaskKey|TestGetTableImporterSetsTiCITaskID' --tags=intest
  rc=$?
  popd
  make failpoint-disable
  exit $rc
)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix TiCI IMPORT INTO pre-split requests to use the same task ID as upload requests.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced task identifier handling in the import-into functionality to ensure more accurate and reliable task tracking during import operations. This refinement improves the consistency and robustness of task identification throughout the import process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68390)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->