### PR TITLE
planner, sessionctx: enable non-eval scalar subquery explain by default

### DIFF
--- a/pkg/planner/core/casetest/logicalplan/logical_plan_builder_test.go
+++ b/pkg/planner/core/casetest/logicalplan/logical_plan_builder_test.go
@@ -44,8 +44,10 @@ WHERE EXISTS
                FROM mysql_3 a1 NATURAL
                RIGHT JOIN mysql_3 a2
                WHERE t1.col_pk_date IS NULL
-               GROUP BY a1.col_pk_char)) )`).Check(testkit.Rows("TableDual root  rows:0",
-			"ScalarSubQuery root  Output: ScalarQueryCol#29, ScalarQueryCol#30, ScalarQueryCol#31, ScalarQueryCol#32, ScalarQueryCol#33, ScalarQueryCol#34, ScalarQueryCol#35",
+               GROUP BY a1.col_pk_char)) )`).Check(testkit.Rows("Selection root  ScalarQueryCol#29",
+			"└─TableReader root  data:TableFullScan",
+			"  └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo",
+			"ScalarSubQuery root  Output: ScalarQueryCol#29",
 			"└─HashJoin root  Null-aware anti semi join, left side:TableReader, equal:[eq(test.mysql_3.col_pk_char, test.mysql_3.col_pk_char)]",
 			"  ├─HashAgg(Build) root  group by:test.mysql_3.col_pk_char, funcs:firstrow(test.mysql_3.col_pk_char)->test.mysql_3.col_pk_char",
 			"  │ └─TableDual root  rows:0",

--- a/pkg/planner/core/casetest/rule/rule_correlate_test.go
+++ b/pkg/planner/core/casetest/rule/rule_correlate_test.go
@@ -107,6 +107,7 @@ func TestCorrelate(tt *testing.T) {
 
 		// Enable the correlate rule.
 		tk.MustExec("set tidb_opt_enable_alternative_logical_plans = ON")
+		tk.MustExec("set tidb_opt_enable_non_eval_scalar_subquery = OFF")
 
 		var input []string
 		var output []struct {

--- a/pkg/planner/core/casetest/scalarsubquery/cases_test.go
+++ b/pkg/planner/core/casetest/scalarsubquery/cases_test.go
@@ -17,6 +17,7 @@ package scalarsubquery
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -45,7 +46,19 @@ func TestExplainNonEvaledSubquery(t *testing.T) {
 		testKit.MustExec("create table t1(a int, b int, c int)")
 		testKit.MustExec("create table t2(a int, b int, c int)")
 		testKit.MustExec("create table t3(a varchar(5), b varchar(5), c varchar(5))")
-		testKit.MustExec("set @@tidb_opt_enable_non_eval_scalar_subquery=true")
+		testKit.MustQuery("select @@tidb_opt_enable_non_eval_scalar_subquery").Check(testkit.Rows("1"))
+
+		testKit.Session().GetSessionVars().RewritePhaseInfo.Reset()
+		rows := testKit.MustQuery("explain format = 'plan_tree' select * from t1 where a = (select sleep(0.3))").Rows()
+		require.Equal(t, 0, testKit.Session().GetSessionVars().RewritePhaseInfo.PreprocessSubQueries)
+		var hasScalarSubQuery, hasSleepFunc bool
+		planRows := testdata.ConvertRowsToStrings(rows)
+		for _, row := range planRows {
+			hasScalarSubQuery = hasScalarSubQuery || strings.Contains(row, "ScalarSubQuery")
+			hasSleepFunc = hasSleepFunc || strings.Contains(row, "sleep(0.3)")
+		}
+		require.True(t, hasScalarSubQuery, "plan should keep the scalar subquery visible: %v", planRows)
+		require.True(t, hasSleepFunc, "plan should keep sleep(0.3) visible: %v", planRows)
 
 		cutExecutionInfoFromExplainAnalyzeOutput := func(rows [][]any) [][]any {
 			// The columns are id, estRows, actRows, task type, access object, execution info, operator info, memory, disk

--- a/pkg/planner/core/casetest/scalarsubquery/cases_test.go
+++ b/pkg/planner/core/casetest/scalarsubquery/cases_test.go
@@ -48,17 +48,42 @@ func TestExplainNonEvaledSubquery(t *testing.T) {
 		testKit.MustExec("create table t3(a varchar(5), b varchar(5), c varchar(5))")
 		testKit.MustQuery("select @@tidb_opt_enable_non_eval_scalar_subquery").Check(testkit.Rows("1"))
 
+		planContains := func(rows [][]any, substr string) (bool, []string) {
+			planRows := testdata.ConvertRowsToStrings(rows)
+			for _, row := range planRows {
+				if strings.Contains(row, substr) {
+					return true, planRows
+				}
+			}
+			return false, planRows
+		}
+		planContainsEvaluatedScalarColumn := func(rows [][]any) (bool, []string) {
+			planRows := testdata.ConvertRowsToStrings(rows)
+			for _, row := range planRows {
+				if strings.Contains(row, "ScalarQueryCol#") && strings.Contains(row, "(0)") {
+					return true, planRows
+				}
+			}
+			return false, planRows
+		}
+
 		testKit.Session().GetSessionVars().RewritePhaseInfo.Reset()
 		rows := testKit.MustQuery("explain format = 'plan_tree' select * from t1 where a = (select sleep(0.3))").Rows()
 		require.Equal(t, 0, testKit.Session().GetSessionVars().RewritePhaseInfo.PreprocessSubQueries)
-		var hasScalarSubQuery, hasSleepFunc bool
-		planRows := testdata.ConvertRowsToStrings(rows)
-		for _, row := range planRows {
-			hasScalarSubQuery = hasScalarSubQuery || strings.Contains(row, "ScalarSubQuery")
-			hasSleepFunc = hasSleepFunc || strings.Contains(row, "sleep(0.3)")
-		}
+		hasScalarSubQuery, planRows := planContains(rows, "ScalarSubQuery")
+		hasSleepFunc, _ := planContains(rows, "sleep(0.3)")
+		hasEvaluatedScalarColumn, _ := planContainsEvaluatedScalarColumn(rows)
 		require.True(t, hasScalarSubQuery, "plan should keep the scalar subquery visible: %v", planRows)
 		require.True(t, hasSleepFunc, "plan should keep sleep(0.3) visible: %v", planRows)
+		require.False(t, hasEvaluatedScalarColumn, "plan should not embed the evaluated scalar subquery result: %v", planRows)
+
+		testKit.MustExec("set @@tidb_opt_enable_non_eval_scalar_subquery=0")
+		testKit.Session().GetSessionVars().RewritePhaseInfo.Reset()
+		rows = testKit.MustQuery("explain format = 'plan_tree' select * from t1 where a = (select sleep(0.3))").Rows()
+		require.Greater(t, testKit.Session().GetSessionVars().RewritePhaseInfo.PreprocessSubQueries, 0)
+		hasEvaluatedScalarColumn, planRows = planContainsEvaluatedScalarColumn(rows)
+		require.True(t, hasEvaluatedScalarColumn, "plan should embed the evaluated scalar subquery result: %v", planRows)
+		testKit.MustExec("set @@tidb_opt_enable_non_eval_scalar_subquery=1")
 
 		cutExecutionInfoFromExplainAnalyzeOutput := func(rows [][]any) [][]any {
 			// The columns are id, estRows, actRows, task type, access object, execution info, operator info, memory, disk

--- a/pkg/planner/core/casetest/scalarsubquery/cases_test.go
+++ b/pkg/planner/core/casetest/scalarsubquery/cases_test.go
@@ -87,8 +87,9 @@ func TestExplainNonEvaledSubquery(t *testing.T) {
 		require.True(t, hasEvaluatedScalarColumn, "brief explain should keep the legacy scalar subquery evaluation behavior: %v", planRows)
 
 		rows = testKit.MustQuery(`explain format = 'brief' select 1 from brief_t1 where a = (select 1 from brief_t1 t join brief_t2 where b <= 1 and t.a)`).Rows()
-		hasOuterTableDual, planRows := planContains(rows, "TableDual")
-		require.True(t, hasOuterTableDual, "brief explain should keep the legacy outer TableDual shape: %v", planRows)
+		planRows = testdata.ConvertRowsToStrings(rows)
+		require.GreaterOrEqual(t, len(planRows), 2)
+		require.Contains(t, planRows[1], "TableDual", "brief explain should keep the legacy outer TableDual shape: %v", planRows)
 
 		testKit.MustExec("set @@tidb_opt_enable_non_eval_scalar_subquery=0")
 		testKit.Session().GetSessionVars().RewritePhaseInfo.Reset()

--- a/pkg/planner/core/casetest/scalarsubquery/cases_test.go
+++ b/pkg/planner/core/casetest/scalarsubquery/cases_test.go
@@ -46,6 +46,9 @@ func TestExplainNonEvaledSubquery(t *testing.T) {
 		testKit.MustExec("create table t1(a int, b int, c int)")
 		testKit.MustExec("create table t2(a int, b int, c int)")
 		testKit.MustExec("create table t3(a varchar(5), b varchar(5), c varchar(5))")
+		testKit.MustExec("create table brief_t1(a int)")
+		testKit.MustExec("create table brief_t2(b blob, key b(b(100)))")
+		testKit.MustExec("insert into brief_t2 values ('1'), ('2'), ('3')")
 		testKit.MustQuery("select @@tidb_opt_enable_non_eval_scalar_subquery").Check(testkit.Rows("1"))
 
 		planContains := func(rows [][]any, substr string) (bool, []string) {
@@ -76,6 +79,16 @@ func TestExplainNonEvaledSubquery(t *testing.T) {
 		require.True(t, hasScalarSubQuery, "plan should keep the scalar subquery visible: %v", planRows)
 		require.True(t, hasSleepFunc, "plan should keep sleep(0.3) visible: %v", planRows)
 		require.False(t, hasEvaluatedScalarColumn, "plan should not embed the evaluated scalar subquery result: %v", planRows)
+
+		testKit.Session().GetSessionVars().RewritePhaseInfo.Reset()
+		rows = testKit.MustQuery("explain format = 'brief' select * from t1 where a = (select sleep(0.3))").Rows()
+		require.Greater(t, testKit.Session().GetSessionVars().RewritePhaseInfo.PreprocessSubQueries, 0)
+		hasEvaluatedScalarColumn, planRows = planContainsEvaluatedScalarColumn(rows)
+		require.True(t, hasEvaluatedScalarColumn, "brief explain should keep the legacy scalar subquery evaluation behavior: %v", planRows)
+
+		rows = testKit.MustQuery(`explain format = 'brief' select 1 from brief_t1 where a = (select 1 from brief_t1 t join brief_t2 where b <= 1 and t.a)`).Rows()
+		hasOuterTableDual, planRows := planContains(rows, "TableDual")
+		require.True(t, hasOuterTableDual, "brief explain should keep the legacy outer TableDual shape: %v", planRows)
 
 		testKit.MustExec("set @@tidb_opt_enable_non_eval_scalar_subquery=0")
 		testKit.Session().GetSessionVars().RewritePhaseInfo.Reset()

--- a/pkg/planner/core/casetest/windows/testdata/window_push_down_suite_out.json
+++ b/pkg/planner/core/casetest/windows/testdata/window_push_down_suite_out.json
@@ -564,13 +564,14 @@
         "Plan": [
           "Projection root  Column",
           "└─Sort root  test.t2.c1, test.t2.c2",
-          "  └─Window root  count(1)->Column over(partition by Column)",
-          "    └─Projection root  0->Column, test.t2.c1, test.t2.c2",
-          "      └─TableReader root  data:TableFullScan",
-          "        └─TableFullScan cop[tikv] table:ref_0 keep order:false, stats:pseudo",
-          "ScalarSubQuery root  Output: ",
+          "  └─Projection root  case(<nil>, Column, 1)->Column, test.t2.c1, test.t2.c2",
+          "    └─Window root  count(1)->Column over(partition by Column)",
+          "      └─Projection root  0->Column, test.t2.c1, test.t2.c2",
+          "        └─TableReader root  data:TableFullScan",
+          "          └─TableFullScan cop[tikv] table:ref_0 keep order:false, stats:pseudo",
+          "ScalarSubQuery root  Output: ScalarQueryCol#6",
           "└─TableDual root  rows:1",
-          "ScalarSubQuery root  Output: ",
+          "ScalarSubQuery root  Output: ScalarQueryCol#10",
           "└─TableDual root  rows:1"
         ],
         "Result": [

--- a/pkg/planner/core/casetest/windows/testdata/window_push_down_suite_xut.json
+++ b/pkg/planner/core/casetest/windows/testdata/window_push_down_suite_xut.json
@@ -564,13 +564,14 @@
         "Plan": [
           "Projection root  Column",
           "└─Sort root  test.t2.c1, test.t2.c2",
-          "  └─Window root  count(1)->Column over(partition by Column)",
-          "    └─Projection root  0->Column, test.t2.c1, test.t2.c2",
-          "      └─TableReader root  data:TableFullScan",
-          "        └─TableFullScan cop[tikv] table:ref_0 keep order:false, stats:pseudo",
-          "ScalarSubQuery root  Output: ",
+          "  └─Projection root  case(<nil>, Column, 1)->Column, test.t2.c1, test.t2.c2",
+          "    └─Window root  count(1)->Column over(partition by Column)",
+          "      └─Projection root  0->Column, test.t2.c1, test.t2.c2",
+          "        └─TableReader root  data:TableFullScan",
+          "          └─TableFullScan cop[tikv] table:ref_0 keep order:false, stats:pseudo",
+          "ScalarSubQuery root  Output: ScalarQueryCol#6",
           "└─TableDual root  rows:1",
-          "ScalarSubQuery root  Output: ",
+          "ScalarSubQuery root  Output: ScalarQueryCol#10",
           "└─TableDual root  rows:1"
         ],
         "Result": [

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1208,8 +1208,8 @@ func (er *expressionRewriter) handleExistSubquery(ctx context.Context, planCtx *
 				scalarSubqueryColID: newColID,
 				evalCtx:             subqueryCtx,
 			}
-			scalarSubQ.RetType = np.Schema().Columns[0].GetType(er.sctx.GetEvalCtx())
-			scalarSubQ.SetCoercibility(np.Schema().Columns[0].Coercibility())
+			scalarSubQ.RetType = types.NewFieldType(mysql.TypeTiny)
+			scalarSubQ.SetCoercibility(expression.CoercibilityNumeric)
 			b.ctx.GetSessionVars().RegisterScalarSubQ(subqueryCtx)
 			if v.Not {
 				notWrapped, err := expression.NewFunction(b.ctx.GetExprCtx(), ast.UnaryNot, types.NewFieldType(mysql.TypeTiny), scalarSubQ)

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -54,6 +54,13 @@ import (
 // EvalSubqueryFirstRow evaluates incorrelated subqueries once, and get first row.
 var EvalSubqueryFirstRow func(ctx context.Context, p base.PhysicalPlan, is infoschema.InfoSchema, sctx base.PlanContext) (row []types.Datum, err error)
 
+func shouldExplainNonEvaledScalarSubQuery(vars *variable.SessionVars) bool {
+	return vars.StmtCtx.InExplainStmt &&
+		!vars.StmtCtx.InExplainAnalyzeStmt &&
+		vars.ExplainNonEvaledSubQuery &&
+		vars.StmtCtx.ExplainFormat != types.ExplainFormatBrief
+}
+
 // evalAstExprWithPlanCtx evaluates ast expression with plan context.
 // Different with expression.EvalSimpleAst, it uses planner context and is more powerful to build some special expressions
 // like subquery, window function, etc.
@@ -1196,7 +1203,7 @@ func (er *expressionRewriter) handleExistSubquery(ctx context.Context, planCtx *
 			er.err = err
 			return v, true
 		}
-		if b.ctx.GetSessionVars().StmtCtx.InExplainStmt && !b.ctx.GetSessionVars().StmtCtx.InExplainAnalyzeStmt && b.ctx.GetSessionVars().ExplainNonEvaledSubQuery {
+		if shouldExplainNonEvaledScalarSubQuery(b.ctx.GetSessionVars()) {
 			newColID := b.ctx.GetSessionVars().AllocPlanColumnID()
 			subqueryCtx := ScalarSubqueryEvalCtx{
 				scalarSubQuery: physicalPlan,
@@ -1559,7 +1566,7 @@ func (er *expressionRewriter) handleScalarSubquery(ctx context.Context, planCtx 
 		er.err = err
 		return v, true
 	}
-	if planCtx.builder.ctx.GetSessionVars().StmtCtx.InExplainStmt && !planCtx.builder.ctx.GetSessionVars().StmtCtx.InExplainAnalyzeStmt && planCtx.builder.ctx.GetSessionVars().ExplainNonEvaledSubQuery {
+	if shouldExplainNonEvaledScalarSubQuery(planCtx.builder.ctx.GetSessionVars()) {
 		subqueryCtx := ScalarSubqueryEvalCtx{
 			scalarSubQuery: physicalPlan,
 			ctx:            ctx,

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -477,12 +477,13 @@ GROUP BY field1;`).Check(testkit.Rows("HashJoin root  CARTESIAN left outer semi 
 			"├─HashAgg(Build) root  group by:Column, Column, funcs:firstrow(1)->Column",
 			"│ └─TableDual root  rows:0",
 			"└─HashAgg(Probe) root  group by:Column, funcs:firstrow(1)->Column",
-			"  └─HashJoin root  CARTESIAN left outer semi join, left side:TableReader",
+			"  └─HashJoin root  CARTESIAN left outer semi join, left side:Selection",
 			"    ├─HashAgg(Build) root  group by:Column, Column, funcs:firstrow(1)->Column",
 			"    │ └─TableDual root  rows:0",
-			"    └─TableReader(Probe) root  data:TableFullScan",
-			"      └─TableFullScan cop[tikv] table:table1 keep order:false, stats:pseudo",
-			"ScalarSubQuery root  Output: ScalarQueryCol#16, ScalarQueryCol#17, ScalarQueryCol#18, ScalarQueryCol#19",
+			"    └─Selection(Probe) root  or(ScalarQueryCol#16, ge(test.t1.b1, 55))",
+			"      └─TableReader root  data:TableFullScan",
+			"        └─TableFullScan cop[tikv] table:table1 keep order:false, stats:pseudo",
+			"ScalarSubQuery root  Output: ScalarQueryCol#16",
 			"└─TableReader root  data:TableFullScan",
 			"  └─TableFullScan cop[tikv] table:SUBQUERY2_t1 keep order:false, stats:pseudo"))
 		tk.MustQuery(`SELECT (4,5) IN (SELECT 8,0 UNION SELECT 8, 8) AS field1

--- a/pkg/planner/indexadvisor/optimizer.go
+++ b/pkg/planner/indexadvisor/optimizer.go
@@ -223,11 +223,13 @@ func (opt *optimizerImpl) QueryPlanCost(sql string, hypoIndexes ...Index) (cost 
 	}
 
 	originalFix43817 := opt.sctx.GetSessionVars().OptimizerFixControl[fixcontrol.Fix43817]
+	originalExplainNonEvaledSubQuery := opt.sctx.GetSessionVars().ExplainNonEvaledSubQuery
 	originalWarns := opt.sctx.GetSessionVars().StmtCtx.GetWarnings()
 	originalExtraWarns := opt.sctx.GetSessionVars().StmtCtx.GetExtraWarnings()
 	originalHypoIndexes := opt.sctx.GetSessionVars().HypoIndexes
 	defer func() {
 		opt.sctx.GetSessionVars().OptimizerFixControl[fixcontrol.Fix43817] = originalFix43817
+		opt.sctx.GetSessionVars().ExplainNonEvaledSubQuery = originalExplainNonEvaledSubQuery
 		opt.sctx.GetSessionVars().StmtCtx.SetWarnings(originalWarns)
 		opt.sctx.GetSessionVars().StmtCtx.SetExtraWarnings(originalExtraWarns)
 		opt.sctx.GetSessionVars().HypoIndexes = originalHypoIndexes
@@ -235,6 +237,8 @@ func (opt *optimizerImpl) QueryPlanCost(sql string, hypoIndexes ...Index) (cost 
 	}()
 	opt.sctx.GetSessionVars().OptimizerFixControl[fixcontrol.Fix43817] = "on"
 	opt.sctx.GetSessionVars().StmtCtx.InExplainStmt = true
+	// QueryPlanCost uses EXPLAIN mode only to obtain plan cost, so keep scalar subquery preprocessing behavior.
+	opt.sctx.GetSessionVars().ExplainNonEvaledSubQuery = false
 	opt.sctx.GetSessionVars().HypoIndexes = nil
 
 	if err := opt.addHypoIndex(hypoIndexes...); err != nil {

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1642,7 +1642,7 @@ const (
 	DefTiDBSkewDistinctAgg                            = false
 	DefTiDB3StageDistinctAgg                          = true
 	DefTiDB3StageMultiDistinctAgg                     = false
-	DefTiDBOptExplainEvaledSubquery                   = false
+	DefTiDBOptExplainEvaledSubquery                   = true
 	DefTiDBReadStaleness                              = 0
 	DefTiDBGCMaxWaitTime                              = 24 * 60 * 60
 	DefMaxAllowedPacket                        uint64 = config.DefMaxAllowedPacket

--- a/tests/integrationtest/r/executor/issues.result
+++ b/tests/integrationtest/r/executor/issues.result
@@ -823,8 +823,10 @@ CREATE TABLE `partsupp` (  `PS_PARTKEY` bigint(20) NOT NULL,`PS_SUPPKEY` bigint(
 CREATE TABLE `supplier` (`S_SUPPKEY` bigint(20) NOT NULL,`S_NAME` char(25) NOT NULL,`S_ADDRESS` varchar(40) NOT NULL,`S_NATIONKEY` bigint(20) NOT NULL,`S_PHONE` char(15) NOT NULL,`S_ACCTBAL` decimal(15,2) NOT NULL,`S_COMMENT` varchar(101) NOT NULL,PRIMARY KEY (`S_SUPPKEY`) /*T![clustered_index] CLUSTERED */) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 CREATE TABLE `nation` (`N_NATIONKEY` bigint(20) NOT NULL,`N_NAME` char(25) NOT NULL,`N_REGIONKEY` bigint(20) NOT NULL,`N_COMMENT` varchar(152) DEFAULT NULL,PRIMARY KEY (`N_NATIONKEY`) /*T![clustered_index] CLUSTERED */) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 set @@tidb_mem_quota_query=128;
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 0;
 explain select ps_partkey, sum(ps_supplycost * ps_availqty) as value from partsupp, supplier, nation where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'MOZAMBIQUE' group by ps_partkey having sum(ps_supplycost * ps_availqty) > ( select sum(ps_supplycost * ps_availqty) * 0.0001000000 from partsupp, supplier, nation where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'MOZAMBIQUE' ) order by value desc;
 Error 8175 (HY000): Your query has been cancelled due to exceeding the allowed memory limit for a single SQL query. Please try narrowing your query scope or increase the tidb_mem_quota_query limit and try again.[conn=<num>]
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 1;
 SET GLOBAL tidb_mem_oom_action = DEFAULT;
 set @@tidb_mem_quota_query=default;
 drop table if exists issue49369;

--- a/tests/integrationtest/r/expression/time.result
+++ b/tests/integrationtest/r/expression/time.result
@@ -100,6 +100,7 @@ dayname("1962-03-01")^7
 drop table if exists t;
 create table t (a bigint primary key, b timestamp);
 insert into t values (1, "2019-04-29 11:56:12");
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 0;
 explain format = 'plan_tree' select * from t where b = (select max(b) from t);
 id	task	access object	operator info
 TableReader	root		data:Selection
@@ -116,6 +117,7 @@ ScalarSubQuery	root		Output: ScalarQueryCol#8
 select * from t where b = (select max(b) from t);
 a	b
 1	2019-04-29 11:56:12
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 1;
 SELECT "1900-01-01 00:00:00" + INTERVAL 1.123456789e3 SECOND;
 "1900-01-01 00:00:00" + INTERVAL 1.123456789e3 SECOND
 1900-01-01 00:18:43.456789

--- a/tests/integrationtest/r/index_merge.result
+++ b/tests/integrationtest/r/index_merge.result
@@ -1,4 +1,5 @@
 ///// SUBQUERY
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 0;
 drop table if exists t1;
 create table t1(c1 int, c2 int, c3 int, key(c1), key(c2));
 insert into t1 values(1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 4), (5, 5, 5);
@@ -336,6 +337,7 @@ c1	c2	c3
 4	4	8
 5	5	10
 drop global binding for select * from t1 where c1 < 10 or c2 < 10 and c3 < 10 order by 1;
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 1;
 ///// CREATE TABLE/VIEW
 drop table if exists t1;
 create table t1(c1 int, c2 int, c3 int, key(c1), key(c2));

--- a/tests/integrationtest/r/planner/core/casetest/rule/rule_join_reorder.result
+++ b/tests/integrationtest/r/planner/core/casetest/rule/rule_join_reorder.result
@@ -4583,6 +4583,7 @@ create table t7(a int, b int, key(a));
 create table t8(a int, b int, key(a));
 insert into t3 values(1, 1), (2, 2), (3, 3);
 analyze table t3 all columns;
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 0;
 explain format='plan_tree' select /*+ straight_join() */ * from t1 join t2 on t1.a=t2.a where t1.a in (select t3.a from t3 where t1.b = t3.b);
 id	task	access object	operator info
 HashJoin	root		semi join, left side:HashJoin, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t3.b) eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t3.a)]
@@ -5944,6 +5945,7 @@ ScalarSubQuery	root		Output: ScalarQueryCol#18
 Level	Code	Message
 Warning	1815	There are no matching table names for (t2) in optimizer hint /*+ LEADING(t3, t2) */. Maybe you can use the table alias name
 Warning	1815	leading hint is inapplicable, check if the leading hint table is valid
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 1;
 drop table if exists t, t1, t2, t3, t4, t5, t6, t7, t8;
 create table t(a int, b int, key(a));
 create table t1(a int, b int, key(a));
@@ -6783,6 +6785,7 @@ Projection	root		planner__core__casetest__rule__rule_join_reorder.t.a, planner__
           └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
 Level	Code	Message
 Warning	1815	Optimizer Hint /*+ INL_JOIN(t1) */ or /*+ TIDB_INLJ(t1) */ is inapplicable
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 0;
 explain format='plan_tree' select /*+ leading(t4) */ * from t1 join t2 on t1.a=t2.a right join t4 on t1.b = t4.b where t1.a in (select t3.a from t3 where t1.b = t3.b);
 id	task	access object	operator info
 HashJoin	root		semi join, left side:Projection, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t3.b) eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t3.a)]
@@ -7478,6 +7481,7 @@ ScalarSubQuery	root		Output: ScalarQueryCol#18
 Level	Code	Message
 Warning	1815	There are no matching table names for (t2) in optimizer hint /*+ LEADING(t3, t2) */. Maybe you can use the table alias name
 Warning	1815	leading hint is inapplicable, check if the leading hint table is valid
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 1;
 drop table if exists t1, t2, t3, t4, t5;
 create table t1(a int, b int, key(a));
 create table t2(a int, b int, key(a));

--- a/tests/integrationtest/r/tpch.result
+++ b/tests/integrationtest/r/tpch.result
@@ -78,6 +78,7 @@ load stats 's/tpch_stats/customer.json';
 load stats 's/tpch_stats/orders.json';
 load stats 's/tpch_stats/lineitem.json';
 set @@session.tidb_opt_agg_push_down = 0;
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 0;
 /*
 Q1 Pricing Summary Report
 This query reports the amount of business that was billed, shipped, and returned.

--- a/tests/integrationtest/t/executor/issues.test
+++ b/tests/integrationtest/t/executor/issues.test
@@ -623,9 +623,11 @@ CREATE TABLE `partsupp` (  `PS_PARTKEY` bigint(20) NOT NULL,`PS_SUPPKEY` bigint(
 CREATE TABLE `supplier` (`S_SUPPKEY` bigint(20) NOT NULL,`S_NAME` char(25) NOT NULL,`S_ADDRESS` varchar(40) NOT NULL,`S_NATIONKEY` bigint(20) NOT NULL,`S_PHONE` char(15) NOT NULL,`S_ACCTBAL` decimal(15,2) NOT NULL,`S_COMMENT` varchar(101) NOT NULL,PRIMARY KEY (`S_SUPPKEY`) /*T![clustered_index] CLUSTERED */) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 CREATE TABLE `nation` (`N_NATIONKEY` bigint(20) NOT NULL,`N_NAME` char(25) NOT NULL,`N_REGIONKEY` bigint(20) NOT NULL,`N_COMMENT` varchar(152) DEFAULT NULL,PRIMARY KEY (`N_NATIONKEY`) /*T![clustered_index] CLUSTERED */) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 set @@tidb_mem_quota_query=128;
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 0;
 -- replace_regex /conn=[-0-9]+/conn=<num>/
 -- error 8175
 explain select ps_partkey, sum(ps_supplycost * ps_availqty) as value from partsupp, supplier, nation where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'MOZAMBIQUE' group by ps_partkey having sum(ps_supplycost * ps_availqty) > ( select sum(ps_supplycost * ps_availqty) * 0.0001000000 from partsupp, supplier, nation where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'MOZAMBIQUE' ) order by value desc;
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 1;
 SET GLOBAL tidb_mem_oom_action = DEFAULT;
 set @@tidb_mem_quota_query=default;
 

--- a/tests/integrationtest/t/expression/time.test
+++ b/tests/integrationtest/t/expression/time.test
@@ -37,8 +37,10 @@ select dayname("1962-03-01")^7;
 drop table if exists t;
 create table t (a bigint primary key, b timestamp);
 insert into t values (1, "2019-04-29 11:56:12");
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 0;
 explain format = 'plan_tree' select * from t where b = (select max(b) from t);
 select * from t where b = (select max(b) from t);
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 1;
 
 # TestDateTimeAddReal
 SELECT "1900-01-01 00:00:00" + INTERVAL 1.123456789e3 SECOND;

--- a/tests/integrationtest/t/index_merge.test
+++ b/tests/integrationtest/t/index_merge.test
@@ -1,4 +1,5 @@
 --echo ///// SUBQUERY
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 0;
 drop table if exists t1;
 create table t1(c1 int, c2 int, c3 int, key(c1), key(c2));
 insert into t1 values(1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 4), (5, 5, 5);
@@ -75,6 +76,7 @@ using
 explain format = 'plan_tree' select * from t1 where c1 < 10 or c2 < 10 and c3 < 10 order by 1;
 select * from t1 where c1 < 10 or c2 < 10 and c3 < 10 order by 1;
 drop global binding for select * from t1 where c1 < 10 or c2 < 10 and c3 < 10 order by 1;
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 1;
 
 --echo ///// CREATE TABLE/VIEW
 drop table if exists t1;

--- a/tests/integrationtest/t/planner/core/casetest/rule/rule_join_reorder.test
+++ b/tests/integrationtest/t/planner/core/casetest/rule/rule_join_reorder.test
@@ -325,6 +325,7 @@ create table t8(a int, b int, key(a));
 insert into t3 values(1, 1), (2, 2), (3, 3);
 analyze table t3 all columns;
 --enable_warnings
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 0;
 explain format='plan_tree' select /*+ straight_join() */ * from t1 join t2 on t1.a=t2.a where t1.a in (select t3.a from t3 where t1.b = t3.b);
 explain format='plan_tree' select /*+ straight_join() */ * from t1 join t2 on t1.a=t2.a where t1.a not in (select t3.a from t3 where t1.b = t3.b);
 explain format='plan_tree' select /*+ straight_join() */ * from t1 join t2 on t1.a=t2.a where exists (select t3.a from t3 where t1.b = t3.b);
@@ -413,6 +414,7 @@ explain format='plan_tree' select /*+ leading(t2@sel_2, t1) */ t1.a, (select min
 explain format='plan_tree' select /*+ leading(t2@sel_2, t3) */ t1.a, (select min(t2.a) from t2) from t1 join t3 on t1.a = t3.a;
 explain format='plan_tree' select /*+ leading(t1, t2@sel_2) */ t1.a, (select min(t2.a) from t2) from t1 join t3 on t1.a = t3.a;
 explain format='plan_tree' select /*+ leading(t3, t2@sel_2) */ t1.a, (select min(t2.a) from t2) from t1 join t3 on t1.a = t3.a;
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 1;
 --disable_warnings
 
 # TestLeadingJoinHint4OuterJoin
@@ -469,6 +471,7 @@ explain format='plan_tree' select /*+ leading(t3) merge_join(t2) */ * from t rig
 explain format='plan_tree' select /*+ leading(t3) merge_join(t3) */ * from t right join t1 on t.a = t1.a join t2 on t1.b = t2.b join t3 on t2.b = t3.b ;
 explain format='plan_tree' select /*+ leading(t3) merge_join(t3) */ * from t left join t1 on t.a = t1.a left join t2 on t1.b = t2.b join t3 on t2.b = t3.b ;
 explain format='plan_tree' select /*+ leading(t2) INL_JOIN(t1) */ * from t join t1 on t.a = t1.a left join t2 on t1.b = t2.b join t3 on t2.b = t3.b ;
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 0;
 explain format='plan_tree' select /*+ leading(t4) */ * from t1 join t2 on t1.a=t2.a right join t4 on t1.b = t4.b where t1.a in (select t3.a from t3 where t1.b = t3.b);
 explain format='plan_tree' select /*+ leading(t3@sel_2) */ * from t1 left join t2 on t1.a=t2.a where t1.a in (select t3.a from t3 where t1.b = t3.b);
 explain format='plan_tree' select /*+ leading(t2, t3@sel_2) */ * from t1 right join t2 on t1.a=t2.a where t1.a in (select t3.a from t3 where t1.b = t3.b);
@@ -512,6 +515,7 @@ explain format='plan_tree' select /*+ leading(t1, t2@sel_2) */ t1.a, (select min
 explain format='plan_tree' select /*+ leading(t1, t3) */ t1.a, (select min(t2.a) from t2) from t1 join t3 on t1.a = t3.a;
 explain format='plan_tree' select /*+ leading(t2@sel_2, t1) */ t1.a, (select min(t2.a) from t2) from t1 left join t3 on t1.a = t3.a;
 explain format='plan_tree' select /*+ leading(t3, t2@sel_2) */ t1.a, (select min(t2.a) from t2) from t1 right join t3 on t1.a = t3.a;
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 1;
 --disable_warnings
 
 # TestLeadingJoinHint4DerivedTable

--- a/tests/integrationtest/t/tpch.test
+++ b/tests/integrationtest/t/tpch.test
@@ -88,6 +88,7 @@ load stats 's/tpch_stats/orders.json';
 load stats 's/tpch_stats/lineitem.json';
 
 set @@session.tidb_opt_agg_push_down = 0;
+set @@session.tidb_opt_enable_non_eval_scalar_subquery = 0;
 
 /*
     Q1 Pricing Summary Report


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66679

Problem Summary:

`EXPLAIN` can currently evaluate scalar subqueries before producing the plan unless `tidb_opt_enable_non_eval_scalar_subquery` is enabled explicitly. That can make `EXPLAIN` slow for heavy scalar subqueries, while the generated plan hides the subquery work that caused the delay.

### What changed and how does it work?

This PR enables `tidb_opt_enable_non_eval_scalar_subquery` by default.

With the default enabled, plain `EXPLAIN` keeps scalar subqueries visible in the displayed plan instead of pre-evaluating them during preprocessing. The regression test also checks that `EXPLAIN ... (select sleep(0.3))` does not increase `RewritePhaseInfo.PreprocessSubQueries`, while both `ScalarSubQuery` and `sleep(0.3)` remain visible in the plan.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```sh
go test -tags=intest,deadlock ./pkg/planner/core/casetest/scalarsubquery -run '^TestExplainNonEvaledSubquery$' -count=1
go test -tags=intest,deadlock ./pkg/planner/indexadvisor -run '^TestIndexAdvisorFixControl43817$' -count=1
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/rule -run '^TestCorrelate$' -count=1
go test -tags=intest,deadlock ./pkg/sessionctx/vardef -count=1
go test -tags=intest,deadlock ./pkg/sessionctx/variable/tests -run '^TestDefaultValuesAreSettable$' -count=1
(cd tests/integrationtest && ./run-tests.sh -r tpch)
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/windows -run '^TestWindowSubqueryOuterRef$' -count=1
go test -tags=intest,deadlock ./pkg/planner/core/casetest/logicalplan -run '^TestGroupBySchema$' -count=1
(cd tests/integrationtest && ./run-tests.sh -r expression/time)
make server SERVER_OUT=tests/integrationtest/integrationtest_tidb-server-norace
(cd tests/integrationtest && ./run-tests.sh -s ./integrationtest_tidb-server-norace -r index_merge)
(cd tests/integrationtest && ./run-tests.sh -s ./integrationtest_tidb-server-norace -r executor/issues)
(cd tests/integrationtest && ./run-tests.sh -s ./integrationtest_tidb-server-norace -r planner/core/casetest/rule/rule_join_reorder)
./tools/check/failpoint-go-test.sh pkg/planner/core/issuetest -run '^TestPlannerIssueRegressions$' -count=1
git diff --check
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Enable EXPLAIN to show scalar subquery plans without evaluating those subqueries by default.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * EXPLAIN output no longer embeds evaluated scalar-subquery results when showing non-evaluated plans, preserving clearer plan structure.

* **Behavior**
  * Default EXPLAIN/display behavior changed to present scalar subqueries in their non-evaluated form by default for more consistent plan trees.

* **Tests**
  * Many tests and golden outputs updated to toggle the session EXPLAIN mode and match revised EXPLAIN formatting and counters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
