### PR TITLE
store: batch analyze full sampling requests

### DIFF
--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -308,6 +308,12 @@ func (builder *RequestBuilder) SetAllowBatchCop(batchCop bool) *RequestBuilder {
 	return builder
 }
 
+// SetStoreBatchSize sets the store batch size for TiKV coprocessor requests.
+func (builder *RequestBuilder) SetStoreBatchSize(storeBatchSize int) *RequestBuilder {
+	builder.Request.StoreBatchSize = storeBatchSize
+	return builder
+}
+
 // SetPartitionIDAndRanges sets `PartitionIDAndRanges` property.
 func (builder *RequestBuilder) SetPartitionIDAndRanges(partitionIDAndRanges []kv.PartitionIDAndRanges) *RequestBuilder {
 	builder.PartitionIDAndRanges = partitionIDAndRanges

--- a/pkg/executor/analyze_col.go
+++ b/pkg/executor/analyze_col.go
@@ -117,6 +117,7 @@ func (e *AnalyzeColumnsExec) buildResp(ctx context.Context, ranges []*ranger.Ran
 		SetStartTS(startTS).
 		SetKeepOrder(true).
 		SetConcurrency(e.concurrency).
+		SetStoreBatchSize(e.ctx.GetSessionVars().StoreBatchSize).
 		SetMemTracker(e.memTracker).
 		SetResourceGroupName(e.ctx.GetSessionVars().StmtCtx.ResourceGroupName).
 		SetExplicitRequestSourceType(e.ctx.GetSessionVars().ExplicitRequestSourceType).

--- a/pkg/executor/analyze_col_sampling.go
+++ b/pkg/executor/analyze_col_sampling.go
@@ -222,6 +222,7 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 	for range totalLen {
 		rootRowCollector.Base().FMSketches = append(rootRowCollector.Base().FMSketches, statistics.NewFMSketch(statistics.MaxSketchSize))
 	}
+	buildSingletons := statistics.ShouldBuildSingletonSketches(e.analyzePB.ColReq.GetNdvRate())
 
 	sc := e.ctx.GetSessionVars().StmtCtx
 
@@ -304,6 +305,31 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 		return 0, nil, nil, nil, err
 	}
 
+	colLen := len(e.colsInfo)
+	estimateNDVs := make([]int64, totalLen)
+	// Each region's sketches were kept separate through the merge (see
+	// statistics.RegionSketchSummary); estimate the global singleton count from
+	// them rather than from a single unioned sketch.
+	regionSummaries := rootRowCollector.Base().RegionSketchSummaries
+	if buildSingletons && len(regionSummaries) > 0 {
+		sampleSize := totalSketchSampleSize(regionSummaries)
+		specialIdx := make(map[int]struct{}, len(indexesWithVirtualColOffsets))
+		for _, offset := range indexesWithVirtualColOffsets {
+			specialIdx[offset] = struct{}{}
+		}
+		for i := range totalLen {
+			// NOTE: Skip special indexes (virtual/prefix columns): their NDV comes from
+			// a dedicated TiKV pushdown, and their sampled sketches reflect
+			// undecoded/untruncated values that would mislead GEE.
+			if i >= colLen {
+				if _, ok := specialIdx[i-colLen]; ok {
+					continue
+				}
+			}
+			estimateNDVs[i] = estimateSamplingNDV(rootRowCollector, regionSummaries, i, sampleSize)
+		}
+	}
+
 	// Decode the data from sample collectors.
 	virtualColIdx := buildVirtualColumnIndex(e.schemaForVirtualColEval, e.colsInfo)
 	// Filling virtual columns is necessary here because these samples are used to build statistics for indexes that constructed by virtual columns.
@@ -335,7 +361,6 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 			return 0, nil, nil, nil, err
 		}
 	}
-	colLen := len(e.colsInfo)
 	// The order of the samples are broken when merging samples from sub-collectors.
 	// So now we need to sort the samples according to the handle in order to calculate correlation.
 	slices.SortFunc(rootRowCollector.Base().Samples, func(i, j *statistics.ReservoirRowSampleItem) int {
@@ -357,7 +382,7 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 	// Start workers to build stats.
 	for range samplingStatsConcurrency {
 		e.samplingBuilderWg.Run(func() {
-			e.subBuildWorker(ctx, buildResultChan, buildTaskChan, hists, topns, exitCh)
+			e.subBuildWorker(ctx, buildResultChan, buildTaskChan, hists, topns, estimateNDVs, exitCh)
 		})
 	}
 	// Generate tasks for building stats.
@@ -712,7 +737,7 @@ func drainPendingSamplingMergeTasks(taskCh <-chan []byte, memTracker *memory.Tra
 	}
 }
 
-func (e *AnalyzeColumnsExec) subBuildWorker(ctx context.Context, resultCh chan error, taskCh chan *samplingBuildTask, hists []*statistics.Histogram, topns []*statistics.TopN, exitCh chan struct{}) {
+func (e *AnalyzeColumnsExec) subBuildWorker(ctx context.Context, resultCh chan error, taskCh chan *samplingBuildTask, hists []*statistics.Histogram, topns []*statistics.TopN, estimateNDVs []int64, exitCh chan struct{}) {
 	defer func() {
 		if r := recover(); r != nil {
 			logutil.BgLogger().Warn("analyze subBuildWorker panicked", zap.Any("recover", r), zap.Stack("stack"))
@@ -886,6 +911,11 @@ workLoop:
 				releaseCollectorMemory()
 				continue
 			}
+			// GEE corrects the FM sketch's undercount under subsampling; 0 means no
+			// estimate was produced, so only adjust upward.
+			if estimateNDVs[task.slicePos] > hist.NDV {
+				hist.NDV = estimateNDVs[task.slicePos]
+			}
 			finalMemSize := hist.MemoryUsage() + topn.MemoryUsage()
 			e.memTracker.Consume(finalMemSize)
 			hists[task.slicePos] = hist
@@ -917,6 +947,55 @@ type samplingBuildTask struct {
 	tp               *types.FieldType
 	isColumn         bool
 	slicePos         int
+}
+
+// totalSketchSampleSize returns the total number of rows across all regions that
+// contributed to the singleton sketches. This is the denominator the GEE
+// estimator expects.
+func totalSketchSampleSize(regions []statistics.RegionSketchSummary) uint64 {
+	var sampleSize uint64
+	for _, r := range regions {
+		sampleSize += uint64(r.SketchSampleCount)
+	}
+	return sampleSize
+}
+
+// estimateSamplingNDV returns the GEE-estimated NDV for column/index position
+// i, or 0 when there is not enough data to estimate.
+func estimateSamplingNDV(rootCollector statistics.RowSampleCollector, regions []statistics.RegionSketchSummary, i int, sampleSize uint64) int64 {
+	sampleNDV := uint64(rootCollector.Base().FMSketches[i].NDV())
+	if sampleNDV == 0 {
+		return 0
+	}
+	count := rootCollector.Base().Count - rootCollector.Base().NullCount[i]
+	if count <= 0 {
+		return 0
+	}
+	rowCount := uint64(count)
+	if sampleNDV > rowCount {
+		sampleNDV = rowCount
+	}
+	ndvSketches := make([]*statistics.FMSketch, 0, len(regions))
+	singletonSketches := make([]*statistics.FMSketch, 0, len(regions))
+	for _, r := range regions {
+		intest.Assert(len(r.SingletonSketches) > 0, "singleton sketches should not be empty")
+		intest.Assert(i < len(r.SingletonSketches), "singleton sketch should exist for the column")
+		intest.Assert(r.SingletonSketches[i] != nil, "singleton sketch should not be nil")
+		if i >= len(r.SingletonSketches) || r.SingletonSketches[i] == nil {
+			continue
+		}
+		// The estimator needs live maps to merge, so rebuild them from the compact
+		// retained form (see statistics.RegionSketchSummary). Doing it per column (this
+		// is called once per column, and these slices are freed on return) caps the
+		// live materialization at O(regions), not O(regions*columns).
+		ndvSketches = append(ndvSketches, statistics.FMSketchFromProto(r.NDVSketches[i]))
+		singletonSketches = append(singletonSketches, statistics.FMSketchFromProto(r.SingletonSketches[i]))
+	}
+	if len(ndvSketches) == 0 {
+		return 0
+	}
+	singletonItems := statistics.EstimateGlobalSingletonBySketches(ndvSketches, singletonSketches)
+	return int64(statistics.EstimateNDVByGEE(sampleNDV, singletonItems, sampleSize, rowCount))
 }
 
 func readDataAndSendTask(ctx context.Context, sctx sessionctx.Context, handler *tableResultHandler, mergeTaskCh chan []byte, memTracker *memory.Tracker) error {

--- a/pkg/executor/analyze_utils_test.go
+++ b/pkg/executor/analyze_utils_test.go
@@ -20,7 +20,11 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/planner/core"
+	"github.com/pingcap/tidb/pkg/statistics"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
+	"github.com/pingcap/tidb/pkg/util/mock"
+	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -66,4 +70,47 @@ func TestCanBroadcastToTiDBRPCForTestRejectsInvalidEndpoints(t *testing.T) {
 func BuildExecutorForTest(ctx context.Context, stmt *ExecStmt) error {
 	_, err := stmt.buildExecutor(ctx)
 	return err
+}
+
+func TestEstimateSamplingNDV(t *testing.T) {
+	rootCollector := statistics.NewReservoirRowSampleCollector(1, 2)
+	rootCollector.Count = 100
+	rootCollector.FMSketches = append(rootCollector.FMSketches,
+		mustBuildFMSketch(t, 1, 2, 3, 4),
+		mustBuildFMSketch(t, 10, 11),
+	)
+
+	// RegionSketchSummary retains sketches in the compact proto form.
+	toProto := func(ss ...*statistics.FMSketch) []*tipb.FMSketch {
+		out := make([]*tipb.FMSketch, len(ss))
+		for i, s := range ss {
+			out[i] = statistics.FMSketchToProto(s)
+		}
+		return out
+	}
+	regions := []statistics.RegionSketchSummary{
+		{
+			NDVSketches:       toProto(mustBuildFMSketch(t, 1, 2, 3), mustBuildFMSketch(t, 10)),
+			SingletonSketches: toProto(mustBuildFMSketch(t, 1, 2, 3), mustBuildFMSketch(t, 10)),
+			SketchSampleCount: 3,
+		},
+		{
+			NDVSketches:       toProto(mustBuildFMSketch(t, 2, 3, 4), mustBuildFMSketch(t, 11)),
+			SingletonSketches: toProto(mustBuildFMSketch(t, 2, 4), mustBuildFMSketch(t, 11)),
+			SketchSampleCount: 3,
+		},
+	}
+
+	require.Equal(t, uint64(6), totalSketchSampleSize(regions))
+	require.Equal(t, int64(10), estimateSamplingNDV(rootCollector, regions, 0, 6))
+}
+
+func mustBuildFMSketch(t *testing.T, values ...int64) *statistics.FMSketch {
+	t.Helper()
+	sketch := statistics.NewFMSketch(1000)
+	sc := mock.NewContext().GetSessionVars().StmtCtx
+	for _, value := range values {
+		require.NoError(t, sketch.InsertValue(sc, types.NewIntDatum(value)))
+	}
+	return sketch
 }

--- a/pkg/executor/analyze_utils_test.go
+++ b/pkg/executor/analyze_utils_test.go
@@ -17,8 +17,10 @@ package executor
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/types"
@@ -73,6 +75,20 @@ func BuildExecutorForTest(ctx context.Context, stmt *ExecStmt) error {
 }
 
 func TestEstimateSamplingNDV(t *testing.T) {
+	t.Run("configured NDV sample rate", func(t *testing.T) {
+		require.Equal(t, float64(statistics.NDVSampleSkipRate), configuredAnalyzeNDVSampleRate(nil))
+		require.Equal(t, 0.25, configuredAnalyzeNDVSampleRate(map[ast.AnalyzeOptionType]uint64{
+			ast.AnalyzeOptNDVRate: math.Float64bits(0.25),
+		}))
+	})
+
+	t.Run("effective NDV sample rate clamp", func(t *testing.T) {
+		// configured >= rowSampleRate: pass through.
+		require.Equal(t, 0.25, effectiveAnalyzeNDVSampleRate(0.25, 0.1))
+		// configured < rowSampleRate: clamp up.
+		require.Equal(t, 0.5, effectiveAnalyzeNDVSampleRate(0.25, 0.5))
+	})
+
 	rootCollector := statistics.NewReservoirRowSampleCollector(1, 2)
 	rootCollector.Count = 100
 	rootCollector.FMSketches = append(rootCollector.FMSketches,

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3169,7 +3169,6 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 		modifyCount = int64(val.(int))
 	})
 	sampleRate := new(float64)
-	ndvRate := float64(statistics.NDVSampleSkipRate)
 	var sampleRateReason string
 	if opts[ast.AnalyzeOptNumSamples] == 0 {
 		*sampleRate = math.Float64frombits(opts[ast.AnalyzeOptSampleRate])
@@ -3195,10 +3194,30 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 			}
 		}
 	}
-	// NDV estimation needs at least as many rows as the row sample to remain statistically
-	// useful; align ndvRate up to sampleRate when a smaller value was configured.
-	if ndvRate < *sampleRate {
-		ndvRate = *sampleRate
+	configuredNDVRate := configuredAnalyzeNDVSampleRate(opts)
+	ndvRate := effectiveAnalyzeNDVSampleRate(configuredNDVRate, *sampleRate)
+	if ndvRate > configuredNDVRate {
+		// handleAnalyzeOptions already rejects the case where both samplerate and
+		// ndvrate are explicit and ndvrate is smaller, so this only fires when
+		// samplerate was auto-adjusted above the user-configured ndvrate.
+		if task.PartitionName != "" {
+			sc.AppendNote(errors.NewNoStackErrorf(
+				`Analyze raised NDV sample rate from %f to %f to match the auto-adjusted row sample rate for table %s.%s's partition %s`,
+				configuredNDVRate,
+				ndvRate,
+				task.DBName,
+				task.TableName,
+				task.PartitionName,
+			))
+		} else {
+			sc.AppendNote(errors.NewNoStackErrorf(
+				`Analyze raised NDV sample rate from %f to %f to match the auto-adjusted row sample rate for table %s.%s`,
+				configuredNDVRate,
+				ndvRate,
+				task.DBName,
+				task.TableName,
+			))
+		}
 	}
 	job := &statistics.AnalyzeJob{
 		DBName:           task.DBName,
@@ -3248,6 +3267,28 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 	}
 	b.err = tables.SetPBColumnsDefaultValue(b.sctx.GetExprCtx(), e.analyzePB.ColReq.ColumnsInfo, task.ColsInfo)
 	return &analyzeTask{taskType: colTask, colExec: e, job: job}
+}
+
+// configuredAnalyzeNDVSampleRate returns the NDV sample rate explicitly set in
+// the analyze options, or NDVSampleSkipRate when the option is absent.
+func configuredAnalyzeNDVSampleRate(opts map[ast.AnalyzeOptionType]uint64) float64 {
+	if val, ok := opts[ast.AnalyzeOptNDVRate]; ok {
+		return math.Float64frombits(val)
+	}
+	return float64(statistics.NDVSampleSkipRate)
+}
+
+// effectiveAnalyzeNDVSampleRate raises the configured NDV sample rate up to
+// rowSampleRate. TiKV builds singleton sketches at ndvrate first and then
+// draws the row sample from that stream at samplerate, so ndvrate < samplerate
+// is incoherent — the row sample cannot exceed the population it is drawn
+// from. The usual trigger is a small table whose samplerate gets auto-adjusted
+// up to 1.0 (full scan) above a smaller configured ndvrate.
+func effectiveAnalyzeNDVSampleRate(configured, rowSampleRate float64) float64 {
+	if configured < rowSampleRate {
+		return rowSampleRate
+	}
+	return configured
 }
 
 // getAdjustedSampleRate calculate the sample rate by the table size. If we cannot get the table size. We use the 0.001 as the default sample rate.

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3169,6 +3169,7 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 		modifyCount = int64(val.(int))
 	})
 	sampleRate := new(float64)
+	ndvRate := float64(statistics.NDVSampleSkipRate)
 	var sampleRateReason string
 	if opts[ast.AnalyzeOptNumSamples] == 0 {
 		*sampleRate = math.Float64frombits(opts[ast.AnalyzeOptSampleRate])
@@ -3193,6 +3194,11 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 				))
 			}
 		}
+	}
+	// NDV estimation needs at least as many rows as the row sample to remain statistically
+	// useful; align ndvRate up to sampleRate when a smaller value was configured.
+	if ndvRate < *sampleRate {
+		ndvRate = *sampleRate
 	}
 	job := &statistics.AnalyzeJob{
 		DBName:           task.DBName,
@@ -3229,6 +3235,7 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 		BucketSize:   int64(opts[ast.AnalyzeOptNumBuckets]),
 		SampleSize:   int64(opts[ast.AnalyzeOptNumSamples]),
 		SampleRate:   sampleRate,
+		NdvRate:      &ndvRate,
 		SketchSize:   statistics.MaxSketchSize,
 		ColumnsInfo:  util.ColumnsToProto(task.ColsInfo, task.TblInfo.PKIsHandle, false, false),
 		ColumnGroups: colGroups,

--- a/pkg/executor/test/analyzetest/BUILD.bazel
+++ b/pkg/executor/test/analyzetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 38,
+    shard_count = 40,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -455,6 +455,83 @@ func TestSnapshotAnalyzeAndMaxTSAnalyze(t *testing.T) {
 	}
 }
 
+func TestAnalyzeUsesNDVRateOption(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_analyze_version = 2")
+	tk.MustExec("create table t_ndv_rate(a int, b int, index idx_b(b))")
+	// 200 rows: col a is fully unique; col b has 10 distinct values, each repeated 20 times.
+	values := make([]string, 0, 200)
+	for i := 1; i <= 200; i++ {
+		values = append(values, fmt.Sprintf("(%d,%d)", i, i%10))
+	}
+	tk.MustExec("insert into t_ndv_rate values " + strings.Join(values, ","))
+
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t_ndv_rate"))
+	require.NoError(t, err)
+	tblInfo := tbl.Meta()
+	readNDV := func(histID int64, isIndex int) int64 {
+		rows := tk.MustQuery(fmt.Sprintf(
+			"select distinct_count from mysql.stats_histograms where table_id = %d and hist_id = %d and is_index = %d",
+			tblInfo.ID,
+			histID,
+			isIndex,
+		)).Rows()
+		require.Len(t, rows, 1)
+		n, err := strconv.ParseInt(rows[0][0].(string), 10, 64)
+		require.NoError(t, err)
+		return n
+	}
+
+	t.Run("exact path with ndvrate=1", func(t *testing.T) {
+		tk.MustExec("analyze table t_ndv_rate with 1 samplerate, 1 ndvrate")
+		require.Equal(t, int64(200), readNDV(tblInfo.Columns[0].ID, 0))
+		require.Equal(t, int64(10), readNDV(tblInfo.Columns[1].ID, 0))
+		require.Equal(t, int64(10), readNDV(tblInfo.Indices[0].ID, 1))
+	})
+
+	t.Run("singleton-sketch path with ndvrate<1", func(t *testing.T) {
+		// Pin the unistore analyze RNG seed so the Bernoulli sketch sampling and the
+		// resulting GEE estimate are deterministic.
+		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/cophandler/mockAnalyzeSamplingSeed", "return(1)"))
+		defer func() {
+			require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/cophandler/mockAnalyzeSamplingSeed"))
+		}()
+		tk.MustExec("analyze table t_ndv_rate with 0.5 samplerate, 0.5 ndvrate")
+		// True NDVs are 200/10/10. Column `a` lands at 141 (instead of 200) because
+		// GEE under-estimates NDV on fully-unique columns from a half-sample; this
+		// confirms the singleton-sketch path is exercised rather than the exact one.
+		require.Equal(t, int64(141), readNDV(tblInfo.Columns[0].ID, 0))
+		require.Equal(t, int64(10), readNDV(tblInfo.Columns[1].ID, 0))
+		require.Equal(t, int64(10), readNDV(tblInfo.Indices[0].ID, 1))
+	})
+}
+
+func TestAnalyzeRaisesNDVRateNote(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_analyze_version = 2")
+	tk.MustExec("create table t_ndv_note(a int)")
+	tk.MustExec("insert into t_ndv_note values (1),(2),(3)")
+
+	// Force stats_meta to a tiny count so getAdjustedSampleRate returns 1, which
+	// will exceed the user's configured ndvrate of 0.5 and trigger the clamp.
+	statsHandle := dom.StatsHandle()
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t_ndv_note"))
+	require.NoError(t, err)
+	tk.MustExec(fmt.Sprintf("update mysql.stats_meta set count = 3 where table_id = %d", tbl.Meta().ID))
+	require.NoError(t, statsHandle.Update(context.Background(), dom.InfoSchema()))
+
+	tk.MustExec("analyze table t_ndv_note with 0.5 ndvrate")
+	tk.MustQuery("show warnings").CheckContain(
+		"Analyze raised NDV sample rate from 0.500000 to 1.000000 to match the auto-adjusted row sample rate for table test.t_ndv_note",
+	)
+}
+
 func TestAdjustSampleRateNote(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/physical_plan_test.go
+++ b/pkg/planner/core/physical_plan_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/coretestsdk"
 	"github.com/pingcap/tidb/pkg/session"
+	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/external"
@@ -62,7 +63,15 @@ func TestAnalyzeBuildSucc(t *testing.T) {
 			succ: true,
 		},
 		{
+			sql:  "analyze table t with 0.5 ndvrate",
+			succ: true,
+		},
+		{
 			sql:  "analyze table t with 10 samplerate",
+			succ: false,
+		},
+		{
+			sql:  "analyze table t with 2 ndvrate",
 			succ: false,
 		},
 		{
@@ -101,20 +110,29 @@ func TestAnalyzeSetRate(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t(a int)")
 	tests := []struct {
-		sql  string
-		rate float64
+		sql     string
+		rate    float64
+		ndvRate float64
 	}{
 		{
-			sql:  "analyze table t",
-			rate: -1,
+			sql:     "analyze table t",
+			rate:    -1,
+			ndvRate: statistics.NDVSampleSkipRate,
 		},
 		{
-			sql:  "analyze table t with 0.1 samplerate",
-			rate: 0.1,
+			sql:     "analyze table t with 0.1 samplerate",
+			rate:    0.1,
+			ndvRate: statistics.NDVSampleSkipRate,
 		},
 		{
-			sql:  "analyze table t with 10000 samples",
-			rate: -1,
+			sql:     "analyze table t with 0.25 ndvrate",
+			rate:    -1,
+			ndvRate: 0.25,
+		},
+		{
+			sql:     "analyze table t with 10000 samples",
+			rate:    -1,
+			ndvRate: statistics.NDVSampleSkipRate,
 		},
 	}
 
@@ -132,6 +150,7 @@ func TestAnalyzeSetRate(t *testing.T) {
 		require.NoError(t, err, comment)
 		ana := p.(*core.Analyze)
 		require.Equal(t, tt.rate, math.Float64frombits(ana.Opts[ast.AnalyzeOptSampleRate]))
+		require.Equal(t, tt.ndvRate, math.Float64frombits(ana.Opts[ast.AnalyzeOptNDVRate]))
 	}
 }
 

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3111,6 +3111,7 @@ var analyzeOptionLimit = map[ast.AnalyzeOptionType]uint64{
 	ast.AnalyzeOptCMSketchDepth: CMSketchSizeLimit,
 	ast.AnalyzeOptNumSamples:    5000000,
 	ast.AnalyzeOptSampleRate:    math.Float64bits(1),
+	ast.AnalyzeOptNDVRate:       math.Float64bits(statistics.NDVSampleSkipRate),
 }
 
 // TopN reduced from 500 to 100 due to concerns over large number of TopN values collected for customers with many tables.
@@ -3122,6 +3123,7 @@ var analyzeOptionDefaultV2 = map[ast.AnalyzeOptionType]uint64{
 	ast.AnalyzeOptCMSketchDepth: 5,
 	ast.AnalyzeOptNumSamples:    0,
 	ast.AnalyzeOptSampleRate:    math.Float64bits(-1),
+	ast.AnalyzeOptNDVRate:       math.Float64bits(statistics.NDVSampleSkipRate),
 }
 
 // GetAnalyzeOptionDefaultV2ForTest returns the default analyze options for test.
@@ -3133,7 +3135,7 @@ func GetAnalyzeOptionDefaultV2ForTest() map[ast.AnalyzeOptionType]uint64 {
 // explicitly specified in the statement.
 func handleAnalyzeOptions(opts []ast.AnalyzeOpt) (map[ast.AnalyzeOptionType]uint64, error) {
 	optMap := make(map[ast.AnalyzeOptionType]uint64, len(analyzeOptionDefaultV2))
-	sampleNum, sampleRate := uint64(0), 0.0
+	sampleNum, sampleRate, ndvRate := uint64(0), 0.0, 0.0
 	for _, opt := range opts {
 		datumValue := opt.Value.(*driver.ValueExpr).Datum
 		switch opt.Type {
@@ -3143,7 +3145,7 @@ func handleAnalyzeOptions(opts []ast.AnalyzeOpt) (map[ast.AnalyzeOptionType]uint
 				return nil, errors.Errorf("Value of analyze option %s should not be larger than %d", ast.AnalyzeOptionString[opt.Type], analyzeOptionLimit[opt.Type])
 			}
 			optMap[opt.Type] = v
-		case ast.AnalyzeOptSampleRate:
+		case ast.AnalyzeOptSampleRate, ast.AnalyzeOptNDVRate:
 			// Only Int/Float/decimal is accepted, so pass nil here is safe.
 			fVal, err := datumValue.ToFloat64(types.DefaultStmtNoWarningContext)
 			if err != nil {
@@ -3153,7 +3155,12 @@ func handleAnalyzeOptions(opts []ast.AnalyzeOpt) (map[ast.AnalyzeOptionType]uint
 			if fVal <= 0 || fVal > limit {
 				return nil, errors.Errorf("Value of analyze option %s should not larger than %f, and should be greater than 0", ast.AnalyzeOptionString[opt.Type], limit)
 			}
-			sampleRate = fVal
+			switch opt.Type {
+			case ast.AnalyzeOptSampleRate:
+				sampleRate = fVal
+			case ast.AnalyzeOptNDVRate:
+				ndvRate = fVal
+			}
 			optMap[opt.Type] = math.Float64bits(fVal)
 		default:
 			v := datumValue.GetUint64()
@@ -3168,6 +3175,15 @@ func handleAnalyzeOptions(opts []ast.AnalyzeOpt) (map[ast.AnalyzeOptionType]uint
 	}
 	if sampleNum > 0 && sampleRate > 0 {
 		return nil, errors.Errorf("You can only either set the value of the sample num or set the value of the sample rate. Don't set both of them")
+	}
+	// TiKV builds singleton sketches at ndvrate first and then draws the row
+	// sample from that stream at samplerate, so ndvrate < samplerate is
+	// incoherent by construction — the row sample cannot exceed the population
+	// it is drawn from. Reject the explicit conflict here so the user sees the
+	// mistake instead of letting execution-time clamping silently raise the
+	// value.
+	if ndvRate > 0 && sampleRate > 0 && ndvRate < sampleRate {
+		return nil, errors.Errorf("Value of analyze option NDVRATE (%f) must not be smaller than SAMPLERATE (%f)", ndvRate, sampleRate)
 	}
 
 	return optMap, nil

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -671,6 +671,16 @@ func TestHandleAnalyzeOptions(t *testing.T) {
 			ExpectedErr: "Value of analyze option SAMPLERATE should not larger than 1.000000, and should be greater than 0",
 		},
 		{
+			name: "Too big NDVRate option",
+			opts: []ast.AnalyzeOpt{
+				{
+					Type:  ast.AnalyzeOptNDVRate,
+					Value: ast.NewValueExpr(2, "", ""),
+				},
+			},
+			ExpectedErr: "Value of analyze option NDVRATE should not larger than 1.000000, and should be greater than 0",
+		},
+		{
 			name: "Too big NumBuckets option",
 			opts: []ast.AnalyzeOpt{
 				{
@@ -693,6 +703,20 @@ func TestHandleAnalyzeOptions(t *testing.T) {
 				},
 			},
 			ExpectedErr: "ou can only either set the value of the sample num or set the value of the sample rate. Don't set both of them",
+		},
+		{
+			name: "NDVRate below SampleRate",
+			opts: []ast.AnalyzeOpt{
+				{
+					Type:  ast.AnalyzeOptSampleRate,
+					Value: ast.NewValueExpr(0.5, "", ""),
+				},
+				{
+					Type:  ast.AnalyzeOptNDVRate,
+					Value: ast.NewValueExpr(0.1, "", ""),
+				},
+			},
+			ExpectedErr: "Value of analyze option NDVRATE (0.100000) must not be smaller than SAMPLERATE (0.500000)",
 		},
 	}
 

--- a/pkg/statistics/BUILD.bazel
+++ b/pkg/statistics/BUILD.bazel
@@ -81,7 +81,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":statistics"],
     flaky = True,
-    shard_count = 44,
+    shard_count = 45,
     deps = [
         "//pkg/config",
         "//pkg/meta/model",

--- a/pkg/statistics/constants.go
+++ b/pkg/statistics/constants.go
@@ -20,4 +20,6 @@ const (
 	DefaultTopNValue = 100
 	// DefaultHistogramBuckets is the default number of histogram buckets
 	DefaultHistogramBuckets = 256
+	// NDVSampleSkipRate is the sample rate at which sampling is skipped, so NDV sketches are built from every row.
+	NDVSampleSkipRate = 1
 )

--- a/pkg/statistics/estimate.go
+++ b/pkg/statistics/estimate.go
@@ -67,45 +67,41 @@ func EstimateNDVByGEE(sampleNDV, singletonItems, sampleSize, rowCount uint64) ui
 }
 
 // EstimateGlobalSingletonBySketches estimates the global singleton count using NDV and singleton sketches.
-// For each node i, we ask: how many of node i's local singletons
-// never appeared in any other node? Those are the values that are
-// truly unique across the entire dataset, contributed by node i.
+// For each region i, we ask: how many of region i's local singletons
+// never appeared in any other region? Those are the values that are
+// truly unique across the entire dataset, contributed by region i.
 //
-// We compute this by merging all *other* nodes' NDV sketches (their full
-// distinct-value sets), then checking how much node i's local singletons
-// grow that union. The growth is approximately node i's singleton's
-// FMSketch that no other node has seen.
+// We compute this by merging all *other* regions' NDV sketches (their full
+// distinct-value sets), then checking how much region i's local singletons
+// grow that union. The growth is approximately region i's singletons
+// that no other region has seen.
 //
-// Summing these per-node contributions gives the global singleton estimate.
+// Summing these per-region contributions gives the global singleton estimate.
 //
-// The implementation splits the nodes into two halves, precomputes one NDV
-// union per half, and then rebuilds only the suffix within each half while
-// keeping a rolling in-half prefix. That keeps the O(k²) time complexity
-// but cuts repeated merge work to roughly one quarter of the naive
-// rebuild-from-scratch loop while preserving O(1) extra sketches. A full
-// prefix-suffix cache could reduce the runtime to O(k), but it would require
-// O(k) extra sketches (~80KB each), which risks significant memory pressure
-// for tables with many nodes.
+// To avoid rebuilding "all other regions" from scratch for every region
+// (O(k^2) merges), we precompute suffix unions and keep a rolling prefix
+// union, so each region's complement is a single prefix-suffix combine. This
+// runs in O(k) merges using O(k) cached union sketches.
 //
-// Example with three nodes:
+// Example with three regions:
 //
-//	Node 0 all distinct values: {a, b, c}    local singletons: {a, b, c}
-//	Node 1 all distinct values: {b, c, d}    local singletons: {b, d}
-//	Node 2 all distinct values: {c, e, f}    local singletons: {e, f}
+//	Region 0 all distinct values: {a, b, c}    local singletons: {a, b, c}
+//	Region 1 all distinct values: {b, c, d}    local singletons: {b, d}
+//	Region 2 all distinct values: {c, e, f}    local singletons: {e, f}
 //
 // True global frequencies: a×1, b×2, c×3, d×1, e×1, f×1
 // True singletons = 4  (the values {a, d, e, f} appear exactly once globally)
 //
-//	Node 0: others' NDV = {b,c,d,e,f} (size 5)
-//	        + node 0 singletons {a,b,c} = {a,b,c,d,e,f} (size 6)
+//	Region 0: others' NDV = {b,c,d,e,f} (size 5)
+//	        + region 0 singletons {a,b,c} = {a,b,c,d,e,f} (size 6)
 //	        contribution = 1  (only `a` is new)
 //
-//	Node 1: others' NDV = {a,b,c,e,f} (size 5)
-//	        + node 1 singletons {b,d} = {a,b,c,d,e,f} (size 6)
+//	Region 1: others' NDV = {a,b,c,e,f} (size 5)
+//	        + region 1 singletons {b,d} = {a,b,c,d,e,f} (size 6)
 //	        contribution = 1  (only `d` is new)
 //
-//	Node 2: others' NDV = {a,b,c,d} (size 4)
-//	        + node 2 singletons {e,f} = {a,b,c,d,e,f} (size 6)
+//	Region 2: others' NDV = {a,b,c,d} (size 4)
+//	        + region 2 singletons {e,f} = {a,b,c,d,e,f} (size 6)
 //	        contribution = 2  (`e` and `f` are new)
 //
 // Estimated singletons = 1 + 1 + 2 = 4
@@ -133,50 +129,32 @@ func EstimateGlobalSingletonBySketches(ndvSketches, singletonSketches []*FMSketc
 		return 0
 	}
 
-	mid := len(ndvSketches) - len(ndvSketches)/2
-	var leftHalfNDV *FMSketch
-	for _, sketch := range ndvSketches[:mid] {
-		leftHalfNDV = mergeCopiedFMSketch(leftHalfNDV, sketch)
-	}
-	var rightHalfNDV *FMSketch
-	for _, sketch := range ndvSketches[mid:] {
-		rightHalfNDV = mergeCopiedFMSketch(rightHalfNDV, sketch)
+	// suffixNDV[i] = union of ndvSketches[i:] (suffixNDV[n] is empty). Precomputing
+	// these makes each region's "union of all others" a prefix∪suffix combine, so the
+	// pass is O(n) merges instead of O(n^2), at the cost of O(n) cached union sketches.
+	n := len(ndvSketches)
+	suffixNDV := make([]*FMSketch, n+1)
+	for i := n - 1; i >= 1; i-- {
+		suffixNDV[i] = mergeCopiedFMSketch(mergeCopiedFMSketch(nil, suffixNDV[i+1]), ndvSketches[i])
 	}
 
-	// NOTE: For each node, we still merge every other node's NDV sketch.
-	globalSingleton := estimateGlobalSingletonInRange(ndvSketches[:mid], singletonSketches[:mid], rightHalfNDV)
-	globalSingleton += estimateGlobalSingletonInRange(ndvSketches[mid:], singletonSketches[mid:], leftHalfNDV)
-	// SAFETY: Each per-node contribution is clamped to >= 0 before accumulation.
-	intest.Assert(globalSingleton >= 0, "globalSingleton must be positive")
-	return uint64(globalSingleton)
-}
-
-func estimateGlobalSingletonInRange(ndvSketches, singletonSketches []*FMSketch, outOfRangeNDVSketch *FMSketch) int64 {
 	var globalSingleton int64
-	// prefixNDVSketch accumulates ndvSketches[0..i-1] as i advances, so
-	// each iteration only rebuilds the suffix (ndvSketches[i+1..]) from
-	// scratch instead of the full "all-except-i" set.
-	var prefixNDVSketch *FMSketch
+	// prefixNDV accumulates the union of ndvSketches[0:i] as i advances.
+	var prefixNDV *FMSketch
 	for i := range ndvSketches {
-		other := mergeCopiedFMSketch(nil, prefixNDVSketch)
-		for _, sketch := range ndvSketches[i+1:] {
-			other = mergeCopiedFMSketch(other, sketch)
-		}
-		other = mergeCopiedFMSketch(other, outOfRangeNDVSketch)
-
-		// NDV of the union of all other nodes before merging this node's singletons.
+		// Union of every region except i = prefix(0:i) ∪ suffix(i+1:).
+		other := mergeCopiedFMSketch(mergeCopiedFMSketch(nil, prefixNDV), suffixNDV[i+1])
 		ndvOther := other.NDV()
 		other = mergeCopiedFMSketch(other, singletonSketches[i])
-
-		// NDV of the union after merging this node's singleton sketch.
-		ndvUnion := other.NDV()
-		// FM sketch NDV estimates are not monotone under merge, so the estimated
-		// union can be smaller than ndvOther. Clamp the per-node contribution to 0.
-		// In practice, this appears to be fairly rare.
-		globalSingleton += max(0, ndvUnion-ndvOther)
-		prefixNDVSketch = mergeCopiedFMSketch(prefixNDVSketch, ndvSketches[i])
+		// FM sketch NDV estimates are not monotone under merge, so the union can come
+		// out smaller than ndvOther; clamp the per-region contribution to >= 0.
+		globalSingleton += max(0, other.NDV()-ndvOther)
+		prefixNDV = mergeCopiedFMSketch(prefixNDV, ndvSketches[i])
+		suffixNDV[i+1] = nil // consumed; release for GC
 	}
-	return globalSingleton
+	// SAFETY: Each per-region contribution is clamped to >= 0 before accumulation.
+	intest.Assert(globalSingleton >= 0, "globalSingleton must be >= 0")
+	return uint64(globalSingleton)
 }
 
 func mergeCopiedFMSketch(dst, src *FMSketch) *FMSketch {

--- a/pkg/statistics/fmsketch.go
+++ b/pkg/statistics/fmsketch.go
@@ -213,6 +213,11 @@ func FMSketchFromProto(protoSketch *tipb.FMSketch) *FMSketch {
 	sketch := &FMSketch{
 		hashset: make(map[uint64]struct{}, len(protoSketch.Hashset)),
 		mask:    protoSketch.Mask,
+		// maxSize is not carried in the proto; restore the standard cap so a later
+		// MergeFMSketch raises the mask level by level as designed. With maxSize 0,
+		// insertHashValue doubles the mask and prunes on every merged key, which
+		// corrupts the NDV estimate.
+		maxSize: MaxSketchSize,
 	}
 	for _, val := range protoSketch.Hashset {
 		sketch.hashset[val] = struct{}{}
@@ -241,7 +246,6 @@ func DecodeFMSketch(data []byte) (*FMSketch, error) {
 		return nil, errors.Trace(err)
 	}
 	fm := FMSketchFromProto(p)
-	fm.maxSize = MaxSketchSize
 	return fm, nil
 }
 

--- a/pkg/statistics/row_sampler.go
+++ b/pkg/statistics/row_sampler.go
@@ -17,6 +17,7 @@ package statistics
 import (
 	"container/heap"
 	"context"
+	"maps"
 	"math/rand"
 	"unsafe"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/collate"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/pingcap/tipb/go-tipb"
@@ -41,12 +43,51 @@ type RowSampleCollector interface {
 }
 
 type baseCollector struct {
-	Samples    WeightedRowSampleHeap
-	NullCount  []int64
+	Samples   WeightedRowSampleHeap
+	NullCount []int64
+	// FMSketches holds the per-column FM sketch for NDV. While sampling it counts this
+	// collector's distinct values; merging unions them, so the root's FMSketches is the
+	// global NDV — used directly (NDV sample rate >= 1) or as the sample NDV in the GEE
+	// correction. This is the merged whole, unlike the per-region RegionSketchSummaries.
 	FMSketches []*FMSketch
-	TotalSizes []int64
-	Count      int64
-	MemSize    int64
+	// SingletonSketches holds the per-column "seen exactly once" sketch. It is filled
+	// only on the producing side (the in-process sampler: Collect -> buildSingletonSketches)
+	// and serialized by ToProto into the response, mirroring TiKV. It stays empty on the
+	// merge side, where received per-region singletons are kept in RegionSketchSummaries.
+	SingletonSketches []*FMSketch
+	// RegionSketchSummaries holds one summary per region collected into this collector
+	// (see RegionSketchSummary): a from-response leaf carries its own region (built in
+	// FromProto, straight from the decoded proto), and a merged collector carries the
+	// concatenation. It is nil when singleton sketches are not collected (NDV sample
+	// rate >= 1).
+	//
+	// It grows with the region count and is not counted in MemSize, so the consumer
+	// must bound and account for it.
+	RegionSketchSummaries []RegionSketchSummary
+	TotalSizes            []int64
+	Count                 int64
+	// SketchSampleCount is the number of rows fed into FMSketches and
+	// SingletonSketches.
+	// It rescales NullCount and TotalSizes to the full population;
+	// 0 means no sub-sampling.
+	SketchSampleCount int64
+	MemSize           int64
+}
+
+// RegionSketchSummary holds one region's NDV and singleton sketches plus the row
+// count that fed them, kept separate per region: unioning singleton sketches breaks
+// "seen exactly once" (a value singleton in two regions occurs twice), so
+// EstimateGlobalSingletonBySketches consumes each region on its own. Sketches use
+// the compact proto form (not Go maps) because one is retained per region until the
+// estimate; the consumer rebuilds each before use.
+type RegionSketchSummary struct {
+	// NDVSketches is the region's per-column distinct-value sketch (compact form).
+	NDVSketches []*tipb.FMSketch
+	// SingletonSketches is the region's per-column sketch of values seen exactly
+	// once in the region (compact form).
+	SingletonSketches []*tipb.FMSketch
+	// SketchSampleCount is the number of rows that fed these sketches.
+	SketchSampleCount int64
 }
 
 // ReservoirRowSampleCollector collects the samples from the source and organize the samples by row.
@@ -64,6 +105,73 @@ type ReservoirRowSampleCollector struct {
 	MaxSampleSize int
 }
 
+// singletonSketchBuilder partitions hash values into singletons (seen exactly
+// once) and the rest. Only singletons feed the final FM sketch, which is the
+// basis for population NDV estimation under sub-sampling.
+type singletonSketchBuilder struct {
+	once     map[uint64]struct{}
+	multiple map[uint64]struct{}
+}
+
+func newSingletonSketchBuilder() *singletonSketchBuilder {
+	return &singletonSketchBuilder{
+		once:     make(map[uint64]struct{}),
+		multiple: make(map[uint64]struct{}),
+	}
+}
+
+func (s *singletonSketchBuilder) insertHashValue(hashVal uint64) {
+	if _, ok := s.multiple[hashVal]; ok {
+		return
+	}
+	if _, ok := s.once[hashVal]; ok {
+		delete(s.once, hashVal)
+		s.multiple[hashVal] = struct{}{}
+	} else {
+		s.once[hashVal] = struct{}{}
+	}
+}
+
+func (s *singletonSketchBuilder) insertValue(sc *stmtctx.StatementContext, value types.Datum) error {
+	hashVal, err := hashDatum(sc, value)
+	if err != nil {
+		return err
+	}
+	s.insertHashValue(hashVal)
+	return nil
+}
+
+func (s *singletonSketchBuilder) insertRowValue(sc *stmtctx.StatementContext, values []types.Datum) error {
+	hashVal, err := hashRow(sc, values)
+	if err != nil {
+		return err
+	}
+	s.insertHashValue(hashVal)
+	return nil
+}
+
+func (s *singletonSketchBuilder) clone() *singletonSketchBuilder {
+	if s == nil {
+		return nil
+	}
+	return &singletonSketchBuilder{
+		once:     maps.Clone(s.once),
+		multiple: maps.Clone(s.multiple),
+	}
+}
+
+func (s *singletonSketchBuilder) build(maxSketchSize int) *FMSketch {
+	if s == nil {
+		return nil
+	}
+	intest.Assert(maxSketchSize > 0, "maxSketchSize should be greater than 0")
+	sketch := NewFMSketch(maxSketchSize)
+	for val := range s.once {
+		sketch.insertHashValue(val)
+	}
+	return sketch
+}
+
 // ReservoirRowSampleItem is the item for the ReservoirRowSampleCollector. The weight is needed for the sampling algorithm.
 type ReservoirRowSampleItem struct {
 	Handle  kv.Handle
@@ -73,6 +181,14 @@ type ReservoirRowSampleItem struct {
 
 // EmptyReservoirSampleItemSize = (24 + 16 + 8) now.
 const EmptyReservoirSampleItemSize = int64(unsafe.Sizeof(ReservoirRowSampleItem{}))
+
+// ShouldBuildSingletonSketches reports whether the configured NDV sample rate
+// requires building per-region singleton sketches (rate < NDVSampleSkipRate means sketches are
+// collected from a subset of rows and a global NDV estimate is derived from
+// the singletons).
+func ShouldBuildSingletonSketches(rate float64) bool {
+	return rate < NDVSampleSkipRate
+}
 
 // MemUsage returns the memory usage of sample item.
 func (i ReservoirRowSampleItem) MemUsage() (sum int64) {
@@ -120,14 +236,24 @@ func (h *WeightedRowSampleHeap) Pop() any {
 
 // RowSampleBuilder is used to construct the ReservoirRowSampleCollector to get the samples.
 type RowSampleBuilder struct {
-	RecordSet       sqlexec.RecordSet
-	Sc              *stmtctx.StatementContext
-	Rng             *rand.Rand
-	ColsFieldType   []*types.FieldType
-	Collators       []collate.Collator
-	ColGroups       [][]int64
-	MaxSampleSize   int
-	SampleRate      float64
+	RecordSet     sqlexec.RecordSet
+	Sc            *stmtctx.StatementContext
+	Rng           *rand.Rand
+	ColsFieldType []*types.FieldType
+	Collators     []collate.Collator
+	ColGroups     [][]int64
+	MaxSampleSize int
+	// SampleRate is the per-row keep probability for the row sample (the rows that
+	// build histograms and TopN). It drives Bernoulli sampling only when
+	// MaxSampleSize is 0; otherwise reservoir sampling is used and this is ignored.
+	SampleRate float64
+	// NDVSampleRate is the per-row keep probability for the per-column aggregates:
+	// FMsketches, NULL counts, and TotalSizes. NULL counts and TotalSizes are
+	// rescaled back to the full population afterwards. It is in (0, 1] and uses a
+	// separate per-row draw from SampleRate. Below NDVSampleSkipRate (1) the
+	// sketches see only a sub-sample, so singleton sketches are built to estimate
+	// population NDV from it.
+	NDVSampleRate   float64
 	MaxFMSketchSize int
 }
 
@@ -145,10 +271,11 @@ func NewRowSampleCollector(maxSampleSize int, sampleRate float64, totalLen int) 
 // NewReservoirRowSampleCollector creates the new collector by the given inputs.
 func NewReservoirRowSampleCollector(maxSampleSize int, totalLen int) *ReservoirRowSampleCollector {
 	base := &baseCollector{
-		Samples:    make(WeightedRowSampleHeap, 0, maxSampleSize),
-		NullCount:  make([]int64, totalLen),
-		FMSketches: make([]*FMSketch, 0, totalLen),
-		TotalSizes: make([]int64, totalLen),
+		Samples:           make(WeightedRowSampleHeap, 0, maxSampleSize),
+		NullCount:         make([]int64, totalLen),
+		FMSketches:        make([]*FMSketch, 0, totalLen),
+		SingletonSketches: make([]*FMSketch, 0, totalLen),
+		TotalSizes:        make([]int64, totalLen),
 	}
 	return &ReservoirRowSampleCollector{
 		baseCollector: base,
@@ -160,9 +287,20 @@ func NewReservoirRowSampleCollector(maxSampleSize int, totalLen int) *ReservoirR
 // column group.
 // Then use the weighted reservoir sampling to collect the samples.
 func (s *RowSampleBuilder) Collect() (RowSampleCollector, error) {
-	collector := NewRowSampleCollector(s.MaxSampleSize, s.SampleRate, len(s.ColsFieldType)+len(s.ColGroups))
-	for range len(s.ColsFieldType) + len(s.ColGroups) {
+	totalLen := len(s.ColsFieldType) + len(s.ColGroups)
+	collector := NewRowSampleCollector(s.MaxSampleSize, s.SampleRate, totalLen)
+	ndvSampleRate := s.NDVSampleRate
+	intest.Assert(ndvSampleRate > 0 && ndvSampleRate <= NDVSampleSkipRate, "NDVSampleRate must be in (0, 1]")
+	buildSingletons := ShouldBuildSingletonSketches(ndvSampleRate)
+	var singletonBuilders []*singletonSketchBuilder
+	if buildSingletons {
+		singletonBuilders = make([]*singletonSketchBuilder, 0, totalLen)
+	}
+	for range totalLen {
 		collector.Base().FMSketches = append(collector.Base().FMSketches, NewFMSketch(s.MaxFMSketchSize))
+		if buildSingletons {
+			singletonBuilders = append(singletonBuilders, newSingletonSketchBuilder())
+		}
 	}
 	ctx := context.TODO()
 	chk := s.RecordSet.NewChunk(nil)
@@ -203,17 +341,25 @@ func (s *RowSampleBuilder) Collect() (RowSampleCollector, error) {
 					datums[i].SetBytes(encodedKey)
 				}
 			}
-			err := collector.Base().collectColumns(s.Sc, datums, sizes)
-			if err != nil {
-				return nil, err
-			}
-			err = collector.Base().collectColumnGroups(s.Sc, datums, s.ColGroups, sizes)
-			if err != nil {
-				return nil, err
+			collectSketch := !buildSingletons || s.Rng.Float64() < ndvSampleRate
+			if collectSketch {
+				if err := collector.Base().collectColumns(s.Sc, datums, sizes, singletonBuilders); err != nil {
+					return nil, err
+				}
+				if err := collector.Base().collectColumnGroups(s.Sc, datums, s.ColGroups, sizes, singletonBuilders); err != nil {
+					return nil, err
+				}
+				if buildSingletons {
+					collector.Base().SketchSampleCount++
+				}
 			}
 			collector.sampleRow(newCols, s.Rng)
 		}
 	}
+	// NDV sub-sampling only tallies NullCount/TotalSizes for rows that passed
+	// the rate check. Rescale them back to per-population estimates before the
+	// single-column-group copy below picks them up.
+	collector.Base().rescaleNullCountAndTotalSizes()
 	for i, group := range s.ColGroups {
 		if len(group) != 1 {
 			continue
@@ -224,17 +370,31 @@ func (s *RowSampleBuilder) Collect() (RowSampleCollector, error) {
 		colIdx := group[0]
 		colGroupIdx := len(s.ColsFieldType) + i
 		collector.Base().FMSketches[colGroupIdx] = collector.Base().FMSketches[colIdx].Copy()
+		if buildSingletons {
+			singletonBuilders[colGroupIdx] = singletonBuilders[colIdx].clone()
+		}
 		collector.Base().NullCount[colGroupIdx] = collector.Base().NullCount[colIdx]
 		collector.Base().TotalSizes[colGroupIdx] = collector.Base().TotalSizes[colIdx]
+	}
+	if buildSingletons {
+		collector.Base().buildSingletonSketches(singletonBuilders, s.MaxFMSketchSize)
 	}
 	return collector, nil
 }
 
 func (s *baseCollector) destroyAndPutToPool() {
 	s.FMSketches = nil // Release for GC.
+	s.SingletonSketches = nil
+	s.RegionSketchSummaries = nil
 }
 
-func (s *baseCollector) collectColumns(sc *stmtctx.StatementContext, cols []types.Datum, sizes []int64) error {
+func (s *baseCollector) collectColumns(
+	sc *stmtctx.StatementContext,
+	cols []types.Datum,
+	sizes []int64,
+	singletonBuilders []*singletonSketchBuilder,
+) error {
+	collectSingletonSketch := singletonBuilders != nil
 	for i, col := range cols {
 		if col.IsNull() {
 			s.NullCount[i]++
@@ -242,16 +402,27 @@ func (s *baseCollector) collectColumns(sc *stmtctx.StatementContext, cols []type
 		}
 		// Minus one is to remove the flag byte.
 		s.TotalSizes[i] += sizes[i] - 1
-		err := s.FMSketches[i].InsertValue(sc, col)
-		if err != nil {
+		if err := s.FMSketches[i].InsertValue(sc, col); err != nil {
 			return err
+		}
+		if collectSingletonSketch {
+			if err := singletonBuilders[i].insertValue(sc, col); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
-func (s *baseCollector) collectColumnGroups(sc *stmtctx.StatementContext, cols []types.Datum, colGroups [][]int64, sizes []int64) error {
+func (s *baseCollector) collectColumnGroups(
+	sc *stmtctx.StatementContext,
+	cols []types.Datum,
+	colGroups [][]int64,
+	sizes []int64,
+	singletonBuilders []*singletonSketchBuilder,
+) error {
 	colLen := len(cols)
+	collectSingletonSketch := singletonBuilders != nil
 	datumBuffer := make([]types.Datum, 0, len(cols))
 	for i, group := range colGroups {
 		if len(group) == 1 {
@@ -268,12 +439,72 @@ func (s *baseCollector) collectColumnGroups(sc *stmtctx.StatementContext, cols [
 				s.TotalSizes[colLen+i] += sizes[c] - 1
 			}
 		}
-		err := s.FMSketches[colLen+i].InsertRowValue(sc, datumBuffer)
-		if err != nil {
+		if err := s.FMSketches[colLen+i].InsertRowValue(sc, datumBuffer); err != nil {
 			return err
+		}
+		if collectSingletonSketch {
+			if err := singletonBuilders[colLen+i].insertRowValue(sc, datumBuffer); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
+}
+
+// rescaleSampledValue scales `sampled` (accumulated over `sampleCount` rows)
+// into an estimate over `totalRowCount` rows using round-half-up division.
+// Only used in the mock store path (unistore cophandler), so int64 is wide
+// enough for any realistic test fixture. Non-positive inputs return 0.
+func rescaleSampledValue(sampled, totalRowCount, sampleCount int64) int64 {
+	intest.Assert(sampleCount > 0, "sampleCount must be positive")
+	if sampled <= 0 {
+		return 0
+	}
+	// Round-half-up integer division: floor(a*b/c + 0.5).
+	return (sampled*totalRowCount + sampleCount/2) / sampleCount
+}
+
+// rescaleNullCountAndTotalSizes converts per-column null counts and total sizes
+// gathered from the NDV sub-sample into estimates over the full row population.
+// Count itself is exact (TiKV reports it from scanned_rows_per_range; the
+// mock store has no scan-level sampling) and is only read here as the
+// scaling divisor — it is never modified. No-op when no sub-sampling occurred
+// (sampleCount == 0 or every row was sampled).
+func (s *baseCollector) rescaleNullCountAndTotalSizes() {
+	sampleCount := s.SketchSampleCount
+	totalRowCount := s.Count
+	// sampleCount > totalRowCount would scale stats *down* and corrupt them.
+	intest.Assert(totalRowCount >= sampleCount, "totalRowCount must be bigger than or equal to sampleCount")
+	// No sub-sampling: values are already exact.
+	if sampleCount <= 0 {
+		return
+	}
+	// Scaling factor is 1.0; nothing to do.
+	if totalRowCount == sampleCount {
+		return
+	}
+	for i, nc := range s.NullCount {
+		s.NullCount[i] = rescaleSampledValue(nc, totalRowCount, sampleCount)
+	}
+	for i, ts := range s.TotalSizes {
+		s.TotalSizes[i] = rescaleSampledValue(ts, totalRowCount, sampleCount)
+	}
+}
+
+func (s *baseCollector) buildSingletonSketches(singletonBuilders []*singletonSketchBuilder, maxSketchSize int) {
+	s.SingletonSketches = make([]*FMSketch, len(singletonBuilders))
+	for i, builder := range singletonBuilders {
+		s.SingletonSketches[i] = builder.build(maxSketchSize)
+	}
+}
+
+// collectRegionSketchSummaries forwards the sub-collector's per-region summaries to
+// this collector — they are kept separate rather than unioned (see RegionSketchSummary).
+// A response leaf builds its summary in FromProto and the in-process sampling path is
+// never merged, so a merged sub already carries whatever summaries it has (possibly
+// none, e.g. NDV sample rate >= 1).
+func (s *baseCollector) collectRegionSketchSummaries(sub *baseCollector) {
+	s.RegionSketchSummaries = append(s.RegionSketchSummaries, sub.RegionSketchSummaries...)
 }
 
 // ToProto converts the collector to pb struct.
@@ -282,12 +513,18 @@ func (s *baseCollector) ToProto() *tipb.RowSampleCollector {
 	for _, sketch := range s.FMSketches {
 		pbFMSketches = append(pbFMSketches, FMSketchToProto(sketch))
 	}
+	pbSingletonSketches := make([]*tipb.FMSketch, 0, len(s.SingletonSketches))
+	for _, sketch := range s.SingletonSketches {
+		pbSingletonSketches = append(pbSingletonSketches, FMSketchToProto(sketch))
+	}
 	collector := &tipb.RowSampleCollector{
-		Samples:    RowSamplesToProto(s.Samples),
-		NullCounts: s.NullCount,
-		Count:      s.Count,
-		FmSketch:   pbFMSketches,
-		TotalSize:  s.TotalSizes,
+		Samples:           RowSamplesToProto(s.Samples),
+		NullCounts:        s.NullCount,
+		Count:             s.Count,
+		FmSketch:          pbFMSketches,
+		TotalSize:         s.TotalSizes,
+		SingletonSketch:   pbSingletonSketches,
+		SketchSampleCount: s.SketchSampleCount,
 	}
 	return collector
 }
@@ -296,8 +533,20 @@ func (s *baseCollector) FromProto(pbCollector *tipb.RowSampleCollector, memTrack
 	s.Count = pbCollector.Count
 	s.NullCount = pbCollector.NullCounts
 	s.FMSketches = make([]*FMSketch, 0, len(pbCollector.FmSketch))
+	s.SketchSampleCount = pbCollector.GetSketchSampleCount()
 	for _, pbSketch := range pbCollector.FmSketch {
 		s.FMSketches = append(s.FMSketches, FMSketchFromProto(pbSketch))
+	}
+	// Retain this region's sketches as one summary, straight from the decoded
+	// response: no re-serialization (the live FMSketches above are only for the root
+	// NDV merge) and no singleton live maps (they are never merged). Merging later
+	// concatenates this into the root; the estimator rebuilds the sketches it needs.
+	if singletons := pbCollector.GetSingletonSketch(); len(singletons) > 0 {
+		s.RegionSketchSummaries = []RegionSketchSummary{{
+			NDVSketches:       pbCollector.FmSketch,
+			SingletonSketches: singletons,
+			SketchSampleCount: pbCollector.GetSketchSampleCount(),
+		}}
 	}
 	s.TotalSizes = pbCollector.TotalSize
 	sampleNum := len(pbCollector.Samples)
@@ -370,9 +619,11 @@ func (s *ReservoirRowSampleCollector) sampleRow(row []types.Datum, rng *rand.Ran
 // MergeCollector merges the collectors to a final one.
 func (s *ReservoirRowSampleCollector) MergeCollector(subCollector RowSampleCollector) {
 	s.Count += subCollector.Base().Count
+	s.SketchSampleCount += subCollector.Base().SketchSampleCount
 	for i, fms := range subCollector.Base().FMSketches {
 		s.FMSketches[i].MergeFMSketch(fms)
 	}
+	s.collectRegionSketchSummaries(subCollector.Base())
 	for i, nullCount := range subCollector.Base().NullCount {
 		s.NullCount[i] += nullCount
 	}
@@ -440,10 +691,11 @@ type BernoulliRowSampleCollector struct {
 // NewBernoulliRowSampleCollector creates the new collector by the given inputs.
 func NewBernoulliRowSampleCollector(sampleRate float64, totalLen int) *BernoulliRowSampleCollector {
 	base := &baseCollector{
-		Samples:    make(WeightedRowSampleHeap, 0, 8),
-		NullCount:  make([]int64, totalLen),
-		FMSketches: make([]*FMSketch, 0, totalLen),
-		TotalSizes: make([]int64, totalLen),
+		Samples:           make(WeightedRowSampleHeap, 0, 8),
+		NullCount:         make([]int64, totalLen),
+		FMSketches:        make([]*FMSketch, 0, totalLen),
+		SingletonSketches: make([]*FMSketch, 0, totalLen),
+		TotalSizes:        make([]int64, totalLen),
 	}
 	return &BernoulliRowSampleCollector{
 		baseCollector: base,
@@ -464,9 +716,11 @@ func (s *BernoulliRowSampleCollector) sampleRow(row []types.Datum, rng *rand.Ran
 // MergeCollector merges the collectors to a final one.
 func (s *BernoulliRowSampleCollector) MergeCollector(subCollector RowSampleCollector) {
 	s.Count += subCollector.Base().Count
+	s.SketchSampleCount += subCollector.Base().SketchSampleCount
 	for i := range subCollector.Base().FMSketches {
 		s.FMSketches[i].MergeFMSketch(subCollector.Base().FMSketches[i])
 	}
+	s.collectRegionSketchSummaries(subCollector.Base())
 	for i := range subCollector.Base().NullCount {
 		s.NullCount[i] += subCollector.Base().NullCount[i]
 	}

--- a/pkg/statistics/sample_test.go
+++ b/pkg/statistics/sample_test.go
@@ -19,10 +19,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/collate"
+	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/stretchr/testify/require"
@@ -75,6 +78,7 @@ func TestWeightedSampling(t *testing.T) {
 			Collators:       make([]collate.Collator, 1),
 			ColGroups:       nil,
 			MaxSampleSize:   int(sampleNum),
+			NDVSampleRate:   NDVSampleSkipRate,
 			MaxFMSketchSize: 1000,
 			Rng:             rand.New(rand.NewSource(time.Now().UnixNano())),
 		}
@@ -117,6 +121,7 @@ func TestDistributedWeightedSampling(t *testing.T) {
 				Collators:       make([]collate.Collator, 1),
 				ColGroups:       nil,
 				MaxSampleSize:   int(sampleNum),
+				NDVSampleRate:   NDVSampleSkipRate,
 				MaxFMSketchSize: 1000,
 				Rng:             rand.New(rand.NewSource(time.Now().UnixNano())),
 			}
@@ -258,6 +263,28 @@ func TestBuildSampleFullNDV(t *testing.T) {
 	require.Equal(t, 2, len(topN.TopN), "TopN should be trimmed to sampleNDV-1 items when ndv > sampleNDV")
 }
 
+func TestRescaleSampledValue(t *testing.T) {
+	cases := []struct {
+		name       string
+		sampled    int64
+		population int64
+		sample     int64
+		expected   int64
+	}{
+		{"identity when sampled == sample", 50, 100, 50, 100},
+		{"scales up linearly", 10, 100, 50, 20},
+		{"rounds half up", 1, 3, 2, 2},
+		{"rounds down below half", 1, 4, 3, 1},
+		{"zero sampled stays zero", 0, 100, 50, 0},
+		{"negative sampled clamps to zero", -5, 100, 50, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.expected, rescaleSampledValue(c.sampled, c.population, c.sample))
+		})
+	}
+}
+
 type testSampleSuite struct {
 	count int
 	rs    sqlexec.RecordSet
@@ -268,6 +295,157 @@ func TestSampleSerial(t *testing.T) {
 	t.Run("SubTestCollectColumnStats", SubTestCollectColumnStats(s))
 	t.Run("SubTestMergeSampleCollector", SubTestMergeSampleCollector(s))
 	t.Run("SubTestCollectorProtoConversion", SubTestCollectorProtoConversion(s))
+	t.Run("SubTestRowSampleDefaultNDVRate", SubTestRowSampleDefaultNDVRate())
+	t.Run("SubTestRowSampleSingletonSketches", SubTestRowSampleSingletonSketches())
+	t.Run("SubTestRowSampleRescalesNullCountUnderSubSampling", SubTestRowSampleRescalesNullCountUnderSubSampling())
+	t.Run("SubTestSingletonSketchBuildRespectsMaxSize", SubTestSingletonSketchBuildRespectsMaxSize())
+	t.Run("SubTestMergePreservesPerRegionSingletonSketches", SubTestMergePreservesPerRegionSingletonSketches())
+}
+
+func SubTestRowSampleDefaultNDVRate() func(*testing.T) {
+	return func(t *testing.T) {
+		rs := recordSetForWeightSamplingTest(100)
+		builder := &RowSampleBuilder{
+			Sc:              mock.NewContext().GetSessionVars().StmtCtx,
+			RecordSet:       rs,
+			ColsFieldType:   []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)},
+			Collators:       make([]collate.Collator, 1),
+			MaxSampleSize:   10,
+			NDVSampleRate:   NDVSampleSkipRate,
+			MaxFMSketchSize: 1000,
+			Rng:             rand.New(rand.NewSource(1)),
+		}
+		collector, err := builder.Collect()
+		require.NoError(t, err)
+
+		require.Equal(t, int64(100), collector.Base().FMSketches[0].NDV())
+		require.Zero(t, collector.Base().SketchSampleCount)
+		require.Empty(t, collector.Base().SingletonSketches)
+
+		pbCollector := collector.Base().ToProto()
+		require.Empty(t, pbCollector.GetSingletonSketch())
+		require.Zero(t, pbCollector.GetSketchSampleCount())
+	}
+}
+
+func SubTestRowSampleSingletonSketches() func(*testing.T) {
+	return func(t *testing.T) {
+		intType := types.NewFieldType(mysql.TypeLonglong)
+		rs := &sqlexec.SimpleRecordSet{
+			ResultFields: []*resolve.ResultField{
+				{Column: &model.ColumnInfo{FieldType: *intType}},
+				{Column: &model.ColumnInfo{FieldType: *intType}},
+			},
+			Rows: [][]any{
+				{int64(1), int64(10)},
+				{int64(2), int64(10)},
+				{int64(2), int64(20)},
+				{int64(3), int64(20)},
+			},
+			MaxChunkSize: 32,
+		}
+
+		builder := &RowSampleBuilder{
+			Sc:              mock.NewContext().GetSessionVars().StmtCtx,
+			RecordSet:       rs,
+			ColsFieldType:   []*types.FieldType{intType, intType},
+			Collators:       make([]collate.Collator, 2),
+			ColGroups:       [][]int64{{0}, {0, 1}},
+			MaxSampleSize:   4,
+			NDVSampleRate:   0.5,
+			MaxFMSketchSize: 1000,
+			// Seed 1 deterministically samples rows [2, 3] under rate=0.5, exercising the
+			// "sketch sampling filtered some rows" path while keeping NDVs deterministic.
+			Rng: rand.New(rand.NewSource(1)),
+		}
+		collector, err := builder.Collect()
+		require.NoError(t, err)
+		base := collector.Base()
+
+		// Only rows (2, 20) and (3, 20) pass the rate=0.5 sketch sampling check.
+		require.Equal(t, int64(2), base.SketchSampleCount)
+		require.Len(t, base.SingletonSketches, 4)
+		require.Equal(t, int64(2), base.SingletonSketches[0].NDV()) // col 0: 2 and 3 are singletons.
+		require.Equal(t, int64(0), base.SingletonSketches[1].NDV()) // col 1: 20 repeats.
+		// Single-column group [0] is cloned from col 0, so its singletons match.
+		require.Equal(t, base.SingletonSketches[0].NDV(), base.SingletonSketches[2].NDV())
+		// Multi-column group [0,1]: (2,20) and (3,20) are singleton row pairs.
+		require.Equal(t, int64(2), base.SingletonSketches[3].NDV())
+
+		pbCollector := base.ToProto()
+		require.Equal(t, int64(2), pbCollector.GetSketchSampleCount())
+		require.Len(t, pbCollector.GetSingletonSketch(), 4)
+
+		restored := NewReservoirRowSampleCollector(4, 4)
+		restored.FromProto(pbCollector, memory.NewTracker(0, -1))
+		require.Equal(t, base.SketchSampleCount, restored.SketchSampleCount)
+		// FromProto retains this region's sketches as one summary, straight from the
+		// decoded response — by reference (no re-serialization round-trip) and without
+		// rebuilding the singleton live maps (never merged); the estimator rebuilds them.
+		require.Len(t, restored.RegionSketchSummaries, 1)
+		summary := restored.RegionSketchSummaries[0]
+		require.Same(t, pbCollector.FmSketch[0], summary.NDVSketches[0])
+		require.Same(t, pbCollector.GetSingletonSketch()[0], summary.SingletonSketches[0])
+		require.Len(t, summary.SingletonSketches, 4)
+		require.Equal(t, base.SingletonSketches[0].NDV(), FMSketchFromProto(summary.SingletonSketches[0]).NDV())
+		require.Equal(t, base.SingletonSketches[3].NDV(), FMSketchFromProto(summary.SingletonSketches[3]).NDV())
+	}
+}
+
+func SubTestRowSampleRescalesNullCountUnderSubSampling() func(*testing.T) {
+	return func(t *testing.T) {
+		intType := types.NewFieldType(mysql.TypeLonglong)
+		rs := &sqlexec.SimpleRecordSet{
+			ResultFields: []*resolve.ResultField{
+				{Column: &model.ColumnInfo{FieldType: *intType}},
+				{Column: &model.ColumnInfo{FieldType: *intType}},
+			},
+			// Seed 1 + rate 0.5 deterministically samples rows [2, 3].
+			// Nulls outside the sampled window are intentionally not "seen" so the
+			// rescaled estimate diverges from the true full-table null count — that
+			// is the entire point of post-sampling rescaling.
+			Rows: [][]any{
+				{nil, int64(10)},      // row 0 — not sampled.
+				{int64(2), nil},       // row 1 — not sampled.
+				{int64(3), int64(20)}, // row 2 — sampled. no nulls.
+				{nil, int64(40)},      // row 3 — sampled. col 0 null.
+			},
+			MaxChunkSize: 32,
+		}
+
+		builder := &RowSampleBuilder{
+			Sc:              mock.NewContext().GetSessionVars().StmtCtx,
+			RecordSet:       rs,
+			ColsFieldType:   []*types.FieldType{intType, intType},
+			Collators:       make([]collate.Collator, 2),
+			MaxSampleSize:   4,
+			NDVSampleRate:   0.5,
+			MaxFMSketchSize: 1000,
+			Rng:             rand.New(rand.NewSource(1)),
+		}
+		collector, err := builder.Collect()
+		require.NoError(t, err)
+		base := collector.Base()
+
+		// Count is exact by construction (mock store doesn't drop rows), so we
+		// don't assert on it here — we only check that NullCount got rescaled.
+		// Rows 2 and 3 are sampled (rate=0.5, seed=1), and within that sample
+		// col 0 has 1 null and col 1 has 0 nulls. Rescale factor is 4/2 = 2.
+		require.Equal(t, int64(2), base.SketchSampleCount)
+		require.Equal(t, int64(2), base.NullCount[0])
+		require.Equal(t, int64(0), base.NullCount[1])
+	}
+}
+
+func SubTestSingletonSketchBuildRespectsMaxSize() func(*testing.T) {
+	return func(t *testing.T) {
+		builder := newSingletonSketchBuilder()
+		for i := range 100 {
+			builder.insertHashValue(uint64(i))
+		}
+
+		require.LessOrEqual(t, len(builder.build(10).hashset), 10)
+	}
 }
 
 func createTestSampleSuite() *testSampleSuite {
@@ -380,5 +558,74 @@ func SubTestCollectorProtoConversion(s *testSampleSuite) func(*testing.T) {
 			require.Equal(t, s.TotalSize, collector.TotalSize)
 			require.Equal(t, len(s.Samples), len(collector.Samples))
 		}
+	}
+}
+
+// SubTestMergePreservesPerRegionSingletonSketches checks that merging keeps each
+// region's sketches separate (in RegionSketchSummaries) rather than unioning the
+// singleton sketches, which would miscount a value that is a singleton in two
+// regions as a global singleton.
+func SubTestMergePreservesPerRegionSingletonSketches() func(*testing.T) {
+	return func(t *testing.T) {
+		// Distinct hash values stand in for distinct data values; with maxSize=1000
+		// the FM sketch mask stays 0 so NDV is exact.
+		const (
+			a = uint64(100)
+			b = uint64(200)
+			c = uint64(300)
+		)
+		// makeRegion builds a single-column leaf collector that mimics one analyze
+		// response: its own NDV sketch and singleton sketch over that region's
+		// sub-sample.
+		makeRegion := func(ndv, singleton []uint64, sketchSampleCount int64) *ReservoirRowSampleCollector {
+			// Build the leaf the way an analyze response does (ToProto -> FromProto) so it
+			// carries its own per-region summary; merging then only concatenates summaries.
+			src := NewReservoirRowSampleCollector(1, 1)
+			src.Base().FMSketches = []*FMSketch{newFMSketchFromHashValues(ndv...)}
+			src.Base().SingletonSketches = []*FMSketch{newFMSketchFromHashValues(singleton...)}
+			src.Base().SketchSampleCount = sketchSampleCount
+			coll := NewReservoirRowSampleCollector(1, 1)
+			coll.FromProto(src.Base().ToProto(), memory.NewTracker(0, -1))
+			return coll
+		}
+
+		// `a` is a local singleton in both regions, so it occurs twice globally and
+		// is not a global singleton. `b` and `c` are the only global singletons.
+		region1 := makeRegion([]uint64{a, b}, []uint64{a, b}, 2)
+		region2 := makeRegion([]uint64{a, c}, []uint64{a, c}, 2)
+
+		root := NewReservoirRowSampleCollector(1, 1)
+		root.Base().FMSketches = []*FMSketch{NewFMSketch(1000)}
+		root.MergeCollector(region1)
+		root.MergeCollector(region2)
+
+		// The two regions stay separate instead of collapsing into one sketch.
+		require.Len(t, root.Base().RegionSketchSummaries, 2)
+		require.Equal(t, int64(4), root.Base().SketchSampleCount)
+
+		ndvSketches := make([]*FMSketch, 0, 2)
+		singletonSketches := make([]*FMSketch, 0, 2)
+		for _, region := range root.Base().RegionSketchSummaries {
+			ndvSketches = append(ndvSketches, FMSketchFromProto(region.NDVSketches[0]))
+			singletonSketches = append(singletonSketches, FMSketchFromProto(region.SingletonSketches[0]))
+		}
+		// Per-region keeps `a` out of the global singleton count (it appears in both
+		// regions' NDV sketches); only `b` and `c` remain.
+		require.Equal(t, uint64(2), EstimateGlobalSingletonBySketches(ndvSketches, singletonSketches))
+
+		// Contrast with the previous behavior: unioning the two regions into a single
+		// sketch over-counts the cross-region duplicate `a` as a global singleton.
+		unionNDV := newFMSketchFromHashValues(a, b, c)
+		unionSingleton := newFMSketchFromHashValues(a, b, c)
+		require.Equal(t, uint64(3),
+			EstimateGlobalSingletonBySketches([]*FMSketch{unionNDV}, []*FMSketch{unionSingleton}),
+			"a union of the regions over-counts the cross-region duplicate")
+
+		// A merged collector contributes its region summaries when merged again, so
+		// per-region granularity survives the second (worker -> root) merge level.
+		top := NewReservoirRowSampleCollector(1, 1)
+		top.Base().FMSketches = []*FMSketch{NewFMSketch(1000)}
+		top.MergeCollector(root)
+		require.Len(t, top.Base().RegionSketchSummaries, 2)
 	}
 }

--- a/pkg/store/copr/copr_test/coprocessor_test.go
+++ b/pkg/store/copr/copr_test/coprocessor_test.go
@@ -270,6 +270,26 @@ func TestBuildCopIteratorWithBatchStoreCopr(t *testing.T) {
 	require.Equal(t, len(tasks), 2)
 	require.Equal(t, len(tasks[0].ToPBBatchTasks()), 1)
 	require.Equal(t, len(tasks[1].ToPBBatchTasks()), 0)
+
+	// Analyze full-sampling requests do not carry DAG row-count hints, but can
+	// still use store-batch tasks because TiKV reduces successful analyze
+	// sub-results into the top-level response.
+	ranges = copr.BuildKeyRanges("a", "c", "d", "e", "h", "x", "y", "z")
+	req = &kv.Request{
+		Tp:             kv.ReqTypeAnalyze,
+		KeyRanges:      kv.NewNonPartitionedKeyRanges(ranges),
+		Concurrency:    15,
+		StoreBatchSize: 3,
+		KeepOrder:      true,
+		RequestSource: kv.RequestSource{
+			RequestSourceInternal: true,
+		},
+	}
+	it, errRes = copClient.BuildCopIterator(ctx, req, vars, opt)
+	require.Nil(t, errRes)
+	tasks = it.GetTasks()
+	require.Equal(t, len(tasks), 1)
+	require.Equal(t, len(tasks[0].ToPBBatchTasks()), 3)
 }
 
 type mockResourceGroupProvider struct {

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -644,7 +644,7 @@ func buildCopTasks(bo *Backoffer, ranges *KeyRanges, opt *buildCopTaskOpt) ([]*c
 	}
 
 	var builder taskBuilder
-	if req.StoreBatchSize > 0 && hints != nil {
+	if req.StoreBatchSize > 0 && (hints != nil || isAnalyzeStoreBatchRequest(req)) {
 		builder = newBatchTaskBuilder(bo, req, cache, req.ReplicaRead)
 	} else {
 		builder = newLegacyTaskBuilder(len(locs))
@@ -819,7 +819,7 @@ func (b *batchStoreTaskBuilder) handle(task *copTask) (err error) {
 		}
 	}()
 	// only batch small tasks for memory control.
-	if b.limit <= 0 || !isSmallTask(task) {
+	if b.limit <= 0 || (!isAnalyzeStoreBatchRequest(b.req) && !isSmallTask(task)) {
 		return nil
 	}
 	batchedTask, err := b.cache.BuildBatchTask(b.bo, b.req, task, b.replicaRead)
@@ -2321,6 +2321,9 @@ func (worker *copIteratorWorker) handleBatchCopResponse(bo *Backoffer, rpcCtx *t
 		}
 	}
 	batchResps := resp.GetBatchResponses()
+	if worker.req.Tp == kv.ReqTypeAnalyze && len(batchResps) == 0 {
+		return nil, nil, nil
+	}
 	batchRespList = make([]*copResponse, 0, len(batchResps))
 	for _, batchResp := range batchResps {
 		taskID := batchResp.GetTaskId()
@@ -2971,6 +2974,9 @@ func optRowHint(req *kv.Request) bool {
 }
 
 func checkStoreBatchCopr(req *kv.Request) bool {
+	if req.Tp == kv.ReqTypeAnalyze {
+		return isAnalyzeStoreBatchRequest(req)
+	}
 	if req.Tp != kv.ReqTypeDAG || req.StoreType != kv.TiKV {
 		return false
 	}
@@ -2988,4 +2994,14 @@ func checkStoreBatchCopr(req *kv.Request) bool {
 		return false
 	}
 	return true
+}
+
+func isAnalyzeStoreBatchRequest(req *kv.Request) bool {
+	if req.Tp != kv.ReqTypeAnalyze || req.StoreType != kv.TiKV {
+		return false
+	}
+	if req.ReplicaRead != kv.ReplicaReadLeader {
+		return false
+	}
+	return !req.Paging.Enable
 }

--- a/pkg/store/mockstore/unistore/cophandler/analyze.go
+++ b/pkg/store/mockstore/unistore/cophandler/analyze.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/badger/y"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -447,6 +448,12 @@ func handleAnalyzeFullSamplingReq(
 		colGroups = append(colGroups, colOffsets)
 	}
 	colReq := analyzeReq.ColReq
+	seed := time.Now().UnixNano()
+	failpoint.Inject("mockAnalyzeSamplingSeed", func(val failpoint.Value) {
+		if s, ok := val.(int); ok {
+			seed = int64(s)
+		}
+	})
 	/* #nosec G404 */
 	builder := &statistics.RowSampleBuilder{
 		Sc:              sctx.GetSessionVars().StmtCtx,
@@ -458,7 +465,7 @@ func handleAnalyzeFullSamplingReq(
 		MaxFMSketchSize: int(colReq.SketchSize),
 		SampleRate:      colReq.GetSampleRate(),
 		NDVSampleRate:   colReq.GetNdvRate(),
-		Rng:             rand.New(rand.NewSource(time.Now().UnixNano())),
+		Rng:             rand.New(rand.NewSource(seed)),
 	}
 	collector, err := builder.Collect()
 	if err != nil {

--- a/pkg/store/mockstore/unistore/cophandler/analyze.go
+++ b/pkg/store/mockstore/unistore/cophandler/analyze.go
@@ -457,7 +457,7 @@ func handleAnalyzeFullSamplingReq(
 		MaxSampleSize:   int(colReq.SampleSize),
 		MaxFMSketchSize: int(colReq.SketchSize),
 		SampleRate:      colReq.GetSampleRate(),
-		NDVSampleRate:   statistics.NDVSampleSkipRate,
+		NDVSampleRate:   colReq.GetNdvRate(),
 		Rng:             rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 	collector, err := builder.Collect()

--- a/pkg/store/mockstore/unistore/cophandler/analyze.go
+++ b/pkg/store/mockstore/unistore/cophandler/analyze.go
@@ -457,6 +457,7 @@ func handleAnalyzeFullSamplingReq(
 		MaxSampleSize:   int(colReq.SampleSize),
 		MaxFMSketchSize: int(colReq.SketchSize),
 		SampleRate:      colReq.GetSampleRate(),
+		NDVSampleRate:   statistics.NDVSampleSkipRate,
 		Rng:             rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 	collector, err := builder.Collect()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref pending

Problem Summary:

Analyze full sampling currently sends one coprocessor request per region. The FM sketches and singleton sketches from every region must stay alive until TiDB finishes NDV estimation, which increases retained memory as region count grows.

### What changed and how does it work?

This PR lets analyze full sampling use store-batch coprocessor requests when `tidb_store_batch_size` is enabled. The request builder forwards the session store batch size, the coprocessor client allows eligible TiKV analyze requests to batch regions, and successful reduced analyze responses are accepted as a single final response.

The PR is stacked on the existing row-sampler singleton-sketch branch.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

- Built patched TiDB with `make server`.
- Ran a local TiUP cluster with the patched TiDB and TiKV binaries.
- Verified batched analyze NDV cases with `tidb_store_batch_size=3`.
- Verified trace request count dropped from 12 Cop RPCs to 3 Cop RPCs for the same analyze workload.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Allow analyze full sampling requests to use store-batch coprocessor requests to reduce retained per-region sketch results.
```
