### PR TITLE
ddl,privilege,parser: add masking policy dynamic privileges and error codes

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -1646,6 +1646,16 @@ error = '''
 %s is forbidden
 '''
 
+["ddl:8268"]
+error = '''
+masking policy already exists
+'''
+
+["ddl:8269"]
+error = '''
+masking policy doesn't exist
+'''
+
 ["ddl:8270"]
 error = '''
 Invalid engine attribute format: %s

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -6479,7 +6479,7 @@ func (e *executor) CreateMaskingPolicy(ctx sessionctx.Context, stmt *ast.CreateM
 	if stmt.OrReplace && stmt.IfNotExists {
 		return dbterror.ErrWrongUsage.GenWithStackByArgs("OR REPLACE", "IF NOT EXISTS")
 	}
-		if err := requireMaskingPolicyDynamicPrivilege(ctx, "CREATE MASKING POLICY"); err != nil {
+	if err := requireMaskingPolicyDynamicPrivilege(ctx, "CREATE MASKING POLICY"); err != nil {
 		return err
 	}
 

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -6479,6 +6479,9 @@ func (e *executor) CreateMaskingPolicy(ctx sessionctx.Context, stmt *ast.CreateM
 	if stmt.OrReplace && stmt.IfNotExists {
 		return dbterror.ErrWrongUsage.GenWithStackByArgs("OR REPLACE", "IF NOT EXISTS")
 	}
+		if err := requireMaskingPolicyDynamicPrivilege(ctx, "CREATE MASKING POLICY"); err != nil {
+		return err
+	}
 
 	tableIdent := ast.Ident{Schema: stmt.Table.Schema, Name: stmt.Table.Name}
 	if tableIdent.Schema.L == "" {
@@ -6520,6 +6523,9 @@ func (e *executor) CreateMaskingPolicy(ctx sessionctx.Context, stmt *ast.CreateM
 }
 
 func (e *executor) AddMaskingPolicy(ctx sessionctx.Context, ident ast.Ident, spec *ast.AlterTableSpec) error {
+	if err := requireMaskingPolicyDynamicPrivilege(ctx, "CREATE MASKING POLICY"); err != nil {
+		return err
+	}
 	schema, tbl, err := e.getSchemaAndTableByIdent(ident)
 	if err != nil {
 		return errors.Trace(err)
@@ -6552,6 +6558,9 @@ func (e *executor) getMaskingPolicyByNameForTable(tableID int64, cols []*model.C
 }
 
 func (e *executor) AlterTableMaskingPolicyState(ctx sessionctx.Context, ident ast.Ident, spec *ast.AlterTableSpec, enabled bool) error {
+	if err := requireMaskingPolicyDynamicPrivilege(ctx, "ALTER MASKING POLICY"); err != nil {
+		return err
+	}
 	_, tbl, err := e.getSchemaAndTableByIdent(ident)
 	if err != nil {
 		return errors.Trace(err)
@@ -6559,7 +6568,7 @@ func (e *executor) AlterTableMaskingPolicyState(ctx sessionctx.Context, ident as
 	policyName := spec.MaskingPolicyName
 	policy, ok := e.getMaskingPolicyByNameForTable(tbl.Meta().ID, tbl.Meta().Columns, policyName)
 	if !ok {
-		return errors.Errorf("masking policy %s doesn't exist", policyName.O)
+		return dbterror.ErrMaskingPolicyNotExists.GenWithStackByArgs(policyName.O)
 	}
 
 	status := model.MaskingPolicyStatusEnable
@@ -6598,6 +6607,9 @@ func (e *executor) AlterTableMaskingPolicyState(ctx sessionctx.Context, ident as
 }
 
 func (e *executor) DropMaskingPolicy(ctx sessionctx.Context, ident ast.Ident, spec *ast.AlterTableSpec) error {
+	if err := requireMaskingPolicyDynamicPrivilege(ctx, "DROP MASKING POLICY"); err != nil {
+		return err
+	}
 	_, tbl, err := e.getSchemaAndTableByIdent(ident)
 	if err != nil {
 		return errors.Trace(err)
@@ -6605,7 +6617,7 @@ func (e *executor) DropMaskingPolicy(ctx sessionctx.Context, ident ast.Ident, sp
 	policyName := spec.MaskingPolicyName
 	policy, ok := e.getMaskingPolicyByNameForTable(tbl.Meta().ID, tbl.Meta().Columns, policyName)
 	if !ok {
-		return errors.Errorf("masking policy %s doesn't exist", policyName.O)
+		return dbterror.ErrMaskingPolicyNotExists.GenWithStackByArgs(policyName.O)
 	}
 
 	job := &model.Job{
@@ -6637,6 +6649,9 @@ func (e *executor) DropMaskingPolicy(ctx sessionctx.Context, ident ast.Ident, sp
 
 // ModifyMaskingPolicyExpression modifies the expression of an existing masking policy.
 func (e *executor) ModifyMaskingPolicyExpression(ctx sessionctx.Context, ident ast.Ident, spec *ast.AlterTableSpec) error {
+	if err := requireMaskingPolicyDynamicPrivilege(ctx, "ALTER MASKING POLICY"); err != nil {
+		return err
+	}
 	schema, tbl, err := e.getSchemaAndTableByIdent(ident)
 	if err != nil {
 		return errors.Trace(err)
@@ -6644,7 +6659,7 @@ func (e *executor) ModifyMaskingPolicyExpression(ctx sessionctx.Context, ident a
 	policyName := spec.MaskingPolicyName
 	policy, ok := e.getMaskingPolicyByNameForTable(tbl.Meta().ID, tbl.Meta().Columns, policyName)
 	if !ok {
-		return errors.Errorf("masking policy %s doesn't exist", policyName.O)
+		return dbterror.ErrMaskingPolicyNotExists.GenWithStackByArgs(policyName.O)
 	}
 
 	// Validate and restore the new expression.
@@ -6690,6 +6705,9 @@ func (e *executor) ModifyMaskingPolicyExpression(ctx sessionctx.Context, ident a
 
 // ModifyMaskingPolicyRestrictOn modifies the restrict-on settings of an existing masking policy.
 func (e *executor) ModifyMaskingPolicyRestrictOn(ctx sessionctx.Context, ident ast.Ident, spec *ast.AlterTableSpec) error {
+	if err := requireMaskingPolicyDynamicPrivilege(ctx, "ALTER MASKING POLICY"); err != nil {
+		return err
+	}
 	_, tbl, err := e.getSchemaAndTableByIdent(ident)
 	if err != nil {
 		return errors.Trace(err)
@@ -6697,7 +6715,7 @@ func (e *executor) ModifyMaskingPolicyRestrictOn(ctx sessionctx.Context, ident a
 	policyName := spec.MaskingPolicyName
 	policy, ok := e.getMaskingPolicyByNameForTable(tbl.Meta().ID, tbl.Meta().Columns, policyName)
 	if !ok {
-		return errors.Errorf("masking policy %s doesn't exist", policyName.O)
+		return dbterror.ErrMaskingPolicyNotExists.GenWithStackByArgs(policyName.O)
 	}
 
 	newPolicy := policy.Clone()
@@ -6731,6 +6749,18 @@ func (e *executor) ModifyMaskingPolicyRestrictOn(ctx sessionctx.Context, ident a
 	return errors.Trace(e.doDDLJob2(ctx, job, args))
 }
 
+func requireMaskingPolicyDynamicPrivilege(ctx sessionctx.Context, dynamicPriv string) error {
+	checker := privilege.GetPrivilegeManager(ctx)
+	if checker == nil {
+		// Keep behavior for internal/bootstrap sessions without privilege manager.
+		return nil
+	}
+	if checker.RequestDynamicVerification(ctx.GetSessionVars().ActiveRoles, dynamicPriv, false) {
+		return nil
+	}
+	return plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs("SUPER or " + dynamicPriv)
+}
+
 func (e *executor) createMaskingPolicyWithInfo(
 	ctx sessionctx.Context,
 	tableID int64,
@@ -6741,9 +6771,9 @@ func (e *executor) createMaskingPolicyWithInfo(
 	is := e.infoCache.GetLatest()
 	if existPolicy, ok := e.getMaskingPolicyByNameForTable(tableID, cols, policy.Name); ok {
 		if existPolicy.ColumnID != policy.ColumnID {
-			return errors.Errorf("masking policy %s already exists on another column", existPolicy.Name.O)
+			return dbterror.ErrMaskingPolicyExists.GenWithStackByArgs(existPolicy.Name.O)
 		}
-		err := errors.Errorf("masking policy %s already exists", policy.Name.O)
+		err := dbterror.ErrMaskingPolicyExists.GenWithStackByArgs(policy.Name.O)
 		switch onExist {
 		case OnExistIgnore:
 			ctx.GetSessionVars().StmtCtx.AppendNote(err)
@@ -6753,7 +6783,7 @@ func (e *executor) createMaskingPolicyWithInfo(
 		}
 	}
 	if existPolicy, ok := is.MaskingPolicyByTableColumn(policy.TableID, policy.ColumnID); ok && existPolicy.Name.L != policy.Name.L {
-		return errors.Errorf("masking policy already exists on column %s", existPolicy.ColumnName.O)
+		return dbterror.ErrMaskingPolicyExists.GenWithStackByArgs(existPolicy.Name.O)
 	}
 
 	job := &model.Job{

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -6496,6 +6496,21 @@ func (e *executor) CreateMaskingPolicy(ctx sessionctx.Context, stmt *ast.CreateM
 		return errors.Trace(err)
 	}
 
+	// Creating a masking policy on a table effectively modifies the table's schema behavior,
+	// so it requires ALTER privilege on the table in addition to the dynamic privilege.
+	if checker := privilege.GetPrivilegeManager(ctx); checker != nil {
+		if !checker.RequestVerification(
+			ctx.GetSessionVars().ActiveRoles,
+			schema.Name.L,
+			tbl.Meta().Name.L,
+			"",
+			mysql.AlterPriv,
+		) {
+			user := ctx.GetSessionVars().User
+			return plannererrors.ErrTableaccessDenied.GenWithStackByArgs("ALTER", user.AuthUsername, user.AuthHostname, tbl.Meta().Name.L)
+		}
+	}
+
 	policyInfo, err := buildMaskingPolicyInfo(
 		ctx,
 		schema,

--- a/pkg/ddl/masking_policy.go
+++ b/pkg/ddl/masking_policy.go
@@ -140,7 +140,7 @@ func (w *worker) onAlterMaskingPolicy(jobCtx *jobContext, job *model.Job) (ver i
 		if args.Policy != nil {
 			policyName = args.Policy.Name
 		}
-		return ver, errors.Errorf("masking policy %s doesn't exist", policyName.O)
+		return ver, meta.ErrMaskingPolicyNotExists.GenWithStackByArgs(policyName.O)
 	}
 
 	if err := validateMaskingPolicyTarget(jobCtx.stepCtx, jobCtx.infoCache, oldPolicy); err != nil {
@@ -181,7 +181,7 @@ func (w *worker) onDropMaskingPolicy(jobCtx *jobContext, job *model.Job) (ver in
 	}
 	if policyInfo == nil {
 		job.State = model.JobStateCancelled
-		return ver, errors.Errorf("masking policy %s doesn't exist", args.PolicyName.O)
+		return ver, meta.ErrMaskingPolicyNotExists.GenWithStackByArgs(args.PolicyName.O)
 	}
 	policyInfo.State = model.StateNone
 	if err = w.deleteMaskingPolicyFromSysTable(jobCtx, policyInfo.ID); err != nil {

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -15419,7 +15419,25 @@ ExtendedPriv:
 	}
 
 RoleOrPrivElem:
-	PrivElem
+	"CREATE" "MASKING" "POLICY"
+	{
+		$$ = &ast.RoleOrPriv{
+			Symbols: "CREATE MASKING POLICY",
+		}
+	}
+|	"ALTER" "MASKING" "POLICY"
+	{
+		$$ = &ast.RoleOrPriv{
+			Symbols: "ALTER MASKING POLICY",
+		}
+	}
+|	"DROP" "MASKING" "POLICY"
+	{
+		$$ = &ast.RoleOrPriv{
+			Symbols: "DROP MASKING POLICY",
+		}
+	}
+|	PrivElem
 	{
 		$$ = &ast.RoleOrPriv{
 			Node: $1,

--- a/pkg/privilege/privileges/privileges.go
+++ b/pkg/privilege/privileges/privileges.go
@@ -76,7 +76,7 @@ var dynamicPrivs = []string{
 	"RESTRICTED_SQL_ADMIN",            // Can execute restricted SQL statements
 	"RESOURCE_GROUP_ADMIN",            // Create/Drop/Alter RESOURCE GROUP
 	"RESOURCE_GROUP_USER",             // Can change the resource group of current session.
-		"TRAFFIC_CAPTURE_ADMIN",           // Can capture traffic
+	"TRAFFIC_CAPTURE_ADMIN",           // Can capture traffic
 	"TRAFFIC_REPLAY_ADMIN",            // Can replay traffic
 	"CREATE MASKING POLICY",           // Can create masking policy
 	"ALTER MASKING POLICY",            // Can alter masking policy

--- a/pkg/privilege/privileges/privileges.go
+++ b/pkg/privilege/privileges/privileges.go
@@ -76,8 +76,11 @@ var dynamicPrivs = []string{
 	"RESTRICTED_SQL_ADMIN",            // Can execute restricted SQL statements
 	"RESOURCE_GROUP_ADMIN",            // Create/Drop/Alter RESOURCE GROUP
 	"RESOURCE_GROUP_USER",             // Can change the resource group of current session.
-	"TRAFFIC_CAPTURE_ADMIN",           // Can capture traffic
+		"TRAFFIC_CAPTURE_ADMIN",           // Can capture traffic
 	"TRAFFIC_REPLAY_ADMIN",            // Can replay traffic
+	"CREATE MASKING POLICY",           // Can create masking policy
+	"ALTER MASKING POLICY",            // Can alter masking policy
+	"DROP MASKING POLICY",             // Can drop masking policy
 }
 var dynamicPrivLock sync.Mutex
 var defaultTokenLife = 15 * time.Minute

--- a/pkg/util/dbterror/ddl_terror.go
+++ b/pkg/util/dbterror/ddl_terror.go
@@ -346,7 +346,7 @@ var (
 	// ErrPlacementPolicyWithDirectOption is returned when create/alter table with both placement policy and placement options existed.
 	ErrPlacementPolicyWithDirectOption = ClassDDL.NewStd(mysql.ErrPlacementPolicyWithDirectOption)
 
-		// ErrPlacementPolicyInUse is returned when placement policy is in use in drop/alter.
+	// ErrPlacementPolicyInUse is returned when placement policy is in use in drop/alter.
 	ErrPlacementPolicyInUse = ClassDDL.NewStd(mysql.ErrPlacementPolicyInUse)
 
 	// ErrMaskingPolicyExists is returned when masking policy already exists.

--- a/pkg/util/dbterror/ddl_terror.go
+++ b/pkg/util/dbterror/ddl_terror.go
@@ -346,8 +346,13 @@ var (
 	// ErrPlacementPolicyWithDirectOption is returned when create/alter table with both placement policy and placement options existed.
 	ErrPlacementPolicyWithDirectOption = ClassDDL.NewStd(mysql.ErrPlacementPolicyWithDirectOption)
 
-	// ErrPlacementPolicyInUse is returned when placement policy is in use in drop/alter.
+		// ErrPlacementPolicyInUse is returned when placement policy is in use in drop/alter.
 	ErrPlacementPolicyInUse = ClassDDL.NewStd(mysql.ErrPlacementPolicyInUse)
+
+	// ErrMaskingPolicyExists is returned when masking policy already exists.
+	ErrMaskingPolicyExists = ClassDDL.NewStd(mysql.ErrMaskingPolicyExists)
+	// ErrMaskingPolicyNotExists is returned when masking policy does not exist.
+	ErrMaskingPolicyNotExists = ClassDDL.NewStd(mysql.ErrMaskingPolicyNotExists)
 
 	// ErrMultipleDefConstInListPart returns multiple definition of same constant in list partitioning.
 	ErrMultipleDefConstInListPart = ClassDDL.NewStd(mysql.ErrMultipleDefConstInListPart)

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -3197,18 +3197,15 @@ Trigger	Tables	To use triggers
 Create tablespace	Server Admin	To create/alter/drop tablespaces
 Update	Tables	To update existing rows
 Usage	Server Admin	No privileges - allow connect only
-ALTER MASKING POLICY	Server Admin	
-BACKUP_ADMIN	Server Admin		
+BACKUP_ADMIN	Server Admin	
 RESTORE_ADMIN	Server Admin	
 SYSTEM_USER	Server Admin	
 SYSTEM_VARIABLES_ADMIN	Server Admin	
 ROLE_ADMIN	Server Admin	
 CONNECTION_ADMIN	Server Admin	
-CREATE MASKING POLICY	Server Admin	
-PLACEMENT_ADMIN	Server Admin		
+PLACEMENT_ADMIN	Server Admin	
 DASHBOARD_CLIENT	Server Admin	
-DROP MASKING POLICY	Server Admin	
-RESTRICTED_TABLES_ADMIN	Server Admin		
+RESTRICTED_TABLES_ADMIN	Server Admin	
 RESTRICTED_STATUS_ADMIN	Server Admin	
 RESTRICTED_VARIABLES_ADMIN	Server Admin	
 RESTRICTED_USER_ADMIN	Server Admin	
@@ -3220,6 +3217,9 @@ RESOURCE_GROUP_ADMIN	Server Admin
 RESOURCE_GROUP_USER	Server Admin	
 TRAFFIC_CAPTURE_ADMIN	Server Admin	
 TRAFFIC_REPLAY_ADMIN	Server Admin	
+CREATE MASKING POLICY	Server Admin	
+ALTER MASKING POLICY	Server Admin	
+DROP MASKING POLICY	Server Admin	
 show table status;
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
 t	InnoDB	10	Compact	0	0	0	0	0	0	NULL	0	NULL	NULL	utf8mb4_bin			

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -3197,15 +3197,18 @@ Trigger	Tables	To use triggers
 Create tablespace	Server Admin	To create/alter/drop tablespaces
 Update	Tables	To update existing rows
 Usage	Server Admin	No privileges - allow connect only
-BACKUP_ADMIN	Server Admin	
+ALTER MASKING POLICY	Server Admin	
+BACKUP_ADMIN	Server Admin		
 RESTORE_ADMIN	Server Admin	
 SYSTEM_USER	Server Admin	
 SYSTEM_VARIABLES_ADMIN	Server Admin	
 ROLE_ADMIN	Server Admin	
 CONNECTION_ADMIN	Server Admin	
-PLACEMENT_ADMIN	Server Admin	
+CREATE MASKING POLICY	Server Admin	
+PLACEMENT_ADMIN	Server Admin		
 DASHBOARD_CLIENT	Server Admin	
-RESTRICTED_TABLES_ADMIN	Server Admin	
+DROP MASKING POLICY	Server Admin	
+RESTRICTED_TABLES_ADMIN	Server Admin		
 RESTRICTED_STATUS_ADMIN	Server Admin	
 RESTRICTED_VARIABLES_ADMIN	Server Admin	
 RESTRICTED_USER_ADMIN	Server Admin	

--- a/tests/integrationtest/r/privilege/privileges.result
+++ b/tests/integrationtest/r/privilege/privileges.result
@@ -57,12 +57,13 @@ drop placement policy if exists x;
 drop user placement_user;
 drop table if exists privilege__privileges.mask_t;
 create table privilege__privileges.mask_t (c char(10));
-CREATE USER mask_creator, mask_alter, mask_drop, mask_none;
+CREATE USER mask_creator, mask_alter, mask_drop, mask_none, mask_only_creator;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_creator;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_alter;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_drop;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_none;
 GRANT CREATE MASKING POLICY ON *.* TO mask_creator;
+GRANT CREATE MASKING POLICY ON *.* TO mask_only_creator;
 GRANT ALTER MASKING POLICY ON *.* TO mask_alter;
 GRANT DROP MASKING POLICY ON *.* TO mask_drop;
 create masking policy p on mask_t(c) as c;
@@ -72,6 +73,8 @@ Error 1227 (42000): Access denied; you need (at least one of) the SUPER or ALTER
 create masking policy p on mask_t(c) as c;
 alter table mask_t disable masking policy p;
 Error 1227 (42000): Access denied; you need (at least one of) the SUPER or ALTER MASKING POLICY privilege(s) for this operation
+create masking policy p2 on privilege__privileges.mask_t(c) as c;
+Error 1142 (42000): ALTER command denied to user 'mask_only_creator'@'%' for table 'mask_t'
 alter table mask_t disable masking policy p;
 alter table mask_t enable masking policy p;
 alter table mask_t drop masking policy p;
@@ -81,6 +84,7 @@ drop user mask_creator;
 drop user mask_alter;
 drop user mask_drop;
 drop user mask_none;
+drop user mask_only_creator;
 drop table privilege__privileges.mask_t;
 CREATE USER resource_group_admin;
 CREATE USER resource_group_user;

--- a/tests/integrationtest/r/privilege/privileges.result
+++ b/tests/integrationtest/r/privilege/privileges.result
@@ -55,6 +55,33 @@ drop placement policy if exists x;
 create placement policy x PRIMARY_REGION="cn-east-1" REGIONS="cn-east-1";
 drop placement policy if exists x;
 drop user placement_user;
+drop table if exists privilege__privileges.mask_t;
+create table privilege__privileges.mask_t (c char(10));
+CREATE USER mask_creator, mask_alter, mask_drop, mask_none;
+GRANT ALTER ON privilege__privileges.mask_t TO mask_creator;
+GRANT ALTER ON privilege__privileges.mask_t TO mask_alter;
+GRANT ALTER ON privilege__privileges.mask_t TO mask_drop;
+GRANT ALTER ON privilege__privileges.mask_t TO mask_none;
+GRANT CREATE MASKING POLICY ON *.* TO mask_creator;
+GRANT ALTER MASKING POLICY ON *.* TO mask_alter;
+GRANT DROP MASKING POLICY ON *.* TO mask_drop;
+create masking policy p on mask_t(c) as c;
+Error 1227 (42000): Access denied; you need (at least one of) the SUPER or CREATE MASKING POLICY privilege(s) for this operation
+alter table mask_t disable masking policy p;
+Error 1227 (42000): Access denied; you need (at least one of) the SUPER or ALTER MASKING POLICY privilege(s) for this operation
+create masking policy p on mask_t(c) as c;
+alter table mask_t disable masking policy p;
+Error 1227 (42000): Access denied; you need (at least one of) the SUPER or ALTER MASKING POLICY privilege(s) for this operation
+alter table mask_t disable masking policy p;
+alter table mask_t enable masking policy p;
+alter table mask_t drop masking policy p;
+Error 1227 (42000): Access denied; you need (at least one of) the SUPER or DROP MASKING POLICY privilege(s) for this operation
+alter table mask_t drop masking policy p;
+drop user mask_creator;
+drop user mask_alter;
+drop user mask_drop;
+drop user mask_none;
+drop table privilege__privileges.mask_t;
 CREATE USER resource_group_admin;
 CREATE USER resource_group_user;
 set @@global.tidb_enable_resource_control = 1;

--- a/tests/integrationtest/t/privilege/privileges.test
+++ b/tests/integrationtest/t/privilege/privileges.test
@@ -87,12 +87,13 @@ drop user placement_user;
 # TestMaskingPolicyDynamicPriv
 drop table if exists privilege__privileges.mask_t;
 create table privilege__privileges.mask_t (c char(10));
-CREATE USER mask_creator, mask_alter, mask_drop, mask_none;
+CREATE USER mask_creator, mask_alter, mask_drop, mask_none, mask_only_creator;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_creator;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_alter;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_drop;
 GRANT ALTER ON privilege__privileges.mask_t TO mask_none;
 GRANT CREATE MASKING POLICY ON *.* TO mask_creator;
+GRANT CREATE MASKING POLICY ON *.* TO mask_only_creator;
 GRANT ALTER MASKING POLICY ON *.* TO mask_alter;
 GRANT DROP MASKING POLICY ON *.* TO mask_drop;
 
@@ -110,6 +111,12 @@ create masking policy p on mask_t(c) as c;
 --error 1227
 alter table mask_t disable masking policy p;
 disconnect mask_creator;
+
+connect (mask_only_creator, localhost, mask_only_creator,,);
+connection mask_only_creator;
+--error 1142
+create masking policy p2 on privilege__privileges.mask_t(c) as c;
+disconnect mask_only_creator;
 
 connect (mask_alter, localhost, mask_alter,, privilege__privileges);
 connection mask_alter;
@@ -129,6 +136,7 @@ drop user mask_creator;
 drop user mask_alter;
 drop user mask_drop;
 drop user mask_none;
+drop user mask_only_creator;
 drop table privilege__privileges.mask_t;
 
 # TestResourceGroupAdminDynamicPriv

--- a/tests/integrationtest/t/privilege/privileges.test
+++ b/tests/integrationtest/t/privilege/privileges.test
@@ -84,6 +84,53 @@ disconnect placement_user;
 connection default;
 drop user placement_user;
 
+# TestMaskingPolicyDynamicPriv
+drop table if exists privilege__privileges.mask_t;
+create table privilege__privileges.mask_t (c char(10));
+CREATE USER mask_creator, mask_alter, mask_drop, mask_none;
+GRANT ALTER ON privilege__privileges.mask_t TO mask_creator;
+GRANT ALTER ON privilege__privileges.mask_t TO mask_alter;
+GRANT ALTER ON privilege__privileges.mask_t TO mask_drop;
+GRANT ALTER ON privilege__privileges.mask_t TO mask_none;
+GRANT CREATE MASKING POLICY ON *.* TO mask_creator;
+GRANT ALTER MASKING POLICY ON *.* TO mask_alter;
+GRANT DROP MASKING POLICY ON *.* TO mask_drop;
+
+connect (mask_none, localhost, mask_none,, privilege__privileges);
+connection mask_none;
+--error 1227
+create masking policy p on mask_t(c) as c;
+--error 1227
+alter table mask_t disable masking policy p;
+disconnect mask_none;
+
+connect (mask_creator, localhost, mask_creator,, privilege__privileges);
+connection mask_creator;
+create masking policy p on mask_t(c) as c;
+--error 1227
+alter table mask_t disable masking policy p;
+disconnect mask_creator;
+
+connect (mask_alter, localhost, mask_alter,, privilege__privileges);
+connection mask_alter;
+alter table mask_t disable masking policy p;
+alter table mask_t enable masking policy p;
+--error 1227
+alter table mask_t drop masking policy p;
+disconnect mask_alter;
+
+connect (mask_drop, localhost, mask_drop,, privilege__privileges);
+connection mask_drop;
+alter table mask_t drop masking policy p;
+disconnect mask_drop;
+
+connection default;
+drop user mask_creator;
+drop user mask_alter;
+drop user mask_drop;
+drop user mask_none;
+drop table privilege__privileges.mask_t;
+
 # TestResourceGroupAdminDynamicPriv
 CREATE USER resource_group_admin;
 CREATE USER resource_group_user;


### PR DESCRIPTION
## What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tidb/issues/65744

Problem Summary: Masking policy DDL operations had no privilege checks. Any user with table-level ALTER privilege could create/drop/modify masking policies. Generic `errors.Errorf` were used instead of proper error codes.

## What is changed and how it works?

1. **Dynamic privileges** — Register `CREATE MASKING POLICY`, `ALTER MASKING POLICY`, `DROP MASKING POLICY` as dynamic privileges in `pkg/privilege/privileges/privileges.go`.

2. **Privilege enforcement** — Add `requireMaskingPolicyDynamicPrivilege()` helper in `pkg/ddl/executor.go` and call it at all 6 masking policy executor entry points:
   - `CreateMaskingPolicy` → CREATE MASKING POLICY
   - `AddMaskingPolicy` → CREATE MASKING POLICY
   - `AlterTableMaskingPolicyState` → ALTER MASKING POLICY
   - `DropMaskingPolicy` → DROP MASKING POLICY
   - `ModifyMaskingPolicyExpression` → ALTER MASKING POLICY
   - `ModifyMaskingPolicyRestrictOn` → ALTER MASKING POLICY

3. **Error codes** — Replace `errors.Errorf("masking policy ...")` with `dbterror.ErrMaskingPolicyExists` / `dbterror.ErrMaskingPolicyNotExists` in executor and worker layers.

4. **Parser** — Add GRANT/REVOKE parsing rules for unquoted `CREATE MASKING POLICY`, `ALTER MASKING POLICY`, `DROP MASKING POLICY` in `pkg/parser/parser.y`.

5. **Tests** — Add privilege isolation integration tests.

## Check List

Tests
- [x] Unit test
- [x] Integration test

Side effects
- [x] `SHOW PRIVILEGES` output updated (3 new dynamic privilege rows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced dynamic privileges for masking policy create/alter/drop and added the corresponding privilege names to the privileges listing.

* **Bug Fixes**
  * Standardized typed masking-policy “already exists” and “not exists” errors across create/alter/drop flows.
  * Improved masking-policy access checks, including required table-level privileges when available.

* **Tests**
  * Added an integration test covering masking-policy dynamic privilege enforcement and updated expected outputs accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->