### PR TITLE
Revert "importinto: require S3-like auth for nextgen import (#68231) (#68233)"

### DIFF
--- a/br/pkg/storage/parse.go
+++ b/br/pkg/storage/parse.go
@@ -167,7 +167,7 @@ func ExtractQueryParameters(u *url.URL, options any) {
 			continue
 		}
 		param := params[0]
-		normalizedKey := NormalizeQueryParameterKey(key)
+		normalizedKey := strings.ToLower(strings.ReplaceAll(key, "_", "-"))
 		if f, ok := tagToField[normalizedKey]; ok {
 			field := o.Field(f.index)
 			switch f.kind {
@@ -185,12 +185,6 @@ func ExtractQueryParameters(u *url.URL, options any) {
 
 	// Clean up the URL finally.
 	u.RawQuery = ""
-}
-
-// NormalizeQueryParameterKey normalizes object storage URL query parameter keys
-// to match backend option tags.
-func NormalizeQueryParameterKey(key string) string {
-	return strings.ToLower(strings.ReplaceAll(key, "_", "-"))
 }
 
 // FormatBackendURL obtains the raw URL which can be used the reconstruct the

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -46,12 +46,6 @@ import (
 var hardcodedS3ChunkSize = 5 * 1024 * 1024
 
 const (
-	// S3AccessKey is the key for the access key used in S3 operations.
-	S3AccessKey = "access-key"
-	// S3SecretAccessKey is the key for the secret access key used in S3 operations.
-	S3SecretAccessKey = "secret-access-key"
-	// S3RoleARN is the key for the role ARN used in S3 operations.
-	S3RoleARN = "role-arn"
 	// S3ExternalID is the key for the external ID used in S3 operations.
 	S3ExternalID = "external-id"
 

--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -162,20 +162,7 @@ func TestNextGenS3ExternalID(t *testing.T) {
 		}
 	})
 
-	t.Run("SEM enabled, require explicit auth for S3 like store", func(t *testing.T) {
-		for i, fns := range semTestPatternFns {
-			t.Run(fmt.Sprint(i), func(t *testing.T) {
-				tk := testkit.NewTestKit(t, store)
-				fns[0](t, tk)
-				t.Cleanup(func() {
-					fns[1](t, tk)
-				})
-				tk.MustMatchErrMsg("IMPORT INTO test.t FROM 's3://bucket'", `(?i).*Feature 'IMPORT INTO .*without access key/secret access key or role ARN' is not supported when security enhanced mode is enabled`)
-			})
-		}
-	})
-
-	t.Run("SEM enabled, set external ID to keyspace name", func(t *testing.T) {
+	t.Run("SEM enabled, set S3 external ID to keyspace name", func(t *testing.T) {
 		bak := config.GetGlobalKeyspaceName()
 		config.UpdateGlobal(func(conf *config.Config) {
 			conf.KeyspaceName = "aaa"
@@ -199,7 +186,7 @@ func TestNextGenS3ExternalID(t *testing.T) {
 					require.Equal(t, "aaa", u.Query().Get(storage.S3ExternalID))
 					panic("FAIL IT, AS WE CANNOT RUN IT HERE")
 				})
-				err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket?access-key=ak&secret-access-key=sk'")
+				err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket'")
 				require.ErrorContains(t, err, "FAIL IT, AS WE CANNOT RUN IT HERE")
 			})
 		}
@@ -260,7 +247,7 @@ func testNextGenUnsupportedLocalSortAndOptions(t *testing.T, store kv.Storage, i
 	t.Run("local sort", func(t *testing.T) {
 		tk := testkit.NewTestKit(t, store)
 		initFn(t, tk)
-		err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket/*.csv?access-key=ak&secret-access-key=sk'")
+		err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket/*.csv'")
 		require.ErrorIs(t, err, plannererrors.ErrNotSupportedWithSem)
 		require.ErrorContains(t, err, "IMPORT INTO with local sort")
 	})
@@ -288,7 +275,7 @@ func testNextGenUnsupportedLocalSortAndOptions(t *testing.T, store kv.Storage, i
 			"checksum_table",
 			"record_errors",
 		} {
-			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv?access-key=ak&secret-access-key=sk' with %s='1'", option))
+			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv' with %s='1'", option))
 			require.ErrorIs(t, err, exeerrors.ErrLoadDataUnsupportedOption)
 			require.ErrorContains(t, err, option)
 		}
@@ -296,7 +283,7 @@ func testNextGenUnsupportedLocalSortAndOptions(t *testing.T, store kv.Storage, i
 			"__force_merge_step",
 			"__manual_recovery",
 		} {
-			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv?access-key=ak&secret-access-key=sk' with %s", option))
+			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv' with %s", option))
 			require.ErrorIs(t, err, exeerrors.ErrLoadDataUnsupportedOption)
 			require.ErrorContains(t, err, option)
 		}

--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     flaky = True,
     shard_count = 13,
     deps = [
+        "//pkg/errno",
         "//pkg/parser",
         "//pkg/planner",
         "//pkg/planner/core/base",

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4726,15 +4726,17 @@ func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStm
 			if importFromServer {
 				return nil, plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO from server disk")
 			}
+			if kerneltype.IsNextGen() && storage.IsS3(u) {
+				if err := checkNextGenS3PathWithSem(u); err != nil {
+					return nil, err
+				}
+			}
 		}
 		// a nextgen cluster might be shared by multiple tenants, and they might
 		// share the same AWS role to access import-into source data bucket, this
 		// external ID can be used to restrict the access only to the current tenant.
 		// when SEM enabled, we need set it.
 		if kerneltype.IsNextGen() && sem.IsEnabled() && storage.IsS3(u) {
-			if err := checkNextGenS3PathWithSem(u); err != nil {
-				return nil, err
-			}
 			values := u.Query()
 			values.Set(storage.S3ExternalID, config.GetGlobalKeyspaceName())
 			u.RawQuery = values.Encode()
@@ -6379,29 +6381,15 @@ func checkAlterDDLJobOptValue(opt *AlterDDLJobOpt) error {
 	return nil
 }
 
-// For nextgen IMPORT INTO with SEM, require explicit S3 authentication and
-// disallow explicit S3 external ID. The keyspace name is used as the S3 external ID.
+// for nextgen import-into with SEM, we disallow user to set S3 external ID explicitly,
+// and we will use the keyspace name as the S3 external ID.
 func checkNextGenS3PathWithSem(u *url.URL) error {
 	values := u.Query()
-	hasAccessKey := false
-	hasSecretAccessKey := false
-	hasRoleARN := false
 	for k := range values {
-		normalizedK := storage.NormalizeQueryParameterKey(k)
-		switch normalizedK {
-		case storage.S3ExternalID:
-			return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO with explicit external ID")
-		case storage.S3AccessKey:
-			hasAccessKey = hasAccessKey || values.Get(k) != ""
-		case storage.S3SecretAccessKey:
-			hasSecretAccessKey = hasSecretAccessKey || values.Get(k) != ""
-		case storage.S3RoleARN:
-			hasRoleARN = hasRoleARN || values.Get(k) != ""
+		lowerK := strings.ToLower(k)
+		if lowerK == storage.S3ExternalID {
+			return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO with S3 external ID")
 		}
-	}
-
-	if !hasRoleARN && !(hasAccessKey && hasSecretAccessKey) {
-		return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO from S3-like storage without access key/secret access key or role ARN")
 	}
 
 	return nil

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -1110,44 +1110,16 @@ func TestGetMaxWriteSpeedFromExpression(t *testing.T) {
 }
 
 func TestProcessNextGenS3Path(t *testing.T) {
-	for _, str := range []string{
-		"S3://bucket?External-id=abc&access-key=ak&secret-access-key=sk",
-		"s3://bucket?external_id=abc&access-key=ak&secret-access-key=sk",
-		"s3://bucket?External-id=abc&role-arn=arn",
-	} {
-		u, err := url.Parse(str)
-		require.NoError(t, err)
-		err = checkNextGenS3PathWithSem(u)
-		require.ErrorIs(t, err, plannererrors.ErrNotSupportedWithSem)
-		require.ErrorContains(t, err, "IMPORT INTO with explicit external ID")
-	}
+	u, err := url.Parse("S3://bucket?External-id=abc")
+	require.NoError(t, err)
+	err = checkNextGenS3PathWithSem(u)
+	require.ErrorIs(t, err, plannererrors.ErrNotSupportedWithSem)
+	require.ErrorContains(t, err, "IMPORT INTO with S3 external ID")
 
-	for _, str := range []string{
-		"s3://bucket?access-key=ak&secret-access-key=sk",
-		"s3://bucket?access_key=ak&secret_access_key=sk",
-		"s3://bucket?role-arn=arn",
-		"s3://bucket?role_arn=arn",
-	} {
-		u, err := url.Parse(str)
-		require.NoError(t, err)
-		err = checkNextGenS3PathWithSem(u)
-		require.NoError(t, err)
-	}
-
-	for _, str := range []string{
-		"s3://bucket",
-		"s3://bucket?access-key=&secret-access-key=",
-		"s3://bucket?access-key=ak",
-		"s3://bucket?secret-access-key=sk",
-		"s3://bucket?profile=dev",
-		"s3://bucket?role-arn=",
-	} {
-		u, err := url.Parse(str)
-		require.NoError(t, err)
-		err = checkNextGenS3PathWithSem(u)
-		require.ErrorIs(t, err, plannererrors.ErrNotSupportedWithSem)
-		require.ErrorContains(t, err, "IMPORT INTO from S3-like storage without access key/secret access key or role ARN")
-	}
+	u, err = url.Parse("s3://bucket")
+	require.NoError(t, err)
+	err = checkNextGenS3PathWithSem(u)
+	require.NoError(t, err)
 }
 
 func TestIndexLookUpReaderTryLookUpPushDown(t *testing.T) {

--- a/pkg/util/sem/compat/BUILD.bazel
+++ b/pkg/util/sem/compat/BUILD.bazel
@@ -28,7 +28,6 @@ go_test(
     flaky = True,
     deps = [
         "//br/pkg/storage",
-        "//pkg/config/kerneltype",
         "//pkg/parser/auth",
         "//pkg/parser/mysql",
         "//pkg/planner/core",

--- a/pkg/util/sem/compat/sem_integration_test.go
+++ b/pkg/util/sem/compat/sem_integration_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/br/pkg/storage"
-	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -52,12 +51,6 @@ func TestRestrictedSQL(t *testing.T) {
 		tk.MustContainErrMsg("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=abc'", "is not supported when security enhanced mode is enabled")
 
 		require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "semuser", Hostname: "localhost"}, nil, nil, nil))
-		if kerneltype.IsNextGen() {
-			tk.MustContainErrMsg("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=allowed'", "IMPORT INTO with explicit external ID")
-			tk.MustQuery("select * from test.t").Check(testkit.Rows())
-			return
-		}
-
 		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/importer/NewImportPlan", func(plan *plannercore.ImportInto) {
 			u, err := url.Parse(plan.Path)
 			require.NoError(t, err)


### PR DESCRIPTION
This PR reverts #68233.

### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tidb/issues/68226

Problem Summary:

The change in #68233 requires corresponding DM control plane updates, but the control plane side is not ready yet. We need to roll back the TiDB-side behavior for now to avoid a partially deployed dependency.

### What changed and how does it work?

Revert commit `eb0ce80ca5` (PR #68233), including:

- removing the strict S3-like auth requirement added for NextGen `IMPORT INTO`
- restoring previous query parameter handling and related SEM checks
- reverting associated unit tests and Bazel test shard entries touched by #68233

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test
- [x] No need to test
  - [x] This PR is a direct revert of #68233

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified S3 URL validation for IMPORT INTO statements; external ID parameters in query strings are no longer accepted.

* **Refactor**
  * Streamlined query parameter handling for S3 imports.

* **Tests**
  * Updated S3 import test cases; removed credential parameters from test URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->