### PR TITLE
executor, planner: support INSERT RETURNING

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -1079,10 +1079,11 @@ func (b *executorBuilder) buildInsert(v *physicalop.Insert) exec.Executor {
 		return b.buildReplace(ivs)
 	}
 	insert := &InsertExec{
-		InsertValues:    ivs,
-		OnDuplicate:     append(v.OnDuplicate, v.GenCols.OnDuplicates...),
-		returningExprs:  v.Returning,
-		returningSchema: v.ReturningSchema,
+		InsertValues:             ivs,
+		OnDuplicate:              append(v.OnDuplicate, v.GenCols.OnDuplicates...),
+		returningExprs:           v.Returning,
+		returningSchema:          v.ReturningSchema,
+		returningNeedExtraHandle: v.NeedExtraHandleReturning,
 	}
 	return insert
 }

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -1042,7 +1042,11 @@ func (b *executorBuilder) buildInsert(v *physicalop.Insert) exec.Executor {
 	if selectExec != nil {
 		children = append(children, selectExec)
 	}
-	baseExec := exec.NewBaseExecutor(b.sctx, nil, v.ID(), children...)
+	var schema *expression.Schema
+	if v.ReturningSchema != nil {
+		schema = v.ReturningSchema
+	}
+	baseExec := exec.NewBaseExecutor(b.sctx, schema, v.ID(), children...)
 	baseExec.SetInitCap(chunk.ZeroCapacity)
 
 	ivs := &InsertValues{
@@ -1075,8 +1079,10 @@ func (b *executorBuilder) buildInsert(v *physicalop.Insert) exec.Executor {
 		return b.buildReplace(ivs)
 	}
 	insert := &InsertExec{
-		InsertValues: ivs,
-		OnDuplicate:  append(v.OnDuplicate, v.GenCols.OnDuplicates...),
+		InsertValues:    ivs,
+		OnDuplicate:     append(v.OnDuplicate, v.GenCols.OnDuplicates...),
+		returningExprs:  v.Returning,
+		returningSchema: v.ReturningSchema,
 	}
 	return insert
 }

--- a/pkg/executor/insert.go
+++ b/pkg/executor/insert.go
@@ -55,38 +55,48 @@ type InsertExec struct {
 	Priority mysql.PriorityEnum
 
 	// For RETURNING clause support
-	returningExprs  []expression.Expression
-	returningSchema *expression.Schema
-	returningRows   [][]types.Datum
-	returningDone   bool
+	returningExprs           []expression.Expression
+	returningSchema          *expression.Schema
+	returningNeedExtraHandle bool
+	returningRows            [][]types.Datum
+	returningDone            bool
 }
 
-func (e *InsertExec) appendReturningRow(row []types.Datum) {
+func (e *InsertExec) appendReturningRow(row []types.Datum, handle kv.Handle) {
 	if len(e.returningExprs) == 0 {
 		return
 	}
-	rowCopy := make([]types.Datum, len(row))
+	rowLen := len(row)
+	if e.returningNeedExtraHandle && !e.hasExtraHandle {
+		rowLen++
+	}
+	rowCopy := make([]types.Datum, rowLen)
 	for i := range row {
 		row[i].Copy(&rowCopy[i])
+	}
+	if e.returningNeedExtraHandle && !e.hasExtraHandle && handle != nil && handle.IsInt() {
+		rowCopy[len(row)].SetInt64(handle.IntValue())
 	}
 	e.returningRows = append(e.returningRows, rowCopy)
 }
 
 func (e *InsertExec) addRecord(ctx context.Context, row []types.Datum, dupKeyCheck table.DupKeyCheckMode) error {
-	if err := e.InsertValues.addRecord(ctx, row, dupKeyCheck); err != nil {
+	handle, err := e.InsertValues.addRecordWithAutoIDHintAndHandle(ctx, row, 0, dupKeyCheck)
+	if err != nil {
 		return err
 	}
-	e.appendReturningRow(row)
+	e.appendReturningRow(row, handle)
 	return nil
 }
 
 func (e *InsertExec) addRecordWithAutoIDHint(
 	ctx context.Context, row []types.Datum, reserveAutoIDCount int, dupKeyCheck table.DupKeyCheckMode,
 ) error {
-	if err := e.InsertValues.addRecordWithAutoIDHint(ctx, row, reserveAutoIDCount, dupKeyCheck); err != nil {
+	handle, err := e.InsertValues.addRecordWithAutoIDHintAndHandle(ctx, row, reserveAutoIDCount, dupKeyCheck)
+	if err != nil {
 		return err
 	}
-	e.appendReturningRow(row)
+	e.appendReturningRow(row, handle)
 	return nil
 }
 
@@ -622,7 +632,7 @@ func (e *InsertExec) doDupRowUpdate(
 		return errors.Trace(err)
 	}
 
-	e.appendReturningRow(newData)
+	e.appendReturningRow(newData, handle)
 
 	if autoColIdx >= 0 {
 		if e.Ctx().GetSessionVars().StmtCtx.AffectedRows() > 0 {

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -1426,25 +1426,34 @@ func (e *InsertValues) equalDatumsAsBinary(a []types.Datum, b []types.Datum) (bo
 }
 
 func (e *InsertValues) addRecord(ctx context.Context, row []types.Datum, dupKeyCheck table.DupKeyCheckMode) error {
-	return e.addRecordWithAutoIDHint(ctx, row, 0, dupKeyCheck)
+	_, err := e.addRecordWithAutoIDHintAndHandle(ctx, row, 0, dupKeyCheck)
+	return err
 }
 
 func (e *InsertValues) addRecordWithAutoIDHint(
 	ctx context.Context, row []types.Datum, reserveAutoIDCount int, dupKeyCheck table.DupKeyCheckMode,
 ) (err error) {
+	_, err = e.addRecordWithAutoIDHintAndHandle(ctx, row, reserveAutoIDCount, dupKeyCheck)
+	return err
+}
+
+func (e *InsertValues) addRecordWithAutoIDHintAndHandle(
+	ctx context.Context, row []types.Datum, reserveAutoIDCount int, dupKeyCheck table.DupKeyCheckMode,
+) (kv.Handle, error) {
 	vars := e.Ctx().GetSessionVars()
 	txn, err := e.Ctx().Txn(true)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	pessimisticLazyCheck := getPessimisticLazyCheckMode(vars)
+	var handle kv.Handle
 	if reserveAutoIDCount > 0 {
-		_, err = e.Table.AddRecord(e.Ctx().GetTableCtx(), txn, row, table.WithCtx(ctx), table.WithReserveAutoIDHint(reserveAutoIDCount), dupKeyCheck, pessimisticLazyCheck)
+		handle, err = e.Table.AddRecord(e.Ctx().GetTableCtx(), txn, row, table.WithCtx(ctx), table.WithReserveAutoIDHint(reserveAutoIDCount), dupKeyCheck, pessimisticLazyCheck)
 	} else {
-		_, err = e.Table.AddRecord(e.Ctx().GetTableCtx(), txn, row, table.WithCtx(ctx), dupKeyCheck, pessimisticLazyCheck)
+		handle, err = e.Table.AddRecord(e.Ctx().GetTableCtx(), txn, row, table.WithCtx(ctx), dupKeyCheck, pessimisticLazyCheck)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	vars.StmtCtx.AddAffectedRows(1)
 	if e.lastInsertID != 0 {
@@ -1454,7 +1463,7 @@ func (e *InsertValues) addRecordWithAutoIDHint(
 		for _, fkc := range e.fkChecks {
 			err = fkc.insertRowNeedToCheck(vars.StmtCtx, row)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
@@ -1464,7 +1473,7 @@ func (e *InsertValues) addRecordWithAutoIDHint(
 		vars.TxnCtx.InsertTTLRowsCount++
 	}
 
-	return nil
+	return handle, nil
 }
 
 // CreateSession will be assigned by session package.

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -6220,7 +6220,16 @@ func (b *PlanBuilder) buildUpdate(ctx context.Context, update *ast.UpdateStmt) (
 	updt.PartitionedTable = b.partitionedTable
 	updt.TblID2Table = tblID2table
 	err = updt.BuildOnUpdateFKTriggers(b.ctx, b.is, tblID2table)
-	return updt, err
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle RETURNING clause
+	if update.Returning != nil {
+		return nil, plannererrors.ErrNotSupportedYet.GenWithStackByArgs("RETURNING clause")
+	}
+
+	return updt, nil
 }
 
 type tblUpdateInfo struct {
@@ -6687,8 +6696,16 @@ func (b *PlanBuilder) buildDelete(ctx context.Context, ds *ast.DeleteStmt) (base
 	p = proj
 	del.SetOutputNames(p.OutputNames())
 	del.SelectPlan, _, err = DoOptimize(ctx, b.ctx, b.optFlag, p)
+	if err != nil {
+		return nil, err
+	}
 
-	return del, err
+	// Handle RETURNING clause
+	if len(ds.Returning) > 0 {
+		return nil, plannererrors.ErrNotSupportedYet.GenWithStackByArgs("RETURNING clause")
+	}
+
+	return del, nil
 }
 
 func resolveIndicesForTblID2Handle(tblID2Handle map[int64][]util.HandleCols, schema *expression.Schema) (map[int64][]util.HandleCols, error) {

--- a/pkg/planner/core/operator/physicalop/physical_common_plans.go
+++ b/pkg/planner/core/operator/physicalop/physical_common_plans.go
@@ -96,6 +96,11 @@ type Insert struct {
 
 	FKChecks   []*FKCheck   `plan-cache-clone:"must-nil"`
 	FKCascades []*FKCascade `plan-cache-clone:"must-nil"`
+
+	// Returning stores the RETURNING clause expression list.
+	Returning       []expression.Expression
+	ReturningSchema *expression.Schema `plan-cache-clone:"shallow"`
+	ReturningNames  types.NameSlice    `plan-cache-clone:"shallow"`
 }
 
 // Init initializes Insert.
@@ -172,6 +177,11 @@ type Update struct {
 
 	FKChecks   map[int64][]*FKCheck   `plan-cache-clone:"must-nil"`
 	FKCascades map[int64][]*FKCascade `plan-cache-clone:"must-nil"`
+
+	// Returning stores the RETURNING clause expression list.
+	Returning       []expression.Expression
+	ReturningSchema *expression.Schema `plan-cache-clone:"shallow"`
+	ReturningNames  types.NameSlice    `plan-cache-clone:"shallow"`
 }
 
 // Init initializes Update.
@@ -222,6 +232,11 @@ type Delete struct {
 	FKCascades map[int64][]*FKCascade `plan-cache-clone:"must-nil"`
 
 	IgnoreErr bool
+
+	// Returning stores the RETURNING clause expression list.
+	Returning       []expression.Expression
+	ReturningSchema *expression.Schema `plan-cache-clone:"shallow"`
+	ReturningNames  types.NameSlice    `plan-cache-clone:"shallow"`
 }
 
 // Init initializes Delete.

--- a/pkg/planner/core/operator/physicalop/physical_common_plans.go
+++ b/pkg/planner/core/operator/physicalop/physical_common_plans.go
@@ -98,9 +98,10 @@ type Insert struct {
 	FKCascades []*FKCascade `plan-cache-clone:"must-nil"`
 
 	// Returning stores the RETURNING clause expression list.
-	Returning       []expression.Expression
-	ReturningSchema *expression.Schema `plan-cache-clone:"shallow"`
-	ReturningNames  types.NameSlice    `plan-cache-clone:"shallow"`
+	Returning                []expression.Expression
+	ReturningSchema          *expression.Schema `plan-cache-clone:"shallow"`
+	ReturningNames           types.NameSlice    `plan-cache-clone:"shallow"`
+	NeedExtraHandleReturning bool
 }
 
 // Init initializes Insert.

--- a/pkg/planner/core/operator/physicalop/plan_clone_generated.go
+++ b/pkg/planner/core/operator/physicalop/plan_clone_generated.go
@@ -43,6 +43,7 @@ func (op *Update) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, bool) {
 	if op.FKCascades != nil {
 		return nil, false
 	}
+	cloned.Returning = utilfuncp.CloneExpressionsForPlanCache(op.Returning, nil)
 	return cloned, true
 }
 
@@ -64,6 +65,7 @@ func (op *Delete) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, bool) {
 	if op.FKCascades != nil {
 		return nil, false
 	}
+	cloned.Returning = utilfuncp.CloneExpressionsForPlanCache(op.Returning, nil)
 	return cloned, true
 }
 
@@ -88,6 +90,7 @@ func (op *Insert) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, bool) {
 	if op.FKCascades != nil {
 		return nil, false
 	}
+	cloned.Returning = utilfuncp.CloneExpressionsForPlanCache(op.Returning, nil)
 	return cloned, true
 }
 

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4242,14 +4242,15 @@ func (b *PlanBuilder) buildInsert(ctx context.Context, insert *ast.InsertStmt) (
 
 	// Handle RETURNING clause
 	if len(insert.Returning) > 0 {
-		returningExprs, returningSchema, returningNames, err := b.buildReturningClause(
-			ctx, insert.Returning, insertPlan.TableSchema, insertPlan.TableColNames, mockTablePlan)
+		returningExprs, returningSchema, returningNames, needExtraHandle, err := b.buildReturningClause(
+			ctx, insert.Returning, insertPlan.TableSchema, insertPlan.TableColNames, mockTablePlan, tableInfo, tn.Schema)
 		if err != nil {
 			return nil, err
 		}
 		insertPlan.Returning = returningExprs
 		insertPlan.ReturningSchema = returningSchema
 		insertPlan.ReturningNames = returningNames
+		insertPlan.NeedExtraHandleReturning = needExtraHandle
 		// Set the output schema for the insert plan to be the returning schema
 		insertPlan.SetSchema(returningSchema)
 		insertPlan.SetOutputNames(returningNames)
@@ -6488,8 +6489,10 @@ func (b *PlanBuilder) buildReturningClause(
 	returning []*ast.SelectField,
 	tableSchema *expression.Schema,
 	tableNames types.NameSlice,
-	mockPlan base.LogicalPlan,
-) ([]expression.Expression, *expression.Schema, types.NameSlice, error) {
+	mockPlan *logicalop.LogicalTableDual,
+	tableInfo *model.TableInfo,
+	dbName ast.CIStr,
+) ([]expression.Expression, *expression.Schema, types.NameSlice, bool, error) {
 	capacity := 0
 	for _, field := range returning {
 		if field.WildCard != nil {
@@ -6501,6 +6504,30 @@ func (b *PlanBuilder) buildReturningClause(
 	exprs := make([]expression.Expression, 0, capacity)
 	cols := make([]*expression.Column, 0, capacity)
 	names := make(types.NameSlice, 0, capacity)
+	inputSchema := tableSchema
+	inputNames := tableNames
+	if !tableInfo.PKIsHandle && !tableInfo.IsCommonHandle {
+		tp := types.NewFieldType(mysql.TypeLonglong)
+		tp.SetFlag(mysql.NotNullFlag | mysql.PriKeyFlag)
+		extraCol := &expression.Column{
+			RetType:  tp,
+			UniqueID: b.ctx.GetSessionVars().AllocPlanColumnID(),
+			ID:       model.ExtraHandleID,
+			Index:    tableSchema.Len(),
+			OrigName: fmt.Sprintf("%v.%v.%v", dbName, tableInfo.Name, model.ExtraHandleName),
+		}
+		inputSchema = expression.NewSchema(append(append([]*expression.Column{}, tableSchema.Columns...), extraCol)...)
+		inputNames = append(tableNames.Shallow(), &types.FieldName{
+			OrigTblName: tableInfo.Name,
+			OrigColName: model.ExtraHandleName,
+			DBName:      dbName,
+			TblName:     tableInfo.Name,
+			ColName:     model.ExtraHandleName,
+		})
+	}
+	mockPlan.SetSchema(inputSchema)
+	mockPlan.SetOutputNames(inputNames)
+	needExtraHandle := false
 
 	for _, field := range returning {
 		// Handle RETURNING *
@@ -6517,9 +6544,15 @@ func (b *PlanBuilder) buildReturningClause(
 		// Handle specific column or expression
 		expr, np, err := b.rewrite(ctx, field.Expr, mockPlan, nil, true)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, false, err
 		}
 		_ = np // We don't need the new plan for simple column references
+		for _, col := range expression.ExtractColumns(expr) {
+			if col.ID == model.ExtraHandleID {
+				needExtraHandle = true
+				break
+			}
+		}
 
 		exprs = append(exprs, expr)
 
@@ -6538,10 +6571,10 @@ func (b *PlanBuilder) buildReturningClause(
 			}
 		} else if col, ok := expr.(*expression.Column); ok {
 			// Find the original column name
-			for i, c := range tableSchema.Columns {
+			for i, c := range inputSchema.Columns {
 				if c.UniqueID == col.UniqueID {
 					// Copy the FieldName
-					origName := tableNames[i]
+					origName := inputNames[i]
 					colName = &types.FieldName{
 						OrigTblName: origName.OrigTblName,
 						OrigColName: origName.OrigColName,
@@ -6560,7 +6593,7 @@ func (b *PlanBuilder) buildReturningClause(
 		} else {
 			exprName, err := b.buildProjectionFieldNameFromExpressions(ctx, field)
 			if err != nil {
-				return nil, nil, nil, err
+				return nil, nil, nil, false, err
 			}
 			colName = &types.FieldName{
 				ColName: exprName,
@@ -6570,5 +6603,5 @@ func (b *PlanBuilder) buildReturningClause(
 	}
 
 	schema := expression.NewSchema(cols...)
-	return exprs, schema, names, nil
+	return exprs, schema, names, needExtraHandle, nil
 }

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4236,7 +4236,26 @@ func (b *PlanBuilder) buildInsert(ctx context.Context, insert *ast.InsertStmt) (
 		return nil, err
 	}
 	err = insertPlan.BuildOnInsertFKTriggers(b.ctx, b.is, tnW.DBInfo.Name.L)
-	return insertPlan, err
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle RETURNING clause
+	if len(insert.Returning) > 0 {
+		returningExprs, returningSchema, returningNames, err := b.buildReturningClause(
+			ctx, insert.Returning, insertPlan.TableSchema, insertPlan.TableColNames, mockTablePlan)
+		if err != nil {
+			return nil, err
+		}
+		insertPlan.Returning = returningExprs
+		insertPlan.ReturningSchema = returningSchema
+		insertPlan.ReturningNames = returningNames
+		// Set the output schema for the insert plan to be the returning schema
+		insertPlan.SetSchema(returningSchema)
+		insertPlan.SetOutputNames(returningNames)
+	}
+
+	return insertPlan, nil
 }
 
 func (*PlanBuilder) getAffectCols(insertStmt *ast.InsertStmt, insertPlan *physicalop.Insert) (affectedValuesCols []*table.Column, err error) {
@@ -6460,4 +6479,96 @@ func (b *PlanBuilder) checkSEMStmt(stmt ast.Node) error {
 	}
 
 	return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs(stmtNode.Text())
+}
+
+// buildReturningClause builds the RETURNING clause for DML statements.
+// It takes the RETURNING select_expr list from AST and converts it to expressions.
+func (b *PlanBuilder) buildReturningClause(
+	ctx context.Context,
+	returning []*ast.SelectField,
+	tableSchema *expression.Schema,
+	tableNames types.NameSlice,
+	mockPlan base.LogicalPlan,
+) ([]expression.Expression, *expression.Schema, types.NameSlice, error) {
+	capacity := 0
+	for _, field := range returning {
+		if field.WildCard != nil {
+			capacity += len(tableSchema.Columns)
+		} else {
+			capacity++
+		}
+	}
+	exprs := make([]expression.Expression, 0, capacity)
+	cols := make([]*expression.Column, 0, capacity)
+	names := make(types.NameSlice, 0, capacity)
+
+	for _, field := range returning {
+		// Handle RETURNING *
+		if field.WildCard != nil {
+			// Expand * to all visible columns
+			for i, col := range tableSchema.Columns {
+				exprs = append(exprs, col)
+				cols = append(cols, col)
+				names = append(names, tableNames[i])
+			}
+			continue
+		}
+
+		// Handle specific column or expression
+		expr, np, err := b.rewrite(ctx, field.Expr, mockPlan, nil, true)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		_ = np // We don't need the new plan for simple column references
+
+		exprs = append(exprs, expr)
+
+		// Build the column for the schema
+		newCol := &expression.Column{
+			UniqueID: b.ctx.GetSessionVars().AllocPlanColumnID(),
+			RetType:  expr.GetType(b.ctx.GetExprCtx().GetEvalCtx()),
+		}
+		cols = append(cols, newCol)
+
+		// Build the name
+		var colName *types.FieldName
+		if field.AsName.L != "" {
+			colName = &types.FieldName{
+				ColName: field.AsName,
+			}
+		} else if col, ok := expr.(*expression.Column); ok {
+			// Find the original column name
+			for i, c := range tableSchema.Columns {
+				if c.UniqueID == col.UniqueID {
+					// Copy the FieldName
+					origName := tableNames[i]
+					colName = &types.FieldName{
+						OrigTblName: origName.OrigTblName,
+						OrigColName: origName.OrigColName,
+						DBName:      origName.DBName,
+						TblName:     origName.TblName,
+						ColName:     origName.ColName,
+					}
+					break
+				}
+			}
+			if colName == nil {
+				colName = &types.FieldName{
+					ColName: ast.NewCIStr(col.OrigName),
+				}
+			}
+		} else {
+			exprName, err := b.buildProjectionFieldNameFromExpressions(ctx, field)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			colName = &types.FieldName{
+				ColName: exprName,
+			}
+		}
+		names = append(names, colName)
+	}
+
+	schema := expression.NewSchema(cols...)
+	return exprs, schema, names, nil
 }

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -1162,6 +1162,10 @@ func checkIfAssignmentListHasSubQuery(list []*ast.Assignment) bool {
 }
 
 func tryUpdatePointPlan(ctx base.PlanContext, updateStmt *ast.UpdateStmt, resolveCtx *resolve.Context) base.Plan {
+	// Avoid using the point_get when RETURNING clause is present (not yet supported).
+	if updateStmt.Returning != nil {
+		return nil
+	}
 	// Avoid using the point_get when assignment_list contains the sub-query in the UPDATE.
 	if checkIfAssignmentListHasSubQuery(updateStmt.List) {
 		return nil
@@ -1314,6 +1318,10 @@ func buildOrderedList(ctx base.PlanContext, plan base.Plan, list []*ast.Assignme
 
 func tryDeletePointPlan(ctx base.PlanContext, delStmt *ast.DeleteStmt, resolveCtx *resolve.Context) base.Plan {
 	if delStmt.IsMultiTable {
+		return nil
+	}
+	// Avoid using the point_get when RETURNING clause is present (not yet supported).
+	if delStmt.Returning != nil {
 		return nil
 	}
 	selStmt := &ast.SelectStmt{

--- a/tests/integrationtest/r/executor/returning.result
+++ b/tests/integrationtest/r/executor/returning.result
@@ -39,6 +39,31 @@ insert into t (id, name, val) values (300, 'orig', 1);
 insert into t (id, name, val) values (300, 'updated', 5) on duplicate key update name=values(name), val=values(val)+1 returning id, name, val;
 id	name	val
 300	updated	6
+drop table if exists t_auto_random_returning;
+create table t_auto_random_returning (id bigint primary key auto_random(3), name varchar(20));
+insert into t_auto_random_returning (name) values ('auto-random-1'), ('auto-random-2') returning id > 0 as generated_id, name;
+generated_id	name
+1	auto-random-1
+1	auto-random-2
+select count(*), count(distinct id), min(id > 0), max(id > 0) from t_auto_random_returning;
+count(*)	count(distinct id)	min(id > 0)	max(id > 0)
+2	2	1	1
+drop table t_auto_random_returning;
+drop table if exists t_nonclustered_returning;
+create table t_nonclustered_returning (id int, name varchar(20), primary key(id) nonclustered);
+insert into t_nonclustered_returning values (1, 'nonclustered-1'), (2, 'nonclustered-2') returning id, name, _tidb_rowid;
+id	name	_tidb_rowid
+1	nonclustered-1	1
+2	nonclustered-2	2
+drop table t_nonclustered_returning;
+drop table if exists t_shard_rowid_returning;
+create table t_shard_rowid_returning (id int, name varchar(20), primary key(id) nonclustered) shard_row_id_bits=4;
+insert into t_shard_rowid_returning values (1, 'shard-1'), (2, 'shard-2'), (3, 'shard-3') returning id, _tidb_rowid, ((1 << (64 - 4 - 1)) - 1) & _tidb_rowid as rowid_sequence;
+id	_tidb_rowid	rowid_sequence
+1	<sharded_rowid>	1
+2	<sharded_rowid>	2
+3	<sharded_rowid>	3
+drop table t_shard_rowid_returning;
 select * from t order by id;
 id	name	val
 1	alice	10

--- a/tests/integrationtest/r/executor/returning.result
+++ b/tests/integrationtest/r/executor/returning.result
@@ -1,0 +1,63 @@
+drop table if exists t;
+create table t (id int auto_increment primary key, name varchar(20), val int default 10);
+insert into t (name) values ('alice') returning *;
+id	name	val
+1	alice	10
+insert into t (name, val) values ('bob', 20) returning id, name;
+id	name
+2	bob
+insert into t (name, val) values ('charlie', 30) returning id, val + 1 as val_plus_one;
+id	val_plus_one
+3	31
+drop table if exists t2;
+create table t2 (id int, animal varchar(20));
+insert into t2(id, animal) values (1, 'Dog'), (2, 'Lion'), (3, 'Tiger'), (4, 'Leopard') returning id, id + id, id & id, id || id;
+id	id + id	id & id	id || id
+1	2	1	1
+2	4	2	1
+3	6	3	1
+4	8	4	1
+drop table t2;
+insert into t (name) values ('dave') returning id, val;
+id	val
+4	10
+insert into t (name, val) values ('eve', 50), ('frank', 60) returning id, name, val;
+id	name	val
+5	eve	50
+6	frank	60
+insert into t set name = 'gina', val = 70 returning id, name, val;
+id	name	val
+7	gina	70
+insert into t (name, val) select 'henry', 80 returning id, name, val;
+id	name	val
+8	henry	80
+insert into t (id, name, val) values (200, 'dup', 1);
+insert ignore into t (id, name, val) values (200, 'dup2', 2), (201, 'ok', 3) returning id, name;
+id	name
+201	ok
+insert into t (id, name, val) values (300, 'orig', 1);
+insert into t (id, name, val) values (300, 'updated', 5) on duplicate key update name=values(name), val=values(val)+1 returning id, name, val;
+id	name	val
+300	updated	6
+select * from t order by id;
+id	name	val
+1	alice	10
+2	bob	20
+3	charlie	30
+4	dave	10
+5	eve	50
+6	frank	60
+7	gina	70
+8	henry	80
+200	dup	1
+201	ok	3
+300	updated	6
+update t set val = val + 1 returning *;
+Error 1235 (42000): This version of TiDB doesn't yet support 'RETURNING clause'
+update t set val = 100 where id = 1 returning id, val;
+Error 1235 (42000): This version of TiDB doesn't yet support 'RETURNING clause'
+delete from t returning *;
+Error 1235 (42000): This version of TiDB doesn't yet support 'RETURNING clause'
+delete from t where id = 1 returning id, name;
+Error 1235 (42000): This version of TiDB doesn't yet support 'RETURNING clause'
+drop table t;

--- a/tests/integrationtest/t/executor/returning.test
+++ b/tests/integrationtest/t/executor/returning.test
@@ -1,0 +1,71 @@
+# Test RETURNING clause support
+# See https://github.com/pingcap/tidb/issues/58939
+
+# Create test table
+drop table if exists t;
+create table t (id int auto_increment primary key, name varchar(20), val int default 10);
+
+# ===========================================
+# INSERT RETURNING tests (fully supported)
+# ===========================================
+
+# Test INSERT RETURNING *
+insert into t (name) values ('alice') returning *;
+
+# Test INSERT RETURNING specific columns
+insert into t (name, val) values ('bob', 20) returning id, name;
+
+# Test INSERT RETURNING with expression
+insert into t (name, val) values ('charlie', 30) returning id, val + 1 as val_plus_one;
+
+# Test INSERT RETURNING with MariaDB-style select expressions
+drop table if exists t2;
+create table t2 (id int, animal varchar(20));
+insert into t2(id, animal) values (1, 'Dog'), (2, 'Lion'), (3, 'Tiger'), (4, 'Leopard') returning id, id + id, id & id, id || id;
+drop table t2;
+
+# Test INSERT RETURNING with default value
+insert into t (name) values ('dave') returning id, val;
+
+# Test multi-row INSERT RETURNING
+insert into t (name, val) values ('eve', 50), ('frank', 60) returning id, name, val;
+
+# Test INSERT ... SET RETURNING
+insert into t set name = 'gina', val = 70 returning id, name, val;
+
+# Test INSERT ... SELECT RETURNING
+insert into t (name, val) select 'henry', 80 returning id, name, val;
+
+# Test INSERT IGNORE RETURNING
+insert into t (id, name, val) values (200, 'dup', 1);
+insert ignore into t (id, name, val) values (200, 'dup2', 2), (201, 'ok', 3) returning id, name;
+
+# Test INSERT ... ON DUPLICATE KEY UPDATE RETURNING
+insert into t (id, name, val) values (300, 'orig', 1);
+insert into t (id, name, val) values (300, 'updated', 5) on duplicate key update name=values(name), val=values(val)+1 returning id, name, val;
+
+# Verify all rows were inserted correctly
+select * from t order by id;
+
+# ===========================================
+# UPDATE RETURNING tests (not supported yet)
+# ===========================================
+
+--error 1235
+update t set val = val + 1 returning *;
+
+--error 1235
+update t set val = 100 where id = 1 returning id, val;
+
+# ===========================================
+# DELETE RETURNING tests (not supported yet)
+# ===========================================
+
+--error 1235
+delete from t returning *;
+
+--error 1235
+delete from t where id = 1 returning id, name;
+
+# Clean up
+drop table t;

--- a/tests/integrationtest/t/executor/returning.test
+++ b/tests/integrationtest/t/executor/returning.test
@@ -44,6 +44,26 @@ insert ignore into t (id, name, val) values (200, 'dup2', 2), (201, 'ok', 3) ret
 insert into t (id, name, val) values (300, 'orig', 1);
 insert into t (id, name, val) values (300, 'updated', 5) on duplicate key update name=values(name), val=values(val)+1 returning id, name, val;
 
+# Test INSERT RETURNING with AUTO_RANDOM primary key
+drop table if exists t_auto_random_returning;
+create table t_auto_random_returning (id bigint primary key auto_random(3), name varchar(20));
+insert into t_auto_random_returning (name) values ('auto-random-1'), ('auto-random-2') returning id > 0 as generated_id, name;
+select count(*), count(distinct id), min(id > 0), max(id > 0) from t_auto_random_returning;
+drop table t_auto_random_returning;
+
+# Test INSERT RETURNING _tidb_rowid on NONCLUSTERED primary key
+drop table if exists t_nonclustered_returning;
+create table t_nonclustered_returning (id int, name varchar(20), primary key(id) nonclustered);
+insert into t_nonclustered_returning values (1, 'nonclustered-1'), (2, 'nonclustered-2') returning id, name, _tidb_rowid;
+drop table t_nonclustered_returning;
+
+# Test INSERT RETURNING _tidb_rowid with SHARD_ROW_ID_BITS
+drop table if exists t_shard_rowid_returning;
+create table t_shard_rowid_returning (id int, name varchar(20), primary key(id) nonclustered) shard_row_id_bits=4;
+--replace_column 2 <sharded_rowid>
+insert into t_shard_rowid_returning values (1, 'shard-1'), (2, 'shard-2'), (3, 'shard-3') returning id, _tidb_rowid, ((1 << (64 - 4 - 1)) - 1) & _tidb_rowid as rowid_sequence;
+drop table t_shard_rowid_returning;
+
 # Verify all rows were inserted correctly
 select * from t order by id;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tidb/issues/68269

This is the executor/planner implementation half split out from #65633 after the parser-only `RETURNING` syntax PR was merged.

### What changed and how does it work?

This PR adds `INSERT ... RETURNING` execution support on top of the merged parser support:

- planner builds RETURNING expressions, schema, and output names for INSERT
- executor evaluates RETURNING expressions from inserted/final rows
- supports `INSERT ... VALUES`, `INSERT ... SET`, `INSERT ... SELECT`, `INSERT IGNORE`, and `ON DUPLICATE KEY UPDATE`
- keeps `UPDATE/DELETE ... RETURNING` parsed but not supported yet
- adds integration coverage for supported INSERT variants and unsupported UPDATE/DELETE cases

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Introduce the `RETURNING` clause support from MariaDB.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * INSERT ... RETURNING: return inserted rows with column selection, expressions, wildcard expansion, multi-row, INSERT ... SELECT, and INSERT ... SET support.
  * RETURNING works with INSERT IGNORE and ON DUPLICATE KEY UPDATE (updated rows participate), and returns AUTO_RANDOM, _tidb_rowid, and computed rowid values where applicable.

* **Behavior**
  * UPDATE ... RETURNING and DELETE ... RETURNING are not supported and now produce a clear error.

* **Tests**
  * Added integration tests covering the above RETURNING behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->