### PR TITLE
feat: improve tidb-verify-profile skill score

### DIFF
--- a/.agents/skills/tidb-verify-profile/SKILL.md
+++ b/.agents/skills/tidb-verify-profile/SKILL.md
@@ -1,38 +1,50 @@
 ---
 name: tidb-verify-profile
-description: Use when choosing local validation scope in TiDB work, especially to separate fast coding-loop checks from completion checks and avoid unnecessary slow commands.
+description: "Selects which local checks to run during TiDB development: targeted unit tests, make lint, integration test recording, or RealTiKV suites. Use when deciding what to test, preparing to mark a task done, running pre-commit validation, or choosing between fast and full verification."
 ---
 
 # TiDB Verification Profiles
 
-## Overview
+Decide how much local validation to run before and after code changes.
+Policy requirements come from `AGENTS.md`; this skill is the execution guide.
 
-Use this skill to decide how much local validation to run before and after code changes.
-Policy requirements still come from `AGENTS.md`; this skill is the execution guide.
+## `WIP` (coding loop)
 
-## Profiles
+Use while still iterating. Run only what validates the changed behavior.
 
-### `WIP` (coding loop)
+```bash
+# Targeted unit test (most common)
+pushd pkg/<package_name>
+go test -run <TestName> -tags=intest,deadlock
+popd
 
-Use while still iterating and not claiming the task is complete.
+# If the package uses failpoints (check first):
+rg --fixed-strings "failpoint." pkg/<package_name>
+# If matches found, use the failpoint wrapper instead:
+./tools/check/failpoint-go-test.sh pkg/<package_name> -run <TestName>
+```
 
-- Run only the smallest scoped checks that validate the changed behavior.
-- Prefer targeted unit tests (`go test -run <TestName> -tags=intest,deadlock`).
-- Avoid slow sweeps by default (`make lint`, package-wide runs, `realtikvtest`).
+Avoid `make lint`, package-wide runs, and `realtikvtest` during WIP.
 
-### `Ready` (completion gate)
+## `Ready` (completion gate)
 
-Use when claiming task completion or PR readiness.
-Mandatory trigger phrases are defined in `AGENTS.md` -> `Quick Decision Matrix`.
+Required before claiming "done", "fixed", "all tests pass", or "ready for review".
 
-1. Map changed paths to required test surfaces via `AGENTS.md` -> `Task -> Validation Matrix`.
-2. Run minimum required targeted tests for those surfaces.
-3. If code changed, run `make lint`.
-4. Follow `AGENTS.md` -> `Agent Output Contract` for final reporting.
+1. **Map changes to test surfaces** using `AGENTS.md` -> `Task -> Validation Matrix`.
+   Common mappings:
+   - `pkg/planner/**` -> planner unit tests + update rule testdata
+   - `pkg/executor/**` -> unit tests + integration tests (`tests/integrationtest`)
+   - `pkg/ddl/**` -> DDL unit/integration tests
+   - `tests/integrationtest/t/**` -> record and verify result files
+2. **Run targeted tests** for each matched surface.
+3. **Run `make lint`** if any Go code changed.
+4. **If lint or tests fail**: fix the issue, re-run the failing command, verify it passes.
+5. **Report** per `AGENTS.md` -> `Agent Output Contract`: files changed, profile used, risks, exact commands run, what was not verified.
 
-### `Heavy` (explicitly required)
+## `Heavy` (explicitly required)
 
 Use only when scope or user request requires expensive checks.
 
 - Examples: CI reproduction, broad refactor confidence, change scope requiring RealTiKV.
 - Never run `make bazel_lint_changed` unless the user explicitly requests it.
+- For RealTiKV lifecycle details see `.agents/skills/tidb-realtikv-runner`.


### PR DESCRIPTION
Hey @hawkingrei 👋

40k stars and a full agent skill suite baked right into the repo, that's something you don't see often. The three-tier verification profile system (WIP, Ready, Heavy) is a really smart way to keep CI costs down while still catching issues early.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| tidb-verify-profile | 61% | 100% | +39% |


`tidb-verify-profile` had the most headroom so I focused there.

Changes made:

- rewrote the frontmatter description with concrete actions (unit tests, lint, integration tests, RealTiKV) and natural trigger terms (test, lint, pre-commit, verification)
- added copy-paste-ready bash commands for the WIP profile including failpoint detection via `rg`
- inlined common package-to-test-surface mappings in the Ready profile so the skill is more self-contained
- added a feedback loop step (fix, re-run, verify) for when lint or tests fail during the Ready gate
- added a cross-reference to `tidb-realtikv-runner` in the Heavy profile for progressive disclosure

I also stress-tested your `tidb-test-diff-triage` skill against a few [real-world task evals](https://tessl.io/registry/skills/github/pingcap/tidb/tidb-verify-profile/evals) and it held up really well on failpoint-related diff triage after a rebase. Kudos for that.

quick honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

If you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me @rohan-tessl, if you hit any snags.

Thanks in advance 🙏
