### PR TITLE
planner: avoid TiCI FTS paths for constant match rewrites | tidb-test=feature/fts tiflash=feature/fts tikv=feature/fts

### DIFF
--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_in.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_in.json
@@ -59,6 +59,7 @@
       "explain format='brief' select * from t1 where match(title) against ('\\\"hello world\\\"' IN BOOLEAN MODE)",
       "explain format='brief' select id from t1 where match(title) against ('+apple -banana' IN BOOLEAN MODE)",
       "explain format='brief' select id from t1 where match(title) against ('-banana' IN BOOLEAN MODE)",
+      "explain format='brief' select id from t1 use index(idx_field1) where field1 = 1 and not match(title) against ('-banana' IN BOOLEAN MODE)",
       "explain format='brief' select id from t1 where match(title) against ('apple' IN BOOLEAN MODE) or match(title) against ('banana' IN BOOLEAN MODE)",
       "explain format='brief' select id from t1 where match(title) against ('\"\"' IN BOOLEAN MODE)",
       "explain format='brief' select * from t1 where match(title) against (NULL IN BOOLEAN MODE)",

--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
@@ -615,10 +615,17 @@
       {
         "SQL": "explain format='brief' select id from t1 where match(title) against ('-banana' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t1.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:0, keep order:false, stats:pseudo"
+          "TableDual 1.00 root  rows:0"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "explain format='brief' select id from t1 use index(idx_field1) where field1 = 1 and not match(title) against ('-banana' IN BOOLEAN MODE)",
+        "Plan": [
+          "Projection 10.00 root  test.t1.id",
+          "└─IndexLookUp 10.00 root  ",
+          "  ├─IndexRangeScan(Build) 10.00 cop[tikv] table:t1, index:idx_field1(field1) range:[1,1], keep order:false, stats:pseudo",
+          "  └─TableRowIDScan(Probe) 10.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -635,10 +642,7 @@
       {
         "SQL": "explain format='brief' select id from t1 where match(title) against ('\"\"' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t1.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:0, keep order:false, stats:pseudo"
+          "TableDual 1.00 root  rows:0"
         ],
         "Warn": null
       },
@@ -702,10 +706,7 @@
       {
         "SQL": "explain format='brief' select id from t6 where match(title) against ('\"\"' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t6.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t6, index:idx_title(title) range:[0,+inf], search func:0, keep order:false, stats:pseudo"
+          "TableDual 1.00 root  rows:0"
         ],
         "Warn": null
       },

--- a/pkg/planner/core/operator/logicalop/logical_datasource.go
+++ b/pkg/planner/core/operator/logicalop/logical_datasource.go
@@ -944,12 +944,17 @@ func (ds *DataSource) buildTiCIFTSPathAndCleanUp(
 	}
 	matchedConds := make([]expression.Expression, 0, len(matchedCondIdxes))
 	tableFilters := make([]expression.Expression, 0, len(ds.PushedDownConds)-len(matchedCondIdxes))
+	sc := ds.SCtx().GetSessionVars().StmtCtx
 	for i, cond := range ds.PushedDownConds {
 		if _, ok := matchedCondSet[i]; ok {
-			// MATCH ... AGAINST(NULL) rewrites to a NULL constant. Keep it as a
-			// residual filter instead of sending a Null expression through FtsQueryInfo.
-			if c, isConst := cond.(*expression.Constant); isConst && c.Value.IsNull() {
-				tableFilters = append(tableFilters, cond)
+			// MATCH ... AGAINST can rewrite to constant false/null for queries
+			// that match no rows, or to constant true through outer wrappers.
+			// Keep false/null as residual filters for normal dual conversion;
+			// drop true constants as no-op predicates. Do not send constants to TiCI.
+			if _, isConst := cond.(*expression.Constant); isConst {
+				if IsConstFalse(sc, cond) {
+					tableFilters = append(tableFilters, cond)
+				}
 				continue
 			}
 			matchedConds = append(matchedConds, cond)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #68413

Problem Summary:

TiCI FTS planning still allowed `MATCH ... AGAINST` predicates that were rewritten to constants to be packed into `FtsQueryInfo.MatchExpr`. This could produce TiCI FTS access paths with constant search expressions such as `search func:0` instead of letting normal predicate simplification turn false/null predicates into `TableDual`. Outer wrappers can also fold a rewritten constant false predicate into constant true, which should not force TiCI FTS path selection or remove other access paths.

### What changed and how does it work?

When a matched TiCI FTS predicate rewrites to a constant:

- false/null constants stay as residual table filters, so normal dual conversion can handle them.
- true constants are dropped as no-op predicates.
- constants are never sent to TiCI as `FtsQueryInfo.MatchExpr`.

The TiCI explain suite now covers negative-only and empty MATCH queries returning `TableDual`, and a `NOT MATCH('-banana')` case with a normal index hint to ensure non-TiCI access paths remain available.

### Check List

Tests

- [x] Unit test
  - `go test -count=1 -run TestTiCISearchExplain --tags=intest ./pkg/planner/core/casetest/tici -record`
  - `go test -count=1 -run TestTiCISearchExplain --tags=intest ./pkg/planner/core/casetest/tici`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of full-text boolean patterns that yield empty results, producing simpler, faster execution plans.
  * Prevented no-op true predicates from being pushed to the search engine and improved index usage for predicates combined with index hints.

* **Tests**
  * Added and updated test expectations to cover boolean full-text cases and the adjusted planning behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->