### PR TITLE
OWNERS: update dumpformat and dxf approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -45,6 +45,7 @@ aliases:
     - D3Hunter
     - gmhdbjd
     - Benjamin2037
+    - joechenrh
   sig-approvers-expression:
     - windtalker
     - XuHuaiyu
@@ -55,6 +56,7 @@ aliases:
     - D3Hunter
     - gmhdbjd
     - OliverS929
+    - joechenrh
   sig-approvers-domain:
     - D3Hunter
     - gmhdbjd
@@ -76,15 +78,17 @@ aliases:
     - xhebox
     - tiancaiamao
     - YangKeao
-  sig-approvers-disttask:
+  sig-approvers-dxf:
     - Benjamin2037
     - D3Hunter
     - gmhdbjd
     - wjhuang2016
+    - joechenrh
   sig-approvers-dumpling:
     - Benjamin2037
     - gmhdbjd
     - D3Hunter
+    - joechenrh
   sig-approvers-infoschema:
     - wjhuang2016
     - D3Hunter

--- a/pkg/dumpformat/OWNERS
+++ b/pkg/dumpformat/OWNERS
@@ -2,4 +2,4 @@
 options:
   no_parent_owners: true
 approvers:
-  - sig-approvers-dxf
+  - sig-approvers-dumpling


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: None

Problem Summary:

Owner metadata for dumpformat and dxf needs to route review approval to the right approver groups and include `joechenrh` in the related approver aliases.

### What changed and how does it work?

- Add `joechenrh` to the executor import, lightning, dxf, and dumpling approver aliases in `OWNERS_ALIASES`.
- Rename the dxf approver alias from `sig-approvers-disttask` to `sig-approvers-dxf`.
- Update `pkg/dxf/OWNERS` to use `sig-approvers-dxf`.
- Add `pkg/dumpformat/OWNERS` so dumpformat changes use the dumpling approver alias.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:

- `git diff --check upstream/master...HEAD`
- `git diff --name-status upstream/master...HEAD -- '*.go' '*.bazel' '*.bzl' BUILD.bazel MODULE.bazel MODULE.bazel.lock WORKSPACE DEPS.bzl go.mod go.sum`
- `git diff -U0 upstream/master...HEAD -- '*.go'`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configuration across multiple approver groups, including member additions and reorganization of alias assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->