### PR TITLE
planner: warn view-style hints on CTE references

### DIFF
--- a/pkg/planner/core/casetest/hint/testdata/integration_suite_in.json
+++ b/pkg/planner/core/casetest/hint/testdata/integration_suite_in.json
@@ -89,6 +89,8 @@
       // cte hint
       "explain format = 'plan_tree' select /*+ qb_name(qb_v7, v7), merge(@qb_v7) */ * from v7;",
       "explain format = 'plan_tree' select /*+ qb_name(qb_v8, v8), merge(@qb_v8) */ * from v8;",
+      "explain format = 'plan_tree' with tt as (select * from t1 where a=2 limit 100) select /*+ qb_name(my_select, tt@sel_1), ignore_index(t1@my_select, idx_a) */ * from tt;",
+      "explain format = 'plan_tree' with tt as (select * from t1 where a=2 limit 100) select /*+ qb_name(my_select_i_am_unused, tt@sel_1), ignore_index(t1@my_select, idx_a) */ * from tt;",
 
       // agg to cop hint
       "explain format = 'plan_tree' select /*+ qb_name(qb_v9, v9), AGG_TO_COP(@qb_v9) */ * from v9;",

--- a/pkg/planner/core/casetest/hint/testdata/integration_suite_out.json
+++ b/pkg/planner/core/casetest/hint/testdata/integration_suite_out.json
@@ -818,6 +818,32 @@
         "Warn": null
       },
       {
+        "SQL": "explain format = 'plan_tree' with tt as (select * from t1 where a=2 limit 100) select /*+ qb_name(my_select, tt@sel_1), ignore_index(t1@my_select, idx_a) */ * from tt;",
+        "Plan": [
+          "IndexLookUp root  limit embedded(offset:0, count:100)",
+          "├─Limit(Build) cop[tikv]  offset:0, count:100",
+          "│ └─IndexRangeScan cop[tikv] table:t1, index:idx_a(a) range:[2,2], keep order:false, stats:pseudo",
+          "└─TableRowIDScan(Probe) cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Warn": [
+          "[planner:1815]Hint ignore_index(`t1`@`my_select` `idx_a`) is ignored due to unknown query block name",
+          "[planner:1815]The qb_name hint my_select is unused, please check whether the table list in the qb_name hint my_select is correct"
+        ]
+      },
+      {
+        "SQL": "explain format = 'plan_tree' with tt as (select * from t1 where a=2 limit 100) select /*+ qb_name(my_select_i_am_unused, tt@sel_1), ignore_index(t1@my_select, idx_a) */ * from tt;",
+        "Plan": [
+          "IndexLookUp root  limit embedded(offset:0, count:100)",
+          "├─Limit(Build) cop[tikv]  offset:0, count:100",
+          "│ └─IndexRangeScan cop[tikv] table:t1, index:idx_a(a) range:[2,2], keep order:false, stats:pseudo",
+          "└─TableRowIDScan(Probe) cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Warn": [
+          "[planner:1815]Hint ignore_index(`t1`@`my_select` `idx_a`) is ignored due to unknown query block name",
+          "[planner:1815]The qb_name hint my_select_i_am_unused is unused, please check whether the table list in the qb_name hint my_select_i_am_unused is correct"
+        ]
+      },
+      {
         "SQL": "explain format = 'plan_tree' select /*+ qb_name(qb_v9, v9), AGG_TO_COP(@qb_v9) */ * from v9;",
         "Plan": [
           "HashAgg root  funcs:sum(Column)->Column",

--- a/pkg/planner/core/casetest/hint/testdata/integration_suite_xut.json
+++ b/pkg/planner/core/casetest/hint/testdata/integration_suite_xut.json
@@ -818,6 +818,32 @@
         "Warn": null
       },
       {
+        "SQL": "explain format = 'plan_tree' with tt as (select * from t1 where a=2 limit 100) select /*+ qb_name(my_select, tt@sel_1), ignore_index(t1@my_select, idx_a) */ * from tt;",
+        "Plan": [
+          "IndexLookUp root  limit embedded(offset:0, count:100)",
+          "├─Limit(Build) cop[tikv]  offset:0, count:100",
+          "│ └─IndexRangeScan cop[tikv] table:t1, index:idx_a(a) range:[2,2], keep order:false, stats:pseudo",
+          "└─TableRowIDScan(Probe) cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Warn": [
+          "[planner:1815]Hint ignore_index(`t1`@`my_select` `idx_a`) is ignored due to unknown query block name",
+          "[planner:1815]The qb_name hint my_select is unused, please check whether the table list in the qb_name hint my_select is correct"
+        ]
+      },
+      {
+        "SQL": "explain format = 'plan_tree' with tt as (select * from t1 where a=2 limit 100) select /*+ qb_name(my_select_i_am_unused, tt@sel_1), ignore_index(t1@my_select, idx_a) */ * from tt;",
+        "Plan": [
+          "IndexLookUp root  limit embedded(offset:0, count:100)",
+          "├─Limit(Build) cop[tikv]  offset:0, count:100",
+          "│ └─IndexRangeScan cop[tikv] table:t1, index:idx_a(a) range:[2,2], keep order:false, stats:pseudo",
+          "└─TableRowIDScan(Probe) cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Warn": [
+          "[planner:1815]Hint ignore_index(`t1`@`my_select` `idx_a`) is ignored due to unknown query block name",
+          "[planner:1815]The qb_name hint my_select_i_am_unused is unused, please check whether the table list in the qb_name hint my_select_i_am_unused is correct"
+        ]
+      },
+      {
         "SQL": "explain format = 'plan_tree' select /*+ qb_name(qb_v9, v9), AGG_TO_COP(@qb_v9) */ * from v9;",
         "Plan": [
           "HashAgg root  funcs:sum(Column)->Column",

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4759,6 +4759,7 @@ func (b *PlanBuilder) tryBuildCTE(ctx context.Context, tn *ast.TableName, asName
 				return p, nil
 			}
 
+			b.warnViewStyleHintsForCTE(tn, asName)
 			b.handleHelper.pushMap(nil)
 
 			hasLimit := false
@@ -4854,6 +4855,37 @@ func (b *PlanBuilder) tryBuildCTE(ctx context.Context, tn *ast.TableName, asName
 	}
 
 	return nil, nil
+}
+
+func (b *PlanBuilder) warnViewStyleHintsForCTE(tn *ast.TableName, asName *ast.CIStr) {
+	if b.hintProcessor == nil || len(b.hintProcessor.ViewQBNameToTable) == 0 {
+		return
+	}
+
+	// View-style QB_NAME hints are collected before name resolution. If they
+	// target a CTE reference, the CTE path cannot consume the forwarded hints,
+	// so report them as ignored instead of silently dropping them.
+	cteRefName := tn.Name
+	if asName != nil && asName.L != "" {
+		cteRefName = *asName
+	}
+	currentOffset := b.getSelectOffset()
+	for qbName, hintedTables := range b.hintProcessor.ViewQBNameToTable {
+		if len(hintedTables) == 0 || hintedTables[0].TableName.L != cteRefName.L {
+			continue
+		}
+		hintOffset := 1
+		if hintedTables[0].QBName.L != "" {
+			hintOffset = b.hintProcessor.GetHintOffset(hintedTables[0].QBName, currentOffset)
+		}
+		if hintOffset != currentOffset {
+			continue
+		}
+		for _, tableHint := range b.hintProcessor.ViewQBNameToHints[qbName] {
+			hintStr := h.RestoreTableOptimizerHint(tableHint)
+			b.ctx.GetSessionVars().StmtCtx.SetHintWarning(fmt.Sprintf("Hint %s is ignored due to unknown query block name", hintStr))
+		}
+	}
 }
 
 // computeCTEInlineFlag, Combine the declaration of CTE and the use of CTE to jointly determine **whether a CTE can be inlined**


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/64570

Problem Summary:

View-style optimizer hints that target a CTE reference can be collected before name resolution, but the CTE builder path does not consume the forwarded view hints. As a result, some hints are silently dropped and only the `qb_name` hint may be reported as unused.

### What changed and how does it work?

This PR detects view-style `QB_NAME` hints when a table name resolves to a CTE reference. If the first hinted table matches the CTE reference in the current query block, the forwarded table hints are reported as ignored due to an unknown query block name.

The hint is still not applied to the CTE body. This keeps the existing plan behavior unchanged while making the warning surface consistent.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that view-style optimizer hints targeting CTE references could be silently ignored instead of reporting an unknown query block warning.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases validating optimizer hint behavior with Common Table Expressions.

* **Bug Fixes**
  * Enhanced warning messages to clarify when optimizer hints cannot be applied to Common Table Expressions due to unknown query block references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->