### PR TITLE
expression: preserve unsigned representation during conversion

### DIFF
--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -1579,6 +1579,7 @@ func RefineComparedConstant(ctx BuildContext, targetFieldType types.FieldType, c
 	}
 	if targetFieldType.GetType() == mysql.TypeBit {
 		targetFieldType = *types.NewFieldType(mysql.TypeLonglong)
+		targetFieldType.AddFlag(mysql.UnsignedFlag)
 	}
 	var intDatum types.Datum
 	// Disable AllowNegativeToUnsigned to make sure return 0 when underflow happens.

--- a/pkg/expression/builtin_compare_test.go
+++ b/pkg/expression/builtin_compare_test.go
@@ -15,12 +15,14 @@
 package expression
 
 import (
+	"math"
 	"testing"
 	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/parser/opcode"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
@@ -439,4 +441,75 @@ func TestRefineArgsWithNullableColumn(t *testing.T) {
 	args := f.refineArgsByUnsignedFlag(ctx, []Expression{uint64Const, int64Column})
 	require.Equal(t, uint64Const, args[0])
 	require.Equal(t, int64Column, args[1])
+}
+
+func TestRefineComparedConstantBitField(t *testing.T) {
+	ctx := createContext(t)
+
+	tests := []struct {
+		name          string
+		flen          int
+		val           uint64
+		op            opcode.Op
+		isExceptional bool
+	}{
+		{
+			name:          "BIT(64) with ULLONG_MAX EQ",
+			flen:          64,
+			val:           math.MaxUint64,
+			op:            opcode.EQ,
+			isExceptional: false,
+		},
+		{
+			name:          "BIT(64) with MaxInt64+1 EQ",
+			flen:          64,
+			val:           math.MaxInt64 + 1,
+			op:            opcode.EQ,
+			isExceptional: false,
+		},
+		{
+			name:          "BIT(64) with small value EQ",
+			flen:          64,
+			val:           42,
+			op:            opcode.EQ,
+			isExceptional: false,
+		},
+		{
+			name:          "BIT(32) with max 32-bit value EQ",
+			flen:          32,
+			val:           math.MaxUint32,
+			op:            opcode.EQ,
+			isExceptional: false,
+		},
+		{
+			name:          "BIT(64) with ULLONG_MAX NullEQ",
+			flen:          64,
+			val:           math.MaxUint64,
+			op:            opcode.NullEQ,
+			isExceptional: false,
+		},
+		{
+			name:          "BIT(64) with ULLONG_MAX LT",
+			flen:          64,
+			val:           math.MaxUint64,
+			op:            opcode.LT,
+			isExceptional: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bitField := types.NewFieldType(mysql.TypeBit)
+			bitField.SetFlen(test.flen)
+
+			lit := types.NewBinaryLiteralFromUint(test.val, 8)
+			con := &Constant{
+				Value:   types.NewBinaryLiteralDatum(lit),
+				RetType: types.NewFieldType(mysql.TypeVarString),
+			}
+
+			_, isExceptional := RefineComparedConstant(ctx, *bitField, con, test.op)
+			require.Equal(t, test.isExceptional, isExceptional, "unexpected isExceptional for %s", test.name)
+		})
+	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
When a BIT type column is queried for `ULLONG_MAX`, the query return an empty result set. 

Issue Number: close #65955

Problem Summary:
This issue is caused when the function `RefineComparedConstant` converts the `BIT` type to `LongLong` which is a signed datatype. Further down the line, this calls `convertToInt` which inturn calls `ConvertUintToInt`. Here the comparison would result in an overflow return as the uint64 value of `2^64 - 1` > `MaxInt64`. 

Log output:
<img width="1082" height="27" alt="image" src="https://github.com/user-attachments/assets/6cf1732b-b8c8-477a-bf96-4598e8fbe1c8" />


### What changed and how does it work?
The fix is to use unsigned comparison, which can be done by adding an unsigned flag while converting to `LongLong`. 
The code flow would now become: `convertToUint` -> `ConvertUintToUint` with an upperbound of `MaxUint64` being used. 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BIT field comparison handling by implementing proper type conversion and unsigned flag assignment during constant refinement, ensuring queries with BIT columns return accurate results.

* **Tests**
  * Added extensive test coverage for BIT field type comparisons, validating refinement behavior across various field sizes and comparison operators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->