### PR TITLE
planner: fix null-safe equality partition pruning

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -906,6 +906,20 @@ ORDER BY t1.a, t2.a, t3.a, var`
 			"10 <nil> <nil> 6",
 		))
 	})
+
+	// constant-left-nulleq-partition-pruning
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		resetTestDB(t, tk)
+		tk.MustExec("create table t_range(a int) partition by range(a) (partition p0 values less than (10), partition p1 values less than maxvalue)")
+		tk.MustExec("insert into t_range values (1), (11), (null)")
+		tk.MustQuery("select /* issue:65991 */ a from t_range where 1 <=> a").Check(testkit.Rows("1"))
+		tk.MustQuery("select /* issue:65991 */ a from t_range where null <=> a").Check(testkit.Rows("<nil>"))
+
+		tk.MustExec("create table t_range_cols(a int) partition by range columns(a) (partition p0 values less than (10), partition p1 values less than (maxvalue))")
+		tk.MustExec("insert into t_range_cols values (1), (11), (null)")
+		tk.MustQuery("select /* issue:65991 */ a from t_range_cols where 1 <=> a").Check(testkit.Rows("1"))
+		tk.MustQuery("select /* issue:65991 */ a from t_range_cols where null <=> a").Check(testkit.Rows("<nil>"))
+	})
 }
 
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {

--- a/pkg/planner/core/rule/rule_partition_processor.go
+++ b/pkg/planner/core/rule/rule_partition_processor.go
@@ -1691,6 +1691,9 @@ func opposite(op string) string {
 		return ast.GE
 	case ast.GE:
 		return ast.LE
+	case ast.NullEQ:
+		// Null-safe equality is symmetric, so flipping operands keeps the same operator.
+		return ast.NullEQ
 	}
 	panic("invalid input parameter" + op)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/65991

Problem Summary:

Queries can panic with `invalid input parameternulleq` when partition pruning sees a constant-left null-safe equality predicate such as `1 <=> partition_col`. The failing issue query derives that shape from a correlated tuple `IN` predicate over partitioned tables.

### What changed and how does it work?

`opposite()` now treats `ast.NullEQ` as symmetric when partition pruning normalizes constant-left predicates into column-left predicates. This keeps `<=>` unchanged after operand flipping instead of falling through to the panic path.

The regression test covers both `PARTITION BY RANGE` and `PARTITION BY RANGE COLUMNS`, including non-NULL and NULL constants.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

```sh
go test -tags=intest,deadlock ./pkg/planner/core/issuetest -run TestPlannerIssueRegressions -count=1
go test -tags=intest,deadlock ./pkg/planner/core/rule -run Test -count=1
make bazel_prepare
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a panic that could occur during partition pruning for constant-left null-safe equality predicates.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of null-safe equality operator in partition-pruned queries.

* **Tests**
  * Added regression test validating partition pruning behavior with null-safe equality operator.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->