### PR TITLE
planner: reuse volatile GROUP BY expressions

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -600,6 +600,37 @@ SELECT t84.c0 FROM t84 NATURAL RIGHT JOIN t0 WHERE true GROUP BY NULL HAVING (t8
 		tk.MustQuery("select * from t1;").Check(testkit.Rows("1 <nil> "))
 	}
 
+	// issue-36386-volatile-group-by-projection
+	{
+		tk := prepareSharedTestKit(t)
+		for _, cascades := range []string{"off", "on"} {
+			tk.MustExec(fmt.Sprintf("set @@tidb_enable_cascades_planner = %s", cascades))
+			tk.MustExec("drop table if exists foo")
+			tk.MustExec("create table foo(a int, b int, c int, d int)")
+			tk.MustExec("insert into foo values(1,1,1,10),(2,2,2,2),(3,1,1,10),(3,2,2,2)")
+
+			query := "select /* issue:36386 */ b*floor(2*rand()) as e, count(d) from foo group by e"
+			planRows := tk.MustQuery("explain format='plan_tree' " + query).Rows()
+			require.NotEmpty(t, planRows, cascades)
+			require.Contains(t, fmt.Sprint(planRows[0]), "Projection", cascades)
+			require.Contains(t, fmt.Sprint(planRows[0]), "Column", cascades)
+			require.NotContains(t, fmt.Sprint(planRows[0]), "rand()", cascades)
+			require.Contains(t, fmt.Sprint(planRows[1]), "HashAgg", cascades)
+			require.Contains(t, fmt.Sprint(planRows[2]), "rand()", cascades)
+
+			for range 20 {
+				rows := tk.MustQuery(query).Rows()
+				seen := make(map[string]struct{}, len(rows))
+				for _, row := range rows {
+					key := fmt.Sprint(row[0])
+					require.NotContainsf(t, seen, key, "cascades=%s rows=%v", cascades, rows)
+					seen[key] = struct{}{}
+				}
+			}
+		}
+		tk.MustExec("set @@tidb_enable_cascades_planner = off")
+	}
+
 	// abs-max-binary-literal-group-by-unique-key
 	{
 		tk := prepareSharedTestKit(t)

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -633,6 +633,14 @@ SELECT t84.c0 FROM t84 NATURAL RIGHT JOIN t0 WHERE true GROUP BY NULL HAVING (t8
 			tk.MustExec("set @@sql_mode = ''")
 			query = "select /* issue:36386 */ b*floor(2*rand()) + 1 as e, count(d) from foo group by b*floor(2*rand())"
 			checkQuery(query, cascades)
+
+			tk.MustExec("drop table if exists ta")
+			tk.MustExec("create table ta(a int, b int)")
+			planRows := tk.MustQuery("explain format='plan_tree' select @n:=@n+1 as e from ta group by e").Rows()
+			require.GreaterOrEqual(t, len(planRows), 2, cascades)
+			require.Contains(t, fmt.Sprint(planRows[0]), "Projection", cascades)
+			require.Contains(t, fmt.Sprint(planRows[0]), "setvar", cascades)
+			require.Contains(t, fmt.Sprint(planRows[1]), "HashAgg", cascades)
 			tk.MustExec("set @@sql_mode = default")
 		}
 		tk.MustExec("set @@tidb_enable_cascades_planner = off")

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -603,17 +603,10 @@ SELECT t84.c0 FROM t84 NATURAL RIGHT JOIN t0 WHERE true GROUP BY NULL HAVING (t8
 	// issue-36386-volatile-group-by-projection
 	{
 		tk := prepareSharedTestKit(t)
-		for _, cascades := range []string{"off", "on"} {
-			tk.MustExec(fmt.Sprintf("set @@tidb_enable_cascades_planner = %s", cascades))
-			tk.MustExec("drop table if exists foo")
-			tk.MustExec("create table foo(a int, b int, c int, d int)")
-			tk.MustExec("insert into foo values(1,1,1,10),(2,2,2,2),(3,1,1,10),(3,2,2,2)")
-
-			query := "select /* issue:36386 */ b*floor(2*rand()) as e, count(d) from foo group by e"
+		checkQuery := func(query, cascades string) {
 			planRows := tk.MustQuery("explain format='plan_tree' " + query).Rows()
-			require.NotEmpty(t, planRows, cascades)
+			require.GreaterOrEqual(t, len(planRows), 3, cascades)
 			require.Contains(t, fmt.Sprint(planRows[0]), "Projection", cascades)
-			require.Contains(t, fmt.Sprint(planRows[0]), "Column", cascades)
 			require.NotContains(t, fmt.Sprint(planRows[0]), "rand()", cascades)
 			require.Contains(t, fmt.Sprint(planRows[1]), "HashAgg", cascades)
 			require.Contains(t, fmt.Sprint(planRows[2]), "rand()", cascades)
@@ -627,6 +620,20 @@ SELECT t84.c0 FROM t84 NATURAL RIGHT JOIN t0 WHERE true GROUP BY NULL HAVING (t8
 					seen[key] = struct{}{}
 				}
 			}
+		}
+		for _, cascades := range []string{"off", "on"} {
+			tk.MustExec(fmt.Sprintf("set @@tidb_enable_cascades_planner = %s", cascades))
+			tk.MustExec("drop table if exists foo")
+			tk.MustExec("create table foo(a int, b int, c int, d int)")
+			tk.MustExec("insert into foo values(1,1,1,10),(2,2,2,2),(3,1,1,10),(3,2,2,2)")
+
+			query := "select /* issue:36386 */ b*floor(2*rand()) as e, count(d) from foo group by e"
+			checkQuery(query, cascades)
+
+			tk.MustExec("set @@sql_mode = ''")
+			query = "select /* issue:36386 */ b*floor(2*rand()) + 1 as e, count(d) from foo group by b*floor(2*rand())"
+			checkQuery(query, cascades)
+			tk.MustExec("set @@sql_mode = default")
 		}
 		tk.MustExec("set @@tidb_enable_cascades_planner = off")
 	}

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -460,7 +460,7 @@ func collectMutableGroupByProjections(ectx expression.EvalContext, gbyExprs []as
 		return nil
 	}
 	projections := make([]groupByProjection, 0, len(gbyExprs))
-	for i, expr := range gbyExprs {
+	for i, astExpr := range gbyExprs {
 		if i >= len(agg.GroupByItems) || !hasMutableEffectsOrNonDeterministicExpr(agg.GroupByItems[i]) {
 			continue
 		}
@@ -469,8 +469,9 @@ func collectMutableGroupByProjections(ectx expression.EvalContext, gbyExprs []as
 			continue
 		}
 		projections = append(projections, groupByProjection{
-			expr: expr,
-			col:  col,
+			astExpr: astExpr,
+			expr:    agg.GroupByItems[i],
+			col:     col,
 		})
 	}
 	return projections
@@ -1823,8 +1824,9 @@ func (b *PlanBuilder) implicitProjectGroupingSetCols(projSchema *expression.Sche
 }
 
 type groupByProjection struct {
-	expr ast.ExprNode
-	col  *expression.Column
+	astExpr ast.ExprNode
+	expr    expression.Expression
+	col     *expression.Column
 }
 
 // buildProjection returns a Projection plan and non-aux columns length.
@@ -1881,6 +1883,7 @@ func (b *PlanBuilder) buildProjection(ctx context.Context, p base.LogicalPlan, f
 			if err != nil {
 				return nil, nil, 0, err
 			}
+			newExpr = replaceMutableGroupByProjections(b.ctx.GetExprCtx().GetEvalCtx(), newExpr, groupByProjections)
 		} else {
 			np = p
 		}
@@ -2042,11 +2045,44 @@ func (b *PlanBuilder) buildProjection(ctx context.Context, p base.LogicalPlan, f
 func resolveProjectionFromGroupBy(expr ast.ExprNode, groupByProjections []groupByProjection) expression.Expression {
 	expr = getInnerFromParenthesesAndUnaryPlus(expr)
 	for _, projection := range groupByProjections {
-		if ast.ExpressionDeepEqual(getInnerFromParenthesesAndUnaryPlus(projection.expr), expr) {
+		if ast.ExpressionDeepEqual(getInnerFromParenthesesAndUnaryPlus(projection.astExpr), expr) {
 			return projection.col
 		}
 	}
 	return nil
+}
+
+func replaceMutableGroupByProjections(ectx expression.EvalContext, expr expression.Expression, groupByProjections []groupByProjection) expression.Expression {
+	if expr == nil || len(groupByProjections) == 0 {
+		return expr
+	}
+	return expr.Traverse(mutableGroupByProjectionReplacer{
+		ectx:               ectx,
+		groupByProjections: groupByProjections,
+	})
+}
+
+type mutableGroupByProjectionReplacer struct {
+	ectx               expression.EvalContext
+	groupByProjections []groupByProjection
+}
+
+func (r mutableGroupByProjectionReplacer) Transform(expr expression.Expression) expression.Expression {
+	for _, projection := range r.groupByProjections {
+		if expr.Equal(r.ectx, projection.expr) {
+			return projection.col
+		}
+	}
+	scalar, ok := expr.(*expression.ScalarFunction)
+	if !ok {
+		return expr
+	}
+	args := scalar.GetArgs()
+	for i, arg := range args {
+		args[i] = arg.Traverse(r)
+	}
+	scalar.CleanHashCode()
+	return scalar
 }
 
 func (b *PlanBuilder) buildDistinct(child base.LogicalPlan, length int) (*logicalop.LogicalAggregation, error) {

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -394,6 +394,23 @@ func (b *PlanBuilder) buildAggregation(ctx context.Context, p base.LogicalPlan, 
 			names = append(names, fullNames[i])
 		}
 	}
+	for _, gbyItem := range gbyItems {
+		if !hasMutableEffectsOrNonDeterministicExpr(gbyItem) ||
+			firstRowColumnForExprInSchema(b.ctx.GetExprCtx().GetEvalCtx(), plan4Agg.AggFuncs, schema4Agg, gbyItem) != nil {
+			continue
+		}
+		newFunc, err := aggregation.NewAggFuncDesc(b.ctx.GetExprCtx(), ast.AggFuncFirstRow, []expression.Expression{gbyItem}, false)
+		if err != nil {
+			return nil, nil, err
+		}
+		plan4Agg.AggFuncs = append(plan4Agg.AggFuncs, newFunc)
+		column := expression.Column{
+			UniqueID: b.ctx.GetSessionVars().AllocPlanColumnID(),
+			RetType:  newFunc.RetTp,
+		}
+		schema4Agg.Append(&column)
+		names = append(names, types.EmptyName)
+	}
 	hasGroupBy := len(gbyItems) > 0
 	for i, aggFunc := range plan4Agg.AggFuncs {
 		err := aggFunc.UpdateNotNullFlag4RetType(hasGroupBy, allAggsFirstRow)
@@ -415,6 +432,48 @@ func (b *PlanBuilder) buildAggregation(ctx context.Context, p base.LogicalPlan, 
 	}
 	plan4Agg.SetSchema(schema4Agg)
 	return plan4Agg, aggIndexMap, nil
+}
+
+func hasMutableEffectsOrNonDeterministicExpr(expr expression.Expression) bool {
+	return expression.IsMutableEffectsExpr(expr) || expression.CheckNonDeterministic(expr)
+}
+
+func firstRowColumnForExpr(ectx expression.EvalContext, plan4Agg *logicalop.LogicalAggregation, expr expression.Expression) *expression.Column {
+	return firstRowColumnForExprInSchema(ectx, plan4Agg.AggFuncs, plan4Agg.Schema(), expr)
+}
+
+func firstRowColumnForExprInSchema(ectx expression.EvalContext, aggFuncs []*aggregation.AggFuncDesc, schema *expression.Schema, expr expression.Expression) *expression.Column {
+	for i, aggFunc := range aggFuncs {
+		if aggFunc.Name != ast.AggFuncFirstRow || len(aggFunc.Args) != 1 || i >= schema.Len() {
+			continue
+		}
+		if aggFunc.Args[0].Equal(ectx, expr) {
+			return schema.Columns[i]
+		}
+	}
+	return nil
+}
+
+func collectMutableGroupByProjections(ectx expression.EvalContext, gbyExprs []ast.ExprNode, p base.LogicalPlan) []groupByProjection {
+	agg, ok := p.(*logicalop.LogicalAggregation)
+	if !ok {
+		return nil
+	}
+	projections := make([]groupByProjection, 0, len(gbyExprs))
+	for i, expr := range gbyExprs {
+		if i >= len(agg.GroupByItems) || !hasMutableEffectsOrNonDeterministicExpr(agg.GroupByItems[i]) {
+			continue
+		}
+		col := firstRowColumnForExpr(ectx, agg, agg.GroupByItems[i])
+		if col == nil {
+			continue
+		}
+		projections = append(projections, groupByProjection{
+			expr: expr,
+			col:  col,
+		})
+	}
+	return projections
 }
 
 func (b *PlanBuilder) buildTableRefs(ctx context.Context, from *ast.TableRefsClause) (p base.LogicalPlan, err error) {
@@ -1763,9 +1822,14 @@ func (b *PlanBuilder) implicitProjectGroupingSetCols(projSchema *expression.Sche
 	return projSchema, projNames, projExprs
 }
 
+type groupByProjection struct {
+	expr ast.ExprNode
+	col  *expression.Column
+}
+
 // buildProjection returns a Projection plan and non-aux columns length.
 func (b *PlanBuilder) buildProjection(ctx context.Context, p base.LogicalPlan, fields []*ast.SelectField, mapper map[*ast.AggregateFuncExpr]int,
-	windowMapper map[*ast.WindowFuncExpr]int, considerWindow bool, expandGenerateColumn bool) (base.LogicalPlan, []expression.Expression, int, error) {
+	windowMapper map[*ast.WindowFuncExpr]int, considerWindow bool, expandGenerateColumn bool, groupByProjections []groupByProjection) (base.LogicalPlan, []expression.Expression, int, error) {
 	err := b.preprocessUserVarTypes(ctx, p, fields, mapper)
 	if err != nil {
 		return nil, nil, 0, err
@@ -1804,9 +1868,21 @@ func (b *PlanBuilder) buildProjection(ctx context.Context, p base.LogicalPlan, f
 			newNames = append(newNames, name)
 			continue
 		}
-		newExpr, np, err := b.rewriteWithPreprocess(ctx, field.Expr, p, mapper, windowMapper, true, nil)
-		if err != nil {
-			return nil, nil, 0, err
+		var (
+			newExpr expression.Expression
+			np      base.LogicalPlan
+			err     error
+		)
+		if len(groupByProjections) > 0 {
+			newExpr = resolveProjectionFromGroupBy(field.Expr, groupByProjections)
+		}
+		if newExpr == nil {
+			newExpr, np, err = b.rewriteWithPreprocess(ctx, field.Expr, p, mapper, windowMapper, true, nil)
+			if err != nil {
+				return nil, nil, 0, err
+			}
+		} else {
+			np = p
 		}
 
 		// for case: select a+1, b, sum(b), grouping(a) from t group by a, b with rollup.
@@ -1961,6 +2037,16 @@ func (b *PlanBuilder) buildProjection(ctx context.Context, p base.LogicalPlan, f
 		}
 	}
 	return proj, proj.Exprs, oldLen, nil
+}
+
+func resolveProjectionFromGroupBy(expr ast.ExprNode, groupByProjections []groupByProjection) expression.Expression {
+	expr = getInnerFromParenthesesAndUnaryPlus(expr)
+	for _, projection := range groupByProjections {
+		if ast.ExpressionDeepEqual(getInnerFromParenthesesAndUnaryPlus(projection.expr), expr) {
+			return projection.col
+		}
+	}
+	return nil
 }
 
 func (b *PlanBuilder) buildDistinct(child base.LogicalPlan, length int) (*logicalop.LogicalAggregation, error) {
@@ -4290,6 +4376,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 		windowAggMap                  map[*ast.AggregateFuncExpr]int
 		correlatedAggMap              map[*ast.AggregateFuncExpr]int
 		gbyCols                       []expression.Expression
+		groupByProjections            []groupByProjection
 		projExprs                     []expression.Expression
 		rollup                        bool
 	)
@@ -4512,6 +4599,9 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 		if err != nil {
 			return nil, err
 		}
+		if !rollup {
+			groupByProjections = collectMutableGroupByProjections(b.ctx.GetExprCtx().GetEvalCtx(), gbyExprs, p)
+		}
 		for agg, idx := range totalMap {
 			totalMap[agg] = aggIndexMap[idx]
 		}
@@ -4520,7 +4610,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 	var oldLen int
 	// According to https://dev.mysql.com/doc/refman/8.0/en/window-functions-usage.html,
 	// we can only process window functions after having clause, so `considerWindow` is false now.
-	p, projExprs, oldLen, err = b.buildProjection(ctx, p, sel.Fields.Fields, totalMap, nil, false, sel.OrderBy != nil)
+	p, projExprs, oldLen, err = b.buildProjection(ctx, p, sel.Fields.Fields, totalMap, nil, false, sel.OrderBy != nil, groupByProjections)
 	if err != nil {
 		return nil, err
 	}
@@ -4558,7 +4648,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 		// In such case plan `p` is not changed, so we don't have to build another projection.
 		if hasWindowFuncField {
 			// Now we build the window function fields.
-			p, projExprs, oldLen, err = b.buildProjection(ctx, p, sel.Fields.Fields, windowAggMap, windowMapper, true, false)
+			p, projExprs, oldLen, err = b.buildProjection(ctx, p, sel.Fields.Fields, windowAggMap, windowMapper, true, false, nil)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -395,7 +395,7 @@ func (b *PlanBuilder) buildAggregation(ctx context.Context, p base.LogicalPlan, 
 		}
 	}
 	for _, gbyItem := range gbyItems {
-		if !hasMutableEffectsOrNonDeterministicExpr(gbyItem) ||
+		if !canReuseMutableGroupByProjection(gbyItem) ||
 			firstRowColumnForExprInSchema(b.ctx.GetExprCtx().GetEvalCtx(), plan4Agg.AggFuncs, schema4Agg, gbyItem) != nil {
 			continue
 		}
@@ -438,6 +438,10 @@ func hasMutableEffectsOrNonDeterministicExpr(expr expression.Expression) bool {
 	return expression.IsMutableEffectsExpr(expr) || expression.CheckNonDeterministic(expr)
 }
 
+func canReuseMutableGroupByProjection(expr expression.Expression) bool {
+	return hasMutableEffectsOrNonDeterministicExpr(expr) && !expression.ExprHasSetVarOrSleep(expr)
+}
+
 func firstRowColumnForExpr(ectx expression.EvalContext, plan4Agg *logicalop.LogicalAggregation, expr expression.Expression) *expression.Column {
 	return firstRowColumnForExprInSchema(ectx, plan4Agg.AggFuncs, plan4Agg.Schema(), expr)
 }
@@ -454,27 +458,49 @@ func firstRowColumnForExprInSchema(ectx expression.EvalContext, aggFuncs []*aggr
 	return nil
 }
 
-func collectMutableGroupByProjections(ectx expression.EvalContext, gbyExprs []ast.ExprNode, p base.LogicalPlan) []groupByProjection {
+func collectMutableGroupByProjections(exprCtx expression.BuildContext, gbyExprs []ast.ExprNode, p base.LogicalPlan) []groupByProjection {
 	agg, ok := p.(*logicalop.LogicalAggregation)
 	if !ok {
 		return nil
 	}
+	ectx := exprCtx.GetEvalCtx()
 	projections := make([]groupByProjection, 0, len(gbyExprs))
 	for i, astExpr := range gbyExprs {
-		if i >= len(agg.GroupByItems) || !hasMutableEffectsOrNonDeterministicExpr(agg.GroupByItems[i]) {
+		if i >= len(agg.GroupByItems) || !canReuseMutableGroupByProjection(agg.GroupByItems[i]) {
 			continue
 		}
 		col := firstRowColumnForExpr(ectx, agg, agg.GroupByItems[i])
 		if col == nil {
 			continue
 		}
+		rewrittenExpr := rewriteGroupByProjectionExpr(exprCtx, agg, agg.GroupByItems[i])
 		projections = append(projections, groupByProjection{
-			astExpr: astExpr,
-			expr:    agg.GroupByItems[i],
-			col:     col,
+			astExpr:       astExpr,
+			expr:          agg.GroupByItems[i],
+			rewrittenExpr: rewrittenExpr,
+			col:           col,
 		})
 	}
 	return projections
+}
+
+func rewriteGroupByProjectionExpr(exprCtx expression.BuildContext, agg *logicalop.LogicalAggregation, expr expression.Expression) expression.Expression {
+	if len(agg.Children()) == 0 {
+		return expr
+	}
+	child := agg.Children()[0]
+	childSchema := child.Schema()
+	firstRowExprs := make([]expression.Expression, 0, childSchema.Len())
+	ectx := exprCtx.GetEvalCtx()
+	for _, col := range childSchema.Columns {
+		firstRowCol := firstRowColumnForExpr(ectx, agg, col)
+		if firstRowCol == nil {
+			firstRowExprs = append(firstRowExprs, col)
+			continue
+		}
+		firstRowExprs = append(firstRowExprs, firstRowCol)
+	}
+	return expression.ColumnSubstitute(exprCtx, expr, childSchema, firstRowExprs)
 }
 
 func (b *PlanBuilder) buildTableRefs(ctx context.Context, from *ast.TableRefsClause) (p base.LogicalPlan, err error) {
@@ -1824,9 +1850,10 @@ func (b *PlanBuilder) implicitProjectGroupingSetCols(projSchema *expression.Sche
 }
 
 type groupByProjection struct {
-	astExpr ast.ExprNode
-	expr    expression.Expression
-	col     *expression.Column
+	astExpr       ast.ExprNode
+	expr          expression.Expression
+	rewrittenExpr expression.Expression
+	col           *expression.Column
 }
 
 // buildProjection returns a Projection plan and non-aux columns length.
@@ -2070,6 +2097,9 @@ type mutableGroupByProjectionReplacer struct {
 func (r mutableGroupByProjectionReplacer) Transform(expr expression.Expression) expression.Expression {
 	for _, projection := range r.groupByProjections {
 		if expr.Equal(r.ectx, projection.expr) {
+			return projection.col
+		}
+		if projection.rewrittenExpr != nil && expr.Equal(r.ectx, projection.rewrittenExpr) {
 			return projection.col
 		}
 	}
@@ -4636,7 +4666,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 			return nil, err
 		}
 		if !rollup {
-			groupByProjections = collectMutableGroupByProjections(b.ctx.GetExprCtx().GetEvalCtx(), gbyExprs, p)
+			groupByProjections = collectMutableGroupByProjections(b.ctx.GetExprCtx(), gbyExprs, p)
 		}
 		for agg, idx := range totalMap {
 			totalMap[agg] = aggIndexMap[idx]


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #36386

Problem Summary:

Issue #36386 shows a wrong result when the SELECT list reuses a volatile GROUP BY expression:

```sql
select b * floor(2 * rand()) as e, count(d) from foo group by e;
```

Before this change, planning computed the volatile group key in the child projection for aggregation, but the final SELECT projection recomputed the same expression over `firstrow(b)`. That allowed `rand()` to be evaluated again after aggregation, so duplicate visible aggregate keys could appear in the final result.

### What changed and how does it work?

This PR keeps the fix planner-local:

- adds a `firstrow(group_by_expr)` output for mutable or non-deterministic GROUP BY expressions;
- maps matching SELECT expressions back to that aggregation output column instead of recomputing them;
- also handles nested SELECT expressions that contain a volatile GROUP BY sub-expression;
- leaves rollup out of this mapping path to keep the change narrow.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a wrong result issue where volatile GROUP BY expressions could be re-evaluated in the final projection.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved query planner to more effectively handle non-deterministic expressions (such as `rand()`) and mutable operations within GROUP BY clauses, resulting in more stable and predictable query execution plans.

* **Tests**
  * Added comprehensive regression tests for volatile expressions in GROUP BY projections to ensure consistent query behavior across different planner configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->