### PR TITLE
planner: preserve rollup alias grouping positions

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -895,6 +895,18 @@ ORDER BY field1`).Check(testkit.Rows())
 		tk.MustQuery("show warnings").Check(testkit.Rows())
 		tk.MustQuery("select /* issue:65965 */ a, b, a as d, sum(c) from t1 group by 1, 2, 3 with rollup").Sort().Check(expected)
 		tk.MustQuery("show warnings").Check(testkit.Rows())
+
+		mixedExpected := testkit.Rows(
+			"1 1 3",
+			"1 <nil> 3",
+			"4 4 6",
+			"4 <nil> 6",
+			"7 7 9",
+			"7 <nil> 9",
+			"<nil> <nil> 18",
+		)
+		tk.MustQuery("select /* issue:65965 */ a, a as d, sum(c) from t1 group by a, d, a with rollup").Sort().Check(mixedExpected)
+		tk.MustQuery("show warnings").Check(testkit.Rows())
 	})
 
 	// issue-67802-mutable-user-var-join-cond-should-not-become-inner-side-filter

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -872,6 +872,31 @@ ORDER BY field1`).Check(testkit.Rows())
 		tk.MustExec("rollback")
 	}
 
+	// issue-65965-rollup-alias-repeated-grouping-key
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		resetTestDB(t, tk)
+		tk.MustExec("set @@sql_mode = default")
+		tk.MustExec("create table t1 (a int, b int, c int)")
+		tk.MustExec("insert into t1 values (1, 2, 3), (4, 5, 6), (7, 8, 9)")
+
+		expected := testkit.Rows(
+			"1 2 1 3",
+			"1 2 <nil> 3",
+			"1 <nil> <nil> 3",
+			"4 5 4 6",
+			"4 5 <nil> 6",
+			"4 <nil> <nil> 6",
+			"7 8 7 9",
+			"7 8 <nil> 9",
+			"7 <nil> <nil> 9",
+			"<nil> <nil> <nil> 18",
+		)
+		tk.MustQuery("select /* issue:65965 */ a, b, a as d, sum(c) from t1 group by a, b, d with rollup").Sort().Check(expected)
+		tk.MustQuery("show warnings").Check(testkit.Rows())
+		tk.MustQuery("select /* issue:65965 */ a, b, a as d, sum(c) from t1 group by 1, 2, 3 with rollup").Sort().Check(expected)
+		tk.MustQuery("show warnings").Check(testkit.Rows())
+	})
+
 	// issue-67802-mutable-user-var-join-cond-should-not-become-inner-side-filter
 	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
 		resetTestDB(t, tk)

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -257,7 +257,14 @@ func (b *PlanBuilder) buildExpand(p base.LogicalPlan, gbyItems []expression.Expr
 	return expand, newGbyItems, nil
 }
 
-func deduplicateRollupGbyItems(gbyItems []expression.Expression, sourceFieldIndices []int) ([]expression.Expression, []int, []int) {
+func deduplicateRollupGbyItems(
+	gbyItems []expression.Expression,
+	sourceFieldIndices []int,
+) (
+	deduplicatedGbyItems []expression.Expression,
+	deduplicatedSourceFieldIndices []int,
+	rollupGbyItemsRefPos []int,
+) {
 	preservePositions := collectPreservedRollupGbyItemPositions(gbyItems, sourceFieldIndices)
 	if !slices.Contains(preservePositions, true) {
 		expandGbyExprs, gbyExprsRefPos := expression.DeduplicateGbyExpression(gbyItems)

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -147,18 +147,11 @@ func (b *PlanBuilder) buildExpand(p base.LogicalPlan, gbyItems []expression.Expr
 	b.optFlag |= rule.FlagResolveExpand
 
 	// Rollup syntax require expand OP to do the data expansion, different data replica supply the different grouping layout.
-	expandGbyExprs := gbyItems
-	expandGbySourceFieldIndices := gbyItemSourceFieldIndices
-	gbyExprsRefPos := make([]int, 0, len(gbyItems))
-	keepGbyItemPositions := needPreserveRollupGbyItemPositions(gbyItems, gbyItemSourceFieldIndices)
-	if !keepGbyItemPositions {
-		expandGbyExprs, gbyExprsRefPos = expression.DeduplicateGbyExpression(gbyItems)
-		expandGbySourceFieldIndices = deriveDeduplicatedGbySourceFieldIndices(gbyExprsRefPos, gbyItemSourceFieldIndices, len(expandGbyExprs))
-	}
+	expandGbyExprs, expandGbySourceFieldIndices, rollupGbyExprsRefPos := deduplicateRollupGbyItems(gbyItems, gbyItemSourceFieldIndices)
 
 	// Build another projection below. When a repeated GROUP BY item is introduced by a SELECT
-	// alias or ordinal, keep every original GROUP BY item position visible to Expand because
-	// those positions can have different ROLLUP output nullability.
+	// alias or ordinal, keep that alias/ordinal-backed position visible to Expand because
+	// its ROLLUP output nullability can differ from ordinary repeated items.
 	proj := logicalop.LogicalProjection{Exprs: make([]expression.Expression, 0, p.Schema().Len()+len(expandGbyExprs))}.Init(b.ctx, b.getSelectOffset())
 	// project: child's output and GbyExprs in advance. (make every group-by item to be a column)
 	projSchema := p.Schema().Clone()
@@ -195,15 +188,7 @@ func (b *PlanBuilder) buildExpand(p base.LogicalPlan, gbyItems []expression.Expr
 	proj.SetSchema(projSchema)
 	proj.SetChildren(p)
 	proj.Proj4Expand = true
-	var newGbyItems []expression.Expression
-	if keepGbyItemPositions {
-		newGbyItems = make([]expression.Expression, 0, len(distinctGbyCols))
-		for _, col := range distinctGbyCols {
-			newGbyItems = append(newGbyItems, col.Clone())
-		}
-	} else {
-		newGbyItems = expression.RestoreGbyExpression(distinctGbyCols, gbyExprsRefPos)
-	}
+	newGbyItems := expression.RestoreGbyExpression(distinctGbyCols, rollupGbyExprsRefPos)
 
 	// build expand.
 	rollupGroupingSets := expression.RollupGroupingSets(newGbyItems)
@@ -272,9 +257,46 @@ func (b *PlanBuilder) buildExpand(p base.LogicalPlan, gbyItems []expression.Expr
 	return expand, newGbyItems, nil
 }
 
-func needPreserveRollupGbyItemPositions(gbyItems []expression.Expression, sourceFieldIndices []int) bool {
-	for i, sourceFieldIndex := range sourceFieldIndices {
-		if sourceFieldIndex < 0 {
+func deduplicateRollupGbyItems(gbyItems []expression.Expression, sourceFieldIndices []int) ([]expression.Expression, []int, []int) {
+	preservePositions := collectPreservedRollupGbyItemPositions(gbyItems, sourceFieldIndices)
+	if !slices.Contains(preservePositions, true) {
+		expandGbyExprs, gbyExprsRefPos := expression.DeduplicateGbyExpression(gbyItems)
+		expandSourceFieldIndices := deriveDeduplicatedGbySourceFieldIndices(gbyExprsRefPos, sourceFieldIndices, len(expandGbyExprs))
+		return expandGbyExprs, expandSourceFieldIndices, gbyExprsRefPos
+	}
+
+	expandGbyExprs := make([]expression.Expression, 0, len(gbyItems))
+	expandSourceFieldIndices := make([]int, 0, len(gbyItems))
+	rollupRefPos := make([]int, 0, len(gbyItems))
+	ordinaryRefPos := make(map[string]int, len(gbyItems))
+
+	for i, item := range gbyItems {
+		sourceFieldIndex := sourceFieldIndexAt(sourceFieldIndices, i)
+		if preservePositions[i] {
+			refPos := len(expandGbyExprs)
+			expandGbyExprs = append(expandGbyExprs, item)
+			expandSourceFieldIndices = append(expandSourceFieldIndices, sourceFieldIndex)
+			rollupRefPos = append(rollupRefPos, refPos)
+			continue
+		}
+
+		key := string(item.CanonicalHashCode())
+		if _, ok := ordinaryRefPos[key]; ok {
+			continue
+		}
+		refPos := len(expandGbyExprs)
+		ordinaryRefPos[key] = refPos
+		expandGbyExprs = append(expandGbyExprs, item)
+		expandSourceFieldIndices = append(expandSourceFieldIndices, sourceFieldIndex)
+		rollupRefPos = append(rollupRefPos, refPos)
+	}
+	return expandGbyExprs, expandSourceFieldIndices, rollupRefPos
+}
+
+func collectPreservedRollupGbyItemPositions(gbyItems []expression.Expression, sourceFieldIndices []int) []bool {
+	preservePositions := make([]bool, len(gbyItems))
+	for i := range gbyItems {
+		if sourceFieldIndexAt(sourceFieldIndices, i) < 0 {
 			continue
 		}
 		for j := range gbyItems {
@@ -282,11 +304,12 @@ func needPreserveRollupGbyItemPositions(gbyItems []expression.Expression, source
 				continue
 			}
 			if bytes.Equal(gbyItems[i].CanonicalHashCode(), gbyItems[j].CanonicalHashCode()) {
-				return true
+				preservePositions[i] = true
+				break
 			}
 		}
 	}
-	return false
+	return preservePositions
 }
 
 func deriveDeduplicatedGbySourceFieldIndices(gbyExprsRefPos []int, sourceFieldIndices []int, distinctLen int) []int {
@@ -296,10 +319,17 @@ func deriveDeduplicatedGbySourceFieldIndices(gbyExprsRefPos []int, sourceFieldIn
 	}
 	for idx, refPos := range gbyExprsRefPos {
 		if res[refPos] == -1 {
-			res[refPos] = sourceFieldIndices[idx]
+			res[refPos] = sourceFieldIndexAt(sourceFieldIndices, idx)
 		}
 	}
 	return res
+}
+
+func sourceFieldIndexAt(sourceFieldIndices []int, idx int) int {
+	if idx < len(sourceFieldIndices) {
+		return sourceFieldIndices[idx]
+	}
+	return -1
 }
 
 func (b *PlanBuilder) buildAggregation(ctx context.Context, p base.LogicalPlan, aggFuncList []*ast.AggregateFuncExpr, gbyItems []expression.Expression,

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"maps"
@@ -141,24 +142,34 @@ func (a *aggOrderByResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 	return inNode, true
 }
 
-func (b *PlanBuilder) buildExpand(p base.LogicalPlan, gbyItems []expression.Expression) (base.LogicalPlan, []expression.Expression, error) {
+func (b *PlanBuilder) buildExpand(p base.LogicalPlan, gbyItems []expression.Expression, gbyItemSourceFieldIndices []int) (base.LogicalPlan, []expression.Expression, error) {
 	ectx := p.SCtx().GetExprCtx().GetEvalCtx()
 	b.optFlag |= rule.FlagResolveExpand
 
 	// Rollup syntax require expand OP to do the data expansion, different data replica supply the different grouping layout.
-	distinctGbyExprs, gbyExprsRefPos := expression.DeduplicateGbyExpression(gbyItems)
-	// build another projection below.
-	proj := logicalop.LogicalProjection{Exprs: make([]expression.Expression, 0, p.Schema().Len()+len(distinctGbyExprs))}.Init(b.ctx, b.getSelectOffset())
-	// project: child's output and distinct GbyExprs in advance. (make every group-by item to be a column)
+	expandGbyExprs := gbyItems
+	expandGbySourceFieldIndices := gbyItemSourceFieldIndices
+	gbyExprsRefPos := make([]int, 0, len(gbyItems))
+	keepGbyItemPositions := needPreserveRollupGbyItemPositions(gbyItems, gbyItemSourceFieldIndices)
+	if !keepGbyItemPositions {
+		expandGbyExprs, gbyExprsRefPos = expression.DeduplicateGbyExpression(gbyItems)
+		expandGbySourceFieldIndices = deriveDeduplicatedGbySourceFieldIndices(gbyExprsRefPos, gbyItemSourceFieldIndices, len(expandGbyExprs))
+	}
+
+	// Build another projection below. When a repeated GROUP BY item is introduced by a SELECT
+	// alias or ordinal, keep every original GROUP BY item position visible to Expand because
+	// those positions can have different ROLLUP output nullability.
+	proj := logicalop.LogicalProjection{Exprs: make([]expression.Expression, 0, p.Schema().Len()+len(expandGbyExprs))}.Init(b.ctx, b.getSelectOffset())
+	// project: child's output and GbyExprs in advance. (make every group-by item to be a column)
 	projSchema := p.Schema().Clone()
 	names := p.OutputNames()
 	for _, col := range projSchema.Columns {
 		proj.Exprs = append(proj.Exprs, col)
 	}
-	distinctGbyColNames := make(types.NameSlice, 0, len(distinctGbyExprs))
-	distinctGbyCols := make([]*expression.Column, 0, len(distinctGbyExprs))
-	for _, expr := range distinctGbyExprs {
-		// distinct group expr has been resolved in resolveGby.
+	distinctGbyColNames := make(types.NameSlice, 0, len(expandGbyExprs))
+	distinctGbyCols := make([]*expression.Column, 0, len(expandGbyExprs))
+	for _, expr := range expandGbyExprs {
+		// group expr has been resolved in resolveGby.
 		proj.Exprs = append(proj.Exprs, expr)
 
 		// add the newly appended names.
@@ -184,7 +195,15 @@ func (b *PlanBuilder) buildExpand(p base.LogicalPlan, gbyItems []expression.Expr
 	proj.SetSchema(projSchema)
 	proj.SetChildren(p)
 	proj.Proj4Expand = true
-	newGbyItems := expression.RestoreGbyExpression(distinctGbyCols, gbyExprsRefPos)
+	var newGbyItems []expression.Expression
+	if keepGbyItemPositions {
+		newGbyItems = make([]expression.Expression, 0, len(distinctGbyCols))
+		for _, col := range distinctGbyCols {
+			newGbyItems = append(newGbyItems, col.Clone())
+		}
+	} else {
+		newGbyItems = expression.RestoreGbyExpression(distinctGbyCols, gbyExprsRefPos)
+	}
 
 	// build expand.
 	rollupGroupingSets := expression.RollupGroupingSets(newGbyItems)
@@ -202,7 +221,8 @@ func (b *PlanBuilder) buildExpand(p base.LogicalPlan, gbyItems []expression.Expr
 		DistinctGroupByCol:  distinctGbyCols,
 		DistinctGbyColNames: distinctGbyColNames,
 		// for resolving grouping function args.
-		DistinctGbyExprs: distinctGbyExprs,
+		DistinctGbyExprs:          expandGbyExprs,
+		GbyItemSourceFieldIndices: expandGbySourceFieldIndices,
 
 		// fill the gen col names when building level projections.
 	}.Init(b.ctx, b.getSelectOffset())
@@ -250,6 +270,36 @@ func (b *PlanBuilder) buildExpand(p base.LogicalPlan, gbyItems []expression.Expr
 
 	// defer generating level-projection as last logical optimization rule.
 	return expand, newGbyItems, nil
+}
+
+func needPreserveRollupGbyItemPositions(gbyItems []expression.Expression, sourceFieldIndices []int) bool {
+	for i, sourceFieldIndex := range sourceFieldIndices {
+		if sourceFieldIndex < 0 {
+			continue
+		}
+		for j := range gbyItems {
+			if i == j {
+				continue
+			}
+			if bytes.Equal(gbyItems[i].CanonicalHashCode(), gbyItems[j].CanonicalHashCode()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func deriveDeduplicatedGbySourceFieldIndices(gbyExprsRefPos []int, sourceFieldIndices []int, distinctLen int) []int {
+	res := make([]int, distinctLen)
+	for i := range res {
+		res[i] = -1
+	}
+	for idx, refPos := range gbyExprsRefPos {
+		if res[refPos] == -1 {
+			res[refPos] = sourceFieldIndices[idx]
+		}
+	}
+	return res
 }
 
 func (b *PlanBuilder) buildAggregation(ctx context.Context, p base.LogicalPlan, aggFuncList []*ast.AggregateFuncExpr, gbyItems []expression.Expression,
@@ -1684,6 +1734,7 @@ func findColFromNaturalUsingJoin(p base.LogicalPlan, col *expression.Column) (na
 
 type resolveGroupingTraverseAction struct {
 	CurrentBlockExpand *logicalop.LogicalExpand
+	SelectFieldIndex   int
 }
 
 func (r resolveGroupingTraverseAction) Transform(expr expression.Expression) (res expression.Expression) {
@@ -1692,18 +1743,18 @@ func (r resolveGroupingTraverseAction) Transform(expr expression.Expression) (re
 		// when meeting a column, judge whether it's a relate grouping set col.
 		// eg: select a, b from t group by a, c with rollup, here a is, while b is not.
 		// in underlying Expand schema (a,b,c,a',c'), a select list should be resolved to a'.
-		res, _ = r.CurrentBlockExpand.TrySubstituteExprWithGroupingSetCol(x)
+		res, _ = r.CurrentBlockExpand.TrySubstituteExprWithGroupingSetColByFieldIndex(x, r.SelectFieldIndex)
 	case *expression.CorrelatedColumn:
 		// select 1 in (select t2.a from t group by t2.a, b with rollup) from t2;
 		// in this case: group by item has correlated column t2.a, and it's select list contains t2.a as well.
-		res, _ = r.CurrentBlockExpand.TrySubstituteExprWithGroupingSetCol(x)
+		res, _ = r.CurrentBlockExpand.TrySubstituteExprWithGroupingSetColByFieldIndex(x, r.SelectFieldIndex)
 	case *expression.Constant:
 		// constant just keep it real: select 1 from t group by a, b with rollup.
 		res = x
 	case *expression.ScalarFunction:
 		// scalar function just try to resolve itself first, then if not changed, trying resolve its children.
 		var substituted bool
-		res, substituted = r.CurrentBlockExpand.TrySubstituteExprWithGroupingSetCol(x)
+		res, substituted = r.CurrentBlockExpand.TrySubstituteExprWithGroupingSetColByFieldIndex(x, r.SelectFieldIndex)
 		if !substituted {
 			// if not changed, try to resolve it children.
 			// select a+1, grouping(b) from t group by a+1 (projected as c), b with rollup: in this case, a+1 is resolved as c as a whole.
@@ -1721,13 +1772,17 @@ func (r resolveGroupingTraverseAction) Transform(expr expression.Expression) (re
 }
 
 func (b *PlanBuilder) replaceGroupingFunc(expr expression.Expression) expression.Expression {
+	return b.replaceGroupingFuncByFieldIndex(expr, -1)
+}
+
+func (b *PlanBuilder) replaceGroupingFuncByFieldIndex(expr expression.Expression, fieldIndex int) expression.Expression {
 	// current block doesn't have an expand OP, just return it.
 	// expr can be nil when rewrite eliminates a predicate in non-scalar contexts.
 	if b.currentBlockExpand == nil || expr == nil {
 		return expr
 	}
 	// curExpand can supply the DistinctGbyExprs and gid col.
-	traverseAction := resolveGroupingTraverseAction{CurrentBlockExpand: b.currentBlockExpand}
+	traverseAction := resolveGroupingTraverseAction{CurrentBlockExpand: b.currentBlockExpand, SelectFieldIndex: fieldIndex}
 	return expr.Traverse(traverseAction)
 }
 
@@ -1812,7 +1867,7 @@ func (b *PlanBuilder) buildProjection(ctx context.Context, p base.LogicalPlan, f
 		// for case: select a+1, b, sum(b), grouping(a) from t group by a, b with rollup.
 		// the column inside aggregate (only sum(b) here) should be resolved to original source column,
 		// while for others, just use expanded columns if exists: a'+ 1, b', group(gid)
-		newExpr = b.replaceGroupingFunc(newExpr)
+		newExpr = b.replaceGroupingFuncByFieldIndex(newExpr, i)
 
 		// For window functions in the order by clause, we will append an field for it.
 		// We need rewrite the window mapper here so order by clause could find the added field.
@@ -3371,7 +3426,8 @@ type gbyResolver struct {
 	isParam    bool
 	skipAggMap map[*ast.AggregateFuncExpr]*expression.CorrelatedColumn
 
-	exprDepth int // exprDepth is the depth of current expression in expression tree.
+	exprDepth        int // exprDepth is the depth of current expression in expression tree.
+	sourceFieldIndex int
 }
 
 func (g *gbyResolver) Enter(inNode ast.Node) (ast.Node, bool) {
@@ -3422,6 +3478,9 @@ func (g *gbyResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 					if isParam, ok := ret.(*driver.ParamMarkerExpr); ok {
 						isParam.UseAsValueInGbyByClause = true
 					}
+					if !g.inExpr {
+						g.sourceFieldIndex = index
+					}
 					return ret, true
 				}
 			}
@@ -3450,6 +3509,7 @@ func (g *gbyResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 			g.err = plannererrors.ErrWrongGroupField.GenWithStackByArgs(fieldName)
 			return inNode, false
 		}
+		g.sourceFieldIndex = pos - 1
 		return ret, true
 	case *ast.ValuesExpr:
 		if v.Column == nil {
@@ -4025,9 +4085,10 @@ func allColFromExprNode(p base.LogicalPlan, n ast.Node, names map[*types.FieldNa
 // The returned `[]ast.Node` may differ from the original `gby.Items` in the group by clause for params. For params, the
 // `gby.Items[].Expr` will not be overwritten. However, the resolved expression is still needed for further processing, so
 // it's returned out.
-func (b *PlanBuilder) resolveGbyExprs(p base.LogicalPlan, gby *ast.GroupByClause, fields []*ast.SelectField) ([]ast.ExprNode, error) {
+func (b *PlanBuilder) resolveGbyExprs(p base.LogicalPlan, gby *ast.GroupByClause, fields []*ast.SelectField) ([]ast.ExprNode, []int, error) {
 	b.curClause = groupByClause
 	exprs := make([]ast.ExprNode, 0, len(gby.Items))
+	sourceFieldIndices := make([]int, 0, len(gby.Items))
 	schema := p.Schema()
 	names := p.OutputNames()
 	// findJoinFullSchema walks through transparent wrappers (LogicalSelection)
@@ -4048,17 +4109,19 @@ func (b *PlanBuilder) resolveGbyExprs(p base.LogicalPlan, gby *ast.GroupByClause
 		resolver.inExpr = false
 		resolver.exprDepth = 0
 		resolver.isParam = false
+		resolver.sourceFieldIndex = -1
 		retExpr, _ := item.Expr.Accept(resolver)
 		if resolver.err != nil {
-			return exprs, errors.Trace(resolver.err)
+			return exprs, sourceFieldIndices, errors.Trace(resolver.err)
 		}
 		if !resolver.isParam {
 			item.Expr = retExpr.(ast.ExprNode)
 		}
 
 		exprs = append(exprs, retExpr.(ast.ExprNode))
+		sourceFieldIndices = append(sourceFieldIndices, resolver.sourceFieldIndex)
 	}
-	return exprs, nil
+	return exprs, sourceFieldIndices, nil
 }
 
 func (b *PlanBuilder) rewriteGbyExprs(ctx context.Context, p base.LogicalPlan, gby *ast.GroupByClause, items []ast.ExprNode) (base.LogicalPlan, []expression.Expression, bool, error) {
@@ -4357,8 +4420,9 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 	}
 
 	var gbyExprs []ast.ExprNode
+	var gbyItemSourceFieldIndices []int
 	if sel.GroupBy != nil {
-		gbyExprs, err = b.resolveGbyExprs(p, sel.GroupBy, sel.Fields.Fields)
+		gbyExprs, gbyItemSourceFieldIndices, err = b.resolveGbyExprs(p, sel.GroupBy, sel.Fields.Fields)
 		if err != nil {
 			return nil, err
 		}
@@ -4502,7 +4566,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 	if needBuildAgg {
 		// if rollup syntax is specified, Expand OP is required to replicate the data to feed different grouping layout.
 		if rollup {
-			p, gbyCols, err = b.buildExpand(p, gbyCols)
+			p, gbyCols, err = b.buildExpand(p, gbyCols, gbyItemSourceFieldIndices)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/planner/core/operator/logicalop/logical_expand.go
+++ b/pkg/planner/core/operator/logicalop/logical_expand.go
@@ -38,6 +38,9 @@ type LogicalExpand struct {
 	// keep the old gbyExprs for resolve cases like grouping(a+b), the args:
 	// a+b should be resolved to new projected gby col according to ref pos.
 	DistinctGbyExprs []expression.Expression `hash64-equals:"true"`
+	// GbyItemSourceFieldIndices records which SELECT field produced each GROUP BY item.
+	// -1 means the GROUP BY item was not resolved from a SELECT field alias or ordinal.
+	GbyItemSourceFieldIndices []int
 
 	// rollup grouping sets.
 	DistinctSize       int                     `hash64-equals:"true"`
@@ -298,6 +301,30 @@ func (p *LogicalExpand) TrySubstituteExprWithGroupingSetCol(expr expression.Expr
 	}
 	// not found.
 	return expr, false
+}
+
+// TrySubstituteExprWithGroupingSetColByFieldIndex is like TrySubstituteExprWithGroupingSetCol,
+// but it first preserves SELECT-field to GROUP-BY-item bindings produced by aliases or ordinals.
+func (p *LogicalExpand) TrySubstituteExprWithGroupingSetColByFieldIndex(expr expression.Expression, fieldIndex int) (expression.Expression, bool) {
+	if fieldIndex >= 0 {
+		for i, sourceFieldIndex := range p.GbyItemSourceFieldIndices {
+			if sourceFieldIndex != fieldIndex {
+				continue
+			}
+			if bytes.Equal(expr.CanonicalHashCode(), p.DistinctGbyExprs[i].CanonicalHashCode()) {
+				return p.DistinctGroupByCol[i], true
+			}
+		}
+		for i, sourceFieldIndex := range p.GbyItemSourceFieldIndices {
+			if sourceFieldIndex != -1 {
+				continue
+			}
+			if bytes.Equal(expr.CanonicalHashCode(), p.DistinctGbyExprs[i].CanonicalHashCode()) {
+				return p.DistinctGroupByCol[i], true
+			}
+		}
+	}
+	return p.TrySubstituteExprWithGroupingSetCol(expr)
 }
 
 // ResolveGroupingFuncArgsInGroupBy checks whether grouping function args is in grouping items.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65965

Problem Summary:

`GROUP BY ... WITH ROLLUP` could return duplicate visible rows when a `GROUP BY` item was a SELECT alias or ordinal that repeated an earlier grouping expression. For example, `SELECT a, b, a AS d, SUM(c) FROM t1 GROUP BY a, b, d WITH ROLLUP` reused the same projected grouping column for both `a` and `d`, so the `{a,b,d}` and `{a,b}` rollup levels both rendered `d` as non-NULL.

### What changed and how does it work?

This PR preserves original `GROUP BY` item positions in the `Expand` plan only when a repeated grouping expression is introduced through a SELECT alias or ordinal. That lets different rollup levels null the repeated visible positions independently.

The existing deduplicated grouping-expression path is kept for ordinary repeated grouping expressions, avoiding broad planner behavior churn.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation:

```bash
go test ./pkg/planner/core/issuetest -run TestPlannerIssueRegressions -count=1 -tags=intest,deadlock
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/physicalplantest -run TestExplainExpand -count=1
git diff --check
make lint
```

Manual replay covered the issue query, `GROUP BY 1, 2, 3 WITH ROLLUP`, ordinary repeated grouping keys, and warning checks.

`make bazel_prepare` was not required because this PR only changes existing Go files and extends an existing top-level Go test function. It does not add, remove, move, or rename Go files, add a new top-level `TestXxx`, or touch Bazel/go.mod/go.sum files.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that `GROUP BY ... WITH ROLLUP` could return duplicate visible rows when a SELECT alias or ordinal repeated an earlier grouping expression.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GROUP BY ... WITH ROLLUP to preserve grouping-item ordering and produce consistent summary rows and null placement for queries using aliases, ordinals, or repeated grouping keys.

* **Tests**
  * Added a regression test exercising multiple GROUP BY WITH ROLLUP variants (including a mixed alias/repeated-key case) and verifying exact results and no warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->