### PR TITLE
expression: fix ANY_VALUE BIT string evaluation

### DIFF
--- a/pkg/expression/builtin_miscellaneous.go
+++ b/pkg/expression/builtin_miscellaneous.go
@@ -455,11 +455,11 @@ func (b *builtinIntAnyValueSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 }
 
 func (b *builtinIntAnyValueSig) evalString(ctx EvalContext, row chunk.Row) (string, bool, error) {
-	if b.tp.GetType() != mysql.TypeBit {
+	if !b.tp.Hybrid() {
 		return b.baseBuiltinFunc.evalString(ctx, row)
 	}
-	// ANY_VALUE preserves the TypeBit return field, but its primary evaluation signature is integer.
-	// String contexts still need the underlying BIT value in its binary string form.
+	// ANY_VALUE can preserve a hybrid return field while using the integer signature.
+	// String contexts still need the underlying hybrid value in its string form.
 	return b.args[0].EvalString(ctx, row)
 }
 

--- a/pkg/expression/builtin_miscellaneous.go
+++ b/pkg/expression/builtin_miscellaneous.go
@@ -454,6 +454,15 @@ func (b *builtinIntAnyValueSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 	return b.args[0].EvalInt(ctx, row)
 }
 
+func (b *builtinIntAnyValueSig) evalString(ctx EvalContext, row chunk.Row) (string, bool, error) {
+	if b.tp.GetType() != mysql.TypeBit {
+		return b.baseBuiltinFunc.evalString(ctx, row)
+	}
+	// ANY_VALUE preserves the TypeBit return field, but its primary evaluation signature is integer.
+	// String contexts still need the underlying BIT value in its binary string form.
+	return b.args[0].EvalString(ctx, row)
+}
+
 type builtinJSONAnyValueSig struct {
 	baseBuiltinFunc
 

--- a/pkg/expression/builtin_miscellaneous_test.go
+++ b/pkg/expression/builtin_miscellaneous_test.go
@@ -259,6 +259,70 @@ func TestAnyValue(t *testing.T) {
 	}
 }
 
+func TestAnyValueHybridStringEvalWithIntSig(t *testing.T) {
+	ctx := createContext(t)
+	enumTp := types.NewFieldType(mysql.TypeEnum)
+	enumTp.SetElems([]string{"a", "b"})
+	enumTp.AddFlag(mysql.EnumSetAsIntFlag)
+	setTp := types.NewFieldType(mysql.TypeSet)
+	setTp.SetElems([]string{"a", "b"})
+	setTp.AddFlag(mysql.EnumSetAsIntFlag)
+	bitTp := types.NewFieldType(mysql.TypeBit)
+
+	tests := []struct {
+		name     string
+		tp       *types.FieldType
+		appendFn func(*chunk.Chunk)
+		expected string
+	}{
+		{
+			name: "enum",
+			tp:   enumTp,
+			appendFn: func(chk *chunk.Chunk) {
+				chk.AppendEnum(0, types.Enum{Name: "b", Value: 2})
+			},
+			expected: "b",
+		},
+		{
+			name: "set",
+			tp:   setTp,
+			appendFn: func(chk *chunk.Chunk) {
+				chk.AppendSet(0, types.Set{Name: "a,b", Value: 3})
+			},
+			expected: "a,b",
+		},
+		{
+			name: "bit",
+			tp:   bitTp,
+			appendFn: func(chk *chunk.Chunk) {
+				chk.AppendBytes(0, []byte{0x01})
+			},
+			expected: "\x01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			col := &Column{Index: 0, RetType: tt.tp}
+			f, err := funcs[ast.AnyValue].getFunction(ctx, []Expression{col})
+			require.NoError(t, err)
+			require.IsType(t, &builtinIntAnyValueSig{}, f)
+
+			input := chunk.New([]*types.FieldType{tt.tp}, 1, 1)
+			tt.appendFn(input)
+			got, isNull, err := f.evalString(ctx, input.GetRow(0))
+			require.NoError(t, err)
+			require.False(t, isNull)
+			require.Equal(t, tt.expected, got)
+
+			result := chunk.NewColumn(types.NewFieldType(mysql.TypeString), 1)
+			require.NoError(t, f.vecEvalString(ctx, input, result))
+			require.False(t, result.IsNull(0))
+			require.Equal(t, tt.expected, result.GetString(0))
+		})
+	}
+}
+
 func TestIsIPv6(t *testing.T) {
 	ctx := createContext(t)
 	tests := []struct {

--- a/pkg/expression/builtin_miscellaneous_vec.go
+++ b/pkg/expression/builtin_miscellaneous_vec.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -367,7 +366,7 @@ func (b *builtinIntAnyValueSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 }
 
 func (b *builtinIntAnyValueSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	if b.tp.GetType() != mysql.TypeBit {
+	if !b.tp.Hybrid() {
 		return b.baseBuiltinFunc.vecEvalString(ctx, input, result)
 	}
 	return b.args[0].VecEvalString(ctx, input, result)

--- a/pkg/expression/builtin_miscellaneous_vec.go
+++ b/pkg/expression/builtin_miscellaneous_vec.go
@@ -365,6 +365,8 @@ func (b *builtinIntAnyValueSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	return b.args[0].VecEvalInt(ctx, input, result)
 }
 
+// Non-hybrid integer results should keep the default string fallback. Hybrid return fields
+// delegate to the argument to preserve its binary/string representation in string contexts.
 func (b *builtinIntAnyValueSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	if !b.tp.Hybrid() {
 		return b.baseBuiltinFunc.vecEvalString(ctx, input, result)

--- a/pkg/expression/builtin_miscellaneous_vec.go
+++ b/pkg/expression/builtin_miscellaneous_vec.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -363,6 +364,13 @@ func (b *builtinIntAnyValueSig) vectorized() bool {
 
 func (b *builtinIntAnyValueSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	return b.args[0].VecEvalInt(ctx, input, result)
+}
+
+func (b *builtinIntAnyValueSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
+	if b.tp.GetType() != mysql.TypeBit {
+		return b.baseBuiltinFunc.vecEvalString(ctx, input, result)
+	}
+	return b.args[0].VecEvalString(ctx, input, result)
 }
 
 func (b *builtinIsIPv4CompatSig) vectorized() bool {

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -4316,6 +4316,23 @@ func TestTiDBRowChecksumBuiltin(t *testing.T) {
 	tk.MustGetDBError("select tidb_row_checksum() from t where id > 0", expression.ErrNotSupportedYet)
 }
 
+func TestIssue66661(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table table1 (active bit)")
+	tk.MustExec("insert into table1 values (1)")
+
+	for _, vectorized := range []string{"on", "off"} {
+		tk.MustExec("set @@tidb_enable_vectorized_expression=" + vectorized)
+		tk.MustQuery("select hex(cast(any_value(active) as char)) from table1").Check(testkit.Rows("01"))
+		tk.MustQuery("select str_to_date(any_value(active), '%h:%i:%s') from table1").Check(testkit.Rows("<nil>"))
+		tk.MustQuery("show warnings").CheckContain("Incorrect datetime value: '0000-00-00 00:00:00")
+		tk.MustQuery("select max(active) as c0 from table1 where str_to_date(any_value(active), '%h:%i:%s')").Check(testkit.Rows("<nil>"))
+		tk.MustQuery("show warnings").CheckContain("Incorrect datetime value: '0000-00-00 00:00:00")
+	}
+}
+
 func TestIssue43527(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/66661

Problem Summary:

`ANY_VALUE(bit_col)` keeps a `BIT` return field type but uses the integer `ANY_VALUE` signature. When a string context later evaluates that expression, such as `STR_TO_DATE(ANY_VALUE(bit_col), ...)` or `CAST(ANY_VALUE(bit_col) AS CHAR)`, TiDB called the default `baseBuiltinFunc.evalString` / `vecEvalString` path and returned internal error 1105.

### What changed and how does it work?

This PR adds scalar and vectorized string evaluation for `builtinIntAnyValueSig` only when its return type is `BIT`.

The implementation delegates string evaluation to the underlying argument so `ANY_VALUE(bit_col)` preserves the same binary string representation as the original `BIT` expression in string contexts. Non-`BIT` integer `ANY_VALUE` calls keep the previous unsupported string-evaluation behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test:

```bash
go test ./pkg/expression -run 'TestAnyValue|TestVectorizedBuiltinMiscellaneousFunc' -count=1
```

Integration test:

```bash
go test --tags=intest ./pkg/expression/integration_test -run TestIssue66661 -count=1
```

Manual test:

```sql
DROP TABLE IF EXISTS test.table1;
CREATE TABLE test.table1 (active BIT);
INSERT INTO test.table1 (active) VALUES (1);
SELECT HEX(CAST(ANY_VALUE(active) AS CHAR)) AS cast_av FROM test.table1;
SELECT STR_TO_DATE(ANY_VALUE(active), '%h:%i:%s') AS issue_inner FROM test.table1;
SELECT MAX(active) AS c0 FROM test.table1 WHERE STR_TO_DATE(ANY_VALUE(active), '%h:%i:%s');
SET tidb_enable_vectorized_expression=0;
SELECT HEX(CAST(ANY_VALUE(active) AS CHAR)) AS cast_av FROM test.table1;
SELECT STR_TO_DATE(ANY_VALUE(active), '%h:%i:%s') AS issue_inner FROM test.table1;
SELECT MAX(active) AS c0 FROM test.table1 WHERE STR_TO_DATE(ANY_VALUE(active), '%h:%i:%s');
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where evaluating ANY_VALUE() on BIT values in string contexts could return an internal error.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed string evaluation of ANY_VALUE() for BIT/enum/set so returned string forms are consistent across execution modes, including vectorized paths; preserved expected warnings and NULLs for invalid datetime casts.

* **Tests**
  * Added integration and unit tests validating ANY_VALUE() string evaluation across vectorized/non-vectorized and hybrid type paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->