### PR TITLE
executor: skip analyze flush broadcast in test binaries

### DIFF
--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -89,6 +90,17 @@ const (
 	idxTask
 )
 
+// runningUnderGoTest reports whether the current process is a Go test binary
+// (`go test`, including `make bench-daily`) rather than a real tidb-server
+// produced by `go build` of cmd/tidb-server. Test binaries register in-process
+// TiDB domains without binding a TiDB RPC listener, so a FLUSH STATS_DELTA
+// CLUSTER broadcast would hit a mock ":10080" and burn the TiKV RPC backoff
+// budget before analyze starts. testing.Testing() is set by the linker only
+// for binaries built via `go test`, so the gate is a no-op in production.
+func runningUnderGoTest() bool {
+	return testing.Testing()
+}
+
 // flushStatsDeltaForAnalyze flushes pending stats deltas for the tables whose column-analyze
 // tasks will capture base count / modify_count from mysql.stats_meta. Without this, a stale
 // pre-analyze delta can be applied later and double count rows or modifications.
@@ -101,12 +113,8 @@ func flushStatsDeltaForAnalyze(ctx context.Context, sctx sessionctx.Context, pla
 		return err
 	}
 
-	// HACK: Some tests register in-process TiDB domains but do not start TiDB RPC
-	// endpoints. Broadcasting FLUSH STATS_DELTA CLUSTER to those mock endpoints can
-	// spend the TiKV RPC backoff budget before analyze really starts. When the test
-	// topology cannot receive TiDB broadcast requests, dumping local deltas is the
-	// only viable approximation.
-	if intest.InTest {
+	// HACK: test binaries have no real RPC peer to broadcast to; dump locally instead.
+	if runningUnderGoTest() {
 		flushedLocally, err := flushAnalyzeStatsDeltaForTest(ctx, sctx, plan)
 		if err != nil {
 			return err


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68416

Problem Summary:
`make bench-daily` (CI job `gobench4`) fails on `BenchmarkNonPartitionPointGetPlanCacheOn`: `analyze table t` hits `context deadline exceeded` after 10s. PR #67939 added `flushStatsDeltaForAnalyze`, which broadcasts `FLUSH STATS_DELTA CLUSTER` via a TiDB-type cop request before each ANALYZE. The local-dump fallback was gated on `intest.InTest`, but that variable is only set under the `intest` build tag. `make bench-daily` runs `go test` without the tag, so the broadcast hits the mockstore session's empty `:10080` and hangs.

### What changed and how does it work?

Replace the gate with a `runningUnderGoTest` helper backed by `testing.Testing()`. The Go linker sets `testing.Testing()` to `true` for any binary produced by `go test` (covering both unit tests and `make bench-daily`) and leaves it `false` for `go build` of `cmd/tidb-server`. The gate is therefore a no-op in production regardless of host or flag configuration, and no longer depends on the `intest` build tag.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Reproduction and verification (same machine, same command):

https://github.com/pingcap/tidb/pull/68417#issuecomment-4476652544

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test execution efficiency by optimizing internal statistics handling during testing. Test processes now use a more efficient local flushing approach instead of cluster-level broadcasts, reducing unnecessary background operations during test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->