### PR TITLE
planner: support using nested `IN` to build IndexMerge path

### DIFF
--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -1052,7 +1052,7 @@ func collectFilters4MVIndex(
 				usedAsAccess[i] = true
 				found = true
 				// access filter type on mv col overrides normal col for the return value of this function
-				if accessTp == unspecifiedFilterTp || accessTp == eqOnNonMVColTp {
+				if accessTp == unspecifiedFilterTp || accessTp == eqOrInOnNonMVColTp {
 					accessTp = tp
 				}
 				break
@@ -1207,7 +1207,7 @@ func indexMergeContainSpecificIndex(path *util.AccessPath, indexSet map[int64]st
 
 const (
 	unspecifiedFilterTp int = iota
-	eqOnNonMVColTp
+	eqOrInOnNonMVColTp
 	multiValuesOROnMVColTp
 	multiValuesANDOnMVColTp
 	singleValueOnMVColTp
@@ -1301,7 +1301,23 @@ func checkAccessFilter4IdxCol(
 	}
 
 	// else: non virtual column
-	if sf.FuncName.L != ast.EQ { // only support EQ now
+	if sf.FuncName.L == ast.In {
+		args := sf.GetArgs()
+		if len(args) < 2 {
+			return false, unspecifiedFilterTp
+		}
+		c, isCol := args[0].(*expression.Column)
+		if !isCol || !c.Equal(sctx.GetExprCtx().GetEvalCtx(), idxCol) {
+			return false, unspecifiedFilterTp
+		}
+		for _, arg := range args[1:] {
+			if _, isCon := arg.(*expression.Constant); !isCon {
+				return false, unspecifiedFilterTp
+			}
+		}
+		return true, eqOrInOnNonMVColTp
+	}
+	if sf.FuncName.L != ast.EQ {
 		return false, unspecifiedFilterTp
 	}
 	args := sf.GetArgs()
@@ -1320,7 +1336,7 @@ func checkAccessFilter4IdxCol(
 		return false, unspecifiedFilterTp
 	}
 	if argCol.Equal(sctx.GetExprCtx().GetEvalCtx(), idxCol) {
-		return true, eqOnNonMVColTp
+		return true, eqOrInOnNonMVColTp
 	}
 	return false, unspecifiedFilterTp
 }

--- a/pkg/planner/core/indexmerge_unfinished_path.go
+++ b/pkg/planner/core/indexmerge_unfinished_path.go
@@ -218,7 +218,7 @@ func initUnfinishedPathsFromExpr(
 				if ok, tp := checkAccessFilter4IdxCol(ds.SCtx(), cnfItem, col); ok &&
 					// Since we only handle the OR list nested in the AND list, and only generate IndexMerge OR path,
 					// we disable the multiValuesANDOnMVColTp case here.
-					(tp == eqOnNonMVColTp || tp == multiValuesOROnMVColTp || tp == singleValueOnMVColTp) {
+					(tp == eqOrInOnNonMVColTp || tp == multiValuesOROnMVColTp || tp == singleValueOnMVColTp) {
 					ret[i].usableFilters = append(ret[i].usableFilters, cnfItem)
 					ret[i].idxColHasUsableFilter[j] = true
 					// Once we find one valid access filter for this column, we directly go to the next column without

--- a/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
@@ -3783,8 +3783,8 @@ id	task	access object	operator info
 Limit	root		offset:0, count:2
 └─Projection	root		planner__core__casetest__physicalplantest__physical_plan.t.a, planner__core__casetest__physicalplantest__physical_plan.t.b, planner__core__casetest__physicalplantest__physical_plan.t.c
   └─IndexMerge	root		type: union
-    ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], keep order:true, stats:pseudo
-    ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx2(b, c)	range:[2,2], keep order:true, stats:pseudo
+    ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx(a, c)	range:[1 1,1 1], [1 2,1 2], [1 3,1 3], keep order:true, stats:pseudo
+    ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx2(b, c)	range:[2 1,2 1], [2 2,2 2], [2 3,2 3], keep order:true, stats:pseudo
     └─Selection(Probe)	cop[tikv]		in(planner__core__casetest__physicalplantest__physical_plan.t.c, 1, 2, 3)
       └─TableRowIDScan	cop[tikv]	table:t	keep order:false, stats:pseudo
 show warnings;
@@ -3793,8 +3793,8 @@ explain format = 'plan_tree' select * from t where (a = 1 or b = 2) and c in (1,
 id	task	access object	operator info
 TopN	root		planner__core__casetest__physicalplantest__physical_plan.t.b, offset:0, count:2
 └─IndexMerge	root		type: union
-  ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], keep order:false, stats:pseudo
-  ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx2(b, c)	range:[2,2], keep order:false, stats:pseudo
+  ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx(a, c)	range:[1 1,1 1], [1 2,1 2], [1 3,1 3], keep order:false, stats:pseudo
+  ├─IndexRangeScan(Build)	cop[tikv]	table:t, index:idx2(b, c)	range:[2 1,2 1], [2 2,2 2], [2 3,2 3], keep order:false, stats:pseudo
   └─TopN(Probe)	cop[tikv]		planner__core__casetest__physicalplantest__physical_plan.t.b, offset:0, count:2
     └─Selection	cop[tikv]		in(planner__core__casetest__physicalplantest__physical_plan.t.c, 1, 2, 3)
       └─TableRowIDScan	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/tests/integrationtest/r/planner/core/indexmerge_path.result
+++ b/tests/integrationtest/r/planner/core/indexmerge_path.result
@@ -1375,21 +1375,21 @@ a	b	c
 8	8	30
 drop table if exists t1;
 create table t1(a int, b int, c int, d int, e int, index iea(e,a), index ieb(e,b), index iec(e,c), index ied(e,d));
-explain select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5));
-id	estRows	task	access object	operator info
-IndexMerge_10	0.00	root		type: union
-├─IndexRangeScan_5(Build)	0.30	cop[tikv]	table:t1, index:iea(e, a)	range:[1 1,1 1], [1 2,1 2], [1 3,1 3], keep order:false, stats:pseudo
-├─IndexRangeScan_6(Build)	0.30	cop[tikv]	table:t1, index:ieb(e, b)	range:[1 2,1 2], [1 3,1 3], [1 4,1 4], keep order:false, stats:pseudo
-├─IndexRangeScan_7(Build)	0.30	cop[tikv]	table:t1, index:iec(e, c)	range:[1 3,1 3], [1 4,1 4], [1 5,1 5], keep order:false, stats:pseudo
-└─Selection_9(Probe)	0.00	cop[tikv]		eq(planner__core__indexmerge_path.t1.e, 1), or(in(planner__core__indexmerge_path.t1.a, 1, 2, 3), or(in(planner__core__indexmerge_path.t1.b, 2, 3, 4), in(planner__core__indexmerge_path.t1.c, 3, 4, 5)))
-  └─TableRowIDScan_8	8.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-explain select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5)) limit 3;
-id	estRows	task	access object	operator info
-Limit_9	1.00	root		offset:0, count:3
-└─IndexMerge_17	0.00	root		type: union
-  ├─IndexRangeScan_11(Build)	0.30	cop[tikv]	table:t1, index:iea(e, a)	range:[1 1,1 1], [1 2,1 2], [1 3,1 3], keep order:false, stats:pseudo
-  ├─IndexRangeScan_12(Build)	0.30	cop[tikv]	table:t1, index:ieb(e, b)	range:[1 2,1 2], [1 3,1 3], [1 4,1 4], keep order:false, stats:pseudo
-  ├─IndexRangeScan_13(Build)	0.30	cop[tikv]	table:t1, index:iec(e, c)	range:[1 3,1 3], [1 4,1 4], [1 5,1 5], keep order:false, stats:pseudo
-  └─Limit_16(Probe)	0.00	cop[tikv]		offset:0, count:3
-    └─Selection_15	0.00	cop[tikv]		eq(planner__core__indexmerge_path.t1.e, 1), or(in(planner__core__indexmerge_path.t1.a, 1, 2, 3), or(in(planner__core__indexmerge_path.t1.b, 2, 3, 4), in(planner__core__indexmerge_path.t1.c, 3, 4, 5)))
-      └─TableRowIDScan_14	8.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+explain format = 'plan_tree' select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5));
+id	task	access object	operator info
+IndexMerge	root		type: union
+├─IndexRangeScan(Build)	cop[tikv]	table:t1, index:iea(e, a)	range:[1 1,1 1], [1 2,1 2], [1 3,1 3], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	cop[tikv]	table:t1, index:ieb(e, b)	range:[1 2,1 2], [1 3,1 3], [1 4,1 4], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	cop[tikv]	table:t1, index:iec(e, c)	range:[1 3,1 3], [1 4,1 4], [1 5,1 5], keep order:false, stats:pseudo
+└─Selection(Probe)	cop[tikv]		eq(planner__core__indexmerge_path.t1.e, 1), or(in(planner__core__indexmerge_path.t1.a, 1, 2, 3), or(in(planner__core__indexmerge_path.t1.b, 2, 3, 4), in(planner__core__indexmerge_path.t1.c, 3, 4, 5)))
+  └─TableRowIDScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+explain format = 'plan_tree' select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5)) limit 3;
+id	task	access object	operator info
+Limit	root		offset:0, count:3
+└─IndexMerge	root		type: union
+  ├─IndexRangeScan(Build)	cop[tikv]	table:t1, index:iea(e, a)	range:[1 1,1 1], [1 2,1 2], [1 3,1 3], keep order:false, stats:pseudo
+  ├─IndexRangeScan(Build)	cop[tikv]	table:t1, index:ieb(e, b)	range:[1 2,1 2], [1 3,1 3], [1 4,1 4], keep order:false, stats:pseudo
+  ├─IndexRangeScan(Build)	cop[tikv]	table:t1, index:iec(e, c)	range:[1 3,1 3], [1 4,1 4], [1 5,1 5], keep order:false, stats:pseudo
+  └─Limit(Probe)	cop[tikv]		offset:0, count:3
+    └─Selection	cop[tikv]		eq(planner__core__indexmerge_path.t1.e, 1), or(in(planner__core__indexmerge_path.t1.a, 1, 2, 3), or(in(planner__core__indexmerge_path.t1.b, 2, 3, 4), in(planner__core__indexmerge_path.t1.c, 3, 4, 5)))
+      └─TableRowIDScan	cop[tikv]	table:t1	keep order:false, stats:pseudo

--- a/tests/integrationtest/r/planner/core/indexmerge_path.result
+++ b/tests/integrationtest/r/planner/core/indexmerge_path.result
@@ -1373,3 +1373,23 @@ a	b	c
 6	6	10
 7	7	20
 8	8	30
+drop table if exists t1;
+create table t1(a int, b int, c int, d int, e int, index iea(e,a), index ieb(e,b), index iec(e,c), index ied(e,d));
+explain select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5));
+id	estRows	task	access object	operator info
+IndexMerge_10	0.00	root		type: union
+├─IndexRangeScan_5(Build)	0.30	cop[tikv]	table:t1, index:iea(e, a)	range:[1 1,1 1], [1 2,1 2], [1 3,1 3], keep order:false, stats:pseudo
+├─IndexRangeScan_6(Build)	0.30	cop[tikv]	table:t1, index:ieb(e, b)	range:[1 2,1 2], [1 3,1 3], [1 4,1 4], keep order:false, stats:pseudo
+├─IndexRangeScan_7(Build)	0.30	cop[tikv]	table:t1, index:iec(e, c)	range:[1 3,1 3], [1 4,1 4], [1 5,1 5], keep order:false, stats:pseudo
+└─Selection_9(Probe)	0.00	cop[tikv]		eq(planner__core__indexmerge_path.t1.e, 1), or(in(planner__core__indexmerge_path.t1.a, 1, 2, 3), or(in(planner__core__indexmerge_path.t1.b, 2, 3, 4), in(planner__core__indexmerge_path.t1.c, 3, 4, 5)))
+  └─TableRowIDScan_8	8.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+explain select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5)) limit 3;
+id	estRows	task	access object	operator info
+Limit_9	1.00	root		offset:0, count:3
+└─IndexMerge_17	0.00	root		type: union
+  ├─IndexRangeScan_11(Build)	0.30	cop[tikv]	table:t1, index:iea(e, a)	range:[1 1,1 1], [1 2,1 2], [1 3,1 3], keep order:false, stats:pseudo
+  ├─IndexRangeScan_12(Build)	0.30	cop[tikv]	table:t1, index:ieb(e, b)	range:[1 2,1 2], [1 3,1 3], [1 4,1 4], keep order:false, stats:pseudo
+  ├─IndexRangeScan_13(Build)	0.30	cop[tikv]	table:t1, index:iec(e, c)	range:[1 3,1 3], [1 4,1 4], [1 5,1 5], keep order:false, stats:pseudo
+  └─Limit_16(Probe)	0.00	cop[tikv]		offset:0, count:3
+    └─Selection_15	0.00	cop[tikv]		eq(planner__core__indexmerge_path.t1.e, 1), or(in(planner__core__indexmerge_path.t1.a, 1, 2, 3), or(in(planner__core__indexmerge_path.t1.b, 2, 3, 4), in(planner__core__indexmerge_path.t1.c, 3, 4, 5)))
+      └─TableRowIDScan_14	8.00	cop[tikv]	table:t1	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/planner/core/indexmerge_path.test
+++ b/tests/integrationtest/t/planner/core/indexmerge_path.test
@@ -593,6 +593,5 @@ select /*+ use_index_merge(t, idx_ac, idx_bc) */ * from t where a = 1 or b > 5 o
 # TestIndexMergeINInORList
 drop table if exists t1;
 create table t1(a int, b int, c int, d int, e int, index iea(e,a), index ieb(e,b), index iec(e,c), index ied(e,d));
-explain select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5));
-explain select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5)) limit 3;
-
+explain format = 'plan_tree' select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5));
+explain format = 'plan_tree' select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5)) limit 3;

--- a/tests/integrationtest/t/planner/core/indexmerge_path.test
+++ b/tests/integrationtest/t/planner/core/indexmerge_path.test
@@ -589,3 +589,10 @@ explain format='plan_tree' select /*+ use_index_merge(t, idx_ac, idx_bc) */ * fr
 select /*+ use_index_merge(t, idx_ac, idx_bc) */ * from t where a = 1 or b > 5 order by c limit 3;
 explain format='plan_tree' select /*+ use_index_merge(t, idx_ac, idx_bc) */ * from t where a = 1 or b > 5 order by c limit 3 offset 1;
 select /*+ use_index_merge(t, idx_ac, idx_bc) */ * from t where a = 1 or b > 5 order by c limit 3 offset 1;
+
+# TestIndexMergeINInORList
+drop table if exists t1;
+create table t1(a int, b int, c int, d int, e int, index iea(e,a), index ieb(e,b), index iec(e,c), index ied(e,d));
+explain select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5));
+explain select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5)) limit 3;
+


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #65822

Problem Summary:

For queries like `SELECT * FROM t1 WHERE e = 1 AND (a IN (1,2,3) OR b IN (2,3,4) OR c IN (3,4,5))`, TiDB previously could not build an IndexMerge path when there are IN expressions in the nested OR list. The query would fall back to a plain IndexLookUp with a residual Selection, which is much less efficient.

This is the first optimization described in the issue.

### What changed and how does it work?

- planner
  - `checkAccessFilter4IdxCol()` (`pkg/planner/core/indexmerge_path.go`): Add support for `ast.In` expressions in the non-virtual column branch. Previously only `ast.EQ` was recognized, so IN expressions like `a IN (1,2,3)` could not be collected as partial access filters in the "gradual collection" path (case 3 in `initUnfinishedPathsFromExpr()`). Now they are collected and later combined with top-level AND conditions (e.g., `e = 1`) by `handleTopLevelANDList()` to build valid ranges for composite indexes.
  - Rename `eqOnNonMVColTp` to `eqOrInOnNonMVColTp` to reflect that it now covers both EQ and IN expressions.

After this fix, the plan becomes:

```
IndexMerge
├─IndexRangeScan  index:iea(e, a)  range:[1 1,1 1], [1 2,1 2], [1 3,1 3]
├─IndexRangeScan  index:ieb(e, b)  range:[1 2,1 2], [1 3,1 3], [1 4,1 4]
├─IndexRangeScan  index:iec(e, c)  range:[1 3,1 3], [1 4,1 4], [1 5,1 5]
└─TableRowIDScan(Probe)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved optimizer so IN predicates on indexed non-virtual columns are planned like equality, yielding more effective index-merge range scans.

* **Behavior Changes**
  * Index-merge plans now emit separate range entries for multi-value IN operands and may alter ordering in range scans.

* **Testing**
  * Added and updated integration tests and expected plans to validate IN + OR scenarios and LIMIT interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->