### PR TITLE
planner: prefer MPP UnionAll when MPP is enforced

### DIFF
--- a/pkg/executor/test/tiflashtest/tiflash_test.go
+++ b/pkg/executor/test/tiflashtest/tiflash_test.go
@@ -2149,7 +2149,7 @@ func TestMppTableReaderCacheForSingleSQL(t *testing.T) {
 		{"select * from t t1 join t t2 on t1.b=t2.b", 1, 1},
 
 		// Cache miss
-		{"select * from t union all select * from t", 0, 2},                      // different mpp task root
+		{"select * from t union all select * from t", 1, 1},                      // same table scan under the MPP Union root
 		{"select * from t where a <= 3 union select * from t where a > 3", 0, 2}, // different range
 
 		// Partition

--- a/pkg/executor/test/tiflashtest/tiflash_test.go
+++ b/pkg/executor/test/tiflashtest/tiflash_test.go
@@ -2149,7 +2149,7 @@ func TestMppTableReaderCacheForSingleSQL(t *testing.T) {
 		{"select * from t t1 join t t2 on t1.b=t2.b", 1, 1},
 
 		// Cache miss
-		{"select * from t union all select * from t", 1, 1},                      // same table scan under the MPP Union root
+		{"select * from t union all select * from t", 0, 2},                      // different MPP task requests
 		{"select * from t where a <= 3 union select * from t where a > 3", 0, 2}, // different range
 
 		// Partition

--- a/pkg/planner/core/casetest/mpp/mpp_test.go
+++ b/pkg/planner/core/casetest/mpp/mpp_test.go
@@ -454,6 +454,8 @@ func TestMppUnionAll(t *testing.T) {
 		// Create virtual tiflash replica info.
 		testkit.SetTiFlashReplica(t, dom, "test", "t")
 		testkit.SetTiFlashReplica(t, dom, "test", "t1")
+		tk.MustExec("set @@tidb_allow_mpp=1")
+		tk.MustExec("set @@tidb_enforce_mpp=1")
 
 		var input []string
 		var output []struct {

--- a/pkg/planner/core/casetest/mpp/testdata/integration_suite_in.json
+++ b/pkg/planner/core/casetest/mpp/testdata/integration_suite_in.json
@@ -156,6 +156,7 @@
     "name": "TestMppUnionAll",
     "cases": [
       "explain format = 'plan_tree' select count(*) from (select a , b from t union all select a , b from t1) tt",
+      "explain format = 'plan_tree' select a from t union all select a from t",
       "explain format = 'plan_tree' select count(*) from (select a , b from t union all select a , b from t1 union all select a, b from t where false) tt",
       "explain format = 'plan_tree' select count(*) from (select a , b from t union all select a , c from t1) tt",
       "explain format = 'plan_tree' select count(*) from (select a , b from t union all select a , c from t1 where false) tt",

--- a/pkg/planner/core/casetest/mpp/testdata/integration_suite_out.json
+++ b/pkg/planner/core/casetest/mpp/testdata/integration_suite_out.json
@@ -1517,6 +1517,16 @@
         ]
       },
       {
+        "SQL": "explain format = 'plan_tree' select a from t union all select a from t",
+        "Plan": [
+          "TableReader root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Union mpp[tiflash]  ",
+          "    ├─TableFullScan mpp[tiflash] table:t keep order:false, stats:pseudo",
+          "    └─TableFullScan mpp[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
         "SQL": "explain format = 'plan_tree' select count(*) from (select a , b from t union all select a , b from t1 union all select a, b from t where false) tt",
         "Plan": [
           "HashAgg root  funcs:count(Column)->Column",

--- a/pkg/planner/core/casetest/mpp/testdata/integration_suite_xut.json
+++ b/pkg/planner/core/casetest/mpp/testdata/integration_suite_xut.json
@@ -1517,6 +1517,16 @@
         ]
       },
       {
+        "SQL": "explain format = 'plan_tree' select a from t union all select a from t",
+        "Plan": [
+          "TableReader root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Union mpp[tiflash]  ",
+          "    ├─TableFullScan mpp[tiflash] table:t keep order:false, stats:pseudo",
+          "    └─TableFullScan mpp[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
         "SQL": "explain format = 'plan_tree' select count(*) from (select a , b from t union all select a , b from t1 union all select a, b from t where false) tt",
         "Plan": [
           "HashAgg root  funcs:count(Column)->Column",

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1497,6 +1497,10 @@ func applyLogicalTopNAndLimitHint(lp base.LogicalPlan, pp base.PhysicalPlan, chi
 }
 
 func hasNormalPreferTask(lp base.LogicalPlan, state *enumerateState, pp base.PhysicalPlan, childTasks []base.Task) (preferred bool) {
+	if ua, ok := pp.(*physicalop.PhysicalUnionAll); ok && ua.Mpp && ua.SCtx().GetSessionVars().IsMPPEnforced() {
+		// Keep a valid MPP UnionAll when MPP is enforced instead of letting a cheaper root candidate win.
+		return true
+	}
 	_, meetThreshold := pushLimitOrTopNForcibly(lp, pp)
 	if meetThreshold {
 		// previously, we set meetThreshold for pruning root task type but mpp task type. so:

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1497,10 +1497,6 @@ func applyLogicalTopNAndLimitHint(lp base.LogicalPlan, pp base.PhysicalPlan, chi
 }
 
 func hasNormalPreferTask(lp base.LogicalPlan, state *enumerateState, pp base.PhysicalPlan, childTasks []base.Task) (preferred bool) {
-	if ua, ok := pp.(*physicalop.PhysicalUnionAll); ok && ua.Mpp && ua.SCtx().GetSessionVars().IsMPPEnforced() {
-		// Keep a valid MPP UnionAll when MPP is enforced instead of letting a cheaper root candidate win.
-		return true
-	}
 	_, meetThreshold := pushLimitOrTopNForcibly(lp, pp)
 	if meetThreshold {
 		// previously, we set meetThreshold for pruning root task type but mpp task type. so:

--- a/pkg/planner/core/plan_cost_ver1.go
+++ b/pkg/planner/core/plan_cost_ver1.go
@@ -1146,6 +1146,11 @@ func getPlanCostVer14PhysicalUnionAll(pp base.PhysicalPlan, taskType property.Ta
 		childMaxCost = math.Max(childMaxCost, childCost)
 	}
 	p.PlanCost = childMaxCost + float64(1+len(p.Children()))*p.SCtx().GetSessionVars().GetConcurrencyFactor()
+	if p.Mpp && p.SCtx().GetSessionVars().IsMPPEnforced() &&
+		!hasCostFlag(costFlag, costusage.CostFlagRecalculate) { // show the real cost in explain-statements
+		// Keep enforced MPP UnionAll comparable through cost instead of bypassing the normal plan comparison path.
+		p.PlanCost /= 1000000000
+	}
 	p.PlanCostInit = true
 	return p.PlanCost, nil
 }

--- a/pkg/planner/core/plan_cost_ver2.go
+++ b/pkg/planner/core/plan_cost_ver2.go
@@ -988,6 +988,11 @@ func getPlanCostVer24PhysicalUnionAll(pp base.PhysicalPlan, taskType property.Ta
 		childCosts = append(childCosts, childCost)
 	}
 	p.PlanCostVer2 = costusage.DivCostVer2(costusage.SumCostVer2(childCosts...), concurrency)
+	if p.Mpp && p.SCtx().GetSessionVars().IsMPPEnforced() &&
+		!hasCostFlag(option.CostFlag, costusage.CostFlagRecalculate) { // show the real cost in explain-statements
+		// Keep enforced MPP UnionAll comparable through cost instead of bypassing the normal plan comparison path.
+		p.PlanCostVer2 = costusage.DivCostVer2(p.PlanCostVer2, 1000000000)
+	}
 	p.PlanCostInit = true
 	return p.PlanCostVer2, nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/61243

Problem Summary:

When MPP is enforced, `UnionAll` can still be costed as a root operator for a top-level query. This makes `select a from t union all select a from t` choose a root `Union` over the valid MPP `Union`, while `count(*)` over the same union already uses MPP because the parent aggregation requests an MPP child.

### What changed and how does it work?

Prefer a valid MPP `PhysicalUnionAll` in normal task selection when `tidb_enforce_mpp` is enabled. This preserves the enforced-MPP behavior without removing root candidates from non-enforced planning.

The regression case is added to the existing `TestMppUnionAll` planner casetest and is covered for both default and cascades optimizer output.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```sh
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/mpp -run TestMppUnionAll -count=1
make lint
git diff --check -- pkg/planner/core/exhaust_physical_plans.go pkg/planner/core/casetest/mpp/mpp_test.go pkg/planner/core/casetest/mpp/testdata/integration_suite_in.json pkg/planner/core/casetest/mpp/testdata/integration_suite_out.json pkg/planner/core/casetest/mpp/testdata/integration_suite_xut.json
```

`make bazel_prepare` was not required: no Go files were added, moved, renamed, or removed; no new top-level Go test function was added; no Bazel or Go module files were changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a planner issue that could choose a root UnionAll plan even when MPP execution is enforced.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Optimization**
  * Adjusted cost normalization for enforced parallel-processing UNION ALL so plan comparisons and explain outputs are more consistent.

* **Tests**
  * Added an explain-plan test case for UNION ALL in parallel-processing mode.
  * Updated test expectations for cache hit/miss behavior with UNION ALL queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->