### PR TITLE
server: harden parseBinaryParams against malformed length-encoded values

### DIFF
--- a/pkg/server/conn_stmt_params.go
+++ b/pkg/server/conn_stmt_params.go
@@ -26,6 +26,35 @@ import (
 
 var errUnknownFieldType = dbterror.ClassServer.NewStd(errno.ErrUnknownFieldType)
 
+func parseLengthEncodedParamValueHeader(paramValues []byte, pos int) (length uint64, isNull bool, nextPos int, err error) {
+	if len(paramValues) <= pos {
+		return 0, false, pos, mysql.ErrMalformPacket
+	}
+	need := 1
+	switch paramValues[pos] {
+	case 0xfc:
+		need = 3
+	case 0xfd:
+		need = 4
+	case 0xfe:
+		need = 9
+	}
+	if len(paramValues)-pos < need {
+		return 0, false, pos, mysql.ErrMalformPacket
+	}
+	var n int
+	length, isNull, n = util2.ParseLengthEncodedInt(paramValues[pos:])
+	return length, isNull, pos + n, nil
+}
+
+func takeBinaryParamValue(paramValues []byte, pos int, length uint64) ([]byte, int, error) {
+	if pos > len(paramValues) || length > uint64(len(paramValues)-pos) {
+		return nil, pos, mysql.ErrMalformPacket
+	}
+	end := pos + int(length)
+	return paramValues[pos:end], end, nil
+}
+
 // parseBinaryParams decodes the binary params according to the protocol
 func parseBinaryParams(params []param.BinaryParam, boundParams [][]byte, nullBitmap, paramTypes, paramValues []byte, enc *util2.InputDecoder) (err error) {
 	pos := 0
@@ -106,42 +135,36 @@ func parseBinaryParams(params []param.BinaryParam, boundParams [][]byte, nullBit
 			length = uint64(paramValues[pos])
 			pos++
 		case mysql.TypeNewDecimal, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
-			if len(paramValues) < (pos + 1) {
-				err = mysql.ErrMalformPacket
+			length, isNull, pos, err = parseLengthEncodedParamValueHeader(paramValues, pos)
+			if err != nil {
 				return
 			}
-			var n int
-			length, isNull, n = util2.ParseLengthEncodedInt(paramValues[pos:])
-			pos += n
 		case mysql.TypeUnspecified, mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeString,
 			mysql.TypeEnum, mysql.TypeSet, mysql.TypeGeometry, mysql.TypeBit:
-			if len(paramValues) < (pos + 1) {
-				err = mysql.ErrMalformPacket
+			length, isNull, pos, err = parseLengthEncodedParamValueHeader(paramValues, pos)
+			if err != nil {
 				return
 			}
-			var n int
-			length, isNull, n = util2.ParseLengthEncodedInt(paramValues[pos:])
-			pos += n
 			decodeWithDecoder = true
 		default:
 			err = errUnknownFieldType.GenWithStack("stmt unknown field type %d", tp)
 			return
 		}
 
-		if len(paramValues) < (pos + int(length)) {
-			err = mysql.ErrMalformPacket
-			return
+		val, nextPos, err := takeBinaryParamValue(paramValues, pos, length)
+		if err != nil {
+			return err
 		}
 		params[i] = param.BinaryParam{
 			Tp:         tp,
 			IsUnsigned: isUnsigned,
 			IsNull:     isNull,
-			Val:        paramValues[pos : pos+int(length)],
+			Val:        val,
 		}
 		if decodeWithDecoder {
 			params[i].Val = enc.DecodeInput(params[i].Val)
 		}
-		pos += int(length)
+		pos = nextPos
 	}
 	return
 }

--- a/pkg/server/conn_stmt_params.go
+++ b/pkg/server/conn_stmt_params.go
@@ -26,27 +26,6 @@ import (
 
 var errUnknownFieldType = dbterror.ClassServer.NewStd(errno.ErrUnknownFieldType)
 
-func parseLengthEncodedParamValueHeader(paramValues []byte, pos int) (length uint64, isNull bool, nextPos int, err error) {
-	if len(paramValues) <= pos {
-		return 0, false, pos, mysql.ErrMalformPacket
-	}
-	need := 1
-	switch paramValues[pos] {
-	case 0xfc:
-		need = 3
-	case 0xfd:
-		need = 4
-	case 0xfe:
-		need = 9
-	}
-	if len(paramValues)-pos < need {
-		return 0, false, pos, mysql.ErrMalformPacket
-	}
-	var n int
-	length, isNull, n = util2.ParseLengthEncodedInt(paramValues[pos:])
-	return length, isNull, pos + n, nil
-}
-
 func takeBinaryParamValue(paramValues []byte, pos int, length uint64) ([]byte, int, error) {
 	if pos > len(paramValues) || length > uint64(len(paramValues)-pos) {
 		return nil, pos, mysql.ErrMalformPacket
@@ -135,16 +114,20 @@ func parseBinaryParams(params []param.BinaryParam, boundParams [][]byte, nullBit
 			length = uint64(paramValues[pos])
 			pos++
 		case mysql.TypeNewDecimal, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
-			length, isNull, pos, err = parseLengthEncodedParamValueHeader(paramValues, pos)
+			var n int
+			length, isNull, n, err = util2.ParseLengthEncodedInt(paramValues[pos:])
 			if err != nil {
-				return
+				return mysql.ErrMalformPacket
 			}
+			pos += n
 		case mysql.TypeUnspecified, mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeString,
 			mysql.TypeEnum, mysql.TypeSet, mysql.TypeGeometry, mysql.TypeBit:
-			length, isNull, pos, err = parseLengthEncodedParamValueHeader(paramValues, pos)
+			var n int
+			length, isNull, n, err = util2.ParseLengthEncodedInt(paramValues[pos:])
 			if err != nil {
-				return
+				return mysql.ErrMalformPacket
 			}
+			pos += n
 			decodeWithDecoder = true
 		default:
 			err = errUnknownFieldType.GenWithStack("stmt unknown field type %d", tp)

--- a/pkg/server/conn_stmt_params_test.go
+++ b/pkg/server/conn_stmt_params_test.go
@@ -282,6 +282,40 @@ func TestParseExecArgs(t *testing.T) {
 	}
 }
 
+func TestParseExecArgsMalformedLengthEncodedParam(t *testing.T) {
+	tests := []struct {
+		name        string
+		paramValues []byte
+	}{
+		{
+			name:        "truncated length-encoded uint64 header",
+			paramValues: []byte{0xfe},
+		},
+		{
+			name: "overflowing length-encoded uint64",
+			// length = 1<<63, which previously could slip past `pos + int(length)` checks and panic on slicing.
+			paramValues: []byte{0xfe, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				args := expression.Args2Expressions4Test(1)
+				err := decodeAndParse(
+					types.DefaultStmtNoWarningContext,
+					args,
+					[][]byte{nil},
+					[]byte{0x0},
+					[]byte{mysql.TypeVarString, 0},
+					tt.paramValues,
+					nil,
+				)
+				require.Truef(t, terror.ErrorEqual(err, mysql.ErrMalformPacket), "err %v", err)
+			})
+		})
+	}
+}
+
 func TestParseExecArgsAndEncode(t *testing.T) {
 	dt := expression.Args2Expressions4Test(1)
 	err := decodeAndParse(types.DefaultStmtNoWarningContext,

--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -547,6 +547,37 @@ func TestHandshakeResponseCompatibilityAndFailurePaths(t *testing.T) {
 		require.ErrorIs(t, err, mysql.ErrMalformPacket)
 	})
 
+	t.Run("truncated connect attrs length header", func(t *testing.T) {
+		data := buildHandshakeResponsePacket(mysql.ClientProtocol41|mysql.ClientConnectAtts, nil, nil)
+		data[len(data)-1] = 0xfe
+
+		var p handshake.Response41
+		offset, err := parse.HandshakeResponseHeader(context.Background(), &p, data)
+		require.NoError(t, err)
+
+		err = parse.HandshakeResponseBody(context.Background(), &p, data, offset)
+		require.ErrorIs(t, err, mysql.ErrMalformPacket)
+	})
+
+	t.Run("truncated auth length header", func(t *testing.T) {
+		var buf bytes.Buffer
+		binary.Write(&buf, binary.LittleEndian, uint32(mysql.ClientProtocol41|mysql.ClientPluginAuthLenencClientData))
+		binary.Write(&buf, binary.LittleEndian, uint32(0)) // max packet size
+		buf.WriteByte(0)                                   // collation
+		buf.Write(make([]byte, 23))                        // reserved
+		buf.WriteString("root")
+		buf.WriteByte(0)    // user null-terminated
+		buf.WriteByte(0xfe) // truncated auth length-encoded header
+		data := buf.Bytes()
+
+		var p handshake.Response41
+		offset, err := parse.HandshakeResponseHeader(context.Background(), &p, data)
+		require.NoError(t, err)
+
+		err = parse.HandshakeResponseBody(context.Background(), &p, data, offset)
+		require.ErrorIs(t, err, mysql.ErrMalformPacket)
+	})
+
 	t.Run("oversize connect attrs declaration rejected", func(t *testing.T) {
 		declaredLen := uint64(1<<20 + 1)
 		data := buildHandshakeResponsePacket(mysql.ClientProtocol41|mysql.ClientConnectAtts, nil, &declaredLen)

--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -561,7 +561,7 @@ func TestHandshakeResponseCompatibilityAndFailurePaths(t *testing.T) {
 
 	t.Run("truncated auth length header", func(t *testing.T) {
 		var buf bytes.Buffer
-		binary.Write(&buf, binary.LittleEndian, uint32(mysql.ClientProtocol41|mysql.ClientPluginAuthLenencClientData))
+		binary.Write(&buf, binary.LittleEndian, mysql.ClientProtocol41|mysql.ClientPluginAuthLenencClientData)
 		binary.Write(&buf, binary.LittleEndian, uint32(0)) // max packet size
 		buf.WriteByte(0)                                   // collation
 		buf.Write(make([]byte, 23))                        // reserved

--- a/pkg/server/internal/parse/parse.go
+++ b/pkg/server/internal/parse/parse.go
@@ -92,7 +92,10 @@ func HandshakeResponseBody(ctx context.Context, packet *handshake.Response41, da
 		if data[offset] == 0x1 { // No auth data
 			offset += 2
 		} else {
-			num, null, off := util2.ParseLengthEncodedInt(data[offset:])
+			num, null, off, err := util2.ParseLengthEncodedInt(data[offset:])
+			if err != nil {
+				return mysql.ErrMalformPacket
+			}
 			offset += off
 			if !null {
 				packet.Auth = data[offset : offset+int(num)]
@@ -133,7 +136,10 @@ func HandshakeResponseBody(ctx context.Context, packet *handshake.Response41, da
 			// Defend some ill-formated packet, connection attribute is not important and can be ignored.
 			return nil
 		}
-		num, null, intOff := util2.ParseLengthEncodedInt(data[offset:])
+		num, null, intOff, err := util2.ParseLengthEncodedInt(data[offset:])
+		if err != nil {
+			return mysql.ErrMalformPacket
+		}
 		offset += intOff // Length of variable length encoded integer itself in bytes
 		if !null {
 			if num > 1<<20 { // 1 MiB hard limit

--- a/pkg/server/internal/util/util.go
+++ b/pkg/server/internal/util/util.go
@@ -66,8 +66,6 @@ func ParseLengthEncodedInt(b []byte) (num uint64, isNull bool, n int, err error)
 	switch b[0] {
 	// 251: NULL
 	case 0xfb:
-		n = 1
-		isNull = true
 		return 0, true, 1, nil
 
 	// 252: value of following 2
@@ -76,7 +74,6 @@ func ParseLengthEncodedInt(b []byte) (num uint64, isNull bool, n int, err error)
 			return 0, false, 0, io.EOF
 		}
 		num = uint64(b[1]) | uint64(b[2])<<8
-		n = 3
 		return num, false, 3, nil
 
 	// 253: value of following 3
@@ -85,7 +82,6 @@ func ParseLengthEncodedInt(b []byte) (num uint64, isNull bool, n int, err error)
 			return 0, false, 0, io.EOF
 		}
 		num = uint64(b[1]) | uint64(b[2])<<8 | uint64(b[3])<<16
-		n = 4
 		return num, false, 4, nil
 
 	// 254: value of following 8
@@ -96,7 +92,6 @@ func ParseLengthEncodedInt(b []byte) (num uint64, isNull bool, n int, err error)
 		num = uint64(b[1]) | uint64(b[2])<<8 | uint64(b[3])<<16 |
 			uint64(b[4])<<24 | uint64(b[5])<<32 | uint64(b[6])<<40 |
 			uint64(b[7])<<48 | uint64(b[8])<<56
-		n = 9
 		return num, false, 9, nil
 	}
 

--- a/pkg/server/internal/util/util.go
+++ b/pkg/server/internal/util/util.go
@@ -57,48 +57,63 @@ func ParseNullTermString(b []byte) (str []byte, remain []byte) {
 }
 
 // ParseLengthEncodedInt parses a length encoded integer.
-func ParseLengthEncodedInt(b []byte) (num uint64, isNull bool, n int) {
+// It returns io.EOF when the length-encoded header is truncated.
+func ParseLengthEncodedInt(b []byte) (num uint64, isNull bool, n int, err error) {
+	if len(b) == 0 {
+		return 0, false, 0, io.EOF
+	}
+
 	switch b[0] {
 	// 251: NULL
 	case 0xfb:
 		n = 1
 		isNull = true
-		return
+		return 0, true, 1, nil
 
 	// 252: value of following 2
 	case 0xfc:
+		if len(b) < 3 {
+			return 0, false, 0, io.EOF
+		}
 		num = uint64(b[1]) | uint64(b[2])<<8
 		n = 3
-		return
+		return num, false, 3, nil
 
 	// 253: value of following 3
 	case 0xfd:
+		if len(b) < 4 {
+			return 0, false, 0, io.EOF
+		}
 		num = uint64(b[1]) | uint64(b[2])<<8 | uint64(b[3])<<16
 		n = 4
-		return
+		return num, false, 4, nil
 
 	// 254: value of following 8
 	case 0xfe:
+		if len(b) < 9 {
+			return 0, false, 0, io.EOF
+		}
 		num = uint64(b[1]) | uint64(b[2])<<8 | uint64(b[3])<<16 |
 			uint64(b[4])<<24 | uint64(b[5])<<32 | uint64(b[6])<<40 |
 			uint64(b[7])<<48 | uint64(b[8])<<56
 		n = 9
-		return
+		return num, false, 9, nil
 	}
 
-	// https://dev.mysql.com/doc/internals/en/integer.html#length-encoded-integer: If the first byte of a packet is a length-encoded integer and its byte value is 0xfe, you must check the length of the packet to verify that it has enough space for a 8-byte integer.
-	// TODO: 0xff is undefined
+	// https://dev.mysql.com/doc/internals/en/integer.html#length-encoded-integer
+	// TODO: 0xff is undefined.
 
 	// 0-250: value of first byte
-	num = uint64(b[0])
-	n = 1
-	return
+	return uint64(b[0]), false, 1, nil
 }
 
 // ParseLengthEncodedBytes parses a length encoded byte slice.
 func ParseLengthEncodedBytes(b []byte) ([]byte, bool, int, error) {
 	// Get length
-	num, isNull, n := ParseLengthEncodedInt(b)
+	num, isNull, n, err := ParseLengthEncodedInt(b)
+	if err != nil {
+		return nil, isNull, n, err
+	}
 	if num < 1 {
 		return nil, isNull, n, nil
 	}

--- a/pkg/server/internal/util/util_test.go
+++ b/pkg/server/internal/util/util_test.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"io"
 	"strconv"
 	"testing"
 
@@ -209,45 +210,82 @@ func TestParseLengthEncodedInt(t *testing.T) {
 		num    uint64
 		isNull bool
 		n      int
+		err    error
 	}{
 		{
 			[]byte{'\xfb'},
 			uint64(0),
 			true,
 			1,
+			nil,
 		},
 		{
 			[]byte{'\x00'},
 			uint64(0),
 			false,
 			1,
+			nil,
 		},
 		{
 			[]byte{'\xfc', '\x01', '\x02'},
 			uint64(513),
 			false,
 			3,
+			nil,
 		},
 		{
 			[]byte{'\xfd', '\x01', '\x02', '\x03'},
 			uint64(197121),
 			false,
 			4,
+			nil,
 		},
 		{
 			[]byte{'\xfe', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07', '\x08'},
 			uint64(578437695752307201),
 			false,
 			9,
+			nil,
+		},
+		{
+			[]byte{},
+			uint64(0),
+			false,
+			0,
+			io.EOF,
+		},
+		{
+			[]byte{'\xfc', '\x01'},
+			uint64(0),
+			false,
+			0,
+			io.EOF,
+		},
+		{
+			[]byte{'\xfd', '\x01', '\x02'},
+			uint64(0),
+			false,
+			0,
+			io.EOF,
+		},
+		{
+			[]byte{'\xfe'},
+			uint64(0),
+			false,
+			0,
+			io.EOF,
 		},
 	}
 
 	for _, tc := range testCases {
-		num, isNull, n := ParseLengthEncodedInt(tc.buffer)
+		num, isNull, n, err := ParseLengthEncodedInt(tc.buffer)
 		require.Equal(t, tc.num, num)
 		require.Equal(t, tc.isNull, isNull)
 		require.Equal(t, tc.n, n)
-		require.Equal(t, tc.n, LengthEncodedIntSize(tc.num))
+		require.ErrorIs(t, err, tc.err)
+		if tc.err == nil {
+			require.Equal(t, tc.n, LengthEncodedIntSize(tc.num))
+		}
 	}
 }
 
@@ -272,6 +310,13 @@ func TestParseLengthEncodedBytes(t *testing.T) {
 	require.False(t, isNull)
 	require.Equal(t, 2, n)
 	require.Equal(t, "EOF", err.Error())
+
+	buffer = []byte{'\xfe'}
+	b, isNull, n, err = ParseLengthEncodedBytes(buffer)
+	require.Nil(t, b)
+	require.False(t, isNull)
+	require.Equal(t, 0, n)
+	require.ErrorIs(t, err, io.EOF)
 }
 
 func TestParseNullTermString(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67486

Problem Summary:

This PR supersedes #67542. I do not have write access to the original contributor branch, so I am carrying the same fix forward on a branch I can maintain.

Malformed length-encoded parameter payloads in `COM_STMT_EXECUTE` may panic in `parseBinaryParams`. Large or truncated values should be rejected as malformed packets instead of reaching unsafe slicing logic.

### What changed and how does it work?

This PR keeps the original hardening change and continues from it:

1. Check that the length-encoded header has enough bytes before decoding it.
2. Check the decoded payload length against the remaining buffer using `uint64`-safe bounds before converting to `int` and slicing.
3. Cover truncated and oversized payload cases with regression tests so malformed packets return an error instead of panicking.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
- [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a panic in `COM_STMT_EXECUTE` parameter parsing by rejecting malformed length-encoded parameter payloads before slicing them.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parsing now returns explicit errors for truncated or malformed length-encoded data, preventing out-of-bounds panics and ensuring malformed packets surface as parse errors.
  * Handshake parsing now reliably detects and fails on truncated auth and connection-attribute payloads.

* **Refactor**
  * Centralized binary-parameter slicing and bounds checks for consistent error handling.

* **Tests**
  * Added/extended tests to cover malformed length-encoded parameters and truncated handshake payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->