### PR TITLE
parser: keep boolean BY items as constants

### DIFF
--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -8204,7 +8204,9 @@ ByItem:
 		valueExpr, ok := expr.(ast.ValueExpr)
 		if ok {
 			position, isPosition := valueExpr.GetValue().(int64)
-			if isPosition {
+			if isPosition && !mysql.HasIsBooleanFlag(valueExpr.GetType().GetFlag()) {
+				// TRUE/FALSE are stored as int64 internally, but MySQL treats them
+				// as constants in BY items rather than ordinal references.
 				expr = &ast.PositionExpr{N: int(position)}
 			}
 		}
@@ -8216,7 +8218,9 @@ ByItem:
 		valueExpr, ok := expr.(ast.ValueExpr)
 		if ok {
 			position, isPosition := valueExpr.GetValue().(int64)
-			if isPosition {
+			if isPosition && !mysql.HasIsBooleanFlag(valueExpr.GetType().GetFlag()) {
+				// TRUE/FALSE are stored as int64 internally, but MySQL treats them
+				// as constants in BY items rather than ordinal references.
 				expr = &ast.PositionExpr{N: int(position)}
 			}
 		}

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -906,6 +906,22 @@ ORDER BY t1.a, t2.a, t3.a, var`
 			"10 <nil> <nil> 6",
 		))
 	})
+
+	// issue-65939-group-by-boolean-literal-in-subquery
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		resetTestDB(t, tk)
+		tk.MustExec("set @@sql_mode = default")
+		tk.MustExec("set @@tidb_enable_inl_join_inner_multi_pattern='OFF'")
+		tk.MustExec("set @@tidb_enable_unsafe_substitute=0")
+
+		tk.MustExec("create table v0 (v1 int, v2 int, v3 int)")
+		tk.MustExec("insert into v0 values (50, 8, 0), (-1, 41, 0)")
+		tk.MustQuery("select (select -1 from v0 group by false, (v2 ^ v2) > v2), 16").
+			Check(testkit.Rows("-1 16"))
+		tk.MustQuery("select -1 from v0 group by false").Check(testkit.Rows("-1"))
+		tk.MustQuery("select -1 from v0 group by true").Check(testkit.Rows("-1"))
+		tk.MustContainErrMsg("select -1 from v0 group by 0", "Unknown column '0' in 'group statement'")
+	})
 }
 
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {

--- a/tests/integrationtest/r/executor/aggregate.result
+++ b/tests/integrationtest/r/executor/aggregate.result
@@ -337,8 +337,7 @@ CREATE TABLE `t0` (`c0` blob DEFAULT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
 INSERT INTO `t0` VALUES (_binary ']'),(_binary '777926278'),(_binary '0.2136404982804636'),(_binary '1901362489'),(_binary '1558203848'),(''),(_binary '1830406335'),(''),(_binary '0'),(NULL),(_binary '601930250'),(_binary '1558203848'),(_binary '-122008948'),(_binary '-2053608489'),(_binary 'hb/vt  <7'),(_binary 'RC&2*'),(_binary '1'),(_binary '-1722334316'),(_binary '1830406335'),(_binary '1372126029'),(_binary '882291196'),(NULL),(_binary '-399693596');
 CREATE ALGORITHM=TEMPTABLE DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v0` (`c0`, `c1`, `c2`) AS SELECT NULL AS `NULL`,`t49`.`c2` AS `c2`,(((CASE _UTF8MB4'I되EkfIO퀶' WHEN NULL THEN `t49`.`c0` WHEN `t49`.`c2` THEN `t0`.`c0` ELSE (CASE `t49`.`c0` WHEN _UTF8MB4'%' THEN 1035293362 ELSE _UTF8MB4',' END) END))<<(`t49`.`c0`)) AS `(((CASE 'I되EkfIO퀶' WHEN NULL THEN t49.c0 WHEN t49.c2 THEN t0.c0 ELSE (CASE t49.c0 WHEN '%' THEN 1035293362 ELSE ',' END ) END ))<<(t49.c0))` FROM (`t0`) JOIN `t49` WHERE TRUE;
 SELECT /*+ STREAM_AGG()*/v0.c0 FROM t49, v0 LEFT OUTER JOIN t0 ON ('Iw') GROUP BY true;
-c0
-NULL
+Error 1055 (42000): Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'executor__aggregate.v0.NULL' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
 drop table if exists t;
 create table t(a json);
 insert into t values ('{"id": 1,"score":23}');

--- a/tests/integrationtest/t/executor/aggregate.test
+++ b/tests/integrationtest/t/executor/aggregate.test
@@ -192,6 +192,7 @@ INSERT INTO `t49` VALUES ('0','0'),('0','1');
 CREATE TABLE `t0` (`c0` blob DEFAULT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 INSERT INTO `t0` VALUES (_binary ']'),(_binary '777926278'),(_binary '0.2136404982804636'),(_binary '1901362489'),(_binary '1558203848'),(''),(_binary '1830406335'),(''),(_binary '0'),(NULL),(_binary '601930250'),(_binary '1558203848'),(_binary '-122008948'),(_binary '-2053608489'),(_binary 'hb/vt  <7'),(_binary 'RC&2*'),(_binary '1'),(_binary '-1722334316'),(_binary '1830406335'),(_binary '1372126029'),(_binary '882291196'),(NULL),(_binary '-399693596');
 CREATE ALGORITHM=TEMPTABLE DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `v0` (`c0`, `c1`, `c2`) AS SELECT NULL AS `NULL`,`t49`.`c2` AS `c2`,(((CASE _UTF8MB4'I되EkfIO퀶' WHEN NULL THEN `t49`.`c0` WHEN `t49`.`c2` THEN `t0`.`c0` ELSE (CASE `t49`.`c0` WHEN _UTF8MB4'%' THEN 1035293362 ELSE _UTF8MB4',' END) END))<<(`t49`.`c0`)) AS `(((CASE 'I되EkfIO퀶' WHEN NULL THEN t49.c0 WHEN t49.c2 THEN t0.c0 ELSE (CASE t49.c0 WHEN '%' THEN 1035293362 ELSE ',' END ) END ))<<(t49.c0))` FROM (`t0`) JOIN `t49` WHERE TRUE;
+--error 1055
 SELECT /*+ STREAM_AGG()*/v0.c0 FROM t49, v0 LEFT OUTER JOIN t0 ON ('Iw') GROUP BY true;
 
 # TestPR15242ShallowCopy


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/65939

Problem Summary:

TiDB treats `GROUP BY FALSE` as `GROUP BY 0` and returns `Unknown column '0' in 'group statement'` for a valid query shape. MySQL accepts boolean literals in `GROUP BY` as constant expressions while still rejecting numeric ordinal `0`.

### What changed and how does it work?

The parser `ByItem` action now preserves boolean literals as constant expressions instead of converting their internal `int64(0)` / `int64(1)` datum into an ordinal `PositionExpr`.

Integer literals still keep the existing ordinal behavior, so `GROUP BY 0` continues to report `Unknown column '0' in 'group statement'`.

Regression coverage was added for the exact subquery case from the issue, `GROUP BY FALSE`, `GROUP BY TRUE`, and the `GROUP BY 0` boundary under both the default planner and cascades.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Manual test (add detailed scripts or steps below)

Manual test:

- MySQL 9.4 Docker oracle:
  - exact issue query returns `-1, 16`
  - `GROUP BY FALSE` and `GROUP BY TRUE` are accepted
  - `GROUP BY 0` and `ORDER BY 0` still return `Unknown column '0'`

Local validation:

- `go test -run TestPlannerIssueRegressions -tags=intest,deadlock ./pkg/planner/core/issuetest -count=1`
- `go test ./... -run TestPositionExprRestore -count=1` from `pkg/parser`
- `make parser_yacc`
- `make bazel_prepare`
- `git diff --check`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that `GROUP BY TRUE` and `GROUP BY FALSE` are incorrectly treated as ordinal references.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parser handling of boolean literals (TRUE/FALSE) in ORDER BY and GROUP BY clauses, which were incorrectly interpreted as positional references. These values are now properly recognized as constants, preventing query errors and ensuring accurate results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->