### PR TITLE
planner: fix time range extraction when time column is on the right side

### DIFF
--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -183,7 +183,7 @@ func (helper *extractHelper) extractColBinaryOpConsExpr(
 	ctx base.PlanContext,
 	extractCols map[int64]*types.FieldName,
 	expr *expression.ScalarFunction,
-) (string, []types.Datum) {
+) (string, []types.Datum, bool) {
 	args := expr.GetArgs()
 	var col *expression.Column
 	var colIdx int
@@ -203,12 +203,12 @@ func (helper *extractHelper) extractColBinaryOpConsExpr(
 		col, colIdx = innerCol, innerColIdx
 	}
 	if col == nil {
-		return "", nil
+		return "", nil, false
 	}
 
 	name, found := extractCols[col.UniqueID]
 	if !found {
-		return "", nil
+		return "", nil, false
 	}
 
 	// The `lhs/rhs` of EQ expression must be a constant
@@ -216,7 +216,7 @@ func (helper *extractHelper) extractColBinaryOpConsExpr(
 	// SELECT * FROM t1 WHERE 'lhs'=c
 	constant, ok := args[1-colIdx].(*expression.Constant)
 	if !ok || constant.DeferredExpr != nil {
-		return "", nil
+		return "", nil, false
 	}
 	v := constant.Value
 	if constant.ParamMarker != nil {
@@ -225,10 +225,10 @@ func (helper *extractHelper) extractColBinaryOpConsExpr(
 		intest.AssertNoError(err, "fail to get param")
 		if err != nil {
 			logutil.BgLogger().Warn("fail to get param", zap.Error(err))
-			return "", nil
+			return "", nil, false
 		}
 	}
-	return name.ColName.L, []types.Datum{v}
+	return name.ColName.L, []types.Datum{v}, colIdx == 0
 }
 
 // extract the OR expression, e.g:
@@ -247,7 +247,8 @@ func (helper *extractHelper) extractColOrExpr(ctx base.PlanContext, extractCols 
 	var extract = func(extractCols map[int64]*types.FieldName, fn *expression.ScalarFunction) (string, []types.Datum) {
 		switch helper.getStringFunctionName(fn) {
 		case ast.EQ:
-			return helper.extractColBinaryOpConsExpr(ctx, extractCols, fn)
+			colName, datums, _ := helper.extractColBinaryOpConsExpr(ctx, extractCols, fn)
+			return colName, datums
 		case ast.LogicOr:
 			return helper.extractColOrExpr(ctx, extractCols, fn)
 		case ast.In:
@@ -319,7 +320,7 @@ func (helper *extractHelper) extractCol(
 		switch helper.getStringFunctionName(fn) {
 		case ast.EQ:
 			helper.enableScalarPushDown = true
-			colName, datums = helper.extractColBinaryOpConsExpr(ctx, extractCols, fn)
+			colName, datums, _ = helper.extractColBinaryOpConsExpr(ctx, extractCols, fn)
 			if colName == extractColName {
 				helper.setColumnPushedDownFn(colName, extractCols, fn)
 			}
@@ -449,7 +450,7 @@ func (helper extractHelper) extractLikePattern(
 	var datums []types.Datum
 	switch fn.FuncName.L {
 	case ast.EQ, ast.Like, ast.Ilike, ast.Regexp, ast.RegexpLike:
-		colName, datums = helper.extractColBinaryOpConsExpr(ctx, extractCols, fn)
+		colName, datums, _ = helper.extractColBinaryOpConsExpr(ctx, extractCols, fn)
 	}
 	if colName != extractColName {
 		return false, ""
@@ -551,13 +552,27 @@ func (helper extractHelper) extractTimeRange(
 
 		var colName string
 		var datums []types.Datum
+		var colOnLeft bool
 		fnName := helper.getTimeFunctionName(fn)
 		switch fnName {
 		case ast.GT, ast.GE, ast.LT, ast.LE, ast.EQ:
-			colName, datums = helper.extractColBinaryOpConsExpr(ctx, extractCols, fn)
+			colName, datums, colOnLeft = helper.extractColBinaryOpConsExpr(ctx, extractCols, fn)
 		}
 
 		if colName == extractColName {
+			if !colOnLeft {
+				switch fnName {
+				case ast.GT:
+					fnName = ast.LT
+				case ast.GE:
+					fnName = ast.LE
+				case ast.LT:
+					fnName = ast.GT
+				case ast.LE:
+					fnName = ast.GE
+				}
+			}
+
 			timeType := types.NewFieldType(mysql.TypeDatetime)
 			timeType.SetDecimal(6)
 			timeDatum, err := datums[0].ConvertTo(ctx.GetSessionVars().StmtCtx.TypeCtx(), timeType)

--- a/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
+++ b/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
@@ -443,6 +443,13 @@ func TestClusterLogTableExtractor(t *testing.T) {
 			endTime:   timestamp(t, "2019-10-11 10:10:10") - 1,
 		},
 		{
+			sql:       "select * from information_schema.cluster_log where '2019-10-10 10:10:10' < time and '2019-10-11 10:10:10' > time",
+			nodeTypes: set.NewStringSet(),
+			instances: set.NewStringSet(),
+			startTime: timestamp(t, "2019-10-10 10:10:10") + 1,
+			endTime:   timestamp(t, "2019-10-11 10:10:10") - 1,
+		},
+		{
 			sql:         "select * from information_schema.cluster_log where time>='2019-10-12 10:10:10' and time<'2019-10-11 10:10:10'",
 			nodeTypes:   set.NewStringSet(),
 			instances:   set.NewStringSet(),
@@ -631,6 +638,12 @@ func TestMetricTableExtractor(t *testing.T) {
 			promQL:    `histogram_quantile(0.9, sum(rate(tidb_server_handle_query_duration_seconds_bucket{}[60s])) by (le,sql_type,instance))`,
 			startTime: parseTime(t, "2019-10-10 10:10:10"),
 			endTime:   parseTime(t, "2019-10-10 10:20:10"),
+		},
+		{
+			sql:       "select * from metrics_schema.tidb_query_duration where '2019-10-10 10:10:10' < time and '2019-10-11 10:10:10' > time",
+			promQL:    `histogram_quantile(0.9, sum(rate(tidb_server_handle_query_duration_seconds_bucket{}[60s])) by (le,sql_type,instance))`,
+			startTime: parseTime(t, "2019-10-10 10:10:10.001"),
+			endTime:   parseTime(t, "2019-10-11 10:10:09.999"),
 		},
 		{
 			sql:         "select * from metrics_schema.tidb_query_duration where time>='2019-10-10 10:10:10' and time<='2019-10-09 10:10:10'",
@@ -1138,6 +1151,14 @@ func TestTiDBHotRegionsHistoryTableExtractor(t *testing.T) {
 		{
 			sql:            "select * from information_schema.tidb_hot_regions_history where update_time>='2019-10-10 10:10:10' and update_time<'2019-10-11 10:10:10'",
 			startTime:      timestamp(t, "2019-10-10 10:10:10"),
+			endTime:        timestamp(t, "2019-10-11 10:10:10") - 1,
+			isLearners:     []bool{false, true},
+			isLeaders:      []bool{false, true},
+			hotRegionTypes: set.NewStringSet(plannercore.HotRegionTypeRead, plannercore.HotRegionTypeWrite),
+		},
+		{
+			sql:            "select * from information_schema.tidb_hot_regions_history where '2019-10-10 10:10:10' < update_time and '2019-10-11 10:10:10' > update_time",
+			startTime:      timestamp(t, "2019-10-10 10:10:10") + 1,
 			endTime:        timestamp(t, "2019-10-11 10:10:10") - 1,
 			isLearners:     []bool{false, true},
 			isLeaders:      []bool{false, true},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68770

Problem Summary:

`extractTimeRange` could not extract correct time bounds when the target time column appeared on the right side of a comparison predicate, such as `'2019-10-10 10:10:10' < update_time`. In that case, the extractor reused the original comparison operator without adjusting for operand order, so the lower or upper bound was missed or interpreted in the wrong direction.

This affects memtable predicate extraction paths that reuse `extractTimeRange`, including `cluster_log`, `tidb_hot_regions_history`, and metrics schema time filtering.

### What changed and how does it work?

This PR fixes operand-order handling in `extractTimeRange`.

  - Extend `extractColBinaryOpConsExpr` to return whether the extracted column is on the left side of the binary comparison.
  - In `extractTimeRange`, when the target column is on the right side, normalize the comparison direction before updating the extracted time range:
    - `<` becomes `>`
    - `<=` becomes `>=`
    - `>` becomes `<`
    - `>=` becomes `<=`
  - Keep the existing behavior unchanged for equality predicates and other helper callers that only need column/constant extraction.

  This PR also adds regression tests for reversed time comparisons in existing extractor test cases:
  - `information_schema.cluster_log`
  - `information_schema.tidb_hot_regions_history`
  - `metrics_schema.tidb_query_duration`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
```
./tools/check/failpoint-go-test.sh pkg/planner/core/operator/logicalop/logicalop_test -run 'TestClusterLogTableExtractor|TestMetricTableExtractor|TestTiDBHotRegionsHistoryTableExtractor' -count=1
```
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed time range filter handling for reversed comparison operators, ensuring both `column > constant` and `constant < column` forms produce correct results

## Tests
* Added comprehensive test coverage for reversed time comparison patterns across multiple table types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->