### PR TITLE
executor: several refinements for MV refresh

### DIFF
--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -785,8 +785,50 @@ func finalizeMLogPurgeHistWithRetry(
 	return errors.Annotatef(retryErr, "first finalize attempt failed: %v", firstErr)
 }
 
-func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx context.Context, s *ast.RefreshMaterializedViewStmt) error {
+func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx context.Context, s *ast.RefreshMaterializedViewStmt) (err error) {
+	const slowRefreshThreshold = 5 * time.Second
+	refreshStart := time.Now()
+	var (
+		lockRefreshInfoRowDur time.Duration
+		executeDataChangesDur time.Duration
+		txnCommitDur          time.Duration
+		mviewID               int64
+	)
 	isInternalSQL := e.Ctx().GetSessionVars().InRestrictedSQL
+	defer func() {
+		total := time.Since(refreshStart)
+		if total < slowRefreshThreshold {
+			return
+		}
+
+		schemaName, mviewName, refreshType := "", "", ""
+		if s != nil {
+			refreshType = strings.ToLower(s.Type.String())
+			if s.ViewName != nil {
+				schemaName = s.ViewName.Schema.O
+				mviewName = s.ViewName.Name.O
+			}
+		}
+
+		fields := []zap.Field{
+			zap.Duration("total", total),
+			zap.Duration("slowThreshold", slowRefreshThreshold),
+			zap.String("schema", schemaName),
+			zap.String("mview", mviewName),
+			zap.Int64("mviewID", mviewID),
+			zap.String("refreshType", refreshType),
+			zap.Bool("internalSQL", isInternalSQL),
+			zap.Bool("success", err == nil),
+			zap.Duration("lockRefreshInfoRow", lockRefreshInfoRowDur),
+			zap.Duration("executeRefreshMaterializedViewDataChanges", executeDataChangesDur),
+			zap.Duration("transactionCommit", txnCommitDur),
+		}
+		if err != nil {
+			fields = append(fields, zap.String("error", err.Error()))
+		}
+		logutil.BgLogger().Info("refresh materialized view is slow", fields...)
+	}()
+
 	refreshMethod, err := validateRefreshMaterializedViewStmt(s, isInternalSQL)
 	if err != nil {
 		return err
@@ -805,6 +847,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 	defer e.ReleaseSysSession(kctx, refreshSctx)
 	sqlExec := refreshSctx.GetSQLExecutor()
 	sessVars := refreshSctx.GetSessionVars()
+
 	restoreSessVars, err := initRefreshMaterializedViewSession(sessVars, tblInfo.MaterializedView)
 	if err != nil {
 		return err
@@ -823,24 +866,34 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 
 	txnStarted := false
 	txnFinished := false
+	txnCommitTimerStarted := false
+	var txnCommitStart time.Time
 	defer func() {
 		if !txnStarted || txnFinished {
 			return
 		}
 		_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
+		txnFinished = true
+		if txnCommitTimerStarted && txnCommitDur == 0 {
+			txnCommitDur = time.Since(txnCommitStart)
+		}
 	}()
 
 	// Use a pessimistic txn to ensure `FOR UPDATE NOWAIT` works as a mutex.
+	txnCommitStart = time.Now()
 	if _, err := sqlExec.ExecuteInternal(kctx, "BEGIN PESSIMISTIC"); err != nil {
 		return errors.Trace(err)
 	}
 	txnStarted = true
+	txnCommitTimerStarted = true
 
 	failpoint.InjectCall("refreshMaterializedViewAfterBegin")
 	failpoint.Inject("pauseRefreshMaterializedViewAfterBegin", func() {})
 
-	mviewID := tblInfo.ID
+	mviewID = tblInfo.ID
+	lockRefreshInfoRowStart := time.Now()
 	lockedReadTSO, lockedReadTSONull, err := lockRefreshInfoRow(kctx, sqlExec, mviewID)
+	lockRefreshInfoRowDur = time.Since(lockRefreshInfoRowStart)
 	if err != nil {
 		return err
 	}
@@ -874,8 +927,11 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 				refreshErrMsg = refreshErrMsg + "; rollback error: " + err.Error()
 			}
 			txnFinished = true
+			if txnCommitTimerStarted && txnCommitDur == 0 {
+				txnCommitDur = time.Since(txnCommitStart)
+			}
 		}
-		if histErr := finalizeRefreshHistWithRetry(
+		histErr := finalizeRefreshHistWithRetry(
 			finalizeCtx,
 			histSQLExec,
 			refreshJobID,
@@ -883,7 +939,8 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 			refreshHistStatusFailed,
 			nil,
 			&refreshErrMsg,
-		); histErr != nil {
+		)
+		if histErr != nil {
 			if rollbackErr != nil {
 				return errors.Annotatef(histErr, "refresh materialized view: rollback failed (%v) and failed to finalize refresh history after error %v", rollbackErr, refreshErr)
 			}
@@ -907,6 +964,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		lastSuccessfulRefreshReadTSO = lockedReadTSO
 	}
 
+	executeDataChangesStart := time.Now()
 	if err := executeRefreshMaterializedViewDataChanges(
 		kctx,
 		sqlExec,
@@ -916,13 +974,16 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		tblInfo,
 		lastSuccessfulRefreshReadTSO,
 	); err != nil {
+		executeDataChangesDur = time.Since(executeDataChangesStart)
 		return finalizeFailure(err)
 	}
+	executeDataChangesDur = time.Since(executeDataChangesStart)
 
 	refreshReadTSO, err := getRefreshReadTSOForSuccess(sessVars)
 	if err != nil {
 		return finalizeFailure(err)
 	}
+
 	nextTime, shouldUpdateNextTime, err := deriveRuntimeMaterializedScheduleNextTime(
 		kctx,
 		scheduleEvalSctx,
@@ -935,6 +996,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 	if err != nil {
 		return finalizeFailure(err)
 	}
+
 	if err := persistRefreshSuccess(
 		kctx,
 		sqlExec,
@@ -947,10 +1009,15 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 	); err != nil {
 		return finalizeFailure(err)
 	}
+
 	if _, err := sqlExec.ExecuteInternal(kctx, "COMMIT"); err != nil {
 		return finalizeFailure(err)
 	}
 	txnFinished = true
+	if txnCommitTimerStarted && txnCommitDur == 0 {
+		txnCommitDur = time.Since(txnCommitStart)
+	}
+
 	if err := finalizeRefreshHistWithRetry(
 		finalizeCtx,
 		histSQLExec,

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -791,7 +791,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 	var (
 		lockRefreshInfoRowDur time.Duration
 		executeDataChangesDur time.Duration
-		txnCommitDur          time.Duration
+		txnTotalDur          time.Duration
 		mviewID               int64
 	)
 	isInternalSQL := e.Ctx().GetSessionVars().InRestrictedSQL
@@ -821,7 +821,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 			zap.Bool("success", err == nil),
 			zap.Duration("lockRefreshInfoRow", lockRefreshInfoRowDur),
 			zap.Duration("executeRefreshMaterializedViewDataChanges", executeDataChangesDur),
-			zap.Duration("transactionCommit", txnCommitDur),
+			zap.Duration("transactionTotal", txnTotalDur),
 		}
 		if err != nil {
 			fields = append(fields, zap.String("error", err.Error()))
@@ -874,8 +874,8 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		}
 		_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
 		txnFinished = true
-		if txnCommitTimerStarted && txnCommitDur == 0 {
-			txnCommitDur = time.Since(txnCommitStart)
+		if txnCommitTimerStarted && txnTotalDur == 0 {
+			txnTotalDur = time.Since(txnCommitStart)
 		}
 	}()
 
@@ -927,8 +927,8 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 				refreshErrMsg = refreshErrMsg + "; rollback error: " + err.Error()
 			}
 			txnFinished = true
-			if txnCommitTimerStarted && txnCommitDur == 0 {
-				txnCommitDur = time.Since(txnCommitStart)
+			if txnCommitTimerStarted && txnTotalDur == 0 {
+				txnTotalDur = time.Since(txnCommitStart)
 			}
 		}
 		histErr := finalizeRefreshHistWithRetry(
@@ -1014,8 +1014,8 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		return finalizeFailure(err)
 	}
 	txnFinished = true
-	if txnCommitTimerStarted && txnCommitDur == 0 {
-		txnCommitDur = time.Since(txnCommitStart)
+	if txnCommitTimerStarted && txnTotalDur == 0 {
+		txnTotalDur = time.Since(txnCommitStart)
 	}
 
 	if err := finalizeRefreshHistWithRetry(

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -32,6 +32,8 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	plannercore "github.com/pingcap/tidb/pkg/planner/core"
+	plannercorebase "github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	storeerr "github.com/pingcap/tidb/pkg/store/driver/error"
@@ -791,7 +793,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 	var (
 		lockRefreshInfoRowDur time.Duration
 		executeDataChangesDur time.Duration
-		txnTotalDur          time.Duration
+		txnTotalDur           time.Duration
 		mviewID               int64
 	)
 	isInternalSQL := e.Ctx().GetSessionVars().InRestrictedSQL
@@ -938,6 +940,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 			mviewID,
 			refreshHistStatusFailed,
 			nil,
+			nil,
 			&refreshErrMsg,
 		)
 		if histErr != nil {
@@ -984,6 +987,11 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		return finalizeFailure(err)
 	}
 
+	var refreshRows *int64
+	if s.Type == ast.RefreshMaterializedViewTypeFast {
+		refreshRows = collectFastRefreshMLogScanRows(sessVars)
+	}
+
 	nextTime, shouldUpdateNextTime, err := deriveRuntimeMaterializedScheduleNextTime(
 		kctx,
 		scheduleEvalSctx,
@@ -1025,6 +1033,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		mviewID,
 		refreshHistStatusSuccess,
 		&refreshReadTSO,
+		refreshRows,
 		nil,
 	); err != nil {
 		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
@@ -1327,6 +1336,86 @@ func getRefreshReadTSOForSuccess(sessVars *variable.SessionVars) (uint64, error)
 	return refreshReadTSO, nil
 }
 
+func collectFastRefreshMLogScanRows(sessVars *variable.SessionVars) *int64 {
+	if sessVars == nil || sessVars.StmtCtx == nil || sessVars.StmtCtx.RuntimeStatsColl == nil {
+		return nil
+	}
+	mergePlan, ok := sessVars.StmtCtx.GetPlan().(*plannercore.MVDeltaMerge)
+	if !ok || mergePlan.Source == nil || mergePlan.MLogTableID == 0 {
+		return nil
+	}
+
+	scanPlanIDs := make(map[int]struct{})
+	collectMLogScanPlanIDs(mergePlan.Source, mergePlan.MLogTableID, scanPlanIDs)
+	if len(scanPlanIDs) != 1 {
+		return nil
+	}
+
+	runtimeStatsColl := sessVars.StmtCtx.RuntimeStatsColl
+	var totalRows int64
+	hasRuntimeStats := false
+	for scanPlanID := range scanPlanIDs {
+		hasCopStats := runtimeStatsColl.ExistsCopStats(scanPlanID)
+		if !hasCopStats && !runtimeStatsColl.ExistsRootStats(scanPlanID) {
+			continue
+		}
+		hasRuntimeStats = true
+		if hasCopStats {
+			_, copRows := runtimeStatsColl.GetCopCountAndRows(scanPlanID)
+			totalRows += copRows
+			continue
+		}
+		totalRows += runtimeStatsColl.GetPlanActRows(scanPlanID)
+	}
+	if !hasRuntimeStats {
+		return nil
+	}
+	return &totalRows
+}
+
+func collectMLogScanPlanIDs(plan plannercorebase.PhysicalPlan, mlogTableID int64, target map[int]struct{}) {
+	if plan == nil {
+		return
+	}
+	switch p := plan.(type) {
+	case *plannercore.PhysicalTableScan:
+		if p.Table != nil && p.Table.ID == mlogTableID {
+			target[p.ID()] = struct{}{}
+		}
+	case *plannercore.PhysicalIndexScan:
+		if p.Table != nil && p.Table.ID == mlogTableID {
+			target[p.ID()] = struct{}{}
+		}
+	case *plannercore.PhysicalTableReader:
+		for _, child := range p.TablePlans {
+			collectMLogScanPlanIDs(child, mlogTableID, target)
+		}
+	case *plannercore.PhysicalIndexReader:
+		for _, child := range p.IndexPlans {
+			collectMLogScanPlanIDs(child, mlogTableID, target)
+		}
+	case *plannercore.PhysicalIndexLookUpReader:
+		for _, child := range p.IndexPlans {
+			collectMLogScanPlanIDs(child, mlogTableID, target)
+		}
+		for _, child := range p.TablePlans {
+			collectMLogScanPlanIDs(child, mlogTableID, target)
+		}
+	case *plannercore.PhysicalIndexMergeReader:
+		for _, partialPlan := range p.PartialPlans {
+			for _, child := range partialPlan {
+				collectMLogScanPlanIDs(child, mlogTableID, target)
+			}
+		}
+		for _, child := range p.TablePlans {
+			collectMLogScanPlanIDs(child, mlogTableID, target)
+		}
+	}
+	for _, child := range plan.Children() {
+		collectMLogScanPlanIDs(child, mlogTableID, target)
+	}
+}
+
 func deriveRuntimeMaterializedScheduleNextTime(
 	kctx context.Context,
 	evalSctx sessionctx.Context,
@@ -1519,6 +1608,7 @@ func finalizeRefreshHistWithRetry(
 	mviewID int64,
 	refreshStatus string,
 	refreshReadTSO *uint64,
+	refreshRows *int64,
 	refreshFailedReason *string,
 ) error {
 	firstErr := finalizeRefreshHist(
@@ -1528,6 +1618,7 @@ func finalizeRefreshHistWithRetry(
 		mviewID,
 		refreshStatus,
 		refreshReadTSO,
+		refreshRows,
 		refreshFailedReason,
 	)
 	if firstErr == nil {
@@ -1540,6 +1631,7 @@ func finalizeRefreshHistWithRetry(
 		mviewID,
 		refreshStatus,
 		refreshReadTSO,
+		refreshRows,
 		refreshFailedReason,
 	)
 	if retryErr == nil {
@@ -1562,6 +1654,7 @@ func finalizeRefreshHist(
 	mviewID int64,
 	refreshStatus string,
 	refreshReadTSO *uint64,
+	refreshRows *int64,
 	refreshFailedReason *string,
 ) error {
 	failpoint.Inject("mockFinalizeRefreshHistError", func(val failpoint.Value) {
@@ -1574,6 +1667,10 @@ func finalizeRefreshHist(
 	if refreshReadTSO != nil {
 		refreshReadTSOArg = *refreshReadTSO
 	}
+	var refreshRowsArg any
+	if refreshRows != nil {
+		refreshRowsArg = *refreshRows
+	}
 	var refreshFailedReasonArg any
 	if refreshFailedReason != nil {
 		refreshFailedReasonArg = *refreshFailedReason
@@ -1582,6 +1679,7 @@ func finalizeRefreshHist(
 SET
 	REFRESH_ENDTIME = NOW(6),
 	REFRESH_STATUS = %?,
+	REFRESH_ROWS = %?,
 	REFRESH_READ_TSO = %?,
 	REFRESH_FAILED_REASON = %?
 WHERE REFRESH_JOB_ID = %?
@@ -1590,6 +1688,7 @@ WHERE REFRESH_JOB_ID = %?
 		kctx,
 		updateSQL,
 		refreshStatus,
+		refreshRowsArg,
 		refreshReadTSOArg,
 		refreshFailedReasonArg,
 		refreshJobID,

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -78,8 +78,8 @@ func TestMaterializedViewRefreshCompleteBasic(t *testing.T) {
 		Check(testkit.Rows("1"))
 	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d", mviewID)).
 		Check(testkit.Rows("1"))
-	tk.MustQuery(fmt.Sprintf("select REFRESH_STATUS, REFRESH_METHOD, REFRESH_ENDTIME is not null, REFRESH_READ_TSO > 0, REFRESH_FAILED_REASON is null from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d", mviewID)).
-		Check(testkit.Rows("success complete manually 1 1 1"))
+	tk.MustQuery(fmt.Sprintf("select REFRESH_STATUS, REFRESH_METHOD, REFRESH_ENDTIME is not null, REFRESH_ROWS is null, REFRESH_READ_TSO > 0, REFRESH_FAILED_REASON is null from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d", mviewID)).
+		Check(testkit.Rows("success complete manually 1 1 1 1"))
 }
 
 func TestMaterializedViewRefreshNextTimeOnlyUpdatesForInternalSQL(t *testing.T) {
@@ -171,14 +171,14 @@ func TestMaterializedViewRefreshFastMethodTracksManualAndAutomatic(t *testing.T)
 	tk.MustExec("insert into t values (2, 3), (3, 4)")
 	tk.MustExec("refresh materialized view mv fast")
 	tk.MustQuery("select a, s, cnt from mv order by a").Check(testkit.Rows("1 15 2", "2 10 2", "3 4 1"))
-	tk.MustQuery("select REFRESH_METHOD from mysql.tidb_mview_refresh_hist order by REFRESH_JOB_ID desc limit 1").
-		Check(testkit.Rows("fast manually"))
+	tk.MustQuery("select REFRESH_METHOD, REFRESH_ROWS > 0 from mysql.tidb_mview_refresh_hist order by REFRESH_JOB_ID desc limit 1").
+		Check(testkit.Rows("fast manually 1"))
 
 	tk.MustExec("insert into t values (4, 8)")
 	mustExecInternal(t, tk, "refresh materialized view mv fast")
 	tk.MustQuery("select a, s, cnt from mv order by a").Check(testkit.Rows("1 15 2", "2 10 2", "3 4 1", "4 8 1"))
-	tk.MustQuery("select REFRESH_METHOD from mysql.tidb_mview_refresh_hist order by REFRESH_JOB_ID desc limit 1").
-		Check(testkit.Rows("fast automatically"))
+	tk.MustQuery("select REFRESH_METHOD, REFRESH_ROWS > 0 from mysql.tidb_mview_refresh_hist order by REFRESH_JOB_ID desc limit 1").
+		Check(testkit.Rows("fast automatically 1"))
 }
 */
 

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -158,7 +158,6 @@ func TestMaterializedViewRefreshInternalSQLStartWithNoNextSetsNextTimeNull(t *te
 	)).Check(testkit.Rows("complete automatically"))
 }
 
-/*
 func TestMaterializedViewRefreshFastMethodTracksManualAndAutomatic(t *testing.T) {
 	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
@@ -180,7 +179,6 @@ func TestMaterializedViewRefreshFastMethodTracksManualAndAutomatic(t *testing.T)
 	tk.MustQuery("select REFRESH_METHOD, REFRESH_ROWS > 0 from mysql.tidb_mview_refresh_hist order by REFRESH_JOB_ID desc limit 1").
 		Check(testkit.Rows("fast automatically 1"))
 }
-*/
 
 func TestMaterializedViewRefreshFastMinMax(t *testing.T) {
 	store, _ := testkit.CreateMockStoreAndDomain(t)

--- a/tests/integrationtest/r/executor/mview_refresh.result
+++ b/tests/integrationtest/r/executor/mview_refresh.result
@@ -2,7 +2,7 @@ use test;
 create table t_mv_txn_66385 (a int not null, b int not null);
 insert into t_mv_txn_66385 values (1, 10), (1, 5), (2, 7);
 create materialized view log on t_mv_txn_66385 (a, b) purge next date_add(now(), interval 1 hour);
-create materialized view mv_txn_66385 (a, s, cnt) refresh fast next now() as
+create materialized view mv_txn_66385 (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as
 select a, sum(b), count(1) from t_mv_txn_66385 group by a;
 begin;
 refresh materialized view mv_txn_66385 complete;

--- a/tests/integrationtest/t/executor/mview_refresh.test
+++ b/tests/integrationtest/t/executor/mview_refresh.test
@@ -5,7 +5,7 @@ use test;
 create table t_mv_txn_66385 (a int not null, b int not null);
 insert into t_mv_txn_66385 values (1, 10), (1, 5), (2, 7);
 create materialized view log on t_mv_txn_66385 (a, b) purge next date_add(now(), interval 1 hour);
-create materialized view mv_txn_66385 (a, s, cnt) refresh fast next now() as
+create materialized view mv_txn_66385 (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as
 select a, sum(b), count(1) from t_mv_txn_66385 group by a;
 
 begin;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:

Materialized view refresh needs better observability for diagnosing slow refresh jobs and understanding refresh work volume.

### What changed and how does it work?

This PR includes several refinements for materialized view refresh observability:

- Log key timing stages when materialized view refresh is slow, so slow refresh jobs can be diagnosed from TiDB logs.
- Fill the materialized view implementation SQL text into slow logs when the original SQL text is empty, so refresh slow logs remain actionable.
- Record fast-refresh mlog scan rows into materialized view refresh history, so users can inspect the refresh input row volume.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Improve materialized view refresh observability by logging key timings for slow refresh jobs, preserving refresh SQL text in slow logs, and recording fast-refresh mlog scan rows in refresh history.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refresh history now records the number of rows processed for materialized view refreshes, including counts derived for fast refreshes.

* **Bug Fixes**
  * Improved slow-refresh diagnostics with finer timing breakdowns.
  * Added a fallback to restore SQL text for slow-log output when original SQL is unavailable.

* **Tests**
  * Added unit tests for the SQL restore fallback, re-enabled and updated materialized-view refresh tests, and adjusted an integration test expectation for refresh scheduling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->