### PR TITLE
config: increase default RUScale from 1.34 to 2.01 (#68000)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -377,7 +377,7 @@ type RUV2Config struct {
 // DefaultRUV2Config returns the default RU v2 configuration.
 func DefaultRUV2Config() RUV2Config {
 	return RUV2Config{
-		RUScale: 1.34,
+		RUScale: 2.01,
 
 		ResultChunkCells:        0.00010000,
 		ExecutorL1:              0.00013278,

--- a/pkg/config/config.toml.example
+++ b/pkg/config/config.toml.example
@@ -439,7 +439,7 @@ engines = ["tikv", "tiflash", "tidb"]
 [ru-v2]
 # ru-scale is the scale factor used to convert RU v2 float values into scaled integer values.
 # It is intentionally chosen to match legacy RU values for compatibility.
-ru-scale = 1.34
+ru-scale = 2.01
 
 # result-chunk-cells is the weight for cells materialized into result chunks.
 result-chunk-cells = 0.00010000
@@ -469,7 +469,7 @@ txn-cnt = 0.03013709
 # ru-scale is the scale factor used to convert RU v2 float values into scaled integer values.
 # It is configured independently from [ru-v2].ru-scale.
 # Keep both values aligned manually if you want TiDB and TiKV RU v2 to use the same scaling.
-ru-scale = 1.40
+ru-scale = 2.10
 
 tikv-kv-engine-cache-miss = 0.45975389
 resource-manager-write-cnt-tikv = 0.09642181

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -925,7 +925,7 @@ grpc-keepalive-timeout = 0.01
 	}
 	require.NoError(t, conf.Load(configFile))
 
-	require.Equal(t, 1.34, conf.RUV2.RUScale)
+	require.Equal(t, 2.01, conf.RUV2.RUScale)
 	require.Equal(t, GetGlobalConfig().TiKVClient.RUV2.RUScale, conf.TiKVClient.RUV2.RUScale)
 
 	// Make sure the example config is the same as default config except `auto_tls`.

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -397,10 +397,10 @@ func TestRUV2MetricsSnapshotCalculateRUValues(t *testing.T) {
 	tikvRU := float64(157258)
 	tiflashRU := float64(24680)
 	totalRU := metrics.TotalRU(weights, tikvRU, tiflashRU)
-	require.InEpsilon(t, 26.8604602238, tidbRU, 0.01)
+	require.InEpsilon(t, 40.2906903357, tidbRU, 0.01)
 	require.InEpsilon(t, 157258.0, tikvRU, 0.01)
 	require.InEpsilon(t, 24680.0, tiflashRU, 0.01)
-	require.InEpsilon(t, 181964.8604602238, totalRU, 0.01)
+	require.InEpsilon(t, 181978.2906903357, totalRU, 0.01)
 
 	t.Run("zero scale stays zero", func(t *testing.T) {
 		zeroScaleWeights := weights
@@ -564,7 +564,7 @@ func TestFormatRUV2MetricsIncludesRUValuesFirst(t *testing.T) {
 	metrics.AddTiKVCoprocessorWorkTotal("BatchTopN", 10)
 	total, formatted := FormatRUV2Summary(metrics, weights, 10987, 246)
 
-	require.Equal(t, "11235.06", total)
+	require.Equal(t, "11236.09", total)
 	require.Equal(t, total, FormatRUV2Total(metrics, weights, 10987, 246))
 	require.Equal(t, formatted, FormatRUV2Metrics(metrics, weights, 10987, 246))
 	require.Contains(t, formatted, "tidb_ru:")
@@ -575,8 +575,8 @@ func TestFormatRUV2MetricsIncludesRUValuesFirst(t *testing.T) {
 
 	parts := strings.Split(formatted, ", ")
 	require.Len(t, parts, 7)
-	require.Equal(t, "total_ru:11235.06", parts[0])
-	require.Equal(t, "tidb_ru:2.06", parts[1])
+	require.Equal(t, "total_ru:11236.09", parts[0])
+	require.Equal(t, "tidb_ru:3.09", parts[1])
 	require.Equal(t, "tikv_ru:10987.00", parts[2])
 	require.Equal(t, "tiflash_ru:246.00", parts[3])
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #67199

Problem Summary:

Cherry-pick the default `RUScale` change from #68000 to `release-nextgen-202603`. The earlier auto cherry-pick #68217 went stale with conflicts on `go.mod` / `go.sum` / `DEPS.bzl`; this redoes it cleanly against the current branch.

### What changed and how does it work?

- Increase TiDB-side default `RUScale` from `1.34` to `2.01` (×1.5) in `pkg/config`.
- Update `config.toml.example` TiKV-side `ru-scale` from `1.40` to `2.10` to match the client-go default.
- Update the dependent unit-test expectations in `pkg/config` and `pkg/util/execdetails`.

The client-go dependency bump from #68000 is intentionally omitted: `release-nextgen-202603` already carries a newer `tikv/client-go` (`v2.0.8-0.20260604122117-78a89808e474`, later than the `20260423085316-fce9638195b3` the original PR pinned), so no `go.mod` / `go.sum` / `DEPS.bzl` change is needed.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RU v2 scaling parameters for Request Unit metric calculations, adjusting how resource utilization values are computed and reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->