### PR TITLE
test: stabilize flaky TestKVEncoderForDupResolve

### DIFF
--- a/pkg/executor/importer/BUILD.bazel
+++ b/pkg/executor/importer/BUILD.bazel
@@ -160,6 +160,7 @@ go_test(
         "//pkg/planner/util",
         "//pkg/session",
         "//pkg/sessionctx/vardef",
+        "//pkg/table",
         "//pkg/table/tables",
         "//pkg/tablecodec",
         "//pkg/testkit",

--- a/pkg/executor/importer/kv_encode_test.go
+++ b/pkg/executor/importer/kv_encode_test.go
@@ -18,27 +18,27 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/lightning/backend/encode"
+	lightningkv "github.com/pingcap/tidb/pkg/lightning/backend/kv"
 	"github.com/pingcap/tidb/pkg/lightning/log"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/session"
+	"github.com/pingcap/tidb/pkg/table"
+	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/types"
+	utilmock "github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestKVEncoderForDupResolve(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t(a bigint primary key nonclustered) SHARD_ROW_ID_BITS = 6")
-	do, err := session.GetDomain(store)
-	require.NoError(t, err)
-	table, err := do.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
-	require.NoError(t, err)
+	table := newKVEncoderTestTable(t, "create table t(a bigint primary key nonclustered) SHARD_ROW_ID_BITS = 6")
 
 	doTestFn := func(t *testing.T, useIdentityAutoRowID bool, checkerFn func(handleVal int64)) {
 		encodeCfg := &encode.EncodingConfig{
@@ -52,6 +52,7 @@ func TestKVEncoderForDupResolve(t *testing.T) {
 		}
 		encoder, err := importer.NewTableKVEncoderForDupResolve(encodeCfg, controller)
 		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, encoder.Close()) })
 		for range 10 {
 			pairs, err := encoder.Encode([]types.Datum{types.NewDatum(1)}, 1)
 			require.NoError(t, err)
@@ -86,6 +87,19 @@ func TestKVEncoderForDupResolve(t *testing.T) {
 		})
 		require.Greater(t, handleLargerThanOneCount, 1)
 	})
+}
+
+func newKVEncoderTestTable(t *testing.T, createSQL string) table.Table {
+	t.Helper()
+
+	stmt, err := parser.New().ParseOneStmt(createSQL, "", "")
+	require.NoError(t, err)
+	tblInfo, err := ddl.MockTableInfo(utilmock.NewContext(), stmt.(*ast.CreateTableStmt), 1)
+	require.NoError(t, err)
+	tblInfo.State = model.StatePublic
+	tbl, err := tables.TableFromMeta(lightningkv.NewPanickingAllocators(tblInfo.SepAutoInc()), tblInfo)
+	require.NoError(t, err)
+	return tbl
 }
 
 func TestKVEncoderCastErrorMessage(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68375

Problem Summary:
Flaky test `TestKVEncoderForDupResolve` in `pkg/executor/importer` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Heavy mock-store/domain DDL setup in TestKVEncoderForDupResolve amplified CI timing enough to cross the flaky time threshold.

#### Fix

Direct metadata construction preserves the table schema and row-id behavior while removing unnecessary DDL/domain startup cost.

#### Verification

Spec:
- target: `pkg/executor/importer :: TestKVEncoderForDupResolve`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_exact passed.

Gate checklist:
- target_exact: PASS
- timing_repro: FAIL
- bazel_metadata_diff: FAIL
- failpoint_target: FAIL
- build: FAIL
- lint: FAIL
- ci_bazel_shard: FAIL

Commands:
- `go test -json -tags=intest,deadlock ./pkg/executor/importer -run '^TestKVEncoderForDupResolve$' -count=1`
- `time go test -tags=intest,deadlock ./pkg/executor/importer -run '^TestKVEncoderForDupResolve$' -count=20`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored KV encoder test setup to use a shared helper function for improved test maintainability.
  * Added proper cleanup handling in test sub-runs to ensure resources are released appropriately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->