### PR TITLE
planner: disable index lookup pushdown with tidb_max_keys_read

### DIFF
--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1289,6 +1289,9 @@ func checkIndexLookUpPushDownSupported(ctx base.PlanContext, tblInfo *model.Tabl
 		unSupportedReason = "stale read is not supported"
 	} else if sessionVars.SnapshotTS != 0 {
 		unSupportedReason = "historical read is not supported"
+	} else if sessionVars.MaxKeysRead > 0 {
+		// https://github.com/tikv/tikv/pull/19518#discussion_r3263461617
+		unSupportedReason = "tidb_max_keys_read is set"
 	}
 
 	if unSupportedReason != "" {

--- a/tests/integrationtest/r/executor/max_keys_read.result
+++ b/tests/integrationtest/r/executor/max_keys_read.result
@@ -64,6 +64,14 @@ Error 8274 (HY000): tidb_max_keys_read limit exceeded
 select /*+ SET_VAR(tidb_max_keys_read=50), USE_INDEX(t_mrs, idx_val) */ sum(extra) from t_mrs where val >= 1;
 sum(extra)
 2000
+select /*+ SET_VAR(tidb_max_keys_read=5), index_lookup_pushdown(t_mrs, idx_val) */ extra from t_mrs where val >= 1;
+Error 8274 (HY000): tidb_max_keys_read limit exceeded
+select /*+ SET_VAR(tidb_max_keys_read=500), index_lookup_pushdown(t_mrs, idx_val) */ sum(extra) from t_mrs where val >= 1;
+sum(extra)
+2000
+show warnings;
+Level	Code	Message
+Warning	1815	hint INDEX_LOOKUP_PUSHDOWN is inapplicable, tidb_max_keys_read is set
 set @@session.tidb_max_keys_read = 1;
 update t_mrs set val = val + 1;
 update t_mrs set val = val - 1;

--- a/tests/integrationtest/t/executor/max_keys_read.test
+++ b/tests/integrationtest/t/executor/max_keys_read.test
@@ -72,6 +72,19 @@ select /*+ SET_VAR(tidb_max_keys_read=25), USE_INDEX(t_mrs, idx_val) */ extra fr
 # sum(extra) forces a table lookup (count(*) / count(id) would be index-only).
 select /*+ SET_VAR(tidb_max_keys_read=50), USE_INDEX(t_mrs, idx_val) */ sum(extra) from t_mrs where val >= 1;
 
+# IndexLookUp pushdown is incompatible with tidb_max_keys_read: the planner
+# refuses pushdown. The query falls back to a non-pushdown plan and still errors
+# via TiDB-side ProcessedKeys accumulation.
+-- error 8274
+select /*+ SET_VAR(tidb_max_keys_read=5), index_lookup_pushdown(t_mrs, idx_val) */ extra from t_mrs where val >= 1;
+
+# High limit, pushdown hint: planner still refuses pushdown because
+# max_keys_read is set, but the non-pushdown fallback succeeds. The
+# "is inapplicable" warning is the load-bearing signal that the planner
+# refusal fired.
+select /*+ SET_VAR(tidb_max_keys_read=500), index_lookup_pushdown(t_mrs, idx_val) */ sum(extra) from t_mrs where val >= 1;
+show warnings;
+
 # DML statements are exempt from tidb_max_keys_read.
 # Use a full-table UPDATE under limit=1 to prove exemption: if DML were
 # subject to the cap it would fail after the first row read.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #66925

Problem Summary:

Current Index lookup pushdown implementation does not support tidb_max_keys_read https://github.com/tikv/tikv/pull/19518/#discussion_r3263461617

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimizer now correctly respects the `tidb_max_keys_read` setting when evaluating INDEX_LOOKUP_PUSHDOWN applicability. When this setting is active, index lookup pushdown becomes inapplicable and queries fall back to standard execution plans.

* **Tests**
  * Added test coverage for `tidb_max_keys_read` interactions with index lookup pushdown functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->