### PR TITLE
planner: project grouped constant max/min

### DIFF
--- a/pkg/planner/core/casetest/integration_test.go
+++ b/pkg/planner/core/casetest/integration_test.go
@@ -522,11 +522,18 @@ FROM (SELECT DISTINCT balance.portfolio_code AS portfolioCode
 			tk.MustQuery(`select /* issue:67009 */ ceil(max(b'101010')) as c0
 				from t_issue67009
 				group by c0
+				having convert_tz('2025-12-31 14:30:00', 'Europe/Amsterdam', '+00:00')`).Check(testkit.Rows("0"))
+			tk.MustQuery("show warnings").Check(testkit.RowsWithSep("|", "Warning|1292|Truncated incorrect DOUBLE value: '*'"))
+			tk.MustQuery(`select /* issue:67009 constant */ max(42) as c0
+				from t_issue67009
+				group by c0
 				having convert_tz('2025-12-31 14:30:00', 'Europe/Amsterdam', '+00:00')`).Check(testkit.Rows("42"))
 			tk.MustQuery("show warnings").Check(testkit.Rows())
 			if !notNull {
 				tk.MustHavePlan("select /* issue:67009 boundary */ max(c0) from t_issue67009 group by c0", "HashAgg")
 				tk.MustNotHavePlan("select /* issue:67009 boundary */ max(c0) from t_issue67009 group by c0", "Projection")
+				tk.MustHavePlan("select /* issue:67009 constant */ max(42) from t_issue67009 group by c0", "HashAgg")
+				tk.MustHavePlan("select /* issue:67009 constant */ max(42) from t_issue67009 group by c0", "Projection")
 			}
 		}
 

--- a/pkg/planner/core/casetest/integration_test.go
+++ b/pkg/planner/core/casetest/integration_test.go
@@ -539,16 +539,16 @@ FROM (SELECT DISTINCT balance.portfolio_code AS portfolioCode
 					"  └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:false, stats:pseudo"))
 			} else {
 				tk.MustQuery("explain format = 'plan_tree' select /* issue:67009 boundary */ max(c0) from t_issue67009 group by c0").Check(testkit.Rows(
-					"HashAgg root  group by:test.t_issue67009.c0, funcs:max(Column)->Column",
-					"└─IndexReader root  index:HashAgg",
-					"  └─HashAgg cop[tikv]  group by:test.t_issue67009.c0, funcs:max(test.t_issue67009.c0)->Column",
-					"    └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:false, stats:pseudo"))
+					"StreamAgg root  group by:test.t_issue67009.c0, funcs:max(Column)->Column",
+					"└─IndexReader root  index:StreamAgg",
+					"  └─StreamAgg cop[tikv]  group by:test.t_issue67009.c0, funcs:max(test.t_issue67009.c0)->Column",
+					"    └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:true, stats:pseudo"))
 				tk.MustQuery("explain format = 'plan_tree' select /* issue:67009 constant */ max(42) from t_issue67009 group by c0").Check(testkit.Rows(
 					"Projection root  42->Column",
-					"└─HashAgg root  group by:test.t_issue67009.c0, funcs:count(Column)->Column",
-					"  └─IndexReader root  index:HashAgg",
-					"    └─HashAgg cop[tikv]  group by:test.t_issue67009.c0, funcs:count(1)->Column",
-					"      └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:false, stats:pseudo"))
+					"└─StreamAgg root  group by:test.t_issue67009.c0, funcs:count(Column)->Column",
+					"  └─IndexReader root  index:StreamAgg",
+					"    └─StreamAgg cop[tikv]  group by:test.t_issue67009.c0, funcs:count(1)->Column",
+					"      └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:true, stats:pseudo"))
 			}
 		}
 

--- a/pkg/planner/core/casetest/integration_test.go
+++ b/pkg/planner/core/casetest/integration_test.go
@@ -539,16 +539,16 @@ FROM (SELECT DISTINCT balance.portfolio_code AS portfolioCode
 					"  └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:false, stats:pseudo"))
 			} else {
 				tk.MustQuery("explain format = 'plan_tree' select /* issue:67009 boundary */ max(c0) from t_issue67009 group by c0").Check(testkit.Rows(
-					"StreamAgg root  group by:test.t_issue67009.c0, funcs:max(Column)->Column",
-					"└─IndexReader root  index:StreamAgg",
-					"  └─StreamAgg cop[tikv]  group by:test.t_issue67009.c0, funcs:max(test.t_issue67009.c0)->Column",
-					"    └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:true, stats:pseudo"))
+					"HashAgg root  group by:test.t_issue67009.c0, funcs:max(Column)->Column",
+					"└─IndexReader root  index:HashAgg",
+					"  └─HashAgg cop[tikv]  group by:test.t_issue67009.c0, funcs:max(test.t_issue67009.c0)->Column",
+					"    └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:false, stats:pseudo"))
 				tk.MustQuery("explain format = 'plan_tree' select /* issue:67009 constant */ max(42) from t_issue67009 group by c0").Check(testkit.Rows(
 					"Projection root  42->Column",
-					"└─StreamAgg root  group by:test.t_issue67009.c0, funcs:count(Column)->Column",
-					"  └─IndexReader root  index:StreamAgg",
-					"    └─StreamAgg cop[tikv]  group by:test.t_issue67009.c0, funcs:count(1)->Column",
-					"      └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:true, stats:pseudo"))
+					"└─HashAgg root  group by:test.t_issue67009.c0, funcs:count(Column)->Column",
+					"  └─IndexReader root  index:HashAgg",
+					"    └─HashAgg cop[tikv]  group by:test.t_issue67009.c0, funcs:count(1)->Column",
+					"      └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:false, stats:pseudo"))
 			}
 		}
 

--- a/pkg/planner/core/casetest/integration_test.go
+++ b/pkg/planner/core/casetest/integration_test.go
@@ -538,12 +538,14 @@ FROM (SELECT DISTINCT balance.portfolio_code AS portfolioCode
 					"└─IndexReader root  index:IndexFullScan",
 					"  └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:false, stats:pseudo"))
 			} else {
-				tk.MustQuery("explain format = 'plan_tree' select /* issue:67009 boundary */ max(c0) from t_issue67009 group by c0").Check(testkit.Rows(
+				// Force HashAgg so this boundary assertion only checks that MAX(c0)
+				// is still aggregated rather than projected as a constant.
+				tk.MustQuery("explain format = 'plan_tree' select /*+ HASH_AGG() */ /* issue:67009 boundary */ max(c0) from t_issue67009 group by c0").Check(testkit.Rows(
 					"HashAgg root  group by:test.t_issue67009.c0, funcs:max(Column)->Column",
 					"└─IndexReader root  index:HashAgg",
 					"  └─HashAgg cop[tikv]  group by:test.t_issue67009.c0, funcs:max(test.t_issue67009.c0)->Column",
 					"    └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:false, stats:pseudo"))
-				tk.MustQuery("explain format = 'plan_tree' select /* issue:67009 constant */ max(42) from t_issue67009 group by c0").Check(testkit.Rows(
+				tk.MustQuery("explain format = 'plan_tree' select /*+ HASH_AGG() */ /* issue:67009 constant */ max(42) from t_issue67009 group by c0").Check(testkit.Rows(
 					"Projection root  42->Column",
 					"└─HashAgg root  group by:test.t_issue67009.c0, funcs:count(Column)->Column",
 					"  └─IndexReader root  index:HashAgg",

--- a/pkg/planner/core/casetest/integration_test.go
+++ b/pkg/planner/core/casetest/integration_test.go
@@ -529,11 +529,26 @@ FROM (SELECT DISTINCT balance.portfolio_code AS portfolioCode
 				group by c0
 				having convert_tz('2025-12-31 14:30:00', 'Europe/Amsterdam', '+00:00')`).Check(testkit.Rows("42"))
 			tk.MustQuery("show warnings").Check(testkit.Rows())
-			if !notNull {
-				tk.MustHavePlan("select /* issue:67009 boundary */ max(c0) from t_issue67009 group by c0", "HashAgg")
-				tk.MustNotHavePlan("select /* issue:67009 boundary */ max(c0) from t_issue67009 group by c0", "Projection")
-				tk.MustHavePlan("select /* issue:67009 constant */ max(42) from t_issue67009 group by c0", "HashAgg")
-				tk.MustHavePlan("select /* issue:67009 constant */ max(42) from t_issue67009 group by c0", "Projection")
+			if notNull {
+				tk.MustQuery("explain format = 'plan_tree' select /* issue:67009 boundary */ max(c0) from t_issue67009 group by c0").Check(testkit.Rows(
+					"IndexReader root  index:IndexFullScan",
+					"└─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:false, stats:pseudo"))
+				tk.MustQuery("explain format = 'plan_tree' select /* issue:67009 constant */ max(42) from t_issue67009 group by c0").Check(testkit.Rows(
+					"Projection root  42->Column",
+					"└─IndexReader root  index:IndexFullScan",
+					"  └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:false, stats:pseudo"))
+			} else {
+				tk.MustQuery("explain format = 'plan_tree' select /* issue:67009 boundary */ max(c0) from t_issue67009 group by c0").Check(testkit.Rows(
+					"HashAgg root  group by:test.t_issue67009.c0, funcs:max(Column)->Column",
+					"└─IndexReader root  index:HashAgg",
+					"  └─HashAgg cop[tikv]  group by:test.t_issue67009.c0, funcs:max(test.t_issue67009.c0)->Column",
+					"    └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:false, stats:pseudo"))
+				tk.MustQuery("explain format = 'plan_tree' select /* issue:67009 constant */ max(42) from t_issue67009 group by c0").Check(testkit.Rows(
+					"Projection root  42->Column",
+					"└─HashAgg root  group by:test.t_issue67009.c0, funcs:count(Column)->Column",
+					"  └─IndexReader root  index:HashAgg",
+					"    └─HashAgg cop[tikv]  group by:test.t_issue67009.c0, funcs:count(1)->Column",
+					"      └─IndexFullScan cop[tikv] table:t_issue67009, index:c0(c0) keep order:false, stats:pseudo"))
 			}
 		}
 

--- a/pkg/planner/core/casetest/integration_test.go
+++ b/pkg/planner/core/casetest/integration_test.go
@@ -510,6 +510,26 @@ FROM (SELECT DISTINCT balance.portfolio_code AS portfolioCode
 		tk.MustExec(`create table tx (a int, b json, key k(a, (cast(b as date array))))`)
 		tk.MustQuery(`select /* issue:49438 */ 1 from tx where a in (1)`).Check(testkit.Rows())
 
+		// issue:67009
+		for _, notNull := range []bool{true, false} {
+			tk.MustExec("drop table if exists t_issue67009")
+			if notNull {
+				tk.MustExec("create table t_issue67009(c0 char unique not null)")
+			} else {
+				tk.MustExec("create table t_issue67009(c0 char unique)")
+			}
+			tk.MustExec("insert into t_issue67009 values (1)")
+			tk.MustQuery(`select /* issue:67009 */ ceil(max(b'101010')) as c0
+				from t_issue67009
+				group by c0
+				having convert_tz('2025-12-31 14:30:00', 'Europe/Amsterdam', '+00:00')`).Check(testkit.Rows("42"))
+			tk.MustQuery("show warnings").Check(testkit.Rows())
+			if !notNull {
+				tk.MustHavePlan("select /* issue:67009 boundary */ max(c0) from t_issue67009 group by c0", "HashAgg")
+				tk.MustNotHavePlan("select /* issue:67009 boundary */ max(c0) from t_issue67009 group by c0", "Projection")
+			}
+		}
+
 		// issue:52023
 		tk.MustExec(`CREATE TABLE t_issue52023 (
 			a binary(1) NOT NULL,

--- a/pkg/planner/core/rule_aggregation_elimination.go
+++ b/pkg/planner/core/rule_aggregation_elimination.go
@@ -143,6 +143,10 @@ func (*aggregationEliminateChecker) tryToProjectConstMaxMin(agg *logicalop.Logic
 			proj.Exprs = append(proj.Exprs, agg.Schema().Columns[i].Clone())
 			continue
 		}
+		if expression.IsBinaryLiteral(af.Args[0]) {
+			proj.Exprs = append(proj.Exprs, agg.Schema().Columns[i].Clone())
+			continue
+		}
 		if af.Args[0].ConstLevel() < expression.ConstOnlyInContext {
 			proj.Exprs = append(proj.Exprs, agg.Schema().Columns[i].Clone())
 			continue

--- a/pkg/planner/core/rule_aggregation_elimination.go
+++ b/pkg/planner/core/rule_aggregation_elimination.go
@@ -123,6 +123,41 @@ func (*aggregationEliminateChecker) tryToEliminateDistinct(agg *logicalop.Logica
 	}
 }
 
+func (*aggregationEliminateChecker) tryToProjectConstMaxMin(agg *logicalop.LogicalAggregation) *logicalop.LogicalProjection {
+	if len(agg.GroupByItems) == 0 {
+		return nil
+	}
+	// For grouped aggregation, each output group is non-empty, so MAX/MIN of a
+	// statement-level constant can be projected as the constant while the
+	// aggregation below still preserves group cardinality.
+	changed := false
+	proj := logicalop.LogicalProjection{
+		Exprs: make([]expression.Expression, 0, len(agg.AggFuncs)),
+	}.Init(agg.SCtx(), agg.QueryBlockOffset())
+	for i, af := range agg.AggFuncs {
+		if af.HasDistinct || len(af.OrderByItems) > 0 || len(af.Args) != 1 {
+			proj.Exprs = append(proj.Exprs, agg.Schema().Columns[i].Clone())
+			continue
+		}
+		if af.Name != ast.AggFuncMax && af.Name != ast.AggFuncMin {
+			proj.Exprs = append(proj.Exprs, agg.Schema().Columns[i].Clone())
+			continue
+		}
+		if af.Args[0].ConstLevel() < expression.ConstOnlyInContext {
+			proj.Exprs = append(proj.Exprs, agg.Schema().Columns[i].Clone())
+			continue
+		}
+		proj.Exprs = append(proj.Exprs, wrapCastFunction(agg.SCtx().GetExprCtx(), af.Args[0], af.RetTp))
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	proj.SetSchema(agg.Schema().Clone())
+	proj.SetChildren(agg)
+	return proj
+}
+
 // CheckCanConvertAggToProj check whether a special old aggregation (which has already been pushed down) to projection.
 // link: issue#44795
 func CheckCanConvertAggToProj(agg *logicalop.LogicalAggregation) bool {
@@ -252,6 +287,9 @@ func (a *AggregationEliminator) Optimize(ctx context.Context, p base.LogicalPlan
 	a.tryToEliminateDistinct(agg)
 	if proj := a.tryToEliminateAggregation(agg); proj != nil {
 		return proj, planChanged, nil
+	}
+	if proj := a.tryToProjectConstMaxMin(agg); proj != nil {
+		return proj, true, nil
 	}
 	return p, planChanged, nil
 }

--- a/pkg/planner/core/rule_aggregation_elimination.go
+++ b/pkg/planner/core/rule_aggregation_elimination.go
@@ -131,32 +131,33 @@ func (*aggregationEliminateChecker) tryToProjectConstMaxMin(agg *logicalop.Logic
 	// statement-level constant can be projected as the constant while the
 	// aggregation below still preserves group cardinality.
 	changed := false
-	proj := logicalop.LogicalProjection{
-		Exprs: make([]expression.Expression, 0, len(agg.AggFuncs)),
-	}.Init(agg.SCtx(), agg.QueryBlockOffset())
+	exprs := make([]expression.Expression, 0, len(agg.AggFuncs))
 	for i, af := range agg.AggFuncs {
 		if af.HasDistinct || len(af.OrderByItems) > 0 || len(af.Args) != 1 {
-			proj.Exprs = append(proj.Exprs, agg.Schema().Columns[i].Clone())
+			exprs = append(exprs, agg.Schema().Columns[i].Clone())
 			continue
 		}
 		if af.Name != ast.AggFuncMax && af.Name != ast.AggFuncMin {
-			proj.Exprs = append(proj.Exprs, agg.Schema().Columns[i].Clone())
+			exprs = append(exprs, agg.Schema().Columns[i].Clone())
 			continue
 		}
 		if expression.IsBinaryLiteral(af.Args[0]) {
-			proj.Exprs = append(proj.Exprs, agg.Schema().Columns[i].Clone())
+			exprs = append(exprs, agg.Schema().Columns[i].Clone())
 			continue
 		}
 		if af.Args[0].ConstLevel() < expression.ConstOnlyInContext {
-			proj.Exprs = append(proj.Exprs, agg.Schema().Columns[i].Clone())
+			exprs = append(exprs, agg.Schema().Columns[i].Clone())
 			continue
 		}
-		proj.Exprs = append(proj.Exprs, wrapCastFunction(agg.SCtx().GetExprCtx(), af.Args[0], af.RetTp))
+		exprs = append(exprs, wrapCastFunction(agg.SCtx().GetExprCtx(), af.Args[0], af.RetTp))
 		changed = true
 	}
 	if !changed {
 		return nil
 	}
+	proj := logicalop.LogicalProjection{
+		Exprs: exprs,
+	}.Init(agg.SCtx(), agg.QueryBlockOffset())
 	proj.SetSchema(agg.Schema().Clone())
 	proj.SetChildren(agg)
 	return proj


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67009

Problem Summary:

Grouped `MAX`/`MIN` over a statement-level constant can be simplified without changing the aggregate result value, but replacing the aggregation itself can change grouped aggregation semantics. Binary literals are a special case where `MAX`/`MIN` preserves string-like aggregate semantics, so the planner must keep the existing aggregate behavior for queries such as `CEIL(MAX(b'101010'))`.

### What changed and how does it work?

This PR adds a planner-only aggregation elimination step for grouped `MAX`/`MIN` over statement-level constants. Instead of removing the aggregation, it keeps the aggregation below a projection so the grouping operator still preserves group cardinality, while the projection returns the constant aggregate value.

The rewrite is intentionally narrow:

- only grouped aggregation is eligible;
- only `MAX` and `MIN` with one argument are eligible;
- `DISTINCT` and `ORDER BY` aggregate variants are skipped;
- binary literal arguments are skipped to preserve aggregate cast and warning semantics;
- only arguments with `ConstLevel() >= ConstOnlyInContext` are rewritten.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation on current head `b702488aa40f05f89bd476bb1e9d5ec35263befc`:

- `./tools/check/failpoint-go-test.sh pkg/planner/core/casetest -run '^TestIntegrationRegression$' -count=1`
- `go test -tags=intest,deadlock ./pkg/planner/core/casetest -run '^TestIntegrationRegression$' -count=1`
- `git diff --check ae3b70a8072bbdd8a37b732fbdf554f2ed5722a9..HEAD`

Previous broader validation before the latest test-only stabilization commit:

- `(cd tests/integrationtest && ./run-tests.sh -t explain)`
- `(cd tests/integrationtest && ./run-tests.sh -b n -t executor/prepared)`
- `(cd tests/integrationtest && ./run-tests.sh -b n -t planner/core/plan_cache)`
- `(cd tests/integrationtest && ./run-tests.sh -b n -t planner/core/plan_cost_ver2)`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix inconsistent grouped `MAX`/`MIN` results over statement-level constants in planner aggregation elimination.
```
