### PR TITLE
importinto: strip S3 external ID from resource params

### DIFF
--- a/lightning/pkg/importinto/job_submitter.go
+++ b/lightning/pkg/importinto/job_submitter.go
@@ -17,6 +17,7 @@ package importinto
 import (
 	"context"
 	"net/url"
+	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/importsdk"
@@ -128,11 +129,32 @@ func (s *DefaultJobSubmitter) buildImportOptions(tableMeta *importsdk.TableMeta)
 	if cfg.Mydumper.SourceDir != "" {
 		u, err := url.Parse(cfg.Mydumper.SourceDir)
 		if err == nil {
-			opts.ResourceParameters = u.RawQuery
+			opts.ResourceParameters = stripS3ExternalIDFromResourceParameters(u.Scheme, u.RawQuery)
 		}
 	}
 
 	return opts
+}
+
+func stripS3ExternalIDFromResourceParameters(scheme, rawQuery string) string {
+	if !strings.EqualFold(scheme, "s3") || rawQuery == "" {
+		return rawQuery
+	}
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return rawQuery
+	}
+	changed := false
+	for key := range values {
+		if strings.EqualFold(key, "external-id") || strings.EqualFold(key, "external_id") {
+			values.Del(key)
+			changed = true
+		}
+	}
+	if !changed {
+		return rawQuery
+	}
+	return values.Encode()
 }
 
 func generateImportSQLForLog(tableMeta *importsdk.TableMeta, options *importsdk.ImportOptions) (string, error) {

--- a/lightning/pkg/importinto/job_submitter_test.go
+++ b/lightning/pkg/importinto/job_submitter_test.go
@@ -107,6 +107,57 @@ func TestJobSubmitterGetGroupKey(t *testing.T) {
 	require.Equal(t, groupKey, submitter.GetGroupKey())
 }
 
+func TestJobSubmitterStripsS3ExternalIDFromResourceParameters(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSDK := sdkmock.NewMockSDK(ctrl)
+	cfg := config.NewConfig()
+	cfg.Mydumper.SourceDir = "s3://bucket/path?role-arn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fimport&external-id=cluster-1&force_path_style=0"
+	submitter := importinto.NewJobSubmitter(mockSDK, cfg, "g1", log.L())
+
+	tableMeta := &importsdk.TableMeta{
+		Database: "db",
+		Table:    "t1",
+	}
+	mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ *importsdk.TableMeta, options *importsdk.ImportOptions) (string, error) {
+			require.Equal(t, "force_path_style=0&role-arn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fimport", options.ResourceParameters)
+			require.NotContains(t, options.ResourceParameters, "external-id")
+			return "IMPORT INTO ...", nil
+		})
+	mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
+
+	job, err := submitter.SubmitTable(context.Background(), tableMeta)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+}
+
+func TestJobSubmitterKeepsNonS3ExternalIDFromResourceParameters(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSDK := sdkmock.NewMockSDK(ctrl)
+	cfg := config.NewConfig()
+	cfg.Mydumper.SourceDir = "gcs://bucket/path?role-arn=role&external-id=cluster-1"
+	submitter := importinto.NewJobSubmitter(mockSDK, cfg, "g1", log.L())
+
+	tableMeta := &importsdk.TableMeta{
+		Database: "db",
+		Table:    "t1",
+	}
+	mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ *importsdk.TableMeta, options *importsdk.ImportOptions) (string, error) {
+			require.Equal(t, "role-arn=role&external-id=cluster-1", options.ResourceParameters)
+			return "IMPORT INTO ...", nil
+		})
+	mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
+
+	job, err := submitter.SubmitTable(context.Background(), tableMeta)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+}
+
 func TestJobSubmitterSubmitTableLogRedaction(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## Summary

- Strip `external-id` / `external_id` from S3 resource parameters before generating `IMPORT INTO` SQL in the Lightning import-into backend.
- Keep the original `Mydumper.SourceDir` available to the import SDK so Lightning can still assume the keyspace role with the external ID while reading source metadata.
- Preserve non-S3 resource parameters unchanged.

## Why

DM import-into uses a keyspace role on S3. The local DM/Lightning side needs `external-id` to assume that role, but NextGen TiDB injects the keyspace name as the external ID for `IMPORT INTO` itself and rejects or mishandles an explicit external ID in the SQL storage URI. Stripping the parameter only at SQL generation time keeps both consumers working.

This complements pingcap/tiflow#12670, which stripped the parameter too early from `Mydumper.SourceDir` and caused Lightning to fail before submitting `IMPORT INTO`.

## How

- Parse `cfg.Mydumper.SourceDir` as before in `DefaultJobSubmitter.buildImportOptions`.
- For S3 source dirs only, remove `external-id` and `external_id` from `ImportOptions.ResourceParameters`.
- Leave non-S3 query parameters unchanged.

## Testing

- [x] Ran `gofmt` on changed files.
- [ ] Not run: full `go test`; this PR was prepared from GitHub contents without a full TiDB checkout in the current workspace.

## Risks and Reviewer Focus

- Please review whether S3-only stripping is the right scope for NextGen import-role semantics.
- `url.Values.Encode()` may reorder query parameters, but it preserves the key/value semantics used by `IMPORT INTO` resource parameters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 import job submission by filtering out external-id parameters from query strings.

* **Tests**
  * Added tests validating external-id parameter handling for S3 and non-S3 data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->