### PR TITLE
*: backport mv metadata, import options, and refresh support fixes

### DIFF
--- a/pkg/ddl/backfilling_test.go
+++ b/pkg/ddl/backfilling_test.go
@@ -285,7 +285,7 @@ func TestCreateMaterializedViewBuildSessionMVMaintenance(t *testing.T) {
 		Location:          &model.TimeZoneLocation{Name: "UTC"},
 		ResourceGroupName: "default",
 	}
-	restore, err := initCreateMaterializedViewBuildSession(sctx, reorgMeta)
+	restore, err := initCreateMaterializedViewBuildSession(sctx, reorgMeta, sctx.GetSessionVars().CurrentDB)
 	require.NoError(t, err)
 	require.True(t, sctx.GetSessionVars().InMaterializedViewMaintenance)
 

--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -548,7 +548,7 @@ func (w *worker) rollbackCreateMaterializedView(jobCtx *jobContext, job *model.J
 	return ver, nil
 }
 
-func buildCreateMaterializedViewImportSQL(schemaName string, mvTblInfo *model.TableInfo) (string, error) {
+func buildCreateMaterializedViewImportSQL(schemaName string, mvTblInfo *model.TableInfo, threadCnt int) (string, error) {
 	if mvTblInfo.MaterializedView == nil || len(mvTblInfo.MaterializedView.SQLContent) == 0 {
 		return "", dbterror.ErrInvalidDDLJob.GenWithStackByArgs("create materialized view: invalid select sql")
 	}
@@ -556,7 +556,11 @@ func buildCreateMaterializedViewImportSQL(schemaName string, mvTblInfo *model.Ta
 	// Build uses current visible data of the source query directly.
 	selectSQL := mvTblInfo.MaterializedView.SQLContent
 	prefix := sqlescape.MustEscapeSQL("IMPORT INTO %n.%n FROM ", schemaName, mvTblInfo.Name.O)
-	return prefix + "(" + selectSQL + ") WITH disable_precheck", nil
+	options := []string{"disable_precheck"}
+	if threadCnt > 0 {
+		options = append(options, fmt.Sprintf("thread=%d", threadCnt))
+	}
+	return prefix + "(" + selectSQL + ") WITH " + strings.Join(options, ", "), nil
 }
 
 func getCreateMaterializedViewBuildReadTS(ctx context.Context, ddlSess *sess.Session) (uint64, error) {
@@ -613,24 +617,27 @@ func (w *worker) hasCreateMaterializedViewBuildRows(ctx context.Context, schemaN
 	return len(rows) > 0, nil
 }
 
-func initCreateMaterializedViewBuildSession(sessCtx sessionctx.Context, reorgMeta *model.DDLReorgMeta) (func(), error) {
+func initCreateMaterializedViewBuildSession(sessCtx sessionctx.Context, reorgMeta *model.DDLReorgMeta, currentDB string) (func(), error) {
 	if reorgMeta == nil {
 		return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("create materialized view: missing reorg metadata")
 	}
 	restore := restoreSessCtx(sessCtx)
 	origInMaterializedViewMaintenance := sessCtx.GetSessionVars().InMaterializedViewMaintenance
+	origCurrentDB := sessCtx.GetSessionVars().CurrentDB
 	if err := initSessCtx(sessCtx, reorgMeta); err != nil {
 		// initSessCtx may mutate session vars before returning error (for example invalid timezone).
 		// Restore immediately to avoid leaking partial state into the pooled session.
 		restore(sessCtx)
 		return nil, errors.Trace(err)
 	}
+	sessCtx.GetSessionVars().CurrentDB = currentDB
 	// MV init build should follow the same TiFlash strict-mode bypass path as MV refresh.
 	// Also marks the session as MV maintenance context so writes bypass the explicit-DML guard.
 	sessCtx.GetSessionVars().InMaterializedViewMaintenance = true
 	return func() {
 		restore(sessCtx)
 		sessCtx.GetSessionVars().InMaterializedViewMaintenance = origInMaterializedViewMaintenance
+		sessCtx.GetSessionVars().CurrentDB = origCurrentDB
 	}, nil
 }
 
@@ -648,7 +655,7 @@ func (w *worker) buildCreateMaterializedViewDataByImport(ctx context.Context, jo
 	if err != nil {
 		return errors.Trace(err)
 	}
-	restoreSess, err := initCreateMaterializedViewBuildSession(sessCtx, job.ReorgMeta)
+	restoreSess, err := initCreateMaterializedViewBuildSession(sessCtx, job.ReorgMeta, job.SchemaName)
 	if err != nil {
 		w.sessPool.Put(sessCtx)
 		return errors.Trace(err)
@@ -659,7 +666,11 @@ func (w *worker) buildCreateMaterializedViewDataByImport(ctx context.Context, jo
 	}()
 
 	ddlSess := sess.NewSession(sessCtx)
-	buildSQL, err := buildCreateMaterializedViewImportSQL(job.SchemaName, mvTblInfo)
+	threadCnt := sessCtx.GetSessionVars().CreateMViewImportThreads
+	if val, ok := job.GetSessionVars(variable.TiDBCreateMViewImportThreads); ok {
+		threadCnt = variable.TidbOptInt(val, threadCnt)
+	}
+	buildSQL, err := buildCreateMaterializedViewImportSQL(job.SchemaName, mvTblInfo, threadCnt)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -671,7 +682,10 @@ func (w *worker) buildCreateMaterializedViewDataByImport(ctx context.Context, jo
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return errors.Trace(w.setCreateMaterializedViewBuildReadTSInReorgCtx(job.ID, readTS))
+	if err := w.setCreateMaterializedViewBuildReadTSInReorgCtx(job.ID, readTS); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 func (w *worker) buildCreateMaterializedViewDataByInsert(ctx context.Context, job *model.Job, mvTblInfo *model.TableInfo) error {
@@ -679,7 +693,7 @@ func (w *worker) buildCreateMaterializedViewDataByInsert(ctx context.Context, jo
 	if err != nil {
 		return errors.Trace(err)
 	}
-	restoreSess, err := initCreateMaterializedViewBuildSession(sessCtx, job.ReorgMeta)
+	restoreSess, err := initCreateMaterializedViewBuildSession(sessCtx, job.ReorgMeta, job.SchemaName)
 	if err != nil {
 		w.sessPool.Put(sessCtx)
 		return errors.Trace(err)

--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -320,28 +320,41 @@ func (w *worker) onCreateMaterializedView(jobCtx *jobContext, job *model.Job) (v
 		job.State = model.JobStateCancelled
 		return ver, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("create materialized view: invalid job args")
 	}
-	if len(mvTblInfo.MaterializedView.BaseTableIDs) != 1 || mvTblInfo.MaterializedView.BaseTableIDs[0] == 0 {
+	baseTableIDs := mvTblInfo.MaterializedView.BaseTableIDs
+	if len(baseTableIDs) == 0 {
 		job.State = model.JobStateCancelled
 		return ver, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("create materialized view: invalid base table id")
+	}
+	seenBaseTableIDs := make(map[int64]struct{}, len(baseTableIDs))
+	for _, baseTableID := range baseTableIDs {
+		if baseTableID == 0 {
+			job.State = model.JobStateCancelled
+			return ver, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("create materialized view: invalid base table id")
+		}
+		if _, ok := seenBaseTableIDs[baseTableID]; ok {
+			job.State = model.JobStateCancelled
+			return ver, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("create materialized view: duplicate base table id")
+		}
+		seenBaseTableIDs[baseTableID] = struct{}{}
 	}
 
 	if job.IsRollingback() {
 		return w.rollbackCreateMaterializedView(jobCtx, job, mvTblInfo)
 	}
 
-	baseTableID := mvTblInfo.MaterializedView.BaseTableIDs[0]
-
 	switch job.SchemaState {
 	case model.StateNone:
 		// Phase-1: create MV physical table and atomically wire base<->mv metadata.
-		if _, err := onCreateMaterializedViewBaseCheck(jobCtx.metaMut, job.SchemaID, baseTableID, job.SchemaName); err != nil {
-			if infoschema.ErrDatabaseNotExists.Equal(err) || infoschema.ErrTableNotExists.Equal(err) {
-				job.State = model.JobStateCancelled
+		for _, baseTableID := range baseTableIDs {
+			if _, err := onCreateMaterializedViewBaseCheck(jobCtx.metaMut, job.SchemaID, baseTableID, job.SchemaName); err != nil {
+				if infoschema.ErrDatabaseNotExists.Equal(err) || infoschema.ErrTableNotExists.Equal(err) {
+					job.State = model.JobStateCancelled
+				}
+				if dbterror.ErrInvalidDDLJob.Equal(err) || dbterror.ErrWrongObject.Equal(err) || dbterror.ErrInvalidDDLState.Equal(err) {
+					job.State = model.JobStateCancelled
+				}
+				return ver, errors.Trace(err)
 			}
-			if dbterror.ErrInvalidDDLJob.Equal(err) || dbterror.ErrWrongObject.Equal(err) || dbterror.ErrInvalidDDLState.Equal(err) {
-				job.State = model.JobStateCancelled
-			}
-			return ver, errors.Trace(err)
 		}
 
 		mvTblInfo.State = model.StateNone
@@ -352,13 +365,11 @@ func (w *worker) onCreateMaterializedView(jobCtx *jobContext, job *model.Job) (v
 		job.TableID = mvTblInfo.ID
 
 		var extraInfos []schemaIDAndTableInfo
-		extra, err := updateMaterializedViewBaseInfoOnCreate(jobCtx, job, mvTblInfo)
+		extras, err := updateMaterializedViewBaseInfoOnCreate(jobCtx, job, mvTblInfo)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
-		if extra != nil {
-			extraInfos = append(extraInfos, *extra)
-		}
+		extraInfos = append(extraInfos, extras...)
 
 		ver, err = updateSchemaVersion(jobCtx, job, extraInfos...)
 		if err != nil {
@@ -447,11 +458,16 @@ func (w *worker) onCreateMaterializedView(jobCtx *jobContext, job *model.Job) (v
 		if job.BinlogInfo != nil {
 			ver = job.BinlogInfo.SchemaVersion
 		}
-		baseTblInfo, err := getTableInfo(jobCtx.metaMut, baseTableID, job.SchemaID)
-		if err != nil {
-			return ver, errors.Trace(err)
+		finishedTableInfos := make([]*model.TableInfo, 0, len(baseTableIDs)+1)
+		finishedTableInfos = append(finishedTableInfos, mvTblInfo)
+		for _, baseTableID := range baseTableIDs {
+			baseTblInfo, getErr := getTableInfo(jobCtx.metaMut, baseTableID, job.SchemaID)
+			if getErr != nil {
+				return ver, errors.Trace(getErr)
+			}
+			finishedTableInfos = append(finishedTableInfos, baseTblInfo)
 		}
-		job.FinishMultipleTableJob(model.JobStateDone, model.StatePublic, ver, []*model.TableInfo{mvTblInfo, baseTblInfo})
+		job.FinishMultipleTableJob(model.JobStateDone, model.StatePublic, ver, finishedTableInfos)
 		return ver, nil
 
 	default:
@@ -490,15 +506,15 @@ func (w *worker) rollbackCreateMaterializedView(jobCtx *jobContext, job *model.J
 
 	var extraInfos []schemaIDAndTableInfo
 	if droppingTblInfo != nil {
-		extra, err := updateMaterializedViewBaseInfoOnDrop(jobCtx, job, droppingTblInfo)
+		extras, err := updateMaterializedViewBaseInfoOnDrop(jobCtx, job, droppingTblInfo)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
-		if extra != nil {
+		for _, extra := range extras {
 			if err := updateTable(jobCtx.metaMut, extra.schemaID, extra.tblInfo); err != nil {
 				return ver, errors.Trace(err)
 			}
-			extraInfos = append(extraInfos, *extra)
+			extraInfos = append(extraInfos, extra)
 		}
 	}
 
@@ -521,11 +537,14 @@ func (w *worker) rollbackCreateMaterializedView(jobCtx *jobContext, job *model.J
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
-	var mlogTableID int64
+	var mlogTableIDs []int64
 	if args, ok := jobCtx.jobArgs.(*model.CreateMaterializedViewArgs); ok && args != nil {
-		mlogTableID = args.MLogTableID
+		mlogTableIDs = args.MLogTableIDs
 	}
-	job.FillArgs(&model.CreateMaterializedViewArgs{TableInfo: mvTblInfo, MLogTableID: mlogTableID})
+	job.FillArgs(&model.CreateMaterializedViewArgs{
+		TableInfo:    mvTblInfo,
+		MLogTableIDs: mlogTableIDs,
+	})
 	return ver, nil
 }
 
@@ -1219,17 +1238,17 @@ func (w *worker) deleteMaterializedViewLogPurgeInfo(jobCtx *jobContext, mlogID i
 
 // updateMaterializedViewBaseInfoOnCreate keeps base-table reverse metadata in sync
 // with MV/MLOG creation in the same DDL transaction.
-func updateMaterializedViewBaseInfoOnCreate(jobCtx *jobContext, job *model.Job, createdTable *model.TableInfo) (*schemaIDAndTableInfo, error) {
-	var baseTableID int64
+func updateMaterializedViewBaseInfoOnCreate(jobCtx *jobContext, job *model.Job, createdTable *model.TableInfo) ([]schemaIDAndTableInfo, error) {
+	var baseTableIDs []int64
 	var apply func(base *model.TableInfo) error
 
 	switch {
 	case createdTable.MaterializedView != nil:
-		if len(createdTable.MaterializedView.BaseTableIDs) != 1 {
+		if len(createdTable.MaterializedView.BaseTableIDs) == 0 {
 			job.State = model.JobStateCancelled
-			return nil, errors.New("materialized view must reference exactly one base table in Stage-1")
+			return nil, errors.New("materialized view must reference at least one base table")
 		}
-		baseTableID = createdTable.MaterializedView.BaseTableIDs[0]
+		baseTableIDs = createdTable.MaterializedView.BaseTableIDs
 		apply = func(base *model.TableInfo) error {
 			if base.MaterializedViewBase == nil {
 				base.MaterializedViewBase = &model.MaterializedViewBaseInfo{}
@@ -1243,7 +1262,7 @@ func updateMaterializedViewBaseInfoOnCreate(jobCtx *jobContext, job *model.Job, 
 			return nil
 		}
 	case createdTable.MaterializedViewLog != nil:
-		baseTableID = createdTable.MaterializedViewLog.BaseTableID
+		baseTableIDs = []int64{createdTable.MaterializedViewLog.BaseTableID}
 		apply = func(base *model.TableInfo) error {
 			if base.MaterializedViewBase == nil {
 				base.MaterializedViewBase = &model.MaterializedViewBaseInfo{}
@@ -1258,20 +1277,34 @@ func updateMaterializedViewBaseInfoOnCreate(jobCtx *jobContext, job *model.Job, 
 		return nil, nil
 	}
 
-	baseTblInfo, err := jobCtx.metaMut.GetTable(job.SchemaID, baseTableID)
-	if err != nil {
-		job.State = model.JobStateCancelled
-		return nil, errors.Trace(err)
+	extraInfos := make([]schemaIDAndTableInfo, 0, len(baseTableIDs))
+	processedBaseTables := make(map[int64]struct{}, len(baseTableIDs))
+	for _, baseTableID := range baseTableIDs {
+		if baseTableID == 0 {
+			job.State = model.JobStateCancelled
+			return nil, errors.New("materialized view base table id is invalid")
+		}
+		if _, ok := processedBaseTables[baseTableID]; ok {
+			continue
+		}
+		processedBaseTables[baseTableID] = struct{}{}
+
+		baseTblInfo, err := jobCtx.metaMut.GetTable(job.SchemaID, baseTableID)
+		if err != nil {
+			job.State = model.JobStateCancelled
+			return nil, errors.Trace(err)
+		}
+		if err := apply(baseTblInfo); err != nil {
+			job.State = model.JobStateCancelled
+			return nil, errors.Trace(err)
+		}
+		if err := updateTable(jobCtx.metaMut, job.SchemaID, baseTblInfo); err != nil {
+			job.State = model.JobStateCancelled
+			return nil, errors.Trace(err)
+		}
+		extraInfos = append(extraInfos, schemaIDAndTableInfo{schemaID: job.SchemaID, tblInfo: baseTblInfo})
 	}
-	if err := apply(baseTblInfo); err != nil {
-		job.State = model.JobStateCancelled
-		return nil, errors.Trace(err)
-	}
-	if err := updateTable(jobCtx.metaMut, job.SchemaID, baseTblInfo); err != nil {
-		job.State = model.JobStateCancelled
-		return nil, errors.Trace(err)
-	}
-	return &schemaIDAndTableInfo{schemaID: job.SchemaID, tblInfo: baseTblInfo}, nil
+	return extraInfos, nil
 }
 
 func (w *worker) createTableWithForeignKeys(jobCtx *jobContext, job *model.Job, args *model.CreateTableArgs) (ver int64, err error) {

--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -548,7 +548,7 @@ func (w *worker) rollbackCreateMaterializedView(jobCtx *jobContext, job *model.J
 	return ver, nil
 }
 
-func buildCreateMaterializedViewImportSQL(schemaName string, mvTblInfo *model.TableInfo, threadCnt int) (string, error) {
+func buildCreateMaterializedViewImportSQL(schemaName string, mvTblInfo *model.TableInfo, threadCnt int, diskQuota string) (string, error) {
 	if mvTblInfo.MaterializedView == nil || len(mvTblInfo.MaterializedView.SQLContent) == 0 {
 		return "", dbterror.ErrInvalidDDLJob.GenWithStackByArgs("create materialized view: invalid select sql")
 	}
@@ -559,6 +559,9 @@ func buildCreateMaterializedViewImportSQL(schemaName string, mvTblInfo *model.Ta
 	options := []string{"disable_precheck"}
 	if threadCnt > 0 {
 		options = append(options, fmt.Sprintf("thread=%d", threadCnt))
+	}
+	if diskQuota != "" {
+		options = append(options, sqlescape.MustEscapeSQL("disk_quota=%?", diskQuota))
 	}
 	return prefix + "(" + selectSQL + ") WITH " + strings.Join(options, ", "), nil
 }
@@ -666,11 +669,15 @@ func (w *worker) buildCreateMaterializedViewDataByImport(ctx context.Context, jo
 	}()
 
 	ddlSess := sess.NewSession(sessCtx)
-	threadCnt := sessCtx.GetSessionVars().CreateMViewImportThreads
-	if val, ok := job.GetSessionVars(variable.TiDBCreateMViewImportThreads); ok {
+	threadCnt := sessCtx.GetSessionVars().MViewMaintainImportThreads
+	if val, ok := job.GetSessionVars(variable.TiDBMViewMaintainImportThreads); ok {
 		threadCnt = variable.TidbOptInt(val, threadCnt)
 	}
-	buildSQL, err := buildCreateMaterializedViewImportSQL(job.SchemaName, mvTblInfo, threadCnt)
+	diskQuota := sessCtx.GetSessionVars().MViewMaintainImportDiskQuota
+	if val, ok := job.GetSessionVars(variable.TiDBMViewMaintainImportDiskQuota); ok {
+		diskQuota = val
+	}
+	buildSQL, err := buildCreateMaterializedViewImportSQL(job.SchemaName, mvTblInfo, threadCnt, diskQuota)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -639,7 +639,7 @@ func TestBuildCreateMaterializedViewImportSQLNoAsOfTimestamp(t *testing.T) {
 			SQLContent: "select a, count(1) from t group by a",
 		},
 	}
-	sql, err := buildCreateMaterializedViewImportSQL("test", mvTblInfo)
+	sql, err := buildCreateMaterializedViewImportSQL("test", mvTblInfo, 0)
 	require.NoError(t, err)
 	require.Contains(t, sql, "IMPORT INTO `test`.`mv` FROM (")
 	require.Contains(t, sql, "WITH disable_precheck")

--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -639,9 +639,21 @@ func TestBuildCreateMaterializedViewImportSQLNoAsOfTimestamp(t *testing.T) {
 			SQLContent: "select a, count(1) from t group by a",
 		},
 	}
-	sql, err := buildCreateMaterializedViewImportSQL("test", mvTblInfo, 0)
+	sql, err := buildCreateMaterializedViewImportSQL("test", mvTblInfo, 0, "")
 	require.NoError(t, err)
 	require.Contains(t, sql, "IMPORT INTO `test`.`mv` FROM (")
 	require.Contains(t, sql, "WITH disable_precheck")
 	require.NotContains(t, strings.ToUpper(sql), "AS OF TIMESTAMP")
+}
+
+func TestBuildCreateMaterializedViewImportSQLDiskQuota(t *testing.T) {
+	mvTblInfo := &model.TableInfo{
+		Name: pmodel.NewCIStr("mv"),
+		MaterializedView: &model.MaterializedViewInfo{
+			SQLContent: "select a, count(1) from t group by a",
+		},
+	}
+	sql, err := buildCreateMaterializedViewImportSQL("test", mvTblInfo, 0, "100gib")
+	require.NoError(t, err)
+	require.Contains(t, sql, "WITH disable_precheck, disk_quota='100gib'")
 }

--- a/pkg/ddl/job_submitter.go
+++ b/pkg/ddl/job_submitter.go
@@ -773,9 +773,12 @@ func job2TableIDs(jobW *JobWrapper) string {
 		return strconv.FormatInt(jobW.TableID, 10) + "," + strconv.FormatInt(newTableID, 10)
 	case model.ActionCreateMaterializedView:
 		args := jobW.JobArgs.(*model.CreateMaterializedViewArgs)
-		intest.Assert(args != nil && args.MLogTableID > 0)
-		if args != nil && args.MLogTableID > 0 {
-			return makeStringForIDs([]int64{jobW.TableID, args.MLogTableID})
+		intest.Assert(args != nil)
+		if args != nil && len(args.MLogTableIDs) > 0 {
+			ids := make([]int64, 0, len(args.MLogTableIDs)+1)
+			ids = append(ids, jobW.TableID)
+			ids = append(ids, args.MLogTableIDs...)
+			return makeStringForIDs(ids)
 		}
 		return strconv.FormatInt(jobW.TableID, 10)
 	case model.ActionCreateMaterializedViewLog:

--- a/pkg/ddl/job_submitter_test.go
+++ b/pkg/ddl/job_submitter_test.go
@@ -526,7 +526,7 @@ func TestCreateMaterializedViewJobTableIDs(t *testing.T) {
 			TableInfo: &model.TableInfo{
 				MaterializedView: &model.MaterializedViewInfo{BaseTableIDs: []int64{baseTableID}},
 			},
-			MLogTableID: mlogTableID,
+			MLogTableIDs: []int64{mlogTableID},
 		},
 		false,
 	)
@@ -541,6 +541,50 @@ func TestCreateMaterializedViewJobTableIDs(t *testing.T) {
 	require.ElementsMatch(t, []string{
 		strconv.FormatInt(jobW.TableID, 10),
 		strconv.FormatInt(mlogTableID, 10),
+	}, tableIDs)
+}
+
+func TestCreateMaterializedViewJobTableIDsMultiMLog(t *testing.T) {
+	store := testkit.CreateMockStore(t, mockstore.WithStoreType(mockstore.EmbedUnistore))
+	// disable DDL to avoid it interfere the test
+	tk := testkit.NewTestKit(t, store)
+	dom := domain.GetDomain(tk.Session())
+	dom.DDL().OwnerManager().CampaignCancel()
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL)
+
+	const (
+		baseTableID1 int64 = 900000000000000010
+		baseTableID2 int64 = 900000000000000011
+		mlogTableID1 int64 = 900000000000000012
+		mlogTableID2 int64 = 900000000000000013
+	)
+	jobW := ddl.NewJobWrapperWithArgs(
+		&model.Job{
+			Version:    model.GetJobVerInUse(),
+			Type:       model.ActionCreateMaterializedView,
+			SchemaName: "test",
+			TableName:  "mv_multi",
+		},
+		&model.CreateMaterializedViewArgs{
+			TableInfo: &model.TableInfo{
+				MaterializedView: &model.MaterializedViewInfo{BaseTableIDs: []int64{baseTableID1, baseTableID2}},
+			},
+			MLogTableIDs: []int64{mlogTableID1, mlogTableID2, mlogTableID1},
+		},
+		false,
+	)
+	submitter := ddl.NewJobSubmitterForTest()
+	require.NoError(t, submitter.GenGIDAndInsertJobsWithRetry(ctx, sess.NewSession(tk.Session()), []*ddl.JobWrapper{jobW}))
+
+	rows := tk.MustQuery(fmt.Sprintf("select table_ids from mysql.tidb_ddl_job where job_id = %d", jobW.ID)).Rows()
+	require.Len(t, rows, 1)
+
+	tableIDs := strings.Split(rows[0][0].(string), ",")
+	require.Len(t, tableIDs, 3)
+	require.ElementsMatch(t, []string{
+		strconv.FormatInt(jobW.TableID, 10),
+		strconv.FormatInt(mlogTableID1, 10),
+		strconv.FormatInt(mlogTableID2, 10),
 	}, tableIDs)
 }
 

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -211,7 +211,8 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 		return err
 	}
 	job.AddSessionVars(variable.TiDBScatterRegion, getScatterScopeFromSessionctx(ctx))
-	job.AddSessionVars(variable.TiDBCreateMViewImportThreads, strconv.Itoa(ctx.GetSessionVars().CreateMViewImportThreads))
+	job.AddSessionVars(variable.TiDBMViewMaintainImportThreads, strconv.Itoa(ctx.GetSessionVars().MViewMaintainImportThreads))
+	job.AddSessionVars(variable.TiDBMViewMaintainImportDiskQuota, ctx.GetSessionVars().MViewMaintainImportDiskQuota)
 	jobW := NewJobWrapperWithArgs(job, &model.CreateMaterializedViewArgs{
 		TableInfo:    mvTableInfo,
 		MLogTableIDs: []int64{mlogTable.Meta().ID},

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -210,7 +210,10 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 		return err
 	}
 	job.AddSessionVars(variable.TiDBScatterRegion, getScatterScopeFromSessionctx(ctx))
-	jobW := NewJobWrapperWithArgs(job, &model.CreateMaterializedViewArgs{TableInfo: mvTableInfo, MLogTableID: mlogTable.Meta().ID}, false)
+	jobW := NewJobWrapperWithArgs(job, &model.CreateMaterializedViewArgs{
+		TableInfo:    mvTableInfo,
+		MLogTableIDs: []int64{mlogTable.Meta().ID},
+	}, false)
 	if err := e.DoDDLJobWrapper(ctx, jobW); err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -16,6 +16,7 @@ package ddl
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -210,6 +211,7 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 		return err
 	}
 	job.AddSessionVars(variable.TiDBScatterRegion, getScatterScopeFromSessionctx(ctx))
+	job.AddSessionVars(variable.TiDBCreateMViewImportThreads, strconv.Itoa(ctx.GetSessionVars().CreateMViewImportThreads))
 	jobW := NewJobWrapperWithArgs(job, &model.CreateMaterializedViewArgs{
 		TableInfo:    mvTableInfo,
 		MLogTableIDs: []int64{mlogTable.Meta().ID},

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -209,6 +209,18 @@ func (w *worker) onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ 
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
+		for _, tblInfo := range tables {
+			if tblInfo.MaterializedView != nil {
+				if err = w.deleteCreateMaterializedViewRefreshInfo(jobCtx, tblInfo.ID); err != nil {
+					return ver, errors.Trace(err)
+				}
+			}
+			if tblInfo.MaterializedViewLog != nil {
+				if err = w.deleteMaterializedViewLogPurgeInfo(jobCtx, tblInfo.ID); err != nil {
+					return ver, errors.Trace(err)
+				}
+			}
+		}
 
 		err = metaMut.UpdateDatabase(dbInfo)
 		if err != nil {

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -102,13 +102,11 @@ func (w *worker) onDropTableOrView(jobCtx *jobContext, job *model.Job) (ver int6
 
 		args.OldPartitionIDs = oldIDs
 		var extraInfos []schemaIDAndTableInfo
-		extra, extraErr := updateMaterializedViewBaseInfoOnDrop(jobCtx, job, tblInfo)
+		extras, extraErr := updateMaterializedViewBaseInfoOnDrop(jobCtx, job, tblInfo)
 		if extraErr != nil {
 			return ver, errors.Trace(extraErr)
 		}
-		if extra != nil {
-			extraInfos = append(extraInfos, *extra)
-		}
+		extraInfos = append(extraInfos, extras...)
 		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != tblInfo.State, extraInfos...)
 		if err != nil {
 			return ver, errors.Trace(err)
@@ -1514,16 +1512,16 @@ func checkDropMaterializedViewLogHasNoDependentMVs(jobCtx *jobContext, job *mode
 	return nil
 }
 
-func updateMaterializedViewBaseInfoOnDrop(jobCtx *jobContext, job *model.Job, droppingTable *model.TableInfo) (*schemaIDAndTableInfo, error) {
-	var baseTableID int64
+func updateMaterializedViewBaseInfoOnDrop(jobCtx *jobContext, job *model.Job, droppingTable *model.TableInfo) ([]schemaIDAndTableInfo, error) {
+	var baseTableIDs []int64
 	var apply func(base *model.TableInfo)
 
 	switch {
 	case droppingTable.MaterializedView != nil:
-		if len(droppingTable.MaterializedView.BaseTableIDs) != 1 {
-			return nil, errors.New("materialized view must reference exactly one base table in Stage-1")
+		if len(droppingTable.MaterializedView.BaseTableIDs) == 0 {
+			return nil, errors.New("materialized view must reference at least one base table")
 		}
-		baseTableID = droppingTable.MaterializedView.BaseTableIDs[0]
+		baseTableIDs = droppingTable.MaterializedView.BaseTableIDs
 		apply = func(base *model.TableInfo) {
 			if base.MaterializedViewBase == nil {
 				return
@@ -1540,7 +1538,7 @@ func updateMaterializedViewBaseInfoOnDrop(jobCtx *jobContext, job *model.Job, dr
 			}
 		}
 	case droppingTable.MaterializedViewLog != nil:
-		baseTableID = droppingTable.MaterializedViewLog.BaseTableID
+		baseTableIDs = []int64{droppingTable.MaterializedViewLog.BaseTableID}
 		apply = func(base *model.TableInfo) {
 			if base.MaterializedViewBase == nil {
 				return
@@ -1556,13 +1554,23 @@ func updateMaterializedViewBaseInfoOnDrop(jobCtx *jobContext, job *model.Job, dr
 		return nil, nil
 	}
 
-	baseTblInfo, err := jobCtx.metaMut.GetTable(job.SchemaID, baseTableID)
-	if err != nil || baseTblInfo == nil {
-		// The base table may already be dropped; keep dropping MV/MLOG table going.
-		return nil, nil
+	extraInfos := make([]schemaIDAndTableInfo, 0, len(baseTableIDs))
+	processedBaseTables := make(map[int64]struct{}, len(baseTableIDs))
+	for _, baseTableID := range baseTableIDs {
+		if _, ok := processedBaseTables[baseTableID]; ok {
+			continue
+		}
+		processedBaseTables[baseTableID] = struct{}{}
+
+		baseTblInfo, err := jobCtx.metaMut.GetTable(job.SchemaID, baseTableID)
+		if err != nil || baseTblInfo == nil {
+			// The base table may already be dropped; keep dropping MV/MLOG table going.
+			continue
+		}
+		apply(baseTblInfo)
+		extraInfos = append(extraInfos, schemaIDAndTableInfo{schemaID: job.SchemaID, tblInfo: baseTblInfo})
 	}
-	apply(baseTblInfo)
-	return &schemaIDAndTableInfo{schemaID: job.SchemaID, tblInfo: baseTblInfo}, nil
+	return extraInfos, nil
 }
 
 func onAlterTableAttributes(jobCtx *jobContext, job *model.Job) (ver int64, err error) {

--- a/pkg/executor/compiler.go
+++ b/pkg/executor/compiler.go
@@ -98,6 +98,14 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (_ *ExecS
 			return nil, err
 		}
 	}
+	// CREATE MATERIALIZED VIEW plans its SELECT during DDL build; avoid strict-mode TiFlash removal for that step.
+	if _, ok := stmtNode.(*ast.CreateMaterializedViewStmt); ok {
+		origMVMaintenance := sessVars.InMaterializedViewMaintenance
+		sessVars.InMaterializedViewMaintenance = true
+		defer func() {
+			sessVars.InMaterializedViewMaintenance = origMVMaintenance
+		}()
+	}
 	// Build the final physical plan.
 	finalPlan, names, err := planner.Optimize(ctx, c.Ctx, nodeW, is)
 	if err != nil {

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -708,7 +708,7 @@ func TestIndexUsageTable(t *testing.T) {
 		testkit.RowsWithSep("|",
 			"test|idt2|idx_4"))
 	tk.MustQuery(`select count(*) from information_schema.tidb_index_usage;`).Check(
-		testkit.RowsWithSep("|", "80"))
+		testkit.RowsWithSep("|", "84"))
 
 	tk.MustQuery(`select TABLE_SCHEMA, TABLE_NAME, INDEX_NAME from information_schema.tidb_index_usage
 				where TABLE_SCHEMA = 'test1';`).Check(testkit.Rows())

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -605,13 +605,12 @@ func purgeMaterializedViewLogData(
 		}
 	})
 
-	const mlogAlias = "mlog"
 	deleteSQL := sqlescape.MustEscapeSQL(
-		"DELETE /*+ read_from_storage(tiflash[%n]) */ FROM %n.%n AS %n WHERE _tidb_commit_ts <= %? LIMIT %?",
-		mlogAlias,
+		"DELETE /*+ read_from_storage(tiflash[%n.%n]) */ FROM %n.%n WHERE _tidb_commit_ts <= %? LIMIT %?",
 		schemaName,
 		mlogName,
-		mlogAlias,
+		schemaName,
+		mlogName,
 		safePurgeTSO,
 		batchSize,
 	)

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -1243,6 +1243,39 @@ func TestDropMaterializedViewLogRecheckWithConcurrentCreateMaterializedView(t *t
 	require.True(t, baseTable.Meta().MaterializedViewBase == nil || (baseTable.Meta().MaterializedViewBase.MLogID == 0 && len(baseTable.Meta().MaterializedViewBase.MViewIDs) == 0))
 }
 
+func TestDropDatabaseCleansMaterializedViewAndLogInfo(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	const dbName = "mv_drop_db_cleanup"
+	tk.MustExec("drop database if exists " + dbName)
+	tk.MustExec("create database " + dbName)
+	tk.MustExec("use " + dbName)
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr(dbName), pmodel.NewCIStr("mv"))
+	require.NoError(t, err)
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr(dbName), pmodel.NewCIStr("$mlog$t"))
+	require.NoError(t, err)
+
+	mvID := mvTable.Meta().ID
+	mlogID := mlogTable.Meta().ID
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).
+		Check(testkit.Rows("1"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogID)).
+		Check(testkit.Rows("1"))
+
+	tk.MustExec("drop database " + dbName)
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).
+		Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogID)).
+		Check(testkit.Rows("0"))
+}
+
 func TestCreateMaterializedViewRetryAfterUpsertFailure(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -268,18 +268,18 @@ func GetCreateMaterializedViewLogArgs(job *Job) (*CreateMaterializedViewLogArgs,
 // CreateMaterializedViewArgs is the arguments for create materialized view job.
 type CreateMaterializedViewArgs struct {
 	TableInfo *TableInfo `json:"table_info,omitempty"`
-	// MLogTableID is the table ID of the materialized view log that this MV depends on.
+	// MLogTableIDs are table IDs of materialized view logs that this MV depends on.
 	// It's used for DDL job discoverability/filtering (e.g. mysql.tidb_ddl_job.table_ids).
-	MLogTableID int64 `json:"mlog_table_id,omitempty"`
+	MLogTableIDs []int64 `json:"mlog_table_ids,omitempty"`
 }
 
 func (a *CreateMaterializedViewArgs) getArgsV1(*Job) []any {
-	return []any{a.TableInfo, a.MLogTableID}
+	return []any{a.TableInfo, a.MLogTableIDs}
 }
 
 func (a *CreateMaterializedViewArgs) decodeV1(job *Job) error {
 	a.TableInfo = &TableInfo{}
-	return errors.Trace(job.decodeArgs(a.TableInfo, &a.MLogTableID))
+	return errors.Trace(job.decodeArgs(a.TableInfo, &a.MLogTableIDs))
 }
 
 // GetCreateMaterializedViewArgs gets the create materialized view args.

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -724,6 +724,7 @@ func (i *MaterializedViewBaseInfo) Clone() *MaterializedViewBaseInfo {
 type MaterializedViewInfo struct {
 	// BaseTableIDs is the table IDs of the base tables referenced by this MV.
 	// For Stage-1, it contains exactly one element.
+	// A slice is used here to keep metadata extensible for future multi-base-table support.
 	BaseTableIDs []int64 `json:"base_table_ids"`
 
 	// SQLContent is the SELECT statement in CREATE MATERIALIZED VIEW.

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
@@ -10,7 +10,8 @@
     "name": "TestTableDual",
     "cases": [
       "explain format = 'brief' select * from t where 1 = 0",
-      "explain format = 'brief' select * from t where 1 = 1 limit 0"
+      "explain format = 'brief' select * from t where 1 = 1 limit 0",
+      "explain format = 'brief' select * from (select a from t) as tidb_mv_query limit 0"
     ]
   },
   {

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
@@ -36,6 +36,12 @@
         "Plan": [
           "TableDual 0.00 root  rows:0"
         ]
+      },
+      {
+        "SQL": "explain format = 'brief' select * from (select a from t) as tidb_mv_query limit 0",
+        "Plan": [
+          "TableDual 0.00 root  rows:0"
+        ]
       }
     ]
   },

--- a/pkg/planner/core/casetest/mview/BUILD.bazel
+++ b/pkg/planner/core/casetest/mview/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "mv_refresh_test.go",
     ],
     flaky = True,
-    shard_count = 8,
+    shard_count = 6,
     deps = [
         "//pkg/domain",
         "//pkg/infoschema",

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -787,7 +787,9 @@ const (
 		REFRESH_ROWS bigint DEFAULT NULL,
 		REFRESH_READ_TSO bigint unsigned DEFAULT NULL,
 		REFRESH_FAILED_REASON text DEFAULT NULL,
-		PRIMARY KEY(REFRESH_JOB_ID))`
+		PRIMARY KEY(REFRESH_JOB_ID),
+		KEY idx_mview_status (MVIEW_ID, REFRESH_STATUS, REFRESH_TIME),
+		KEY idx_refresh_status (REFRESH_STATUS, REFRESH_TIME))`
 
 	// CreateTiDBMLogPurgeHistTable is a table to store mlog purge history.
 	CreateTiDBMLogPurgeHistTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mlog_purge_hist (
@@ -799,7 +801,9 @@ const (
 		PURGE_ROWS bigint NOT NULL,
 		PURGE_STATUS varchar(16) DEFAULT NULL,
 		PURGE_FAILED_REASON text DEFAULT NULL,
-		PRIMARY KEY(PURGE_JOB_ID))`
+		PRIMARY KEY(PURGE_JOB_ID),
+		KEY idx_mlog_status (MLOG_ID, PURGE_STATUS, PURGE_TIME),
+		KEY idx_purge_status (PURGE_STATUS, PURGE_TIME))`
 )
 
 // CreateTimers is a table to store all timers for tidb

--- a/pkg/session/bootstraptest/mview_systable_test.go
+++ b/pkg/session/bootstraptest/mview_systable_test.go
@@ -49,6 +49,10 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='PRIMARY' order by seq_in_index").
 		Check(testkit.Rows("refresh_job_id"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_mview_status' order by seq_in_index").
+		Check(testkit.Rows("mview_id", "refresh_status", "refresh_time"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_refresh_status' order by seq_in_index").
+		Check(testkit.Rows("refresh_status", "refresh_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' order by ordinal_position limit 1").
 		Check(testkit.Rows("refresh_job_id"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_JOB_ID'").
@@ -59,6 +63,10 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 		Check(testkit.Rows("6", "6"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='PRIMARY' order by seq_in_index").
 		Check(testkit.Rows("purge_job_id"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='idx_mlog_status' order by seq_in_index").
+		Check(testkit.Rows("mlog_id", "purge_status", "purge_time"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='idx_purge_status' order by seq_in_index").
+		Check(testkit.Rows("purge_status", "purge_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' order by ordinal_position limit 1").
 		Check(testkit.Rows("purge_job_id"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='PURGE_JOB_ID'").

--- a/pkg/session/test/variable/BUILD.bazel
+++ b/pkg/session/test/variable/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "variable_test.go",
     ],
     flaky = True,
-    shard_count = 10,
+    shard_count = 11,
     deps = [
         "//pkg/config",
         "//pkg/kv",

--- a/pkg/session/test/variable/variable_test.go
+++ b/pkg/session/test/variable/variable_test.go
@@ -75,6 +75,18 @@ func TestMVMaintainMemQuota(t *testing.T) {
 	tk2.MustQuery("select @@tidb_mv_maintain_mem_quota").Check(testkit.Rows("3221225472"))
 }
 
+func TestMViewMaintainImportDiskQuota(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustQuery("select @@tidb_mview_maintain_import_disk_quota").Check(testkit.Rows(""))
+
+	tk.MustExec("set @@session.tidb_mview_maintain_import_disk_quota = '100gib'")
+	tk.MustQuery("select @@tidb_mview_maintain_import_disk_quota").Check(testkit.Rows("100gib"))
+
+	tk.MustGetErrMsg("set @@session.tidb_mview_maintain_import_disk_quota = 'bad'", "[variable:1231]Variable 'tidb_mview_maintain_import_disk_quota' can't be set to the value of 'bad'")
+}
+
 func TestCoprocessorOOMAction(t *testing.T) {
 	// Assert Coprocessor OOMAction
 	store := testkit.CreateMockStore(t)

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1532,8 +1532,10 @@ type SessionVars struct {
 	// InMaterializedViewMaintenance indicates the session is executing internal MV refresh / MV log purge statements.
 	// When enabled, TiFlash can be considered for the SELECT part of non-readonly statements even if sql_mode is strict.
 	InMaterializedViewMaintenance bool
-	// CreateMViewImportThreads controls the thread count for MV initial build IMPORT INTO.
-	CreateMViewImportThreads int
+	// MViewMaintainImportThreads controls the thread count for MV initial build IMPORT INTO.
+	MViewMaintainImportThreads int
+	// MViewMaintainImportDiskQuota controls the disk quota for MV initial build IMPORT INTO.
+	MViewMaintainImportDiskQuota string
 
 	// EnableUnsafeSubstitute indicates whether to enable generate column takes unsafe substitute.
 	EnableUnsafeSubstitute bool
@@ -2263,7 +2265,8 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		DefaultCollationForUTF8MB4:    mysql.DefaultCollationName,
 		GroupConcatMaxLen:             DefGroupConcatMaxLen,
 		EnableRedactLog:               DefTiDBRedactLog,
-		CreateMViewImportThreads:      DefTiDBCreateMViewImportThreads,
+		MViewMaintainImportThreads:    DefTiDBMViewMaintainImportThreads,
+		MViewMaintainImportDiskQuota:  DefTiDBMViewMaintainImportDiskQuota,
 		EnableWindowFunction:          DefEnableWindowFunction,
 		OptOrderingIdxSelRatio:        DefTiDBOptOrderingIdxSelRatio,
 		CostModelVersion:              DefTiDBCostModelVer,

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1532,6 +1532,8 @@ type SessionVars struct {
 	// InMaterializedViewMaintenance indicates the session is executing internal MV refresh / MV log purge statements.
 	// When enabled, TiFlash can be considered for the SELECT part of non-readonly statements even if sql_mode is strict.
 	InMaterializedViewMaintenance bool
+	// CreateMViewImportThreads controls the thread count for MV initial build IMPORT INTO.
+	CreateMViewImportThreads int
 
 	// EnableUnsafeSubstitute indicates whether to enable generate column takes unsafe substitute.
 	EnableUnsafeSubstitute bool
@@ -2261,6 +2263,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		DefaultCollationForUTF8MB4:    mysql.DefaultCollationName,
 		GroupConcatMaxLen:             DefGroupConcatMaxLen,
 		EnableRedactLog:               DefTiDBRedactLog,
+		CreateMViewImportThreads:      DefTiDBCreateMViewImportThreads,
 		EnableWindowFunction:          DefEnableWindowFunction,
 		OptOrderingIdxSelRatio:        DefTiDBOptOrderingIdxSelRatio,
 		CostModelVersion:              DefTiDBCostModelVer,

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2768,6 +2768,10 @@ var defaultSysVars = []*SysVar{
 		}
 		return nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBCreateMViewImportThreads, Value: strconv.Itoa(DefTiDBCreateMViewImportThreads), Type: TypeInt, MinValue: 0, MaxValue: MaxConfigurableConcurrency, SetSession: func(s *SessionVars, val string) error {
+		s.CreateMViewImportThreads = TidbOptInt(val, DefTiDBCreateMViewImportThreads)
+		return nil
+	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBNonTransactionalIgnoreError, Value: BoolToOnOff(DefTiDBBatchDMLIgnoreError), Type: TypeBool,
 		SetSession: func(s *SessionVars, val string) error {
 			s.NonTransactionalIgnoreError = TiDBOptOn(val)

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2718,6 +2718,23 @@ var defaultSysVars = []*SysVar{
 		}
 		return normalizedValue, nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBMViewMaintainImportThreads, Value: strconv.Itoa(DefTiDBMViewMaintainImportThreads), Type: TypeInt, MinValue: 0, MaxValue: MaxConfigurableConcurrency, SetSession: func(s *SessionVars, val string) error {
+		s.MViewMaintainImportThreads = TidbOptInt(val, DefTiDBMViewMaintainImportThreads)
+		return nil
+	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBMViewMaintainImportDiskQuota, Value: DefTiDBMViewMaintainImportDiskQuota, Type: TypeStr, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
+		if normalizedValue == "" {
+			return normalizedValue, nil
+		}
+		byteSize, err := units.RAMInBytes(normalizedValue)
+		if err != nil || byteSize <= 0 {
+			return "", ErrWrongValueForVar.GenWithStackByArgs(TiDBMViewMaintainImportDiskQuota, originalValue)
+		}
+		return normalizedValue, nil
+	}, SetSession: func(s *SessionVars, val string) error {
+		s.MViewMaintainImportDiskQuota = val
+		return nil
+	}},
 	{Scope: ScopeGlobal, Name: TiDBMViewTaskMax, Value: strconv.Itoa(DefTiDBMViewTaskMax), Type: TypeInt, MinValue: 0, MaxValue: 256, SetGlobal: func(_ context.Context, _ *SessionVars, s string) error {
 		val, err := strconv.Atoi(s)
 		if err != nil {
@@ -2766,10 +2783,6 @@ var defaultSysVars = []*SysVar{
 		if setter := SetMVServiceMLogPurgeHistRetention.Load(); setter != nil {
 			(*setter)(time.Duration(val) * time.Hour)
 		}
-		return nil
-	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBCreateMViewImportThreads, Value: strconv.Itoa(DefTiDBCreateMViewImportThreads), Type: TypeInt, MinValue: 0, MaxValue: MaxConfigurableConcurrency, SetSession: func(s *SessionVars, val string) error {
-		s.CreateMViewImportThreads = TidbOptInt(val, DefTiDBCreateMViewImportThreads)
 		return nil
 	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBNonTransactionalIgnoreError, Value: BoolToOnOff(DefTiDBBatchDMLIgnoreError), Type: TypeBool,

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -156,6 +156,8 @@ const (
 	TiDBMViewRefreshHistTime = "tidb_mview_refresh_hist_time"
 	// TiDBMLogPurgeHistTime controls the retention time of mysql.tidb_mlog_purge_hist in hours.
 	TiDBMLogPurgeHistTime = "tidb_mlog_purge_hist_time"
+	// TiDBCreateMViewImportThreads controls the thread count for MV initial build IMPORT INTO.
+	TiDBCreateMViewImportThreads = "tidb_create_mview_import_threads"
 	// TiDBMemQuotaApplyCache controls the memory quota of a query.
 	TiDBMemQuotaApplyCache = "tidb_mem_quota_apply_cache"
 
@@ -1496,6 +1498,7 @@ const (
 	DefTiDBMViewTaskThresholdMemory                   = 0.8
 	DefTiDBMViewRefreshHistTime                       = 168
 	DefTiDBMLogPurgeHistTime                          = 168
+	DefTiDBCreateMViewImportThreads                   = 0
 	DefTiDBStatsCacheMemQuota                         = 0
 	MaxTiDBStatsCacheMemQuota                         = 1024 * 1024 * 1024 * 1024 // 1TB
 	DefTiDBQueryLogMaxLen                             = 4096

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -146,6 +146,10 @@ const (
 	TiDBMemQuotaQuery = "tidb_mem_quota_query" // Bytes.
 	// TiDBMVMaintainMemQuota controls the memory quota used by MV refresh / MV log purge internal maintenance sessions.
 	TiDBMVMaintainMemQuota = "tidb_mv_maintain_mem_quota" // Bytes.
+	// TiDBMViewMaintainImportThreads controls the thread count for MV initial build IMPORT INTO.
+	TiDBMViewMaintainImportThreads = "tidb_mview_maintain_import_threads"
+	// TiDBMViewMaintainImportDiskQuota controls the disk quota for MV initial build IMPORT INTO.
+	TiDBMViewMaintainImportDiskQuota = "tidb_mview_maintain_import_disk_quota"
 	// TiDBMViewTaskMax controls the max concurrency of MV background tasks. 0 means using GOMAXPROCS.
 	TiDBMViewTaskMax = "tidb_mview_task_max"
 	// TiDBMViewTaskThresholdCPU controls MV task backpressure CPU threshold.
@@ -156,8 +160,6 @@ const (
 	TiDBMViewRefreshHistTime = "tidb_mview_refresh_hist_time"
 	// TiDBMLogPurgeHistTime controls the retention time of mysql.tidb_mlog_purge_hist in hours.
 	TiDBMLogPurgeHistTime = "tidb_mlog_purge_hist_time"
-	// TiDBCreateMViewImportThreads controls the thread count for MV initial build IMPORT INTO.
-	TiDBCreateMViewImportThreads = "tidb_create_mview_import_threads"
 	// TiDBMemQuotaApplyCache controls the memory quota of a query.
 	TiDBMemQuotaApplyCache = "tidb_mem_quota_apply_cache"
 
@@ -1493,12 +1495,13 @@ const (
 	DefTiDBEnableBatchDML                             = false
 	DefTiDBMemQuotaQuery                              = memory.DefMemQuotaQuery // 1GB
 	DefTiDBMVMaintainMemQuota                         = int64(2 * size.GB)
+	DefTiDBMViewMaintainImportThreads                 = 0
+	DefTiDBMViewMaintainImportDiskQuota               = ""
 	DefTiDBMViewTaskMax                               = 0
 	DefTiDBMViewTaskThresholdCPU                      = 0.8
 	DefTiDBMViewTaskThresholdMemory                   = 0.8
 	DefTiDBMViewRefreshHistTime                       = 168
 	DefTiDBMLogPurgeHistTime                          = 168
-	DefTiDBCreateMViewImportThreads                   = 0
 	DefTiDBStatsCacheMemQuota                         = 0
 	MaxTiDBStatsCacheMemQuota                         = 1024 * 1024 * 1024 * 1024 // 1TB
 	DefTiDBQueryLogMaxLen                             = 4096


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:

- backport a set of materialized view fixes required by the release-8.5 materialized view branch
- the branch now includes metadata, executor, bootstrap, and session variable changes beyond the original MV dependency cleanup scope

### What changed and how does it work?

- generalize MV dependency metadata so one MV can reference multiple base tables and one base table can be referenced by multiple MVs at the metadata layer
- clean MV and materialized view log metadata automatically when dropping a schema
- add MV maintain import-related system variables and thread configuration
- keep TiFlash in CREATE MATERIALIZED VIEW compile
- adjust purge SQL for materialized view log deletion
- add status indexes for MV refresh history

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Manual test steps:

- `make bazel_prepare`
- `make bazel_lint_changed`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```