### PR TITLE
ddl: validate partial indexes for foreign keys

### DIFF
--- a/br/pkg/restore/ingestrec/foreign_key.go
+++ b/br/pkg/restore/ingestrec/foreign_key.go
@@ -119,12 +119,12 @@ func NewForeignKeyRecordManagerForTables(
 
 func (tm *TableForeignKeyRecordManager) RemoveForeignKeys(tableInfo *model.TableInfo, indexInfo *model.IndexInfo) {
 	for key, fkRecord := range tm.fkRecordMap {
-		if model.IsIndexPrefixCovered(tableInfo, indexInfo, fkRecord.Cols...) {
+		if model.IsIndexPrefixCoveredForForeignKey(tableInfo, indexInfo, fkRecord.Cols...) {
 			delete(tm.fkRecordMap, key)
 		}
 	}
 	for key, fkRecord := range tm.referredFKRecordMap {
-		if model.IsIndexPrefixCovered(tableInfo, indexInfo, fkRecord.RefCols...) {
+		if model.IsIndexPrefixCoveredForForeignKey(tableInfo, indexInfo, fkRecord.RefCols...) {
 			delete(tm.referredFKRecordMap, key)
 		}
 	}

--- a/br/pkg/restore/ingestrec/foreign_key_test.go
+++ b/br/pkg/restore/ingestrec/foreign_key_test.go
@@ -100,6 +100,44 @@ func TestForeignKeyRecordManager(t *testing.T) {
 		foreignKeyRecordManager.Merge(parentTableForeignKeyRecordManager)
 		require.Len(t, foreignKeyRecordManager.GetFKRecordMap(), 0)
 	}
+
+	tk.MustExec("create table test.partial_parent (id int, index parent_idx(id))")
+	tk.MustExec("create table test.partial_child (id int, pid int, marker int, index unsafe_pid(pid) where marker is not null, index safe_pid(pid) where pid is not null, foreign key (pid) references test.partial_parent (id))")
+
+	infoSchema = s.Mock.InfoSchema()
+	partialChildTableInfo, err := infoSchema.TableInfoByName(ast.NewCIStr("test"), ast.NewCIStr("partial_child"))
+	require.NoError(t, err)
+	unsafeIdx := partialChildTableInfo.FindIndexByName("unsafe_pid")
+	require.NotNil(t, unsafeIdx)
+	safeIdx := partialChildTableInfo.FindIndexByName("safe_pid")
+	require.NotNil(t, safeIdx)
+
+	partialChildForeignKeyRecordManager, err := ingestrec.NewForeignKeyRecordManagerForTables(ctx, infoSchema, ast.NewCIStr("test"), partialChildTableInfo)
+	require.NoError(t, err)
+	require.Len(t, partialChildForeignKeyRecordManager.GetFKRecordMap(), 1)
+	partialChildForeignKeyRecordManager.RemoveForeignKeys(partialChildTableInfo, unsafeIdx)
+	require.Len(t, partialChildForeignKeyRecordManager.GetFKRecordMap(), 1)
+	partialChildForeignKeyRecordManager.RemoveForeignKeys(partialChildTableInfo, safeIdx)
+	require.Len(t, partialChildForeignKeyRecordManager.GetFKRecordMap(), 0)
+
+	tk.MustExec("create table test.partial_ref_parent (id int, marker int, index unsafe_id(id) where marker is not null, index safe_id(id) where id is not null)")
+	tk.MustExec("create table test.partial_ref_child (id int, pid int, index child_pid(pid), foreign key (pid) references test.partial_ref_parent (id))")
+
+	infoSchema = s.Mock.InfoSchema()
+	partialRefParentInfo, err := infoSchema.TableInfoByName(ast.NewCIStr("test"), ast.NewCIStr("partial_ref_parent"))
+	require.NoError(t, err)
+	unsafeRefIdx := partialRefParentInfo.FindIndexByName("unsafe_id")
+	require.NotNil(t, unsafeRefIdx)
+	safeRefIdx := partialRefParentInfo.FindIndexByName("safe_id")
+	require.NotNil(t, safeRefIdx)
+
+	partialRefParentForeignKeyRecordManager, err := ingestrec.NewForeignKeyRecordManagerForTables(ctx, infoSchema, ast.NewCIStr("test"), partialRefParentInfo)
+	require.NoError(t, err)
+	require.Len(t, partialRefParentForeignKeyRecordManager.GetReferredFKRecordMap(), 1)
+	partialRefParentForeignKeyRecordManager.RemoveForeignKeys(partialRefParentInfo, unsafeRefIdx)
+	require.Len(t, partialRefParentForeignKeyRecordManager.GetReferredFKRecordMap(), 1)
+	partialRefParentForeignKeyRecordManager.RemoveForeignKeys(partialRefParentInfo, safeRefIdx)
+	require.Len(t, partialRefParentForeignKeyRecordManager.GetReferredFKRecordMap(), 0)
 }
 
 func TestForeignKeyRecordManagerForPK1(t *testing.T) {

--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -1672,7 +1672,7 @@ func addIndexForForeignKey(ctx *metabuild.Context, tbInfo *model.TableInfo) erro
 		if handleCol != nil && len(fk.Cols) == 1 && handleCol.Name.L == fk.Cols[0].L {
 			continue
 		}
-		if model.FindIndexByColumns(tbInfo, tbInfo.Indices, fk.Cols...) != nil {
+		if model.FindIndexByColumnsForForeignKey(tbInfo, tbInfo.Indices, fk.Cols...) != nil {
 			continue
 		}
 		idxName := fk.Name

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -5280,7 +5280,7 @@ func (e *executor) CreateForeignKey(ctx sessionctx.Context, ti ast.Ident, fkName
 	if err != nil {
 		return err
 	}
-	if model.FindIndexByColumns(t.Meta(), t.Meta().Indices, fkInfo.Cols...) == nil {
+	if model.FindIndexByColumnsForForeignKey(t.Meta(), t.Meta().Indices, fkInfo.Cols...) == nil {
 		// Need to auto create index for fk cols
 		if ctx.GetSessionVars().StmtCtx.MultiSchemaInfo == nil {
 			ctx.GetSessionVars().StmtCtx.MultiSchemaInfo = model.NewMultiSchemaInfo()

--- a/pkg/ddl/foreign_key.go
+++ b/pkg/ddl/foreign_key.go
@@ -292,7 +292,7 @@ func checkTableForeignKey(referTblInfo, tblInfo *model.TableInfo, fkInfo *model.
 		}
 	}
 	// check refer columns should have index.
-	if model.FindIndexByColumns(referTblInfo, referTblInfo.Indices, fkInfo.RefCols...) == nil {
+	if model.FindIndexByColumnsForForeignKey(referTblInfo, referTblInfo.Indices, fkInfo.RefCols...) == nil {
 		return infoschema.ErrForeignKeyNoIndexInParent.GenWithStackByArgs(fkInfo.Name, fkInfo.RefTable)
 	}
 	return nil
@@ -453,7 +453,7 @@ func checkIndexNeededInForeignKey(is infoschema.InfoSchema, dbName string, tbInf
 		remainIdxs = append(remainIdxs, idx)
 	}
 	checkFn := func(cols []ast.CIStr) error {
-		if !model.IsIndexPrefixCovered(tbInfo, idxInfo, cols...) {
+		if !model.IsIndexPrefixCoveredForForeignKey(tbInfo, idxInfo, cols...) {
 			return nil
 		}
 		if tbInfo.PKIsHandle && len(cols) == 1 {
@@ -463,7 +463,7 @@ func checkIndexNeededInForeignKey(is infoschema.InfoSchema, dbName string, tbInf
 			}
 		}
 		for _, index := range remainIdxs {
-			if model.IsIndexPrefixCovered(tbInfo, index, cols...) {
+			if model.IsIndexPrefixCoveredForForeignKey(tbInfo, index, cols...) {
 				return nil
 			}
 		}
@@ -661,7 +661,7 @@ func checkAddForeignKeyValidInOwner(infoCache *infoschema.InfoCache, schema stri
 			return nil
 		}
 	}
-	if model.FindIndexByColumns(tbInfo, tbInfo.Indices, fk.Cols...) == nil {
+	if model.FindIndexByColumnsForForeignKey(tbInfo, tbInfo.Indices, fk.Cols...) == nil {
 		return errors.Errorf("Failed to add the foreign key constraint. Missing index for '%s' foreign key columns in the table '%s'", fk.Name, tbInfo.Name)
 	}
 	return nil

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -426,7 +426,7 @@ func checkOperateDropIndexUseByForeignKey(info *model.MultiSchemaInfo, t table.T
 	}
 
 	for _, fk := range info.AddForeignKeys {
-		if droppingIdx := model.FindIndexByColumns(tbInfo, droppingIndexes, fk.Cols...); droppingIdx != nil && model.FindIndexByColumns(tbInfo, remainIndexes, fk.Cols...) == nil {
+		if droppingIdx := model.FindIndexByColumnsForForeignKey(tbInfo, droppingIndexes, fk.Cols...); droppingIdx != nil && model.FindIndexByColumnsForForeignKey(tbInfo, remainIndexes, fk.Cols...) == nil {
 			return dbterror.ErrDropIndexNeededInForeignKey.GenWithStackByArgs(droppingIdx.Name)
 		}
 	}

--- a/pkg/ddl/tests/fk/foreign_key_test.go
+++ b/pkg/ddl/tests/fk/foreign_key_test.go
@@ -136,6 +136,19 @@ func TestCreateTableWithForeignKeyMetaInfo(t *testing.T) {
 	}, *tb5Info.ForeignKeys[0])
 	require.Equal(t, 1, len(tb5Info.Indices))
 	require.Equal(t, "fk_1", tb5Info.Indices[0].Name.L)
+
+	tk.MustExec("create table partial_parent (id int key)")
+	tk.MustExec("create table partial_child_unsafe (id int key, pid int, marker int, index unsafe_pid(pid) where marker is not null, foreign key fk_pid(pid) references partial_parent(id))")
+	partialUnsafeInfo := getTableInfo(t, dom, "test2", "partial_child_unsafe")
+	require.Equal(t, 2, len(partialUnsafeInfo.Indices))
+	require.Equal(t, "unsafe_pid", partialUnsafeInfo.Indices[0].Name.L)
+	require.Equal(t, "fk_pid", partialUnsafeInfo.Indices[1].Name.L)
+
+	tk.MustExec("create table partial_child_safe (id int key, pid int, index safe_pid(pid) where pid is not null, foreign key fk_pid(pid) references partial_parent(id))")
+	partialSafeInfo := getTableInfo(t, dom, "test2", "partial_child_safe")
+	require.Equal(t, 1, len(partialSafeInfo.Indices))
+	require.Equal(t, "safe_pid", partialSafeInfo.Indices[0].Name.L)
+
 	require.Equal(t, 1, len(dom.InfoSchema().GetTableReferredForeignKeys("test", "t1")))
 	require.Equal(t, 1, len(dom.InfoSchema().GetTableReferredForeignKeys("test2", "t2")))
 	require.Equal(t, 0, len(dom.InfoSchema().GetTableReferredForeignKeys("test2", "t3")))
@@ -1168,6 +1181,42 @@ func TestAddForeignKey(t *testing.T) {
 		"  `a` int(11) DEFAULT NULL,\n" +
 		"  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
+
+	// Test unsafe partial index should not be used as the child foreign key index.
+	tk.MustExec("drop table if exists t1,t2")
+	tk.MustExec("create table t1 (id int key);")
+	tk.MustExec("create table t2 (id int key, b int, c int, index idx_b(b) where c is not null);")
+	tk.MustExec("alter table t2 add constraint fk_b foreign key (b) references t1(id);")
+	tbl2Info = getTableInfo(t, dom, "test", "t2")
+	require.Equal(t, 2, len(tbl2Info.Indices))
+	require.Equal(t, "idx_b", tbl2Info.Indices[0].Name.L)
+	require.Equal(t, "fk_b", tbl2Info.Indices[1].Name.L)
+	tk.MustExec("insert into t1 values (1);")
+	tk.MustExec("insert into t2 values (1, 1, null);")
+	tk.MustGetDBError("delete from t1 where id = 1", plannererrors.ErrRowIsReferenced2)
+	tk.MustExec("alter table t2 drop index idx_b;")
+	tk.MustGetDBError("alter table t2 drop index fk_b", dbterror.ErrDropIndexNeededInForeignKey)
+
+	// Test IS NOT NULL partial indexes are safe for foreign key checks.
+	tk.MustExec("drop table if exists t1,t2")
+	tk.MustExec("create table t1 (id int key);")
+	tk.MustExec("create table t2 (id int key, b int, index idx_b(b) where b is not null);")
+	tk.MustExec("alter table t2 add constraint fk_b foreign key (b) references t1(id);")
+	tbl2Info = getTableInfo(t, dom, "test", "t2")
+	require.Equal(t, 1, len(tbl2Info.Indices))
+	require.Equal(t, "idx_b", tbl2Info.Indices[0].Name.L)
+	tk.MustExec("insert into t1 values (1);")
+	tk.MustExec("insert into t2 values (1, 1);")
+	tk.MustGetDBError("delete from t1 where id = 1", plannererrors.ErrRowIsReferenced2)
+
+	// Test IS NOT NULL partial indexes are safe for referenced columns.
+	tk.MustExec("drop table if exists t1,t2")
+	tk.MustExec("create table t1 (id int key, a int, index idx_a(a) where a is not null);")
+	tk.MustExec("create table t2 (id int key, b int, index idx_b(b));")
+	tk.MustExec("alter table t2 add constraint fk_b foreign key (b) references t1(a);")
+	tk.MustExec("insert into t1 values (1, 10);")
+	tk.MustExec("insert into t2 values (1, 10);")
+	tk.MustGetDBError("insert into t2 values (2, 20)", plannererrors.ErrNoReferencedRow2)
 }
 
 func TestAlterTableAddForeignKeyError(t *testing.T) {
@@ -1291,6 +1340,30 @@ func TestAlterTableAddForeignKeyError(t *testing.T) {
 				"create table t2 (a int, b varchar(10));",
 			},
 			alter: "alter  table t2 add foreign key fk_b(b) references t1(a)",
+			err:   "[schema:1822]Failed to add the foreign key constraint. Missing index for constraint 'fk_b' in the referenced table 't1'",
+		},
+		{
+			prepares: []string{
+				"create table t1 (id int key, a int, b int, index idx_a(a) where b = 1);",
+				"create table t2 (a int, b int, index(b));",
+			},
+			alter: "alter table t2 add foreign key fk_b(b) references t1(a)",
+			err:   "[schema:1822]Failed to add the foreign key constraint. Missing index for constraint 'fk_b' in the referenced table 't1'",
+		},
+		{
+			prepares: []string{
+				"create table t1 (id int key, a int, index idx_a(a) where a is null);",
+				"create table t2 (a int, b int, index(b));",
+			},
+			alter: "alter table t2 add foreign key fk_b(b) references t1(a)",
+			err:   "[schema:1822]Failed to add the foreign key constraint. Missing index for constraint 'fk_b' in the referenced table 't1'",
+		},
+		{
+			prepares: []string{
+				"create table t1 (id int key, a int, b int, index idx_a(a) where b is not null);",
+				"create table t2 (a int, b int, index(b));",
+			},
+			alter: "alter table t2 add foreign key fk_b(b) references t1(a)",
 			err:   "[schema:1822]Failed to add the foreign key constraint. Missing index for constraint 'fk_b' in the referenced table 't1'",
 		},
 		{

--- a/pkg/executor/test/fktest/foreign_key_test.go
+++ b/pkg/executor/test/fktest/foreign_key_test.go
@@ -1003,6 +1003,15 @@ func TestForeignKeyOnDeleteCascade(t *testing.T) {
 		tk.MustQuery("select * from t1").Check(testkit.Rows())
 		tk.MustQuery("select * from t2").Check(testkit.Rows())
 	}
+
+	tk.MustExec("drop table if exists t2;")
+	tk.MustExec("drop table if exists t1;")
+	tk.MustExec("create table t1 (id int key);")
+	tk.MustExec("create table t2 (id int key, pid int, index safe_pid(pid) where pid is not null, foreign key fk_pid(pid) references t1(id) on delete cascade);")
+	tk.MustExec("insert into t1 values (1),(2);")
+	tk.MustExec("insert into t2 values (1, 1),(2, 2),(3, null);")
+	tk.MustExec("delete from t1 where id = 1;")
+	tk.MustQuery("select id, pid from t2 order by id").Check(testkit.Rows("2 2", "3 <nil>"))
 }
 
 func TestForeignKeyOnDeleteCascade2(t *testing.T) {
@@ -1377,6 +1386,15 @@ func TestForeignKeyOnDeleteSetNull(t *testing.T) {
 			tk.MustQuery("select id, a, b, name from t2 order by id").Check(testkit.Rows("1 <nil> <nil> a", "2 <nil> <nil> b"))
 		}
 	}
+
+	tk.MustExec("drop table if exists t2;")
+	tk.MustExec("drop table if exists t1;")
+	tk.MustExec("create table t1 (id int key);")
+	tk.MustExec("create table t2 (id int key, pid int, marker int, index unsafe_pid(pid) where marker is not null, foreign key fk_pid(pid) references t1(id) on delete set null);")
+	tk.MustExec("insert into t1 values (1),(2);")
+	tk.MustExec("insert into t2 values (1, 1, null),(2, 2, 1),(3, null, null);")
+	tk.MustExec("delete from t1 where id = 1;")
+	tk.MustQuery("select id, pid, marker from t2 order by id").Check(testkit.Rows("1 <nil> <nil>", "2 2 1", "3 <nil> <nil>"))
 }
 
 func TestForeignKeyOnDeleteSetNull2(t *testing.T) {
@@ -1810,6 +1828,15 @@ func TestForeignKeyOnUpdateCascade(t *testing.T) {
 	tk.MustExec("update t1 set id = id + 100 where id in (1, 2, 3)")
 	tk.MustQuery("select id, a, b from t1 order by id").Check(testkit.Rows("4 14 24", "101 11 21", "102 12 22", "103 13 23"))
 	tk.MustQuery("select id, a, b, name from t2 order by id").Check(testkit.Rows("11 101 21 a", "12 102 22 b", "13 103 23 c", "14 4 24 d"))
+
+	tk.MustExec("drop table if exists t2;")
+	tk.MustExec("drop table if exists t1;")
+	tk.MustExec("create table t1 (id int key);")
+	tk.MustExec("create table t2 (id int key, pid int, marker int, index unsafe_pid(pid) where marker is not null, foreign key fk_pid(pid) references t1(id) on update cascade);")
+	tk.MustExec("insert into t1 values (1),(2);")
+	tk.MustExec("insert into t2 values (1, 1, null),(2, 2, 1),(3, null, null);")
+	tk.MustExec("update t1 set id = 10 where id = 1;")
+	tk.MustQuery("select id, pid, marker from t2 order by id").Check(testkit.Rows("1 10 <nil>", "2 2 1", "3 <nil> <nil>"))
 }
 
 func TestForeignKeyOnUpdateCascade2(t *testing.T) {

--- a/pkg/meta/model/BUILD.bazel
+++ b/pkg/meta/model/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "//pkg/parser/mysql",
         "//pkg/parser/terror",
         "//pkg/parser/types",
+        "//pkg/types/parser_driver",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_pd_client//http",
     ],

--- a/pkg/meta/model/index.go
+++ b/pkg/meta/model/index.go
@@ -478,6 +478,49 @@ func IsIndexPrefixCovered(tbInfo *TableInfo, index *IndexInfo, cols ...ast.CIStr
 	return true
 }
 
+// FindIndexByColumnsForForeignKey finds an index that can be safely used by a foreign key.
+func FindIndexByColumnsForForeignKey(tbInfo *TableInfo, indices []*IndexInfo, cols ...ast.CIStr) *IndexInfo {
+	for _, index := range indices {
+		if IsIndexPrefixCoveredForForeignKey(tbInfo, index, cols...) {
+			return index
+		}
+	}
+	return nil
+}
+
+// IsIndexPrefixCoveredForForeignKey checks whether the index covers the foreign key columns
+// and whether the partial index predicate, if any, is safe for foreign key checks.
+func IsIndexPrefixCoveredForForeignKey(tbInfo *TableInfo, index *IndexInfo, cols ...ast.CIStr) bool {
+	if !IsIndexPrefixCovered(tbInfo, index, cols...) {
+		return false
+	}
+	return isIndexConditionCoveredByForeignKeyCols(index, cols...)
+}
+
+func isIndexConditionCoveredByForeignKeyCols(index *IndexInfo, cols ...ast.CIStr) bool {
+	if !index.HasCondition() {
+		return true
+	}
+	expr, err := index.ConditionExpr()
+	if err != nil {
+		return false
+	}
+	isNullExpr, ok := expr.(*ast.IsNullExpr)
+	if !ok || !isNullExpr.Not {
+		return false
+	}
+	colExpr, ok := isNullExpr.Expr.(*ast.ColumnNameExpr)
+	if !ok {
+		return false
+	}
+	for _, col := range cols {
+		if colExpr.Name.Name.L == col.L {
+			return true
+		}
+	}
+	return false
+}
+
 // FindIndexInfoByID finds IndexInfo in indices by id.
 func FindIndexInfoByID(indices []*IndexInfo, id int64) *IndexInfo {
 	for _, idx := range indices {

--- a/pkg/meta/model/index.go
+++ b/pkg/meta/model/index.go
@@ -497,6 +497,15 @@ func IsIndexPrefixCoveredForForeignKey(tbInfo *TableInfo, index *IndexInfo, cols
 	return isIndexConditionCoveredByForeignKeyCols(index, cols...)
 }
 
+// isIndexConditionCoveredByForeignKeyCols returns whether the partial index predicate
+// is implied by the rows that need foreign key checks.
+//
+// Foreign keys currently use MATCH SIMPLE semantics: for a composite foreign key,
+// a row participates in checks and cascades only when all foreign key columns are
+// non-NULL. Therefore, a predicate of "<fk-col> IS NOT NULL" on any one foreign
+// key column is safe, because every row that needs a foreign key lookup satisfies
+// it. Predicates on non-foreign-key columns, or stricter predicates such as
+// comparisons, may filter out rows that still need checks and are not safe here.
 func isIndexConditionCoveredByForeignKeyCols(index *IndexInfo, cols ...ast.CIStr) bool {
 	if !index.HasCondition() {
 		return true

--- a/pkg/meta/model/index_test.go
+++ b/pkg/meta/model/index_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	_ "github.com/pingcap/tidb/pkg/types/parser_driver"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,6 +70,28 @@ func TestIsIndexPrefixCovered(t *testing.T) {
 	require.Equal(t, true, IsIndexPrefixCovered(tbl, i1, ast.NewCIStr("c_4")))
 	require.Equal(t, true, IsIndexPrefixCovered(tbl, i1, ast.NewCIStr("c_4"), ast.NewCIStr("c_2")))
 	require.Equal(t, false, IsIndexPrefixCovered(tbl, i0, ast.NewCIStr("c_2")))
+
+	safePartial := newIndexForTest(2, c0, c1)
+	safePartial.ConditionExprString = "`c_1` is not null"
+	require.True(t, IsIndexPrefixCoveredForForeignKey(tbl, safePartial, ast.NewCIStr("c_0"), ast.NewCIStr("c_1")))
+
+	unsafePartialOnNonFKCol := newIndexForTest(3, c0, c1)
+	unsafePartialOnNonFKCol.ConditionExprString = "`c_2` is not null"
+	require.False(t, IsIndexPrefixCoveredForForeignKey(tbl, unsafePartialOnNonFKCol, ast.NewCIStr("c_0"), ast.NewCIStr("c_1")))
+
+	unsafePartialIsNull := newIndexForTest(4, c0)
+	unsafePartialIsNull.ConditionExprString = "`c_0` is null"
+	require.False(t, IsIndexPrefixCoveredForForeignKey(tbl, unsafePartialIsNull, ast.NewCIStr("c_0")))
+
+	unsafePartialBinaryCondition := newIndexForTest(5, c0)
+	unsafePartialBinaryCondition.ConditionExprString = "`c_0` > 0"
+	require.False(t, IsIndexPrefixCoveredForForeignKey(tbl, unsafePartialBinaryCondition, ast.NewCIStr("c_0")))
+
+	badCondition := newIndexForTest(6, c0)
+	badCondition.ConditionExprString = "`c_0` is"
+	require.False(t, IsIndexPrefixCoveredForForeignKey(tbl, badCondition, ast.NewCIStr("c_0")))
+
+	require.Same(t, safePartial, FindIndexByColumnsForForeignKey(tbl, []*IndexInfo{unsafePartialOnNonFKCol, safePartial}, ast.NewCIStr("c_0"), ast.NewCIStr("c_1")))
 }
 
 func TestGlobalIndexV1SupportedForNextGen(t *testing.T) {

--- a/pkg/meta/model/index_test.go
+++ b/pkg/meta/model/index_test.go
@@ -75,19 +75,23 @@ func TestIsIndexPrefixCovered(t *testing.T) {
 	safePartial.ConditionExprString = "`c_1` is not null"
 	require.True(t, IsIndexPrefixCoveredForForeignKey(tbl, safePartial, ast.NewCIStr("c_0"), ast.NewCIStr("c_1")))
 
-	unsafePartialOnNonFKCol := newIndexForTest(3, c0, c1)
+	safePartialOnFirstFKCol := newIndexForTest(3, c0, c1)
+	safePartialOnFirstFKCol.ConditionExprString = "`c_0` is not null"
+	require.True(t, IsIndexPrefixCoveredForForeignKey(tbl, safePartialOnFirstFKCol, ast.NewCIStr("c_0"), ast.NewCIStr("c_1")))
+
+	unsafePartialOnNonFKCol := newIndexForTest(4, c0, c1)
 	unsafePartialOnNonFKCol.ConditionExprString = "`c_2` is not null"
 	require.False(t, IsIndexPrefixCoveredForForeignKey(tbl, unsafePartialOnNonFKCol, ast.NewCIStr("c_0"), ast.NewCIStr("c_1")))
 
-	unsafePartialIsNull := newIndexForTest(4, c0)
+	unsafePartialIsNull := newIndexForTest(5, c0)
 	unsafePartialIsNull.ConditionExprString = "`c_0` is null"
 	require.False(t, IsIndexPrefixCoveredForForeignKey(tbl, unsafePartialIsNull, ast.NewCIStr("c_0")))
 
-	unsafePartialBinaryCondition := newIndexForTest(5, c0)
+	unsafePartialBinaryCondition := newIndexForTest(6, c0)
 	unsafePartialBinaryCondition.ConditionExprString = "`c_0` > 0"
 	require.False(t, IsIndexPrefixCoveredForForeignKey(tbl, unsafePartialBinaryCondition, ast.NewCIStr("c_0")))
 
-	badCondition := newIndexForTest(6, c0)
+	badCondition := newIndexForTest(7, c0)
 	badCondition.ConditionExprString = "`c_0` is"
 	require.False(t, IsIndexPrefixCoveredForForeignKey(tbl, badCondition, ast.NewCIStr("c_0")))
 

--- a/pkg/planner/core/operator/physicalop/foreign_key.go
+++ b/pkg/planner/core/operator/physicalop/foreign_key.go
@@ -489,7 +489,7 @@ func buildFKCheck(ctx base.PlanContext, tbl table.Table, cols []ast.CIStr, faile
 		}
 	}
 
-	referTbIdxInfo := model.FindIndexByColumns(tblInfo, tblInfo.Indices, cols...)
+	referTbIdxInfo := model.FindIndexByColumnsForForeignKey(tblInfo, tblInfo.Indices, cols...)
 	if referTbIdxInfo == nil {
 		return nil, failedErr
 	}
@@ -535,7 +535,7 @@ func buildFKCascade(ctx base.PlanContext, tp FKCascadeType, referredFK *model.Re
 			return fkCascade, nil
 		}
 	}
-	indexForFK := model.FindIndexByColumns(childTable.Meta(), childTable.Meta().Indices, fk.Cols...)
+	indexForFK := model.FindIndexByColumnsForForeignKey(childTable.Meta(), childTable.Meta().Indices, fk.Cols...)
 	if indexForFK == nil {
 		return nil, errors.Errorf("Missing index for '%s' foreign key columns in the table '%s'", fk.Name, childTable.Meta().Name)
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68587

Problem Summary:

Partial indexes could be incorrectly treated as valid supporting indexes for foreign key constraints. If the partial index predicate filters out rows that still participate in the foreign key relationship, foreign key checks and cascaded actions may miss those rows and leave
orphan child rows.

### What changed and how does it work?

This PR adds foreign-key-specific index matching logic.

A partial index is only considered valid for foreign key enforcement when its predicate cannot exclude rows that need foreign key checks. Currently, this means ordinary full indexes are accepted as before, while partial indexes are only accepted when the predicate is an `IS NOT
NULL` condition on one of the foreign key columns.

The new helper is used by:

- DDL foreign key validation and auto-index creation
- Drop-index checks for foreign key dependencies
- Planner foreign key check/cascade index selection
- BR ingest repair foreign key record cleanup

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

```bash
./tools/check/failpoint-go-test.sh pkg/meta/model -run '^TestIsIndexPrefixCovered$' -count=1
./tools/check/failpoint-go-test.sh pkg/executor/test/fktest -run '^(TestForeignKeyOnDeleteCascade|TestForeignKeyOnDeleteSetNull|TestForeignKeyOnUpdateCascade)$' -count=1
go test -run '^(TestCreateTableWithForeignKeyMetaInfo|TestAddForeignKey|TestAlterTableAddForeignKeyError)$' -tags=intest,deadlock -count=1 ./pkg/ddl/tests/fk
go test -run '^TestForeignKeyRecordManager$' -tags=intest,deadlock -count=1 ./br/pkg/restore/ingestrec
make lint
PATH=/tmp/tidb-tools:$PATH make bazel_prepare
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Foreign keys now accept conditional (filtered) indexes whose predicate is "IS NOT NULL" on the FK columns.

* **Bug Fixes**
  * Foreign-key index detection and dependency checks now correctly treat safe partial indexes, preventing incorrect index creation or drops and ensuring cascades/enforcement behave properly.

* **Tests**
  * Added extensive regression and unit tests covering foreign-key behavior with partial/filtered indexes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->