### PR TITLE
executor: support compare materialized view

### DIFF
--- a/docs/note/materialized_view/mv_compare.md
+++ b/docs/note/materialized_view/mv_compare.md
@@ -1,20 +1,21 @@
 # Materialized View Compare (Implementation and Design Notes)
 
-This document describes the design and implementation plan for:
+This document describes the design and implementation notes for:
 
 ```sql
 COMPARE MATERIALIZED VIEW <mv> AS OF TIMESTAMP <ts_expr> [OUTPUT INTO TABLE <table>]
 ```
 
-Current status:
+Current implementation status:
 
-- Parser / AST / planner / executor skeleton exists.
-- Privilege skeleton tests exist.
-- Runtime compare logic is not implemented yet.
+- Parser / AST / planner / executor support is implemented.
+- Compare execution uses explicit snapshot semantics from `AS OF TIMESTAMP`.
+- The target MV metadata is resolved from the snapshot InfoSchema at the compare snapshot `S`, not from the current InfoSchema. This keeps the MV table ID, column schema, and refresh-info lookup consistent with snapshot `S`, including out-of-place refresh cutover cases.
+- `OUTPUT INTO TABLE` is implemented. The output table is created from the snapshot MV public-column schema plus the differ-type column; it does not inherit MV indexes, constraints, partitioning, or MV-specific metadata.
 
 ## Goals
 
-1. Compare current MV table data and base-query snapshot data with explicit snapshot semantics.
+1. Compare MV table data at snapshot `S` and base-query snapshot data at refresh watermark `R`.
 2. Preserve correctness under different read timestamps:
    - MV side reads at statement snapshot `S`.
    - Base-query side reads at refresh watermark `R` (`LAST_SUCCESS_READ_TSO`).
@@ -42,10 +43,13 @@ Semantics:
 
 1. Let `S` be the compare statement snapshot timestamp (from `AS OF TIMESTAMP`).
    - In execution terms, `S` is the read snapshot of this compare statement (the statement-level read TS / start TS).
-2. Read MV table and refresh-info row at snapshot `S`.
-3. Read `R = mysql.tidb_mview_refresh_info.LAST_SUCCESS_READ_TSO` from that same snapshot `S`.
-4. Execute MV definition SQL on base tables at snapshot `R`.
-5. Compare `MV@S` vs `BaseQuery@R` by full-outer semantics on group keys.
+2. Load snapshot InfoSchema at `S` and resolve the target MV from that snapshot.
+   - The MV physical table ID used for refresh-info lookup must come from snapshot `S`.
+   - This is required when an out-of-place refresh cutover has changed the current MV physical table ID after `S`.
+3. Read MV table and refresh-info row at snapshot `S`.
+4. Read `R = mysql.tidb_mview_refresh_info.LAST_SUCCESS_READ_TSO` from that same snapshot `S`.
+5. Execute MV definition SQL on base tables at snapshot `R`.
+6. Compare `MV@S` vs `BaseQuery@R` by full-outer semantics on group keys.
 
 Output behavior:
 
@@ -59,7 +63,9 @@ Output behavior:
    - TiDB automatically creates the target table;
    - if the target table already exists, the statement returns table-exists error;
    - execution requires `CREATE` and `INSERT` privileges on the target table schema.
-   - if target-table creation succeeds but compare later fails, the created table may remain; compare does not promise DDL rollback.
+   - the target table schema is built from snapshot `S` MV public columns plus the differ-type column;
+   - the target table does not copy MV indexes, constraints, partitioning, or MV-specific metadata;
+   - if target-table creation succeeds but compare later fails, the created table may remain; if output rows have already been flushed, committed batches may also remain.
 
 Privilege semantics:
 
@@ -90,20 +96,21 @@ The chosen semantics (`MV@S` vs `Base@R`) answers the operational question more 
 
 Use a utility executor (`CompareMaterializedViewExec`) to orchestrate two snapshot readers, then wire a full outer `HashJoinV1Exec` as the diff engine inside compare execution.
 
-### Phase 1: Resolve target and validate
+### Phase 1: Capture snapshot, resolve target, and validate
 
-1. Resolve target MV table and ensure `MaterializedView` metadata exists.
-2. Ensure MV is `Ready`.
-3. Check base-table `SELECT` privilege (`checkRefreshMaterializedViewBaseTableSelect`).
-4. If `OUTPUT INTO TABLE` is set:
+1. Evaluate compare statement `AS OF` to get `S` and validate stale-read TS.
+2. Load snapshot InfoSchema for `S`.
+3. Resolve the target MV table from snapshot InfoSchema `S` and ensure `MaterializedView` metadata exists.
+4. Ensure MV is `Ready` at snapshot `S`.
+5. Check base-table `SELECT` privilege against snapshot MV metadata (`checkRefreshMaterializedViewBaseTableSelect`).
+6. If `OUTPUT INTO TABLE` is set:
    - check target table does not exist;
    - check `CREATE` and `INSERT` privileges on the target schema.
 
-### Phase 2: Capture snapshots and read watermark
+### Phase 2: Read refresh watermark
 
-1. Evaluate compare statement `AS OF` to get `S` and validate stale-read TS.
-2. Read `LAST_SUCCESS_READ_TSO` from `mysql.tidb_mview_refresh_info` at snapshot `S`.
-3. Let `R = LAST_SUCCESS_READ_TSO`.
+1. Read `LAST_SUCCESS_READ_TSO` from `mysql.tidb_mview_refresh_info` at snapshot `S`, using the snapshot MV table ID from Phase 1.
+2. Let `R = LAST_SUCCESS_READ_TSO`.
 
 Rules:
 
@@ -117,6 +124,7 @@ Rules:
    - row shape: MV table public columns in MV order.
 2. Base reader at snapshot `R`:
    - SQL source: `mv.MaterializedView.SQLContent`;
+   - session SQL mode, time zone, and related definition-time settings restored from MV metadata;
    - field aliases rewritten to MV column names (same as complete-diff builder contract);
    - row shape aligned to MV columns.
 
@@ -164,7 +172,7 @@ This keeps full outer join concurrency and row-matching behavior reused from the
 
 Output table schema contract:
 
-1. Start from the MV public-column schema in MV column order.
+1. Start from the snapshot `S` MV public-column schema in MV column order.
 2. Add one extra column named `_Differ_type_`.
 3. If the MV already contains `_Differ_type_`, append a numeric suffix and use `_Differ_type_1`, `_Differ_type_2`, and so on until the name is unique.
 4. `_Differ_type_` values are:
@@ -172,9 +180,10 @@ Output table schema contract:
    - `mview_vacuum`
    - `mview_excessive`
 5. Row-value source in the output table is:
-   - `mview_differ`: write the current MV row values;
-   - `mview_excessive`: write the current MV row values;
+   - `mview_differ`: write the `MV@S` row values;
+   - `mview_excessive`: write the `MV@S` row values;
    - `mview_vacuum`: write the base-query row values from snapshot `R`.
+6. The output table keeps MV public column types/defaults/comments where applicable, but it does not inherit indexes, primary/unique constraints, foreign keys, check constraints, partitioning, TTL, placement, TiFlash replica, auto-id options, or MV-specific metadata.
 
 ## Contract with existing MV logic
 
@@ -200,64 +209,25 @@ For grouped MV, this keeps compare semantics aligned with COMPLETE DELTA APPLY d
 1. Correctness is the primary requirement, but the implementation should still avoid obviously poor performance.
 2. Summary mode should still count differing rows accurately; it cannot stop after the first mismatch.
 3. Output-table mode should stream diff rows and avoid retaining full diff in memory.
-4. The current design uses full-outer diff semantics for clarity and correctness. If a better execution strategy is introduced later, it should preserve the same compare semantics.
+4. Output-table writes are batched to avoid a single very large transaction.
+5. The current design uses full-outer diff semantics for clarity and correctness. If a better execution strategy is introduced later, it should preserve the same compare semantics.
 
 ## Code map (implementation landing)
 
-- Parser / AST (already present):
+- Parser / AST:
   - `pkg/parser/parser.y`
   - `pkg/parser/ast/misc.go`
-- Planner skeleton (already present):
+- Planner:
   - `pkg/planner/core/planbuilder.go` (`buildCompareMaterializedView`)
   - `pkg/planner/core/common_plans.go` (`CompareMaterializedView`)
-- Executor implementation (to fill):
+- Executor implementation:
   - `pkg/executor/materialized_view.go` (`CompareMaterializedViewExec`)
 - Reusable MV diff metadata helpers:
   - `pkg/planner/mview/mvmerge.go`
 
-## Suggested implementation stages
+## Test coverage
 
-### Stage 1: snapshot and metadata flow
-
-1. Implement `S` evaluation from compare `AS OF`.
-2. Read `R` from refresh-info at snapshot `S`.
-3. Add full validation/error paths.
-
-Acceptance:
-
-1. compare statement reaches deterministic precheck outcome.
-
-### Stage 2: dual-reader execution
-
-1. Build MV reader at `S` and base reader at `R`.
-2. Align base output columns to MV schema order.
-
-Acceptance:
-
-1. both readers can be drained independently with aligned row shape.
-
-### Stage 3: executor-level full outer join reuse
-
-1. Build `MV@S` / `Base@R` child executors with aligned schemas.
-2. Wire them into a full outer `HashJoinV1Exec` with the same nullable-key rules as COMPLETE DELTA APPLY.
-3. Consume join output and produce differing-row count plus per-row differ classification.
-
-Acceptance:
-
-1. insert-only/delete-only/update-only/mixed/no-op cases are correct.
-
-### Stage 4: output modes
-
-1. Summary row mode (`compare result` text output).
-2. `OUTPUT INTO TABLE` auto-create and persistence mode.
-
-Acceptance:
-
-1. output table mode auto-creates the target table, writes stable diff rows, and keeps existing privilege checks.
-
-## Test plan (minimum)
-
-1. Privilege path (existing skeleton) remains valid.
+1. Privilege path remains valid.
 2. Correctness cases:
    - no diff,
    - `mview_vacuum`,
@@ -268,6 +238,7 @@ Acceptance:
 4. `LAST_SUCCESS_READ_TSO` null/missing row/system-table missing.
 5. GC-safe-point rejection for snapshot `R`.
 6. `OUTPUT INTO TABLE` success, table-exists conflict, and `_Differ_type_` name-conflict handling.
+7. Snapshot metadata after out-of-place refresh cutover, including output table creation from snapshot MV schema rather than current MV indexes.
 
 ## Open follow-ups
 

--- a/docs/note/materialized_view/mv_compare.md
+++ b/docs/note/materialized_view/mv_compare.md
@@ -65,7 +65,7 @@ Output behavior:
    - execution requires `CREATE` and `INSERT` privileges on the target table schema.
    - the target table schema is built from snapshot `S` MV public columns plus the differ-type column;
    - the target table does not copy MV indexes, constraints, partitioning, or MV-specific metadata;
-   - if target-table creation succeeds but compare later fails, TiDB rolls back the current output-write transaction and drops the auto-created target table, including any already committed output batches.
+   - if target-table creation succeeds but compare later fails, TiDB rolls back the current output-write transaction and attempts to drop the auto-created target table, including any already committed output batches.
 
 Privilege semantics:
 
@@ -204,7 +204,7 @@ For grouped MV, this keeps compare semantics aligned with COMPLETE DELTA APPLY d
 3. `LAST_SUCCESS_READ_TSO` is `NULL` -> explicit compare precondition error.
 4. Snapshot `R` older than GC safe point -> stale-read validation error.
 5. Any internal reader execution failure -> return original error.
-6. If `OUTPUT INTO TABLE` was used and the target table was auto-created, any later compare failure triggers output-table cleanup before returning the error. If cleanup also fails, the returned error includes the cleanup failure.
+6. If `OUTPUT INTO TABLE` was used and the target table was auto-created, any later compare failure triggers best-effort output-table cleanup before returning the original error. If cleanup fails, TiDB writes a warning log.
 
 ## Performance notes
 

--- a/docs/note/materialized_view/mv_compare.md
+++ b/docs/note/materialized_view/mv_compare.md
@@ -11,7 +11,7 @@ Current implementation status:
 - Parser / AST / planner / executor support is implemented.
 - Compare execution uses explicit snapshot semantics from `AS OF TIMESTAMP`.
 - The target MV metadata is resolved from the snapshot InfoSchema at the compare snapshot `S`, not from the current InfoSchema. This keeps the MV table ID, column schema, and refresh-info lookup consistent with snapshot `S`, including out-of-place refresh cutover cases.
-- `OUTPUT INTO TABLE` is implemented. The output table is created from the snapshot MV public-column schema plus the differ-type column; it does not inherit MV indexes, constraints, partitioning, or MV-specific metadata.
+- `OUTPUT INTO TABLE` is implemented. The output table is created from the snapshot MV public-column schema plus the differ-type column; it does not inherit MV indexes, constraints, partitioning, or MV-specific metadata. If compare fails after creating the output table, the statement drops the auto-created output table during cleanup.
 
 ## Goals
 
@@ -65,7 +65,7 @@ Output behavior:
    - execution requires `CREATE` and `INSERT` privileges on the target table schema.
    - the target table schema is built from snapshot `S` MV public columns plus the differ-type column;
    - the target table does not copy MV indexes, constraints, partitioning, or MV-specific metadata;
-   - if target-table creation succeeds but compare later fails, the created table may remain; if output rows have already been flushed, committed batches may also remain.
+   - if target-table creation succeeds but compare later fails, TiDB rolls back the current output-write transaction and drops the auto-created target table, including any already committed output batches.
 
 Privilege semantics:
 
@@ -169,6 +169,7 @@ This keeps full outer join concurrency and row-matching behavior reused from the
 2. Output-table mode (`OUTPUT INTO TABLE` present):
    - auto-create the target table before writing compare results;
    - output table schema is the same as the MV public-column schema, plus one extra differ-type column.
+   - if compare fails after creating the output table, drop the auto-created output table before returning the error.
 
 Output table schema contract:
 
@@ -203,6 +204,7 @@ For grouped MV, this keeps compare semantics aligned with COMPLETE DELTA APPLY d
 3. `LAST_SUCCESS_READ_TSO` is `NULL` -> explicit compare precondition error.
 4. Snapshot `R` older than GC safe point -> stale-read validation error.
 5. Any internal reader execution failure -> return original error.
+6. If `OUTPUT INTO TABLE` was used and the target table was auto-created, any later compare failure triggers output-table cleanup before returning the error. If cleanup also fails, the returned error includes the cleanup failure.
 
 ## Performance notes
 

--- a/docs/note/materialized_view/mv_compare.md
+++ b/docs/note/materialized_view/mv_compare.md
@@ -57,8 +57,8 @@ Output behavior:
    - whether any difference exists;
    - the number of differing rows.
 2. Recommended output text follows the current spec direction:
-   - `There are ... differences result in ... compared to source base tables at timestamp 'xxxx'`
-   - the rendered timestamp should be `R` (the base-query comparison snapshot), because the comparison source side is `BaseQuery@R`.
+   - `There are ... differences result in ... compared to source base tables at timestamp 'xxxx' (TSO: yyyy)`
+   - the rendered timestamp and TSO should be `R` (the base-query comparison snapshot), because the comparison source side is `BaseQuery@R`.
 3. With `OUTPUT INTO TABLE`:
    - TiDB automatically creates the target table;
    - if the target table already exists, the statement returns table-exists error;

--- a/docs/note/materialized_view/mv_compare.md
+++ b/docs/note/materialized_view/mv_compare.md
@@ -53,7 +53,7 @@ Output behavior:
    - whether any difference exists;
    - the number of differing rows.
 2. Recommended output text follows the current spec direction:
-   - `There are ... differencies result in ... compared to source base tables at timestamp 'xxxx'`
+   - `There are ... differences result in ... compared to source base tables at timestamp 'xxxx'`
    - the rendered timestamp should be `R` (the base-query comparison snapshot), because the comparison source side is `BaseQuery@R`.
 3. With `OUTPUT INTO TABLE`:
    - TiDB automatically creates the target table;

--- a/docs/note/materialized_view/mv_compare.md
+++ b/docs/note/materialized_view/mv_compare.md
@@ -1,0 +1,275 @@
+# Materialized View Compare (Implementation and Design Notes)
+
+This document describes the design and implementation plan for:
+
+```sql
+COMPARE MATERIALIZED VIEW <mv> AS OF TIMESTAMP <ts_expr> [OUTPUT INTO TABLE <table>]
+```
+
+Current status:
+
+- Parser / AST / planner / executor skeleton exists.
+- Privilege skeleton tests exist.
+- Runtime compare logic is not implemented yet.
+
+## Goals
+
+1. Compare current MV table data and base-query snapshot data with explicit snapshot semantics.
+2. Preserve correctness under different read timestamps:
+   - MV side reads at statement snapshot `S`.
+   - Base-query side reads at refresh watermark `R` (`LAST_SUCCESS_READ_TSO`).
+3. Reuse existing MV diff semantics (group-key identity + null-safe payload comparison).
+4. Support two output modes:
+   - no `OUTPUT INTO TABLE`: return whether differences exist and the number of differing rows.
+   - with `OUTPUT INTO TABLE`: auto-create an output table and persist compare results into it.
+
+## Non-goals
+
+1. No automatic repair / no write-back to MV.
+2. No async compare scheduler.
+3. No compare for non-grouped MV definitions.
+4. No cost-based engine/path selection work (correctness first).
+
+## SQL behavior (user view)
+
+Syntax (spec form):
+
+```sql
+COMPARE MATERIALIZED VIEW mv1 AS OF TIMESTAMP 'xxxx' [OUTPUT INTO TABLE [db1.]t1];
+```
+
+Semantics:
+
+1. Let `S` be the compare statement snapshot timestamp (from `AS OF TIMESTAMP`).
+   - In execution terms, `S` is the read snapshot of this compare statement (the statement-level read TS / start TS).
+2. Read MV table and refresh-info row at snapshot `S`.
+3. Read `R = mysql.tidb_mview_refresh_info.LAST_SUCCESS_READ_TSO` from that same snapshot `S`.
+4. Execute MV definition SQL on base tables at snapshot `R`.
+5. Compare `MV@S` vs `BaseQuery@R` by full-outer semantics on group keys.
+
+Output behavior:
+
+1. Without `OUTPUT INTO TABLE`: return one row in `compare result` describing:
+   - whether any difference exists;
+   - the number of differing rows.
+2. Recommended output text follows the current spec direction:
+   - `There are ... differencies result in ... compared to source base tables at timestamp 'xxxx'`
+   - the rendered timestamp should be `R` (the base-query comparison snapshot), because the comparison source side is `BaseQuery@R`.
+3. With `OUTPUT INTO TABLE`:
+   - TiDB automatically creates the target table;
+   - if the target table already exists, the statement returns table-exists error;
+   - execution requires `CREATE` and `INSERT` privileges on the target table schema.
+   - if target-table creation succeeds but compare later fails, the created table may remain; compare does not promise DDL rollback.
+
+Privilege semantics:
+
+1. `COMPARE MATERIALIZED VIEW` requires `OPERATE VIEW` privilege on the target MV.
+2. Compare execution also requires `SELECT` privilege on the MV base table(s), consistent with existing refresh-side validation.
+3. If `OUTPUT INTO TABLE` is present, `CREATE` and `INSERT` privileges on the target schema are additionally required.
+
+## Why this is not one SQL statement
+
+A single SQL statement cannot safely express `MV@S` joined with `Base@R` when `S != R`.
+
+Reason:
+
+- stale-read processor enforces one statement-level `AS OF` timestamp across tables;
+- mixed timestamps in one statement are rejected (`can not set different time in the as of`).
+
+So compare must be orchestrated as a utility workflow with two read snapshots.
+
+## Why not read both sides at `R`
+
+Reading both sides at `R` would only verify "refresh-at-`R` equivalence" and cannot detect later MV drift/corruption after `R`.
+
+The chosen semantics (`MV@S` vs `Base@R`) answers the operational question more directly:
+
+- "Is the currently served MV state still consistent with what it should be based on the last successful refresh watermark?"
+
+## Chosen direction
+
+Use a utility executor (`CompareMaterializedViewExec`) to orchestrate two snapshot readers, then wire a full outer `HashJoinV1Exec` as the diff engine inside compare execution.
+
+### Phase 1: Resolve target and validate
+
+1. Resolve target MV table and ensure `MaterializedView` metadata exists.
+2. Ensure MV is `Ready`.
+3. Check base-table `SELECT` privilege (`checkRefreshMaterializedViewBaseTableSelect`).
+4. If `OUTPUT INTO TABLE` is set:
+   - check target table does not exist;
+   - check `CREATE` and `INSERT` privileges on the target schema.
+
+### Phase 2: Capture snapshots and read watermark
+
+1. Evaluate compare statement `AS OF` to get `S` and validate stale-read TS.
+2. Read `LAST_SUCCESS_READ_TSO` from `mysql.tidb_mview_refresh_info` at snapshot `S`.
+3. Let `R = LAST_SUCCESS_READ_TSO`.
+
+Rules:
+
+1. If refresh-info row is missing: fail as metadata inconsistency.
+2. If `R` is `NULL`: fail (`compare` requires a successful refresh watermark).
+3. If `R > S`: fail as metadata inconsistency.
+
+### Phase 3: Build two read executors
+
+1. MV reader at snapshot `S`:
+   - row shape: MV table public columns in MV order.
+2. Base reader at snapshot `R`:
+   - SQL source: `mv.MaterializedView.SQLContent`;
+   - field aliases rewritten to MV column names (same as complete-diff builder contract);
+   - row shape aligned to MV columns.
+
+Both readers are read-only and independent.
+
+### Phase 4: Reuse full outer hash join in compare executor
+
+Join identity and comparison rules reuse COMPLETE DELTA APPLY semantics:
+
+1. Identity key is `GROUP BY` key columns.
+2. Key comparison:
+   - `=` for `NOT NULL` key columns.
+   - `<=>` for nullable key columns.
+3. Side-missing detection should reuse the same deterministic marker-column rule as COMPLETE DELTA APPLY:
+   - use one visible `NOT NULL` MV column as side-missing marker;
+   - do not infer side-missing from nullable key columns.
+4. Payload comparison after join output:
+   - null-safe by column (`<=>` semantic).
+
+Diff categories:
+
+1. `mview_differ`: MV row and base-query row both exist, but payload differs.
+2. `mview_vacuum`: compared with base-query result at `R`, MV is missing corresponding rows.
+3. `mview_excessive`: compared with base-query result at `R`, MV has extra corresponding rows.
+
+Implementation shape:
+
+1. Build `MV@S` and `Base@R` child executors.
+2. In `CompareMaterializedViewExec`, wire those two child executors into a full outer `HashJoinV1Exec`.
+3. Consume hash-join output rows and classify them into:
+   - matched-but-different -> `mview_differ`
+   - base-only -> `mview_vacuum`
+   - mv-only -> `mview_excessive`
+
+This keeps full outer join concurrency and row-matching behavior reused from the existing hash join executor, while leaving compare-specific result classification in `CompareMaterializedViewExec`.
+
+### Phase 5: Emit summary or persist diffs
+
+1. Summary mode (`OUTPUT INTO TABLE` absent):
+   - return one summary row in `compare result`;
+   - result includes only whether differences exist and the differing-row count.
+2. Output-table mode (`OUTPUT INTO TABLE` present):
+   - auto-create the target table before writing compare results;
+   - output table schema is the same as the MV public-column schema, plus one extra differ-type column.
+
+Output table schema contract:
+
+1. Start from the MV public-column schema in MV column order.
+2. Add one extra column named `_Differ_type_`.
+3. If the MV already contains `_Differ_type_`, append a numeric suffix and use `_Differ_type_1`, `_Differ_type_2`, and so on until the name is unique.
+4. `_Differ_type_` values are:
+   - `mview_differ`
+   - `mview_vacuum`
+   - `mview_excessive`
+5. Row-value source in the output table is:
+   - `mview_differ`: write the current MV row values;
+   - `mview_excessive`: write the current MV row values;
+   - `mview_vacuum`: write the base-query row values from snapshot `R`.
+
+## Contract with existing MV logic
+
+To avoid semantic drift, compare should reuse metadata extraction logic used by MV refresh diff paths:
+
+1. Reuse grouped-key extraction contract from MV definition SQL.
+2. Reuse nullable-key vs not-null-key comparison rule (`NullEQ` vs `EQ`).
+3. Reuse side-missing marker selection rule.
+4. Reuse payload null-safe equality semantics.
+
+For grouped MV, this keeps compare semantics aligned with COMPLETE DELTA APPLY diff semantics.
+
+## Error handling
+
+1. Missing system table (`mysql.tidb_mview_refresh_info`) -> explicit error.
+2. Missing refresh-info row for target MV -> explicit metadata error.
+3. `LAST_SUCCESS_READ_TSO` is `NULL` -> explicit compare precondition error.
+4. Snapshot `R` older than GC safe point -> stale-read validation error.
+5. Any internal reader execution failure -> return original error.
+
+## Performance notes
+
+1. Correctness is the primary requirement, but the implementation should still avoid obviously poor performance.
+2. Summary mode should still count differing rows accurately; it cannot stop after the first mismatch.
+3. Output-table mode should stream diff rows and avoid retaining full diff in memory.
+4. The current design uses full-outer diff semantics for clarity and correctness. If a better execution strategy is introduced later, it should preserve the same compare semantics.
+
+## Code map (implementation landing)
+
+- Parser / AST (already present):
+  - `pkg/parser/parser.y`
+  - `pkg/parser/ast/misc.go`
+- Planner skeleton (already present):
+  - `pkg/planner/core/planbuilder.go` (`buildCompareMaterializedView`)
+  - `pkg/planner/core/common_plans.go` (`CompareMaterializedView`)
+- Executor implementation (to fill):
+  - `pkg/executor/materialized_view.go` (`CompareMaterializedViewExec`)
+- Reusable MV diff metadata helpers:
+  - `pkg/planner/mview/mvmerge.go`
+
+## Suggested implementation stages
+
+### Stage 1: snapshot and metadata flow
+
+1. Implement `S` evaluation from compare `AS OF`.
+2. Read `R` from refresh-info at snapshot `S`.
+3. Add full validation/error paths.
+
+Acceptance:
+
+1. compare statement reaches deterministic precheck outcome.
+
+### Stage 2: dual-reader execution
+
+1. Build MV reader at `S` and base reader at `R`.
+2. Align base output columns to MV schema order.
+
+Acceptance:
+
+1. both readers can be drained independently with aligned row shape.
+
+### Stage 3: executor-level full outer join reuse
+
+1. Build `MV@S` / `Base@R` child executors with aligned schemas.
+2. Wire them into a full outer `HashJoinV1Exec` with the same nullable-key rules as COMPLETE DELTA APPLY.
+3. Consume join output and produce differing-row count plus per-row differ classification.
+
+Acceptance:
+
+1. insert-only/delete-only/update-only/mixed/no-op cases are correct.
+
+### Stage 4: output modes
+
+1. Summary row mode (`compare result` text output).
+2. `OUTPUT INTO TABLE` auto-create and persistence mode.
+
+Acceptance:
+
+1. output table mode auto-creates the target table, writes stable diff rows, and keeps existing privilege checks.
+
+## Test plan (minimum)
+
+1. Privilege path (existing skeleton) remains valid.
+2. Correctness cases:
+   - no diff,
+   - `mview_vacuum`,
+   - `mview_excessive`,
+   - `mview_differ`,
+   - mixed.
+3. Nullable key and nullable payload cases.
+4. `LAST_SUCCESS_READ_TSO` null/missing row/system-table missing.
+5. GC-safe-point rejection for snapshot `R`.
+6. `OUTPUT INTO TABLE` success, table-exists conflict, and `_Differ_type_` name-conflict handling.
+
+## Open follow-ups
+
+1. Whether to expose richer compare stats (for example scanned rows, elapsed time per side).
+2. Whether to add a dry-run/profile style observability output for compare workflow.

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1821,6 +1821,13 @@ func (e *CompareMaterializedViewExec) readCompareMaterializedViewLastSuccessRead
 	if readTSONull {
 		return 0, errors.New("compare materialized view: LAST_SUCCESS_READ_TSO is NULL")
 	}
+	if readTSO > compareSnapshotTS {
+		return 0, errors.Errorf(
+			"compare materialized view: LAST_SUCCESS_READ_TSO %d is newer than compare snapshot %d",
+			readTSO,
+			compareSnapshotTS,
+		)
+	}
 	return readTSO, nil
 }
 

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1618,27 +1618,32 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
 
-	schemaName, targetTable, tblInfo, err := e.resolveCompareMaterializedViewTarget()
+	compareSnapshotTS, err := e.resolveCompareMaterializedViewSnapshotTS(ctx)
 	if err != nil {
 		return err
 	}
-	if err := checkRefreshMaterializedViewBaseTableSelect(e.Ctx(), domain.GetDomain(e.Ctx()).InfoSchema(), tblInfo.MaterializedView); err != nil {
+	snapshotIS, err := domain.GetDomain(e.Ctx()).GetSnapshotInfoSchema(compareSnapshotTS)
+	if err != nil {
+		return err
+	}
+
+	schemaName, targetTable, tblInfo, err := e.resolveCompareMaterializedViewTarget(snapshotIS)
+	if err != nil {
+		return err
+	}
+	if err := checkRefreshMaterializedViewBaseTableSelect(e.Ctx(), snapshotIS, tblInfo.MaterializedView); err != nil {
 		return err
 	}
 	if err := e.checkCompareMaterializedViewOutputTableNotExists(); err != nil {
 		return err
 	}
 
-	compareSnapshotTS, err := e.resolveCompareMaterializedViewSnapshotTS(ctx)
-	if err != nil {
-		return err
-	}
 	lastSuccessReadTSO, err := e.readCompareMaterializedViewLastSuccessReadTSO(ctx, schemaName, tblInfo.ID, compareSnapshotTS)
 	if err != nil {
 		return err
 	}
 
-	diffMeta, err := mvmerge.BuildCompleteDiffSource(e.Ctx().GetPlanCtx(), domain.GetDomain(e.Ctx()).InfoSchema(), tblInfo)
+	diffMeta, err := mvmerge.BuildCompleteDiffSource(e.Ctx().GetPlanCtx(), snapshotIS, tblInfo)
 	if err != nil {
 		return err
 	}
@@ -1770,8 +1775,7 @@ func (e *CompareMaterializedViewExec) checkCompareMaterializedViewOutputTableNot
 	return nil
 }
 
-func (e *CompareMaterializedViewExec) resolveCompareMaterializedViewTarget() (pmodel.CIStr, table.Table, *model.TableInfo, error) {
-	is := e.Ctx().GetDomainInfoSchema().(infoschema.InfoSchema)
+func (e *CompareMaterializedViewExec) resolveCompareMaterializedViewTarget(is infoschema.InfoSchema) (pmodel.CIStr, table.Table, *model.TableInfo, error) {
 	schemaName := e.stmt.ViewName.Schema
 	if schemaName.O == "" {
 		if e.Ctx().GetSessionVars().CurrentDB == "" {

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -124,6 +124,7 @@ type compareMaterializedViewOutputWriter struct {
 	batchBytes    int
 	pendingRows   int
 	release       func(context.Context)
+	dropTable     func(context.Context) error
 }
 
 // CancelMaterializedViewJobExec executes "CANCEL MATERIALIZED VIEW ... JOB" as a utility-style statement.
@@ -1663,7 +1664,7 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 		}
 		defer func() {
 			if outputWriter != nil {
-				outputWriter.rollback(ctx)
+				outputWriter.rollback(context.WithoutCancel(ctx))
 			}
 		}()
 	}
@@ -1750,7 +1751,7 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 		return nil
 	}
 
-	req.AppendString(0, formatCompareMaterializedViewSummary(lastSuccessReadTSO, diffRows))
+	req.AppendString(0, formatCompareMaterializedViewSummary(lastSuccessReadTSO, diffRows, e.Ctx().GetSessionVars().Location()))
 	return nil
 }
 
@@ -1929,9 +1930,13 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewOutputWriter(
 		return nil, err
 	}
 	e.ReleaseSysSession(ctx, ddlSctx)
+	dropOutputTable := func(dropCtx context.Context) error {
+		return e.dropCompareMaterializedViewOutputTable(dropCtx, e.stmt.OutputTable)
+	}
 
 	insertSctx, err := e.GetSysSession()
 	if err != nil {
+		_ = dropOutputTable(context.WithoutCancel(ctx))
 		return nil, err
 	}
 	releaseInsertSession := func(releaseCtx context.Context) {
@@ -1942,6 +1947,7 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewOutputWriter(
 	targetTable, err := outputIS.TableByName(context.Background(), e.stmt.OutputTable.Schema, e.stmt.OutputTable.Name)
 	if err != nil {
 		releaseInsertSession(ctx)
+		_ = dropOutputTable(context.WithoutCancel(ctx))
 		return nil, err
 	}
 	writableCols := targetTable.WritableCols()
@@ -1958,7 +1964,19 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewOutputWriter(
 		batchSize:     compareMaterializedViewOutputWriterBatchSize,
 		batchBytes:    resolveCompareMaterializedViewOutputWriterBatchBytes(),
 		release:       releaseInsertSession,
+		dropTable:     dropOutputTable,
 	}, nil
+}
+
+func (e *CompareMaterializedViewExec) dropCompareMaterializedViewOutputTable(ctx context.Context, outputTable *ast.TableName) error {
+	ddlSctx, err := e.GetSysSession()
+	if err != nil {
+		return err
+	}
+	defer e.ReleaseSysSession(ctx, ddlSctx)
+
+	dropSQL := sqlescape.MustEscapeSQL("DROP TABLE IF EXISTS %n.%n", outputTable.Schema.O, outputTable.Name.O)
+	return executeRefreshMaterializedViewInternalSQL(ctx, ddlSctx.GetSQLExecutor(), dropSQL)
 }
 
 func buildCompareMaterializedViewOutputCreateTableSQL(
@@ -2304,19 +2322,24 @@ func classifyCompareMaterializedViewRowDiff(leftMissing, rightMissing, payloadCh
 	}
 }
 
-func formatCompareMaterializedViewSummary(lastSuccessReadTSO uint64, diffRows int64) string {
-	resultTime := oracle.GetTimeFromTS(lastSuccessReadTSO).Format(types.TimeFSPFormat)
+func formatCompareMaterializedViewSummary(lastSuccessReadTSO uint64, diffRows int64, loc *time.Location) string {
+	if loc == nil {
+		loc = time.Local
+	}
+	resultTime := oracle.GetTimeFromTS(lastSuccessReadTSO).In(loc).Format(types.TimeFSPFormat + " -07:00")
 	if diffRows == 0 {
 		return fmt.Sprintf(
-			"There are no differences result in %d rows compared to source base tables at timestamp '%s'",
+			"There are no differences result in %d rows compared to source base tables at timestamp '%s' (TSO: %d)",
 			diffRows,
 			resultTime,
+			lastSuccessReadTSO,
 		)
 	}
 	return fmt.Sprintf(
-		"There are differences result in %d rows compared to source base tables at timestamp '%s'",
+		"There are differences result in %d rows compared to source base tables at timestamp '%s' (TSO: %d)",
 		diffRows,
 		resultTime,
+		lastSuccessReadTSO,
 	)
 }
 
@@ -2379,6 +2402,12 @@ func (w *compareMaterializedViewOutputWriter) flushBatch(ctx context.Context) er
 	w.sctx.GetSessionVars().SetInTxn(false)
 	w.txn = nil
 	w.pendingRows = 0
+	failpoint.Inject("mockCompareMaterializedViewOutputFlushError", func(val failpoint.Value) {
+		if msg, ok := val.(string); ok {
+			failpoint.Return(errors.New(msg))
+		}
+		failpoint.Return(errors.New("mock compare materialized view output flush error"))
+	})
 	return nil
 }
 
@@ -2420,9 +2449,9 @@ func (w *compareMaterializedViewOutputWriter) commit(ctx context.Context) error 
 	return nil
 }
 
-func (w *compareMaterializedViewOutputWriter) rollback(ctx context.Context) {
+func (w *compareMaterializedViewOutputWriter) rollback(ctx context.Context) error {
 	if w == nil || w.sctx == nil {
-		return
+		return nil
 	}
 	if w.txn != nil {
 		w.sctx.RollbackTxn(ctx)
@@ -2433,6 +2462,10 @@ func (w *compareMaterializedViewOutputWriter) rollback(ctx context.Context) {
 	w.sctx = nil
 	w.txn = nil
 	w.pendingRows = 0
+	if w.dropTable != nil {
+		return w.dropTable(ctx)
+	}
+	return nil
 }
 
 // Next implements the Executor Next interface.

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1874,11 +1874,11 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewQueryExec(
 		_ = cleanup()
 		return nil, errors.New("compare materialized view: query returned nil record set")
 	}
-	schema := buildCompareMaterializedViewRecordSetSchema(rs)
-	if schema.Len() == 0 {
+	schema, err := buildCompareMaterializedViewRecordSetSchema(rs)
+	if err != nil {
 		_ = rs.Close()
 		_ = cleanup()
-		return nil, errors.New("compare materialized view: query returned empty schema")
+		return nil, err
 	}
 	return &compareMaterializedViewRecordSetExec{
 		BaseExecutor: exec.NewBaseExecutor(e.Ctx(), schema, 0),
@@ -2216,12 +2216,18 @@ func buildCompareMaterializedViewJoinSchema(leftTypes, rightTypes []*types.Field
 	return expression.NewSchema(cols...)
 }
 
-func buildCompareMaterializedViewRecordSetSchema(rs sqlexec.RecordSet) *expression.Schema {
+func buildCompareMaterializedViewRecordSetSchema(rs sqlexec.RecordSet) (*expression.Schema, error) {
 	fields := rs.Fields()
+	if len(fields) == 0 {
+		return nil, errors.New("compare materialized view: query returned empty schema")
+	}
 	cols := make([]*expression.Column, 0, len(fields))
 	for i, field := range fields {
-		if field == nil || field.Column == nil {
-			continue
+		if field == nil {
+			return nil, errors.Errorf("compare materialized view: query returned nil field at offset %d", i)
+		}
+		if field.Column == nil {
+			return nil, errors.Errorf("compare materialized view: query returned nil column at offset %d", i)
 		}
 		cols = append(cols, &expression.Column{
 			ID:      field.Column.ID,
@@ -2229,7 +2235,7 @@ func buildCompareMaterializedViewRecordSetSchema(rs sqlexec.RecordSet) *expressi
 			RetType: &field.Column.FieldType,
 		})
 	}
-	return expression.NewSchema(cols...)
+	return expression.NewSchema(cols...), nil
 }
 
 func buildCompareMaterializedViewSelectSQL(

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1673,35 +1673,21 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	baseQueryExecIsClosed := false
-	defer func() {
-		if !baseQueryExecIsClosed {
-			_ = baseQueryExec.Close()
-		}
-	}()
+	defer func() { _ = baseQueryExec.Close() }()
 
 	mvQuerySQL := buildCompareMaterializedViewSelectSQL(schemaName, tblInfo.Name, visibleCols)
 	mvQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, schemaName, compareSnapshotTS, tblInfo.MaterializedView, mvQuerySQL)
 	if err != nil {
 		return err
 	}
-	mvQueryExecIsClosed := false
-	defer func() {
-		if !mvQueryExecIsClosed {
-			_ = mvQueryExec.Close()
-		}
-	}()
+	defer func() { _ = mvQueryExec.Close() }()
 
 	hashJoinExec := newCompareMaterializedViewHashJoinExec(e.Ctx(), baseQueryExec, mvQueryExec, layout.groupKeyOffsets, visibleCols)
 	if err := exec.Open(ctx, hashJoinExec); err != nil {
 		_ = hashJoinExec.Close()
 		return err
 	}
-	defer func() {
-		_ = hashJoinExec.Close()
-		baseQueryExecIsClosed = true
-		mvQueryExecIsClosed = true
-	}()
+	defer func() { _ = hashJoinExec.Close() }()
 
 	joinResult := exec.NewFirstChunk(hashJoinExec)
 	rowIdxes := make([]int, 0, joinResult.Capacity())
@@ -2375,20 +2361,25 @@ func (e *compareMaterializedViewRecordSetExec) Open(ctx context.Context) error {
 }
 
 func (e *compareMaterializedViewRecordSetExec) Next(ctx context.Context, req *chunk.Chunk) error {
-	req.Reset()
 	return e.recordSet.Next(ctx, req)
 }
 
 func (e *compareMaterializedViewRecordSetExec) Close() error {
 	e.closeOnce.Do(func() {
+		defer func() {
+			if baseErr := e.BaseExecutor.Close(); e.closeErr == nil {
+				e.closeErr = baseErr
+			}
+		}()
+		defer func() {
+			if e.release != nil {
+				if releaseErr := e.release(); e.closeErr == nil {
+					e.closeErr = releaseErr
+				}
+			}
+		}()
 		if e.recordSet != nil {
 			e.closeErr = e.recordSet.Close()
-		}
-		if releaseErr := e.release(); e.closeErr == nil {
-			e.closeErr = releaseErr
-		}
-		if baseErr := e.BaseExecutor.Close(); e.closeErr == nil {
-			e.closeErr = baseErr
 		}
 	})
 	return e.closeErr

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -90,6 +90,9 @@ const (
 	compareMaterializedViewDifferType         = "mview_differ"
 	compareMaterializedViewVacuumType         = "mview_vacuum"
 	compareMaterializedViewExcessiveType      = "mview_excessive"
+
+	compareMaterializedViewOutputWriterBatchSize     = 1024
+	compareMaterializedViewOutputWriterBatchBytesCap = 16 * 1024 * 1024
 )
 
 type compareMaterializedViewDiffLayout struct {
@@ -115,6 +118,9 @@ type compareMaterializedViewOutputWriter struct {
 	fieldTypes    []*types.FieldType
 	row           []types.Datum
 	mvColumnCount int
+	batchSize     int
+	batchBytes    int
+	pendingRows   int
 	release       func(context.Context)
 }
 
@@ -1655,14 +1661,14 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 		}()
 	}
 
-	baseQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, schemaName, lastSuccessReadTSO, tblInfo.MaterializedView.SQLContent)
+	baseQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, schemaName, lastSuccessReadTSO, tblInfo.MaterializedView, tblInfo.MaterializedView.SQLContent)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = baseQueryExec.Close() }()
 
 	mvQuerySQL := buildCompareMaterializedViewSelectSQL(schemaName, tblInfo.Name, visibleCols)
-	mvQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, schemaName, compareSnapshotTS, mvQuerySQL)
+	mvQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, schemaName, compareSnapshotTS, tblInfo.MaterializedView, mvQuerySQL)
 	if err != nil {
 		return err
 	}
@@ -1835,11 +1841,22 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewQueryExec(
 	ctx context.Context,
 	defaultDB pmodel.CIStr,
 	snapshotTS uint64,
+	mviewInfo *model.MaterializedViewInfo,
 	sql string,
 ) (exec.Executor, error) {
 	sctx, cleanup, err := e.openCompareMaterializedViewSnapshotSession(ctx, defaultDB, snapshotTS)
 	if err != nil {
 		return nil, err
+	}
+	restoreDefinitionSession, err := initRefreshMaterializedViewSession(sctx.GetSessionVars(), mviewInfo)
+	if err != nil {
+		_ = cleanup()
+		return nil, err
+	}
+	snapshotCleanup := cleanup
+	cleanup = func() error {
+		restoreDefinitionSession()
+		return snapshotCleanup()
 	}
 
 	rs, err := sctx.GetSQLExecutor().ExecuteInternal(ctx, sql)
@@ -1927,16 +1944,6 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewOutputWriter(
 	releaseInsertSession := func(releaseCtx context.Context) {
 		e.ReleaseSysSession(releaseCtx, insertSctx)
 	}
-	if err := sessiontxn.NewTxn(ctx, insertSctx); err != nil {
-		releaseInsertSession(ctx)
-		return nil, err
-	}
-	txn, err := insertSctx.Txn(true)
-	if err != nil {
-		releaseInsertSession(ctx)
-		return nil, err
-	}
-	insertSctx.GetSessionVars().SetInTxn(true)
 
 	outputIS := domain.GetDomain(e.Ctx()).InfoSchema()
 	targetTable, err := outputIS.TableByName(context.Background(), e.stmt.OutputTable.Schema, e.stmt.OutputTable.Name)
@@ -1952,10 +1959,11 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewOutputWriter(
 	return &compareMaterializedViewOutputWriter{
 		sctx:          insertSctx,
 		targetTable:   targetTable,
-		txn:           txn,
 		fieldTypes:    fieldTypes,
 		row:           make([]types.Datum, len(writableCols)),
 		mvColumnCount: len(visibleCols),
+		batchSize:     compareMaterializedViewOutputWriterBatchSize,
+		batchBytes:    resolveCompareMaterializedViewOutputWriterBatchBytes(),
 		release:       releaseInsertSession,
 	}, nil
 }
@@ -2269,7 +2277,48 @@ func (e *compareMaterializedViewRecordSetExec) Close() error {
 	return e.closeErr
 }
 
+func resolveCompareMaterializedViewOutputWriterBatchBytes() int {
+	txnLimit := kv.TxnTotalSizeLimit.Load() / 4
+	if compareMaterializedViewOutputWriterBatchBytesCap > 0 && txnLimit > uint64(compareMaterializedViewOutputWriterBatchBytesCap) {
+		txnLimit = uint64(compareMaterializedViewOutputWriterBatchBytesCap)
+	}
+	return max(int(txnLimit), 1)
+}
+
+func (w *compareMaterializedViewOutputWriter) ensureTxn(ctx context.Context) error {
+	if w.txn != nil {
+		return nil
+	}
+	if err := sessiontxn.NewTxnInStmt(ctx, w.sctx); err != nil {
+		return err
+	}
+	txn, err := w.sctx.Txn(true)
+	if err != nil {
+		return err
+	}
+	w.txn = txn
+	w.pendingRows = 0
+	return nil
+}
+
+func (w *compareMaterializedViewOutputWriter) flushBatch(ctx context.Context) error {
+	if w.txn == nil {
+		return nil
+	}
+	w.sctx.StmtCommit(ctx)
+	if err := w.sctx.CommitTxn(ctx); err != nil {
+		return err
+	}
+	w.sctx.GetSessionVars().SetInTxn(false)
+	w.txn = nil
+	w.pendingRows = 0
+	return nil
+}
+
 func (w *compareMaterializedViewOutputWriter) writeRow(ctx context.Context, row chunk.Row, diffType string) error {
+	if err := w.ensureTxn(ctx); err != nil {
+		return err
+	}
 	useRight := diffType != compareMaterializedViewVacuumType
 	for colIdx := 0; colIdx < w.mvColumnCount; colIdx++ {
 		sourceColIdx := colIdx
@@ -2282,6 +2331,10 @@ func (w *compareMaterializedViewOutputWriter) writeRow(ctx context.Context, row 
 	if _, err := w.targetTable.AddRecord(w.sctx.GetTableCtx(), w.txn, w.row, table.WithCtx(ctx), table.DupKeyCheckLazy); err != nil {
 		return err
 	}
+	w.pendingRows++
+	if w.pendingRows >= w.batchSize || w.txn.Size() >= w.batchBytes {
+		return w.flushBatch(ctx)
+	}
 	return nil
 }
 
@@ -2289,8 +2342,7 @@ func (w *compareMaterializedViewOutputWriter) commit(ctx context.Context) error 
 	if w == nil || w.sctx == nil {
 		return nil
 	}
-	w.sctx.StmtCommit(ctx)
-	if err := w.sctx.CommitTxn(ctx); err != nil {
+	if err := w.flushBatch(ctx); err != nil {
 		return err
 	}
 	if w.release != nil {
@@ -2305,11 +2357,15 @@ func (w *compareMaterializedViewOutputWriter) rollback(ctx context.Context) {
 	if w == nil || w.sctx == nil {
 		return
 	}
+	if w.txn != nil {
+		w.sctx.RollbackTxn(ctx)
+	}
 	if w.release != nil {
 		w.release(ctx)
 	}
 	w.sctx = nil
 	w.txn = nil
+	w.pendingRows = 0
 }
 
 // Next implements the Executor Next interface.

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1641,7 +1641,7 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 		return err
 	}
 
-	lastSuccessReadTSO, err := e.readCompareMaterializedViewLastSuccessReadTSO(ctx, schemaName, tblInfo.ID, compareSnapshotTS)
+	lastSuccessReadTSO, err := e.readCompareMaterializedViewLastSuccessReadTSO(ctx, tblInfo.ID, compareSnapshotTS)
 	if err != nil {
 		return err
 	}
@@ -1669,14 +1669,14 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 		}()
 	}
 
-	baseQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, schemaName, lastSuccessReadTSO, tblInfo.MaterializedView, tblInfo.MaterializedView.SQLContent)
+	baseQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, lastSuccessReadTSO, tblInfo.MaterializedView, tblInfo.MaterializedView.SQLContent)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = baseQueryExec.Close() }()
 
 	mvQuerySQL := buildCompareMaterializedViewSelectSQL(schemaName, tblInfo.Name, visibleCols)
-	mvQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, schemaName, compareSnapshotTS, tblInfo.MaterializedView, mvQuerySQL)
+	mvQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, compareSnapshotTS, tblInfo.MaterializedView, mvQuerySQL)
 	if err != nil {
 		return err
 	}
@@ -1817,11 +1817,10 @@ func (e *CompareMaterializedViewExec) resolveCompareMaterializedViewSnapshotTS(c
 
 func (e *CompareMaterializedViewExec) readCompareMaterializedViewLastSuccessReadTSO(
 	ctx context.Context,
-	schemaName pmodel.CIStr,
 	mviewID int64,
 	compareSnapshotTS uint64,
 ) (uint64, error) {
-	sctx, cleanup, err := e.openCompareMaterializedViewSnapshotSession(ctx, schemaName, compareSnapshotTS)
+	sctx, cleanup, err := e.openCompareMaterializedViewSnapshotSession(ctx, compareSnapshotTS)
 	if err != nil {
 		return 0, err
 	}
@@ -1846,12 +1845,11 @@ func (e *CompareMaterializedViewExec) readCompareMaterializedViewLastSuccessRead
 
 func (e *CompareMaterializedViewExec) openCompareMaterializedViewQueryExec(
 	ctx context.Context,
-	defaultDB pmodel.CIStr,
 	snapshotTS uint64,
 	mviewInfo *model.MaterializedViewInfo,
 	sql string,
 ) (exec.Executor, error) {
-	sctx, cleanup, err := e.openCompareMaterializedViewSnapshotSession(ctx, defaultDB, snapshotTS)
+	sctx, cleanup, err := e.openCompareMaterializedViewSnapshotSession(ctx, snapshotTS)
 	if err != nil {
 		return nil, err
 	}
@@ -1890,14 +1888,13 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewQueryExec(
 
 func (e *CompareMaterializedViewExec) openCompareMaterializedViewSnapshotSession(
 	ctx context.Context,
-	defaultDB pmodel.CIStr,
 	snapshotTS uint64,
 ) (sessionctx.Context, func() error, error) {
 	sctx, err := e.GetSysSession()
 	if err != nil {
 		return nil, nil, err
 	}
-	restore, err := prepareCompareMaterializedViewSnapshotSession(sctx, defaultDB, snapshotTS)
+	restore, err := prepareCompareMaterializedViewSnapshotSession(sctx, snapshotTS)
 	if err != nil {
 		e.ReleaseSysSession(ctx, sctx)
 		return nil, nil, err
@@ -2057,42 +2054,34 @@ func buildCompareMaterializedViewOutputCreateTableSQL(
 
 func prepareCompareMaterializedViewSnapshotSession(
 	sctx sessionctx.Context,
-	defaultDB pmodel.CIStr,
 	snapshotTS uint64,
 ) (func() error, error) {
 	sessVars := sctx.GetSessionVars()
-	origCurrentDB := sessVars.CurrentDB
 	origSnapshotTS := sessVars.SnapshotTS
-	origSnapshotInfoSchema := sessVars.SnapshotInfoschema
 
-	sessVars.CurrentDB = defaultDB.O
-	if err := sessVars.SetSystemVar(variable.TiDBSnapshot, strconv.FormatUint(snapshotTS, 10)); err != nil {
-		sessVars.CurrentDB = origCurrentDB
-		return nil, err
-	}
-	if err := loadSnapshotInfoSchemaIfNeeded(sctx, snapshotTS); err != nil {
-		_ = sessVars.SetSystemVar(variable.TiDBSnapshot, "")
-		sessVars.SnapshotInfoschema = origSnapshotInfoSchema
-		sessVars.SnapshotTS = origSnapshotTS
-		sessVars.CurrentDB = origCurrentDB
+	if err := setCompareMaterializedViewSnapshot(sctx, snapshotTS); err != nil {
 		return nil, err
 	}
 
 	return func() error {
-		sessVars.CurrentDB = origCurrentDB
-		if origSnapshotTS == 0 {
-			if err := sessVars.SetSystemVar(variable.TiDBSnapshot, ""); err != nil {
-				return err
-			}
-		} else {
-			if err := sessVars.SetSystemVar(variable.TiDBSnapshot, strconv.FormatUint(origSnapshotTS, 10)); err != nil {
-				return err
-			}
-		}
-		sessVars.SnapshotTS = origSnapshotTS
-		sessVars.SnapshotInfoschema = origSnapshotInfoSchema
-		return nil
+		return setCompareMaterializedViewSnapshot(sctx, origSnapshotTS)
 	}, nil
+}
+
+func setCompareMaterializedViewSnapshot(sctx sessionctx.Context, snapshotTS uint64) error {
+	snapshot := ""
+	if snapshotTS != 0 {
+		snapshot = strconv.FormatUint(snapshotTS, 10)
+	}
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnMVMaintenance)
+	rs, err := sctx.GetSQLExecutor().ExecuteInternal(ctx, "SET @@tidb_snapshot = %?", snapshot)
+	if err != nil {
+		return err
+	}
+	if rs != nil {
+		return rs.Close()
+	}
+	return nil
 }
 
 func buildCompareMaterializedViewDiffLayout(

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -2256,13 +2256,13 @@ func formatCompareMaterializedViewSummary(lastSuccessReadTSO uint64, diffRows in
 	resultTime := oracle.GetTimeFromTS(lastSuccessReadTSO).Format(types.TimeFSPFormat)
 	if diffRows == 0 {
 		return fmt.Sprintf(
-			"There are no differencies result in %d rows compared to source base tables at timestamp '%s'",
+			"There are no differences result in %d rows compared to source base tables at timestamp '%s'",
 			diffRows,
 			resultTime,
 		)
 	}
 	return fmt.Sprintf(
-		"There are differencies result in %d rows compared to source base tables at timestamp '%s'",
+		"There are differences result in %d rows compared to source base tables at timestamp '%s'",
 		diffRows,
 		resultTime,
 	)

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
+	"github.com/pingcap/tidb/pkg/executor/join"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -43,11 +44,14 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	plannercorebase "github.com/pingcap/tidb/pkg/planner/core/base"
+	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
+	mvmerge "github.com/pingcap/tidb/pkg/planner/mview"
 	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/privilege"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/sessiontxn"
 	"github.com/pingcap/tidb/pkg/sessiontxn/staleread"
 	storeerr "github.com/pingcap/tidb/pkg/store/driver/error"
 	"github.com/pingcap/tidb/pkg/table"
@@ -61,6 +65,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/sqlescape"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
+	"github.com/tikv/client-go/v2/oracle"
 	"go.uber.org/zap"
 )
 
@@ -78,6 +83,39 @@ type CompareMaterializedViewExec struct {
 	exec.BaseExecutor
 	stmt *ast.CompareMaterializedViewStmt
 	done bool
+}
+
+const (
+	compareMaterializedViewDifferTypeBaseName = "_Differ_type_"
+	compareMaterializedViewDifferType         = "mview_differ"
+	compareMaterializedViewVacuumType         = "mview_vacuum"
+	compareMaterializedViewExcessiveType      = "mview_excessive"
+)
+
+type compareMaterializedViewDiffLayout struct {
+	groupKeyOffsets       []int
+	leftMarkerColIdx      int
+	rightMarkerColIdx     int
+	payloadCompareColumns []mvCompleteDeltaCompareColumn
+}
+
+type compareMaterializedViewRecordSetExec struct {
+	exec.BaseExecutor
+
+	recordSet sqlexec.RecordSet
+	release   func() error
+	closeOnce sync.Once
+	closeErr  error
+}
+
+type compareMaterializedViewOutputWriter struct {
+	sctx          sessionctx.Context
+	targetTable   table.Table
+	txn           kv.Transaction
+	fieldTypes    []*types.FieldType
+	row           []types.Datum
+	mvColumnCount int
+	release       func(context.Context)
 }
 
 // CancelMaterializedViewJobExec executes "CANCEL MATERIALIZED VIEW ... JOB" as a utility-style statement.
@@ -1595,13 +1633,16 @@ func (e *RefreshMaterializedViewExec) Next(ctx context.Context, _ *chunk.Chunk) 
 }
 
 // Next implements the Executor Next interface.
-func (e *CompareMaterializedViewExec) Next(_ context.Context, _ *chunk.Chunk) error {
+func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk) error {
+	req.Reset()
 	if e.done {
 		return nil
 	}
 	e.done = true
 
-	_, tblInfo, err := e.resolveCompareMaterializedViewTarget()
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
+
+	schemaName, targetTable, tblInfo, err := e.resolveCompareMaterializedViewTarget()
 	if err != nil {
 		return err
 	}
@@ -1611,7 +1652,123 @@ func (e *CompareMaterializedViewExec) Next(_ context.Context, _ *chunk.Chunk) er
 	if err := e.checkCompareMaterializedViewOutputTableNotExists(); err != nil {
 		return err
 	}
-	return errors.NewNoStackError("COMPARE MATERIALIZED VIEW is not implemented")
+
+	compareSnapshotTS, err := e.resolveCompareMaterializedViewSnapshotTS(ctx)
+	if err != nil {
+		return err
+	}
+	lastSuccessReadTSO, err := e.readCompareMaterializedViewLastSuccessReadTSO(ctx, schemaName, tblInfo.ID, compareSnapshotTS)
+	if err != nil {
+		return err
+	}
+
+	diffMeta, err := mvmerge.BuildCompleteDiffSource(e.Ctx().GetPlanCtx(), domain.GetDomain(e.Ctx()).InfoSchema(), tblInfo)
+	if err != nil {
+		return err
+	}
+	visibleCols := targetTable.VisibleCols()
+	layout, err := buildCompareMaterializedViewDiffLayout(diffMeta, visibleCols)
+	if err != nil {
+		return err
+	}
+
+	var outputWriter *compareMaterializedViewOutputWriter
+	if e.stmt.OutputTable != nil {
+		outputWriter, err = e.openCompareMaterializedViewOutputWriter(ctx, schemaName, tblInfo, visibleCols)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if outputWriter != nil {
+				outputWriter.rollback(ctx)
+			}
+		}()
+	}
+
+	baseQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, schemaName, lastSuccessReadTSO, tblInfo.MaterializedView.SQLContent)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = baseQueryExec.Close() }()
+
+	mvQuerySQL := buildCompareMaterializedViewSelectSQL(schemaName, tblInfo.Name, visibleCols)
+	mvQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, schemaName, compareSnapshotTS, mvQuerySQL)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = mvQueryExec.Close() }()
+
+	hashJoinExec := newCompareMaterializedViewHashJoinExec(e.Ctx(), baseQueryExec, mvQueryExec, layout.groupKeyOffsets, visibleCols)
+	if err := exec.Open(ctx, hashJoinExec); err != nil {
+		_ = hashJoinExec.Close()
+		return err
+	}
+	defer func() { _ = hashJoinExec.Close() }()
+
+	joinResult := exec.NewFirstChunk(hashJoinExec)
+	rowIdxes := make([]int, 0, joinResult.Capacity())
+	changedRows := make([]uint8, 0, joinResult.Capacity())
+	var diffRows int64
+	for {
+		joinResult.Reset()
+		if err := exec.Next(ctx, hashJoinExec, joinResult); err != nil {
+			return err
+		}
+		if joinResult.NumRows() == 0 {
+			break
+		}
+
+		rowIdxes = prepareCompareMaterializedViewRowIdxes(rowIdxes, joinResult.NumRows())
+		if cap(changedRows) < joinResult.NumRows() {
+			changedRows = make([]uint8, joinResult.NumRows())
+		} else {
+			changedRows = changedRows[:joinResult.NumRows()]
+			clear(changedRows)
+		}
+		for _, compareCol := range layout.payloadCompareColumns {
+			if err := markMVCompleteDeltaTouchedRowsByColumn(
+				rowIdxes,
+				changedRows,
+				1,
+				true,
+				compareCol,
+				joinResult.Column(compareCol.mInputColID),
+				joinResult.Column(compareCol.qInputColID),
+			); err != nil {
+				return err
+			}
+		}
+
+		leftMarkerCol := joinResult.Column(layout.leftMarkerColIdx)
+		rightMarkerCol := joinResult.Column(layout.rightMarkerColIdx)
+		for rowIdx := 0; rowIdx < joinResult.NumRows(); rowIdx++ {
+			diffType := classifyCompareMaterializedViewRowDiff(
+				leftMarkerCol.IsNull(rowIdx),
+				rightMarkerCol.IsNull(rowIdx),
+				changedRows[rowIdx] != 0,
+			)
+			if diffType == "" {
+				continue
+			}
+			diffRows++
+			if outputWriter != nil {
+				if err := outputWriter.writeRow(ctx, joinResult.GetRow(rowIdx), diffType); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	if outputWriter != nil {
+		if err := outputWriter.commit(ctx); err != nil {
+			return err
+		}
+		outputWriter = nil
+		return nil
+	}
+
+	req.AppendString(0, formatCompareMaterializedViewSummary(lastSuccessReadTSO, diffRows))
+	return nil
 }
 
 func (e *CompareMaterializedViewExec) checkCompareMaterializedViewOutputTableNotExists() error {
@@ -1637,35 +1794,545 @@ func (e *CompareMaterializedViewExec) checkCompareMaterializedViewOutputTableNot
 	return nil
 }
 
-func (e *CompareMaterializedViewExec) resolveCompareMaterializedViewTarget() (pmodel.CIStr, *model.TableInfo, error) {
+func (e *CompareMaterializedViewExec) resolveCompareMaterializedViewTarget() (pmodel.CIStr, table.Table, *model.TableInfo, error) {
 	is := e.Ctx().GetDomainInfoSchema().(infoschema.InfoSchema)
 	schemaName := e.stmt.ViewName.Schema
 	if schemaName.O == "" {
 		if e.Ctx().GetSessionVars().CurrentDB == "" {
-			return pmodel.CIStr{}, nil, errors.Trace(plannererrors.ErrNoDB)
+			return pmodel.CIStr{}, nil, nil, errors.Trace(plannererrors.ErrNoDB)
 		}
 		schemaName = pmodel.NewCIStr(e.Ctx().GetSessionVars().CurrentDB)
 		e.stmt.ViewName.Schema = schemaName
 	}
 	if _, ok := is.SchemaByName(schemaName); !ok {
-		return pmodel.CIStr{}, nil, infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
+		return pmodel.CIStr{}, nil, nil, infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
 	}
 
 	tbl, err := is.TableByName(context.Background(), schemaName, e.stmt.ViewName.Name)
 	if err != nil {
-		return pmodel.CIStr{}, nil, err
+		return pmodel.CIStr{}, nil, nil, err
 	}
 	tblInfo := tbl.Meta()
 	if tblInfo.MaterializedView == nil {
-		return pmodel.CIStr{}, nil, dbterror.ErrWrongObject.GenWithStackByArgs(schemaName.O, e.stmt.ViewName.Name.O, "MATERIALIZED VIEW")
+		return pmodel.CIStr{}, nil, nil, dbterror.ErrWrongObject.GenWithStackByArgs(schemaName.O, e.stmt.ViewName.Name.O, "MATERIALIZED VIEW")
 	}
 	if len(tblInfo.MaterializedView.SQLContent) == 0 {
-		return pmodel.CIStr{}, nil, errors.New("compare materialized view: invalid select sql")
+		return pmodel.CIStr{}, nil, nil, errors.New("compare materialized view: invalid select sql")
 	}
 	if err := checkRefreshMaterializedViewReady(schemaName, tblInfo); err != nil {
-		return pmodel.CIStr{}, nil, err
+		return pmodel.CIStr{}, nil, nil, err
 	}
-	return schemaName, tblInfo, nil
+	return schemaName, tbl, tblInfo, nil
+}
+
+func (e *CompareMaterializedViewExec) resolveCompareMaterializedViewSnapshotTS(ctx context.Context) (uint64, error) {
+	if e.stmt.AsOf == nil {
+		return 0, errors.New("compare materialized view: missing AS OF TIMESTAMP")
+	}
+	return staleread.CalculateAsOfTsExpr(ctx, e.Ctx().GetPlanCtx(), e.stmt.AsOf.TsExpr)
+}
+
+func (e *CompareMaterializedViewExec) readCompareMaterializedViewLastSuccessReadTSO(
+	ctx context.Context,
+	schemaName pmodel.CIStr,
+	mviewID int64,
+	compareSnapshotTS uint64,
+) (uint64, error) {
+	sctx, cleanup, err := e.openCompareMaterializedViewSnapshotSession(ctx, schemaName, compareSnapshotTS)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = cleanup() }()
+
+	readTSO, readTSONull, err := readRefreshInfoReadTSO(ctx, sctx.GetSQLExecutor(), mviewID)
+	if err != nil {
+		return 0, err
+	}
+	if readTSONull {
+		return 0, errors.New("compare materialized view: LAST_SUCCESS_READ_TSO is NULL")
+	}
+	return readTSO, nil
+}
+
+func (e *CompareMaterializedViewExec) openCompareMaterializedViewQueryExec(
+	ctx context.Context,
+	defaultDB pmodel.CIStr,
+	snapshotTS uint64,
+	sql string,
+) (exec.Executor, error) {
+	sctx, cleanup, err := e.openCompareMaterializedViewSnapshotSession(ctx, defaultDB, snapshotTS)
+	if err != nil {
+		return nil, err
+	}
+
+	rs, err := sctx.GetSQLExecutor().ExecuteInternal(ctx, sql)
+	if err != nil {
+		_ = cleanup()
+		return nil, err
+	}
+	if rs == nil {
+		_ = cleanup()
+		return nil, errors.New("compare materialized view: query returned nil record set")
+	}
+	schema := buildCompareMaterializedViewRecordSetSchema(rs)
+	if schema.Len() == 0 {
+		_ = rs.Close()
+		_ = cleanup()
+		return nil, errors.New("compare materialized view: query returned empty schema")
+	}
+	return &compareMaterializedViewRecordSetExec{
+		BaseExecutor: exec.NewBaseExecutor(e.Ctx(), schema, 0),
+		recordSet:    rs,
+		release:      cleanup,
+	}, nil
+}
+
+func (e *CompareMaterializedViewExec) openCompareMaterializedViewSnapshotSession(
+	ctx context.Context,
+	defaultDB pmodel.CIStr,
+	snapshotTS uint64,
+) (sessionctx.Context, func() error, error) {
+	sctx, err := e.GetSysSession()
+	if err != nil {
+		return nil, nil, err
+	}
+	restore, err := prepareCompareMaterializedViewSnapshotSession(sctx, defaultDB, snapshotTS)
+	if err != nil {
+		e.ReleaseSysSession(ctx, sctx)
+		return nil, nil, err
+	}
+	return sctx, func() error {
+		restoreErr := restore()
+		e.ReleaseSysSession(ctx, sctx)
+		return restoreErr
+	}, nil
+}
+
+func (e *CompareMaterializedViewExec) openCompareMaterializedViewOutputWriter(
+	ctx context.Context,
+	schemaName pmodel.CIStr,
+	tblInfo *model.TableInfo,
+	visibleCols []*table.Column,
+) (*compareMaterializedViewOutputWriter, error) {
+	diffTypeColName := chooseCompareMaterializedViewDifferTypeColumnName(visibleCols)
+
+	ddlSctx, err := e.GetSysSession()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := ddlSctx.GetSQLExecutor().ExecuteInternal(
+		ctx,
+		"CREATE TABLE %n.%n LIKE %n.%n",
+		e.stmt.OutputTable.Schema.O,
+		e.stmt.OutputTable.Name.O,
+		schemaName.O,
+		tblInfo.Name.O,
+	); err != nil {
+		e.ReleaseSysSession(ctx, ddlSctx)
+		return nil, err
+	}
+	if _, err := ddlSctx.GetSQLExecutor().ExecuteInternal(
+		ctx,
+		"ALTER TABLE %n.%n ADD COLUMN %n VARCHAR(32) NOT NULL",
+		e.stmt.OutputTable.Schema.O,
+		e.stmt.OutputTable.Name.O,
+		diffTypeColName.O,
+	); err != nil {
+		e.ReleaseSysSession(ctx, ddlSctx)
+		return nil, err
+	}
+	e.ReleaseSysSession(ctx, ddlSctx)
+
+	insertSctx, err := e.GetSysSession()
+	if err != nil {
+		return nil, err
+	}
+	releaseInsertSession := func(releaseCtx context.Context) {
+		e.ReleaseSysSession(releaseCtx, insertSctx)
+	}
+	if err := sessiontxn.NewTxn(ctx, insertSctx); err != nil {
+		releaseInsertSession(ctx)
+		return nil, err
+	}
+	txn, err := insertSctx.Txn(true)
+	if err != nil {
+		releaseInsertSession(ctx)
+		return nil, err
+	}
+	insertSctx.GetSessionVars().SetInTxn(true)
+
+	outputIS := domain.GetDomain(e.Ctx()).InfoSchema()
+	targetTable, err := outputIS.TableByName(context.Background(), e.stmt.OutputTable.Schema, e.stmt.OutputTable.Name)
+	if err != nil {
+		releaseInsertSession(ctx)
+		return nil, err
+	}
+	writableCols := targetTable.WritableCols()
+	fieldTypes := make([]*types.FieldType, len(writableCols))
+	for i := range writableCols {
+		fieldTypes[i] = &writableCols[i].FieldType
+	}
+	return &compareMaterializedViewOutputWriter{
+		sctx:          insertSctx,
+		targetTable:   targetTable,
+		txn:           txn,
+		fieldTypes:    fieldTypes,
+		row:           make([]types.Datum, len(writableCols)),
+		mvColumnCount: len(visibleCols),
+		release:       releaseInsertSession,
+	}, nil
+}
+
+func prepareCompareMaterializedViewSnapshotSession(
+	sctx sessionctx.Context,
+	defaultDB pmodel.CIStr,
+	snapshotTS uint64,
+) (func() error, error) {
+	sessVars := sctx.GetSessionVars()
+	origCurrentDB := sessVars.CurrentDB
+	origSnapshotTS := sessVars.SnapshotTS
+	origSnapshotInfoSchema := sessVars.SnapshotInfoschema
+
+	sessVars.CurrentDB = defaultDB.O
+	if err := sessVars.SetSystemVar(variable.TiDBSnapshot, strconv.FormatUint(snapshotTS, 10)); err != nil {
+		sessVars.CurrentDB = origCurrentDB
+		return nil, err
+	}
+	if err := loadSnapshotInfoSchemaIfNeeded(sctx, snapshotTS); err != nil {
+		_ = sessVars.SetSystemVar(variable.TiDBSnapshot, "")
+		sessVars.SnapshotInfoschema = origSnapshotInfoSchema
+		sessVars.SnapshotTS = origSnapshotTS
+		sessVars.CurrentDB = origCurrentDB
+		return nil, err
+	}
+
+	return func() error {
+		sessVars.CurrentDB = origCurrentDB
+		if origSnapshotTS == 0 {
+			if err := sessVars.SetSystemVar(variable.TiDBSnapshot, ""); err != nil {
+				return err
+			}
+		} else {
+			if err := sessVars.SetSystemVar(variable.TiDBSnapshot, strconv.FormatUint(origSnapshotTS, 10)); err != nil {
+				return err
+			}
+		}
+		sessVars.SnapshotTS = origSnapshotTS
+		sessVars.SnapshotInfoschema = origSnapshotInfoSchema
+		return nil
+	}, nil
+}
+
+func buildCompareMaterializedViewDiffLayout(
+	diffMeta *mvmerge.CompleteDiffBuildResult,
+	visibleCols []*table.Column,
+) (*compareMaterializedViewDiffLayout, error) {
+	if diffMeta == nil {
+		return nil, errors.New("compare materialized view: diff metadata is nil")
+	}
+	if len(visibleCols) != diffMeta.MVColumnCount {
+		return nil, errors.New("compare materialized view: hidden MV columns are unsupported")
+	}
+
+	groupKeySet := make(map[int]struct{}, len(diffMeta.GroupKeyMVOffsets))
+	for _, offset := range diffMeta.GroupKeyMVOffsets {
+		groupKeySet[offset] = struct{}{}
+	}
+
+	layout := &compareMaterializedViewDiffLayout{
+		groupKeyOffsets:   append([]int(nil), diffMeta.GroupKeyMVOffsets...),
+		leftMarkerColIdx:  diffMeta.MarkerMVOffset,
+		rightMarkerColIdx: len(visibleCols) + diffMeta.MarkerMVOffset,
+	}
+	layout.payloadCompareColumns = make([]mvCompleteDeltaCompareColumn, 0, len(visibleCols)-len(groupKeySet))
+	for offset, col := range visibleCols {
+		if _, ok := groupKeySet[offset]; ok {
+			continue
+		}
+		layout.payloadCompareColumns = append(layout.payloadCompareColumns, mvCompleteDeltaCompareColumn{
+			mInputColID:    offset,
+			qInputColID:    len(visibleCols) + offset,
+			fieldType:      &col.FieldType,
+			notNull:        mysql.HasNotNullFlag(col.GetFlag()),
+			touchedBitMask: 1,
+		})
+	}
+	return layout, nil
+}
+
+func newCompareMaterializedViewHashJoinExec(
+	ctx sessionctx.Context,
+	leftExec exec.Executor,
+	rightExec exec.Executor,
+	groupKeyOffsets []int,
+	visibleCols []*table.Column,
+) *join.HashJoinV1Exec {
+	leftTypes, rightTypes := exec.RetTypes(leftExec), exec.RetTypes(rightExec)
+	joinedSchema := buildCompareMaterializedViewJoinSchema(leftTypes, rightTypes)
+	concurrency := uint(ctx.GetSessionVars().Concurrency.HashJoinConcurrency())
+	if concurrency == 0 {
+		concurrency = 1
+	}
+
+	hashJoinExec := &join.HashJoinV1Exec{
+		BaseExecutor:          exec.NewBaseExecutor(ctx, joinedSchema, 0, leftExec, rightExec),
+		ProbeSideTupleFetcher: &join.ProbeSideTupleFetcherV1{},
+		ProbeWorkers:          make([]*join.ProbeWorkerV1, concurrency),
+		BuildWorker:           &join.BuildWorkerV1{},
+		HashJoinCtxV1: &join.HashJoinCtxV1{
+			IsOuterJoin:     true,
+			UseOuterToBuild: false,
+		},
+	}
+	hashJoinExec.HashJoinCtxV1.SessCtx = ctx
+	hashJoinExec.HashJoinCtxV1.JoinType = logicalop.FullOuterJoin
+	hashJoinExec.HashJoinCtxV1.Concurrency = concurrency
+	hashJoinExec.HashJoinCtxV1.ChunkAllocPool = hashJoinExec.AllocPool
+	hashJoinExec.HashJoinCtxV1.IsNullEQ = buildCompareMaterializedViewNullEQFlags(groupKeyOffsets, visibleCols)
+	hashJoinExec.FullOuterJoinBuildFilter = nil
+	hashJoinExec.FullOuterJoinProbeFilter = nil
+
+	probeKeyColIdx := append([]int(nil), groupKeyOffsets...)
+	buildKeyColIdx := append([]int(nil), groupKeyOffsets...)
+	hashJoinExec.ProbeSideTupleFetcher.ProbeSideExec = leftExec
+	hashJoinExec.BuildWorker.BuildKeyColIdx = buildKeyColIdx
+	hashJoinExec.BuildWorker.BuildSideExec = rightExec
+	hashJoinExec.BuildWorker.HashJoinCtx = hashJoinExec.HashJoinCtxV1
+
+	childrenUsedSchema := [][]int{
+		buildCompareMaterializedViewOrdinalSlice(len(leftTypes)),
+		buildCompareMaterializedViewOrdinalSlice(len(rightTypes)),
+	}
+	fullJoinBuildJoiner := join.NewJoiner(
+		ctx,
+		logicalop.RightOuterJoin,
+		true,
+		make([]types.Datum, len(leftTypes)),
+		nil,
+		leftTypes,
+		rightTypes,
+		childrenUsedSchema,
+		false,
+	)
+	fullJoinProbeJoiner := join.NewJoiner(
+		ctx,
+		logicalop.LeftOuterJoin,
+		false,
+		make([]types.Datum, len(rightTypes)),
+		nil,
+		leftTypes,
+		rightTypes,
+		childrenUsedSchema,
+		false,
+	)
+	for i := uint(0); i < concurrency; i++ {
+		probeJoiner := fullJoinProbeJoiner.Clone()
+		hashJoinExec.ProbeWorkers[i] = &join.ProbeWorkerV1{
+			HashJoinCtx:         hashJoinExec.HashJoinCtxV1,
+			ProbeKeyColIdx:      probeKeyColIdx,
+			Joiner:              probeJoiner,
+			FullJoinBuildJoiner: fullJoinBuildJoiner.Clone(),
+			FullJoinProbeJoiner: probeJoiner,
+		}
+		hashJoinExec.ProbeWorkers[i].WorkerID = i
+	}
+
+	hashJoinExec.BuildTypes = buildCompareMaterializedViewKeyTypes(rightTypes, groupKeyOffsets)
+	hashJoinExec.ProbeTypes = buildCompareMaterializedViewKeyTypes(leftTypes, groupKeyOffsets)
+	return hashJoinExec
+}
+
+func buildCompareMaterializedViewNullEQFlags(groupKeyOffsets []int, visibleCols []*table.Column) []bool {
+	flags := make([]bool, len(groupKeyOffsets))
+	for i, offset := range groupKeyOffsets {
+		flags[i] = !mysql.HasNotNullFlag(visibleCols[offset].GetFlag())
+	}
+	return flags
+}
+
+func buildCompareMaterializedViewKeyTypes(fieldTypes []*types.FieldType, groupKeyOffsets []int) []*types.FieldType {
+	keyTypes := make([]*types.FieldType, len(groupKeyOffsets))
+	for i, offset := range groupKeyOffsets {
+		keyTypes[i] = fieldTypes[offset].Clone()
+	}
+	return keyTypes
+}
+
+func buildCompareMaterializedViewJoinSchema(leftTypes, rightTypes []*types.FieldType) *expression.Schema {
+	cols := make([]*expression.Column, 0, len(leftTypes)+len(rightTypes))
+	for i, ft := range leftTypes {
+		cols = append(cols, &expression.Column{Index: i, RetType: ft})
+	}
+	offset := len(leftTypes)
+	for i, ft := range rightTypes {
+		cols = append(cols, &expression.Column{Index: offset + i, RetType: ft})
+	}
+	return expression.NewSchema(cols...)
+}
+
+func buildCompareMaterializedViewRecordSetSchema(rs sqlexec.RecordSet) *expression.Schema {
+	fields := rs.Fields()
+	cols := make([]*expression.Column, 0, len(fields))
+	for i, field := range fields {
+		if field == nil || field.Column == nil {
+			continue
+		}
+		cols = append(cols, &expression.Column{
+			ID:      field.Column.ID,
+			Index:   i,
+			RetType: &field.Column.FieldType,
+		})
+	}
+	return expression.NewSchema(cols...)
+}
+
+func buildCompareMaterializedViewSelectSQL(
+	schemaName pmodel.CIStr,
+	tableName pmodel.CIStr,
+	visibleCols []*table.Column,
+) string {
+	var sb strings.Builder
+	sb.WriteString("SELECT ")
+	for i, col := range visibleCols {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(sqlescape.MustEscapeSQL("%n", col.Name.O))
+	}
+	sb.WriteString(" FROM ")
+	sb.WriteString(sqlescape.MustEscapeSQL("%n.%n", schemaName.O, tableName.O))
+	return sb.String()
+}
+
+func chooseCompareMaterializedViewDifferTypeColumnName(visibleCols []*table.Column) pmodel.CIStr {
+	used := make(map[string]struct{}, len(visibleCols))
+	for _, col := range visibleCols {
+		used[col.Name.L] = struct{}{}
+	}
+	base := compareMaterializedViewDifferTypeBaseName
+	name := base
+	for suffix := 1; ; suffix++ {
+		if _, exists := used[strings.ToLower(name)]; !exists {
+			return pmodel.NewCIStr(name)
+		}
+		name = fmt.Sprintf("%s%d", base, suffix)
+	}
+}
+
+func prepareCompareMaterializedViewRowIdxes(rowIdxes []int, rowCnt int) []int {
+	if cap(rowIdxes) < rowCnt {
+		rowIdxes = make([]int, rowCnt)
+	} else {
+		rowIdxes = rowIdxes[:rowCnt]
+	}
+	for i := 0; i < rowCnt; i++ {
+		rowIdxes[i] = i
+	}
+	return rowIdxes
+}
+
+func buildCompareMaterializedViewOrdinalSlice(colCnt int) []int {
+	ordinals := make([]int, colCnt)
+	for i := 0; i < colCnt; i++ {
+		ordinals[i] = i
+	}
+	return ordinals
+}
+
+func classifyCompareMaterializedViewRowDiff(leftMissing, rightMissing, payloadChanged bool) string {
+	switch {
+	case leftMissing:
+		return compareMaterializedViewExcessiveType
+	case rightMissing:
+		return compareMaterializedViewVacuumType
+	case payloadChanged:
+		return compareMaterializedViewDifferType
+	default:
+		return ""
+	}
+}
+
+func formatCompareMaterializedViewSummary(lastSuccessReadTSO uint64, diffRows int64) string {
+	resultTime := oracle.GetTimeFromTS(lastSuccessReadTSO).Format(types.TimeFSPFormat)
+	if diffRows == 0 {
+		return fmt.Sprintf(
+			"There are no differencies result in %d rows compared to source base tables at timestamp '%s'",
+			diffRows,
+			resultTime,
+		)
+	}
+	return fmt.Sprintf(
+		"There are differencies result in %d rows compared to source base tables at timestamp '%s'",
+		diffRows,
+		resultTime,
+	)
+}
+
+func (e *compareMaterializedViewRecordSetExec) Open(ctx context.Context) error {
+	return e.BaseExecutor.Open(ctx)
+}
+
+func (e *compareMaterializedViewRecordSetExec) Next(ctx context.Context, req *chunk.Chunk) error {
+	req.Reset()
+	return e.recordSet.Next(ctx, req)
+}
+
+func (e *compareMaterializedViewRecordSetExec) Close() error {
+	e.closeOnce.Do(func() {
+		if e.recordSet != nil {
+			e.closeErr = e.recordSet.Close()
+		}
+		if releaseErr := e.release(); e.closeErr == nil {
+			e.closeErr = releaseErr
+		}
+		if baseErr := e.BaseExecutor.Close(); e.closeErr == nil {
+			e.closeErr = baseErr
+		}
+	})
+	return e.closeErr
+}
+
+func (w *compareMaterializedViewOutputWriter) writeRow(ctx context.Context, row chunk.Row, diffType string) error {
+	useRight := diffType != compareMaterializedViewVacuumType
+	for colIdx := 0; colIdx < w.mvColumnCount; colIdx++ {
+		sourceColIdx := colIdx
+		if useRight {
+			sourceColIdx += w.mvColumnCount
+		}
+		row.DatumWithBuffer(sourceColIdx, w.fieldTypes[colIdx], &w.row[colIdx])
+	}
+	w.row[w.mvColumnCount].SetString(diffType, mysql.DefaultCollationName)
+	if _, err := w.targetTable.AddRecord(w.sctx.GetTableCtx(), w.txn, w.row, table.WithCtx(ctx), table.DupKeyCheckLazy); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *compareMaterializedViewOutputWriter) commit(ctx context.Context) error {
+	if w == nil || w.sctx == nil {
+		return nil
+	}
+	w.sctx.StmtCommit(ctx)
+	if err := w.sctx.CommitTxn(ctx); err != nil {
+		return err
+	}
+	if w.release != nil {
+		w.release(ctx)
+	}
+	w.sctx = nil
+	w.txn = nil
+	return nil
+}
+
+func (w *compareMaterializedViewOutputWriter) rollback(ctx context.Context) {
+	if w == nil || w.sctx == nil {
+		return
+	}
+	if w.release != nil {
+		w.release(ctx)
+	}
+	w.sctx = nil
+	w.txn = nil
 }
 
 // Next implements the Executor Next interface.

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta/autoid"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/mvservice"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -65,6 +66,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/sqlescape"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
+	"github.com/pingcap/tidb/pkg/util/stringutil"
 	"github.com/tikv/client-go/v2/oracle"
 	"go.uber.org/zap"
 )
@@ -1655,7 +1657,7 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 
 	var outputWriter *compareMaterializedViewOutputWriter
 	if e.stmt.OutputTable != nil {
-		outputWriter, err = e.openCompareMaterializedViewOutputWriter(ctx, schemaName, tblInfo, visibleCols)
+		outputWriter, err = e.openCompareMaterializedViewOutputWriter(ctx, tblInfo, visibleCols)
 		if err != nil {
 			return err
 		}
@@ -1908,7 +1910,6 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewSnapshotSession
 
 func (e *CompareMaterializedViewExec) openCompareMaterializedViewOutputWriter(
 	ctx context.Context,
-	schemaName pmodel.CIStr,
 	tblInfo *model.TableInfo,
 	visibleCols []*table.Column,
 ) (*compareMaterializedViewOutputWriter, error) {
@@ -1918,24 +1919,12 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewOutputWriter(
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ddlSctx.GetSQLExecutor().ExecuteInternal(
-		ctx,
-		"CREATE TABLE %n.%n LIKE %n.%n",
-		e.stmt.OutputTable.Schema.O,
-		e.stmt.OutputTable.Name.O,
-		schemaName.O,
-		tblInfo.Name.O,
-	); err != nil {
+	createSQL, err := buildCompareMaterializedViewOutputCreateTableSQL(ddlSctx, e.stmt.OutputTable, tblInfo, visibleCols, diffTypeColName)
+	if err != nil {
 		e.ReleaseSysSession(ctx, ddlSctx)
 		return nil, err
 	}
-	if _, err := ddlSctx.GetSQLExecutor().ExecuteInternal(
-		ctx,
-		"ALTER TABLE %n.%n ADD COLUMN %n VARCHAR(32) NOT NULL",
-		e.stmt.OutputTable.Schema.O,
-		e.stmt.OutputTable.Name.O,
-		diffTypeColName.O,
-	); err != nil {
+	if _, err := ddlSctx.GetSQLExecutor().ExecuteInternal(ctx, createSQL); err != nil {
 		e.ReleaseSysSession(ctx, ddlSctx)
 		return nil, err
 	}
@@ -1970,6 +1959,69 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewOutputWriter(
 		batchBytes:    resolveCompareMaterializedViewOutputWriterBatchBytes(),
 		release:       releaseInsertSession,
 	}, nil
+}
+
+func buildCompareMaterializedViewOutputCreateTableSQL(
+	sctx sessionctx.Context,
+	outputTable *ast.TableName,
+	tblInfo *model.TableInfo,
+	visibleCols []*table.Column,
+	diffTypeColName pmodel.CIStr,
+) (string, error) {
+	outputTblInfo := &model.TableInfo{
+		Name:    outputTable.Name,
+		Charset: tblInfo.Charset,
+		Collate: tblInfo.Collate,
+		State:   model.StatePublic,
+		Columns: make([]*model.ColumnInfo, 0, len(visibleCols)+1),
+	}
+	const outputColumnExcludedFlags = mysql.PriKeyFlag |
+		mysql.UniqueKeyFlag |
+		mysql.MultipleKeyFlag |
+		mysql.AutoIncrementFlag |
+		mysql.NoDefaultValueFlag |
+		mysql.OnUpdateNowFlag
+	for i, col := range visibleCols {
+		colInfo := col.ToInfo().Clone()
+		colInfo.Offset = i
+		colInfo.State = model.StatePublic
+		colInfo.FieldType.SetFlag(colInfo.GetFlag() &^ outputColumnExcludedFlags)
+		outputTblInfo.Columns = append(outputTblInfo.Columns, colInfo)
+	}
+	outputCharset, outputCollate := outputTblInfo.Charset, outputTblInfo.Collate
+	if outputCharset == "" {
+		outputCharset = mysql.DefaultCharset
+	}
+	if outputCollate == "" {
+		outputCollate = getDefaultCollate(outputCharset)
+	}
+	diffTypeCol := &model.ColumnInfo{
+		ID:     int64(len(outputTblInfo.Columns) + 1),
+		Name:   diffTypeColName,
+		Offset: len(outputTblInfo.Columns),
+		FieldType: *types.NewFieldTypeBuilder().
+			SetType(mysql.TypeVarchar).
+			SetFlen(32).
+			SetFlag(mysql.NotNullFlag).
+			SetCharset(outputCharset).
+			SetCollate(outputCollate).
+			BuildP(),
+		State: model.StatePublic,
+	}
+	outputTblInfo.Columns = append(outputTblInfo.Columns, diffTypeCol)
+
+	var tableDef bytes.Buffer
+	if err := ConstructResultOfShowCreateTable(sctx, outputTblInfo, autoid.Allocators{}, &tableDef); err != nil {
+		return "", err
+	}
+	sqlMode := sctx.GetSessionVars().SQLMode
+	tablePrefix := "CREATE TABLE " + stringutil.Escape(outputTable.Name.O, sqlMode)
+	tableDefSQL := tableDef.String()
+	if !strings.HasPrefix(tableDefSQL, tablePrefix) {
+		return "", errors.Errorf("compare materialized view: invalid output table DDL %q", tableDefSQL)
+	}
+	qualifiedName := stringutil.Escape(outputTable.Schema.O, sqlMode) + "." + stringutil.Escape(outputTable.Name.O, sqlMode)
+	return "CREATE TABLE " + qualifiedName + strings.TrimPrefix(tableDefSQL, tablePrefix), nil
 }
 
 func prepareCompareMaterializedViewSnapshotSession(

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1673,21 +1673,35 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer func() { _ = baseQueryExec.Close() }()
+	baseQueryExecIsClosed := false
+	defer func() {
+		if !baseQueryExecIsClosed {
+			_ = baseQueryExec.Close()
+		}
+	}()
 
 	mvQuerySQL := buildCompareMaterializedViewSelectSQL(schemaName, tblInfo.Name, visibleCols)
 	mvQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, schemaName, compareSnapshotTS, tblInfo.MaterializedView, mvQuerySQL)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = mvQueryExec.Close() }()
+	mvQueryExecIsClosed := false
+	defer func() {
+		if !mvQueryExecIsClosed {
+			_ = mvQueryExec.Close()
+		}
+	}()
 
 	hashJoinExec := newCompareMaterializedViewHashJoinExec(e.Ctx(), baseQueryExec, mvQueryExec, layout.groupKeyOffsets, visibleCols)
 	if err := exec.Open(ctx, hashJoinExec); err != nil {
 		_ = hashJoinExec.Close()
 		return err
 	}
-	defer func() { _ = hashJoinExec.Close() }()
+	defer func() {
+		_ = hashJoinExec.Close()
+		baseQueryExecIsClosed = true
+		mvQueryExecIsClosed = true
+	}()
 
 	joinResult := exec.NewFirstChunk(hashJoinExec)
 	rowIdxes := make([]int, 0, joinResult.Capacity())

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -124,7 +124,7 @@ type compareMaterializedViewOutputWriter struct {
 	batchBytes    int
 	pendingRows   int
 	release       func(context.Context)
-	dropTable     func(context.Context) error
+	dropTable     func(context.Context)
 }
 
 // CancelMaterializedViewJobExec executes "CANCEL MATERIALIZED VIEW ... JOB" as a utility-style statement.
@@ -1930,13 +1930,13 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewOutputWriter(
 		return nil, err
 	}
 	e.ReleaseSysSession(ctx, ddlSctx)
-	dropOutputTable := func(dropCtx context.Context) error {
-		return e.dropCompareMaterializedViewOutputTable(dropCtx, e.stmt.OutputTable)
+	dropOutputTable := func(dropCtx context.Context) {
+		e.cleanupCompareMaterializedViewOutputTable(dropCtx, e.stmt.OutputTable)
 	}
 
 	insertSctx, err := e.GetSysSession()
 	if err != nil {
-		_ = dropOutputTable(context.WithoutCancel(ctx))
+		dropOutputTable(context.WithoutCancel(ctx))
 		return nil, err
 	}
 	releaseInsertSession := func(releaseCtx context.Context) {
@@ -1947,7 +1947,7 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewOutputWriter(
 	targetTable, err := outputIS.TableByName(context.Background(), e.stmt.OutputTable.Schema, e.stmt.OutputTable.Name)
 	if err != nil {
 		releaseInsertSession(ctx)
-		_ = dropOutputTable(context.WithoutCancel(ctx))
+		dropOutputTable(context.WithoutCancel(ctx))
 		return nil, err
 	}
 	writableCols := targetTable.WritableCols()
@@ -1968,15 +1968,28 @@ func (e *CompareMaterializedViewExec) openCompareMaterializedViewOutputWriter(
 	}, nil
 }
 
-func (e *CompareMaterializedViewExec) dropCompareMaterializedViewOutputTable(ctx context.Context, outputTable *ast.TableName) error {
+func (e *CompareMaterializedViewExec) cleanupCompareMaterializedViewOutputTable(ctx context.Context, outputTable *ast.TableName) {
 	ddlSctx, err := e.GetSysSession()
 	if err != nil {
-		return err
+		logutil.BgLogger().Warn(
+			"failed to cleanup compare materialized view output table",
+			zap.String("schema", outputTable.Schema.O),
+			zap.String("table", outputTable.Name.O),
+			zap.Error(err),
+		)
+		return
 	}
 	defer e.ReleaseSysSession(ctx, ddlSctx)
 
 	dropSQL := sqlescape.MustEscapeSQL("DROP TABLE IF EXISTS %n.%n", outputTable.Schema.O, outputTable.Name.O)
-	return executeRefreshMaterializedViewInternalSQL(ctx, ddlSctx.GetSQLExecutor(), dropSQL)
+	if err := executeRefreshMaterializedViewInternalSQL(ctx, ddlSctx.GetSQLExecutor(), dropSQL); err != nil {
+		logutil.BgLogger().Warn(
+			"failed to cleanup compare materialized view output table",
+			zap.String("schema", outputTable.Schema.O),
+			zap.String("table", outputTable.Name.O),
+			zap.Error(err),
+		)
+	}
 }
 
 func buildCompareMaterializedViewOutputCreateTableSQL(
@@ -2449,9 +2462,9 @@ func (w *compareMaterializedViewOutputWriter) commit(ctx context.Context) error 
 	return nil
 }
 
-func (w *compareMaterializedViewOutputWriter) rollback(ctx context.Context) error {
+func (w *compareMaterializedViewOutputWriter) rollback(ctx context.Context) {
 	if w == nil || w.sctx == nil {
-		return nil
+		return
 	}
 	if w.txn != nil {
 		w.sctx.RollbackTxn(ctx)
@@ -2463,9 +2476,8 @@ func (w *compareMaterializedViewOutputWriter) rollback(ctx context.Context) erro
 	w.txn = nil
 	w.pendingRows = 0
 	if w.dropTable != nil {
-		return w.dropTable(ctx)
+		w.dropTable(ctx)
 	}
-	return nil
 }
 
 // Next implements the Executor Next interface.

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -2144,6 +2144,11 @@ func newCompareMaterializedViewHashJoinExec(
 		buildCompareMaterializedViewOrdinalSlice(len(leftTypes)),
 		buildCompareMaterializedViewOrdinalSlice(len(rightTypes)),
 	}
+	// Compare always uses BaseQuery@R as the probe/left side and MV@S as the
+	// build/right side. This matches the full outer hash join builder setup for
+	// build=right, probe=left:
+	// - unmatched build rows are (NULL-left, right), handled by RightOuterJoin;
+	// - unmatched probe rows are (left, NULL-right), handled by LeftOuterJoin.
 	fullJoinBuildJoiner := join.NewJoiner(
 		ctx,
 		logicalop.RightOuterJoin,

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -3666,6 +3666,37 @@ func TestCompareMaterializedViewSummaryAndOutput(t *testing.T) {
 		))
 }
 
+func TestCompareMaterializedViewUsesSnapshotMetadataAfterOutOfPlaceCutover(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_compare_oop_snapshot (a int not null, b int not null)")
+	tk.MustExec("insert into t_compare_oop_snapshot values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t_compare_oop_snapshot (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_compare_oop_snapshot (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_compare_oop_snapshot group by a")
+
+	compareTS := nextCompareTimestamp(t, tk)
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv_compare_oop_snapshot"))
+	require.NoError(t, err)
+	oldMViewID := mvTable.Meta().ID
+
+	tk.MustExec("insert into t_compare_oop_snapshot values (2, 3), (3, 4)")
+	tk.MustExec("refresh materialized view mv_compare_oop_snapshot complete out of place")
+
+	is = dom.InfoSchema()
+	mvTable, err = is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv_compare_oop_snapshot"))
+	require.NoError(t, err)
+	require.NotEqual(t, oldMViewID, mvTable.Meta().ID)
+
+	rows := tk.MustQuery(fmt.Sprintf(
+		"compare materialized view test.mv_compare_oop_snapshot as of timestamp '%s'",
+		compareTS,
+	)).Rows()
+	require.Len(t, rows, 1)
+	require.Contains(t, fmt.Sprint(rows[0][0]), "0 rows")
+}
+
 func TestCompareMaterializedViewOutputWriterBatchesByTxnSize(t *testing.T) {
 	const rowCount = 900
 

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -87,8 +87,10 @@ func requireRowsContainSubstring(t *testing.T, rows [][]any, substr string) {
 func nextCompareTimestamp(t *testing.T, tk *testkit.TestKit) string {
 	t.Helper()
 
+	mustSetMockGCSafePoint(t, tk, time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC))
+	ts := fmt.Sprint(tk.MustQuery("select now(6)").Rows()[0][0])
 	time.Sleep(10 * time.Millisecond)
-	return fmt.Sprint(tk.MustQuery("select now(6)").Rows()[0][0])
+	return ts
 }
 
 func requireRefreshTiFlashSessionVarsApplied(

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -3622,6 +3622,7 @@ func TestCompareMaterializedViewSummaryAndOutput(t *testing.T) {
 	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
+	tk.MustExec("set time_zone = '+08:00'")
 	tk.MustExec("create table t_compare_diff (a int not null, b int not null)")
 	tk.MustExec("insert into t_compare_diff values (1, 10), (2, 20)")
 	tk.MustExec("create materialized view log on t_compare_diff (a, b) purge next date_add(now(), interval 1 hour)")
@@ -3654,8 +3655,16 @@ func TestCompareMaterializedViewSummaryAndOutput(t *testing.T) {
 	summaryRows := tk.MustQuery(compareSQL).Rows()
 	require.Len(t, summaryRows, 1)
 	summary := fmt.Sprint(summaryRows[0][0])
-	require.Contains(t, summary, "3 rows")
-	require.Contains(t, summary, oracle.GetTimeFromTS(lastSuccessReadTSO).Format("2006-01-02 15:04:05.000000"))
+	expectedTimestamp := oracle.GetTimeFromTS(lastSuccessReadTSO).In(tk.Session().GetSessionVars().Location()).Format("2006-01-02 15:04:05.000000 -07:00")
+	require.Equal(
+		t,
+		fmt.Sprintf(
+			"There are differences result in 3 rows compared to source base tables at timestamp '%s' (TSO: %d)",
+			expectedTimestamp,
+			lastSuccessReadTSO,
+		),
+		summary,
+	)
 
 	tk.MustExec(compareSQL + " output into table test.mv_compare_diff_output")
 	tk.MustQuery("select a, s, cnt, _Differ_type_ from test.mv_compare_diff_output order by a").
@@ -3740,6 +3749,37 @@ func TestCompareMaterializedViewOutputWriterBatchesByTxnSize(t *testing.T) {
 	)
 	tk.MustExec(compareSQL)
 	tk.MustQuery("select count(*) from test.mv_compare_output_batch_diff").Check(testkit.Rows(fmt.Sprint(rowCount)))
+}
+
+func TestCompareMaterializedViewDropsOutputTableOnWriteFailure(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_compare_output_cleanup (a int not null, b int not null)")
+	tk.MustExec("insert into t_compare_output_cleanup values (1, 10)")
+	tk.MustExec("create materialized view log on t_compare_output_cleanup (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_compare_output_cleanup (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_compare_output_cleanup group by a")
+
+	origInMVMaintenance := tk.Session().GetSessionVars().InMaterializedViewMaintenance
+	tk.Session().GetSessionVars().InMaterializedViewMaintenance = true
+	mustExecInternal(t, tk, "update mv_compare_output_cleanup set s = s + 1 where a = 1")
+	mustExecInternal(t, tk, "commit")
+	tk.Session().GetSessionVars().InMaterializedViewMaintenance = origInMVMaintenance
+
+	failpointName := "github.com/pingcap/tidb/pkg/executor/mockCompareMaterializedViewOutputFlushError"
+	require.NoError(t, failpoint.Enable(failpointName, `return("mock compare output flush error")`))
+	defer func() {
+		require.NoError(t, failpoint.Disable(failpointName))
+	}()
+
+	compareSQL := fmt.Sprintf(
+		"compare materialized view test.mv_compare_output_cleanup as of timestamp '%s' output into table test.mv_compare_output_cleanup_diff",
+		nextCompareTimestamp(t, tk),
+	)
+	err := tk.ExecToErr(compareSQL)
+	require.ErrorContains(t, err, "mock compare output flush error")
+	tk.MustQuery("select count(*) from information_schema.tables where table_schema = 'test' and table_name = 'mv_compare_output_cleanup_diff'").
+		Check(testkit.Rows("0"))
 }
 
 func TestCompareMaterializedViewUsesDefinitionTimeZone(t *testing.T) {

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -3688,13 +3688,16 @@ func TestCompareMaterializedViewUsesSnapshotMetadataAfterOutOfPlaceCutover(t *te
 	mvTable, err = is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv_compare_oop_snapshot"))
 	require.NoError(t, err)
 	require.NotEqual(t, oldMViewID, mvTable.Meta().ID)
+	tk.MustExec("create index idx_current_s on mv_compare_oop_snapshot (s)")
+	require.NotEmpty(t, tk.MustQuery("show index from mv_compare_oop_snapshot").Rows())
 
-	rows := tk.MustQuery(fmt.Sprintf(
-		"compare materialized view test.mv_compare_oop_snapshot as of timestamp '%s'",
-		compareTS,
-	)).Rows()
+	compareSQL := fmt.Sprintf("compare materialized view test.mv_compare_oop_snapshot as of timestamp '%s'", compareTS)
+	rows := tk.MustQuery(compareSQL).Rows()
 	require.Len(t, rows, 1)
 	require.Contains(t, fmt.Sprint(rows[0][0]), "0 rows")
+
+	tk.MustExec(compareSQL + " output into table test.mv_compare_oop_snapshot_diff")
+	tk.MustQuery("show index from mv_compare_oop_snapshot_diff").Check(testkit.Rows())
 }
 
 func TestCompareMaterializedViewOutputWriterBatchesByTxnSize(t *testing.T) {

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -3715,6 +3715,27 @@ func TestCompareMaterializedViewEmptyInputs(t *testing.T) {
 	tk.MustQuery("select count(*) from test.mv_compare_empty_output").Check(testkit.Rows("0"))
 }
 
+func TestCompareMaterializedViewRejectsReadTSOAfterSnapshot(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@session.time_zone = '+00:00'")
+	tk.MustExec("create table t_compare_tso_guard (a int not null, b int not null)")
+	tk.MustExec("insert into t_compare_tso_guard values (1, 10)")
+	tk.MustExec("create materialized view log on t_compare_tso_guard (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_compare_tso_guard (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_compare_tso_guard group by a")
+
+	futureTSO := oracle.GoTimeToTS(time.Now().UTC().Add(time.Hour))
+	tk.MustExec(fmt.Sprintf(
+		"update mysql.tidb_mview_refresh_info set LAST_SUCCESS_READ_TSO = %d where MVIEW_ID = (select tidb_table_id from information_schema.tables where table_schema = 'test' and table_name = 'mv_compare_tso_guard')",
+		futureTSO,
+	))
+
+	compareTS := nextCompareTimestamp(t, tk)
+	err := tk.QueryToErr(fmt.Sprintf("compare materialized view test.mv_compare_tso_guard as of timestamp '%s'", compareTS))
+	require.ErrorContains(t, err, "LAST_SUCCESS_READ_TSO")
+}
+
 func TestMaterializedViewRefreshCancelWatcherUsesHistRequest(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -84,6 +84,13 @@ func requireRowsContainSubstring(t *testing.T, rows [][]any, substr string) {
 	require.Failf(t, "substring not found", "substring=%s rows=%v", substr, rows)
 }
 
+func nextCompareTimestamp(t *testing.T, tk *testkit.TestKit) string {
+	t.Helper()
+
+	time.Sleep(10 * time.Millisecond)
+	return fmt.Sprint(tk.MustQuery("select now(6)").Rows()[0][0])
+}
+
 func requireRefreshTiFlashSessionVarsApplied(
 	t *testing.T,
 	refresh func(),
@@ -3579,7 +3586,8 @@ func TestCompareMaterializedViewPrivilegeSkeleton(t *testing.T) {
 	tkUser := testkit.NewTestKit(t, store)
 	require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "mv_compare_u", Hostname: "%"}, nil, nil, nil))
 
-	compareSQL := "compare materialized view test.mv_compare_priv as of timestamp '2026-05-21 10:00:00'"
+	compareTS := nextCompareTimestamp(t, tk)
+	compareSQL := fmt.Sprintf("compare materialized view test.mv_compare_priv as of timestamp '%s'", compareTS)
 	err := tkUser.ExecToErr(compareSQL)
 	require.ErrorContains(t, err, "OPERATE VIEW command denied")
 
@@ -3588,8 +3596,9 @@ func TestCompareMaterializedViewPrivilegeSkeleton(t *testing.T) {
 	require.ErrorContains(t, err, "SELECT command denied")
 
 	tk.MustExec("grant select on test.t_compare_priv to 'mv_compare_u'@'%'")
-	err = tkUser.QueryToErr(compareSQL)
-	require.ErrorContains(t, err, "COMPARE MATERIALIZED VIEW is not implemented")
+	rows := tkUser.MustQuery(compareSQL).Rows()
+	require.Len(t, rows, 1)
+	require.Contains(t, fmt.Sprint(rows[0][0]), "timestamp")
 
 	outputSQL := compareSQL + " output into table test.mv_compare_priv_diff"
 	err = tkUser.ExecToErr(outputSQL)
@@ -3600,12 +3609,110 @@ func TestCompareMaterializedViewPrivilegeSkeleton(t *testing.T) {
 	require.ErrorContains(t, err, "INSERT command denied")
 
 	tk.MustExec("grant insert on test.* to 'mv_compare_u'@'%'")
-	err = tkUser.ExecToErr(outputSQL)
-	require.ErrorContains(t, err, "COMPARE MATERIALIZED VIEW is not implemented")
+	tkUser.MustExec(outputSQL)
+	tk.MustQuery("select count(*) from test.mv_compare_priv_diff").Check(testkit.Rows("0"))
 
+	tk.MustExec("drop table mv_compare_priv_diff")
 	tk.MustExec("create table mv_compare_priv_diff (a int)")
 	err = tkUser.ExecToErr(outputSQL)
 	require.ErrorContains(t, err, "Table 'test.mv_compare_priv_diff' already exists")
+}
+
+func TestCompareMaterializedViewSummaryAndOutput(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_compare_diff (a int not null, b int not null)")
+	tk.MustExec("insert into t_compare_diff values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_compare_diff (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_compare_diff (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_compare_diff group by a")
+
+	lastSuccessRows := tk.MustQuery(
+		"select LAST_SUCCESS_READ_TSO from mysql.tidb_mview_refresh_info where MVIEW_ID = (select tidb_table_id from information_schema.tables where table_schema = 'test' and table_name = 'mv_compare_diff')",
+	).Rows()
+	lastSuccessReadTSO, err := strconv.ParseUint(fmt.Sprint(lastSuccessRows[0][0]), 10, 64)
+	require.NoError(t, err)
+
+	origInMVMaintenance := tk.Session().GetSessionVars().InMaterializedViewMaintenance
+	tk.Session().GetSessionVars().InMaterializedViewMaintenance = true
+	mustExecInternal(t, tk, "update mv_compare_diff set s = s + 7 where a = 1")
+	mustExecInternal(t, tk, "delete from mv_compare_diff where a = 2")
+	mustExecInternal(t, tk, "insert into mv_compare_diff values (3, 30, 1)")
+	mustExecInternal(t, tk, "commit")
+	tk.Session().GetSessionVars().InMaterializedViewMaintenance = origInMVMaintenance
+	tk.MustQuery("select a, s, cnt from mv_compare_diff order by a").Check(testkit.Rows(
+		"1 17 1",
+		"3 30 1",
+	))
+
+	compareTS := nextCompareTimestamp(t, tk)
+	compareSQL := fmt.Sprintf(
+		"compare materialized view test.mv_compare_diff as of timestamp '%s'",
+		compareTS,
+	)
+
+	summaryRows := tk.MustQuery(compareSQL).Rows()
+	require.Len(t, summaryRows, 1)
+	summary := fmt.Sprint(summaryRows[0][0])
+	require.Contains(t, summary, "3 rows")
+	require.Contains(t, summary, oracle.GetTimeFromTS(lastSuccessReadTSO).Format("2006-01-02 15:04:05.000000"))
+
+	tk.MustExec(compareSQL + " output into table test.mv_compare_diff_output")
+	tk.MustQuery("select a, s, cnt, _Differ_type_ from test.mv_compare_diff_output order by a").
+		Check(testkit.Rows(
+			"1 17 1 mview_differ",
+			"2 20 1 mview_vacuum",
+			"3 30 1 mview_excessive",
+		))
+}
+
+func TestCompareMaterializedViewNullableGroupKeyMinMax(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_compare_nullable_minmax (a int, b int)")
+	tk.MustExec("create index idx_a_b on t_compare_nullable_minmax (a, b)")
+	tk.MustExec("insert into t_compare_nullable_minmax values (null, 1), (null, 3), (1, 5)")
+	tk.MustExec("create materialized view log on t_compare_nullable_minmax (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_compare_nullable_minmax (a, cnt, mx, mn) refresh fast next date_add(now(), interval 1 hour) as select a, count(1), max(b), min(b) from t_compare_nullable_minmax group by a")
+
+	origInMVMaintenance := tk.Session().GetSessionVars().InMaterializedViewMaintenance
+	tk.Session().GetSessionVars().InMaterializedViewMaintenance = true
+	mustExecInternal(t, tk, "update mv_compare_nullable_minmax set mx = 99 where a is null")
+	mustExecInternal(t, tk, "commit")
+	tk.Session().GetSessionVars().InMaterializedViewMaintenance = origInMVMaintenance
+
+	compareSQL := fmt.Sprintf(
+		"compare materialized view test.mv_compare_nullable_minmax as of timestamp '%s'",
+		nextCompareTimestamp(t, tk),
+	)
+	summaryRows := tk.MustQuery(compareSQL).Rows()
+	require.Len(t, summaryRows, 1)
+	require.Contains(t, fmt.Sprint(summaryRows[0][0]), "1 rows")
+
+	tk.MustExec(compareSQL + " output into table test.mv_compare_nullable_minmax_output")
+	tk.MustQuery("select a, cnt, mx, mn, _Differ_type_ from test.mv_compare_nullable_minmax_output").
+		Check(testkit.Rows("<nil> 2 99 1 mview_differ"))
+}
+
+func TestCompareMaterializedViewEmptyInputs(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_compare_empty (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on t_compare_empty (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_compare_empty (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_compare_empty group by a")
+
+	compareSQL := fmt.Sprintf(
+		"compare materialized view test.mv_compare_empty as of timestamp '%s'",
+		nextCompareTimestamp(t, tk),
+	)
+	summaryRows := tk.MustQuery(compareSQL).Rows()
+	require.Len(t, summaryRows, 1)
+	require.Contains(t, fmt.Sprint(summaryRows[0][0]), "0 rows")
+
+	tk.MustExec(compareSQL + " output into table test.mv_compare_empty_output")
+	tk.MustQuery("select count(*) from test.mv_compare_empty_output").Check(testkit.Rows("0"))
 }
 
 func TestMaterializedViewRefreshCancelWatcherUsesHistRequest(t *testing.T) {

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -3666,6 +3666,69 @@ func TestCompareMaterializedViewSummaryAndOutput(t *testing.T) {
 		))
 }
 
+func TestCompareMaterializedViewOutputWriterBatchesByTxnSize(t *testing.T) {
+	const rowCount = 900
+
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_compare_output_batch (a int not null, c varchar(1700) not null)")
+	tk.MustExec("create index idx_a on t_compare_output_batch (a)")
+	for start := 0; start < rowCount; start += 100 {
+		var sb strings.Builder
+		sb.WriteString("insert into t_compare_output_batch values ")
+		end := min(start+100, rowCount)
+		for i := start; i < end; i++ {
+			if i > start {
+				sb.WriteString(", ")
+			}
+			val := fmt.Sprintf("%04d_%s", i, strings.Repeat("x", 1500))
+			fmt.Fprintf(&sb, "(%d, '%s')", i, val)
+		}
+		tk.MustExec(sb.String())
+	}
+	tk.MustExec("create materialized view log on t_compare_output_batch (a, c) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_compare_output_batch (a, mx, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, max(c), count(1) from t_compare_output_batch group by a")
+
+	origInMVMaintenance := tk.Session().GetSessionVars().InMaterializedViewMaintenance
+	tk.Session().GetSessionVars().InMaterializedViewMaintenance = true
+	mustExecInternal(t, tk, "delete from mv_compare_output_batch")
+	mustExecInternal(t, tk, "commit")
+	tk.Session().GetSessionVars().InMaterializedViewMaintenance = origInMVMaintenance
+
+	origTxnLimit := kv.TxnTotalSizeLimit.Load()
+	kv.TxnTotalSizeLimit.Store(1024 * 1024)
+	defer kv.TxnTotalSizeLimit.Store(origTxnLimit)
+
+	compareSQL := fmt.Sprintf(
+		"compare materialized view test.mv_compare_output_batch as of timestamp '%s' output into table test.mv_compare_output_batch_diff",
+		nextCompareTimestamp(t, tk),
+	)
+	tk.MustExec(compareSQL)
+	tk.MustQuery("select count(*) from test.mv_compare_output_batch_diff").Check(testkit.Rows(fmt.Sprint(rowCount)))
+}
+
+func TestCompareMaterializedViewUsesDefinitionTimeZone(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@session.time_zone = '+00:00'")
+	tk.MustExec("create table t_compare_tz (a int not null, ts timestamp not null, b int not null)")
+	tk.MustExec("insert into t_compare_tz values (1, '2025-12-31 23:30:00', 20), (1, '2026-01-01 00:30:00', 10)")
+	tk.MustExec("create materialized view log on t_compare_tz (a, ts, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_compare_tz (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_compare_tz where ts >= '2026-01-01 00:00:00' group by a")
+	tk.MustQuery("select a, s, cnt from mv_compare_tz").Check(testkit.Rows("1 10 1"))
+
+	tk.MustExec("set @@session.time_zone = '+08:00'")
+	compareSQL := fmt.Sprintf(
+		"compare materialized view test.mv_compare_tz as of timestamp '%s'",
+		nextCompareTimestamp(t, tk),
+	)
+	rows := tk.MustQuery(compareSQL).Rows()
+	require.Len(t, rows, 1)
+	require.Contains(t, fmt.Sprint(rows[0][0]), "0 rows")
+}
+
 func TestCompareMaterializedViewNullableGroupKeyMinMax(t *testing.T) {
 	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/18023

Problem Summary:
TiDB currently has materialized view refresh support, but lacks a built-in way to validate whether an MV’s stored result is still consistent with its base-query result at the last successful refresh watermark. This makes it hard to diagnose MV drift, corruption, or refresh correctness issues without manually reconstructing the MV query and comparing results outside the system.

### What changed and how does it work?
This PR implements:

```sql
COMPARE MATERIALIZED VIEW <mv> AS OF TIMESTAMP <ts> [OUTPUT INTO TABLE <table>]
```

The executor first resolves the compare snapshot `S` from `AS OF TIMESTAMP`, then loads the snapshot InfoSchema at `S` and resolves the MV from that snapshot metadata. It reads the MV data and `mysql.tidb_mview_refresh_info` at `S`, obtains `R = LAST_SUCCESS_READ_TSO`, and executes the MV definition SQL against base tables at snapshot `R`. It then compares `MV@S` with `BaseQuery@R`.

The comparison reuses the MV complete-delta diff semantics: group-key identity, nullable-key handling with null-safe equality where needed, deterministic side-missing detection, and null-safe payload comparison. Internally, compare builds two snapshot readers and wires them into a full outer hash join, then classifies differences as:

- `mview_differ`: both sides have the row, but payload differs.
- `mview_vacuum`: the MV is missing a row that exists in the base-query result.
- `mview_excessive`: the MV has an extra row not present in the base-query result.

Without `OUTPUT INTO TABLE`, the statement returns a summary row with the number of differing rows. With `OUTPUT INTO TABLE`, TiDB auto-creates a plain diff table from the snapshot MV public-column schema plus a differ-type column, then writes diff rows in batches to avoid one large transaction.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fully implemented `COMPARE MATERIALIZED VIEW` with snapshot-aware `AS OF TIMESTAMP` execution using the last successful refresh time.
  * Produces summary results or detailed rows via `OUTPUT INTO TABLE`, including automatic destination table creation with a diff-type column.

* **Documentation**
  * Added a design/usage note defining syntax, snapshot semantics, diff classification rules, output table schema contract, and acceptance criteria.

* **Tests**
  * Expanded coverage for privilege behavior, summary/output correctness, nullable group-key handling, empty-input cases, output writer batching by transaction size, time zone effects, and rejection when `LAST_SUCCESS_READ_TSO` is newer than the compare snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->