### PR TITLE
importinto: allow explicit external ID matching target value

### DIFF
--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -6392,17 +6392,23 @@ func checkAlterDDLJobOptValue(opt *AlterDDLJobOpt) error {
 }
 
 // For nextgen IMPORT INTO with SEM, require explicit S3 authentication and
-// disallow explicit S3 external ID. The keyspace name is used as the S3 external ID.
+// disallow explicit S3 external ID unless it is the keyspace name. The keyspace
+// name is used as the S3 external ID.
 func checkNextGenS3PathWithSem(u *url.URL) error {
 	values := u.Query()
+	expectedExternalID := config.GetGlobalKeyspaceName()
 	hasAccessKey := false
 	hasSecretAccessKey := false
 	hasRoleARN := false
-	for k := range values {
+	for k, vs := range values {
 		normalizedK := objstore.NormalizeQueryParameterKey(k)
 		switch normalizedK {
 		case s3like.S3ExternalID:
-			return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO with explicit external ID")
+			for _, v := range vs {
+				if v != expectedExternalID {
+					return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO with explicit external ID")
+				}
+			}
 		case s3like.S3AccessKey:
 			hasAccessKey = hasAccessKey || values.Get(k) != ""
 		case s3like.S3SecretAccessKey:

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/aggregation"
@@ -1131,9 +1132,20 @@ func TestGetMaxWriteSpeedFromExpression(t *testing.T) {
 }
 
 func TestProcessNextGenS3Path(t *testing.T) {
+	bak := config.GetGlobalKeyspaceName()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.KeyspaceName = "aaa"
+	})
+	t.Cleanup(func() {
+		config.UpdateGlobal(func(conf *config.Config) {
+			conf.KeyspaceName = bak
+		})
+	})
+
 	for _, str := range []string{
 		"S3://bucket?External-id=abc&access-key=ak&secret-access-key=sk",
 		"s3://bucket?external_id=abc&access-key=ak&secret-access-key=sk",
+		"s3://bucket?external-id=aaa&external_id=abc&access-key=ak&secret-access-key=sk",
 		"oss://bucket?External-id=abc&role-arn=arn",
 		"oSS://bucket?External-id=abc&access-key=ak&secret-access-key=sk",
 	} {
@@ -1145,6 +1157,9 @@ func TestProcessNextGenS3Path(t *testing.T) {
 	}
 
 	for _, str := range []string{
+		"s3://bucket?external-id=aaa&access-key=ak&secret-access-key=sk",
+		"s3://bucket?external_id=aaa&access-key=ak&secret-access-key=sk",
+		"s3://bucket?external-id=aaa&external_id=aaa&access-key=ak&secret-access-key=sk",
 		"s3://bucket?access-key=ak&secret-access-key=sk",
 		"s3://bucket?access_key=ak&secret_access_key=sk",
 		"oss://bucket?role-arn=arn",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60418

Problem Summary:

The original PR [pingcap/tidb#61315](https://github.com/pingcap/tidb/pull/61315) made nextgen `IMPORT INTO` inject the keyspace name as the S3 external ID when security enhanced mode is enabled, and rejected user-provided external IDs. This is stricter than necessary when the user-provided external ID is exactly the same value TiDB plans to inject.

### What changed and how does it work?

Allow nextgen `IMPORT INTO` with security enhanced mode to accept an explicit S3-like `external-id` only when every provided normalized external ID value matches the current keyspace name. Mismatched values are still rejected with the existing SEM error, including mixed duplicate or alias query parameters such as `external-id=<keyspace>&external_id=<other>`.

The planner still writes `external-id=<keyspace>` into the final import path after validation, so downstream import execution continues to receive the planned keyspace external ID.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```bash
./tools/check/failpoint-go-test.sh pkg/planner/core -run TestProcessNextGenS3Path -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Allow nextgen IMPORT INTO with security enhanced mode to use an explicit S3 external ID when it matches the keyspace name.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of S3 external ID credentials during import operations. External ID query parameters are now properly accepted and validated when provided values match the active keyspace configuration. This enables users to securely import data from S3 sources using external ID authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->