### PR TITLE
planner: tighten full-range fast path for index estimation

### DIFF
--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -1816,31 +1816,34 @@ func TestAnalyzeMVIndex(t *testing.T) {
 	))
 	// 3.2. emulate the background async loading
 	require.NoError(t, h.LoadNeededHistograms(dom.InfoSchema()))
-	// 3.3. now, stats on all indexes should be loaded
+	// 3.3. The chosen MV-index histograms loaded by LoadNeededHistograms now show up
+	// in the partial-stats list; non-MV indexes like ia that aren't used by the chosen
+	// plan are no longer queued for async loading (full-range scans short-circuit
+	// before IndexStatsIsInvalid), so ia stays allEvicted.
 	tk.MustQuery("explain format = brief select /*+ use_index_merge(t, ij_signed) */ * from t where 1 member of (j->'$.signed')").Check(testkit.Rows(
 		"IndexMerge 27.00 root  type: union",
-		"├─IndexRangeScan(Build) 27.00 cop[tikv] table:t, index:ij_signed(cast(json_extract(`j`, _utf8mb4'$.signed') as signed array)) range:[1,1], keep order:false, stats:partial[j:unInitialized]",
-		"└─TableRowIDScan(Probe) 27.00 cop[tikv] table:t keep order:false, stats:partial[j:unInitialized]",
+		"├─IndexRangeScan(Build) 27.00 cop[tikv] table:t, index:ij_signed(cast(json_extract(`j`, _utf8mb4'$.signed') as signed array)) range:[1,1], keep order:false, stats:partial[ia:allEvicted, j:unInitialized]",
+		"└─TableRowIDScan(Probe) 27.00 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, j:unInitialized]",
 	))
 	tk.MustQuery("explain format = brief select /*+ use_index_merge(t, ij_unsigned) */* from t where 1 member of (j->'$.unsigned')").Check(testkit.Rows(
 		"IndexMerge 18.00 root  type: union",
-		"├─IndexRangeScan(Build) 18.00 cop[tikv] table:t, index:ij_unsigned(cast(json_extract(`j`, _utf8mb4'$.unsigned') as unsigned array)) range:[1,1], keep order:false, stats:partial[j:unInitialized]",
-		"└─TableRowIDScan(Probe) 18.00 cop[tikv] table:t keep order:false, stats:partial[j:unInitialized]",
+		"├─IndexRangeScan(Build) 18.00 cop[tikv] table:t, index:ij_unsigned(cast(json_extract(`j`, _utf8mb4'$.unsigned') as unsigned array)) range:[1,1], keep order:false, stats:partial[ia:allEvicted, j:unInitialized]",
+		"└─TableRowIDScan(Probe) 18.00 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, j:unInitialized]",
 	))
 	tk.MustQuery("explain format = brief select /*+ use_index_merge(t, ij_double) */ * from t where 10.01 member of (j->'$.dbl')").Check(testkit.Rows(
 		"TableReader 21.60 root  data:Selection",
 		"└─Selection 21.60 cop[tikv]  json_memberof(cast(10.01, json BINARY), json_extract(test.t.j, \"$.dbl\"))",
-		"  └─TableFullScan 27.00 cop[tikv] table:t keep order:false, stats:partial[j:unInitialized]",
+		"  └─TableFullScan 27.00 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, j:unInitialized]",
 	))
 	tk.MustQuery("explain format = brief select /*+ use_index_merge(t, ij_binary) */ * from t where '1' member of (j->'$.bin')").Check(testkit.Rows(
 		"IndexMerge 14.83 root  type: union",
-		"├─IndexRangeScan(Build) 14.83 cop[tikv] table:t, index:ij_binary(cast(json_extract(`j`, _utf8mb4'$.bin') as binary(50) array)) range:[\"1\",\"1\"], keep order:false, stats:partial[j:unInitialized]",
-		"└─TableRowIDScan(Probe) 14.83 cop[tikv] table:t keep order:false, stats:partial[j:unInitialized]",
+		"├─IndexRangeScan(Build) 14.83 cop[tikv] table:t, index:ij_binary(cast(json_extract(`j`, _utf8mb4'$.bin') as binary(50) array)) range:[\"1\",\"1\"], keep order:false, stats:partial[ia:allEvicted, j:unInitialized]",
+		"└─TableRowIDScan(Probe) 14.83 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, j:unInitialized]",
 	))
 	tk.MustQuery("explain format = brief select /*+ use_index_merge(t, ij_char) */ * from t where '1' member of (j->'$.char')").Check(testkit.Rows(
 		"IndexMerge 13.50 root  type: union",
-		"├─IndexRangeScan(Build) 13.50 cop[tikv] table:t, index:ij_char(cast(json_extract(`j`, _utf8mb4'$.char') as char(50) array)) range:[\"1\",\"1\"], keep order:false, stats:partial[j:unInitialized]",
-		"└─TableRowIDScan(Probe) 13.50 cop[tikv] table:t keep order:false, stats:partial[j:unInitialized]",
+		"├─IndexRangeScan(Build) 13.50 cop[tikv] table:t, index:ij_char(cast(json_extract(`j`, _utf8mb4'$.char') as char(50) array)) range:[\"1\",\"1\"], keep order:false, stats:partial[ia:allEvicted, j:unInitialized]",
+		"└─TableRowIDScan(Probe) 13.50 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, j:unInitialized]",
 	))
 
 	// 3.4. clean up the stats and re-analyze the table

--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -43,6 +43,14 @@ func GetRowCountByIndexRanges(sctx planctx.PlanContext, coll *statistics.HistCol
 	sc := sctx.GetSessionVars().StmtCtx
 	idx := coll.GetIdx(idxID)
 	recordUsedItemStatsStatus(sctx, idx, coll.PhysicalID, idxID)
+	// Fast-path: a full-range scan over a non-MV, non-partial index returns exactly
+	// RealtimeCount regardless of histogram availability, so we can short-circuit
+	// before IndexStatsIsInvalid — which would otherwise queue an unnecessary async
+	// histogram load whenever the index stats are not fully loaded.
+	if idx != nil && canSkipIndexEstimation(idx, indexRanges) {
+		realtimeCnt, _ := coll.GetScaledRealtimeAndModifyCnt(idx)
+		return statistics.DefaultRowEst(float64(realtimeCnt)), nil
+	}
 	if statistics.IndexStatsIsInvalid(sctx, idx, coll, idxID) {
 		if hasColumnStats(sctx, coll, idxCols) && !ranger.HasFullRange(indexRanges, false) {
 			count, maxCount, err = getPseudoRowCountWithPartialStats(sctx, coll, indexRanges, float64(coll.RealtimeCount), idxCols)
@@ -58,9 +66,6 @@ func GetRowCountByIndexRanges(sctx planctx.PlanContext, coll *statistics.HistCol
 		return result, err
 	}
 	realtimeCnt, modifyCount := coll.GetScaledRealtimeAndModifyCnt(idx)
-	if canSkipIndexEstimation(idx, indexRanges) {
-		return statistics.DefaultRowEst(float64(realtimeCnt)), nil
-	}
 	if idx.CMSketch != nil && idx.StatsVer == statistics.Version1 {
 		count, err = getIndexRowCountForStatsV1(sctx, coll, idxID, indexRanges)
 		result = statistics.DefaultRowEst(count)
@@ -608,10 +613,16 @@ func canSkipIndexEstimation(idx *statistics.Index, indexRanges []*ranger.Range) 
 }
 
 // isFullRangeIncludingNulls checks if a single range covers all values including NULLs.
-// Unlike ranger.IsFullRange, this requires the low bound to be NULL (KindNull),
-// not KindMinNotNull, ensuring NULL rows are included in the count.
+// Unlike ranger.IsFullRange, this requires the low bound to be NULL (KindNull) inclusive,
+// not KindMinNotNull and not an exclusive lower bound, so NULL rows are guaranteed to be
+// included in the count.
 func isFullRangeIncludingNulls(ran *ranger.Range) bool {
 	if len(ran.LowVal) != len(ran.HighVal) || len(ran.LowVal) == 0 {
+		return false
+	}
+	// An exclusive bound on NULL (low) or +inf (high) would drop those endpoints
+	// and shrink the range, so the fast path must not apply.
+	if ran.LowExclude || ran.HighExclude {
 		return false
 	}
 	for i := range ran.LowVal {

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -549,29 +549,39 @@ func TestCanSkipIndexEstimation(t *testing.T) {
 	tblInfo := tb.Meta()
 
 	// Use mock stats so Idx2ColUniqueIDs is populated (required by getIndexRowCountForStatsV2).
-	realtimeCount := int64(51) // 50 rows + 1 NULL
+	// 50 distinct non-NULL values + 10 NULL rows, so the not-null range produces a
+	// strictly smaller estimate than RealtimeCount and catches a buggy fast-path that
+	// returns RealtimeCount for [MinNotNull,+inf).
+	const nonNullCount = 50
+	const nullCount = 10
+	realtimeCount := int64(nonNullCount + nullCount)
 	statsTbl := mockStatsTable(tblInfo, realtimeCount)
-	colValues, err := generateIntDatum(1, 51)
+	colValues, err := generateIntDatum(1, nonNullCount)
 	require.NoError(t, err)
 	for i := 1; i <= 2; i++ {
+		colHist := mockStatsHistogram(int64(i), colValues, 1, types.NewFieldType(mysql.TypeLonglong))
+		colHist.NullCount = nullCount
 		statsTbl.SetCol(int64(i), &statistics.Column{
-			Histogram:         *mockStatsHistogram(int64(i), colValues, 1, types.NewFieldType(mysql.TypeLonglong)),
+			Histogram:         *colHist,
 			Info:              tblInfo.Columns[i-1],
 			StatsLoadedStatus: statistics.NewStatsFullLoadStatus(),
 			StatsVer:          2,
 		})
 	}
 	// Index histogram must store encoded key bytes (same as getIndexRowCountForStatsV2 uses for l/r).
-	idxValues := make([]types.Datum, 51)
-	for i := 0; i < 51; i++ {
+	idxValues := make([]types.Datum, nonNullCount)
+	for i := range idxValues {
 		enc, err := codec.EncodeKey(time.UTC, nil, types.NewIntDatum(int64(i)))
 		require.NoError(t, err)
 		idxValues[i].SetBytes(enc)
 	}
+	idxHist := mockStatsHistogram(tblInfo.Indices[0].ID, idxValues, 1, types.NewFieldType(mysql.TypeBlob))
+	idxHist.NullCount = nullCount
 	statsTbl.SetIdx(tblInfo.Indices[0].ID, &statistics.Index{
-		Histogram: *mockStatsHistogram(tblInfo.Indices[0].ID, idxValues, 1, types.NewFieldType(mysql.TypeBlob)),
-		Info:      tblInfo.Indices[0],
-		StatsVer:  2,
+		Histogram:         *idxHist,
+		Info:              tblInfo.Indices[0],
+		StatsLoadedStatus: statistics.NewStatsFullLoadStatus(),
+		StatsVer:          2,
 	})
 	generateMapsForMockStatsTbl(statsTbl)
 
@@ -586,13 +596,14 @@ func TestCanSkipIndexEstimation(t *testing.T) {
 	require.Equal(t, float64(realtimeCount), countResult.Est,
 		"full range [NULL,+inf) should use fast path and return RealtimeCount")
 
-	// Full range excluding NULLs [MinNotNull, +inf) should NOT use fast path.
-	// It goes through histogram estimation.
+	// Full range excluding NULLs [MinNotNull, +inf) must NOT use the fast path.
+	// With nullCount > 0, the histogram estimate must be strictly below RealtimeCount;
+	// equality would mean the fast path was wrongly taken.
 	fullNotNullRanges := ranger.FullNotNullRange()
 	countResult2, err := cardinality.GetRowCountByIndexRanges(sctx, &statsTbl.HistColl, idxID, fullNotNullRanges, nil)
 	require.NoError(t, err)
-	require.LessOrEqual(t, countResult2.Est, float64(realtimeCount),
-		"full not-null range excludes NULLs, estimate should be <= RealtimeCount")
+	require.Less(t, countResult2.Est, float64(realtimeCount),
+		"full not-null range excludes %d NULL row(s), estimate must be < RealtimeCount", nullCount)
 
 	// Bounded range should NOT use fast path.
 	boundedRanges := getRange(1, 10)
@@ -600,6 +611,21 @@ func TestCanSkipIndexEstimation(t *testing.T) {
 	require.NoError(t, err)
 	require.Less(t, countResult3.Est, float64(realtimeCount),
 		"bounded range should use histogram estimation, not fast path")
+
+	// (NULL, +inf) with an exclusive lower bound drops the NULL endpoint, so the
+	// fast path must not apply — otherwise the NULL row would be silently counted.
+	var nullDatum types.Datum
+	nullDatum.SetNull()
+	exclusiveNullRanges := []*ranger.Range{{
+		LowVal:     []types.Datum{nullDatum},
+		HighVal:    []types.Datum{types.MaxValueDatum()},
+		LowExclude: true,
+		Collators:  collate.GetBinaryCollatorSlice(1),
+	}}
+	countResult4, err := cardinality.GetRowCountByIndexRanges(sctx, &statsTbl.HistColl, idxID, exclusiveNullRanges, nil)
+	require.NoError(t, err)
+	require.Less(t, countResult4.Est, float64(realtimeCount),
+		"exclusive lower bound on NULL must drop the NULL row, estimate must be < RealtimeCount")
 }
 
 func TestEstimationForUnknownValuesAfterModify(t *testing.T) {

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -575,26 +575,47 @@ func TestCanSkipIndexEstimation(t *testing.T) {
 		require.NoError(t, err)
 		idxValues[i].SetBytes(enc)
 	}
+	// Mark the index as NOT fully loaded so we can prove the fast path runs before
+	// IndexStatsIsInvalid: under a not-fully-loaded status, the slow path would queue
+	// this index into AsyncLoadHistogramNeededItems, and the assertion below would
+	// fail if canSkipIndexEstimation no longer short-circuited the call.
 	idxHist := mockStatsHistogram(tblInfo.Indices[0].ID, idxValues, 1, types.NewFieldType(mysql.TypeBlob))
 	idxHist.NullCount = nullCount
 	statsTbl.SetIdx(tblInfo.Indices[0].ID, &statistics.Index{
 		Histogram:         *idxHist,
 		Info:              tblInfo.Indices[0],
-		StatsLoadedStatus: statistics.NewStatsFullLoadStatus(),
+		StatsLoadedStatus: statistics.NewStatsAllEvictedStatus(),
 		StatsVer:          2,
 	})
 	generateMapsForMockStatsTbl(statsTbl)
 
 	idxID := tblInfo.Indices[0].ID
-	sctx := mock.NewContext()
+	// Use the testkit's real session so recordUsedItemStatsStatus can resolve the
+	// table via domain.GetDomain(sctx).InfoSchema(); the bare mock.NewContext() has
+	// no domain registered and would panic now that the index is not FullLoad.
+	sctx := tk.Session().GetPlanCtx()
+	idxItem := model.TableItemID{TableID: tblInfo.ID, ID: idxID, IsIndex: true}
+	hasAsyncLoadEntry := func() bool {
+		for _, item := range asyncload.AsyncLoadHistogramNeededItems.AllItems() {
+			if item.TableItemID == idxItem {
+				return true
+			}
+		}
+		return false
+	}
 
 	// Full range including NULLs [NULL, +inf) triggers canSkipIndexEstimation fast path.
-	// Result should equal RealtimeCount exactly (no histogram estimation).
+	// Result should equal RealtimeCount exactly (no histogram estimation), and the fast
+	// path must run before IndexStatsIsInvalid so the evicted index is NOT queued for
+	// async load — otherwise the optimization would still pay for the wasted I/O.
+	asyncload.AsyncLoadHistogramNeededItems.Delete(idxItem)
 	fullRanges := ranger.FullRange()
 	countResult, err := cardinality.GetRowCountByIndexRanges(sctx, &statsTbl.HistColl, idxID, fullRanges, nil)
 	require.NoError(t, err)
 	require.Equal(t, float64(realtimeCount), countResult.Est,
 		"full range [NULL,+inf) should use fast path and return RealtimeCount")
+	require.False(t, hasAsyncLoadEntry(),
+		"fast path must short-circuit before IndexStatsIsInvalid and not queue the evicted index for async load")
 
 	// Full range excluding NULLs [MinNotNull, +inf) must NOT use the fast path.
 	// With nullCount > 0, the histogram estimate must be strictly below RealtimeCount;


### PR DESCRIPTION
Two fixes raised in the release-8.5 cherry-pick review (PR #66695) that also apply on master:

1. Move canSkipIndexEstimation ahead of IndexStatsIsInvalid so the full-range fast path short-circuits before IndexStatsIsInvalid queues an unnecessary async histogram load when the index stats are not fully loaded. Guarded by idx != nil so the pseudo fallback is preserved.

2. Reject ranges with LowExclude or HighExclude in isFullRangeIncludingNulls. A range like (NULL, +inf) drops the NULL endpoint and shrinks the result, so it must not trigger the fast path.

Tighten TestCanSkipIndexEstimation to actually exercise these cases: model 10 NULL rows in the index histogram (NullCount=10) so the not-null estimate is strictly below RealtimeCount, switch the assertion to require.Less, and add a case covering (NULL, +inf) with an exclusive lower bound.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #64791 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cardinality estimation: planner now short-circuits earlier for eligible indexes and correctly rejects ranges with exclusive endpoints, preventing incorrect fast-path use and ensuring counts exclude endpoints like NULL when appropriate.

* **Tests**
  * Tightened tests and updated plan expectations to verify the fast-path only applies to NULL-inclusive full ranges and async stats-loading behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->