### PR TITLE
planner: fix preparing EXPLAIN with view parameters

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -671,6 +671,21 @@ SELECT t84.c0 FROM t84 NATURAL RIGHT JOIN t0 WHERE true GROUP BY NULL HAVING (t8
 		tk.MustQuery("SELECT /* issue:58999 */ 1 FROM t0, v0 WHERE t0.c2=(-(-1|v0.c0))").Check(testkit.Rows())
 	}
 
+	// issue-63898-prepared-explain-view-parameter-marker
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec("CREATE TABLE t0(c0 CHAR)")
+		tk.MustExec("CREATE VIEW v0(c0) AS SELECT ((FIELD(t0.c0, 1)) != (false)) FROM t0")
+		tk.MustExec("SET @a='a', @b='b'")
+		tk.MustExec("PREPARE stmt63898 FROM 'EXPLAIN SELECT /* issue:63898 */ t0.c0 FROM v0, t0 WHERE ((t0.c0)=(REPLACE(?, v0.c0, ?)))'")
+		tk.MustQuery("EXECUTE stmt63898 USING @a, @b").MultiCheckContain([]string{
+			"HashJoin",
+			"replace(a",
+			"table:t0",
+		})
+		tk.MustExec("DEALLOCATE PREPARE stmt63898")
+	}
+
 	// Regression test for https://github.com/pingcap/tidb/issues/66339
 	// Read-only user variables with uppercase names should be converted to constant
 	// and use IndexRangeScan, same as lowercase names.

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5802,14 +5802,21 @@ func (b *PlanBuilder) buildExplain(ctx context.Context, explain *ast.ExplainStmt
 	stmtCtx := sctx.GetSessionVars().StmtCtx
 	var targetPlan base.Plan
 	if explain.Stmt != nil && !explain.Explore {
-		nodeW := resolve.NewNodeWWithCtx(explain.Stmt, b.resolveCtx)
-		if stmtCtx.ExplainFormat == types.ExplainFormatPlanCache {
-			targetPlan, _, err = OptimizeAstNode(ctx, sctx, nodeW, b.is)
-		} else {
-			targetPlan, _, err = OptimizeAstNodeNoCache(ctx, sctx, nodeW, b.is)
-		}
-		if err != nil {
-			return nil, err
+		paramChecker := &expression.ParamMarkerInPrepareChecker{}
+		explain.Stmt.Accept(paramChecker)
+		// Prepare-time EXPLAIN only needs the fixed EXPLAIN result schema. The
+		// target plan must be optimized at EXECUTE time after parameter values
+		// are available.
+		if !paramChecker.InPrepareStmt {
+			nodeW := resolve.NewNodeWWithCtx(explain.Stmt, b.resolveCtx)
+			if stmtCtx.ExplainFormat == types.ExplainFormatPlanCache {
+				targetPlan, _, err = OptimizeAstNode(ctx, sctx, nodeW, b.is)
+			} else {
+				targetPlan, _, err = OptimizeAstNodeNoCache(ctx, sctx, nodeW, b.is)
+			}
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63898

Problem Summary:

Preparing an `EXPLAIN` statement could optimize the target query too early while its parameter markers still had no execution-time values. For a query that reads a view and uses the view column inside `REPLACE(?, v.c0, ?)`, this produced a physical projection whose expression could not resolve against its child schema, so `PREPARE` failed with:

```text
Can't find column Column#4 in schema Column: [test.t0._tidb_rowid] PKOrUK: [] NullableUK: []
```

### What changed and how does it work?

`PlanBuilder.buildExplain` now detects prepare-time parameter markers in the `EXPLAIN` target statement. In that case, the prepare phase only builds the fixed `EXPLAIN` result schema and leaves target-plan optimization to `EXECUTE`, where the prepared plan-cache path has already installed the actual parameter values.

This keeps normal `EXPLAIN` behavior unchanged and avoids touching hidden-rowid/schema-resolution plumbing.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that could make PREPARE fail for EXPLAIN statements whose target query accesses a view and uses parameter markers.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of `EXPLAIN` statements in prepared statements with variable parameters.

* **Tests**
  * Added regression test for issue `#63898` validating correct plan execution for prepared `EXPLAIN` statements with variable parameters in view expressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->