### PR TITLE
lightning: use usable CPU count for region concurrency

### DIFF
--- a/pkg/lightning/config/BUILD.bazel
+++ b/pkg/lightning/config/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/parser/ast",
         "//pkg/parser/mysql",
         "//pkg/util",
+        "//pkg/util/cpu",
         "//pkg/util/table-filter",
         "//pkg/util/table-router",
         "@com_github_burntsushi_toml//:toml",
@@ -46,6 +47,7 @@ go_test(
     shard_count = 50,
     deps = [
         "@com_github_burntsushi_toml//:toml",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/lightning/config/config.go
+++ b/pkg/lightning/config/config.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/cpu"
 	filter "github.com/pingcap/tidb/pkg/util/table-filter"
 	router "github.com/pingcap/tidb/pkg/util/table-router"
 	"go.uber.org/atomic"
@@ -367,7 +368,7 @@ func (l *Lightning) adjust(i *TikvImporter) {
 			l.MetaSchemaName = defaultMetaSchemaName
 		}
 		// RegionConcurrency > NumCPU is meaningless.
-		cpuCount := runtime.NumCPU()
+		cpuCount := cpu.GetCPUCount()
 		if l.RegionConcurrency > cpuCount {
 			l.RegionConcurrency = cpuCount
 		}
@@ -1461,7 +1462,7 @@ func (c *Conflict) adjust(i *TikvImporter) error {
 func NewConfig() *Config {
 	return &Config{
 		App: Lightning{
-			RegionConcurrency:  runtime.NumCPU(),
+			RegionConcurrency:  cpu.GetCPUCount(),
 			TableConcurrency:   0,
 			IndexConcurrency:   0,
 			IOConcurrency:      5,

--- a/pkg/lightning/config/config_test.go
+++ b/pkg/lightning/config/config_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/pingcap/failpoint"
 	"github.com/stretchr/testify/require"
 )
 
@@ -911,6 +912,22 @@ func TestDefaultImporterBackendValue(t *testing.T) {
 	require.Equal(t, 2, cfg.App.IndexConcurrency)
 	require.Equal(t, 6, cfg.App.TableConcurrency)
 	require.Equal(t, 4096, cfg.TikvImporter.RegionSplitBatchSize)
+}
+
+func TestRegionConcurrencyUsesUsableCPUCount(t *testing.T) {
+	const usableCPUCount = 2
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", "return(2)"))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu"))
+	})
+
+	cfg := NewConfig()
+	require.Equal(t, usableCPUCount, cfg.App.RegionConcurrency)
+
+	cfg.App.RegionConcurrency = usableCPUCount + 1
+	cfg.TikvImporter.Backend = BackendLocal
+	cfg.App.adjust(&cfg.TikvImporter)
+	require.Equal(t, usableCPUCount, cfg.App.RegionConcurrency)
 }
 
 func TestDefaultTidbBackendValue(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69061

Problem Summary:

In Kubernetes pods, `runtime.NumCPU()` may be larger than the CPU count usable by the current process. TiDB Lightning used `runtime.NumCPU()` to initialize and cap `lightning.region-concurrency`, so the effective region concurrency could exceed the pod's CPU allowance.

### What changed and how does it work?

Use `cpu.GetCPUCount()` when initializing the default `lightning.region-concurrency` and when capping it for the local backend. `cpu.GetCPUCount()` returns TiDB's process-usable CPU count helper instead of the host logical CPU count.

Add a regression test that mocks the usable CPU count and verifies both `NewConfig()` and local-backend adjustment honor that value.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/lightning/config -run TestRegionConcurrencyUsesUsableCPUCount -count=1`
  - Red check: applying only the regression test to `upstream/master` failed with `expected: 2`, `actual: 10`.
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - `make bazel_prepare`
  - `make lint`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix TiDB Lightning to use the CPU count usable by the current process when setting the default and cap for region concurrency.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the method used to determine CPU count for Lightning region concurrency configuration defaults and validation.

* **Tests**
  * Added new test to verify region concurrency is correctly calculated based on detected CPU count.

* **Chores**
  * Updated build dependencies to support new utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->