### PR TITLE
planner: address partial order topn review comments

### DIFF
--- a/pkg/planner/core/operator/physicalop/physical_limit.go
+++ b/pkg/planner/core/operator/physicalop/physical_limit.go
@@ -114,8 +114,11 @@ func (p *PhysicalLimit) MemoryUsage() (sum int64) {
 
 	sum = p.PhysicalSchemaProducer.MemoryUsage() +
 		size.SizeOfUint64*2 + // Offset, Count
-		size.SizeOfInt64 + // PrefixColID
+		size.SizeOfPointer + // PrefixCol
 		size.SizeOfInt // PrefixLen
+	if p.PrefixCol != nil {
+		sum += p.PrefixCol.MemoryUsage()
+	}
 	return
 }
 

--- a/pkg/planner/core/operator/physicalop/physical_topn.go
+++ b/pkg/planner/core/operator/physicalop/physical_topn.go
@@ -116,13 +116,16 @@ func (p *PhysicalTopN) MemoryUsage() (sum int64) {
 	sum = p.BasePhysicalPlan.MemoryUsage() + size.SizeOfSlice +
 		int64(cap(p.ByItems))*size.SizeOfPointer +
 		size.SizeOfUint64*2 + // Offset, Count
-		size.SizeOfInt64 + // PrefixColID
+		size.SizeOfPointer + // PrefixCol
 		size.SizeOfInt // PrefixLen
 	for _, byItem := range p.ByItems {
 		sum += byItem.MemoryUsage()
 	}
 	for _, item := range p.PartitionBy {
 		sum += item.MemoryUsage()
+	}
+	if p.PrefixCol != nil {
+		sum += p.PrefixCol.MemoryUsage()
 	}
 	return
 }

--- a/pkg/planner/core/operator/physicalop/task_base.go
+++ b/pkg/planner/core/operator/physicalop/task_base.go
@@ -468,7 +468,7 @@ func (t *CopTask) MemoryUsage() (sum int64) {
 	}
 
 	sum = size.SizeOfInterface*(2+int64(cap(t.IdxMergePartPlans)+cap(t.RootTaskConds))) + size.SizeOfBool*3 + size.SizeOfUint64 +
-		size.SizeOfPointer*(3+int64(cap(t.CommonHandleCols)+cap(t.TblCols))) + size.SizeOfSlice*4 + t.PhysPlanPartInfo.MemoryUsage()
+		size.SizeOfPointer*(4+int64(cap(t.CommonHandleCols)+cap(t.TblCols))) + size.SizeOfSlice*4 + t.PhysPlanPartInfo.MemoryUsage()
 	if t.IndexPlan != nil {
 		sum += t.IndexPlan.MemoryUsage()
 	}
@@ -493,6 +493,9 @@ func (t *CopTask) MemoryUsage() (sum int64) {
 	}
 	for _, expr := range t.RootTaskConds {
 		sum += expr.MemoryUsage()
+	}
+	if t.PartialOrderMatchResult != nil {
+		sum += t.PartialOrderMatchResult.MemoryUsage()
 	}
 	return
 }

--- a/pkg/planner/property/physical_property.go
+++ b/pkg/planner/property/physical_property.go
@@ -353,6 +353,23 @@ func (p *PartialOrderInfo) AllSameOrder() (isSame bool, desc bool) {
 	return true, p.SortItems[0].Desc
 }
 
+const emptyPartialOrderInfoSize = int64(unsafe.Sizeof(PartialOrderInfo{}))
+
+// MemoryUsage returns the memory usage of PartialOrderInfo.
+func (p *PartialOrderInfo) MemoryUsage() (sum int64) {
+	if p == nil {
+		return
+	}
+
+	sum = emptyPartialOrderInfoSize + int64(cap(p.SortItems))*size.SizeOfPointer
+	for _, item := range p.SortItems {
+		if item != nil {
+			sum += item.MemoryUsage()
+		}
+	}
+	return
+}
+
 // PartialOrderMatchResult records the result of matching partial order property with an access path.
 // It is stored in candidatePath to allow each path to have its own match result.
 type PartialOrderMatchResult struct {
@@ -368,6 +385,21 @@ type PartialOrderMatchResult struct {
 
 	// PrefixLen is the prefix length in bytes for prefix index, only used for executor part
 	PrefixLen int
+}
+
+const emptyPartialOrderMatchResultSize = int64(unsafe.Sizeof(PartialOrderMatchResult{}))
+
+// MemoryUsage returns the memory usage of PartialOrderMatchResult.
+func (p *PartialOrderMatchResult) MemoryUsage() (sum int64) {
+	if p == nil {
+		return
+	}
+
+	sum = emptyPartialOrderMatchResultSize
+	if p.PrefixCol != nil {
+		sum += p.PrefixCol.MemoryUsage()
+	}
+	return
 }
 
 // IndexJoinRuntimeProp is the inner runtime property for index join.
@@ -729,6 +761,9 @@ func (p *PhysicalProperty) MemoryUsage() (sum int64) {
 	}
 	for _, sortItem := range p.AdvisorySortItems {
 		sum += sortItem.MemoryUsage()
+	}
+	if p.PartialOrderInfo != nil {
+		sum += p.PartialOrderInfo.MemoryUsage()
 	}
 	return
 }

--- a/tests/integrationtest/r/planner/core/partial_order_topn.result
+++ b/tests/integrationtest/r/planner/core/partial_order_topn.result
@@ -499,7 +499,7 @@ TopN	3.00	root		planner__core__partial_order_topn.t_prefix_len.short_prefix, off
   ├─Limit(Build)	3.00	cop[tikv]		offset:0, count:3, prefix_col:planner__core__partial_order_topn.t_prefix_len.short_prefix, prefix_len:5
   │ └─IndexFullScan	10000.00	cop[tikv]	table:t_prefix_len, index:idx_short(short_prefix)	keep order:true, stats:pseudo
   └─TableRowIDScan(Probe)	3.00	cop[tikv]	table:t_prefix_len	keep order:false, stats:pseudo
-explain format='brief' select  /*+ force_index(t_prefix_len, long_prefix) */  * from t_prefix_len order by long_prefix limit 3;
+explain format='brief' select  /*+ force_index(t_prefix_len, idx_long) */  * from t_prefix_len order by long_prefix limit 3;
 id	estRows	task	access object	operator info
 TopN	3.00	root		planner__core__partial_order_topn.t_prefix_len.long_prefix, offset:0, count:3, prefix_col:planner__core__partial_order_topn.t_prefix_len.long_prefix, prefix_len:50
 └─IndexLookUp	3.00	root		

--- a/tests/integrationtest/t/planner/core/partial_order_topn.test
+++ b/tests/integrationtest/t/planner/core/partial_order_topn.test
@@ -404,7 +404,7 @@ insert into t_prefix_len (short_prefix, long_prefix) values
 explain format='brief' select  /*+ force_index(t_prefix_len, idx_short) */  * from t_prefix_len order by short_prefix limit 3;
 
 # Long prefix (50 bytes)
-explain format='brief' select  /*+ force_index(t_prefix_len, long_prefix) */  * from t_prefix_len order by long_prefix limit 3;
+explain format='brief' select  /*+ force_index(t_prefix_len, idx_long) */  * from t_prefix_len order by long_prefix limit 3;
 
 # ==========================================
 # Section 7.4: Verify actual query results are correct


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: N/A

Problem Summary:

This PR follows up on CodeRabbit review comments from pingcap/tidb#68995. The comments were checked against the current master branch, and this PR fixes the parts that still exist and are reasonable as low-risk follow-up changes.

Comments source: CodeRabbit inline review comments on https://github.com/pingcap/tidb/pull/68995.

### What changed and how does it work?

- Add memory accounting for partial-order fields:
  - `PhysicalTopN.PrefixCol`
  - `PhysicalLimit.PrefixCol`
  - `CopTask.PartialOrderMatchResult`
  - `PhysicalProperty.PartialOrderInfo`
- Add `MemoryUsage` methods for `property.PartialOrderInfo` and `property.PartialOrderMatchResult`.
- Fix the partial-order TopN integration test hint to use the index name `idx_long` instead of the column name `long_prefix`.

The other checked CodeRabbit comments around `ForcePartialOrder` mutation and `estimateMaxXForPartialOrder` were not included here because straightforward fixes caused broad partial-order TopN plan churn on master and need separate behavior/estimation design.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```sh
make bazel_prepare
./tools/check/failpoint-go-test.sh pkg/planner/core -run TestFindBestTaskSuite -count=1
./run-tests.sh -r planner/core/partial_order_topn
./run-tests.sh -b n -t planner/core/partial_order_topn
make lint
git diff --check
```

Note: the recording run completed the SQL cases and refreshed the result file, but the race build reported an unrelated grpc startup data race. The non-recording integration verification with `-b n` passed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected incorrect index name references in partial order TopN test cases.
  * Improved accuracy of query planning memory calculations for prefix column optimization in limit and TopN operations.
  * Enhanced memory usage tracking for partial order match results in query optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->