### PR TITLE
planner: use TiCI FTS row count for upper plan stats | tidb-test=feature/fts tiflash=feature/fts tikv=feature/fts (#68620)

### DIFF
--- a/pkg/planner/core/casetest/tici/stats_test.go
+++ b/pkg/planner/core/casetest/tici/stats_test.go
@@ -62,11 +62,19 @@ func TestTiCISearchEstimateOnlyForMultiTable(t *testing.T) {
 		fulltext index idx_title(title)
 	)`)
 	tk.MustExec("create table t2(a int primary key)")
+	var tValues, t2Values strings.Builder
 	for i := 1; i <= 100; i++ {
-		tk.MustExec(fmt.Sprintf("insert into t values (%d, 'hello')", i))
-		tk.MustExec(fmt.Sprintf("insert into t2 values (%d)", i))
+		if i > 1 {
+			tValues.WriteString(",")
+			t2Values.WriteString(",")
+		}
+		fmt.Fprintf(&tValues, "(%d, 'hello')", i)
+		fmt.Fprintf(&t2Values, "(%d)", i)
 	}
+	tk.MustExec("insert into t values " + tValues.String())
+	tk.MustExec("insert into t2 values " + t2Values.String())
 	tk.MustExec("analyze table t")
+	tk.MustExec("analyze table t2")
 
 	dom := domain.GetDomain(tk.Session())
 	testkit.SetTiFlashReplica(t, dom, "test", "t")
@@ -74,15 +82,27 @@ func TestTiCISearchEstimateOnlyForMultiTable(t *testing.T) {
 	singleTablePlan := testdata.ConvertRowsToStrings(
 		tk.MustQuery("explain format='brief' select id from t where fts_match_word('hello', title)").Rows())
 	requirePlanLineContains(t, singleTablePlan, "IndexRangeScan 10.00", "search func:fts_match_word")
+	requirePlanLineContains(t, singleTablePlan, "Projection 10.00", "test.t.id")
 
 	multiTablePlan := testdata.ConvertRowsToStrings(
-		tk.MustQuery("explain format='brief' select /*+ inl_join(t) */ t.id from t2, t where t.id = t2.a and fts_match_word('hello', t.title)").Rows())
+		tk.MustQuery("explain format='brief' select /*+ hash_join(t2, t) */ t.id from t2, t where t.id = t2.a and fts_match_word('hello', t.title)").Rows())
 	requirePlanLineContains(t, multiTablePlan, "IndexRangeScan 100.00", "search func:fts_match_word")
+	requirePlanLineContains(t, multiTablePlan, "HashJoin 100.00")
 
 	tk.MustExec(fmt.Sprintf("set global %s = off", vardef.TiDBEnableTiCIEstimate))
 	disabledEstimatePlan := testdata.ConvertRowsToStrings(
 		tk.MustQuery("explain format='brief' select /*+ inl_join(t) */ t.id from t2, t where t.id = t2.a and match(t.title) against ('hello' in boolean mode)").Rows())
 	requirePlanLineContains(t, disabledEstimatePlan, "IndexRangeScan 10.00", "search func:fts_match_word")
+
+	tk.MustExec(fmt.Sprintf("set global %s = on", vardef.TiDBEnableTiCIEstimate))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/mockstorage/MockTiCIEstimateCount", `return(1)`))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/mockstore/mockstorage/MockTiCIEstimateCount"))
+	}()
+	smallEstimatePlan := testdata.ConvertRowsToStrings(
+		tk.MustQuery("explain format='brief' select /*+ hash_join(t2, t) */ t.id from t2, t where t.id = t2.a and fts_match_word('hello', t.title)").Rows())
+	requirePlanLineContains(t, smallEstimatePlan, "IndexRangeScan 1.00", "search func:fts_match_word")
+	requirePlanLineContains(t, smallEstimatePlan, "HashJoin 1.00")
 }
 
 func requirePlanLineContains(t *testing.T, plan []string, expected ...string) {

--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
@@ -23,9 +23,9 @@
       {
         "SQL": "explain format='brief' select title from t1 where fts_match_word('hello', title)",
         "Plan": [
-          "Projection 10000.00 root  test.t1.title",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t1.title",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -42,19 +42,19 @@
       {
         "SQL": "explain format='brief' select * from t1 where fts_match_prefix('hello', title) and id = 10",
         "Plan": [
-          "IndexLookUp 0.00 root  ",
-          "├─Selection(Build) 0.00 cop[tici]  eq(test.t1.id, 10)",
+          "IndexLookUp 0.10 root  ",
+          "├─Selection(Build) 0.10 cop[tici]  eq(test.t1.id, 10)",
           "│ └─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:[10,10], search func:fts_match_prefix(\"hello\", test.t1.title), keep order:false, stats:pseudo",
-          "└─TableRowIDScan(Probe) 0.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+          "└─TableRowIDScan(Probe) 0.10 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
       {
         "SQL": "explain format='brief' select id from t1 where fts_match_word('hello', title)",
         "Plan": [
-          "Projection 10000.00 root  test.t1.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t1.id",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -62,30 +62,30 @@
       {
         "SQL": "explain format='brief' select * from t1 where fts_match_word('hello', title) AND id > 10",
         "Plan": [
-          "IndexLookUp 0.00 root  ",
-          "├─Selection(Build) 0.00 cop[tici]  gt(test.t1.id, 10)",
+          "IndexLookUp 333.33 root  ",
+          "├─Selection(Build) 333.33 cop[tici]  gt(test.t1.id, 10)",
           "│ └─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:(10,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
-          "└─TableRowIDScan(Probe) 0.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+          "└─TableRowIDScan(Probe) 333.33 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
       {
         "SQL": "explain format='brief' select * from t1 where fts_match_word('hello', title) AND id > 10 AND LENGTH(title) > 1",
         "Plan": [
-          "IndexLookUp 0.00 root  ",
-          "├─Selection(Build) 0.00 cop[tici]  gt(length(test.t1.title), 1), gt(test.t1.id, 10)",
+          "IndexLookUp 266.67 root  ",
+          "├─Selection(Build) 266.67 cop[tici]  gt(length(test.t1.title), 1), gt(test.t1.id, 10)",
           "│ └─IndexRangeScan 1000.00 cop[tici] table:t1, index:idx_title(title) range:(10,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
-          "└─TableRowIDScan(Probe) 0.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+          "└─TableRowIDScan(Probe) 266.67 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
       {
         "SQL": "explain format='brief' select title from t1 where fts_match_word('hello', title) AND id > 10 AND LENGTH(title) > 1",
         "Plan": [
-          "TableReader 2666.67 root  MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 2666.67 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 2666.67 mpp[tiflash]  test.t1.title",
-          "    └─Selection 2666.67 mpp[tiflash]  gt(length(test.t1.title), 1), gt(test.t1.id, 10)",
+          "TableReader 266.67 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 266.67 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 266.67 mpp[tiflash]  test.t1.title",
+          "    └─Selection 266.67 mpp[tiflash]  gt(length(test.t1.title), 1), gt(test.t1.id, 10)",
           "      └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:(10,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -115,9 +115,9 @@
       {
         "SQL": "explain format='brief' select id from t1 where fts_match_word('hello', title)",
         "Plan": [
-          "Projection 10000.00 root  test.t1.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t1.id",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -125,10 +125,10 @@
       {
         "SQL": "explain format='brief' select id from t1 where fts_match_word('hello', title) AND id > 10",
         "Plan": [
-          "TableReader 3333.33 root  MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 3333.33 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 3333.33 mpp[tiflash]  test.t1.id",
-          "    └─Selection 3333.33 mpp[tiflash]  gt(test.t1.id, 10)",
+          "TableReader 333.33 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 333.33 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 333.33 mpp[tiflash]  test.t1.id",
+          "    └─Selection 333.33 mpp[tiflash]  gt(test.t1.id, 10)",
           "      └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:(10,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -136,10 +136,10 @@
       {
         "SQL": "explain format='brief' select id from t1 where (not fts_match_word('hello', title)) AND id > 10",
         "Plan": [
-          "TableReader 3333.33 root  MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 3333.33 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 3333.33 mpp[tiflash]  test.t1.id",
-          "    └─Selection 3333.33 mpp[tiflash]  gt(test.t1.id, 10)",
+          "TableReader 333.33 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 333.33 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 333.33 mpp[tiflash]  test.t1.id",
+          "    └─Selection 333.33 mpp[tiflash]  gt(test.t1.id, 10)",
           "      └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:(10,+inf], search func:not(istrue_with_null(fts_match_word(\"hello\", test.t1.title))), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -147,10 +147,10 @@
       {
         "SQL": "explain format='brief' select id from t1 where fts_match_word('hello', title) AND LENGTH(body) > 10",
         "Plan": [
-          "Projection 8000.00 root  test.t1.id",
-          "└─IndexLookUp 8000.00 root  ",
+          "Projection 800.00 root  test.t1.id",
+          "└─IndexLookUp 800.00 root  ",
           "  ├─IndexRangeScan(Build) 1000.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
-          "  └─Selection(Probe) 8000.00 cop[tikv]  gt(length(test.t1.body), 10)",
+          "  └─Selection(Probe) 800.00 cop[tikv]  gt(length(test.t1.body), 10)",
           "    └─TableRowIDScan 1000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -159,17 +159,17 @@
         "SQL": "explain format='brief' select * from t1 where fts_match_word('hello', title) limit 1",
         "Plan": [
           "IndexLookUp 1.00 root  limit embedded(offset:0, count:1)",
-          "├─IndexRangeScan(Build) 0.10 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
-          "└─TableRowIDScan(Probe) 0.10 cop[tikv] table:t1 keep order:false, stats:pseudo"
+          "├─IndexRangeScan(Build) 1.00 cop[tici] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
+          "└─TableRowIDScan(Probe) 1.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
       {
         "SQL": "explain format='brief' select id from t1 where fts_match_word('hello', title) and fts_match_word('world', title)",
         "Plan": [
-          "Projection 10000.00 root  test.t1.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t1.id",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), fts_match_word(\"world\", test.t1.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -177,9 +177,9 @@
       {
         "SQL": "explain format='brief' select id from t1 where (fts_match_word('apple', title) and fts_match_word('boy', title)) or (fts_match_word('banana', title) and fts_match_word('girl', title))",
         "Plan": [
-          "Projection 10000.00 root  test.t1.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t1.id",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:or(and(istrue_with_null(fts_match_word(\"apple\", test.t1.title)), istrue_with_null(fts_match_word(\"boy\", test.t1.title))), and(istrue_with_null(fts_match_word(\"banana\", test.t1.title)), istrue_with_null(fts_match_word(\"girl\", test.t1.title)))), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -187,9 +187,9 @@
       {
         "SQL": "explain format='brief' select id from t1 where (fts_match_prefix('apple', title) and fts_match_word('boy', title)) or (fts_match_word('banana', title) and fts_match_word('girl', title))",
         "Plan": [
-          "Projection 10000.00 root  test.t1.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t1.id",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:or(and(istrue_with_null(fts_match_prefix(\"apple\", test.t1.title)), istrue_with_null(fts_match_word(\"boy\", test.t1.title))), and(istrue_with_null(fts_match_word(\"banana\", test.t1.title)), istrue_with_null(fts_match_word(\"girl\", test.t1.title)))), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -213,9 +213,9 @@
       {
         "SQL": "explain format='brief' select a from t3 where fts_match_word('hello', title)",
         "Plan": [
-          "Projection 10000.00 root  test.t3.a",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t3.a",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t3, index:title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t3.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -224,9 +224,9 @@
         "SQL": "explain format='brief' select /*+ LIMIT_TO_COP() */ a from t3 where fts_match_word('hello', title) limit 1",
         "Plan": [
           "Limit 1.00 root  offset:0, count:1",
-          "└─TableReader 0.10 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 0.10 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─IndexRangeScan 0.10 mpp[tiflash] table:t3, index:title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t3.title), keep order:false, stats:pseudo"
+          "└─TableReader 1.00 root  MppVersion: 3, data:ExchangeSender",
+          "  └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─IndexRangeScan 1.00 mpp[tiflash] table:t3, index:title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t3.title), keep order:false, stats:pseudo"
         ],
         "Warn": [
           "[planner:1815]Optimizer Hint LIMIT_TO_COP is inapplicable"
@@ -246,9 +246,9 @@
       {
         "SQL": "explain format='brief' select b from t3 where fts_match_word('hello', title)",
         "Plan": [
-          "Projection 10000.00 root  test.t3.b",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t3.b",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t3, index:title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t3.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -256,9 +256,9 @@
       {
         "SQL": "explain format='brief' select a, b from t3 where fts_match_word('hello', title)",
         "Plan": [
-          "Projection 10000.00 root  test.t3.a, test.t3.b",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t3.a, test.t3.b",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t3, index:title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t3.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -266,9 +266,9 @@
       {
         "SQL": "explain format='brief' select b, a from t3 where fts_match_word('hello', title)",
         "Plan": [
-          "Projection 10000.00 root  test.t3.b, test.t3.a",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t3.b, test.t3.a",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t3, index:title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t3.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -310,22 +310,23 @@
       {
         "SQL": "explain format='brief' select count(*) from t3 where fts_match_word('hello', title) group by a",
         "Plan": [
-          "TableReader 8000.00 root  MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 8000.00 mpp[tiflash]  Column#5",
-          "    └─HashAgg 8000.00 mpp[tiflash]  group by:test.t3.a, funcs:count(1)->Column#5",
-          "      └─ExchangeReceiver 1000.00 mpp[tiflash]  ",
-          "        └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t3.a, collate: binary]",
-          "          └─IndexRangeScan 1000.00 mpp[tiflash] table:t3, index:title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t3.title), keep order:false, stats:pseudo"
+          "TableReader 800.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 800.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 800.00 mpp[tiflash]  Column#5",
+          "    └─HashAgg 800.00 mpp[tiflash]  group by:test.t3.a, funcs:sum(Column#12)->Column#5",
+          "      └─ExchangeReceiver 800.00 mpp[tiflash]  ",
+          "        └─ExchangeSender 800.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t3.a, collate: binary]",
+          "          └─HashAgg 800.00 mpp[tiflash]  group by:test.t3.a, funcs:count(1)->Column#12",
+          "            └─IndexRangeScan 1000.00 mpp[tiflash] table:t3, index:title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t3.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
       {
         "SQL": "explain format='brief' select * from t4 where i > 1",
         "Plan": [
-          "Projection 10000.00 root  test.t4.i, test.t4.ts, test.t4.d, test.t4.t",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t4.i, test.t4.ts, test.t4.d, test.t4.t",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t4, index:idx1(i, ts, d, t) range:[NULL,+inf], search func:gt(test.t4.i, 1), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -333,9 +334,9 @@
       {
         "SQL": "explain format='brief' select * from t4 where i > 1 and ts < '2025-11-30 00:00:00'",
         "Plan": [
-          "Projection 10000.00 root  test.t4.i, test.t4.ts, test.t4.d, test.t4.t",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t4.i, test.t4.ts, test.t4.d, test.t4.t",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t4, index:idx1(i, ts, d, t) range:[NULL,+inf], search func:gt(test.t4.i, 1), lt(test.t4.ts, 2025-11-30 00:00:00.000000), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -344,19 +345,19 @@
         "SQL": "explain format='brief' select * from t4 where i > 1 and ts < '2025-11-30 00:00:00' limit 10 offset 15",
         "Plan": [
           "Limit 10.00 root  offset:15, count:10",
-          "└─TableReader 2.50 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 2.50 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─IndexRangeScan 2.50 mpp[tiflash] table:t4, index:idx1(i, ts, d, t) range:[NULL,+inf], search func:gt(test.t4.i, 1), lt(test.t4.ts, 2025-11-30 00:00:00.000000), keep order:false, stats:pseudo"
+          "└─TableReader 25.00 root  MppVersion: 3, data:ExchangeSender",
+          "  └─ExchangeSender 25.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─IndexRangeScan 25.00 mpp[tiflash] table:t4, index:idx1(i, ts, d, t) range:[NULL,+inf], search func:gt(test.t4.i, 1), lt(test.t4.ts, 2025-11-30 00:00:00.000000), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
       {
         "SQL": "explain format='brief' select * from t4 where i in (1, 2, 3) and t = 'apple' order by i",
         "Plan": [
-          "Sort 10000.00 root  test.t4.i",
-          "└─Projection 10000.00 root  test.t4.i, test.t4.ts, test.t4.d, test.t4.t",
-          "  └─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "    └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "Sort 1000.00 root  test.t4.i",
+          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─Projection 1000.00 mpp[tiflash]  test.t4.i, test.t4.ts, test.t4.d, test.t4.t",
           "      └─IndexRangeScan 1000.00 mpp[tiflash] table:t4, index:idx1(i, ts, d, t) range:[NULL,+inf], search func:eq(test.t4.t, \"apple\"), in(test.t4.i, 1, 2, 3), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -452,7 +453,7 @@
       {
         "SQL": "explain format='brief' select * from t1, t4 where t1.id = t4.i and t4.ts < '2025-11-30 00:00:00' and fts_match_word('hello', t1.title)",
         "Plan": [
-          "HashJoin 12500.00 root  inner join, equal:[eq(test.t1.id, test.t4.i)]",
+          "HashJoin 1250.00 root  inner join, equal:[eq(test.t1.id, test.t4.i)]",
           "├─TableReader(Build) 1000.00 root  MppVersion: 3, data:ExchangeSender",
           "│ └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
           "│   └─IndexRangeScan 1000.00 mpp[tiflash] table:t4, index:idx1(i, ts, d, t) range:[NULL,+inf], search func:lt(test.t4.ts, 2025-11-30 00:00:00.000000), keep order:false, stats:pseudo",
@@ -465,10 +466,10 @@
       {
         "SQL": "explain format='brief' select t3.a, t4.i from t3, t4 where t3.a = t4.i and fts_match_word('hello', t3.title) and t4.t = 'apple'",
         "Plan": [
-          "TableReader 12500.00 root  MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 12500.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 12500.00 mpp[tiflash]  test.t3.a, test.t4.i",
-          "    └─HashJoin 12500.00 mpp[tiflash]  inner join, equal:[eq(test.t3.a, test.t4.i)]",
+          "TableReader 1250.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1250.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1250.00 mpp[tiflash]  test.t3.a, test.t4.i",
+          "    └─HashJoin 1250.00 mpp[tiflash]  inner join, equal:[eq(test.t3.a, test.t4.i)]",
           "      ├─ExchangeReceiver(Build) 1000.00 mpp[tiflash]  ",
           "      │ └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
           "      │   └─IndexRangeScan 1000.00 mpp[tiflash] table:t3, index:title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t3.title), keep order:false, stats:pseudo",
@@ -479,15 +480,15 @@
       {
         "SQL": "explain format='brief' select t3.a, count(*) from t3, t4 where t3.a = t4.i and fts_match_word('hello', t3.title) and t4.t = 'apple' group by t3.a",
         "Plan": [
-          "TableReader 8000.00 root  MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 8000.00 mpp[tiflash]  test.t3.a, Column#10",
-          "    └─Projection 8000.00 mpp[tiflash]  Column#10, test.t3.a",
-          "      └─HashAgg 8000.00 mpp[tiflash]  group by:test.t3.a, funcs:count(1)->Column#10, funcs:firstrow(test.t3.a)->test.t3.a",
-          "        └─ExchangeReceiver 12500.00 mpp[tiflash]  ",
-          "          └─ExchangeSender 12500.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t3.a, collate: binary]",
-          "            └─Projection 12500.00 mpp[tiflash]  test.t3.a",
-          "              └─HashJoin 12500.00 mpp[tiflash]  inner join, equal:[eq(test.t3.a, test.t4.i)]",
+          "TableReader 800.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 800.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 800.00 mpp[tiflash]  test.t3.a, Column#10",
+          "    └─Projection 800.00 mpp[tiflash]  Column#10, test.t3.a",
+          "      └─HashAgg 800.00 mpp[tiflash]  group by:test.t3.a, funcs:count(1)->Column#10, funcs:firstrow(test.t3.a)->test.t3.a",
+          "        └─ExchangeReceiver 1250.00 mpp[tiflash]  ",
+          "          └─ExchangeSender 1250.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t3.a, collate: binary]",
+          "            └─Projection 1250.00 mpp[tiflash]  test.t3.a",
+          "              └─HashJoin 1250.00 mpp[tiflash]  inner join, equal:[eq(test.t3.a, test.t4.i)]",
           "                ├─ExchangeReceiver(Build) 1000.00 mpp[tiflash]  ",
           "                │ └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
           "                │   └─IndexRangeScan 1000.00 mpp[tiflash] table:t3, index:title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t3.title), keep order:false, stats:pseudo",
@@ -498,14 +499,13 @@
       {
         "SQL": "explain format='brief' select /*+ inl_join(t4), use_index(t4, idx) */ * from t4, t2 where t2.a=t4.i and t4.t = 'apple'",
         "Plan": [
-          "Projection 12487.50 root  test.t4.i, test.t4.ts, test.t4.d, test.t4.t, test.t2.a, test.t2.col",
-          "└─HashJoin 12487.50 root  inner join, equal:[eq(test.t2.a, test.t4.i)]",
-          "  ├─TableReader(Build) 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  │ └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  │   └─IndexRangeScan 1000.00 mpp[tiflash] table:t4, index:idx1(i, ts, d, t) range:[NULL,+inf], search func:eq(test.t4.t, \"apple\"), keep order:false, stats:pseudo",
-          "  └─TableReader(Probe) 9990.00 root  data:Selection",
-          "    └─Selection 9990.00 cop[tikv]  not(isnull(test.t2.a))",
-          "      └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+          "HashJoin 1250.00 root  inner join, equal:[eq(test.t4.i, test.t2.a)]",
+          "├─TableReader(Build) 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "│ └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "│   └─IndexRangeScan 1000.00 mpp[tiflash] table:t4, index:idx1(i, ts, d, t) range:[NULL,+inf], search func:eq(test.t4.t, \"apple\"), keep order:false, stats:pseudo",
+          "└─TableReader(Probe) 9990.00 root  data:Selection",
+          "  └─Selection 9990.00 cop[tikv]  not(isnull(test.t2.a))",
+          "    └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "Warn": [
           "[planner:1815]Optimizer Hint /*+ INL_JOIN(t4) */ or /*+ TIDB_INLJ(t4) */ is inapplicable"
@@ -514,9 +514,9 @@
       {
         "SQL": "explain format='brief' select * from t5 where t = 'apple'",
         "Plan": [
-          "Projection 10000.00 root  test.t5.i, test.t5.ts, test.t5.d, test.t5.t",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t5.i, test.t5.ts, test.t5.d, test.t5.t",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t5, index:idx1(ts, d, t) range:[NULL,+inf], search func:eq(test.t5.t, \"apple\"), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -524,9 +524,9 @@
       {
         "SQL": "explain format='brief' select * from t5 where t = 'apple' and ts < '2025-11-30 00:00:00'",
         "Plan": [
-          "Projection 10000.00 root  test.t5.i, test.t5.ts, test.t5.d, test.t5.t",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t5.i, test.t5.ts, test.t5.d, test.t5.t",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t5, index:idx1(ts, d, t) range:[NULL,+inf], search func:eq(test.t5.t, \"apple\"), lt(test.t5.ts, 2025-11-30 00:00:00.000000), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -534,10 +534,10 @@
       {
         "SQL": "explain format='brief' select * from t5 where t = 'apple' and i > 10",
         "Plan": [
-          "TableReader 3333.33 root  MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 3333.33 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 3333.33 mpp[tiflash]  test.t5.i, test.t5.ts, test.t5.d, test.t5.t",
-          "    └─Selection 3333.33 mpp[tiflash]  gt(test.t5.i, 10)",
+          "TableReader 333.33 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 333.33 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 333.33 mpp[tiflash]  test.t5.i, test.t5.ts, test.t5.d, test.t5.t",
+          "    └─Selection 333.33 mpp[tiflash]  gt(test.t5.i, 10)",
           "      └─IndexRangeScan 1000.00 mpp[tiflash] table:t5, index:idx1(ts, d, t) range:[NULL,+inf], search func:eq(test.t5.t, \"apple\"), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -576,10 +576,10 @@
       {
         "SQL": "explain format='brief' select title from t1 where match(title) against ('hello' IN BOOLEAN MODE) and title = 'hello'",
         "Plan": [
-          "TableReader 10.00 root  MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 10.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 10.00 mpp[tiflash]  test.t1.title",
-          "    └─Selection 10.00 mpp[tiflash]  eq(test.t1.title, \"hello\")",
+          "TableReader 1.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1.00 mpp[tiflash]  test.t1.title",
+          "    └─Selection 1.00 mpp[tiflash]  eq(test.t1.title, \"hello\")",
           "      └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -605,9 +605,9 @@
       {
         "SQL": "explain format='brief' select id from t1 where match(title) against ('+apple -banana' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t1.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t1.id",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:and(istrue_with_null(fts_match_word(\"apple\", test.t1.title)), not(fts_match_word(\"banana\", test.t1.title))), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -615,9 +615,9 @@
       {
         "SQL": "explain format='brief' select id from t1 where match(title) against ('-banana' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t1.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t1.id",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:0, keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -625,9 +625,9 @@
       {
         "SQL": "explain format='brief' select id from t1 where match(title) against ('apple' IN BOOLEAN MODE) or match(title) against ('banana' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t1.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t1.id",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:or(istrue_with_null(fts_match_word(\"apple\", test.t1.title)), istrue_with_null(fts_match_word(\"banana\", test.t1.title))), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -635,9 +635,9 @@
       {
         "SQL": "explain format='brief' select id from t1 where match(title) against ('\"\"' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t1.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t1.id",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:0, keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -652,9 +652,9 @@
       {
         "SQL": "explain format='brief' select * from t6 where match(title) against ('hello' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t6.id, test.t6.title",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t6.id, test.t6.title",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t6, index:idx_title(title) range:[0,+inf], search func:fts_match_phrase(\"hello\", test.t6.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -662,9 +662,9 @@
       {
         "SQL": "explain format='brief' select * from t6 where match(title) against ('hello*' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t6.id, test.t6.title",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t6.id, test.t6.title",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t6, index:idx_title(title) range:[0,+inf], search func:fts_match_prefix(\"hello\", test.t6.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -672,9 +672,9 @@
       {
         "SQL": "explain format='brief' select * from t6 where match(title) against ('\\\"hello world\\\"' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t6.id, test.t6.title",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t6.id, test.t6.title",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t6, index:idx_title(title) range:[0,+inf], search func:fts_match_phrase(\"hello world\", test.t6.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -682,9 +682,9 @@
       {
         "SQL": "explain format='brief' select * from t6 where match(title) against ('\\\"a>b\\\"' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t6.id, test.t6.title",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t6.id, test.t6.title",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t6, index:idx_title(title) range:[0,+inf], search func:fts_match_phrase(\"a b\", test.t6.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -692,9 +692,9 @@
       {
         "SQL": "explain format='brief' select id from t6 where match(title) against ('+apple -banana' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t6.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t6.id",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t6, index:idx_title(title) range:[0,+inf], search func:and(istrue_with_null(fts_match_phrase(\"apple\", test.t6.title)), not(fts_match_phrase(\"banana\", test.t6.title))), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -702,9 +702,9 @@
       {
         "SQL": "explain format='brief' select id from t6 where match(title) against ('\"\"' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t6.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t6.id",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t6, index:idx_title(title) range:[0,+inf], search func:0, keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -712,9 +712,9 @@
       {
         "SQL": "explain format='brief' select * from t7 where match(title, body) against ('hello' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t7.id, test.t7.title, test.t7.body",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t7.id, test.t7.title, test.t7.body",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t7, index:idx_title_body(title, body) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t7.title, test.t7.body), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -722,9 +722,9 @@
       {
         "SQL": "explain format='brief' select * from t7 where match(body, title) against ('hello' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t7.id, test.t7.title, test.t7.body",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t7.id, test.t7.title, test.t7.body",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t7, index:idx_title_body(title, body) range:[-inf,+inf], search func:fts_match_word(\"hello\", test.t7.body, test.t7.title), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -732,9 +732,9 @@
       {
         "SQL": "explain format='brief' select id from t7 where match(title, body) against ('+apple -banana' IN BOOLEAN MODE)",
         "Plan": [
-          "Projection 10000.00 root  test.t7.id",
-          "└─TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "  └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1000.00 mpp[tiflash]  test.t7.id",
           "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t7, index:idx_title_body(title, body) range:[-inf,+inf], search func:and(istrue_with_null(fts_match_word(\"apple\", test.t7.title, test.t7.body)), not(fts_match_word(\"banana\", test.t7.title, test.t7.body))), keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -814,10 +814,10 @@
       {
         "SQL": "explain format='brief' select e.id, e.fname, s.name from employees partition(p1) e use index(h_idx) join stores s on e.store_id = s.id where e.id > 101",
         "Plan": [
-          "TableReader 12500.00 root partition:p1 MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 12500.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 12500.00 mpp[tiflash]  test.employees.id, test.employees.fname, test.stores.name",
-          "    └─HashJoin 12500.00 mpp[tiflash]  inner join, equal:[eq(test.employees.store_id, test.stores.id)]",
+          "TableReader 1250.00 root partition:p1 MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1250.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1250.00 mpp[tiflash]  test.employees.id, test.employees.fname, test.stores.name",
+          "    └─HashJoin 1250.00 mpp[tiflash]  inner join, equal:[eq(test.employees.store_id, test.stores.id)]",
           "      ├─ExchangeReceiver(Build) 1000.00 mpp[tiflash]  ",
           "      │ └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
           "      │   └─IndexRangeScan 1000.00 mpp[tiflash] table:e, index:h_idx(id, fname, store_id, body) range:[NULL,+inf], search func:gt(test.employees.id, 101), keep order:false, stats:pseudo",
@@ -828,10 +828,10 @@
       {
         "SQL": "explain format='brief' select e.id, e.fname, s.name from employees e use index(h_idx) join stores s on e.store_id = s.id where e.id > 101",
         "Plan": [
-          "TableReader 12500.00 root partition:p1,p2 MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 12500.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 12500.00 mpp[tiflash]  test.employees.id, test.employees.fname, test.stores.name",
-          "    └─HashJoin 12500.00 mpp[tiflash]  inner join, equal:[eq(test.employees.store_id, test.stores.id)]",
+          "TableReader 1250.00 root partition:p1,p2 MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1250.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 1250.00 mpp[tiflash]  test.employees.id, test.employees.fname, test.stores.name",
+          "    └─HashJoin 1250.00 mpp[tiflash]  inner join, equal:[eq(test.employees.store_id, test.stores.id)]",
           "      ├─ExchangeReceiver(Build) 1000.00 mpp[tiflash]  ",
           "      │ └─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
           "      │   └─IndexRangeScan 1000.00 mpp[tiflash] table:e, index:h_idx(id, fname, store_id, body) range:[NULL,+inf], search func:gt(test.employees.id, 101), keep order:false, stats:pseudo",

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -242,15 +242,44 @@ func fillIndexPath(ds *logicalop.DataSource, path *util.AccessPath, conds []expr
 
 func deriveSearchPathStats(ds *logicalop.DataSource, path *util.AccessPath) {
 	path.IndexFilters, path.TableFilters = splitIndexFilterConditions(ds, path.TableFilters, path.FullIdxCols, path.FullIdxColLens)
+	countAfterAccess := min(float64(ds.StatisticTable.RealtimeCount)/10, 1000)
 	// TiCI count estimation is only used to refine multi-table plan choices.
 	// StmtCtx.Tables is de-duplicated, so self-joins on one table use the local fallback.
 	if len(ds.SCtx().GetSessionVars().StmtCtx.Tables) > 1 {
 		if count, ok := deriveTiCISearchPathStats(ds, path); ok {
-			path.CountAfterAccess = count
-			return
+			countAfterAccess = count
 		}
 	}
-	path.CountAfterAccess = min(float64(ds.StatisticTable.RealtimeCount)/10, 1000)
+	updateTiCISearchPathStats(ds, path, countAfterAccess)
+}
+
+func updateTiCISearchPathStats(ds *logicalop.DataSource, path *util.AccessPath, countAfterAccess float64) {
+	calcSelectivity := func(filters []expression.Expression) float64 {
+		selectivity, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, filters, nil)
+		if err != nil || selectivity <= 0 {
+			logutil.BgLogger().Debug("calculate selectivity failed, use selection factor", zap.Error(err))
+			return cost.SelectionFactor
+		}
+		return selectivity
+	}
+
+	path.CountAfterAccess = countAfterAccess
+	path.CountAfterIndex = countAfterAccess
+	countAfterFilters := countAfterAccess
+	if len(path.IndexFilters) > 0 {
+		selectivity := calcSelectivity(path.IndexFilters)
+		path.CountAfterIndex = countAfterAccess * selectivity
+		countAfterFilters = path.CountAfterIndex
+	}
+	if len(path.TableFilters) > 0 {
+		selectivity := calcSelectivity(path.TableFilters)
+		countAfterFilters *= selectivity
+	}
+	// TODO: Let deriveStatsByFilter produce this final DataSource stats after TiCI FTS
+	// predicates can participate in normal selectivity estimation. Today those predicates
+	// are consumed into FtsQueryInfo before deriveStatsByFilter runs, and the TiCI search
+	// count is only known during path stats derivation.
+	ds.SetStats(ds.TableStats.ScaleByExpectCnt(ds.SCtx().GetSessionVars(), countAfterFilters))
 }
 
 func deriveTiCISearchPathStats(ds *logicalop.DataSource, path *util.AccessPath) (float64, bool) {

--- a/pkg/store/mockstore/mockstorage/BUILD.bazel
+++ b/pkg/store/mockstore/mockstorage/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/store/copr",
         "//pkg/store/driver/txn",
         "//pkg/store/helper",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/deadlock",
         "@com_github_pingcap_kvproto//pkg/keyspacepb",
         "@com_github_tikv_client_go_v2//config",

--- a/pkg/store/mockstore/mockstorage/storage.go
+++ b/pkg/store/mockstore/mockstorage/storage.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pingcap/failpoint"
 	deadlockpb "github.com/pingcap/kvproto/pkg/deadlock"
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -102,6 +103,11 @@ func (s *mockStorage) Describe() string {
 }
 
 func (s *mockStorage) EstimateTiCICount(ctx context.Context, req *kv.TiCIEstimateCountRequest, timeout time.Duration) (uint64, error) {
+	failpoint.Inject("MockTiCIEstimateCount", func(val failpoint.Value) {
+		if count, ok := val.(int); ok {
+			failpoint.Return(uint64(count), nil)
+		}
+	})
 	return 1000, nil
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->
cherry-pick 68620

Issue Number: close #68618

Problem Summary:

The TiCI FTS access path updates `AccessPath.CountAfterAccess`, but the logical `DataSource` stats still used the row count derived without the FTS predicate. As a result, operators above the TiCI scan, such as Selection, Projection, and Join, could still be costed with the original table row count.

### What changed and how does it work?

This PR updates TiCI search path stats after the TiCI FTS count is known:

- fills `CountAfterAccess` and `CountAfterIndex` for TiCI search paths;
- applies residual index/table filter selectivity to derive the final output row count;
- refreshes `DataSource.StatsInfo` so upper operators use the TiCI FTS row count;
- adds regression coverage that verifies both the TiCI scan and upper join/projection estimates use the expected row counts.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```
make failpoint-enable
go test ./pkg/planner/core/casetest/tici -run TestTiCISearchEstimateOnlyForMultiTable --tags=intest
go test ./pkg/planner/core/casetest/tici --tags=intest
make failpoint-disable
git diff --check
make bazel_lint_changed
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix TiCI FTS row count estimates for operators above TiCI scans.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced query optimizer cost estimation for full-text search operations, resulting in more accurate execution plans.

* **Tests**
  * Expanded test coverage and updated expectations for query planner behavior with full-text search and multi-table join scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->