### PR TITLE
ddl: Handle mlog name confliction for materialized view

### DIFF
--- a/br/pkg/restore/snap_client/BUILD.bazel
+++ b/br/pkg/restore/snap_client/BUILD.bazel
@@ -84,7 +84,7 @@ go_test(
     ],
     embed = [":snap_client"],
     flaky = True,
-    shard_count = 18,
+    shard_count = 19,
     deps = [
         "//br/pkg/errors",
         "//br/pkg/glue",

--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -298,12 +298,16 @@ func (w *worker) onCreateMaterializedViewLog(jobCtx *jobContext, job *model.Job)
 	}
 	if baseTblInfo.MaterializedViewBase != nil && baseTblInfo.MaterializedViewBase.MLogID != 0 {
 		job.State = model.JobStateCancelled
-		return ver, infoschema.ErrTableExists.GenWithStackByArgs(ast.Ident{Schema: pmodel.NewCIStr(job.SchemaName), Name: mlogTblInfo.Name})
+		return ver, ErrMLogAlreadyExists.GenWithStackByArgs(ast.Ident{Schema: pmodel.NewCIStr(job.SchemaName), Name: baseTblInfo.Name})
 	}
 
 	mlogTblInfo.State = model.StateNone
 	mlogTblInfo, err = createTable(jobCtx, job, &model.CreateTableArgs{TableInfo: mlogTblInfo, FKCheck: false})
 	if err != nil {
+		if infoschema.ErrTableExists.Equal(err) || meta.ErrTableExists.Equal(err) {
+			job.State = model.JobStateCancelled
+			return ver, ErrMLogTableNameConflict.GenWithStackByArgs(ast.Ident{Schema: pmodel.NewCIStr(job.SchemaName), Name: mlogTblInfo.Name})
+		}
 		return ver, errors.Trace(err)
 	}
 

--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/pingcap/tidb/pkg/ddl/testargsv1"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
@@ -178,34 +179,119 @@ func TestBuildCreateMaterializedViewLogPurgeInfoUpsertSQL(t *testing.T) {
 func TestBuildMaterializedViewLogTableName(t *testing.T) {
 	oldMLogSeq := MLogTableNameSeq.Load()
 	oldShortSeq := MLogShortTableNameSeq.Load()
-	MLogTableNameSeq.Store(0)
-	MLogShortTableNameSeq.Store(0)
 	t.Cleanup(func() {
 		MLogTableNameSeq.Store(oldMLogSeq)
 		MLogShortTableNameSeq.Store(oldShortSeq)
 	})
 
-	exists := map[string]struct{}{
-		"$mlog$1base_table_name": {},
-		"$mlog$1":                {},
-	}
-	tableExists := func(name pmodel.CIStr) (bool, error) {
-		_, ok := exists[name.O]
-		return ok, nil
+	const baseTableName = "base_table_name"
+	longPrefixedBaseTableName := materializedViewLogTablePrefix + strings.Repeat("t", mysql.MaxTableNameLength-len(materializedViewLogTablePrefix))
+	longBaseTableName := strings.Repeat("t", mysql.MaxTableNameLength-len(materializedViewLogTablePrefix)+1)
+
+	tests := []struct {
+		name             string
+		baseTableName    string
+		existingTables   []string
+		expectedName     string
+		expectedMLogSeq  uint64
+		expectedShortSeq uint64
+	}{
+		{
+			name:            "prefixed base name is renamed",
+			baseTableName:   materializedViewLogTablePrefix + baseTableName,
+			expectedName:    materializedViewLogTablePrefix + "1" + baseTableName,
+			expectedMLogSeq: 1,
+		},
+		{
+			name:          "prefixed base name retries until renamed name does not conflict",
+			baseTableName: materializedViewLogTablePrefix + baseTableName,
+			existingTables: []string{
+				materializedViewLogTablePrefix + "1" + baseTableName,
+				materializedViewLogTablePrefix + "2" + baseTableName,
+			},
+			expectedName:    materializedViewLogTablePrefix + "3" + baseTableName,
+			expectedMLogSeq: 3,
+		},
+		{
+			name:             "prefixed base name falls back to short name when renamed name is too long",
+			baseTableName:    longPrefixedBaseTableName,
+			expectedName:     materializedViewLogTablePrefix + "1",
+			expectedMLogSeq:  1,
+			expectedShortSeq: 1,
+		},
+		{
+			name:          "prefixed base name falls back to short name and retries conflict",
+			baseTableName: longPrefixedBaseTableName,
+			existingTables: []string{
+				materializedViewLogTablePrefix + "1",
+				materializedViewLogTablePrefix + "2",
+			},
+			expectedName:     materializedViewLogTablePrefix + "3",
+			expectedMLogSeq:  1,
+			expectedShortSeq: 3,
+		},
+		{
+			name:             "regular base name falls back to short name when mlog name is too long",
+			baseTableName:    longBaseTableName,
+			expectedName:     materializedViewLogTablePrefix + "1",
+			expectedShortSeq: 1,
+		},
+		{
+			name:          "regular base name falls back to short name and retries conflict after mlog name is too long",
+			baseTableName: longBaseTableName,
+			existingTables: []string{
+				materializedViewLogTablePrefix + "1",
+				materializedViewLogTablePrefix + "2",
+			},
+			expectedName:     materializedViewLogTablePrefix + "3",
+			expectedShortSeq: 3,
+		},
+		{
+			name:          "regular base name falls back to short name when mlog name conflicts",
+			baseTableName: baseTableName,
+			existingTables: []string{
+				materializedViewLogTablePrefix + baseTableName,
+			},
+			expectedName:     materializedViewLogTablePrefix + "1",
+			expectedShortSeq: 1,
+		},
+		{
+			name:          "regular base name falls back to short name and retries conflict after mlog name conflicts",
+			baseTableName: baseTableName,
+			existingTables: []string{
+				materializedViewLogTablePrefix + baseTableName,
+				materializedViewLogTablePrefix + "1",
+				materializedViewLogTablePrefix + "2",
+			},
+			expectedName:     materializedViewLogTablePrefix + "3",
+			expectedShortSeq: 3,
+		},
 	}
 
-	name, err := GenerateMLogTableName(pmodel.NewCIStr("$mlog$base_table_name"), tableExists)
-	require.NoError(t, err)
-	require.Equal(t, "$mlog$2base_table_name", name.O)
-	require.Equal(t, uint64(2), MLogTableNameSeq.Load())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			MLogTableNameSeq.Store(0)
+			MLogShortTableNameSeq.Store(0)
+			exists := make(map[string]struct{}, len(tt.existingTables))
+			for _, tableName := range tt.existingTables {
+				exists[strings.ToLower(tableName)] = struct{}{}
+			}
+			tableExists := func(name pmodel.CIStr) (bool, error) {
+				_, ok := exists[name.L]
+				return ok, nil
+			}
 
-	name, err = GenerateMLogTableName(pmodel.NewCIStr(strings.Repeat("表", mysql.MaxTableNameLength)), tableExists)
-	require.NoError(t, err)
-	require.Equal(t, "$mlog$2", name.O)
-	require.Equal(t, uint64(2), MLogShortTableNameSeq.Load())
+			name, err := GenerateMLogTableName(pmodel.NewCIStr(tt.baseTableName), tableExists)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedName, name.O)
+			require.LessOrEqual(t, utf8.RuneCountInString(name.L), mysql.MaxTableNameLength)
+			require.Equal(t, tt.expectedMLogSeq, MLogTableNameSeq.Load())
+			require.Equal(t, tt.expectedShortSeq, MLogShortTableNameSeq.Load())
+		})
+	}
 
 	MLogTableNameSeq.Store(math.MaxUint64)
-	_, err = nextMLogTableNameNumber(&MLogTableNameSeq, "out of range")
+	_, err := nextMLogTableNameNumber(&MLogTableNameSeq, "out of range")
 	require.ErrorContains(t, err, "out of range")
 }
 

--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -172,6 +173,40 @@ func TestBuildCreateMaterializedViewLogPurgeInfoUpsertSQL(t *testing.T) {
 	require.Contains(t, sqlWithNull, "NEXT_TIME")
 	require.Contains(t, sqlWithNull, "VALUES(NEXT_TIME)")
 	require.Contains(t, sqlWithNull, ", NULL)")
+}
+
+func TestBuildMaterializedViewLogTableName(t *testing.T) {
+	oldMLogSeq := MLogTableNameSeq.Load()
+	oldShortSeq := MLogShortTableNameSeq.Load()
+	MLogTableNameSeq.Store(0)
+	MLogShortTableNameSeq.Store(0)
+	t.Cleanup(func() {
+		MLogTableNameSeq.Store(oldMLogSeq)
+		MLogShortTableNameSeq.Store(oldShortSeq)
+	})
+
+	exists := map[string]struct{}{
+		"$mlog$1base_table_name": {},
+		"$mlog$1":                {},
+	}
+	tableExists := func(name pmodel.CIStr) (bool, error) {
+		_, ok := exists[name.O]
+		return ok, nil
+	}
+
+	name, err := BuildMaterializedViewLogTableName(pmodel.NewCIStr("$mlog$base_table_name"), tableExists)
+	require.NoError(t, err)
+	require.Equal(t, "$mlog$2base_table_name", name.O)
+	require.Equal(t, uint64(2), MLogTableNameSeq.Load())
+
+	name, err = BuildMaterializedViewLogTableName(pmodel.NewCIStr(strings.Repeat("表", mysql.MaxTableNameLength)), tableExists)
+	require.NoError(t, err)
+	require.Equal(t, "$mlog$2", name.O)
+	require.Equal(t, uint64(2), MLogShortTableNameSeq.Load())
+
+	MLogTableNameSeq.Store(math.MaxUint64)
+	_, err = nextMaterializedViewLogTableNameNumber(&MLogTableNameSeq, "out of range")
+	require.ErrorContains(t, err, "out of range")
 }
 
 func TestBuildMViewRefreshOutOfPlaceCutoverInvolvingSchemaInfo(t *testing.T) {

--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -194,18 +194,18 @@ func TestBuildMaterializedViewLogTableName(t *testing.T) {
 		return ok, nil
 	}
 
-	name, err := BuildMaterializedViewLogTableName(pmodel.NewCIStr("$mlog$base_table_name"), tableExists)
+	name, err := GenerateMLogTableName(pmodel.NewCIStr("$mlog$base_table_name"), tableExists)
 	require.NoError(t, err)
 	require.Equal(t, "$mlog$2base_table_name", name.O)
 	require.Equal(t, uint64(2), MLogTableNameSeq.Load())
 
-	name, err = BuildMaterializedViewLogTableName(pmodel.NewCIStr(strings.Repeat("表", mysql.MaxTableNameLength)), tableExists)
+	name, err = GenerateMLogTableName(pmodel.NewCIStr(strings.Repeat("表", mysql.MaxTableNameLength)), tableExists)
 	require.NoError(t, err)
 	require.Equal(t, "$mlog$2", name.O)
 	require.Equal(t, uint64(2), MLogShortTableNameSeq.Load())
 
 	MLogTableNameSeq.Store(math.MaxUint64)
-	_, err = nextMaterializedViewLogTableNameNumber(&MLogTableNameSeq, "out of range")
+	_, err = nextMLogTableNameNumber(&MLogTableNameSeq, "out of range")
 	require.ErrorContains(t, err, "out of range")
 }
 

--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -283,8 +283,8 @@ func TestBuildMaterializedViewLogTableName(t *testing.T) {
 
 			name, err := GenerateMLogTableName(pmodel.NewCIStr(tt.baseTableName), tableExists)
 			require.NoError(t, err)
-			require.Equal(t, tt.expectedName, name.O)
-			require.LessOrEqual(t, utf8.RuneCountInString(name.L), mysql.MaxTableNameLength)
+			require.Equal(t, tt.expectedName, name)
+			require.LessOrEqual(t, utf8.RuneCountInString(strings.ToLower(name)), mysql.MaxTableNameLength)
 			require.Equal(t, tt.expectedMLogSeq, MLogTableNameSeq.Load())
 			require.Equal(t, tt.expectedShortSeq, MLogShortTableNameSeq.Load())
 		})

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1085,17 +1085,15 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	if baseTable.Meta().IsView() || baseTable.Meta().IsSequence() || baseTable.Meta().TempTableType != model.TempTableNone {
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
+	if baseInfo := baseTable.Meta().MaterializedViewBase; baseInfo != nil && baseInfo.MLogID != 0 {
+		return infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Meta().Name.O))
+	}
 
-	mlogName := "$mlog$" + baseTable.Meta().Name.O
-	mlogNameCIStr := pmodel.NewCIStr(mlogName)
-	if err := checkTooLongTable(mlogNameCIStr); err != nil {
-		return err
-	}
-	_, err = is.TableByName(e.ctx, schemaName, mlogNameCIStr)
-	if err == nil {
-		return infoschema.ErrTableExists.GenWithStackByArgs(ast.Ident{Schema: schemaName, Name: mlogNameCIStr})
-	}
-	if !infoschema.ErrTableNotExists.Equal(err) {
+	mlogNameCIStr, err := BuildMaterializedViewLogTableName(
+		baseTable.Meta().Name,
+		getExistenceOfMLogTableChecker(e.ctx, is, schemaName),
+	)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1089,9 +1089,9 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 		return infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Meta().Name.O))
 	}
 
-	mlogNameCIStr, err := BuildMaterializedViewLogTableName(
+	mlogNameCIStr, err := GenerateMLogTableName(
 		baseTable.Meta().Name,
-		getExistenceOfMLogTableChecker(e.ctx, is, schemaName),
+		getExistenceOfMLogTableNameChecker(e.ctx, is, schemaName),
 	)
 	if err != nil {
 		return err

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -109,7 +109,7 @@ type Executor interface {
 	DropSchema(ctx sessionctx.Context, stmt *ast.DropDatabaseStmt) error
 	CreateTable(ctx sessionctx.Context, stmt *ast.CreateTableStmt) error
 	CreateMaterializedView(ctx sessionctx.Context, stmt *ast.CreateMaterializedViewStmt) error
-	CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.CreateMaterializedViewLogStmt) error
+	CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.CreateMaterializedViewLogStmt, mlogTableName string) (string, error)
 	CreateView(ctx sessionctx.Context, stmt *ast.CreateViewStmt) error
 	DropTable(ctx sessionctx.Context, stmt *ast.DropTableStmt) (err error)
 	DropMaterializedView(ctx sessionctx.Context, stmt *ast.DropMaterializedViewStmt) error
@@ -1063,30 +1063,30 @@ func (e *executor) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStmt) (
 	return e.CreateTableWithInfo(ctx, schema.Name, tbInfo, involvingRef, WithOnExist(onExist))
 }
 
-func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.CreateMaterializedViewLogStmt) error {
+func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.CreateMaterializedViewLogStmt, _ string) (string, error) {
 	is := e.infoCache.GetLatest()
 	schemaName := s.Table.Schema
 	if schemaName.O == "" {
 		if ctx.GetSessionVars().CurrentDB == "" {
-			return errors.Trace(plannererrors.ErrNoDB)
+			return "", errors.Trace(plannererrors.ErrNoDB)
 		}
 		schemaName = pmodel.NewCIStr(ctx.GetSessionVars().CurrentDB)
 	}
 	schema, ok := is.SchemaByName(schemaName)
 	if !ok {
-		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
+		return "", infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
 	}
 
 	baseTable, err := is.TableByName(e.ctx, schemaName, s.Table.Name)
 	if err != nil {
-		return err
+		return "", err
 	}
 	baseTableID := baseTable.Meta().ID
 	if baseTable.Meta().IsView() || baseTable.Meta().IsSequence() || baseTable.Meta().TempTableType != model.TempTableNone {
-		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
+		return "", dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
 	if baseInfo := baseTable.Meta().MaterializedViewBase; baseInfo != nil && baseInfo.MLogID != 0 {
-		return infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Meta().Name.O))
+		return "", infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Meta().Name.O))
 	}
 
 	mlogNameCIStr, err := GenerateMLogTableName(
@@ -1094,7 +1094,7 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 		getExistenceOfMLogTableNameChecker(e.ctx, is, schemaName),
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	colMap := make(map[string]*model.ColumnInfo, len(baseTable.Meta().Columns))
@@ -1106,16 +1106,16 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	colDefs := make([]*ast.ColumnDef, 0, len(s.Cols)+2)
 	for _, c := range s.Cols {
 		if _, exists := seenCols[c.L]; exists {
-			return infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
+			return "", infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
 		}
 		seenCols[c.L] = struct{}{}
 		if c.L == strings.ToLower(model.MaterializedViewLogDMLTypeColumnName) ||
 			c.L == strings.ToLower(model.MaterializedViewLogOldNewColumnName) {
-			return infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
+			return "", infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
 		}
 		baseCol := colMap[c.L]
 		if baseCol == nil {
-			return infoschema.ErrColumnNotExists.GenWithStackByArgs(c.O, s.Table.Name.O)
+			return "", infoschema.ErrColumnNotExists.GenWithStackByArgs(c.O, s.Table.Name.O)
 		}
 		ft := baseCol.FieldType
 		ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
@@ -1157,7 +1157,7 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 		schema.PlacementPolicyRef,
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	var purgeMethod string
@@ -1165,21 +1165,21 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	var purgeNext string
 	if s.Purge != nil {
 		if s.Purge.Immediate {
-			return errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
+			return "", errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
 		}
 		purgeMethod = "DEFERRED"
 		if s.Purge.StartWith != nil {
 			purgeStartWith, err = BuildAndValidateMViewScheduleExpr(ctx, s.Purge.StartWith, "PURGE START WITH")
 			if err != nil {
-				return err
+				return "", err
 			}
 		}
 		if s.Purge.Next == nil {
-			return errors.New("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
+			return "", errors.New("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
 		}
 		purgeNext, err = BuildAndValidateMViewScheduleExpr(ctx, s.Purge.Next, "PURGE NEXT")
 		if err != nil {
-			return err
+			return "", err
 		}
 	}
 
@@ -1211,14 +1211,14 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	job.AddSessionVars(variable.TiDBScatterRegion, getScatterScopeFromSessionctx(ctx))
 	jobW := NewJobWrapperWithArgs(job, &model.CreateMaterializedViewLogArgs{TableInfo: mlogTableInfo}, false)
 	if err := e.DoDDLJobWrapper(ctx, jobW); err != nil {
-		return errors.Trace(err)
+		return "", errors.Trace(err)
 	}
 
 	var scatterScope string
 	if val, ok := jobW.GetSessionVars(variable.TiDBScatterRegion); ok {
 		scatterScope = val
 	}
-	return errors.Trace(e.createTableWithInfoPost(ctx, mlogTableInfo, jobW.SchemaID, scatterScope))
+	return mlogNameCIStr.O, errors.Trace(e.createTableWithInfoPost(ctx, mlogTableInfo, jobW.SchemaID, scatterScope))
 }
 
 func restoreExprToCanonicalSQL(expr ast.ExprNode) (string, error) {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -109,8 +109,9 @@ type Executor interface {
 	DropSchema(ctx sessionctx.Context, stmt *ast.DropDatabaseStmt) error
 	CreateTable(ctx sessionctx.Context, stmt *ast.CreateTableStmt) error
 	CreateMaterializedView(ctx sessionctx.Context, stmt *ast.CreateMaterializedViewStmt) error
-	CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.CreateMaterializedViewLogStmt, mlogTableName string) (string, error)
+	CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.CreateMaterializedViewLogStmt, mlogTableName string) error
 	CreateView(ctx sessionctx.Context, stmt *ast.CreateViewStmt) error
+	GenerateMLogTableName(ctx sessionctx.Context, s *ast.CreateMaterializedViewLogStmt) (string, error)
 	DropTable(ctx sessionctx.Context, stmt *ast.DropTableStmt) (err error)
 	DropMaterializedView(ctx sessionctx.Context, stmt *ast.DropMaterializedViewStmt) error
 	DropMaterializedViewLog(ctx sessionctx.Context, stmt *ast.DropMaterializedViewLogStmt) error
@@ -1063,7 +1064,8 @@ func (e *executor) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStmt) (
 	return e.CreateTableWithInfo(ctx, schema.Name, tbInfo, involvingRef, WithOnExist(onExist))
 }
 
-func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.CreateMaterializedViewLogStmt, _ string) (string, error) {
+// GenerateMLogTableName implements the DDL interface.
+func (e *executor) GenerateMLogTableName(ctx sessionctx.Context, s *ast.CreateMaterializedViewLogStmt) (string, error) {
 	is := e.infoCache.GetLatest()
 	schemaName := s.Table.Schema
 	if schemaName.O == "" {
@@ -1072,16 +1074,11 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 		}
 		schemaName = pmodel.NewCIStr(ctx.GetSessionVars().CurrentDB)
 	}
-	schema, ok := is.SchemaByName(schemaName)
-	if !ok {
-		return "", infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
-	}
 
 	baseTable, err := is.TableByName(e.ctx, schemaName, s.Table.Name)
 	if err != nil {
 		return "", err
 	}
-	baseTableID := baseTable.Meta().ID
 	if baseTable.Meta().IsView() || baseTable.Meta().IsSequence() || baseTable.Meta().TempTableType != model.TempTableNone {
 		return "", dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
@@ -1089,12 +1086,41 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 		return "", infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Meta().Name.O))
 	}
 
-	mlogNameCIStr, err := GenerateMLogTableName(
+	mlogName, err := GenerateMLogTableName(
 		baseTable.Meta().Name,
 		getExistenceOfMLogTableNameChecker(e.ctx, is, schemaName),
 	)
 	if err != nil {
 		return "", err
+	}
+
+	return mlogName, nil
+}
+
+func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.CreateMaterializedViewLogStmt, mlogTableName string) error {
+	is := e.infoCache.GetLatest()
+	schemaName := s.Table.Schema
+	if schemaName.O == "" {
+		if ctx.GetSessionVars().CurrentDB == "" {
+			return errors.Trace(plannererrors.ErrNoDB)
+		}
+		schemaName = pmodel.NewCIStr(ctx.GetSessionVars().CurrentDB)
+	}
+	schema, ok := is.SchemaByName(schemaName)
+	if !ok {
+		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
+	}
+
+	baseTable, err := is.TableByName(e.ctx, schemaName, s.Table.Name)
+	if err != nil {
+		return err
+	}
+	baseTableID := baseTable.Meta().ID
+	if baseTable.Meta().IsView() || baseTable.Meta().IsSequence() || baseTable.Meta().TempTableType != model.TempTableNone {
+		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
+	}
+	if baseInfo := baseTable.Meta().MaterializedViewBase; baseInfo != nil && baseInfo.MLogID != 0 {
+		return infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Meta().Name.O))
 	}
 
 	colMap := make(map[string]*model.ColumnInfo, len(baseTable.Meta().Columns))
@@ -1106,16 +1132,16 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	colDefs := make([]*ast.ColumnDef, 0, len(s.Cols)+2)
 	for _, c := range s.Cols {
 		if _, exists := seenCols[c.L]; exists {
-			return "", infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
+			return infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
 		}
 		seenCols[c.L] = struct{}{}
 		if c.L == strings.ToLower(model.MaterializedViewLogDMLTypeColumnName) ||
 			c.L == strings.ToLower(model.MaterializedViewLogOldNewColumnName) {
-			return "", infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
+			return infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
 		}
 		baseCol := colMap[c.L]
 		if baseCol == nil {
-			return "", infoschema.ErrColumnNotExists.GenWithStackByArgs(c.O, s.Table.Name.O)
+			return infoschema.ErrColumnNotExists.GenWithStackByArgs(c.O, s.Table.Name.O)
 		}
 		ft := baseCol.FieldType
 		ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
@@ -1145,7 +1171,7 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	}
 
 	createTableStmt := &ast.CreateTableStmt{
-		Table:   &ast.TableName{Schema: schemaName, Name: mlogNameCIStr},
+		Table:   &ast.TableName{Schema: schemaName, Name: pmodel.NewCIStr(mlogTableName)},
 		Cols:    colDefs,
 		Options: s.Options,
 	}
@@ -1157,7 +1183,7 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 		schema.PlacementPolicyRef,
 	)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	var purgeMethod string
@@ -1165,21 +1191,21 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	var purgeNext string
 	if s.Purge != nil {
 		if s.Purge.Immediate {
-			return "", errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
+			return errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
 		}
 		purgeMethod = "DEFERRED"
 		if s.Purge.StartWith != nil {
 			purgeStartWith, err = BuildAndValidateMViewScheduleExpr(ctx, s.Purge.StartWith, "PURGE START WITH")
 			if err != nil {
-				return "", err
+				return err
 			}
 		}
 		if s.Purge.Next == nil {
-			return "", errors.New("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
+			return errors.New("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
 		}
 		purgeNext, err = BuildAndValidateMViewScheduleExpr(ctx, s.Purge.Next, "PURGE NEXT")
 		if err != nil {
-			return "", err
+			return err
 		}
 	}
 
@@ -1211,14 +1237,14 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	job.AddSessionVars(variable.TiDBScatterRegion, getScatterScopeFromSessionctx(ctx))
 	jobW := NewJobWrapperWithArgs(job, &model.CreateMaterializedViewLogArgs{TableInfo: mlogTableInfo}, false)
 	if err := e.DoDDLJobWrapper(ctx, jobW); err != nil {
-		return "", errors.Trace(err)
+		return errors.Trace(err)
 	}
 
 	var scatterScope string
 	if val, ok := jobW.GetSessionVars(variable.TiDBScatterRegion); ok {
 		scatterScope = val
 	}
-	return mlogNameCIStr.O, errors.Trace(e.createTableWithInfoPost(ctx, mlogTableInfo, jobW.SchemaID, scatterScope))
+	return errors.Trace(e.createTableWithInfoPost(ctx, mlogTableInfo, jobW.SchemaID, scatterScope))
 }
 
 func restoreExprToCanonicalSQL(expr ast.ExprNode) (string, error) {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1083,7 +1083,7 @@ func (e *executor) GenerateMLogTableName(ctx sessionctx.Context, s *ast.CreateMa
 		return "", dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
 	if baseInfo := baseTable.Meta().MaterializedViewBase; baseInfo != nil && baseInfo.MLogID != 0 {
-		return "", infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Meta().Name.O))
+		return "", ErrMLogAlreadyExists.GenWithStackByArgs(ast.Ident{Schema: schemaName, Name: baseTable.Meta().Name})
 	}
 
 	mlogName, err := GenerateMLogTableName(
@@ -1120,7 +1120,7 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
 	if baseInfo := baseTable.Meta().MaterializedViewBase; baseInfo != nil && baseInfo.MLogID != 0 {
-		return infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Meta().Name.O))
+		return ErrMLogAlreadyExists.GenWithStackByArgs(ast.Ident{Schema: schemaName, Name: baseTable.Meta().Name})
 	}
 
 	colMap := make(map[string]*model.ColumnInfo, len(baseTable.Meta().Columns))

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -102,7 +102,12 @@ func GenerateMLogTableName(
 		candidate = pmodel.NewCIStr(materializedViewLogTablePrefix + baseTableName.O)
 	}
 
-	if utf8.RuneCountInString(candidate.L) <= mysql.MaxTableNameLength {
+	exists, err := checkTableExistence(candidate)
+	if err != nil {
+		return pmodel.CIStr{}, err
+	}
+
+	if !exists && utf8.RuneCountInString(candidate.L) <= mysql.MaxTableNameLength {
 		return candidate, nil
 	}
 

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -67,8 +67,6 @@ var (
 )
 
 // GenerateMLogTableName generates an available mlog table name for the base table.
-//
-// TODO(xzx) add ut for this function
 func GenerateMLogTableName(
 	baseTableName pmodel.CIStr,
 	checkTableExistence func(pmodel.CIStr) (bool, error),
@@ -111,7 +109,6 @@ func GenerateMLogTableName(
 		return candidate, nil
 	}
 
-	// TODO(xzx) more ut for this code
 	for {
 		var err error
 		number, err := nextMLogTableNameNumber(

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -66,8 +66,9 @@ var (
 	MLogShortTableNameSeq atomic.Uint64
 )
 
-// BuildMaterializedViewLogTableName builds an available mlog table name for the base table.
-func BuildMaterializedViewLogTableName(
+// TODO(xzx) add ut for this function
+// GenerateMLogTableName generates an available mlog table name for the base table.
+func GenerateMLogTableName(
 	baseTableName pmodel.CIStr,
 	checkTableExistence func(pmodel.CIStr) (bool, error),
 ) (pmodel.CIStr, error) {
@@ -80,7 +81,7 @@ func BuildMaterializedViewLogTableName(
 		suffix := baseTableName.O[len(materializedViewLogTablePrefix):]
 		for {
 			var err error
-			number, err := nextMaterializedViewLogTableNameNumber(
+			number, err := nextMLogTableNameNumber(
 				&MLogTableNameSeq,
 				"materialized view log table name number is out of range",
 			)
@@ -104,9 +105,10 @@ func BuildMaterializedViewLogTableName(
 		return candidate, nil
 	}
 
+	// TODO(xzx) more ut for this code
 	for {
 		var err error
-		number, err := nextMaterializedViewLogTableNameNumber(
+		number, err := nextMLogTableNameNumber(
 			&MLogShortTableNameSeq,
 			"materialized view log short table name number is out of range",
 		)
@@ -127,7 +129,7 @@ func BuildMaterializedViewLogTableName(
 	}
 }
 
-func nextMaterializedViewLogTableNameNumber(counter *atomic.Uint64, outOfRangeErr string) (uint64, error) {
+func nextMLogTableNameNumber(counter *atomic.Uint64, outOfRangeErr string) (uint64, error) {
 	if counter.Load() == math.MaxUint64 {
 		return 0, errors.New(outOfRangeErr)
 	}
@@ -138,7 +140,7 @@ func nextMaterializedViewLogTableNameNumber(counter *atomic.Uint64, outOfRangeEr
 	return next, nil
 }
 
-func getExistenceOfMLogTableChecker(
+func getExistenceOfMLogTableNameChecker(
 	ctx context.Context,
 	is infoschema.InfoSchema,
 	schemaName pmodel.CIStr,
@@ -155,17 +157,17 @@ func getExistenceOfMLogTableChecker(
 	}
 }
 
-// ResolveMLogTableByBaseTable returns the mlog table recorded on the base table metadata.
-func ResolveMLogTableByBaseTable(
+// GetMLogTableByBaseTable returns the mlog table recorded on the base table metadata.
+func GetMLogTableByBaseTable(
 	ctx context.Context,
 	is infoschema.InfoSchema,
 	schemaName pmodel.CIStr,
 	baseTableMeta *model.TableInfo,
 ) (table.Table, error) {
-	return resolveMLogTableByBaseTable(ctx, is, schemaName, baseTableMeta)
+	return getMLogTableByBaseTable(ctx, is, schemaName, baseTableMeta)
 }
 
-func resolveMLogTableByBaseTable(
+func getMLogTableByBaseTable(
 	ctx context.Context,
 	is infoschema.InfoSchema,
 	schemaName pmodel.CIStr,
@@ -191,13 +193,13 @@ func resolveMLogTableByBaseTable(
 			baseTableMeta.Name.O,
 		)
 	}
-	mlogName := mlogTable.Meta().Name
+
 	mlogInfo := mlogTable.Meta().MaterializedViewLog
 	if mlogInfo == nil || mlogInfo.BaseTableID != baseTableMeta.ID {
 		return nil, errors.Errorf(
 			"table %s.%s is not a materialized view log for base table %s.%s",
 			schemaName.O,
-			mlogName.O,
+			mlogTable.Meta().Name.O,
 			schemaName.O,
 			baseTableMeta.Name.O,
 		)
@@ -387,7 +389,7 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 	}
 	baseTableID := baseTable.Meta().ID
 
-	mlogTable, err := resolveMLogTableByBaseTable(e.ctx, is, baseTableName.Schema, baseTable.Meta())
+	mlogTable, err := getMLogTableByBaseTable(e.ctx, is, baseTableName.Schema, baseTable.Meta())
 	if err != nil {
 		return err
 	}
@@ -578,7 +580,7 @@ func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMa
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
 
-	mlogTable, err := resolveMLogTableByBaseTable(e.ctx, is, schemaName, baseTable.Meta())
+	mlogTable, err := getMLogTableByBaseTable(e.ctx, is, schemaName, baseTable.Meta())
 	if err != nil {
 		return err
 	}
@@ -702,7 +704,7 @@ func (e *executor) AlterMaterializedViewLog(ctx sessionctx.Context, s *ast.Alter
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
 
-	mlogTable, err := resolveMLogTableByBaseTable(e.ctx, is, schemaName, baseTable.Meta())
+	mlogTable, err := getMLogTableByBaseTable(e.ctx, is, schemaName, baseTable.Meta())
 	if err != nil {
 		return err
 	}

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -17,8 +17,11 @@ package ddl
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
+	"sync/atomic"
+	"unicode/utf8"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -37,6 +40,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	storeerr "github.com/pingcap/tidb/pkg/store/driver/error"
+	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/types"
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
@@ -47,10 +51,159 @@ import (
 )
 
 const (
+	materializedViewLogTablePrefix                        = "$mlog$"
 	mviewAttrAlertWarning                                 = "mview_alert_warning"
 	mviewAttrAlertOverdue                                 = "mview_alert_overdue"
 	alterMaterializedScheduleInfoUpdateLockWaitTimeoutSec = int64(10)
 )
+
+var (
+	// MLogTableNameSeq allocates numeric components for mlog names derived from
+	// base tables whose names already start with "$mlog$".
+	MLogTableNameSeq atomic.Uint64
+	// MLogShortTableNameSeq allocates numeric components for shortened mlog names
+	// used when the derived name exceeds TiDB's table-name length limit.
+	MLogShortTableNameSeq atomic.Uint64
+)
+
+// BuildMaterializedViewLogTableName builds an available mlog table name for the base table.
+func BuildMaterializedViewLogTableName(
+	baseTableName pmodel.CIStr,
+	checkTableExistence func(pmodel.CIStr) (bool, error),
+) (pmodel.CIStr, error) {
+	if checkTableExistence == nil {
+		return pmodel.CIStr{}, errors.New("materialized view log table name exists checker is nil")
+	}
+
+	var candidate pmodel.CIStr
+	if strings.HasPrefix(baseTableName.L, materializedViewLogTablePrefix) {
+		suffix := baseTableName.O[len(materializedViewLogTablePrefix):]
+		for {
+			var err error
+			number, err := nextMaterializedViewLogTableNameNumber(
+				&MLogTableNameSeq,
+				"materialized view log table name number is out of range",
+			)
+			if err != nil {
+				return pmodel.CIStr{}, err
+			}
+			candidate = pmodel.NewCIStr(materializedViewLogTablePrefix + strconv.FormatUint(number, 10) + suffix)
+			exists, err := checkTableExistence(candidate)
+			if err != nil {
+				return pmodel.CIStr{}, err
+			}
+			if !exists {
+				break
+			}
+		}
+	} else {
+		candidate = pmodel.NewCIStr(materializedViewLogTablePrefix + baseTableName.O)
+	}
+
+	if utf8.RuneCountInString(candidate.L) <= mysql.MaxTableNameLength {
+		return candidate, nil
+	}
+
+	for {
+		var err error
+		number, err := nextMaterializedViewLogTableNameNumber(
+			&MLogShortTableNameSeq,
+			"materialized view log short table name number is out of range",
+		)
+		if err != nil {
+			return pmodel.CIStr{}, err
+		}
+		candidate = pmodel.NewCIStr(materializedViewLogTablePrefix + strconv.FormatUint(number, 10))
+		if utf8.RuneCountInString(candidate.L) > mysql.MaxTableNameLength {
+			return pmodel.CIStr{}, dbterror.ErrTooLongIdent.GenWithStackByArgs(candidate)
+		}
+		exists, err := checkTableExistence(candidate)
+		if err != nil {
+			return pmodel.CIStr{}, err
+		}
+		if !exists {
+			return candidate, nil
+		}
+	}
+}
+
+func nextMaterializedViewLogTableNameNumber(counter *atomic.Uint64, outOfRangeErr string) (uint64, error) {
+	if counter.Load() == math.MaxUint64 {
+		return 0, errors.New(outOfRangeErr)
+	}
+	next := counter.Add(1)
+	if next == 0 {
+		return 0, errors.New(outOfRangeErr)
+	}
+	return next, nil
+}
+
+func getExistenceOfMLogTableChecker(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	schemaName pmodel.CIStr,
+) func(pmodel.CIStr) (bool, error) {
+	return func(tableName pmodel.CIStr) (bool, error) {
+		_, err := is.TableByName(ctx, schemaName, tableName)
+		if err == nil {
+			return true, nil
+		}
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return false, nil
+		}
+		return false, err
+	}
+}
+
+// ResolveMLogTableByBaseTable returns the mlog table recorded on the base table metadata.
+func ResolveMLogTableByBaseTable(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	schemaName pmodel.CIStr,
+	baseTableMeta *model.TableInfo,
+) (table.Table, error) {
+	return resolveMLogTableByBaseTable(ctx, is, schemaName, baseTableMeta)
+}
+
+func resolveMLogTableByBaseTable(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	schemaName pmodel.CIStr,
+	baseTableMeta *model.TableInfo,
+) (table.Table, error) {
+	if baseTableMeta == nil {
+		return nil, errors.New("materialized view log: invalid base table metadata")
+	}
+	if baseTableMeta.MaterializedViewBase == nil || baseTableMeta.MaterializedViewBase.MLogID == 0 {
+		return nil, errors.Errorf(
+			"materialized view log does not exist for base table %s.%s",
+			schemaName.O,
+			baseTableMeta.Name.O,
+		)
+	}
+
+	mlogID := baseTableMeta.MaterializedViewBase.MLogID
+	mlogTable, ok := is.TableByID(ctx, mlogID)
+	if !ok {
+		return nil, errors.Errorf(
+			"materialized view log does not exist for base table %s.%s",
+			schemaName.O,
+			baseTableMeta.Name.O,
+		)
+	}
+	mlogName := mlogTable.Meta().Name
+	mlogInfo := mlogTable.Meta().MaterializedViewLog
+	if mlogInfo == nil || mlogInfo.BaseTableID != baseTableMeta.ID {
+		return nil, errors.Errorf(
+			"table %s.%s is not a materialized view log for base table %s.%s",
+			schemaName.O,
+			mlogName.O,
+			schemaName.O,
+			baseTableMeta.Name.O,
+		)
+	}
+	return mlogTable, nil
+}
 
 // ApplyMViewExecutionSessionVars applies MV execution vars onto a session and returns a restore closure.
 func ApplyMViewExecutionSessionVars(sessVars *variable.SessionVars, target variable.MViewExecutionSessionVars) (func(), error) {
@@ -234,16 +387,9 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 	}
 	baseTableID := baseTable.Meta().ID
 
-	mlogName := pmodel.NewCIStr("$mlog$" + baseTable.Meta().Name.O)
-	mlogTable, err := is.TableByName(e.ctx, baseTableName.Schema, mlogName)
+	mlogTable, err := resolveMLogTableByBaseTable(e.ctx, is, baseTableName.Schema, baseTable.Meta())
 	if err != nil {
-		if infoschema.ErrTableNotExists.Equal(err) {
-			return errors.Errorf("materialized view log does not exist for base table %s.%s", baseTableName.Schema.O, baseTableName.Name.O)
-		}
 		return err
-	}
-	if mlogTable.Meta().MaterializedViewLog == nil || mlogTable.Meta().MaterializedViewLog.BaseTableID != baseTableID {
-		return errors.Errorf("table %s.%s is not a materialized view log for base table %s.%s", baseTableName.Schema.O, mlogName.O, baseTableName.Schema.O, baseTableName.Name.O)
 	}
 
 	// Validate Stage-1 query contract and ensure MV LOG columns cover query references.
@@ -431,16 +577,12 @@ func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMa
 	if baseTable.Meta().IsView() || baseTable.Meta().IsSequence() || baseTable.Meta().TempTableType != model.TempTableNone {
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
-	baseTableID := baseTable.Meta().ID
 
-	mlogName := pmodel.NewCIStr("$mlog$" + baseTable.Meta().Name.O)
-	mlogTable, err := is.TableByName(e.ctx, schemaName, mlogName)
+	mlogTable, err := resolveMLogTableByBaseTable(e.ctx, is, schemaName, baseTable.Meta())
 	if err != nil {
 		return err
 	}
-	if mlogTable.Meta().MaterializedViewLog == nil || mlogTable.Meta().MaterializedViewLog.BaseTableID != baseTableID {
-		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName.O, mlogName, "MATERIALIZED VIEW LOG")
-	}
+	mlogName := mlogTable.Meta().Name
 
 	// MV LOG cannot be dropped while any MV still depends on the base table.
 	if hasMaterializedViewDependsOnBaseTable(baseTable.Meta()) {
@@ -559,16 +701,12 @@ func (e *executor) AlterMaterializedViewLog(ctx sessionctx.Context, s *ast.Alter
 	if baseTable.Meta().IsView() || baseTable.Meta().IsSequence() || baseTable.Meta().TempTableType != model.TempTableNone {
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
-	baseTableID := baseTable.Meta().ID
 
-	mlogName := pmodel.NewCIStr("$mlog$" + baseTable.Meta().Name.O)
-	mlogTable, err := is.TableByName(e.ctx, schemaName, mlogName)
+	mlogTable, err := resolveMLogTableByBaseTable(e.ctx, is, schemaName, baseTable.Meta())
 	if err != nil {
 		return err
 	}
-	if mlogTable.Meta().MaterializedViewLog == nil || mlogTable.Meta().MaterializedViewLog.BaseTableID != baseTableID {
-		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName.O, mlogName, "MATERIALIZED VIEW LOG")
-	}
+	mlogName := mlogTable.Meta().Name
 
 	for _, action := range s.Actions {
 		switch action.Tp {

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -66,8 +66,9 @@ var (
 	MLogShortTableNameSeq atomic.Uint64
 )
 
-// TODO(xzx) add ut for this function
 // GenerateMLogTableName generates an available mlog table name for the base table.
+//
+// TODO(xzx) add ut for this function
 func GenerateMLogTableName(
 	baseTableName pmodel.CIStr,
 	checkTableExistence func(pmodel.CIStr) (bool, error),
@@ -155,6 +156,15 @@ func getExistenceOfMLogTableNameChecker(
 		}
 		return false, err
 	}
+}
+
+// GetExistenceOfMLogTableNameChecker returns a checker for whether an mlog table name already exists.
+func GetExistenceOfMLogTableNameChecker(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	schemaName pmodel.CIStr,
+) func(pmodel.CIStr) (bool, error) {
+	return getExistenceOfMLogTableNameChecker(ctx, is, schemaName)
 }
 
 // GetMLogTableByBaseTable returns the mlog table recorded on the base table metadata.

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -70,9 +70,9 @@ var (
 func GenerateMLogTableName(
 	baseTableName pmodel.CIStr,
 	checkTableExistence func(pmodel.CIStr) (bool, error),
-) (pmodel.CIStr, error) {
+) (string, error) {
 	if checkTableExistence == nil {
-		return pmodel.CIStr{}, errors.New("materialized view log table name exists checker is nil")
+		return "", errors.New("materialized view log table name exists checker is nil")
 	}
 
 	var candidate pmodel.CIStr
@@ -85,12 +85,12 @@ func GenerateMLogTableName(
 				"materialized view log table name number is out of range",
 			)
 			if err != nil {
-				return pmodel.CIStr{}, err
+				return "", err
 			}
 			candidate = pmodel.NewCIStr(materializedViewLogTablePrefix + strconv.FormatUint(number, 10) + suffix)
 			exists, err := checkTableExistence(candidate)
 			if err != nil {
-				return pmodel.CIStr{}, err
+				return "", err
 			}
 			if !exists {
 				break
@@ -102,11 +102,11 @@ func GenerateMLogTableName(
 
 	exists, err := checkTableExistence(candidate)
 	if err != nil {
-		return pmodel.CIStr{}, err
+		return "", err
 	}
 
 	if !exists && utf8.RuneCountInString(candidate.L) <= mysql.MaxTableNameLength {
-		return candidate, nil
+		return candidate.O, nil
 	}
 
 	for {
@@ -116,18 +116,18 @@ func GenerateMLogTableName(
 			"materialized view log short table name number is out of range",
 		)
 		if err != nil {
-			return pmodel.CIStr{}, err
+			return "", err
 		}
 		candidate = pmodel.NewCIStr(materializedViewLogTablePrefix + strconv.FormatUint(number, 10))
 		if utf8.RuneCountInString(candidate.L) > mysql.MaxTableNameLength {
-			return pmodel.CIStr{}, dbterror.ErrTooLongIdent.GenWithStackByArgs(candidate)
+			return "", dbterror.ErrTooLongIdent.GenWithStackByArgs(candidate)
 		}
 		exists, err := checkTableExistence(candidate)
 		if err != nil {
-			return pmodel.CIStr{}, err
+			return "", err
 		}
 		if !exists {
-			return candidate, nil
+			return candidate.O, nil
 		}
 	}
 }

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/format"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/parser/terror"
 	mvmerge "github.com/pingcap/tidb/pkg/planner/mview"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
@@ -65,7 +66,23 @@ var (
 	// MLogShortTableNameSeq allocates numeric components for shortened mlog names
 	// used when the derived name exceeds TiDB's table-name length limit.
 	MLogShortTableNameSeq atomic.Uint64
+	// ErrMLogAlreadyExists is returned when the base table already has an mlog.
+	ErrMLogAlreadyExists = dbterror.ClassSchema.NewStdErr(
+		mysql.ErrTableExists,
+		mysql.Message("materialized view log for base table '%-.192s' already exists", nil),
+	)
+	// ErrMLogTableNameConflict is returned when a generated mlog table name is
+	// occupied by a concurrent DDL. It is an internal retry signal for executor.
+	ErrMLogTableNameConflict = dbterror.ClassDDL.NewStdErr(
+		mysql.ErrTableExists,
+		mysql.Message("generated materialized view log table name '%-.192s' already exists", nil),
+	)
 )
+
+// IsMLogTableNameConflict reports whether err is a generated mlog table-name conflict.
+func IsMLogTableNameConflict(err error) bool {
+	return terror.ErrorEqual(err, ErrMLogTableNameConflict)
+}
 
 // GenerateMLogTableName generates an available mlog table name for the base table.
 func GenerateMLogTableName(

--- a/pkg/ddl/schematracker/BUILD.bazel
+++ b/pkg/ddl/schematracker/BUILD.bazel
@@ -49,7 +49,7 @@ go_test(
     ],
     embed = [":schematracker"],
     flaky = True,
-    shard_count = 17,
+    shard_count = 18,
     deps = [
         "//pkg/executor",
         "//pkg/infoschema",

--- a/pkg/ddl/schematracker/checker.go
+++ b/pkg/ddl/schematracker/checker.go
@@ -278,12 +278,25 @@ func (d *Checker) CreateView(ctx sessionctx.Context, stmt *ast.CreateViewStmt) e
 
 // CreateMaterializedViewLog implements the DDL interface.
 func (d *Checker) CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.CreateMaterializedViewLogStmt) error {
+	mlogSeqBefore := ddl.MLogTableNameSeq.Load()
+	shortSeqBefore := ddl.MLogShortTableNameSeq.Load()
 	err := d.realExecutor.CreateMaterializedViewLog(ctx, stmt)
 	if err != nil || d.closed.Load() {
 		return err
 	}
+	mlogSeqAfter := ddl.MLogTableNameSeq.Load()
+	shortSeqAfter := ddl.MLogShortTableNameSeq.Load()
 
-	err = d.tracker.CreateMaterializedViewLog(ctx, stmt)
+	// Replay the same DDL from the pre-real sequence so SchemaTracker derives the same mlog name.
+	ddl.MLogTableNameSeq.Store(mlogSeqBefore)
+	ddl.MLogShortTableNameSeq.Store(shortSeqBefore)
+	func() {
+		defer func() {
+			ddl.MLogTableNameSeq.Store(mlogSeqAfter)
+			ddl.MLogShortTableNameSeq.Store(shortSeqAfter)
+		}()
+		err = d.tracker.CreateMaterializedViewLog(ctx, stmt)
+	}()
 	if err != nil {
 		panic(err)
 	}
@@ -292,7 +305,12 @@ func (d *Checker) CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.Cr
 	if schemaName.O == "" {
 		schemaName = pmodel.NewCIStr(ctx.GetSessionVars().CurrentDB)
 	}
-	d.checkTableInfo(ctx, schemaName, pmodel.NewCIStr("$mlog$"+stmt.Table.Name.O))
+	baseTable, _ := d.infoCache.GetLatest().TableByName(context.Background(), schemaName, stmt.Table.Name)
+	if baseTable != nil && baseTable.Meta().MaterializedViewBase != nil {
+		if mlogTable, ok := d.infoCache.GetLatest().TableByID(context.Background(), baseTable.Meta().MaterializedViewBase.MLogID); ok {
+			d.checkTableInfo(ctx, schemaName, mlogTable.Meta().Name)
+		}
+	}
 	d.checkTableInfo(ctx, schemaName, stmt.Table.Name)
 	return nil
 }

--- a/pkg/ddl/schematracker/checker.go
+++ b/pkg/ddl/schematracker/checker.go
@@ -277,26 +277,13 @@ func (d *Checker) CreateView(ctx sessionctx.Context, stmt *ast.CreateViewStmt) e
 }
 
 // CreateMaterializedViewLog implements the DDL interface.
-func (d *Checker) CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.CreateMaterializedViewLogStmt) error {
-	mlogSeqBefore := ddl.MLogTableNameSeq.Load()
-	shortSeqBefore := ddl.MLogShortTableNameSeq.Load()
-	err := d.realExecutor.CreateMaterializedViewLog(ctx, stmt)
+func (d *Checker) CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.CreateMaterializedViewLogStmt, _ string) (string, error) {
+	mlogTableName, err := d.realExecutor.CreateMaterializedViewLog(ctx, stmt, "")
 	if err != nil || d.closed.Load() {
-		return err
+		return mlogTableName, err
 	}
-	mlogSeqAfter := ddl.MLogTableNameSeq.Load()
-	shortSeqAfter := ddl.MLogShortTableNameSeq.Load()
 
-	// Replay the same DDL from the pre-real sequence so SchemaTracker derives the same mlog name.
-	ddl.MLogTableNameSeq.Store(mlogSeqBefore)
-	ddl.MLogShortTableNameSeq.Store(shortSeqBefore)
-	func() {
-		defer func() {
-			ddl.MLogTableNameSeq.Store(mlogSeqAfter)
-			ddl.MLogShortTableNameSeq.Store(shortSeqAfter)
-		}()
-		err = d.tracker.CreateMaterializedViewLog(ctx, stmt)
-	}()
+	_, err = d.tracker.CreateMaterializedViewLog(ctx, stmt, mlogTableName)
 	if err != nil {
 		panic(err)
 	}
@@ -305,14 +292,9 @@ func (d *Checker) CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.Cr
 	if schemaName.O == "" {
 		schemaName = pmodel.NewCIStr(ctx.GetSessionVars().CurrentDB)
 	}
-	baseTable, _ := d.infoCache.GetLatest().TableByName(context.Background(), schemaName, stmt.Table.Name)
-	if baseTable != nil && baseTable.Meta().MaterializedViewBase != nil {
-		if mlogTable, ok := d.infoCache.GetLatest().TableByID(context.Background(), baseTable.Meta().MaterializedViewBase.MLogID); ok {
-			d.checkTableInfo(ctx, schemaName, mlogTable.Meta().Name)
-		}
-	}
+	d.checkTableInfo(ctx, schemaName, pmodel.NewCIStr(mlogTableName))
 	d.checkTableInfo(ctx, schemaName, stmt.Table.Name)
-	return nil
+	return mlogTableName, nil
 }
 
 // CreateMaterializedView implements the DDL interface.

--- a/pkg/ddl/schematracker/checker.go
+++ b/pkg/ddl/schematracker/checker.go
@@ -276,14 +276,19 @@ func (d *Checker) CreateView(ctx sessionctx.Context, stmt *ast.CreateViewStmt) e
 	return nil
 }
 
+// GenerateMLogTableName implements the DDL interface.
+func (d *Checker) GenerateMLogTableName(ctx sessionctx.Context, s *ast.CreateMaterializedViewLogStmt) (string, error) {
+	return d.realExecutor.GenerateMLogTableName(ctx, s)
+}
+
 // CreateMaterializedViewLog implements the DDL interface.
-func (d *Checker) CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.CreateMaterializedViewLogStmt, _ string) (string, error) {
-	mlogTableName, err := d.realExecutor.CreateMaterializedViewLog(ctx, stmt, "")
+func (d *Checker) CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.CreateMaterializedViewLogStmt, mlogTableName string) error {
+	err := d.realExecutor.CreateMaterializedViewLog(ctx, stmt, mlogTableName)
 	if err != nil || d.closed.Load() {
-		return mlogTableName, err
+		return err
 	}
 
-	_, err = d.tracker.CreateMaterializedViewLog(ctx, stmt, mlogTableName)
+	err = d.tracker.CreateMaterializedViewLog(ctx, stmt, mlogTableName)
 	if err != nil {
 		panic(err)
 	}
@@ -294,7 +299,7 @@ func (d *Checker) CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.Cr
 	}
 	d.checkTableInfo(ctx, schemaName, pmodel.NewCIStr(mlogTableName))
 	d.checkTableInfo(ctx, schemaName, stmt.Table.Name)
-	return mlogTableName, nil
+	return nil
 }
 
 // CreateMaterializedView implements the DDL interface.

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -232,43 +232,43 @@ func (d *SchemaTracker) CreateTable(ctx sessionctx.Context, s *ast.CreateTableSt
 }
 
 // CreateMaterializedViewLog implements the DDL interface.
-func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.CreateMaterializedViewLogStmt) error {
+func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.CreateMaterializedViewLogStmt, mlogTableName string) (string, error) {
 	schemaName := s.Table.Schema
 	if schemaName.O == "" {
 		if ctx == nil || ctx.GetSessionVars().CurrentDB == "" {
-			return errors.Trace(plannererrors.ErrNoDB)
+			return "", errors.Trace(plannererrors.ErrNoDB)
 		}
 		schemaName = pmodel.NewCIStr(ctx.GetSessionVars().CurrentDB)
 	}
 	schema := d.SchemaByName(schemaName)
 	if schema == nil {
-		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
+		return "", infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
+	}
+
+	mlogNameCIStr := pmodel.NewCIStr(mlogTableName)
+	mlogExists, err := ddl.GetExistenceOfMLogTableNameChecker(
+		context.Background(),
+		InfoStoreAdaptor{inner: d.InfoStore},
+		schemaName,
+	)(mlogNameCIStr)
+
+	if err != nil {
+		return "", err
+	}
+
+	if mlogExists {
+		return "", infoschema.ErrTableExists.GenWithStackByArgs(ast.Ident{Schema: schemaName, Name: mlogNameCIStr})
 	}
 
 	baseTable, err := d.TableClonedByName(schemaName, s.Table.Name)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if baseTable.IsView() || baseTable.IsSequence() || baseTable.TempTableType != model.TempTableNone {
-		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
+		return "", dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
 	if baseTable.MaterializedViewBase != nil && baseTable.MaterializedViewBase.MLogID != 0 {
-		return infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Name.O))
-	}
-
-	mlogNameCIStr, err := ddl.GenerateMLogTableName(
-		baseTable.Name,
-		func(tableName pmodel.CIStr) (bool, error) {
-			if _, err := d.TableByName(context.Background(), schemaName, tableName); err == nil {
-				return true, nil
-			} else if !infoschema.ErrTableNotExists.Equal(err) {
-				return false, err
-			}
-			return false, nil
-		},
-	)
-	if err != nil {
-		return err
+		return "", infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Name.O))
 	}
 
 	colMap := make(map[string]*model.ColumnInfo, len(baseTable.Columns))
@@ -280,16 +280,16 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	colDefs := make([]*ast.ColumnDef, 0, len(s.Cols)+2)
 	for _, c := range s.Cols {
 		if _, exists := seenCols[c.L]; exists {
-			return infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
+			return "", infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
 		}
 		seenCols[c.L] = struct{}{}
 		if c.L == strings.ToLower(model.MaterializedViewLogDMLTypeColumnName) ||
 			c.L == strings.ToLower(model.MaterializedViewLogOldNewColumnName) {
-			return infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
+			return "", infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
 		}
 		baseCol := colMap[c.L]
 		if baseCol == nil {
-			return infoschema.ErrColumnNotExists.GenWithStackByArgs(c.O, s.Table.Name.O)
+			return "", infoschema.ErrColumnNotExists.GenWithStackByArgs(c.O, s.Table.Name.O)
 		}
 		ft := baseCol.FieldType
 		ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
@@ -332,7 +332,7 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	)
 	mlogTableInfo, err := ddl.BuildTableInfoWithStmt(metaBuildCtx, createTableStmt, schema.Charset, schema.Collate, nil)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	var purgeMethod string
@@ -340,21 +340,21 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	var purgeNext string
 	if s.Purge != nil {
 		if s.Purge.Immediate {
-			return errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
+			return "", errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
 		}
 		purgeMethod = "DEFERRED"
 		if s.Purge.StartWith != nil {
 			purgeStartWith, err = ddl.BuildAndValidateMViewScheduleExpr(ctx, s.Purge.StartWith, "PURGE START WITH")
 			if err != nil {
-				return err
+				return "", err
 			}
 		}
 		if s.Purge.Next == nil {
-			return errors.New("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
+			return "", errors.New("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
 		}
 		purgeNext, err = ddl.BuildAndValidateMViewScheduleExpr(ctx, s.Purge.Next, "PURGE NEXT")
 		if err != nil {
-			return err
+			return "", err
 		}
 	}
 
@@ -367,7 +367,7 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 		DefinitionSQLMode: ctx.GetSessionVars().SQLMode,
 	}
 	if err := d.CreateTableWithInfo(ctx, schemaName, mlogTableInfo, nil); err != nil {
-		return err
+		return "", err
 	}
 
 	if baseTable.MaterializedViewBase == nil {
@@ -379,7 +379,7 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 		// SchemaTracker doesn't allocate physical table IDs, use a non-zero sentinel.
 		baseTable.MaterializedViewBase.MLogID = 1
 	}
-	return d.PutTable(schemaName, baseTable)
+	return mlogNameCIStr.O, d.PutTable(schemaName, baseTable)
 }
 
 // CreateMaterializedView implements the DDL interface.

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -20,8 +20,8 @@ package schematracker
 
 import (
 	"context"
+	"fmt"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl"
@@ -252,15 +252,22 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	if baseTable.IsView() || baseTable.IsSequence() || baseTable.TempTableType != model.TempTableNone {
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
-
-	mlogName := "$mlog$" + baseTable.Name.O
-	mlogNameCIStr := pmodel.NewCIStr(mlogName)
-	if utf8.RuneCountInString(mlogNameCIStr.L) > mysql.MaxTableNameLength {
-		return dbterror.ErrTooLongIdent.GenWithStackByArgs(mlogNameCIStr)
+	if baseTable.MaterializedViewBase != nil && baseTable.MaterializedViewBase.MLogID != 0 {
+		return infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Name.O))
 	}
-	if _, err := d.TableByName(context.Background(), schemaName, mlogNameCIStr); err == nil {
-		return infoschema.ErrTableExists.GenWithStackByArgs(ast.Ident{Schema: schemaName, Name: mlogNameCIStr})
-	} else if !infoschema.ErrTableNotExists.Equal(err) {
+
+	mlogNameCIStr, err := ddl.BuildMaterializedViewLogTableName(
+		baseTable.Name,
+		func(tableName pmodel.CIStr) (bool, error) {
+			if _, err := d.TableByName(context.Background(), schemaName, tableName); err == nil {
+				return true, nil
+			} else if !infoschema.ErrTableNotExists.Equal(err) {
+				return false, err
+			}
+			return false, nil
+		},
+	)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -256,7 +256,7 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 		return infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Name.O))
 	}
 
-	mlogNameCIStr, err := ddl.BuildMaterializedViewLogTableName(
+	mlogNameCIStr, err := ddl.GenerateMLogTableName(
 		baseTable.Name,
 		func(tableName pmodel.CIStr) (bool, error) {
 			if _, err := d.TableByName(context.Background(), schemaName, tableName); err == nil {

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -231,18 +231,23 @@ func (d *SchemaTracker) CreateTable(ctx sessionctx.Context, s *ast.CreateTableSt
 	return d.CreateTableWithInfo(ctx, schema.Name, tbInfo, nil, ddl.WithOnExist(onExist))
 }
 
+// GenerateMLogTableName implements the DDL interface.
+func (*SchemaTracker) GenerateMLogTableName(sessionctx.Context, *ast.CreateMaterializedViewLogStmt) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 // CreateMaterializedViewLog implements the DDL interface.
-func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.CreateMaterializedViewLogStmt, mlogTableName string) (string, error) {
+func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.CreateMaterializedViewLogStmt, mlogTableName string) error {
 	schemaName := s.Table.Schema
 	if schemaName.O == "" {
 		if ctx == nil || ctx.GetSessionVars().CurrentDB == "" {
-			return "", errors.Trace(plannererrors.ErrNoDB)
+			return errors.Trace(plannererrors.ErrNoDB)
 		}
 		schemaName = pmodel.NewCIStr(ctx.GetSessionVars().CurrentDB)
 	}
 	schema := d.SchemaByName(schemaName)
 	if schema == nil {
-		return "", infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
+		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
 	}
 
 	mlogNameCIStr := pmodel.NewCIStr(mlogTableName)
@@ -253,22 +258,22 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	)(mlogNameCIStr)
 
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	if mlogExists {
-		return "", infoschema.ErrTableExists.GenWithStackByArgs(ast.Ident{Schema: schemaName, Name: mlogNameCIStr})
+		return infoschema.ErrTableExists.GenWithStackByArgs(ast.Ident{Schema: schemaName, Name: mlogNameCIStr})
 	}
 
 	baseTable, err := d.TableClonedByName(schemaName, s.Table.Name)
 	if err != nil {
-		return "", err
+		return err
 	}
 	if baseTable.IsView() || baseTable.IsSequence() || baseTable.TempTableType != model.TempTableNone {
-		return "", dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
+		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
 	if baseTable.MaterializedViewBase != nil && baseTable.MaterializedViewBase.MLogID != 0 {
-		return "", infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Name.O))
+		return infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Name.O))
 	}
 
 	colMap := make(map[string]*model.ColumnInfo, len(baseTable.Columns))
@@ -280,16 +285,16 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	colDefs := make([]*ast.ColumnDef, 0, len(s.Cols)+2)
 	for _, c := range s.Cols {
 		if _, exists := seenCols[c.L]; exists {
-			return "", infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
+			return infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
 		}
 		seenCols[c.L] = struct{}{}
 		if c.L == strings.ToLower(model.MaterializedViewLogDMLTypeColumnName) ||
 			c.L == strings.ToLower(model.MaterializedViewLogOldNewColumnName) {
-			return "", infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
+			return infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
 		}
 		baseCol := colMap[c.L]
 		if baseCol == nil {
-			return "", infoschema.ErrColumnNotExists.GenWithStackByArgs(c.O, s.Table.Name.O)
+			return infoschema.ErrColumnNotExists.GenWithStackByArgs(c.O, s.Table.Name.O)
 		}
 		ft := baseCol.FieldType
 		ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
@@ -332,7 +337,7 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	)
 	mlogTableInfo, err := ddl.BuildTableInfoWithStmt(metaBuildCtx, createTableStmt, schema.Charset, schema.Collate, nil)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	var purgeMethod string
@@ -340,21 +345,21 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	var purgeNext string
 	if s.Purge != nil {
 		if s.Purge.Immediate {
-			return "", errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
+			return errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
 		}
 		purgeMethod = "DEFERRED"
 		if s.Purge.StartWith != nil {
 			purgeStartWith, err = ddl.BuildAndValidateMViewScheduleExpr(ctx, s.Purge.StartWith, "PURGE START WITH")
 			if err != nil {
-				return "", err
+				return err
 			}
 		}
 		if s.Purge.Next == nil {
-			return "", errors.New("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
+			return errors.New("PURGE NEXT is required for CREATE MATERIALIZED VIEW LOG")
 		}
 		purgeNext, err = ddl.BuildAndValidateMViewScheduleExpr(ctx, s.Purge.Next, "PURGE NEXT")
 		if err != nil {
-			return "", err
+			return err
 		}
 	}
 
@@ -367,7 +372,7 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 		DefinitionSQLMode: ctx.GetSessionVars().SQLMode,
 	}
 	if err := d.CreateTableWithInfo(ctx, schemaName, mlogTableInfo, nil); err != nil {
-		return "", err
+		return err
 	}
 
 	if baseTable.MaterializedViewBase == nil {
@@ -379,7 +384,7 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 		// SchemaTracker doesn't allocate physical table IDs, use a non-zero sentinel.
 		baseTable.MaterializedViewBase.MLogID = 1
 	}
-	return mlogNameCIStr.O, d.PutTable(schemaName, baseTable)
+	return d.PutTable(schemaName, baseTable)
 }
 
 // CreateMaterializedView implements the DDL interface.

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -20,7 +20,6 @@ package schematracker
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -273,7 +272,7 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
 	if baseTable.MaterializedViewBase != nil && baseTable.MaterializedViewBase.MLogID != 0 {
-		return infoschema.ErrTableExists.GenWithStackByArgs(fmt.Sprintf("mlog of %s.%s has been created before", schemaName, baseTable.Name.O))
+		return ddl.ErrMLogAlreadyExists.GenWithStackByArgs(ast.Ident{Schema: schemaName, Name: baseTable.Name})
 	}
 
 	colMap := make(map[string]*model.ColumnInfo, len(baseTable.Columns))

--- a/pkg/ddl/schematracker/dm_tracker_test.go
+++ b/pkg/ddl/schematracker/dm_tracker_test.go
@@ -570,9 +570,24 @@ func TestCreateMaterializedViewLogScheduleExprTypeCheck(t *testing.T) {
 		return stmt.(*ast.CreateMaterializedViewLogStmt)
 	}
 
-	err := tracker.CreateMaterializedViewLog(sctx, parseStmt("create materialized view log on test.t (a) purge start with 1 next date_add(now(), interval 1 hour)"))
+	_, err := tracker.CreateMaterializedViewLog(sctx, parseStmt("create materialized view log on test.t (a) purge start with 1 next date_add(now(), interval 1 hour)"), "test_mlog")
 	require.ErrorContains(t, err, "PURGE START WITH expression must return DATETIME/TIMESTAMP")
 
-	err = tracker.CreateMaterializedViewLog(sctx, parseStmt("create materialized view log on test.t (a) purge start with now() next 1"))
+	_, err = tracker.CreateMaterializedViewLog(sctx, parseStmt("create materialized view log on test.t (a) purge start with now() next 1"), "test_mlog")
 	require.ErrorContains(t, err, "PURGE NEXT expression must return DATETIME/TIMESTAMP")
+}
+
+func TestCreateMaterializedViewLogRejectExistingMLogName(t *testing.T) {
+	tracker := schematracker.NewSchemaTracker(2)
+	tracker.CreateTestDB(nil)
+	execCreate(t, tracker, "create table test.t (a int)")
+	execCreate(t, tracker, "create table test.test_mlog (a int)")
+
+	sctx := mock.NewContext()
+	p := parser.New()
+	stmt, err := p.ParseOneStmt("create materialized view log on test.t (a)", "", "")
+	require.NoError(t, err)
+
+	_, err = tracker.CreateMaterializedViewLog(sctx, stmt.(*ast.CreateMaterializedViewLogStmt), "test_mlog")
+	require.True(t, infoschema.ErrTableExists.Equal(err), err)
 }

--- a/pkg/ddl/schematracker/dm_tracker_test.go
+++ b/pkg/ddl/schematracker/dm_tracker_test.go
@@ -570,10 +570,10 @@ func TestCreateMaterializedViewLogScheduleExprTypeCheck(t *testing.T) {
 		return stmt.(*ast.CreateMaterializedViewLogStmt)
 	}
 
-	_, err := tracker.CreateMaterializedViewLog(sctx, parseStmt("create materialized view log on test.t (a) purge start with 1 next date_add(now(), interval 1 hour)"), "test_mlog")
+	err := tracker.CreateMaterializedViewLog(sctx, parseStmt("create materialized view log on test.t (a) purge start with 1 next date_add(now(), interval 1 hour)"), "test_mlog")
 	require.ErrorContains(t, err, "PURGE START WITH expression must return DATETIME/TIMESTAMP")
 
-	_, err = tracker.CreateMaterializedViewLog(sctx, parseStmt("create materialized view log on test.t (a) purge start with now() next 1"), "test_mlog")
+	err = tracker.CreateMaterializedViewLog(sctx, parseStmt("create materialized view log on test.t (a) purge start with now() next 1"), "test_mlog")
 	require.ErrorContains(t, err, "PURGE NEXT expression must return DATETIME/TIMESTAMP")
 }
 
@@ -588,6 +588,6 @@ func TestCreateMaterializedViewLogRejectExistingMLogName(t *testing.T) {
 	stmt, err := p.ParseOneStmt("create materialized view log on test.t (a)", "", "")
 	require.NoError(t, err)
 
-	_, err = tracker.CreateMaterializedViewLog(sctx, stmt.(*ast.CreateMaterializedViewLogStmt), "test_mlog")
+	err = tracker.CreateMaterializedViewLog(sctx, stmt.(*ast.CreateMaterializedViewLogStmt), "test_mlog")
 	require.True(t, infoschema.ErrTableExists.Equal(err), err)
 }

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -333,6 +333,7 @@ go_test(
         "cluster_table_test.go",
         "compact_table_test.go",
         "copr_cache_test.go",
+        "ddl_test.go",
         "delete_test.go",
         "detach_integration_test.go",
         "detach_test.go",

--- a/pkg/executor/ddl.go
+++ b/pkg/executor/ddl.go
@@ -166,7 +166,7 @@ func (e *DDLExec) Next(ctx context.Context, _ *chunk.Chunk) (err error) {
 	case *ast.CreateMaterializedViewStmt:
 		err = e.ddlExecutor.CreateMaterializedView(e.Ctx(), x)
 	case *ast.CreateMaterializedViewLogStmt:
-		err = e.ddlExecutor.CreateMaterializedViewLog(e.Ctx(), x)
+		_, err = e.ddlExecutor.CreateMaterializedViewLog(e.Ctx(), x, "")
 	case *ast.AlterMaterializedViewStmt:
 		err = e.ddlExecutor.AlterMaterializedView(e.Ctx(), x)
 	case *ast.AlterMaterializedViewLogStmt:

--- a/pkg/executor/ddl.go
+++ b/pkg/executor/ddl.go
@@ -166,7 +166,7 @@ func (e *DDLExec) Next(ctx context.Context, _ *chunk.Chunk) (err error) {
 	case *ast.CreateMaterializedViewStmt:
 		err = e.ddlExecutor.CreateMaterializedView(e.Ctx(), x)
 	case *ast.CreateMaterializedViewLogStmt:
-		_, err = e.ddlExecutor.CreateMaterializedViewLog(e.Ctx(), x, "")
+		err = e.executeCreateMaterializedViewLog(x)
 	case *ast.AlterMaterializedViewStmt:
 		err = e.ddlExecutor.AlterMaterializedView(e.Ctx(), x)
 	case *ast.AlterMaterializedViewLogStmt:
@@ -328,6 +328,24 @@ func (e *DDLExec) executeCreateView(ctx context.Context, s *ast.CreateViewStmt) 
 
 	e.Ctx().GetSessionVars().ClearRelatedTableForMDL()
 	return e.ddlExecutor.CreateView(e.Ctx(), s)
+}
+
+func (e *DDLExec) executeCreateMaterializedViewLog(stmt *ast.CreateMaterializedViewLogStmt) error {
+	for {
+		mlogTableName, err := e.ddlExecutor.GenerateMLogTableName(e.Ctx(), stmt)
+		if err != nil {
+			return err
+		}
+
+		err = e.ddlExecutor.CreateMaterializedViewLog(e.Ctx(), stmt, mlogTableName)
+		if err != nil {
+			if infoschema.ErrTableExists.Equal(err) {
+				continue
+			}
+			return err
+		}
+		return nil
+	}
 }
 
 func (e *DDLExec) executeCreateIndex(s *ast.CreateIndexStmt) error {

--- a/pkg/executor/ddl.go
+++ b/pkg/executor/ddl.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
@@ -57,6 +59,31 @@ type DDLExec struct {
 	is           infoschema.InfoSchema
 	tempTableDDL temptable.TemporaryTableDDL
 	done         bool
+}
+
+const (
+	maxCreateMLogNameConflictRetries = 8
+	createMLogNameConflictBackoff    = time.Millisecond
+	maxCreateMLogNameConflictBackoff = 32 * time.Millisecond
+)
+
+var waitCreateMLogNameConflictRetry = func(ctx context.Context, retry int) error {
+	delay := createMLogNameConflictBackoff
+	for i := 0; i < retry && delay < maxCreateMLogNameConflictBackoff; i++ {
+		delay *= 2
+		if delay > maxCreateMLogNameConflictBackoff {
+			delay = maxCreateMLogNameConflictBackoff
+		}
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // toErr converts the error to the ErrInfoSchemaChanged when the schema is outdated.
@@ -166,7 +193,7 @@ func (e *DDLExec) Next(ctx context.Context, _ *chunk.Chunk) (err error) {
 	case *ast.CreateMaterializedViewStmt:
 		err = e.ddlExecutor.CreateMaterializedView(e.Ctx(), x)
 	case *ast.CreateMaterializedViewLogStmt:
-		err = e.executeCreateMaterializedViewLog(x)
+		err = e.executeCreateMaterializedViewLog(ctx, x)
 	case *ast.AlterMaterializedViewStmt:
 		err = e.ddlExecutor.AlterMaterializedView(e.Ctx(), x)
 	case *ast.AlterMaterializedViewLogStmt:
@@ -330,16 +357,25 @@ func (e *DDLExec) executeCreateView(ctx context.Context, s *ast.CreateViewStmt) 
 	return e.ddlExecutor.CreateView(e.Ctx(), s)
 }
 
-func (e *DDLExec) executeCreateMaterializedViewLog(stmt *ast.CreateMaterializedViewLogStmt) error {
+func (e *DDLExec) executeCreateMaterializedViewLog(ctx context.Context, stmt *ast.CreateMaterializedViewLogStmt) error {
+	retries := 0
 	for {
 		mlogTableName, err := e.ddlExecutor.GenerateMLogTableName(e.Ctx(), stmt)
 		if err != nil {
 			return err
 		}
 
+		failpoint.InjectCall("afterCreateMaterializedViewLogNameGenerated", mlogTableName)
 		err = e.ddlExecutor.CreateMaterializedViewLog(e.Ctx(), stmt, mlogTableName)
 		if err != nil {
-			if infoschema.ErrTableExists.Equal(err) {
+			if ddl.IsMLogTableNameConflict(err) {
+				if retries >= maxCreateMLogNameConflictRetries {
+					return err
+				}
+				if backoffErr := waitCreateMLogNameConflictRetry(ctx, retries); backoffErr != nil {
+					return backoffErr
+				}
+				retries++
 				continue
 			}
 			return err

--- a/pkg/executor/ddl_test.go
+++ b/pkg/executor/ddl_test.go
@@ -15,6 +15,7 @@
 package executor
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -57,7 +58,29 @@ func (m *mockMLogDDLExecutor) CreateMaterializedViewLog(_ sessionctx.Context, _ 
 
 func TestDDLExecExecuteCreateMaterializedViewLog(t *testing.T) {
 	tableExistsErr := infoschema.ErrTableExists.GenWithStackByArgs("mlog")
+	mlogAlreadyExistsErr := ddl.ErrMLogAlreadyExists.GenWithStackByArgs("test.t")
+	tableNameConflictErr := ddl.ErrMLogTableNameConflict.GenWithStackByArgs("mlog")
 	otherErr := errors.New("non table exists error")
+	oldBackoff := waitCreateMLogNameConflictRetry
+	waitCreateMLogNameConflictRetry = func(context.Context, int) error { return nil }
+	defer func() {
+		waitCreateMLogNameConflictRetry = oldBackoff
+	}()
+
+	repeatNames := func(name string, n int) []string {
+		names := make([]string, n)
+		for i := range names {
+			names[i] = name
+		}
+		return names
+	}
+	repeatErrs := func(err error, n int) []error {
+		errs := make([]error, n)
+		for i := range errs {
+			errs[i] = err
+		}
+		return errs
+	}
 
 	tests := []struct {
 		name           string
@@ -67,10 +90,31 @@ func TestDDLExecExecuteCreateMaterializedViewLog(t *testing.T) {
 		expectedErr    error
 	}{
 		{
-			name:           "retry on table exists",
+			name:           "return ordinary table exists error",
+			generatedNames: []string{"$mlog$t"},
+			createErrs:     []error{tableExistsErr},
+			expectedNames:  []string{"$mlog$t"},
+			expectedErr:    tableExistsErr,
+		},
+		{
+			name:           "return base mlog already exists error",
+			generatedNames: []string{"$mlog$t"},
+			createErrs:     []error{mlogAlreadyExistsErr},
+			expectedNames:  []string{"$mlog$t"},
+			expectedErr:    mlogAlreadyExistsErr,
+		},
+		{
+			name:           "retry on generated table name conflict",
 			generatedNames: []string{"$mlog$t", "$mlog$1"},
-			createErrs:     []error{tableExistsErr, nil},
+			createErrs:     []error{tableNameConflictErr, nil},
 			expectedNames:  []string{"$mlog$t", "$mlog$1"},
+		},
+		{
+			name:           "return generated table name conflict after retry limit",
+			generatedNames: repeatNames("$mlog$t", maxCreateMLogNameConflictRetries+1),
+			createErrs:     repeatErrs(tableNameConflictErr, maxCreateMLogNameConflictRetries+1),
+			expectedNames:  repeatNames("$mlog$t", maxCreateMLogNameConflictRetries+1),
+			expectedErr:    tableNameConflictErr,
 		},
 		{
 			name:           "return non table exists error",
@@ -98,7 +142,7 @@ func TestDDLExecExecuteCreateMaterializedViewLog(t *testing.T) {
 				ddlExecutor:  ddlExecutor,
 			}
 
-			err := exec.executeCreateMaterializedViewLog(&ast.CreateMaterializedViewLogStmt{})
+			err := exec.executeCreateMaterializedViewLog(context.Background(), &ast.CreateMaterializedViewLogStmt{})
 			if tt.expectedErr != nil {
 				require.ErrorIs(t, err, tt.expectedErr)
 			} else {

--- a/pkg/executor/ddl_test.go
+++ b/pkg/executor/ddl_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/ddl"
+	execpkg "github.com/pingcap/tidb/pkg/executor/internal/exec"
+	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/util/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockMLogDDLExecutor struct {
+	ddl.Executor
+
+	generatedNames []string
+	createErrs     []error
+
+	generateCalls int
+	createNames   []string
+}
+
+func (m *mockMLogDDLExecutor) GenerateMLogTableName(sessionctx.Context, *ast.CreateMaterializedViewLogStmt) (string, error) {
+	if m.generateCalls >= len(m.generatedNames) {
+		return "", errors.New("unexpected GenerateMLogTableName call")
+	}
+	name := m.generatedNames[m.generateCalls]
+	m.generateCalls++
+	return name, nil
+}
+
+func (m *mockMLogDDLExecutor) CreateMaterializedViewLog(_ sessionctx.Context, _ *ast.CreateMaterializedViewLogStmt, mlogTableName string) error {
+	m.createNames = append(m.createNames, mlogTableName)
+	idx := len(m.createNames) - 1
+	if idx >= len(m.createErrs) {
+		return nil
+	}
+	return m.createErrs[idx]
+}
+
+func TestDDLExecExecuteCreateMaterializedViewLog(t *testing.T) {
+	tableExistsErr := infoschema.ErrTableExists.GenWithStackByArgs("mlog")
+	otherErr := errors.New("non table exists error")
+
+	tests := []struct {
+		name           string
+		generatedNames []string
+		createErrs     []error
+		expectedNames  []string
+		expectedErr    error
+	}{
+		{
+			name:           "retry on table exists",
+			generatedNames: []string{"$mlog$t", "$mlog$1"},
+			createErrs:     []error{tableExistsErr, nil},
+			expectedNames:  []string{"$mlog$t", "$mlog$1"},
+		},
+		{
+			name:           "return non table exists error",
+			generatedNames: []string{"$mlog$t"},
+			createErrs:     []error{otherErr},
+			expectedNames:  []string{"$mlog$t"},
+			expectedErr:    otherErr,
+		},
+		{
+			name:           "return nil on success",
+			generatedNames: []string{"$mlog$t"},
+			createErrs:     []error{nil},
+			expectedNames:  []string{"$mlog$t"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ddlExecutor := &mockMLogDDLExecutor{
+				generatedNames: tt.generatedNames,
+				createErrs:     tt.createErrs,
+			}
+			exec := &DDLExec{
+				BaseExecutor: execpkg.NewBaseExecutor(mock.NewContext(), nil, 0),
+				ddlExecutor:  ddlExecutor,
+			}
+
+			err := exec.executeCreateMaterializedViewLog(&ast.CreateMaterializedViewLogStmt{})
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.expectedNames, ddlExecutor.createNames)
+			require.Equal(t, len(tt.expectedNames), ddlExecutor.generateCalls)
+		})
+	}
+}

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1952,29 +1952,12 @@ func (e *PurgeMaterializedViewLogExec) resolvePurgeMaterializedViewLogMeta(
 		return schemaName, nil, mlogName, 0, nil, dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
 	baseTableMeta = baseTable.Meta()
-	baseTableID := baseTableMeta.ID
 
-	mlogName = pmodel.NewCIStr("$mlog$" + baseTableMeta.Name.O)
-	mlogTable, err := is.TableByName(context.Background(), schemaName, mlogName)
+	mlogTable, err := ddl.ResolveMLogTableByBaseTable(context.Background(), is, schemaName, baseTableMeta)
 	if err != nil {
-		if infoschema.ErrTableNotExists.Equal(err) {
-			return schemaName, baseTableMeta, mlogName, 0, nil, errors.Errorf(
-				"materialized view log does not exist for base table %s.%s",
-				schemaName.O,
-				s.Table.Name.O,
-			)
-		}
 		return schemaName, baseTableMeta, mlogName, 0, nil, err
 	}
-	if mlogTable.Meta().MaterializedViewLog == nil || mlogTable.Meta().MaterializedViewLog.BaseTableID != baseTableID {
-		return schemaName, baseTableMeta, mlogName, 0, nil, errors.Errorf(
-			"table %s.%s is not a materialized view log for base table %s.%s",
-			schemaName.O,
-			mlogName.O,
-			schemaName.O,
-			s.Table.Name.O,
-		)
-	}
+	mlogName = mlogTable.Meta().Name
 	mlogID = mlogTable.Meta().ID
 	mlogInfo = mlogTable.Meta().MaterializedViewLog
 

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1953,7 +1953,7 @@ func (e *PurgeMaterializedViewLogExec) resolvePurgeMaterializedViewLogMeta(
 	}
 	baseTableMeta = baseTable.Meta()
 
-	mlogTable, err := ddl.ResolveMLogTableByBaseTable(context.Background(), is, schemaName, baseTableMeta)
+	mlogTable, err := ddl.GetMLogTableByBaseTable(context.Background(), is, schemaName, baseTableMeta)
 	if err != nil {
 		return schemaName, baseTableMeta, mlogName, 0, nil, err
 	}

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -71,6 +71,17 @@ func differentIsolationReadEnginesForTest(current string) string {
 	return "tikv"
 }
 
+func resetMLogNameSeqForTest(t *testing.T) {
+	oldMLogSeq := ddl.MLogTableNameSeq.Load()
+	oldShortSeq := ddl.MLogShortTableNameSeq.Load()
+	ddl.MLogTableNameSeq.Store(0)
+	ddl.MLogShortTableNameSeq.Store(0)
+	t.Cleanup(func() {
+		ddl.MLogTableNameSeq.Store(oldMLogSeq)
+		ddl.MLogShortTableNameSeq.Store(oldShortSeq)
+	})
+}
+
 func TestCreateMaterializedViewLogBasic(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
@@ -123,6 +134,26 @@ func TestCreateMaterializedViewLogBasic(t *testing.T) {
 
 	// Duplicated MV LOG should fail (same derived table name).
 	tk.MustGetErrMsg("create materialized view log on t (a)", "[schema:1050]Table 'test.$mlog$t' already exists")
+}
+
+func TestCreateMaterializedViewLogNameWithMLogPrefix(t *testing.T) {
+	resetMLogNameSeqForTest(t)
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table `$mlog$base_table_name` (a int, key idx_a(a))")
+	tk.MustExec("create table `$mlog$1base_table_name` (a int)")
+
+	tk.MustExec("create materialized view log on `$mlog$base_table_name` (a)")
+	tk.MustQuery("show tables like '$mlog$2base_table_name'").Check(testkit.Rows("$mlog$2base_table_name"))
+	tk.MustQuery("show create materialized view log on `$mlog$base_table_name`").
+		CheckContain("CREATE MATERIALIZED VIEW LOG ON `$mlog$base_table_name` (`a`)")
+
+	tk.MustExec("create materialized view mv_mlog_prefix (a, cnt) refresh fast as select a, count(1) from `$mlog$base_table_name` group by a")
+	tk.MustExec("alter materialized view log on `$mlog$base_table_name` purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("drop materialized view mv_mlog_prefix")
+	tk.MustExec("drop materialized view log on `$mlog$base_table_name`")
+	tk.MustQuery("show tables like '$mlog$2base_table_name'").Check(testkit.Rows())
 }
 
 func TestShowCreateMaterializedViewLog(t *testing.T) {
@@ -480,6 +511,7 @@ func TestCreateMaterializedViewLogRejectNonBaseObject(t *testing.T) {
 }
 
 func TestCreateMaterializedViewLogNameLengthByRune(t *testing.T) {
+	resetMLogNameSeqForTest(t)
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -490,8 +522,12 @@ func TestCreateMaterializedViewLogNameLengthByRune(t *testing.T) {
 	tk.MustQuery(fmt.Sprintf("select count(*) from information_schema.tables where table_schema='test' and table_name='%s'", "$mlog$"+maxName)).Check(testkit.Rows("1"))
 
 	tooLongName := strings.Repeat("表", 59)
+	tk.MustExec("create table `$mlog$1` (a int)")
 	tk.MustExec(fmt.Sprintf("create table `%s` (a int)", tooLongName))
-	tk.MustGetErrCode(fmt.Sprintf("create materialized view log on `%s` (a)", tooLongName), errno.ErrTooLongIdent)
+	tk.MustExec(fmt.Sprintf("create materialized view log on `%s` (a)", tooLongName))
+	tk.MustQuery("select count(*) from information_schema.tables where table_schema='test' and table_name='$mlog$2'").Check(testkit.Rows("1"))
+	tk.MustQuery(fmt.Sprintf("show create materialized view log on `%s`", tooLongName)).
+		CheckContain(fmt.Sprintf("CREATE MATERIALIZED VIEW LOG ON `%s` (`a`)", tooLongName))
 }
 
 func TestCreateMaterializedViewLogUpdatesPlacementBundle(t *testing.T) {

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -132,8 +132,50 @@ func TestCreateMaterializedViewLogBasic(t *testing.T) {
 	require.True(t, hasDMLType)
 	require.True(t, hasOldNew)
 
-	// Duplicated MV LOG should fail (same derived table name).
-	tk.MustGetErrMsg("create materialized view log on t (a)", "[schema:1050]Table 'mlog of test.t has been created before' already exists")
+	// Duplicated MV LOG should fail because the base table already has one.
+	tk.MustGetErrMsg("create materialized view log on t (a)", "[schema:1050]materialized view log for base table 'test.t' already exists")
+}
+
+func TestCreateMaterializedViewLogRetriesWhenGeneratedNameStolen(t *testing.T) {
+	resetMLogNameSeqForTest(t)
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	if ttlJobManager := dom.TTLJobManager(); ttlJobManager != nil {
+		ttlJobManager.Stop()
+		require.NoError(t, ttlJobManager.WaitStopped(context.Background(), 10*time.Second))
+	}
+	tk := testkit.NewTestKit(t, store)
+	thief := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	thief.MustExec("use test")
+	tk.MustExec("create table t_retry_mlog_name (a int)")
+
+	const stolenMLogName = "$mlog$t_retry_mlog_name"
+	var stolen atomic.Bool
+	failpointName := "github.com/pingcap/tidb/pkg/executor/afterCreateMaterializedViewLogNameGenerated"
+	require.NoError(t, failpoint.EnableCall(failpointName, func(mlogTableName string) {
+		if mlogTableName != stolenMLogName {
+			return
+		}
+		if stolen.CompareAndSwap(false, true) {
+			thief.MustExec(fmt.Sprintf("create table `%s` (a int)", mlogTableName))
+		}
+	}))
+	defer func() {
+		require.NoError(t, failpoint.Disable(failpointName))
+	}()
+
+	tk.MustExec("create materialized view log on t_retry_mlog_name (a)")
+	require.True(t, stolen.Load())
+	tk.MustQuery("show tables like '$mlog$t_retry_mlog_name'").Check(testkit.Rows("$mlog$t_retry_mlog_name"))
+	tk.MustQuery("show tables like '$mlog$1'").Check(testkit.Rows("$mlog$1"))
+
+	is := dom.InfoSchema()
+	baseTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t_retry_mlog_name"))
+	require.NoError(t, err)
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$1"))
+	require.NoError(t, err)
+	require.NotNil(t, baseTable.Meta().MaterializedViewBase)
+	require.Equal(t, mlogTable.Meta().ID, baseTable.Meta().MaterializedViewBase.MLogID)
 }
 
 func TestCreateMaterializedViewLogPrivilege(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68840 #66768

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Handle mlog name confliction for materialized view
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved materialized view log creation: deterministic name generation (handles base names with $mlog$), retries on name conflicts, enforces table-name length limits, and returns clearer errors when a log already exists or name allocation fails.

* **Tests**
  * Added and updated tests covering name generation, conflict retries, length-edge cases, and creation failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->