### PR TITLE
session: guard process info StmtCtx reads

### DIFF
--- a/pkg/dxf/importinto/BUILD.bazel
+++ b/pkg/dxf/importinto/BUILD.bazel
@@ -110,7 +110,7 @@ go_test(
     ],
     embed = [":importinto"],
     flaky = True,
-    shard_count = 28,
+    shard_count = 29,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/infoschema/test/clustertablestest/tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/tables_test.go
@@ -144,11 +144,12 @@ func TestInfoSchemaFieldValue(t *testing.T) {
 	// Fix issue 9836
 	sm := &testkit.MockSessionManager{PS: make([]*sessmgr.ProcessInfo, 0)}
 	sm.PS = append(sm.PS, &sessmgr.ProcessInfo{
-		ID:      1,
-		User:    "root",
-		Host:    "127.0.0.1",
-		Command: mysql.ComQuery,
-		StmtCtx: tk.Session().GetSessionVars().StmtCtx,
+		ID:                1,
+		User:              "root",
+		Host:              "127.0.0.1",
+		Command:           mysql.ComQuery,
+		StmtCtx:           tk.Session().GetSessionVars().StmtCtx,
+		RefCountOfStmtCtx: &tk.Session().GetSessionVars().RefCountOfStmtCtx,
 	})
 	tk.Session().SetSessionManager(sm)
 	tk.MustQuery("SELECT user,host,command FROM information_schema.processlist;").Check(testkit.Rows("root 127.0.0.1 Query"))
@@ -232,6 +233,7 @@ func TestSomeTables(t *testing.T) {
 		StmtCtx:           tk.Session().GetSessionVars().StmtCtx,
 		ResourceGroupName: "rg1",
 		SessionAlias:      "alias1",
+		RefCountOfStmtCtx: &tk.Session().GetSessionVars().RefCountOfStmtCtx,
 	})
 	sm.PS = append(sm.PS, &sessmgr.ProcessInfo{
 		ID:                2,
@@ -245,6 +247,7 @@ func TestSomeTables(t *testing.T) {
 		Info:              strings.Repeat("x", 101),
 		StmtCtx:           tk.Session().GetSessionVars().StmtCtx,
 		ResourceGroupName: "rg2",
+		RefCountOfStmtCtx: &tk.Session().GetSessionVars().RefCountOfStmtCtx,
 	})
 	sm.PS = append(sm.PS, &sessmgr.ProcessInfo{
 		ID:                3,
@@ -259,6 +262,7 @@ func TestSomeTables(t *testing.T) {
 		StmtCtx:           se2.GetSessionVars().StmtCtx,
 		ResourceGroupName: "rg3",
 		SessionAlias:      "中文alias",
+		RefCountOfStmtCtx: &se2.GetSessionVars().RefCountOfStmtCtx,
 	})
 	tk.Session().SetSessionManager(sm)
 	tk.Session().GetSessionVars().TimeZone = time.UTC
@@ -307,6 +311,7 @@ func TestSomeTables(t *testing.T) {
 		ResourceGroupName: "rg2",
 		SessionAlias:      "alias3",
 		StmtCtx:           se2.GetSessionVars().StmtCtx,
+		RefCountOfStmtCtx: &se2.GetSessionVars().RefCountOfStmtCtx,
 	})
 	tk.Session().SetSessionManager(sm)
 	tk.Session().GetSessionVars().TimeZone = time.UTC

--- a/pkg/session/sessmgr/processinfo.go
+++ b/pkg/session/sessmgr/processinfo.go
@@ -139,27 +139,28 @@ func (pi *ProcessInfo) ToRow(tz *time.Location) []any {
 	bytesConsumed := int64(0)
 	diskConsumed := int64(0)
 	var memArbitration, memWaitArbitrateStartTime, memWaitArbitrateBytes any
-	if pi.StmtCtx != nil {
-		if pi.MemTracker != nil {
-			bytesConsumed = pi.MemTracker.BytesConsumed()
-		}
-		if dur := pi.StmtCtx.MemTracker.MemArbitration(); dur > 0 {
-			memArbitration = dur.Seconds()
-		}
-		if ts, sz := pi.StmtCtx.MemTracker.WaitArbitrate(); sz > 0 {
-			memWaitArbitrateStartTime = ts.In(tz).Format("2006-01-02 15:04:05.999")
-			memWaitArbitrateBytes = sz
-		}
-		if pi.DiskTracker != nil {
-			diskConsumed = pi.DiskTracker.BytesConsumed()
+	var affectedRows any
+	if pi.RefCountOfStmtCtx.TryIncrease() {
+		defer pi.RefCountOfStmtCtx.Decrease()
+		if pi.StmtCtx != nil {
+			if pi.MemTracker != nil {
+				bytesConsumed = pi.MemTracker.BytesConsumed()
+			}
+			if dur := pi.StmtCtx.MemTracker.MemArbitration(); dur > 0 {
+				memArbitration = dur.Seconds()
+			}
+			if ts, sz := pi.StmtCtx.MemTracker.WaitArbitrate(); sz > 0 {
+				memWaitArbitrateStartTime = ts.In(tz).Format("2006-01-02 15:04:05.999")
+				memWaitArbitrateBytes = sz
+			}
+			if pi.DiskTracker != nil {
+				diskConsumed = pi.DiskTracker.BytesConsumed()
+			}
+			affectedRows = pi.StmtCtx.AffectedRows()
 		}
 	}
 
-	var affectedRows any
 	var cpuUsages ppcpuusage.CPUUsages
-	if pi.StmtCtx != nil {
-		affectedRows = pi.StmtCtx.AffectedRows()
-	}
 	if pi.SQLCPUUsage != nil {
 		cpuUsages = pi.SQLCPUUsage.GetCPUUsages()
 	}

--- a/pkg/session/sessmgr/processinfo.go
+++ b/pkg/session/sessmgr/processinfo.go
@@ -140,7 +140,7 @@ func (pi *ProcessInfo) ToRow(tz *time.Location) []any {
 	diskConsumed := int64(0)
 	var memArbitration, memWaitArbitrateStartTime, memWaitArbitrateBytes any
 	var affectedRows any
-	if pi.RefCountOfStmtCtx.TryIncrease() {
+	if pi.RefCountOfStmtCtx != nil && pi.RefCountOfStmtCtx.TryIncrease() {
 		defer pi.RefCountOfStmtCtx.Decrease()
 		if pi.StmtCtx != nil {
 			if pi.MemTracker != nil {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68012

Problem Summary:

`ProcessInfo.ToRow` can read fields from `StmtCtx` while the owning session is resetting or reusing the statement context. This can race with process info collection triggered by global memory control.

### What changed and how does it work?

Guard `ProcessInfo.ToRow` reads of `StmtCtx` with `RefCountOfStmtCtx.TryIncrease`, and release the refcount after reading. Mock `ProcessInfo` values used by cluster table tests now initialize the refcount when they provide a `StmtCtx`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

- `make failpoint-enable`
- `go test -tags=intest ./pkg/session/sessmgr ./pkg/infoschema/test/clustertablestest ./pkg/executor/test/analyzetest/memorycontrol -run "TestProcessInfoShallowCP|TestInfoSchemaFieldValue|TestSomeTables|TestGlobalMemoryControlForPrepareAnalyze" -count=1`
- `make failpoint-disable`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of session context handling so process listings and session metrics are reported consistently under concurrent access.

* **Tests**
  * Updated tests to initialize session reference counting to better reflect real-world session behavior.

* **Chores**
  * Adjusted test execution configuration to refine parallel test sharding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->