### PR TITLE
test: stabilize flaky TestTimeoutRecv

### DIFF
--- a/br/pkg/backup/store_test.go
+++ b/br/pkg/backup/store_test.go
@@ -54,29 +54,45 @@ func (mbbc *MockBackupBackupClient) Recv() (*backuppb.BackupResponse, error) {
 
 func TestTimeoutRecv(t *testing.T) {
 	ctx := context.Background()
+	originTimeout := TimeoutOneResponse
 	TimeoutOneResponse = time.Millisecond * 800
+	t.Cleanup(func() {
+		TimeoutOneResponse = originTimeout
+	})
+	recordTimeoutErr := func(ctx context.Context, timeoutObserved chan<- bool) error {
+		err := ctx.Err()
+		timeoutObserved <- err != nil
+		if err != nil {
+			return err
+		}
+		return context.Canceled
+	}
 	// Just Timeout Once
 	{
+		timeoutObserved := make(chan bool, 1)
 		err := startBackup(ctx, 0, NewResourceMemoryLimiter(100), backuppb.BackupRequest{}, &MockBackupClient{
 			recvFunc: func(ctx context.Context) (*backuppb.BackupResponse, error) {
 				time.Sleep(time.Second)
-				require.Error(t, ctx.Err())
-				return nil, ctx.Err()
+				return nil, recordTimeoutErr(ctx, timeoutObserved)
 			},
 		}, 1, nil)
 		require.Error(t, err)
+		require.True(t, <-timeoutObserved)
 	}
 
 	// Timeout Not At First
 	{
 		count := 0
+		timeoutObserved := make(chan bool, 1)
 		err := startBackup(ctx, 0, NewResourceMemoryLimiter(100), backuppb.BackupRequest{}, &MockBackupClient{
 			recvFunc: func(ctx context.Context) (*backuppb.BackupResponse, error) {
-				require.NoError(t, ctx.Err())
+				if err := ctx.Err(); err != nil {
+					timeoutObserved <- true
+					return nil, err
+				}
 				if count == 15 {
 					time.Sleep(time.Second)
-					require.Error(t, ctx.Err())
-					return nil, ctx.Err()
+					return nil, recordTimeoutErr(ctx, timeoutObserved)
 				}
 				count += 1
 				time.Sleep(time.Millisecond * 80)
@@ -85,6 +101,7 @@ func TestTimeoutRecv(t *testing.T) {
 		}, 1, make(chan *ResponseAndStore, 15))
 		require.Error(t, err)
 		require.Equal(t, count, 15)
+		require.True(t, <-timeoutObserved)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68365

Problem Summary:
Flaky test `TestTimeoutRecv` in `br/pkg/backup` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

`require.*` inside the mocked Recv worker goroutine could Goexit before returning the timeout error that `startBackup` was supposed to surface.

#### Fix

Returning the observed context error and asserting timeout observation on the main goroutine preserves the timeout contract while removing the goroutine assertion race.

#### Verification

Spec:
- target: `br/pkg/backup :: TestTimeoutRecv`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package: FAIL
- build: FAIL
- lint: SKIPPED
- prow_backup_test: SKIPPED

Commands:
- `go test -json -tags=intest,deadlock ./br/pkg/backup -run '^TestTimeoutRecv$' -count=1`
- `go test -json -tags=intest,deadlock ./br/pkg/backup -count=1`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved timeout tests to be more reliable and less flaky.
  * Temporarily adjust timeout behavior during tests with automatic restoration.
  * Added helpers and observation checks to verify timeouts are detected as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->