### PR TITLE
planner: fix prepared GROUP BY ordinal param

### DIFF
--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 2,
+    shard_count = 3,
     deps = [
         "//pkg/errno",
         "//pkg/parser",

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -908,6 +908,24 @@ ORDER BY t1.a, t2.a, t3.a, var`
 	})
 }
 
+func TestPreparedGroupByOrdinalWithParamSelectItem(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t0")
+	tk.MustExec("create table t0(c0 decimal)")
+	tk.MustExec("insert ignore into t0 values (1)")
+
+	tk.MustQuery("select /* issue:63640 */ 2 from t0 where t0.c0 group by 1").Check(testkit.Rows("2"))
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+
+	tk.MustExec("set @a = 2")
+	tk.MustExec("prepare prepare_query from 'select /* issue:63640 */ ? from t0 where t0.c0 group by 1'")
+	tk.MustQuery("execute prepare_query using @a").Check(testkit.Rows("2"))
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+	tk.MustExec("deallocate prepare prepare_query")
+}
+
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
 		testKit.MustExec("use test")

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3441,6 +3441,13 @@ func (g *gbyResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 			return inNode, false
 		}
 		ret := g.fields[pos-1].Expr
+		if isParam, ok := ret.(*driver.ParamMarkerExpr); ok {
+			// GROUP BY ordinals can resolve to a select-list parameter marker; keep
+			// the original ordinal so EXECUTE will not treat the parameter value as
+			// another column position.
+			isParam.UseAsValueInGbyByClause = true
+			g.isParam = true
+		}
 		ret.Accept(extractor)
 		if len(extractor.AggFuncs) != 0 || ast.HasWindowFlag(ret) {
 			fieldName := g.fields[pos-1].AsName.String()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/63640

Problem Summary:

Prepared statements can fail when `GROUP BY` uses an ordinal that resolves to a parameter marker in the select list.

For example, the normal query returns `2`:

```sql
SELECT 2 FROM t0 WHERE t0.c0 GROUP BY 1;
```

but the prepared form failed during `EXECUTE` with `Unknown column '2' in 'group statement'`:

```sql
PREPARE prepare_query FROM 'SELECT ? FROM t0 WHERE t0.c0 GROUP BY 1';
EXECUTE prepare_query USING @a;
```

### What changed and how does it work?

When `gbyResolver` resolves a `GROUP BY` ordinal to a select-list `ParamMarkerExpr`, it now keeps the original ordinal in the reusable AST and marks the resolved parameter marker as a group-by value.

This preserves the prepared statement boundary:

- `GROUP BY 1` remains the original ordinal expression in the prepared AST.
- The resolved expression used for planning is still the select-list parameter marker.
- `EXECUTE` no longer reinterprets the parameter value as a new ordinal column position.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Manual MySQL compatibility check with `mysql:9.4`:

```sql
DROP TABLE IF EXISTS t0;
CREATE TABLE t0(c0 DECIMAL);
INSERT IGNORE INTO t0 VALUES (1);
SELECT 2 FROM t0 WHERE t0.c0 GROUP BY 1;
SHOW WARNINGS;
SET @a = 2;
PREPARE prepare_query FROM 'SELECT ? FROM t0 WHERE t0.c0 GROUP BY 1';
EXECUTE prepare_query USING @a;
SHOW WARNINGS;
DEALLOCATE PREPARE prepare_query;
```

Both normal and prepared forms returned `2`, and `SHOW WARNINGS` returned no warnings.

Validation:

```bash
go test -run TestPreparedGroupByOrdinalWithParamSelectItem -tags=intest,deadlock ./pkg/planner/core/issuetest
go test -run TestPreparedIssue8153 -tags=intest,deadlock ./pkg/executor/test/seqtest
make bazel_prepare
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that prepared statements could report an unknown column error when a GROUP BY ordinal references a parameter marker select item.
```
