### PR TITLE
lightning: fix write limit test timing flake

### DIFF
--- a/lightning/tests/lightning_write_limit/config.toml
+++ b/lightning/tests/lightning_write_limit/config.toml
@@ -1,5 +1,5 @@
 [tikv-importer]
-store-write-bwlimit = "1MiB"
+store-write-bwlimit = "512KiB"
 
 [mydumper.csv]
 header = false

--- a/lightning/tests/lightning_write_limit/run.sh
+++ b/lightning/tests/lightning_write_limit/run.sh
@@ -35,7 +35,7 @@ CREATE TABLE test.t (
 );
 EOF
 
-# Generate 200k rows. Total size is about 5MiB.
+# Generate 200k rows. Total CSV size is about 5MiB and encoded KV size is about 10MiB.
 set +x
 for i in {1..200000}; do
   echo "$i,$i,$i,$i" >>"$TEST_DIR/data/test.t.0.csv"
@@ -47,8 +47,12 @@ run_lightning --backend local -d "$TEST_DIR/data" --config "$CUR/config.toml"
 end=$(date +%s)
 take=$((end - start))
 
-# The encoded kv size is 10MiB. Usually it should take more than 10s.
+# With store-write-bwlimit=512KiB and the write limiter's initial 20% burst,
+# importing about 10MiB of encoded KV data should still take much more than 10s.
+# Keep the threshold below the expected limited runtime to avoid boundary failures
+# from second-resolution timing and normal CI variance.
 if [ $take -lt 10 ]; then
   echo "Lightning runs too fast. The write limiter doesn't work."
+  echo "take=${take}s"
   exit 1
 fi


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68915

Problem Summary:

The `lightning_write_limit` integration test can fail even when the write limiter is working. With the old `store-write-bwlimit = "1MiB"` setting, the CI log showed `10337356` imported bytes and a completed Lightning run of `9.836501468s`, but the shell test measured integer seconds with `date +%s` and failed because `take=9`.

The store write limiter also allows an initial 20% burst, so the expected wait for that imported size is about `8.66s`. That makes the test's `10s` cutoff a timing boundary rather than reliable evidence that the limiter is broken.

### What changed and how does it work?

This PR lowers the test-only `store-write-bwlimit` from `1MiB` to `512KiB`, so the same imported data is expected to spend about `19s` under the limiter before crossing the existing `10s` assertion. The test still fails quickly if the limiter is not applied, but it no longer sits on the boundary caused by burst allowance and second-resolution timing.

The test comments now document the encoded KV size, burst behavior, and why the threshold is intentionally below the expected limited runtime. The failure path also prints `take=<n>s` to make future CI triage clearer.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit and manual validation:

```bash
# Red condition before the fix: failed with expected_wait_ceiling_seconds=9 threshold=10
limit=$((1024 * 1024)); burst=$((limit + limit / 5)); size=10337356; threshold=10; expected=$(( (size - burst + limit - 1) / limit )); echo "size=$size limit=$limit burst=$burst expected_wait_ceiling_seconds=$expected threshold=$threshold"; test "$expected" -ge "$threshold"

bash -n lightning/tests/lightning_write_limit/run.sh

git diff --check

# Green deterministic boundary check: passed with expected_wait_ceiling_seconds=19 threshold=10
limit=$((512 * 1024)); burst=$((limit + limit / 5)); size=10337356; threshold=10; expected=$(( (size - burst + limit - 1) / limit )); echo "size=$size limit=$limit burst=$burst expected_wait_ceiling_seconds=$expected threshold=$threshold"; test "$expected" -ge "$threshold"

pushd pkg/lightning/config >/dev/null && go test -run TestByteSizeTOMLDecode -tags=intest,deadlock -count=1 && popd >/dev/null

make lint
```

I did not run `TEST_NAME=lightning_write_limit lightning/tests/run.sh` locally because this worktree does not have the required `bin/tidb-server`, `bin/tikv-server`, `bin/pd-server`, and `bin/tidb-lightning` binaries.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for write-limit scenarios with adjusted bandwidth limit settings.
  * Enhanced test documentation with detailed inline comments describing expected row counts and dataset sizes for import operations.
  * Improved failure messages to display measured timing information for more effective troubleshooting of write-limiting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->