### PR TITLE
test: stabilize flaky TestGlobalMemArbitrator

### DIFF
--- a/pkg/executor/test/memtest/mem_test.go
+++ b/pkg/executor/test/memtest/mem_test.go
@@ -16,6 +16,7 @@ package memtest
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -47,12 +48,33 @@ func TestInsertUpdateTrackerOnCleanUp(t *testing.T) {
 	require.Equal(t, afterConsume, originConsume)
 }
 
+func globalSysVar(t *testing.T, tk *testkit.TestKit, name string) string {
+	t.Helper()
+	return tk.MustQuery("select @@global." + name).Rows()[0][0].(string)
+}
+
+func restoreGlobalSysVar(t *testing.T, tk *testkit.TestKit, name, value string) {
+	t.Helper()
+	tk.MustExec(fmt.Sprintf("set global %s = '%s'", name, strings.ReplaceAll(value, "'", "''")))
+}
+
 func TestGlobalMemArbitrator(t *testing.T) {
 	memory.SetupGlobalMemArbitratorForTest(t.TempDir())
-	defer memory.CleanupGlobalMemArbitratorForTest()
+	t.Cleanup(memory.CleanupGlobalMemArbitratorForTest)
 
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
+
+	originMemArbitratorMode := globalSysVar(t, tk, "tidb_mem_arbitrator_mode")
+	originServerMemoryLimit := globalSysVar(t, tk, "tidb_server_memory_limit")
+	originMemArbitratorSoftLimit := globalSysVar(t, tk, "tidb_mem_arbitrator_soft_limit")
+	originResourceControl := globalSysVar(t, tk, "tidb_enable_resource_control")
+	t.Cleanup(func() {
+		restoreGlobalSysVar(t, tk, "tidb_enable_resource_control", originResourceControl)
+		restoreGlobalSysVar(t, tk, "tidb_mem_arbitrator_soft_limit", originMemArbitratorSoftLimit)
+		restoreGlobalSysVar(t, tk, "tidb_server_memory_limit", originServerMemoryLimit)
+		restoreGlobalSysVar(t, tk, "tidb_mem_arbitrator_mode", originMemArbitratorMode)
+	})
 
 	tk.MustExecToErr("set @@tidb_mem_arbitrator_mode = standard") // only global
 	require.Equal(t, tk.ExecToErr("set global tidb_mem_arbitrator_mode = 1").Error(), "tidb_mem_arbitrator_mode: disable; standard; priority;")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68327

Problem Summary:
`TestGlobalMemArbitrator` can fail with `[tikv:8252]Exceeded resource group quota limitation` while testing memory arbitration.

### What changed and how does it work?

#### Failure evidence

- Build: https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/merged_unit_test/32/
- Failed TiDB revision: `57fb61f655e5aa00f6e541d076e1b86b7ca3ae19`.
- Log: https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/merged_unit_test/32/artifact/bazel-target-output-L2984-4340.log
- The first `rg1` query succeeds and reports `Request_unit_read=466.14210917154946`.
- `rg1` starts with 111 tokens. The subsequent limiter log reports `current-ltb-tokens=-355.14210917154946`, `current-ltb-rate=0`, and `burst=0`.
- After switching the memory arbitrator to priority mode, the second `rg1` query fails at `mem_test.go:168` with error 8252.

#### Root Cause

The test creates non-burstable resource groups with small RU budgets. The mock resource manager's `AcquireTokenBuckets` returns no token grants. A query can consume more than the initial token balance, leaving a later query throttled within the same test.

This evidence does not establish cross-test global-state leakage or a particular RU-model change as the cause.

#### Fix

Add `BURSTABLE` to the three existing resource-group creation statements so RU throttling does not interfere with this memory-arbitration test. Keep the RU values (111/222/333), priorities, resource control, and every original assertion, including priority counters and memory-arbitrator cancellation errors.

Remove the earlier cleanup helpers and global-variable restoration changes from this PR: they do not address the observed within-test token exhaustion. No production code, shared mock, or unrelated test is changed.

#### Verification

Validation profile: Ready. Tested on macOS arm64 with Go 1.25.10, against this PR's base `066d1c458053e58b799f1d63128383fd3f6a1f20` plus the three-line fix:

- PASS: `GOTOOLCHAIN=go1.25.10 go test -tags=intest,deadlock ./pkg/executor/test/memtest -run '^TestGlobalMemArbitrator$' -count=10 -timeout=15m`
- PASS: `GOTOOLCHAIN=go1.25.10 go test -p 2 -race -tags=intest,deadlock ./pkg/executor/test/memtest -run '^TestGlobalMemArbitrator$' -count=3 -timeout=15m`
- PASS: `GOTOOLCHAIN=go1.25.10 go test -tags=intest,deadlock ./pkg/executor/test/memtest -count=1 -timeout=15m`
- PASS: `GOTOOLCHAIN=go1.25.10 make lint`
- PASS: `GOTOOLCHAIN=go1.25.10 make bazel_prepare BAZEL_GLOBAL_CONFIG= BAZEL_CMD_CONFIG=` (local overrides avoid the default Jenkins-only `/home/jenkins` path; no generated metadata changes remain).
- PASS: `git diff --check`; `gofmt -l pkg/executor/test/memtest/mem_test.go` reports no files.

The target package has no `failpoint.` / `testfailpoint.` calls or direct failpoint dependency in `BUILD.bazel`, so these Go test runs did not require source failpoint rewriting.

Limitations: the unmodified base test also passed 10 normal runs and 3 race runs using a Go overlay of the original test file. The original flaky failure was not reproduced locally; the failure evidence above is from Jenkins. These local checks do not reproduce the Linux Bazel CI workload or execute the later failing revision. Race builds emitted a macOS linker warning about `LC_DYSYMTAB` but completed successfully. No full server build was run for this test-only patch.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68327


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated memory management tests to use burstable resource groups.
  * Simplified global resource arbitrator cleanup and test handling for more consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->