### PR TITLE
ddl, parser: support materialized view alert attributes

### DIFF
--- a/pkg/ddl/bdr_test.go
+++ b/pkg/ddl/bdr_test.go
@@ -225,6 +225,11 @@ func TestDeniedByBDR(t *testing.T) {
 		{ast.BDRRoleSecondary, model.ActionAlterMaterializedViewRefresh, true},
 		{ast.BDRRoleNone, model.ActionAlterMaterializedViewRefresh, false},
 
+		// Roles for ActionAlterMaterializedViewAttributes
+		{ast.BDRRolePrimary, model.ActionAlterMaterializedViewAttributes, false},
+		{ast.BDRRoleSecondary, model.ActionAlterMaterializedViewAttributes, true},
+		{ast.BDRRoleNone, model.ActionAlterMaterializedViewAttributes, false},
+
 		// Roles for ActionAlterMaterializedViewLogPurge
 		{ast.BDRRolePrimary, model.ActionAlterMaterializedViewLogPurge, false},
 		{ast.BDRRoleSecondary, model.ActionAlterMaterializedViewLogPurge, true},

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -1006,6 +1006,8 @@ func (w *worker) runOneJobStep(
 		ver, err = onModifyTableComment(jobCtx, job)
 	case model.ActionAlterMaterializedViewRefresh:
 		ver, err = onAlterMaterializedViewRefresh(jobCtx, job, w.sess)
+	case model.ActionAlterMaterializedViewAttributes:
+		ver, err = onAlterMaterializedViewAttributes(jobCtx, job, w.sess)
 	case model.ActionAlterMaterializedViewLogPurge:
 		ver, err = onAlterMaterializedViewLogPurge(jobCtx, job, w.sess)
 	case model.ActionModifyTableAutoIDCache:

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -16,6 +16,7 @@ package ddl
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -39,6 +40,11 @@ import (
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	plannererrors "github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 	"go.uber.org/zap"
+)
+
+const (
+	mviewAttrAlertWarning = "mview_alert_warning"
+	mviewAttrAlertOverdue = "mview_alert_overdue"
 )
 
 func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateMaterializedViewStmt) error {
@@ -174,6 +180,10 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 	if err != nil {
 		return err
 	}
+	alertWarningSec, alertOverdueSec, err := parseMViewAttributes(s.Attributes)
+	if err != nil {
+		return err
+	}
 	tzName, tzOffset := ddlutil.GetTimeZone(ctx)
 	mvTableInfo.MaterializedView = &model.MaterializedViewInfo{
 		BaseTableIDs:      []int64{baseTableID},
@@ -181,6 +191,8 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 		RefreshMethod:     refreshMethod,
 		RefreshStartWith:  refreshStartWith,
 		RefreshNext:       refreshNext,
+		AlertWarningSec:   alertWarningSec,
+		AlertOverdueSec:   alertOverdueSec,
 		DefinitionSQLMode: ctx.GetSessionVars().SQLMode,
 		DefinitionTimeZone: model.TimeZoneLocation{
 			Name:   tzName,
@@ -320,6 +332,10 @@ func (e *executor) AlterMaterializedView(ctx sessionctx.Context, s *ast.AlterMat
 			if _, _, _, err := buildMViewRefreshMeta(ctx, action.Refresh); err != nil {
 				return err
 			}
+		case ast.AlterMaterializedViewActionAttributes:
+			if _, _, err := parseMViewAttributes(action.Attributes); err != nil {
+				return err
+			}
 		default:
 			return errors.Errorf("unknown alter materialized view action type: %d", action.Tp)
 		}
@@ -349,6 +365,17 @@ func (e *executor) AlterMaterializedView(ctx sessionctx.Context, s *ast.AlterMat
 				s.ViewName.Name,
 				tbl.Meta().ID,
 				action.Refresh,
+			); err != nil {
+				return err
+			}
+		case ast.AlterMaterializedViewActionAttributes:
+			if err := e.alterMaterializedViewAttributes(
+				ctx,
+				schema.ID,
+				schemaName,
+				s.ViewName.Name,
+				tbl.Meta().ID,
+				action.Attributes,
 			); err != nil {
 				return err
 			}
@@ -534,6 +561,37 @@ func (e *executor) alterMaterializedViewRefresh(
 	return errors.Trace(e.updateMaterializedViewRefreshInfoNextTime(ctx, mviewID, nextTime))
 }
 
+func (e *executor) alterMaterializedViewAttributes(
+	ctx sessionctx.Context,
+	schemaID int64,
+	schemaName pmodel.CIStr,
+	viewName pmodel.CIStr,
+	mviewID int64,
+	attrs string,
+) error {
+	alertWarningSec, alertOverdueSec, err := parseMViewAttributes(attrs)
+	if err != nil {
+		return err
+	}
+
+	job := &model.Job{
+		Version:        model.GetJobVerInUse(),
+		SchemaID:       schemaID,
+		TableID:        mviewID,
+		SchemaName:     schemaName.L,
+		TableName:      viewName.L,
+		Type:           model.ActionAlterMaterializedViewAttributes,
+		BinlogInfo:     &model.HistoryInfo{},
+		CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
+		SQLMode:        ctx.GetSessionVars().SQLMode,
+	}
+	args := &model.AlterMaterializedViewAttributesArgs{
+		AlertWarningSec: alertWarningSec,
+		AlertOverdueSec: alertOverdueSec,
+	}
+	return errors.Trace(e.doDDLJob2(ctx, job, args))
+}
+
 func (e *executor) updateMaterializedViewRefreshInfoNextTime(
 	ctx sessionctx.Context,
 	mviewID int64,
@@ -703,6 +761,54 @@ func buildMViewRefreshMeta(sctx sessionctx.Context, refresh *ast.MViewRefreshCla
 	default:
 		return "", "", "", errors.New("unknown refresh method")
 	}
+}
+
+func parseMViewAttributes(attrs string) (alertWarningSec, alertOverdueSec int64, err error) {
+	attrs = strings.TrimSpace(attrs)
+	if attrs == "" {
+		return 0, 0, nil
+	}
+
+	seen := make(map[string]struct{}, 2)
+	for _, rawKV := range strings.Split(attrs, ",") {
+		kv := strings.TrimSpace(rawKV)
+		if kv == "" {
+			return 0, 0, errors.New("invalid ATTRIBUTES format: empty key-value pair")
+		}
+		pos := strings.Index(kv, "=")
+		if pos <= 0 || pos >= len(kv)-1 {
+			return 0, 0, errors.Errorf("invalid ATTRIBUTES format: %q", kv)
+		}
+		key := strings.ToLower(strings.TrimSpace(kv[:pos]))
+		valStr := strings.TrimSpace(kv[pos+1:])
+		if key == "" || valStr == "" {
+			return 0, 0, errors.Errorf("invalid ATTRIBUTES format: %q", kv)
+		}
+		if _, ok := seen[key]; ok {
+			return 0, 0, errors.Errorf("duplicate ATTRIBUTES key: %s", key)
+		}
+		seen[key] = struct{}{}
+
+		val, convErr := strconv.ParseInt(valStr, 10, 64)
+		if convErr != nil || val < 0 {
+			return 0, 0, errors.Errorf("invalid ATTRIBUTES value for %s: %s (must be non-negative integer seconds)", key, valStr)
+		}
+
+		switch key {
+		case mviewAttrAlertWarning:
+			alertWarningSec = val
+		case mviewAttrAlertOverdue:
+			alertOverdueSec = val
+		default:
+			return 0, 0, errors.Errorf("unsupported ATTRIBUTES key: %s", key)
+		}
+	}
+
+	if alertWarningSec > 0 && alertOverdueSec > 0 && alertWarningSec > alertOverdueSec {
+		return 0, 0, errors.Errorf("invalid ATTRIBUTES: %s (%d) must be less than or equal to %s (%d)",
+			mviewAttrAlertWarning, alertWarningSec, mviewAttrAlertOverdue, alertOverdueSec)
+	}
+	return alertWarningSec, alertOverdueSec, nil
 }
 
 type mviewGroupByInfo struct {

--- a/pkg/ddl/notifier/events.go
+++ b/pkg/ddl/notifier/events.go
@@ -126,6 +126,28 @@ func (s *SchemaChangeEvent) GetAlterMaterializedViewRefreshInfo() *model.TableIn
 	return s.inner.TableInfo
 }
 
+// NewAlterMaterializedViewAttributesEvent creates a SchemaChangeEvent whose type is
+// ActionAlterMaterializedViewAttributes.
+func NewAlterMaterializedViewAttributesEvent(
+	tableInfo *model.TableInfo,
+	oldTableInfo *model.TableInfo,
+) *SchemaChangeEvent {
+	return &SchemaChangeEvent{
+		inner: &jsonSchemaChangeEvent{
+			Tp:           model.ActionAlterMaterializedViewAttributes,
+			TableInfo:    tableInfo,
+			OldTableInfo: oldTableInfo,
+		},
+	}
+}
+
+// GetAlterMaterializedViewAttributesInfo returns the table info of the SchemaChangeEvent whose type is
+// ActionAlterMaterializedViewAttributes.
+func (s *SchemaChangeEvent) GetAlterMaterializedViewAttributesInfo() *model.TableInfo {
+	intest.Assert(s.inner.Tp == model.ActionAlterMaterializedViewAttributes)
+	return s.inner.TableInfo
+}
+
 // NewAlterMaterializedViewLogPurgeEvent creates a SchemaChangeEvent whose type is
 // ActionAlterMaterializedViewLogPurge.
 func NewAlterMaterializedViewLogPurgeEvent(

--- a/pkg/ddl/notifier/events_test.go
+++ b/pkg/ddl/notifier/events_test.go
@@ -86,6 +86,11 @@ func TestMVAlterEventConstructors(t *testing.T) {
 	require.Same(t, mvTbl, alterMVRefresh.GetAlterMaterializedViewRefreshInfo())
 	require.Same(t, oldMVTbl, alterMVRefresh.inner.OldTableInfo)
 
+	alterMVAttrs := NewAlterMaterializedViewAttributesEvent(mvTbl, oldMVTbl)
+	require.Equal(t, model.ActionAlterMaterializedViewAttributes, alterMVAttrs.GetType())
+	require.Same(t, mvTbl, alterMVAttrs.GetAlterMaterializedViewAttributesInfo())
+	require.Same(t, oldMVTbl, alterMVAttrs.inner.OldTableInfo)
+
 	alterMLogPurge := NewAlterMaterializedViewLogPurgeEvent(mlogTbl, oldMLogTbl)
 	require.Equal(t, model.ActionAlterMaterializedViewLogPurge, alterMLogPurge.GetType())
 	require.Same(t, mlogTbl, alterMLogPurge.GetAlterMaterializedViewLogPurgeInfo())

--- a/pkg/ddl/rollingback.go
+++ b/pkg/ddl/rollingback.go
@@ -679,6 +679,7 @@ func convertJob2RollbackJob(w *worker, jobCtx *jobContext, job *model.Job) (ver 
 	case model.ActionRebaseAutoID, model.ActionShardRowID, model.ActionAddForeignKey,
 		model.ActionRenameTable, model.ActionRenameTables,
 		model.ActionModifyTableCharsetAndCollate, model.ActionAlterMaterializedViewRefresh,
+		model.ActionAlterMaterializedViewAttributes,
 		model.ActionAlterMaterializedViewLogPurge,
 		model.ActionModifySchemaCharsetAndCollate, model.ActionRepairTable,
 		model.ActionModifyTableAutoIDCache, model.ActionAlterIndexVisibility,

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -1087,6 +1087,44 @@ func onAlterMaterializedViewRefresh(jobCtx *jobContext, job *model.Job, se *sess
 	return ver, nil
 }
 
+func onAlterMaterializedViewAttributes(jobCtx *jobContext, job *model.Job, se *sess.Session) (ver int64, _ error) {
+	args, err := model.GetAlterMaterializedViewAttributesArgs(job)
+	if err != nil {
+		job.State = model.JobStateCancelled
+		return ver, errors.Trace(err)
+	}
+
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+	if tblInfo.MaterializedView == nil {
+		job.State = model.JobStateCancelled
+		return ver, dbterror.ErrWrongObject.GenWithStackByArgs(job.SchemaName, job.TableName, "MATERIALIZED VIEW")
+	}
+
+	if job.MultiSchemaInfo != nil && job.MultiSchemaInfo.Revertible {
+		job.MarkNonRevertible()
+		return ver, nil
+	}
+
+	oldTblInfo := tblInfo.Clone()
+	tblInfo.MaterializedView.AlertWarningSec = args.AlertWarningSec
+	tblInfo.MaterializedView.AlertOverdueSec = args.AlertOverdueSec
+
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+	alterMVAttributesEvent := notifier.NewAlterMaterializedViewAttributesEvent(tblInfo, oldTblInfo)
+	err = asyncNotifyEvent(jobCtx, alterMVAttributesEvent, job, noSubJob, se)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+	job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
+	return ver, nil
+}
+
 func onAlterMaterializedViewLogPurge(jobCtx *jobContext, job *model.Job, se *sess.Session) (ver int64, _ error) {
 	args, err := model.GetAlterMaterializedViewLogPurgeArgs(job)
 	if err != nil {

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -1823,6 +1823,16 @@ func fetchShowCreateTable4MaterializedView(ctx sessionctx.Context, tb *model.Tab
 	if tb.PreSplitRegions > 0 {
 		fmt.Fprintf(buf, " PRE_SPLIT_REGIONS = %d", tb.PreSplitRegions)
 	}
+	attrPairs := make([]string, 0, 2)
+	if mvInfo.AlertWarningSec > 0 {
+		attrPairs = append(attrPairs, fmt.Sprintf("mview_alert_warning=%d", mvInfo.AlertWarningSec))
+	}
+	if mvInfo.AlertOverdueSec > 0 {
+		attrPairs = append(attrPairs, fmt.Sprintf("mview_alert_overdue=%d", mvInfo.AlertOverdueSec))
+	}
+	if len(attrPairs) > 0 {
+		fmt.Fprintf(buf, " ATTRIBUTES='%s'", strings.Join(attrPairs, ","))
+	}
 	fmt.Fprintf(buf, " AS %s", mvInfo.SQLContent)
 }
 

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -124,6 +124,28 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	require.Equal(t, "", mvCountColTable.Meta().MaterializedView.RefreshStartWith)
 	require.Equal(t, "", mvCountColTable.Meta().MaterializedView.RefreshNext)
 
+	// ATTRIBUTES configures overdue-alert thresholds for automatically scheduled MV refresh tasks.
+	tk.MustExec("create materialized view mv_alert (a, cnt) refresh fast attributes='mview_alert_warning=300,mview_alert_overdue=600' as select a, count(1) from t group by a")
+	is = dom.InfoSchema()
+	mvAlertTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv_alert"))
+	require.NoError(t, err)
+	require.Equal(t, int64(300), mvAlertTable.Meta().MaterializedView.AlertWarningSec)
+	require.Equal(t, int64(600), mvAlertTable.Meta().MaterializedView.AlertOverdueSec)
+
+	tk.MustExec("create materialized view mv_alert_zero (a, cnt) refresh fast attributes='mview_alert_warning=0,mview_alert_overdue=0' as select a, count(1) from t group by a")
+	is = dom.InfoSchema()
+	mvAlertZeroTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv_alert_zero"))
+	require.NoError(t, err)
+	require.Equal(t, int64(0), mvAlertZeroTable.Meta().MaterializedView.AlertWarningSec)
+	require.Equal(t, int64(0), mvAlertZeroTable.Meta().MaterializedView.AlertOverdueSec)
+
+	err = tk.ExecToErr("create materialized view mv_alert_bad_key (a, cnt) attributes='unknown=1' as select a, count(1) from t group by a")
+	require.ErrorContains(t, err, "unsupported ATTRIBUTES key")
+	err = tk.ExecToErr("create materialized view mv_alert_bad_value (a, cnt) attributes='mview_alert_warning=-1' as select a, count(1) from t group by a")
+	require.ErrorContains(t, err, "must be non-negative integer seconds")
+	err = tk.ExecToErr("create materialized view mv_alert_bad_order (a, cnt) attributes='mview_alert_warning=600,mview_alert_overdue=300' as select a, count(1) from t group by a")
+	require.ErrorContains(t, err, "must be less than or equal")
+
 	// Aggregate function names are case-insensitive in CREATE MATERIALIZED VIEW.
 	tk.MustExec("create materialized view mv_upper_agg (a, s, cnt) as select a, SUM(b), COUNT(1) from t group by a")
 	tk.MustQuery("select a, s, cnt from mv_upper_agg order by a").Check(testkit.Rows("1 15 2", "2 7 1"))
@@ -249,6 +271,8 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	// Drop MV and then drop MV LOG.
 	tk.MustExec("drop materialized view mv")
 	tk.MustExec("drop materialized view mv_count_col")
+	tk.MustExec("drop materialized view mv_alert")
+	tk.MustExec("drop materialized view mv_alert_zero")
 	tk.MustExec("drop materialized view mv_upper_agg")
 	tk.MustExec("drop materialized view mv_alias")
 	tk.MustExec("drop materialized view mv_nullable")
@@ -559,11 +583,27 @@ func TestShowCreateMaterializedView(t *testing.T) {
 	require.Contains(t, showCreate, "COMMENT = 'c1'")
 	require.Contains(t, showCreate, "REFRESH FAST NEXT NOW()")
 	require.Contains(t, showCreate, "SHARD_ROW_ID_BITS = 2 PRE_SPLIT_REGIONS = 2")
+	require.NotContains(t, showCreate, "ATTRIBUTES='")
 	require.Contains(t, showCreate, "AS SELECT `a`,SUM(`b`),COUNT(1) FROM `test`.`t_show_mv` GROUP BY `a`")
 	_, err := parser.New().ParseOneStmt(showCreate, "", "")
 	require.NoError(t, err)
 	require.Equal(t, "utf8mb4", rows[0][2])
 	require.Equal(t, "utf8mb4_bin", rows[0][3])
+
+	tk.MustExec("create materialized view mv_show_mv_attr (a, s, cnt) refresh fast attributes='mview_alert_warning=5,mview_alert_overdue=10' as select a, sum(b), count(1) from t_show_mv group by a")
+	attrRows := tk.MustQuery("show create materialized view mv_show_mv_attr").Rows()
+	require.Len(t, attrRows, 1)
+	attrShowCreate, ok := attrRows[0][1].(string)
+	require.True(t, ok)
+	require.Contains(t, attrShowCreate, "ATTRIBUTES='mview_alert_warning=5,mview_alert_overdue=10'")
+
+	tk.MustExec("create materialized view mv_show_mv_attr_partial (a, s, cnt) refresh fast attributes='mview_alert_warning=0,mview_alert_overdue=10' as select a, sum(b), count(1) from t_show_mv group by a")
+	attrPartialRows := tk.MustQuery("show create materialized view mv_show_mv_attr_partial").Rows()
+	require.Len(t, attrPartialRows, 1)
+	attrPartialShowCreate, ok := attrPartialRows[0][1].(string)
+	require.True(t, ok)
+	require.Contains(t, attrPartialShowCreate, "ATTRIBUTES='mview_alert_overdue=10'")
+	require.NotContains(t, attrPartialShowCreate, "mview_alert_warning=0")
 }
 
 func TestCreateMaterializedViewRefreshExprTypeValidation(t *testing.T) {
@@ -603,6 +643,47 @@ func TestAlterMaterializedViewRefreshExprTypeValidation(t *testing.T) {
 	tk.MustExec("alter materialized view mv_ok refresh start with now() next now()")
 	tk.MustExec("drop materialized view mv_ok")
 	tk.MustExec("drop materialized view log on t")
+}
+
+func TestAlterMaterializedViewAttributesUpdatesAlertThresholds(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_attr (a, s, cnt) refresh fast next date_add(now(), interval 2 hour) attributes='mview_alert_warning=300,mview_alert_overdue=600' as select a, sum(b), count(1) from t group by a")
+
+	getMViewMeta := func() *model.MaterializedViewInfo {
+		is := dom.InfoSchema()
+		mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv_attr"))
+		require.NoError(t, err)
+		require.NotNil(t, mvTable.Meta().MaterializedView)
+		return mvTable.Meta().MaterializedView
+	}
+
+	mvInfo := getMViewMeta()
+	require.Equal(t, int64(300), mvInfo.AlertWarningSec)
+	require.Equal(t, int64(600), mvInfo.AlertOverdueSec)
+	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 2 HOUR)", mvInfo.RefreshNext)
+
+	tk.MustExec("alter materialized view mv_attr attributes='mview_alert_warning=5,mview_alert_overdue=5'")
+	mvInfo = getMViewMeta()
+	require.Equal(t, int64(5), mvInfo.AlertWarningSec)
+	require.Equal(t, int64(5), mvInfo.AlertOverdueSec)
+	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 2 HOUR)", mvInfo.RefreshNext)
+
+	tk.MustExec("alter materialized view mv_attr refresh next date_add(now(), interval 25 minute)")
+	tk.MustExec("alter materialized view mv_attr attributes='mview_alert_warning=10,mview_alert_overdue=20'")
+	mvInfo = getMViewMeta()
+	require.Equal(t, int64(10), mvInfo.AlertWarningSec)
+	require.Equal(t, int64(20), mvInfo.AlertOverdueSec)
+	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 25 MINUTE)", mvInfo.RefreshNext)
+
+	err := tk.ExecToErr("alter materialized view mv_attr attributes='unknown=1'")
+	require.ErrorContains(t, err, "unsupported ATTRIBUTES key")
+	err = tk.ExecToErr("alter materialized view mv_attr attributes='mview_alert_warning=20,mview_alert_overdue=10'")
+	require.ErrorContains(t, err, "must be less than or equal")
 }
 
 func TestAlterMaterializedViewRefreshUpdatesMetaAndNextTime(t *testing.T) {

--- a/pkg/meta/model/bdr.go
+++ b/pkg/meta/model/bdr.go
@@ -49,6 +49,7 @@ var BDRActionMap = map[DDLBDRType][]ActionType{
 		ActionSetDefaultValue,
 		ActionModifyTableComment,
 		ActionAlterMaterializedViewRefresh,
+		ActionAlterMaterializedViewAttributes,
 		ActionAlterMaterializedViewLogPurge,
 		ActionRenameIndex,
 		ActionAddTablePartition,

--- a/pkg/meta/model/job.go
+++ b/pkg/meta/model/job.go
@@ -96,101 +96,103 @@ const (
 	ActionAlterTablePlacement           ActionType = 56
 	ActionAlterCacheTable               ActionType = 57
 	// not used
-	ActionAlterTableStatsOptions        ActionType = 58
-	ActionAlterNoCacheTable             ActionType = 59
-	ActionCreateTables                  ActionType = 60
-	ActionMultiSchemaChange             ActionType = 61
-	ActionFlashbackCluster              ActionType = 62
-	ActionRecoverSchema                 ActionType = 63
-	ActionReorganizePartition           ActionType = 64
-	ActionAlterTTLInfo                  ActionType = 65
-	ActionAlterTTLRemove                ActionType = 67
-	ActionCreateResourceGroup           ActionType = 68
-	ActionAlterResourceGroup            ActionType = 69
-	ActionDropResourceGroup             ActionType = 70
-	ActionAlterTablePartitioning        ActionType = 71
-	ActionRemovePartitioning            ActionType = 72
-	ActionAddVectorIndex                ActionType = 73
-	ActionCreateMaterializedViewLog     ActionType = 74
-	ActionCreateMaterializedView        ActionType = 75
-	ActionAlterMaterializedViewRefresh  ActionType = 76
-	ActionAlterMaterializedViewLogPurge ActionType = 77
+	ActionAlterTableStatsOptions          ActionType = 58
+	ActionAlterNoCacheTable               ActionType = 59
+	ActionCreateTables                    ActionType = 60
+	ActionMultiSchemaChange               ActionType = 61
+	ActionFlashbackCluster                ActionType = 62
+	ActionRecoverSchema                   ActionType = 63
+	ActionReorganizePartition             ActionType = 64
+	ActionAlterTTLInfo                    ActionType = 65
+	ActionAlterTTLRemove                  ActionType = 67
+	ActionCreateResourceGroup             ActionType = 68
+	ActionAlterResourceGroup              ActionType = 69
+	ActionDropResourceGroup               ActionType = 70
+	ActionAlterTablePartitioning          ActionType = 71
+	ActionRemovePartitioning              ActionType = 72
+	ActionAddVectorIndex                  ActionType = 73
+	ActionCreateMaterializedViewLog       ActionType = 74
+	ActionCreateMaterializedView          ActionType = 75
+	ActionAlterMaterializedViewRefresh    ActionType = 76
+	ActionAlterMaterializedViewLogPurge   ActionType = 77
+	ActionAlterMaterializedViewAttributes ActionType = 78
 )
 
 // ActionMap is the map of DDL ActionType to string.
 var ActionMap = map[ActionType]string{
-	ActionCreateSchema:                  "create schema",
-	ActionDropSchema:                    "drop schema",
-	ActionCreateTable:                   "create table",
-	ActionCreateMaterializedViewLog:     "create materialized view log",
-	ActionCreateMaterializedView:        "create materialized view",
-	ActionAlterMaterializedViewRefresh:  "alter materialized view refresh",
-	ActionAlterMaterializedViewLogPurge: "alter materialized view log purge",
-	ActionCreateTables:                  "create tables",
-	ActionDropTable:                     "drop table",
-	ActionAddColumn:                     "add column",
-	ActionDropColumn:                    "drop column",
-	ActionAddIndex:                      "add index",
-	ActionDropIndex:                     "drop index",
-	ActionAddForeignKey:                 "add foreign key",
-	ActionDropForeignKey:                "drop foreign key",
-	ActionTruncateTable:                 "truncate table",
-	ActionModifyColumn:                  "modify column",
-	ActionRebaseAutoID:                  "rebase auto_increment ID",
-	ActionRenameTable:                   "rename table",
-	ActionRenameTables:                  "rename tables",
-	ActionSetDefaultValue:               "set default value",
-	ActionShardRowID:                    "shard row ID",
-	ActionModifyTableComment:            "modify table comment",
-	ActionRenameIndex:                   "rename index",
-	ActionAddTablePartition:             "add partition",
-	ActionDropTablePartition:            "drop partition",
-	ActionCreateView:                    "create view",
-	ActionModifyTableCharsetAndCollate:  "modify table charset and collate",
-	ActionTruncateTablePartition:        "truncate partition",
-	ActionDropView:                      "drop view",
-	ActionRecoverTable:                  "recover table",
-	ActionModifySchemaCharsetAndCollate: "modify schema charset and collate",
-	ActionLockTable:                     "lock table",
-	ActionUnlockTable:                   "unlock table",
-	ActionRepairTable:                   "repair table",
-	ActionSetTiFlashReplica:             "set tiflash replica",
-	ActionUpdateTiFlashReplicaStatus:    "update tiflash replica status",
-	ActionAddPrimaryKey:                 "add primary key",
-	ActionDropPrimaryKey:                "drop primary key",
-	ActionCreateSequence:                "create sequence",
-	ActionAlterSequence:                 "alter sequence",
-	ActionDropSequence:                  "drop sequence",
-	ActionModifyTableAutoIDCache:        "modify auto id cache",
-	ActionRebaseAutoRandomBase:          "rebase auto_random ID",
-	ActionAlterIndexVisibility:          "alter index visibility",
-	ActionExchangeTablePartition:        "exchange partition",
-	ActionAddCheckConstraint:            "add check constraint",
-	ActionDropCheckConstraint:           "drop check constraint",
-	ActionAlterCheckConstraint:          "alter check constraint",
-	ActionAlterTableAttributes:          "alter table attributes",
-	ActionAlterTablePartitionPlacement:  "alter table partition placement",
-	ActionAlterTablePartitionAttributes: "alter table partition attributes",
-	ActionCreatePlacementPolicy:         "create placement policy",
-	ActionAlterPlacementPolicy:          "alter placement policy",
-	ActionDropPlacementPolicy:           "drop placement policy",
-	ActionModifySchemaDefaultPlacement:  "modify schema default placement",
-	ActionAlterTablePlacement:           "alter table placement",
-	ActionAlterCacheTable:               "alter table cache",
-	ActionAlterNoCacheTable:             "alter table nocache",
-	ActionAlterTableStatsOptions:        "alter table statistics options",
-	ActionMultiSchemaChange:             "alter table multi-schema change",
-	ActionFlashbackCluster:              "flashback cluster",
-	ActionRecoverSchema:                 "flashback schema",
-	ActionReorganizePartition:           "alter table reorganize partition",
-	ActionAlterTTLInfo:                  "alter table ttl",
-	ActionAlterTTLRemove:                "alter table no_ttl",
-	ActionCreateResourceGroup:           "create resource group",
-	ActionAlterResourceGroup:            "alter resource group",
-	ActionDropResourceGroup:             "drop resource group",
-	ActionAlterTablePartitioning:        "alter table partition by",
-	ActionRemovePartitioning:            "alter table remove partitioning",
-	ActionAddVectorIndex:                "add vector index",
+	ActionCreateSchema:                    "create schema",
+	ActionDropSchema:                      "drop schema",
+	ActionCreateTable:                     "create table",
+	ActionCreateMaterializedViewLog:       "create materialized view log",
+	ActionCreateMaterializedView:          "create materialized view",
+	ActionAlterMaterializedViewRefresh:    "alter materialized view refresh",
+	ActionAlterMaterializedViewLogPurge:   "alter materialized view log purge",
+	ActionAlterMaterializedViewAttributes: "alter materialized view attributes",
+	ActionCreateTables:                    "create tables",
+	ActionDropTable:                       "drop table",
+	ActionAddColumn:                       "add column",
+	ActionDropColumn:                      "drop column",
+	ActionAddIndex:                        "add index",
+	ActionDropIndex:                       "drop index",
+	ActionAddForeignKey:                   "add foreign key",
+	ActionDropForeignKey:                  "drop foreign key",
+	ActionTruncateTable:                   "truncate table",
+	ActionModifyColumn:                    "modify column",
+	ActionRebaseAutoID:                    "rebase auto_increment ID",
+	ActionRenameTable:                     "rename table",
+	ActionRenameTables:                    "rename tables",
+	ActionSetDefaultValue:                 "set default value",
+	ActionShardRowID:                      "shard row ID",
+	ActionModifyTableComment:              "modify table comment",
+	ActionRenameIndex:                     "rename index",
+	ActionAddTablePartition:               "add partition",
+	ActionDropTablePartition:              "drop partition",
+	ActionCreateView:                      "create view",
+	ActionModifyTableCharsetAndCollate:    "modify table charset and collate",
+	ActionTruncateTablePartition:          "truncate partition",
+	ActionDropView:                        "drop view",
+	ActionRecoverTable:                    "recover table",
+	ActionModifySchemaCharsetAndCollate:   "modify schema charset and collate",
+	ActionLockTable:                       "lock table",
+	ActionUnlockTable:                     "unlock table",
+	ActionRepairTable:                     "repair table",
+	ActionSetTiFlashReplica:               "set tiflash replica",
+	ActionUpdateTiFlashReplicaStatus:      "update tiflash replica status",
+	ActionAddPrimaryKey:                   "add primary key",
+	ActionDropPrimaryKey:                  "drop primary key",
+	ActionCreateSequence:                  "create sequence",
+	ActionAlterSequence:                   "alter sequence",
+	ActionDropSequence:                    "drop sequence",
+	ActionModifyTableAutoIDCache:          "modify auto id cache",
+	ActionRebaseAutoRandomBase:            "rebase auto_random ID",
+	ActionAlterIndexVisibility:            "alter index visibility",
+	ActionExchangeTablePartition:          "exchange partition",
+	ActionAddCheckConstraint:              "add check constraint",
+	ActionDropCheckConstraint:             "drop check constraint",
+	ActionAlterCheckConstraint:            "alter check constraint",
+	ActionAlterTableAttributes:            "alter table attributes",
+	ActionAlterTablePartitionPlacement:    "alter table partition placement",
+	ActionAlterTablePartitionAttributes:   "alter table partition attributes",
+	ActionCreatePlacementPolicy:           "create placement policy",
+	ActionAlterPlacementPolicy:            "alter placement policy",
+	ActionDropPlacementPolicy:             "drop placement policy",
+	ActionModifySchemaDefaultPlacement:    "modify schema default placement",
+	ActionAlterTablePlacement:             "alter table placement",
+	ActionAlterCacheTable:                 "alter table cache",
+	ActionAlterNoCacheTable:               "alter table nocache",
+	ActionAlterTableStatsOptions:          "alter table statistics options",
+	ActionMultiSchemaChange:               "alter table multi-schema change",
+	ActionFlashbackCluster:                "flashback cluster",
+	ActionRecoverSchema:                   "flashback schema",
+	ActionReorganizePartition:             "alter table reorganize partition",
+	ActionAlterTTLInfo:                    "alter table ttl",
+	ActionAlterTTLRemove:                  "alter table no_ttl",
+	ActionCreateResourceGroup:             "create resource group",
+	ActionAlterResourceGroup:              "alter resource group",
+	ActionDropResourceGroup:               "drop resource group",
+	ActionAlterTablePartitioning:          "alter table partition by",
+	ActionRemovePartitioning:              "alter table remove partitioning",
+	ActionAddVectorIndex:                  "add vector index",
 
 	// `ActionAlterTableAlterPartition` is removed and will never be used.
 	// Just left a tombstone here for compatibility.

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -742,6 +742,25 @@ func GetAlterMaterializedViewRefreshArgs(job *Job) (*AlterMaterializedViewRefres
 	return getOrDecodeArgs[*AlterMaterializedViewRefreshArgs](&AlterMaterializedViewRefreshArgs{}, job)
 }
 
+// AlterMaterializedViewAttributesArgs is the arguments for ActionAlterMaterializedViewAttributes ddl.
+type AlterMaterializedViewAttributesArgs struct {
+	AlertWarningSec int64 `json:"alert_warning_sec,omitempty"`
+	AlertOverdueSec int64 `json:"alert_overdue_sec,omitempty"`
+}
+
+func (a *AlterMaterializedViewAttributesArgs) getArgsV1(*Job) []any {
+	return []any{a.AlertWarningSec, a.AlertOverdueSec}
+}
+
+func (a *AlterMaterializedViewAttributesArgs) decodeV1(job *Job) error {
+	return errors.Trace(job.decodeArgs(&a.AlertWarningSec, &a.AlertOverdueSec))
+}
+
+// GetAlterMaterializedViewAttributesArgs gets the args for ActionAlterMaterializedViewAttributes.
+func GetAlterMaterializedViewAttributesArgs(job *Job) (*AlterMaterializedViewAttributesArgs, error) {
+	return getOrDecodeArgs[*AlterMaterializedViewAttributesArgs](&AlterMaterializedViewAttributesArgs{}, job)
+}
+
 // AlterMaterializedViewLogPurgeArgs is the arguments for ActionAlterMaterializedViewLogPurge ddl.
 type AlterMaterializedViewLogPurgeArgs struct {
 	PurgeMethod    string `json:"purge_method,omitempty"`

--- a/pkg/meta/model/job_args_test.go
+++ b/pkg/meta/model/job_args_test.go
@@ -577,6 +577,20 @@ func TestGetAlterMaterializedViewRefreshArgs(t *testing.T) {
 	}
 }
 
+func TestGetAlterMaterializedViewAttributesArgs(t *testing.T) {
+	inArgs := &AlterMaterializedViewAttributesArgs{
+		AlertWarningSec: 10,
+		AlertOverdueSec: 20,
+	}
+	for _, v := range []JobVersion{JobVersion1, JobVersion2} {
+		j2 := &Job{}
+		require.NoError(t, j2.Decode(getJobBytes(t, inArgs, v, ActionAlterMaterializedViewAttributes)))
+		args, err := GetAlterMaterializedViewAttributesArgs(j2)
+		require.NoError(t, err)
+		require.Equal(t, inArgs, args)
+	}
+}
+
 func TestGetAlterMaterializedViewLogPurgeArgs(t *testing.T) {
 	inArgs := &AlterMaterializedViewLogPurgeArgs{
 		PurgeMethod:    "DEFERRED",

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -543,7 +543,7 @@ func shouldHandleMVCreateEvent(event *notifier.SchemaChangeEvent) bool {
 	case meta.ActionDropTable:
 		dropped := event.GetDropTableInfo()
 		return hasMVRelatedTableInfo(dropped)
-	case meta.ActionAlterMaterializedViewRefresh, meta.ActionAlterMaterializedViewLogPurge:
+	case meta.ActionAlterMaterializedViewRefresh, meta.ActionAlterMaterializedViewAttributes, meta.ActionAlterMaterializedViewLogPurge:
 		return true
 	default:
 		// For other DDL types, rely on the periodic metadata refresh.

--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -1684,12 +1684,13 @@ func (n *MViewRefreshClause) Restore(ctx *format.RestoreCtx) error {
 type CreateMaterializedViewStmt struct {
 	ddlNode
 
-	ViewName *TableName
-	Cols     []model.CIStr
-	Comment  string
-	Refresh  *MViewRefreshClause
-	Options  []*TableOption
-	Select   ResultSetNode
+	ViewName   *TableName
+	Cols       []model.CIStr
+	Comment    string
+	Refresh    *MViewRefreshClause
+	Attributes string
+	Options    []*TableOption
+	Select     ResultSetNode
 }
 
 // Restore implements Node interface.
@@ -1722,6 +1723,11 @@ func (n *CreateMaterializedViewStmt) Restore(ctx *format.RestoreCtx) error {
 		if err := option.Restore(ctx); err != nil {
 			return errors.Annotatef(err, "An error occurred while restore CreateMaterializedViewStmt.TableOption[%d]", i)
 		}
+	}
+	if n.Attributes != "" {
+		ctx.WriteKeyWord(" ATTRIBUTES")
+		ctx.WritePlain("=")
+		ctx.WriteString(n.Attributes)
 	}
 	ctx.WriteKeyWord(" AS ")
 	if err := n.Select.Restore(ctx); err != nil {
@@ -1891,14 +1897,16 @@ type AlterMaterializedViewActionType int
 const (
 	AlterMaterializedViewActionComment AlterMaterializedViewActionType = iota
 	AlterMaterializedViewActionRefresh
+	AlterMaterializedViewActionAttributes
 )
 
 // AlterMaterializedViewAction is one action in ALTER MATERIALIZED VIEW.
 type AlterMaterializedViewAction struct {
 	node
-	Tp      AlterMaterializedViewActionType
-	Comment string
-	Refresh *MViewRefreshClause
+	Tp         AlterMaterializedViewActionType
+	Comment    string
+	Refresh    *MViewRefreshClause
+	Attributes string
 }
 
 // Restore implements Node interface.
@@ -1932,6 +1940,11 @@ func (n *AlterMaterializedViewAction) Restore(ctx *format.RestoreCtx) error {
 				}
 			}
 		}
+		return nil
+	case AlterMaterializedViewActionAttributes:
+		ctx.WriteKeyWord("ATTRIBUTES")
+		ctx.WritePlain("=")
+		ctx.WriteString(n.Attributes)
 		return nil
 	default:
 		return nil

--- a/pkg/parser/mview_stmt_options.go
+++ b/pkg/parser/mview_stmt_options.go
@@ -22,6 +22,9 @@ type mviewCreateOptions struct {
 	hasRefresh bool
 	refresh    *ast.MViewRefreshClause
 
+	hasAttributes bool
+	attributes    string
+
 	hasShardRowIDBits bool
 	hasPreSplitRegion bool
 	options           []*ast.TableOption

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -5252,12 +5252,13 @@ CreateMaterializedViewStmt:
 	{
 		opts := $8.(*mviewCreateOptions)
 		x := &ast.CreateMaterializedViewStmt{
-			ViewName: $4.(*ast.TableName),
-			Cols:     $6.([]model.CIStr),
-			Comment:  opts.comment,
-			Refresh:  opts.refresh,
-			Options:  opts.options,
-			Select:   $10.(ast.StmtNode).(ast.ResultSetNode),
+			ViewName:   $4.(*ast.TableName),
+			Cols:       $6.([]model.CIStr),
+			Comment:    opts.comment,
+			Refresh:    opts.refresh,
+			Attributes: opts.attributes,
+			Options:    opts.options,
+			Select:     $10.(ast.StmtNode).(ast.ResultSetNode),
 		}
 		$$ = x
 	}
@@ -5295,6 +5296,13 @@ MViewCreateOptionList:
 			opts.hasRefresh = true
 			opts.refresh = opt.refresh
 		}
+		if opt.hasAttributes {
+			if opts.hasAttributes {
+				yylex.AppendError(yylex.Errorf("Duplicate ATTRIBUTES specified in CREATE MATERIALIZED VIEW"))
+			}
+			opts.hasAttributes = true
+			opts.attributes = opt.attributes
+		}
 		if opt.hasShardRowIDBits {
 			if opts.hasShardRowIDBits {
 				yylex.AppendError(yylex.Errorf("Duplicate SHARD_ROW_ID_BITS specified in CREATE MATERIALIZED VIEW"))
@@ -5319,6 +5327,10 @@ MViewCreateOption:
 |	MViewRefreshClause
 	{
 		$$ = &mviewCreateOptions{hasRefresh: true, refresh: $1.(*ast.MViewRefreshClause)}
+	}
+|	"ATTRIBUTES" EqOpt stringLit
+	{
+		$$ = &mviewCreateOptions{hasAttributes: true, attributes: $3}
 	}
 |	"SHARD_ROW_ID_BITS" EqOpt LengthNum
 	{
@@ -5518,6 +5530,10 @@ AlterMaterializedViewAction:
 			refresh.Next = schedule.Next
 		}
 		$$ = &ast.AlterMaterializedViewAction{Tp: ast.AlterMaterializedViewActionRefresh, Refresh: refresh}
+	}
+|	"ATTRIBUTES" EqOpt stringLit
+	{
+		$$ = &ast.AlterMaterializedViewAction{Tp: ast.AlterMaterializedViewActionAttributes, Attributes: $3}
 	}
 
 AlterMaterializedViewLogStmt:

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5224,6 +5224,10 @@ func TestMaterializedViewDuplicateOptionsErrMsg(t *testing.T) {
 			substring: "Duplicate PRE_SPLIT_REGIONS specified in CREATE MATERIALIZED VIEW",
 		},
 		{
+			sql:       "CREATE MATERIALIZED VIEW mv (a) ATTRIBUTES='a=b' ATTRIBUTES='c=d' AS SELECT 1",
+			substring: "Duplicate ATTRIBUTES specified in CREATE MATERIALIZED VIEW",
+		},
+		{
 			sql:       "CREATE MATERIALIZED VIEW LOG ON t (a) SHARD_ROW_ID_BITS = 1 SHARD_ROW_ID_BITS = 2",
 			substring: "Duplicate SHARD_ROW_ID_BITS specified in CREATE MATERIALIZED VIEW LOG",
 		},
@@ -5348,6 +5352,16 @@ func TestMaterializedViewStatements(t *testing.T) {
 			"CREATE MATERIALIZED VIEW `mv` (`a`) REFRESH FAST NEXT 300 AS SELECT 1",
 		},
 		{
+			"CREATE MATERIALIZED VIEW mv (a) ATTRIBUTES='mview_alert_warning=300,mview_alert_overdue=600' AS SELECT 1",
+			true,
+			"CREATE MATERIALIZED VIEW `mv` (`a`) ATTRIBUTES='mview_alert_warning=300,mview_alert_overdue=600' AS SELECT 1",
+		},
+		{
+			"CREATE MATERIALIZED VIEW mv (a) REFRESH FAST ATTRIBUTES='mview_alert_warning=300' AS SELECT 1",
+			true,
+			"CREATE MATERIALIZED VIEW `mv` (`a`) REFRESH FAST ATTRIBUTES='mview_alert_warning=300' AS SELECT 1",
+		},
+		{
 			"CREATE MATERIALIZED VIEW LOG ON t (a,b)",
 			true,
 			"CREATE MATERIALIZED VIEW LOG ON `t` (`a`, `b`)",
@@ -5401,6 +5415,11 @@ func TestMaterializedViewStatements(t *testing.T) {
 			"ALTER MATERIALIZED VIEW mv REFRESH NEXT 300",
 			true,
 			"ALTER MATERIALIZED VIEW `mv` REFRESH NEXT 300",
+		},
+		{
+			"ALTER MATERIALIZED VIEW mv ATTRIBUTES='mview_alert_warning=5,mview_alert_overdue=5'",
+			true,
+			"ALTER MATERIALIZED VIEW `mv` ATTRIBUTES='mview_alert_warning=5,mview_alert_overdue=5'",
 		},
 		{
 			"ALTER MATERIALIZED VIEW LOG ON t PURGE IMMEDIATE",

--- a/pkg/statistics/handle/ddl/subscriber.go
+++ b/pkg/statistics/handle/ddl/subscriber.go
@@ -262,6 +262,13 @@ func (h subscriber) handle(
 				)
 			}
 		}
+	case model.ActionAlterMaterializedViewRefresh,
+		model.ActionAlterMaterializedViewAttributes,
+		model.ActionAlterMaterializedViewLogPurge,
+		model.ActionCreateMaterializedViewLog,
+		model.ActionCreateMaterializedView:
+		// MV refresh/attributes/mvlog-purge DDL updates only MV runtime metadata.
+		// It doesn't change table data or partition topology, so stats meta should stay unchanged.
 	default:
 		intest.Assert(false)
 		logutil.StatsLogger().Error("Unhandled schema change event",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

Materialized views need a way to configure refresh alert thresholds in MV metadata so the MV service can use per-MV alert settings.

### What changed and how does it work?

This PR adds materialized view `ATTRIBUTES` support for alert thresholds:

- Support `CREATE MATERIALIZED VIEW ... ATTRIBUTES='mview_alert_warning=...,mview_alert_overdue=...'`.
- Support `ALTER MATERIALIZED VIEW ... ATTRIBUTES='mview_alert_warning=...,mview_alert_overdue=...'`.
- Persist the parsed alert thresholds in materialized view metadata.
- Include MV attributes in `SHOW CREATE MATERIALIZED VIEW` output.
- Add the DDL job args, notifier event, BDR, rollback, statistics subscriber, parser, and DDL tests needed for the new action.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit tests:

```sh
go test ./pkg/meta/model -run 'TestGetAlterMaterializedViewAttributesArgs' -count=1
cd pkg/parser && go test . -run 'TestMaterializedView' -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support configuring materialized view refresh alert thresholds through materialized view attributes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ATTRIBUTES='...' support for CREATE MATERIALIZED VIEW to set alert thresholds (mview_alert_warning, mview_alert_overdue).
  * Added ALTER MATERIALIZED VIEW ... ATTRIBUTES to update those thresholds.
  * ATTRIBUTES now appears in SHOW CREATE MATERIALIZED VIEW when thresholds are set; zero/missing values are omitted.

* **Tests**
  * Expanded tests for creation, alteration, validation, rendering, and error cases (duplicates, negatives, ordering).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->