### PR TITLE
expression: fix signed bigint subtraction overflow | tidb-test=pr/2742

### DIFF
--- a/pkg/expression/builtin_arithmetic.go
+++ b/pkg/expression/builtin_arithmetic.go
@@ -519,7 +519,7 @@ func (s *builtinArithmeticMinusIntSig) overflowCheck(isLHSUnsigned, isRHSUnsigne
 				return true
 			}
 		} else {
-			if a > 0 && b < 0 {
+			if a >= 0 && b < 0 {
 				resUnsigned = true
 			} else if a < 0 && b > 0 && res >= 0 {
 				return true

--- a/pkg/expression/builtin_arithmetic.go
+++ b/pkg/expression/builtin_arithmetic.go
@@ -519,6 +519,7 @@ func (s *builtinArithmeticMinusIntSig) overflowCheck(isLHSUnsigned, isRHSUnsigne
 				return true
 			}
 		} else {
+			// 0 - math.MinInt64 exceeds MaxInt64, so zero belongs to the non-negative path.
 			if a >= 0 && b < 0 {
 				resUnsigned = true
 			} else if a < 0 && b > 0 && res >= 0 {

--- a/pkg/expression/builtin_arithmetic_test.go
+++ b/pkg/expression/builtin_arithmetic_test.go
@@ -206,6 +206,47 @@ func TestArithmeticMinus(t *testing.T) {
 	require.False(t, isNull)
 	require.Equal(t, int64(11), intResult)
 
+	for _, tc := range []struct {
+		name   string
+		args   []any
+		expect any
+		errStr string
+	}{
+		{
+			name:   "zero minus signed min overflows",
+			args:   []any{int64(0), int64(math.MinInt64)},
+			errStr: "BIGINT value is out of range",
+		},
+		{
+			name:   "positive minus signed min overflows",
+			args:   []any{int64(1), int64(math.MinInt64)},
+			errStr: "BIGINT value is out of range",
+		},
+		{
+			name:   "negative one minus signed min stays in range",
+			args:   []any{int64(-1), int64(math.MinInt64)},
+			expect: int64(math.MaxInt64),
+		},
+		{
+			name:   "zero minus negative one stays in range",
+			args:   []any{int64(0), int64(-1)},
+			expect: int64(1),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sig, err := funcs[ast.Minus].getFunction(ctx, datumsToConstants(types.MakeDatums(tc.args...)))
+			require.NoError(t, err)
+			require.NotNil(t, sig)
+			val, err := evalBuiltinFunc(sig, ctx, chunk.Row{})
+			if tc.errStr == "" {
+				require.NoError(t, err)
+				testutil.DatumEqual(t, types.NewDatum(tc.expect), val)
+			} else {
+				require.ErrorContains(t, err, tc.errStr)
+			}
+		})
+	}
+
 	// case 2
 	args = []any{1.01001, -0.01}
 

--- a/pkg/expression/builtin_arithmetic_vec_test.go
+++ b/pkg/expression/builtin_arithmetic_vec_test.go
@@ -198,6 +198,20 @@ func TestVectorizedBuiltinArithmeticFunc(t *testing.T) {
 
 func TestVectorizedDecimalErrOverflow(t *testing.T) {
 	ctx := mock.NewContext()
+	t.Run("int_minus", func(t *testing.T) {
+		fts := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong), types.NewFieldType(mysql.TypeLonglong)}
+		input := chunk.New(fts, 1, 1)
+		input.AppendInt64(0, 0)
+		input.AppendInt64(1, math.MinInt64)
+		cols := []Expression{&Column{Index: 0, RetType: fts[0]}, &Column{Index: 1, RetType: fts[1]}}
+		baseFunc, err := funcs[ast.Minus].getFunction(ctx, cols)
+		require.NoError(t, err)
+		require.True(t, baseFunc.vectorized() && baseFunc.isChildrenVectorized())
+		result := chunk.NewColumn(eType2FieldType(types.ETInt), 1)
+		err = vecEvalType(ctx, baseFunc, types.ETInt, input, result)
+		require.EqualError(t, err, "[types:1690]BIGINT value is out of range in '(Column#0 - Column#0)'")
+	})
+
 	testCases := []struct {
 		args     []float64
 		funcName string


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67211

Problem Summary:

Signed BIGINT subtraction missed the `0 - math.MinInt64` overflow boundary. TiDB could return `-9223372036854775808` without warnings for `(0) - a` when `a` was `-9223372036854775808`, while MySQL reports an out-of-range error.

### What changed and how does it work?

The signed/signed integer subtraction overflow check now treats zero the same as other non-negative left operands when subtracting a negative right operand. This preserves in-range cases such as `-1 - math.MinInt64` while raising overflow for `0 - math.MinInt64`.

Regression coverage was added for both row-based and vectorized BIGINT subtraction evaluation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test:

```bash
./tools/check/failpoint-go-test.sh pkg/expression -run 'TestArithmeticMinus|TestVectorizedDecimalErrOverflow' -count=1
make lint
```

Manual test:

- Replayed the issue SQL locally with a temporary testkit harness before and after the fix.
- Before the fix, `(0) - a` returned `-9223372036854775808` without warnings.
- After the fix, `(0) - a` and `(1) - a` return error 1690, while `(-1) - a` still returns `9223372036854775807`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where signed BIGINT subtraction could silently overflow for `0 - -9223372036854775808` instead of returning an out-of-range error.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted overflow detection logic for integer subtraction when the first operand equals zero.

* **Tests**
  * Added comprehensive test cases covering integer subtraction boundary conditions with minimum integer values.
  * Added vectorized operation tests for integer subtraction overflow scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->