### PR TITLE
executor: cache RUv2 metadata on executor and skip per-Next drain

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -188,7 +188,6 @@ func (a *recordSet) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 	ctx = inheritStmtRUV2Context(ctx, a.stmt)
 
 	err = a.stmt.next(ctx, a.executor, req)
-	syncRUV2MetricsAfterExec(a.stmt)
 	if err != nil {
 		a.lastErrs = append(a.lastErrs, err)
 		return err
@@ -211,18 +210,6 @@ func inheritStmtRUV2Context(ctx context.Context, stmt *ExecStmt) context.Context
 		return ctx
 	}
 	return execdetails.ContextWithInheritedRUV2Details(ctx, stmt.GoCtx)
-}
-
-func syncRUV2MetricsAfterExec(stmt *ExecStmt) {
-	if stmt == nil || stmt.GoCtx == nil {
-		return
-	}
-	sessVars := stmt.Ctx.GetSessionVars()
-	if sessVars.RUV2Metrics == nil {
-		return
-	}
-	ruDetail, _ := stmt.GoCtx.Value(util.RUDetailsCtxKey).(*util.RUDetails)
-	execdetails.SyncRUV2MetricsFromRUDetails(sessVars.RUV2Metrics, ruDetail)
 }
 
 // NewChunk create a chunk base on top-level executor's exec.NewFirstChunk().
@@ -1131,7 +1118,6 @@ func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, e exec.Executor) (
 	}
 
 	err = a.next(ctx, e, exec.TryNewCacheChunk(e))
-	syncRUV2MetricsAfterExec(a)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1767,6 +1767,14 @@ func recordInsertRows2Metrics(sessVars *variable.SessionVars) {
 	stmtCtx.InsertRowsAsRUV2Recorded = true
 }
 
+// finalizeStatementRUV2Metrics is the sole drain point for RUv2 raw counters
+// since the per-Next syncRUV2MetricsAfterExec calls were removed. It runs
+// before LogSlowQuery / SummaryStmt, so post-statement consumers see fully
+// drained metrics. The trade-off: ResourceManagerReadCnt and
+// ResourceManagerWriteCnt on RUV2Metrics stay at zero until this drain fires,
+// so an in-flight TopRU sample read between Open() and FinishExecuteStmt will
+// not see those two fields' contribution. Per-statement totals telescope to
+// the correct sum because the post-finalize sample picks up the residual.
 func (a *ExecStmt) finalizeStatementRUV2Metrics() {
 	sessVars := a.Ctx.GetSessionVars()
 	if sessVars.RUV2Metrics == nil || sessVars.RUV2Metrics.Bypass() {

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1767,14 +1767,9 @@ func recordInsertRows2Metrics(sessVars *variable.SessionVars) {
 	stmtCtx.InsertRowsAsRUV2Recorded = true
 }
 
-// finalizeStatementRUV2Metrics is the sole drain point for RUv2 raw counters
-// since the per-Next syncRUV2MetricsAfterExec calls were removed. It runs
-// before LogSlowQuery / SummaryStmt, so post-statement consumers see fully
-// drained metrics. The trade-off: ResourceManagerReadCnt and
-// ResourceManagerWriteCnt on RUV2Metrics stay at zero until this drain fires,
-// so an in-flight TopRU sample read between Open() and FinishExecuteStmt will
-// not see those two fields' contribution. Per-statement totals telescope to
-// the correct sum because the post-finalize sample picks up the residual.
+// finalizeStatementRUV2Metrics is the sole drain of raw RUv2 counters. In-flight
+// TopRU samples see ResourceManager{Read,Write}Cnt as zero until this runs;
+// per-statement totals telescope correctly across the post-finalize sample.
 func (a *ExecStmt) finalizeStatementRUV2Metrics() {
 	sessVars := a.Ctx.GetSessionVars()
 	if sessVars.RUV2Metrics == nil || sessVars.RUV2Metrics.Bypass() {

--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -128,17 +128,17 @@ var ruv2ExecutorMetricByType = map[string]ruv2ExecutorMetric{
 // metrics container collapses to metrics==nil so Next() short-circuits with a
 // single check.
 type ruv2NextCacheState struct {
+	metrics    *execdetails.RUV2Metrics
 	regionName string
 	info       ruv2ExecutorMetric
 	hasInfo    bool
-	metrics    *execdetails.RUV2Metrics
 }
 
 type ruv2CacheProvider interface {
 	ruv2NextCache() *ruv2NextCacheState
 }
 
-func populateRUV2NextCache(cache *ruv2NextCacheState, ctx context.Context, e Executor) {
+func populateRUV2NextCache(ctx context.Context, cache *ruv2NextCacheState, e Executor) {
 	execType := reflect.TypeOf(e).String()
 	cache.regionName = execType + ".Next"
 	cache.info, cache.hasInfo = ruv2ExecutorMetricByType[execType]
@@ -406,14 +406,13 @@ func newExecutorKillerHandler(handler signalHandler) executorKillerHandler {
 
 // BaseExecutorV2 is a simplified version of `BaseExecutor`, which doesn't contain a full session context
 type BaseExecutorV2 struct {
-	_ constructor.Constructor `ctor:"NewBaseExecutorV2,BuildNewBaseExecutorV2"`
-
+	_              constructor.Constructor `ctor:"NewBaseExecutorV2,BuildNewBaseExecutorV2"`
+	ruv2CacheState ruv2NextCacheState
 	executorKillerHandler
 	executorStats
 	executorMeta
 	executorChunkAllocator
 	nextIOAccState nextIOAcc // reusable accumulator context for RUv2 tracking
-	ruv2CacheState ruv2NextCacheState
 }
 
 // NewBaseExecutorV2 creates a new BaseExecutorV2 instance.
@@ -575,7 +574,7 @@ func Open(ctx context.Context, e Executor) (err error) {
 		defer func() { e.RuntimeStats().RecordOpen(time.Since(start)) }()
 	}
 	if provider, ok := e.(ruv2CacheProvider); ok {
-		populateRUV2NextCache(provider.ruv2NextCache(), ctx, e)
+		populateRUV2NextCache(ctx, provider.ruv2NextCache(), e)
 	}
 	return e.Open(ctx)
 }
@@ -605,7 +604,7 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 	if provider, ok := e.(ruv2CacheProvider); ok {
 		cache := provider.ruv2NextCache()
 		if cache.regionName == "" {
-			populateRUV2NextCache(cache, ctx, e)
+			populateRUV2NextCache(ctx, cache, e)
 		}
 		regionName = cache.regionName
 		info, trackRUV2 = cache.info, cache.hasInfo

--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -607,18 +607,22 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 			populateRUV2NextCache(ctx, cache, e)
 		}
 		regionName = cache.regionName
-		info, trackRUV2 = cache.info, cache.hasInfo
+		info = cache.info
 		ruv2Metrics = cache.metrics
 	} else {
 		execType := reflect.TypeOf(e).String()
 		regionName = execType + ".Next"
-		info, trackRUV2 = ruv2ExecutorMetricByType[execType]
-		if trackRUV2 {
+		var hasInfo bool
+		if info, hasInfo = ruv2ExecutorMetricByType[execType]; hasInfo {
 			if m := execdetails.RUV2MetricsFromContext(ctx); m != nil && !m.Bypass() {
 				ruv2Metrics = m
 			}
 		}
 	}
+	// trackRUV2 means "this Next call will record into the metrics container".
+	// A tracked-type executor whose statement is bypassed leaves ruv2Metrics nil
+	// and must skip the per-child IO accumulator setup as well as the late update.
+	trackRUV2 = ruv2Metrics != nil
 
 	r, ctx := tracing.StartRegionEx(ctx, regionName)
 	defer r.End()
@@ -649,7 +653,7 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 		parentAcc.addInput(outRows, outCols)
 	}
 
-	if !trackRUV2 || ruv2Metrics == nil {
+	if !trackRUV2 {
 		// recheck whether the session/query is killed during the Next()
 		return e.HandleSQLKillerSignal()
 	}

--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -124,13 +124,47 @@ var ruv2ExecutorMetricByType = map[string]ruv2ExecutorMetric{
 	"*aggregate.StreamAggExec":      {level: 3, label: "StreamAggExec", useCells: false},
 }
 
-func addRUV2ExecutorMetricWithInfo(ctx context.Context, info ruv2ExecutorMetric, useCells bool, delta int64) {
-	if delta == 0 || info.useCells != useCells {
+// ruv2NextCacheState is repopulated on every Open(); a bypassed or missing
+// metrics container collapses to metrics==nil so Next() short-circuits with a
+// single check.
+type ruv2NextCacheState struct {
+	regionName string
+	info       ruv2ExecutorMetric
+	hasInfo    bool
+	metrics    *execdetails.RUV2Metrics
+}
+
+type ruv2CacheProvider interface {
+	ruv2NextCache() *ruv2NextCacheState
+}
+
+func populateRUV2NextCache(cache *ruv2NextCacheState, ctx context.Context, e Executor) {
+	execType := reflect.TypeOf(e).String()
+	cache.regionName = execType + ".Next"
+	cache.info, cache.hasInfo = ruv2ExecutorMetricByType[execType]
+	cache.metrics = nil
+	if !cache.hasInfo {
 		return
 	}
-	if ruv2Metrics := execdetails.RUV2MetricsFromContext(ctx); ruv2Metrics != nil {
-		ruv2Metrics.AddExecutorMetric(info.level, info.label, delta)
+	metrics := execdetails.RUV2MetricsFromContext(ctx)
+	if metrics == nil || metrics.Bypass() {
+		return
 	}
+	cache.metrics = metrics
+}
+
+func addRUV2ExecutorMetricCached(metrics *execdetails.RUV2Metrics, info ruv2ExecutorMetric, inRows, outRows, inCells, outCells int64) {
+	if metrics == nil {
+		return
+	}
+	delta := inRows + outRows
+	if info.useCells {
+		delta = inCells + outCells
+	}
+	if delta == 0 {
+		return
+	}
+	metrics.AddExecutorMetric(info.level, info.label, delta)
 }
 
 // Executor is the physical implementation of an algebra operator.
@@ -379,6 +413,7 @@ type BaseExecutorV2 struct {
 	executorMeta
 	executorChunkAllocator
 	nextIOAccState nextIOAcc // reusable accumulator context for RUv2 tracking
+	ruv2CacheState ruv2NextCacheState
 }
 
 // NewBaseExecutorV2 creates a new BaseExecutorV2 instance.
@@ -428,6 +463,10 @@ func (*BaseExecutorV2) Detach() (Executor, bool) {
 func (e *BaseExecutorV2) reusableNextIOAcc() *nextIOAcc {
 	e.nextIOAccState.reset()
 	return &e.nextIOAccState
+}
+
+func (e *BaseExecutorV2) ruv2NextCache() *ruv2NextCacheState {
+	return &e.ruv2CacheState
 }
 
 // BuildNewBaseExecutorV2 builds a new `BaseExecutorV2` based on the configuration of the current base executor.
@@ -535,6 +574,9 @@ func Open(ctx context.Context, e Executor) (err error) {
 		start := time.Now()
 		defer func() { e.RuntimeStats().RecordOpen(time.Since(start)) }()
 	}
+	if provider, ok := e.(ruv2CacheProvider); ok {
+		populateRUV2NextCache(provider.ruv2NextCache(), ctx, e)
+	}
 	return e.Open(ctx)
 }
 
@@ -554,12 +596,35 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 		return err
 	}
 
-	execType := reflect.TypeOf(e).String()
-	r, ctx := tracing.StartRegionEx(ctx, execType+".Next")
+	var (
+		regionName  string
+		info        ruv2ExecutorMetric
+		trackRUV2   bool
+		ruv2Metrics *execdetails.RUV2Metrics
+	)
+	if provider, ok := e.(ruv2CacheProvider); ok {
+		cache := provider.ruv2NextCache()
+		if cache.regionName == "" {
+			populateRUV2NextCache(cache, ctx, e)
+		}
+		regionName = cache.regionName
+		info, trackRUV2 = cache.info, cache.hasInfo
+		ruv2Metrics = cache.metrics
+	} else {
+		execType := reflect.TypeOf(e).String()
+		regionName = execType + ".Next"
+		info, trackRUV2 = ruv2ExecutorMetricByType[execType]
+		if trackRUV2 {
+			if m := execdetails.RUV2MetricsFromContext(ctx); m != nil && !m.Bypass() {
+				ruv2Metrics = m
+			}
+		}
+	}
+
+	r, ctx := tracing.StartRegionEx(ctx, regionName)
 	defer r.End()
 
 	parentAcc, _ := ctx.Value(nextIOAccKey).(*nextIOAcc)
-	info, trackRUV2 := ruv2ExecutorMetricByType[execType]
 	childCount := len(e.AllChildren())
 	needLocalAcc := needNextIOAcc(trackRUV2, parentAcc, childCount)
 	var myAcc *nextIOAcc
@@ -585,7 +650,7 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 		parentAcc.addInput(outRows, outCols)
 	}
 
-	if !trackRUV2 {
+	if !trackRUV2 || ruv2Metrics == nil {
 		// recheck whether the session/query is killed during the Next()
 		return e.HandleSQLKillerSignal()
 	}
@@ -596,19 +661,7 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 		inCells = stdatomic.LoadInt64(&myAcc.inCells)
 	}
 	outCells := calcCellCount(outRows, outCols)
-	// Dispatch both row-based and cell-based deltas; info.useCells filters each executor to its configured unit.
-	if inRows != 0 {
-		addRUV2ExecutorMetricWithInfo(ctx, info, false, inRows)
-	}
-	if outRows != 0 {
-		addRUV2ExecutorMetricWithInfo(ctx, info, false, int64(outRows))
-	}
-	if inCells != 0 {
-		addRUV2ExecutorMetricWithInfo(ctx, info, true, inCells)
-	}
-	if outCells != 0 {
-		addRUV2ExecutorMetricWithInfo(ctx, info, true, outCells)
-	}
+	addRUV2ExecutorMetricCached(ruv2Metrics, info, inRows, int64(outRows), inCells, outCells)
 	// recheck whether the session/query is killed during the Next()
 	return e.HandleSQLKillerSignal()
 }

--- a/pkg/util/topsql/stmtstats/BUILD.bazel
+++ b/pkg/util/topsql/stmtstats/BUILD.bazel
@@ -34,7 +34,7 @@ go_test(
     ],
     embed = [":stmtstats"],
     flaky = True,
-    shard_count = 36,
+    shard_count = 37,
     deps = [
         "//pkg/testkit/testsetup",
         "//pkg/util/execdetails",

--- a/pkg/util/topsql/stmtstats/stmtstats_test.go
+++ b/pkg/util/topsql/stmtstats/stmtstats_test.go
@@ -321,6 +321,71 @@ func TestStatementStatsRUV2Sampling(t *testing.T) {
 	})
 }
 
+// TestStatementStatsRUV2InFlightSamplingExcludesDrainOnlyFields documents the
+// contract introduced by removing the per-Next syncRUV2MetricsAfterExec drain:
+// ResourceManagerReadCnt and ResourceManagerWriteCnt on RUV2Metrics are
+// populated only by the end-of-statement drain (finalizeStatementRUV2Metrics).
+// In-flight TopRU samples taken before that drain see these two fields as
+// zero; the sum of the in-flight delta and the finalize delta still telescopes
+// to the full per-statement total.
+func TestStatementStatsRUV2InFlightSamplingExcludesDrainOnlyFields(t *testing.T) {
+	stats := &StatementStats{
+		data:             StatementStatsMap{},
+		finished:         atomic.NewBool(false),
+		finishedRUBuffer: RUIncrementMap{},
+	}
+	ru := util.NewRUDetails()
+	metrics := execdetails.NewRUV2Metrics()
+	weights := execdetails.RUV2Weights{
+		RUScale:                 1,
+		PlanCnt:                 1,
+		ResourceManagerReadCnt:  0.02,
+		ResourceManagerWriteCnt: 0.07,
+	}
+
+	// Planner-side increments are written live, not via drain.
+	metrics.AddPlanCnt(1)
+
+	stats.OnExecutionBegin([]byte("sql"), []byte("plan"), &ExecBeginInfo{
+		Ctx:          context.WithValue(context.Background(), util.RUDetailsCtxKey, ru),
+		User:         "u1",
+		TopRUEnabled: true,
+		RUVersion:    rmclient.RUVersionV2,
+		RUV2Metrics:  metrics,
+		RUV2Weights:  weights,
+	})
+	key := RUKey{User: "u1", SQLDigest: BinaryDigest("sql"), PlanDigest: BinaryDigest("plan")}
+
+	// Mid-statement sample. PlanCnt contributes; ResourceManager{Read,Write}Cnt
+	// are still zero on metrics because no drain has happened yet.
+	inFlight := stats.MergeRUInto()
+	require.InDelta(t, 1.0, inFlight[key].TotalRU, 1e-9)
+	require.Equal(t, uint64(1), inFlight[key].ExecCount)
+
+	// Simulate what finalizeStatementRUV2Metrics does at end of statement:
+	// drain raw counters into RUV2Metrics. Real TiKV responses would arrive
+	// via client-go RUDetails.AddRUV2; here we set the metric fields directly
+	// (the post-drain state is equivalent and avoids a kvproto test dep).
+	metrics.AddResourceManagerReadCnt(5)
+	metrics.AddResourceManagerWriteCnt(3)
+	require.Equal(t, int64(5), metrics.ResourceManagerReadCnt())
+	require.Equal(t, int64(3), metrics.ResourceManagerWriteCnt())
+
+	// Finalize the statement. The post-drain delta is now visible:
+	// 5*0.02 + 3*0.07 = 0.31 RU.
+	stats.OnExecutionFinished([]byte("sql"), []byte("plan"), &ExecFinishInfo{
+		RUDetails:    ru,
+		User:         "u1",
+		ExecDuration: time.Second,
+		TopRUEnabled: true,
+	})
+	finish := stats.MergeRUInto()
+	require.InDelta(t, 0.31, finish[key].TotalRU, 1e-9)
+
+	// Telescoping: in-flight + finalize == full per-statement total (1.31 RU).
+	require.InDelta(t, 1.31, inFlight[key].TotalRU+finish[key].TotalRU, 1e-9)
+}
+
 func TestStatementStatsResetRUStateOnVersionChangePreservesStmtStats(t *testing.T) {
 	cases := []struct {
 		name           string

--- a/pkg/util/topsql/stmtstats/stmtstats_test.go
+++ b/pkg/util/topsql/stmtstats/stmtstats_test.go
@@ -367,7 +367,7 @@ func TestStatementStatsRUV2InFlightSamplingExcludesDrainOnlyFields(t *testing.T)
 		TopRUEnabled: true,
 	})
 	finish := stats.MergeRUInto()
-	require.InDelta(t, 0.31, finish[key].TotalRU, 1e-9)              // 5*0.02 + 3*0.07
+	require.InDelta(t, 0.31, finish[key].TotalRU, 1e-9) // 5*0.02 + 3*0.07
 	require.InDelta(t, 1.31, inFlight[key].TotalRU+finish[key].TotalRU, 1e-9)
 }
 

--- a/pkg/util/topsql/stmtstats/stmtstats_test.go
+++ b/pkg/util/topsql/stmtstats/stmtstats_test.go
@@ -321,13 +321,10 @@ func TestStatementStatsRUV2Sampling(t *testing.T) {
 	})
 }
 
-// TestStatementStatsRUV2InFlightSamplingExcludesDrainOnlyFields documents the
-// contract introduced by removing the per-Next syncRUV2MetricsAfterExec drain:
-// ResourceManagerReadCnt and ResourceManagerWriteCnt on RUV2Metrics are
-// populated only by the end-of-statement drain (finalizeStatementRUV2Metrics).
-// In-flight TopRU samples taken before that drain see these two fields as
-// zero; the sum of the in-flight delta and the finalize delta still telescopes
-// to the full per-statement total.
+// TestStatementStatsRUV2InFlightSamplingExcludesDrainOnlyFields asserts that
+// ResourceManager{Read,Write}Cnt are invisible to in-flight TopRU samples
+// until the end-of-statement drain, and that the in-flight + finalize deltas
+// telescope to the full per-statement total.
 func TestStatementStatsRUV2InFlightSamplingExcludesDrainOnlyFields(t *testing.T) {
 	stats := &StatementStats{
 		data:             StatementStatsMap{},
@@ -342,9 +339,7 @@ func TestStatementStatsRUV2InFlightSamplingExcludesDrainOnlyFields(t *testing.T)
 		ResourceManagerReadCnt:  0.02,
 		ResourceManagerWriteCnt: 0.07,
 	}
-
-	// Planner-side increments are written live, not via drain.
-	metrics.AddPlanCnt(1)
+	metrics.AddPlanCnt(1) // live field, not drain-fed
 
 	stats.OnExecutionBegin([]byte("sql"), []byte("plan"), &ExecBeginInfo{
 		Ctx:          context.WithValue(context.Background(), util.RUDetailsCtxKey, ru),
@@ -356,23 +351,15 @@ func TestStatementStatsRUV2InFlightSamplingExcludesDrainOnlyFields(t *testing.T)
 	})
 	key := RUKey{User: "u1", SQLDigest: BinaryDigest("sql"), PlanDigest: BinaryDigest("plan")}
 
-	// Mid-statement sample. PlanCnt contributes; ResourceManager{Read,Write}Cnt
-	// are still zero on metrics because no drain has happened yet.
+	// In-flight sample: only PlanCnt visible, drain-fed fields still zero.
 	inFlight := stats.MergeRUInto()
 	require.InDelta(t, 1.0, inFlight[key].TotalRU, 1e-9)
 	require.Equal(t, uint64(1), inFlight[key].ExecCount)
 
-	// Simulate what finalizeStatementRUV2Metrics does at end of statement:
-	// drain raw counters into RUV2Metrics. Real TiKV responses would arrive
-	// via client-go RUDetails.AddRUV2; here we set the metric fields directly
-	// (the post-drain state is equivalent and avoids a kvproto test dep).
+	// Equivalent of finalizeStatementRUV2Metrics's drain; bypassing kvproto.
 	metrics.AddResourceManagerReadCnt(5)
 	metrics.AddResourceManagerWriteCnt(3)
-	require.Equal(t, int64(5), metrics.ResourceManagerReadCnt())
-	require.Equal(t, int64(3), metrics.ResourceManagerWriteCnt())
 
-	// Finalize the statement. The post-drain delta is now visible:
-	// 5*0.02 + 3*0.07 = 0.31 RU.
 	stats.OnExecutionFinished([]byte("sql"), []byte("plan"), &ExecFinishInfo{
 		RUDetails:    ru,
 		User:         "u1",
@@ -380,9 +367,7 @@ func TestStatementStatsRUV2InFlightSamplingExcludesDrainOnlyFields(t *testing.T)
 		TopRUEnabled: true,
 	})
 	finish := stats.MergeRUInto()
-	require.InDelta(t, 0.31, finish[key].TotalRU, 1e-9)
-
-	// Telescoping: in-flight + finalize == full per-statement total (1.31 RU).
+	require.InDelta(t, 0.31, finish[key].TotalRU, 1e-9)              // 5*0.02 + 3*0.07
 	require.InDelta(t, 1.31, inFlight[key].TotalRU+finish[key].TotalRU, 1e-9)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68118

Problem Summary:

Statement-level RU v2 accounting (#67030) introduced per-`Next()` overhead on the executor hot path that survives #67508 and the in-flight #68119:

1. Every `Next()` recomputes `reflect.TypeOf(e).String()`, performs a type-keyed map lookup, and walks the context chain up to four times for `RUV2MetricsCtxKey` — all invariant for the executor's lifetime within a statement.
2. Every `recordSet.Next()` and `handleNoDelayExecutor` drains raw RU v2 counters from `RUDetails` into the statement metrics, duplicating the drain already performed by `finalizeStatementRUV2Metrics` at end of statement.

### What changed and how does it work?

**Cache RU v2 metadata on `BaseExecutorV2`.**
A new `ruv2NextCacheState` field is repopulated on every `Open()`, capturing the tracing region name, the executor's metric entry, and the statement's `*RUV2Metrics` pointer (set to `nil` when the executor is untracked or the statement is bypassed). `Next()` reads from the cache via an unexported `ruv2CacheProvider` interface, eliminating per-call reflection, map lookup, the `ctx.Value` chain walk, and the `Bypass()` atomic load. The four conditional `addRUV2ExecutorMetricWithInfo` invocations collapse into one cached call. Executors that don't embed `BaseExecutorV2` (test stubs) retain the original per-call path. `Open()` overwrites the cache unconditionally so reused executors (PointGet plan cache via `Recreated()`) always see fresh per-statement state.

**Hoist the per-Next drain to statement end.**
Removes `syncRUV2MetricsAfterExec` calls from `recordSet.Next()` and `handleNoDelayExecutor`, and the function itself. `finalizeStatementRUV2Metrics` (in `FinishExecuteStmt`, reached on every exit path) already performs the same `SyncRUV2MetricsFromRUDetails` drain before `LogSlowQuery` and `SummaryStmt` read the metrics. Per-statement RU totals and PD reporting are unchanged. Cursor delta reporting is unaffected — `CursorRUV2Tracker.reportDelta` keeps its own drain. The only observable behavior change: in-flight TopRU samples on long-running queries see two small-weight TiDB-side fields (`ResourceManagerReadCnt` × 0.02, `ResourceManagerWriteCnt` × 0.07) under-attributed until finalize; per-statement totals telescope to the same value.

`TestFinishExecuteStmtSyncsTiDBRUV2FromRUDetails` already asserts the end-of-statement drain path this change relies on.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Reduce RU v2 accounting overhead on the executor `Next()` hot path for point-select workloads.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized RUv2 counter drainage to statement finalization and tightened RUv2 execution-context propagation during iteration for consistent metrics.
  * Added per-iteration caching of executor RUv2 metadata to avoid repeated lookups and streamline RUv2 metric updates.
* **Tests**
  * Added a test ensuring in-flight RUv2 sampling excludes drain-only counters until statement finalization.
* **Chores**
  * Adjusted test shard count in build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->