### PR TITLE
session: backfill OPERATE VIEW privilege for SUPER users during bootstrap upgrade

### DIFF
--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -3461,6 +3461,7 @@ func upgradeToVer228(s sessiontypes.Session, ver int64) {
 	doReentrantDDL(s, "ALTER TABLE mysql.db ADD COLUMN `Operate_view_priv` ENUM('N','Y') NOT NULL DEFAULT 'N' AFTER `Show_view_priv`", infoschema.ErrColumnExists)
 	doReentrantDDL(s, "ALTER TABLE mysql.tables_priv MODIFY COLUMN Table_priv SET('Select','Insert','Update','Delete','Create','Drop','Grant','Index','Alter','Create View','Show View','Operate View','Trigger','References')")
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mlog_purge_hist ADD COLUMN `PURGE_CUTOFF_TSO` bigint unsigned DEFAULT NULL AFTER `PURGE_STATUS`", infoschema.ErrColumnExists)
+	mustExecute(s, "UPDATE HIGH_PRIORITY mysql.user SET Operate_view_priv='Y' WHERE Super_priv='Y'")
 }
 
 // initGlobalVariableIfNotExists initialize a global variable with specific val if it does not exist.

--- a/pkg/session/bootstraptest/mview_systable_test.go
+++ b/pkg/session/bootstraptest/mview_systable_test.go
@@ -647,6 +647,10 @@ func TestUpgradeToVer228MaterializedViewLogPurgeCutoffTSO(t *testing.T) {
 		KEY idx_purge_time (PURGE_TIME),
 		KEY idx_purge_status (PURGE_STATUS, PURGE_TIME))`)
 	session.MustExec(t, seV227, "commit")
+	session.MustExec(t, seV227, "create user 'v228_super'@'%'")
+	session.MustExec(t, seV227, "create user 'v228_normal'@'%'")
+	session.MustExec(t, seV227, "update mysql.user set Super_priv='Y', Operate_view_priv='N' where User='v228_super' and Host='%'")
+	session.MustExec(t, seV227, "update mysql.user set Super_priv='N', Operate_view_priv='N' where User='v228_normal' and Host='%'")
 
 	session.UnsetStoreBootstrapped(store.UUID())
 	ver, err := session.GetBootstrapVersion(seV227)
@@ -661,4 +665,6 @@ func TestUpgradeToVer228MaterializedViewLogPurgeCutoffTSO(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='PURGE_CUTOFF_TSO'").
 		Check(testkit.Rows("bigint(20) unsigned"))
+	tk.MustQuery("select User, Operate_view_priv from mysql.user where User in ('v228_super', 'v228_normal') order by User").
+		Check(testkit.Rows("v228_normal N", "v228_super Y"))
 }


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

After upgrading to bootstrap version 228, existing users with `SUPER` privilege may not have the newly added `Operate_view_priv` global privilege. As a result, even `root` can fail to execute statements such as `GRANT OPERATE VIEW ON *.* ...` because granting a static privilege requires the grantor to already hold that privilege.

### What changed and how does it work?

This PR updates the v228 bootstrap upgrade path to backfill `Operate_view_priv='Y'` for existing users whose `Super_priv='Y'`.

It also extends the v228 upgrade test to verify that:

- a user with `Super_priv='Y'` gets `Operate_view_priv='Y'` after upgrade
- a normal user without `SUPER` keeps `Operate_view_priv='N'`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```sh
make failpoint-enable && (pushd pkg/session/bootstraptest >/dev/null && go test -run TestUpgradeToVer228MaterializedViewLogPurgeCutoffTSO -tags=intest,deadlock; rc=$?; popd >/dev/null; make failpoint-disable; exit $rc)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that existing SUPER users may lack the OPERATE VIEW privilege after upgrading.
```