### PR TITLE
planner: warn when bindings overwrite manual hints in EXPLAIN

### DIFF
--- a/pkg/bindinfo/tests/BUILD.bazel
+++ b/pkg/bindinfo/tests/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 24,
+    shard_count = 25,
     deps = [
         "//pkg/bindinfo",
         "//pkg/domain",

--- a/pkg/bindinfo/tests/bind_test.go
+++ b/pkg/bindinfo/tests/bind_test.go
@@ -880,3 +880,32 @@ func TestInvalidBindingCheck(t *testing.T) {
 	tk.MustExec("create binding using select * from *.t where c=1")
 	tk.MustExec("create binding using select * from t where c=?")
 }
+
+func TestIssue68550(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, b int, key(a), key(b))")
+
+	expectedWarning := "Warning 1105 The system ignores the hints in the current query and uses the hints specified in the bindSQL: SELECT /*+ use_index(`t` `a`)*/ * FROM `test`.`t` WHERE `a` = 1 AND `b` = 1"
+
+	tk.MustExec("create global binding using select /*+ use_index(t, a) */ * from t where a=1 and b=1")
+
+	// Case 1 (repro): EXPLAIN + conflicting manual hint -> warning fires.
+	tk.MustQuery("explain select /*+ use_index(t, b) */ * from t where a=1 and b=1")
+	tk.MustQuery("show warnings").Check(testkit.Rows(expectedWarning))
+
+	// Case 2 (regression guard): plain SELECT + conflicting hint still warns.
+	tk.MustQuery("select /*+ use_index(t, b) */ * from t where a=1 and b=1")
+	tk.MustQuery("show warnings").Check(testkit.Rows(expectedWarning))
+
+	// Case 3 (false-positive guard): binding present, no manual hint -> no warning.
+	tk.MustQuery("explain select * from t where a=1 and b=1")
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+
+	// Case 4: no binding -> user's manual hint applies, no warning.
+	tk.MustExec("drop global binding for select * from t where a=1 and b=1")
+	tk.MustQuery("explain select /*+ use_index(t, b) */ * from t where a=1 and b=1")
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+}

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -230,6 +230,15 @@ func optimizeNoCache(ctx context.Context, sctx sessionctx.Context, node *resolve
 	sessVars := sctx.GetSessionVars()
 
 	tableHints := hint.ExtractTableHintsFromStmtNode(node.Node, sessVars.StmtCtx)
+	// ExtractTableHintsFromStmtNode does not recurse into ExplainStmt, but
+	// MatchSQLBinding unwraps it (see NormalizeStmtForBinding) so the binding
+	// is applied to the inner stmt and rewrites its /*+ ... */ hints. Capture
+	// the inner stmt's hints up-front so the "binding overrides hints" warning
+	// below still fires for `EXPLAIN SELECT /*+ ... */ ...`.
+	var wrappedInnerHints []*ast.TableOptimizerHint
+	if explain, ok := node.Node.(*ast.ExplainStmt); ok && explain.Stmt != nil {
+		wrappedInnerHints = hint.ExtractTableHintsFromStmtNode(explain.Stmt, sessVars.StmtCtx)
+	}
 	originStmtHints, _, warns := hint.ParseStmtHints(tableHints,
 		setVarHintChecker, hypoIndexChecker(ctx, is),
 		sessVars.CurrentDB, byte(kv.ReplicaReadFollower))
@@ -339,7 +348,7 @@ func optimizeNoCache(ctx context.Context, sctx sessionctx.Context, node *resolve
 			} else {
 				sessVars.StmtCtx.AppendExtraNote(errors.NewNoStackErrorf("Using the bindSQL: %v", chosenBinding.BindSQL))
 			}
-			if originStmtHints.QueryHasHints {
+			if originStmtHints.QueryHasHints || len(wrappedInnerHints) > 0 {
 				sessVars.StmtCtx.AppendWarning(errors.NewNoStackErrorf("The system ignores the hints in the current query and uses the hints specified in the bindSQL: %v", chosenBinding.BindSQL))
 			}
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68550

Problem Summary:

When a binding overrides a manual `/*+ ... */` hint in a plain `SELECT`, the optimizer appends a warning ("The system ignores the hints in the current query and uses the hints specified in the bindSQL: ..."). The same conflict in `EXPLAIN SELECT /*+ ... */ ...` silently drops the warning, so users debugging the plan see the binding's index choice without any signal that their hint was ignored.

Root cause: `ExtractTableHintsFromStmtNode` does not recurse into `*ast.ExplainStmt`, so `originStmtHints.QueryHasHints` evaluates false on the outer call. Binding matching, on the other hand, does unwrap EXPLAIN via `NormalizeStmtForBinding`, so the binding is applied but the warning at the override site is skipped.

### What changed and how does it work?

- Capture the wrapped statement's hints up-front when the outer node is `*ast.ExplainStmt`, and OR that into the warning condition. `ExtractTableHintsFromStmtNode` itself is left unchanged to avoid double-processing of `SET_VAR`-style hints when the wrapped stmt is optimized recursively.
- Add `TestIssue68550` covering the EXPLAIN bug, the plain-SELECT regression, and two no-warning guards (binding without manual hint; manual hint without binding).

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Emit the existing "system ignores hints" warning for `EXPLAIN` statements as well, so users debugging hint-vs-binding conflicts via `EXPLAIN` see the same notice that plain queries already produced.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of binding hints to correctly emit warnings when bindings override user-provided hints, now including cases where hints appear in EXPLAIN-wrapped queries.

* **Tests**
  * Added test coverage for binding hint conflict detection, validating warning behavior with manual hints, and verifying hint application after binding removal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->