### PR TITLE
expression: format real cast as string like MySQL | tidb-test=pr/2741

### DIFF
--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -1458,10 +1458,12 @@ func (b *builtinCastRealAsStringSig) evalString(ctx EvalContext, row chunk.Row) 
 	return padZeroForBinaryType(res, b.tp, ctx)
 }
 
+// formatRealForCastAsString follows MySQL 9.4 behavior for CAST(real AS CHAR).
+// MySQL keeps ordinary magnitudes in fixed-point form and switches to scientific notation for large
+// or tiny real values, such as 1e100 -> "1e100" while 1e10 -> "10000000000".
 func formatRealForCastAsString(val float64, bits int) string {
 	absVal := math.Abs(val)
 	format := byte('f')
-	// MySQL keeps ordinary magnitudes in fixed-point form and switches only large or tiny real values to scientific notation.
 	if absVal >= 1e15 || (absVal > 0 && absVal < 1e-7) {
 		format = 'e'
 	}

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -1451,11 +1451,21 @@ func (b *builtinCastRealAsStringSig) evalString(ctx EvalContext, row chunk.Row) 
 		bits = 32
 	}
 
-	res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(val, 'f', -1, bits), b.tp, typeCtx(ctx), false)
+	res, err = types.ProduceStrWithSpecifiedTp(formatRealForCastAsString(val, bits), b.tp, typeCtx(ctx), false)
 	if err != nil {
 		return res, false, err
 	}
 	return padZeroForBinaryType(res, b.tp, ctx)
+}
+
+func formatRealForCastAsString(val float64, bits int) string {
+	absVal := math.Abs(val)
+	format := byte('f')
+	// MySQL keeps ordinary magnitudes in fixed-point form and switches only large or tiny real values to scientific notation.
+	if absVal >= 1e15 || (absVal > 0 && absVal < 1e-7) {
+		format = 'e'
+	}
+	return strings.Replace(strconv.FormatFloat(val, format, -1, bits), "e+", "e", 1)
 }
 
 type builtinCastRealAsTimeSig struct {

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -616,22 +616,77 @@ func TestCastFuncSig(t *testing.T) {
 		},
 		{
 			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
-			"-179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+			"-1.7976931348623157e308",
 			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(-math.MaxFloat64)}),
 		},
 		{
 			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
-			"-0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005",
+			"-5e-324",
 			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(-math.SmallestNonzeroFloat64)}),
 		},
 		{
+			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
+			"1e100",
+			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(1e100)}),
+		},
+		{
+			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
+			"1e20",
+			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(1e20)}),
+		},
+		{
+			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
+			"1e19",
+			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(1e19)}),
+		},
+		{
+			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
+			"1e15",
+			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(1e15)}),
+		},
+		{
+			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
+			"10000000000",
+			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(1e10)}),
+		},
+		{
+			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
+			"0.0001",
+			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(1e-4)}),
+		},
+		{
+			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
+			"0.00001",
+			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(1e-5)}),
+		},
+		{
+			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
+			"0.000001",
+			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(1e-6)}),
+		},
+		{
+			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
+			"0.0000001",
+			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(1e-7)}),
+		},
+		{
+			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
+			"1.23456789",
+			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(1.23456789)}),
+		},
+		{
+			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
+			"1.234567890123456e15",
+			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(1234567890123456e0)}),
+		},
+		{
 			&Column{RetType: types.NewFieldType(mysql.TypeFloat), Index: 0},
-			"-340282350000000000000000000000000000000",
+			"-3.4028235e38",
 			chunk.MutRowFromDatums([]types.Datum{types.NewFloat32Datum(-math.MaxFloat32)}),
 		},
 		{
 			&Column{RetType: types.NewFieldType(mysql.TypeFloat), Index: 0},
-			"-0.000000000000000000000000000000000000000000001",
+			"-1e-45",
 			chunk.MutRowFromDatums([]types.Datum{types.NewFloat32Datum(-math.SmallestNonzeroFloat32)}),
 		},
 		// cast decimal as string.

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -222,7 +222,7 @@ func (b *builtinCastRealAsStringSig) vecEvalString(ctx EvalContext, input *chunk
 			result.AppendNull()
 			continue
 		}
-		res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(v, 'f', -1, bits), b.tp, tc, false)
+		res, err = types.ProduceStrWithSpecifiedTp(formatRealForCastAsString(v, bits), b.tp, tc, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/61142

Problem Summary:

`CAST(real AS CHAR)` always used fixed-point formatting in TiDB. For very large values such as `1e100`, this expanded the string to all digits, so `LENGTH(CAST(1e100 AS CHAR))` returned `101` instead of MySQL's `5`.

### What changed and how does it work?

This PR adds a shared formatter for `CAST(real AS CHAR)` and uses it in both scalar and vectorized evaluation.

The formatter keeps ordinary magnitudes in fixed-point form, but switches large and tiny real values to scientific notation to match the sampled MySQL 9.4 behavior:

- `1e100` formats as `1e100`
- `1e10` stays `10000000000`
- `1e-7` stays `0.0000001`
- subnormal and maximum real values use scientific notation

It also normalizes Go's positive exponent output from `e+N` to MySQL-style `eN`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Manual MySQL 9.4 oracle:

```sql
SELECT CAST(1e100 AS CHAR), LENGTH(CAST(1e100 AS CHAR));
SELECT CAST(1e20 AS CHAR), CAST(1e19 AS CHAR), CAST(1e15 AS CHAR), CAST(1e10 AS CHAR);
SELECT CAST(1e-4 AS CHAR), CAST(1e-5 AS CHAR), CAST(1e-6 AS CHAR), CAST(1e-7 AS CHAR);
SELECT CAST(1.23456789 AS CHAR), CAST(1234567890123456e0 AS CHAR), CAST(1.7976931348623157e308 AS CHAR), CAST(5e-324 AS CHAR);
```

Validation:

```bash
./tools/check/failpoint-go-test.sh pkg/expression -run 'TestCastFuncSig|TestVectorizedBuiltinCastFunc' -count=1 -v
git diff --check
```

Worker validation also included:

```bash
go test ./.tmp/issue61142 -run TestIssue61142Replay -count=1 -tags=intest,deadlock -v
make lint
```

`make bazel_prepare` was not required because only existing Go files changed and no Bazel, module, generated, added, moved, renamed, or removed files were involved.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that casting a very large real value to CHAR could return a fixed-point string instead of MySQL-compatible scientific notation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved floating-point→string casting: selects scientific or fixed-point format based on magnitude, normalizes exponent styling, and yields more consistent results for very large/small values and edge cases.
* **Tests**
  * Updated float-to-string cast test vectors to match the new formatting behavior and expected outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->