### PR TITLE
planner: keep BIGINT join-key casts on lossy compare path

### DIFF
--- a/pkg/planner/core/casetest/join/join_test.go
+++ b/pkg/planner/core/casetest/join/join_test.go
@@ -242,6 +242,14 @@ func TestJoinRegression(t *testing.T) {
 		tk.MustExec(`create table issue65325_t1(c0 double)`)
 		tk.MustQuery(`SELECT /* issue:65325 */ issue65325_t1.c0, issue65325_t1.c0 FROM issue65325_t0 NATURAL JOIN issue65325_t1 ORDER BY CASE DEFAULT(issue65325_t1.c0) WHEN issue65325_t1.c0 THEN 397344251 ELSE issue65325_t0.c0 END`).Check(testkit.Rows())
 
+		tk.MustExec(`drop table if exists issue67731_t1, issue67731_t2`)
+		tk.MustExec(`create table issue67731_t1(a varchar(20))`)
+		tk.MustExec(`create table issue67731_t2(a bigint)`)
+		tk.MustExec(`insert into issue67731_t1 values('9007199254740993')`)
+		tk.MustExec(`insert into issue67731_t2 values(9007199254740992)`)
+		tk.MustQuery(`select /* issue:67731 */ '9007199254740993' = 9007199254740992`).Check(testkit.Rows("1"))
+		tk.MustQuery(`select /* issue:67731 */ issue67731_t1.a, issue67731_t2.a from issue67731_t1 join issue67731_t2 on issue67731_t1.a = issue67731_t2.a`).Check(testkit.Rows("9007199254740993 9007199254740992"))
+
 		tk.MustExec(`create table t1 (a int)`)
 		tk.MustExec(`create table t2 (a int, b int, c int, d int, key ab(a, b), key abcd(a, b, c, d))`)
 		tk.MustUseIndex(`select /* issue:63949 */ /*+ tidb_inlj(t2) */ t2.a from t1, t2 where t1.a=t2.a and t2.b=1 and t2.d=1`, "abcd")

--- a/pkg/planner/core/rule/rule_join_key_type_cast.go
+++ b/pkg/planner/core/rule/rule_join_key_type_cast.go
@@ -303,7 +303,13 @@ func findCastInProj(proj *logicalop.LogicalProjection, col *expression.Column, e
 func classifyCastPair(leftInfo, rightInfo *projCastInfo) (intInfo, strInfo *projCastInfo) {
 	isSignedInt := func(info *projCastInfo) bool {
 		tp := info.origCol.GetType(nil)
-		return tp.EvalType() == types.ETInt && !mysql.HasUnsignedFlag(tp.GetFlag())
+		if tp.EvalType() != types.ETInt || mysql.HasUnsignedFlag(tp.GetFlag()) {
+			return false
+		}
+		// Keep BIGINT on the original DOUBLE-domain comparison path. Rewriting
+		// VARCHAR = BIGINT to integer equality changes the observable result once
+		// values cross DOUBLE's exact-integer boundary (for example 2^53 + 1).
+		return tp.GetType() != mysql.TypeLonglong
 	}
 	isStr := func(info *projCastInfo) bool {
 		return info.origCol.GetType(nil).EvalType().IsStringKind()

--- a/tests/integrationtest/r/planner/core/join_key_type_cast.result
+++ b/tests/integrationtest/r/planner/core/join_key_type_cast.result
@@ -161,6 +161,7 @@ insert into t_overflow_str values ('9223372036854775807', 10), ('922337203685477
 select * from t_overflow_int join t_overflow_str on t_overflow_int.id = t_overflow_str.id;
 id	v	id	v
 9223372036854775807	1	9223372036854775807	10
+9223372036854775807	1	9223372036854775808	20
 select * from t_int, t_varchar where t_int.id = t_varchar.id order by t_int.id;
 id	v	id	v
 0	0	abc	99


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67731

Problem Summary:

`rule_join_key_type_cast` rewrites mixed string/integer join keys to integer equality so index joins can keep using the integer side. That rewrite is correct for smaller signed integers, but it changes observable semantics for `VARCHAR = BIGINT` once values cross `DOUBLE`'s exact integer boundary. In that shape scalar comparison still follows the lossy `DOUBLE` path, while the join rewrite switches to exact `BIGINT` comparison and can turn a matching join into an empty result.

### What changed and how does it work?

- Skip the join-key cast rewrite when the integer side is `SIGNED BIGINT`
- Add a join regression that locks the original `#67731` reproduction

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue) to write a quality release note.

```release-note
Fix incorrect empty join results for some VARCHAR = BIGINT comparisons after join-key cast rewriting.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected join behavior for columns with mismatched types (string vs integer), preserving accurate comparison semantics for very large numeric values so rows across numeric boundaries match as expected.

* **Tests**
  * Added regression and integration checks for joins between differing column types to ensure correctness for boundary numeric values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->