### PR TITLE
*: several ddl enhancement for mv

### DIFF
--- a/pkg/ddl/bdr_test.go
+++ b/pkg/ddl/bdr_test.go
@@ -220,6 +220,16 @@ func TestDeniedByBDR(t *testing.T) {
 		{ast.BDRRoleSecondary, model.ActionModifyTableComment, true},
 		{ast.BDRRoleNone, model.ActionModifyTableComment, false},
 
+		// Roles for ActionAlterMaterializedViewRefresh
+		{ast.BDRRolePrimary, model.ActionAlterMaterializedViewRefresh, false},
+		{ast.BDRRoleSecondary, model.ActionAlterMaterializedViewRefresh, true},
+		{ast.BDRRoleNone, model.ActionAlterMaterializedViewRefresh, false},
+
+		// Roles for ActionAlterMaterializedViewLogPurge
+		{ast.BDRRolePrimary, model.ActionAlterMaterializedViewLogPurge, false},
+		{ast.BDRRoleSecondary, model.ActionAlterMaterializedViewLogPurge, true},
+		{ast.BDRRoleNone, model.ActionAlterMaterializedViewLogPurge, false},
+
 		// Roles for ActionRenameIndex
 		{ast.BDRRolePrimary, model.ActionRenameIndex, false},
 		{ast.BDRRoleSecondary, model.ActionRenameIndex, true},

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1142,22 +1142,21 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	var purgeNext string
 	if s.Purge != nil {
 		if s.Purge.Immediate {
-			purgeMethod = "IMMEDIATE"
-		} else {
-			purgeMethod = "DEFERRED"
-			if s.Purge.StartWith != nil {
-				purgeStartWith, err = BuildAndValidateMViewScheduleExpr(ctx, s.Purge.StartWith, "PURGE START WITH")
-				if err != nil {
-					return err
-				}
-			}
-			if s.Purge.Next == nil {
-				return errors.New("PURGE NEXT is required unless PURGE IMMEDIATE is specified")
-			}
-			purgeNext, err = BuildAndValidateMViewScheduleExpr(ctx, s.Purge.Next, "PURGE NEXT")
+			return errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
+		}
+		purgeMethod = "DEFERRED"
+		if s.Purge.StartWith != nil {
+			purgeStartWith, err = BuildAndValidateMViewScheduleExpr(ctx, s.Purge.StartWith, "PURGE START WITH")
 			if err != nil {
 				return err
 			}
+		}
+		if s.Purge.Next == nil {
+			return errors.New("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
+		}
+		purgeNext, err = BuildAndValidateMViewScheduleExpr(ctx, s.Purge.Next, "PURGE NEXT")
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1868,6 +1868,134 @@ func isAlterTiFlashReplica(specs []*ast.AlterTableSpec) bool {
 	return len(specs) == 1 && specs[0].Tp == ast.AlterTableSetTiFlashReplica
 }
 
+func isAlterTableOnlyIndexOperations(specs []*ast.AlterTableSpec) bool {
+	if len(specs) == 0 {
+		return false
+	}
+	for _, spec := range specs {
+		switch spec.Tp {
+		case ast.AlterTableDropIndex, ast.AlterTableRenameIndex, ast.AlterTableIndexInvisible:
+		case ast.AlterTableAddConstraint:
+			if spec.Constraint == nil {
+				return false
+			}
+			switch spec.Constraint.Tp {
+			case ast.ConstraintKey, ast.ConstraintIndex, ast.ConstraintUniq, ast.ConstraintUniqKey, ast.ConstraintUniqIndex:
+			default:
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func collectAlterTableSpecAffectedColumns(spec *ast.AlterTableSpec) []string {
+	cols := make([]string, 0, 2)
+	appendColumnName := func(col *ast.ColumnName) {
+		if col != nil {
+			cols = append(cols, col.Name.L)
+		}
+	}
+	appendColumnDefName := func(colDef *ast.ColumnDef) {
+		if colDef != nil && colDef.Name != nil {
+			cols = append(cols, colDef.Name.Name.L)
+		}
+	}
+
+	switch spec.Tp {
+	case ast.AlterTableDropColumn, ast.AlterTableChangeColumn, ast.AlterTableRenameColumn:
+		appendColumnName(spec.OldColumnName)
+	}
+
+	switch spec.Tp {
+	case ast.AlterTableModifyColumn, ast.AlterTableChangeColumn, ast.AlterTableAlterColumn:
+		if len(spec.NewColumns) > 0 {
+			appendColumnDefName(spec.NewColumns[0])
+		}
+	case ast.AlterTableRenameColumn:
+		appendColumnName(spec.NewColumnName)
+	}
+
+	return cols
+}
+
+func checkAlterTableBaseTableMLogColumnConstraints(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	tblInfo *model.TableInfo,
+	specs []*ast.AlterTableSpec,
+	op string,
+) error {
+	if tblInfo.MaterializedViewBase == nil || tblInfo.MaterializedViewBase.MLogID == 0 {
+		return nil
+	}
+
+	mlogTbl, ok := is.TableByID(ctx, tblInfo.MaterializedViewBase.MLogID)
+	if !ok || mlogTbl.Meta().MaterializedViewLog == nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf("%s on base table with invalid materialized view log metadata", op),
+		)
+	}
+
+	mlogCols := make(map[string]struct{}, len(mlogTbl.Meta().MaterializedViewLog.Columns))
+	for _, col := range mlogTbl.Meta().MaterializedViewLog.Columns {
+		mlogCols[col.L] = struct{}{}
+	}
+
+	for _, spec := range specs {
+		// CONVERT TO charset/collation rewrites all columns, including logged columns.
+		if spec.Tp == ast.AlterTableOption && NeedToOverwriteColCharset(spec.Options) && len(mlogCols) > 0 {
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				fmt.Sprintf("%s on base table columns referenced by materialized view log", op),
+			)
+		}
+		for _, colName := range collectAlterTableSpecAffectedColumns(spec) {
+			if _, ok := mlogCols[colName]; !ok {
+				continue
+			}
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				fmt.Sprintf("%s on base table column %s referenced by materialized view log", op, colName),
+			)
+		}
+	}
+	return nil
+}
+
+func checkAlterTableMaterializedViewConstraints(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	tblInfo *model.TableInfo,
+	specs []*ast.AlterTableSpec,
+	op string,
+) error {
+	if tblInfo.MaterializedViewLog != nil {
+		// MATERIALIZED VIEW LOG table only allows ALTER TABLE ... SET TIFLASH REPLICA for now.
+		if isAlterTiFlashReplica(specs) {
+			return nil
+		}
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on materialized view log table", op))
+	}
+
+	if tblInfo.MaterializedView != nil {
+		// MATERIALIZED VIEW table allows TiFlash replica and index-related ALTER TABLE operations.
+		if isAlterTiFlashReplica(specs) || isAlterTableOnlyIndexOperations(specs) {
+			return nil
+		}
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on materialized view table", op))
+	}
+
+	return checkAlterTableBaseTableMLogColumnConstraints(ctx, is, tblInfo, specs, op)
+}
+
+func checkIndexOperationMaterializedViewConstraints(tblInfo *model.TableInfo, op string) error {
+	if tblInfo.MaterializedViewLog != nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on materialized view log table", op))
+	}
+	return nil
+}
+
 func (e *executor) AlterTable(ctx context.Context, sctx sessionctx.Context, stmt *ast.AlterTableStmt) (err error) {
 	return e.alterTable(ctx, sctx, stmt, false)
 }
@@ -1888,12 +2016,8 @@ func (e *executor) alterTable(ctx context.Context, sctx sessionctx.Context, stmt
 		return dbterror.ErrWrongObject.GenWithStackByArgs(ident.Schema, ident.Name, "BASE TABLE")
 	}
 	if !allowMaterializedViewRelated {
-		// ALTER TABLE ... SET TIFLASH REPLICA only changes replica placement metadata.
-		// It is safe for both MV tables and base tables with MV dependencies.
-		if !isAlterTiFlashReplica(validSpecs) {
-			if err := checkTableMaterializedViewConstraints(tb.Meta(), "ALTER TABLE"); err != nil {
-				return errors.Trace(err)
-			}
+		if err := checkAlterTableMaterializedViewConstraints(ctx, is, tb.Meta(), validSpecs, "ALTER TABLE"); err != nil {
+			return errors.Trace(err)
 		}
 	}
 	if tb.Meta().TableCacheStatusType != model.TableCacheStatusDisable {
@@ -5091,7 +5215,7 @@ func (e *executor) createIndex(ctx sessionctx.Context, ti ast.Ident, keyType ast
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := checkTableMaterializedViewConstraintsAllowMVTable(t.Meta(), "CREATE INDEX"); err != nil {
+	if err := checkIndexOperationMaterializedViewConstraints(t.Meta(), "CREATE INDEX"); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -5543,7 +5667,7 @@ func (e *executor) dropIndex(ctx sessionctx.Context, ti ast.Ident, indexName pmo
 	if err != nil {
 		return errors.Trace(infoschema.ErrTableNotExists.GenWithStackByArgs(ti.Schema, ti.Name))
 	}
-	if err := checkTableMaterializedViewConstraintsAllowMVTable(t.Meta(), "DROP INDEX"); err != nil {
+	if err := checkIndexOperationMaterializedViewConstraints(t.Meta(), "DROP INDEX"); err != nil {
 		return errors.Trace(err)
 	}
 	if t.Meta().TableCacheStatusType != model.TableCacheStatusDisable {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1996,6 +1996,63 @@ func checkIndexOperationMaterializedViewConstraints(tblInfo *model.TableInfo, op
 	return nil
 }
 
+func checkBaseTableDependentMViewMinMaxIndexConstraints(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	sctx sessionctx.Context,
+	schemaName pmodel.CIStr,
+	baseTableInfo *model.TableInfo,
+	indexName pmodel.CIStr,
+	op string,
+) error {
+	if baseTableInfo.MaterializedViewBase == nil || len(baseTableInfo.MaterializedViewBase.MViewIDs) == 0 {
+		return nil
+	}
+	mlogTbl, ok := is.TableByID(ctx, baseTableInfo.MaterializedViewBase.MLogID)
+	if !ok || mlogTbl.Meta().MaterializedViewLog == nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf("%s on base table with invalid materialized view log metadata", op),
+		)
+	}
+	baseTableName := &ast.TableName{Schema: schemaName, Name: baseTableInfo.Name}
+
+	for _, mvID := range baseTableInfo.MaterializedViewBase.MViewIDs {
+		mvTbl, ok := is.TableByID(ctx, mvID)
+		if !ok || mvTbl.Meta().MaterializedView == nil {
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				fmt.Sprintf("%s on base table with invalid dependent materialized view metadata", op),
+			)
+		}
+		queryAnalysis, err := analyzeStoredMaterializedViewQuery(
+			sctx,
+			baseTableName,
+			baseTableInfo,
+			mlogTbl.Meta().MaterializedViewLog.Columns,
+			mvTbl.Meta().MaterializedView.SQLContent,
+		)
+		if err != nil {
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				fmt.Sprintf("%s on base table with invalid dependent materialized view %s metadata", op, mvTbl.Meta().Name.O),
+			)
+		}
+		if !queryAnalysis.HasMinOrMax {
+			continue
+		}
+		if hasVisiblePublicIndexWithPrefixCoveringGroupByColumns(baseTableInfo, queryAnalysis.GroupByCols, indexName.L) {
+			continue
+		}
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf(
+				"%s on base table index %s required by materialized view %s for MIN/MAX fast refresh",
+				op,
+				indexName.O,
+				mvTbl.Meta().Name.O,
+			),
+		)
+	}
+	return nil
+}
+
 func (e *executor) AlterTable(ctx context.Context, sctx sessionctx.Context, stmt *ast.AlterTableStmt) (err error) {
 	return e.alterTable(ctx, sctx, stmt, false)
 }
@@ -5704,6 +5761,19 @@ func (e *executor) dropIndex(ctx sessionctx.Context, ti ast.Ident, indexName pmo
 		}
 		return err
 	}
+	if !isPK {
+		if err := checkBaseTableDependentMViewMinMaxIndexConstraints(
+			context.Background(),
+			is,
+			ctx,
+			schema.Name,
+			t.Meta(),
+			indexName,
+			"DROP INDEX",
+		); err != nil {
+			return errors.Trace(err)
+		}
+	}
 
 	err = checkIndexNeededInForeignKey(is, schema.Name.L, t.Meta(), indexInfo)
 	if err != nil {
@@ -6256,6 +6326,19 @@ func (e *executor) AlterIndexVisibility(ctx sessionctx.Context, ident ast.Ident,
 	}
 	if skip {
 		return nil
+	}
+	if invisible {
+		if err := checkBaseTableDependentMViewMinMaxIndexConstraints(
+			context.Background(),
+			e.infoCache.GetLatest(),
+			ctx,
+			schema.Name,
+			tb.Meta(),
+			indexName,
+			"ALTER INDEX INVISIBLE",
+		); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	job := &model.Job{

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -2005,6 +2005,30 @@ func checkBaseTableDependentMViewMinMaxIndexConstraints(
 	indexName pmodel.CIStr,
 	op string,
 ) error {
+	return checkBaseTableDependentMViewMinMaxIndexConstraintsWithEffectiveTable(
+		ctx,
+		is,
+		sctx,
+		schemaName,
+		baseTableInfo,
+		baseTableInfo,
+		indexName,
+		indexName,
+		op,
+	)
+}
+
+func checkBaseTableDependentMViewMinMaxIndexConstraintsWithEffectiveTable(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	sctx sessionctx.Context,
+	schemaName pmodel.CIStr,
+	baseTableInfo *model.TableInfo,
+	effectiveBaseTableInfo *model.TableInfo,
+	excludedIndexName pmodel.CIStr,
+	indexNameForErr pmodel.CIStr,
+	op string,
+) error {
 	if baseTableInfo.MaterializedViewBase == nil || len(baseTableInfo.MaterializedViewBase.MViewIDs) == 0 {
 		return nil
 	}
@@ -2038,14 +2062,14 @@ func checkBaseTableDependentMViewMinMaxIndexConstraints(
 		if !queryAnalysis.HasMinOrMax {
 			continue
 		}
-		if hasVisiblePublicIndexWithPrefixCoveringGroupByColumns(baseTableInfo, queryAnalysis.GroupByCols, indexName.L) {
+		if hasVisiblePublicIndexWithPrefixCoveringGroupByColumns(effectiveBaseTableInfo, queryAnalysis.GroupByCols, excludedIndexName.L) {
 			continue
 		}
 		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
 			fmt.Sprintf(
 				"%s on base table index %s required by materialized view %s for MIN/MAX fast refresh",
 				op,
-				indexName.O,
+				indexNameForErr.O,
 				mvTbl.Meta().Name.O,
 			),
 		)
@@ -2387,7 +2411,7 @@ func (e *executor) multiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info 
 	}
 	job.AddSessionVars(variable.TiDBEnableStatsUpdateDuringDDL, getEnableDDLAnalyze(ctx))
 	job.AddSessionVars(variable.TiDBAnalyzeVersion, getAnalyzeVersion(ctx))
-	err = checkMultiSchemaInfo(info, t)
+	err = checkMultiSchemaInfo(info, t, e.infoCache.GetLatest(), ctx, schema.Name)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -5761,7 +5785,7 @@ func (e *executor) dropIndex(ctx sessionctx.Context, ti ast.Ident, indexName pmo
 		}
 		return err
 	}
-	if !isPK {
+	if ctx.GetSessionVars().StmtCtx.MultiSchemaInfo == nil {
 		if err := checkBaseTableDependentMViewMinMaxIndexConstraints(
 			context.Background(),
 			is,
@@ -6328,16 +6352,18 @@ func (e *executor) AlterIndexVisibility(ctx sessionctx.Context, ident ast.Ident,
 		return nil
 	}
 	if invisible {
-		if err := checkBaseTableDependentMViewMinMaxIndexConstraints(
-			context.Background(),
-			e.infoCache.GetLatest(),
-			ctx,
-			schema.Name,
-			tb.Meta(),
-			indexName,
-			"ALTER INDEX INVISIBLE",
-		); err != nil {
-			return errors.Trace(err)
+		if ctx.GetSessionVars().StmtCtx.MultiSchemaInfo == nil {
+			if err := checkBaseTableDependentMViewMinMaxIndexConstraints(
+				context.Background(),
+				e.infoCache.GetLatest(),
+				ctx,
+				schema.Name,
+				tb.Meta(),
+				indexName,
+				"ALTER INDEX INVISIBLE",
+			); err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1142,7 +1142,7 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	var purgeNext string
 	if s.Purge != nil {
 		if s.Purge.Immediate {
-			return errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStack("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
 		}
 		purgeMethod = "DEFERRED"
 		if s.Purge.StartWith != nil {
@@ -1152,7 +1152,7 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 			}
 		}
 		if s.Purge.Next == nil {
-			return errors.New("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStack("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
 		}
 		purgeNext, err = BuildAndValidateMViewScheduleExpr(ctx, s.Purge.Next, "PURGE NEXT")
 		if err != nil {
@@ -5208,6 +5208,13 @@ func (e *executor) createIndex(ctx sessionctx.Context, ti ast.Ident, keyType ast
 		return dbterror.ErrUnsupportedIndexType.GenWithStack("FULLTEXT and SPATIAL index is not supported")
 	}
 	if keyType == ast.IndexKeyTypeVector {
+		_, t, err := e.getSchemaAndTableByIdent(ti)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if err := checkIndexOperationMaterializedViewConstraints(t.Meta(), "CREATE INDEX"); err != nil {
+			return errors.Trace(err)
+		}
 		return e.createVectorIndex(ctx, ti, indexName, indexPartSpecifications, indexOption, ifNotExists)
 	}
 	unique := keyType == ast.IndexKeyTypeUnique

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -555,7 +555,7 @@ func validateAlterIndexVisibility(ctx sessionctx.Context, indexName pmodel.CIStr
 }
 
 func onAlterIndexVisibility(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
-	tblInfo, from, invisible, err := checkAlterIndexVisibility(jobCtx.metaMut, job)
+	tblInfo, from, invisible, err := checkAlterIndexVisibility(jobCtx.infoCache, jobCtx.metaMut, job)
 	if err != nil || tblInfo == nil {
 		return ver, errors.Trace(err)
 	}
@@ -1975,6 +1975,66 @@ func removeIndexInfo(tblInfo *model.TableInfo, idxInfo *model.IndexInfo) {
 	tblInfo.Indices = append(tblInfo.Indices[:offset], tblInfo.Indices[offset+1:]...)
 }
 
+func buildEffectiveBaseTableInfoForDropIndexMViewMinMaxConstraints(
+	baseTableInfo *model.TableInfo,
+	indexInfos []*model.IndexInfo,
+	dropPrimaryKey bool,
+) *model.TableInfo {
+	effectiveBaseTableInfo := baseTableInfo.Clone()
+	for _, indexInfo := range indexInfos {
+		removeIndexInfo(effectiveBaseTableInfo, indexInfo)
+	}
+	if dropPrimaryKey {
+		effectiveBaseTableInfo.PKIsHandle = false
+	}
+	return effectiveBaseTableInfo
+}
+
+func buildEffectiveBaseTableInfoForAlterIndexVisibilityMViewMinMaxConstraints(
+	baseTableInfo *model.TableInfo,
+	indexName pmodel.CIStr,
+	invisible bool,
+) *model.TableInfo {
+	effectiveBaseTableInfo := baseTableInfo.Clone()
+	setIndexVisibility(effectiveBaseTableInfo, indexName, invisible)
+	return effectiveBaseTableInfo
+}
+
+func checkBaseTableDependentMViewMinMaxIndexConstraintsInOwner(
+	infoCache *infoschema.InfoCache,
+	job *model.Job,
+	baseTableInfo *model.TableInfo,
+	effectiveBaseTableInfo *model.TableInfo,
+	indexName pmodel.CIStr,
+	op string,
+) error {
+	// Multi-schema changes already validate dependent MV MIN/MAX constraints
+	// against the final effective table shape. Re-checking each sub-job here
+	// would validate an intermediate owner state and incorrectly reject
+	// drop+replace index combinations within the same multi-schema DDL.
+	if job.MultiSchemaInfo != nil {
+		return nil
+	}
+	if !hasMaterializedViewDependsOnBaseTable(baseTableInfo) {
+		return nil
+	}
+	if err := checkBaseTableDependentMViewMinMaxIndexConstraintsWithEffectiveTable(
+		context.Background(),
+		infoCache.GetLatest(),
+		nil,
+		pmodel.NewCIStr(job.SchemaName),
+		baseTableInfo,
+		effectiveBaseTableInfo,
+		pmodel.CIStr{},
+		indexName,
+		op,
+	); err != nil {
+		job.State = model.JobStateCancelled
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 func checkDropIndex(infoCache *infoschema.InfoCache, t *meta.Mutator, job *model.Job) (*model.TableInfo, []*model.IndexInfo, bool /* ifExists */, error) {
 	schemaID := job.SchemaID
 	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, schemaID)
@@ -2007,6 +2067,23 @@ func checkDropIndex(infoCache *infoschema.InfoCache, t *meta.Mutator, job *model
 			return nil, nil, false, errors.Trace(err)
 		}
 		indexInfos = append(indexInfos, indexInfo)
+	}
+	effectiveBaseTableInfo := buildEffectiveBaseTableInfoForDropIndexMViewMinMaxConstraints(
+		tblInfo,
+		indexInfos,
+		job.Type == model.ActionDropPrimaryKey,
+	)
+	for _, idxArg := range args.IndexArgs {
+		if err := checkBaseTableDependentMViewMinMaxIndexConstraintsInOwner(
+			infoCache,
+			job,
+			tblInfo,
+			effectiveBaseTableInfo,
+			idxArg.IndexName,
+			"DROP INDEX",
+		); err != nil {
+			return nil, nil, false, err
+		}
 	}
 	return tblInfo, indexInfos, false, nil
 }
@@ -2062,7 +2139,7 @@ func checkRenameIndex(t *meta.Mutator, job *model.Job) (*model.TableInfo, pmodel
 	return tblInfo, from, to, errors.Trace(err)
 }
 
-func checkAlterIndexVisibility(t *meta.Mutator, job *model.Job) (*model.TableInfo, pmodel.CIStr, bool, error) {
+func checkAlterIndexVisibility(infoCache *infoschema.InfoCache, t *meta.Mutator, job *model.Job) (*model.TableInfo, pmodel.CIStr, bool, error) {
 	var (
 		indexName pmodel.CIStr
 		invisible bool
@@ -2089,6 +2166,19 @@ func checkAlterIndexVisibility(t *meta.Mutator, job *model.Job) (*model.TableInf
 	if skip {
 		job.State = model.JobStateDone
 		return nil, indexName, invisible, nil
+	}
+	if invisible {
+		effectiveBaseTableInfo := buildEffectiveBaseTableInfoForAlterIndexVisibilityMViewMinMaxConstraints(tblInfo, indexName, true)
+		if err := checkBaseTableDependentMViewMinMaxIndexConstraintsInOwner(
+			infoCache,
+			job,
+			tblInfo,
+			effectiveBaseTableInfo,
+			indexName,
+			"ALTER INDEX INVISIBLE",
+		); err != nil {
+			return nil, indexName, invisible, err
+		}
 	}
 	return tblInfo, indexName, invisible, nil
 }

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -554,8 +554,8 @@ func validateAlterIndexVisibility(ctx sessionctx.Context, indexName pmodel.CIStr
 	return false, nil
 }
 
-func onAlterIndexVisibility(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
-	tblInfo, from, invisible, err := checkAlterIndexVisibility(jobCtx.infoCache, jobCtx.metaMut, job)
+func onAlterIndexVisibility(sctx sessionctx.Context, jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+	tblInfo, from, invisible, err := checkAlterIndexVisibility(sctx, jobCtx.infoCache, jobCtx.metaMut, job)
 	if err != nil || tblInfo == nil {
 		return ver, errors.Trace(err)
 	}
@@ -729,7 +729,7 @@ func checkAndBuildIndexInfo(
 func (w *worker) onCreateVectorIndex(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	// Handle the rolling back job.
 	if job.IsRollingback() {
-		ver, err = onDropIndex(jobCtx, job)
+		ver, err = onDropIndex(w.sess.Session(), jobCtx, job)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -957,7 +957,7 @@ func (w *worker) checkVectorIndexProcessOnce(jobCtx *jobContext, tbl table.Table
 func (w *worker) onCreateIndex(jobCtx *jobContext, job *model.Job, isPK bool) (ver int64, err error) {
 	// Handle the rolling back job.
 	if job.IsRollingback() {
-		ver, err = onDropIndex(jobCtx, job)
+		ver, err = onDropIndex(w.sess.Session(), jobCtx, job)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -1808,8 +1808,8 @@ func runReorgJobAndHandleErr(
 	return true, ver, nil
 }
 
-func onDropIndex(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
-	tblInfo, allIndexInfos, ifExists, err := checkDropIndex(jobCtx.infoCache, jobCtx.metaMut, job)
+func onDropIndex(sctx sessionctx.Context, jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+	tblInfo, allIndexInfos, ifExists, err := checkDropIndex(sctx, jobCtx.infoCache, jobCtx.metaMut, job)
 	if err != nil {
 		if ifExists && dbterror.ErrCantDropFieldOrKey.Equal(err) {
 			job.Warning = toTError(err)
@@ -2001,6 +2001,7 @@ func buildEffectiveBaseTableInfoForAlterIndexVisibilityMViewMinMaxConstraints(
 }
 
 func checkBaseTableDependentMViewMinMaxIndexConstraintsInOwner(
+	sctx sessionctx.Context,
 	infoCache *infoschema.InfoCache,
 	job *model.Job,
 	baseTableInfo *model.TableInfo,
@@ -2021,7 +2022,7 @@ func checkBaseTableDependentMViewMinMaxIndexConstraintsInOwner(
 	if err := checkBaseTableDependentMViewMinMaxIndexConstraintsWithEffectiveTable(
 		context.Background(),
 		infoCache.GetLatest(),
-		nil,
+		sctx,
 		pmodel.NewCIStr(job.SchemaName),
 		baseTableInfo,
 		effectiveBaseTableInfo,
@@ -2035,7 +2036,7 @@ func checkBaseTableDependentMViewMinMaxIndexConstraintsInOwner(
 	return nil
 }
 
-func checkDropIndex(infoCache *infoschema.InfoCache, t *meta.Mutator, job *model.Job) (*model.TableInfo, []*model.IndexInfo, bool /* ifExists */, error) {
+func checkDropIndex(sctx sessionctx.Context, infoCache *infoschema.InfoCache, t *meta.Mutator, job *model.Job) (*model.TableInfo, []*model.IndexInfo, bool /* ifExists */, error) {
 	schemaID := job.SchemaID
 	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, schemaID)
 	if err != nil {
@@ -2075,6 +2076,7 @@ func checkDropIndex(infoCache *infoschema.InfoCache, t *meta.Mutator, job *model
 	)
 	for _, idxArg := range args.IndexArgs {
 		if err := checkBaseTableDependentMViewMinMaxIndexConstraintsInOwner(
+			sctx,
 			infoCache,
 			job,
 			tblInfo,
@@ -2139,7 +2141,7 @@ func checkRenameIndex(t *meta.Mutator, job *model.Job) (*model.TableInfo, pmodel
 	return tblInfo, from, to, errors.Trace(err)
 }
 
-func checkAlterIndexVisibility(infoCache *infoschema.InfoCache, t *meta.Mutator, job *model.Job) (*model.TableInfo, pmodel.CIStr, bool, error) {
+func checkAlterIndexVisibility(sctx sessionctx.Context, infoCache *infoschema.InfoCache, t *meta.Mutator, job *model.Job) (*model.TableInfo, pmodel.CIStr, bool, error) {
 	var (
 		indexName pmodel.CIStr
 		invisible bool
@@ -2170,6 +2172,7 @@ func checkAlterIndexVisibility(infoCache *infoschema.InfoCache, t *meta.Mutator,
 	if invisible {
 		effectiveBaseTableInfo := buildEffectiveBaseTableInfoForAlterIndexVisibilityMViewMinMaxConstraints(tblInfo, indexName, true)
 		if err := checkBaseTableDependentMViewMinMaxIndexConstraintsInOwner(
+			sctx,
 			infoCache,
 			job,
 			tblInfo,

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -1004,6 +1004,10 @@ func (w *worker) runOneJobStep(
 		ver, err = w.onShardRowID(jobCtx, job)
 	case model.ActionModifyTableComment:
 		ver, err = onModifyTableComment(jobCtx, job)
+	case model.ActionAlterMaterializedViewRefresh:
+		ver, err = onAlterMaterializedViewRefresh(jobCtx, job)
+	case model.ActionAlterMaterializedViewLogPurge:
+		ver, err = onAlterMaterializedViewLogPurge(jobCtx, job)
 	case model.ActionModifyTableAutoIDCache:
 		ver, err = onModifyTableAutoIDCache(jobCtx, job)
 	case model.ActionAddTablePartition:

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -985,7 +985,7 @@ func (w *worker) runOneJobStep(
 	case model.ActionAddVectorIndex:
 		ver, err = w.onCreateVectorIndex(jobCtx, job)
 	case model.ActionDropIndex, model.ActionDropPrimaryKey:
-		ver, err = onDropIndex(jobCtx, job)
+		ver, err = onDropIndex(w.sess.Session(), jobCtx, job)
 	case model.ActionRenameIndex:
 		ver, err = onRenameIndex(jobCtx, job)
 	case model.ActionAddForeignKey:
@@ -1027,7 +1027,7 @@ func (w *worker) runOneJobStep(
 	case model.ActionCreateSequence:
 		ver, err = onCreateSequence(jobCtx, job)
 	case model.ActionAlterIndexVisibility:
-		ver, err = onAlterIndexVisibility(jobCtx, job)
+		ver, err = onAlterIndexVisibility(w.sess.Session(), jobCtx, job)
 	case model.ActionAlterSequence:
 		ver, err = onAlterSequence(jobCtx, job)
 	case model.ActionRenameTables:

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/format"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
@@ -93,7 +94,7 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 	}
 
 	// Validate Stage-1 query contract and ensure MV LOG columns cover query references.
-	groupByInfos, err := validateCreateMaterializedViewQuery(
+	queryAnalysis, err := validateCreateMaterializedViewQuery(
 		ctx,
 		baseTableName,
 		baseTable.Meta(),
@@ -103,6 +104,7 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 	if err != nil {
 		return err
 	}
+	groupByInfos := queryAnalysis.GroupByInfos
 
 	selectSQL, err := restoreNodeToCanonicalSQL(s.Select)
 	if err != nil {
@@ -707,13 +709,19 @@ type mviewGroupByInfo struct {
 	NotNull   bool
 }
 
+type mviewQueryAnalysis struct {
+	GroupByInfos []mviewGroupByInfo
+	GroupByCols  []string
+	HasMinOrMax  bool
+}
+
 func validateCreateMaterializedViewQuery(
 	sctx sessionctx.Context,
 	baseTableName *ast.TableName,
 	baseTableInfo *model.TableInfo,
 	mlogColumns []pmodel.CIStr,
 	selectNode ast.ResultSetNode,
-) (groupByInfos []mviewGroupByInfo, _ error) {
+) (*mviewQueryAnalysis, error) {
 	sel, ok := selectNode.(*ast.SelectStmt)
 	if !ok {
 		return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStack("CREATE MATERIALIZED VIEW only supports SELECT statement")
@@ -881,7 +889,7 @@ func validateCreateMaterializedViewQuery(
 		return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStack("CREATE MATERIALIZED VIEW must contain count(*)/count(1)")
 	}
 
-	groupByInfos = make([]mviewGroupByInfo, 0, len(sel.GroupBy.Items))
+	groupByInfos := make([]mviewGroupByInfo, 0, len(sel.GroupBy.Items))
 	for _, item := range sel.GroupBy.Items {
 		colExpr := item.Expr.(*ast.ColumnNameExpr)
 		colName, err := resolveMViewColumnName(colExpr.Name, baseTableName, fromAlias, baseColMap)
@@ -905,7 +913,11 @@ func validateCreateMaterializedViewQuery(
 		}
 	}
 
-	return groupByInfos, nil
+	return &mviewQueryAnalysis{
+		GroupByInfos: groupByInfos,
+		GroupByCols:  groupByCols,
+		HasMinOrMax:  hasMinOrMax,
+	}, nil
 }
 
 func extractSingleTableNameFromSelect(sel *ast.SelectStmt) (*ast.TableName, error) {
@@ -988,6 +1000,23 @@ func isCountStarOrOne(arg ast.ExprNode) bool {
 }
 
 func hasIndexWithPrefixCoveringGroupByColumns(baseTableInfo *model.TableInfo, groupByCols []string) bool {
+	return hasPrefixCoveringGroupByColumns(baseTableInfo, groupByCols, "", false)
+}
+
+func hasVisiblePublicIndexWithPrefixCoveringGroupByColumns(
+	baseTableInfo *model.TableInfo,
+	groupByCols []string,
+	excludedIndexName string,
+) bool {
+	return hasPrefixCoveringGroupByColumns(baseTableInfo, groupByCols, excludedIndexName, true)
+}
+
+func hasPrefixCoveringGroupByColumns(
+	baseTableInfo *model.TableInfo,
+	groupByCols []string,
+	excludedIndexName string,
+	requireVisiblePublic bool,
+) bool {
 	prefixLen := len(groupByCols)
 	if prefixLen == 0 {
 		return false
@@ -997,10 +1026,9 @@ func hasIndexWithPrefixCoveringGroupByColumns(baseTableInfo *model.TableInfo, gr
 		groupBySet[col] = struct{}{}
 	}
 
-	if baseTableInfo.PKIsHandle && prefixLen == 1 {
+	if baseTableInfo.PKIsHandle && prefixLen == 1 && excludedIndexName != strings.ToLower(mysql.PrimaryKeyName) {
 		if pkCol := baseTableInfo.GetPkColInfo(); pkCol != nil {
-			_, ok := groupBySet[pkCol.Name.L]
-			if ok {
+			if _, ok := groupBySet[pkCol.Name.L]; ok {
 				return true
 			}
 		}
@@ -1008,6 +1036,12 @@ func hasIndexWithPrefixCoveringGroupByColumns(baseTableInfo *model.TableInfo, gr
 
 	for _, idx := range baseTableInfo.Indices {
 		if idx == nil || len(idx.Columns) < prefixLen {
+			continue
+		}
+		if requireVisiblePublic && (idx.State != model.StatePublic || idx.Invisible) {
+			continue
+		}
+		if excludedIndexName != "" && idx.Name.L == excludedIndexName {
 			continue
 		}
 		matched := make(map[string]struct{}, prefixLen)
@@ -1034,6 +1068,30 @@ func hasIndexWithPrefixCoveringGroupByColumns(baseTableInfo *model.TableInfo, gr
 		}
 	}
 	return false
+}
+
+func analyzeStoredMaterializedViewQuery(
+	sctx sessionctx.Context,
+	baseTableName *ast.TableName,
+	baseTableInfo *model.TableInfo,
+	mlogColumns []pmodel.CIStr,
+	sql string,
+) (*mviewQueryAnalysis, error) {
+	charset, collation := "", ""
+	p := parser.New()
+	if sctx != nil && sctx.GetSessionVars() != nil {
+		charset, collation = sctx.GetSessionVars().GetCharsetInfo()
+		p.SetParserConfig(sctx.GetSessionVars().BuildParserConfig())
+	}
+	stmt, err := p.ParseOneStmt(sql, charset, collation)
+	if err != nil {
+		return nil, err
+	}
+	sel, ok := stmt.(*ast.SelectStmt)
+	if !ok {
+		return nil, errors.Errorf("expected select statement, got %T", stmt)
+	}
+	return validateCreateMaterializedViewQuery(sctx, baseTableName, baseTableInfo, mlogColumns, sel)
 }
 
 func hasMaterializedViewDependsOnBaseTable(baseTableInfo *model.TableInfo) bool {

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -903,7 +903,7 @@ func validateCreateMaterializedViewQuery(
 		groupByInfos = append(groupByInfos, mviewGroupByInfo{SelectIdx: idx, NotNull: groupByNotNull[colName]})
 	}
 
-	if hasMinOrMax && !hasIndexWithPrefixCoveringGroupByColumns(baseTableInfo, groupByCols) {
+	if hasMinOrMax && !hasVisiblePublicIndexWithPrefixCoveringGroupByColumns(baseTableInfo, groupByCols, "") {
 		return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStack("CREATE MATERIALIZED VIEW with MIN/MAX requires base table index whose leading columns cover all GROUP BY columns")
 	}
 

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -15,6 +15,9 @@
 package ddl
 
 import (
+	"context"
+
+	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -405,7 +408,151 @@ func checkOperateDropIndexUseByForeignKey(info *model.MultiSchemaInfo, t table.T
 	return nil
 }
 
-func checkMultiSchemaInfo(info *model.MultiSchemaInfo, t table.Table) error {
+// buildEffectiveBaseTableInfoForMViewMinMaxIndexConstraints materializes the
+// post-DDL index view for multi-schema validation. We only need the fields that
+// affect MIN/MAX fast refresh index coverage checks.
+func buildEffectiveBaseTableInfoForMViewMinMaxIndexConstraints(baseTableInfo *model.TableInfo, info *model.MultiSchemaInfo) *model.TableInfo {
+	effectiveBaseTableInfo := baseTableInfo.Clone()
+	for _, subJob := range info.SubJobs {
+		switch subJob.Type {
+		case model.ActionAddIndex, model.ActionAddPrimaryKey:
+			args := subJob.JobArgs.(*model.ModifyIndexArgs)
+			for _, idxArg := range args.IndexArgs {
+				idxInfo := &model.IndexInfo{
+					Name:  idxArg.IndexName,
+					State: model.StatePublic,
+				}
+				if idxArg.IndexOption != nil && idxArg.IndexOption.Visibility == ast.IndexVisibilityInvisible {
+					idxInfo.Invisible = true
+				}
+				for _, spec := range idxArg.IndexPartSpecifications {
+					if spec == nil || spec.Column == nil || spec.Expr != nil {
+						idxInfo = nil
+						break
+					}
+					colInfo := model.FindColumnInfo(effectiveBaseTableInfo.Columns, spec.Column.Name.L)
+					if colInfo == nil {
+						idxInfo = nil
+						break
+					}
+					idxInfo.Columns = append(idxInfo.Columns, &model.IndexColumn{
+						Name:   spec.Column.Name,
+						Offset: colInfo.Offset,
+						Length: spec.Length,
+					})
+				}
+				if idxInfo != nil {
+					effectiveBaseTableInfo.Indices = append(effectiveBaseTableInfo.Indices, idxInfo)
+				}
+			}
+		case model.ActionDropIndex, model.ActionDropPrimaryKey:
+			args := subJob.JobArgs.(*model.ModifyIndexArgs)
+			for _, idxArg := range args.IndexArgs {
+				filtered := effectiveBaseTableInfo.Indices[:0]
+				for _, idx := range effectiveBaseTableInfo.Indices {
+					if idx.Name.L != idxArg.IndexName.L {
+						filtered = append(filtered, idx)
+					}
+				}
+				effectiveBaseTableInfo.Indices = filtered
+			}
+			if subJob.Type == model.ActionDropPrimaryKey {
+				effectiveBaseTableInfo.PKIsHandle = false
+			}
+		case model.ActionRenameIndex:
+			args := subJob.JobArgs.(*model.ModifyIndexArgs)
+			from, to := args.GetRenameIndexes()
+			if idxInfo := effectiveBaseTableInfo.FindIndexByName(from.L); idxInfo != nil {
+				idxInfo.Name = to
+			}
+		case model.ActionAlterIndexVisibility:
+			args := subJob.JobArgs.(*model.AlterIndexVisibilityArgs)
+			if idxInfo := effectiveBaseTableInfo.FindIndexByName(args.IndexName.L); idxInfo != nil {
+				idxInfo.Invisible = args.Invisible
+			}
+		}
+	}
+	return effectiveBaseTableInfo
+}
+
+// Multi-schema change collects sub-jobs incrementally while parsing ALTER
+// specs, so per-spec prechecks can observe an incomplete future index set.
+// Validate dependent MV MIN/MAX constraints here after all staged index changes
+// are available.
+func checkOperateBaseTableDependentMViewMinMaxIndexConstraints(
+	is infoschema.InfoSchema,
+	sctx sessionctx.Context,
+	schemaName pmodel.CIStr,
+	t table.Table,
+	info *model.MultiSchemaInfo,
+) error {
+	baseTableInfo := t.Meta()
+	if baseTableInfo.MaterializedViewBase == nil || len(baseTableInfo.MaterializedViewBase.MViewIDs) == 0 {
+		return nil
+	}
+
+	hasDestructiveIndexChange := false
+	for _, subJob := range info.SubJobs {
+		switch subJob.Type {
+		case model.ActionDropIndex, model.ActionDropPrimaryKey:
+			hasDestructiveIndexChange = true
+		case model.ActionAlterIndexVisibility:
+			if subJob.JobArgs.(*model.AlterIndexVisibilityArgs).Invisible {
+				hasDestructiveIndexChange = true
+			}
+		}
+		if hasDestructiveIndexChange {
+			break
+		}
+	}
+	if !hasDestructiveIndexChange {
+		return nil
+	}
+
+	effectiveBaseTableInfo := buildEffectiveBaseTableInfoForMViewMinMaxIndexConstraints(baseTableInfo, info)
+	for _, subJob := range info.SubJobs {
+		switch subJob.Type {
+		case model.ActionDropIndex, model.ActionDropPrimaryKey:
+			args := subJob.JobArgs.(*model.ModifyIndexArgs)
+			for _, idxArg := range args.IndexArgs {
+				if err := checkBaseTableDependentMViewMinMaxIndexConstraintsWithEffectiveTable(
+					context.Background(),
+					is,
+					sctx,
+					schemaName,
+					baseTableInfo,
+					effectiveBaseTableInfo,
+					pmodel.CIStr{},
+					idxArg.IndexName,
+					"DROP INDEX",
+				); err != nil {
+					return err
+				}
+			}
+		case model.ActionAlterIndexVisibility:
+			args := subJob.JobArgs.(*model.AlterIndexVisibilityArgs)
+			if !args.Invisible {
+				continue
+			}
+			if err := checkBaseTableDependentMViewMinMaxIndexConstraintsWithEffectiveTable(
+				context.Background(),
+				is,
+				sctx,
+				schemaName,
+				baseTableInfo,
+				effectiveBaseTableInfo,
+				pmodel.CIStr{},
+				args.IndexName,
+				"ALTER INDEX INVISIBLE",
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func checkMultiSchemaInfo(info *model.MultiSchemaInfo, t table.Table, is infoschema.InfoSchema, sctx sessionctx.Context, schemaName pmodel.CIStr) error {
 	err := checkOperateSameColAndIdx(info)
 	if err != nil {
 		return err
@@ -417,6 +564,11 @@ func checkMultiSchemaInfo(info *model.MultiSchemaInfo, t table.Table) error {
 	}
 
 	err = checkOperateDropIndexUseByForeignKey(info, t)
+	if err != nil {
+		return err
+	}
+
+	err = checkOperateBaseTableDependentMViewMinMaxIndexConstraints(is, sctx, schemaName, t, info)
 	if err != nil {
 		return err
 	}

--- a/pkg/ddl/rollingback.go
+++ b/pkg/ddl/rollingback.go
@@ -677,7 +677,8 @@ func convertJob2RollbackJob(w *worker, jobCtx *jobContext, job *model.Job) (ver 
 		ver, err = rollingbackTruncateTablePartition(jobCtx, job)
 	case model.ActionRebaseAutoID, model.ActionShardRowID, model.ActionAddForeignKey,
 		model.ActionRenameTable, model.ActionRenameTables,
-		model.ActionModifyTableCharsetAndCollate,
+		model.ActionModifyTableCharsetAndCollate, model.ActionAlterMaterializedViewRefresh,
+		model.ActionAlterMaterializedViewLogPurge,
 		model.ActionModifySchemaCharsetAndCollate, model.ActionRepairTable,
 		model.ActionModifyTableAutoIDCache, model.ActionAlterIndexVisibility,
 		model.ActionModifySchemaDefaultPlacement, model.ActionRecoverSchema:

--- a/pkg/ddl/rollingback.go
+++ b/pkg/ddl/rollingback.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"go.uber.org/zap"
@@ -253,8 +254,8 @@ func rollingbackDropColumn(jobCtx *jobContext, job *model.Job) (ver int64, err e
 	return ver, nil
 }
 
-func rollingbackDropIndex(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
-	_, indexInfo, _, err := checkDropIndex(jobCtx.infoCache, jobCtx.metaMut, job)
+func rollingbackDropIndex(sctx sessionctx.Context, jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	_, indexInfo, _, err := checkDropIndex(sctx, jobCtx.infoCache, jobCtx.metaMut, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -656,7 +657,7 @@ func convertJob2RollbackJob(w *worker, jobCtx *jobContext, job *model.Job) (ver 
 	case model.ActionDropColumn:
 		ver, err = rollingbackDropColumn(jobCtx, job)
 	case model.ActionDropIndex, model.ActionDropPrimaryKey:
-		ver, err = rollingbackDropIndex(jobCtx, job)
+		ver, err = rollingbackDropIndex(w.sess.Session(), jobCtx, job)
 	case model.ActionDropTable, model.ActionDropView, model.ActionDropSequence:
 		err = rollingbackDropTableOrView(jobCtx, job)
 	case model.ActionDropTablePartition:

--- a/pkg/ddl/schematracker/BUILD.bazel
+++ b/pkg/ddl/schematracker/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "//pkg/planner/core/resolve",
         "//pkg/sessionctx",
         "//pkg/util/chunk",
+        "//pkg/util/dbterror",
         "//pkg/util/mock",
         "//pkg/util/sqlexec",
         "@com_github_stretchr_testify//require",

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -327,22 +327,21 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	var purgeNext string
 	if s.Purge != nil {
 		if s.Purge.Immediate {
-			purgeMethod = "IMMEDIATE"
-		} else {
-			purgeMethod = "DEFERRED"
-			if s.Purge.StartWith != nil {
-				purgeStartWith, err = ddl.BuildAndValidateMViewScheduleExpr(ctx, s.Purge.StartWith, "PURGE START WITH")
-				if err != nil {
-					return err
-				}
-			}
-			if s.Purge.Next == nil {
-				return errors.New("PURGE NEXT is required unless PURGE IMMEDIATE is specified")
-			}
-			purgeNext, err = ddl.BuildAndValidateMViewScheduleExpr(ctx, s.Purge.Next, "PURGE NEXT")
+			return errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
+		}
+		purgeMethod = "DEFERRED"
+		if s.Purge.StartWith != nil {
+			purgeStartWith, err = ddl.BuildAndValidateMViewScheduleExpr(ctx, s.Purge.StartWith, "PURGE START WITH")
 			if err != nil {
 				return err
 			}
+		}
+		if s.Purge.Next == nil {
+			return errors.New("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
+		}
+		purgeNext, err = ddl.BuildAndValidateMViewScheduleExpr(ctx, s.Purge.Next, "PURGE NEXT")
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -327,7 +327,7 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	var purgeNext string
 	if s.Purge != nil {
 		if s.Purge.Immediate {
-			return errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStack("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
 		}
 		purgeMethod = "DEFERRED"
 		if s.Purge.StartWith != nil {
@@ -337,7 +337,7 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 			}
 		}
 		if s.Purge.Next == nil {
-			return errors.New("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStack("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
 		}
 		purgeNext, err = ddl.BuildAndValidateMViewScheduleExpr(ctx, s.Purge.Next, "PURGE NEXT")
 		if err != nil {

--- a/pkg/ddl/schematracker/dm_tracker_test.go
+++ b/pkg/ddl/schematracker/dm_tracker_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/stretchr/testify/require"
@@ -575,4 +576,10 @@ func TestCreateMaterializedViewLogScheduleExprTypeCheck(t *testing.T) {
 
 	err = tracker.CreateMaterializedViewLog(sctx, parseStmt("create materialized view log on test.t (a) purge start with now() next 1"))
 	require.ErrorContains(t, err, "PURGE NEXT expression must return DATETIME/TIMESTAMP")
+
+	stmt := parseStmt("create materialized view log on test.t (a) purge start with now() next now()")
+	stmt.Purge.Next = nil
+	err = tracker.CreateMaterializedViewLog(sctx, stmt)
+	require.Truef(t, dbterror.ErrGeneralUnsupportedDDL.Equal(err), "err %v", err)
+	require.ErrorContains(t, err, "PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
 }

--- a/pkg/executor/test/ddl/BUILD.bazel
+++ b/pkg/executor/test/ddl/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "//pkg/kv",
         "//pkg/meta",
         "//pkg/meta/autoid",
+        "//pkg/meta/model",
         "//pkg/parser/auth",
         "//pkg/parser/model",
         "//pkg/parser/mysql",

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -293,12 +293,36 @@ func TestMaterializedViewDDLProtectsMinMaxSupportingBaseTableIndexes(t *testing.
 	require.ErrorContains(t, err, "required by materialized view mv_invisible_idx")
 	require.ErrorContains(t, err, "MIN/MAX fast refresh")
 
+	tk.MustExec("create table t_create_invisible_idx (a int not null, b int not null, c int not null, index idx_ab(a, b))")
+	tk.MustExec("create materialized view log on t_create_invisible_idx (a, b, c) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("alter table t_create_invisible_idx alter index idx_ab invisible")
+	err = tk.ExecToErr("create materialized view mv_create_invisible_idx (a, b, minc, cnt) refresh fast next now() as select a, b, min(c), count(1) from t_create_invisible_idx group by a, b")
+	require.ErrorContains(t, err, "requires base table index whose leading columns cover all GROUP BY columns")
+
+	tk.MustExec("create table t_drop_pk (a int not null primary key nonclustered, c int not null)")
+	tk.MustExec("create materialized view log on t_drop_pk (a, c) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_drop_pk (a, minc, cnt) refresh fast next now() as select a, min(c), count(1) from t_drop_pk group by a")
+	err = tk.ExecToErr("alter table t_drop_pk drop primary key")
+	require.ErrorContains(t, err, "required by materialized view mv_drop_pk")
+	require.ErrorContains(t, err, "MIN/MAX fast refresh")
+
 	createMinMaxMV("t_alt_idx", "mv_alt_idx", ", index idx_ab(a, b), index idx_ba(b, a)")
 	tk.MustExec("alter table t_alt_idx alter index idx_ab invisible")
 	tk.MustExec("drop index idx_ab on t_alt_idx")
 	tk.MustExec("insert into t_alt_idx values (1, 2, 10), (1, 2, 5)")
 	tk.MustExec("refresh materialized view mv_alt_idx fast")
 	tk.MustQuery("select a, b, minc, cnt from mv_alt_idx").Check(testkit.Rows("1 2 5 2"))
+
+	createMinMaxMV("t_multi_schema_replace_idx", "mv_multi_schema_replace_idx", ", index idx_ab(a, b)")
+	tk.MustExec("alter table t_multi_schema_replace_idx drop index idx_ab, add index idx_ba(b, a)")
+	tk.MustExec("insert into t_multi_schema_replace_idx values (1, 2, 10), (1, 2, 5)")
+	tk.MustExec("refresh materialized view mv_multi_schema_replace_idx fast")
+	tk.MustQuery("select a, b, minc, cnt from mv_multi_schema_replace_idx").Check(testkit.Rows("1 2 5 2"))
+
+	createMinMaxMV("t_multi_schema_bad_idx", "mv_multi_schema_bad_idx", ", index idx_ab(a, b)")
+	err = tk.ExecToErr("alter table t_multi_schema_bad_idx drop index idx_ab, add index idx_c(c)")
+	require.ErrorContains(t, err, "required by materialized view mv_multi_schema_bad_idx")
+	require.ErrorContains(t, err, "MIN/MAX fast refresh")
 }
 
 func TestCreateMaterializedViewRefreshExprTypeValidation(t *testing.T) {

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -74,7 +74,7 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	require.ErrorContains(t, err, "materialized view log does not exist")
 
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 	tk.MustQuery("select a, s, cnt from mv order by a").Check(testkit.Rows("1 15 2", "2 7 1"))
 
@@ -135,19 +135,19 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 
 	// SUM/MIN/MAX currently require NOT NULL argument columns.
 	tk.MustExec("create table t_sum_nullable (a int not null, b int)")
-	tk.MustExec("create materialized view log on t_sum_nullable (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t_sum_nullable (a, b) purge next date_add(now(), interval 1 hour)")
 	err = tk.ExecToErr("create materialized view mv_bad_sum_nullable (a, s, c) as select a, sum(b), count(1) from t_sum_nullable group by a")
 	require.ErrorContains(t, err, "only supports SUM/MIN/MAX on NOT NULL column")
 
 	// MIN/MAX requires a base-table index whose leading columns cover all GROUP BY columns.
 	tk.MustExec("create table t_minmax_bad (a int not null, b int not null, c int not null, index idx_cab(c, a, b))")
-	tk.MustExec("create materialized view log on t_minmax_bad (a, b, c) purge immediate")
+	tk.MustExec("create materialized view log on t_minmax_bad (a, b, c) purge next date_add(now(), interval 1 hour)")
 	err = tk.ExecToErr("create materialized view mv_bad_minmax_index (a, b, minc, c1) as select a, b, min(c), count(1) from t_minmax_bad group by a, b")
 	require.ErrorContains(t, err, "requires base table index whose leading columns cover all GROUP BY columns")
 	err = tk.ExecToErr("create materialized view mv_bad_minmax_index_upper (a, b, minc, c1) as select a, b, MIN(c), COUNT(1) from t_minmax_bad group by a, b")
 	require.ErrorContains(t, err, "requires base table index whose leading columns cover all GROUP BY columns")
 	tk.MustExec("create table t_minmax_ok (a int not null, b int not null, c int not null, index idx_bac(b, a, c))")
-	tk.MustExec("create materialized view log on t_minmax_ok (a, b, c) purge immediate")
+	tk.MustExec("create materialized view log on t_minmax_ok (a, b, c) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_minmax_ok (a, b, minc, c1) as select a, b, min(c), count(1) from t_minmax_ok group by a, b")
 
 	// SELECT clauses outside Stage-1 scope should be rejected.
@@ -168,7 +168,7 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 
 	// MV LOG must contain all referenced columns.
 	tk.MustExec("create table t_mlog_missing (a int not null, b int not null)")
-	tk.MustExec("create materialized view log on t_mlog_missing (a) purge immediate")
+	tk.MustExec("create materialized view log on t_mlog_missing (a) purge next date_add(now(), interval 1 hour)")
 	err = tk.ExecToErr("create materialized view mv_bad_mlog_cols (a, s, c) as select a, sum(b), count(1) from t_mlog_missing group by a")
 	require.ErrorContains(t, err, "does not contain column b")
 	err = tk.ExecToErr("create materialized view mv_bad_mlog_cols_count (a, cnt_b, cnt) as select a, count(b), count(1) from t_mlog_missing group by a")
@@ -176,7 +176,7 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 
 	// Nullable group-by key should use UNIQUE KEY.
 	tk.MustExec("create table t_nullable (a int, b int)")
-	tk.MustExec("create materialized view log on t_nullable (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t_nullable (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_nullable (a, c) as select a, count(1) from t_nullable group by a")
 	showCreate = tk.MustQuery("show create table mv_nullable").Rows()[0][1].(string)
 	require.Contains(t, showCreate, "UNIQUE KEY")
@@ -184,7 +184,7 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 
 	// CREATE MATERIALIZED VIEW supports SHARD_ROW_ID_BITS/PRE_SPLIT_REGIONS and follows table pre-split flow.
 	tk.MustExec("create table t_presplit (a int, b int not null)")
-	tk.MustExec("create materialized view log on t_presplit (a) purge immediate")
+	tk.MustExec("create materialized view log on t_presplit (a) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_presplit (a, cnt) shard_row_id_bits = 2 pre_split_regions = 2 as select a, count(1) from t_presplit group by a")
 	showCreate = tk.MustQuery("show create table mv_presplit").Rows()[0][1].(string)
 	require.Contains(t, showCreate, "SHARD_ROW_ID_BITS=2")
@@ -250,13 +250,35 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	require.True(t, baseTable.Meta().MaterializedViewBase == nil || (baseTable.Meta().MaterializedViewBase.MLogID == 0 && len(baseTable.Meta().MaterializedViewBase.MViewIDs) == 0))
 }
 
+func TestShowCreateMaterializedView(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_show_mv (a int, b int not null)")
+	tk.MustExec("create materialized view log on t_show_mv (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_show_mv (a, s, cnt) comment = 'c1' refresh fast next now() shard_row_id_bits = 2 pre_split_regions = 2 as select a, sum(b), count(1) from t_show_mv group by a")
+
+	rows := tk.MustQuery("show create materialized view mv_show_mv").Rows()
+	require.Len(t, rows, 1)
+	require.Equal(t, "mv_show_mv", rows[0][0])
+	showCreate, ok := rows[0][1].(string)
+	require.True(t, ok)
+	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW `mv_show_mv` (`a`, `s`, `cnt`)")
+	require.Contains(t, showCreate, "COMMENT = 'c1'")
+	require.Contains(t, showCreate, "REFRESH FAST NEXT NOW()")
+	require.Contains(t, showCreate, "SHARD_ROW_ID_BITS = 2 PRE_SPLIT_REGIONS = 2")
+	require.Contains(t, showCreate, "AS SELECT `a`,SUM(`b`),COUNT(1) FROM `test`.`t_show_mv` GROUP BY `a`")
+	require.Equal(t, "utf8mb4", rows[0][2])
+	require.Equal(t, "utf8mb4_bin", rows[0][3])
+}
+
 func TestCreateMaterializedViewRefreshExprTypeValidation(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	err := tk.ExecToErr("create materialized view mv_bad_next (a, s, cnt) refresh fast next 300 as select a, sum(b), count(1) from t group by a")
 	require.ErrorContains(t, err, "REFRESH NEXT expression must return DATETIME/TIMESTAMP")
@@ -275,7 +297,7 @@ func TestAlterMaterializedViewRefreshExprTypeValidation(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_ok (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 
 	err := tk.ExecToErr("alter materialized view mv_ok refresh next 300")
@@ -295,7 +317,7 @@ func TestAlterMaterializedViewRefreshUpdatesMetaAndNextTime(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 2 hour) as select a, sum(b), count(1) from t group by a")
 
 	getMViewMeta := func() (int64, *model.MaterializedViewInfo) {
@@ -356,7 +378,7 @@ func TestCreateMaterializedViewRefreshInfoNextTimeDerivation(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	getMViewID := func(name string) int64 {
 		is := dom.InfoSchema()
@@ -411,7 +433,7 @@ func TestCreateMaterializedViewRefreshInfoNextTimeUsesUTC(t *testing.T) {
 	tk.MustExec("set time_zone = '+08:00'")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	getMViewID := func(name string) int64 {
 		is := dom.InfoSchema()
@@ -455,7 +477,7 @@ func TestCreateMaterializedViewRefreshInfoRunningAndSuccess(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	const pauseBuildFailpoint = "github.com/pingcap/tidb/pkg/ddl/pauseCreateMaterializedViewBuild"
 	require.NoError(t, failpoint.Enable(pauseBuildFailpoint, "pause"))
@@ -514,7 +536,7 @@ func TestCreateMaterializedViewSuccessRefreshInfoVisibilityBeforeCommit(t *testi
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	const afterUpsertFailpoint = "github.com/pingcap/tidb/pkg/ddl/afterCreateMaterializedViewSuccessRefreshInfoUpsert"
 	const postUpsertRetryableErr = "github.com/pingcap/tidb/pkg/ddl/mockCreateMaterializedViewPostBuildAfterRefreshInfoUpsertRetryableErr"
@@ -598,7 +620,7 @@ func TestCreateMaterializedViewBuildFailureRollback(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockCreateMaterializedViewBuildErr", "return"))
 	defer func() {
@@ -625,7 +647,7 @@ func TestCreateMaterializedViewBuildContextCanceledRollback(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockCreateMaterializedViewBuildErr", `return("context-canceled")`))
 	defer func() {
@@ -664,7 +686,7 @@ func TestCreateMaterializedViewCancelRollback(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	tkCancel := testkit.NewTestKit(t, store)
 	tkCancel.MustExec("use test")
@@ -726,7 +748,7 @@ func TestCreateMaterializedViewPauseAndResume(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	pauseBuildFailpoint := "github.com/pingcap/tidb/pkg/ddl/pauseCreateMaterializedViewBuild"
 	require.NoError(t, failpoint.Enable(pauseBuildFailpoint, "pause"))
@@ -796,7 +818,7 @@ func TestCreateMaterializedViewRollbackIgnoreMissingRefreshInfoTable(t *testing.
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockCreateMaterializedViewBuildErr", "return"))
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockDeleteCreateMaterializedViewRefreshInfoTableNotExists", "return(true)"))
@@ -825,7 +847,7 @@ func TestCreateMaterializedViewRefreshInfoUpsertFailureRollback(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockUpsertCreateMaterializedViewRefreshInfoTableNotExists", "1*return(true)"))
 	defer func() {
@@ -859,7 +881,7 @@ func TestCreateMaterializedViewRetryWithResidualBuildRowsRollback(t *testing.T) 
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (null, 7), (null, 3)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockCreateMaterializedViewPostBuildRetryableErr", "1*return(true)"))
 	defer func() {
@@ -888,7 +910,7 @@ func TestDropMaterializedViewLogRecheckWithConcurrentCreateMaterializedView(t *t
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	const pauseDropFailpoint = "github.com/pingcap/tidb/pkg/ddl/pauseDropMaterializedViewLogAfterCheck"
 	require.NoError(t, failpoint.Enable(pauseDropFailpoint, "pause"))
@@ -933,7 +955,7 @@ func TestCreateMaterializedViewRetryAfterUpsertFailure(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockUpsertCreateMaterializedViewRefreshInfoTableNotExists", "1*return(true)"))
 	defer func() {
@@ -956,7 +978,7 @@ func TestCreateTableLikeShouldNotCarryMaterializedViewMetadata(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_src (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 
 	tk.MustExec("create table t_like like t")

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -325,6 +325,75 @@ func TestMaterializedViewDDLProtectsMinMaxSupportingBaseTableIndexes(t *testing.
 	require.ErrorContains(t, err, "MIN/MAX fast refresh")
 }
 
+func TestMaterializedViewDDLProtectsMinMaxSupportingBaseTableIndexesAgainstConcurrentDrop(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_concurrent_drop_idx (a int not null, b int not null, c int not null, index idx_ab(a, b), index idx_ba(b, a))")
+	tk.MustExec("create materialized view log on t_concurrent_drop_idx (a, b, c) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_concurrent_drop_idx (a, b, minc, cnt) refresh fast next now() as select a, b, min(c), count(1) from t_concurrent_drop_idx group by a, b")
+
+	var pausedJobID int64
+	pauseCh := make(chan struct{})
+	blockedCh := make(chan struct{}, 1)
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onJobRunBefore", func(job *model.Job) {
+		if job.Type != model.ActionDropIndex || job.TableName != "t_concurrent_drop_idx" || job.SchemaState != model.StatePublic {
+			return
+		}
+		if !atomic.CompareAndSwapInt64(&pausedJobID, 0, job.ID) {
+			return
+		}
+		select {
+		case blockedCh <- struct{}{}:
+		default:
+		}
+		<-pauseCh
+	})
+
+	tk1 := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+	tk2 := testkit.NewTestKit(t, store)
+	tk2.MustExec("use test")
+
+	var (
+		err1 error
+		err2 error
+		wg   sync.WaitGroup
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err1 = tk1.ExecToErr("drop index idx_ab on t_concurrent_drop_idx")
+	}()
+
+	select {
+	case <-blockedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first drop index job to pause")
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err2 = tk2.ExecToErr("drop index idx_ba on t_concurrent_drop_idx")
+	}()
+
+	require.Eventually(t, func() bool {
+		return fmt.Sprint(tk.MustQuery("select count(*) from mysql.tidb_ddl_job").Rows()[0][0]) == "2"
+	}, 5*time.Second, 50*time.Millisecond)
+
+	close(pauseCh)
+	wg.Wait()
+
+	require.NoError(t, err1)
+	require.ErrorContains(t, err2, "required by materialized view mv_concurrent_drop_idx")
+	require.ErrorContains(t, err2, "MIN/MAX fast refresh")
+
+	tk.MustExec("insert into t_concurrent_drop_idx values (1, 2, 10), (1, 2, 5)")
+	tk.MustExec("refresh materialized view mv_concurrent_drop_idx fast")
+	tk.MustQuery("select a, b, minc, cnt from mv_concurrent_drop_idx").Check(testkit.Rows("1 2 5 2"))
+}
+
 func TestCreateMaterializedViewRefreshExprTypeValidation(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -313,6 +313,34 @@ func TestMaterializedViewDDLProtectsMinMaxSupportingBaseTableIndexes(t *testing.
 	tk.MustExec("refresh materialized view mv_alt_idx fast")
 	tk.MustQuery("select a, b, minc, cnt from mv_alt_idx").Check(testkit.Rows("1 2 5 2"))
 
+	createMinMaxMVWithWhere := func(baseTable, mvName string) {
+		tk.MustExec(fmt.Sprintf(
+			"create table %s (a int not null, b int not null, c int not null, index idx_ab(a, b), index idx_ba(b, a))",
+			baseTable,
+		))
+		tk.MustExec(fmt.Sprintf(
+			"create materialized view log on %s (a, b, c) purge next date_add(now(), interval 1 hour)",
+			baseTable,
+		))
+		tk.MustExec(fmt.Sprintf(
+			"create materialized view %s (a, b, minc, cnt) refresh fast next now() as select a, b, min(c), count(1) from %s where c > 0 group by a, b",
+			mvName,
+			baseTable,
+		))
+	}
+
+	createMinMaxMVWithWhere("t_where_drop_idx", "mv_where_drop_idx")
+	tk.MustExec("drop index idx_ab on t_where_drop_idx")
+	err = tk.ExecToErr("drop index idx_ba on t_where_drop_idx")
+	require.ErrorContains(t, err, "required by materialized view mv_where_drop_idx")
+	require.ErrorContains(t, err, "MIN/MAX fast refresh")
+
+	createMinMaxMVWithWhere("t_where_invisible_idx", "mv_where_invisible_idx")
+	tk.MustExec("alter table t_where_invisible_idx alter index idx_ab invisible")
+	err = tk.ExecToErr("alter table t_where_invisible_idx alter index idx_ba invisible")
+	require.ErrorContains(t, err, "required by materialized view mv_where_invisible_idx")
+	require.ErrorContains(t, err, "MIN/MAX fast refresh")
+
 	createMinMaxMV("t_multi_schema_replace_idx", "mv_multi_schema_replace_idx", ", index idx_ab(a, b)")
 	tk.MustExec("alter table t_multi_schema_replace_idx drop index idx_ab, add index idx_ba(b, a)")
 	tk.MustExec("insert into t_multi_schema_replace_idx values (1, 2, 10), (1, 2, 5)")

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -301,28 +301,6 @@ func TestMaterializedViewDDLProtectsMinMaxSupportingBaseTableIndexes(t *testing.
 	tk.MustQuery("select a, b, minc, cnt from mv_alt_idx").Check(testkit.Rows("1 2 5 2"))
 }
 
-func TestShowCreateMaterializedView(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t_show_mv (a int, b int not null)")
-	tk.MustExec("create materialized view log on t_show_mv (a, b) purge next date_add(now(), interval 1 hour)")
-	tk.MustExec("create materialized view mv_show_mv (a, s, cnt) comment = 'c1' refresh fast next now() shard_row_id_bits = 2 pre_split_regions = 2 as select a, sum(b), count(1) from t_show_mv group by a")
-
-	rows := tk.MustQuery("show create materialized view mv_show_mv").Rows()
-	require.Len(t, rows, 1)
-	require.Equal(t, "mv_show_mv", rows[0][0])
-	showCreate, ok := rows[0][1].(string)
-	require.True(t, ok)
-	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW `mv_show_mv` (`a`, `s`, `cnt`)")
-	require.Contains(t, showCreate, "COMMENT = 'c1'")
-	require.Contains(t, showCreate, "REFRESH FAST NEXT NOW()")
-	require.Contains(t, showCreate, "SHARD_ROW_ID_BITS = 2 PRE_SPLIT_REGIONS = 2")
-	require.Contains(t, showCreate, "AS SELECT `a`,SUM(`b`),COUNT(1) FROM `test`.`t_show_mv` GROUP BY `a`")
-	require.Equal(t, "utf8mb4", rows[0][2])
-	require.Equal(t, "utf8mb4_bin", rows[0][3])
-}
-
 func TestCreateMaterializedViewRefreshExprTypeValidation(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -256,6 +256,51 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	require.True(t, baseTable.Meta().MaterializedViewBase == nil || (baseTable.Meta().MaterializedViewBase.MLogID == 0 && len(baseTable.Meta().MaterializedViewBase.MViewIDs) == 0))
 }
 
+func TestMaterializedViewDDLProtectsMinMaxSupportingBaseTableIndexes(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	createMinMaxMV := func(baseTable, mvName, indexDDL string) {
+		tk.MustExec(fmt.Sprintf(
+			"create table %s (a int not null, b int not null, c int not null%s)",
+			baseTable,
+			indexDDL,
+		))
+		tk.MustExec(fmt.Sprintf(
+			"create materialized view log on %s (a, b, c) purge next date_add(now(), interval 1 hour)",
+			baseTable,
+		))
+		tk.MustExec(fmt.Sprintf(
+			"create materialized view %s (a, b, minc, cnt) refresh fast next now() as select a, b, min(c), count(1) from %s group by a, b",
+			mvName,
+			baseTable,
+		))
+	}
+
+	createMinMaxMV("t_drop_idx", "mv_drop_idx", ", index idx_ab(a, b)")
+	err := tk.ExecToErr("drop index idx_ab on t_drop_idx")
+	require.ErrorContains(t, err, "required by materialized view mv_drop_idx")
+	require.ErrorContains(t, err, "MIN/MAX fast refresh")
+
+	createMinMaxMV("t_alter_drop_idx", "mv_alter_drop_idx", ", index idx_ab(a, b)")
+	err = tk.ExecToErr("alter table t_alter_drop_idx drop index idx_ab")
+	require.ErrorContains(t, err, "required by materialized view mv_alter_drop_idx")
+	require.ErrorContains(t, err, "MIN/MAX fast refresh")
+
+	createMinMaxMV("t_invisible_idx", "mv_invisible_idx", ", index idx_ab(a, b)")
+	err = tk.ExecToErr("alter table t_invisible_idx alter index idx_ab invisible")
+	require.ErrorContains(t, err, "required by materialized view mv_invisible_idx")
+	require.ErrorContains(t, err, "MIN/MAX fast refresh")
+
+	createMinMaxMV("t_alt_idx", "mv_alt_idx", ", index idx_ab(a, b), index idx_ba(b, a)")
+	tk.MustExec("alter table t_alt_idx alter index idx_ab invisible")
+	tk.MustExec("drop index idx_ab on t_alt_idx")
+	tk.MustExec("insert into t_alt_idx values (1, 2, 10), (1, 2, 5)")
+	tk.MustExec("refresh materialized view mv_alt_idx fast")
+	tk.MustQuery("select a, b, minc, cnt from mv_alt_idx").Check(testkit.Rows("1 2 5 2"))
+}
+
 func TestShowCreateMaterializedView(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -232,6 +232,94 @@ func TestCreateMaterializedViewLogPurgeInfoNextTimeUsesUTC(t *testing.T) {
 	)).Check(testkit.Rows("1 1 1 1"))
 }
 
+func TestAlterMaterializedViewLogPurgeExprTypeValidation(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int, b int)")
+	tk.MustExec("create materialized view log on t (a) purge immediate")
+
+	err := tk.ExecToErr("alter materialized view log on t purge start with 1 next now()")
+	require.ErrorContains(t, err, "PURGE START WITH expression must return DATETIME/TIMESTAMP")
+
+	err = tk.ExecToErr("alter materialized view log on t purge next 300")
+	require.ErrorContains(t, err, "PURGE NEXT expression must return DATETIME/TIMESTAMP")
+
+	tk.MustExec("alter materialized view log on t purge start with now() next now()")
+}
+
+func TestAlterMaterializedViewLogPurgeUpdatesMetaAndNextTime(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int, b int)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 2 hour)")
+
+	getMLogMeta := func() (int64, string, string, string) {
+		is := dom.InfoSchema()
+		mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t"))
+		require.NoError(t, err)
+		require.NotNil(t, mlogTable.Meta().MaterializedViewLog)
+		return mlogTable.Meta().ID,
+			mlogTable.Meta().MaterializedViewLog.PurgeMethod,
+			mlogTable.Meta().MaterializedViewLog.PurgeStartWith,
+			mlogTable.Meta().MaterializedViewLog.PurgeNext
+	}
+
+	mlogID, purgeMethod, purgeStartWith, purgeNext := getMLogMeta()
+	require.Equal(t, "DEFERRED", purgeMethod)
+	require.Equal(t, "", purgeStartWith)
+	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 2 HOUR)", purgeNext)
+
+	tk.MustExec("alter materialized view log on t purge start with date_add(now(), interval 40 minute) next date_add(now(), interval 20 minute)")
+	_, purgeMethod, purgeStartWith, purgeNext = getMLogMeta()
+	require.Equal(t, "DEFERRED", purgeMethod)
+	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 40 MINUTE)", purgeStartWith)
+	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 20 MINUTE)", purgeNext)
+	tk.MustQuery(fmt.Sprintf(
+		"select NEXT_TIME is not null, NEXT_TIME > UTC_TIMESTAMP() + interval 30 minute, NEXT_TIME < UTC_TIMESTAMP() + interval 2 hour from mysql.tidb_mlog_purge_info where MLOG_ID = %d",
+		mlogID,
+	)).Check(testkit.Rows("1 1 1"))
+
+	tk.MustExec("alter materialized view log on t purge next date_add(now(), interval 25 minute)")
+	_, purgeMethod, purgeStartWith, purgeNext = getMLogMeta()
+	require.Equal(t, "DEFERRED", purgeMethod)
+	require.Equal(t, "", purgeStartWith)
+	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 25 MINUTE)", purgeNext)
+	tk.MustQuery(fmt.Sprintf(
+		"select NEXT_TIME is not null, NEXT_TIME > UTC_TIMESTAMP() + interval 15 minute, NEXT_TIME < UTC_TIMESTAMP() + interval 1 hour from mysql.tidb_mlog_purge_info where MLOG_ID = %d",
+		mlogID,
+	)).Check(testkit.Rows("1 1 1"))
+
+	beforeRows := tk.MustQuery(fmt.Sprintf(
+		"select TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) from mysql.tidb_mlog_purge_info where MLOG_ID = %d",
+		mlogID,
+	)).Rows()
+	tk.MustExec("alter materialized view log on t purge")
+	_, purgeMethod, purgeStartWith, purgeNext = getMLogMeta()
+	require.Equal(t, "DEFERRED", purgeMethod)
+	require.Equal(t, "", purgeStartWith)
+	require.Equal(t, "", purgeNext)
+	afterRows := tk.MustQuery(fmt.Sprintf(
+		"select TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) from mysql.tidb_mlog_purge_info where MLOG_ID = %d",
+		mlogID,
+	)).Rows()
+	require.Equal(t, beforeRows, afterRows)
+
+	tk.MustExec("alter materialized view log on t purge immediate")
+	_, purgeMethod, purgeStartWith, purgeNext = getMLogMeta()
+	require.Equal(t, "IMMEDIATE", purgeMethod)
+	require.Equal(t, "", purgeStartWith)
+	require.Equal(t, "", purgeNext)
+	afterImmediateRows := tk.MustQuery(fmt.Sprintf(
+		"select TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) from mysql.tidb_mlog_purge_info where MLOG_ID = %d",
+		mlogID,
+	)).Rows()
+	require.Equal(t, afterRows, afterImmediateRows)
+
+	tk.MustExec("drop materialized view log on t")
+}
+
 func TestCreateMaterializedViewLogMetaColumnNameConflict(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -106,7 +106,7 @@ func TestCreateMaterializedViewLogPreSplitOptions(t *testing.T) {
 	tk.MustExec("set @@session.tidb_scatter_region='table'")
 	tk.MustExec("create table t_mlog_presplit (a int, b int)")
 
-	tk.MustExec("create materialized view log on t_mlog_presplit (a) shard_row_id_bits = 2 pre_split_regions = 2 purge immediate")
+	tk.MustExec("create materialized view log on t_mlog_presplit (a) shard_row_id_bits = 2 pre_split_regions = 2 purge next date_add(now(), interval 1 hour)")
 
 	showCreate := tk.MustQuery("show create table `$mlog$t_mlog_presplit`").Rows()[0][1].(string)
 	require.Contains(t, showCreate, "SHARD_ROW_ID_BITS=2")
@@ -134,7 +134,10 @@ func TestCreateMaterializedViewLogPurgeExprTypeValidation(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int, b int)")
 
-	err := tk.ExecToErr("create materialized view log on t (a) purge start with 1 next now()")
+	err := tk.ExecToErr("create materialized view log on t (a) purge immediate")
+	require.ErrorContains(t, err, "PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
+
+	err = tk.ExecToErr("create materialized view log on t (a) purge start with 1 next now()")
 	require.ErrorContains(t, err, "PURGE START WITH expression must return DATETIME/TIMESTAMP")
 
 	err = tk.ExecToErr("create materialized view log on t (a) purge next 600")
@@ -237,7 +240,7 @@ func TestAlterMaterializedViewLogPurgeExprTypeValidation(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int, b int)")
-	tk.MustExec("create materialized view log on t (a) purge immediate")
+	tk.MustExec("create materialized view log on t (a) purge next date_add(now(), interval 1 hour)")
 
 	err := tk.ExecToErr("alter materialized view log on t purge start with 1 next now()")
 	require.ErrorContains(t, err, "PURGE START WITH expression must return DATETIME/TIMESTAMP")
@@ -475,7 +478,7 @@ func TestPurgeMaterializedViewLogPrivilege(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t_purge_priv (a int)")
-	tk.MustExec("create materialized view log on t_purge_priv (a) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_priv (a) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create user 'u1'@'%'")
 	tk.MustExec("grant select on test.t_purge_priv to 'u1'@'%'")
 
@@ -517,7 +520,7 @@ func TestPurgeMaterializedViewLogLockRowMissing(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t_purge_lock_row_missing (a int)")
-	tk.MustExec("create materialized view log on t_purge_lock_row_missing (a) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_lock_row_missing (a) purge next date_add(now(), interval 1 hour)")
 
 	is := dom.InfoSchema()
 	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_lock_row_missing"))
@@ -536,7 +539,7 @@ func TestPurgeMaterializedViewLogNowaitConflict(t *testing.T) {
 	tk1.MustExec("use test")
 	tk2.MustExec("use test")
 	tk1.MustExec("create table t_purge_nowait_conflict (a int)")
-	tk1.MustExec("create materialized view log on t_purge_nowait_conflict (a) purge immediate")
+	tk1.MustExec("create materialized view log on t_purge_nowait_conflict (a) purge next date_add(now(), interval 1 hour)")
 
 	is := dom.InfoSchema()
 	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_nowait_conflict"))
@@ -567,7 +570,7 @@ func TestPurgeMaterializedViewLogBatchDelete(t *testing.T) {
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t_purge_batch_delete (id int primary key, v int)")
-	tk.MustExec("create materialized view log on t_purge_batch_delete (id, v) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_batch_delete (id, v) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("insert into t_purge_batch_delete values (1, 10), (2, 20), (3, 30), (4, 40), (5, 50)")
 
 	is := dom.InfoSchema()
@@ -594,7 +597,7 @@ func TestPurgeMaterializedViewLogLastPurgedTSOShortCircuit(t *testing.T) {
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t_purge_short_circuit (a int not null, b int)")
-	tk.MustExec("create materialized view log on t_purge_short_circuit (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_short_circuit (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_purge_short_circuit (a, cnt) refresh fast next now() as select a, count(1) from t_purge_short_circuit group by a")
 	tk.MustExec("insert into t_purge_short_circuit values (1, 10), (1, 20), (2, 30)")
 
@@ -636,7 +639,7 @@ func TestPurgeMaterializedViewLogDeleteErrorNoDirtyWrite(t *testing.T) {
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t_purge_delete_err (id int primary key, v int)")
-	tk.MustExec("create materialized view log on t_purge_delete_err (id, v) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_delete_err (id, v) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("insert into t_purge_delete_err values (1, 10), (2, 20), (3, 30)")
 
 	is := dom.InfoSchema()
@@ -762,7 +765,7 @@ func TestPurgeMaterializedViewLogLockConflictAfterPartialSuccess(t *testing.T) {
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t_purge_partial_conflict (id int primary key, v int)")
-	tk.MustExec("create materialized view log on t_purge_partial_conflict (id, v) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_partial_conflict (id, v) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("insert into t_purge_partial_conflict values (1, 10), (2, 20), (3, 30)")
 
 	is := dom.InfoSchema()
@@ -847,7 +850,7 @@ func TestPurgeMaterializedViewLogMissingPublicMViewRefreshRow(t *testing.T) {
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t_purge_missing_public_refresh (a int)")
-	tk.MustExec("create materialized view log on t_purge_missing_public_refresh (a) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_missing_public_refresh (a) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_purge_missing_public_refresh (a, cnt) refresh fast next now() as select a, count(1) from t_purge_missing_public_refresh group by a")
 
 	is := dom.InfoSchema()
@@ -873,7 +876,7 @@ func TestPurgeMaterializedViewLogWritesState(t *testing.T) {
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t_purge_state (id int primary key, v int)")
-	tk.MustExec("create materialized view log on t_purge_state (id, v) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_state (id, v) purge next date_add(now(), interval 1 hour)")
 
 	is := dom.InfoSchema()
 	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_state"))

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -398,8 +398,9 @@ func TestMaterializedViewRelatedTablesDDLRejected(t *testing.T) {
 	tk.MustExec("create materialized view log on t_ddl_mv (a, b)")
 	tk.MustExec("create materialized view mv_ddl_mv (a, cnt) refresh fast next now() as select a, count(1) from t_ddl_mv group by a")
 
-	err := tk.ExecToErr("alter table t_ddl_mv add column c int")
-	require.ErrorContains(t, err, "ALTER TABLE on base table with materialized view dependencies")
+	tk.MustExec("alter table t_ddl_mv add column c int")
+	err := tk.ExecToErr("alter table t_ddl_mv modify column a bigint")
+	require.ErrorContains(t, err, "referenced by materialized view log")
 	err = tk.ExecToErr("drop table t_ddl_mv")
 	require.ErrorContains(t, err, "DROP TABLE on base table with materialized view dependencies")
 	err = tk.ExecToErr("rename table t_ddl_mv to t_ddl_mv2")
@@ -411,6 +412,19 @@ func TestMaterializedViewRelatedTablesDDLRejected(t *testing.T) {
 	require.ErrorContains(t, err, "DROP TABLE on materialized view table")
 	err = tk.ExecToErr("rename table mv_ddl_mv to mv_ddl_mv2")
 	require.ErrorContains(t, err, "RENAME TABLE on materialized view table")
+
+	err = tk.ExecToErr("alter table `$mlog$t_ddl_mv` set tiflash replica 1")
+	if err != nil {
+		require.NotContains(t, err.Error(), "ALTER TABLE on materialized view log table")
+	}
+	err = tk.ExecToErr("alter table `$mlog$t_ddl_mv` add index idx_mlog_b(b)")
+	require.ErrorContains(t, err, "ALTER TABLE on materialized view log table")
+	err = tk.ExecToErr("alter table `$mlog$t_ddl_mv` add column c int")
+	require.ErrorContains(t, err, "ALTER TABLE on materialized view log table")
+	err = tk.ExecToErr("create index idx_mlog_b_create on `$mlog$t_ddl_mv`(b)")
+	require.ErrorContains(t, err, "CREATE INDEX on materialized view log table")
+	err = tk.ExecToErr("drop index idx_mlog_b_create on `$mlog$t_ddl_mv`")
+	require.ErrorContains(t, err, "DROP INDEX on materialized view log table")
 }
 
 func TestTruncateOrdinaryTableStillWorks(t *testing.T) {

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -528,7 +528,7 @@ func TestPurgeMaterializedViewLogDisallowExplicitTransaction(t *testing.T) {
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t_mlog_purge_txn (a int not null, b int not null)")
-	tk.MustExec("create materialized view log on t_mlog_purge_txn (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t_mlog_purge_txn (a, b) purge next date_add(now(), interval 1 hour)")
 
 	tk.MustExec("begin")
 	tk.MustGetErrMsg(

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/stretchr/testify/require"
@@ -135,6 +136,7 @@ func TestCreateMaterializedViewLogPurgeExprTypeValidation(t *testing.T) {
 	tk.MustExec("create table t (a int, b int)")
 
 	err := tk.ExecToErr("create materialized view log on t (a) purge immediate")
+	require.Truef(t, dbterror.ErrGeneralUnsupportedDDL.Equal(err), "err %v", err)
 	require.ErrorContains(t, err, "PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
 
 	err = tk.ExecToErr("create materialized view log on t (a) purge start with 1 next now()")
@@ -425,6 +427,19 @@ func TestMaterializedViewRelatedTablesDDLRejected(t *testing.T) {
 	require.ErrorContains(t, err, "CREATE INDEX on materialized view log table")
 	err = tk.ExecToErr("drop index idx_mlog_b_create on `$mlog$t_ddl_mv`")
 	require.ErrorContains(t, err, "DROP INDEX on materialized view log table")
+}
+
+func TestCreateVectorIndexOnMaterializedViewLogTableRejected(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomainWithSchemaLease(t, 100*time.Millisecond, mockstore.WithMockTiFlash(2))
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mlog_vec (id int, v vector(3))")
+	tk.MustExec("create materialized view log on t_mlog_vec (v) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("alter table `$mlog$t_mlog_vec` set tiflash replica 1")
+
+	err := tk.ExecToErr("create vector index idx_mlog_vec on `$mlog$t_mlog_vec`((vec_cosine_distance(v))) USING HNSW")
+	require.Truef(t, dbterror.ErrGeneralUnsupportedDDL.Equal(err), "err %v", err)
+	require.ErrorContains(t, err, "CREATE INDEX on materialized view log table")
 }
 
 func TestTruncateOrdinaryTableStillWorks(t *testing.T) {

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -695,7 +695,7 @@ func TestPurgeMaterializedViewLogFinalizeFailureAfterCommitIsWarning(t *testing.
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t_purge_finalize_warn (id int primary key, v int)")
-	tk.MustExec("create materialized view log on t_purge_finalize_warn (id, v) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_finalize_warn (id, v) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("insert into t_purge_finalize_warn values (1, 10), (2, 20), (3, 30)")
 
 	is := dom.InfoSchema()
@@ -720,7 +720,7 @@ func TestPurgeMaterializedViewLogFinalizeRetrySucceeds(t *testing.T) {
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t_purge_finalize_retry (id int primary key, v int)")
-	tk.MustExec("create materialized view log on t_purge_finalize_retry (id, v) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_finalize_retry (id, v) purge next date_add(now(), interval 1 hour)")
 
 	is := dom.InfoSchema()
 	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_finalize_retry"))
@@ -745,7 +745,7 @@ func TestPurgeMaterializedViewLogFinalizeFailureUsesWithoutCancel(t *testing.T) 
 	tkObserver.MustExec("use test")
 
 	tk.MustExec("create table t_purge_cancel_finalize (id int primary key, v int)")
-	tk.MustExec("create materialized view log on t_purge_cancel_finalize (id, v) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_cancel_finalize (id, v) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("insert into t_purge_cancel_finalize values (1, 10)")
 
 	is := dom.InfoSchema()
@@ -822,7 +822,7 @@ func TestPurgeMaterializedViewLogBeginFailureAfterPartialSuccess(t *testing.T) {
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t_purge_begin_fail (id int primary key, v int)")
-	tk.MustExec("create materialized view log on t_purge_begin_fail (id, v) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_begin_fail (id, v) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("insert into t_purge_begin_fail values (1, 10), (2, 20), (3, 30)")
 
 	is := dom.InfoSchema()
@@ -852,7 +852,7 @@ func TestPurgeMaterializedViewLogZeroStartTS(t *testing.T) {
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t_purge_zero_start_ts (id int primary key, v int)")
-	tk.MustExec("create materialized view log on t_purge_zero_start_ts (id, v) purge immediate")
+	tk.MustExec("create materialized view log on t_purge_zero_start_ts (id, v) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("insert into t_purge_zero_start_ts values (1, 10), (2, 20)")
 
 	is := dom.InfoSchema()

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -44,7 +44,7 @@ func TestMaterializedViewRefreshCompleteBasic(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 	tk.MustQuery("select a, s, cnt from mv order by a").Check(testkit.Rows("1 15 2", "2 7 1"))
 
@@ -88,7 +88,7 @@ func TestMaterializedViewRefreshNextTimeOnlyUpdatesForInternalSQL(t *testing.T) 
 	tk.MustExec("use test")
 	tk.MustExec("create table t_internal_next (a int not null, b int not null)")
 	tk.MustExec("insert into t_internal_next values (1, 10), (2, 20)")
-	tk.MustExec("create materialized view log on t_internal_next (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t_internal_next (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_internal_next (a, s, cnt) refresh fast start with date_add(now(), interval 2 hour) next date_add(now(), interval 40 minute) as select a, sum(b), count(1) from t_internal_next group by a")
 
 	is := dom.InfoSchema()
@@ -125,7 +125,7 @@ func TestMaterializedViewRefreshInternalSQLStartWithNoNextSetsNextTimeNull(t *te
 	tk.MustExec("use test")
 	tk.MustExec("create table t_internal_start_only (a int not null, b int not null)")
 	tk.MustExec("insert into t_internal_start_only values (1, 10), (2, 20)")
-	tk.MustExec("create materialized view log on t_internal_start_only (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t_internal_start_only (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_internal_start_only (a, s, cnt) refresh fast start with date_add(now(), interval 2 hour) next date_add(now(), interval 40 minute) as select a, sum(b), count(1) from t_internal_start_only group by a")
 
 	is := dom.InfoSchema()
@@ -165,7 +165,7 @@ func TestMaterializedViewRefreshFastMethodTracksManualAndAutomatic(t *testing.T)
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 
 	tk.MustExec("insert into t values (2, 3), (3, 4)")
@@ -216,7 +216,7 @@ func TestMaterializedViewRefreshCompleteUsesDefinitionSessionSemantics(t *testin
 	tk.MustExec("set @@session.time_zone = '+00:00'")
 	tk.MustExec("create table t (a int not null, b int not null, ts timestamp not null)")
 	tk.MustExec("insert into t values (1, 10, '2020-01-01 00:30:00'), (2, 20, '2019-12-31 23:30:00')")
-	tk.MustExec("create materialized view log on t (a, b, ts) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b, ts) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec(`create materialized view mv (a, s, cnt) refresh fast next now() as
 select a, sum(b), count(1) from t
 where ts >= '2020-01-01 00:00:00'
@@ -248,7 +248,7 @@ func TestMaterializedViewRefreshCompleteFinalizeHistoryRetry(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 
 	is := dom.InfoSchema()
@@ -278,7 +278,7 @@ func TestMaterializedViewRefreshCompleteRunningHistLifecycle(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 
 	is := dom.InfoSchema()
@@ -352,7 +352,7 @@ UPDATE variable_value = '%[2]s', comment = '%[3]s'`, safePointName, safePointVal
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 	tk.MustQuery("select a, s, cnt from mv order by a").Check(testkit.Rows("1 15 2"))
 
@@ -430,7 +430,7 @@ func TestMaterializedViewRefreshCompleteRefreshInfoCASUpdateAfterConcurrentPreUp
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 	tk.MustQuery("select a, s, cnt from mv order by a").Check(testkit.Rows("1 15 2", "2 7 1"))
 
@@ -519,7 +519,7 @@ func TestMaterializedViewRefreshCompleteConcurrentNowait(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 
 	is := dom.InfoSchema()
@@ -550,7 +550,7 @@ func TestMaterializedViewRefreshCompleteMissingRefreshInfoRow(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 
 	is := dom.InfoSchema()
@@ -570,7 +570,7 @@ func TestMaterializedViewRefreshWithSyncModeComplete(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 
 	tk.MustExec("insert into t values (2, 3), (3, 4)")
@@ -584,7 +584,7 @@ func TestMaterializedViewRefreshCompleteFailureKeepsRefreshInfoReadTSO(t *testin
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 	tk.MustQuery("select a, s, cnt from mv order by a").Check(testkit.Rows("1 15 2", "2 7 1"))
 
@@ -635,7 +635,7 @@ func TestMaterializedViewRefreshCompleteWithConstraintCheckInPlacePessimisticOff
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 
 	// Turn off in-place constraint check for pessimistic txn.
@@ -653,7 +653,7 @@ func TestMaterializedViewRefreshRequiresAlterPrivilege(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
 	tk.MustExec("create user 'mv_refresh_u'@'%' identified by ''")
 	defer tk.MustExec("drop user 'mv_refresh_u'@'%'")

--- a/pkg/executor/test/writetest/BUILD.bazel
+++ b/pkg/executor/test/writetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "write_test.go",
     ],
     flaky = True,
-    shard_count = 46,
+    shard_count = 45,
     deps = [
         "//pkg/config",
         "//pkg/errctx",

--- a/pkg/executor/test/writetest/mview_log_write_test.go
+++ b/pkg/executor/test/writetest/mview_log_write_test.go
@@ -950,63 +950,24 @@ func TestMLogOnlineDDLDropUntrackedColumn(t *testing.T) {
 	))
 }
 
-// TODO: DDL should reject dropping a tracked column
-func TestMLogOnlineDDLDropTrackedColumnCurrentBehavior(t *testing.T) {
+func TestMLogDropTrackedColumnRejected(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	tk.MustExec("set @@global.tidb_enable_metadata_lock=0")
 
 	tk.MustExec("create table t (id int primary key, tracked int, untracked int)")
 	tk.MustExec("create materialized view log on t (id, tracked)")
+	err := tk.ExecToErr("alter table t drop column tracked")
+	require.ErrorContains(t, err, "Unsupported ALTER TABLE on base table column tracked referenced by materialized view log")
+
+	// The failed DDL should leave both the base table schema and mlog behavior intact.
 	tk.MustExec("insert into t values (1, 10, 100)")
-	execAsMViewMaintenance(tk, "delete from `$mlog$t`")
-
-	tkDDL := testkit.NewTestKit(t, store)
-	tkDDL.MustExec("use test")
-	ctrl := startDDLPausedAtFailpoint(
-		t,
-		tkDDL,
-		dropColumnStateWriteOnlyFailpoint,
-		"alter table t drop column tracked",
-	)
-	defer ctrl.releaseAndWaitFinish(t)
-
-	ctrl.waitUntilPaused(t, "drop-tracked-column write-only")
-
-	// While online DDL is paused in an intermediate state, tracked column offsets in mlog metadata
-	// can no longer match the partial insert row layout, so mlog writing fails in the DML path.
-	err := tk.ExecToErr("insert into t (id, untracked) values (2, 200)")
-	require.ErrorContains(t, err, "write mlog row: column at offset")
-
-	ctrl.releaseAndWaitFinish(t)
-
-	// Current behavior after DDL completion: wrapped DML fails because tracked column metadata
-	// still exists in mlog definition but is removed from the base table schema.
-	err = tk.ExecToErr("insert into t (id, untracked) values (3, 300)")
-	require.ErrorContains(t, err, "wrap table with mlog: base column tracked not found")
-}
-
-// TODO: DDL should reject dropping a tracked column
-func TestMLogDropTrackedColumnCurrentBehavior(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-
-	tk.MustExec("create table t (id int primary key, tracked int, untracked int)")
-	tk.MustExec("create materialized view log on t (id, tracked)")
-	tk.MustExec("alter table t drop column tracked")
-
-	// Current behavior: DDL succeeds, then wrapped DML fails at execution build time because
-	// mlog metadata still references a tracked column that no longer exists on base table.
-	err := tk.ExecToErr("insert into t values (1, 100)")
-	require.ErrorContains(t, err, "wrap table with mlog: base column tracked not found")
-
-	err = tk.ExecToErr("update t set untracked = 101 where id = 1")
-	require.ErrorContains(t, err, "wrap table with mlog: base column tracked not found")
-
-	err = tk.ExecToErr("delete from t where id = 1")
-	require.ErrorContains(t, err, "wrap table with mlog: base column tracked not found")
+	tk.MustQuery(
+		"select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`",
+	).Check(testkit.Rows(
+		"1 10 I 1",
+	))
+	tk.MustQuery("select id, tracked, untracked from t").Check(testkit.Rows("1 10 100"))
 }
 
 func TestMLogGeneratedColumn(t *testing.T) {

--- a/pkg/meta/model/bdr.go
+++ b/pkg/meta/model/bdr.go
@@ -48,6 +48,8 @@ var BDRActionMap = map[DDLBDRType][]ActionType{
 		ActionModifyColumn, // add or update comments for column, change default values of one particular column
 		ActionSetDefaultValue,
 		ActionModifyTableComment,
+		ActionAlterMaterializedViewRefresh,
+		ActionAlterMaterializedViewLogPurge,
 		ActionRenameIndex,
 		ActionAddTablePartition,
 		ActionDropPrimaryKey,

--- a/pkg/meta/model/job.go
+++ b/pkg/meta/model/job.go
@@ -96,23 +96,25 @@ const (
 	ActionAlterTablePlacement           ActionType = 56
 	ActionAlterCacheTable               ActionType = 57
 	// not used
-	ActionAlterTableStatsOptions    ActionType = 58
-	ActionAlterNoCacheTable         ActionType = 59
-	ActionCreateTables              ActionType = 60
-	ActionMultiSchemaChange         ActionType = 61
-	ActionFlashbackCluster          ActionType = 62
-	ActionRecoverSchema             ActionType = 63
-	ActionReorganizePartition       ActionType = 64
-	ActionAlterTTLInfo              ActionType = 65
-	ActionAlterTTLRemove            ActionType = 67
-	ActionCreateResourceGroup       ActionType = 68
-	ActionAlterResourceGroup        ActionType = 69
-	ActionDropResourceGroup         ActionType = 70
-	ActionAlterTablePartitioning    ActionType = 71
-	ActionRemovePartitioning        ActionType = 72
-	ActionAddVectorIndex            ActionType = 73
-	ActionCreateMaterializedViewLog ActionType = 74
-	ActionCreateMaterializedView    ActionType = 75
+	ActionAlterTableStatsOptions        ActionType = 58
+	ActionAlterNoCacheTable             ActionType = 59
+	ActionCreateTables                  ActionType = 60
+	ActionMultiSchemaChange             ActionType = 61
+	ActionFlashbackCluster              ActionType = 62
+	ActionRecoverSchema                 ActionType = 63
+	ActionReorganizePartition           ActionType = 64
+	ActionAlterTTLInfo                  ActionType = 65
+	ActionAlterTTLRemove                ActionType = 67
+	ActionCreateResourceGroup           ActionType = 68
+	ActionAlterResourceGroup            ActionType = 69
+	ActionDropResourceGroup             ActionType = 70
+	ActionAlterTablePartitioning        ActionType = 71
+	ActionRemovePartitioning            ActionType = 72
+	ActionAddVectorIndex                ActionType = 73
+	ActionCreateMaterializedViewLog     ActionType = 74
+	ActionCreateMaterializedView        ActionType = 75
+	ActionAlterMaterializedViewRefresh  ActionType = 76
+	ActionAlterMaterializedViewLogPurge ActionType = 77
 )
 
 // ActionMap is the map of DDL ActionType to string.
@@ -122,6 +124,8 @@ var ActionMap = map[ActionType]string{
 	ActionCreateTable:                   "create table",
 	ActionCreateMaterializedViewLog:     "create materialized view log",
 	ActionCreateMaterializedView:        "create materialized view",
+	ActionAlterMaterializedViewRefresh:  "alter materialized view refresh",
+	ActionAlterMaterializedViewLogPurge: "alter materialized view log purge",
 	ActionCreateTables:                  "create tables",
 	ActionDropTable:                     "drop table",
 	ActionAddColumn:                     "add column",

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -722,6 +722,46 @@ func GetModifyTableCommentArgs(job *Job) (*ModifyTableCommentArgs, error) {
 	return getOrDecodeArgs[*ModifyTableCommentArgs](&ModifyTableCommentArgs{}, job)
 }
 
+// AlterMaterializedViewRefreshArgs is the arguments for ActionAlterMaterializedViewRefresh ddl.
+type AlterMaterializedViewRefreshArgs struct {
+	RefreshMethod    string `json:"refresh_method,omitempty"`
+	RefreshStartWith string `json:"refresh_start_with,omitempty"`
+	RefreshNext      string `json:"refresh_next,omitempty"`
+}
+
+func (a *AlterMaterializedViewRefreshArgs) getArgsV1(*Job) []any {
+	return []any{a.RefreshMethod, a.RefreshStartWith, a.RefreshNext}
+}
+
+func (a *AlterMaterializedViewRefreshArgs) decodeV1(job *Job) error {
+	return errors.Trace(job.decodeArgs(&a.RefreshMethod, &a.RefreshStartWith, &a.RefreshNext))
+}
+
+// GetAlterMaterializedViewRefreshArgs gets the args for ActionAlterMaterializedViewRefresh.
+func GetAlterMaterializedViewRefreshArgs(job *Job) (*AlterMaterializedViewRefreshArgs, error) {
+	return getOrDecodeArgs[*AlterMaterializedViewRefreshArgs](&AlterMaterializedViewRefreshArgs{}, job)
+}
+
+// AlterMaterializedViewLogPurgeArgs is the arguments for ActionAlterMaterializedViewLogPurge ddl.
+type AlterMaterializedViewLogPurgeArgs struct {
+	PurgeMethod    string `json:"purge_method,omitempty"`
+	PurgeStartWith string `json:"purge_start_with,omitempty"`
+	PurgeNext      string `json:"purge_next,omitempty"`
+}
+
+func (a *AlterMaterializedViewLogPurgeArgs) getArgsV1(*Job) []any {
+	return []any{a.PurgeMethod, a.PurgeStartWith, a.PurgeNext}
+}
+
+func (a *AlterMaterializedViewLogPurgeArgs) decodeV1(job *Job) error {
+	return errors.Trace(job.decodeArgs(&a.PurgeMethod, &a.PurgeStartWith, &a.PurgeNext))
+}
+
+// GetAlterMaterializedViewLogPurgeArgs gets the args for ActionAlterMaterializedViewLogPurge.
+func GetAlterMaterializedViewLogPurgeArgs(job *Job) (*AlterMaterializedViewLogPurgeArgs, error) {
+	return getOrDecodeArgs[*AlterMaterializedViewLogPurgeArgs](&AlterMaterializedViewLogPurgeArgs{}, job)
+}
+
 // ModifyTableCharsetAndCollateArgs is the arguments for ActionModifyTableCharsetAndCollate ddl.
 type ModifyTableCharsetAndCollateArgs struct {
 	ToCharset          string `json:"to_charset,omitempty"`

--- a/pkg/meta/model/job_args_test.go
+++ b/pkg/meta/model/job_args_test.go
@@ -561,6 +561,38 @@ func TestGetModifyTableCommentArgs(t *testing.T) {
 	}
 }
 
+func TestGetAlterMaterializedViewRefreshArgs(t *testing.T) {
+	inArgs := &AlterMaterializedViewRefreshArgs{
+		RefreshMethod:    "FAST",
+		RefreshStartWith: "DATE_ADD(NOW(), INTERVAL 1 HOUR)",
+		RefreshNext:      "DATE_ADD(NOW(), INTERVAL 30 MINUTE)",
+	}
+
+	for _, v := range []JobVersion{JobVersion1, JobVersion2} {
+		j2 := &Job{}
+		require.NoError(t, j2.Decode(getJobBytes(t, inArgs, v, ActionAlterMaterializedViewRefresh)))
+		args, err := GetAlterMaterializedViewRefreshArgs(j2)
+		require.NoError(t, err)
+		require.Equal(t, inArgs, args)
+	}
+}
+
+func TestGetAlterMaterializedViewLogPurgeArgs(t *testing.T) {
+	inArgs := &AlterMaterializedViewLogPurgeArgs{
+		PurgeMethod:    "DEFERRED",
+		PurgeStartWith: "DATE_ADD(NOW(), INTERVAL 1 HOUR)",
+		PurgeNext:      "DATE_ADD(NOW(), INTERVAL 30 MINUTE)",
+	}
+
+	for _, v := range []JobVersion{JobVersion1, JobVersion2} {
+		j2 := &Job{}
+		require.NoError(t, j2.Decode(getJobBytes(t, inArgs, v, ActionAlterMaterializedViewLogPurge)))
+		args, err := GetAlterMaterializedViewLogPurgeArgs(j2)
+		require.NoError(t, err)
+		require.Equal(t, inArgs, args)
+	}
+}
+
 func TestGetAlterIndexVisibilityArgs(t *testing.T) {
 	inArgs := &AlterIndexVisibilityArgs{
 		IndexName: model.NewCIStr("index-name"),

--- a/pkg/session/test/common/BUILD.bazel
+++ b/pkg/session/test/common/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//pkg/config",
         "//pkg/expression",

--- a/pkg/session/test/common/common_test.go
+++ b/pkg/session/test/common/common_test.go
@@ -104,7 +104,7 @@ func TestRefreshMaterializedViewDoesNotMarkDDLExecution(t *testing.T) {
 
 	tk.MustExec("create table t_mv_flag (a int not null, b int not null)")
 	tk.MustExec("insert into t_mv_flag values (1, 10)")
-	tk.MustExec("create materialized view log on t_mv_flag (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t_mv_flag (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_flag (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t_mv_flag group by a")
 	require.NotNil(t, tk.Session().Value(sessionctx.LastExecuteDDL))
 
@@ -113,13 +113,35 @@ func TestRefreshMaterializedViewDoesNotMarkDDLExecution(t *testing.T) {
 	require.Nil(t, tk.Session().Value(sessionctx.LastExecuteDDL))
 }
 
+func TestPurgeMaterializedViewLogDisallowExplicitTransaction(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_mlog_purge_txn (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on t_mlog_purge_txn (a, b) purge next date_add(now(), interval 1 hour)")
+
+	tk.MustExec("begin")
+	tk.MustGetErrMsg(
+		"purge materialized view log on t_mlog_purge_txn",
+		"cannot run PURGE MATERIALIZED VIEW LOG in explicit transaction",
+	)
+	tk.MustExec("rollback")
+
+	tk.MustExec(`prepare stmt from "purge materialized view log on t_mlog_purge_txn"`)
+	defer tk.MustExec("deallocate prepare stmt")
+	tk.MustExec("begin")
+	tk.MustGetErrMsg("execute stmt", "cannot run PURGE MATERIALIZED VIEW LOG in explicit transaction")
+	tk.MustExec("rollback")
+}
+
 func TestPurgeMaterializedViewLogDoesNotMarkDDLExecution(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t_mlog_purge_flag (id int primary key, v int)")
-	tk.MustExec("create materialized view log on t_mlog_purge_flag (id, v) purge immediate")
+	tk.MustExec("create materialized view log on t_mlog_purge_flag (id, v) purge next date_add(now(), interval 1 hour)")
 	require.NotNil(t, tk.Session().Value(sessionctx.LastExecuteDDL))
 
 	tk.MustExec("insert into t_mlog_purge_flag values (1, 10), (2, 20)")

--- a/tests/integrationtest/r/executor/mview_log_dml.result
+++ b/tests/integrationtest/r/executor/mview_log_dml.result
@@ -108,12 +108,11 @@ drop table if exists `$mlog$t`;
 create table t (id int primary key, tracked int, untracked int);
 create materialized view log on t (id, tracked);
 alter table t drop column tracked;
-insert into t values (1, 100);
-Error 1105 (HY000): wrap table with mlog: base column tracked not found
-update t set untracked = 101 where id = 1;
-Error 1105 (HY000): wrap table with mlog: base column tracked not found
-delete from t where id = 1;
-Error 1105 (HY000): wrap table with mlog: base column tracked not found
+Error 8200 (HY000): Unsupported ALTER TABLE on base table column tracked referenced by materialized view log
+insert into t values (1, 100, 1000);
+select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`;
+id	tracked	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
+1	100	I	1
 drop table if exists t, `$mlog$t`;
 create table t(a int);
 create materialized view log on t (a);

--- a/tests/integrationtest/r/executor/mview_refresh.result
+++ b/tests/integrationtest/r/executor/mview_refresh.result
@@ -1,7 +1,7 @@
 use test;
 create table t_mv_txn_66385 (a int not null, b int not null);
 insert into t_mv_txn_66385 values (1, 10), (1, 5), (2, 7);
-create materialized view log on t_mv_txn_66385 (a, b) purge immediate;
+create materialized view log on t_mv_txn_66385 (a, b) purge next date_add(now(), interval 1 hour);
 create materialized view mv_txn_66385 (a, s, cnt) refresh fast next now() as
 select a, sum(b), count(1) from t_mv_txn_66385 group by a;
 begin;

--- a/tests/integrationtest/t/executor/mview_log_dml.test
+++ b/tests/integrationtest/t/executor/mview_log_dml.test
@@ -96,19 +96,16 @@ alter table t drop column untracked;
 update t set tracked = 11 where id = 1;
 select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 
-# Current behavior: DDL on tracked columns is not rejected up-front
+# DDL on tracked columns is rejected up-front
 
 drop table if exists t;
 drop table if exists `$mlog$t`;
 create table t (id int primary key, tracked int, untracked int);
 create materialized view log on t (id, tracked);
+--error 8200
 alter table t drop column tracked;
---error 1105
-insert into t values (1, 100);
---error 1105
-update t set untracked = 101 where id = 1;
---error 1105
-delete from t where id = 1;
+insert into t values (1, 100, 1000);
+select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`;
 
 # Test for issue #66245, the mlog table should not use the base table's auto-increment id by mistake.
 drop table if exists t, `$mlog$t`;

--- a/tests/integrationtest/t/executor/mview_refresh.test
+++ b/tests/integrationtest/t/executor/mview_refresh.test
@@ -4,7 +4,7 @@ use test;
 
 create table t_mv_txn_66385 (a int not null, b int not null);
 insert into t_mv_txn_66385 values (1, 10), (1, 5), (2, 7);
-create materialized view log on t_mv_txn_66385 (a, b) purge immediate;
+create materialized view log on t_mv_txn_66385 (a, b) purge next date_add(now(), interval 1 hour);
 create materialized view mv_txn_66385 (a, s, cnt) refresh fast next now() as
 select a, sum(b), count(1) from t_mv_txn_66385 group by a;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:

This PR adds several DDL refinements for materialized views and materialized view logs. It fills in schedule-alter support, rejects an invalid create-time purge mode, and narrows MV-related ALTER/INDEX constraints so safe index operations can proceed while unsafe metadata or column changes remain blocked.

### What changed and how does it work?

- Support altering MV and MV log schedules:
  - Add DDL support for `ALTER MATERIALIZED VIEW ... REFRESH [START WITH ...] [NEXT ...]`.
  - Add DDL support for `ALTER MATERIALIZED VIEW LOG ON ... PURGE [START WITH ...] [NEXT ...]`.
  - Validate schedule expressions and persist the updated `START WITH` / `NEXT` metadata through DDL job args.

- Reject create-time `PURGE IMMEDIATE` for materialized view logs:
  - `CREATE MATERIALIZED VIEW LOG ... PURGE IMMEDIATE` is now rejected.
  - Create-time purge scheduling requires deferred purge semantics with `PURGE NEXT ...`.
  - Schema tracker behavior and tests are updated consistently.

- Refine MV-related ALTER/INDEX constraints:
  - Allow safe index operations on materialized view tables, including create/drop/rename/invisible index operations and index constraints.
  - Keep materialized view log tables protected from unsupported ALTER/INDEX operations, except allowed TiFlash replica metadata changes.
  - Prevent ALTER TABLE operations on base table columns that are referenced by a materialized view log, including column drop/change/modify/rename and table charset/collation conversion that rewrites logged columns.

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Manual test:

```sh
bazel build //pkg/ddl:ddl //pkg/executor/test/ddl:ddl_test
make bazel_prepare
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Support altering materialized view and materialized view log schedules, reject create-time `PURGE IMMEDIATE` for materialized view logs, and refine MV-related ALTER/INDEX constraints.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ALTER MATERIALIZED VIEW ... REFRESH to manage refresh schedules
  * ALTER MATERIALIZED VIEW LOG ... PURGE to manage log purge schedules

* **Behavior Changes**
  * CREATE MATERIALIZED VIEW LOG requires deferred purge; PURGE IMMEDIATE unsupported; NEXT required for creates
  * Schedule expressions must evaluate to DATETIME/TIMESTAMP
  * Stronger ALTER TABLE/INDEX restrictions: operations touching columns/indexes referenced by MVs/MV-logs are rejected up‑front; MIN/MAX fast-refresh index dependencies enforced

* **Tests**
  * Added/updated tests for refresh/purge scheduling, metadata persistence, and dependency/error behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->