### PR TITLE
planner: prefer live explain-for-connection stats

### DIFF
--- a/pkg/executor/explainfor_test.go
+++ b/pkg/executor/explainfor_test.go
@@ -23,11 +23,13 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/parser/auth"
+	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/session/sessmgr"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
+	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/stretchr/testify/require"
 )
 
@@ -76,11 +78,28 @@ func TestExplainFor(t *testing.T) {
 				buf.WriteString(fmt.Sprintf("%v", v))
 			}
 		}
-		require.Regexp(t, `TableReader(?:_\d+)? 10000\.00 0 root  time:0s, open:0s, close:0s, loops:0(?:, RU:\d+\.\d+)? data:TableFullScan(?:_\d+)? N/A N/A\n`+
+		require.Regexp(t, `TableReader(?:_\d+)? 10000\.00 0 root  time:[^ ]+.* data:TableFullScan(?:_\d+)? N/A N/A\n`+
 			`└─TableFullScan(?:_\d+)? 10000\.00 0 cop\[tikv\] table:t1 .* keep order:false, stats:pseudo N/A N/A`,
 			buf.String())
 	}
 	tkRoot.MustQuery("select * from t1;")
+	tkRootProcess = tkRoot.Session().ShowProcess()
+	require.NotEmpty(t, tkRootProcess.BriefBinaryPlan)
+	targetPlan, ok := tkRootProcess.Plan.(base.Plan)
+	require.True(t, ok)
+	statsColl := execdetails.NewRuntimeStatsColl(nil)
+	statsColl.GetBasicRuntimeStats(targetPlan.ID(), true).Record(time.Millisecond, 7)
+	// Keep the binary snapshot stale while replacing RuntimeStatsColl to verify live stats rendering.
+	processWithLiveStats := *tkRootProcess
+	processWithLiveStats.RuntimeStatsColl = statsColl
+	ps = []*sessmgr.ProcessInfo{&processWithLiveStats}
+	tkStatsExplain := testkit.NewTestKit(t, store)
+	tkStatsExplain.MustExec("use test")
+	tkStatsExplain.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
+	rows := tkStatsExplain.MustQuery(fmt.Sprintf("explain for connection %d", processWithLiveStats.ID)).Rows()
+	require.Len(t, rows, 2)
+	require.Len(t, rows[0], 9)
+	require.Equal(t, "7", rows[0][2])
 	check()
 	tkRoot.MustQuery("explain analyze format = 'brief' select * from t1;")
 	check()

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -838,8 +838,9 @@ func (e *Explain) RenderResult() error {
 			e.SCtx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError("'explain format=true_card_cost' cannot support this plan"))
 		}
 	}
-	// For explain for connection, we can directly decode the binary plan to get the explain rows.
-	if e.BriefBinaryPlan != "" {
+	// EXPLAIN FOR CONNECTION should prefer the live runtime stats collector because
+	// BriefBinaryPlan is only a snapshot taken when ProcessInfo was recorded.
+	if e.BriefBinaryPlan != "" && e.RuntimeStatsColl == nil {
 		if strings.ToLower(e.Format) != types.ExplainFormatBrief && strings.ToLower(e.Format) != types.ExplainFormatROW && strings.ToLower(e.Format) != types.ExplainFormatVerbose {
 			return errors.Errorf("explain format '%s' for connection is not supported now", e.Format)
 		}

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -789,6 +789,19 @@ func (e *Explain) renderResultForExplore() error {
 	return nil
 }
 
+func (e *Explain) shouldDecodeBriefBinaryPlan() bool {
+	if e.BriefBinaryPlan == "" {
+		return false
+	}
+	if e.RuntimeStatsColl == nil {
+		return true
+	}
+	// Prepared Execute plans can keep ParamMarker or DeferredExpr nodes whose values
+	// belong to the original execution context, so live rendering may evaluate missing params.
+	_, isExecute := e.TargetPlan.(*Execute)
+	return isExecute
+}
+
 // RenderResult renders the explain result as specified format.
 func (e *Explain) RenderResult() error {
 	if e.Explore {
@@ -840,7 +853,7 @@ func (e *Explain) RenderResult() error {
 	}
 	// EXPLAIN FOR CONNECTION should prefer the live runtime stats collector because
 	// BriefBinaryPlan is only a snapshot taken when ProcessInfo was recorded.
-	if e.BriefBinaryPlan != "" && e.RuntimeStatsColl == nil {
+	if e.shouldDecodeBriefBinaryPlan() {
 		if strings.ToLower(e.Format) != types.ExplainFormatBrief && strings.ToLower(e.Format) != types.ExplainFormatROW && strings.ToLower(e.Format) != types.ExplainFormatVerbose {
 			return errors.Errorf("explain format '%s' for connection is not supported now", e.Format)
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64699

Problem Summary:

`EXPLAIN FOR CONNECTION` stores both a `BriefBinaryPlan` snapshot and a live
`RuntimeStatsColl` pointer in `ProcessInfo`. The binary plan is serialized when
`ProcessInfo` is recorded, while the runtime stats collector can continue to be
updated by the running statement.

The current rendering path always decodes `BriefBinaryPlan` first, so the live
collector is ignored and fields such as `actRows` can stay stale while the
statement is still running.

### What changed and how does it work?

- Prefer rendering from `TargetPlan` plus `RuntimeStatsColl` when
  `EXPLAIN FOR CONNECTION` has live runtime stats.
- Keep the binary-plan decode path as the fallback when no runtime stats
  collector is available, preserving the cached-plan fix that avoids rebuilding
  target executors with unavailable parameter values.
- Add a regression in `TestExplainFor` that keeps the binary snapshot stale while
  replacing `RuntimeStatsColl`, and verifies `EXPLAIN FOR CONNECTION` uses the
  live `actRows` value.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

Tested:

```bash
make bazel_prepare
go test -tags=intest,deadlock ./pkg/executor -run '^TestExplainFor$' -count=1
go test -tags=intest,deadlock ./pkg/executor -run 'TestExplainFor' -count=1
```

### Release note

```release-note
Fix `EXPLAIN FOR CONNECTION` to prefer live runtime statistics over stale binary plan snapshots.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * EXPLAIN FOR CONNECTION now prefers live runtime statistics and avoids decoding stale cached binary plans; prepared executions that require decoding are still handled correctly.

* **Tests**
  * Updated tests to accept variable timing formats in runtime stats and added validations to ensure cached snapshots do not override live runtime statistics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->