### PR TITLE
test: stabilize flaky TestLoadDataListPartition

### DIFF
--- a/pkg/server/tests/tidb_serial_test.go
+++ b/pkg/server/tests/tidb_serial_test.go
@@ -97,12 +97,30 @@ func TestDBStmtCount(t *testing.T) {
 }
 
 func TestLoadDataListPartition(t *testing.T) {
-	ts := servertestkit.CreateTidbTestSuite(t)
-
-	ts.RunTestLoadDataForListPartition(t)
-	ts.RunTestLoadDataForListPartition2(t)
-	ts.RunTestLoadDataForListColumnPartition(t)
-	ts.RunTestLoadDataForListColumnPartition2(t)
+	cases := []struct {
+		name string
+		run  func(*testing.T, *servertestkit.TidbTestSuite)
+	}{
+		{"list", func(t *testing.T, ts *servertestkit.TidbTestSuite) {
+			ts.RunTestLoadDataForListPartition(t)
+		}},
+		{"listGeneratedColumn", func(t *testing.T, ts *servertestkit.TidbTestSuite) {
+			ts.RunTestLoadDataForListPartition2(t)
+		}},
+		{"listColumns", func(t *testing.T, ts *servertestkit.TidbTestSuite) {
+			ts.RunTestLoadDataForListColumnPartition(t)
+		}},
+		{"listColumnsMultiColumn", func(t *testing.T, ts *servertestkit.TidbTestSuite) {
+			ts.RunTestLoadDataForListColumnPartition2(t)
+		}},
+	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ts := servertestkit.CreateTidbTestSuite(t)
+			tt.run(t, ts)
+		})
+	}
 }
 
 func TestPrepareExecute(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68259

Problem Summary:
Flaky test `TestLoadDataListPartition` in `pkg/server/tests` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Shared suite/database ownership across independent LOAD DATA list-partition scenarios made the test sensitive to setup/cleanup overlap.

#### Fix

Creating a fresh `TidbTestSuite` per scenario isolates server/store/database lifecycle while preserving every original scenario assertion.

#### Verification

Spec:
- target: `pkg/server/tests :: TestLoadDataListPartition`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `WRAPPED_GO_TEST`
- wrapper: `./tools/check/failpoint-go-test.sh`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package_surface passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package_surface: PASS
- build: PASS
- lint: PASS

Commands:
- `./tools/check/failpoint-go-test.sh pkg/server/tests -json -run '^TestLoadDataListPartition$' -count=1`
- `./tools/check/failpoint-go-test.sh pkg/server/tests -json -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test structure and reliability for data loading partition tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->