### PR TITLE
planner: prune TiCI MPP index scan partitions | tidb-test=release-fts-202602 tiflash=release-fts-202602 tikv=release-fts-202602

### DIFF
--- a/pkg/planner/core/casetest/tici/BUILD.bazel
+++ b/pkg/planner/core/casetest/tici/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 15,
+    shard_count = 16,
     deps = [
         "//pkg/config",
         "//pkg/ddl/ingest/testutil",
@@ -22,6 +22,7 @@ go_test(
         "//pkg/testkit/testdata",
         "//pkg/testkit/testmain",
         "//pkg/testkit/testsetup",
+        "//pkg/tici",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",

--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_in.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_in.json
@@ -83,5 +83,12 @@
       "explain format='brief' select count(*) from t2 use index(primary) where i > 10",
       "explain format='brief' select /*+ order_index(t2, primary) */ * from t2 where i > 10 order by i"
     ]
+  },
+  {
+    "name": "TestTiCIMPPIndexScanPartitionPruning",
+    "cases": [
+      "explain format='brief' select e.id, e.fname, s.name from employees partition(p1) e use index(h_idx) join stores s on e.store_id = s.id where e.id > 101",
+      "explain format='brief' select e.id, e.fname, s.name from employees e use index(h_idx) join stores s on e.store_id = s.id where e.id > 101"
+    ]
   }
 ]

--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
@@ -807,5 +807,38 @@
         "Warn": null
       }
     ]
+  },
+  {
+    "Name": "TestTiCIMPPIndexScanPartitionPruning",
+    "Cases": [
+      {
+        "SQL": "explain format='brief' select e.id, e.fname, s.name from employees partition(p1) e use index(h_idx) join stores s on e.store_id = s.id where e.id > 101",
+        "Plan": [
+          "TableReader 12500.00 root partition:p1 MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 12500.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 12500.00 mpp[tiflash]  test.employees.id, test.employees.fname, test.stores.name",
+          "    └─HashJoin 12500.00 mpp[tiflash]  inner join, equal:[eq(test.employees.store_id, test.stores.id)]",
+          "      ├─ExchangeReceiver(Build) 1000.00 mpp[tiflash]  ",
+          "      │ └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
+          "      │   └─IndexRangeScan 1000.00 mpp[tiflash] table:e, index:h_idx(id, fname, store_id, body) range:[NULL,+inf], search func:gt(test.employees.id, 101), keep order:false, stats:pseudo",
+          "      └─TableFullScan(Probe) 10000.00 mpp[tiflash] table:s keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "explain format='brief' select e.id, e.fname, s.name from employees e use index(h_idx) join stores s on e.store_id = s.id where e.id > 101",
+        "Plan": [
+          "TableReader 12500.00 root partition:p1,p2 MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 12500.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 12500.00 mpp[tiflash]  test.employees.id, test.employees.fname, test.stores.name",
+          "    └─HashJoin 12500.00 mpp[tiflash]  inner join, equal:[eq(test.employees.store_id, test.stores.id)]",
+          "      ├─ExchangeReceiver(Build) 1000.00 mpp[tiflash]  ",
+          "      │ └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
+          "      │   └─IndexRangeScan 1000.00 mpp[tiflash] table:e, index:h_idx(id, fname, store_id, body) range:[NULL,+inf], search func:gt(test.employees.id, 101), keep order:false, stats:pseudo",
+          "      └─TableFullScan(Probe) 10000.00 mpp[tiflash] table:s keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      }
+    ]
   }
 ]

--- a/pkg/planner/core/casetest/tici/tici_test.go
+++ b/pkg/planner/core/casetest/tici/tici_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
+	ticipkg "github.com/pingcap/tidb/pkg/tici"
 	"github.com/stretchr/testify/require"
 )
 
@@ -578,6 +579,70 @@ func TestTiCIJoinWithNonTiCITable(t *testing.T) {
 		tk.MustQuery(sql).CheckContain("cop[tici]")
 		tk.MustQuery(sql).CheckContain("cop[tikv]")
 		tk.MustQuery(sql).CheckNotContain("mpp[tiflash]")
+	})
+}
+
+func TestTiCIMPPIndexScanPartitionPruning(t *testing.T) {
+	ticipkg.InstallMockTiCIManagerForTest(t)
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/tici/MockCheckAddIndexProgress", `return(true)`))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/tici/MockFinishPartitionUpload", `return(true)`))
+	defer func() {
+		err := failpoint.Disable("github.com/pingcap/tidb/pkg/tici/MockCheckAddIndexProgress")
+		require.NoError(t, err)
+		err = failpoint.Disable("github.com/pingcap/tidb/pkg/tici/MockFinishPartitionUpload")
+		require.NoError(t, err)
+	}()
+
+	runTiCITest(t, func(tk *testkit.TestKit) {
+		tk.MustExec("set tidb_allow_mpp=on")
+		tk.MustExec("set tidb_enforce_mpp=on")
+		tk.MustExec(`create table employees(
+			id bigint primary key,
+			fname varchar(25) not null,
+			store_id bigint not null,
+			body text
+		) partition by range(id) (
+			partition p0 values less than (100),
+			partition p1 values less than (200),
+			partition p2 values less than maxvalue
+		)`)
+		tk.MustExec(`create hybrid index h_idx on employees(id, fname, store_id, body) parameter '{
+			"inverted": {
+				"columns": ["id", "fname", "store_id", "body"]
+			},
+			"sort": {
+				"columns": ["id", "fname", "store_id"],
+				"order": ["asc", "desc", "asc"]
+			},
+			"sharding_key": {
+				"columns": ["id", "fname", "store_id"]
+			}
+		}'`)
+		tk.MustExec(`create table stores(
+			id bigint primary key,
+			name varchar(25) not null
+		)`)
+		dom := domain.GetDomain(tk.Session())
+		testkit.SetTiFlashReplica(t, dom, "test", "employees")
+		testkit.SetTiFlashReplica(t, dom, "test", "stores")
+
+		var input []string
+		var output []struct {
+			SQL  string
+			Plan []string
+			Warn []string
+		}
+		integrationSuiteData := GetFTSIndexSuiteData()
+		integrationSuiteData.LoadTestCasesByName("TestTiCIMPPIndexScanPartitionPruning", t, &input, &output)
+		for i, tt := range input {
+			testdata.OnRecord(func() {
+				output[i].SQL = tt
+				output[i].Plan = testdata.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+				output[i].Warn = testdata.ConvertSQLWarnToStrings(tk.Session().GetSessionVars().StmtCtx.GetWarnings())
+			})
+			tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
+			require.Equal(t, output[i].Warn, testdata.ConvertSQLWarnToStrings(tk.Session().GetSessionVars().StmtCtx.GetWarnings()))
+		}
 	})
 }
 

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -2382,6 +2382,14 @@ func convertToIndexScan(ds *logicalop.DataSource, prop *property.PhysicalPropert
 			return base.InvalidTask, nil
 		}
 		mppTask := physicalop.NewMppTask(is, property.AnyType, nil, ds.TblColHists, nil)
+		if ds.TableInfo.GetPartitionInfo() != nil {
+			is.PlanPartInfo = &physicalop.PhysPlanPartInfo{
+				PruningConds:   ds.AllConds,
+				PartitionNames: ds.PartitionNames,
+				Columns:        ds.TblCols,
+				ColumnNames:    ds.OutputNames(),
+			}
+		}
 		finalStats := ds.StatsInfo().ScaleByExpectCnt(ds.SCtx().GetSessionVars(), prop.ExpectedCnt)
 		if err = addPushedDownSelectionToMppTask4PhysicalIndexScan(is, mppTask, path, finalStats); err != nil {
 			return base.InvalidTask, err

--- a/pkg/planner/core/operator/physicalop/fragment.go
+++ b/pkg/planner/core/operator/physicalop/fragment.go
@@ -643,23 +643,12 @@ func (e *mppTaskGenerator) constructMPPTasksForTiCIFTSIndexScan(ctx context.Cont
 			}
 			e.KVRanges = append(e.KVRanges, req.KeyRanges...)
 		} else {
-			// Dynamic-prune path currently doesn't carry partition-pruning conditions on IndexScan,
-			// so keep all partition ranges here.
-			physicalTableIDs = make([]int64, len(pi.Definitions))
-			partitionIDAndRanges := make([]kv.PartitionIDAndRanges, len(pi.Definitions))
-			for i, def := range pi.Definitions {
-				pid := def.ID
-				kvRanges, kvErr := distsql.TableHandleRangesToKVRanges(e.ctx.GetDistSQLCtx(), []int64{pid}, is.Table.IsCommonHandle, splitedRanges)
-				if kvErr != nil {
-					return nil, errors.Trace(kvErr)
-				}
-				physicalTableIDs[i] = pid
-				partitionIDAndRanges[i].ID = pid
-				partitionIDAndRanges[i].KeyRanges = kvRanges.FirstPartitionRange()
-				e.KVRanges = append(e.KVRanges, partitionIDAndRanges[i].KeyRanges...)
+			req, physicalTableIDs, err = e.constructMPPBuildTaskReqForTiCIPartitionedIndexScan(ctx, is, splitedRanges)
+			if err != nil {
+				return nil, errors.Trace(err)
 			}
-			req = &kv.MPPBuildTasksRequest{
-				PartitionIDAndRanges: partitionIDAndRanges,
+			for _, partitionKVRanges := range req.PartitionIDAndRanges {
+				e.KVRanges = append(e.KVRanges, partitionKVRanges.KeyRanges...)
 			}
 		}
 	} else {
@@ -679,6 +668,40 @@ func (e *mppTaskGenerator) constructMPPTasksForTiCIFTSIndexScan(ctx context.Cont
 		return nil, err
 	}
 	return e.constructMPPTasksFromRequest(ctx, req, is.Table.ID, nil, false)
+}
+
+func (e *mppTaskGenerator) constructMPPBuildTaskReqForTiCIPartitionedIndexScan(ctx context.Context, is *PhysicalIndexScan, splitedRanges []*ranger.Range) (*kv.MPPBuildTasksRequest, []int64, error) {
+	pi := is.Table.GetPartitionInfo()
+	if pi == nil {
+		return nil, nil, errors.New("TiCI partitioned IndexScan requires a partition table")
+	}
+	if is.PlanPartInfo != nil {
+		tmp, _ := e.is.TableByID(ctx, is.Table.ID)
+		tbl := tmp.(table.PartitionedTable)
+		partitions, err := partitionPruning(e.ctx.GetPlanCtx(), tbl, is.PlanPartInfo.PruningConds, is.PlanPartInfo.PartitionNames, is.PlanPartInfo.Columns, is.PlanPartInfo.ColumnNames)
+		if err != nil {
+			return nil, nil, err
+		}
+		return e.constructMPPBuildTaskReqForPhysicalPartitions(is.Table.IsCommonHandle, splitedRanges, partitions)
+	}
+
+	// Keep the legacy fallback when the IndexScan does not carry partition-pruning metadata.
+	physicalTableIDs := make([]int64, len(pi.Definitions))
+	partitionIDAndRanges := make([]kv.PartitionIDAndRanges, len(pi.Definitions))
+	for i, def := range pi.Definitions {
+		pid := def.ID
+		kvRanges, err := distsql.TableHandleRangesToKVRanges(e.ctx.GetDistSQLCtx(), []int64{pid}, is.Table.IsCommonHandle, splitedRanges)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		physicalTableIDs[i] = pid
+		partitionIDAndRanges[i].ID = pid
+		partitionIDAndRanges[i].KeyRanges = kvRanges.FirstPartitionRange()
+	}
+	req := &kv.MPPBuildTasksRequest{
+		PartitionIDAndRanges: partitionIDAndRanges,
+	}
+	return req, physicalTableIDs, nil
 }
 
 func (e *mppTaskGenerator) attachTiCIFTSInfoToMPPBuildTaskReq(req *kv.MPPBuildTasksRequest, is *PhysicalIndexScan, physicalTableIDs []int64) error {
@@ -719,6 +742,10 @@ func (e *mppTaskGenerator) attachTiCIFTSInfoToMPPBuildTaskReq(req *kv.MPPBuildTa
 }
 
 func (e *mppTaskGenerator) constructMPPBuildTaskReqForPartitionedTable(ts *PhysicalTableScan, splitedRanges []*ranger.Range, partitions []table.PhysicalTable) (*kv.MPPBuildTasksRequest, []int64, error) {
+	return e.constructMPPBuildTaskReqForPhysicalPartitions(ts.Table.IsCommonHandle, splitedRanges, partitions)
+}
+
+func (e *mppTaskGenerator) constructMPPBuildTaskReqForPhysicalPartitions(isCommonHandle bool, splitedRanges []*ranger.Range, partitions []table.PhysicalTable) (*kv.MPPBuildTasksRequest, []int64, error) {
 	slices.SortFunc(partitions, func(i, j table.PhysicalTable) int {
 		return cmp.Compare(i.GetPhysicalID(), j.GetPhysicalID())
 	})
@@ -728,7 +755,7 @@ func (e *mppTaskGenerator) constructMPPBuildTaskReqForPartitionedTable(ts *Physi
 	for i, p := range partitions {
 		pid := p.GetPhysicalID()
 		meta := p.Meta()
-		kvRanges, err := distsql.TableHandleRangesToKVRanges(e.ctx.GetDistSQLCtx(), []int64{pid}, meta != nil && ts.Table.IsCommonHandle, splitedRanges)
+		kvRanges, err := distsql.TableHandleRangesToKVRanges(e.ctx.GetDistSQLCtx(), []int64{pid}, meta != nil && isCommonHandle, splitedRanges)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}

--- a/pkg/planner/core/operator/physicalop/physical_index_scan.go
+++ b/pkg/planner/core/operator/physicalop/physical_index_scan.go
@@ -109,6 +109,10 @@ type PhysicalIndexScan struct {
 
 	FtsQueryInfo *tipb.FTSQueryInfo `plan-cache-clone:"must-nil"`
 
+	// PlanPartInfo carries partition-pruning metadata for TiCI MPP IndexScan.
+	// TiKV IndexScan keeps using the outer IndexReader/IndexLookUpReader's PlanPartInfo.
+	PlanPartInfo *PhysPlanPartInfo `plan-cache-clone:"must-nil"`
+
 	// For GroupedRanges and GroupByColIdxs, please see comments in struct AccessPath.
 	GroupedRanges  [][]*ranger.Range `plan-cache-clone:"shallow"`
 	GroupByColIdxs []int             `plan-cache-clone:"shallow"`
@@ -181,6 +185,9 @@ func (p *PhysicalIndexScan) MemoryUsage() (sum int64) {
 	}
 	if p.DataSourceSchema != nil {
 		sum += p.DataSourceSchema.MemoryUsage()
+	}
+	if p.PlanPartInfo != nil {
+		sum += p.PlanPartInfo.MemoryUsage()
 	}
 	// slice memory usage
 	for _, cond := range p.AccessCondition {

--- a/pkg/planner/core/operator/physicalop/physical_plan_misc.go
+++ b/pkg/planner/core/operator/physicalop/physical_plan_misc.go
@@ -140,15 +140,16 @@ func (pi *PhysPlanPartInfo) MemoryUsage() (sum int64) {
 	return
 }
 
-// TableScanAndPartitionInfo is to save PhysicalTableScan and PhysPlanPartInfo Info
-type TableScanAndPartitionInfo struct {
+// ScanAndPartitionInfo is to save scan plan and PhysPlanPartInfo Info
+type ScanAndPartitionInfo struct {
 	// TODO(hawkingrei): we can make it private after moving PhysicalTableReader into physicalop
 	TableScan        *PhysicalTableScan
+	IndexScan        *PhysicalIndexScan
 	PhysPlanPartInfo *PhysPlanPartInfo
 }
 
-// MemoryUsage return the memory usage of TableScanAndPartitionInfo
-func (t *TableScanAndPartitionInfo) MemoryUsage() (sum int64) {
+// MemoryUsage return the memory usage of ScanAndPartitionInfo
+func (t *ScanAndPartitionInfo) MemoryUsage() (sum int64) {
 	if t == nil {
 		return
 	}
@@ -156,6 +157,9 @@ func (t *TableScanAndPartitionInfo) MemoryUsage() (sum int64) {
 	sum += t.PhysPlanPartInfo.MemoryUsage()
 	if t.TableScan != nil {
 		sum += t.TableScan.MemoryUsage()
+	}
+	if t.IndexScan != nil {
+		sum += t.IndexScan.MemoryUsage()
 	}
 	return
 }

--- a/pkg/planner/core/operator/physicalop/physical_table_reader.go
+++ b/pkg/planner/core/operator/physicalop/physical_table_reader.go
@@ -79,8 +79,8 @@ type PhysicalTableReader struct {
 
 	// Used by partition table.
 	PlanPartInfo *PhysPlanPartInfo
-	// Used by MPP, because MPP plan may contain join/union/union all, it is possible that a physical table reader contains more than 1 table scan
-	TableScanAndPartitionInfos []TableScanAndPartitionInfo `plan-cache-clone:"must-nil"`
+	// Used by MPP, because MPP plan may contain join/union/union all, it is possible that a physical table reader contains more than 1 scan
+	ScanAndPartitionInfos []ScanAndPartitionInfo `plan-cache-clone:"must-nil"`
 }
 
 // Init initializes PhysicalTableReader.
@@ -156,7 +156,7 @@ func (p *PhysicalTableReader) MemoryUsage() (sum int64) {
 		sum += p.TablePlan.MemoryUsage()
 	}
 	// since TablePlans is the flats of TablePlan, so we don't count it
-	for _, pInfo := range p.TableScanAndPartitionInfos {
+	for _, pInfo := range p.ScanAndPartitionInfos {
 		sum += pInfo.MemoryUsage()
 	}
 	return
@@ -173,7 +173,7 @@ func (p *PhysicalTableReader) AccessObject(sctx base.PlanContext) base.AccessObj
 	if !sctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
 		return access.DynamicPartitionAccessObjects(nil)
 	}
-	if len(p.TableScanAndPartitionInfos) == 0 {
+	if len(p.ScanAndPartitionInfos) == 0 {
 		ts, ok := p.TablePlans[0].(*PhysicalTableScan)
 		if !ok {
 			return access.OtherAccessObject("")
@@ -188,14 +188,8 @@ func (p *PhysicalTableReader) AccessObject(sctx base.PlanContext) base.AccessObj
 		}
 		return access.DynamicPartitionAccessObjects{res}
 	}
-	if len(p.TableScanAndPartitionInfos) == 1 {
-		tp := p.TableScanAndPartitionInfos[0]
-		ts := tp.TableScan
-		asName := ""
-		if ts.TableAsName != nil && len(ts.TableAsName.O) > 0 {
-			asName = ts.TableAsName.O
-		}
-		res := GetDynamicAccessPartition(sctx, ts.Table, tp.PhysPlanPartInfo, asName)
+	if len(p.ScanAndPartitionInfos) == 1 {
+		res := p.accessObjectForScanAndPartitionInfo(sctx, p.ScanAndPartitionInfos[0])
 		if res == nil {
 			return access.DynamicPartitionAccessObjects(nil)
 		}
@@ -203,16 +197,8 @@ func (p *PhysicalTableReader) AccessObject(sctx base.PlanContext) base.AccessObj
 	}
 
 	res := make(access.DynamicPartitionAccessObjects, 0)
-	for _, info := range p.TableScanAndPartitionInfos {
-		if info.TableScan.Table.GetPartitionInfo() == nil {
-			continue
-		}
-		ts := info.TableScan
-		asName := ""
-		if ts.TableAsName != nil && len(ts.TableAsName.O) > 0 {
-			asName = ts.TableAsName.O
-		}
-		accessObj := GetDynamicAccessPartition(sctx, ts.Table, info.PhysPlanPartInfo, asName)
+	for _, info := range p.ScanAndPartitionInfos {
+		accessObj := p.accessObjectForScanAndPartitionInfo(sctx, info)
 		if accessObj != nil {
 			res = append(res, accessObj)
 		}
@@ -221,6 +207,35 @@ func (p *PhysicalTableReader) AccessObject(sctx base.PlanContext) base.AccessObj
 		return access.DynamicPartitionAccessObjects(nil)
 	}
 	return res
+}
+
+func (*PhysicalTableReader) accessObjectForScanAndPartitionInfo(sctx base.PlanContext, info ScanAndPartitionInfo) *access.DynamicPartitionAccessObject {
+	if info.PhysPlanPartInfo == nil {
+		return nil
+	}
+	if info.TableScan != nil {
+		ts := info.TableScan
+		if ts.Table.GetPartitionInfo() == nil {
+			return nil
+		}
+		asName := ""
+		if ts.TableAsName != nil && len(ts.TableAsName.O) > 0 {
+			asName = ts.TableAsName.O
+		}
+		return GetDynamicAccessPartition(sctx, ts.Table, info.PhysPlanPartInfo, asName)
+	}
+	if info.IndexScan != nil {
+		is := info.IndexScan
+		if is.Table.GetPartitionInfo() == nil {
+			return nil
+		}
+		asName := ""
+		if is.TableAsName != nil && len(is.TableAsName.O) > 0 {
+			asName = is.TableAsName.O
+		}
+		return GetDynamicAccessPartition(sctx, is.Table, info.PhysPlanPartInfo, asName)
+	}
+	return nil
 }
 
 // Clone implements op.PhysicalPlan interface.

--- a/pkg/planner/core/operator/physicalop/plan_clone_generated.go
+++ b/pkg/planner/core/operator/physicalop/plan_clone_generated.go
@@ -153,6 +153,9 @@ func (op *PhysicalIndexScan) CloneForPlanCache(newCtx base.PlanContext) (base.Pl
 	if op.FtsQueryInfo != nil {
 		return nil, false
 	}
+	if op.PlanPartInfo != nil {
+		return nil, false
+	}
 	return cloned, true
 }
 
@@ -356,7 +359,7 @@ func (op *PhysicalTableReader) CloneForPlanCache(newCtx base.PlanContext) (base.
 	}
 	cloned.TablePlans = FlattenListPushDownPlan(cloned.TablePlan)
 	cloned.PlanPartInfo = op.PlanPartInfo.CloneForPlanCache()
-	if op.TableScanAndPartitionInfos != nil {
+	if op.ScanAndPartitionInfos != nil {
 		return nil, false
 	}
 	return cloned, true

--- a/pkg/planner/core/operator/physicalop/task.go
+++ b/pkg/planner/core/operator/physicalop/task.go
@@ -33,13 +33,17 @@ func tryExpandVirtualColumn(p base.PhysicalPlan) {
 	}
 }
 
-func collectPartitionInfosFromMPPPlan(p *PhysicalTableReader, mppPlan base.PhysicalPlan) {
+func collectScanPartitionInfosFromMPPPlan(p *PhysicalTableReader, mppPlan base.PhysicalPlan) {
 	switch x := mppPlan.(type) {
 	case *PhysicalTableScan:
-		p.TableScanAndPartitionInfos = append(p.TableScanAndPartitionInfos, TableScanAndPartitionInfo{TableScan: x, PhysPlanPartInfo: x.PlanPartInfo})
+		p.ScanAndPartitionInfos = append(p.ScanAndPartitionInfos, ScanAndPartitionInfo{TableScan: x, PhysPlanPartInfo: x.PlanPartInfo})
+	case *PhysicalIndexScan:
+		if x.PlanPartInfo != nil {
+			p.ScanAndPartitionInfos = append(p.ScanAndPartitionInfos, ScanAndPartitionInfo{IndexScan: x, PhysPlanPartInfo: x.PlanPartInfo})
+		}
 	default:
 		for _, ch := range mppPlan.Children() {
-			collectPartitionInfosFromMPPPlan(p, ch)
+			collectScanPartitionInfosFromMPPPlan(p, ch)
 		}
 	}
 }

--- a/pkg/planner/core/operator/physicalop/task_base.go
+++ b/pkg/planner/core/operator/physicalop/task_base.go
@@ -309,7 +309,7 @@ func (t *MppTask) ConvertToRootTaskImpl(ctx base.PlanContext) (rt *RootTask) {
 		StoreType: kv.TiFlash,
 	}.Init(ctx, t.p.QueryBlockOffset())
 	p.SetStats(t.p.StatsInfo())
-	collectPartitionInfosFromMPPPlan(p, t.p)
+	collectScanPartitionInfosFromMPPPlan(p, t.p)
 	rt = &RootTask{}
 	rt.SetPlan(p)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: N/A

Problem Summary:

TiCI MPP covering IndexScan on partitioned tables did not carry partition-pruning metadata, so the MPP task builder kept all partition ranges for TiCI routing even when the query selected a subset of partitions.

### What changed and how does it work?

Cherry-pick https://github.com/pingcap/tidb/pull/68470

- Add optional partition-pruning metadata to PhysicalIndexScan for TiCI MPP IndexScan.
- Populate that metadata when building an MPP IndexScan on a partitioned table.
- Reuse existing partition pruning while constructing TiCI MPP IndexScan task requests, and keep the legacy all-partition fallback when metadata is absent.
- Show the pruned partitions in EXPLAIN for PhysicalIndexScan access objects.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix TiCI MPP IndexScan partition pruning for partitioned tables.
```

Tests:

- `go test -run TestTiCIMPPIndexScanPartitionPruning --tags=intest ./pkg/planner/core/casetest/tici`
- `make failpoint-enable`
- `go test -run 'TestTiCI.*Partition|TestTiCISearchExplain' --tags=intest ./pkg/planner/core/casetest/tici`
- `make failpoint-disable`
- `make gogenerate`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced partition pruning support for index scans in MPP execution to improve query performance on partitioned tables.

* **Tests**
  * Added test coverage for partition-pruned index scans with partitioned table joins.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->