### PR TITLE
[DNM] for test async prepare in importinto

### DIFF
--- a/pkg/dxf/framework/integrationtests/framework_test.go
+++ b/pkg/dxf/framework/integrationtests/framework_test.go
@@ -29,6 +29,7 @@ import (
 	mockexecute "github.com/pingcap/tidb/pkg/dxf/framework/mock/execute"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/scheduler"
+	mockDispatch "github.com/pingcap/tidb/pkg/dxf/framework/scheduler/mock"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor"
 	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/execute"
@@ -341,30 +342,152 @@ func TestDXFAlwaysEnabledOnNextGen(t *testing.T) {
 }
 
 func TestMaxRuntimeSlots(t *testing.T) {
-	c := testutil.NewTestDXFContext(t, 1, 16, true)
+	t.Run("limit-runtime-slots-in-target-steps", func(t *testing.T) {
+		c := testutil.NewTestDXFContext(t, 1, 16, true)
 
-	registerExampleTask(t, c.MockCtrl, testutil.GetMockBasicSchedulerExt(c.MockCtrl), c.TestContext, nil)
+		registerExampleTask(t, c.MockCtrl, testutil.GetMockBasicSchedulerExt(c.MockCtrl), c.TestContext, nil)
 
-	var callCount atomic.Int32
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/beforeSetFrameworkInfo", func(rc *proto.StepResource) {
-		val := callCount.Add(1)
-		if val == 1 {
-			require.Equal(t, 12, int(rc.CPU.Capacity()))
-		} else {
-			require.Equal(t, 16, int(rc.CPU.Capacity()))
-		}
+		var callCount atomic.Int32
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/beforeSetFrameworkInfo", func(rc *proto.StepResource) {
+			val := callCount.Add(1)
+			if val == 1 {
+				require.Equal(t, 12, int(rc.CPU.Capacity()))
+			} else {
+				require.Equal(t, 16, int(rc.CPU.Capacity()))
+			}
+		})
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/dxf/framework/storage/beforeSubmitTask",
+			func(requiredSlots *int, params *proto.ExtraParams) {
+				params.MaxRuntimeSlots = 12
+				params.TargetSteps = []proto.Step{proto.StepOne}
+			},
+		)
+		scope := handle.GetTargetScope()
+		cpuCount, err := c.TaskMgr.GetCPUCountOfNode(c.Ctx)
+		require.NoError(t, err)
+		require.Equal(t, 16, cpuCount)
+		task := testutil.SubmitAndWaitTask(c.Ctx, t, "key1", scope, 16)
+		require.Equal(t, proto.TaskStateSucceed, task.State)
+		require.EqualValues(t, 2, callCount.Load())
 	})
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/dxf/framework/storage/beforeSubmitTask",
-		func(requiredSlots *int, params *proto.ExtraParams) {
-			params.MaxRuntimeSlots = 12
-			params.TargetSteps = []proto.Step{proto.StepOne}
-		},
-	)
-	scope := handle.GetTargetScope()
-	cpuCount, err := c.TaskMgr.GetCPUCountOfNode(c.Ctx)
-	require.NoError(t, err)
-	require.Equal(t, 16, cpuCount)
-	task := testutil.SubmitAndWaitTask(c.Ctx, t, "key1", scope, 16)
-	require.Equal(t, proto.TaskStateSucceed, task.State)
-	require.EqualValues(t, 2, callCount.Load())
+
+	t.Run("prepare-mode-required-propagates-onprepare-updates", func(t *testing.T) {
+		c := testutil.NewTestDXFContext(t, 1, 16, true)
+		const (
+			prepareMeta     = `{"prepare":"done"}`
+			prepareSlots    = 7
+			prepareNodeCap  = 1
+			initialTaskMeta = `{"prepare":"init"}`
+		)
+		var onPrepareCalled atomic.Int32
+		var stepOneTaskSeen atomic.Int32
+
+		stepTransition := map[proto.Step]proto.Step{
+			proto.StepInit: proto.StepOne,
+			proto.StepOne:  proto.StepDone,
+		}
+		schedulerExt := mockDispatch.NewMockExtension(c.MockCtrl)
+		schedulerExt.EXPECT().OnTick(gomock.Any(), gomock.Any()).Return().AnyTimes()
+		schedulerExt.EXPECT().GetEligibleInstances(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		schedulerExt.EXPECT().IsRetryableErr(gomock.Any()).Return(false).AnyTimes()
+		schedulerExt.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
+			func(task *proto.TaskBase) proto.Step {
+				nextStep, ok := stepTransition[task.Step]
+				require.True(t, ok, "unexpected step: %s", task.Step)
+				return nextStep
+			},
+		).AnyTimes()
+		schedulerExt.EXPECT().OnPrepare(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ storage.TaskHandle, task *proto.Task) error {
+				onPrepareCalled.Add(1)
+				task.Meta = []byte(prepareMeta)
+				task.RequiredSlots = prepareSlots
+				task.MaxNodeCount = prepareNodeCap
+				return nil
+			}).Times(1)
+		schedulerExt.EXPECT().OnNextSubtasksBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ storage.TaskHandle, task *proto.Task, _ []string, nextStep proto.Step) ([][]byte, error) {
+				require.Equal(t, proto.StepOne, nextStep)
+				require.Equal(t, proto.StepPrepared, task.Step)
+				require.Equal(t, []byte(prepareMeta), task.Meta)
+				require.Equal(t, prepareSlots, task.RequiredSlots)
+				require.Equal(t, prepareNodeCap, task.MaxNodeCount)
+				return [][]byte{[]byte("step-one-subtask")}, nil
+			}).Times(1)
+		schedulerExt.EXPECT().OnDone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+		executorExt := testutil.GetCommonTaskExecutorExt(c.MockCtrl, func(task *proto.Task) (execute.StepExecutor, error) {
+			if task.Step == proto.StepOne {
+				stepOneTaskSeen.Add(1)
+				require.Equal(t, []byte(prepareMeta), task.Meta)
+				require.Equal(t, prepareSlots, task.RequiredSlots)
+				require.Equal(t, prepareNodeCap, task.MaxNodeCount)
+			}
+			return testutil.GetCommonStepExecutor(c.MockCtrl, task.Step, func(_ context.Context, subtask *proto.Subtask) error {
+				require.Equal(t, proto.StepOne, subtask.Step)
+				return nil
+			}), nil
+		})
+		testutil.RegisterExampleTask(t, schedulerExt, executorExt, testutil.GetCommonCleanUpRoutine(c.MockCtrl))
+
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/dxf/framework/storage/beforeSubmitTask",
+			func(_ *int, params *proto.ExtraParams) {
+				params.PrepareMode = proto.PrepareModeRequired
+			},
+		)
+		scope := handle.GetTargetScope()
+		task, err := handle.SubmitTask(c.Ctx, "prepare-mode-required", proto.TaskTypeExample, c.Store.GetKeyspace(), 1, scope, 0, []byte(initialTaskMeta))
+		require.NoError(t, err)
+		doneTask := testutil.WaitTaskDone(c.Ctx, t, task.Key)
+		require.Equal(t, proto.TaskStateSucceed, doneTask.State)
+		require.EqualValues(t, 1, onPrepareCalled.Load())
+		require.EqualValues(t, 1, stepOneTaskSeen.Load())
+	})
+
+	t.Run("prepare-mode-disabled-keeps-backward-compatible-path", func(t *testing.T) {
+		c := testutil.NewTestDXFContext(t, 1, 16, true)
+		const initialTaskMeta = `{"prepare":"old-disabled"}`
+
+		stepTransition := map[proto.Step]proto.Step{
+			proto.StepInit: proto.StepOne,
+			proto.StepOne:  proto.StepDone,
+		}
+		schedulerExt := mockDispatch.NewMockExtension(c.MockCtrl)
+		schedulerExt.EXPECT().OnTick(gomock.Any(), gomock.Any()).Return().AnyTimes()
+		schedulerExt.EXPECT().GetEligibleInstances(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		schedulerExt.EXPECT().IsRetryableErr(gomock.Any()).Return(false).AnyTimes()
+		schedulerExt.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
+			func(task *proto.TaskBase) proto.Step {
+				nextStep, ok := stepTransition[task.Step]
+				require.True(t, ok, "unexpected step: %s", task.Step)
+				return nextStep
+			},
+		).AnyTimes()
+		schedulerExt.EXPECT().OnPrepare(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+		schedulerExt.EXPECT().OnNextSubtasksBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ storage.TaskHandle, task *proto.Task, _ []string, nextStep proto.Step) ([][]byte, error) {
+				require.Equal(t, proto.StepOne, nextStep)
+				require.Equal(t, proto.StepInit, task.Step)
+				require.Equal(t, []byte(initialTaskMeta), task.Meta)
+				return [][]byte{[]byte("step-one-subtask")}, nil
+			}).Times(1)
+		schedulerExt.EXPECT().OnDone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+		executorExt := testutil.GetCommonTaskExecutorExt(c.MockCtrl, func(task *proto.Task) (execute.StepExecutor, error) {
+			if task.Step == proto.StepOne {
+				require.Equal(t, []byte(initialTaskMeta), task.Meta)
+			}
+			return testutil.GetCommonStepExecutor(c.MockCtrl, task.Step, func(_ context.Context, subtask *proto.Subtask) error {
+				require.Equal(t, proto.StepOne, subtask.Step)
+				return nil
+			}), nil
+		})
+		testutil.RegisterExampleTask(t, schedulerExt, executorExt, testutil.GetCommonCleanUpRoutine(c.MockCtrl))
+
+		scope := handle.GetTargetScope()
+		task, err := handle.SubmitTask(c.Ctx, "prepare-mode-disabled", proto.TaskTypeExample, c.Store.GetKeyspace(), 1, scope, 0, []byte(initialTaskMeta))
+		require.NoError(t, err)
+		doneTask := testutil.WaitTaskDone(c.Ctx, t, task.Key)
+		require.Equal(t, proto.TaskStateSucceed, doneTask.State)
+	})
 }

--- a/pkg/dxf/framework/mock/scheduler_mock.go
+++ b/pkg/dxf/framework/mock/scheduler_mock.go
@@ -175,6 +175,20 @@ func (mr *MockSchedulerMockRecorder) OnNextSubtasksBatch(arg0, arg1, arg2, arg3,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNextSubtasksBatch", reflect.TypeOf((*MockScheduler)(nil).OnNextSubtasksBatch), arg0, arg1, arg2, arg3, arg4)
 }
 
+// OnPrepare mocks base method.
+func (m *MockScheduler) OnPrepare(arg0 context.Context, arg1 storage.TaskHandle, arg2 *proto.Task) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OnPrepare", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// OnPrepare indicates an expected call of OnPrepare.
+func (mr *MockSchedulerMockRecorder) OnPrepare(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPrepare", reflect.TypeOf((*MockScheduler)(nil).OnPrepare), arg0, arg1, arg2)
+}
+
 // OnTick mocks base method.
 func (m *MockScheduler) OnTick(arg0 context.Context, arg1 *proto.Task) {
 	m.ctrl.T.Helper()

--- a/pkg/dxf/framework/mock/scheduler_mock.go
+++ b/pkg/dxf/framework/mock/scheduler_mock.go
@@ -667,6 +667,21 @@ func (mr *MockTaskManagerMockRecorder) SucceedTask(arg0, arg1 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SucceedTask", reflect.TypeOf((*MockTaskManager)(nil).SucceedTask), arg0, arg1)
 }
 
+// SwitchTaskStepAfterPrepare mocks base method.
+func (m *MockTaskManager) SwitchTaskStepAfterPrepare(arg0 context.Context, arg1 *proto.Task) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SwitchTaskStepAfterPrepare", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SwitchTaskStepAfterPrepare indicates an expected call of SwitchTaskStepAfterPrepare.
+func (mr *MockTaskManagerMockRecorder) SwitchTaskStepAfterPrepare(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SwitchTaskStepAfterPrepare", reflect.TypeOf((*MockTaskManager)(nil).SwitchTaskStepAfterPrepare), arg0, arg1)
+}
+
 // SwitchTaskStep mocks base method.
 func (m *MockTaskManager) SwitchTaskStep(arg0 context.Context, arg1 *proto.Task, arg2 proto.TaskState, arg3 proto.Step, arg4 []*proto.Subtask) error {
 	m.ctrl.T.Helper()

--- a/pkg/dxf/framework/proto/step.go
+++ b/pkg/dxf/framework/proto/step.go
@@ -40,11 +40,12 @@ const (
 func Step2Str(t TaskType, s Step) string {
 	// StepInit, StepDone and StepPrepared are special steps, we don't check task
 	// type for them.
-	if s == StepInit {
+	switch s {
+	case StepInit:
 		return "init"
-	} else if s == StepDone {
+	case StepDone:
 		return "done"
-	} else if s == StepPrepared {
+	case StepPrepared:
 		return "prepared"
 	}
 	switch t {

--- a/pkg/dxf/framework/proto/step.go
+++ b/pkg/dxf/framework/proto/step.go
@@ -28,6 +28,9 @@ type Step int64
 const (
 	StepInit Step = -1
 	StepDone Step = -2
+	// StepPrepared marks that framework prepare logic has finished while task
+	// state is still pending.
+	StepPrepared Step = -3
 
 	unknownStepPrefix = "unknown step"
 )
@@ -35,11 +38,14 @@ const (
 // Step2Str converts step to string.
 // it's too bad that we define step as int 🙃.
 func Step2Str(t TaskType, s Step) string {
-	// StepInit and StepDone are special steps, we don't check task type for them.
+	// StepInit, StepDone and StepPrepared are special steps, we don't check task
+	// type for them.
 	if s == StepInit {
 		return "init"
 	} else if s == StepDone {
 		return "done"
+	} else if s == StepPrepared {
+		return "prepared"
 	}
 	switch t {
 	case Backfill:
@@ -187,4 +193,15 @@ func backfillStep2Str(s Step) string {
 
 func unknownStepStr(s Step) string {
 	return fmt.Sprintf("%s %d", unknownStepPrefix, s)
+}
+
+// FrameworkStep2BusinessStep converts framework-only marker steps to the
+// business-step view used by scheduler next-step resolution.
+// StepPrepared means "prepare finished", so it should continue business-step
+// progression from StepInit.
+func FrameworkStep2BusinessStep(s Step) Step {
+	if s == StepPrepared {
+		return StepInit
+	}
+	return s
 }

--- a/pkg/dxf/framework/proto/step_test.go
+++ b/pkg/dxf/framework/proto/step_test.go
@@ -26,6 +26,7 @@ func TestStep(t *testing.T) {
 	require.Equal(t, "read-index", Step2Str(Backfill, BackfillStepReadIndex))
 	require.Equal(t, "merge-sort", Step2Str(Backfill, BackfillStepMergeSort))
 	require.Equal(t, "ingest", Step2Str(Backfill, BackfillStepWriteAndIngest))
+	require.Equal(t, "prepared", Step2Str(Backfill, StepPrepared))
 	require.Equal(t, "done", Step2Str(Backfill, StepDone))
 	require.Equal(t, "unknown step 111", Step2Str(Backfill, 111))
 
@@ -38,6 +39,7 @@ func TestStep(t *testing.T) {
 	require.Equal(t, "ingest", Step2Str(ImportInto, ImportStepWriteAndIngest))
 	require.Equal(t, "collect-conflicts", Step2Str(ImportInto, ImportStepCollectConflicts))
 	require.Equal(t, "conflict-resolution", Step2Str(ImportInto, ImportStepConflictResolution))
+	require.Equal(t, "prepared", Step2Str(ImportInto, StepPrepared))
 	require.Equal(t, "done", Step2Str(ImportInto, StepDone))
 	require.Equal(t, "unknown step 123", Step2Str(ImportInto, 123))
 
@@ -45,16 +47,24 @@ func TestStep(t *testing.T) {
 	require.Equal(t, "init", Step2Str(TaskTypeExample, StepInit))
 	require.Equal(t, "one", Step2Str(TaskTypeExample, StepOne))
 	require.Equal(t, "two", Step2Str(TaskTypeExample, StepTwo))
+	require.Equal(t, "prepared", Step2Str(TaskTypeExample, StepPrepared))
 	require.Equal(t, "done", Step2Str(TaskTypeExample, StepDone))
 	require.Equal(t, "unknown step 333", Step2Str(TaskTypeExample, 333))
 
 	// unknown type
 	require.Equal(t, "unknown type 123", Step2Str(TaskType("123"), 123))
+
+	// framework -> business step mapping
+	require.Equal(t, StepInit, FrameworkStep2BusinessStep(StepPrepared))
+	require.Equal(t, StepInit, FrameworkStep2BusinessStep(StepInit))
+	require.Equal(t, StepDone, FrameworkStep2BusinessStep(StepDone))
+	require.Equal(t, StepOne, FrameworkStep2BusinessStep(StepOne))
 }
 
 func TestIsValidStep(t *testing.T) {
 	require.True(t, IsValidStep(Backfill, BackfillStepReadIndex))
 	require.False(t, IsValidStep(Backfill, 123))
+	require.True(t, IsValidStep(Backfill, StepPrepared))
 	require.True(t, IsValidStep(ImportInto, ImportStepWriteAndIngest))
 	require.False(t, IsValidStep(ImportInto, 456))
 }

--- a/pkg/dxf/framework/proto/task.go
+++ b/pkg/dxf/framework/proto/task.go
@@ -41,6 +41,15 @@ type (
 	TaskState string
 	// TaskType is the type of task.
 	TaskType string
+	// PrepareMode controls whether a task needs prepare-mode scheduling.
+	PrepareMode int
+)
+
+const (
+	// PrepareModeDisabled means prepare mode is disabled, this is the default.
+	PrepareModeDisabled PrepareMode = 0
+	// PrepareModeRequired means task scheduling must enter prepare mode.
+	PrepareModeRequired PrepareMode = 1
 )
 
 func (t TaskType) String() string {
@@ -91,6 +100,9 @@ type ExtraParams struct {
 	// normally OOM only happens in some specific steps, so we can just limit the
 	// concurrency in those steps to reduce the impact on the overall performance.
 	TargetSteps []Step `json:"target_steps,omitempty"`
+	// PrepareMode controls whether this task requires prepare-mode scheduling.
+	// default is PrepareModeDisabled for backward compatibility.
+	PrepareMode PrepareMode `json:"prepare_mode,omitempty"`
 }
 
 // TaskBase contains the basic information of a task.

--- a/pkg/dxf/framework/proto/task.go
+++ b/pkg/dxf/framework/proto/task.go
@@ -60,6 +60,17 @@ func (s TaskState) String() string {
 	return string(s)
 }
 
+func (m PrepareMode) String() string {
+	switch m {
+	case PrepareModeDisabled:
+		return "disabled"
+	case PrepareModeRequired:
+		return "required"
+	default:
+		return fmt.Sprintf("unknown(%d)", m)
+	}
+}
+
 // CanMoveToModifying checks if current state can move to 'modifying' state.
 func (s TaskState) CanMoveToModifying() bool {
 	return s == TaskStatePending || s == TaskStateRunning || s == TaskStatePaused

--- a/pkg/dxf/framework/proto/task_test.go
+++ b/pkg/dxf/framework/proto/task_test.go
@@ -15,6 +15,7 @@
 package proto
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -25,6 +26,29 @@ func TestTaskStep(t *testing.T) {
 	// make sure we don't change the value of StepInit accidentally
 	require.Equal(t, int64(-1), int64(StepInit))
 	require.Equal(t, int64(-2), int64(StepDone))
+	// make sure we don't change prepare mode constants accidentally.
+	require.Equal(t, 0, int(PrepareModeDisabled))
+	require.Equal(t, 1, int(PrepareModeRequired))
+
+	// default prepare mode should be omitted for backward-compatible json payload.
+	data, err := json.Marshal(ExtraParams{})
+	require.NoError(t, err)
+	require.JSONEq(t, `{}`, string(data))
+
+	// existing fields should keep old payload shape when prepare mode is default.
+	data, err = json.Marshal(ExtraParams{ManualRecovery: true})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"manual_recovery":true}`, string(data))
+
+	data, err = json.Marshal(ExtraParams{PrepareMode: PrepareModeRequired})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"prepare_mode":1}`, string(data))
+
+	var extraParams ExtraParams
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &extraParams))
+	require.Equal(t, PrepareModeDisabled, extraParams.PrepareMode)
+	require.NoError(t, json.Unmarshal([]byte(`{"prepare_mode":1}`), &extraParams))
+	require.Equal(t, PrepareModeRequired, extraParams.PrepareMode)
 }
 
 func TestTaskIsDone(t *testing.T) {

--- a/pkg/dxf/framework/proto/task_test.go
+++ b/pkg/dxf/framework/proto/task_test.go
@@ -29,6 +29,9 @@ func TestTaskStep(t *testing.T) {
 	// make sure we don't change prepare mode constants accidentally.
 	require.Equal(t, 0, int(PrepareModeDisabled))
 	require.Equal(t, 1, int(PrepareModeRequired))
+	require.Equal(t, "disabled", PrepareModeDisabled.String())
+	require.Equal(t, "required", PrepareModeRequired.String())
+	require.Equal(t, "unknown(123)", PrepareMode(123).String())
 
 	// default prepare mode should be omitted for backward-compatible json payload.
 	data, err := json.Marshal(ExtraParams{})

--- a/pkg/dxf/framework/scheduler/interface.go
+++ b/pkg/dxf/framework/scheduler/interface.go
@@ -156,6 +156,15 @@ type Extension interface {
 	ModifyMeta(oldMeta []byte, modifies []proto.Modification) ([]byte, error)
 }
 
+// PrepareExtension is an optional extension for tasks that require a framework
+// prepare phase before business-step subtask scheduling.
+type PrepareExtension interface {
+	// OnPrepare is called when task is in pending+init and prepare mode is
+	// required. The implementation may update task fields (for example task
+	// meta), and the framework will persist step transition afterwards.
+	OnPrepare(ctx context.Context, h storage.TaskHandle, task *proto.Task) error
+}
+
 // Param is used to pass parameters when creating scheduler.
 type Param struct {
 	taskMgr        TaskManager

--- a/pkg/dxf/framework/scheduler/interface.go
+++ b/pkg/dxf/framework/scheduler/interface.go
@@ -81,6 +81,11 @@ type TaskManager interface {
 	// And each subtask of this step must be different, to handle the network
 	// partition or owner change.
 	SwitchTaskStepInBatch(ctx context.Context, task *proto.Task, nextState proto.TaskState, nextStep proto.Step, subtasks []*proto.Subtask) error
+	// SwitchTaskStepAfterPrepare atomically persists prepare completion when task
+	// is still pending+init. It updates task to pending+prepared and persists
+	// prepare-computed fields.
+	// Return switched=false means the CAS matched zero rows (benign owner/state race).
+	SwitchTaskStepAfterPrepare(ctx context.Context, task *proto.Task) (switched bool, err error)
 	// GetUsedSlotsOnNodes returns the used slots on nodes that have subtask scheduled.
 	// subtasks of each task on one node is only accounted once as we don't support
 	// running them concurrently.

--- a/pkg/dxf/framework/scheduler/interface.go
+++ b/pkg/dxf/framework/scheduler/interface.go
@@ -153,21 +153,20 @@ type Extension interface {
 	// NOTE: don't depend on task meta to decide the next step, if it's really needed,
 	// initialize required fields on scheduler.Init
 	GetNextStep(task *proto.TaskBase) proto.Step
+	// OnPrepare is called when task is in pending+init and prepare mode is
+	// required.
+	// The implementation is allowed to update:
+	//   - task.Meta
+	//   - task.RequiredSlots
+	//   - task.MaxNodeCount
+	// and should not modify other task fields.
+	OnPrepare(ctx context.Context, h storage.TaskHandle, task *proto.Task) error
 	// ModifyMeta is used to modify the task meta when the task is in modifying
 	// state, it should return new meta after applying the modifications to the
 	// old meta.
 	// Note: the application side only need to modify meta, no need to do notify,
 	// task executor will do it later.
 	ModifyMeta(oldMeta []byte, modifies []proto.Modification) ([]byte, error)
-}
-
-// PrepareExtension is an optional extension for tasks that require a framework
-// prepare phase before business-step subtask scheduling.
-type PrepareExtension interface {
-	// OnPrepare is called when task is in pending+init and prepare mode is
-	// required. The implementation may update task fields (for example task
-	// meta), and the framework will persist step transition afterwards.
-	OnPrepare(ctx context.Context, h storage.TaskHandle, task *proto.Task) error
 }
 
 // Param is used to pass parameters when creating scheduler.

--- a/pkg/dxf/framework/scheduler/mock/scheduler_mock.go
+++ b/pkg/dxf/framework/scheduler/mock/scheduler_mock.go
@@ -133,6 +133,20 @@ func (mr *MockExtensionMockRecorder) OnNextSubtasksBatch(arg0, arg1, arg2, arg3,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNextSubtasksBatch", reflect.TypeOf((*MockExtension)(nil).OnNextSubtasksBatch), arg0, arg1, arg2, arg3, arg4)
 }
 
+// OnPrepare mocks base method.
+func (m *MockExtension) OnPrepare(arg0 context.Context, arg1 storage.TaskHandle, arg2 *proto.Task) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OnPrepare", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// OnPrepare indicates an expected call of OnPrepare.
+func (mr *MockExtensionMockRecorder) OnPrepare(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPrepare", reflect.TypeOf((*MockExtension)(nil).OnPrepare), arg0, arg1, arg2)
+}
+
 // OnTick mocks base method.
 func (m *MockExtension) OnTick(arg0 context.Context, arg1 *proto.Task) {
 	m.ctrl.T.Helper()

--- a/pkg/dxf/framework/scheduler/scheduler.go
+++ b/pkg/dxf/framework/scheduler/scheduler.go
@@ -151,14 +151,6 @@ func (s *BaseScheduler) GetTask() *proto.Task {
 	return s.task.Load()
 }
 
-// OnPrepare implements Extension with default delegation to Extension.
-func (s *BaseScheduler) OnPrepare(ctx context.Context, h storage.TaskHandle, task *proto.Task) error {
-	if s.Extension == nil || s.Extension == s {
-		return nil
-	}
-	return s.Extension.OnPrepare(ctx, h, task)
-}
-
 // getTaskClone returns a clone of the task.
 func (s *BaseScheduler) getTaskClone() *proto.Task {
 	clone := *s.GetTask()

--- a/pkg/dxf/framework/scheduler/scheduler.go
+++ b/pkg/dxf/framework/scheduler/scheduler.go
@@ -389,8 +389,12 @@ func (s *BaseScheduler) onPending() error {
 		if err := prepareExt.OnPrepare(s.ctx, s, task); err != nil {
 			return errors.Trace(err)
 		}
-		if err := s.taskMgr.SwitchTaskStep(s.ctx, task, proto.TaskStatePending, proto.StepPrepared, nil); err != nil {
+		switched, err := s.taskMgr.SwitchTaskStepAfterPrepare(s.ctx, task)
+		if err != nil {
 			return errors.Trace(err)
+		}
+		if !switched {
+			return s.refreshTaskIfNeeded()
 		}
 		task.Step = proto.StepPrepared
 		s.task.Store(task)

--- a/pkg/dxf/framework/scheduler/scheduler.go
+++ b/pkg/dxf/framework/scheduler/scheduler.go
@@ -132,14 +132,12 @@ func (s *BaseScheduler) Init() error {
 // ScheduleTask implements the Scheduler interface.
 func (s *BaseScheduler) ScheduleTask() {
 	task := s.GetTask()
-	logFields := []zap.Field{
+	s.logger.Info("schedule task",
 		zap.Stringer("state", task.State),
+		zap.String("step", proto.Step2Str(task.Type, task.Step)),
 		zap.Int("requiredSlots", task.RequiredSlots),
-	}
-	if task.Step == proto.StepInit || task.Step == proto.StepPrepared {
-		logFields = append(logFields, zap.Stringer("prepare-mode", task.ExtraParams.PrepareMode))
-	}
-	s.logger.Info("schedule task", logFields...)
+		zap.Stringer("prepare-mode", task.ExtraParams.PrepareMode),
+	)
 	s.scheduleTask()
 }
 
@@ -500,17 +498,12 @@ func (s *BaseScheduler) switch2NextStep() error {
 	taskBase4Next := task.TaskBase
 	taskBase4Next.Step = proto.FrameworkStep2BusinessStep(taskBase4Next.Step)
 	nextStep := s.GetNextStep(&taskBase4Next)
-	logFields := []zap.Field{
+	s.logger.Info("switch to next step",
 		zap.String("current-step", proto.Step2Str(task.Type, task.Step)),
 		zap.String("next-step", proto.Step2Str(task.Type, nextStep)),
 		zap.Int("required-slots", task.RequiredSlots),
 		zap.Int("runtime-slots", task.GetRuntimeSlots()),
-	}
-	if task.State == proto.TaskStatePending &&
-		(task.Step == proto.StepInit || task.Step == proto.StepPrepared) {
-		logFields = append(logFields, zap.Stringer("prepare-mode", task.ExtraParams.PrepareMode))
-	}
-	s.logger.Info("switch to next step", logFields...)
+	)
 
 	if nextStep == proto.StepDone {
 		if err := s.OnDone(s.ctx, s, task); err != nil {

--- a/pkg/dxf/framework/scheduler/scheduler.go
+++ b/pkg/dxf/framework/scheduler/scheduler.go
@@ -132,8 +132,14 @@ func (s *BaseScheduler) Init() error {
 // ScheduleTask implements the Scheduler interface.
 func (s *BaseScheduler) ScheduleTask() {
 	task := s.GetTask()
-	s.logger.Info("schedule task",
-		zap.Stringer("state", task.State), zap.Int("requiredSlots", task.RequiredSlots))
+	logFields := []zap.Field{
+		zap.Stringer("state", task.State),
+		zap.Int("requiredSlots", task.RequiredSlots),
+	}
+	if task.Step == proto.StepInit || task.Step == proto.StepPrepared {
+		logFields = append(logFields, zap.Stringer("prepare-mode", task.ExtraParams.PrepareMode))
+	}
+	s.logger.Info("schedule task", logFields...)
 	s.scheduleTask()
 }
 
@@ -145,6 +151,11 @@ func (s *BaseScheduler) Close() {
 // GetTask implements the Scheduler interface.
 func (s *BaseScheduler) GetTask() *proto.Task {
 	return s.task.Load()
+}
+
+// OnPrepare implements Extension with a no-op default.
+func (*BaseScheduler) OnPrepare(context.Context, storage.TaskHandle, *proto.Task) error {
+	return nil
 }
 
 // getTaskClone returns a clone of the task.
@@ -382,11 +393,7 @@ func (s *BaseScheduler) onPending() error {
 	s.logger.Debug("on pending state", zap.Stringer("state", task.State),
 		zap.String("step", proto.Step2Str(task.Type, task.Step)))
 	if task.Step == proto.StepInit && task.ExtraParams.PrepareMode == proto.PrepareModeRequired {
-		prepareExt, ok := s.Extension.(PrepareExtension)
-		if !ok {
-			return errors.New("prepare mode required but scheduler does not implement PrepareExtension")
-		}
-		if err := prepareExt.OnPrepare(s.ctx, s, task); err != nil {
+		if err := s.Extension.OnPrepare(s.ctx, s, task); err != nil {
 			return errors.Trace(err)
 		}
 		switched, err := s.taskMgr.SwitchTaskStepAfterPrepare(s.ctx, task)
@@ -394,7 +401,7 @@ func (s *BaseScheduler) onPending() error {
 			return errors.Trace(err)
 		}
 		if !switched {
-			return s.refreshTaskIfNeeded()
+			return nil
 		}
 		task.Step = proto.StepPrepared
 		s.task.Store(task)
@@ -493,12 +500,17 @@ func (s *BaseScheduler) switch2NextStep() error {
 	taskBase4Next := task.TaskBase
 	taskBase4Next.Step = proto.FrameworkStep2BusinessStep(taskBase4Next.Step)
 	nextStep := s.GetNextStep(&taskBase4Next)
-	s.logger.Info("switch to next step",
+	logFields := []zap.Field{
 		zap.String("current-step", proto.Step2Str(task.Type, task.Step)),
 		zap.String("next-step", proto.Step2Str(task.Type, nextStep)),
 		zap.Int("required-slots", task.RequiredSlots),
 		zap.Int("runtime-slots", task.GetRuntimeSlots()),
-	)
+	}
+	if task.State == proto.TaskStatePending &&
+		(task.Step == proto.StepInit || task.Step == proto.StepPrepared) {
+		logFields = append(logFields, zap.Stringer("prepare-mode", task.ExtraParams.PrepareMode))
+	}
+	s.logger.Info("switch to next step", logFields...)
 
 	if nextStep == proto.StepDone {
 		if err := s.OnDone(s.ctx, s, task); err != nil {

--- a/pkg/dxf/framework/scheduler/scheduler.go
+++ b/pkg/dxf/framework/scheduler/scheduler.go
@@ -151,9 +151,12 @@ func (s *BaseScheduler) GetTask() *proto.Task {
 	return s.task.Load()
 }
 
-// OnPrepare implements Extension with a no-op default.
-func (*BaseScheduler) OnPrepare(context.Context, storage.TaskHandle, *proto.Task) error {
-	return nil
+// OnPrepare implements Extension with default delegation to Extension.
+func (s *BaseScheduler) OnPrepare(ctx context.Context, h storage.TaskHandle, task *proto.Task) error {
+	if s.Extension == nil || s.Extension == s {
+		return nil
+	}
+	return s.Extension.OnPrepare(ctx, h, task)
 }
 
 // getTaskClone returns a clone of the task.
@@ -391,7 +394,7 @@ func (s *BaseScheduler) onPending() error {
 	s.logger.Debug("on pending state", zap.Stringer("state", task.State),
 		zap.String("step", proto.Step2Str(task.Type, task.Step)))
 	if task.Step == proto.StepInit && task.ExtraParams.PrepareMode == proto.PrepareModeRequired {
-		if err := s.Extension.OnPrepare(s.ctx, s, task); err != nil {
+		if err := s.OnPrepare(s.ctx, s, task); err != nil {
 			return errors.Trace(err)
 		}
 		switched, err := s.taskMgr.SwitchTaskStepAfterPrepare(s.ctx, task)

--- a/pkg/dxf/framework/scheduler/scheduler.go
+++ b/pkg/dxf/framework/scheduler/scheduler.go
@@ -378,9 +378,24 @@ func (s *BaseScheduler) onReverting() error {
 
 // handle task in pending state, schedule subtasks.
 func (s *BaseScheduler) onPending() error {
-	task := s.GetTask()
+	task := s.getTaskClone()
 	s.logger.Debug("on pending state", zap.Stringer("state", task.State),
 		zap.String("step", proto.Step2Str(task.Type, task.Step)))
+	if task.Step == proto.StepInit && task.ExtraParams.PrepareMode == proto.PrepareModeRequired {
+		prepareExt, ok := s.Extension.(PrepareExtension)
+		if !ok {
+			return errors.New("prepare mode required but scheduler does not implement PrepareExtension")
+		}
+		if err := prepareExt.OnPrepare(s.ctx, s, task); err != nil {
+			return errors.Trace(err)
+		}
+		if err := s.taskMgr.SwitchTaskStep(s.ctx, task, proto.TaskStatePending, proto.StepPrepared, nil); err != nil {
+			return errors.Trace(err)
+		}
+		task.Step = proto.StepPrepared
+		s.task.Store(task)
+		return nil
+	}
 	return s.switch2NextStep()
 }
 
@@ -471,7 +486,9 @@ func (s *BaseScheduler) onFinished() {
 
 func (s *BaseScheduler) switch2NextStep() error {
 	task := s.getTaskClone()
-	nextStep := s.GetNextStep(&task.TaskBase)
+	taskBase4Next := task.TaskBase
+	taskBase4Next.Step = proto.FrameworkStep2BusinessStep(taskBase4Next.Step)
+	nextStep := s.GetNextStep(&taskBase4Next)
 	s.logger.Info("switch to next step",
 		zap.String("current-step", proto.Step2Str(task.Type, task.Step)),
 		zap.String("next-step", proto.Step2Str(task.Type, nextStep)),

--- a/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
@@ -49,15 +49,6 @@ func createScheduler(task *proto.Task, allocatedSlots bool, taskMgr TaskManager,
 	return sch
 }
 
-type extensionWithPrepare struct {
-	Extension
-	onPrepare func(context.Context, storage.TaskHandle, *proto.Task) error
-}
-
-func (e *extensionWithPrepare) OnPrepare(ctx context.Context, h storage.TaskHandle, task *proto.Task) error {
-	return e.onPrepare(ctx, h, task)
-}
-
 func TestSchedulerOnNextStage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -495,46 +486,58 @@ func TestSchedulerMaintainTaskFields(t *testing.T) {
 		scheduler.task.Store(&taskWithPrepare)
 		scheduler.Extension = schExt
 
-		require.ErrorContains(t, scheduler.onPending(), "scheduler does not implement PrepareExtension")
+		schExt.EXPECT().OnPrepare(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("prepare err"))
+		require.ErrorContains(t, scheduler.onPending(), "prepare err")
 		require.Equal(t, taskWithPrepare, *scheduler.GetTask())
 		require.True(t, ctrl.Satisfied())
 
-		prepareExt := schmock.NewMockExtension(ctrl)
-		scheduler.Extension = &extensionWithPrepare{
-			Extension: prepareExt,
-			onPrepare: func(_ context.Context, _ storage.TaskHandle, inTask *proto.Task) error {
+		schExt.EXPECT().OnPrepare(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ storage.TaskHandle, inTask *proto.Task) error {
 				inTask.Meta = []byte(`{"prepare":"done"}`)
+				inTask.RequiredSlots = 8
+				inTask.MaxNodeCount = 6
 				return nil
-			},
-		}
+			})
 		taskMgr.EXPECT().SwitchTaskStepAfterPrepare(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, inTask *proto.Task) (bool, error) {
 				require.Equal(t, []byte(`{"prepare":"done"}`), inTask.Meta)
+				require.Equal(t, 8, inTask.RequiredSlots)
+				require.Equal(t, 6, inTask.MaxNodeCount)
 				return true, nil
 			})
 		require.NoError(t, scheduler.onPending())
 		taskWithPrepare.Step = proto.StepPrepared
 		taskWithPrepare.Meta = []byte(`{"prepare":"done"}`)
+		taskWithPrepare.RequiredSlots = 8
+		taskWithPrepare.MaxNodeCount = 6
 		require.Equal(t, taskWithPrepare, *scheduler.GetTask())
 		require.True(t, ctrl.Satisfied())
 
 		taskWithPrepare.Step = proto.StepInit
 		taskWithPrepare.Meta = []byte(`{"prepare":"init"}`)
+		taskWithPrepare.RequiredSlots = task.RequiredSlots
+		taskWithPrepare.MaxNodeCount = task.MaxNodeCount
 		scheduler.task.Store(&taskWithPrepare)
 		taskPreparedByOtherOwner := taskWithPrepare
 		taskPreparedByOtherOwner.Step = proto.StepPrepared
 		taskPreparedByOtherOwner.Meta = []byte(`{"prepare":"by-other-owner"}`)
+		schExt.EXPECT().OnPrepare(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ storage.TaskHandle, inTask *proto.Task) error {
+				inTask.Meta = []byte(`{"prepare":"done"}`)
+				inTask.RequiredSlots = 8
+				inTask.MaxNodeCount = 6
+				return nil
+			})
 		taskMgr.EXPECT().SwitchTaskStepAfterPrepare(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, inTask *proto.Task) (bool, error) {
 				require.Equal(t, []byte(`{"prepare":"done"}`), inTask.Meta)
+				require.Equal(t, 8, inTask.RequiredSlots)
+				require.Equal(t, 6, inTask.MaxNodeCount)
 				return false, nil
 			})
-		taskMgr.EXPECT().GetTaskBaseByID(gomock.Any(), taskWithPrepare.ID).Return(&taskPreparedByOtherOwner.TaskBase, nil)
-		taskMgr.EXPECT().GetTaskByID(gomock.Any(), taskWithPrepare.ID).Return(&taskPreparedByOtherOwner, nil)
 		require.NoError(t, scheduler.onPending())
-		require.Equal(t, taskPreparedByOtherOwner, *scheduler.GetTask())
+		require.Equal(t, taskWithPrepare, *scheduler.GetTask())
 		require.True(t, ctrl.Satisfied())
-		scheduler.Extension = schExt
 	})
 
 	t.Run("test StepPrepared mapping in next-step resolution", func(t *testing.T) {
@@ -551,13 +554,8 @@ func TestSchedulerMaintainTaskFields(t *testing.T) {
 		nextStepExt.EXPECT().GetEligibleInstances(gomock.Any(), gomock.Any()).Return([]string{":4000"}, nil)
 		nextStepExt.EXPECT().OnNextSubtasksBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil, nil)
-		scheduler.Extension = &extensionWithPrepare{
-			Extension: nextStepExt,
-			onPrepare: func(context.Context, storage.TaskHandle, *proto.Task) error {
-				t.Fatalf("prepare hook should not run for StepPrepared")
-				return nil
-			},
-		}
+		nextStepExt.EXPECT().OnPrepare(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+		scheduler.Extension = nextStepExt
 
 		taskMgr.EXPECT().GetUsedSlotsOnNodes(gomock.Any()).Return(nil, nil)
 		taskMgr.EXPECT().SwitchTaskStep(gomock.Any(), gomock.Any(), proto.TaskStateRunning, proto.StepOne, gomock.Any()).Return(nil)

--- a/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
@@ -507,16 +507,32 @@ func TestSchedulerMaintainTaskFields(t *testing.T) {
 				return nil
 			},
 		}
-		taskMgr.EXPECT().SwitchTaskStep(gomock.Any(), gomock.Any(), proto.TaskStatePending, proto.StepPrepared, gomock.Any()).
-			DoAndReturn(func(_ context.Context, inTask *proto.Task, _ proto.TaskState, _ proto.Step, subtasks []*proto.Subtask) error {
-				require.Empty(t, subtasks)
+		taskMgr.EXPECT().SwitchTaskStepAfterPrepare(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, inTask *proto.Task) (bool, error) {
 				require.Equal(t, []byte(`{"prepare":"done"}`), inTask.Meta)
-				return nil
+				return true, nil
 			})
 		require.NoError(t, scheduler.onPending())
 		taskWithPrepare.Step = proto.StepPrepared
 		taskWithPrepare.Meta = []byte(`{"prepare":"done"}`)
 		require.Equal(t, taskWithPrepare, *scheduler.GetTask())
+		require.True(t, ctrl.Satisfied())
+
+		taskWithPrepare.Step = proto.StepInit
+		taskWithPrepare.Meta = []byte(`{"prepare":"init"}`)
+		scheduler.task.Store(&taskWithPrepare)
+		taskPreparedByOtherOwner := taskWithPrepare
+		taskPreparedByOtherOwner.Step = proto.StepPrepared
+		taskPreparedByOtherOwner.Meta = []byte(`{"prepare":"by-other-owner"}`)
+		taskMgr.EXPECT().SwitchTaskStepAfterPrepare(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, inTask *proto.Task) (bool, error) {
+				require.Equal(t, []byte(`{"prepare":"done"}`), inTask.Meta)
+				return false, nil
+			})
+		taskMgr.EXPECT().GetTaskBaseByID(gomock.Any(), taskWithPrepare.ID).Return(&taskPreparedByOtherOwner.TaskBase, nil)
+		taskMgr.EXPECT().GetTaskByID(gomock.Any(), taskWithPrepare.ID).Return(&taskPreparedByOtherOwner, nil)
+		require.NoError(t, scheduler.onPending())
+		require.Equal(t, taskPreparedByOtherOwner, *scheduler.GetTask())
 		require.True(t, ctrl.Satisfied())
 		scheduler.Extension = schExt
 	})

--- a/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
@@ -49,6 +49,15 @@ func createScheduler(task *proto.Task, allocatedSlots bool, taskMgr TaskManager,
 	return sch
 }
 
+type extensionWithPrepare struct {
+	Extension
+	onPrepare func(context.Context, storage.TaskHandle, *proto.Task) error
+}
+
+func (e *extensionWithPrepare) OnPrepare(ctx context.Context, h storage.TaskHandle, task *proto.Task) error {
+	return e.onPrepare(ctx, h, task)
+}
+
 func TestSchedulerOnNextStage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -478,6 +487,70 @@ func TestSchedulerMaintainTaskFields(t *testing.T) {
 		tmpTask.State = proto.TaskStateSucceed
 		tmpTask.Step = proto.StepDone
 		require.Equal(t, *scheduler.getTaskClone(), tmpTask)
+	})
+
+	t.Run("test onPending prepare mode required", func(t *testing.T) {
+		taskWithPrepare := task
+		taskWithPrepare.ExtraParams.PrepareMode = proto.PrepareModeRequired
+		scheduler.task.Store(&taskWithPrepare)
+		scheduler.Extension = schExt
+
+		require.ErrorContains(t, scheduler.onPending(), "scheduler does not implement PrepareExtension")
+		require.Equal(t, taskWithPrepare, *scheduler.GetTask())
+		require.True(t, ctrl.Satisfied())
+
+		prepareExt := schmock.NewMockExtension(ctrl)
+		scheduler.Extension = &extensionWithPrepare{
+			Extension: prepareExt,
+			onPrepare: func(_ context.Context, _ storage.TaskHandle, inTask *proto.Task) error {
+				inTask.Meta = []byte(`{"prepare":"done"}`)
+				return nil
+			},
+		}
+		taskMgr.EXPECT().SwitchTaskStep(gomock.Any(), gomock.Any(), proto.TaskStatePending, proto.StepPrepared, gomock.Any()).
+			DoAndReturn(func(_ context.Context, inTask *proto.Task, _ proto.TaskState, _ proto.Step, subtasks []*proto.Subtask) error {
+				require.Empty(t, subtasks)
+				require.Equal(t, []byte(`{"prepare":"done"}`), inTask.Meta)
+				return nil
+			})
+		require.NoError(t, scheduler.onPending())
+		taskWithPrepare.Step = proto.StepPrepared
+		taskWithPrepare.Meta = []byte(`{"prepare":"done"}`)
+		require.Equal(t, taskWithPrepare, *scheduler.GetTask())
+		require.True(t, ctrl.Satisfied())
+		scheduler.Extension = schExt
+	})
+
+	t.Run("test StepPrepared mapping in next-step resolution", func(t *testing.T) {
+		taskWithPrepared := task
+		taskWithPrepared.Step = proto.StepPrepared
+		taskWithPrepared.ExtraParams.PrepareMode = proto.PrepareModeRequired
+		scheduler.task.Store(&taskWithPrepared)
+
+		nextStepExt := schmock.NewMockExtension(ctrl)
+		nextStepExt.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(func(base *proto.TaskBase) proto.Step {
+			require.Equal(t, proto.StepInit, base.Step)
+			return proto.StepOne
+		})
+		nextStepExt.EXPECT().GetEligibleInstances(gomock.Any(), gomock.Any()).Return([]string{":4000"}, nil)
+		nextStepExt.EXPECT().OnNextSubtasksBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, nil)
+		scheduler.Extension = &extensionWithPrepare{
+			Extension: nextStepExt,
+			onPrepare: func(context.Context, storage.TaskHandle, *proto.Task) error {
+				t.Fatalf("prepare hook should not run for StepPrepared")
+				return nil
+			},
+		}
+
+		taskMgr.EXPECT().GetUsedSlotsOnNodes(gomock.Any()).Return(nil, nil)
+		taskMgr.EXPECT().SwitchTaskStep(gomock.Any(), gomock.Any(), proto.TaskStateRunning, proto.StepOne, gomock.Any()).Return(nil)
+		require.NoError(t, scheduler.switch2NextStep())
+		taskWithPrepared.Step = proto.StepOne
+		taskWithPrepared.State = proto.TaskStateRunning
+		require.Equal(t, taskWithPrepared, *scheduler.GetTask())
+		require.True(t, ctrl.Satisfied())
+		scheduler.Extension = schExt
 	})
 
 	t.Run("test revertTask", func(t *testing.T) {

--- a/pkg/dxf/framework/storage/table_test.go
+++ b/pkg/dxf/framework/storage/table_test.go
@@ -338,10 +338,7 @@ func TestSwitchTaskStep(t *testing.T) {
 		require.Equal(t, []byte(`{"prepare":"done"}`), persistedTask.Meta)
 		require.Equal(t, 8, persistedTask.RequiredSlots)
 		require.Equal(t, 6, persistedTask.MaxNodeCount)
-		require.Equal(t, proto.ExtraParams{
-			ManualRecovery: true,
-			PrepareMode:    proto.PrepareModeRequired,
-		}, persistedTask.ExtraParams)
+		require.Equal(t, proto.ExtraParams{}, persistedTask.ExtraParams)
 		require.Zero(t, persistedTask.StartTime)
 		require.GreaterOrEqual(t, persistedTask.StateUpdateTime, switchTime)
 		tk.MustQuery(fmt.Sprintf("select count(1) from mysql.tidb_background_subtask where task_key = %d", prepareTaskID)).
@@ -362,10 +359,7 @@ func TestSwitchTaskStep(t *testing.T) {
 		require.Equal(t, []byte(`{"prepare":"done"}`), persistedTask.Meta)
 		require.Equal(t, 8, persistedTask.RequiredSlots)
 		require.Equal(t, 6, persistedTask.MaxNodeCount)
-		require.Equal(t, proto.ExtraParams{
-			ManualRecovery: true,
-			PrepareMode:    proto.PrepareModeRequired,
-		}, persistedTask.ExtraParams)
+		require.Equal(t, proto.ExtraParams{}, persistedTask.ExtraParams)
 	})
 }
 

--- a/pkg/dxf/framework/storage/table_test.go
+++ b/pkg/dxf/framework/storage/table_test.go
@@ -312,6 +312,61 @@ func TestSwitchTaskStep(t *testing.T) {
 	// start time should not change
 	require.Equal(t, taskStartTime, task.StartTime)
 	checkAfterSwitchStep(t, startTime, task, subtasksStepTwo, proto.StepTwo)
+
+	t.Run("prepare transition persists fields and exposes zero-row CAS", func(t *testing.T) {
+		prepareTaskID, err := tm.CreateTask(ctx, "prepare-key", "test", "", 1, "", 1, proto.ExtraParams{}, []byte("init-meta"))
+		require.NoError(t, err)
+		prepareTask, err := tm.GetTaskByID(ctx, prepareTaskID)
+		require.NoError(t, err)
+		checkTaskStateStep(t, prepareTask, proto.TaskStatePending, proto.StepInit)
+
+		prepareTask.Meta = []byte(`{"prepare":"done"}`)
+		prepareTask.RequiredSlots = 8
+		prepareTask.MaxNodeCount = 6
+		prepareTask.ExtraParams = proto.ExtraParams{
+			ManualRecovery: true,
+			PrepareMode:    proto.PrepareModeRequired,
+		}
+		switchTime := time.Unix(time.Now().Unix(), 0)
+		switched, err := tm.SwitchTaskStepAfterPrepare(ctx, prepareTask)
+		require.NoError(t, err)
+		require.True(t, switched)
+
+		persistedTask, err := tm.GetTaskByID(ctx, prepareTaskID)
+		require.NoError(t, err)
+		checkTaskStateStep(t, persistedTask, proto.TaskStatePending, proto.StepPrepared)
+		require.Equal(t, []byte(`{"prepare":"done"}`), persistedTask.Meta)
+		require.Equal(t, 8, persistedTask.RequiredSlots)
+		require.Equal(t, 6, persistedTask.MaxNodeCount)
+		require.Equal(t, proto.ExtraParams{
+			ManualRecovery: true,
+			PrepareMode:    proto.PrepareModeRequired,
+		}, persistedTask.ExtraParams)
+		require.Zero(t, persistedTask.StartTime)
+		require.GreaterOrEqual(t, persistedTask.StateUpdateTime, switchTime)
+		tk.MustQuery(fmt.Sprintf("select count(1) from mysql.tidb_background_subtask where task_key = %d", prepareTaskID)).
+			Check(testkit.Rows("0"))
+
+		prepareTask.Meta = []byte(`{"prepare":"stale-owner"}`)
+		prepareTask.RequiredSlots = 99
+		prepareTask.MaxNodeCount = 99
+		prepareTask.ExtraParams = proto.ExtraParams{
+			PrepareMode: proto.PrepareModeDisabled,
+		}
+		switched, err = tm.SwitchTaskStepAfterPrepare(ctx, prepareTask)
+		require.NoError(t, err)
+		require.False(t, switched)
+
+		persistedTask, err = tm.GetTaskByID(ctx, prepareTaskID)
+		require.NoError(t, err)
+		require.Equal(t, []byte(`{"prepare":"done"}`), persistedTask.Meta)
+		require.Equal(t, 8, persistedTask.RequiredSlots)
+		require.Equal(t, 6, persistedTask.MaxNodeCount)
+		require.Equal(t, proto.ExtraParams{
+			ManualRecovery: true,
+			PrepareMode:    proto.PrepareModeRequired,
+		}, persistedTask.ExtraParams)
+	})
 }
 
 func TestGetSubtaskSummaries(t *testing.T) {

--- a/pkg/dxf/framework/storage/task_table.go
+++ b/pkg/dxf/framework/storage/task_table.go
@@ -863,6 +863,38 @@ func (mgr *TaskManager) SwitchTaskStep(
 	})
 }
 
+// SwitchTaskStepAfterPrepare atomically persists prepare completion from
+// pending+init to pending+prepared.
+func (mgr *TaskManager) SwitchTaskStepAfterPrepare(ctx context.Context, task *proto.Task) (bool, error) {
+	if err := injectfailpoint.DXFRandomErrorWithOnePercent(); err != nil {
+		return false, err
+	}
+	extraParamsBytes, err := json.Marshal(task.ExtraParams)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	switched := false
+	err = mgr.WithNewTxn(ctx, func(se sessionctx.Context) error {
+		_, err = sqlexec.ExecSQL(ctx, se.GetSQLExecutor(), `
+			update mysql.tidb_global_task
+			set step = %?,
+				state_update_time = CURRENT_TIMESTAMP(),
+				meta = %?,
+				concurrency = %?,
+				max_node_count = %?,
+				extra_params = %?
+			where id = %? and state = %? and step = %?`,
+			proto.StepPrepared, task.Meta, task.RequiredSlots, task.MaxNodeCount, json.RawMessage(extraParamsBytes),
+			task.ID, proto.TaskStatePending, proto.StepInit)
+		if err != nil {
+			return err
+		}
+		switched = se.GetSessionVars().StmtCtx.AffectedRows() > 0
+		return nil
+	})
+	return switched, err
+}
+
 func (*TaskManager) updateTaskStateStep(ctx context.Context, se sessionctx.Context,
 	task *proto.Task, nextState proto.TaskState, nextStep proto.Step) error {
 	if err := injectfailpoint.DXFRandomErrorWithOnePercent(); err != nil {

--- a/pkg/dxf/framework/storage/task_table.go
+++ b/pkg/dxf/framework/storage/task_table.go
@@ -869,22 +869,17 @@ func (mgr *TaskManager) SwitchTaskStepAfterPrepare(ctx context.Context, task *pr
 	if err := injectfailpoint.DXFRandomErrorWithOnePercent(); err != nil {
 		return false, err
 	}
-	extraParamsBytes, err := json.Marshal(task.ExtraParams)
-	if err != nil {
-		return false, errors.Trace(err)
-	}
 	switched := false
-	err = mgr.WithNewTxn(ctx, func(se sessionctx.Context) error {
-		_, err = sqlexec.ExecSQL(ctx, se.GetSQLExecutor(), `
+	err := mgr.WithNewTxn(ctx, func(se sessionctx.Context) error {
+		_, err := sqlexec.ExecSQL(ctx, se.GetSQLExecutor(), `
 			update mysql.tidb_global_task
 			set step = %?,
 				state_update_time = CURRENT_TIMESTAMP(),
 				meta = %?,
 				concurrency = %?,
-				max_node_count = %?,
-				extra_params = %?
+				max_node_count = %?
 			where id = %? and state = %? and step = %?`,
-			proto.StepPrepared, task.Meta, task.RequiredSlots, task.MaxNodeCount, json.RawMessage(extraParamsBytes),
+			proto.StepPrepared, task.Meta, task.RequiredSlots, task.MaxNodeCount,
 			task.ID, proto.TaskStatePending, proto.StepInit)
 		if err != nil {
 			return err

--- a/pkg/dxf/importinto/job.go
+++ b/pkg/dxf/importinto/job.go
@@ -64,6 +64,12 @@ func SubmitTask(ctx context.Context, plan *importer.Plan, stmt string) (int64, *
 	return doSubmitTask(ctx, plan, stmt, nil, nil)
 }
 
+// ShouldUseScopedPrepareIntegration enables framework prepare integration only
+// for nextgen + global-sort path.
+func ShouldUseScopedPrepareIntegration(plan *importer.Plan) bool {
+	return plan != nil && kerneltype.IsNextGen() && plan.IsGlobalSort()
+}
+
 func doSubmitTask(ctx context.Context, plan *importer.Plan, stmt string, instance *serverinfo.ServerInfo, chunkMap map[int32][]importer.Chunk) (int64, *proto.TaskBase, error) {
 	var instances []*serverinfo.ServerInfo
 	if instance != nil {
@@ -87,6 +93,11 @@ func doSubmitTask(ctx context.Context, plan *importer.Plan, stmt string, instanc
 		TaskType:   proto.ImportInto,
 		ThreadCnt:  plan.ThreadCnt,
 		MaxNodeCnt: plan.MaxNodeCnt,
+	}
+	if ShouldUseScopedPrepareIntegration(plan) {
+		logicalPlan.PrepareMode = proto.PrepareModeRequired
+		planCtx.ThreadCnt = 1
+		planCtx.MaxNodeCnt = 1
 	}
 	var (
 		jobID, taskID int64

--- a/pkg/dxf/importinto/job.go
+++ b/pkg/dxf/importinto/job.go
@@ -64,9 +64,11 @@ func SubmitTask(ctx context.Context, plan *importer.Plan, stmt string) (int64, *
 	return doSubmitTask(ctx, plan, stmt, nil, nil)
 }
 
-// ShouldUseScopedPrepareIntegration enables framework prepare integration only
-// for nextgen + global-sort path.
-func ShouldUseScopedPrepareIntegration(plan *importer.Plan) bool {
+// ShouldUseAsyncPrepareForImportInto returns whether IMPORT INTO should use
+// DXF prepare-mode asynchronous prepare.
+// Nextgen only supports global sort for IMPORT INTO in production, but local
+// sort can still be exercised in tests, so keep the IsGlobalSort check.
+func ShouldUseAsyncPrepareForImportInto(plan *importer.Plan) bool {
 	return plan != nil && kerneltype.IsNextGen() && plan.IsGlobalSort()
 }
 
@@ -94,7 +96,7 @@ func doSubmitTask(ctx context.Context, plan *importer.Plan, stmt string, instanc
 		ThreadCnt:  plan.ThreadCnt,
 		MaxNodeCnt: plan.MaxNodeCnt,
 	}
-	if ShouldUseScopedPrepareIntegration(plan) {
+	if ShouldUseAsyncPrepareForImportInto(plan) {
 		logicalPlan.PrepareMode = proto.PrepareModeRequired
 		planCtx.ThreadCnt = 1
 		planCtx.MaxNodeCnt = 1

--- a/pkg/dxf/importinto/job.go
+++ b/pkg/dxf/importinto/job.go
@@ -64,11 +64,11 @@ func SubmitTask(ctx context.Context, plan *importer.Plan, stmt string) (int64, *
 	return doSubmitTask(ctx, plan, stmt, nil, nil)
 }
 
-// ShouldUseAsyncPrepareForImportInto returns whether IMPORT INTO should use
+// ShouldUseAsyncPrepare returns whether IMPORT INTO should use
 // DXF prepare-mode asynchronous prepare.
 // Nextgen only supports global sort for IMPORT INTO in production, but local
 // sort can still be exercised in tests, so keep the IsGlobalSort check.
-func ShouldUseAsyncPrepareForImportInto(plan *importer.Plan) bool {
+func ShouldUseAsyncPrepare(plan *importer.Plan) bool {
 	return plan != nil && kerneltype.IsNextGen() && plan.IsGlobalSort()
 }
 
@@ -96,7 +96,7 @@ func doSubmitTask(ctx context.Context, plan *importer.Plan, stmt string, instanc
 		ThreadCnt:  plan.ThreadCnt,
 		MaxNodeCnt: plan.MaxNodeCnt,
 	}
-	if ShouldUseAsyncPrepareForImportInto(plan) {
+	if ShouldUseAsyncPrepare(plan) {
 		logicalPlan.PrepareMode = proto.PrepareModeRequired
 		planCtx.ThreadCnt = 1
 		planCtx.MaxNodeCnt = 1

--- a/pkg/dxf/importinto/job_testkit_test.go
+++ b/pkg/dxf/importinto/job_testkit_test.go
@@ -166,6 +166,30 @@ func TestSubmitTaskNextgen(t *testing.T) {
 		sysKSTK.MustQuery("select count(1) from mysql.tidb_import_jobs where id = ?", jobID).Check(testkit.Rows("0"))
 		userKSTK.MustQuery("select count(1) from mysql.tidb_global_task where id = ?", task.ID).Check(testkit.Rows("0"))
 	})
+
+	t.Run("submit global-sort task uses scoped prepare integration", func(t *testing.T) {
+		sysKSTK.MustExec("delete from mysql.tidb_import_jobs")
+		sysKSTK.MustExec("delete from mysql.tidb_global_task")
+		config.UpdateGlobal(func(conf *config.Config) {
+			conf.KeyspaceName = keyspace.System
+		})
+		manuallyInitFn(t, sysKSStore, sysKSStore)
+
+		jobID, task, err := importinto.SubmitTask(ctx, &importer.Plan{
+			TableInfo:       &model.TableInfo{},
+			Parameters:      &importer.ImportParameters{},
+			ThreadCnt:       16,
+			MaxNodeCnt:      8,
+			CloudStorageURI: "local:///tmp/prepare-mode-sort",
+		}, "import into t from 's3://bucket/test.csv'")
+		require.NoError(t, err)
+		sysKSTK.MustQuery("select count(1) from mysql.tidb_import_jobs where id = ?", jobID).Check(testkit.Rows("1"))
+		sysKSTK.MustQuery(
+			"select concurrency, max_node_count, json_extract(extra_params, '$.prepare_mode') "+
+				"from mysql.tidb_global_task where id = ?",
+			task.ID,
+		).Check(testkit.Rows("1 1 1"))
+	})
 }
 
 func TestGetTaskImportedRows(t *testing.T) {

--- a/pkg/dxf/importinto/job_testkit_test.go
+++ b/pkg/dxf/importinto/job_testkit_test.go
@@ -167,7 +167,7 @@ func TestSubmitTaskNextgen(t *testing.T) {
 		userKSTK.MustQuery("select count(1) from mysql.tidb_global_task where id = ?", task.ID).Check(testkit.Rows("0"))
 	})
 
-	t.Run("submit global-sort task uses scoped prepare integration", func(t *testing.T) {
+	t.Run("submit global-sort task uses async prepare mode", func(t *testing.T) {
 		sysKSTK.MustExec("delete from mysql.tidb_import_jobs")
 		sysKSTK.MustExec("delete from mysql.tidb_global_task")
 		config.UpdateGlobal(func(conf *config.Config) {

--- a/pkg/dxf/importinto/planner.go
+++ b/pkg/dxf/importinto/planner.go
@@ -56,7 +56,11 @@ type LogicalPlan struct {
 	Stmt              string
 	EligibleInstances []*serverinfo.ServerInfo
 	ChunkMap          map[int32][]importer.Chunk
-	Logger            *zap.Logger
+	PrepareMode       proto.PrepareMode
+	// PreparedChunkMapExternalPath points to externally persisted chunk
+	// metadata produced during framework prepare stage.
+	PreparedChunkMapExternalPath string
+	Logger                       *zap.Logger
 
 	// summary for next step
 	summary importer.StepSummary
@@ -66,17 +70,19 @@ type LogicalPlan struct {
 func (p *LogicalPlan) GetTaskExtraParams() proto.ExtraParams {
 	return proto.ExtraParams{
 		ManualRecovery: p.Plan.ManualRecovery,
+		PrepareMode:    p.PrepareMode,
 	}
 }
 
 // ToTaskMeta converts the logical plan to task meta.
 func (p *LogicalPlan) ToTaskMeta() ([]byte, error) {
 	taskMeta := TaskMeta{
-		JobID:             p.JobID,
-		Plan:              p.Plan,
-		Stmt:              p.Stmt,
-		EligibleInstances: p.EligibleInstances,
-		ChunkMap:          p.ChunkMap,
+		JobID:                        p.JobID,
+		Plan:                         p.Plan,
+		Stmt:                         p.Stmt,
+		EligibleInstances:            p.EligibleInstances,
+		ChunkMap:                     p.ChunkMap,
+		PreparedChunkMapExternalPath: p.PreparedChunkMapExternalPath,
 	}
 	return json.Marshal(taskMeta)
 }
@@ -92,6 +98,7 @@ func (p *LogicalPlan) FromTaskMeta(bs []byte) error {
 	p.Stmt = taskMeta.Stmt
 	p.EligibleInstances = taskMeta.EligibleInstances
 	p.ChunkMap = taskMeta.ChunkMap
+	p.PreparedChunkMapExternalPath = taskMeta.PreparedChunkMapExternalPath
 	return nil
 }
 
@@ -362,7 +369,13 @@ func buildControllerForPlan(p *LogicalPlan) (*importer.LoadDataController, error
 
 func generateImportSpecs(pCtx planner.PlanCtx, p *LogicalPlan) ([]planner.PipelineSpec, error) {
 	var chunkMap map[int32][]importer.Chunk
-	if len(p.ChunkMap) > 0 {
+	if p.PreparedChunkMapExternalPath != "" {
+		var err error
+		chunkMap, err = readPreparedChunkMap(pCtx.Ctx, &p.Plan, p.PreparedChunkMapExternalPath)
+		if err != nil {
+			return nil, err
+		}
+	} else if len(p.ChunkMap) > 0 {
 		chunkMap = p.ChunkMap
 	} else {
 		controller, err2 := buildControllerForPlan(p)
@@ -400,6 +413,27 @@ func generateImportSpecs(pCtx planner.PlanCtx, p *LogicalPlan) ([]planner.Pipeli
 		importSpecs = append(importSpecs, importSpec)
 	}
 	return importSpecs, nil
+}
+
+func readPreparedChunkMap(
+	ctx context.Context,
+	plan *importer.Plan,
+	externalPath string,
+) (map[int32][]importer.Chunk, error) {
+	store, err := importer.GetSortStore(ctx, plan.CloudStorageURI)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	data, err := store.ReadFile(ctx, externalPath)
+	if err != nil {
+		return nil, err
+	}
+	var chunkMap map[int32][]importer.Chunk
+	if err := json.Unmarshal(data, &chunkMap); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return chunkMap, nil
 }
 
 func skipMergeSort(kvGroup string, stats []simplesst.MultipleFilesStat, concurrency int) bool {

--- a/pkg/dxf/importinto/planner.go
+++ b/pkg/dxf/importinto/planner.go
@@ -425,13 +425,10 @@ func readPreparedChunkMap(
 		return nil, err
 	}
 	defer store.Close()
-	data, err := store.ReadFile(ctx, externalPath)
-	if err != nil {
-		return nil, err
-	}
+	baseMeta := globalsort.BaseExternalMeta{ExternalPath: externalPath}
 	var chunkMap map[int32][]importer.Chunk
-	if err := json.Unmarshal(data, &chunkMap); err != nil {
-		return nil, errors.Trace(err)
+	if err := baseMeta.ReadJSONFromExternalStorage(ctx, store, &chunkMap); err != nil {
+		return nil, err
 	}
 	return chunkMap, nil
 }

--- a/pkg/dxf/importinto/planner.go
+++ b/pkg/dxf/importinto/planner.go
@@ -425,13 +425,10 @@ func readPreparedChunkMap(
 		return nil, err
 	}
 	defer store.Close()
-	data, err := store.ReadFile(ctx, externalPath)
-	if err != nil {
-		return nil, err
+	preparedChunkMapMeta := PreparedChunkMapMeta{
+		BaseExternalMeta: globalsort.BaseExternalMeta{ExternalPath: externalPath},
 	}
-
-	var preparedChunkMapMeta PreparedChunkMapMeta
-	if err := json.Unmarshal(data, &preparedChunkMapMeta); err != nil {
+	if err := preparedChunkMapMeta.ReadJSONFromExternalStorage(ctx, store, &preparedChunkMapMeta); err != nil {
 		return nil, err
 	}
 	if preparedChunkMapMeta.ChunkMap != nil {
@@ -441,7 +438,7 @@ func readPreparedChunkMap(
 	// Compatible with legacy format where the external file stored chunkMap
 	// directly as the top-level JSON object.
 	var legacyChunkMap map[int32][]importer.Chunk
-	if err := json.Unmarshal(data, &legacyChunkMap); err != nil {
+	if err := preparedChunkMapMeta.ReadJSONFromExternalStorage(ctx, store, &legacyChunkMap); err != nil {
 		return nil, err
 	}
 	return legacyChunkMap, nil

--- a/pkg/dxf/importinto/planner.go
+++ b/pkg/dxf/importinto/planner.go
@@ -425,12 +425,26 @@ func readPreparedChunkMap(
 		return nil, err
 	}
 	defer store.Close()
-	baseMeta := globalsort.BaseExternalMeta{ExternalPath: externalPath}
-	var chunkMap map[int32][]importer.Chunk
-	if err := baseMeta.ReadJSONFromExternalStorage(ctx, store, &chunkMap); err != nil {
+	data, err := store.ReadFile(ctx, externalPath)
+	if err != nil {
 		return nil, err
 	}
-	return chunkMap, nil
+
+	var preparedChunkMapMeta PreparedChunkMapMeta
+	if err := json.Unmarshal(data, &preparedChunkMapMeta); err != nil {
+		return nil, err
+	}
+	if preparedChunkMapMeta.ChunkMap != nil {
+		return preparedChunkMapMeta.ChunkMap, nil
+	}
+
+	// Compatible with legacy format where the external file stored chunkMap
+	// directly as the top-level JSON object.
+	var legacyChunkMap map[int32][]importer.Chunk
+	if err := json.Unmarshal(data, &legacyChunkMap); err != nil {
+		return nil, err
+	}
+	return legacyChunkMap, nil
 }
 
 func skipMergeSort(kvGroup string, stats []simplesst.MultipleFilesStat, concurrency int) bool {

--- a/pkg/dxf/importinto/planner_test.go
+++ b/pkg/dxf/importinto/planner_test.go
@@ -150,8 +150,10 @@ func TestToPhysicalPlan(t *testing.T) {
 		preparedChunkMap := map[int32][]importer.Chunk{
 			1: {{Path: "gs://test-load/2.csv"}},
 		}
-		externalPath := "100/prepare-chunk-map/mock-attempt/meta.json"
-		data, err := json.Marshal(preparedChunkMap)
+		externalPath := globalsort.PlanMetaPath(100, "prepare-chunk-map/mock-attempt", 1)
+		data, err := json.Marshal(PreparedChunkMapMeta{
+			ChunkMap: preparedChunkMap,
+		})
 		require.NoError(t, err)
 		require.NoError(t, store.WriteFile(context.Background(), externalPath, data))
 
@@ -170,6 +172,34 @@ func TestToPhysicalPlan(t *testing.T) {
 		require.Equal(t, int32(1), importSpec.ID)
 		require.Len(t, importSpec.Chunks, 1)
 		require.Equal(t, "gs://test-load/2.csv", importSpec.Chunks[0].Path)
+	})
+
+	t.Run("legacy prepared chunk map format is still readable", func(t *testing.T) {
+		cloudStorageURI := "local://" + filepath.ToSlash(t.TempDir())
+		store, err := importer.GetSortStore(context.Background(), cloudStorageURI)
+		require.NoError(t, err)
+		defer store.Close()
+
+		preparedChunkMap := map[int32][]importer.Chunk{
+			1: {{Path: "gs://test-load/legacy.csv"}},
+		}
+		externalPath := globalsort.PlanMetaPath(101, "prepare-chunk-map/mock-attempt", 1)
+		data, err := json.Marshal(preparedChunkMap)
+		require.NoError(t, err)
+		require.NoError(t, store.WriteFile(context.Background(), externalPath, data))
+
+		specs, err := generateImportSpecs(planner.PlanCtx{Ctx: context.Background()}, &LogicalPlan{
+			Plan: importer.Plan{
+				CloudStorageURI: cloudStorageURI,
+			},
+			PreparedChunkMapExternalPath: externalPath,
+		})
+		require.NoError(t, err)
+		require.Len(t, specs, 1)
+		importSpec := specs[0].(*ImportSpec)
+		require.Equal(t, int32(1), importSpec.ID)
+		require.Len(t, importSpec.Chunks, 1)
+		require.Equal(t, "gs://test-load/legacy.csv", importSpec.Chunks[0].Path)
 	})
 }
 

--- a/pkg/dxf/importinto/planner_test.go
+++ b/pkg/dxf/importinto/planner_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/pingcap/errors"
@@ -139,6 +140,37 @@ func TestToPhysicalPlan(t *testing.T) {
 	_, err = logicalPlan.ToPhysicalPlan(planCtx)
 	// error when build controller plan
 	require.ErrorContains(t, err, "provide a valid URI")
+
+	t.Run("prepared chunk map external path is preferred", func(t *testing.T) {
+		cloudStorageURI := "local://" + filepath.ToSlash(t.TempDir())
+		store, err := importer.GetSortStore(context.Background(), cloudStorageURI)
+		require.NoError(t, err)
+		defer store.Close()
+
+		preparedChunkMap := map[int32][]importer.Chunk{
+			1: {{Path: "gs://test-load/2.csv"}},
+		}
+		externalPath := "100/prepare-chunk-map/mock-attempt/meta.json"
+		data, err := json.Marshal(preparedChunkMap)
+		require.NoError(t, err)
+		require.NoError(t, store.WriteFile(context.Background(), externalPath, data))
+
+		specs, err := generateImportSpecs(planner.PlanCtx{Ctx: context.Background()}, &LogicalPlan{
+			Plan: importer.Plan{
+				CloudStorageURI: cloudStorageURI,
+			},
+			ChunkMap: map[int32][]importer.Chunk{
+				2: {{Path: "gs://test-load/ignored.csv"}},
+			},
+			PreparedChunkMapExternalPath: externalPath,
+		})
+		require.NoError(t, err)
+		require.Len(t, specs, 1)
+		importSpec := specs[0].(*ImportSpec)
+		require.Equal(t, int32(1), importSpec.ID)
+		require.Len(t, importSpec.Chunks, 1)
+		require.Equal(t, "gs://test-load/2.csv", importSpec.Chunks[0].Path)
+	})
 }
 
 func genEncodeStepMetas(t *testing.T, cnt int) [][]byte {

--- a/pkg/dxf/importinto/planner_test.go
+++ b/pkg/dxf/importinto/planner_test.go
@@ -150,12 +150,12 @@ func TestToPhysicalPlan(t *testing.T) {
 		preparedChunkMap := map[int32][]importer.Chunk{
 			1: {{Path: "gs://test-load/2.csv"}},
 		}
-		externalPath := globalsort.PlanMetaPath(100, "prepare-chunk-map/mock-attempt", 1)
-		data, err := json.Marshal(PreparedChunkMapMeta{
-			ChunkMap: preparedChunkMap,
-		})
-		require.NoError(t, err)
-		require.NoError(t, store.WriteFile(context.Background(), externalPath, data))
+		externalPath := globalsort.PreparedMetaPath(100)
+		preparedMeta := PreparedChunkMapMeta{
+			BaseExternalMeta: globalsort.BaseExternalMeta{ExternalPath: externalPath},
+			ChunkMap:         preparedChunkMap,
+		}
+		require.NoError(t, preparedMeta.WriteJSONToExternalStorage(context.Background(), store, preparedMeta))
 
 		specs, err := generateImportSpecs(planner.PlanCtx{Ctx: context.Background()}, &LogicalPlan{
 			Plan: importer.Plan{
@@ -183,7 +183,7 @@ func TestToPhysicalPlan(t *testing.T) {
 		preparedChunkMap := map[int32][]importer.Chunk{
 			1: {{Path: "gs://test-load/legacy.csv"}},
 		}
-		externalPath := globalsort.PlanMetaPath(101, "prepare-chunk-map/mock-attempt", 1)
+		externalPath := globalsort.PreparedMetaPath(101)
 		data, err := json.Marshal(preparedChunkMap)
 		require.NoError(t, err)
 		require.NoError(t, store.WriteFile(context.Background(), externalPath, data))

--- a/pkg/dxf/importinto/proto.go
+++ b/pkg/dxf/importinto/proto.go
@@ -62,7 +62,13 @@ type TaskMeta struct {
 // Keep this wrapper generic so future prepare-stage fields can be added without
 // changing the on-disk top-level JSON shape again.
 type PreparedChunkMapMeta struct {
-	ChunkMap map[int32][]importer.Chunk `json:"chunk_map,omitempty"`
+	globalsort.BaseExternalMeta
+	ChunkMap map[int32][]importer.Chunk `json:"chunk_map,omitempty" external:"true"`
+}
+
+// Marshal marshals the prepared chunk map meta to JSON.
+func (m *PreparedChunkMapMeta) Marshal() ([]byte, error) {
+	return m.BaseExternalMeta.Marshal(m)
 }
 
 // ImportStepMeta is the meta of import step.

--- a/pkg/dxf/importinto/proto.go
+++ b/pkg/dxf/importinto/proto.go
@@ -53,6 +53,9 @@ type TaskMeta struct {
 	// we use a map from engine ID to chunks since we need support split_file for CSV,
 	// so need to split them into engines before passing to scheduler.
 	ChunkMap map[int32][]importer.Chunk
+	// PreparedChunkMapExternalPath points to external chunk metadata prepared by
+	// framework OnPrepare for nextgen global-sort path.
+	PreparedChunkMapExternalPath string `json:"prepared_chunk_map_external_path,omitempty"`
 }
 
 // ImportStepMeta is the meta of import step.

--- a/pkg/dxf/importinto/proto.go
+++ b/pkg/dxf/importinto/proto.go
@@ -58,6 +58,13 @@ type TaskMeta struct {
 	PreparedChunkMapExternalPath string `json:"prepared_chunk_map_external_path,omitempty"`
 }
 
+// PreparedChunkMapMeta stores chunk-map metadata generated in prepare stage.
+// Keep this wrapper generic so future prepare-stage fields can be added without
+// changing the on-disk top-level JSON shape again.
+type PreparedChunkMapMeta struct {
+	ChunkMap map[int32][]importer.Chunk `json:"chunk_map,omitempty"`
+}
+
 // ImportStepMeta is the meta of import step.
 // Scheduler will split the task into subtasks(FileInfos -> Chunks)
 // All the field should be serializable.

--- a/pkg/dxf/importinto/scheduler.go
+++ b/pkg/dxf/importinto/scheduler.go
@@ -19,12 +19,10 @@ import (
 	"encoding/json"
 	goerrors "errors"
 	"fmt"
-	"path"
 	"strconv"
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/br/pkg/utils"
@@ -65,12 +63,10 @@ const (
 	// the target table, it's known to be slow to import in this case.
 	// the value if chosen as most tables have less than 32 indexes, we can adjust
 	// it later if needed.
-	warningIndexCount         = 32
-	registerTaskTTL           = 10 * time.Minute
-	refreshTaskTTLInterval    = 3 * time.Minute
-	registerTimeout           = 5 * time.Second
-	preparedChunkMapPathStep  = "prepare-chunk-map"
-	preparedChunkMapMetaIndex = 1
+	warningIndexCount      = 32
+	registerTaskTTL        = 10 * time.Minute
+	refreshTaskTTLInterval = 3 * time.Minute
+	registerTimeout        = 5 * time.Second
 )
 
 var (
@@ -304,18 +300,16 @@ func (sch *importScheduler) writePreparedChunkMap(
 		return "", err
 	}
 	defer store.Close()
-	externalPath := globalsort.PlanMetaPath(
-		taskID,
-		path.Join(preparedChunkMapPathStep, uuid.NewString()),
-		preparedChunkMapMetaIndex,
-	)
-	baseMeta := globalsort.BaseExternalMeta{ExternalPath: externalPath}
-	if err = baseMeta.WriteJSONToExternalStorage(ctx, store, PreparedChunkMapMeta{
+	preparedMeta := PreparedChunkMapMeta{
+		BaseExternalMeta: globalsort.BaseExternalMeta{
+			ExternalPath: globalsort.PreparedMetaPath(taskID),
+		},
 		ChunkMap: chunkMap,
-	}); err != nil {
+	}
+	if err = preparedMeta.WriteJSONToExternalStorage(ctx, store, preparedMeta); err != nil {
 		return "", err
 	}
-	return externalPath, nil
+	return preparedMeta.ExternalPath, nil
 }
 
 // OnPrepare implements scheduler.Extension.

--- a/pkg/dxf/importinto/scheduler.go
+++ b/pkg/dxf/importinto/scheduler.go
@@ -65,11 +65,12 @@ const (
 	// the target table, it's known to be slow to import in this case.
 	// the value if chosen as most tables have less than 32 indexes, we can adjust
 	// it later if needed.
-	warningIndexCount            = 32
-	registerTaskTTL              = 10 * time.Minute
-	refreshTaskTTLInterval       = 3 * time.Minute
-	registerTimeout              = 5 * time.Second
-	preparedChunkMetaPathPurpose = "prepare-chunk-map"
+	warningIndexCount         = 32
+	registerTaskTTL           = 10 * time.Minute
+	refreshTaskTTLInterval    = 3 * time.Minute
+	registerTimeout           = 5 * time.Second
+	preparedChunkMapPathStep  = "prepare-chunk-map"
+	preparedChunkMapMetaIndex = 1
 )
 
 var (
@@ -303,14 +304,15 @@ func (sch *importScheduler) writePreparedChunkMap(
 		return "", err
 	}
 	defer store.Close()
-	externalPath := path.Join(
-		strconv.FormatInt(taskID, 10),
-		preparedChunkMetaPathPurpose,
-		uuid.NewString(),
-		"meta.json",
+	externalPath := globalsort.PlanMetaPath(
+		taskID,
+		path.Join(preparedChunkMapPathStep, uuid.NewString()),
+		preparedChunkMapMetaIndex,
 	)
 	baseMeta := globalsort.BaseExternalMeta{ExternalPath: externalPath}
-	if err = baseMeta.WriteJSONToExternalStorage(ctx, store, chunkMap); err != nil {
+	if err = baseMeta.WriteJSONToExternalStorage(ctx, store, PreparedChunkMapMeta{
+		ChunkMap: chunkMap,
+	}); err != nil {
 		return "", err
 	}
 	return externalPath, nil
@@ -322,13 +324,8 @@ func (sch *importScheduler) OnPrepare(ctx context.Context, _ storage.TaskHandle,
 	if err := json.Unmarshal(task.Meta, taskMeta); err != nil {
 		return errors.Annotate(err, "unmarshal task meta failed")
 	}
-	if task.ExtraParams.PrepareMode == proto.PrepareModeRequired {
-		if err := sch.startJob(ctx, sch.GetLogger(), taskMeta, importer.JobStepPreparing); err != nil {
-			return err
-		}
-	}
-	if !ShouldUseAsyncPrepareForImportInto(&taskMeta.Plan) {
-		return nil
+	if err := sch.startJob(ctx, sch.GetLogger(), taskMeta, importer.JobStepPreparing); err != nil {
+		return err
 	}
 
 	logicalPlan := &LogicalPlan{

--- a/pkg/dxf/importinto/scheduler.go
+++ b/pkg/dxf/importinto/scheduler.go
@@ -803,7 +803,7 @@ func (sch *importScheduler) updatePreparedJobInfo(ctx context.Context, logger *z
 					exec,
 					taskMeta.JobID,
 					taskMeta.Plan.TotalFileSize,
-					taskMeta.Plan.Parameters,
+					taskMeta.Plan.Format,
 				)
 			})
 		},

--- a/pkg/dxf/importinto/scheduler.go
+++ b/pkg/dxf/importinto/scheduler.go
@@ -19,10 +19,12 @@ import (
 	"encoding/json"
 	goerrors "errors"
 	"fmt"
+	"path"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/br/pkg/utils"
@@ -62,10 +64,11 @@ const (
 	// the target table, it's known to be slow to import in this case.
 	// the value if chosen as most tables have less than 32 indexes, we can adjust
 	// it later if needed.
-	warningIndexCount      = 32
-	registerTaskTTL        = 10 * time.Minute
-	refreshTaskTTLInterval = 3 * time.Minute
-	registerTimeout        = 5 * time.Second
+	warningIndexCount            = 32
+	registerTaskTTL              = 10 * time.Minute
+	refreshTaskTTLInterval       = 3 * time.Minute
+	registerTimeout              = 5 * time.Second
+	preparedChunkMetaPathPurpose = "prepare-chunk-map"
 )
 
 var (
@@ -164,6 +167,7 @@ type importScheduler struct {
 }
 
 var _ scheduler.Extension = (*importScheduler)(nil)
+var _ scheduler.PrepareExtension = (*importScheduler)(nil)
 
 // NewImportScheduler creates a new import scheduler.
 func NewImportScheduler(
@@ -286,6 +290,114 @@ func (sch *importScheduler) checkImportTableEmpty(ctx context.Context, taskMeta 
 		}
 		return nil
 	})
+}
+
+func (sch *importScheduler) checkActiveImportJobs(ctx context.Context, taskMeta *TaskMeta) error {
+	taskManager, err := sch.getTaskMgrForAccessingImportJob()
+	if err != nil {
+		return err
+	}
+	return taskManager.WithNewSession(func(se sessionctx.Context) error {
+		exec := se.GetSQLExecutor()
+		activeCnt, err := importer.GetActiveJobCnt(ctx, exec, taskMeta.Plan.DBName, taskMeta.Plan.TableInfo.Name.L)
+		if err != nil {
+			return err
+		}
+		// The current prepare-enabled job is already in pending state, so we only
+		// fail when there are other active jobs on the same table.
+		if activeCnt > 1 {
+			return exeerrors.ErrLoadDataPreCheckFailed.FastGenByArgs("there is active job on the target table already")
+		}
+		return nil
+	})
+}
+
+func (sch *importScheduler) writePreparedChunkMap(
+	ctx context.Context,
+	taskID int64,
+	cloudStorageURI string,
+	chunkMap map[int32][]importer.Chunk,
+) (string, error) {
+	store, err := importer.GetSortStore(ctx, cloudStorageURI)
+	if err != nil {
+		return "", err
+	}
+	defer store.Close()
+	externalPath := path.Join(
+		strconv.FormatInt(taskID, 10),
+		preparedChunkMetaPathPurpose,
+		uuid.NewString(),
+		"meta.json",
+	)
+	data, err := json.Marshal(chunkMap)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if err = store.WriteFile(ctx, externalPath, data); err != nil {
+		return "", err
+	}
+	return externalPath, nil
+}
+
+// OnPrepare implements scheduler.PrepareExtension.
+func (sch *importScheduler) OnPrepare(ctx context.Context, _ storage.TaskHandle, task *proto.Task) error {
+	taskMeta := &TaskMeta{}
+	if err := json.Unmarshal(task.Meta, taskMeta); err != nil {
+		return errors.Annotate(err, "unmarshal task meta failed")
+	}
+	if !ShouldUseScopedPrepareIntegration(&taskMeta.Plan) {
+		return nil
+	}
+
+	logicalPlan := &LogicalPlan{
+		Plan:   taskMeta.Plan,
+		Stmt:   taskMeta.Stmt,
+		Logger: sch.GetLogger(),
+	}
+	controller, err := buildControllerForPlan(logicalPlan)
+	if err != nil {
+		return err
+	}
+	defer controller.Close()
+
+	if err = controller.InitDataFiles(ctx); err != nil {
+		return err
+	}
+	if controller.TotalFileSize == 0 {
+		return exeerrors.ErrLoadDataPreCheckFailed.FastGenByArgs(
+			"No file matched, or the file is empty. Please provide a valid file location.",
+		)
+	}
+	if err = sch.checkActiveImportJobs(ctx, taskMeta); err != nil {
+		return err
+	}
+	if err = sch.checkImportTableEmpty(ctx, taskMeta); err != nil {
+		return err
+	}
+	if err = controller.CalResourceParams(ctx, sch.TaskStore.GetCodec().GetKeyspace()); err != nil {
+		return err
+	}
+	controller.SetExecuteNodeCnt(controller.MaxNodeCnt)
+	chunkMap, err := controller.PopulateChunks(ctx)
+	if err != nil {
+		return err
+	}
+	chunkMapPath, err := sch.writePreparedChunkMap(ctx, task.ID, controller.Plan.CloudStorageURI, chunkMap)
+	if err != nil {
+		return err
+	}
+
+	taskMeta.Plan = *controller.Plan
+	taskMeta.ChunkMap = nil
+	taskMeta.PreparedChunkMapExternalPath = chunkMapPath
+	metaBytes, err := json.Marshal(taskMeta)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	task.Meta = metaBytes
+	task.RequiredSlots = controller.ThreadCnt
+	task.MaxNodeCount = controller.MaxNodeCnt
+	return nil
 }
 
 // OnNextSubtasksBatch generate batch of next stage's plan.

--- a/pkg/dxf/importinto/scheduler.go
+++ b/pkg/dxf/importinto/scheduler.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/pkg/dxf/framework/scheduler"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/executor/importer"
+	"github.com/pingcap/tidb/pkg/ingestor/globalsort"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/lightning/common"
 	"github.com/pingcap/tidb/pkg/lightning/config"
@@ -291,26 +292,6 @@ func (sch *importScheduler) checkImportTableEmpty(ctx context.Context, taskMeta 
 	})
 }
 
-func (sch *importScheduler) checkActiveImportJobs(ctx context.Context, taskMeta *TaskMeta) error {
-	taskManager, err := sch.getTaskMgrForAccessingImportJob()
-	if err != nil {
-		return err
-	}
-	return taskManager.WithNewSession(func(se sessionctx.Context) error {
-		exec := se.GetSQLExecutor()
-		activeCnt, err := importer.GetActiveJobCnt(ctx, exec, taskMeta.Plan.DBName, taskMeta.Plan.TableInfo.Name.L)
-		if err != nil {
-			return err
-		}
-		// The current prepare-enabled job is already in pending state, so we only
-		// fail when there are other active jobs on the same table.
-		if activeCnt > 1 {
-			return exeerrors.ErrLoadDataPreCheckFailed.FastGenByArgs("there is active job on the target table already")
-		}
-		return nil
-	})
-}
-
 func (sch *importScheduler) writePreparedChunkMap(
 	ctx context.Context,
 	taskID int64,
@@ -328,11 +309,8 @@ func (sch *importScheduler) writePreparedChunkMap(
 		uuid.NewString(),
 		"meta.json",
 	)
-	data, err := json.Marshal(chunkMap)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	if err = store.WriteFile(ctx, externalPath, data); err != nil {
+	baseMeta := globalsort.BaseExternalMeta{ExternalPath: externalPath}
+	if err = baseMeta.WriteJSONToExternalStorage(ctx, store, chunkMap); err != nil {
 		return "", err
 	}
 	return externalPath, nil
@@ -349,7 +327,7 @@ func (sch *importScheduler) OnPrepare(ctx context.Context, _ storage.TaskHandle,
 			return err
 		}
 	}
-	if !ShouldUseScopedPrepareIntegration(&taskMeta.Plan) {
+	if !ShouldUseAsyncPrepareForImportInto(&taskMeta.Plan) {
 		return nil
 	}
 
@@ -372,9 +350,6 @@ func (sch *importScheduler) OnPrepare(ctx context.Context, _ storage.TaskHandle,
 			"No file matched, or the file is empty. Please provide a valid file location.",
 		)
 	}
-	if err = sch.checkActiveImportJobs(ctx, taskMeta); err != nil {
-		return err
-	}
 	if err = sch.checkImportTableEmpty(ctx, taskMeta); err != nil {
 		return err
 	}
@@ -394,6 +369,9 @@ func (sch *importScheduler) OnPrepare(ctx context.Context, _ storage.TaskHandle,
 	taskMeta.Plan = *controller.Plan
 	taskMeta.ChunkMap = nil
 	taskMeta.PreparedChunkMapExternalPath = chunkMapPath
+	if err = sch.updatePreparedJobInfo(ctx, sch.GetLogger(), taskMeta); err != nil {
+		return err
+	}
 	metaBytes, err := json.Marshal(taskMeta)
 	if err != nil {
 		return errors.Trace(err)
@@ -814,6 +792,28 @@ func (sch *importScheduler) job2Step(ctx context.Context, logger *zap.Logger, ta
 			return true, taskManager.WithNewSession(func(se sessionctx.Context) error {
 				exec := se.GetSQLExecutor()
 				return importer.Job2Step(ctx, exec, taskMeta.JobID, step)
+			})
+		},
+	)
+}
+
+func (sch *importScheduler) updatePreparedJobInfo(ctx context.Context, logger *zap.Logger, taskMeta *TaskMeta) error {
+	taskManager, err := sch.getTaskMgrForAccessingImportJob()
+	if err != nil {
+		return err
+	}
+	backoffer := backoff.NewExponential(scheduler.RetrySQLInterval, 2, scheduler.RetrySQLMaxInterval)
+	return handle.RunWithRetry(ctx, scheduler.RetrySQLTimes, backoffer, logger,
+		func(ctx context.Context) (bool, error) {
+			return true, taskManager.WithNewSession(func(se sessionctx.Context) error {
+				exec := se.GetSQLExecutor()
+				return importer.UpdateJobPreparedInfo(
+					ctx,
+					exec,
+					taskMeta.JobID,
+					taskMeta.Plan.TotalFileSize,
+					taskMeta.Plan.Parameters,
+				)
 			})
 		},
 	)

--- a/pkg/dxf/importinto/scheduler.go
+++ b/pkg/dxf/importinto/scheduler.go
@@ -345,6 +345,11 @@ func (sch *importScheduler) OnPrepare(ctx context.Context, _ storage.TaskHandle,
 	if err := json.Unmarshal(task.Meta, taskMeta); err != nil {
 		return errors.Annotate(err, "unmarshal task meta failed")
 	}
+	if task.ExtraParams.PrepareMode == proto.PrepareModeRequired {
+		if err := sch.startJob(ctx, sch.GetLogger(), taskMeta, importer.JobStepPreparing); err != nil {
+			return err
+		}
+	}
 	if !ShouldUseScopedPrepareIntegration(&taskMeta.Plan) {
 		return nil
 	}
@@ -445,8 +450,14 @@ func (sch *importScheduler) OnNextSubtasksBatch(
 		if sch.GlobalSort {
 			jobStep = importer.JobStepGlobalSorting
 		}
-		if err = sch.startJob(ctx, logger, taskMeta, jobStep); err != nil {
-			return nil, err
+		if task.ExtraParams.PrepareMode == proto.PrepareModeRequired {
+			if err = sch.job2Step(ctx, logger, taskMeta, jobStep); err != nil {
+				return nil, err
+			}
+		} else {
+			if err = sch.startJob(ctx, logger, taskMeta, jobStep); err != nil {
+				return nil, err
+			}
 		}
 		if importer.GetNumOfIndexGenKV(taskMeta.Plan.TableInfo) > warningIndexCount {
 			dxfmetric.ScheduleEventCounter.WithLabelValues(fmt.Sprint(task.ID), dxfmetric.EventTooManyIdx).Inc()

--- a/pkg/dxf/importinto/scheduler.go
+++ b/pkg/dxf/importinto/scheduler.go
@@ -167,7 +167,6 @@ type importScheduler struct {
 }
 
 var _ scheduler.Extension = (*importScheduler)(nil)
-var _ scheduler.PrepareExtension = (*importScheduler)(nil)
 
 // NewImportScheduler creates a new import scheduler.
 func NewImportScheduler(
@@ -339,7 +338,7 @@ func (sch *importScheduler) writePreparedChunkMap(
 	return externalPath, nil
 }
 
-// OnPrepare implements scheduler.PrepareExtension.
+// OnPrepare implements scheduler.Extension.
 func (sch *importScheduler) OnPrepare(ctx context.Context, _ storage.TaskHandle, task *proto.Task) error {
 	taskMeta := &TaskMeta{}
 	if err := json.Unmarshal(task.Meta, taskMeta); err != nil {

--- a/pkg/dxf/importinto/scheduler_testkit_test.go
+++ b/pkg/dxf/importinto/scheduler_testkit_test.go
@@ -194,6 +194,53 @@ func TestSchedulerExtLocalSort(t *testing.T) {
 	gotJobInfo, err = importer.GetJob(ctx, conn, jobID, "root", true)
 	require.NoError(t, err)
 	require.Equal(t, "cancelled", gotJobInfo.Status)
+
+	t.Run("prepare-enabled job transitions from preparing to first business phase", func(t *testing.T) {
+		jobID, err := importer.CreateJob(ctx, conn, "test", "t", 1,
+			"root", "", &importer.ImportParameters{}, 123)
+		require.NoError(t, err)
+
+		logicalPlan.JobID = jobID
+		bs, err := logicalPlan.ToTaskMeta()
+		require.NoError(t, err)
+		task.Meta = bs
+		task.Step = proto.StepInit
+		task.State = proto.TaskStatePending
+		task.ExtraParams.PrepareMode = proto.PrepareModeRequired
+		task.ID, err = manager.CreateTask(
+			ctx,
+			importinto.TaskKey(jobID),
+			proto.ImportInto,
+			"",
+			1,
+			"",
+			1,
+			proto.ExtraParams{PrepareMode: proto.PrepareModeRequired},
+			bs,
+		)
+		require.NoError(t, err)
+
+		prepareExt, ok := ext.(scheduler.PrepareExtension)
+		require.True(t, ok)
+		require.NoError(t, prepareExt.OnPrepare(ctx, d, task))
+
+		gotJobInfo, err := importer.GetJob(ctx, conn, jobID, "root", true)
+		require.NoError(t, err)
+		require.Equal(t, importer.JobStatusRunning, gotJobInfo.Status)
+		require.Equal(t, importer.JobStepPreparing, gotJobInfo.Step)
+		require.False(t, gotJobInfo.StartTime.IsZero())
+		startTime := gotJobInfo.StartTime
+
+		task.Step = proto.StepPrepared
+		subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, proto.ImportStepImport)
+		require.NoError(t, err)
+		require.Len(t, subtaskMetas, 1)
+		gotJobInfo, err = importer.GetJob(ctx, conn, jobID, "root", true)
+		require.NoError(t, err)
+		require.Equal(t, importer.JobStatusRunning, gotJobInfo.Status)
+		require.Equal(t, importer.JobStepImporting, gotJobInfo.Step)
+		require.Equal(t, startTime, gotJobInfo.StartTime)
+	})
 }
 
 func TestSchedulerOnDoneCancelResetsTableMode(t *testing.T) {

--- a/pkg/dxf/importinto/scheduler_testkit_test.go
+++ b/pkg/dxf/importinto/scheduler_testkit_test.go
@@ -196,6 +196,10 @@ func TestSchedulerExtLocalSort(t *testing.T) {
 	require.Equal(t, "cancelled", gotJobInfo.Status)
 
 	t.Run("prepare-enabled job transitions from preparing to first business phase", func(t *testing.T) {
+		if !importinto.ShouldUseAsyncPrepare(&logicalPlan.Plan) {
+			t.Skip("prepare mode only applies when async prepare is enabled")
+		}
+
 		jobID, err := importer.CreateJob(ctx, conn, "test", "t", 1,
 			"root", "", &importer.ImportParameters{}, 123)
 		require.NoError(t, err)

--- a/pkg/dxf/importinto/scheduler_testkit_test.go
+++ b/pkg/dxf/importinto/scheduler_testkit_test.go
@@ -220,9 +220,7 @@ func TestSchedulerExtLocalSort(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		prepareExt, ok := ext.(scheduler.PrepareExtension)
-		require.True(t, ok)
-		require.NoError(t, prepareExt.OnPrepare(ctx, d, task))
+		require.NoError(t, ext.OnPrepare(ctx, d, task))
 
 		gotJobInfo, err := importer.GetJob(ctx, conn, jobID, "root", true)
 		require.NoError(t, err)

--- a/pkg/executor/import_into.go
+++ b/pkg/executor/import_into.go
@@ -106,13 +106,16 @@ func (e *ImportIntoExec) Next(ctx context.Context, req *chunk.Chunk) (err error)
 		return e.importFromSelect(ctx)
 	}
 
-	if err2 := e.controller.InitDataFiles(ctx); err2 != nil {
-		return err2
-	}
-	if kerneltype.IsNextGen() {
-		ksCodec := e.userSctx.GetStore().GetCodec().GetKeyspace()
-		if err2 := e.controller.CalResourceParams(ctx, ksCodec); err2 != nil {
+	useScopedPrepareIntegration := importinto.ShouldUseScopedPrepareIntegration(e.controller.Plan)
+	if !useScopedPrepareIntegration {
+		if err2 := e.controller.InitDataFiles(ctx); err2 != nil {
 			return err2
+		}
+		if kerneltype.IsNextGen() {
+			ksCodec := e.userSctx.GetStore().GetCodec().GetKeyspace()
+			if err2 := e.controller.CalResourceParams(ctx, ksCodec); err2 != nil {
+				return err2
+			}
 		}
 	}
 
@@ -122,8 +125,10 @@ func (e *ImportIntoExec) Next(ctx context.Context, req *chunk.Chunk) (err error)
 		return err2
 	}
 	defer CloseSession(newSCtx)
-	if err2 = e.controller.CheckRequirements(ctx, newSCtx); err2 != nil {
-		return err2
+	if !useScopedPrepareIntegration {
+		if err2 = e.controller.CheckRequirements(ctx, newSCtx); err2 != nil {
+			return err2
+		}
 	}
 
 	if err := e.controller.InitTiKVConfigs(ctx, newSCtx); err != nil {
@@ -217,12 +222,16 @@ func (e *ImportIntoExec) submitTask(ctx context.Context) (int64, *proto.TaskBase
 	}
 	logutil.Logger(ctx).Info("get job importer", zap.Stringer("param", e.controller.Parameters),
 		zap.Bool("dist-task-enabled", vardef.EnableDistTask.Load()))
+	useScopedPrepareIntegration := importinto.ShouldUseScopedPrepareIntegration(e.controller.Plan)
 	if importFromServer {
-		chunkMap, err2 := e.controller.PopulateChunks(ctx)
-		if err2 != nil {
-			return 0, nil, err2
+		if !useScopedPrepareIntegration {
+			chunkMap, err2 := e.controller.PopulateChunks(ctx)
+			if err2 != nil {
+				return 0, nil, err2
+			}
+			return importinto.SubmitStandaloneTask(ctx, e.controller.Plan, e.stmt, chunkMap)
 		}
-		return importinto.SubmitStandaloneTask(ctx, e.controller.Plan, e.stmt, chunkMap)
+		return importinto.SubmitStandaloneTask(ctx, e.controller.Plan, e.stmt, nil)
 	}
 	// if tidb_enable_dist_task=true, we import distributively, otherwise we import on current node.
 	if vardef.EnableDistTask.Load() {

--- a/pkg/executor/import_into.go
+++ b/pkg/executor/import_into.go
@@ -106,7 +106,7 @@ func (e *ImportIntoExec) Next(ctx context.Context, req *chunk.Chunk) (err error)
 		return e.importFromSelect(ctx)
 	}
 
-	useAsyncPrepare := importinto.ShouldUseAsyncPrepareForImportInto(e.controller.Plan)
+	useAsyncPrepare := importinto.ShouldUseAsyncPrepare(e.controller.Plan)
 	if !useAsyncPrepare {
 		if err2 := e.controller.InitDataFiles(ctx); err2 != nil {
 			return err2

--- a/pkg/executor/import_into.go
+++ b/pkg/executor/import_into.go
@@ -106,8 +106,8 @@ func (e *ImportIntoExec) Next(ctx context.Context, req *chunk.Chunk) (err error)
 		return e.importFromSelect(ctx)
 	}
 
-	useScopedPrepareIntegration := importinto.ShouldUseScopedPrepareIntegration(e.controller.Plan)
-	if !useScopedPrepareIntegration {
+	useAsyncPrepare := importinto.ShouldUseAsyncPrepareForImportInto(e.controller.Plan)
+	if !useAsyncPrepare {
 		if err2 := e.controller.InitDataFiles(ctx); err2 != nil {
 			return err2
 		}
@@ -125,10 +125,12 @@ func (e *ImportIntoExec) Next(ctx context.Context, req *chunk.Chunk) (err error)
 		return err2
 	}
 	defer CloseSession(newSCtx)
-	if !useScopedPrepareIntegration {
-		if err2 = e.controller.CheckRequirements(ctx, newSCtx); err2 != nil {
+	if useAsyncPrepare {
+		if err2 = e.controller.CheckRequirementsBeforeInitDataFiles(ctx, newSCtx); err2 != nil {
 			return err2
 		}
+	} else if err2 = e.controller.CheckRequirements(ctx, newSCtx); err2 != nil {
+		return err2
 	}
 
 	if err := e.controller.InitTiKVConfigs(ctx, newSCtx); err != nil {
@@ -222,16 +224,12 @@ func (e *ImportIntoExec) submitTask(ctx context.Context) (int64, *proto.TaskBase
 	}
 	logutil.Logger(ctx).Info("get job importer", zap.Stringer("param", e.controller.Parameters),
 		zap.Bool("dist-task-enabled", vardef.EnableDistTask.Load()))
-	useScopedPrepareIntegration := importinto.ShouldUseScopedPrepareIntegration(e.controller.Plan)
 	if importFromServer {
-		if !useScopedPrepareIntegration {
-			chunkMap, err2 := e.controller.PopulateChunks(ctx)
-			if err2 != nil {
-				return 0, nil, err2
-			}
-			return importinto.SubmitStandaloneTask(ctx, e.controller.Plan, e.stmt, chunkMap)
+		chunkMap, err2 := e.controller.PopulateChunks(ctx)
+		if err2 != nil {
+			return 0, nil, err2
 		}
-		return importinto.SubmitStandaloneTask(ctx, e.controller.Plan, e.stmt, nil)
+		return importinto.SubmitStandaloneTask(ctx, e.controller.Plan, e.stmt, chunkMap)
 	}
 	// if tidb_enable_dist_task=true, we import distributively, otherwise we import on current node.
 	if vardef.EnableDistTask.Load() {

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -1643,7 +1643,11 @@ func (e *LoadDataController) detectAndUpdateFormat(path string) {
 		e.Format = parseFileType(path)
 		e.logger.Info("detect and update import plan format based on file extension",
 			zap.String("file", path), zap.String("detected format", e.Format))
-		e.Parameters.Format = e.Format
+		// Plan.Parameters is not persisted in dist-task task meta. Keep this
+		// in-memory update best-effort for non-prepare paths.
+		if e.Parameters != nil {
+			e.Parameters.Format = e.Format
+		}
 	}
 }
 

--- a/pkg/executor/importer/job.go
+++ b/pkg/executor/importer/job.go
@@ -272,19 +272,43 @@ func UpdateJobPreparedInfo(
 	conn sqlexec.SQLExecutor,
 	jobID int64,
 	sourceFileSize int64,
-	parameters *ImportParameters,
+	format string,
 ) error {
-	if parameters == nil {
-		parameters = &ImportParameters{}
+	ctx = util.WithInternalSourceType(ctx, kv.InternalImportInto)
+	rs, err := conn.ExecuteInternal(ctx, `SELECT parameters FROM mysql.tidb_import_jobs
+		WHERE id = %? AND status = %?;`,
+		jobID, JobStatusRunning)
+	if err != nil {
+		return err
 	}
+	defer terror.Call(rs.Close)
+	rows, err := sqlexec.DrainRecordSet(ctx, rs, 1)
+	if err != nil {
+		return err
+	}
+	// no matched running job, keep historical behavior: no-op.
+	if len(rows) == 0 {
+		return nil
+	}
+
+	parameters := &ImportParameters{}
+	parametersStr := rows[0].GetString(0)
+	if len(parametersStr) > 0 {
+		if err = json.Unmarshal([]byte(parametersStr), parameters); err != nil {
+			return err
+		}
+	}
+	if format != "" {
+		parameters.Format = format
+	}
+
 	paramsBytes, err := json.Marshal(parameters)
 	if err != nil {
 		return err
 	}
-	ctx = util.WithInternalSourceType(ctx, kv.InternalImportInto)
 	_, err = conn.ExecuteInternal(ctx, `UPDATE mysql.tidb_import_jobs
-			SET update_time = CURRENT_TIMESTAMP(6), source_file_size = %?, parameters = %?
-			WHERE id = %? AND status = %?;`,
+				SET update_time = CURRENT_TIMESTAMP(6), source_file_size = %?, parameters = %?
+				WHERE id = %? AND status = %?;`,
 		sourceFileSize, paramsBytes, jobID, JobStatusRunning)
 	return err
 }

--- a/pkg/executor/importer/job.go
+++ b/pkg/executor/importer/job.go
@@ -61,11 +61,18 @@ const (
 
 	// when the job is finished, step will be set to none.
 	jobStepNone = ""
+	// JobStepPreparing is used by prepare-enabled jobs before generating
+	// first business-step subtasks.
+	JobStepPreparing = "preparing"
 	// JobStepGlobalSorting is the first step when using global sort,
 	// step goes from none -> global-sorting -> importing -> validating -> none.
+	// for prepare-enabled global sort, step goes from none -> preparing ->
+	// global-sorting -> importing -> validating -> none.
 	JobStepGlobalSorting = "global-sorting"
 	// JobStepImporting is the first step when using local sort,
 	// step goes from none -> importing -> validating -> none.
+	// for prepare-enabled local sort, step goes from none -> preparing ->
+	// importing -> validating -> none.
 	// when used in global sort, it means importing the sorted data.
 	// when used in local sort, it means encode&sort data and then importing the data.
 	JobStepImporting = "importing"

--- a/pkg/executor/importer/job.go
+++ b/pkg/executor/importer/job.go
@@ -71,8 +71,6 @@ const (
 	JobStepGlobalSorting = "global-sorting"
 	// JobStepImporting is the first step when using local sort,
 	// step goes from none -> importing -> validating -> none.
-	// for prepare-enabled local sort, step goes from none -> preparing ->
-	// importing -> validating -> none.
 	// when used in global sort, it means importing the sorted data.
 	// when used in local sort, it means encode&sort data and then importing the data.
 	JobStepImporting = "importing"
@@ -260,10 +258,34 @@ func StartJob(ctx context.Context, conn sqlexec.SQLExecutor, jobID int64, step s
 func Job2Step(ctx context.Context, conn sqlexec.SQLExecutor, jobID int64, step string) error {
 	ctx = util.WithInternalSourceType(ctx, kv.InternalImportInto)
 	_, err := conn.ExecuteInternal(ctx, `UPDATE mysql.tidb_import_jobs
-		SET update_time = CURRENT_TIMESTAMP(6), step = %?
-		WHERE id = %? AND status = %?;`,
+			SET update_time = CURRENT_TIMESTAMP(6), step = %?
+			WHERE id = %? AND status = %?;`,
 		step, jobID, JobStatusRunning)
 
+	return err
+}
+
+// UpdateJobPreparedInfo updates import job fields that are known only after
+// async prepare succeeds.
+func UpdateJobPreparedInfo(
+	ctx context.Context,
+	conn sqlexec.SQLExecutor,
+	jobID int64,
+	sourceFileSize int64,
+	parameters *ImportParameters,
+) error {
+	if parameters == nil {
+		parameters = &ImportParameters{}
+	}
+	paramsBytes, err := json.Marshal(parameters)
+	if err != nil {
+		return err
+	}
+	ctx = util.WithInternalSourceType(ctx, kv.InternalImportInto)
+	_, err = conn.ExecuteInternal(ctx, `UPDATE mysql.tidb_import_jobs
+			SET update_time = CURRENT_TIMESTAMP(6), source_file_size = %?, parameters = %?
+			WHERE id = %? AND status = %?;`,
+		sourceFileSize, paramsBytes, jobID, JobStatusRunning)
 	return err
 }
 

--- a/pkg/executor/importer/job_test.go
+++ b/pkg/executor/importer/job_test.go
@@ -179,6 +179,18 @@ func TestJobHappyPath(t *testing.T) {
 		require.Equal(t, importer.JobStatusRunning, info.Status)
 		require.Equal(t, importer.JobStepImporting, info.Step)
 		require.Equal(t, startTime, info.StartTime)
+
+		updatedParams := &importer.ImportParameters{
+			Format: importer.DataFormatCSV,
+			Options: map[string]any{
+				"thread": float64(16),
+			},
+		}
+		require.NoError(t, importer.UpdateJobPreparedInfo(ctx, conn, jobID, 456, updatedParams))
+		info, err = importer.GetJob(ctx, conn, jobID, "root@%", true)
+		require.NoError(t, err)
+		require.EqualValues(t, 456, info.SourceFileSize)
+		require.Equal(t, updatedParams.Options, info.Parameters.Options)
 	})
 }
 

--- a/pkg/executor/importer/job_test.go
+++ b/pkg/executor/importer/job_test.go
@@ -161,8 +161,16 @@ func TestJobHappyPath(t *testing.T) {
 	}
 
 	t.Run("prepare phase transition", func(t *testing.T) {
+		createdParams := &importer.ImportParameters{
+			FileLocation: "s3://bucket/path.csv",
+			Format:       importer.DataFormatAuto,
+			Options: map[string]any{
+				"detached": nil,
+				"thread":   float64(16),
+			},
+		}
 		jobID, err := importer.CreateJob(ctx, conn, "test", "t", 1,
-			"root@%", "", &importer.ImportParameters{Format: importer.DataFormatCSV}, 123)
+			"root@%", "", createdParams, 123)
 		require.NoError(t, err)
 
 		require.NoError(t, importer.StartJob(ctx, conn, jobID, importer.JobStepPreparing))
@@ -180,17 +188,13 @@ func TestJobHappyPath(t *testing.T) {
 		require.Equal(t, importer.JobStepImporting, info.Step)
 		require.Equal(t, startTime, info.StartTime)
 
-		updatedParams := &importer.ImportParameters{
-			Format: importer.DataFormatCSV,
-			Options: map[string]any{
-				"thread": float64(16),
-			},
-		}
-		require.NoError(t, importer.UpdateJobPreparedInfo(ctx, conn, jobID, 456, updatedParams))
+		require.NoError(t, importer.UpdateJobPreparedInfo(ctx, conn, jobID, 456, importer.DataFormatCSV))
 		info, err = importer.GetJob(ctx, conn, jobID, "root@%", true)
 		require.NoError(t, err)
 		require.EqualValues(t, 456, info.SourceFileSize)
-		require.Equal(t, updatedParams.Options, info.Parameters.Options)
+		require.Equal(t, importer.DataFormatCSV, info.Parameters.Format)
+		require.Equal(t, createdParams.FileLocation, info.Parameters.FileLocation)
+		require.Equal(t, createdParams.Options, info.Parameters.Options)
 	})
 }
 

--- a/pkg/executor/importer/job_test.go
+++ b/pkg/executor/importer/job_test.go
@@ -159,6 +159,27 @@ func TestJobHappyPath(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, endTime, gotJobInfo.EndTime)
 	}
+
+	t.Run("prepare phase transition", func(t *testing.T) {
+		jobID, err := importer.CreateJob(ctx, conn, "test", "t", 1,
+			"root@%", "", &importer.ImportParameters{Format: importer.DataFormatCSV}, 123)
+		require.NoError(t, err)
+
+		require.NoError(t, importer.StartJob(ctx, conn, jobID, importer.JobStepPreparing))
+		info, err := importer.GetJob(ctx, conn, jobID, "root@%", true)
+		require.NoError(t, err)
+		require.Equal(t, importer.JobStatusRunning, info.Status)
+		require.Equal(t, importer.JobStepPreparing, info.Step)
+		require.False(t, info.StartTime.IsZero())
+		startTime := info.StartTime
+
+		require.NoError(t, importer.Job2Step(ctx, conn, jobID, importer.JobStepImporting))
+		info, err = importer.GetJob(ctx, conn, jobID, "root@%", true)
+		require.NoError(t, err)
+		require.Equal(t, importer.JobStatusRunning, info.Status)
+		require.Equal(t, importer.JobStepImporting, info.Step)
+		require.Equal(t, startTime, info.StartTime)
+	})
 }
 
 func TestGetAndCancelJob(t *testing.T) {

--- a/pkg/executor/importer/precheck.go
+++ b/pkg/executor/importer/precheck.go
@@ -47,6 +47,16 @@ var GetEtcdClient = store.NewEtcdCli
 //
 // we check them one by one, and return the first error we meet.
 func (e *LoadDataController) CheckRequirements(ctx context.Context, se sessionctx.Context) error {
+	return e.checkRequirements(ctx, se, true)
+}
+
+// CheckRequirementsBeforeInitDataFiles checks requirements that don't depend on
+// discovered data files, and is used by async-prepare submit path.
+func (e *LoadDataController) CheckRequirementsBeforeInitDataFiles(ctx context.Context, se sessionctx.Context) error {
+	return e.checkRequirements(ctx, se, false)
+}
+
+func (e *LoadDataController) checkRequirements(ctx context.Context, se sessionctx.Context, checkTotalFileSize bool) error {
 	conn := se.GetSQLExecutor()
 	if e.DataSourceType == DataSourceTypeFile {
 		cnt, err := GetActiveJobCnt(ctx, conn, e.Plan.DBName, e.Plan.TableInfo.Name.L)
@@ -56,8 +66,10 @@ func (e *LoadDataController) CheckRequirements(ctx context.Context, se sessionct
 		if cnt > 0 {
 			return exeerrors.ErrLoadDataPreCheckFailed.FastGenByArgs("there is active job on the target table already")
 		}
-		if err := e.checkTotalFileSize(); err != nil {
-			return err
+		if checkTotalFileSize {
+			if err := e.checkTotalFileSize(); err != nil {
+				return err
+			}
 		}
 	}
 	if err := e.checkTableEmpty(ctx, conn); err != nil {

--- a/pkg/executor/importer/precheck_test.go
+++ b/pkg/executor/importer/precheck_test.go
@@ -136,9 +136,16 @@ func TestCheckRequirements(t *testing.T) {
 	err = c.CheckRequirements(ctx, tk.Session())
 	require.ErrorIs(t, err, exeerrors.ErrLoadDataPreCheckFailed)
 	require.ErrorContains(t, err, "there is active job on the target table already")
+	err = c.CheckRequirementsBeforeInitDataFiles(ctx, tk.Session())
+	require.ErrorIs(t, err, exeerrors.ErrLoadDataPreCheckFailed)
+	require.ErrorContains(t, err, "there is active job on the target table already")
 	// cancel the job
 	require.NoError(t, importer.CancelJob(ctx, conn, jobID))
 
+	// async-prepare submit path skips file-size check before InitDataFiles.
+	c.DisablePrecheck = true
+	require.NoError(t, c.CheckRequirementsBeforeInitDataFiles(ctx, tk.Session()))
+	c.DisablePrecheck = false
 	// source data file size = 0
 	require.ErrorIs(t, c.CheckRequirements(ctx, tk.Session()), exeerrors.ErrLoadDataPreCheckFailed)
 

--- a/pkg/executor/show_test.go
+++ b/pkg/executor/show_test.go
@@ -107,6 +107,15 @@ func TestFillOneImportJobInfo(t *testing.T) {
 	require.Equal(t, "12 conflicts", c.GetRow(5).GetString(fmap["CurStepProcessedSize"]))
 	require.Equal(t, "34 conflicts", c.GetRow(5).GetString(fmap["CurStepTotalSize"]))
 	require.Equal(t, "5 conflicts/s", c.GetRow(5).GetString(fmap["CurStepSpeed"]))
+
+	// preparing phase should be visible while current business step is still init.
+	jobInfo.Step = importer.JobStepPreparing
+	ri = &importinto.RuntimeInfo{
+		Step: proto.StepInit,
+	}
+	executor.FillOneImportJobInfo(c, jobInfo, ri)
+	require.Equal(t, importer.JobStepPreparing, c.GetRow(6).GetString(fmap["Phase"]))
+	require.Equal(t, proto.Step2Str(proto.ImportInto, proto.StepInit), c.GetRow(6).GetString(fmap["CurStep"]))
 }
 
 func TestShow(t *testing.T) {

--- a/pkg/ingestor/globalsort/util.go
+++ b/pkg/ingestor/globalsort/util.go
@@ -274,6 +274,11 @@ func PlanMetaPath(taskID int64, step string, idx int) string {
 	return path.Join(strconv.FormatInt(taskID, 10), "plan", step, strconv.Itoa(idx), metaName)
 }
 
+// PreparedMetaPath returns the path of the prepared meta file.
+func PreparedMetaPath(taskID int64) string {
+	return path.Join(strconv.FormatInt(taskID, 10), "plan", "prepared", metaName)
+}
+
 // SubtaskMetaPath returns the path of the subtask meta file.
 func SubtaskMetaPath(taskID int64, subtaskID int64) string {
 	return path.Join(strconv.FormatInt(taskID, 10), strconv.FormatInt(subtaskID, 10), metaName)

--- a/pkg/ingestor/globalsort/util_test.go
+++ b/pkg/ingestor/globalsort/util_test.go
@@ -375,6 +375,8 @@ func TestReadWriteJSON(t *testing.T) {
 func TestExternalMetaPath(t *testing.T) {
 	require.Equal(t, "1/plan/merge-sort/1/meta.json", PlanMetaPath(1, "merge-sort", 1))
 	require.Equal(t, "2/plan/ingest/3/meta.json", PlanMetaPath(2, "ingest", 3))
+	require.Equal(t, "1/plan/prepared/meta.json", PreparedMetaPath(1))
+	require.Equal(t, "2/plan/prepared/meta.json", PreparedMetaPath(2))
 
 	require.Equal(t, "1/1/meta.json", SubtaskMetaPath(1, 1))
 	require.Equal(t, "2/3/meta.json", SubtaskMetaPath(2, 3))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prepare mode support enabling asynchronous task preparation.
  * IMPORT INTO global-sort operations now support async prepare phase.
  * Job preparation state persists prepared data externally for efficiency.

* **Bug Fixes**
  * Fixed potential crash in import format detection when initializing parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->