### PR TITLE
ttl: stabilize TestRowToTTLTask against task GC race

### DIFF
--- a/pkg/ttl/cache/task_test.go
+++ b/pkg/ttl/cache/task_test.go
@@ -46,6 +46,7 @@ func (tg *taskGetter) mustGetTestTask() *cache.TTLTask {
 	require.NoError(tg.t, err)
 	rows, err := session.GetRows4Test(context.Background(), tg.tk.Session(), rs)
 	require.NoError(tg.t, err)
+	require.Len(tg.t, rows, 1)
 	task, err := cache.RowToTTLTask(tg.tk.Session().GetSessionVars().Location(), rows[0])
 	require.NoError(tg.t, err)
 	return task
@@ -61,6 +62,18 @@ func TestRowToTTLTask(t *testing.T) {
 
 	now := time.Now()
 	now = now.Round(time.Second)
+
+	// Keep a matching running TTL job status to prevent task GC from removing
+	// this test row during the test.
+	_, err := tk.Session().ExecuteInternal(
+		ctx,
+		`INSERT INTO mysql.tidb_ttl_table_status (
+			table_id, parent_table_id, current_job_id,
+			current_job_owner_id, current_job_owner_hb_time, current_job_status
+		) VALUES (%?, %?, %?, %?, %?, %?)`,
+		1, 1, "test-job", "test-owner", now.Add(time.Hour), "running",
+	)
+	require.NoError(t, err)
 
 	sql, args, err := cache.InsertIntoTTLTask(tk.Session().GetSessionVars().Location(), "test-job", 1, 1, nil, nil, now, now)
 	require.NoError(t, err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68657

Problem Summary:

`TestRowToTTLTask` can panic with `index out of range` when background TTL GC removes an orphan `mysql.tidb_ttl_task` row during test execution.

### What changed and how does it work?

- Add a matching `mysql.tidb_ttl_table_status` row before inserting the `test-job` task in `TestRowToTTLTask`, so the task is not GCed as an orphan during the test.
- Add `require.Len(rows, 1)` in `mustGetTestTask` before indexing `rows[0]`, turning panic into an assertion failure if the row is unexpectedly missing.
- Use `ExecuteInternal` for the new status-row insert to align with existing parameter-handling style in this test file.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test setup for TTL task handling to improve test reliability and prevent task cleanup during test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->