### PR TITLE
executor, execdetails: pre-resolve hot L1 RUv2 recorders

### DIFF
--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -149,9 +149,9 @@ func ruv2ExecutorMetricByType(execType string) (ruv2ExecutorMetric, bool) {
 // single check.
 type ruv2NextCacheState struct {
 	metrics    *execdetails.RUV2Metrics
+	recorder   execdetails.ExecutorMetricRecorder
 	regionName string
 	info       ruv2ExecutorMetric
-	recorder   execdetails.ExecutorMetricRecorder
 	hasInfo    bool
 }
 

--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -151,6 +151,7 @@ type ruv2NextCacheState struct {
 	metrics    *execdetails.RUV2Metrics
 	regionName string
 	info       ruv2ExecutorMetric
+	recorder   execdetails.ExecutorMetricRecorder
 	hasInfo    bool
 }
 
@@ -163,6 +164,7 @@ func populateRUV2NextCache(ctx context.Context, cache *ruv2NextCacheState, e Exe
 	cache.regionName = execType + ".Next"
 	cache.info, cache.hasInfo = ruv2ExecutorMetricByType(execType)
 	cache.metrics = nil
+	cache.recorder = execdetails.ExecutorMetricRecorder{}
 	if !cache.hasInfo {
 		return
 	}
@@ -171,9 +173,10 @@ func populateRUV2NextCache(ctx context.Context, cache *ruv2NextCacheState, e Exe
 		return
 	}
 	cache.metrics = metrics
+	cache.recorder = execdetails.ResolveExecutorMetric(cache.info.level, cache.info.label)
 }
 
-func addRUV2ExecutorMetricCached(metrics *execdetails.RUV2Metrics, info ruv2ExecutorMetric, inRows, outRows, inCells, outCells int64) {
+func addRUV2ExecutorMetricCached(metrics *execdetails.RUV2Metrics, info ruv2ExecutorMetric, recorder execdetails.ExecutorMetricRecorder, inRows, outRows, inCells, outCells int64) {
 	if metrics == nil {
 		return
 	}
@@ -182,6 +185,10 @@ func addRUV2ExecutorMetricCached(metrics *execdetails.RUV2Metrics, info ruv2Exec
 		delta = inCells + outCells
 	}
 	if delta == 0 {
+		return
+	}
+	if recorder.Available() {
+		recorder.Record(metrics, delta)
 		return
 	}
 	metrics.AddExecutorMetric(info.level, info.label, delta)
@@ -620,6 +627,7 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 		info        ruv2ExecutorMetric
 		trackRUV2   bool
 		ruv2Metrics *execdetails.RUV2Metrics
+		recorder    execdetails.ExecutorMetricRecorder
 	)
 	if provider, ok := e.(ruv2CacheProvider); ok {
 		cache := provider.ruv2NextCache()
@@ -629,6 +637,7 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 		regionName = cache.regionName
 		info = cache.info
 		ruv2Metrics = cache.metrics
+		recorder = cache.recorder
 	} else {
 		execType := reflect.TypeOf(e).String()
 		regionName = execType + ".Next"
@@ -636,6 +645,7 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 		if info, hasInfo = ruv2ExecutorMetricByType(execType); hasInfo {
 			if m := execdetails.RUV2MetricsFromContext(ctx); m != nil && !m.Bypass() {
 				ruv2Metrics = m
+				recorder = execdetails.ResolveExecutorMetric(info.level, info.label)
 			}
 		}
 	}
@@ -687,7 +697,7 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 		inCells = stdatomic.LoadInt64(&myAcc.inCells)
 	}
 	outCells := calcCellCount(outRows, outCols)
-	addRUV2ExecutorMetricCached(ruv2Metrics, info, inRows, int64(outRows), inCells, outCells)
+	addRUV2ExecutorMetricCached(ruv2Metrics, info, recorder, inRows, int64(outRows), inCells, outCells)
 	// recheck whether the session/query is killed during the Next()
 	return e.HandleSQLKillerSignal()
 }

--- a/pkg/util/execdetails/BUILD.bazel
+++ b/pkg/util/execdetails/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "@com_github_pingcap_kvproto//pkg/kvrpcpb",
         "@com_github_pingcap_kvproto//pkg/resource_manager",
         "@com_github_pingcap_tipb//go-tipb",
+        "@com_github_prometheus_client_golang//prometheus",
         "@com_github_tikv_client_go_v2//util",
         "@com_github_tikv_pd_client//resource_group/controller",
         "@org_uber_go_zap//:zap",

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -565,6 +565,35 @@ func TestUpdateRUV2MetricsFromRUV2Bypass(t *testing.T) {
 	require.Zero(t, metrics.TiKVStorageProcessedKeysBatchGet())
 }
 
+func TestExecutorMetricRecorderFastPath(t *testing.T) {
+	for _, label := range []string{
+		ruv2LabelBatchPointGetExec,
+		ruv2LabelPointGetExecutor,
+		ruv2LabelLimitExec,
+	} {
+		require.True(t, ResolveExecutorMetric(1, label).Available(), label)
+	}
+
+	require.False(t, ResolveExecutorMetric(1, "Unknown").Available())
+	require.False(t, ResolveExecutorMetric(2, "HashAggExec").Available())
+	require.False(t, ResolveExecutorMetric(3, "SortExec").Available())
+	require.False(t, ResolveExecutorMetric(0, ruv2LabelBatchPointGetExec).Available())
+
+	var zero ExecutorMetricRecorder
+	require.False(t, zero.Available())
+
+	fast := NewRUV2Metrics()
+	slow := NewRUV2Metrics()
+	ResolveExecutorMetric(1, ruv2LabelBatchPointGetExec).Record(fast, 7)
+	ResolveExecutorMetric(1, ruv2LabelPointGetExecutor).Record(fast, 3)
+	ResolveExecutorMetric(1, ruv2LabelLimitExec).Record(fast, 5)
+	slow.AddExecutorMetric(1, ruv2LabelBatchPointGetExec, 7)
+	slow.AddExecutorMetric(1, ruv2LabelPointGetExecutor, 3)
+	slow.AddExecutorMetric(1, ruv2LabelLimitExec, 5)
+
+	require.Equal(t, slow.executorL1.snapshot(), fast.executorL1.snapshot())
+}
+
 func TestFormatRUV2MetricsIncludesRUValuesFirst(t *testing.T) {
 	weights := defaultRUV2WeightsForTest()
 	metrics := NewRUV2Metrics()

--- a/pkg/util/execdetails/ruv2_metrics.go
+++ b/pkg/util/execdetails/ruv2_metrics.go
@@ -70,56 +70,70 @@ func RUV2MetricsFromContext(ctx context.Context) *RUV2Metrics {
 }
 
 // UpdateRUV2MetricsFromRUV2 adds raw RUv2 counters into the statement-level metrics snapshot.
-func UpdateRUV2MetricsFromRUV2(metrics *RUV2Metrics, ru *kvrpcpb.RUV2) {
-	if metrics == nil || ru == nil {
+func UpdateRUV2MetricsFromRUV2(m *RUV2Metrics, ru *kvrpcpb.RUV2) {
+	if m == nil || ru == nil || m.Bypass() {
 		return
 	}
-	if ru.ReadRpcCount != 0 {
-		metrics.AddResourceManagerReadCnt(int64(ru.ReadRpcCount))
+	m.applyRawCounters(ru)
+}
+
+// applyRawCounters writes ru into m. Caller must check Bypass.
+func (m *RUV2Metrics) applyRawCounters(ru *kvrpcpb.RUV2) {
+	if v := ru.ReadRpcCount; v != 0 {
+		metrics.RUV2ResourceManagerReadCnt.Add(float64(v))
+		atomic.AddInt64(&m.resourceManagerReadCnt, int64(v))
 	}
-	if ru.WriteRpcCount != 0 {
-		metrics.AddResourceManagerWriteCnt(int64(ru.WriteRpcCount))
+	if v := ru.KvEngineCacheMiss; v != 0 {
+		metrics.RUV2TiKVKVEngineCacheMiss.Add(float64(v))
+		atomic.AddInt64(&m.tikvKvEngineCacheMiss, int64(v))
 	}
-	if ru.KvEngineCacheMiss != 0 {
-		metrics.AddTiKVKVEngineCacheMiss(int64(ru.KvEngineCacheMiss))
+	if v := ru.StorageProcessedKeysBatchGet; v != 0 {
+		metrics.RUV2TiKVStorageProcessedKeysBatchGet.Add(float64(v))
+		atomic.AddInt64(&m.tikvStorageProcessedKeysBatchGet, int64(v))
 	}
-	if ru.CoprocessorExecutorIterations != 0 {
-		metrics.AddTiKVCoprocessorExecutorIterations(int64(ru.CoprocessorExecutorIterations))
+	if v := ru.StorageProcessedKeysGet; v != 0 {
+		metrics.RUV2TiKVStorageProcessedKeysGet.Add(float64(v))
+		atomic.AddInt64(&m.tikvStorageProcessedKeysGet, int64(v))
 	}
-	if ru.CoprocessorResponseBytes != 0 {
-		metrics.AddTiKVCoprocessorResponseBytes(int64(ru.CoprocessorResponseBytes))
+
+	var extra *ruv2MetricsExtra
+	ensureExtra := func() *ruv2MetricsExtra {
+		if extra == nil {
+			extra = m.ensureExtra()
+		}
+		return extra
 	}
-	if ru.RaftstoreStoreWriteTriggerWbBytes != 0 {
-		metrics.AddTiKVRaftstoreStoreWriteTriggerWB(int64(ru.RaftstoreStoreWriteTriggerWbBytes))
+	if v := ru.WriteRpcCount; v != 0 {
+		metrics.RUV2ResourceManagerWriteCnt.Add(float64(v))
+		atomic.AddInt64(&ensureExtra().resourceManagerWriteCnt, int64(v))
 	}
-	if ru.StorageProcessedKeysBatchGet != 0 {
-		metrics.AddTiKVStorageProcessedKeysBatchGet(int64(ru.StorageProcessedKeysBatchGet))
+	if v := ru.CoprocessorExecutorIterations; v != 0 {
+		metrics.RUV2TiKVCoprocessorExecutorIterations.Add(float64(v))
+		atomic.AddInt64(&ensureExtra().tikvCoprocessorExecutorIterations, int64(v))
 	}
-	if ru.StorageProcessedKeysGet != 0 {
-		metrics.AddTiKVStorageProcessedKeysGet(int64(ru.StorageProcessedKeysGet))
+	if v := ru.CoprocessorResponseBytes; v != 0 {
+		metrics.RUV2TiKVCoprocessorResponseBytes.Add(float64(v))
+		atomic.AddInt64(&ensureExtra().tikvCoprocessorResponseBytes, int64(v))
+	}
+	if v := ru.RaftstoreStoreWriteTriggerWbBytes; v != 0 {
+		metrics.RUV2TiKVRaftstoreStoreWriteTriggerWB.Add(float64(v))
+		atomic.AddInt64(&ensureExtra().tikvRaftstoreStoreWriteTriggerWB, int64(v))
 	}
 	if inputs := ru.ExecutorInputs; inputs != nil {
-		if inputs.TikvCoprocessorExecutorWorkTotalBatchIndexScan != 0 {
-			metrics.AddTiKVCoprocessorWorkTotal("BatchIndexScan", int64(inputs.TikvCoprocessorExecutorWorkTotalBatchIndexScan))
+		addWork := func(label string, v uint64) {
+			if v == 0 {
+				return
+			}
+			metrics.RUV2TiKVCoprocessorWorkTotalCounter(label).Add(float64(v))
+			addRUV2ExtraLabelCounter(&ensureExtra().tikvCoprocessorWorkTotal, label, int64(v))
 		}
-		if inputs.TikvCoprocessorExecutorWorkTotalBatchTableScan != 0 {
-			metrics.AddTiKVCoprocessorWorkTotal("BatchTableScan", int64(inputs.TikvCoprocessorExecutorWorkTotalBatchTableScan))
-		}
-		if inputs.TikvCoprocessorExecutorWorkTotalBatchSelection != 0 {
-			metrics.AddTiKVCoprocessorWorkTotal("BatchSelection", int64(inputs.TikvCoprocessorExecutorWorkTotalBatchSelection))
-		}
-		if inputs.TikvCoprocessorExecutorWorkTotalBatchTopN != 0 {
-			metrics.AddTiKVCoprocessorWorkTotal("BatchTopN", int64(inputs.TikvCoprocessorExecutorWorkTotalBatchTopN))
-		}
-		if inputs.TikvCoprocessorExecutorWorkTotalBatchLimit != 0 {
-			metrics.AddTiKVCoprocessorWorkTotal("BatchLimit", int64(inputs.TikvCoprocessorExecutorWorkTotalBatchLimit))
-		}
-		if inputs.TikvCoprocessorExecutorWorkTotalBatchSimpleAggr != 0 {
-			metrics.AddTiKVCoprocessorWorkTotal("BatchSimpleAggr", int64(inputs.TikvCoprocessorExecutorWorkTotalBatchSimpleAggr))
-		}
-		if inputs.TikvCoprocessorExecutorWorkTotalBatchFastHashAggr != 0 {
-			metrics.AddTiKVCoprocessorWorkTotal("BatchFastHashAggr", int64(inputs.TikvCoprocessorExecutorWorkTotalBatchFastHashAggr))
-		}
+		addWork("BatchIndexScan", inputs.TikvCoprocessorExecutorWorkTotalBatchIndexScan)
+		addWork("BatchTableScan", inputs.TikvCoprocessorExecutorWorkTotalBatchTableScan)
+		addWork("BatchSelection", inputs.TikvCoprocessorExecutorWorkTotalBatchSelection)
+		addWork("BatchTopN", inputs.TikvCoprocessorExecutorWorkTotalBatchTopN)
+		addWork("BatchLimit", inputs.TikvCoprocessorExecutorWorkTotalBatchLimit)
+		addWork("BatchSimpleAggr", inputs.TikvCoprocessorExecutorWorkTotalBatchSimpleAggr)
+		addWork("BatchFastHashAggr", inputs.TikvCoprocessorExecutorWorkTotalBatchFastHashAggr)
 	}
 }
 
@@ -230,6 +244,65 @@ func (m *RUV2Metrics) AddExecutorMetric(level int, label string, delta int64) {
 	case 3:
 		addRUV2ExtraLabelCounter(&m.ensureExtra().executorL3, label, delta)
 	}
+}
+
+// ExecutorMetricRecorder is a pre-resolved counter for one executor metric.
+// The zero value records nothing; callers must check Available before Record.
+type ExecutorMetricRecorder struct {
+	add func(m *RUV2Metrics, delta int64)
+}
+
+// Available reports whether this recorder was resolved.
+func (r ExecutorMetricRecorder) Available() bool { return r.add != nil }
+
+// Record applies delta. Caller must ensure m is non-nil and not bypassed.
+func (r ExecutorMetricRecorder) Record(m *RUV2Metrics, delta int64) { r.add(m, delta) }
+
+// ResolveExecutorMetric returns a pre-resolved recorder for hot L1 executor
+// labels, or the zero recorder for everything else.
+func ResolveExecutorMetric(level int, label string) ExecutorMetricRecorder {
+	ensureExecutorL1Recorders()
+	if level == 1 {
+		switch label {
+		case ruv2LabelBatchPointGetExec:
+			return execL1RecorderBatchPointGet
+		case ruv2LabelPointGetExecutor:
+			return execL1RecorderPointGet
+		case ruv2LabelLimitExec:
+			return execL1RecorderLimit
+		}
+	}
+	return ExecutorMetricRecorder{}
+}
+
+var (
+	execL1RecorderBatchPointGet ExecutorMetricRecorder
+	execL1RecorderPointGet      ExecutorMetricRecorder
+	execL1RecorderLimit         ExecutorMetricRecorder
+	executorL1RecordersOnce     sync.Once
+)
+
+func ensureExecutorL1Recorders() {
+	executorL1RecordersOnce.Do(func() {
+		if c := metrics.RUV2ExecutorCounter(1, ruv2LabelBatchPointGetExec); c != nil {
+			execL1RecorderBatchPointGet = ExecutorMetricRecorder{add: func(m *RUV2Metrics, d int64) {
+				c.Add(float64(d))
+				atomic.AddInt64(&m.executorL1.batchPointGetExec, d)
+			}}
+		}
+		if c := metrics.RUV2ExecutorCounter(1, ruv2LabelPointGetExecutor); c != nil {
+			execL1RecorderPointGet = ExecutorMetricRecorder{add: func(m *RUV2Metrics, d int64) {
+				c.Add(float64(d))
+				atomic.AddInt64(&m.executorL1.pointGetExecutor, d)
+			}}
+		}
+		if c := metrics.RUV2ExecutorCounter(1, ruv2LabelLimitExec); c != nil {
+			execL1RecorderLimit = ExecutorMetricRecorder{add: func(m *RUV2Metrics, d int64) {
+				c.Add(float64(d))
+				atomic.AddInt64(&m.executorL1.limitExec, d)
+			}}
+		}
+	})
 }
 
 // AddExecutorL5InsertRows records affected insert rows for RUv2 accounting.

--- a/pkg/util/execdetails/ruv2_metrics.go
+++ b/pkg/util/execdetails/ruv2_metrics.go
@@ -247,9 +247,7 @@ func (m *RUV2Metrics) AddExecutorMetric(level int, label string, delta int64) {
 	}
 }
 
-// execL1Kind identifies which RUV2Metrics.executorL1 scalar field a recorder
-// writes. The zero value (execL1None) means "not a hot L1 label", so callers
-// fall back to AddExecutorMetric. Keep this in sync with ruv2ExecutorL1Counter.add.
+// execL1Kind selects one of the hot L1 executor counter fields; execL1None means none.
 type execL1Kind uint8
 
 const (
@@ -259,10 +257,8 @@ const (
 	execL1Limit
 )
 
-// ExecutorMetricRecorder is a pre-resolved counter for one hot L1 executor
-// metric. It pairs the process-global Prometheus counter (resolved once) with
-// the per-RUV2Metrics scalar field selected at Record time. The zero value
-// records nothing; callers must check Available before Record.
+// ExecutorMetricRecorder is a pre-resolved counter for one hot L1 executor metric.
+// The zero value records nothing; callers must check Available before Record.
 type ExecutorMetricRecorder struct {
 	counter prometheus.Counter
 	kind    execL1Kind
@@ -274,33 +270,17 @@ func (r ExecutorMetricRecorder) Available() bool { return r.kind != execL1None }
 // Record applies delta. Caller must ensure m is non-nil and not bypassed.
 func (r ExecutorMetricRecorder) Record(m *RUV2Metrics, delta int64) {
 	r.counter.Add(float64(delta))
-	switch r.kind {
-	case execL1BatchPointGet:
-		atomic.AddInt64(&m.executorL1.batchPointGetExec, delta)
-	case execL1PointGet:
-		atomic.AddInt64(&m.executorL1.pointGetExecutor, delta)
-	case execL1Limit:
-		atomic.AddInt64(&m.executorL1.limitExec, delta)
-	}
+	atomic.AddInt64(m.executorL1.fieldByKind(r.kind), delta)
 }
 
 // ResolveExecutorMetric returns a pre-resolved recorder for hot L1 executor
-// labels, or the zero recorder for everything else. The Prometheus counter is
-// already cached by metrics.RUV2ExecutorCounter, so this is cheap to call from
-// Open() and needs no further memoization.
+// labels, or the zero recorder for everything else.
 func ResolveExecutorMetric(level int, label string) ExecutorMetricRecorder {
 	if level != 1 {
 		return ExecutorMetricRecorder{}
 	}
-	var kind execL1Kind
-	switch label {
-	case ruv2LabelBatchPointGetExec:
-		kind = execL1BatchPointGet
-	case ruv2LabelPointGetExecutor:
-		kind = execL1PointGet
-	case ruv2LabelLimitExec:
-		kind = execL1Limit
-	default:
+	kind := execL1KindForLabel(label)
+	if kind == execL1None {
 		return ExecutorMetricRecorder{}
 	}
 	c := metrics.RUV2ExecutorCounter(level, label)
@@ -308,6 +288,19 @@ func ResolveExecutorMetric(level int, label string) ExecutorMetricRecorder {
 		return ExecutorMetricRecorder{}
 	}
 	return ExecutorMetricRecorder{counter: c, kind: kind}
+}
+
+func execL1KindForLabel(label string) execL1Kind {
+	switch label {
+	case ruv2LabelBatchPointGetExec:
+		return execL1BatchPointGet
+	case ruv2LabelPointGetExecutor:
+		return execL1PointGet
+	case ruv2LabelLimitExec:
+		return execL1Limit
+	default:
+		return execL1None
+	}
 }
 
 // AddExecutorL5InsertRows records affected insert rows for RUv2 accounting.
@@ -476,16 +469,23 @@ type ruv2ExtraLabelCounter struct {
 }
 
 func (c *ruv2ExecutorL1Counter) add(label string, delta int64) {
-	switch label {
-	case ruv2LabelBatchPointGetExec:
-		atomic.AddInt64(&c.batchPointGetExec, delta)
-	case ruv2LabelPointGetExecutor:
-		atomic.AddInt64(&c.pointGetExecutor, delta)
-	case ruv2LabelLimitExec:
-		atomic.AddInt64(&c.limitExec, delta)
-	default:
-		addRUV2ExtraLabelCounter(&c.extra, label, delta)
+	if p := c.fieldByKind(execL1KindForLabel(label)); p != nil {
+		atomic.AddInt64(p, delta)
+		return
 	}
+	addRUV2ExtraLabelCounter(&c.extra, label, delta)
+}
+
+func (c *ruv2ExecutorL1Counter) fieldByKind(kind execL1Kind) *int64 {
+	switch kind {
+	case execL1BatchPointGet:
+		return &c.batchPointGetExec
+	case execL1PointGet:
+		return &c.pointGetExecutor
+	case execL1Limit:
+		return &c.limitExec
+	}
+	return nil
 }
 
 func (c *ruv2ExecutorL1Counter) snapshot() map[string]int64 {

--- a/pkg/util/execdetails/ruv2_metrics.go
+++ b/pkg/util/execdetails/ruv2_metrics.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	tikvutil "github.com/tikv/client-go/v2/util"
 )
 
@@ -246,63 +247,67 @@ func (m *RUV2Metrics) AddExecutorMetric(level int, label string, delta int64) {
 	}
 }
 
-// ExecutorMetricRecorder is a pre-resolved counter for one executor metric.
-// The zero value records nothing; callers must check Available before Record.
+// execL1Kind identifies which RUV2Metrics.executorL1 scalar field a recorder
+// writes. The zero value (execL1None) means "not a hot L1 label", so callers
+// fall back to AddExecutorMetric. Keep this in sync with ruv2ExecutorL1Counter.add.
+type execL1Kind uint8
+
+const (
+	execL1None execL1Kind = iota
+	execL1BatchPointGet
+	execL1PointGet
+	execL1Limit
+)
+
+// ExecutorMetricRecorder is a pre-resolved counter for one hot L1 executor
+// metric. It pairs the process-global Prometheus counter (resolved once) with
+// the per-RUV2Metrics scalar field selected at Record time. The zero value
+// records nothing; callers must check Available before Record.
 type ExecutorMetricRecorder struct {
-	add func(m *RUV2Metrics, delta int64)
+	counter prometheus.Counter
+	kind    execL1Kind
 }
 
 // Available reports whether this recorder was resolved.
-func (r ExecutorMetricRecorder) Available() bool { return r.add != nil }
+func (r ExecutorMetricRecorder) Available() bool { return r.kind != execL1None }
 
 // Record applies delta. Caller must ensure m is non-nil and not bypassed.
-func (r ExecutorMetricRecorder) Record(m *RUV2Metrics, delta int64) { r.add(m, delta) }
-
-// ResolveExecutorMetric returns a pre-resolved recorder for hot L1 executor
-// labels, or the zero recorder for everything else.
-func ResolveExecutorMetric(level int, label string) ExecutorMetricRecorder {
-	ensureExecutorL1Recorders()
-	if level == 1 {
-		switch label {
-		case ruv2LabelBatchPointGetExec:
-			return execL1RecorderBatchPointGet
-		case ruv2LabelPointGetExecutor:
-			return execL1RecorderPointGet
-		case ruv2LabelLimitExec:
-			return execL1RecorderLimit
-		}
+func (r ExecutorMetricRecorder) Record(m *RUV2Metrics, delta int64) {
+	r.counter.Add(float64(delta))
+	switch r.kind {
+	case execL1BatchPointGet:
+		atomic.AddInt64(&m.executorL1.batchPointGetExec, delta)
+	case execL1PointGet:
+		atomic.AddInt64(&m.executorL1.pointGetExecutor, delta)
+	case execL1Limit:
+		atomic.AddInt64(&m.executorL1.limitExec, delta)
 	}
-	return ExecutorMetricRecorder{}
 }
 
-var (
-	execL1RecorderBatchPointGet ExecutorMetricRecorder
-	execL1RecorderPointGet      ExecutorMetricRecorder
-	execL1RecorderLimit         ExecutorMetricRecorder
-	executorL1RecordersOnce     sync.Once
-)
-
-func ensureExecutorL1Recorders() {
-	executorL1RecordersOnce.Do(func() {
-		if c := metrics.RUV2ExecutorCounter(1, ruv2LabelBatchPointGetExec); c != nil {
-			execL1RecorderBatchPointGet = ExecutorMetricRecorder{add: func(m *RUV2Metrics, d int64) {
-				c.Add(float64(d))
-				atomic.AddInt64(&m.executorL1.batchPointGetExec, d)
-			}}
-		}
-		if c := metrics.RUV2ExecutorCounter(1, ruv2LabelPointGetExecutor); c != nil {
-			execL1RecorderPointGet = ExecutorMetricRecorder{add: func(m *RUV2Metrics, d int64) {
-				c.Add(float64(d))
-				atomic.AddInt64(&m.executorL1.pointGetExecutor, d)
-			}}
-		}
-		if c := metrics.RUV2ExecutorCounter(1, ruv2LabelLimitExec); c != nil {
-			execL1RecorderLimit = ExecutorMetricRecorder{add: func(m *RUV2Metrics, d int64) {
-				c.Add(float64(d))
-				atomic.AddInt64(&m.executorL1.limitExec, d)
-			}}
-		}
-	})
+// ResolveExecutorMetric returns a pre-resolved recorder for hot L1 executor
+// labels, or the zero recorder for everything else. The Prometheus counter is
+// already cached by metrics.RUV2ExecutorCounter, so this is cheap to call from
+// Open() and needs no further memoization.
+func ResolveExecutorMetric(level int, label string) ExecutorMetricRecorder {
+	if level != 1 {
+		return ExecutorMetricRecorder{}
+	}
+	var kind execL1Kind
+	switch label {
+	case ruv2LabelBatchPointGetExec:
+		kind = execL1BatchPointGet
+	case ruv2LabelPointGetExecutor:
+		kind = execL1PointGet
+	case ruv2LabelLimitExec:
+		kind = execL1Limit
+	default:
+		return ExecutorMetricRecorder{}
+	}
+	c := metrics.RUV2ExecutorCounter(level, label)
+	if c == nil {
+		return ExecutorMetricRecorder{}
+	}
+	return ExecutorMetricRecorder{counter: c, kind: kind}
 }
 
 // AddExecutorL5InsertRows records affected insert rows for RUv2 accounting.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #68118

Problem Summary:

After #67508, #68119, and #68696 reduced the per-Next RUv2 overhead introduced by #67030, two residual costs remain on the executor hot path:

1. `AddExecutorMetric` performs an atomic `Bypass()` load and a level/label switch on every Next() call, even for the three hot L1 executors (BatchPointGetExec, PointGetExecutor, LimitExec) that dominate point-select workloads.
2. `UpdateRUV2MetricsFromRUV2` fans out to 8+ public `Add*` methods at statement-end drain time, each re-reading the same Bypass flag and (for extra-struct fields) racing on `ensureExtra` independently.

### What changed and how does it work?

- Introduce `ExecutorMetricRecorder`, a small `(prometheus counter, kind)` value that pairs the process-global counter (already cached by `RUV2ExecutorCounter`) with the per-`RUV2Metrics` scalar field selected at record time. It is resolved at `Open()` via `ResolveExecutorMetric` for the three hot L1 labels; everything else returns the zero recorder and falls back to `AddExecutorMetric` unchanged. The recorder value needs no allocation, so there is no `sync.Once`/package-level caching.
- Cache the recorder alongside the existing per-executor RUv2 cache in `ruv2NextCacheState`. The hot Next() path now does one `Record` call (a single Prometheus `Add` plus a small `kind` switch and atomic add) instead of: Bypass atomic load + level switch + label switch + atomic add.
- Refactor `UpdateRUV2MetricsFromRUV2` to check Bypass once at entry, delegate to a private `applyRawCounters`, and lazily call `ensureExtra` at most once per drain.

Public `Add*` APIs and slow-path behavior are unchanged. The fast path is opt-in via `Available()`, so callers outside the cached path stay on the existing dispatch.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved RUv2 metrics tracking for executors by adding a cached fast-path recorder to more efficiently capture per-executor IO deltas, reducing overhead and improving metrics accuracy.

* **Tests**
  * Added a test validating recorder resolution and ensuring consistency between the new fast-path recorder and the existing metric recording path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
