### PR TITLE
executor: fix slow log push down bug

### DIFF
--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -60,6 +60,12 @@ type signalsKey struct{}
 // ParseSlowLogBatchSize is the batch size of slow-log lines for a worker to parse, exported for testing.
 var ParseSlowLogBatchSize = 64
 
+// slowLogTimeRangeInternalTolerance only widens internal file pruning and
+// reverse-scan stop checks. Rows are still filtered by the original time ranges
+// in slowLogChecker. In a real use cluster, the max time unorder thrift is 50ms.
+// The 1s tolerance should be enough.
+const slowLogTimeRangeInternalTolerance = time.Second
+
 // slowQueryRetriever is used to read slow log data.
 type slowQueryRetriever struct {
 	table                 *model.TableInfo
@@ -401,7 +407,7 @@ func newSlowLogReverseScanner(e *slowQueryRetriever, sctx sessionctx.Context) *s
 				minStart = tr.startTime
 			}
 		}
-		scanner.minStartTime = minStart
+		scanner.minStartTime = slowLogTimeWithTolerance(minStart, tz, -slowLogTimeRangeInternalTolerance)
 		scanner.hasMinStart = true
 	}
 	return scanner
@@ -1261,6 +1267,7 @@ func (e *slowQueryRetriever) getAllFiles(ctx context.Context, sctx sessionctx.Co
 	if err != nil {
 		return nil, err
 	}
+	tz := sctx.GetSessionVars().Location()
 	walkFn := func(path string, info os.DirEntry) error {
 		if info.IsDir() {
 			return nil
@@ -1289,12 +1296,11 @@ func (e *slowQueryRetriever) getAllFiles(ctx context.Context, sctx sessionctx.Co
 		if err != nil {
 			return handleErr(err)
 		}
-		tz := sctx.GetSessionVars().Location()
 		start := types.NewTime(types.FromGoTime(fileStartTime.In(tz)), mysql.TypeDatetime, types.MaxFsp)
 		if e.checker.enableTimeCheck {
 			notInAllTimeRanges := true
 			for _, tr := range e.checker.timeRanges {
-				if start.Compare(tr.endTime) <= 0 {
+				if start.Compare(slowLogTimeWithTolerance(tr.endTime, tz, slowLogTimeRangeInternalTolerance)) <= 0 {
 					notInAllTimeRanges = false
 					break
 				}
@@ -1316,7 +1322,7 @@ func (e *slowQueryRetriever) getAllFiles(ctx context.Context, sctx sessionctx.Co
 				end := types.NewTime(types.FromGoTime(fileEndTime.In(tz)), mysql.TypeDatetime, types.MaxFsp)
 				inTimeRanges := false
 				for _, tr := range e.checker.timeRanges {
-					if !(start.Compare(tr.endTime) > 0 || end.Compare(tr.startTime) < 0) {
+					if slowLogMayOverlapTimeRange(start, end, tr, tz) {
 						inTimeRanges = true
 						break
 					}
@@ -1360,7 +1366,7 @@ func (e *slowQueryRetriever) getAllFiles(ctx context.Context, sctx sessionctx.Co
 		end := logFiles[i+1].start
 		inTimeRanges := false
 		for _, tr := range e.checker.timeRanges {
-			if !(start.Compare(tr.endTime) > 0 || end.Compare(tr.startTime) < 0) {
+			if slowLogMayOverlapTimeRange(start, end, tr, tz) {
 				inTimeRanges = true
 				break
 			}
@@ -1370,6 +1376,20 @@ func (e *slowQueryRetriever) getAllFiles(ctx context.Context, sctx sessionctx.Co
 		}
 	}
 	return ret, err
+}
+
+func slowLogMayOverlapTimeRange(start, end types.Time, tr *timeRange, tz *time.Location) bool {
+	rangeStart := slowLogTimeWithTolerance(tr.startTime, tz, -slowLogTimeRangeInternalTolerance)
+	rangeEnd := slowLogTimeWithTolerance(tr.endTime, tz, slowLogTimeRangeInternalTolerance)
+	return !(start.Compare(rangeEnd) > 0 || end.Compare(rangeStart) < 0)
+}
+
+func slowLogTimeWithTolerance(t types.Time, tz *time.Location, tolerance time.Duration) types.Time {
+	goTime, err := t.CoreTime().GoTime(tz)
+	if err != nil {
+		return t
+	}
+	return types.NewTime(types.FromGoTime(goTime.Add(tolerance)), t.Type(), t.Fsp())
 }
 
 func (*slowQueryRetriever) getFileStartTime(ctx context.Context, file *os.File, compressed bool) (time.Time, error) {
@@ -1540,7 +1560,16 @@ func readLastLines(ctx context.Context, file *os.File, endCursor int64) ([]strin
 		}
 	}
 	finalStr := string(lines[firstNonNewlinePos:])
-	return strings.Split(strings.ReplaceAll(finalStr, "\r\n", "\n"), "\n"), len(finalStr), nil
+	return splitSlowLogLines(finalStr), len(finalStr), nil
+}
+
+func splitSlowLogLines(s string) []string {
+	lines := strings.Split(strings.ReplaceAll(s, "\r\n", "\n"), "\n")
+	// strip the last empty string if the ending is new line symbol.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
 }
 
 func (e *slowQueryRetriever) initializeAsyncParsing(ctx context.Context, sctx sessionctx.Context) {

--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -1322,7 +1322,7 @@ func (e *slowQueryRetriever) getAllFiles(ctx context.Context, sctx sessionctx.Co
 				end := types.NewTime(types.FromGoTime(fileEndTime.In(tz)), mysql.TypeDatetime, types.MaxFsp)
 				inTimeRanges := false
 				for _, tr := range e.checker.timeRanges {
-					if slowLogMayOverlapTimeRange(start, end, tr, tz) {
+					if slowLogMayOverlapTimeRangeWithTolerance(start, end, tr, tz) {
 						inTimeRanges = true
 						break
 					}
@@ -1366,7 +1366,7 @@ func (e *slowQueryRetriever) getAllFiles(ctx context.Context, sctx sessionctx.Co
 		end := logFiles[i+1].start
 		inTimeRanges := false
 		for _, tr := range e.checker.timeRanges {
-			if slowLogMayOverlapTimeRange(start, end, tr, tz) {
+			if slowLogMayOverlapTimeRangeWithTolerance(start, end, tr, tz) {
 				inTimeRanges = true
 				break
 			}
@@ -1378,7 +1378,7 @@ func (e *slowQueryRetriever) getAllFiles(ctx context.Context, sctx sessionctx.Co
 	return ret, err
 }
 
-func slowLogMayOverlapTimeRange(start, end types.Time, tr *timeRange, tz *time.Location) bool {
+func slowLogMayOverlapTimeRangeWithTolerance(start, end types.Time, tr *timeRange, tz *time.Location) bool {
 	rangeStart := slowLogTimeWithTolerance(tr.startTime, tz, -slowLogTimeRangeInternalTolerance)
 	rangeEnd := slowLogTimeWithTolerance(tr.endTime, tz, slowLogTimeRangeInternalTolerance)
 	return !(start.Compare(rangeEnd) > 0 || end.Compare(rangeStart) < 0)

--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -62,7 +62,7 @@ var ParseSlowLogBatchSize = 64
 
 // slowLogTimeRangeInternalTolerance only widens internal file pruning and
 // reverse-scan stop checks. Rows are still filtered by the original time ranges
-// in slowLogChecker. In a real use cluster, the max time unorder thrift is 50ms.
+// in slowLogChecker. In a real use cluster, the max time unorder drift is 50ms.
 // The 1s tolerance should be enough.
 const slowLogTimeRangeInternalTolerance = time.Second
 

--- a/pkg/executor/slow_query_test.go
+++ b/pkg/executor/slow_query_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/metadef"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
@@ -814,6 +815,16 @@ select 9;`
 	}
 }
 
+func getTimeColIdxFromRetrieverOutput(t *testing.T, outputCol []*model.ColumnInfo) int {
+	for idx, col := range outputCol {
+		if col.Name.O == variable.SlowLogTimeStr {
+			return idx
+		}
+	}
+	t.Fatalf("cannot find Time column in retriever output, %v", outputCol)
+	return -1
+}
+
 func TestSlowQueryRetrieverReversedScanWithLimit(t *testing.T) {
 	fileName := "tidb-slow-limit-reverse-scan.log"
 	slowLog := `# Time: 2020-02-15T18:00:01.000000+08:00
@@ -840,14 +851,7 @@ select 5;`
 	retriever.extractor = &plannercore.SlowQueryExtractor{Desc: true}
 	retriever.limit = 2
 
-	timeColIdx := -1
-	for idx, col := range retriever.outputCols {
-		if col.Name.O == variable.SlowLogTimeStr {
-			timeColIdx = idx
-			break
-		}
-	}
-	require.GreaterOrEqual(t, timeColIdx, 0)
+	timeColIdx := getTimeColIdxFromRetrieverOutput(t, retriever.outputCols)
 
 	DashboardSlowLogReadBlockCnt4Test = 0
 	ctx := context.Background()
@@ -872,7 +876,8 @@ select 5;`
 	require.NoError(t, retriever.close())
 
 	// The long DB line makes the middle slow-log block cross readLastLines chunks.
-	// Forward scan can parse it; reverse scan should not synthesize blank lines and drop it.
+	// Forward scan can parse it; reverse scan should not synthesize blank lines and
+	// drop it. Previous there's a bug when in the execution path of LIMIT.
 	crossChunkFileName := "tidb-slow-limit-reverse-scan-cross-chunk.log"
 	crossChunkSlowLog := fmt.Sprintf(`# Time: 2020-02-15T18:00:01.000000+08:00
 select 1;
@@ -945,6 +950,17 @@ select in-window-3;`
 	forwardRows, err := parseLog(forwardRetriever, sctx, reader)
 	require.NoError(t, err)
 	require.Len(t, forwardRows, 3)
+	timeColIdx := getTimeColIdxFromRetrieverOutput(t, forwardRetriever.outputCols)
+	t0, err := forwardRows[0][timeColIdx].ToString()
+	require.NoError(t, err)
+	t1, err := forwardRows[1][timeColIdx].ToString()
+	require.NoError(t, err)
+	t2, err := forwardRows[2][timeColIdx].ToString()
+	require.NoError(t, err)
+	require.Equal(t, "2020-02-15 18:00:00.000500", t0)
+	require.Equal(t, "2020-02-15 18:00:00.001000", t1)
+	require.Equal(t, "2020-02-15 18:00:00.001500", t2)
+
 	require.NoError(t, forwardRetriever.close())
 
 	// This mirrors real slow logs where adjacent # Time values can move backwards
@@ -964,6 +980,15 @@ select in-window-3;`
 		reverseRows = append(reverseRows, rows...)
 	}
 	require.Len(t, reverseRows, 3)
+	t0, err = reverseRows[0][timeColIdx].ToString()
+	require.NoError(t, err)
+	t1, err = reverseRows[1][timeColIdx].ToString()
+	require.NoError(t, err)
+	t2, err = reverseRows[2][timeColIdx].ToString()
+	require.NoError(t, err)
+	require.Equal(t, "2020-02-15 18:00:00.000500", t2)
+	require.Equal(t, "2020-02-15 18:00:00.001000", t1)
+	require.Equal(t, "2020-02-15 18:00:00.001500", t0)
 	require.NoError(t, reverseRetriever.close())
 }
 

--- a/pkg/executor/slow_query_test.go
+++ b/pkg/executor/slow_query_test.go
@@ -612,7 +612,7 @@ select 7;`
 	}
 }
 
-func TestSplitbyColon(t *testing.T) {
+func TestSplitByColon(t *testing.T) {
 	cases := []struct {
 		line   string
 		fields []string
@@ -870,6 +870,101 @@ select 5;`
 	require.Equal(t, "2020-02-15 22:00:05.000000", t0)
 	require.Equal(t, "2020-02-15 21:00:05.000000", t1)
 	require.NoError(t, retriever.close())
+
+	// The long DB line makes the middle slow-log block cross readLastLines chunks.
+	// Forward scan can parse it; reverse scan should not synthesize blank lines and drop it.
+	crossChunkFileName := "tidb-slow-limit-reverse-scan-cross-chunk.log"
+	crossChunkSlowLog := fmt.Sprintf(`# Time: 2020-02-15T18:00:01.000000+08:00
+select 1;
+# Time: 2020-02-15T19:00:05.000000+08:00
+# DB: %s
+select 2;
+# Time: 2020-02-15T20:00:05.000000+08:00
+select 3;`, strings.Repeat("x", 5000))
+	prepareLogs(t, []string{crossChunkSlowLog}, []string{crossChunkFileName})
+	defer removeFiles([]string{crossChunkFileName})
+	sctx.GetSessionVars().SlowQueryFile = crossChunkFileName
+
+	forwardRetriever, err := newSlowQueryRetriever()
+	require.NoError(t, err)
+	require.NoError(t, forwardRetriever.initialize(context.Background(), sctx))
+	reader, err := forwardRetriever.getNextReader()
+	require.NoError(t, err)
+	forwardRows, err := parseLog(forwardRetriever, sctx, reader)
+	require.NoError(t, err)
+	require.Len(t, forwardRows, 3)
+	require.NoError(t, forwardRetriever.close())
+
+	reverseRetriever, err := newSlowQueryRetriever()
+	require.NoError(t, err)
+	reverseRetriever.extractor = &plannercore.SlowQueryExtractor{Desc: true}
+	reverseRetriever.limit = 3
+	reverseRows := make([][]types.Datum, 0, reverseRetriever.limit)
+	for {
+		rows, err := reverseRetriever.retrieve(context.Background(), sctx)
+		require.NoError(t, err)
+		if len(rows) == 0 {
+			break
+		}
+		reverseRows = append(reverseRows, rows...)
+	}
+	require.Len(t, reverseRows, 3)
+	require.NoError(t, reverseRetriever.close())
+}
+
+func TestSlowQueryRetrieverReversedScanWithTimeJitter(t *testing.T) {
+	fileName := "tidb-slow-limit-reverse-scan-time-jitter.log"
+	slowLog := `# Time: 2020-02-15T18:00:00.000500+08:00
+select in-window-1;
+# Time: 2020-02-15T18:00:00.001000+08:00
+select in-window-2;
+# Time: 2020-02-15T17:59:59.999700+08:00
+select just-before-window;
+# Time: 2020-02-15T18:00:00.001500+08:00
+select in-window-3;`
+	prepareLogs(t, []string{slowLog}, []string{fileName})
+	defer removeFiles([]string{fileName})
+
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	require.NoError(t, err)
+	sctx := mock.NewContext()
+	sctx.ResetSessionAndStmtTimeZone(loc)
+	sctx.GetSessionVars().SlowQueryFile = fileName
+	startTime, err := ParseTime("2020-02-15T18:00:00.000000+08:00")
+	require.NoError(t, err)
+	endTime, err := ParseTime("2020-02-15T18:00:00.002000+08:00")
+	require.NoError(t, err)
+	timeRange := []*plannercore.TimeRange{{StartTime: startTime, EndTime: endTime}}
+
+	forwardRetriever, err := newSlowQueryRetriever()
+	require.NoError(t, err)
+	forwardRetriever.extractor = &plannercore.SlowQueryExtractor{Enable: true, TimeRanges: timeRange}
+	require.NoError(t, forwardRetriever.initialize(context.Background(), sctx))
+	reader, err := forwardRetriever.getNextReader()
+	require.NoError(t, err)
+	forwardRows, err := parseLog(forwardRetriever, sctx, reader)
+	require.NoError(t, err)
+	require.Len(t, forwardRows, 3)
+	require.NoError(t, forwardRetriever.close())
+
+	// This mirrors real slow logs where adjacent # Time values can move backwards
+	// by a few milliseconds. A block just before the lower bound should not make
+	// reverse scan stop before earlier in-range blocks are read.
+	reverseRetriever, err := newSlowQueryRetriever()
+	require.NoError(t, err)
+	reverseRetriever.extractor = &plannercore.SlowQueryExtractor{Enable: true, Desc: true, TimeRanges: timeRange}
+	reverseRetriever.limit = 3
+	reverseRows := make([][]types.Datum, 0, reverseRetriever.limit)
+	for {
+		rows, err := reverseRetriever.retrieve(context.Background(), sctx)
+		require.NoError(t, err)
+		if len(rows) == 0 {
+			break
+		}
+		reverseRows = append(reverseRows, rows...)
+	}
+	require.Len(t, reverseRows, 3)
+	require.NoError(t, reverseRetriever.close())
 }
 
 func TestPBPlanBuilderPushDownLimitToSlowQueryRetriever(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68758

bug 1: if the new line symbol is at the ending of internal chunk, the file scan will be finsihed too early because empty string will break the loop

bug 2: slow log has some time drift because record time and write time is different. We should tolerate it

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below) 
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

checked with real slow log files collected from user.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slow query log scanning and pruning with tolerance for minor time-order variations, improving reverse scans and file selection
  * Normalized slow-log tail parsing to handle mixed line endings and avoid dropped entries

* **Tests**
  * Added tests for time-boundary jitter and cross-chunk scenarios (including long lines); renamed an existing parsing test for clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->