### PR TITLE
planner: fix null-reject proof for WEEK and YEARWEEK

### DIFF
--- a/pkg/planner/util/null_misc.go
+++ b/pkg/planner/util/null_misc.go
@@ -217,6 +217,14 @@ func proveNullRejectedScalarFunc(
 		return proveNullRejectedIn(ctx, innerSchema, expr, allowNullifiedFold)
 	case ast.IsNull:
 		return nullRejectProof{}
+	case ast.Week, ast.YearWeek:
+		// Only the date argument is NULL-preserving. A NULL mode argument is
+		// treated as mode 0 by MySQL/TiDB, so these functions cannot be listed
+		// in nullRejectNullPreservingFunctions.
+		if proveNullRejected(ctx, innerSchema, expr.GetArgs()[0], allowNullifiedFold).mustNull {
+			return nullRejectProof{nonTrue: true, mustNull: true}
+		}
+		return nullRejectProof{}
 	}
 
 	if mode, ok := nullRejectRejectNullTests[expr.FuncName.L]; ok {

--- a/pkg/planner/util/null_misc_builtins.go
+++ b/pkg/planner/util/null_misc_builtins.go
@@ -129,7 +129,6 @@ var nullRejectNullPreservingFunctions = map[string]struct{}{
 	ast.Right:           {},
 	ast.Rpad:            {},
 	ast.RTrim:           {},
-	ast.Soundex:         {},
 	ast.Space:           {},
 	ast.Substr:          {},
 	ast.Substring:       {},
@@ -185,11 +184,9 @@ var nullRejectNullPreservingFunctions = map[string]struct{}{
 	ast.ToDays:        {},
 	ast.ToSeconds:     {},
 	ast.UnixTimestamp: {},
-	ast.Week:          {},
 	ast.Weekday:       {},
 	ast.WeekOfYear:    {},
 	ast.Year:          {},
-	ast.YearWeek:      {},
 
 	// Encryption, hashing, and compression.
 	ast.Compress:           {},

--- a/pkg/planner/util/null_misc_builtins.go
+++ b/pkg/planner/util/null_misc_builtins.go
@@ -32,7 +32,6 @@ var nullRejectNullPreservingFunctions = map[string]struct{}{
 	// Cast and unary operators.
 	ast.Cast:       {},
 	ast.UnaryNot:   {},
-	ast.UnaryPlus:  {},
 	ast.UnaryMinus: {},
 	ast.BitNeg:     {},
 

--- a/pkg/planner/util/null_misc_test.go
+++ b/pkg/planner/util/null_misc_test.go
@@ -55,7 +55,8 @@ func TestIsNullRejectedProofModes(t *testing.T) {
 	outerC := newNullRejectIntColumn(3)
 	innerS := newNullRejectStringColumn(4)
 	innerUnsignedD := newNullRejectUintColumn(5)
-	innerSchema := expression.NewSchema(innerA, innerB, innerS, innerUnsignedD)
+	innerDate := newNullRejectDatetimeColumn(6)
+	innerSchema := expression.NewSchema(innerA, innerB, innerS, innerUnsignedD, innerDate)
 
 	gtInnerAZero := newNullRejectFunc(t, exprCtx, ast.GT, types.NewFieldType(mysql.TypeTiny), innerA, expression.NewZero())
 	eqInnerAZero := newNullRejectFunc(t, exprCtx, ast.EQ, types.NewFieldType(mysql.TypeTiny), innerA, expression.NewZero())
@@ -196,6 +197,22 @@ func TestIsNullRejectedProofModes(t *testing.T) {
 		types.NewFieldType(mysql.TypeLonglong),
 		newNullRejectStringConst("2024-01-08"),
 		innerA,
+	)
+	weekWithNullableDateAndOuterMode := newNullRejectFunc(
+		t,
+		exprCtx,
+		ast.Week,
+		types.NewFieldType(mysql.TypeLonglong),
+		innerDate,
+		outerC,
+	)
+	yearWeekWithNullableDateAndOuterMode := newNullRejectFunc(
+		t,
+		exprCtx,
+		ast.YearWeek,
+		types.NewFieldType(mysql.TypeLonglong),
+		innerDate,
+		outerC,
 	)
 	deferredInnerGTZero := newNullRejectDeferredConst(exprCtx, gtInnerAZero)
 	deferredCoalesceInnerATwoGTTwo := newNullRejectDeferredConst(exprCtx,
@@ -383,6 +400,30 @@ func TestIsNullRejectedProofModes(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "week_nullable_date_rejects_null_even_with_outer_mode",
+			expr: newNullRejectFunc(
+				t,
+				exprCtx,
+				ast.GE,
+				types.NewFieldType(mysql.TypeTiny),
+				weekWithNullableDateAndOuterMode,
+				expression.NewZero(),
+			),
+			expected: true,
+		},
+		{
+			name: "yearweek_nullable_date_rejects_null_even_with_outer_mode",
+			expr: newNullRejectFunc(
+				t,
+				exprCtx,
+				ast.GE,
+				types.NewFieldType(mysql.TypeTiny),
+				yearWeekWithNullableDateAndOuterMode,
+				expression.NewZero(),
+			),
+			expected: true,
+		},
+		{
 			name:     "deferred_expr_uses_symbolic_null_reject_proof",
 			expr:     deferredInnerGTZero,
 			expected: true,
@@ -430,6 +471,15 @@ func newNullRejectUintColumn(id int64) *expression.Column {
 		ID:       id,
 		Index:    int(id),
 		RetType:  newNullRejectUintFieldType(mysql.TypeLonglong),
+	}
+}
+
+func newNullRejectDatetimeColumn(id int64) *expression.Column {
+	return &expression.Column{
+		UniqueID: id,
+		ID:       id,
+		Index:    int(id),
+		RetType:  types.NewFieldType(mysql.TypeDatetime),
 	}
 }
 

--- a/pkg/planner/util/null_misc_test.go
+++ b/pkg/planner/util/null_misc_test.go
@@ -181,6 +181,22 @@ func TestIsNullRejectedProofModes(t *testing.T) {
 		newNullRejectStringConst("abc"),
 		innerS,
 	)
+	weekWithNullableMode := newNullRejectFunc(
+		t,
+		exprCtx,
+		ast.Week,
+		types.NewFieldType(mysql.TypeLonglong),
+		newNullRejectStringConst("2024-01-08"),
+		innerA,
+	)
+	yearWeekWithNullableMode := newNullRejectFunc(
+		t,
+		exprCtx,
+		ast.YearWeek,
+		types.NewFieldType(mysql.TypeLonglong),
+		newNullRejectStringConst("2024-01-08"),
+		innerA,
+	)
 	deferredInnerGTZero := newNullRejectDeferredConst(exprCtx, gtInnerAZero)
 	deferredCoalesceInnerATwoGTTwo := newNullRejectDeferredConst(exprCtx,
 		newNullRejectFunc(t, exprCtx, ast.GT, types.NewFieldType(mysql.TypeTiny), coalesceInnerATwo, newNullRejectIntConst(2)),
@@ -340,6 +356,30 @@ func TestIsNullRejectedProofModes(t *testing.T) {
 		{
 			name:     "json_search_nullable_escape_falls_back_to_default_escape",
 			expr:     newNullRejectNotNull(t, exprCtx, jsonSearchNullableEscape),
+			expected: false,
+		},
+		{
+			name: "week_nullable_mode_uses_default_mode_zero",
+			expr: newNullRejectFunc(
+				t,
+				exprCtx,
+				ast.GE,
+				types.NewFieldType(mysql.TypeTiny),
+				weekWithNullableMode,
+				expression.NewZero(),
+			),
+			expected: false,
+		},
+		{
+			name: "yearweek_nullable_mode_uses_default_mode_zero",
+			expr: newNullRejectFunc(
+				t,
+				exprCtx,
+				ast.GE,
+				types.NewFieldType(mysql.TypeTiny),
+				yearWeekWithNullableMode,
+				expression.NewZero(),
+			),
 			expected: false,
 		},
 		{

--- a/pkg/planner/util/null_misc_test.go
+++ b/pkg/planner/util/null_misc_test.go
@@ -40,6 +40,15 @@ func TestNullRejectBuiltinRegistrySnapshot(t *testing.T) {
 	require.NotEmpty(t, names)
 	require.Equal(t, "729f5252bcd91efe1a4bbf0c383a36c5a2e52ed2d90d7aab0a3e0b450322294c", hex.EncodeToString(sum[:]))
 
+	internalScalarNames := map[string]struct{}{
+		ast.Cast: {},
+	}
+	for name := range nullRejectNullPreservingFunctions {
+		if _, ok := internalScalarNames[name]; ok {
+			continue
+		}
+		require.Contains(t, names, name)
+	}
 	for name := range nullRejectRejectNullTests {
 		require.Contains(t, names, name)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68816

Problem Summary:

`WEEK(date, mode)` and `YEARWEEK(date, mode)` were classified as whole-function NULL-preserving builtins for null-reject proof. This is unsafe because TiDB/MySQL treats a `NULL` mode argument as mode `0`, so predicates such as `WEEK('2024-01-08', nullable_mode) >= 0` are not null-rejecting on `nullable_mode`.

### What changed and how does it work?

- Remove `WEEK` and `YEARWEEK` from the whole-function NULL-preserving builtin table.
- Add a narrow proof rule that keeps the valid behavior for their date argument: if the date argument is proven NULL, the function result is NULL.
- Remove unreachable NULL-preserving table entries for builtins that are not registered as scalar functions.
- Extend the registry snapshot test to reject future NULL-preserving table entries that are not registered builtins, except for the internal scalar `CAST`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test:

```bash
go test -count=1 -tags=intest,deadlock ./pkg/planner/util -run 'Test(IsNullRejectedProofModes|NullRejectBuiltinRegistrySnapshot)'
```

Other checks:

```bash
make lint
git diff --check origin/master..HEAD
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a potential wrong result caused by unsafe null-reject proof for WEEK and YEARWEEK with a NULL mode argument.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected null-handling for WEEK and YEARWEEK date functions and refined which built-ins are treated as null-preserving to improve query accuracy.

* **Tests**
  * Expanded test coverage for null-rejection behavior, added registry presence checks for built-ins, and added datetime-focused cases to validate WEEK/YEARWEEK handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->