### PR TITLE
server: support optional resultset metadata

### DIFF
--- a/pkg/errno/errcode.go
+++ b/pkg/errno/errcode.go
@@ -899,6 +899,7 @@ const (
 	ErrCTEMaxRecursionDepth                                  = 3636
 	ErrNotHintUpdatable                                      = 3637
 	ErrExistsInHistoryPassword                               = 3638
+	ErrClientDoesNotSupport                                  = 3640
 	ErrInvalidDefaultUTF8MB4Collation                        = 3721
 	ErrForeignKeyCannotDropParent                            = 3730
 	ErrForeignKeyCannotUseVirtualColumn                      = 3733

--- a/pkg/errno/errname.go
+++ b/pkg/errno/errname.go
@@ -895,6 +895,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrLockAcquireFailAndNoWaitSet:                           mysql.Message("Statement aborted because lock(s) could not be acquired immediately and NOWAIT is set.", nil),
 	ErrNotHintUpdatable:                                      mysql.Message("Variable '%s' might not be affected by SET_VAR hint.", nil),
 	ErrExistsInHistoryPassword:                               mysql.Message("Cannot use these credentials for '%s@%s' because they contradict the password history policy.", nil),
+	ErrClientDoesNotSupport:                                  mysql.Message("The client doesn't support %s", nil),
 	ErrInvalidDefaultUTF8MB4Collation:                        mysql.Message("Invalid default collation %s: utf8mb4_0900_ai_ci or utf8mb4_general_ci or utf8mb4_bin expected", nil),
 	ErrForeignKeyCannotDropParent:                            mysql.Message("Cannot drop table '%s' referenced by a foreign key constraint '%s' on table '%s'.", nil),
 	ErrForeignKeyCannotUseVirtualColumn:                      mysql.Message("Foreign key '%s' uses virtual column '%s' which is not supported.", nil),

--- a/pkg/parser/mysql/const.go
+++ b/pkg/parser/mysql/const.go
@@ -230,7 +230,7 @@ const (
 	ClientHandleExpiredPasswords                        // CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS, Not supported: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_expired_passwords.html
 	ClientSessionTrack                                  // CLIENT_SESSION_TRACK, Not supported: https://github.com/pingcap/tidb/issues/35309
 	ClientDeprecateEOF                                  // CLIENT_DEPRECATE_EOF
-	ClientOptionalResultsetMetadata                     // CLIENT_OPTIONAL_RESULTSET_METADATA, Not supported: https://dev.mysql.com/doc/c-api/8.0/en/c-api-optional-metadata.html
+	ClientOptionalResultsetMetadata                     // CLIENT_OPTIONAL_RESULTSET_METADATA
 	ClientZstdCompressionAlgorithm                      // CLIENT_ZSTD_COMPRESSION_ALGORITHM
 	// 1 << 27 == CLIENT_QUERY_ATTRIBUTES
 	// 1 << 28 == MULTI_FACTOR_AUTHENTICATION
@@ -242,6 +242,12 @@ const (
 // Cache type information.
 const (
 	TypeNoCache byte = 0xff
+)
+
+// Optional result set metadata markers.
+const (
+	ResultsetMetadataNone byte = 0
+	ResultsetMetadataFull byte = 1
 )
 
 // Auth name information.

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -2489,11 +2489,13 @@ func (cc *clientConn) handleFieldList(ctx context.Context, sql string) (err erro
 	data := cc.alloc.AllocWithLen(4, 1024)
 	cc.initResultEncoder(ctx)
 	defer cc.rsEncoder.Clean()
-	for _, column := range columns {
-		data = data[0:4]
-		data = column.DumpWithDefault(data, cc.rsEncoder)
-		if err := cc.writePacket(data); err != nil {
-			return err
+	if cc.resultsetMetadata() == mysql.ResultsetMetadataFull {
+		for _, column := range columns {
+			data = data[0:4]
+			data = column.DumpWithDefault(data, cc.rsEncoder)
+			if err := cc.writePacket(data); err != nil {
+				return err
+			}
 		}
 	}
 	if err := cc.writeEOF(ctx, cc.ctx.Status()); err != nil {
@@ -2547,11 +2549,33 @@ func (cc *clientConn) writeResultSet(ctx context.Context, rs resultset.ResultSet
 	return false, cc.flush(ctx)
 }
 
+func (cc *clientConn) optionalResultsetMetadataEnabled() bool {
+	return cc.capability&mysql.ClientOptionalResultsetMetadata != 0
+}
+
+func (cc *clientConn) resultsetMetadata() byte {
+	if !cc.optionalResultsetMetadataEnabled() {
+		return mysql.ResultsetMetadataFull
+	}
+	ctx := cc.getCtx()
+	if ctx == nil {
+		return mysql.ResultsetMetadataFull
+	}
+	return ctx.GetSessionVars().ResultsetMetadata
+}
+
 func (cc *clientConn) writeColumnInfo(columns []*column.Info) error {
 	data := cc.alloc.AllocWithLen(4, 1024)
 	data = dump.LengthEncodedInt(data, uint64(len(columns)))
+	metadata := cc.resultsetMetadata()
+	if cc.optionalResultsetMetadataEnabled() {
+		data = append(data, metadata)
+	}
 	if err := cc.writePacket(data); err != nil {
 		return err
+	}
+	if metadata == mysql.ResultsetMetadataNone {
+		return nil
 	}
 	for _, v := range columns {
 		data = data[0:4]

--- a/pkg/server/conn_stmt.go
+++ b/pkg/server/conn_stmt.go
@@ -89,6 +89,10 @@ func (cc *clientConn) HandleStmtPrepare(ctx context.Context, sql string) error {
 	data = append(data, 0)
 	// warning count
 	data = append(data, 0, 0) // TODO support warning count
+	metadata := cc.resultsetMetadata()
+	if cc.optionalResultsetMetadataEnabled() {
+		data = append(data, metadata)
+	}
 
 	if err := cc.writePacket(data); err != nil {
 		return err
@@ -96,7 +100,7 @@ func (cc *clientConn) HandleStmtPrepare(ctx context.Context, sql string) error {
 
 	cc.initResultEncoder(ctx)
 	defer cc.rsEncoder.Clean()
-	if len(params) > 0 {
+	if metadata == mysql.ResultsetMetadataFull && len(params) > 0 {
 		for i := range params {
 			data = data[0:4]
 			data = params[i].Dump(data, cc.rsEncoder)
@@ -114,7 +118,7 @@ func (cc *clientConn) HandleStmtPrepare(ctx context.Context, sql string) error {
 		}
 	}
 
-	if len(columns) > 0 {
+	if metadata == mysql.ResultsetMetadataFull && len(columns) > 0 {
 		for i := range columns {
 			data = data[0:4]
 			data = columns[i].Dump(data, cc.rsEncoder)

--- a/pkg/server/conn_stmt_test.go
+++ b/pkg/server/conn_stmt_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/server/internal"
 	"github.com/pingcap/tidb/pkg/server/internal/column"
 	"github.com/pingcap/tidb/pkg/server/internal/resultset"
+	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/arena"
@@ -56,6 +57,69 @@ func (m *mockCursorRUV2ConsumptionReporter) ReportRUV2Consumption(resourceGroupN
 	m.tikvRUV2 += tikvRUV2
 	m.tidbRUV2 += tidbRUV2
 	m.tiflashRU += tiflashRUV2
+}
+
+func TestOptionalResultsetMetadataPreparedStatement(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	srv := CreateMockServer(t, store)
+	srv.SetDomain(dom)
+	defer srv.Close()
+
+	ctx := context.Background()
+	appendUint32 := binary.LittleEndian.AppendUint32
+	c := CreateMockConn(t, srv).(*mockConn)
+	tk := testkit.NewTestKitWithSession(t, store, c.Context().Session)
+	tk.MustExec("use test")
+
+	optionalMetadataMode(t, c, tk, mysql.ClientProtocol41, vardef.ResultsetMetadataFull)
+	out := c.GetOutput()
+	require.NoError(t, c.HandleStmtPrepare(ctx, "select ? as a"))
+	payloads := packetPayloads(t, out.Bytes())
+	require.Len(t, payloads[0], 12)
+	require.Equal(t, 2, columnDefinitionPayloadCount(payloads))
+
+	optionalMetadataMode(t, c, tk, mysql.ClientProtocol41|mysql.ClientOptionalResultsetMetadata, vardef.ResultsetMetadataFull)
+	out = c.GetOutput()
+	require.NoError(t, c.HandleStmtPrepare(ctx, "select ? as a"))
+	payloads = packetPayloads(t, out.Bytes())
+	require.Len(t, payloads[0], 13)
+	require.Equal(t, mysql.ResultsetMetadataFull, payloads[0][12])
+	require.Equal(t, 2, columnDefinitionPayloadCount(payloads))
+
+	optionalMetadataMode(t, c, tk, mysql.ClientProtocol41|mysql.ClientOptionalResultsetMetadata, vardef.ResultsetMetadataNone)
+	out = c.GetOutput()
+	require.NoError(t, c.HandleStmtPrepare(ctx, "select ? as a"))
+	payloads = packetPayloads(t, out.Bytes())
+	require.Len(t, payloads, 1)
+	require.Len(t, payloads[0], 13)
+	require.Equal(t, mysql.ResultsetMetadataNone, payloads[0][12])
+
+	stmt, _, _, err := c.Context().Prepare("select 1 as a")
+	require.NoError(t, err)
+	out = c.GetOutput()
+	require.NoError(t, c.Dispatch(ctx, append(appendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt.ID())), 0x0, 0x1, 0x0, 0x0, 0x0)))
+	payloads = packetPayloads(t, out.Bytes())
+	require.Equal(t, []byte{0x01, mysql.ResultsetMetadataNone}, payloads[0])
+	require.Equal(t, 0, columnDefinitionPayloadCount(payloads))
+
+	cursorStmt, _, _, err := c.Context().Prepare("select * from (select 1 as id union all select 2 as id) t order by id")
+	require.NoError(t, err)
+	out = c.GetOutput()
+	require.NoError(t, c.Dispatch(ctx, append(
+		appendUint32([]byte{mysql.ComStmtExecute}, uint32(cursorStmt.ID())),
+		mysql.CursorTypeReadOnly, 0x1, 0x0, 0x0, 0x0,
+	)))
+	payloads = packetPayloads(t, out.Bytes())
+	require.Equal(t, []byte{0x01, mysql.ResultsetMetadataNone}, payloads[0])
+	require.Equal(t, 0, columnDefinitionPayloadCount(payloads))
+	require.True(t, mysql.HasCursorExistsFlag(binary.LittleEndian.Uint16(payloads[len(payloads)-1][3:5])))
+
+	out = c.GetOutput()
+	require.NoError(t, c.Dispatch(ctx, appendUint32(appendUint32([]byte{mysql.ComStmtFetch}, uint32(cursorStmt.ID())), 1)))
+	require.NoError(t, c.flush(ctx))
+	payloads = packetPayloads(t, out.Bytes())
+	require.Equal(t, 0, columnDefinitionPayloadCount(payloads))
+	require.True(t, mysql.HasCursorExistsFlag(binary.LittleEndian.Uint16(payloads[len(payloads)-1][3:5])))
 }
 
 type mockCursorTrackerRecordSet struct{}

--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -957,6 +957,109 @@ func testDispatch(t *testing.T, inputs []dispatchInput, capability uint32) {
 	}
 }
 
+func packetPayloads(t *testing.T, data []byte) [][]byte {
+	t.Helper()
+
+	var payloads [][]byte
+	for len(data) > 0 {
+		require.GreaterOrEqual(t, len(data), 4)
+		length := int(data[0]) | int(data[1])<<8 | int(data[2])<<16
+		require.GreaterOrEqual(t, len(data), 4+length)
+		payloads = append(payloads, append([]byte(nil), data[4:4+length]...))
+		data = data[4+length:]
+	}
+	return payloads
+}
+
+func columnDefinitionPayloadCount(payloads [][]byte) int {
+	count := 0
+	for _, payload := range payloads {
+		if len(payload) >= 4 && payload[0] == 0x03 && bytes.Equal(payload[1:4], []byte("def")) {
+			count++
+		}
+	}
+	return count
+}
+
+func optionalMetadataMode(t *testing.T, c *mockConn, tk *testkit.TestKit, capability uint32, mode string) {
+	t.Helper()
+
+	c.capability = capability
+	c.Context().SetClientCapability(capability)
+	tk.MustExec(fmt.Sprintf("set session resultset_metadata = '%s'", mode))
+}
+
+func TestOptionalResultsetMetadata(t *testing.T) {
+	require.NotZero(t, defaultCapability&mysql.ClientOptionalResultsetMetadata)
+
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	srv := CreateMockServer(t, store)
+	srv.SetDomain(dom)
+	defer srv.Close()
+
+	ctx := context.Background()
+	c := CreateMockConn(t, srv).(*mockConn)
+	tk := testkit.NewTestKitWithSession(t, store, c.Context().Session)
+	tk.MustExec("use test")
+
+	t.Run("text protocol legacy full and none", func(t *testing.T) {
+		optionalMetadataMode(t, c, tk, 0, vardef.ResultsetMetadataFull)
+		out := c.GetOutput()
+		require.NoError(t, c.HandleQuery(ctx, "select 1 as a"))
+		payloads := packetPayloads(t, out.Bytes())
+		require.Equal(t, []byte{0x01}, payloads[0])
+		require.Equal(t, 1, columnDefinitionPayloadCount(payloads))
+
+		optionalMetadataMode(t, c, tk, mysql.ClientOptionalResultsetMetadata, vardef.ResultsetMetadataFull)
+		out = c.GetOutput()
+		require.NoError(t, c.HandleQuery(ctx, "select 1 as a"))
+		payloads = packetPayloads(t, out.Bytes())
+		require.Equal(t, []byte{0x01, mysql.ResultsetMetadataFull}, payloads[0])
+		require.Equal(t, 1, columnDefinitionPayloadCount(payloads))
+
+		optionalMetadataMode(t, c, tk, mysql.ClientOptionalResultsetMetadata, vardef.ResultsetMetadataNone)
+		out = c.GetOutput()
+		require.NoError(t, c.HandleQuery(ctx, "select 1 as a"))
+		payloads = packetPayloads(t, out.Bytes())
+		require.Equal(t, []byte{0x01, mysql.ResultsetMetadataNone}, payloads[0])
+		require.Equal(t, 0, columnDefinitionPayloadCount(payloads))
+	})
+
+	t.Run("multiple result sets include marker for each result", func(t *testing.T) {
+		optionalMetadataMode(t, c, tk, mysql.ClientOptionalResultsetMetadata|mysql.ClientMultiStatements, vardef.ResultsetMetadataNone)
+		out := c.GetOutput()
+		require.NoError(t, c.HandleQuery(ctx, "select 1 as a; select 2 as b"))
+		payloads := packetPayloads(t, out.Bytes())
+		markers := 0
+		for _, payload := range payloads {
+			if bytes.Equal(payload, []byte{0x01, mysql.ResultsetMetadataNone}) {
+				markers++
+			}
+		}
+		require.Equal(t, 2, markers)
+		require.Equal(t, 0, columnDefinitionPayloadCount(payloads))
+	})
+
+	t.Run("field list respects metadata mode", func(t *testing.T) {
+		tk.MustExec("drop table if exists optional_metadata_field_list")
+		tk.MustExec("create table optional_metadata_field_list(a int)")
+
+		optionalMetadataMode(t, c, tk, mysql.ClientOptionalResultsetMetadata, vardef.ResultsetMetadataFull)
+		out := c.GetOutput()
+		require.NoError(t, c.handleFieldList(ctx, "optional_metadata_field_list\x00"))
+		payloads := packetPayloads(t, out.Bytes())
+		require.Equal(t, 1, columnDefinitionPayloadCount(payloads))
+		require.Equal(t, byte(mysql.EOFHeader), payloads[len(payloads)-1][0])
+
+		optionalMetadataMode(t, c, tk, mysql.ClientOptionalResultsetMetadata, vardef.ResultsetMetadataNone)
+		out = c.GetOutput()
+		require.NoError(t, c.handleFieldList(ctx, "optional_metadata_field_list\x00"))
+		payloads = packetPayloads(t, out.Bytes())
+		require.Equal(t, 1, len(payloads))
+		require.Equal(t, byte(mysql.EOFHeader), payloads[0][0])
+	})
+}
+
 func TestGetSessionVarsWaitTimeout(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -117,7 +117,8 @@ const defaultCapability = mysql.ClientLongPassword | mysql.ClientLongFlag |
 	mysql.ClientTransactions | mysql.ClientSecureConnection | mysql.ClientFoundRows |
 	mysql.ClientMultiStatements | mysql.ClientMultiResults | mysql.ClientLocalFiles |
 	mysql.ClientConnectAtts | mysql.ClientPluginAuth | mysql.ClientInteractive |
-	mysql.ClientDeprecateEOF | mysql.ClientCompress | mysql.ClientZstdCompressionAlgorithm
+	mysql.ClientDeprecateEOF | mysql.ClientOptionalResultsetMetadata |
+	mysql.ClientCompress | mysql.ClientZstdCompressionAlgorithm
 
 const normalClosedConnsCapacity = 1000
 

--- a/pkg/sessionctx/vardef/sysvar.go
+++ b/pkg/sessionctx/vardef/sysvar.go
@@ -50,6 +50,8 @@ const (
 	CharacterSetFilesystem = "character_set_filesystem"
 	// CharacterSetClient is the name for character_set_client system variable.
 	CharacterSetClient = "character_set_client"
+	// ResultsetMetadata is the name for resultset_metadata system variable.
+	ResultsetMetadata = "resultset_metadata"
 	// CharacterSetSystem is the name for character_set_system system variable.
 	CharacterSetSystem = "character_set_system"
 	// GeneralLog is the name for 'general_log' system variable.
@@ -349,4 +351,10 @@ const (
 	ValidatePasswordSpecialCharCount = "validate_password.special_char_count"
 	// ValidatePasswordDictionary specified the dictionary that validate_password uses for checking passwords. Each word is separated by semicolon (;).
 	ValidatePasswordDictionary = "validate_password.dictionary"
+)
+
+// Resultset metadata modes.
+const (
+	ResultsetMetadataNone = "NONE"
+	ResultsetMetadataFull = "FULL"
 )

--- a/pkg/sessionctx/variable/error.go
+++ b/pkg/sessionctx/variable/error.go
@@ -34,6 +34,7 @@ var (
 	ErrTruncatedWrongValue         = dbterror.ClassVariable.NewStd(mysql.ErrTruncatedWrongValue)
 	ErrMaxPreparedStmtCountReached = dbterror.ClassVariable.NewStd(mysql.ErrMaxPreparedStmtCountReached)
 	ErrUnsupportedIsolationLevel   = dbterror.ClassVariable.NewStd(mysql.ErrUnsupportedIsolationLevel)
+	ErrClientDoesNotSupport        = dbterror.ClassVariable.NewStd(mysql.ErrClientDoesNotSupport)
 	errUnknownSystemVariable       = dbterror.ClassVariable.NewStd(mysql.ErrUnknownSystemVariable)
 	errGlobalVariable              = dbterror.ClassVariable.NewStd(mysql.ErrGlobalVariable)
 	errLocalVariable               = dbterror.ClassVariable.NewStd(mysql.ErrLocalVariable)

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -873,6 +873,9 @@ type SessionVars struct {
 	// ClientCapability is client's capability.
 	ClientCapability uint32
 
+	// ResultsetMetadata controls whether optional result-set metadata is sent.
+	ResultsetMetadata byte
+
 	// TLSConnectionState is the TLS connection state (nil if not using TLS).
 	TLSConnectionState *tls.ConnectionState
 
@@ -2494,6 +2497,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		IndexLookUpPushDownPolicy:        vardef.DefTiDBIndexLookUpPushDownPolicy,
 		OptPartialOrderedIndexForTopN:    vardef.DefTiDBOptPartialOrderedIndexForTopN,
 		EnableCachePrepareStmt:           vardef.DefEnableCachePrepareStmt,
+		ResultsetMetadata:                mysql.ResultsetMetadataFull,
 	}
 	vars.TiFlashFineGrainedShuffleBatchSize = vardef.DefTiFlashFineGrainedShuffleBatchSize
 	vars.status.Store(uint32(mysql.ServerStatusAutocommit))

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -164,6 +164,20 @@ var defaultSysVars = []*SysVar{
 	}, GetStateValue: func(s *SessionVars) (string, bool, error) {
 		return "", false, nil
 	}},
+	{Scope: vardef.ScopeSession, Name: vardef.ResultsetMetadata, Value: vardef.ResultsetMetadataFull, Type: vardef.TypeEnum, PossibleValues: []string{vardef.ResultsetMetadataNone, vardef.ResultsetMetadataFull}, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope vardef.ScopeFlag) (string, error) {
+		if normalizedValue != vardef.ResultsetMetadataFull && vars.ClientCapability&mysql.ClientOptionalResultsetMetadata == 0 {
+			return normalizedValue, ErrClientDoesNotSupport.GenWithStackByArgs("optional metadata transfer")
+		}
+		return normalizedValue, nil
+	}, SetSession: func(s *SessionVars, val string) error {
+		switch val {
+		case vardef.ResultsetMetadataNone:
+			s.ResultsetMetadata = mysql.ResultsetMetadataNone
+		case vardef.ResultsetMetadataFull:
+			s.ResultsetMetadata = mysql.ResultsetMetadataFull
+		}
+		return nil
+	}},
 	/* TiDB specific variables */
 	{Scope: vardef.ScopeSession, Name: vardef.TiDBTxnReadTS, Value: "", Hidden: true, SetSession: func(s *SessionVars, val string) error {
 		return setTxnReadTS(s, val)

--- a/pkg/sessionctx/variable/tests/BUILD.bazel
+++ b/pkg/sessionctx/variable/tests/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "variable_test.go",
     ],
     flaky = True,
-    shard_count = 47,
+    shard_count = 48,
     deps = [
         "//pkg/config",
         "//pkg/config/deploymode",

--- a/pkg/sessionctx/variable/tests/session_test.go
+++ b/pkg/sessionctx/variable/tests/session_test.go
@@ -871,6 +871,33 @@ func TestTiDBOptPartialOrderedIndexForTopNSessionAndGlobal(t *testing.T) {
 	require.Equal(t, "COST", vars.OptPartialOrderedIndexForTopN)
 }
 
+func TestResultsetMetadata(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustQuery("select @@session.resultset_metadata").Check(testkit.Rows(vardef.ResultsetMetadataFull))
+	require.Equal(t, mysql.ResultsetMetadataFull, tk.Session().GetSessionVars().ResultsetMetadata)
+
+	tk.MustExec("set session resultset_metadata = 'FULL'")
+	tk.MustQuery("select @@session.resultset_metadata").Check(testkit.Rows(vardef.ResultsetMetadataFull))
+	require.Equal(t, mysql.ResultsetMetadataFull, tk.Session().GetSessionVars().ResultsetMetadata)
+
+	err := tk.ExecToErr("set session resultset_metadata = 'NONE'")
+	require.ErrorContains(t, err, "The client doesn't support optional metadata transfer")
+	require.Equal(t, mysql.ResultsetMetadataFull, tk.Session().GetSessionVars().ResultsetMetadata)
+
+	tk.Session().SetClientCapability(mysql.ClientOptionalResultsetMetadata)
+	tk.MustExec("set session resultset_metadata = 'NONE'")
+	tk.MustQuery("select @@session.resultset_metadata").Check(testkit.Rows(vardef.ResultsetMetadataNone))
+	require.Equal(t, mysql.ResultsetMetadataNone, tk.Session().GetSessionVars().ResultsetMetadata)
+
+	err = tk.ExecToErr("set global resultset_metadata = 'NONE'")
+	require.ErrorContains(t, err, "SESSION variable")
+
+	err = tk.ExecToErr("set session resultset_metadata = 'INVALID'")
+	require.Error(t, err)
+}
+
 func TestTiDBOptPartialOrderedIndexForTopN(t *testing.T) {
 	// Test that the variable exists and has correct properties
 	sv := variable.GetSysVar(vardef.TiDBOptPartialOrderedIndexForTopN)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68597

Problem Summary:

TiDB did not support MySQL's `CLIENT_OPTIONAL_RESULTSET_METADATA` capability, so clients that already know result shapes still had to receive and parse result-set metadata for every result set. This keeps metadata transfer on the hot path for point-select-style workloads with small, repeated result sets.

### What changed and how does it work?

This PR adds MySQL-compatible optional result-set metadata support:

- Advertise `CLIENT_OPTIONAL_RESULTSET_METADATA` during handshake.
- Add session-only `@@session.resultset_metadata` with `FULL` as the default and `NONE` as the opt-in metadata suppression mode.
- Reject `resultset_metadata = NONE` when the client did not negotiate `CLIENT_OPTIONAL_RESULTSET_METADATA`, matching MySQL's compatibility contract.
- Emit the `metadata_follows` marker for capable clients and skip column/parameter metadata when the session mode is `NONE`.
- Cover text protocol result sets, `COM_FIELD_LIST`, `COM_STMT_PREPARE`, `COM_STMT_EXECUTE`, and cursor execute/fetch paths while preserving the legacy packet layout for clients that do not negotiate the capability.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
TiDB now supports MySQL's `CLIENT_OPTIONAL_RESULTSET_METADATA` capability and the session variable `resultset_metadata` for optional result-set metadata transfer.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `resultset_metadata` session variable allowing clients to control optional result-set metadata delivery (`FULL` or `NONE` modes).
  * Server now advertises support for optional result-set metadata in its protocol capabilities, enabling clients to reduce bandwidth by opting out of column metadata when not needed.

* **Tests**
  * Added comprehensive test coverage for optional result-set metadata handling in prepared statements and text protocol queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->