### PR TITLE
import/add-index: use task runtime and sweep idle cross-keyspace runtimes

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -333,6 +333,7 @@ go_test(
         "//pkg/domain/affinity",
         "//pkg/domain/infosync",
         "//pkg/domain/serverinfo",
+        "//pkg/domain/sqlsvrapi/mock",
         "//pkg/dxf/framework/mock",
         "//pkg/dxf/framework/proto",
         "//pkg/dxf/framework/scheduler",

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/pkg/lightning/common"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
-	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/table"
 	"go.uber.org/zap"
 )
@@ -130,19 +129,8 @@ func (s *backfillDistExecutor) newBackfillStepExecutor(
 	jobMeta := &s.taskMeta.Job
 	ddlObj := s.d
 
-	store := s.TaskStore
-	sessPool := ddlObj.sessPool
-	taskKS := s.task.Keyspace
-	if ddlObj.store.GetKeyspace() != taskKS {
-		if err := s.GetTaskTable().WithNewSession(func(se sessionctx.Context) error {
-			svr := se.GetSQLServer()
-			sp, err := svr.GetKSSessPool(taskKS)
-			sessPool = sess.NewSessionPool(sp)
-			return err
-		}); err != nil {
-			return nil, err
-		}
-	}
+	store := s.TaskRuntime.Store()
+	sessPool := sess.NewSessionPool(s.TaskRuntime.SysSessionPool())
 	// TODO getTableByTxn is using DDL ctx which is never cancelled except when shutdown.
 	// we should move this operation out of GetStepExecutor, and put into Init.
 	_, tblIface, err := getTableByTxn(ddlObj.ctx, store, jobMeta.SchemaID, jobMeta.TableID)

--- a/pkg/ddl/backfilling_dist_scheduler.go
+++ b/pkg/ddl/backfilling_dist_scheduler.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ingestor/simplesst"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/meta/autoid"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/objstore"
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
@@ -141,7 +142,8 @@ func (sch *LitBackfillScheduler) OnNextSubtasksBatch(
 	}
 	job := &backfillMeta.Job
 	logger.Info("on next subtasks batch")
-	tbl, err := getUserTableFromTaskStore(ctx, sch.d, sch.TaskStore, job)
+	store := sch.TaskRuntime.Store()
+	tbl, err := getUserTableFromTaskStore(ctx, store, job)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -151,7 +153,7 @@ func (sch *LitBackfillScheduler) OnNextSubtasksBatch(
 		// TODO(tangenta): use available disk during adding index.
 		availableDisk := sch.nodeRes.GetTaskDiskResource(&task.TaskBase, vardef.DDLDiskQuota.Load())
 		logger.Info("available local disk space resource", zap.String("size", units.BytesSize(float64(availableDisk))))
-		return generateReadIndexPlan(ctx, sch.d, sch.TaskStore, tbl, job, sch.GlobalSort, nodeCnt, logger)
+		return generateReadIndexPlan(ctx, sch.d, store, tbl, job, sch.GlobalSort, nodeCnt, logger)
 	case proto.BackfillStepMergeSort:
 		metaBytes, err2 := generateMergeSortPlan(ctx, taskHandle, task, nodeCnt, backfillMeta.CloudStorageURI, logger)
 		if err2 != nil {
@@ -174,7 +176,7 @@ func (sch *LitBackfillScheduler) OnNextSubtasksBatch(
 			})
 			return generateGlobalSortIngestPlan(
 				ctx,
-				sch.TaskStore.(kv.StorageWithPD),
+				store.(kv.StorageWithPD),
 				taskHandle,
 				task,
 				backfillMeta.CloudStorageURI,
@@ -182,7 +184,7 @@ func (sch *LitBackfillScheduler) OnNextSubtasksBatch(
 		}
 		return nil, nil
 	case proto.BackfillStepMergeTempIndex:
-		return generateMergeTempIndexPlan(ctx, sch.TaskStore, tbl, nodeCnt, backfillMeta.EleIDs, logger)
+		return generateMergeTempIndexPlan(ctx, store, tbl, nodeCnt, backfillMeta.EleIDs, logger)
 	default:
 		return nil, nil
 	}
@@ -190,7 +192,6 @@ func (sch *LitBackfillScheduler) OnNextSubtasksBatch(
 
 func getUserTableFromTaskStore(
 	ctx context.Context,
-	d *ddl,
 	taskStore kv.Storage,
 	job *model.Job,
 ) (table.Table, error) {
@@ -198,7 +199,8 @@ func getUserTableFromTaskStore(
 	if err != nil {
 		return nil, err
 	}
-	tbl, err := getTable(d.ddlCtx.getAutoIDRequirement(), job.SchemaID, tblInfo)
+	// we don't touch table data during add-index, a fake Allocators is enough.
+	tbl, err := table.TableFromMeta(autoid.NewAllocators(tblInfo.SepAutoInc()), tblInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ddl/backfilling_dist_scheduler_test.go
+++ b/pkg/ddl/backfilling_dist_scheduler_test.go
@@ -27,27 +27,45 @@ import (
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
+	sqlsvrapimock "github.com/pingcap/tidb/pkg/domain/sqlsvrapi/mock"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/scheduler"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/ingestor/globalsort"
 	"github.com/pingcap/tidb/pkg/ingestor/simplesst"
 	"github.com/pingcap/tidb/pkg/keyspace"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/testkit"
+	tidbutil "github.com/pingcap/tidb/pkg/util"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/util"
+	"go.uber.org/mock/gomock"
 )
 
+func newBackfillingSchedulerTestRuntime(ctrl *gomock.Controller, store kv.Storage, sessPool tidbutil.DestroyableSessionPool) *sqlsvrapimock.MockRuntime {
+	runtime := sqlsvrapimock.NewMockRuntime(ctrl)
+	runtime.EXPECT().Store().Return(store).AnyTimes()
+	runtime.EXPECT().SysSessionPool().Return(sessPool).AnyTimes()
+	return runtime
+}
+
+func backfillingSchedulerParamForTest(ctrl *gomock.Controller, store kv.Storage, sessPool tidbutil.DestroyableSessionPool) scheduler.Param {
+	return scheduler.Param{TaskRuntime: newBackfillingSchedulerTestRuntime(ctrl, store, sessPool)}
+}
+
 func TestBackfillingSchedulerLocalMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	sch, err := ddl.NewBackfillingSchedulerForTest(dom.DDL())
 	require.NoError(t, err)
 	sch.(*ddl.LitBackfillScheduler).BaseScheduler = &scheduler.BaseScheduler{
-		Param: scheduler.Param{TaskStore: store},
+		Param: backfillingSchedulerParamForTest(ctrl, store, dom.SysSessionPool()),
 	}
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -149,6 +167,9 @@ func TestCalculateRegionBatch(t *testing.T) {
 }
 
 func TestBackfillingSchedulerGlobalSortMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	// init test env.
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
@@ -176,7 +197,7 @@ func TestBackfillingSchedulerGlobalSortMode(t *testing.T) {
 	require.NoError(t, err)
 	ext.(*ddl.LitBackfillScheduler).GlobalSort = true
 	ext.(*ddl.LitBackfillScheduler).BaseScheduler = &scheduler.BaseScheduler{
-		Param: scheduler.Param{TaskStore: store},
+		Param: backfillingSchedulerParamForTest(ctrl, store, dom.SysSessionPool()),
 	}
 	sch.Extension = ext
 

--- a/pkg/domain/crossks/cross_ks.go
+++ b/pkg/domain/crossks/cross_ks.go
@@ -357,6 +357,8 @@ func (m *Manager) release(targetKS string, holderID string) {
 // callers to use Acquire instead of GetOrCreate directly.
 func (m *Manager) RunSystemKSGCLoop(ctx context.Context) {
 	interval := crossKSRuntimeSweepInterval
+	idleTimeout := crossKSRuntimeIdleTimeout
+	failpoint.InjectCall("mockRuntimeGCLoopConfig", &interval, &idleTimeout)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -365,7 +367,7 @@ func (m *Manager) RunSystemKSGCLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			m.sweepIdleRuntimes(crossKSRuntimeIdleTimeout)
+			m.sweepIdleRuntimes(idleTimeout)
 		}
 	}
 }

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -853,6 +853,13 @@ func (do *Domain) Start(startMode ddl.StartMode) error {
 			return err
 		}
 	}
+	// only SYSTEM ks need this GC loop, user keyspace is only allowed to access
+	// SYSTEM ks, we can keep it alive.
+	if kv.IsSystemKS(do.store) {
+		do.wg.Run(func() {
+			do.crossKSSessMgr.RunSystemKSGCLoop(do.ctx)
+		}, "crossKSSessMgrGCLoop")
+	}
 
 	return nil
 }

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -853,8 +853,13 @@ func (do *Domain) Start(startMode ddl.StartMode) error {
 			return err
 		}
 	}
-	// only SYSTEM ks need this GC loop, user keyspace is only allowed to access
-	// SYSTEM ks, we can keep it alive.
+	// Only the SYSTEM keyspace domain runs this GC loop: user-keyspace domains
+	// only access the long-lived SYSTEM keyspace runtime, which is never evicted
+	// here.
+	// there are still calls to GetKSInfoCache/GetKSStore without holder ID, but
+	// they are only used in the path of creating session when the runtime is
+	// Acquired with a holder ID, so it's ok. we cannot remove those calls now
+	// as explained in the comments of GetKSStore.
 	if kv.IsSystemKS(do.store) {
 		do.wg.Run(func() {
 			do.crossKSSessMgr.RunSystemKSGCLoop(do.ctx)

--- a/pkg/domain/sqlsvrapi/mock/server_mock.go
+++ b/pkg/domain/sqlsvrapi/mock/server_mock.go
@@ -13,9 +13,7 @@ import (
 	reflect "reflect"
 
 	sqlsvrapi "github.com/pingcap/tidb/pkg/domain/sqlsvrapi"
-	kv "github.com/pingcap/tidb/pkg/kv"
 	owner "github.com/pingcap/tidb/pkg/owner"
-	util "github.com/pingcap/tidb/pkg/util"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -74,36 +72,6 @@ func (m *MockServer) GetDDLOwnerMgr() owner.Manager {
 func (mr *MockServerMockRecorder) GetDDLOwnerMgr() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDDLOwnerMgr", reflect.TypeOf((*MockServer)(nil).GetDDLOwnerMgr))
-}
-
-// GetKSSessPool mocks base method.
-func (m *MockServer) GetKSSessPool(arg0 string) (util.DestroyableSessionPool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetKSSessPool", arg0)
-	ret0, _ := ret[0].(util.DestroyableSessionPool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetKSSessPool indicates an expected call of GetKSSessPool.
-func (mr *MockServerMockRecorder) GetKSSessPool(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKSSessPool", reflect.TypeOf((*MockServer)(nil).GetKSSessPool), arg0)
-}
-
-// GetKSStore mocks base method.
-func (m *MockServer) GetKSStore(arg0 string) (kv.Storage, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetKSStore", arg0)
-	ret0, _ := ret[0].(kv.Storage)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetKSStore indicates an expected call of GetKSStore.
-func (mr *MockServerMockRecorder) GetKSStore(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKSStore", reflect.TypeOf((*MockServer)(nil).GetKSStore), arg0)
 }
 
 // GetRuntime mocks base method.

--- a/pkg/domain/sqlsvrapi/server.go
+++ b/pkg/domain/sqlsvrapi/server.go
@@ -45,7 +45,5 @@ type Server interface {
 	// The acquired handle should be released after use.
 	// this is only used in next-gen to access keyspace other than current.
 	AcquireKSRuntime(targetKS string, holderID string) (KSRuntimeHandle, error)
-	GetKSSessPool(targetKS string) (util.DestroyableSessionPool, error)
-	GetKSStore(targetKS string) (store kv.Storage, err error)
 	GetDDLOwnerMgr() owner.Manager
 }

--- a/pkg/dxf/framework/scheduler/interface.go
+++ b/pkg/dxf/framework/scheduler/interface.go
@@ -187,9 +187,10 @@ type Param struct {
 }
 
 // NewParamForTest creates a new Param for test.
-func NewParamForTest(taskMgr TaskManager) Param {
+func NewParamForTest(taskMgr TaskManager, runtime sqlsvrapi.Runtime) Param {
 	return Param{
-		taskMgr: taskMgr,
+		taskMgr:     taskMgr,
+		TaskRuntime: runtime,
 	}
 }
 

--- a/pkg/dxf/framework/scheduler/interface.go
+++ b/pkg/dxf/framework/scheduler/interface.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/execute"
-	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/util/syncutil"
 )
@@ -185,15 +184,12 @@ type Param struct {
 	nodeRes        *proto.NodeResource
 	// TaskRuntime is the non-owning task keyspace runtime view. Managers own its release.
 	TaskRuntime sqlsvrapi.Runtime
-	// TaskStore is kept temporarily while DXF task implementations migrate to TaskRuntime.
-	TaskStore kv.Storage
 }
 
 // NewParamForTest creates a new Param for test.
-func NewParamForTest(taskMgr TaskManager, store kv.Storage) Param {
+func NewParamForTest(taskMgr TaskManager) Param {
 	return Param{
-		taskMgr:   taskMgr,
-		TaskStore: store,
+		taskMgr: taskMgr,
 	}
 }
 

--- a/pkg/dxf/framework/scheduler/scheduler_manager.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager.go
@@ -369,7 +369,6 @@ func (sm *Manager) startScheduler(basicTask *proto.TaskBase, allocateSlots bool,
 		allocatedSlots: allocateSlots,
 		nodeRes:        sm.nodeRes,
 		TaskRuntime:    taskRuntime,
-		TaskStore:      taskRuntime.Store(),
 	})
 	if err = scheduler.Init(); err != nil {
 		sm.logger.Error("init scheduler failed", zap.Error(err))

--- a/pkg/dxf/framework/taskexecutor/manager.go
+++ b/pkg/dxf/framework/taskexecutor/manager.go
@@ -352,7 +352,6 @@ func (m *Manager) startTaskExecutor(taskBase *proto.TaskBase) (executorStarted b
 		nodeRc:      m.getNodeResource(),
 		execID:      m.id,
 		TaskRuntime: taskRuntime,
-		TaskStore:   taskRuntime.Store(),
 	})
 	err = executor.Init(m.ctx)
 	if err != nil {

--- a/pkg/dxf/framework/taskexecutor/task_executor.go
+++ b/pkg/dxf/framework/taskexecutor/task_executor.go
@@ -35,7 +35,6 @@ import (
 	"github.com/pingcap/tidb/pkg/dxf/framework/scheduler"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/execute"
-	"github.com/pingcap/tidb/pkg/kv"
 	llog "github.com/pingcap/tidb/pkg/lightning/log"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/backoff"
@@ -78,18 +77,15 @@ type Param struct {
 	execID string
 	// TaskRuntime is the non-owning task keyspace runtime view. Managers own its release.
 	TaskRuntime sqlsvrapi.Runtime
-	// TaskStore is kept temporarily while DXF task implementations migrate to TaskRuntime.
-	TaskStore kv.Storage
 }
 
 // NewParamForTest creates a new Param for test.
-func NewParamForTest(taskTable TaskTable, slotMgr *slotManager, nodeRc *proto.NodeResource, execID string, store kv.Storage) Param {
+func NewParamForTest(taskTable TaskTable, slotMgr *slotManager, nodeRc *proto.NodeResource, execID string) Param {
 	return Param{
 		taskTable: taskTable,
 		slotMgr:   slotMgr,
 		nodeRc:    nodeRc,
 		execID:    execID,
-		TaskStore: store,
 	}
 }
 

--- a/pkg/dxf/framework/taskexecutor/task_executor_testkit_test.go
+++ b/pkg/dxf/framework/taskexecutor/task_executor_testkit_test.go
@@ -56,7 +56,7 @@ func runOneTask(ctx context.Context, t *testing.T, mgr *storage.TaskManager, tas
 	require.NoError(t, err)
 	factory := taskexecutor.GetTaskExecutorFactory(task.Type)
 	require.NotNil(t, factory)
-	executor := factory(ctx, task, taskexecutor.NewParamForTest(mgr, nil, proto.NodeResourceForTest, ":4000", nil))
+	executor := factory(ctx, task, taskexecutor.NewParamForTest(mgr, nil, proto.NodeResourceForTest, ":4000"))
 	executor.Run()
 	checkSubtasks(proto.StepOne, proto.SubtaskStateSucceed)
 	// 2. stepTwo

--- a/pkg/dxf/importinto/BUILD.bazel
+++ b/pkg/dxf/importinto/BUILD.bazel
@@ -119,6 +119,7 @@ go_test(
         "//pkg/domain/serverinfo",
         "//pkg/domain/sqlsvrapi/mock",
         "//pkg/dxf/framework/handle",
+        "//pkg/dxf/framework/mock",
         "//pkg/dxf/framework/planner",
         "//pkg/dxf/framework/proto",
         "//pkg/dxf/framework/scheduler",

--- a/pkg/dxf/importinto/scheduler.go
+++ b/pkg/dxf/importinto/scheduler.go
@@ -277,11 +277,7 @@ func (sch *importScheduler) unregisterTask(ctx context.Context, task *proto.Task
 }
 
 func (sch *importScheduler) checkImportTableEmpty(ctx context.Context, taskMeta *TaskMeta) error {
-	taskMgr, err := sch.getTaskMgrForAccessingImportJob()
-	if err != nil {
-		return err
-	}
-	return taskMgr.WithNewTxn(ctx, func(se sessionctx.Context) error {
+	return sch.WithNewTxn(ctx, func(se sessionctx.Context) error {
 		isEmpty, err2 := ddl.CheckImportIntoTableIsEmpty(sch.TaskRuntime.Store(), se, taskMeta.Plan.TableInfo)
 		if err2 != nil {
 			return err2

--- a/pkg/dxf/importinto/scheduler.go
+++ b/pkg/dxf/importinto/scheduler.go
@@ -256,7 +256,7 @@ func (sch *importScheduler) switchTiKVMode(ctx context.Context, task *proto.Task
 		logger.Warn("get tikv mode switcher failed", zap.Error(err))
 		return
 	}
-	pdHTTPCli := sch.TaskStore.(kv.StorageWithPD).GetPDHTTPClient()
+	pdHTTPCli := sch.TaskRuntime.Store().(kv.StorageWithPD).GetPDHTTPClient()
 	switcher := importer.NewTiKVModeSwitcher(tls, pdHTTPCli, logger)
 
 	switcher.ToImportMode(ctx)
@@ -264,7 +264,7 @@ func (sch *importScheduler) switchTiKVMode(ctx context.Context, task *proto.Task
 }
 
 func (sch *importScheduler) registerTask(ctx context.Context, task *proto.Task) {
-	val, _ := sch.taskInfoMap.LoadOrStore(task.ID, &taskInfo{store: sch.TaskStore, taskID: task.ID, logger: sch.GetLogger()})
+	val, _ := sch.taskInfoMap.LoadOrStore(task.ID, &taskInfo{store: sch.TaskRuntime.Store(), taskID: task.ID, logger: sch.GetLogger()})
 	info := val.(*taskInfo)
 	info.register(ctx)
 }
@@ -277,8 +277,12 @@ func (sch *importScheduler) unregisterTask(ctx context.Context, task *proto.Task
 }
 
 func (sch *importScheduler) checkImportTableEmpty(ctx context.Context, taskMeta *TaskMeta) error {
-	return sch.WithNewTxn(ctx, func(se sessionctx.Context) error {
-		isEmpty, err2 := ddl.CheckImportIntoTableIsEmpty(sch.TaskStore, se, taskMeta.Plan.TableInfo)
+	taskMgr, err := sch.getTaskMgrForAccessingImportJob()
+	if err != nil {
+		return err
+	}
+	return taskMgr.WithNewTxn(ctx, func(se sessionctx.Context) error {
+		isEmpty, err2 := ddl.CheckImportIntoTableIsEmpty(sch.TaskRuntime.Store(), se, taskMeta.Plan.TableInfo)
 		if err2 != nil {
 			return err2
 		}
@@ -339,7 +343,7 @@ func (sch *importScheduler) OnPrepare(ctx context.Context, _ storage.TaskHandle,
 	if err = controller.CheckImportDataSize(); err != nil {
 		return err
 	}
-	if err = controller.CalResourceParams(ctx, sch.TaskStore.GetCodec().GetKeyspace()); err != nil {
+	if err = controller.CalResourceParams(ctx, sch.TaskRuntime.Store().GetCodec().GetKeyspace()); err != nil {
 		return err
 	}
 	if err = sch.updatePreparedJobInfo(ctx, sch.GetLogger(), taskMeta.JobID, controller.Plan); err != nil {
@@ -515,7 +519,7 @@ func (sch *importScheduler) OnNextSubtasksBatch(
 		GlobalSort:           sch.GlobalSort,
 		NextTaskStep:         nextStep,
 		ExecuteNodesCnt:      nodeCnt,
-		Store:                sch.TaskStore,
+		Store:                sch.TaskRuntime.Store(),
 		ThreadCnt:            task.GetRuntimeSlots(),
 	}
 	logicalPlan := &LogicalPlan{Logger: logger}
@@ -652,7 +656,7 @@ func (sch *importScheduler) switchTiKV2NormalMode(ctx context.Context, task *pro
 		logger.Warn("get tikv mode switcher failed", zap.Error(err))
 		return
 	}
-	pdHTTPCli := sch.TaskStore.(kv.StorageWithPD).GetPDHTTPClient()
+	pdHTTPCli := sch.TaskRuntime.Store().(kv.StorageWithPD).GetPDHTTPClient()
 	switcher := importer.NewTiKVModeSwitcher(tls, pdHTTPCli, logger)
 
 	switcher.ToNormalMode(ctx)
@@ -905,17 +909,8 @@ func (sch *importScheduler) getTaskMgrForAccessingImportJob() (scheduler.TaskMan
 		return sch.taskKSTaskMgr, nil
 	}
 
-	if kv.IsUserKS(sch.TaskStore) {
-		var taskKSSessPool util.SessionPool
-		taskKS := sch.GetTask().Keyspace
-		if err := sch.BaseScheduler.WithNewSession(func(se sessionctx.Context) error {
-			var err2 error
-			taskKSSessPool, err2 = se.GetSQLServer().GetKSSessPool(taskKS)
-			return err2
-		}); err != nil {
-			return nil, errors.Annotatef(errGetCrossKSSessionPool, "keyspace %s", taskKS)
-		}
-		sch.taskKSTaskMgr = storage.NewTaskManager(taskKSSessPool)
+	if kv.IsUserKS(sch.TaskRuntime.Store()) {
+		sch.taskKSTaskMgr = storage.NewTaskManager(sch.TaskRuntime.SysSessionPool())
 	} else {
 		sch.taskKSTaskMgr = sch.GetTaskMgr()
 	}

--- a/pkg/dxf/importinto/scheduler_test.go
+++ b/pkg/dxf/importinto/scheduler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	sqlsvrapimock "github.com/pingcap/tidb/pkg/domain/sqlsvrapi/mock"
+	"github.com/pingcap/tidb/pkg/dxf/framework/mock"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/scheduler"
 	"github.com/pingcap/tidb/pkg/executor/importer"
@@ -69,7 +70,6 @@ func newSchedulerParamForTest(t *testing.T, store kv.Storage) scheduler.Param {
 
 	return scheduler.Param{
 		TaskRuntime: newMockRuntime(ctrl, store, sePool),
-		TaskStore:   store,
 	}
 }
 
@@ -124,6 +124,9 @@ func (s *importIntoSuite) TestUpdateCurrentTask() {
 }
 
 func (s *importIntoSuite) TestSchedulerInit() {
+	ctrl := gomock.NewController(s.T())
+	defer ctrl.Finish()
+
 	meta := TaskMeta{
 		Plan: importer.Plan{
 			CloudStorageURI: "",
@@ -165,6 +168,46 @@ func (s *importIntoSuite) TestSchedulerInit() {
 		}
 		s.ErrorContains(sch.Init(), "store keyspace mismatch with task")
 	}
+}
+
+func newImportSchedulerTestRuntime(ctrl *gomock.Controller, store kv.Storage, sessPool tidbutil.DestroyableSessionPool) *sqlsvrapimock.MockRuntime {
+	runtime := sqlsvrapimock.NewMockRuntime(ctrl)
+	runtime.EXPECT().Store().Return(store).AnyTimes()
+	runtime.EXPECT().SysSessionPool().Return(sessPool).AnyTimes()
+	return runtime
+}
+
+func newImportSchedulerParamForTest(ctrl *gomock.Controller, taskMgr scheduler.TaskManager, store kv.Storage, sessPool tidbutil.DestroyableSessionPool) scheduler.Param {
+	param := scheduler.NewParamForTest(taskMgr)
+	param.TaskRuntime = newImportSchedulerTestRuntime(ctrl, store, sessPool)
+	return param
+}
+
+func (s *importIntoSuite) TestGetTaskMgrForAccessingImportJobUsesTaskRuntime() {
+	if !kerneltype.IsNextGen() {
+		s.T().Skip("TaskRuntime is used only for nextgen user keyspace tasks")
+	}
+	ctrl := gomock.NewController(s.T())
+	defer ctrl.Finish()
+	taskMgr := mock.NewMockTaskManager(ctrl)
+
+	sessPool := tidbutil.NewSessionPool(1, func() (pools.Resource, error) {
+		return nil, errors.New("unexpected session pool use")
+	}, nil, nil, nil)
+	s.T().Cleanup(sessPool.Close)
+
+	taskKS := "user_keyspace"
+	param := newImportSchedulerParamForTest(ctrl, taskMgr, &StoreWithKS{ks: taskKS}, sessPool)
+	sch := importScheduler{
+		BaseScheduler: scheduler.NewBaseScheduler(context.Background(), &proto.Task{
+			TaskBase: proto.TaskBase{Keyspace: taskKS},
+		}, param),
+	}
+
+	got, err := sch.getTaskMgrForAccessingImportJob()
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), got)
+	require.Same(s.T(), got, sch.taskKSTaskMgr)
 }
 
 func (s *importIntoSuite) TestGetNextStep() {

--- a/pkg/dxf/importinto/scheduler_test.go
+++ b/pkg/dxf/importinto/scheduler_test.go
@@ -57,20 +57,27 @@ func newMockRuntime(
 	return runtime
 }
 
-func newSchedulerParamForTest(t *testing.T, store kv.Storage) scheduler.Param {
+func newSchedulerParamForTest(
+	t *testing.T,
+	taskMgr scheduler.TaskManager,
+	store kv.Storage,
+	sePool tidbutil.DestroyableSessionPool,
+) scheduler.Param {
 	t.Helper()
 
 	ctrl := gomock.NewController(t)
-	sePool := tidbutil.NewSessionPool(1, func() (pools.Resource, error) {
-		se := utilmock.NewContext()
-		se.Store = store
-		return se, nil
-	}, nil, nil, nil)
-	t.Cleanup(sePool.Close)
-
-	return scheduler.Param{
-		TaskRuntime: newMockRuntime(ctrl, store, sePool),
+	if sePool == nil {
+		sePool = tidbutil.NewSessionPool(1, func() (pools.Resource, error) {
+			se := utilmock.NewContext()
+			se.Store = store
+			return se, nil
+		}, nil, nil, nil)
+		t.Cleanup(sePool.Close)
 	}
+
+	param := scheduler.NewParamForTest(taskMgr)
+	param.TaskRuntime = newMockRuntime(ctrl, store, sePool)
+	return param
 }
 
 func (s *importIntoSuite) enableFailPoint(path, term string) {
@@ -142,7 +149,7 @@ func (s *importIntoSuite) TestSchedulerInit() {
 		BaseScheduler: scheduler.NewBaseScheduler(context.Background(), &proto.Task{
 			TaskBase: proto.TaskBase{Keyspace: taskKS},
 			Meta:     bytes,
-		}, newSchedulerParamForTest(s.T(), &StoreWithKS{ks: taskKS})),
+		}, newSchedulerParamForTest(s.T(), nil, &StoreWithKS{ks: taskKS}, nil)),
 	}
 	s.NoError(sch.Init())
 	s.False(sch.Extension.(*importScheduler).GlobalSort)
@@ -154,7 +161,7 @@ func (s *importIntoSuite) TestSchedulerInit() {
 		BaseScheduler: scheduler.NewBaseScheduler(context.Background(), &proto.Task{
 			TaskBase: proto.TaskBase{Keyspace: taskKS},
 			Meta:     bytes,
-		}, newSchedulerParamForTest(s.T(), &StoreWithKS{ks: taskKS})),
+		}, newSchedulerParamForTest(s.T(), nil, &StoreWithKS{ks: taskKS}, nil)),
 	}
 	s.NoError(sch.Init())
 	s.True(sch.Extension.(*importScheduler).GlobalSort)
@@ -164,23 +171,10 @@ func (s *importIntoSuite) TestSchedulerInit() {
 			BaseScheduler: scheduler.NewBaseScheduler(context.Background(), &proto.Task{
 				TaskBase: proto.TaskBase{Keyspace: taskKS},
 				Meta:     bytes,
-			}, newSchedulerParamForTest(s.T(), &StoreWithKS{})),
+			}, newSchedulerParamForTest(s.T(), nil, &StoreWithKS{}, nil)),
 		}
 		s.ErrorContains(sch.Init(), "store keyspace mismatch with task")
 	}
-}
-
-func newImportSchedulerTestRuntime(ctrl *gomock.Controller, store kv.Storage, sessPool tidbutil.DestroyableSessionPool) *sqlsvrapimock.MockRuntime {
-	runtime := sqlsvrapimock.NewMockRuntime(ctrl)
-	runtime.EXPECT().Store().Return(store).AnyTimes()
-	runtime.EXPECT().SysSessionPool().Return(sessPool).AnyTimes()
-	return runtime
-}
-
-func newImportSchedulerParamForTest(ctrl *gomock.Controller, taskMgr scheduler.TaskManager, store kv.Storage, sessPool tidbutil.DestroyableSessionPool) scheduler.Param {
-	param := scheduler.NewParamForTest(taskMgr)
-	param.TaskRuntime = newImportSchedulerTestRuntime(ctrl, store, sessPool)
-	return param
 }
 
 func (s *importIntoSuite) TestGetTaskMgrForAccessingImportJobUsesTaskRuntime() {
@@ -197,7 +191,7 @@ func (s *importIntoSuite) TestGetTaskMgrForAccessingImportJobUsesTaskRuntime() {
 	s.T().Cleanup(sessPool.Close)
 
 	taskKS := "user_keyspace"
-	param := newImportSchedulerParamForTest(ctrl, taskMgr, &StoreWithKS{ks: taskKS}, sessPool)
+	param := newSchedulerParamForTest(s.T(), taskMgr, &StoreWithKS{ks: taskKS}, sessPool)
 	sch := importScheduler{
 		BaseScheduler: scheduler.NewBaseScheduler(context.Background(), &proto.Task{
 			TaskBase: proto.TaskBase{Keyspace: taskKS},

--- a/pkg/dxf/importinto/scheduler_test.go
+++ b/pkg/dxf/importinto/scheduler_test.go
@@ -75,8 +75,7 @@ func newSchedulerParamForTest(
 		t.Cleanup(sePool.Close)
 	}
 
-	param := scheduler.NewParamForTest(taskMgr)
-	param.TaskRuntime = newMockRuntime(ctrl, store, sePool)
+	param := scheduler.NewParamForTest(taskMgr, newMockRuntime(ctrl, store, sePool))
 	return param
 }
 
@@ -131,9 +130,6 @@ func (s *importIntoSuite) TestUpdateCurrentTask() {
 }
 
 func (s *importIntoSuite) TestSchedulerInit() {
-	ctrl := gomock.NewController(s.T())
-	defer ctrl.Finish()
-
 	meta := TaskMeta{
 		Plan: importer.Plan{
 			CloudStorageURI: "",

--- a/pkg/dxf/importinto/scheduler_testkit_test.go
+++ b/pkg/dxf/importinto/scheduler_testkit_test.go
@@ -68,12 +68,6 @@ func newImportTestRuntime(ctrl *gomock.Controller, store kv.Storage, sessPool *p
 	return runtime
 }
 
-func importSchedulerParamForTest(ctrl *gomock.Controller, taskMgr scheduler.TaskManager, store kv.Storage, sessPool *pools.ResourcePool) scheduler.Param {
-	param := scheduler.NewParamForTest(taskMgr)
-	param.TaskRuntime = newImportTestRuntime(ctrl, store, sessPool)
-	return param
-}
-
 func TestSchedulerExtLocalSort(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -131,7 +125,8 @@ func TestSchedulerExtLocalSort(t *testing.T) {
 
 	// to import stage, job should be running
 	d := sch.MockScheduler(task)
-	ext := importinto.NewImportSchedulerForTest(false, task, importSchedulerParamForTest(ctrl, manager, store, pool))
+	var taskMgr scheduler.TaskManager = manager
+	ext := importinto.NewImportSchedulerForTest(false, task, scheduler.NewParamForTest(taskMgr, newImportTestRuntime(ctrl, store, pool)))
 	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
@@ -343,7 +338,8 @@ func TestSchedulerPrepareEnabledJobTransitionsFromPreparingToFirstBusinessPhase(
 	)
 	require.NoError(t, err)
 	d := sch.MockScheduler(task)
-	ext := importinto.NewImportSchedulerForTest(true, task, importSchedulerParamForTest(ctrl, mgr, store, pool))
+	var taskMgr scheduler.TaskManager = mgr
+	ext := importinto.NewImportSchedulerForTest(true, task, scheduler.NewParamForTest(taskMgr, newImportTestRuntime(ctrl, store, pool)))
 
 	require.NoError(t, ext.OnPrepare(ctx, d, task))
 	gotJobInfo, err := importer.GetJob(ctx, conn, jobID, "root", true)
@@ -439,7 +435,8 @@ func TestSchedulerOnDoneCancelResetsTableMode(t *testing.T) {
 		Error: errors.New("cancelled by user"),
 	}
 
-	ext := importinto.NewImportSchedulerForTest(false, task, importSchedulerParamForTest(ctrl, mgr, store, pool))
+	var taskMgr scheduler.TaskManager = mgr
+	ext := importinto.NewImportSchedulerForTest(false, task, scheduler.NewParamForTest(taskMgr, newImportTestRuntime(ctrl, store, pool)))
 	require.NoError(t, ext.OnDone(ctx, nil, task))
 
 	tbl, err = dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
@@ -536,7 +533,8 @@ func TestSchedulerExtGlobalSort(t *testing.T) {
 
 	// to encode-sort stage, job should be running
 	d := sch.MockScheduler(task)
-	ext := importinto.NewImportSchedulerForTest(true, task, importSchedulerParamForTest(ctrl, manager, store, pool))
+	var taskMgr scheduler.TaskManager = manager
+	ext := importinto.NewImportSchedulerForTest(true, task, scheduler.NewParamForTest(taskMgr, newImportTestRuntime(ctrl, store, pool)))
 	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 2)

--- a/pkg/dxf/importinto/scheduler_testkit_test.go
+++ b/pkg/dxf/importinto/scheduler_testkit_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/domain/serverinfo"
+	sqlsvrapimock "github.com/pingcap/tidb/pkg/domain/sqlsvrapi/mock"
 	"github.com/pingcap/tidb/pkg/dxf/framework/handle"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/scheduler"
@@ -36,16 +37,47 @@ import (
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/ingestor/globalsort"
 	"github.com/pingcap/tidb/pkg/ingestor/simplesst"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	tidbutil "github.com/pingcap/tidb/pkg/util"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/util"
+	"go.uber.org/mock/gomock"
 )
 
+type importTestSessionPool struct {
+	*pools.ResourcePool
+}
+
+func (p importTestSessionPool) Destroy(resource pools.Resource) {
+	resource.Close()
+}
+
+func newImportTestRuntime(ctrl *gomock.Controller, store kv.Storage, sessPool *pools.ResourcePool) *sqlsvrapimock.MockRuntime {
+	var destroyableSessPool tidbutil.DestroyableSessionPool
+	if sessPool != nil {
+		destroyableSessPool = importTestSessionPool{ResourcePool: sessPool}
+	}
+	runtime := sqlsvrapimock.NewMockRuntime(ctrl)
+	runtime.EXPECT().Store().Return(store).AnyTimes()
+	runtime.EXPECT().SysSessionPool().Return(destroyableSessPool).AnyTimes()
+	return runtime
+}
+
+func importSchedulerParamForTest(ctrl *gomock.Controller, taskMgr scheduler.TaskManager, store kv.Storage, sessPool *pools.ResourcePool) scheduler.Param {
+	param := scheduler.NewParamForTest(taskMgr)
+	param.TaskRuntime = newImportTestRuntime(ctrl, store, sessPool)
+	return param
+}
+
 func TestSchedulerExtLocalSort(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	pool := pools.NewResourcePool(func() (pools.Resource, error) {
@@ -99,7 +131,7 @@ func TestSchedulerExtLocalSort(t *testing.T) {
 
 	// to import stage, job should be running
 	d := sch.MockScheduler(task)
-	ext := importinto.NewImportSchedulerForTest(false, task, scheduler.NewParamForTest(manager, store))
+	ext := importinto.NewImportSchedulerForTest(false, task, importSchedulerParamForTest(ctrl, manager, store, pool))
 	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
@@ -198,6 +230,9 @@ func TestSchedulerExtLocalSort(t *testing.T) {
 }
 
 func TestSchedulerPrepareEnabledJobTransitionsFromPreparingToFirstBusinessPhase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	if !kerneltype.IsNextGen() {
 		t.Skip("prepare mode only applies in nextgen kernel")
 	}
@@ -308,7 +343,7 @@ func TestSchedulerPrepareEnabledJobTransitionsFromPreparingToFirstBusinessPhase(
 	)
 	require.NoError(t, err)
 	d := sch.MockScheduler(task)
-	ext := importinto.NewImportSchedulerForTest(true, task, scheduler.NewParamForTest(mgr, store))
+	ext := importinto.NewImportSchedulerForTest(true, task, importSchedulerParamForTest(ctrl, mgr, store, pool))
 
 	require.NoError(t, ext.OnPrepare(ctx, d, task))
 	gotJobInfo, err := importer.GetJob(ctx, conn, jobID, "root", true)
@@ -334,6 +369,9 @@ func TestSchedulerPrepareEnabledJobTransitionsFromPreparingToFirstBusinessPhase(
 }
 
 func TestSchedulerOnDoneCancelResetsTableMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	if !kerneltype.IsClassic() {
 		t.Skip("table mode is only set in classic kernel")
 	}
@@ -401,7 +439,7 @@ func TestSchedulerOnDoneCancelResetsTableMode(t *testing.T) {
 		Error: errors.New("cancelled by user"),
 	}
 
-	ext := importinto.NewImportSchedulerForTest(false, task, scheduler.NewParamForTest(mgr, store))
+	ext := importinto.NewImportSchedulerForTest(false, task, importSchedulerParamForTest(ctrl, mgr, store, pool))
 	require.NoError(t, ext.OnDone(ctx, nil, task))
 
 	tbl, err = dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
@@ -410,6 +448,9 @@ func TestSchedulerOnDoneCancelResetsTableMode(t *testing.T) {
 }
 
 func TestSchedulerExtGlobalSort(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	host := "127.0.0.1"
 	port := uint16(4448)
 	opt := fakestorage.Options{
@@ -495,7 +536,7 @@ func TestSchedulerExtGlobalSort(t *testing.T) {
 
 	// to encode-sort stage, job should be running
 	d := sch.MockScheduler(task)
-	ext := importinto.NewImportSchedulerForTest(true, task, scheduler.NewParamForTest(manager, store))
+	ext := importinto.NewImportSchedulerForTest(true, task, importSchedulerParamForTest(ctrl, manager, store, pool))
 	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 2)

--- a/pkg/dxf/importinto/task_executor.go
+++ b/pkg/dxf/importinto/task_executor.go
@@ -909,7 +909,7 @@ func (e *importExecutor) GetStepExecutor(task *proto.Task) (execute.StepExecutor
 	indicesGenKV := importer.GetIndicesGenKV(taskMeta.Plan.TableInfo)
 	logger.Info("got indices that generate kv", zap.Any("indices", indicesGenKV))
 
-	store := e.TaskStore
+	store := e.TaskRuntime.Store()
 	switch task.Step {
 	case proto.ImportStepImport, proto.ImportStepEncodeAndSort:
 		return &importStepExecutor{

--- a/pkg/dxf/importinto/task_executor_test.go
+++ b/pkg/dxf/importinto/task_executor_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ingestor/globalsort"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 type StoreWithKS struct {
@@ -38,13 +39,18 @@ func (s *StoreWithKS) GetKeyspace() string {
 }
 
 func TestImportTaskExecutor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	ctx := context.Background()
+	param := taskexecutor.NewParamForTest(nil, nil, nil, ":4000")
+	param.TaskRuntime = newImportSchedulerTestRuntime(ctrl, &StoreWithKS{}, nil)
 	executor := NewImportExecutor(
 		ctx,
 		&proto.Task{
 			TaskBase: proto.TaskBase{ID: 1},
 		},
-		taskexecutor.NewParamForTest(nil, nil, nil, ":4000", &StoreWithKS{}),
+		param,
 	).(*importExecutor)
 
 	require.NotNil(t, executor.BaseTaskExecutor.Extension)
@@ -70,15 +76,20 @@ func TestImportTaskExecutor(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestImportTaskExecutorUsesTaskStoreWithoutExtraLookup(t *testing.T) {
+func TestImportTaskExecutorUsesTaskRuntimeStoreWithoutExtraLookup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	ctx := context.Background()
 	taskStore := &StoreWithKS{ks: "task_ks"}
+	param := taskexecutor.NewParamForTest(nil, nil, nil, ":4000")
+	param.TaskRuntime = newImportSchedulerTestRuntime(ctrl, taskStore, nil)
 	executor := NewImportExecutor(
 		ctx,
 		&proto.Task{
 			TaskBase: proto.TaskBase{ID: 2},
 		},
-		taskexecutor.NewParamForTest(nil, nil, nil, ":4000", taskStore),
+		param,
 	).(*importExecutor)
 
 	taskMeta := []byte(`{"Plan":{"TableInfo":{}}}`)

--- a/pkg/dxf/importinto/task_executor_test.go
+++ b/pkg/dxf/importinto/task_executor_test.go
@@ -44,7 +44,7 @@ func TestImportTaskExecutor(t *testing.T) {
 
 	ctx := context.Background()
 	param := taskexecutor.NewParamForTest(nil, nil, nil, ":4000")
-	param.TaskRuntime = newImportSchedulerTestRuntime(ctrl, &StoreWithKS{}, nil)
+	param.TaskRuntime = newMockRuntime(ctrl, &StoreWithKS{}, nil)
 	executor := NewImportExecutor(
 		ctx,
 		&proto.Task{
@@ -83,7 +83,7 @@ func TestImportTaskExecutorUsesTaskRuntimeStoreWithoutExtraLookup(t *testing.T) 
 	ctx := context.Background()
 	taskStore := &StoreWithKS{ks: "task_ks"}
 	param := taskexecutor.NewParamForTest(nil, nil, nil, ":4000")
-	param.TaskRuntime = newImportSchedulerTestRuntime(ctrl, taskStore, nil)
+	param.TaskRuntime = newMockRuntime(ctrl, taskStore, nil)
 	executor := NewImportExecutor(
 		ctx,
 		&proto.Task{

--- a/pkg/dxf/importinto/task_executor_testkit_test.go
+++ b/pkg/dxf/importinto/task_executor_testkit_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 )
 
@@ -114,6 +115,9 @@ func TestPostProcessStepExecutor(t *testing.T) {
 }
 
 func TestImportStepExecutorCleanupAllLocalEnginesOnRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	if kerneltype.IsNextGen() {
 		t.Skip("next-gen doesn't support local sort, skip this test")
 	}
@@ -154,10 +158,12 @@ func TestImportStepExecutorCleanupAllLocalEnginesOnRetry(t *testing.T) {
 		},
 		Meta: taskMetaBytes,
 	}
+	param := taskexecutor.NewParamForTest(nil, nil, nil, ":4000")
+	param.TaskRuntime = newImportTestRuntime(ctrl, store, nil)
 	taskExecutor := importinto.NewImportExecutor(
 		context.Background(),
 		task,
-		taskexecutor.NewParamForTest(nil, nil, nil, ":4000", store),
+		param,
 	)
 	t.Cleanup(taskExecutor.Close)
 

--- a/tests/realtikvtest/sessiontest/BUILD.bazel
+++ b/tests/realtikvtest/sessiontest/BUILD.bazel
@@ -4,6 +4,7 @@ go_test(
     name = "sessiontest_test",
     timeout = "moderate",
     srcs = [
+        "cross_ks_gc_test.go",
         "infoschema_test.go",
         "infoschema_v2_test.go",
         "main_test.go",
@@ -12,7 +13,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 17,
+    shard_count = 18,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",
@@ -24,6 +25,7 @@ go_test(
         "//pkg/sessionctx/vardef",
         "//pkg/store/helper",
         "//pkg/testkit",
+        "//pkg/testkit/testfailpoint",
         "//pkg/util/sqlkiller",
         "//tests/realtikvtest",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/tests/realtikvtest/sessiontest/cross_ks_gc_test.go
+++ b/tests/realtikvtest/sessiontest/cross_ks_gc_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sessiontest
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/pingcap/tidb/pkg/keyspace"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	"github.com/pingcap/tidb/tests/realtikvtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCrossKSRuntimeGCLoopStartedBySystemDomain(t *testing.T) {
+	if kerneltype.IsClassic() {
+		t.Skip("only runs in nextgen kernel")
+	}
+
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/domain/crossks/mockRuntimeGCLoopConfig",
+		func(interval, idleTimeout *time.Duration) {
+			*interval = 50 * time.Millisecond
+			*idleTimeout = 100 * time.Millisecond
+		})
+
+	const targetKS = "keyspace1"
+	_, systemDom := realtikvtest.CreateMockStoreAndDomainAndSetup(t,
+		realtikvtest.WithKeyspaceName(keyspace.System),
+		realtikvtest.WithAllocPort(true))
+
+	handle, err := systemDom.AcquireKSRuntime(targetKS, "test/cross-ks-gc-loop")
+	require.NoError(t, err)
+	require.Contains(t, systemDom.GetCrossKSMgr().GetAllKeyspace(), targetKS)
+
+	handle.Release()
+
+	require.Eventually(t, func() bool {
+		return !slices.Contains(systemDom.GetCrossKSMgr().GetAllKeyspace(), targetKS)
+	}, 5*time.Second, 20*time.Millisecond)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68883

Problem Summary:

**this pr wires up(part 2) the changes we have done in previous prs**
NextGen DXF tasks can run IMPORT and distributed DDL backfill work for user keyspaces from the SYSTEM keyspace. Those task consumers should use the task runtime already resolved by the DXF scheduler/executor managers instead of keeping a parallel task-store path or asking the SQL server for raw cross-keyspace stores/session pools. Released cross-keyspace runtimes also need a system-domain GC loop so idle user-keyspace runtimes are eventually evicted.

### What changed and how does it work?

This PR finishes the task-runtime migration for the current IMPORT and distributed DDL backfill paths, and wires runtime cleanup into the SYSTEM domain:

- Remove the temporary `TaskStore` field from DXF scheduler and task-executor params; tests now inject `TaskRuntime` directly.
- Drop direct `GetKSStore` and `GetKSSessPool` access from `sqlsvrapi.Server` and its mock so cross-keyspace consumers go through acquired runtimes.
- Update IMPORT scheduler/executor code to use `TaskRuntime.Store()` and `TaskRuntime.SysSessionPool()` for TiKV mode switching, empty-table checks, subtask planning, task-manager creation, and step execution.
- Update distributed DDL backfill scheduler/executor code to use the task runtime store/session pool, including metadata-only table construction for backfill planning.
- Start `crossKSSessMgr.RunSystemKSGCLoop` from the SYSTEM domain and add a failpoint for shortening the runtime GC interval and idle timeout in tests.
- Add/update focused tests and Bazel metadata for DDL/IMPORT runtime injection and RealTiKV verification that the SYSTEM domain starts the cross-keyspace runtime GC loop and evicts released runtimes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

tempoary change code to make the cross ks gc interval/timeout to 30 seconds
run 20 tidb with different tidb, each run a import-into, from logs we confirmed that all 20 cross ks are released and closed after timeout. no error logs too. and we confirm from profile, no such routines exists.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```
make bazel_prepare
./tools/check/failpoint-go-test.sh pkg/ddl -run 'TestBackfillingSchedulerLocalMode|TestBackfillingSchedulerGlobalSortMode' -count=1 -tags=intest,deadlock,nextgen
./tools/check/failpoint-go-test.sh pkg/dxf/importinto -run 'TestImportInto/(TestSchedulerInit|TestGetTaskMgrForAccessingImportJobUsesTaskRuntime)$|TestSchedulerPrepareEnabledJobTransitionsFromPreparingToFirstBusinessPhase|TestImportTaskExecutor$|TestImportTaskExecutorUsesTaskRuntimeStoreWithoutExtraLookup' -count=1 -tags=intest,deadlock,nextgen
./tools/check/failpoint-go-test.sh pkg/dxf/importinto -run 'TestSchedulerExtLocalSort|TestSchedulerOnDoneCancelResetsTableMode|TestSchedulerExtGlobalSort|TestImportStepExecutorCleanupAllLocalEnginesOnRetry' -count=1 -tags=intest,deadlock
make failpoint-enable
PD_ADDR=127.0.0.1:2379
(
  cleanup() {
    [ -n "${PLAYGROUND_PID:-}" ] && kill "${PLAYGROUND_PID}" 2>/dev/null || true
    [ -n "${PLAYGROUND_PID:-}" ] && wait "${PLAYGROUND_PID}" 2>/dev/null || true
    rm -rf "${HOME}/.tiup/data/realtikvtest"
    make failpoint-disable
  }
  trap cleanup EXIT INT TERM

  tiup playground --mode tikv-slim --tag realtikvtest &
  PLAYGROUND_PID=$!
  until curl -sf "http://${PD_ADDR}/pd/api/v1/version" >/dev/null; do sleep 1; done
  go test -run TestCrossKSRuntimeGCLoopStartedBySystemDomain -tags=intest,deadlock,nextgen ./tests/realtikvtest/sessiontest/...
)
! curl -sf "http://${PD_ADDR}/pd/api/v1/version"
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Refactored internal runtime and storage access patterns across task scheduling, execution, and backfilling components to use a unified runtime abstraction.
  * Updated interface definitions to simplify runtime access patterns.

* **Tests**
  * Added comprehensive test coverage for cross-keyspace runtime acquisition and validation.
  * Enhanced mock utilities for runtime and session pool handling in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
