### PR TITLE
importinto: revert S3-like auth requirement for nextgen import (#68234)

### DIFF
--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -164,21 +164,6 @@ func TestNextGenS3ExternalID(t *testing.T) {
 		}
 	})
 
-	t.Run("SEM enabled, require explicit auth for S3 like store", func(t *testing.T) {
-		for i, fns := range semTestPatternFns {
-			t.Run(fmt.Sprint(i), func(t *testing.T) {
-				tk := testkit.NewTestKit(t, store)
-				fns[0](t, tk)
-				t.Cleanup(func() {
-					fns[1](t, tk)
-				})
-				for _, schema := range []string{"s3", "oss"} {
-					tk.MustMatchErrMsg(fmt.Sprintf("IMPORT INTO test.t FROM '%s://bucket'", schema), `(?i).*Feature 'IMPORT INTO .*without access key/secret access key or role ARN' is not supported when security enhanced mode is enabled`)
-				}
-			})
-		}
-	})
-
 	t.Run("SEM enabled, set external ID to keyspace name", func(t *testing.T) {
 		bak := config.GetGlobalKeyspaceName()
 		config.UpdateGlobal(func(conf *config.Config) {
@@ -204,7 +189,7 @@ func TestNextGenS3ExternalID(t *testing.T) {
 					panic("FAIL IT, AS WE CANNOT RUN IT HERE")
 				})
 				for _, schema := range []string{"s3", "oss"} {
-					err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM '%s://bucket?access-key=ak&secret-access-key=sk'", schema))
+					err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM '%s://bucket'", schema))
 					require.ErrorContains(t, err, "FAIL IT, AS WE CANNOT RUN IT HERE")
 				}
 			})
@@ -266,7 +251,7 @@ func testNextGenUnsupportedLocalSortAndOptions(t *testing.T, store kv.Storage, i
 	t.Run("local sort", func(t *testing.T) {
 		tk := testkit.NewTestKit(t, store)
 		initFn(t, tk)
-		err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket/*.csv?access-key=ak&secret-access-key=sk'")
+		err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket/*.csv'")
 		require.ErrorIs(t, err, plannererrors.ErrNotSupportedWithSem)
 		require.ErrorContains(t, err, "IMPORT INTO with local sort")
 	})
@@ -294,7 +279,7 @@ func testNextGenUnsupportedLocalSortAndOptions(t *testing.T, store kv.Storage, i
 			"checksum_table",
 			"record_errors",
 		} {
-			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv?access-key=ak&secret-access-key=sk' with %s='1'", option))
+			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv' with %s='1'", option))
 			require.ErrorIs(t, err, exeerrors.ErrLoadDataUnsupportedOption)
 			require.ErrorContains(t, err, option)
 		}
@@ -302,7 +287,7 @@ func testNextGenUnsupportedLocalSortAndOptions(t *testing.T, store kv.Storage, i
 			"__force_merge_step",
 			"__manual_recovery",
 		} {
-			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv?access-key=ak&secret-access-key=sk' with %s", option))
+			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv' with %s", option))
 			require.ErrorIs(t, err, exeerrors.ErrLoadDataUnsupportedOption)
 			require.ErrorContains(t, err, option)
 		}

--- a/pkg/objstore/parse.go
+++ b/pkg/objstore/parse.go
@@ -182,7 +182,7 @@ func ExtractQueryParameters(u *url.URL, options any) {
 			continue
 		}
 		param := params[0]
-		normalizedKey := NormalizeQueryParameterKey(key)
+		normalizedKey := strings.ToLower(strings.ReplaceAll(key, "_", "-"))
 		if f, ok := tagToField[normalizedKey]; ok {
 			field := o.Field(f.index)
 			switch f.kind {
@@ -200,12 +200,6 @@ func ExtractQueryParameters(u *url.URL, options any) {
 
 	// Clean up the URL finally.
 	u.RawQuery = ""
-}
-
-// NormalizeQueryParameterKey normalizes object storage URL query parameter keys
-// to match backend option tags.
-func NormalizeQueryParameterKey(key string) string {
-	return strings.ToLower(strings.ReplaceAll(key, "_", "-"))
 }
 
 // FormatBackendURL obtains the raw URL which can be used the reconstruct the

--- a/pkg/objstore/s3like/store.go
+++ b/pkg/objstore/s3like/store.go
@@ -45,12 +45,6 @@ import (
 var HardcodedChunkSize = 5 * 1024 * 1024
 
 const (
-	// S3AccessKey is the key for the access key used in S3 operations.
-	S3AccessKey = "access-key"
-	// S3SecretAccessKey is the key for the secret access key used in S3 operations.
-	S3SecretAccessKey = "secret-access-key"
-	// S3RoleARN is the key for the role ARN used in S3 operations.
-	S3RoleARN = "role-arn"
 	// S3ExternalID is the key for the external ID used in S3 operations.
 	S3ExternalID = "external-id"
 

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4665,9 +4665,15 @@ func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStm
 			return nil, exeerrors.ErrLoadDataInvalidURI.FastGenByArgs(ImportIntoDataSource, err.Error())
 		}
 		importFromServer = objstore.IsLocal(u)
+		// for SEM v2, they are checked by configured rules.
 		if semv1.IsEnabled() {
 			if importFromServer {
 				return nil, plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO from server disk")
+			}
+			if kerneltype.IsNextGen() && objstore.IsS3Like(u) {
+				if err := checkNextGenS3PathWithSem(u); err != nil {
+					return nil, err
+				}
 			}
 		}
 		// a nextgen cluster might be shared by multiple tenants, and they might
@@ -4675,9 +4681,6 @@ func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStm
 		// external ID can be used to restrict the access only to the current tenant.
 		// when SEM enabled, we need set it.
 		if kerneltype.IsNextGen() && sem.IsEnabled() && objstore.IsS3Like(u) {
-			if err := checkNextGenS3PathWithSem(u); err != nil {
-				return nil, err
-			}
 			values := u.Query()
 			values.Set(s3like.S3ExternalID, config.GetGlobalKeyspaceName())
 			u.RawQuery = values.Encode()
@@ -6316,29 +6319,15 @@ func checkAlterDDLJobOptValue(opt *AlterDDLJobOpt) error {
 	return nil
 }
 
-// For nextgen IMPORT INTO with SEM, require explicit S3 authentication and
-// disallow explicit S3 external ID. The keyspace name is used as the S3 external ID.
+// for nextgen import-into with SEM, we disallow user to set S3 external ID explicitly,
+// and we will use the keyspace name as the S3 external ID.
 func checkNextGenS3PathWithSem(u *url.URL) error {
 	values := u.Query()
-	hasAccessKey := false
-	hasSecretAccessKey := false
-	hasRoleARN := false
 	for k := range values {
-		normalizedK := objstore.NormalizeQueryParameterKey(k)
-		switch normalizedK {
-		case s3like.S3ExternalID:
+		lowerK := strings.ToLower(k)
+		if lowerK == s3like.S3ExternalID {
 			return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO with explicit external ID")
-		case s3like.S3AccessKey:
-			hasAccessKey = hasAccessKey || values.Get(k) != ""
-		case s3like.S3SecretAccessKey:
-			hasSecretAccessKey = hasSecretAccessKey || values.Get(k) != ""
-		case s3like.S3RoleARN:
-			hasRoleARN = hasRoleARN || values.Get(k) != ""
 		}
-	}
-
-	if !hasRoleARN && !(hasAccessKey && hasSecretAccessKey) {
-		return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO from S3-like storage without access key/secret access key or role ARN")
 	}
 
 	return nil

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -1132,10 +1132,9 @@ func TestGetMaxWriteSpeedFromExpression(t *testing.T) {
 
 func TestProcessNextGenS3Path(t *testing.T) {
 	for _, str := range []string{
-		"S3://bucket?External-id=abc&access-key=ak&secret-access-key=sk",
-		"s3://bucket?external_id=abc&access-key=ak&secret-access-key=sk",
-		"oss://bucket?External-id=abc&role-arn=arn",
-		"oSS://bucket?External-id=abc&access-key=ak&secret-access-key=sk",
+		"S3://bucket?External-id=abc",
+		"oss://bucket?External-id=abc",
+		"oSS://bucket?External-id=abc",
 	} {
 		u, err := url.Parse(str)
 		require.NoError(t, err)
@@ -1145,31 +1144,13 @@ func TestProcessNextGenS3Path(t *testing.T) {
 	}
 
 	for _, str := range []string{
-		"s3://bucket?access-key=ak&secret-access-key=sk",
-		"s3://bucket?access_key=ak&secret_access_key=sk",
-		"oss://bucket?role-arn=arn",
-		"oss://bucket?role_arn=arn",
-	} {
-		u, err := url.Parse(str)
-		require.NoError(t, err)
-		err = checkNextGenS3PathWithSem(u)
-		require.NoError(t, err)
-	}
-
-	for _, str := range []string{
 		"s3://bucket",
-		"s3://bucket?access-key=&secret-access-key=",
-		"s3://bucket?access-key=ak",
-		"s3://bucket?secret-access-key=sk",
-		"s3://bucket?profile=dev",
 		"oss://bucket",
-		"oss://bucket?role-arn=",
 	} {
 		u, err := url.Parse(str)
 		require.NoError(t, err)
 		err = checkNextGenS3PathWithSem(u)
-		require.ErrorIs(t, err, plannererrors.ErrNotSupportedWithSem)
-		require.ErrorContains(t, err, "IMPORT INTO from S3-like storage without access key/secret access key or role ARN")
+		require.NoError(t, err)
 	}
 }
 

--- a/pkg/util/sem/compat/BUILD.bazel
+++ b/pkg/util/sem/compat/BUILD.bazel
@@ -27,7 +27,6 @@ go_test(
     embed = [":compat"],
     flaky = True,
     deps = [
-        "//pkg/config/kerneltype",
         "//pkg/objstore/s3like",
         "//pkg/parser/auth",
         "//pkg/parser/mysql",

--- a/pkg/util/sem/compat/sem_integration_test.go
+++ b/pkg/util/sem/compat/sem_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/objstore/s3like"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
@@ -52,12 +51,6 @@ func TestRestrictedSQL(t *testing.T) {
 		tk.MustContainErrMsg("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=abc'", "is not supported when security enhanced mode is enabled")
 
 		require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "semuser", Hostname: "localhost"}, nil, nil, nil))
-		if kerneltype.IsNextGen() {
-			tk.MustContainErrMsg("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=allowed'", "IMPORT INTO with explicit external ID")
-			tk.MustQuery("select * from test.t").Check(testkit.Rows())
-			return
-		}
-
 		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/importer/NewImportPlan", func(plan *plannercore.ImportInto) {
 			u, err := url.Parse(plan.Path)
 			require.NoError(t, err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #68226

Problem Summary:

PR #68234 (CPPR of #68231) introduced stricter auth validation for S3-like `IMPORT INTO` paths in NextGen SEM. That behavior also requires corresponding DM control plane changes. On `release-nextgen-202603`, if we keep the TiDB-side change without the DM-side update, newly created DM tasks can break on this branch version.

### What changed and how does it work?

This PR temporarily reverts commit `77ac297d31b3eac9fe1a787aba52418fedaca470` (PR #68234):

- Reverts the NextGen SEM requirement that S3-like `IMPORT INTO` must provide explicit `access-key/secret-access-key` or `role-arn`.
- Restores previous behavior and related tests on this release branch.
- Keeps branch behavior compatible with the current DM control plane implementation until the corresponding DM-side change is ready.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit tests:

- `./tools/check/failpoint-go-test.sh pkg/planner/core -tags=intest,deadlock,nextgen -run TestProcessNextGenS3Path -count=1`
- `./tools/check/failpoint-go-test.sh pkg/executor -tags=intest,deadlock,nextgen -run TestNextGenS3ExternalID -count=1`
- `./tools/check/failpoint-go-test.sh pkg/util/sem/compat -tags=intest,deadlock,nextgen -run TestRestrictedSQL -count=1`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Temporarily revert NextGen SEM S3-like IMPORT INTO auth enforcement on release-nextgen-202603 until corresponding DM control plane changes are available.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * S3-like storage authentication now exclusively uses external ID approach; access key and secret access key parameters in S3 URLs are no longer supported during IMPORT INTO operations.

* **Tests**
  * Updated IMPORT INTO test coverage for S3 and OSS storage URIs to reflect new authentication requirements.

* **Chores**
  * Removed unused build dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->