### PR TITLE
test: stabilize flaky TestParallelLockNewTask

### DIFF
--- a/pkg/ttl/ttlworker/task_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/task_manager_integration_test.go
@@ -43,6 +43,7 @@ import (
 
 func TestParallelLockNewTask(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
+	waitAndStopTTLManager(t, dom)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("set global tidb_ttl_running_tasks = 1000")
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnTTL)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68941

Problem Summary:
Flaky test `TestParallelLockNewTask` in `pkg/ttl/ttlworker` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Background TTLJobManager/GC could race with manual task-table rows created by TestParallelLockNewTask.

#### Fix

Stopping the TTLJobManager removes unrelated background ownership/GC behavior from a test whose intent is concurrent LockScanTask semantics.

#### Verification

Spec:
- target: `pkg/ttl/ttlworker :: TestParallelLockNewTask`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: failed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target-flaky passed.
timing-repro passed.

Gate checklist:
- target-flaky: PASS
- timing-repro: PASS
- package-raw: SKIPPED
- build: BLOCKED
- lint: BLOCKED

Commands:
- `go test -json -tags=intest,deadlock ./pkg/ttl/ttlworker -run '^TestParallelLockNewTask$' -count=1`
- `GO_FAILPOINTS='github.com/pingcap/tidb/pkg/ttl/ttlworker/gc-interval=return(1000000);github.com/pingcap/tidb/pkg/ttl/ttlworker/check-job-interval=return(1000000);github.com/pingcap/tidb/pkg/ttl/ttlworker/sync-timer=return(1000000);github.com/pingcap/tidb/pkg/ttl/ttlworker/task-manager-loop-interval=return(1000000)' ./tools/check/failpoint-go-test.sh pkg/ttl/ttlworker -run '^TestParallelLockNewTask$' -count=1`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified parallel lock task test to include resource cleanup during test initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->