### PR TITLE
objstore, importer: redact cloud storage URI in bucket errors

### DIFF
--- a/pkg/executor/importer/precheck_test.go
+++ b/pkg/executor/importer/precheck_test.go
@@ -228,6 +228,13 @@ func TestCheckRequirements(t *testing.T) {
 	c.Plan.ThreadCnt = 2
 	c.Plan.CloudStorageURI = ":"
 	require.ErrorIs(t, c.CheckRequirements(ctx, tk.Session()), exeerrors.ErrLoadDataInvalidURI)
+	c.Plan.CloudStorageURI = "s3:///path?access-key=secret-id&secret-access-key=secret-key&session-token=secret-token"
+	err = c.CheckRequirements(ctx, tk.Session())
+	require.ErrorIs(t, err, exeerrors.ErrLoadDataInvalidURI)
+	require.Contains(t, err.Error(), "please specify the bucket for s3 in s3:///path?access-key=xxxxxx&secret-access-key=xxxxxx&session-token=xxxxxx")
+	require.NotContains(t, err.Error(), "secret-id")
+	require.NotContains(t, err.Error(), "secret-key")
+	require.NotContains(t, err.Error(), "secret-token")
 	c.Plan.CloudStorageURI = "sdsdsdsd://sdsdsdsd"
 	require.ErrorIs(t, c.CheckRequirements(ctx, tk.Session()), exeerrors.ErrLoadDataInvalidURI)
 	c.Plan.CloudStorageURI = "local:///tmp"

--- a/pkg/objstore/BUILD.bazel
+++ b/pkg/objstore/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/objstore/s3like",
         "//pkg/objstore/s3store",
         "//pkg/objstore/storeapi",
+        "//pkg/parser/ast",
         "//pkg/sessionctx/variable",
         "//pkg/util",
         "//pkg/util/intest",

--- a/pkg/objstore/parse.go
+++ b/pkg/objstore/parse.go
@@ -25,6 +25,7 @@ import (
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/pkg/objstore/s3like"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 )
 
 // BackendOptions further configures the storage backend not expressed by the
@@ -95,7 +96,7 @@ func parseBackend(u *url.URL, rawURL string, options *BackendOptions) (*backuppb
 
 	case "s3", "ks3", "oss":
 		if u.Host == "" {
-			return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "please specify the bucket for s3 in %s", redactSensitiveURL(rawURL))
+			return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "please specify the bucket for s3 in %s", ast.RedactURL(rawURL))
 		}
 		prefix := strings.Trim(u.Path, "/")
 		s3 := &backuppb.S3{Bucket: u.Host, Prefix: prefix}
@@ -117,7 +118,7 @@ func parseBackend(u *url.URL, rawURL string, options *BackendOptions) (*backuppb
 
 	case "gs", "gcs":
 		if u.Host == "" {
-			return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "please specify the bucket for gcs in %s", redactSensitiveURL(rawURL))
+			return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "please specify the bucket for gcs in %s", ast.RedactURL(rawURL))
 		}
 		prefix := strings.Trim(u.Path, "/")
 		gcs := &backuppb.GCS{Bucket: u.Host, Prefix: prefix}
@@ -133,7 +134,7 @@ func parseBackend(u *url.URL, rawURL string, options *BackendOptions) (*backuppb
 
 	case "azure", "azblob":
 		if u.Host == "" {
-			return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "please specify the bucket for azblob in %s", redactSensitiveURL(rawURL))
+			return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "please specify the bucket for azblob in %s", ast.RedactURL(rawURL))
 		}
 		prefix := strings.Trim(u.Path, "/")
 		azblob := &backuppb.AzureBlobStorage{Bucket: u.Host, Prefix: prefix}
@@ -149,46 +150,6 @@ func parseBackend(u *url.URL, rawURL string, options *BackendOptions) (*backuppb
 	default:
 		return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "storage %s not support yet", u.Scheme)
 	}
-}
-
-func redactSensitiveURL(rawURL string) string {
-	u, err := ParseRawURL(rawURL)
-	if err != nil {
-		return rawURL
-	}
-
-	var redactKeys map[string]struct{}
-	switch strings.ToLower(u.Scheme) {
-	case "s3", "ks3", "oss":
-		redactKeys = map[string]struct{}{
-			"access-key":        {},
-			"secret-access-key": {},
-			"session-token":     {},
-		}
-	case "azure", "azblob":
-		redactKeys = map[string]struct{}{
-			"account-key":    {},
-			"encryption-key": {},
-			"sas-token":      {},
-		}
-	}
-	if len(redactKeys) == 0 {
-		return rawURL
-	}
-
-	values := u.Query()
-	redacted := false
-	for key := range values {
-		if _, ok := redactKeys[NormalizeQueryParameterKey(key)]; ok {
-			values[key] = []string{"xxxxxx"}
-			redacted = true
-		}
-	}
-	if !redacted {
-		return rawURL
-	}
-	u.RawQuery = values.Encode()
-	return u.String()
 }
 
 // ExtractQueryParameters moves the query parameters of the URL into the options

--- a/pkg/objstore/parse.go
+++ b/pkg/objstore/parse.go
@@ -95,7 +95,7 @@ func parseBackend(u *url.URL, rawURL string, options *BackendOptions) (*backuppb
 
 	case "s3", "ks3", "oss":
 		if u.Host == "" {
-			return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "please specify the bucket for s3 in %s", rawURL)
+			return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "please specify the bucket for s3 in %s", redactSensitiveURL(rawURL))
 		}
 		prefix := strings.Trim(u.Path, "/")
 		s3 := &backuppb.S3{Bucket: u.Host, Prefix: prefix}
@@ -117,7 +117,7 @@ func parseBackend(u *url.URL, rawURL string, options *BackendOptions) (*backuppb
 
 	case "gs", "gcs":
 		if u.Host == "" {
-			return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "please specify the bucket for gcs in %s", rawURL)
+			return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "please specify the bucket for gcs in %s", redactSensitiveURL(rawURL))
 		}
 		prefix := strings.Trim(u.Path, "/")
 		gcs := &backuppb.GCS{Bucket: u.Host, Prefix: prefix}
@@ -133,7 +133,7 @@ func parseBackend(u *url.URL, rawURL string, options *BackendOptions) (*backuppb
 
 	case "azure", "azblob":
 		if u.Host == "" {
-			return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "please specify the bucket for azblob in %s", rawURL)
+			return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "please specify the bucket for azblob in %s", redactSensitiveURL(rawURL))
 		}
 		prefix := strings.Trim(u.Path, "/")
 		azblob := &backuppb.AzureBlobStorage{Bucket: u.Host, Prefix: prefix}
@@ -149,6 +149,46 @@ func parseBackend(u *url.URL, rawURL string, options *BackendOptions) (*backuppb
 	default:
 		return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "storage %s not support yet", u.Scheme)
 	}
+}
+
+func redactSensitiveURL(rawURL string) string {
+	u, err := ParseRawURL(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	var redactKeys map[string]struct{}
+	switch strings.ToLower(u.Scheme) {
+	case "s3", "ks3", "oss":
+		redactKeys = map[string]struct{}{
+			"access-key":        {},
+			"secret-access-key": {},
+			"session-token":     {},
+		}
+	case "azure", "azblob":
+		redactKeys = map[string]struct{}{
+			"account-key":    {},
+			"encryption-key": {},
+			"sas-token":      {},
+		}
+	}
+	if len(redactKeys) == 0 {
+		return rawURL
+	}
+
+	values := u.Query()
+	redacted := false
+	for key := range values {
+		if _, ok := redactKeys[NormalizeQueryParameterKey(key)]; ok {
+			values[key] = []string{"xxxxxx"}
+			redacted = true
+		}
+	}
+	if !redacted {
+		return rawURL
+	}
+	u.RawQuery = values.Encode()
+	return u.String()
 }
 
 // ExtractQueryParameters moves the query parameters of the URL into the options

--- a/pkg/objstore/parse_test.go
+++ b/pkg/objstore/parse_test.go
@@ -51,9 +51,12 @@ func TestCreateStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hdfs://127.0.0.1:1231/backup", s.GetHdfs().GetRemote())
 
-	_, err = ParseBackend("s3:///bucket/more/prefix/", &BackendOptions{})
+	_, err = ParseBackend("s3:///bucket/more/prefix/?access-key=secret-id&secret-access-key=secret-key&session-token=secret-token", &BackendOptions{})
 	require.Error(t, err)
-	require.Regexp(t, `please specify the bucket for s3 in s3:///bucket/more/prefix/.*`, err.Error())
+	require.Contains(t, err.Error(), "please specify the bucket for s3 in s3:///bucket/more/prefix/?access-key=xxxxxx&secret-access-key=xxxxxx&session-token=xxxxxx")
+	require.NotContains(t, err.Error(), "secret-id")
+	require.NotContains(t, err.Error(), "secret-key")
+	require.NotContains(t, err.Error(), "secret-token")
 
 	s3opt := &BackendOptions{
 		S3: s3like.S3BackendOptions{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68928

Problem Summary:

When parsing an invalid cloud storage URI with a missing bucket, the object storage parser embedded the raw URI in the error message. For `cloud_storage_uri`, this error is wrapped as executor error 8158 and may expose sensitive credential query values such as `access-key`, `secret-access-key`, and `session-token`.

### What changed and how does it work?

This PR redacts sensitive cloud storage URL query values before putting missing-bucket URI values into object storage parse errors.

- Redacts S3-like `access-key`, `secret-access-key`, and `session-token` in missing-bucket errors for `s3`, `ks3`, and `oss`.
- Uses the same helper for Azure Blob sensitive query keys (`account-key`, `encryption-key`, and `sas-token`) on the same missing-bucket error path.
- Keeps the original URI unchanged when no sensitive query key is present, avoiding unnecessary error text churn.
- Adds regression coverage for both the object storage parser and the executor importer precheck path that returns error 8158.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit tests and checks:

```bash
./tools/check/failpoint-go-test.sh pkg/objstore -run '^TestCreateStorage$' -count=1
./tools/check/failpoint-go-test.sh pkg/executor/importer -run '^TestCheckRequirements$' -count=1
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug where invalid cloud storage URI errors could expose sensitive credential query values when the bucket is missing.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages for missing cloud storage bucket configurations now redact credential query parameters so API keys and tokens are not exposed.

* **Tests**
  * Test coverage updated to assert that error messages include redacted URLs and do not contain raw secret values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->