### PR TITLE
expression: handle negated min int prepared params

### DIFF
--- a/pkg/expression/builtin_op.go
+++ b/pkg/expression/builtin_op.go
@@ -1022,9 +1022,14 @@ func (c *unaryMinusFunctionClass) getFunction(ctx BuildContext, args []Expressio
 
 	argExpr, argExprTp := args[0], args[0].GetType(ctx.GetEvalCtx())
 	_, intOverflow := c.typeInfer(ctx.GetEvalCtx(), argExpr)
+	argIsParamMarker := false
+	if con, ok := argExpr.(*Constant); ok && con.ParamMarker != nil {
+		argIsParamMarker = true
+	}
 
 	var bf baseBuiltinFunc
 	evalType := argExprTp.EvalType()
+	usesDecimalSig := false
 	switch evalType {
 	case types.ETInt:
 		if intOverflow {
@@ -1032,6 +1037,7 @@ func (c *unaryMinusFunctionClass) getFunction(ctx BuildContext, args []Expressio
 			if err != nil {
 				return nil, err
 			}
+			usesDecimalSig = true
 			sig = &builtinUnaryMinusDecimalSig{bf, true}
 			sig.setPbCode(tipb.ScalarFuncSig_UnaryMinusDecimal)
 		} else {
@@ -1064,6 +1070,7 @@ func (c *unaryMinusFunctionClass) getFunction(ctx BuildContext, args []Expressio
 				return nil, err
 			}
 			bf.tp.SetDecimalUnderLimit(argExprTp.GetDecimal())
+			usesDecimalSig = true
 			sig = &builtinUnaryMinusDecimalSig{bf, false}
 			sig.setPbCode(tipb.ScalarFuncSig_UnaryMinusDecimal)
 		} else {
@@ -1075,7 +1082,16 @@ func (c *unaryMinusFunctionClass) getFunction(ctx BuildContext, args []Expressio
 			sig.setPbCode(tipb.ScalarFuncSig_UnaryMinusReal)
 		}
 	}
-	bf.tp.SetFlenUnderLimit(argExprTp.GetFlen() + 1)
+	if usesDecimalSig &&
+		argIsParamMarker &&
+		argExprTp.GetFlen() < mysql.MaxIntWidth+1 {
+		// Execute-time parameters can need one more digit after negation,
+		// for example -(-9223372036854775808). Keep the inferred decimal
+		// width large enough for callers.
+		bf.tp.SetFlen(mysql.MaxIntWidth + 1)
+	} else {
+		bf.tp.SetFlenUnderLimit(argExprTp.GetFlen() + 1)
+	}
 	return sig, err
 }
 

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -4207,6 +4207,22 @@ func TestIssue16205(t *testing.T) {
 	require.NotEqual(t, rows1[0][0].(string), rows2[0][0].(string))
 }
 
+func TestPreparedCeilFloorWithUnaryMinusMinInt(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set @a = -9223372036854775808")
+	expectedRows := testkit.Rows("9223372036854775808")
+
+	for _, fn := range []string{"ceiling", "floor"} {
+		// Parameter width is unknown at prepare time, but -MinInt64 needs
+		// decimal output.
+		tk.MustExec(fmt.Sprintf("prepare stmt from 'select %s((- (?)))'", fn))
+		tk.MustQuery("execute stmt using @a").Check(expectedRows)
+		tk.MustExec("deallocate prepare stmt")
+	}
+}
+
 func calculateChecksum(cols ...any) string {
 	buf := make([]byte, 0, 64)
 	for _, col := range cols {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63899

Problem Summary:

A prepared statement can fail with `ERROR 1690` when `CEILING` or `FLOOR` wraps a unary minus over a parameter whose execute-time value is `-9223372036854775808`:

```sql
SET @a = -9223372036854775808;
PREPARE prepare_query FROM 'SELECT CEILING((- (?)))';
EXECUTE prepare_query USING @a;
```

The literal equivalent returns `9223372036854775808`, and `-(?)` itself also evaluates to the decimal value `9223372036854775808`. The failure happens because the decimal unary-minus result over a parameter marker kept the prepare-time placeholder width, so outer `CEILING` / `FLOOR` could choose an integer return signature and overflow at execution time.

### What changed and how does it work?

This PR keeps decimal unary-minus results over parameter markers wide enough for execute-time values that need one more digit after negation, such as `-(-9223372036854775808)`.

The change is limited to expression type metadata for unary minus over parameter markers. It does not change global overflow policy, prepared-statement framework behavior, stats/analyze behavior, or unrelated expression cleanup.

A regression test covers prepared `CEILING((- (?)))` and `FLOOR((- (?)))` with `@a = -9223372036854775808`.

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Manual test:

```bash
go build -o /tmp/tidb-63899-server ./cmd/tidb-server
mysql --force --table -h 127.0.0.1 -P 4003 -uroot < .agenthubmemory/artifacts/issue-63899/replay_63899.sql
mysql --force --table -h 127.0.0.1 -P 4003 -uroot < .agenthubmemory/artifacts/issue-63899/probe_63899.sql
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix an overflow error when executing prepared statements that apply `CEILING` or `FLOOR` to a negated minimum BIGINT parameter.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CEILING and FLOOR functions to correctly handle prepared statements when operating on negative large integer values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->