### PR TITLE
tests: disable ssl for br full cluster restore check

### DIFF
--- a/br/tests/br_full_cluster_restore/run.sh
+++ b/br/tests/br_full_cluster_restore/run.sh
@@ -129,7 +129,11 @@ check_contains "SELECT command denied to user"
 # user3 can only query db1.t1 using ssl
 # ci env uses mariadb client, ssl flag is different with mysql client
 # enforce a non-SSL attempt first; some clients may auto-negotiate TLS by default.
-run_sql_as user3 "123456" "select count(*) from db1.t1" --skip-ssl || true
+disable_ssl="--ssl-mode=DISABLED"
+if mysql --version | grep 'MariaDB'; then
+    disable_ssl="--skip-ssl"
+fi
+run_sql_as user3 "123456" "select count(*) from db1.t1" "$disable_ssl" || true
 check_contains "Access denied for user"
 run_sql_as user3 "123456" "select count(*) from db1.t1" --ssl
 check_contains "count(*): 2"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68913

Problem Summary:

Backport the BR full cluster restore test fix from commit 8d9bf5de107ab4101ceb0b3ff7b8cd80e3b0ac66 to `release-8.5`. The test should explicitly disable SSL for the negative user3 check, but MySQL and MariaDB clients use different flags.

### What changed and how does it work?

Use `--ssl-mode=DISABLED` by default and switch to `--skip-ssl` when the local client is MariaDB.

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Manual test:

- `bash -n br/tests/br_full_cluster_restore/run.sh`
- `git diff --check`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved SSL configuration handling in cluster restore tests to enhance compatibility across MySQL and MariaDB environments, ensuring more reliable test execution in CI pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->