### PR TITLE
WIP: statistics: skip stats cache update when incoming table is older

### DIFF
--- a/pkg/statistics/handle/cache/BUILD.bazel
+++ b/pkg/statistics/handle/cache/BUILD.bazel
@@ -45,7 +45,7 @@ go_test(
     ],
     embed = [":cache"],
     flaky = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         "//pkg/config",
         "//pkg/statistics",

--- a/pkg/statistics/handle/cache/statscache_test.go
+++ b/pkg/statistics/handle/cache/statscache_test.go
@@ -128,20 +128,18 @@ func TestUpdateSkipsOlderTableVersion(t *testing.T) {
 		c: newMockStatsCacheInner(current),
 	}
 
-	// Pin the current behavior: the older snapshot overwrites the newer cached entry on both the
-	// Update and CopyAndUpdate paths. The next commit adds the guard and flips these expectations.
 	cache.Update([]*statistics.Table{stale}, nil, false)
 
 	got, ok := cache.c.Get(current.PhysicalID)
 	require.True(t, ok)
-	require.Equal(t, uint64(1), got.Version)
-	require.Equal(t, int64(640), got.RealtimeCount)
+	require.Equal(t, uint64(2), got.Version)
+	require.Equal(t, int64(1280), got.RealtimeCount)
 
 	copied := cache.CopyAndUpdate([]*statistics.Table{stale}, nil)
 	got, ok = copied.c.Get(current.PhysicalID)
 	require.True(t, ok)
-	require.Equal(t, uint64(1), got.Version)
-	require.Equal(t, int64(640), got.RealtimeCount)
+	require.Equal(t, uint64(2), got.Version)
+	require.Equal(t, int64(1280), got.RealtimeCount)
 }
 
 func TestPutSkipsOlderTableVersion(t *testing.T) {
@@ -155,14 +153,14 @@ func TestPutSkipsOlderTableVersion(t *testing.T) {
 	}
 
 	// Put is the path used by targeted InitStats/InitStatsLite (e.g. REFRESH STATS) to publish a
-	// freshly read table into the live cache. Pin the current behavior: the older snapshot
-	// overwrites the newer analyze result for the same physical table. The next commit guards it.
+	// freshly read table into the live cache. A stale snapshot must not overwrite a newer analyze
+	// result for the same physical table.
 	cache.Put(stale.PhysicalID, stale)
 
 	got, ok := cache.c.Get(current.PhysicalID)
 	require.True(t, ok)
-	require.Equal(t, uint64(1), got.Version)
-	require.Equal(t, int64(640), got.RealtimeCount)
+	require.Equal(t, uint64(2), got.Version)
+	require.Equal(t, int64(1280), got.RealtimeCount)
 }
 
 func newMockTable(t *testing.T, physicalID int64, pseudo bool, realtimeCount, modifyCount int64, analyzeVersion uint64) *statistics.Table {

--- a/pkg/statistics/handle/cache/statscache_test.go
+++ b/pkg/statistics/handle/cache/statscache_test.go
@@ -118,6 +118,53 @@ func TestUpdateStatsHealthyMetrics(t *testing.T) {
 	}
 }
 
+func TestUpdateSkipsOlderTableVersion(t *testing.T) {
+	current := newMockTable(t, 1, false, 1280, 0, 1)
+	current.Version = 2
+	stale := newMockTable(t, 1, false, 640, 0, 1)
+	stale.Version = 1
+
+	cache := &StatsCache{
+		c: newMockStatsCacheInner(current),
+	}
+
+	// Pin the current behavior: the older snapshot overwrites the newer cached entry on both the
+	// Update and CopyAndUpdate paths. The next commit adds the guard and flips these expectations.
+	cache.Update([]*statistics.Table{stale}, nil, false)
+
+	got, ok := cache.c.Get(current.PhysicalID)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), got.Version)
+	require.Equal(t, int64(640), got.RealtimeCount)
+
+	copied := cache.CopyAndUpdate([]*statistics.Table{stale}, nil)
+	got, ok = copied.c.Get(current.PhysicalID)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), got.Version)
+	require.Equal(t, int64(640), got.RealtimeCount)
+}
+
+func TestPutSkipsOlderTableVersion(t *testing.T) {
+	current := newMockTable(t, 1, false, 1280, 0, 1)
+	current.Version = 2
+	stale := newMockTable(t, 1, false, 640, 0, 1)
+	stale.Version = 1
+
+	cache := &StatsCache{
+		c: newMockStatsCacheInner(current),
+	}
+
+	// Put is the path used by targeted InitStats/InitStatsLite (e.g. REFRESH STATS) to publish a
+	// freshly read table into the live cache. Pin the current behavior: the older snapshot
+	// overwrites the newer analyze result for the same physical table. The next commit guards it.
+	cache.Put(stale.PhysicalID, stale)
+
+	got, ok := cache.c.Get(current.PhysicalID)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), got.Version)
+	require.Equal(t, int64(640), got.RealtimeCount)
+}
+
 func newMockTable(t *testing.T, physicalID int64, pseudo bool, realtimeCount, modifyCount int64, analyzeVersion uint64) *statistics.Table {
 	hist := statistics.NewHistColl(physicalID, realtimeCount, modifyCount, 0, 0)
 	table := &statistics.Table{
@@ -162,15 +209,17 @@ func (m *mockStatsCacheInner) Values() []*statistics.Table {
 }
 
 func (m *mockStatsCacheInner) Get(id int64) (*statistics.Table, bool) {
-	panic("not implemented")
+	tbl, ok := m.items[id]
+	return tbl, ok
 }
 
 func (m *mockStatsCacheInner) Put(id int64, tbl *statistics.Table) bool {
-	panic("not implemented")
+	m.items[id] = tbl
+	return true
 }
 
 func (m *mockStatsCacheInner) Del(id int64) {
-	panic("not implemented")
+	delete(m.items, id)
 }
 
 func (m *mockStatsCacheInner) Cost() int64 {
@@ -178,11 +227,15 @@ func (m *mockStatsCacheInner) Cost() int64 {
 }
 
 func (m *mockStatsCacheInner) Len() int {
-	panic("not implemented")
+	return len(m.items)
 }
 
 func (m *mockStatsCacheInner) Copy() internal.StatsCacheInner {
-	panic("not implemented")
+	copied := make(map[int64]*statistics.Table, len(m.items))
+	for id, tbl := range m.items {
+		copied[id] = tbl
+	}
+	return &mockStatsCacheInner{items: copied}
 }
 
 func (*mockStatsCacheInner) SetCapacity(int64) {

--- a/pkg/statistics/handle/cache/statscacheinner.go
+++ b/pkg/statistics/handle/cache/statscacheinner.go
@@ -95,6 +95,10 @@ func (sc *StatsCache) putCache(id int64, t *statistics.Table) bool {
 
 // Put puts the table statistics to the cache.
 func (sc *StatsCache) put(id int64, t *statistics.Table) {
+	// An older snapshot must not overwrite a newer one for the same physical table.
+	if sc.shouldSkipTableUpdate(t) {
+		return
+	}
 	i := 1
 	for {
 		// retry if the cache is full
@@ -143,11 +147,22 @@ func (sc *StatsCache) Version() uint64 {
 	return sc.maxTblStatsVer.Load()
 }
 
+// shouldSkipTableUpdate reports whether the incoming table stats are older than
+// what is already cached for the same physical table. Skipping the update prevents
+// a stale write from overwriting a newer analyze result.
+func (sc *StatsCache) shouldSkipTableUpdate(tbl *statistics.Table) bool {
+	current, ok := sc.c.Get(tbl.PhysicalID)
+	return ok && current != nil && current.Version > tbl.Version
+}
+
 // CopyAndUpdate copies a new cache and updates the new statistics table cache. It is only used in the COW mode.
 func (sc *StatsCache) CopyAndUpdate(tables []*statistics.Table, deletedIDs []int64) *StatsCache {
 	newCache := &StatsCache{c: sc.c.Copy()}
 	newCache.maxTblStatsVer.Store(sc.maxTblStatsVer.Load())
 	for _, tbl := range tables {
+		if newCache.shouldSkipTableUpdate(tbl) {
+			continue
+		}
 		id := tbl.PhysicalID
 		newCache.c.Put(id, tbl)
 	}
@@ -167,6 +182,9 @@ func (sc *StatsCache) CopyAndUpdate(tables []*statistics.Table, deletedIDs []int
 // Update updates the new statistics table cache.
 func (sc *StatsCache) Update(tables []*statistics.Table, deletedIDs []int64, skipMoveForwardStatsCache bool) {
 	for _, tbl := range tables {
+		if sc.shouldSkipTableUpdate(tbl) {
+			continue
+		}
 		id := tbl.PhysicalID
 		metrics.UpdateCounter.Inc()
 		sc.c.Put(id, tbl)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #67355

Problem Summary:

`TestSubsetIdxCardinality` can fail with `IndexFullScan 640.00` instead of `1280.00`.

The root cause is that `StatsCache` can accept an older table stats object and overwrite newer analyzed stats already stored in memory. The observed flake comes from async histogram loading, but the same stale-overwrite risk also exists in the `StatsCache.Put` path used by targeted stats refreshes.

### What changed and how does it work?

This PR adds a version guard before stats cache writes. If the cache already has stats for the same physical table with a newer `Version`, the incoming older table is skipped.

The guard covers both write paths:

- `Update` / `CopyAndUpdate`, used by async and sync histogram loading.
- `StatsCache.Put`, used by targeted `InitStats` / `InitStatsLite` refreshes such as `REFRESH STATS <table>`.

Skipping the stale write keeps the newer analyze result in memory. If the skipped table is still needed later, its histogram can be loaded lazily on the next query.

This also prevents a pseudo table with `Version 0` from replacing a concurrently loaded analyzed table on a cache miss.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Added cache-layer regression tests for both paths:

- `TestUpdateSkipsOlderTableVersion`
- `TestPutSkipsOlderTableVersion`

Each test fails without the guard and passes with it.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a race where stale table stats could overwrite newer analyzed stats in the in-memory stats cache.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale table statistics from overwriting newer cached data, preserving latest counts and versions during both direct updates and copy-on-write flows.

* **Tests**
  * Added unit tests verifying outdated table-version updates are skipped and newest statistics are preserved across update paths.

* **Chores**
  * Increased test shard count to improve CI test distribution and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
