### PR TITLE
br: persist to s3 after checkpoint advanced

### DIFF
--- a/br/pkg/conn/BUILD.bazel
+++ b/br/pkg/conn/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "@com_github_pingcap_kvproto//pkg/logbackuppb",
         "@com_github_pingcap_kvproto//pkg/metapb",
         "@com_github_pingcap_log//:log",
-        "@com_github_tikv_client_go_v2//oracle",
         "@com_github_tikv_client_go_v2//tikv",
         "@com_github_tikv_client_go_v2//txnkv/txnlock",
         "@com_github_tikv_pd_client//:client",

--- a/br/pkg/conn/conn.go
+++ b/br/pkg/conn/conn.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -32,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/kv"
-	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/txnkv/txnlock"
 	pd "github.com/tikv/pd/client"
@@ -306,12 +304,7 @@ func (mgr *Mgr) Close() {
 
 // GetCurrentTsFromPD gets current ts from PD.
 func (mgr *Mgr) GetCurrentTsFromPD(ctx context.Context) (uint64, error) {
-	p, l, err := mgr.GetPDClient().GetTS(ctx)
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
-
-	return oracle.ComposeTS(p, l), nil
+	return util.GetCurrentTsFromPD(ctx, mgr.GetPDClient())
 }
 
 // ProcessTiKVConfigs handle the tikv config for region split size, region split keys, and import goroutines in place.
@@ -385,81 +378,43 @@ func (mgr *Mgr) IsLogBackupEnabled(ctx context.Context, client *http.Client) (bo
 	return logbackupEnable, errors.Trace(err)
 }
 
-// GetConfigFromTiKV get configs from all alive tikv stores.
-func (mgr *Mgr) GetConfigFromTiKV(ctx context.Context, cli *http.Client, fn func(*http.Response) error) error {
-	allStores, err := GetAllTiKVStoresWithRetry(ctx, mgr.GetPDClient(), util.SkipTiFlash)
+// GetConfigFromTiKV gets configs from all alive TiKV stores.
+func GetConfigFromTiKV(
+	ctx context.Context,
+	pdClient util.StoreMeta,
+	cli *http.Client,
+	httpPrefix string,
+	fn func(*http.Response) error,
+) error {
+	allStores, err := GetAllTiKVStoresWithRetry(ctx, pdClient, util.SkipTiFlash)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	return util.GetConfigFromTiKVStores(ctx, allStores, cli, httpPrefix, fn)
+}
 
+// GetConfigFromTiKV get configs from all alive tikv stores.
+func (mgr *Mgr) GetConfigFromTiKV(ctx context.Context, cli *http.Client, fn func(*http.Response) error) error {
 	httpPrefix := "http://"
 	if mgr.GetTLSConfig() != nil {
 		httpPrefix = "https://"
 	}
+	return GetConfigFromTiKV(ctx, mgr.GetPDClient(), cli, httpPrefix, fn)
+}
 
-	for _, store := range allStores {
-		if store.State != metapb.StoreState_Up {
-			continue
-		}
-		// we need make sure every available store support backup-stream otherwise we might lose data.
-		// so check every store's config
-		addr, err := handleTiKVAddress(store, httpPrefix)
-		if err != nil {
-			return err
-		}
-		configAddr := fmt.Sprintf("%s/config", addr.String())
-
-		err = utils.WithRetry(ctx, func() error {
-			resp, e := cli.Get(configAddr)
-			if e != nil {
-				return e
-			}
-			defer resp.Body.Close()
-			err = fn(resp)
-			if err != nil {
-				return err
-			}
-			return nil
-		}, utils.NewPDReqBackoffer())
-		if err != nil {
-			// if one store failed, break and return error
-			return err
-		}
+// GetConfigBytesFromTiKV gets config response bodies from all alive tikv stores.
+func (mgr *Mgr) GetConfigBytesFromTiKV(ctx context.Context, cli *http.Client, collect func([]byte) error) error {
+	httpPrefix := "http://"
+	if mgr.GetTLSConfig() != nil {
+		httpPrefix = "https://"
 	}
-	return nil
+	allStores, err := GetAllTiKVStoresWithRetry(ctx, mgr.GetPDClient(), util.SkipTiFlash)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return util.GetConfigBytesFromTiKVStores(ctx, allStores, cli, httpPrefix, collect)
 }
 
 func handleTiKVAddress(store *metapb.Store, httpPrefix string) (*url.URL, error) {
-	statusAddr := store.GetStatusAddress()
-	nodeAddr := store.GetAddress()
-	if !strings.HasPrefix(statusAddr, "http") {
-		statusAddr = httpPrefix + statusAddr
-	}
-	if !strings.HasPrefix(nodeAddr, "http") {
-		nodeAddr = httpPrefix + nodeAddr
-	}
-
-	statusUrl, err := url.Parse(statusAddr)
-	if err != nil {
-		return nil, err
-	}
-	nodeUrl, err := url.Parse(nodeAddr)
-	if err != nil {
-		return nil, err
-	}
-
-	// we try status address as default
-	addr := statusUrl
-	// but in sometimes we may not get the correct status address from PD.
-	if statusUrl.Hostname() != nodeUrl.Hostname() {
-		// if not matched, we use the address as default, but change the port
-		addr.Host = net.JoinHostPort(nodeUrl.Hostname(), statusUrl.Port())
-		log.Warn("store address and status address mismatch the host, we will use the store address as hostname",
-			zap.Uint64("store", store.Id),
-			zap.String("status address", statusAddr),
-			zap.String("node address", nodeAddr),
-			zap.Any("request address", statusUrl),
-		)
-	}
-	return addr, nil
+	return util.HandleTiKVAddress(store, httpPrefix)
 }

--- a/br/pkg/conn/util/BUILD.bazel
+++ b/br/pkg/conn/util/BUILD.bazel
@@ -7,9 +7,16 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//br/pkg/errors",
+        "//br/pkg/logutil",
+        "//br/pkg/utils",
         "//pkg/util/engine",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_kvproto//pkg/metapb",
         "@com_github_tikv_pd_client//:client",
+        "@com_github_pingcap_log//:log",
+        "@com_github_tikv_client_go_v2//oracle",
+        "@com_github_tikv_pd_client//:client",
+        "@com_github_tikv_pd_client//opt",
+        "@org_uber_go_zap//:zap",
     ],
 )

--- a/br/pkg/conn/util/util.go
+++ b/br/pkg/conn/util/util.go
@@ -4,12 +4,22 @@ package util
 
 import (
 	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/log"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
+	"github.com/pingcap/tidb/br/pkg/logutil"
+	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/pkg/util/engine"
+	"github.com/tikv/client-go/v2/oracle"
 	pd "github.com/tikv/pd/client"
+	"go.uber.org/zap"
 )
 
 // StoreBehavior is the action to do in GetAllTiKVStores when a non-TiKV
@@ -70,4 +80,134 @@ func GetAllTiKVStores(
 		j++
 	}
 	return stores[:j], nil
+}
+
+// GetCurrentTsFromPD gets current ts from PD.
+func GetCurrentTsFromPD(ctx context.Context, pdClient pd.Client) (uint64, error) {
+	p, l, err := pdClient.GetTS(ctx)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+
+	return oracle.ComposeTS(p, l), nil
+}
+
+// GetCurrentTsFromPDWithRetry gets current ts from PD with retry.
+func GetCurrentTsFromPDWithRetry(ctx context.Context, pdClient pd.Client) (uint64, error) {
+	var currentTS uint64
+	var retry uint
+	err := utils.WithRetry(ctx, func() error {
+		ts, err := GetCurrentTsFromPD(ctx, pdClient)
+		retry++
+		if err != nil {
+			log.Warn("failed to get current TS from PD, retry it",
+				zap.Uint("retry time", retry),
+				logutil.ShortError(err))
+			return err
+		}
+		currentTS = ts
+		return nil
+	}, utils.NewPDReqBackoffer())
+	if err != nil {
+		log.Error("failed to get current TS from PD", zap.Error(err))
+	}
+	return currentTS, errors.Trace(err)
+}
+
+// GetConfigFromTiKVStores gets configs from the specified TiKV stores.
+func GetConfigFromTiKVStores(
+	ctx context.Context,
+	stores []*metapb.Store,
+	cli *http.Client,
+	httpPrefix string,
+	fn func(*http.Response) error,
+) error {
+	for _, store := range stores {
+		if store.State != metapb.StoreState_Up {
+			continue
+		}
+		// We need make sure every available store support backup-stream otherwise we might lose data,
+		// so check every store's config.
+		addr, err := HandleTiKVAddress(store, httpPrefix)
+		if err != nil {
+			return err
+		}
+		configAddr := addr.JoinPath("config").String()
+
+		err = utils.WithRetry(ctx, func() error {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, configAddr, nil)
+			if err != nil {
+				return err
+			}
+			resp, err := cli.Do(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			return fn(resp)
+		}, utils.NewPDReqBackoffer())
+		if err != nil {
+			// if one store failed, break and return error
+			return err
+		}
+	}
+	return nil
+}
+
+// GetConfigBytesFromTiKVStores gets config response bodies from the specified TiKV stores.
+func GetConfigBytesFromTiKVStores(
+	ctx context.Context,
+	stores []*metapb.Store,
+	cli *http.Client,
+	httpPrefix string,
+	collect func([]byte) error,
+) error {
+	return GetConfigFromTiKVStores(ctx, stores, cli, httpPrefix, func(resp *http.Response) error {
+		if resp.StatusCode != http.StatusOK {
+			return errors.Errorf("request %s failed: %s", resp.Request.URL.String(), resp.Status)
+		}
+		respBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return collect(respBytes)
+	})
+}
+
+// HandleTiKVAddress returns the TiKV status HTTP address used to fetch configs.
+func HandleTiKVAddress(store *metapb.Store, httpPrefix string) (*url.URL, error) {
+	statusAddr := store.GetStatusAddress()
+	if statusAddr == "" {
+		return nil, errors.Errorf("TiKV store %d does not have status address", store.GetId())
+	}
+	nodeAddr := store.GetAddress()
+	if !strings.HasPrefix(statusAddr, "http") {
+		statusAddr = httpPrefix + statusAddr
+	}
+	if !strings.HasPrefix(nodeAddr, "http") {
+		nodeAddr = httpPrefix + nodeAddr
+	}
+
+	statusURL, err := url.Parse(statusAddr)
+	if err != nil {
+		return nil, err
+	}
+	nodeURL, err := url.Parse(nodeAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	// We try status address as default.
+	addr := statusURL
+	// But sometimes we may not get the correct status address from PD.
+	if statusURL.Hostname() != nodeURL.Hostname() {
+		// If not matched, use the address hostname but keep the status port.
+		addr.Host = net.JoinHostPort(nodeURL.Hostname(), statusURL.Port())
+		log.Warn("store address and status address mismatch the host, we will use the store address as hostname",
+			zap.Uint64("store", store.Id),
+			zap.String("status address", statusAddr),
+			zap.String("node address", nodeAddr),
+			zap.Any("request address", statusURL))
+	}
+	return addr, nil
 }

--- a/br/pkg/streamhelper/BUILD.bazel
+++ b/br/pkg/streamhelper/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/br/pkg/streamhelper",
     visibility = ["//visibility:public"],
     deps = [
+        "//br/pkg/conn/util",
         "//br/pkg/errors",
         "//br/pkg/logutil",
         "//br/pkg/storage",
@@ -72,7 +73,7 @@ go_test(
     embed = [":streamhelper"],
     flaky = True,
     race = "on",
-    shard_count = 42,
+    shard_count = 44,
     deps = [
         "//br/pkg/errors",
         "//br/pkg/logutil",

--- a/br/pkg/streamhelper/BUILD.bazel
+++ b/br/pkg/streamhelper/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//br/pkg/errors",
         "//br/pkg/logutil",
+        "//br/pkg/storage",
         "//br/pkg/streamhelper/config",
         "//br/pkg/streamhelper/spans",
         "//br/pkg/utils",
@@ -71,7 +72,7 @@ go_test(
     embed = [":streamhelper"],
     flaky = True,
     race = "on",
-    shard_count = 38,
+    shard_count = 42,
     deps = [
         "//br/pkg/errors",
         "//br/pkg/logutil",
@@ -80,6 +81,7 @@ go_test(
         "//br/pkg/streamhelper/spans",
         "//br/pkg/utils",
         "//pkg/kv",
+        "//pkg/metrics",
         "//pkg/sessionctx/variable",
         "//pkg/tablecodec",
         "//pkg/util/codec",
@@ -92,6 +94,7 @@ go_test(
         "@com_github_pingcap_kvproto//pkg/logbackuppb",
         "@com_github_pingcap_kvproto//pkg/metapb",
         "@com_github_pingcap_log//:log",
+        "@com_github_prometheus_client_golang//prometheus/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//kv",

--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -5,7 +5,9 @@ package streamhelper
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
+	"path"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -16,6 +18,7 @@ import (
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/logutil"
+	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/br/pkg/streamhelper/config"
 	"github.com/pingcap/tidb/br/pkg/streamhelper/spans"
 	"github.com/pingcap/tidb/br/pkg/utils"
@@ -31,6 +34,13 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
+
+const (
+	streamBackupGlobalCheckpointPrefix = "v1/global_checkpoint"
+	globalCheckpointFileName           = checkpointTypeGlobal + ".ts"
+)
+
+var createGlobalCheckpointStorage = storage.Create
 
 // CheckpointAdvancer is the central node for advancing the checkpoint of log backup.
 // It's a part of "checkpoint v3".
@@ -59,9 +69,10 @@ type CheckpointAdvancer struct {
 
 	// The concurrency accessed task:
 	// both by the task listener and ticking.
-	task      *backuppb.StreamBackupTaskInfo
-	taskRange []kv.KeyRange
-	taskMu    sync.Mutex
+	task              *backuppb.StreamBackupTaskInfo
+	taskRange         []kv.KeyRange
+	checkpointStorage storage.ExternalStorage
+	taskMu            sync.Mutex
 
 	// the read-only config.
 	// once tick begin, this should not be changed for now.
@@ -419,6 +430,7 @@ func (c *CheckpointAdvancer) onTaskEvent(ctx context.Context, e TaskEvent) error
 	switch e.Type {
 	case EventAdd:
 		utils.LogBackupTaskCountInc()
+		c.closeGlobalCheckpointStorage()
 		c.task = e.Info
 		c.taskRange = spans.Collapse(len(e.Ranges), func(i int) kv.KeyRange { return e.Ranges[i] })
 		c.setCheckpoints(spans.Sorted(spans.NewFullWith(e.Ranges, 0)))
@@ -440,6 +452,7 @@ func (c *CheckpointAdvancer) onTaskEvent(ctx context.Context, e TaskEvent) error
 			zap.Stringer("ranges", logutil.StringifyKeys(c.taskRange)), zap.Uint64("current-checkpoint", p))
 	case EventDel:
 		utils.LogBackupTaskCountDec()
+		c.closeGlobalCheckpointStorage()
 		c.task = nil
 		c.isPaused.Store(false)
 		c.taskRange = nil
@@ -456,6 +469,7 @@ func (c *CheckpointAdvancer) onTaskEvent(ctx context.Context, e TaskEvent) error
 			log.Warn("failed to remove service GC safepoint", logutil.ShortError(err))
 		}
 		metrics.LastCheckpoint.DeleteLabelValues(e.Name)
+		metrics.ExternalStorageCheckpoint.DeleteLabelValues(e.Name)
 	case EventPause:
 		if c.task.GetName() == e.Name {
 			c.isPaused.Store(true)
@@ -591,6 +605,69 @@ func (c *CheckpointAdvancer) isCheckpointLagged(ctx context.Context) (bool, erro
 	return false, nil
 }
 
+func (c *CheckpointAdvancer) closeGlobalCheckpointStorage() {
+	if c.checkpointStorage != nil {
+		c.checkpointStorage.Close()
+		c.checkpointStorage = nil
+	}
+}
+
+func (c *CheckpointAdvancer) getGlobalCheckpointStorage(ctx context.Context) (storage.ExternalStorage, error) {
+	if c.task == nil || c.task.GetStorage() == nil {
+		return nil, nil
+	}
+	if c.checkpointStorage != nil {
+		return c.checkpointStorage, nil
+	}
+
+	storage, err := createGlobalCheckpointStorage(ctx, c.task.GetStorage(), false)
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to create external storage for global checkpoint")
+	}
+	c.checkpointStorage = storage
+	return storage, nil
+}
+
+func (c *CheckpointAdvancer) writeGlobalCheckpointToStorage(ctx context.Context, checkpoint uint64) error {
+	storage, err := c.getGlobalCheckpointStorage(ctx)
+	if err != nil {
+		return err
+	}
+	if storage == nil {
+		return nil
+	}
+	data := make([]byte, 8)
+	binary.LittleEndian.PutUint64(data, checkpoint)
+	fileName := path.Join(streamBackupGlobalCheckpointPrefix, globalCheckpointFileName)
+	if err := storage.WriteFile(ctx, fileName, data); err != nil {
+		return errors.Annotate(err, "failed to write global checkpoint to external storage")
+	}
+	metrics.ExternalStorageCheckpoint.WithLabelValues(c.task.Name).Set(float64(checkpoint))
+	log.Info("uploaded global checkpoint to external storage",
+		zap.String("category", "log backup advancer"),
+		zap.Uint64("checkpoint", checkpoint),
+		zap.String("file", fileName))
+	return nil
+}
+
+func (c *CheckpointAdvancer) tryWriteGlobalCheckpointToStorage(ctx context.Context) {
+	if c.task == nil || c.task.GetStorage() == nil {
+		return
+	}
+	writeCtx, cancel := context.WithTimeout(ctx, c.Config().TickTimeout())
+	defer cancel()
+	globalCheckpoint, err := c.env.GetGlobalCheckpointForTask(writeCtx, c.task.Name)
+	if err != nil {
+		log.Warn("failed to get uploaded global checkpoint, skip uploading to external storage",
+			zap.String("category", "log backup advancer"), logutil.ShortError(err))
+		return
+	}
+	if err := c.writeGlobalCheckpointToStorage(writeCtx, globalCheckpoint); err != nil {
+		log.Warn("failed to upload global checkpoint to external storage, skip it",
+			zap.String("category", "log backup advancer"), logutil.ShortError(err))
+	}
+}
+
 func (c *CheckpointAdvancer) importantTick(ctx context.Context) error {
 	c.checkpointsMu.Lock()
 	c.setCheckpoint(c.checkpoints.Min())
@@ -624,6 +701,7 @@ func (c *CheckpointAdvancer) importantTick(ctx context.Context) error {
 	if p <= c.lastCheckpoint.safeTS() {
 		log.Info("updated log backup GC safe point.",
 			zap.Uint64("checkpoint", p), zap.Uint64("target", c.lastCheckpoint.safeTS()))
+		c.tryWriteGlobalCheckpointToStorage(ctx)
 	}
 	if p > c.lastCheckpoint.safeTS() {
 		log.Warn("update log backup GC safe point failed: stale.",

--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -92,6 +92,12 @@ type CheckpointAdvancer struct {
 	subscriberMu sync.Mutex
 }
 
+// Keep resolve-lock ScanLock maxVersion well behind very recent transactions.
+// client-go's default lock TTL is 3000ms; use 2x TTL here so ScanLock avoids
+// active memory locks that may trigger the locked error described in
+// https://github.com/pingcap/tidb/issues/57134.
+const resolveLockMaxVersionRecentMargin = 6 * time.Second
+
 // HasTask returns whether the advancer has been bound to a task.
 func (c *CheckpointAdvancer) HasTask() bool {
 	c.taskMu.Lock()
@@ -117,6 +123,9 @@ type checkpoint struct {
 
 	// It's better to use PD timestamp in future, for now
 	// use local time to decide the time to resolve lock is ok.
+	// It is refreshed when this checkpoint is created and after a successful
+	// resolve-lock round for the same checkpoint, so ScanLock is throttled by
+	// the configured flush interval.
 	resolveLockTime time.Time
 }
 
@@ -148,14 +157,12 @@ func (c *checkpoint) equal(o *checkpoint) bool {
 		bytes.Equal(c.EndKey, o.EndKey) && c.TS == o.TS
 }
 
-// if a checkpoint stay in a time too long(3 min)
-// we should try to resolve lock for the range
-// to keep the RPO in 5 min.
-func (c *checkpoint) needResolveLocks() bool {
+// if a checkpoint stays unchanged for too long, try to resolve locks for the range.
+func (c *checkpoint) needResolveLocks(interval time.Duration) bool {
 	failpoint.Inject("NeedResolveLocks", func(val failpoint.Value) {
 		failpoint.Return(val.(bool))
 	})
-	return time.Since(c.resolveLockTime) > 3*time.Minute
+	return time.Since(c.resolveLockTime) > interval
 }
 
 // NewTiDBCheckpointAdvancer creates a checkpoint advancer with the env in the TiDB node.
@@ -269,8 +276,11 @@ func (c *CheckpointAdvancer) tryAdvance(ctx context.Context, length int,
 }
 
 func tsoBefore(n time.Duration) uint64 {
-	now := time.Now()
-	return oracle.ComposeTS(now.UnixMilli()-n.Milliseconds(), 0)
+	return tsoBeforeFrom(time.Now(), n)
+}
+
+func tsoBeforeFrom(now time.Time, n time.Duration) uint64 {
+	return oracle.GoTimeToTS(now.Add(-n))
 }
 
 func tsoAfter(ts uint64, n time.Duration) uint64 {
@@ -711,28 +721,8 @@ func (c *CheckpointAdvancer) importantTick(ctx context.Context) error {
 }
 
 func (c *CheckpointAdvancer) optionalTick(cx context.Context) error {
-	// lastCheckpoint is not increased too long enough.
-	// assume the cluster has expired locks for whatever reasons.
-	var targets []spans.Valued
-	if c.lastCheckpoint != nil && c.lastCheckpoint.needResolveLocks() && c.inResolvingLock.CompareAndSwap(false, true) {
-		c.WithCheckpoints(func(vsf *spans.ValueSortedFull) {
-			// when get locks here. assume these locks are not belong to same txn,
-			// but these locks' start ts are close to 1 minute. try resolve these locks at one time
-			vsf.TraverseValuesLessThan(tsoAfter(c.lastCheckpoint.TS, time.Minute), func(v spans.Valued) bool {
-				targets = append(targets, v)
-				return true
-			})
-		})
-		if len(targets) != 0 {
-			log.Info("Advancer starts to resolve locks", zap.Int("targets", len(targets)))
-			// use new context here to avoid timeout
-			ctx := context.Background()
-			c.asyncResolveLocksForRanges(ctx, targets)
-		} else {
-			// don't forget set state back
-			c.inResolvingLock.Store(false)
-		}
-	}
+	c.tryResolveLocksForCheckpoint()
+
 	threshold := c.Config().GetDefaultStartPollThreshold()
 	if err := c.subscribeTick(cx); err != nil {
 		log.Warn("Subscriber meet error, would polling the checkpoint.", zap.String("category", "log backup advancer"),
@@ -743,6 +733,69 @@ func (c *CheckpointAdvancer) optionalTick(cx context.Context) error {
 	return c.advanceCheckpointBy(cx, func(cx context.Context) (spans.Valued, error) {
 		return c.CalculateGlobalCheckpointLight(cx, threshold)
 	})
+}
+
+func (c *CheckpointAdvancer) tryResolveLocksForCheckpoint() {
+	// lastCheckpoint is not increased for long enough.
+	// assume the cluster has expired locks for whatever reasons.
+	resolveLockInterval := c.Config().GetResolveLockInterval()
+	checkpointToResolve := c.checkpointToResolve(resolveLockInterval)
+	if checkpointToResolve == nil ||
+		!c.inResolvingLock.CompareAndSwap(false, true) {
+		return
+	}
+	now := time.Now()
+	safeMaxVersion := tsoBeforeFrom(now, resolveLockMaxVersionRecentMargin)
+	targetUpperBound := resolveLockTargetUpperBound(checkpointToResolve.TS, resolveLockInterval, now)
+	maxVersion := resolveLockMaxVersion(targetUpperBound, safeMaxVersion)
+	if maxVersion <= checkpointToResolve.TS {
+		log.Info("skip resolving locks because maxVersion is not greater than checkpoint",
+			zap.Uint64("checkpoint", checkpointToResolve.TS),
+			zap.Duration("resolve-lock-interval", resolveLockInterval),
+			zap.Uint64("target-upper-bound", targetUpperBound),
+			zap.Uint64("safe-max-version", safeMaxVersion),
+			zap.Uint64("max-version", maxVersion))
+		c.inResolvingLock.Store(false)
+		return
+	}
+	targets := c.resolveLockTargetsForCheckpoint(checkpointToResolve, targetUpperBound)
+	if len(targets) != 0 {
+		log.Info("Advancer starts to resolve locks",
+			zap.Int("targets", len(targets)),
+			zap.Duration("resolve-lock-interval", resolveLockInterval),
+			zap.Uint64("target-upper-bound", targetUpperBound),
+			zap.Uint64("safe-max-version", safeMaxVersion),
+			zap.Uint64("max-version", maxVersion))
+		// use new context here to avoid timeout
+		ctx := context.Background()
+		c.asyncResolveLocksForRanges(ctx, targets, checkpointToResolve, resolveLockInterval, targetUpperBound, safeMaxVersion, maxVersion)
+	} else {
+		// don't forget set state back
+		c.inResolvingLock.Store(false)
+	}
+}
+
+func (c *CheckpointAdvancer) checkpointToResolve(resolveLockInterval time.Duration) *checkpoint {
+	c.lastCheckpointMu.Lock()
+	defer c.lastCheckpointMu.Unlock()
+	if c.lastCheckpoint == nil || !c.lastCheckpoint.needResolveLocks(resolveLockInterval) {
+		return nil
+	}
+	return c.lastCheckpoint
+}
+
+func (c *CheckpointAdvancer) resolveLockTargetsForCheckpoint(checkpointToResolve *checkpoint, upperBound uint64) []spans.Valued {
+	var targets []spans.Valued
+	c.WithCheckpoints(func(vsf *spans.ValueSortedFull) {
+		if vsf == nil || vsf.MinValue() != checkpointToResolve.TS {
+			return
+		}
+		vsf.TraverseValuesLessThan(upperBound, func(v spans.Valued) bool {
+			targets = append(targets, v)
+			return true
+		})
+	})
+	return targets
 }
 
 func (c *CheckpointAdvancer) tick(ctx context.Context) error {
@@ -772,22 +825,48 @@ func (c *CheckpointAdvancer) tick(ctx context.Context) error {
 	return errs
 }
 
-func (c *CheckpointAdvancer) asyncResolveLocksForRanges(ctx context.Context, targets []spans.Valued) {
+func resolveLockTargetUpperBound(checkpointTS uint64, resolveLockInterval time.Duration, now time.Time) uint64 {
+	upperBound := checkpointTS + 1
+	if resolveLockInterval <= 0 {
+		return upperBound
+	}
+	if flushedBefore := tsoBeforeFrom(now, resolveLockInterval); flushedBefore > upperBound {
+		upperBound = flushedBefore
+	}
+	if checkpointWindow := tsoAfter(checkpointTS, resolveLockInterval/3); checkpointWindow > upperBound {
+		upperBound = checkpointWindow
+	}
+	return upperBound
+}
+
+func resolveLockMaxVersion(targetUpperBound uint64, safeMaxVersion uint64) uint64 {
+	if safeMaxVersion > 0 && safeMaxVersion < targetUpperBound {
+		return safeMaxVersion
+	}
+	return targetUpperBound
+}
+
+func (c *CheckpointAdvancer) asyncResolveLocksForRanges(
+	ctx context.Context,
+	targets []spans.Valued,
+	checkpointToResolve *checkpoint,
+	resolveLockInterval time.Duration,
+	targetUpperBound uint64,
+	safeMaxVersion uint64,
+	maxVersion uint64,
+) {
 	// run in another goroutine
 	// do not block main tick here
 	go func() {
 		failpoint.Inject("AsyncResolveLocks", func() {})
-		maxTs := uint64(0)
-		for _, t := range targets {
-			maxTs = max(maxTs, t.Value)
-		}
 		handler := func(ctx context.Context, r tikvstore.KeyRange) (rangetask.TaskStat, error) {
 			// we will scan all locks and try to resolve them by check txn status.
 			return tikv.ResolveLocksForRange(
-				ctx, c.env, maxTs+1, r.StartKey, r.EndKey, tikv.NewGcResolveLockMaxBackoffer, tikv.GCScanLockLimit)
+				ctx, c.env, maxVersion, r.StartKey, r.EndKey, tikv.NewGcResolveLockMaxBackoffer, tikv.GCScanLockLimit)
 		}
 		workerPool := util.NewWorkerPool(uint(config.DefaultMaxConcurrencyAdvance), "advancer resolve locks")
 		var wg sync.WaitGroup
+		var meetError atomic.Bool
 		for _, r := range targets {
 			targetRange := r
 			wg.Add(1)
@@ -802,6 +881,7 @@ func (c *CheckpointAdvancer) asyncResolveLocksForRanges(ctx context.Context, tar
 				err := runner.RunOnRange(ctx, targetRange.Key.StartKey, targetRange.Key.EndKey)
 				if err != nil {
 					// wait for next tick
+					meetError.Store(true)
 					log.Warn("resolve locks failed, wait for next tick", zap.String("category", "advancer"),
 						zap.String("uuid", "log backup advancer"),
 						zap.Error(err))
@@ -811,14 +891,28 @@ func (c *CheckpointAdvancer) asyncResolveLocksForRanges(ctx context.Context, tar
 		wg.Wait()
 		log.Info("finish resolve locks for checkpoint", zap.String("category", "advancer"),
 			zap.String("uuid", "log backup advancer"),
-			logutil.Key("StartKey", c.lastCheckpoint.StartKey),
-			logutil.Key("EndKey", c.lastCheckpoint.EndKey),
+			logutil.Key("StartKey", checkpointToResolve.StartKey),
+			logutil.Key("EndKey", checkpointToResolve.EndKey),
+			zap.Uint64("checkpoint", checkpointToResolve.TS),
+			zap.Duration("resolve-lock-interval", resolveLockInterval),
+			zap.Uint64("target-upper-bound", targetUpperBound),
+			zap.Uint64("safe-max-version", safeMaxVersion),
+			zap.Uint64("max-version", maxVersion),
 			zap.Int("targets", len(targets)))
-		c.lastCheckpointMu.Lock()
-		c.lastCheckpoint.resolveLockTime = time.Now()
-		c.lastCheckpointMu.Unlock()
+		c.updateResolveLockTimeAfterResolving(checkpointToResolve, meetError.Load())
 		c.inResolvingLock.Store(false)
 	}()
+}
+
+func (c *CheckpointAdvancer) updateResolveLockTimeAfterResolving(checkpointToResolve *checkpoint, meetError bool) {
+	if meetError {
+		return
+	}
+	c.lastCheckpointMu.Lock()
+	defer c.lastCheckpointMu.Unlock()
+	if c.lastCheckpoint != nil && c.lastCheckpoint.equal(checkpointToResolve) {
+		c.lastCheckpoint.resolveLockTime = time.Now()
+	}
 }
 
 func (c *CheckpointAdvancer) TEST_registerCallbackForSubscriptions(f func()) int {

--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -78,6 +78,9 @@ type CheckpointAdvancer struct {
 	// once tick begin, this should not be changed for now.
 	cfg config.Config
 
+	logBackupFlushIntervalGetter LogBackupFlushIntervalGetter
+	resolveLockInterval          atomic.Int64
+
 	// the cached last checkpoint.
 	// if no progress, this cache can help us don't to send useless requests.
 	lastCheckpoint   *checkpoint
@@ -92,11 +95,23 @@ type CheckpointAdvancer struct {
 	subscriberMu sync.Mutex
 }
 
-// Keep resolve-lock ScanLock maxVersion well behind very recent transactions.
-// client-go's default lock TTL is 3000ms; use 2x TTL here so ScanLock avoids
-// active memory locks that may trigger the locked error described in
-// https://github.com/pingcap/tidb/issues/57134.
-const resolveLockMaxVersionRecentMargin = 6 * time.Second
+const (
+	// Keep resolve-lock ScanLock maxVersion well behind very recent transactions.
+	// client-go's default lock TTL is 3000ms; use 2x TTL here so ScanLock avoids
+	// active memory locks that may trigger the locked error described in
+	// https://github.com/pingcap/tidb/issues/57134.
+	resolveLockMaxVersionRecentMargin = 6 * time.Second
+
+	// If ScanLock still meets a newer in-memory lock, retry with a lower
+	// maxVersion. Keep the retry bounded so an active workload cannot make the
+	// advancer scan locks repeatedly in one tick.
+	resolveLockMaxVersionMaxRetry = 2
+
+	logBackupConfigRefreshInterval = time.Minute
+	logBackupConfigFetchTimeout    = 10 * time.Second
+)
+
+type LogBackupFlushIntervalGetter func(context.Context) (time.Duration, error)
 
 // HasTask returns whether the advancer has been bound to a task.
 func (c *CheckpointAdvancer) HasTask() bool {
@@ -189,6 +204,18 @@ func (c *CheckpointAdvancer) UpdateConfig(newConf config.Config) {
 	c.cfg = newConf
 }
 
+// SetLogBackupFlushIntervalGetter sets a getter that periodically refreshes TiKV log-backup.flush-interval.
+func (c *CheckpointAdvancer) SetLogBackupFlushIntervalGetter(getter LogBackupFlushIntervalGetter) {
+	c.logBackupFlushIntervalGetter = getter
+}
+
+func (c *CheckpointAdvancer) getResolveLockInterval() time.Duration {
+	if interval := time.Duration(c.resolveLockInterval.Load()); interval > 0 {
+		return interval
+	}
+	return c.Config().GetResolveLockInterval()
+}
+
 // UpdateLastCheckpoint modify the checkpoint in ticking.
 func (c *CheckpointAdvancer) UpdateLastCheckpoint(p *checkpoint) {
 	c.lastCheckpointMu.Lock()
@@ -204,6 +231,59 @@ func (c *CheckpointAdvancer) Config() config.Config {
 // GetInResolvingLock only used for test.
 func (c *CheckpointAdvancer) GetInResolvingLock() bool {
 	return c.inResolvingLock.Load()
+}
+
+func (c *CheckpointAdvancer) spawnLogBackupConfigUpdater(ctx context.Context) {
+	if c.logBackupFlushIntervalGetter == nil {
+		return
+	}
+	go c.runLogBackupConfigUpdater(ctx)
+}
+
+func (c *CheckpointAdvancer) runLogBackupConfigUpdater(ctx context.Context) {
+	c.refreshLogBackupFlushInterval(ctx)
+	ticker := time.NewTicker(logBackupConfigRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.refreshLogBackupFlushInterval(ctx)
+		}
+	}
+}
+
+func (c *CheckpointAdvancer) refreshLogBackupFlushInterval(ctx context.Context) {
+	if c.logBackupFlushIntervalGetter == nil {
+		return
+	}
+	timeout := c.Config().TickTimeout()
+	if timeout < logBackupConfigFetchTimeout {
+		timeout = logBackupConfigFetchTimeout
+	}
+	fetchCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	flushInterval, err := c.logBackupFlushIntervalGetter(fetchCtx)
+	if err != nil {
+		log.Warn("failed to refresh TiKV log-backup.flush-interval; keep previous resolve lock interval",
+			zap.Duration("current-resolve-lock-interval", c.getResolveLockInterval()),
+			logutil.ShortError(err))
+		return
+	}
+	if flushInterval <= 0 {
+		log.Warn("ignore invalid TiKV log-backup.flush-interval; keep previous resolve lock interval",
+			zap.Duration("flush-interval", flushInterval),
+			zap.Duration("current-resolve-lock-interval", c.getResolveLockInterval()))
+		return
+	}
+	previous := c.getResolveLockInterval()
+	c.resolveLockInterval.Store(int64(flushInterval))
+	if previous != flushInterval {
+		log.Info("refreshed TiKV log-backup.flush-interval for resolve lock",
+			zap.Duration("previous-resolve-lock-interval", previous),
+			zap.Duration("resolve-lock-interval", flushInterval))
+	}
 }
 
 // GetCheckpointInRange scans the regions in the range,
@@ -281,6 +361,15 @@ func tsoBefore(n time.Duration) uint64 {
 
 func tsoBeforeFrom(now time.Time, n time.Duration) uint64 {
 	return oracle.GoTimeToTS(now.Add(-n))
+}
+
+func tsoBeforeFromTS(ts uint64, n time.Duration) uint64 {
+	physical := oracle.ExtractPhysical(ts)
+	beforePhysical := physical - n.Milliseconds()
+	if beforePhysical <= 0 {
+		return 0
+	}
+	return oracle.ComposeTS(beforePhysical, 0)
 }
 
 func tsoAfter(ts uint64, n time.Duration) uint64 {
@@ -721,7 +810,7 @@ func (c *CheckpointAdvancer) importantTick(ctx context.Context) error {
 }
 
 func (c *CheckpointAdvancer) optionalTick(cx context.Context) error {
-	c.tryResolveLocksForCheckpoint()
+	c.tryResolveLocksForCheckpoint(cx)
 
 	threshold := c.Config().GetDefaultStartPollThreshold()
 	if err := c.subscribeTick(cx); err != nil {
@@ -735,26 +824,38 @@ func (c *CheckpointAdvancer) optionalTick(cx context.Context) error {
 	})
 }
 
-func (c *CheckpointAdvancer) tryResolveLocksForCheckpoint() {
+func (c *CheckpointAdvancer) tryResolveLocksForCheckpoint(ctx context.Context) {
 	// lastCheckpoint is not increased for long enough.
 	// assume the cluster has expired locks for whatever reasons.
-	resolveLockInterval := c.Config().GetResolveLockInterval()
+	resolveLockInterval := c.getResolveLockInterval()
 	checkpointToResolve := c.checkpointToResolve(resolveLockInterval)
 	if checkpointToResolve == nil ||
 		!c.inResolvingLock.CompareAndSwap(false, true) {
 		return
 	}
-	now := time.Now()
-	safeMaxVersion := tsoBeforeFrom(now, resolveLockMaxVersionRecentMargin)
-	targetUpperBound := resolveLockTargetUpperBound(checkpointToResolve.TS, resolveLockInterval, now)
+	currentTS, err := c.env.FetchCurrentTS(ctx)
+	if err != nil {
+		log.Warn("failed to fetch current timestamp for resolving locks",
+			zap.Duration("resolve-lock-interval", resolveLockInterval),
+			logutil.ShortError(err))
+		c.inResolvingLock.Store(false)
+		return
+	}
+	safeMaxVersion := tsoBeforeFromTS(currentTS, resolveLockMaxVersionRecentMargin)
+	targetUpperBound := resolveLockTargetUpperBound(checkpointToResolve.TS, resolveLockInterval, currentTS)
 	maxVersion := resolveLockMaxVersion(targetUpperBound, safeMaxVersion)
+	retryStartMaxVersion, retryStartValid := resolveLockRetryStartMaxVersion(
+		checkpointToResolve.TS, resolveLockInterval, currentTS, maxVersion)
 	if maxVersion <= checkpointToResolve.TS {
 		log.Info("skip resolving locks because maxVersion is not greater than checkpoint",
 			zap.Uint64("checkpoint", checkpointToResolve.TS),
+			zap.Uint64("current-ts", currentTS),
 			zap.Duration("resolve-lock-interval", resolveLockInterval),
 			zap.Uint64("target-upper-bound", targetUpperBound),
 			zap.Uint64("safe-max-version", safeMaxVersion),
-			zap.Uint64("max-version", maxVersion))
+			zap.Uint64("max-version", maxVersion),
+			zap.Uint64("retry-start-max-version", retryStartMaxVersion),
+			zap.Bool("retry-start-valid", retryStartValid))
 		c.inResolvingLock.Store(false)
 		return
 	}
@@ -763,12 +864,16 @@ func (c *CheckpointAdvancer) tryResolveLocksForCheckpoint() {
 		log.Info("Advancer starts to resolve locks",
 			zap.Int("targets", len(targets)),
 			zap.Duration("resolve-lock-interval", resolveLockInterval),
+			zap.Uint64("current-ts", currentTS),
 			zap.Uint64("target-upper-bound", targetUpperBound),
 			zap.Uint64("safe-max-version", safeMaxVersion),
-			zap.Uint64("max-version", maxVersion))
+			zap.Uint64("max-version", maxVersion),
+			zap.Uint64("retry-start-max-version", retryStartMaxVersion),
+			zap.Bool("retry-start-valid", retryStartValid))
 		// use new context here to avoid timeout
 		ctx := context.Background()
-		c.asyncResolveLocksForRanges(ctx, targets, checkpointToResolve, resolveLockInterval, targetUpperBound, safeMaxVersion, maxVersion)
+		c.asyncResolveLocksForRanges(ctx, targets, checkpointToResolve, resolveLockInterval,
+			targetUpperBound, safeMaxVersion, maxVersion, retryStartMaxVersion, retryStartValid)
 	} else {
 		// don't forget set state back
 		c.inResolvingLock.Store(false)
@@ -825,12 +930,12 @@ func (c *CheckpointAdvancer) tick(ctx context.Context) error {
 	return errs
 }
 
-func resolveLockTargetUpperBound(checkpointTS uint64, resolveLockInterval time.Duration, now time.Time) uint64 {
+func resolveLockTargetUpperBound(checkpointTS uint64, resolveLockInterval time.Duration, currentTS uint64) uint64 {
 	upperBound := checkpointTS + 1
 	if resolveLockInterval <= 0 {
 		return upperBound
 	}
-	if flushedBefore := tsoBeforeFrom(now, resolveLockInterval); flushedBefore > upperBound {
+	if flushedBefore := tsoBeforeFromTS(currentTS, resolveLockInterval); flushedBefore > upperBound {
 		upperBound = flushedBefore
 	}
 	if checkpointWindow := tsoAfter(checkpointTS, resolveLockInterval/3); checkpointWindow > upperBound {
@@ -846,6 +951,72 @@ func resolveLockMaxVersion(targetUpperBound uint64, safeMaxVersion uint64) uint6
 	return targetUpperBound
 }
 
+func resolveLockRetryStartMaxVersion(
+	checkpointTS uint64,
+	resolveLockInterval time.Duration,
+	currentTS uint64,
+	maxVersion uint64,
+) (uint64, bool) {
+	if resolveLockInterval <= 0 {
+		return 0, false
+	}
+	flushedBefore := tsoBeforeFromTS(currentTS, resolveLockInterval)
+	checkpointWindow := tsoAfter(checkpointTS, resolveLockInterval/3)
+	retryStartMaxVersion := min(checkpointWindow, flushedBefore)
+	return retryStartMaxVersion, retryStartMaxVersion > checkpointTS && retryStartMaxVersion < maxVersion
+}
+
+func isScanLockLockedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := err.Error()
+	return strings.Contains(errMsg, "unexpected scanlock error") &&
+		strings.Contains(errMsg, "locked")
+}
+
+func lowerResolveLockMaxVersion(maxVersion uint64, lowerBound uint64) (uint64, bool) {
+	if maxVersion <= lowerBound || maxVersion-lowerBound <= 1 {
+		return 0, false
+	}
+	// Lower within the unresolved checkpoint window instead of subtracting a
+	// fixed duration, so a large lag can move away from recent memory locks fast
+	// while still keeping maxVersion above the checkpoint.
+	return lowerBound + (maxVersion-lowerBound)/2, true
+}
+
+func resolveLocksForRangeWithMaxVersionRetry(
+	ctx context.Context,
+	resolver tikv.RegionLockResolver,
+	maxVersion uint64,
+	minMaxVersion uint64,
+	retryStartMaxVersion uint64,
+	retryStartValid bool,
+	startKey []byte,
+	endKey []byte,
+) (rangetask.TaskStat, error) {
+	currentMaxVersion := maxVersion
+	for retry := 0; ; retry++ {
+		stat, err := tikv.ResolveLocksForRange(
+			ctx, resolver, currentMaxVersion, startKey, endKey, tikv.NewGcResolveLockMaxBackoffer, tikv.GCScanLockLimit)
+		if err == nil || !isScanLockLockedError(err) || retry >= resolveLockMaxVersionMaxRetry {
+			return stat, err
+		}
+		nextMaxVersion, ok := retryStartMaxVersion, retryStartValid && retry == 0
+		if !ok {
+			nextMaxVersion, ok = lowerResolveLockMaxVersion(currentMaxVersion, minMaxVersion)
+		}
+		if !ok {
+			return stat, err
+		}
+		log.Warn("retry resolving locks with lower maxVersion due to ScanLock locked error",
+			zap.Uint64("current-max-version", currentMaxVersion),
+			zap.Uint64("next-max-version", nextMaxVersion),
+			logutil.ShortError(err))
+		currentMaxVersion = nextMaxVersion
+	}
+}
+
 func (c *CheckpointAdvancer) asyncResolveLocksForRanges(
 	ctx context.Context,
 	targets []spans.Valued,
@@ -854,6 +1025,8 @@ func (c *CheckpointAdvancer) asyncResolveLocksForRanges(
 	targetUpperBound uint64,
 	safeMaxVersion uint64,
 	maxVersion uint64,
+	retryStartMaxVersion uint64,
+	retryStartValid bool,
 ) {
 	// run in another goroutine
 	// do not block main tick here
@@ -861,8 +1034,9 @@ func (c *CheckpointAdvancer) asyncResolveLocksForRanges(
 		failpoint.Inject("AsyncResolveLocks", func() {})
 		handler := func(ctx context.Context, r tikvstore.KeyRange) (rangetask.TaskStat, error) {
 			// we will scan all locks and try to resolve them by check txn status.
-			return tikv.ResolveLocksForRange(
-				ctx, c.env, maxVersion, r.StartKey, r.EndKey, tikv.NewGcResolveLockMaxBackoffer, tikv.GCScanLockLimit)
+			return resolveLocksForRangeWithMaxVersionRetry(
+				ctx, c.env, maxVersion, checkpointToResolve.TS, retryStartMaxVersion, retryStartValid,
+				r.StartKey, r.EndKey)
 		}
 		workerPool := util.NewWorkerPool(uint(config.DefaultMaxConcurrencyAdvance), "advancer resolve locks")
 		var wg sync.WaitGroup
@@ -898,6 +1072,8 @@ func (c *CheckpointAdvancer) asyncResolveLocksForRanges(
 			zap.Uint64("target-upper-bound", targetUpperBound),
 			zap.Uint64("safe-max-version", safeMaxVersion),
 			zap.Uint64("max-version", maxVersion),
+			zap.Uint64("retry-start-max-version", retryStartMaxVersion),
+			zap.Bool("retry-start-valid", retryStartValid),
 			zap.Int("targets", len(targets)))
 		c.updateResolveLockTimeAfterResolving(checkpointToResolve, meetError.Load())
 		c.inResolvingLock.Store(false)

--- a/br/pkg/streamhelper/advancer_daemon.go
+++ b/br/pkg/streamhelper/advancer_daemon.go
@@ -35,6 +35,7 @@ func (c *CheckpointAdvancer) OnStart(ctx context.Context) {
 func (c *CheckpointAdvancer) OnBecomeOwner(ctx context.Context) {
 	metrics.AdvancerOwner.Set(1.0)
 	c.SpawnSubscriptionHandler(ctx)
+	c.spawnLogBackupConfigUpdater(ctx)
 	go func() {
 		<-ctx.Done()
 		c.OnStop()

--- a/br/pkg/streamhelper/advancer_daemon.go
+++ b/br/pkg/streamhelper/advancer_daemon.go
@@ -49,6 +49,10 @@ func (c *CheckpointAdvancer) Name() string {
 func (c *CheckpointAdvancer) OnStop() {
 	metrics.AdvancerOwner.Set(0.0)
 	metrics.LastCheckpoint.Reset()
+	metrics.ExternalStorageCheckpoint.Reset()
+	c.taskMu.Lock()
+	c.closeGlobalCheckpointStorage()
+	c.taskMu.Unlock()
 	c.stopSubscriber()
 }
 

--- a/br/pkg/streamhelper/advancer_env.go
+++ b/br/pkg/streamhelper/advancer_env.go
@@ -4,19 +4,23 @@ package streamhelper
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"time"
 
 	"github.com/pingcap/errors"
 	logbackup "github.com/pingcap/kvproto/pkg/logbackuppb"
+	"github.com/pingcap/log"
+	connutil "github.com/pingcap/tidb/br/pkg/conn/util"
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/pkg/config"
+	tidbutil "github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/engine"
-	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/txnkv/txnlock"
 	pd "github.com/tikv/pd/client"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 )
@@ -70,9 +74,8 @@ func (c PDRegionScanner) UnblockGC(ctx context.Context) error {
 	return err
 }
 
-// TODO: It should be able to synchoronize the current TS with the PD.
 func (c PDRegionScanner) FetchCurrentTS(ctx context.Context) (uint64, error) {
-	return oracle.ComposeTS(time.Now().UnixMilli(), 0), nil
+	return connutil.GetCurrentTsFromPDWithRetry(ctx, c.Client)
 }
 
 // RegionScan gets a list of regions, starts from the region that contains key.
@@ -165,6 +168,82 @@ func TiDBEnv(tikvStore tikv.Storage, pdCli pd.Client, etcdCli *clientv3.Client, 
 
 	env.clis.DialTimeout = dialTimeOut
 	return env, nil
+}
+
+func NewTiDBLogBackupFlushIntervalGetter(pdClient pd.Client) LogBackupFlushIntervalGetter {
+	return func(ctx context.Context) (time.Duration, error) {
+		return GetLogBackupFlushIntervalFromTiKVConfig(ctx, func(ctx context.Context, collect func([]byte) error) error {
+			stores, err := connutil.GetAllTiKVStores(ctx, pdClient, connutil.SkipTiFlash)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			return connutil.GetConfigBytesFromTiKVStores(ctx, stores, tidbutil.InternalHTTPClient(),
+				tidbutil.InternalHTTPSchema()+"://", collect)
+		})
+	}
+}
+
+func GetLogBackupFlushIntervalFromTiKVConfig(
+	ctx context.Context,
+	fetchTiKVConfigs func(context.Context, func([]byte) error) error,
+) (time.Duration, error) {
+	var maxFlushInterval time.Duration
+	var minFlushInterval time.Duration
+	storeCount := 0
+	err := fetchTiKVConfigs(ctx, func(resp []byte) error {
+		flushInterval, err := parseLogBackupFlushIntervalFromConfig(resp)
+		if err != nil {
+			log.Warn("failed to parse log-backup.flush-interval from TiKV config", zap.Error(err))
+			return err
+		}
+		if storeCount == 0 || flushInterval < minFlushInterval {
+			minFlushInterval = flushInterval
+		}
+		if flushInterval > maxFlushInterval {
+			maxFlushInterval = flushInterval
+		}
+		storeCount++
+		return nil
+	})
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	if storeCount == 0 {
+		return 0, errors.New("no TiKV config found for log-backup.flush-interval")
+	}
+	if minFlushInterval != maxFlushInterval {
+		log.Warn("TiKV log-backup.flush-interval is not consistent; use the max value for resolve lock",
+			zap.Int("stores", storeCount),
+			zap.Duration("min-flush-interval", minFlushInterval),
+			zap.Duration("max-flush-interval", maxFlushInterval))
+	}
+	return maxFlushInterval, nil
+}
+
+func parseLogBackupFlushIntervalFromConfig(resp []byte) (time.Duration, error) {
+	type logbackup struct {
+		FlushInterval string `json:"flush-interval"`
+	}
+
+	type config struct {
+		LogBackup logbackup `json:"log-backup"`
+	}
+	var c config
+	e := json.Unmarshal(resp, &c)
+	if e != nil {
+		return 0, e
+	}
+	if c.LogBackup.FlushInterval == "" {
+		return 0, errors.New("log-backup.flush-interval is not found in TiKV config")
+	}
+	flushInterval, e := time.ParseDuration(c.LogBackup.FlushInterval)
+	if e != nil {
+		return 0, errors.Annotate(e, "failed to parse log-backup.flush-interval from TiKV config")
+	}
+	if flushInterval <= 0 {
+		return 0, errors.Errorf("invalid log-backup.flush-interval %s", c.LogBackup.FlushInterval)
+	}
+	return flushInterval, nil
 }
 
 type LogBackupService interface {

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -3,7 +3,6 @@
 package streamhelper_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -587,7 +586,7 @@ func TestResolveLock(t *testing.T) {
 
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx := context.Background()
-	minCheckpoint := c.advanceCheckpoints()
+	minCheckpoint := oracle.GoTimeToTS(time.Now().Add(-10 * time.Second))
 	env := newTestEnv(c, t)
 
 	lockRegion := c.findRegionByKey([]byte("01"))
@@ -628,33 +627,24 @@ func TestResolveLock(t *testing.T) {
 		})
 		<-allowResolve
 		// The third lock has skipped, because it's less than max version.
+		resolveLockRef.Store(true)
+		// Locks close to the current checkpoint should be scanned in one round.
 		require.ElementsMatch(t, locks, allLocks[:2])
 		resolveLockRef.Store(true)
 		return loc, nil
 	}
 	adv := streamhelper.NewCheckpointAdvancer(env)
+	adv.UpdateConfigWith(func(c *config.CommandConfig) {
+		c.TickDuration = 50 * time.Millisecond
+	})
 	adv.StartTaskListener(ctx)
 
-	coll := streamhelper.NewClusterCollector(ctx, env)
-	coll.SetOnSuccessHook(func(u uint64, kr kv.KeyRange) {
-		adv.WithCheckpoints(func(s *spans.ValueSortedFull) {
-			for _, lock := range allLocks {
-				// if there is any lock key in the range
-				if bytes.Compare(kr.StartKey, lock.Key) <= 0 && (bytes.Compare(lock.Key, kr.EndKey) < 0 || len(kr.EndKey) == 0) {
-					// mock lock behavior, do not update checkpoint
-					s.Merge(spans.Valued{Key: kr, Value: minCheckpoint})
-					return
-				}
-			}
-			s.Merge(spans.Valued{Key: kr, Value: u})
-		})
+	outsideUpperBoundTS := oracle.GoTimeToTS(oracle.GetTimeFromTS(minCheckpoint).Add(2 * time.Minute))
+	adv.WithCheckpoints(func(s *spans.ValueSortedFull) {
+		s.Merge(spans.Valued{Key: kv.KeyRange{}, Value: minCheckpoint})
+		s.Merge(spans.Valued{Key: kv.KeyRange{EndKey: lockRegion.Range.StartKey}, Value: outsideUpperBoundTS})
+		s.Merge(spans.Valued{Key: kv.KeyRange{StartKey: lockRegion.Range.EndKey}, Value: outsideUpperBoundTS})
 	})
-	err := adv.GetCheckpointInRange(ctx, []byte{}, []byte{}, coll)
-	require.NoError(t, err)
-	r, err := coll.Finish(ctx)
-	require.NoError(t, err)
-	require.Len(t, r.FailureSubRanges, 0)
-	require.Equal(t, r.Checkpoint, minCheckpoint, "%d %d", r.Checkpoint, minCheckpoint)
 
 	require.NoError(t, adv.OnTick(ctx))
 
@@ -682,11 +672,125 @@ func TestResolveLock(t *testing.T) {
 	case <-time.After(time.Second):
 		require.Fail(t, "timed out waiting for advancer tick to finish")
 	}
+	adv.TESTSetLastCheckpointToCurrentMin()
+	require.Equal(t, 1, adv.TESTResolveLockTargetCount())
+	time.Sleep(adv.Config().GetResolveLockInterval() + 10*time.Millisecond)
+	adv.TESTTryResolveLocksForCheckpoint()
 	require.Eventually(t, func() bool { return resolveLockRef.Load() },
 		8*time.Second, 50*time.Microsecond)
 	// state must set to false after tick
 	require.Eventually(t, func() bool { return !adv.GetInResolvingLock() },
 		8*time.Second, 50*time.Microsecond)
+}
+
+func TestResolveLockMaxVersion(t *testing.T) {
+	checkpointTime := time.Unix(100, 0)
+	checkpointTS := oracle.GoTimeToTS(checkpointTime)
+	resolveLockInterval := 30 * time.Second
+
+	require.Equal(t,
+		oracle.GoTimeToTS(checkpointTime.Add(10*time.Second)),
+		streamhelper.TESTResolveLockTargetUpperBound(checkpointTS, resolveLockInterval, checkpointTime.Add(35*time.Second)))
+	require.Equal(t,
+		oracle.GoTimeToTS(checkpointTime.Add(30*time.Second)),
+		streamhelper.TESTResolveLockTargetUpperBound(checkpointTS, resolveLockInterval, checkpointTime.Add(time.Minute)))
+	require.Equal(t,
+		checkpointTS+1,
+		streamhelper.TESTResolveLockTargetUpperBound(checkpointTS, 0, checkpointTime.Add(time.Minute)))
+
+	targetUpperBound := oracle.GoTimeToTS(checkpointTime.Add(30 * time.Second))
+	require.Equal(t,
+		targetUpperBound,
+		streamhelper.TESTResolveLockMaxVersion(targetUpperBound, oracle.GoTimeToTS(checkpointTime.Add(40*time.Second))))
+	require.Equal(t,
+		oracle.GoTimeToTS(checkpointTime.Add(24*time.Second)),
+		streamhelper.TESTResolveLockMaxVersion(targetUpperBound, oracle.GoTimeToTS(checkpointTime.Add(24*time.Second))))
+}
+
+func TestResolveLockTargetsUseUpperBound(t *testing.T) {
+	c := createFakeCluster(t, 4, false)
+	ctx := context.Background()
+	env := newTestEnv(c, t)
+	adv := streamhelper.NewCheckpointAdvancer(env)
+	adv.UpdateConfigWith(func(c *config.CommandConfig) {
+		c.TickDuration = 10 * time.Second
+	})
+	adv.StartTaskListener(ctx)
+
+	checkpointTime := time.Now().Add(-25 * time.Second)
+	checkpointTS := oracle.GoTimeToTS(checkpointTime)
+	withinUpperBoundTS := oracle.GoTimeToTS(checkpointTime.Add(6 * time.Second))
+	outsideUpperBoundTS := oracle.GoTimeToTS(checkpointTime.Add(8 * time.Second))
+	adv.WithCheckpoints(func(s *spans.ValueSortedFull) {
+		s.Merge(spans.Valued{Key: kv.KeyRange{}, Value: checkpointTS})
+		s.Merge(spans.Valued{Key: kv.KeyRange{StartKey: []byte("a"), EndKey: []byte("b")}, Value: withinUpperBoundTS})
+		s.Merge(spans.Valued{Key: kv.KeyRange{StartKey: []byte("b")}, Value: outsideUpperBoundTS})
+	})
+
+	adv.TESTSetLastCheckpointToCurrentMin()
+	require.Equal(t, 2, adv.TESTResolveLockTargetCount())
+}
+
+func TestResolveLockRetryWhenCheckpointNotAdvanced(t *testing.T) {
+	c := createFakeCluster(t, 4, false)
+	defer func() {
+		if t.Failed() {
+			fmt.Println(c)
+		}
+	}()
+
+	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
+	ctx := context.Background()
+	minCheckpoint := oracle.GoTimeToTS(time.Now().Add(-10 * time.Second))
+	env := newTestEnv(c, t)
+
+	lockRegion := c.FindRegionByKey([]byte("01"))
+	allLocks := []*txnlock.Lock{
+		{
+			Key:   []byte("011"),
+			TxnID: minCheckpoint,
+		},
+	}
+	c.LockRegion(lockRegion, allLocks)
+
+	resolveLockCount := atomic.NewInt32(0)
+	env.resolveLocks = func(locks []*txnlock.Lock, loc *tikv.KeyLocation) (*tikv.KeyLocation, error) {
+		require.ElementsMatch(t, locks, allLocks)
+		resolveLockCount.Inc()
+		return loc, nil
+	}
+
+	adv := streamhelper.NewCheckpointAdvancer(env)
+	adv.UpdateConfigWith(func(c *config.CommandConfig) {
+		c.TickDuration = 50 * time.Millisecond
+	})
+	adv.StartTaskListener(ctx)
+
+	outsideUpperBoundTS := oracle.GoTimeToTS(oracle.GetTimeFromTS(minCheckpoint).Add(2 * time.Minute))
+	adv.WithCheckpoints(func(s *spans.ValueSortedFull) {
+		s.Merge(spans.Valued{Key: kv.KeyRange{}, Value: minCheckpoint})
+		s.Merge(spans.Valued{Key: kv.KeyRange{EndKey: lockRegion.Range.StartKey}, Value: outsideUpperBoundTS})
+		s.Merge(spans.Valued{Key: kv.KeyRange{StartKey: lockRegion.Range.EndKey}, Value: outsideUpperBoundTS})
+	})
+	adv.TESTSetLastCheckpointToCurrentMin()
+	require.Equal(t, 1, adv.TESTResolveLockTargetCount())
+	time.Sleep(adv.Config().GetResolveLockInterval() + 10*time.Millisecond)
+
+	adv.TESTTryResolveLocksForCheckpoint()
+	require.Eventually(t, func() bool {
+		return resolveLockCount.Load() == 1 && !adv.GetInResolvingLock()
+	}, time.Second, time.Millisecond)
+
+	lockRegion.Locks = allLocks
+	adv.TESTTryResolveLocksForCheckpoint()
+	time.Sleep(adv.Config().GetResolveLockInterval() / 2)
+	require.Equal(t, int32(1), resolveLockCount.Load())
+
+	time.Sleep(adv.Config().GetResolveLockInterval() + 10*time.Millisecond)
+	adv.TESTTryResolveLocksForCheckpoint()
+	require.Eventually(t, func() bool {
+		return resolveLockCount.Load() == 2 && !adv.GetInResolvingLock()
+	}, time.Second, time.Millisecond)
 }
 
 func TestOwnerDropped(t *testing.T) {

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -587,6 +587,7 @@ func TestResolveLock(t *testing.T) {
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx := context.Background()
 	minCheckpoint := oracle.GoTimeToTS(time.Now().Add(-10 * time.Second))
+	c.SetCurrentTS(oracle.GoTimeToTS(oracle.GetTimeFromTS(minCheckpoint).Add(10 * time.Second)))
 	env := newTestEnv(c, t)
 
 	lockRegion := c.findRegionByKey([]byte("01"))
@@ -683,6 +684,83 @@ func TestResolveLock(t *testing.T) {
 		8*time.Second, 50*time.Microsecond)
 }
 
+func TestResolveLockRetryWithLowerMaxVersionOnScanLockLocked(t *testing.T) {
+	c := createFakeCluster(t, 4, false)
+	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
+	ctx := context.Background()
+	checkpointTime := time.Now().Add(-30 * time.Second)
+	minCheckpoint := oracle.GoTimeToTS(checkpointTime)
+	c.SetCurrentTS(oracle.GoTimeToTS(checkpointTime.Add(30 * time.Second)))
+	env := newTestEnv(c, t)
+
+	lockRegion := c.FindRegionByKey([]byte("01"))
+	allLocks := []*txnlock.Lock{
+		{
+			Key:   []byte("011"),
+			TxnID: oracle.GoTimeToTS(checkpointTime.Add(time.Millisecond)),
+		},
+	}
+	c.LockRegion(lockRegion, allLocks)
+
+	scanLockCount := atomic.NewInt32(0)
+	firstMaxVersion := atomic.NewUint64(0)
+	secondMaxVersion := atomic.NewUint64(0)
+	thirdMaxVersion := atomic.NewUint64(0)
+	env.scanLocks = func(_ []byte, _ []byte, maxVersion uint64) ([]*txnlock.Lock, *tikv.KeyLocation, error) {
+		switch scanLockCount.Inc() {
+		case 1:
+			firstMaxVersion.Store(maxVersion)
+			return nil, nil, errors.New("unexpected scanlock error: error:<locked:<primary_lock:\"011\" lock_version:1>>")
+		case 2:
+			secondMaxVersion.Store(maxVersion)
+			return nil, nil, errors.New("unexpected scanlock error: error:<locked:<primary_lock:\"011\" lock_version:1>>")
+		case 3:
+			thirdMaxVersion.Store(maxVersion)
+			return allLocks, &tikv.KeyLocation{Region: tikv.NewRegionVerID(lockRegion.ID, 0, 0)}, nil
+		default:
+			return nil, nil, errors.Errorf("unexpected scan lock retry count %d", scanLockCount.Load())
+		}
+	}
+
+	resolveLockCount := atomic.NewInt32(0)
+	env.resolveLocks = func(locks []*txnlock.Lock, loc *tikv.KeyLocation) (*tikv.KeyLocation, error) {
+		resolveLockCount.Inc()
+		require.ElementsMatch(t, locks, allLocks)
+		return loc, nil
+	}
+
+	adv := streamhelper.NewCheckpointAdvancer(env)
+	adv.UpdateConfigWith(func(c *config.CommandConfig) {
+		c.TickDuration = 50 * time.Millisecond
+	})
+	adv.StartTaskListener(ctx)
+
+	outsideUpperBoundTS := oracle.GoTimeToTS(checkpointTime.Add(2 * time.Minute))
+	adv.WithCheckpoints(func(s *spans.ValueSortedFull) {
+		s.Merge(spans.Valued{Key: kv.KeyRange{}, Value: minCheckpoint})
+		s.Merge(spans.Valued{Key: kv.KeyRange{EndKey: lockRegion.Range.StartKey}, Value: outsideUpperBoundTS})
+		s.Merge(spans.Valued{Key: kv.KeyRange{StartKey: lockRegion.Range.EndKey}, Value: outsideUpperBoundTS})
+	})
+
+	adv.TESTSetLastCheckpointToCurrentMin()
+	require.Equal(t, 1, adv.TESTResolveLockTargetCount())
+	time.Sleep(adv.Config().GetResolveLockInterval() + 10*time.Millisecond)
+	adv.TESTTryResolveLocksForCheckpoint()
+	require.Eventually(t, func() bool { return resolveLockCount.Load() >= 1 },
+		8*time.Second, 50*time.Microsecond)
+	require.Eventually(t, func() bool { return !adv.GetInResolvingLock() },
+		8*time.Second, 50*time.Microsecond)
+	require.Equal(t, int32(3), scanLockCount.Load())
+	require.Greater(t, firstMaxVersion.Load(), secondMaxVersion.Load())
+	require.Greater(t, secondMaxVersion.Load(), minCheckpoint)
+	require.Equal(t,
+		oracle.GoTimeToTS(oracle.GetTimeFromTS(minCheckpoint).Add(adv.Config().GetResolveLockInterval()/3)),
+		secondMaxVersion.Load())
+	require.Greater(t, secondMaxVersion.Load(), thirdMaxVersion.Load())
+	require.Greater(t, thirdMaxVersion.Load(), minCheckpoint)
+	require.Equal(t, minCheckpoint+(secondMaxVersion.Load()-minCheckpoint)/2, thirdMaxVersion.Load())
+}
+
 func TestResolveLockMaxVersion(t *testing.T) {
 	checkpointTime := time.Unix(100, 0)
 	checkpointTS := oracle.GoTimeToTS(checkpointTime)
@@ -707,6 +785,55 @@ func TestResolveLockMaxVersion(t *testing.T) {
 		streamhelper.TESTResolveLockMaxVersion(targetUpperBound, oracle.GoTimeToTS(checkpointTime.Add(24*time.Second))))
 }
 
+func TestResolveLockIntervalUsesTiKVFlushInterval(t *testing.T) {
+	c := createFakeCluster(t, 4, false)
+	env := newTestEnv(c, t)
+	adv := streamhelper.NewCheckpointAdvancer(env)
+	adv.UpdateConfigWith(func(c *config.CommandConfig) {
+		c.TickDuration = 50 * time.Millisecond
+	})
+	require.Equal(t, 100*time.Millisecond, adv.TESTResolveLockInterval())
+
+	adv.SetLogBackupFlushIntervalGetter(func(context.Context) (time.Duration, error) {
+		return 180 * time.Millisecond, nil
+	})
+	adv.TESTRefreshLogBackupFlushInterval(context.Background())
+	require.Equal(t, 180*time.Millisecond, adv.TESTResolveLockInterval())
+
+	adv.SetLogBackupFlushIntervalGetter(func(context.Context) (time.Duration, error) {
+		return 0, errors.New("tikv config is temporarily unavailable")
+	})
+	adv.TESTRefreshLogBackupFlushInterval(context.Background())
+	require.Equal(t, 180*time.Millisecond, adv.TESTResolveLockInterval())
+}
+
+func TestGetLogBackupFlushIntervalFromTiKVConfig(t *testing.T) {
+	flushInterval, err := streamhelper.GetLogBackupFlushIntervalFromTiKVConfig(
+		context.Background(),
+		func(_ context.Context, collect func([]byte) error) error {
+			if err := collect([]byte(`{"log-backup":{"flush-interval":"20s"}}`)); err != nil {
+				return err
+			}
+			return collect([]byte(`{"log-backup":{"flush-interval":"30s"}}`))
+		})
+	require.NoError(t, err)
+	require.Equal(t, 30*time.Second, flushInterval)
+
+	_, err = streamhelper.GetLogBackupFlushIntervalFromTiKVConfig(
+		context.Background(),
+		func(_ context.Context, collect func([]byte) error) error {
+			return collect([]byte(`{"log-backup":{"enable":true}}`))
+		})
+	require.ErrorContains(t, err, "log-backup.flush-interval is not found")
+
+	_, err = streamhelper.GetLogBackupFlushIntervalFromTiKVConfig(
+		context.Background(),
+		func(context.Context, func([]byte) error) error {
+			return nil
+		})
+	require.ErrorContains(t, err, "no TiKV config found")
+}
+
 func TestResolveLockTargetsUseUpperBound(t *testing.T) {
 	c := createFakeCluster(t, 4, false)
 	ctx := context.Background()
@@ -718,6 +845,7 @@ func TestResolveLockTargetsUseUpperBound(t *testing.T) {
 	adv.StartTaskListener(ctx)
 
 	checkpointTime := time.Now().Add(-25 * time.Second)
+	c.SetCurrentTS(oracle.GoTimeToTS(checkpointTime.Add(25 * time.Second)))
 	checkpointTS := oracle.GoTimeToTS(checkpointTime)
 	withinUpperBoundTS := oracle.GoTimeToTS(checkpointTime.Add(6 * time.Second))
 	outsideUpperBoundTS := oracle.GoTimeToTS(checkpointTime.Add(8 * time.Second))
@@ -742,6 +870,7 @@ func TestResolveLockRetryWhenCheckpointNotAdvanced(t *testing.T) {
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx := context.Background()
 	minCheckpoint := oracle.GoTimeToTS(time.Now().Add(-10 * time.Second))
+	c.SetCurrentTS(oracle.GoTimeToTS(oracle.GetTimeFromTS(minCheckpoint).Add(10 * time.Second)))
 	env := newTestEnv(c, t)
 
 	lockRegion := c.FindRegionByKey([]byte("01"))

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -643,23 +643,16 @@ func TestResolveLock(t *testing.T) {
 	outsideUpperBoundTS := oracle.GoTimeToTS(oracle.GetTimeFromTS(minCheckpoint).Add(2 * time.Minute))
 	adv.WithCheckpoints(func(s *spans.ValueSortedFull) {
 		s.Merge(spans.Valued{Key: kv.KeyRange{}, Value: minCheckpoint})
-		s.Merge(spans.Valued{Key: kv.KeyRange{EndKey: lockRegion.Range.StartKey}, Value: outsideUpperBoundTS})
-		s.Merge(spans.Valued{Key: kv.KeyRange{StartKey: lockRegion.Range.EndKey}, Value: outsideUpperBoundTS})
+		s.Merge(spans.Valued{Key: kv.KeyRange{EndKey: lockRegion.rng.StartKey}, Value: outsideUpperBoundTS})
+		s.Merge(spans.Valued{Key: kv.KeyRange{StartKey: lockRegion.rng.EndKey}, Value: outsideUpperBoundTS})
 	})
 
 	require.NoError(t, adv.OnTick(ctx))
 
 	adv.ForceResolveLocksForTest()
-	env.maxTs = adv.ResolveLockMaxVersionForTest()
-	tickErrCh := make(chan error, 1)
-	go func() {
-		tickErrCh <- adv.OnTick(ctx)
-	}()
+	require.NoError(t, adv.OnTick(ctx))
 	select {
 	case <-resolveStarted:
-	case err := <-tickErrCh:
-		require.NoError(t, err)
-		require.Fail(t, "asyncResolveLocks finished before resolving locks")
 	case <-time.After(time.Second):
 		require.Fail(t, "timed out waiting for asyncResolveLocks to start")
 	}
@@ -667,12 +660,8 @@ func TestResolveLock(t *testing.T) {
 	require.Eventually(t, func() bool { return adv.GetInResolvingLock() },
 		time.Second, 50*time.Millisecond)
 	releaseResolve()
-	select {
-	case err := <-tickErrCh:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for advancer tick to finish")
-	}
+	require.Eventually(t, func() bool { return !adv.GetInResolvingLock() },
+		time.Second, 50*time.Millisecond)
 	adv.TESTSetLastCheckpointToCurrentMin()
 	require.Equal(t, 1, adv.TESTResolveLockTargetCount())
 	time.Sleep(adv.Config().GetResolveLockInterval() + 10*time.Millisecond)
@@ -693,7 +682,7 @@ func TestResolveLockRetryWithLowerMaxVersionOnScanLockLocked(t *testing.T) {
 	c.SetCurrentTS(oracle.GoTimeToTS(checkpointTime.Add(30 * time.Second)))
 	env := newTestEnv(c, t)
 
-	lockRegion := c.FindRegionByKey([]byte("01"))
+	lockRegion := c.findRegionByKey([]byte("01"))
 	allLocks := []*txnlock.Lock{
 		{
 			Key:   []byte("011"),
@@ -706,7 +695,7 @@ func TestResolveLockRetryWithLowerMaxVersionOnScanLockLocked(t *testing.T) {
 	firstMaxVersion := atomic.NewUint64(0)
 	secondMaxVersion := atomic.NewUint64(0)
 	thirdMaxVersion := atomic.NewUint64(0)
-	env.scanLocks = func(_ []byte, _ []byte, maxVersion uint64) ([]*txnlock.Lock, *tikv.KeyLocation, error) {
+	env.scanLocks = func(_ []byte, maxVersion uint64) ([]*txnlock.Lock, *tikv.KeyLocation, error) {
 		switch scanLockCount.Inc() {
 		case 1:
 			firstMaxVersion.Store(maxVersion)
@@ -716,7 +705,7 @@ func TestResolveLockRetryWithLowerMaxVersionOnScanLockLocked(t *testing.T) {
 			return nil, nil, errors.New("unexpected scanlock error: error:<locked:<primary_lock:\"011\" lock_version:1>>")
 		case 3:
 			thirdMaxVersion.Store(maxVersion)
-			return allLocks, &tikv.KeyLocation{Region: tikv.NewRegionVerID(lockRegion.ID, 0, 0)}, nil
+			return allLocks, &tikv.KeyLocation{Region: tikv.NewRegionVerID(lockRegion.id, 0, 0)}, nil
 		default:
 			return nil, nil, errors.Errorf("unexpected scan lock retry count %d", scanLockCount.Load())
 		}
@@ -738,8 +727,8 @@ func TestResolveLockRetryWithLowerMaxVersionOnScanLockLocked(t *testing.T) {
 	outsideUpperBoundTS := oracle.GoTimeToTS(checkpointTime.Add(2 * time.Minute))
 	adv.WithCheckpoints(func(s *spans.ValueSortedFull) {
 		s.Merge(spans.Valued{Key: kv.KeyRange{}, Value: minCheckpoint})
-		s.Merge(spans.Valued{Key: kv.KeyRange{EndKey: lockRegion.Range.StartKey}, Value: outsideUpperBoundTS})
-		s.Merge(spans.Valued{Key: kv.KeyRange{StartKey: lockRegion.Range.EndKey}, Value: outsideUpperBoundTS})
+		s.Merge(spans.Valued{Key: kv.KeyRange{EndKey: lockRegion.rng.StartKey}, Value: outsideUpperBoundTS})
+		s.Merge(spans.Valued{Key: kv.KeyRange{StartKey: lockRegion.rng.EndKey}, Value: outsideUpperBoundTS})
 	})
 
 	adv.TESTSetLastCheckpointToCurrentMin()
@@ -873,7 +862,7 @@ func TestResolveLockRetryWhenCheckpointNotAdvanced(t *testing.T) {
 	c.SetCurrentTS(oracle.GoTimeToTS(oracle.GetTimeFromTS(minCheckpoint).Add(10 * time.Second)))
 	env := newTestEnv(c, t)
 
-	lockRegion := c.FindRegionByKey([]byte("01"))
+	lockRegion := c.findRegionByKey([]byte("01"))
 	allLocks := []*txnlock.Lock{
 		{
 			Key:   []byte("011"),
@@ -898,8 +887,8 @@ func TestResolveLockRetryWhenCheckpointNotAdvanced(t *testing.T) {
 	outsideUpperBoundTS := oracle.GoTimeToTS(oracle.GetTimeFromTS(minCheckpoint).Add(2 * time.Minute))
 	adv.WithCheckpoints(func(s *spans.ValueSortedFull) {
 		s.Merge(spans.Valued{Key: kv.KeyRange{}, Value: minCheckpoint})
-		s.Merge(spans.Valued{Key: kv.KeyRange{EndKey: lockRegion.Range.StartKey}, Value: outsideUpperBoundTS})
-		s.Merge(spans.Valued{Key: kv.KeyRange{StartKey: lockRegion.Range.EndKey}, Value: outsideUpperBoundTS})
+		s.Merge(spans.Valued{Key: kv.KeyRange{EndKey: lockRegion.rng.StartKey}, Value: outsideUpperBoundTS})
+		s.Merge(spans.Valued{Key: kv.KeyRange{StartKey: lockRegion.rng.EndKey}, Value: outsideUpperBoundTS})
 	})
 	adv.TESTSetLastCheckpointToCurrentMin()
 	require.Equal(t, 1, adv.TESTResolveLockTargetCount())
@@ -910,7 +899,7 @@ func TestResolveLockRetryWhenCheckpointNotAdvanced(t *testing.T) {
 		return resolveLockCount.Load() == 1 && !adv.GetInResolvingLock()
 	}, time.Second, time.Millisecond)
 
-	lockRegion.Locks = allLocks
+	lockRegion.locks = allLocks
 	adv.TESTTryResolveLocksForCheckpoint()
 	time.Sleep(adv.Config().GetResolveLockInterval() / 2)
 	require.Equal(t, int32(1), resolveLockCount.Load())

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -5,7 +5,10 @@ package streamhelper_test
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -15,11 +18,14 @@ import (
 	backup "github.com/pingcap/kvproto/pkg/brpb"
 	logbackup "github.com/pingcap/kvproto/pkg/logbackuppb"
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/br/pkg/streamhelper"
 	"github.com/pingcap/tidb/br/pkg/streamhelper/config"
 	"github.com/pingcap/tidb/br/pkg/streamhelper/spans"
 	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/util/redact"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/oracle"
@@ -70,6 +76,240 @@ func TestTick(t *testing.T) {
 		require.NoError(t, adv.OnTick(ctx))
 		require.Equal(t, env.getCheckpoint(), cp)
 	}
+}
+
+type countingStorage struct {
+	storage.ExternalStorage
+	closeCount *atomic.Int32
+}
+
+func (s *countingStorage) Close() {
+	s.closeCount.Inc()
+	s.ExternalStorage.Close()
+}
+
+type writeFailStorage struct {
+	storage.ExternalStorage
+	onWrite func()
+}
+
+func (s writeFailStorage) WriteFile(context.Context, string, []byte) error {
+	if s.onWrite != nil {
+		s.onWrite()
+	}
+	return errors.New("injected external storage error")
+}
+
+type writeBlockStorage struct {
+	storage.ExternalStorage
+	onWriteDone func(error)
+}
+
+func (s writeBlockStorage) WriteFile(ctx context.Context, _ string, _ []byte) error {
+	<-ctx.Done()
+	err := ctx.Err()
+	if s.onWriteDone != nil {
+		s.onWriteDone(err)
+	}
+	return err
+}
+
+type writeRecordStorage struct {
+	storage.ExternalStorage
+	writeCount *atomic.Int32
+}
+
+func (s writeRecordStorage) WriteFile(ctx context.Context, name string, data []byte) error {
+	s.writeCount.Inc()
+	return s.ExternalStorage.WriteFile(ctx, name, data)
+}
+
+func TestTickWritesGlobalCheckpointToStorage(t *testing.T) {
+	metrics.ExternalStorageCheckpoint.DeleteLabelValues("whole")
+	defer metrics.ExternalStorageCheckpoint.DeleteLabelValues("whole")
+
+	c := createFakeCluster(t, 4, false)
+	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	storageDir := t.TempDir()
+	createCount := atomic.NewInt32(0)
+	closeCount := atomic.NewInt32(0)
+	restoreFactory := streamhelper.SetGlobalCheckpointStorageFactoryForTest(
+		func(ctx context.Context, backend *backup.StorageBackend, sendCreds bool) (storage.ExternalStorage, error) {
+			createCount.Inc()
+			storage, err := storage.Create(ctx, backend, sendCreds)
+			if err != nil {
+				return nil, err
+			}
+			return &countingStorage{ExternalStorage: storage, closeCount: closeCount}, nil
+		})
+	defer restoreFactory()
+
+	env := newTestEnv(c, t)
+	env.task.Info.Storage = &backup.StorageBackend{
+		Backend: &backup.StorageBackend_Local{
+			Local: &backup.Local{Path: storageDir},
+		},
+	}
+	adv := streamhelper.NewCheckpointAdvancer(env)
+	adv.StartTaskListener(ctx)
+	require.NoError(t, adv.OnTick(ctx))
+	require.Equal(t, int32(1), createCount.Load())
+
+	_ = c.advanceCheckpoints()
+	require.NoError(t, adv.OnTick(ctx))
+	require.Equal(t, int32(1), createCount.Load())
+
+	checkpoint := c.advanceCheckpoints()
+	require.NoError(t, adv.OnTick(ctx))
+	require.Equal(t, int32(1), createCount.Load())
+
+	data, err := os.ReadFile(filepath.Join(storageDir, "v1", "global_checkpoint", "central_global.ts"))
+	require.NoError(t, err)
+	require.Len(t, data, 8)
+	require.Equal(t, checkpoint, binary.LittleEndian.Uint64(data))
+	require.Equal(t, float64(checkpoint), promtest.ToFloat64(metrics.ExternalStorageCheckpoint.WithLabelValues("whole")))
+
+	adv.OnStop()
+	require.Equal(t, int32(1), closeCount.Load())
+}
+
+func TestTickIgnoresGlobalCheckpointStorageFailure(t *testing.T) {
+	metrics.ExternalStorageCheckpoint.DeleteLabelValues("whole")
+	defer metrics.ExternalStorageCheckpoint.DeleteLabelValues("whole")
+
+	c := createFakeCluster(t, 4, false)
+	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	storageDir := t.TempDir()
+	gcBlockedBeforeWrite := atomic.NewBool(false)
+	var env *testEnv
+	restoreFactory := streamhelper.SetGlobalCheckpointStorageFactoryForTest(
+		func(ctx context.Context, backend *backup.StorageBackend, sendCreds bool) (storage.ExternalStorage, error) {
+			storage, err := storage.Create(ctx, backend, sendCreds)
+			if err != nil {
+				return nil, err
+			}
+			return writeFailStorage{
+				ExternalStorage: storage,
+				onWrite: func() {
+					gcBlockedBeforeWrite.Store(env.serviceGCSafePointSet)
+				},
+			}, nil
+		})
+	defer restoreFactory()
+
+	env = newTestEnv(c, t)
+	env.task.Info.Storage = &backup.StorageBackend{
+		Backend: &backup.StorageBackend_Local{
+			Local: &backup.Local{Path: storageDir},
+		},
+	}
+	adv := streamhelper.NewCheckpointAdvancer(env)
+	adv.StartTaskListener(ctx)
+
+	checkpoint := c.advanceCheckpoints()
+	require.NoError(t, adv.OnTick(ctx))
+	require.Equal(t, checkpoint, env.getCheckpoint())
+	require.True(t, env.serviceGCSafePointSet)
+	require.Equal(t, checkpoint-1, env.serviceGCSafePoint)
+	require.True(t, gcBlockedBeforeWrite.Load())
+	require.Equal(t, 0.0, promtest.ToFloat64(metrics.ExternalStorageCheckpoint.WithLabelValues("whole")))
+}
+
+func TestTickDoesNotWriteGlobalCheckpointToStorageWhenBlockGCFailed(t *testing.T) {
+	metrics.ExternalStorageCheckpoint.DeleteLabelValues("whole")
+	defer metrics.ExternalStorageCheckpoint.DeleteLabelValues("whole")
+
+	c := createFakeCluster(t, 4, false)
+	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	storageDir := t.TempDir()
+	writeCount := atomic.NewInt32(0)
+	restoreFactory := streamhelper.SetGlobalCheckpointStorageFactoryForTest(
+		func(ctx context.Context, backend *backup.StorageBackend, sendCreds bool) (storage.ExternalStorage, error) {
+			storage, err := storage.Create(ctx, backend, sendCreds)
+			if err != nil {
+				return nil, err
+			}
+			return writeRecordStorage{ExternalStorage: storage, writeCount: writeCount}, nil
+		})
+	defer restoreFactory()
+
+	env := newTestEnv(c, t)
+	env.task.Info.Storage = &backup.StorageBackend{
+		Backend: &backup.StorageBackend_Local{
+			Local: &backup.Local{Path: storageDir},
+		},
+	}
+	adv := streamhelper.NewCheckpointAdvancer(env)
+	adv.StartTaskListener(ctx)
+
+	checkpoint := c.advanceCheckpoints()
+	env.serviceGCSafePoint = checkpoint
+	require.ErrorContains(t, adv.OnTick(ctx), "failed to update service GC safe point")
+	require.Equal(t, int32(0), writeCount.Load())
+	require.Equal(t, 0.0, promtest.ToFloat64(metrics.ExternalStorageCheckpoint.WithLabelValues("whole")))
+}
+
+func TestTickTimesOutGlobalCheckpointStorageWrite(t *testing.T) {
+	metrics.ExternalStorageCheckpoint.DeleteLabelValues("whole")
+	defer metrics.ExternalStorageCheckpoint.DeleteLabelValues("whole")
+
+	c := createFakeCluster(t, 4, false)
+	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	storageDir := t.TempDir()
+	writeErrCh := make(chan error, 1)
+	restoreFactory := streamhelper.SetGlobalCheckpointStorageFactoryForTest(
+		func(ctx context.Context, backend *backup.StorageBackend, sendCreds bool) (storage.ExternalStorage, error) {
+			storage, err := storage.Create(ctx, backend, sendCreds)
+			if err != nil {
+				return nil, err
+			}
+			return writeBlockStorage{
+				ExternalStorage: storage,
+				onWriteDone: func(err error) {
+					writeErrCh <- err
+				},
+			}, nil
+		})
+	defer restoreFactory()
+
+	env := newTestEnv(c, t)
+	env.task.Info.Storage = &backup.StorageBackend{
+		Backend: &backup.StorageBackend_Local{
+			Local: &backup.Local{Path: storageDir},
+		},
+	}
+	adv := streamhelper.NewCheckpointAdvancer(env)
+	adv.UpdateConfigWith(func(cfg *config.CommandConfig) {
+		cfg.TickDuration = 200 * time.Millisecond
+	})
+	adv.StartTaskListener(ctx)
+
+	checkpoint := c.advanceCheckpoints()
+	start := time.Now()
+	require.NoError(t, adv.OnTick(ctx))
+	require.Less(t, time.Since(start), time.Second)
+	require.Equal(t, checkpoint, env.getCheckpoint())
+	require.True(t, env.serviceGCSafePointSet)
+	require.Equal(t, checkpoint-1, env.serviceGCSafePoint)
+	select {
+	case err := <-writeErrCh:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for external storage write timeout")
+	}
+	require.Equal(t, 0.0, promtest.ToFloat64(metrics.ExternalStorageCheckpoint.WithLabelValues("whole")))
 }
 
 func TestWithFailure(t *testing.T) {
@@ -344,12 +584,6 @@ func TestResolveLock(t *testing.T) {
 			fmt.Println(c)
 		}
 	}()
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/streamhelper/NeedResolveLocks", `return(true)`))
-	// make sure asyncResolveLocks stuck in optionalTick later.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/streamhelper/AsyncResolveLocks", `pause`))
-	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/streamhelper/NeedResolveLocks"))
-	}()
 
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx := context.Background()
@@ -378,16 +612,29 @@ func TestResolveLock(t *testing.T) {
 
 	// ensure resolve locks triggered and collect all locks from scan locks
 	resolveLockRef := atomic.NewBool(false)
+	resolveStarted := make(chan struct{})
+	allowResolve := make(chan struct{})
+	var resolveOnce sync.Once
+	var allowResolveOnce sync.Once
+	releaseResolve := func() {
+		allowResolveOnce.Do(func() {
+			close(allowResolve)
+		})
+	}
+	defer releaseResolve()
 	env.resolveLocks = func(locks []*txnlock.Lock, loc *tikv.KeyLocation) (*tikv.KeyLocation, error) {
-		resolveLockRef.Store(true)
+		resolveOnce.Do(func() {
+			close(resolveStarted)
+		})
+		<-allowResolve
 		// The third lock has skipped, because it's less than max version.
 		require.ElementsMatch(t, locks, allLocks[:2])
+		resolveLockRef.Store(true)
 		return loc, nil
 	}
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.StartTaskListener(ctx)
 
-	maxTargetTs := uint64(0)
 	coll := streamhelper.NewClusterCollector(ctx, env)
 	coll.SetOnSuccessHook(func(u uint64, kr kv.KeyRange) {
 		adv.WithCheckpoints(func(s *spans.ValueSortedFull) {
@@ -400,7 +647,6 @@ func TestResolveLock(t *testing.T) {
 				}
 			}
 			s.Merge(spans.Valued{Key: kr, Value: u})
-			maxTargetTs = max(maxTargetTs, u)
 		})
 	})
 	err := adv.GetCheckpointInRange(ctx, []byte{}, []byte{}, coll)
@@ -410,12 +656,32 @@ func TestResolveLock(t *testing.T) {
 	require.Len(t, r.FailureSubRanges, 0)
 	require.Equal(t, r.Checkpoint, minCheckpoint, "%d %d", r.Checkpoint, minCheckpoint)
 
-	env.maxTs = maxTargetTs + 1
-	require.Eventually(t, func() bool { return adv.OnTick(ctx) == nil },
+	require.NoError(t, adv.OnTick(ctx))
+
+	adv.ForceResolveLocksForTest()
+	env.maxTs = adv.ResolveLockMaxVersionForTest()
+	tickErrCh := make(chan error, 1)
+	go func() {
+		tickErrCh <- adv.OnTick(ctx)
+	}()
+	select {
+	case <-resolveStarted:
+	case err := <-tickErrCh:
+		require.NoError(t, err)
+		require.Fail(t, "asyncResolveLocks finished before resolving locks")
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for asyncResolveLocks to start")
+	}
+	// now the lock state must be true, because asyncResolveLocks is blocked in resolveLocks.
+	require.Eventually(t, func() bool { return adv.GetInResolvingLock() },
 		time.Second, 50*time.Millisecond)
-	// now the lock state must be ture. because tick finished and asyncResolveLocks got stuck.
-	require.True(t, adv.GetInResolvingLock())
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/streamhelper/AsyncResolveLocks"))
+	releaseResolve()
+	select {
+	case err := <-tickErrCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for advancer tick to finish")
+	}
 	require.Eventually(t, func() bool { return resolveLockRef.Load() },
 		8*time.Second, 50*time.Microsecond)
 	// state must set to false after tick

--- a/br/pkg/streamhelper/basic_lib_for_test.go
+++ b/br/pkg/streamhelper/basic_lib_for_test.go
@@ -791,7 +791,7 @@ func (t *testEnv) putTask() {
 func (t *testEnv) ScanLocksInOneRegion(bo *tikv.Backoffer, key []byte, maxVersion uint64, limit uint32) ([]*txnlock.Lock, *tikv.KeyLocation, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.maxTs != maxVersion {
+	if t.maxTs != 0 && t.maxTs != maxVersion {
 		return nil, nil, errors.Errorf("unexpect max version in scan lock, expected %d, actual %d", t.maxTs, maxVersion)
 	}
 	for _, r := range t.regions {

--- a/br/pkg/streamhelper/basic_lib_for_test.go
+++ b/br/pkg/streamhelper/basic_lib_for_test.go
@@ -657,6 +657,7 @@ type testEnv struct {
 	task           streamhelper.TaskEvent
 
 	resolveLocks func([]*txnlock.Lock, *tikv.KeyLocation) (*tikv.KeyLocation, error)
+	scanLocks    func(key []byte, endKey []byte, maxVersion uint64) ([]*txnlock.Lock, *tikv.KeyLocation, error)
 
 	mu sync.Mutex
 	pd.Client
@@ -791,6 +792,9 @@ func (t *testEnv) putTask() {
 func (t *testEnv) ScanLocksInOneRegion(bo *tikv.Backoffer, key []byte, maxVersion uint64, limit uint32) ([]*txnlock.Lock, *tikv.KeyLocation, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if t.scanLocks != nil {
+		return t.scanLocks(key, endKey, maxVersion)
+	}
 	if t.maxTs != 0 && t.maxTs != maxVersion {
 		return nil, nil, errors.Errorf("unexpect max version in scan lock, expected %d, actual %d", t.maxTs, maxVersion)
 	}

--- a/br/pkg/streamhelper/basic_lib_for_test.go
+++ b/br/pkg/streamhelper/basic_lib_for_test.go
@@ -292,6 +292,10 @@ func (f *fakeCluster) FetchCurrentTS(ctx context.Context) (uint64, error) {
 	return f.currentTS, nil
 }
 
+func (f *fakeCluster) SetCurrentTS(ts uint64) {
+	f.currentTS = ts
+}
+
 // RegionScan gets a list of regions, starts from the region that contains key.
 // Limit limits the maximum number of regions returned.
 func (f *fakeCluster) RegionScan(ctx context.Context, key []byte, endKey []byte, limit int) ([]streamhelper.RegionWithLeader, error) {
@@ -657,7 +661,7 @@ type testEnv struct {
 	task           streamhelper.TaskEvent
 
 	resolveLocks func([]*txnlock.Lock, *tikv.KeyLocation) (*tikv.KeyLocation, error)
-	scanLocks    func(key []byte, endKey []byte, maxVersion uint64) ([]*txnlock.Lock, *tikv.KeyLocation, error)
+	scanLocks    func(key []byte, maxVersion uint64) ([]*txnlock.Lock, *tikv.KeyLocation, error)
 
 	mu sync.Mutex
 	pd.Client
@@ -793,7 +797,7 @@ func (t *testEnv) ScanLocksInOneRegion(bo *tikv.Backoffer, key []byte, maxVersio
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.scanLocks != nil {
-		return t.scanLocks(key, endKey, maxVersion)
+		return t.scanLocks(key, maxVersion)
 	}
 	if t.maxTs != 0 && t.maxTs != maxVersion {
 		return nil, nil, errors.Errorf("unexpect max version in scan lock, expected %d, actual %d", t.maxTs, maxVersion)

--- a/br/pkg/streamhelper/config/BUILD.bazel
+++ b/br/pkg/streamhelper/config/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     timeout = "short",
     srcs = ["config_test.go"],
     flaky = True,
+    shard_count = 2,
     deps = [
         ":config",
         "//pkg/testkit",

--- a/br/pkg/streamhelper/config/command_conf.go
+++ b/br/pkg/streamhelper/config/command_conf.go
@@ -137,6 +137,11 @@ func (conf *CommandConfig) GetSubscriberErrorStartPollThreshold() time.Duration 
 	return conf.TryAdvanceThreshold * 9 / 20
 }
 
+// GetResolveLockInterval returns how long an unchanged checkpoint waits before resolving locks.
+func (conf *CommandConfig) GetResolveLockInterval() time.Duration {
+	return conf.TickDuration * 2
+}
+
 // TickTimeout returns the max duration for each tick.
 func (conf *CommandConfig) TickTimeout() time.Duration {
 	// If a tick blocks longer than the interval of ticking, we may need to break it and retry.

--- a/br/pkg/streamhelper/config/config_test.go
+++ b/br/pkg/streamhelper/config/config_test.go
@@ -32,3 +32,12 @@ func TestCheckPointLimit(t *testing.T) {
 	require.Equal(t, time.Hour*100, config.DefaultTiDBConfig().GetCheckPointLagLimit())
 	require.Equal(t, time.Hour*48, config.DefaultCommandConfig().GetCheckPointLagLimit())
 }
+
+func TestResolveLockInterval(t *testing.T) {
+	require.Equal(t, config.DefaultTickInterval*2, config.DefaultTiDBConfig().GetResolveLockInterval())
+
+	conf := config.DefaultCommandConfig().(*config.CommandConfig)
+	require.Equal(t, config.DefaultTickInterval*2, conf.GetResolveLockInterval())
+	conf.TickDuration = 10 * time.Second
+	require.Equal(t, 20*time.Second, conf.GetResolveLockInterval())
+}

--- a/br/pkg/streamhelper/config/types.go
+++ b/br/pkg/streamhelper/config/types.go
@@ -31,6 +31,8 @@ type Config interface {
 	// GetSubscriberErrorStartPollThreshold returns the threshold of begin polling the checkpoint
 	// when the subscriber meets error.
 	GetSubscriberErrorStartPollThreshold() time.Duration
+	// GetResolveLockInterval returns how long an unchanged checkpoint waits before resolving locks.
+	GetResolveLockInterval() time.Duration
 	// The maximum lag could be tolerated for the checkpoint lag.
 	GetCheckPointLagLimit() time.Duration
 }

--- a/br/pkg/streamhelper/export_test.go
+++ b/br/pkg/streamhelper/export_test.go
@@ -15,10 +15,14 @@
 package streamhelper
 
 import (
+	"context"
 	"math/rand"
 	"time"
 
+	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/br/pkg/streamhelper/config"
+	"github.com/pingcap/tidb/br/pkg/streamhelper/spans"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 )
 
@@ -47,5 +51,41 @@ func (c *CheckpointAdvancer) UpdateCheckPointLagLimit(limit time.Duration) {
 		c.UpdateConfig(cfg)
 	} else {
 		variable.AdvancerCheckPointLagLimit.Store(limit)
+	}
+}
+
+func (c *CheckpointAdvancer) ForceResolveLocksForTest() {
+	c.lastCheckpointMu.Lock()
+	defer c.lastCheckpointMu.Unlock()
+	if c.lastCheckpoint != nil {
+		c.lastCheckpoint.resolveLockTime = time.Now().Add(-4 * time.Minute)
+	}
+}
+
+func (c *CheckpointAdvancer) ResolveLockMaxVersionForTest() uint64 {
+	c.lastCheckpointMu.Lock()
+	lastCheckpoint := c.lastCheckpoint
+	c.lastCheckpointMu.Unlock()
+	if lastCheckpoint == nil {
+		return 0
+	}
+
+	maxTs := uint64(0)
+	c.checkpointsMu.Lock()
+	defer c.checkpointsMu.Unlock()
+	c.checkpoints.TraverseValuesLessThan(tsoAfter(lastCheckpoint.TS, time.Minute), func(v spans.Valued) bool {
+		maxTs = max(maxTs, v.Value)
+		return true
+	})
+	return maxTs + 1
+}
+
+func SetGlobalCheckpointStorageFactoryForTest(
+	factory func(context.Context, *backuppb.StorageBackend, bool) (storage.ExternalStorage, error),
+) func() {
+	original := createGlobalCheckpointStorage
+	createGlobalCheckpointStorage = factory
+	return func() {
+		createGlobalCheckpointStorage = original
 	}
 }

--- a/br/pkg/streamhelper/export_test.go
+++ b/br/pkg/streamhelper/export_test.go
@@ -89,3 +89,34 @@ func SetGlobalCheckpointStorageFactoryForTest(
 		createGlobalCheckpointStorage = original
 	}
 }
+
+func (c *CheckpointAdvancer) TESTResolveLockTargetCount() int {
+	c.lastCheckpointMu.Lock()
+	checkpointToResolve := c.lastCheckpoint
+	c.lastCheckpointMu.Unlock()
+	if checkpointToResolve == nil {
+		return 0
+	}
+	upperBound := resolveLockTargetUpperBound(checkpointToResolve.TS, c.Config().GetResolveLockInterval(), time.Now())
+	return len(c.resolveLockTargetsForCheckpoint(checkpointToResolve, upperBound))
+}
+
+func (c *CheckpointAdvancer) TESTSetLastCheckpointToCurrentMin() {
+	var p *checkpoint
+	c.WithCheckpoints(func(vsf *spans.ValueSortedFull) {
+		p = newCheckpointWithSpan(vsf.Min())
+	})
+	c.UpdateLastCheckpoint(p)
+}
+
+func (c *CheckpointAdvancer) TESTTryResolveLocksForCheckpoint() {
+	c.tryResolveLocksForCheckpoint()
+}
+
+func TESTResolveLockTargetUpperBound(checkpointTS uint64, resolveLockInterval time.Duration, now time.Time) uint64 {
+	return resolveLockTargetUpperBound(checkpointTS, resolveLockInterval, now)
+}
+
+func TESTResolveLockMaxVersion(targetUpperBound uint64, safeMaxVersion uint64) uint64 {
+	return resolveLockMaxVersion(targetUpperBound, safeMaxVersion)
+}

--- a/br/pkg/streamhelper/export_test.go
+++ b/br/pkg/streamhelper/export_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/streamhelper/config"
 	"github.com/pingcap/tidb/br/pkg/streamhelper/spans"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/tikv/client-go/v2/oracle"
 )
 
 func NewCheckpointAdvancer(env Env) *CheckpointAdvancer {
@@ -97,7 +98,11 @@ func (c *CheckpointAdvancer) TESTResolveLockTargetCount() int {
 	if checkpointToResolve == nil {
 		return 0
 	}
-	upperBound := resolveLockTargetUpperBound(checkpointToResolve.TS, c.Config().GetResolveLockInterval(), time.Now())
+	currentTS, err := c.env.FetchCurrentTS(context.Background())
+	if err != nil {
+		return 0
+	}
+	upperBound := resolveLockTargetUpperBound(checkpointToResolve.TS, c.getResolveLockInterval(), currentTS)
 	return len(c.resolveLockTargetsForCheckpoint(checkpointToResolve, upperBound))
 }
 
@@ -110,11 +115,19 @@ func (c *CheckpointAdvancer) TESTSetLastCheckpointToCurrentMin() {
 }
 
 func (c *CheckpointAdvancer) TESTTryResolveLocksForCheckpoint() {
-	c.tryResolveLocksForCheckpoint()
+	c.tryResolveLocksForCheckpoint(context.Background())
+}
+
+func (c *CheckpointAdvancer) TESTRefreshLogBackupFlushInterval(ctx context.Context) {
+	c.refreshLogBackupFlushInterval(ctx)
+}
+
+func (c *CheckpointAdvancer) TESTResolveLockInterval() time.Duration {
+	return c.getResolveLockInterval()
 }
 
 func TESTResolveLockTargetUpperBound(checkpointTS uint64, resolveLockInterval time.Duration, now time.Time) uint64 {
-	return resolveLockTargetUpperBound(checkpointTS, resolveLockInterval, now)
+	return resolveLockTargetUpperBound(checkpointTS, resolveLockInterval, oracle.GoTimeToTS(now))
 }
 
 func TESTResolveLockMaxVersion(targetUpperBound uint64, safeMaxVersion uint64) uint64 {

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -976,6 +976,13 @@ func RunStreamAdvancer(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 	env := streamhelper.CliEnv(mgr.StoreManager, mgr.GetStore(), etcdCLI)
 	advancer := streamhelper.NewCommandCheckpointAdvancer(env)
 	advancer.UpdateConfig(&cfg.AdvancerCfg)
+	httpCli := httputil.NewClient(mgr.GetTLSConfig())
+	advancer.SetLogBackupFlushIntervalGetter(func(ctx context.Context) (time.Duration, error) {
+		return streamhelper.GetLogBackupFlushIntervalFromTiKVConfig(ctx,
+			func(ctx context.Context, collect func([]byte) error) error {
+				return mgr.GetConfigBytesFromTiKV(ctx, httpCli, collect)
+			})
+	})
 	ownerMgr := streamhelper.OwnerManagerForLogBackup(ctx, etcdCLI)
 	defer func() {
 		ownerMgr.Close()

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1585,6 +1585,7 @@ func (do *Domain) initLogBackup(ctx context.Context, pdClient pd.Client) error {
 		return err
 	}
 	adv := streamhelper.NewTiDBCheckpointAdvancer(env)
+	adv.SetLogBackupFlushIntervalGetter(streamhelper.NewTiDBLogBackupFlushIntervalGetter(pdClient))
 	do.brOwnerMgr = streamhelper.OwnerManagerForLogBackup(ctx, do.etcdClient)
 	do.logBackupAdvancer = daemon.New(adv, do.brOwnerMgr, adv.Config().TickTimeout())
 	loop, err := do.logBackupAdvancer.Begin(ctx)

--- a/pkg/metrics/log_backup.go
+++ b/pkg/metrics/log_backup.go
@@ -22,6 +22,7 @@ import (
 // see the `Help` field for details.
 var (
 	LastCheckpoint                    *prometheus.GaugeVec
+	ExternalStorageCheckpoint         *prometheus.GaugeVec
 	AdvancerOwner                     prometheus.Gauge
 	AdvancerTickDuration              *prometheus.HistogramVec
 	GetCheckpointBatchSize            *prometheus.HistogramVec
@@ -40,6 +41,13 @@ func InitLogBackupMetrics() {
 		Subsystem: "log_backup",
 		Name:      "last_checkpoint",
 		Help:      "The last global checkpoint of log backup.",
+	}, []string{"task"})
+
+	ExternalStorageCheckpoint = NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "tidb",
+		Subsystem: "log_backup",
+		Name:      "external_storage_checkpoint",
+		Help:      "The global checkpoint that has been successfully persisted to external storage.",
 	}, []string{"task"})
 
 	AdvancerOwner = NewGauge(prometheus.GaugeOpts{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -250,6 +250,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TxnStatusEnteringCounter)
 	prometheus.MustRegister(TxnDurationHistogram)
 	prometheus.MustRegister(LastCheckpoint)
+	prometheus.MustRegister(ExternalStorageCheckpoint)
 	prometheus.MustRegister(AdvancerOwner)
 	prometheus.MustRegister(AdvancerTickDuration)
 	prometheus.MustRegister(GetCheckpointBatchSize)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->
This PR is cherry-picked from https://github.com/pingcap/tidb/pull/68956

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #68857

Problem Summary:
When checkpoint ts is advanced, it cannot be persisted to s3 in a timely manner.
### What changed and how does it work?
persist checkpoint ts to s3 after the checkpoint ts is advanced.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist global checkpoints to external storage for stronger backup durability.
  * Improved asynchronous lock-resolution with coordinated checkpoint snapshots.
  * Dynamic retrieval of log-backup flush interval from TiKV configuration.

* **Chores**
  * Added a metric to track external-storage checkpoint progress.
  * Updated build/test configurations and dependencies (including test sharding).

* **Tests**
  * New tests validating checkpoint persistence, error/timeouts, and resolve-lock coordination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->