### PR TITLE
executor, mvservice: use unsigned TSO for materialized view metadata

### DIFF
--- a/docs/note/materialized_view/mv_refresh.md
+++ b/docs/note/materialized_view/mv_refresh.md
@@ -266,7 +266,7 @@ Core execution semantics:
 - `FAST` uses internal-only statement `RefreshMaterializedViewImplementStmt` and a dedicated incremental merge plan.
 - For `FAST`, executor constructs `RefreshMaterializedViewImplementStmt` with:
   - original `RefreshMaterializedViewStmt` (must be `Type=FAST`)
-  - `LAST_SUCCESS_READ_TSO` value (must be non-`NULL` int64)
+  - `LAST_SUCCESS_READ_TSO` value (must be non-`NULL` unsigned TSO)
 - `FAST` execution goes through `ExecuteInternalStmt(ctx, stmtNode)`.
 - If `ExecuteInternalStmt` returns non-nil `RecordSet`, refresh drains it before `Close()` to guarantee full executor-tree execution.
 - `RefreshMaterializedViewStmt` is a normal `StmtNode` with no DDL-statement semantics

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -409,14 +409,9 @@ func calcMaterializedViewLogSafePurgeTSO(
 		}
 
 		if len(minRows) > 0 && !minRows[0].IsNull(0) {
-			v := minRows[0].GetInt64(0)
-			if v <= 0 {
-				safePurgeTSO = 0
-			} else {
-				safePurgeTSO = uint64(v)
-				if safePurgeTSO > purgeStartTS {
-					safePurgeTSO = purgeStartTS
-				}
+			safePurgeTSO = minRows[0].GetUint64(0)
+			if safePurgeTSO > purgeStartTS {
+				safePurgeTSO = purgeStartTS
 			}
 		}
 	}
@@ -520,11 +515,7 @@ func acquireMaterializedViewLogPurgeLock(
 	if rows[0].IsNull(0) {
 		return 0, false, nil
 	}
-	v := rows[0].GetInt64(0)
-	if v < 0 {
-		return 0, false, errors.Errorf("invalid LAST_PURGED_TSO %d for mlog id %d", v, mlogID)
-	}
-	return uint64(v), true, nil
+	return rows[0].GetUint64(0), true, nil
 }
 
 func isMLogPurgeLockConflict(err error) bool {
@@ -958,9 +949,9 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 	failpoint.InjectCall("refreshMaterializedViewAfterInsertRefreshHistRunning")
 	failpoint.Inject("pauseRefreshMaterializedViewAfterInsertRefreshHistRunning", func() {})
 
-	var lastSuccessfulRefreshReadTSO int64
+	var lastSuccessfulRefreshReadTSO uint64
 	if s.Type == ast.RefreshMaterializedViewTypeFast {
-		// LAST_SUCCESS_READ_TSO is BIGINT DEFAULT NULL. FAST refresh requires it to be non-NULL.
+		// LAST_SUCCESS_READ_TSO is BIGINT UNSIGNED DEFAULT NULL. FAST refresh requires it to be non-NULL.
 		if lockedReadTSONull {
 			return finalizeFailure(errors.New("refresh materialized view fast: LAST_SUCCESS_READ_TSO is NULL"))
 		}
@@ -1155,7 +1146,7 @@ func lockRefreshInfoRow(
 	kctx context.Context,
 	sqlExec sqlexec.SQLExecutor,
 	mviewID int64,
-) (lockedReadTSO int64, lockedReadTSONull bool, err error) {
+) (lockedReadTSO uint64, lockedReadTSONull bool, err error) {
 	lockRS, err := sqlExec.ExecuteInternal(
 		kctx,
 		// Also select LAST_SUCCESS_READ_TSO so FAST refresh can reuse this mutex/metadata load path.
@@ -1186,7 +1177,7 @@ func lockRefreshInfoRow(
 	lockedRow := lockRows[0]
 	lockedReadTSONull = lockedRow.IsNull(1)
 	if !lockedReadTSONull {
-		lockedReadTSO = lockedRow.GetInt64(1)
+		lockedReadTSO = lockedRow.GetUint64(1)
 	}
 	return lockedReadTSO, lockedReadTSONull, nil
 }
@@ -1195,7 +1186,7 @@ func readRefreshInfoReadTSO(
 	kctx context.Context,
 	sqlExec sqlexec.SQLExecutor,
 	mviewID int64,
-) (readTSO int64, readTSONull bool, err error) {
+) (readTSO uint64, readTSONull bool, err error) {
 	recheckRS, err := sqlExec.ExecuteInternal(
 		kctx,
 		"SELECT LAST_SUCCESS_READ_TSO FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID = %?",
@@ -1224,7 +1215,7 @@ func readRefreshInfoReadTSO(
 	recheckRow := recheckRows[0]
 	readTSONull = recheckRow.IsNull(0)
 	if !readTSONull {
-		readTSO = recheckRow.GetInt64(0)
+		readTSO = recheckRow.GetUint64(0)
 	}
 	return readTSO, readTSONull, nil
 }
@@ -1236,7 +1227,7 @@ func executeRefreshMaterializedViewDataChanges(
 	s *ast.RefreshMaterializedViewStmt,
 	schemaName pmodel.CIStr,
 	tblInfo *model.TableInfo,
-	lastSuccessfulRefreshReadTSO int64,
+	lastSuccessfulRefreshReadTSO uint64,
 ) error {
 	// TiFlash read is blocked for write statements when sql_mode is strict. Refresh prefers TiFlash for the
 	// scan part, so we bypass this guard for MV maintenance statements.
@@ -1521,7 +1512,7 @@ func persistRefreshSuccess(
 	kctx context.Context,
 	sqlExec sqlexec.SQLExecutor,
 	mviewID int64,
-	lockedReadTSO int64,
+	lockedReadTSO uint64,
 	lockedReadTSONull bool,
 	refreshReadTSO uint64,
 	nextTime *string,
@@ -1560,7 +1551,7 @@ WHERE MVIEW_ID = %%? AND LAST_SUCCESS_READ_TSO <=> %%?`,
 	if err != nil {
 		return err
 	}
-	if persistedReadTSONull || persistedReadTSO < 0 || uint64(persistedReadTSO) != refreshReadTSO {
+	if persistedReadTSONull || persistedReadTSO != refreshReadTSO {
 		return errors.New("refresh materialized view: inconsistent LAST_SUCCESS_READ_TSO after success update")
 	}
 	return nil

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -397,7 +397,7 @@ func calcMaterializedViewLogSafePurgeTSO(
 	}
 	if len(allIDs) > 0 {
 		minSQL := fmt.Sprintf(
-			"SELECT MIN(COALESCE(LAST_SUCCESS_READ_TSO, 0)) FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID IN (%s)",
+			"SELECT MIN(COALESCE(LAST_SUCCESS_READ_TSO, CAST(0 AS UNSIGNED))) FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID IN (%s)",
 			buildINList(allIDs),
 		)
 		minRows, err := sqlexec.ExecSQL(kctx, sqlExec, minSQL)

--- a/pkg/meta/model/column.go
+++ b/pkg/meta/model/column.go
@@ -321,6 +321,7 @@ func NewExtraCommitTSColInfo() *ColumnInfo {
 		Name: ExtraCommitTSName,
 	}
 	colInfo.SetType(mysql.TypeLonglong)
+	colInfo.SetFlag(mysql.UnsignedFlag)
 	flen, decimal := mysql.GetDefaultFieldLengthAndDecimal(mysql.TypeLonglong)
 	colInfo.SetFlen(flen)
 	colInfo.SetDecimal(decimal)

--- a/pkg/meta/model/column_test.go
+++ b/pkg/meta/model/column_test.go
@@ -103,4 +103,8 @@ func TestDefaultValue(t *testing.T) {
 	extraPhysTblIDCol := NewExtraPhysTblIDColInfo()
 	require.Equal(t, mysql.NotNullFlag, extraPhysTblIDCol.GetFlag())
 	require.Equal(t, mysql.TypeLonglong, extraPhysTblIDCol.GetType())
+
+	extraCommitTSCol := NewExtraCommitTSColInfo()
+	require.True(t, mysql.HasUnsignedFlag(extraCommitTSCol.GetFlag()))
+	require.Equal(t, mysql.TypeLonglong, extraCommitTSCol.GetType())
 }

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -437,9 +437,9 @@ func (*serviceHelper) loadAllTiDBMVRefresh(ctx context.Context, sysSessionPool b
 		var lastSuccessReadTSO uint64
 		var lastSuccessTime time.Time
 		if !row.IsNull(2) {
-			tso := row.GetInt64(2)
+			tso := row.GetUint64(2)
 			if tso > 0 {
-				lastSuccessReadTSO = uint64(tso)
+				lastSuccessReadTSO = tso
 				lastSuccessTime = mvsUnixMilli(oracle.ExtractPhysical(lastSuccessReadTSO))
 			}
 		}

--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -530,7 +530,7 @@ type RefreshMaterializedViewImplementStmt struct {
 	stmtNode
 
 	RefreshStmt                  *RefreshMaterializedViewStmt
-	LastSuccessfulRefreshReadTSO int64
+	LastSuccessfulRefreshReadTSO uint64
 }
 
 // Restore implements Node interface.
@@ -543,7 +543,7 @@ func (n *RefreshMaterializedViewImplementStmt) Restore(ctx *format.RestoreCtx) e
 		return errors.Annotate(err, "An error occurred while restore RefreshMaterializedViewImplementStmt.RefreshStmt")
 	}
 	ctx.WriteKeyWord(" USING TIMESTAMP ")
-	ctx.WritePlain(strconv.FormatInt(n.LastSuccessfulRefreshReadTSO, 10))
+	ctx.WritePlain(strconv.FormatUint(n.LastSuccessfulRefreshReadTSO, 10))
 	return nil
 }
 

--- a/pkg/planner/core/operator/logicalop/logical_datasource.go
+++ b/pkg/planner/core/operator/logicalop/logical_datasource.go
@@ -633,7 +633,7 @@ func (ds *DataSource) NewExtraHandleSchemaCol() *expression.Column {
 
 // NewExtraCommitTSSchemaCol creates a new column for extra commit ts.
 func (ds *DataSource) NewExtraCommitTSSchemaCol() *expression.Column {
-	tp := types.NewFieldType(mysql.TypeLonglong)
+	tp := model.NewExtraCommitTSColInfo().FieldType.Clone()
 	return &expression.Column{
 		RetType:  tp,
 		UniqueID: ds.SCtx().GetSessionVars().AllocPlanColumnID(),

--- a/pkg/planner/core/operator/logicalop/logicalop_test/BUILD.bazel
+++ b/pkg/planner/core/operator/logicalop/logicalop_test/BUILD.bazel
@@ -11,11 +11,12 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         "//pkg/domain",
         "//pkg/expression",
         "//pkg/expression/aggregation",
+        "//pkg/meta/model",
         "//pkg/parser",
         "//pkg/parser/ast",
         "//pkg/parser/model",

--- a/pkg/planner/core/operator/logicalop/logicalop_test/logical_operator_test.go
+++ b/pkg/planner/core/operator/logicalop/logicalop_test/logical_operator_test.go
@@ -18,7 +18,9 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/expression"
+	metamodel "github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
@@ -68,6 +70,23 @@ func TestLogicalSchemaClone(t *testing.T) {
 	// the column slice inside schema will grow at both case.
 	require.Equal(t, cloneSp.Schema().Len(), 2)
 	require.Equal(t, sp.Schema().Len(), 2)
+}
+
+func TestNewExtraCommitTSSchemaColType(t *testing.T) {
+	ctx := mock.NewContext()
+	ds := &logicalop.DataSource{
+		DBName: model.NewCIStr("test"),
+		TableInfo: &metamodel.TableInfo{
+			Name: model.NewCIStr("t"),
+		},
+	}
+	ds.LogicalSchemaProducer = logicalop.LogicalSchemaProducer{
+		BaseLogicalPlan: logicalop.NewBaseLogicalPlan(ctx, "DataSource", ds, 0),
+	}
+
+	col := ds.NewExtraCommitTSSchemaCol()
+	require.Equal(t, mysql.TypeLonglong, col.RetType.GetType())
+	require.True(t, mysql.HasUnsignedFlag(col.RetType.GetFlag()))
 }
 
 func TestLogicalApplyClone(t *testing.T) {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3880,10 +3880,7 @@ func (b *PlanBuilder) buildRefreshMaterializedViewImplement(ctx context.Context,
 		return nil, errors.New("RefreshMaterializedViewImplementStmt: invalid transaction")
 	}
 
-	if stmt.LastSuccessfulRefreshReadTSO < 0 {
-		return nil, errors.Errorf("RefreshMaterializedViewImplementStmt: invalid LastSuccessfulRefreshReadTSO %d", stmt.LastSuccessfulRefreshReadTSO)
-	}
-	fromTS := uint64(stmt.LastSuccessfulRefreshReadTSO)
+	fromTS := stmt.LastSuccessfulRefreshReadTSO
 
 	optimizeSelect := func(optCtx context.Context, sel *ast.SelectStmt) (base.PhysicalPlan, error) {
 		nodeW := resolve.NewNodeW(sel)

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -765,7 +765,7 @@ const (
 	// CreateTiDBMViewRefreshInfoTable is a table to store current refresh scheduling info for each materialized view.
 	CreateTiDBMViewRefreshInfoTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mview_refresh_info (
 		MVIEW_ID bigint NOT NULL,
-		LAST_SUCCESS_READ_TSO bigint DEFAULT NULL,
+		LAST_SUCCESS_READ_TSO bigint unsigned DEFAULT NULL,
 		NEXT_TIME datetime DEFAULT NULL,
 		PRIMARY KEY(MVIEW_ID))`
 
@@ -773,25 +773,25 @@ const (
 	CreateTiDBMLogPurgeInfoTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mlog_purge_info (
 		MLOG_ID bigint NOT NULL,
 		NEXT_TIME datetime DEFAULT NULL,
-		LAST_PURGED_TSO bigint DEFAULT NULL,
+		LAST_PURGED_TSO bigint unsigned DEFAULT NULL,
 		PRIMARY KEY(MLOG_ID))`
 
 	// CreateTiDBMViewRefreshHistTable is a table to store mview refresh history.
 	CreateTiDBMViewRefreshHistTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mview_refresh_hist (
-		REFRESH_JOB_ID bigint NOT NULL,
+		REFRESH_JOB_ID bigint unsigned NOT NULL,
 		MVIEW_ID bigint NOT NULL,
 		REFRESH_METHOD varchar(32) NOT NULL,
 		REFRESH_TIME datetime(6) DEFAULT NULL,
 		REFRESH_ENDTIME datetime(6) DEFAULT NULL,
 		REFRESH_STATUS varchar(16) DEFAULT NULL,
 		REFRESH_ROWS bigint DEFAULT NULL,
-		REFRESH_READ_TSO bigint DEFAULT NULL,
+		REFRESH_READ_TSO bigint unsigned DEFAULT NULL,
 		REFRESH_FAILED_REASON text DEFAULT NULL,
 		PRIMARY KEY(REFRESH_JOB_ID))`
 
 	// CreateTiDBMLogPurgeHistTable is a table to store mlog purge history.
 	CreateTiDBMLogPurgeHistTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mlog_purge_hist (
-		PURGE_JOB_ID bigint NOT NULL,
+		PURGE_JOB_ID bigint unsigned NOT NULL,
 		MLOG_ID bigint NOT NULL,
 		PURGE_METHOD varchar(32) NOT NULL,
 		PURGE_TIME datetime(6) DEFAULT NULL,

--- a/pkg/session/bootstraptest/mview_systable_test.go
+++ b/pkg/session/bootstraptest/mview_systable_test.go
@@ -42,21 +42,27 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_info' and index_name='PRIMARY' order by seq_in_index").
 		Check(testkit.Rows("mlog_id"))
-	tk.MustQuery("select count(*) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_info' and column_name='LAST_PURGED_TSO' and lower(data_type)='bigint' and column_default is null").
-		Check(testkit.Rows("1"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_info' and column_name='LAST_SUCCESS_READ_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_info' and column_name='LAST_PURGED_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
 
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='PRIMARY' order by seq_in_index").
 		Check(testkit.Rows("refresh_job_id"))
 	tk.MustQuery("select lower(column_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' order by ordinal_position limit 1").
 		Check(testkit.Rows("refresh_job_id"))
-	tk.MustQuery("select lower(data_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_JOB_ID'").
-		Check(testkit.Rows("bigint"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_JOB_ID'").
+		Check(testkit.Rows("bigint(20) unsigned"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_READ_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
 	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name in ('REFRESH_TIME', 'REFRESH_ENDTIME') order by column_name").
 		Check(testkit.Rows("6", "6"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='PRIMARY' order by seq_in_index").
 		Check(testkit.Rows("purge_job_id"))
 	tk.MustQuery("select lower(column_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' order by ordinal_position limit 1").
 		Check(testkit.Rows("purge_job_id"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='PURGE_JOB_ID'").
+		Check(testkit.Rows("bigint(20) unsigned"))
 	tk.MustQuery("select count(*) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='PURGE_FAILED_REASON' and lower(data_type)='text'").
 		Check(testkit.Rows("1"))
 	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name in ('PURGE_TIME', 'PURGE_ENDTIME') order by column_name").
@@ -99,8 +105,16 @@ func TestUpgradeToVer221MaterializedViewSystemTables(t *testing.T) {
 	} {
 		tk.MustQuery("select count(*) from information_schema.tables where table_schema='mysql' and table_name='" + tbl + "'").Check(testkit.Rows("1"))
 	}
-	tk.MustQuery("select count(*) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_info' and column_name='LAST_PURGED_TSO' and lower(data_type)='bigint' and column_default is null").
-		Check(testkit.Rows("1"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_info' and column_name='LAST_SUCCESS_READ_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_info' and column_name='LAST_PURGED_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_JOB_ID'").
+		Check(testkit.Rows("bigint(20) unsigned"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_READ_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='PURGE_JOB_ID'").
+		Check(testkit.Rows("bigint(20) unsigned"))
 	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name in ('REFRESH_TIME', 'REFRESH_ENDTIME') order by column_name").
 		Check(testkit.Rows("6", "6"))
 	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name in ('PURGE_TIME', 'PURGE_ENDTIME') order by column_name").

--- a/pkg/util/rowcodec/decoder.go
+++ b/pkg/util/rowcodec/decoder.go
@@ -231,7 +231,7 @@ func (decoder *ChunkDecoder) decodeToChunk(rowData []byte, commitTS uint64, hand
 		}
 		if col.ID == model.ExtraCommitTSID {
 			if withCommitTS {
-				chk.AppendInt64(colIdx, int64(commitTS))
+				chk.AppendUint64(colIdx, commitTS)
 			} else {
 				chk.AppendNull(colIdx)
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

Materialized view system tables store TSO values and TSO-derived job IDs as signed BIGINT columns. This is inconsistent with TiDB TSO and `_tidb_commit_ts` semantics, which should be handled as unsigned 64-bit values.

### What changed and how does it work?

- Change MV refresh/purge system table TSO columns and TSO-derived job ID columns to `BIGINT UNSIGNED`.
- Use `uint64` / `GetUint64` / `FormatUint` for MV refresh and purge TSO plumbing.
- Cast the `COALESCE` fallback to unsigned when calculating MV log safe purge TSO.
- Update bootstrap tests and related expectations for unsigned MV system table columns.
- Update MV docs for the unsigned TSO representation.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Not run locally in this round.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Use unsigned BIGINT for materialized view system table TSO columns and TSO-derived job ID columns.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated materialized view refresh design notes: FAST refresh now described as operational within the shared transactional framework and documents its user-visible limitation and usage constraints.

* **Bug Fixes**
  * Standardized TSO/timestamp handling across materialized view components to use unsigned 64-bit values for consistency and correctness.

* **Tests**
  * Added and updated tests validating timestamp column types and materialized-view system table schema.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->