### PR TITLE
expression: add fulltext analyzers | tidb-test=feature/fts tiflash=feature/fts tikv=feature/fts

### DIFF
--- a/pkg/expression/fulltext/BUILD.bazel
+++ b/pkg/expression/fulltext/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "fulltext",
+    srcs = ["analyzer.go"],
+    importpath = "github.com/pingcap/tidb/pkg/expression/fulltext",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/sessionctx",
+        "//pkg/sessionctx/vardef",
+        "//pkg/sessionctx/variable",
+    ],
+)
+
+go_test(
+    name = "fulltext_test",
+    timeout = "short",
+    srcs = ["analyzer_test.go"],
+    embed = [":fulltext"],
+    flaky = False,
+    shard_count = 5,
+    deps = [
+        "//pkg/sessionctx/vardef",
+        "//pkg/sessionctx/variable",
+        "//pkg/util/mock",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/expression/fulltext/analyzer.go
+++ b/pkg/expression/fulltext/analyzer.go
@@ -27,14 +27,10 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 )
 
-// Token is the analyzed fulltext token. OffsetFrom and OffsetTo are UTF-8 byte
-// offsets in the original input text.
+// Token is the analyzed fulltext token.
 type Token struct {
-	Text           string
-	Position       int
-	OffsetFrom     int
-	OffsetTo       int
-	PositionLength int
+	Text     string
+	Position int
 }
 
 // PreserveUnderscoreTokenize tokenizes text with TiCI's PreserveUnderscore
@@ -60,11 +56,8 @@ func PreserveUnderscoreTokenize(text string) []Token {
 			j = next
 		}
 		tokens = append(tokens, Token{
-			Text:           text[start:j],
-			Position:       pos,
-			OffsetFrom:     start,
-			OffsetTo:       j,
-			PositionLength: 1,
+			Text:     text[start:j],
+			Position: pos,
 		})
 		pos++
 		i = j
@@ -276,11 +269,8 @@ func ngramFilter(tokens []Token, minGram, maxGram int) []Token {
 				startByte := spans[startIdx].byteStart
 				endByte := spans[endIdx-1].byteEnd
 				out = append(out, Token{
-					Text:           token.Text[startByte:endByte],
-					Position:       basePosition + startIdx,
-					OffsetFrom:     token.OffsetFrom + startByte,
-					OffsetTo:       token.OffsetFrom + endByte,
-					PositionLength: token.PositionLength,
+					Text:     token.Text[startByte:endByte],
+					Position: basePosition + startIdx,
 				})
 			}
 		}

--- a/pkg/expression/fulltext/analyzer.go
+++ b/pkg/expression/fulltext/analyzer.go
@@ -155,7 +155,7 @@ func stopwordSetFromSysVars(enableStopword, serverStopwordTable, userStopwordTab
 	if strings.TrimSpace(serverStopwordTable) != "" || strings.TrimSpace(userStopwordTable) != "" {
 		return map[string]struct{}{}
 	}
-	return englishStopwords
+	return builtinInnoDBEnglishStopwords
 }
 
 func getFulltextSysVar(sessVars *variable.SessionVars, name string) (string, error) {
@@ -299,7 +299,9 @@ func utf8CharSpans(text string) []charSpan {
 	return spans
 }
 
-var englishStopwords = map[string]struct{}{
+// builtinInnoDBEnglishStopwords is used by the STANDARD analyzer when
+// innodb_ft_enable_stopword is ON and no custom stopword table is configured.
+var builtinInnoDBEnglishStopwords = map[string]struct{}{
 	"a": {}, "an": {}, "and": {}, "are": {}, "as": {}, "at": {}, "be": {}, "but": {},
 	"by": {}, "for": {}, "if": {}, "in": {}, "into": {}, "is": {}, "it": {}, "no": {},
 	"not": {}, "of": {}, "on": {}, "or": {}, "such": {}, "that": {}, "the": {},

--- a/pkg/expression/fulltext/analyzer.go
+++ b/pkg/expression/fulltext/analyzer.go
@@ -130,15 +130,7 @@ func parserInfoFromSessionContext(sctx sessionctx.Context) (parserInfo, error) {
 	if err != nil {
 		return parserInfo{}, err
 	}
-	serverStopwordTable, err := getFulltextSysVar(sessVars, vardef.InnodbFtServerStopwordTable)
-	if err != nil {
-		return parserInfo{}, err
-	}
-	userStopwordTable, err := getFulltextSysVar(sessVars, vardef.InnodbFtUserStopwordTable)
-	if err != nil {
-		return parserInfo{}, err
-	}
-	stopwords := stopwordSetFromSysVars(enableStopword, serverStopwordTable, userStopwordTable)
+	stopwords := stopwordSetFromSysVar(enableStopword)
 
 	return parserInfo{
 		innodbFtMinTokenSize: minTokenSize,
@@ -148,14 +140,12 @@ func parserInfoFromSessionContext(sctx sessionctx.Context) (parserInfo, error) {
 	}, nil
 }
 
-func stopwordSetFromSysVars(enableStopword, serverStopwordTable, userStopwordTable string) map[string]struct{} {
+func stopwordSetFromSysVar(enableStopword string) map[string]struct{} {
 	if !variable.TiDBOptOn(enableStopword) {
 		return nil
 	}
-	if strings.TrimSpace(serverStopwordTable) != "" || strings.TrimSpace(userStopwordTable) != "" {
-		return map[string]struct{}{}
-	}
-	return builtinInnoDBEnglishStopwords
+	// TiDB does not resolve InnoDB stopword table contents on this path yet.
+	return map[string]struct{}{}
 }
 
 func getFulltextSysVar(sessVars *variable.SessionVars, name string) (string, error) {
@@ -297,14 +287,4 @@ func utf8CharSpans(text string) []charSpan {
 		})
 	}
 	return spans
-}
-
-// builtinInnoDBEnglishStopwords is used by the STANDARD analyzer when
-// innodb_ft_enable_stopword is ON and no custom stopword table is configured.
-var builtinInnoDBEnglishStopwords = map[string]struct{}{
-	"a": {}, "an": {}, "and": {}, "are": {}, "as": {}, "at": {}, "be": {}, "but": {},
-	"by": {}, "for": {}, "if": {}, "in": {}, "into": {}, "is": {}, "it": {}, "no": {},
-	"not": {}, "of": {}, "on": {}, "or": {}, "such": {}, "that": {}, "the": {},
-	"their": {}, "then": {}, "there": {}, "these": {}, "they": {}, "this": {}, "to": {},
-	"was": {}, "will": {}, "with": {},
 }

--- a/pkg/expression/fulltext/analyzer.go
+++ b/pkg/expression/fulltext/analyzer.go
@@ -1,0 +1,318 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fulltext
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+)
+
+// Token is the analyzed fulltext token. OffsetFrom and OffsetTo are UTF-8 byte
+// offsets in the original input text.
+type Token struct {
+	Text           string
+	Position       int
+	OffsetFrom     int
+	OffsetTo       int
+	PositionLength int
+}
+
+// PreserveUnderscoreTokenize tokenizes text with TiCI's PreserveUnderscore
+// tokenizer semantics: Unicode alphanumeric characters and '_' form tokens;
+// every other character is a delimiter.
+func PreserveUnderscoreTokenize(text string) []Token {
+	tokens := make([]Token, 0)
+	pos := 0
+	for i := 0; i < len(text); {
+		ch, next := runeAtByte(text, i)
+		if !isTokenChar(ch) {
+			i = next
+			continue
+		}
+
+		start := i
+		j := next
+		for j < len(text) {
+			ch, next = runeAtByte(text, j)
+			if !isTokenChar(ch) {
+				break
+			}
+			j = next
+		}
+		tokens = append(tokens, Token{
+			Text:           text[start:j],
+			Position:       pos,
+			OffsetFrom:     start,
+			OffsetTo:       j,
+			PositionLength: 1,
+		})
+		pos++
+		i = j
+	}
+	return tokens
+}
+
+// AnalyzeStandardV1 runs the STANDARD_V1 analyzer:
+// PreserveUnderscore tokenizer, length filter, lower-case filter, and optional
+// stopword filter.
+func AnalyzeStandardV1(sctx sessionctx.Context, text string) ([]Token, error) {
+	parserInfo, err := parserInfoFromSessionContext(sctx)
+	if err != nil {
+		return nil, err
+	}
+	return analyzeStandardV1(text, parserInfo), nil
+}
+
+func analyzeStandardV1(text string, parserInfo parserInfo) []Token {
+	tokens := PreserveUnderscoreTokenize(text)
+	tokens = lengthFilter(tokens, parserInfo.innodbFtMinTokenSize, parserInfo.innodbFtMaxTokenSize)
+	tokens = lowerFilter(tokens)
+	tokens = stopwordFilter(tokens, parserInfo)
+	return tokens
+}
+
+// AnalyzeNgramV1 runs the NGRAM_V1 analyzer:
+// PreserveUnderscore tokenizer, fixed-size ngram filter, and lower-case filter.
+func AnalyzeNgramV1(sctx sessionctx.Context, text string) ([]Token, error) {
+	parserInfo, err := parserInfoFromSessionContext(sctx)
+	if err != nil {
+		return nil, err
+	}
+	return analyzeNgramV1(text, parserInfo), nil
+}
+
+func analyzeNgramV1(text string, parserInfo parserInfo) []Token {
+	tokens := PreserveUnderscoreTokenize(text)
+	tokens = ngramFilter(tokens, parserInfo.ngramTokenSize, parserInfo.ngramTokenSize)
+	tokens = lowerFilter(tokens)
+	return tokens
+}
+
+type parserInfo struct {
+	innodbFtMinTokenSize int
+	innodbFtMaxTokenSize int
+	ngramTokenSize       int
+	stopwords            map[string]struct{}
+}
+
+func parserInfoFromSessionContext(sctx sessionctx.Context) (parserInfo, error) {
+	if sctx == nil || sctx.GetSessionVars() == nil {
+		return parserInfo{}, fmt.Errorf("missing session context for fulltext analyzer")
+	}
+	sessVars := sctx.GetSessionVars()
+
+	enableStopword, err := getFulltextSysVar(sessVars, vardef.InnodbFtEnableStopword)
+	if err != nil {
+		return parserInfo{}, err
+	}
+	minTokenSize, err := getFulltextIntSysVar(sessVars, vardef.InnodbFtMinTokenSize)
+	if err != nil {
+		return parserInfo{}, err
+	}
+	maxTokenSize, err := getFulltextIntSysVar(sessVars, vardef.InnodbFtMaxTokenSize)
+	if err != nil {
+		return parserInfo{}, err
+	}
+	ngramTokenSize, err := getFulltextIntSysVar(sessVars, vardef.NgramTokenSize)
+	if err != nil {
+		return parserInfo{}, err
+	}
+	serverStopwordTable, err := getFulltextSysVar(sessVars, vardef.InnodbFtServerStopwordTable)
+	if err != nil {
+		return parserInfo{}, err
+	}
+	userStopwordTable, err := getFulltextSysVar(sessVars, vardef.InnodbFtUserStopwordTable)
+	if err != nil {
+		return parserInfo{}, err
+	}
+	stopwords := stopwordSetFromSysVars(enableStopword, serverStopwordTable, userStopwordTable)
+
+	return parserInfo{
+		innodbFtMinTokenSize: minTokenSize,
+		innodbFtMaxTokenSize: maxTokenSize,
+		ngramTokenSize:       ngramTokenSize,
+		stopwords:            stopwords,
+	}, nil
+}
+
+func stopwordSetFromSysVars(enableStopword, serverStopwordTable, userStopwordTable string) map[string]struct{} {
+	if !variable.TiDBOptOn(enableStopword) {
+		return nil
+	}
+	if strings.TrimSpace(serverStopwordTable) != "" || strings.TrimSpace(userStopwordTable) != "" {
+		return map[string]struct{}{}
+	}
+	return englishStopwords
+}
+
+func getFulltextSysVar(sessVars *variable.SessionVars, name string) (string, error) {
+	val, err := sessVars.GetSessionOrGlobalSystemVar(context.Background(), name)
+	if err != nil {
+		return "", fmt.Errorf("get %s for fulltext analyzer: %w", name, err)
+	}
+	return val, nil
+}
+
+func getFulltextIntSysVar(sessVars *variable.SessionVars, name string) (int, error) {
+	val, err := getFulltextSysVar(sessVars, name)
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s for fulltext analyzer: %w", name, err)
+	}
+	return n, nil
+}
+
+func runeAtByte(text string, offset int) (rune, int) {
+	ch, size := utf8.DecodeRuneInString(text[offset:])
+	if size == 0 {
+		return 0, len(text)
+	}
+	return ch, offset + size
+}
+
+func isTokenChar(ch rune) bool {
+	return unicode.IsLetter(ch) || unicode.IsNumber(ch) || ch == '_'
+}
+
+func lengthFilter(tokens []Token, minLen, maxLen int) []Token {
+	if minLen > maxLen {
+		return nil
+	}
+
+	out := make([]Token, 0, len(tokens))
+	for _, token := range tokens {
+		n := charLen(token.Text)
+		if minLen <= n && n <= maxLen {
+			out = append(out, token)
+		}
+	}
+	return out
+}
+
+func charLen(s string) int {
+	n := 0
+	for range s {
+		n++
+	}
+	return n
+}
+
+func lowerFilter(tokens []Token) []Token {
+	for i := range tokens {
+		tokens[i].Text = strings.ToLower(tokens[i].Text)
+	}
+	return tokens
+}
+
+func stopwordFilter(tokens []Token, parserInfo parserInfo) []Token {
+	if parserInfo.stopwords == nil {
+		return tokens
+	}
+
+	out := make([]Token, 0, len(tokens))
+	for _, token := range tokens {
+		if _, ok := parserInfo.stopwords[token.Text]; !ok {
+			out = append(out, token)
+		}
+	}
+	return out
+}
+
+func stopwordSet(words ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(words))
+	for _, word := range words {
+		set[word] = struct{}{}
+	}
+	return set
+}
+
+func ngramFilter(tokens []Token, minGram, maxGram int) []Token {
+	if minGram <= 0 || maxGram < minGram {
+		return nil
+	}
+
+	out := make([]Token, 0)
+	nextPositionBase := 0
+	for _, token := range tokens {
+		basePosition := max(token.Position, nextPositionBase)
+		spans := utf8CharSpans(token.Text)
+		charCount := len(spans)
+		if charCount < minGram {
+			nextPositionBase = max(nextPositionBase, token.Position+1)
+			continue
+		}
+
+		maxLimit := min(maxGram, charCount)
+		for startIdx := range charCount {
+			for gramLen := minGram; gramLen <= maxLimit; gramLen++ {
+				endIdx := startIdx + gramLen
+				if endIdx > charCount {
+					break
+				}
+
+				startByte := spans[startIdx].byteStart
+				endByte := spans[endIdx-1].byteEnd
+				out = append(out, Token{
+					Text:           token.Text[startByte:endByte],
+					Position:       basePosition + startIdx,
+					OffsetFrom:     token.OffsetFrom + startByte,
+					OffsetTo:       token.OffsetFrom + endByte,
+					PositionLength: token.PositionLength,
+				})
+			}
+		}
+		nextPositionBase = basePosition + charCount - minGram + 1
+	}
+	return out
+}
+
+type charSpan struct {
+	byteStart int
+	byteEnd   int
+}
+
+func utf8CharSpans(text string) []charSpan {
+	spans := make([]charSpan, 0, len(text))
+	for start, ch := range text {
+		size := utf8.RuneLen(ch)
+		if size < 0 {
+			size = 1
+		}
+		spans = append(spans, charSpan{
+			byteStart: start,
+			byteEnd:   start + size,
+		})
+	}
+	return spans
+}
+
+var englishStopwords = map[string]struct{}{
+	"a": {}, "an": {}, "and": {}, "are": {}, "as": {}, "at": {}, "be": {}, "but": {},
+	"by": {}, "for": {}, "if": {}, "in": {}, "into": {}, "is": {}, "it": {}, "no": {},
+	"not": {}, "of": {}, "on": {}, "or": {}, "such": {}, "that": {}, "the": {},
+	"their": {}, "then": {}, "there": {}, "these": {}, "they": {}, "this": {}, "to": {},
+	"was": {}, "will": {}, "with": {},
+}

--- a/pkg/expression/fulltext/analyzer.go
+++ b/pkg/expression/fulltext/analyzer.go
@@ -29,7 +29,8 @@ import (
 
 // Token is the analyzed fulltext token.
 type Token struct {
-	Text     string
+	Text string
+	// Position is the token-stream ordinal, not a byte or rune offset.
 	Position int
 }
 
@@ -38,7 +39,7 @@ type Token struct {
 // every other character is a delimiter.
 func PreserveUnderscoreTokenize(text string) []Token {
 	tokens := make([]Token, 0)
-	pos := 0
+	tokenPos := 0
 	for i := 0; i < len(text); {
 		ch, next := runeAtByte(text, i)
 		if !isTokenChar(ch) {
@@ -57,9 +58,9 @@ func PreserveUnderscoreTokenize(text string) []Token {
 		}
 		tokens = append(tokens, Token{
 			Text:     text[start:j],
-			Position: pos,
+			Position: tokenPos,
 		})
-		pos++
+		tokenPos++
 		i = j
 	}
 	return tokens
@@ -185,13 +186,14 @@ func lengthFilter(tokens []Token, minLen, maxLen int) []Token {
 		return nil
 	}
 
-	out := make([]Token, 0, len(tokens))
+	out := tokens[:0]
 	for _, token := range tokens {
 		n := charLen(token.Text)
 		if minLen <= n && n <= maxLen {
 			out = append(out, token)
 		}
 	}
+	clear(tokens[len(out):])
 	return out
 }
 
@@ -215,12 +217,13 @@ func stopwordFilter(tokens []Token, parserInfo parserInfo) []Token {
 		return tokens
 	}
 
-	out := make([]Token, 0, len(tokens))
+	out := tokens[:0]
 	for _, token := range tokens {
 		if _, ok := parserInfo.stopwords[token.Text]; !ok {
 			out = append(out, token)
 		}
 	}
+	clear(tokens[len(out):])
 	return out
 }
 
@@ -276,15 +279,14 @@ type charSpan struct {
 
 func utf8CharSpans(text string) []charSpan {
 	spans := make([]charSpan, 0, len(text))
-	for start, ch := range text {
-		size := utf8.RuneLen(ch)
-		if size < 0 {
-			size = 1
-		}
+	for start := 0; start < len(text); {
+		_, size := utf8.DecodeRuneInString(text[start:])
+		end := start + size
 		spans = append(spans, charSpan{
 			byteStart: start,
-			byteEnd:   start + size,
+			byteEnd:   end,
 		})
+		start = end
 	}
 	return spans
 }

--- a/pkg/expression/fulltext/analyzer_test.go
+++ b/pkg/expression/fulltext/analyzer_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fulltext
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/util/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreserveUnderscoreTokenize(t *testing.T) {
+	tokens := PreserveUnderscoreTokenize("abc_def,ghi 你好-world")
+	require.Equal(t, []Token{
+		{Text: "abc_def", Position: 0, OffsetFrom: 0, OffsetTo: 7, PositionLength: 1},
+		{Text: "ghi", Position: 1, OffsetFrom: 8, OffsetTo: 11, PositionLength: 1},
+		{Text: "你好", Position: 2, OffsetFrom: 12, OffsetTo: 18, PositionLength: 1},
+		{Text: "world", Position: 3, OffsetFrom: 19, OffsetTo: 24, PositionLength: 1},
+	}, tokens)
+}
+
+func TestAnalyzeStandardV1(t *testing.T) {
+	sctx := newFulltextTestContext(t)
+
+	tokens, err := AnalyzeStandardV1(sctx, "The foo_bar, a 好")
+	require.NoError(t, err)
+	require.Equal(t, []Token{
+		{Text: "foo_bar", Position: 1, OffsetFrom: 4, OffsetTo: 11, PositionLength: 1},
+	}, tokens)
+
+	require.NoError(t, sctx.GetSessionVars().SetSystemVar(vardef.InnodbFtEnableStopword, vardef.Off))
+	tokens, err = AnalyzeStandardV1(sctx, "The cat")
+	require.NoError(t, err)
+	require.Equal(t, []Token{
+		{Text: "the", Position: 0, OffsetFrom: 0, OffsetTo: 3, PositionLength: 1},
+		{Text: "cat", Position: 1, OffsetFrom: 4, OffsetTo: 7, PositionLength: 1},
+	}, tokens)
+}
+
+func TestAnalyzeStandardV1ReadsTokenSizesFromSessionContext(t *testing.T) {
+	sctx := newFulltextTestContext(t)
+	setGlobalSysVar(t, sctx, vardef.InnodbFtMinTokenSize, "1")
+	require.NoError(t, sctx.GetSessionVars().SetSystemVar(vardef.InnodbFtEnableStopword, vardef.Off))
+
+	tokens, err := AnalyzeStandardV1(sctx, "A 好 xy")
+	require.NoError(t, err)
+	require.Equal(t, []Token{
+		{Text: "a", Position: 0, OffsetFrom: 0, OffsetTo: 1, PositionLength: 1},
+		{Text: "好", Position: 1, OffsetFrom: 2, OffsetTo: 5, PositionLength: 1},
+		{Text: "xy", Position: 2, OffsetFrom: 6, OffsetTo: 8, PositionLength: 1},
+	}, tokens)
+}
+
+func TestAnalyzeNgramV1(t *testing.T) {
+	sctx := newFulltextTestContext(t)
+
+	tokens, err := AnalyzeNgramV1(sctx, "Hi世界 foo-bar")
+	require.NoError(t, err)
+	require.Equal(t, []Token{
+		{Text: "hi", Position: 0, OffsetFrom: 0, OffsetTo: 2, PositionLength: 1},
+		{Text: "i世", Position: 1, OffsetFrom: 1, OffsetTo: 5, PositionLength: 1},
+		{Text: "世界", Position: 2, OffsetFrom: 2, OffsetTo: 8, PositionLength: 1},
+		{Text: "fo", Position: 3, OffsetFrom: 9, OffsetTo: 11, PositionLength: 1},
+		{Text: "oo", Position: 4, OffsetFrom: 10, OffsetTo: 12, PositionLength: 1},
+		{Text: "ba", Position: 5, OffsetFrom: 13, OffsetTo: 15, PositionLength: 1},
+		{Text: "ar", Position: 6, OffsetFrom: 14, OffsetTo: 16, PositionLength: 1},
+	}, tokens)
+}
+
+func TestAnalyzeNgramV1ShortTokenAdvancesPositionBase(t *testing.T) {
+	sctx := newFulltextTestContext(t)
+
+	tokens, err := AnalyzeNgramV1(sctx, "abc x def")
+	require.NoError(t, err)
+	require.Equal(t, []Token{
+		{Text: "ab", Position: 0, OffsetFrom: 0, OffsetTo: 2, PositionLength: 1},
+		{Text: "bc", Position: 1, OffsetFrom: 1, OffsetTo: 3, PositionLength: 1},
+		{Text: "de", Position: 2, OffsetFrom: 6, OffsetTo: 8, PositionLength: 1},
+		{Text: "ef", Position: 3, OffsetFrom: 7, OffsetTo: 9, PositionLength: 1},
+	}, tokens)
+}
+
+func TestAnalyzeNgramV1ReadsTokenSizeFromSessionContext(t *testing.T) {
+	sctx := newFulltextTestContext(t)
+	setGlobalSysVar(t, sctx, vardef.NgramTokenSize, "3")
+
+	tokens, err := AnalyzeNgramV1(sctx, "abcd")
+	require.NoError(t, err)
+	require.Equal(t, []Token{
+		{Text: "abc", Position: 0, OffsetFrom: 0, OffsetTo: 3, PositionLength: 1},
+		{Text: "bcd", Position: 1, OffsetFrom: 1, OffsetTo: 4, PositionLength: 1},
+	}, tokens)
+}
+
+func TestAnalyzeStandardV1CustomStopwords(t *testing.T) {
+	tokens := analyzeStandardV1("foo the bar", parserInfo{
+		innodbFtMinTokenSize: 3,
+		innodbFtMaxTokenSize: 84,
+		stopwords:            stopwordSet("foo"),
+	})
+	require.Equal(t, []Token{
+		{Text: "the", Position: 1, OffsetFrom: 4, OffsetTo: 7, PositionLength: 1},
+		{Text: "bar", Position: 2, OffsetFrom: 8, OffsetTo: 11, PositionLength: 1},
+	}, tokens)
+}
+
+func newFulltextTestContext(t *testing.T) *mock.Context {
+	sctx := mock.NewContext()
+	globalAccessor := variable.NewMockGlobalAccessor4Tests()
+	globalAccessor.SessionVars = sctx.GetSessionVars()
+	sctx.GetSessionVars().GlobalVarsAccessor = globalAccessor
+	return sctx
+}
+
+func setGlobalSysVar(t *testing.T, sctx *mock.Context, name, value string) {
+	globalAccessor, ok := sctx.GetSessionVars().GlobalVarsAccessor.(*variable.MockGlobalAccessor)
+	require.True(t, ok)
+	require.NoError(t, globalAccessor.SetGlobalSysVarOnly(context.Background(), name, value, false))
+}

--- a/pkg/expression/fulltext/analyzer_test.go
+++ b/pkg/expression/fulltext/analyzer_test.go
@@ -27,10 +27,10 @@ import (
 func TestPreserveUnderscoreTokenize(t *testing.T) {
 	tokens := PreserveUnderscoreTokenize("abc_def,ghi 你好-world")
 	require.Equal(t, []Token{
-		{Text: "abc_def", Position: 0, OffsetFrom: 0, OffsetTo: 7, PositionLength: 1},
-		{Text: "ghi", Position: 1, OffsetFrom: 8, OffsetTo: 11, PositionLength: 1},
-		{Text: "你好", Position: 2, OffsetFrom: 12, OffsetTo: 18, PositionLength: 1},
-		{Text: "world", Position: 3, OffsetFrom: 19, OffsetTo: 24, PositionLength: 1},
+		{Text: "abc_def", Position: 0},
+		{Text: "ghi", Position: 1},
+		{Text: "你好", Position: 2},
+		{Text: "world", Position: 3},
 	}, tokens)
 }
 
@@ -40,15 +40,15 @@ func TestAnalyzeStandardV1(t *testing.T) {
 	tokens, err := AnalyzeStandardV1(sctx, "The foo_bar, a 好")
 	require.NoError(t, err)
 	require.Equal(t, []Token{
-		{Text: "foo_bar", Position: 1, OffsetFrom: 4, OffsetTo: 11, PositionLength: 1},
+		{Text: "foo_bar", Position: 1},
 	}, tokens)
 
 	require.NoError(t, sctx.GetSessionVars().SetSystemVar(vardef.InnodbFtEnableStopword, vardef.Off))
 	tokens, err = AnalyzeStandardV1(sctx, "The cat")
 	require.NoError(t, err)
 	require.Equal(t, []Token{
-		{Text: "the", Position: 0, OffsetFrom: 0, OffsetTo: 3, PositionLength: 1},
-		{Text: "cat", Position: 1, OffsetFrom: 4, OffsetTo: 7, PositionLength: 1},
+		{Text: "the", Position: 0},
+		{Text: "cat", Position: 1},
 	}, tokens)
 }
 
@@ -60,9 +60,9 @@ func TestAnalyzeStandardV1ReadsTokenSizesFromSessionContext(t *testing.T) {
 	tokens, err := AnalyzeStandardV1(sctx, "A 好 xy")
 	require.NoError(t, err)
 	require.Equal(t, []Token{
-		{Text: "a", Position: 0, OffsetFrom: 0, OffsetTo: 1, PositionLength: 1},
-		{Text: "好", Position: 1, OffsetFrom: 2, OffsetTo: 5, PositionLength: 1},
-		{Text: "xy", Position: 2, OffsetFrom: 6, OffsetTo: 8, PositionLength: 1},
+		{Text: "a", Position: 0},
+		{Text: "好", Position: 1},
+		{Text: "xy", Position: 2},
 	}, tokens)
 }
 
@@ -72,13 +72,13 @@ func TestAnalyzeNgramV1(t *testing.T) {
 	tokens, err := AnalyzeNgramV1(sctx, "Hi世界 foo-bar")
 	require.NoError(t, err)
 	require.Equal(t, []Token{
-		{Text: "hi", Position: 0, OffsetFrom: 0, OffsetTo: 2, PositionLength: 1},
-		{Text: "i世", Position: 1, OffsetFrom: 1, OffsetTo: 5, PositionLength: 1},
-		{Text: "世界", Position: 2, OffsetFrom: 2, OffsetTo: 8, PositionLength: 1},
-		{Text: "fo", Position: 3, OffsetFrom: 9, OffsetTo: 11, PositionLength: 1},
-		{Text: "oo", Position: 4, OffsetFrom: 10, OffsetTo: 12, PositionLength: 1},
-		{Text: "ba", Position: 5, OffsetFrom: 13, OffsetTo: 15, PositionLength: 1},
-		{Text: "ar", Position: 6, OffsetFrom: 14, OffsetTo: 16, PositionLength: 1},
+		{Text: "hi", Position: 0},
+		{Text: "i世", Position: 1},
+		{Text: "世界", Position: 2},
+		{Text: "fo", Position: 3},
+		{Text: "oo", Position: 4},
+		{Text: "ba", Position: 5},
+		{Text: "ar", Position: 6},
 	}, tokens)
 }
 
@@ -88,10 +88,10 @@ func TestAnalyzeNgramV1ShortTokenAdvancesPositionBase(t *testing.T) {
 	tokens, err := AnalyzeNgramV1(sctx, "abc x def")
 	require.NoError(t, err)
 	require.Equal(t, []Token{
-		{Text: "ab", Position: 0, OffsetFrom: 0, OffsetTo: 2, PositionLength: 1},
-		{Text: "bc", Position: 1, OffsetFrom: 1, OffsetTo: 3, PositionLength: 1},
-		{Text: "de", Position: 2, OffsetFrom: 6, OffsetTo: 8, PositionLength: 1},
-		{Text: "ef", Position: 3, OffsetFrom: 7, OffsetTo: 9, PositionLength: 1},
+		{Text: "ab", Position: 0},
+		{Text: "bc", Position: 1},
+		{Text: "de", Position: 2},
+		{Text: "ef", Position: 3},
 	}, tokens)
 }
 
@@ -102,8 +102,8 @@ func TestAnalyzeNgramV1ReadsTokenSizeFromSessionContext(t *testing.T) {
 	tokens, err := AnalyzeNgramV1(sctx, "abcd")
 	require.NoError(t, err)
 	require.Equal(t, []Token{
-		{Text: "abc", Position: 0, OffsetFrom: 0, OffsetTo: 3, PositionLength: 1},
-		{Text: "bcd", Position: 1, OffsetFrom: 1, OffsetTo: 4, PositionLength: 1},
+		{Text: "abc", Position: 0},
+		{Text: "bcd", Position: 1},
 	}, tokens)
 }
 
@@ -114,8 +114,8 @@ func TestAnalyzeStandardV1CustomStopwords(t *testing.T) {
 		stopwords:            stopwordSet("foo"),
 	})
 	require.Equal(t, []Token{
-		{Text: "the", Position: 1, OffsetFrom: 4, OffsetTo: 7, PositionLength: 1},
-		{Text: "bar", Position: 2, OffsetFrom: 8, OffsetTo: 11, PositionLength: 1},
+		{Text: "the", Position: 1},
+		{Text: "bar", Position: 2},
 	}, tokens)
 }
 

--- a/pkg/expression/fulltext/analyzer_test.go
+++ b/pkg/expression/fulltext/analyzer_test.go
@@ -40,6 +40,7 @@ func TestAnalyzeStandardV1(t *testing.T) {
 	tokens, err := AnalyzeStandardV1(sctx, "The foo_bar, a 好")
 	require.NoError(t, err)
 	require.Equal(t, []Token{
+		{Text: "the", Position: 0},
 		{Text: "foo_bar", Position: 1},
 	}, tokens)
 

--- a/pkg/expression/fulltext/analyzer_test.go
+++ b/pkg/expression/fulltext/analyzer_test.go
@@ -86,14 +86,24 @@ func TestAnalyzeNgramV1(t *testing.T) {
 func TestAnalyzeNgramV1ShortTokenAdvancesPositionBase(t *testing.T) {
 	sctx := newFulltextTestContext(t)
 
-	tokens, err := AnalyzeNgramV1(sctx, "abc x def")
+	tokens, err := AnalyzeNgramV1(sctx, "abc x 好 y A_b 中z")
 	require.NoError(t, err)
 	require.Equal(t, []Token{
 		{Text: "ab", Position: 0},
 		{Text: "bc", Position: 1},
-		{Text: "de", Position: 2},
-		{Text: "ef", Position: 3},
+		{Text: "a_", Position: 4},
+		{Text: "_b", Position: 5},
+		{Text: "中z", Position: 6},
 	}, tokens)
+}
+
+func TestUTF8CharSpansInvalidUTF8(t *testing.T) {
+	text := string([]byte{'a', 0xff, 'b'})
+	require.Equal(t, []charSpan{
+		{byteStart: 0, byteEnd: 1},
+		{byteStart: 1, byteEnd: 2},
+		{byteStart: 2, byteEnd: 3},
+	}, utf8CharSpans(text))
 }
 
 func TestAnalyzeNgramV1ReadsTokenSizeFromSessionContext(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: N/A

Problem Summary:

This PR adds TiDB-side fulltext analyzers so future `MATCH ... AGAINST` and `fts_match_xxx` evaluation can reuse the same tokenization behavior in the expression layer.

### What changed and how does it work?

This PR adds `pkg/expression/fulltext` with:

- `STANDARD_V1` analyzer using PreserveUnderscore tokenization, token length filtering, lowercasing, and an empty stopword set for the current TiDB-side path.
- `NGRAM_V1` analyzer using PreserveUnderscore tokenization, fixed-size ngram generation, and lowercasing.
- Session-context based parser settings for token sizes and stopword enablement.
- Unit tests covering tokenizer behavior, token size variables, ngram generation, short-token position handling, and stopword filter plumbing.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Tests run:

- `go test ./pkg/expression/fulltext`
- `bazel --nohome_rc test //pkg/expression/fulltext:fulltext_test`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fulltext analyzer with Standard and N-gram modes, UTF-8‑aware tokenization, underscore-preserving tokens, configurable token sizes and stopword handling via session/system settings.

* **Tests**
  * Added comprehensive tests covering tokenization, position handling, session-driven configuration, custom stopwords, n-gram generation, and UTF-8 edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->