### PR TITLE
planner: validate NAME_CONST arguments like MySQL

### DIFF
--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -1568,22 +1568,6 @@ func TestGetLock(t *testing.T) {
 	tk.MustQuery("SELECT release_all_locks()").Check(testkit.Rows("0"))
 }
 
-func TestNameConstBuiltin(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-
-	tk.MustGetErrMsg("select /* issue:59459 */ name_const('bool1', true)", "[planner:1210]Incorrect arguments to NAME_CONST")
-	tk.MustGetErrMsg("select /* issue:59459 */ name_const('bool2', false)", "[planner:1210]Incorrect arguments to NAME_CONST")
-	tk.MustQuery("select /* issue:59459 */ name_const('pi', pi())").Check(testkit.Rows("3.141592653589793"))
-
-	tk.MustQuery("select name_const('neg', -1), name_const('negd', -1.0), name_const('str', 'x'), name_const('nil', null)").Check(testkit.Rows("-1 -1.0 x <nil>"))
-	tk.MustQuery("select name_const('paren_neg', -(1)) or 1").Check(testkit.Rows("1"))
-	tk.MustGetErrMsg("select name_const('expr', 1+1)", "[planner:1210]Incorrect arguments to NAME_CONST")
-	tk.MustGetErrMsg("select name_const('now', now())", "[planner:1210]Incorrect arguments to NAME_CONST")
-}
-
 func TestInfoBuiltin(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -1580,6 +1580,7 @@ func TestNameConstBuiltin(t *testing.T) {
 
 	tk.MustQuery("select name_const('neg', -1), name_const('negd', -1.0), name_const('str', 'x'), name_const('nil', null)").Check(testkit.Rows("-1 -1.0 x <nil>"))
 	tk.MustGetErrMsg("select name_const('expr', 1+1)", "[planner:1210]Incorrect arguments to NAME_CONST")
+	tk.MustGetErrMsg("select name_const('now', now())", "[planner:1210]Incorrect arguments to NAME_CONST")
 }
 
 func TestInfoBuiltin(t *testing.T) {

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -1579,6 +1579,7 @@ func TestNameConstBuiltin(t *testing.T) {
 	tk.MustQuery("select /* issue:59459 */ name_const('pi', pi())").Check(testkit.Rows("3.141592653589793"))
 
 	tk.MustQuery("select name_const('neg', -1), name_const('negd', -1.0), name_const('str', 'x'), name_const('nil', null)").Check(testkit.Rows("-1 -1.0 x <nil>"))
+	tk.MustQuery("select name_const('paren_neg', -(1)) or 1").Check(testkit.Rows("1"))
 	tk.MustGetErrMsg("select name_const('expr', 1+1)", "[planner:1210]Incorrect arguments to NAME_CONST")
 	tk.MustGetErrMsg("select name_const('now', now())", "[planner:1210]Incorrect arguments to NAME_CONST")
 }

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -1568,6 +1568,20 @@ func TestGetLock(t *testing.T) {
 	tk.MustQuery("SELECT release_all_locks()").Check(testkit.Rows("0"))
 }
 
+func TestNameConstBuiltin(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustGetErrMsg("select /* issue:59459 */ name_const('bool1', true)", "[planner:1210]Incorrect arguments to NAME_CONST")
+	tk.MustGetErrMsg("select /* issue:59459 */ name_const('bool2', false)", "[planner:1210]Incorrect arguments to NAME_CONST")
+	tk.MustQuery("select /* issue:59459 */ name_const('pi', pi())").Check(testkit.Rows("3.141592653589793"))
+
+	tk.MustQuery("select name_const('neg', -1), name_const('negd', -1.0), name_const('str', 'x'), name_const('nil', null)").Check(testkit.Rows("-1 -1.0 x <nil>"))
+	tk.MustGetErrMsg("select name_const('expr', 1+1)", "[planner:1210]Incorrect arguments to NAME_CONST")
+}
+
 func TestInfoBuiltin(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -48,6 +48,19 @@ func TestPlannerIssueRegressions(t *testing.T) {
 		return sharedTK
 	}
 
+	// issue-59459-name-const-argument-validation
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustGetErrMsg("select /* issue:59459 */ name_const('bool1', true)", "[planner:1210]Incorrect arguments to NAME_CONST")
+		tk.MustGetErrMsg("select /* issue:59459 */ name_const('bool2', false)", "[planner:1210]Incorrect arguments to NAME_CONST")
+		tk.MustQuery("select /* issue:59459 */ name_const('pi', pi())").Check(testkit.Rows("3.141592653589793"))
+
+		tk.MustQuery("select /* issue:59459 */ name_const('neg', -1), name_const('negd', -1.0), name_const('str', 'x'), name_const('nil', null)").Check(testkit.Rows("-1 -1.0 x <nil>"))
+		tk.MustQuery("select /* issue:59459 */ name_const('paren_neg', -(1)) or 1").Check(testkit.Rows("1"))
+		tk.MustGetErrMsg("select /* issue:59459 */ name_const('expr', 1+1)", "[planner:1210]Incorrect arguments to NAME_CONST")
+		tk.MustGetErrMsg("select /* issue:59459 */ name_const('now', now())", "[planner:1210]Incorrect arguments to NAME_CONST")
+	}
+
 	// index-lookup-columns-mismatch
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -686,13 +686,7 @@ func (p *preprocessor) Leave(in ast.Node) (out ast.Node, ok bool) {
 				p.err = expression.ErrIncorrectParameterCount.GenWithStackByArgs(x.FnName.L)
 			} else {
 				_, isValueExpr1 := x.Args[0].(*driver.ValueExpr)
-				isValueExpr2 := false
-				switch x.Args[1].(type) {
-				case *driver.ValueExpr, *ast.UnaryOperationExpr:
-					isValueExpr2 = true
-				}
-
-				if !isValueExpr1 || !isValueExpr2 {
+				if !isValueExpr1 || !isValidNameConstValue(x.Args[1]) {
 					p.err = plannererrors.ErrWrongArguments.GenWithStackByArgs("NAME_CONST")
 				}
 			}
@@ -749,6 +743,29 @@ func (p *preprocessor) Leave(in ast.Node) (out ast.Node, ok bool) {
 	}
 
 	return in, p.err == nil
+}
+
+func isValidNameConstValue(arg ast.ExprNode) bool {
+	switch v := arg.(type) {
+	case *driver.ValueExpr:
+		// MySQL rejects TRUE/FALSE pseudo-literals here even though the parser represents them as value expressions.
+		return !mysql.HasIsBooleanFlag(v.Type.GetFlag())
+	case *ast.UnaryOperationExpr:
+		return isValidNameConstUnaryValue(v)
+	case *ast.FuncCallExpr:
+		return v.FnName.L == ast.PI && len(v.Args) == 0
+	default:
+		return false
+	}
+}
+
+func isValidNameConstUnaryValue(arg *ast.UnaryOperationExpr) bool {
+	switch v := arg.V.(type) {
+	case *driver.ValueExpr:
+		return !mysql.HasIsBooleanFlag(v.Type.GetFlag())
+	default:
+		return false
+	}
 }
 
 func checkAutoIncrementOp(colDef *ast.ColumnDef, index int) (bool, error) {

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -745,6 +745,9 @@ func (p *preprocessor) Leave(in ast.Node) (out ast.Node, ok bool) {
 	return in, p.err == nil
 }
 
+// NAME_CONST follows MySQL's narrow constant contract: ordinary literals are accepted,
+// TRUE/FALSE pseudo-literals are rejected, unary literals are checked separately, and
+// zero-argument PI() is the only allowed function special case.
 func isValidNameConstValue(arg ast.ExprNode) bool {
 	switch v := arg.(type) {
 	case *driver.ValueExpr:
@@ -759,6 +762,8 @@ func isValidNameConstValue(arg ast.ExprNode) bool {
 	}
 }
 
+// Unary plus/minus wraps literal values in the AST, but NAME_CONST should not accept
+// boolean pseudo-literals or more complex unary expressions through that wrapper.
 func isValidNameConstUnaryValue(arg *ast.UnaryOperationExpr) bool {
 	switch v := arg.V.(type) {
 	case *driver.ValueExpr:

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -762,10 +762,18 @@ func isValidNameConstValue(arg ast.ExprNode) bool {
 	}
 }
 
-// Unary plus/minus wraps literal values in the AST, but NAME_CONST should not accept
-// boolean pseudo-literals or more complex unary expressions through that wrapper.
+// Unary plus/minus may wrap parenthesized literal values in the AST, but NAME_CONST
+// should not accept boolean pseudo-literals or more complex unary expressions through that wrapper.
 func isValidNameConstUnaryValue(arg *ast.UnaryOperationExpr) bool {
-	switch v := arg.V.(type) {
+	expr := arg.V
+	for {
+		parenthesized, ok := expr.(*ast.ParenthesesExpr)
+		if !ok {
+			break
+		}
+		expr = parenthesized.Expr
+	}
+	switch v := expr.(type) {
 	case *driver.ValueExpr:
 		return !mysql.HasIsBooleanFlag(v.Type.GetFlag())
 	default:


### PR DESCRIPTION
### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/59459

Problem Summary:

`NAME_CONST()` accepted `TRUE` / `FALSE` pseudo-literals but rejected `PI()`, which is incompatible with MySQL. MySQL returns incorrect-arguments errors for the boolean pseudo-literals and accepts `NAME_CONST('pi', PI())`.

### What changed and how does it work?

This PR keeps the fix local to `NAME_CONST` preprocessing validation:

- reject `TRUE` / `FALSE` pseudo-literals by checking the parser value expression's boolean flag;
- keep ordinary literal and unary literal values valid;
- allow the MySQL-compatible special case `PI()` as a zero-argument function value;
- keep other expression/function values rejected.
- keep the issue regression coverage in `pkg/planner/core/issuetest`, where the `NAME_CONST` preprocessing validation is owned.

The expression evaluation signatures are unchanged. The owner path is `pkg/planner/core/preprocess.go`, where `NAME_CONST` already validates constant-like arguments before expression building.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix NAME_CONST() argument validation to reject TRUE and FALSE pseudo-literals and accept PI(), matching MySQL behavior.
```

### Tests

```sh
go test -run TestPlannerIssueRegressions -tags=intest,deadlock ./pkg/planner/core/issuetest -count=1
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the `NAME_CONST` SQL function's second argument to correctly reject boolean values and arithmetic expressions, while properly supporting unary operators and zero-argument function calls like `PI()`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
