### PR TITLE
expression: fix ELT result length with NULL params

### DIFF
--- a/pkg/expression/builtin_string.go
+++ b/pkg/expression/builtin_string.go
@@ -3316,6 +3316,9 @@ func (c *eltFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 		if types.IsBinaryStr(argType) {
 			types.SetBinChsClnFlag(bf.tp)
 		}
+		if argType.GetType() == mysql.TypeNull {
+			continue
+		}
 		flen := argType.GetFlen()
 		if flen == types.UnspecifiedLength || flen > bf.tp.GetFlen() {
 			bf.tp.SetFlen(argType.GetFlen())

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -947,6 +947,17 @@ ORDER BY t1.a, t2.a, t3.a, var`
 		tk.MustQuery("SELECT /* issue:66706 */ ref0 FROM (SELECT v0.c0 AS ref0, SIGN(v0.c0) AS ref1 FROM v0) AS s WHERE ref1").Check(testkit.Rows("0.99"))
 		tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows())
 	})
+
+	// issue-63900-elt-prepared-null-param
+	{
+		tk := prepareSharedTestKit(t)
+		tk.MustQuery("select /* issue:63900 */ 1 where elt(1, 1, 'a', null)").Check(testkit.Rows("1"))
+		tk.MustExec("set @d = 'a'")
+		tk.MustExec("set @e = null")
+		tk.MustExec(`prepare prepare_query from "select 1 where elt(1, 1, ?, ?)"`)
+		tk.MustQuery("execute prepare_query using @d, @e").Check(testkit.Rows("1"))
+		tk.MustExec("deallocate prepare prepare_query")
+	}
 }
 
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63900

Problem Summary:

Prepared `ELT(1, 1, ?, ?)` could return no rows when a later parameter was `NULL`, even though the equivalent literal and user-variable forms returned `1`. The prepared path inferred the `ELT` return length from a `NULL` parameter marker with `flen = 0`, so deferred predicate evaluation truncated the actual result before truth evaluation.

### What changed and how does it work?

Skip `TypeNull` arguments when deriving the maximum return length for `ELT`. A `NULL` branch does not contribute an actual string value length, and it should not overwrite the usable length inferred from other value arguments.

The regression is added to the existing planner issue suite and keeps the fix scoped to expression type inference for `ELT`.

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [x] Manual test
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Manual and focused validation:

- `go test -tags=intest,deadlock ./pkg/planner/core/issuetest -run TestPlannerIssueRegressions -count=1`
- `./tools/check/failpoint-go-test.sh pkg/expression -run TestElt -count=1`
- `git diff --check`
- `make lint`
- `go build -o bin/tidb-server ./cmd/tidb-server`
- Manual before/after replay of the exact `ELT(1, 1, ?, ?)` prepared statement.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that prepared ELT expressions with NULL parameters could return empty results unexpectedly.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ELT function to correctly handle NULL parameters in prepared statements.

* **Tests**
  * Added regression test for ELT function with NULL parameter handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->