### PR TITLE
planner: preserve side-effect projections under aggregation | tidb-test=pr/2746

### DIFF
--- a/pkg/planner/core/casetest/rule/BUILD.bazel
+++ b/pkg/planner/core/casetest/rule/BUILD.bazel
@@ -21,7 +21,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 23,
+    shard_count = 24,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/core/casetest/rule/dual_test.go
+++ b/pkg/planner/core/casetest/rule/dual_test.go
@@ -45,3 +45,19 @@ func TestDual(t *testing.T) {
 			"TableDual root  rows:0"))
 	})
 }
+
+func TestCountOverDerivedTablePreservesSideEffects(t *testing.T) {
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		tk.MustExec("use test")
+
+		tk.MustExec("set @str1 = 100")
+		tk.MustQuery("select /* issue:31364 */ count(*) from (select @str1:=200) a").Check(testkit.Rows("1"))
+		tk.MustQuery("show warnings").Check(testkit.Rows())
+		tk.MustQuery("select @str1").Check(testkit.Rows("200"))
+
+		tk.MustExec("set @str1 = 100")
+		tk.MustQuery("select * from (select @str1:=200) a").Check(testkit.Rows("200"))
+		tk.MustQuery("show warnings").Check(testkit.Rows())
+		tk.MustQuery("select @str1").Check(testkit.Rows("200"))
+	})
+}

--- a/pkg/planner/core/rule_aggregation_push_down.go
+++ b/pkg/planner/core/rule_aggregation_push_down.go
@@ -557,18 +557,22 @@ func (a *AggregationPushDownSolver) aggPushDown(p base.LogicalPlan) (_ base.Logi
 				// TODO: This optimization is not always reasonable. We have not supported pushing projection to kv layer yet,
 				// so we must do this optimization.
 				ctx := p.SCtx()
-				noSideEffects := true
+				// The aggregate may not reference every projection expression, for example count(*) over
+				// a derived table. Keep side-effect projections in place so their expressions are executed.
+				noSideEffects := !expression.ExprsHasSideEffects(proj.Exprs)
 				newGbyItems := make([]expression.Expression, 0, len(agg.GroupByItems))
-				for _, gbyItem := range agg.GroupByItems {
-					_, failed, groupBy := expression.ColumnSubstituteImpl(ctx.GetExprCtx(), gbyItem, proj.Schema(), proj.Exprs, true)
-					if failed {
-						noSideEffects = false
-						break
-					}
-					newGbyItems = append(newGbyItems, groupBy)
-					if expression.ExprsHasSideEffects(newGbyItems) {
-						noSideEffects = false
-						break
+				if noSideEffects {
+					for _, gbyItem := range agg.GroupByItems {
+						_, failed, groupBy := expression.ColumnSubstituteImpl(ctx.GetExprCtx(), gbyItem, proj.Schema(), proj.Exprs, true)
+						if failed {
+							noSideEffects = false
+							break
+						}
+						newGbyItems = append(newGbyItems, groupBy)
+						if expression.ExprsHasSideEffects(newGbyItems) {
+							noSideEffects = false
+							break
+						}
 					}
 				}
 				oldAggFuncsArgs := make([][]expression.Expression, 0, len(agg.AggFuncs))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #31364

Problem Summary:

`count(*)` over an expression-only derived table could skip user-variable assignment side effects. For example:

```sql
set @str1 = 100;
select count(*) from (select @str1:=200) a;
select @str1;
```

TiDB returned `@str1 = 100`, while MySQL evaluates the derived projection and returns `@str1 = 200`.

### What changed and how does it work?

Aggregation pushdown can merge `Aggregation -> Projection -> child` into `Aggregation -> child`. The old guard only checked side effects after substituting projection expressions into aggregate arguments and group-by items. For `count(*)`, the aggregate does not reference the derived projection output, so `setvar(str1, 200)` was bypassed.

This PR refuses aggregation-through-projection pushdown when the child projection itself contains side-effect expressions. Ordinary side-effect-free projections still follow the existing optimization path.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that user-variable assignments in derived-table projections could be skipped by aggregation pushdown.
```

### Tests

```bash
go test -tags=intest,deadlock ./pkg/planner/core/casetest/rule -run '^TestCountOverDerivedTablePreservesSideEffects$' -count=1 -v
go test -tags=intest,deadlock ./pkg/planner/core/casetest/rule -run '^(TestCountOverDerivedTablePreservesSideEffects|TestDual)$' -count=1 -v
go test -tags=intest,deadlock ./pkg/planner/core -run '^TestEagerAggregation$' -count=1 -v
git diff --check
make bazel_prepare
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved query optimization logic for aggregation operations to correctly handle and preserve side effects when working with derived tables.

* **Tests**
  * Added test case verifying proper handling of side effects in count aggregate operations with derived table variable assignments.

* **Chores**
  * Updated test infrastructure configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

