### PR TITLE
planner: fix scalar context for nested IN subquery

### DIFF
--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -587,7 +587,10 @@ func (er *expressionRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
 			})
 		}
 		if len(v.List) != 1 {
-			break
+			// IN-list operands are scalar expression children. A nested IN-subquery on the left
+			// must therefore append its boolean result for this parent IN expression.
+			er.asScalar = true
+			return inNode, false
 		}
 		// For 10 in ((select * from t)), the parser won't set v.Sel.
 		// So we must process this case here.

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -872,6 +872,18 @@ ORDER BY field1`).Check(testkit.Rows())
 		tk.MustExec("rollback")
 	}
 
+	// issue-64854-in-subquery-inside-not-in-list
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		resetTestDB(t, tk)
+		tk.MustExec("create table t0(c1 float8, c2 double, unique(c2, c1))")
+
+		tk.MustQuery(`select /* issue:64854 */ t0.c1 as ca1, t0.c1 as ca2, t0.c2 as ca3
+			from t0
+			where ((t0.c2) in (select t0.c1 as ca4 from t0)) not in
+				(((t0.c1 is false)),
+				((((binary (null ^ true)) not regexp ((binary bit_length((default(t0.c2))) >> 17))) is not true)))`).Check(testkit.Rows())
+	})
+
 	// issue-67802-mutable-user-var-join-cond-should-not-become-inner-side-filter
 	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
 		resetTestDB(t, tk)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/64854

Problem Summary:

A query can use an `IN (subquery)` expression as a scalar operand of a parent `NOT IN (...)` list. The planner currently treats the nested `IN (subquery)` as filter context for multi-item `IN` lists, so it rewrites the subquery into the plan without appending a boolean result expression. The parent `inToExpression` then reads a missing stack operand and panics with `runtime error: index out of range [-1]`.

### What changed and how does it work?

For ordinary non-subquery `IN` lists with more than one list item, mark the child traversal as scalar context. This preserves the existing special handling for `IN ((subquery))`, while ensuring every child operand of the parent `IN` expression contributes a scalar expression to the rewrite stack.

The regression test covers the original nested `IN (subquery)` inside `NOT IN (...)` shape and runs under both cascades modes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test
- [ ] No need to test

Executed:

- `go test -tags=intest ./pkg/planner/core/issuetest -run TestPlannerIssueRegressions -count=1`
- `go test -tags=intest ./pkg/planner/core -run 'TestPatternIn|TestSubquery|TestAddLimitForCorrelatedExistsSubquery|TestCorrelatedScalarSubquery|TestIndexJoinHintInSubquery' -count=1`
- `make bazel_prepare`
- `git diff --check`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a planner panic when an IN subquery is used as an operand of another IN-list expression.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect handling of nested IN expressions in complex queries involving IN subqueries combined with NOT IN logic, ensuring accurate query results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->