### PR TITLE
statistics: add merge-sampling pipeline trace for ANALYZE

### DIFF
--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -308,6 +308,12 @@ func (builder *RequestBuilder) SetAllowBatchCop(batchCop bool) *RequestBuilder {
 	return builder
 }
 
+// SetStoreBatchSize sets the store batch size for TiKV coprocessor requests.
+func (builder *RequestBuilder) SetStoreBatchSize(storeBatchSize int) *RequestBuilder {
+	builder.Request.StoreBatchSize = storeBatchSize
+	return builder
+}
+
 // SetPartitionIDAndRanges sets `PartitionIDAndRanges` property.
 func (builder *RequestBuilder) SetPartitionIDAndRanges(partitionIDAndRanges []kv.PartitionIDAndRanges) *RequestBuilder {
 	builder.PartitionIDAndRanges = partitionIDAndRanges

--- a/pkg/distsql/select_result.go
+++ b/pkg/distsql/select_result.go
@@ -67,6 +67,9 @@ var (
 type SelectResult interface {
 	// NextRaw gets the next raw result.
 	NextRaw(context.Context) ([]byte, error)
+	// NextRawSubset gets the next raw result as a kv.ResultSubset,
+	// which exposes per-response metadata like RespTime().
+	NextRawSubset(context.Context) (kv.ResultSubset, error)
 	// Next reads the data into chunk.
 	Next(context.Context, *chunk.Chunk) error
 	// IntoIter converts the SelectResult into an iterator.
@@ -221,6 +224,10 @@ func (*sortedSelectResults) NextRaw(context.Context) ([]byte, error) {
 	panic("Not support NextRaw for sortedSelectResults")
 }
 
+func (*sortedSelectResults) NextRawSubset(context.Context) (kv.ResultSubset, error) {
+	panic("Not support NextRawSubset for sortedSelectResults")
+}
+
 func (ssr *sortedSelectResults) Next(ctx context.Context, c *chunk.Chunk) (err error) {
 	c.Reset()
 	for i := range ssr.cachedChunks {
@@ -296,6 +303,20 @@ func (ssr *serialSelectResults) NextRaw(ctx context.Context) ([]byte, error) {
 			return resultSubset, nil
 		}
 		ssr.cur++ // move to the next SelectResult
+	}
+	return nil, nil
+}
+
+func (ssr *serialSelectResults) NextRawSubset(ctx context.Context) (kv.ResultSubset, error) {
+	for ssr.cur < len(ssr.selectResults) {
+		rs, err := ssr.selectResults[ssr.cur].NextRawSubset(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if rs != nil {
+			return rs, nil
+		}
+		ssr.cur++
 	}
 	return nil, nil
 }
@@ -548,6 +569,16 @@ func (r *selectResult) NextRaw(ctx context.Context) (data []byte, err error) {
 		data = resultSubset.GetData()
 	}
 	return data, err
+}
+
+// NextRawSubset returns the next raw partial result as a kv.ResultSubset.
+func (r *selectResult) NextRawSubset(ctx context.Context) (kv.ResultSubset, error) {
+	if r.iter != nil {
+		return nil, errors.New("selectResult is invalid after IntoIter()")
+	}
+	resultSubset, err := r.resp.Next(ctx)
+	r.partialCount++
+	return resultSubset, err
 }
 
 func (r *selectResult) readFromDefault(ctx context.Context, chk *chunk.Chunk) error {

--- a/pkg/executor/analyze_col.go
+++ b/pkg/executor/analyze_col.go
@@ -117,6 +117,7 @@ func (e *AnalyzeColumnsExec) buildResp(ctx context.Context, ranges []*ranger.Ran
 		SetStartTS(startTS).
 		SetKeepOrder(true).
 		SetConcurrency(e.concurrency).
+		SetStoreBatchSize(e.ctx.GetSessionVars().StoreBatchSize).
 		SetMemTracker(e.memTracker).
 		SetResourceGroupName(e.ctx.GetSessionVars().StmtCtx.ResourceGroupName).
 		SetExplicitRequestSourceType(e.ctx.GetSessionVars().ExplicitRequestSourceType).

--- a/pkg/executor/analyze_col_sampling.go
+++ b/pkg/executor/analyze_col_sampling.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	stderrors "errors"
 	"slices"
+	"sync/atomic"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -49,6 +50,28 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
+
+// samplingMergeTrace collects lightweight metrics that reveal the performance
+// profile of the merge-sampling pipeline.  All fields are updated atomically
+// so that concurrent merge workers can write without a mutex.
+type samplingMergeTrace struct {
+	// readDataAndSendTask (single goroutine)
+	fetchCount       atomic.Int64
+	fetchBytes       atomic.Int64
+	fetchElapsedNs   atomic.Int64
+	// subMergeWorker (N goroutines)
+	responseCount    atomic.Int64
+	responseBytes    atomic.Int64
+	fmSketchCount    atomic.Int64
+	fmSketchBytes    atomic.Int64
+	unmarshalNs      atomic.Int64
+	fromProtoNs      atomic.Int64
+	fmFromProtoNs    atomic.Int64
+	mergeNs          atomic.Int64
+	fmMergeNs        atomic.Int64
+	workerWaitNs     atomic.Int64
+	workerBusyNs     atomic.Int64
+}
 
 func (e *AnalyzeColumnsExec) analyzeColumnsPushDown(ctx context.Context, gp *gp.Pool) *statistics.AnalyzeResults {
 	var ranges []*ranger.Range
@@ -228,6 +251,8 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 	// Start workers to merge the result from collectors.
 	mergeResultCh := make(chan *samplingMergeResult, 1)
 	mergeTaskCh := make(chan []byte, 1)
+	trace := &samplingMergeTrace{}
+	mergeStart := time.Now()
 	taskCtx, taskCancel := context.WithCancelCause(ctx)
 	defer taskCancel(nil)
 	var taskEg errgroup.Group
@@ -238,7 +263,7 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 				err = getAnalyzePanicErr(r)
 			}
 		}()
-		err = readDataAndSendTask(taskCtx, e.ctx, e.resultHandler, mergeTaskCh, e.memTracker)
+		err = readDataAndSendTask(taskCtx, e.ctx, e.resultHandler, mergeTaskCh, e.memTracker, trace)
 		if err != nil {
 			taskCancel(err)
 		}
@@ -251,7 +276,7 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 	for i := range samplingStatsConcurrency {
 		id := i
 		gp.Go(func() {
-			e.subMergeWorker(mergeCtx, taskCancel, mergeResultCh, mergeTaskCh, totalLen, id)
+			e.subMergeWorker(mergeCtx, taskCancel, mergeResultCh, mergeTaskCh, totalLen, id, trace)
 		})
 	}
 	// Merge the result from collectors.
@@ -303,6 +328,38 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 		taskCancel(err)
 		return 0, nil, nil, nil, err
 	}
+
+	// Log the merge-sampling pipeline trace.
+	mergeWall := time.Since(mergeStart)
+	totalWait := time.Duration(trace.workerWaitNs.Load())
+	totalBusy := time.Duration(trace.workerBusyNs.Load())
+	busyPct := float64(0)
+	if totalWait+totalBusy > 0 {
+		busyPct = float64(totalBusy) / float64(totalWait+totalBusy) * 100
+	}
+	logutil.BgLogger().Info("analyze full sampling merge trace",
+		zap.Int64("tableID", e.tableID.TableID),
+		zap.Duration("mergeWall", mergeWall),
+		zap.Int("mergeWorkers", samplingStatsConcurrency),
+		// fetch pipeline (single goroutine)
+		zap.Int64("fetchCount", trace.fetchCount.Load()),
+		zap.Int64("fetchBytes", trace.fetchBytes.Load()),
+		zap.Duration("fetchElapsed", time.Duration(trace.fetchElapsedNs.Load())),
+		// merge worker aggregates
+		zap.Int64("responses", trace.responseCount.Load()),
+		zap.Int64("responseBytes", trace.responseBytes.Load()),
+		zap.Int64("fmSketchCount", trace.fmSketchCount.Load()),
+		zap.Int64("fmSketchBytes", trace.fmSketchBytes.Load()),
+		zap.Duration("unmarshalElapsed", time.Duration(trace.unmarshalNs.Load())),
+		zap.Duration("fromProtoElapsed", time.Duration(trace.fromProtoNs.Load())),
+		zap.Duration("fmSketchFromProtoElapsed", time.Duration(trace.fmFromProtoNs.Load())),
+		zap.Duration("mergeCollectorElapsed", time.Duration(trace.mergeNs.Load())),
+		zap.Duration("fmSketchMergeElapsed", time.Duration(trace.fmMergeNs.Load())),
+		// worker utilization
+		zap.Duration("workerWaitTotal", totalWait),
+		zap.Duration("workerBusyTotal", totalBusy),
+		zap.Float64("workerBusyPercent", busyPct),
+	)
 
 	// Decode the data from sample collectors.
 	virtualColIdx := buildVirtualColumnIndex(e.schemaForVirtualColEval, e.colsInfo)
@@ -603,6 +660,7 @@ func (e *AnalyzeColumnsExec) subMergeWorker(
 	taskCh <-chan []byte,
 	totalLen int,
 	index int,
+	trace *samplingMergeTrace,
 ) {
 	// Only close the resultCh in the first worker.
 	closeTheResultCh := index == 0
@@ -651,15 +709,30 @@ func (e *AnalyzeColumnsExec) subMergeWorker(
 	statsHandle := domain.GetDomain(e.ctx).StatsHandle()
 	// Merge sampled batches until the producer closes taskCh or cancellation arrives.
 	for {
+		waitStart := time.Now()
 		select {
 		case data, ok := <-taskCh:
+			trace.workerWaitNs.Add(time.Since(waitStart).Nanoseconds())
 			if !ok {
 				resultCh <- &samplingMergeResult{collector: retCollector}
 				return
 			}
+			busyStart := time.Now()
 			inflightDataSize = int64(cap(data))
 			colResp := &tipb.AnalyzeColumnsResp{}
+			unmarshalStart := time.Now()
 			err := colResp.Unmarshal(data)
+			unmarshalElapsed := time.Since(unmarshalStart)
+			rowCollector := colResp.GetRowCollector()
+			fmSketchBytes := 0
+			for _, sketch := range rowCollector.GetFmSketch() {
+				fmSketchBytes += sketch.Size()
+			}
+			trace.responseCount.Add(1)
+			trace.responseBytes.Add(int64(len(data)))
+			trace.fmSketchCount.Add(int64(len(rowCollector.GetFmSketch())))
+			trace.fmSketchBytes.Add(int64(fmSketchBytes))
+			trace.unmarshalNs.Add(unmarshalElapsed.Nanoseconds())
 			if err != nil {
 				e.memTracker.Release(inflightDataSize)
 				inflightDataSize = 0
@@ -671,12 +744,20 @@ func (e *AnalyzeColumnsExec) subMergeWorker(
 			e.memTracker.Consume(inflightRespSize)
 
 			subCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), totalLen)
-			subCollector.Base().FromProto(colResp.RowCollector, e.memTracker)
+			fromProtoStart := time.Now()
+			fmFromProtoElapsed := subCollector.Base().FromProto(colResp.RowCollector, e.memTracker)
+			fromProtoElapsed := time.Since(fromProtoStart)
+			trace.fromProtoNs.Add(fromProtoElapsed.Nanoseconds())
+			trace.fmFromProtoNs.Add(fmFromProtoElapsed.Nanoseconds())
 			statsHandle.UpdateAnalyzeJobProgress(e.job, subCollector.Base().Count)
 
 			oldRetCollectorSize := retCollector.Base().MemSize
 			oldRetCollectorCount := retCollector.Base().Count
-			retCollector.MergeCollector(subCollector)
+			mergeCollectorStart := time.Now()
+			fmMergeElapsed := retCollector.MergeCollector(subCollector)
+			mergeCollectorElapsed := time.Since(mergeCollectorStart)
+			trace.mergeNs.Add(mergeCollectorElapsed.Nanoseconds())
+			trace.fmMergeNs.Add(fmMergeElapsed.Nanoseconds())
 			newRetCollectorCount := retCollector.Base().Count
 			printAnalyzeMergeCollectorLog(oldRetCollectorCount, newRetCollectorCount, subCollector.Base().Count,
 				e.tableID.TableID, e.tableID.PartitionID, e.TableID.IsPartitionTable(),
@@ -689,6 +770,7 @@ func (e *AnalyzeColumnsExec) subMergeWorker(
 			inflightDataSize = 0
 			inflightRespSize = 0
 			subCollector.DestroyAndPutToPool()
+			trace.workerBusyNs.Add(time.Since(busyStart).Nanoseconds())
 		case <-ctx.Done():
 			err := normalizeCtxErrWithCause(ctx, ctx.Err())
 			if err != nil {
@@ -919,7 +1001,7 @@ type samplingBuildTask struct {
 	slicePos         int
 }
 
-func readDataAndSendTask(ctx context.Context, sctx sessionctx.Context, handler *tableResultHandler, mergeTaskCh chan []byte, memTracker *memory.Tracker) error {
+func readDataAndSendTask(ctx context.Context, sctx sessionctx.Context, handler *tableResultHandler, mergeTaskCh chan []byte, memTracker *memory.Tracker, trace *samplingMergeTrace) error {
 	// After all tasks are sent, close the mergeTaskCh to notify the mergeWorker that all tasks have been sent.
 	defer close(mergeTaskCh)
 	for {
@@ -944,7 +1026,10 @@ func readDataAndSendTask(ctx context.Context, sctx sessionctx.Context, handler *
 			}
 		})
 
+		fetchStart := time.Now()
 		data, err := handler.nextRaw(ctx)
+		trace.fetchElapsedNs.Add(time.Since(fetchStart).Nanoseconds())
+		trace.fetchCount.Add(1)
 		if err != nil {
 			err = normalizeCtxErrWithCause(ctx, err)
 			return errors.Trace(err)
@@ -952,6 +1037,7 @@ func readDataAndSendTask(ctx context.Context, sctx sessionctx.Context, handler *
 		if data == nil {
 			break
 		}
+		trace.fetchBytes.Add(int64(len(data)))
 
 		dataSize := int64(cap(data))
 		memTracker.Consume(dataSize)

--- a/pkg/executor/analyze_col_sampling.go
+++ b/pkg/executor/analyze_col_sampling.go
@@ -17,7 +17,6 @@ package executor
 import (
 	"context"
 	stderrors "errors"
-	"fmt"
 	"slices"
 	"sync/atomic"
 	"time"
@@ -52,32 +51,14 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func analyzeSummaryBottleneck(fetchPct, busyPct float64) string {
-	if fetchPct > 90 {
-		return "response fetch pipeline (>90% of wall time spent waiting for TiKV responses; " +
-			"try increasing tidb_store_batch_size to reduce request count, " +
-			"or tidb_analyze_distsql_scan_concurrency to increase concurrency)"
-	}
-	if busyPct > 50 {
-		return "merge computation (merge workers busy >50% of time; " +
-			"try increasing tidb_build_sampling_stats_concurrency)"
-	}
-	return "mixed (no single dominant bottleneck)"
-}
-
 // samplingMergeTrace collects lightweight metrics that reveal the performance
 // profile of the merge-sampling pipeline.  All fields are updated atomically
 // so that concurrent merge workers can write without a mutex.
 type samplingMergeTrace struct {
 	// readDataAndSendTask (single goroutine)
-	fetchCount       atomic.Int64
-	fetchBytes       atomic.Int64
-	fetchElapsedNs   atomic.Int64
-	fetchMinNs       atomic.Int64 // min per-response fetch latency
-	fetchMaxNs       atomic.Int64 // max per-response fetch latency
-	fetchLt1msCount  atomic.Int64 // count of fetches < 1ms
-	fetchLt10msCount atomic.Int64 // count of fetches 1ms–10ms
-	fetchLt100msCount atomic.Int64 // count of fetches 10ms–100ms
+	fetchElapsedNs    atomic.Int64
+	fetchMaxNs        atomic.Int64 // max per-response fetch latency
+	fetchLt1msCount   atomic.Int64 // count of fetches < 1ms
 	fetchGe100msCount atomic.Int64 // count of fetches >= 100ms
 	scanConcurrency  int          // set once before goroutines start
 	// per-response cop timing (from copIterator)
@@ -360,77 +341,57 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 	if totalWait+totalBusy > 0 {
 		busyPct = float64(totalBusy) / float64(totalWait+totalBusy) * 100
 	}
-	fetchCount := trace.fetchCount.Load()
+	responseCount := trace.responseCount.Load()
 	fetchElapsed := time.Duration(trace.fetchElapsedNs.Load())
-	fetchAvgNs := int64(0)
-	if fetchCount > 0 {
-		fetchAvgNs = trace.fetchElapsedNs.Load() / fetchCount
-	}
 	copRespTimeSum := time.Duration(trace.copRespTimeNs.Load())
+	// fetchAvg and copRespAvg use responseCount (excludes the final nil-returning EOF call).
+	fetchAvgNs := int64(0)
+	copRespAvgNs := int64(0)
+	if responseCount > 0 {
+		fetchAvgNs = trace.fetchElapsedNs.Load() / responseCount
+		copRespAvgNs = trace.copRespTimeNs.Load() / responseCount
+	}
+	fetchPct := float64(0)
+	if mergeWall > 0 {
+		fetchPct = float64(fetchElapsed) / float64(mergeWall) * 100
+	}
 	logutil.BgLogger().Info("analyze full sampling merge trace",
 		zap.Int64("tableID", e.tableID.TableID),
+		// overall
 		zap.Duration("mergeWall", mergeWall),
 		zap.Int("mergeWorkers", samplingStatsConcurrency),
 		zap.Int("scanConcurrency", trace.scanConcurrency),
-		// fetch pipeline (single goroutine)
-		zap.Int64("fetchCount", fetchCount),
-		zap.Int64("fetchBytes", trace.fetchBytes.Load()),
+		// fetch pipeline — single goroutine reads cop responses in region order (KeepOrder=true).
+		// fetchElapsed: wall time this goroutine spent inside nextRawSubset() calls.
+		// Most calls return instantly (<1ms) because the response is already buffered;
+		// a few block >=100ms waiting for TiKV (head-of-line blocking due to ordered consumption).
+		zap.Int64("responses", responseCount),
+		zap.Int64("responseBytes", trace.responseBytes.Load()),
 		zap.Duration("fetchElapsed", fetchElapsed),
-		zap.Duration("fetchAvg", time.Duration(fetchAvgNs)),
-		zap.Duration("fetchMin", time.Duration(trace.fetchMinNs.Load())),
+		zap.Float64("fetchPctOfWall", fetchPct),
+		zap.Duration("fetchAvgPerResp", time.Duration(fetchAvgNs)),
 		zap.Duration("fetchMax", time.Duration(trace.fetchMaxNs.Load())),
 		zap.Int64("fetchLt1ms", trace.fetchLt1msCount.Load()),
-		zap.Int64("fetchLt10ms", trace.fetchLt10msCount.Load()),
-		zap.Int64("fetchLt100ms", trace.fetchLt100msCount.Load()),
 		zap.Int64("fetchGe100ms", trace.fetchGe100msCount.Load()),
-		// cop response time (TiDB-measured per-request RPC round-trip)
+		// copRespTimeSum: sum of all per-request RPC round-trip times as measured by TiDB cop workers.
+		// Because workers run concurrently, these times overlap — copRespTimeSum is NOT wall time.
+		// copRespAvg × responses / scanConcurrency ≈ fetchElapsed under ideal parallelism.
 		zap.Duration("copRespTimeSum", copRespTimeSum),
-		// merge worker aggregates
-		zap.Int64("responses", trace.responseCount.Load()),
-		zap.Int64("responseBytes", trace.responseBytes.Load()),
+		zap.Duration("copRespAvg", time.Duration(copRespAvgNs)),
+		// merge worker aggregates — what happens after a response is received and decoded.
 		zap.Int64("fmSketchCount", trace.fmSketchCount.Load()),
 		zap.Int64("fmSketchBytes", trace.fmSketchBytes.Load()),
 		zap.Duration("unmarshalElapsed", time.Duration(trace.unmarshalNs.Load())),
 		zap.Duration("fromProtoElapsed", time.Duration(trace.fromProtoNs.Load())),
-		zap.Duration("fmSketchFromProtoElapsed", time.Duration(trace.fmFromProtoNs.Load())),
-		zap.Duration("mergeCollectorElapsed", time.Duration(trace.mergeNs.Load())),
-		zap.Duration("fmSketchMergeElapsed", time.Duration(trace.fmMergeNs.Load())),
-		// worker utilization
-		zap.Duration("workerWaitTotal", totalWait),
+		zap.Duration("fmFromProtoElapsed", time.Duration(trace.fmFromProtoNs.Load())),
+		zap.Duration("mergeElapsed", time.Duration(trace.mergeNs.Load())),
+		zap.Duration("fmMergeElapsed", time.Duration(trace.fmMergeNs.Load())),
+		// worker utilization — how much time merge workers spend computing vs waiting for data.
+		// Low utilization (<1%) means the bottleneck is upstream (fetch), not merge.
 		zap.Duration("workerBusyTotal", totalBusy),
-		zap.Float64("workerBusyPercent", busyPct),
+		zap.Duration("workerWaitTotal", totalWait),
+		zap.Float64("workerUtilPct", busyPct),
 	)
-
-	// Human-readable summary explaining where time is spent.
-	fetchPct := float64(0)
-	mergePct := float64(0)
-	if mergeWall > 0 {
-		fetchPct = float64(fetchElapsed) / float64(mergeWall) * 100
-		mergePct = float64(totalBusy) / float64(mergeWall) * 100
-	}
-	responseCount := trace.responseCount.Load()
-	copRespAvg := time.Duration(0)
-	if responseCount > 0 {
-		copRespAvg = copRespTimeSum / time.Duration(responseCount)
-	}
-	logutil.BgLogger().Info(fmt.Sprintf(
-		"analyze full sampling summary: wall=%v, fetch=%v (%.1f%% of wall), "+
-			"merge_compute=%v (%.1f%% of wall, workers %.1f%% utilized). "+
-			"Fetch breakdown: %d cop responses via %d concurrent workers, "+
-			"copRespTimeSum=%v (sum of per-request RPC round-trips, concurrent requests overlap), "+
-			"avg_rpc_per_request=%v. "+
-			"Fetch latency distribution: %d (<1ms, already buffered) + %d (1-10ms) + %d (10-100ms) + %d (>=100ms, waiting for TiKV). "+
-			"Note: ANALYZE uses KeepOrder=true for correlation, so responses must be consumed in region order; "+
-			"head-of-line blocking occurs when the next region's response has not arrived yet. "+
-			"Bottleneck: %s",
-		mergeWall, fetchElapsed, fetchPct,
-		totalBusy, mergePct, busyPct,
-		responseCount, trace.scanConcurrency,
-		copRespTimeSum, copRespAvg,
-		trace.fetchLt1msCount.Load(), trace.fetchLt10msCount.Load(),
-		trace.fetchLt100msCount.Load(), trace.fetchGe100msCount.Load(),
-		analyzeSummaryBottleneck(fetchPct, busyPct),
-	), zap.Int64("tableID", e.tableID.TableID))
 
 	// Decode the data from sample collectors.
 	virtualColIdx := buildVirtualColumnIndex(e.schemaForVirtualColEval, e.colsInfo)
@@ -1101,17 +1062,7 @@ func readDataAndSendTask(ctx context.Context, sctx sessionctx.Context, handler *
 		rs, err := handler.nextRawSubset(ctx)
 		fetchNs := time.Since(fetchStart).Nanoseconds()
 		trace.fetchElapsedNs.Add(fetchNs)
-		trace.fetchCount.Add(1)
 		// Track per-response latency distribution.
-		for {
-			cur := trace.fetchMinNs.Load()
-			if cur != 0 && cur <= fetchNs {
-				break
-			}
-			if trace.fetchMinNs.CompareAndSwap(cur, fetchNs) {
-				break
-			}
-		}
 		for {
 			cur := trace.fetchMaxNs.Load()
 			if cur >= fetchNs {
@@ -1124,10 +1075,6 @@ func readDataAndSendTask(ctx context.Context, sctx sessionctx.Context, handler *
 		switch {
 		case fetchNs < 1e6: // < 1ms
 			trace.fetchLt1msCount.Add(1)
-		case fetchNs < 10e6: // 1ms–10ms
-			trace.fetchLt10msCount.Add(1)
-		case fetchNs < 100e6: // 10ms–100ms
-			trace.fetchLt100msCount.Add(1)
 		default: // >= 100ms
 			trace.fetchGe100msCount.Add(1)
 		}
@@ -1139,7 +1086,6 @@ func readDataAndSendTask(ctx context.Context, sctx sessionctx.Context, handler *
 			break
 		}
 		data := rs.GetData()
-		trace.fetchBytes.Add(int64(len(data)))
 		trace.copRespTimeNs.Add(rs.RespTime().Nanoseconds())
 
 		dataSize := int64(cap(data))

--- a/pkg/executor/analyze_col_sampling.go
+++ b/pkg/executor/analyze_col_sampling.go
@@ -17,6 +17,7 @@ package executor
 import (
 	"context"
 	stderrors "errors"
+	"fmt"
 	"slices"
 	"sync/atomic"
 	"time"
@@ -51,6 +52,19 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+func analyzeSummaryBottleneck(fetchPct, busyPct float64) string {
+	if fetchPct > 90 {
+		return "response fetch pipeline (>90% of wall time spent waiting for TiKV responses; " +
+			"try increasing tidb_store_batch_size to reduce request count, " +
+			"or tidb_analyze_distsql_scan_concurrency to increase concurrency)"
+	}
+	if busyPct > 50 {
+		return "merge computation (merge workers busy >50% of time; " +
+			"try increasing tidb_build_sampling_stats_concurrency)"
+	}
+	return "mixed (no single dominant bottleneck)"
+}
+
 // samplingMergeTrace collects lightweight metrics that reveal the performance
 // profile of the merge-sampling pipeline.  All fields are updated atomically
 // so that concurrent merge workers can write without a mutex.
@@ -66,6 +80,8 @@ type samplingMergeTrace struct {
 	fetchLt100msCount atomic.Int64 // count of fetches 10ms–100ms
 	fetchGe100msCount atomic.Int64 // count of fetches >= 100ms
 	scanConcurrency  int          // set once before goroutines start
+	// per-response cop timing (from copIterator)
+	copRespTimeNs    atomic.Int64 // sum of cop worker RPC round-trip times
 	// subMergeWorker (N goroutines)
 	responseCount    atomic.Int64
 	responseBytes    atomic.Int64
@@ -345,10 +361,12 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 		busyPct = float64(totalBusy) / float64(totalWait+totalBusy) * 100
 	}
 	fetchCount := trace.fetchCount.Load()
+	fetchElapsed := time.Duration(trace.fetchElapsedNs.Load())
 	fetchAvgNs := int64(0)
 	if fetchCount > 0 {
 		fetchAvgNs = trace.fetchElapsedNs.Load() / fetchCount
 	}
+	copRespTimeSum := time.Duration(trace.copRespTimeNs.Load())
 	logutil.BgLogger().Info("analyze full sampling merge trace",
 		zap.Int64("tableID", e.tableID.TableID),
 		zap.Duration("mergeWall", mergeWall),
@@ -357,7 +375,7 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 		// fetch pipeline (single goroutine)
 		zap.Int64("fetchCount", fetchCount),
 		zap.Int64("fetchBytes", trace.fetchBytes.Load()),
-		zap.Duration("fetchElapsed", time.Duration(trace.fetchElapsedNs.Load())),
+		zap.Duration("fetchElapsed", fetchElapsed),
 		zap.Duration("fetchAvg", time.Duration(fetchAvgNs)),
 		zap.Duration("fetchMin", time.Duration(trace.fetchMinNs.Load())),
 		zap.Duration("fetchMax", time.Duration(trace.fetchMaxNs.Load())),
@@ -365,6 +383,8 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 		zap.Int64("fetchLt10ms", trace.fetchLt10msCount.Load()),
 		zap.Int64("fetchLt100ms", trace.fetchLt100msCount.Load()),
 		zap.Int64("fetchGe100ms", trace.fetchGe100msCount.Load()),
+		// cop response time (TiDB-measured per-request RPC round-trip)
+		zap.Duration("copRespTimeSum", copRespTimeSum),
 		// merge worker aggregates
 		zap.Int64("responses", trace.responseCount.Load()),
 		zap.Int64("responseBytes", trace.responseBytes.Load()),
@@ -380,6 +400,37 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 		zap.Duration("workerBusyTotal", totalBusy),
 		zap.Float64("workerBusyPercent", busyPct),
 	)
+
+	// Human-readable summary explaining where time is spent.
+	fetchPct := float64(0)
+	mergePct := float64(0)
+	if mergeWall > 0 {
+		fetchPct = float64(fetchElapsed) / float64(mergeWall) * 100
+		mergePct = float64(totalBusy) / float64(mergeWall) * 100
+	}
+	responseCount := trace.responseCount.Load()
+	copRespAvg := time.Duration(0)
+	if responseCount > 0 {
+		copRespAvg = copRespTimeSum / time.Duration(responseCount)
+	}
+	logutil.BgLogger().Info(fmt.Sprintf(
+		"analyze full sampling summary: wall=%v, fetch=%v (%.1f%% of wall), "+
+			"merge_compute=%v (%.1f%% of wall, workers %.1f%% utilized). "+
+			"Fetch breakdown: %d cop responses via %d concurrent workers, "+
+			"copRespTimeSum=%v (sum of per-request RPC round-trips, concurrent requests overlap), "+
+			"avg_rpc_per_request=%v. "+
+			"Fetch latency distribution: %d (<1ms, already buffered) + %d (1-10ms) + %d (10-100ms) + %d (>=100ms, waiting for TiKV). "+
+			"Note: ANALYZE uses KeepOrder=true for correlation, so responses must be consumed in region order; "+
+			"head-of-line blocking occurs when the next region's response has not arrived yet. "+
+			"Bottleneck: %s",
+		mergeWall, fetchElapsed, fetchPct,
+		totalBusy, mergePct, busyPct,
+		responseCount, trace.scanConcurrency,
+		copRespTimeSum, copRespAvg,
+		trace.fetchLt1msCount.Load(), trace.fetchLt10msCount.Load(),
+		trace.fetchLt100msCount.Load(), trace.fetchGe100msCount.Load(),
+		analyzeSummaryBottleneck(fetchPct, busyPct),
+	), zap.Int64("tableID", e.tableID.TableID))
 
 	// Decode the data from sample collectors.
 	virtualColIdx := buildVirtualColumnIndex(e.schemaForVirtualColEval, e.colsInfo)
@@ -1047,7 +1098,7 @@ func readDataAndSendTask(ctx context.Context, sctx sessionctx.Context, handler *
 		})
 
 		fetchStart := time.Now()
-		data, err := handler.nextRaw(ctx)
+		rs, err := handler.nextRawSubset(ctx)
 		fetchNs := time.Since(fetchStart).Nanoseconds()
 		trace.fetchElapsedNs.Add(fetchNs)
 		trace.fetchCount.Add(1)
@@ -1084,10 +1135,12 @@ func readDataAndSendTask(ctx context.Context, sctx sessionctx.Context, handler *
 			err = normalizeCtxErrWithCause(ctx, err)
 			return errors.Trace(err)
 		}
-		if data == nil {
+		if rs == nil {
 			break
 		}
+		data := rs.GetData()
 		trace.fetchBytes.Add(int64(len(data)))
+		trace.copRespTimeNs.Add(rs.RespTime().Nanoseconds())
 
 		dataSize := int64(cap(data))
 		memTracker.Consume(dataSize)

--- a/pkg/executor/analyze_col_sampling.go
+++ b/pkg/executor/analyze_col_sampling.go
@@ -59,6 +59,13 @@ type samplingMergeTrace struct {
 	fetchCount       atomic.Int64
 	fetchBytes       atomic.Int64
 	fetchElapsedNs   atomic.Int64
+	fetchMinNs       atomic.Int64 // min per-response fetch latency
+	fetchMaxNs       atomic.Int64 // max per-response fetch latency
+	fetchLt1msCount  atomic.Int64 // count of fetches < 1ms
+	fetchLt10msCount atomic.Int64 // count of fetches 1ms–10ms
+	fetchLt100msCount atomic.Int64 // count of fetches 10ms–100ms
+	fetchGe100msCount atomic.Int64 // count of fetches >= 100ms
+	scanConcurrency  int          // set once before goroutines start
 	// subMergeWorker (N goroutines)
 	responseCount    atomic.Int64
 	responseBytes    atomic.Int64
@@ -251,7 +258,7 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 	// Start workers to merge the result from collectors.
 	mergeResultCh := make(chan *samplingMergeResult, 1)
 	mergeTaskCh := make(chan []byte, 1)
-	trace := &samplingMergeTrace{}
+	trace := &samplingMergeTrace{scanConcurrency: e.concurrency}
 	mergeStart := time.Now()
 	taskCtx, taskCancel := context.WithCancelCause(ctx)
 	defer taskCancel(nil)
@@ -337,14 +344,27 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 	if totalWait+totalBusy > 0 {
 		busyPct = float64(totalBusy) / float64(totalWait+totalBusy) * 100
 	}
+	fetchCount := trace.fetchCount.Load()
+	fetchAvgNs := int64(0)
+	if fetchCount > 0 {
+		fetchAvgNs = trace.fetchElapsedNs.Load() / fetchCount
+	}
 	logutil.BgLogger().Info("analyze full sampling merge trace",
 		zap.Int64("tableID", e.tableID.TableID),
 		zap.Duration("mergeWall", mergeWall),
 		zap.Int("mergeWorkers", samplingStatsConcurrency),
+		zap.Int("scanConcurrency", trace.scanConcurrency),
 		// fetch pipeline (single goroutine)
-		zap.Int64("fetchCount", trace.fetchCount.Load()),
+		zap.Int64("fetchCount", fetchCount),
 		zap.Int64("fetchBytes", trace.fetchBytes.Load()),
 		zap.Duration("fetchElapsed", time.Duration(trace.fetchElapsedNs.Load())),
+		zap.Duration("fetchAvg", time.Duration(fetchAvgNs)),
+		zap.Duration("fetchMin", time.Duration(trace.fetchMinNs.Load())),
+		zap.Duration("fetchMax", time.Duration(trace.fetchMaxNs.Load())),
+		zap.Int64("fetchLt1ms", trace.fetchLt1msCount.Load()),
+		zap.Int64("fetchLt10ms", trace.fetchLt10msCount.Load()),
+		zap.Int64("fetchLt100ms", trace.fetchLt100msCount.Load()),
+		zap.Int64("fetchGe100ms", trace.fetchGe100msCount.Load()),
 		// merge worker aggregates
 		zap.Int64("responses", trace.responseCount.Load()),
 		zap.Int64("responseBytes", trace.responseBytes.Load()),
@@ -1028,8 +1048,38 @@ func readDataAndSendTask(ctx context.Context, sctx sessionctx.Context, handler *
 
 		fetchStart := time.Now()
 		data, err := handler.nextRaw(ctx)
-		trace.fetchElapsedNs.Add(time.Since(fetchStart).Nanoseconds())
+		fetchNs := time.Since(fetchStart).Nanoseconds()
+		trace.fetchElapsedNs.Add(fetchNs)
 		trace.fetchCount.Add(1)
+		// Track per-response latency distribution.
+		for {
+			cur := trace.fetchMinNs.Load()
+			if cur != 0 && cur <= fetchNs {
+				break
+			}
+			if trace.fetchMinNs.CompareAndSwap(cur, fetchNs) {
+				break
+			}
+		}
+		for {
+			cur := trace.fetchMaxNs.Load()
+			if cur >= fetchNs {
+				break
+			}
+			if trace.fetchMaxNs.CompareAndSwap(cur, fetchNs) {
+				break
+			}
+		}
+		switch {
+		case fetchNs < 1e6: // < 1ms
+			trace.fetchLt1msCount.Add(1)
+		case fetchNs < 10e6: // 1ms–10ms
+			trace.fetchLt10msCount.Add(1)
+		case fetchNs < 100e6: // 10ms–100ms
+			trace.fetchLt100msCount.Add(1)
+		default: // >= 100ms
+			trace.fetchGe100msCount.Add(1)
+		}
 		if err != nil {
 			err = normalizeCtxErrWithCause(ctx, err)
 			return errors.Trace(err)

--- a/pkg/executor/table_reader.go
+++ b/pkg/executor/table_reader.go
@@ -704,6 +704,24 @@ func (tr *tableResultHandler) nextRaw(ctx context.Context) (data []byte, err err
 	return data, nil
 }
 
+func (tr *tableResultHandler) nextRawSubset(ctx context.Context) (kv.ResultSubset, error) {
+	if !tr.optionalFinished {
+		rs, err := tr.optionalResult.NextRawSubset(ctx)
+		if err != nil {
+			return nil, normalizeCtxErrWithCause(ctx, err)
+		}
+		if rs != nil {
+			return rs, nil
+		}
+		tr.optionalFinished = true
+	}
+	rs, err := tr.result.NextRawSubset(ctx)
+	if err != nil {
+		return nil, normalizeCtxErrWithCause(ctx, err)
+	}
+	return rs, nil
+}
+
 func (tr *tableResultHandler) Close() error {
 	err := closeAll(tr.optionalResult, tr.result)
 	tr.optionalResult, tr.result = nil, nil

--- a/pkg/statistics/row_sampler.go
+++ b/pkg/statistics/row_sampler.go
@@ -18,6 +18,7 @@ import (
 	"container/heap"
 	"context"
 	"math/rand"
+	"time"
 	"unsafe"
 
 	"github.com/pingcap/tidb/pkg/kv"
@@ -34,7 +35,7 @@ import (
 
 // RowSampleCollector implements the needed interface for a row-based sample collector.
 type RowSampleCollector interface {
-	MergeCollector(collector RowSampleCollector)
+	MergeCollector(collector RowSampleCollector) time.Duration
 	sampleRow(row []types.Datum, rng *rand.Rand)
 	Base() *baseCollector
 	DestroyAndPutToPool()
@@ -292,13 +293,15 @@ func (s *baseCollector) ToProto() *tipb.RowSampleCollector {
 	return collector
 }
 
-func (s *baseCollector) FromProto(pbCollector *tipb.RowSampleCollector, memTracker *memory.Tracker) {
+func (s *baseCollector) FromProto(pbCollector *tipb.RowSampleCollector, memTracker *memory.Tracker) time.Duration {
 	s.Count = pbCollector.Count
 	s.NullCount = pbCollector.NullCounts
+	fmStart := time.Now()
 	s.FMSketches = make([]*FMSketch, 0, len(pbCollector.FmSketch))
 	for _, pbSketch := range pbCollector.FmSketch {
 		s.FMSketches = append(s.FMSketches, FMSketchFromProto(pbSketch))
 	}
+	fmSketchElapsed := time.Since(fmStart)
 	s.TotalSizes = pbCollector.TotalSize
 	sampleNum := len(pbCollector.Samples)
 	s.Samples = make(WeightedRowSampleHeap, 0, sampleNum)
@@ -325,6 +328,7 @@ func (s *baseCollector) FromProto(pbCollector *tipb.RowSampleCollector, memTrack
 		s.MemSize += deltaSize
 	}
 	memTracker.Consume(bufferedMemSize)
+	return fmSketchElapsed
 }
 
 // Base implements the RowSampleCollector interface.
@@ -368,11 +372,13 @@ func (s *ReservoirRowSampleCollector) sampleRow(row []types.Datum, rng *rand.Ran
 }
 
 // MergeCollector merges the collectors to a final one.
-func (s *ReservoirRowSampleCollector) MergeCollector(subCollector RowSampleCollector) {
+func (s *ReservoirRowSampleCollector) MergeCollector(subCollector RowSampleCollector) time.Duration {
 	s.Count += subCollector.Base().Count
+	fmStart := time.Now()
 	for i, fms := range subCollector.Base().FMSketches {
 		s.FMSketches[i].MergeFMSketch(fms)
 	}
+	fmSketchElapsed := time.Since(fmStart)
 	for i, nullCount := range subCollector.Base().NullCount {
 		s.NullCount[i] += nullCount
 	}
@@ -391,6 +397,7 @@ func (s *ReservoirRowSampleCollector) MergeCollector(subCollector RowSampleColle
 	} else {
 		s.MemSize = (s.MemSize + subCollector.Base().MemSize) * int64(newSampleNum) / int64(totalSampleNum)
 	}
+	return fmSketchElapsed
 }
 
 // DestroyAndPutToPool implements the interface RowSampleCollector.
@@ -462,11 +469,13 @@ func (s *BernoulliRowSampleCollector) sampleRow(row []types.Datum, rng *rand.Ran
 }
 
 // MergeCollector merges the collectors to a final one.
-func (s *BernoulliRowSampleCollector) MergeCollector(subCollector RowSampleCollector) {
+func (s *BernoulliRowSampleCollector) MergeCollector(subCollector RowSampleCollector) time.Duration {
 	s.Count += subCollector.Base().Count
+	fmStart := time.Now()
 	for i := range subCollector.Base().FMSketches {
 		s.FMSketches[i].MergeFMSketch(subCollector.Base().FMSketches[i])
 	}
+	fmSketchElapsed := time.Since(fmStart)
 	for i := range subCollector.Base().NullCount {
 		s.NullCount[i] += subCollector.Base().NullCount[i]
 	}
@@ -475,6 +484,7 @@ func (s *BernoulliRowSampleCollector) MergeCollector(subCollector RowSampleColle
 	}
 	s.baseCollector.Samples = append(s.baseCollector.Samples, subCollector.Base().Samples...)
 	s.MemSize += subCollector.Base().MemSize
+	return fmSketchElapsed
 }
 
 // Base implements the interface RowSampleCollector.

--- a/pkg/store/copr/copr_test/coprocessor_test.go
+++ b/pkg/store/copr/copr_test/coprocessor_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/testutils"
 	"github.com/tikv/client-go/v2/tikvrpc"
@@ -270,6 +271,33 @@ func TestBuildCopIteratorWithBatchStoreCopr(t *testing.T) {
 	require.Equal(t, len(tasks), 2)
 	require.Equal(t, len(tasks[0].ToPBBatchTasks()), 1)
 	require.Equal(t, len(tasks[1].ToPBBatchTasks()), 0)
+
+	// Analyze full-sampling requests do not carry DAG row-count hints, but can
+	// still use store-batch tasks because TiKV reduces successful analyze
+	// sub-results into the top-level response.
+	analyzeReq := &tipb.AnalyzeReq{
+		Tp:     tipb.AnalyzeType_TypeFullSampling,
+		ColReq: &tipb.AnalyzeColumnsReq{},
+	}
+	analyzeReqData, err := analyzeReq.Marshal()
+	require.NoError(t, err)
+	ranges = copr.BuildKeyRanges("a", "c", "d", "e", "h", "x", "y", "z")
+	req = &kv.Request{
+		Tp:             kv.ReqTypeAnalyze,
+		Data:           analyzeReqData,
+		KeyRanges:      kv.NewNonPartitionedKeyRanges(ranges),
+		Concurrency:    15,
+		StoreBatchSize: 3,
+		KeepOrder:      true,
+		RequestSource: kv.RequestSource{
+			RequestSourceInternal: true,
+		},
+	}
+	it, errRes = copClient.BuildCopIterator(ctx, req, vars, opt)
+	require.Nil(t, errRes)
+	tasks = it.GetTasks()
+	require.Equal(t, len(tasks), 1)
+	require.Equal(t, len(tasks[0].ToPBBatchTasks()), 3)
 }
 
 type mockResourceGroupProvider struct {

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -644,7 +644,7 @@ func buildCopTasks(bo *Backoffer, ranges *KeyRanges, opt *buildCopTaskOpt) ([]*c
 	}
 
 	var builder taskBuilder
-	if req.StoreBatchSize > 0 && hints != nil {
+	if req.StoreBatchSize > 0 && (hints != nil || isAnalyzeStoreBatchRequest(req)) {
 		builder = newBatchTaskBuilder(bo, req, cache, req.ReplicaRead)
 	} else {
 		builder = newLegacyTaskBuilder(len(locs))
@@ -819,7 +819,7 @@ func (b *batchStoreTaskBuilder) handle(task *copTask) (err error) {
 		}
 	}()
 	// only batch small tasks for memory control.
-	if b.limit <= 0 || !isSmallTask(task) {
+	if b.limit <= 0 || (!isAnalyzeStoreBatchRequest(b.req) && !isSmallTask(task)) {
 		return nil
 	}
 	batchedTask, err := b.cache.BuildBatchTask(b.bo, b.req, task, b.replicaRead)
@@ -2321,6 +2321,10 @@ func (worker *copIteratorWorker) handleBatchCopResponse(bo *Backoffer, rpcCtx *t
 		}
 	}
 	batchResps := resp.GetBatchResponses()
+	if worker.req.Tp == kv.ReqTypeAnalyze && len(batchResps) == 0 &&
+		resp.GetRegionError() == nil && resp.GetLocked() == nil && resp.GetOtherError() == "" {
+		return nil, nil, nil
+	}
 	batchRespList = make([]*copResponse, 0, len(batchResps))
 	for _, batchResp := range batchResps {
 		taskID := batchResp.GetTaskId()
@@ -2971,6 +2975,9 @@ func optRowHint(req *kv.Request) bool {
 }
 
 func checkStoreBatchCopr(req *kv.Request) bool {
+	if req.Tp == kv.ReqTypeAnalyze {
+		return isAnalyzeStoreBatchRequest(req)
+	}
 	if req.Tp != kv.ReqTypeDAG || req.StoreType != kv.TiKV {
 		return false
 	}
@@ -2988,4 +2995,18 @@ func checkStoreBatchCopr(req *kv.Request) bool {
 		return false
 	}
 	return true
+}
+
+func isAnalyzeStoreBatchRequest(req *kv.Request) bool {
+	if req.Tp != kv.ReqTypeAnalyze || req.StoreType != kv.TiKV {
+		return false
+	}
+	if req.ReplicaRead != kv.ReplicaReadLeader || req.Paging.Enable {
+		return false
+	}
+	analyzeReq := &tipb.AnalyzeReq{}
+	if err := proto.Unmarshal(req.Data, analyzeReq); err != nil {
+		return false
+	}
+	return analyzeReq.GetTp() == tipb.AnalyzeType_TypeFullSampling && analyzeReq.GetColReq() != nil
 }


### PR DESCRIPTION
## Summary

Add lightweight instrumentation to the full-sampling ANALYZE pipeline to diagnose why increasing `tidb_build_sampling_stats_concurrency` does not improve performance on large tables while `tidb_store_batch_size` does.

Emits a single INFO-level log line per `ANALYZE TABLE` execution with:
- **Fetch pipeline metrics**: fetchCount, fetchBytes, fetchElapsed — the single-goroutine `readDataAndSendTask` that sequentially consumes cop responses
- **Merge worker metrics**: unmarshal/fromProto/mergeCollector elapsed, with FM sketch timing broken out
- **Worker utilization**: workerWaitTotal vs workerBusyTotal, directly showing whether merge workers are the bottleneck

### Key findings (10M rows, ~1000 regions, 3 TiKV)

| Configuration | Wall time | fetchElapsed | workerBusyTotal | workerBusyPercent |
|---|---|---|---|---|
| no batch, merge_conc=2 | 46s | 45.7s | 212ms | 0.23% |
| no batch, merge_conc=32 | ~46s | similar | similar | 0.01% |
| batch=10, merge_conc=2 (with TiKV-side reduce) | 19s | 18.5s | 208ms | 0.33% |

- Merge workers are busy for only ~200ms out of a 46s ANALYZE (0.23% utilization) — **not the bottleneck**.
- 99.8% of wall time is spent waiting for cop responses from TiKV.
- FM sketch merge accounts for 99%+ of merge computation, but only ~60ms total.

### Changes
- `RowSampleCollector.MergeCollector` returns `time.Duration` (FM sketch merge elapsed)
- `baseCollector.FromProto` returns `time.Duration` (FM sketch conversion elapsed)
- `samplingMergeTrace` struct aggregates metrics atomically across concurrent merge workers