### PR TITLE
server: remove hot-path disconnect monitor

### DIFF
--- a/pkg/expression/builtin_miscellaneous_vec.go
+++ b/pkg/expression/builtin_miscellaneous_vec.go
@@ -500,7 +500,10 @@ func doSleep(secs float64, sessVars *variable.SessionVars) (isKilled bool) {
 			// MySQL 8.0 sleep: https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_sleep
 			// Regular kill or Killed because of max execution time
 			if err := sessVars.SQLKiller.HandleSignal(); err != nil {
-				if len(sessVars.StmtCtx.TableIDs) == 0 {
+				if len(sessVars.StmtCtx.TableIDs) == 0 &&
+					!sessVars.StmtCtx.InInsertStmt &&
+					!sessVars.StmtCtx.InUpdateStmt &&
+					!sessVars.StmtCtx.InDeleteStmt {
 					sessVars.SQLKiller.Reset()
 				}
 				timer.Stop()

--- a/pkg/expression/evaluator_test.go
+++ b/pkg/expression/evaluator_test.go
@@ -172,6 +172,19 @@ func TestSleep(t *testing.T) {
 	require.Equal(t, int64(1), res.GetInt64())
 	require.LessOrEqual(t, sub.Nanoseconds(), int64(2*1e9))
 	require.GreaterOrEqual(t, sub.Nanoseconds(), int64(1*1e9))
+
+	sessVars.SQLKiller.Reset()
+	sessVars.StmtCtx.InInsertStmt = true
+	sessVars.SQLKiller.SendKillSignal(sqlkiller.QueryInterrupted)
+	d[0].SetFloat64(0.01)
+	f, err = fc.getFunction(ctx, datumsToConstants(d))
+	require.NoError(t, err)
+	res, err = evalBuiltinFunc(f, ctx, chunk.Row{})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), res.GetInt64())
+	require.NotZero(t, sessVars.SQLKiller.GetKillSignal())
+	sessVars.SQLKiller.Reset()
+	sessVars.StmtCtx.InInsertStmt = false
 }
 
 func TestBinopComparison(t *testing.T) {

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -111,7 +111,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
-	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	tlsutil "github.com/pingcap/tidb/pkg/util/tls"
 	"github.com/pingcap/tidb/pkg/util/topsql"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
@@ -2166,61 +2165,30 @@ func setResourceGroupTaggerForMultiStmtPrefetch(snapshot kv.Snapshot, sqls strin
 }
 
 // setSQLKillerConnectionAlive installs a connection-liveness probe on the
-// session SQLKiller and starts a background monitor for the current statement.
-// The returned cleanup is idempotent and must be called when the statement is
-// done to stop the monitor and clear the probe.
+// session SQLKiller for execution checkpoints such as HandleSignal and the
+// slow pre-commit backstop. It intentionally does not start a background
+// monitor, so short statements do not pay goroutine, ticker, or channel costs.
 func (cc *clientConn) setSQLKillerConnectionAlive() func() {
-	fn := func() bool {
-		if cc.bufReadConn != nil {
-			// IsAlive returns 0 only when the connection is known dead. Treat
-			// unknown states as alive so we do not interrupt queries
-			// conservatively when the liveness check itself cannot run.
-			return cc.bufReadConn.IsAlive() != 0
-		}
-		return true
-	}
-	cc.ctx.GetSessionVars().SQLKiller.IsConnectionAlive.Store(&fn)
-	stopMonitor := make(chan struct{})
-	doneMonitor := make(chan struct{})
-	go cc.monitorConnectionAlive(fn, stopMonitor, doneMonitor)
+	sessVars := cc.ctx.GetSessionVars()
+	isAlive := cc.isConnectionAlive
+	sessVars.SQLKiller.IsConnectionAlive.Store(&isAlive)
 
 	var clearOnce sync.Once
 	return func() {
 		clearOnce.Do(func() {
-			close(stopMonitor)
-			<-doneMonitor
-			cc.ctx.GetSessionVars().SQLKiller.IsConnectionAlive.Store(nil)
+			sessVars.SQLKiller.IsConnectionAlive.CompareAndSwap(&isAlive, nil)
 		})
 	}
 }
 
-func (cc *clientConn) monitorConnectionAlive(isAlive func() bool, stop <-chan struct{}, done chan<- struct{}) {
-	defer close(done)
-	checkInterval := time.Second
-	failpoint.Inject("mockConnectionAliveMonitorInterval", func(val failpoint.Value) {
-		if interval, ok := val.(int); ok {
-			checkInterval = time.Duration(interval) * time.Millisecond
-		}
-	})
-	ticker := time.NewTicker(checkInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			if !isAlive() {
-				select {
-				case <-stop:
-					return
-				default:
-				}
-				cc.ctx.GetSessionVars().SQLKiller.SendKillSignal(sqlkiller.QueryInterrupted)
-				cc.cancelDispatch()
-				return
-			}
-		case <-stop:
-			return
-		}
+func (cc *clientConn) isConnectionAlive() bool {
+	if cc.bufReadConn != nil {
+		// IsAlive returns 0 only when the connection is known dead. Treat
+		// unknown states as alive so we do not interrupt queries
+		// conservatively when the liveness check itself cannot run.
+		return cc.bufReadConn.IsAlive() != 0
 	}
+	return true
 }
 
 func (cc *clientConn) cancelDispatch() {
@@ -2232,7 +2200,7 @@ func (cc *clientConn) cancelDispatch() {
 	}
 }
 
-func shouldMonitorConnectionAliveDuringExecute(stmt ast.StmtNode, sessVars *variable.SessionVars) bool {
+func shouldInstallConnectionAliveDuringExecute(stmt ast.StmtNode, sessVars *variable.SessionVars) bool {
 	if !sessVars.IsAutocommit() || sessVars.InTxn() {
 		return false
 	}
@@ -2274,8 +2242,8 @@ func (cc *clientConn) handleStmt(
 	}
 
 	clearConnectionAlive := func() {}
-	monitoringConnectionAlive := shouldMonitorConnectionAliveDuringExecute(stmt, cc.ctx.GetSessionVars())
-	if monitoringConnectionAlive {
+	checkingConnectionAlive := shouldInstallConnectionAliveDuringExecute(stmt, cc.ctx.GetSessionVars())
+	if checkingConnectionAlive {
 		clearConnectionAlive = cc.setSQLKillerConnectionAlive()
 		defer clearConnectionAlive()
 	}
@@ -2313,7 +2281,7 @@ func (cc *clientConn) handleStmt(
 		if cc.getStatus() == connStatusShutdown {
 			return false, exeerrors.ErrQueryInterrupted
 		}
-		if !monitoringConnectionAlive {
+		if !checkingConnectionAlive {
 			clearConnectionAlive = cc.setSQLKillerConnectionAlive()
 			defer clearConnectionAlive()
 		}

--- a/pkg/server/conn_stmt.go
+++ b/pkg/server/conn_stmt.go
@@ -311,10 +311,10 @@ func (cc *clientConn) executePreparedStmtAndWriteResult(ctx context.Context, stm
 	}
 	execStmt.SetText(charset.EncodingUTF8Impl, sql)
 	clearConnectionAlive := func() {}
-	monitoringConnectionAlive := false
+	checkingConnectionAlive := false
 	if planCacheStmt != nil && planCacheStmt.PreparedAst != nil {
-		monitoringConnectionAlive = shouldMonitorConnectionAliveDuringExecute(planCacheStmt.PreparedAst.Stmt, vars)
-		if monitoringConnectionAlive {
+		checkingConnectionAlive = shouldInstallConnectionAliveDuringExecute(planCacheStmt.PreparedAst.Stmt, vars)
+		if checkingConnectionAlive {
 			clearConnectionAlive = cc.setSQLKillerConnectionAlive()
 			defer clearConnectionAlive()
 		}
@@ -325,7 +325,7 @@ func (cc *clientConn) executePreparedStmtAndWriteResult(ctx context.Context, stm
 	}
 	var lazy bool
 	if rs != nil {
-		if !monitoringConnectionAlive {
+		if !checkingConnectionAlive {
 			clearConnectionAlive = cc.setSQLKillerConnectionAlive()
 			defer clearConnectionAlive()
 		}

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3506,7 +3506,6 @@ func TestIssue57531(t *testing.T) {
 
 func TestClientDisconnectKillsAutocommitInsert(t *testing.T) {
 	ts := servertestkit.CreateTidbTestSuite(t)
-	enableFastConnectionAliveMonitor(t)
 
 	for _, prepared := range []bool{false, true} {
 		name := "query"
@@ -3599,16 +3598,6 @@ func runClientDisconnectAutocommitInsert(t *testing.T, dbt *testkit.DBTestKit, t
 	err = dbt.GetDB().QueryRowContext(context.Background(), "select count(*) from "+tableName).Scan(&cnt)
 	require.NoError(t, err)
 	require.Equal(t, 0, cnt)
-}
-
-func enableFastConnectionAliveMonitor(t *testing.T) {
-	require.NoError(t, failpoint.Enable(
-		"github.com/pingcap/tidb/pkg/server/mockConnectionAliveMonitorInterval",
-		`return(1)`,
-	))
-	t.Cleanup(func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/server/mockConnectionAliveMonitorInterval"))
-	})
 }
 
 func getRawNetConn(t *testing.T, conn *sql.Conn) net.Conn {

--- a/pkg/session/tidb.go
+++ b/pkg/session/tidb.go
@@ -274,8 +274,16 @@ func isLoadDataLocal(sql sqlexec.Statement) bool {
 	return false
 }
 
+// Avoid probing the socket on fast OLTP DML. This matches SQLKiller's normal
+// connection-alive throttle, while still covering long statements that reach
+// the disconnect-before-commit race without hitting another checkpoint.
+const minConnectionAliveCheckBeforeCommitDuration = time.Second
+
 func shouldCheckConnectionAliveBeforeCommit(sessVars *variable.SessionVars, sql sqlexec.Statement) bool {
 	if !sessVars.IsAutocommit() || sessVars.InTxn() {
+		return false
+	}
+	if !sessVars.StartTime.IsZero() && time.Since(sessVars.StartTime) < minConnectionAliveCheckBeforeCommitDuration {
 		return false
 	}
 	stmt, err := resolvePreparedStmt(sql.GetStmtNode(), sessVars)


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68633

Problem Summary:

PR #68237 added active connection-liveness monitoring for autocommit `INSERT`/`UPDATE`/`DELETE` so TiDB can notice some client disconnects before commit. That put fixed work on every eligible autocommit DML statement, including per-statement monitor goroutine/ticker/channel setup and an eager pre-commit socket probe. In the high-QPS sysbench `oltp_delete` case, that hot-path cost caused the 3.7% regression reported in #68633.

### What changed and how does it work?

- Remove the background disconnect monitor from the autocommit DML execution path. TiDB now only installs `SQLKiller.IsConnectionAlive` while the statement is executing, so existing interruption checkpoints can probe the socket synchronously with SQLKiller's normal throttle.
- Keep result-set statements covered by installing the same callback while the result set is being drained.
- Keep the pre-commit liveness check only as a slow-statement backstop for statements that have already run for at least 1 second, avoiding socket probes on fast OLTP DML.
- Preserve the `INSERT ... SLEEP()` disconnect regression coverage by keeping the kill signal for write statements when `SLEEP()` observes the interruption; the statement then aborts and rolls back instead of committing partial rows.
- Scope note: this PR does not add active liveness hooks inside client-go backoff, lock-wait, or prewrite waits. Covering those wait points without polling the TiDB hot path should be handled separately by passing a liveness/cancel callback into the relevant client-go wait points.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test commands:

```bash
./tools/check/failpoint-go-test.sh pkg/server/tests/commontest -run TestClientDisconnectKillsAutocommitInsert -count=1
./tools/check/failpoint-go-test.sh pkg/expression -run 'TestSleep(Vectorized)?$' -count=1
./tools/check/failpoint-go-test.sh pkg/server -run '^$' -count=1
./tools/check/failpoint-go-test.sh pkg/session -run '^$' -count=1
make bazel_prepare
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a performance regression in autocommit DML caused by hot-path disconnect monitoring overhead.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined connection liveness checking behavior during statement execution and improved handling of SLEEP function interruption during data modification operations.

* **Performance**
  * Optimized pre-commit connection checks for fast autocommit sessions using elapsed-time thresholds.

* **Tests**
  * Added test coverage for SLEEP function interruption during insert statement execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->