### PR TITLE
planner: build sequence for set-op CTEs

### DIFF
--- a/pkg/planner/core/casetest/enforcempp/enforce_mpp_test.go
+++ b/pkg/planner/core/casetest/enforcempp/enforce_mpp_test.go
@@ -635,39 +635,6 @@ func TestMPPSharedCTEScan(t *testing.T) {
 		checkEnforceMPPPlanRows(t, res, output[i].Plan, tt)
 		require.Equal(t, output[i].Warn, testdata.ConvertSQLWarnToStrings(tk.Session().GetSessionVars().StmtCtx.GetWarnings()))
 	}
-
-	issue61242Plan := strings.Join(testdata.ConvertRowsToStrings(tk.MustQuery(`
-explain format = 'plan_tree' with cte1 as (
-  select
-    p_partkey,
-    substring(p_comment, 1, 20) as col0,
-    substring(p_comment, 18, 10) as col1,
-    substring(p_name, p_size % 10, 6) as col2
-  from part
-)
-select /* issue:61242 */
-  t3.col0,
-  t3.col1
-from (
-  select
-    t1.p_partkey as col0,
-    t1.col0 as col1
-  from cte1 t1
-  join cte1 t2 on t1.col0 = t2.col1
-) as t3
-join (
-  select
-    orders.o_orderkey as col0
-  from cte1 as t4
-  join orders on t4.col2 = substring(orders.o_comment, 1, 6)
-) as t5 on t3.col0 = t5.col0
-`).Rows()), "\n")
-	require.Contains(t, issue61242Plan, "Sequence mpp[tiflash]")
-	require.Contains(t, issue61242Plan, "CTE_0 mpp[tiflash]  Non-Recursive CTE Storage")
-	require.Contains(t, issue61242Plan, "CTEFullScan mpp[tiflash] CTE:cte1 AS t4 data:CTE_0")
-	require.NotContains(t, issue61242Plan, "CTEFullScan root")
-	require.NotContains(t, issue61242Plan, "CTE_0 root")
-	require.Empty(t, testdata.ConvertSQLWarnToStrings(tk.Session().GetSessionVars().StmtCtx.GetWarnings()))
 }
 
 func TestRollupMPP(t *testing.T) {

--- a/pkg/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_in.json
+++ b/pkg/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_in.json
@@ -201,7 +201,11 @@
       // A little change that the inner WITH statement references the outer's c1.
       "explain format = 'plan_tree' with c1 as (select * from t), c2 as (select c1.* from c1, c1 c2 where c1.b=c2.c) select * from c2 c1, c2, (with c3 as (select * from c1) select c3.* from c3, c3 c4 where c3.c=c4.b) c3 where c1.a=c2.b and c1.a=c3.a",
       // The outer one will fail to use MPP. Since the inner one is references the outer one, the whole SQL cannot MPP.
-      "explain format = 'plan_tree' with c1 as (select /*+ read_from_storage(tikv[t]) */ * from t), c2 as (select c1.* from c1, c1 c2 where c1.b=c2.c) select * from c2 c1, c2, (with c3 as (select * from c1) select c3.* from c3, c3 c4 where c3.c=c4.b) c3 where c1.a=c2.b and c1.a=c3.a"
+      "explain format = 'plan_tree' with c1 as (select /*+ read_from_storage(tikv[t]) */ * from t), c2 as (select c1.* from c1, c1 c2 where c1.b=c2.c) select * from c2 c1, c2, (with c3 as (select * from c1) select c3.* from c3, c3 c4 where c3.c=c4.b) c3 where c1.a=c2.b and c1.a=c3.a",
+      // issue #61242: shared CTE with multiple join consumers should keep the CTE storage and consumers in MPP.
+      "explain format = 'plan_tree' with cte1 as (select p_partkey, substring(p_comment, 1, 20) as col0, substring(p_comment, 18, 10) as col1, substring(p_name, p_size % 10, 6) as col2 from part) select t3.col0, t3.col1 from (select t1.p_partkey as col0, t1.col0 as col1 from cte1 t1 join cte1 t2 on t1.col0 = t2.col1) as t3 join (select orders.o_orderkey as col0 from cte1 as t4 join orders on t4.col2 = substring(orders.o_comment, 1, 6)) as t5 on t3.col0 = t5.col0",
+      // issue #61682: shared CTE under top-level set operations should keep window and CTE consumers in MPP.
+      "explain format = 'plan_tree' with cte1 as (select a, row_number() over (partition by b order by c) as rn from t) select a, rn from cte1 union all select a, rn from cte1"
     ]
   },
   {

--- a/pkg/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_out.json
+++ b/pkg/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_out.json
@@ -2022,6 +2022,56 @@
         "Warn": [
           "MPP mode may be blocked because you have set a hint to read table `t` from TiKV."
         ]
+      },
+      {
+        "SQL": "explain format = 'plan_tree' with cte1 as (select p_partkey, substring(p_comment, 1, 20) as col0, substring(p_comment, 18, 10) as col1, substring(p_name, p_size % 10, 6) as col2 from part) select t3.col0, t3.col1 from (select t1.p_partkey as col0, t1.col0 as col1 from cte1 t1 join cte1 t2 on t1.col0 = t2.col1) as t3 join (select orders.o_orderkey as col0 from cte1 as t4 join orders on t4.col2 = substring(orders.o_comment, 1, 6)) as t5 on t3.col0 = t5.col0",
+        "Plan": [
+          "TableReader root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Sequence mpp[tiflash]  Sequence Node",
+          "    ├─CTE_0 mpp[tiflash]  Non-Recursive CTE Storage",
+          "    │ └─Projection mpp[tiflash]  test.part.p_partkey, substring(test.part.p_comment, 1, 20)->Column, substring(test.part.p_comment, 18, 10)->Column, substring(test.part.p_name, mod(test.part.p_size, 10), 6)->Column",
+          "    │   └─TableFullScan mpp[tiflash] table:part keep order:false, stats:pseudo",
+          "    └─Projection mpp[tiflash]  test.part.p_partkey, Column",
+          "      └─HashJoin mpp[tiflash]  inner join, equal:[eq(Column, Column)]",
+          "        ├─ExchangeReceiver(Build) mpp[tiflash]  ",
+          "        │ └─ExchangeSender mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
+          "        │   └─CTEFullScan mpp[tiflash] CTE:cte1 AS t4 data:CTE_0",
+          "        └─Projection(Probe) mpp[tiflash]  test.part.p_partkey, Column, Column",
+          "          └─HashJoin mpp[tiflash]  inner join, equal:[eq(test.part.p_partkey, test.orders.o_orderkey)]",
+          "            ├─ExchangeReceiver(Build) mpp[tiflash]  ",
+          "            │ └─ExchangeSender mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
+          "            │   └─Projection mpp[tiflash]  test.part.p_partkey, Column",
+          "            │     └─HashJoin mpp[tiflash]  inner join, equal:[eq(Column, Column)]",
+          "            │       ├─ExchangeReceiver(Build) mpp[tiflash]  ",
+          "            │       │ └─ExchangeSender mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
+          "            │       │   └─Selection mpp[tiflash]  not(isnull(Column)), not(isnull(test.part.p_partkey))",
+          "            │       │     └─CTEFullScan mpp[tiflash] CTE:cte1 AS t1 data:CTE_0",
+          "            │       └─Selection(Probe) mpp[tiflash]  not(isnull(Column))",
+          "            │         └─CTEFullScan mpp[tiflash] CTE:cte1 AS t2 data:CTE_0",
+          "            └─Projection(Probe) mpp[tiflash]  test.orders.o_orderkey, substring(test.orders.o_comment, 1, 6)->Column",
+          "              └─TableFullScan mpp[tiflash] table:orders keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "explain format = 'plan_tree' with cte1 as (select a, row_number() over (partition by b order by c) as rn from t) select a, rn from cte1 union all select a, rn from cte1",
+        "Plan": [
+          "TableReader root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Sequence mpp[tiflash]  Sequence Node",
+          "    ├─CTE_0 mpp[tiflash]  Non-Recursive CTE Storage",
+          "    │ └─Projection mpp[tiflash]  test.t.a, Column, stream_count: 8",
+          "    │   └─Window mpp[tiflash]  row_number()->Column over(partition by test.t.b order by test.t.c rows between current row and current row), stream_count: 8",
+          "    │     └─Sort mpp[tiflash]  test.t.b, test.t.c, stream_count: 8",
+          "    │       └─ExchangeReceiver mpp[tiflash]  stream_count: 8",
+          "    │         └─ExchangeSender mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t.b, collate: binary], stream_count: 8",
+          "    │           └─TableFullScan mpp[tiflash] table:t keep order:false, stats:pseudo",
+          "    └─Union mpp[tiflash]  ",
+          "      ├─CTEFullScan mpp[tiflash] CTE:cte1 data:CTE_0",
+          "      └─CTEFullScan mpp[tiflash] CTE:cte1 data:CTE_0"
+        ],
+        "Warn": null
       }
     ]
   },

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -2106,12 +2106,14 @@ func (b *PlanBuilder) buildProjection4Union(_ context.Context, u *logicalop.Logi
 }
 
 func (b *PlanBuilder) buildSetOpr(ctx context.Context, setOpr *ast.SetOprStmt) (base.LogicalPlan, error) {
+	var currentLayerCTEs []*cteInfo
 	if setOpr.With != nil {
 		l := len(b.outerCTEs)
 		defer func() {
 			b.outerCTEs = b.outerCTEs[:l]
 		}()
-		_, err := b.buildWith(ctx, setOpr.With)
+		var err error
+		currentLayerCTEs, err = b.buildWith(ctx, setOpr.With)
 		if err != nil {
 			return nil, err
 		}
@@ -2191,9 +2193,9 @@ func (b *PlanBuilder) buildSetOpr(ctx context.Context, setOpr *ast.SetOprStmt) (
 		}
 		proj.SetOutputNames(setOprPlan.OutputNames()[:oldLen])
 		proj.SetSchema(schema)
-		return proj, nil
+		return b.tryToBuildSequence(currentLayerCTEs, proj), nil
 	}
-	return setOprPlan, nil
+	return b.tryToBuildSequence(currentLayerCTEs, setOprPlan), nil
 }
 
 func (b *PlanBuilder) buildSemiJoinForSetOperator(


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61682

Problem Summary:

Shared CTE consumers under a top-level `WITH ... UNION ALL ...` plan could stay in root even when the CTE producer and window computation were eligible for TiFlash MPP.

### What changed and how does it work?

This PR adds a regression for the issue #61682 plan shape and updates `buildSetOpr` to keep the current-layer CTEs returned by `buildWith`.

For set operation statements with a top-level `WITH`, the final set-op plan is now wrapped with `tryToBuildSequence`, matching the existing `buildSelect` behavior. This lets the shared CTE producer status flow through `LogicalSequence`, so eligible `CTEFullScan` consumers can be planned as MPP tasks instead of falling back to root.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `go test -tags=intest,deadlock ./pkg/planner/core/casetest/enforcempp -run TestMPPSharedCTEScan -count=1`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that shared CTE consumers under top-level set operations could not be pushed down to TiFlash MPP when the CTE contains window functions.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared CTE execution in distributed (MPP) queries so CTEs behave correctly with multiple consumers and when used with set operations.

* **Tests**
  * Added new test cases covering shared CTEs with multiple joins and with top-level set operations to validate MPP behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->