### PR TITLE
metrics: fix resource control failed query instance filter

### DIFF
--- a/pkg/metrics/grafana/tidb_resource_control.json
+++ b/pkg/metrics/grafana/tidb_resource_control.json
@@ -4946,7 +4946,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(increase(tidb_server_execute_error_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\",resource_group=~\"$resource_group\"}[1m])) by (type, instance,resource_group)",
+                     "expr": "sum(increase(tidb_server_execute_error_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\",resource_group=~\"$resource_group\"}[1m])) by (type, instance,resource_group)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}}-{{instance}}-{{resource_group}}",

--- a/pkg/metrics/grafana/tidb_resource_control.jsonnet
+++ b/pkg/metrics/grafana/tidb_resource_control.jsonnet
@@ -1482,7 +1482,7 @@ local FailedQueryOPMPanel = graphPanel.new(
   description="The number of failed queries per minute",
 ).addTarget(
   prometheus.target(
-    'sum(increase(tidb_server_execute_error_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance",resource_group=~"$resource_group"}[1m])) by (type, instance,resource_group)',
+    'sum(increase(tidb_server_execute_error_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance",resource_group=~"$resource_group"}[1m])) by (type, instance,resource_group)',
     legendFormat="{{type}}-{{instance}}-{{resource_group}}",
   )
 );

--- a/pkg/metrics/nextgengrafana/tidb_resource_control_with_keyspace_name.json
+++ b/pkg/metrics/nextgengrafana/tidb_resource_control_with_keyspace_name.json
@@ -3892,7 +3892,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(increase(tidb_server_execute_error_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\",resource_group=~\"$resource_group\"}[1m])) by (type, instance,resource_group)",
+                     "expr": "sum(increase(tidb_server_execute_error_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tidb_instance\",resource_group=~\"$resource_group\"}[1m])) by (type, instance,resource_group)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}}-{{instance}}-{{resource_group}}",

--- a/pkg/metrics/nextgengrafana/tidb_resource_control_with_keyspace_name.jsonnet
+++ b/pkg/metrics/nextgengrafana/tidb_resource_control_with_keyspace_name.jsonnet
@@ -1191,7 +1191,7 @@ local FailedQueryOPMPanel = graphPanel.new(
   description="The number of failed queries per minute",
 ).addTarget(
   prometheus.target(
-    'sum(increase(tidb_server_execute_error_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance",resource_group=~"$resource_group"}[1m])) by (type, instance,resource_group)',
+    'sum(increase(tidb_server_execute_error_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$tidb_instance",resource_group=~"$resource_group"}[1m])) by (type, instance,resource_group)',
     legendFormat="{{type}}-{{instance}}-{{resource_group}}",
   )
 );


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69104

Problem Summary:

The Resource Control dashboards define the TiDB instance template variable as `tidb_instance`, but the existing `Failed Query OPM` panel filters `tidb_server_execute_error_total` with the undefined `$instance` variable.

As a result, the panel does not correctly follow the TiDB instance selector and may show no data or an incorrect instance filter.

### What changed and how does it work?

This PR updates the `Failed Query OPM` panel in both Resource Control dashboards to use `$tidb_instance`:

- `pkg/metrics/grafana/tidb_resource_control.jsonnet`
- `pkg/metrics/nextgengrafana/tidb_resource_control_with_keyspace_name.jsonnet`

The generated dashboard JSON files are regenerated accordingly.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

before:
<img width="1245" height="692" alt="image" src="https://github.com/user-attachments/assets/25732431-60f2-4aae-8bad-bf6063ab12e7" />

after:
<img width="1240" height="683" alt="image" src="https://github.com/user-attachments/assets/6e19d831-ee22-4dc4-b222-726e55cdfcf5" />


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected instance variable reference in the "Failed Query OPM" monitoring panel across Grafana dashboards to ensure proper filtering of TiDB instance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
