### PR TITLE
dxf: batch cancel pending/running subtasks in CancelSubtask

### DIFF
--- a/pkg/dxf/framework/storage/subtask_state.go
+++ b/pkg/dxf/framework/storage/subtask_state.go
@@ -99,8 +99,7 @@ func (mgr *TaskManager) CancelSubtask(ctx context.Context, execID string, taskID
 		end_time = CURRENT_TIMESTAMP()
 		where exec_id = %? and
 		task_key = %? and
-		state in (%?, %?)
-		limit 1;`,
+		state in (%?, %?);`,
 		proto.SubtaskStateCanceled,
 		execID,
 		taskID,

--- a/pkg/dxf/framework/storage/table_test.go
+++ b/pkg/dxf/framework/storage/table_test.go
@@ -1411,6 +1411,17 @@ func TestSubtasksState(t *testing.T) {
 	endTime, err = testutil.GetSubtaskEndTime(ctx, sm, subtask.ID)
 	require.NoError(t, err)
 	require.Greater(t, endTime, ts)
+
+	// 4. CancelSubtask should cancel all pending/running subtasks for one exec/task.
+	subtaskID1 := testutil.CreateSubTask(t, sm, 5, proto.StepInit, "for_test_multi", []byte("test"), proto.TaskTypeExample, 11)
+	testutil.CreateSubTask(t, sm, 5, proto.StepInit, "for_test_multi", []byte("test"), proto.TaskTypeExample, 11)
+	require.NoError(t, sm.StartSubtask(ctx, subtaskID1, "for_test_multi"))
+	require.NoError(t, sm.CancelSubtask(ctx, "for_test_multi", 5))
+	cntByStates, err := sm.GetSubtaskCntGroupByStates(ctx, 5, proto.StepInit)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), cntByStates[proto.SubtaskStateCanceled])
+	require.Equal(t, int64(0), cntByStates[proto.SubtaskStatePending])
+	require.Equal(t, int64(0), cntByStates[proto.SubtaskStateRunning])
 }
 
 func checkBasicTaskEq(t *testing.T, expectedTask, task *proto.TaskBase) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68717

Problem Summary:

`CANCEL IMPORT JOB` can take more than one minute in the revert path when many pending/running subtasks are assigned to one executor, which is more obvious in NextGen clusters with on-demand scale-out. The current implementation cancels only one subtask row per manager loop iteration.

### What changed and how does it work?

- Remove `LIMIT 1` from `CancelSubtask` in DXF storage so one call cancels all matching pending/running subtasks for the same `exec_id` and `task_key`.
- Add regression coverage in `TestSubtasksState` to ensure one `CancelSubtask` call cancels multiple subtasks for the same executor/task.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Speed up `CANCEL IMPORT JOB` by canceling all matching pending/running distributed subtasks in one update, reducing long cancellation delays when many subtasks are assigned to one executor.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified subtask cancellation behavior to cancel all pending and running subtasks for a task execution, rather than limiting to a single subtask.

* **Tests**
  * Added test coverage verifying that canceling a task execution cancels all associated pending and running subtasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->