### PR TITLE
pkg/planner: preserve suffix order for MergeJoin with constant leading keys | tidb-test=release-8.5-20251125-v8.5.4

### DIFF
--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/types"
 	h "github.com/pingcap/tidb/pkg/util/hint"
+	"github.com/pingcap/tidb/pkg/util/intset"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 	"github.com/pingcap/tidb/pkg/util/ranger"
@@ -98,30 +99,69 @@ func moveEqualToOtherConditions(p *logicalop.LogicalJoin, offsets []int) []expre
 	return otherConds
 }
 
-// Only if the input required prop is the prefix fo join keys, we can pass through this property.
-func (p *PhysicalMergeJoin) tryToGetChildReqProp(prop *property.PhysicalProperty) ([]*property.PhysicalProperty, bool) {
+// Only if the input required prop is compatible with join-key order, we can pass through this property.
+// Leading join keys fixed to a single value can be skipped when matching the required order.
+func (p *PhysicalMergeJoin) tryToGetChildReqProp(prop *property.PhysicalProperty, constantCols intset.FastIntSet) ([]*property.PhysicalProperty, bool) {
 	all, desc := prop.AllSameOrder()
 	lProp := property.NewPhysicalProperty(property.RootTaskType, p.LeftJoinKeys, desc, math.MaxFloat64, false)
 	rProp := property.NewPhysicalProperty(property.RootTaskType, p.RightJoinKeys, desc, math.MaxFloat64, false)
 	lProp.CTEProducerStatus = prop.CTEProducerStatus
+	lProp.NoCopPushDown = prop.NoCopPushDown
 	rProp.CTEProducerStatus = prop.CTEProducerStatus
+	rProp.NoCopPushDown = prop.NoCopPushDown
 	if !prop.IsSortItemEmpty() {
 		// sort merge join fits the cases of massive ordered data, so desc scan is always expensive.
 		if !all {
 			return nil, false
 		}
-		if !prop.IsPrefix(lProp) && !prop.IsPrefix(rProp) {
+		matchLeft := isSortPropCompatibleWithJoinKeys(prop.SortItems, p.LeftJoinKeys, constantCols)
+		matchRight := isSortPropCompatibleWithJoinKeys(prop.SortItems, p.RightJoinKeys, constantCols)
+		if !matchLeft && !matchRight {
 			return nil, false
 		}
-		if prop.IsPrefix(rProp) && p.JoinType == logicalop.LeftOuterJoin {
+		if matchRight && p.JoinType == base.LeftOuterJoin {
 			return nil, false
 		}
-		if prop.IsPrefix(lProp) && p.JoinType == logicalop.RightOuterJoin {
+		if matchLeft && p.JoinType == base.RightOuterJoin {
 			return nil, false
 		}
 	}
 
 	return []*property.PhysicalProperty{lProp, rProp}, true
+}
+
+// isSortPropCompatibleWithJoinKeys checks whether the required order can be
+// satisfied by the join-key order when some leading join keys are fixed to a
+// single value.
+//
+// Examples:
+//   - join keys: (a, b), constant cols: {a}, required order: (b)
+//     This returns true because rows ordered by (a, b) are also ordered by (b)
+//     once a is fixed by predicates such as `a = 1`.
+//   - join keys: (a, b, c), constant cols: {a}, required order: (c)
+//     This returns false because b is neither part of the required order nor
+//     proven constant, so the scan order on c is not guaranteed.
+func isSortPropCompatibleWithJoinKeys(sortItems []property.SortItem, joinKeys []*expression.Column, constantCols intset.FastIntSet) bool {
+	keyPos := 0
+	for _, item := range sortItems {
+		matched := false
+		for keyPos < len(joinKeys) {
+			if item.Col.EqualColumn(joinKeys[keyPos]) {
+				keyPos++
+				matched = true
+				break
+			}
+			if constantCols.Has(int(joinKeys[keyPos].UniqueID)) {
+				keyPos++
+				continue
+			}
+			return false
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
 }
 
 func checkJoinKeyCollation(leftKeys, rightKeys []*expression.Column) bool {
@@ -144,6 +184,7 @@ func GetMergeJoin(p *logicalop.LogicalJoin, prop *property.PhysicalProperty, sch
 	joins := make([]base.PhysicalPlan, 0, len(p.LeftProperties)+1)
 	// The LeftProperties caches all the possible properties that are provided by its children.
 	leftJoinKeys, rightJoinKeys, isNullEQ, hasNullEQ := p.GetJoinKeys()
+	constantCols := p.ExtractFD().ConstantCols()
 
 	// EnumType/SetType Unsupported: merge join conflicts with index order.
 	// ref: https://github.com/pingcap/tidb/issues/24473, https://github.com/pingcap/tidb/issues/25669
@@ -204,7 +245,7 @@ func GetMergeJoin(p *logicalop.LogicalJoin, prop *property.PhysicalProperty, sch
 		mergeJoin.SetSchema(schema)
 		mergeJoin.OtherConditions = moveEqualToOtherConditions(p, offsets)
 		mergeJoin.initCompareFuncs()
-		if reqProps, ok := mergeJoin.tryToGetChildReqProp(prop); ok {
+		if reqProps, ok := mergeJoin.tryToGetChildReqProp(prop, constantCols); ok {
 			// Adjust expected count for children nodes.
 			if prop.ExpectedCnt < statsInfo.RowCount {
 				expCntScale := prop.ExpectedCnt / statsInfo.RowCount

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -106,9 +106,7 @@ func (p *PhysicalMergeJoin) tryToGetChildReqProp(prop *property.PhysicalProperty
 	lProp := property.NewPhysicalProperty(property.RootTaskType, p.LeftJoinKeys, desc, math.MaxFloat64, false)
 	rProp := property.NewPhysicalProperty(property.RootTaskType, p.RightJoinKeys, desc, math.MaxFloat64, false)
 	lProp.CTEProducerStatus = prop.CTEProducerStatus
-	lProp.NoCopPushDown = prop.NoCopPushDown
 	rProp.CTEProducerStatus = prop.CTEProducerStatus
-	rProp.NoCopPushDown = prop.NoCopPushDown
 	if !prop.IsSortItemEmpty() {
 		// sort merge join fits the cases of massive ordered data, so desc scan is always expensive.
 		if !all {
@@ -119,10 +117,10 @@ func (p *PhysicalMergeJoin) tryToGetChildReqProp(prop *property.PhysicalProperty
 		if !matchLeft && !matchRight {
 			return nil, false
 		}
-		if matchRight && p.JoinType == base.LeftOuterJoin {
+		if matchRight && p.JoinType == logicalop.LeftOuterJoin {
 			return nil, false
 		}
-		if matchLeft && p.JoinType == base.RightOuterJoin {
+		if matchLeft && p.JoinType == logicalop.RightOuterJoin {
 			return nil, false
 		}
 	}

--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     data = glob(["testdata/**"]),
     flaky = True,
     race = "on",
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         "//pkg/parser",
         "//pkg/planner",

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -310,6 +310,23 @@ func TestJoinReorderWithAddSelection(t *testing.T) {
 		`      └─TableFullScan 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo`))
 }
 
+func TestMergeJoinWithLimit(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec("create table t1(a int not null, b int not null, c int, primary key(a, b));")
+	tk.MustExec("create table t2(a int not null, b int not null, c int, primary key(a, b));")
+
+	tk.MustQuery("explain format='plan_tree' select /*+ merge_join(t1, t2) */ t1.a, t1.b from t1 join t2 on t1.a = t2.a and t1.b = t2.b where t1.a = 1 and t2.c > 10 group by t1.a, t1.b order by t1.b limit 2").Check(
+		testkit.Rows("Limit root  offset:0, count:2",
+			"└─MergeJoin root  inner join, left key:test.t2.a, test.t2.b, right key:test.t1.a, test.t1.b",
+			"  ├─TableReader(Build) root  data:TableRangeScan",
+			"  │ └─TableRangeScan cop[tikv] table:t1 range:[1,1], keep order:true, stats:pseudo",
+			"  └─TableReader(Probe) root  data:Selection",
+			"    └─Selection cop[tikv]  gt(test.t2.c, 10)",
+			"      └─TableRangeScan cop[tikv] table:t2 range:[1,1], keep order:true, stats:pseudo"))
+}
+
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67755

Problem Summary: manually cherry pick https://github.com/pingcap/tidb/pull/68001

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge-join planning so required sort/order is considered compatible when some join-key columns are constant, producing more accurate plans and better performance for queries with LIMIT.

* **Tests**
  * Added a regression test covering merge-join queries with filters, grouping, ordering, and LIMIT to ensure stable optimization and plan shapes.

* **Chores**
  * Adjusted test shard configuration to rebalance test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->