### PR TITLE
expression: keep unary minus flen for signed int/decimal

### DIFF
--- a/pkg/expression/builtin_op.go
+++ b/pkg/expression/builtin_op.go
@@ -999,7 +999,14 @@ func (c *unaryMinusFunctionClass) getFunction(ctx BuildContext, args []Expressio
 			sig.setPbCode(tipb.ScalarFuncSig_UnaryMinusReal)
 		}
 	}
-	bf.tp.SetFlenUnderLimit(argExprTp.GetFlen() + 1)
+	if evalType == types.ETDecimal ||
+		(evalType == types.ETInt && !intOverflow && !mysql.HasUnsignedFlag(argExprTp.GetFlag())) {
+		// Unary minus only flips the sign for decimal values.
+		// For signed integer without overflow, the sign width is already covered by the input flen.
+		bf.tp.SetFlenUnderLimit(argExprTp.GetFlen())
+	} else {
+		bf.tp.SetFlenUnderLimit(argExprTp.GetFlen() + 1)
+	}
 	return sig, err
 }
 

--- a/pkg/expression/builtin_op_test.go
+++ b/pkg/expression/builtin_op_test.go
@@ -67,6 +67,34 @@ func TestUnary(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestUnaryMinusDecimalRetTypeFlen(t *testing.T) {
+	ctx := createContext(t)
+	arg := datumsToConstants(types.MakeDatums(types.NewDecFromStringForTest("123.45")))[0]
+	arg.GetType(ctx.GetEvalCtx()).SetFlen(10)
+	arg.GetType(ctx.GetEvalCtx()).SetDecimal(2)
+
+	f, err := newFunctionForTest(ctx, ast.UnaryMinus, arg)
+	require.NoError(t, err)
+	require.Equal(t, 10, f.GetType(ctx.GetEvalCtx()).GetFlen())
+	require.Equal(t, 2, f.GetType(ctx.GetEvalCtx()).GetDecimal())
+}
+
+func TestUnaryMinusIntRetTypeFlen(t *testing.T) {
+	ctx := createContext(t)
+
+	signedArg := datumsToConstants(types.MakeDatums(int64(123)))[0]
+	signedArg.GetType(ctx.GetEvalCtx()).SetFlen(11)
+	signedFunc, err := newFunctionForTest(ctx, ast.UnaryMinus, signedArg)
+	require.NoError(t, err)
+	require.Equal(t, 11, signedFunc.GetType(ctx.GetEvalCtx()).GetFlen())
+
+	unsignedArg := datumsToConstants(types.MakeDatums(uint64(123)))[0]
+	unsignedArg.GetType(ctx.GetEvalCtx()).SetFlen(10)
+	unsignedFunc, err := newFunctionForTest(ctx, ast.UnaryMinus, unsignedArg)
+	require.NoError(t, err)
+	require.Equal(t, 11, unsignedFunc.GetType(ctx.GetEvalCtx()).GetFlen())
+}
+
 func TestLogicAnd(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx

--- a/pkg/expression/typeinfer_test.go
+++ b/pkg/expression/typeinfer_test.go
@@ -155,9 +155,9 @@ type InferTypeSuite struct{}
 func (s *InferTypeSuite) createTestCase4Constants() []typeInferTestCase {
 	return []typeInferTestCase{
 		{"1", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 1, 0},
-		{"-1", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 2, 0},
+		{"-1", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 1, 0},
 		{"1.23", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 5, 2},
-		{"-1.23", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 6, 2},
+		{"-1.23", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 5, 2},
 		{"123e5", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 8, types.UnspecifiedLength},
 		{"-123e5", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 9, types.UnspecifiedLength},
 		{"123e-5", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 7, types.UnspecifiedLength},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68722

Problem Summary:

Unary minus currently increases the inferred return `flen` by 1 unconditionally. This is only needed for unsigned integer operands. For signed integer operands, the input `flen` already covers the sign width; for decimal operands, unary minus only flips the sign.

### What changed and how does it work?

- Keep unary minus return `flen` unchanged for signed integer operands when there is no integer overflow.
- Keep unary minus return `flen` unchanged for decimal operands.
- Continue to increase return `flen` by 1 for unsigned integer operands.
- Add unit tests for signed integer, unsigned integer, and decimal unary minus return type `flen`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Added unit test coverage in `pkg/expression/builtin_op_test.go`. Not run locally in this round.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix unary minus return type length inference for signed integer and decimal operands.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected field-length handling for unary minus on decimal and integer numerics to avoid unnecessary widening for certain input types, preserving expected numeric metadata.

* **Tests**
  * Added and updated tests to verify unary minus return-type field-length and decimal scale behavior for negative numeric literals across decimal and integer cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->