### PR TITLE
tools: fail fast for read-only failpoint state

### DIFF
--- a/tools/check/failpoint-state.sh
+++ b/tools/check/failpoint-state.sh
@@ -97,7 +97,15 @@ case "${log_color_mode}" in
 		;;
 esac
 
-mkdir -p "${state_dir}"
+if ! mkdir -p "${state_dir}"; then
+	echo "failed to create failpoint state directory: ${state_dir}" >&2
+	exit 1
+fi
+
+if [ ! -w "${state_dir}" ]; then
+	echo "failpoint state directory is not writable: ${state_dir}" >&2
+	exit 1
+fi
 
 read_refcount() {
 	if [ ! -f "${refcount_file}" ]; then


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: N/A

Problem Summary:

`tools/check/failpoint-state.sh` stores its refcount and lock state under the repository Git directory, for example `.git/.failpoint-state` or `.git/worktrees/<name>/.failpoint-state` for a Git worktree.

In managed sandbox environments, the worktree files can be writable while the Git directory is mounted read-only. When `.failpoint-state` does not exist, `mkdir -p "${state_dir}"` fails immediately. However, if `.failpoint-state` was created by a previous non-sandbox run and only `refcount` remains, `mkdir -p "${state_dir}"` succeeds and the script reaches `acquire_lock`.

`acquire_lock` previously ran `mkdir "${lock_dir}" 2>/dev/null` in a retry loop. A read-only filesystem error while creating `lock` was therefore indistinguishable from normal lock contention, so `make failpoint-enable`, `make failpoint-disable`, or `tools/check/failpoint-go-test.sh` could appear to hang until `FAILPOINT_LOCK_WAIT_SECONDS` expired.

### What changed and how does it work?

Check the failpoint state directory before entering lock acquisition:

- report a clear error if the state directory cannot be created;
- report a clear error if the state directory exists but is not writable;
- keep the existing lock retry loop unchanged for real lock contention.

This makes read-only Git directory failures fail fast instead of being treated as a held failpoint lock.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test commands:

```bash
bash -n tools/check/failpoint-state.sh
git diff --check
```

Simulated a pre-existing but read-only `.git/.failpoint-state` directory:

```bash
tmp=$(mktemp -d /tmp/failpoint-state-pr.XXXXXX)
cleanup() { chmod -R u+w "$tmp" 2>/dev/null || true; rm -rf "$tmp"; }
trap cleanup EXIT
mkdir -p "$tmp/repo/tools/check"
cp tools/check/failpoint-state.sh "$tmp/repo/tools/check/failpoint-state.sh"
cd "$tmp/repo"
git init -q
mkdir -p .git/.failpoint-state
printf '0\n' > .git/.failpoint-state/refcount
chmod 555 .git/.failpoint-state
FAILPOINT_LOCK_WAIT_SECONDS=30 timeout 5s ./tools/check/failpoint-state.sh disable go
```

The command now fails immediately with:

```text
failpoint state directory is not writable: <tmp>/repo/.git/.failpoint-state
```

Also checked the current sandbox path:

```bash
timeout 10s ./tools/check/failpoint-state.sh enable go
timeout 10s ./tools/check/failpoint-go-test.sh pkg/parser/terror -run '^$'
```

Both commands fail fast with a read-only Git directory error instead of waiting for the failpoint lock timeout.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build validation robustness with enhanced error detection for directory initialization and accessibility, ensuring failed checks exit cleanly with proper error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->