### PR TITLE
executor: show materialized view log status

### DIFF
--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -225,10 +225,10 @@ func (e *ShowExec) fetchAll(ctx context.Context) error {
 		return e.fetchShowMaterializedViews(ctx)
 	case ast.ShowMaterializedViewLogs:
 		return e.fetchShowMaterializedViewLogs(ctx)
-	case ast.ShowMaterializedView:
-		return e.fetchShowMaterializedView(ctx)
-	case ast.ShowMaterializedViewLog:
-		return e.fetchShowMaterializedViewLog(ctx)
+	case ast.ShowMaterializedViewRemainLogs:
+		return e.fetchShowMaterializedViewRemainLogs(ctx)
+	case ast.ShowMaterializedViewLogWaitPurge:
+		return e.fetchShowMaterializedViewLogWaitPurge(ctx)
 	case ast.ShowOpenTables:
 		return e.fetchShowOpenTables()
 	case ast.ShowTableStatus:
@@ -764,10 +764,10 @@ func (e *ShowExec) fetchShowMaterializedViewLogs(ctx context.Context) error {
 	return nil
 }
 
-func (e *ShowExec) fetchShowMaterializedView(ctx context.Context) error {
-	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
-	if !e.is.SchemaExists(e.DBName) {
-		return exeerrors.ErrBadDB.GenWithStackByArgs(e.DBName)
+func (e *ShowExec) fetchShowMaterializedViewRemainLogs(ctx context.Context) error {
+	db, ok := e.is.SchemaByName(e.DBName)
+	if !ok {
+		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(e.DBName.O)
 	}
 
 	mvTable, err := e.getTable()
@@ -775,56 +775,96 @@ func (e *ShowExec) fetchShowMaterializedView(ctx context.Context) error {
 		return errors.Trace(err)
 	}
 	mvMeta := mvTable.Meta()
-	mvInfo := mvMeta.MaterializedView
-	if mvInfo == nil {
-		return exeerrors.ErrWrongObject.GenWithStackByArgs(e.DBName.O, mvMeta.Name.O, "MATERIALIZED VIEW")
+	if mvMeta.MaterializedView == nil {
+		return exeerrors.ErrWrongObject.GenWithStackByArgs(db.Name.O, mvMeta.Name.O, "MATERIALIZED VIEW")
+	}
+	if len(mvMeta.MaterializedView.BaseTableIDs) == 0 {
+		return errors.Errorf("base table does not exist for materialized view %s.%s", db.Name.O, mvMeta.Name.O)
 	}
 
-	sysSctx, err := e.GetSysSession()
-	if err != nil {
-		return err
-	}
-	defer e.ReleaseSysSession(ctx, sysSctx)
-	sqlExec := sysSctx.GetSQLExecutor()
-
-	lastSuccessReadTSO, err := fetchMViewLastSuccessReadTSO(ctx, sqlExec, mvMeta.ID)
-	if err != nil {
-		return err
+	type mlogShowTarget struct {
+		schema pmodel.CIStr
+		meta   *model.TableInfo
 	}
 
-	var pendingRows int64
-	for _, baseID := range mvInfo.BaseTableIDs {
-		baseTable, ok := e.is.TableByID(ctx, baseID)
-		if !ok || baseTable.Meta().MaterializedViewBase == nil || baseTable.Meta().MaterializedViewBase.MLogID == 0 {
+	seenMLogIDs := make(map[int64]struct{}, len(mvMeta.MaterializedView.BaseTableIDs))
+	mlogs := make([]mlogShowTarget, 0, len(mvMeta.MaterializedView.BaseTableIDs))
+	for _, baseTableID := range mvMeta.MaterializedView.BaseTableIDs {
+		baseTable, ok := e.is.TableByID(ctx, baseTableID)
+		if !ok {
+			return errors.Errorf("base table does not exist for materialized view %s.%s", db.Name.O, mvMeta.Name.O)
+		}
+		baseMeta := baseTable.Meta()
+		if baseMeta.MaterializedViewBase == nil || baseMeta.MaterializedViewBase.MLogID == 0 {
+			return errors.Errorf("materialized view log does not exist for base table %s", baseMeta.Name.O)
+		}
+		if _, ok = seenMLogIDs[baseMeta.MaterializedViewBase.MLogID]; ok {
 			continue
 		}
-		mlogTable, ok := e.is.TableByID(ctx, baseTable.Meta().MaterializedViewBase.MLogID)
+		seenMLogIDs[baseMeta.MaterializedViewBase.MLogID] = struct{}{}
+
+		mlogTable, ok := e.is.TableByID(ctx, baseMeta.MaterializedViewBase.MLogID)
 		if !ok {
-			continue
+			return errors.Errorf("materialized view log does not exist for base table %s", baseMeta.Name.O)
 		}
 		mlogMeta := mlogTable.Meta()
-		if mlogMeta.MaterializedViewLog == nil || mlogMeta.MaterializedViewLog.BaseTableID != baseID {
-			continue
-		}
-		baseDB, ok := infoschema.SchemaByTable(e.is, baseTable.Meta())
+		mlogSchema, ok := infoschema.SchemaByTable(e.is, mlogMeta)
 		if !ok {
-			continue
+			return errors.Errorf("schema does not exist for materialized view log %s", mlogMeta.Name.O)
 		}
-		cnt, err := countMaterializedViewLogRows(ctx, sqlExec, baseDB.Name.O, mlogMeta.Name.O, &lastSuccessReadTSO, nil)
-		if err != nil {
-			return err
-		}
-		pendingRows += cnt
+		mlogs = append(mlogs, mlogShowTarget{
+			schema: mlogSchema.Name,
+			meta:   mlogMeta,
+		})
 	}
 
-	e.appendRow([]any{mvMeta.ID, mvMeta.Name.O, pendingRows})
+	execCtx, sqlExec, _, cleanup, err := e.beginMViewLogShowInternalTxn(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer cleanup()
+
+	rows, err := sqlexec.ExecSQL(execCtx, sqlExec,
+		"SELECT LAST_SUCCESS_READ_TSO FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID = %?",
+		mvMeta.ID,
+	)
+	if err != nil {
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return errors.New("show materialized view remain logs: required system table mysql.tidb_mview_refresh_info does not exist")
+		}
+		return errors.Trace(err)
+	}
+	if len(rows) == 0 {
+		return errors.Errorf("show materialized view remain logs: refresh info row missing for materialized view %s.%s", db.Name.O, mvMeta.Name.O)
+	}
+	if rows[0].IsNull(0) {
+		return errors.Errorf("show materialized view remain logs: last success read tso is null for materialized view %s.%s", db.Name.O, mvMeta.Name.O)
+	}
+	lastSuccessReadTSO := rows[0].GetUint64(0)
+
+	for _, mlog := range mlogs {
+		countSQL := sqlescape.MustEscapeSQL(
+			"SELECT COUNT(*) FROM %n.%n WHERE _tidb_commit_ts > %?",
+			mlog.schema.O,
+			mlog.meta.Name.O,
+			lastSuccessReadTSO,
+		)
+		countRows, err := sqlexec.ExecSQL(execCtx, sqlExec, countSQL)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		remainLogs := int64(0)
+		if len(countRows) > 0 && !countRows[0].IsNull(0) {
+			remainLogs = countRows[0].GetInt64(0)
+		}
+		e.appendRow([]any{mvMeta.ID, mvMeta.Name.O, mlog.meta.ID, mlog.meta.Name.O, remainLogs})
+	}
 	return nil
 }
 
-func (e *ShowExec) fetchShowMaterializedViewLog(ctx context.Context) error {
-	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
-	if !e.is.SchemaExists(e.DBName) {
-		return exeerrors.ErrBadDB.GenWithStackByArgs(e.DBName)
+func (e *ShowExec) fetchShowMaterializedViewLogWaitPurge(ctx context.Context) error {
+	if _, ok := e.is.SchemaByName(e.DBName); !ok {
+		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(e.DBName.O)
 	}
 
 	baseTable, err := e.getTable()
@@ -835,159 +875,265 @@ func (e *ShowExec) fetchShowMaterializedViewLog(ctx context.Context) error {
 	if baseMeta.IsView() || baseMeta.IsSequence() || baseMeta.TempTableType != model.TempTableNone {
 		return exeerrors.ErrWrongObject.GenWithStackByArgs(e.DBName.O, baseMeta.Name.O, "BASE TABLE")
 	}
+	if baseMeta.MaterializedViewBase == nil || baseMeta.MaterializedViewBase.MLogID == 0 {
+		return errors.Errorf("materialized view log does not exist for base table %s.%s", e.DBName.O, baseMeta.Name.O)
+	}
 
-	mlogTable, err := e.getMaterializedViewLogForBase(baseMeta)
-	if err != nil {
-		return err
+	mlogTable, ok := e.is.TableByID(ctx, baseMeta.MaterializedViewBase.MLogID)
+	if !ok {
+		return errors.Errorf("materialized view log does not exist for base table %s.%s", e.DBName.O, baseMeta.Name.O)
 	}
 	mlogMeta := mlogTable.Meta()
-
-	sysSctx, err := e.GetSysSession()
-	if err != nil {
-		return err
-	}
-	defer e.ReleaseSysSession(ctx, sysSctx)
-	sqlExec := sysSctx.GetSQLExecutor()
-
-	txn, err := e.Ctx().Txn(true)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	publicMVIDs, buildingMVIDs, err := collectDependentMViewIDsForMLogPurge(ctx, sqlExec, baseMeta, mlogMeta.ID)
-	if err != nil {
-		return err
-	}
-	safePurgeTSO, err := calcMaterializedViewLogSafePurgeTSO(
-		ctx,
-		sqlExec,
-		e.DBName.O,
-		baseMeta.Name.O,
-		txn.StartTS(),
-		publicMVIDs,
-		buildingMVIDs,
-	)
-	if err != nil {
-		return err
-	}
-
-	lastPurgedTSO, hasLastPurgedTSO, err := fetchMLogLastPurgedTSO(ctx, sqlExec, mlogMeta.ID)
-	if err != nil {
-		return err
-	}
-	var lower *uint64
-	if hasLastPurgedTSO {
-		lower = &lastPurgedTSO
-	}
-	pendingRows, err := countMaterializedViewLogRows(ctx, sqlExec, e.DBName.O, mlogMeta.Name.O, lower, &safePurgeTSO)
-	if err != nil {
-		return err
-	}
-
-	e.appendRow([]any{mlogMeta.ID, mlogMeta.Name.O, baseMeta.ID, baseMeta.Name.O, pendingRows})
-	return nil
-}
-
-func (e *ShowExec) getMaterializedViewLogForBase(baseMeta *model.TableInfo) (table.Table, error) {
-	if baseMeta.MaterializedViewBase == nil || baseMeta.MaterializedViewBase.MLogID == 0 {
-		return nil, errors.Errorf("materialized view log does not exist for base table %s.%s", e.DBName.O, baseMeta.Name.O)
-	}
-	mlogTable, ok := e.is.TableByID(context.Background(), baseMeta.MaterializedViewBase.MLogID)
-	if !ok {
-		return nil, errors.Errorf("materialized view log does not exist for base table %s.%s", e.DBName.O, baseMeta.Name.O)
-	}
-	mlogInfo := mlogTable.Meta().MaterializedViewLog
-	if mlogInfo == nil || mlogInfo.BaseTableID != baseMeta.ID {
-		return nil, errors.Errorf(
+	if mlogMeta.MaterializedViewLog == nil || mlogMeta.MaterializedViewLog.BaseTableID != baseMeta.ID {
+		return errors.Errorf(
 			"table %s.%s is not a materialized view log for base table %s.%s",
 			e.DBName.O,
-			mlogTable.Meta().Name.O,
+			mlogMeta.Name.O,
 			e.DBName.O,
 			baseMeta.Name.O,
 		)
 	}
-	return mlogTable, nil
-}
+	mlogSchema, ok := infoschema.SchemaByTable(e.is, mlogMeta)
+	if !ok {
+		return errors.Errorf("schema does not exist for materialized view log %s", mlogMeta.Name.O)
+	}
 
-func fetchMViewLastSuccessReadTSO(ctx context.Context, sqlExec sqlexec.SQLExecutor, mviewID int64) (uint64, error) {
-	sql := sqlescape.MustEscapeSQL(
-		"SELECT LAST_SUCCESS_READ_TSO FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID = %?",
-		mviewID,
-	)
-	rows, err := sqlexec.ExecSQL(ctx, sqlExec, sql)
+	execCtx, sqlExec, showStartTS, cleanup, err := e.beginMViewLogShowInternalTxn(ctx)
 	if err != nil {
-		if infoschema.ErrTableNotExists.Equal(err) {
-			return 0, errors.New("show materialized view: required system table mysql.tidb_mview_refresh_info does not exist")
-		}
-		return 0, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	if len(rows) == 0 || rows[0].IsNull(0) {
-		return 0, errors.New("show materialized view: refresh info row missing in mysql.tidb_mview_refresh_info")
-	}
-	return rows[0].GetUint64(0), nil
-}
+	defer cleanup()
 
-func fetchMLogLastPurgedTSO(ctx context.Context, sqlExec sqlexec.SQLExecutor, mlogID int64) (uint64, bool, error) {
-	sql := sqlescape.MustEscapeSQL(
+	rows, err := sqlexec.ExecSQL(execCtx, sqlExec,
 		"SELECT LAST_PURGED_TSO FROM mysql.tidb_mlog_purge_info WHERE MLOG_ID = %?",
-		mlogID,
+		mlogMeta.ID,
 	)
-	rows, err := sqlexec.ExecSQL(ctx, sqlExec, sql)
 	if err != nil {
 		if infoschema.ErrTableNotExists.Equal(err) {
-			return 0, false, errors.New("show materialized view log: required system table mysql.tidb_mlog_purge_info does not exist")
+			return errors.New("show materialized view log wait purge: required system table mysql.tidb_mlog_purge_info does not exist")
 		}
-		return 0, false, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	if len(rows) == 0 || rows[0].IsNull(0) {
-		return 0, false, nil
+	if len(rows) == 0 {
+		return errors.Errorf("show materialized view log wait purge: purge info row missing for materialized view log on %s.%s", e.DBName.O, baseMeta.Name.O)
 	}
-	return rows[0].GetUint64(0), true, nil
+	var lastPurgedTSO uint64
+	hasLastPurgedTSO := !rows[0].IsNull(0)
+	if hasLastPurgedTSO {
+		lastPurgedTSO = rows[0].GetUint64(0)
+	}
+
+	publicMVIDs, buildingMVIDs, err := e.collectDependentMViewIDsForMLogShow(execCtx, sqlExec, baseMeta, mlogMeta.ID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	safePurgeTSO, err := e.calcMLogSafePurgeTSOForShow(
+		execCtx,
+		sqlExec,
+		e.DBName.O,
+		baseMeta.Name.O,
+		showStartTS,
+		publicMVIDs,
+		buildingMVIDs,
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	waitPurge := int64(0)
+	if safePurgeTSO > 0 && (!hasLastPurgedTSO || lastPurgedTSO < safePurgeTSO) {
+		var countSQL string
+		if hasLastPurgedTSO {
+			countSQL = sqlescape.MustEscapeSQL(
+				"SELECT COUNT(*) FROM %n.%n WHERE _tidb_commit_ts > %? AND _tidb_commit_ts <= %?",
+				mlogSchema.Name.O,
+				mlogMeta.Name.O,
+				lastPurgedTSO,
+				safePurgeTSO,
+			)
+		} else {
+			countSQL = sqlescape.MustEscapeSQL(
+				"SELECT COUNT(*) FROM %n.%n WHERE _tidb_commit_ts <= %?",
+				mlogSchema.Name.O,
+				mlogMeta.Name.O,
+				safePurgeTSO,
+			)
+		}
+		countRows, err := sqlexec.ExecSQL(execCtx, sqlExec, countSQL)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if len(countRows) > 0 && !countRows[0].IsNull(0) {
+			waitPurge = countRows[0].GetInt64(0)
+		}
+	}
+
+	e.appendRow([]any{mlogMeta.ID, mlogMeta.Name.O, baseMeta.ID, baseMeta.Name.O, waitPurge})
+	return nil
 }
 
-func countMaterializedViewLogRows(
+func (e *ShowExec) beginMViewLogShowInternalTxn(ctx context.Context) (
+	context.Context,
+	sqlexec.SQLExecutor,
+	uint64,
+	func(),
+	error,
+) {
+	execCtx := kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
+	releaseCtx := context.WithoutCancel(execCtx)
+
+	internalSctx, err := e.GetSysSession()
+	if err != nil {
+		return nil, nil, 0, nil, errors.Trace(err)
+	}
+	sqlExec := internalSctx.GetSQLExecutor()
+	if _, err = sqlExec.ExecuteInternal(execCtx, "BEGIN"); err != nil {
+		e.ReleaseSysSession(releaseCtx, internalSctx)
+		return nil, nil, 0, nil, errors.Trace(err)
+	}
+	cleanup := func() {
+		_, _ = sqlExec.ExecuteInternal(releaseCtx, "ROLLBACK")
+		e.ReleaseSysSession(releaseCtx, internalSctx)
+	}
+	txn, err := internalSctx.Txn(true)
+	if err != nil {
+		cleanup()
+		return nil, nil, 0, nil, errors.Trace(err)
+	}
+	return execCtx, sqlExec, txn.StartTS(), cleanup, nil
+}
+
+func (e *ShowExec) collectDependentMViewIDsForMLogShow(
 	ctx context.Context,
 	sqlExec sqlexec.SQLExecutor,
-	schemaName string,
-	mlogName string,
-	lowerTSO *uint64,
-	upperTSO *uint64,
-) (int64, error) {
-	var countSQL string
-	switch {
-	case lowerTSO != nil && upperTSO != nil:
-		countSQL = sqlescape.MustEscapeSQL(
-			"SELECT COUNT(*) FROM %n.%n WHERE _tidb_commit_ts > %? AND _tidb_commit_ts <= %?",
-			schemaName,
-			mlogName,
-			*lowerTSO,
-			*upperTSO,
-		)
-	case lowerTSO != nil:
-		countSQL = sqlescape.MustEscapeSQL(
-			"SELECT COUNT(*) FROM %n.%n WHERE _tidb_commit_ts > %?",
-			schemaName,
-			mlogName,
-			*lowerTSO,
-		)
-	case upperTSO != nil:
-		countSQL = sqlescape.MustEscapeSQL(
-			"SELECT COUNT(*) FROM %n.%n WHERE _tidb_commit_ts <= %?",
-			schemaName,
-			mlogName,
-			*upperTSO,
-		)
-	default:
-		countSQL = sqlescape.MustEscapeSQL("SELECT COUNT(*) FROM %n.%n", schemaName, mlogName)
+	baseTableMeta *model.TableInfo,
+	mlogID int64,
+) (publicMVIDs, buildingMVIDs map[int64]struct{}, _ error) {
+	publicMVIDs = make(map[int64]struct{})
+	if baseMeta := baseTableMeta.MaterializedViewBase; baseMeta != nil {
+		for _, id := range baseMeta.MViewIDs {
+			if id > 0 {
+				publicMVIDs[id] = struct{}{}
+			}
+		}
 	}
 
-	rows, err := sqlexec.ExecSQL(ctx, sqlExec, countSQL)
+	buildingMVIDs = make(map[int64]struct{})
+	jobSQL := sqlescape.MustEscapeSQL(
+		"SELECT job_meta FROM mysql.tidb_ddl_job WHERE type = %? AND FIND_IN_SET(%?, table_ids)",
+		model.ActionCreateMaterializedView,
+		mlogID,
+	)
+	jobRows, err := sqlexec.ExecSQL(ctx, sqlExec, jobSQL)
 	if err != nil {
-		return 0, errors.Trace(err)
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return publicMVIDs, buildingMVIDs, errors.New("required system table mysql.tidb_ddl_job does not exist")
+		}
+		return publicMVIDs, buildingMVIDs, errors.Trace(err)
 	}
-	if len(rows) == 0 || rows[0].IsNull(0) {
-		return 0, nil
+	for _, row := range jobRows {
+		jobBytes := row.GetBytes(0)
+		if len(jobBytes) == 0 {
+			continue
+		}
+		job := model.Job{}
+		if err := job.Decode(jobBytes); err != nil {
+			return publicMVIDs, buildingMVIDs, errors.Trace(err)
+		}
+		if job.TableID > 0 {
+			if _, ok := publicMVIDs[job.TableID]; !ok {
+				buildingMVIDs[job.TableID] = struct{}{}
+			}
+		}
 	}
-	return rows[0].GetInt64(0), nil
+	return publicMVIDs, buildingMVIDs, nil
+}
+
+func (e *ShowExec) calcMLogSafePurgeTSOForShow(
+	ctx context.Context,
+	sqlExec sqlexec.SQLExecutor,
+	baseSchema string,
+	baseTable string,
+	purgeStartTS uint64,
+	publicMVIDs map[int64]struct{},
+	buildingMVIDs map[int64]struct{},
+) (uint64, error) {
+	safePurgeTSO := purgeStartTS
+	buildINList := func(ids []int64) string {
+		var sb strings.Builder
+		for i, id := range ids {
+			if i > 0 {
+				sb.WriteString(",")
+			}
+			sb.WriteString(strconv.FormatInt(id, 10))
+		}
+		return sb.String()
+	}
+
+	publicIDs := make([]int64, 0, len(publicMVIDs))
+	for mvID := range publicMVIDs {
+		publicIDs = append(publicIDs, mvID)
+	}
+	if len(publicIDs) > 0 {
+		countSQL := fmt.Sprintf(
+			"SELECT COUNT(1) FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID IN (%s)",
+			buildINList(publicIDs),
+		)
+		countRows, err := sqlexec.ExecSQL(ctx, sqlExec, countSQL)
+		if err != nil {
+			if infoschema.ErrTableNotExists.Equal(err) {
+				return safePurgeTSO, errors.New("required system table mysql.tidb_mview_refresh_info does not exist")
+			}
+			return safePurgeTSO, errors.Trace(err)
+		}
+
+		var cnt int64
+		if len(countRows) > 0 {
+			cnt = countRows[0].GetInt64(0)
+		}
+		if cnt != int64(len(publicIDs)) {
+			return safePurgeTSO, errors.Errorf(
+				"materialized view refresh info is missing for some dependent materialized views on base table %s.%s (expected %d, got %d)",
+				baseSchema,
+				baseTable,
+				len(publicIDs),
+				cnt,
+			)
+		}
+	}
+
+	allMVIDs := make(map[int64]struct{}, len(publicMVIDs)+len(buildingMVIDs))
+	for mvID := range publicMVIDs {
+		allMVIDs[mvID] = struct{}{}
+	}
+	for mvID := range buildingMVIDs {
+		allMVIDs[mvID] = struct{}{}
+	}
+	allIDs := make([]int64, 0, len(allMVIDs))
+	for mvID := range allMVIDs {
+		allIDs = append(allIDs, mvID)
+	}
+	if len(allIDs) > 0 {
+		minSQL := fmt.Sprintf(
+			"SELECT MIN(COALESCE(LAST_SUCCESS_READ_TSO, CAST(0 AS UNSIGNED))) FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID IN (%s)",
+			buildINList(allIDs),
+		)
+		minRows, err := sqlexec.ExecSQL(ctx, sqlExec, minSQL)
+		if err != nil {
+			if infoschema.ErrTableNotExists.Equal(err) {
+				return safePurgeTSO, errors.New("required system table mysql.tidb_mview_refresh_info does not exist")
+			}
+			return safePurgeTSO, errors.Trace(err)
+		}
+
+		if len(minRows) > 0 && !minRows[0].IsNull(0) {
+			safePurgeTSO = minRows[0].GetUint64(0)
+			if safePurgeTSO > purgeStartTS {
+				safePurgeTSO = purgeStartTS
+			}
+		}
+	}
+	return safePurgeTSO, nil
 }
 
 func hasAnyMaterializedViewVisiblePriv(

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -923,11 +923,11 @@ func (e *ShowExec) fetchShowMaterializedViewLogWaitPurge(ctx context.Context) er
 		lastPurgedTSO = rows[0].GetUint64(0)
 	}
 
-	publicMVIDs, buildingMVIDs, err := e.collectDependentMViewIDsForMLogShow(execCtx, sqlExec, baseMeta, mlogMeta.ID)
+	publicMVIDs, buildingMVIDs, err := collectDependentMViewIDsForMLogPurge(execCtx, sqlExec, baseMeta, mlogMeta.ID)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	safePurgeTSO, err := e.calcMLogSafePurgeTSOForShow(
+	safePurgeTSO, err := calcMaterializedViewLogSafePurgeTSO(
 		execCtx,
 		sqlExec,
 		e.DBName.O,
@@ -1001,139 +1001,6 @@ func (e *ShowExec) beginMViewLogShowInternalTxn(ctx context.Context) (
 		return nil, nil, 0, nil, errors.Trace(err)
 	}
 	return execCtx, sqlExec, txn.StartTS(), cleanup, nil
-}
-
-func (e *ShowExec) collectDependentMViewIDsForMLogShow(
-	ctx context.Context,
-	sqlExec sqlexec.SQLExecutor,
-	baseTableMeta *model.TableInfo,
-	mlogID int64,
-) (publicMVIDs, buildingMVIDs map[int64]struct{}, _ error) {
-	publicMVIDs = make(map[int64]struct{})
-	if baseMeta := baseTableMeta.MaterializedViewBase; baseMeta != nil {
-		for _, id := range baseMeta.MViewIDs {
-			if id > 0 {
-				publicMVIDs[id] = struct{}{}
-			}
-		}
-	}
-
-	buildingMVIDs = make(map[int64]struct{})
-	jobSQL := sqlescape.MustEscapeSQL(
-		"SELECT job_meta FROM mysql.tidb_ddl_job WHERE type = %? AND FIND_IN_SET(%?, table_ids)",
-		model.ActionCreateMaterializedView,
-		mlogID,
-	)
-	jobRows, err := sqlexec.ExecSQL(ctx, sqlExec, jobSQL)
-	if err != nil {
-		if infoschema.ErrTableNotExists.Equal(err) {
-			return publicMVIDs, buildingMVIDs, errors.New("required system table mysql.tidb_ddl_job does not exist")
-		}
-		return publicMVIDs, buildingMVIDs, errors.Trace(err)
-	}
-	for _, row := range jobRows {
-		jobBytes := row.GetBytes(0)
-		if len(jobBytes) == 0 {
-			continue
-		}
-		job := model.Job{}
-		if err := job.Decode(jobBytes); err != nil {
-			return publicMVIDs, buildingMVIDs, errors.Trace(err)
-		}
-		if job.TableID > 0 {
-			if _, ok := publicMVIDs[job.TableID]; !ok {
-				buildingMVIDs[job.TableID] = struct{}{}
-			}
-		}
-	}
-	return publicMVIDs, buildingMVIDs, nil
-}
-
-func (e *ShowExec) calcMLogSafePurgeTSOForShow(
-	ctx context.Context,
-	sqlExec sqlexec.SQLExecutor,
-	baseSchema string,
-	baseTable string,
-	purgeStartTS uint64,
-	publicMVIDs map[int64]struct{},
-	buildingMVIDs map[int64]struct{},
-) (uint64, error) {
-	safePurgeTSO := purgeStartTS
-	buildINList := func(ids []int64) string {
-		var sb strings.Builder
-		for i, id := range ids {
-			if i > 0 {
-				sb.WriteString(",")
-			}
-			sb.WriteString(strconv.FormatInt(id, 10))
-		}
-		return sb.String()
-	}
-
-	publicIDs := make([]int64, 0, len(publicMVIDs))
-	for mvID := range publicMVIDs {
-		publicIDs = append(publicIDs, mvID)
-	}
-	if len(publicIDs) > 0 {
-		countSQL := fmt.Sprintf(
-			"SELECT COUNT(1) FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID IN (%s)",
-			buildINList(publicIDs),
-		)
-		countRows, err := sqlexec.ExecSQL(ctx, sqlExec, countSQL)
-		if err != nil {
-			if infoschema.ErrTableNotExists.Equal(err) {
-				return safePurgeTSO, errors.New("required system table mysql.tidb_mview_refresh_info does not exist")
-			}
-			return safePurgeTSO, errors.Trace(err)
-		}
-
-		var cnt int64
-		if len(countRows) > 0 {
-			cnt = countRows[0].GetInt64(0)
-		}
-		if cnt != int64(len(publicIDs)) {
-			return safePurgeTSO, errors.Errorf(
-				"materialized view refresh info is missing for some dependent materialized views on base table %s.%s (expected %d, got %d)",
-				baseSchema,
-				baseTable,
-				len(publicIDs),
-				cnt,
-			)
-		}
-	}
-
-	allMVIDs := make(map[int64]struct{}, len(publicMVIDs)+len(buildingMVIDs))
-	for mvID := range publicMVIDs {
-		allMVIDs[mvID] = struct{}{}
-	}
-	for mvID := range buildingMVIDs {
-		allMVIDs[mvID] = struct{}{}
-	}
-	allIDs := make([]int64, 0, len(allMVIDs))
-	for mvID := range allMVIDs {
-		allIDs = append(allIDs, mvID)
-	}
-	if len(allIDs) > 0 {
-		minSQL := fmt.Sprintf(
-			"SELECT MIN(COALESCE(LAST_SUCCESS_READ_TSO, CAST(0 AS UNSIGNED))) FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID IN (%s)",
-			buildINList(allIDs),
-		)
-		minRows, err := sqlexec.ExecSQL(ctx, sqlExec, minSQL)
-		if err != nil {
-			if infoschema.ErrTableNotExists.Equal(err) {
-				return safePurgeTSO, errors.New("required system table mysql.tidb_mview_refresh_info does not exist")
-			}
-			return safePurgeTSO, errors.Trace(err)
-		}
-
-		if len(minRows) > 0 && !minRows[0].IsNull(0) {
-			safePurgeTSO = minRows[0].GetUint64(0)
-			if safePurgeTSO > purgeStartTS {
-				safePurgeTSO = purgeStartTS
-			}
-		}
-	}
-	return safePurgeTSO, nil
 }
 
 func hasAnyMaterializedViewVisiblePriv(

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -617,14 +617,14 @@ func TestShowMaterializedViewStatusPrivilege(t *testing.T) {
 	err = tkUser.ExecToErr("show materialized view test.mv_show_status remain_logs")
 	require.ErrorContains(t, err, "SHOW VIEW command denied")
 	err = tkUser.ExecToErr("show materialized view log on test.t_show_mv_status wait_purge")
-	require.ErrorContains(t, err, "SELECT command denied")
+	require.ErrorContains(t, err, "SHOW VIEW command denied")
 
 	tk.MustExec("grant show view on test.mv_show_status to 'show_mv_status_u'@'%'")
 	tkUser.MustQuery("show materialized view test.mv_show_status remain_logs").Check(testkit.Rows(mvExpected(0)))
 	err = tkUser.ExecToErr("show materialized view log on test.t_show_mv_status wait_purge")
-	require.ErrorContains(t, err, "SELECT command denied")
+	require.ErrorContains(t, err, "SHOW VIEW command denied")
 
-	tk.MustExec("grant select on test.t_show_mv_status to 'show_mv_status_u'@'%'")
+	tk.MustExec("grant show view on test.t_show_mv_status to 'show_mv_status_u'@'%'")
 	tkUser.MustQuery("show materialized view log on test.t_show_mv_status wait_purge").Check(testkit.Rows(mlogExpected(2)))
 }
 

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -628,6 +628,41 @@ func TestShowMaterializedViewStatusPrivilege(t *testing.T) {
 	tkUser.MustQuery("show materialized view log on test.t_show_mv_status wait_purge").Check(testkit.Rows(mlogExpected(2)))
 }
 
+func TestShowMaterializedViewRemainLogs(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_remain_logs (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on t_remain_logs (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_remain_logs (a, s, cnt) refresh fast as select a, sum(b), count(1) from t_remain_logs group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv_remain_logs"))
+	require.NoError(t, err)
+	baseTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t_remain_logs"))
+	require.NoError(t, err)
+	require.NotNil(t, baseTable.Meta().MaterializedViewBase)
+	mlogID := baseTable.Meta().MaterializedViewBase.MLogID
+	mlogTable, ok := is.TableByID(context.Background(), mlogID)
+	require.True(t, ok)
+
+	expectedRow := func(remainLogs int64) string {
+		return fmt.Sprintf("%d mv_remain_logs %d %s %d", mvTable.Meta().ID, mlogID, mlogTable.Meta().Name.O, remainLogs)
+	}
+	tk.MustQuery("show materialized view mv_remain_logs remain_logs").Check(testkit.Rows(expectedRow(0)))
+
+	tk.MustExec("insert into t_remain_logs values (1, 10), (1, 20), (2, 30)")
+	tk.MustQuery("show materialized view mv_remain_logs remain_logs").Check(testkit.Rows(expectedRow(3)))
+
+	tk.MustExec("refresh materialized view mv_remain_logs fast")
+	tk.MustQuery("show materialized view mv_remain_logs remain_logs").Check(testkit.Rows(expectedRow(0)))
+
+	err = tk.QueryToErr("show materialized view t_remain_logs remain_logs")
+	require.ErrorContains(t, err, "is not MATERIALIZED VIEW")
+	err = tk.ExecToErr("show materialized view mv_remain_logs unknown_option")
+	require.ErrorContains(t, err, "unknown SHOW MATERIALIZED VIEW option unknown_option")
+}
+
 func TestCreateMaterializedViewLogColumnKeyFlag(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -586,7 +586,7 @@ func TestShowMaterializedViewStatusPrivilege(t *testing.T) {
 	require.True(t, ok)
 
 	mvExpected := func(pending int64) string {
-		return fmt.Sprintf("%d mv_show_status %d", mvID, pending)
+		return fmt.Sprintf("%d mv_show_status %d %s %d", mvID, mlogTable.Meta().ID, mlogTable.Meta().Name.O, pending)
 	}
 	mlogExpected := func(pending int64) string {
 		return fmt.Sprintf(
@@ -660,7 +660,7 @@ func TestShowMaterializedViewRemainLogs(t *testing.T) {
 	err = tk.QueryToErr("show materialized view t_remain_logs remain_logs")
 	require.ErrorContains(t, err, "is not MATERIALIZED VIEW")
 	err = tk.ExecToErr("show materialized view mv_remain_logs unknown_option")
-	require.ErrorContains(t, err, "unknown SHOW MATERIALIZED VIEW option unknown_option")
+	require.ErrorContains(t, err, "syntax error: expected REMAIN_LOGS")
 }
 
 func TestShowMaterializedViewLogWaitPurge(t *testing.T) {
@@ -697,7 +697,7 @@ func TestShowMaterializedViewLogWaitPurge(t *testing.T) {
 	err = tk.QueryToErr("show materialized view log on t_wait_purge_no_log wait_purge")
 	require.ErrorContains(t, err, "materialized view log does not exist for base table test.t_wait_purge_no_log")
 	err = tk.ExecToErr("show materialized view log on t_wait_purge unknown_option")
-	require.ErrorContains(t, err, "unknown SHOW MATERIALIZED VIEW LOG option unknown_option")
+	require.ErrorContains(t, err, "syntax error: expected WAIT_PURGE")
 }
 
 func TestCreateMaterializedViewLogColumnKeyFlag(t *testing.T) {

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -663,6 +663,43 @@ func TestShowMaterializedViewRemainLogs(t *testing.T) {
 	require.ErrorContains(t, err, "unknown SHOW MATERIALIZED VIEW option unknown_option")
 }
 
+func TestShowMaterializedViewLogWaitPurge(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_wait_purge (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on t_wait_purge (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_wait_purge (a, s, cnt) refresh fast as select a, sum(b), count(1) from t_wait_purge group by a")
+
+	is := dom.InfoSchema()
+	baseTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t_wait_purge"))
+	require.NoError(t, err)
+	require.NotNil(t, baseTable.Meta().MaterializedViewBase)
+	mlogID := baseTable.Meta().MaterializedViewBase.MLogID
+	mlogTable, ok := is.TableByID(context.Background(), mlogID)
+	require.True(t, ok)
+
+	expectedRow := func(waitPurge int64) string {
+		return fmt.Sprintf("%d %s %d t_wait_purge %d", mlogID, mlogTable.Meta().Name.O, baseTable.Meta().ID, waitPurge)
+	}
+	tk.MustQuery("show materialized view log on t_wait_purge wait_purge").Check(testkit.Rows(expectedRow(0)))
+
+	tk.MustExec("insert into t_wait_purge values (1, 10), (1, 20), (2, 30)")
+	tk.MustQuery("show materialized view log on t_wait_purge wait_purge").Check(testkit.Rows(expectedRow(0)))
+
+	tk.MustExec("refresh materialized view mv_wait_purge fast")
+	tk.MustQuery("show materialized view log on t_wait_purge wait_purge").Check(testkit.Rows(expectedRow(3)))
+
+	tk.MustExec("purge materialized view log on t_wait_purge")
+	tk.MustQuery("show materialized view log on t_wait_purge wait_purge").Check(testkit.Rows(expectedRow(0)))
+
+	tk.MustExec("create table t_wait_purge_no_log (a int)")
+	err = tk.QueryToErr("show materialized view log on t_wait_purge_no_log wait_purge")
+	require.ErrorContains(t, err, "materialized view log does not exist for base table test.t_wait_purge_no_log")
+	err = tk.ExecToErr("show materialized view log on t_wait_purge unknown_option")
+	require.ErrorContains(t, err, "unknown SHOW MATERIALIZED VIEW LOG option unknown_option")
+}
+
 func TestCreateMaterializedViewLogColumnKeyFlag(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -693,6 +693,9 @@ func TestShowMaterializedViewLogWaitPurge(t *testing.T) {
 	tk.MustExec("purge materialized view log on t_wait_purge")
 	tk.MustQuery("show materialized view log on t_wait_purge wait_purge").Check(testkit.Rows(expectedRow(0)))
 
+	tk.MustExec("create temporary table t_wait_purge (a int)")
+	tk.MustQuery("show materialized view log on t_wait_purge wait_purge").Check(testkit.Rows(expectedRow(0)))
+
 	tk.MustExec("create table t_wait_purge_no_log (a int)")
 	err = tk.QueryToErr("show materialized view log on t_wait_purge_no_log wait_purge")
 	require.ErrorContains(t, err, "materialized view log does not exist for base table test.t_wait_purge_no_log")

--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -3000,8 +3000,8 @@ const (
 	ShowTables
 	ShowMaterializedViews
 	ShowMaterializedViewLogs
-	ShowMaterializedView
-	ShowMaterializedViewLog
+	ShowMaterializedViewRemainLogs
+	ShowMaterializedViewLogWaitPurge
 	ShowTableStatus
 	ShowColumns
 	ShowWarnings
@@ -3182,13 +3182,13 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 		if err := n.Table.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore ShowStmt.MATERIALIZED VIEW LOG")
 		}
-	case ShowMaterializedView:
+	case ShowMaterializedViewRemainLogs:
 		ctx.WriteKeyWord("MATERIALIZED VIEW ")
 		if err := n.Table.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore ShowStmt.MATERIALIZED VIEW")
 		}
 		ctx.WriteKeyWord(" REMAIN_LOGS")
-	case ShowMaterializedViewLog:
+	case ShowMaterializedViewLogWaitPurge:
 		ctx.WriteKeyWord("MATERIALIZED VIEW LOG ON ")
 		if err := n.Table.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore ShowStmt.MATERIALIZED VIEW LOG")

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -12167,14 +12167,14 @@ ShowStmt:
 |	"SHOW" "MATERIALIZED" "VIEW" ShowMaterializedViewName ShowMaterializedViewRemainLogs
 	{
 		$$ = &ast.ShowStmt{
-			Tp:    ast.ShowMaterializedView,
+			Tp:    ast.ShowMaterializedViewRemainLogs,
 			Table: $4.(*ast.TableName),
 		}
 	}
 |	"SHOW" "MATERIALIZED" "VIEW" "LOG" "ON" TableName ShowMaterializedViewLogWaitPurge
 	{
 		$$ = &ast.ShowStmt{
-			Tp:    ast.ShowMaterializedViewLog,
+			Tp:    ast.ShowMaterializedViewLogWaitPurge,
 			Table: $6.(*ast.TableName),
 		}
 	}

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -1389,9 +1389,6 @@ import (
 	TableLock                              "Table name and lock type"
 	TableLockList                          "Table lock list"
 	TableName                              "Table name"
-	ShowMaterializedViewName               "SHOW MATERIALIZED VIEW table name"
-	ShowMaterializedViewRemainLogs         "SHOW MATERIALIZED VIEW REMAIN_LOGS suffix"
-	ShowMaterializedViewLogWaitPurge       "SHOW MATERIALIZED VIEW LOG ON ... WAIT_PURGE suffix"
 	TableNameOptWild                       "Table name with optional wildcard"
 	TableNameList                          "Table name list"
 	TableNameListOpt                       "Table name list opt"
@@ -9656,41 +9653,6 @@ TableName:
 		$$ = &ast.TableName{Schema: model.NewCIStr("*"), Name: model.NewCIStr($3)}
 	}
 
-ShowMaterializedViewName:
-	Identifier
-	{
-		$$ = &ast.TableName{Name: model.NewCIStr($1)}
-	}
-|	Identifier '.' Identifier
-	{
-		schema := $1
-		if isInCorrectIdentifierName(schema) {
-			yylex.AppendError(ErrWrongDBName.GenWithStackByArgs(schema))
-			return 1
-		}
-		$$ = &ast.TableName{Schema: model.NewCIStr(schema), Name: model.NewCIStr($3)}
-	}
-
-ShowMaterializedViewRemainLogs:
-	identifier
-	{
-		if !strings.EqualFold($1, "remain_logs") {
-			yylex.AppendError(yylex.Errorf("syntax error: expected REMAIN_LOGS"))
-			return 1
-		}
-		$$ = nil
-	}
-
-ShowMaterializedViewLogWaitPurge:
-	identifier
-	{
-		if !strings.EqualFold($1, "wait_purge") {
-			yylex.AppendError(yylex.Errorf("syntax error: expected WAIT_PURGE"))
-			return 1
-		}
-		$$ = nil
-	}
-
 TableNameList:
 	TableName
 	{
@@ -12164,15 +12126,23 @@ ShowStmt:
 		}
 		$$ = stmt
 	}
-|	"SHOW" "MATERIALIZED" "VIEW" ShowMaterializedViewName ShowMaterializedViewRemainLogs
+|	"SHOW" "MATERIALIZED" "VIEW" TableName identifier
 	{
+		if !strings.EqualFold($5, "remain_logs") {
+			yylex.AppendError(yylex.Errorf("syntax error: expected REMAIN_LOGS"))
+			return 1
+		}
 		$$ = &ast.ShowStmt{
 			Tp:    ast.ShowMaterializedViewRemainLogs,
 			Table: $4.(*ast.TableName),
 		}
 	}
-|	"SHOW" "MATERIALIZED" "VIEW" "LOG" "ON" TableName ShowMaterializedViewLogWaitPurge
+|	"SHOW" "MATERIALIZED" "VIEW" "LOG" "ON" TableName identifier
 	{
+		if !strings.EqualFold($7, "wait_purge") {
+			yylex.AppendError(yylex.Errorf("syntax error: expected WAIT_PURGE"))
+			return 1
+		}
 		$$ = &ast.ShowStmt{
 			Tp:    ast.ShowMaterializedViewLogWaitPurge,
 			Table: $6.(*ast.TableName),

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3586,23 +3586,18 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (base.P
 			p.Extractor = extractor
 			buildPattern = false
 		}
-	case ast.ShowCreateTable, ast.ShowCreateSequence, ast.ShowCreateMaterializedViewLog, ast.ShowMaterializedView, ast.ShowMaterializedViewLog, ast.ShowPlacementForTable, ast.ShowPlacementForPartition:
+	case ast.ShowCreateTable, ast.ShowCreateSequence, ast.ShowCreateMaterializedViewLog, ast.ShowMaterializedViewLogWaitPurge, ast.ShowPlacementForTable, ast.ShowPlacementForPartition:
 		var err error
 		if table, err := b.is.TableByName(ctx, show.Table.Schema, show.Table.Name); err == nil {
 			isView = table.Meta().IsView()
 			isSequence = table.Meta().IsSequence()
 		}
 		user := b.ctx.GetSessionVars().User
-		if show.Tp == ast.ShowCreateMaterializedViewLog || show.Tp == ast.ShowMaterializedViewLog {
+		if show.Tp == ast.ShowCreateMaterializedViewLog || show.Tp == ast.ShowMaterializedViewLogWaitPurge {
 			if user != nil {
 				err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SELECT", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
 			}
 			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
-		} else if show.Tp == ast.ShowMaterializedView {
-			if user != nil {
-				err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW VIEW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
-			}
-			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
 		} else if isView {
 			if user != nil {
 				err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW VIEW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
@@ -3636,6 +3631,12 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (base.P
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
 		if user != nil {
+			err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW VIEW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
+		}
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
+	case ast.ShowMaterializedViewRemainLogs:
+		var err error
+		if user := b.ctx.GetSessionVars().User; user != nil {
 			err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW VIEW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
@@ -6585,11 +6586,11 @@ func buildShowSchema(s *ast.ShowStmt, isView bool, isSequence bool) (schema *exp
 	case ast.ShowMaterializedViewLogs:
 		names = []string{"mlog_id", "mlog_name", "base_table_id", "base_table_name"}
 		ftypes = []byte{mysql.TypeLonglong, mysql.TypeVarchar, mysql.TypeLonglong, mysql.TypeVarchar}
-	case ast.ShowMaterializedView:
-		names = []string{"mview_id", "mview_name", "pending_rows"}
-		ftypes = []byte{mysql.TypeLonglong, mysql.TypeVarchar, mysql.TypeLonglong}
-	case ast.ShowMaterializedViewLog:
-		names = []string{"mlog_id", "mlog_name", "base_table_id", "base_table_name", "pending_rows"}
+	case ast.ShowMaterializedViewRemainLogs:
+		names = []string{"mview_id", "mview_name", "mlog_id", "mlog_name", "remain_logs"}
+		ftypes = []byte{mysql.TypeLonglong, mysql.TypeVarchar, mysql.TypeLonglong, mysql.TypeVarchar, mysql.TypeLonglong}
+	case ast.ShowMaterializedViewLogWaitPurge:
+		names = []string{"mlog_id", "mlog_name", "base_table_id", "base_table_name", "wait_purge"}
 		ftypes = []byte{mysql.TypeLonglong, mysql.TypeVarchar, mysql.TypeLonglong, mysql.TypeVarchar, mysql.TypeLonglong}
 	case ast.ShowTableStatus:
 		names = []string{"Name", "Engine", "Version", "Row_format", "Rows", "Avg_row_length",

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3586,14 +3586,14 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (base.P
 			p.Extractor = extractor
 			buildPattern = false
 		}
-	case ast.ShowCreateTable, ast.ShowCreateSequence, ast.ShowCreateMaterializedViewLog, ast.ShowMaterializedViewLogWaitPurge, ast.ShowPlacementForTable, ast.ShowPlacementForPartition:
+	case ast.ShowCreateTable, ast.ShowCreateSequence, ast.ShowCreateMaterializedViewLog, ast.ShowPlacementForTable, ast.ShowPlacementForPartition:
 		var err error
 		if table, err := b.is.TableByName(ctx, show.Table.Schema, show.Table.Name); err == nil {
 			isView = table.Meta().IsView()
 			isSequence = table.Meta().IsSequence()
 		}
 		user := b.ctx.GetSessionVars().User
-		if show.Tp == ast.ShowCreateMaterializedViewLog || show.Tp == ast.ShowMaterializedViewLogWaitPurge {
+		if show.Tp == ast.ShowCreateMaterializedViewLog {
 			if user != nil {
 				err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SELECT", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
 			}
@@ -3634,7 +3634,7 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (base.P
 			err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW VIEW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
-	case ast.ShowMaterializedViewRemainLogs:
+	case ast.ShowMaterializedViewRemainLogs, ast.ShowMaterializedViewLogWaitPurge:
 		var err error
 		if user := b.ctx.GetSessionVars().User; user != nil {
 			err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW VIEW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -557,7 +557,11 @@ func (p *preprocessor) tableByName(tn *ast.TableName) (table.Table, error) {
 	is := p.ensureInfoSchema()
 
 	// for 'SHOW CREATE VIEW/MATERIALIZED VIEW/SEQUENCE ...' statement, ignore local temporary tables.
-	if p.stmtTp == TypeShow && (p.showTp == ast.ShowCreateView || p.showTp == ast.ShowCreateMaterializedView || p.showTp == ast.ShowCreateSequence) {
+	if p.stmtTp == TypeShow &&
+		(p.showTp == ast.ShowCreateView ||
+			p.showTp == ast.ShowCreateMaterializedView ||
+			p.showTp == ast.ShowMaterializedViewRemainLogs ||
+			p.showTp == ast.ShowCreateSequence) {
 		is = temptable.DetachLocalTemporaryTableInfoSchema(is)
 	}
 

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -561,6 +561,7 @@ func (p *preprocessor) tableByName(tn *ast.TableName) (table.Table, error) {
 		(p.showTp == ast.ShowCreateView ||
 			p.showTp == ast.ShowCreateMaterializedView ||
 			p.showTp == ast.ShowMaterializedViewRemainLogs ||
+			p.showTp == ast.ShowMaterializedViewLogWaitPurge ||
 			p.showTp == ast.ShowCreateSequence) {
 		is = temptable.DetachLocalTemporaryTableInfoSchema(is)
 	}

--- a/tests/integrationtest/r/executor/mview_privilege.result
+++ b/tests/integrationtest/r/executor/mview_privilege.result
@@ -77,6 +77,7 @@ create user 'u_refresh_select'@'%';
 grant show view on mview_privilege_test.mv to 'u_show_mv'@'%';
 grant show view, select on mview_privilege_test.mv to 'u_show_create'@'%';
 grant select on mview_privilege_test.t to 'u_show_log'@'%';
+grant show view on mview_privilege_test.t to 'u_show_log'@'%';
 grant operate view on mview_privilege_test.mv to 'u_refresh_select'@'%';
 grant select on mview_privilege_test.t to 'u_refresh_select'@'%';
 create user 'u_db_refresh'@'%';
@@ -111,8 +112,8 @@ grant operate view on *.* to 'u_purge_global'@'%';
 create user 'u_dml'@'%';
 grant select, insert, update, delete on mview_privilege_test.* to 'u_dml'@'%';
 show materialized view mv remain_logs;
-mview_id	mview_name	pending_rows
-<mview_id>	mv	1
+mview_id	mview_name	mlog_id	mlog_name	remain_logs
+<mview_id>	mv	<mlog_id>	$mlog$t	1
 show materialized views from mview_privilege_test;
 mview_id	mview_name
 <mview_id>	mv
@@ -127,8 +128,8 @@ Grants for u_show_create@%
 GRANT USAGE ON *.* TO 'u_show_create'@'%'
 GRANT SHOW VIEW ON `mview_privilege_test`.`mv` TO 'u_show_create'@'%'
 show materialized view mv remain_logs;
-mview_id	mview_name	pending_rows
-<mview_id>	mv	1
+mview_id	mview_name	mlog_id	mlog_name	remain_logs
+<mview_id>	mv	<mlog_id>	$mlog$t	1
 show create materialized view mv;
 Error 1142 (42000): SELECT command denied to user 'u_show_create'@'%' for table 'mv'
 grant select on mview_privilege_test.mv to 'u_show_create'@'%';
@@ -150,23 +151,25 @@ mlog_id	mlog_name	base_table_id	base_table_name
 show materialized view logs from mview_privilege_test like 'mview_privilege_test.$mlog$%';
 mlog_id	mlog_name	base_table_id	base_table_name
 show materialized view log on t wait_purge;
-mlog_id	mlog_name	base_table_id	base_table_name	pending_rows
+mlog_id	mlog_name	base_table_id	base_table_name	wait_purge
 <mlog_id>	$mlog$t	<base_table_id>	t	0
 show create materialized view log on t;
 Materialized View Log	Create Materialized View Log
 t	CREATE MATERIALIZED VIEW LOG ON `t` (`a`, `b`) PURGE NEXT DATE_ADD(NOW(), INTERVAL 1 HOUR)
 show materialized view log on t_hidden wait_purge;
-Error 1142 (42000): SELECT command denied to user 'u_show_log'@'%' for table 't_hidden'
+Error 1142 (42000): SHOW VIEW command denied to user 'u_show_log'@'%' for table 't_hidden'
 revoke select on mview_privilege_test.t from 'u_show_log'@'%';
 show grants for 'u_show_log'@'%';
 Grants for u_show_log@%
 GRANT USAGE ON *.* TO 'u_show_log'@'%'
+GRANT SHOW VIEW ON `mview_privilege_test`.`t` TO 'u_show_log'@'%'
 show materialized views from mview_privilege_test;
 mview_id	mview_name
 show materialized view logs from mview_privilege_test;
 mlog_id	mlog_name	base_table_id	base_table_name
 show materialized view log on mview_privilege_test.t wait_purge;
-Error 1142 (42000): SELECT command denied to user 'u_show_log'@'%' for table 't'
+mlog_id	mlog_name	base_table_id	base_table_name	wait_purge
+<mlog_id>	$mlog$t	<base_table_id>	t	0
 show create materialized view log on mview_privilege_test.t;
 Error 1142 (42000): SELECT command denied to user 'u_show_log'@'%' for table 't'
 refresh materialized view mv complete delta apply;

--- a/tests/integrationtest/t/executor/mview_privilege.test
+++ b/tests/integrationtest/t/executor/mview_privilege.test
@@ -32,6 +32,7 @@ create user 'u_refresh_select'@'%';
 grant show view on mview_privilege_test.mv to 'u_show_mv'@'%';
 grant show view, select on mview_privilege_test.mv to 'u_show_create'@'%';
 grant select on mview_privilege_test.t to 'u_show_log'@'%';
+grant show view on mview_privilege_test.t to 'u_show_log'@'%';
 grant operate view on mview_privilege_test.mv to 'u_refresh_select'@'%';
 grant select on mview_privilege_test.t to 'u_refresh_select'@'%';
 
@@ -68,7 +69,7 @@ grant select, insert, update, delete on mview_privilege_test.* to 'u_dml'@'%';
 
 connect (u_show_mv, localhost, u_show_mv,,mview_privilege_test);
 connection u_show_mv;
---replace_column 1 <mview_id>
+--replace_column 1 <mview_id> 3 <mlog_id>
 show materialized view mv remain_logs;
 --replace_column 1 <mview_id>
 show materialized views from mview_privilege_test;
@@ -86,7 +87,7 @@ revoke select on mview_privilege_test.mv from 'u_show_create'@'%';
 show grants for 'u_show_create'@'%';
 connect (u_show_create, localhost, u_show_create,,mview_privilege_test);
 connection u_show_create;
---replace_column 1 <mview_id>
+--replace_column 1 <mview_id> 3 <mlog_id>
 show materialized view mv remain_logs;
 -- error 1142
 show create materialized view mv;
@@ -127,7 +128,7 @@ connection u_show_log;
 show materialized views from mview_privilege_test;
 --replace_column 1 <mlog_id> 3 <base_table_id>
 show materialized view logs from mview_privilege_test;
--- error 1142
+--replace_column 1 <mlog_id> 3 <base_table_id>
 show materialized view log on mview_privilege_test.t wait_purge;
 -- error 1142
 show create materialized view log on mview_privilege_test.t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary:
This PR adds observability for materialized view log progress:
- `SHOW MATERIALIZED VIEW <mv> REMAIN_LOGS` reports how many related mlog rows have not been refreshed into the MV.
- `SHOW MATERIALIZED VIEW LOG ON <base_table> WAIT_PURGE` reports how many purgeable mlog rows have not been purged yet.

### What changed and how does it work?

- Added parser, AST restore, planner schema, executor dispatch, and tests for both SHOW paths.
- `REMAIN_LOGS` counts mlog rows whose `_tidb_commit_ts` is greater than the MV `LAST_SUCCESS_READ_TSO`.
- `WAIT_PURGE` reuses the mlog purge safe TSO calculation and counts mlog rows in `(LAST_PURGED_TSO, safe_purge_tso]`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands run:
- `go test -run TestDBAStmt -count=1` in `pkg/parser`
- `go test ./pkg/executor/test/ddl -run TestShowMaterializedView(LogWaitPurge|RemainLogs)$ -tags=intest,deadlock -count=1`
- `make bazel_lint_changed`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Add SHOW statements to inspect materialized view log refresh and purge progress.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `SHOW MATERIALIZED VIEW <mv> REMAIN LOGS` command to display remaining log entry counts for materialized views, which reset after refresh operations.
  * Added `SHOW MATERIALIZED VIEW LOG ON <base> WAIT_PURGE` command to display purge wait status for materialized view logs associated with base tables.
  * Implemented privilege validation and proper error handling for both new commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->