### PR TITLE
expression: fix FORMAT_BYTES byte output

### DIFF
--- a/pkg/expression/builtin_info_test.go
+++ b/pkg/expression/builtin_info_test.go
@@ -318,7 +318,14 @@ func TestFormatBytes(t *testing.T) {
 		Ret any
 	}{
 		{nil, nil},
-		{float64(0), "0 bytes"},
+		{float64(0), "   0 bytes"},
+		{float64(0.9), "   0 bytes"},
+		{float64(-0.9), "   0 bytes"},
+		{float64(1), "   1 bytes"},
+		{float64(-1), "  -1 bytes"},
+		{float64(1023), "1023 bytes"},
+		{float64(1023.999999999), "1023 bytes"},
+		{float64(-1023.999999999), "-1023 bytes"},
 		{float64(2048), "2.00 KiB"},
 		{float64(75295729), "71.81 MiB"},
 		{float64(5287242702), "4.92 GiB"},

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -1592,6 +1592,18 @@ func TestInfoBuiltin(t *testing.T) {
 	result = tk.MustQuery("select last_insert_id();")
 	result.Check(testkit.Rows("5"))
 
+	// for format_bytes
+	tk.MustQuery("select /* issue:59455 */ format_bytes(1023.999999999)").Check([][]any{{"1023 bytes"}})
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+	tk.MustQuery("select /* issue:59455 */ format_bytes(b'11111111')").Check([][]any{{" 255 bytes"}})
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+	tk.MustQuery("select /* issue:59455 */ format_bytes('')").Check([][]any{{"   0 bytes"}})
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+	tk.MustQuery("select /* issue:59455 */ format_bytes(char(52))").Check([][]any{{"   4 bytes"}})
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+	tk.MustQuery("select /* issue:59455 */ format_bytes(json_extract('{\"x\": 512}', '$.x'))").Check([][]any{{" 512 bytes"}})
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+
 	// for found_rows
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a int)")

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1829,7 +1829,12 @@ func GetFormatBytes(bytes float64) string {
 	}
 
 	if divisor == 1 {
-		return strconv.FormatFloat(bytes, 'f', 0, 64) + " " + unit
+		bytes = math.Trunc(bytes)
+		if bytes == 0 {
+			// Avoid formatting negative zero as "-0 bytes".
+			bytes = 0
+		}
+		return fmt.Sprintf("%4.0f %s", bytes, unit)
 	}
 	value := bytes / divisor
 	if math.Abs(value) >= 100000.0 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59455

Problem Summary:

`FORMAT_BYTES()` did not match MySQL for byte-sized values. TiDB rounded fractional byte values and omitted MySQL's leading padding for the byte unit.

### What changed and how does it work?

For the `bytes` unit branch in `GetFormatBytes`, truncate fractional byte values toward zero and format the numeric byte field with width 4 before appending the unit. Non-byte units keep the existing scaled formatting path.

The PR also adds regression coverage for direct builtin evaluation and SQL-level issue examples, including `BIT`, empty string, `CHAR()`, and `JSON_EXTRACT()` inputs.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

Refreshed the oracle with a local `mysql:9.4` container for the issue examples:

```sql
SELECT CONCAT('[', FORMAT_BYTES(1023.999999999), ']'), HEX(FORMAT_BYTES(1023.999999999)), LENGTH(FORMAT_BYTES(1023.999999999));
SELECT CONCAT('[', FORMAT_BYTES(b'11111111'), ']'), HEX(FORMAT_BYTES(b'11111111')), LENGTH(FORMAT_BYTES(b'11111111'));
SELECT CONCAT('[', FORMAT_BYTES(''), ']'), HEX(FORMAT_BYTES('')), LENGTH(FORMAT_BYTES(''));
SELECT CONCAT('[', FORMAT_BYTES(CHAR(52)), ']'), HEX(FORMAT_BYTES(CHAR(52))), LENGTH(FORMAT_BYTES(CHAR(52)));
SELECT CONCAT('[', FORMAT_BYTES(JSON_EXTRACT('{"x": 512}', '$.x')), ']'), HEX(FORMAT_BYTES(JSON_EXTRACT('{"x": 512}', '$.x'))), LENGTH(FORMAT_BYTES(JSON_EXTRACT('{"x": 512}', '$.x')));
```

Local validation:

```sh
./tools/check/failpoint-go-test.sh pkg/expression -run TestFormatBytes -count=1
./tools/check/failpoint-go-test.sh pkg/expression/integration_test -run TestInfoBuiltin -count=1
git diff --check
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix `FORMAT_BYTES()` byte output to match MySQL by truncating fractional byte values and preserving byte-unit leading padding.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved byte formatting to properly handle fractional and negative values, avoiding edge cases like "-0 bytes" output.

* **Tests**
  * Added comprehensive test coverage for byte formatting with various input types and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->