### PR TITLE
ttl: trigger startup GC when job manager becomes leader

### DIFF
--- a/pkg/ttl/ttlworker/job_manager.go
+++ b/pkg/ttl/ttlworker/job_manager.go
@@ -201,10 +201,18 @@ func (m *JobManager) jobLoopWithSession(se session.Session) (err error) {
 	cmdWatcher := m.cmdCli.WatchCommand(m.ctx)
 	scanTaskNotificationWatcher := m.notificationCli.WatchNotification(m.ctx, scanTaskNotificationType)
 	m.taskManager.resizeWorkersWithSysVar()
+	lastLeaderState := false
 	for {
 		m.reportMetrics(se)
 		m.taskManager.reportMetrics()
 		now := se.Now()
+		currentLeaderState := m.isLeader()
+		if currentLeaderState && !lastLeaderState {
+			gcCtx, cancel := context.WithTimeout(m.ctx, ttlInternalSQLTimeout)
+			m.DoGC(gcCtx, se, now)
+			cancel()
+		}
+		lastLeaderState = currentLeaderState
 
 		select {
 		// misc

--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -1837,6 +1837,35 @@ func TestTimerJobAfterDropTable(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, job)
 	require.True(t, job.Finished)
+
+	t.Run("leader startup triggers GC immediately", func(t *testing.T) {
+		tk.MustExec("create table t2 (created_at datetime) TTL = created_at + INTERVAL 1 HOUR")
+		tbl2, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t2"))
+		require.NoError(t, err)
+		tk.MustExec("drop table t2")
+
+		// Simulate stale metadata left by a previous leader after the job state was already
+		// cleared. Startup as leader should GC it immediately instead of waiting for the
+		// default 10-minute gcTicker.
+		tk.MustExec("insert into mysql.tidb_ttl_table_status (table_id, parent_table_id) values (?, ?)", tbl2.Meta().ID, tbl2.Meta().ID)
+		tk.MustExec(`insert into mysql.tidb_ttl_task
+			(job_id, table_id, scan_id, expire_time, created_time)
+			values (?, ?, ?, now(), now())`, "stale-job", tbl2.Meta().ID, 1)
+		tk.MustQuery("select count(*) from mysql.tidb_ttl_table_status where table_id = ?", tbl2.Meta().ID).Check(testkit.Rows("1"))
+		tk.MustQuery("select count(*) from mysql.tidb_ttl_task where table_id = ?", tbl2.Meta().ID).Check(testkit.Rows("1"))
+
+		startupManager := ttlworker.NewJobManager("test-job-manager-startup-gc", pool, store, nil, func() bool { return true })
+		startupManager.Start()
+		defer func() {
+			startupManager.Stop()
+			require.NoError(t, startupManager.WaitStopped(context.Background(), time.Minute))
+		}()
+
+		require.Eventually(t, func() bool {
+			return tk.MustQuery("select count(*) from mysql.tidb_ttl_table_status where table_id = ?", tbl2.Meta().ID).Rows()[0][0].(string) == "0" &&
+				tk.MustQuery("select count(*) from mysql.tidb_ttl_task where table_id = ?", tbl2.Meta().ID).Rows()[0][0].(string) == "0"
+		}, 5*time.Second, 100*time.Millisecond)
+	})
 }
 
 func testIterationOfRunningJobWithTimeout(t *testing.T, sessionTimeout time.Duration, tableCount int64, sleepPerTable time.Duration) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/68602

Problem Summary:

TTL metadata GC only ran on the periodic `gcTicker` in `JobManager`, whose default interval is 10 minutes. If a TiDB node starts as TTL leader but does not stay alive long enough, stale rows in `mysql.tidb_ttl_table_status` and `mysql.tidb_ttl_task` can survive for the whole process lifetime instead of being cleaned immediately.

### What changed and how does it work?

This PR triggers `DoGC` immediately when `pkg/ttl/ttlworker.JobManager` transitions from non-leader to leader inside `jobLoopWithSession`.

The change keeps the existing `DoGC` implementation and only adjusts when it is called:

- track the previous leader state in the job loop
- when the current iteration becomes leader and the previous iteration was not leader, run `DoGC` once with the loop-owned internal session
- keep the periodic GC ticker unchanged

The regression test extends `TestTimerJobAfterDropTable` with a subtest that inserts orphan TTL metadata for a dropped table, starts a leader job manager, and asserts that the stale rows are removed within seconds. The same subtest fails before the code change and passes after it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix the issue that a newly started TTL leader may wait until the periodic GC interval before cleaning stale TTL metadata.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cleanup of stale TTL (time-to-live) entries when a database instance transitions to a leadership role, ensuring orphaned data is promptly removed from the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->