### PR TITLE
session: guard next-gen user keyspace bootstrap by target version

### DIFF
--- a/pkg/session/BUILD.bazel
+++ b/pkg/session/BUILD.bazel
@@ -190,6 +190,7 @@ go_test(
         "//pkg/sessionctx/vardef",
         "//pkg/sessionctx/variable",
         "//pkg/statistics",
+        "//pkg/store",
         "//pkg/store/mockstore",
         "//pkg/store/mockstore/teststore",
         "//pkg/table/tblsession",

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4306,12 +4306,14 @@ func BootstrapSession4DistExecution(store kv.Storage) (*domain.Domain, error) {
 func bootstrapSessionImpl(ctx context.Context, store kv.Storage, createSessionsImpl func(store kv.Storage, cnt int) ([]*session, error)) (*domain.Domain, error) {
 	ver := getStoreBootstrapVersionWithCache(store)
 	if kv.IsUserKS(store) {
+		targetVer := currentBootstrapVersion
 		systemKSVer := mustGetStoreBootstrapVersion(kvstore.GetSystemStorage())
 		if systemKSVer == notBootstrapped {
 			logutil.BgLogger().Fatal("SYSTEM keyspace is not bootstrapped")
-		} else if ver > systemKSVer {
-			logutil.BgLogger().Fatal("bootstrap version of user keyspace must be smaller or equal to that of SYSTEM keyspace",
-				zap.Int64("user", ver), zap.Int64("system", systemKSVer))
+		} else if targetVer > systemKSVer {
+			logutil.BgLogger().Fatal("bootstrap version of user keyspace must be smaller or equal to that of SYSTEM keyspace. if you are upgrading user keyspace, please make sure to upgrade SYSTEM keyspace first",
+				zap.Int64("userCurr", ver), zap.Int64("userTarget", targetVer),
+				zap.Int64("system", systemKSVer))
 		}
 	}
 

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -106,16 +106,16 @@ func TestBootstrapSessionImplUserKSVersionGuard(t *testing.T) {
 		restoreLog := log.ReplaceGlobals(lg, p)
 		defer restoreLog()
 
-		fatal2panic := false
+		var panicVal any
 		_, _ = func() (_ *domain.Domain, err error) {
 			defer func() {
-				if recover() != nil {
-					fatal2panic = true
-				}
+				panicVal = recover()
 			}()
 			return bootstrapSessionImpl(context.Background(), userStore, createSessionStub)
 		}()
-		require.True(t, fatal2panic)
+		require.NotNil(t, panicVal)
+		panicMsg := fmt.Sprint(panicVal)
+		require.True(t, strings.HasPrefix(panicMsg, "bootstrap version of user keyspace must be smaller or equal"))
 		require.False(t, createSessionCalled)
 	})
 }

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -16,14 +16,27 @@ package session
 
 import (
 	"cmp"
+	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl"
+	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/keyspace"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/metadef"
+	kvstore "github.com/pingcap/tidb/pkg/store"
+	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestGetStartMode(t *testing.T) {
@@ -31,6 +44,80 @@ func TestGetStartMode(t *testing.T) {
 	require.Equal(t, ddl.Normal, getStartMode(currentBootstrapVersion+1))
 	require.Equal(t, ddl.Upgrade, getStartMode(currentBootstrapVersion-1))
 	require.Equal(t, ddl.Bootstrap, getStartMode(0))
+}
+
+func TestBootstrapSessionImplUserKSVersionGuard(t *testing.T) {
+	if kerneltype.IsClassic() {
+		t.Skip("keyspace guard only applies to next-gen kernel")
+	}
+
+	const (
+		systemKeyspaceID uint32 = 0xFFFFFF - 1
+		userKeyspaceID   uint32 = 0xFFFFFF - 2
+	)
+
+	newKSStore := func(t *testing.T, keyspaceID uint32, keyspaceName string) kv.Storage {
+		t.Helper()
+		store, err := mockstore.NewMockStore(
+			mockstore.WithStoreType(mockstore.EmbedUnistore),
+			mockstore.WithCurrentKeyspaceMeta(&keyspacepb.KeyspaceMeta{
+				Id:   keyspaceID,
+				Name: keyspaceName,
+			}),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, store.Close())
+		})
+		return store
+	}
+
+	setBootstrapVersion := func(t *testing.T, store kv.Storage, ver int64) {
+		t.Helper()
+		txn, err := store.Begin()
+		require.NoError(t, err)
+		err = meta.NewMutator(txn).FinishBootstrap(ver)
+		require.NoError(t, err)
+		require.NoError(t, txn.Commit(context.Background()))
+		store.SetOption(StoreBootstrappedKey, nil)
+	}
+
+	t.Run("fatal when user target version is ahead of system version", func(t *testing.T) {
+		systemStore := newKSStore(t, systemKeyspaceID, keyspace.System)
+		userStore := newKSStore(t, userKeyspaceID, "user_keyspace_guard_fatal")
+		setBootstrapVersion(t, systemStore, currentBootstrapVersion-1)
+		setBootstrapVersion(t, userStore, currentBootstrapVersion-1)
+
+		originSystemStore := kvstore.GetSystemStorage()
+		kvstore.SetSystemStorage(systemStore)
+		t.Cleanup(func() {
+			kvstore.SetSystemStorage(originSystemStore)
+		})
+
+		createSessionCalled := false
+		createSessionStub := func(_ kv.Storage, _ int) ([]*session, error) {
+			createSessionCalled = true
+			return nil, errors.New("must-not-be-called")
+		}
+
+		conf := new(log.Config)
+		lg, p, err := log.InitLogger(conf, zap.WithFatalHook(zapcore.WriteThenPanic))
+		require.NoError(t, err)
+		restoreLog := log.ReplaceGlobals(lg, p)
+		defer restoreLog()
+
+		fatal2panic := false
+		_, _ = func() (_ *domain.Domain, err error) {
+			defer func() {
+				if recover() != nil {
+					fatal2panic = true
+				}
+			}()
+			return bootstrapSessionImpl(context.Background(), userStore, createSessionStub)
+		}()
+		require.True(t, fatal2panic)
+		require.False(t, createSessionCalled)
+	})
 }
 
 func TestDDLTableVersionTables(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68608

Problem Summary:
In next-gen mode, user-keyspace bootstrap guarded user vs SYSTEM using the user keyspace current bootstrap version. This lets the first user-keyspace upgrade pass while SYSTEM is still behind, and only later user-keyspace bootstraps can be blocked.

### What changed and how does it work?

- Change `bootstrapSessionImpl` to compare the user keyspace target version (`currentBootstrapVersion`) against SYSTEM keyspace bootstrap version.
- Keep SYSTEM-not-bootstrapped as fatal and improve fatal logs to include current user version, target user version, and SYSTEM version.
- Add a regression unit test that verifies bootstrap fails before creating sessions when user target version is ahead of SYSTEM.
- Include required Bazel metadata update in `pkg/session/BUILD.bazel`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

bootstrap SYSTEM with v8.5.4-nextgen.202510.22-5-g494b2d14cd
bootstrap ks1 with v8.5.4-nextgen.202510.22-5-g494b2d14cd
then upgrade ks1 to master branch, it reports with:
```
[2026/05/23 13:11:02.909 +08:00] [FATAL] [session.go:4314] ["bootstrap version of user keyspace must be smaller or equal to that of SYSTEM keyspace. if you are upgrading user keyspace, please make sure to upgrade SYSTEM keyspace first"] [keyspaceName=keyspace1] [user=260] [system=253] [stack="github.com/pingcap/tidb/pkg/session.bootstrapSessionImpl\n\t/Users/jujiajia/code/pingcap/tidb/pkg/session/session.go:4314\ngithub.com/pingcap/tidb/pkg/session.BootstrapSession\n\t/Users/jujiajia/code/pingcap/tidb/pkg/session/session.go:4286\nmain.createStoreDDLOwnerMgrAndDomain\n\t/Users/jujiajia/code/pingcap/tidb/cmd/tidb-server/main.go:567\nmain.main\n\t/Users/jujiajia/code/pingcap/tidb/cmd/tidb-server/main.go:427\nruntime.main\n\t/Users/jujiajia/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:285"]
```

in the older version the first upgrade of ks1 success, only second and later tidb failes.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands run:

```bash
./tools/check/failpoint-go-test.sh pkg/session -run TestBootstrapSessionImplUserKSVersionGuard -count=1
make bazel_prepare
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix next-gen user keyspace bootstrap guard to block upgrades when target bootstrap version is ahead of SYSTEM keyspace bootstrap version.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened session bootstrap checks to fail fast if system keyspace isn't ready or if a user keyspace would bootstrap to an incompatible version.
* **Tests**
  * Added a test that verifies the version-guard prevents improper user keyspace bootstrapping and ensures session creation is not attempted.
* **Chores**
  * Updated build configuration to include an additional dependency for tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->