### PR TITLE
test: stabilize flaky TestLoadData

### DIFF
--- a/pkg/executor/test/loaddatatest/BUILD.bazel
+++ b/pkg/executor/test/loaddatatest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 14,
+    shard_count = 4,
     deps = [
         "//pkg/config",
         "//pkg/executor",

--- a/pkg/executor/test/loaddatatest/load_data_test.go
+++ b/pkg/executor/test/loaddatatest/load_data_test.go
@@ -317,7 +317,39 @@ func TestLoadData(t *testing.T) {
 	//checkCases(tests, ld, t, tk, ctx, selectSQL, deleteSQL)
 }
 
-func TestLoadDataEscape(t *testing.T) {
+func TestLoadDataNULL(t *testing.T) {
+	testLoadDataNULL(t)
+	for _, tt := range []struct {
+		name string
+		fn   func(*testing.T)
+	}{
+		{name: "TestLoadDataEscape", fn: testLoadDataEscape},
+		{name: "TestLoadDataSpecifiedColumns", fn: testLoadDataSpecifiedColumns},
+		{name: "TestLoadDataIgnoreLines", fn: testLoadDataIgnoreLines},
+		{name: "TestLoadDataReplace", fn: testLoadDataReplace},
+		{name: "TestLoadDataOverflowBigintUnsigned", fn: testLoadDataOverflowBigintUnsigned},
+	} {
+		t.Run(tt.name, tt.fn)
+	}
+}
+
+func TestLoadDataWithUppercaseUserVars(t *testing.T) {
+	testLoadDataWithUppercaseUserVars(t)
+	for _, tt := range []struct {
+		name string
+		fn   func(*testing.T)
+	}{
+		{name: "TestLoadDataIntoPartitionedTable", fn: testLoadDataIntoPartitionedTable},
+		{name: "TestLoadDataFromServerFile", fn: testLoadDataFromServerFile},
+		{name: "TestFix56408", fn: testFix56408},
+		{name: "TestLoadDataAutoRandomError", fn: testLoadDataAutoRandomError},
+		{name: "TestLoadDataLowPrioritySetsKVLowPriority", fn: testLoadDataLowPrioritySetsKVLowPriority},
+	} {
+		t.Run(tt.name, tt.fn)
+	}
+}
+
+func testLoadDataEscape(t *testing.T) {
 	trivialMsg := "Records: 1  Deleted: 0  Skipped: 0  Warnings: 0"
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -344,7 +376,7 @@ func TestLoadDataEscape(t *testing.T) {
 }
 
 // TestLoadDataSpecifiedColumns reuse TestLoadDataEscape's test case :-)
-func TestLoadDataSpecifiedColumns(t *testing.T) {
+func testLoadDataSpecifiedColumns(t *testing.T) {
 	trivialMsg := "Records: 1  Deleted: 0  Skipped: 0  Warnings: 0"
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -367,7 +399,7 @@ func TestLoadDataSpecifiedColumns(t *testing.T) {
 	checkCases(tests, loadSQL, t, tk, ctx, selectSQL, deleteSQL)
 }
 
-func TestLoadDataIgnoreLines(t *testing.T) {
+func testLoadDataIgnoreLines(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test; drop table if exists load_data_test;")
@@ -383,7 +415,7 @@ func TestLoadDataIgnoreLines(t *testing.T) {
 	checkCases(tests, loadSQL, t, tk, ctx, selectSQL, deleteSQL)
 }
 
-func TestLoadDataNULL(t *testing.T) {
+func testLoadDataNULL(t *testing.T) {
 	// https://dev.mysql.com/doc/refman/8.0/en/load-data.html
 	// - For the default FIELDS and LINES values, NULL is written as a field value of \N for output, and a field value of \N is read as NULL for input (assuming that the ESCAPED BY character is \).
 	// - If FIELDS ENCLOSED BY is not empty, a field containing the literal word NULL as its value is read as a NULL value. This differs from the word NULL enclosed within FIELDS ENCLOSED BY characters, which is read as the string 'NULL'.
@@ -409,7 +441,7 @@ FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n';`
 	checkCases(tests, loadSQL, t, tk, ctx, selectSQL, deleteSQL)
 }
 
-func TestLoadDataReplace(t *testing.T) {
+func testLoadDataReplace(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("USE test; DROP TABLE IF EXISTS load_data_replace;")
@@ -426,8 +458,8 @@ func TestLoadDataReplace(t *testing.T) {
 	checkCases(tests, loadSQL, t, tk, ctx, selectSQL, deleteSQL)
 }
 
-// TestLoadDataOverflowBigintUnsigned related to issue 6360
-func TestLoadDataOverflowBigintUnsigned(t *testing.T) {
+// testLoadDataOverflowBigintUnsigned related to issue 6360
+func testLoadDataOverflowBigintUnsigned(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test; drop table if exists load_data_test;")
@@ -443,7 +475,7 @@ func TestLoadDataOverflowBigintUnsigned(t *testing.T) {
 	checkCases(tests, loadSQL, t, tk, ctx, selectSQL, deleteSQL)
 }
 
-func TestLoadDataWithUppercaseUserVars(t *testing.T) {
+func testLoadDataWithUppercaseUserVars(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test; drop table if exists load_data_test;")
@@ -459,7 +491,7 @@ func TestLoadDataWithUppercaseUserVars(t *testing.T) {
 	checkCases(tests, loadSQL, t, tk, ctx, selectSQL, deleteSQL)
 }
 
-func TestLoadDataIntoPartitionedTable(t *testing.T) {
+func testLoadDataIntoPartitionedTable(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -477,7 +509,7 @@ func TestLoadDataIntoPartitionedTable(t *testing.T) {
 	checkCases(tests, loadSQL, t, tk, ctx, selectSQL, deleteSQL)
 }
 
-func TestLoadDataFromServerFile(t *testing.T) {
+func testLoadDataFromServerFile(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -486,7 +518,7 @@ func TestLoadDataFromServerFile(t *testing.T) {
 	require.ErrorContains(t, err, "[executor:8154]Don't support load data from tidb-server's disk.")
 }
 
-func TestFix56408(t *testing.T) {
+func testFix56408(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("USE test; DROP TABLE IF EXISTS load_data_replace;")
@@ -505,11 +537,11 @@ func TestFix56408(t *testing.T) {
 	tk.MustExec("ADMIN CHECK TABLE a")
 }
 
-// TestLoadDataAutoRandomError tests that LOAD DATA returns proper error
+// testLoadDataAutoRandomError tests that LOAD DATA returns proper error
 // when inserting explicit values into AUTO_RANDOM column without
 // allow_auto_random_explicit_insert enabled.
 // See https://github.com/pingcap/tidb/issues/65585
-func TestLoadDataAutoRandomError(t *testing.T) {
+func testLoadDataAutoRandomError(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -566,7 +598,7 @@ func (c *checkKVPrioClient) SendRequest(ctx context.Context, addr string, req *t
 	return c.Client.SendRequest(ctx, addr, req, timeout)
 }
 
-func TestLoadDataLowPrioritySetsKVLowPriority(t *testing.T) {
+func testLoadDataLowPrioritySetsKVLowPriority(t *testing.T) {
 	cli := &checkKVPrioClient{}
 	store := testkit.CreateMockStore(t, mockstore.WithClientHijacker(func(c tikv.Client) tikv.Client {
 		cli.Client = c


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68279

Problem Summary:
Flaky test `TestLoadData` in `pkg/executor/test/loaddatatest` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Race-enabled `loaddatatest` over-sharded 14 mockstore-heavy top-level tests, creating CI resource-pressure timeouts.

#### Fix

Grouping smaller cases as subtests preserves assertions and setup while reducing generated shard_count from 14 to 4.

#### Verification

Spec:
- target: `pkg/executor/test/loaddatatest :: TestLoadData`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package passed.
bazel_prepare passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package: PASS
- bazel_prepare: PASS
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/executor/test/loaddatatest -run '^TestLoadData$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/executor/test/loaddatatest -count=1`
- `XDG_CACHE_HOME=/tmp/bazelisk-cache PATH=/tmp/bazelbin:$PATH make bazel_prepare`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reorganized the LOAD DATA test suite into grouped parent tests with subtests, improving test organization and reporting.
  * Adjusted test parallelization settings to streamline execution while preserving existing test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->