### PR TITLE
ddl: forbid unique indexes on materialized view

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1993,17 +1993,19 @@ func checkAlterTableOnlyNonRenamingModifyOrChangeColumns(specs []*ast.AlterTable
 	}
 	return nil
 }
-func hasAlterTableAddUniqueIndexOperation(specs []*ast.AlterTableSpec) bool {
+func hasAlterTableAddUniqueIndexOperation(specs []*ast.AlterTableSpec) (string, bool) {
 	for _, spec := range specs {
 		if spec.Tp != ast.AlterTableAddConstraint || spec.Constraint == nil {
 			continue
 		}
 		switch spec.Constraint.Tp {
 		case ast.ConstraintUniq, ast.ConstraintUniqKey, ast.ConstraintUniqIndex:
-			return true
+			return "ALTER TABLE ADD UNIQUE INDEX", true
+		case ast.ConstraintPrimaryKey:
+			return "ALTER TABLE ADD PRIMARY KEY", true
 		}
 	}
-	return false
+	return "", false
 }
 
 func collectAlterTableSpecAffectedColumns(spec *ast.AlterTableSpec) []string {
@@ -2124,8 +2126,8 @@ func checkAlterTableMaterializedViewConstraints(
 
 	if tblInfo.MaterializedView != nil {
 		// MATERIALIZED VIEW table allows TiFlash replica and index-related ALTER TABLE operations.
-		if hasAlterTableAddUniqueIndexOperation(specs) {
-			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("ALTER TABLE ADD UNIQUE INDEX on materialized view table")
+		if op, ok := hasAlterTableAddUniqueIndexOperation(specs); ok {
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on materialized view table", op))
 		}
 		if isAlterTiFlashReplica(specs) || isAlterTableOnlyIndexOperations(specs) {
 			return nil
@@ -5275,6 +5277,9 @@ func (e *executor) CreatePrimaryKey(ctx sessionctx.Context, ti ast.Ident, indexN
 	schema, t, err := e.getSchemaAndTableByIdent(ti)
 	if err != nil {
 		return errors.Trace(err)
+	}
+	if err := CheckIndexOperationMaterializedViewConstraints(ctx.GetSessionVars(), t.Meta(), "ALTER TABLE ADD PRIMARY KEY", true); err != nil {
+		return err
 	}
 
 	if err = checkTooLongIndex(indexName); err != nil {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1993,6 +1993,18 @@ func checkAlterTableOnlyNonRenamingModifyOrChangeColumns(specs []*ast.AlterTable
 	}
 	return nil
 }
+func hasAlterTableAddUniqueIndexOperation(specs []*ast.AlterTableSpec) bool {
+	for _, spec := range specs {
+		if spec.Tp != ast.AlterTableAddConstraint || spec.Constraint == nil {
+			continue
+		}
+		switch spec.Constraint.Tp {
+		case ast.ConstraintUniq, ast.ConstraintUniqKey, ast.ConstraintUniqIndex:
+			return true
+		}
+	}
+	return false
+}
 
 func collectAlterTableSpecAffectedColumns(spec *ast.AlterTableSpec) []string {
 	cols := make([]string, 0, 2)
@@ -2112,6 +2124,9 @@ func checkAlterTableMaterializedViewConstraints(
 
 	if tblInfo.MaterializedView != nil {
 		// MATERIALIZED VIEW table allows TiFlash replica and index-related ALTER TABLE operations.
+		if hasAlterTableAddUniqueIndexOperation(specs) {
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("ALTER TABLE ADD UNIQUE INDEX on materialized view table")
+		}
 		if isAlterTiFlashReplica(specs) || isAlterTableOnlyIndexOperations(specs) {
 			return nil
 		}
@@ -2137,13 +2152,15 @@ func checkAlterTableMaterializedViewConstraints(
 	return checkAlterTableBaseTableMLogColumnConstraints(ctx, is, tblInfo, specs, op)
 }
 
-func checkIndexOperationMaterializedViewConstraints(
-	sv *variable.SessionVars,
-	tblInfo *model.TableInfo,
-	op string,
-) error {
+// CheckIndexOperationMaterializedViewConstraints checks whether a CREATE, ALTER, or DROP
+// index operation is disallowed on a materialized view log table, a materialized view
+// table (for unique indexes), or a materialized view shadow table.
+func CheckIndexOperationMaterializedViewConstraints(sv *variable.SessionVars, tblInfo *model.TableInfo, op string, unique bool) error {
 	if tblInfo.MaterializedViewLog != nil {
 		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on materialized view log table", op))
+	}
+	if unique && tblInfo.MaterializedView != nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on materialized view table", op))
 	}
 	return checkProtectedMaterializedViewShadowConstraint(sv, tblInfo, op)
 }
@@ -5417,7 +5434,7 @@ func (e *executor) createVectorIndex(ctx sessionctx.Context, ti ast.Ident, index
 	}
 
 	tblInfo := t.Meta()
-	if err := checkIndexOperationMaterializedViewConstraints(ctx.GetSessionVars(), tblInfo, "CREATE INDEX"); err != nil {
+	if err := CheckIndexOperationMaterializedViewConstraints(ctx.GetSessionVars(), tblInfo, "CREATE INDEX", false); err != nil {
 		return errors.Trace(err)
 	}
 	if err := checkTableTypeForVectorIndex(tblInfo); err != nil {
@@ -5534,7 +5551,7 @@ func (e *executor) createIndex(ctx sessionctx.Context, ti ast.Ident, keyType ast
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if err := checkIndexOperationMaterializedViewConstraints(ctx.GetSessionVars(), t.Meta(), "CREATE INDEX"); err != nil {
+		if err := CheckIndexOperationMaterializedViewConstraints(ctx.GetSessionVars(), t.Meta(), "CREATE INDEX", false); err != nil {
 			return errors.Trace(err)
 		}
 		return e.createVectorIndex(ctx, ti, indexName, indexPartSpecifications, indexOption, ifNotExists)
@@ -5544,7 +5561,11 @@ func (e *executor) createIndex(ctx sessionctx.Context, ti ast.Ident, keyType ast
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := checkIndexOperationMaterializedViewConstraints(ctx.GetSessionVars(), t.Meta(), "CREATE INDEX"); err != nil {
+	op := "CREATE INDEX"
+	if unique {
+		op = "CREATE UNIQUE INDEX"
+	}
+	if err := CheckIndexOperationMaterializedViewConstraints(ctx.GetSessionVars(), t.Meta(), op, unique); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -6007,7 +6028,7 @@ func (e *executor) dropIndex(ctx sessionctx.Context, ti ast.Ident, indexName pmo
 	if err != nil {
 		return errors.Trace(infoschema.ErrTableNotExists.GenWithStackByArgs(ti.Schema, ti.Name))
 	}
-	if err := checkIndexOperationMaterializedViewConstraints(ctx.GetSessionVars(), t.Meta(), "DROP INDEX"); err != nil {
+	if err := CheckIndexOperationMaterializedViewConstraints(ctx.GetSessionVars(), t.Meta(), "DROP INDEX", false); err != nil {
 		return errors.Trace(err)
 	}
 	if t.Meta().TableCacheStatusType != model.TableCacheStatusDisable {
@@ -7523,15 +7544,6 @@ func (e *executor) DoDDLJobWrapper(ctx sessionctx.Context, jobW *JobWrapper) (re
 		}
 		panic("When the state is JobStateRollbackDone or JobStateCancelled, historyJob.Error should never be nil")
 	}
-}
-
-func getRenameTableUniqueIDs(jobW *JobWrapper, schema bool) []int64 {
-	if !schema {
-		return []int64{jobW.TableID}
-	}
-
-	oldSchemaID := jobW.JobArgs.(*model.RenameTableArgs).OldSchemaID
-	return []int64{oldSchemaID, jobW.SchemaID}
 }
 
 // HandleLockTablesOnSuccessSubmit handles the table lock for the job which is submitted

--- a/pkg/ddl/mv_index_test.go
+++ b/pkg/ddl/mv_index_test.go
@@ -130,3 +130,32 @@ func TestCreateMaterializedViewOnPartitionTable(t *testing.T) {
 		"[ddl:8200]Unsupported CREATE MATERIALIZED VIEW on partition table",
 	)
 }
+
+func TestCreateUniqueIndexOnMaterializedView(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec(`create table t_mv_unique (
+		id bigint not null primary key,
+		g1 int not null,
+		v1 bigint not null,
+		key idx_g1 (g1)
+	)`)
+	tk.MustExec("insert into t_mv_unique values (1, 1, 10), (2, 1, 20)")
+	tk.MustExec("create materialized view log on t_mv_unique (id, g1, v1)")
+	tk.MustExec(`create materialized view mv_unique_agg (g1, cnt)
+		refresh fast
+		as select g1, count(*) as cnt from t_mv_unique group by g1`)
+
+	tk.MustGetErrMsg(
+		"create unique index u_g1 on mv_unique_agg (g1)",
+		"[ddl:8200]Unsupported CREATE UNIQUE INDEX on materialized view table",
+	)
+	tk.MustGetErrMsg(
+		"alter table mv_unique_agg add unique key uk_g1 (g1)",
+		"[ddl:8200]Unsupported ALTER TABLE ADD UNIQUE INDEX on materialized view table",
+	)
+	tk.MustExec("create index idx_mv_g1 on mv_unique_agg (g1)")
+	tk.MustExec("alter table mv_unique_agg add key idx_mv_cnt (cnt)")
+}

--- a/pkg/ddl/mv_index_test.go
+++ b/pkg/ddl/mv_index_test.go
@@ -156,6 +156,26 @@ func TestCreateUniqueIndexOnMaterializedView(t *testing.T) {
 		"alter table mv_unique_agg add unique key uk_g1 (g1)",
 		"[ddl:8200]Unsupported ALTER TABLE ADD UNIQUE INDEX on materialized view table",
 	)
+	tk.MustGetErrMsg(
+		"alter table mv_unique_agg add primary key (g1) nonclustered",
+		"[ddl:8200]Unsupported ALTER TABLE ADD PRIMARY KEY on materialized view table",
+	)
 	tk.MustExec("create index idx_mv_g1 on mv_unique_agg (g1)")
 	tk.MustExec("alter table mv_unique_agg add key idx_mv_cnt (cnt)")
+
+	tk.MustExec(`create table t_mv_nullable_key (
+		id bigint not null primary key,
+		g1 int,
+		v1 bigint not null,
+		key idx_g1 (g1)
+	)`)
+	tk.MustExec("insert into t_mv_nullable_key values (1, null, 10)")
+	tk.MustExec("create materialized view log on t_mv_nullable_key (id, g1, v1)")
+	tk.MustExec(`create materialized view mv_nullable_key_agg (g1, cnt)
+		refresh fast
+		as select g1, count(*) as cnt from t_mv_nullable_key group by g1`)
+	tk.MustGetErrMsg(
+		"alter table mv_nullable_key_agg add primary key (cnt) nonclustered",
+		"[ddl:8200]Unsupported ALTER TABLE ADD PRIMARY KEY on materialized view table",
+	)
 }

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -1047,6 +1047,9 @@ func (d *SchemaTracker) createPrimaryKey(
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if err := ddl.CheckIndexOperationMaterializedViewConstraints(ctx.GetSessionVars(), tblInfo, "ALTER TABLE ADD PRIMARY KEY", true); err != nil {
+		return err
+	}
 
 	defer d.putTableIfNoError(err, ti.Schema, tblInfo)
 

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -571,7 +571,7 @@ func (d *SchemaTracker) DropView(_ sessionctx.Context, stmt *ast.DropTableStmt) 
 func (d *SchemaTracker) CreateIndex(ctx sessionctx.Context, stmt *ast.CreateIndexStmt) error {
 	ident := ast.Ident{Schema: stmt.Table.Schema, Name: stmt.Table.Name}
 	return d.createIndex(ctx, ident, stmt.KeyType, pmodel.NewCIStr(stmt.IndexName),
-		stmt.IndexPartSpecifications, stmt.IndexOption, stmt.IfNotExists)
+		stmt.IndexPartSpecifications, stmt.IndexOption, stmt.IfNotExists, "CREATE INDEX")
 }
 
 func (d *SchemaTracker) putTableIfNoError(err error, dbName pmodel.CIStr, tbInfo *model.TableInfo) {
@@ -590,10 +590,17 @@ func (d *SchemaTracker) createIndex(
 	indexPartSpecifications []*ast.IndexPartSpecification,
 	indexOption *ast.IndexOption,
 	ifNotExists bool,
+	op string,
 ) (err error) {
 	unique := keyType == ast.IndexKeyTypeUnique
 	tblInfo, err := d.TableClonedByName(ti.Schema, ti.Name)
 	if err != nil {
+		return err
+	}
+	if unique && op == "CREATE INDEX" {
+		op = "CREATE UNIQUE INDEX"
+	}
+	if err := ddl.CheckIndexOperationMaterializedViewConstraints(ctx.GetSessionVars(), tblInfo, op, unique); err != nil {
 		return err
 	}
 
@@ -1132,10 +1139,10 @@ func (d *SchemaTracker) AlterTable(ctx context.Context, sctx sessionctx.Context,
 			switch spec.Constraint.Tp {
 			case ast.ConstraintKey, ast.ConstraintIndex:
 				err = d.createIndex(sctx, ident, ast.IndexKeyTypeNone, pmodel.NewCIStr(constr.Name),
-					spec.Constraint.Keys, constr.Option, constr.IfNotExists)
+					spec.Constraint.Keys, constr.Option, constr.IfNotExists, "ALTER TABLE ADD INDEX")
 			case ast.ConstraintUniq, ast.ConstraintUniqIndex, ast.ConstraintUniqKey:
 				err = d.createIndex(sctx, ident, ast.IndexKeyTypeUnique, pmodel.NewCIStr(constr.Name),
-					spec.Constraint.Keys, constr.Option, false) // IfNotExists should be not applied
+					spec.Constraint.Keys, constr.Option, false, "ALTER TABLE ADD UNIQUE INDEX") // IfNotExists should be not applied
 			case ast.ConstraintPrimaryKey:
 				err = d.createPrimaryKey(sctx, ident, pmodel.NewCIStr(constr.Name), spec.Constraint.Keys, constr.Option)
 			case ast.ConstraintForeignKey,

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -4349,6 +4349,12 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		return finalizeFailure(err)
 	}
 	executeDataChangesDur = time.Since(executeDataChangesStart)
+	failpoint.Inject("mockRefreshMaterializedViewErrorAfterDataChanges", func(val failpoint.Value) {
+		if msg, ok := val.(string); ok {
+			failpoint.Return(finalizeFailure(errors.New(msg)))
+		}
+		failpoint.Return(finalizeFailure(errors.New("mock refresh materialized view error after data changes")))
+	})
 	refreshStmtResult := captureMVRefreshStmtResult(sessVars)
 
 	actualRefreshReadTSO, err := getRefreshReadTSOForSuccess(sessVars)
@@ -4582,6 +4588,12 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedViewCompleteOutO
 	}); err != nil {
 		return 0, err
 	}
+	failpoint.Inject("mockRefreshMaterializedViewOutOfPlaceBuildErrorAfterLoadShadow", func(val failpoint.Value) {
+		if msg, ok := val.(string); ok {
+			failpoint.Return(uint64(0), errors.New(msg))
+		}
+		failpoint.Return(uint64(0), errors.New("mock refresh materialized view out-of-place build error after load shadow"))
+	})
 	failpoint.Inject("mockRefreshMaterializedViewOutOfPlaceBuildReadTSO", func(val failpoint.Value) {
 		s, ok := val.(string)
 		if !ok {

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -2961,12 +2961,17 @@ func TestMaterializedViewRefreshCompleteDeltaApplyRollbackOnError(t *testing.T) 
 	require.NoError(t, err)
 	require.NotZero(t, oldTS)
 
-	tk.MustExec("create unique index idx_unique_s on mv (s)")
 	tk.MustExec("insert into t values (2, 8)")
+
+	const refreshFailpoint = "github.com/pingcap/tidb/pkg/executor/mockRefreshMaterializedViewErrorAfterDataChanges"
+	require.NoError(t, failpoint.Enable(refreshFailpoint, `return("mock refresh data change failure")`))
+	defer func() {
+		require.NoError(t, failpoint.Disable(refreshFailpoint))
+	}()
 
 	err = tk.ExecToErr("refresh materialized view mv complete delta apply")
 	require.Error(t, err)
-	require.ErrorContains(t, err, "Duplicate")
+	require.ErrorContains(t, err, "mock refresh data change failure")
 
 	tk.MustQuery("select a, s, cnt from mv order by a").Check(testkit.Rows("1 15 2", "2 7 1"))
 	tk.MustQuery(fmt.Sprintf("select LAST_SUCCESS_READ_TSO = %d from mysql.tidb_mview_refresh_info where MVIEW_ID = %d", oldTS, mviewID)).
@@ -2977,7 +2982,7 @@ func TestMaterializedViewRefreshCompleteDeltaApplyRollbackOnError(t *testing.T) 
 		Check(testkit.Rows("0"))
 	reasonRow := tk.MustQuery(fmt.Sprintf("select REFRESH_FAILED_REASON from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d order by REFRESH_JOB_ID desc limit 1", mviewID)).Rows()
 	require.Len(t, reasonRow, 1)
-	require.Contains(t, fmt.Sprintf("%v", reasonRow[0][0]), "Duplicate")
+	require.Contains(t, fmt.Sprintf("%v", reasonRow[0][0]), "mock refresh data change failure")
 }
 
 func TestMaterializedViewRefreshEarlyFailureWritesHist(t *testing.T) {
@@ -3229,12 +3234,17 @@ func TestMaterializedViewRefreshCompleteOutOfPlaceBuildFailureCleansShadow(t *te
 	require.Len(t, mviewIDRows, 1)
 	mviewID, err := strconv.ParseInt(fmt.Sprintf("%v", mviewIDRows[0][0]), 10, 64)
 	require.NoError(t, err)
-	tk.MustExec("create unique index idx_unique_s on mv (s)")
 	tk.MustExec("insert into t values (2, 8)")
+
+	const buildFailpoint = "github.com/pingcap/tidb/pkg/executor/mockRefreshMaterializedViewOutOfPlaceBuildErrorAfterLoadShadow"
+	require.NoError(t, failpoint.Enable(buildFailpoint, `return("mock out-of-place shadow load failure")`))
+	defer func() {
+		require.NoError(t, failpoint.Disable(buildFailpoint))
+	}()
 
 	err = tk.ExecToErr("refresh materialized view mv complete out of place")
 	require.Error(t, err)
-	require.ErrorContains(t, err, "Duplicate")
+	require.ErrorContains(t, err, "mock out-of-place shadow load failure")
 	tk.MustQuery(fmt.Sprintf(
 		"select REFRESH_STATUS, REFRESH_METHOD, REFRESH_READ_TSO is null, REFRESH_FAILED_REASON is not null from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d order by REFRESH_JOB_ID desc limit 1",
 		mviewID,
@@ -3469,11 +3479,13 @@ func TestMaterializedViewRefreshCompleteFailureKeepsRefreshInfoReadTSO(t *testin
 	require.NoError(t, err)
 	require.NotZero(t, oldTS)
 
-	// Create a unique index that will be violated after refresh.
-	tk.MustExec("create unique index idx_unique_s on mv (s)")
-
-	// Make the refreshed MV contain duplicate `s` values: sum(b) for a=2 becomes 15.
 	tk.MustExec("insert into t values (2, 8)")
+
+	const refreshFailpoint = "github.com/pingcap/tidb/pkg/executor/mockRefreshMaterializedViewErrorAfterDataChanges"
+	require.NoError(t, failpoint.Enable(refreshFailpoint, `return("mock refresh data change failure")`))
+	defer func() {
+		require.NoError(t, failpoint.Disable(refreshFailpoint))
+	}()
 
 	const finalizeFailpoint = "github.com/pingcap/tidb/pkg/executor/mockFinalizeRefreshHistError"
 	require.NoError(t, failpoint.Enable(finalizeFailpoint, "1*return(true)"))
@@ -3483,7 +3495,7 @@ func TestMaterializedViewRefreshCompleteFailureKeepsRefreshInfoReadTSO(t *testin
 
 	err = tk.ExecToErr("refresh materialized view mv complete delta apply")
 	require.Error(t, err)
-	require.ErrorContains(t, err, "Duplicate")
+	require.ErrorContains(t, err, "mock refresh data change failure")
 
 	// MV data should remain unchanged due to transactional refresh.
 	tk.MustQuery("select a, s, cnt from mv order by a").Check(testkit.Rows("1 15 2", "2 7 1"))
@@ -3496,7 +3508,7 @@ func TestMaterializedViewRefreshCompleteFailureKeepsRefreshInfoReadTSO(t *testin
 		Check(testkit.Rows("0"))
 	reasonRow := tk.MustQuery(fmt.Sprintf("select REFRESH_FAILED_REASON from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d order by REFRESH_JOB_ID desc limit 1", mviewID)).Rows()
 	require.Len(t, reasonRow, 1)
-	require.Contains(t, fmt.Sprintf("%v", reasonRow[0][0]), "Duplicate")
+	require.Contains(t, fmt.Sprintf("%v", reasonRow[0][0]), "mock refresh data change failure")
 }
 
 func TestMaterializedViewRefreshFailureReportsAlertBeforeFinalizeHistFailure(t *testing.T) {
@@ -3513,8 +3525,13 @@ func TestMaterializedViewRefreshFailureReportsAlertBeforeFinalizeHistFailure(t *
 	require.NoError(t, err)
 	mviewID := mvTable.Meta().ID
 
-	tk.MustExec("create unique index idx_unique_s on mv (s)")
 	tk.MustExec("insert into t values (2, 8)")
+
+	const refreshFailpoint = "github.com/pingcap/tidb/pkg/executor/mockRefreshMaterializedViewErrorAfterDataChanges"
+	require.NoError(t, failpoint.Enable(refreshFailpoint, `return("mock refresh data change failure")`))
+	defer func() {
+		require.NoError(t, failpoint.Disable(refreshFailpoint))
+	}()
 
 	const finalizeFailpoint = "github.com/pingcap/tidb/pkg/executor/mockFinalizeRefreshHistError"
 	require.NoError(t, failpoint.Enable(finalizeFailpoint, "return(true)"))
@@ -3525,7 +3542,7 @@ func TestMaterializedViewRefreshFailureReportsAlertBeforeFinalizeHistFailure(t *
 	err = tk.ExecToErr("refresh materialized view mv complete delta apply")
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to finalize refresh history after error")
-	require.ErrorContains(t, err, "Duplicate")
+	require.ErrorContains(t, err, "mock refresh data change failure")
 
 	tk.MustQuery(fmt.Sprintf(
 		"select REFRESH_FAILED, ALERT_LEVEL is null from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66777

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that we can create unique index on materialized view
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explicitly reject unique index/constraint operations on materialized-view tables (including `CREATE UNIQUE INDEX`, `ALTER TABLE ... ADD UNIQUE KEY`, and `ALTER TABLE ... ADD UNIQUE INDEX`) with clear `[ddl:8200]` errors.
  * Also reject index operations on materialized-view log tables.
  * Continue allowing non-unique index additions on materialized-view tables.

* **Tests**
  * Replaced prior materialized-view DDL test with `TestCreateUniqueIndexOnMaterializedView` to verify unique operations fail and non-unique operations succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->