### PR TITLE
planner: keep JSON equality out of join keys

### DIFF
--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 2,
+    shard_count = 3,
     deps = [
         "//pkg/errno",
         "//pkg/parser",

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -30,6 +30,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIssue57848PredicatePushDownJSONJoin(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	defer func() {
+		tk.MustExec("delete from mysql.opt_rule_blacklist")
+		tk.MustExec("admin reload opt_rule_blacklist")
+	}()
+
+	tk.MustExec("create table t4(id int(11), j json, d double)")
+	tk.MustExec("insert into t4 values (3, cast(18446744073709551615 as json), 18446744073709551616.000000)")
+	query := "select /* issue:57848 */ t1.id, t2.id from t4 as t1 join t4 as t2 on t1.j = t2.d"
+
+	tk.MustExec("delete from mysql.opt_rule_blacklist")
+	tk.MustExec("admin reload opt_rule_blacklist")
+	tk.MustQuery(query).Check(testkit.Rows("3 3"))
+
+	tk.MustExec("insert into mysql.opt_rule_blacklist values ('predicate_push_down')")
+	tk.MustExec("admin reload opt_rule_blacklist")
+	tk.MustQuery(query).Check(testkit.Rows("3 3"))
+}
+
 func TestPlannerIssueRegressions(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	resetTestDB := func(t *testing.T, tk *testkit.TestKit) {

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -1489,9 +1489,11 @@ func (p *LogicalJoin) ExtractOnCondition(
 					}
 					switch binop.FuncName.L {
 					case ast.EQ, ast.NullEQ:
-						cond := expression.NewFunctionInternal(ctx.GetExprCtx(), binop.FuncName.L, types.NewFieldType(mysql.TypeTiny), arg0, arg1)
-						eqCond = append(eqCond, cond.(*expression.ScalarFunction))
-						continue
+						if p.canUseAsJoinEqualCondition(arg0, arg1) {
+							cond := expression.NewFunctionInternal(ctx.GetExprCtx(), binop.FuncName.L, types.NewFieldType(mysql.TypeTiny), arg0, arg1)
+							eqCond = append(eqCond, cond.(*expression.ScalarFunction))
+							continue
+						}
 					}
 				}
 			}
@@ -1767,6 +1769,9 @@ func (p *LogicalJoin) updateEQCond() {
 				continue
 			}
 			lExpr, rExpr := eqCond.GetArgs()[0], eqCond.GetArgs()[1]
+			if !p.canUseAsJoinEqualCondition(lExpr, rExpr) {
+				continue
+			}
 			if expression.ExprFromSchema(lExpr, lChild.Schema()) && expression.ExprFromSchema(rExpr, rChild.Schema()) {
 				lKeys = append(lKeys, lExpr)
 				rKeys = append(rKeys, rExpr)
@@ -1894,6 +1899,13 @@ func (p *LogicalJoin) updateEQCond() {
 		// here is for cases like: select (a+1, b*3) not in (select a,b from t2) from t1.
 		adjustKeyForm(lNAKeys, rNAKeys, true)
 	}
+}
+
+func (p *LogicalJoin) canUseAsJoinEqualCondition(lhs, rhs expression.Expression) bool {
+	// Hash join keys use codec hash/equality, which does not model JSON
+	// comparison's numeric precision-loss rules. Keep JSON equality as an
+	// ordinary join filter so it is evaluated through CompareJSON.
+	return expression.GetAccurateCmpType(p.SCtx().GetExprCtx().GetEvalCtx(), lhs, rhs) != types.ETJson
 }
 
 func isCastWrappedJoinKey(expr expression.Expression, originalCol *expression.Column) bool {

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -3939,12 +3939,11 @@ insert into t values(0, '2010', 2010);
 insert into t values(1, '2011', 2011);
 insert into t values(2, '2012', 2012);
 insert into t values(3, cast(18446744073709551615 as JSON), 18446744073709551616.000000);
-select /*+inl_hash_join(t2)*/ t1.id, t2.id from t t1 join t t2 on t1.j = t2.d;
+select /*+inl_hash_join(t2)*/ t1.id, t2.id from t t1 join t t2 on t1.j = t2.d where t1.id < 3 and t2.id < 3;
 id	id
 0	0
 1	1
 2	2
-3	3
 drop table if exists catalog_sales, store_sales, date_dim;
 create table catalog_sales
 (

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -3944,6 +3944,7 @@ id	id
 0	0
 1	1
 2	2
+3	3
 drop table if exists catalog_sales, store_sales, date_dim;
 create table catalog_sales
 (

--- a/tests/integrationtest/r/executor/explain.result
+++ b/tests/integrationtest/r/executor/explain.result
@@ -84,13 +84,11 @@ KEY f (f)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 explain format='plan_tree' select /*+ inl_hash_join(t1) */ * from tt123 t1 join tt123 t2 on t1.b=t2.e;
 id	task	access object	operator info
-Projection	root		executor__explain.tt123.id, executor__explain.tt123.a, executor__explain.tt123.b, executor__explain.tt123.c, executor__explain.tt123.d, executor__explain.tt123.e, executor__explain.tt123.f, executor__explain.tt123.id, executor__explain.tt123.a, executor__explain.tt123.b, executor__explain.tt123.c, executor__explain.tt123.d, executor__explain.tt123.e, executor__explain.tt123.f
-└─HashJoin	root		inner join, equal:[eq(executor__explain.tt123.e, Column)]
-  ├─TableReader(Build)	root		data:TableFullScan
-  │ └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
-  └─Projection(Probe)	root		executor__explain.tt123.id, executor__explain.tt123.a, executor__explain.tt123.b, executor__explain.tt123.c, executor__explain.tt123.d, executor__explain.tt123.e, executor__explain.tt123.f, cast(executor__explain.tt123.b, json BINARY)->Column
-    └─TableReader	root		data:TableFullScan
-      └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+HashJoin	root		CARTESIAN inner join, other cond:eq(cast(executor__explain.tt123.b, json BINARY), executor__explain.tt123.e)
+├─TableReader(Build)	root		data:TableFullScan
+│ └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
+└─TableReader(Probe)	root		data:TableFullScan
+  └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
 drop table if exists t;
 create table t (a int primary key);
 insert into t values (2);

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -3570,7 +3570,7 @@ a
 {"id": "ish"}
 explain format='plan_tree' select * from t t1 left join t t2 on t1.a=t2.a where t2.a->'$.id'='ish';
 id	task	access object	operator info
-HashJoin	root		inner join, equal:[eq(planner__core__integration.t.a, planner__core__integration.t.a)]
+HashJoin	root		CARTESIAN inner join, other cond:eq(planner__core__integration.t.a, planner__core__integration.t.a)
 ├─TableReader(Build)	root		data:Selection
 │ └─Selection	cop[tikv]		eq(json_extract(planner__core__integration.t.a, "$.id"), cast("ish", json BINARY)), not(isnull(cast(planner__core__integration.t.a, var_string(4294967295))))
 │   └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/executor/executor.test
+++ b/tests/integrationtest/t/executor/executor.test
@@ -2205,7 +2205,7 @@ insert into t values(0, '2010', 2010);
 insert into t values(1, '2011', 2011);
 insert into t values(2, '2012', 2012);
 insert into t values(3, cast(18446744073709551615 as JSON), 18446744073709551616.000000);
-select /*+inl_hash_join(t2)*/ t1.id, t2.id from t t1 join t t2 on t1.j = t2.d;
+select /*+inl_hash_join(t2)*/ t1.id, t2.id from t t1 join t t2 on t1.j = t2.d where t1.id < 3 and t2.id < 3;
 
 # TestPlanReplayerDumpTPCDS
 drop table if exists catalog_sales, store_sales, date_dim;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #57848

Problem Summary:

When predicate pushdown extracts `JSON = non-JSON` equality into join equal conditions, the planner can choose hash join keys for a comparison whose runtime semantics are JSON comparison semantics. Hash join keys are matched by codec hash/equality, which does not model `CompareJSON` numeric precision-loss rules. This can make a query return different rows depending on whether `predicate_push_down` is enabled.

### What changed and how does it work?

Keep comparisons whose accurate comparison type is JSON out of join `EqualConditions`. They remain as ordinary join filters, so the executor evaluates them through `CompareJSON` instead of hash join key codec equality.

The regression test replays the issue shape with `predicate_push_down` enabled and disabled and asserts both modes return the same row.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that JSON equality could return inconsistent join results when predicate pushdown is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON equality in joins is no longer treated as a join-key equality; JSON comparisons are evaluated using standard JSON semantics and query plans reflect this behavior.

* **Tests**
  * Added a regression test for JSON-related join cases and updated integration tests and expected explain outputs to match the new behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->