### PR TITLE
ddl, executor: support adding columns to materialized view log

### DIFF
--- a/pkg/ddl/add_column.go
+++ b/pkg/ddl/add_column.go
@@ -156,18 +156,35 @@ func setMLogAddedColumnOriginDefault(colInfo *model.ColumnInfo) error {
 	if colInfo == nil {
 		return nil
 	}
-	if field_types.HasCharset(&colInfo.FieldType) && colInfo.GetCharset() != charset.CharsetBin {
+	if !mysql.HasNotNullFlag(colInfo.GetFlag()) {
+		return nil
+	}
+
+	if useSingleSpaceDefaultForMLogStringColumn(colInfo) {
 		return colInfo.SetOriginDefaultValue(" ")
 	}
 	if colInfo.GetOriginDefaultValue() != nil {
 		return nil
 	}
-	zeroVal := table.GetZeroValue(colInfo)
-	originDefault, err := zeroVal.ToString()
+	originDefault, err := generateOriginDefaultValue(colInfo, nil, true)
 	if err != nil {
 		return errors.Trace(err)
 	}
+
 	return colInfo.SetOriginDefaultValue(originDefault)
+}
+
+func useSingleSpaceDefaultForMLogStringColumn(colInfo *model.ColumnInfo) bool {
+	if colInfo.GetCharset() == charset.CharsetBin {
+		return false
+	}
+	switch colInfo.GetType() {
+	case mysql.TypeString, mysql.TypeVarchar, mysql.TypeVarString,
+		mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
+		return true
+	default:
+		return false
+	}
 }
 
 func syncMLogColumnsAfterAddColumn(tblInfo *model.TableInfo) {

--- a/pkg/ddl/add_column.go
+++ b/pkg/ddl/add_column.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/exprctx"
 	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/autoid"
 	"github.com/pingcap/tidb/pkg/meta/metabuild"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -76,6 +77,10 @@ func (w *worker) onAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err
 			job.State = model.JobStateDone
 			return ver, nil
 		}
+		return ver, errors.Trace(err)
+	}
+	if err = refreshMLogAddedColumnFromBase(jobCtx.metaMut, job, tblInfo, columnInfo, colFromArgs); err != nil {
+		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
 	if columnInfo == nil {
@@ -150,6 +155,44 @@ func (w *worker) onAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err
 	}
 
 	return ver, errors.Trace(err)
+}
+
+func refreshMLogAddedColumnFromBase(
+	t *meta.Mutator,
+	job *model.Job,
+	mlogTblInfo *model.TableInfo,
+	columnInfo *model.ColumnInfo,
+	colFromArgs *model.ColumnInfo,
+) error {
+	if mlogTblInfo == nil || mlogTblInfo.MaterializedViewLog == nil || colFromArgs == nil {
+		return nil
+	}
+	if columnInfo != nil {
+		switch columnInfo.State {
+		case model.StateNone, model.StateDeleteOnly, model.StateWriteOnly:
+		default:
+			return nil
+		}
+	}
+
+	baseTblInfo, err := t.GetTable(job.SchemaID, mlogTblInfo.MaterializedViewLog.BaseTableID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if baseTblInfo == nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			"ALTER MATERIALIZED VIEW LOG with invalid base table metadata",
+		)
+	}
+	baseCol := model.FindColumnInfo(baseTblInfo.Columns, colFromArgs.Name.L)
+	if baseCol == nil || baseCol.State != model.StatePublic {
+		return infoschema.ErrColumnNotExists.GenWithStackByArgs(colFromArgs.Name, baseTblInfo.Name)
+	}
+
+	ft := *baseCol.FieldType.Clone()
+	ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
+	colFromArgs.FieldType = ft
+	return nil
 }
 
 func setMLogAddedColumnOriginDefault(colInfo *model.ColumnInfo) error {

--- a/pkg/ddl/add_column.go
+++ b/pkg/ddl/add_column.go
@@ -79,6 +79,12 @@ func (w *worker) onAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err
 		return ver, errors.Trace(err)
 	}
 	if columnInfo == nil {
+		if tblInfo.MaterializedViewLog != nil {
+			if err = setMLogAddedColumnOriginDefault(colFromArgs); err != nil {
+				job.State = model.JobStateCancelled
+				return ver, errors.Trace(err)
+			}
+		}
 		columnInfo = InitAndAddColumnToTable(tblInfo, colFromArgs)
 		logutil.DDLLogger().Info("run add column job", zap.Stringer("job", job), zap.Reflect("columnInfo", *columnInfo))
 		if err = checkAddColumnTooManyColumns(len(tblInfo.Columns)); err != nil {
@@ -126,6 +132,7 @@ func (w *worker) onAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err
 		}
 		tblInfo.MoveColumnInfo(columnInfo.Offset, offset)
 		columnInfo.State = model.StatePublic
+		syncMLogColumnsAfterAddColumn(tblInfo)
 		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != columnInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
@@ -143,6 +150,43 @@ func (w *worker) onAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err
 	}
 
 	return ver, errors.Trace(err)
+}
+
+func setMLogAddedColumnOriginDefault(colInfo *model.ColumnInfo) error {
+	if colInfo == nil {
+		return nil
+	}
+	if field_types.HasCharset(&colInfo.FieldType) && colInfo.GetCharset() != charset.CharsetBin {
+		return colInfo.SetOriginDefaultValue(" ")
+	}
+	if colInfo.GetOriginDefaultValue() != nil {
+		return nil
+	}
+	zeroVal := table.GetZeroValue(colInfo)
+	originDefault, err := zeroVal.ToString()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return colInfo.SetOriginDefaultValue(originDefault)
+}
+
+func syncMLogColumnsAfterAddColumn(tblInfo *model.TableInfo) {
+	if tblInfo == nil || tblInfo.MaterializedViewLog == nil {
+		return
+	}
+	trackedCols := make([]pmodel.CIStr, 0, len(tblInfo.Columns))
+	for _, col := range tblInfo.Columns {
+		if col.State != model.StatePublic || isMLogMetaColumnName(col.Name.L) {
+			continue
+		}
+		trackedCols = append(trackedCols, col.Name)
+	}
+	tblInfo.MaterializedViewLog.Columns = trackedCols
+}
+
+func isMLogMetaColumnName(name string) bool {
+	return name == strings.ToLower(model.MaterializedViewLogDMLTypeColumnName) ||
+		name == strings.ToLower(model.MaterializedViewLogOldNewColumnName)
 }
 
 func checkAndCreateNewColumn(ctx sessionctx.Context, ti ast.Ident, schema *model.DBInfo, spec *ast.AlterTableSpec, t table.Table, specNewColumn *ast.ColumnDef) (*table.Column, error) {

--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -253,6 +253,12 @@ func checkDropColumn(jobCtx *jobContext, job *model.Job) (*model.TableInfo, *mod
 		job.State = model.JobStateCancelled
 		return nil, nil, nil, ifExists, dbterror.ErrCantDropFieldOrKey.GenWithStack("column %s doesn't exist", colName)
 	}
+	if colInfo.State == model.StatePublic {
+		if err = checkDropColumnWithMLogBaseConstraint(jobCtx.metaMut, job.SchemaID, tblInfo, colName); err != nil {
+			job.State = model.JobStateCancelled
+			return nil, nil, nil, false, errors.Trace(err)
+		}
+	}
 	if err = isDroppableColumn(tblInfo, colName); err != nil {
 		job.State = model.JobStateCancelled
 		return nil, nil, nil, false, errors.Trace(err)
@@ -265,6 +271,32 @@ func checkDropColumn(jobCtx *jobContext, job *model.Job) (*model.TableInfo, *mod
 	}
 	idxInfos := listIndicesWithColumn(colName.L, tblInfo.Indices)
 	return tblInfo, colInfo, idxInfos, false, nil
+}
+
+func checkDropColumnWithMLogBaseConstraint(
+	t *meta.Mutator,
+	schemaID int64,
+	tblInfo *model.TableInfo,
+	colName pmodel.CIStr,
+) error {
+	if tblInfo.MaterializedViewBase == nil || tblInfo.MaterializedViewBase.MLogID == 0 {
+		return nil
+	}
+
+	mlogTblInfo, err := t.GetTable(schemaID, tblInfo.MaterializedViewBase.MLogID)
+	if err != nil || mlogTblInfo == nil || mlogTblInfo.MaterializedViewLog == nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			"ALTER TABLE on base table with invalid materialized view log metadata",
+		)
+	}
+	for _, mlogCol := range mlogTblInfo.MaterializedViewLog.Columns {
+		if mlogCol.L == colName.L {
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				fmt.Sprintf("ALTER TABLE on base table column %s referenced by materialized view log", colName.L),
+			)
+		}
+	}
+	return nil
 }
 
 func isDroppableColumn(tblInfo *model.TableInfo, colName pmodel.CIStr) error {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -2362,6 +2362,9 @@ func (e *executor) multiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info 
 	}
 
 	var involvingSchemaInfo []model.InvolvingSchemaInfo
+	if mlogInvolving := buildMaterializedViewLogBaseInvolvingSchemaInfo(e.ctx, e.infoCache.GetLatest(), schema.Name.L, t.Meta()); len(mlogInvolving) > 0 {
+		involvingSchemaInfo = append(involvingSchemaInfo, mlogInvolving...)
+	}
 	for _, j := range subJobs {
 		if j.Type == model.ActionAddForeignKey {
 			ref := j.JobArgs.(*model.AddForeignKeyArgs).FkInfo
@@ -2582,6 +2585,9 @@ func (e *executor) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.Alt
 		BinlogInfo:     &model.HistoryInfo{},
 		CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
 		SQLMode:        ctx.GetSessionVars().SQLMode,
+	}
+	if involving := buildMaterializedViewLogInvolvingSchemaInfo(e.ctx, e.infoCache.GetLatest(), schema.Name.L, tbInfo); len(involving) > 0 {
+		job.InvolvingSchemaInfo = involving
 	}
 
 	args := &model.TableColumnArgs{

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -623,18 +623,55 @@ func (e *executor) AlterMaterializedViewLog(ctx sessionctx.Context, s *ast.Alter
 				return err
 			}
 		case ast.AlterMaterializedViewLogActionAddColumn:
+			baseCols := make([]*model.ColumnInfo, 0, len(action.Cols))
 			for _, col := range action.Cols {
-				baseCol := baseColMap[col.L]
-				if err := e.addMaterializedViewLogColumn(ctx, schemaName, mlogName, baseCol, lastTrackedCol); err != nil {
-					return err
-				}
-				lastTrackedCol = col
+				baseCols = append(baseCols, baseColMap[col.L])
+			}
+			if err := e.addMaterializedViewLogColumns(ctx, schemaName, mlogName, baseCols, lastTrackedCol); err != nil {
+				return err
+			}
+			if len(action.Cols) > 0 {
+				lastTrackedCol = action.Cols[len(action.Cols)-1]
 			}
 		default:
 			return errors.Errorf("unknown alter materialized view log action type: %d", action.Tp)
 		}
 	}
 	return nil
+}
+
+func (e *executor) addMaterializedViewLogColumns(
+	ctx sessionctx.Context,
+	schemaName pmodel.CIStr,
+	mlogName pmodel.CIStr,
+	baseCols []*model.ColumnInfo,
+	afterCol pmodel.CIStr,
+) error {
+	if len(baseCols) == 0 {
+		return nil
+	}
+	if len(baseCols) == 1 {
+		return e.addMaterializedViewLogColumn(ctx, schemaName, mlogName, baseCols[0], afterCol)
+	}
+
+	stmtCtx := ctx.GetSessionVars().StmtCtx
+	originalMultiSchemaInfo := stmtCtx.MultiSchemaInfo
+	stmtCtx.MultiSchemaInfo = model.NewMultiSchemaInfo()
+	defer func() {
+		stmtCtx.MultiSchemaInfo = originalMultiSchemaInfo
+	}()
+
+	// Each sub-job inserts after the same existing tracked column. Submit them in
+	// reverse so the final public column order matches the ADD COLUMN list.
+	for i := len(baseCols) - 1; i >= 0; i-- {
+		if err := e.addMaterializedViewLogColumn(ctx, schemaName, mlogName, baseCols[i], afterCol); err != nil {
+			return err
+		}
+	}
+
+	info := stmtCtx.MultiSchemaInfo
+	stmtCtx.MultiSchemaInfo = originalMultiSchemaInfo
+	return e.multiSchemaChange(ctx, ast.Ident{Schema: schemaName, Name: mlogName}, info)
 }
 
 func (e *executor) addMaterializedViewLogColumn(
@@ -644,7 +681,7 @@ func (e *executor) addMaterializedViewLogColumn(
 	baseCol *model.ColumnInfo,
 	afterCol pmodel.CIStr,
 ) error {
-	ft := baseCol.FieldType
+	ft := *baseCol.FieldType.Clone()
 	ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
 	spec := &ast.AlterTableSpec{
 		Tp: ast.AlterTableAddColumns,
@@ -661,6 +698,41 @@ func (e *executor) addMaterializedViewLogColumn(
 		}
 	}
 	return e.AddColumn(ctx, ast.Ident{Schema: schemaName, Name: mlogName}, spec)
+}
+
+func buildMaterializedViewLogInvolvingSchemaInfo(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	schemaName string,
+	mlogInfo *model.TableInfo,
+) []model.InvolvingSchemaInfo {
+	if mlogInfo == nil || mlogInfo.MaterializedViewLog == nil {
+		return nil
+	}
+	involving := []model.InvolvingSchemaInfo{{
+		Database: schemaName,
+		Table:    mlogInfo.Name.L,
+	}}
+	return append(involving, buildMaterializedViewLogBaseInvolvingSchemaInfo(ctx, is, schemaName, mlogInfo)...)
+}
+
+func buildMaterializedViewLogBaseInvolvingSchemaInfo(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	schemaName string,
+	mlogInfo *model.TableInfo,
+) []model.InvolvingSchemaInfo {
+	if is == nil || mlogInfo == nil || mlogInfo.MaterializedViewLog == nil {
+		return nil
+	}
+	baseTable, ok := is.TableByID(ctx, mlogInfo.MaterializedViewLog.BaseTableID)
+	if !ok {
+		return nil
+	}
+	return []model.InvolvingSchemaInfo{{
+		Database: schemaName,
+		Table:    baseTable.Meta().Name.L,
+	}}
 }
 
 func (e *executor) alterMaterializedViewLogPurge(

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -572,6 +572,16 @@ func (e *executor) AlterMaterializedViewLog(ctx sessionctx.Context, s *ast.Alter
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName.O, mlogName, "MATERIALIZED VIEW LOG")
 	}
 
+	addColumnActionCount := 0
+	for _, action := range s.Actions {
+		if action.Tp == ast.AlterMaterializedViewLogActionAddColumn {
+			addColumnActionCount++
+		}
+	}
+	if addColumnActionCount > 1 {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("ALTER MATERIALIZED VIEW LOG with multiple ADD COLUMN actions")
+	}
+
 	baseColMap := make(map[string]*model.ColumnInfo, len(baseTable.Meta().Columns))
 	for _, col := range baseTable.Meta().Columns {
 		if col.State != model.StatePublic {

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -574,6 +574,9 @@ func (e *executor) AlterMaterializedViewLog(ctx sessionctx.Context, s *ast.Alter
 
 	baseColMap := make(map[string]*model.ColumnInfo, len(baseTable.Meta().Columns))
 	for _, col := range baseTable.Meta().Columns {
+		if col.State != model.StatePublic {
+			continue
+		}
 		baseColMap[col.Name.L] = col
 	}
 	mlogColSet := make(map[string]struct{}, len(mlogTable.Meta().Columns)+len(s.Actions))

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -572,20 +572,40 @@ func (e *executor) AlterMaterializedViewLog(ctx sessionctx.Context, s *ast.Alter
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName.O, mlogName, "MATERIALIZED VIEW LOG")
 	}
 
-	// TODO: split ALTER MATERIALIZED VIEW LOG into per-action handlers and
-	// dedicated DDL job args when schema-changing actions (for example column
-	// add/drop) are supported.
+	baseColMap := make(map[string]*model.ColumnInfo, len(baseTable.Meta().Columns))
+	for _, col := range baseTable.Meta().Columns {
+		baseColMap[col.Name.L] = col
+	}
+	mlogColSet := make(map[string]struct{}, len(mlogTable.Meta().Columns)+len(s.Actions))
+	for _, col := range mlogTable.Meta().Columns {
+		mlogColSet[col.Name.L] = struct{}{}
+	}
 	for _, action := range s.Actions {
 		switch action.Tp {
 		case ast.AlterMaterializedViewLogActionPurge:
 			if _, _, _, err := buildMLogPurgeMeta(ctx, action.Purge); err != nil {
 				return err
 			}
+		case ast.AlterMaterializedViewLogActionAddColumn:
+			for _, col := range action.Cols {
+				if _, exists := mlogColSet[col.L]; exists {
+					return infoschema.ErrColumnExists.GenWithStackByArgs(col.O)
+				}
+				if baseColMap[col.L] == nil {
+					return infoschema.ErrColumnNotExists.GenWithStackByArgs(col.O, s.Table.Name.O)
+				}
+				mlogColSet[col.L] = struct{}{}
+			}
 		default:
 			return errors.Errorf("unknown alter materialized view log action type: %d", action.Tp)
 		}
 	}
 
+	lastTrackedCol := pmodel.CIStr{}
+	mlogInfo := mlogTable.Meta().MaterializedViewLog
+	if len(mlogInfo.Columns) > 0 {
+		lastTrackedCol = mlogInfo.Columns[len(mlogInfo.Columns)-1]
+	}
 	for _, action := range s.Actions {
 		switch action.Tp {
 		case ast.AlterMaterializedViewLogActionPurge:
@@ -599,11 +619,45 @@ func (e *executor) AlterMaterializedViewLog(ctx sessionctx.Context, s *ast.Alter
 			); err != nil {
 				return err
 			}
+		case ast.AlterMaterializedViewLogActionAddColumn:
+			for _, col := range action.Cols {
+				baseCol := baseColMap[col.L]
+				if err := e.addMaterializedViewLogColumn(ctx, schemaName, mlogName, baseCol, lastTrackedCol); err != nil {
+					return err
+				}
+				lastTrackedCol = col
+			}
 		default:
 			return errors.Errorf("unknown alter materialized view log action type: %d", action.Tp)
 		}
 	}
 	return nil
+}
+
+func (e *executor) addMaterializedViewLogColumn(
+	ctx sessionctx.Context,
+	schemaName pmodel.CIStr,
+	mlogName pmodel.CIStr,
+	baseCol *model.ColumnInfo,
+	afterCol pmodel.CIStr,
+) error {
+	ft := baseCol.FieldType
+	ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
+	spec := &ast.AlterTableSpec{
+		Tp: ast.AlterTableAddColumns,
+		NewColumns: []*ast.ColumnDef{{
+			Name: &ast.ColumnName{Name: baseCol.Name},
+			Tp:   &ft,
+		}},
+		Position: &ast.ColumnPosition{Tp: ast.ColumnPositionFirst},
+	}
+	if afterCol.L != "" {
+		spec.Position = &ast.ColumnPosition{
+			Tp:             ast.ColumnPositionAfter,
+			RelativeColumn: &ast.ColumnName{Name: afterCol},
+		}
+	}
+	return e.AddColumn(ctx, ast.Ident{Schema: schemaName, Name: mlogName}, spec)
 }
 
 func (e *executor) alterMaterializedViewLogPurge(

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -135,6 +135,9 @@ func TestCreateMaterializedViewLogBasic(t *testing.T) {
 	tk.MustGetErrMsg("create materialized view log on t (a)", "[schema:1050]Table 'test.$mlog$t' already exists")
 }
 
+// TestAlterMaterializedViewLogAddColumnBasic verifies that ADD COLUMN updates
+// mlog metadata, backfills old log rows with mlog defaults, and records future
+// changes only when newly tracked columns are touched.
 func TestAlterMaterializedViewLogAddColumnBasic(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
@@ -191,6 +194,9 @@ func TestAlterMaterializedViewLogAddColumnBasic(t *testing.T) {
 		))
 }
 
+// TestAlterMaterializedViewLogAddColumnDefaultSemantics verifies the default
+// values used for existing mlog rows when ADD COLUMN tracks nullable columns,
+// enum/set columns, and not-null string columns.
 func TestAlterMaterializedViewLogAddColumnDefaultSemantics(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -227,6 +233,9 @@ func TestAlterMaterializedViewLogAddColumnDefaultSemantics(t *testing.T) {
 		Check(testkit.Rows("1 1 a  1 1 20 20 I 1"))
 }
 
+// TestAlterMaterializedViewLogAddColumnRejectsInvalidColumns verifies that ADD
+// COLUMN rejects duplicate tracked columns, duplicate names in one statement,
+// missing base columns, and reserved mlog metadata columns.
 func TestAlterMaterializedViewLogAddColumnRejectsInvalidColumns(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -240,6 +249,9 @@ func TestAlterMaterializedViewLogAddColumnRejectsInvalidColumns(t *testing.T) {
 	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (`_MLOG$_DML_TYPE`)", errno.ErrDupFieldName)
 }
 
+// TestAlterMaterializedViewLogAddColumnPrivilege verifies that ADD COLUMN
+// requires ALTER privilege on the mlog table and SELECT privilege on the base
+// table.
 func TestAlterMaterializedViewLogAddColumnPrivilege(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -264,6 +276,9 @@ func TestAlterMaterializedViewLogAddColumnPrivilege(t *testing.T) {
 	tkOK.MustExec("alter materialized view log on test.t_add_mlog_priv add column (b)")
 }
 
+// TestAlterMaterializedViewLogAddColumnSupportsNewMaterializedView verifies
+// that a fast-refresh materialized view can be created and refreshed after its
+// referenced base column is added to the materialized view log.
 func TestAlterMaterializedViewLogAddColumnSupportsNewMaterializedView(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -280,13 +280,17 @@ func TestAlterMaterializedViewLogAddColumnRejectsInvalidColumns(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	tk.MustExec("create table t_add_mlog_invalid (a int, b int)")
+	tk.MustExec("create table t_add_mlog_invalid (a int, b int, c int)")
 	tk.MustExec("create materialized view log on t_add_mlog_invalid (a)")
 
 	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (a)", errno.ErrDupFieldName)
 	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (b, b)", errno.ErrDupFieldName)
 	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (missing_col)", errno.ErrBadField)
 	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (`_MLOG$_DML_TYPE`)", errno.ErrDupFieldName)
+	tk.MustGetErrMsg(
+		"alter materialized view log on t_add_mlog_invalid add column (b), add column (c)",
+		"[ddl:8200]Unsupported ALTER MATERIALIZED VIEW LOG with multiple ADD COLUMN actions",
+	)
 }
 
 // TestAlterMaterializedViewLogAddColumnPrivilege verifies that ADD COLUMN

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -191,6 +191,35 @@ func TestAlterMaterializedViewLogAddColumnBasic(t *testing.T) {
 		))
 }
 
+func TestAlterMaterializedViewLogAddColumnDefaultSemantics(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_add_mlog_defaults (" +
+		"id int," +
+		"nullable_varchar varchar(10)," +
+		"nullable_text text," +
+		"nn_enum enum('a','b') not null," +
+		"nn_set set('x','y') not null," +
+		"nullable_enum enum('a','b')," +
+		"nullable_set set('x','y')," +
+		"nn_varchar varchar(10) not null," +
+		"nn_text text not null)")
+	tk.MustExec("create materialized view log on t_add_mlog_defaults (id)")
+	tk.MustExec("insert into t_add_mlog_defaults values (1, null, null, 'b', 'x', null, null, 'old', 'memo')")
+
+	tk.MustExec("alter materialized view log on t_add_mlog_defaults add column (" +
+		"nullable_varchar, nullable_text, nn_enum, nn_set, nullable_enum, nullable_set, nn_varchar, nn_text)")
+
+	tk.MustQuery("select " +
+		"nullable_varchar is null, nullable_text is null, " +
+		"cast(nn_enum as char), cast(nn_set as char), " +
+		"nullable_enum is null, nullable_set is null, " +
+		"hex(nn_varchar), hex(nn_text), `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` " +
+		"from `$mlog$t_add_mlog_defaults`").
+		Check(testkit.Rows("1 1 a  1 1 20 20 I 1"))
+}
+
 func TestAlterMaterializedViewLogAddColumnRejectsInvalidColumns(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -192,6 +192,46 @@ func TestAlterMaterializedViewLogAddColumnBasic(t *testing.T) {
 			"1 7 new 2026-01-02 memo U 1",
 			"1 7 old 2026-01-02 memo U -1",
 		))
+
+	tk.MustExec("create table t_add_mlog_atomic (id int, b int, c int)")
+	tk.MustExec("create materialized view log on t_add_mlog_atomic (id)")
+	cancelTK := testkit.NewTestKit(t, store)
+	cancelTK.MustExec("use test")
+	cancelTriggered := atomic.Bool{}
+	cancelDone := make(chan error, 1)
+	require.NoError(t, failpoint.EnableCall("github.com/pingcap/tidb/pkg/ddl/onJobUpdated", func(job *metamodel.Job) {
+		if !cancelTriggered.CompareAndSwap(false, true) {
+			return
+		}
+		if job.Type != metamodel.ActionMultiSchemaChange ||
+			job.SchemaName != "test" ||
+			job.TableName != "$mlog$t_add_mlog_atomic" ||
+			job.MultiSchemaInfo == nil ||
+			len(job.MultiSchemaInfo.SubJobs) != 2 ||
+			job.MultiSchemaInfo.SubJobs[1].SchemaState != metamodel.StateWriteReorganization {
+			cancelTriggered.Store(false)
+			return
+		}
+		errs, err := ddl.CancelJobs(context.Background(), cancelTK.Session(), []int64{job.ID})
+		if len(errs) > 0 && errs[0] != nil {
+			cancelDone <- errs[0]
+			return
+		}
+		cancelDone <- err
+	}))
+	err = tk.ExecToErr("alter materialized view log on t_add_mlog_atomic add column (b, c)")
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/onJobUpdated"))
+	require.ErrorContains(t, err, "Cancelled DDL job")
+	select {
+	case cancelErr := <-cancelDone:
+		require.NoError(t, cancelErr)
+	default:
+		require.FailNow(t, "expected mlog multi-column add cancellation")
+	}
+	showCreate = tk.MustQuery("show create materialized view log on t_add_mlog_atomic").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW LOG ON `t_add_mlog_atomic` (`id`)")
+	require.NotContains(t, showCreate, "`b`")
+	require.NotContains(t, showCreate, "`c`")
 }
 
 // TestAlterMaterializedViewLogAddColumnDefaultSemantics verifies the default

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/kv"
+	metamodel "github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
@@ -40,6 +41,15 @@ import (
 
 func mustExecInternal(t *testing.T, tk *testkit.TestKit, sql string) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnMVMaintenance)
+	vars := tk.Session().GetSessionVars()
+	origMaint := vars.InMaterializedViewMaintenance
+	origRestr := vars.InRestrictedSQL
+	vars.InMaterializedViewMaintenance = true
+	vars.InRestrictedSQL = true
+	defer func() {
+		vars.InMaterializedViewMaintenance = origMaint
+		vars.InRestrictedSQL = origRestr
+	}()
 	rs, err := tk.Session().ExecuteInternal(ctx, sql)
 	require.NoError(t, err)
 	require.Nil(t, rs)
@@ -123,6 +133,126 @@ func TestCreateMaterializedViewLogBasic(t *testing.T) {
 
 	// Duplicated MV LOG should fail (same derived table name).
 	tk.MustGetErrMsg("create materialized view log on t (a)", "[schema:1050]Table 'test.$mlog$t' already exists")
+}
+
+func TestAlterMaterializedViewLogAddColumnBasic(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_add_mlog_col (id int not null, n int not null, s varchar(10) not null, d date not null, note text not null, untouched int)")
+	tk.MustExec("create materialized view log on t_add_mlog_col (id)")
+	tk.MustExec("insert into t_add_mlog_col values (1, 7, 'old', '2026-01-02', 'memo', 100)")
+
+	tk.MustExec("alter materialized view log on t_add_mlog_col add column (n, s, d, note)")
+
+	is := dom.InfoSchema()
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_add_mlog_col"))
+	require.NoError(t, err)
+	mlogInfo := mlogTable.Meta().MaterializedViewLog
+	require.NotNil(t, mlogInfo)
+	require.Equal(t, []pmodel.CIStr{
+		pmodel.NewCIStr("id"),
+		pmodel.NewCIStr("n"),
+		pmodel.NewCIStr("s"),
+		pmodel.NewCIStr("d"),
+		pmodel.NewCIStr("note"),
+	}, mlogInfo.Columns)
+
+	colNames := make([]string, 0, len(mlogTable.Meta().Columns))
+	colByName := make(map[string]*metamodel.ColumnInfo, len(mlogTable.Meta().Columns))
+	for _, col := range mlogTable.Meta().Columns {
+		colNames = append(colNames, col.Name.O)
+		colByName[col.Name.L] = col
+	}
+	require.Equal(t, []string{"id", "n", "s", "d", "note", "_MLOG$_DML_TYPE", "_MLOG$_OLD_NEW"}, colNames)
+	for _, name := range []string{"n", "s", "d", "note"} {
+		require.True(t, mysql.HasNotNullFlag(colByName[name].GetFlag()))
+	}
+	require.Equal(t, "0", fmt.Sprint(colByName["n"].GetOriginDefaultValue()))
+	require.Equal(t, " ", fmt.Sprint(colByName["s"].GetOriginDefaultValue()))
+	require.Equal(t, "0000-00-00", fmt.Sprint(colByName["d"].GetOriginDefaultValue()))
+	require.Equal(t, " ", fmt.Sprint(colByName["note"].GetOriginDefaultValue()))
+
+	tk.MustQuery("select n, hex(s), cast(d as char), hex(note), `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t_add_mlog_col`").
+		Check(testkit.Rows("0 20 0000-00-00 20 I 1"))
+
+	showCreate := tk.MustQuery("show create materialized view log on t_add_mlog_col").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW LOG ON `t_add_mlog_col` (`id`, `n`, `s`, `d`, `note`)")
+
+	mustExecInternal(t, tk, "delete from `$mlog$t_add_mlog_col`")
+	tk.MustExec("update t_add_mlog_col set untouched = 101 where id = 1")
+	tk.MustQuery("select * from `$mlog$t_add_mlog_col`").Check(testkit.Rows())
+
+	tk.MustExec("update t_add_mlog_col set s = 'new' where id = 1")
+	tk.MustQuery("select id, n, s, cast(d as char), note, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t_add_mlog_col`").Sort().
+		Check(testkit.Rows(
+			"1 7 new 2026-01-02 memo U 1",
+			"1 7 old 2026-01-02 memo U -1",
+		))
+}
+
+func TestAlterMaterializedViewLogAddColumnRejectsInvalidColumns(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_add_mlog_invalid (a int, b int)")
+	tk.MustExec("create materialized view log on t_add_mlog_invalid (a)")
+
+	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (a)", errno.ErrDupFieldName)
+	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (b, b)", errno.ErrDupFieldName)
+	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (missing_col)", errno.ErrBadField)
+	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (`_MLOG$_DML_TYPE`)", errno.ErrDupFieldName)
+}
+
+func TestAlterMaterializedViewLogAddColumnPrivilege(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_add_mlog_priv (a int, b int)")
+	tk.MustExec("create materialized view log on t_add_mlog_priv (a)")
+	tk.MustExec("create user 'u_add_mlog_no_select'@'%'")
+	tk.MustExec("create user 'u_add_mlog_ok'@'%'")
+	defer tk.MustExec("drop user 'u_add_mlog_no_select'@'%'")
+	defer tk.MustExec("drop user 'u_add_mlog_ok'@'%'")
+
+	tk.MustExec("grant alter on test.`$mlog$t_add_mlog_priv` to 'u_add_mlog_no_select'@'%'")
+	tkNoSelect := testkit.NewTestKit(t, store)
+	require.NoError(t, tkNoSelect.Session().Auth(&auth.UserIdentity{Username: "u_add_mlog_no_select", Hostname: "%"}, nil, nil, nil))
+	err := tkNoSelect.ExecToErr("alter materialized view log on test.t_add_mlog_priv add column (b)")
+	require.ErrorContains(t, err, "SELECT command denied")
+
+	tk.MustExec("grant alter on test.`$mlog$t_add_mlog_priv` to 'u_add_mlog_ok'@'%'")
+	tk.MustExec("grant select on test.t_add_mlog_priv to 'u_add_mlog_ok'@'%'")
+	tkOK := testkit.NewTestKit(t, store)
+	require.NoError(t, tkOK.Session().Auth(&auth.UserIdentity{Username: "u_add_mlog_ok", Hostname: "%"}, nil, nil, nil))
+	tkOK.MustExec("alter materialized view log on test.t_add_mlog_priv add column (b)")
+}
+
+func TestAlterMaterializedViewLogAddColumnSupportsNewMaterializedView(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_add_mlog_mv (a int not null, b int not null, c int not null)")
+	tk.MustExec("insert into t_add_mlog_mv values (1, 10, 100), (1, 20, 200), (2, 30, 300)")
+	tk.MustExec("create materialized view log on t_add_mlog_mv (a, b)")
+
+	err := tk.ExecToErr("create materialized view mv_add_mlog_col_before (a, s, cnt) refresh fast as select a, sum(c), count(1) from t_add_mlog_mv group by a")
+	require.ErrorContains(t, err, "materialized view log does not contain column c")
+
+	tk.MustExec("alter materialized view log on t_add_mlog_mv add column (c)")
+	tk.MustExec("create materialized view mv_add_mlog_col_after (a, s, cnt) refresh fast as select a, sum(c), count(1) from t_add_mlog_mv group by a")
+	tk.MustQuery("select a, s, cnt from mv_add_mlog_col_after order by a").Check(testkit.Rows(
+		"1 300 2",
+		"2 300 1",
+	))
+
+	tk.MustExec("update t_add_mlog_mv set c = 150 where a = 1 and b = 10")
+	tk.MustExec("insert into t_add_mlog_mv values (2, 40, 400)")
+	tk.MustExec("refresh materialized view mv_add_mlog_col_after fast")
+	tk.MustQuery("select a, s, cnt from mv_add_mlog_col_after order by a").Check(testkit.Rows(
+		"1 350 2",
+		"2 700 2",
+	))
 }
 
 func TestCreateMaterializedViewLogPrivilege(t *testing.T) {

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -195,6 +195,10 @@ func TestAlterMaterializedViewLogAddColumnDefaultSemantics(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
+	// This table covers the mlog backfill defaults that differ from normal AddColumn:
+	// nullable columns should keep NULL for old mlog rows, enum/set should use the
+	// regular TiDB default semantics, and not-null string columns should use a
+	// single-space placeholder required by materialized view log history rows.
 	tk.MustExec("create table t_add_mlog_defaults (" +
 		"id int," +
 		"nullable_varchar varchar(10)," +
@@ -211,6 +215,9 @@ func TestAlterMaterializedViewLogAddColumnDefaultSemantics(t *testing.T) {
 	tk.MustExec("alter materialized view log on t_add_mlog_defaults add column (" +
 		"nullable_varchar, nullable_text, nn_enum, nn_set, nullable_enum, nullable_set, nn_varchar, nn_text)")
 
+	// The existing INSERT log row is historical data. It should not read current
+	// base-table values for newly tracked columns; it should only expose the
+	// metadata default chosen for old mlog rows.
 	tk.MustQuery("select " +
 		"nullable_varchar is null, nullable_text is null, " +
 		"cast(nn_enum as char), cast(nn_set as char), " +

--- a/pkg/executor/test/writetest/BUILD.bazel
+++ b/pkg/executor/test/writetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "write_test.go",
     ],
     flaky = True,
-    shard_count = 45,
+    shard_count = 46,
     deps = [
         "//pkg/config",
         "//pkg/errctx",

--- a/pkg/executor/test/writetest/BUILD.bazel
+++ b/pkg/executor/test/writetest/BUILD.bazel
@@ -9,10 +9,11 @@ go_test(
         "write_test.go",
     ],
     flaky = True,
-    shard_count = 46,
+    shard_count = 47,
     deps = [
         "//pkg/config",
         "//pkg/errctx",
+        "//pkg/errno",
         "//pkg/executor",
         "//pkg/kv",
         "//pkg/lightning/mydump",

--- a/pkg/executor/test/writetest/mview_log_write_test.go
+++ b/pkg/executor/test/writetest/mview_log_write_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/lightning/mydump"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -879,6 +880,47 @@ func TestMLogOnlineDDLAddUntrackedColumn(t *testing.T) {
 		"1 0 10 101",
 		"2 0 20 200",
 	))
+}
+
+// TestMLogAddColumnRejectsNonPublicBaseColumn verifies that ALTER MATERIALIZED
+// VIEW LOG only accepts public base-table columns. A column being added by
+// concurrent online DDL is visible in metadata before it becomes public, and mlog
+// tracking must reject it until the base DDL finishes.
+func TestMLogAddColumnRejectsNonPublicBaseColumn(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@global.tidb_enable_metadata_lock=0")
+
+	tk.MustExec("create table t (id int primary key, tracked int)")
+	tk.MustExec("create materialized view log on t (id)")
+
+	tkDDL := testkit.NewTestKit(t, store)
+	tkDDL.MustExec("use test")
+	ctrl := startDDLPausedAtFailpoint(
+		t,
+		tkDDL,
+		addColumnStateWriteReorgFailpoint,
+		"alter table t add column added int default 0",
+	)
+	defer ctrl.releaseAndWaitFinish(t)
+
+	ctrl.waitUntilPaused(t, "base-table add-column write-reorg")
+
+	// The base column is non-public while ADD COLUMN is paused, so the mlog
+	// should treat it as unavailable instead of adding a transient column.
+	tk.MustGetErrCode("alter materialized view log on t add column (added)", errno.ErrBadField)
+
+	ctrl.releaseAndWaitFinish(t)
+
+	// Once the base ADD COLUMN completes, the same column is public and can be
+	// tracked by the mlog normally.
+	tk.MustExec("alter materialized view log on t add column (added)")
+	rows := tk.MustQuery("show create materialized view log on t").Rows()
+	require.Len(t, rows, 1)
+	showCreate, ok := rows[0][1].(string)
+	require.True(t, ok)
+	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW LOG ON `t` (`id`, `added`)")
 }
 
 // TestMLogOnlineDDLAddTrackedColumn verifies mlog writes while ADD COLUMN is in

--- a/pkg/executor/test/writetest/mview_log_write_test.go
+++ b/pkg/executor/test/writetest/mview_log_write_test.go
@@ -973,6 +973,44 @@ func TestMLogOnlineDDLAddTrackedColumn(t *testing.T) {
 		"1 11 100 U -1",
 		"1 11 101 U 1",
 	))
+
+	tk.MustExec("create table t_drop_race (id int primary key, tracked int, added int)")
+	tk.MustExec("create materialized view log on t_drop_race (id)")
+	tkDDL2 := testkit.NewTestKit(t, store)
+	tkDDL2.MustExec("use test")
+	ctrl2 := startDDLPausedAtFailpoint(
+		t,
+		tkDDL2,
+		addColumnStateWriteReorgFailpoint,
+		"alter materialized view log on t_drop_race add column (added)",
+	)
+	defer ctrl2.releaseAndWaitFinish(t)
+	ctrl2.waitUntilPaused(t, "mlog add-column write-reorg before base drop")
+
+	tkDrop := testkit.NewTestKit(t, store)
+	tkDrop.MustExec("use test")
+	dropDone := make(chan error, 1)
+	go func() {
+		dropDone <- tkDrop.ExecToErr("alter table t_drop_race drop column added")
+	}()
+	select {
+	case err := <-dropDone:
+		require.FailNow(t, "base drop column finished before mlog add completed", "err=%v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	ctrl2.releaseAndWaitFinish(t)
+	select {
+	case err := <-dropDone:
+		require.ErrorContains(t, err, "referenced by materialized view log")
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "timed out waiting base drop column to finish")
+	}
+	rows := tk.MustQuery("show create materialized view log on t_drop_race").Rows()
+	require.Len(t, rows, 1)
+	showCreate, ok := rows[0][1].(string)
+	require.True(t, ok)
+	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW LOG ON `t_drop_race` (`id`, `added`)")
 }
 
 func TestMLogOnlineDDLDropUntrackedColumn(t *testing.T) {

--- a/pkg/executor/test/writetest/mview_log_write_test.go
+++ b/pkg/executor/test/writetest/mview_log_write_test.go
@@ -881,6 +881,54 @@ func TestMLogOnlineDDLAddUntrackedColumn(t *testing.T) {
 	))
 }
 
+func TestMLogOnlineDDLAddTrackedColumn(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@global.tidb_enable_metadata_lock=0")
+
+	tk.MustExec("create table t (id int primary key, tracked int, added int, untracked int)")
+	tk.MustExec("create materialized view log on t (id, tracked)")
+	tk.MustExec("insert into t values (1, 10, 100, 1000)")
+	execAsMViewMaintenance(tk, "delete from `$mlog$t`")
+
+	tkDDL := testkit.NewTestKit(t, store)
+	tkDDL.MustExec("use test")
+	ctrl := startDDLPausedAtFailpoint(
+		t,
+		tkDDL,
+		addColumnStateWriteReorgFailpoint,
+		"alter materialized view log on t add column (added)",
+	)
+	defer ctrl.releaseAndWaitFinish(t)
+
+	ctrl.waitUntilPaused(t, "mlog add-column write-reorg")
+
+	// The new mlog column is not public yet, so mlog writing should continue with the
+	// previous tracked column set instead of treating the transient metadata as corrupt.
+	tk.MustExec("update t set tracked = 11 where id = 1")
+	tk.MustQuery(
+		"select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`",
+	).Sort().Check(testkit.Rows(
+		"1 10 U -1",
+		"1 11 U 1",
+	))
+
+	ctrl.releaseAndWaitFinish(t)
+
+	execAsMViewMaintenance(tk, "delete from `$mlog$t`")
+	tk.MustExec("update t set untracked = 1001 where id = 1")
+	tk.MustQuery("select * from `$mlog$t`").Check(testkit.Rows())
+
+	tk.MustExec("update t set added = 101 where id = 1")
+	tk.MustQuery(
+		"select id, tracked, added, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`",
+	).Sort().Check(testkit.Rows(
+		"1 11 100 U -1",
+		"1 11 101 U 1",
+	))
+}
+
 func TestMLogOnlineDDLDropUntrackedColumn(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/writetest/mview_log_write_test.go
+++ b/pkg/executor/test/writetest/mview_log_write_test.go
@@ -881,6 +881,10 @@ func TestMLogOnlineDDLAddUntrackedColumn(t *testing.T) {
 	))
 }
 
+// TestMLogOnlineDDLAddTrackedColumn verifies mlog writes while ADD COLUMN is in
+// progress: before the new mlog column is public, writes still use the old
+// tracked-column set; after it is public, the new tracked column participates in
+// update logging.
 func TestMLogOnlineDDLAddTrackedColumn(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -2032,13 +2032,14 @@ type AlterMaterializedViewLogAction struct {
 	node
 	Tp    AlterMaterializedViewLogActionType
 	Purge *MLogPurgeClause
+	Cols  []model.CIStr
 }
 
 type AlterMaterializedViewLogActionType int
 
 const (
-	// TODO: support column-level ALTER MATERIALIZED VIEW LOG actions.
 	AlterMaterializedViewLogActionPurge AlterMaterializedViewLogActionType = iota
+	AlterMaterializedViewLogActionAddColumn
 )
 
 // Restore implements Node interface.
@@ -2049,6 +2050,16 @@ func (n *AlterMaterializedViewLogAction) Restore(ctx *format.RestoreCtx) error {
 			return nil
 		}
 		return n.Purge.Restore(ctx)
+	case AlterMaterializedViewLogActionAddColumn:
+		ctx.WriteKeyWord("ADD COLUMN (")
+		for i, col := range n.Cols {
+			if i > 0 {
+				ctx.WritePlain(", ")
+			}
+			ctx.WriteName(col.O)
+		}
+		ctx.WritePlain(")")
+		return nil
 	default:
 		return nil
 	}

--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -2032,7 +2032,8 @@ type AlterMaterializedViewLogAction struct {
 	node
 	Tp    AlterMaterializedViewLogActionType
 	Purge *MLogPurgeClause
-	Cols  []model.CIStr
+	// Cols contains the base-table column names involved in an ADD COLUMN action.
+	Cols []model.CIStr
 }
 
 type AlterMaterializedViewLogActionType int
@@ -2051,7 +2052,8 @@ func (n *AlterMaterializedViewLogAction) Restore(ctx *format.RestoreCtx) error {
 		}
 		return n.Purge.Restore(ctx)
 	case AlterMaterializedViewLogActionAddColumn:
-		ctx.WriteKeyWord("ADD COLUMN (")
+		ctx.WriteKeyWord("ADD COLUMN ")
+		ctx.WritePlain("(")
 		for i, col := range n.Cols {
 			if i > 0 {
 				ctx.WritePlain(", ")

--- a/pkg/parser/ast/ddl_test.go
+++ b/pkg/parser/ast/ddl_test.go
@@ -49,6 +49,7 @@ func TestDDLVisitorCover(t *testing.T) {
 		{&CreateMaterializedViewLogStmt{Table: &TableName{}, Purge: &MLogPurgeClause{Immediate: true}}, 0, 0},
 		{&AlterMaterializedViewStmt{ViewName: &TableName{}, Actions: []*AlterMaterializedViewAction{{Tp: AlterMaterializedViewActionComment}}}, 0, 0},
 		{&AlterMaterializedViewLogStmt{Table: &TableName{}, Actions: []*AlterMaterializedViewLogAction{{Tp: AlterMaterializedViewLogActionPurge, Purge: &MLogPurgeClause{Immediate: true}}}}, 0, 0},
+		{&AlterMaterializedViewLogStmt{Table: &TableName{}, Actions: []*AlterMaterializedViewLogAction{{Tp: AlterMaterializedViewLogActionAddColumn}}}, 0, 0},
 		{&DropMaterializedViewStmt{ViewName: &TableName{}}, 0, 0},
 		{&DropMaterializedViewLogStmt{Table: &TableName{}}, 0, 0},
 		{&AlterTableSpec{}, 0, 0},

--- a/pkg/parser/ast/ddl_test.go
+++ b/pkg/parser/ast/ddl_test.go
@@ -49,6 +49,7 @@ func TestDDLVisitorCover(t *testing.T) {
 		{&CreateMaterializedViewLogStmt{Table: &TableName{}, Purge: &MLogPurgeClause{Immediate: true}}, 0, 0},
 		{&AlterMaterializedViewStmt{ViewName: &TableName{}, Actions: []*AlterMaterializedViewAction{{Tp: AlterMaterializedViewActionComment}}}, 0, 0},
 		{&AlterMaterializedViewLogStmt{Table: &TableName{}, Actions: []*AlterMaterializedViewLogAction{{Tp: AlterMaterializedViewLogActionPurge, Purge: &MLogPurgeClause{Immediate: true}}}}, 0, 0},
+		// Covers AST visitor traversal for ALTER MATERIALIZED VIEW LOG ADD COLUMN.
 		{&AlterMaterializedViewLogStmt{Table: &TableName{}, Actions: []*AlterMaterializedViewLogAction{{Tp: AlterMaterializedViewLogActionAddColumn}}}, 0, 0},
 		{&DropMaterializedViewStmt{ViewName: &TableName{}}, 0, 0},
 		{&DropMaterializedViewLogStmt{Table: &TableName{}}, 0, 0},

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -5608,6 +5608,10 @@ AlterMaterializedViewLogAction:
 		}
 		$$ = &ast.AlterMaterializedViewLogAction{Tp: ast.AlterMaterializedViewLogActionPurge, Purge: &ast.MLogPurgeClause{Immediate: false, StartWith: startWith, Next: next}}
 	}
+|	"ADD" ColumnKeywordOpt '(' ColumnList ')'
+	{
+		$$ = &ast.AlterMaterializedViewLogAction{Tp: ast.AlterMaterializedViewLogActionAddColumn, Cols: $4.([]model.CIStr)}
+	}
 
 DropMaterializedViewStmt:
 	"DROP" "MATERIALIZED" "VIEW" TableName

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1296,6 +1296,7 @@ func TestDBAStmt(t *testing.T) {
 		// for show create materialized view log
 		{"show create materialized view log on test.t", true, "SHOW CREATE MATERIALIZED VIEW LOG ON `test`.`t`"},
 		{"show create materialized view log on t", true, "SHOW CREATE MATERIALIZED VIEW LOG ON `t`"},
+		{"alter materialized view log on test.t add column (a, b)", true, "ALTER MATERIALIZED VIEW LOG ON `test`.`t` ADD COLUMN (`a`, `b`)"},
 		// for show materialized views
 		{"show materialized views", true, "SHOW MATERIALIZED VIEWS"},
 		{"show materialized views from test", true, "SHOW MATERIALIZED VIEWS IN `test`"},

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1296,6 +1296,7 @@ func TestDBAStmt(t *testing.T) {
 		// for show create materialized view log
 		{"show create materialized view log on test.t", true, "SHOW CREATE MATERIALIZED VIEW LOG ON `test`.`t`"},
 		{"show create materialized view log on t", true, "SHOW CREATE MATERIALIZED VIEW LOG ON `t`"},
+		// Covers parsing and restoring ALTER MATERIALIZED VIEW LOG ADD COLUMN.
 		{"alter materialized view log on test.t add column (a, b)", true, "ALTER MATERIALIZED VIEW LOG ON `test`.`t` ADD COLUMN (`a`, `b`)"},
 		// for show materialized views
 		{"show materialized views", true, "SHOW MATERIALIZED VIEWS"},

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -6308,13 +6308,20 @@ func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (base.Plan
 			return nil, plannererrors.ErrNoDB
 		}
 		mlogName := b.materializedViewLogNameForBaseTable(ctx, dbName, v.Table.Name)
-		// TODO: add action-specific privilege checks for ALTER MATERIALIZED VIEW LOG
-		// (for example base-table SELECT for future column-level actions).
+		var selectAuthErr error
 		if b.ctx.GetSessionVars().User != nil {
+			selectAuthErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SELECT", b.ctx.GetSessionVars().User.AuthUsername,
+				b.ctx.GetSessionVars().User.AuthHostname, v.Table.Name.L)
 			authErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("ALTER", b.ctx.GetSessionVars().User.AuthUsername,
 				b.ctx.GetSessionVars().User.AuthHostname, mlogName.L)
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.AlterPriv, dbName, mlogName.L, "", authErr)
+		for _, action := range v.Actions {
+			if action.Tp == ast.AlterMaterializedViewLogActionAddColumn {
+				b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, dbName, v.Table.Name.L, "", selectAuthErr)
+				break
+			}
+		}
 	case *ast.OptimizeTableStmt:
 		return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStack("OPTIMIZE TABLE is not supported")
 	}

--- a/pkg/table/tables/mview_log.go
+++ b/pkg/table/tables/mview_log.go
@@ -61,7 +61,12 @@ const (
 )
 
 func validateMLogMetaColumn(mlogMeta *model.TableInfo) error {
-	cols := mlogMeta.Columns
+	cols := make([]*model.ColumnInfo, 0, len(mlogMeta.Columns))
+	for _, col := range mlogMeta.Columns {
+		if col.State == model.StatePublic {
+			cols = append(cols, col)
+		}
+	}
 	trackedCols := mlogMeta.MaterializedViewLog.Columns
 	expectedLen := len(trackedCols) + 2
 	if len(cols) != expectedLen {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

Existing materialized view logs cannot be extended with newly needed base table columns. This blocks creating later fast-refresh materialized views that depend on columns omitted from the original MLog definition.

### What changed and how does it work?

This PR supports `ALTER MATERIALIZED VIEW LOG ON <table> ADD COLUMN (...)`.

- Adds parser/AST restore support for `ALTER MATERIALIZED VIEW LOG ... ADD COLUMN`.
- Validates added columns against the base table and rejects duplicates, missing columns, and internal MLog column names.
- Reuses online `ADD COLUMN` on the internal MLog table, preserving base column type and `NOT NULL`, while clearing key/auto-increment/on-update flags.
- Stores historical default values for pre-existing MLog rows: numeric/date zero values and a single space for textual columns.
- Updates `MaterializedViewLog.Columns` when the added column becomes public and ignores non-public columns while validating MLog metadata during online DDL.
- Requires base-table `SELECT` privilege for add-column actions in addition to `ALTER` on the MLog table.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support adding columns to an existing materialized view log using `ALTER MATERIALIZED VIEW LOG ... ADD COLUMN`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ALTER MATERIALIZED VIEW LOG ... ADD COLUMN: add tracked columns online while preserving ordering and backfilling tracking for historical rows.

* **Bug Fixes**
  * Ensures tracked-column lists refresh during add-column transitions; sets appropriate origin-defaults for newly tracked columns; job aborts on origin-default errors; treats non-public columns as metadata for validations.

* **Tests**
  * Expanded tests for add-column semantics, defaults/nulls, ordering, privileges, error cases, and online/concurrent behavior.

* **Parser**
  * Added syntax and AST support for ADD COLUMN on materialized view logs.

* **Planner**
  * Requires SELECT on base table in addition to ALTER on the log when adding columns.

* **Chores**
  * Adjusted test shard configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->