### PR TITLE
planner: some optimizer enhancements for FTS queries | tidb-test=release-fts-202602 tiflash=release-fts-202602 tikv=release-fts-202602

### DIFF
--- a/pkg/expression/fts_to_like.go
+++ b/pkg/expression/fts_to_like.go
@@ -24,8 +24,8 @@ import (
 )
 
 // ftsSearchTerm represents a single token in a boolean-mode FTS search string
-// surviving the strict-subset validator: a plain alphanumeric word optionally
-// prefixed with `+` (required) or `-` (excluded).
+// surviving the strict-subset validator: a plain alphanumeric word, optionally
+// quoted and optionally prefixed with `+` (required) or `-` (excluded).
 type ftsSearchTerm struct {
 	word       string
 	isRequired bool
@@ -35,14 +35,19 @@ type ftsSearchTerm struct {
 // parseFTSBooleanSearchString splits a boolean-mode search string into terms.
 // Inputs reach this function only after ValidateFTSSearchStringForLikeFallback
 // has accepted them, so every whitespace-separated field is either a bare
-// alphanumeric word or `+word`/`-word`.
+// alphanumeric word or `+word`/`-word`, with an optional pair of double quotes
+// around the word body.
 func parseFTSBooleanSearchString(text string) []ftsSearchTerm {
-	fields := strings.Fields(text)
-	if len(fields) == 0 {
+	tokens, err := normalizeFTSSearchStringForLikeFallback(text, ast.FulltextSearchModifierBooleanMode)
+	if err != nil || len(tokens) == 0 {
 		return nil
 	}
-	terms := make([]ftsSearchTerm, 0, len(fields))
-	for _, w := range fields {
+	return parseFTSBooleanSearchTokens(tokens)
+}
+
+func parseFTSBooleanSearchTokens(tokens []string) []ftsSearchTerm {
+	terms := make([]ftsSearchTerm, 0, len(tokens))
+	for _, w := range tokens {
 		terms = append(terms, parseFTSSearchTerm(w))
 	}
 	return terms
@@ -50,7 +55,8 @@ func parseFTSBooleanSearchString(text string) []ftsSearchTerm {
 
 // parseFTSSearchTerm parses a single boolean-mode token. The strict-subset
 // validator guarantees `word`, `+word`, or `-word` with an alphanumeric body,
-// so only the leading operator needs interpretation.
+// so only the leading operator needs interpretation. Quoted words have already
+// been normalized to their unquoted form.
 func parseFTSSearchTerm(word string) ftsSearchTerm {
 	if word == "" {
 		return ftsSearchTerm{}
@@ -97,46 +103,90 @@ func escapeFTSLikePattern(term string) string {
 	return result.String()
 }
 
-// ValidateFTSSearchStringForLikeFallback reports whether searchText falls
-// inside the strict subset that the LIKE fallback is allowed to translate.
-// The supported subset is, by mode:
+// normalizeFTSSearchStringForLikeFallback reports whether searchText falls
+// inside the strict subset that the LIKE fallback is allowed to translate and
+// returns the normalized tokens used to build the ILIKE predicates. The
+// supported subset is, by mode:
 //
 //   - Boolean mode: each whitespace-separated token must be `word`, `+word`,
-//     or `-word`, where `word` consists of ASCII alphanumeric characters or
-//     non-ASCII UTF-8 bytes (the same definition used by isFTSWordByte).
+//     `-word`, `"word"`, `+"word"`, or `-"word"`, where `word` consists of
+//     ASCII alphanumeric characters or non-ASCII UTF-8 bytes (the same
+//     definition used by isFTSWordByte).
 //   - Natural-language mode: each whitespace-separated token must be a `word`
-//     of the same alphanumeric form (no leading +/- operators).
+//     or `"word"` of the same alphanumeric form (no leading +/- operators).
 //
 // An empty or whitespace-only search string is valid; BuildFTSToILikeExpression
 // short-circuits to a constant-0 result for it.
 //
-// Anything outside this subset (phrases, * prefix, > < ~ relevance modifiers,
-// () grouping, mid-word punctuation like `xx-yy`, etc.) is rejected because
-// MySQL FTS tokenizes those constructs in ways that differ from a substring
-// LIKE match. The planner uses this signal to skip the LIKE fallback for
-// rejected strings; the native FTSMysqlMatchAgainst builtin can still serve
-// the query when an FTS index is available.
-func ValidateFTSSearchStringForLikeFallback(searchText string, modifier ast.FulltextSearchModifier) error {
+// Anything outside this subset (multi-word phrases like `"xx yy"`, * prefix,
+// > < ~ relevance modifiers, () grouping, mid-word punctuation like `xx-yy`,
+// etc.) is rejected because MySQL FTS tokenizes those constructs in ways that
+// differ from a substring LIKE match. The planner uses this signal to skip the
+// LIKE fallback for rejected strings; the native FTSMysqlMatchAgainst builtin
+// can still serve the query when an FTS index is available.
+func normalizeFTSSearchStringForLikeFallback(searchText string, modifier ast.FulltextSearchModifier) ([]string, error) {
 	isBoolean := modifier.IsBooleanMode()
-	for _, token := range strings.Fields(searchText) {
-		body := token
-		// strings.Fields never returns an empty token (consecutive whitespace
-		// is collapsed), so body[0] is safe today. Keep the len(body) > 0
-		// guard explicit so the indexing is obviously bounded and the check
-		// stays correct if the tokenization ever changes.
-		if isBoolean && len(body) > 0 && (body[0] == '+' || body[0] == '-') {
-			body = body[1:]
+	fields := strings.Fields(searchText)
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	tokens := make([]string, 0, len(fields))
+	for _, token := range fields {
+		normalized, err := normalizeFTSSearchTokenForLikeFallback(token, isBoolean)
+		if err != nil {
+			return nil, err
 		}
-		if body == "" {
-			return ErrNotSupportedYet.GenWithStackByArgs(
+		tokens = append(tokens, normalized)
+	}
+	return tokens, nil
+}
+
+// normalizeFTSSearchTokenForLikeFallback validates one whitespace-delimited
+// search token and strips optional double quotes around a single word body.
+//
+// Examples:
+//   - natural mode: `word` -> `word`, `"word"` -> `word`
+//   - boolean mode: `+word` -> `+word`, `+"word"` -> `+word`,
+//     `-"word"` -> `-word`
+//   - rejected: `"wo rd"` because it is split into invalid partial tokens,
+//     `*hello` because `*` is not a word byte, `aa'bb` because `'` is not a
+//     word byte
+func normalizeFTSSearchTokenForLikeFallback(token string, isBoolean bool) (string, error) {
+	body := token
+	prefix := byte(0)
+	// strings.Fields never returns an empty token (consecutive whitespace is
+	// collapsed), so body[0] is safe today. Keep the len(body) > 0 guard
+	// explicit so the indexing is obviously bounded and the check stays
+	// correct if the tokenization ever changes.
+	if isBoolean && len(body) > 0 && (body[0] == '+' || body[0] == '-') {
+		prefix = body[0]
+		body = body[1:]
+	}
+	if len(body) >= 2 && body[0] == '"' && body[len(body)-1] == '"' {
+		body = body[1 : len(body)-1]
+	}
+	if body == "" {
+		return "", ErrNotSupportedYet.GenWithStackByArgs(
+			"MATCH...AGAINST search term '" + token + "' is not supported in the LIKE fallback")
+	}
+	for i := range len(body) {
+		if !isFTSWordByte(body[i]) {
+			return "", ErrNotSupportedYet.GenWithStackByArgs(
 				"MATCH...AGAINST search term '" + token + "' is not supported in the LIKE fallback")
 		}
-		for i := range len(body) {
-			if !isFTSWordByte(body[i]) {
-				return ErrNotSupportedYet.GenWithStackByArgs(
-					"MATCH...AGAINST search term '" + token + "' is not supported in the LIKE fallback")
-			}
-		}
+	}
+	if prefix != 0 {
+		return string(prefix) + body, nil
+	}
+	return body, nil
+}
+
+// ValidateFTSSearchStringForLikeFallback reports whether searchText falls
+// inside the strict subset that the LIKE fallback is allowed to translate.
+func ValidateFTSSearchStringForLikeFallback(searchText string, modifier ast.FulltextSearchModifier) error {
+	_, err := normalizeFTSSearchStringForLikeFallback(searchText, modifier)
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -184,19 +234,20 @@ func BuildFTSToILikeExpression(
 	// redirecting to the native builtin, or selectivity estimation falling
 	// through to a default estimate) should call this validator directly and
 	// react to its error.
-	if err := ValidateFTSSearchStringForLikeFallback(searchText, modifier); err != nil {
+	tokens, err := normalizeFTSSearchStringForLikeFallback(searchText, modifier)
+	if err != nil {
 		return nil, err
 	}
 
-	if searchText == "" {
+	if len(tokens) == 0 {
 		return ftsZeroIntConst(), nil
 	}
 
 	if modifier.IsBooleanMode() {
-		return buildFTSBooleanModeILikeExpression(ctx, columns, searchText)
+		return buildFTSBooleanModeILikeExpression(ctx, columns, tokens)
 	}
 	if modifier.IsNaturalLanguageMode() {
-		return buildFTSNaturalLanguageModeILikeExpression(ctx, columns, searchText)
+		return buildFTSNaturalLanguageModeILikeExpression(ctx, columns, tokens)
 	}
 	return nil, ErrNotSupportedYet.GenWithStackByArgs("MATCH...AGAINST modifier is not supported in the LIKE fallback")
 }
@@ -215,8 +266,8 @@ func ftsZeroIntConst() Expression {
 // terms become an AND of per-term column-DNFs, excluded terms become NOT over
 // per-term column-DNFs, and optional terms anchor the result only when no
 // required terms exist (since LIKE cannot rank).
-func buildFTSBooleanModeILikeExpression(ctx BuildContext, columns []Expression, searchText string) (Expression, error) {
-	terms := parseFTSBooleanSearchString(searchText)
+func buildFTSBooleanModeILikeExpression(ctx BuildContext, columns []Expression, tokens []string) (Expression, error) {
+	terms := parseFTSBooleanSearchTokens(tokens)
 	if len(terms) == 0 {
 		return ftsZeroIntConst(), nil
 	}
@@ -316,8 +367,7 @@ func buildFTSBooleanModeILikeExpression(ctx BuildContext, columns []Expression, 
 // buildFTSNaturalLanguageModeILikeExpression handles the default
 // natural-language mode by splitting the search string into whitespace
 // tokens and OR-ing per-column per-word ILIKE predicates together.
-func buildFTSNaturalLanguageModeILikeExpression(ctx BuildContext, columns []Expression, searchText string) (Expression, error) {
-	words := strings.Fields(searchText)
+func buildFTSNaturalLanguageModeILikeExpression(ctx BuildContext, columns []Expression, words []string) (Expression, error) {
 	if len(words) == 0 {
 		return ftsZeroIntConst(), nil
 	}

--- a/pkg/expression/fts_to_like_test.go
+++ b/pkg/expression/fts_to_like_test.go
@@ -34,26 +34,31 @@ func TestValidateFTSSearchStringForLikeFallback(t *testing.T) {
 		modifier ast.FulltextSearchModifier
 		wantErr  bool
 	}{
-		// Natural-language mode: plain alphanumeric words only.
+		// Natural-language mode: plain alphanumeric words, optionally quoted one word at a time.
 		{name: "natural empty", text: "", modifier: naturalMode, wantErr: false},
 		{name: "natural whitespace only", text: " \t\n ", modifier: naturalMode, wantErr: false},
 		{name: "natural single word", text: "MySQL", modifier: naturalMode, wantErr: false},
 		{name: "natural multi word", text: "MySQL tutorial PostgreSQL", modifier: naturalMode, wantErr: false},
 		{name: "natural alphanumeric mix", text: "abc123 mysql8", modifier: naturalMode, wantErr: false},
+		{name: "natural quoted single word", text: `"phrase"`, modifier: naturalMode, wantErr: false},
+		{name: "natural quoted words", text: `"word" "hello"`, modifier: naturalMode, wantErr: false},
 		{name: "natural rejects mid-word dash", text: "x-x", modifier: naturalMode, wantErr: true},
 		{name: "natural rejects punctuation suffix", text: "MySQL,", modifier: naturalMode, wantErr: true},
 		{name: "natural rejects + operator", text: "+word", modifier: naturalMode, wantErr: true},
 		{name: "natural rejects - operator", text: "-word", modifier: naturalMode, wantErr: true},
-		{name: "natural rejects quote", text: `"phrase"`, modifier: naturalMode, wantErr: true},
+		{name: "natural rejects quoted phrase", text: `"exact phrase"`, modifier: naturalMode, wantErr: true},
 		{name: "natural rejects wildcard", text: "word*", modifier: naturalMode, wantErr: true},
 		{name: "natural rejects percent", text: "100%", modifier: naturalMode, wantErr: true},
 		{name: "natural rejects underscore", text: "test_file", modifier: naturalMode, wantErr: true},
 
-		// Boolean mode: plain word, +word, -word with alphanumeric body only.
+		// Boolean mode: plain word, +word, -word with alphanumeric body, optionally quoted.
 		{name: "boolean empty", text: "", modifier: booleanMode, wantErr: false},
 		{name: "boolean plain word", text: "MySQL", modifier: booleanMode, wantErr: false},
 		{name: "boolean required word", text: "+MySQL", modifier: booleanMode, wantErr: false},
 		{name: "boolean excluded word", text: "-MySQL", modifier: booleanMode, wantErr: false},
+		{name: "boolean quoted word", text: `"MySQL"`, modifier: booleanMode, wantErr: false},
+		{name: "boolean quoted required word", text: `+"MySQL"`, modifier: booleanMode, wantErr: false},
+		{name: "boolean quoted excluded word", text: `-"MySQL"`, modifier: booleanMode, wantErr: false},
 		{name: "boolean mix", text: "+apple -cherry pie", modifier: booleanMode, wantErr: false},
 		{name: "boolean rejects mid-word dash", text: "xx-yy", modifier: booleanMode, wantErr: true},
 		{name: "boolean rejects bare operator", text: "+", modifier: booleanMode, wantErr: true},
@@ -85,6 +90,38 @@ func TestValidateFTSSearchStringForLikeFallback(t *testing.T) {
 	}
 }
 
+func TestNormalizeFTSSearchStringForLikeFallbackQuotedWords(t *testing.T) {
+	naturalMode := ast.FulltextSearchModifier(ast.FulltextSearchModifierNaturalLanguageMode)
+	booleanMode := ast.FulltextSearchModifier(ast.FulltextSearchModifierBooleanMode)
+
+	tests := []struct {
+		name     string
+		text     string
+		modifier ast.FulltextSearchModifier
+		expected []string
+		wantErr  bool
+	}{
+		{name: "natural quoted word", text: `"word"`, modifier: naturalMode, expected: []string{"word"}},
+		{name: "natural quoted words", text: `"word" "hello"`, modifier: naturalMode, expected: []string{"word", "hello"}},
+		{name: "boolean quoted words", text: `+"word" -"hello" plain`, modifier: booleanMode, expected: []string{"+word", "-hello", "plain"}},
+		{name: "reject quoted phrase", text: `"wo rd"`, modifier: naturalMode, wantErr: true},
+		{name: "reject wildcard", text: `*hello`, modifier: booleanMode, wantErr: true},
+		{name: "reject quote inside word", text: `aa'bb`, modifier: naturalMode, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens, err := normalizeFTSSearchStringForLikeFallback(tt.text, tt.modifier)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, tokens)
+		})
+	}
+}
+
 // TestParseFTSBooleanSearchString covers the strict-subset inputs the boolean
 // parser is expected to handle in production. Inputs outside the subset
 // (phrases, wildcards, relevance modifiers, mid-word punctuation, etc.) are
@@ -107,6 +144,14 @@ func TestParseFTSBooleanSearchString(t *testing.T) {
 			expected: []ftsSearchTerm{
 				{word: "apple", isRequired: true},
 				{word: "cherry", isExcluded: true},
+			},
+		},
+		{
+			input: `+"apple" -"cherry" pie`,
+			expected: []ftsSearchTerm{
+				{word: "apple", isRequired: true},
+				{word: "cherry", isExcluded: true},
+				{word: "pie"},
 			},
 		},
 		{

--- a/pkg/planner/core/casetest/tici/BUILD.bazel
+++ b/pkg/planner/core/casetest/tici/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 16,
+    shard_count = 17,
     deps = [
         "//pkg/config",
         "//pkg/ddl/ingest/testutil",

--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_in.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_in.json
@@ -59,6 +59,7 @@
       "explain format='brief' select * from t1 where match(title) against ('\\\"hello world\\\"' IN BOOLEAN MODE)",
       "explain format='brief' select id from t1 where match(title) against ('+apple -banana' IN BOOLEAN MODE)",
       "explain format='brief' select id from t1 where match(title) against ('-banana' IN BOOLEAN MODE)",
+      "explain format='brief' select id from t1 use index(idx_field1) where field1 = 1 and not match(title) against ('-banana' IN BOOLEAN MODE)",
       "explain format='brief' select id from t1 where match(title) against ('apple' IN BOOLEAN MODE) or match(title) against ('banana' IN BOOLEAN MODE)",
       "explain format='brief' select id from t1 where match(title) against ('\"\"' IN BOOLEAN MODE)",
       "explain format='brief' select * from t1 where match(title) against (NULL IN BOOLEAN MODE)",

--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
@@ -615,10 +615,17 @@
       {
         "SQL": "explain format='brief' select id from t1 where match(title) against ('-banana' IN BOOLEAN MODE)",
         "Plan": [
-          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 1000.00 mpp[tiflash]  test.t1.id",
-          "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:0, keep order:false, stats:pseudo"
+          "TableDual 1.00 root  rows:0"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "explain format='brief' select id from t1 use index(idx_field1) where field1 = 1 and not match(title) against ('-banana' IN BOOLEAN MODE)",
+        "Plan": [
+          "Projection 10.00 root  test.t1.id",
+          "└─IndexLookUp 10.00 root  ",
+          "  ├─IndexRangeScan(Build) 10.00 cop[tikv] table:t1, index:idx_field1(field1) range:[1,1], keep order:false, stats:pseudo",
+          "  └─TableRowIDScan(Probe) 10.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -635,10 +642,7 @@
       {
         "SQL": "explain format='brief' select id from t1 where match(title) against ('\"\"' IN BOOLEAN MODE)",
         "Plan": [
-          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 1000.00 mpp[tiflash]  test.t1.id",
-          "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t1, index:idx_title(title) range:[-inf,+inf], search func:0, keep order:false, stats:pseudo"
+          "TableDual 1.00 root  rows:0"
         ],
         "Warn": null
       },
@@ -702,10 +706,7 @@
       {
         "SQL": "explain format='brief' select id from t6 where match(title) against ('\"\"' IN BOOLEAN MODE)",
         "Plan": [
-          "TableReader 1000.00 root  MppVersion: 3, data:ExchangeSender",
-          "└─ExchangeSender 1000.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 1000.00 mpp[tiflash]  test.t6.id",
-          "    └─IndexRangeScan 1000.00 mpp[tiflash] table:t6, index:idx_title(title) range:[0,+inf], search func:0, keep order:false, stats:pseudo"
+          "TableDual 1.00 root  rows:0"
         ],
         "Warn": null
       },

--- a/pkg/planner/core/casetest/tici/tici_test.go
+++ b/pkg/planner/core/casetest/tici/tici_test.go
@@ -727,3 +727,63 @@ func TestTiCIAlternativeLogicalPlansIgnoreIndexRoutesToLikeFallback(t *testing.T
 		tk.MustQuery(sqlWithIgnoreHint).CheckNotContain("fts_match_word")
 	})
 }
+
+func TestTiCIMatchAgainstQuotedWordLikeFallback(t *testing.T) {
+	runTiCITest(t, func(tk *testkit.TestKit) {
+		tk.MustExec(`create table amazon_review(
+			id bigint primary key,
+			review_body text,
+			review_headline text,
+			product_title text,
+			fulltext index review_body(review_body, review_headline, product_title)
+		)`)
+		tk.MustExec(`insert into amazon_review values
+			(1, 'stainless steel bottle', 'durable bottle', 'travel bottle'),
+			(2, 'stainless lunch box', 'steel lunch box', 'kitchen organizer'),
+			(3, 'plastic container', 'light container', 'storage box'),
+			(4, 'ceramic mug', 'coffee mug', 'kitchen mug')`)
+		dom := domain.GetDomain(tk.Session())
+		testkit.SetTiFlashReplica(t, dom, "test", "amazon_review")
+		tk.MustExec("set @@tidb_opt_enable_alternative_logical_plans = 1")
+
+		sql := `explain select count(*) from amazon_review ignore index(review_body)
+			where match(review_body, review_headline, product_title)
+			against('"stainless"' in boolean mode)`
+		tk.MustQuery(sql).CheckContain("ilike(")
+		tk.MustQuery(sql).CheckContain("%stainless%")
+		tk.MustQuery(sql).CheckContain("TableFullScan")
+		tk.MustQuery(sql).CheckNotContain("fts_match_word")
+	})
+}
+
+func TestTiCIIsolationReadEnginesFiltersFTSPath(t *testing.T) {
+	runTiCITest(t, func(tk *testkit.TestKit) {
+		tk.MustExec(`create table obj_new(
+			id bigint primary key,
+			label text,
+			fulltext index idx_label(label)
+		)`)
+		dom := domain.GetDomain(tk.Session())
+		testkit.SetTiFlashReplica(t, dom, "test", "obj_new")
+		tk.MustExec("set @@sql_mode = ''")
+		tk.MustExec("set @@tidb_isolation_read_engines = 'tikv,tiflash,tidb'")
+
+		sql := `explain format = 'brief' select id from obj_new
+			where match(label) against ('"BFACPXUZXEIN"' in boolean mode)`
+
+		_, err := tk.Exec(sql)
+		require.NoError(t, err)
+
+		tk.MustExec("set @@tx_isolation = 'READ-COMMITTED'")
+		tk.MustExec("begin pessimistic")
+		_, err = tk.Exec(sql)
+		require.NoError(t, err)
+		tk.MustExec("rollback")
+
+		tk.MustExec("set @@tidb_isolation_read_engines = 'tikv,tidb'") // TiCI indexes depend on the TiFlash store type.
+		tk.MustExec("begin pessimistic")
+		_, err = tk.Exec(sql)
+		require.EqualError(t, err, "[planner:1815]Internal : No access path for table 'obj_new' is found with 'tidb_isolation_read_engines' = 'tikv,tidb', valid values can be 'tiflash'.")
+		tk.MustExec("rollback")
+	})
+}

--- a/pkg/planner/core/fulltext_to_like.go
+++ b/pkg/planner/core/fulltext_to_like.go
@@ -57,14 +57,16 @@ import (
 // Search-string subset accepted by the rewrite (enforced upstream by
 // expression.ValidateFTSSearchStringForLikeFallback):
 //
-//   - Natural-language mode: whitespace-separated alphanumeric words only.
+//   - Natural-language mode: whitespace-separated alphanumeric words, where
+//     a single-word token may optionally be wrapped in double quotes.
 //   - Boolean mode: each token is `word`, `+word` (required), or `-word`
-//     (excluded), where `word` is alphanumeric (ASCII or non-ASCII UTF-8).
+//     (excluded), where `word` is alphanumeric (ASCII or non-ASCII UTF-8) and
+//     may optionally be wrapped in double quotes.
 //
-// Anything outside that subset — phrases, * prefix, > < ~ relevance
-// modifiers, () grouping, mid-word punctuation like `xx-yy` — is rejected
-// at plan time with ErrNotSupportedYet because MySQL FTS tokenizes those
-// constructs in ways a substring LIKE cannot reproduce. WITH QUERY
+// Anything outside that subset — multi-word phrases, * prefix, > < ~
+// relevance modifiers, () grouping, mid-word punctuation like `xx-yy` — is
+// rejected at plan time with ErrNotSupportedYet because MySQL FTS tokenizes
+// those constructs in ways a substring LIKE cannot reproduce. WITH QUERY
 // EXPANSION is likewise rejected (no LIKE approximation exists for the
 // second-pass tokenization).
 func (er *expressionRewriter) convertMatchAgainstToLike(

--- a/pkg/planner/core/operator/logicalop/logical_datasource.go
+++ b/pkg/planner/core/operator/logicalop/logical_datasource.go
@@ -944,12 +944,17 @@ func (ds *DataSource) buildTiCIFTSPathAndCleanUp(
 	}
 	matchedConds := make([]expression.Expression, 0, len(matchedCondIdxes))
 	tableFilters := make([]expression.Expression, 0, len(ds.PushedDownConds)-len(matchedCondIdxes))
+	sc := ds.SCtx().GetSessionVars().StmtCtx
 	for i, cond := range ds.PushedDownConds {
 		if _, ok := matchedCondSet[i]; ok {
-			// MATCH ... AGAINST(NULL) rewrites to a NULL constant. Keep it as a
-			// residual filter instead of sending a Null expression through FtsQueryInfo.
-			if c, isConst := cond.(*expression.Constant); isConst && c.Value.IsNull() {
-				tableFilters = append(tableFilters, cond)
+			// MATCH ... AGAINST can rewrite to constant false/null for queries
+			// that match no rows, or to constant true through outer wrappers.
+			// Keep false/null as residual filters for normal dual conversion;
+			// drop true constants as no-op predicates. Do not send constants to TiCI.
+			if _, isConst := cond.(*expression.Constant); isConst {
+				if IsConstFalse(sc, cond) {
+					tableFilters = append(tableFilters, cond)
+				}
 				continue
 			}
 			matchedConds = append(matchedConds, cond)

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -242,15 +242,116 @@ func fillIndexPath(ds *logicalop.DataSource, path *util.AccessPath, conds []expr
 
 func deriveSearchPathStats(ds *logicalop.DataSource, path *util.AccessPath) {
 	path.IndexFilters, path.TableFilters = splitIndexFilterConditions(ds, path.TableFilters, path.FullIdxCols, path.FullIdxColLens)
-	countAfterAccess := min(float64(ds.StatisticTable.RealtimeCount)/10, 1000)
+	countAfterAccess := defaultTiCISearchPathCount(ds)
 	// TiCI count estimation is only used to refine multi-table plan choices.
 	// StmtCtx.Tables is de-duplicated, so self-joins on one table use the local fallback.
 	if len(ds.SCtx().GetSessionVars().StmtCtx.Tables) > 1 {
 		if count, ok := deriveTiCISearchPathStats(ds, path); ok {
 			countAfterAccess = count
 		}
+	} else {
+		// For a single-table FTS query, there is no join-order decision to refine
+		// with a remote TiCI estimate. Use the average rows per distinct indexed
+		// text value as the local default instead of the capped selectivity fallback.
+		countAfterAccess = deriveSingleTableTiCISearchPathCount(ds, path)
 	}
 	updateTiCISearchPathStats(ds, path, countAfterAccess)
+}
+
+func defaultTiCISearchPathCount(ds *logicalop.DataSource) float64 {
+	return min(float64(ds.StatisticTable.RealtimeCount)/10, 1000)
+}
+
+func deriveSingleTableTiCISearchPathCount(ds *logicalop.DataSource, path *util.AccessPath) float64 {
+	totalRows := float64(ds.StatisticTable.RealtimeCount)
+	if totalRows <= 0 {
+		return 0
+	}
+	ndv, ok := estimateTiCISearchPathNDV(ds, path)
+	if !ok || ndv <= 0 {
+		return defaultTiCISearchPathCount(ds)
+	}
+	return totalRows / max(ndv, 1)
+}
+
+func estimateTiCISearchPathNDV(ds *logicalop.DataSource, path *util.AccessPath) (float64, bool) {
+	if !canUseTiCISearchPathNDV(path.AccessConds) {
+		return 0, false
+	}
+	// Prefer the columns referenced by the FTS predicate. If extraction cannot find
+	// them, fall back to the full TiCI index columns so multi-column fulltext indexes
+	// still get a stable local estimate.
+	matchedCols := expression.ExtractColumnsFromExpressions(path.AccessConds, func(col *expression.Column) bool {
+		if col == nil {
+			return false
+		}
+		for _, idxCol := range path.FullIdxCols {
+			if idxCol != nil && col.EqualColumn(idxCol) {
+				return true
+			}
+		}
+		return false
+	}, false)
+	if len(matchedCols) == 0 {
+		matchedCols = path.FullIdxCols
+	}
+	ndv := 0.0
+	for _, col := range matchedCols {
+		if col == nil {
+			continue
+		}
+		colStats := ds.StatisticTable.GetCol(col.ID)
+		if ds.StatisticTable.Pseudo || colStats == nil || !colStats.IsStatsInitialized() {
+			// Avoid EstimateColumnNDV's synthetic no-stats NDV; keep no-stats
+			// behavior on the conservative capped fallback.
+			return 0, false
+		}
+		ndv = max(ndv, cardinality.EstimateColumnNDV(ds.StatisticTable, col.ID))
+	}
+	return ndv, true
+}
+
+// canUseTiCISearchPathNDV returns true only for search literals whose selectivity
+// can be approximated from value NDV without invoking standard tokenization.
+// Terms with operators or punctuation, such as "ab.cd" or "*abc", must go
+// through the formal FTS tokenizer before we can reason about their real terms,
+// so they keep the conservative fallback estimate.
+func canUseTiCISearchPathNDV(accessConds []expression.Expression) bool {
+	if len(accessConds) != 1 {
+		return false
+	}
+	sf, ok := accessConds[0].(*expression.ScalarFunction)
+	if !ok {
+		return false
+	}
+	switch sf.FuncName.L {
+	case ast.FTSMatchWord, ast.FTSMatchPhrase:
+	default:
+		return false
+	}
+	args := sf.GetArgs()
+	if len(args) < 2 {
+		return false
+	}
+	query, ok := args[0].(*expression.Constant)
+	if !ok || query.Value.IsNull() {
+		return false
+	}
+	return isSimpleFTSSearchWord(query.Value.GetString())
+}
+
+func isSimpleFTSSearchWord(query string) bool {
+	if query == "" {
+		return false
+	}
+	for i := range len(query) {
+		ch := query[i]
+		if ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func updateTiCISearchPathStats(ds *logicalop.DataSource, path *util.AccessPath, countAfterAccess float64) {

--- a/pkg/planner/util/misc.go
+++ b/pkg/planner/util/misc.go
@@ -290,15 +290,16 @@ func FilterPathByIsolationRead(ctx base.PlanContext, paths []*AccessPath, tblNam
 	availableEngine := map[kv.StoreType]struct{}{}
 	var availableEngineStr string
 	for i := len(paths) - 1; i >= 0; i-- {
+		engine := isolationReadEngineForPath(paths[i].StoreType)
 		// availableEngineStr is for warning message.
-		if _, ok := availableEngine[paths[i].StoreType]; !ok {
-			availableEngine[paths[i].StoreType] = struct{}{}
+		if _, ok := availableEngine[engine]; !ok {
+			availableEngine[engine] = struct{}{}
 			if availableEngineStr != "" {
 				availableEngineStr += ", "
 			}
-			availableEngineStr += paths[i].StoreType.Name()
+			availableEngineStr += engine.Name()
 		}
-		if _, ok := isolationReadEngines[paths[i].StoreType]; !ok && paths[i].StoreType != kv.TiDB {
+		if _, ok := isolationReadEngines[engine]; !ok && engine != kv.TiDB {
 			paths = slices.Delete(paths, i, i+1)
 		}
 	}
@@ -327,4 +328,11 @@ func FilterPathByIsolationRead(ctx base.PlanContext, paths []*AccessPath, tblNam
 		}
 	}
 	return paths, err
+}
+
+func isolationReadEngineForPath(storeType kv.StoreType) kv.StoreType {
+	if storeType == kv.TiCI {
+		return kv.TiFlash
+	}
+	return storeType
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68703, close #68714

Problem Summary:

This PR improves TiCI/FTS planning behavior:

1. Quoted single-word `MATCH AGAINST` predicates should be eligible for LIKE fallback.
2. Single-table TiCI FTS path estimation should use NDV instead of the fixed capped selectivity fallback.
3. TiCI full-text access paths should not be filtered out by `tidb_isolation_read_engines` in pessimistic READ COMMITTED transactions when TiFlash is allowed.

### What changed and how does it work?

1. Support quoted single words in `MATCH AGAINST` LIKE fallback, for example `match(col) against('"word"')` can be rewritten to `LIKE '%word%'`.
2. Update the default estimation of single-table TiCI `MATCH AGAINST` with single word from `min(rows/10, 1000)` to `rows / NDV`.
3. Map `kv.TiCI` to `kv.TiFlash` while applying isolation-read engine filtering and while building the error message's valid engine list. This keeps TiCI paths available whenever TiFlash is allowed, and still rejects them when TiFlash is excluded.

And add more tests for above changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

```sh
make failpoint-enable
(
  cd pkg/planner/core/casetest/tici
  GOCACHE=/tmp/tidb-go-build go test -run 'TestTiCI(IsolationReadEnginesFiltersFTSPath|MatchAgainstQuotedWordLikeFallback)' --tags=intest
)
(
  cd pkg/planner/core
  GOCACHE=/tmp/tidb-go-build go test -run TestNoneAccessPathsFoundByIsolationRead --tags=intest
)
make failpoint-disable
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support quoted single-word `MATCH AGAINST` LIKE fallback and fix a planner error where TiCI full-text queries could lose their only access path in pessimistic READ COMMITTED transactions when TiFlash is allowed by `tidb_isolation_read_engines`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for quoted terms in full-text search boolean mode queries
  * Enhanced query planning for full-text search with improved engine filtering

* **Bug Fixes**
  * Improved MATCH...AGAINST fallback behavior for unsupported search patterns
  * Fixed query plan selection for boolean-mode full-text queries with only excluded terms
  * Optimized query statistics estimation for single-table full-text search queries

* **Tests**
  * Added test coverage for quoted words in full-text search
  * Added integration tests for full-text search query planning and engine selection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
