### PR TITLE
br: let `restore log` check `--restore-ts` instead of the full backup ts

### DIFF
--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1265,8 +1265,7 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 	if cfg.CheckRequirements {
 		// When `restore point`, we have already checked changefeed compatibility outside.
 		if cfg.piTRTaskInfo == nil {
-			log.Info("Checking incompatible TiCDC changefeeds before restoring.",
-				logutil.ShortError(err), zap.Uint64("restore-ts", backupMeta.EndVersion))
+			log.Info("Checking incompatible TiCDC changefeeds before restoring.", zap.Uint64("restore-ts", backupMeta.EndVersion))
 			if err := checkIncompatibleChangefeed(ctx, backupMeta.EndVersion, mgr.GetDomain().GetEtcdClient()); err != nil {
 				return errors.Trace(err)
 			}

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1263,10 +1263,13 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 		}
 	}
 	if cfg.CheckRequirements {
-		log.Info("Checking incompatible TiCDC changefeeds before restoring.",
-			logutil.ShortError(err), zap.Uint64("restore-ts", backupMeta.EndVersion))
-		if err := checkIncompatibleChangefeed(ctx, backupMeta.EndVersion, mgr.GetDomain().GetEtcdClient()); err != nil {
-			return errors.Trace(err)
+		// When `restore point`, we have already checked changefeed compatibility outside.
+		if cfg.piTRTaskInfo == nil {
+			log.Info("Checking incompatible TiCDC changefeeds before restoring.",
+				logutil.ShortError(err), zap.Uint64("restore-ts", backupMeta.EndVersion))
+			if err := checkIncompatibleChangefeed(ctx, backupMeta.EndVersion, mgr.GetDomain().GetEtcdClient()); err != nil {
+				return errors.Trace(err)
+			}
 		}
 
 		backupVersion := version.NormalizeBackupVersion(backupMeta.ClusterVersion)

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1305,7 +1305,7 @@ func checkTaskCompat(cfg *RestoreConfig, task streamhelper.Task) error {
 func checkIncompatibleChangefeed(ctx context.Context, backupTS uint64, etcdCLI *clientv3.Client) error {
 	nameSet, err := cdcutil.GetIncompatibleChangefeedsWithSafeTS(ctx, etcdCLI, backupTS)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if !nameSet.Empty() {
 		return errors.Errorf("%splease remove changefeed(s) before restore", nameSet.MessageToUser())
@@ -1432,6 +1432,12 @@ func RunStreamRestore(
 	cfg.RestoreStartTS = restoreStartTS
 	log.Info("captured restore start timestamp for blocklist",
 		zap.Uint64("restoreStartTS", restoreStartTS))
+
+	if cfg.CheckRequirements {
+		if err := checkIncompatibleChangefeed(ctx, cfg.RestoreTS, mgr.GetDomain().GetEtcdClient()); err != nil {
+			return err
+		}
+	}
 
 	// restore full snapshot.
 	if taskInfo.NeedFullRestore {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68660

Problem Summary:

For PITR, TiCDC should only replicate changes after the restored point. Before this PR, the TiCDC compatibility check in the snapshot restore phase used the full backup `EndVersion`, which is only the log restore start boundary for PITR. As a result, a changefeed whose checkpoint is after the full backup TS but before the final PITR `RestoreTS` could be missed.

### What changed and how does it work?

- Run the TiCDC compatibility check in `RunStreamRestore` with the final PITR `cfg.RestoreTS`.
- Place the check after restore registration, so it uses any registry-resolved `RestoreTS`.
- Skip the old snapshot-phase TiCDC check when snapshot restore is invoked as part of `restore point`, because the outer PITR flow has already checked the correct timestamp.
- Keep non-PITR snapshot restore behavior unchanged: it still checks TiCDC changefeeds against `backupMeta.EndVersion`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test with a real TiCDC changefeed:

1. Build BR from this branch:
   ```bash
   make build_br
   ```
2. Start a local cluster and TiCDC:
   ```bash
   /root/.tiup/bin/tiup playground v9.0.0-beta.2.pre-nightly --tag pitr-cdc-e2e --without-monitor --db 1 --pd 1 --kv 1 --tiflash 0
   /root/.tiup/components/cdc/v9.0.0-beta.2.pre/cdc server --addr=127.0.0.1:8300 --advertise-addr=127.0.0.1:8300 --pd=http://127.0.0.1:2379
   ```
3. Create test data, take a full backup at `BASE_TS`, start log backup from `BASE_TS`, insert more rows, and force flush logs until the log checkpoint passes `RESTORE_TS`.
4. Create a real TiCDC changefeed with `start-ts = BASE_TS` and `sink-uri = blackhole://`.
5. Run PITR restore to `RESTORE_TS`:
   ```bash
   ./bin/br restore point --pd 127.0.0.1:2379 \
     --storage local://<workdir>/log \
     --full-backup-storage local://<workdir>/full \
     --restored-ts <RESTORE_TS> \
     --with-sys-table=false \
     --check-requirements=true
   ```
6. Observed result:
   ```text
   Error: found CDC changefeed(s): cluster/namespace: default/default changefeed(s): [pitr-cdc-e2e-cf-1780037671], please remove changefeed(s) before restore
   ```

Evidence from the run:

- `BASE_TS = 466626195423756341`
- `RESTORE_TS = 466626196380581889`
- TiCDC query showed `state = normal`, `start_ts = 466626195423756341`, `checkpoint_tso = 466626195423756341`, `creator_version = v9.0.0-beta.2`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
BR now checks running TiCDC changefeeds against the PITR restored timestamp before point-in-time restore.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error tracing for changefeed compatibility checks.
  * Skipped redundant compatibility checks in point-in-time restore scenarios.

* **New Features**
  * Added an optional pre-restore compatibility validation for stream restores, aborting when incompatible changefeeds are detected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->