### PR TITLE
executor, sessionctx/variable: add MV maintenance memory quota

### DIFF
--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -118,6 +118,17 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		return err
 	}
 	defer e.ReleaseSysSession(kctx, purgeSctx)
+	purgeSessVars := purgeSctx.GetSessionVars()
+	targetMaintainMemQuota, err := resolveMVMaintenanceMemQuota(kctx, e.Ctx().GetSessionVars(), isInternalSQL)
+	if err != nil {
+		return err
+	}
+	restorePurgeMemQuota, err := applyMVMaintenanceMemQuota(purgeSessVars, targetMaintainMemQuota)
+	if err != nil {
+		return err
+	}
+	defer restorePurgeMemQuota()
+	failpoint.InjectCall("mvMaintainMemQuotaAppliedOnPurgeSession", purgeSessVars.MemQuotaQuery, targetMaintainMemQuota)
 	sqlExec := purgeSctx.GetSQLExecutor()
 
 	histSctx, err := e.GetSysSession()
@@ -840,6 +851,16 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 	defer e.ReleaseSysSession(kctx, refreshSctx)
 	sqlExec := refreshSctx.GetSQLExecutor()
 	sessVars := refreshSctx.GetSessionVars()
+	targetMaintainMemQuota, err := resolveMVMaintenanceMemQuota(kctx, e.Ctx().GetSessionVars(), isInternalSQL)
+	if err != nil {
+		return err
+	}
+	restoreRefreshMemQuota, err := applyMVMaintenanceMemQuota(sessVars, targetMaintainMemQuota)
+	if err != nil {
+		return err
+	}
+	defer restoreRefreshMemQuota()
+	failpoint.InjectCall("mvMaintainMemQuotaAppliedOnRefreshSession", sessVars.MemQuotaQuery, targetMaintainMemQuota)
 
 	restoreSessVars, err := initRefreshMaterializedViewSession(sessVars, tblInfo.MaterializedView)
 	if err != nil {
@@ -1032,6 +1053,47 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		)
 	}
 	return nil
+}
+
+func applyMVMaintenanceMemQuota(sessVars *variable.SessionVars, targetMemQuota int64) (func(), error) {
+	if sessVars == nil {
+		return nil, errors.New("mv maintenance: session vars is nil")
+	}
+	originMemQuota := sessVars.MemQuotaQuery
+	if originMemQuota == targetMemQuota {
+		return func() {}, nil
+	}
+	if err := sessVars.SetSystemVar(variable.TiDBMemQuotaQuery, strconv.FormatInt(targetMemQuota, 10)); err != nil {
+		return nil, errors.Annotate(err, "mv maintenance: failed to apply tidb_mv_maintain_mem_quota to tidb_mem_quota_query")
+	}
+	return func() {
+		if err := sessVars.SetSystemVar(variable.TiDBMemQuotaQuery, strconv.FormatInt(originMemQuota, 10)); err != nil {
+			logutil.BgLogger().Warn(
+				"mv maintenance: failed to restore tidb_mem_quota_query after using tidb_mv_maintain_mem_quota",
+				zap.Int64("originMemQuota", originMemQuota),
+				zap.Int64("targetMemQuota", targetMemQuota),
+				zap.Error(err),
+			)
+		}
+	}, nil
+}
+
+func resolveMVMaintenanceMemQuota(kctx context.Context, sessVars *variable.SessionVars, isInternalSQL bool) (int64, error) {
+	if sessVars == nil {
+		return 0, errors.New("mv maintenance: session vars is nil")
+	}
+	if !isInternalSQL {
+		return sessVars.MVMaintainMemQuota, nil
+	}
+	globalQuotaVal, err := sessVars.GetGlobalSystemVar(kctx, variable.TiDBMVMaintainMemQuota)
+	if err != nil {
+		return 0, errors.Annotate(err, "mv maintenance: failed to read global tidb_mv_maintain_mem_quota")
+	}
+	globalQuota, err := strconv.ParseInt(globalQuotaVal, 10, 64)
+	if err != nil {
+		return 0, errors.Annotate(err, "mv maintenance: invalid global tidb_mv_maintain_mem_quota")
+	}
+	return globalQuota, nil
 }
 
 func initRefreshMaterializedViewSession(

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -535,6 +535,46 @@ func TestPurgeMaterializedViewLogMissingMLog(t *testing.T) {
 	require.ErrorContains(t, err, "materialized view log does not exist")
 }
 
+func TestPurgeMaterializedViewLogUsesMVMaintainMemQuota(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_purge_quota (id int primary key, v int)")
+	tk.MustExec("create materialized view log on t_purge_quota (id, v) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("insert into t_purge_quota values (1, 10), (2, 20), (3, 30)")
+	tk.MustExec("set @@session.tidb_mem_quota_query = 1073741824")
+	tk.MustExec("set @@global.tidb_mv_maintain_mem_quota = 536870912")
+	tk.MustExec("set @@session.tidb_mv_maintain_mem_quota = 268435456")
+	defer tk.MustExec(fmt.Sprintf("set @@global.tidb_mv_maintain_mem_quota = %d", 2*1024*1024*1024))
+
+	applied := false
+	lastAppliedMemQuotaQuery := int64(0)
+	lastAppliedMaintainQuota := int64(0)
+	failpointName := "github.com/pingcap/tidb/pkg/executor/mvMaintainMemQuotaAppliedOnPurgeSession"
+	require.NoError(t, failpoint.EnableCall(failpointName, func(memQuotaQuery int64, maintainMemQuota int64) {
+		applied = true
+		lastAppliedMemQuotaQuery = memQuotaQuery
+		lastAppliedMaintainQuota = maintainMemQuota
+	}))
+	defer func() {
+		require.NoError(t, failpoint.Disable(failpointName))
+	}()
+
+	tk.MustExec("purge materialized view log on t_purge_quota")
+	require.True(t, applied)
+	require.Equal(t, int64(268435456), lastAppliedMaintainQuota)
+	require.Equal(t, lastAppliedMaintainQuota, lastAppliedMemQuotaQuery)
+
+	tk.MustExec("insert into t_purge_quota values (4, 40)")
+	applied = false
+	lastAppliedMemQuotaQuery = 0
+	lastAppliedMaintainQuota = 0
+	mustExecInternal(t, tk, "purge materialized view log on t_purge_quota")
+	require.True(t, applied)
+	require.Equal(t, int64(536870912), lastAppliedMaintainQuota)
+	require.Equal(t, lastAppliedMaintainQuota, lastAppliedMemQuotaQuery)
+}
+
 func TestPurgeMaterializedViewLogPrivilege(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -82,6 +82,42 @@ func TestMaterializedViewRefreshCompleteBasic(t *testing.T) {
 		Check(testkit.Rows("success complete manually 1 1 1 1"))
 }
 
+func TestMaterializedViewRefreshUsesMVMaintainMemQuota(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_quota_refresh (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_quota_refresh values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_mv_quota_refresh (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_mv_quota_refresh (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t_mv_quota_refresh group by a")
+	tk.MustExec("set @@session.tidb_mem_quota_query = 1073741824")
+	tk.MustExec("set @@global.tidb_mv_maintain_mem_quota = 536870912")
+	tk.MustExec("set @@session.tidb_mv_maintain_mem_quota = 268435456")
+	defer tk.MustExec(fmt.Sprintf("set @@global.tidb_mv_maintain_mem_quota = %d", 2*1024*1024*1024))
+
+	applied := false
+	lastAppliedMemQuotaQuery := int64(0)
+	lastAppliedMaintainQuota := int64(0)
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/mvMaintainMemQuotaAppliedOnRefreshSession", func(memQuotaQuery int64, maintainMemQuota int64) {
+		applied = true
+		lastAppliedMemQuotaQuery = memQuotaQuery
+		lastAppliedMaintainQuota = maintainMemQuota
+	})
+
+	tk.MustExec("refresh materialized view mv_mv_quota_refresh complete")
+	require.True(t, applied)
+	require.Equal(t, int64(268435456), lastAppliedMaintainQuota)
+	require.Equal(t, lastAppliedMaintainQuota, lastAppliedMemQuotaQuery)
+
+	applied = false
+	lastAppliedMemQuotaQuery = 0
+	lastAppliedMaintainQuota = 0
+	mustExecInternal(t, tk, "refresh materialized view mv_mv_quota_refresh complete")
+	require.True(t, applied)
+	require.Equal(t, int64(536870912), lastAppliedMaintainQuota)
+	require.Equal(t, lastAppliedMaintainQuota, lastAppliedMemQuotaQuery)
+}
+
 func TestMaterializedViewRefreshNextTimeOnlyUpdatesForInternalSQL(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/session/test/variable/BUILD.bazel
+++ b/pkg/session/test/variable/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "variable_test.go",
     ],
     flaky = True,
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//pkg/config",
         "//pkg/kv",

--- a/pkg/session/test/variable/variable_test.go
+++ b/pkg/session/test/variable/variable_test.go
@@ -57,6 +57,24 @@ func TestForbidSettingBothTSVariable(t *testing.T) {
 	tk.MustExec("set @@tidb_snapshot = '2007-01-01 15:04:05.999999'")
 }
 
+func TestMVMaintainMemQuota(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	// Default is 2GiB.
+	tk.MustQuery("select @@tidb_mv_maintain_mem_quota").Check(testkit.Rows("2147483648"))
+
+	// Session scope should work independently.
+	tk.MustExec("set @@session.tidb_mv_maintain_mem_quota = 536870912")
+	tk.MustQuery("select @@tidb_mv_maintain_mem_quota").Check(testkit.Rows("536870912"))
+	tk.MustQuery("select @@tidb_mem_quota_query").Check(testkit.Rows("1073741824"))
+
+	// Global scope should be visible to a new session.
+	tk.MustExec("set @@global.tidb_mv_maintain_mem_quota = 3221225472")
+	tk2 := testkit.NewTestKit(t, store)
+	tk2.MustQuery("select @@tidb_mv_maintain_mem_quota").Check(testkit.Rows("3221225472"))
+}
+
 func TestCoprocessorOOMAction(t *testing.T) {
 	// Assert Coprocessor OOMAction
 	store := testkit.CreateMockStore(t)

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2290,6 +2290,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 	}
 	vars.MemQuota = MemQuota{
 		MemQuotaQuery:      DefTiDBMemQuotaQuery,
+		MVMaintainMemQuota: DefTiDBMVMaintainMemQuota,
 		MemQuotaApplyCache: DefTiDBMemQuotaApplyCache,
 	}
 	vars.BatchSize = BatchSize{
@@ -3236,6 +3237,8 @@ func (c *Concurrency) UnionConcurrency() int {
 type MemQuota struct {
 	// MemQuotaQuery defines the memory quota for a query.
 	MemQuotaQuery int64
+	// MVMaintainMemQuota defines the memory quota used by MV maintenance internal sessions.
+	MVMaintainMemQuota int64
 	// MemQuotaApplyCache defines the memory capacity for apply cache.
 	MemQuotaApplyCache int64
 }

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2707,6 +2707,17 @@ var defaultSysVars = []*SysVar{
 		}
 		return normalizedValue, nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBMVMaintainMemQuota, Value: strconv.FormatInt(DefTiDBMVMaintainMemQuota, 10), Type: TypeInt, MinValue: -1, MaxValue: math.MaxInt64, SetSession: func(s *SessionVars, val string) error {
+		s.MVMaintainMemQuota = TidbOptInt64(val, DefTiDBMVMaintainMemQuota)
+		return nil
+	}, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
+		intVal := TidbOptInt64(normalizedValue, DefTiDBMVMaintainMemQuota)
+		if intVal > 0 && intVal < 128 {
+			vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(TiDBMVMaintainMemQuota, originalValue))
+			normalizedValue = "128"
+		}
+		return normalizedValue, nil
+	}},
 	{Scope: ScopeGlobal, Name: TiDBMViewTaskMax, Value: strconv.Itoa(DefTiDBMViewTaskMax), Type: TypeInt, MinValue: 0, MaxValue: 256, SetGlobal: func(_ context.Context, _ *SessionVars, s string) error {
 		val, err := strconv.Atoi(s)
 		if err != nil {

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -144,6 +144,8 @@ const (
 
 	// TiDBMemQuotaQuery controls the memory quota of a query.
 	TiDBMemQuotaQuery = "tidb_mem_quota_query" // Bytes.
+	// TiDBMVMaintainMemQuota controls the memory quota used by MV refresh / MV log purge internal maintenance sessions.
+	TiDBMVMaintainMemQuota = "tidb_mv_maintain_mem_quota" // Bytes.
 	// TiDBMViewTaskMax controls the max concurrency of MV background tasks. 0 means using GOMAXPROCS.
 	TiDBMViewTaskMax = "tidb_mview_task_max"
 	// TiDBMViewTaskThresholdCPU controls MV task backpressure CPU threshold.
@@ -1488,6 +1490,7 @@ const (
 	DefMaxAllowedPacket                        uint64 = 67108864
 	DefTiDBEnableBatchDML                             = false
 	DefTiDBMemQuotaQuery                              = memory.DefMemQuotaQuery // 1GB
+	DefTiDBMVMaintainMemQuota                         = int64(2 * size.GB)
 	DefTiDBMViewTaskMax                               = 0
 	DefTiDBMViewTaskThresholdCPU                      = 0.8
 	DefTiDBMViewTaskThresholdMemory                   = 0.8


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:

MV refresh and MV log purge maintenance statements currently use the ordinary query memory quota of the internal session. This makes it hard to configure a dedicated quota for MV maintenance work.

### What changed and how does it work?

This PR adds `tidb_mv_maintain_mem_quota` and applies it to MV refresh and MV log purge internal maintenance sessions by temporarily mapping it to `tidb_mem_quota_query` while the maintenance SQL runs.

The PR also adds coverage for session/global variable behavior and verifies that MV refresh and MV log purge use the configured maintenance quota.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom "No need to test" reasons -->

Manual test commands:

```bash
make bazel_prepare
make bazel_lint_changed
GOCACHE=/tmp/tidb-gocache go test ./pkg/session/test/variable -run "TestMVMaintainMemQuota$" -tags=intest,deadlock -count=1
GOCACHE=/tmp/tidb-gocache go test ./pkg/executor/test/executor -run "TestMaterializedViewRefreshUsesMVMaintainMemQuota$" -tags=intest,deadlock -count=1
GOCACHE=/tmp/tidb-gocache go test ./pkg/executor/test/ddl -run "TestPurgeMaterializedViewLogUsesMVMaintainMemQuota$" -tags=intest,deadlock -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Add the `tidb_mv_maintain_mem_quota` system variable to configure the query memory quota used by materialized view refresh and materialized view log purge maintenance tasks.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tidb_mv_maintain_mem_quota (default 2GB) to control memory used for materialized view maintenance (refresh and log purge).
  * Maintenance operations now apply an appropriate memory quota for both user-driven and internal maintenance sessions.

* **Tests**
  * Added tests verifying memory-quota behavior for MV refresh and MV log purge and a unit test for the new sysvar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->