### PR TITLE
ddl: fix missing streaming for multi-schema add-index

### DIFF
--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -533,9 +533,11 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 		idxResults  []IndexRecordChunk
 		execDetails kvutil.ExecDetails
 	)
+
 	// Local ingest may trigger partial import/reset while the scan transaction is
 	// still open, so only the global-sort path can stream results immediately.
-	enableStreaming := w.reorgMeta.UseCloudStorage
+	enableStreaming := w.cpOp == nil
+	failpoint.InjectCall("checkEnableStreaming", enableStreaming)
 	sendResult := func(idxResult IndexRecordChunk) {
 		sender(idxResult)
 		if w.cpOp != nil {

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -536,7 +536,7 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 
 	// Local ingest may trigger partial import/reset while the scan transaction is
 	// still open, so only the global-sort path can stream results immediately.
-	enableStreaming := w.cpOp == nil
+	enableStreaming := w.reorgMeta.UseCloudStorage
 	failpoint.InjectCall("checkEnableStreaming", enableStreaming)
 	sendResult := func(idxResult IndexRecordChunk) {
 		sender(idxResult)

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -108,6 +108,12 @@ func newReadIndexExecutor(
 
 func (r *readIndexStepExecutor) Init(ctx context.Context) error {
 	logutil.DDLLogger().Info("read index executor init subtask exec env")
+	if r.isGlobalSort() {
+		// Multi-schema proxy jobs may not carry UseCloudStorage. Set it here
+		// before the framework starts detectAndHandleParamModifyLoop, which
+		// reads the flag concurrently via ResourceModified.
+		r.job.ReorgMeta.UseCloudStorage = true
+	}
 	cfg := config.GetGlobalConfig()
 	if cfg.Store == config.StoreTypeTiKV {
 		if !r.isGlobalSort() {
@@ -232,9 +238,6 @@ func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 
 	concurrency := int(r.GetResource().CPU.Capacity())
 	if r.isGlobalSort() {
-		// Multi-schema proxy jobs may not carry UseCloudStorage, while this executor
-		// has already selected the global-sort path by cloudStorageURI.
-		r.job.ReorgMeta.UseCloudStorage = true
 		return r.runGlobalPipeline(ctx, wctx, subtask, sm, concurrency, objStore)
 	}
 	return r.runLocalPipeline(ctx, wctx, subtask, sm, concurrency)

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -232,6 +232,9 @@ func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 
 	concurrency := int(r.GetResource().CPU.Capacity())
 	if r.isGlobalSort() {
+		// Multi-schema proxy jobs may not carry UseCloudStorage, while this executor
+		// has already selected the global-sort path by cloudStorageURI.
+		r.job.ReorgMeta.UseCloudStorage = true
 		return r.runGlobalPipeline(ctx, wctx, subtask, sm, concurrency, objStore)
 	}
 	return r.runLocalPipeline(ctx, wctx, subtask, sm, concurrency)

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -200,6 +200,12 @@ func TestGlobalSortBasic(t *testing.T) {
 		jobID = job.ID
 	})
 
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkEnableStreaming",
+		func(enabled bool) {
+			require.True(t, enabled, "streaming should be enabled with global sort")
+		},
+	)
+
 	tk.MustExec("alter table t add index idx(a);")
 	checkDataAndShowJobs(t, tk, size)
 	checkExternalFields(t, tk)
@@ -282,6 +288,14 @@ func TestGlobalSortMultiSchemaChange(t *testing.T) {
 					t.Skip("DXF is always enabled on nextgen")
 				}
 			}
+
+			testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkEnableStreaming",
+				func(enabled bool) {
+					expected := tc.cloudStorageURI != ""
+					require.Equal(t, expected, enabled)
+				},
+			)
+
 			if kerneltype.IsClassic() {
 				tk.MustExec("set @@global.tidb_ddl_enable_fast_reorg = " + tc.enableFastReorg + ";")
 				tk.MustExec("set @@global.tidb_enable_dist_task = " + tc.enableDistTask + ";")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #64911

Problem Summary:

On nextgen clusters, multi-schema-change ADD INDEX still consumes massive memory for grpc after #67452.

Root cause: #67452 changed `tableScanWorker.scanRecords` to check `w.reorgMeta.UseCloudStorage`, which is set by proxy job for multi schema change. But it doesn't copy back to the parent job (which is changed in https://github.com/pingcap/tidb/pull/64337), so at StateWriteReorg the DXF task meta is cloned from a stale proxy job, and the worker reads `UseCloudStorage = false`.

> [!NOTE]
> In the previous test for #67452, we used release-nextgen-20251011 for tidb, so this problem was not exposed. And this PR doesn't need to be cherry-picked back to that branch too.

### What changed and how does it work?

In `readIndexStepExecutor.RunSubtask`, when `r.isGlobalSort()`, set `r.job.ReorgMeta.UseCloudStorage = true` before invoking it.

A `checkEnableStreaming` failpoint hook is added in `scanRecords` so tests can assert the streaming-vs-batch decision at runtime. `TestGlobalSortBasic` and `TestGlobalSortMultiSchemaChange` are extended to use it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Run `alter table xxx add index(pad_8), add index(pad_128)`.

**Before** 

<img width="3802" height="602" alt="image" src="https://github.com/user-attachments/assets/8c1f664b-362a-4eb2-a820-26460d0fde1a" />

After

<img width="3838" height="602" alt="image" src="https://github.com/user-attachments/assets/6795b933-8986-463f-889b-5905e096e6f1" />

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```
