### PR TITLE
sessionctx: avoid restoring ROW_COUNT as affected rows

### DIFF
--- a/pkg/executor/select.go
+++ b/pkg/executor/select.go
@@ -1228,7 +1228,9 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	}
 	sc.LastInsertIDSet = false
 	sc.PrevAffectedRows = 0
-	if vars.StmtCtx.InUpdateStmt || vars.StmtCtx.InDeleteStmt || vars.StmtCtx.InInsertStmt || vars.StmtCtx.InSetSessionStatesStmt {
+	if vars.StmtCtx.InSetSessionStatesStmt {
+		sc.PrevAffectedRows = vars.StmtCtx.PrevAffectedRows
+	} else if vars.StmtCtx.InUpdateStmt || vars.StmtCtx.InDeleteStmt || vars.StmtCtx.InInsertStmt {
 		sc.PrevAffectedRows = int64(vars.StmtCtx.AffectedRows())
 	} else if vars.StmtCtx.InSelectStmt {
 		sc.PrevAffectedRows = -1

--- a/pkg/sessionctx/sessionstates/session_states_test.go
+++ b/pkg/sessionctx/sessionstates/session_states_test.go
@@ -712,6 +712,7 @@ func TestStatementCtx(t *testing.T) {
 				return nil
 			},
 			checkFunc: func(tk *testkit.TestKit, param any) {
+				require.Equal(t, uint64(0), tk.Session().AffectedRows())
 				tk.MustQuery("select row_count()").Check(testkit.Rows("-1"))
 			},
 		},

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -3237,7 +3237,7 @@ func (s *SessionVars) DecodeSessionStates(_ context.Context, sessionStates *sess
 	s.HypoTiFlashReplicas = sessionStates.HypoTiFlashReplicas
 
 	// Decode StatementContext.
-	s.StmtCtx.SetAffectedRows(uint64(sessionStates.LastAffectedRows))
+	s.StmtCtx.PrevAffectedRows = sessionStates.LastAffectedRows
 	s.StmtCtx.PrevLastInsertID = sessionStates.LastInsertID
 	s.StmtCtx.SetWarnings(sessionStates.Warnings)
 	return


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68865

Problem Summary:

`SET SESSION_STATES` restored `LastAffectedRows` through `StmtCtx.SetAffectedRows(uint64(...))`. When the migrated previous statement was a `SELECT`, `ROW_COUNT()` semantics store `LastAffectedRows` as `-1`, so the conversion produced `math.MaxUint64` as the current statement affected rows. This could pollute statement summary / statementlog fields such as `sum_affected_rows`.

### What changed and how does it work?

Restore migrated `LastAffectedRows` into `StmtCtx.PrevAffectedRows` instead of the current statement affected rows.

When the next statement starts after `SET SESSION_STATES`, preserve that restored `PrevAffectedRows` value so `ROW_COUNT()` keeps the migrated semantics. `SET SESSION_STATES` itself now keeps current affected rows at `0`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed an issue that SET SESSION_STATES could restore ROW_COUNT() from a previous SELECT as the current statement affected rows, causing affected-row metrics and statement summary records to report 18446744073709551615.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved affected rows tracking in session state management to ensure more accurate row count reporting across various SQL operations.
  * Refined calculation and application of previous affected rows values for different SQL statement types (SET SESSION, UPDATE, DELETE, INSERT, SELECT).
  * Enhanced session state restoration mechanism to correctly preserve and retrieve affected rows information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->