### PR TITLE
ddl, mvservice: backport materialized view maintenance fixes

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -2856,6 +2856,9 @@ func (e *executor) AlterTablePartitioning(ctx sessionctx.Context, ident ast.Iden
 	if err != nil {
 		return errors.Trace(infoschema.ErrTableNotExists.FastGenByArgs(ident.Schema, ident.Name))
 	}
+	if err = checkBaseTableMaterializedViewDependencyConstraints(t.Meta(), "ALTER TABLE ... PARTITION BY"); err != nil {
+		return err
+	}
 
 	meta := t.Meta().Clone()
 	piOld := meta.GetPartitionInfo()
@@ -2991,6 +2994,9 @@ func (e *executor) RemovePartitioning(ctx sessionctx.Context, ident ast.Ident, s
 	schema, t, err := e.getSchemaAndTableByIdent(ident)
 	if err != nil {
 		return errors.Trace(infoschema.ErrTableNotExists.FastGenByArgs(ident.Schema, ident.Name))
+	}
+	if err = checkBaseTableMaterializedViewDependencyConstraints(t.Meta(), "ALTER TABLE ... REMOVE PARTITIONING"); err != nil {
+		return err
 	}
 
 	meta := t.Meta().Clone()
@@ -3511,7 +3517,45 @@ func checkExchangePartition(pt *model.TableInfo, nt *model.TableInfo) error {
 	if len(nt.ForeignKeys) > 0 {
 		return errors.Trace(dbterror.ErrPartitionExchangeForeignKey.GenWithStackByArgs(nt.Name))
 	}
+	if err := checkExchangePartitionMaterializedViewConstraints(pt, "partitioned table"); err != nil {
+		return err
+	}
+	return checkExchangePartitionMaterializedViewConstraints(nt, "non-partitioned table")
+}
 
+func checkExchangePartitionMaterializedViewConstraints(tblInfo *model.TableInfo, tableRole string) error {
+	if tblInfo.MaterializedViewLog != nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf("EXCHANGE PARTITION on %s with materialized view log", tableRole),
+		)
+	}
+	if tblInfo.MaterializedView != nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf("EXCHANGE PARTITION on %s materialized view table", tableRole),
+		)
+	}
+	if tblInfo.MaterializedViewShadow != nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf("EXCHANGE PARTITION on %s materialized view shadow table", tableRole),
+		)
+	}
+	return checkBaseTableMaterializedViewDependencyConstraints(tblInfo, fmt.Sprintf("EXCHANGE PARTITION on %s", tableRole))
+}
+
+func checkBaseTableMaterializedViewDependencyConstraints(tblInfo *model.TableInfo, op string) error {
+	if tblInfo.MaterializedViewBase == nil {
+		return nil
+	}
+	if len(tblInfo.MaterializedViewBase.MViewIDs) > 0 {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf("%s with materialized view dependencies", op),
+		)
+	}
+	if tblInfo.MaterializedViewBase.MLogID != 0 {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf("%s with materialized view log", op),
+		)
+	}
 	return nil
 }
 

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1105,8 +1105,13 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 		colMap[col.Name.L] = col
 	}
 
+	seenCols := make(map[string]struct{}, len(s.Cols))
 	colDefs := make([]*ast.ColumnDef, 0, len(s.Cols)+2)
 	for _, c := range s.Cols {
+		if _, exists := seenCols[c.L]; exists {
+			return infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
+		}
+		seenCols[c.L] = struct{}{}
 		if c.L == strings.ToLower(model.MaterializedViewLogDMLTypeColumnName) ||
 			c.L == strings.ToLower(model.MaterializedViewLogOldNewColumnName) {
 			return infoschema.ErrColumnExists.GenWithStackByArgs(c.O)

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -269,8 +269,13 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 		colMap[col.Name.L] = col
 	}
 
+	seenCols := make(map[string]struct{}, len(s.Cols))
 	colDefs := make([]*ast.ColumnDef, 0, len(s.Cols)+2)
 	for _, c := range s.Cols {
+		if _, exists := seenCols[c.L]; exists {
+			return infoschema.ErrColumnExists.GenWithStackByArgs(c.O)
+		}
+		seenCols[c.L] = struct{}{}
 		if c.L == strings.ToLower(model.MaterializedViewLogDMLTypeColumnName) ||
 			c.L == strings.ToLower(model.MaterializedViewLogOldNewColumnName) {
 			return infoschema.ErrColumnExists.GenWithStackByArgs(c.O)

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -60,6 +60,20 @@ func TestCreateMaterializedViewBuildReadTSQueryTypeAlignment(t *testing.T) {
 	require.Equal(t, expected, readTS)
 }
 
+func TestCreateMaterializedViewLogRejectsDuplicateColumns(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec(`create table t_dup (
+  id bigint not null primary key,
+  g1 int not null
+)`)
+
+	err := tk.ExecToErr("create materialized view log on t_dup (id, id)")
+	require.ErrorContains(t, err, "Duplicate column name")
+}
+
 func TestMaterializedViewDDLBasic(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -318,6 +318,140 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	require.True(t, baseTable.Meta().MaterializedViewBase == nil || (baseTable.Meta().MaterializedViewBase.MLogID == 0 && len(baseTable.Meta().MaterializedViewBase.MViewIDs) == 0))
 }
 
+func TestExchangePartitionRejectsMaterializedViewRelatedTable(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_enable_exchange_partition=1")
+	defer tk.MustExec("set @@tidb_enable_exchange_partition=0")
+
+	tk.MustExec(`create table t_base (
+  id bigint not null primary key,
+  v int not null
+)`)
+	tk.MustExec(`create table pt (
+  id bigint not null primary key,
+  v int not null
+)
+partition by range (id) (
+  partition p0 values less than (100),
+  partition p1 values less than maxvalue
+)`)
+	tk.MustExec("insert into t_base values (98, 10), (99, 20)")
+	tk.MustExec("insert into pt values (1, 1), (2, 2), (101, 1001), (102, 1002)")
+
+	tk.MustExec("create materialized view log on t_base (id, v)")
+	tk.MustExec(`create table pt_mlog (
+  id bigint not null,
+  v int not null,
+  _MLOG$_DML_TYPE varchar(1) not null,
+  _MLOG$_OLD_NEW tinyint not null
+)
+partition by range (v) (
+  partition p0 values less than (100),
+  partition p1 values less than maxvalue
+)`)
+	err := tk.ExecToErr("alter table pt_mlog exchange partition p0 with table `$mlog$t_base`")
+	require.ErrorContains(t, err, "EXCHANGE PARTITION on non-partitioned table with materialized view log")
+
+	err = tk.ExecToErr("alter table pt exchange partition p0 with table t_base")
+	require.ErrorContains(t, err, "EXCHANGE PARTITION on non-partitioned table with materialized view log")
+
+	tk.MustExec(`create materialized view mv (v, cnt, s_id)
+refresh fast
+as
+select v, count(*) as cnt, sum(id) as s_id
+from t_base
+group by v`)
+	tk.MustExec("refresh materialized view mv fast")
+
+	err = tk.ExecToErr("alter table pt exchange partition p0 with table t_base")
+	require.ErrorContains(t, err, "EXCHANGE PARTITION on non-partitioned table with materialized view dependencies")
+
+	tk.MustExec("create database repro015")
+	tk.MustExec("use repro015")
+	tk.MustExec(`create table t_base (
+  id bigint not null,
+  v int not null primary key
+)
+partition by range (v) (
+  partition p0 values less than (100),
+  partition p1 values less than maxvalue
+)`)
+	tk.MustExec("insert into t_base values (98, 10), (99, 20)")
+	tk.MustExec("create materialized view log on repro015.t_base (id, v)")
+	tk.MustExec(`create materialized view repro015.mv (cnt, v)
+refresh fast
+as
+select count(*) as cnt, v
+from repro015.t_base
+group by v`)
+	tk.MustExec(`create table repro015.` + "`right`" + ` (
+  id bigint not null,
+  v int not null,
+  primary key (v) /*T![clustered_index] CLUSTERED */
+)`)
+	err = tk.ExecToErr("alter table repro015.t_base exchange partition p0 with table repro015.`right`")
+	require.ErrorContains(t, err, "EXCHANGE PARTITION on partitioned table with materialized view dependencies")
+
+	tk.MustExec("drop table repro015.`right`")
+	tk.MustExec("drop materialized view repro015.mv")
+	tk.MustExec("drop materialized view log on repro015.t_base")
+	tk.MustExec("drop table repro015.t_base")
+	tk.MustExec(`create table repro015.t_base (
+  id bigint not null,
+  v int not null
+)`)
+	tk.MustExec(`create table repro015.pt (
+  id bigint not null,
+  v int not null primary key
+)
+partition by range (v) (
+  partition p0 values less than (100),
+  partition p1 values less than maxvalue
+)`)
+	tk.MustExec("create materialized view log on repro015.t_base (id, v)")
+	tk.MustExec(`create materialized view repro015.mv (cnt, v)
+refresh fast
+as
+select count(*) as cnt, v
+from repro015.t_base
+group by v`)
+	tk.MustExec("refresh materialized view repro015.mv fast")
+	err = tk.ExecToErr("alter table repro015.pt exchange partition p0 with table repro015.mv")
+	require.ErrorContains(t, err, "EXCHANGE PARTITION on non-partitioned table materialized view table")
+}
+
+func TestAlterTablePartitioningRejectsMaterializedViewBaseTable(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec(`create table t_base (
+  id bigint not null,
+  v int not null
+)`)
+	tk.MustExec("create materialized view log on t_base (id, v)")
+	err := tk.ExecToErr(`alter table t_base
+partition by range (id) (
+  partition p0 values less than (100),
+  partition p1 values less than maxvalue
+)`)
+	require.ErrorContains(t, err, "ALTER TABLE ... PARTITION BY with materialized view log")
+
+	tk.MustExec(`create table t_base_part (
+  id bigint not null,
+  v int not null
+)
+partition by range (id) (
+  partition p0 values less than (100),
+  partition p1 values less than maxvalue
+)`)
+	tk.MustExec("create materialized view log on t_base_part (id, v)")
+	err = tk.ExecToErr("alter table t_base_part remove partitioning")
+	require.ErrorContains(t, err, "ALTER TABLE ... REMOVE PARTITIONING with materialized view log")
+}
+
 func TestMaterializedViewDDLProtectsMinMaxSupportingBaseTableIndexes(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/mvservice/BUILD.bazel
+++ b/pkg/mvservice/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/chunk",
         "//pkg/util/cpu",
+        "//pkg/util/disttask",
         "//pkg/util/logutil",
         "//pkg/util/memory",
         "//pkg/util/sqlexec",
@@ -56,6 +57,7 @@ go_test(
     shard_count = 50,
     deps = [
         "//pkg/ddl/notifier",
+        "//pkg/domain/infosync",
         "//pkg/infoschema",
         "//pkg/infoschema/context",
         "//pkg/kv",

--- a/pkg/mvservice/server_maintainer.go
+++ b/pkg/mvservice/server_maintainer.go
@@ -25,7 +25,10 @@ import (
 )
 
 type serverInfo struct {
-	ID string
+	ID             string
+	IP             string
+	Port           uint
+	StartTimestamp int64
 }
 
 func int64KeyToBinaryBytes(key int64) []byte {

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	basic "github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	disttaskutil "github.com/pingcap/tidb/pkg/util/disttask"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/prometheus/client_golang/prometheus"
@@ -107,22 +108,48 @@ func (*serviceHelper) getServerInfo() (serverInfo, error) {
 		return serverInfo{}, err
 	}
 	return serverInfo{
-		ID: localSrv.ID,
+		ID:             localSrv.ID,
+		IP:             localSrv.IP,
+		Port:           localSrv.Port,
+		StartTimestamp: localSrv.StartTimestamp,
 	}, nil
 }
 
 func (*serviceHelper) getAllServerInfo(ctx context.Context) (map[string]serverInfo, error) {
-	servers := make(map[string]serverInfo)
 	allServers, err := infosync.GetAllServerInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
+	return latestServerInfosByInstance(allServers), nil
+}
+
+func latestServerInfosByInstance(allServers map[string]*infosync.ServerInfo) map[string]serverInfo {
+	servers := make(map[string]serverInfo, len(allServers))
+	instanceToID := make(map[string]string, len(allServers))
 	for _, srv := range allServers {
-		servers[srv.ID] = serverInfo{
-			ID: srv.ID,
+		if srv == nil {
+			continue
 		}
+		instance := disttaskutil.GenerateExecID(srv)
+		info := serverInfo{
+			ID:             srv.ID,
+			IP:             srv.IP,
+			Port:           srv.Port,
+			StartTimestamp: srv.StartTimestamp,
+		}
+		if existingID, ok := instanceToID[instance]; ok {
+			existing := servers[existingID]
+			// A fast restart can leave both the old and new ddl_id visible in infosync.
+			// Keep the latest entry for the same IP:Port so ownership stays on the live node.
+			if info.StartTimestamp <= existing.StartTimestamp {
+				continue
+			}
+			delete(servers, existingID)
+		}
+		instanceToID[instance] = info.ID
+		servers[info.ID] = info
 	}
-	return servers, nil
+	return servers
 }
 
 func resolveMVIdentityByID(

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ngaut/pools"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
+	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	infoschemacontext "github.com/pingcap/tidb/pkg/infoschema/context"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -200,6 +201,52 @@ func buildMockMVBaseAndMVLogTables(baseTableID, mLogID int64, mViewIDs ...int64)
 		State: meta.StatePublic,
 	}
 	return baseTable, mlogTable
+}
+
+func TestLatestServerInfosByInstanceKeepsNewestDDLID(t *testing.T) {
+	allServers := map[string]*infosync.ServerInfo{
+		"old-node": {
+			StaticServerInfo: infosync.StaticServerInfo{
+				ID:             "old-node",
+				IP:             "127.0.0.1",
+				Port:           4000,
+				StartTimestamp: 100,
+			},
+		},
+		"new-node": {
+			StaticServerInfo: infosync.StaticServerInfo{
+				ID:             "new-node",
+				IP:             "127.0.0.1",
+				Port:           4000,
+				StartTimestamp: 200,
+			},
+		},
+		"peer-node": {
+			StaticServerInfo: infosync.StaticServerInfo{
+				ID:             "peer-node",
+				IP:             "127.0.0.2",
+				Port:           4000,
+				StartTimestamp: 150,
+			},
+		},
+	}
+
+	got := latestServerInfosByInstance(allServers)
+
+	require.Len(t, got, 2)
+	require.NotContains(t, got, "old-node")
+	require.Equal(t, serverInfo{
+		ID:             "new-node",
+		IP:             "127.0.0.1",
+		Port:           4000,
+		StartTimestamp: 200,
+	}, got["new-node"])
+	require.Equal(t, serverInfo{
+		ID:             "peer-node",
+		IP:             "127.0.0.2",
+		Port:           4000,
+		StartTimestamp: 150,
+	}, got["peer-node"])
 }
 
 func waitExecutorFinishedCount(t *testing.T, svc *MVService, expected int64) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

This PR backports several materialized view maintenance fixes to the release-8.5 materialized view feature branch.

### What changed and how does it work?

- Ignore stale MV service infosync entries after node restarts, so the maintainer does not treat stale internal sessions as active workers.
- Add the required Bazel metadata for the MV service dependency changes.
- Reject partitioning DDL and EXCHANGE PARTITION on materialized-view-related tables where the operation can break MV metadata or MV log semantics.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit tests and checks:

- `go test ./pkg/executor/test/ddl -run 'Test(ExchangePartitionRejectsMaterializedViewRelatedTable|AlterTablePartitioningRejectsMaterializedViewBaseTable)$' -tags=intest,deadlock -count=1`
- `make bazel_lint_changed`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix stale MV service node bookkeeping and reject unsupported partition DDL on materialized-view-related tables.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for materialized view operations to prevent duplicate column definitions and block invalid partition modifications when materialized views are present.
  * Improved server discovery deduplication to ensure consistency when handling distributed operations across multiple instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->