### PR TITLE
ddl: wait TiFlash placement before scattering DDL-created ranges

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -295,6 +295,7 @@ go_test(
         "schema_test.go",
         "schema_version_test.go",
         "sequence_test.go",
+        "split_region_test.go",
         "stat_test.go",
         "table_mode_test.go",
         "table_modify_test.go",

--- a/pkg/ddl/split_region.go
+++ b/pkg/ddl/split_region.go
@@ -158,9 +158,9 @@ func waitTiFlashPlacementBeforeScatterWithCheck(
 	}
 }
 
-func tablePlacementRange(physicalID int64) ([]byte, []byte) {
-	startKey := codec.EncodeBytes(nil, tablecodec.GenTablePrefix(physicalID))
-	endKey := codec.EncodeBytes(nil, tablecodec.GenTablePrefix(physicalID+1))
+func tablePlacementRange(physicalID int64) (startKey, endKey []byte) {
+	startKey = codec.EncodeBytes(nil, tablecodec.GenTablePrefix(physicalID))
+	endKey = codec.EncodeBytes(nil, tablecodec.GenTablePrefix(physicalID+1))
 	return startKey, endKey
 }
 

--- a/pkg/ddl/split_region.go
+++ b/pkg/ddl/split_region.go
@@ -17,9 +17,11 @@ package ddl
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/logutil"
+	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/exprctx"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -34,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/regionsplit"
 	tikverr "github.com/tikv/client-go/v2/error"
@@ -43,11 +46,72 @@ import (
 // GlobalScatterGroupID is used to indicate the global scatter group ID.
 const GlobalScatterGroupID int64 = -1
 
+func shouldWaitTiFlashPlacementBeforeScatter(tbInfo *model.TableInfo, scatterScope string) bool {
+	return scatterScope != vardef.ScatterOff && tbInfo.TiFlashReplica != nil && tbInfo.TiFlashReplica.Count > 0
+}
+
+func waitTiFlashPlacementBeforeScatter(ctx context.Context, tbInfo *model.TableInfo, physicalIDs ...int64) {
+	if len(physicalIDs) == 0 {
+		return
+	}
+
+	logutil.DDLLogger().Info("wait tiflash placement before scatter",
+		zap.String("table", tbInfo.Name.O),
+		zap.Int64s("physicalIDs", physicalIDs),
+	)
+
+	var warnedErr bool
+	for {
+		allReady := true
+		for _, physicalID := range physicalIDs {
+			startKey := codec.EncodeBytes(nil, tablecodec.GenTablePrefix(physicalID))
+			endKey := codec.EncodeBytes(nil, tablecodec.GenTablePrefix(physicalID+1))
+			state, err := infosync.GetReplicationState(ctx, startKey, endKey)
+			if err != nil {
+				if !warnedErr {
+					logutil.DDLLogger().Warn("wait tiflash placement before scatter failed",
+						zap.String("table", tbInfo.Name.O),
+						zap.Int64("physicalID", physicalID),
+						zap.Error(err))
+					warnedErr = true
+				}
+				allReady = false
+				break
+			}
+			if state != infosync.PlacementScheduleStateScheduled {
+				allReady = false
+				break
+			}
+		}
+		if allReady {
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			logutil.DDLLogger().Warn("wait tiflash placement before scatter timeout",
+				zap.String("table", tbInfo.Name.O),
+				zap.Int64s("physicalIDs", physicalIDs),
+				zap.Error(ctx.Err()))
+			return
+		case <-time.After(tiflashCheckTiDBHTTPAPIHalfInterval):
+		}
+	}
+}
+
 func splitPartitionTableRegion(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *model.TableInfo, parts []model.PartitionDefinition, scatterScope string) {
 	// Max partition count is 8192, should we sample and just choose some partitions to split?
 	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), ctx.GetSessionVars().GetSplitRegionTimeout())
 	defer cancel()
 	ctxWithTimeout = kv.WithInternalSourceType(ctxWithTimeout, kv.InternalTxnDDL)
+
+	if shouldWaitTiFlashPlacementBeforeScatter(tbInfo, scatterScope) {
+		physicalIDs := make([]int64, 0, len(parts))
+		for _, def := range parts {
+			physicalIDs = append(physicalIDs, def.ID)
+		}
+		waitTiFlashPlacementBeforeScatter(ctxWithTimeout, tbInfo, physicalIDs...)
+	}
 
 	var regionIDs []uint64
 	if hasSplitPolicies(tbInfo) {
@@ -80,6 +144,10 @@ func splitTableRegion(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *
 	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), ctx.GetSessionVars().GetSplitRegionTimeout())
 	defer cancel()
 	ctxWithTimeout = kv.WithInternalSourceType(ctxWithTimeout, kv.InternalTxnDDL)
+
+	if shouldWaitTiFlashPlacementBeforeScatter(tbInfo, scatterScope) {
+		waitTiFlashPlacementBeforeScatter(ctxWithTimeout, tbInfo, tbInfo.ID)
+	}
 
 	var regionIDs []uint64
 	if hasSplitPolicies(tbInfo) {

--- a/pkg/ddl/split_region.go
+++ b/pkg/ddl/split_region.go
@@ -52,7 +52,7 @@ func shouldWaitTiFlashPlacementBeforeScatter(tbInfo *model.TableInfo, scatterSco
 
 func waitTiFlashPlacementBeforeScatterIfNeeded(ctx sessionctx.Context, tbInfo *model.TableInfo, scatterScope string, physicalIDs ...int64) {
 	waitTiFlashPlacementBeforeScatterIfNeededWithCheck(ctx, tbInfo, scatterScope,
-		infosync.IsReplicationStateAvailable,
+		infosync.HasPDHTTPClient,
 		infosync.GetReplicationState,
 		physicalIDs...)
 }
@@ -61,14 +61,14 @@ func waitTiFlashPlacementBeforeScatterIfNeededWithCheck(
 	ctx sessionctx.Context,
 	tbInfo *model.TableInfo,
 	scatterScope string,
-	isReplicationStateAvailable func() (bool, error),
+	hasPDHTTPClient func() (bool, error),
 	getReplicationState func(context.Context, []byte, []byte) (infosync.PlacementScheduleState, error),
 	physicalIDs ...int64,
 ) {
 	if !shouldWaitTiFlashPlacementBeforeScatter(tbInfo, scatterScope) {
 		return
 	}
-	available, err := isReplicationStateAvailable()
+	available, err := hasPDHTTPClient()
 	if err != nil {
 		logutil.DDLLogger().Warn("skip wait tiflash placement before scatter because replication state is unavailable",
 			zap.String("table", tbInfo.Name.O),

--- a/pkg/ddl/split_region.go
+++ b/pkg/ddl/split_region.go
@@ -50,12 +50,34 @@ func shouldWaitTiFlashPlacementBeforeScatter(tbInfo *model.TableInfo, scatterSco
 	return scatterScope != vardef.ScatterOff && tbInfo.TiFlashReplica != nil && tbInfo.TiFlashReplica.Count > 0
 }
 
-func waitTiFlashPlacementBeforeScatterIfNeeded(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *model.TableInfo, scatterScope string, physicalIDs ...int64) {
+func waitTiFlashPlacementBeforeScatterIfNeeded(ctx sessionctx.Context, tbInfo *model.TableInfo, scatterScope string, physicalIDs ...int64) {
+	waitTiFlashPlacementBeforeScatterIfNeededWithCheck(ctx, tbInfo, scatterScope,
+		infosync.IsReplicationStateAvailable,
+		infosync.GetReplicationState,
+		physicalIDs...)
+}
+
+func waitTiFlashPlacementBeforeScatterIfNeededWithCheck(
+	ctx sessionctx.Context,
+	tbInfo *model.TableInfo,
+	scatterScope string,
+	isReplicationStateAvailable func() (bool, error),
+	getReplicationState func(context.Context, []byte, []byte) (infosync.PlacementScheduleState, error),
+	physicalIDs ...int64,
+) {
 	if !shouldWaitTiFlashPlacementBeforeScatter(tbInfo, scatterScope) {
 		return
 	}
-	if !hasPDHTTPClientForPlacementCheck(store) {
-		logutil.DDLLogger().Info("skip wait tiflash placement before scatter because pd http client is unavailable",
+	available, err := isReplicationStateAvailable()
+	if err != nil {
+		logutil.DDLLogger().Warn("skip wait tiflash placement before scatter because replication state is unavailable",
+			zap.String("table", tbInfo.Name.O),
+			zap.Int64s("physicalIDs", physicalIDs),
+			zap.Error(err))
+		return
+	}
+	if !available {
+		logutil.DDLLogger().Info("skip wait tiflash placement before scatter because replication state is unavailable",
 			zap.String("table", tbInfo.Name.O),
 			zap.Int64s("physicalIDs", physicalIDs))
 		return
@@ -63,12 +85,7 @@ func waitTiFlashPlacementBeforeScatterIfNeeded(ctx sessionctx.Context, store kv.
 
 	waitCtx, cancel := newSplitRegionContext(ctx)
 	defer cancel()
-	waitTiFlashPlacementBeforeScatter(waitCtx, tbInfo, physicalIDs...)
-}
-
-func hasPDHTTPClientForPlacementCheck(store kv.SplittableStore) bool {
-	storeWithPD, ok := store.(kv.StorageWithPD)
-	return ok && storeWithPD.GetPDHTTPClient() != nil
+	waitTiFlashPlacementBeforeScatterWithCheck(waitCtx, tbInfo, tiflashCheckTiDBHTTPAPIHalfInterval, getReplicationState, physicalIDs...)
 }
 
 func waitTiFlashPlacementBeforeScatter(ctx context.Context, tbInfo *model.TableInfo, physicalIDs ...int64) {
@@ -93,13 +110,18 @@ func waitTiFlashPlacementBeforeScatterWithCheck(
 
 	var warnedErr bool
 	var lastErr error
+	var lastErrPhysicalID int64
+	pendingPhysicalIDs := append([]int64(nil), physicalIDs...)
 	for {
-		allReady := true
-		for _, physicalID := range physicalIDs {
+		lastErr = nil
+		lastErrPhysicalID = 0
+		nextPendingPhysicalIDs := pendingPhysicalIDs[:0]
+		for _, physicalID := range pendingPhysicalIDs {
 			startKey, endKey := tablePlacementRange(physicalID)
 			state, err := getReplicationState(ctx, startKey, endKey)
 			if err != nil {
 				lastErr = err
+				lastErrPhysicalID = physicalID
 				if !warnedErr {
 					logutil.DDLLogger().Warn("wait tiflash placement before scatter failed",
 						zap.String("table", tbInfo.Name.O),
@@ -107,15 +129,15 @@ func waitTiFlashPlacementBeforeScatterWithCheck(
 						zap.Error(err))
 					warnedErr = true
 				}
-				allReady = false
-				break
+				nextPendingPhysicalIDs = append(nextPendingPhysicalIDs, physicalID)
+				continue
 			}
 			if state != infosync.PlacementScheduleStateScheduled {
-				allReady = false
-				break
+				nextPendingPhysicalIDs = append(nextPendingPhysicalIDs, physicalID)
 			}
 		}
-		if allReady {
+		pendingPhysicalIDs = nextPendingPhysicalIDs
+		if len(pendingPhysicalIDs) == 0 {
 			return
 		}
 
@@ -124,10 +146,14 @@ func waitTiFlashPlacementBeforeScatterWithCheck(
 			fields := []zap.Field{
 				zap.String("table", tbInfo.Name.O),
 				zap.Int64s("physicalIDs", physicalIDs),
+				zap.Int64s("pendingPhysicalIDs", pendingPhysicalIDs),
 				zap.Error(ctx.Err()),
 			}
 			if lastErr != nil {
-				fields = append(fields, zap.NamedError("lastErr", lastErr))
+				fields = append(fields,
+					zap.Int64("lastErrPhysicalID", lastErrPhysicalID),
+					zap.NamedError("lastReplicationStateErr", lastErr),
+				)
 			}
 			logutil.DDLLogger().Warn("wait tiflash placement before scatter timeout", fields...)
 			return
@@ -149,11 +175,13 @@ func newSplitRegionContext(ctx sessionctx.Context) (context.Context, context.Can
 
 func splitPartitionTableRegion(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *model.TableInfo, parts []model.PartitionDefinition, scatterScope string) {
 	// Max partition count is 8192, should we sample and just choose some partitions to split?
-	physicalIDs := make([]int64, 0, len(parts))
-	for _, def := range parts {
-		physicalIDs = append(physicalIDs, def.ID)
+	if shouldWaitTiFlashPlacementBeforeScatter(tbInfo, scatterScope) {
+		physicalIDs := make([]int64, 0, len(parts))
+		for _, def := range parts {
+			physicalIDs = append(physicalIDs, def.ID)
+		}
+		waitTiFlashPlacementBeforeScatterIfNeeded(ctx, tbInfo, scatterScope, physicalIDs...)
 	}
-	waitTiFlashPlacementBeforeScatterIfNeeded(ctx, store, tbInfo, scatterScope, physicalIDs...)
 
 	ctxWithTimeout, cancel := newSplitRegionContext(ctx)
 	defer cancel()
@@ -186,7 +214,7 @@ func splitPartitionTableRegion(ctx sessionctx.Context, store kv.SplittableStore,
 }
 
 func splitTableRegion(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *model.TableInfo, scatterScope string) {
-	waitTiFlashPlacementBeforeScatterIfNeeded(ctx, store, tbInfo, scatterScope, tbInfo.ID)
+	waitTiFlashPlacementBeforeScatterIfNeeded(ctx, tbInfo, scatterScope, tbInfo.ID)
 
 	ctxWithTimeout, cancel := newSplitRegionContext(ctx)
 	defer cancel()

--- a/pkg/ddl/split_region.go
+++ b/pkg/ddl/split_region.go
@@ -50,6 +50,27 @@ func shouldWaitTiFlashPlacementBeforeScatter(tbInfo *model.TableInfo, scatterSco
 	return scatterScope != vardef.ScatterOff && tbInfo.TiFlashReplica != nil && tbInfo.TiFlashReplica.Count > 0
 }
 
+func waitTiFlashPlacementBeforeScatterIfNeeded(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *model.TableInfo, scatterScope string, physicalIDs ...int64) {
+	if !shouldWaitTiFlashPlacementBeforeScatter(tbInfo, scatterScope) {
+		return
+	}
+	if !hasPDHTTPClientForPlacementCheck(store) {
+		logutil.DDLLogger().Info("skip wait tiflash placement before scatter because pd http client is unavailable",
+			zap.String("table", tbInfo.Name.O),
+			zap.Int64s("physicalIDs", physicalIDs))
+		return
+	}
+
+	waitCtx, cancel := newSplitRegionContext(ctx)
+	defer cancel()
+	waitTiFlashPlacementBeforeScatter(waitCtx, tbInfo, physicalIDs...)
+}
+
+func hasPDHTTPClientForPlacementCheck(store kv.SplittableStore) bool {
+	storeWithPD, ok := store.(kv.StorageWithPD)
+	return ok && storeWithPD.GetPDHTTPClient() != nil
+}
+
 func waitTiFlashPlacementBeforeScatter(ctx context.Context, tbInfo *model.TableInfo, physicalIDs ...int64) {
 	waitTiFlashPlacementBeforeScatterWithCheck(ctx, tbInfo, tiflashCheckTiDBHTTPAPIHalfInterval, infosync.GetReplicationState, physicalIDs...)
 }
@@ -71,12 +92,14 @@ func waitTiFlashPlacementBeforeScatterWithCheck(
 	)
 
 	var warnedErr bool
+	var lastErr error
 	for {
 		allReady := true
 		for _, physicalID := range physicalIDs {
 			startKey, endKey := tablePlacementRange(physicalID)
 			state, err := getReplicationState(ctx, startKey, endKey)
 			if err != nil {
+				lastErr = err
 				if !warnedErr {
 					logutil.DDLLogger().Warn("wait tiflash placement before scatter failed",
 						zap.String("table", tbInfo.Name.O),
@@ -98,10 +121,15 @@ func waitTiFlashPlacementBeforeScatterWithCheck(
 
 		select {
 		case <-ctx.Done():
-			logutil.DDLLogger().Warn("wait tiflash placement before scatter timeout",
+			fields := []zap.Field{
 				zap.String("table", tbInfo.Name.O),
 				zap.Int64s("physicalIDs", physicalIDs),
-				zap.Error(ctx.Err()))
+				zap.Error(ctx.Err()),
+			}
+			if lastErr != nil {
+				fields = append(fields, zap.NamedError("lastErr", lastErr))
+			}
+			logutil.DDLLogger().Warn("wait tiflash placement before scatter timeout", fields...)
 			return
 		case <-time.After(checkInterval):
 		}
@@ -121,15 +149,11 @@ func newSplitRegionContext(ctx sessionctx.Context) (context.Context, context.Can
 
 func splitPartitionTableRegion(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *model.TableInfo, parts []model.PartitionDefinition, scatterScope string) {
 	// Max partition count is 8192, should we sample and just choose some partitions to split?
-	if shouldWaitTiFlashPlacementBeforeScatter(tbInfo, scatterScope) {
-		physicalIDs := make([]int64, 0, len(parts))
-		for _, def := range parts {
-			physicalIDs = append(physicalIDs, def.ID)
-		}
-		waitCtx, cancel := newSplitRegionContext(ctx)
-		waitTiFlashPlacementBeforeScatter(waitCtx, tbInfo, physicalIDs...)
-		cancel()
+	physicalIDs := make([]int64, 0, len(parts))
+	for _, def := range parts {
+		physicalIDs = append(physicalIDs, def.ID)
 	}
+	waitTiFlashPlacementBeforeScatterIfNeeded(ctx, store, tbInfo, scatterScope, physicalIDs...)
 
 	ctxWithTimeout, cancel := newSplitRegionContext(ctx)
 	defer cancel()
@@ -162,11 +186,7 @@ func splitPartitionTableRegion(ctx sessionctx.Context, store kv.SplittableStore,
 }
 
 func splitTableRegion(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *model.TableInfo, scatterScope string) {
-	if shouldWaitTiFlashPlacementBeforeScatter(tbInfo, scatterScope) {
-		waitCtx, cancel := newSplitRegionContext(ctx)
-		waitTiFlashPlacementBeforeScatter(waitCtx, tbInfo, tbInfo.ID)
-		cancel()
-	}
+	waitTiFlashPlacementBeforeScatterIfNeeded(ctx, store, tbInfo, scatterScope, tbInfo.ID)
 
 	ctxWithTimeout, cancel := newSplitRegionContext(ctx)
 	defer cancel()

--- a/pkg/ddl/split_region.go
+++ b/pkg/ddl/split_region.go
@@ -88,10 +88,6 @@ func waitTiFlashPlacementBeforeScatterIfNeededWithCheck(
 	waitTiFlashPlacementBeforeScatterWithCheck(waitCtx, tbInfo, tiflashCheckTiDBHTTPAPIHalfInterval, getReplicationState, physicalIDs...)
 }
 
-func waitTiFlashPlacementBeforeScatter(ctx context.Context, tbInfo *model.TableInfo, physicalIDs ...int64) {
-	waitTiFlashPlacementBeforeScatterWithCheck(ctx, tbInfo, tiflashCheckTiDBHTTPAPIHalfInterval, infosync.GetReplicationState, physicalIDs...)
-}
-
 func waitTiFlashPlacementBeforeScatterWithCheck(
 	ctx context.Context,
 	tbInfo *model.TableInfo,

--- a/pkg/ddl/split_region.go
+++ b/pkg/ddl/split_region.go
@@ -51,6 +51,16 @@ func shouldWaitTiFlashPlacementBeforeScatter(tbInfo *model.TableInfo, scatterSco
 }
 
 func waitTiFlashPlacementBeforeScatter(ctx context.Context, tbInfo *model.TableInfo, physicalIDs ...int64) {
+	waitTiFlashPlacementBeforeScatterWithCheck(ctx, tbInfo, tiflashCheckTiDBHTTPAPIHalfInterval, infosync.GetReplicationState, physicalIDs...)
+}
+
+func waitTiFlashPlacementBeforeScatterWithCheck(
+	ctx context.Context,
+	tbInfo *model.TableInfo,
+	checkInterval time.Duration,
+	getReplicationState func(context.Context, []byte, []byte) (infosync.PlacementScheduleState, error),
+	physicalIDs ...int64,
+) {
 	if len(physicalIDs) == 0 {
 		return
 	}
@@ -64,9 +74,8 @@ func waitTiFlashPlacementBeforeScatter(ctx context.Context, tbInfo *model.TableI
 	for {
 		allReady := true
 		for _, physicalID := range physicalIDs {
-			startKey := codec.EncodeBytes(nil, tablecodec.GenTablePrefix(physicalID))
-			endKey := codec.EncodeBytes(nil, tablecodec.GenTablePrefix(physicalID+1))
-			state, err := infosync.GetReplicationState(ctx, startKey, endKey)
+			startKey, endKey := tablePlacementRange(physicalID)
+			state, err := getReplicationState(ctx, startKey, endKey)
 			if err != nil {
 				if !warnedErr {
 					logutil.DDLLogger().Warn("wait tiflash placement before scatter failed",
@@ -94,24 +103,36 @@ func waitTiFlashPlacementBeforeScatter(ctx context.Context, tbInfo *model.TableI
 				zap.Int64s("physicalIDs", physicalIDs),
 				zap.Error(ctx.Err()))
 			return
-		case <-time.After(tiflashCheckTiDBHTTPAPIHalfInterval):
+		case <-time.After(checkInterval):
 		}
 	}
 }
 
+func tablePlacementRange(physicalID int64) ([]byte, []byte) {
+	startKey := codec.EncodeBytes(nil, tablecodec.GenTablePrefix(physicalID))
+	endKey := codec.EncodeBytes(nil, tablecodec.GenTablePrefix(physicalID+1))
+	return startKey, endKey
+}
+
+func newSplitRegionContext(ctx sessionctx.Context) (context.Context, context.CancelFunc) {
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), ctx.GetSessionVars().GetSplitRegionTimeout())
+	return kv.WithInternalSourceType(ctxWithTimeout, kv.InternalTxnDDL), cancel
+}
+
 func splitPartitionTableRegion(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *model.TableInfo, parts []model.PartitionDefinition, scatterScope string) {
 	// Max partition count is 8192, should we sample and just choose some partitions to split?
-	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), ctx.GetSessionVars().GetSplitRegionTimeout())
-	defer cancel()
-	ctxWithTimeout = kv.WithInternalSourceType(ctxWithTimeout, kv.InternalTxnDDL)
-
 	if shouldWaitTiFlashPlacementBeforeScatter(tbInfo, scatterScope) {
 		physicalIDs := make([]int64, 0, len(parts))
 		for _, def := range parts {
 			physicalIDs = append(physicalIDs, def.ID)
 		}
-		waitTiFlashPlacementBeforeScatter(ctxWithTimeout, tbInfo, physicalIDs...)
+		waitCtx, cancel := newSplitRegionContext(ctx)
+		waitTiFlashPlacementBeforeScatter(waitCtx, tbInfo, physicalIDs...)
+		cancel()
 	}
+
+	ctxWithTimeout, cancel := newSplitRegionContext(ctx)
+	defer cancel()
 
 	var regionIDs []uint64
 	if hasSplitPolicies(tbInfo) {
@@ -141,13 +162,14 @@ func splitPartitionTableRegion(ctx sessionctx.Context, store kv.SplittableStore,
 }
 
 func splitTableRegion(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *model.TableInfo, scatterScope string) {
-	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), ctx.GetSessionVars().GetSplitRegionTimeout())
-	defer cancel()
-	ctxWithTimeout = kv.WithInternalSourceType(ctxWithTimeout, kv.InternalTxnDDL)
-
 	if shouldWaitTiFlashPlacementBeforeScatter(tbInfo, scatterScope) {
-		waitTiFlashPlacementBeforeScatter(ctxWithTimeout, tbInfo, tbInfo.ID)
+		waitCtx, cancel := newSplitRegionContext(ctx)
+		waitTiFlashPlacementBeforeScatter(waitCtx, tbInfo, tbInfo.ID)
+		cancel()
 	}
+
+	ctxWithTimeout, cancel := newSplitRegionContext(ctx)
+	defer cancel()
 
 	var regionIDs []uint64
 	if hasSplitPolicies(tbInfo) {

--- a/pkg/ddl/split_region_test.go
+++ b/pkg/ddl/split_region_test.go
@@ -22,13 +22,11 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/domain/infosync"
-	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
-	pd "github.com/tikv/pd/client"
-	pdhttp "github.com/tikv/pd/client/http"
 )
 
 func TestShouldWaitTiFlashPlacementBeforeScatter(t *testing.T) {
@@ -44,10 +42,26 @@ func TestShouldWaitTiFlashPlacementBeforeScatter(t *testing.T) {
 	require.True(t, shouldWaitTiFlashPlacementBeforeScatter(tbInfo, vardef.ScatterGlobal))
 }
 
-func TestHasPDHTTPClientForPlacementCheck(t *testing.T) {
-	require.False(t, hasPDHTTPClientForPlacementCheck(mockSplittableStore{}))
-	require.False(t, hasPDHTTPClientForPlacementCheck(mockSplittableStoreWithPD{}))
-	require.True(t, hasPDHTTPClientForPlacementCheck(mockSplittableStoreWithPD{pdHTTPClient: mockPlacementPDHTTPClient{}}))
+func TestWaitTiFlashPlacementBeforeScatterIfNeededSkipsWhenReplicationStateUnavailable(t *testing.T) {
+	tbInfo := &model.TableInfo{
+		Name:           ast.NewCIStr("t"),
+		TiFlashReplica: &model.TiFlashReplicaInfo{Count: 1},
+	}
+	var calls atomic.Int32
+	waitTiFlashPlacementBeforeScatterIfNeededWithCheck(
+		mock.NewContext(),
+		tbInfo,
+		vardef.ScatterTable,
+		func() (bool, error) {
+			return false, nil
+		},
+		func(context.Context, []byte, []byte) (infosync.PlacementScheduleState, error) {
+			calls.Add(1)
+			return infosync.PlacementScheduleStateScheduled, nil
+		},
+		123,
+	)
+	require.Equal(t, int32(0), calls.Load())
 }
 
 func TestWaitTiFlashPlacementBeforeScatterWaitsUntilScheduled(t *testing.T) {
@@ -71,6 +85,34 @@ func TestWaitTiFlashPlacementBeforeScatterWaitsUntilScheduled(t *testing.T) {
 		physicalID,
 	)
 	require.Equal(t, int32(2), calls.Load())
+}
+
+func TestWaitTiFlashPlacementBeforeScatterSkipsScheduledPhysicalIDs(t *testing.T) {
+	tbInfo := &model.TableInfo{Name: ast.NewCIStr("t")}
+
+	var calls atomic.Int32
+	var scheduledIDCalls atomic.Int32
+	waitTiFlashPlacementBeforeScatterWithCheck(
+		context.Background(),
+		tbInfo,
+		0,
+		func(_ context.Context, startKey []byte, _ []byte) (infosync.PlacementScheduleState, error) {
+			call := calls.Add(1)
+			expectedScheduledStartKey, _ := tablePlacementRange(1)
+			if string(startKey) == string(expectedScheduledStartKey) {
+				scheduledIDCalls.Add(1)
+				return infosync.PlacementScheduleStateScheduled, nil
+			}
+			if call == 2 {
+				return infosync.PlacementScheduleStatePending, nil
+			}
+			return infosync.PlacementScheduleStateScheduled, nil
+		},
+		1,
+		2,
+	)
+	require.Equal(t, int32(3), calls.Load())
+	require.Equal(t, int32(1), scheduledIDCalls.Load())
 }
 
 func TestWaitTiFlashPlacementBeforeScatterRetriesGetReplicationStateError(t *testing.T) {
@@ -112,41 +154,3 @@ func TestWaitTiFlashPlacementBeforeScatterReturnsOnContextDone(t *testing.T) {
 	require.Equal(t, int32(1), calls.Load())
 	require.Less(t, time.Since(start), time.Second)
 }
-
-type mockSplittableStore struct{}
-
-func (mockSplittableStore) SplitRegions(context.Context, [][]byte, bool, *int64) ([]uint64, error) {
-	return nil, nil
-}
-
-func (mockSplittableStore) WaitScatterRegionFinish(context.Context, uint64, int) error {
-	return nil
-}
-
-func (mockSplittableStore) CheckRegionInScattering(uint64) (bool, error) {
-	return false, nil
-}
-
-type mockSplittableStoreWithPD struct {
-	mockSplittableStore
-	pdHTTPClient pdhttp.Client
-}
-
-func (mockSplittableStoreWithPD) GetPDClient() pd.Client {
-	return nil
-}
-
-func (s mockSplittableStoreWithPD) GetPDHTTPClient() pdhttp.Client {
-	return s.pdHTTPClient
-}
-
-type mockPlacementPDHTTPClient struct {
-	pdhttp.Client
-}
-
-var (
-	_ kv.SplittableStore = mockSplittableStore{}
-	_ kv.SplittableStore = mockSplittableStoreWithPD{}
-	_ kv.StorageWithPD   = mockSplittableStoreWithPD{}
-	_ pdhttp.Client      = mockPlacementPDHTTPClient{}
-)

--- a/pkg/ddl/split_region_test.go
+++ b/pkg/ddl/split_region_test.go
@@ -64,6 +64,28 @@ func TestWaitTiFlashPlacementBeforeScatterIfNeededSkipsWhenReplicationStateUnava
 	require.Equal(t, int32(0), calls.Load())
 }
 
+func TestWaitTiFlashPlacementBeforeScatterIfNeededSkipsWhenReplicationStateAvailabilityCheckFails(t *testing.T) {
+	tbInfo := &model.TableInfo{
+		Name:           ast.NewCIStr("t"),
+		TiFlashReplica: &model.TiFlashReplicaInfo{Count: 1},
+	}
+	var calls atomic.Int32
+	waitTiFlashPlacementBeforeScatterIfNeededWithCheck(
+		mock.NewContext(),
+		tbInfo,
+		vardef.ScatterTable,
+		func() (bool, error) {
+			return false, errors.New("replication state unavailable")
+		},
+		func(context.Context, []byte, []byte) (infosync.PlacementScheduleState, error) {
+			calls.Add(1)
+			return infosync.PlacementScheduleStateScheduled, nil
+		},
+		123,
+	)
+	require.Equal(t, int32(0), calls.Load())
+}
+
 func TestWaitTiFlashPlacementBeforeScatterWaitsUntilScheduled(t *testing.T) {
 	tbInfo := &model.TableInfo{Name: ast.NewCIStr("t")}
 	physicalID := int64(123)

--- a/pkg/ddl/split_region_test.go
+++ b/pkg/ddl/split_region_test.go
@@ -43,47 +43,44 @@ func TestShouldWaitTiFlashPlacementBeforeScatter(t *testing.T) {
 }
 
 func TestWaitTiFlashPlacementBeforeScatterIfNeededSkipsWhenReplicationStateUnavailable(t *testing.T) {
-	tbInfo := &model.TableInfo{
-		Name:           ast.NewCIStr("t"),
-		TiFlashReplica: &model.TiFlashReplicaInfo{Count: 1},
+	tests := []struct {
+		name      string
+		available bool
+		err       error
+	}{
+		{
+			name:      "client unavailable",
+			available: false,
+		},
+		{
+			name:      "availability check failed",
+			available: false,
+			err:       errors.New("replication state unavailable"),
+		},
 	}
-	var calls atomic.Int32
-	waitTiFlashPlacementBeforeScatterIfNeededWithCheck(
-		mock.NewContext(),
-		tbInfo,
-		vardef.ScatterTable,
-		func() (bool, error) {
-			return false, nil
-		},
-		func(context.Context, []byte, []byte) (infosync.PlacementScheduleState, error) {
-			calls.Add(1)
-			return infosync.PlacementScheduleStateScheduled, nil
-		},
-		123,
-	)
-	require.Equal(t, int32(0), calls.Load())
-}
-
-func TestWaitTiFlashPlacementBeforeScatterIfNeededSkipsWhenReplicationStateAvailabilityCheckFails(t *testing.T) {
-	tbInfo := &model.TableInfo{
-		Name:           ast.NewCIStr("t"),
-		TiFlashReplica: &model.TiFlashReplicaInfo{Count: 1},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tbInfo := &model.TableInfo{
+				Name:           ast.NewCIStr("t"),
+				TiFlashReplica: &model.TiFlashReplicaInfo{Count: 1},
+			}
+			var calls atomic.Int32
+			waitTiFlashPlacementBeforeScatterIfNeededWithCheck(
+				mock.NewContext(),
+				tbInfo,
+				vardef.ScatterTable,
+				func() (bool, error) {
+					return tt.available, tt.err
+				},
+				func(context.Context, []byte, []byte) (infosync.PlacementScheduleState, error) {
+					calls.Add(1)
+					return infosync.PlacementScheduleStateScheduled, nil
+				},
+				123,
+			)
+			require.Equal(t, int32(0), calls.Load())
+		})
 	}
-	var calls atomic.Int32
-	waitTiFlashPlacementBeforeScatterIfNeededWithCheck(
-		mock.NewContext(),
-		tbInfo,
-		vardef.ScatterTable,
-		func() (bool, error) {
-			return false, errors.New("replication state unavailable")
-		},
-		func(context.Context, []byte, []byte) (infosync.PlacementScheduleState, error) {
-			calls.Add(1)
-			return infosync.PlacementScheduleStateScheduled, nil
-		},
-		123,
-	)
-	require.Equal(t, int32(0), calls.Load())
 }
 
 func TestWaitTiFlashPlacementBeforeScatterWaitsUntilScheduled(t *testing.T) {

--- a/pkg/ddl/split_region_test.go
+++ b/pkg/ddl/split_region_test.go
@@ -16,15 +16,19 @@ package ddl
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/domain/infosync"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/stretchr/testify/require"
+	pd "github.com/tikv/pd/client"
+	pdhttp "github.com/tikv/pd/client/http"
 )
 
 func TestShouldWaitTiFlashPlacementBeforeScatter(t *testing.T) {
@@ -38,6 +42,12 @@ func TestShouldWaitTiFlashPlacementBeforeScatter(t *testing.T) {
 	require.False(t, shouldWaitTiFlashPlacementBeforeScatter(tbInfo, vardef.ScatterOff))
 	require.True(t, shouldWaitTiFlashPlacementBeforeScatter(tbInfo, vardef.ScatterTable))
 	require.True(t, shouldWaitTiFlashPlacementBeforeScatter(tbInfo, vardef.ScatterGlobal))
+}
+
+func TestHasPDHTTPClientForPlacementCheck(t *testing.T) {
+	require.False(t, hasPDHTTPClientForPlacementCheck(mockSplittableStore{}))
+	require.False(t, hasPDHTTPClientForPlacementCheck(mockSplittableStoreWithPD{}))
+	require.True(t, hasPDHTTPClientForPlacementCheck(mockSplittableStoreWithPD{pdHTTPClient: mockPlacementPDHTTPClient{}}))
 }
 
 func TestWaitTiFlashPlacementBeforeScatterWaitsUntilScheduled(t *testing.T) {
@@ -63,6 +73,25 @@ func TestWaitTiFlashPlacementBeforeScatterWaitsUntilScheduled(t *testing.T) {
 	require.Equal(t, int32(2), calls.Load())
 }
 
+func TestWaitTiFlashPlacementBeforeScatterRetriesGetReplicationStateError(t *testing.T) {
+	tbInfo := &model.TableInfo{Name: ast.NewCIStr("t")}
+
+	var calls atomic.Int32
+	waitTiFlashPlacementBeforeScatterWithCheck(
+		context.Background(),
+		tbInfo,
+		0,
+		func(context.Context, []byte, []byte) (infosync.PlacementScheduleState, error) {
+			if calls.Add(1) == 1 {
+				return infosync.PlacementScheduleStatePending, errors.New("temporary failure")
+			}
+			return infosync.PlacementScheduleStateScheduled, nil
+		},
+		123,
+	)
+	require.Equal(t, int32(2), calls.Load())
+}
+
 func TestWaitTiFlashPlacementBeforeScatterReturnsOnContextDone(t *testing.T) {
 	tbInfo := &model.TableInfo{Name: ast.NewCIStr("t")}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -83,3 +112,41 @@ func TestWaitTiFlashPlacementBeforeScatterReturnsOnContextDone(t *testing.T) {
 	require.Equal(t, int32(1), calls.Load())
 	require.Less(t, time.Since(start), time.Second)
 }
+
+type mockSplittableStore struct{}
+
+func (mockSplittableStore) SplitRegions(context.Context, [][]byte, bool, *int64) ([]uint64, error) {
+	return nil, nil
+}
+
+func (mockSplittableStore) WaitScatterRegionFinish(context.Context, uint64, int) error {
+	return nil
+}
+
+func (mockSplittableStore) CheckRegionInScattering(uint64) (bool, error) {
+	return false, nil
+}
+
+type mockSplittableStoreWithPD struct {
+	mockSplittableStore
+	pdHTTPClient pdhttp.Client
+}
+
+func (mockSplittableStoreWithPD) GetPDClient() pd.Client {
+	return nil
+}
+
+func (s mockSplittableStoreWithPD) GetPDHTTPClient() pdhttp.Client {
+	return s.pdHTTPClient
+}
+
+type mockPlacementPDHTTPClient struct {
+	pdhttp.Client
+}
+
+var (
+	_ kv.SplittableStore = mockSplittableStore{}
+	_ kv.SplittableStore = mockSplittableStoreWithPD{}
+	_ kv.StorageWithPD   = mockSplittableStoreWithPD{}
+	_ pdhttp.Client      = mockPlacementPDHTTPClient{}
+)

--- a/pkg/ddl/split_region_test.go
+++ b/pkg/ddl/split_region_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/domain/infosync"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldWaitTiFlashPlacementBeforeScatter(t *testing.T) {
+	tbInfo := &model.TableInfo{}
+	require.False(t, shouldWaitTiFlashPlacementBeforeScatter(tbInfo, vardef.ScatterTable))
+
+	tbInfo.TiFlashReplica = &model.TiFlashReplicaInfo{}
+	require.False(t, shouldWaitTiFlashPlacementBeforeScatter(tbInfo, vardef.ScatterTable))
+
+	tbInfo.TiFlashReplica.Count = 1
+	require.False(t, shouldWaitTiFlashPlacementBeforeScatter(tbInfo, vardef.ScatterOff))
+	require.True(t, shouldWaitTiFlashPlacementBeforeScatter(tbInfo, vardef.ScatterTable))
+	require.True(t, shouldWaitTiFlashPlacementBeforeScatter(tbInfo, vardef.ScatterGlobal))
+}
+
+func TestWaitTiFlashPlacementBeforeScatterWaitsUntilScheduled(t *testing.T) {
+	tbInfo := &model.TableInfo{Name: ast.NewCIStr("t")}
+	physicalID := int64(123)
+	expectedStartKey, expectedEndKey := tablePlacementRange(physicalID)
+
+	var calls atomic.Int32
+	waitTiFlashPlacementBeforeScatterWithCheck(
+		context.Background(),
+		tbInfo,
+		0,
+		func(_ context.Context, startKey []byte, endKey []byte) (infosync.PlacementScheduleState, error) {
+			require.Equal(t, expectedStartKey, startKey)
+			require.Equal(t, expectedEndKey, endKey)
+			if calls.Add(1) == 1 {
+				return infosync.PlacementScheduleStatePending, nil
+			}
+			return infosync.PlacementScheduleStateScheduled, nil
+		},
+		physicalID,
+	)
+	require.Equal(t, int32(2), calls.Load())
+}
+
+func TestWaitTiFlashPlacementBeforeScatterReturnsOnContextDone(t *testing.T) {
+	tbInfo := &model.TableInfo{Name: ast.NewCIStr("t")}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var calls atomic.Int32
+	start := time.Now()
+	waitTiFlashPlacementBeforeScatterWithCheck(
+		ctx,
+		tbInfo,
+		time.Hour,
+		func(context.Context, []byte, []byte) (infosync.PlacementScheduleState, error) {
+			calls.Add(1)
+			return infosync.PlacementScheduleStatePending, nil
+		},
+		123,
+	)
+	require.Equal(t, int32(1), calls.Load())
+	require.Less(t, time.Since(start), time.Second)
+}

--- a/pkg/domain/infosync/region.go
+++ b/pkg/domain/infosync/region.go
@@ -71,8 +71,8 @@ func GetReplicationState(ctx context.Context, startKey []byte, endKey []byte) (P
 	return st, nil
 }
 
-// IsReplicationStateAvailable returns whether GetReplicationState can query PD.
-func IsReplicationStateAvailable() (bool, error) {
+// HasPDHTTPClient returns whether the global info syncer has a PD HTTP client.
+func HasPDHTTPClient() (bool, error) {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
 		return false, err

--- a/pkg/domain/infosync/region.go
+++ b/pkg/domain/infosync/region.go
@@ -71,6 +71,15 @@ func GetReplicationState(ctx context.Context, startKey []byte, endKey []byte) (P
 	return st, nil
 }
 
+// IsReplicationStateAvailable returns whether GetReplicationState can query PD.
+func IsReplicationStateAvailable() (bool, error) {
+	is, err := getGlobalInfoSyncer()
+	if err != nil {
+		return false, err
+	}
+	return is.pdHTTPCli != nil, nil
+}
+
 // GetRegionDistributionByKeyRange is used to get the region distributions by given key range from PD.
 func GetRegionDistributionByKeyRange(ctx context.Context, startKey []byte, endKey []byte, engine string) (*pd.RegionDistributions, error) {
 	is, err := getGlobalInfoSyncer()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68401

Problem Summary:

When a table has TiFlash replica and `tidb_scatter_region` is enabled, some DDL operations create new physical table or partition ranges and then immediately trigger split/scatter for those ranges.

PD requires the corresponding placement rules to be satisfied before scatter can proceed. However, the TiFlash placement rules for the new ranges may still be pending at that point, so the scatter operation can fail. Since scatter failure is logged as a warning and DDL continues, the DDL can finish while the newly created ranges are not scattered as expected.

### What changed and how does it work?

This PR waits for TiFlash placement to become scheduled before split/scatter when both conditions are true:

- The table has TiFlash replica configured.
- `tidb_scatter_region` is not `OFF`.

The wait is added to the common split/scatter path for table and partition ranges. It checks PD replication state for the affected physical table IDs and proceeds once the state becomes scheduled.

The wait remains best-effort:

- If the PD HTTP client is unavailable, DDL skips the wait and continues.
- If querying PD replication state returns temporary errors, DDL retries until the split-region timeout.
- If the wait times out, DDL logs a warning and continues.
- Existing scatter failure handling remains unchanged.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that scatter could fail before TiFlash placement rules are satisfied for newly created DDL ranges when `tidb_scatter_region` is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Region splitting now coordinates with TiFlash replica placement readiness before scatter-based splits.
  * Improved pre-wait behavior and logging for placement-state tracking and error/timeout details.

* **Tests**
  * Added comprehensive tests covering wait conditions, placement-schedule polling, retry behavior, and timeout/early-exit cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68402)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->