### PR TITLE
ddl: push prefix index projection for add index scans

### DIFF
--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -533,9 +533,11 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 		idxResults  []IndexRecordChunk
 		execDetails kvutil.ExecDetails
 	)
+
 	// Local ingest may trigger partial import/reset while the scan transaction is
 	// still open, so only the global-sort path can stream results immediately.
-	enableStreaming := w.reorgMeta.UseCloudStorage
+	enableStreaming := w.cpOp == nil
+	failpoint.InjectCall("checkEnableStreaming", enableStreaming)
 	sendResult := func(idxResult IndexRecordChunk) {
 		sender(idxResult)
 		if w.cpOp != nil {

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -536,7 +536,7 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 
 	// Local ingest may trigger partial import/reset while the scan transaction is
 	// still open, so only the global-sort path can stream results immediately.
-	enableStreaming := w.cpOp == nil
+	enableStreaming := w.reorgMeta.UseCloudStorage
 	failpoint.InjectCall("checkEnableStreaming", enableStreaming)
 	sendResult := func(idxResult IndexRecordChunk) {
 		sender(idxResult)

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -108,6 +108,12 @@ func newReadIndexExecutor(
 
 func (r *readIndexStepExecutor) Init(ctx context.Context) error {
 	logutil.DDLLogger().Info("read index executor init subtask exec env")
+	if r.isGlobalSort() {
+		// Multi-schema proxy jobs may not carry UseCloudStorage. Set it here
+		// before the framework starts detectAndHandleParamModifyLoop, which
+		// reads the flag concurrently via ResourceModified.
+		r.job.ReorgMeta.UseCloudStorage = true
+	}
 	cfg := config.GetGlobalConfig()
 	if cfg.Store == config.StoreTypeTiKV {
 		if !r.isGlobalSort() {
@@ -232,9 +238,6 @@ func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 
 	concurrency := int(r.GetResource().CPU.Capacity())
 	if r.isGlobalSort() {
-		// Multi-schema proxy jobs may not carry UseCloudStorage, while this executor
-		// has already selected the global-sort path by cloudStorageURI.
-		r.job.ReorgMeta.UseCloudStorage = true
 		return r.runGlobalPipeline(ctx, wctx, subtask, sm, concurrency, objStore)
 	}
 	return r.runLocalPipeline(ctx, wctx, subtask, sm, concurrency)

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -232,6 +232,9 @@ func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 
 	concurrency := int(r.GetResource().CPU.Capacity())
 	if r.isGlobalSort() {
+		// Multi-schema proxy jobs may not carry UseCloudStorage, while this executor
+		// has already selected the global-sort path by cloudStorageURI.
+		r.job.ReorgMeta.UseCloudStorage = true
 		return r.runGlobalPipeline(ctx, wctx, subtask, sm, concurrency, objStore)
 	}
 	return r.runLocalPipeline(ctx, wctx, subtask, sm, concurrency)

--- a/pkg/ddl/copr/copr_ctx.go
+++ b/pkg/ddl/copr/copr_ctx.go
@@ -49,6 +49,9 @@ type CopContextBase struct {
 
 	ColumnInfos []*model.ColumnInfo
 	FieldTypes  []*types.FieldType
+	// PrefixColumnLengths records optional prefix lengths for returned columns.
+	// A zero length means the column must be returned unchanged.
+	PrefixColumnLengths []int
 
 	ExprColumnInfos             []*expression.Column
 	HandleOutputOffsets         []int
@@ -182,6 +185,7 @@ func NewCopContextSingleIndex(
 	if err != nil {
 		return nil, err
 	}
+	base.initPrefixColumnLengths([]*model.IndexInfo{idxInfo})
 	idxOffsets := resolveIndicesForIndex(base.ExprColumnInfos, idxInfo, tblInfo)
 	return &CopContextSingleIndex{
 		CopContextBase:      base,
@@ -256,6 +260,7 @@ func NewCopContextMultiIndex(
 	if err != nil {
 		return nil, err
 	}
+	base.initPrefixColumnLengths(allIdxInfo)
 
 	idxOffsets := make([][]int, 0, len(allIdxInfo))
 	for _, idxInfo := range allIdxInfo {
@@ -349,6 +354,79 @@ func fillUsedColumns(
 		}
 	}
 	return usedCols, nil
+}
+
+// initPrefixColumnLengths marks scan outputs that can be safely returned as
+// SUBSTRING(col, 1, n) for ADD PREFIX INDEX backfill.
+func (c *CopContextBase) initPrefixColumnLengths(allIdxInfo []*model.IndexInfo) {
+	if !canUsePrefixProjection(c, allIdxInfo) {
+		return
+	}
+
+	prefixLens := make(map[int64]int)
+	if c.PrimaryKeyInfo != nil && c.TableInfo.IsCommonHandle {
+		collectPrefixProjectionRequirements(c.TableInfo, prefixLens, c.PrimaryKeyInfo.Columns)
+	}
+	for _, idxInfo := range allIdxInfo {
+		collectPrefixProjectionRequirements(c.TableInfo, prefixLens, idxInfo.Columns)
+	}
+
+	lengths := make([]int, len(c.ColumnInfos))
+	hasPrefix := false
+	for i, col := range c.ColumnInfos {
+		length := prefixLens[col.ID]
+		if length > 0 {
+			lengths[i] = length
+			hasPrefix = true
+		}
+	}
+	if hasPrefix {
+		c.PrefixColumnLengths = lengths
+	}
+}
+
+func canUsePrefixProjection(c *CopContextBase, allIdxInfo []*model.IndexInfo) bool {
+	if len(c.VirtualColumnsOutputOffsets) > 0 {
+		return false
+	}
+	for _, idxInfo := range allIdxInfo {
+		if idxInfo.HasCondition() || idxInfo.MVIndex {
+			return false
+		}
+	}
+	return true
+}
+
+// fullValueConsumer is a local sentinel in prefixLens. It means at least one
+// consumer needs the original full value, so this column cannot be truncated.
+const fullValueConsumer = -1
+
+func collectPrefixProjectionRequirements(
+	tblInfo *model.TableInfo,
+	prefixLens map[int64]int,
+	idxCols []*model.IndexColumn,
+) {
+	for _, idxCol := range idxCols {
+		col := tblInfo.Columns[idxCol.Offset]
+		if prefixLens[col.ID] == fullValueConsumer {
+			continue
+		}
+		if !canPushPrefixProjection(col, idxCol) {
+			prefixLens[col.ID] = fullValueConsumer
+			continue
+		}
+		prefixLens[col.ID] = max(prefixLens[col.ID], idxCol.Length)
+	}
+}
+
+func canPushPrefixProjection(col *model.ColumnInfo, idxCol *model.IndexColumn) bool {
+	if idxCol.Length == types.UnspecifiedLength || idxCol.Length <= 0 {
+		return false
+	}
+	if col.IsGenerated() {
+		return false
+	}
+	return types.IsString(col.GetType())
 }
 
 func resolveIndicesForIndex(

--- a/pkg/ddl/index_cop.go
+++ b/pkg/ddl/index_cop.go
@@ -29,6 +29,8 @@ import (
 	"github.com/pingcap/tidb/pkg/expression/exprctx"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
@@ -65,7 +67,7 @@ func wrapInBeginRollback(se *sess.Session, f func(startTS uint64) error) error {
 }
 
 func buildTableScan(ctx context.Context, c *copr.CopContextBase, distSQLCtx *distsqlctx.DistSQLContext, startTS uint64, start, end kv.Key, selectExpr expression.Expression) (distsql.SelectResult, bool, error) {
-	dagPB, conditionPushed, err := buildDAGPB(ctx, c.ExprCtx, distSQLCtx, c.PushDownFlags, c.TableInfo, c.ColumnInfos, selectExpr)
+	dagPB, conditionPushed, err := buildDAGPB(ctx, c.ExprCtx, distSQLCtx, c.PushDownFlags, c.TableInfo, c.ColumnInfos, c.PrefixColumnLengths, selectExpr)
 	if err != nil {
 		return nil, false, err
 	}
@@ -173,7 +175,7 @@ func getRestoreData(tblInfo *model.TableInfo, targetIdx, pkIdx *model.IndexInfo,
 	return dtToRestored
 }
 
-func buildDAGPB(ctx context.Context, exprCtx exprctx.BuildContext, distSQLCtx *distsqlctx.DistSQLContext, pushDownFlags uint64, tblInfo *model.TableInfo, colInfos []*model.ColumnInfo, selectExpr expression.Expression) (*tipb.DAGRequest, bool, error) {
+func buildDAGPB(ctx context.Context, exprCtx exprctx.BuildContext, distSQLCtx *distsqlctx.DistSQLContext, pushDownFlags uint64, tblInfo *model.TableInfo, colInfos []*model.ColumnInfo, prefixColumnLengths []int, selectExpr expression.Expression) (*tipb.DAGRequest, bool, error) {
 	conditionPushed := false
 
 	dagReq := &tipb.DAGRequest{}
@@ -188,6 +190,7 @@ func buildDAGPB(ctx context.Context, exprCtx exprctx.BuildContext, distSQLCtx *d
 	}
 
 	var selectionPB *tipb.Executor
+	rootPB := tblScanPB
 	if selectExpr != nil {
 		selectionPB, err = constructSelectionPB(exprCtx, selectExpr, distSQLCtx, tblScanPB)
 	}
@@ -197,6 +200,7 @@ func buildDAGPB(ctx context.Context, exprCtx exprctx.BuildContext, distSQLCtx *d
 	if err == nil && selectionPB != nil {
 		conditionPushed = true
 		dagReq.Executors = append(dagReq.Executors, tblScanPB, selectionPB)
+		rootPB = selectionPB
 	} else {
 		if selectExpr != nil {
 			selectExprStr := selectExpr.StringWithCtx(exprCtx.GetEvalCtx(), errors.RedactLogDisable)
@@ -206,6 +210,15 @@ func buildDAGPB(ctx context.Context, exprCtx exprctx.BuildContext, distSQLCtx *d
 				zap.Error(err))
 		}
 		dagReq.Executors = append(dagReq.Executors, tblScanPB)
+	}
+
+	projectionPB, err := constructPrefixProjectionPB(exprCtx, distSQLCtx, colInfos, prefixColumnLengths, rootPB)
+	if err != nil {
+		logutil.Logger(ctx).Info("fail to push down prefix index projection for add index",
+			zap.String("table", tblInfo.Name.O),
+			zap.Error(err))
+	} else if projectionPB != nil {
+		dagReq.Executors = append(dagReq.Executors, projectionPB)
 	}
 
 	distsql.SetEncodeType(distSQLCtx, dagReq)
@@ -219,6 +232,66 @@ func constructTableScanPB(ctx exprctx.BuildContext, tblInfo *model.TableInfo, co
 	tblScan.TableId = tblInfo.ID
 	err := tables.SetPBColumnsDefaultValue(ctx, tblScan.Columns, colInfos)
 	return &tipb.Executor{Tp: tipb.ExecType_TypeTableScan, TblScan: tblScan}, err
+}
+
+func constructPrefixProjectionPB(
+	ctx exprctx.BuildContext,
+	distSQLCtx *distsqlctx.DistSQLContext,
+	colInfos []*model.ColumnInfo,
+	prefixColumnLengths []int,
+	child *tipb.Executor,
+) (*tipb.Executor, error) {
+	if len(prefixColumnLengths) != len(colInfos) || !hasPrefixProjection(prefixColumnLengths) {
+		return nil, nil
+	}
+
+	exprs := make([]expression.Expression, 0, len(colInfos))
+	for i, colInfo := range colInfos {
+		col := &expression.Column{
+			RetType: &colInfo.FieldType,
+			ID:      colInfo.ID,
+			Index:   i,
+		}
+		if prefixColumnLengths[i] == 0 {
+			exprs = append(exprs, col)
+			continue
+		}
+
+		start := &expression.Constant{
+			Value:   types.NewIntDatum(1),
+			RetType: types.NewFieldType(mysql.TypeLonglong),
+		}
+		length := &expression.Constant{
+			Value:   types.NewIntDatum(int64(prefixColumnLengths[i])),
+			RetType: types.NewFieldType(mysql.TypeLonglong),
+		}
+		expr, err := expression.NewFunction(ctx, ast.Substring, colInfo.FieldType.Clone(), col, start, length)
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, expr)
+	}
+
+	pbExprs, err := expression.ProjectionExpressionsToPBList(ctx.GetEvalCtx(), exprs, distSQLCtx.Client)
+	if err != nil {
+		return nil, err
+	}
+	return &tipb.Executor{
+		Tp: tipb.ExecType_TypeProjection,
+		Projection: &tipb.Projection{
+			Exprs: pbExprs,
+			Child: child,
+		},
+	}, nil
+}
+
+func hasPrefixProjection(prefixColumnLengths []int) bool {
+	for _, length := range prefixColumnLengths {
+		if length > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func constructSelectionPB(ctx exprctx.BuildContext, expr expression.Expression, distSQLCtx *distsqlctx.DistSQLContext, child *tipb.Executor) (*tipb.Executor, error) {

--- a/pkg/ddl/index_cop_test.go
+++ b/pkg/ddl/index_cop_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/ddl"
-	"github.com/pingcap/tidb/pkg/ddl/copr"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -37,16 +36,22 @@ func TestAddIndexFetchRowsFromCoprocessor(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
-	testFetchRows := func(db, tb, idx string) ([]kv.Handle, [][]types.Datum) {
+	testFetchRowsForIndexes := func(db, tb string, idxNames []string, targetIdx string) ([]kv.Handle, [][]types.Datum) {
 		tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr(db), ast.NewCIStr(tb))
 		require.NoError(t, err)
 		tblInfo := tbl.Meta()
-		idxInfo := tblInfo.FindIndexByName(idx)
+		idxInfos := make([]*model.IndexInfo, 0, len(idxNames))
+		for _, idx := range idxNames {
+			idxInfo := tblInfo.FindIndexByName(idx)
+			require.NotNil(t, idxInfo)
+			idxInfos = append(idxInfos, idxInfo)
+		}
+		targetIdxInfo := tblInfo.FindIndexByName(targetIdx)
+		require.NotNil(t, targetIdxInfo)
 
 		sctx := tk.Session()
-		copCtx, err := ddl.NewReorgCopContext(ddl.NewDDLReorgMeta(sctx), tblInfo, []*model.IndexInfo{idxInfo}, "")
+		copCtx, err := ddl.NewReorgCopContext(ddl.NewDDLReorgMeta(sctx), tblInfo, idxInfos, "")
 		require.NoError(t, err)
-		require.IsType(t, copCtx, &copr.CopContextSingleIndex{})
 		startKey := tbl.RecordPrefix()
 		endKey := startKey.PrefixNext()
 		txn, err := store.Begin()
@@ -59,10 +64,11 @@ func TestAddIndexFetchRowsFromCoprocessor(t *testing.T) {
 		handles := make([]kv.Handle, 0, copChunk.NumRows())
 		values := make([][]types.Datum, 0, copChunk.NumRows())
 		handleDataBuf := make([]types.Datum, len(copCtx.GetBase().HandleOutputOffsets))
-		idxDataBuf := make([]types.Datum, len(idxInfo.Columns))
+		idxDataBuf := make([]types.Datum, len(targetIdxInfo.Columns))
 
 		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-			handle, idxDatum, err := ConvertRowToHandleAndIndexDatum(tk.Session().GetExprCtx().GetEvalCtx(), handleDataBuf, idxDataBuf, row, copCtx, idxInfo.ID)
+			handle, idxDatum, err := ConvertRowToHandleAndIndexDatum(
+				tk.Session().GetExprCtx().GetEvalCtx(), handleDataBuf, idxDataBuf, row, copCtx, targetIdxInfo.ID)
 			require.NoError(t, err)
 			handles = append(handles, handle)
 			copiedIdxDatum := make([]types.Datum, len(idxDatum))
@@ -70,6 +76,9 @@ func TestAddIndexFetchRowsFromCoprocessor(t *testing.T) {
 			values = append(values, copiedIdxDatum)
 		}
 		return handles, values
+	}
+	testFetchRows := func(db, tb, idx string) ([]kv.Handle, [][]types.Datum) {
+		return testFetchRowsForIndexes(db, tb, []string{idx}, idx)
 	}
 
 	// Test nonclustered primary key table.
@@ -113,4 +122,73 @@ func TestAddIndexFetchRowsFromCoprocessor(t *testing.T) {
 		require.Len(t, vals[i], 1)
 		require.Equal(t, vals[i][0].GetInt64(), int64(i))
 	}
+
+	// Test prefix index values are truncated in coprocessor for index-only columns.
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a varchar(20) character set utf8mb4 collate utf8mb4_bin, index idx (a(2)));")
+	tk.MustExec("insert into t values ('abcdef'), ('你好世界');")
+	hds, vals = testFetchRows("test", "t", "idx")
+	require.Len(t, hds, 2)
+	require.Len(t, vals[0], 1)
+	require.Equal(t, "ab", vals[0][0].GetString())
+	require.Len(t, vals[1], 1)
+	require.Equal(t, "你好", vals[1][0].GetString())
+
+	// Test binary prefix index values are truncated by bytes.
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a varbinary(20), index idx (a(2)));")
+	tk.MustExec("insert into t values (x'e4bda0e5a5bd');")
+	hds, vals = testFetchRows("test", "t", "idx")
+	require.Len(t, hds, 1)
+	require.Len(t, vals[0], 1)
+	require.Equal(t, []byte{0xe4, 0xbd}, vals[0][0].GetBytes())
+
+	// Test common-handle prefix columns fetch the longest prefix needed by all
+	// handle and secondary-index consumers.
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a varchar(20), primary key (a(4)) clustered, index idx (a(2)));")
+	tk.MustExec("insert into t values ('abcdef');")
+	hds, vals = testFetchRows("test", "t", "idx")
+	require.Len(t, hds, 1)
+	require.Equal(t, "{abcd}", hds[0].String())
+	require.Len(t, vals[0], 1)
+	require.Equal(t, "abcd", vals[0][0].GetString())
+
+	// Test full common-handle columns still fetch the full value.
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a varchar(20), primary key (a) clustered, index idx (a(2)));")
+	tk.MustExec("insert into t values ('abcdef');")
+	hds, vals = testFetchRows("test", "t", "idx")
+	require.Len(t, hds, 1)
+	require.Equal(t, "{abcdef}", hds[0].String())
+	require.Len(t, vals[0], 1)
+	require.Equal(t, "abcdef", vals[0][0].GetString())
+
+	// Test merged add-index scan fetches the longest prefix needed by all indexes
+	// over the same source column.
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a varchar(20), index idx_short(a(2)), index idx_long(a(4)));")
+	tk.MustExec("insert into t values ('abcdef');")
+	hds, vals = testFetchRowsForIndexes("test", "t", []string{"idx_short", "idx_long"}, "idx_short")
+	require.Len(t, hds, 1)
+	require.Len(t, vals[0], 1)
+	require.Equal(t, "abcd", vals[0][0].GetString())
+
+	// Test any full-value consumer disables prefix projection for that source column.
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a varchar(20), index idx_prefix(a(2)), index idx_full(a));")
+	tk.MustExec("insert into t values ('abcdef');")
+	hds, vals = testFetchRowsForIndexes("test", "t", []string{"idx_prefix", "idx_full"}, "idx_prefix")
+	require.Len(t, hds, 1)
+	require.Len(t, vals[0], 1)
+	require.Equal(t, "abcdef", vals[0][0].GetString())
+
+	// Test partial-index conditions keep full values for condition/checker safety.
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a varchar(20), b int, index idx (a(2)) where b > 0);")
+	tk.MustExec("insert into t values ('abcdef', 1);")
+	hds, vals = testFetchRows("test", "t", "idx")
+	require.Len(t, hds, 1)
+	require.Len(t, vals[0], 1)
+	require.Equal(t, "abcdef", vals[0][0].GetString())
 }

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -200,6 +200,12 @@ func TestGlobalSortBasic(t *testing.T) {
 		jobID = job.ID
 	})
 
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkEnableStreaming",
+		func(enabled bool) {
+			require.True(t, enabled, "streaming should be enabled with global sort")
+		},
+	)
+
 	tk.MustExec("alter table t add index idx(a);")
 	checkDataAndShowJobs(t, tk, size)
 	checkExternalFields(t, tk)
@@ -282,6 +288,14 @@ func TestGlobalSortMultiSchemaChange(t *testing.T) {
 					t.Skip("DXF is always enabled on nextgen")
 				}
 			}
+
+			testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkEnableStreaming",
+				func(enabled bool) {
+					expected := tc.cloudStorageURI != ""
+					require.Equal(t, expected, enabled)
+				},
+			)
+
 			if kerneltype.IsClassic() {
 				tk.MustExec("set @@global.tidb_ddl_enable_fast_reorg = " + tc.enableFastReorg + ";")
 				tk.MustExec("set @@global.tidb_enable_dist_task = " + tc.enableDistTask + ";")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #

Problem Summary:

When adding a prefix index through the coprocessor scan path, TiDB currently fetches the full column value from TiKV even if only an index prefix is needed. This can transfer unnecessary data for large string or binary columns.

### What changed and how does it work?

This PR adds a conservative prefix-projection path for add-index coprocessor scans:

- Tracks per-output-column prefix lengths in the add-index coprocessor context.
- Pushes a TiKV projection using `SUBSTRING(col, 1, prefix_len)` when all consumers of that column only need a bounded prefix.
- Uses the maximum required prefix length when multiple target indexes or a clustered common handle need different prefix lengths.
- Falls back to the full column value when a full-value consumer exists, including full clustered common handle columns.
- Disables this projection for partial indexes, multi-valued indexes, generated columns, non-string columns, and virtual-column output.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual validation:

```bash
go test ./pkg/ddl/copr -run Test -count=1
./tools/check/failpoint-go-test.sh pkg/ddl -run TestAddIndexFetchRowsFromCoprocessor -count=1
make server
tiup playground nightly --db 1 --db.binpath /mnt/data/joechenrh/pingcap/tidb/worktrees/prefix-index-compressor/bin/tidb-server --pd 1 --kv 1 --tiflash 0 --without-monitor --tag prefix-corner-rerun --port-offset 28000
mysql --comments --host 127.0.0.1 --port 32000 -u root --batch --raw
git diff --check
```

The TiUP playground run covered local ingest add-index cases for multiple prefix indexes on the same column, prefix plus full index on the same column, clustered common handle with prefix and full primary keys, composite indexes, `utf8mb4_bin`, `utf8mb4_general_ci`, `gbk`, `ascii_bin`, `varbinary`, generated columns, partial indexes, and multi-valued indexes.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
