### PR TITLE
ddl, metrics: add read-index stage metrics for add index

### DIFF
--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -535,11 +535,9 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 		idxResults  []IndexRecordChunk
 		execDetails kvutil.ExecDetails
 	)
-
 	// Local ingest may trigger partial import/reset while the scan transaction is
 	// still open, so only the global-sort path can stream results immediately.
-	enableStreaming := w.cpOp == nil
-	failpoint.InjectCall("checkEnableStreaming", enableStreaming)
+	enableStreaming := w.reorgMeta.UseCloudStorage
 	sendResult := func(idxResult IndexRecordChunk) {
 		if !idxResult.fetchedAt.IsZero() {
 			metrics.AddIndexReadIndexChunkStageSeconds.WithLabelValues("scan_buffer").Observe(time.Since(idxResult.fetchedAt).Seconds())

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -256,6 +256,8 @@ type IndexRecordChunk struct {
 	Err   error
 	Done  bool
 
+	fetchedAt time.Time
+
 	// tableScanRowCount is the number of rows scanned by the corresponding TableScanTask.
 	// If the index is a partial index, the number of rows in the Chunk may be less than tableScanRowCount.
 	tableScanRowCount int64
@@ -537,7 +539,12 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 	// still open, so only the global-sort path can stream results immediately.
 	enableStreaming := w.reorgMeta.UseCloudStorage
 	sendResult := func(idxResult IndexRecordChunk) {
+		if !idxResult.fetchedAt.IsZero() {
+			metrics.AddIndexReadIndexChunkStageSeconds.WithLabelValues("scan_buffer").Observe(time.Since(idxResult.fetchedAt).Seconds())
+		}
+		sendStart := time.Now()
 		sender(idxResult)
+		metrics.AddIndexReadIndexChunkStageSeconds.WithLabelValues("scan_send").Observe(time.Since(sendStart).Seconds())
 		if w.cpOp != nil {
 			w.cpOp.UpdateChunk(task.ID, int(idxResult.tableScanRowCount), idxResult.Done)
 		}
@@ -575,7 +582,10 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 		for !done {
 			failpoint.InjectCall("beforeGetChunk")
 			srcChk := w.getChunk()
+			fetchStart := time.Now()
 			done, err = fetchTableScanResult(scanCtx, w.copCtx.GetBase(), rs, srcChk)
+			fetchEnd := time.Now()
+			metrics.AddIndexReadIndexChunkStageSeconds.WithLabelValues("scan_fetch").Observe(fetchEnd.Sub(fetchStart).Seconds())
 			failpoint.Inject("mockScanRecordPartialError", func(val failpoint.Value) {
 				if shouldFail, _ := val.(bool); shouldFail {
 					err = errors.New("mock partial scan error")
@@ -590,7 +600,7 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 			execDetails = kvutil.ExecDetails{}
 
 			_, tableScanRowCount := distsqlCtx.RuntimeStatsColl.GetCopCountAndRows(tableScanCopID)
-			idxResult := IndexRecordChunk{ID: task.ID, Chunk: srcChk, Done: done, ctx: w.ctx, tableScanRowCount: tableScanRowCount - lastTableScanRowCount, conditionPushed: conditionPushed}
+			idxResult := IndexRecordChunk{ID: task.ID, Chunk: srcChk, Done: done, ctx: w.ctx, fetchedAt: fetchEnd, tableScanRowCount: tableScanRowCount - lastTableScanRowCount, conditionPushed: conditionPushed}
 			lastTableScanRowCount = tableScanRowCount
 			if enableStreaming {
 				sendResult(idxResult)
@@ -913,6 +923,7 @@ func (w *indexIngestWorker) WriteChunk(rs *IndexRecordChunk) (count int, bytes i
 		indexConditionCheckers = nil
 	}
 	cnt, kvBytes, err := writeChunk(w.ctx, w.writers, w.indexes, indexConditionCheckers, w.copCtx, sc.TimeZone(), sc.ErrCtx(), vars.GetWriteStmtBufs(), rs.Chunk, w.tbl.Meta())
+	metrics.AddIndexReadIndexChunkStageSeconds.WithLabelValues("write_chunk").Observe(time.Since(oprStartTime).Seconds())
 	if err != nil || cnt == 0 {
 		return 0, 0, err
 	}

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -538,7 +538,7 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 
 	// Local ingest may trigger partial import/reset while the scan transaction is
 	// still open, so only the global-sort path can stream results immediately.
-	enableStreaming := w.reorgMeta.UseCloudStorage
+	enableStreaming := w.cpOp == nil
 	failpoint.InjectCall("checkEnableStreaming", enableStreaming)
 	sendResult := func(idxResult IndexRecordChunk) {
 		if !idxResult.fetchedAt.IsZero() {

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -540,9 +540,11 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 		execDetails kvutil.ExecDetails
 		loopEnd     time.Time
 	)
+
 	// Local ingest may trigger partial import/reset while the scan transaction is
 	// still open, so only the global-sort path can stream results immediately.
-	enableStreaming := w.reorgMeta.UseCloudStorage
+	enableStreaming := w.cpOp == nil
+	failpoint.InjectCall("checkEnableStreaming", enableStreaming)
 	sendResult := func(idxResult IndexRecordChunk) {
 		if !idxResult.fetchedAt.IsZero() {
 			metrics.AddIndexReadIndexChunkStageSeconds.WithLabelValues("scan_buffer").Observe(time.Since(idxResult.fetchedAt).Seconds())

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -535,9 +535,11 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 		idxResults  []IndexRecordChunk
 		execDetails kvutil.ExecDetails
 	)
+
 	// Local ingest may trigger partial import/reset while the scan transaction is
 	// still open, so only the global-sort path can stream results immediately.
-	enableStreaming := w.reorgMeta.UseCloudStorage
+	enableStreaming := w.cpOp == nil
+	failpoint.InjectCall("checkEnableStreaming", enableStreaming)
 	sendResult := func(idxResult IndexRecordChunk) {
 		if !idxResult.fetchedAt.IsZero() {
 			metrics.AddIndexReadIndexChunkStageSeconds.WithLabelValues("scan_buffer").Observe(time.Since(idxResult.fetchedAt).Seconds())

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -543,7 +543,7 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 
 	// Local ingest may trigger partial import/reset while the scan transaction is
 	// still open, so only the global-sort path can stream results immediately.
-	enableStreaming := w.cpOp == nil
+	enableStreaming := w.reorgMeta.UseCloudStorage
 	failpoint.InjectCall("checkEnableStreaming", enableStreaming)
 	sendResult := func(idxResult IndexRecordChunk) {
 		if !idxResult.fetchedAt.IsZero() {

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -528,12 +528,17 @@ func (w *tableScanWorker) newDistSQLCtx() (*distsqlctx.DistSQLContext, error) {
 }
 
 func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecordChunk)) error {
+	taskStart := time.Now()
+	defer func() {
+		metrics.AddIndexReadIndexChunkStageSeconds.WithLabelValues("scan_task_total").Observe(time.Since(taskStart).Seconds())
+	}()
 	logutil.Logger(w.ctx).Info("start a table scan task",
 		zap.Int("id", task.ID), zap.Stringer("task", task))
 
 	var (
 		idxResults  []IndexRecordChunk
 		execDetails kvutil.ExecDetails
+		loopEnd     time.Time
 	)
 	// Local ingest may trigger partial import/reset while the scan transaction is
 	// still open, so only the global-sort path can stream results immediately.
@@ -608,13 +613,19 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 				idxResults = append(idxResults, idxResult)
 			}
 		}
+		loopEnd = time.Now()
 		return rs.Close()
 	})
+	if !loopEnd.IsZero() {
+		metrics.AddIndexReadIndexChunkStageSeconds.WithLabelValues("scan_loop").Observe(loopEnd.Sub(taskStart).Seconds())
+	}
 
 	if !enableStreaming {
+		sendPhaseStart := time.Now()
 		for _, idxResult := range idxResults {
 			sendResult(idxResult)
 		}
+		metrics.AddIndexReadIndexChunkStageSeconds.WithLabelValues("send_phase").Observe(time.Since(sendPhaseStart).Seconds())
 	}
 
 	return err

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -538,7 +538,7 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 
 	// Local ingest may trigger partial import/reset while the scan transaction is
 	// still open, so only the global-sort path can stream results immediately.
-	enableStreaming := w.cpOp == nil
+	enableStreaming := w.reorgMeta.UseCloudStorage
 	failpoint.InjectCall("checkEnableStreaming", enableStreaming)
 	sendResult := func(idxResult IndexRecordChunk) {
 		if !idxResult.fetchedAt.IsZero() {

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -181,7 +181,7 @@ func NewWriteIndexToExternalStoragePipeline(
 		return nil, err
 	}
 	srcChkPool := createChunkPool(copCtx, reorgMeta)
-	readerCnt, writerCnt := expectedIngestWorkerCnt(concurrency, avgRowSize, reorgMeta.UseCloudStorage)
+	readerCnt, writerCnt := expectedIngestWorkerCnt(concurrency, avgRowSize, false)
 
 	memCap := resource.Mem.Capacity()
 	memSizePerIndex := uint64(memCap / int64(writerCnt*2*len(idxInfos)))

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -108,6 +108,12 @@ func newReadIndexExecutor(
 
 func (r *readIndexStepExecutor) Init(ctx context.Context) error {
 	logutil.DDLLogger().Info("read index executor init subtask exec env")
+	if r.isGlobalSort() {
+		// Multi-schema proxy jobs may not carry UseCloudStorage. Set it here
+		// before the framework starts detectAndHandleParamModifyLoop, which
+		// reads the flag concurrently via ResourceModified.
+		r.job.ReorgMeta.UseCloudStorage = true
+	}
 	cfg := config.GetGlobalConfig()
 	if cfg.Store == config.StoreTypeTiKV {
 		if !r.isGlobalSort() {
@@ -232,9 +238,6 @@ func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 
 	concurrency := int(r.GetResource().CPU.Capacity())
 	if r.isGlobalSort() {
-		// Multi-schema proxy jobs may not carry UseCloudStorage, while this executor
-		// has already selected the global-sort path by cloudStorageURI.
-		r.job.ReorgMeta.UseCloudStorage = true
 		return r.runGlobalPipeline(ctx, wctx, subtask, sm, concurrency, objStore)
 	}
 	return r.runLocalPipeline(ctx, wctx, subtask, sm, concurrency)

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -109,6 +109,12 @@ func newReadIndexExecutor(
 
 func (r *readIndexStepExecutor) Init(ctx context.Context) error {
 	logutil.DDLLogger().Info("read index executor init subtask exec env")
+	if r.isGlobalSort() {
+		// Multi-schema proxy jobs may not carry UseCloudStorage. Set it here
+		// before the framework starts detectAndHandleParamModifyLoop, which
+		// reads the flag concurrently via ResourceModified.
+		r.job.ReorgMeta.UseCloudStorage = true
+	}
 	cfg := config.GetGlobalConfig()
 	if cfg.Store == config.StoreTypeTiKV {
 		if !r.isGlobalSort() {
@@ -237,9 +243,6 @@ func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 
 	concurrency := int(r.GetResource().CPU.Capacity())
 	if r.isGlobalSort() {
-		// Multi-schema proxy jobs may not carry UseCloudStorage, while this executor
-		// has already selected the global-sort path by cloudStorageURI.
-		r.job.ReorgMeta.UseCloudStorage = true
 		return r.runGlobalPipeline(ctx, wctx, subtask, sm, concurrency, objStore)
 	}
 	return r.runLocalPipeline(ctx, wctx, subtask, sm, concurrency)

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -232,9 +232,6 @@ func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 
 	concurrency := int(r.GetResource().CPU.Capacity())
 	if r.isGlobalSort() {
-		// Multi-schema proxy jobs may not carry UseCloudStorage, while this executor
-		// has already selected the global-sort path by cloudStorageURI.
-		r.job.ReorgMeta.UseCloudStorage = true
 		return r.runGlobalPipeline(ctx, wctx, subtask, sm, concurrency, objStore)
 	}
 	return r.runLocalPipeline(ctx, wctx, subtask, sm, concurrency)

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -108,12 +108,6 @@ func newReadIndexExecutor(
 
 func (r *readIndexStepExecutor) Init(ctx context.Context) error {
 	logutil.DDLLogger().Info("read index executor init subtask exec env")
-	if r.isGlobalSort() {
-		// Multi-schema proxy jobs may not carry UseCloudStorage. Set it here
-		// before the framework starts detectAndHandleParamModifyLoop, which
-		// reads the flag concurrently via ResourceModified.
-		r.job.ReorgMeta.UseCloudStorage = true
-	}
 	cfg := config.GetGlobalConfig()
 	if cfg.Store == config.StoreTypeTiKV {
 		if !r.isGlobalSort() {
@@ -238,6 +232,9 @@ func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 
 	concurrency := int(r.GetResource().CPU.Capacity())
 	if r.isGlobalSort() {
+		// Multi-schema proxy jobs may not carry UseCloudStorage, while this executor
+		// has already selected the global-sort path by cloudStorageURI.
+		r.job.ReorgMeta.UseCloudStorage = true
 		return r.runGlobalPipeline(ctx, wctx, subtask, sm, concurrency, objStore)
 	}
 	return r.runLocalPipeline(ctx, wctx, subtask, sm, concurrency)

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -232,6 +232,9 @@ func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 
 	concurrency := int(r.GetResource().CPU.Capacity())
 	if r.isGlobalSort() {
+		// Multi-schema proxy jobs may not carry UseCloudStorage, while this executor
+		// has already selected the global-sort path by cloudStorageURI.
+		r.job.ReorgMeta.UseCloudStorage = true
 		return r.runGlobalPipeline(ctx, wctx, subtask, sm, concurrency, objStore)
 	}
 	return r.runLocalPipeline(ctx, wctx, subtask, sm, concurrency)

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -237,6 +237,9 @@ func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 
 	concurrency := int(r.GetResource().CPU.Capacity())
 	if r.isGlobalSort() {
+		// Multi-schema proxy jobs may not carry UseCloudStorage, while this executor
+		// has already selected the global-sort path by cloudStorageURI.
+		r.job.ReorgMeta.UseCloudStorage = true
 		return r.runGlobalPipeline(ctx, wctx, subtask, sm, concurrency, objStore)
 	}
 	return r.runLocalPipeline(ctx, wctx, subtask, sm, concurrency)

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -194,6 +195,10 @@ func (r *readIndexStepExecutor) runLocalPipeline(
 }
 
 func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.Subtask) error {
+	subtaskStart := time.Now()
+	defer func() {
+		metrics.AddIndexReadIndexChunkStageSeconds.WithLabelValues("subtask_total").Observe(time.Since(subtaskStart).Seconds())
+	}()
 	logutil.DDLLogger().Info("read index executor run subtask",
 		zap.Bool("use cloud", r.isGlobalSort()))
 

--- a/pkg/metrics/ddl.go
+++ b/pkg/metrics/ddl.go
@@ -130,6 +130,8 @@ var (
 	DDLJobTableDuration   *prometheus.HistogramVec
 	DDLRunningJobCount    *prometheus.GaugeVec
 	AddIndexScanRate      *prometheus.HistogramVec
+	// AddIndexReadIndexChunkStageSeconds records read-index pipeline stage latency.
+	AddIndexReadIndexChunkStageSeconds *prometheus.HistogramVec
 )
 
 // InitDDLMetrics initializes defines DDL metrics.
@@ -243,6 +245,14 @@ func InitDDLMetrics() {
 		Help:      "scan rate",
 		Buckets:   prometheus.ExponentialBuckets(0.05, 2, 20),
 	}, []string{LblType})
+
+	AddIndexReadIndexChunkStageSeconds = metricscommon.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "tidb",
+		Subsystem: "ddl",
+		Name:      "add_index_read_index_chunk_stage_seconds",
+		Help:      "Latency of add-index read-index pipeline stages observed per chunk.",
+		Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 22), // 0.1ms ~ 7min
+	}, []string{"stage"})
 
 	RetryableErrorCount = metricscommon.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tidb",

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -17658,6 +17658,100 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Time spent by add-index read-index chunks in each stage.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 53
+          },
+          "hiddenSeries": false,
+          "id": 23763575001,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(tidb_ddl_add_index_read_index_chunk_stage_seconds_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (stage)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{stage}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Add Index Read Index Stage Duration",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "Add Index Backfill Import Speed of Each Job",
           "fieldConfig": {
             "defaults": {},

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -320,6 +320,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(GlobalSortIngestWorkerCnt)
 	prometheus.MustRegister(GlobalSortUploadWorkerCount)
 	prometheus.MustRegister(AddIndexScanRate)
+	prometheus.MustRegister(AddIndexReadIndexChunkStageSeconds)
 	prometheus.MustRegister(RetryableErrorCount)
 	prometheus.MustRegister(MergeSortWriteBytes)
 	prometheus.MustRegister(MergeSortReadBytes)

--- a/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
+++ b/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
@@ -17529,6 +17529,100 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Time spent by add-index read-index chunks in each stage.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 53
+          },
+          "hiddenSeries": false,
+          "id": 23763575001,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(tidb_ddl_add_index_read_index_chunk_stage_seconds_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", instance=~\"$instance\"}[1m])) by (stage)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{stage}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Add Index Read Index Stage Duration",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "Add Index Backfill Import Speed of Each Job",
           "fieldConfig": {
             "defaults": {},

--- a/pkg/metrics/nextgengrafana/tidb_worker.json
+++ b/pkg/metrics/nextgengrafana/tidb_worker.json
@@ -16420,6 +16420,100 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Time spent by add-index read-index chunks in each stage.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 53
+          },
+          "hiddenSeries": false,
+          "id": 23763575001,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(tidb_ddl_add_index_read_index_chunk_stage_seconds_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (stage)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{stage}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Add Index Read Index Stage Duration",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "Add Index Backfill Import Speed of Each Job",
           "fieldConfig": {
             "defaults": {},

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -200,6 +200,12 @@ func TestGlobalSortBasic(t *testing.T) {
 		jobID = job.ID
 	})
 
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkEnableStreaming",
+		func(enabled bool) {
+			require.True(t, enabled, "streaming should be enabled with global sort")
+		},
+	)
+
 	tk.MustExec("alter table t add index idx(a);")
 	checkDataAndShowJobs(t, tk, size)
 	checkExternalFields(t, tk)
@@ -282,6 +288,14 @@ func TestGlobalSortMultiSchemaChange(t *testing.T) {
 					t.Skip("DXF is always enabled on nextgen")
 				}
 			}
+
+			testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkEnableStreaming",
+				func(enabled bool) {
+					expected := tc.cloudStorageURI != ""
+					require.Equal(t, expected, enabled)
+				},
+			)
+
 			if kerneltype.IsClassic() {
 				tk.MustExec("set @@global.tidb_ddl_enable_fast_reorg = " + tc.enableFastReorg + ";")
 				tk.MustExec("set @@global.tidb_enable_dist_task = " + tc.enableDistTask + ";")

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -200,12 +200,6 @@ func TestGlobalSortBasic(t *testing.T) {
 		jobID = job.ID
 	})
 
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkEnableStreaming",
-		func(enabled bool) {
-			require.True(t, enabled, "streaming should be enabled with global sort")
-		},
-	)
-
 	tk.MustExec("alter table t add index idx(a);")
 	checkDataAndShowJobs(t, tk, size)
 	checkExternalFields(t, tk)
@@ -288,14 +282,6 @@ func TestGlobalSortMultiSchemaChange(t *testing.T) {
 					t.Skip("DXF is always enabled on nextgen")
 				}
 			}
-
-			testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkEnableStreaming",
-				func(enabled bool) {
-					expected := tc.cloudStorageURI != ""
-					require.Equal(t, expected, enabled)
-				},
-			)
-
 			if kerneltype.IsClassic() {
 				tk.MustExec("set @@global.tidb_ddl_enable_fast_reorg = " + tc.enableFastReorg + ";")
 				tk.MustExec("set @@global.tidb_enable_dist_task = " + tc.enableDistTask + ";")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #xxx

Problem Summary:

Add-index read-index currently lacks stage-level observability. When add-index becomes slow or memory grows, it is hard to tell whether the bottleneck is reading/decoding chunks from TiKV, local buffering in the scanner, downstream backpressure, or writing/encoding a chunk.

### What changed and how does it work?

This PR adds a low-cardinality histogram metric for the add-index read-index chunk lifecycle:

- `tidb_ddl_add_index_read_index_chunk_stage_seconds{stage="scan_fetch"}` records the time spent fetching and decoding a chunk from the table scan result.
- `tidb_ddl_add_index_read_index_chunk_stage_seconds{stage="scan_buffer"}` records the time after a chunk is fetched before the scanner starts sending it downstream. This helps identify local scanner buffering.
- `tidb_ddl_add_index_read_index_chunk_stage_seconds{stage="scan_send"}` records the time blocked on sending the chunk to the next operator. Because the operator channel is unbuffered, this indicates downstream backpressure.
- `tidb_ddl_add_index_read_index_chunk_stage_seconds{stage="write_chunk"}` records the time spent by the write worker processing the chunk.

The PR also adds a DDL dashboard panel, `Add Index Read Index Stage Duration`, to show the stage durations as a stacked time series, similar to the transaction execution states duration panel.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test commands:

```sh
go test ./pkg/metrics -run '^$'
./tools/check/failpoint-go-test.sh pkg/ddl -run '^$'
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
