### PR TITLE
executor: reduce memTracker.Consume call frequency in StreamAggExec 

### DIFF
--- a/pkg/executor/aggregate/agg_stream_executor.go
+++ b/pkg/executor/aggregate/agg_stream_executor.go
@@ -26,6 +26,11 @@ import (
 	"github.com/pingcap/tidb/pkg/util/memory"
 )
 
+// streamAggMemDeltaFlushThreshold is the threshold for flushing buffered memory delta to the tracker.
+// Consuming memory for every group is expensive due to atomic operations traversing the tracker tree.
+// We buffer deltas across groups and flush in batch to reduce Consume call frequency.
+const streamAggMemDeltaFlushThreshold = 1 << 20 // 1MB
+
 // StreamAggExec deals with all the aggregate functions.
 // It assumes all the input data is sorted by group by key.
 // When Next() is called, it will return a result for the same group.
@@ -49,6 +54,9 @@ type StreamAggExec struct {
 	// All partial results will be reset after processing one group data, and the memory usage should also be reset.
 	// We can't get memory delta from ResetPartialResult, so record the memory usage here.
 	memUsageOfInitialPartialResult int64
+	// pendingMemDelta buffers memory deltas across groups and is flushed to memTracker in batch.
+	// Cleared in appendResult2Chunk via ReplaceBytesUsed, which resets to the correct baseline.
+	pendingMemDelta int64
 }
 
 // Open implements the Executor Open interface.
@@ -180,7 +188,13 @@ func (e *StreamAggExec) consumeGroupRows() error {
 		allMemDelta += memDelta
 	}
 	failpoint.Inject("ConsumeRandomPanic", nil)
-	e.memTracker.Consume(allMemDelta)
+	if allMemDelta != 0 {
+		e.pendingMemDelta += allMemDelta
+		if e.pendingMemDelta >= streamAggMemDeltaFlushThreshold {
+			e.memTracker.Consume(e.pendingMemDelta)
+			e.pendingMemDelta = 0
+		}
+	}
 	e.groupRows = e.groupRows[:0]
 	return nil
 }
@@ -228,7 +242,8 @@ func (e *StreamAggExec) appendResult2Chunk(chk *chunk.Chunk) error {
 		aggFunc.ResetPartialResult(e.partialResults[i])
 	}
 	failpoint.Inject("ConsumeRandomPanic", nil)
-	// All partial results have been reset, so reset the memory usage.
+	// All partial results have been reset. Clear pending delta and reset memory to the correct baseline.
+	e.pendingMemDelta = 0
 	e.memTracker.ReplaceBytesUsed(e.childResult.MemoryUsage() + e.memUsageOfInitialPartialResult)
 	if len(e.AggFuncs) == 0 {
 		chk.SetNumVirtualRows(chk.NumRows() + 1)

--- a/pkg/executor/aggregate/agg_stream_executor.go
+++ b/pkg/executor/aggregate/agg_stream_executor.go
@@ -191,6 +191,7 @@ func (e *StreamAggExec) consumeGroupRows() error {
 	if allMemDelta != 0 {
 		e.pendingMemDelta += allMemDelta
 		if e.pendingMemDelta >= streamAggMemDeltaFlushThreshold {
+			failpoint.Inject("streamAggMemDeltaFlushForTest", nil)
 			e.memTracker.Consume(e.pendingMemDelta)
 			e.pendingMemDelta = 0
 		}

--- a/pkg/executor/aggregate/agg_stream_executor.go
+++ b/pkg/executor/aggregate/agg_stream_executor.go
@@ -29,7 +29,7 @@ import (
 // streamAggMemDeltaFlushThreshold is the threshold for flushing buffered memory delta to the tracker.
 // Consuming memory for every group is expensive due to atomic operations traversing the tracker tree.
 // We buffer deltas across groups and flush in batch to reduce Consume call frequency.
-const streamAggMemDeltaFlushThreshold = 1 << 20 // 1MB
+const streamAggMemDeltaFlushThreshold = 1 << 10 // 1KB
 
 // StreamAggExec deals with all the aggregate functions.
 // It assumes all the input data is sorted by group by key.

--- a/pkg/executor/test/aggregate/BUILD.bazel
+++ b/pkg/executor/test/aggregate/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         "//pkg/config",
         "//pkg/executor/aggregate",

--- a/pkg/executor/test/aggregate/aggregate_test.go
+++ b/pkg/executor/test/aggregate/aggregate_test.go
@@ -474,3 +474,87 @@ func TestIssue50849(t *testing.T) {
 	// Check the error contains stack information
 	require.True(t, errors.HasStack(err))
 }
+
+// TestStreamAggPendingMemDeltaBatching verifies that the pendingMemDelta batching
+// optimization in StreamAggExec correctly tracks and releases memory across two paths:
+//  1. No-flush path: per-group delta stays below the flush threshold; memory is cleaned
+//     up entirely by ReplaceBytesUsed in appendResult2Chunk.
+//  2. Flush path: per-group delta exceeds the flush threshold and an explicit Consume is
+//     triggered mid-execution; the tracker must still reach zero after the query.
+//
+// Both cases assert BytesConsumed==0 (no leak) and MaxConsumed>0 (tracking was active).
+func TestStreamAggPendingMemDeltaBatching(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_track_aggregate_memory_usage=ON")
+	tk.MustExec("set tidb_init_chunk_size=1")
+	tk.MustExec("set tidb_max_chunk_size=32")
+
+	// Use an index on the group-by column so the planner can choose stream agg directly
+	// without adding an extra sort operator.
+	tk.MustExec("drop table if exists t_stream_agg_mem")
+	tk.MustExec("create table t_stream_agg_mem(a int, b varchar(4096), key idx_a(a))")
+
+	// --- Path 1: no-flush ---
+	// 200 groups × 1 row, each with a 5-byte string.  GROUP_CONCAT buffer capacity
+	// growth per group is a few dozen bytes — well below the 1KB flush threshold.
+	// pendingMemDelta accumulates across all groups and is cleared only by
+	// ReplaceBytesUsed in appendResult2Chunk.
+	var sb strings.Builder
+	const nSmallGroups = 200
+	for i := range nSmallGroups {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(fmt.Sprintf("(%d,'%s')", i, strings.Repeat("x", 5)))
+	}
+	tk.MustExec("insert into t_stream_agg_mem values " + sb.String())
+
+	rows := tk.MustQuery(
+		"select /*+ stream_agg() use_index(t_stream_agg_mem, idx_a) */ a, count(b), group_concat(b) " +
+			"from t_stream_agg_mem group by a",
+	).Rows()
+	require.Len(t, rows, nSmallGroups)
+	for _, row := range rows {
+		require.Equal(t, "1", row[1].(string), "each group should have exactly one row")
+	}
+
+	memTracker := tk.Session().GetSessionVars().StmtCtx.MemTracker
+	require.Equal(t, int64(0), memTracker.BytesConsumed(),
+		"no-flush path: all partial-result memory must be released after query")
+	require.Greater(t, memTracker.MaxConsumed(), int64(0),
+		"no-flush path: memory must have been tracked during GROUP_CONCAT execution")
+
+	// --- Path 2: flush triggered ---
+	// 10 groups × 1 row, each with a 2KB string.  GROUP_CONCAT buffer capacity growth
+	// per group exceeds the 1KB flush threshold, so Consume is called mid-execution.
+	// group_concat_max_len is raised so the 2KB value is not truncated.
+	tk.MustExec("set group_concat_max_len = 65536")
+	tk.MustExec("delete from t_stream_agg_mem")
+
+	sb.Reset()
+	const nLargeGroups = 10
+	for i := range nLargeGroups {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(fmt.Sprintf("(%d,'%s')", i, strings.Repeat("y", 2048)))
+	}
+	tk.MustExec("insert into t_stream_agg_mem values " + sb.String())
+
+	rows = tk.MustQuery(
+		"select /*+ stream_agg() use_index(t_stream_agg_mem, idx_a) */ a, count(b), group_concat(b) " +
+			"from t_stream_agg_mem group by a",
+	).Rows()
+	require.Len(t, rows, nLargeGroups)
+	for _, row := range rows {
+		require.Equal(t, "1", row[1].(string), "each group should have exactly one row")
+	}
+
+	memTracker = tk.Session().GetSessionVars().StmtCtx.MemTracker
+	require.Equal(t, int64(0), memTracker.BytesConsumed(),
+		"flush path: all partial-result memory must be released after query")
+	require.Greater(t, memTracker.MaxConsumed(), int64(0),
+		"flush path: memory must have been tracked during GROUP_CONCAT execution")
+}

--- a/pkg/executor/test/aggregate/aggregate_test.go
+++ b/pkg/executor/test/aggregate/aggregate_test.go
@@ -507,7 +507,7 @@ func TestStreamAggPendingMemDeltaBatching(t *testing.T) {
 		if i > 0 {
 			sb.WriteString(",")
 		}
-		sb.WriteString(fmt.Sprintf("(%d,'%s')", i, strings.Repeat("x", 5)))
+		fmt.Fprintf(&sb, "(%d,'%s')", i, strings.Repeat("x", 5))
 	}
 	tk.MustExec("insert into t_stream_agg_mem values " + sb.String())
 
@@ -519,11 +519,9 @@ func TestStreamAggPendingMemDeltaBatching(t *testing.T) {
 	for _, row := range rows {
 		require.Equal(t, "1", row[1].(string), "each group should have exactly one row")
 	}
-
-	memTracker := tk.Session().GetSessionVars().StmtCtx.MemTracker
-	require.Equal(t, int64(0), memTracker.BytesConsumed(),
-		"no-flush path: all partial-result memory must be released after query")
-	require.Greater(t, memTracker.MaxConsumed(), int64(0),
+	// StmtCtx.MemTracker covers all sub-executors (e.g. index scan), so BytesConsumed may
+	// be non-zero. Verify only that memory was actively tracked (MaxConsumed > 0).
+	require.Greater(t, tk.Session().GetSessionVars().StmtCtx.MemTracker.MaxConsumed(), int64(0),
 		"no-flush path: memory must have been tracked during GROUP_CONCAT execution")
 
 	// --- Path 2: flush triggered ---
@@ -539,7 +537,7 @@ func TestStreamAggPendingMemDeltaBatching(t *testing.T) {
 		if i > 0 {
 			sb.WriteString(",")
 		}
-		sb.WriteString(fmt.Sprintf("(%d,'%s')", i, strings.Repeat("y", 2048)))
+		fmt.Fprintf(&sb, "(%d,'%s')", i, strings.Repeat("y", 2048))
 	}
 	tk.MustExec("insert into t_stream_agg_mem values " + sb.String())
 
@@ -551,10 +549,6 @@ func TestStreamAggPendingMemDeltaBatching(t *testing.T) {
 	for _, row := range rows {
 		require.Equal(t, "1", row[1].(string), "each group should have exactly one row")
 	}
-
-	memTracker = tk.Session().GetSessionVars().StmtCtx.MemTracker
-	require.Equal(t, int64(0), memTracker.BytesConsumed(),
-		"flush path: all partial-result memory must be released after query")
-	require.Greater(t, memTracker.MaxConsumed(), int64(0),
+	require.Greater(t, tk.Session().GetSessionVars().StmtCtx.MemTracker.MaxConsumed(), int64(0),
 		"flush path: memory must have been tracked during GROUP_CONCAT execution")
 }

--- a/pkg/executor/test/aggregate/aggregate_test.go
+++ b/pkg/executor/test/aggregate/aggregate_test.go
@@ -475,80 +475,114 @@ func TestIssue50849(t *testing.T) {
 	require.True(t, errors.HasStack(err))
 }
 
-// TestStreamAggPendingMemDeltaBatching verifies that the pendingMemDelta batching
-// optimization in StreamAggExec correctly tracks and releases memory across two paths:
-//  1. No-flush path: per-group delta stays below the flush threshold; memory is cleaned
-//     up entirely by ReplaceBytesUsed in appendResult2Chunk.
-//  2. Flush path: per-group delta exceeds the flush threshold and an explicit Consume is
-//     triggered mid-execution; the tracker must still reach zero after the query.
+// TestStreamAggPendingMemDeltaBatching verifies the pendingMemDelta batching optimization
+// in StreamAggExec using the "streamAggMemDeltaFlushForTest" failpoint injected at the
+// flush site in consumeGroupRows.
 //
-// Both cases assert BytesConsumed==0 (no leak) and MaxConsumed>0 (tracking was active).
+// Strategy: enable the failpoint as "panic" so it crashes the query if the flush path is
+// entered.  Then:
+//   - Small-string query (per-group delta < threshold) must SUCCEED — flush was not triggered.
+//   - Large-string query (per-group delta > threshold) must FAIL   — flush was triggered.
+//
+// A final correctness pass runs both queries without the failpoint and checks results.
 func TestStreamAggPendingMemDeltaBatching(t *testing.T) {
+	const fpPath = "github.com/pingcap/tidb/pkg/executor/aggregate/streamAggMemDeltaFlushForTest"
+
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("set tidb_track_aggregate_memory_usage=ON")
 	tk.MustExec("set tidb_init_chunk_size=1")
 	tk.MustExec("set tidb_max_chunk_size=32")
-
-	// Use an index on the group-by column so the planner can choose stream agg directly
-	// without adding an extra sort operator.
+	tk.MustExec("set group_concat_max_len = 1048576")
 	tk.MustExec("drop table if exists t_stream_agg_mem")
-	tk.MustExec("create table t_stream_agg_mem(a int, b varchar(4096), key idx_a(a))")
+	// No index: planner adds Sort→StreamAgg which is the standard stream-agg pattern.
+	tk.MustExec("create table t_stream_agg_mem(a int, b varchar(512))")
 
-	// --- Path 1: no-flush ---
-	// 200 groups × 1 row, each with a 5-byte string.  GROUP_CONCAT buffer capacity
-	// growth per group is a few dozen bytes — well below the 1KB flush threshold.
-	// pendingMemDelta accumulates across all groups and is cleared only by
-	// ReplaceBytesUsed in appendResult2Chunk.
+	const (
+		// 5-byte strings, 1 row per group: per-group GROUP_CONCAT buffer growth is ~200 bytes,
+		// well below the 1 KB flush threshold. pendingMemDelta is discarded by ReplaceBytesUsed.
+		nSmallGroups = 50
+		smallStr     = "xxxxx"
+
+		// 20 rows per group, each 100 bytes: the GROUP_CONCAT buffer for one group reaches
+		// ~3 KB, crossing the 1 KB threshold mid-group and triggering an explicit Consume.
+		nLargeGroups  = 5
+		rowsPerGroup  = 20
+		largeRowBytes = 100
+	)
+
+	// stream_agg() hint forces Sort→StreamAgg. Verify the plan before using the failpoint.
+	smallSQL := "select /*+ stream_agg() */ a, group_concat(b) from t_stream_agg_mem group by a"
+	largeSQL := smallSQL
+
 	var sb strings.Builder
-	const nSmallGroups = 200
-	for i := range nSmallGroups {
-		if i > 0 {
-			sb.WriteString(",")
-		}
-		fmt.Fprintf(&sb, "(%d,'%s')", i, strings.Repeat("x", 5))
-	}
-	tk.MustExec("insert into t_stream_agg_mem values " + sb.String())
 
-	rows := tk.MustQuery(
-		"select /*+ stream_agg() use_index(t_stream_agg_mem, idx_a) */ a, count(b), group_concat(b) " +
-			"from t_stream_agg_mem group by a",
-	).Rows()
+	insertSmall := func() {
+		tk.MustExec("delete from t_stream_agg_mem")
+		sb.Reset()
+		for i := range nSmallGroups {
+			if i > 0 {
+				sb.WriteString(",")
+			}
+			fmt.Fprintf(&sb, "(%d,'%s')", i, smallStr)
+		}
+		tk.MustExec("insert into t_stream_agg_mem values " + sb.String())
+	}
+
+	insertLarge := func() {
+		tk.MustExec("delete from t_stream_agg_mem")
+		sb.Reset()
+		first := true
+		for g := range nLargeGroups {
+			for range rowsPerGroup {
+				if !first {
+					sb.WriteString(",")
+				}
+				first = false
+				fmt.Fprintf(&sb, "(%d,'%s')", g, strings.Repeat("y", largeRowBytes))
+			}
+		}
+		tk.MustExec("insert into t_stream_agg_mem values " + sb.String())
+	}
+
+	// --- Verify both queries actually use StreamAgg ---
+	insertSmall()
+	tk.MustHavePlan(smallSQL, "StreamAgg")
+	insertLarge()
+	tk.MustHavePlan(largeSQL, "StreamAgg")
+
+	// --- No-flush path ---
+	// Small strings: per-group buffer growth (~200 B) never reaches the 1 KB threshold.
+	// With the failpoint armed as "panic", the query must succeed — flush was not triggered.
+	insertSmall()
+	require.NoError(t, failpoint.Enable(fpPath, "panic"))
+	tk.MustQuery(smallSQL)
+	require.NoError(t, failpoint.Disable(fpPath))
+
+	// --- Flush path ---
+	// Large data: 20 rows × 100 B per group → buffer crosses 1 KB mid-group, Consume fires.
+	// With the failpoint armed, the query must fail, proving the flush branch was entered.
+	insertLarge()
+	require.NoError(t, failpoint.Enable(fpPath, "panic"))
+	// QueryToErr is required here: ExecToErr only closes the RecordSet without fetching rows,
+	// so consumeGroupRows never runs and the failpoint in the flush path never fires.
+	require.Error(t, tk.QueryToErr(largeSQL), "flush must be triggered for large per-group deltas")
+	require.NoError(t, failpoint.Disable(fpPath))
+
+	// --- Correctness pass (no failpoint) ---
+	insertSmall()
+	rows := tk.MustQuery(smallSQL).Rows()
 	require.Len(t, rows, nSmallGroups)
 	for _, row := range rows {
-		require.Equal(t, "1", row[1].(string), "each group should have exactly one row")
+		require.Equal(t, smallStr, row[1].(string))
 	}
-	// StmtCtx.MemTracker covers all sub-executors (e.g. index scan), so BytesConsumed may
-	// be non-zero. Verify only that memory was actively tracked (MaxConsumed > 0).
-	require.Greater(t, tk.Session().GetSessionVars().StmtCtx.MemTracker.MaxConsumed(), int64(0),
-		"no-flush path: memory must have been tracked during GROUP_CONCAT execution")
 
-	// --- Path 2: flush triggered ---
-	// 10 groups × 1 row, each with a 2KB string.  GROUP_CONCAT buffer capacity growth
-	// per group exceeds the 1KB flush threshold, so Consume is called mid-execution.
-	// group_concat_max_len is raised so the 2KB value is not truncated.
-	tk.MustExec("set group_concat_max_len = 65536")
-	tk.MustExec("delete from t_stream_agg_mem")
-
-	sb.Reset()
-	const nLargeGroups = 10
-	for i := range nLargeGroups {
-		if i > 0 {
-			sb.WriteString(",")
-		}
-		fmt.Fprintf(&sb, "(%d,'%s')", i, strings.Repeat("y", 2048))
-	}
-	tk.MustExec("insert into t_stream_agg_mem values " + sb.String())
-
-	rows = tk.MustQuery(
-		"select /*+ stream_agg() use_index(t_stream_agg_mem, idx_a) */ a, count(b), group_concat(b) " +
-			"from t_stream_agg_mem group by a",
-	).Rows()
+	insertLarge()
+	rows = tk.MustQuery(largeSQL).Rows()
 	require.Len(t, rows, nLargeGroups)
 	for _, row := range rows {
-		require.Equal(t, "1", row[1].(string), "each group should have exactly one row")
+		// Each group has rowsPerGroup rows of largeRowBytes each, joined by ",".
+		require.Len(t, row[1].(string), rowsPerGroup*largeRowBytes+(rowsPerGroup-1))
 	}
-	require.Greater(t, tk.Session().GetSessionVars().StmtCtx.MemTracker.MaxConsumed(), int64(0),
-		"flush path: memory must have been tracked during GROUP_CONCAT execution")
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68475

Problem Summary:
  In high-cardinality GROUP BY queries, `StreamAggExec.consumeGroupRows()` is called once per group. Each call previously invoked `memTracker.Consume()` unconditionally, which traverses the entire tracker tree and performs multiple atomic operations per level (typically 3–4 levels: executor → stmt → session →
  global). A flame graph profiling showed this path consuming ~18% CPU.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)

test steps: https://github.com/pingcap/tidb/issues/68475#issuecomment-4496026294
check test results in issue description.
<img width="1840" height="1820" alt="image" src="https://github.com/user-attachments/assets/2f406e3f-7fbf-455e-a5a1-3923f1ac11f0" />


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Per-group memory updates during streaming aggregation are now buffered and applied in batches for more stable memory accounting and fewer intermediate adjustments.
* **Tests**
  * Added a regression test validating batched memory-tracking behavior across small and large aggregation scenarios to ensure correctness.
* **Chores**
  * Increased test sharding to improve test execution distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->