### PR TITLE
test: stabilize flaky TestTimerFullProcess

### DIFF
--- a/pkg/timer/runtime/runtime_test.go
+++ b/pkg/timer/runtime/runtime_test.go
@@ -869,7 +869,6 @@ func TestTimerFullProcess(t *testing.T) {
 	})
 	require.NoError(t, err)
 	timerID := timer.ID
-	close(hookStartWait)
 
 	hook.On("OnPreSchedEvent", mock.Anything, mock.Anything).
 		Return(api.PreSchedEventResult{EventData: []byte("eventdata1")}, nil).
@@ -880,6 +879,8 @@ func TestTimerFullProcess(t *testing.T) {
 		Return(nil).
 		Once().
 		Run(checkOnSchedEventFunc([]byte("eventdata1"), *now.Load()))
+
+	close(hookStartWait)
 	waitDone(onSchedDone, 5*time.Second)
 	onSchedDone = make(chan struct{})
 	hook.AssertExpectations(t)
@@ -912,7 +913,7 @@ func TestTimerFullProcess(t *testing.T) {
 	checkNotDone(onSchedDone, time.Second)
 
 	// trigger again after 1 minute
-	setNow(now.Load().Add(time.Minute))
+	nextTriggerTime := now.Load().Add(time.Minute)
 	hook.On("OnPreSchedEvent", mock.Anything, mock.Anything).
 		Return(api.PreSchedEventResult{EventData: []byte("eventdata2")}, nil).
 		Once().
@@ -921,7 +922,8 @@ func TestTimerFullProcess(t *testing.T) {
 	hook.On("OnSchedEvent", mock.Anything, mock.Anything).
 		Return(nil).
 		Once().
-		Run(checkOnSchedEventFunc([]byte("eventdata2"), *now.Load()))
+		Run(checkOnSchedEventFunc([]byte("eventdata2"), nextTriggerTime))
+	setNow(nextTriggerTime)
 	waitDone(onSchedDone, 5*time.Second)
 	onSchedDone = make(chan struct{})
 	hook.AssertExpectations(t)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68210

Problem Summary:
Flaky test `TestTimerFullProcess` in `pkg/timer/runtime` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The test had a real goroutine-ordering race between runtime worker hook calls and mock expectation registration.

#### Fix

Registering expectations before unblocking the worker or advancing mock time removes the invalid timing assumption without weakening assertions.

#### Verification

Spec:
- target: `pkg/timer/runtime :: TestTimerFullProcess`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package_runtime passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package_runtime: PASS
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/timer/runtime -run '^TestTimerFullProcess$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/timer/runtime -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timer test synchronization and timing accuracy to ensure consistent test behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/tidb/pull/68814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->