### PR TITLE
planner: fix mixed union IN subquery comparison

### DIFF
--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1615,6 +1615,8 @@ func mixedUnionNumericSourceType(
 		case types.ETInt, types.ETReal, types.ETDecimal:
 			if numericTp == nil {
 				numericTp = sourceTp.Clone()
+			} else {
+				numericTp = unionJoinFieldType(numericTp, sourceTp)
 			}
 		case types.ETString:
 			hasStringSource = true

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1345,6 +1345,7 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 			return v, true
 		}
 	}
+	rexpr = er.adjustInSubqueryUnionCompareExpr(np, rexpr)
 	checkCondition, err := er.constructBinaryOpFunction(lexpr, rexpr, ast.EQ)
 	if err != nil {
 		er.err = err
@@ -1518,6 +1519,128 @@ func isNoDecorrelate(planCtx *exprRewriterPlanCtx, corCols []*expression.Correla
 	}
 	return noDecorrelate
 }
+
+//revive:disable:cyclomatic,cognitive-complexity,function-length
+func (er *expressionRewriter) adjustInSubqueryUnionCompareExpr(
+	np base.LogicalPlan,
+	rexpr expression.Expression,
+) expression.Expression {
+	rCol, ok := rexpr.(*expression.Column)
+	if !ok || !rCol.GetType(er.sctx.GetEvalCtx()).EvalType().IsStringKind() {
+		return rexpr
+	}
+	castTp := findMixedUnionNumericSourceType(
+		np,
+		rCol.UniqueID,
+		er.sctx.GetEvalCtx(),
+	)
+	if castTp == nil {
+		return rexpr
+	}
+	// MySQL keeps displayed UNION output as string, but IN-subquery comparison
+	// still uses a numeric domain when one UNION branch is numeric.
+	rColCopy := *rCol
+	rColCopy.InOperand = true
+	return expression.BuildCastFunction(er.sctx, &rColCopy, castTp)
+}
+
+func findMixedUnionNumericSourceType(
+	p base.LogicalPlan,
+	targetColID int64,
+	evalCtx expression.EvalContext,
+) *types.FieldType {
+	switch x := p.(type) {
+	case *logicalop.LogicalAggregation:
+		for i, col := range x.Schema().Columns {
+			if col.UniqueID != targetColID ||
+				i >= len(x.AggFuncs) ||
+				len(x.AggFuncs[i].Args) != 1 {
+				continue
+			}
+			argCol, ok := x.AggFuncs[i].Args[0].(*expression.Column)
+			if !ok || len(x.Children()) == 0 {
+				return nil
+			}
+			return findMixedUnionNumericSourceType(
+				x.Children()[0],
+				argCol.UniqueID,
+				evalCtx,
+			)
+		}
+	case *logicalop.LogicalProjection:
+		for i, col := range x.Schema().Columns {
+			if col.UniqueID != targetColID || i >= len(x.Exprs) {
+				continue
+			}
+			argCol, ok := x.Exprs[i].(*expression.Column)
+			if ok && len(x.Children()) > 0 {
+				return findMixedUnionNumericSourceType(
+					x.Children()[0],
+					argCol.UniqueID,
+					evalCtx,
+				)
+			}
+			return nil
+		}
+	case *logicalop.LogicalUnionAll:
+		for i, col := range x.Schema().Columns {
+			if col.UniqueID == targetColID {
+				return mixedUnionNumericSourceType(x, i, evalCtx)
+			}
+		}
+	default:
+		return nil
+	}
+	return nil
+}
+
+func mixedUnionNumericSourceType(
+	u *logicalop.LogicalUnionAll,
+	colIdx int,
+	evalCtx expression.EvalContext,
+) *types.FieldType {
+	if colIdx >= u.Schema().Len() ||
+		!u.Schema().Columns[colIdx].GetType(evalCtx).EvalType().IsStringKind() {
+		return nil
+	}
+	var numericTp *types.FieldType
+	hasStringSource := false
+	for _, child := range u.Children() {
+		proj, ok := child.(*logicalop.LogicalProjection)
+		if !ok || colIdx >= len(proj.Exprs) {
+			return nil
+		}
+		sourceTp := unionProjectionSourceType(proj.Exprs[colIdx], evalCtx)
+		switch sourceTp.EvalType() {
+		case types.ETInt, types.ETReal, types.ETDecimal:
+			if numericTp == nil {
+				numericTp = sourceTp.Clone()
+			}
+		case types.ETString:
+			hasStringSource = true
+		default:
+			return nil
+		}
+	}
+	if numericTp == nil || !hasStringSource {
+		return nil
+	}
+	numericTp.DelFlag(mysql.NotNullFlag)
+	return numericTp
+}
+
+func unionProjectionSourceType(
+	expr expression.Expression,
+	evalCtx expression.EvalContext,
+) *types.FieldType {
+	sf, ok := expr.(*expression.ScalarFunction)
+	if ok && sf.FuncName.L == ast.Cast && len(sf.GetArgs()) == 1 {
+		return sf.GetArgs()[0].GetType(evalCtx)
+	}
+	return expr.GetType(evalCtx)
+}
+
+//revive:enable:cyclomatic,cognitive-complexity,function-length
 
 func (er *expressionRewriter) handleScalarSubquery(ctx context.Context, planCtx *exprRewriterPlanCtx, v *ast.SubqueryExpr) (ast.Node, bool) {
 	intest.AssertNotNil(planCtx)

--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 2,
+    shard_count = 3,
     deps = [
         "//pkg/errno",
         "//pkg/parser",

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -985,5 +985,11 @@ func TestIssue25600InSubqueryMixedUnionComparison(t *testing.T) {
 		tk.MustQuery(
 			`select /* issue:25600 */ 'sc' in (select '' union select '0')`,
 		).Check(testkit.Rows("0"))
+		tk.MustQuery(
+			`select /* issue:25600 */ '1.1' in (select 1 union select 1.9)`,
+		).Check(testkit.Rows("0"))
+		tk.MustQuery(
+			`select /* issue:25600 */ '1.1' in (select 1.9 union select 1)`,
+		).Check(testkit.Rows("0"))
 	})
 }

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -958,3 +958,32 @@ func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {
 		testKit.MustQuery("select a,min(a) from t where -1=a;").Check(testkit.Rows("<nil> <nil>"))
 	})
 }
+
+func TestIssue25600InSubqueryMixedUnionComparison(t *testing.T) {
+	testkit.RunTestUnderCascades(t, func(
+		_ *testing.T,
+		tk *testkit.TestKit,
+		_, _ string,
+	) {
+		tk.MustExec("use test")
+		tk.MustExec("drop table if exists a")
+		tk.MustExec("drop table if exists d")
+		tk.MustExec("create table a(b char, c varchar(50));")
+		tk.MustExec(`insert a values("", "sc");`)
+		tk.MustExec("create table d(e varchar(0));")
+		tk.MustExec(`insert d values("");`)
+
+		query := "select /* issue:25600 */ if(b = '', '<empty>', b), c " +
+			"from a where c in (select b union select avg(e) from d)"
+		tk.MustQuery(query).Check(testkit.Rows("<empty> sc"))
+		tk.MustQuery(
+			`select /* issue:25600 */ 'sc' in (select 0 union select '')`,
+		).Check(testkit.Rows("1"))
+		tk.MustQuery(
+			`select /* issue:25600 */ 'sc' not in (select 0 union select '')`,
+		).Check(testkit.Rows("0"))
+		tk.MustQuery(
+			`select /* issue:25600 */ 'sc' in (select '' union select '0')`,
+		).Check(testkit.Rows("0"))
+	})
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #25600

Problem Summary:

TiDB returned an empty result for an `IN (subquery)` predicate when the subquery
was a `UNION` over mixed string and numeric source expressions:

```sql
SELECT * FROM a WHERE c IN(SELECT b UNION SELECT avg(e) FROM d);
```

MySQL evaluates this mixed-source `UNION` in a numeric comparison domain for the
`IN` predicate, so varchar value `sc` compares equal to numeric `0`. TiDB first
normalized the `UNION` output to string, then built a string/string equality for
the semi-join condition, so the matching row was missed.

### What changed and how does it work?

The planner now detects scalar `IN` subquery RHS columns that trace back to a
`UNION` output with both string and numeric source branches. For that specific
shape, it casts the RHS comparison key back to the numeric source type before
building the equality condition.

The displayed `UNION` output type is unchanged. The fix is local to `IN`
subquery comparison construction and does not change global string/integer
comparison or aggregate coercion policy.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Manual test (add detailed scripts or steps below)

Manual test:

```bash
go build -o /tmp/tidb-25600-server ./cmd/tidb-server
go build -o /tmp/tidb-25600-server-patched2 ./cmd/tidb-server
go test --tags=intest,deadlock ./pkg/planner/core/issuetest -run '^TestIssue25600InSubqueryMixedUnionComparison$' -count=1
go test --tags=intest,deadlock ./pkg/planner/core/issuetest -count=1
golangci-lint run --new-from-rev=origin/master ./pkg/planner/core ./pkg/planner/core/issuetest
make bazel_prepare
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that TiDB could return wrong results for IN subqueries whose UNION result has mixed string and numeric source expressions.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected IN-subquery equality behavior when a UNION combines numeric and string column types so comparisons cast and evaluate consistently.
* **Tests**
  * Added a regression test covering IN/NOT IN against UNION subqueries with mixed-type branches to prevent future regressions.
* **Chores**
  * Adjusted test sharding configuration to change test execution splitting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->