### PR TITLE
*: serialize failpoint state toggles and tighten bazel_prepare gate

### DIFF
--- a/.agents/skills/tidb-bazel-prepare-gate/SKILL.md
+++ b/.agents/skills/tidb-bazel-prepare-gate/SKILL.md
@@ -20,6 +20,8 @@ git status --short
 git diff --name-status
 git diff --name-status --cached
 git ls-files --others --exclude-standard
+git diff -U0 -- '*.go'
+git diff -U0 --cached -- '*.go'
 git diff -U0 -- '*_test.go'
 git diff -U0 --cached -- '*_test.go'
 ```
@@ -37,6 +39,17 @@ For the top-level test-function trigger in existing `*_test.go` files, inspect a
 ```
 
 and treat that as requiring `make bazel_prepare`.
+
+For import-section changes in existing Go files, inspect `git diff -U0 -- '*.go'` and
+`git diff -U0 --cached -- '*.go'` for added/removed import lines, for example:
+
+```diff
++import (
+-import "fmt"
++	"context"
+```
+
+and treat those changes as requiring `make bazel_prepare`.
 
 If any condition matches, run `make bazel_prepare`.
 If none of the rules match, continue without `make bazel_prepare` and report the evidence.

--- a/.agents/skills/tidb-bazel-prepare-gate/SKILL.md
+++ b/.agents/skills/tidb-bazel-prepare-gate/SKILL.md
@@ -20,8 +20,8 @@ git status --short
 git diff --name-status
 git diff --name-status --cached
 git ls-files --others --exclude-standard
-git diff -U0 -- '*.go'
-git diff -U0 --cached -- '*.go'
+git diff -U0 -- '*.go' ':(exclude)*_test.go'
+git diff -U0 --cached -- '*.go' ':(exclude)*_test.go'
 git diff -U0 -- '*_test.go'
 git diff -U0 --cached -- '*_test.go'
 ```
@@ -40,8 +40,10 @@ For the top-level test-function trigger in existing `*_test.go` files, inspect a
 
 and treat that as requiring `make bazel_prepare`.
 
-For import-section changes in existing Go files, inspect `git diff -U0 -- '*.go'` and
-`git diff -U0 --cached -- '*.go'` for added/removed import lines, for example:
+For import-section changes in existing non-test Go files, inspect
+`git diff -U0 -- '*.go' ':(exclude)*_test.go'` and
+`git diff -U0 --cached -- '*.go' ':(exclude)*_test.go'` for added/removed import
+lines, for example:
 
 ```diff
 +import (

--- a/.agents/skills/tidb-bazel-prepare-gate/SKILL.md
+++ b/.agents/skills/tidb-bazel-prepare-gate/SKILL.md
@@ -20,10 +20,8 @@ git status --short
 git diff --name-status
 git diff --name-status --cached
 git ls-files --others --exclude-standard
-git diff -U0 -- '*.go' ':(exclude)*_test.go'
-git diff -U0 --cached -- '*.go' ':(exclude)*_test.go'
-git diff -U0 -- '*_test.go'
-git diff -U0 --cached -- '*_test.go'
+git diff -U0 -- '*.go'
+git diff -U0 --cached -- '*.go'
 ```
 
 ## Decision Rules
@@ -31,8 +29,8 @@ git diff -U0 --cached -- '*_test.go'
 Trigger conditions are defined in `AGENTS.md` -> `Build Flow` -> `When make bazel_prepare is required`.
 Compare the output from the commands above against those conditions.
 
-For the top-level test-function trigger in existing `*_test.go` files, inspect added lines in the
-`git diff -U0` output for patterns like:
+For the top-level test-function trigger in existing `*_test.go` files, inspect added lines in
+`git diff -U0 -- '*.go'` and `git diff -U0 --cached -- '*.go'` output for patterns like:
 
 ```diff
 +func TestXxx(t *testing.T) {
@@ -40,10 +38,8 @@ For the top-level test-function trigger in existing `*_test.go` files, inspect a
 
 and treat that as requiring `make bazel_prepare`.
 
-For import-section changes in existing non-test Go files, inspect
-`git diff -U0 -- '*.go' ':(exclude)*_test.go'` and
-`git diff -U0 --cached -- '*.go' ':(exclude)*_test.go'` for added/removed import
-lines, for example:
+For import-section changes in existing Go files, inspect `git diff -U0 -- '*.go'` and
+`git diff -U0 --cached -- '*.go'` for added/removed import lines, for example:
 
 ```diff
 +import (

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ When writing complex features or significant refactors, use an ExecPlan from des
 
 | Task | Required action |
 | --- | --- |
-| Added/moved/renamed/removed Go files, added a new top-level Go test function matching `func TestXxx(t *testing.T)` in an existing `*_test.go` file, changed Bazel files, updated Bazel test targets, or changed `go.mod`/`go.sum` | MUST run `make bazel_prepare` and include resulting Bazel metadata changes in the PR (for example `BUILD.bazel`, `**/*.bazel`, and `**/*.bzl`). |
+| Added/moved/renamed/removed Go files, changed the import section of an existing Go file, added a new top-level Go test function matching `func TestXxx(t *testing.T)` in an existing `*_test.go` file, changed Bazel files, updated Bazel test targets, or changed `go.mod`/`go.sum` | MUST run `make bazel_prepare` and include resulting Bazel metadata changes in the PR (for example `BUILD.bazel`, `**/*.bazel`, and `**/*.bzl`). |
 | Running package unit tests | SHOULD run targeted tests and avoid full-package runs unless needed (see `docs/agents/testing-flow.md` -> `Unit tests`). |
 | Unit tests in a package that uses failpoints | MUST enable failpoints before tests and disable afterward (see `docs/agents/testing-flow.md` -> `Failpoint decision for unit tests`). |
 | Recording integration tests | MUST use the recording command in `docs/agents/testing-flow.md` -> `Integration tests` (not `-record`; `-record` is for unit-test suites that explicitly support it). |
@@ -97,6 +97,7 @@ Run `make bazel_prepare` before building when any of the following is true:
 - New workspace or fresh clone.
 - Bazel-related files changed (for example `WORKSPACE`, `DEPS.bzl`, `BUILD.bazel`, `MODULE.bazel`, `MODULE.bazel.lock`).
 - Any Go source file is added/removed/renamed/moved in the PR.
+- The import section changed in any existing Go source file (including `*_test.go`).
 - A code change adds a new top-level Go test function matching `func TestXxx(t *testing.T)` in an existing `*_test.go` file.
 - Go module dependencies changed (for example `go.mod`, `go.sum`), including adding third-party dependencies.
 - Bazel test targets were updated (for example `shard_count` changed, test `srcs` list edited, or `tests/realtikvtest/**/BUILD.bazel` modified).

--- a/Makefile
+++ b/Makefile
@@ -348,11 +348,11 @@ failpoint-disable: tools/bin/failpoint-ctl
 
 .PHONY: bazel-failpoint-enable
 bazel-failpoint-enable:
-	find $$PWD/ -mindepth 1 -maxdepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable
+	BAZEL_GLOBAL_CONFIG="$(BAZEL_GLOBAL_CONFIG)" BAZEL_CMD_CONFIG="$(BAZEL_CMD_CONFIG)" ./tools/check/failpoint-state.sh enable bazel
 
 .PHONY: bazel-failpoint-disable
 bazel-failpoint-disable:
-	find $$PWD/ -mindepth 1 -maxdepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable
+	BAZEL_GLOBAL_CONFIG="$(BAZEL_GLOBAL_CONFIG)" BAZEL_CMD_CONFIG="$(BAZEL_CMD_CONFIG)" ./tools/check/failpoint-state.sh disable bazel
 
 .PHONY: tools/bin/ut
 tools/bin/ut: tools/check/ut.go tools/check/longtests.go

--- a/Makefile.common
+++ b/Makefile.common
@@ -78,8 +78,8 @@ FILES_TIDB_TESTS := $$(find $$($(PACKAGE_DIRECTORIES_TIDB_TESTS)) -name "*.go" -
 UNCONVERT_PACKAGES_LIST := go list ./...| grep -vE "lightning/checkpoints|lightning/manual|lightning/common|tidb-binlog/proto/go-binlog"
 UNCONVERT_PACKAGES := $$($(UNCONVERT_PACKAGES_LIST))
 
-FAILPOINT_ENABLE  := find $$PWD/ -mindepth 1 -maxdepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs tools/bin/failpoint-ctl enable
-FAILPOINT_DISABLE := find $$PWD/ -mindepth 1 -maxdepth 1 -type d | grep -vE "(\.git|\.idea|tools)" | xargs tools/bin/failpoint-ctl disable
+FAILPOINT_ENABLE  := ./tools/check/failpoint-state.sh enable go
+FAILPOINT_DISABLE := ./tools/check/failpoint-state.sh disable go
 
 GITHASH := $(shell git rev-parse HEAD)
 GITBRANCH := $(shell git rev-parse --abbrev-ref HEAD)

--- a/docs/agents/ddl/04-dev-checklist.md
+++ b/docs/agents/ddl/04-dev-checklist.md
@@ -76,7 +76,7 @@ make failpoint-enable && (
 
 Build system note (Bazel):
 
-- If you add/remove/move Go files (including new `_test.go`), run `make bazel_prepare` and include generated `*.bazel/*.bzl` changes.
+- If you add/remove/move Go files (including new `_test.go`) or change an existing Go file import section, run `make bazel_prepare` and include generated `*.bazel/*.bzl` changes.
 
 ## 4) Debugging and observability tips
 

--- a/docs/agents/testing-flow.md
+++ b/docs/agents/testing-flow.md
@@ -40,6 +40,7 @@ test -f pkg/<package_name>/BUILD.bazel && rg -n --fixed-strings -- "@com_github_
 ```
 
 - The script enables failpoints, runs `go test`, and always disables failpoints during cleanup.
+- The underlying enable/disable path is serialized by `tools/check/failpoint-state.sh`; do not invoke `tools/bin/failpoint-ctl` directly from parallel agent tasks in the same worktree.
 - Pass additional `go test` flags after the package path, for example `./tools/check/failpoint-go-test.sh pkg/<package_name> -run <TestName> -count=1`.
 - If `-tags` is omitted, the script defaults to `-tags=intest,deadlock`.
 - Pass `-tags=intest,deadlock,nextgen` when a test run also needs `nextgen`.

--- a/tools/check/failpoint-state.sh
+++ b/tools/check/failpoint-state.sh
@@ -28,6 +28,8 @@ Arguments:
 
 Environment:
   FAILPOINT_LOCK_WAIT_SECONDS  Lock wait timeout (default: 600).
+  FAILPOINT_LOG_CHANNEL        Log channel: stderr|stdout|both (default: stderr).
+  FAILPOINT_LOG_COLOR          Color mode: auto|always|never (default: auto).
   BAZEL_GLOBAL_CONFIG          Optional bazel global flags.
   BAZEL_CMD_CONFIG             Optional bazel command flags.
 EOF
@@ -74,6 +76,26 @@ lock_dir="${state_dir}/lock"
 lock_pid_file="${lock_dir}/pid"
 refcount_file="${state_dir}/refcount"
 lock_wait_seconds="${FAILPOINT_LOCK_WAIT_SECONDS:-600}"
+log_channel="${FAILPOINT_LOG_CHANNEL:-stderr}"
+log_color_mode="${FAILPOINT_LOG_COLOR:-auto}"
+
+case "${log_channel}" in
+	stdout|stderr|both)
+		;;
+	*)
+		echo "invalid FAILPOINT_LOG_CHANNEL: ${log_channel} (expected stdout|stderr|both)" >&2
+		exit 1
+		;;
+esac
+
+case "${log_color_mode}" in
+	auto|always|never)
+		;;
+	*)
+		echo "invalid FAILPOINT_LOG_COLOR: ${log_color_mode} (expected auto|always|never)" >&2
+		exit 1
+		;;
+esac
 
 mkdir -p "${state_dir}"
 
@@ -94,6 +116,95 @@ read_refcount() {
 write_refcount() {
 	local count="$1"
 	printf '%s\n' "${count}" > "${refcount_file}"
+}
+
+log_state() {
+	local message="$1"
+	case "${log_channel}" in
+		stdout)
+			emit_log_to_fd 1 "${message}"
+			;;
+		stderr)
+			emit_log_to_fd 2 "${message}"
+			;;
+		both)
+			emit_log_to_fd 1 "${message}"
+			emit_log_to_fd 2 "${message}"
+			;;
+	esac
+}
+
+emit_log_to_fd() {
+	local fd="$1"
+	local message="$2"
+	if [ "${fd}" -eq 1 ]; then
+		printf '[failpoint-state] %s\n' "${message}"
+	else
+		printf '[failpoint-state] %s\n' "${message}" >&2
+	fi
+}
+
+use_color_for_fd() {
+	local fd="$1"
+	case "${log_color_mode}" in
+		always)
+			return 0
+			;;
+		never)
+			return 1
+			;;
+		auto)
+			[ -z "${NO_COLOR:-}" ] || return 1
+			[ "${TERM:-}" != "dumb" ] || return 1
+			[ -t "${fd}" ]
+			return
+			;;
+	esac
+}
+
+format_decision_for_fd() {
+	local fd="$1"
+	local message="$2"
+	local line="[DECISION] >>> ${message} <<<"
+	local color_reset=$'\033[0m'
+	local color_decision
+	case "${message}" in
+		decision=run-*)
+			color_decision=$'\033[1;32m'
+			;;
+		decision=skip-*)
+			color_decision=$'\033[1;33m'
+			;;
+		*)
+			color_decision=$'\033[1;36m'
+			;;
+	esac
+	if use_color_for_fd "${fd}"; then
+		printf '%s%s%s' "${color_decision}" "${line}" "${color_reset}"
+	else
+		printf '%s' "${line}"
+	fi
+}
+
+log_decision() {
+	local message="$1"
+	local formatted
+	case "${log_channel}" in
+		stdout)
+			formatted="$(format_decision_for_fd 1 "${message}")"
+			emit_log_to_fd 1 "${formatted}"
+			;;
+		stderr)
+			formatted="$(format_decision_for_fd 2 "${message}")"
+			emit_log_to_fd 2 "${formatted}"
+			;;
+		both)
+			formatted="$(format_decision_for_fd 1 "${message}")"
+			emit_log_to_fd 1 "${formatted}"
+			formatted="$(format_decision_for_fd 2 "${message}")"
+			emit_log_to_fd 2 "${formatted}"
+			;;
+	esac
 }
 
 collect_target_dirs() {
@@ -178,22 +289,33 @@ trap release_lock EXIT INT TERM
 acquire_lock
 
 refcount="$(read_refcount)"
+log_state "action=${action} backend=${backend} log_channel=${log_channel} log_color=${log_color_mode} refcount=${refcount}"
 case "${action}" in
 	enable)
 		if [ "${refcount}" -eq 0 ]; then
+			log_decision "decision=run-enable reason=refcount-is-zero"
 			run_failpoint_ctl enable
+		else
+			log_decision "decision=skip-enable reason=already-enabled"
 		fi
-		write_refcount "$((refcount + 1))"
+		new_refcount=$((refcount + 1))
+		write_refcount "${new_refcount}"
+		log_state "new_refcount=${new_refcount}"
 		;;
 	disable)
 		if [ "${refcount}" -le 0 ]; then
 			write_refcount 0
+			log_decision "decision=skip-disable reason=refcount-non-positive new_refcount=0"
 			exit 0
 		fi
 		new_refcount=$((refcount - 1))
 		if [ "${new_refcount}" -eq 0 ]; then
+			log_decision "decision=run-disable reason=refcount-reaches-zero"
 			run_failpoint_ctl disable
+		else
+			log_decision "decision=skip-disable reason=still-referenced"
 		fi
 		write_refcount "${new_refcount}"
+		log_state "new_refcount=${new_refcount}"
 		;;
 esac

--- a/tools/check/failpoint-state.sh
+++ b/tools/check/failpoint-state.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Copyright 2026 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: tools/check/failpoint-state.sh <enable|disable> [go|bazel]
+
+Serialize failpoint enable/disable operations in a repository and avoid
+parallel state corruption from overlapping failpoint-ctl runs.
+
+Arguments:
+  enable|disable  Desired failpoint state transition.
+  go|bazel        Backend to use (default: go).
+
+Environment:
+  FAILPOINT_LOCK_WAIT_SECONDS  Lock wait timeout (default: 600).
+  BAZEL_GLOBAL_CONFIG          Optional bazel global flags.
+  BAZEL_CMD_CONFIG             Optional bazel command flags.
+EOF
+}
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+	usage >&2
+	exit 1
+fi
+
+action="$1"
+backend="${2:-go}"
+
+case "${action}" in
+	enable|disable)
+		;;
+	*)
+		usage >&2
+		exit 1
+		;;
+esac
+
+case "${backend}" in
+	go|bazel)
+		;;
+	*)
+		usage >&2
+		exit 1
+		;;
+esac
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+
+if git_dir="$(git -C "${repo_root}" rev-parse --git-dir 2>/dev/null)"; then
+	if [[ "${git_dir}" != /* ]]; then
+		git_dir="${repo_root}/${git_dir}"
+	fi
+	state_dir="${git_dir}/.failpoint-state"
+else
+	state_dir="${repo_root}/.git/.failpoint-state"
+fi
+lock_dir="${state_dir}/lock"
+lock_pid_file="${lock_dir}/pid"
+refcount_file="${state_dir}/refcount"
+lock_wait_seconds="${FAILPOINT_LOCK_WAIT_SECONDS:-600}"
+
+mkdir -p "${state_dir}"
+
+read_refcount() {
+	if [ ! -f "${refcount_file}" ]; then
+		echo 0
+		return
+	fi
+	local raw
+	raw="$(tr -d '[:space:]' < "${refcount_file}")"
+	if [[ ! "${raw}" =~ ^[0-9]+$ ]]; then
+		echo "invalid failpoint refcount in ${refcount_file}: ${raw}" >&2
+		exit 1
+	fi
+	echo "${raw}"
+}
+
+write_refcount() {
+	local count="$1"
+	printf '%s\n' "${count}" > "${refcount_file}"
+}
+
+collect_target_dirs() {
+	local dir
+	target_dirs=()
+	while IFS= read -r -d '' dir; do
+		case "$(basename "${dir}")" in
+			.git|.idea|tools)
+				continue
+				;;
+		esac
+		target_dirs+=("${dir}")
+	done < <(find "${repo_root}" -mindepth 1 -maxdepth 1 -type d -print0)
+	if [ "${#target_dirs[@]}" -eq 0 ]; then
+		echo "no target directories found for failpoint-ctl under ${repo_root}" >&2
+		exit 1
+	fi
+}
+
+run_go_failpoint_ctl() {
+	local mode="$1"
+	collect_target_dirs
+	"${repo_root}/tools/bin/failpoint-ctl" "${mode}" "${target_dirs[@]}"
+}
+
+run_bazel_failpoint_ctl() {
+	local mode="$1"
+	local -a bazel_global_args=()
+	local -a bazel_cmd_args=()
+	if [ -n "${BAZEL_GLOBAL_CONFIG:-}" ]; then
+		# shellcheck disable=SC2206
+		bazel_global_args=(${BAZEL_GLOBAL_CONFIG})
+	fi
+	if [ -n "${BAZEL_CMD_CONFIG:-}" ]; then
+		# shellcheck disable=SC2206
+		bazel_cmd_args=(${BAZEL_CMD_CONFIG})
+	fi
+	collect_target_dirs
+	bazel "${bazel_global_args[@]}" run "${bazel_cmd_args[@]}" @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- "${mode}" "${target_dirs[@]}"
+}
+
+run_failpoint_ctl() {
+	local mode="$1"
+	case "${backend}" in
+		go)
+			run_go_failpoint_ctl "${mode}"
+			;;
+		bazel)
+			run_bazel_failpoint_ctl "${mode}"
+			;;
+	esac
+}
+
+release_lock() {
+	rm -f "${lock_pid_file}" 2>/dev/null || true
+	rmdir "${lock_dir}" 2>/dev/null || true
+}
+
+acquire_lock() {
+	local waited=0
+	while ! mkdir "${lock_dir}" 2>/dev/null; do
+		if [ -f "${lock_pid_file}" ]; then
+			local holder
+			holder="$(tr -d '[:space:]' < "${lock_pid_file}" || true)"
+			if [ -n "${holder}" ] && ! kill -0 "${holder}" 2>/dev/null; then
+				rm -f "${lock_pid_file}" 2>/dev/null || true
+				rmdir "${lock_dir}" 2>/dev/null || true
+				continue
+			fi
+		fi
+		if [ "${waited}" -ge "${lock_wait_seconds}" ]; then
+			echo "timed out waiting for failpoint lock after ${lock_wait_seconds}s: ${lock_dir}" >&2
+			exit 1
+		fi
+		sleep 1
+		waited=$((waited + 1))
+	done
+	printf '%s\n' "$$" > "${lock_pid_file}"
+}
+
+trap release_lock EXIT INT TERM
+acquire_lock
+
+refcount="$(read_refcount)"
+case "${action}" in
+	enable)
+		if [ "${refcount}" -eq 0 ]; then
+			run_failpoint_ctl enable
+		fi
+		write_refcount "$((refcount + 1))"
+		;;
+	disable)
+		if [ "${refcount}" -le 0 ]; then
+			write_refcount 0
+			exit 0
+		fi
+		new_refcount=$((refcount - 1))
+		if [ "${new_refcount}" -eq 0 ]; then
+			run_failpoint_ctl disable
+		fi
+		write_refcount "${new_refcount}"
+		;;
+esac


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #63847

Problem Summary:

Agent-oriented development workflows had two gaps:
1. `make bazel_prepare` gating did not explicitly include import-section changes in existing Go files.
2. Parallel failpoint enable/disable flows could interleave and leave transformed source content in the worktree.

### What changed and how does it work?

- Added `tools/check/failpoint-state.sh` to serialize failpoint state transitions with:
  - a worktree-aware lock under the resolved git dir,
  - reference counting to ensure only the first `enable` and last `disable` invoke `failpoint-ctl`.
<img width="1342" height="736" alt="img_v3_0211u_99593bfd-b571-4917-8d0d-b25bfbc5b03g" src="https://github.com/user-attachments/assets/4b30e9dd-117c-472b-80c8-3830b458d18f" />

- Added failpoint transition diagnostics in `tools/check/failpoint-state.sh`:
  - logs current `refcount` and explicit run/skip decisions,
  - supports configurable log channel via `FAILPOINT_LOG_CHANNEL=stderr|stdout|both`,
  - supports optional decision highlighting via `FAILPOINT_LOG_COLOR=auto|always|never`.
- Routed Make targets through the wrapper:
  - `FAILPOINT_ENABLE` / `FAILPOINT_DISABLE` in `Makefile.common`,
  - `bazel-failpoint-enable` / `bazel-failpoint-disable` in `Makefile`.
- Updated agent policy/docs so changing an existing Go file import section also requires `make bazel_prepare`:
  - `AGENTS.md`,
  - `.agents/skills/tidb-bazel-prepare-gate/SKILL.md`,
  - `docs/agents/ddl/04-dev-checklist.md`.
- Documented the parallel-safety rule in `docs/agents/testing-flow.md`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - `bash -n tools/check/failpoint-state.sh`
  - `make failpoint-enable && make failpoint-disable`
  - `FAILPOINT_LOG_CHANNEL=stdout FAILPOINT_LOG_COLOR=auto ./tools/check/failpoint-state.sh enable go`
  - `FAILPOINT_LOG_CHANNEL=both FAILPOINT_LOG_COLOR=always ./tools/check/failpoint-state.sh disable go`
  - `make -n bazel-failpoint-enable`
  - `make -n bazel-failpoint-disable`
  - `make lint`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that changing the import section of existing Go files requires running make bazel_prepare; updated decision/checklist guidance and agent docs.
  * Added guidance warning that failpoint enable/disable operations are serialized to avoid concurrent conflicts.

* **Build System Improvements**
  * Make targets updated to use a centralized, serialized failpoint control mechanism.

* **New Tool**
  * Added a repo-local serialized failpoint controller with locking, refcounting, and configurable logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
