### PR TITLE
executor: resolve ALTER USER USER() by auth username

### DIFF
--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -1694,6 +1694,7 @@ func (e *SimpleExec) executeAlterUser(ctx context.Context, s *ast.AlterUserStmt)
 		}
 		// Use AuthHostname to search the user record, set Hostname as AuthHostname.
 		userCopy := *user
+		userCopy.Username = userCopy.AuthUsername
 		userCopy.Hostname = userCopy.AuthHostname
 		spec := &ast.UserSpec{
 			User:    &userCopy,
@@ -1776,7 +1777,7 @@ func (e *SimpleExec) executeAlterUser(ctx context.Context, s *ast.AlterUserStmt)
 
 	for _, spec := range s.Specs {
 		user := e.Ctx().GetSessionVars().User
-		alterCurrentUser := spec.User.CurrentUser || ((user != nil) && (user.Username == spec.User.Username) && (user.AuthHostname == spec.User.Hostname))
+		alterCurrentUser := spec.User.CurrentUser || ((user != nil) && (user.AuthUsername == spec.User.Username) && (user.AuthHostname == spec.User.Hostname))
 		alterPassword := false
 		if spec.AuthOpt != nil && spec.AuthOpt.AuthPlugin == "" {
 			if len(s.AuthTokenOrTLSOptions) == 0 && len(s.ResourceOptions) == 0 && len(s.PasswordOrLockOptions) == 0 {
@@ -1784,7 +1785,7 @@ func (e *SimpleExec) executeAlterUser(ctx context.Context, s *ast.AlterUserStmt)
 			}
 		}
 		if alterCurrentUser && alterPassword {
-			spec.User.Username = user.Username
+			spec.User.Username = user.AuthUsername
 			spec.User.Hostname = user.AuthHostname
 		}
 		needAdminPrivCheck := !(alterCurrentUser && alterPassword)

--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -412,10 +412,19 @@ func TestUser(t *testing.T) {
 	require.NoError(t, err)
 	tk.SetSession(sess)
 	ctx := tk.Session().(sessionctx.Context)
-	ctx.GetSessionVars().User = &auth.UserIdentity{Username: "test1", Hostname: "localhost", AuthHostname: "localhost"}
+	ctx.GetSessionVars().User = &auth.UserIdentity{Username: "test1", Hostname: "localhost", AuthUsername: "test1", AuthHostname: "localhost"}
 	tk.MustExec(alterUserSQL)
 	result = tk.MustQuery(`SELECT authentication_string FROM mysql.User WHERE User="test1" and Host="localhost"`)
 	result.Check(testkit.Rows(auth.EncodePassword("1")))
+
+	tk.MustExec(`CREATE USER 'dpauth'@'localhost' IDENTIFIED BY 'authpw', 'dplogin'@'localhost' IDENTIFIED BY 'loginpw';`)
+	ctx.GetSessionVars().User = &auth.UserIdentity{Username: "dplogin", Hostname: "localhost", AuthUsername: "dpauth", AuthHostname: "localhost"}
+	tk.MustExec(`ALTER USER USER() IDENTIFIED BY 'newauthpw';`)
+	tk.MustQuery(`SELECT authentication_string FROM mysql.User WHERE User="dpauth" and Host="localhost"`).
+		Check(testkit.Rows(auth.EncodePassword("newauthpw")))
+	tk.MustQuery(`SELECT authentication_string FROM mysql.User WHERE User="dplogin" and Host="localhost"`).
+		Check(testkit.Rows(auth.EncodePassword("loginpw")))
+
 	dropUserSQL = `DROP USER 'test1'@'localhost', 'test2'@'localhost', 'test3'@'localhost';`
 	tk.MustExec(dropUserSQL)
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68937

Problem Summary:

`ALTER USER USER()` builds and classifies the current-user target from the session's claimed `Username` instead of the authenticated `AuthUsername`. For mapped-account sessions where these fields differ, the statement can update the wrong account row.

### What changed and how does it work?

Use the authenticated username when resolving and classifying the `ALTER USER USER()` target, matching the existing `AuthHostname` handling and `SET PASSWORD` behavior.

Add a regression case that sets `Username != AuthUsername` and verifies `ALTER USER USER()` updates the authenticated account while leaving the claimed login account unchanged.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed an issue that `ALTER USER USER()` could update the wrong account when the login username differs from the authenticated username.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `ALTER USER USER()` command to correctly apply password changes to the authenticated user identity when it differs from the session username.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->