### PR TITLE
br: use configured prefix for S3 permission check

### DIFF
--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -624,9 +624,10 @@ func listObjectsCheck(ctx context.Context, svc S3API, qs *backuppb.S3) error {
 
 // getObjectCheck checks the permission of getObject
 func getObjectCheck(ctx context.Context, svc S3API, qs *backuppb.S3) error {
+	key := genPermCheckObjectKey()
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(qs.Bucket),
-		Key:    aws.String("not-exists"),
+		Key:    aws.String(qs.Prefix + key),
 	}
 	_, err := svc.GetObject(ctx, input)
 	var aerr smithy.APIError
@@ -640,6 +641,11 @@ func getObjectCheck(ctx context.Context, svc S3API, qs *backuppb.S3) error {
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+// genPermCheckObjectKey generates a unique object key for permission checking.
+func genPermCheckObjectKey() string {
+	return path.Join("perm-check", uuid.New().String())
 }
 
 // PutAndDeleteObjectCheck checks the permission of putObject

--- a/br/pkg/storage/s3_test.go
+++ b/br/pkg/storage/s3_test.go
@@ -419,6 +419,50 @@ func TestS3Storage(t *testing.T) {
 	for i := range tests {
 		testFn(&tests[i], t)
 	}
+
+	t.Run("get object permission check uses configured prefix", func(t *testing.T) {
+		var (
+			mu    sync.Mutex
+			paths []string
+		)
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			paths = append(paths, r.URL.Path)
+			mu.Unlock()
+
+			w.Header().Set(bucketRegionHeader, "us-west-2")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer s.Close()
+
+		_, err := New(context.Background(), &backuppb.StorageBackend{
+			Backend: &backuppb.StorageBackend_S3{
+				S3: &backuppb.S3{
+					Region:         "",
+					Endpoint:       s.URL,
+					Bucket:         "bucket",
+					Prefix:         "prefix",
+					ForcePathStyle: true,
+				},
+			},
+		}, &ExternalStorageOptions{
+			SendCredentials:  true,
+			CheckPermissions: []Permission{GetObject},
+		})
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		var getObjectPath string
+		for _, p := range paths {
+			if strings.Contains(p, "perm-check") || strings.Contains(p, "not-exists") {
+				getObjectPath = p
+				break
+			}
+		}
+		require.NotEmpty(t, getObjectPath, "recorded paths: %v", paths)
+		require.True(t, strings.HasPrefix(getObjectPath, "/bucket/prefix/perm-check/"), "recorded paths: %v", paths)
+	})
 }
 
 func TestS3URI(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68583

Problem Summary:

The S3 `GetObject` permission check probes the hard-coded bucket-root key `not-exists`. This fails for credentials that are intentionally scoped to the configured BR prefix.

### What changed and how does it work?

The S3 permission check now generates a `perm-check/<uuid>` key and checks it under the configured S3 prefix, matching the main branch behavior while keeping the release-8.5 patch local to the existing storage code.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a BR S3 permission check issue where prefix-scoped credentials could fail because the GetObject probe used a bucket-root key.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 permission checking reliability by generating unique object keys for testing instead of using fixed identifiers, reducing false error detection.

* **Tests**
  * Added test coverage for S3 permission checks to verify proper prefix handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->