### PR TITLE
executor: optimize join chunk initial capacity

### DIFF
--- a/pkg/executor/delete.go
+++ b/pkg/executor/delete.go
@@ -91,7 +91,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 		vardef.EnableBatchDML.Load() && batchDMLSize > 0
 	fields := exec.RetTypes(e.Children(0))
 	datumRow := make([]types.Datum, 0, len(fields))
-	chk := exec.TryNewCacheChunk(e.Children(0))
+	chk := newDMLChildChunk(e, fields, e.Children(0).InitCap())
 	columns := e.Children(0).Schema().Columns
 	rowCount := 0
 	if len(columns) != len(fields) {

--- a/pkg/executor/executor_required_rows_test.go
+++ b/pkg/executor/executor_required_rows_test.go
@@ -209,6 +209,34 @@ func buildLimitExec(ctx sessionctx.Context, src exec.Executor, offset, count int
 	return limitExec
 }
 
+func TestDMLChildChunkInitCapByRowWidth(t *testing.T) {
+	sctx := defaultCtx()
+	child := buildLimitExec(sctx, newRequiredRowsDataSource(sctx, 10, nil), 0, 1000)
+	require.Equal(t, 1000, child.InitCap())
+
+	base := exec.NewBaseExecutor(sctx, nil, 0, child)
+	base.SetInitCap(chunk.ZeroCapacity)
+	dmlExec := &DeleteExec{BaseExecutor: base}
+
+	chk := newDMLChildChunk(dmlExec, exec.RetTypes(child), child.InitCap())
+	require.Equal(t, 1000, chk.Capacity())
+	require.Equal(t, sctx.GetSessionVars().MaxChunkSize, chk.RequiredRows())
+
+	fields := make([]*types.FieldType, 1024)
+	cols := make([]*expression.Column, len(fields))
+	for i := range fields {
+		fields[i] = types.NewFieldTypeBuilder().SetType(mysql.TypeVarchar).SetFlen(1000).BuildP()
+		cols[i] = &expression.Column{Index: i, RetType: fields[i]}
+	}
+	wideChild := buildLimitExec(sctx, &requiredRowsDataSource{
+		BaseExecutor: exec.NewBaseExecutor(sctx, expression.NewSchema(cols...), 0),
+	}, 0, 1000)
+
+	chk = newDMLChildChunk(dmlExec, exec.RetTypes(wideChild), wideChild.InitCap())
+	require.Equal(t, 1, chk.Capacity())
+	require.Equal(t, sctx.GetSessionVars().MaxChunkSize, chk.RequiredRows())
+}
+
 func defaultCtx() sessionctx.Context {
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().InitChunkSize = vardef.DefInitChunkSize

--- a/pkg/executor/join/hash_join_base.go
+++ b/pkg/executor/join/hash_join_base.go
@@ -301,13 +301,17 @@ func (w *buildWorkerBase) fetchBuildSideRows(ctx context.Context, hashJoinCtx *h
 		}
 	})
 
-	sessVars := hashJoinCtx.SessCtx.GetSessionVars()
 	failpoint.Inject("issue51998", func(val failpoint.Value) {
 		if val.(bool) {
 			time.Sleep(2 * time.Second)
 		}
 	})
 
+	sessVars := hashJoinCtx.SessCtx.GetSessionVars()
+	nextChunkCap, maxChunkSize := sessVars.InitChunkSize, sessVars.MaxChunkSize
+	if nextChunkCap <= 0 {
+		nextChunkCap = chunk.InitialCapacity
+	}
 	for {
 		err := checkAndSpillRowTableIfNeeded(fetcherAndWorkerSyncer, spillHelper)
 		issue59377Intest(&err)
@@ -328,7 +332,8 @@ func (w *buildWorkerBase) fetchBuildSideRows(ctx context.Context, hashJoinCtx *h
 			return
 		}
 
-		chk := hashJoinCtx.ChunkAllocPool.Alloc(w.BuildSideExec.RetFieldTypes(), sessVars.MaxChunkSize, sessVars.MaxChunkSize)
+		chkCap := min(nextChunkCap, maxChunkSize)
+		chk := hashJoinCtx.ChunkAllocPool.Alloc(w.BuildSideExec.RetFieldTypes(), chkCap, maxChunkSize)
 		err = exec.Next(ctx, w.BuildSideExec, chk)
 
 		failpoint.Inject("issue51998", func(val failpoint.Value) {
@@ -347,10 +352,14 @@ func (w *buildWorkerBase) fetchBuildSideRows(ctx context.Context, hashJoinCtx *h
 		failpoint.Inject("errorFetchBuildSideRowsMockOOMPanic", nil)
 		failpoint.Inject("ConsumeRandomPanic", nil)
 
-		if chk.NumRows() == 0 {
+		rows := chk.NumRows()
+		if rows == 0 {
 			return
 		}
 
+		if rows >= chkCap && nextChunkCap < maxChunkSize {
+			nextChunkCap = min(max(nextChunkCap*2, rows), maxChunkSize)
+		}
 		syncerAdd(fetcherAndWorkerSyncer)
 		select {
 		case <-doneCh:

--- a/pkg/executor/join/index_lookup_join.go
+++ b/pkg/executor/join/index_lookup_join.go
@@ -463,9 +463,10 @@ func (ow *outerWorker) buildTask(ctx context.Context) (*lookUpJoinTask, error) {
 		nextChunkCap = chunk.InitialCapacity
 	}
 	for remainingRows := requiredRows - task.outerResult.Len(); remainingRows > 0; remainingRows = requiredRows - task.outerResult.Len() {
-		chkCap := min(nextChunkCap, remainingRows, maxChunkSize)
+		fetchRequiredRows := min(remainingRows, maxChunkSize)
+		chkCap := min(nextChunkCap, fetchRequiredRows)
 		chk := ow.executor.NewChunkWithCapacity(ow.OuterCtx.RowTypes, chkCap, maxChunkSize)
-		chk = chk.SetRequiredRows(remainingRows, maxChunkSize)
+		chk = chk.SetRequiredRows(fetchRequiredRows, maxChunkSize)
 		err := exec.Next(ctx, ow.executor, chk)
 		if err != nil {
 			return task, err
@@ -476,7 +477,7 @@ func (ow *outerWorker) buildTask(ctx context.Context) (*lookUpJoinTask, error) {
 		}
 		task.outerResult.Add(chk)
 		if rows >= chkCap && nextChunkCap < maxChunkSize {
-			nextChunkCap = min(nextChunkCap*2, maxChunkSize)
+			nextChunkCap = min(max(nextChunkCap*2, rows), maxChunkSize)
 		}
 	}
 	if task.outerResult.Len() == 0 {

--- a/pkg/executor/join/index_lookup_join.go
+++ b/pkg/executor/join/index_lookup_join.go
@@ -458,18 +458,26 @@ func (ow *outerWorker) buildTask(ctx context.Context) (*lookUpJoinTask, error) {
 			requiredRows = parentRequired
 		}
 	}
-	maxChunkSize := ow.ctx.GetSessionVars().MaxChunkSize
-	for requiredRows > task.outerResult.Len() {
-		chk := ow.executor.NewChunkWithCapacity(ow.OuterCtx.RowTypes, requiredRows, maxChunkSize)
-		chk = chk.SetRequiredRows(requiredRows, maxChunkSize)
+	nextChunkCap, maxChunkSize := ow.executor.InitCap(), ow.executor.MaxChunkSize()
+	if nextChunkCap <= 0 {
+		nextChunkCap = chunk.InitialCapacity
+	}
+	for remainingRows := requiredRows - task.outerResult.Len(); remainingRows > 0; remainingRows = requiredRows - task.outerResult.Len() {
+		chkCap := min(nextChunkCap, remainingRows, maxChunkSize)
+		chk := ow.executor.NewChunkWithCapacity(ow.OuterCtx.RowTypes, chkCap, maxChunkSize)
+		chk = chk.SetRequiredRows(remainingRows, maxChunkSize)
 		err := exec.Next(ctx, ow.executor, chk)
 		if err != nil {
 			return task, err
 		}
-		if chk.NumRows() == 0 {
+		rows := chk.NumRows()
+		if rows == 0 {
 			break
 		}
 		task.outerResult.Add(chk)
+		if rows >= chkCap && nextChunkCap < maxChunkSize {
+			nextChunkCap = min(nextChunkCap*2, maxChunkSize)
+		}
 	}
 	if task.outerResult.Len() == 0 {
 		return nil, nil

--- a/pkg/executor/join/index_lookup_merge_join.go
+++ b/pkg/executor/join/index_lookup_merge_join.go
@@ -185,7 +185,7 @@ func (e *IndexLookUpMergeJoin) startWorkers(ctx context.Context) {
 	for i := range concurrency {
 		e.joinChkResourceCh[i] = make(chan *chunk.Chunk, numResChkHold)
 		for range numResChkHold {
-			e.joinChkResourceCh[i] <- chunk.NewChunkWithCapacity(e.RetFieldTypes(), e.MaxChunkSize())
+			e.joinChkResourceCh[i] <- e.NewChunk()
 		}
 	}
 	workerCtx, cancelFunc := context.WithCancel(ctx)
@@ -717,7 +717,7 @@ func (imw *innerMergeWorker) dedupDatumLookUpKeys(lookUpContents []*IndexJoinLoo
 
 // fetchNextInnerResult collects a chunk of inner results from inner child executor.
 func (imw *innerMergeWorker) fetchNextInnerResult(ctx context.Context, task *lookUpMergeJoinTask) (beginRow chunk.Row, err error) {
-	task.innerResult = imw.innerExec.NewChunkWithCapacity(imw.innerExec.RetFieldTypes(), imw.innerExec.MaxChunkSize(), imw.innerExec.MaxChunkSize())
+	task.innerResult = imw.innerExec.NewChunkWithCapacity(imw.innerExec.RetFieldTypes(), imw.innerExec.InitCap(), imw.innerExec.MaxChunkSize())
 	err = exec.Next(ctx, imw.innerExec, task.innerResult)
 	task.innerIter = chunk.NewIterator4Chunk(task.innerResult)
 	beginRow = task.innerIter.Begin()

--- a/pkg/executor/join/joiner.go
+++ b/pkg/executor/join/joiner.go
@@ -195,7 +195,8 @@ func NewJoiner(ctx sessionctx.Context, joinType plannerbase.JoinType,
 		return &antiLeftOuterSemiJoiner{base}
 	case plannerbase.LeftOuterJoin, plannerbase.RightOuterJoin, plannerbase.InnerJoin:
 		if len(base.conditions) > 0 {
-			base.chk = chunk.NewChunkWithCapacity(shallowRowType, ctx.GetSessionVars().MaxChunkSize)
+			vars := ctx.GetSessionVars()
+			base.chk = chunk.New(shallowRowType, vars.InitChunkSize, vars.MaxChunkSize)
 		}
 		switch joinType {
 		case plannerbase.LeftOuterJoin:

--- a/pkg/executor/join/joiner_test.go
+++ b/pkg/executor/join/joiner_test.go
@@ -15,10 +15,10 @@
 package join
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/sessionctx"
@@ -65,28 +65,42 @@ func TestRequiredRows(t *testing.T) {
 				maxChunkSize := defaultCtx().GetSessionVars().MaxChunkSize
 				lfields := convertTypes(ltype)
 				rfields := convertTypes(rtype)
-				outerRow := genTestChunk(maxChunkSize, 1, lfields).GetRow(0)
-				innerChk := genTestChunk(maxChunkSize, maxChunkSize, rfields)
+				outerIsRight := joinType == base.RightOuterJoin
+				outerFields, innerFields := lfields, rfields
+				if outerIsRight {
+					outerFields, innerFields = rfields, lfields
+				}
+				outerRow := genTestChunk(maxChunkSize, 1, outerFields).GetRow(0)
+				innerChk := genTestChunk(maxChunkSize, maxChunkSize, innerFields)
 				var defaultInner []types.Datum
-				for i, f := range rfields {
+				for i, f := range innerFields {
 					defaultInner = append(defaultInner, innerChk.GetRow(0).GetDatum(i, f))
 				}
-				joiner := NewJoiner(defaultCtx(), joinType, false, defaultInner, nil, lfields, rfields, nil, false)
+				conditionCases := []struct {
+					name       string
+					conditions []expression.Expression
+				}{
+					{name: "withoutConditions"},
+					{name: "withConditions", conditions: []expression.Expression{expression.NewOne()}},
+				}
 
 				fields := make([]*types.FieldType, 0, len(lfields)+len(rfields))
-				fields = append(fields, rfields...)
 				fields = append(fields, lfields...)
-				result := chunk.New(fields, maxChunkSize, maxChunkSize)
+				fields = append(fields, rfields...)
 
-				for range 10 {
-					required := rand.Int()%maxChunkSize + 1
-					result.SetRequiredRows(required, maxChunkSize)
-					result.Reset()
-					it := chunk.NewIterator4Chunk(innerChk)
-					it.Begin()
-					_, _, err := joiner.TryToMatchInners(outerRow, it, result)
-					require.NoError(t, err)
-					require.Equal(t, required, result.NumRows())
+				for _, conditionCase := range conditionCases {
+					joiner := NewJoiner(defaultCtx(), joinType, outerIsRight, defaultInner, conditionCase.conditions, lfields, rfields, nil, false)
+					result := chunk.New(fields, maxChunkSize, maxChunkSize)
+
+					for _, required := range []int{1, vardef.DefInitChunkSize + 1, maxChunkSize} {
+						result.SetRequiredRows(required, maxChunkSize)
+						result.Reset()
+						it := chunk.NewIterator4Chunk(innerChk)
+						it.Begin()
+						_, _, err := joiner.TryToMatchInners(outerRow, it, result)
+						require.NoError(t, err, conditionCase.name)
+						require.Equal(t, required, result.NumRows(), conditionCase.name)
+					}
 				}
 			}
 		}

--- a/pkg/executor/join/joiner_test.go
+++ b/pkg/executor/join/joiner_test.go
@@ -42,6 +42,53 @@ func defaultCtx() sessionctx.Context {
 	return ctx
 }
 
+func TestJoinerOtherConditionChunkUsesInitChunkSize(t *testing.T) {
+	lfields := []*types.FieldType{types.NewFieldType(mysql.TypeLong)}
+	rfields := []*types.FieldType{types.NewFieldType(mysql.TypeLong)}
+	fields := append(append([]*types.FieldType{}, lfields...), rfields...)
+	conditions := []expression.Expression{expression.NewOne()}
+	defaultInner := []types.Datum{types.NewIntDatum(0)}
+
+	for _, joinType := range []base.JoinType{base.InnerJoin, base.LeftOuterJoin, base.RightOuterJoin} {
+		ctx := defaultCtx()
+		initChunkSize := 8
+		ctx.GetSessionVars().InitChunkSize = initChunkSize
+		maxChunkSize := ctx.GetSessionVars().MaxChunkSize
+		joiner := NewJoiner(ctx, joinType, false, defaultInner, conditions, lfields, rfields, nil, false)
+		base := joinerBaseForTest(t, joiner)
+		require.NotNil(t, base.chk)
+		require.Equal(t, initChunkSize, base.chk.Capacity())
+
+		cloned := joiner.Clone()
+		clonedBase := joinerBaseForTest(t, cloned)
+		require.NotNil(t, clonedBase.chk)
+		require.Equal(t, initChunkSize, clonedBase.chk.Capacity())
+
+		outerRow := genTestChunk(maxChunkSize, 1, lfields).GetRow(0)
+		innerChk := genTestChunk(maxChunkSize, initChunkSize+1, rfields)
+		result := chunk.New(fields, maxChunkSize, maxChunkSize)
+		iter := chunk.NewIterator4Chunk(innerChk)
+		iter.Begin()
+		_, _, err := joiner.TryToMatchInners(outerRow, iter, result)
+		require.NoError(t, err)
+		require.Equal(t, initChunkSize+1, result.NumRows())
+	}
+}
+
+func joinerBaseForTest(t *testing.T, joiner Joiner) *baseJoiner {
+	switch j := joiner.(type) {
+	case *innerJoiner:
+		return &j.baseJoiner
+	case *leftOuterJoiner:
+		return &j.baseJoiner
+	case *rightOuterJoiner:
+		return &j.baseJoiner
+	default:
+		t.Fatalf("unexpected joiner type %T", joiner)
+	}
+	return nil
+}
+
 func TestRequiredRows(t *testing.T) {
 	joinTypes := []base.JoinType{base.InnerJoin, base.LeftOuterJoin, base.RightOuterJoin}
 	lTypes := [][]byte{

--- a/pkg/executor/join/joiner_test.go
+++ b/pkg/executor/join/joiner_test.go
@@ -15,6 +15,7 @@
 package join
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/domain"
@@ -112,42 +113,28 @@ func TestRequiredRows(t *testing.T) {
 				maxChunkSize := defaultCtx().GetSessionVars().MaxChunkSize
 				lfields := convertTypes(ltype)
 				rfields := convertTypes(rtype)
-				outerIsRight := joinType == base.RightOuterJoin
-				outerFields, innerFields := lfields, rfields
-				if outerIsRight {
-					outerFields, innerFields = rfields, lfields
-				}
-				outerRow := genTestChunk(maxChunkSize, 1, outerFields).GetRow(0)
-				innerChk := genTestChunk(maxChunkSize, maxChunkSize, innerFields)
+				outerRow := genTestChunk(maxChunkSize, 1, lfields).GetRow(0)
+				innerChk := genTestChunk(maxChunkSize, maxChunkSize, rfields)
 				var defaultInner []types.Datum
-				for i, f := range innerFields {
+				for i, f := range rfields {
 					defaultInner = append(defaultInner, innerChk.GetRow(0).GetDatum(i, f))
 				}
-				conditionCases := []struct {
-					name       string
-					conditions []expression.Expression
-				}{
-					{name: "withoutConditions"},
-					{name: "withConditions", conditions: []expression.Expression{expression.NewOne()}},
-				}
+				joiner := NewJoiner(defaultCtx(), joinType, false, defaultInner, nil, lfields, rfields, nil, false)
 
 				fields := make([]*types.FieldType, 0, len(lfields)+len(rfields))
-				fields = append(fields, lfields...)
 				fields = append(fields, rfields...)
+				fields = append(fields, lfields...)
+				result := chunk.New(fields, maxChunkSize, maxChunkSize)
 
-				for _, conditionCase := range conditionCases {
-					joiner := NewJoiner(defaultCtx(), joinType, outerIsRight, defaultInner, conditionCase.conditions, lfields, rfields, nil, false)
-					result := chunk.New(fields, maxChunkSize, maxChunkSize)
-
-					for _, required := range []int{1, vardef.DefInitChunkSize + 1, maxChunkSize} {
-						result.SetRequiredRows(required, maxChunkSize)
-						result.Reset()
-						it := chunk.NewIterator4Chunk(innerChk)
-						it.Begin()
-						_, _, err := joiner.TryToMatchInners(outerRow, it, result)
-						require.NoError(t, err, conditionCase.name)
-						require.Equal(t, required, result.NumRows(), conditionCase.name)
-					}
+				for range 10 {
+					required := rand.Int()%maxChunkSize + 1
+					result.SetRequiredRows(required, maxChunkSize)
+					result.Reset()
+					it := chunk.NewIterator4Chunk(innerChk)
+					it.Begin()
+					_, _, err := joiner.TryToMatchInners(outerRow, it, result)
+					require.NoError(t, err)
+					require.Equal(t, required, result.NumRows())
 				}
 			}
 		}

--- a/pkg/executor/update.go
+++ b/pkg/executor/update.go
@@ -378,7 +378,7 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 	fields := exec.RetTypes(e.Children(0))
 	colsInfo := physicalop.GetUpdateColumnsInfo(e.tblID2table, e.tblColPosInfos, len(fields))
 	globalRowIdx := 0
-	chk := exec.TryNewCacheChunk(e.Children(0))
+	chk := newDMLChildChunk(e, fields, e.Children(0).InitCap())
 	if !e.allAssignmentsAreConstant {
 		e.evalBuffer = chunk.MutRowFromTypes(fields)
 	}

--- a/pkg/executor/utils.go
+++ b/pkg/executor/utils.go
@@ -20,10 +20,13 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/extension"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 )
 
 var (
@@ -64,6 +67,29 @@ func deleteFromSet(set []string, value string) []string {
 		}
 	}
 	return set
+}
+
+const dmlChildChunkTargetBytes = 256 * 1024
+
+// Use child InitCap as the upper bound, but reduce it for wide rows to avoid large upfront allocation.
+func newDMLChildChunk(dmlExec exec.Executor, fields []*types.FieldType, maxInitCap int) *chunk.Chunk {
+	maxChunkSize := dmlExec.MaxChunkSize()
+	initCap := estimateDMLChildChunkInitCap(fields, maxChunkSize, maxInitCap)
+	return dmlExec.NewChunkWithCapacity(fields, initCap, maxChunkSize)
+}
+
+func estimateDMLChildChunkInitCap(fields []*types.FieldType, maxChunkSize, maxInitCap int) int {
+	if maxChunkSize <= 0 || maxInitCap <= 0 {
+		return chunk.ZeroCapacity
+	}
+	rowWidth := 0
+	for _, field := range fields {
+		rowWidth += chunk.EstimateTypeWidth(field)
+	}
+	if rowWidth <= 0 {
+		return min(maxChunkSize, maxInitCap)
+	}
+	return max(1, min(maxChunkSize, maxInitCap, dmlChildChunkTargetBytes/rowWidth))
 }
 
 // batchRetrieverHelper is a helper for batch returning data with known total rows. This helps implementing memtable


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #68545

cherry-pick #68959

This PR reduces unnecessary upfront chunk allocation in executor paths that previously allocated chunks directly with `MaxChunkSize`.

For DML statements such as `UPDATE` / `DELETE`, the child executor may be a `LimitExec` whose `InitCap` is derived from `LIMIT n`. When the child output row is wide, allocating the DML child chunk directly from the child executor can create a large upfront allocation. This is especially visible when `LIMIT n` is large and the child schema contains many or wide columns.

### What changed and how does it work?

This PR makes chunk allocation more consistent with executor `InitCap` semantics:

- Use a dedicated `newDMLChildChunk` helper for `UPDATE` / `DELETE`.
- Use the child executor's `InitCap` as the upper bound for DML child chunk allocation.
- Estimate row width with `chunk.EstimateTypeWidth` and reduce the initial capacity for wide rows to keep the upfront allocation around a bounded target size.
- Refactor join-related chunk creation to use executor `InitCap` where appropriate instead of always allocating with `MaxChunkSize`.
- Preserve `RequiredRows` behavior so executor batch-size semantics are not changed by the initial-capacity optimization.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Unit test
  - Added coverage for DML child chunk initial capacity with narrow and wide child schemas.
  - Added coverage that joiner temporary chunks for other conditions use `InitChunkSize`.
  - Extended join required-rows tests to cover joins with other conditions.

### Release note

```release-note
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved memory allocation and chunk sizing across join, lookup, delete, and update operations for more consistent buffering and fewer oversized allocations.
  * Added capacity-aware chunk initialization and progressive growth during row fetching to reduce churn and improve runtime stability, especially for wide rows.
* **Tests**
  * Added deterministic tests to validate chunk sizing/required-row behavior and ensure joiners use the configured initial capacity correctly, reducing regression risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->