### PR TITLE
br: respect custom S3 endpoint in FIPS mode

### DIFF
--- a/pkg/objstore/s3store/s3_test.go
+++ b/pkg/objstore/s3store/s3_test.go
@@ -1639,6 +1639,31 @@ func TestS3StorageBucketRegion(t *testing.T) {
 	}
 }
 
+func TestS3StorageCustomAWSEndpointWithFIPSMode(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "ab")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "cd")
+	t.Setenv("AWS_SESSION_TOKEN", "ef")
+	t.Setenv("AWS_USE_FIPS_ENDPOINT", "true")
+
+	s := createGetBucketRegionServer("us-west-2", 200, true)
+	defer s.Close()
+
+	es, err := New(context.Background(),
+		&backuppb.StorageBackend{Backend: &backuppb.StorageBackend_S3{S3: &backuppb.S3{
+			Region:         "us-west-2",
+			Bucket:         "bucket",
+			Prefix:         "prefix",
+			Provider:       "aws",
+			Endpoint:       s.URL,
+			ForcePathStyle: true,
+		}}},
+		&storeapi.Options{})
+	require.NoError(t, err)
+	ss, ok := es.(*Storage)
+	require.True(t, ok)
+	require.Equal(t, "us-west-2", ss.GetOptions().Region)
+}
+
 func TestRetryError(t *testing.T) {
 	var count int32 = 0
 	var errString = "read tcp *.*.*.*:*->*.*.*.*:*: read: connection reset by peer"

--- a/pkg/objstore/s3store/store.go
+++ b/pkg/objstore/s3store/store.go
@@ -200,6 +200,7 @@ func NewS3Storage(ctx context.Context, backend *backuppb.S3, opts *storeapi.Opti
 	if len(qs.Endpoint) != 0 && qs.Provider == "aws" {
 		s3Opts = append(s3Opts, func(o *s3.Options) {
 			o.BaseEndpoint = &qs.Endpoint
+			o.EndpointOptions.UseFIPSEndpoint = aws.FIPSEndpointStateDisabled
 		})
 
 		// Recreate client with endpoint resolver


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68966

Problem Summary:

BR can fail in AWS FedRAMP/FIPS environments when `AWS_USE_FIPS_ENDPOINT=true` is injected and the user explicitly configures a standard AWS S3 endpoint. The AWS SDK rejects combining a custom `BaseEndpoint` with FIPS endpoint resolution.

### What changed and how does it work?

When BR creates an AWS S3 client with an explicit endpoint, disable the AWS SDK S3 FIPS endpoint resolver for that client. This keeps the user-provided endpoint authoritative while leaving the FIPS-enabled boringcrypto build behavior unchanged.

A regression test covers the custom AWS endpoint path with `AWS_USE_FIPS_ENDPOINT=true`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test details:

- Before the fix, `./tools/check/failpoint-go-test.sh pkg/objstore/s3store -run TestS3StorageCustomAWSEndpointWithFIPSMode -count=1` failed with `A custom endpoint cannot be combined with FIPS`.
- After the fix, `./tools/check/failpoint-go-test.sh pkg/objstore/s3store -run TestS3StorageCustomAWSEndpointWithFIPSMode -count=1` passed.
- `./tools/check/failpoint-go-test.sh pkg/objstore/s3store -run 'TestS3Storage(BucketRegion|CustomAWSEndpointWithFIPSMode)' -count=1`
- `make bazel_prepare`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that BR might fail to access a custom AWS S3 endpoint when AWS FIPS endpoint mode is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * S3 storage now correctly handles custom AWS endpoints when FIPS endpoint mode is enabled

* **Tests**
  * Added test coverage for S3 storage with custom AWS endpoint and FIPS mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->