### PR TITLE
test: stabilize flaky TestLoadDataSpecifiedColumns

### DIFF
--- a/pkg/executor/test/loaddatatest/load_data_test.go
+++ b/pkg/executor/test/loaddatatest/load_data_test.go
@@ -345,26 +345,40 @@ func TestLoadDataEscape(t *testing.T) {
 
 // TestLoadDataSpecifiedColumns reuse TestLoadDataEscape's test case :-)
 func TestLoadDataSpecifiedColumns(t *testing.T) {
-	trivialMsg := "Records: 1  Deleted: 0  Skipped: 0  Warnings: 0"
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test; drop table if exists load_data_test;")
 	tk.MustExec(`create table load_data_test (id int PRIMARY KEY AUTO_INCREMENT, c1 int, c2 varchar(255) default "def", c3 int default 0);`)
 	loadSQL := "load data local infile '/tmp/nonexistence.csv' into table load_data_test (c1, c2)"
 	ctx := tk.Session().(sessionctx.Context)
-	// test
-	tests := []testCase{
-		{[]byte("7\ta string\n"), []string{"1|7|a string|0"}, trivialMsg},
-		{[]byte("8\tstr \\t\n"), []string{"2|8|str \t|0"}, trivialMsg},
-		{[]byte("9\tstr \\n\n"), []string{"3|9|str \n|0"}, trivialMsg},
-		{[]byte("10\tboth \\t\\n\n"), []string{"4|10|both \t\n|0"}, trivialMsg},
-		{[]byte("11\tstr \\\\\n"), []string{"5|11|str \\|0"}, trivialMsg},
-		{[]byte("12\t\\r\\t\\n\\0\\Z\\b\n"), []string{"6|12|" + string([]byte{'\r', '\t', '\n', 0, 26, '\b'}) + "|0"}, trivialMsg},
-		{[]byte("\\N\ta string\n"), []string{"7|<nil>|a string|0"}, trivialMsg},
+
+	var reader io.ReadCloser = mydump.NewStringReader("7\ta string\n" +
+		"8\tstr \\t\n" +
+		"9\tstr \\n\n" +
+		"10\tboth \\t\\n\n" +
+		"11\tstr \\\\\n" +
+		"12\t\\r\\t\\n\\0\\Z\\b\n" +
+		"\\N\ta string\n")
+	var readerBuilder = executor.LoadDataReaderBuilder{
+		Build: func(_ string) (
+			r io.ReadCloser, err error,
+		) {
+			return reader, nil
+		},
+		Wg: &sync.WaitGroup{},
 	}
-	deleteSQL := "delete from load_data_test"
-	selectSQL := "select * from load_data_test;"
-	checkCases(tests, loadSQL, t, tk, ctx, selectSQL, deleteSQL)
+	ctx.SetValue(executor.LoadDataReaderBuilderKey, readerBuilder)
+	tk.MustExec(loadSQL)
+	require.Equal(t, "Records: 7  Deleted: 0  Skipped: 0  Warnings: 0", tk.Session().LastMessage())
+	tk.MustQuery("select * from load_data_test order by id;").Check(testkit.RowsWithSep("|",
+		"1|7|a string|0",
+		"2|8|str \t|0",
+		"3|9|str \n|0",
+		"4|10|both \t\n|0",
+		"5|11|str \\|0",
+		"6|12|"+string([]byte{'\r', '\t', '\n', 0, 26, '\b'})+"|0",
+		"7|<nil>|a string|0",
+	))
 }
 
 func TestLoadDataIgnoreLines(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68289

Problem Summary:
Flaky test `TestLoadDataSpecifiedColumns` in `pkg/executor/test/loaddatatest` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Seven separate LOAD DATA executions multiplied timing/setup cost for one semantic fixture.

#### Fix

Loading the same seven rows in one statement removes six redundant reader/setup/commit cycles.

#### Verification

Spec:
- target: `pkg/executor/test/loaddatatest :: TestLoadDataSpecifiedColumns`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package: PASS
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/executor/test/loaddatatest -run '^TestLoadDataSpecifiedColumns$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/executor/test/loaddatatest -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure for improved test maintainability and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68735?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->