### PR TITLE
br: mark PITR meta KV writes as physical import

### DIFF
--- a/br/pkg/stream/meta_kv.go
+++ b/br/pkg/stream/meta_kv.go
@@ -249,6 +249,10 @@ func (v *RawWriteCFValue) UpdateShortValue(value []byte) {
 	v.shortValue = value
 }
 
+func (v *RawWriteCFValue) MarkPhysicalImportTxnSource() {
+	v.txnSource |= kv.LightningPhysicalImportTxnSource
+}
+
 func (v *RawWriteCFValue) GetStartTs() uint64 {
 	return v.startTs
 }

--- a/br/pkg/stream/rewrite_meta_rawkv.go
+++ b/br/pkg/stream/rewrite_meta_rawkv.go
@@ -527,13 +527,6 @@ func (sr *SchemasReplace) rewriteValue(value []byte, cf string, rewriteFunc func
 			return rewriteResult{}, errors.Trace(err)
 		}
 
-		if rawWriteCFValue.IsDelete() {
-			return rewriteResult{
-				NewValue: value,
-				Deleted:  true,
-				Put:      false,
-			}, nil
-		}
 		if rawWriteCFValue.IsRollback() {
 			return rewriteResult{
 				NewValue: value,
@@ -541,9 +534,18 @@ func (sr *SchemasReplace) rewriteValue(value []byte, cf string, rewriteFunc func
 				Put:      false,
 			}, nil
 		}
+
+		rawWriteCFValue.MarkPhysicalImportTxnSource()
+		if rawWriteCFValue.IsDelete() {
+			return rewriteResult{
+				NewValue: rawWriteCFValue.EncodeTo(),
+				Deleted:  true,
+				Put:      false,
+			}, nil
+		}
 		if !rawWriteCFValue.HasShortValue() {
 			return rewriteResult{
-				NewValue: value,
+				NewValue: rawWriteCFValue.EncodeTo(),
 				Put:      true,
 			}, nil
 		}

--- a/br/pkg/stream/rewrite_meta_rawkv_test.go
+++ b/br/pkg/stream/rewrite_meta_rawkv_test.go
@@ -124,6 +124,18 @@ func TestRewriteDBInfo(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, DBInfo.ID, sr.DbReplaceMap[dbID].DbID)
 	require.Equal(t, newId, sr.DbReplaceMap[dbID].DbID)
+
+	writeValue := RawWriteCFValue{
+		t:          WriteTypePut,
+		startTs:    1,
+		shortValue: value,
+		txnSource:  7,
+	}
+	result, err := sr.rewriteValue(writeValue.EncodeTo(), consts.WriteCF, sr.rewriteDBInfo)
+	require.Nil(t, err)
+	rewrittenWriteValue := new(RawWriteCFValue)
+	require.Nil(t, rewrittenWriteValue.ParseFrom(result.NewValue))
+	require.Equal(t, rewrittenWriteValue.txnSource, uint64(7)|kv.LightningPhysicalImportTxnSource)
 }
 
 func TestRewriteKeyForTable(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68660 

Problem Summary:

During PITR metadata KV rewriting, non-rollback write CF records could be emitted without the transaction source bit that identifies Lightning physical import writes.

### What changed and how does it work?

This PR marks PITR metadata write CF records as physical import writes while preserving existing transaction source bits.

For write CF values, `SchemasReplace.rewriteValue` now leaves rollback records unchanged, sets `kv.LightningPhysicalImportTxnSource` on non-rollback records, and re-encodes delete records and put records without short values so the marker is persisted in the rewritten value.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

```bash
./tools/check/failpoint-go-test.sh br/pkg/stream -run TestRewriteDBInfo -count=1
```

- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a potential issue that PITR metadata KV writes are not marked as Lightning physical import transactions during restore.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved write record identification and handling during physical import operations for enhanced backup/restore reliability.

* **Tests**
  * Strengthened test coverage for write record rewriting and physical import source tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->