### PR TITLE
store/copr: balance TiCI shard tasks by store load  | tidb-test=feature/fts tiflash=feature/fts tikv=feature/fts

### DIFF
--- a/pkg/store/copr/BUILD.bazel
+++ b/pkg/store/copr/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "region_cache.go",
         "store.go",
         "tici_estimate_count.go",
+        "tici_shard_balance.go",
         "tici_shard_cache.go",
         "tici_sorted_shards.go",
     ],

--- a/pkg/store/copr/batch_coprocessor.go
+++ b/pkg/store/copr/batch_coprocessor.go
@@ -1800,18 +1800,7 @@ func buildBatchCopTasksForFullText(ctx context.Context, store *kvStore, tableID 
 		return nil, errors.New("No shard info found")
 	}
 
-	storeShard := make(map[string][]*coprocessor.ShardInfo)
-	for _, shard := range ret {
-		// Always use the first local cache address as the store address.
-		if _, ok := storeShard[shard.localCacheAddrs[0]]; !ok {
-			storeShard[shard.localCacheAddrs[0]] = make([]*coprocessor.ShardInfo, 0)
-		}
-		storeShard[shard.localCacheAddrs[0]] = append(storeShard[shard.localCacheAddrs[0]], &coprocessor.ShardInfo{
-			ShardId:    shard.ShardID,
-			ShardEpoch: shard.Epoch,
-			Ranges:     shard.Ranges.ToPBRanges(),
-		})
-	}
+	storeShard := buildTiCIShardInfosByAddrFromLocations(ret)
 
 	for addr, shardInfos := range storeShard {
 		tableShardInfos := []*coprocessor.TableShardInfos{}

--- a/pkg/store/copr/batch_coprocessor.go
+++ b/pkg/store/copr/batch_coprocessor.go
@@ -1800,7 +1800,10 @@ func buildBatchCopTasksForFullText(ctx context.Context, store *kvStore, tableID 
 		return nil, errors.New("No shard info found")
 	}
 
-	storeShard := buildTiCIShardInfosByAddrFromLocations(ret)
+	storeShard, err := buildTiCIShardInfosByAddrFromLocations(ret)
+	if err != nil {
+		return nil, err
+	}
 
 	for addr, shardInfos := range storeShard {
 		tableShardInfos := []*coprocessor.TableShardInfos{}

--- a/pkg/store/copr/batch_coprocessor_test.go
+++ b/pkg/store/copr/batch_coprocessor_test.go
@@ -469,7 +469,7 @@ func TestBuildTiCIShardInfosByStoreAddrContextPropagation(t *testing.T) {
 		require.Len(t, infoByAddr["addr-b"][0].ShardInfos, 2)
 	})
 
-	t.Run("keeps loc input order when later shard is constrained", func(t *testing.T) {
+	t.Run("count single-candidate shards before selecting multi-candidate shards", func(t *testing.T) {
 		client := &mppTiCIMockShardClient{
 			result: []*ShardWithAddr{
 				{
@@ -493,10 +493,11 @@ func TestBuildTiCIShardInfosByStoreAddrContextPropagation(t *testing.T) {
 
 		infoByAddr, err := buildTiCIShardInfosByStoreAddr(context.Background(), cache, req, tiflashcompute.DispatchPolicyConsistentHash, tiflash.AllReplicas)
 		require.NoError(t, err)
-		require.Len(t, infoByAddr, 1)
-		require.Len(t, infoByAddr["addr-a"][0].ShardInfos, 2)
-		require.EqualValues(t, 1, infoByAddr["addr-a"][0].ShardInfos[0].ShardId)
-		require.EqualValues(t, 2, infoByAddr["addr-a"][0].ShardInfos[1].ShardId)
+		require.Len(t, infoByAddr, 2)
+		require.Len(t, infoByAddr["addr-a"][0].ShardInfos, 1)
+		require.EqualValues(t, 2, infoByAddr["addr-a"][0].ShardInfos[0].ShardId)
+		require.Len(t, infoByAddr["addr-b"][0].ShardInfos, 1)
+		require.EqualValues(t, 1, infoByAddr["addr-b"][0].ShardInfos[0].ShardId)
 	})
 
 	t.Run("return error when shard has no local cache addr", func(t *testing.T) {

--- a/pkg/store/copr/batch_coprocessor_test.go
+++ b/pkg/store/copr/batch_coprocessor_test.go
@@ -400,6 +400,138 @@ func TestBuildTiCIShardInfosByStoreAddrContextPropagation(t *testing.T) {
 		require.Len(t, infos[0].ShardInfos, 1)
 		require.EqualValues(t, 4, infos[0].ShardInfos[0].ShardId)
 	})
+
+	t.Run("balance each loc against current candidate pressure", func(t *testing.T) {
+		client := &mppTiCIMockShardClient{
+			result: []*ShardWithAddr{
+				{
+					Shard:           Shard{ShardID: 1, Epoch: 2, StartKey: []byte("a"), EndKey: []byte("b")},
+					localCacheAddrs: []string{"addr-a", "addr-b", "addr-c"},
+				},
+				{
+					Shard:           Shard{ShardID: 2, Epoch: 2, StartKey: []byte("b"), EndKey: []byte("c")},
+					localCacheAddrs: []string{"addr-a", "addr-b"},
+				},
+			},
+		}
+		cache := NewTiCIShardCache(client)
+		req := &kv.MPPBuildTasksRequest{
+			TiCI:           true,
+			TiCITableID:    11,
+			TiCIIndexID:    22,
+			TiCIExecutorID: "executor-1",
+			TiCIKeyRanges:  []kv.KeyRange{{StartKey: []byte("a"), EndKey: []byte("c")}},
+		}
+
+		infoByAddr, err := buildTiCIShardInfosByStoreAddr(context.Background(), cache, req, tiflashcompute.DispatchPolicyConsistentHash, tiflash.AllReplicas)
+		require.NoError(t, err)
+		require.Len(t, infoByAddr, 2)
+		require.Len(t, infoByAddr["addr-a"][0].ShardInfos, 1)
+		require.EqualValues(t, 1, infoByAddr["addr-a"][0].ShardInfos[0].ShardId)
+		require.Len(t, infoByAddr["addr-b"][0].ShardInfos, 1)
+		require.EqualValues(t, 2, infoByAddr["addr-b"][0].ShardInfos[0].ShardId)
+	})
+
+	t.Run("balance shards between candidate addrs", func(t *testing.T) {
+		client := &mppTiCIMockShardClient{
+			result: []*ShardWithAddr{
+				{
+					Shard:           Shard{ShardID: 1, Epoch: 2, StartKey: []byte("a"), EndKey: []byte("b")},
+					localCacheAddrs: []string{"addr-a", "addr-b"},
+				},
+				{
+					Shard:           Shard{ShardID: 2, Epoch: 2, StartKey: []byte("b"), EndKey: []byte("c")},
+					localCacheAddrs: []string{"addr-a", "addr-b"},
+				},
+				{
+					Shard:           Shard{ShardID: 3, Epoch: 2, StartKey: []byte("c"), EndKey: []byte("d")},
+					localCacheAddrs: []string{"addr-a", "addr-b"},
+				},
+				{
+					Shard:           Shard{ShardID: 4, Epoch: 2, StartKey: []byte("d"), EndKey: []byte("e")},
+					localCacheAddrs: []string{"addr-a", "addr-b"},
+				},
+			},
+		}
+		cache := NewTiCIShardCache(client)
+		req := &kv.MPPBuildTasksRequest{
+			TiCI:           true,
+			TiCITableID:    11,
+			TiCIIndexID:    22,
+			TiCIExecutorID: "executor-1",
+			TiCIKeyRanges:  []kv.KeyRange{{StartKey: []byte("a"), EndKey: []byte("e")}},
+		}
+
+		infoByAddr, err := buildTiCIShardInfosByStoreAddr(context.Background(), cache, req, tiflashcompute.DispatchPolicyConsistentHash, tiflash.AllReplicas)
+		require.NoError(t, err)
+		require.Len(t, infoByAddr, 2)
+		require.Len(t, infoByAddr["addr-a"][0].ShardInfos, 2)
+		require.Len(t, infoByAddr["addr-b"][0].ShardInfos, 2)
+	})
+
+	t.Run("keeps loc input order when later shard is constrained", func(t *testing.T) {
+		client := &mppTiCIMockShardClient{
+			result: []*ShardWithAddr{
+				{
+					Shard:           Shard{ShardID: 1, Epoch: 2, StartKey: []byte("a"), EndKey: []byte("b")},
+					localCacheAddrs: []string{"addr-a", "addr-b"},
+				},
+				{
+					Shard:           Shard{ShardID: 2, Epoch: 2, StartKey: []byte("b"), EndKey: []byte("c")},
+					localCacheAddrs: []string{"addr-a"},
+				},
+			},
+		}
+		cache := NewTiCIShardCache(client)
+		req := &kv.MPPBuildTasksRequest{
+			TiCI:           true,
+			TiCITableID:    11,
+			TiCIIndexID:    22,
+			TiCIExecutorID: "executor-1",
+			TiCIKeyRanges:  []kv.KeyRange{{StartKey: []byte("a"), EndKey: []byte("c")}},
+		}
+
+		infoByAddr, err := buildTiCIShardInfosByStoreAddr(context.Background(), cache, req, tiflashcompute.DispatchPolicyConsistentHash, tiflash.AllReplicas)
+		require.NoError(t, err)
+		require.Len(t, infoByAddr, 1)
+		require.Len(t, infoByAddr["addr-a"][0].ShardInfos, 2)
+		require.EqualValues(t, 1, infoByAddr["addr-a"][0].ShardInfos[0].ShardId)
+		require.EqualValues(t, 2, infoByAddr["addr-a"][0].ShardInfos[1].ShardId)
+	})
+
+}
+
+func TestBuildBatchCopTasksForFullTextBalancesShards(t *testing.T) {
+	client := &mppTiCIMockShardClient{
+		result: []*ShardWithAddr{
+			{
+				Shard:           Shard{ShardID: 1, Epoch: 2, StartKey: []byte("a"), EndKey: []byte("b")},
+				localCacheAddrs: []string{"addr-a", "addr-b"},
+			},
+			{
+				Shard:           Shard{ShardID: 2, Epoch: 2, StartKey: []byte("b"), EndKey: []byte("c")},
+				localCacheAddrs: []string{"addr-a", "addr-b"},
+			},
+			{
+				Shard:           Shard{ShardID: 3, Epoch: 2, StartKey: []byte("c"), EndKey: []byte("d")},
+				localCacheAddrs: []string{"addr-a", "addr-b"},
+			},
+			{
+				Shard:           Shard{ShardID: 4, Epoch: 2, StartKey: []byte("d"), EndKey: []byte("e")},
+				localCacheAddrs: []string{"addr-a", "addr-b"},
+			},
+		},
+	}
+	cache := NewTiCIShardCache(client)
+
+	tasks, err := buildBatchCopTasksForFullText(context.Background(), &kvStore{TiCIShardCache: cache}, 11, 22, "executor-1", NewKeyRanges([]kv.KeyRange{{StartKey: []byte("a"), EndKey: []byte("e")}}))
+	require.NoError(t, err)
+
+	shardCountByAddr := make(map[string]int)
+	for _, task := range tasks {
+		shardCountByAddr[task.storeAddr] += len(task.TableShardInfos[0].ShardInfos)
+	}
+	require.Equal(t, map[string]int{"addr-a": 2, "addr-b": 2}, shardCountByAddr)
 }
 
 func TestConstructMPPTasksTiCIUsesTiCIMPPTaskMeta(t *testing.T) {

--- a/pkg/store/copr/batch_coprocessor_test.go
+++ b/pkg/store/copr/batch_coprocessor_test.go
@@ -499,39 +499,38 @@ func TestBuildTiCIShardInfosByStoreAddrContextPropagation(t *testing.T) {
 		require.EqualValues(t, 2, infoByAddr["addr-a"][0].ShardInfos[1].ShardId)
 	})
 
-}
+	t.Run("balance full text shards between candidate addrs", func(t *testing.T) {
+		client := &mppTiCIMockShardClient{
+			result: []*ShardWithAddr{
+				{
+					Shard:           Shard{ShardID: 1, Epoch: 2, StartKey: []byte("a"), EndKey: []byte("b")},
+					localCacheAddrs: []string{"addr-a", "addr-b"},
+				},
+				{
+					Shard:           Shard{ShardID: 2, Epoch: 2, StartKey: []byte("b"), EndKey: []byte("c")},
+					localCacheAddrs: []string{"addr-a", "addr-b"},
+				},
+				{
+					Shard:           Shard{ShardID: 3, Epoch: 2, StartKey: []byte("c"), EndKey: []byte("d")},
+					localCacheAddrs: []string{"addr-a", "addr-b"},
+				},
+				{
+					Shard:           Shard{ShardID: 4, Epoch: 2, StartKey: []byte("d"), EndKey: []byte("e")},
+					localCacheAddrs: []string{"addr-a", "addr-b"},
+				},
+			},
+		}
+		cache := NewTiCIShardCache(client)
 
-func TestBuildBatchCopTasksForFullTextBalancesShards(t *testing.T) {
-	client := &mppTiCIMockShardClient{
-		result: []*ShardWithAddr{
-			{
-				Shard:           Shard{ShardID: 1, Epoch: 2, StartKey: []byte("a"), EndKey: []byte("b")},
-				localCacheAddrs: []string{"addr-a", "addr-b"},
-			},
-			{
-				Shard:           Shard{ShardID: 2, Epoch: 2, StartKey: []byte("b"), EndKey: []byte("c")},
-				localCacheAddrs: []string{"addr-a", "addr-b"},
-			},
-			{
-				Shard:           Shard{ShardID: 3, Epoch: 2, StartKey: []byte("c"), EndKey: []byte("d")},
-				localCacheAddrs: []string{"addr-a", "addr-b"},
-			},
-			{
-				Shard:           Shard{ShardID: 4, Epoch: 2, StartKey: []byte("d"), EndKey: []byte("e")},
-				localCacheAddrs: []string{"addr-a", "addr-b"},
-			},
-		},
-	}
-	cache := NewTiCIShardCache(client)
+		tasks, err := buildBatchCopTasksForFullText(context.Background(), &kvStore{TiCIShardCache: cache}, 11, 22, "executor-1", NewKeyRanges([]kv.KeyRange{{StartKey: []byte("a"), EndKey: []byte("e")}}))
+		require.NoError(t, err)
 
-	tasks, err := buildBatchCopTasksForFullText(context.Background(), &kvStore{TiCIShardCache: cache}, 11, 22, "executor-1", NewKeyRanges([]kv.KeyRange{{StartKey: []byte("a"), EndKey: []byte("e")}}))
-	require.NoError(t, err)
-
-	shardCountByAddr := make(map[string]int)
-	for _, task := range tasks {
-		shardCountByAddr[task.storeAddr] += len(task.TableShardInfos[0].ShardInfos)
-	}
-	require.Equal(t, map[string]int{"addr-a": 2, "addr-b": 2}, shardCountByAddr)
+		shardCountByAddr := make(map[string]int)
+		for _, task := range tasks {
+			shardCountByAddr[task.storeAddr] += len(task.TableShardInfos[0].ShardInfos)
+		}
+		require.Equal(t, map[string]int{"addr-a": 2, "addr-b": 2}, shardCountByAddr)
+	})
 }
 
 func TestConstructMPPTasksTiCIUsesTiCIMPPTaskMeta(t *testing.T) {

--- a/pkg/store/copr/batch_coprocessor_test.go
+++ b/pkg/store/copr/batch_coprocessor_test.go
@@ -499,6 +499,40 @@ func TestBuildTiCIShardInfosByStoreAddrContextPropagation(t *testing.T) {
 		require.EqualValues(t, 2, infoByAddr["addr-a"][0].ShardInfos[1].ShardId)
 	})
 
+	t.Run("return error when shard has no local cache addr", func(t *testing.T) {
+		client := &mppTiCIMockShardClient{
+			result: []*ShardWithAddr{
+				{
+					Shard:           Shard{ShardID: 1, Epoch: 2, StartKey: []byte("a"), EndKey: []byte("b")},
+					localCacheAddrs: nil,
+				},
+			},
+		}
+		cache := NewTiCIShardCache(client)
+		req := &kv.MPPBuildTasksRequest{
+			TiCI:           true,
+			TiCITableID:    11,
+			TiCIIndexID:    22,
+			TiCIExecutorID: "executor-1",
+			TiCIKeyRanges:  []kv.KeyRange{{StartKey: []byte("a"), EndKey: []byte("b")}},
+		}
+
+		_, err := buildTiCIShardInfosByStoreAddr(context.Background(), cache, req, tiflashcompute.DispatchPolicyConsistentHash, tiflash.AllReplicas)
+		require.ErrorContains(t, err, "tici shard 1 has no local cache address")
+	})
+
+	t.Run("return error when shard has nil ranges", func(t *testing.T) {
+		_, err := buildTiCIShardInfosByAddrFromLocations([]*ShardLocation{
+			{
+				ShardWithAddr: &ShardWithAddr{
+					Shard:           Shard{ShardID: 1, Epoch: 2, StartKey: []byte("a"), EndKey: []byte("b")},
+					localCacheAddrs: []string{"addr-a"},
+				},
+			},
+		})
+		require.ErrorContains(t, err, "tici shard 1 has nil ranges")
+	})
+
 	t.Run("balance full text shards between candidate addrs", func(t *testing.T) {
 		client := &mppTiCIMockShardClient{
 			result: []*ShardWithAddr{

--- a/pkg/store/copr/batch_coprocessor_test.go
+++ b/pkg/store/copr/batch_coprocessor_test.go
@@ -367,7 +367,7 @@ func TestBuildTiCIShardInfosByStoreAddrContextPropagation(t *testing.T) {
 		require.ErrorIs(t, client.lastCtxErr, context.Canceled)
 	})
 
-	t.Run("prefer first local cache addr", func(t *testing.T) {
+	t.Run("select a local cache addr", func(t *testing.T) {
 		client := &mppTiCIMockShardClient{
 			result: []*ShardWithAddr{
 				{
@@ -394,7 +394,12 @@ func TestBuildTiCIShardInfosByStoreAddrContextPropagation(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, client.scanCalled)
 		require.Len(t, infoByAddr, 1)
-		infos := infoByAddr["addr-a"]
+		var selectedAddr string
+		for addr := range infoByAddr {
+			selectedAddr = addr
+		}
+		require.Contains(t, []string{"addr-a", "addr-b"}, selectedAddr)
+		infos := infoByAddr[selectedAddr]
 		require.Len(t, infos, 1)
 		require.Equal(t, "executor-1", infos[0].ExecutorId)
 		require.Len(t, infos[0].ShardInfos, 1)
@@ -426,10 +431,20 @@ func TestBuildTiCIShardInfosByStoreAddrContextPropagation(t *testing.T) {
 		infoByAddr, err := buildTiCIShardInfosByStoreAddr(context.Background(), cache, req, tiflashcompute.DispatchPolicyConsistentHash, tiflash.AllReplicas)
 		require.NoError(t, err)
 		require.Len(t, infoByAddr, 2)
-		require.Len(t, infoByAddr["addr-a"][0].ShardInfos, 1)
-		require.EqualValues(t, 1, infoByAddr["addr-a"][0].ShardInfos[0].ShardId)
-		require.Len(t, infoByAddr["addr-b"][0].ShardInfos, 1)
-		require.EqualValues(t, 2, infoByAddr["addr-b"][0].ShardInfos[0].ShardId)
+		var shard1Addr, shard2Addr string
+		for addr, infos := range infoByAddr {
+			require.Len(t, infos, 1)
+			require.Len(t, infos[0].ShardInfos, 1)
+			shardID := infos[0].ShardInfos[0].ShardId
+			require.True(t, shardID == 1 || shardID == 2)
+			if shardID == 1 {
+				shard1Addr = addr
+			} else {
+				shard2Addr = addr
+			}
+		}
+		require.Contains(t, []string{"addr-a", "addr-b", "addr-c"}, shard1Addr)
+		require.Contains(t, []string{"addr-a", "addr-b"}, shard2Addr)
 	})
 
 	t.Run("balance shards between candidate addrs", func(t *testing.T) {
@@ -607,7 +622,7 @@ func TestConstructMPPTasksTiCIUsesTiCIMPPTaskMeta(t *testing.T) {
 		require.True(t, isTiCIMeta)
 		_, isBatchCopMeta := metas[0].(*batchCopTask)
 		require.False(t, isBatchCopMeta)
-		require.Equal(t, "addr-a", metas[0].GetAddress())
+		require.Contains(t, []string{"addr-a", "addr-b"}, metas[0].GetAddress())
 	})
 
 	t.Run("retry-transient-build-error", func(t *testing.T) {

--- a/pkg/store/copr/mpp.go
+++ b/pkg/store/copr/mpp.go
@@ -124,24 +124,6 @@ func shouldRetryTiCIDispatch(meta kv.MPPTaskMeta, errMsg string) bool {
 	}
 }
 
-func selectTiCIShardAddr(addrs []string, shardID uint64, dispatchPolicy tiflashcompute.DispatchPolicy, tiflashReplicaReadPolicy tiflash.ReplicaRead) string {
-	if len(addrs) == 0 {
-		return ""
-	}
-	if len(addrs) == 1 {
-		return addrs[0]
-	}
-	// For TiCI MPP, MetaService already returns shard-local candidates in preferred order.
-	// Keep using the first one to avoid dispatching to a candidate whose local cache/worker
-	// is not ready yet (e.g. GetShardLocalCacheInfo failed: 13/14).
-	//
-	// Keep parameters for call-site compatibility.
-	_ = shardID
-	_ = dispatchPolicy
-	_ = tiflashReplicaReadPolicy
-	return addrs[0]
-}
-
 func buildTiCIShardInfosByStoreAddr(ctx context.Context, cache *TiCIShardCache, req *kv.MPPBuildTasksRequest, dispatchPolicy tiflashcompute.DispatchPolicy, tiflashReplicaReadPolicy tiflash.ReplicaRead) (map[string][]*coprocessor.TableShardInfos, error) {
 	if cache == nil {
 		return nil, errors.New("tici shard cache client is not initialized")
@@ -159,7 +141,7 @@ func buildTiCIShardInfosByStoreAddr(ctx context.Context, cache *TiCIShardCache, 
 		}
 	}
 
-	storeShard := make(map[string][]*coprocessor.ShardInfo)
+	shardLocations := make([]*ShardLocation, 0)
 	for _, partitionIDAndRange := range ticiPartitionIDAndRanges {
 		if len(partitionIDAndRange.KeyRanges) == 0 {
 			continue
@@ -168,25 +150,9 @@ func buildTiCIShardInfosByStoreAddr(ctx context.Context, cache *TiCIShardCache, 
 		if err != nil {
 			return nil, err
 		}
-		for _, loc := range locs {
-			addrs := loc.localCacheAddrs
-			if len(addrs) == 0 {
-				continue
-			}
-			if loc.Ranges == nil {
-				continue
-			}
-			addr := selectTiCIShardAddr(addrs, loc.ShardID, dispatchPolicy, tiflashReplicaReadPolicy)
-			if len(addr) == 0 {
-				continue
-			}
-			storeShard[addr] = append(storeShard[addr], &coprocessor.ShardInfo{
-				ShardId:    loc.ShardID,
-				ShardEpoch: loc.Epoch,
-				Ranges:     loc.Ranges.ToPBRanges(),
-			})
-		}
+		shardLocations = append(shardLocations, locs...)
 	}
+	storeShard := buildTiCIShardInfosByAddrFromLocations(shardLocations)
 	if len(storeShard) == 0 {
 		return nil, errors.New("No shard info found")
 	}

--- a/pkg/store/copr/mpp.go
+++ b/pkg/store/copr/mpp.go
@@ -152,7 +152,10 @@ func buildTiCIShardInfosByStoreAddr(ctx context.Context, cache *TiCIShardCache, 
 		}
 		shardLocations = append(shardLocations, locs...)
 	}
-	storeShard := buildTiCIShardInfosByAddrFromLocations(shardLocations)
+	storeShard, err := buildTiCIShardInfosByAddrFromLocations(shardLocations)
+	if err != nil {
+		return nil, err
+	}
 	if len(storeShard) == 0 {
 		return nil, errors.New("No shard info found")
 	}

--- a/pkg/store/copr/tici_shard_balance.go
+++ b/pkg/store/copr/tici_shard_balance.go
@@ -30,9 +30,6 @@ func buildTiCIShardInfosByAddrFromLocations(locs []*ShardLocation) (map[string][
 			return nil, errors.Errorf("tici shard %d has nil ranges", loc.ShardID)
 		}
 		addr := selectTiCIShardAddr(loc.localCacheAddrs, addrLoad)
-		if addr == "" {
-			continue
-		}
 		storeShard[addr] = append(storeShard[addr], &coprocessor.ShardInfo{
 			ShardId:    loc.ShardID,
 			ShardEpoch: loc.Epoch,
@@ -43,17 +40,15 @@ func buildTiCIShardInfosByAddrFromLocations(locs []*ShardLocation) (map[string][
 }
 
 func selectTiCIShardAddr(addrs []string, addrLoad map[string]int) string {
-	var selected string
-	selectedLoad := 0
-	for _, addr := range addrs {
+	selected := addrs[0]
+	selectedLoad := addrLoad[selected]
+	for _, addr := range addrs[1:] {
 		load := addrLoad[addr]
-		if selected == "" || load < selectedLoad {
+		if load < selectedLoad {
 			selected = addr
 			selectedLoad = load
 		}
 	}
-	if selected != "" {
-		addrLoad[selected]++
-	}
+	addrLoad[selected]++
 	return selected
 }

--- a/pkg/store/copr/tici_shard_balance.go
+++ b/pkg/store/copr/tici_shard_balance.go
@@ -19,6 +19,9 @@ import (
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 )
 
+// buildTiCIShardInfosByAddrFromLocations assigns shards in loc order. Each shard
+// chooses the candidate store with the lowest current shard count; ties keep the
+// candidate order returned by TiCI.
 func buildTiCIShardInfosByAddrFromLocations(locs []*ShardLocation) (map[string][]*coprocessor.ShardInfo, error) {
 	storeShard := make(map[string][]*coprocessor.ShardInfo)
 	addrLoad := make(map[string]int)

--- a/pkg/store/copr/tici_shard_balance.go
+++ b/pkg/store/copr/tici_shard_balance.go
@@ -1,0 +1,53 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package copr
+
+import "github.com/pingcap/kvproto/pkg/coprocessor"
+
+func buildTiCIShardInfosByAddrFromLocations(locs []*ShardLocation) map[string][]*coprocessor.ShardInfo {
+	storeShard := make(map[string][]*coprocessor.ShardInfo)
+	addrLoad := make(map[string]int)
+	for _, loc := range locs {
+		if len(loc.localCacheAddrs) == 0 || loc.Ranges == nil {
+			continue
+		}
+		addr := selectTiCIShardAddr(loc.localCacheAddrs, addrLoad)
+		if addr == "" {
+			continue
+		}
+		storeShard[addr] = append(storeShard[addr], &coprocessor.ShardInfo{
+			ShardId:    loc.ShardID,
+			ShardEpoch: loc.Epoch,
+			Ranges:     loc.Ranges.ToPBRanges(),
+		})
+	}
+	return storeShard
+}
+
+func selectTiCIShardAddr(addrs []string, addrLoad map[string]int) string {
+	var selected string
+	selectedLoad := 0
+	for _, addr := range addrs {
+		load := addrLoad[addr]
+		if selected == "" || load < selectedLoad {
+			selected = addr
+			selectedLoad = load
+		}
+	}
+	if selected != "" {
+		addrLoad[selected]++
+	}
+	return selected
+}

--- a/pkg/store/copr/tici_shard_balance.go
+++ b/pkg/store/copr/tici_shard_balance.go
@@ -14,14 +14,20 @@
 
 package copr
 
-import "github.com/pingcap/kvproto/pkg/coprocessor"
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/coprocessor"
+)
 
-func buildTiCIShardInfosByAddrFromLocations(locs []*ShardLocation) map[string][]*coprocessor.ShardInfo {
+func buildTiCIShardInfosByAddrFromLocations(locs []*ShardLocation) (map[string][]*coprocessor.ShardInfo, error) {
 	storeShard := make(map[string][]*coprocessor.ShardInfo)
 	addrLoad := make(map[string]int)
 	for _, loc := range locs {
-		if len(loc.localCacheAddrs) == 0 || loc.Ranges == nil {
-			continue
+		if len(loc.localCacheAddrs) == 0 {
+			return nil, errors.Errorf("tici shard %d has no local cache address", loc.ShardID)
+		}
+		if loc.Ranges == nil {
+			return nil, errors.Errorf("tici shard %d has nil ranges", loc.ShardID)
 		}
 		addr := selectTiCIShardAddr(loc.localCacheAddrs, addrLoad)
 		if addr == "" {
@@ -33,7 +39,7 @@ func buildTiCIShardInfosByAddrFromLocations(locs []*ShardLocation) map[string][]
 			Ranges:     loc.Ranges.ToPBRanges(),
 		})
 	}
-	return storeShard
+	return storeShard, nil
 }
 
 func selectTiCIShardAddr(addrs []string, addrLoad map[string]int) string {

--- a/pkg/store/copr/tici_shard_balance.go
+++ b/pkg/store/copr/tici_shard_balance.go
@@ -19,11 +19,10 @@ import (
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 )
 
-// buildTiCIShardInfosByAddrFromLocations assigns shards in loc order. Each shard
-// chooses the candidate store with the lowest current shard count; ties keep the
-// candidate order returned by TiCI.
+// buildTiCIShardInfosByAddrFromLocations pre-counts single-candidate shards as
+// fixed load, then assigns shards in loc order. Multi-candidate shards choose the
+// candidate store with the lowest current load; ties keep TiCI's candidate order.
 func buildTiCIShardInfosByAddrFromLocations(locs []*ShardLocation) (map[string][]*coprocessor.ShardInfo, error) {
-	storeShard := make(map[string][]*coprocessor.ShardInfo)
 	addrLoad := make(map[string]int)
 	for _, loc := range locs {
 		if len(loc.localCacheAddrs) == 0 {
@@ -32,6 +31,13 @@ func buildTiCIShardInfosByAddrFromLocations(locs []*ShardLocation) (map[string][
 		if loc.Ranges == nil {
 			return nil, errors.Errorf("tici shard %d has nil ranges", loc.ShardID)
 		}
+		if len(loc.localCacheAddrs) == 1 {
+			addrLoad[loc.localCacheAddrs[0]]++
+		}
+	}
+
+	storeShard := make(map[string][]*coprocessor.ShardInfo)
+	for _, loc := range locs {
 		addr := selectTiCIShardAddr(loc.localCacheAddrs, addrLoad)
 		storeShard[addr] = append(storeShard[addr], &coprocessor.ShardInfo{
 			ShardId:    loc.ShardID,
@@ -43,6 +49,9 @@ func buildTiCIShardInfosByAddrFromLocations(locs []*ShardLocation) (map[string][
 }
 
 func selectTiCIShardAddr(addrs []string, addrLoad map[string]int) string {
+	if len(addrs) == 1 {
+		return addrs[0]
+	}
 	selected := addrs[0]
 	selectedLoad := addrLoad[selected]
 	for _, addr := range addrs[1:] {

--- a/pkg/store/copr/tici_shard_balance.go
+++ b/pkg/store/copr/tici_shard_balance.go
@@ -15,13 +15,15 @@
 package copr
 
 import (
+	"math/rand"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 )
 
 // buildTiCIShardInfosByAddrFromLocations pre-counts single-candidate shards as
 // fixed load, then assigns shards in loc order. Multi-candidate shards choose the
-// candidate store with the lowest current load; ties keep TiCI's candidate order.
+// candidate store with the lowest current load from a random scan start.
 func buildTiCIShardInfosByAddrFromLocations(locs []*ShardLocation) (map[string][]*coprocessor.ShardInfo, error) {
 	addrLoad := make(map[string]int)
 	for _, loc := range locs {
@@ -52,9 +54,18 @@ func selectTiCIShardAddr(addrs []string, addrLoad map[string]int) string {
 	if len(addrs) == 1 {
 		return addrs[0]
 	}
-	selected := addrs[0]
+
+	start_idx := rand.Intn(len(addrs))
+	selected := addrs[start_idx]
 	selectedLoad := addrLoad[selected]
-	for _, addr := range addrs[1:] {
+	for _, addr := range addrs[start_idx:] {
+		load := addrLoad[addr]
+		if load < selectedLoad {
+			selected = addr
+			selectedLoad = load
+		}
+	}
+	for _, addr := range addrs[:start_idx] {
 		load := addrLoad[addr]
 		if load < selectedLoad {
 			selected = addr

--- a/pkg/store/copr/tici_shard_balance.go
+++ b/pkg/store/copr/tici_shard_balance.go
@@ -55,17 +55,17 @@ func selectTiCIShardAddr(addrs []string, addrLoad map[string]int) string {
 		return addrs[0]
 	}
 
-	start_idx := rand.Intn(len(addrs))
-	selected := addrs[start_idx]
+	startIdx := rand.Intn(len(addrs))
+	selected := addrs[startIdx]
 	selectedLoad := addrLoad[selected]
-	for _, addr := range addrs[start_idx:] {
+	for _, addr := range addrs[startIdx:] {
 		load := addrLoad[addr]
 		if load < selectedLoad {
 			selected = addr
 			selectedLoad = load
 		}
 	}
-	for _, addr := range addrs[:start_idx] {
+	for _, addr := range addrs[:startIdx] {
 		load := addrLoad[addr]
 		if load < selectedLoad {
 			selected = addr


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary:

TiCI shard task building always used the first local cache address for each shard. When shards have replicas on multiple TiFlash stores, this can concentrate shard tasks on the same store instead of balancing them across available candidates.

### What changed and how does it work?

This PR adds a shared TiCI shard assignment helper for MPP and full text batch cop tasks.

For each shard location, the helper checks the shard's local cache candidate stores and selects the store with the lowest current assigned shard count. If multiple candidates have the same load, it keeps the candidate order returned by the shard location.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Balance TiCI shard tasks across available local cache replicas.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved shard routing and task grouping to balance load across stores and unify task assembly for query and MPP execution.
* **Bug Fixes**
  * Added validation and immediate error reporting when shard location or range information is missing or invalid.
* **Tests**
  * Expanded tests for shard-to-address balancing, ordering, error cases, and full-text batch task distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->