### PR TITLE
planner: keep partition processor for static pruning

### DIFF
--- a/pkg/executor/partition_table_test.go
+++ b/pkg/executor/partition_table_test.go
@@ -2228,6 +2228,33 @@ partition p2 values less than (11))`)
 	}
 }
 
+func TestSelectLockWithStaticPruneAndPartitionProcessorBlacklist(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@session.tidb_partition_prune_mode = 'static'")
+	tk.MustExec("delete from mysql.opt_rule_blacklist")
+	tk.MustExec("admin reload opt_rule_blacklist")
+	t.Cleanup(func() {
+		tk.MustExec("delete from mysql.opt_rule_blacklist")
+		tk.MustExec("admin reload opt_rule_blacklist")
+	})
+
+	tk.MustExec(`create table t (
+		id int primary key,
+		balance decimal(10,2),
+		balance2 decimal(10,2) generated always as (-balance) virtual,
+		created_at timestamp
+	) partition by hash (id) partitions 8`)
+	tk.MustExec("insert into t (id, balance, created_at) values (1, 100, '2021-06-17 22:35:20')")
+	tk.MustQuery("select * from t where id = 1 for update").Check(testkit.Rows("1 100.00 -100.00 2021-06-17 22:35:20"))
+
+	tk.MustExec(`insert into mysql.opt_rule_blacklist values ("predicate_push_down"), ("partition_processor")`)
+	tk.MustExec("admin reload opt_rule_blacklist")
+	tk.MustQuery("select * from t where id = 1 for update").Check(testkit.Rows("1 100.00 -100.00 2021-06-17 22:35:20"))
+}
+
 func TestIssue26251(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 

--- a/pkg/executor/partition_table_test.go
+++ b/pkg/executor/partition_table_test.go
@@ -2253,6 +2253,8 @@ func TestSelectLockWithStaticPruneAndPartitionProcessorBlacklist(t *testing.T) {
 	tk.MustExec(`insert into mysql.opt_rule_blacklist values ("predicate_push_down"), ("partition_processor")`)
 	tk.MustExec("admin reload opt_rule_blacklist")
 	tk.MustQuery("select * from t where id = 1 for update").Check(testkit.Rows("1 100.00 -100.00 2021-06-17 22:35:20"))
+	require.Contains(t, fmt.Sprint(tk.MustQuery("show warnings").Rows()),
+		"partition_processor in mysql.opt_rule_blacklist is ignored because static partition pruning requires it for correctness")
 }
 
 func TestIssue26251(t *testing.T) {

--- a/pkg/executor/partition_table_test.go
+++ b/pkg/executor/partition_table_test.go
@@ -2247,11 +2247,19 @@ func TestSelectLockWithStaticPruneAndPartitionProcessorBlacklist(t *testing.T) {
 		balance2 decimal(10,2) generated always as (-balance) virtual,
 		created_at timestamp
 	) partition by hash (id) partitions 8`)
+	tk.MustExec(`create table t_non_partitioned (
+		id int primary key,
+		balance decimal(10,2),
+		created_at timestamp
+	)`)
 	tk.MustExec("insert into t (id, balance, created_at) values (1, 100, '2021-06-17 22:35:20')")
+	tk.MustExec("insert into t_non_partitioned values (1, 100, '2021-06-17 22:35:20')")
 	tk.MustQuery("select * from t where id = 1 for update").Check(testkit.Rows("1 100.00 -100.00 2021-06-17 22:35:20"))
 
 	tk.MustExec(`insert into mysql.opt_rule_blacklist values ("predicate_push_down"), ("partition_processor")`)
 	tk.MustExec("admin reload opt_rule_blacklist")
+	tk.MustQuery("select * from t_non_partitioned where id = 1 for update").Check(testkit.Rows("1 100.00 2021-06-17 22:35:20"))
+	tk.MustQuery("show warnings").Check(testkit.Rows())
 	tk.MustQuery("select * from t where id = 1 for update").Check(testkit.Rows("1 100.00 -100.00 2021-06-17 22:35:20"))
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 partition_processor in mysql.opt_rule_blacklist is ignored because static partition pruning requires it for correctness"))
 }

--- a/pkg/executor/partition_table_test.go
+++ b/pkg/executor/partition_table_test.go
@@ -2253,8 +2253,7 @@ func TestSelectLockWithStaticPruneAndPartitionProcessorBlacklist(t *testing.T) {
 	tk.MustExec(`insert into mysql.opt_rule_blacklist values ("predicate_push_down"), ("partition_processor")`)
 	tk.MustExec("admin reload opt_rule_blacklist")
 	tk.MustQuery("select * from t where id = 1 for update").Check(testkit.Rows("1 100.00 -100.00 2021-06-17 22:35:20"))
-	require.Contains(t, fmt.Sprint(tk.MustQuery("show warnings").Rows()),
-		"partition_processor in mysql.opt_rule_blacklist is ignored because static partition pruning requires it for correctness")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 partition_processor in mysql.opt_rule_blacklist is ignored because static partition pruning requires it for correctness"))
 }
 
 func TestIssue26251(t *testing.T) {

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -1043,13 +1043,26 @@ func isLogicalRuleDisabled(r base.LogicalOptRule, logic base.LogicalPlan) bool {
 	if !disabled {
 		return false
 	}
-	if _, ok := r.(*rule.PartitionProcessor); ok && !logic.SCtx().GetSessionVars().StmtCtx.UseDynamicPruneMode {
+	if _, ok := r.(*rule.PartitionProcessor); ok && !logic.SCtx().GetSessionVars().StmtCtx.UseDynamicPruneMode &&
+		hasPartitionedDataSource(logic) {
 		// Static pruning needs PartitionProcessor to rewrite logical partition scans
 		// into concrete partition scans; skipping it can make partition data invisible.
 		appendPartitionProcessorStaticPruneBlacklistWarning(logic)
 		return false
 	}
 	return true
+}
+
+func hasPartitionedDataSource(logic base.LogicalPlan) bool {
+	if ds, ok := logic.(*logicalop.DataSource); ok {
+		return ds.TableInfo != nil && ds.TableInfo.GetPartitionInfo() != nil
+	}
+	for _, child := range logic.Children() {
+		if hasPartitionedDataSource(child) {
+			return true
+		}
+	}
+	return false
 }
 
 func appendPartitionProcessorStaticPruneBlacklistWarning(logic base.LogicalPlan) {

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -986,7 +986,7 @@ func normalizeOptimize(ctx context.Context, flag uint64, logic base.LogicalPlan)
 		// The order of flags is same as the order of optRule in the list.
 		// We use a bitmask to record which opt rules should be used. If the i-th bit is 1, it means we should
 		// apply i-th optimizing rule.
-		if flag&(1<<uint(i)) == 0 || isLogicalRuleDisabled(rule) {
+		if flag&(1<<uint(i)) == 0 || isLogicalRuleDisabled(rule, logic) {
 			continue
 		}
 		logic, _, err = rule.Optimize(ctx, logic)
@@ -1008,7 +1008,7 @@ func logicalOptimize(ctx context.Context, flag uint64, logic base.LogicalPlan) (
 		// The order of flags is same as the order of optRule in the list.
 		// We use a bitmask to record which opt rules should be used. If the i-th bit is 1, it means we should
 		// apply i-th optimizing rule.
-		if flag&(1<<uint(i)) == 0 || isLogicalRuleDisabled(rule) {
+		if flag&(1<<uint(i)) == 0 || isLogicalRuleDisabled(rule, logic) {
 			continue
 		}
 		var planChanged bool
@@ -1018,7 +1018,7 @@ func logicalOptimize(ctx context.Context, flag uint64, logic base.LogicalPlan) (
 		}
 		// Compute interaction rules that should be optimized again
 		interactionRule, ok := optInteractionRuleList[rule]
-		if planChanged && ok && isLogicalRuleDisabled(interactionRule) {
+		if planChanged && ok && isLogicalRuleDisabled(interactionRule, logic) {
 			againRuleList = append(againRuleList, interactionRule)
 		}
 	}
@@ -1034,7 +1034,12 @@ func logicalOptimize(ctx context.Context, flag uint64, logic base.LogicalPlan) (
 	return logic, err
 }
 
-func isLogicalRuleDisabled(r base.LogicalOptRule) bool {
+func isLogicalRuleDisabled(r base.LogicalOptRule, logic base.LogicalPlan) bool {
+	if _, ok := r.(*rule.PartitionProcessor); ok && !logic.SCtx().GetSessionVars().StmtCtx.UseDynamicPruneMode {
+		// Static pruning needs PartitionProcessor to rewrite logical partition scans
+		// into concrete partition scans; skipping it can make partition data invisible.
+		return false
+	}
 	disabled := DefaultDisabledLogicalRulesList.Load().(set.StringSet).Exist(r.Name())
 	return disabled
 }

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -1018,7 +1018,7 @@ func logicalOptimize(ctx context.Context, flag uint64, logic base.LogicalPlan) (
 		}
 		// Compute interaction rules that should be optimized again
 		interactionRule, ok := optInteractionRuleList[rule]
-		if planChanged && ok && isLogicalRuleDisabled(interactionRule, logic) {
+		if planChanged && ok && !isLogicalRuleDisabled(interactionRule, logic) {
 			againRuleList = append(againRuleList, interactionRule)
 		}
 	}

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -71,7 +71,11 @@ var OptimizeAstNodeNoCache func(ctx context.Context, sctx sessionctx.Context, no
 // AllowCartesianProduct means whether tidb allows cartesian join without equal conditions.
 var AllowCartesianProduct = atomic.NewBool(true)
 
-const initialMaxCores uint64 = 10000
+const (
+	initialMaxCores uint64 = 10000
+
+	partitionProcessorStaticPruneBlacklistWarning = "partition_processor in mysql.opt_rule_blacklist is ignored because static partition pruning requires it for correctness"
+)
 
 var (
 	// the old ref of optRuleList for downgrading to old optimizing routine.
@@ -1042,12 +1046,20 @@ func isLogicalRuleDisabled(r base.LogicalOptRule, logic base.LogicalPlan) bool {
 	if _, ok := r.(*rule.PartitionProcessor); ok && !logic.SCtx().GetSessionVars().StmtCtx.UseDynamicPruneMode {
 		// Static pruning needs PartitionProcessor to rewrite logical partition scans
 		// into concrete partition scans; skipping it can make partition data invisible.
-		logic.SCtx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError(
-			"partition_processor in mysql.opt_rule_blacklist is ignored because static partition pruning requires it for correctness",
-		))
+		appendPartitionProcessorStaticPruneBlacklistWarning(logic)
 		return false
 	}
 	return true
+}
+
+func appendPartitionProcessorStaticPruneBlacklistWarning(logic base.LogicalPlan) {
+	stmtCtx := logic.SCtx().GetSessionVars().StmtCtx
+	for _, warn := range stmtCtx.GetWarnings() {
+		if warn.Err != nil && warn.Err.Error() == partitionProcessorStaticPruneBlacklistWarning {
+			return
+		}
+	}
+	stmtCtx.AppendWarning(errors.NewNoStackError(partitionProcessorStaticPruneBlacklistWarning))
 }
 
 func physicalOptimize(logic base.LogicalPlan) (plan base.PhysicalPlan, cost float64, err error) {

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -1035,13 +1035,19 @@ func logicalOptimize(ctx context.Context, flag uint64, logic base.LogicalPlan) (
 }
 
 func isLogicalRuleDisabled(r base.LogicalOptRule, logic base.LogicalPlan) bool {
+	disabled := DefaultDisabledLogicalRulesList.Load().(set.StringSet).Exist(r.Name())
+	if !disabled {
+		return false
+	}
 	if _, ok := r.(*rule.PartitionProcessor); ok && !logic.SCtx().GetSessionVars().StmtCtx.UseDynamicPruneMode {
 		// Static pruning needs PartitionProcessor to rewrite logical partition scans
 		// into concrete partition scans; skipping it can make partition data invisible.
+		logic.SCtx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError(
+			"partition_processor in mysql.opt_rule_blacklist is ignored because static partition pruning requires it for correctness",
+		))
 		return false
 	}
-	disabled := DefaultDisabledLogicalRulesList.Load().(set.StringSet).Exist(r.Name())
-	return disabled
+	return true
 }
 
 func physicalOptimize(logic base.LogicalPlan) (plan base.PhysicalPlan, cost float64, err error) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #57861

Problem Summary:

In static partition prune mode, `partition_processor` is required to rewrite a logical partitioned table scan into concrete partition scans. If the rule is disabled through `mysql.opt_rule_blacklist`, `SELECT ... FOR UPDATE` can be planned over the logical table scan and return an empty result even though the row exists in a partition.

### What changed and how does it work?

This PR treats `PartitionProcessor` as a correctness rule when the statement uses static partition pruning. In that mode, the logical optimizer ignores the opt-rule blacklist entry for `partition_processor`, emits a warning, and still runs the static partition rewrite. Dynamic partition pruning keeps the existing blacklist behavior.

It also adds a regression test for a hash-partitioned table with a virtual generated column, `SELECT ... FOR UPDATE`, and both `predicate_push_down` and `partition_processor` listed in `mysql.opt_rule_blacklist`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Test command:

```sh
go test --tags=intest ./pkg/executor -run TestSelectLockWithStaticPruneAndPartitionProcessorBlacklist -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that `SELECT ... FOR UPDATE` on partitioned tables could return empty results in static partition pruning mode when the partition processor rule is disabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test validating SELECT ... FOR UPDATE with static partition pruning when optimizer rules are blacklisted, ensuring queries on partitioned and non-partitioned tables return expected rows.

* **Bug Fixes**
  * Ensured the partition-processor rule is effectively enabled for correctness under static pruning and emits a deduplicated warning when a blacklist override occurs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->