### PR TITLE
ranger: reduce large IN range overhead

### DIFF
--- a/pkg/util/ranger/bench_test.go
+++ b/pkg/util/ranger/bench_test.go
@@ -16,6 +16,8 @@ package ranger_test
 
 import (
 	"context"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/expression"
@@ -27,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/ranger"
 	"github.com/stretchr/testify/require"
 )
@@ -136,4 +139,123 @@ WHERE
 		require.NoError(b, err)
 	}
 	b.StopTimer()
+}
+
+func BenchmarkDetachCondAndBuildRangeForIndexLeadingLongIN(b *testing.B) {
+	sctx, selection, dataSource := buildBenchmarkSelection(b, `
+CREATE TABLE t (
+    org_id bigint(20) NOT NULL,
+    flag tinyint(1) NOT NULL,
+    end_time bigint(20) NOT NULL,
+    KEY idx (org_id, flag, end_time)
+)`, "SELECT * FROM test.t WHERE org_id IN ("+makeBenchmarkIntList(512)+") AND flag = 0 AND end_time < 1437233819011")
+	conds := benchmarkConditions(sctx, selection)
+	cols, lengths := plannerutil.IndexInfo2PrefixCols(dataSource.TableInfo.Columns, selection.Schema().Columns, dataSource.TableInfo.Indices[0])
+	require.NotNil(b, cols)
+
+	b.ResetTimer()
+	pctx := sctx.GetPlanCtx()
+	var rangeCount int
+	var rangeBytes int64
+	for range b.N {
+		res, err := ranger.DetachCondAndBuildRangeForIndex(pctx.GetRangerCtx(), conds, cols, lengths, 0)
+		require.NoError(b, err)
+		rangeCount = len(res.Ranges)
+		rangeBytes = res.Ranges.MemUsage()
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(rangeCount), "ranges/op")
+	b.ReportMetric(float64(rangeBytes), "range-bytes/op")
+}
+
+func BenchmarkBuildColumnRangeLongIN(b *testing.B) {
+	sctx, selection, dataSource := buildBenchmarkSelection(b, `
+CREATE TABLE t (
+    org_id bigint(20) NOT NULL,
+    payload bigint(20) NOT NULL,
+    KEY idx (payload)
+)`, "SELECT * FROM test.t WHERE org_id IN ("+makeBenchmarkIntList(512)+")")
+	conds := benchmarkConditions(sctx, selection)
+	tp := &dataSource.TableInfo.Columns[0].FieldType
+
+	b.ResetTimer()
+	rctx := sctx.GetPlanCtx().GetRangerCtx()
+	var rangeCount int
+	var rangeBytes int64
+	for range b.N {
+		ranges, _, _, err := ranger.BuildColumnRange(conds, rctx, tp, types.UnspecifiedLength, 0)
+		require.NoError(b, err)
+		rangeCount = len(ranges)
+		rangeBytes = ranges.MemUsage()
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(rangeCount), "ranges/op")
+	b.ReportMetric(float64(rangeBytes), "range-bytes/op")
+}
+
+func buildBenchmarkSelection(b *testing.B, createTable, query string) (sessionctx.Context, *logicalop.LogicalSelection, *logicalop.DataSource) {
+	store := testkit.CreateMockStore(b)
+	testKit := testkit.NewTestKit(b, store)
+	testKit.MustExec("USE test")
+	testKit.MustExec("DROP TABLE IF EXISTS t")
+	testKit.MustExec(createTable)
+	sctx := testKit.Session().(sessionctx.Context)
+	stmts, err := session.Parse(sctx, query)
+	require.NoError(b, err)
+	require.Len(b, stmts, 1)
+	ret := &plannercore.PreprocessorReturn{}
+	nodeW := resolve.NewNodeW(stmts[0])
+	err = plannercore.Preprocess(context.Background(), sctx, nodeW, plannercore.WithPreprocessorReturn(ret))
+	require.NoError(b, err)
+	p, err := plannercore.BuildLogicalPlanForTest(context.Background(), sctx, nodeW, ret.InfoSchema)
+	require.NoError(b, err)
+	plan := p.(base.LogicalPlan)
+	selection := findBenchmarkSelection(plan)
+	require.NotNil(b, selection)
+	dataSource := findBenchmarkDataSource(selection)
+	require.NotNil(b, dataSource)
+	return sctx, selection, dataSource
+}
+
+func benchmarkConditions(sctx sessionctx.Context, selection *logicalop.LogicalSelection) []expression.Expression {
+	conds := make([]expression.Expression, len(selection.Conditions))
+	for i, cond := range selection.Conditions {
+		conds[i] = expression.PushDownNot(sctx.GetExprCtx(), cond)
+	}
+	return conds
+}
+
+func findBenchmarkSelection(plan base.LogicalPlan) *logicalop.LogicalSelection {
+	if selection, ok := plan.(*logicalop.LogicalSelection); ok {
+		return selection
+	}
+	for _, child := range plan.Children() {
+		if selection := findBenchmarkSelection(child); selection != nil {
+			return selection
+		}
+	}
+	return nil
+}
+
+func findBenchmarkDataSource(plan base.LogicalPlan) *logicalop.DataSource {
+	if dataSource, ok := plan.(*logicalop.DataSource); ok {
+		return dataSource
+	}
+	for _, child := range plan.Children() {
+		if dataSource := findBenchmarkDataSource(child); dataSource != nil {
+			return dataSource
+		}
+	}
+	return nil
+}
+
+func makeBenchmarkIntList(n int) string {
+	var buf strings.Builder
+	for i := range n {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(strconv.Itoa(i + 1))
+	}
+	return buf.String()
 }

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -656,6 +656,8 @@ func (r *builder) buildFromIn(
 ) ([]*point, bool) {
 	list := expr.GetArgs()[1:]
 	rangePoints := make([]*point, 0, len(list)*2)
+	pointObjs := make([]point, len(list)*2)
+	pointCount := 0
 	hasNull := false
 	ft := expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx())
 	colCollate := ft.GetCollate()
@@ -676,19 +678,18 @@ func (r *builder) buildFromIn(
 			hasNull = true
 			continue
 		}
-		if expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()).GetType() == mysql.TypeEnum {
+		if ft.GetType() == mysql.TypeEnum {
 			switch dt.Kind() {
 			case types.KindString, types.KindBytes, types.KindBinaryLiteral:
 				// Can't use ConvertTo directly, since we shouldn't convert numerical string to Enum in select stmt.
-				targetType := expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx())
-				enum, parseErr := types.ParseEnumName(targetType.GetElems(), dt.GetString(), targetType.GetCollate())
+				enum, parseErr := types.ParseEnumName(ft.GetElems(), dt.GetString(), ft.GetCollate())
 				if parseErr == nil {
-					dt.SetMysqlEnum(enum, targetType.GetCollate())
+					dt.SetMysqlEnum(enum, ft.GetCollate())
 				} else {
 					err = parseErr
 				}
 			default:
-				dt, err = dt.ConvertTo(tc, expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()))
+				dt, err = dt.ConvertTo(tc, ft)
 			}
 
 			if err != nil {
@@ -696,21 +697,23 @@ func (r *builder) buildFromIn(
 				continue
 			}
 		}
-		if expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()).GetType() == mysql.TypeYear {
-			dt, err = dt.ConvertToMysqlYear(tc, expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()))
+		if ft.GetType() == mysql.TypeYear {
+			dt, err = dt.ConvertToMysqlYear(tc, ft)
 			if err != nil {
 				// in (..., an impossible value (not valid year), ...), the range is empty, so skip it.
 				continue
 			}
 		}
-		if expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()).EvalType() == types.ETString && (dt.Kind() == types.KindString || dt.Kind() == types.KindBinaryLiteral) {
-			dt.SetString(dt.GetString(), expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()).GetCollate()) // refine the string like what we did in builder.buildFromBinOp
+		if ft.EvalType() == types.ETString && (dt.Kind() == types.KindString || dt.Kind() == types.KindBinaryLiteral) {
+			dt.SetString(dt.GetString(), ft.GetCollate()) // refine the string like what we did in builder.buildFromBinOp
 		}
-		var startValue, endValue types.Datum
-		dt.Copy(&startValue)
-		dt.Copy(&endValue)
-		startPoint := &point{value: startValue, start: true}
-		endPoint := &point{value: endValue}
+		dt.Copy(&pointObjs[pointCount].value)
+		pointObjs[pointCount].start = true
+		startPoint := &pointObjs[pointCount]
+		pointCount++
+		dt.Copy(&pointObjs[pointCount].value)
+		endPoint := &pointObjs[pointCount]
+		pointCount++
 		rangePoints = append(rangePoints, startPoint, endPoint)
 	}
 	sorter := pointSorter{points: rangePoints, tc: tc, collator: collate.GetCollator(colCollate)}

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -18,7 +18,7 @@ import (
 	"cmp"
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
@@ -71,66 +71,43 @@ func (rp *point) String() string {
 	return fmt.Sprintf("%v%s", val, symbol)
 }
 
-func (rp *point) Clone(value types.Datum) *point {
-	return &point{
-		value: value,
-		excl:  rp.excl,
-		start: rp.start,
-	}
-}
-
-type pointSorter struct {
-	err      error
-	collator collate.Collator
-	tc       types.Context
-	points   []*point
-}
-
-func (r *pointSorter) Len() int {
-	return len(r.points)
-}
-
-func (r *pointSorter) Less(i, j int) bool {
-	a := r.points[i]
-	b := r.points[j]
-	less, err := rangePointLess(r.tc, a, b, r.collator)
-	if err != nil {
-		r.err = err
-	}
-	return less
-}
-
-func rangePointLess(tc types.Context, a, b *point, collator collate.Collator) (bool, error) {
+func rangePointCmp(tc types.Context, a, b *point, collator collate.Collator) (int, error) {
 	if a.value.Kind() == types.KindMysqlEnum && b.value.Kind() == types.KindMysqlEnum {
-		return rangePointEnumLess(a, b)
+		return rangePointEnumCmp(a, b)
 	}
 	cmp, err := a.value.Compare(tc, &b.value, collator)
 	if cmp != 0 {
-		return cmp < 0, nil
+		return cmp, nil
 	}
-	return rangePointEqualValueLess(a, b), errors.Trace(err)
+	return rangePointEqualValueCmp(a, b), errors.Trace(err)
 }
 
-func rangePointEnumLess(a, b *point) (bool, error) {
+func rangePointEnumCmp(a, b *point) (int, error) {
 	cmp := cmp.Compare(a.value.GetInt64(), b.value.GetInt64())
 	if cmp != 0 {
-		return cmp < 0, nil
+		return cmp, nil
 	}
-	return rangePointEqualValueLess(a, b), nil
+	return rangePointEqualValueCmp(a, b), nil
 }
 
-func rangePointEqualValueLess(a, b *point) bool {
+func rangePointEqualValueCmp(a, b *point) int {
+	var result bool
 	if a.start && b.start {
-		return !a.excl && b.excl
+		result = !a.excl && b.excl
 	} else if a.start {
-		return !a.excl && !b.excl
+		result = !a.excl && !b.excl
 	} else if b.start {
-		return a.excl || b.excl
+		result = a.excl || b.excl
+	} else {
+		result = a.excl && !b.excl
 	}
-	return a.excl && !b.excl
+	if result {
+		return -1
+	}
+	return 0
 }
 
-func pointsConvertToSortKey(sctx *rangerctx.RangerContext, inputPs []*point, newTp *types.FieldType) ([]*point, error) {
+func convertPointsToSortKeyInPlace(sctx *rangerctx.RangerContext, points []*point, newTp *types.FieldType) error {
 	// Only handle normal string type here.
 	// Currently, set won't be pushed down and it shouldn't reach here in theory.
 	// For enum, we have separate logic for it, like handleEnumFromBinOp(). For now, it only supports point range,
@@ -138,31 +115,27 @@ func pointsConvertToSortKey(sctx *rangerctx.RangerContext, inputPs []*point, new
 	if newTp.EvalType() != types.ETString ||
 		newTp.GetType() == mysql.TypeEnum ||
 		newTp.GetType() == mysql.TypeSet {
-		return inputPs, nil
+		return nil
 	}
-	ps := make([]*point, 0, len(inputPs))
-	for _, p := range inputPs {
-		np, err := pointConvertToSortKey(sctx, p, newTp, true)
-		if err != nil {
-			return nil, err
+	for _, p := range points {
+		if err := convertPointToSortKeyInPlace(sctx, p, newTp, true); err != nil {
+			return err
 		}
-		ps = append(ps, np)
 	}
-	return ps, nil
+	return nil
 }
 
-func pointConvertToSortKey(
+func convertPointToSortKeyInPlace(
 	sctx *rangerctx.RangerContext,
-	inputP *point,
+	p *point,
 	newTp *types.FieldType,
 	trimTrailingSpace bool,
-) (*point, error) {
-	p, err := convertPoint(sctx, inputP, newTp)
-	if err != nil {
-		return nil, err
+) error {
+	if err := convertPointInPlace(sctx, p, newTp); err != nil {
+		return err
 	}
 	if p.value.Kind() != types.KindString || newTp.GetCollate() == charset.CollationBin || !collate.NewCollationEnabled() {
-		return p, nil
+		return nil
 	}
 	sortKey := p.value.GetBytes()
 	if !trimTrailingSpace {
@@ -171,11 +144,8 @@ func pointConvertToSortKey(
 		sortKey = collate.GetCollator(newTp.GetCollate()).Key(string(hack.String(sortKey)))
 	}
 
-	return &point{value: types.NewBytesDatum(sortKey), excl: p.excl, start: p.start}, nil
-}
-
-func (r *pointSorter) Swap(i, j int) {
-	r.points[i], r.points[j] = r.points[j], r.points[i]
+	p.value = types.NewBytesDatum(sortKey)
+	return nil
 }
 
 /*
@@ -460,8 +430,7 @@ func (r *builder) buildFromBinOp(
 	}
 	cutPrefixForPoints(res, prefixLen, ft)
 	if convertToSortKey {
-		res, err = pointsConvertToSortKey(r.sctx, res, newTp)
-		if err != nil {
+		if err = convertPointsToSortKeyInPlace(r.sctx, res, newTp); err != nil {
 			r.err = err
 			return getFullRange()
 		}
@@ -716,11 +685,11 @@ func (r *builder) buildFromIn(
 		pointCount++
 		rangePoints = append(rangePoints, startPoint, endPoint)
 	}
-	sorter := pointSorter{points: rangePoints, tc: tc, collator: collate.GetCollator(colCollate)}
-	sort.Sort(&sorter)
-	if sorter.err != nil {
-		r.err = sorter.err
-	}
+	collator := collate.GetCollator(colCollate)
+	slices.SortFunc(rangePoints, func(a, b *point) (cmpare int) {
+		cmpare, r.err = rangePointCmp(tc, a, b, collator)
+		return cmpare
+	})
 	// check and remove duplicates
 	curPos, frontPos := 0, 0
 	for frontPos < len(rangePoints) {
@@ -737,10 +706,8 @@ func (r *builder) buildFromIn(
 	}
 	rangePoints = rangePoints[:curPos]
 	cutPrefixForPoints(rangePoints, prefixLen, ft)
-	var err error
 	if convertToSortKey {
-		rangePoints, err = pointsConvertToSortKey(r.sctx, rangePoints, newTp)
-		if err != nil {
+		if err := convertPointsToSortKeyInPlace(r.sctx, rangePoints, newTp); err != nil {
 			r.err = err
 			return getFullRange(), false
 		}
@@ -775,8 +742,7 @@ func (r *builder) newBuildFromPatternLike(
 		endPoint := &point{value: types.NewStringDatum("")}
 		res := []*point{startPoint, endPoint}
 		if convertToSortKey {
-			res, err = pointsConvertToSortKey(r.sctx, res, newTp)
-			if err != nil {
+			if err := convertPointsToSortKeyInPlace(r.sctx, res, newTp); err != nil {
 				r.err = err
 				return getFullRange()
 			}
@@ -834,8 +800,7 @@ func (r *builder) newBuildFromPatternLike(
 		res := []*point{startPoint, endPoint}
 		cutPrefixForPoints(res, prefixLen, tpOfPattern)
 		if convertToSortKey {
-			res, err = pointsConvertToSortKey(r.sctx, res, newTp)
-			if err != nil {
+			if err := convertPointsToSortKeyInPlace(r.sctx, res, newTp); err != nil {
 				r.err = err
 				return getFullRange()
 			}
@@ -855,9 +820,9 @@ func (r *builder) newBuildFromPatternLike(
 
 	// non-exceptional return case 4-2: build a range for the wildcard
 	// the end_key is sortKey(start_value) + 1
-	originalStartPoint := &point{start: true, excl: exclude}
+	originalStartPoint := point{start: true, excl: exclude}
 	originalStartPoint.value.SetBytesAsString(lowValue, tpOfPattern.GetCollate(), uint32(tpOfPattern.GetFlen()))
-	cutPrefixForPoints([]*point{originalStartPoint}, prefixLen, tpOfPattern)
+	cutPrefixForPoints([]*point{&originalStartPoint}, prefixLen, tpOfPattern)
 
 	// If we don't trim the trailing spaces, which means using KeyWithoutTrimRightSpace() instead of Key(), we can build
 	// a smaller range for better performance, e.g., LIKE '  %'.
@@ -866,13 +831,13 @@ func (r *builder) newBuildFromPatternLike(
 	// column, the start key should be 'abd' instead of 'abc ', but the end key can be 'abc!'. ( ' ' is 32 and '!' is 33
 	// in ASCII)
 	shouldTrimTrailingSpace := collate.IsPadSpaceCollation(collation)
-	startPoint, err := pointConvertToSortKey(r.sctx, originalStartPoint, newTp, shouldTrimTrailingSpace)
-	if err != nil {
+	startPoint := originalStartPoint
+	if err := convertPointToSortKeyInPlace(r.sctx, &startPoint, newTp, shouldTrimTrailingSpace); err != nil {
 		r.err = errors.Trace(err)
 		return getFullRange()
 	}
-	sortKeyPointWithoutTrim, err := pointConvertToSortKey(r.sctx, originalStartPoint, newTp, false)
-	if err != nil {
+	sortKeyPointWithoutTrim := originalStartPoint
+	if err := convertPointToSortKeyInPlace(r.sctx, &sortKeyPointWithoutTrim, newTp, false); err != nil {
 		r.err = errors.Trace(err)
 		return getFullRange()
 	}
@@ -892,7 +857,7 @@ func (r *builder) newBuildFromPatternLike(
 			endPoint.value = types.MaxValueDatum()
 		}
 	}
-	return []*point{startPoint, endPoint}
+	return []*point{&startPoint, endPoint}
 }
 
 func (r *builder) buildFromNot(
@@ -948,9 +913,7 @@ func (r *builder) buildFromNot(
 		retRangePoints = append(retRangePoints, &point{value: types.MaxValueDatum()})
 		cutPrefixForPoints(retRangePoints, prefixLen, expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()))
 		if convertToSortKey {
-			var err error
-			retRangePoints, err = pointsConvertToSortKey(r.sctx, retRangePoints, newTp)
-			if err != nil {
+			if err := convertPointsToSortKeyInPlace(r.sctx, retRangePoints, newTp); err != nil {
 				r.err = err
 				return getFullRange()
 			}
@@ -1033,12 +996,12 @@ func (r *builder) mergeSorted(a, b []*point, collator collate.Collator) []*point
 	i, j := 0, 0
 	tc := r.sctx.TypeCtx
 	for i < len(a) && j < len(b) {
-		less, err := rangePointLess(tc, a[i], b[j], collator)
+		cmp, err := rangePointCmp(tc, a[i], b[j], collator)
 		if err != nil {
 			r.err = err
 			return nil
 		}
-		if less {
+		if cmp < 0 {
 			ret = append(ret, a[i])
 			i++
 		} else {

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -60,9 +60,9 @@ func validInterval(ec errctx.Context, loc *time.Location, low, high *point) (boo
 	return bytes.Compare(l, r) < 0, nil
 }
 
-// convertPoints does some preprocessing on rangePoints to make them ready to build ranges. Preprocessing includes converting
-// points to the specified type, validating intervals and skipping impossible intervals.
-func convertPoints(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *types.FieldType, skipNull bool, tableRange bool) ([]*point, error) {
+// convertPointsInPlace does some preprocessing on rangePoints to make them ready to build ranges. It converts
+// points to the specified type in place, validates intervals, and compacts valid intervals to the front of rangePoints.
+func convertPointsInPlace(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *types.FieldType, skipNull bool, tableRange bool) ([]*point, error) {
 	i := 0
 	numPoints := len(rangePoints)
 	var minValueDatum, maxValueDatum types.Datum
@@ -78,8 +78,8 @@ func convertPoints(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 		}
 	}
 	for j := 0; j < numPoints; j += 2 {
-		startPoint, err := convertPoint(sctx, rangePoints[j], newTp)
-		if err != nil {
+		startPoint := rangePoints[j]
+		if err := convertPointInPlace(sctx, startPoint, newTp); err != nil {
 			return nil, errors.Trace(err)
 		}
 		if tableRange {
@@ -90,8 +90,8 @@ func convertPoints(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 				startPoint.value = minValueDatum
 			}
 		}
-		endPoint, err := convertPoint(sctx, rangePoints[j+1], newTp)
-		if err != nil {
+		endPoint := rangePoints[j+1]
+		if err := convertPointInPlace(sctx, endPoint, newTp); err != nil {
 			return nil, errors.Trace(err)
 		}
 		if tableRange {
@@ -127,12 +127,12 @@ func estimateMemUsageForPoints2Ranges(rangePoints []*point) int64 {
 // rangeMaxSize is the max memory limit for ranges. O indicates no memory limit.
 // If the second return value is true, it means that the estimated memory usage of ranges exceeds rangeMaxSize and it falls back to full range.
 func points2Ranges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *types.FieldType, rangeMaxSize int64) (Ranges, bool, error) {
-	convertedPoints, err := convertPoints(sctx, rangePoints, newTp, mysql.HasNotNullFlag(newTp.GetFlag()), false)
+	rangePoints, err := convertPointsInPlace(sctx, rangePoints, newTp, mysql.HasNotNullFlag(newTp.GetFlag()), false)
 	if err != nil {
 		return nil, false, errors.Trace(err)
 	}
 	// Estimate whether rangeMaxSize will be exceeded first before converting points to ranges.
-	if rangeMaxSize > 0 && estimateMemUsageForPoints2Ranges(convertedPoints) > rangeMaxSize {
+	if rangeMaxSize > 0 && estimateMemUsageForPoints2Ranges(rangePoints) > rangeMaxSize {
 		var fullRange Ranges
 		if mysql.HasNotNullFlag(newTp.GetFlag()) {
 			fullRange = FullNotNullRange()
@@ -141,7 +141,7 @@ func points2Ranges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 		}
 		return fullRange, true, nil
 	}
-	rangeCount := len(convertedPoints) / 2
+	rangeCount := len(rangePoints) / 2
 	// Keep emitted ranges and their single-column backing slices in batch
 	// storage to avoid per-range heap allocations on long-IN workloads.
 	ranges := make(Ranges, rangeCount)
@@ -151,7 +151,7 @@ func points2Ranges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 	collatorBuf := make([]collate.Collator, rangeCount)
 	rangeCollator := collate.GetCollator(newTp.GetCollate())
 	for i := range rangeCount {
-		startPoint, endPoint := convertedPoints[i*2], convertedPoints[i*2+1]
+		startPoint, endPoint := rangePoints[i*2], rangePoints[i*2+1]
 		// Batch-allocate the backing arrays, but clamp each slice to len==cap.
 		// Some callers append tail datums to an emitted range later, and that append
 		// must not overwrite the neighboring ranges that share the same buffer.
@@ -174,16 +174,16 @@ func points2Ranges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 	return ranges, false, nil
 }
 
-func convertPoint(sctx *rangerctx.RangerContext, point *point, newTp *types.FieldType) (*point, error) {
-	switch point.value.Kind() {
+func convertPointInPlace(sctx *rangerctx.RangerContext, p *point, newTp *types.FieldType) error {
+	switch p.value.Kind() {
 	case types.KindMaxValue, types.KindMinNotNull:
-		return point, nil
+		return nil
 	}
-	casted, err := point.value.ConvertTo(sctx.TypeCtx, newTp)
+	casted, err := p.value.ConvertTo(sctx.TypeCtx, newTp)
 	if err != nil {
 		if sctx.InPreparedPlanBuilding {
 			// skip plan cache in this case for safety.
-			sctx.SetSkipPlanCache(fmt.Sprintf("%s when converting %v", err.Error(), point.value))
+			sctx.SetSkipPlanCache(fmt.Sprintf("%s when converting %v", err.Error(), p.value))
 		}
 		//revive:disable:empty-block
 		if newTp.GetType() == mysql.TypeYear && terror.ErrorEqual(err, types.ErrWarnDataOutOfRange) {
@@ -195,16 +195,16 @@ func convertPoint(sctx *rangerctx.RangerContext, point *point, newTp *types.Fiel
 			// A trimmed valid boundary point value would be returned then. Accordingly, the `excl` of the point
 			// would be adjusted. Impossible ranges would be skipped by the `validInterval` call later.
 			// tests in TestIndexRange/TestIndexRangeForDecimal
-		} else if point.value.Kind() == types.KindMysqlTime && newTp.GetType() == mysql.TypeTimestamp && terror.ErrorEqual(err, types.ErrWrongValue) {
+		} else if p.value.Kind() == types.KindMysqlTime && newTp.GetType() == mysql.TypeTimestamp && terror.ErrorEqual(err, types.ErrWrongValue) {
 			// See issue #28424: query failed after add index
 			// Ignore conversion from Date[Time] to Timestamp since it must be either out of range or impossible date, which will not match a point select
 		} else if newTp.GetType() == mysql.TypeEnum && terror.ErrorEqual(err, types.ErrTruncated) {
 			// Ignore the types.ErrorTruncated when we convert TypeEnum values.
 			// We should cover Enum upper overflow, and convert to the biggest value.
-			if point.value.GetInt64() > 0 {
+			if p.value.GetInt64() > 0 {
 				upperEnum, err := types.ParseEnumValue(newTp.GetElems(), uint64(len(newTp.GetElems())))
 				if err != nil {
-					return nil, err
+					return err
 				}
 				casted.SetMysqlEnum(upperEnum, newTp.GetCollate())
 			}
@@ -212,46 +212,46 @@ func convertPoint(sctx *rangerctx.RangerContext, point *point, newTp *types.Fiel
 			// The invalid string can be produced by changing datum's underlying bytes directly.
 			// For example, newBuildFromPatternLike calculates the end point by adding 1 to bytes.
 			// We need to skip these invalid strings.
-			return point, nil
+			return nil
 		} else {
-			return point, errors.Trace(err)
+			return errors.Trace(err)
 		}
 		//revive:enable:empty-block
 	}
-	valCmpCasted, err := point.value.Compare(sctx.TypeCtx, &casted, collate.GetCollator(newTp.GetCollate()))
+	valCmpCasted, err := p.value.Compare(sctx.TypeCtx, &casted, collate.GetCollator(newTp.GetCollate()))
 	if err != nil {
-		return point, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	npoint := point.Clone(casted)
+	p.value = casted
 	if valCmpCasted == 0 {
-		return npoint, nil
+		return nil
 	}
-	if npoint.start {
-		if npoint.excl {
+	if p.start {
+		if p.excl {
 			if valCmpCasted < 0 {
 				// e.g. "a > 1.9" convert to "a >= 2".
-				npoint.excl = false
+				p.excl = false
 			}
 		} else {
 			if valCmpCasted > 0 {
 				// e.g. "a >= 1.1 convert to "a > 1"
-				npoint.excl = true
+				p.excl = true
 			}
 		}
 	} else {
-		if npoint.excl {
+		if p.excl {
 			if valCmpCasted > 0 {
 				// e.g. "a < 1.1" convert to "a <= 1"
-				npoint.excl = false
+				p.excl = false
 			}
 		} else {
 			if valCmpCasted < 0 {
 				// e.g. "a <= 1.9" convert to "a < 2"
-				npoint.excl = true
+				p.excl = true
 			}
 		}
 	}
-	return npoint, nil
+	return nil
 }
 
 func getRangesTotalDatumSize(ranges Ranges) (sum int64) {
@@ -293,12 +293,12 @@ func estimateMemUsageForAppendPoints2Ranges(origin Ranges, rangePoints []*point)
 // rangeMaxSize and the function rejects appending points to ranges.
 func appendPoints2Ranges(sctx *rangerctx.RangerContext, origin Ranges, rangePoints []*point,
 	newTp *types.FieldType, rangeMaxSize int64) (Ranges, bool, error) {
-	convertedPoints, err := convertPoints(sctx, rangePoints, newTp, false, false)
+	rangePoints, err := convertPointsInPlace(sctx, rangePoints, newTp, false, false)
 	if err != nil {
 		return nil, false, errors.Trace(err)
 	}
 	// Estimate whether rangeMaxSize will be exceeded first before appending points to ranges.
-	if rangeMaxSize > 0 && estimateMemUsageForAppendPoints2Ranges(origin, convertedPoints) > rangeMaxSize {
+	if rangeMaxSize > 0 && estimateMemUsageForAppendPoints2Ranges(origin, rangePoints) > rangeMaxSize {
 		return origin, true, nil
 	}
 	var newIndexRanges Ranges
@@ -307,7 +307,7 @@ func appendPoints2Ranges(sctx *rangerctx.RangerContext, origin Ranges, rangePoin
 		if !oRange.IsPoint(sctx) {
 			newIndexRanges = append(newIndexRanges, oRange)
 		} else {
-			newRanges, err := appendPoints2IndexRange(oRange, convertedPoints, newTp)
+			newRanges, err := appendPoints2IndexRange(oRange, rangePoints, newTp)
 			if err != nil {
 				return nil, false, errors.Trace(err)
 			}
@@ -464,16 +464,16 @@ func AppendRanges2PointRanges(pointRanges Ranges, ranges Ranges, rangeMaxSize in
 // rangeMaxSize is the max memory limit for ranges. O indicates no memory limit.
 // If the second return value is true, it means that the estimated memory usage of ranges exceeds rangeMaxSize and it falls back to full range.
 func points2TableRanges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *types.FieldType, rangeMaxSize int64) (Ranges, bool, error) {
-	convertedPoints, err := convertPoints(sctx, rangePoints, newTp, true, true)
+	rangePoints, err := convertPointsInPlace(sctx, rangePoints, newTp, true, true)
 	if err != nil {
 		return nil, false, errors.Trace(err)
 	}
-	if rangeMaxSize > 0 && estimateMemUsageForPoints2Ranges(convertedPoints) > rangeMaxSize {
+	if rangeMaxSize > 0 && estimateMemUsageForPoints2Ranges(rangePoints) > rangeMaxSize {
 		return FullIntRange(mysql.HasUnsignedFlag(newTp.GetFlag())), true, nil
 	}
-	ranges := make(Ranges, 0, len(convertedPoints)/2)
-	for i := 0; i < len(convertedPoints); i += 2 {
-		startPoint, endPoint := convertedPoints[i], convertedPoints[i+1]
+	ranges := make(Ranges, 0, len(rangePoints)/2)
+	for i := 0; i < len(rangePoints); i += 2 {
+		startPoint, endPoint := rangePoints[i], rangePoints[i+1]
 		ran := &Range{
 			LowVal:      []types.Datum{startPoint.value},
 			LowExclude:  startPoint.excl,

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -141,17 +141,35 @@ func points2Ranges(sctx *rangerctx.RangerContext, rangePoints []*point, newTp *t
 		}
 		return fullRange, true, nil
 	}
-	ranges := make(Ranges, 0, len(convertedPoints)/2)
-	for i := 0; i < len(convertedPoints); i += 2 {
-		startPoint, endPoint := convertedPoints[i], convertedPoints[i+1]
-		ran := &Range{
-			LowVal:      []types.Datum{startPoint.value},
+	rangeCount := len(convertedPoints) / 2
+	// Keep emitted ranges and their single-column backing slices in batch
+	// storage to avoid per-range heap allocations on long-IN workloads.
+	ranges := make(Ranges, rangeCount)
+	rangeObjs := make([]Range, rangeCount)
+	lowValBuf := make([]types.Datum, rangeCount)
+	highValBuf := make([]types.Datum, rangeCount)
+	collatorBuf := make([]collate.Collator, rangeCount)
+	rangeCollator := collate.GetCollator(newTp.GetCollate())
+	for i := range rangeCount {
+		startPoint, endPoint := convertedPoints[i*2], convertedPoints[i*2+1]
+		// Batch-allocate the backing arrays, but clamp each slice to len==cap.
+		// Some callers append tail datums to an emitted range later, and that append
+		// must not overwrite the neighboring ranges that share the same buffer.
+		lowVal := lowValBuf[i : i+1 : i+1]
+		lowVal[0] = startPoint.value
+		highVal := highValBuf[i : i+1 : i+1]
+		highVal[0] = endPoint.value
+		collators := collatorBuf[i : i+1 : i+1]
+		collators[0] = rangeCollator
+
+		rangeObjs[i] = Range{
+			LowVal:      lowVal,
 			LowExclude:  startPoint.excl,
-			HighVal:     []types.Datum{endPoint.value},
+			HighVal:     highVal,
 			HighExclude: endPoint.excl,
-			Collators:   []collate.Collator{collate.GetCollator(newTp.GetCollate())},
+			Collators:   collators,
 		}
-		ranges = append(ranges, ran)
+		ranges[i] = &rangeObjs[i]
 	}
 	return ranges, false, nil
 }
@@ -300,30 +318,49 @@ func appendPoints2Ranges(sctx *rangerctx.RangerContext, origin Ranges, rangePoin
 }
 
 func appendPoints2IndexRange(origin *Range, rangePoints []*point, ft *types.FieldType) (Ranges, error) {
-	newRanges := make(Ranges, 0, len(rangePoints)/2)
+	rangeCount := len(rangePoints) / 2
+	// Keep emitted ranges in batch storage; each range will take one widened
+	// low/high/collator segment from the backing buffers below.
+	newRanges := make(Ranges, rangeCount)
+	rangeObjs := make([]Range, rangeCount)
+	lowWidth := len(origin.LowVal) + 1
+	highWidth := len(origin.HighVal) + 1
+	collatorWidth := len(origin.Collators) + 1
+	extraCollator := collate.GetCollator(ft.GetCollate())
+
+	lowValBuf := make([]types.Datum, rangeCount*lowWidth)
+	highValBuf := make([]types.Datum, rangeCount*highWidth)
+	collatorBuf := make([]collate.Collator, rangeCount*collatorWidth)
 	for i := 0; i < len(rangePoints); i += 2 {
+		rangeIdx := i / 2
 		startPoint, endPoint := rangePoints[i], rangePoints[i+1]
 
-		lowVal := make([]types.Datum, len(origin.LowVal)+1)
+		// Batch-allocate the backing arrays, but clamp each slice to len==cap.
+		// Some callers append tail datums to an emitted range later, and that append
+		// must not overwrite the neighboring ranges that share the same buffer.
+		lowOffset := rangeIdx * lowWidth
+		lowVal := lowValBuf[lowOffset : lowOffset+lowWidth : lowOffset+lowWidth]
 		copy(lowVal, origin.LowVal)
 		lowVal[len(origin.LowVal)] = startPoint.value
 
-		highVal := make([]types.Datum, len(origin.HighVal)+1)
+		highOffset := rangeIdx * highWidth
+		highVal := highValBuf[highOffset : highOffset+highWidth : highOffset+highWidth]
 		copy(highVal, origin.HighVal)
 		highVal[len(origin.HighVal)] = endPoint.value
 
-		collators := make([]collate.Collator, len(origin.Collators)+1)
+		collatorOffset := rangeIdx * collatorWidth
+		collators := collatorBuf[collatorOffset : collatorOffset+collatorWidth : collatorOffset+collatorWidth]
 		copy(collators, origin.Collators)
-		collators[len(origin.Collators)] = collate.GetCollator(ft.GetCollate())
+		collators[len(origin.Collators)] = extraCollator
 
-		ir := &Range{
+		rangeObjs[rangeIdx] = Range{
 			LowVal:      lowVal,
 			LowExclude:  startPoint.excl,
 			HighVal:     highVal,
 			HighExclude: endPoint.excl,
 			Collators:   collators,
 		}
-		newRanges = append(newRanges, ir)
+		newRanges[rangeIdx] = &rangeObjs[rangeIdx]
 	}
 	return newRanges, nil
 }
@@ -338,29 +375,6 @@ func estimateMemUsageForAppendRanges2PointRanges(pointRanges Ranges, ranges Rang
 	return (EmptyRangeSize+collatorSize)*len1*len2 + getRangesTotalDatumSize(pointRanges)*len2 + getRangesTotalDatumSize(ranges)*len1
 }
 
-// appendRange2PointRange appends suffixRange to pointRange.
-func appendRange2PointRange(pointRange, suffixRange *Range) *Range {
-	lowVal := make([]types.Datum, 0, len(pointRange.LowVal)+len(suffixRange.LowVal))
-	lowVal = append(lowVal, pointRange.LowVal...)
-	lowVal = append(lowVal, suffixRange.LowVal...)
-
-	highVal := make([]types.Datum, 0, len(pointRange.HighVal)+len(suffixRange.HighVal))
-	highVal = append(highVal, pointRange.HighVal...)
-	highVal = append(highVal, suffixRange.HighVal...)
-
-	collators := make([]collate.Collator, 0, len(pointRange.Collators)+len(suffixRange.Collators))
-	collators = append(collators, pointRange.Collators...)
-	collators = append(collators, suffixRange.Collators...)
-
-	return &Range{
-		LowVal:      lowVal,
-		LowExclude:  suffixRange.LowExclude,
-		HighVal:     highVal,
-		HighExclude: suffixRange.HighExclude,
-		Collators:   collators,
-	}
-}
-
 // AppendRanges2PointRanges appends additional ranges to point ranges.
 // rangeMaxSize is the max memory limit for ranges. O indicates no memory limit.
 // If the second return value is true, it means that the estimated memory after appending additional ranges to point ranges
@@ -373,10 +387,73 @@ func AppendRanges2PointRanges(pointRanges Ranges, ranges Ranges, rangeMaxSize in
 	if rangeMaxSize > 0 && estimateMemUsageForAppendRanges2PointRanges(pointRanges, ranges) > rangeMaxSize {
 		return pointRanges, true
 	}
-	newRanges := make(Ranges, 0, len(pointRanges)*len(ranges))
+	rangeCount := len(pointRanges) * len(ranges)
+	sumPointLow := 0
+	sumPointHigh := 0
+	sumPointCollator := 0
 	for _, pointRange := range pointRanges {
+		sumPointLow += len(pointRange.LowVal)
+		sumPointHigh += len(pointRange.HighVal)
+		sumPointCollator += len(pointRange.Collators)
+	}
+	sumRangeLow := 0
+	sumRangeHigh := 0
+	sumRangeCollator := 0
+	for _, r := range ranges {
+		sumRangeLow += len(r.LowVal)
+		sumRangeHigh += len(r.HighVal)
+		sumRangeCollator += len(r.Collators)
+	}
+	totalLowDatumCount := sumPointLow*len(ranges) + sumRangeLow*len(pointRanges)
+	totalHighDatumCount := sumPointHigh*len(ranges) + sumRangeHigh*len(pointRanges)
+	totalCollatorCount := sumPointCollator*len(ranges) + sumRangeCollator*len(pointRanges)
+
+	// Allocate storage for the full fanout once. Individual result ranges take
+	// capped subslices below, which avoids per-result slice allocation.
+	newRanges := make(Ranges, rangeCount)
+	rangeObjs := make([]Range, rangeCount)
+	lowValBuf := make([]types.Datum, totalLowDatumCount)
+	highValBuf := make([]types.Datum, totalHighDatumCount)
+	collatorBuf := make([]collate.Collator, totalCollatorCount)
+	rangeIdx := 0
+	lowDatumOffset := 0
+	highDatumOffset := 0
+	collatorOffset := 0
+	for _, pointRange := range pointRanges {
+		pointLowWidth := len(pointRange.LowVal)
+		pointHighWidth := len(pointRange.HighVal)
+		pointCollatorWidth := len(pointRange.Collators)
 		for _, r := range ranges {
-			newRanges = append(newRanges, appendRange2PointRange(pointRange, r))
+			lowWidth := pointLowWidth + len(r.LowVal)
+			highWidth := pointHighWidth + len(r.HighVal)
+			// Batch-allocate the backing arrays, but clamp each slice to len==cap.
+			// Some callers append tail datums to an emitted range later, and that append
+			// must not overwrite the neighboring ranges that share the same buffer.
+			lowVal := lowValBuf[lowDatumOffset : lowDatumOffset+lowWidth : lowDatumOffset+lowWidth]
+			copy(lowVal, pointRange.LowVal)
+			copy(lowVal[pointLowWidth:], r.LowVal)
+
+			highVal := highValBuf[highDatumOffset : highDatumOffset+highWidth : highDatumOffset+highWidth]
+			copy(highVal, pointRange.HighVal)
+			copy(highVal[pointHighWidth:], r.HighVal)
+
+			collatorWidth := pointCollatorWidth + len(r.Collators)
+			collators := collatorBuf[collatorOffset : collatorOffset+collatorWidth : collatorOffset+collatorWidth]
+			copy(collators, pointRange.Collators)
+			copy(collators[pointCollatorWidth:], r.Collators)
+
+			rangeObjs[rangeIdx] = Range{
+				LowVal:      lowVal,
+				LowExclude:  r.LowExclude,
+				HighVal:     highVal,
+				HighExclude: r.HighExclude,
+				Collators:   collators,
+			}
+			newRanges[rangeIdx] = &rangeObjs[rangeIdx]
+			rangeIdx++
+			lowDatumOffset += lowWidth
+			highDatumOffset += highWidth
+			collatorOffset += collatorWidth
 		}
 	}
 	return newRanges, false

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -1923,6 +1923,92 @@ func TestRangeFallbackForDetachCondAndBuildRangeForIndex(t *testing.T) {
 		"[]",
 		"[[10 40 70,10 40 80] [10 50 70,10 50 80] [10 60 70,10 60 80] [20 40 70,20 40 80] [20 50 70,20 50 80] [20 60 70,20 60 80] [30 40 70,30 40 80] [30 50 70,30 50 80] [30 60 70,30 60 80]]")
 	checkRangeFallbackAndReset(t, sctx, false)
+
+	t.Run("appending to one emitted range does not corrupt peer ranges", func(t *testing.T) {
+		appendTK := testkit.NewTestKit(t, store)
+		appendTK.MustExec("use test")
+		appendSctx := appendTK.Session()
+		appendRctx := appendSctx.GetRangerCtx()
+		sql := "select * from t1 where a in (10,20,30) and b in (40,50,60)"
+		selection := getSelectionFromQuery(t, appendSctx, sql)
+		conds := selection.Conditions
+		cols, lengths := plannerutil.IndexInfo2PrefixCols(tblInfo.Columns, selection.Schema().Columns, tblInfo.Indices[0])
+		res, err := ranger.DetachCondAndBuildRangeForIndex(appendRctx, conds, cols, lengths, 0)
+		require.NoError(t, err)
+		require.Len(t, res.Ranges, 9)
+		peer := res.Ranges[1].Clone()
+		anotherPeer := res.Ranges[3].Clone()
+
+		res.Ranges[0].LowVal = append(res.Ranges[0].LowVal, types.NewIntDatum(999))
+		res.Ranges[0].HighVal = append(res.Ranges[0].HighVal, types.NewIntDatum(999))
+		res.Ranges[0].Collators = append(res.Ranges[0].Collators, nil)
+
+		require.Equal(t, peer.LowVal, res.Ranges[1].LowVal)
+		require.Equal(t, peer.HighVal, res.Ranges[1].HighVal)
+		require.NotNil(t, res.Ranges[1].Collators[0])
+		require.NotNil(t, res.Ranges[1].Collators[1])
+		require.Equal(t, anotherPeer.LowVal, res.Ranges[3].LowVal)
+		require.Equal(t, anotherPeer.HighVal, res.Ranges[3].HighVal)
+		require.NotNil(t, res.Ranges[3].Collators[0])
+		require.NotNil(t, res.Ranges[3].Collators[1])
+	})
+
+	t.Run("appending to point-plus-tail ranges does not corrupt peer ranges", func(t *testing.T) {
+		binaryCollator := collate.GetBinaryCollator()
+		pointRanges := ranger.Ranges{
+			{
+				LowVal:     []types.Datum{types.NewIntDatum(10)},
+				HighVal:    []types.Datum{types.NewIntDatum(10)},
+				Collators:  []collate.Collator{binaryCollator},
+				LowExclude: false,
+			},
+			{
+				LowVal:     []types.Datum{types.NewIntDatum(20)},
+				HighVal:    []types.Datum{types.NewIntDatum(20)},
+				Collators:  []collate.Collator{binaryCollator},
+				LowExclude: false,
+			},
+		}
+		tailRanges := ranger.Ranges{
+			{
+				LowVal:      []types.Datum{types.NewIntDatum(40), types.NewIntDatum(70)},
+				HighVal:     []types.Datum{types.NewIntDatum(40), types.NewIntDatum(80)},
+				Collators:   []collate.Collator{binaryCollator, binaryCollator},
+				LowExclude:  false,
+				HighExclude: false,
+			},
+			{
+				LowVal:      []types.Datum{types.NewIntDatum(50), types.NewIntDatum(70)},
+				HighVal:     []types.Datum{types.NewIntDatum(50), types.NewIntDatum(80)},
+				Collators:   []collate.Collator{binaryCollator, binaryCollator},
+				LowExclude:  false,
+				HighExclude: false,
+			},
+		}
+
+		appended, rangeFallback := ranger.AppendRanges2PointRanges(pointRanges, tailRanges, 0)
+		require.False(t, rangeFallback)
+		require.Len(t, appended, 4)
+		require.Equal(t, "[[10 40 70,10 40 80] [10 50 70,10 50 80] [20 40 70,20 40 80] [20 50 70,20 50 80]]", fmt.Sprintf("%v", appended))
+
+		peer := appended[1].Clone()
+		anotherPeer := appended[2].Clone()
+		appended[0].LowVal = append(appended[0].LowVal, types.NewIntDatum(999))
+		appended[0].HighVal = append(appended[0].HighVal, types.NewIntDatum(999))
+		appended[0].Collators = append(appended[0].Collators, nil)
+
+		require.Equal(t, peer.LowVal, appended[1].LowVal)
+		require.Equal(t, peer.HighVal, appended[1].HighVal)
+		require.NotNil(t, appended[1].Collators[0])
+		require.NotNil(t, appended[1].Collators[1])
+		require.NotNil(t, appended[1].Collators[2])
+		require.Equal(t, anotherPeer.LowVal, appended[2].LowVal)
+		require.Equal(t, anotherPeer.HighVal, appended[2].HighVal)
+		require.NotNil(t, appended[2].Collators[0])
+		require.NotNil(t, appended[2].Collators[1])
+		require.NotNil(t, appended[2].Collators[2])
+	})
+
 	quota := res.Ranges.MemUsage() - 1
 	res, err = ranger.DetachCondAndBuildRangeForIndex(rctx, conds, cols, lengths, quota)
 	require.NoError(t, err)
@@ -2205,6 +2291,17 @@ func TestRangeFallbackForBuildColumnRange(t *testing.T) {
 	require.Equal(t, "[]", expression.StringifyExpressionsWithCtx(ectx, remained))
 	checkRangeFallbackAndReset(t, sctx, false)
 	quota := ranges.MemUsage() - 1
+	peer := ranges[1].Clone()
+	anotherPeer := ranges[3].Clone()
+	ranges[0].LowVal = append(ranges[0].LowVal, types.NewStringDatum("tail-low"))
+	ranges[0].HighVal = append(ranges[0].HighVal, types.NewStringDatum("tail-high"))
+	ranges[0].Collators = append(ranges[0].Collators, nil)
+	require.Equal(t, peer.LowVal, ranges[1].LowVal)
+	require.Equal(t, peer.HighVal, ranges[1].HighVal)
+	require.NotNil(t, ranges[1].Collators[0])
+	require.Equal(t, anotherPeer.LowVal, ranges[3].LowVal)
+	require.Equal(t, anotherPeer.HighVal, ranges[3].HighVal)
+	require.NotNil(t, ranges[3].Collators[0])
 	ranges, access, remained, err = ranger.BuildColumnRange(conds, rctx, cola.RetType, types.UnspecifiedLength, quota)
 	require.NoError(t, err)
 	require.Equal(t, "[[NULL,+inf]]", fmt.Sprintf("%v", ranges))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #67756

Problem Summary:

This manually cherry-picks the large-IN ranger performance improvements to release-8.5.

Manual cherry-pick note: this is a manual cherry-pick/backport onto release-8.5, not an automatic cherry-pick. The second commit had conflicts resolved manually to preserve the existing release-8.5 plan-cache guard and avoid bringing unrelated master-only benchmark-daily context into this branch.

Cherry-picked commits:

- 6ebbfa33ab9f7716b9490acd899b892b4fd73752: pkg/util/ranger: reduce range allocation overhead (#68022)
- a591266df788c8118c6faea7658009c96e3c46af: ranger: reduce point conversion overhead (#68247)

### What changed and how does it work?

- Backport ranger range allocation reductions for large IN lists.
- Backport in-place point conversion changes to avoid extra point cloning/conversion allocation.
- Add the relevant ranger benchmark coverage introduced by the cherry-picked commits.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Ran:

- `go test -tags=intest ./pkg/util/ranger`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added benchmarks for range building with long IN lists to measure performance and memory usage.
  * Enhanced test coverage with assertions validating range cloning and appending logic integrity.

* **Refactor**
  * Optimized internal range-point operations to use in-place conversions and reduce memory allocations during range construction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->