### PR TITLE
expression: fix prepared ELT return length

### DIFF
--- a/pkg/expression/builtin_string.go
+++ b/pkg/expression/builtin_string.go
@@ -3317,8 +3317,23 @@ func (c *eltFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 			types.SetBinChsClnFlag(bf.tp)
 		}
 		flen := argType.GetFlen()
+		if flen == 0 && argType.GetType() == mysql.TypeNull {
+			// NULL-typed branches have no width and must not make ELT's deferred
+			// result a zero-length string.
+			continue
+		}
+		if flen == 0 {
+			if con, ok := arg.(*Constant); ok {
+				val, isNull, err := con.EvalString(ctx.GetEvalCtx(), chunk.Row{})
+				if err == nil && !isNull {
+					// Casted constants can expose flen=0 before folding; derive
+					// the real width so truthiness conversion does not truncate it.
+					flen = utf8.RuneCountInString(val)
+				}
+			}
+		}
 		if flen == types.UnspecifiedLength || flen > bf.tp.GetFlen() {
-			bf.tp.SetFlen(argType.GetFlen())
+			bf.tp.SetFlen(flen)
 		}
 	}
 	sig := &builtinEltSig{bf}

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -906,6 +906,29 @@ ORDER BY t1.a, t2.a, t3.a, var`
 			"10 <nil> <nil> 6",
 		))
 	})
+
+	// issue-65804-prepared-elt-where-keeps-selected-value-length
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		resetTestDB(t, tk)
+		tk.MustExec("set @@sql_mode = default")
+
+		tk.MustExec("create table t_issue_65804(c0 bool)")
+		tk.MustExec("insert into t_issue_65804 values (true)")
+		query := "select c0 from t_issue_65804 where elt(0.6706395853005295, 758832383, '&', null)"
+		tk.MustQuery(query).Check(testkit.Rows("1"))
+		tk.MustQuery("show warnings").Check(testkit.Rows())
+
+		tk.MustExec("set @c = '&'")
+		tk.MustExec("set @d = null")
+		tk.MustExec("prepare expr_issue_65804 from 'select elt(0.6706395853005295, 758832383, ?, ?)'")
+		tk.MustQuery("execute expr_issue_65804 using @c, @d").Check(testkit.Rows("758832383"))
+		// The selected integer constant must not be folded through a zero-length string type.
+		require.NotContains(t, fmt.Sprint(tk.MustQuery("show warnings").Rows()), "Data Too Long")
+
+		tk.MustExec("prepare stmt_issue_65804 from 'select c0 from t_issue_65804 where elt(0.6706395853005295, 758832383, ?, ?)'")
+		tk.MustQuery("execute stmt_issue_65804 using @c, @d").Check(testkit.Rows("1"))
+		tk.MustQuery("show warnings").Check(testkit.Rows())
+	})
 }
 
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/65804

Problem Summary:

Prepared statements could return an incorrect empty result when `ELT` was used in a `WHERE` condition. In the reported case, the literal query returned one row, but the prepared form folded the selected `ELT` value through a zero-length string return type and evaluated the predicate as false.

### What changed and how does it work?

`ELT` now avoids deriving its result width from zero-length `NULL`-typed branches. When a zero-length constant argument has a non-null string value, the result width is derived from the evaluated string value. This keeps deferred folding from truncating the selected branch before `WHERE` truthiness conversion.

The regression test covers the literal query, the prepared `ELT` expression, and the prepared `WHERE ELT(...)` predicate under both the default optimizer and cascades.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Commands:

```bash
go test -tags=intest,deadlock ./pkg/planner/core/issuetest -run TestPlannerIssueRegressions -count=1
go test -tags=intest,deadlock ./pkg/expression -run TestInferType -count=1
make bazel_prepare
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix incorrect results for prepared statements that use the ELT function in WHERE conditions.
```
