### PR TITLE
ttl: stabilize GC integration tests against background TTL GC race

### DIFF
--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -849,8 +849,12 @@ func waitAndStopTTLManager(t *testing.T, dom *domain.Domain) {
 }
 
 func TestGCScanTasks(t *testing.T) {
-	store := testkit.CreateMockStore(t)
+	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
+
+	// stop TTLJobManager to avoid background GC racing with local assertions
+	waitAndStopTTLManager(t, dom)
+
 	addTableStatusRecord := func(tableID, parentTableID, curJobID int64) {
 		tk.MustExec("INSERT INTO mysql.tidb_ttl_table_status (table_id,parent_table_id) VALUES (?, ?)", tableID, parentTableID)
 		if curJobID == 0 {
@@ -938,8 +942,12 @@ func TestGCTableStatus(t *testing.T) {
 }
 
 func TestGCTTLHistory(t *testing.T) {
-	store := testkit.CreateMockStore(t)
+	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
+
+	// stop TTLJobManager to avoid background GC racing with local assertions
+	waitAndStopTTLManager(t, dom)
+
 	addHistory := func(jobID, createdBeforeDays int) {
 		tk.MustExec(fmt.Sprintf(`INSERT INTO mysql.tidb_ttl_job_history (
 				job_id,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close pingcap/tidb#68658, close pingcap/tidb#68607

Problem Summary:
`TestGCScanTasks` and `TestGCTTLHistory` are flaky because the default domain background `TTLJobManager` may run GC concurrently with test assertions, causing nondeterministic row counts.

### What changed and how does it work?
- Switch both tests to `CreateMockStoreAndDomain` so the test can access the domain-owned TTL manager.
- Stop the default `TTLJobManager` via `waitAndStopTTLManager` before inserting/asserting TTL metadata.
- Keep GC behavior under explicit control of the test-owned `JobManager` (`DoGC`) to remove background interference.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by preventing race conditions between background operations and test assertions in TTL manager tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->