### PR TITLE
planner: skip plan cache for join ON subqueries

### DIFF
--- a/pkg/planner/core/casetest/plancache/BUILD.bazel
+++ b/pkg/planner/core/casetest/plancache/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "//pkg/planner/core:plan_clone_utils.go",
     ],
     flaky = True,
-    shard_count = 46,
+    shard_count = 47,
     deps = [
         "//pkg/expression",
         "//pkg/infoschema",

--- a/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
@@ -733,6 +733,25 @@ func TestPlanCacheWithSubquery(t *testing.T) {
 	}
 }
 
+func TestPlanCachePreparedJoinOnSubquery(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_enable_prepared_plan_cache=1")
+	tk.MustExec("create table t0(c0 char, c1 bool, c2 bool)")
+	tk.MustExec("replace into t0 values (null, false, false)")
+
+	tk.MustQuery("select /* issue:65975 */ t0.c0 from t0 left join t0 as t0_0 on (('') != ((select t0.c1 from t0 where t0.c1 group by t0.c1 having ((t0.c2) and (null)))))").Check(testkit.Rows("<nil>"))
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+
+	tk.MustExec("set @d = ''")
+	tk.MustExec("set @f = null")
+	tk.MustExec("prepare stmt from 'select /* issue:65975 */ t0.c0 from t0 left join t0 as t0_0 on ((?) != ((select t0.c1 from t0 where t0.c1 group by t0.c1 having ((t0.c2) and (?)))))'")
+	tk.MustQuery("execute stmt using @d, @f").Check(testkit.Rows("<nil>"))
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 skip prepared plan-cache: query has sub-queries in ON condition is un-cacheable"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+}
+
 func convertQueryToPrepExecStmt(q string) (normalQuery, prepStmt string, parameters []string) {
 	// select ... from t where a = #?1# and b = #?2#
 	normalQuery = strings.ReplaceAll(q, "#", "")

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -930,6 +930,7 @@ func (b *PlanBuilder) buildJoin(ctx context.Context, joinNode *ast.Join) (base.L
 		}
 	} else if joinNode.On != nil {
 		b.curClause = onClause
+		b.skipPlanCacheForJoinOnSubquery(joinNode.On.Expr)
 		onExpr, newPlan, err := b.rewrite(ctx, joinNode.On.Expr, joinPlan, nil, false)
 		if err != nil {
 			return nil, err
@@ -948,6 +949,20 @@ func (b *PlanBuilder) buildJoin(ctx context.Context, joinNode *ast.Join) (base.L
 		joinPlan.AttachOnConds(onCondition)
 	}
 	return joinPlan, nil
+}
+
+func (b *PlanBuilder) skipPlanCacheForJoinOnSubquery(expr ast.ExprNode) {
+	if !b.ctx.GetSessionVars().StmtCtx.UseCache() {
+		return
+	}
+	extractor := &subqueryExprExtractor{}
+	expr.Accept(extractor)
+	if len(extractor.exprs) == 0 {
+		return
+	}
+	// ON subqueries may need build-time evaluation. Keep EXECUTE parameters as
+	// concrete constants so the rewriter does not build an unsupported Apply.
+	b.ctx.GetSessionVars().StmtCtx.SetSkipPlanCache("query has sub-queries in ON condition is un-cacheable")
 }
 
 // buildLateralJoin builds a LogicalApply for LATERAL derived tables.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/65975

Problem Summary:

Prepared statements could fail with `ON condition doesn't support subqueries yet` when the query used an uncorrelated scalar subquery in a `JOIN ... ON` condition. The equivalent normal `SELECT` succeeds because the subquery can be evaluated during plan build, but the prepared plan-cache path kept `?` markers as mutable constants long enough for the ON rewriter to build an unsupported `Apply`.

### What changed and how does it work?

When planning a join `ON` expression that contains subqueries, skip plan cache before rewriting the ON expression. This keeps prepared `EXECUTE` parameters as concrete constants for the current execution, so the existing build-time subquery evaluation path can handle the uncorrelated subquery instead of producing an unsupported `Apply`.

A regression test covers the normal query and the prepared `EXECUTE` form from the issue, and checks that the prepared path skips plan cache.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Manual test

Compared with MySQL 9.4.0 in a local temporary container. Both normal and prepared forms return one `NULL` row; MySQL reports a `1292 Truncated incorrect INTEGER value: ''` warning for the prepared form.

### Tests

```bash
go test -tags=intest,deadlock ./pkg/planner/core/casetest/plancache -run TestPlanCachePreparedJoinOnSubquery -count=1
go test -tags=intest,deadlock ./pkg/planner/core/casetest/plancache -run 'TestPlanCache(PreparedJoinOnSubquery|WithSubquery)$' -count=1
make bazel_prepare
git diff --check
```

### Release note

```release-note
Fix a prepared statement error when a JOIN ON condition contains an uncorrelated subquery.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled prepared plan caching for JOIN queries containing subqueries in the ON condition to ensure correct query execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->