### PR TITLE
tests: add external starter mode realtikv harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -805,7 +805,7 @@ bazel_sessiontest: failpoint-enable bazel_ci_simple_prepare
 
 .PHONY: bazel_startertest
 bazel_startertest: failpoint-enable bazel_ci_simple_prepare
-	NEXT_GEN=1 tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh --under-cluster startertest 40m -count=1
+	tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh --under-cluster startertest 40m -count=1
 
 .PHONY: bazel_statisticstest
 bazel_statisticstest: failpoint-enable bazel_ci_simple_prepare

--- a/Makefile
+++ b/Makefile
@@ -803,6 +803,10 @@ bazel_sessiontest: failpoint-enable bazel_ci_simple_prepare
 	bazel $(BAZEL_GLOBAL_CONFIG) test $(BAZEL_CMD_CONFIG) --test_arg=-with-real-tikv --define gotags=$(REAL_TIKV_TEST_TAGS) --jobs=1 \
 		-- //tests/realtikvtest/sessiontest/...
 
+.PHONY: bazel_startertest
+bazel_startertest: failpoint-enable bazel_ci_simple_prepare
+	NEXT_GEN=1 tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh --under-cluster startertest 40m -count=1
+
 .PHONY: bazel_statisticstest
 bazel_statisticstest: failpoint-enable bazel_ci_simple_prepare
 	bazel $(BAZEL_GLOBAL_CONFIG) test $(BAZEL_CMD_CONFIG) --test_arg=-with-real-tikv --define gotags=$(REAL_TIKV_TEST_TAGS) --jobs=1 \

--- a/Makefile
+++ b/Makefile
@@ -805,7 +805,9 @@ bazel_sessiontest: failpoint-enable bazel_ci_simple_prepare
 
 .PHONY: bazel_startertest
 bazel_startertest: failpoint-enable bazel_ci_simple_prepare
-	tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh --under-cluster startertest 40m -count=1
+	# Starter mode needs an external tidb-server process, so this wrapper
+	# intentionally invokes the starter shell runner instead of bazel test.
+	STARTER_RUN_EXIT_WAIT_TEST=1 tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh --under-cluster startertest 40m -count=1
 
 .PHONY: bazel_statisticstest
 bazel_statisticstest: failpoint-enable bazel_ci_simple_prepare

--- a/tests/realtikvtest/scripts/next-gen/README.md
+++ b/tests/realtikvtest/scripts/next-gen/README.md
@@ -73,10 +73,11 @@ against the activated external server. For the default `startertest` run, the
 script also runs a final destructive phase that verifies graceful exit waits for
 held client connections before shutting down the external `tidb-server`.
 
-This script is an independent entry point and is not invoked by `run-tests.sh`.
-CI jobs that need external starter coverage should call this script directly.
-For the standard next-gen RealTiKV CI flow, use the Makefile wrapper through
-`run-tests.sh`:
+This script is an independent direct entry point and is not part of generic
+`run-tests.sh` suite discovery. For the standard next-gen RealTiKV CI flow, use
+the `bazel_startertest` Makefile wrapper through `run-tests.sh`; that wrapper
+intentionally calls this shell runner because starter coverage needs an external
+`tidb-server` process:
 
 ```bash
 tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_startertest
@@ -134,7 +135,8 @@ Useful environment variables:
   `tidb-server` (default: `120`)
 - `STARTER_RUN_EXIT_WAIT_TEST`: Whether to run the final destructive
   graceful-exit wait test. By default it runs only for `startertest` when no
-  extra `go test` arguments are passed.
+  extra `go test` arguments are passed. The `bazel_startertest` Makefile wrapper
+  sets this to `1` explicitly because it passes `-count=1`.
 - `STARTER_EXIT_WAIT_TEST_TIMEOUT`: Timeout for the final destructive
   graceful-exit wait test (default: `2m`)
 - `STARTER_TIDB_PORT` / `STARTER_TIDB_STATUS_PORT`: Preferred starting ports

--- a/tests/realtikvtest/scripts/next-gen/README.md
+++ b/tests/realtikvtest/scripts/next-gen/README.md
@@ -82,12 +82,10 @@ For the standard next-gen RealTiKV CI flow, use the Makefile wrapper through
 tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_startertest
 ```
 
-The `tidb-server` binary must be built as a next-gen binary before running the
-script:
-
-```bash
-NEXT_GEN=1 make server
-```
+When `TIDB_SERVER_BIN` is not set, the script builds `bin/tidb-server` from the
+current checkout before starting the external server. The script exports
+`NEXT_GEN=1` internally, so the built binary and the Go tests both use the
+next-gen code paths.
 
 Because the script reuses `bootstrap-test-with-cluster.sh`, `bin/pd-server`,
 `bin/tikv-server`, and `bin/tikv-worker` must also be available.
@@ -112,7 +110,7 @@ tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh startertest
 
 Useful environment variables:
 - `TIDB_SERVER_BIN`: Path to the next-gen `tidb-server` binary
-  (default: `bin/tidb-server`)
+  (default: `bin/tidb-server`, built from the current checkout by the script)
 - `STARTER_MAX_ALLOWED_PACKET`: Starter `max-allowed-packet` config used by
   the external server (default: `65536`)
 - `STARTER_TIKV_WORKER_URL`: Starter `tikv-worker-url` config used by the

--- a/tests/realtikvtest/scripts/next-gen/README.md
+++ b/tests/realtikvtest/scripts/next-gen/README.md
@@ -75,6 +75,12 @@ held client connections before shutting down the external `tidb-server`.
 
 This script is an independent entry point and is not invoked by `run-tests.sh`.
 CI jobs that need external starter coverage should call this script directly.
+For the standard next-gen RealTiKV CI flow, use the Makefile wrapper through
+`run-tests.sh`:
+
+```bash
+tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_startertest
+```
 
 The `tidb-server` binary must be built as a next-gen binary before running the
 script:

--- a/tests/realtikvtest/scripts/next-gen/README.md
+++ b/tests/realtikvtest/scripts/next-gen/README.md
@@ -61,6 +61,82 @@ Example:
 ./run-tests.sh bazel_addindextest
 ```
 
+### run-starter-tests-with-server.sh
+
+This script runs external starter-mode tests against a real `tidb-server`
+process. It first reuses `bootstrap-test-with-cluster.sh` to start PD, TiKV,
+TiKV-Worker, and MinIO. Then it starts `bin/tidb-server` with
+`deploy-mode = "starter"` and runs Go tests through the MySQL protocol and
+status HTTP APIs. By default, the script starts TiDB in standby mode, activates
+the configured keyspace through `/tidb-pool/activate`, and then runs the tests
+against the activated external server. For the default `startertest` run, the
+script also runs a final destructive phase that verifies graceful exit waits for
+held client connections before shutting down the external `tidb-server`.
+
+This script is an independent entry point and is not invoked by `run-tests.sh`.
+CI jobs that need external starter coverage should call this script directly.
+
+The `tidb-server` binary must be built as a next-gen binary before running the
+script:
+
+```bash
+NEXT_GEN=1 make server
+```
+
+Because the script reuses `bootstrap-test-with-cluster.sh`, `bin/pd-server`,
+`bin/tikv-server`, and `bin/tikv-worker` must also be available.
+
+Usage:
+
+```bash
+tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh [<test_suite>] [<timeout>] [<go test args>...]
+```
+
+Arguments:
+- `<test_suite>`: The test suite directory under `./tests/realtikvtest/`
+  (default: `startertest`)
+- `<timeout>`: Optional timeout for the test suite (default: `40m`)
+- `<go test args>`: Optional extra arguments passed to `go test`
+
+Example:
+
+```bash
+tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh startertest 40m -run TestExternalStarterSysVarContracts
+```
+
+Useful environment variables:
+- `TIDB_SERVER_BIN`: Path to the next-gen `tidb-server` binary
+  (default: `bin/tidb-server`)
+- `STARTER_MAX_ALLOWED_PACKET`: Starter `max-allowed-packet` config used by
+  the external server (default: `65536`)
+- `STARTER_TIKV_WORKER_URL`: Starter `tikv-worker-url` config used by the
+  external server (default: `localhost:19000`)
+- `STARTER_KEYSPACE_NAME`: Starter keyspace activated by the script
+  (default: `SYSTEM`)
+- `STARTER_STANDBY_MODE`: Whether to start in standby mode and activate before
+  running tests (default: `1`; set to `0` to start directly with
+  `-keyspace-name`)
+- `STARTER_ACTIVATE_EXPORT_ID`: `export_id` sent in the standby activation
+  request (default: `starter-external-export`)
+- `STARTER_ACTIVATE_MAX_IDLE_SECONDS`: `max_idle_seconds` sent in the standby
+  activation request (default: `60`)
+- `STARTER_KEYSPACE_OBSERVABILITY`: Whether to configure starter keyspace
+  observability mappings and send activation metadata for those mappings
+  (default: follows `STARTER_STANDBY_MODE`; requires standby activation)
+- `STARTER_KEYSPACE_META_TENANT` / `STARTER_KEYSPACE_META_PROJECT`: Metadata
+  values sent in the standby activation request and expected in starter
+  observability labels (defaults: `starter_tenant` / `starter_project`)
+- `STARTER_ACTIVATION_TIMEOUT`: Starter standby activation timeout passed to
+  `tidb-server` (default: `120`)
+- `STARTER_RUN_EXIT_WAIT_TEST`: Whether to run the final destructive
+  graceful-exit wait test. By default it runs only for `startertest` when no
+  extra `go test` arguments are passed.
+- `STARTER_EXIT_WAIT_TEST_TIMEOUT`: Timeout for the final destructive
+  graceful-exit wait test (default: `2m`)
+- `STARTER_TIDB_PORT` / `STARTER_TIDB_STATUS_PORT`: Preferred starting ports
+  for the SQL and status listeners (defaults: `4000` / `10080`; the script
+  advances to the next available port if needed)
+
 ## Configuration Files
 
 The test cluster uses configuration files from `tests/realtikvtest/configs/next-gen/`:

--- a/tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh
@@ -317,7 +317,7 @@ EOF
         echo "Running destructive external starter exit-wait test"
         go test "./tests/realtikvtest/${test_suite}" -v --tags=intest,nextgen \
             -timeout "${STARTER_EXIT_WAIT_TEST_TIMEOUT:-2m}" \
-            -run '^TestExternalStarterExitRequiresManagerNotifierForManagerFree/graceful_exit_waits_for_open_connection$' \
+            -run '^TestExternalStarterExitWaitAndManagerNotifierContracts/graceful_exit_waits_for_open_connection$' \
             -count=1
         if [[ -n "${starter_tidb_pid:-}" ]] && kill -0 "${starter_tidb_pid}" >/dev/null 2>&1; then
             wait "${starter_tidb_pid}" >/dev/null 2>&1 || true

--- a/tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set -euo pipefail
+export NEXT_GEN=1
 
 starter_data_dir=""
 starter_tidb_pid=""
@@ -154,6 +155,21 @@ function activate_starter_server() {
     return 1
 }
 
+function prepare_tidb_server_binary() {
+    local tidb_server_bin="$1"
+
+    if [[ -z "${TIDB_SERVER_BIN:-}" ]]; then
+        echo "Building next-gen tidb-server from current checkout"
+        make server
+    fi
+
+    if [[ ! -x "${tidb_server_bin}" ]]; then
+        echo "tidb-server binary '${tidb_server_bin}' does not exist or is not executable." >&2
+        echo "Build a next-gen TiDB server first, for example: make server" >&2
+        return 1
+    fi
+}
+
 function run_under_cluster() {
     local test_suite="${1:-startertest}"
     local suite_timeout="${2:-40m}"
@@ -168,11 +184,7 @@ function run_under_cluster() {
     cd "${repo_root}"
 
     local tidb_server_bin="${TIDB_SERVER_BIN:-bin/tidb-server}"
-    if [[ ! -x "${tidb_server_bin}" ]]; then
-        echo "tidb-server binary '${tidb_server_bin}' does not exist or is not executable." >&2
-        echo "Build a next-gen TiDB server first, for example: NEXT_GEN=1 make server" >&2
-        return 1
-    fi
+    prepare_tidb_server_binary "${tidb_server_bin}"
 
     local max_allowed_packet="${STARTER_MAX_ALLOWED_PACKET:-65536}"
     local keyspace_name="${STARTER_KEYSPACE_NAME:-SYSTEM}"
@@ -291,7 +303,7 @@ EOF
     fi
 
     echo "Running external starter tests: ./tests/realtikvtest/${test_suite}"
-    NEXT_GEN=1 go test "./tests/realtikvtest/${test_suite}" -v --tags=intest,nextgen -timeout "${suite_timeout}" "${extra_go_test_args[@]}"
+    go test "./tests/realtikvtest/${test_suite}" -v --tags=intest,nextgen -timeout "${suite_timeout}" "${extra_go_test_args[@]}"
 
     if [[ -z "${run_exit_wait_test}" ]]; then
         if [[ "${test_suite}" == "startertest" && "${#extra_go_test_args[@]}" -eq 0 ]]; then
@@ -303,7 +315,7 @@ EOF
     if is_true "${run_exit_wait_test}" && [[ "${test_suite}" == "startertest" ]]; then
         export TIDB_STARTER_RUN_EXIT_WAIT_TEST=1
         echo "Running destructive external starter exit-wait test"
-        NEXT_GEN=1 go test "./tests/realtikvtest/${test_suite}" -v --tags=intest,nextgen \
+        go test "./tests/realtikvtest/${test_suite}" -v --tags=intest,nextgen \
             -timeout "${STARTER_EXIT_WAIT_TEST_TIMEOUT:-2m}" \
             -run '^TestExternalStarterExitRequiresManagerNotifierForManagerFree/graceful_exit_waits_for_open_connection$' \
             -count=1

--- a/tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh
@@ -1,0 +1,332 @@
+#! /usr/bin/env bash
+#
+# Copyright 2026 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+starter_data_dir=""
+starter_tidb_pid=""
+
+function find_available_port() {
+    local port="$1"
+    while [[ "${port}" -lt 65536 ]]; do
+        if ! lsof -nP -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1; then
+            echo "${port}"
+            return 0
+        fi
+        port=$((port + 1))
+    done
+    echo "no available port found from $1" >&2
+    return 1
+}
+
+function cleanup_tidb_server() {
+    if [[ -n "${starter_tidb_pid:-}" ]]; then
+        if kill -0 "${starter_tidb_pid}" >/dev/null 2>&1; then
+            kill -TERM "${starter_tidb_pid}" >/dev/null 2>&1 || true
+        fi
+        wait "${starter_tidb_pid}" >/dev/null 2>&1 || true
+        starter_tidb_pid=""
+    fi
+    if [[ -n "${starter_data_dir:-}" && -d "${starter_data_dir}" ]]; then
+        rm -rf -- "${starter_data_dir}"
+        starter_data_dir=""
+    fi
+}
+
+function wait_for_tidb_server() {
+    local status_url="$1"
+    local tidb_pid="$2"
+    local log_file="$3"
+    local stdout_log_file="$4"
+
+    for _ in {1..60}; do
+        if curl -sf "${status_url}/status" >/dev/null 2>&1; then
+            return 0
+        fi
+        if ! kill -0 "${tidb_pid}" >/dev/null 2>&1; then
+            echo "tidb-server exited before becoming ready. Log tail:" >&2
+            tail -200 "${log_file}" >&2 || true
+            tail -200 "${stdout_log_file}" >&2 || true
+            return 1
+        fi
+        sleep 1
+    done
+
+    echo "timed out waiting for tidb-server. Log tail:" >&2
+    tail -200 "${log_file}" >&2 || true
+    tail -200 "${stdout_log_file}" >&2 || true
+    return 1
+}
+
+function is_true() {
+    local value
+    value="$(printf "%s" "$1" | tr '[:upper:]' '[:lower:]')"
+    case "${value}" in
+        1|true|yes|on)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+function activate_starter_server() {
+    local status_url="$1"
+    local tidb_pid="$2"
+    local log_file="$3"
+    local stdout_log_file="$4"
+    local response_file="$5"
+    local keyspace_name="$6"
+    local export_id="$7"
+    local max_idle_seconds="$8"
+    local metadata_json="${9:-}"
+    local activate_err_file="${response_file}.err"
+    local activate_rc_file="${response_file}.rc"
+    local activate_body
+
+    if [[ -n "${metadata_json}" ]]; then
+        activate_body="$(printf '{"keyspace_name":"%s","export_id":"%s","max_idle_seconds":%s,"metadata":%s,"tidb_enable_ddl":true,"run_auto_analyze":true}' \
+            "${keyspace_name}" "${export_id}" "${max_idle_seconds}" "${metadata_json}")"
+    else
+        activate_body="$(printf '{"keyspace_name":"%s","export_id":"%s","max_idle_seconds":%s,"tidb_enable_ddl":true,"run_auto_analyze":true}' \
+            "${keyspace_name}" "${export_id}" "${max_idle_seconds}")"
+    fi
+
+    echo "Activating external starter tidb-server for keyspace ${keyspace_name}, export ID ${export_id}"
+    (
+        set +e
+        curl -fsS --max-time 120 \
+            -X POST "${status_url}/tidb-pool/activate" \
+            -H "Content-Type: application/json" \
+            -d "${activate_body}" \
+            > "${response_file}" 2> "${activate_err_file}"
+        echo "$?" > "${activate_rc_file}"
+    ) &
+    local activate_pid="$!"
+
+    for _ in {1..150}; do
+        if [[ -f "${activate_rc_file}" ]]; then
+            local activate_rc
+            activate_rc="$(cat "${activate_rc_file}")"
+            wait "${activate_pid}" >/dev/null 2>&1 || true
+            if [[ "${activate_rc}" != "0" ]]; then
+                echo "starter activation failed. curl stderr:" >&2
+                cat "${activate_err_file}" >&2 || true
+                echo "tidb-server log tail:" >&2
+                tail -200 "${log_file}" >&2 || true
+                tail -200 "${stdout_log_file}" >&2 || true
+                return "${activate_rc}"
+            fi
+            echo "Starter activation response:"
+            cat "${response_file}" || true
+            return 0
+        fi
+        if ! kill -0 "${tidb_pid}" >/dev/null 2>&1; then
+            echo "tidb-server exited before activation completed. Log tail:" >&2
+            tail -200 "${log_file}" >&2 || true
+            tail -200 "${stdout_log_file}" >&2 || true
+            cat "${activate_err_file}" >&2 || true
+            return 1
+        fi
+        sleep 1
+    done
+
+    echo "timed out waiting for starter activation. Log tail:" >&2
+    kill -TERM "${activate_pid}" >/dev/null 2>&1 || true
+    wait "${activate_pid}" >/dev/null 2>&1 || true
+    tail -200 "${log_file}" >&2 || true
+    tail -200 "${stdout_log_file}" >&2 || true
+    cat "${activate_err_file}" >&2 || true
+    return 1
+}
+
+function run_under_cluster() {
+    local test_suite="${1:-startertest}"
+    local suite_timeout="${2:-40m}"
+    shift || true
+    shift || true
+    local extra_go_test_args=("$@")
+
+    local self_dir
+    self_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+    local repo_root
+    repo_root="$(realpath "${self_dir}/../../../..")"
+    cd "${repo_root}"
+
+    local tidb_server_bin="${TIDB_SERVER_BIN:-bin/tidb-server}"
+    if [[ ! -x "${tidb_server_bin}" ]]; then
+        echo "tidb-server binary '${tidb_server_bin}' does not exist or is not executable." >&2
+        echo "Build a next-gen TiDB server first, for example: NEXT_GEN=1 make server" >&2
+        return 1
+    fi
+
+    local max_allowed_packet="${STARTER_MAX_ALLOWED_PACKET:-65536}"
+    local keyspace_name="${STARTER_KEYSPACE_NAME:-SYSTEM}"
+    local standby_mode="${STARTER_STANDBY_MODE:-1}"
+    local run_exit_wait_test="${STARTER_RUN_EXIT_WAIT_TEST:-}"
+    local activate_export_id="${STARTER_ACTIVATE_EXPORT_ID:-starter-external-export}"
+    local activate_max_idle_seconds="${STARTER_ACTIVATE_MAX_IDLE_SECONDS:-60}"
+    local keyspace_observability="${STARTER_KEYSPACE_OBSERVABILITY:-}"
+    if [[ -z "${keyspace_observability}" ]]; then
+        keyspace_observability="${standby_mode}"
+    fi
+    local keyspace_meta_tenant="${STARTER_KEYSPACE_META_TENANT:-starter_tenant}"
+    local keyspace_meta_project="${STARTER_KEYSPACE_META_PROJECT:-starter_project}"
+    if is_true "${keyspace_observability}" && ! is_true "${standby_mode}"; then
+        echo "STARTER_KEYSPACE_OBSERVABILITY requires STARTER_STANDBY_MODE=1 because keyspace metadata is supplied by standby activation." >&2
+        return 1
+    fi
+    starter_data_dir="$(mktemp -d)"
+    local config_file="${starter_data_dir}/starter.toml"
+    local log_file="${starter_data_dir}/tidb.log"
+    local stdout_log_file="${starter_data_dir}/tidb-stdout.log"
+    local activate_response_file="${starter_data_dir}/activate-response.json"
+    local tidb_port
+    tidb_port="$(find_available_port "${STARTER_TIDB_PORT:-4000}")"
+    local status_port
+    status_port="$(find_available_port "${STARTER_TIDB_STATUS_PORT:-10080}")"
+    if [[ "${status_port}" == "${tidb_port}" ]]; then
+        status_port="$(find_available_port "$((status_port + 1))")"
+    fi
+    local pd_endpoints="${STARTER_PD_ENDPOINTS:-127.0.0.1:2379,127.0.0.1:2382,127.0.0.1:2384}"
+    local first_pd_endpoint="${pd_endpoints%%,*}"
+    local pd_status_url="${first_pd_endpoint}"
+    if [[ "${pd_status_url}" != http://* && "${pd_status_url}" != https://* ]]; then
+        pd_status_url="http://${pd_status_url}"
+    fi
+    local tikv_worker_url="${STARTER_TIKV_WORKER_URL:-localhost:19000}"
+
+    cat > "${config_file}" <<EOF
+deploy-mode = "starter"
+max-allowed-packet = ${max_allowed_packet}
+tikv-worker-url = "${tikv_worker_url}"
+EOF
+
+    local activate_metadata_json=""
+    if is_true "${keyspace_observability}"; then
+        cat >> "${config_file}" <<EOF
+
+[[keyspace-observability.fields]]
+source = "tenant"
+metric-label = "keyspace_meta_tenant"
+slow-log-field = "Keyspace_meta_tenant"
+stmt-log-field = "tenant"
+required = true
+
+[[keyspace-observability.fields]]
+source = "project"
+metric-label = "keyspace_meta_project"
+slow-log-field = "Keyspace_meta_project"
+stmt-log-field = "project"
+required = true
+EOF
+        activate_metadata_json="$(printf '{"tenant":"%s","project":"%s"}' "${keyspace_meta_tenant}" "${keyspace_meta_project}")"
+    fi
+
+    local tidb_server_args=(
+        -P "${tidb_port}"
+        -status "${status_port}"
+        -host "127.0.0.1"
+        -advertise-address "127.0.0.1"
+        -status-host "127.0.0.1"
+        -store tikv
+        -path "${pd_endpoints}"
+        -config "${config_file}"
+        -tidb-service-scope dxf_service
+        -log-file "${log_file}"
+    )
+
+    local starter_activated_from_standby="0"
+    if is_true "${standby_mode}"; then
+        starter_activated_from_standby="1"
+        tidb_server_args+=(
+            -standby=true
+            -activation-timeout "${STARTER_ACTIVATION_TIMEOUT:-120}"
+        )
+    else
+        tidb_server_args+=(
+            -keyspace-name "${keyspace_name}"
+        )
+    fi
+
+    echo "Starting external starter tidb-server on port ${tidb_port}, status port ${status_port}, log file ${log_file}"
+    "${tidb_server_bin}" "${tidb_server_args[@]}" > "${stdout_log_file}" 2>&1 &
+    starter_tidb_pid="$!"
+    trap cleanup_tidb_server EXIT
+
+    local status_url="http://127.0.0.1:${status_port}"
+    wait_for_tidb_server "${status_url}" "${starter_tidb_pid}" "${log_file}" "${stdout_log_file}"
+    if [[ "${starter_activated_from_standby}" == "1" ]]; then
+        activate_starter_server "${status_url}" "${starter_tidb_pid}" "${log_file}" "${stdout_log_file}" \
+            "${activate_response_file}" "${keyspace_name}" "${activate_export_id}" "${activate_max_idle_seconds}" "${activate_metadata_json}"
+        wait_for_tidb_server "${status_url}" "${starter_tidb_pid}" "${log_file}" "${stdout_log_file}"
+    fi
+
+    export TIDB_STARTER_TEST_DSN="root@tcp(127.0.0.1:${tidb_port})/?timeout=5s&readTimeout=30s&writeTimeout=30s&multiStatements=true"
+    export TIDB_STARTER_STATUS_URL="${status_url}"
+    export TIDB_STARTER_PD_STATUS_URL="${pd_status_url}"
+    export TIDB_STARTER_MAX_ALLOWED_PACKET="${max_allowed_packet}"
+    export TIDB_STARTER_TIKV_WORKER_URL="${tikv_worker_url}"
+    export TIDB_STARTER_KEYSPACE_NAME="${keyspace_name}"
+    export TIDB_STARTER_ACTIVATED_FROM_STANDBY="${starter_activated_from_standby}"
+    export TIDB_STARTER_ACTIVATE_EXPORT_ID="${activate_export_id}"
+    if is_true "${keyspace_observability}"; then
+        export TIDB_STARTER_KEYSPACE_OBSERVABILITY=1
+        export TIDB_STARTER_KEYSPACE_META_TENANT="${keyspace_meta_tenant}"
+        export TIDB_STARTER_KEYSPACE_META_PROJECT="${keyspace_meta_project}"
+    fi
+
+    echo "Running external starter tests: ./tests/realtikvtest/${test_suite}"
+    NEXT_GEN=1 go test "./tests/realtikvtest/${test_suite}" -v --tags=intest,nextgen -timeout "${suite_timeout}" "${extra_go_test_args[@]}"
+
+    if [[ -z "${run_exit_wait_test}" ]]; then
+        if [[ "${test_suite}" == "startertest" && "${#extra_go_test_args[@]}" -eq 0 ]]; then
+            run_exit_wait_test="1"
+        else
+            run_exit_wait_test="0"
+        fi
+    fi
+    if is_true "${run_exit_wait_test}" && [[ "${test_suite}" == "startertest" ]]; then
+        export TIDB_STARTER_RUN_EXIT_WAIT_TEST=1
+        echo "Running destructive external starter exit-wait test"
+        NEXT_GEN=1 go test "./tests/realtikvtest/${test_suite}" -v --tags=intest,nextgen \
+            -timeout "${STARTER_EXIT_WAIT_TEST_TIMEOUT:-2m}" \
+            -run '^TestExternalStarterExitRequiresManagerNotifierForManagerFree/graceful_exit_waits_for_open_connection$' \
+            -count=1
+        if [[ -n "${starter_tidb_pid:-}" ]] && kill -0 "${starter_tidb_pid}" >/dev/null 2>&1; then
+            wait "${starter_tidb_pid}" >/dev/null 2>&1 || true
+        fi
+        starter_tidb_pid=""
+    fi
+}
+
+function main() {
+    local self_dir
+    self_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+    local repo_root
+    repo_root="$(realpath "${self_dir}/../../../..")"
+    cd "${repo_root}"
+
+    "${self_dir}/bootstrap-test-with-cluster.sh" "${self_dir}/run-starter-tests-with-server.sh" --under-cluster "$@"
+}
+
+if [[ "${1:-}" == "--under-cluster" ]]; then
+    shift
+    run_under_cluster "$@"
+else
+    main "$@"
+fi

--- a/tests/realtikvtest/startertest/BUILD.bazel
+++ b/tests/realtikvtest/startertest/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "startertest_test",
+    timeout = "moderate",
+    srcs = ["starter_external_test.go"],
+    flaky = True,
+    shard_count = 13,
+    deps = [
+        "@com_github_go_sql_driver_mysql//:mysql",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/tests/realtikvtest/startertest/starter_external_test.go
+++ b/tests/realtikvtest/startertest/starter_external_test.go
@@ -1,0 +1,880 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package startertest
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	envStarterDSN              = "TIDB_STARTER_TEST_DSN"
+	envStarterStatusURL        = "TIDB_STARTER_STATUS_URL"
+	envStarterPDStatusURL      = "TIDB_STARTER_PD_STATUS_URL"
+	envStarterMaxAllowedPacket = "TIDB_STARTER_MAX_ALLOWED_PACKET"
+	envStarterTiKVWorkerURL    = "TIDB_STARTER_TIKV_WORKER_URL"
+	envStarterKeyspaceName     = "TIDB_STARTER_KEYSPACE_NAME"
+	envStarterStandbyActivated = "TIDB_STARTER_ACTIVATED_FROM_STANDBY"
+	envStarterActivateExportID = "TIDB_STARTER_ACTIVATE_EXPORT_ID"
+	envStarterRunExitWaitTest  = "TIDB_STARTER_RUN_EXIT_WAIT_TEST"
+	envStarterKeyspaceObs      = "TIDB_STARTER_KEYSPACE_OBSERVABILITY"
+	envStarterMetaTenant       = "TIDB_STARTER_KEYSPACE_META_TENANT"
+	envStarterMetaProject      = "TIDB_STARTER_KEYSPACE_META_PROJECT"
+
+	starterServiceScope = "dxf_service"
+)
+
+type starterLabelRule struct {
+	ID string `json:"id"`
+}
+
+type starterPoolStatus struct {
+	State        string `json:"state"`
+	KeyspaceName string `json:"keyspace_name"`
+	ExportID     string `json:"export_id"`
+}
+
+type starterKeyspaceObservabilityField struct {
+	Source       string `json:"source"`
+	MetricLabel  string `json:"metric-label"`
+	SlowLogField string `json:"slow-log-field"`
+	StmtLogField string `json:"stmt-log-field"`
+	Required     bool   `json:"required"`
+}
+
+type starterAutoIDOwnerStatus struct {
+	IsOwner *bool `json:"is_owner"`
+}
+
+func TestExternalStarterConfigEndpoint(t *testing.T) {
+	statusURL := requireStarterStatusURL(t)
+	expectedMaxAllowedPacket := requireStarterMaxAllowedPacket(t)
+	expectedTiKVWorkerURL := requireStarterTiKVWorkerURL(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, statusURL+"/config", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var cfg struct {
+		DeployMode       string `json:"deploy-mode"`
+		MaxAllowedPacket uint64 `json:"max-allowed-packet"`
+		KeyspaceName     string `json:"keyspace-name"`
+		Store            string `json:"store"`
+		TiKVWorkerURL    string `json:"tikv-worker-url"`
+		Standby          struct {
+			EnableZeroBackend bool `json:"enable-zero-backend"`
+		} `json:"standby"`
+		Instance struct {
+			TiDBServiceScope string `json:"tidb_service_scope"`
+		} `json:"instance"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&cfg))
+
+	require.Equal(t, "starter", cfg.DeployMode)
+	require.EqualValues(t, expectedMaxAllowedPacket, cfg.MaxAllowedPacket)
+	require.Equal(t, "SYSTEM", cfg.KeyspaceName)
+	require.Equal(t, "tikv", cfg.Store)
+	require.Equal(t, expectedTiKVWorkerURL, cfg.TiKVWorkerURL)
+	requireHostPort(t, cfg.TiKVWorkerURL)
+	require.True(t, cfg.Standby.EnableZeroBackend)
+	require.Equal(t, starterServiceScope, cfg.Instance.TiDBServiceScope)
+}
+
+func TestExternalStarterStandbyActivationStatusIncludesExportID(t *testing.T) {
+	requireStarterActivatedFromStandby(t)
+	statusURL := requireStarterStatusURL(t)
+	expectedKeyspace := requireStarterKeyspaceName(t)
+	expectedExportID := requireStarterActivateExportID(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	statusCode, body := getStarterStatusPath(ctx, t, statusURL, "/tidb-pool/status")
+	require.Equal(t, http.StatusOK, statusCode)
+	var status starterPoolStatus
+	require.NoError(t, json.Unmarshal(body, &status))
+	require.Equal(t, "activated", status.State)
+	require.Equal(t, expectedKeyspace, status.KeyspaceName)
+	require.Equal(t, expectedExportID, status.ExportID)
+
+	statusCode, body = getStarterStatusPath(ctx, t, statusURL, "/config")
+	require.Equal(t, http.StatusOK, statusCode)
+	var cfg struct {
+		StarterParams struct {
+			ExportID string `json:"export-id"`
+		} `json:"starter-params"`
+	}
+	require.NoError(t, json.Unmarshal(body, &cfg))
+	require.Equal(t, expectedExportID, cfg.StarterParams.ExportID)
+}
+
+func TestExternalStarterKeyspaceObservabilityFromActivationMetadata(t *testing.T) {
+	requireStarterKeyspaceObservability(t)
+	requireStarterActivatedFromStandby(t)
+	statusURL := requireStarterStatusURL(t)
+	expectedKeyspace := requireStarterKeyspaceName(t)
+	expectedTenant := requireStarterMetaTenant(t)
+	expectedProject := requireStarterMetaProject(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	statusCode, body := getStarterStatusPath(ctx, t, statusURL, "/config")
+	require.Equal(t, http.StatusOK, statusCode)
+	var cfg struct {
+		KeyspaceName          string `json:"keyspace-name"`
+		KeyspaceObservability struct {
+			Fields []starterKeyspaceObservabilityField `json:"fields"`
+		} `json:"keyspace-observability"`
+	}
+	require.NoError(t, json.Unmarshal(body, &cfg))
+	require.Equal(t, expectedKeyspace, cfg.KeyspaceName)
+	requireStarterObservabilityField(t, cfg.KeyspaceObservability.Fields, starterKeyspaceObservabilityField{
+		Source:       "tenant",
+		MetricLabel:  "keyspace_meta_tenant",
+		SlowLogField: "Keyspace_meta_tenant",
+		StmtLogField: "tenant",
+		Required:     true,
+	})
+	requireStarterObservabilityField(t, cfg.KeyspaceObservability.Fields, starterKeyspaceObservabilityField{
+		Source:       "project",
+		MetricLabel:  "keyspace_meta_project",
+		SlowLogField: "Keyspace_meta_project",
+		StmtLogField: "project",
+		Required:     true,
+	})
+
+	db := openStarterDB(t)
+	require.NoError(t, db.PingContext(ctx))
+	require.Equal(t, "1", queryString(ctx, t, db, "select 1"))
+
+	statusCode, body = getStarterStatusPath(ctx, t, statusURL, "/metrics")
+	require.Equal(t, http.StatusOK, statusCode)
+	metrics := string(body)
+	require.Contains(t, metrics, fmt.Sprintf(`keyspace_name="%s"`, expectedKeyspace))
+	require.Contains(t, metrics, fmt.Sprintf(`keyspace_meta_tenant="%s"`, expectedTenant))
+	require.Contains(t, metrics, fmt.Sprintf(`keyspace_meta_project="%s"`, expectedProject))
+}
+
+func TestExternalStarterAutoIDOwnerEndpoint(t *testing.T) {
+	statusURL := requireStarterStatusURL(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := queryStarterAutoIDOwner(ctx, statusURL)
+	require.NoError(t, err)
+}
+
+func TestExternalStarterExitRejectsInvalidOptions(t *testing.T) {
+	requireStarterActivatedFromStandby(t)
+	statusURL := requireStarterStatusURL(t)
+	keyspaceName := requireStarterKeyspaceName(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tests := []struct {
+		name  string
+		query url.Values
+		want  string
+	}{
+		{
+			name: "invalid graceful",
+			query: url.Values{
+				"keyspace": {"SYSTEM"},
+				"graceful": {"maybe"},
+			},
+			want: "invalid graceful\n",
+		},
+		{
+			name: "wait duration above max",
+			query: url.Values{
+				"keyspace": {"SYSTEM"},
+				"wait":     {"24h1s"},
+			},
+			want: "invalid wait\n",
+		},
+		{
+			name: "wait legacy seconds above max",
+			query: url.Values{
+				"keyspace": {"SYSTEM"},
+				"wait":     {"86401"},
+			},
+			want: "invalid wait\n",
+		},
+		{
+			name: "negative wait",
+			query: url.Values{
+				"keyspace": {"SYSTEM"},
+				"wait":     {"-1"},
+			},
+			want: "invalid wait\n",
+		},
+		{
+			name: "overflow wait",
+			query: url.Values{
+				"keyspace": {"SYSTEM"},
+				"wait":     {"9223372036854775807"},
+			},
+			want: "invalid wait\n",
+		},
+		{
+			name: "invalid skip auto id owner",
+			query: url.Values{
+				"keyspace":           {"SYSTEM"},
+				"skip_auto_id_owner": {"maybe"},
+			},
+			want: "invalid skip_auto_id_owner\n",
+		},
+		{
+			name: "invalid need manager free",
+			query: url.Values{
+				"keyspace":      {"SYSTEM"},
+				"need_mgr_free": {"maybe"},
+			},
+			want: "invalid need_mgr_free\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.query.Set("keyspace", keyspaceName)
+			statusCode, body := getStarterStatusPath(ctx, t, statusURL, "/tidb-pool/exit?"+tt.query.Encode())
+			require.Equal(t, http.StatusBadRequest, statusCode)
+			require.Equal(t, tt.want, string(body))
+		})
+	}
+}
+
+func TestExternalStarterExitRejectsMismatchedKeyspace(t *testing.T) {
+	requireStarterActivatedFromStandby(t)
+	statusURL := requireStarterStatusURL(t)
+	expectedKeyspace := requireStarterKeyspaceName(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	query := url.Values{
+		"keyspace": {"OTHER"},
+		"graceful": {"true"},
+	}
+	statusCode, body := getStarterStatusPath(ctx, t, statusURL, "/tidb-pool/exit?"+query.Encode())
+	require.Equal(t, http.StatusPreconditionFailed, statusCode)
+	var mismatch struct {
+		Remote string `json:"remote"`
+		Local  string `json:"local"`
+	}
+	require.NoError(t, json.Unmarshal(body, &mismatch))
+	require.Equal(t, "OTHER", mismatch.Remote)
+	require.Equal(t, expectedKeyspace, mismatch.Local)
+}
+
+func TestExternalStarterExitRequiresManagerNotifierForManagerFree(t *testing.T) {
+	requireStarterActivatedFromStandby(t)
+	statusURL := requireStarterStatusURL(t)
+	keyspaceName := requireStarterKeyspaceName(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tests := []struct {
+		name string
+		wait string
+	}{
+		{name: "without wait"},
+		{name: "zero seconds", wait: "0"},
+		{name: "zero duration", wait: "0s"},
+		{name: "duration", wait: "1s"},
+		{name: "compound duration", wait: "1h30m"},
+		{name: "legacy seconds", wait: "60"},
+		{name: "max duration", wait: "24h"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := url.Values{
+				"keyspace":      {keyspaceName},
+				"graceful":      {"true"},
+				"need_mgr_free": {"true"},
+			}
+			if tt.wait != "" {
+				query.Set("wait", tt.wait)
+			}
+			statusCode, body := getStarterStatusPath(ctx, t, statusURL, "/tidb-pool/exit?"+query.Encode())
+			require.Equal(t, http.StatusServiceUnavailable, statusCode)
+			require.Equal(t, "manager notifier is unavailable\n", string(body))
+		})
+	}
+
+	db := openStarterDB(t)
+	require.NoError(t, db.PingContext(ctx))
+
+	t.Run("graceful_exit_waits_for_open_connection", func(t *testing.T) {
+		requireStarterExitWaitTestEnabled(t)
+		runExternalStarterGracefulExitWaitsForOpenConnection(t, statusURL, keyspaceName)
+	})
+}
+
+func TestExternalStarterExitSkipsAutoIDOwner(t *testing.T) {
+	requireStarterActivatedFromStandby(t)
+	statusURL := requireStarterStatusURL(t)
+	keyspaceName := requireStarterKeyspaceName(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if !waitForStarterAutoIDOwner(ctx, statusURL) {
+		t.Skip("external starter tidb-server did not become auto ID owner before timeout")
+	}
+
+	query := url.Values{
+		"keyspace":           {keyspaceName},
+		"skip_auto_id_owner": {"true"},
+	}
+	statusCode, _ := getStarterStatusPath(ctx, t, statusURL, "/tidb-pool/exit?"+query.Encode())
+	require.Equal(t, http.StatusNotModified, statusCode)
+
+	db := openStarterDB(t)
+	require.NoError(t, db.PingContext(ctx))
+}
+
+func TestExternalStarterSysVarContracts(t *testing.T) {
+	db := openStarterDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	expectedMaxAllowedPacket := requireStarterMaxAllowedPacket(t)
+	require.NoError(t, db.PingContext(ctx))
+	require.NoError(t, execSQL(ctx, db, "create database if not exists starter_external"))
+	require.NoError(t, execSQL(ctx, db, "drop table if exists starter_external.contract"))
+	require.NoError(t, execSQL(ctx, db, "create table starter_external.contract (id int primary key, v varchar(32))"))
+	require.NoError(t, execSQL(ctx, db, "insert into starter_external.contract values (1, 'starter')"))
+
+	require.EqualValues(t, expectedMaxAllowedPacket, queryInt(ctx, t, db, "select @@global.max_allowed_packet"))
+	require.EqualValues(t, expectedMaxAllowedPacket, queryInt(ctx, t, db, "select @@session.max_allowed_packet"))
+	require.Equal(t, starterServiceScope, queryString(ctx, t, db, "select @@global.tidb_service_scope"))
+	require.Equal(t, "starter", queryString(ctx, t, db, "select v from starter_external.contract where id = 1"))
+
+	requireErrorContains(t, execSQL(ctx, db, "set @@global.max_allowed_packet = 16384"),
+		"SET GLOBAL max_allowed_packet is not supported in starter deployment mode")
+
+	require.Contains(t, []string{"1", "ON"}, strings.ToUpper(queryString(ctx, t, db, "select @@global.require_secure_transport")))
+	requireErrorContains(t, execSQL(ctx, db, "set @@global.require_secure_transport = on"),
+		"require_secure_transport can not be set in starter mode")
+	requireErrorContains(t, execSQL(ctx, db, "set @@global.require_secure_transport = off"),
+		"require_secure_transport can not be set in starter mode")
+}
+
+func TestExternalStarterMaxAllowedPacketIsEnforcedAtProtocolBoundary(t *testing.T) {
+	db := openStarterDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	maxAllowedPacket := requireStarterMaxAllowedPacket(t)
+	oversizedSQL := fmt.Sprintf("select '%s'", strings.Repeat("a", maxAllowedPacket+1024))
+	err := execSQL(ctx, db, oversizedSQL)
+	require.Error(t, err)
+	errText := strings.ToLower(err.Error())
+	require.Truef(t,
+		strings.Contains(errText, "max_allowed_packet") ||
+			strings.Contains(errText, "packet bigger") ||
+			strings.Contains(errText, "invalid connection"),
+		"unexpected error: %v", err)
+}
+
+func TestExternalStarterSessionStatesRoundTrip(t *testing.T) {
+	source := openStarterDB(t)
+	target := openStarterDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	require.NoError(t, execSQL(ctx, source, "set @starter_state = 'external-starter'"))
+	require.NoError(t, execSQL(ctx, source, "set timestamp = 100"))
+
+	var state string
+	var token sql.NullString
+	require.NoError(t, source.QueryRowContext(ctx, "show session_states").Scan(&state, &token))
+	require.NotEmpty(t, state)
+
+	require.NoError(t, execSQL(ctx, target, fmt.Sprintf("set session_states %q", state)))
+	require.Equal(t, "external-starter", queryString(ctx, t, target, "select @starter_state"))
+	require.Equal(t, "100", queryString(ctx, t, target, "select @@timestamp"))
+}
+
+func TestExternalStarterUsernamePrefixContracts(t *testing.T) {
+	db := openStarterDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, db.PingContext(ctx))
+
+	cleanupStarterUsernamePrefixData(ctx, t, db)
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		cleanupStarterUsernamePrefixData(cleanupCtx, t, db)
+	})
+
+	requireErrorContains(t,
+		execSQL(ctx, db, "create user `ext_starter_reject`@`%` identified by 'starter_pwd'"),
+		"User name must start with `SYSTEM.`")
+	requireErrorContains(t,
+		execSQL(ctx, db, "create role `ext_starter_role_reject`"),
+		"User name must start with `SYSTEM.`")
+
+	require.NoError(t, execSQL(ctx, db, "create user `SYSTEM.ext_starter_user`@`%` identified by 'starter_pwd1'"))
+	require.NoError(t, execSQL(ctx, db, "create user `SYSTEM.ext.starter_user`@`%` identified by 'starter_dot_pwd'"))
+	require.NoError(t, execSQL(ctx, db, "create role `SYSTEM.ext_starter_role`"))
+
+	requireErrorContains(t,
+		execSQL(ctx, db, "rename user `SYSTEM.ext_starter_user`@`%` to `ext_starter_renamed`@`%`"),
+		"User name must start with `SYSTEM.`")
+
+	require.NoError(t, execSQL(ctx, db, "grant ext_starter_role to ext_starter_user"))
+	require.Equal(t, "SYSTEM.ext_starter_user", queryString(ctx, t, db,
+		"select TO_USER from mysql.role_edges where FROM_USER='SYSTEM.ext_starter_role' and TO_USER='SYSTEM.ext_starter_user' and TO_HOST='%'"))
+
+	require.NoError(t, execSQL(ctx, db, "revoke ext_starter_role from ext_starter_user"))
+	require.Equal(t, 0, queryInt(ctx, t, db,
+		"select count(*) from mysql.role_edges where FROM_USER='SYSTEM.ext_starter_role' and TO_USER='SYSTEM.ext_starter_user' and TO_HOST='%'"))
+
+	require.NoError(t, execSQL(ctx, db, "grant ext_starter_role to ext_starter_user"))
+	require.NoError(t, execSQL(ctx, db, "set default role ext_starter_role to ext_starter_user"))
+	require.Equal(t, "SYSTEM.ext_starter_role", queryString(ctx, t, db,
+		"select DEFAULT_ROLE_USER from mysql.default_roles where USER='SYSTEM.ext_starter_user' and DEFAULT_ROLE_USER='SYSTEM.ext_starter_role'"))
+
+	require.NoError(t, execSQL(ctx, db, "alter user ext_starter_user identified by 'starter_pwd2'"))
+	require.NoError(t, execSQL(ctx, db, "alter user `ext.starter_user`@`%` identified by 'starter_dot_pwd2'"))
+
+	userDB := openStarterDBAs(t, "ext_starter_user", "starter_pwd2")
+	require.NoError(t, userDB.PingContext(ctx))
+	require.Equal(t, "SYSTEM.ext_starter_user@%", queryString(ctx, t, userDB, "select current_user()"))
+
+	dotUserDB := openStarterDBAs(t, "ext.starter_user", "starter_dot_pwd2")
+	require.NoError(t, dotUserDB.PingContext(ctx))
+	require.Equal(t, "SYSTEM.ext.starter_user@%", queryString(ctx, t, dotUserDB, "select current_user()"))
+
+	wrongKeyspaceDB := openStarterDBAs(t, "OTHER.ext_starter_user", "starter_pwd2")
+	requireErrorContains(t, wrongKeyspaceDB.PingContext(ctx), "User name prefix does not match the assigned keyspace")
+}
+
+func TestExternalStarterAttributesUseKeyspaceScopedLabelRules(t *testing.T) {
+	db := openStarterDB(t)
+	pdStatusURL := requireStarterPDStatusURL(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, db.PingContext(ctx))
+
+	const schemaName = "starter_external_attrs"
+	cleanupStarterAttributeData(ctx, t, db)
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		cleanupStarterAttributeData(cleanupCtx, t, db)
+	})
+
+	keyspaceID := queryString(ctx, t, db, "select keyspace_id from information_schema.keyspace_meta")
+	require.NotEmpty(t, keyspaceID)
+
+	require.NoError(t, execSQL(ctx, db, "create database starter_external_attrs"))
+	require.NoError(t, execSQL(ctx, db, `create table starter_external_attrs.attr_t (c int)
+partition by range (c) (
+	partition p0 values less than (10),
+	partition p1 values less than (20)
+)`))
+	require.NoError(t, execSQL(ctx, db, `alter table starter_external_attrs.attr_t attributes="merge_option=allow,purpose=starter_table"`))
+	require.NoError(t, execSQL(ctx, db, `alter table starter_external_attrs.attr_t partition p0 attributes="merge_option=deny,purpose=starter_partition"`))
+
+	require.Equal(t, `"merge_option=allow","purpose=starter_table"`, queryString(ctx, t, db,
+		"select attributes from information_schema.attributes where id='schema/starter_external_attrs/attr_t'"))
+	require.Equal(t, `"merge_option=deny","purpose=starter_partition"`, queryString(ctx, t, db,
+		"select attributes from information_schema.attributes where id='schema/starter_external_attrs/attr_t/p0'"))
+	require.Equal(t, 0, queryInt(ctx, t, db,
+		"select count(*) from information_schema.attributes where id like 'keyspace/%/schema/starter_external_attrs/%'"))
+
+	rules := queryStarterLabelRules(ctx, t, pdStatusURL)
+	requireStarterLabelRuleID(t, rules, fmt.Sprintf("keyspace/%s/schema/%s/attr_t", keyspaceID, schemaName))
+	requireStarterLabelRuleID(t, rules, fmt.Sprintf("keyspace/%s/schema/%s/attr_t/p0", keyspaceID, schemaName))
+	requireNoStarterLabelRuleID(t, rules, fmt.Sprintf("schema/%s/attr_t", schemaName))
+	requireNoStarterLabelRuleID(t, rules, fmt.Sprintf("schema/%s/attr_t/p0", schemaName))
+}
+
+func openStarterDB(t *testing.T) *sql.DB {
+	t.Helper()
+	cfg := requireStarterDSNConfig(t)
+	return openStarterDBWithDSN(t, cfg.FormatDSN())
+}
+
+func openStarterDBAs(t *testing.T, user, password string) *sql.DB {
+	t.Helper()
+	cfg := requireStarterDSNConfig(t)
+	cfg.User = user
+	cfg.Passwd = password
+	return openStarterDBWithDSN(t, cfg.FormatDSN())
+}
+
+func requireStarterDSNConfig(t *testing.T) *mysql.Config {
+	t.Helper()
+	dsn := os.Getenv(envStarterDSN)
+	if dsn == "" {
+		t.Skipf("%s is not set; run tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh", envStarterDSN)
+	}
+	cfg, err := mysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	return cfg
+}
+
+func openStarterDBWithDSN(t *testing.T, dsn string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Some tests intentionally trigger protocol errors that leave the connection bad.
+		_ = db.Close()
+	})
+	return db
+}
+
+func requireStarterStatusURL(t *testing.T) string {
+	t.Helper()
+	statusURL := strings.TrimRight(os.Getenv(envStarterStatusURL), "/")
+	if statusURL == "" {
+		t.Skipf("%s is not set; run tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh", envStarterStatusURL)
+	}
+	return statusURL
+}
+
+func requireStarterPDStatusURL(t *testing.T) string {
+	t.Helper()
+	statusURL := strings.TrimRight(os.Getenv(envStarterPDStatusURL), "/")
+	if statusURL == "" {
+		t.Skipf("%s is not set; run tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh", envStarterPDStatusURL)
+	}
+	return statusURL
+}
+
+func requireStarterMaxAllowedPacket(t *testing.T) int {
+	t.Helper()
+	raw := os.Getenv(envStarterMaxAllowedPacket)
+	if raw == "" {
+		t.Skipf("%s is not set; run tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh", envStarterMaxAllowedPacket)
+	}
+	v, err := strconv.Atoi(raw)
+	require.NoError(t, err)
+	return v
+}
+
+func requireStarterTiKVWorkerURL(t *testing.T) string {
+	t.Helper()
+	value := os.Getenv(envStarterTiKVWorkerURL)
+	if value == "" {
+		t.Skipf("%s is not set; run tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh", envStarterTiKVWorkerURL)
+	}
+	requireHostPort(t, value)
+	return value
+}
+
+func requireStarterKeyspaceName(t *testing.T) string {
+	t.Helper()
+	value := os.Getenv(envStarterKeyspaceName)
+	if value == "" {
+		return "SYSTEM"
+	}
+	return value
+}
+
+func requireStarterActivatedFromStandby(t *testing.T) {
+	t.Helper()
+	if os.Getenv(envStarterStandbyActivated) != "1" {
+		t.Skipf("%s is not 1; run tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh with STARTER_STANDBY_MODE=1", envStarterStandbyActivated)
+	}
+}
+
+func requireStarterActivateExportID(t *testing.T) string {
+	t.Helper()
+	value := os.Getenv(envStarterActivateExportID)
+	if value == "" {
+		t.Skipf("%s is not set; run tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh", envStarterActivateExportID)
+	}
+	return value
+}
+
+func requireStarterExitWaitTestEnabled(t *testing.T) {
+	t.Helper()
+	if os.Getenv(envStarterRunExitWaitTest) != "1" {
+		t.Skipf("%s is not 1; the destructive exit-wait case is run as the final script phase only", envStarterRunExitWaitTest)
+	}
+}
+
+func requireStarterKeyspaceObservability(t *testing.T) {
+	t.Helper()
+	if os.Getenv(envStarterKeyspaceObs) != "1" {
+		t.Skipf("%s is not 1; run tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh with starter keyspace observability enabled", envStarterKeyspaceObs)
+	}
+}
+
+func requireStarterMetaTenant(t *testing.T) string {
+	t.Helper()
+	value := os.Getenv(envStarterMetaTenant)
+	if value == "" {
+		t.Skipf("%s is not set; run tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh", envStarterMetaTenant)
+	}
+	return value
+}
+
+func requireStarterMetaProject(t *testing.T) string {
+	t.Helper()
+	value := os.Getenv(envStarterMetaProject)
+	if value == "" {
+		t.Skipf("%s is not set; run tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh", envStarterMetaProject)
+	}
+	return value
+}
+
+func requireHostPort(t *testing.T, value string) {
+	t.Helper()
+	host, port, err := net.SplitHostPort(value)
+	require.NoError(t, err)
+	require.NotEmpty(t, host)
+	require.Regexp(t, `^[0-9]+$`, port)
+}
+
+func execSQL(ctx context.Context, db *sql.DB, query string) error {
+	_, err := db.ExecContext(ctx, query)
+	return err
+}
+
+func getStarterStatusPath(ctx context.Context, t *testing.T, statusURL, path string) (int, []byte) {
+	t.Helper()
+	statusCode, body, err := tryStarterStatusPath(ctx, statusURL, path)
+	require.NoError(t, err)
+	return statusCode, body
+}
+
+func tryStarterStatusPath(ctx context.Context, statusURL, path string) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, statusURL+path, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, body, nil
+}
+
+func runExternalStarterGracefulExitWaitsForOpenConnection(t *testing.T, statusURL, keyspaceName string) {
+	t.Helper()
+	db := openStarterDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+	require.NoError(t, conn.PingContext(ctx))
+
+	const waitValue = "10s"
+	query := url.Values{
+		"keyspace": {keyspaceName},
+		"graceful": {"true"},
+		"wait":     {waitValue},
+	}
+	exitStart := time.Now()
+	statusCode, body := getStarterStatusPath(ctx, t, statusURL, "/tidb-pool/exit?"+query.Encode())
+	require.Equal(t, http.StatusOK, statusCode, string(body))
+
+	require.NoError(t, waitForStarterStatusCode(ctx, statusURL, http.StatusInternalServerError))
+
+	time.Sleep(1200 * time.Millisecond)
+	statusCode, _, err = tryStarterStatusPath(ctx, statusURL, "/status")
+	require.NoError(t, err, "tidb-server exited before the held connection was closed")
+	require.Equal(t, http.StatusInternalServerError, statusCode)
+	require.Less(t, time.Since(exitStart), 10*time.Second)
+
+	require.NoError(t, conn.Close())
+	require.NoError(t, waitForStarterStatusUnavailable(ctx, statusURL))
+}
+
+func waitForStarterStatusCode(ctx context.Context, statusURL string, want int) error {
+	for {
+		statusCode, _, err := tryStarterStatusPath(ctx, statusURL, "/status")
+		if err == nil && statusCode == want {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for /status code %d: last status=%d, err=%v", want, statusCode, err)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+func waitForStarterStatusUnavailable(ctx context.Context, statusURL string) error {
+	for {
+		_, _, err := tryStarterStatusPath(ctx, statusURL, "/status")
+		if err != nil {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for /status to become unavailable")
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+func queryStarterAutoIDOwner(ctx context.Context, statusURL string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, statusURL+"/owner_manager/auto_id_service", nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+		return false, fmt.Errorf("unexpected auto ID owner status code %d: %s", resp.StatusCode, string(body))
+	}
+	var status starterAutoIDOwnerStatus
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		return false, err
+	}
+	if status.IsOwner == nil {
+		return false, fmt.Errorf("auto ID owner response missing is_owner")
+	}
+	return *status.IsOwner, nil
+}
+
+func waitForStarterAutoIDOwner(ctx context.Context, statusURL string) bool {
+	for {
+		isOwner, err := queryStarterAutoIDOwner(ctx, statusURL)
+		if err == nil && isOwner {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func cleanupStarterUsernamePrefixData(ctx context.Context, t *testing.T, db *sql.DB) {
+	t.Helper()
+	for _, query := range []string{
+		"drop user if exists `SYSTEM.ext_starter_user`@`%`",
+		"drop user if exists `SYSTEM.ext.starter_user`@`%`",
+		"drop user if exists `SYSTEM.ext_starter_renamed`@`%`",
+		"drop user if exists `SYSTEM.ext_starter_reject`@`%`",
+		"drop user if exists `SYSTEM.OTHER.ext_starter_user`@`%`",
+		"drop role if exists `SYSTEM.ext_starter_role`",
+		"drop role if exists `SYSTEM.ext_starter_role_reject`",
+	} {
+		require.NoError(t, execSQL(ctx, db, query))
+	}
+}
+
+func cleanupStarterAttributeData(ctx context.Context, t *testing.T, db *sql.DB) {
+	t.Helper()
+	require.NoError(t, execSQL(ctx, db, "drop database if exists starter_external_attrs"))
+}
+
+func queryStarterLabelRules(ctx context.Context, t *testing.T, pdStatusURL string) []starterLabelRule {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pdStatusURL+"/pd/api/v1/config/region-label/rules", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var rules []starterLabelRule
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&rules))
+	return rules
+}
+
+func requireStarterLabelRuleID(t *testing.T, rules []starterLabelRule, id string) {
+	t.Helper()
+	for _, rule := range rules {
+		if rule.ID == id {
+			return
+		}
+	}
+	require.Failf(t, "missing starter label rule", "rule ID %q not found in %v", id, rules)
+}
+
+func requireNoStarterLabelRuleID(t *testing.T, rules []starterLabelRule, id string) {
+	t.Helper()
+	for _, rule := range rules {
+		require.NotEqual(t, id, rule.ID)
+	}
+}
+
+func requireStarterObservabilityField(t *testing.T, fields []starterKeyspaceObservabilityField, want starterKeyspaceObservabilityField) {
+	t.Helper()
+	for _, field := range fields {
+		if field == want {
+			return
+		}
+	}
+	require.Failf(t, "missing starter keyspace observability field", "field %+v not found in %+v", want, fields)
+}
+
+func queryString(ctx context.Context, t *testing.T, db *sql.DB, query string) string {
+	t.Helper()
+	var value string
+	require.NoError(t, db.QueryRowContext(ctx, query).Scan(&value))
+	return value
+}
+
+func queryInt(ctx context.Context, t *testing.T, db *sql.DB, query string) int {
+	t.Helper()
+	var value int
+	require.NoError(t, db.QueryRowContext(ctx, query).Scan(&value))
+	return value
+}
+
+func requireErrorContains(t *testing.T, err error, contains string) {
+	t.Helper()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), contains)
+}

--- a/tests/realtikvtest/startertest/starter_external_test.go
+++ b/tests/realtikvtest/startertest/starter_external_test.go
@@ -329,8 +329,10 @@ func TestExternalStarterExitWaitAndManagerNotifierContracts(t *testing.T) {
 		})
 	}
 
-	db := openStarterDB(t)
-	require.NoError(t, db.PingContext(ctx))
+	if os.Getenv(envStarterRunExitWaitTest) != "1" {
+		db := openStarterDB(t)
+		require.NoError(t, db.PingContext(ctx))
+	}
 
 	t.Run("graceful_exit_waits_for_open_connection", func(t *testing.T) {
 		requireStarterExitWaitTestEnabled(t)
@@ -737,8 +739,13 @@ func runExternalStarterGracefulExitWaitsForOpenConnection(t *testing.T, statusUR
 	}, 3*time.Second, 100*time.Millisecond, "tidb-server exited before the held connection was closed")
 	require.Less(t, time.Since(exitStart), 10*time.Second)
 
+	closeStart := time.Now()
 	require.NoError(t, conn.Close())
-	require.NoError(t, waitForStarterStatusUnavailable(ctx, statusURL))
+	require.NoError(t, db.Close())
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer shutdownCancel()
+	require.NoError(t, waitForStarterStatusUnavailable(shutdownCtx, statusURL))
+	require.Less(t, time.Since(closeStart), 3*time.Second)
 }
 
 func waitForStarterStatusCode(ctx context.Context, statusURL string, want int) error {

--- a/tests/realtikvtest/startertest/starter_external_test.go
+++ b/tests/realtikvtest/startertest/starter_external_test.go
@@ -76,6 +76,7 @@ func TestExternalStarterConfigEndpoint(t *testing.T) {
 	statusURL := requireStarterStatusURL(t)
 	expectedMaxAllowedPacket := requireStarterMaxAllowedPacket(t)
 	expectedTiKVWorkerURL := requireStarterTiKVWorkerURL(t)
+	expectedKeyspace := requireStarterKeyspaceName(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -104,7 +105,7 @@ func TestExternalStarterConfigEndpoint(t *testing.T) {
 
 	require.Equal(t, "starter", cfg.DeployMode)
 	require.EqualValues(t, expectedMaxAllowedPacket, cfg.MaxAllowedPacket)
-	require.Equal(t, "SYSTEM", cfg.KeyspaceName)
+	require.Equal(t, expectedKeyspace, cfg.KeyspaceName)
 	require.Equal(t, "tikv", cfg.Store)
 	require.Equal(t, expectedTiKVWorkerURL, cfg.TiKVWorkerURL)
 	requireHostPort(t, cfg.TiKVWorkerURL)
@@ -212,7 +213,6 @@ func TestExternalStarterExitRejectsInvalidOptions(t *testing.T) {
 		{
 			name: "invalid graceful",
 			query: url.Values{
-				"keyspace": {"SYSTEM"},
 				"graceful": {"maybe"},
 			},
 			want: "invalid graceful\n",
@@ -220,39 +220,34 @@ func TestExternalStarterExitRejectsInvalidOptions(t *testing.T) {
 		{
 			name: "wait duration above max",
 			query: url.Values{
-				"keyspace": {"SYSTEM"},
-				"wait":     {"24h1s"},
+				"wait": {"24h1s"},
 			},
 			want: "invalid wait\n",
 		},
 		{
 			name: "wait legacy seconds above max",
 			query: url.Values{
-				"keyspace": {"SYSTEM"},
-				"wait":     {"86401"},
+				"wait": {"86401"},
 			},
 			want: "invalid wait\n",
 		},
 		{
 			name: "negative wait",
 			query: url.Values{
-				"keyspace": {"SYSTEM"},
-				"wait":     {"-1"},
+				"wait": {"-1"},
 			},
 			want: "invalid wait\n",
 		},
 		{
 			name: "overflow wait",
 			query: url.Values{
-				"keyspace": {"SYSTEM"},
-				"wait":     {"9223372036854775807"},
+				"wait": {"9223372036854775807"},
 			},
 			want: "invalid wait\n",
 		},
 		{
 			name: "invalid skip auto id owner",
 			query: url.Values{
-				"keyspace":           {"SYSTEM"},
 				"skip_auto_id_owner": {"maybe"},
 			},
 			want: "invalid skip_auto_id_owner\n",
@@ -260,7 +255,6 @@ func TestExternalStarterExitRejectsInvalidOptions(t *testing.T) {
 		{
 			name: "invalid need manager free",
 			query: url.Values{
-				"keyspace":      {"SYSTEM"},
 				"need_mgr_free": {"maybe"},
 			},
 			want: "invalid need_mgr_free\n",
@@ -284,8 +278,9 @@ func TestExternalStarterExitRejectsMismatchedKeyspace(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	remoteKeyspace := otherStarterKeyspaceName(expectedKeyspace)
 	query := url.Values{
-		"keyspace": {"OTHER"},
+		"keyspace": {remoteKeyspace},
 		"graceful": {"true"},
 	}
 	statusCode, body := getStarterStatusPath(ctx, t, statusURL, "/tidb-pool/exit?"+query.Encode())
@@ -295,11 +290,11 @@ func TestExternalStarterExitRejectsMismatchedKeyspace(t *testing.T) {
 		Local  string `json:"local"`
 	}
 	require.NoError(t, json.Unmarshal(body, &mismatch))
-	require.Equal(t, "OTHER", mismatch.Remote)
+	require.Equal(t, remoteKeyspace, mismatch.Remote)
 	require.Equal(t, expectedKeyspace, mismatch.Local)
 }
 
-func TestExternalStarterExitRequiresManagerNotifierForManagerFree(t *testing.T) {
+func TestExternalStarterExitWaitAndManagerNotifierContracts(t *testing.T) {
 	requireStarterActivatedFromStandby(t)
 	statusURL := requireStarterStatusURL(t)
 	keyspaceName := requireStarterKeyspaceName(t)
@@ -434,53 +429,67 @@ func TestExternalStarterUsernamePrefixContracts(t *testing.T) {
 	defer cancel()
 	require.NoError(t, db.PingContext(ctx))
 
-	cleanupStarterUsernamePrefixData(ctx, t, db)
+	keyspaceName := requireStarterKeyspaceName(t)
+	prefixError := fmt.Sprintf("User name must start with `%s.`", keyspaceName)
+	userName := keyspaceName + ".ext_starter_user"
+	dotUserName := keyspaceName + ".ext.starter_user"
+	renamedUserName := keyspaceName + ".ext_starter_renamed"
+	roleName := keyspaceName + ".ext_starter_role"
+	wrongKeyspaceUserName := otherStarterKeyspaceName(keyspaceName) + ".ext_starter_user"
+
+	cleanupStarterUsernamePrefixData(ctx, t, db, keyspaceName)
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cleanupCancel()
-		cleanupStarterUsernamePrefixData(cleanupCtx, t, db)
+		cleanupStarterUsernamePrefixData(cleanupCtx, t, db, keyspaceName)
 	})
 
 	requireErrorContains(t,
 		execSQL(ctx, db, "create user `ext_starter_reject`@`%` identified by 'starter_pwd'"),
-		"User name must start with `SYSTEM.`")
+		prefixError)
 	requireErrorContains(t,
 		execSQL(ctx, db, "create role `ext_starter_role_reject`"),
-		"User name must start with `SYSTEM.`")
+		prefixError)
 
-	require.NoError(t, execSQL(ctx, db, "create user `SYSTEM.ext_starter_user`@`%` identified by 'starter_pwd1'"))
-	require.NoError(t, execSQL(ctx, db, "create user `SYSTEM.ext.starter_user`@`%` identified by 'starter_dot_pwd'"))
-	require.NoError(t, execSQL(ctx, db, "create role `SYSTEM.ext_starter_role`"))
+	require.NoError(t, execSQL(ctx, db, fmt.Sprintf("create user %s@%s identified by 'starter_pwd1'",
+		quoteSQLIdentifier(userName), quoteSQLIdentifier("%"))))
+	require.NoError(t, execSQL(ctx, db, fmt.Sprintf("create user %s@%s identified by 'starter_dot_pwd'",
+		quoteSQLIdentifier(dotUserName), quoteSQLIdentifier("%"))))
+	require.NoError(t, execSQL(ctx, db, fmt.Sprintf("create role %s", quoteSQLIdentifier(roleName))))
 
 	requireErrorContains(t,
-		execSQL(ctx, db, "rename user `SYSTEM.ext_starter_user`@`%` to `ext_starter_renamed`@`%`"),
-		"User name must start with `SYSTEM.`")
+		execSQL(ctx, db, fmt.Sprintf("rename user %s@%s to %s@%s",
+			quoteSQLIdentifier(userName), quoteSQLIdentifier("%"), quoteSQLIdentifier(renamedUserName), quoteSQLIdentifier("%"))),
+		prefixError)
 
 	require.NoError(t, execSQL(ctx, db, "grant ext_starter_role to ext_starter_user"))
-	require.Equal(t, "SYSTEM.ext_starter_user", queryString(ctx, t, db,
-		"select TO_USER from mysql.role_edges where FROM_USER='SYSTEM.ext_starter_role' and TO_USER='SYSTEM.ext_starter_user' and TO_HOST='%'"))
+	require.Equal(t, userName, queryString(ctx, t, db, fmt.Sprintf(
+		"select TO_USER from mysql.role_edges where FROM_USER=%s and TO_USER=%s and TO_HOST=%s",
+		quoteSQLString(roleName), quoteSQLString(userName), quoteSQLString("%"))))
 
 	require.NoError(t, execSQL(ctx, db, "revoke ext_starter_role from ext_starter_user"))
-	require.Equal(t, 0, queryInt(ctx, t, db,
-		"select count(*) from mysql.role_edges where FROM_USER='SYSTEM.ext_starter_role' and TO_USER='SYSTEM.ext_starter_user' and TO_HOST='%'"))
+	require.Equal(t, 0, queryInt(ctx, t, db, fmt.Sprintf(
+		"select count(*) from mysql.role_edges where FROM_USER=%s and TO_USER=%s and TO_HOST=%s",
+		quoteSQLString(roleName), quoteSQLString(userName), quoteSQLString("%"))))
 
 	require.NoError(t, execSQL(ctx, db, "grant ext_starter_role to ext_starter_user"))
 	require.NoError(t, execSQL(ctx, db, "set default role ext_starter_role to ext_starter_user"))
-	require.Equal(t, "SYSTEM.ext_starter_role", queryString(ctx, t, db,
-		"select DEFAULT_ROLE_USER from mysql.default_roles where USER='SYSTEM.ext_starter_user' and DEFAULT_ROLE_USER='SYSTEM.ext_starter_role'"))
+	require.Equal(t, roleName, queryString(ctx, t, db, fmt.Sprintf(
+		"select DEFAULT_ROLE_USER from mysql.default_roles where USER=%s and DEFAULT_ROLE_USER=%s",
+		quoteSQLString(userName), quoteSQLString(roleName))))
 
 	require.NoError(t, execSQL(ctx, db, "alter user ext_starter_user identified by 'starter_pwd2'"))
 	require.NoError(t, execSQL(ctx, db, "alter user `ext.starter_user`@`%` identified by 'starter_dot_pwd2'"))
 
 	userDB := openStarterDBAs(t, "ext_starter_user", "starter_pwd2")
 	require.NoError(t, userDB.PingContext(ctx))
-	require.Equal(t, "SYSTEM.ext_starter_user@%", queryString(ctx, t, userDB, "select current_user()"))
+	require.Equal(t, userName+"@%", queryString(ctx, t, userDB, "select current_user()"))
 
 	dotUserDB := openStarterDBAs(t, "ext.starter_user", "starter_dot_pwd2")
 	require.NoError(t, dotUserDB.PingContext(ctx))
-	require.Equal(t, "SYSTEM.ext.starter_user@%", queryString(ctx, t, dotUserDB, "select current_user()"))
+	require.Equal(t, dotUserName+"@%", queryString(ctx, t, dotUserDB, "select current_user()"))
 
-	wrongKeyspaceDB := openStarterDBAs(t, "OTHER.ext_starter_user", "starter_pwd2")
+	wrongKeyspaceDB := openStarterDBAs(t, wrongKeyspaceUserName, "starter_pwd2")
 	requireErrorContains(t, wrongKeyspaceDB.PingContext(ctx), "User name prefix does not match the assigned keyspace")
 }
 
@@ -719,10 +728,13 @@ func runExternalStarterGracefulExitWaitsForOpenConnection(t *testing.T, statusUR
 
 	require.NoError(t, waitForStarterStatusCode(ctx, statusURL, http.StatusInternalServerError))
 
-	time.Sleep(1200 * time.Millisecond)
-	statusCode, _, err = tryStarterStatusPath(ctx, statusURL, "/status")
-	require.NoError(t, err, "tidb-server exited before the held connection was closed")
-	require.Equal(t, http.StatusInternalServerError, statusCode)
+	require.Eventually(t, func() bool {
+		if time.Since(exitStart) < time.Second {
+			return false
+		}
+		statusCode, _, err = tryStarterStatusPath(ctx, statusURL, "/status")
+		return err == nil && statusCode == http.StatusInternalServerError
+	}, 3*time.Second, 100*time.Millisecond, "tidb-server exited before the held connection was closed")
 	require.Less(t, time.Since(exitStart), 10*time.Second)
 
 	require.NoError(t, conn.Close())
@@ -798,19 +810,41 @@ func waitForStarterAutoIDOwner(ctx context.Context, statusURL string) bool {
 	}
 }
 
-func cleanupStarterUsernamePrefixData(ctx context.Context, t *testing.T, db *sql.DB) {
+func cleanupStarterUsernamePrefixData(ctx context.Context, t *testing.T, db *sql.DB, keyspaceName string) {
 	t.Helper()
-	for _, query := range []string{
-		"drop user if exists `SYSTEM.ext_starter_user`@`%`",
-		"drop user if exists `SYSTEM.ext.starter_user`@`%`",
-		"drop user if exists `SYSTEM.ext_starter_renamed`@`%`",
-		"drop user if exists `SYSTEM.ext_starter_reject`@`%`",
-		"drop user if exists `SYSTEM.OTHER.ext_starter_user`@`%`",
-		"drop role if exists `SYSTEM.ext_starter_role`",
-		"drop role if exists `SYSTEM.ext_starter_role_reject`",
-	} {
-		require.NoError(t, execSQL(ctx, db, query))
+	host := quoteSQLIdentifier("%")
+	userNames := []string{
+		keyspaceName + ".ext_starter_user",
+		keyspaceName + ".ext.starter_user",
+		keyspaceName + ".ext_starter_renamed",
+		keyspaceName + ".ext_starter_reject",
+		otherStarterKeyspaceName(keyspaceName) + ".ext_starter_user",
 	}
+	roleNames := []string{
+		keyspaceName + ".ext_starter_role",
+		keyspaceName + ".ext_starter_role_reject",
+	}
+	for _, userName := range userNames {
+		require.NoError(t, execSQL(ctx, db, fmt.Sprintf("drop user if exists %s@%s", quoteSQLIdentifier(userName), host)))
+	}
+	for _, roleName := range roleNames {
+		require.NoError(t, execSQL(ctx, db, fmt.Sprintf("drop role if exists %s", quoteSQLIdentifier(roleName))))
+	}
+}
+
+func otherStarterKeyspaceName(keyspaceName string) string {
+	if strings.EqualFold(keyspaceName, "OTHER") {
+		return "DIFFERENT"
+	}
+	return "OTHER"
+}
+
+func quoteSQLIdentifier(value string) string {
+	return "`" + strings.ReplaceAll(value, "`", "``") + "`"
+}
+
+func quoteSQLString(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
 func cleanupStarterAttributeData(ctx context.Context, t *testing.T, db *sql.DB) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67765

**Problem Summary**

Starter mode has gained several behaviors that only become fully meaningful when TiDB is running as a real external `tidb-server` process, especially standby activation, activation metadata, shutdown coordination, starter-specific config overrides, keyspace-scoped behavior, and observability labels.

The existing next-gen RealTiKV tests mainly exercised Go test suites against a prepared next-gen cluster, but did not provide a dedicated harness that starts an external starter-mode `tidb-server`, activates it through the starter HTTP API, and verifies its SQL protocol and status API behavior end to end. As a result, regressions in starter process startup, activation request handling, HTTP exit options, keyspace-scoped contracts, and starter observability could be missed by package-level unit tests.

**What changed and how does it work**

This PR adds an external starter-mode RealTiKV test harness under `tests/realtikvtest/scripts/next-gen`. The new runner reuses the existing next-gen cluster bootstrap, starts a real next-gen `tidb-server` binary with `deploy-mode = "starter"`, optionally starts it in standby mode, activates it through `/tidb-pool/activate`, exports the SQL DSN and status endpoints to Go tests, and then runs `tests/realtikvtest/startertest` against that external process.

The new `startertest` suite verifies starter behavior through real SQL and HTTP APIs, including:

- `/config` starter configuration such as deploy mode, `max-allowed-packet`, keyspace name, TiKV worker URL, standby zero-backend config, and TiDB service scope.
- Standby activation status, including activated keyspace and starter export ID propagation.
- Starter keyspace observability from activation metadata, including configured `keyspace-observability` mappings and Prometheus labels exposed by `/metrics`.
- Starter pool exit API validation, including invalid `graceful`, `wait`, `skip_auto_id_owner`, and `need_mgr_free` values.
- Keyspace mismatch handling for `/tidb-pool/exit`.
- Manager notifier requirements for manager-free shutdown.
- Auto ID owner skip behavior.
- Starter-specific system variable contracts, including immutable `max_allowed_packet` and `require_secure_transport` behavior.
- Protocol-level enforcement of starter `max-allowed-packet`.
- `SHOW SESSION_STATES` / `SET SESSION_STATES` round trip through the external server.
- Starter username/keyspace prefix contracts for users, roles, grants, default roles, password changes, and login validation.
- Keyspace-scoped table/partition attribute label rules in PD.
- A final destructive shutdown phase that triggers external `tidb-server` graceful exit and verifies the configured wait behavior while a SQL connection is still held open.

The runner also documents the new environment variables for customizing the starter binary path, standby activation inputs, keyspace observability metadata, ports, and the destructive exit-wait phase. Bazel metadata is updated for the new starter test target and shard count.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive end-to-end integration tests for external starter-mode TiDB covering config/status endpoints, standby activation, keyspace observability, exit/exit-wait behavior, auto-ID ownership, session-state roundtrips, sysvar/packet enforcement, user/role contracts, and attribute/label-rule checks; tests are CI-ready with sharding/flaky support and exported envs for downstream suites.
* **Documentation**
  * Added runner usage, prerequisites, options, environment variables, port defaults, and activation/standby/exit semantics.
* **Chores**
  * Added a Make target to invoke the starter-mode test runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->