### PR TITLE
executor, planner: push down table_id/index_id filters for tiflash_indexes (#68821)

### DIFF
--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -3542,7 +3542,7 @@ func (e *TiFlashSystemTableRetriever) retrieve(ctx context.Context, sctx session
 	}
 
 	for {
-		rows, err := e.dataForTiFlashSystemTables(ctx, sctx, e.extractor.TiDBDatabases, e.extractor.TiDBTables)
+		rows, err := e.dataForTiFlashSystemTables(ctx, sctx, e.extractor.TiDBDatabases, e.extractor.TiDBTables, e.extractor.TableIDs, e.extractor.IndexIDs)
 		if err != nil {
 			return nil, err
 		}
@@ -3593,7 +3593,18 @@ var tiflashTargetTableName = map[string]string{
 	"tiflash_indexes":  "dt_local_indexes",
 }
 
-func (e *TiFlashSystemTableRetriever) dataForTiFlashSystemTables(ctx context.Context, sctx sessionctx.Context, tidbDatabases string, tidbTables string) ([][]types.Datum, error) {
+// joinInt64s renders a sorted []int64 (as produced by the
+// TiFlashSystemTableExtractor) into a comma-separated decimal list suitable
+// for embedding inside a TiFlash SQL `IN (...)` filter.
+func joinInt64s(ids []int64) string {
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, strconv.FormatInt(id, 10))
+	}
+	return strings.Join(parts, ",")
+}
+
+func (e *TiFlashSystemTableRetriever) dataForTiFlashSystemTables(ctx context.Context, sctx sessionctx.Context, tidbDatabases string, tidbTables string, tableIDs []int64, indexIDs []int64) ([][]types.Datum, error) {
 	maxCount := 1024
 	targetTable := tiflashTargetTableName[e.table.Name.L]
 
@@ -3608,6 +3619,12 @@ func (e *TiFlashSystemTableRetriever) dataForTiFlashSystemTables(ctx context.Con
 	}
 	if len(tidbTables) > 0 {
 		filters = append(filters, fmt.Sprintf("tidb_table IN (%s)", strings.ReplaceAll(tidbTables, "\"", "'")))
+	}
+	if len(tableIDs) > 0 {
+		filters = append(filters, fmt.Sprintf("table_id IN (%s)", joinInt64s(tableIDs)))
+	}
+	if len(indexIDs) > 0 {
+		filters = append(filters, fmt.Sprintf("index_id IN (%s)", joinInt64s(indexIDs)))
 	}
 	sql := fmt.Sprintf("SELECT * FROM system.%s", targetTable)
 	if len(filters) > 0 {

--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -1496,6 +1496,19 @@ type TiFlashSystemTableExtractor struct {
 	// TidbTables represents tidbTables applied to, and we should apply all tidb table if there is no table specified.
 	// e.g: SELECT * FROM information_schema.<table_name> WHERE tidb_table in ('t', 't2').
 	TiDBTables string
+	// TableIDs represents the `table_id` predicates extracted from the WHERE clause.
+	// Only set when the queried table exposes a `table_id` column (currently
+	// `tiflash_tables`, `tiflash_segments`, and `tiflash_indexes`). When non-empty
+	// the retriever pushes a `table_id IN (...)` filter to TiFlash so progress
+	// polling against `information_schema.tiflash_indexes` for a specific table
+	// does not scan all TiFlash local-index metadata.
+	// e.g: SELECT * FROM information_schema.tiflash_indexes WHERE table_id = 12345.
+	TableIDs []int64
+	// IndexIDs represents the `index_id` predicates extracted from the WHERE clause.
+	// Only the `tiflash_indexes` table exposes `index_id`; on the other tables this
+	// is a no-op via `extractCol`'s missing-column fast path.
+	// e.g: SELECT * FROM information_schema.tiflash_indexes WHERE index_id IN (1, 2).
+	IndexIDs []int64
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface
@@ -1510,14 +1523,43 @@ func (e *TiFlashSystemTableExtractor) Extract(ctx base.PlanContext,
 	remained, databaseSkip, tidbDatabases := e.extractCol(ctx, schema, names, remained, "tidb_database", true)
 	// Extract the `tidb_table` columns.
 	remained, tableSkip, tidbTables := e.extractCol(ctx, schema, names, remained, "tidb_table", true)
-	e.SkipRequest = instanceSkip || databaseSkip || tableSkip
+	// Extract the `table_id` and `index_id` columns when present. Both columns
+	// are declared as TypeLonglong in pkg/infoschema/tables.go; we parse the
+	// extracted values as int64. Parse failures (e.g. an unrelated cast) drop
+	// the extraction so we fall back to a broad query rather than emit invalid
+	// IDs to TiFlash.
+	remained, tableIDSkip, tableIDs := e.extractCol(ctx, schema, names, remained, "table_id", true)
+	remained, indexIDSkip, indexIDs := e.extractCol(ctx, schema, names, remained, "index_id", true)
+	e.SkipRequest = instanceSkip || databaseSkip || tableSkip || tableIDSkip || indexIDSkip
 	if e.SkipRequest {
 		return nil
 	}
 	e.TiFlashInstances = tiflashInstances
 	e.TiDBDatabases = extractStringFromStringSet(tidbDatabases)
 	e.TiDBTables = extractStringFromStringSet(tidbTables)
+	e.TableIDs = parseInt64StringSet(tableIDs)
+	e.IndexIDs = parseInt64StringSet(indexIDs)
 	return remained
+}
+
+// parseInt64StringSet converts the StringSet returned by extractCol for a
+// TypeLonglong column into a sorted []int64. On any parse failure the entire
+// extraction is dropped (returns nil) so the retriever falls back to a broad
+// query instead of emitting an invalid identifier to TiFlash.
+func parseInt64StringSet(s set.StringSet) []int64 {
+	if len(s) == 0 {
+		return nil
+	}
+	out := make([]int64, 0, len(s))
+	for k := range s {
+		v, err := strconv.ParseInt(k, 10, 64)
+		if err != nil {
+			return nil
+		}
+		out = append(out, v)
+	}
+	slices.Sort(out)
+	return out
 }
 
 // ExplainInfo implements base.MemTablePredicateExtractor interface.
@@ -1535,12 +1577,31 @@ func (e *TiFlashSystemTableExtractor) ExplainInfo(_ base.PhysicalPlan) string {
 	if len(e.TiDBTables) > 0 {
 		fmt.Fprintf(r, "tidb_tables:[%s], ", e.TiDBTables)
 	}
+	if len(e.TableIDs) > 0 {
+		fmt.Fprintf(r, "table_ids:[%s], ", formatInt64Slice(e.TableIDs))
+	}
+	if len(e.IndexIDs) > 0 {
+		fmt.Fprintf(r, "index_ids:[%s], ", formatInt64Slice(e.IndexIDs))
+	}
 	// remove the last ", " in the message info
 	s := r.String()
 	if len(s) > 2 {
 		return s[:len(s)-2]
 	}
 	return s
+}
+
+// formatInt64Slice renders the IDs as a comma-separated list for ExplainInfo
+// output. The slice is expected to be sorted by the caller.
+func formatInt64Slice(ids []int64) string {
+	if len(ids) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, strconv.FormatInt(id, 10))
+	}
+	return strings.Join(parts, ",")
 }
 
 // StatementsSummaryExtractor is used to extract some predicates of statements summary table.

--- a/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
+++ b/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
@@ -1625,6 +1625,118 @@ func TestTikvRegionPeersExtractor(t *testing.T) {
 	}
 }
 
+func TestTiFlashSystemTableExtractor(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+
+	se, err := session.CreateSession4Test(store)
+	require.NoError(t, err)
+
+	cases := []struct {
+		sql              string
+		tableIDs         []int64
+		indexIDs         []int64
+		tiflashInstances set.StringSet
+		tidbDatabases    string
+		tidbTables       string
+		skipRequest      bool
+	}{
+		// Equality on table_id / index_id for tiflash_indexes.
+		{
+			sql:      "select * from information_schema.tiflash_indexes where table_id = 12345",
+			tableIDs: []int64{12345},
+		},
+		{
+			sql:      "select * from information_schema.tiflash_indexes where index_id = 7",
+			indexIDs: []int64{7},
+		},
+		{
+			sql:      "select * from information_schema.tiflash_indexes where table_id = 1 and index_id = 2",
+			tableIDs: []int64{1},
+			indexIDs: []int64{2},
+		},
+		// IN predicates and disjunctions on table_id / index_id.
+		{
+			sql:      "select * from information_schema.tiflash_indexes where table_id in (1, 2, 3)",
+			tableIDs: []int64{1, 2, 3},
+		},
+		{
+			sql:      "select * from information_schema.tiflash_indexes where index_id in (10, 20)",
+			indexIDs: []int64{10, 20},
+		},
+		{
+			sql:      "select * from information_schema.tiflash_indexes where table_id = 1 or table_id = 2",
+			tableIDs: []int64{1, 2},
+		},
+		// Mixed with the existing string predicates.
+		{
+			sql:           "select * from information_schema.tiflash_indexes where table_id = 1 and tidb_database = 'test'",
+			tableIDs:      []int64{1},
+			tidbDatabases: "\"test\"",
+		},
+		{
+			sql:        "select * from information_schema.tiflash_indexes where table_id in (1, 2) and tidb_table = 't'",
+			tableIDs:   []int64{1, 2},
+			tidbTables: "\"t\"",
+		},
+		// table_id is also exposed by tiflash_tables / tiflash_segments;
+		// extraction should work there too. index_id is unique to tiflash_indexes
+		// and on the other tables it is silently ignored (no-op via extractCol's
+		// missing-column fast path).
+		{
+			sql:      "select * from information_schema.tiflash_tables where table_id = 99",
+			tableIDs: []int64{99},
+		},
+		{
+			sql:      "select * from information_schema.tiflash_segments where table_id in (5, 6)",
+			tableIDs: []int64{5, 6},
+		},
+		// Queries without table_id / index_id should not be affected.
+		{
+			sql:           "select * from information_schema.tiflash_indexes where tidb_database = 'test'",
+			tidbDatabases: "\"test\"",
+		},
+		{
+			sql: "select * from information_schema.tiflash_indexes",
+		},
+		// Contradictory predicates short-circuit via SkipRequest, mirroring the
+		// behavior of the existing string-column extraction.
+		{
+			sql:         "select * from information_schema.tiflash_indexes where table_id = 1 and table_id = 2",
+			skipRequest: true,
+		},
+		{
+			sql:         "select * from information_schema.tiflash_indexes where index_id = 1 and index_id = 2",
+			skipRequest: true,
+		},
+		{
+			sql:      "select * from information_schema.tiflash_indexes where table_id in (1, 2) and table_id in (2, 3)",
+			tableIDs: []int64{2},
+		},
+	}
+	parser := parser.New()
+	for _, ca := range cases {
+		logicalMemTable, ok := getLogicalMemTable(t, dom, se, parser, ca.sql)
+		if !ok {
+			// Contradictory predicates may be pruned away above the LogicalMemTable
+			// (the planner produces a TableDual). That is a valid form of
+			// `SkipRequest` for this extractor, mirroring TestTikvRegionPeersExtractor.
+			require.True(t, ca.skipRequest, "SQL: %v", ca.sql)
+			continue
+		}
+		require.NotNil(t, logicalMemTable.Extractor, "SQL: %v", ca.sql)
+
+		extractor := logicalMemTable.Extractor.(*plannercore.TiFlashSystemTableExtractor)
+		require.Equal(t, ca.skipRequest, extractor.SkipRequest, "SQL: %v", ca.sql)
+		if ca.skipRequest {
+			continue
+		}
+		require.EqualValues(t, ca.tableIDs, extractor.TableIDs, "SQL: %v", ca.sql)
+		require.EqualValues(t, ca.indexIDs, extractor.IndexIDs, "SQL: %v", ca.sql)
+		require.Equal(t, ca.tidbDatabases, extractor.TiDBDatabases, "SQL: %v", ca.sql)
+		require.Equal(t, ca.tidbTables, extractor.TiDBTables, "SQL: %v", ca.sql)
+	}
+}
+
 func TestColumns(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68821

When a cluster has many TiFlash vector-index tables, the DDL progress
checker queries `information_schema.tiflash_indexes` for a specific
table/index. Today `TiFlashSystemTableExtractor` only extracts predicates
for `tiflash_instance`, `tidb_database`, and `tidb_table`. It does not
extract `table_id` or `index_id`, so the TiDB retriever sends a broad
TiFlash system-table query that scales with all TiFlash local-index
metadata in the cluster instead of just the target table/index. At the
~100k vector-index table scale described in the issue, this dominated
`ADD VECTOR INDEX` progress polling cost.

### What is changed and how it works?

- `TiFlashSystemTableExtractor` (in `pkg/planner/core/memtable_predicate_extractor.go`)
  gains `TableIDs []int64` and `IndexIDs []int64` fields, populated from
  equality and `IN` predicates on the matching columns. Contradictions
  (e.g. `table_id = 1 AND table_id = 2`) propagate into `SkipRequest`
  exactly like the existing string-column logic, and a parse failure for
  any extracted ID drops the extraction (we fall back to a broad query
  rather than emit an invalid identifier to TiFlash).
- `TiFlashSystemTableRetriever.dataForTiFlashSystemTables` (in
  `pkg/executor/infoschema_reader.go`) takes the new ID slices and
  appends `table_id IN (…)` / `index_id IN (…)` filters to the SQL it
  sends to TiFlash.
- `ExplainInfo` renders the new fragments so `EXPLAIN` shows the
  pushed-down predicates, satisfying the issue's acceptance criterion.
- Behavior is unchanged for queries without `table_id`/`index_id`
  filters and for the other TiFlash system tables (`tiflash_tables`,
  `tiflash_segments`); both no-op cleanly because their schemas either
  share `table_id` (which is then correctly pushed down) or omit
  `index_id` (no-op via `extractCol`'s missing-column fast path).

This is the TiDB side of a two-layer fix; the companion TiFlash change
is tracked in pingcap/tiflash#10880.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features

### Release note

```release-note
Push down `table_id` and `index_id` predicates for queries against
`information_schema.tiflash_indexes`, so `ADD VECTOR INDEX` progress
polling no longer scales with all TiFlash local-index metadata in the
cluster.
```

### Notes for reviewers

This is a draft PR. Local validation status (per AGENTS.md `Ready`
profile expectations):

- `go build ./pkg/planner/core/... ./pkg/executor/...`: clean.
- `go vet -tags=intest ./pkg/planner/core/operator/logicalop/logicalop_test/...`:
  clean.
- `gofmt -l` on the three changed files: clean.
- Targeted test pass: `go test -tags=intest -run
  'TestTiFlashSystemTableExtractor|TestTikvRegionPeersExtractor|TestColumns|TestTikvRegionStatusExtractor|TestExtractorInPreparedStmt'
  ./pkg/planner/core/operator/logicalop/logicalop_test/...` — OK on
  HEAD; demonstrated fail-before / pass-after by stashing the extractor
  changes and re-running (build fails referencing the new
  `extractor.TableIDs` / `extractor.IndexIDs` fields), then unstashing
  (test passes).
- `make bazel_prepare` and `make lint` were NOT run locally; bazel is
  not available on this machine. I added a new top-level `TestXxx`
  function in an existing `*_test.go`, so per the AGENTS.md decision
  matrix `make bazel_prepare` should regenerate the relevant
  `BUILD.bazel`. Please rely on TiDB CI to validate that step (or let
  me know if the maintainer prefers I install bazel and reroll).
- I have not exercised the runtime path against a live TiFlash
  cluster; the change is verified at the extractor level. The retriever
  filter assembly mirrors the existing `tidb_database` / `tidb_table`
  pattern so the same SQL-build invariants hold.

I would appreciate a maintainer sanity-check on:

1. Whether `int64` (matching the column's `TypeLonglong` declaration in
   `pkg/infoschema/tables.go` and the executor's later `GetInt64()`
   reads) is preferable over `uint64` (which `tikv_region_peers` uses).
2. Whether limiting the extraction to equality and `IN` (no range
   predicates) matches the TiFlash side's pruning capability.