### PR TITLE
expression: fix prepared DATE_FORMAT return length

### DIFF
--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -834,7 +834,13 @@ func (c *dateFormatFunctionClass) getFunction(ctx BuildContext, args []Expressio
 		return nil, err
 	}
 	// worst case: formatMask=%r%r%r...%r, each %r takes 11 characters
-	bf.tp.SetFlen((args[1].GetType(ctx.GetEvalCtx()).GetFlen() + 1) / 2 * 11)
+	formatFlen := args[1].GetType(ctx.GetEvalCtx()).GetFlen()
+	// A mutable or unknown-width format mask may be folded later with a wider parameter value.
+	if formatFlen == types.UnspecifiedLength || containMutableConst(ctx.GetEvalCtx(), []Expression{args[1]}) {
+		bf.tp.SetFlen(types.UnspecifiedLength)
+	} else {
+		bf.tp.SetFlen((formatFlen + 1) / 2 * 11)
+	}
 	sig := &builtinDateFormatSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_DateFormatSig)
 	return sig, nil

--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -359,7 +359,7 @@ func TestDateFunc2Pb(t *testing.T) {
 	require.NotNil(t, pbExprs[0])
 	js, err := json.Marshal(pbExprs[0])
 	require.NoError(t, err)
-	require.Equal(t, "{\"tp\":10000,\"children\":[{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":12,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},{\"tp\":201,\"val\":\"gAAAAAAAAAI=\",\"sig\":0,\"field_type\":{\"tp\":254,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-46,\"charset\":\"utf8mb4\",\"array\":false},\"has_distinct\":false}],\"sig\":6001,\"field_type\":{\"tp\":253,\"flag\":0,\"flen\":0,\"decimal\":-1,\"collate\":-46,\"charset\":\"utf8mb4\",\"array\":false},\"has_distinct\":false}", string(js))
+	require.Equal(t, "{\"tp\":10000,\"children\":[{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":12,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},{\"tp\":201,\"val\":\"gAAAAAAAAAI=\",\"sig\":0,\"field_type\":{\"tp\":254,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-46,\"charset\":\"utf8mb4\",\"array\":false},\"has_distinct\":false}],\"sig\":6001,\"field_type\":{\"tp\":253,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-46,\"charset\":\"utf8mb4\",\"array\":false},\"has_distinct\":false}", string(js))
 }
 
 func TestLogicalFunc2Pb(t *testing.T) {

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -885,6 +885,7 @@ ORDER BY field1`).Check(testkit.Rows())
 
 		tk.MustExec("set @c = -81775")
 		tk.MustExec("prepare stmt65717 from 'select t29.c0 from t29 where date_format(422123206, (binary (?)))'")
+		defer tk.MustExec("deallocate prepare stmt65717")
 		tk.MustQuery("execute stmt65717 using @c").Check(testkit.Rows("1"))
 		require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
 		tk.MustQuery("show warnings").Check(testkit.Rows())

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -872,6 +872,28 @@ ORDER BY field1`).Check(testkit.Rows())
 		tk.MustExec("rollback")
 	}
 
+	// issue-65717-date-format-format-mask-param-marker
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		resetTestDB(t, tk)
+		tk.MustExec("create table t29(c0 decimal)")
+		tk.MustExec("replace into t29(c0) values (1)")
+		tk.MustExec("set @@tidb_enable_prepared_plan_cache = 1")
+
+		tk.MustQuery("select t29.c0 from t29 where date_format(422123206, (binary (-81775)))").
+			Check(testkit.Rows("1"))
+		tk.MustQuery("show warnings").Check(testkit.Rows())
+
+		tk.MustExec("set @c = -81775")
+		tk.MustExec("prepare stmt65717 from 'select t29.c0 from t29 where date_format(422123206, (binary (?)))'")
+		tk.MustQuery("execute stmt65717 using @c").Check(testkit.Rows("1"))
+		require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+		tk.MustQuery("show warnings").Check(testkit.Rows())
+
+		tk.MustQuery("execute stmt65717 using @c").Check(testkit.Rows("1"))
+		require.True(t, tk.Session().GetSessionVars().FoundInPlanCache)
+		tk.MustQuery("show warnings").Check(testkit.Rows())
+	})
+
 	// issue-67802-mutable-user-var-join-cond-should-not-become-inner-side-filter
 	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
 		resetTestDB(t, tk)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/65717

Problem Summary:

Prepared statements could return an incorrect empty result when `DATE_FORMAT` used a mutable `BINARY (?)` format mask in a `WHERE` condition. The literal query returned one row, but the prepared form derived a zero-length result type for the format expression, folded the parameter value through that type, and evaluated the predicate as false.

### What changed and how does it work?

`DATE_FORMAT` now treats mutable or unknown-width format masks as `types.UnspecifiedLength` instead of deriving a concrete zero result length from compile-time metadata. Literal format masks still keep the existing worst-case length estimate.

The regression test covers the literal predicate, prepared first execution, prepared cached execution, no-warning behavior, and both default optimizer and cascades planner modes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Commands:

```bash
go test -run TestPlannerIssueRegressions -tags=intest,deadlock ./pkg/planner/core/issuetest -count=1
./tools/check/failpoint-go-test.sh pkg/expression -run 'TestDateFormat|TestInferType' -count=1
make lint
git -c core.fsmonitor=false diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix incorrect results for prepared statements that use DATE_FORMAT with a mutable binary format mask in WHERE conditions.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DATE_FORMAT now correctly handles variable or dynamic format masks, returning unspecified length when needed to ensure accurate results and planning.

* **Tests**
  * Added a regression test validating DATE_FORMAT with prepared statements and bound format parameters.
  * Updated serialized date-format test expectations to match the corrected behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->