### PR TITLE
planner: preserve type-sensitive HAVING predicates

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -947,6 +947,30 @@ ORDER BY t1.a, t2.a, t3.a, var`
 		tk.MustQuery("SELECT /* issue:66706 */ ref0 FROM (SELECT v0.c0 AS ref0, SIGN(v0.c0) AS ref1 FROM v0) AS s WHERE ref1").Check(testkit.Rows("0.99"))
 		tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows())
 	})
+
+	// issue-68052-having-derived-where-equivalence
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		resetTestDB(t, tk)
+		tk.MustExec("CREATE TABLE t0(c0 NUMERIC UNSIGNED, c1 FLOAT UNSIGNED, c2 FLOAT UNSIGNED)")
+		tk.MustExec("INSERT INTO t0 VALUES (1443408820, 0.34189489665228545, 0.36490945335401803)")
+
+		havingQuery := `
+SELECT /* issue:68052 */ CONCAT(IFNULL(t0.c2, '__NULL__'))
+FROM t0
+GROUP BY t0.c2
+HAVING (((BIT_OR(t0.c2)) > (AVG(t0.c2))) OR ((t0.c2) > ((CAST(TRIM((CASE t0.c2 WHEN t0.c2 THEN t0.c2 ELSE 1923309721 END)) AS CHAR)) >= (t0.c2))))`
+		derivedQuery := `
+SELECT /* issue:68052 */ ref0
+FROM (
+    SELECT CONCAT(IFNULL(t0.c2, '__NULL__')) AS ref0,
+        (((BIT_OR(t0.c2)) > (AVG(t0.c2))) OR ((t0.c2) > ((CAST(TRIM((CASE t0.c2 WHEN t0.c2 THEN t0.c2 ELSE 1923309721 END)) AS CHAR)) >= (t0.c2)))) AS ref1
+    FROM t0
+    GROUP BY t0.c2
+) AS s
+WHERE ref1`
+		tk.MustQuery(havingQuery).Check(testkit.Rows("0.36490944"))
+		tk.MustQuery(derivedQuery).Check(testkit.Rows("0.36490944"))
+	})
 }
 
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -970,6 +970,19 @@ FROM (
 WHERE ref1`
 		tk.MustQuery(havingQuery).Check(testkit.Rows("0.36490944"))
 		tk.MustQuery(derivedQuery).Check(testkit.Rows("0.36490944"))
+
+		mixedPredicatePlan := fmt.Sprint(tk.MustQuery(`
+EXPLAIN FORMAT='brief'
+SELECT /* issue:68052 */ ref0
+FROM (
+    SELECT CONCAT(IFNULL(t0.c2, '__NULL__')) AS ref0,
+        (((BIT_OR(t0.c2)) > (AVG(t0.c2))) OR ((t0.c2) > ((CAST(TRIM((CASE t0.c2 WHEN t0.c2 THEN t0.c2 ELSE 1923309721 END)) AS CHAR)) >= (t0.c2)))) AS ref1,
+        t0.c2 AS ref2
+    FROM t0
+    GROUP BY t0.c2
+) AS s
+WHERE ref1 AND ref2 > 0`).Rows())
+		require.Contains(t, mixedPredicatePlan, "cop[tikv]  gt(test.t0.c2, 0)")
 	})
 }
 

--- a/pkg/planner/core/operator/logicalop/logical_projection.go
+++ b/pkg/planner/core/operator/logicalop/logical_projection.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/cardinality"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -92,6 +93,15 @@ func (p *LogicalProjection) HashCode() []byte {
 // PredicatePushDown implements base.LogicalPlan.<1st> interface.
 func (p *LogicalProjection) PredicatePushDown(predicates []expression.Expression) (ret []expression.Expression, retPlan base.LogicalPlan, err error) {
 	if slices.ContainsFunc(p.Exprs, expression.HasAssignSetVarFunc) {
+		_, child, err := p.BaseLogicalPlan.PredicatePushDown(nil)
+		return predicates, child, err
+	}
+	// Keep type-sensitive HAVING predicates above Projection -> Aggregation.
+	// Rebuilding control-function comparisons below this projection can change
+	// coercion against pre-aggregation columns and filter rows that should
+	// survive HAVING.
+	if _, ok := p.Children()[0].(*LogicalAggregation); ok &&
+		hasTypeSensitiveProjectionPredicate(p.Schema(), p.Exprs, predicates) {
 		_, child, err := p.BaseLogicalPlan.PredicatePushDown(nil)
 		return predicates, child, err
 	}
@@ -657,6 +667,33 @@ func breakDownPredicates(p *LogicalProjection, predicates []expression.Expressio
 		}
 	}
 	return canBePushed, canNotBePushed
+}
+
+func hasTypeSensitiveProjectionPredicate(schema *expression.Schema, projectionExprs, predicates []expression.Expression) bool {
+	for _, predicate := range predicates {
+		if hasTypeSensitiveProjectionPredicateExpr(predicate) {
+			return true
+		}
+		for _, col := range expression.ExtractColumns(predicate) {
+			idx := schema.ColumnIndex(col)
+			if idx >= 0 && hasTypeSensitiveProjectionPredicateExpr(projectionExprs[idx]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasTypeSensitiveProjectionPredicateExpr(expr expression.Expression) bool {
+	sf, ok := expr.(*expression.ScalarFunction)
+	if !ok {
+		return false
+	}
+	switch sf.FuncName.L {
+	case ast.Case, ast.Coalesce, ast.If, ast.Ifnull:
+		return true
+	}
+	return slices.ContainsFunc(sf.GetArgs(), hasTypeSensitiveProjectionPredicateExpr)
 }
 
 // todo: merge with rule_eliminate_projection.go

--- a/pkg/planner/core/operator/logicalop/logical_projection.go
+++ b/pkg/planner/core/operator/logicalop/logical_projection.go
@@ -96,13 +96,13 @@ func (p *LogicalProjection) PredicatePushDown(predicates []expression.Expression
 		_, child, err := p.BaseLogicalPlan.PredicatePushDown(nil)
 		return predicates, child, err
 	}
-	if _, ok := p.Children()[0].(*LogicalAggregation); ok {
-		ordinaryPredicates, sensitivePredicates := splitTypeSensitiveProjectionPredicates(p.Schema(), p.Exprs, predicates)
+	if agg, ok := p.Children()[0].(*LogicalAggregation); ok {
+		ordinaryPredicates, sensitivePredicates := splitTypeSensitiveProjectionPredicates(p, agg, predicates)
 		if len(sensitivePredicates) > 0 {
-			// Keep type-sensitive HAVING predicates above Projection -> Aggregation.
-			// Rebuilding control-function comparisons below this projection can change
-			// coercion against pre-aggregation columns and filter rows that should
-			// survive HAVING. Ordinary predicates can still use the normal pushdown path.
+			// Keep type-sensitive HAVING predicates above Projection -> Aggregation
+			// only when a single CNF item still depends on aggregate results after
+			// projection substitution. CNF items that use only grouping columns should
+			// continue through aggregation so they match direct HAVING pushdown.
 			canBePushed, canNotBePushed := breakDownPredicates(p, ordinaryPredicates)
 			remained, child, err := p.BaseLogicalPlan.PredicatePushDown(canBePushed)
 			return append(append(remained, canNotBePushed...), sensitivePredicates...), child, err
@@ -672,11 +672,11 @@ func breakDownPredicates(p *LogicalProjection, predicates []expression.Expressio
 	return canBePushed, canNotBePushed
 }
 
-func splitTypeSensitiveProjectionPredicates(schema *expression.Schema, projectionExprs, predicates []expression.Expression) (ordinary, sensitive []expression.Expression) {
+func splitTypeSensitiveProjectionPredicates(p *LogicalProjection, agg *LogicalAggregation, predicates []expression.Expression) (ordinary, sensitive []expression.Expression) {
 	ordinary = make([]expression.Expression, 0, len(predicates))
 	sensitive = make([]expression.Expression, 0, len(predicates))
 	for _, predicate := range predicates {
-		if isTypeSensitiveProjectionPredicate(schema, projectionExprs, predicate) {
+		if isTypeSensitiveProjectionPredicate(p, agg, predicate) {
 			sensitive = append(sensitive, predicate)
 			continue
 		}
@@ -685,13 +685,36 @@ func splitTypeSensitiveProjectionPredicates(schema *expression.Schema, projectio
 	return ordinary, sensitive
 }
 
-func isTypeSensitiveProjectionPredicate(schema *expression.Schema, projectionExprs []expression.Expression, predicate expression.Expression) bool {
+func isTypeSensitiveProjectionPredicate(p *LogicalProjection, agg *LogicalAggregation, predicate expression.Expression) bool {
+	substituted, hasFailed, newFilter := expression.ColumnSubstituteImpl(p.SCtx().GetExprCtx(), predicate, p.Schema(), p.Exprs, true)
+	if substituted && !hasFailed && !expression.HasGetSetVarFunc(newFilter) {
+		return hasTypeSensitiveAggCNFItem(newFilter, agg)
+	}
 	if hasTypeSensitiveProjectionPredicateExpr(predicate) {
 		return true
 	}
 	for _, col := range expression.ExtractColumns(predicate) {
-		idx := schema.ColumnIndex(col)
-		if idx >= 0 && hasTypeSensitiveProjectionPredicateExpr(projectionExprs[idx]) {
+		idx := p.Schema().ColumnIndex(col)
+		if idx >= 0 && hasTypeSensitiveProjectionPredicateExpr(p.Exprs[idx]) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasTypeSensitiveAggCNFItem(predicate expression.Expression, agg *LogicalAggregation) bool {
+	for _, cnfItem := range expression.SplitCNFItems(predicate) {
+		if hasTypeSensitiveProjectionPredicateExpr(cnfItem) && hasRealAggFuncColumn(cnfItem, agg) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRealAggFuncColumn(expr expression.Expression, agg *LogicalAggregation) bool {
+	for _, col := range expression.ExtractColumns(expr) {
+		idx := agg.Schema().ColumnIndex(col)
+		if idx >= 0 && idx < len(agg.AggFuncs) && agg.AggFuncs[idx].Name != ast.AggFuncFirstRow {
 			return true
 		}
 	}

--- a/pkg/planner/core/operator/logicalop/logical_projection.go
+++ b/pkg/planner/core/operator/logicalop/logical_projection.go
@@ -96,14 +96,17 @@ func (p *LogicalProjection) PredicatePushDown(predicates []expression.Expression
 		_, child, err := p.BaseLogicalPlan.PredicatePushDown(nil)
 		return predicates, child, err
 	}
-	// Keep type-sensitive HAVING predicates above Projection -> Aggregation.
-	// Rebuilding control-function comparisons below this projection can change
-	// coercion against pre-aggregation columns and filter rows that should
-	// survive HAVING.
-	if _, ok := p.Children()[0].(*LogicalAggregation); ok &&
-		hasTypeSensitiveProjectionPredicate(p.Schema(), p.Exprs, predicates) {
-		_, child, err := p.BaseLogicalPlan.PredicatePushDown(nil)
-		return predicates, child, err
+	if _, ok := p.Children()[0].(*LogicalAggregation); ok {
+		ordinaryPredicates, sensitivePredicates := splitTypeSensitiveProjectionPredicates(p.Schema(), p.Exprs, predicates)
+		if len(sensitivePredicates) > 0 {
+			// Keep type-sensitive HAVING predicates above Projection -> Aggregation.
+			// Rebuilding control-function comparisons below this projection can change
+			// coercion against pre-aggregation columns and filter rows that should
+			// survive HAVING. Ordinary predicates can still use the normal pushdown path.
+			canBePushed, canNotBePushed := breakDownPredicates(p, ordinaryPredicates)
+			remained, child, err := p.BaseLogicalPlan.PredicatePushDown(canBePushed)
+			return append(append(remained, canNotBePushed...), sensitivePredicates...), child, err
+		}
 	}
 	canBePushed, canNotBePushed := breakDownPredicates(p, predicates)
 	remained, child, err := p.BaseLogicalPlan.PredicatePushDown(canBePushed)
@@ -669,16 +672,27 @@ func breakDownPredicates(p *LogicalProjection, predicates []expression.Expressio
 	return canBePushed, canNotBePushed
 }
 
-func hasTypeSensitiveProjectionPredicate(schema *expression.Schema, projectionExprs, predicates []expression.Expression) bool {
+func splitTypeSensitiveProjectionPredicates(schema *expression.Schema, projectionExprs, predicates []expression.Expression) (ordinary, sensitive []expression.Expression) {
+	ordinary = make([]expression.Expression, 0, len(predicates))
+	sensitive = make([]expression.Expression, 0, len(predicates))
 	for _, predicate := range predicates {
-		if hasTypeSensitiveProjectionPredicateExpr(predicate) {
-			return true
+		if isTypeSensitiveProjectionPredicate(schema, projectionExprs, predicate) {
+			sensitive = append(sensitive, predicate)
+			continue
 		}
-		for _, col := range expression.ExtractColumns(predicate) {
-			idx := schema.ColumnIndex(col)
-			if idx >= 0 && hasTypeSensitiveProjectionPredicateExpr(projectionExprs[idx]) {
-				return true
-			}
+		ordinary = append(ordinary, predicate)
+	}
+	return ordinary, sensitive
+}
+
+func isTypeSensitiveProjectionPredicate(schema *expression.Schema, projectionExprs []expression.Expression, predicate expression.Expression) bool {
+	if hasTypeSensitiveProjectionPredicateExpr(predicate) {
+		return true
+	}
+	for _, col := range expression.ExtractColumns(predicate) {
+		idx := schema.ColumnIndex(col)
+		if idx >= 0 && hasTypeSensitiveProjectionPredicateExpr(projectionExprs[idx]) {
+			return true
 		}
 	}
 	return false

--- a/pkg/planner/core/operator/logicalop/logical_projection.go
+++ b/pkg/planner/core/operator/logicalop/logical_projection.go
@@ -103,6 +103,8 @@ func (p *LogicalProjection) PredicatePushDown(predicates []expression.Expression
 			// only when a single CNF item still depends on aggregate results after
 			// projection substitution. CNF items that use only grouping columns should
 			// continue through aggregation so they match direct HAVING pushdown.
+			// For example, keep `ifnull(sum(a), 0) > 0` here, but still push a
+			// separate grouping-key predicate like `b > 0`.
 			canBePushed, canNotBePushed := breakDownPredicates(p, ordinaryPredicates)
 			remained, child, err := p.BaseLogicalPlan.PredicatePushDown(canBePushed)
 			return append(append(remained, canNotBePushed...), sensitivePredicates...), child, err
@@ -714,6 +716,11 @@ func hasTypeSensitiveAggCNFItem(predicate expression.Expression, agg *LogicalAgg
 func hasRealAggFuncColumn(expr expression.Expression, agg *LogicalAggregation) bool {
 	for _, col := range expression.ExtractColumns(expr) {
 		idx := agg.Schema().ColumnIndex(col)
+		// Aggregation output columns stay aligned with AggFuncs; PruneColumns
+		// deletes schema columns and AggFuncs together to preserve this invariant.
+		// For example, `ifnull(sum(a), 0)` references a real aggregate column,
+		// while an internal `firstrow(b)` for a grouping key should still be
+		// treated as a grouping-column predicate.
 		if idx >= 0 && idx < len(agg.AggFuncs) && agg.AggFuncs[idx].Name != ast.AggFuncFirstRow {
 			return true
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68052

Problem Summary:

`HAVING` predicates and equivalent derived-table `WHERE` predicates can return different results when a grouped predicate contains control-function type coercion. For the issue case, MySQL returns one row for both query forms, while TiDB filtered the `HAVING` row.

### What changed and how does it work?

Keep type-sensitive predicates above `Projection -> Aggregation` when the predicate itself, or a referenced projection expression, contains a control function (`CASE`, `IF`, `IFNULL`, or `COALESCE`). This avoids rebuilding the predicate below the projection with pre-aggregation column coercion semantics while preserving ordinary projection predicate pushdown, including implicit cast comparisons.

Added a regression case for the issue SQL in `TestPlannerIssueRegressions`, covering both the direct `HAVING` form and the equivalent derived-table `WHERE` form.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix inconsistent results between HAVING and equivalent derived-table WHERE predicates for grouped queries with control-function type coercion.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved planner correctness so HAVING conditions that are equivalent to derived-table WHERE clauses are handled consistently.
  * Better handling of type-sensitive expressions (CASE, COALESCE, IF, IFNULL) so predicates are preserved or pushed appropriately during optimization.

* **Tests**
  * Added a regression test validating HAVING vs. derived-table WHERE equivalence and asserting the planner’s generated plan.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->