### PR TITLE
planner: expand large-gap index heuristic to small LIMIT without ORDE…

### DIFF
--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -909,9 +909,15 @@ func compareCandidates(sctx base.PlanContext, statsTbl *statistics.Table, prop *
 
 	// This rule is empirical but not always correct.
 	// If x's range row count is significantly lower than y's, for example, 1000 times, we think x is better.
+	//
+	// Besides the no-limit case (ExpectedCnt == MaxFloat64), we also apply this rule to small expected counts
+	// (typical LIMIT queries) when there is no ordering requirement. For these queries, cardinality estimates among
+	// many similar indexes can be noisy, while a huge access-row-count gap is usually still a strong signal.
+	applyLargeGapHeuristic := prop.ExpectedCnt == math.MaxFloat64 ||
+		(prop.IsSortItemEmpty() && prop.ExpectedCnt > 0 && prop.ExpectedCnt <= 1000)
 	if lhs.path.CountAfterAccess > 100 && rhs.path.CountAfterAccess > 100 && // to prevent some extreme cases, e.g. 0.01 : 10
 		len(lhs.path.PartialIndexPaths) == 0 && len(rhs.path.PartialIndexPaths) == 0 && // not IndexMerge since its row count estimation is not accurate enough
-		prop.ExpectedCnt == math.MaxFloat64 { // Limit may affect access row count
+		applyLargeGapHeuristic {
 		threshold := float64(fixcontrol.GetIntWithDefault(sctx.GetSessionVars().OptimizerFixControl, fixcontrol.Fix45132, 1000))
 		sctx.GetSessionVars().RecordRelevantOptFix(fixcontrol.Fix45132)
 		if threshold > 0 { // set it to 0 to disable this rule

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -17,6 +17,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"testing"
@@ -68,6 +69,44 @@ func TestPredicatePushDown(t *testing.T) {
 		})
 		require.Equal(t, output[ith], ToString(p), fmt.Sprintf("for %s %d", ca, ith))
 	}
+}
+
+func TestCompareCandidatesLargeGapHeuristicWithLimit(t *testing.T) {
+	sctx := coretestsdk.MockContext()
+	require.NoError(t, sctx.GetSessionVars().SetSystemVar(vardef.TiDBOptFixControl, "45132:1000"))
+	lhs := &candidatePath{
+		path: &util.AccessPath{
+			Index:            &model.IndexInfo{Name: ast.NewCIStr("idx_lhs")},
+			IsSingleScan:     true,
+			CountAfterAccess: 200000,
+		},
+		matchPropResult: property.PropNotMatched,
+	}
+	rhs := &candidatePath{
+		path: &util.AccessPath{
+			Index:            &model.IndexInfo{Name: ast.NewCIStr("idx_rhs")},
+			IsSingleScan:     true,
+			CountAfterAccess: 101,
+		},
+		matchPropResult: property.PropNotMatched,
+	}
+
+	noLimitProp := &property.PhysicalProperty{ExpectedCnt: math.MaxFloat64}
+	result, _ := compareCandidates(sctx, nil, noLimitProp, lhs, rhs, false)
+	require.Equal(t, -1, result)
+
+	limitProp := &property.PhysicalProperty{ExpectedCnt: 100}
+	result, _ = compareCandidates(sctx, nil, limitProp, lhs, rhs, false)
+	require.Equal(t, -1, result)
+
+	orderedLimitProp := &property.PhysicalProperty{
+		ExpectedCnt: 100,
+		SortItems: []property.SortItem{
+			{Col: &expression.Column{UniqueID: 1}},
+		},
+	}
+	result, _ = compareCandidates(sctx, nil, orderedLimitProp, lhs, rhs, false)
+	require.Equal(t, 0, result)
 }
 
 // Issue: 31399


### PR DESCRIPTION
在 TPC-H SF=1 且存在大量额外索引的场景下，优化器在候选访问路径排序时可能选到明显慢于其他候选的计划。该问题在无 `ORDER BY` 的小 `LIMIT` 查询中更容易出现：当多个二级索引统计信息接近且估算存在噪声时，路径比较可能不够稳定，导致偏向访问行数更高的路径。

### What changed and how does it work?
本 PR 扩展了 `compareCandidates` 中“大访问行数差距”启发式的适用范围，并补充回归测试。

主要改动如下：
1. 在 `pkg/planner/core/find_best_task.go` 中新增 `applyLargeGapHeuristic` 条件：  
   - 保留原有“近似无 LIMIT”场景：`ExpectedCnt == math.MaxFloat64`；  
   - 新增“无排序的小 LIMIT”场景：`prop.IsSortItemEmpty() && ExpectedCnt > 0 && ExpectedCnt <= 1000`。  
2. 启发式仍受既有保护条件约束（如非 IndexMerge、双方访问行数下限、fix-control 阈值等），仅在满足条件时比较大行数差距信号。  
3. 在 `pkg/planner/core/logical_plans_test.go` 新增 `TestCompareCandidatesLargeGapHeuristicWithLimit`，覆盖：  
   - 无 LIMIT 场景（启发式生效）；  
   - 小 LIMIT 且无排序场景（启发式生效）；  
   - 小 LIMIT 且有排序场景（启发式不生效）。  

### Check List
Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

已执行测试命令：
- `GOFLAGS='-p=1' go test ./pkg/planner/core -run TestCompareCandidatesLargeGapHeuristicWithLimit -count=1 -tags=intest,deadlock`（通过）