### PR TITLE
planner: Fix flaky testglobalstatsandsqlbinding (#62512)

### DIFF
--- a/pkg/statistics/handle/globalstats/global_stats_internal_test.go
+++ b/pkg/statistics/handle/globalstats/global_stats_internal_test.go
@@ -406,18 +406,15 @@ func testGlobalStatsAndSQLBinding(tk *testkit.TestKit) {
 	tk.MustExec("insert into trange values " + strings.Join(vals, ","))
 	tk.MustExec("insert into tlist values " + strings.Join(listVals, ","))
 
-	// before analyzing, the planner will choose TableScan to access the 1% of records
-	tk.MustHavePlan("select * from thash where a<100", "TableFullScan")
-	tk.MustHavePlan("select * from trange where a<100", "TableFullScan")
-	tk.MustHavePlan("select * from tlist where a<1", "TableFullScan")
-
 	tk.MustExec("analyze table thash")
 	tk.MustExec("analyze table trange")
 	tk.MustExec("analyze table tlist")
 
-	tk.MustHavePlan("select * from thash where a<100", "TableFullScan")
-	tk.MustHavePlan("select * from trange where a<100", "TableFullScan")
-	tk.MustHavePlan("select * from tlist where a<1", "TableFullScan")
+	// Set table cost factor high to ensure index is preferred without bindings.
+	tk.MustExec("set @@session.tidb_opt_table_full_scan_cost_factor=100")
+	tk.MustHavePlan("select * from thash where a<100", "IndexRangeScan")
+	tk.MustHavePlan("select * from trange where a<100", "IndexRangeScan")
+	tk.MustHavePlan("select * from tlist where a<1", "IndexRangeScan")
 
 	// create SQL bindings
 	tk.MustExec("create session binding for select * from thash where a<100 using select * from thash ignore index(a) where a<100")
@@ -434,7 +431,11 @@ func testGlobalStatsAndSQLBinding(tk *testkit.TestKit) {
 	tk.MustExec("drop session binding for select * from trange where a<100")
 	tk.MustExec("drop session binding for select * from tlist where a<100")
 
-	tk.MustHavePlan("select * from thash where a<100", "TableFullScan")
-	tk.MustHavePlan("select * from trange where a<100", "TableFullScan")
-	tk.MustHavePlan("select * from tlist where a<1", "TableFullScan")
+	tk.MustHavePlan("select * from thash where a<100", "IndexRangeScan")
+	tk.MustHavePlan("select * from trange where a<100", "IndexRangeScan")
+	tk.MustHavePlan("select * from tlist where a<1", "IndexRangeScan")
+	// Reset auto analyze after test
+	tk.MustExec("set @@global.tidb_enable_auto_analyze='ON'")
+	// Reset table cost factor
+	tk.MustExec("set @@session.tidb_opt_table_full_scan_cost_factor=1")
 }


### PR DESCRIPTION
Cherry-pick of #62512 to release-8.5 with merge conflict resolved.

This PR fixes the flaky test  by:
- Setting  to ensure index is preferred without bindings
- Checking for  instead of  after analyzing
- Adding proper cleanup after the test

Resolves merge conflict with release-8.5 branch.

Signed-off-by: ti-chi-bot <ti-community-prow-bot@tidb.io>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for query optimizer decisions with table statistics and cost parameters.
  * Improved validation of index selection behavior when cost-based optimization factors are adjusted.
  * Strengthened verification of session variable configuration and reset functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->