### PR TITLE
test: stabilize flaky TestPopulateChunks

### DIFF
--- a/pkg/executor/importer/importer_testkit_test.go
+++ b/pkg/executor/importer/importer_testkit_test.go
@@ -16,7 +16,6 @@ package importer_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -52,6 +51,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
@@ -424,27 +424,51 @@ func TestProcessChunkWith(t *testing.T) {
 }
 
 func TestPopulateChunks(t *testing.T) {
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalImportInto)
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tidbCfg := tidb.GetGlobalConfig()
-	tidbCfg.TempDir = t.TempDir()
-
-	tk.MustExec("use test")
-	tk.MustExec("create table t(a int, b int, c int)")
-	require.NoError(t, os.WriteFile(path.Join(tidbCfg.TempDir, "test-01.csv"),
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	require.NoError(t, os.WriteFile(path.Join(tempDir, "test-01.csv"),
 		[]byte("1,2,3\n4,5,6\n7,8,9\n"), 0o644))
-	require.NoError(t, os.WriteFile(path.Join(tidbCfg.TempDir, "test-02.csv"),
+	require.NoError(t, os.WriteFile(path.Join(tempDir, "test-02.csv"),
 		[]byte("8,8,8\n"), 0o644))
-	require.NoError(t, os.WriteFile(path.Join(tidbCfg.TempDir, "test-03.csv"),
+	require.NoError(t, os.WriteFile(path.Join(tempDir, "test-03.csv"),
 		[]byte("9,9,9\n10,10,10\n"), 0o644))
-	ti := getTableImporter(ctx, t, store, "t", fmt.Sprintf("%s/test-*.csv", tidbCfg.TempDir), importer.DataFormatCSV, []*plannercore.LoadDataOpt{{Name: "__max_engine_size", Value: expression.NewStrConst("20")}})
-	defer func() {
-		ti.LoadDataController.Close()
-		ti.Backend().CloseEngineMgr()
-	}()
-	require.NoError(t, ti.InitDataFiles(ctx))
-	engines, err := ti.PopulateChunks(ctx)
+
+	fieldType := types.NewFieldType(mysql.TypeLong)
+	tblInfo := &model.TableInfo{
+		ID:    1,
+		Name:  ast.NewCIStr("t"),
+		State: model.StatePublic,
+		Columns: []*model.ColumnInfo{
+			{ID: 1, Name: ast.NewCIStr("a"), Offset: 0, FieldType: *fieldType, State: model.StatePublic},
+			{ID: 2, Name: ast.NewCIStr("b"), Offset: 1, FieldType: *fieldType, State: model.StatePublic},
+			{ID: 3, Name: ast.NewCIStr("c"), Offset: 2, FieldType: *fieldType, State: model.StatePublic},
+		},
+	}
+	charset := "utf8mb4"
+	controller, err := importer.NewLoadDataController(&importer.Plan{
+		DBName:           "test",
+		DBID:             1,
+		TableInfo:        tblInfo,
+		DesiredTableInfo: tblInfo,
+		Path:             path.Join(tempDir, "test-*.csv"),
+		Format:           importer.DataFormatCSV,
+		Charset:          &charset,
+		FieldNullDef:     []string{`\N`},
+		LineFieldsInfo: plannercore.LineFieldsInfo{
+			FieldsTerminatedBy: `,`,
+			FieldsEnclosedBy:   `"`,
+			FieldsEscapedBy:    `\`,
+		},
+		ThreadCnt:      2,
+		MaxEngineSize:  config.ByteSize(20),
+		InImportInto:   true,
+		DataSourceType: importer.DataSourceTypeFile,
+	}, tables.MockTableFromMeta(tblInfo), &importer.ASTArgs{}, importer.WithLogger(zap.NewNop()))
+	require.NoError(t, err)
+	defer controller.Close()
+
+	require.NoError(t, controller.InitDataFiles(ctx))
+	engines, err := controller.PopulateChunks(ctx)
 	require.NoError(t, err)
 	require.Len(t, engines, 3)
 	require.Len(t, engines[0], 2)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68332

Problem Summary:
Flaky test `TestPopulateChunks` in `pkg/executor/importer` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TestPopulateChunks used full TiDB bootstrap for a local PopulateChunks chunk-splitting assertion, making timeout-style flakiness plausible under resource pressure.

#### Fix

Direct LoadDataController construction preserves the CSV inputs, table columns, max engine size, and engine assertions while removing unrelated bootstrap work.

#### Verification

Spec:
- target: `pkg/executor/importer :: TestPopulateChunks`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
timing_repro passed.

Gate checklist:
- target_flaky: PASS
- timing_repro: PASS
- package_failpoint: FAIL
- bazel_prepare: FAIL
- build: FAIL
- lint: FAIL

Commands:
- `go test -json -tags=intest,deadlock ./pkg/executor/importer -run '^TestPopulateChunks$' -count=1`
- `go test -tags=intest,deadlock ./pkg/executor/importer -run '^TestPopulateChunks$' -count=1 -timeout=1s`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored data import validation tests to improve test infrastructure and configuration verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->