### PR TITLE
parser: fix between upper bound precedence

### DIFF
--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -1740,7 +1740,7 @@ func getMaskingPolicyRestrictOp(name string) (ast.MaskingPolicyRestrictOps, bool
 %left andand and
 %left between
 %precedence lowerThanEq
-%left eq ge le neq neqSynonym '>' '<' is like ilike in
+%left eq ge le neq neqSynonym nulleq '>' '<' is like ilike in
 %left '|'
 %left '&'
 %left rsh lsh
@@ -6800,8 +6800,9 @@ PredicateExpr:
 		sq.MultiRows = true
 		$$ = &ast.PatternInExpr{Expr: $1, Not: !$2.(bool), Sel: sq}
 	}
-|	BitExpr BetweenOrNotOp BitExpr "AND" PredicateExpr
+|	BitExpr BetweenOrNotOp BitExpr "AND" BoolPri
 	{
+		// The upper bound must include comparison-level expressions before the BETWEEN predicate is reduced.
 		$$ = &ast.BetweenExpr{
 			Expr:  $1,
 			Left:  $3,

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -975,6 +975,7 @@ func getMaskingPolicyRestrictOp(name string) (ast.MaskingPolicyRestrictOps, bool
 	MaxValueOrExpression            "maxvalue or expression"
 	DefaultOrExpression             "default or expression"
 	BoolPri                         "boolean primary expression"
+	BetweenUpperBound               "between upper bound expression"
 	ExprOrDefault                   "expression or default"
 	PredicateExpr                   "Predicate expression factor"
 	SetExpr                         "Set variable statement value's expression"
@@ -6715,6 +6716,22 @@ CompareOp:
 		$$ = opcode.NullEQ
 	}
 
+BetweenUpperBound:
+	BoolPri %prec between
+|	BoolPri IsOrNotOp trueKwd %prec is
+	{
+		$$ = &ast.IsTruthExpr{Expr: $1, Not: !$2.(bool), True: int64(1)}
+	}
+|	BoolPri IsOrNotOp falseKwd %prec is
+	{
+		$$ = &ast.IsTruthExpr{Expr: $1, Not: !$2.(bool), True: int64(0)}
+	}
+|	BoolPri IsOrNotOp "UNKNOWN" %prec is
+	{
+		/* https://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#operator_is */
+		$$ = &ast.IsNullExpr{Expr: $1, Not: !$2.(bool)}
+	}
+
 BetweenOrNotOp:
 	"BETWEEN"
 	{
@@ -6800,7 +6817,7 @@ PredicateExpr:
 		sq.MultiRows = true
 		$$ = &ast.PatternInExpr{Expr: $1, Not: !$2.(bool), Sel: sq}
 	}
-|	BitExpr BetweenOrNotOp BitExpr "AND" BoolPri
+|	BitExpr BetweenOrNotOp BitExpr "AND" BetweenUpperBound
 	{
 		// The upper bound must include comparison-level expressions before the BETWEEN predicate is reduced.
 		$$ = &ast.BetweenExpr{

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -7498,6 +7498,7 @@ func TestRestoreBinOpWithBrackets(t *testing.T) {
 	cases := []testCase{
 		{"select mod(a+b, 4)+1", true, "SELECT (((`a` + `b`) % 4) + 1)"},
 		{"SELECT MOD(10, 2 BETWEEN 0 and 5)", true, "SELECT (10 % (2 BETWEEN 0 AND 5))"}, // issue #59000
+		{"SELECT c0 BETWEEN 2.5 AND c0 >> 1 > 1 - c0", true, "SELECT `c0` BETWEEN 2.5 AND ((`c0` >> 1) > (1 - `c0`))"}, // issue #66045
 		{"select mod( year(a) - abs(weekday(a) + dayofweek(a)), 4) + 1", true, "SELECT (((year(`a`) - abs((weekday(`a`) + dayofweek(`a`)))) % 4) + 1)"},
 	}
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -7497,7 +7497,7 @@ func TestWithoutCharsetFlags(t *testing.T) {
 func TestRestoreBinOpWithBrackets(t *testing.T) {
 	cases := []testCase{
 		{"select mod(a+b, 4)+1", true, "SELECT (((`a` + `b`) % 4) + 1)"},
-		{"SELECT MOD(10, 2 BETWEEN 0 and 5)", true, "SELECT (10 % (2 BETWEEN 0 AND 5))"}, // issue #59000
+		{"SELECT MOD(10, 2 BETWEEN 0 and 5)", true, "SELECT (10 % (2 BETWEEN 0 AND 5))"},                               // issue #59000
 		{"SELECT c0 BETWEEN 2.5 AND c0 >> 1 > 1 - c0", true, "SELECT `c0` BETWEEN 2.5 AND ((`c0` >> 1) > (1 - `c0`))"}, // issue #66045
 		{"select mod( year(a) - abs(weekday(a) + dayofweek(a)), 4) + 1", true, "SELECT (((year(`a`) - abs((weekday(`a`) + dayofweek(`a`)))) % 4) + 1)"},
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -7536,6 +7536,62 @@ func TestRestoreBinOpWithBrackets(t *testing.T) {
 			require.Equal(t, tbl.restore, restoreSQLs, comment)
 		}
 	}
+
+	for _, tbl := range []struct {
+		src        string
+		assertType func(t *testing.T, expr ast.ExprNode)
+	}{
+		{
+			src: "select c0 between 1 and c1 is true",
+			assertType: func(t *testing.T, expr ast.ExprNode) {
+				between, ok := expr.(*ast.BetweenExpr)
+				require.True(t, ok)
+				right, ok := between.Right.(*ast.IsTruthExpr)
+				require.True(t, ok)
+				require.False(t, right.Not)
+				require.Equal(t, int64(1), right.True)
+			},
+		},
+		{
+			src: "select c0 between 1 and c1 is false",
+			assertType: func(t *testing.T, expr ast.ExprNode) {
+				between, ok := expr.(*ast.BetweenExpr)
+				require.True(t, ok)
+				right, ok := between.Right.(*ast.IsTruthExpr)
+				require.True(t, ok)
+				require.False(t, right.Not)
+				require.Equal(t, int64(0), right.True)
+			},
+		},
+		{
+			src: "select c0 between 1 and c1 is not true",
+			assertType: func(t *testing.T, expr ast.ExprNode) {
+				between, ok := expr.(*ast.BetweenExpr)
+				require.True(t, ok)
+				right, ok := between.Right.(*ast.IsTruthExpr)
+				require.True(t, ok)
+				require.True(t, right.Not)
+				require.Equal(t, int64(1), right.True)
+			},
+		},
+		{
+			src: "select c0 between 1 and c1 is unknown",
+			assertType: func(t *testing.T, expr ast.ExprNode) {
+				between, ok := expr.(*ast.BetweenExpr)
+				require.True(t, ok)
+				right, ok := between.Right.(*ast.IsNullExpr)
+				require.True(t, ok)
+				require.False(t, right.Not)
+			},
+		},
+	} {
+		stmt, err := p.ParseOneStmt(tbl.src, "", "")
+		require.NoError(t, err, tbl.src)
+		sel, ok := stmt.(*ast.SelectStmt)
+		require.True(t, ok, tbl.src)
+		require.Len(t, sel.Fields.Fields, 1, tbl.src)
+		tbl.assertType(t, sel.Fields.Fields[0].Expr)
+	}
 }
 
 // For CTE bindings.

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -7584,6 +7584,16 @@ func TestRestoreBinOpWithBrackets(t *testing.T) {
 				require.False(t, right.Not)
 			},
 		},
+		{
+			src: "select c0 between 1 and c1 <=> 1",
+			assertType: func(t *testing.T, expr ast.ExprNode) {
+				between, ok := expr.(*ast.BetweenExpr)
+				require.True(t, ok)
+				right, ok := between.Right.(*ast.BinaryOperationExpr)
+				require.True(t, ok)
+				require.Equal(t, opcode.NullEQ, right.Op)
+			},
+		},
 	} {
 		stmt, err := p.ParseOneStmt(tbl.src, "", "")
 		require.NoError(t, err, tbl.src)

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -48,7 +48,8 @@ func TestPlannerIssueRegressions(t *testing.T) {
 		return sharedTK
 	}
 
-	// issue-66045
+	// issue-66045: the implicit query verifies BETWEEN upper-bound parsing when comparison and
+	// bitwise operators are present; it should be equivalent to the explicit parenthesized form.
 	{
 		tk := prepareSharedTestKit(t)
 		tk.MustExec("create table t0 (id int auto_increment primary key, c0 double, index idx_c0 (c0))")

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -48,6 +48,17 @@ func TestPlannerIssueRegressions(t *testing.T) {
 		return sharedTK
 	}
 
+	// issue-66045
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("create table t0 (id int auto_increment primary key, c0 double, index idx_c0 (c0))")
+		tk.MustExec("insert into t0 (c0) values (1), (2.5), (10), (18.8), (-2.4), (-1.4134e10)")
+		implicit := `select * from t0 where c0 * -1 < 0 and c0 between 2.5 and c0 >> 1 > 1 - c0 and c0 ^ 3 << 2 < 41 order by c0`
+		explicit := `select * from t0 where ((c0 * (-1)) < 0) and (c0 between 2.5 and ((c0 >> 1) > (1 - c0))) and (((c0 ^ 3) << 2) < 41) order by c0`
+		tk.MustQuery(implicit).Check(testkit.Rows())
+		tk.MustQuery(explicit).Check(testkit.Rows())
+	}
+
 	// index-lookup-columns-mismatch
 	{
 		tk := prepareSharedTestKit(t)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/66045

Problem Summary:

TiDB parsed `BETWEEN` expressions with an upper bound that contains comparison and bitwise operators differently from the explicitly parenthesized form. For example, `c0 BETWEEN 2.5 AND c0 >> 1 > 1 - c0` could be reduced as a `BETWEEN` predicate before the comparison expression was fully included in the upper bound, which led to incorrect query results.

### What changed and how does it work?

This PR changes the parser grammar so the right side of a `BETWEEN ... AND ...` predicate accepts a `BoolPri` expression before reducing the `BETWEEN` predicate. It also gives `<=>` the same comparison precedence as the other comparison operators, avoiding a new parser conflict after the upper bound is widened.

Regression coverage is added for:

- parser restore behavior for the ambiguous `BETWEEN` upper-bound expression
- the reported issue query and its explicitly parenthesized equivalent

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Executed:

- `go test -run TestRestoreBinOpWithBrackets .`
- `go test -tags=intest,deadlock ./pkg/planner/core/issuetest -run TestPlannerIssueRegressions`
- `git diff --check`

Attempted:

- `make bazel_prepare`
  - Failed twice due transient `goproxy.cn` TLS handshake timeouts while fetching unrelated modules.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix incorrect results for some BETWEEN expressions whose upper bound contains comparison and bitwise operators.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved ambiguity in BETWEEN predicate parsing so upper‑bound expressions (including IS TRUE/FALSE/UNKNOWN and comparison forms) are interpreted correctly, preventing incorrect reductions.

* **Tests**
  * Added and expanded tests to validate complex BETWEEN expressions and a regression test to guard against recurrence of related parsing/ordering issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->