### PR TITLE
meta, session: add mysql.tidb_export_jobs system table

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore.go
+++ b/br/pkg/restore/snap_client/systable_restore.go
@@ -109,6 +109,8 @@ var unRecoverableTable = map[string]map[string]struct{}{
 		"tidb_ddl_notifier": {},
 		// v7.2.0. Based on Distributed eXecution Framework, records running import jobs.
 		"tidb_import_jobs": {},
+		// Based on Distributed eXecution Framework, records running export jobs.
+		"tidb_export_jobs": {},
 
 		"help_topic": {},
 		// records the RU for each resource group temporary, no need to recovered.

--- a/br/pkg/restore/snap_client/systable_restore.go
+++ b/br/pkg/restore/snap_client/systable_restore.go
@@ -109,7 +109,7 @@ var unRecoverableTable = map[string]map[string]struct{}{
 		"tidb_ddl_notifier": {},
 		// v7.2.0. Based on Distributed eXecution Framework, records running import jobs.
 		"tidb_import_jobs": {},
-		// Based on Distributed eXecution Framework, records running export jobs.
+		// Records export jobs; runtime job state that should not be restored, same as tidb_import_jobs.
 		"tidb_export_jobs": {},
 
 		"help_topic": {},

--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -393,7 +393,7 @@ func TestCheckPrivilegeTableRowsCollateCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(261), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(262), session.CurrentBootstrapVersion)
 }
 
 func TestIsStatsTemporaryTable(t *testing.T) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -189,6 +189,8 @@ const (
 	BaseNextGenBootTableVersion NextGenBootTableVersion = 1
 	// MaskingPolicyNextGenBootTableVersion adds mysql.tidb_masking_policy.
 	MaskingPolicyNextGenBootTableVersion NextGenBootTableVersion = 2
+	// ExportJobsNextGenBootTableVersion adds mysql.tidb_export_jobs.
+	ExportJobsNextGenBootTableVersion NextGenBootTableVersion = 3
 )
 
 // DDLTableVersion is to display ddl related table versions

--- a/pkg/meta/metadef/system.go
+++ b/pkg/meta/metadef/system.go
@@ -156,6 +156,8 @@ const (
 	TiDBSoftDeleteTableStatusTableID = ReservedGlobalIDUpperBound - 61
 	// TiDBMaskingPolicyTableID is the table ID of `tidb_masking_policy`.
 	TiDBMaskingPolicyTableID = ReservedGlobalIDUpperBound - 62
+	// TiDBExportJobsTableID is the table ID of `tidb_export_jobs`.
+	TiDBExportJobsTableID = ReservedGlobalIDUpperBound - 63
 )
 
 // IsReservedID checks if the given ID is a reserved global ID.

--- a/pkg/meta/metadef/system_tables_def.go
+++ b/pkg/meta/metadef/system_tables_def.go
@@ -714,7 +714,7 @@ const (
 		format VARCHAR(64) NOT NULL,
 		created_by VARCHAR(300) NOT NULL,
 		parameters text NOT NULL,
-		total_size bigint(64) NOT NULL DEFAULT 0,
+		exported_size bigint(64) NOT NULL DEFAULT 0,
 		status VARCHAR(64) NOT NULL,
 		step VARCHAR(64) NOT NULL,
 		summary text DEFAULT NULL,

--- a/pkg/meta/metadef/system_tables_def.go
+++ b/pkg/meta/metadef/system_tables_def.go
@@ -700,6 +700,29 @@ const (
 		KEY idx_group_key(group_key),
 		KEY (status));`
 
+	// CreateTiDBExportJobsTable is a table that EXPORT TABLE uses to track export jobs.
+	CreateTiDBExportJobsTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_export_jobs (
+		id bigint(64) NOT NULL AUTO_INCREMENT,
+		create_time TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+		start_time TIMESTAMP(6) NULL DEFAULT NULL,
+		update_time TIMESTAMP(6) NULL DEFAULT NULL,
+		end_time TIMESTAMP(6) NULL DEFAULT NULL,
+		table_schema VARCHAR(64) NOT NULL,
+		table_name VARCHAR(64) NOT NULL,
+		table_id bigint(64) NOT NULL,
+		destination VARCHAR(2048) NOT NULL,
+		format VARCHAR(64) NOT NULL,
+		created_by VARCHAR(300) NOT NULL,
+		parameters text NOT NULL,
+		total_size bigint(64) NOT NULL DEFAULT 0,
+		status VARCHAR(64) NOT NULL,
+		step VARCHAR(64) NOT NULL,
+		summary text DEFAULT NULL,
+		error_message TEXT DEFAULT NULL,
+		PRIMARY KEY (id),
+		KEY (created_by),
+		KEY (status));`
+
 	// CreateTiDBPITRIDMapTable is a table that records the id map from upstream to downstream for PITR.
 	// set restore id default to 0 to make it compatible for old BR tool to restore to a new TiDB, such case should be
 	// rare though.

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -335,6 +335,11 @@ var (
 	systemTablesOfMaskingPolicyNextGenVersion = []TableBasicInfo{
 		{ID: metadef.TiDBMaskingPolicyTableID, Name: "tidb_masking_policy", SQL: metadef.CreateTiDBMaskingPolicyTable},
 	}
+	// systemTablesOfExportJobsNextGenVersion contains system tables introduced in
+	// the export-jobs bootstrap version.
+	systemTablesOfExportJobsNextGenVersion = []TableBasicInfo{
+		{ID: metadef.TiDBExportJobsTableID, Name: "tidb_export_jobs", SQL: metadef.CreateTiDBExportJobsTable},
+	}
 )
 
 type versionedBootstrapSchema struct {
@@ -354,6 +359,9 @@ var versionedBootstrapSchemas = []versionedBootstrapSchema{
 	}},
 	{ver: meta.MaskingPolicyNextGenBootTableVersion, databases: []DatabaseBasicInfo{
 		{ID: metadef.SystemDatabaseID, Name: mysql.SystemDB, Tables: systemTablesOfMaskingPolicyNextGenVersion},
+	}},
+	{ver: meta.ExportJobsNextGenBootTableVersion, databases: []DatabaseBasicInfo{
+		{ID: metadef.SystemDatabaseID, Name: mysql.SystemDB, Tables: systemTablesOfExportJobsNextGenVersion},
 	}},
 }
 

--- a/pkg/session/test/bootstraptest/BUILD.bazel
+++ b/pkg/session/test/bootstraptest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 44,
+    shard_count = 45,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1152,6 +1152,97 @@ func TestUpgradeVersion260MaskingPolicy(t *testing.T) {
 	checkTiDBMaskingPolicyTableSchema(t, tk)
 }
 
+func checkTiDBExportJobsTableSchema(t *testing.T, tk *testkit.TestKit) {
+	tk.MustQuery("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='mysql' AND table_name='tidb_export_jobs'").Check(testkit.Rows("1"))
+	tk.MustQuery(`
+SELECT column_name, LOWER(column_type), is_nullable
+FROM information_schema.columns
+WHERE table_schema='mysql' AND table_name='tidb_export_jobs'
+ORDER BY ordinal_position`).Check(testkit.Rows(
+		"id bigint(64) NO",
+		"create_time timestamp(6) NO",
+		"start_time timestamp(6) YES",
+		"update_time timestamp(6) YES",
+		"end_time timestamp(6) YES",
+		"table_schema varchar(64) NO",
+		"table_name varchar(64) NO",
+		"table_id bigint(64) NO",
+		"destination varchar(2048) NO",
+		"format varchar(64) NO",
+		"created_by varchar(300) NO",
+		"parameters text NO",
+		"exported_size bigint(64) NO",
+		"status varchar(64) NO",
+		"step varchar(64) NO",
+		"summary text YES",
+		"error_message text YES",
+	))
+	tk.MustQuery(`
+SELECT index_name, non_unique, seq_in_index, column_name
+FROM information_schema.statistics
+WHERE table_schema='mysql' AND table_name='tidb_export_jobs'
+ORDER BY index_name, seq_in_index`).Check(testkit.Rows(
+		"PRIMARY 0 1 id",
+		"created_by 1 1 created_by",
+		"status 1 1 status",
+	))
+}
+
+func TestUpgradeVersion262ExportJobs(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
+	}
+	const fromVersion = 261
+
+	store, dom := session.CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	seFrom := session.CreateSessionAndSetID(t, store)
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	err = m.FinishBootstrap(int64(fromVersion))
+	require.NoError(t, err)
+	err = txn.Commit(context.Background())
+	require.NoError(t, err)
+	revertVersionAndVariables(t, seFrom, fromVersion)
+
+	is := dom.InfoSchema()
+	exportTbl, err := is.TableByName(context.Background(), ast.NewCIStr("mysql"), ast.NewCIStr("tidb_export_jobs"))
+	require.NoError(t, err)
+	exportDBID := exportTbl.Meta().DBID
+	exportTblID := exportTbl.Meta().ID
+
+	txn, err = store.Begin()
+	require.NoError(t, err)
+	m = meta.NewMutator(txn)
+	err = m.DropTableOrView(exportDBID, exportTblID)
+	require.NoError(t, err)
+	exists, err := m.CheckTableExists(exportDBID, exportTblID)
+	require.NoError(t, err)
+	require.False(t, exists)
+	err = txn.Commit(context.Background())
+	require.NoError(t, err)
+
+	store.SetOption(session.StoreBootstrappedKey, nil)
+	ver, err := session.GetBootstrapVersion(seFrom)
+	require.NoError(t, err)
+	require.Equal(t, int64(fromVersion), ver)
+	dom.Close()
+
+	newVer, err := session.BootstrapSession(store)
+	require.NoError(t, err)
+	defer newVer.Close()
+
+	seLatestV := session.CreateSessionAndSetID(t, store)
+	ver, err = session.GetBootstrapVersion(seLatestV)
+	require.NoError(t, err)
+	require.Equal(t, session.CurrentBootstrapVersion, ver)
+
+	tk := testkit.NewTestKit(t, store)
+	checkTiDBExportJobsTableSchema(t, tk)
+}
+
 func TestUpgradeWithAnalyzeColumnOptions(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1062,39 +1062,48 @@ func TestUpgradeBindInfo(t *testing.T) {
 	seLatestV.Close()
 }
 
-func checkTiDBMaskingPolicyTableSchema(t *testing.T, tk *testkit.TestKit) {
-	tk.MustQuery("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='mysql' AND table_name='tidb_masking_policy'").Check(testkit.Rows("1"))
-	tk.MustQuery(`
+// checkSystemTableSchema asserts that mysql.<table> exists with exactly the given
+// columns ("name lower(type) is_nullable" rows in ordinal order) and indexes
+// ("index_name non_unique seq_in_index column_name" rows).
+func checkSystemTableSchema(t *testing.T, tk *testkit.TestKit, table string, columns, indexes []string) {
+	tk.MustQuery(fmt.Sprintf("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='mysql' AND table_name='%s'", table)).Check(testkit.Rows("1"))
+	tk.MustQuery(fmt.Sprintf(`
 SELECT column_name, LOWER(column_type), is_nullable
 FROM information_schema.columns
-WHERE table_schema='mysql' AND table_name='tidb_masking_policy'
-ORDER BY ordinal_position`).Check(testkit.Rows(
-		"policy_id bigint(64) NO",
-		"policy_name varchar(64) NO",
-		"db_name varchar(64) NO",
-		"table_name varchar(64) NO",
-		"table_id bigint(64) NO",
-		"column_name varchar(64) NO",
-		"column_id bigint(64) NO",
-		"expression text NO",
-		"status varchar(16) NO",
-		"masking_type varchar(32) NO",
-		"restrict_on varchar(256) NO",
-		"created_at datetime(6) NO",
-		"updated_at datetime(6) NO",
-		"created_by varchar(288) NO",
-	))
-	tk.MustQuery(`
+WHERE table_schema='mysql' AND table_name='%s'
+ORDER BY ordinal_position`, table)).Check(testkit.Rows(columns...))
+	tk.MustQuery(fmt.Sprintf(`
 SELECT index_name, non_unique, seq_in_index, column_name
 FROM information_schema.statistics
-WHERE table_schema='mysql' AND table_name='tidb_masking_policy'
-ORDER BY index_name, seq_in_index`).Check(testkit.Rows(
-		"PRIMARY 0 1 policy_id",
-		"uk_table_column 0 1 table_id",
-		"uk_table_column 0 2 column_id",
-		"uk_table_policy 0 1 table_id",
-		"uk_table_policy 0 2 policy_name",
-	))
+WHERE table_schema='mysql' AND table_name='%s'
+ORDER BY index_name, seq_in_index`, table)).Check(testkit.Rows(indexes...))
+}
+
+func checkTiDBMaskingPolicyTableSchema(t *testing.T, tk *testkit.TestKit) {
+	checkSystemTableSchema(t, tk, "tidb_masking_policy",
+		[]string{
+			"policy_id bigint(64) NO",
+			"policy_name varchar(64) NO",
+			"db_name varchar(64) NO",
+			"table_name varchar(64) NO",
+			"table_id bigint(64) NO",
+			"column_name varchar(64) NO",
+			"column_id bigint(64) NO",
+			"expression text NO",
+			"status varchar(16) NO",
+			"masking_type varchar(32) NO",
+			"restrict_on varchar(256) NO",
+			"created_at datetime(6) NO",
+			"updated_at datetime(6) NO",
+			"created_by varchar(288) NO",
+		},
+		[]string{
+			"PRIMARY 0 1 policy_id",
+			"uk_table_column 0 1 table_id",
+			"uk_table_column 0 2 column_id",
+			"uk_table_policy 0 1 table_id",
+			"uk_table_policy 0 2 policy_name",
+		})
 }
 
 func TestUpgradeVersion260MaskingPolicy(t *testing.T) {
@@ -1153,39 +1162,31 @@ func TestUpgradeVersion260MaskingPolicy(t *testing.T) {
 }
 
 func checkTiDBExportJobsTableSchema(t *testing.T, tk *testkit.TestKit) {
-	tk.MustQuery("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='mysql' AND table_name='tidb_export_jobs'").Check(testkit.Rows("1"))
-	tk.MustQuery(`
-SELECT column_name, LOWER(column_type), is_nullable
-FROM information_schema.columns
-WHERE table_schema='mysql' AND table_name='tidb_export_jobs'
-ORDER BY ordinal_position`).Check(testkit.Rows(
-		"id bigint(64) NO",
-		"create_time timestamp(6) NO",
-		"start_time timestamp(6) YES",
-		"update_time timestamp(6) YES",
-		"end_time timestamp(6) YES",
-		"table_schema varchar(64) NO",
-		"table_name varchar(64) NO",
-		"table_id bigint(64) NO",
-		"destination varchar(2048) NO",
-		"format varchar(64) NO",
-		"created_by varchar(300) NO",
-		"parameters text NO",
-		"exported_size bigint(64) NO",
-		"status varchar(64) NO",
-		"step varchar(64) NO",
-		"summary text YES",
-		"error_message text YES",
-	))
-	tk.MustQuery(`
-SELECT index_name, non_unique, seq_in_index, column_name
-FROM information_schema.statistics
-WHERE table_schema='mysql' AND table_name='tidb_export_jobs'
-ORDER BY index_name, seq_in_index`).Check(testkit.Rows(
-		"PRIMARY 0 1 id",
-		"created_by 1 1 created_by",
-		"status 1 1 status",
-	))
+	checkSystemTableSchema(t, tk, "tidb_export_jobs",
+		[]string{
+			"id bigint(64) NO",
+			"create_time timestamp(6) NO",
+			"start_time timestamp(6) YES",
+			"update_time timestamp(6) YES",
+			"end_time timestamp(6) YES",
+			"table_schema varchar(64) NO",
+			"table_name varchar(64) NO",
+			"table_id bigint(64) NO",
+			"destination varchar(2048) NO",
+			"format varchar(64) NO",
+			"created_by varchar(300) NO",
+			"parameters text NO",
+			"exported_size bigint(64) NO",
+			"status varchar(64) NO",
+			"step varchar(64) NO",
+			"summary text YES",
+			"error_message text YES",
+		},
+		[]string{
+			"PRIMARY 0 1 id",
+			"created_by 1 1 created_by",
+			"status 1 1 status",
+		})
 }
 
 func TestUpgradeVersion262ExportJobs(t *testing.T) {

--- a/pkg/session/test/meta/session_test.go
+++ b/pkg/session/test/meta/session_test.go
@@ -276,5 +276,5 @@ func TestNextgenBootstrap(t *testing.T) {
 		}
 	}
 	require.EqualValues(t, 2, reservedSchemaCnt)
-	require.EqualValues(t, 60, reservedTableCnt)
+	require.EqualValues(t, 61, reservedTableCnt)
 }

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -507,6 +507,9 @@ const (
 	// Backfill tidb_default_string_match_selectivity for upgraded clusters where the row in
 	// mysql.global_variables was never materialized when the variable was introduced.
 	version261 = 261
+
+	// version262 adds mysql.tidb_export_jobs table.
+	version262 = 262
 )
 
 // versionedUpgradeFunction is a struct that holds the upgrade function related
@@ -520,7 +523,7 @@ type versionedUpgradeFunction struct {
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version261
+var currentBootstrapVersion int64 = version262
 
 var (
 	// this list must be ordered by version in ascending order, and the function
@@ -706,6 +709,7 @@ var (
 		{version: version259, fn: upgradeToVer259},
 		{version: version260, fn: upgradeToVer260},
 		{version: version261, fn: upgradeToVer261},
+		{version: version262, fn: upgradeToVer262},
 	}
 )
 
@@ -2138,4 +2142,8 @@ func upgradeToVer260(s sessionapi.Session, _ int64) {
 func upgradeToVer261(s sessionapi.Session, _ int64) {
 	// the prior default behavior is "0.8", keep it for compatibility for old clusters.
 	initGlobalVariableIfNotExists(s, vardef.TiDBDefaultStrMatchSelectivity, "0.8")
+}
+
+func upgradeToVer262(s sessionapi.Session, _ int64) {
+	mustExecute(s, metadef.CreateTiDBExportJobsTable)
 }

--- a/pkg/statistics/handle/handletest/initstats/init_stats_test.go
+++ b/pkg/statistics/handle/handletest/initstats/init_stats_test.go
@@ -266,7 +266,7 @@ func testConcurrentlyInitStats(t *testing.T) {
 	}
 	maxID := maxPhysicalTableID(h, is)
 	if kerneltype.IsClassic() {
-		require.Equal(t, int64(132), maxID)
+		require.Equal(t, int64(134), maxID)
 	} else {
 		// In next-gen, the table ID is different from classic because the system table IDs and the regular table IDs are different,
 		// so the next-gen table ID will be ahead of the classic table ID.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68984

Problem Summary:

The distributed single-table export feature (`EXPORT TABLE`, tracked in #68984) needs a user-facing job table to track export jobs (status / progress / `SHOW EXPORT JOB`), analogous to `mysql.tidb_import_jobs` for IMPORT INTO.

This is a small, self-contained sub-PR split out of the prototype #68972: it **only creates the system table**. Reading/writing it (the executor, `SHOW`/`CANCEL`, progress aggregation) lands in a later PR.

### What changed and how does it work?

Add `mysql.tidb_export_jobs`, modeled on `mysql.tidb_import_jobs` with export-specific columns (`destination`, `format`, `total_size`).

Registered for both kernels, following the latest (masking-policy) convention:

- **next-gen kernel** — a new `ExportJobsNextGenBootTableVersion` boot-table version plus a `systemTablesOfExportJobsNextGenVersion` schema entry, so already-bootstrapped next-gen clusters create the table incrementally via meta KV (reserved table ID `TiDBExportJobsTableID`).
- **classic kernel** — fresh clusters create it through `versionedBootstrapSchemas` in `doDDLWorks`; existing clusters get it via a new upgrade step `upgradeToVer262` (`mustExecute(CreateTiDBExportJobsTable)`). `currentBootstrapVersion` is bumped to `262`.

No table is read or written yet, so there is no user-visible behavior change beyond the new (empty) system table.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > Pure system-table creation, exercised by the existing bootstrap/upgrade test suites (fresh bootstrap + `currentBootstrapVersion` upgrade path). A dedicated test for reading/writing the table will accompany the follow-up usage PR.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a system table to track EXPORT TABLE jobs (metadata, status, creator, destination, format, size, summary, errors) with indexes for common queries.

* **Upgrade**
  * Cluster upgrades include a new bootstrap milestone (version 262) to create and initialize this table.

* **Backup/Restore**
  * Export-job records are treated as internal runtime data and excluded from standard restore flows.

* **Tests**
  * Tests and bootstrap expectations updated; added upgrade test validating table schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->