### PR TITLE
store/copr: add timeout for TiCI estimate locate  | tidb-test=42c2474b6e2e1ef3430d07a1743ca7e17fd97acc tiflash=feature-fts tikv=feature-fts

### DIFF
--- a/pkg/store/copr/tici_estimate_count.go
+++ b/pkg/store/copr/tici_estimate_count.go
@@ -27,6 +27,11 @@ import (
 	"github.com/tikv/client-go/v2/tikvrpc"
 )
 
+const (
+	ticiEstimateLocateTimeout         = 5 * time.Minute
+	ticiEstimatePseudoRowCount uint64 = 1000
+)
+
 type ticiEstimateShardGroup struct {
 	addr          string
 	shardInfos    []*coprocessor.ShardInfo
@@ -51,8 +56,13 @@ func (s *Store) EstimateTiCICount(ctx context.Context, req *kv.TiCIEstimateCount
 	}
 
 	kvRanges := req.KeyRanges.AppendSelfTo(nil)
-	locations, err := cache.BatchLocateKeyRanges(ctx, req.TableID, req.IndexID, kvRanges)
+	locateCtx, cancel := context.WithTimeout(ctx, ticiEstimateLocateTimeout)
+	locations, err := cache.BatchLocateKeyRanges(locateCtx, req.TableID, req.IndexID, kvRanges)
+	cancel()
 	if err != nil {
+		if errors.Cause(err) == context.DeadlineExceeded {
+			return ticiEstimatePseudoRowCount, nil
+		}
 		return 0, err
 	}
 	groups, totalUniqueShards := buildTiCIEstimateShardGroups(locations)

--- a/pkg/store/copr/tici_estimate_count_test.go
+++ b/pkg/store/copr/tici_estimate_count_test.go
@@ -15,12 +15,73 @@
 package copr
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 )
+
+type deadlineCaptureTiCIShardClient struct {
+	deadline    time.Time
+	hasDeadline bool
+}
+
+func (m *deadlineCaptureTiCIShardClient) ScanRanges(ctx context.Context, _ int64, _ int64, _ []kv.KeyRange, _ int) ([]*ShardWithAddr, error) {
+	m.deadline, m.hasDeadline = ctx.Deadline()
+	return nil, context.Canceled
+}
+
+func (m *deadlineCaptureTiCIShardClient) Close() {}
+
+func TestEstimateTiCICountUsesFiveMinuteTimeoutForLocate(t *testing.T) {
+	client := &deadlineCaptureTiCIShardClient{}
+	store := &Store{
+		kvStore: &kvStore{
+			TiCIShardCache: NewTiCIShardCache(client),
+		},
+	}
+	startedAt := time.Now()
+
+	_, err := store.EstimateTiCICount(context.Background(), &kv.TiCIEstimateCountRequest{
+		TableID:      1,
+		IndexID:      2,
+		FTSQueryInfo: &tipb.FTSQueryInfo{QueryType: tipb.FTSQueryType_FTSQueryTypeWithScore},
+		KeyRanges: kv.NewNonPartitionedKeyRanges([]kv.KeyRange{
+			{StartKey: []byte("a"), EndKey: []byte("b")},
+		}),
+	}, time.Millisecond)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.True(t, client.hasDeadline)
+	require.GreaterOrEqual(t, client.deadline.Sub(startedAt), 5*time.Minute)
+	require.Less(t, time.Until(client.deadline), 5*time.Minute)
+}
+
+func TestEstimateTiCICountReturnsPseudoCountWhenLocateTimesOut(t *testing.T) {
+	client := &cancelAwareFullTextMockShardClient{wait: time.Second}
+	store := &Store{
+		kvStore: &kvStore{
+			TiCIShardCache: NewTiCIShardCache(client),
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+
+	count, err := store.EstimateTiCICount(ctx, &kv.TiCIEstimateCountRequest{
+		TableID:      1,
+		IndexID:      2,
+		FTSQueryInfo: &tipb.FTSQueryInfo{QueryType: tipb.FTSQueryType_FTSQueryTypeWithScore},
+		KeyRanges: kv.NewNonPartitionedKeyRanges([]kv.KeyRange{
+			{StartKey: []byte("a"), EndKey: []byte("b")},
+		}),
+	}, time.Millisecond)
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), count)
+}
 
 func TestTiCIEstimateCountHelpers(t *testing.T) {
 	t.Run("build shard groups", func(t *testing.T) {

--- a/pkg/store/copr/tici_estimate_count_test.go
+++ b/pkg/store/copr/tici_estimate_count_test.go
@@ -24,42 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type deadlineCaptureTiCIShardClient struct {
-	deadline    time.Time
-	hasDeadline bool
-}
-
-func (m *deadlineCaptureTiCIShardClient) ScanRanges(ctx context.Context, _ int64, _ int64, _ []kv.KeyRange, _ int) ([]*ShardWithAddr, error) {
-	m.deadline, m.hasDeadline = ctx.Deadline()
-	return nil, context.Canceled
-}
-
-func (m *deadlineCaptureTiCIShardClient) Close() {}
-
-func TestEstimateTiCICountUsesFiveMinuteTimeoutForLocate(t *testing.T) {
-	client := &deadlineCaptureTiCIShardClient{}
-	store := &Store{
-		kvStore: &kvStore{
-			TiCIShardCache: NewTiCIShardCache(client),
-		},
-	}
-	startedAt := time.Now()
-
-	_, err := store.EstimateTiCICount(context.Background(), &kv.TiCIEstimateCountRequest{
-		TableID:      1,
-		IndexID:      2,
-		FTSQueryInfo: &tipb.FTSQueryInfo{QueryType: tipb.FTSQueryType_FTSQueryTypeWithScore},
-		KeyRanges: kv.NewNonPartitionedKeyRanges([]kv.KeyRange{
-			{StartKey: []byte("a"), EndKey: []byte("b")},
-		}),
-	}, time.Millisecond)
-
-	require.ErrorIs(t, err, context.Canceled)
-	require.True(t, client.hasDeadline)
-	require.GreaterOrEqual(t, client.deadline.Sub(startedAt), 5*time.Minute)
-	require.Less(t, time.Until(client.deadline), 5*time.Minute)
-}
-
 func TestEstimateTiCICountReturnsPseudoCountWhenLocateTimesOut(t *testing.T) {
 	client := &cancelAwareFullTextMockShardClient{wait: time.Second}
 	store := &Store{

--- a/pkg/store/copr/tici_estimate_count_test.go
+++ b/pkg/store/copr/tici_estimate_count_test.go
@@ -24,30 +24,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEstimateTiCICountReturnsPseudoCountWhenLocateTimesOut(t *testing.T) {
-	client := &cancelAwareFullTextMockShardClient{wait: time.Second}
-	store := &Store{
-		kvStore: &kvStore{
-			TiCIShardCache: NewTiCIShardCache(client),
-		},
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
-	defer cancel()
-
-	count, err := store.EstimateTiCICount(ctx, &kv.TiCIEstimateCountRequest{
-		TableID:      1,
-		IndexID:      2,
-		FTSQueryInfo: &tipb.FTSQueryInfo{QueryType: tipb.FTSQueryType_FTSQueryTypeWithScore},
-		KeyRanges: kv.NewNonPartitionedKeyRanges([]kv.KeyRange{
-			{StartKey: []byte("a"), EndKey: []byte("b")},
-		}),
-	}, time.Millisecond)
-
-	require.NoError(t, err)
-	require.Equal(t, uint64(1000), count)
-}
-
 func TestTiCIEstimateCountHelpers(t *testing.T) {
+	t.Run("return pseudo count when locate times out", func(t *testing.T) {
+		client := &cancelAwareFullTextMockShardClient{wait: time.Second}
+		store := &Store{
+			kvStore: &kvStore{
+				TiCIShardCache: NewTiCIShardCache(client),
+			},
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+		defer cancel()
+
+		count, err := store.EstimateTiCICount(ctx, &kv.TiCIEstimateCountRequest{
+			TableID:      1,
+			IndexID:      2,
+			FTSQueryInfo: &tipb.FTSQueryInfo{QueryType: tipb.FTSQueryType_FTSQueryTypeWithScore},
+			KeyRanges: kv.NewNonPartitionedKeyRanges([]kv.KeyRange{
+				{StartKey: []byte("a"), EndKey: []byte("b")},
+			}),
+		}, time.Millisecond)
+
+		require.NoError(t, err)
+		require.Equal(t, uint64(1000), count)
+	})
+
 	t.Run("build shard groups", func(t *testing.T) {
 		locations := []*ShardLocation{
 			{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: https://github.com/pingcap-inc/tici/issues/1279

Problem Summary:

`EstimateTiCICount` can spend too long locating TiCI key ranges before sending the estimate request. If locating ranges times out, the caller should get a pseudo estimate instead of failing the estimate path.

### What changed and how does it work?

- Add a 5-minute timeout to the context used by `EstimateTiCICount` when calling `BatchLocateKeyRanges`.
- Return a pseudo estimate count of `1000` when locating ranges hits `context.DeadlineExceeded`.
- Keep non-timeout locate errors returned to the caller.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience for key-range lookups: long-running locate operations now time out gracefully and return a safe fallback estimate instead of failing, reducing query errors and improving stability.
* **Tests**
  * Added a test covering the timeout/fallback behavior to ensure consistent handling of lookup timeouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->