### PR TITLE
ddl: forbid the creating of mlog on partition base table

### DIFF
--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -291,6 +291,10 @@ func (w *worker) onCreateMaterializedViewLog(jobCtx *jobContext, job *model.Job)
 		job.State = model.JobStateCancelled
 		return ver, dbterror.ErrWrongObject.GenWithStackByArgs(job.SchemaName, baseTblInfo.Name, "BASE TABLE")
 	}
+	if baseTblInfo.GetPartitionInfo() != nil {
+		job.State = model.JobStateCancelled
+		return ver, errUnsupportedMaterializedViewOnPartitionTable("CREATE MATERIALIZED VIEW LOG")
+	}
 	if baseTblInfo.State != model.StatePublic {
 		job.State = model.JobStateCancelled
 		return ver, dbterror.ErrInvalidDDLState.GenWithStack("table %s is not in public, but %s", baseTblInfo.Name, baseTblInfo.State)
@@ -347,6 +351,9 @@ func onCreateMaterializedViewBaseCheck(metaMut *meta.Mutator, schemaID int64, ba
 	if baseTblInfo.IsView() || baseTblInfo.IsSequence() || baseTblInfo.TempTableType != model.TempTableNone {
 		return nil, dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, baseTblInfo.Name, "BASE TABLE")
 	}
+	if baseTblInfo.GetPartitionInfo() != nil {
+		return nil, errUnsupportedMaterializedViewOnPartitionTable("CREATE MATERIALIZED VIEW")
+	}
 	intest.Assert(baseTblInfo.State == model.StatePublic)
 	if baseTblInfo.MaterializedViewBase == nil || baseTblInfo.MaterializedViewBase.MLogID == 0 {
 		return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("create materialized view: base table has no materialized view log")
@@ -360,6 +367,15 @@ func onCreateMaterializedViewBaseCheck(metaMut *meta.Mutator, schemaID int64, ba
 	}
 	intest.Assert(mlogTblInfo.State == model.StatePublic)
 	return baseTblInfo, nil
+}
+
+func isCreateMaterializedViewBaseCheckCancelledErr(err error) bool {
+	return infoschema.ErrDatabaseNotExists.Equal(err) ||
+		infoschema.ErrTableNotExists.Equal(err) ||
+		dbterror.ErrInvalidDDLJob.Equal(err) ||
+		dbterror.ErrWrongObject.Equal(err) ||
+		dbterror.ErrInvalidDDLState.Equal(err) ||
+		dbterror.ErrGeneralUnsupportedDDL.Equal(err)
 }
 
 func (w *worker) onCreateMaterializedView(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
@@ -406,10 +422,7 @@ func (w *worker) onCreateMaterializedView(jobCtx *jobContext, job *model.Job) (v
 		// Phase-1: create MV physical table and atomically wire base<->mv metadata.
 		for _, baseTableID := range baseTableIDs {
 			if _, err := onCreateMaterializedViewBaseCheck(jobCtx.metaMut, job.SchemaID, baseTableID, job.SchemaName); err != nil {
-				if infoschema.ErrDatabaseNotExists.Equal(err) || infoschema.ErrTableNotExists.Equal(err) {
-					job.State = model.JobStateCancelled
-				}
-				if dbterror.ErrInvalidDDLJob.Equal(err) || dbterror.ErrWrongObject.Equal(err) || dbterror.ErrInvalidDDLState.Equal(err) {
+				if isCreateMaterializedViewBaseCheckCancelledErr(err) {
 					job.State = model.JobStateCancelled
 				}
 				return ver, errors.Trace(err)

--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -132,6 +132,16 @@ func TestGetJobCheckIntervalForCreateMaterializedViewShadow(t *testing.T) {
 	require.False(t, changed)
 }
 
+func TestIsCreateMaterializedViewBaseCheckCancelledErr(t *testing.T) {
+	require.True(t, isCreateMaterializedViewBaseCheckCancelledErr(infoschema.ErrDatabaseNotExists.GenWithStackByArgs("test")))
+	require.True(t, isCreateMaterializedViewBaseCheckCancelledErr(infoschema.ErrTableNotExists.GenWithStackByArgs("test", "t")))
+	require.True(t, isCreateMaterializedViewBaseCheckCancelledErr(dbterror.ErrInvalidDDLJob.GenWithStackByArgs("invalid job")))
+	require.True(t, isCreateMaterializedViewBaseCheckCancelledErr(dbterror.ErrWrongObject.GenWithStackByArgs("test", "t", "BASE TABLE")))
+	require.True(t, isCreateMaterializedViewBaseCheckCancelledErr(dbterror.ErrInvalidDDLState.GenWithStackByArgs("table", model.StateDeleteOnly)))
+	require.True(t, isCreateMaterializedViewBaseCheckCancelledErr(errUnsupportedMaterializedViewOnPartitionTable("CREATE MATERIALIZED VIEW")))
+	require.False(t, isCreateMaterializedViewBaseCheckCancelledErr(fmt.Errorf("retry later")))
+}
+
 func TestBuildCreateMaterializedViewRefreshInfoUpsertSQL(t *testing.T) {
 	compactSQL := func(sql string) string {
 		return strings.Join(strings.Fields(sql), " ")

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1086,7 +1086,9 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	if baseTable.Meta().IsView() || baseTable.Meta().IsSequence() || baseTable.Meta().TempTableType != model.TempTableNone {
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
-
+	if baseTable.Meta().GetPartitionInfo() != nil {
+		return errUnsupportedMaterializedViewOnPartitionTable("CREATE MATERIALIZED VIEW LOG")
+	}
 	mlogNameCIStr := model.MaterializedViewLogTableName(baseTable.Meta().Name)
 	if err := checkTooLongTable(mlogNameCIStr); err != nil {
 		return err
@@ -4954,10 +4956,6 @@ func (e *executor) TruncateTable(ctx sessionctx.Context, ti ast.Ident) error {
 
 func checkTableMaterializedViewConstraints(sv *variable.SessionVars, tblInfo *model.TableInfo, op string) error {
 	return checkTableMaterializedViewConstraintsWithOptions(sv, tblInfo, op, false)
-}
-
-func checkTableMaterializedViewConstraintsAllowMVTable(sv *variable.SessionVars, tblInfo *model.TableInfo, op string) error {
-	return checkTableMaterializedViewConstraintsWithOptions(sv, tblInfo, op, true)
 }
 
 func checkTableMaterializedViewConstraintsWithOptions(

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -54,6 +54,10 @@ const (
 	alterMaterializedScheduleInfoUpdateLockWaitTimeoutSec = int64(10)
 )
 
+func errUnsupportedMaterializedViewOnPartitionTable(op string) error {
+	return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(op + " on partition table")
+}
+
 // ApplyMViewExecutionSessionVars applies MV execution vars onto a session and returns a restore closure.
 func ApplyMViewExecutionSessionVars(sessVars *variable.SessionVars, target variable.MViewExecutionSessionVars) (func(), error) {
 	return applyMViewExecutionSessionVars(sessVars, target, false)
@@ -233,6 +237,9 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 	}
 	if baseTable.Meta().IsView() || baseTable.Meta().IsSequence() || baseTable.Meta().TempTableType != model.TempTableNone {
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, baseTableName.Name, "BASE TABLE")
+	}
+	if baseTable.Meta().GetPartitionInfo() != nil {
+		return errUnsupportedMaterializedViewOnPartitionTable("CREATE MATERIALIZED VIEW")
 	}
 	baseTableID := baseTable.Meta().ID
 

--- a/pkg/ddl/mv_index_test.go
+++ b/pkg/ddl/mv_index_test.go
@@ -104,3 +104,29 @@ func TestCreateMaterializedViewLogTruncatesLongPhysicalName(t *testing.T) {
 	tk.MustQuery(fmt.Sprintf("select table_name from information_schema.tables where table_schema = database() and table_name = '%s'", mlogName)).
 		Check(testkit.Rows())
 }
+
+func TestCreateMaterializedViewOnPartitionTable(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists t_part_range, `$mlog$t_part_range`, mv_part_range")
+	tk.MustExec(`create table t_part_range (
+		id bigint not null primary key,
+		g1 int not null,
+		v1 bigint not null
+	) partition by range (id) (
+		partition p0 values less than (100),
+		partition p1 values less than (maxvalue)
+	)`)
+
+	tk.MustGetErrMsg(
+		"create materialized view log on t_part_range (id, g1, v1)",
+		"[ddl:8200]Unsupported CREATE MATERIALIZED VIEW LOG on partition table",
+	)
+	tk.MustQuery("show tables like '$mlog$t_part_range'").Check(testkit.Rows())
+	tk.MustGetErrMsg(
+		"create materialized view mv_part_range (g1, cnt) as select g1, count(*) as cnt from t_part_range group by g1",
+		"[ddl:8200]Unsupported CREATE MATERIALIZED VIEW on partition table",
+	)
+}

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -251,6 +251,9 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	if baseTable.IsView() || baseTable.IsSequence() || baseTable.TempTableType != model.TempTableNone {
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
+	if baseTable.GetPartitionInfo() != nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("CREATE MATERIALIZED VIEW LOG on partition table")
+	}
 
 	mlogNameCIStr := model.MaterializedViewLogTableName(baseTable.Name)
 	if _, err := d.TableByName(context.Background(), schemaName, mlogNameCIStr); err == nil {

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -556,25 +556,16 @@ partition by range (v) (
   partition p0 values less than (100),
   partition p1 values less than maxvalue
 )`)
-	tk.MustExec("insert into t_base values (98, 10), (99, 20)")
-	tk.MustExec("create materialized view log on repro015.t_base (id, v)")
-	tk.MustExec(`create materialized view repro015.mv (cnt, v)
+	err = tk.ExecToErr("create materialized view log on repro015.t_base (id, v)")
+	require.ErrorContains(t, err, "CREATE MATERIALIZED VIEW LOG on partition table")
+	err = tk.ExecToErr(`create materialized view repro015.mv (cnt, v)
 refresh fast
 as
 select count(*) as cnt, v
 from repro015.t_base
 group by v`)
-	tk.MustExec(`create table repro015.` + "`right`" + ` (
-  id bigint not null,
-  v int not null,
-  primary key (v) /*T![clustered_index] CLUSTERED */
-)`)
-	err = tk.ExecToErr("alter table repro015.t_base exchange partition p0 with table repro015.`right`")
-	require.ErrorContains(t, err, "EXCHANGE PARTITION on partitioned table with materialized view dependencies")
+	require.ErrorContains(t, err, "CREATE MATERIALIZED VIEW on partition table")
 
-	tk.MustExec("drop table repro015.`right`")
-	tk.MustExec("drop materialized view repro015.mv")
-	tk.MustExec("drop materialized view log on repro015.t_base")
 	tk.MustExec("drop table repro015.t_base")
 	tk.MustExec(`create table repro015.t_base (
   id bigint not null,

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -625,9 +625,8 @@ partition by range (id) (
   partition p0 values less than (100),
   partition p1 values less than maxvalue
 )`)
-	tk.MustExec("create materialized view log on t_base_part (id, v)")
-	err = tk.ExecToErr("alter table t_base_part remove partitioning")
-	require.ErrorContains(t, err, "ALTER TABLE ... REMOVE PARTITIONING with materialized view log")
+	err = tk.ExecToErr("create materialized view log on t_base_part (id, v)")
+	require.ErrorContains(t, err, "CREATE MATERIALIZED VIEW LOG on partition table")
 }
 
 func TestMaterializedViewDDLProtectsMinMaxSupportingBaseTableIndexes(t *testing.T) {

--- a/pkg/executor/test/writetest/mview_log_write_test.go
+++ b/pkg/executor/test/writetest/mview_log_write_test.go
@@ -1287,9 +1287,7 @@ func TestMLogPartitionedTableNotSupported(t *testing.T) {
 			"partition p1 values less than (maxvalue)" +
 			")",
 	)
-	tk.MustExec("create materialized view log on t (a, b)")
-
-	tk.MustGetErrCode("insert into t values (1,100)", mysql.ErrNotSupportedYet)
+	tk.MustGetErrCode("create materialized view log on t (a, b)", errno.ErrUnsupportedDDLOperation)
 }
 
 func TestMLogTransactionRollback(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66778

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that CREATE MATERIALIZED VIEW LOG / CREATE MATERIALIZED VIEW accept partitioned base tables instead of rejecting them
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Materialized view and materialized view log creation now immediately reject partitioned base tables with an unsupported DDL error (e.g., error code `8200`), instead of proceeding to later failures.
* **Tests**
  * Updated and added coverage to confirm `CREATE MATERIALIZED VIEW LOG` and `CREATE MATERIALIZED VIEW` fail right away on partition tables.
  * Added unit test coverage for the validation/job-cancellation decision used during materialized view creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->