### PR TITLE
build: upgrade Go to 1.25.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # production environment, please refer to https://github.com/PingCAP-QE/artifacts/blob/main/dockerfiles/cd/builders/tidb/Dockerfile.
 
 # Builder image
-FROM golang:1.25.9 as builder
+FROM golang:1.25.10 as builder
 WORKDIR /tidb
 
 COPY . .

--- a/Dockerfile.enterprise
+++ b/Dockerfile.enterprise
@@ -14,7 +14,7 @@
 
 # The current dockerfile is only used for development purposes.
 # Builder image
-FROM golang:1.25.9 as builder
+FROM golang:1.25.10 as builder
 WORKDIR /tidb
 
 COPY . .

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -96,7 +96,7 @@ go_download_sdk(
         "https://mirrors.aliyun.com/golang/{}",
         "https://dl.google.com/go/{}",
     ],
-    version = "1.25.9",
+    version = "1.25.10",
 )
 
 gazelle_dependencies(go_sdk = "go_sdk")

--- a/build/image/base
+++ b/build/image/base
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 
 # install golang toolchain
 # renovate: datasource=docker depName=golang
-ARG GOLANG_VERSION=1.25.9
+ARG GOLANG_VERSION=1.25.10
 RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
     curl -fsSL https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin/:$PATH

--- a/build/image/parser_test
+++ b/build/image/parser_test
@@ -14,7 +14,7 @@
 
 FROM rockylinux:9
 
-ENV GOLANG_VERSION 1.25.9
+ENV GOLANG_VERSION 1.25.10
 ENV ARCH amd64
 ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-$ARCH.tar.gz
 ENV GOPATH /home/prow/go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tidb
 
-go 1.25.9
+go 1.25.10
 
 require (
 	cloud.google.com/go/kms v1.15.8


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68884

Problem Summary:

The master branch still uses Go 1.25.9 in patch-pinned toolchain locations. This PR updates those pins to Go 1.25.10.

### What changed and how does it work?

This PR updates the Go patch version from 1.25.9 to 1.25.10 in the root module, Bazel Go SDK configuration, and container image Go toolchain pins.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test details:

- `git diff --check`
- `GOTOOLCHAIN=local go list -m -json`
- `rg -n "1\\.25\\.9|GOLANG_VERSION[ =]1\\.25\\.9|golang:1\\.25\\.9"`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to version 1.25.10 across build and packaging configurations, ensuring the build environment and module directive target the new Go version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->