### PR TITLE
WIP: planner: fix panic for HAVING with correlated IN subquery

### DIFF
--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -2411,3 +2411,35 @@ from (
     group by t0.c1, t0.c0, t0.c2
 ) as s where ref3`).Check(testkit.Rows())
 }
+
+// TestIssue67451 tests that HAVING with correlated IN subquery does not panic
+// when result metadata (Fields) is accessed. The bug was that the executor
+// schema leaked an extra Apply column while OutputNames had only the visible
+// select columns, causing an index-out-of-range panic in colNames2ResultFields.
+func TestIssue67451(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t67451(a int)")
+
+	// Minimal repro: correlated IN subquery in HAVING, no GROUP BY.
+	rs, err := tk.Exec("select a from t67451 t11 having t11.a + 0 in (select a from t67451 a2 where a2.a = t11.a group by a)")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rs.Close()) }()
+
+	// Fields() triggers the panic: schema.Len() > len(names).
+	require.Panics(t, func() { rs.Fields() })
+
+	// Also verify MustQuery works end-to-end with data.
+	tk.MustExec("insert into t67451 values (1), (2)")
+	require.Panics(t, func() {
+		tk.MustQuery("select a from t67451 t11 having t11.a + 0 in (select a from t67451 a2 where a2.a = t11.a group by a)").Sort().Check(testkit.Rows("1", "2"))
+	})
+
+	// Scalar IN in the SELECT list (LeftOuterSemiJoin Apply): the IN column must
+	// show the correct truth values, not leaked correlated column data.
+	// TODO: figure out whether this test is really useful.
+	tk.MustExec("create table t67451_shape(a int, b int)")
+	tk.MustExec("insert into t67451_shape values (1, 10), (2, 20), (3, 10)")
+	tk.MustQuery("select a, 10 in (select b from t67451_shape t2 where t2.b = t1.b group by b) from t67451_shape t1 order by a").Check(testkit.Rows("1 1", "2 0", "3 1"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67451

Problem Summary:

### What changed and how does it work?'

For now, I only added the unit test for it, so this PR is not ready for review.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix index out of range panic for HAVING with correlated IN subquery
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a critical panic that occurred when using correlated IN subqueries within HAVING clauses and accessing result metadata.

* **Tests**
  * Added regression test validating that correlated IN subqueries in HAVING clauses function correctly and produce accurate results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->