### PR TITLE
ddl, executor, planner: backport duplicate count expr support for nullable MV aggs

### DIFF
--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -882,6 +882,8 @@ func validateCreateMaterializedViewQuery(
 	groupBySet := make(map[string]struct{}, len(sel.GroupBy.Items))
 	groupByCols := make([]string, 0, len(sel.GroupBy.Items))
 	groupByNotNull := make(map[string]bool, len(sel.GroupBy.Items))
+	countExprCols := make(map[string]struct{})
+	nullableSumCols := make(map[string]struct{})
 	usedCols := make(map[string]struct{}, 8)
 
 	for _, item := range sel.GroupBy.Items {
@@ -960,6 +962,7 @@ func validateCreateMaterializedViewQuery(
 					if err != nil {
 						return nil, err
 					}
+					countExprCols[colName] = struct{}{}
 					usedCols[colName] = struct{}{}
 					continue
 				}
@@ -983,13 +986,13 @@ func validateCreateMaterializedViewQuery(
 				if err != nil {
 					return nil, err
 				}
-				if !mysql.HasNotNullFlag(baseColMap[colName].GetFlag()) {
-					return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStack("CREATE MATERIALIZED VIEW only supports SUM/MIN/MAX on NOT NULL column")
-				}
 				if aggFunc == ast.AggFuncSum {
 					tp := baseColMap[colName].GetType()
 					if types.IsTypeTime(tp) || tp == mysql.TypeDuration {
 						return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStack("CREATE MATERIALIZED VIEW does not support SUM on DATE/DATETIME/TIMESTAMP/TIME column")
+					}
+					if !mysql.HasNotNullFlag(baseColMap[colName].GetFlag()) {
+						nullableSumCols[colName] = struct{}{}
 					}
 				}
 				if aggFunc == ast.AggFuncMin || aggFunc == ast.AggFuncMax {
@@ -1005,6 +1008,13 @@ func validateCreateMaterializedViewQuery(
 	}
 	if !hasCountStarOrOne {
 		return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStack("CREATE MATERIALIZED VIEW must contain count(*)/count(1)")
+	}
+	for colName := range nullableSumCols {
+		if _, ok := countExprCols[colName]; !ok {
+			return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStack(
+				fmt.Sprintf("CREATE MATERIALIZED VIEW SUM on nullable column %s requires matching COUNT(%s) in SELECT list", colName, colName),
+			)
+		}
 	}
 
 	groupByInfos := make([]mviewGroupByInfo, 0, len(sel.GroupBy.Items))

--- a/pkg/executor/mview_delta_merge_agg_builder.go
+++ b/pkg/executor/mview_delta_merge_agg_builder.go
@@ -349,10 +349,10 @@ func mviewDeltaMergeAggArgExpr(
 				len(dependencies),
 			)
 		}
-		// MIN/MAX nullability should follow the original aggregate expression (encoded in dependency arity),
-		// instead of nullable delta payload columns.
+		// MIN/MAX nullability should follow the original aggregate argument nullability instead of
+		// nullable delta payload columns.
 		retType = retType.Clone()
-		if len(dependencies) == 4 {
+		if aggInfo.ArgNotNull {
 			retType.AddFlag(mysql.NotNullFlag)
 		} else {
 			retType.DelFlag(mysql.NotNullFlag)

--- a/pkg/executor/mviewdeltamergeagg/exec_test.go
+++ b/pkg/executor/mviewdeltamergeagg/exec_test.go
@@ -1466,8 +1466,9 @@ func TestMinMaxFallbackToCountStarWithoutFinalCountDependency(t *testing.T) {
 	require.True(t, maxCol.IsNull(0))
 }
 
-func TestAllowMinMaxFallbackToCountStarForNullableExpr(t *testing.T) {
+func TestMinMaxFallbackToCountStarForNullableExpr(t *testing.T) {
 	sctx := mock.NewContext()
+	sctx.GetSessionVars().ExecutorConcurrency = 1
 	ftInt := types.NewFieldType(mysql.TypeLonglong)
 	fts := []*types.FieldType{
 		ftInt, // [0] delta_count(*)
@@ -1479,7 +1480,16 @@ func TestAllowMinMaxFallbackToCountStarForNullableExpr(t *testing.T) {
 		ftInt, // [6] mv_count(*)
 		ftInt, // [7] mv_max(v)
 	}
-	src := newMockSource(sctx, fts, nil)
+	chk := chunk.NewChunkWithCapacity(fts, 1)
+	chk.AppendInt64(0, 0)
+	chk.AppendNull(1)
+	chk.AppendInt64(2, 0)
+	chk.AppendInt64(3, 10)
+	chk.AppendInt64(4, 1)
+	chk.AppendInt64(5, 1)
+	chk.AppendInt64(6, 3)
+	chk.AppendInt64(7, 10)
+	src := newMockSource(sctx, fts, []*chunk.Chunk{chk})
 
 	countStarDesc, err := aggregation.NewAggFuncDesc(sctx.GetExprCtx(), ast.AggFuncCount, []expression.Expression{expression.NewOne()}, false)
 	require.NoError(t, err)
@@ -1487,6 +1497,21 @@ func TestAllowMinMaxFallbackToCountStarForNullableExpr(t *testing.T) {
 	maxArg := &expression.Column{Index: 1, RetType: ftInt}
 	maxDesc, err := aggregation.NewAggFuncDesc(sctx.GetExprCtx(), ast.AggFuncMax, []expression.Expression{maxArg}, false)
 	require.NoError(t, err)
+
+	keyDatum := new(types.Datum)
+	keyCol := &expression.CorrelatedColumn{
+		Column: expression.Column{Index: 0, RetType: ftInt},
+		Data:   keyDatum,
+	}
+	recomputeExec := &mockSingleRowRecomputeExec{
+		BaseExecutor: exec.NewBaseExecutor(
+			sctx,
+			expression.NewSchema(&expression.Column{Index: 0, RetType: ftInt}),
+			0,
+		),
+		keyCols: []*expression.CorrelatedColumn{keyCol},
+		values:  map[int64]int64{},
+	}
 
 	mergeExec := &Exec{
 		BaseExecutor: exec.NewBaseExecutor(sctx, nil, 0, src),
@@ -1497,27 +1522,41 @@ func TestAllowMinMaxFallbackToCountStarForNullableExpr(t *testing.T) {
 				ColID:           []int{7},
 				DependencyColID: []int{1, 2, 3, 4},
 				MinMaxRecompute: &MinMaxRecomputeSpec{
-					Strategy:            MinMaxRecomputeBatch,
-					BatchResultColIdxes: []int{1},
+					Strategy: MinMaxRecomputeSingleRow,
+					SingleRow: &MinMaxRecomputeSingleRowExec{
+						Workers: []MinMaxRecomputeSingleRowWorker{
+							{
+								KeyCols: []*expression.CorrelatedColumn{keyCol},
+								Exec:    recomputeExec,
+							},
+						},
+					},
 				},
 			},
 		},
 		DeltaAggColCount: 6,
 		WorkerCnt:        1,
 		MinMaxRecompute: &MinMaxRecomputeExec{
-			KeyInputColIDs:    []int{5},
-			KeyResultColIdxes: []int{0},
-			BatchBuilder:      &mockBatchRecomputeBuilder{},
+			KeyInputColIDs: []int{5},
 		},
 	}
-	err = mergeExec.Open(context.Background())
-	require.NoError(t, err)
-	require.Len(t, mergeExec.compiledMergers, 2)
-	maxMerger, ok := mergeExec.compiledMergers[1].(*minMaxIntMerger)
-	require.True(t, ok)
-	require.Equal(t, depFromComputed, maxMerger.countRef.source)
-	require.Equal(t, 0, maxMerger.countRef.idx)
+	writer := &collectWriter{}
+	mergeExec.Writer = writer
+
+	require.NoError(t, mergeExec.Open(context.Background()))
+	outChk := exec.NewFirstChunk(mergeExec)
+	require.NoError(t, mergeExec.Next(context.Background(), outChk))
 	require.NoError(t, mergeExec.Close())
+
+	require.Equal(t, 1, recomputeExec.calls)
+	require.Len(t, writer.results, 1)
+	res := writer.results[0]
+	require.Len(t, res.RowOps, 1)
+	require.Equal(t, RowOpUpdate, res.RowOps[0].Tp)
+
+	maxCol := res.ComputedCols[7]
+	require.NotNil(t, maxCol)
+	require.True(t, maxCol.IsNull(0))
 }
 
 func TestRejectMinMaxFinalCountForNonNullableExpr(t *testing.T) {

--- a/pkg/executor/mviewdeltamergeagg/exec_test.go
+++ b/pkg/executor/mviewdeltamergeagg/exec_test.go
@@ -1537,7 +1537,8 @@ func TestMinMaxFallbackToCountStarForNullableExpr(t *testing.T) {
 		DeltaAggColCount: 6,
 		WorkerCnt:        1,
 		MinMaxRecompute: &MinMaxRecomputeExec{
-			KeyInputColIDs: []int{5},
+			KeyInputColIDs:    []int{5},
+			KeyResultColIdxes: []int{0},
 		},
 	}
 	writer := &collectWriter{}

--- a/pkg/executor/mviewdeltamergeagg/exec_test.go
+++ b/pkg/executor/mviewdeltamergeagg/exec_test.go
@@ -142,17 +142,27 @@ func (m *mockSingleRowRecomputeExecMulti) Next(_ context.Context, req *chunk.Chu
 	return nil
 }
 
+type mockBatchRecomputeRow struct {
+	key         int64
+	value       int64
+	valueIsNull bool
+}
+
 type mockBatchRecomputeExec struct {
 	exec.BaseExecutor
-	rows [][2]int64
+	rows []mockBatchRecomputeRow
 	idx  int
 }
 
 func (m *mockBatchRecomputeExec) Next(_ context.Context, req *chunk.Chunk) error {
 	req.Reset()
 	for m.idx < len(m.rows) && req.NumRows() < req.Capacity() {
-		req.AppendInt64(0, m.rows[m.idx][0])
-		req.AppendInt64(1, m.rows[m.idx][1])
+		req.AppendInt64(0, m.rows[m.idx].key)
+		if m.rows[m.idx].valueIsNull {
+			req.AppendNull(1)
+		} else {
+			req.AppendInt64(1, m.rows[m.idx].value)
+		}
 		m.idx++
 	}
 	return nil
@@ -162,17 +172,26 @@ type mockBatchRecomputeBuilder struct {
 	sctx          sessionctx.Context
 	retTp         []*types.FieldType
 	values        map[int64]int64
+	nullKeys      map[int64]struct{}
 	reverseOutput bool
 	extraRows     [][2]int64
+	calls         int
 }
 
 func (b *mockBatchRecomputeBuilder) Build(_ context.Context, req *MinMaxBatchBuildRequest) (exec.Executor, error) {
-	rows := make([][2]int64, 0, len(req.LookupKeys))
+	b.calls++
+	rows := make([]mockBatchRecomputeRow, 0, len(req.LookupKeys)+len(b.extraRows))
 	for _, key := range req.LookupKeys {
 		k := key.Keys[0].GetInt64()
-		rows = append(rows, [2]int64{k, b.values[k]})
+		row := mockBatchRecomputeRow{key: k, value: b.values[k]}
+		if _, isNull := b.nullKeys[k]; isNull {
+			row.valueIsNull = true
+		}
+		rows = append(rows, row)
 	}
-	rows = append(rows, b.extraRows...)
+	for _, row := range b.extraRows {
+		rows = append(rows, mockBatchRecomputeRow{key: row[0], value: row[1]})
+	}
 	if b.reverseOutput {
 		for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
 			rows[i], rows[j] = rows[j], rows[i]
@@ -1498,19 +1517,10 @@ func TestMinMaxFallbackToCountStarForNullableExpr(t *testing.T) {
 	maxDesc, err := aggregation.NewAggFuncDesc(sctx.GetExprCtx(), ast.AggFuncMax, []expression.Expression{maxArg}, false)
 	require.NoError(t, err)
 
-	keyDatum := new(types.Datum)
-	keyCol := &expression.CorrelatedColumn{
-		Column: expression.Column{Index: 0, RetType: ftInt},
-		Data:   keyDatum,
-	}
-	recomputeExec := &mockSingleRowRecomputeExec{
-		BaseExecutor: exec.NewBaseExecutor(
-			sctx,
-			expression.NewSchema(&expression.Column{Index: 0, RetType: ftInt}),
-			0,
-		),
-		keyCols: []*expression.CorrelatedColumn{keyCol},
-		values:  map[int64]int64{},
+	batchBuilder := &mockBatchRecomputeBuilder{
+		sctx:     sctx,
+		retTp:    []*types.FieldType{ftInt, ftInt},
+		nullKeys: map[int64]struct{}{1: {}},
 	}
 
 	mergeExec := &Exec{
@@ -1522,15 +1532,8 @@ func TestMinMaxFallbackToCountStarForNullableExpr(t *testing.T) {
 				ColID:           []int{7},
 				DependencyColID: []int{1, 2, 3, 4},
 				MinMaxRecompute: &MinMaxRecomputeSpec{
-					Strategy: MinMaxRecomputeSingleRow,
-					SingleRow: &MinMaxRecomputeSingleRowExec{
-						Workers: []MinMaxRecomputeSingleRowWorker{
-							{
-								KeyCols: []*expression.CorrelatedColumn{keyCol},
-								Exec:    recomputeExec,
-							},
-						},
-					},
+					Strategy:            MinMaxRecomputeBatch,
+					BatchResultColIdxes: []int{1},
 				},
 			},
 		},
@@ -1539,6 +1542,7 @@ func TestMinMaxFallbackToCountStarForNullableExpr(t *testing.T) {
 		MinMaxRecompute: &MinMaxRecomputeExec{
 			KeyInputColIDs:    []int{5},
 			KeyResultColIdxes: []int{0},
+			BatchBuilder:      batchBuilder,
 		},
 	}
 	writer := &collectWriter{}
@@ -1549,7 +1553,7 @@ func TestMinMaxFallbackToCountStarForNullableExpr(t *testing.T) {
 	require.NoError(t, mergeExec.Next(context.Background(), outChk))
 	require.NoError(t, mergeExec.Close())
 
-	require.Equal(t, 1, recomputeExec.calls)
+	require.Equal(t, 1, batchBuilder.calls)
 	require.Len(t, writer.results, 1)
 	res := writer.results[0]
 	require.Len(t, res.RowOps, 1)

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -156,11 +156,17 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	err = tk.ExecToErr("create materialized view mv_bad_where (a, c) as select a, count(1) from t where rand() > 0 group by a")
 	require.ErrorContains(t, err, "WHERE clause must be deterministic")
 
-	// SUM/MIN/MAX currently require NOT NULL argument columns.
+	// SUM on nullable columns requires matching COUNT(column); MIN/MAX does not.
 	tk.MustExec("create table t_sum_nullable (a int not null, b int)")
 	tk.MustExec("create materialized view log on t_sum_nullable (a, b) purge next date_add(now(), interval 1 hour)")
 	err = tk.ExecToErr("create materialized view mv_bad_sum_nullable (a, s, c) as select a, sum(b), count(1) from t_sum_nullable group by a")
-	require.ErrorContains(t, err, "only supports SUM/MIN/MAX on NOT NULL column")
+	require.ErrorContains(t, err, "requires matching COUNT")
+	tk.MustExec("create materialized view mv_sum_nullable (a, s, cnt_b, c) as select a, sum(b), count(b), count(1) from t_sum_nullable group by a")
+	tk.MustExec("create materialized view mv_sum_nullable_dup_cnt (a, s, cnt_b1, cnt_b2, c) as select a, sum(b), count(b) as cnt_b1, count(b) as cnt_b2, count(1) from t_sum_nullable group by a")
+
+	tk.MustExec("create table t_minmax_nullable (a int not null, b int, index idx_ab(a, b))")
+	tk.MustExec("create materialized view log on t_minmax_nullable (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_minmax_nullable (a, minb, maxb, c) as select a, min(b), max(b), count(1) from t_minmax_nullable group by a")
 
 	// SUM does not support time or duration columns.
 	tk.MustExec("create table t_sum_time (a int not null, d date not null default '2020-01-01', dt datetime not null default '2020-01-01 00:00:00', ts timestamp not null default '2020-01-01 00:00:00', dur time not null default '00:00:00')")
@@ -276,7 +282,10 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	tk.MustExec("drop materialized view mv_upper_agg")
 	tk.MustExec("drop materialized view mv_alias")
 	tk.MustExec("drop materialized view mv_nullable")
+	tk.MustExec("drop materialized view mv_sum_nullable")
+	tk.MustExec("drop materialized view mv_sum_nullable_dup_cnt")
 	tk.MustExec("drop materialized view mv_minmax_ok")
+	tk.MustExec("drop materialized view mv_minmax_nullable")
 	tk.MustExec("drop materialized view mv_presplit")
 	tk.MustExec("drop materialized view log on t")
 	tk.MustExec("drop materialized view log on t_nullable")
@@ -284,6 +293,7 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	tk.MustExec("drop materialized view log on t_sum_time")
 	tk.MustExec("drop materialized view log on t_minmax_bad")
 	tk.MustExec("drop materialized view log on t_minmax_ok")
+	tk.MustExec("drop materialized view log on t_minmax_nullable")
 	tk.MustExec("drop materialized view log on t_presplit")
 	tk.MustQuery("select count(*) from mysql.tidb_mview_refresh_info").Check(testkit.Rows("0"))
 

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -417,6 +417,45 @@ func TestMaterializedViewRefreshFastMinMax(t *testing.T) {
 	))
 }
 
+func TestMaterializedViewRefreshFastNullableAggregatesWithDuplicateCountExpr(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_mv_fast_nullable_dup_count (a int not null, b int, key idx_ab(a, b))")
+	tk.MustExec("create materialized view log on t_mv_fast_nullable_dup_count (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec(`create materialized view mv_fast_nullable_dup_count (a, cnt, cnt_b1, cnt_b2, s, mx, mn)
+		refresh fast as
+		select a, count(1), count(b) as cnt_b1, count(b) as cnt_b2, sum(b), max(b), min(b)
+		from t_mv_fast_nullable_dup_count
+		group by a`)
+
+	tk.MustExec("insert into t_mv_fast_nullable_dup_count values (1, 10), (1, null), (1, 5), (2, null)")
+	tk.MustExec("refresh materialized view mv_fast_nullable_dup_count complete")
+	tk.MustQuery("select a, cnt, cnt_b1, cnt_b2, s, mx, mn from mv_fast_nullable_dup_count order by a").Check(testkit.Rows(
+		"1 3 2 2 15 10 5",
+		"2 1 0 0 <nil> <nil> <nil>",
+	))
+
+	tk.MustExec("delete from t_mv_fast_nullable_dup_count where a = 1 and b = 10")
+	tk.MustExec("insert into t_mv_fast_nullable_dup_count values (1, 20), (1, null), (2, 7), (3, null), (3, 4)")
+	tk.MustExec("refresh materialized view mv_fast_nullable_dup_count fast")
+	tk.MustQuery("select a, cnt, cnt_b1, cnt_b2, s, mx, mn from mv_fast_nullable_dup_count order by a").Check(testkit.Rows(
+		"1 4 2 2 25 20 5",
+		"2 2 1 1 7 7 7",
+		"3 2 1 1 4 4 4",
+	))
+
+	tk.MustExec("delete from t_mv_fast_nullable_dup_count where a = 1 and b in (5, 20)")
+	tk.MustExec("delete from t_mv_fast_nullable_dup_count where a = 2 and b = 7")
+	tk.MustExec("refresh materialized view mv_fast_nullable_dup_count fast")
+	tk.MustQuery("select a, cnt, cnt_b1, cnt_b2, s, mx, mn from mv_fast_nullable_dup_count order by a").Check(testkit.Rows(
+		"1 2 0 0 <nil> <nil> <nil>",
+		"2 1 0 0 <nil> <nil> <nil>",
+		"3 2 1 1 4 4 4",
+	))
+}
+
 func TestMaterializedViewRefreshFastMinMaxWhereSeparateIndexes(t *testing.T) {
 	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/casetest/mview/BUILD.bazel
+++ b/pkg/planner/core/casetest/mview/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "mv_refresh_test.go",
     ],
     flaky = True,
-    shard_count = 6,
+    shard_count = 8,
     deps = [
         "//pkg/domain",
         "//pkg/infoschema",

--- a/pkg/planner/mview/BUILD.bazel
+++ b/pkg/planner/mview/BUILD.bazel
@@ -28,7 +28,7 @@ go_test(
     timeout = "short",
     srcs = ["mview_test.go"],
     flaky = True,
-    shard_count = 10,
+    shard_count = 12,
     deps = [
         ":mview",
         "//pkg/domain",

--- a/pkg/planner/mview/BUILD.bazel
+++ b/pkg/planner/mview/BUILD.bazel
@@ -28,7 +28,7 @@ go_test(
     timeout = "short",
     srcs = ["mview_test.go"],
     flaky = True,
-    shard_count = 12,
+    shard_count = 13,
     deps = [
         ":mview",
         "//pkg/domain",

--- a/pkg/planner/mview/mview.go
+++ b/pkg/planner/mview/mview.go
@@ -138,6 +138,8 @@ type AggInfo struct {
 
 	// ArgColName is the base-table column name used as the aggregate argument. Empty for COUNT(*).
 	ArgColName string
+	// ArgNotNull records whether the aggregate argument column is NOT NULL in the base table schema.
+	ArgNotNull bool
 
 	// Dependencies stores dependency offsets in merge-source output schema.
 	// The meaning depends on Kind:
@@ -151,8 +153,9 @@ type AggInfo struct {
 	//       COUNT(expr) must be updated before SUM(expr), and SUM should read this updated MV value.
 	//       The same matched COUNT(expr) can be a dependency for multiple aggregate functions.
 	//   - AggMax / AggMin:
-	//     - [added_val, added_cnt, removed_val, removed_cnt] when argument is NOT NULL.
-	//     - [added_val, added_cnt, removed_val, removed_cnt, matched_count_expr_mv] otherwise.
+	//     - [added_val, added_cnt, removed_val, removed_cnt] always.
+	//     - [added_val, added_cnt, removed_val, removed_cnt, matched_count_expr_mv] optionally when a
+	//       matching COUNT(expr) exists for a nullable argument and can be used as an optimization.
 	//     - added_cnt/removed_cnt are counts of rows whose argument equals added_val/removed_val
 	//       in the added/removed subdomain respectively (MAX/MIN_COUNT semantics).
 	Dependencies []int
@@ -446,6 +449,7 @@ func buildFromLocal(
 	outAggInfos := make([]AggInfo, 0, len(local.aggCols))
 	for i, ac := range local.aggCols {
 		di := ac.info
+		di.ArgNotNull = aggArgNotNullByOffset[di.MVOffset]
 		deps := make([]int, 0, 5)
 		if ac.deltaName != "" {
 			off, ok := deltaOffsetByName[ac.deltaName]
@@ -478,11 +482,7 @@ func buildFromLocal(
 				return nil, errors.Errorf("internal error: delta column %s not found in output", ac.removedCountDelta)
 			}
 			deps = append(deps, addedCntOff, removedValOff, removedCntOff)
-			if !aggArgNotNullByOffset[di.MVOffset] {
-				countIdx, ok := minMaxToCountExprIdx[i]
-				if !ok {
-					return nil, errors.Errorf("internal error: %v at mv offset %d has no COUNT(expr) dependency", di.Kind, di.MVOffset)
-				}
+			if countIdx, ok := minMaxToCountExprIdx[i]; ok {
 				countAgg := local.aggCols[countIdx]
 				deps = append(deps, mvColumnOffsetBase+countAgg.info.MVOffset)
 			}
@@ -808,9 +808,9 @@ func extractAggInfosFromMVSelect(sel *ast.SelectStmt) (aggCols []aggColInfo, has
 	return aggCols, hasMinMax, nil
 }
 
-// mapSumToCountExprDependencies finds, for every nullable SUM(expr), the unique matching
-// COUNT(expr) aggregate in the same MV SELECT list. The dependency is required to preserve
-// SUM(NULL) semantics when applying incremental updates.
+// mapSumToCountExprDependencies finds, for every nullable SUM(expr), the first structurally
+// matching COUNT(expr) aggregate in the same MV SELECT list. The dependency is required to
+// preserve SUM(NULL) semantics when applying incremental updates.
 func mapSumToCountExprDependencies(aggCols []aggColInfo, sumArgNotNullByOffset map[int]bool) (map[int]int, error) {
 	sumToCountIdx := make(map[int]int)
 	for i, ac := range aggCols {
@@ -831,13 +831,8 @@ func mapSumToCountExprDependencies(aggCols []aggColInfo, sumArgNotNullByOffset m
 			if !exprStructuralEqual(ac.argExpr, cand.argExpr) {
 				continue
 			}
-			if matchIdx >= 0 {
-				return nil, errors.Errorf(
-					"SUM expression %s at mv offset %d has multiple matching COUNT(expr) dependencies (offsets %d and %d)",
-					restoreExpr(ac.argExpr), ac.info.MVOffset, aggCols[matchIdx].info.MVOffset, cand.info.MVOffset,
-				)
-			}
 			matchIdx = j
+			break
 		}
 		if matchIdx < 0 {
 			return nil, errors.Errorf(
@@ -850,9 +845,9 @@ func mapSumToCountExprDependencies(aggCols []aggColInfo, sumArgNotNullByOffset m
 	return sumToCountIdx, nil
 }
 
-// mapMinMaxToCountExprDependencies finds, for every nullable MIN(expr)/MAX(expr), the unique matching
-// COUNT(expr) aggregate in the same MV SELECT list. The dependency is required to preserve NULL semantics
-// when fast-refresh applies MIN/MAX deltas and needs to distinguish "result is NULL" from "no non-NULL row remains".
+// mapMinMaxToCountExprDependencies finds an optional first matching COUNT(expr) for nullable
+// MIN/MAX(expr). Missing COUNT(expr) does not block build because MIN/MAX can fall back to
+// count(*) + full recompute when needed.
 func mapMinMaxToCountExprDependencies(aggCols []aggColInfo, aggArgNotNullByOffset map[int]bool) (map[int]int, error) {
 	minMaxToCountIdx := make(map[int]int)
 	for i, ac := range aggCols {
@@ -873,19 +868,11 @@ func mapMinMaxToCountExprDependencies(aggCols []aggColInfo, aggArgNotNullByOffse
 			if !exprStructuralEqual(ac.argExpr, cand.argExpr) {
 				continue
 			}
-			if matchIdx >= 0 {
-				return nil, errors.Errorf(
-					"%v expression %s at mv offset %d has multiple matching COUNT(expr) dependencies (offsets %d and %d)",
-					ac.info.Kind, restoreExpr(ac.argExpr), ac.info.MVOffset, aggCols[matchIdx].info.MVOffset, cand.info.MVOffset,
-				)
-			}
 			matchIdx = j
+			break
 		}
 		if matchIdx < 0 {
-			return nil, errors.Errorf(
-				"%v expression %s at mv offset %d requires matching COUNT(expr) in SELECT list",
-				ac.info.Kind, restoreExpr(ac.argExpr), ac.info.MVOffset,
-			)
+			continue
 		}
 		minMaxToCountIdx[i] = matchIdx
 	}

--- a/pkg/planner/mview/mview_test.go
+++ b/pkg/planner/mview/mview_test.go
@@ -785,22 +785,22 @@ func TestBuildMinMaxNullableWithoutCountExpr(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	res, err := mvmerge.Build(
+	res, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mv,
-		mvmerge.BuildOptions{FromTS: 1},
+		mview.BuildOptions{FromTS: 1},
 		nil,
 	)
 	require.NoError(t, err)
 
 	for _, ai := range res.AggInfos {
 		switch ai.Kind {
-		case mvmerge.AggCountStar:
+		case mview.AggCountStar:
 			requireDependencies(t, ai, []int{0})
-		case mvmerge.AggMax:
+		case mview.AggMax:
 			requireDependencies(t, ai, []int{1, 2, 3, 4})
-		case mvmerge.AggMin:
+		case mview.AggMin:
 			requireDependencies(t, ai, []int{5, 6, 7, 8})
 		}
 	}
@@ -858,20 +858,20 @@ func TestBuildSumNullableWithDuplicateCountExpr(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	res, err := mvmerge.Build(
+	res, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mv,
-		mvmerge.BuildOptions{FromTS: 1},
+		mview.BuildOptions{FromTS: 1},
 		nil,
 	)
 	require.NoError(t, err)
 
 	for _, ai := range res.AggInfos {
 		switch ai.Kind {
-		case mvmerge.AggCountStar:
+		case mview.AggCountStar:
 			requireDependencies(t, ai, []int{0})
-		case mvmerge.AggCount:
+		case mview.AggCount:
 			require.Equal(t, "b", ai.ArgColName)
 			if ai.MVOffset == 2 {
 				requireDependencies(t, ai, []int{1})
@@ -879,7 +879,7 @@ func TestBuildSumNullableWithDuplicateCountExpr(t *testing.T) {
 				require.Equal(t, 3, ai.MVOffset)
 				requireDependencies(t, ai, []int{2})
 			}
-		case mvmerge.AggSum:
+		case mview.AggSum:
 			requireDependencies(t, ai, []int{3, 6})
 		}
 	}
@@ -938,20 +938,20 @@ func TestBuildMinMaxNullableWithDuplicateCountExpr(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
 	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
 
-	res, err := mvmerge.Build(
+	res, err := mview.Build(
 		sctx.GetPlanCtx(),
 		is,
 		mv,
-		mvmerge.BuildOptions{FromTS: 1},
+		mview.BuildOptions{FromTS: 1},
 		nil,
 	)
 	require.NoError(t, err)
 
 	for _, ai := range res.AggInfos {
 		switch ai.Kind {
-		case mvmerge.AggCountStar:
+		case mview.AggCountStar:
 			requireDependencies(t, ai, []int{0})
-		case mvmerge.AggCount:
+		case mview.AggCount:
 			require.Equal(t, "b", ai.ArgColName)
 			if ai.MVOffset == 2 {
 				requireDependencies(t, ai, []int{1})
@@ -959,9 +959,9 @@ func TestBuildMinMaxNullableWithDuplicateCountExpr(t *testing.T) {
 				require.Equal(t, 3, ai.MVOffset)
 				requireDependencies(t, ai, []int{2})
 			}
-		case mvmerge.AggMax:
+		case mview.AggMax:
 			requireDependencies(t, ai, []int{3, 4, 5, 6, 13})
-		case mvmerge.AggMin:
+		case mview.AggMin:
 			requireDependencies(t, ai, []int{7, 8, 9, 10, 13})
 		}
 	}

--- a/pkg/planner/mview/mview_test.go
+++ b/pkg/planner/mview/mview_test.go
@@ -734,6 +734,239 @@ func TestBuildMinMaxNullableDependencyOrder(t *testing.T) {
 	}
 }
 
+func TestBuildMinMaxNullableWithoutCountExpr(t *testing.T) {
+	sctx := core.MockContext()
+
+	baseID := int64(210)
+	mlogID := int64(220)
+	mvID := int64(230)
+
+	base := &model.TableInfo{
+		ID:    baseID,
+		Name:  pmodel.NewCIStr("t"),
+		State: model.StatePublic,
+		Columns: []*model.ColumnInfo{
+			mkCol(1, "a", 0, mysql.TypeLong),
+			mkCol(2, "b", 1, mysql.TypeLong),
+		},
+		MaterializedViewBase: &model.MaterializedViewBaseInfo{MLogID: mlogID},
+	}
+	mlog := &model.TableInfo{
+		ID:    mlogID,
+		Name:  pmodel.NewCIStr("$mlog$t"),
+		State: model.StatePublic,
+		Columns: []*model.ColumnInfo{
+			mkCol(1, "a", 0, mysql.TypeLong),
+			mkCol(2, "b", 1, mysql.TypeLong),
+			mkCol(3, model.MaterializedViewLogDMLTypeColumnName, 2, mysql.TypeVarchar),
+			mkCol(4, model.MaterializedViewLogOldNewColumnName, 3, mysql.TypeTiny),
+		},
+		MaterializedViewLog: &model.MaterializedViewLogInfo{
+			BaseTableID: baseID,
+			Columns:     []pmodel.CIStr{pmodel.NewCIStr("a"), pmodel.NewCIStr("b")},
+		},
+	}
+	mv := &model.TableInfo{
+		ID:    mvID,
+		Name:  pmodel.NewCIStr("mv_minmax_nullable_no_count_tbl"),
+		State: model.StatePublic,
+		Columns: []*model.ColumnInfo{
+			mkCol(1, "x", 0, mysql.TypeLong),
+			mkCol(2, "cnt", 1, mysql.TypeLonglong),
+			mkCol(3, "mx", 2, mysql.TypeLong),
+			mkCol(4, "mn", 3, mysql.TypeLong),
+		},
+		MaterializedView: &model.MaterializedViewInfo{
+			BaseTableIDs: []int64{baseID},
+			SQLContent:   "select a, count(1), max(b), min(b) from t group by a",
+		},
+	}
+
+	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
+	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
+
+	res, err := mvmerge.Build(
+		sctx.GetPlanCtx(),
+		is,
+		mv,
+		mvmerge.BuildOptions{FromTS: 1},
+		nil,
+	)
+	require.NoError(t, err)
+
+	for _, ai := range res.AggInfos {
+		switch ai.Kind {
+		case mvmerge.AggCountStar:
+			requireDependencies(t, ai, []int{0})
+		case mvmerge.AggMax:
+			requireDependencies(t, ai, []int{1, 2, 3, 4})
+		case mvmerge.AggMin:
+			requireDependencies(t, ai, []int{5, 6, 7, 8})
+		}
+	}
+}
+
+func TestBuildSumNullableWithDuplicateCountExpr(t *testing.T) {
+	sctx := core.MockContext()
+
+	baseID := int64(211)
+	mlogID := int64(221)
+	mvID := int64(231)
+
+	base := &model.TableInfo{
+		ID:    baseID,
+		Name:  pmodel.NewCIStr("t"),
+		State: model.StatePublic,
+		Columns: []*model.ColumnInfo{
+			mkCol(1, "a", 0, mysql.TypeLong),
+			mkCol(2, "b", 1, mysql.TypeLong),
+		},
+		MaterializedViewBase: &model.MaterializedViewBaseInfo{MLogID: mlogID},
+	}
+	mlog := &model.TableInfo{
+		ID:    mlogID,
+		Name:  pmodel.NewCIStr("$mlog$t"),
+		State: model.StatePublic,
+		Columns: []*model.ColumnInfo{
+			mkCol(1, "a", 0, mysql.TypeLong),
+			mkCol(2, "b", 1, mysql.TypeLong),
+			mkCol(3, model.MaterializedViewLogDMLTypeColumnName, 2, mysql.TypeVarchar),
+			mkCol(4, model.MaterializedViewLogOldNewColumnName, 3, mysql.TypeTiny),
+		},
+		MaterializedViewLog: &model.MaterializedViewLogInfo{
+			BaseTableID: baseID,
+			Columns:     []pmodel.CIStr{pmodel.NewCIStr("a"), pmodel.NewCIStr("b")},
+		},
+	}
+	mv := &model.TableInfo{
+		ID:    mvID,
+		Name:  pmodel.NewCIStr("mv_sum_nullable_dup_count_tbl"),
+		State: model.StatePublic,
+		Columns: []*model.ColumnInfo{
+			mkCol(1, "x", 0, mysql.TypeLong),
+			mkCol(2, "cnt", 1, mysql.TypeLonglong),
+			mkCol(3, "cnt_b1", 2, mysql.TypeLonglong),
+			mkCol(4, "cnt_b2", 3, mysql.TypeLonglong),
+			mkCol(5, "s", 4, mysql.TypeLonglong),
+		},
+		MaterializedView: &model.MaterializedViewInfo{
+			BaseTableIDs: []int64{baseID},
+			SQLContent:   "select a, count(1), count(b), count(b), sum(b) from t group by a",
+		},
+	}
+
+	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
+	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
+
+	res, err := mvmerge.Build(
+		sctx.GetPlanCtx(),
+		is,
+		mv,
+		mvmerge.BuildOptions{FromTS: 1},
+		nil,
+	)
+	require.NoError(t, err)
+
+	for _, ai := range res.AggInfos {
+		switch ai.Kind {
+		case mvmerge.AggCountStar:
+			requireDependencies(t, ai, []int{0})
+		case mvmerge.AggCount:
+			require.Equal(t, "b", ai.ArgColName)
+			if ai.MVOffset == 2 {
+				requireDependencies(t, ai, []int{1})
+			} else {
+				require.Equal(t, 3, ai.MVOffset)
+				requireDependencies(t, ai, []int{2})
+			}
+		case mvmerge.AggSum:
+			requireDependencies(t, ai, []int{3, 6})
+		}
+	}
+}
+
+func TestBuildMinMaxNullableWithDuplicateCountExpr(t *testing.T) {
+	sctx := core.MockContext()
+
+	baseID := int64(212)
+	mlogID := int64(222)
+	mvID := int64(232)
+
+	base := &model.TableInfo{
+		ID:    baseID,
+		Name:  pmodel.NewCIStr("t"),
+		State: model.StatePublic,
+		Columns: []*model.ColumnInfo{
+			mkCol(1, "a", 0, mysql.TypeLong),
+			mkCol(2, "b", 1, mysql.TypeLong),
+		},
+		MaterializedViewBase: &model.MaterializedViewBaseInfo{MLogID: mlogID},
+	}
+	mlog := &model.TableInfo{
+		ID:    mlogID,
+		Name:  pmodel.NewCIStr("$mlog$t"),
+		State: model.StatePublic,
+		Columns: []*model.ColumnInfo{
+			mkCol(1, "a", 0, mysql.TypeLong),
+			mkCol(2, "b", 1, mysql.TypeLong),
+			mkCol(3, model.MaterializedViewLogDMLTypeColumnName, 2, mysql.TypeVarchar),
+			mkCol(4, model.MaterializedViewLogOldNewColumnName, 3, mysql.TypeTiny),
+		},
+		MaterializedViewLog: &model.MaterializedViewLogInfo{
+			BaseTableID: baseID,
+			Columns:     []pmodel.CIStr{pmodel.NewCIStr("a"), pmodel.NewCIStr("b")},
+		},
+	}
+	mv := &model.TableInfo{
+		ID:    mvID,
+		Name:  pmodel.NewCIStr("mv_minmax_nullable_dup_count_tbl"),
+		State: model.StatePublic,
+		Columns: []*model.ColumnInfo{
+			mkCol(1, "x", 0, mysql.TypeLong),
+			mkCol(2, "cnt", 1, mysql.TypeLonglong),
+			mkCol(3, "cnt_b1", 2, mysql.TypeLonglong),
+			mkCol(4, "cnt_b2", 3, mysql.TypeLonglong),
+			mkCol(5, "mx", 4, mysql.TypeLong),
+			mkCol(6, "mn", 5, mysql.TypeLong),
+		},
+		MaterializedView: &model.MaterializedViewInfo{
+			BaseTableIDs: []int64{baseID},
+			SQLContent:   "select a, count(1), count(b), count(b), max(b), min(b) from t group by a",
+		},
+	}
+
+	is := infoschema.MockInfoSchema([]*model.TableInfo{base, mlog, mv})
+	domain.GetDomain(sctx).MockInfoCacheAndLoadInfoSchema(is)
+
+	res, err := mvmerge.Build(
+		sctx.GetPlanCtx(),
+		is,
+		mv,
+		mvmerge.BuildOptions{FromTS: 1},
+		nil,
+	)
+	require.NoError(t, err)
+
+	for _, ai := range res.AggInfos {
+		switch ai.Kind {
+		case mvmerge.AggCountStar:
+			requireDependencies(t, ai, []int{0})
+		case mvmerge.AggCount:
+			require.Equal(t, "b", ai.ArgColName)
+			if ai.MVOffset == 2 {
+				requireDependencies(t, ai, []int{1})
+			} else {
+				require.Equal(t, 3, ai.MVOffset)
+				requireDependencies(t, ai, []int{2})
+			}
+		case mvmerge.AggMax:
+			requireDependencies(t, ai, []int{3, 4, 5, 6, 13})
+		case mvmerge.AggMin:
+			requireDependencies(t, ai, []int{7, 8, 9, 10, 13})
+		}
+	}
+}
+
 func TestBuildSumWithoutCountExpr(t *testing.T) {
 	sctx := core.MockContext()
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:
Backport support for duplicate COUNT(expr) dependencies in nullable MV aggregates to the release-8.5 materialized view branch.

### What changed and how does it work?

- allow nullable SUM(expr) to reuse the first matching COUNT(expr) dependency even when duplicate COUNT(expr) items exist
- allow nullable MIN/MAX(expr) to use the first matching COUNT(expr) when present, and fall back to count(*) plus recompute when it is absent
- propagate aggregate argument nullability into MV delta-merge planning/execution on this branch layout
- add planner, executor, DDL, and refresh coverage for duplicate COUNT(expr) and nullable MIN/MAX fallback cases
- adapt the backport to this branch's MV refactor and refresh Bazel shard counts accordingly

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Test commands:
- go test ./pkg/planner/mview -run TestBuildMinMaxNullableWithoutCountExpr\|TestBuildSumNullableWithDuplicateCountExpr\|TestBuildMinMaxNullableWithDuplicateCountExpr -tags=intest,deadlock -count=1
- go test ./pkg/executor/mviewdeltamergeagg -run TestMinMaxFallbackToCountStarForNullableExpr -tags=intest,deadlock -count=1
- make bazel_lint_changed

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SUM is now allowed on nullable base columns when a matching COUNT(expr) appears in the SELECT list.
  * Improved support for MIN/MAX on nullable columns in materialized view definitions.

* **Bug Fixes**
  * Fixed aggregate nullability handling in fast-refresh/merge paths and fallback behavior so MIN/MAX and SUM behave correctly with NULL inputs.

* **Tests / Chores**
  * Added and updated tests covering nullable aggregates and refresh behavior; increased test sharding for stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->