### PR TITLE
*: add skill for critical evaluation of prescribed change instructions

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -17,6 +17,7 @@ Current operational workflow skills:
 - `tidb-test-guidelines`: test placement, naming, writing conventions, and shard_count guidance.
 - `tidb-issue-metadata-guard`: create or update TiDB issues without breaking required templates, labels, or issue metadata conventions.
 - `tidb-pr-metadata-guard`: create or update TiDB PR descriptions without breaking PR title scope conventions, required templates, HTML comments, or bot-parsed checklist sections.
+- `tidb-change-instruction-critic`: evaluate user/reviewer-prescribed code-change instructions critically, compare alternatives, and ask clarification questions before proceeding when risk or ambiguity exists.
 
 Use `AGENTS.md` for repository policy, validation/reporting requirements, and the pre-flight checklist.
 Use `docs/agents/testing-flow.md` for canonical build/test command playbooks.

--- a/.agents/skills/tidb-change-instruction-critic/SKILL.md
+++ b/.agents/skills/tidb-change-instruction-critic/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: tidb-change-instruction-critic
+description: Use when implementing a user- or reviewer-prescribed code change (including review comments with suggested fixes or options), especially when the requested edit may be risky, incomplete, ambiguous, or misaligned with TiDB correctness and compatibility constraints.
+---
+
+# TiDB Change Instruction Critic
+
+## Trigger
+
+Use this skill when:
+
+- The request specifies a concrete implementation direction (for example: "change it this way", "use option B", "just follow this patch idea").
+- The task is to address review comments that include direct fix instructions or multiple solution options.
+- The requested approach might be correct, but the risk or tradeoff is unclear.
+
+## Principle
+
+Treat every implementation instruction as a hypothesis, not a command to apply blindly.
+First validate problem understanding and constraints, then select the safest solution that satisfies the real goal.
+
+## Workflow
+
+1. Decompose the instruction.
+   - Separate `intent` (what problem is being solved), `constraints` (must-have boundaries), and `proposed method` (how to solve it).
+   - Mark each item as either `mandatory` or `negotiable`.
+2. Reconstruct the actual problem before coding.
+   - Locate concrete evidence in code/tests/review context for the defect or concern.
+   - Restate the issue in one or two precise sentences before implementation.
+3. Evaluate solution candidates.
+   - Always evaluate the requested approach.
+   - When feasible, compare with at least one alternative.
+   - Judge by correctness, compatibility, performance, maintenance cost, and validation coverage.
+4. Choose and justify.
+   - Prefer the lowest-risk solution that still satisfies the real intent.
+   - If the requested method is weaker than an alternative, explain why and propose the better option.
+5. Challenge gate before implementation.
+   Ask the user for clarification before coding when any condition holds:
+   - Requirement or review intent is ambiguous or internally conflicting.
+   - Requested change may alter SQL semantics, compatibility, or distributed behavior in non-obvious ways.
+   - Requested change increases blast radius (broad refactor, cross-module behavior shift, fragile workaround).
+   - Validation plan cannot prove safety with scoped tests.
+   Keep questions concise and decision-enabling; do not proceed on assumptions.
+6. Implement after alignment.
+   - Keep diff minimal and focused on agreed intent.
+   - Add or update regression coverage when behavior changes or bugs are fixed.
+   - Report residual risks explicitly if any tradeoff remains.
+
+## Question Patterns
+
+- "The requested fix and current behavior contract conflict on `<constraint>`. Which priority is correct?"
+- "I can implement `<requested approach>` now, but `<alternative>` has lower risk because `<reason>`. Which should we proceed with?"
+- "This change may impact `<scope>`. Should I keep scope limited to `<safe scope>` in this patch?"
+
+## Output Checklist
+
+- Clear problem statement confirmed from evidence.
+- Chosen solution and reason for rejecting alternatives.
+- Any user-confirmed risk decisions captured before coding.
+- Validation scope aligned with change risk.

--- a/.agents/skills/tidb-change-instruction-critic/SKILL.md
+++ b/.agents/skills/tidb-change-instruction-critic/SKILL.md
@@ -16,7 +16,7 @@ Use this skill when:
 ## Principle
 
 Treat every implementation instruction as a hypothesis, not a command to apply blindly.
-First validate problem understanding and constraints, then select the safest solution that satisfies the real goal.
+First validate problem understanding and constraints, then select the solution that best preserves correctness and contract intent; use risk as a secondary filter.
 
 ## Workflow
 
@@ -31,16 +31,19 @@ First validate problem understanding and constraints, then select the safest sol
    - When feasible, compare with at least one alternative.
    - Judge by correctness, compatibility, performance, maintenance cost, and validation coverage.
 4. Choose and justify.
-   - Prefer the lowest-risk solution that still satisfies the real intent.
+   - Prioritize correctness and behavior-contract fit over mechanical risk minimization.
+   - Use lower-risk preference only when multiple candidates satisfy the same contract and intent.
    - If the requested method is weaker than an alternative, explain why and propose the better option.
-5. Challenge gate before implementation.
+5. Share analysis summary before coding.
+   - Provide a short self-analysis summary: reconstructed problem, compared options, chosen solution, and why alternatives were rejected.
+6. Challenge gate before implementation.
    Ask the user for clarification before coding when any condition holds:
    - Requirement or review intent is ambiguous or internally conflicting.
    - Requested change may alter SQL semantics, compatibility, or distributed behavior in non-obvious ways.
    - Requested change increases blast radius (broad refactor, cross-module behavior shift, fragile workaround).
    - Validation plan cannot prove safety with scoped tests.
    Keep questions concise and decision-enabling; do not proceed on assumptions.
-6. Implement after alignment.
+7. Implement after alignment.
    - Keep diff minimal and focused on agreed intent.
    - Add or update regression coverage when behavior changes or bugs are fixed.
    - Report residual risks explicitly if any tradeoff remains.
@@ -48,12 +51,13 @@ First validate problem understanding and constraints, then select the safest sol
 ## Question Patterns
 
 - "The requested fix and current behavior contract conflict on `<constraint>`. Which priority is correct?"
-- "I can implement `<requested approach>` now, but `<alternative>` has lower risk because `<reason>`. Which should we proceed with?"
+- "I can implement `<requested approach>`, but `<alternative>` better matches `<contract>` with acceptable risk. Which should we proceed with?"
 - "This change may impact `<scope>`. Should I keep scope limited to `<safe scope>` in this patch?"
 
 ## Output Checklist
 
 - Clear problem statement confirmed from evidence.
 - Chosen solution and reason for rejecting alternatives.
+- Short self-analysis summary shared before implementation.
 - Any user-confirmed risk decisions captured before coding.
 - Validation scope aligned with change risk.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #63847

Problem Summary:
Add a repo-local skill that forces critical evaluation of prescriptive change instructions (from users or review comments) before implementation, so agents avoid blindly applying potentially risky or ambiguous edits.

### What changed and how does it work?

- Added `.agents/skills/tidb-change-instruction-critic/SKILL.md`.
  - Triggers on user/reviewer-prescribed implementation directions.
  - Requires: problem reconstruction from evidence, requested-solution evaluation, alternative comparison, explicit solution choice, and pre-implementation clarification questions for risky/ambiguous cases.
- Updated `.agents/skills/README.md` to index the new skill.

Evidence for behavior in review-fix scenario:

- During the fix of review discussion https://github.com/pingcap/tidb/pull/68570#discussion_r3285754699, two approaches were explored:
  - Add git pathspec exclusions and keep separate `*_test.go` diff commands (`git diff -U0 -- '*.go' ':(exclude)*_test.go'`) in commit `643eb480b724508daa7ed49e0775f6eeba7b697f`.
  - Remove separate `git diff -U0 -- '*_test.go'` lines (the command pattern referred to as `git diff -U@ -- '*_test.go'` in discussion) and simplify to `git diff -U0 -- '*.go'` in commit `2b4a6073383a4fe51d5c2d77a2a3e94596821bdd`.
- The final selected approach was the simplification (remove dedicated `*_test.go` lines instead of introducing exclude options), consistent with this skill's "evaluate alternatives and choose lower-risk/clearer behavior" rule.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > - Skill/docs-only update under `.agents/skills`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new operational skill that evaluates code-change instructions and flags ambiguous or high-risk items for clarification.
  * Included a detailed workflow, step-by-step guidance, example question patterns, and an output checklist covering problem confirmation, solution rationale, risk notes, and validation scope.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->