### PR TITLE
expression: fix unary minus flen inference

### DIFF
--- a/pkg/expression/builtin_op.go
+++ b/pkg/expression/builtin_op.go
@@ -1075,10 +1075,13 @@ func (c *unaryMinusFunctionClass) getFunction(ctx BuildContext, args []Expressio
 			sig.setPbCode(tipb.ScalarFuncSig_UnaryMinusReal)
 		}
 	}
-	if evalType == types.ETDecimal ||
-		(evalType == types.ETInt && !intOverflow && !mysql.HasUnsignedFlag(argExprTp.GetFlag())) {
-		// Unary minus only flips the sign for decimal values.
-		// For signed integer without overflow, the sign width is already covered by the input flen.
+	_, isColumn := argExpr.(*Column)
+	if _, ok := argExpr.(*CorrelatedColumn); ok {
+		isColumn = true
+	}
+	if isColumn && (evalType == types.ETDecimal ||
+		(evalType == types.ETInt && !intOverflow && !mysql.HasUnsignedFlag(argExprTp.GetFlag()))) {
+		// Column types already reserve their signed display width, so unary minus does not widen them.
 		bf.tp.SetFlenUnderLimit(argExprTp.GetFlen())
 	} else {
 		bf.tp.SetFlenUnderLimit(argExprTp.GetFlen() + 1)

--- a/pkg/expression/builtin_op.go
+++ b/pkg/expression/builtin_op.go
@@ -1075,7 +1075,14 @@ func (c *unaryMinusFunctionClass) getFunction(ctx BuildContext, args []Expressio
 			sig.setPbCode(tipb.ScalarFuncSig_UnaryMinusReal)
 		}
 	}
-	bf.tp.SetFlenUnderLimit(argExprTp.GetFlen() + 1)
+	if evalType == types.ETDecimal ||
+		(evalType == types.ETInt && !intOverflow && !mysql.HasUnsignedFlag(argExprTp.GetFlag())) {
+		// Unary minus only flips the sign for decimal values.
+		// For signed integer without overflow, the sign width is already covered by the input flen.
+		bf.tp.SetFlenUnderLimit(argExprTp.GetFlen())
+	} else {
+		bf.tp.SetFlenUnderLimit(argExprTp.GetFlen() + 1)
+	}
 	return sig, err
 }
 

--- a/pkg/expression/builtin_op_test.go
+++ b/pkg/expression/builtin_op_test.go
@@ -67,6 +67,34 @@ func TestUnary(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestUnaryMinusDecimalRetTypeFlen(t *testing.T) {
+	ctx := createContext(t)
+	arg := datumsToConstants(types.MakeDatums(types.NewDecFromStringForTest("123.45")))[0]
+	arg.GetType(ctx.GetEvalCtx()).SetFlen(10)
+	arg.GetType(ctx.GetEvalCtx()).SetDecimal(2)
+
+	f, err := newFunctionForTest(ctx, ast.UnaryMinus, arg)
+	require.NoError(t, err)
+	require.Equal(t, 10, f.GetType(ctx.GetEvalCtx()).GetFlen())
+	require.Equal(t, 2, f.GetType(ctx.GetEvalCtx()).GetDecimal())
+}
+
+func TestUnaryMinusIntRetTypeFlen(t *testing.T) {
+	ctx := createContext(t)
+
+	signedArg := datumsToConstants(types.MakeDatums(int64(123)))[0]
+	signedArg.GetType(ctx.GetEvalCtx()).SetFlen(11)
+	signedFunc, err := newFunctionForTest(ctx, ast.UnaryMinus, signedArg)
+	require.NoError(t, err)
+	require.Equal(t, 11, signedFunc.GetType(ctx.GetEvalCtx()).GetFlen())
+
+	unsignedArg := datumsToConstants(types.MakeDatums(uint64(123)))[0]
+	unsignedArg.GetType(ctx.GetEvalCtx()).SetFlen(10)
+	unsignedFunc, err := newFunctionForTest(ctx, ast.UnaryMinus, unsignedArg)
+	require.NoError(t, err)
+	require.Equal(t, 11, unsignedFunc.GetType(ctx.GetEvalCtx()).GetFlen())
+}
+
 func TestLogicAnd(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx

--- a/pkg/expression/builtin_op_test.go
+++ b/pkg/expression/builtin_op_test.go
@@ -75,6 +75,14 @@ func TestUnaryMinusDecimalRetTypeFlen(t *testing.T) {
 
 	f, err := newFunctionForTest(ctx, ast.UnaryMinus, arg)
 	require.NoError(t, err)
+	require.Equal(t, 11, f.GetType(ctx.GetEvalCtx()).GetFlen())
+	require.Equal(t, 2, f.GetType(ctx.GetEvalCtx()).GetDecimal())
+
+	colType := types.NewFieldType(mysql.TypeNewDecimal)
+	colType.SetFlen(10)
+	colType.SetDecimal(2)
+	f, err = newFunctionForTest(ctx, ast.UnaryMinus, &Column{RetType: colType})
+	require.NoError(t, err)
 	require.Equal(t, 10, f.GetType(ctx.GetEvalCtx()).GetFlen())
 	require.Equal(t, 2, f.GetType(ctx.GetEvalCtx()).GetDecimal())
 }
@@ -85,6 +93,12 @@ func TestUnaryMinusIntRetTypeFlen(t *testing.T) {
 	signedArg := datumsToConstants(types.MakeDatums(int64(123)))[0]
 	signedArg.GetType(ctx.GetEvalCtx()).SetFlen(11)
 	signedFunc, err := newFunctionForTest(ctx, ast.UnaryMinus, signedArg)
+	require.NoError(t, err)
+	require.Equal(t, 12, signedFunc.GetType(ctx.GetEvalCtx()).GetFlen())
+
+	signedColType := types.NewFieldType(mysql.TypeLonglong)
+	signedColType.SetFlen(11)
+	signedFunc, err = newFunctionForTest(ctx, ast.UnaryMinus, &Column{RetType: signedColType})
 	require.NoError(t, err)
 	require.Equal(t, 11, signedFunc.GetType(ctx.GetEvalCtx()).GetFlen())
 

--- a/pkg/expression/typeinfer_test.go
+++ b/pkg/expression/typeinfer_test.go
@@ -155,9 +155,9 @@ type InferTypeSuite struct{}
 func (s *InferTypeSuite) createTestCase4Constants() []typeInferTestCase {
 	return []typeInferTestCase{
 		{"1", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 1, 0},
-		{"-1", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 2, 0},
+		{"-1", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 1, 0},
 		{"1.23", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 5, 2},
-		{"-1.23", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 6, 2},
+		{"-1.23", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 5, 2},
 		{"123e5", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 8, types.UnspecifiedLength},
 		{"-123e5", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 9, types.UnspecifiedLength},
 		{"123e-5", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 7, types.UnspecifiedLength},

--- a/pkg/expression/typeinfer_test.go
+++ b/pkg/expression/typeinfer_test.go
@@ -155,9 +155,9 @@ type InferTypeSuite struct{}
 func (s *InferTypeSuite) createTestCase4Constants() []typeInferTestCase {
 	return []typeInferTestCase{
 		{"1", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 1, 0},
-		{"-1", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 1, 0},
+		{"-1", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 2, 0},
 		{"1.23", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 5, 2},
-		{"-1.23", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 5, 2},
+		{"-1.23", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 6, 2},
 		{"123e5", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 8, types.UnspecifiedLength},
 		{"-123e5", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 9, types.UnspecifiedLength},
 		{"123e-5", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag | mysql.NotNullFlag, 7, types.UnspecifiedLength},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68722

Problem Summary:

Unary minus type inference should reserve display width for the sign when the operand is a literal/constant. The previous change preserved `flen` too broadly for signed integer and decimal operands, causing constants such as `-1` to infer the same `flen` as `1`.

### What changed and how does it work?

This PR limits the "do not widen `flen`" rule to column-like operands (`Column` and `CorrelatedColumn`) whose field types already reserve signed display width. Constants and other expressions keep the previous unary minus behavior and add one extra width for the minus sign.

It also adds regression coverage for integer and decimal constants versus columns, and updates the type inference cases for negative constants.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the inferred display width for unary minus constants.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unary minus operator to correctly handle field-length calculations for decimal and integer input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->