### PR TITLE
expression: avoid pushing JSON_EXTRACT over runtime JSON casts

### DIFF
--- a/pkg/executor/test/issuetest/BUILD.bazel
+++ b/pkg/executor/test/issuetest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/autoid_service",
         "//pkg/config",

--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -793,3 +793,60 @@ func TestIssue60926(t *testing.T) {
 	tk.MustQuery("select * from t1 join (select col0, sum(col1) from t2 group by col0) as r on t1.col0 = r.col0;")
 	require.True(t, join.IsChildCloseCalledForTest.Load())
 }
+
+func TestIssue67614(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists t_json_filter_order")
+	tk.MustExec(`create table t_json_filter_order (
+		id bigint primary key auto_increment,
+		d date not null,
+		category varchar(64) not null,
+		payload varchar(2048) default null,
+		key idx_d (d)
+	)`)
+	tk.MustExec(`insert into t_json_filter_order (d, category, payload) values
+		('2026-03-29', 'OTHER', ''),
+		('2026-03-29', 'OTHER', 'not-json-{broken'),
+		('2026-03-29', 'TARGET', '{"k":"CHN","other":1}')`)
+
+	query1 := `select id from t_json_filter_order
+		where d = str_to_date('20260329', '%Y%m%d')
+		  and category = 'TARGET'
+		  and json_extract(payload, '$.k') = 'CHN'`
+	query2 := `select id from t_json_filter_order
+		where d = str_to_date('20260329', '%Y%m%d')
+		  and json_extract(payload, '$.k') = 'CHN'
+		  and category = 'TARGET'`
+
+	tk.MustQuery(query1).Check(testkit.Rows("3"))
+	tk.MustQuery(query2).Check(testkit.Rows("3"))
+
+	planRows := tk.MustQuery("explain format = 'brief' " + query2).Rows()
+	plan := fmt.Sprintf("%v", planRows)
+	require.NotContains(t, plan, "Selection cop[tikv]  eq(json_extract")
+	require.Contains(t, plan, "root  eq(json_extract(cast(test.t_json_filter_order.payload, json BINARY), \"$.k\")")
+
+	tk.MustExec("drop table if exists t_json_pushdown_control")
+	tk.MustExec(`create table t_json_pushdown_control (
+		id bigint primary key auto_increment,
+		d date not null,
+		category varchar(64) not null,
+		payload json,
+		key idx_d (d)
+	)`)
+	tk.MustExec(`insert into t_json_pushdown_control (d, category, payload) values
+		('2026-03-29', 'OTHER', '{}'),
+		('2026-03-29', 'TARGET', '{"k":"CHN","other":1}')`)
+
+	controlQuery := `select id from t_json_pushdown_control
+		where d = str_to_date('20260329', '%Y%m%d')
+		  and json_extract(payload, '$.k') = 'CHN'
+		  and category = 'TARGET'`
+	controlPlanRows := tk.MustQuery("explain format = 'brief' " + controlQuery).Rows()
+	controlPlan := fmt.Sprintf("%v", controlPlanRows)
+	require.Contains(t, controlPlan, "cop[tikv]")
+	require.Contains(t, controlPlan, "json_extract(test.t_json_pushdown_control.payload")
+}

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -126,6 +126,9 @@ func canScalarFuncPushDown(ctx PushDownContext, scalarFunc *ScalarFunction, stor
 		ctx.AppendWarning(warnErr)
 		return false
 	}
+	if shouldBlockTiKVJSONExtractPushDown(ctx.EvalCtx(), scalarFunc, storeType) {
+		return false
+	}
 	canEnumPush := canEnumPushdownPreliminarily(scalarFunc)
 	// Check whether all of its parameters can be pushed.
 	for _, arg := range scalarFunc.GetArgs() {
@@ -143,6 +146,23 @@ func canScalarFuncPushDown(ctx PushDownContext, scalarFunc *ScalarFunction, stor
 		}
 	}
 	return true
+}
+
+func shouldBlockTiKVJSONExtractPushDown(ctx EvalContext, scalarFunc *ScalarFunction, storeType kv.StoreType) bool {
+	if storeType != kv.TiKV || scalarFunc.FuncName.L != ast.JSONExtract {
+		return false
+	}
+	if len(scalarFunc.GetArgs()) == 0 {
+		return false
+	}
+	castArg, ok := scalarFunc.GetArgs()[0].(*ScalarFunction)
+	if !ok || castArg.FuncName.L != ast.Cast {
+		return false
+	}
+	if castArg.RetType.GetType() != mysql.TypeJSON || len(castArg.GetArgs()) == 0 {
+		return false
+	}
+	return castArg.GetArgs()[0].GetType(ctx).GetType() != mysql.TypeJSON
 }
 
 func canExprPushDown(ctx PushDownContext, expr Expression, storeType kv.StoreType, canEnumPush bool) bool {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67614

Problem Summary:

`JSON_EXTRACT(payload, '$.k')` can be pushed to TiKV even when `payload` is a runtime `varchar -> JSON` cast. In that shape, predicate order changes whether invalid JSON rows are filtered out before TiKV evaluates the pushed expression, so the same query can either return the expected row or fail with `Invalid JSON text`.

### What changed and how does it work?

- block TiKV pushdown for `JSON_EXTRACT` only when its first argument is a runtime `CAST(... AS JSON)` from a non-JSON source type
- keep normal pushdown for native JSON columns unchanged
- add issue coverage for both predicate orders
- add plan-boundary checks proving the runtime-cast case stays at root while the native JSON control still pushes to TiKV

### Check List

Tests

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JSON predicate pushdown in TiKV so filters on non-native JSON values (e.g., text-cast JSON) produce correct results and expected execution plans.

* **Tests**
  * Added a regression test that validates JSON filter behavior and explains to ensure consistent results across query variants.

* **Chores**
  * Adjusted test sharding configuration for the executor test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->