### PR TITLE
ddl: fix some bug in create mv/ create mv log

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1096,6 +1096,7 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 			return infoschema.ErrColumnNotExists.GenWithStackByArgs(c.O, s.Table.Name.O)
 		}
 		ft := baseCol.FieldType
+		ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
 		colDefs = append(colDefs, &ast.ColumnDef{
 			Name: &ast.ColumnName{Name: c},
 			Tp:   &ft,

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -875,6 +875,12 @@ func validateCreateMaterializedViewQuery(
 				if !mysql.HasNotNullFlag(baseColMap[colName].GetFlag()) {
 					return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStack("CREATE MATERIALIZED VIEW only supports SUM/MIN/MAX on NOT NULL column")
 				}
+				if aggFunc == ast.AggFuncSum {
+					tp := baseColMap[colName].GetType()
+					if types.IsTypeTime(tp) || tp == mysql.TypeDuration {
+						return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStack("CREATE MATERIALIZED VIEW does not support SUM on DATE/DATETIME/TIMESTAMP/TIME column")
+					}
+				}
 				if aggFunc == ast.AggFuncMin || aggFunc == ast.AggFuncMax {
 					hasMinOrMax = true
 				}

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -126,6 +126,7 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 	colDefs := make([]*ast.ColumnDef, 0, len(resultFields))
 	for i, rf := range resultFields {
 		ft := rf.Column.FieldType
+		ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
 		colDefs = append(colDefs, &ast.ColumnDef{
 			Name: &ast.ColumnName{Name: s.Cols[i]},
 			Tp:   &ft,

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -280,6 +280,7 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 			return infoschema.ErrColumnNotExists.GenWithStackByArgs(c.O, s.Table.Name.O)
 		}
 		ft := baseCol.FieldType
+		ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
 		colDefs = append(colDefs, &ast.ColumnDef{
 			Name: &ast.ColumnName{Name: c},
 			Tp:   &ft,

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -140,6 +140,18 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	err = tk.ExecToErr("create materialized view mv_bad_sum_nullable (a, s, c) as select a, sum(b), count(1) from t_sum_nullable group by a")
 	require.ErrorContains(t, err, "only supports SUM/MIN/MAX on NOT NULL column")
 
+	// SUM does not support time or duration columns.
+	tk.MustExec("create table t_sum_time (a int not null, d date not null default '2020-01-01', dt datetime not null default '2020-01-01 00:00:00', ts timestamp not null default '2020-01-01 00:00:00', dur time not null default '00:00:00')")
+	tk.MustExec("create materialized view log on t_sum_time (a, d, dt, ts, dur) purge next date_add(now(), interval 1 hour)")
+	err = tk.ExecToErr("create materialized view mv_bad_sum_date (a, s, c) as select a, sum(d), count(1) from t_sum_time group by a")
+	require.ErrorContains(t, err, "does not support SUM on DATE/DATETIME/TIMESTAMP/TIME column")
+	err = tk.ExecToErr("create materialized view mv_bad_sum_datetime (a, s, c) as select a, sum(dt), count(1) from t_sum_time group by a")
+	require.ErrorContains(t, err, "does not support SUM on DATE/DATETIME/TIMESTAMP/TIME column")
+	err = tk.ExecToErr("create materialized view mv_bad_sum_timestamp (a, s, c) as select a, sum(ts), count(1) from t_sum_time group by a")
+	require.ErrorContains(t, err, "does not support SUM on DATE/DATETIME/TIMESTAMP/TIME column")
+	err = tk.ExecToErr("create materialized view mv_bad_sum_time (a, s, c) as select a, sum(dur), count(1) from t_sum_time group by a")
+	require.ErrorContains(t, err, "does not support SUM on DATE/DATETIME/TIMESTAMP/TIME column")
+
 	// MIN/MAX requires a base-table index whose leading columns cover all GROUP BY columns.
 	tk.MustExec("create table t_minmax_bad (a int not null, b int not null, c int not null, index idx_cab(c, a, b))")
 	tk.MustExec("create materialized view log on t_minmax_bad (a, b, c) purge next date_add(now(), interval 1 hour)")
@@ -245,6 +257,7 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	tk.MustExec("drop materialized view log on t")
 	tk.MustExec("drop materialized view log on t_nullable")
 	tk.MustExec("drop materialized view log on t_sum_nullable")
+	tk.MustExec("drop materialized view log on t_sum_time")
 	tk.MustExec("drop materialized view log on t_minmax_bad")
 	tk.MustExec("drop materialized view log on t_minmax_ok")
 	tk.MustExec("drop materialized view log on t_presplit")

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -423,6 +423,18 @@ func TestMaterializedViewDDLProtectsMinMaxSupportingBaseTableIndexesAgainstConcu
 	tk.MustQuery("select a, b, minc, cnt from mv_concurrent_drop_idx").Check(testkit.Rows("1 2 5 2"))
 }
 
+func TestCreateMaterializedViewLogColumnKeyFlag(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table base_test(id int, v1 int, v2 int, v3 int, v4 int, index k(v1,v2,v3,v4))")
+	tk.MustExec("create materialized view log on base_test(v1, v2) purge next date_add(now(), interval 1 hour)")
+	tk.MustQuery("select column_key from information_schema.columns where table_schema='test' and table_name='$mlog$base_test' and column_name='v1'").
+		Check(testkit.Rows(""))
+	tk.MustQuery("select column_key from information_schema.columns where table_schema='test' and table_name='$mlog$base_test' and column_name='v2'").
+		Check(testkit.Rows(""))
+}
+
 func TestShowCreateMaterializedView(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -435,6 +435,23 @@ func TestCreateMaterializedViewLogColumnKeyFlag(t *testing.T) {
 		Check(testkit.Rows(""))
 }
 
+func TestCreateMaterializedViewColumnFlags(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table base_mv_flags(id bigint not null auto_increment primary key, g1 int not null, v1 bigint not null, key idx_g1_id(g1, id))")
+	tk.MustExec("create materialized view log on base_mv_flags(id, g1, v1) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_flags (g1, cnt, s_v1, min_id, max_id) as select g1, count(1), sum(v1), min(id), max(id) from base_mv_flags group by g1")
+	tk.MustQuery("select column_key from information_schema.columns where table_schema='test' and table_name='mv_flags' and column_name='min_id'").
+		Check(testkit.Rows(""))
+	tk.MustQuery("select extra from information_schema.columns where table_schema='test' and table_name='mv_flags' and column_name='min_id'").
+		Check(testkit.Rows(""))
+	tk.MustQuery("select column_key from information_schema.columns where table_schema='test' and table_name='mv_flags' and column_name='max_id'").
+		Check(testkit.Rows(""))
+	tk.MustQuery("select extra from information_schema.columns where table_schema='test' and table_name='mv_flags' and column_name='max_id'").
+		Check(testkit.Rows(""))
+}
+
 func TestShowCreateMaterializedView(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:

Some materialized view and materialized view log DDL paths can inherit source column flags that should not be preserved on derived storage columns. In addition, SUM over temporal columns is not supported by the current MV maintenance implementation and should be rejected at CREATE MATERIALIZED VIEW validation time.

### What changed and how does it work?

This PR contains several materialized-view DDL refinements:

- Clear primary-key, unique-key, multiple-key, auto-increment, and ON UPDATE flags when deriving materialized view log columns from base table columns.
- Clear the same inherited flags when deriving materialized view physical columns from the MV SELECT result fields.
- Reject CREATE MATERIALIZED VIEW definitions that use SUM on DATE, DATETIME, TIMESTAMP, or TIME columns.
- Add regression coverage for MV log column key flags, MV physical column flags, and SUM over temporal columns.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit tests run:

```bash
/bin/bash -lc '(find "$PWD"/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl enable); pushd pkg/executor/test/ddl >/dev/null; go test -run "TestCreateMaterializedViewLogColumnKeyFlag$" -tags=intest,deadlock -count=1; rc=$?; popd >/dev/null; find "$PWD"/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable; exit $rc'
/bin/bash -lc '(find "$PWD"/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl enable); pushd pkg/executor/test/ddl >/dev/null; go test -run "Test(CreateMaterializedViewColumnFlags|MaterializedViewDDLBasic)$" -tags=intest,deadlock -count=1; rc=$?; popd >/dev/null; find "$PWD"/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable; exit $rc'
make bazel_lint_changed
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Refine materialized view DDL validation and derived column metadata handling.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Materialized view logs now correctly exclude inherited base table column attributes and constraints.
  * Removed unnecessary key and constraint flags from materialized view log columns.

* **Improvements**
  * Added validation to reject SUM aggregate functions on time and duration column types with appropriate error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->