### PR TITLE
planner: preserve setvar order for ORDER BY

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -132,6 +132,13 @@ order by id, version desc`).MultiCheckContain([]string{
 			"Projection root  test.t58129.id, test.t58129.version, setvar(row_num",
 			"└─Sort root  test.t58129.id, test.t58129.version:desc",
 		})
+
+		tk.MustQuery(`explain format='plan_tree' select rand() as r, @row_num := @row_num + 1 as rn
+from t58129, (select @row_num := 0) r
+order by r`).MultiCheckContain([]string{
+			"Sort root  Column",
+			"└─Projection root  rand()->Column, setvar(row_num",
+		})
 	}
 
 	// inl-join-inner-multi-pattern

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -106,6 +106,34 @@ func TestPlannerIssueRegressions(t *testing.T) {
 				"    └─TableFullScan cop[tikv] table:t7 keep order:false"))
 	}
 
+	// issue-58129-setvar-after-sort
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustExec(`create table t58129 (
+			id bigint unsigned not null,
+			version int not null,
+			primary key (id, version)
+		)`)
+		tk.MustExec("insert into t58129 values (1,100),(1,102),(2,29),(2,34),(2,60),(2,50),(1,129),(1,128)")
+		tk.MustQuery(`select id, version, @row_num := if(@id_last = id, @row_num + 1, 1) as rn, @id_last := id
+from t58129, (select @row_num := 0, @id_last := null) r
+order by id, version desc`).Check(testkit.Rows(
+			"1 129 1 1",
+			"1 128 2 1",
+			"1 102 3 1",
+			"1 100 4 1",
+			"2 60 1 2",
+			"2 50 2 2",
+			"2 34 3 2",
+			"2 29 4 2"))
+		tk.MustQuery(`explain format='plan_tree' select id, version, @row_num := if(@id_last = id, @row_num + 1, 1) as rn, @id_last := id
+from t58129, (select @row_num := 0, @id_last := null) r
+order by id, version desc`).MultiCheckContain([]string{
+			"Projection root  test.t58129.id, test.t58129.version, setvar(row_num",
+			"└─Sort root  test.t58129.id, test.t58129.version:desc",
+		})
+	}
+
 	// inl-join-inner-multi-pattern
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4629,12 +4629,13 @@ func (b *PlanBuilder) tryMoveSortBelowSetVarProjection(p base.LogicalPlan) base.
 
 	// SELECT-list variable assignments should observe the ORDER BY result order.
 	// Move the sort below the assignment projection only when the sort keys can
-	// be evaluated from the projection child without reading or assigning variables.
+	// be safely re-evaluated from the projection child.
 	exprCtx := b.ctx.GetExprCtx()
 	byItems := make([]*util.ByItems, 0, len(sort.ByItems))
 	for _, item := range sort.ByItems {
 		_, failed, expr := expression.ColumnSubstituteImpl(exprCtx, item.Expr, proj.Schema(), proj.Exprs, true)
-		if failed || expression.HasGetSetVarFunc(expr) {
+		if failed || expression.HasGetSetVarFunc(expr) || expression.CheckNonDeterministic(expr) ||
+			expression.IsMutableEffectsExpr(expr) {
 			return p
 		}
 		byItems = append(byItems, &util.ByItems{Expr: expr, Desc: item.Desc})

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4590,6 +4590,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 			if err != nil {
 				return nil, err
 			}
+			p = b.tryMoveSortBelowSetVarProjection(p)
 		}
 	}
 
@@ -4614,6 +4615,35 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 	}
 
 	return b.tryToBuildSequence(currentLayerCTEs, p), nil
+}
+
+func (b *PlanBuilder) tryMoveSortBelowSetVarProjection(p base.LogicalPlan) base.LogicalPlan {
+	sort, ok := p.(*logicalop.LogicalSort)
+	if !ok || len(sort.Children()) != 1 {
+		return p
+	}
+	proj, ok := sort.Children()[0].(*logicalop.LogicalProjection)
+	if !ok || len(proj.Children()) != 1 || !slices.ContainsFunc(proj.Exprs, expression.HasAssignSetVarFunc) {
+		return p
+	}
+
+	// SELECT-list variable assignments should observe the ORDER BY result order.
+	// Move the sort below the assignment projection only when the sort keys can
+	// be evaluated from the projection child without reading or assigning variables.
+	exprCtx := b.ctx.GetExprCtx()
+	byItems := make([]*util.ByItems, 0, len(sort.ByItems))
+	for _, item := range sort.ByItems {
+		_, failed, expr := expression.ColumnSubstituteImpl(exprCtx, item.Expr, proj.Schema(), proj.Exprs, true)
+		if failed || expression.HasGetSetVarFunc(expr) {
+			return p
+		}
+		byItems = append(byItems, &util.ByItems{Expr: expr, Desc: item.Desc})
+	}
+
+	sort.ByItems = byItems
+	sort.SetChildren(proj.Children()[0])
+	proj.SetChildren(sort)
+	return proj
 }
 
 func (b *PlanBuilder) tryToBuildSequence(ctes []*cteInfo, p base.LogicalPlan) base.LogicalPlan {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #58129

Problem Summary:

For queries that assign user variables in the SELECT list and also use ORDER BY, TiDB could evaluate the assignment projection before sorting. The user-visible row numbers were then assigned in the pre-sort scan order instead of the final ordered result, diverging from MySQL.

### What changed and how does it work?

This PR detects the direct `LogicalSort -> LogicalProjection` shape when the projection contains user-variable assignment. If the ORDER BY expressions can be substituted through the projection and do not themselves read or assign user variables, the planner moves the sort below the assignment projection so SELECT-list assignments observe the ordered row stream.

The rewrite is intentionally narrow:

- only direct `LogicalSort(LogicalProjection(...))` is changed;
- only projections with assignment-style `setvar` expressions are considered;
- ORDER BY items must substitute cleanly from the projection child;
- substituted ORDER BY expressions containing get/set variable functions are rejected.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Test command:

```sh
git diff --check
go test -run '^TestPlannerIssueRegressions$' -count=1 -tags=intest,deadlock -v ./pkg/planner/core/issuetest
make bazel_prepare
```

Note: `make bazel_prepare` did not complete because Bazel failed to fetch `github.com/uber/jaeger-lib@v2.4.1+incompatible` from `goproxy.cn` with a TLS handshake timeout. The partial generated `DEPS.bzl` change from that failed run was discarded, and the final diff only contains the planner code and focused regression test.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that queries using ORDER BY and SELECT-list user-variable assignment could assign variables before sorting, producing row numbers inconsistent with MySQL.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning so sorts behave correctly when queries assign user variables, ensuring stable results and correct ordering.

* **Tests**
  * Added a regression test covering sort + variable-assignment cases (including deterministic and non-deterministic ordering) and verification of the produced execution plan.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->