### PR TITLE
planner: CAST to BINARY correctness issue

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -168,8 +168,22 @@ func rebuildIndexRanges(ectx expression.BuildContext, rctx *rangerctx.RangerCont
 		access = append(access, newCond)
 	}
 	// All of access conditions must be used to build ranges, so we don't limit range memory usage.
-	ranges, _, _, err = ranger.DetachSimpleCondAndBuildRangeForIndex(rctx, access, idxCols, colLens, 0)
-	return ranges, err
+	var remainedConds []expression.Expression
+	ranges, _, remainedConds, err = ranger.DetachSimpleCondAndBuildRangeForIndex(rctx, access, idxCols, colLens, 0)
+	if err != nil {
+		return nil, err
+	}
+	// Preserve residual predicates returned by the detacher (e.g., CAST(... AS BINARY)
+	// comparisons whose index ranges only approximate the predicate). Merge them back
+	// into the access condition set so they are not lost on the correlated-access path
+	// and remain available to subsequent KV-range / filter logic as residual predicates.
+	if len(remainedConds) > 0 {
+		merged := make([]expression.Expression, 0, len(access)+len(remainedConds))
+		merged = append(merged, access...)
+		merged = append(merged, remainedConds...)
+		is.AccessCondition = merged
+	}
+	return ranges, nil
 }
 
 type indexReaderExecutorContext struct {

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -173,13 +173,15 @@ func rebuildIndexRanges(ectx expression.BuildContext, rctx *rangerctx.RangerCont
 	if err != nil {
 		return nil, err
 	}
-	// The planner only admits an AccessCondition into the correlated-access path when the
-	// detacher can fully encode it as ranges (e.g. binary-collation residuals require a
-	// Constant operand, which is rejected before reaching here). If a future planner change
-	// lets residuals through, they would need to be applied as filters via PhysicalSelection
-	// or an equivalent re-applied predicate list -- PhysicalIndexScan.ToPB does not encode
-	// AccessCondition into the DAG request, so attaching them to is.AccessCondition would
-	// neither push them down nor evaluate them locally.
+	// Residuals from the detacher don't cause incorrect results on this path:
+	//   - Binary-collation residuals are blocked upstream -- SplitCorColAccessCondFromFilters
+	//     in pkg/planner/util/path.go rejects collation-mismatched predicates before they
+	//     can be promoted into is.AccessCondition.
+	//   - For other shouldReserve cases (prefix indexes, range predicates), the planner
+	//     retains the original predicate in path.TableFilters, which becomes a parent
+	//     Selection / table-side filter; rebuilding only the access ranges here is safe.
+	// The assert below is a regression guard in case a future planner change introduces a
+	// shouldReserve case that isn't covered by one of these two mechanisms.
 	intest.Assert(len(remainedConds) == 0, "rebuildIndexRanges: detacher returned residuals on correlated-access path")
 	return ranges, nil
 }

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -173,19 +173,14 @@ func rebuildIndexRanges(ectx expression.BuildContext, rctx *rangerctx.RangerCont
 	if err != nil {
 		return nil, err
 	}
-	// Preserve residual predicates returned by the detacher (e.g., CAST(... AS BINARY)
-	// comparisons whose index ranges only approximate the predicate). Merge them back
-	// into the access condition set so they are not lost on the correlated-access path
-	// and remain available to subsequent KV-range / filter logic as residual predicates.
-	// Defensive: today the planner's checker only admits binary-collation residuals when
-	// one operand is a Constant, so correlated forms don't reach this path. This guards
-	// future planner changes or other predicate shapes that produce remainedConds here.
-	if len(remainedConds) > 0 {
-		merged := make([]expression.Expression, 0, len(access)+len(remainedConds))
-		merged = append(merged, access...)
-		merged = append(merged, remainedConds...)
-		is.AccessCondition = merged
-	}
+	// The planner only admits an AccessCondition into the correlated-access path when the
+	// detacher can fully encode it as ranges (e.g. binary-collation residuals require a
+	// Constant operand, which is rejected before reaching here). If a future planner change
+	// lets residuals through, they would need to be applied as filters via PhysicalSelection
+	// or an equivalent re-applied predicate list -- PhysicalIndexScan.ToPB does not encode
+	// AccessCondition into the DAG request, so attaching them to is.AccessCondition would
+	// neither push them down nor evaluate them locally.
+	intest.Assert(len(remainedConds) == 0, "rebuildIndexRanges: detacher returned residuals on correlated-access path")
 	return ranges, nil
 }
 

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -177,6 +177,9 @@ func rebuildIndexRanges(ectx expression.BuildContext, rctx *rangerctx.RangerCont
 	// comparisons whose index ranges only approximate the predicate). Merge them back
 	// into the access condition set so they are not lost on the correlated-access path
 	// and remain available to subsequent KV-range / filter logic as residual predicates.
+	// Defensive: today the planner's checker only admits binary-collation residuals when
+	// one operand is a Constant, so correlated forms don't reach this path. This guards
+	// future planner changes or other predicate shapes that produce remainedConds here.
 	if len(remainedConds) > 0 {
 		merged := make([]expression.Expression, 0, len(access)+len(remainedConds))
 		merged = append(merged, access...)

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -139,6 +139,14 @@ func getPotentialEqOrInColOffset(sctx *rangerctx.RangerContext, expr expression.
 			}
 		}
 
+		// TODO: This collation-compatibility check rejects columns with binary-casted literals
+		// (e.g. f = CAST('a' AS BINARY) on a non-binary string column), which causes the EQ/IN
+		// extraction path to demote such predicates to filters. As a consequence, suffix index
+		// columns on a composite index (e.g. index on (f,g) with f = CAST('a' AS BINARY) AND g = 1)
+		// cannot be used as index equalities and are treated as filters as well. Relax this check
+		// for the CAST(... AS BINARY) / binary-collation case so binary-cast equality predicates
+		// can be treated as index-equalities, and add a regression test for the composite-index
+		// scenario above. Fix in a later release.
 		if c.RetType.EvalType() == types.ETString && !collate.CompatibleCollate(c.RetType.GetCollate(), collation) {
 			return -1
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67899

Problem Summary:

### What changed and how does it work?

This fix lives on the correlated-access runtime path (rebuildIndexRanges only runs when corColInAccess is true), and the original PR #67898's tests only cover the non-correlated planner path.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

### Codex review

 No correctness issues found for CAST(... AS BINARY) predicates after this
  branch/PR.

The key path is correct: binary-collation EQ/NullEQ and IN predicates on string index columns are allowed to build approximate index ranges, but are also retained as residual filters via shouldReserve=true in tidb/pkg/util/ranger/checker.go:69 and tidb/pkg/util/ranger/checker.go:132. Those residuals are preserved by the detacher in tidb/pkg/util/ranger/detacher.go:583,  assigned to path filters in tidb/pkg/planner/core/stats.go:410, and then become pushed/root selections in tidb/pkg/planner/core/find_best_task.go:2561. That is what prevents false positives from case-insensitive index ranges.

The branch’s correlated-access guard in tidb/pkg/executor/distsql.go:172 is also reasonable: if DetachSimpleCondAndBuildRangeForIndex ever returns residuals there, they cannot be made correct by appending them back to AccessCondition, because PhysicalIndexScan.ToPB does not encode access conditions into the DAG request. The assertion documents that invariant without introducing a misleading runtime “fix”.

One limitation remains, already documented in tidb/pkg/util/ranger/detacher.go:145: for a composite index like (f,g), f = CAST('a' AS BINARY) AND g = 1 will not currently use g as an index equality. That is a performance gap, not a correctness issue, because g = 1 remains a filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve residual filter conditions discovered during index range calculation so correlated index access applies all relevant predicates.
  * Add a validation that flags cases leaving unapplied residual predicates to prevent silent omissions.

* **Documentation**
  * Add an internal note about collation/compatibility behavior affecting EQ/IN predicate extraction (composite-index implications).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->