### PR TITLE
session: avoid scan-concurrency cap-to-2 for non-transactional DML shard discovery

### DIFF
--- a/pkg/session/nontransactional.go
+++ b/pkg/session/nontransactional.go
@@ -464,8 +464,30 @@ func buildShardJobs(ctx context.Context, stmt *ast.NonTransactionalDMLStmt, se s
 	defer func() {
 		se.GetSessionVars().MaxExecutionTime = originalMaxExecutionTime
 	}()
+	// The shard-discovery SELECT below uses ORDER BY, which forces KeepOrder=true.
+	// In distsql.RequestBuilder.Build, requests with KeepOrder and the default
+	// tidb_distsql_scan_concurrency (DefDistSQLScanConcurrency) get capped to a
+	// concurrency of 2, on the assumption that the bottleneck is the MySQL
+	// protocol returning rows to a client. That assumption does not hold here:
+	// the rows feed the shard planner and are not returned to the client.
+	// Temporarily nudge the concurrency off the default so the cap predicate is
+	// false, then restore the user's value via defer. See issue #67329.
+	originalDistSQLScanConcurrency := se.GetSessionVars().DistSQLScanConcurrency()
+	if originalDistSQLScanConcurrency == vardef.DefDistSQLScanConcurrency {
+		se.GetSessionVars().SetDistSQLScanConcurrency(originalDistSQLScanConcurrency + 1)
+	}
+	defer func() {
+		se.GetSessionVars().SetDistSQLScanConcurrency(originalDistSQLScanConcurrency)
+	}()
 	// NT-DML is a write operation, and should not be affected by read_staleness that is supposed to affect only SELECT.
 	rss, err := se.Execute(ctx, selectSQL)
+	failpoint.Inject("CheckShardSelectScanConcurrency", func(val failpoint.Value) {
+		if val.(bool) {
+			if se.GetSessionVars().DistSQLScanConcurrency() == vardef.DefDistSQLScanConcurrency {
+				err = errors.New("non-transactional DML shard-discovery SELECT is using default scan concurrency")
+			}
+		}
+	})
 	se.GetSessionVars().SelectLimit = originalSelectLimit
 
 	if err != nil {

--- a/pkg/session/test/nontransactionaltest/nontransactional_test.go
+++ b/pkg/session/test/nontransactionaltest/nontransactional_test.go
@@ -524,3 +524,44 @@ func TestNonTransactionalDmlIgnoreMaxExecutionTime(t *testing.T) {
 	defer failpoint.Disable("github.com/pingcap/tidb/pkg/session/CheckMaxExecutionTime")
 	tk.MustExec("batch on a limit 10 update t set b = b + 1 where b > 0")
 }
+
+// TestNonTransactionalDmlNonDefaultScanConcurrency is the regression test for
+// issue #67329: the shard-discovery SELECT inside a non-transactional DML used
+// to inherit the default tidb_distsql_scan_concurrency, which the request
+// builder caps to 2 for ordered scans on the assumption that the bottleneck is
+// the MySQL protocol returning rows to the client. That assumption does not
+// hold for the internal NT-DML SELECT, which feeds the shard planner. With the
+// fix, buildShardJobs nudges DistSQLScanConcurrency off the default for the
+// duration of the inner SELECT and restores it via defer.
+//
+// The CheckShardSelectScanConcurrency failpoint, enabled below, asserts the
+// invariant from inside buildShardJobs: while the inner SELECT runs, the
+// session's DistSQLScanConcurrency is NOT the default value. On the
+// pre-fix code this assertion would fail and surface as an execution error
+// from the BATCH ... DELETE statement.
+func TestNonTransactionalDmlNonDefaultScanConcurrency(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set @@tidb_max_chunk_size=10")
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int, b int, key(a))")
+	for i := range 50 {
+		tk.MustExec(fmt.Sprintf("insert into t values (%d, %d)", i, i*2))
+	}
+
+	// Confirm the session is at default scan concurrency before the test.
+	original := tk.MustQuery("select @@tidb_distsql_scan_concurrency").Rows()[0][0].(string)
+
+	require.NoError(t, failpoint.Enable(
+		"github.com/pingcap/tidb/pkg/session/CheckShardSelectScanConcurrency",
+		`return(true)`))
+	defer failpoint.Disable("github.com/pingcap/tidb/pkg/session/CheckShardSelectScanConcurrency")
+
+	tk.MustExec("batch on a limit 10 delete from t where b >= 0")
+
+	// The session-level value MUST be unchanged after the NT-DML completes;
+	// the defer in buildShardJobs is responsible for the restore.
+	after := tk.MustQuery("select @@tidb_distsql_scan_concurrency").Rows()[0][0].(string)
+	require.Equal(t, original, after,
+		"tidb_distsql_scan_concurrency was not restored after non-transactional DML")
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB!
Please refer to https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md for the contributing guidelines.
-->

### What problem does this PR solve?

<!--
Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".
-->

Issue Number: close #67329

Problem Summary: when a non-transactional DML (`BATCH ... DELETE/UPDATE/INSERT`) runs, `buildShardJobs` issues an internal SELECT with `ORDER BY` to discover shard boundaries. In `pkg/distsql/request_builder.go::(*RequestBuilder).Build`, ordered requests at the default `tidb_distsql_scan_concurrency` (15) are capped to a concurrency of 2 under the assumption that the bottleneck is the MySQL protocol returning rows to a client. That assumption does not hold for the internal NT-DML SELECT — its rows feed the shard planner, not a client — so the cap unnecessarily slows the first phase of every non-transactional DML run at default settings.

### What is changed and how it works?

What's Changed:

`buildShardJobs` now temporarily nudges `DistSQLScanConcurrency` off the default value for the duration of the internal shard-discovery SELECT and restores it via `defer`, mirroring the existing save/restore pattern already used in this function for `SelectLimit`, `MaxExecutionTime`, `ReadStaleness`, and `BulkDMLEnabled`. The `Concurrency == DefDistSQLScanConcurrency` predicate in `RequestBuilder.Build` is now false on this path, so the cap-to-2 branch is skipped. No public APIs change and no user-facing SQL semantics change.

A new `CheckShardSelectScanConcurrency` failpoint asserts the invariant (the inner SELECT does not run at the default scan concurrency) from inside `buildShardJobs`. It is exercised by a regression test in `pkg/session/test/nontransactionaltest`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > Reason: <!-- Reason for not adding tests -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features

### Release note

```release-note
Fix a slowdown in the first phase of non-transactional DML
(`BATCH ON ... DELETE/UPDATE/INSERT`) caused by the shard-discovery
SELECT being capped to scan concurrency 2 at default settings.
```

### Notes for reviewers

Per the AGENTS.md `Ready` profile expectation, here is the local validation status:

- `gofmt`: clean on both changed files.
- `go vet ./pkg/session/...`: not completed locally — interrupted due to local-disk constraints (~10 GB free, insufficient for a full TiDB build cache). I have NOT run `make bazel_prepare`, `make lint`, or the targeted `go test` cycle locally. Please rely on TiDB CI to validate.
- The failpoint and regression test follow the pattern of the adjacent `CheckMaxExecutionTime` / `TestNonTransactionalDmlIgnoreMaxExecutionTime` pair.
- This is a draft PR. I'd appreciate maintainer feedback on whether the failpoint location and test invariant match the project's preferred testing style for this subsystem before promoting to ready-for-review.
