### PR TITLE
planner: support "explain explore replayer" syntax

### DIFF
--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -29,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/planner/extstore"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
@@ -44,6 +46,10 @@ import (
 
 var _ exec.Executor = &PlanReplayerExec{}
 var _ exec.Executor = &PlanReplayerLoadExec{}
+
+func init() {
+	plannercore.LoadPlanReplayerForExplainExplore = loadPlanReplayerForExplainExplore
+}
 
 // PlanReplayerExec represents a plan replayer executor.
 type PlanReplayerExec struct {
@@ -280,6 +286,59 @@ func (e *PlanReplayerLoadExec) Next(_ context.Context, req *chunk.Chunk) error {
 	return nil
 }
 
+func loadPlanReplayerForExplainExplore(ctx sessionctx.Context, path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("plan replayer: file path is empty")
+	}
+
+	// #nosec G304 -- EXPLAIN EXPLORE REPLAYER intentionally reads the user-specified replayer file.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", errors.AddStack(err)
+	}
+
+	targetSQL, err := extractPlanReplayerTargetSQL(data)
+	if err != nil {
+		return "", err
+	}
+	err = (&PlanReplayerLoadInfo{
+		Path: path,
+		Ctx:  ctx,
+	}).Update(data)
+	if err != nil {
+		return "", err
+	}
+	return targetSQL, nil
+}
+
+func extractPlanReplayerTargetSQL(data []byte) (string, error) {
+	z, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", errors.AddStack(err)
+	}
+	for _, zipFile := range z.File {
+		if zipFile.Name != "sql/sql0.sql" || !zipFile.Mode().IsRegular() {
+			continue
+		}
+		r, err := zipFile.Open()
+		if err != nil {
+			return "", errors.AddStack(err)
+		}
+		//nolint:errcheck
+		defer r.Close()
+		buf := new(bytes.Buffer)
+		if _, err = buf.ReadFrom(r); err != nil {
+			return "", errors.AddStack(err)
+		}
+		targetSQL := strings.TrimSpace(buf.String())
+		if targetSQL == "" {
+			return "", errors.New("plan replayer: target SQL is empty")
+		}
+		return targetSQL, nil
+	}
+	return "", errors.New("plan replayer: target SQL file sql/sql0.sql not found")
+}
+
 func loadSetTiFlashReplica(ctx sessionctx.Context, z *zip.Reader) error {
 	for _, zipFile := range z.File {
 		if strings.Compare(zipFile.Name, domain.PlanReplayerTiFlashReplicasFile) == 0 {
@@ -457,6 +516,10 @@ func createSchemaAndItems(ctx sessionctx.Context, f *zip.File) error {
 		}
 		_, err = ctx.GetSQLExecutor().Execute(c, sqlText)
 		if err != nil {
+			if infoschema.ErrTableExists.Equal(err) {
+				logutil.BgLogger().Debug("plan replayer: skip existing schema item", zap.Error(err))
+				continue
+			}
 			return err
 		}
 	}

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -324,11 +324,14 @@ func extractPlanReplayerTargetSQL(data []byte) (string, error) {
 		if err != nil {
 			return "", errors.AddStack(err)
 		}
-		//nolint:errcheck
-		defer r.Close()
 		buf := new(bytes.Buffer)
-		if _, err = buf.ReadFrom(r); err != nil {
-			return "", errors.AddStack(err)
+		_, readErr := buf.ReadFrom(r)
+		closeErr := r.Close()
+		if readErr != nil {
+			return "", errors.AddStack(readErr)
+		}
+		if closeErr != nil {
+			return "", errors.AddStack(closeErr)
 		}
 		targetSQL := strings.TrimSpace(buf.String())
 		if targetSQL == "" {

--- a/pkg/executor/test/planreplayer/BUILD.bazel
+++ b/pkg/executor/test/planreplayer/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "plan_replayer_test.go",
     ],
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         "//pkg/config",
         "//pkg/meta/autoid",

--- a/pkg/executor/test/planreplayer/plan_replayer_test.go
+++ b/pkg/executor/test/planreplayer/plan_replayer_test.go
@@ -227,6 +227,41 @@ func TestPlanReplayerDumpSingle(t *testing.T) {
 	}
 }
 
+func TestExplainExploreReplayer(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	storage, err := extstore.NewExtStorage(ctx, "file://"+tempDir, "")
+	require.NoError(t, err)
+	extstore.SetGlobalExtStorageForTest(storage)
+	defer func() {
+		extstore.SetGlobalExtStorageForTest(nil)
+		storage.Close()
+	}()
+
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_explain_explore_replayer(a int, b int, key(a))")
+	tk.MustExec("insert into t_explain_explore_replayer values (1, 1), (2, 2), (3, 1)")
+	tk.MustExec("analyze table t_explain_explore_replayer")
+	tk.MustExec("create global binding using select * from test.t_explain_explore_replayer where b=1")
+	res := tk.MustQuery("plan replayer dump explain select * from test.t_explain_explore_replayer where b=1")
+	path := testdata.ConvertRowsToStrings(res.Rows())
+	require.Len(t, path, 1)
+
+	loadStore := testkit.CreateMockStore(t)
+	loadTK := testkit.NewTestKit(t, loadStore)
+	replayerPath := filepath.Join(tempDir, replayer.GetPlanReplayerDirName(), path[0])
+	replayerPath = strings.ReplaceAll(replayerPath, "'", "''")
+	for range 2 {
+		rows := loadTK.MustQuery(fmt.Sprintf("explain explore replayer '%s'", replayerPath)).Rows()
+		require.NotEmpty(t, rows)
+		for _, row := range rows {
+			require.NotEmpty(t, row[3])
+		}
+	}
+}
+
 func TestPlanReplayerDumpMultipleError(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -217,6 +217,8 @@ type ExplainStmt struct {
 	Explore bool
 	// SQLDigest to explain, used in `EXPLAIN EXPLORE <sql_digest>`.
 	SQLDigest string
+	// ReplayerFile to load, used in `EXPLAIN EXPLORE REPLAYER <replayer_file_path>`.
+	ReplayerFile string
 	// PlanDigest to explain, used in `EXPLAIN [ANALYZE] <plan_digest>`.
 	PlanDigest string
 }
@@ -242,7 +244,10 @@ func (n *ExplainStmt) Restore(ctx *format.RestoreCtx) error {
 	}
 	if n.Explore {
 		ctx.WriteKeyWord("EXPLORE ")
-		if n.SQLDigest != "" {
+		if n.ReplayerFile != "" {
+			ctx.WriteKeyWord("REPLAYER ")
+			ctx.WriteString(n.ReplayerFile)
+		} else if n.SQLDigest != "" {
 			ctx.WriteString(n.SQLDigest)
 		}
 	} else if !n.Analyze || strings.ToLower(n.Format) != "row" {

--- a/pkg/parser/hintparser.y
+++ b/pkg/parser/hintparser.y
@@ -51,6 +51,7 @@ import (
 
 	/*yy:token "'%c'" */
 	hintStringLit
+
 	/* SET_VAR-only decimal/float literal. Integer values still use hintIntLit. */
 	hintNumericLit
 

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -1734,6 +1734,8 @@ func getMaskingPolicyRestrictOp(name string) (ast.MaskingPolicyRestrictOps, bool
 %precedence local
 %precedence lowerThanRemove
 %precedence remove
+%precedence lowerThanReplayer
+%precedence replayer
 %precedence lowerThenOrder
 %precedence order
 %precedence returning
@@ -5869,6 +5871,13 @@ ExplainStmt:
 			Explore:   true,
 		}
 	}
+|	ExplainSym "EXPLORE" "REPLAYER" stringLit
+	{
+		$$ = &ast.ExplainStmt{
+			ReplayerFile: $4,
+			Explore:      true,
+		}
+	}
 |	ExplainSym "EXPLORE" "ANALYZE" SelectStmt
 	{
 		startOffset := parser.startOffset(&yyS[yypt])
@@ -7322,7 +7331,7 @@ UnReservedKeyword:
 |	"ESCAPE"
 |	"EVOLVE"
 |	"EXECUTE"
-|	"EXPLORE"
+|	"EXPLORE" %prec lowerThanReplayer
 |	"EXTENDED"
 |	"FIELDS"
 |	"FILE"
@@ -16361,22 +16370,22 @@ StatsObject:
 	{
 		$$ = &ast.StatsObject{
 			StatsObjectScope: ast.StatsObjectScopeDatabase,
-			DBName:             ast.NewCIStr($1),
+			DBName:           ast.NewCIStr($1),
 		}
 	}
 |	Identifier '.' Identifier
 	{
 		$$ = &ast.StatsObject{
 			StatsObjectScope: ast.StatsObjectScopeTable,
-			DBName:             ast.NewCIStr($1),
-			TableName:          ast.NewCIStr($3),
+			DBName:           ast.NewCIStr($1),
+			TableName:        ast.NewCIStr($3),
 		}
 	}
 |	Identifier
 	{
 		$$ = &ast.StatsObject{
 			StatsObjectScope: ast.StatsObjectScopeTable,
-			TableName:          ast.NewCIStr($1),
+			TableName:        ast.NewCIStr($1),
 		}
 	}
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -8144,11 +8144,22 @@ func TestVector(t *testing.T) {
 func TestExplainExplore(t *testing.T) {
 	cases := []testCase{
 		{`explain explore 'digestxxx'`, true, `EXPLAIN EXPLORE 'digestxxx'`},
+		{`explain explore replayer '/tmp/replayer.zip'`, true, `EXPLAIN EXPLORE REPLAYER '/tmp/replayer.zip'`},
 		{`explain explore select 1 from t`, true, "EXPLAIN EXPLORE SELECT 1 FROM `t`"},
 		{`explain explore select 1 from t1, t2`, true, "EXPLAIN EXPLORE SELECT 1 FROM (`t1`) JOIN `t2`"},
 		{`explain explore select 1 from t where t1.a > (select max(a) from t2)`, true, "EXPLAIN EXPLORE SELECT 1 FROM `t` WHERE `t1`.`a`>(SELECT MAX(`a`) FROM `t2`)"},
 	}
 	RunTest(t, cases, false, false)
+
+	p := parser.New()
+	stmt, err := p.ParseOneStmt(`explain explore replayer '/tmp/replayer.zip'`, "", "")
+	require.NoError(t, err)
+	explain, ok := stmt.(*ast.ExplainStmt)
+	require.True(t, ok)
+	require.True(t, explain.Explore)
+	require.Equal(t, "/tmp/replayer.zip", explain.ReplayerFile)
+	require.Empty(t, explain.SQLDigest)
+	require.Nil(t, explain.Stmt)
 }
 
 // TestCompatMariaDB is to test for MariaDB specific table options

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/costusage"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/table"
@@ -47,6 +48,9 @@ import (
 	"github.com/pingcap/tidb/pkg/util/texttree"
 	"github.com/pingcap/tipb/go-tipb"
 )
+
+// LoadPlanReplayerForExplainExplore loads a plan replayer file and returns the target SQL for EXPLAIN EXPLORE.
+var LoadPlanReplayerForExplainExplore func(sessionctx.Context, string) (string, error)
 
 // ShowDDL is for showing DDL information.
 type ShowDDL struct {
@@ -643,6 +647,7 @@ type Explain struct {
 	Analyze          bool
 	Explore          bool   // EXPLAIN EXPLORE statement
 	SQLDigest        string // "EXPLAIN EXPLORE <sql_digest>"
+	ReplayerFile     string // "EXPLAIN EXPLORE REPLAYER <replayer_file_path>"
 	ExecStmt         ast.StmtNode
 	RuntimeStatsColl *execdetails.RuntimeStatsColl
 
@@ -755,11 +760,26 @@ func (e *Explain) prepareSchema() error {
 }
 
 func (e *Explain) renderResultForExplore() error {
-	bindingHandle := domain.GetDomain(e.SCtx()).BindingHandle()
 	sqlOrDigest := e.SQLDigest
-	if sqlOrDigest == "" {
+	if e.ReplayerFile != "" {
+		if LoadPlanReplayerForExplainExplore == nil {
+			return errors.NewNoStackError("EXPLAIN EXPLORE REPLAYER is not available")
+		}
+		sctx, err := AsSctx(e.SCtx())
+		if err != nil {
+			return err
+		}
+		sqlOrDigest, err = LoadPlanReplayerForExplainExplore(sctx, e.ReplayerFile)
+		if err != nil {
+			return err
+		}
+	} else if sqlOrDigest == "" {
+		if e.ExecStmt == nil {
+			return errors.NewNoStackError("EXPLAIN EXPLORE target SQL is empty")
+		}
 		sqlOrDigest = e.ExecStmt.Text()
 	}
+	bindingHandle := domain.GetDomain(e.SCtx()).BindingHandle()
 	plans, err := bindingHandle.ExplorePlansForSQL(e.SCtx(), sqlOrDigest, e.Analyze)
 	if err != nil {
 		return err

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5711,7 +5711,7 @@ func (b *PlanBuilder) buildTrace(trace *ast.TraceStmt) (base.Plan, error) {
 	return p, nil
 }
 
-func (b *PlanBuilder) buildExplainPlan(targetPlan base.Plan, format string, explainBriefBinary string, analyze, explore bool, execStmt ast.StmtNode, runtimeStats *execdetails.RuntimeStatsColl, sqlDigest string) (base.Plan, error) {
+func (b *PlanBuilder) buildExplainPlan(targetPlan base.Plan, format string, explainBriefBinary string, analyze, explore bool, execStmt ast.StmtNode, runtimeStats *execdetails.RuntimeStatsColl, sqlDigest, replayerFile string) (base.Plan, error) {
 	format = strings.ToLower(format)
 	if format == types.ExplainFormatTrueCardCost && !analyze {
 		return nil, errors.Errorf("'explain format=%v' cannot work without 'analyze', please use 'explain analyze format=%v'", format, format)
@@ -5723,6 +5723,7 @@ func (b *PlanBuilder) buildExplainPlan(targetPlan base.Plan, format string, expl
 		Analyze:          analyze,
 		Explore:          explore,
 		SQLDigest:        sqlDigest,
+		ReplayerFile:     replayerFile,
 		ExecStmt:         execStmt,
 		BriefBinaryPlan:  explainBriefBinary,
 		RuntimeStatsColl: runtimeStats,
@@ -5755,7 +5756,7 @@ func (b *PlanBuilder) buildExplainFor(explainFor *ast.ExplainForStmt) (base.Plan
 	if explainForFormat != types.ExplainFormatBrief && explainForFormat != types.ExplainFormatROW && explainForFormat != types.ExplainFormatVerbose {
 		return nil, errors.Errorf("explain format '%s' for connection is not supported now", explainForFormat)
 	}
-	return b.buildExplainPlan(targetPlan, explainForFormat, processInfo.BriefBinaryPlan, false, false, nil, processInfo.RuntimeStatsColl, "")
+	return b.buildExplainPlan(targetPlan, explainForFormat, processInfo.BriefBinaryPlan, false, false, nil, processInfo.RuntimeStatsColl, "", "")
 }
 
 // getHintedStmtThroughPlanDigest gets the hinted SQL like `select /*+ ... */ * from t where ...` from `stmt_summary`
@@ -5821,7 +5822,7 @@ func (b *PlanBuilder) buildExplain(ctx context.Context, explain *ast.ExplainStmt
 		}
 	}
 
-	return b.buildExplainPlan(targetPlan, explain.Format, "", explain.Analyze, explain.Explore, explain.Stmt, nil, explain.SQLDigest)
+	return b.buildExplainPlan(targetPlan, explain.Format, "", explain.Analyze, explain.Explore, explain.Stmt, nil, explain.SQLDigest, explain.ReplayerFile)
 }
 
 func (b *PlanBuilder) buildSelectInto(ctx context.Context, sel *ast.SelectStmt) (base.Plan, error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66881

Problem Summary: planner: support "explain explore replayer" syntax

### What changed and how does it work?

planner: support "explain explore replayer" syntax

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added EXPLAIN EXPLORE REPLAYER: load and analyze execution plans from an external replayer file path.

* **Bug Fixes**
  * Replayer setup now skips already-existing tables instead of failing, allowing smoother replayer loads.

* **Tests**
  * New tests validating EXPLAIN EXPLORE REPLAYER behavior and results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->