### PR TITLE
executor: fix a performance regression on IndexLookUp queries with small limit

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -868,41 +868,6 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, initBatchSiz
 		indexTypes := e.getRetTpsForIndexReader()
 
 		if !needMerge {
-			if len(kvRanges) == 1 {
-				result, err := e.buildIndexSelectResultForRange(
-					ctx,
-					0,
-					kvRanges[0],
-					tblScanIdxForRewritePartitionID,
-					tps,
-					idxID,
-					tracker,
-					len(kvRanges),
-					worker.batchSize,
-					0,
-					nil,
-				)
-				if err != nil {
-					if result != nil {
-						result.Close()
-					}
-					worker.syncErr(err)
-					return
-				}
-				ctx1, cancel := context.WithCancel(ctx)
-				selResultList := newSelectResultList([]distsql.SelectResult{result})
-				err = worker.fetchHandles(ctx1, selResultList, indexTypes)
-				cancel()
-				if err != nil {
-					worker.syncErr(err)
-				}
-				return
-			}
-			logutil.Logger(ctx).Info("index lookup skip single-range fast path",
-				zap.Int("kvRanges", len(kvRanges)),
-				zap.Bool("keepOrder", e.keepOrder),
-				zap.Int("byItems", len(e.byItems)),
-				zap.Uint64("connectionID", e.dctx.ConnectionID))
 			maxInFlight := getIndexScanMaxInFlight(e.dctx.DistSQLConcurrency)
 			nextRange := 0
 			pushDownIntermediateTypes := [][]*types.FieldType{indexTypes}

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -1097,6 +1097,9 @@ func (e *IndexLookUpExecutor) buildIndexSelectResultForRange(
 	}
 
 	var builder distsql.RequestBuilder
+	if indexScanConcurrency > 0 {
+		builder.SetConcurrency(indexScanConcurrency)
+	}
 	builder.SetDAGRequest(e.dagPB).
 		SetStartTS(e.startTS).
 		SetDesc(e.desc).
@@ -1104,7 +1107,6 @@ func (e *IndexLookUpExecutor) buildIndexSelectResultForRange(
 		SetTxnScope(e.txnScope).
 		SetReadReplicaScope(e.readReplicaScope).
 		SetIsStaleness(e.isStaleness).
-		SetConcurrency(indexScanConcurrency).
 		SetFromSessionVars(e.dctx).
 		SetFromInfoSchema(e.infoSchema).
 		SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.dctx, &builder.Request, e.idxNetDataSize/float64(totalRanges))).

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -1062,6 +1062,8 @@ func (e *IndexLookUpExecutor) buildIndexSelectResultForRange(
 	}
 
 	var builder distsql.RequestBuilder
+	// Set concurrency before SetDAGRequest intentionally.
+	// SetDAGRequest may override this value (e.g. to 1) for small-limit DAGs.
 	if indexScanConcurrency > 0 {
 		builder.SetConcurrency(indexScanConcurrency)
 	}

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -898,6 +898,11 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, initBatchSiz
 				}
 				return
 			}
+			logutil.Logger(ctx).Info("index lookup skip single-range fast path",
+				zap.Int("kvRanges", len(kvRanges)),
+				zap.Bool("keepOrder", e.keepOrder),
+				zap.Int("byItems", len(e.byItems)),
+				zap.Uint64("connectionID", e.dctx.ConnectionID))
 			maxInFlight := getIndexScanMaxInFlight(e.dctx.DistSQLConcurrency)
 			nextRange := 0
 			pushDownIntermediateTypes := [][]*types.FieldType{indexTypes}

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -883,7 +883,9 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, initBatchSiz
 					nil,
 				)
 				if err != nil {
-					result.Close()
+					if result != nil {
+						result.Close()
+					}
 					worker.syncErr(err)
 					return
 				}

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -868,6 +868,34 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, initBatchSiz
 		indexTypes := e.getRetTpsForIndexReader()
 
 		if !needMerge {
+			if len(kvRanges) == 1 {
+				result, err := e.buildIndexSelectResultForRange(
+					ctx,
+					0,
+					kvRanges[0],
+					tblScanIdxForRewritePartitionID,
+					tps,
+					idxID,
+					tracker,
+					len(kvRanges),
+					worker.batchSize,
+					0,
+					nil,
+				)
+				if err != nil {
+					result.Close()
+					worker.syncErr(err)
+					return
+				}
+				ctx1, cancel := context.WithCancel(ctx)
+				selResultList := newSelectResultList([]distsql.SelectResult{result})
+				err = worker.fetchHandles(ctx1, selResultList, indexTypes)
+				cancel()
+				if err != nil {
+					worker.syncErr(err)
+				}
+				return
+			}
 			maxInFlight := getIndexScanMaxInFlight(e.dctx.DistSQLConcurrency)
 			nextRange := 0
 			pushDownIntermediateTypes := [][]*types.FieldType{indexTypes}

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1805,20 +1805,16 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 		if exit {
 			return nil, nil
 		}
+		defer func() {
+			worker.requestRateLimit.PutToken()
+		}()
 	}
 	// Keep the request-rate token and send attempt in a small scope so the
 	// token is released immediately after the send attempt returns, while
 	// still remaining panic-safe.
-	resp, rpcCtx, storeAddr, err := func() (*tikvrpc.Response, *tikv.RPCContext, string, error) {
-		defer func() {
-			if worker.requestRateLimit != nil {
-				worker.requestRateLimit.PutToken()
-			}
-		}()
-		failpoint.InjectCall("onBeforeSendReqCtx", req)
-		return worker.kvclient.SendReqCtx(bo.TiKVBackoffer(), req, task.region,
-			timeout, getEndPointType(task.storeType), task.storeAddr, ops...)
-	}()
+	failpoint.InjectCall("onBeforeSendReqCtx", req)
+	resp, rpcCtx, storeAddr, err := worker.kvclient.SendReqCtx(bo.TiKVBackoffer(), req, task.region,
+		timeout, getEndPointType(task.storeType), task.storeAddr, ops...)
 	err = derr.ToTiDBErr(err)
 	if worker.req.RunawayChecker != nil {
 		err = worker.req.RunawayChecker.CheckThresholds(nil, 0, err)

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1805,16 +1805,20 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 		if exit {
 			return nil, nil
 		}
-		defer func() {
-			worker.requestRateLimit.PutToken()
-		}()
 	}
 	// Keep the request-rate token and send attempt in a small scope so the
 	// token is released immediately after the send attempt returns, while
 	// still remaining panic-safe.
-	failpoint.InjectCall("onBeforeSendReqCtx", req)
-	resp, rpcCtx, storeAddr, err := worker.kvclient.SendReqCtx(bo.TiKVBackoffer(), req, task.region,
-		timeout, getEndPointType(task.storeType), task.storeAddr, ops...)
+	resp, rpcCtx, storeAddr, err := func() (*tikvrpc.Response, *tikv.RPCContext, string, error) {
+		defer func() {
+			if worker.requestRateLimit != nil {
+				worker.requestRateLimit.PutToken()
+			}
+		}()
+		failpoint.InjectCall("onBeforeSendReqCtx", req)
+		return worker.kvclient.SendReqCtx(bo.TiKVBackoffer(), req, task.region,
+			timeout, getEndPointType(task.storeType), task.storeAddr, ops...)
+	}()
 	err = derr.ToTiDBErr(err)
 	if worker.req.RunawayChecker != nil {
 		err = worker.req.RunawayChecker.CheckThresholds(nil, 0, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68596

Problem Summary:
After https://github.com/pingcap/tidb/pull/67676, `SetConcurrency(indexScanConcurrency)` was applied in a way that overrode the small-limit concurrency set in `SetDAGRequest`.
As a result, some small-limit IndexLookUp queries ran with unnecessarily high concurrency, causing extra cop requests and extra data reads.

### What changed and how does it work?
Set the concurrency before `SetDAGRequest`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index lookup concurrency configuration to apply only when appropriate, avoiding unnecessary concurrency settings in certain scenarios. This refinement enhances query execution behavior for index-based lookups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->