### PR TITLE
release-8.5: backport #66290 | tidb-test=release-8.5-20251125-v8.5.4

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -5854,13 +5854,13 @@ def go_deps():
         name = "com_github_pingcap_tipb",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/pingcap/tipb",
-        sha256 = "1b707429b5b938a05b250b5770be2a6aa243d6a4983d23b01bbca164e86b3e3c",
-        strip_prefix = "github.com/pingcap/tipb@v0.0.0-20241022082558-0607513e7fa4",
+        sha256 = "a1f1f8523c7a8f788e73fed28c2accee002f0c5c502fdbed257eb6a42810e784",
+        strip_prefix = "github.com/pingcap/tipb@v0.0.0-20260522023117-6ceadabb61de",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20241022082558-0607513e7fa4.zip",
-            "http://ats.apps.svc/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20241022082558-0607513e7fa4.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20241022082558-0607513e7fa4.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20241022082558-0607513e7fa4.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20260522023117-6ceadabb61de.zip",
+            "http://ats.apps.svc/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20260522023117-6ceadabb61de.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20260522023117-6ceadabb61de.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20260522023117-6ceadabb61de.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9
 	github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20211011031125-9b13dc409c5e
-	github.com/pingcap/tipb v0.0.0-20241022082558-0607513e7fa4
+	github.com/pingcap/tipb v0.0.0-20260522023117-6ceadabb61de
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -682,6 +682,8 @@ github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5 h1:T4pXRhBflzDeA
 github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5/go.mod h1:rlimy0GcTvjiJqvD5mXTRr8O2eNZPBrcUgiWVYp9530=
 github.com/pingcap/tipb v0.0.0-20241022082558-0607513e7fa4 h1:wvaUybJT0fUReCDcFtV3CEvMuI9iu+G7IW72tbSlil4=
 github.com/pingcap/tipb v0.0.0-20241022082558-0607513e7fa4/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
+github.com/pingcap/tipb v0.0.0-20260522023117-6ceadabb61de h1:zZNGJcObLgFvuOF9CPviXomIN9QGAEDj9w9SUGp3s64=
+github.com/pingcap/tipb v0.0.0-20260522023117-6ceadabb61de/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/go.sum
+++ b/go.sum
@@ -680,8 +680,6 @@ github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGa
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9/go.mod h1:ORfBOFp1eteu2odzsyaxI+b8TzJwgjwyQcGhI+9SfEA=
 github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5 h1:T4pXRhBflzDeAhmOQHNPRRogMYxP13V7BkYw3ZsoSfE=
 github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5/go.mod h1:rlimy0GcTvjiJqvD5mXTRr8O2eNZPBrcUgiWVYp9530=
-github.com/pingcap/tipb v0.0.0-20241022082558-0607513e7fa4 h1:wvaUybJT0fUReCDcFtV3CEvMuI9iu+G7IW72tbSlil4=
-github.com/pingcap/tipb v0.0.0-20241022082558-0607513e7fa4/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pingcap/tipb v0.0.0-20260522023117-6ceadabb61de h1:zZNGJcObLgFvuOF9CPviXomIN9QGAEDj9w9SUGp3s64=
 github.com/pingcap/tipb v0.0.0-20260522023117-6ceadabb61de/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -2191,13 +2191,13 @@ func (a *ExecStmt) observeStmtBeginForTopSQL(ctx context.Context) context.Contex
 		}
 		// Always attach the SQL and plan info uses to catch the running SQL when Top SQL is enabled in execution.
 		if stats != nil {
-			stats.OnExecutionBegin(sqlDigestByte, planDigestByte)
+			stats.OnExecutionBegin(sqlDigestByte, planDigestByte, vars.InPacketBytes.Load())
 		}
 		return topsql.AttachSQLAndPlanInfo(ctx, sqlDigest, planDigest)
 	}
 
 	if stats != nil {
-		stats.OnExecutionBegin(sqlDigestByte, planDigestByte)
+		stats.OnExecutionBegin(sqlDigestByte, planDigestByte, vars.InPacketBytes.Load())
 		// This is a special logic prepared for TiKV's SQLExecCount.
 		sc.KvExecCounter = stats.CreateKvExecCounter(sqlDigestByte, planDigestByte)
 	}
@@ -2222,7 +2222,7 @@ func (a *ExecStmt) observeStmtFinishedForTopSQL() {
 	if stats := a.Ctx.GetStmtStats(); stats != nil && topsqlstate.TopSQLEnabled() {
 		sqlDigest, planDigest := a.getSQLPlanDigest()
 		execDuration := vars.GetTotalCostDuration()
-		stats.OnExecutionFinished(sqlDigest, planDigest, execDuration)
+		stats.OnExecutionFinished(sqlDigest, planDigest, execDuration, vars.OutPacketBytes.Load())
 	}
 }
 

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -486,7 +486,11 @@ func (cc *clientConn) readPacket() ([]byte, error) {
 	if cc.getCtx() != nil {
 		cc.pkt.SetMaxAllowedPacket(cc.ctx.GetSessionVars().MaxAllowedPacket)
 	}
-	return cc.pkt.ReadPacket()
+	data, err := cc.pkt.ReadPacket()
+	if err == nil && cc.getCtx() != nil {
+		cc.ctx.GetSessionVars().InPacketBytes.Add(uint64(len(data)))
+	}
+	return data, err
 }
 
 func (cc *clientConn) writePacket(data []byte) error {
@@ -495,6 +499,9 @@ func (cc *clientConn) writePacket(data []byte) error {
 			failpoint.Return(nil)
 		}
 	})
+	if cc.getCtx() != nil {
+		cc.ctx.GetSessionVars().OutPacketBytes.Add(uint64(len(data)))
+	}
 	return cc.pkt.WritePacket(data)
 }
 
@@ -1275,6 +1282,8 @@ func (cc *clientConn) dispatch(ctx context.Context, data []byte) error {
 	defer func() {
 		// reset killed for each request
 		cc.ctx.GetSessionVars().SQLKiller.Reset()
+		cc.ctx.GetSessionVars().InPacketBytes.Store(0)
+		cc.ctx.GetSessionVars().OutPacketBytes.Store(0)
 	}()
 	t := time.Now()
 	if (cc.ctx.Status() & mysql.ServerStatusInTrans) > 0 {

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1720,6 +1720,12 @@ type SessionVars struct {
 
 	// InternalSQLScanUserTable indicates whether to use user table for internal SQL. it will be used by TTL scan
 	InternalSQLScanUserTable bool
+
+	// InPacketBytes records the total incoming packet bytes from clients for current session.
+	InPacketBytes atomic.Uint64
+
+	// OutPacketBytes records the total outcoming packet bytes to clients for current session.
+	OutPacketBytes atomic.Uint64
 }
 
 // GetSessionVars implements the `SessionVarsProvider` interface.

--- a/pkg/util/topsql/reporter/BUILD.bazel
+++ b/pkg/util/topsql/reporter/BUILD.bazel
@@ -45,7 +45,7 @@ go_test(
     ],
     embed = [":reporter"],
     flaky = True,
-    shard_count = 36,
+    shard_count = 37,
     deps = [
         "//pkg/config",
         "//pkg/testkit/testsetup",

--- a/pkg/util/topsql/reporter/reporter.go
+++ b/pkg/util/topsql/reporter/reporter.go
@@ -25,6 +25,7 @@ import (
 	reporter_metrics "github.com/pingcap/tidb/pkg/util/topsql/reporter/metrics"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
 	"github.com/pingcap/tidb/pkg/util/topsql/stmtstats"
+	"github.com/wangjohn/quickselect"
 	"go.uber.org/zap"
 )
 
@@ -233,18 +234,60 @@ func (tsr *RemoteTopSQLReporter) processCPUTimeData(timestamp uint64, data cpuRe
 func (tsr *RemoteTopSQLReporter) processStmtStatsData() {
 	defer util.Recover("top-sql", "processStmtStatsData", nil, false)
 
+	maxLen := 0
+	for _, data := range tsr.stmtStatsBuffer {
+		maxLen = max(maxLen, len(data))
+	}
+	u64Slice := make([]uint64, 0, maxLen)
+	k := int(topsqlstate.GlobalState.MaxStatementCount.Load())
 	for timestamp, data := range tsr.stmtStatsBuffer {
+		kthNetworkBytes := findKthNetworkBytes(data, k, u64Slice)
 		for digest, item := range data {
 			sqlDigest, planDigest := []byte(digest.SQLDigest), []byte(digest.PlanDigest)
-			if tsr.collecting.hasEvicted(timestamp, sqlDigest, planDigest) {
-				// This timestamp+sql+plan has been evicted due to low CPUTime.
+			// Note, by filtering with the kthNetworkBytes, we get fewer than N records(N - 1 records, at most time). The actual picked records
+			// count is decided by the count of duplicated kthNetworkBytes，if kthNetworkBytes is unique,
+			// For performance reason, do not convert the whole map into a slice and pick exactly topN records.
+			if item.NetworkInBytes+item.NetworkOutBytes > kthNetworkBytes || !tsr.collecting.hasEvicted(timestamp, sqlDigest, planDigest) {
+				tsr.collecting.getOrCreateRecord(sqlDigest, planDigest).appendStmtStatsItem(timestamp, *item)
+			} else {
 				tsr.collecting.appendOthersStmtStatsItem(timestamp, *item)
-				continue
 			}
-			tsr.collecting.getOrCreateRecord(sqlDigest, planDigest).appendStmtStatsItem(timestamp, *item)
 		}
 	}
 	tsr.stmtStatsBuffer = map[uint64]stmtstats.StatementStatsMap{}
+}
+
+// The uint64Slice type attaches the QuickSelect interface to an array of uint64s. It
+// implements Interface so that you can call QuickSelect(k) on any IntSlice.
+type uint64Slice []uint64
+
+func (t uint64Slice) Len() int {
+	return len(t)
+}
+
+func (t uint64Slice) Less(i, j int) bool {
+	return t[i] > t[j]
+}
+
+func (t uint64Slice) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}
+
+// findKthNetworkBytes finds the k-th largest network bytes in data using quickselect algorithm.
+func findKthNetworkBytes(data stmtstats.StatementStatsMap, k int, u64Slice []uint64) uint64 {
+	var kthNetworkBytes uint64
+	if len(data) > k {
+		u64Slice = u64Slice[:0]
+		for _, item := range data {
+			u64Slice = append(u64Slice, item.NetworkInBytes+item.NetworkOutBytes)
+		}
+		_ = quickselect.QuickSelect(uint64Slice(u64Slice), k)
+		kthNetworkBytes = u64Slice[0]
+		for i := range k {
+			kthNetworkBytes = min(kthNetworkBytes, u64Slice[i])
+		}
+	}
+	return kthNetworkBytes
 }
 
 // takeDataAndSendToReportChan takes records data and then send to the report channel for reporting.

--- a/pkg/util/topsql/reporter/reporter_test.go
+++ b/pkg/util/topsql/reporter/reporter_test.go
@@ -15,6 +15,7 @@
 package reporter
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -518,6 +519,188 @@ func TestReporterWorker(t *testing.T) {
 	assert.Len(t, data.DataRecords, 1)
 	assert.Equal(t, []byte("S1"), data.DataRecords[0].SqlDigest)
 	assert.Equal(t, []byte("P1"), data.DataRecords[0].PlanDigest)
+}
+
+func TestProcessStmtStatsData(t *testing.T) {
+	topsqlstate.GlobalState.ReportIntervalSeconds.Store(3)
+	topsqlstate.GlobalState.MaxStatementCount.Store(3)
+
+	r := NewRemoteTopSQLReporter(mockPlanBinaryDecoderFunc, mockPlanBinaryCompressFunc)
+	r.Start()
+	defer r.Close()
+
+	ch := make(chan *ReportData, 1)
+	ds := newMockDataSink(ch)
+	err := r.Register(ds)
+	assert.NoError(t, err)
+
+	r.Collect(nil)
+	r.Collect([]collector.SQLCPUTimeRecord{
+		{
+			SQLDigest:  []byte("S1"),
+			PlanDigest: []byte("P1"),
+			CPUTimeMs:  1,
+		},
+		{
+			SQLDigest:  []byte("S2"),
+			PlanDigest: []byte("P2"),
+			CPUTimeMs:  2,
+		},
+	})
+	r.CollectStmtStatsMap(nil)
+	r.CollectStmtStatsMap(stmtstats.StatementStatsMap{
+		stmtstats.SQLPlanDigest{
+			SQLDigest:  "S1",
+			PlanDigest: "P1",
+		}: &stmtstats.StatementStatsItem{
+			ExecCount:       1,
+			NetworkInBytes:  1,
+			NetworkOutBytes: 0,
+		},
+		stmtstats.SQLPlanDigest{
+			SQLDigest:  "S2",
+			PlanDigest: "P2",
+		}: &stmtstats.StatementStatsItem{
+			ExecCount:       2,
+			NetworkInBytes:  0,
+			NetworkOutBytes: 2,
+		},
+		stmtstats.SQLPlanDigest{
+			SQLDigest:  "S3",
+			PlanDigest: "P3",
+		}: &stmtstats.StatementStatsItem{
+			ExecCount:       3,
+			NetworkInBytes:  1,
+			NetworkOutBytes: 2,
+		},
+	})
+
+	var data *ReportData
+	select {
+	case data = <-ch:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "no data in ch")
+	}
+
+	assert.Len(t, data.DataRecords, 3)
+	sort.Slice(data.DataRecords, func(i, j int) bool {
+		return data.DataRecords[i].Items[0].StmtNetworkInBytes+data.DataRecords[i].Items[0].StmtNetworkOutBytes <
+			data.DataRecords[j].Items[0].StmtNetworkInBytes+data.DataRecords[j].Items[0].StmtNetworkOutBytes
+	})
+	// Check Si, Pi and corresponding item value i.
+	for i, record := range data.DataRecords {
+		j := i + 1
+		assert.Equal(t, []byte(fmt.Sprintf("S%d", j)), record.SqlDigest)
+		assert.Equal(t, []byte(fmt.Sprintf("P%d", j)), record.PlanDigest)
+		assert.Equal(t, uint64(j), record.Items[0].StmtNetworkInBytes+record.Items[0].StmtNetworkOutBytes)
+	}
+	// S3, P3 has no recorded CPU time data, so the CpuTimeMs is 0.
+	assert.Equal(t, uint32(0), data.DataRecords[2].Items[0].CpuTimeMs)
+
+	// Check cases with others and evicted
+	r.Collect(nil)
+	// S1/P1 and S4/P4 will be evicted since MaxStatementCount is 3 and its cputime is the lowest.
+	r.Collect([]collector.SQLCPUTimeRecord{
+		{
+			SQLDigest:  []byte("S1"),
+			PlanDigest: []byte("P1"),
+			CPUTimeMs:  1,
+		},
+		{
+			SQLDigest:  []byte("S2"),
+			PlanDigest: []byte("P2"),
+			CPUTimeMs:  2,
+		},
+		{
+			SQLDigest:  []byte("S3"),
+			PlanDigest: []byte("P3"),
+			CPUTimeMs:  3,
+		},
+		{
+			SQLDigest:  []byte("S4"),
+			PlanDigest: []byte("P4"),
+			CPUTimeMs:  0,
+		},
+		{
+			SQLDigest:  []byte("S7"),
+			PlanDigest: []byte("P7"),
+			CPUTimeMs:  7,
+		},
+	})
+	r.CollectStmtStatsMap(nil)
+	// S1/P1 and S7/P7 will be picked from network dimension, and added
+	// Also S2/P2 is not picked from network dimension, while it is not evicted in cputime data, so it won't be added to others.
+	// S4/P4 is not picked from network dimension, and evicted in cputime data, so it will be added to others.
+	r.CollectStmtStatsMap(stmtstats.StatementStatsMap{
+		stmtstats.SQLPlanDigest{
+			SQLDigest:  "S1",
+			PlanDigest: "P1",
+		}: &stmtstats.StatementStatsItem{
+			ExecCount:       10,
+			NetworkInBytes:  10,
+			NetworkOutBytes: 0,
+		},
+		stmtstats.SQLPlanDigest{
+			SQLDigest:  "S2",
+			PlanDigest: "P2",
+		}: &stmtstats.StatementStatsItem{
+			ExecCount:       2,
+			NetworkInBytes:  0,
+			NetworkOutBytes: 2,
+		},
+		stmtstats.SQLPlanDigest{
+			SQLDigest:  "S4",
+			PlanDigest: "P4",
+		}: &stmtstats.StatementStatsItem{
+			ExecCount:       4,
+			NetworkInBytes:  1,
+			NetworkOutBytes: 3,
+		},
+		stmtstats.SQLPlanDigest{
+			SQLDigest:  "S6",
+			PlanDigest: "P6",
+		}: &stmtstats.StatementStatsItem{
+			ExecCount:       6,
+			NetworkInBytes:  2,
+			NetworkOutBytes: 4,
+		},
+	})
+
+	select {
+	case data = <-ch:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "no data in ch")
+	}
+	assert.Len(t, data.DataRecords, 6)
+	sort.Slice(data.DataRecords, func(i, j int) bool {
+		return (data.DataRecords[i].Items[0].StmtNetworkInBytes+data.DataRecords[i].Items[0].StmtNetworkOutBytes)*100+uint64(data.DataRecords[i].Items[0].CpuTimeMs) <
+			(data.DataRecords[j].Items[0].StmtNetworkInBytes+data.DataRecords[j].Items[0].StmtNetworkOutBytes)*100+uint64(data.DataRecords[j].Items[0].CpuTimeMs)
+	})
+	// DataRecords should be:
+	// S3, P3, CpuTime=3, Network=0
+	// S7, P7, CpuTime=7, Network=0
+	// S2, P2, CpuTime=2, Network=2
+	// Other,  CpuTime=1, Network=4
+	// S6, P6, CpuTime=0, Network=6
+	// S1, P1, CpuTime=0, Network=10
+	assert.Equal(t, []byte("S3"), data.DataRecords[0].SqlDigest)
+	assert.Equal(t, uint32(3), data.DataRecords[0].Items[0].CpuTimeMs)
+	assert.Equal(t, uint64(0), data.DataRecords[0].Items[0].StmtNetworkInBytes+data.DataRecords[0].Items[0].StmtNetworkOutBytes)
+	assert.Equal(t, []byte("S7"), data.DataRecords[1].SqlDigest)
+	assert.Equal(t, uint32(7), data.DataRecords[1].Items[0].CpuTimeMs)
+	assert.Equal(t, uint64(0), data.DataRecords[1].Items[0].StmtNetworkInBytes+data.DataRecords[0].Items[0].StmtNetworkOutBytes)
+	assert.Equal(t, []byte("S2"), data.DataRecords[2].SqlDigest)
+	assert.Equal(t, uint32(2), data.DataRecords[2].Items[0].CpuTimeMs)
+	assert.Equal(t, uint64(2), data.DataRecords[2].Items[0].StmtNetworkInBytes+data.DataRecords[2].Items[0].StmtNetworkOutBytes)
+	assert.Equal(t, []byte(nil), data.DataRecords[3].SqlDigest)
+	assert.Equal(t, uint32(1), data.DataRecords[3].Items[0].CpuTimeMs)
+	assert.Equal(t, uint64(4), data.DataRecords[3].Items[0].StmtNetworkInBytes+data.DataRecords[3].Items[0].StmtNetworkOutBytes)
+	assert.Equal(t, []byte("S6"), data.DataRecords[4].SqlDigest)
+	assert.Equal(t, uint32(0), data.DataRecords[4].Items[0].CpuTimeMs)
+	assert.Equal(t, uint64(6), data.DataRecords[4].Items[0].StmtNetworkInBytes+data.DataRecords[4].Items[0].StmtNetworkOutBytes)
+	assert.Equal(t, []byte("S1"), data.DataRecords[5].SqlDigest)
+	assert.Equal(t, uint32(0), data.DataRecords[5].Items[0].CpuTimeMs)
+	assert.Equal(t, uint64(10), data.DataRecords[5].Items[0].StmtNetworkInBytes+data.DataRecords[5].Items[0].StmtNetworkOutBytes)
 }
 
 func initializeCache(maxStatementsNum, interval int) (*RemoteTopSQLReporter, *mockDataSink2) {

--- a/pkg/util/topsql/stmtstats/BUILD.bazel
+++ b/pkg/util/topsql/stmtstats/BUILD.bazel
@@ -28,7 +28,7 @@ go_test(
     ],
     embed = [":stmtstats"],
     flaky = True,
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         "//pkg/testkit/testsetup",
         "//pkg/util/topsql/state",

--- a/pkg/util/topsql/stmtstats/aggregator_test.go
+++ b/pkg/util/topsql/stmtstats/aggregator_test.go
@@ -58,8 +58,8 @@ func Test_aggregator_register_collect(t *testing.T) {
 		finished: atomic.NewBool(false),
 	}
 	a.register(stats)
-	stats.OnExecutionBegin([]byte("SQL-1"), []byte(""))
-	stats.OnExecutionFinished([]byte("SQL-1"), []byte(""), time.Millisecond)
+	stats.OnExecutionBegin([]byte("SQL-1"), []byte(""), 0)
+	stats.OnExecutionFinished([]byte("SQL-1"), []byte(""), time.Millisecond, 0)
 	total := StatementStatsMap{}
 	a.registerCollector(newMockCollector(func(data StatementStatsMap) {
 		total.Merge(data)

--- a/pkg/util/topsql/stmtstats/stmtstats.go
+++ b/pkg/util/topsql/stmtstats/stmtstats.go
@@ -30,13 +30,13 @@ var _ StatementObserver = &StatementStats{}
 // corresponding locations, without paying attention to implementation details.
 type StatementObserver interface {
 	// OnExecutionBegin should be called before statement execution.
-	OnExecutionBegin(sqlDigest, planDigest []byte)
+	OnExecutionBegin(sqlDigest, planDigest []byte, inNetworkBytes uint64)
 
 	// OnExecutionFinished should be called after the statement is executed.
 	// WARNING: Currently Only call StatementObserver API when TopSQL is enabled,
 	// there is no guarantee that both OnExecutionBegin and OnExecutionFinished will be called for a SQL,
 	// such as TopSQL is enabled during a SQL execution.
-	OnExecutionFinished(sqlDigest, planDigest []byte, execDuration time.Duration)
+	OnExecutionFinished(sqlDigest, planDigest []byte, execDuration time.Duration, outNetworkBytes uint64)
 }
 
 // StatementStats is a counter used locally in each session.
@@ -60,17 +60,18 @@ func CreateStatementStats() *StatementStats {
 }
 
 // OnExecutionBegin implements StatementObserver.OnExecutionBegin.
-func (s *StatementStats) OnExecutionBegin(sqlDigest, planDigest []byte) {
+func (s *StatementStats) OnExecutionBegin(sqlDigest, planDigest []byte, inNetworkBytes uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	item := s.GetOrCreateStatementStatsItem(sqlDigest, planDigest)
 
 	item.ExecCount++
+	item.NetworkInBytes += inNetworkBytes
 	// Count more data here.
 }
 
 // OnExecutionFinished implements StatementObserver.OnExecutionFinished.
-func (s *StatementStats) OnExecutionFinished(sqlDigest, planDigest []byte, execDuration time.Duration) {
+func (s *StatementStats) OnExecutionFinished(sqlDigest, planDigest []byte, execDuration time.Duration, outNetworkBytes uint64) {
 	ns := execDuration.Nanoseconds()
 	if ns < 0 {
 		return
@@ -82,6 +83,7 @@ func (s *StatementStats) OnExecutionFinished(sqlDigest, planDigest []byte, execD
 
 	item.SumDurationNs += uint64(ns)
 	item.DurationCount++
+	item.NetworkOutBytes += outNetworkBytes
 	// Count more data here.
 }
 
@@ -182,6 +184,10 @@ type StatementStatsItem struct {
 	// DurationCount represents the number of SQL executions specially
 	// used to calculate SQLDuration.
 	DurationCount uint64
+	// NetworkInBytes represents the total number of network input bytes from client.
+	NetworkInBytes uint64
+	// NetworkOutBytes represents the total number of network input bytes to client.
+	NetworkOutBytes uint64
 }
 
 // NewStatementStatsItem creates an empty StatementStatsItem.
@@ -205,6 +211,8 @@ func (i *StatementStatsItem) Merge(other *StatementStatsItem) {
 	i.ExecCount += other.ExecCount
 	i.SumDurationNs += other.SumDurationNs
 	i.DurationCount += other.DurationCount
+	i.NetworkInBytes += other.NetworkInBytes
+	i.NetworkOutBytes += other.NetworkOutBytes
 	i.KvStatsItem.Merge(other.KvStatsItem)
 }
 

--- a/pkg/util/topsql/stmtstats/stmtstats_test.go
+++ b/pkg/util/topsql/stmtstats/stmtstats_test.go
@@ -85,18 +85,24 @@ func TestKvStatementStatsItem_Merge(t *testing.T) {
 
 func TestStatementsStatsItem_Merge(t *testing.T) {
 	item1 := &StatementStatsItem{
-		ExecCount:     1,
-		SumDurationNs: 100,
-		KvStatsItem:   NewKvStatementStatsItem(),
+		ExecCount:       1,
+		SumDurationNs:   100,
+		KvStatsItem:     NewKvStatementStatsItem(),
+		NetworkInBytes:  10,
+		NetworkOutBytes: 20,
 	}
 	item2 := &StatementStatsItem{
-		ExecCount:     2,
-		SumDurationNs: 50,
-		KvStatsItem:   NewKvStatementStatsItem(),
+		ExecCount:       2,
+		SumDurationNs:   50,
+		KvStatsItem:     NewKvStatementStatsItem(),
+		NetworkInBytes:  50,
+		NetworkOutBytes: 60,
 	}
 	item1.Merge(item2)
 	assert.Equal(t, uint64(3), item1.ExecCount)
 	assert.Equal(t, uint64(150), item1.SumDurationNs)
+	assert.Equal(t, uint64(60), item1.NetworkInBytes)
+	assert.Equal(t, uint64(80), item1.NetworkOutBytes)
 }
 
 func TestStatementStatsMap_Merge(t *testing.T) {
@@ -180,17 +186,17 @@ func TestExecCounter_AddExecCount_Take(t *testing.T) {
 	m := stats.Take()
 	assert.Len(t, m, 0)
 	for range 1 {
-		stats.OnExecutionBegin([]byte("SQL-1"), []byte(""))
+		stats.OnExecutionBegin([]byte("SQL-1"), []byte(""), 0)
 	}
 	for range 2 {
-		stats.OnExecutionBegin([]byte("SQL-2"), []byte(""))
-		stats.OnExecutionFinished([]byte("SQL-2"), []byte(""), time.Second)
+		stats.OnExecutionBegin([]byte("SQL-2"), []byte(""), 0)
+		stats.OnExecutionFinished([]byte("SQL-2"), []byte(""), time.Second, 0)
 	}
 	for range 3 {
-		stats.OnExecutionBegin([]byte("SQL-3"), []byte(""))
-		stats.OnExecutionFinished([]byte("SQL-3"), []byte(""), time.Millisecond)
+		stats.OnExecutionBegin([]byte("SQL-3"), []byte(""), 0)
+		stats.OnExecutionFinished([]byte("SQL-3"), []byte(""), time.Millisecond, 0)
 	}
-	stats.OnExecutionFinished([]byte("SQL-3"), []byte(""), -time.Millisecond)
+	stats.OnExecutionFinished([]byte("SQL-3"), []byte(""), -time.Millisecond, 0)
 	m = stats.Take()
 	assert.Len(t, m, 3)
 	assert.Equal(t, uint64(1), m[SQLPlanDigest{SQLDigest: "SQL-1"}].ExecCount)
@@ -201,4 +207,39 @@ func TestExecCounter_AddExecCount_Take(t *testing.T) {
 	assert.Equal(t, uint64(3*10e5), m[SQLPlanDigest{SQLDigest: "SQL-3"}].SumDurationNs)
 	m = stats.Take()
 	assert.Len(t, m, 0)
+}
+
+func TestNetworkBytesAccumulation(t *testing.T) {
+	stats := CreateStatementStats()
+	sqlDigest := []byte("SQL-1")
+	planDigest := []byte("PLAN-1")
+
+	// Test NetworkInBytes accumulation in OnExecutionBegin
+	// Call OnExecutionBegin multiple times with different network input bytes
+	stats.OnExecutionBegin(sqlDigest, planDigest, 100)
+	stats.OnExecutionBegin(sqlDigest, planDigest, 200)
+	stats.OnExecutionBegin(sqlDigest, planDigest, 300)
+
+	m := stats.Take()
+	assert.Len(t, m, 1)
+	key := SQLPlanDigest{SQLDigest: BinaryDigest(sqlDigest), PlanDigest: BinaryDigest(planDigest)}
+	item := m[key]
+	assert.NotNil(t, item)
+	// NetworkInBytes should be accumulated: 100 + 200 + 300 = 600
+	assert.Equal(t, uint64(600), item.NetworkInBytes)
+	assert.Equal(t, uint64(3), item.ExecCount)
+
+	// Test NetworkOutBytes accumulation in OnExecutionFinished
+	// Call OnExecutionFinished multiple times with different network output bytes
+	stats.OnExecutionFinished(sqlDigest, planDigest, time.Second, 50)
+	stats.OnExecutionFinished(sqlDigest, planDigest, time.Second, 150)
+	stats.OnExecutionFinished(sqlDigest, planDigest, time.Second, 250)
+
+	m = stats.Take()
+	assert.Len(t, m, 1)
+	item = m[key]
+	assert.NotNil(t, item)
+	// NetworkOutBytes should be accumulated: 50 + 150 + 250 = 450
+	assert.Equal(t, uint64(450), item.NetworkOutBytes)
+	assert.Equal(t, uint64(3), item.DurationCount)
 }


### PR DESCRIPTION
This is a backport of https://github.com/pingcap/tidb/pull/66290 to release-8.5-20251125-v8.5.4.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62920

Problem Summary:
Add client network in/out stats in TopSQL. And record topN network usage SQLs alongside current topN CPU usage SQLs. Note one SQL will be added at most once.

### What changed and how does it work?
- Add two new session variables `InPacketBytes` and `OutPacketBytes` to record the network traffic from/to clients.
- When a query finishes, record the network traffic info to TopSQL stmtstats.
- Pick topN queries with highest network traffic.
- Bump `github.com/pingcap/tipb` to `v0.0.0-20260522023117-6ceadabb61de` (merge commit of `pingcap/tipb#411`) to include the TopSQL network fields protocol.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Collects client network data for topsql to pick topN sql with highest network traffic.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * TopSQL now tracks and reports incoming and outgoing network bytes per statement, providing enhanced visibility into network resource consumption alongside existing CPU metrics.
  * Improved per-session packet byte monitoring for better statement resource consumption analysis.

* **Chores**
  * Updated dependencies and test infrastructure configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->