### PR TITLE
config: capitalize keyspace metadata slow log fields

### DIFF
--- a/cmd/tidb-server/main_test.go
+++ b/cmd/tidb-server/main_test.go
@@ -181,7 +181,7 @@ func TestSetupKeyspaceObservabilityForStarter(t *testing.T) {
 			Fields: []config.KeyspaceObservabilityField{{
 				Source:       "meta_a",
 				MetricLabel:  "keyspace_meta_label_a",
-				SlowLogField: "keyspace_meta_slow_a",
+				SlowLogField: "Keyspace_meta_slow_a",
 				StmtLogField: "stmt_meta_a",
 				Required:     true,
 			}},
@@ -196,7 +196,7 @@ func TestSetupKeyspaceObservabilityForStarter(t *testing.T) {
 	cfg := config.GetGlobalConfig()
 	require.Equal(t, map[string]string{"keyspace_name": "ks", "keyspace_meta_label_a": "value_a"}, cfg.GetKeyspaceObservabilityMetricLabels())
 	require.Equal(t, []config.KeyspaceObservabilityLogField{
-		{Name: "keyspace_meta_slow_a", Value: "value_a"},
+		{Name: "Keyspace_meta_slow_a", Value: "value_a"},
 	}, cfg.GetKeyspaceObservabilitySlowLogFields())
 	require.Equal(t, map[string]string{"stmt_meta_a": "value_a"}, cfg.GetKeyspaceObservabilityStmtLogFields())
 }

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -451,7 +451,7 @@ engines = ["tikv", "tiflash", "tidb"]
 # [[keyspace-observability.fields]]
 # source = "meta_key"
 # metric-label = "keyspace_meta_metric_label"
-# slow-log-field = "keyspace_meta_slow_log_field"
+# slow-log-field = "Keyspace_meta_slow_log_field"
 # stmt-log-field = "stmt_log_field"
 # required = false
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -176,14 +176,14 @@ func TestKeyspaceObservability(t *testing.T) {
 [[keyspace-observability.fields]]
 source = "meta_a"
 metric-label = "keyspace_meta_label_a"
-slow-log-field = "keyspace_meta_slow_a"
+slow-log-field = "Keyspace_meta_slow_a"
 stmt-log-field = "stmt_meta_a"
 required = true
 
 [[keyspace-observability.fields]]
 source = "meta_b"
 metric-label = "keyspace_meta_label_b"
-slow-log-field = "keyspace_meta_slow_b"
+slow-log-field = "Keyspace_meta_slow_b"
 `
 	_, err := toml.Decode(content, conf)
 	require.NoError(t, err)
@@ -194,8 +194,8 @@ slow-log-field = "keyspace_meta_slow_b"
 	}))
 	require.Equal(t, map[string]string{"keyspace_meta_label_a": "value_a", "keyspace_meta_label_b": "value_b"}, conf.GetKeyspaceObservabilityMetricLabels())
 	require.Equal(t, []KeyspaceObservabilityLogField{
-		{Name: "keyspace_meta_slow_a", Value: "value_a"},
-		{Name: "keyspace_meta_slow_b", Value: "value_b"},
+		{Name: "Keyspace_meta_slow_a", Value: "value_a"},
+		{Name: "Keyspace_meta_slow_b", Value: "value_b"},
 	}, conf.GetKeyspaceObservabilitySlowLogFields())
 	require.Equal(t, map[string]string{"stmt_meta_a": "value_a"}, conf.GetKeyspaceObservabilityStmtLogFields())
 
@@ -299,7 +299,16 @@ metric-label = "task_id"
 	source = "meta_a"
 	slow-log-field = "Digest"
 	`,
-			err: `slow-log-field "Digest" must start with "keyspace_meta_"`,
+			err: `slow-log-field "Digest" must start with "Keyspace_meta_"`,
+		},
+		{
+			name: "slow log field with lowercase prefix",
+			content: `
+	[[keyspace-observability.fields]]
+	source = "meta_a"
+	slow-log-field = "keyspace_meta_slow"
+	`,
+			err: `slow-log-field "keyspace_meta_slow" must start with "Keyspace_meta_"`,
 		},
 		{
 			name: "invalid slow log field",
@@ -315,13 +324,13 @@ slow-log-field = "Bad Field"
 			content: `
 	[[keyspace-observability.fields]]
 	source = "meta_a"
-	slow-log-field = "keyspace_meta_slow"
+	slow-log-field = "Keyspace_meta_slow"
 
 	[[keyspace-observability.fields]]
 	source = "meta_b"
-	slow-log-field = "KEYSPACE_META_SLOW"
+	slow-log-field = "Keyspace_meta_SLOW"
 	`,
-			err: `duplicated slow-log-field "KEYSPACE_META_SLOW"`,
+			err: `duplicated slow-log-field "Keyspace_meta_SLOW"`,
 		},
 		{
 			name: "duplicate stmt log field",

--- a/pkg/config/keyspace_observability.go
+++ b/pkg/config/keyspace_observability.go
@@ -50,7 +50,10 @@ type KeyspaceObservabilityLogField struct {
 	Value string
 }
 
-const keyspaceObservabilityMetricLabelPrefix = "keyspace_meta_"
+const (
+	keyspaceObservabilityMetricLabelPrefix  = "keyspace_meta_"
+	keyspaceObservabilitySlowLogFieldPrefix = "Keyspace_meta_"
+)
 
 // Valid validates metadata observability mappings.
 func (o KeyspaceObservability) Valid() error {
@@ -81,10 +84,10 @@ func (o KeyspaceObservability) Valid() error {
 			if !validKeyspaceObservabilityLogFieldName(field.SlowLogField) {
 				return fmt.Errorf("[keyspace-observability.fields.%d] invalid slow-log-field %q", i, field.SlowLogField)
 			}
-			key := strings.ToLower(field.SlowLogField)
-			if !strings.HasPrefix(key, keyspaceObservabilityMetricLabelPrefix) {
-				return fmt.Errorf("[keyspace-observability.fields.%d] slow-log-field %q must start with %q", i, field.SlowLogField, keyspaceObservabilityMetricLabelPrefix)
+			if !strings.HasPrefix(field.SlowLogField, keyspaceObservabilitySlowLogFieldPrefix) {
+				return fmt.Errorf("[keyspace-observability.fields.%d] slow-log-field %q must start with %q", i, field.SlowLogField, keyspaceObservabilitySlowLogFieldPrefix)
 			}
+			key := strings.ToLower(field.SlowLogField)
 			if _, ok := slowLogFields[key]; ok {
 				return fmt.Errorf("[keyspace-observability.fields.%d] duplicated slow-log-field %q", i, field.SlowLogField)
 			}

--- a/pkg/sessionctx/variable/tests/session_test.go
+++ b/pkg/sessionctx/variable/tests/session_test.go
@@ -391,13 +391,13 @@ func TestSlowLogFormat(t *testing.T) {
 		conf.KeyspaceObservability = config.KeyspaceObservability{
 			Fields: []config.KeyspaceObservabilityField{{
 				Source:       "meta_a",
-				SlowLogField: "keyspace_meta_slow_a",
+				SlowLogField: "Keyspace_meta_slow_a",
 			}},
 		}
 		require.NoError(t, conf.ResolveKeyspaceObservability(map[string]string{"meta_a": "value_a"}))
 	})
 	logString = seVar.SlowLogFormat(logItems)
-	require.Equal(t, resultFields+"\n"+"# keyspace_meta_slow_a: value_a\n"+sql, logString)
+	require.Equal(t, resultFields+"\n"+"# Keyspace_meta_slow_a: value_a\n"+sql, logString)
 
 	// test PrepareSlowLogItemsForRules and CompleteSlowLogItemsForRules
 	seVar.SlowLogRules = slowlogrule.NewSessionSlowLogRules(&slowlogrule.SlowLogRules{


### PR DESCRIPTION
### What changed

This PR changes keyspace observability slow log fields to require the `Keyspace_meta_` prefix, matching the existing slow log convention where fields usually start with an uppercase letter.

`ResolveKeyspaceObservability` now emits the configured slow log field name directly. It no longer normalizes `keyspace_meta_*` to `Keyspace_meta_*`; instead, `slow-log-field` validation rejects lowercase `keyspace_meta_*` and requires `Keyspace_meta_*`.

Metric labels are unchanged and still use the lowercase `keyspace_meta_` prefix. Statement log fields are unchanged.

### Tests

- `go test ./pkg/config -run '^TestKeyspaceObservability' -count=1`
- `go test ./cmd/tidb-server -run '^TestSetupKeyspaceObservabilityForStarter$' -count=1`
- `go test --tags=intest ./pkg/sessionctx/variable/tests -run '^TestSlowLogFormat$' -count=1`
- `go test ./pkg/util/stmtsummary/v2 -run '^TestStmtRecord$' -count=1`

Note: broader `go test ./pkg/config -run 'TestKeyspaceObservability|TestConfig' -count=1` still fails on this branch because `TestConfig` expects `GetGlobalConfig().TiKVClient.RUV2.RUScale` to match the example config, but the current values are `2.1` vs `1.4`; this is unrelated to this PR.

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced consistent capitalization for keyspace observability slow-log field names. Configured slow-log identifiers and emitted slow-log lines now use a standardized prefix/casing, improving readability and preventing mismatches between configuration, validation, and slow-log output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->