### PR TITLE
go.mod: update PD client for pd#10845 (#69056)

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -7819,13 +7819,13 @@ def go_deps():
         build_tags = ["nextgen", "intest"],
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/pd/client",
-        sha256 = "80c305a966604f259a7aa330d4608c0cd6f86caf15e22f3b4cdf5863f6549ef5",
-        strip_prefix = "github.com/tikv/pd/client@v0.0.0-20260514035418-08d563f93b67",
+        sha256 = "5e82af833aaeb975e0cf75dfd20da56c86d2b5ca81a6f044eb31459c0f8013e3",
+        strip_prefix = "github.com/tikv/pd/client@v0.0.0-20260609055630-9fdd9714fe74",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260514035418-08d563f93b67.zip",
-            "http://ats.apps.svc/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260514035418-08d563f93b67.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260514035418-08d563f93b67.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260514035418-08d563f93b67.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260609055630-9fdd9714fe74.zip",
+            "http://ats.apps.svc/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260609055630-9fdd9714fe74.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260609055630-9fdd9714fe74.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260609055630-9fdd9714fe74.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
 	github.com/tikv/client-go/v2 v2.0.8-0.20260609081337-227cdde78911
-	github.com/tikv/pd/client v0.0.0-20260514035418-08d563f93b67
+	github.com/tikv/pd/client v0.0.0-20260609055630-9fdd9714fe74
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67
 	github.com/twmb/murmur3 v1.1.6
 	github.com/uber/jaeger-client-go v2.22.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -899,6 +899,8 @@ github.com/tikv/client-go/v2 v2.0.8-0.20260609081337-227cdde78911 h1:3iufLPa9PU1
 github.com/tikv/client-go/v2 v2.0.8-0.20260609081337-227cdde78911/go.mod h1:rg9c3yf9lfQdj9rt5FvwRP9xDubUY6C9hyH4g9zFH1s=
 github.com/tikv/pd/client v0.0.0-20260514035418-08d563f93b67 h1:hjtDlZl/S5/ar4M0cbPlTqJP0N/sZ88w9VjVDaWltGE=
 github.com/tikv/pd/client v0.0.0-20260514035418-08d563f93b67/go.mod h1:4kxXuAQAREpH+lVbydVwGNNDmcwdj0RG4Ofwky08W/k=
+github.com/tikv/pd/client v0.0.0-20260609055630-9fdd9714fe74 h1:cTGpsN+5svuOcD/F9X/SN+Eb9FMByWwVHqTl0ZPHvh8=
+github.com/tikv/pd/client v0.0.0-20260609055630-9fdd9714fe74/go.mod h1:4kxXuAQAREpH+lVbydVwGNNDmcwdj0RG4Ofwky08W/k=
 github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 h1:9LPGD+jzxMlnk5r6+hJnar67cgpDIz/iyD+rfl5r2Vk=
 github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67/go.mod h1:mkjARE7Yr8qU23YcGMSALbIxTQ9r9QBVahQOBRfU460=
 github.com/tjfoc/gmsm v1.3.2/go.mod h1:HaUcFuY0auTiaHB9MHFGCPx5IaLhTUd2atbCFBQXn9w=


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref tikv/pd#10744

Problem Summary:

PD has merged the `release-nextgen-202603` cherry-pick `tikv/pd#10845` for `tikv/pd#10745`, which keeps the PD client resource-control token-bucket limiter clock monotonic under stale timestamps. TiDB `release-nextgen-202603` needs to consume that release-nextgen PD client revision.

The TiDB master dependency bump is tracked by `pingcap/tidb#69056`.

### What changed and how does it work?

- Bump `github.com/tikv/pd/client` to `v0.0.0-20260609055630-9fdd9714fe74`, the merged `tikv/pd` `release-nextgen-202603` commit from `tikv/pd#10845`.
- Refresh `DEPS.bzl` with `make bazel_prepare` so Bazel fetches the same PD client module version.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test steps:
- `go get github.com/tikv/pd/client@9fdd9714fe740c97076cb4ad438739465f8ff759`
- `make bazel_prepare`
- `./tools/check/failpoint-go-test.sh pkg/resourcegroup/runaway -run '^$' -count=1 -tags=intest,deadlock,nextgen`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a third‑party TiKV client dependency to a newer pinned version to improve compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->