### PR TITLE
lightning: preserve worker errors after doImport workerpool release

### DIFF
--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1692,7 +1692,9 @@ func (local *Backend) doImport(
 		// Close the pool, as well as the channel.
 		wctx.Cancel()
 		pool.Release()
-		return nil
+		// The worker may set operator error after jobWg.Wait() is unblocked. Re-check
+		// here to avoid losing worker errors due to cancellation ordering.
+		return wctx.OperatorErr()
 	})
 
 	err := workGroup.Wait()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #47775

Problem Summary:

`doImport` can return `nil` even when a worker has already reported an operator error. During shutdown, `jobWg.Wait()` may unblock before the worker context error is observed by the caller, so the error can be dropped.

### What changed and how does it work?

After `jobWg.Wait()`, `doImport` still cancels the worker context and releases the worker pool, but now it re-reads and returns `wctx.OperatorErr()` from that path. This preserves worker errors that are set around the cancellation/release window and avoids falsely reporting success.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/ingestor/ingestctrl -run TestDoImport -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/ingestor/ingestctrl -run TestDoImport -count=10`
  - `./tools/check/failpoint-go-test.sh pkg/ingestor/ingestctrl -run 'TestDoImport|TestRegionJobResetRetryCounter|TestCtxCancelIsIgnored|TestWorkerFailedWhenGeneratingJobs' -count=1`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling in the import workflow to ensure worker errors are properly reported instead of being missed during processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->