### PR TITLE
ddl: fail stale backfill task meta

### DIFF
--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -37,8 +37,7 @@ import (
 var errBackfillTaskMetaOutdated = errors.New("backfill task meta is outdated")
 
 func isBackfillTaskMetaOutdatedErr(err error) bool {
-	return errors.Cause(err) == errBackfillTaskMetaOutdated ||
-		strings.Contains(err.Error(), errBackfillTaskMetaOutdated.Error())
+	return errors.Cause(err) == errBackfillTaskMetaOutdated
 }
 
 // Version constants for BackfillTaskMeta.

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -17,7 +17,6 @@ package ddl
 import (
 	"context"
 	"encoding/json"
-	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/logutil"

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -171,7 +171,7 @@ func (s *backfillDistExecutor) newBackfillStepExecutor(
 				zap.Int64("table ID", tbl.Meta().ID),
 				zap.Int64("index ID", eid))
 			return nil, errors.Annotatef(errIndexInfoNotFound,
-				"index info not found: %d, table ID: %d, job ID: %d",
+				"eid: %d, table ID: %d, job ID: %d",
 				eid, tbl.Meta().ID, jobMeta.ID)
 		}
 		indexInfos = append(indexInfos, indexInfo)

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -33,10 +33,10 @@ import (
 	"go.uber.org/zap"
 )
 
-var errBackfillTaskMetaOutdated = errors.New("backfill task meta is outdated")
+var errIndexInfoNotFound = errors.New("index info not found")
 
-func isBackfillTaskMetaOutdatedErr(err error) bool {
-	return errors.Cause(err) == errBackfillTaskMetaOutdated
+func isIndexInfoNotFoundErr(err error) bool {
+	return errors.Cause(err) == errIndexInfoNotFound
 }
 
 // Version constants for BackfillTaskMeta.
@@ -170,7 +170,7 @@ func (s *backfillDistExecutor) newBackfillStepExecutor(
 			logutil.DDLIngestLogger().Warn("index info not found",
 				zap.Int64("table ID", tbl.Meta().ID),
 				zap.Int64("index ID", eid))
-			return nil, errors.Annotatef(errBackfillTaskMetaOutdated,
+			return nil, errors.Annotatef(errIndexInfoNotFound,
 				"index info not found: %d, table ID: %d, job ID: %d",
 				eid, tbl.Meta().ID, jobMeta.ID)
 		}
@@ -254,7 +254,7 @@ func (*backfillDistExecutor) IsIdempotent(*proto.Subtask) bool {
 }
 
 func (*backfillDistExecutor) IsRetryableError(err error) bool {
-	if isBackfillTaskMetaOutdatedErr(err) {
+	if isIndexInfoNotFoundErr(err) {
 		return false
 	}
 	return common.IsRetryableError(err) || isRetryableError(err, true)

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -17,6 +17,7 @@ package ddl
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/logutil"
@@ -32,6 +33,13 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	"go.uber.org/zap"
 )
+
+var errBackfillTaskMetaOutdated = errors.New("backfill task meta is outdated")
+
+func isBackfillTaskMetaOutdatedErr(err error) bool {
+	return errors.Cause(err) == errBackfillTaskMetaOutdated ||
+		strings.Contains(err.Error(), errBackfillTaskMetaOutdated.Error())
+}
 
 // Version constants for BackfillTaskMeta.
 const (
@@ -164,7 +172,9 @@ func (s *backfillDistExecutor) newBackfillStepExecutor(
 			logutil.DDLIngestLogger().Warn("index info not found",
 				zap.Int64("table ID", tbl.Meta().ID),
 				zap.Int64("index ID", eid))
-			return nil, errors.Errorf("index info not found: %d", eid)
+			return nil, errors.Annotatef(errBackfillTaskMetaOutdated,
+				"index info not found: %d, table ID: %d, job ID: %d",
+				eid, tbl.Meta().ID, jobMeta.ID)
 		}
 		indexInfos = append(indexInfos, indexInfo)
 	}
@@ -246,6 +256,9 @@ func (*backfillDistExecutor) IsIdempotent(*proto.Subtask) bool {
 }
 
 func (*backfillDistExecutor) IsRetryableError(err error) bool {
+	if isBackfillTaskMetaOutdatedErr(err) {
+		return false
+	}
 	return common.IsRetryableError(err) || isRetryableError(err, true)
 }
 

--- a/pkg/ddl/backfilling_test.go
+++ b/pkg/ddl/backfilling_test.go
@@ -65,9 +65,9 @@ func TestDoneTaskKeeper(t *testing.T) {
 	require.True(t, bytes.Equal(n.nextKey, kv.Key("h")))
 }
 
-func TestOutdatedBackfillTaskMetaIsNonRetryable(t *testing.T) {
-	err := errors.Annotatef(errBackfillTaskMetaOutdated, "index info not found: %d", 1)
-	require.False(t, isRetryableError(err, true))
+func TestIndexInfoNotFoundIsNonRetryable(t *testing.T) {
+	err := errors.Annotatef(errIndexInfoNotFound, "index info not found: %d", 1)
+	require.True(t, isIndexInfoNotFoundErr(err))
 	require.False(t, (&backfillDistExecutor{}).IsRetryableError(err))
 }
 

--- a/pkg/ddl/backfilling_test.go
+++ b/pkg/ddl/backfilling_test.go
@@ -17,16 +17,20 @@ package ddl
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"math"
 	"testing"
 	"time"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/copr"
 	"github.com/pingcap/tidb/pkg/ddl/ingest"
 	distsqlctx "github.com/pingcap/tidb/pkg/distsql/context"
+	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/expression/exprstatic"
 	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/resourcemanager/pool/workerpool"
@@ -62,6 +66,46 @@ func TestDoneTaskKeeper(t *testing.T) {
 
 	n.updateNextKey(6, kv.Key("h"))
 	require.True(t, bytes.Equal(n.nextKey, kv.Key("h")))
+}
+
+func TestOutdatedBackfillTaskMetaIsNonRetryable(t *testing.T) {
+	err := errors.Annotatef(errBackfillTaskMetaOutdated, "index info not found: %d", 1)
+	require.False(t, isRetryableError(err, true))
+	require.False(t, (&backfillDistExecutor{}).IsRetryableError(err))
+
+	restoredErr := errors.New(err.Error())
+	require.False(t, isRetryableError(restoredErr, true))
+	require.False(t, (&backfillDistExecutor{}).IsRetryableError(restoredErr))
+}
+
+func TestValidateBackfillTaskMeta(t *testing.T) {
+	job := &model.Job{ID: 1, SchemaID: 2, TableID: 3}
+	reorgInfo := &reorgInfo{
+		Job:         job,
+		elements:    []*meta.Element{{ID: 10, TypeKey: meta.IndexElementKey}},
+		currElement: &meta.Element{ID: 10, TypeKey: meta.IndexElementKey},
+	}
+	taskMeta := &BackfillTaskMeta{
+		Job:        *job,
+		EleIDs:     []int64{10},
+		EleTypeKey: meta.IndexElementKey,
+	}
+	taskMetaBytes, err := json.Marshal(taskMeta)
+	require.NoError(t, err)
+	task := &proto.Task{
+		TaskBase: proto.TaskBase{
+			ID:  5,
+			Key: "ddl/backfill/1",
+		},
+		Meta: taskMetaBytes,
+	}
+	require.NoError(t, validateBackfillTaskMeta(task, reorgInfo))
+
+	taskMeta.EleIDs = []int64{11}
+	task.Meta, err = json.Marshal(taskMeta)
+	require.NoError(t, err)
+	err = validateBackfillTaskMeta(task, reorgInfo)
+	require.ErrorIs(t, errors.Cause(err), errBackfillTaskMetaOutdated)
 }
 
 func TestPickBackfillType(t *testing.T) {

--- a/pkg/ddl/backfilling_test.go
+++ b/pkg/ddl/backfilling_test.go
@@ -17,7 +17,6 @@ package ddl
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"math"
 	"testing"
 	"time"
@@ -26,11 +25,9 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl/copr"
 	"github.com/pingcap/tidb/pkg/ddl/ingest"
 	distsqlctx "github.com/pingcap/tidb/pkg/distsql/context"
-	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/expression/exprstatic"
 	"github.com/pingcap/tidb/pkg/kv"
-	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/resourcemanager/pool/workerpool"
@@ -72,40 +69,6 @@ func TestOutdatedBackfillTaskMetaIsNonRetryable(t *testing.T) {
 	err := errors.Annotatef(errBackfillTaskMetaOutdated, "index info not found: %d", 1)
 	require.False(t, isRetryableError(err, true))
 	require.False(t, (&backfillDistExecutor{}).IsRetryableError(err))
-
-	restoredErr := errors.New(err.Error())
-	require.False(t, isRetryableError(restoredErr, true))
-	require.False(t, (&backfillDistExecutor{}).IsRetryableError(restoredErr))
-}
-
-func TestValidateBackfillTaskMeta(t *testing.T) {
-	job := &model.Job{ID: 1, SchemaID: 2, TableID: 3}
-	reorgInfo := &reorgInfo{
-		Job:         job,
-		elements:    []*meta.Element{{ID: 10, TypeKey: meta.IndexElementKey}},
-		currElement: &meta.Element{ID: 10, TypeKey: meta.IndexElementKey},
-	}
-	taskMeta := &BackfillTaskMeta{
-		Job:        *job,
-		EleIDs:     []int64{10},
-		EleTypeKey: meta.IndexElementKey,
-	}
-	taskMetaBytes, err := json.Marshal(taskMeta)
-	require.NoError(t, err)
-	task := &proto.Task{
-		TaskBase: proto.TaskBase{
-			ID:  5,
-			Key: "ddl/backfill/1",
-		},
-		Meta: taskMetaBytes,
-	}
-	require.NoError(t, validateBackfillTaskMeta(task, reorgInfo))
-
-	taskMeta.EleIDs = []int64{11}
-	task.Meta, err = json.Marshal(taskMeta)
-	require.NoError(t, err)
-	err = validateBackfillTaskMeta(task, reorgInfo)
-	require.ErrorIs(t, errors.Cause(err), errBackfillTaskMetaOutdated)
 }
 
 func TestPickBackfillType(t *testing.T) {

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1935,9 +1935,6 @@ func isRetryableJobError(err error, jobErrCnt int64) bool {
 }
 
 func isRetryableError(err error, retryUnknown bool) bool {
-	if isBackfillTaskMetaOutdatedErr(err) {
-		return false
-	}
 	errMsg := err.Error()
 	for _, m := range dbterror.ReorgRetryableErrMsgs {
 		if strings.Contains(errMsg, m) {

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -3104,15 +3104,6 @@ func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *r
 		if err := json.Unmarshal(task.Meta, taskMeta); err != nil {
 			return errors.Trace(err)
 		}
-		if err := validateBackfillTaskMeta(task, reorgInfo); err != nil {
-			if !task.TaskBase.IsDone() {
-				if err1 := taskManager.FailTask(w.workCtx, task.ID, task.State, err); err1 != nil {
-					return err1
-				}
-				handle.NotifyTaskChange()
-			}
-			return err
-		}
 		taskID = task.ID
 		lastRequiredSlots = task.RequiredSlots
 		lastBatchSize = taskMeta.Job.ReorgMeta.GetBatchSize()
@@ -3219,23 +3210,6 @@ func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *r
 
 	err = g.Wait()
 	return err
-}
-
-func validateBackfillTaskMeta(task *proto.Task, reorgInfo *reorgInfo) error {
-	taskMeta := &BackfillTaskMeta{}
-	if err := json.Unmarshal(task.Meta, taskMeta); err != nil {
-		return errors.Trace(err)
-	}
-	job := reorgInfo.Job
-	if taskMeta.Job.ID != job.ID ||
-		taskMeta.Job.SchemaID != job.SchemaID ||
-		taskMeta.Job.TableID != job.TableID ||
-		!bytes.Equal(taskMeta.EleTypeKey, reorgInfo.currElement.TypeKey) ||
-		!slices.Equal(taskMeta.EleIDs, extractElemIDs(reorgInfo)) {
-		return errors.Annotatef(errBackfillTaskMetaOutdated,
-			"task ID: %d, task key: %s, job ID: %d", task.ID, task.Key, job.ID)
-	}
-	return nil
 }
 
 func (w *worker) checkRunnableOrHandlePauseOrCanceled(stepCtx context.Context, taskKey string) (err error) {

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1935,6 +1935,9 @@ func isRetryableJobError(err error, jobErrCnt int64) bool {
 }
 
 func isRetryableError(err error, retryUnknown bool) bool {
+	if isBackfillTaskMetaOutdatedErr(err) {
+		return false
+	}
 	errMsg := err.Error()
 	for _, m := range dbterror.ReorgRetryableErrMsgs {
 		if strings.Contains(errMsg, m) {
@@ -3101,6 +3104,15 @@ func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *r
 		if err := json.Unmarshal(task.Meta, taskMeta); err != nil {
 			return errors.Trace(err)
 		}
+		if err := validateBackfillTaskMeta(task, reorgInfo); err != nil {
+			if !task.TaskBase.IsDone() {
+				if err1 := taskManager.FailTask(w.workCtx, task.ID, task.State, err); err1 != nil {
+					return err1
+				}
+				handle.NotifyTaskChange()
+			}
+			return err
+		}
 		taskID = task.ID
 		lastRequiredSlots = task.RequiredSlots
 		lastBatchSize = taskMeta.Job.ReorgMeta.GetBatchSize()
@@ -3207,6 +3219,23 @@ func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *r
 
 	err = g.Wait()
 	return err
+}
+
+func validateBackfillTaskMeta(task *proto.Task, reorgInfo *reorgInfo) error {
+	taskMeta := &BackfillTaskMeta{}
+	if err := json.Unmarshal(task.Meta, taskMeta); err != nil {
+		return errors.Trace(err)
+	}
+	job := reorgInfo.Job
+	if taskMeta.Job.ID != job.ID ||
+		taskMeta.Job.SchemaID != job.SchemaID ||
+		taskMeta.Job.TableID != job.TableID ||
+		!bytes.Equal(taskMeta.EleTypeKey, reorgInfo.currElement.TypeKey) ||
+		!slices.Equal(taskMeta.EleIDs, extractElemIDs(reorgInfo)) {
+		return errors.Annotatef(errBackfillTaskMetaOutdated,
+			"task ID: %d, task key: %s, job ID: %d", task.ID, task.Key, job.ID)
+	}
+	return nil
 }
 
 func (w *worker) checkRunnableOrHandlePauseOrCanceled(stepCtx context.Context, taskKey string) (err error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68828

Problem Summary:

Distributed add-index backfill can pick up an existing DXF task by task key and resume it with stale `BackfillTaskMeta`. If the old task meta contains `EleIDs` that no longer exist in the current table metadata, the backfill executor returns `index info not found`; because that error was treated as retryable, DXF could retry the same deterministic failure forever without making progress.

### What changed and how does it work?

- Add a dedicated `index info not found` error for stale DXF backfill task metadata whose `EleIDs` no longer match current table indexes.
- Convert `index info not found` during distributed backfill executor setup into the typed non-retryable error with index, table, and DDL job identifiers.
- Treat the typed `index info not found` error as non-retryable in the backfill DXF executor.
- Rely on DXF's existing non-retryable error handling to fail/revert the task instead of manually validating and failing an existing task during DDL resume.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

```sh
PATH=/usr/local/go/bin:$PATH ./tools/check/failpoint-go-test.sh pkg/ddl -run TestIndexInfoNotFoundIsNonRetryable -count=1
PATH=/tmp/tidb-bazel/bin:/usr/local/go/bin:$PATH make bazel_prepare
env -u GOROOT PATH=/tmp/tidb-bazel/bin:/usr/local/go/bin:$PATH make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug that could cause distributed `ADD INDEX` backfill to keep retrying forever when it resumed a stale DXF task whose metadata no longer matched the current table indexes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing index metadata during backfill jobs, so these cases are now clearly identified as non-retryable.
  * Updated error details to include helpful context such as index ID, table ID, and job ID to simplify troubleshooting.
* **Tests**
  * Added coverage to ensure the new non-retryable classification remains correct even when errors are wrapped/annotated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
