### PR TITLE
executor, parser, planner: support SHOW CREATE for materialized views

### DIFF
--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -654,7 +654,7 @@ func buildMLogPurgeMeta(sctx sessionctx.Context, purge *ast.MLogPurgeClause) (me
 		return "", "", "", nil
 	}
 	if purge.Immediate {
-		return "IMMEDIATE", "", "", nil
+		return "", "", "", dbterror.ErrGeneralUnsupportedDDL.GenWithStack("PURGE IMMEDIATE is not supported for ALTER MATERIALIZED VIEW LOG")
 	}
 
 	method = "DEFERRED"

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -1604,23 +1604,21 @@ func (e *ShowExec) fetchShowCreateMaterializedViewLog() error {
 	}
 
 	if baseMeta.MaterializedViewBase == nil || baseMeta.MaterializedViewBase.MLogID == 0 {
-		return errors.Errorf("materialized view log does not exist for base table %s.%s", e.DBName.O, baseMeta.Name.O)
+		return exeerrors.ErrWrongObject.GenWithStackByArgs(e.DBName.O, baseMeta.Name.O, "BASE TABLE WITH MATERIALIZED VIEW LOG")
 	}
 	mlogID := baseMeta.MaterializedViewBase.MLogID
 	mlogTable, ok := e.is.TableByID(context.Background(), mlogID)
 	if !ok {
-		return errors.Errorf("materialized view log does not exist for base table %s.%s", e.DBName.O, baseMeta.Name.O)
+		return exeerrors.ErrWrongObject.GenWithStackByArgs(e.DBName.O, baseMeta.Name.O, "BASE TABLE WITH MATERIALIZED VIEW LOG")
 	}
 	mlogName := mlogTable.Meta().Name
 
 	mlogInfo := mlogTable.Meta().MaterializedViewLog
 	if mlogInfo == nil || mlogInfo.BaseTableID != baseMeta.ID {
-		return errors.Errorf(
-			"table %s.%s is not a materialized view log for base table %s.%s",
+		return exeerrors.ErrWrongObject.GenWithStackByArgs(
 			e.DBName.O,
 			mlogName.O,
-			e.DBName.O,
-			baseMeta.Name.O,
+			fmt.Sprintf("MATERIALIZED VIEW LOG FOR BASE TABLE %s.%s", e.DBName.O, baseMeta.Name.O),
 		)
 	}
 

--- a/pkg/executor/test/ddl/BUILD.bazel
+++ b/pkg/executor/test/ddl/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "//pkg/meta",
         "//pkg/meta/autoid",
         "//pkg/meta/model",
+        "//pkg/parser",
         "//pkg/parser/auth",
         "//pkg/parser/model",
         "//pkg/parser/mysql",

--- a/pkg/executor/test/ddl/BUILD.bazel
+++ b/pkg/executor/test/ddl/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "//pkg/types",
         "//pkg/util/chunk",
         "//pkg/util/dbterror",
+        "//pkg/util/dbterror/exeerrors",
         "//pkg/util/dbterror/plannererrors",
         "@com_github_docker_go_units//:go-units",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -422,6 +422,28 @@ func TestMaterializedViewDDLProtectsMinMaxSupportingBaseTableIndexesAgainstConcu
 	tk.MustQuery("select a, b, minc, cnt from mv_concurrent_drop_idx").Check(testkit.Rows("1 2 5 2"))
 }
 
+func TestShowCreateMaterializedView(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_show_mv (a int, b int not null)")
+	tk.MustExec("create materialized view log on t_show_mv (a, b) purge immediate")
+	tk.MustExec("create materialized view mv_show_mv (a, s, cnt) comment = 'c1' refresh fast next now() shard_row_id_bits = 2 pre_split_regions = 2 as select a, sum(b), count(1) from t_show_mv group by a")
+
+	rows := tk.MustQuery("show create materialized view mv_show_mv").Rows()
+	require.Len(t, rows, 1)
+	require.Equal(t, "mv_show_mv", rows[0][0])
+	showCreate, ok := rows[0][1].(string)
+	require.True(t, ok)
+	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW `mv_show_mv` (`a`, `s`, `cnt`)")
+	require.Contains(t, showCreate, "COMMENT = 'c1'")
+	require.Contains(t, showCreate, "REFRESH FAST NEXT NOW()")
+	require.Contains(t, showCreate, "SHARD_ROW_ID_BITS = 2 PRE_SPLIT_REGIONS = 2")
+	require.Contains(t, showCreate, "AS SELECT `a`,SUM(`b`),COUNT(1) FROM `test`.`t_show_mv` GROUP BY `a`")
+	require.Equal(t, "utf8mb4", rows[0][2])
+	require.Equal(t, "utf8mb4_bin", rows[0][3])
+}
+
 func TestCreateMaterializedViewRefreshExprTypeValidation(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -427,7 +427,7 @@ func TestShowCreateMaterializedView(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t_show_mv (a int, b int not null)")
-	tk.MustExec("create materialized view log on t_show_mv (a, b) purge immediate")
+	tk.MustExec("create materialized view log on t_show_mv (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_show_mv (a, s, cnt) comment = 'c1' refresh fast next now() shard_row_id_bits = 2 pre_split_regions = 2 as select a, sum(b), count(1) from t_show_mv group by a")
 
 	rows := tk.MustQuery("show create materialized view mv_show_mv").Rows()

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -29,6 +29,7 @@ import (
 	ddlsess "github.com/pingcap/tidb/pkg/ddl/session"
 	ddlutil "github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
@@ -440,6 +441,8 @@ func TestShowCreateMaterializedView(t *testing.T) {
 	require.Contains(t, showCreate, "REFRESH FAST NEXT NOW()")
 	require.Contains(t, showCreate, "SHARD_ROW_ID_BITS = 2 PRE_SPLIT_REGIONS = 2")
 	require.Contains(t, showCreate, "AS SELECT `a`,SUM(`b`),COUNT(1) FROM `test`.`t_show_mv` GROUP BY `a`")
+	_, err := parser.New().ParseOneStmt(showCreate, "", "")
+	require.NoError(t, err)
 	require.Equal(t, "utf8mb4", rows[0][2])
 	require.Equal(t, "utf8mb4_bin", rows[0][3])
 }

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -97,6 +97,27 @@ func TestCreateMaterializedViewLogBasic(t *testing.T) {
 	tk.MustGetErrMsg("create materialized view log on t (a)", "[schema:1050]Table 'test.$mlog$t' already exists")
 }
 
+func TestShowCreateMaterializedViewLog(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_show_mlog (a int, b int)")
+	tk.MustExec("create materialized view log on t_show_mlog (a, b) shard_row_id_bits = 2 pre_split_regions = 2 purge start with cast('2026-01-02 03:04:05' as datetime) next date_add(now(), interval 1 hour)")
+
+	rows := tk.MustQuery("show create materialized view log on t_show_mlog").Rows()
+	require.Len(t, rows, 1)
+	require.Equal(t, "t_show_mlog", rows[0][0])
+	showCreate, ok := rows[0][1].(string)
+	require.True(t, ok)
+	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW LOG ON `t_show_mlog` (`a`, `b`)")
+	require.Contains(t, showCreate, "SHARD_ROW_ID_BITS = 2 PRE_SPLIT_REGIONS = 2")
+	require.Contains(t, showCreate, "PURGE START WITH CAST('2026-01-02 03:04:05' AS DATETIME) NEXT DATE_ADD(NOW(), INTERVAL 1 HOUR)")
+
+	tk.MustExec("create table t_no_mlog (a int)")
+	err := tk.QueryToErr("show create materialized view log on t_no_mlog")
+	require.ErrorContains(t, err, "materialized view log does not exist for base table test.t_no_mlog")
+}
+
 func TestCreateMaterializedViewLogPreSplitOptions(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
+	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -116,9 +117,15 @@ func TestShowCreateMaterializedViewLog(t *testing.T) {
 	_, err := parser.New().ParseOneStmt(showCreate, "", "")
 	require.NoError(t, err)
 
+	tk.MustExec("create temporary table t_show_mlog (a int)")
+	rows = tk.MustQuery("show create materialized view log on t_show_mlog").Rows()
+	require.Len(t, rows, 1)
+	require.Equal(t, "t_show_mlog", rows[0][0])
+	require.Contains(t, rows[0][1], "CREATE MATERIALIZED VIEW LOG ON `t_show_mlog` (`a`, `b`)")
+
 	tk.MustExec("create table t_no_mlog (a int)")
 	err = tk.QueryToErr("show create materialized view log on t_no_mlog")
-	require.ErrorContains(t, err, "materialized view log does not exist for base table test.t_no_mlog")
+	require.Truef(t, exeerrors.ErrWrongObject.Equal(err), "err %v", err)
 }
 
 func TestCreateMaterializedViewLogPreSplitOptions(t *testing.T) {

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -112,9 +113,11 @@ func TestShowCreateMaterializedViewLog(t *testing.T) {
 	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW LOG ON `t_show_mlog` (`a`, `b`)")
 	require.Contains(t, showCreate, "SHARD_ROW_ID_BITS = 2 PRE_SPLIT_REGIONS = 2")
 	require.Contains(t, showCreate, "PURGE START WITH CAST('2026-01-02 03:04:05' AS DATETIME) NEXT DATE_ADD(NOW(), INTERVAL 1 HOUR)")
+	_, err := parser.New().ParseOneStmt(showCreate, "", "")
+	require.NoError(t, err)
 
 	tk.MustExec("create table t_no_mlog (a int)")
-	err := tk.QueryToErr("show create materialized view log on t_no_mlog")
+	err = tk.QueryToErr("show create materialized view log on t_no_mlog")
 	require.ErrorContains(t, err, "materialized view log does not exist for base table test.t_no_mlog")
 }
 
@@ -321,22 +324,24 @@ func TestAlterMaterializedViewLogPurgeUpdatesMetaAndNextTime(t *testing.T) {
 		"select TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) from mysql.tidb_mlog_purge_info where MLOG_ID = %d",
 		mlogID,
 	)).Rows()
-	tk.MustExec("alter materialized view log on t purge")
+	err := tk.ExecToErr("alter materialized view log on t purge")
+	require.Error(t, err)
 	_, purgeMethod, purgeStartWith, purgeNext = getMLogMeta()
 	require.Equal(t, "DEFERRED", purgeMethod)
 	require.Equal(t, "", purgeStartWith)
-	require.Equal(t, "", purgeNext)
+	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 25 MINUTE)", purgeNext)
 	afterRows := tk.MustQuery(fmt.Sprintf(
 		"select TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) from mysql.tidb_mlog_purge_info where MLOG_ID = %d",
 		mlogID,
 	)).Rows()
 	require.Equal(t, beforeRows, afterRows)
 
-	tk.MustExec("alter materialized view log on t purge immediate")
+	err = tk.ExecToErr("alter materialized view log on t purge immediate")
+	require.ErrorContains(t, err, "PURGE IMMEDIATE is not supported for ALTER MATERIALIZED VIEW LOG")
 	_, purgeMethod, purgeStartWith, purgeNext = getMLogMeta()
-	require.Equal(t, "IMMEDIATE", purgeMethod)
+	require.Equal(t, "DEFERRED", purgeMethod)
 	require.Equal(t, "", purgeStartWith)
-	require.Equal(t, "", purgeNext)
+	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 25 MINUTE)", purgeNext)
 	afterImmediateRows := tk.MustQuery(fmt.Sprintf(
 		"select TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) from mysql.tidb_mlog_purge_info where MLOG_ID = %d",
 		mlogID,

--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -3003,6 +3003,7 @@ const (
 	ShowCollation
 	ShowCreateTable
 	ShowCreateView
+	ShowCreateMaterializedView
 	ShowCreateUser
 	ShowCreateSequence
 	ShowCreatePlacementPolicy
@@ -3161,6 +3162,11 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteKeyWord("CREATE VIEW ")
 		if err := n.Table.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore ShowStmt.VIEW")
+		}
+	case ShowCreateMaterializedView:
+		ctx.WriteKeyWord("CREATE MATERIALIZED VIEW ")
+		if err := n.Table.Restore(ctx); err != nil {
+			return errors.Annotate(err, "An error occurred while restore ShowStmt.MATERIALIZED VIEW")
 		}
 	case ShowCreateDatabase:
 		ctx.WriteKeyWord("CREATE DATABASE ")
@@ -3519,7 +3525,7 @@ func (n *ShowStmt) NeedLimitRSRow() bool {
 	default:
 		// There are five classes of Show STMT.
 		// 1) The STMT Only return one row:
-		//    ShowCreateTable, ShowCreateView, ShowCreateUser, ShowCreateDatabase, ShowMasterStatus,
+		//    ShowCreateTable, ShowCreateView, ShowCreateMaterializedView, ShowCreateUser, ShowCreateDatabase, ShowMasterStatus,
 		//
 		// 2) The STMT is a MySQL syntax extend, so just keep it behavior as before:
 		//    ShowCreateSequence, ShowCreatePlacementPolicy, ShowConfig, ShowStatsExtended,

--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -3004,6 +3004,7 @@ const (
 	ShowCreateTable
 	ShowCreateView
 	ShowCreateMaterializedView
+	ShowCreateMaterializedViewLog
 	ShowCreateUser
 	ShowCreateSequence
 	ShowCreatePlacementPolicy
@@ -3167,6 +3168,11 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteKeyWord("CREATE MATERIALIZED VIEW ")
 		if err := n.Table.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore ShowStmt.MATERIALIZED VIEW")
+		}
+	case ShowCreateMaterializedViewLog:
+		ctx.WriteKeyWord("CREATE MATERIALIZED VIEW LOG ON ")
+		if err := n.Table.Restore(ctx); err != nil {
+			return errors.Annotate(err, "An error occurred while restore ShowStmt.MATERIALIZED VIEW LOG")
 		}
 	case ShowCreateDatabase:
 		ctx.WriteKeyWord("CREATE DATABASE ")
@@ -3525,7 +3531,8 @@ func (n *ShowStmt) NeedLimitRSRow() bool {
 	default:
 		// There are five classes of Show STMT.
 		// 1) The STMT Only return one row:
-		//    ShowCreateTable, ShowCreateView, ShowCreateMaterializedView, ShowCreateUser, ShowCreateDatabase, ShowMasterStatus,
+		//    ShowCreateTable, ShowCreateView, ShowCreateMaterializedView, ShowCreateMaterializedViewLog,
+		//    ShowCreateUser, ShowCreateDatabase, ShowMasterStatus,
 		//
 		// 2) The STMT is a MySQL syntax extend, so just keep it behavior as before:
 		//    ShowCreateSequence, ShowCreatePlacementPolicy, ShowConfig, ShowStatsExtended,

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -367,14 +367,14 @@ import (
 	collation             "COLLATION"
 	columns               "COLUMNS"
 	columnFormat          "COLUMN_FORMAT"
-		comment               "COMMENT"
-		commit                "COMMIT"
-		committed             "COMMITTED"
-		compact               "COMPACT"
-		complete              "COMPLETE"
-		compressed            "COMPRESSED"
-		compression           "COMPRESSION"
-		compressionLevel      "COMPRESSION_LEVEL"
+	comment               "COMMENT"
+	commit                "COMMIT"
+	committed             "COMMITTED"
+	compact               "COMPACT"
+	complete              "COMPLETE"
+	compressed            "COMPRESSED"
+	compression           "COMPRESSION"
+	compressionLevel      "COMPRESSION_LEVEL"
 	compressionType       "COMPRESSION_TYPE"
 	concurrency           "CONCURRENCY"
 	config                "CONFIG"
@@ -969,148 +969,148 @@ import (
 	ProcedureCall                   "Procedure call with Identifier or identifier"
 
 %type	<statement>
-	AdminStmt                  "Check table statement or show ddl statement"
-	AlterDatabaseStmt          "Alter database statement"
-	AlterTableStmt             "Alter table statement"
-	AlterUserStmt              "Alter user statement"
-	AlterInstanceStmt          "Alter instance statement"
-	AlterRangeStmt             "Alter data range configuration statement"
-	AlterPolicyStmt            "Alter Placement Policy statement"
-	AlterResourceGroupStmt     "Alter Resource Group statement"
-	AlterSequenceStmt          "Alter sequence statement"
-	AnalyzeTableStmt           "Analyze table statement"
-	BeginTransactionStmt       "BEGIN TRANSACTION statement"
-	BinlogStmt                 "Binlog base64 statement"
-	BRIEStmt                   "BACKUP or RESTORE statement"
-	CalibrateResourceStmt      "CALIBRATE RESOURCE statement"
-	CancelDistributionJobStmt  "CANCEL DISTRIBUTION JOB statement"
-	CommitStmt                 "COMMIT statement"
-	CreateTableStmt            "CREATE TABLE statement"
-	CreateViewStmt             "CREATE VIEW  statement"
-	CreateMaterializedViewStmt "CREATE MATERIALIZED VIEW statement"
+	AdminStmt                     "Check table statement or show ddl statement"
+	AlterDatabaseStmt             "Alter database statement"
+	AlterTableStmt                "Alter table statement"
+	AlterUserStmt                 "Alter user statement"
+	AlterInstanceStmt             "Alter instance statement"
+	AlterRangeStmt                "Alter data range configuration statement"
+	AlterPolicyStmt               "Alter Placement Policy statement"
+	AlterResourceGroupStmt        "Alter Resource Group statement"
+	AlterSequenceStmt             "Alter sequence statement"
+	AnalyzeTableStmt              "Analyze table statement"
+	BeginTransactionStmt          "BEGIN TRANSACTION statement"
+	BinlogStmt                    "Binlog base64 statement"
+	BRIEStmt                      "BACKUP or RESTORE statement"
+	CalibrateResourceStmt         "CALIBRATE RESOURCE statement"
+	CancelDistributionJobStmt     "CANCEL DISTRIBUTION JOB statement"
+	CommitStmt                    "COMMIT statement"
+	CreateTableStmt               "CREATE TABLE statement"
+	CreateViewStmt                "CREATE VIEW  statement"
+	CreateMaterializedViewStmt    "CREATE MATERIALIZED VIEW statement"
 	CreateMaterializedViewLogStmt "CREATE MATERIALIZED VIEW LOG statement"
-	AlterMaterializedViewStmt  "ALTER MATERIALIZED VIEW statement"
-	AlterMaterializedViewLogStmt "ALTER MATERIALIZED VIEW LOG statement"
-	DropMaterializedViewStmt   "DROP MATERIALIZED VIEW statement"
-	DropMaterializedViewLogStmt "DROP MATERIALIZED VIEW LOG statement"
-	PurgeMaterializedViewLogStmt "PURGE MATERIALIZED VIEW LOG statement"
-	RefreshMaterializedViewStmt "REFRESH MATERIALIZED VIEW statement"
-	CreateUserStmt             "CREATE User statement"
-	CreateRoleStmt             "CREATE Role statement"
-	CreateDatabaseStmt         "Create Database Statement"
-	CreateIndexStmt            "CREATE INDEX statement"
-	CreateBindingStmt          "CREATE BINDING statement"
-	CreatePolicyStmt           "CREATE PLACEMENT POLICY statement"
-	CreateProcedureStmt        "CREATE PROCEDURE statement"
-	AddQueryWatchStmt          "ADD QUERY WATCH statement"
-	CreateResourceGroupStmt    "CREATE RESOURCE GROUP statement"
-	CreateSequenceStmt         "CREATE SEQUENCE statement"
-	CreateStatisticsStmt       "CREATE STATISTICS statement"
-	DoStmt                     "Do statement"
-	DropDatabaseStmt           "DROP DATABASE statement"
-	DropIndexStmt              "DROP INDEX statement"
-	DropProcedureStmt          "DROP PROCEDURE statement"
-	DropQueryWatchStmt         "DROP QUERY WATCH statement"
-	DropResourceGroupStmt      "DROP RESOURCE GROUP statement"
-	DropStatisticsStmt         "DROP STATISTICS statement"
-	DropStatsStmt              "DROP STATS statement"
-	DropTableStmt              "DROP TABLE statement"
-	DropSequenceStmt           "DROP SEQUENCE statement"
-	DropUserStmt               "DROP USER"
-	DropRoleStmt               "DROP ROLE"
-	DropViewStmt               "DROP VIEW statement"
-	DropBindingStmt            "DROP BINDING  statement"
-	DropPolicyStmt             "DROP PLACEMENT POLICY statement"
-	DeallocateStmt             "Deallocate prepared statement"
-	DeleteFromStmt             "DELETE FROM statement"
-	DeleteWithoutUsingStmt     "Normal DELETE statement"
-	DeleteWithUsingStmt        "DELETE USING statement"
-	DistributeTableStmt        "Distribute table statement"
-	EmptyStmt                  "empty statement"
-	ExecuteStmt                "Execute statement"
-	ExplainStmt                "EXPLAIN statement"
-	ExplainableStmt            "explainable statement"
-	FlushStmt                  "Flush statement"
-	FlashbackTableStmt         "Flashback table statement"
-	FlashbackToTimestampStmt   "Flashback cluster statement"
-	FlashbackDatabaseStmt      "Flashback Database statement"
-	GrantStmt                  "Grant statement"
-	GrantProxyStmt             "Grant proxy statement"
-	GrantRoleStmt              "Grant role statement"
-	InsertIntoStmt             "INSERT INTO statement"
-	CallStmt                   "CALL statement"
-	ImportIntoStmt             "IMPORT INTO statement"
-	ImportFromSelectStmt       "SELECT statement of IMPORT INTO"
-	KillStmt                   "Kill statement"
-	LoadDataStmt               "Load data statement"
-	LoadStatsStmt              "Load statistic statement"
-	LockStatsStmt              "Lock statistic statement"
-	UnlockStatsStmt            "Unlock statistic statement"
-	LockTablesStmt             "Lock tables statement"
-	NonTransactionalDMLStmt    "Non-transactional DML statement"
-	OptimizeTableStmt          "OPTIMIZE statement"
-	PlanReplayerStmt           "Plan replayer statement"
-	PreparedStmt               "PreparedStmt"
-	ProcedureProcStmt          "The entrance of procedure statements which contains all kinds of statements in procedure"
-	ProcedureStatementStmt     "The normal statements in procedure, such as dml, select, set ..."
-	SelectStmt                 "SELECT statement"
-	SelectStmtWithClause       "common table expression SELECT statement"
-	RenameTableStmt            "rename table statement"
-	RenameUserStmt             "rename user statement"
-	ReplaceIntoStmt            "REPLACE INTO statement"
-	RecoverTableStmt           "recover table statement"
-	RevokeStmt                 "Revoke statement"
-	RevokeRoleStmt             "Revoke role statement"
-	RollbackStmt               "ROLLBACK statement"
-	ReleaseSavepointStmt       "RELEASE SAVEPOINT statement"
-	SavepointStmt              "SAVEPOINT statement"
-	SplitRegionStmt            "Split index region statement"
-	SetStmt                    "Set variable statement"
-	SetBindingStmt             "Set binding statement"
-	SetRoleStmt                "Set active role statement"
-	SetDefaultRoleStmt         "Set default statement for some user"
-	ShowStmt                   "Show engines/databases/tables/user/columns/warnings/status statement"
-	Statement                  "statement"
-	TraceStmt                  "TRACE statement"
-	TraceableStmt              "traceable statement"
-	TruncateTableStmt          "TRUNCATE TABLE statement"
-	UnlockTablesStmt           "Unlock tables statement"
-	UpdateStmt                 "UPDATE statement"
-	SetOprStmt                 "Union/Except/Intersect select statement"
-	SetOprStmtWithLimitOrderBy "Union/Except/Intersect select statement with limit and order by"
-	SetOprStmtWoutLimitOrderBy "Union/Except/Intersect select statement without limit and order by"
-	UseStmt                    "USE statement"
-	ShutdownStmt               "SHUTDOWN statement"
-	RestartStmt                "RESTART statement"
-	RecommendIndexStmt         "RECOMMEND INDEX statement"
-	CreateViewSelectOpt        "Select/Union/Except/Intersect statement in CREATE VIEW ... AS SELECT"
-	BindableStmt               "Statement that can be created binding on"
-	UpdateStmtNoWith           "Update statement without CTE clause"
-	HelpStmt                   "HELP statement"
-	ShardableStmt              "Shardable statement that can be used in non-transactional DMLs"
-	CancelImportStmt           "CANCEL IMPORT JOB statement"
-	ProcedureUnlabeledBlock    "The statement block without label in procedure"
-	ProcedureBlockContent      "The statement block in procedure expressed with 'Begin ... End'"
-	SimpleWhenThen             "Procedure case when then"
-	SearchWhenThen             "Procedure search when then"
-	ProcedureIfstmt            "The if statement in procedure, expressed by if ... elseif .. else ... end if"
-	procedurceElseIfs          "The else block in procedure, expressed by elseif or else or nil"
-	ProcedureIf                "The if block in procedure, expressed by expr then statement procedurceElseIfs"
-	ProcedureUnlabelLoopBlock  "The loop block without label in procedure "
-	ProcedureUnlabelLoopStmt   "The loop statement in procedure, expressed by repeat/do while/loop"
-	ProcedureCaseStmt          "Case statement in procedure, expressed by `case ... when.. then ..`"
-	ProcedureSimpleCase        "The simpe case statement in procedure, expressed by `case expr when expr then statement ... end case`"
-	ProcedureSearchedCase      "The searched case statement in procedure, expressed by `case when expr then statement ... end case`"
-	ProcedureCursorSelectStmt  "The select stmt can used in procedure cursor."
-	ProcedureOpenCur           "The open cursor statement in procedure, expressed by `open ...`"
-	ProcedureCloseCur          "The close cursor statement in procedure, expressed by `close ...`"
-	ProcedureFetchInto         "The fetch into statement in procedure, expressed by `fetch ... into ...`"
-	ProcedureHcond             "The handler value statement in procedure, expressed by condition_value"
-	ProcedurceCond             "The handler code statement in procedure, expressed by code error num or `sqlstate ...`"
-	ProcedureLabeledBlock      "The statement block with label in procedure"
-	ProcedurelabeledLoopStmt   "The loop block with label in procedure"
-	ProcedureIterate           "The iterate statement in procedure, expressed by `iterate ...`"
-	ProcedureLeave             "The leave statement in procedure, expressed by `leave ...`"
+	AlterMaterializedViewStmt     "ALTER MATERIALIZED VIEW statement"
+	AlterMaterializedViewLogStmt  "ALTER MATERIALIZED VIEW LOG statement"
+	DropMaterializedViewStmt      "DROP MATERIALIZED VIEW statement"
+	DropMaterializedViewLogStmt   "DROP MATERIALIZED VIEW LOG statement"
+	PurgeMaterializedViewLogStmt  "PURGE MATERIALIZED VIEW LOG statement"
+	RefreshMaterializedViewStmt   "REFRESH MATERIALIZED VIEW statement"
+	CreateUserStmt                "CREATE User statement"
+	CreateRoleStmt                "CREATE Role statement"
+	CreateDatabaseStmt            "Create Database Statement"
+	CreateIndexStmt               "CREATE INDEX statement"
+	CreateBindingStmt             "CREATE BINDING statement"
+	CreatePolicyStmt              "CREATE PLACEMENT POLICY statement"
+	CreateProcedureStmt           "CREATE PROCEDURE statement"
+	AddQueryWatchStmt             "ADD QUERY WATCH statement"
+	CreateResourceGroupStmt       "CREATE RESOURCE GROUP statement"
+	CreateSequenceStmt            "CREATE SEQUENCE statement"
+	CreateStatisticsStmt          "CREATE STATISTICS statement"
+	DoStmt                        "Do statement"
+	DropDatabaseStmt              "DROP DATABASE statement"
+	DropIndexStmt                 "DROP INDEX statement"
+	DropProcedureStmt             "DROP PROCEDURE statement"
+	DropQueryWatchStmt            "DROP QUERY WATCH statement"
+	DropResourceGroupStmt         "DROP RESOURCE GROUP statement"
+	DropStatisticsStmt            "DROP STATISTICS statement"
+	DropStatsStmt                 "DROP STATS statement"
+	DropTableStmt                 "DROP TABLE statement"
+	DropSequenceStmt              "DROP SEQUENCE statement"
+	DropUserStmt                  "DROP USER"
+	DropRoleStmt                  "DROP ROLE"
+	DropViewStmt                  "DROP VIEW statement"
+	DropBindingStmt               "DROP BINDING  statement"
+	DropPolicyStmt                "DROP PLACEMENT POLICY statement"
+	DeallocateStmt                "Deallocate prepared statement"
+	DeleteFromStmt                "DELETE FROM statement"
+	DeleteWithoutUsingStmt        "Normal DELETE statement"
+	DeleteWithUsingStmt           "DELETE USING statement"
+	DistributeTableStmt           "Distribute table statement"
+	EmptyStmt                     "empty statement"
+	ExecuteStmt                   "Execute statement"
+	ExplainStmt                   "EXPLAIN statement"
+	ExplainableStmt               "explainable statement"
+	FlushStmt                     "Flush statement"
+	FlashbackTableStmt            "Flashback table statement"
+	FlashbackToTimestampStmt      "Flashback cluster statement"
+	FlashbackDatabaseStmt         "Flashback Database statement"
+	GrantStmt                     "Grant statement"
+	GrantProxyStmt                "Grant proxy statement"
+	GrantRoleStmt                 "Grant role statement"
+	InsertIntoStmt                "INSERT INTO statement"
+	CallStmt                      "CALL statement"
+	ImportIntoStmt                "IMPORT INTO statement"
+	ImportFromSelectStmt          "SELECT statement of IMPORT INTO"
+	KillStmt                      "Kill statement"
+	LoadDataStmt                  "Load data statement"
+	LoadStatsStmt                 "Load statistic statement"
+	LockStatsStmt                 "Lock statistic statement"
+	UnlockStatsStmt               "Unlock statistic statement"
+	LockTablesStmt                "Lock tables statement"
+	NonTransactionalDMLStmt       "Non-transactional DML statement"
+	OptimizeTableStmt             "OPTIMIZE statement"
+	PlanReplayerStmt              "Plan replayer statement"
+	PreparedStmt                  "PreparedStmt"
+	ProcedureProcStmt             "The entrance of procedure statements which contains all kinds of statements in procedure"
+	ProcedureStatementStmt        "The normal statements in procedure, such as dml, select, set ..."
+	SelectStmt                    "SELECT statement"
+	SelectStmtWithClause          "common table expression SELECT statement"
+	RenameTableStmt               "rename table statement"
+	RenameUserStmt                "rename user statement"
+	ReplaceIntoStmt               "REPLACE INTO statement"
+	RecoverTableStmt              "recover table statement"
+	RevokeStmt                    "Revoke statement"
+	RevokeRoleStmt                "Revoke role statement"
+	RollbackStmt                  "ROLLBACK statement"
+	ReleaseSavepointStmt          "RELEASE SAVEPOINT statement"
+	SavepointStmt                 "SAVEPOINT statement"
+	SplitRegionStmt               "Split index region statement"
+	SetStmt                       "Set variable statement"
+	SetBindingStmt                "Set binding statement"
+	SetRoleStmt                   "Set active role statement"
+	SetDefaultRoleStmt            "Set default statement for some user"
+	ShowStmt                      "Show engines/databases/tables/user/columns/warnings/status statement"
+	Statement                     "statement"
+	TraceStmt                     "TRACE statement"
+	TraceableStmt                 "traceable statement"
+	TruncateTableStmt             "TRUNCATE TABLE statement"
+	UnlockTablesStmt              "Unlock tables statement"
+	UpdateStmt                    "UPDATE statement"
+	SetOprStmt                    "Union/Except/Intersect select statement"
+	SetOprStmtWithLimitOrderBy    "Union/Except/Intersect select statement with limit and order by"
+	SetOprStmtWoutLimitOrderBy    "Union/Except/Intersect select statement without limit and order by"
+	UseStmt                       "USE statement"
+	ShutdownStmt                  "SHUTDOWN statement"
+	RestartStmt                   "RESTART statement"
+	RecommendIndexStmt            "RECOMMEND INDEX statement"
+	CreateViewSelectOpt           "Select/Union/Except/Intersect statement in CREATE VIEW ... AS SELECT"
+	BindableStmt                  "Statement that can be created binding on"
+	UpdateStmtNoWith              "Update statement without CTE clause"
+	HelpStmt                      "HELP statement"
+	ShardableStmt                 "Shardable statement that can be used in non-transactional DMLs"
+	CancelImportStmt              "CANCEL IMPORT JOB statement"
+	ProcedureUnlabeledBlock       "The statement block without label in procedure"
+	ProcedureBlockContent         "The statement block in procedure expressed with 'Begin ... End'"
+	SimpleWhenThen                "Procedure case when then"
+	SearchWhenThen                "Procedure search when then"
+	ProcedureIfstmt               "The if statement in procedure, expressed by if ... elseif .. else ... end if"
+	procedurceElseIfs             "The else block in procedure, expressed by elseif or else or nil"
+	ProcedureIf                   "The if block in procedure, expressed by expr then statement procedurceElseIfs"
+	ProcedureUnlabelLoopBlock     "The loop block without label in procedure "
+	ProcedureUnlabelLoopStmt      "The loop statement in procedure, expressed by repeat/do while/loop"
+	ProcedureCaseStmt             "Case statement in procedure, expressed by `case ... when.. then ..`"
+	ProcedureSimpleCase           "The simpe case statement in procedure, expressed by `case expr when expr then statement ... end case`"
+	ProcedureSearchedCase         "The searched case statement in procedure, expressed by `case when expr then statement ... end case`"
+	ProcedureCursorSelectStmt     "The select stmt can used in procedure cursor."
+	ProcedureOpenCur              "The open cursor statement in procedure, expressed by `open ...`"
+	ProcedureCloseCur             "The close cursor statement in procedure, expressed by `close ...`"
+	ProcedureFetchInto            "The fetch into statement in procedure, expressed by `fetch ... into ...`"
+	ProcedureHcond                "The handler value statement in procedure, expressed by condition_value"
+	ProcedurceCond                "The handler code statement in procedure, expressed by code error num or `sqlstate ...`"
+	ProcedureLabeledBlock         "The statement block with label in procedure"
+	ProcedurelabeledLoopStmt      "The loop block with label in procedure"
+	ProcedureIterate              "The iterate statement in procedure, expressed by `iterate ...`"
+	ProcedureLeave                "The leave statement in procedure, expressed by `leave ...`"
 
 %type	<item>
 	AdminShowSlow                          "Admin Show Slow statement"
@@ -1428,18 +1428,18 @@ import (
 	MViewCreateOption                      "materialized view create option"
 	MViewRefreshClause                     "materialized view refresh clause"
 	MViewRefreshOnClauseOpt                "materialized view refresh ON clause"
-		MViewStartWithOpt                      "materialized view START WITH option"
-		MViewNextOpt                           "materialized view NEXT option"
-		MViewStartWithOrNextOpt                "materialized view START WITH/NEXT option list"
-		MViewStartWithOrNext                   "materialized view START WITH/NEXT option"
-		MLogCreateOptionListOpt                "materialized view log create options"
-		MLogCreateOptionList                   "materialized view log create option list"
-		MLogCreateOption                       "materialized view log create option"
-		MLogPurgeClauseOpt                     "materialized view log optional PURGE clause"
-		MLogPurgeClause                        "materialized view log PURGE clause"
-		MLogStartWithOpt                       "materialized view log START WITH option"
-		MLogNextOpt                            "materialized view log NEXT option"
-		AlterMaterializedViewAction            "ALTER MATERIALIZED VIEW action"
+	MViewStartWithOpt                      "materialized view START WITH option"
+	MViewNextOpt                           "materialized view NEXT option"
+	MViewStartWithOrNextOpt                "materialized view START WITH/NEXT option list"
+	MViewStartWithOrNext                   "materialized view START WITH/NEXT option"
+	MLogCreateOptionListOpt                "materialized view log create options"
+	MLogCreateOptionList                   "materialized view log create option list"
+	MLogCreateOption                       "materialized view log create option"
+	MLogPurgeClauseOpt                     "materialized view log optional PURGE clause"
+	MLogPurgeClause                        "materialized view log PURGE clause"
+	MLogStartWithOpt                       "materialized view log START WITH option"
+	MLogNextOpt                            "materialized view log NEXT option"
+	AlterMaterializedViewAction            "ALTER MATERIALIZED VIEW action"
 	AlterMaterializedViewActionList        "ALTER MATERIALIZED VIEW action list"
 	AlterMaterializedViewLogAction         "ALTER MATERIALIZED VIEW LOG action"
 	AlterMaterializedViewLogActionList     "ALTER MATERIALIZED VIEW LOG action list"
@@ -5249,26 +5249,20 @@ ViewCheckOption:
 		$$ = model.CheckOptionLocal
 	}
 
-/*******************************************************************
- *
- *  Materialized View Statements
- *
- *******************************************************************/
-
 CreateMaterializedViewStmt:
 	"CREATE" "MATERIALIZED" "VIEW" TableName '(' ColumnList ')' MViewCreateOptionListOpt "AS" CreateViewSelectOpt
-		{
-			opts := $8.(*mviewCreateOptions)
-			x := &ast.CreateMaterializedViewStmt{
-				ViewName:        $4.(*ast.TableName),
-				Cols:            $6.([]model.CIStr),
-				Comment:         opts.comment,
-				Refresh:         opts.refresh,
-				Options:         opts.options,
-				Select:          $10.(ast.StmtNode).(ast.ResultSetNode),
-			}
-			$$ = x
+	{
+		opts := $8.(*mviewCreateOptions)
+		x := &ast.CreateMaterializedViewStmt{
+			ViewName: $4.(*ast.TableName),
+			Cols:     $6.([]model.CIStr),
+			Comment:  opts.comment,
+			Refresh:  opts.refresh,
+			Options:  opts.options,
+			Select:   $10.(ast.StmtNode).(ast.ResultSetNode),
 		}
+		$$ = x
+	}
 
 MViewCreateOptionListOpt:
 	/* EMPTY */
@@ -5408,18 +5402,18 @@ MViewNextOpt:
 		$$ = $2
 	}
 
-	CreateMaterializedViewLogStmt:
-		"CREATE" "MATERIALIZED" "VIEW" "LOG" "ON" TableName '(' ColumnList ')' MLogCreateOptionListOpt MLogPurgeClauseOpt
-		{
-			opts := $10.(*mlogCreateOptions)
-			x := &ast.CreateMaterializedViewLogStmt{
-				Table:   $6.(*ast.TableName),
-				Cols:    $8.([]model.CIStr),
-				Options: opts.options,
-				Purge:   $11.(*ast.MLogPurgeClause),
-			}
-			$$ = x
+CreateMaterializedViewLogStmt:
+	"CREATE" "MATERIALIZED" "VIEW" "LOG" "ON" TableName '(' ColumnList ')' MLogCreateOptionListOpt MLogPurgeClauseOpt
+	{
+		opts := $10.(*mlogCreateOptions)
+		x := &ast.CreateMaterializedViewLogStmt{
+			Table:   $6.(*ast.TableName),
+			Cols:    $8.([]model.CIStr),
+			Options: opts.options,
+			Purge:   $11.(*ast.MLogPurgeClause),
 		}
+		$$ = x
+	}
 
 MLogCreateOptionListOpt:
 	/* EMPTY */
@@ -5542,16 +5536,16 @@ AlterMaterializedViewActionList:
 		$$ = append($1.([]*ast.AlterMaterializedViewAction), $3.(*ast.AlterMaterializedViewAction))
 	}
 
-	AlterMaterializedViewAction:
-		"COMMENT" "=" stringLit
-		{
-			$$ = &ast.AlterMaterializedViewAction{Tp: ast.AlterMaterializedViewActionComment, Comment: $3}
-		}
-	|	"REFRESH" MViewStartWithOpt MViewNextOpt
-		{
-			var startWith ast.ExprNode
-			if $2 != nil {
-				startWith = $2.(ast.ExprNode)
+AlterMaterializedViewAction:
+	"COMMENT" "=" stringLit
+	{
+		$$ = &ast.AlterMaterializedViewAction{Tp: ast.AlterMaterializedViewActionComment, Comment: $3}
+	}
+|	"REFRESH" MViewStartWithOpt MViewNextOpt
+	{
+		var startWith ast.ExprNode
+		if $2 != nil {
+			startWith = $2.(ast.ExprNode)
 		}
 		var next ast.ExprNode
 		if $3 != nil {
@@ -5581,13 +5575,13 @@ AlterMaterializedViewLogActionList:
 		$$ = append($1.([]*ast.AlterMaterializedViewLogAction), $3.(*ast.AlterMaterializedViewLogAction))
 	}
 
-	AlterMaterializedViewLogAction:
-		"PURGE" "IMMEDIATE"
-		{
-			$$ = &ast.AlterMaterializedViewLogAction{Tp: ast.AlterMaterializedViewLogActionPurge, Purge: &ast.MLogPurgeClause{Immediate: true}}
-		}
-	|	"PURGE" MLogStartWithOpt MLogNextOpt
-		{
+AlterMaterializedViewLogAction:
+	"PURGE" "IMMEDIATE"
+	{
+		$$ = &ast.AlterMaterializedViewLogAction{Tp: ast.AlterMaterializedViewLogActionPurge, Purge: &ast.MLogPurgeClause{Immediate: true}}
+	}
+|	"PURGE" MLogStartWithOpt MLogNextOpt
+	{
 		var startWith ast.ExprNode
 		if $2 != nil {
 			startWith = $2.(ast.ExprNode)
@@ -12021,6 +12015,13 @@ ShowStmt:
 		$$ = &ast.ShowStmt{
 			Tp:    ast.ShowCreateMaterializedView,
 			Table: $5.(*ast.TableName),
+		}
+	}
+|	"SHOW" "CREATE" "MATERIALIZED" "VIEW" "LOG" "ON" TableName
+	{
+		$$ = &ast.ShowStmt{
+			Tp:    ast.ShowCreateMaterializedViewLog,
+			Table: $7.(*ast.TableName),
 		}
 	}
 |	"SHOW" "CREATE" "DATABASE" IfNotExists DBName

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -12016,6 +12016,13 @@ ShowStmt:
 			Table: $4.(*ast.TableName),
 		}
 	}
+|	"SHOW" "CREATE" "MATERIALIZED" "VIEW" TableName
+	{
+		$$ = &ast.ShowStmt{
+			Tp:    ast.ShowCreateMaterializedView,
+			Table: $5.(*ast.TableName),
+		}
+	}
 |	"SHOW" "CREATE" "DATABASE" IfNotExists DBName
 	{
 		$$ = &ast.ShowStmt{

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -1428,8 +1428,6 @@ import (
 	MViewCreateOption                      "materialized view create option"
 	MViewRefreshClause                     "materialized view refresh clause"
 	MViewRefreshOnClauseOpt                "materialized view refresh ON clause"
-	MViewStartWithOpt                      "materialized view START WITH option"
-	MViewNextOpt                           "materialized view NEXT option"
 	MViewStartWithOrNextOpt                "materialized view START WITH/NEXT option list"
 	MViewStartWithOrNext                   "materialized view START WITH/NEXT option"
 	MLogCreateOptionListOpt                "materialized view log create options"
@@ -1438,7 +1436,6 @@ import (
 	MLogPurgeClauseOpt                     "materialized view log optional PURGE clause"
 	MLogPurgeClause                        "materialized view log PURGE clause"
 	MLogStartWithOpt                       "materialized view log START WITH option"
-	MLogNextOpt                            "materialized view log NEXT option"
 	AlterMaterializedViewAction            "ALTER MATERIALIZED VIEW action"
 	AlterMaterializedViewActionList        "ALTER MATERIALIZED VIEW action list"
 	AlterMaterializedViewLogAction         "ALTER MATERIALIZED VIEW LOG action"
@@ -5382,26 +5379,6 @@ MViewStartWithOrNext:
 		$$ = &ast.MViewRefreshClause{Next: $2.(ast.ExprNode)}
 	}
 
-MViewStartWithOpt:
-	/* EMPTY */
-	{
-		$$ = nil
-	}
-|	"START" "WITH" Expression
-	{
-		$$ = $3
-	}
-
-MViewNextOpt:
-	/* EMPTY */
-	{
-		$$ = nil
-	}
-|	"NEXT" Expression
-	{
-		$$ = $2
-	}
-
 CreateMaterializedViewLogStmt:
 	"CREATE" "MATERIALIZED" "VIEW" "LOG" "ON" TableName '(' ColumnList ')' MLogCreateOptionListOpt MLogPurgeClauseOpt
 	{
@@ -5506,16 +5483,6 @@ MLogStartWithOpt:
 		$$ = $3
 	}
 
-MLogNextOpt:
-	/* EMPTY */
-	{
-		$$ = nil
-	}
-|	"NEXT" Expression
-	{
-		$$ = $2
-	}
-
 AlterMaterializedViewStmt:
 	"ALTER" "MATERIALIZED" "VIEW" TableName AlterMaterializedViewActionList
 	{
@@ -5541,17 +5508,14 @@ AlterMaterializedViewAction:
 	{
 		$$ = &ast.AlterMaterializedViewAction{Tp: ast.AlterMaterializedViewActionComment, Comment: $3}
 	}
-|	"REFRESH" MViewStartWithOpt MViewNextOpt
+|	"REFRESH" MViewStartWithOrNextOpt
 	{
-		var startWith ast.ExprNode
+		refresh := &ast.MViewRefreshClause{Method: ast.MViewRefreshMethodFast}
 		if $2 != nil {
-			startWith = $2.(ast.ExprNode)
+			schedule := $2.(*ast.MViewRefreshClause)
+			refresh.StartWith = schedule.StartWith
+			refresh.Next = schedule.Next
 		}
-		var next ast.ExprNode
-		if $3 != nil {
-			next = $3.(ast.ExprNode)
-		}
-		refresh := &ast.MViewRefreshClause{Method: ast.MViewRefreshMethodFast, StartWith: startWith, Next: next}
 		$$ = &ast.AlterMaterializedViewAction{Tp: ast.AlterMaterializedViewActionRefresh, Refresh: refresh}
 	}
 
@@ -5576,21 +5540,9 @@ AlterMaterializedViewLogActionList:
 	}
 
 AlterMaterializedViewLogAction:
-	"PURGE" "IMMEDIATE"
+	MLogPurgeClause
 	{
-		$$ = &ast.AlterMaterializedViewLogAction{Tp: ast.AlterMaterializedViewLogActionPurge, Purge: &ast.MLogPurgeClause{Immediate: true}}
-	}
-|	"PURGE" MLogStartWithOpt MLogNextOpt
-	{
-		var startWith ast.ExprNode
-		if $2 != nil {
-			startWith = $2.(ast.ExprNode)
-		}
-		var next ast.ExprNode
-		if $3 != nil {
-			next = $3.(ast.ExprNode)
-		}
-		$$ = &ast.AlterMaterializedViewLogAction{Tp: ast.AlterMaterializedViewLogActionPurge, Purge: &ast.MLogPurgeClause{Immediate: false, StartWith: startWith, Next: next}}
+		$$ = &ast.AlterMaterializedViewLogAction{Tp: ast.AlterMaterializedViewLogActionPurge, Purge: $1.(*ast.MLogPurgeClause)}
 	}
 
 DropMaterializedViewStmt:

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1285,6 +1285,9 @@ func TestDBAStmt(t *testing.T) {
 		// for show create materialized view
 		{"show create materialized view test.t", true, "SHOW CREATE MATERIALIZED VIEW `test`.`t`"},
 		{"show create materialized view t", true, "SHOW CREATE MATERIALIZED VIEW `t`"},
+		// for show create materialized view log
+		{"show create materialized view log on test.t", true, "SHOW CREATE MATERIALIZED VIEW LOG ON `test`.`t`"},
+		{"show create materialized view log on t", true, "SHOW CREATE MATERIALIZED VIEW LOG ON `t`"},
 		// for show create database
 		{"show create database d1", true, "SHOW CREATE DATABASE `d1`"},
 		{"show create database if not exists d1", true, "SHOW CREATE DATABASE IF NOT EXISTS `d1`"},

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1282,6 +1282,9 @@ func TestDBAStmt(t *testing.T) {
 		// for show create view
 		{"show create view test.t", true, "SHOW CREATE VIEW `test`.`t`"},
 		{"show create view t", true, "SHOW CREATE VIEW `t`"},
+		// for show create materialized view
+		{"show create materialized view test.t", true, "SHOW CREATE MATERIALIZED VIEW `test`.`t`"},
+		{"show create materialized view t", true, "SHOW CREATE MATERIALIZED VIEW `t`"},
 		// for show create database
 		{"show create database d1", true, "SHOW CREATE DATABASE `d1`"},
 		{"show create database if not exists d1", true, "SHOW CREATE DATABASE IF NOT EXISTS `d1`"},

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5384,8 +5384,8 @@ func TestMaterializedViewStatements(t *testing.T) {
 		},
 		{
 			"ALTER MATERIALIZED VIEW mv REFRESH START WITH now()",
-			true,
-			"ALTER MATERIALIZED VIEW `mv` REFRESH START WITH NOW()",
+			false,
+			"",
 		},
 		{
 			"ALTER MATERIALIZED VIEW mv REFRESH NEXT 300",
@@ -5399,13 +5399,13 @@ func TestMaterializedViewStatements(t *testing.T) {
 		},
 		{
 			"ALTER MATERIALIZED VIEW LOG ON t PURGE",
-			true,
-			"ALTER MATERIALIZED VIEW LOG ON `t` PURGE",
+			false,
+			"",
 		},
 		{
 			"ALTER MATERIALIZED VIEW LOG ON t PURGE START WITH now()",
-			true,
-			"ALTER MATERIALIZED VIEW LOG ON `t` PURGE START WITH NOW()",
+			false,
+			"",
 		},
 		{
 			"ALTER MATERIALIZED VIEW LOG ON t PURGE NEXT 300",

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3557,7 +3557,7 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (base.P
 			p.Extractor = extractor
 			buildPattern = false
 		}
-	case ast.ShowCreateTable, ast.ShowCreateSequence, ast.ShowPlacementForTable, ast.ShowPlacementForPartition:
+	case ast.ShowCreateTable, ast.ShowCreateSequence, ast.ShowCreateMaterializedViewLog, ast.ShowPlacementForTable, ast.ShowPlacementForPartition:
 		var err error
 		if table, err := b.is.TableByName(ctx, show.Table.Schema, show.Table.Name); err == nil {
 			isView = table.Meta().IsView()
@@ -6365,6 +6365,8 @@ func buildShowSchema(s *ast.ShowStmt, isView bool, isSequence bool) (schema *exp
 		names = []string{"View", "Create View", "character_set_client", "collation_connection"}
 	case ast.ShowCreateMaterializedView:
 		names = []string{"Materialized View", "Create Materialized View", "character_set_client", "collation_connection"}
+	case ast.ShowCreateMaterializedViewLog:
+		names = []string{"Materialized View Log", "Create Materialized View Log"}
 	case ast.ShowCreateDatabase:
 		names = []string{"Database", "Create Database"}
 	case ast.ShowGrants:

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3589,6 +3589,17 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (base.P
 			err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW VIEW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
+	case ast.ShowCreateMaterializedView:
+		var err error
+		user := b.ctx.GetSessionVars().User
+		if user != nil {
+			err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SELECT", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
+		}
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
+		if user != nil {
+			err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW VIEW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
+		}
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
 	case ast.ShowBackups:
 		err := plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs("SUPER or BACKUP_ADMIN")
 		b.visitInfo = appendDynamicVisitInfo(b.visitInfo, []string{"BACKUP_ADMIN"}, false, err)
@@ -6352,6 +6363,8 @@ func buildShowSchema(s *ast.ShowStmt, isView bool, isSequence bool) (schema *exp
 		}
 	case ast.ShowCreateView:
 		names = []string{"View", "Create View", "character_set_client", "collation_connection"}
+	case ast.ShowCreateMaterializedView:
+		names = []string{"Materialized View", "Create Materialized View", "character_set_client", "collation_connection"}
 	case ast.ShowCreateDatabase:
 		names = []string{"Database", "Create Database"}
 	case ast.ShowGrants:

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3521,6 +3521,12 @@ func splitWhere(where ast.ExprNode) []ast.ExprNode {
 
 func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (base.Plan, error) {
 	tnW := b.resolveCtx.GetTableName(show.Table)
+	resolvedDBName := ""
+	if tnW != nil && tnW.DBInfo != nil {
+		resolvedDBName = tnW.DBInfo.Name.L
+	} else if show.Table != nil {
+		resolvedDBName = show.Table.Schema.L
+	}
 	p := logicalop.LogicalShow{
 		ShowContents: logicalop.ShowContents{
 			Tp:                    show.Tp,
@@ -3568,12 +3574,12 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (base.P
 			if user != nil {
 				err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW VIEW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
 			}
-			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
+			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, resolvedDBName, show.Table.Name.L, "", err)
 		} else {
 			if user != nil {
 				err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
 			}
-			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.AllPrivMask, show.Table.Schema.L, show.Table.Name.L, "", err)
+			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.AllPrivMask, resolvedDBName, show.Table.Name.L, "", err)
 		}
 	case ast.ShowConfig:
 		privErr := plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs("CONFIG")
@@ -3584,22 +3590,22 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (base.P
 		if user != nil {
 			err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SELECT", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
 		}
-		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, resolvedDBName, show.Table.Name.L, "", err)
 		if user != nil {
 			err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW VIEW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
 		}
-		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, resolvedDBName, show.Table.Name.L, "", err)
 	case ast.ShowCreateMaterializedView:
 		var err error
 		user := b.ctx.GetSessionVars().User
 		if user != nil {
 			err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SELECT", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
 		}
-		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, resolvedDBName, show.Table.Name.L, "", err)
 		if user != nil {
 			err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW VIEW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
 		}
-		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, resolvedDBName, show.Table.Name.L, "", err)
 	case ast.ShowBackups:
 		err := plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs("SUPER or BACKUP_ADMIN")
 		b.visitInfo = appendDynamicVisitInfo(b.visitInfo, []string{"BACKUP_ADMIN"}, false, err)

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -542,8 +542,8 @@ func (p *preprocessor) tableByName(tn *ast.TableName) (table.Table, error) {
 	sName := pmodel.NewCIStr(currentDB)
 	is := p.ensureInfoSchema()
 
-	// for 'SHOW CREATE VIEW/SEQUENCE ...' statement, ignore local temporary tables.
-	if p.stmtTp == TypeShow && (p.showTp == ast.ShowCreateView || p.showTp == ast.ShowCreateSequence) {
+	// for 'SHOW CREATE VIEW/MATERIALIZED VIEW/SEQUENCE ...' statement, ignore local temporary tables.
+	if p.stmtTp == TypeShow && (p.showTp == ast.ShowCreateView || p.showTp == ast.ShowCreateMaterializedView || p.showTp == ast.ShowCreateSequence) {
 		is = temptable.DetachLocalTemporaryTableInfoSchema(is)
 	}
 

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -542,8 +542,8 @@ func (p *preprocessor) tableByName(tn *ast.TableName) (table.Table, error) {
 	sName := pmodel.NewCIStr(currentDB)
 	is := p.ensureInfoSchema()
 
-	// for 'SHOW CREATE VIEW/MATERIALIZED VIEW/SEQUENCE ...' statement, ignore local temporary tables.
-	if p.stmtTp == TypeShow && (p.showTp == ast.ShowCreateView || p.showTp == ast.ShowCreateMaterializedView || p.showTp == ast.ShowCreateSequence) {
+	// for 'SHOW CREATE VIEW/MATERIALIZED VIEW/MATERIALIZED VIEW LOG/SEQUENCE ...' statement, ignore local temporary tables.
+	if p.stmtTp == TypeShow && (p.showTp == ast.ShowCreateView || p.showTp == ast.ShowCreateMaterializedView || p.showTp == ast.ShowCreateMaterializedViewLog || p.showTp == ast.ShowCreateSequence) {
 		is = temptable.DetachLocalTemporaryTableInfoSchema(is)
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:

Materialized view users need SHOW CREATE support to inspect MV and MV log definitions in a stable SQL form.

### What changed and how does it work?

This PR adds parser, planner, and executor support for:

- `SHOW CREATE MATERIALIZED VIEW <mv_name>`
- `SHOW CREATE MATERIALIZED VIEW LOG ON <base_table>`

The executor reconstructs the MV definition and MV log definition from table metadata, including column list, comment, refresh or purge schedule, shard row ID bits, pre-split regions, and the original MV query where applicable.

This PR also keeps the SHOW CREATE output replayable by aligning ALTER with the CREATE grammar and execution semantics. ALTER no longer accepts MV refresh or MV log purge metadata states that CREATE cannot replay, including refresh start-only schedules, bare deferred purge, purge start-only schedules, and unsupported purge immediate metadata for MV logs.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Support SHOW CREATE MATERIALIZED VIEW and SHOW CREATE MATERIALIZED VIEW LOG. Restrict ALTER MATERIALIZED VIEW schedule and ALTER MATERIALIZED VIEW LOG purge clauses from creating metadata states that SHOW CREATE cannot replay.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SHOW CREATE MATERIALIZED VIEW and SHOW CREATE MATERIALIZED VIEW LOG ON now return full definitions: column lists, comments, REFRESH/PURGE clauses, shard/presplit settings, AS SELECT, and charset/collation where applicable.

* **Behavior Change**
  * ALTER MATERIALIZED VIEW LOG now rejects PURGE IMMEDIATE (returns an error).

* **Tests**
  * Added tests covering SHOW CREATE outputs, parsing of returned DDL, and related error cases (missing log, invalid PURGE forms).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->