### PR TITLE
lightning: extend duplicate resolution wait

### DIFF
--- a/lightning/tests/lightning_duplicate_resolution_incremental/run.sh
+++ b/lightning/tests/lightning_duplicate_resolution_incremental/run.sh
@@ -22,6 +22,7 @@ check_cluster_version 5 2 0 'duplicate detection' || exit 0
 
 LOG_FILE1="$TEST_DIR/lightning-duplicate-resolution1.log"
 LOG_FILE2="$TEST_DIR/lightning-duplicate-resolution2.log"
+WAIT_LIGHTNING_START_SECONDS=120
 
 # let lightning run a bit slow to avoid some table in the first lightning finish too fast.
 export GO_FAILPOINTS="github.com/pingcap/tidb/lightning/pkg/importer/SlowDownCheckDupe=return(10)"
@@ -29,7 +30,7 @@ run_lightning --backend local --sorted-kv-dir "$TEST_DIR/lightning_duplicate_res
   --enable-checkpoint=1 --log-file "$LOG_FILE1" --config "$CUR/config1.toml" &
 
 counter=0
-while [ $counter -lt 10 ]; do
+while [ $counter -lt $WAIT_LIGHTNING_START_SECONDS ]; do
     if grep -Fq "start to sleep several seconds before checking other dupe" "$LOG_FILE1"; then
         echo "lightning 1 already starts waiting for dupe"
         break
@@ -39,7 +40,7 @@ while [ $counter -lt 10 ]; do
     sleep 1
 done
 
-if [ $counter -ge 10 ]; then
+if [ $counter -ge $WAIT_LIGHTNING_START_SECONDS ]; then
   echo "fail to wait for lightning 1 starts"
   exit 1
 fi

--- a/lightning/tests/lightning_duplicate_resolution_incremental/run.sh
+++ b/lightning/tests/lightning_duplicate_resolution_incremental/run.sh
@@ -22,7 +22,7 @@ check_cluster_version 5 2 0 'duplicate detection' || exit 0
 
 LOG_FILE1="$TEST_DIR/lightning-duplicate-resolution1.log"
 LOG_FILE2="$TEST_DIR/lightning-duplicate-resolution2.log"
-WAIT_LIGHTNING_START_SECONDS=120
+WAIT_LIGHTNING_START_SECONDS=30
 
 # let lightning run a bit slow to avoid some table in the first lightning finish too fast.
 export GO_FAILPOINTS="github.com/pingcap/tidb/lightning/pkg/importer/SlowDownCheckDupe=return(10)"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69083

Problem Summary:

`lightning_duplicate_resolution_incremental` waits for the first Lightning process to reach the `SlowDownCheckDupe` marker before starting the second Lightning process. The marker is reached after Lightning startup and checkpoint/task-info setup, so the previous 10-second wait could timeout under CI latency before the test reached the intended duplicate-resolution synchronization point.

### What changed and how does it work?

Increase the wait window in `lightning_duplicate_resolution_incremental/run.sh` from 10 seconds to 30 seconds by introducing `WAIT_LIGHTNING_START_SECONDS`.

The synchronization condition is unchanged: the test still waits for `start to sleep several seconds before checking other dupe` in the first Lightning log before launching the second Lightning process.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - `bash -n lightning/tests/lightning_duplicate_resolution_incremental/run.sh`
  - `git diff --check`
  - `make lint`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test reliability by making timing configuration more flexible for duplicate-resolution testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->