### PR TITLE
planner: cap large IN estimates for all-TopN misses

### DIFF
--- a/pkg/planner/cardinality/BUILD.bazel
+++ b/pkg/planner/cardinality/BUILD.bazel
@@ -58,7 +58,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":cardinality"],
     flaky = True,
-    shard_count = 48,
+    shard_count = 49,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/cardinality/row_count_column.go
+++ b/pkg/planner/cardinality/row_count_column.go
@@ -69,37 +69,37 @@ func GetRowCountByColumnRanges(sctx planctx.PlanContext, coll *statistics.HistCo
 }
 
 // equalRowCountOnColumn estimates the row count by a slice of Range and a Datum.
-func equalRowCountOnColumn(sctx planctx.PlanContext, c *statistics.Column, val types.Datum, encodedVal []byte, realtimeRowCount, modifyCount int64) (result statistics.RowEstimate, err error) {
+func equalRowCountOnColumn(sctx planctx.PlanContext, c *statistics.Column, val types.Datum, encodedVal []byte, realtimeRowCount, modifyCount int64) (result statistics.RowEstimate, allTopNMiss bool, err error) {
 	if val.IsNull() {
-		return statistics.DefaultRowEst(float64(c.NullCount)), nil
+		return statistics.DefaultRowEst(float64(c.NullCount)), false, nil
 	}
 	if c.StatsVer < statistics.Version2 {
 		// All the values are null.
 		if c.Histogram.Bounds.NumRows() == 0 {
-			return statistics.DefaultRowEst(0.0), nil
+			return statistics.DefaultRowEst(0.0), false, nil
 		}
 		if c.Histogram.NDV > 0 && c.OutOfRange(val) {
 			outOfRangeCnt := outOfRangeEQSelectivity(sctx, c.Histogram.NDV, realtimeRowCount, int64(c.TotalRowCount())) * c.TotalRowCount()
-			return statistics.DefaultRowEst(outOfRangeCnt), nil
+			return statistics.DefaultRowEst(outOfRangeCnt), false, nil
 		}
 		if c.CMSketch != nil {
 			count, err := statistics.QueryValue(sctx, c.CMSketch, c.TopN, val)
-			return statistics.DefaultRowEst(float64(count)), errors.Trace(err)
+			return statistics.DefaultRowEst(float64(count)), false, errors.Trace(err)
 		}
 		histRowCount, _ := c.Histogram.EqualRowCount(sctx, val, false)
-		return statistics.DefaultRowEst(histRowCount), nil
+		return statistics.DefaultRowEst(histRowCount), false, nil
 	}
 
 	// Stats version == 2
 	// All the values are null.
 	if c.Histogram.Bounds.NumRows() == 0 && c.TopN.Num() == 0 {
-		return statistics.DefaultRowEst(0), nil
+		return statistics.DefaultRowEst(0), false, nil
 	}
 	// 1. try to find this value in TopN
 	if c.TopN != nil {
 		rowcount, ok := c.TopN.QueryTopN(sctx, encodedVal)
 		if ok {
-			return statistics.DefaultRowEst(float64(rowcount)), nil
+			return statistics.DefaultRowEst(float64(rowcount)), false, nil
 		}
 	}
 	// 2. try to find this value in bucket.Repeat(the last value in every bucket)
@@ -109,18 +109,19 @@ func equalRowCountOnColumn(sctx planctx.PlanContext, c *statistics.Column, val t
 	// also check if this last bucket end value is underrepresented
 	if matched && !IsLastBucketEndValueUnderrepresented(sctx,
 		&c.Histogram, val, histCnt, histNDV, realtimeRowCount, modifyCount) {
-		return statistics.DefaultRowEst(histCnt), nil
+		return statistics.DefaultRowEst(histCnt), false, nil
 	}
 	// 3. use uniform distribution assumption for the rest, and address special cases for out of range
 	// or all values assumed to be contained within TopN.
 	rowEstimate := estimateRowCountWithUniformDistribution(sctx, c, realtimeRowCount, modifyCount)
-	return rowEstimate, nil
+	return rowEstimate, histNDV <= 0, nil
 }
 
 // getColumnRowCount estimates the row count by a slice of Range.
 func getColumnRowCount(sctx planctx.PlanContext, c *statistics.Column, ranges []*ranger.Range, realtimeRowCount, modifyCount int64, pkIsHandle bool) (statistics.RowEstimate, error) {
 	sc := sctx.GetSessionVars().StmtCtx
 	var totalCount statistics.RowEstimate
+	var allTopNMissPointCount statistics.RowEstimate
 	for _, rg := range ranges {
 		highVal := *rg.HighVal[0].Clone()
 		lowVal := *rg.LowVal[0].Clone()
@@ -153,13 +154,18 @@ func getColumnRowCount(sctx planctx.PlanContext, c *statistics.Column, ranges []
 					continue
 				}
 				var cnt statistics.RowEstimate
-				cnt, err = equalRowCountOnColumn(sctx, c, lowVal, lowEncoded, realtimeRowCount, modifyCount)
+				var allTopNMiss bool
+				cnt, allTopNMiss, err = equalRowCountOnColumn(sctx, c, lowVal, lowEncoded, realtimeRowCount, modifyCount)
 				if err != nil {
 					return statistics.DefaultRowEst(0), errors.Trace(err)
 				}
 				// If the current table row count has changed, we should scale the row count accordingly.
 				cnt.MultiplyAll(c.GetIncreaseFactor(realtimeRowCount))
-				totalCount.Add(cnt)
+				if allTopNMiss {
+					allTopNMissPointCount.Add(cnt)
+				} else {
+					totalCount.Add(cnt)
+				}
 			}
 			continue
 		}
@@ -171,7 +177,7 @@ func getColumnRowCount(sctx planctx.PlanContext, c *statistics.Column, ranges []
 			// case 2: it's a small range && using ver1 stats
 			if rangeVals != nil {
 				for _, val := range rangeVals {
-					cnt, err := equalRowCountOnColumn(sctx, c, val, lowEncoded, realtimeRowCount, modifyCount)
+					cnt, _, err := equalRowCountOnColumn(sctx, c, val, lowEncoded, realtimeRowCount, modifyCount)
 					if err != nil {
 						return statistics.DefaultRowEst(0), err
 					}
@@ -192,7 +198,7 @@ func getColumnRowCount(sctx planctx.PlanContext, c *statistics.Column, ranges []
 		// And because we use (2, MaxValue] to represent expressions like a > 2 and use [MinNotNull, 3) to represent
 		//   expressions like b < 3, we need to exclude the special values.
 		if rg.LowExclude && !lowVal.IsNull() && lowVal.Kind() != types.KindMaxValue && lowVal.Kind() != types.KindMinNotNull {
-			lowCnt, err := equalRowCountOnColumn(sctx, c, lowVal, lowEncoded, realtimeRowCount, modifyCount)
+			lowCnt, _, err := equalRowCountOnColumn(sctx, c, lowVal, lowEncoded, realtimeRowCount, modifyCount)
 			if err != nil {
 				return statistics.DefaultRowEst(0), errors.Trace(err)
 			}
@@ -203,7 +209,7 @@ func getColumnRowCount(sctx planctx.PlanContext, c *statistics.Column, ranges []
 			cnt.AddAll(float64(c.NullCount))
 		}
 		if !rg.HighExclude && highVal.Kind() != types.KindMaxValue && highVal.Kind() != types.KindMinNotNull {
-			highCnt, err := equalRowCountOnColumn(sctx, c, highVal, highEncoded, realtimeRowCount, modifyCount)
+			highCnt, _, err := equalRowCountOnColumn(sctx, c, highVal, highEncoded, realtimeRowCount, modifyCount)
 			if err != nil {
 				return statistics.DefaultRowEst(0), errors.Trace(err)
 			}
@@ -233,6 +239,7 @@ func getColumnRowCount(sctx planctx.PlanContext, c *statistics.Column, ranges []
 
 		totalCount.Add(cnt)
 	}
+	totalCount.Add(capAllTopNMissPointEstimate(allTopNMissPointCount, c.TotalRowCount(), realtimeRowCount, modifyCount))
 	totalCount.Clamp(1.0, float64(realtimeRowCount))
 	return totalCount, nil
 }

--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -189,6 +189,7 @@ func isSingleColIdxNullRange(idx *statistics.Index, ran *ranger.Range) bool {
 func getIndexRowCountForStatsV2(sctx planctx.PlanContext, idx *statistics.Index, coll *statistics.HistColl, indexRanges []*ranger.Range, realtimeRowCount, modifyCount int64) (totalCount statistics.RowEstimate, err error) {
 	sc := sctx.GetSessionVars().StmtCtx
 	isSingleColIdx := len(idx.Info.Columns) == 1
+	var allTopNMissPointCount statistics.RowEstimate
 	for _, indexRange := range indexRanges {
 		var count statistics.RowEstimate
 		var lb, rb []byte
@@ -218,10 +219,15 @@ func getIndexRowCountForStatsV2(sctx planctx.PlanContext, idx *statistics.Index,
 					totalCount = statistics.DefaultRowEst(float64(idx.NullCount))
 					continue
 				}
-				count = equalRowCountOnIndex(sctx, idx, lb, realtimeRowCount, modifyCount)
+				var allTopNMiss bool
+				count, allTopNMiss = equalRowCountOnIndex(sctx, idx, lb, realtimeRowCount, modifyCount)
 				// If the current table row count has changed, we should scale the row count accordingly.
 				count.MultiplyAll(idx.GetIncreaseFactor(realtimeRowCount))
-				totalCount.Add(count)
+				if allTopNMiss {
+					allTopNMissPointCount.Add(count)
+				} else {
+					totalCount.Add(count)
+				}
 				continue
 			}
 		}
@@ -314,6 +320,7 @@ func getIndexRowCountForStatsV2(sctx planctx.PlanContext, idx *statistics.Index,
 
 		totalCount.Add(count)
 	}
+	totalCount.Add(capAllTopNMissPointEstimate(allTopNMissPointCount, idx.TotalRowCount(), realtimeRowCount, modifyCount))
 	totalCount.Clamp(1.0, float64(realtimeRowCount))
 	return totalCount, nil
 }
@@ -389,31 +396,49 @@ func estimateRowCountWithUniformDistribution(
 	return statistics.DefaultRowEst(avgRowEstimate)
 }
 
+func capAllTopNMissPointEstimate(pointCount statistics.RowEstimate, analyzedRowCount float64, realtimeRowCount, modifyCount int64) statistics.RowEstimate {
+	if pointCount.Est <= 0 {
+		return pointCount
+	}
+	upperLimit := float64(realtimeRowCount) - analyzedRowCount
+	if upperLimit <= 0 && modifyCount > 0 {
+		// The searched values are absent from TopN when TopN already represents all analyzed NDVs.
+		// Only rows changed after analyze can contain those newly emerging point values, so a large IN list
+		// should not accumulate more rows than the post-analyze change window.
+		upperLimit = min(float64(modifyCount), float64(realtimeRowCount))
+	}
+	if upperLimit <= 0 {
+		return statistics.DefaultRowEst(0)
+	}
+	pointCount.Clamp(0, upperLimit)
+	return pointCount
+}
+
 // equalRowCountOnIndex estimates the row count by a slice of Range and a Datum.
-func equalRowCountOnIndex(sctx planctx.PlanContext, idx *statistics.Index, b []byte, realtimeRowCount, modifyCount int64) (result statistics.RowEstimate) {
+func equalRowCountOnIndex(sctx planctx.PlanContext, idx *statistics.Index, b []byte, realtimeRowCount, modifyCount int64) (result statistics.RowEstimate, allTopNMiss bool) {
 	if len(idx.Info.Columns) == 1 {
 		if bytes.Equal(b, nullKeyBytes) {
-			return statistics.DefaultRowEst(float64(idx.Histogram.NullCount))
+			return statistics.DefaultRowEst(float64(idx.Histogram.NullCount)), false
 		}
 	}
 	val := types.NewBytesDatum(b)
 	if idx.StatsVer < statistics.Version2 {
 		if idx.Histogram.NDV > 0 && outOfRangeOnIndex(idx, val) {
 			outOfRangeCnt := outOfRangeEQSelectivity(sctx, idx.Histogram.NDV, realtimeRowCount, int64(idx.TotalRowCount())) * idx.TotalRowCount()
-			return statistics.DefaultRowEst(outOfRangeCnt)
+			return statistics.DefaultRowEst(outOfRangeCnt), false
 		}
 		if idx.CMSketch != nil {
-			return statistics.DefaultRowEst(float64(idx.QueryBytes(sctx, b)))
+			return statistics.DefaultRowEst(float64(idx.QueryBytes(sctx, b))), false
 		}
 		histRowCount, _ := idx.Histogram.EqualRowCount(sctx, val, false)
-		return statistics.DefaultRowEst(histRowCount)
+		return statistics.DefaultRowEst(histRowCount), false
 	}
 	// stats version == 2
 	// 1. try to find this value in TopN
 	if idx.TopN != nil {
 		count, found := idx.TopN.QueryTopN(sctx, b)
 		if found {
-			return statistics.DefaultRowEst(float64(count))
+			return statistics.DefaultRowEst(float64(count)), false
 		}
 	}
 	// 2. try to find this value in bucket.Repeat(the last value in every bucket)
@@ -423,14 +448,14 @@ func equalRowCountOnIndex(sctx planctx.PlanContext, idx *statistics.Index, b []b
 	// also check if this last bucket end value is underrepresented
 	if matched && !IsLastBucketEndValueUnderrepresented(sctx,
 		&idx.Histogram, val, histCnt, histNDV, realtimeRowCount, modifyCount) {
-		return statistics.DefaultRowEst(histCnt)
+		return statistics.DefaultRowEst(histCnt), false
 	}
 	// 3. use uniform distribution assumption for the rest (even when this value is not covered by the range of stats)
 	// branch1: histDNV <= 0 means that all NDV's are in TopN, and no histograms.
 	// branch2: histDNA > 0 basically means while there is still a case, c.Histogram.NDV >
 	// c.TopN.Num() a little bit, but the histogram is still empty. In this case, we should use the branch1 and for the diff
 	// in NDV, it's mainly comes from the NDV is conducted and calculated ahead of sampling.
-	return estimateRowCountWithUniformDistribution(sctx, idx, realtimeRowCount, modifyCount)
+	return estimateRowCountWithUniformDistribution(sctx, idx, realtimeRowCount, modifyCount), histNDV <= 0
 }
 
 // expBackoffEstimation estimate the multi-col cases following the Exponential Backoff. See comment below for details.

--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -402,6 +402,8 @@ func capAllTopNMissPointEstimate(pointCount statistics.RowEstimate, analyzedRowC
 	}
 	upperLimit := float64(realtimeRowCount) - analyzedRowCount
 	if upperLimit <= 0 && modifyCount > 0 {
+		// upperLimit <= 0 covers update/delete-only stale stats, where the table did
+		// not grow or even shrank while modified rows may contain values absent from TopN.
 		// The searched values are absent from TopN when TopN already represents all analyzed NDVs.
 		// Only rows changed after analyze can contain those newly emerging point values, so a large IN list
 		// should not accumulate more rows than the post-analyze change window.

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -2226,6 +2226,44 @@ func TestBuiltinInEstWithoutStats(t *testing.T) {
 	}
 }
 
+func TestLargeInListAllTopNMissCapsAtStatsDelta(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("set @@session.tidb_analyze_version=2")
+	tk.MustExec("create table t(a varchar(20), key ia(a))")
+	values := []string{"Active", "Archived", "Deleted", "Inactive", "Pending"}
+	for _, value := range values {
+		rows := make([]string, 0, 20)
+		for range 20 {
+			rows = append(rows, fmt.Sprintf("('%s')", value))
+		}
+		tk.MustExec("insert into t values " + strings.Join(rows, ","))
+	}
+	tk.MustExec("analyze table t all columns with 5 topn, 1 buckets")
+
+	rows := make([]string, 0, 9)
+	for range 9 {
+		rows = append(rows, "('Active')")
+	}
+	tk.MustExec("insert into t values " + strings.Join(rows, ","))
+	tk.MustExec("flush stats_delta *.*")
+	require.NoError(t, dom.StatsHandle().Update(context.Background(), dom.InfoSchema()))
+
+	inItems := make([]string, 0, 101)
+	for i := 1; i <= 201; i += 2 {
+		inItems = append(inItems, fmt.Sprintf("'%d'", i))
+	}
+	inList := strings.Join(inItems, ",")
+	require.Contains(t,
+		tk.MustQuery("explain format='brief' select * from t use index(ia) where a in ("+inList+")").String(),
+		"IndexReader 9.00 root")
+	require.Contains(t,
+		tk.MustQuery("explain format='brief' select /*+ ignore_index(t, ia) */ * from t where a in ("+inList+")").String(),
+		"Selection 9.00")
+}
+
 func TestRiskEqSkewRatio(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	testKit := testkit.NewTestKit(t, store)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #65636

Problem Summary:

When stats v2 TopN already covers all analyzed NDVs and the histogram has no remaining values, point values that miss TopN are estimated with the out-of-range fallback for post-analyze rows. This is reasonable for one equality, but a large `IN` list can accumulate that fallback hundreds of times and estimate more rows than the post-analyze change window can contain.

### What changed and how does it work?

This PR keeps the single-point out-of-TopN fallback unchanged, but tracks point ranges whose estimate comes from an all-TopN miss. The aggregate contribution from only those point ranges is capped by the rows changed after analyze:

- use `realtimeRowCount - analyzedRowCount` when the table grew after analyze;
- otherwise use `min(modifyCount, realtimeRowCount)` for update/delete-only stale stats.

The cap is applied in both column and single-column index row-count paths. It does not change TopN construction, histogram semantics, or analyze behavior.

For the issue replayer on current master, the original query estimate changes from `35090.14` to `5818.09`. The estimate does not become zero because the stats are stale and rows changed after analyze may contain values absent from TopN.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Manual test details:

- `go test --tags=intest ./pkg/planner/cardinality -run 'TestLargeInListAllTopNMissCapsAtStatsDelta|TestRiskEqSkewRatio' -count=1`
- `go test --tags=intest ./pkg/planner/cardinality -count=1`
- `make check-bazel-prepare`
- `git diff --check`
- `make server SERVER_OUT=/tmp/tidb-server-65636-patch`
- Load the attached plan replayer from #65636 with `PLAN REPLAYER LOAD`.
- Run the issue query with `EXPLAIN FORMAT='brief'` and `EXPLAIN ANALYZE`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Improve cardinality estimation for large IN lists whose point values miss all-NDV TopN statistics.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cardinality estimates for point and range predicates, including cases with many frequent-value misses, yielding more accurate plan costs.

* **Tests**
  * Added a test to validate behavior for large IN-list predicates when frequent values are missed.

* **Chores**
  * Adjusted test sharding configuration to improve test execution distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

