### PR TITLE
executor: forbid ADMIN RECOVER INDEX on materialized view

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -79,6 +79,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/cteutil"
+	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
@@ -615,6 +616,10 @@ func (b *executorBuilder) buildRecoverIndex(v *plannercore.RecoverIndex) exec.Ex
 	t, err := b.is.TableByName(context.Background(), v.Table.Schema, tblInfo.Name)
 	if err != nil {
 		b.err = err
+		return nil
+	}
+	if t.Meta().MaterializedView != nil {
+		b.err = dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("ADMIN RECOVER INDEX on materialized view table")
 		return nil
 	}
 	idxName := strings.ToLower(v.IndexName)

--- a/pkg/executor/test/admintest/BUILD.bazel
+++ b/pkg/executor/test/admintest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 23,
+    shard_count = 24,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -249,6 +249,19 @@ func TestAdminRecoverMVIndex(t *testing.T) {
 	tk.MustExec("admin check table t")
 }
 
+func TestAdminRecoverIndexOnMaterializedViewRejected(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_recover_mv (id bigint not null primary key, g1 int not null, v1 bigint not null, key idx_g1 (g1))")
+	tk.MustExec("create materialized view log on t_recover_mv (id, g1, v1)")
+	tk.MustExec("create materialized view mv_recover_idx (g1, cnt) refresh fast as select g1, count(*) as cnt from t_recover_mv group by g1")
+	tk.MustExec("create index i_g1 on mv_recover_idx (g1)")
+
+	err := tk.ExecToErr("admin recover index mv_recover_idx i_g1")
+	require.ErrorContains(t, err, "ADMIN RECOVER INDEX on materialized view table")
+}
+
 func TestAdminCleanupMVIndex(t *testing.T) {
 	store, domain := testkit.CreateMockStoreAndDomain(t)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66775

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that we can execute ADMIN RECOVER INDEX on materialized view
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `ADMIN RECOVER INDEX` command now properly rejects attempts to recover indices on materialized view tables, returning an error instead of proceeding with unsupported operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->