### PR TITLE
Fix #68454: Add validation for table/schema qualifiers in index definition

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -4699,7 +4699,7 @@ func (e *executor) CreatePrimaryKey(ctx sessionctx.Context, ti ast.Ident, indexN
 	// After DDL job is put to the queue, and if the check fail, TiDB will run the DDL cancel logic.
 	// The recover step causes DDL wait a few seconds, makes the unit test painfully slow.
 	// For same reason, decide whether index is global here.
-	indexColumns, _, err := buildIndexColumns(NewMetaBuildContextWithSctx(ctx), tblInfo.Columns, indexPartSpecifications, model.ColumnarIndexTypeNA)
+	indexColumns, _, err := buildIndexColumns(NewMetaBuildContextWithSctx(ctx), tblInfo.Columns, indexPartSpecifications, model.ColumnarIndexTypeNA, tblInfo.Name.L)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -4880,7 +4880,7 @@ func (e *executor) createColumnarIndex(ctx sessionctx.Context, ti ast.Ident, ind
 	// After DDL job is put to the queue, and if the check fail, TiDB will run the DDL cancel logic.
 	// The recover step causes DDL wait a few seconds, makes the unit test painfully slow.
 	// For same reason, decide whether index is global here.
-	_, _, err = buildIndexColumns(metaBuildCtx, tblInfo.Columns, indexPartSpecifications, columnarIndexType)
+	_, _, err = buildIndexColumns(metaBuildCtx, tblInfo.Columns, indexPartSpecifications, columnarIndexType, tblInfo.Name.L)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -5004,7 +5004,7 @@ func (e *executor) createIndex(ctx sessionctx.Context, ti ast.Ident, keyType ast
 	// After DDL job is put to the queue, and if the check fail, TiDB will run the DDL cancel logic.
 	// The recover step causes DDL wait a few seconds, makes the unit test painfully slow.
 	// For same reason, decide whether index is global here.
-	indexColumns, _, err := buildIndexColumns(metaBuildCtx, finalColumns, indexPartSpecifications, model.ColumnarIndexTypeNA)
+	indexColumns, _, err := buildIndexColumns(metaBuildCtx, finalColumns, indexPartSpecifications, model.ColumnarIndexTypeNA, tblInfo.Name.L)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -110,7 +110,7 @@ var DefaultCumulativeTimeout = 1 * time.Minute
 // exported for testing.
 var DefaultAnalyzeCheckInterval = 10 * time.Second
 
-func buildIndexColumns(ctx *metabuild.Context, columns []*model.ColumnInfo, indexPartSpecifications []*ast.IndexPartSpecification, columnarIndexType model.ColumnarIndexType) ([]*model.IndexColumn, bool, error) {
+func buildIndexColumns(ctx *metabuild.Context, columns []*model.ColumnInfo, indexPartSpecifications []*ast.IndexPartSpecification, columnarIndexType model.ColumnarIndexType, currentTableName string) ([]*model.IndexColumn, bool, error) { // Added currentTableName parameter
 	// Build offsets.
 	idxParts := make([]*model.IndexColumn, 0, len(indexPartSpecifications))
 	var col *model.ColumnInfo
@@ -119,6 +119,15 @@ func buildIndexColumns(ctx *metabuild.Context, columns []*model.ColumnInfo, inde
 	// The sum of length of all index columns.
 	sumLength := 0
 	for _, ip := range indexPartSpecifications {
+		// --- START OF PROPOSED CHANGE ---
+		if ip.Column.Schema.L != "" {
+			return nil, false, dbterror.ErrWrongColumnName.GenWithStack("column '%s' specifies a database prefix, which is not allowed in index definition", ip.Column.OrigColName())
+		}
+		if ip.Column.Table.L != "" && !strings.EqualFold(ip.Column.Table.L, currentTableName) {
+			return nil, false, dbterror.ErrWrongColumnName.GenWithStack("column '%s' specifies an invalid table prefix '%s'. Expected column from table '%s'", ip.Column.OrigColName(), ip.Column.Table.O, currentTableName)
+		}
+		// --- END OF PROPOSED CHANGE ---
+
 		col = model.FindColumnInfo(columns, ip.Column.Name.L)
 		if col == nil {
 			return nil, false, dbterror.ErrKeyColumnDoesNotExits.GenWithStack("column does not exist: %s", ip.Column.Name)
@@ -427,7 +436,7 @@ func BuildIndexInfo(
 
 	var err error
 	allTableColumns := tblInfo.Columns
-	idxInfo.Columns, idxInfo.MVIndex, err = buildIndexColumns(ctx, allTableColumns, indexPartSpecifications, columnarIndexType)
+	idxInfo.Columns, idxInfo.MVIndex, err = buildIndexColumns(ctx, allTableColumns, indexPartSpecifications, columnarIndexType, tblInfo.Name.L)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/ddl/index_test.go
+++ b/pkg/ddl/index_test.go
@@ -1,0 +1,105 @@
+
+package ddl
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/ddl/internal/metabuild"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/parser/terror"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildIndexColumnsValidation(t *testing.T) {
+	colName := "c1"
+	tableName := "t1"
+
+	tests := []struct {
+		name              string
+		indexPartSpec     []*ast.IndexPartSpecification
+		currentTableName  string
+		expectedErr       error
+	}{
+		{
+			name: "No qualifiers, valid",
+			indexPartSpec: []*ast.IndexPartSpecification{
+				{
+					Column: &ast.ColumnName{
+						Name: model.NewCIStr(colName),
+					},
+				},
+			},
+			currentTableName: tableName,
+			expectedErr:      nil,
+		},
+		{
+			name: "Schema qualifier, invalid",
+			indexPartSpec: []*ast.IndexPartSpecification{
+				{
+					Column: &ast.ColumnName{
+						Schema: model.NewCIStr("db1"),
+						Name:   model.NewCIStr(colName),
+					},
+				},
+			},
+			currentTableName: tableName,
+			expectedErr:      dbterror.ErrWrongColumnName,
+		},
+		{
+			name: "Correct table qualifier, valid",
+			indexPartSpec: []*ast.IndexPartSpecification{
+				{
+					Column: &ast.ColumnName{
+						Table: model.NewCIStr(tableName),
+						Name:  model.NewCIStr(colName),
+					},
+				},
+			},
+			currentTableName: tableName,
+			expectedErr:      nil,
+		},
+		{
+			name: "Incorrect table qualifier, invalid",
+			indexPartSpec: []*ast.IndexPartSpecification{
+				{
+					Column: &ast.ColumnName{
+						Table: model.NewCIStr("t2"),
+						Name:  model.NewCIStr(colName),
+					},
+				},
+			},
+			currentTableName: tableName,
+			expectedErr:      dbterror.ErrWrongColumnName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mocking necessary components
+			ctx := &metabuild.Context{}
+			columns := []*model.ColumnInfo{
+				{
+					Name: model.NewCIStr(colName),
+				},
+			}
+
+			_, _, err := buildIndexColumns(ctx, columns, tt.indexPartSpec, model.ColumnarIndexTypeNA, tt.currentTableName)
+
+			if tt.expectedErr != nil {
+				require.NotNil(t, err)
+				require.True(t, terror.ErrorEqual(err, tt.expectedErr), "expected error %v, got %v", tt.expectedErr, err)
+				require.True(t, strings.Contains(err.Error(), "column '"+colName+"'"), "error message should contain column name")
+				if tt.indexPartSpec[0].Column.Table.L != "" && !strings.EqualFold(tt.indexPartSpec[0].Column.Table.L, tt.currentTableName) {
+					require.True(t, strings.Contains(err.Error(), fmt.Sprintf("specifies an invalid table prefix '%s'. Expected column from table '%s'", tt.indexPartSpec[0].Column.Table.O, tt.currentTableName)), "error message should contain table prefix info")
+				} else if tt.indexPartSpec[0].Column.Schema.L != "" {
+					require.True(t, strings.Contains(err.Error(), "specifies a database prefix, which is not allowed in index definition"), "error message should contain schema prefix info")
+				}
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68454

### What is changed and how it works?

This PR addresses issue #68454 by adding validation for table and schema qualifiers in index definitions. Specifically:

- The `buildIndexColumns` function now validates `ip.Column.Schema.L` and `ip.Column.Table.L`.
- If a schema prefix is present, an error `ErrWrongColumnName` is returned.
- If a table prefix is present and does not match the current table name, an error `ErrWrongColumnName` is returned.

This change aligns TiDB's behavior with MySQL, which correctly rejects such invalid syntax during index creation.

### Check List

#### Tests

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

The tests include the following scenarios:
- Successful index column creation with no schema or table qualifiers.
- Failure when a schema qualifier is present (e.g., `db.table.col`).
- Successful index column creation when a table qualifier matches the current table name (e.g., `table.col` where `table` is the current table).
- Failure when an incorrect table qualifier is present (e.g., `another_table.col`).

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```
