### PR TITLE
planner/mview: clean up mvmerge naming

### DIFF
--- a/pkg/executor/mview_delta_merge_agg_builder.go
+++ b/pkg/executor/mview_delta_merge_agg_builder.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
-	mviewmerge "github.com/pingcap/tidb/pkg/planner/mview"
+	"github.com/pingcap/tidb/pkg/planner/mview"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/ranger"
@@ -147,7 +147,7 @@ func (b *executorBuilder) buildMViewDeltaMerge(v *plannercore.MVDeltaMerge) exec
 
 func buildMViewDeltaMergeAggMappings(
 	sctx sessionctx.Context,
-	aggInfos []mviewmerge.AggInfo,
+	aggInfos []mview.AggInfo,
 	sourceFieldTypes []*types.FieldType,
 	deltaAggColCount int,
 ) ([]MViewDeltaMergeAggMapping, error) {
@@ -180,7 +180,7 @@ func buildMViewDeltaMergeAggMappings(
 			ColID:           []int{outputColID},
 			DependencyColID: deps,
 		}
-		if countStarMappingIdx < 0 && aggInfo.Kind == mviewmerge.AggCountStar {
+		if countStarMappingIdx < 0 && aggInfo.Kind == mview.AggCountStar {
 			countStarMappingIdx = mappingIdx
 		}
 		mappings = append(mappings, mapping)
@@ -292,15 +292,15 @@ func buildMViewDeltaMergeAggMappings(
 	return ordered, nil
 }
 
-func mviewDeltaMergeAggFuncName(kind mviewmerge.AggKind) (string, error) {
+func mviewDeltaMergeAggFuncName(kind mview.AggKind) (string, error) {
 	switch kind {
-	case mviewmerge.AggCountStar, mviewmerge.AggCount:
+	case mview.AggCountStar, mview.AggCount:
 		return ast.AggFuncCount, nil
-	case mviewmerge.AggSum:
+	case mview.AggSum:
 		return ast.AggFuncSum, nil
-	case mviewmerge.AggMin:
+	case mview.AggMin:
 		return ast.AggFuncMin, nil
-	case mviewmerge.AggMax:
+	case mview.AggMax:
 		return ast.AggFuncMax, nil
 	default:
 		return "", errors.Errorf("unsupported MViewDeltaMerge aggregate kind %v", kind)
@@ -308,11 +308,11 @@ func mviewDeltaMergeAggFuncName(kind mviewmerge.AggKind) (string, error) {
 }
 
 func mviewDeltaMergeAggArgExpr(
-	aggInfo mviewmerge.AggInfo,
+	aggInfo mview.AggInfo,
 	dependencies []int,
 	sourceFieldTypes []*types.FieldType,
 ) (expression.Expression, error) {
-	if aggInfo.Kind == mviewmerge.AggCountStar {
+	if aggInfo.Kind == mview.AggCountStar {
 		return expression.NewOne(), nil
 	}
 	if len(dependencies) == 0 {
@@ -340,7 +340,7 @@ func mviewDeltaMergeAggArgExpr(
 			dep,
 		)
 	}
-	if aggInfo.Kind == mviewmerge.AggMin || aggInfo.Kind == mviewmerge.AggMax {
+	if aggInfo.Kind == mview.AggMin || aggInfo.Kind == mview.AggMax {
 		if len(dependencies) != 4 && len(dependencies) != 5 {
 			return nil, errors.Errorf(
 				"MVDeltaMerge aggregate %v at mview offset %d expects 4 or 5 dependencies, got %d",
@@ -510,7 +510,7 @@ func buildMVDeltaMergeMinMaxResultColByMViewOffset(v *plannercore.MVDeltaMerge) 
 				v.MVColumnCount,
 			)
 		}
-		if aggInfo.Kind != mviewmerge.AggMin && aggInfo.Kind != mviewmerge.AggMax {
+		if aggInfo.Kind != mview.AggMin && aggInfo.Kind != mview.AggMax {
 			continue
 		}
 		if minMaxResultColByMViewOffset == nil {

--- a/pkg/planner/core/casetest/mview/mv_refresh_test.go
+++ b/pkg/planner/core/casetest/mview/mv_refresh_test.go
@@ -115,14 +115,14 @@ func TestBuildRefreshMVFastPlan(t *testing.T) {
 	var hasCountStar, hasCountExpr, hasSum bool
 	for _, aggInfo := range mergePlan.AggInfos {
 		switch aggInfo.Kind {
-		case mvmerge.AggCountStar:
+		case mview.AggCountStar:
 			hasCountStar = true
 			require.Equal(t, []int{0}, aggInfo.Dependencies)
-		case mvmerge.AggCount:
+		case mview.AggCount:
 			hasCountExpr = true
 			require.Equal(t, "b", aggInfo.ArgColName)
 			require.Equal(t, []int{1}, aggInfo.Dependencies)
-		case mvmerge.AggSum:
+		case mview.AggSum:
 			hasSum = true
 			require.Equal(t, "b", aggInfo.ArgColName)
 			require.Equal(t, []int{2, 5}, aggInfo.Dependencies)
@@ -240,7 +240,7 @@ func TestBuildRefreshMVFastPlanWithMinMaxHasFullUpdate(t *testing.T) {
 	require.NotNil(t, mergePlan.FullUpdateInnerSource)
 	minMaxCount := 0
 	for _, ai := range mergePlan.AggInfos {
-		if ai.Kind == mvmerge.AggMin || ai.Kind == mvmerge.AggMax {
+		if ai.Kind == mview.AggMin || ai.Kind == mview.AggMax {
 			minMaxCount++
 		}
 	}
@@ -259,7 +259,7 @@ func TestBuildRefreshMVFastPlanWithMinMaxHasFullUpdate(t *testing.T) {
 		mvOffsetCount[mvOffset]++
 	}
 	for _, ai := range mergePlan.AggInfos {
-		if ai.Kind == mvmerge.AggMin || ai.Kind == mvmerge.AggMax {
+		if ai.Kind == mview.AggMin || ai.Kind == mview.AggMax {
 			require.Equal(t, 1, mvOffsetCount[ai.MVOffset])
 		}
 	}
@@ -573,10 +573,10 @@ func TestBuildRefreshMVFastSumNotNullNoCountExpr(t *testing.T) {
 	var hasCountStar, hasSum bool
 	for _, aggInfo := range mergePlan.AggInfos {
 		switch aggInfo.Kind {
-		case mvmerge.AggCountStar:
+		case mview.AggCountStar:
 			hasCountStar = true
 			require.Equal(t, []int{0}, aggInfo.Dependencies)
-		case mvmerge.AggSum:
+		case mview.AggSum:
 			hasSum = true
 			require.Equal(t, "b", aggInfo.ArgColName)
 			require.Equal(t, []int{1}, aggInfo.Dependencies)
@@ -586,7 +586,7 @@ func TestBuildRefreshMVFastSumNotNullNoCountExpr(t *testing.T) {
 	require.True(t, hasSum)
 }
 
-func TestMVMergeBuildResultHandleCols(t *testing.T) {
+func TestMViewBuildResultHandleCols(t *testing.T) {
 	type handleCase struct {
 		name               string
 		baseID             int64
@@ -625,7 +625,7 @@ func TestMVMergeBuildResultHandleCols(t *testing.T) {
 			},
 			expectHandleIsInt:  true,
 			expectHandleIdxs:   []int{3},
-			expectHandleLayout: []string{"__mvmerge_mv_rowid"},
+			expectHandleLayout: []string{"__mview_mv_rowid"},
 		},
 		{
 			name:   "int_handle",
@@ -707,7 +707,7 @@ func TestMVMergeBuildResultHandleCols(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			baseTbl, mlogTbl := buildBaseAndMLogForHandleTest(tc.baseID, tc.mlogID, tc.baseCols)
 			mvTbl := tc.buildMV(tc.baseID, tc.mvID)
-			res, outputNames := buildMVMergeResultForHandleTest(t, baseTbl, mlogTbl, mvTbl)
+			res, outputNames := buildMViewResultForHandleTest(t, baseTbl, mlogTbl, mvTbl)
 			require.NotNil(t, res.MVTablePKCols)
 			require.Equal(t, tc.expectHandleIsInt, res.MVTablePKCols.IsInt())
 			require.Equal(t, len(tc.expectHandleIdxs), res.MVTablePKCols.NumCols())
@@ -767,20 +767,20 @@ func buildBaseAndMLogForHandleTest(baseID, mlogID int64, cols []handleColDef) (*
 	return baseTbl, mlogTbl
 }
 
-func buildMVMergeResultForHandleTest(
+func buildMViewResultForHandleTest(
 	t *testing.T,
 	baseTbl, mlogTbl, mvTbl *model.TableInfo,
-) (*mvmerge.BuildResult, types.NameSlice) {
+) (*mview.BuildResult, types.NameSlice) {
 	t.Helper()
 	sctx := plannercore.MockContext()
 	is := infoschema.MockInfoSchema([]*model.TableInfo{baseTbl, mlogTbl, mvTbl})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	res, err := mvmerge.Build(
+	res, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mvTbl,
-		mvmerge.BuildOptions{FromTS: 1},
+		mview.BuildOptions{FromTS: 1},
 		nil,
 	)
 	require.NoError(t, err)
@@ -801,7 +801,7 @@ func buildMVMergeResultForHandleTest(
 
 func assertHandleColsMatchMergeSourceLayout(
 	t *testing.T,
-	res *mvmerge.BuildResult,
+	res *mview.BuildResult,
 	outputNames types.NameSlice,
 	expectedCols []string,
 ) {

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -604,7 +604,7 @@ type MVDeltaMerge struct {
 	GroupKeyMVOffsets []int           `plan-cache-clone:"shallow"`
 	CountStarMVOffset int
 
-	AggInfos []mvmerge.AggInfo `plan-cache-clone:"shallow"`
+	AggInfos []mview.AggInfo `plan-cache-clone:"shallow"`
 }
 
 // ExplainInfo returns aggregate dependency information for MV delta merge.
@@ -628,7 +628,7 @@ func (p *MVDeltaMerge) ExplainInfo() string {
 	return builder.String()
 }
 
-func formatMVDeltaMergeAggDependency(aggInfo mvmerge.AggInfo) string {
+func formatMVDeltaMergeAggDependency(aggInfo mview.AggInfo) string {
 	var builder strings.Builder
 	builder.WriteString(formatMVDeltaMergeAggName(aggInfo))
 	builder.WriteString("@")
@@ -638,8 +638,8 @@ func formatMVDeltaMergeAggDependency(aggInfo mvmerge.AggInfo) string {
 	return builder.String()
 }
 
-func formatMVDeltaMergeAggName(aggInfo mvmerge.AggInfo) string {
-	if aggInfo.Kind == mvmerge.AggCountStar {
+func formatMVDeltaMergeAggName(aggInfo mview.AggInfo) string {
+	if aggInfo.Kind == mview.AggCountStar {
 		return "count(*)"
 	}
 	aggKindName := formatMVDeltaMergeAggKind(aggInfo.Kind)
@@ -649,15 +649,15 @@ func formatMVDeltaMergeAggName(aggInfo mvmerge.AggInfo) string {
 	return aggKindName + "(" + aggInfo.ArgColName + ")"
 }
 
-func formatMVDeltaMergeAggKind(kind mvmerge.AggKind) string {
+func formatMVDeltaMergeAggKind(kind mview.AggKind) string {
 	switch kind {
-	case mvmerge.AggCount:
+	case mview.AggCount:
 		return "count"
-	case mvmerge.AggSum:
+	case mview.AggSum:
 		return "sum"
-	case mvmerge.AggMin:
+	case mview.AggMin:
 		return "min"
-	case mvmerge.AggMax:
+	case mview.AggMax:
 		return "max"
 	default:
 		return fmt.Sprintf("agg(%d)", kind)

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3889,7 +3889,7 @@ func (b *PlanBuilder) buildRefreshMaterializedViewImplement(ctx context.Context,
 		}
 		logic, ok := p.(base.LogicalPlan)
 		if !ok {
-			return nil, errors.Errorf("mvmerge: expected logical plan from select, got %T", p)
+			return nil, errors.Errorf("mview: expected logical plan from select, got %T", p)
 		}
 		pp, _, err := DoOptimize(optCtx, b.ctx, innerBuilder.GetOptFlag(), logic)
 		if err != nil {
@@ -3898,13 +3898,13 @@ func (b *PlanBuilder) buildRefreshMaterializedViewImplement(ctx context.Context,
 		return pp, nil
 	}
 
-	res, err := mvmerge.Build(b.ctx, b.is, mvInfo, mvmerge.BuildOptions{FromTS: fromTS}, nil)
+	res, err := mview.Build(b.ctx, b.is, mvInfo, mview.BuildOptions{FromTS: fromTS}, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	if res.MergeSourceSelect == nil {
-		return nil, errors.New("mvmerge: merge source select is nil")
+		return nil, errors.New("mview: merge source select is nil")
 	}
 	sourcePlan, err := optimizeSelect(ctx, res.MergeSourceSelect)
 	if err != nil {
@@ -3927,11 +3927,11 @@ func (b *PlanBuilder) buildRefreshMaterializedViewImplement(ctx context.Context,
 	)
 	if res.FullUpdateLookupTemplateSelect != nil {
 		if res.FullUpdateLookupColumnCount <= 0 {
-			return nil, errors.New("mvmerge full-update lookup template: invalid output column count")
+			return nil, errors.New("mview full-update lookup template: invalid output column count")
 		}
 		if len(res.FullUpdateLookupMVOffsets) != res.FullUpdateLookupColumnCount {
 			return nil, errors.Errorf(
-				"mvmerge full-update lookup template: invalid mv-offset mapping length: got %d, expected %d",
+				"mview full-update lookup template: invalid mv-offset mapping length: got %d, expected %d",
 				len(res.FullUpdateLookupMVOffsets),
 				res.FullUpdateLookupColumnCount,
 			)
@@ -3946,7 +3946,7 @@ func (b *PlanBuilder) buildRefreshMaterializedViewImplement(ctx context.Context,
 			return nil, err
 		}
 		if fullUpdateLookupPlan.Schema().Len() != res.FullUpdateLookupColumnCount {
-			return nil, errors.Errorf("mvmerge full-update lookup template: unexpected output schema length: got %d, expected %d", fullUpdateLookupPlan.Schema().Len(), res.FullUpdateLookupColumnCount)
+			return nil, errors.Errorf("mview full-update lookup template: unexpected output schema length: got %d, expected %d", fullUpdateLookupPlan.Schema().Len(), res.FullUpdateLookupColumnCount)
 		}
 		var template *mvFullUpdateLookupTemplate
 		template, err = extractMVFullUpdateLookupTemplate(
@@ -3999,7 +3999,7 @@ type mvFullUpdateLookupTemplate struct {
 
 // extractMVFullUpdateLookupTemplate extracts executor-facing lookup metadata from the optimized
 // full-update lookup template plan. The optimized plan is expected to contain an IndexJoin-style
-// shape produced from mvmerge.FullUpdateLookupTemplateSelect; this helper discards the outer probe
+// shape produced from mview.FullUpdateLookupTemplateSelect; this helper discards the outer probe
 // side and keeps only the inner lookup child, index-range template, key-position mapping, and the
 // output-column to MV-offset mapping needed by MVDeltaMerge full recomputation.
 //
@@ -4015,18 +4015,18 @@ func extractMVFullUpdateLookupTemplate(
 	groupKeyMVOffsets []int,
 ) (*mvFullUpdateLookupTemplate, error) {
 	if lookupPlan == nil {
-		return nil, errors.New("mvmerge full-update lookup template: lookup plan is nil")
+		return nil, errors.New("mview full-update lookup template: lookup plan is nil")
 	}
 	if len(expectedOutputMVOffsets) != expectedInnerColumnCount {
 		return nil, errors.Errorf(
-			"mvmerge full-update lookup template: unexpected output mv-offset mapping length: got %d, expected %d",
+			"mview full-update lookup template: unexpected output mv-offset mapping length: got %d, expected %d",
 			len(expectedOutputMVOffsets),
 			expectedInnerColumnCount,
 		)
 	}
 	if len(groupKeyMVOffsets) != expectedGroupKeyCount {
 		return nil, errors.Errorf(
-			"mvmerge full-update lookup template: unexpected group key mv-offset length: got %d, expected %d",
+			"mview full-update lookup template: unexpected group key mv-offset length: got %d, expected %d",
 			len(groupKeyMVOffsets),
 			expectedGroupKeyCount,
 		)
@@ -4034,29 +4034,29 @@ func extractMVFullUpdateLookupTemplate(
 
 	indexJoin := findMVFullUpdateIndexJoinTemplatePlan(lookupPlan)
 	if indexJoin == nil {
-		return nil, errors.New("mvmerge full-update lookup template: expected index join plan but not found")
+		return nil, errors.New("mview full-update lookup template: expected index join plan but not found")
 	}
 	if indexJoin.innerPlan == nil {
-		return nil, errors.New("mvmerge full-update lookup template: index join inner plan is nil")
+		return nil, errors.New("mview full-update lookup template: index join inner plan is nil")
 	}
 	if indexJoin.innerPlan.Schema().Len() != expectedInnerColumnCount {
 		return nil, errors.Errorf(
-			"mvmerge full-update lookup template: unexpected inner schema length: got %d, expected %d",
+			"mview full-update lookup template: unexpected inner schema length: got %d, expected %d",
 			indexJoin.innerPlan.Schema().Len(),
 			expectedInnerColumnCount,
 		)
 	}
 	if indexJoin.Ranges == nil || len(indexJoin.Ranges.Range()) == 0 {
-		return nil, errors.New("mvmerge full-update lookup template: index join ranges are empty")
+		return nil, errors.New("mview full-update lookup template: index join ranges are empty")
 	}
 	// The fallback template is built from pure group-key equality join without range-comparison predicates.
-	intest.Assert(indexJoin.CompareFilters == nil, "mvmerge full-update lookup template should not have compare filters")
+	intest.Assert(indexJoin.CompareFilters == nil, "mview full-update lookup template should not have compare filters")
 
 	// Keep key mapping in MV group-key order; executor side will refill each key into the corresponding index position.
 	keyOff2IdxOff := append([]int(nil), indexJoin.KeyOff2IdxOff...)
 	if len(keyOff2IdxOff) != expectedGroupKeyCount {
 		return nil, errors.Errorf(
-			"mvmerge full-update lookup template: unexpected keyOff2IdxOff length: got %d, expected %d",
+			"mview full-update lookup template: unexpected keyOff2IdxOff length: got %d, expected %d",
 			len(keyOff2IdxOff),
 			expectedGroupKeyCount,
 		)
@@ -4065,7 +4065,7 @@ func extractMVFullUpdateLookupTemplate(
 	for i, idxOff := range keyOff2IdxOff {
 		if idxOff < 0 || idxOff >= rangeWidth {
 			return nil, errors.Errorf(
-				"mvmerge full-update lookup template: invalid keyOff2IdxOff[%d]=%d for range width %d",
+				"mview full-update lookup template: invalid keyOff2IdxOff[%d]=%d for range width %d",
 				i,
 				idxOff,
 				rangeWidth,
@@ -4074,7 +4074,7 @@ func extractMVFullUpdateLookupTemplate(
 	}
 	if len(indexJoin.InnerJoinKeys) != expectedGroupKeyCount {
 		return nil, errors.Errorf(
-			"mvmerge full-update lookup template: unexpected inner join key count: got %d, expected %d",
+			"mview full-update lookup template: unexpected inner join key count: got %d, expected %d",
 			len(indexJoin.InnerJoinKeys),
 			expectedGroupKeyCount,
 		)
@@ -4084,7 +4084,7 @@ func extractMVFullUpdateLookupTemplate(
 		keyResultColIdx := indexJoin.InnerJoinKeys[i].Index
 		if keyResultColIdx < 0 || keyResultColIdx >= indexJoin.innerPlan.Schema().Len() {
 			return nil, errors.Errorf(
-				"mvmerge full-update lookup template: invalid inner join key index %d at position %d for inner schema len %d",
+				"mview full-update lookup template: invalid inner join key index %d at position %d for inner schema len %d",
 				keyResultColIdx,
 				i,
 				indexJoin.innerPlan.Schema().Len(),
@@ -4125,14 +4125,14 @@ func deriveMVFullUpdateOutputMVOffsetsByInnerSchema(
 ) ([]int, error) {
 	if len(lookupOutputMVOffsets) != innerColumnCount {
 		return nil, errors.Errorf(
-			"mvmerge full-update lookup template: unexpected lookup output mv-offset length: got %d, expected %d",
+			"mview full-update lookup template: unexpected lookup output mv-offset length: got %d, expected %d",
 			len(lookupOutputMVOffsets),
 			innerColumnCount,
 		)
 	}
 	if len(groupKeyMVOffsets) != len(keyResultColIdxes) {
 		return nil, errors.Errorf(
-			"mvmerge full-update lookup template: group key mapping length mismatch: group key mv offsets=%d, key result indexes=%d",
+			"mview full-update lookup template: group key mapping length mismatch: group key mv offsets=%d, key result indexes=%d",
 			len(groupKeyMVOffsets),
 			len(keyResultColIdxes),
 		)
@@ -4147,27 +4147,27 @@ func deriveMVFullUpdateOutputMVOffsetsByInnerSchema(
 	for keyPos, mvOffset := range groupKeyMVOffsets {
 		if mvOffset < 0 {
 			return nil, errors.Errorf(
-				"mvmerge full-update lookup template: invalid group key mv offset %d at position %d",
+				"mview full-update lookup template: invalid group key mv offset %d at position %d",
 				mvOffset,
 				keyPos,
 			)
 		}
 		if _, dup := groupKeySet[mvOffset]; dup {
-			return nil, errors.Errorf("mvmerge full-update lookup template: duplicate group key mv offset %d", mvOffset)
+			return nil, errors.Errorf("mview full-update lookup template: duplicate group key mv offset %d", mvOffset)
 		}
 		groupKeySet[mvOffset] = struct{}{}
 
 		keyResultColIdx := keyResultColIdxes[keyPos]
 		if keyResultColIdx < 0 || keyResultColIdx >= innerColumnCount {
 			return nil, errors.Errorf(
-				"mvmerge full-update lookup template: key result col idx %d at position %d out of range [0,%d)",
+				"mview full-update lookup template: key result col idx %d at position %d out of range [0,%d)",
 				keyResultColIdx,
 				keyPos,
 				innerColumnCount,
 			)
 		}
 		if outputMVOffsets[keyResultColIdx] >= 0 {
-			return nil, errors.Errorf("mvmerge full-update lookup template: duplicate key result col idx %d", keyResultColIdx)
+			return nil, errors.Errorf("mview full-update lookup template: duplicate key result col idx %d", keyResultColIdx)
 		}
 		outputMVOffsets[keyResultColIdx] = mvOffset
 	}
@@ -4175,7 +4175,7 @@ func deriveMVFullUpdateOutputMVOffsetsByInnerSchema(
 	nonKeyMVOffsets := make([]int, 0, len(lookupOutputMVOffsets)-len(groupKeyMVOffsets))
 	for _, mvOffset := range lookupOutputMVOffsets {
 		if mvOffset < 0 {
-			return nil, errors.Errorf("mvmerge full-update lookup template: invalid output mv offset %d", mvOffset)
+			return nil, errors.Errorf("mview full-update lookup template: invalid output mv offset %d", mvOffset)
 		}
 		if _, isKey := groupKeySet[mvOffset]; isKey {
 			continue
@@ -4190,7 +4190,7 @@ func deriveMVFullUpdateOutputMVOffsetsByInnerSchema(
 	}
 	if len(unassignedResultColIdxes) != len(nonKeyMVOffsets) {
 		return nil, errors.Errorf(
-			"mvmerge full-update lookup template: non-key column mapping mismatch: unassigned result columns=%d, non-key mv offsets=%d",
+			"mview full-update lookup template: non-key column mapping mismatch: unassigned result columns=%d, non-key mv offsets=%d",
 			len(unassignedResultColIdxes),
 			len(nonKeyMVOffsets),
 		)

--- a/pkg/planner/mview/BUILD.bazel
+++ b/pkg/planner/mview/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "mview",
-    srcs = ["mvmerge.go"],
+    srcs = ["mview.go"],
     importpath = "github.com/pingcap/tidb/pkg/planner/mview",
     visibility = ["//visibility:public"],
     deps = [
@@ -26,7 +26,7 @@ go_library(
 go_test(
     name = "mview_test",
     timeout = "short",
-    srcs = ["mvmerge_test.go"],
+    srcs = ["mview_test.go"],
     flaky = True,
     shard_count = 10,
     deps = [

--- a/pkg/planner/mview/mview.go
+++ b/pkg/planner/mview/mview.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mvmerge
+package mview
 
 import (
 	"fmt"
@@ -41,8 +41,8 @@ const (
 	fullUpdateOuterAlias = "full_outer"
 	fullUpdateInnerAlias = "full_inner"
 
-	deltaCntStarName = "__mvmerge_delta_cnt_star"
-	mvRowIDName      = "__mvmerge_mv_rowid"
+	deltaCntStarName = "__mview_delta_cnt_star"
+	mvRowIDName      = "__mview_mv_rowid"
 )
 
 // SQL construction overview:
@@ -312,7 +312,7 @@ func buildLocal(
 		}
 	}
 	if countStarMVOffset < 0 {
-		return nil, errors.New("materialized view definition must include COUNT(*) for mvmerge")
+		return nil, errors.New("materialized view definition must include COUNT(*) for mview")
 	}
 
 	return &buildLocalResult{
@@ -336,7 +336,7 @@ func buildLocal(
 //
 // Final SQL shape:
 //
-//	SELECT <delta payload cols>, <mv cols>, [mv._tidb_rowid AS __mvmerge_mv_rowid]
+//	SELECT <delta payload cols>, <mv cols>, [mv._tidb_rowid AS __mview_mv_rowid]
 //	FROM (
 //	  <stage-1 delta aggregation on mlog>
 //	) AS delta
@@ -352,10 +352,10 @@ func buildFromLocal(
 	aggArgNotNullByOffset map[int]bool,
 ) (*BuildResult, error) {
 	if local == nil {
-		return nil, errors.New("mvmerge: local result is nil")
+		return nil, errors.New("mview: local result is nil")
 	}
 	if local.MVSelect == nil {
-		return nil, errors.New("mvmerge: local MVSelect is nil")
+		return nil, errors.New("mview: local MVSelect is nil")
 	}
 	if aggArgNotNullByOffset == nil {
 		aggArgNotNullByOffset = inferAggArgNotNullByOffset(local)
@@ -395,12 +395,12 @@ func buildFromLocal(
 			return nil, err
 		}
 		if fullUpdateSel.Fields == nil {
-			return nil, errors.New("mvmerge: full-update lookup template has nil field list")
+			return nil, errors.New("mview: full-update lookup template has nil field list")
 		}
 		fullUpdateColumnCount = len(fullUpdateSel.Fields.Fields)
 		if len(fullUpdateMVOffsets) != fullUpdateColumnCount {
 			return nil, errors.Errorf(
-				"mvmerge: full-update lookup template mv-offset mapping length mismatch: got %d, expected %d",
+				"mview: full-update lookup template mv-offset mapping length mismatch: got %d, expected %d",
 				len(fullUpdateMVOffsets),
 				fullUpdateColumnCount,
 			)
@@ -427,7 +427,7 @@ func buildFromLocal(
 	}
 
 	// TODO: Revisit dependency-check ownership. We currently validate/derive aggregate dependencies
-	// in planner mvmerge, but this may be moved to another stage (for example, MV creation-time checks)
+	// in planner mview, but this may be moved to another stage (for example, MV creation-time checks)
 	// after we evaluate end-to-end guarantees and maintenance cost.
 	sumToCountExprIdx, err := mapSumToCountExprDependencies(local.aggCols, aggArgNotNullByOffset)
 	if err != nil {
@@ -695,7 +695,7 @@ func extractGroupKeyOffsetsFromMVSelect(sel *ast.SelectStmt) ([]int, error) {
 	for _, item := range sel.GroupBy.Items {
 		col, ok := item.Expr.(*ast.ColumnNameExpr)
 		if !ok {
-			return nil, errors.New("GROUP BY expression must be a column name for mvmerge")
+			return nil, errors.New("GROUP BY expression must be a column name for mview")
 		}
 		off, ok := offsetByColName[col.Name.Name.L]
 		if !ok {
@@ -717,10 +717,10 @@ func extractAggInfosFromMVSelect(sel *ast.SelectStmt) (aggCols []aggColInfo, has
 		switch strings.ToLower(agg.F) {
 		case ast.AggFuncCount:
 			if len(agg.Args) != 1 {
-				return nil, false, errors.New("COUNT must have exactly one argument for mvmerge stage-1")
+				return nil, false, errors.New("COUNT must have exactly one argument for mview stage-1")
 			}
 			if agg.Distinct {
-				return nil, false, errors.New("COUNT(DISTINCT ...) is not supported in mvmerge stage-1")
+				return nil, false, errors.New("COUNT(DISTINCT ...) is not supported in mview stage-1")
 			}
 			if isCountStarOrOneArg(agg.Args[0]) {
 				aggCols = append(aggCols, aggColInfo{
@@ -743,15 +743,15 @@ func extractAggInfosFromMVSelect(sel *ast.SelectStmt) (aggCols []aggColInfo, has
 					}
 					return ai
 				}(),
-				deltaName: fmt.Sprintf("__mvmerge_delta_cnt_%d", i),
+				deltaName: fmt.Sprintf("__mview_delta_cnt_%d", i),
 				argExpr:   stripColumnQualifier(agg.Args[0]),
 			})
 		case ast.AggFuncSum:
 			if len(agg.Args) != 1 {
-				return nil, false, errors.New("SUM must have exactly one argument for mvmerge stage-1")
+				return nil, false, errors.New("SUM must have exactly one argument for mview stage-1")
 			}
 			if agg.Distinct {
-				return nil, false, errors.New("SUM(DISTINCT ...) is not supported in mvmerge stage-1")
+				return nil, false, errors.New("SUM(DISTINCT ...) is not supported in mview stage-1")
 			}
 			ai := AggInfo{
 				Kind:     AggSum,
@@ -762,13 +762,13 @@ func extractAggInfosFromMVSelect(sel *ast.SelectStmt) (aggCols []aggColInfo, has
 			}
 			aggCols = append(aggCols, aggColInfo{
 				info:      ai,
-				deltaName: fmt.Sprintf("__mvmerge_delta_sum_%d", i),
+				deltaName: fmt.Sprintf("__mview_delta_sum_%d", i),
 				argExpr:   stripColumnQualifier(agg.Args[0]),
 			})
 		case ast.AggFuncMax:
 			argCol, ok := agg.Args[0].(*ast.ColumnNameExpr)
 			if !ok {
-				return nil, false, errors.New("MAX argument must be a column name for mvmerge")
+				return nil, false, errors.New("MAX argument must be a column name for mview")
 			}
 			hasMinMax = true
 			aggCols = append(aggCols, aggColInfo{
@@ -777,16 +777,16 @@ func extractAggInfosFromMVSelect(sel *ast.SelectStmt) (aggCols []aggColInfo, has
 					MVOffset:   i,
 					ArgColName: argCol.Name.Name.L,
 				},
-				deltaName:           fmt.Sprintf("__mvmerge_max_in_added_%d", i),
-				addedCountDeltaName: fmt.Sprintf("__mvmerge_max_cnt_in_added_%d", i),
-				removedValueDelta:   fmt.Sprintf("__mvmerge_max_in_removed_%d", i),
-				removedCountDelta:   fmt.Sprintf("__mvmerge_max_cnt_in_removed_%d", i),
+				deltaName:           fmt.Sprintf("__mview_max_in_added_%d", i),
+				addedCountDeltaName: fmt.Sprintf("__mview_max_cnt_in_added_%d", i),
+				removedValueDelta:   fmt.Sprintf("__mview_max_in_removed_%d", i),
+				removedCountDelta:   fmt.Sprintf("__mview_max_cnt_in_removed_%d", i),
 				argExpr:             stripColumnQualifier(agg.Args[0]),
 			})
 		case ast.AggFuncMin:
 			argCol, ok := agg.Args[0].(*ast.ColumnNameExpr)
 			if !ok {
-				return nil, false, errors.New("MIN argument must be a column name for mvmerge")
+				return nil, false, errors.New("MIN argument must be a column name for mview")
 			}
 			hasMinMax = true
 			aggCols = append(aggCols, aggColInfo{
@@ -795,14 +795,14 @@ func extractAggInfosFromMVSelect(sel *ast.SelectStmt) (aggCols []aggColInfo, has
 					MVOffset:   i,
 					ArgColName: argCol.Name.Name.L,
 				},
-				deltaName:           fmt.Sprintf("__mvmerge_min_in_added_%d", i),
-				addedCountDeltaName: fmt.Sprintf("__mvmerge_min_cnt_in_added_%d", i),
-				removedValueDelta:   fmt.Sprintf("__mvmerge_min_in_removed_%d", i),
-				removedCountDelta:   fmt.Sprintf("__mvmerge_min_cnt_in_removed_%d", i),
+				deltaName:           fmt.Sprintf("__mview_min_in_added_%d", i),
+				addedCountDeltaName: fmt.Sprintf("__mview_min_cnt_in_added_%d", i),
+				removedValueDelta:   fmt.Sprintf("__mview_min_in_removed_%d", i),
+				removedCountDelta:   fmt.Sprintf("__mview_min_cnt_in_removed_%d", i),
 				argExpr:             stripColumnQualifier(agg.Args[0]),
 			})
 		default:
-			return nil, false, errors.Errorf("unsupported aggregate function %s in mvmerge stage-1", agg.F)
+			return nil, false, errors.Errorf("unsupported aggregate function %s in mview stage-1", agg.F)
 		}
 	}
 	return aggCols, hasMinMax, nil
@@ -1119,12 +1119,12 @@ func stripAllParentheses(expr ast.ExprNode) ast.ExprNode {
 //
 //	SELECT
 //	  <group keys from MV SELECT list>,
-//	  SUM(old_new) AS __mvmerge_delta_cnt_star,
-//	  SUM(IF(<count arg> IS NOT NULL, old_new, 0)) AS __mvmerge_delta_cnt_<i>,
-//	  SUM(IF(old_new = 1, <sum arg>, -<sum arg>)) AS __mvmerge_delta_sum_<i>,
-//	  MAX(IF(old_new = 1, <arg>, NULL)) AS __mvmerge_max_in_added_<i>,
-//	  MIN(IF(old_new = 1, <arg>, NULL)) AS __mvmerge_min_in_added_<i>,
-//	  SUM(IF(old_new = -1, 1, 0)) AS __mvmerge_removed_rows   -- only when MIN/MAX exists
+//	  SUM(old_new) AS __mview_delta_cnt_star,
+//	  SUM(IF(<count arg> IS NOT NULL, old_new, 0)) AS __mview_delta_cnt_<i>,
+//	  SUM(IF(old_new = 1, <sum arg>, -<sum arg>)) AS __mview_delta_sum_<i>,
+//	  MAX(IF(old_new = 1, <arg>, NULL)) AS __mview_max_in_added_<i>,
+//	  MIN(IF(old_new = 1, <arg>, NULL)) AS __mview_min_in_added_<i>,
+//	  SUM(IF(old_new = -1, 1, 0)) AS __mview_removed_rows   -- only when MIN/MAX exists
 //	FROM <db>.<mlog>
 //	WHERE _tidb_commit_ts > FromTS
 //	  AND <MV WHERE predicate>
@@ -1187,7 +1187,7 @@ func buildMLogDeltaSelect(
 			continue
 		case AggCount:
 			if ac.argExpr == nil {
-				return nil, errors.New("COUNT aggregate argument is nil for mvmerge")
+				return nil, errors.New("COUNT aggregate argument is nil for mview")
 			}
 			argExpr, err := cloneExprByRestore(sctx, ac.argExpr)
 			if err != nil {
@@ -1200,7 +1200,7 @@ func buildMLogDeltaSelect(
 			})
 		case AggSum:
 			if ac.argExpr == nil {
-				return nil, errors.New("SUM aggregate argument is nil for mvmerge")
+				return nil, errors.New("SUM aggregate argument is nil for mview")
 			}
 			argExpr, err := cloneExprByRestore(sctx, ac.argExpr)
 			if err != nil {
@@ -1213,7 +1213,7 @@ func buildMLogDeltaSelect(
 			})
 		case AggMax:
 			if ac.info.ArgColName == "" {
-				return nil, errors.New("MAX aggregate argument column is empty for mvmerge")
+				return nil, errors.New("MAX aggregate argument column is empty for mview")
 			}
 			argCol := colExpr(ac.info.ArgColName)
 			addedCond := binary(opcode.EQ, oldNewCol, ast.NewValueExpr(int64(1), "", ""))
@@ -1240,7 +1240,7 @@ func buildMLogDeltaSelect(
 			)
 		case AggMin:
 			if ac.info.ArgColName == "" {
-				return nil, errors.New("MIN aggregate argument column is empty for mvmerge")
+				return nil, errors.New("MIN aggregate argument column is empty for mview")
 			}
 			argCol := colExpr(ac.info.ArgColName)
 			addedCond := binary(opcode.EQ, oldNewCol, ast.NewValueExpr(int64(1), "", ""))
@@ -1306,7 +1306,7 @@ func buildMLogDeltaSelect(
 //	  delta.<all delta payload cols>,
 //	  delta.<group-key mv columns>,   -- projected from delta side to keep changed groups
 //	  mv.<non-group-key mv columns>,
-//	  mv._tidb_rowid AS __mvmerge_mv_rowid  -- only for extra row-id handle tables
+//	  mv._tidb_rowid AS __mview_mv_rowid  -- only for extra row-id handle tables
 //	FROM (<stage-1 delta select>) AS delta
 //	LEFT JOIN <db>.<mv> AS mv
 //	  ON delta.<group_key_1> [= | <=>] mv.<group_key_1>
@@ -1350,7 +1350,7 @@ func buildMergeSourceSelect(
 		}
 	}
 	if onExpr == nil {
-		return nil, nil, -1, errors.New("empty join key for mvmerge")
+		return nil, nil, -1, errors.New("empty join key for mview")
 	}
 
 	// Use delta as left side so every changed group survives even when MV row doesn't exist yet.
@@ -1444,7 +1444,7 @@ func buildMergeSourceSelect(
 //	JOIN (
 //	  <buildFullUpdateLookupInnerSelect result>
 //	) AS full_inner
-//	  ON full_outer.__mvmerge_full_outer_gk_<mv_offset_i> <=> full_inner.<base_group_key_i>
+//	  ON full_outer.__mview_full_outer_gk_<mv_offset_i> <=> full_inner.<base_group_key_i>
 //
 // This function is only used for MIN/MAX fallback.
 // It builds a stable outer+inner IndexJoin template:
@@ -1517,7 +1517,7 @@ func buildFullUpdateLookupTemplateSelect(
 		onExpr = andExpr(onExpr, binary(opcode.NullEQ, outerGK, innerGK))
 	}
 	if onExpr == nil {
-		return nil, nil, errors.New("mvmerge: empty group key offsets for full-update lookup template")
+		return nil, nil, errors.New("mview: empty group key offsets for full-update lookup template")
 	}
 
 	fields := make([]*ast.SelectField, 0, len(mvCols))
@@ -1567,7 +1567,7 @@ func buildFullUpdateLookupTemplateSelect(
 // SQL shape (simplified):
 //
 //	SELECT
-//	  <group_key_i> AS __mvmerge_full_outer_gk_<mv_offset_i>
+//	  <group_key_i> AS __mview_full_outer_gk_<mv_offset_i>
 //	FROM <db>.<base_table>
 //	WHERE <MV WHERE predicate>
 //	LIMIT 1
@@ -1582,10 +1582,10 @@ func buildFullUpdateLookupOuterSelect(
 	groupKeyOffsets []int,
 ) (*ast.SelectStmt, map[int]string, error) {
 	if baseTable == nil {
-		return nil, nil, errors.New("mvmerge: base table is nil")
+		return nil, nil, errors.New("mview: base table is nil")
 	}
 	if len(groupKeyOffsets) == 0 {
-		return nil, nil, errors.New("mvmerge: empty group key offsets for full-update lookup template")
+		return nil, nil, errors.New("mview: empty group key offsets for full-update lookup template")
 	}
 
 	fields := make([]*ast.SelectField, 0, len(groupKeyOffsets))
@@ -1595,7 +1595,7 @@ func buildFullUpdateLookupOuterSelect(
 		if err != nil {
 			return nil, nil, err
 		}
-		alias := fmt.Sprintf("__mvmerge_full_outer_gk_%d", mvOffset)
+		alias := fmt.Sprintf("__mview_full_outer_gk_%d", mvOffset)
 		groupKeyAliasByMVOffset[mvOffset] = alias
 		fields = append(fields, &ast.SelectField{
 			Expr:   baseColExpr,
@@ -1649,10 +1649,10 @@ func buildFullUpdateLookupInnerSelect(
 	aggCols []aggColInfo,
 ) (*ast.SelectStmt, error) {
 	if baseTable == nil {
-		return nil, errors.New("mvmerge: base table is nil")
+		return nil, errors.New("mview: base table is nil")
 	}
 	if len(groupKeyOffsets) == 0 {
-		return nil, errors.New("mvmerge: empty group key offsets for full-update lookup template")
+		return nil, errors.New("mview: empty group key offsets for full-update lookup template")
 	}
 
 	aggByMVOffset := make(map[int]aggColInfo, len(aggCols))

--- a/pkg/planner/mview/mview_test.go
+++ b/pkg/planner/mview/mview_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mvmerge_test
+package mview_test
 
 import (
 	"context"
@@ -29,7 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core"
 	corebase "github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
-	mvmerge "github.com/pingcap/tidb/pkg/planner/mview"
+	"github.com/pingcap/tidb/pkg/planner/mview"
 	_ "github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
@@ -41,7 +41,7 @@ const (
 	deltaTableAlias = "delta"
 	mvTableAlias    = "mv"
 
-	deltaCntStarName = "__mvmerge_delta_cnt_star"
+	deltaCntStarName = "__mview_delta_cnt_star"
 )
 
 func optimizeForTest(sctx sessionctx.Context, is infoschema.InfoSchema) func(ctx context.Context, sel *ast.SelectStmt) (corebase.PhysicalPlan, types.NameSlice, error) {
@@ -120,11 +120,11 @@ func TestBuildCountSum(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	res, err := mvmerge.Build(
+	res, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mv,
-		mvmerge.BuildOptions{FromTS: 10},
+		mview.BuildOptions{FromTS: 10},
 		nil,
 	)
 	require.NoError(t, err)
@@ -137,14 +137,14 @@ func TestBuildCountSum(t *testing.T) {
 	var hasCountStar, hasCountExpr, hasSum bool
 	for _, ai := range res.AggInfos {
 		switch ai.Kind {
-		case mvmerge.AggCountStar:
+		case mview.AggCountStar:
 			hasCountStar = true
 			requireDependencies(t, ai, []int{0})
-		case mvmerge.AggSum:
+		case mview.AggSum:
 			hasSum = true
 			require.Equal(t, "b", ai.ArgColName)
 			requireDependencies(t, ai, []int{2, 5})
-		case mvmerge.AggCount:
+		case mview.AggCount:
 			hasCountExpr = true
 			require.Equal(t, "b", ai.ArgColName)
 			requireDependencies(t, ai, []int{1})
@@ -160,13 +160,13 @@ func TestBuildCountSum(t *testing.T) {
 	mvDBName := item.DBName.O
 	requireMergePlanOutputNames(t, plan, outputNames, []fieldNameInfo{
 		{Pos: 0, Tbl: deltaTableAlias, Col: deltaCntStarName},
-		{Pos: 1, Tbl: deltaTableAlias, Col: "__mvmerge_delta_cnt_2"},
-		{Pos: 2, Tbl: deltaTableAlias, Col: "__mvmerge_delta_sum_3"},
+		{Pos: 1, Tbl: deltaTableAlias, Col: "__mview_delta_cnt_2"},
+		{Pos: 2, Tbl: deltaTableAlias, Col: "__mview_delta_sum_3"},
 		{Pos: 3, DB: mvDBName, Tbl: deltaTableAlias, Col: "x", OrigTbl: mlog.Name.O, OrigCol: "a"},
 		{Pos: 4, DB: mvDBName, Tbl: mvTableAlias, Col: "cnt", OrigTbl: mv.Name.O, OrigCol: "cnt"},
 		{Pos: 5, DB: mvDBName, Tbl: mvTableAlias, Col: "cnt_b", OrigTbl: mv.Name.O, OrigCol: "cnt_b"},
 		{Pos: 6, DB: mvDBName, Tbl: mvTableAlias, Col: "s", OrigTbl: mv.Name.O, OrigCol: "s"},
-		{Pos: 7, DB: mvDBName, Tbl: mvTableAlias, Col: "__mvmerge_mv_rowid", OrigCol: "_tidb_rowid"},
+		{Pos: 7, DB: mvDBName, Tbl: mvTableAlias, Col: "__mview_mv_rowid", OrigCol: "_tidb_rowid"},
 	})
 }
 
@@ -221,11 +221,11 @@ func TestBuildCountExprSumExpr(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	res, err := mvmerge.Build(
+	res, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mv,
-		mvmerge.BuildOptions{FromTS: 10},
+		mview.BuildOptions{FromTS: 10},
 		nil,
 	)
 	require.NoError(t, err)
@@ -237,14 +237,14 @@ func TestBuildCountExprSumExpr(t *testing.T) {
 	var hasCountStar, hasCount, hasSum bool
 	for _, ai := range res.AggInfos {
 		switch ai.Kind {
-		case mvmerge.AggCountStar:
+		case mview.AggCountStar:
 			hasCountStar = true
 			requireDependencies(t, ai, []int{0})
-		case mvmerge.AggCount:
+		case mview.AggCount:
 			hasCount = true
 			require.Empty(t, ai.ArgColName)
 			requireDependencies(t, ai, []int{1})
-		case mvmerge.AggSum:
+		case mview.AggSum:
 			hasSum = true
 			require.Empty(t, ai.ArgColName)
 			requireDependencies(t, ai, []int{2, 5})
@@ -259,13 +259,13 @@ func TestBuildCountExprSumExpr(t *testing.T) {
 	mvDBName := item.DBName.O
 	requireMergePlanOutputNames(t, plan, outputNames, []fieldNameInfo{
 		{Pos: 0, Tbl: deltaTableAlias, Col: deltaCntStarName},
-		{Pos: 1, Tbl: deltaTableAlias, Col: "__mvmerge_delta_cnt_2"},
-		{Pos: 2, Tbl: deltaTableAlias, Col: "__mvmerge_delta_sum_3"},
+		{Pos: 1, Tbl: deltaTableAlias, Col: "__mview_delta_cnt_2"},
+		{Pos: 2, Tbl: deltaTableAlias, Col: "__mview_delta_sum_3"},
 		{Pos: 3, DB: mvDBName, Tbl: deltaTableAlias, Col: "x", OrigTbl: mlog.Name.O, OrigCol: "a"},
 		{Pos: 4, DB: mvDBName, Tbl: mvTableAlias, Col: "cnt_star", OrigTbl: mv.Name.O, OrigCol: "cnt_star"},
 		{Pos: 5, DB: mvDBName, Tbl: mvTableAlias, Col: "cnt_b", OrigTbl: mv.Name.O, OrigCol: "cnt_b"},
 		{Pos: 6, DB: mvDBName, Tbl: mvTableAlias, Col: "s_expr", OrigTbl: mv.Name.O, OrigCol: "s_expr"},
-		{Pos: 7, DB: mvDBName, Tbl: mvTableAlias, Col: "__mvmerge_mv_rowid", OrigCol: "_tidb_rowid"},
+		{Pos: 7, DB: mvDBName, Tbl: mvTableAlias, Col: "__mview_mv_rowid", OrigCol: "_tidb_rowid"},
 	})
 }
 
@@ -340,11 +340,11 @@ func TestBuildMLogDeltaSelectTiFlashHint(t *testing.T) {
 			is := infoschema.MockInfoSchema([]*model.TableInfo{base, &mlogClone, mv})
 			domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-			res, err := mvmerge.Build(
+			res, err := mview.Build(
 				sctx.GetPlanCtx(),
 				is,
 				mv,
-				mvmerge.BuildOptions{FromTS: 10},
+				mview.BuildOptions{FromTS: 10},
 				nil,
 			)
 			require.NoError(t, err)
@@ -418,11 +418,11 @@ func TestBuildMLogDeltaSelectCommitTSWindow(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	res, err := mvmerge.Build(
+	res, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mv,
-		mvmerge.BuildOptions{FromTS: 10},
+		mview.BuildOptions{FromTS: 10},
 		nil,
 	)
 	require.NoError(t, err)
@@ -505,11 +505,11 @@ func TestBuildMergeSourceSelectJoinOperatorByMVNullability(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	res, err := mvmerge.Build(
+	res, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mv,
-		mvmerge.BuildOptions{FromTS: 10},
+		mview.BuildOptions{FromTS: 10},
 		nil,
 	)
 	require.NoError(t, err)
@@ -598,11 +598,11 @@ func TestBuildMinMaxHasRemovedGate(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	res, err := mvmerge.Build(
+	res, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mv,
-		mvmerge.BuildOptions{FromTS: 1},
+		mview.BuildOptions{FromTS: 1},
 		nil,
 	)
 	require.NoError(t, err)
@@ -621,15 +621,15 @@ func TestBuildMinMaxHasRemovedGate(t *testing.T) {
 
 	var hasMax, hasMin bool
 	for _, ai := range res.AggInfos {
-		if ai.Kind == mvmerge.AggMax {
+		if ai.Kind == mview.AggMax {
 			hasMax = true
 			requireDependencies(t, ai, []int{1, 2, 3, 4})
 		}
-		if ai.Kind == mvmerge.AggMin {
+		if ai.Kind == mview.AggMin {
 			hasMin = true
 			requireDependencies(t, ai, []int{5, 6, 7, 8})
 		}
-		if ai.Kind == mvmerge.AggCountStar {
+		if ai.Kind == mview.AggCountStar {
 			requireDependencies(t, ai, []int{0})
 		}
 	}
@@ -642,19 +642,19 @@ func TestBuildMinMaxHasRemovedGate(t *testing.T) {
 	mvDBName := item.DBName.O
 	requireMergePlanOutputNames(t, plan, outputNames, []fieldNameInfo{
 		{Pos: 0, Tbl: deltaTableAlias, Col: deltaCntStarName},
-		{Pos: 1, Tbl: deltaTableAlias, Col: "__mvmerge_max_in_added_2"},
-		{Pos: 2, Tbl: deltaTableAlias, Col: "__mvmerge_max_cnt_in_added_2"},
-		{Pos: 3, Tbl: deltaTableAlias, Col: "__mvmerge_max_in_removed_2"},
-		{Pos: 4, Tbl: deltaTableAlias, Col: "__mvmerge_max_cnt_in_removed_2"},
-		{Pos: 5, Tbl: deltaTableAlias, Col: "__mvmerge_min_in_added_3"},
-		{Pos: 6, Tbl: deltaTableAlias, Col: "__mvmerge_min_cnt_in_added_3"},
-		{Pos: 7, Tbl: deltaTableAlias, Col: "__mvmerge_min_in_removed_3"},
-		{Pos: 8, Tbl: deltaTableAlias, Col: "__mvmerge_min_cnt_in_removed_3"},
+		{Pos: 1, Tbl: deltaTableAlias, Col: "__mview_max_in_added_2"},
+		{Pos: 2, Tbl: deltaTableAlias, Col: "__mview_max_cnt_in_added_2"},
+		{Pos: 3, Tbl: deltaTableAlias, Col: "__mview_max_in_removed_2"},
+		{Pos: 4, Tbl: deltaTableAlias, Col: "__mview_max_cnt_in_removed_2"},
+		{Pos: 5, Tbl: deltaTableAlias, Col: "__mview_min_in_added_3"},
+		{Pos: 6, Tbl: deltaTableAlias, Col: "__mview_min_cnt_in_added_3"},
+		{Pos: 7, Tbl: deltaTableAlias, Col: "__mview_min_in_removed_3"},
+		{Pos: 8, Tbl: deltaTableAlias, Col: "__mview_min_cnt_in_removed_3"},
 		{Pos: 9, DB: mvDBName, Tbl: deltaTableAlias, Col: "x", OrigTbl: mlog.Name.O, OrigCol: "a"},
 		{Pos: 10, DB: mvDBName, Tbl: mvTableAlias, Col: "cnt", OrigTbl: mv.Name.O, OrigCol: "cnt"},
 		{Pos: 11, DB: mvDBName, Tbl: mvTableAlias, Col: "mx", OrigTbl: mv.Name.O, OrigCol: "mx"},
 		{Pos: 12, DB: mvDBName, Tbl: mvTableAlias, Col: "mn", OrigTbl: mv.Name.O, OrigCol: "mn"},
-		{Pos: 13, DB: mvDBName, Tbl: mvTableAlias, Col: "__mvmerge_mv_rowid", OrigCol: "_tidb_rowid"},
+		{Pos: 13, DB: mvDBName, Tbl: mvTableAlias, Col: "__mview_mv_rowid", OrigCol: "_tidb_rowid"},
 	})
 }
 
@@ -710,25 +710,25 @@ func TestBuildMinMaxNullableDependencyOrder(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	res, err := mvmerge.Build(
+	res, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mv,
-		mvmerge.BuildOptions{FromTS: 1},
+		mview.BuildOptions{FromTS: 1},
 		nil,
 	)
 	require.NoError(t, err)
 
 	for _, ai := range res.AggInfos {
 		switch ai.Kind {
-		case mvmerge.AggCountStar:
+		case mview.AggCountStar:
 			requireDependencies(t, ai, []int{0})
-		case mvmerge.AggCount:
+		case mview.AggCount:
 			require.Equal(t, "b", ai.ArgColName)
 			requireDependencies(t, ai, []int{1})
-		case mvmerge.AggMax:
+		case mview.AggMax:
 			requireDependencies(t, ai, []int{2, 3, 4, 5, 12})
-		case mvmerge.AggMin:
+		case mview.AggMin:
 			requireDependencies(t, ai, []int{6, 7, 8, 9, 12})
 		}
 	}
@@ -784,11 +784,11 @@ func TestBuildSumWithoutCountExpr(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	_, err := mvmerge.Build(
+	_, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mv,
-		mvmerge.BuildOptions{FromTS: 1},
+		mview.BuildOptions{FromTS: 1},
 		nil,
 	)
 	require.ErrorContains(t, err, "requires matching COUNT(expr)")
@@ -844,11 +844,11 @@ func TestBuildMissingCountStar(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	_, err := mvmerge.Build(
+	_, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mv,
-		mvmerge.BuildOptions{FromTS: 1},
+		mview.BuildOptions{FromTS: 1},
 		nil,
 	)
 	require.ErrorContains(t, err, "must include COUNT(*)")
@@ -900,11 +900,11 @@ func TestBuildMissingOldNew(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	_, err := mvmerge.Build(
+	_, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mv,
-		mvmerge.BuildOptions{FromTS: 1},
+		mview.BuildOptions{FromTS: 1},
 		nil,
 	)
 	require.ErrorContains(t, err, model.MaterializedViewLogOldNewColumnName)
@@ -944,7 +944,7 @@ func mkCol(id int64, name string, offset int, tp byte) *model.ColumnInfo {
 	}
 }
 
-func requireDependencies(t *testing.T, ai mvmerge.AggInfo, expected []int) {
+func requireDependencies(t *testing.T, ai mview.AggInfo, expected []int) {
 	t.Helper()
 	require.Equal(t, expected, ai.Dependencies)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68636

Problem Summary:

The planner materialized-view package had been renamed to `mview`, but some file names, package names, import aliases, helper names, error prefixes, and generated internal column aliases still used the old `mvmerge` name.

### What changed and how does it work?

This PR renames the planner mview source/test files and Go package identifiers from `mvmerge` to `mview`, updates downstream references, and changes the generated internal aliases from `__mvmerge_*` to `__mview_*`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```sh
go test -run 'TestBuild' -tags=intest,deadlock ./pkg/planner/mview
go test -run 'Test(BuildRefreshMVFastPlan|BuildRefreshMVFastPlanWithMinMaxHasFullUpdate|BuildRefreshMVFastSumNotNullNoCountExpr|MViewBuildResultHandleCols)$' -tags=intest,deadlock ./pkg/planner/core/casetest/mview
tools/bin/failpoint-ctl enable pkg/executor
go test -run '^$' -tags=intest,deadlock ./pkg/executor
tools/bin/failpoint-ctl disable pkg/executor
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal materialized view incremental merge processing implementation with consistent naming conventions and standardized type definitions across related components.

* **Tests**
  * Updated test suite to align with refactored materialized view processing structure.

* **Chores**
  * Updated build configuration for refactored modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->