### PR TITLE
executor, table: fix UnionScan virtual generated columns

### DIFF
--- a/pkg/executor/union_scan.go
+++ b/pkg/executor/union_scan.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
-	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/table"
@@ -156,25 +155,6 @@ func (us *UnionScanExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		}
 		mutableRow.SetDatums(row...)
 
-		sctx := us.Ctx()
-		for _, idx := range us.virtualColumnIndex {
-			datum, err := us.Schema().Columns[idx].EvalVirtualColumn(sctx.GetExprCtx().GetEvalCtx(), mutableRow.ToRow())
-			if err != nil {
-				return err
-			}
-			// Because the expression might return different type from
-			// the generated column, we should wrap a CAST on the result.
-			castDatum, err := table.CastValue(us.Ctx(), datum, us.columns[idx], false, true)
-			if err != nil {
-				return err
-			}
-			// Handle the bad null error.
-			if (mysql.HasNotNullFlag(us.columns[idx].GetFlag()) || mysql.HasPreventNullInsertFlag(us.columns[idx].GetFlag())) && castDatum.IsNull() {
-				castDatum = table.GetZeroValue(us.columns[idx])
-			}
-			mutableRow.SetDatum(idx, castDatum)
-		}
-
 		matched, _, err := expression.EvalBool(us.Ctx().GetExprCtx().GetEvalCtx(), us.conditionsWithVirCol, mutableRow.ToRow())
 		if err != nil {
 			return err
@@ -216,6 +196,12 @@ func (us *UnionScanExec) getOneRow(ctx context.Context) ([]types.Datum, error) {
 	} else if snapshotRow == nil {
 		row = addedRow
 	} else {
+		if err := us.fillVirtualColumns(snapshotRow); err != nil {
+			return nil, err
+		}
+		if err := us.fillVirtualColumns(addedRow); err != nil {
+			return nil, err
+		}
 		isSnapshotRowInt, err := us.compare(us.Ctx().GetSessionVars().StmtCtx, snapshotRow, addedRow)
 		if err != nil {
 			return nil, err
@@ -229,6 +215,9 @@ func (us *UnionScanExec) getOneRow(ctx context.Context) ([]types.Datum, error) {
 	}
 	if row == nil {
 		return nil, nil
+	}
+	if err := us.fillVirtualColumns(row); err != nil {
+		return nil, err
 	}
 
 	if isSnapshotRow {
@@ -289,6 +278,28 @@ func (us *UnionScanExec) getAddedRow() ([]types.Datum, error) {
 		}
 	}
 	return us.cursor4AddRows, nil
+}
+
+func (us *UnionScanExec) fillVirtualColumns(row []types.Datum) error {
+	if len(us.virtualColumnIndex) == 0 {
+		return nil
+	}
+
+	mutableRow := chunk.MutRowFromTypes(exec.RetTypes(us))
+	mutableRow.SetDatums(row...)
+	for _, idx := range us.virtualColumnIndex {
+		datum, err := us.Schema().Columns[idx].EvalVirtualColumn(us.Ctx().GetExprCtx().GetEvalCtx(), mutableRow.ToRow())
+		if err != nil {
+			return err
+		}
+		castDatum, err := table.CastGeneratedColumnValue(us.Ctx().GetExprCtx(), datum, us.columns[idx], true)
+		if err != nil {
+			return err
+		}
+		row[idx] = castDatum
+		mutableRow.SetDatum(idx, castDatum)
+	}
+	return nil
 }
 
 type compareExec struct {

--- a/pkg/executor/union_scan_test.go
+++ b/pkg/executor/union_scan_test.go
@@ -170,6 +170,51 @@ func TestUnionScanForMemBufferReader(t *testing.T) {
 			tk.MustQuery("select * from t1 use index(idx);").Check(testkit.Rows("1 1 2", "2 2 2"))
 			tk.MustExec("commit")
 			tk.MustExec("admin check table t1;")
+
+			tk.MustExec("drop table if exists t_union_unsigned")
+			tk.MustExec(`create table t_union_unsigned (
+				a int,
+				g bigint unsigned generated always as (a - 10) virtual,
+				key idx_g(g)
+			)`)
+			tk.MustExec("begin")
+			tk.MustExec("insert ignore into t_union_unsigned(a) values (1)")
+			tk.MustQuery("select /* issue:67991 */ a, g from t_union_unsigned").Check(testkit.Rows("1 0"))
+			tk.MustQuery("select /* issue:67991 */ a, g from t_union_unsigned use index(idx_g)").Check(testkit.Rows("1 0"))
+			tk.MustExec("commit")
+			tk.MustQuery("select /* issue:67991 */ a, g from t_union_unsigned").Check(testkit.Rows("1 0"))
+			tk.MustExec("admin check table t_union_unsigned")
+
+			tk.MustExec("drop table if exists union_vgc_limit_bug")
+			tk.MustExec(`create table union_vgc_limit_bug (
+				id int primary key,
+				a int,
+				b int generated always as (a + 1) virtual,
+				key idx_b(b)
+			)`)
+			tk.MustExec("analyze table union_vgc_limit_bug")
+			tk.MustExec("insert into union_vgc_limit_bug(id, a) values (1, 1), (2, 4)")
+			tk.MustQuery(`select /* issue:68003 */ id, a, b
+				from union_vgc_limit_bug use index(idx_b)
+				where b >= 2
+				order by b, id
+				limit 1`).Check(testkit.Rows("1 1 2"))
+			tk.MustExec("begin")
+			tk.MustExec("insert into union_vgc_limit_bug(id, a) values (3, 2)")
+			query := `select /* issue:68003 */ id, a, b
+				from union_vgc_limit_bug use index(idx_b)
+				where b >= 2
+				order by b, id
+				limit 1`
+			tk.MustHavePlan(query, "IndexLookUp")
+			tk.MustHavePlan(query, "UnionScan")
+			tk.MustQuery(query).Check(testkit.Rows("1 1 2"))
+			tk.MustQuery(`select /* issue:68003 */ id, a, b
+				from union_vgc_limit_bug ignore index(idx_b)
+				where b >= 2
+				order by b, id
+				limit 1`).Check(testkit.Rows("1 1 2"))
+			tk.MustExec("rollback")
 		}
 
 		// Test update with 2 index, one untouched, the other index is touched.

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -346,6 +346,40 @@ func CastColumnValue(ctx expression.BuildContext, val types.Datum, col *model.Co
 	return castColumnValue(evalCtx.TypeCtx(), evalCtx.ErrCtx(), evalCtx.SQLMode(), val, &col.FieldType, col.Name.O, ctx.ConnectionID(), returnErr, forceIgnoreTruncate)
 }
 
+// CastGeneratedColumnValue casts a generated-column evaluation result using the
+// same clipping and null-handling rules as FillVirtualColumnValue.
+// It keeps CastColumnValue on the non-returnErr path so read-side materialization
+// continues to follow statement-context warning/ignore behavior.
+func CastGeneratedColumnValue(ctx exprctx.BuildContext, val types.Datum, col *model.ColumnInfo, forceIgnoreTruncate bool) (casted types.Datum, err error) {
+	casted, err = CastColumnValue(ctx, val, col, false, forceIgnoreTruncate)
+	if err != nil {
+		return casted, err
+	}
+
+	tc := ctx.GetEvalCtx().TypeCtx()
+	if mysql.HasUnsignedFlag(col.FieldType.GetFlag()) && !casted.IsNull() && tc.Flags().AllowNegativeToUnsigned() {
+		switch val.Kind() {
+		case types.KindInt64:
+			if val.GetInt64() < 0 {
+				casted = GetZeroValue(col)
+			}
+		case types.KindFloat32, types.KindFloat64:
+			if types.RoundFloat(val.GetFloat64()) < 0 {
+				casted = GetZeroValue(col)
+			}
+		case types.KindMysqlDecimal:
+			if val.GetMysqlDecimal().IsNegative() {
+				casted = GetZeroValue(col)
+			}
+		}
+	}
+
+	if (mysql.HasNotNullFlag(col.GetFlag()) || mysql.HasPreventNullInsertFlag(col.GetFlag())) && casted.IsNull() {
+		casted = GetZeroValue(col)
+	}
+	return casted, nil
+}
+
 // castColumnValue casts a value based on column type.
 func castColumnValue(tc types.Context, ec errctx.Context, sqlMode mysql.SQLMode, val types.Datum, ft *types.FieldType, colName string, connID uint64, returnErr, forceIgnoreTruncate bool) (casted types.Datum, err error) {
 	casted, err = val.ConvertTo(tc, ft)
@@ -776,41 +810,15 @@ func FillVirtualColumnValue(virtualRetTypes []*types.FieldType, virtualColumnInd
 	virCols := chunk.NewChunkWithCapacity(virtualRetTypes, req.Capacity())
 	iter := chunk.NewIterator4Chunk(req)
 	evalCtx := ectx.GetEvalCtx()
-	tc := evalCtx.TypeCtx()
 	for i, idx := range virtualColumnIndex {
 		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 			datum, err := expCols[idx].EvalVirtualColumn(evalCtx, row)
 			if err != nil {
 				return err
 			}
-			// Because the expression might return different type from
-			// the generated column, we should wrap a CAST on the result.
-			castDatum, err := CastColumnValue(ectx, datum, colInfos[idx], false, true)
+			castDatum, err := CastGeneratedColumnValue(ectx, datum, colInfos[idx], true)
 			if err != nil {
 				return err
-			}
-
-			// Clip to zero if get negative value after cast to unsigned.
-			if mysql.HasUnsignedFlag(colInfos[idx].FieldType.GetFlag()) && !castDatum.IsNull() && tc.Flags().AllowNegativeToUnsigned() {
-				switch datum.Kind() {
-				case types.KindInt64:
-					if datum.GetInt64() < 0 {
-						castDatum = GetZeroValue(colInfos[idx])
-					}
-				case types.KindFloat32, types.KindFloat64:
-					if types.RoundFloat(datum.GetFloat64()) < 0 {
-						castDatum = GetZeroValue(colInfos[idx])
-					}
-				case types.KindMysqlDecimal:
-					if datum.GetMysqlDecimal().IsNegative() {
-						castDatum = GetZeroValue(colInfos[idx])
-					}
-				}
-			}
-
-			// Handle the bad null error.
-			if (mysql.HasNotNullFlag(colInfos[idx].GetFlag()) || mysql.HasPreventNullInsertFlag(colInfos[idx].GetFlag())) && castDatum.IsNull() {
-				castDatum = GetZeroValue(colInfos[idx])
 			}
 			virCols.AppendDatum(i, &castDatum)
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67991, ref #68003

Problem Summary:

UnionScan still handles virtual generated columns inconsistently in transaction-local reads:

- `#67991`: generated unsigned values derived from negative intermediate results can differ before and after commit.
- `#68003`: UnionScan can compare snapshot and dirty rows before virtual generated columns are materialized, which breaks ordered `IndexLookUp + UnionScan + LIMIT` queries on virtual generated columns.

### What changed and how does it work?

- add `table.CastGeneratedColumnValue` so UnionScan reuses the same generated-column cast/clipping rules as `FillVirtualColumnValue`
- materialize UnionScan virtual generated columns before snapshot/dirty row comparison
- compute UnionScan virtual generated column indexes for `IndexReaderExecutor`
- add regression coverage for both issue shapes in `TestUnionScanForMemBufferReader`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test steps:

- `go test ./.tmp/issue67991 -run 'TestIssue67991CurrentMaster|TestIssue68003CurrentMaster' -count=1 -tags=intest,deadlock -v`
- `./tools/check/failpoint-go-test.sh pkg/executor -run TestUnionScanForMemBufferReader -count=1`
- `go test ./pkg/table -run TestCastValue -count=1 -tags=intest,deadlock`
- `git diff --check`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix incorrect UnionScan results on virtual generated columns in transaction-local reads.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved virtual generated column computation and casting to ensure correct behavior in transactions and indexed queries.

* **Tests**
  * Added regression tests for virtual generated column scenarios, including unsigned columns and indexed query operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->