### PR TITLE
test: stabilize flaky TestWithTaskManager

### DIFF
--- a/pkg/resourcemanager/pool/spool/spool_test.go
+++ b/pkg/resourcemanager/pool/spool/spool_test.go
@@ -194,8 +194,20 @@ func TestWithTaskManager(t *testing.T) {
 	require.NoError(t, err)
 	defer p.ReleaseAndWait()
 	fnChan := make(chan func(), 10)
+	defer close(fnChan)
 	require.NoError(t, p.RunWithConcurrency(fnChan, 2), "submit when pool is not full shouldn't return error")
-	time.Sleep(100 * time.Microsecond)
+	workerReady := make(chan struct{})
+	fnChan <- func() {
+		close(workerReady)
+	}
+	require.Eventually(t, func() bool {
+		select {
+		case <-workerReady:
+			return true
+		default:
+			return false
+		}
+	}, 1*time.Second, 10*time.Millisecond)
 	require.Equal(t, int32(1), p.Running())
 
 	// increase the concurrency
@@ -210,5 +222,4 @@ func TestWithTaskManager(t *testing.T) {
 	require.Eventually(t, func() bool { return p.Running() == 2 }, 1*time.Second, 200*time.Millisecond)
 	p.Tune(1)
 	require.Eventually(t, func() bool { return p.Running() == 1 }, 1*time.Second, 200*time.Millisecond)
-	close(fnChan)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68266

Problem Summary:
Flaky test `TestWithTaskManager` in `pkg/resourcemanager/pool/spool` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Fixed startup synchronization in TestWithTaskManager so it no longer relies on a 100us sleep before task-manager tuning.

#### Fix

The queued signaling function proves the worker is active before Tune is exercised, which is the state the test intended to validate.

#### Verification

Spec:
- target: `pkg/resourcemanager/pool/spool :: TestWithTaskManager`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky_validation passed.
package_validation passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky_validation: PASS
- package_validation: PASS
- scheduler_stress: SKIPPED
- build: PASS
- lint: PASS
- external_ci: SKIPPED

Commands:
- `go test -json -tags=intest,deadlock ./pkg/resourcemanager/pool/spool -run '^TestWithTaskManager$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/resourcemanager/pool/spool -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and efficiency by replacing fixed delays with synchronization-based waiting mechanisms.

**Note:** This release contains only internal testing improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68798?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->