### PR TITLE
executor: fix MV refresh internal-session usage collection

### DIFF
--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -849,6 +849,11 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		return err
 	}
 	defer e.ReleaseSysSession(kctx, refreshSctx)
+	if collectorAware, ok := refreshSctx.(interface{ AttachStatsCollectorForInternalSession() func() }); ok {
+		// REFRESH MATERIALIZED VIEW runs real maintenance reads/writes against user tables, so
+		// reuse the full session collectors here, including index usage collection when enabled.
+		defer collectorAware.AttachStatsCollectorForInternalSession()()
+	}
 	sqlExec := refreshSctx.GetSQLExecutor()
 	sessVars := refreshSctx.GetSessionVars()
 	targetMaintainMemQuota, err := resolveMVMaintenanceMemQuota(kctx, e.Ctx().GetSessionVars(), isInternalSQL)

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -272,6 +272,49 @@ func TestMaterializedViewRefreshFastMinMax(t *testing.T) {
 	))
 }
 
+func TestMaterializedViewRefreshFastMinMaxWhereSeparateIndexes(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec(`create table t_mv_fast_minmax_where (
+		id bigint not null primary key,
+		g1 int not null,
+		v1 bigint not null,
+		v2 decimal(10,2) not null,
+		c1 int not null,
+		f1 int not null,
+		key idx_g1(g1),
+		key idx_f1(f1)
+	)`)
+	tk.MustExec("create materialized view log on t_mv_fast_minmax_where (id, g1, v1, v2, c1, f1) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec(`create materialized view mv_fast_minmax_where (g1, cnt, s_v1, min_v2, max_v2, cnt_c1)
+		refresh fast next now() as
+		select g1, count(*), sum(v1), min(v2), max(v2), count(c1)
+		from t_mv_fast_minmax_where
+		where f1 = 1
+		group by g1`)
+
+	tk.MustExec("insert into t_mv_fast_minmax_where values (19001, 1, 1, 1.00, 1, 1), (19002, 2, 2, 2.00, 1, 1)")
+	tk.MustExec("refresh materialized view mv_fast_minmax_where with sync mode fast")
+	tk.MustQuery("select * from mv_fast_minmax_where order by g1").Check(testkit.Rows(
+		"1 1 1 1.00 1.00 1",
+		"2 1 2 2.00 2.00 1",
+	))
+
+	tk.MustExec("update t_mv_fast_minmax_where set g1 = 2, v1 = 10, f1 = 2, v2 = 9.00, c1 = 1 where id = 19001")
+	tk.MustExec("refresh materialized view mv_fast_minmax_where with sync mode fast")
+	tk.MustQuery("select * from mv_fast_minmax_where order by g1").Check(testkit.Rows(
+		"2 1 2 2.00 2.00 1",
+	))
+
+	tk.MustExec("update t_mv_fast_minmax_where set f1 = 1 where id = 19001")
+	tk.MustExec("refresh materialized view mv_fast_minmax_where with sync mode fast")
+	tk.MustQuery("select * from mv_fast_minmax_where order by g1").Check(testkit.Rows(
+		"2 2 12 2.00 9.00 2",
+	))
+}
+
 func TestMaterializedViewRefreshCompleteUsesDefinitionSessionSemantics(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -216,6 +216,36 @@ func TestMaterializedViewRefreshFastMethodTracksManualAndAutomatic(t *testing.T)
 		Check(testkit.Rows("fast automatically 1"))
 }
 
+func TestMaterializedViewRefreshFastUpdatesStatsModifyCount(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_fast_stats (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_fast_stats values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t_mv_fast_stats (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_fast_stats (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t_mv_fast_stats group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv_fast_stats"))
+	require.NoError(t, err)
+	mvID := mvTable.Meta().ID
+
+	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(true))
+	tk.MustExec("analyze table mv_fast_stats")
+	tk.MustQuery(fmt.Sprintf("select modify_count, count from mysql.stats_meta where table_id = %d", mvID)).
+		Check(testkit.Rows("0 2"))
+
+	tk.MustExec("delete from t_mv_fast_stats where a = 1 and b = 10")
+	tk.MustExec("delete from t_mv_fast_stats where a = 2 and b = 7")
+	tk.MustExec("insert into t_mv_fast_stats values (3, 4)")
+	tk.MustExec("refresh materialized view mv_fast_stats fast")
+	tk.MustQuery("select a, s, cnt from mv_fast_stats order by a").Check(testkit.Rows("1 5 1", "3 4 1"))
+
+	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(true))
+	tk.MustQuery(fmt.Sprintf("select modify_count, count from mysql.stats_meta where table_id = %d", mvID)).
+		Check(testkit.Rows("3 2"))
+}
+
 func TestMaterializedViewRefreshFastMinMax(t *testing.T) {
 	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3903,6 +3903,32 @@ func attachStatsCollector(s *session, dom *domain.Domain) *session {
 	return s
 }
 
+// AttachStatsCollectorForInternalSession lazily attaches the same collectors used by
+// regular sessions for a specific internal session when the caller knows it will touch
+// user tables. This intentionally keeps index usage collection enabled as well when
+// tidb_enable_collect_execution_info is on, because internal maintenance SQL should be
+// reflected in usage accounting just like foreground SQL.
+// It returns a restore function that detaches only the collectors attached by this call.
+func (s *session) AttachStatsCollectorForInternalSession() func() {
+	dom, ok := s.dom.(*domain.Domain)
+	if !ok || dom == nil {
+		return func() {}
+	}
+	hadStatsCollector := s.statsCollector != nil
+	hadIdxUsageCollector := s.idxUsageCollector != nil
+	attachStatsCollector(s, dom)
+	return func() {
+		if !hadStatsCollector && s.statsCollector != nil {
+			s.statsCollector.Delete()
+			s.statsCollector = nil
+		}
+		if !hadIdxUsageCollector && s.idxUsageCollector != nil {
+			s.idxUsageCollector.Flush()
+			s.idxUsageCollector = nil
+		}
+	}
+}
+
 // detachStatsCollector removes the stats collector in the session
 func detachStatsCollector(s *session) *session {
 	if s.statsCollector != nil {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

This PR improves materialized view refresh correctness coverage around internal refresh planning/execution:

- MV refresh internal sessions did not attach the outer session's index/stats usage collector, so index and statistics usage generated by internal refresh statements could be lost.
- The full-update lookup `INL_JOIN` hint DB-name issue is already fixed in the current base branch; this PR adds executor-level regression coverage for that MV refresh scenario.

### What changed and how does it work?

- Attach the index/stats usage collector to MV refresh internal sessions.
- Add regression coverage for MV refresh full-update lookup with separate indexes, covering the `INL_JOIN` hint DB-name scenario.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix materialized view refresh internal-session index/statistics usage collection and add regression coverage for full-update lookup planning.
```
