### PR TITLE
expression: fix isBinCollation to recognize utf8mb4_0900_bin

### DIFF
--- a/pkg/expression/collation.go
+++ b/pkg/expression/collation.go
@@ -571,7 +571,7 @@ func isUnicodeCollation(ch string) bool {
 func isBinCollation(collate string) bool {
 	return collate == charset.CollationASCII || collate == charset.CollationLatin1 ||
 		collate == charset.CollationUTF8 || collate == charset.CollationUTF8MB4 ||
-		collate == charset.CollationGBKBin
+		collate == charset.CollationGBKBin || collate == charset.CollationUTF8MB40900Bin
 }
 
 // getBinCollation get binary collation by charset

--- a/pkg/expression/collation.go
+++ b/pkg/expression/collation.go
@@ -568,6 +568,19 @@ func isUnicodeCollation(ch string) bool {
 	return ch == charset.CharsetUTF8 || ch == charset.CharsetUTF8MB4
 }
 
+// isBinCollation checks whether the collation has _bin semantics for coercibility
+// derivation. In MySQL's aggregation rules, when two same-charset collations conflict
+// with equal coercibility, a _bin collation yields to a non-_bin one (e.g. gbk_bin
+// yields to gbk_chinese_ci) instead of degrading to CoercibilityNone.
+//
+// This is DIFFERENT from collate.IsBinCollation which tests "sortkey == raw data"
+// (a storage-level property). The two diverge on:
+//   - gbk_bin: is a _bin collation (listed here) but its Key() does UTF-8→GBK
+//     conversion, so sortkey ≠ data (NOT in collate.IsBinCollation).
+//   - "binary": sortkey == data (in collate.IsBinCollation) but belongs to
+//     charset=bin which takes a different coercibility path (NOT listed here).
+//
+// If you add a new _bin collation here, also check collate.IsBinCollation.
 func isBinCollation(collate string) bool {
 	return collate == charset.CollationASCII || collate == charset.CollationLatin1 ||
 		collate == charset.CollationUTF8 || collate == charset.CollationUTF8MB4 ||

--- a/pkg/expression/collation_test.go
+++ b/pkg/expression/collation_test.go
@@ -147,6 +147,36 @@ func TestInferCollation(t *testing.T) {
 			false,
 			&ExprCollation{CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, charset.CollationUTF8MB4},
 		},
+		// Regression test: utf8mb4_0900_bin is a binary collation and should win
+		// over non-bin collations at the same coercibility (same as utf8mb4_bin).
+		{
+			[]Expression{
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, charset.CollationUTF8MB40900Bin),
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, "utf8mb4_unicode_ci"),
+			},
+			false,
+			&ExprCollation{CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, charset.CollationUTF8MB40900Bin},
+		},
+		{
+			[]Expression{
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, "utf8mb4_unicode_ci"),
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, charset.CollationUTF8MB40900Bin),
+			},
+			false,
+			&ExprCollation{CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, charset.CollationUTF8MB40900Bin},
+		},
+		// Regression test: two utf8mb4 columns with utf8mb4_0900_bin + utf8mb4_unicode_ci
+		// combined with a binary blob. utf8mb4_0900_bin should be recognized as bin
+		// collation so binary wins without triggering from_binary() cast.
+		{
+			[]Expression{
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, charset.CollationUTF8MB40900Bin),
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, "utf8mb4_unicode_ci"),
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetBin, charset.CollationBin),
+			},
+			false,
+			&ExprCollation{CoercibilityImplicit, UNICODE, charset.CharsetBin, charset.CollationBin},
+		},
 		// binary charset with non-binary charset.
 		{
 			[]Expression{

--- a/pkg/parser/charset/charset.go
+++ b/pkg/parser/charset/charset.go
@@ -238,6 +238,8 @@ const (
 	CollationLatin1 = "latin1_bin"
 	// CollationGBKBin is the default collation for CharsetGBK when new collation is disabled.
 	CollationGBKBin = "gbk_bin"
+	// CollationUTF8MB40900Bin is the utf8mb4_0900_bin collation (MySQL 8.0 binary collation for utf8mb4).
+	CollationUTF8MB40900Bin = "utf8mb4_0900_bin"
 	// CollationGBKChineseCI is the default collation for CharsetGBK when new collation is enabled.
 	CollationGBKChineseCI = "gbk_chinese_ci"
 	// CollationGB18030Bin is the default collation for CharsetGB18030 when new collation is disabled.

--- a/pkg/util/collate/collate.go
+++ b/pkg/util/collate/collate.go
@@ -335,14 +335,22 @@ func ConvertAndGetBinCollator(collate string) Collator {
 	return GetCollator(ConvertAndGetBinCollation(collate))
 }
 
-// IsBinCollation returns if the collation is 'xx_bin' or 'bin'.
-// The function is to determine whether the sortkey of a char type of data under the collation is equal to the data itself,
-// and both xx_bin and collationBin are satisfied.
+// IsBinCollation returns whether the sortkey of a char/varchar under this collation
+// equals the raw data itself. This is a STORAGE-LEVEL property used by:
+//   - tablecodec: deciding whether restore-data is needed
+//   - NeedRestoredData: padding optimization
+//   - ranger/selectivity: assuming sortkey == data for fast paths
+//
+// DO NOT use this for coercibility derivation (use expression.isBinCollation instead).
+// The two concepts diverge on GBK: gbk_bin's Key() does UTF-8→GBK encoding conversion
+// (sortkey ≠ data), but it IS still a _bin collation for coercibility purposes.
+//
+// Included: ascii_bin, latin1_bin, utf8_bin, utf8mb4_bin, binary, utf8mb4_0900_bin
+// NOT included: gbk_bin (its Key() transforms data via encoding)
 func IsBinCollation(collate string) bool {
 	return collate == charset.CollationASCII || collate == charset.CollationLatin1 ||
 		collate == charset.CollationUTF8 || collate == charset.CollationUTF8MB4 ||
-		collate == charset.CollationBin || collate == "utf8mb4_0900_bin"
-	// TODO: define a constant to reference collations
+		collate == charset.CollationBin || collate == charset.CollationUTF8MB40900Bin
 }
 
 // IsPadSpaceCollation returns whether the collation is a PAD SPACE collation.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68845

Problem Summary:

`CONCAT_WS` over a `utf8mb4_0900_bin` column + a `utf8mb4_unicode_ci` column + a `mediumblob` column fails with `ERROR 3854 (HY000): Cannot convert string from binary to utf8mb4`. The root cause is that `isBinCollation()` in `pkg/expression/collation.go` does not recognize `utf8mb4_0900_bin` as a binary collation, causing `inferCollation` to degrade to `CoercibilityNone` instead of keeping the `_bin` collation. This leads to an incorrect `from_binary()` cast on the blob.

### What changed and how does it work?

1. Added `CollationUTF8MB40900Bin = "utf8mb4_0900_bin"` constant to `pkg/parser/charset/charset.go`.
2. Added `charset.CollationUTF8MB40900Bin` to the `isBinCollation()` check in `pkg/expression/collation.go`.
3. Added 3 regression test cases in `pkg/expression/collation_test.go`:
   - `utf8mb4_0900_bin` vs `utf8mb4_unicode_ci` (both orders) → `_bin` wins
   - Three-column case (`utf8mb4_0900_bin` + `utf8mb4_unicode_ci` + `binary`) → `binary` wins without `from_binary()` cast

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix a bug where CONCAT_WS with utf8mb4_0900_bin and a blob column incorrectly returned ERROR 3854 instead of returning binary result
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collation handling to properly recognize utf8mb4_0900_bin as a binary collation, ensuring correct collation inference when mixed with other collations.

* **Tests**
  * Added regression test coverage for utf8mb4_0900_bin collation handling scenarios.

* **Documentation**
  * Clarified binary-collation recognition behavior to reduce ambiguity in collation conflict resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->