### PR TITLE
dumpling: reject --rows/--filesize templates without {{.Index}}

### DIFF
--- a/dumpling/export/config.go
+++ b/dumpling/export/config.go
@@ -387,7 +387,7 @@ func (*Config) DefineFlags(flags *pflag.FlagSet) {
 	flags.String(flagCsvSeparator, ",", "The separator for csv files, default ','")
 	flags.String(flagCsvDelimiter, "\"", "The delimiter for values in csv files, default '\"'")
 	flags.String(flagCsvLineTerminator, "\r\n", "The line terminator for csv files, default '\\r\\n'")
-	flags.String(flagOutputFilenameTemplate, "", "The output filename template (without file extension). When used with --rows/-r, include {{.Index}} (for example: '{{.DB}}.{{.Table}}.{{.Index}}') to avoid overwriting chunk files")
+	flags.String(flagOutputFilenameTemplate, "", "The output filename template (without file extension). When used with --rows/-r or --filesize/-F in split mode, include {{.Index}} (for example: '{{.DB}}.{{.Table}}.{{.Index}}') to avoid overwriting chunk files")
 	flags.Bool(flagCompleteInsert, false, "Use complete INSERT statements that include column names")
 	flags.StringToString(flagParams, nil, `Extra session variables used while dumping, accepted format: --params "character_set_client=latin1,character_set_connection=latin1"`)
 	flags.Bool(FlagHelp, false, "Print help message and quit")
@@ -637,8 +637,9 @@ func (conf *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	if err != nil {
 		return errors.Errorf("failed to parse output filename template (--output-filename-template '%s')", outputFilenameFormat)
 	}
-	if flags.Changed(flagRows) && flags.Changed(flagOutputFilenameTemplate) && !outputTemplateUsesIndex(tmpl, outputFileTemplateData) {
-		return errors.New("--output-filename-template must include {{.Index}} when --rows/-r is specified; otherwise chunk files may overwrite each other")
+	outputSplitIntoMultipleFiles := conf.Rows != UnspecifiedSize || conf.FileSize != UnspecifiedSize
+	if flags.Changed(flagOutputFilenameTemplate) && outputSplitIntoMultipleFiles && !outputTemplateUsesIndex(tmpl, outputFileTemplateData) {
+		return errors.New("--output-filename-template must include {{.Index}} when split mode is enabled by --rows/-r or --filesize/-F; otherwise chunk files may overwrite each other")
 	}
 	conf.OutputFileTemplate = tmpl
 

--- a/dumpling/export/config.go
+++ b/dumpling/export/config.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"text/template/parse"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -386,7 +387,7 @@ func (*Config) DefineFlags(flags *pflag.FlagSet) {
 	flags.String(flagCsvSeparator, ",", "The separator for csv files, default ','")
 	flags.String(flagCsvDelimiter, "\"", "The delimiter for values in csv files, default '\"'")
 	flags.String(flagCsvLineTerminator, "\r\n", "The line terminator for csv files, default '\\r\\n'")
-	flags.String(flagOutputFilenameTemplate, "", "The output filename template (without file extension)")
+	flags.String(flagOutputFilenameTemplate, "", "The output filename template (without file extension). When used with --rows/-r, include {{.Index}} (for example: '{{.DB}}.{{.Table}}.{{.Index}}') to avoid overwriting chunk files")
 	flags.Bool(flagCompleteInsert, false, "Use complete INSERT statements that include column names")
 	flags.StringToString(flagParams, nil, `Extra session variables used while dumping, accepted format: --params "character_set_client=latin1,character_set_connection=latin1"`)
 	flags.Bool(FlagHelp, false, "Print help message and quit")
@@ -636,6 +637,9 @@ func (conf *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	if err != nil {
 		return errors.Errorf("failed to parse output filename template (--output-filename-template '%s')", outputFilenameFormat)
 	}
+	if flags.Changed(flagRows) && flags.Changed(flagOutputFilenameTemplate) && !outputTemplateUsesIndex(tmpl, outputFileTemplateData) {
+		return errors.New("--output-filename-template must include {{.Index}} when --rows/-r is specified; otherwise chunk files may overwrite each other")
+	}
 	conf.OutputFileTemplate = tmpl
 
 	compressType, err := flags.GetString(flagCompress)
@@ -703,6 +707,112 @@ func (conf *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	}
 
 	return nil
+}
+
+func outputTemplateUsesIndex(tmpl *template.Template, templateName string) bool {
+	if tmpl == nil {
+		return false
+	}
+
+	visitedTemplate := make(map[string]struct{})
+	visitedNode := make(map[parse.Node]struct{})
+
+	var visitTemplate func(name string) bool
+	visitTemplate = func(name string) bool {
+		if _, ok := visitedTemplate[name]; ok {
+			return false
+		}
+		visitedTemplate[name] = struct{}{}
+
+		t := tmpl.Lookup(name)
+		if t == nil || t.Tree == nil || t.Tree.Root == nil {
+			return false
+		}
+
+		var visitNode func(node parse.Node) bool
+		visitNode = func(node parse.Node) bool {
+			if node == nil {
+				return false
+			}
+			if _, ok := visitedNode[node]; ok {
+				return false
+			}
+			visitedNode[node] = struct{}{}
+
+			switch n := node.(type) {
+			case *parse.FieldNode:
+				for _, ident := range n.Ident {
+					if ident == "Index" {
+						return true
+					}
+				}
+			case *parse.VariableNode:
+				for _, ident := range n.Ident {
+					if ident == "Index" {
+						return true
+					}
+				}
+			case *parse.ChainNode:
+				for _, ident := range n.Field {
+					if ident == "Index" {
+						return true
+					}
+				}
+				return visitNode(n.Node)
+			case *parse.ListNode:
+				for _, child := range n.Nodes {
+					if visitNode(child) {
+						return true
+					}
+				}
+			case *parse.ActionNode:
+				return visitNode(n.Pipe)
+			case *parse.PipeNode:
+				for _, decl := range n.Decl {
+					if visitNode(decl) {
+						return true
+					}
+				}
+				for _, cmd := range n.Cmds {
+					if visitNode(cmd) {
+						return true
+					}
+				}
+			case *parse.CommandNode:
+				for _, arg := range n.Args {
+					if visitNode(arg) {
+						return true
+					}
+				}
+			case *parse.TemplateNode:
+				if visitNode(n.Pipe) {
+					return true
+				}
+				return visitTemplate(n.Name)
+			case *parse.IfNode:
+				if visitNode(n.Pipe) || visitNode(n.List) {
+					return true
+				}
+				return visitNode(n.ElseList)
+			case *parse.RangeNode:
+				if visitNode(n.Pipe) || visitNode(n.List) {
+					return true
+				}
+				return visitNode(n.ElseList)
+			case *parse.WithNode:
+				if visitNode(n.Pipe) || visitNode(n.List) {
+					return true
+				}
+				return visitNode(n.ElseList)
+			}
+
+			return false
+		}
+
+		return visitNode(t.Tree.Root)
+	}
+
+	return visitTemplate(templateName)
 }
 
 // ParseFileSize parses file size from tables-list and filter arguments

--- a/dumpling/export/config.go
+++ b/dumpling/export/config.go
@@ -639,7 +639,7 @@ func (conf *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	}
 	outputSplitIntoMultipleFiles := conf.Rows != UnspecifiedSize || conf.FileSize != UnspecifiedSize
 	if flags.Changed(flagOutputFilenameTemplate) && outputSplitIntoMultipleFiles && !outputTemplateUsesIndex(tmpl, outputFileTemplateData) {
-		return errors.New("--output-filename-template must include {{.Index}} when split mode is enabled by --rows/-r or --filesize/-F; otherwise chunk files may overwrite each other")
+		return errors.New("--output-filename-template must include a standalone {{.Index}} outside conditional blocks (for example: '{{.DB}}.{{.Table}}.{{.Index}}') when split mode is enabled by --rows/-r or --filesize/-F; otherwise chunk files may overwrite each other")
 	}
 	conf.OutputFileTemplate = tmpl
 
@@ -715,105 +715,108 @@ func outputTemplateUsesIndex(tmpl *template.Template, templateName string) bool 
 		return false
 	}
 
-	visitedTemplate := make(map[string]struct{})
-	visitedNode := make(map[parse.Node]struct{})
+	type templateVisitState struct {
+		name          string
+		inConditional bool
+	}
+	visitedTemplate := make(map[templateVisitState]struct{})
 
-	var visitTemplate func(name string) bool
-	visitTemplate = func(name string) bool {
-		if _, ok := visitedTemplate[name]; ok {
+	var visitTemplate func(name string, inConditional bool) bool
+	var visitNode func(node parse.Node, inConditional bool) bool
+	visitTemplate = func(name string, inConditional bool) bool {
+		state := templateVisitState{name: name, inConditional: inConditional}
+		if _, ok := visitedTemplate[state]; ok {
 			return false
 		}
-		visitedTemplate[name] = struct{}{}
+		visitedTemplate[state] = struct{}{}
 
 		t := tmpl.Lookup(name)
 		if t == nil || t.Tree == nil || t.Tree.Root == nil {
 			return false
 		}
 
-		var visitNode func(node parse.Node) bool
-		visitNode = func(node parse.Node) bool {
-			if node == nil {
-				return false
-			}
-			if _, ok := visitedNode[node]; ok {
-				return false
-			}
-			visitedNode[node] = struct{}{}
+		return visitNode(t.Tree.Root, inConditional)
+	}
 
-			switch n := node.(type) {
-			case *parse.FieldNode:
-				for _, ident := range n.Ident {
-					if ident == "Index" {
-						return true
-					}
-				}
-			case *parse.VariableNode:
-				for _, ident := range n.Ident {
-					if ident == "Index" {
-						return true
-					}
-				}
-			case *parse.ChainNode:
-				for _, ident := range n.Field {
-					if ident == "Index" {
-						return true
-					}
-				}
-				return visitNode(n.Node)
-			case *parse.ListNode:
-				for _, child := range n.Nodes {
-					if visitNode(child) {
-						return true
-					}
-				}
-			case *parse.ActionNode:
-				return visitNode(n.Pipe)
-			case *parse.PipeNode:
-				for _, decl := range n.Decl {
-					if visitNode(decl) {
-						return true
-					}
-				}
-				for _, cmd := range n.Cmds {
-					if visitNode(cmd) {
-						return true
-					}
-				}
-			case *parse.CommandNode:
-				for _, arg := range n.Args {
-					if visitNode(arg) {
-						return true
-					}
-				}
-			case *parse.TemplateNode:
-				if visitNode(n.Pipe) {
-					return true
-				}
-				return visitTemplate(n.Name)
-			case *parse.IfNode:
-				if visitNode(n.Pipe) || visitNode(n.List) {
-					return true
-				}
-				return visitNode(n.ElseList)
-			case *parse.RangeNode:
-				if visitNode(n.Pipe) || visitNode(n.List) {
-					return true
-				}
-				return visitNode(n.ElseList)
-			case *parse.WithNode:
-				if visitNode(n.Pipe) || visitNode(n.List) {
-					return true
-				}
-				return visitNode(n.ElseList)
-			}
-
+	visitNode = func(node parse.Node, inConditional bool) bool {
+		if node == nil {
 			return false
 		}
 
-		return visitNode(t.Tree.Root)
+		switch n := node.(type) {
+		case *parse.ListNode:
+			if n == nil {
+				return false
+			}
+			for _, child := range n.Nodes {
+				if visitNode(child, inConditional) {
+					return true
+				}
+			}
+		case *parse.ActionNode:
+			if n == nil {
+				return false
+			}
+			if inConditional {
+				return false
+			}
+			return isStandaloneOutputIndexAction(n)
+		case *parse.TemplateNode:
+			if n == nil {
+				return false
+			}
+			return visitTemplate(n.Name, inConditional)
+		case *parse.IfNode:
+			if n == nil {
+				return false
+			}
+			if visitNode(n.List, true) {
+				return true
+			}
+			return visitNode(n.ElseList, true)
+		case *parse.RangeNode:
+			if n == nil {
+				return false
+			}
+			if visitNode(n.List, true) {
+				return true
+			}
+			return visitNode(n.ElseList, true)
+		case *parse.WithNode:
+			if n == nil {
+				return false
+			}
+			if visitNode(n.List, true) {
+				return true
+			}
+			return visitNode(n.ElseList, true)
+		}
+
+		return false
 	}
 
-	return visitTemplate(templateName)
+	return visitTemplate(templateName, false)
+}
+
+func isStandaloneOutputIndexAction(action *parse.ActionNode) bool {
+	if action == nil || action.Pipe == nil {
+		return false
+	}
+
+	// A standalone {{.Index}} must be a single command with a single argument.
+	if len(action.Pipe.Decl) != 0 || len(action.Pipe.Cmds) != 1 {
+		return false
+	}
+	cmd := action.Pipe.Cmds[0]
+	if cmd == nil || len(cmd.Args) != 1 {
+		return false
+	}
+
+	field, ok := cmd.Args[0].(*parse.FieldNode)
+	if !ok {
+		return false
+	}
+	return len(field.Ident) == 1 && field.Ident[0] == "Index"
 }
 
 // ParseFileSize parses file size from tables-list and filter arguments

--- a/dumpling/export/config_test.go
+++ b/dumpling/export/config_test.go
@@ -89,17 +89,41 @@ func TestParseParquetSizeFlags(t *testing.T) {
 }
 
 func TestOutputFilenameTemplateWithRowsValidation(t *testing.T) {
-	t.Run("reject template without index when rows and output template are both specified", func(t *testing.T) {
+	t.Run("reject template without index when rows split mode and output template are both specified", func(t *testing.T) {
 		_, err := parseConfigFromArgsForTestWithErr(t,
 			"--rows", "10",
 			"--output-filename-template", "{{.DB}}.{{.Table}}",
 		)
-		require.ErrorContains(t, err, "--output-filename-template must include {{.Index}} when --rows/-r is specified")
+		require.ErrorContains(t, err, "--output-filename-template must include {{.Index}} when split mode is enabled by --rows/-r or --filesize/-F")
 	})
 
 	t.Run("accept template with index when rows and output template are both specified", func(t *testing.T) {
 		_, err := parseConfigFromArgsForTestWithErr(t,
 			"--rows", "10",
+			"--output-filename-template", "{{.DB}}.{{.Table}}.{{.Index}}",
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("accept template without index when rows is explicitly set to zero", func(t *testing.T) {
+		_, err := parseConfigFromArgsForTestWithErr(t,
+			"--rows", "0",
+			"--output-filename-template", "{{.DB}}.{{.Table}}",
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("reject template without index when filesize split mode and output template are both specified", func(t *testing.T) {
+		_, err := parseConfigFromArgsForTestWithErr(t,
+			"--filesize", "1MiB",
+			"--output-filename-template", "{{.DB}}.{{.Table}}",
+		)
+		require.ErrorContains(t, err, "--output-filename-template must include {{.Index}} when split mode is enabled by --rows/-r or --filesize/-F")
+	})
+
+	t.Run("accept template with index when filesize and output template are both specified", func(t *testing.T) {
+		_, err := parseConfigFromArgsForTestWithErr(t,
+			"--filesize", "1MiB",
 			"--output-filename-template", "{{.DB}}.{{.Table}}.{{.Index}}",
 		)
 		require.NoError(t, err)

--- a/dumpling/export/config_test.go
+++ b/dumpling/export/config_test.go
@@ -94,13 +94,37 @@ func TestOutputFilenameTemplateWithRowsValidation(t *testing.T) {
 			"--rows", "10",
 			"--output-filename-template", "{{.DB}}.{{.Table}}",
 		)
-		require.ErrorContains(t, err, "--output-filename-template must include {{.Index}} when split mode is enabled by --rows/-r or --filesize/-F")
+		require.ErrorContains(t, err, "--output-filename-template must include a standalone {{.Index}} outside conditional blocks (for example: '{{.DB}}.{{.Table}}.{{.Index}}') when split mode is enabled by --rows/-r or --filesize/-F")
 	})
 
 	t.Run("accept template with index when rows and output template are both specified", func(t *testing.T) {
 		_, err := parseConfigFromArgsForTestWithErr(t,
 			"--rows", "10",
 			"--output-filename-template", "{{.DB}}.{{.Table}}.{{.Index}}",
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("reject template when index only appears in a conditional guard", func(t *testing.T) {
+		_, err := parseConfigFromArgsForTestWithErr(t,
+			"--rows", "10",
+			"--output-filename-template", "{{if .Index}}{{end}}{{.DB}}.{{.Table}}",
+		)
+		require.ErrorContains(t, err, "--output-filename-template must include a standalone {{.Index}} outside conditional blocks (for example: '{{.DB}}.{{.Table}}.{{.Index}}') when split mode is enabled by --rows/-r or --filesize/-F")
+	})
+
+	t.Run("reject template when index is only conditionally rendered", func(t *testing.T) {
+		_, err := parseConfigFromArgsForTestWithErr(t,
+			"--rows", "10",
+			"--output-filename-template", "{{if lt .Index 2}}{{.Index}}{{end}}{{.DB}}.{{.Table}}",
+		)
+		require.ErrorContains(t, err, "--output-filename-template must include a standalone {{.Index}} outside conditional blocks (for example: '{{.DB}}.{{.Table}}.{{.Index}}') when split mode is enabled by --rows/-r or --filesize/-F")
+	})
+
+	t.Run("accept template when standalone index exists outside conditionals", func(t *testing.T) {
+		_, err := parseConfigFromArgsForTestWithErr(t,
+			"--rows", "10",
+			"--output-filename-template", "{{if lt .Index 2}}prefix.{{end}}{{.DB}}.{{.Table}}.{{.Index}}",
 		)
 		require.NoError(t, err)
 	})
@@ -118,7 +142,7 @@ func TestOutputFilenameTemplateWithRowsValidation(t *testing.T) {
 			"--filesize", "1MiB",
 			"--output-filename-template", "{{.DB}}.{{.Table}}",
 		)
-		require.ErrorContains(t, err, "--output-filename-template must include {{.Index}} when split mode is enabled by --rows/-r or --filesize/-F")
+		require.ErrorContains(t, err, "--output-filename-template must include a standalone {{.Index}} outside conditional blocks (for example: '{{.DB}}.{{.Table}}.{{.Index}}') when split mode is enabled by --rows/-r or --filesize/-F")
 	})
 
 	t.Run("accept template with index when filesize and output template are both specified", func(t *testing.T) {

--- a/dumpling/export/config_test.go
+++ b/dumpling/export/config_test.go
@@ -88,9 +88,40 @@ func TestParseParquetSizeFlags(t *testing.T) {
 	require.EqualValues(t, 128*units.MiB, conf.ParquetRowGroupSize)
 }
 
+func TestOutputFilenameTemplateWithRowsValidation(t *testing.T) {
+	t.Run("reject template without index when rows and output template are both specified", func(t *testing.T) {
+		_, err := parseConfigFromArgsForTestWithErr(t,
+			"--rows", "10",
+			"--output-filename-template", "{{.DB}}.{{.Table}}",
+		)
+		require.ErrorContains(t, err, "--output-filename-template must include {{.Index}} when --rows/-r is specified")
+	})
+
+	t.Run("accept template with index when rows and output template are both specified", func(t *testing.T) {
+		_, err := parseConfigFromArgsForTestWithErr(t,
+			"--rows", "10",
+			"--output-filename-template", "{{.DB}}.{{.Table}}.{{.Index}}",
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("accept template without index when rows is not specified", func(t *testing.T) {
+		_, err := parseConfigFromArgsForTestWithErr(t,
+			"--output-filename-template", "{{.DB}}.{{.Table}}",
+		)
+		require.NoError(t, err)
+	})
+}
+
 func parseConfigFromArgsForTest(t *testing.T, args ...string) *Config {
 	t.Helper()
+	conf, err := parseConfigFromArgsForTestWithErr(t, args...)
+	require.NoError(t, err)
+	return conf
+}
 
+func parseConfigFromArgsForTestWithErr(t *testing.T, args ...string) (*Config, error) {
+	t.Helper()
 	conf := DefaultConfig()
 	flags := pflag.NewFlagSet("dumpling", pflag.ContinueOnError)
 	conf.DefineFlags(flags)
@@ -99,7 +130,8 @@ func parseConfigFromArgsForTest(t *testing.T, args ...string) *Config {
 	t.Cleanup(func() {
 		pflag.CommandLine = oldCommandLine
 	})
-	require.NoError(t, flags.Parse(args))
-	require.NoError(t, conf.ParseFromFlags(flags))
-	return conf
+	if err := flags.Parse(args); err != nil {
+		return nil, err
+	}
+	return conf, conf.ParseFromFlags(flags)
 }

--- a/dumpling/tests/basic/run.sh
+++ b/dumpling/tests/basic/run.sh
@@ -100,6 +100,15 @@ cnt=$(cat ${DUMPLING_OUTPUT_DIR}/${TABLE_NAME}.${DB_NAME}.000000000.csv|wc -l)
 echo "records count is ${cnt}"
 [ "$cnt" = 101 ]
 
+echo "Test for --rows with --output-filename-template without {{.Index}} should report an error."
+set +e
+run_dumpling --rows 10 --output-filename-template "${TABLE_NAME}.${DB_NAME}" > ${DUMPLING_OUTPUT_DIR}/dumpling.log
+set -e
+
+actual=$(grep -w -- "--output-filename-template must include {{.Index}} when --rows/-r is specified" ${DUMPLING_OUTPUT_DIR}/dumpling.log | wc -l)
+echo "expected 1 return error when specifying --rows with --output-filename-template without {{.Index}}, actual ${actual}"
+[ "$actual" = 1 ]
+
 export DUMPLING_TEST_PORT=4000
 echo "Test for --sql option."
 run_sql "drop database if exists \`$DB_NAME\`;"

--- a/dumpling/tests/basic/run.sh
+++ b/dumpling/tests/basic/run.sh
@@ -105,7 +105,7 @@ set +e
 run_dumpling --rows 10 --output-filename-template "${TABLE_NAME}.${DB_NAME}" > ${DUMPLING_OUTPUT_DIR}/dumpling.log
 set -e
 
-actual=$(grep -w -- "--output-filename-template must include {{.Index}}" ${DUMPLING_OUTPUT_DIR}/dumpling.log | wc -l)
+actual=$(grep -F -- "--output-filename-template must include a standalone {{.Index}} outside conditional blocks" ${DUMPLING_OUTPUT_DIR}/dumpling.log | wc -l)
 echo "expected 1 return error when specifying --rows with --output-filename-template without {{.Index}}, actual ${actual}"
 [ "$actual" = 1 ]
 
@@ -114,7 +114,7 @@ set +e
 run_dumpling --filesize 1MiB --output-filename-template "${TABLE_NAME}.${DB_NAME}" > ${DUMPLING_OUTPUT_DIR}/dumpling.log
 set -e
 
-actual=$(grep -w -- "--output-filename-template must include {{.Index}}" ${DUMPLING_OUTPUT_DIR}/dumpling.log | wc -l)
+actual=$(grep -F -- "--output-filename-template must include a standalone {{.Index}} outside conditional blocks" ${DUMPLING_OUTPUT_DIR}/dumpling.log | wc -l)
 echo "expected 1 return error when specifying --filesize with --output-filename-template without {{.Index}}, actual ${actual}"
 [ "$actual" = 1 ]
 

--- a/dumpling/tests/basic/run.sh
+++ b/dumpling/tests/basic/run.sh
@@ -105,8 +105,17 @@ set +e
 run_dumpling --rows 10 --output-filename-template "${TABLE_NAME}.${DB_NAME}" > ${DUMPLING_OUTPUT_DIR}/dumpling.log
 set -e
 
-actual=$(grep -w -- "--output-filename-template must include {{.Index}} when --rows/-r is specified" ${DUMPLING_OUTPUT_DIR}/dumpling.log | wc -l)
+actual=$(grep -w -- "--output-filename-template must include {{.Index}}" ${DUMPLING_OUTPUT_DIR}/dumpling.log | wc -l)
 echo "expected 1 return error when specifying --rows with --output-filename-template without {{.Index}}, actual ${actual}"
+[ "$actual" = 1 ]
+
+echo "Test for --filesize with --output-filename-template without {{.Index}} should report an error."
+set +e
+run_dumpling --filesize 1MiB --output-filename-template "${TABLE_NAME}.${DB_NAME}" > ${DUMPLING_OUTPUT_DIR}/dumpling.log
+set -e
+
+actual=$(grep -w -- "--output-filename-template must include {{.Index}}" ${DUMPLING_OUTPUT_DIR}/dumpling.log | wc -l)
+echo "expected 1 return error when specifying --filesize with --output-filename-template without {{.Index}}, actual ${actual}"
 [ "$actual" = 1 ]
 
 export DUMPLING_TEST_PORT=4000


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68611

Problem Summary:
When `dumpling` runs in split mode (`--rows/-r` or `--filesize/-F`) with a custom `--output-filename-template`, chunk files can collide if the template does not render the chunk index in the output name. Referencing `.Index` only in control flow (for example `{{if .Index}}{{end}}`) can still produce identical filenames across chunks, causing overwrite and incomplete dump data.

### What changed and how does it work?

- Added split-mode validation in Dumpling config parsing:
  - when `--output-filename-template` is explicitly set together with `--rows/-r` or `--filesize/-F`,
  - Dumpling now requires a standalone `{{.Index}}` outside conditional blocks.
- Added `outputTemplateUsesIndex(...)` + `isStandaloneOutputIndexAction(...)` to walk template AST (including nested template references) and reject `.Index` usages that only appear in control-flow nodes (`if/range/with`).
- Updated `--output-filename-template` help text and validation error message with an explicit valid example: `{{.DB}}.{{.Table}}.{{.Index}}`.
- Added unit tests for positive/negative cases, including:
  - missing `{{.Index}}`,
  - `.Index` only in conditional guard,
  - `.Index` only conditionally rendered,
  - accepted template with unconditional standalone `{{.Index}}`.
- Updated `dumpling/tests/basic/run.sh` checks to match the new validation error wording for both `--rows` and `--filesize` split modes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test steps:

```bash
# Prepare test table and split regions
mysql -h127.0.0.1 -P4000 -uroot -e "drop database if exists agent_rows_template_guard; create database agent_rows_template_guard; create table agent_rows_template_guard.t(a int primary key, b int); insert into agent_rows_template_guard.t values (1,1),(2,2),(3,3);"

# Verify validation error is returned
bin/dumpling -u root -h 127.0.0.1 -P 4000 \
  -B agent_rows_template_guard -f agent_rows_template_guard.t \
  -o /tmp/dumpling-guard-out \
  --rows 10 --output-filename-template "{{.DB}}.{{.Table}}"
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Dumpling now rejects split-mode (`--rows/-r` or `--filesize/-F`) `--output-filename-template` values that do not contain a standalone `{{.Index}}` outside conditional blocks, preventing chunk file overwrite.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforce filename-template validation in split/chunk mode: when chunking by rows or filesize, templates must include a standalone {{.Index}} (except when rows is explicitly 0), otherwise the template is rejected to prevent overwrites.

* **Documentation**
  * CLI help updated to document the standalone {{.Index}} requirement for filename templates in split mode.

* **Tests**
  * Added unit tests and negative integration tests to verify the new validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
