### PR TITLE
ranger: enhance range extraction for complex OR filters

### DIFF
--- a/pkg/planner/core/casetest/index/testdata/index_range_out.json
+++ b/pkg/planner/core/casetest/index/testdata/index_range_out.json
@@ -429,8 +429,8 @@
           "StreamAgg root  funcs:count(Column)->Column",
           "└─IndexReader root  index:StreamAgg",
           "  └─StreamAgg cop[tikv]  funcs:count(1)->Column",
-          "    └─Selection cop[tikv]  lt(test.t1.b1, 5), or(gt(test.t1.a1, 1), and(eq(test.t1.a1, 1), gt(test.t1.b1, 10))), or(lt(test.t1.a1, 2), and(eq(test.t1.a1, 2), lt(test.t1.b1, 20)))",
-          "      └─IndexRangeScan cop[tikv] table:t1, index:pkx(a1, b1) range:[1,1], [2,2], keep order:false, stats:pseudo"
+          "    └─Selection cop[tikv]  lt(test.t1.b1, 5)",
+          "      └─IndexRangeScan cop[tikv] table:t1, index:pkx(a1, b1) range:(1 10,1 +inf], [2 -inf,2 20), keep order:false, stats:pseudo"
         ],
         "Result": [
           "14"

--- a/pkg/planner/core/casetest/index/testdata/index_range_xut.json
+++ b/pkg/planner/core/casetest/index/testdata/index_range_xut.json
@@ -429,8 +429,8 @@
           "StreamAgg root  funcs:count(Column)->Column",
           "└─IndexReader root  index:StreamAgg",
           "  └─StreamAgg cop[tikv]  funcs:count(1)->Column",
-          "    └─Selection cop[tikv]  lt(test.t1.b1, 5), or(gt(test.t1.a1, 1), and(eq(test.t1.a1, 1), gt(test.t1.b1, 10))), or(lt(test.t1.a1, 2), and(eq(test.t1.a1, 2), lt(test.t1.b1, 20)))",
-          "      └─IndexRangeScan cop[tikv] table:t1, index:pkx(a1, b1) range:[1,1], [2,2], keep order:false, stats:pseudo"
+          "    └─Selection cop[tikv]  lt(test.t1.b1, 5)",
+          "      └─IndexRangeScan cop[tikv] table:t1, index:pkx(a1, b1) range:(1 10,1 +inf], [2 -inf,2 20), keep order:false, stats:pseudo"
         ],
         "Result": [
           "14"

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -290,16 +290,17 @@ func intersectCNFItemWithBaseRange(
 		bestCNFItemRes.rangeResult.AccessConds,
 	)
 	coveredConds := bestCNFItemRes.rangeResult.AccessConds
-	if bestCNFItemRes.offset >= 0 && bestCNFItemRes.offset < len(originalConditions) {
+	if len(bestCNFItemRes.rangeResult.RemainedConds) == 0 &&
+		bestCNFItemRes.offset >= 0 && bestCNFItemRes.offset < len(originalConditions) {
 		coveredConds = AppendConditionsIfNotExist(
 			sctx.ExprCtx.GetEvalCtx(),
 			coveredConds,
 			[]expression.Expression{originalConditions[bestCNFItemRes.offset]},
 		)
 	}
-	// The composite CNF item is now represented by the intersected range. Remove
-	// both its access conditions and original DNF condition from RemainedConds to
-	// avoid redundant filters while keeping exact semantics.
+	// The composite CNF item is fully represented by the intersected range only
+	// when its detach result has no residual filters. Otherwise, keep the
+	// original condition so the final plan still applies the exact predicate.
 	baseRes.RemainedConds = removeConditions(
 		sctx.ExprCtx.GetEvalCtx(),
 		baseRes.RemainedConds,
@@ -310,6 +311,11 @@ func intersectCNFItemWithBaseRange(
 	// covered composite item, append only the new conditions that are neither
 	// covered by that item nor already represented by the final access range.
 	remainedConds := removeConditions(sctx.ExprCtx.GetEvalCtx(), newConditions, coveredConds)
+	remainedConds = AppendConditionsIfNotExist(
+		sctx.ExprCtx.GetEvalCtx(),
+		remainedConds,
+		bestCNFItemRes.rangeResult.RemainedConds,
+	)
 	remainedConds = removeConditions(sctx.ExprCtx.GetEvalCtx(), remainedConds, baseRes.AccessConds)
 	baseRes.RemainedConds = AppendConditionsIfNotExist(sctx.ExprCtx.GetEvalCtx(), baseRes.RemainedConds, remainedConds)
 	return true, baseRes

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -250,6 +250,57 @@ func compareCNFItemRangeResult(curResult, bestResult *cnfItemRangeResult) (curIs
 	return curResult.sameLenPointRanges
 }
 
+// intersectCNFItemWithBaseRange narrows the base first-column CNF range with a composite CNF item range.
+// The original CNF item can still stay in remained conditions to preserve exact filter semantics.
+func intersectCNFItemWithBaseRange(
+	sctx *rangerctx.RangerContext,
+	baseRes *DetachRangeResult,
+	bestCNFItemRes *cnfItemRangeResult,
+	newConditions []expression.Expression,
+	originalConditions []expression.Expression,
+) (bool, *DetachRangeResult) {
+	if baseRes == nil || bestCNFItemRes == nil || bestCNFItemRes.rangeResult == nil {
+		return false, nil
+	}
+	if len(baseRes.Ranges) == 0 || len(bestCNFItemRes.rangeResult.Ranges) == 0 || bestCNFItemRes.maxColNum <= 1 {
+		return false, nil
+	}
+
+	intersectedRanges := bestCNFItemRes.rangeResult.Ranges.IntersectRanges(sctx.TypeCtx, baseRes.Ranges)
+	if intersectedRanges == nil {
+		return false, nil
+	}
+	if len(intersectedRanges) == 0 {
+		return true, &DetachRangeResult{}
+	}
+
+	baseRes.Ranges = intersectedRanges
+	baseRes.AccessConds = AppendConditionsIfNotExist(
+		sctx.ExprCtx.GetEvalCtx(),
+		baseRes.AccessConds,
+		bestCNFItemRes.rangeResult.AccessConds,
+	)
+	coveredConds := bestCNFItemRes.rangeResult.AccessConds
+	if bestCNFItemRes.offset >= 0 && bestCNFItemRes.offset < len(originalConditions) {
+		coveredConds = AppendConditionsIfNotExist(
+			sctx.ExprCtx.GetEvalCtx(),
+			coveredConds,
+			[]expression.Expression{originalConditions[bestCNFItemRes.offset]},
+		)
+	}
+	// The composite CNF item is now represented by the intersected range, so do
+	// not keep an equivalent copy in RemainedConds and add a redundant filter.
+	baseRes.RemainedConds = removeConditions(
+		sctx.ExprCtx.GetEvalCtx(),
+		baseRes.RemainedConds,
+		coveredConds,
+	)
+	remainedConds := removeConditions(sctx.ExprCtx.GetEvalCtx(), newConditions, coveredConds)
+	remainedConds = removeConditions(sctx.ExprCtx.GetEvalCtx(), remainedConds, baseRes.AccessConds)
+	baseRes.RemainedConds = AppendConditionsIfNotExist(sctx.ExprCtx.GetEvalCtx(), baseRes.RemainedConds, remainedConds)
+	return true, baseRes
+}
+
 // mergeTwoCNFRanges merges two ranges results rangeResult and otherRangeResult.
 // The main objective of this function is to apply intersection between these two
 // ranges when possible. The overall logic is:
@@ -553,6 +604,10 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expressi
 		// of all conjuncts. Even when we add support for intersection, it could be turned off by a flag or it could be
 		// incomplete due to a long list of conjuncts.
 		if bestCNFItemRes != nil && res != nil && len(res.Ranges) != 0 {
+			if ok, intersectedRes := intersectCNFItemWithBaseRange(d.sctx, res, bestCNFItemRes, newConditions, conditions); ok {
+				intersectedRes.ColumnValues = res.ColumnValues
+				return intersectedRes, nil
+			}
 			bestCNFIsSubset := bestCNFItemRes.rangeResult.Ranges.Subset(d.sctx.TypeCtx, res.Ranges)
 			pointRangeIsSubset := res.Ranges.Subset(d.sctx.TypeCtx, bestCNFItemRes.rangeResult.Ranges)
 			// Pick bestCNFIsSubset if it is more selective than point ranges(res).

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -250,8 +250,10 @@ func compareCNFItemRangeResult(curResult, bestResult *cnfItemRangeResult) (curIs
 	return curResult.sameLenPointRanges
 }
 
-// intersectCNFItemWithBaseRange narrows the base first-column CNF range with a composite CNF item range.
-// The original CNF item can still stay in remained conditions to preserve exact filter semantics.
+// intersectCNFItemWithBaseRange narrows the base first-column CNF range with a
+// composite CNF item range. IntersectRanges preserves the exact lexical overlap
+// between both access ranges, so the composite CNF item becomes covered by the
+// final access range and does not need an equivalent residual filter.
 func intersectCNFItemWithBaseRange(
 	sctx *rangerctx.RangerContext,
 	baseRes *DetachRangeResult,
@@ -288,8 +290,9 @@ func intersectCNFItemWithBaseRange(
 			[]expression.Expression{originalConditions[bestCNFItemRes.offset]},
 		)
 	}
-	// The composite CNF item is now represented by the intersected range, so do
-	// not keep an equivalent copy in RemainedConds and add a redundant filter.
+	// The composite CNF item is now represented by the intersected range. Remove
+	// both its access conditions and original DNF condition from RemainedConds to
+	// avoid redundant filters while keeping exact semantics.
 	baseRes.RemainedConds = removeConditions(
 		sctx.ExprCtx.GetEvalCtx(),
 		baseRes.RemainedConds,
@@ -604,10 +607,9 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expressi
 		// TODO: we will optimize it later.
 		res.RemainedConds = AppendConditionsIfNotExist(d.sctx.ExprCtx.GetEvalCtx(), res.RemainedConds, remainedConds)
 		res.Ranges = ranges
-		// Choosing between point ranges and bestCNF is needed since bestCNF does not cover the intersection
-		// of all conjuncts. Even when we add support for intersection, it could be turned off by a flag or it could be
-		// incomplete due to a long list of conjuncts.
 		if bestCNFItemRes != nil && res != nil && len(res.Ranges) != 0 {
+			// Try the real multi-column intersection first. If it cannot derive
+			// a valid overlap, fall back to the older subset comparison below.
 			if ok, intersectedRes := intersectCNFItemWithBaseRange(d.sctx, res, bestCNFItemRes, newConditions, conditions); ok {
 				intersectedRes.ColumnValues = res.ColumnValues
 				return intersectedRes, nil

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -254,6 +254,13 @@ func compareCNFItemRangeResult(curResult, bestResult *cnfItemRangeResult) (curIs
 // composite CNF item range. IntersectRanges preserves the exact lexical overlap
 // between both access ranges, so the composite CNF item becomes covered by the
 // final access range and does not need an equivalent residual filter.
+//
+// For example, with index (c14, c25, c1), a base CNF range from
+// `c14 >= 1747663372 AND c14 <= 1748705453` may overlap a DNF branch range from
+// `c14 = 1748604343 AND c25 < 216627868`. The intersection keeps only the
+// composite range `[1748604343 -inf, 1748604343 216627868)`, instead of scanning
+// the wider first-column range `[1748604343, 1748604343]` and relying on a
+// residual filter for c25.
 func intersectCNFItemWithBaseRange(
 	sctx *rangerctx.RangerContext,
 	baseRes *DetachRangeResult,

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -261,6 +261,19 @@ func compareCNFItemRangeResult(curResult, bestResult *cnfItemRangeResult) (curIs
 // composite range `[1748604343 -inf, 1748604343 216627868)`, instead of scanning
 // the wider first-column range `[1748604343, 1748604343]` and relying on a
 // residual filter for c25.
+//
+// Parameter roles:
+//   - baseRes is the current CNF detach result, usually built from direct
+//     first-column access conditions.
+//   - bestCNFItemRes is the most useful single CNF item result found by
+//     extractBestCNFItemRanges. It carries both its composite range and the
+//     original condition offset.
+//   - newConditions is the working condition list after direct Eq/In extraction.
+//     Conditions not covered by the intersected access range are rebuilt from it
+//     as residual filters.
+//   - originalConditions is the untouched CNF input. bestCNFItemRes.offset refers
+//     to this slice, so it is used to remove the original composite item only
+//     when that item is fully represented by the final access range.
 func intersectCNFItemWithBaseRange(
 	sctx *rangerctx.RangerContext,
 	baseRes *DetachRangeResult,

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -295,6 +295,10 @@ func intersectCNFItemWithBaseRange(
 		baseRes.RemainedConds,
 		coveredConds,
 	)
+	// baseRes.RemainedConds must keep a DNF-equivalent exact-filter contract
+	// for conditions not covered by baseRes.AccessConds. After removing the
+	// covered composite item, append only the new conditions that are neither
+	// covered by that item nor already represented by the final access range.
 	remainedConds := removeConditions(sctx.ExprCtx.GetEvalCtx(), newConditions, coveredConds)
 	remainedConds = removeConditions(sctx.ExprCtx.GetEvalCtx(), remainedConds, baseRes.AccessConds)
 	baseRes.RemainedConds = AppendConditionsIfNotExist(sctx.ExprCtx.GetEvalCtx(), baseRes.RemainedConds, remainedConds)

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -2510,6 +2510,41 @@ func TestIssue40997(t *testing.T) {
 	})
 }
 
+func TestRangeExtractionForComplexORFilter(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1(c1 bigint, c14 bigint, c25 bigint, index i12(c14, c25, c1))")
+
+	sctx := tk.Session()
+	ectx := sctx.GetExprCtx().GetEvalCtx()
+	sql := `select * from t1 use index(i12) where
+		c14 >= 1747663372 and c14 <= 1748705453 and
+		(c14 < 1748015999 or
+			(c14 = 1748604343 and c25 < 216627868) or
+			(c14 = 1748604343 and c25 = 473050276 and c1 > 154835914))`
+	selection := getSelectionFromQuery(t, sctx, sql)
+	conds := make([]expression.Expression, len(selection.Conditions))
+	for i, cond := range selection.Conditions {
+		conds[i] = expression.PushDownNot(sctx.GetExprCtx(), cond)
+	}
+	tbl := selection.Children()[0].(*logicalop.DataSource).TableInfo
+	cols, lengths := plannerutil.IndexInfo2PrefixCols(tbl.Columns, selection.Schema().Columns, tbl.Indices[0])
+
+	res, err := ranger.DetachCondAndBuildRangeForIndex(sctx.GetRangerCtx(), conds, cols, lengths, 0)
+	require.NoError(t, err)
+	require.Equal(t,
+		"[ge(test.t1.c14, 1747663372) le(test.t1.c14, 1748705453) or(lt(test.t1.c14, 1748015999), or(eq(test.t1.c14, 1748604343), eq(test.t1.c14, 1748604343))) or(lt(test.t1.c14, 1748015999), or(and(eq(test.t1.c14, 1748604343), lt(test.t1.c25, 216627868)), and(eq(test.t1.c14, 1748604343), and(eq(test.t1.c25, 473050276), gt(test.t1.c1, 154835914)))))]",
+		expression.StringifyExpressionsWithCtx(ectx, res.AccessConds))
+	require.Equal(t,
+		"[]",
+		expression.StringifyExpressionsWithCtx(ectx, res.RemainedConds))
+	require.Equal(t,
+		"[[1747663372,1748015999) [1748604343 -inf,1748604343 216627868) (1748604343 473050276 154835914,1748604343 473050276 +inf]]",
+		fmt.Sprintf("%v", res.Ranges))
+}
+
 func TestIssue50051(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -2550,6 +2550,35 @@ func TestRangeExtractionForComplexORFilter(t *testing.T) {
 	require.Equal(t,
 		"[[1747663372,1748015999) [1748604343 -inf,1748604343 216627868) (1748604343 473050276 154835914,1748604343 473050276 +inf]]",
 		fmt.Sprintf("%v", res.Ranges))
+
+	tk.MustExec("insert into t1 values (0, 1748604343, 100)")
+	tk.MustExec("insert into t1 values (7, 1747900000, 999)")
+	tk.MustExec("insert into t1 values (154835914, 1748604343, 100)")
+	tk.MustExec("insert into t1 values (154835915, 1748604343, 473050276)")
+	residualFilterSQL := `select c1, c14, c25 from t1 use index(i12) where
+		c14 >= 1747663372 and c14 <= 1748705453 and
+		(c14 < 1748015999 or
+			(c14 = 1748604343 and c25 < 216627868 and c1 + 1 = 154835915) or
+			(c14 = 1748604343 and c25 = 473050276 and c1 > 154835914))`
+	residualSQL := residualFilterSQL + " order by c1, c25"
+	tk.MustQuery(residualSQL).Check(testkit.Rows(
+		"7 1747900000 999",
+		"154835914 1748604343 100",
+		"154835915 1748604343 473050276",
+	))
+
+	selection = getSelectionFromQuery(t, sctx, residualFilterSQL)
+	conds = make([]expression.Expression, len(selection.Conditions))
+	for i, cond := range selection.Conditions {
+		conds[i] = expression.PushDownNot(sctx.GetExprCtx(), cond)
+	}
+	tbl = selection.Children()[0].(*logicalop.DataSource).TableInfo
+	cols, lengths = plannerutil.IndexInfo2PrefixCols(tbl.Columns, selection.Schema().Columns, tbl.Indices[0])
+	res, err = ranger.DetachCondAndBuildRangeForIndex(sctx.GetRangerCtx(), conds, cols, lengths, 0)
+	require.NoError(t, err)
+	filterConds := expression.StringifyExpressionsWithCtx(ectx, res.RemainedConds)
+	require.Contains(t, filterConds, "eq(plus(test.t1.c1, 1), 154835915)")
+	require.Contains(t, filterConds, "or(lt(test.t1.c14, 1748015999)")
 }
 
 func TestIssue50051(t *testing.T) {

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -2524,6 +2524,13 @@ func TestRangeExtractionForComplexORFilter(t *testing.T) {
 		(c14 < 1748015999 or
 			(c14 = 1748604343 and c25 < 216627868) or
 			(c14 = 1748604343 and c25 = 473050276 and c1 > 154835914))`
+	planRows := tk.MustQuery("explain format = 'brief' " + sql).Rows()
+	planText := fmt.Sprint(planRows)
+	require.Contains(t, planText, "IndexRangeScan")
+	require.Contains(t, planText,
+		"range:[1747663372,1748015999), [1748604343 -inf,1748604343 216627868), (1748604343 473050276 154835914,1748604343 473050276 +inf]")
+	require.NotContains(t, planText, "range:[1747663372,1748015999), [1748604343,1748604343]")
+
 	selection := getSelectionFromQuery(t, sctx, sql)
 	conds := make([]expression.Expression, len(selection.Conditions))
 	for i, cond := range selection.Conditions {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68408

Problem Summary:

For a complex OR filter on an index such as `(c14, c25, c1)`, range extraction could keep a wide first-column range like `[1748604343,1748604343]` instead of intersecting it with the more selective composite DNF item ranges on `c25` and `c1`.

### What changed and how does it work?

This PR keeps the fix local to `pkg/util/ranger`:

- Intersect the base first-column CNF range with the best composite CNF item range when that item uses later index columns.
- Keep the original DNF item in remained conditions so exact filter semantics are preserved while the access range becomes narrower.
- Add a focused ranger regression that asserts access conditions, remained conditions, and the final composite range shape.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

```bash
go test ./pkg/util/ranger -run TestRangeExtractionForComplexORFilter -count=1 -tags=intest,deadlock
go test ./pkg/util/ranger -run 'TestIssue40997|TestMinAccessCondsForDNFCond|TestRangeExtractionForComplexORFilter' -count=1 -tags=intest,deadlock
make bazel_prepare
git diff --check
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve range extraction for complex OR filters.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Index-range building now applies an earlier direct intersection of composite range conditions, producing narrower merged ranges and updated access/remained conditions; query plans may show broader interval ranges and simplified selection predicates.

* **Tests**
  * Added a test for complex OR predicates with index bounds and updated expected plan snapshots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->