### PR TITLE
executor, parser: add show materialized views and show materialized view logs

### DIFF
--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -220,6 +220,10 @@ func (e *ShowExec) fetchAll(ctx context.Context) error {
 		return e.fetchShowStatus()
 	case ast.ShowTables:
 		return e.fetchShowTables(ctx)
+	case ast.ShowMaterializedViews:
+		return e.fetchShowMaterializedViews(ctx)
+	case ast.ShowMaterializedViewLogs:
+		return e.fetchShowMaterializedViewLogs(ctx)
 	case ast.ShowOpenTables:
 		return e.fetchShowOpenTables()
 	case ast.ShowTableStatus:
@@ -625,6 +629,106 @@ func (e *ShowExec) fetchShowTables(ctx context.Context) error {
 		} else {
 			e.appendRow([]any{v})
 		}
+	}
+	return nil
+}
+
+func (e *ShowExec) fetchShowMaterializedViews(ctx context.Context) error {
+	checker := privilege.GetPrivilegeManager(e.Ctx())
+	if checker != nil && e.Ctx().GetSessionVars().User != nil {
+		if !checker.DBIsVisible(e.Ctx().GetSessionVars().ActiveRoles, e.DBName.O) {
+			return e.dbAccessDenied()
+		}
+	}
+	if !e.is.SchemaExists(e.DBName) {
+		return exeerrors.ErrBadDB.GenWithStackByArgs(e.DBName)
+	}
+
+	tables, err := e.is.SchemaTableInfos(ctx, e.DBName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	activeRoles := e.Ctx().GetSessionVars().ActiveRoles
+	type mvRow struct {
+		id   int64
+		name string
+	}
+	rows := make([]mvRow, 0)
+	for _, tbl := range tables {
+		if tbl.MaterializedView == nil {
+			continue
+		}
+		if checker != nil && !checker.RequestVerification(activeRoles, e.DBName.O, tbl.Name.O, "", mysql.AllPrivMask) {
+			continue
+		}
+		rows = append(rows, mvRow{id: tbl.ID, name: tbl.Name.O})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].name == rows[j].name {
+			return rows[i].id < rows[j].id
+		}
+		return rows[i].name < rows[j].name
+	})
+	for _, row := range rows {
+		e.appendRow([]any{row.id, row.name})
+	}
+	return nil
+}
+
+func (e *ShowExec) fetchShowMaterializedViewLogs(ctx context.Context) error {
+	checker := privilege.GetPrivilegeManager(e.Ctx())
+	if checker != nil && e.Ctx().GetSessionVars().User != nil {
+		if !checker.DBIsVisible(e.Ctx().GetSessionVars().ActiveRoles, e.DBName.O) {
+			return e.dbAccessDenied()
+		}
+	}
+	if !e.is.SchemaExists(e.DBName) {
+		return exeerrors.ErrBadDB.GenWithStackByArgs(e.DBName)
+	}
+
+	tables, err := e.is.SchemaTableInfos(ctx, e.DBName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	activeRoles := e.Ctx().GetSessionVars().ActiveRoles
+	type mlogRow struct {
+		id       int64
+		name     string
+		baseID   int64
+		baseName string
+	}
+	rows := make([]mlogRow, 0)
+	for _, tbl := range tables {
+		if tbl.MaterializedViewLog == nil {
+			continue
+		}
+		if checker != nil && !checker.RequestVerification(activeRoles, e.DBName.O, tbl.Name.O, "", mysql.AllPrivMask) {
+			continue
+		}
+		baseID := tbl.MaterializedViewLog.BaseTableID
+		baseName := ""
+		if baseID != 0 {
+			if baseTbl, ok := e.is.TableByID(ctx, baseID); ok {
+				baseName = baseTbl.Meta().Name.O
+			}
+		}
+		rows = append(rows, mlogRow{
+			id:       tbl.ID,
+			name:     tbl.Name.O,
+			baseID:   baseID,
+			baseName: baseName,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].name == rows[j].name {
+			return rows[i].id < rows[j].id
+		}
+		return rows[i].name < rows[j].name
+	})
+	for _, row := range rows {
+		e.appendRow([]any{row.id, row.name, row.baseID, row.baseName})
 	}
 	return nil
 }

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -650,6 +650,14 @@ func (e *ShowExec) fetchShowMaterializedViews(ctx context.Context) error {
 	}
 
 	activeRoles := e.Ctx().GetSessionVars().ActiveRoles
+	var (
+		fieldFilter       string
+		fieldPatternsLike collate.WildcardPattern
+	)
+	if e.Extractor != nil {
+		fieldFilter = e.Extractor.Field()
+		fieldPatternsLike = e.Extractor.FieldPatternLike()
+	}
 	type mvRow struct {
 		id   int64
 		name string
@@ -660,6 +668,12 @@ func (e *ShowExec) fetchShowMaterializedViews(ctx context.Context) error {
 			continue
 		}
 		if checker != nil && !checker.RequestVerification(activeRoles, e.DBName.O, tbl.Name.O, "", mysql.AllPrivMask) {
+			continue
+		}
+		if fieldFilter != "" && tbl.Name.L != fieldFilter {
+			continue
+		}
+		if fieldPatternsLike != nil && !fieldPatternsLike.DoMatch(tbl.Name.L) {
 			continue
 		}
 		rows = append(rows, mvRow{id: tbl.ID, name: tbl.Name.O})
@@ -693,6 +707,14 @@ func (e *ShowExec) fetchShowMaterializedViewLogs(ctx context.Context) error {
 	}
 
 	activeRoles := e.Ctx().GetSessionVars().ActiveRoles
+	var (
+		fieldFilter       string
+		fieldPatternsLike collate.WildcardPattern
+	)
+	if e.Extractor != nil {
+		fieldFilter = e.Extractor.Field()
+		fieldPatternsLike = e.Extractor.FieldPatternLike()
+	}
 	type mlogRow struct {
 		id       int64
 		name     string
@@ -705,6 +727,12 @@ func (e *ShowExec) fetchShowMaterializedViewLogs(ctx context.Context) error {
 			continue
 		}
 		if checker != nil && !checker.RequestVerification(activeRoles, e.DBName.O, tbl.Name.O, "", mysql.AllPrivMask) {
+			continue
+		}
+		if fieldFilter != "" && tbl.Name.L != fieldFilter {
+			continue
+		}
+		if fieldPatternsLike != nil && !fieldPatternsLike.DoMatch(tbl.Name.L) {
 			continue
 		}
 		baseID := tbl.MaterializedViewLog.BaseTableID

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -443,17 +443,28 @@ func TestShowMaterializedViews(t *testing.T) {
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv (a, s, cnt) as select a, sum(b), count(1) from t group by a")
+	tk.MustExec("create database test_show_mv_other")
+	tk.MustExec("create table test_show_mv_other.t (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on test_show_mv_other.t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view test_show_mv_other.mv_other (a, s, cnt) as select a, sum(b), count(1) from test_show_mv_other.t group by a")
 
 	is := dom.InfoSchema()
 	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv"))
 	require.NoError(t, err)
 	mvID := mvTable.Meta().ID
+	otherMVTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test_show_mv_other"), pmodel.NewCIStr("mv_other"))
+	require.NoError(t, err)
+	otherMVID := otherMVTable.Meta().ID
 
 	tk.MustQuery("show materialized views").Check(testkit.Rows(fmt.Sprintf("%d mv", mvID)))
 	tk.MustQuery(fmt.Sprintf("show materialized views where mview_id = %d", mvID)).
 		Check(testkit.Rows(fmt.Sprintf("%d mv", mvID)))
 	tk.MustQuery("show materialized views where mview_name = 'mv'").Check(testkit.Rows(fmt.Sprintf("%d mv", mvID)))
 	tk.MustQuery("show materialized views where mview_name = 'mv_not_exist'").Check(testkit.Rows())
+	tk.MustQuery("show materialized views from test_show_mv_other").
+		Check(testkit.Rows(fmt.Sprintf("%d mv_other", otherMVID)))
+	tk.MustQuery("show materialized views in test_show_mv_other like 'mv_%'").
+		Check(testkit.Rows(fmt.Sprintf("%d mv_other", otherMVID)))
 }
 
 func TestShowMaterializedViewLogs(t *testing.T) {
@@ -462,6 +473,9 @@ func TestShowMaterializedViewLogs(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create database test_show_mlog_other")
+	tk.MustExec("create table test_show_mlog_other.t_other (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on test_show_mlog_other.t_other (a, b) purge next date_add(now(), interval 1 hour)")
 
 	is := dom.InfoSchema()
 	baseTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
@@ -473,6 +487,14 @@ func TestShowMaterializedViewLogs(t *testing.T) {
 	mlogName := mlogTable.Meta().Name.O
 	baseID := baseTable.Meta().ID
 	baseName := baseTable.Meta().Name.O
+	otherBaseTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test_show_mlog_other"), pmodel.NewCIStr("t_other"))
+	require.NoError(t, err)
+	require.NotNil(t, otherBaseTable.Meta().MaterializedViewBase)
+	otherMLogID := otherBaseTable.Meta().MaterializedViewBase.MLogID
+	otherMLogTable, ok := is.TableByID(context.Background(), otherMLogID)
+	require.True(t, ok)
+	otherMLogName := otherMLogTable.Meta().Name.O
+	otherExpected := fmt.Sprintf("%d %s %d %s", otherMLogID, otherMLogName, otherBaseTable.Meta().ID, otherBaseTable.Meta().Name.O)
 
 	expected := fmt.Sprintf("%d %s %d %s", mlogID, mlogName, baseID, baseName)
 	tk.MustQuery("show materialized view logs").Check(testkit.Rows(expected))
@@ -485,6 +507,10 @@ func TestShowMaterializedViewLogs(t *testing.T) {
 	tk.MustQuery(fmt.Sprintf("show materialized view logs where base_table_name = '%s'", baseName)).
 		Check(testkit.Rows(expected))
 	tk.MustQuery("show materialized view logs where base_table_name = 't_not_exist'").Check(testkit.Rows())
+	tk.MustQuery("show materialized view logs from test_show_mlog_other").
+		Check(testkit.Rows(otherExpected))
+	tk.MustQuery("show materialized view logs in test_show_mlog_other like '$mlog$%'").
+		Check(testkit.Rows(otherExpected))
 }
 
 func TestCreateMaterializedViewLogColumnKeyFlag(t *testing.T) {

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -436,6 +436,57 @@ func TestMaterializedViewDDLProtectsMinMaxSupportingBaseTableIndexesAgainstConcu
 	tk.MustQuery("select a, b, minc, cnt from mv_concurrent_drop_idx").Check(testkit.Rows("1 2 5 2"))
 }
 
+func TestShowMaterializedViews(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) as select a, sum(b), count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv"))
+	require.NoError(t, err)
+	mvID := mvTable.Meta().ID
+
+	tk.MustQuery("show materialized views").Check(testkit.Rows(fmt.Sprintf("%d mv", mvID)))
+	tk.MustQuery(fmt.Sprintf("show materialized views where mview_id = %d", mvID)).
+		Check(testkit.Rows(fmt.Sprintf("%d mv", mvID)))
+	tk.MustQuery("show materialized views where mview_name = 'mv'").Check(testkit.Rows(fmt.Sprintf("%d mv", mvID)))
+	tk.MustQuery("show materialized views where mview_name = 'mv_not_exist'").Check(testkit.Rows())
+}
+
+func TestShowMaterializedViewLogs(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+
+	is := dom.InfoSchema()
+	baseTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
+	require.NoError(t, err)
+	require.NotNil(t, baseTable.Meta().MaterializedViewBase)
+	mlogID := baseTable.Meta().MaterializedViewBase.MLogID
+	mlogTable, ok := is.TableByID(context.Background(), mlogID)
+	require.True(t, ok)
+	mlogName := mlogTable.Meta().Name.O
+	baseID := baseTable.Meta().ID
+	baseName := baseTable.Meta().Name.O
+
+	expected := fmt.Sprintf("%d %s %d %s", mlogID, mlogName, baseID, baseName)
+	tk.MustQuery("show materialized view logs").Check(testkit.Rows(expected))
+	tk.MustQuery(fmt.Sprintf("show materialized view logs where mlog_id = %d", mlogID)).
+		Check(testkit.Rows(expected))
+	tk.MustQuery(fmt.Sprintf("show materialized view logs where base_table_id = %d", baseID)).
+		Check(testkit.Rows(expected))
+	tk.MustQuery(fmt.Sprintf("show materialized view logs where mlog_name = '%s'", mlogName)).
+		Check(testkit.Rows(expected))
+	tk.MustQuery(fmt.Sprintf("show materialized view logs where base_table_name = '%s'", baseName)).
+		Check(testkit.Rows(expected))
+	tk.MustQuery("show materialized view logs where base_table_name = 't_not_exist'").Check(testkit.Rows())
+}
+
 func TestCreateMaterializedViewLogColumnKeyFlag(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -2994,6 +2994,8 @@ const (
 	ShowEngines
 	ShowDatabases
 	ShowTables
+	ShowMaterializedViews
+	ShowMaterializedViewLogs
 	ShowTableStatus
 	ShowColumns
 	ShowWarnings
@@ -3358,6 +3360,10 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 			restoreOptFull()
 			ctx.WriteKeyWord("TABLES")
 			restoreShowDatabaseNameOpt()
+		case ShowMaterializedViews:
+			ctx.WriteKeyWord("MATERIALIZED VIEWS")
+		case ShowMaterializedViewLogs:
+			ctx.WriteKeyWord("MATERIALIZED VIEW LOGS")
 		case ShowOpenTables:
 			ctx.WriteKeyWord("OPEN TABLES")
 			restoreShowDatabaseNameOpt()
@@ -3525,7 +3531,7 @@ func (n *ShowStmt) Accept(v Visitor) (Node, bool) {
 func (n *ShowStmt) NeedLimitRSRow() bool {
 	switch n.Tp {
 	// Show statements need to have consistence behavior with MySQL Does
-	case ShowEngines, ShowDatabases, ShowTables, ShowColumns, ShowTableStatus, ShowWarnings,
+	case ShowEngines, ShowDatabases, ShowTables, ShowMaterializedViews, ShowMaterializedViewLogs, ShowColumns, ShowTableStatus, ShowWarnings,
 		ShowCharset, ShowVariables, ShowStatus, ShowCollation, ShowIndex, ShowPlugins:
 		return true
 	default:

--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -3362,8 +3362,10 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 			restoreShowDatabaseNameOpt()
 		case ShowMaterializedViews:
 			ctx.WriteKeyWord("MATERIALIZED VIEWS")
+			restoreShowDatabaseNameOpt()
 		case ShowMaterializedViewLogs:
 			ctx.WriteKeyWord("MATERIALIZED VIEW LOGS")
+			restoreShowDatabaseNameOpt()
 		case ShowOpenTables:
 			ctx.WriteKeyWord("OPEN TABLES")
 			restoreShowDatabaseNameOpt()

--- a/pkg/parser/keywords.go
+++ b/pkg/parser/keywords.go
@@ -635,6 +635,7 @@ var Keywords = []KeywordsType{
 	{"VARIABLES", false, "unreserved"},
 	{"VECTOR", false, "unreserved"},
 	{"VIEW", false, "unreserved"},
+	{"VIEWS", false, "unreserved"},
 	{"VISIBLE", false, "unreserved"},
 	{"WAIT", false, "unreserved"},
 	{"WAIT_TIFLASH_READY", false, "unreserved"},

--- a/pkg/parser/keywords_test.go
+++ b/pkg/parser/keywords_test.go
@@ -36,7 +36,7 @@ func TestKeywords(t *testing.T) {
 }
 
 func TestKeywordsLength(t *testing.T) {
-	require.Equal(t, 665, len(parser.Keywords))
+	require.Equal(t, 666, len(parser.Keywords))
 
 	reservedNr := 0
 	for _, kw := range parser.Keywords {

--- a/pkg/parser/misc.go
+++ b/pkg/parser/misc.go
@@ -910,6 +910,7 @@ var tokenMap = map[string]int{
 	"VOTER_CONSTRAINTS":        voterConstraints,
 	"VOTERS":                   voters,
 	"VIEW":                     view,
+	"VIEWS":                    views,
 	"VIRTUAL":                  virtual,
 	"VISIBLE":                  visible,
 	"WARNINGS":                 warnings,

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -690,6 +690,7 @@ import (
 	variables             "VARIABLES"
 	vectorType            "VECTOR"
 	view                  "VIEW"
+	views                 "VIEWS"
 	visible               "VISIBLE"
 	wait                  "WAIT"
 	waitTiflashReady      "WAIT_TIFLASH_READY"
@@ -7334,6 +7335,7 @@ UnReservedKeyword:
 |	"BINLOG"
 |	"FUNCTION"
 |	"VIEW"
+|	"VIEWS"
 |	"BINDING"
 |	"BINDINGS"
 |	"MODIFY"
@@ -11945,6 +11947,22 @@ ShowStmt:
 			} else {
 				stmt.Where = $3.(ast.ExprNode)
 			}
+		}
+		$$ = stmt
+	}
+|	"SHOW" "MATERIALIZED" "VIEWS" WhereClauseOptional
+	{
+		stmt := &ast.ShowStmt{Tp: ast.ShowMaterializedViews}
+		if $4 != nil {
+			stmt.Where = $4.(ast.ExprNode)
+		}
+		$$ = stmt
+	}
+|	"SHOW" "MATERIALIZED" "VIEW" "LOGS" WhereClauseOptional
+	{
+		stmt := &ast.ShowStmt{Tp: ast.ShowMaterializedViewLogs}
+		if $5 != nil {
+			stmt.Where = $5.(ast.ExprNode)
 		}
 		$$ = stmt
 	}

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -11950,19 +11950,29 @@ ShowStmt:
 		}
 		$$ = stmt
 	}
-|	"SHOW" "MATERIALIZED" "VIEWS" WhereClauseOptional
+|	"SHOW" "MATERIALIZED" "VIEWS" ShowDatabaseNameOpt ShowLikeOrWhereOpt
 	{
 		stmt := &ast.ShowStmt{Tp: ast.ShowMaterializedViews}
-		if $4 != nil {
-			stmt.Where = $4.(ast.ExprNode)
+		stmt.DBName = $4
+		if $5 != nil {
+			if x, ok := $5.(*ast.PatternLikeOrIlikeExpr); ok && x.Expr == nil {
+				stmt.Pattern = x
+			} else {
+				stmt.Where = $5.(ast.ExprNode)
+			}
 		}
 		$$ = stmt
 	}
-|	"SHOW" "MATERIALIZED" "VIEW" "LOGS" WhereClauseOptional
+|	"SHOW" "MATERIALIZED" "VIEW" "LOGS" ShowDatabaseNameOpt ShowLikeOrWhereOpt
 	{
 		stmt := &ast.ShowStmt{Tp: ast.ShowMaterializedViewLogs}
-		if $5 != nil {
-			stmt.Where = $5.(ast.ExprNode)
+		stmt.DBName = $5
+		if $6 != nil {
+			if x, ok := $6.(*ast.PatternLikeOrIlikeExpr); ok && x.Expr == nil {
+				stmt.Pattern = x
+			} else {
+				stmt.Where = $6.(ast.ExprNode)
+			}
 		}
 		$$ = stmt
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1288,6 +1288,12 @@ func TestDBAStmt(t *testing.T) {
 		// for show create materialized view log
 		{"show create materialized view log on test.t", true, "SHOW CREATE MATERIALIZED VIEW LOG ON `test`.`t`"},
 		{"show create materialized view log on t", true, "SHOW CREATE MATERIALIZED VIEW LOG ON `t`"},
+		// for show materialized views
+		{"show materialized views", true, "SHOW MATERIALIZED VIEWS"},
+		{"show materialized views where mview_id = 1", true, "SHOW MATERIALIZED VIEWS WHERE `mview_id`=1"},
+		// for show materialized view logs
+		{"show materialized view logs", true, "SHOW MATERIALIZED VIEW LOGS"},
+		{"show materialized view logs where mlog_id = 1", true, "SHOW MATERIALIZED VIEW LOGS WHERE `mlog_id`=1"},
 		// for show create database
 		{"show create database d1", true, "SHOW CREATE DATABASE `d1`"},
 		{"show create database if not exists d1", true, "SHOW CREATE DATABASE IF NOT EXISTS `d1`"},

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1290,9 +1290,13 @@ func TestDBAStmt(t *testing.T) {
 		{"show create materialized view log on t", true, "SHOW CREATE MATERIALIZED VIEW LOG ON `t`"},
 		// for show materialized views
 		{"show materialized views", true, "SHOW MATERIALIZED VIEWS"},
+		{"show materialized views from test", true, "SHOW MATERIALIZED VIEWS IN `test`"},
+		{"show materialized views in test like 'mv%'", true, "SHOW MATERIALIZED VIEWS IN `test` LIKE _UTF8MB4'mv%'"},
 		{"show materialized views where mview_id = 1", true, "SHOW MATERIALIZED VIEWS WHERE `mview_id`=1"},
 		// for show materialized view logs
 		{"show materialized view logs", true, "SHOW MATERIALIZED VIEW LOGS"},
+		{"show materialized view logs from test", true, "SHOW MATERIALIZED VIEW LOGS IN `test`"},
+		{"show materialized view logs in test like '$mlog$%'", true, "SHOW MATERIALIZED VIEW LOGS IN `test` LIKE _UTF8MB4'$mlog$%'"},
 		{"show materialized view logs where mlog_id = 1", true, "SHOW MATERIALIZED VIEW LOGS WHERE `mlog_id`=1"},
 		// for show create database
 		{"show create database d1", true, "SHOW CREATE DATABASE `d1`"},

--- a/pkg/planner/core/casetest/mview/BUILD.bazel
+++ b/pkg/planner/core/casetest/mview/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "mv_refresh_test.go",
     ],
     flaky = True,
-    shard_count = 6,
+    shard_count = 8,
     deps = [
         "//pkg/domain",
         "//pkg/infoschema",

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3555,8 +3555,8 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (base.P
 	buildPattern := true
 
 	switch show.Tp {
-	case ast.ShowDatabases, ast.ShowVariables, ast.ShowTables, ast.ShowColumns, ast.ShowTableStatus, ast.ShowCollation:
-		if (show.Tp == ast.ShowTables || show.Tp == ast.ShowTableStatus) && p.DBName == "" {
+	case ast.ShowDatabases, ast.ShowVariables, ast.ShowTables, ast.ShowMaterializedViews, ast.ShowMaterializedViewLogs, ast.ShowColumns, ast.ShowTableStatus, ast.ShowCollation:
+		if (show.Tp == ast.ShowTables || show.Tp == ast.ShowTableStatus || show.Tp == ast.ShowMaterializedViews || show.Tp == ast.ShowMaterializedViewLogs) && p.DBName == "" {
 			return nil, plannererrors.ErrNoDB
 		}
 		if extractor := newShowBaseExtractor(*show); extractor.Extract() {
@@ -6327,6 +6327,12 @@ func buildShowSchema(s *ast.ShowStmt, isView bool, isSequence bool) (schema *exp
 		if s.Full {
 			names = append(names, "Table_type")
 		}
+	case ast.ShowMaterializedViews:
+		names = []string{"mview_id", "mview_name"}
+		ftypes = []byte{mysql.TypeLonglong, mysql.TypeVarchar}
+	case ast.ShowMaterializedViewLogs:
+		names = []string{"mlog_id", "mlog_name", "base_table_id", "base_table_name"}
+		ftypes = []byte{mysql.TypeLonglong, mysql.TypeVarchar, mysql.TypeLonglong, mysql.TypeVarchar}
 	case ast.ShowTableStatus:
 		names = []string{"Name", "Engine", "Version", "Row_format", "Rows", "Avg_row_length",
 			"Data_length", "Max_data_length", "Index_length", "Data_free", "Auto_increment",

--- a/pkg/planner/core/show_predicate_extractor.go
+++ b/pkg/planner/core/show_predicate_extractor.go
@@ -87,7 +87,7 @@ func (e *ShowBaseExtractor) ExplainInfo() string {
 	switch e.ShowStmt.Tp {
 	case ast.ShowVariables, ast.ShowColumns:
 		key = fieldKey
-	case ast.ShowTables, ast.ShowTableStatus:
+	case ast.ShowTables, ast.ShowMaterializedViews, ast.ShowMaterializedViewLogs, ast.ShowTableStatus:
 		key = tableKey
 	case ast.ShowDatabases:
 		key = databaseKey


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

TiDB has internal metadata for materialized views and materialized view logs, but there is no dedicated `SHOW` statement for users to list them directly.

### What changed and how does it work?

This PR adds:

- `SHOW MATERIALIZED VIEWS`, returning `mview_id` and `mview_name`.
- `SHOW MATERIALIZED VIEW LOGS`, returning `mlog_id`, `mlog_name`, `base_table_id`, and `base_table_name`.
- Parser, planner schema, executor, and regression test coverage for the new statements.
- Existing `SHOW ... WHERE ...` filtering support through the normal `SHOW` statement path.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support `SHOW MATERIALIZED VIEWS` and `SHOW MATERIALIZED VIEW LOGS` statements.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SHOW MATERIALIZED VIEWS and SHOW MATERIALIZED VIEW LOGS, including FROM/IN qualifiers, optional LIKE/WHERE filtering, deterministic result ordering, and privilege-aware visibility. Logs include base table ID and base table name when available.

* **Tests**
  * Added coverage validating introspection, filtering, cross-database queries, and empty-result cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->