### PR TITLE
tests/realtikvtest/addindextest2: stabilize TestNextGenMetering duration assertion

### DIFF
--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -1028,7 +1028,9 @@ func TestNextGenMetering(t *testing.T) {
 			items["index_kv_bytes"].(int64) == 153 &&
 			items[metering.RequiredSlotsField].(int) == task.RequiredSlots &&
 			items[metering.MaxNodeCountField].(int) == task.MaxNodeCount &&
-			items[metering.DurationSecondsField].(int64) > 0
+			// duration_seconds uses integer seconds; tasks finishing in <1s
+			// are truncated to 0.
+			items[metering.DurationSecondsField].(int64) >= 0
 	}, 30*time.Second, 100*time.Millisecond)
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66367

Problem Summary:

`TestNextGenMetering` in `tests/realtikvtest/addindextest2/global_sort_test.go` was flaky because it required `duration_seconds > 0`, but metering stores duration in integer seconds. Fast tasks can finish in under one second and report `duration_seconds = 0`.

### What changed and how does it work?

- Relaxed the assertion from `duration_seconds > 0` to `duration_seconds >= 0` in `TestNextGenMetering`.
- Added an inline comment explaining that sub-second durations are truncated to `0`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated metering duration test to accept zero values, allowing durations under one second to be recorded as zero instead of being rejected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->