### PR TITLE
ddl, mvservice: notify alter MV and MV log events

### DIFF
--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -1005,9 +1005,9 @@ func (w *worker) runOneJobStep(
 	case model.ActionModifyTableComment:
 		ver, err = onModifyTableComment(jobCtx, job)
 	case model.ActionAlterMaterializedViewRefresh:
-		ver, err = onAlterMaterializedViewRefresh(jobCtx, job)
+		ver, err = onAlterMaterializedViewRefresh(jobCtx, job, w.sess)
 	case model.ActionAlterMaterializedViewLogPurge:
-		ver, err = onAlterMaterializedViewLogPurge(jobCtx, job)
+		ver, err = onAlterMaterializedViewLogPurge(jobCtx, job, w.sess)
 	case model.ActionModifyTableAutoIDCache:
 		ver, err = onModifyTableAutoIDCache(jobCtx, job)
 	case model.ActionAddTablePartition:

--- a/pkg/ddl/notifier/BUILD.bazel
+++ b/pkg/ddl/notifier/BUILD.bazel
@@ -36,7 +36,7 @@ go_test(
     ],
     embed = [":notifier"],
     flaky = True,
-    shard_count = 12,
+    shard_count = 13,
     deps = [
         "//pkg/ddl",
         "//pkg/ddl/session",

--- a/pkg/ddl/notifier/events.go
+++ b/pkg/ddl/notifier/events.go
@@ -104,6 +104,50 @@ func (s *SchemaChangeEvent) GetCreateTableInfo() *model.TableInfo {
 	return s.inner.TableInfo
 }
 
+// NewAlterMaterializedViewRefreshEvent creates a SchemaChangeEvent whose type is
+// ActionAlterMaterializedViewRefresh.
+func NewAlterMaterializedViewRefreshEvent(
+	tableInfo *model.TableInfo,
+	oldTableInfo *model.TableInfo,
+) *SchemaChangeEvent {
+	return &SchemaChangeEvent{
+		inner: &jsonSchemaChangeEvent{
+			Tp:           model.ActionAlterMaterializedViewRefresh,
+			TableInfo:    tableInfo,
+			OldTableInfo: oldTableInfo,
+		},
+	}
+}
+
+// GetAlterMaterializedViewRefreshInfo returns the table info of the SchemaChangeEvent whose type is
+// ActionAlterMaterializedViewRefresh.
+func (s *SchemaChangeEvent) GetAlterMaterializedViewRefreshInfo() *model.TableInfo {
+	intest.Assert(s.inner.Tp == model.ActionAlterMaterializedViewRefresh)
+	return s.inner.TableInfo
+}
+
+// NewAlterMaterializedViewLogPurgeEvent creates a SchemaChangeEvent whose type is
+// ActionAlterMaterializedViewLogPurge.
+func NewAlterMaterializedViewLogPurgeEvent(
+	tableInfo *model.TableInfo,
+	oldTableInfo *model.TableInfo,
+) *SchemaChangeEvent {
+	return &SchemaChangeEvent{
+		inner: &jsonSchemaChangeEvent{
+			Tp:           model.ActionAlterMaterializedViewLogPurge,
+			TableInfo:    tableInfo,
+			OldTableInfo: oldTableInfo,
+		},
+	}
+}
+
+// GetAlterMaterializedViewLogPurgeInfo returns the table info of the SchemaChangeEvent whose type is
+// ActionAlterMaterializedViewLogPurge.
+func (s *SchemaChangeEvent) GetAlterMaterializedViewLogPurgeInfo() *model.TableInfo {
+	intest.Assert(s.inner.Tp == model.ActionAlterMaterializedViewLogPurge)
+	return s.inner.TableInfo
+}
+
 // NewTruncateTableEvent creates a SchemaChangeEvent whose type is
 // ActionTruncateTable.
 func NewTruncateTableEvent(

--- a/pkg/ddl/notifier/events_test.go
+++ b/pkg/ddl/notifier/events_test.go
@@ -68,3 +68,26 @@ func TestEventString(t *testing.T) {
 		"Index ID: 9, Index Name: Index1, Index ID: 10, Index Name: Index2)"
 	require.Equal(t, expected, result)
 }
+
+func TestMVAlterEventConstructors(t *testing.T) {
+	mvTbl := &model.TableInfo{
+		ID:   101,
+		Name: pmodel.NewCIStr("mv"),
+	}
+	oldMVTbl := mvTbl.Clone()
+	mlogTbl := &model.TableInfo{
+		ID:   102,
+		Name: pmodel.NewCIStr("$mlog$t"),
+	}
+	oldMLogTbl := mlogTbl.Clone()
+
+	alterMVRefresh := NewAlterMaterializedViewRefreshEvent(mvTbl, oldMVTbl)
+	require.Equal(t, model.ActionAlterMaterializedViewRefresh, alterMVRefresh.GetType())
+	require.Same(t, mvTbl, alterMVRefresh.GetAlterMaterializedViewRefreshInfo())
+	require.Same(t, oldMVTbl, alterMVRefresh.inner.OldTableInfo)
+
+	alterMLogPurge := NewAlterMaterializedViewLogPurgeEvent(mlogTbl, oldMLogTbl)
+	require.Equal(t, model.ActionAlterMaterializedViewLogPurge, alterMLogPurge.GetType())
+	require.Same(t, mlogTbl, alterMLogPurge.GetAlterMaterializedViewLogPurgeInfo())
+	require.Same(t, oldMLogTbl, alterMLogPurge.inner.OldTableInfo)
+}

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -1048,7 +1048,7 @@ func onModifyTableComment(jobCtx *jobContext, job *model.Job) (ver int64, _ erro
 	return ver, nil
 }
 
-func onAlterMaterializedViewRefresh(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+func onAlterMaterializedViewRefresh(jobCtx *jobContext, job *model.Job, se *sess.Session) (ver int64, _ error) {
 	args, err := model.GetAlterMaterializedViewRefreshArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
@@ -1069,6 +1069,7 @@ func onAlterMaterializedViewRefresh(jobCtx *jobContext, job *model.Job) (ver int
 		return ver, nil
 	}
 
+	oldTblInfo := tblInfo.Clone()
 	tblInfo.MaterializedView.RefreshMethod = args.RefreshMethod
 	tblInfo.MaterializedView.RefreshStartWith = args.RefreshStartWith
 	tblInfo.MaterializedView.RefreshNext = args.RefreshNext
@@ -1077,11 +1078,16 @@ func onAlterMaterializedViewRefresh(jobCtx *jobContext, job *model.Job) (ver int
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
+	alterMVRefreshEvent := notifier.NewAlterMaterializedViewRefreshEvent(tblInfo, oldTblInfo)
+	err = asyncNotifyEvent(jobCtx, alterMVRefreshEvent, job, noSubJob, se)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
 	job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
 	return ver, nil
 }
 
-func onAlterMaterializedViewLogPurge(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+func onAlterMaterializedViewLogPurge(jobCtx *jobContext, job *model.Job, se *sess.Session) (ver int64, _ error) {
 	args, err := model.GetAlterMaterializedViewLogPurgeArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
@@ -1102,11 +1108,17 @@ func onAlterMaterializedViewLogPurge(jobCtx *jobContext, job *model.Job) (ver in
 		return ver, nil
 	}
 
+	oldTblInfo := tblInfo.Clone()
 	tblInfo.MaterializedViewLog.PurgeMethod = args.PurgeMethod
 	tblInfo.MaterializedViewLog.PurgeStartWith = args.PurgeStartWith
 	tblInfo.MaterializedViewLog.PurgeNext = args.PurgeNext
 
 	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+	alterMLogPurgeEvent := notifier.NewAlterMaterializedViewLogPurgeEvent(tblInfo, oldTblInfo)
+	err = asyncNotifyEvent(jobCtx, alterMLogPurgeEvent, job, noSubJob, se)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}

--- a/pkg/executor/test/writetest/BUILD.bazel
+++ b/pkg/executor/test/writetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "write_test.go",
     ],
     flaky = True,
-    shard_count = 45,
+    shard_count = 46,
     deps = [
         "//pkg/config",
         "//pkg/errctx",

--- a/pkg/executor/test/writetest/mview_log_write_test.go
+++ b/pkg/executor/test/writetest/mview_log_write_test.go
@@ -950,6 +950,31 @@ func TestMLogOnlineDDLDropUntrackedColumn(t *testing.T) {
 	))
 }
 
+func TestMLogOnlineDDLDropTrackedColumnRejected(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@global.tidb_enable_metadata_lock=0")
+
+	tk.MustExec("create table t (id int primary key, tracked int, untracked int)")
+	tk.MustExec("create materialized view log on t (id, tracked)")
+	tk.MustExec("insert into t values (1, 10, 100)")
+	execAsMViewMaintenance(tk, "delete from `$mlog$t`")
+
+	tkDDL := testkit.NewTestKit(t, store)
+	tkDDL.MustExec("use test")
+	err := tkDDL.ExecToErr("alter table t drop column tracked")
+	require.ErrorContains(t, err, "Unsupported ALTER TABLE on base table column tracked referenced by materialized view log")
+
+	// The tracked column remains valid after rejected DDL and mlog writing should work.
+	tk.MustExec("insert into t values (2, 20, 200)")
+	tk.MustQuery(
+		"select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`",
+	).Sort().Check(testkit.Rows(
+		"2 20 I 1",
+	))
+}
+
 func TestMLogDropTrackedColumnRejected(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -960,14 +985,19 @@ func TestMLogDropTrackedColumnRejected(t *testing.T) {
 	err := tk.ExecToErr("alter table t drop column tracked")
 	require.ErrorContains(t, err, "Unsupported ALTER TABLE on base table column tracked referenced by materialized view log")
 
-	// The failed DDL should leave both the base table schema and mlog behavior intact.
+	// DML remains writable and tracked-column change logs are still generated as expected.
 	tk.MustExec("insert into t values (1, 10, 100)")
+	tk.MustExec("update t set tracked = 11 where id = 1")
+	tk.MustExec("delete from t where id = 1")
 	tk.MustQuery(
 		"select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`",
-	).Check(testkit.Rows(
+	).Sort().Check(testkit.Rows(
 		"1 10 I 1",
+		"1 10 U -1",
+		"1 11 D -1",
+		"1 11 U 1",
 	))
-	tk.MustQuery("select id, tracked, untracked from t").Check(testkit.Rows("1 10 100"))
+	tk.MustQuery("select count(*) from information_schema.columns where table_schema = 'test' and table_name = 't' and column_name = 'tracked'").Check(testkit.Rows("1"))
 }
 
 func TestMLogGeneratedColumn(t *testing.T) {

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -543,6 +543,8 @@ func shouldHandleMVCreateEvent(event *notifier.SchemaChangeEvent) bool {
 	case meta.ActionDropTable:
 		dropped := event.GetDropTableInfo()
 		return hasMVRelatedTableInfo(dropped)
+	case meta.ActionAlterMaterializedViewRefresh, meta.ActionAlterMaterializedViewLogPurge:
+		return true
 	default:
 		// For other DDL types, rely on the periodic metadata refresh.
 		return false

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -1144,6 +1144,16 @@ func TestRegisterMVServiceBootstrapAndDDLHandler(t *testing.T) {
 	})
 	require.NoError(t, gotHandler(context.Background(), nil, dropMVTableEvent))
 	require.Equal(t, int32(3), called.Load())
+
+	alterMVRefreshEvent := &notifier.SchemaChangeEvent{}
+	require.NoError(t, alterMVRefreshEvent.UnmarshalJSON([]byte(fmt.Sprintf(`{"type":%d}`, meta.ActionAlterMaterializedViewRefresh))))
+	require.NoError(t, gotHandler(context.Background(), nil, alterMVRefreshEvent))
+	require.Equal(t, int32(4), called.Load())
+
+	alterMLogPurgeEvent := &notifier.SchemaChangeEvent{}
+	require.NoError(t, alterMLogPurgeEvent.UnmarshalJSON([]byte(fmt.Sprintf(`{"type":%d}`, meta.ActionAlterMaterializedViewLogPurge))))
+	require.NoError(t, gotHandler(context.Background(), nil, alterMLogPurgeEvent))
+	require.Equal(t, int32(5), called.Load())
 }
 
 func TestServerHelperLoadAllTiDBMLogPurge(t *testing.T) {

--- a/tests/integrationtest/r/executor/mview_log_dml.result
+++ b/tests/integrationtest/r/executor/mview_log_dml.result
@@ -109,10 +109,15 @@ create table t (id int primary key, tracked int, untracked int);
 create materialized view log on t (id, tracked);
 alter table t drop column tracked;
 Error 8200 (HY000): Unsupported ALTER TABLE on base table column tracked referenced by materialized view log
-insert into t values (1, 100, 1000);
-select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`;
+insert into t values (1, 10, 100);
+update t set tracked = 11 where id = 1;
+delete from t where id = 1;
+select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 id	tracked	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
-1	100	I	1
+1	10	I	1
+1	10	U	-1
+1	11	D	-1
+1	11	U	1
 drop table if exists t, `$mlog$t`;
 create table t(a int);
 create materialized view log on t (a);

--- a/tests/integrationtest/t/executor/mview_log_dml.test
+++ b/tests/integrationtest/t/executor/mview_log_dml.test
@@ -96,7 +96,7 @@ alter table t drop column untracked;
 update t set tracked = 11 where id = 1;
 select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 
-# DDL on tracked columns is rejected up-front
+# DDL on tracked columns is rejected up-front and mlog remains usable
 
 drop table if exists t;
 drop table if exists `$mlog$t`;
@@ -104,8 +104,10 @@ create table t (id int primary key, tracked int, untracked int);
 create materialized view log on t (id, tracked);
 --error 8200
 alter table t drop column tracked;
-insert into t values (1, 100, 1000);
-select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`;
+insert into t values (1, 10, 100);
+update t set tracked = 11 where id = 1;
+delete from t where id = 1;
+select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 
 # Test for issue #66245, the mlog table should not use the base table's auto-increment id by mistake.
 drop table if exists t, `$mlog$t`;


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

MV service needs to be notified when materialized view or materialized view log scheduling metadata is changed by `ALTER`, so that background refresh/purge scheduling can react asynchronously instead of waiting only for periodic polling.

### What changed and how does it work?

This PR adds async DDL notifier events for materialized view and materialized view log alter operations:

- Adds notifier event types for `ALTER MATERIALIZED VIEW` and `ALTER MATERIALIZED VIEW LOG`.
- Emits the corresponding async notifier events when these DDL jobs are processed.
- Lets MV service consume these events and refresh related task metadata.
- Adds/updates tests for notifier events, MV service task handling, and MV log write behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support async notification for materialized view and materialized view log alter events.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event notification support for materialized view refresh and log purge DDL operations.

* **Bug Fixes**
  * Improved session handling in materialized view DDL job dispatchers.
  * Enhanced validation to properly reject online DDL operations on base table columns tracked by materialized view logs.

* **Tests**
  * Expanded test coverage for materialized view event constructors and online DDL scenarios with materialized view logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->