### PR TITLE
planner: simplify null-safe equality predicates

### DIFF
--- a/pkg/planner/core/casetest/rule/testdata/predicate_simplification_in.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_simplification_in.json
@@ -7,6 +7,8 @@
       "select * from (select col_47 from t7c899916 limit 1) t where col_47 in ('2034-05-27', '2001-06-27') and col_47 in (null, '1996-06-27');",
       "with cte_263 ( col_1350,col_1351,col_1352 ) AS ( select /*+ read_from_storage(tiflash[ tad03b424,tlfdfece63 ]) */ /*+ use_index_merge( tlfdfece63,tad03b424 ) */ /*+ merge_join( tlfdfece63 , tad03b424 */ rpad( tad03b424.col_44 , 6 , tad03b424.col_48 ) as r0 , insert( tlfdfece63.col_44 , 0 , 10 , tlfdfece63.col_43 ) as r1 , tad03b424.col_41 as r2 from tlfdfece63 , tad03b424 where not( tlfdfece63.col_42 = '[\"Sl9DRlDnSdIOxbfequ02VeikDWiphuDO6suBf0F7esJeCWrRJWQbd3BK3vT58Coz\",\"MmC5saHdTUqosY50IrxprAR52oD08XgGhqJCcYeoaDJKrYxBdbi0QuVDDArCghyL\"]' ) order by r0,r1,r2 limit 348170821 ) ( select 1,col_1350,col_1351,col_1352 from cte_263 where not( cte_263.col_1352 != '2020-06-30' ) and cte_263.col_1352 in ( null ,'1983-08-09' ) order by 1,2,3,4  );",
       "select * from t6 where  (a, b, c) in ((1, 1, 1), (2, 2, 2))",
+      "select /* issue:63741 */ * from t6 where (a = b) or (a is null and b is null)",
+      "select /* issue:63741 */ * from t6 where (b is null and a is null) or (b = a)",
       "SELECT column_1, column_2, column_3, column_4, column_5, column_6 FROM ISSUE64263 WHERE column_3 = 'M 5 9 2 9 2 5 4 6 8 4 9' AND (column_2 IN (1) OR column_4 = 121092106) ORDER BY column_6 DESC, column_1 DESC LIMIT 1000;",
       "SELECT STRAIGHT_JOIN * FROM t1 LEFT JOIN t0 ON t1.a = t0.a WHERE t1.a = t0.a OR t1.a = t0.b;"
     ]

--- a/pkg/planner/core/casetest/rule/testdata/predicate_simplification_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_simplification_out.json
@@ -96,6 +96,30 @@
         "Warning": null
       },
       {
+        "SQL": "select /* issue:63741 */ * from t6 where (a = b) or (a is null and b is null)",
+        "Plan": [
+          "TableReader root  data:Selection",
+          "└─Selection cop[tikv]  nulleq(test.t6.a, test.t6.b)",
+          "  └─TableFullScan cop[tikv] table:t6 keep order:false, stats:pseudo"
+        ],
+        "LastPlanFromCache": [
+          "1"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "select /* issue:63741 */ * from t6 where (b is null and a is null) or (b = a)",
+        "Plan": [
+          "TableReader root  data:Selection",
+          "└─Selection cop[tikv]  nulleq(test.t6.b, test.t6.a)",
+          "  └─TableFullScan cop[tikv] table:t6 keep order:false, stats:pseudo"
+        ],
+        "LastPlanFromCache": [
+          "1"
+        ],
+        "Warning": null
+      },
+      {
         "SQL": "SELECT column_1, column_2, column_3, column_4, column_5, column_6 FROM ISSUE64263 WHERE column_3 = 'M 5 9 2 9 2 5 4 6 8 4 9' AND (column_2 IN (1) OR column_4 = 121092106) ORDER BY column_6 DESC, column_1 DESC LIMIT 1000;",
         "Plan": [
           "TopN root  test.issue64263.column_6:desc, test.issue64263.column_1:desc, offset:0, count:1000",

--- a/pkg/planner/core/casetest/rule/testdata/predicate_simplification_xut.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_simplification_xut.json
@@ -96,6 +96,30 @@
         "Warning": null
       },
       {
+        "SQL": "select /* issue:63741 */ * from t6 where (a = b) or (a is null and b is null)",
+        "Plan": [
+          "TableReader root  data:Selection",
+          "└─Selection cop[tikv]  nulleq(test.t6.a, test.t6.b)",
+          "  └─TableFullScan cop[tikv] table:t6 keep order:false, stats:pseudo"
+        ],
+        "LastPlanFromCache": [
+          "1"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "select /* issue:63741 */ * from t6 where (b is null and a is null) or (b = a)",
+        "Plan": [
+          "TableReader root  data:Selection",
+          "└─Selection cop[tikv]  nulleq(test.t6.b, test.t6.a)",
+          "  └─TableFullScan cop[tikv] table:t6 keep order:false, stats:pseudo"
+        ],
+        "LastPlanFromCache": [
+          "1"
+        ],
+        "Warning": null
+      },
+      {
         "SQL": "SELECT column_1, column_2, column_3, column_4, column_5, column_6 FROM ISSUE64263 WHERE column_3 = 'M 5 9 2 9 2 5 4 6 8 4 9' AND (column_2 IN (1) OR column_4 = 121092106) ORDER BY column_6 DESC, column_1 DESC LIMIT 1000;",
         "Plan": [
           "TopN root  test.issue64263.column_6:desc, test.issue64263.column_1:desc, offset:0, count:1000",

--- a/pkg/planner/core/rule/rule_predicate_simplification.go
+++ b/pkg/planner/core/rule/rule_predicate_simplification.go
@@ -223,6 +223,7 @@ func applyPredicateSimplificationHelper(sctx base.PlanContext, predicates []expr
 		}
 	}
 	simplifiedPredicate = shortCircuitLogicalConstants(sctx, simplifiedPredicate)
+	simplifiedPredicate = simplifyNullSafeEqualPredicates(sctx, simplifiedPredicate)
 	simplifiedPredicate = mergeInAndNotEQLists(sctx, simplifiedPredicate)
 	removeRedundantORBranch(sctx, simplifiedPredicate)
 	simplifiedPredicate = pruneEmptyORBranches(sctx, simplifiedPredicate)
@@ -548,6 +549,118 @@ func shortCircuitLogicalConstants(sctx base.PlanContext, predicates []expression
 	}
 
 	return finalResult
+}
+
+func simplifyNullSafeEqualPredicates(sctx base.PlanContext, predicates []expression.Expression) []expression.Expression {
+	for i, predicate := range predicates {
+		predicates[i] = simplifyNullSafeEqualPredicate(sctx, predicate)
+	}
+	return predicates
+}
+
+func simplifyNullSafeEqualPredicate(sctx base.PlanContext, predicate expression.Expression) expression.Expression {
+	sf, ok := predicate.(*expression.ScalarFunction)
+	if !ok {
+		return predicate
+	}
+
+	switch sf.FuncName.L {
+	case ast.LogicOr:
+		nullSafeEqual, rewritten := buildNullSafeEqualFromOR(sctx, sf)
+		if !rewritten {
+			return predicate
+		}
+		if expression.MaybeOverOptimized4PlanCache(sctx.GetExprCtx(), predicate) {
+			sctx.GetSessionVars().StmtCtx.SetSkipPlanCache("null-safe equality predicate simplification is triggered")
+		}
+		return nullSafeEqual
+	case ast.LogicAnd:
+		cnfItems := expression.SplitCNFItems(sf)
+		rewritten := false
+		evalCtx := sctx.GetExprCtx().GetEvalCtx()
+		for i, item := range cnfItems {
+			newItem := simplifyNullSafeEqualPredicate(sctx, item)
+			if !newItem.Equal(evalCtx, item) {
+				cnfItems[i] = newItem
+				rewritten = true
+			}
+		}
+		if rewritten {
+			return expression.ComposeCNFCondition(sctx.GetExprCtx(), cnfItems...)
+		}
+	}
+
+	return predicate
+}
+
+func buildNullSafeEqualFromOR(sctx base.PlanContext, orFunc *expression.ScalarFunction) (expression.Expression, bool) {
+	dnfItems := expression.SplitDNFItems(orFunc)
+	if len(dnfItems) != 2 {
+		return nil, false
+	}
+
+	if nullSafeEqual, ok := buildNullSafeEqualFromItems(sctx, dnfItems[0], dnfItems[1]); ok {
+		return nullSafeEqual, true
+	}
+	return buildNullSafeEqualFromItems(sctx, dnfItems[1], dnfItems[0])
+}
+
+func buildNullSafeEqualFromItems(sctx base.PlanContext, equalItem, nullItem expression.Expression) (expression.Expression, bool) {
+	equalFunc, ok := equalItem.(*expression.ScalarFunction)
+	if !ok || equalFunc.FuncName.L != ast.EQ {
+		return nil, false
+	}
+	args := equalFunc.GetArgs()
+	if len(args) != 2 || expression.IsMutableEffectsExpr(args[0]) || expression.IsMutableEffectsExpr(args[1]) {
+		return nil, false
+	}
+	if _, ok := args[0].(*expression.Column); !ok {
+		return nil, false
+	}
+	if _, ok := args[1].(*expression.Column); !ok {
+		return nil, false
+	}
+
+	nullArgs, ok := extractIsNullArgs(nullItem)
+	if !ok {
+		return nil, false
+	}
+	evalCtx := sctx.GetExprCtx().GetEvalCtx()
+	matched := args[0].Equal(evalCtx, nullArgs[0]) && args[1].Equal(evalCtx, nullArgs[1])
+	matched = matched || args[0].Equal(evalCtx, nullArgs[1]) && args[1].Equal(evalCtx, nullArgs[0])
+	if !matched {
+		return nil, false
+	}
+
+	nullSafeEqual, err := expression.NewFunction(sctx.GetExprCtx(), ast.NullEQ, types.NewFieldType(mysql.TypeTiny), args...)
+	if err != nil {
+		return nil, false
+	}
+	return nullSafeEqual, true
+}
+
+func extractIsNullArgs(nullItem expression.Expression) ([2]expression.Expression, bool) {
+	cnfItems := expression.SplitCNFItems(nullItem)
+	var nullArgs [2]expression.Expression
+	if len(cnfItems) != len(nullArgs) {
+		return nullArgs, false
+	}
+
+	for i, item := range cnfItems {
+		isNullFunc, ok := item.(*expression.ScalarFunction)
+		if !ok || isNullFunc.FuncName.L != ast.IsNull || len(isNullFunc.GetArgs()) != 1 {
+			return nullArgs, false
+		}
+		nullArg := isNullFunc.GetArgs()[0]
+		if expression.IsMutableEffectsExpr(nullArg) {
+			return nullArgs, false
+		}
+		if _, ok := nullArg.(*expression.Column); !ok {
+			return nullArgs, false
+		}
+		nullArgs[i] = nullArg
+	}
+	return nullArgs, true
 }
 
 // removeRedundantORBranch recursively iterates over a list of predicates, try to find OR lists and remove redundant in


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63741

Problem Summary:

TiDB does not simplify `(i = j) OR (i IS NULL AND j IS NULL)` into the equivalent null-safe equality predicate `i <=> j`. The unsimplified predicate remains as a compound `OR` selection in both the default planner and cascades test output.

### What changed and how does it work?

This PR adds a narrow predicate simplification rule for the column-column pattern:

- `(col1 = col2) OR (col1 IS NULL AND col2 IS NULL)` -> `col1 <=> col2`
- The rewrite also handles the reversed `OR` branch order and reversed `IS NULL` argument order.
- The first implementation is intentionally limited to column-column equality, and skips mutable-effect expressions.
- The existing plan-cache guard is preserved when the rewrite is triggered.

Regression coverage is added to the predicate simplification rule casetest outputs for both default and cascades paths.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Commands:

- `./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/rule -run TestPredicateSimplification -count=1`
- `git diff --check origin/master...HEAD`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that TiDB does not simplify a null-safe equality pattern into the `<=>` predicate.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query optimizer handling of predicates combining equality checks with NULL value conditions. The query planner now detects and simplifies expressions like `(a = b) OR (a IS NULL AND b IS NULL)` into null-safe equality operations, enabling more efficient query execution and reducing execution time for affected queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->