### PR TITLE
fix(ddl): reject truncating mview-related tables

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -4719,6 +4719,9 @@ func (e *executor) TruncateTable(ctx sessionctx.Context, ti ast.Ident) error {
 	if tblInfo.MaterializedViewLog != nil {
 		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("TRUNCATE TABLE on materialized view log table")
 	}
+	if tblInfo.MaterializedViewBase != nil && tblInfo.MaterializedViewBase.MLogID != 0 {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("TRUNCATE TABLE on base table with materialized view log")
+	}
 	if err := checkTableMaterializedViewConstraints(ctx.GetSessionVars(), tblInfo, "TRUNCATE TABLE"); err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -143,3 +143,15 @@ func TestImportIntoChildSessionInheritsMaintenanceFlag(t *testing.T) {
 	require.True(t, invoked)
 	require.True(t, childMaintenance)
 }
+
+func TestImportIntoRejectsMaterializedViewLogBaseTable(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table src (a int)")
+	tk.MustExec("create table dst (a int)")
+	tk.MustExec("create materialized view log on dst (a)")
+
+	err := tk.ExecToErr("import into dst from select * from src with disable_precheck")
+	require.ErrorContains(t, err, "IMPORT INTO on tables with materialized view log")
+}

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -514,16 +514,22 @@ func TestTruncateMaterializedViewRelatedTablesRejected(t *testing.T) {
 	tk.MustExec("create table t_truncate_mv (a int not null, b int)")
 	tk.MustExec("create materialized view log on t_truncate_mv (a, b)")
 
+	err := tk.ExecToErr("truncate table t_truncate_mv")
+	require.ErrorContains(t, err, "TRUNCATE TABLE on base table with materialized view log")
+
+	err = tk.ExecToErr("truncate table `$mlog$t_truncate_mv`")
+	require.ErrorContains(t, err, "TRUNCATE TABLE on materialized view log table")
+
 	tk.MustExec("create materialized view mv_truncate_mv (a, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, count(1) from t_truncate_mv group by a")
 
-	err := tk.ExecToErr("truncate table mv_truncate_mv")
+	err = tk.ExecToErr("truncate table mv_truncate_mv")
 	require.ErrorContains(t, err, "TRUNCATE TABLE on materialized view table")
 
 	err = tk.ExecToErr("truncate table `$mlog$t_truncate_mv`")
 	require.ErrorContains(t, err, "TRUNCATE TABLE on materialized view log table")
 
 	err = tk.ExecToErr("truncate table t_truncate_mv")
-	require.ErrorContains(t, err, "TRUNCATE TABLE on base table with materialized view dependencies")
+	require.ErrorContains(t, err, "TRUNCATE TABLE on base table with materialized view log")
 }
 
 func TestMaterializedViewRelatedTablesDDLRejected(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

Base tables that already have a materialized view log could still be truncated when no materialized view dependency existed yet. This should be rejected because the base table is already tied to the materialized view log metadata and log table.

The truncate behavior around materialized view log tables should also be covered in the same mlog-only state, so `TRUNCATE TABLE` on the physical mlog table is explicitly locked down before any materialized view exists.

### What changed and how does it work?

Reject `TRUNCATE TABLE` when the target base table has mlog, returning `TRUNCATE TABLE on base table with materialized view log`.

This is intentional even after dependent materialized views already exist. Once a base table is associated with an MLog, this PR treats the presence of that MLog as the primary guard for both `TRUNCATE TABLE` and `IMPORT INTO` on the base table, instead of preserving the older truncate-specific dependency error path.

Add regression coverage for:

- `TRUNCATE TABLE` on an mlog-only base table before any materialized view exists.
- `TRUNCATE TABLE` on the physical materialized view log table before any materialized view exists.
- `TRUNCATE TABLE` on a base table after a materialized view exists, keeping the error based on the materialized view log.
- `IMPORT INTO ... WITH disable_precheck` on a base table with a materialized view log, locking the existing behavior.

Note that this PR does not try to close the general `IMPORT INTO` concurrency gap. `IMPORT INTO` is documented as requiring no concurrent DDL/DML on the target table, and the existing code does not provide a complete target-table mutual exclusion mechanism. The change here only enforces the metadata-visible case where the target base table already has an MLog when `IMPORT INTO` or `TRUNCATE TABLE` starts.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Disallow truncating tables associated with materialized view logs.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TRUNCATE TABLE now rejects truncating base tables that have materialized view logs, preventing accidental data loss
  * IMPORT INTO now rejects operations on tables with materialized view logs to ensure data consistency
  * Error messages clarified to better explain why these operations are disallowed

* **Tests**
  * Added tests verifying IMPORT INTO and TRUNCATE behavior with materialized view logs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
