### PR TITLE
test: stabilize flaky TestRowToTTLTask

### DIFF
--- a/pkg/ttl/cache/task_test.go
+++ b/pkg/ttl/cache/task_test.go
@@ -40,6 +40,16 @@ func newTaskGetter(ctx context.Context, t *testing.T, tk *testkit.TestKit) *task
 	}
 }
 
+func newTaskTestKit(t *testing.T) *testkit.TestKit {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	dom.TTLJobManager().Stop()
+	require.NoError(t, dom.TTLJobManager().WaitStopped(context.Background(), time.Minute))
+
+	tk := testkit.NewTestKit(t, store)
+	tk.Session().GetSessionVars().TimeZone = time.Local
+	return tk
+}
+
 func (tg *taskGetter) mustGetTestTask() *cache.TTLTask {
 	sql, args := cache.SelectFromTTLTaskWithJobID("test-job")
 	rs, err := tg.tk.Session().ExecuteInternal(tg.ctx, sql, args...)
@@ -52,9 +62,7 @@ func (tg *taskGetter) mustGetTestTask() *cache.TTLTask {
 }
 
 func TestRowToTTLTask(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.Session().GetSessionVars().TimeZone = time.Local
+	tk := newTaskTestKit(t)
 
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnTTL)
 	tg := newTaskGetter(ctx, t, tk)
@@ -92,9 +100,7 @@ func TestRowToTTLTask(t *testing.T) {
 }
 
 func TestInsertIntoTTLTask(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.Session().GetSessionVars().TimeZone = time.Local
+	tk := newTaskTestKit(t)
 
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnTTL)
 	tg := newTaskGetter(ctx, t, tk)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68657

Problem Summary:
Flaky test `TestRowToTTLTask` in `pkg/ttl/cache` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Background TTL startup GC could delete the test’s unmanaged `tidb_ttl_task` row before the second read.

#### Fix

Stopping the TTL job manager isolates row conversion tests from unrelated scheduling/GC behavior.

#### Verification

Spec:
- target: `pkg/ttl/cache :: TestRowToTTLTask`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package passed.
build passed.
lint passed.

Gate checklist:
- native_repro: SKIPPED
- target_flaky: PASS
- package: PASS
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/ttl/cache -run '^TestRowToTTLTask$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/ttl/cache -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test setup by introducing a shared helper function to reduce code duplication across multiple test cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->