### PR TITLE
executor: fix RU v2 executor accounting (#68578)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -358,21 +358,22 @@ type RUV2Config struct {
 	// ExecutorL1 is the weight for fast-path executors that scale by cells:
 	// BatchPointGet, PointGet, and Limit.
 	ExecutorL1 float64 `toml:"executor-l1" json:"executor-l1"`
-	// ExecutorL2 is the weight for general executors, including HashAgg,
+	// ExecutorL2 is the weight for general executors, including Expand, HashAgg,
 	// HashJoin, IndexLookUpJoin, IndexLookUpExecutor, IndexReaderExecutor,
-	// MemTableReaderExec, SelectionExec, TableDualExec, TableReaderExecutor,
-	// UnionScanExec, and SelectLockExec.
+	// MemTableReaderExec, MergeJoin, Projection, SelectionExec, SelectLockExec,
+	// TableDualExec, TableReaderExecutor, TopN, UnionScanExec, and Window.
 	ExecutorL2 float64 `toml:"executor-l2" json:"executor-l2"`
 	// ExecutorL3 is the weight for heavier operators: Sort and StreamAgg.
 	ExecutorL3 float64 `toml:"executor-l3" json:"executor-l3"`
-	// ExecutorL5InsertRows is the per-row weight for insert work. Level 4 is
-	// intentionally unused today because only L1/L2/L3 executor groups and this
-	// insert-specific tier are currently modeled.
+	// ExecutorL5InsertRows is the weight for insert rows multiplied by inserted
+	// column count. Level 4 is intentionally unused today because only L1/L2/L3
+	// executor groups and this insert-specific tier are currently modeled.
 	ExecutorL5InsertRows    float64 `toml:"executor-l5-insert-rows" json:"executor-l5-insert-rows"`
 	PlanCnt                 float64 `toml:"plan-cnt" json:"plan-cnt"`
 	PlanDeriveStatsPaths    float64 `toml:"plan-derive-stats-paths" json:"plan-derive-stats-paths"`
 	ResourceManagerReadCnt  float64 `toml:"resource-manager-read-cnt" json:"resource-manager-read-cnt"`
 	ResourceManagerWriteCnt float64 `toml:"resource-manager-write-cnt" json:"resource-manager-write-cnt"`
+	WriteKeys               float64 `toml:"write-keys" json:"write-keys"`
 	SessionParserTotal      float64 `toml:"session-parser-total" json:"session-parser-total"`
 	TxnCnt                  float64 `toml:"txn-cnt" json:"txn-cnt"`
 }
@@ -391,6 +392,7 @@ func DefaultRUV2Config() RUV2Config {
 		PlanDeriveStatsPaths:    0.24968182,
 		ResourceManagerReadCnt:  0.02072003,
 		ResourceManagerWriteCnt: 0.07179779,
+		WriteKeys:               0.330760861554226,
 		SessionParserTotal:      0.19230499,
 		TxnCnt:                  0.03013709,
 	}

--- a/pkg/config/config.toml.example
+++ b/pkg/config/config.toml.example
@@ -448,19 +448,20 @@ result-chunk-cells = 0.00010000
 executor-l1 = 0.00013278
 # executor-l2 covers general executors:
 # HashAgg, HashJoin, IndexLookUpJoin, IndexLookUpExecutor, IndexReaderExecutor,
-# MemTableReaderExec, SelectionExec, TableDualExec, TableReaderExecutor,
-# UnionScanExec, and SelectLockExec.
+# MemTableReaderExec, MergeJoin, Projection, SelectionExec, SelectLockExec,
+# TableDualExec, TableReaderExecutor, TopN, UnionScanExec, Window, and Expand.
 executor-l2 = 0.00000383
 # executor-l3 covers heavier operators: Sort and StreamAgg.
 executor-l3 = 0.00141739
-# executor-l5-insert-rows is the per-row insert weight. Level 4 is
-# intentionally unused today because only L1/L2/L3 executor groups and this
-# insert-specific tier are currently modeled.
+# executor-l5-insert-rows is the weight for insert rows multiplied by inserted
+# column count. Level 4 is intentionally unused today because only L1/L2/L3
+# executor groups and this insert-specific tier are currently modeled.
 executor-l5-insert-rows = 0.00472572
 plan-cnt = 0.15392217
 plan-derive-stats-paths = 0.24968182
 resource-manager-read-cnt = 0.02072003
 resource-manager-write-cnt = 0.07179779
+write-keys = 0.330760861554226
 session-parser-total = 0.19230499
 txn-cnt = 0.03013709
 

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1650,7 +1650,6 @@ func (a *ExecStmt) FinishExecuteStmt(txnTS uint64, err error, hasMoreResults boo
 		sessVars.StmtCtx.SetPlan(a.Plan)
 	}
 
-	a.recordInsertRows2Metrics()
 	a.finalizeStatementRUV2Metrics()
 	a.updateNetworkTrafficStatsAndMetrics()
 	// `LowSlowQuery` and `SummaryStmt` must be called before recording `PrevStmt`.
@@ -1738,30 +1737,22 @@ func (a *ExecStmt) recordAffectedRows2Metrics() {
 	}
 }
 
-func (a *ExecStmt) recordInsertRows2Metrics() {
-	recordInsertRows2Metrics(a.Ctx.GetSessionVars())
+func recordDMLRowsColMultiply2Metrics(sessVars *variable.SessionVars, rowCount, columnCount int64) {
+	if rowCount <= 0 || columnCount <= 0 {
+		return
+	}
+
+	rowsColMultiply := rowCount * columnCount
+	if rowCount > math.MaxInt64/columnCount {
+		rowsColMultiply = math.MaxInt64
+	}
+	if sessVars.RUV2Metrics != nil {
+		sessVars.RUV2Metrics.AddExecutorL5InsertRows(rowsColMultiply)
+	}
 }
 
-func recordInsertRows2Metrics(sessVars *variable.SessionVars) {
-	stmtCtx := sessVars.StmtCtx
-	if stmtCtx.StmtType != "Insert" {
-		return
-	}
-	// EXPLAIN ANALYZE INSERT snapshots RU before FinishExecuteStmt runs, while the final statement reporting
-	// still goes through FinishExecuteStmt. Keep this accounting idempotent so both paths can share it safely.
-	if stmtCtx.InsertRowsAsRUV2Recorded {
-		return
-	}
-
-	affectedRows := stmtCtx.AffectedRows()
-	if affectedRows <= 0 {
-		return
-	}
-
-	if sessVars.RUV2Metrics != nil {
-		sessVars.RUV2Metrics.AddExecutorL5InsertRows(int64(affectedRows))
-	}
-	stmtCtx.InsertRowsAsRUV2Recorded = true
+func recordInsertRowsColMultiply2Metrics(sessVars *variable.SessionVars, rowsColMultiply int64) {
+	recordDMLRowsColMultiply2Metrics(sessVars, rowsColMultiply, 1)
 }
 
 // finalizeStatementRUV2Metrics is the sole drain of raw RUv2 counters. In-flight
@@ -1772,6 +1763,9 @@ func (a *ExecStmt) finalizeStatementRUV2Metrics() {
 	if sessVars.RUV2Metrics == nil || sessVars.RUV2Metrics.Bypass() {
 		return
 	}
+
+	execDetail := sessVars.StmtCtx.GetExecDetails()
+	execdetails.UpdateRUV2MetricsFromCommitDetails(sessVars.RUV2Metrics, execDetail.CommitDetail)
 
 	ruDetailRaw := a.GoCtx.Value(util.RUDetailsCtxKey)
 	ruDetail, _ := ruDetailRaw.(*util.RUDetails)

--- a/pkg/executor/adapter_test.go
+++ b/pkg/executor/adapter_test.go
@@ -499,10 +499,16 @@ func TestFinishExecuteStmtSyncsTiDBRUV2FromRUDetails(t *testing.T) {
 	}
 	ruDetails.AddRUV2(rawRUV2)
 	ruDetails.UpdateTiFlash(&rmpb.Consumption{RRU: 345, WRU: 67})
+	commitDetails := &util.CommitDetails{
+		WriteKeys: 3,
+		WriteSize: 66,
+	}
+	sessVars.StmtCtx.SyncExecDetails.MergeExecDetails(commitDetails)
 	// Build expected metrics by cloning the current state and manually adding
-	// the RUV2 counters (without draining ruDetails, since FinishExecuteStmt will drain).
+	// the pending counters (without draining ruDetails, since FinishExecuteStmt will drain).
 	expected := sessVars.RUV2Metrics.Clone()
 	execdetails.UpdateRUV2MetricsFromRUV2(expected, rawRUV2)
+	execdetails.UpdateRUV2MetricsFromCommitDetails(expected, commitDetails)
 
 	execStmt := &executor.ExecStmt{
 		Ctx:      ctx,
@@ -515,6 +521,8 @@ func TestFinishExecuteStmtSyncsTiDBRUV2FromRUDetails(t *testing.T) {
 	require.Equal(t, int64(5), sessVars.RUV2Metrics.ResourceManagerReadCnt())
 	require.Equal(t, int64(7), sessVars.RUV2Metrics.ResourceManagerWriteCnt())
 	require.Equal(t, int64(11), sessVars.RUV2Metrics.TiKVStorageProcessedKeysBatchGet())
+	require.Equal(t, int64(3), sessVars.RUV2Metrics.WriteKeys())
+	require.Equal(t, int64(66), sessVars.RUV2Metrics.WriteSize())
 	require.Equal(t, "rg1", reporter.group)
 	require.Equal(t, float64(23456), reporter.tikvRUV2)
 	require.Equal(t, expected.CalculateRUValues(sessVars.RUV2Weights()), reporter.tidbRUV2)
@@ -879,4 +887,83 @@ func TestMaxExecutionTimeIncludesTSOWaitTime(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInsertRowsColMultiplyRUV2SQLPath(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int primary key, b int, c int)")
+	tk.MustExec("create table src(a int primary key, b int, c int)")
+	tk.MustExec("insert into src values (10, 11, 12), (20, 21, 22)")
+
+	runInsert := func(sql string) int64 {
+		ctx := execdetails.ContextWithInitializedExecDetails(context.Background())
+		tk.MustExecWithContext(ctx, sql)
+		metrics := execdetails.RUV2MetricsFromContext(ctx)
+		require.NotNil(t, metrics)
+		return metrics.ExecutorL5InsertRows()
+	}
+
+	require.Equal(t, int64(6), runInsert("insert into t values (1, 2, 3), (2, 3, 4)"))
+	require.Equal(t, int64(4), runInsert("insert into t(a, c) values (3, 5), (4, 6)"))
+	require.Equal(t, int64(4), runInsert("insert into t(a, b) select a, b from src"))
+
+	oldEnableBatchDML := vardef.EnableBatchDML.Load()
+	vardef.EnableBatchDML.Store(true)
+	defer vardef.EnableBatchDML.Store(oldEnableBatchDML)
+
+	tk.MustExec("set @@session.tidb_batch_insert=1")
+	tk.MustExec("set @@session.tidb_dml_batch_size=2")
+	tk.MustExec("create table batch_t(a int primary key, b int, c int)")
+	tk.MustExec("insert into batch_t values (100, 100, 100)")
+
+	ctx := execdetails.ContextWithInitializedExecDetails(context.Background())
+	_, err := tk.ExecWithContext(ctx, "insert into batch_t values (1, 2, 3), (2, 3, 4), (100, 5, 6), (3, 4, 5)")
+	require.Error(t, err)
+	metrics := execdetails.RUV2MetricsFromContext(ctx)
+	require.NotNil(t, metrics)
+	require.Equal(t, int64(12), metrics.ExecutorL5InsertRows())
+	tk.MustQuery("select a, b, c from batch_t order by a").Check(testkit.Rows(
+		"1 2 3",
+		"2 3 4",
+		"100 100 100",
+	))
+}
+
+func TestDMLRowsColMultiplyRUV2SQLPath(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int primary key, b int, c int)")
+
+	runDML := func(sql string) int64 {
+		ctx := execdetails.ContextWithInitializedExecDetails(context.Background())
+		tk.MustExecWithContext(ctx, sql)
+		metrics := execdetails.RUV2MetricsFromContext(ctx)
+		require.NotNil(t, metrics)
+		return metrics.ExecutorL5InsertRows()
+	}
+
+	require.Equal(t, int64(6), runDML("replace into t values (1, 2, 3), (2, 3, 4)"))
+	require.Equal(t, int64(6), runDML("update t set b = b + 10 where a in (1, 2)"))
+	require.Equal(t, int64(3), runDML("delete from t where a = 1"))
+
+	tk.MustExec("create table multi_del_l(a int primary key)")
+	tk.MustExec("create table multi_del_r(a int primary key)")
+	tk.MustExec("insert into multi_del_l values (1), (2)")
+	tk.MustExec("insert into multi_del_r values (1), (2)")
+	require.Equal(t, int64(4), runDML("delete multi_del_l, multi_del_r from multi_del_l join multi_del_r on multi_del_l.a = multi_del_r.a"))
+
+	tk.MustExec("create table outer_l(a int primary key, b int)")
+	tk.MustExec("create table outer_r(a int primary key, b int)")
+	tk.MustExec("insert into outer_l values (1, 10), (2, 20)")
+	tk.MustExec("insert into outer_r values (1, 100)")
+	require.Equal(t, int64(2), runDML("update outer_l left join outer_r on outer_l.a = outer_r.a set outer_r.b = outer_r.b + 1"))
+
+	tk.MustExec("create table dup_t(a int primary key, b int)")
+	tk.MustExec("create table dup_s(a int, b int)")
+	tk.MustExec("insert into dup_t values (1, 10)")
+	tk.MustExec("insert into dup_s values (1, 100), (1, 200)")
+	require.Equal(t, int64(2), runDML("update dup_t join dup_s on dup_t.a = dup_s.a set dup_t.b = dup_t.b + 1"))
 }

--- a/pkg/executor/delete.go
+++ b/pkg/executor/delete.go
@@ -16,6 +16,7 @@ package executor
 
 import (
 	"context"
+	"math"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
@@ -52,6 +53,16 @@ type DeleteExec struct {
 	fkCascades map[int64][]*FKCascadeExec
 
 	ignoreErr bool
+}
+
+func addDeleteRowsColMultiply(total, delta int64) int64 {
+	if delta <= 0 || total == math.MaxInt64 {
+		return total
+	}
+	if total > math.MaxInt64-delta {
+		return math.MaxInt64
+	}
+	return total + delta
 }
 
 // Next implements the Executor Next interface.
@@ -102,6 +113,11 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 		return errors.New("schema columns and fields mismatch")
 	}
 	memUsageOfChk := int64(0)
+	var rowsColMultiply int64
+	recordRowsColMultiply := func() {
+		recordDMLRowsColMultiply2Metrics(e.Ctx().GetSessionVars(), rowsColMultiply, 1)
+		rowsColMultiply = 0
+	}
 
 	for {
 		e.memTracker.Consume(-memUsageOfChk)
@@ -117,6 +133,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 		e.memTracker.Consume(memUsageOfChk)
 		for chunkRow := iter.Begin(); chunkRow != iter.End(); chunkRow = iter.Next() {
 			if batchDelete && rowCount >= batchDMLSize {
+				recordRowsColMultiply()
 				if err := e.doBatchDelete(ctx); err != nil {
 					return err
 				}
@@ -143,10 +160,15 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 					continue
 				}
 			}
+			columnCount := len(datumRow)
+			if isExtraHandle {
+				columnCount--
+			}
 			err = e.deleteOneRow(tbl, colPosInfo, isExtraHandle, datumRow)
 			if err != nil {
 				return err
 			}
+			rowsColMultiply = addDeleteRowsColMultiply(rowsColMultiply, int64(columnCount))
 			rowCount++
 			datumRow = datumRow[:0]
 		}
@@ -158,6 +180,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 		}
 	}
 
+	recordRowsColMultiply()
 	return nil
 }
 
@@ -242,6 +265,7 @@ func (e *DeleteExec) deleteMultiTablesByChunk(ctx context.Context) error {
 }
 
 func (e *DeleteExec) removeRowsInTblRowMap(ctx context.Context, tblRowMap tableRowMapType) error {
+	var rowsColMultiply int64
 	for id, rowMap := range tblRowMap {
 		var err error
 		rowMap.Range(func(h kv.Handle, val handleInfoPair) bool {
@@ -259,12 +283,17 @@ func (e *DeleteExec) removeRowsInTblRowMap(ctx context.Context, tblRowMap tableR
 			}
 
 			err = e.removeRow(e.Ctx(), e.tblID2Table[id], h, val.handleVal, val.posInfo)
-			return err == nil
+			if err != nil {
+				return false
+			}
+			rowsColMultiply = addDeleteRowsColMultiply(rowsColMultiply, int64(len(val.handleVal)))
+			return true
 		})
 		if err != nil {
 			return err
 		}
 	}
+	recordDMLRowsColMultiply2Metrics(e.Ctx().GetSessionVars(), rowsColMultiply, 1)
 	return nil
 }
 

--- a/pkg/executor/explain.go
+++ b/pkg/executor/explain.go
@@ -136,7 +136,6 @@ func (e *ExplainExec) executeAnalyzeExec(ctx context.Context) (err error) {
 	}
 	// Register the RU runtime stats to the runtime stats collection after the analyze executor has been executed.
 	if e.explain.Analyze && e.analyzeExec != nil && e.executed {
-		recordInsertRows2Metrics(e.Ctx().GetSessionVars())
 		ruDetailsRaw := ctx.Value(clientutil.RUDetailsCtxKey)
 		if coll := e.Ctx().GetSessionVars().StmtCtx.RuntimeStatsColl; coll != nil {
 			var ruDetails *clientutil.RUDetails

--- a/pkg/executor/explain_unit_test.go
+++ b/pkg/executor/explain_unit_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
@@ -44,6 +45,30 @@ type mockErrorOperator struct {
 	exec.BaseExecutor
 	toPanic bool
 	closed  bool
+}
+
+func TestInsertRowsColMultiplyRUV2Metrics(t *testing.T) {
+	ctx := mock.NewContext()
+	ctx.GetSessionVars().StmtCtx.StmtType = "Insert"
+	ctx.GetSessionVars().RUV2Metrics = execdetails.NewRUV2Metrics()
+
+	insertValues := &InsertValues{
+		BaseExecutor:              exec.NewBaseExecutor(ctx, nil, 0),
+		rowCount:                  4,
+		recordRUV2RowsColMultiply: true,
+		insertColumns:             make([]*table.Column, 3),
+	}
+	require.Equal(t, int64(12), insertValues.rowsColMultiply())
+
+	insertValues.recordRowsColMultiply2RUV2Metrics()
+	require.Equal(t, int64(12), ctx.GetSessionVars().RUV2Metrics.ExecutorL5InsertRows())
+
+	insertValues.recordRowsColMultiply2RUV2Metrics()
+	require.Equal(t, int64(12), ctx.GetSessionVars().RUV2Metrics.ExecutorL5InsertRows())
+
+	insertValues.rowCount = 5
+	insertValues.recordRowsColMultiply2RUV2Metrics()
+	require.Equal(t, int64(15), ctx.GetSessionVars().RUV2Metrics.ExecutorL5InsertRows())
 }
 
 type mockEmptyOperator struct {
@@ -138,10 +163,9 @@ func TestExplainAnalyzeInvokeNextAndClose(t *testing.T) {
 	require.EqualError(t, err, "next panic, close error")
 	require.True(t, mockOpr.closed)
 
-	t.Run("insert ru snapshot is complete before finish and remains idempotent", func(t *testing.T) {
+	t.Run("insert ru snapshot is complete before finish", func(t *testing.T) {
 		ctx := mock.NewContext()
 		ctx.GetSessionVars().StmtCtx.StmtType = "Insert"
-		ctx.GetSessionVars().StmtCtx.AddAffectedRows(5)
 		ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStatsColl(nil)
 
 		goCtx := execdetails.ContextWithInitializedExecDetails(context.Background())
@@ -161,17 +185,17 @@ func TestExplainAnalyzeInvokeNextAndClose(t *testing.T) {
 			analyzeExec: analyzeExec,
 		}
 
+		recordInsertRowsColMultiply2Metrics(ctx.GetSessionVars(), 15)
 		require.NoError(t, explainExec.executeAnalyzeExec(goCtx))
 
 		metrics := ctx.GetSessionVars().RUV2Metrics
-		require.Equal(t, int64(5), metrics.ExecutorL5InsertRows())
+		require.Equal(t, int64(15), metrics.ExecutorL5InsertRows())
 		// DefaultRUVersion is v1 (no domain in unit test), so RU stats show RRU+WRU format.
 		// Verify the stats are registered and contain "RU:" prefix.
 		rootStatsStr := ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetRootStats(targetPlan.ID()).String()
 		require.Contains(t, rootStatsStr, "RU:")
 
-		recordInsertRows2Metrics(ctx.GetSessionVars())
-		require.Equal(t, int64(5), ctx.GetSessionVars().RUV2Metrics.ExecutorL5InsertRows())
+		require.Equal(t, int64(15), ctx.GetSessionVars().RUV2Metrics.ExecutorL5InsertRows())
 	})
 
 	t.Run("explain analyze drains pending raw ruv2 before snapshot", func(t *testing.T) {

--- a/pkg/executor/insert.go
+++ b/pkg/executor/insert.go
@@ -362,6 +362,7 @@ func (e *InsertExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	if e.collectRuntimeStatsEnabled() {
 		ctx = context.WithValue(ctx, autoid.AllocatorRuntimeStatsCtxKey, e.stats.AllocatorRuntimeStats)
 	}
+	e.recordRUV2RowsColMultiply = true
 
 	if !e.EmptyChildren() && e.Children(0) != nil {
 		return insertRowsFromSelect(ctx, e)

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -55,10 +55,12 @@ import (
 type InsertValues struct {
 	exec.BaseExecutor
 
-	rowCount       uint64
-	curBatchCnt    uint64
-	maxRowsInBatch uint64
-	lastInsertID   uint64
+	rowCount                    uint64
+	curBatchCnt                 uint64
+	maxRowsInBatch              uint64
+	lastInsertID                uint64
+	recordRUV2RowsColMultiply   bool
+	ruv2RecordedRowsColMultiply int64
 
 	SelectExec exec.Executor
 
@@ -97,6 +99,32 @@ type InsertValues struct {
 	fkCascades []*FKCascadeExec
 
 	ignoreErr bool
+}
+
+func (e *InsertValues) rowsColMultiply() int64 {
+	colCount := len(e.insertColumns)
+	if e.rowCount == 0 || colCount == 0 {
+		return 0
+	}
+
+	const maxInt64 = uint64(1<<63 - 1)
+	if e.rowCount > maxInt64/uint64(colCount) {
+		return int64(maxInt64)
+	}
+	return int64(e.rowCount * uint64(colCount))
+}
+
+func (e *InsertValues) recordRowsColMultiply2RUV2Metrics() {
+	if !e.recordRUV2RowsColMultiply {
+		return
+	}
+	current := e.rowsColMultiply()
+	delta := current - e.ruv2RecordedRowsColMultiply
+	if delta <= 0 {
+		return
+	}
+	recordInsertRowsColMultiply2Metrics(e.Ctx().GetSessionVars(), delta)
+	e.ruv2RecordedRowsColMultiply = current
 }
 
 type defaultVal struct {
@@ -234,6 +262,7 @@ func insertRows(ctx context.Context, base insertCommon) (err error) {
 			if err = base.exec(ctx, rows); err != nil {
 				return err
 			}
+			e.recordRowsColMultiply2RUV2Metrics()
 			rows = rows[:0]
 			memTracker.Consume(-memUsageOfRows)
 			memUsageOfRows = 0
@@ -255,6 +284,7 @@ func insertRows(ctx context.Context, base insertCommon) (err error) {
 	if err != nil {
 		return err
 	}
+	e.recordRowsColMultiply2RUV2Metrics()
 	memTracker.Consume(-memUsageOfRows)
 	return nil
 }
@@ -505,6 +535,7 @@ func insertRowsFromSelect(ctx context.Context, base insertCommon) error {
 				if err = base.exec(ctx, rows); err != nil {
 					return err
 				}
+				e.recordRowsColMultiply2RUV2Metrics()
 				rows = rows[:0]
 				extraColsInSel = extraColsInSel[:0]
 				totalMemDelta += -memUsageOfRows - memUsageOfExtraCols
@@ -526,6 +557,7 @@ func insertRowsFromSelect(ctx context.Context, base insertCommon) error {
 		if err != nil {
 			return err
 		}
+		e.recordRowsColMultiply2RUV2Metrics()
 		rows = rows[:0]
 		extraColsInSel = extraColsInSel[:0]
 		memTracker.Consume(-memUsageOfRows - memUsageOfExtraCols - chkMemUsage)

--- a/pkg/executor/internal/exec/BUILD.bazel
+++ b/pkg/executor/internal/exec/BUILD.bazel
@@ -42,7 +42,7 @@ go_test(
     ],
     embed = [":exec"],
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         "//pkg/domain",
         "//pkg/kv",

--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -99,9 +99,10 @@ type ruv2ExecutorMetric struct {
 // by both RU v2 statement metrics and the configurable RU v2 weights.
 //
 // L1: BatchPointGet, PointGet, Limit.
-// L2: HashAgg, HashJoin, IndexLookUpJoin, IndexLookUpExecutor,
-// IndexReaderExecutor, MemTableReaderExec, SelectionExec, TableDualExec,
-// TableReaderExecutor, UnionScanExec, SelectLockExec.
+// L2: Expand, HashAgg, HashJoin, IndexLookUpJoin, IndexLookUpExecutor,
+// IndexLookUpMergeJoin, IndexNestedLoopHashJoin, IndexReaderExecutor,
+// MemTableReaderExec, MergeJoin, Projection, SelectionExec, TableDualExec,
+// TableReaderExecutor, TopN, UnionScanExec, SelectLockExec, Window.
 // L3: Sort, StreamAgg.
 // L4: intentionally unused today.
 // L5: reserved for insert-row accounting outside this executor map.
@@ -115,30 +116,46 @@ func ruv2ExecutorMetricByType(execType string) (ruv2ExecutorMetric, bool) {
 		return ruv2ExecutorMetric{level: 1, label: "LimitExec", useCells: true}, true
 	case "*aggregate.HashAggExec":
 		return ruv2ExecutorMetric{level: 2, label: "HashAggExec", useCells: false}, true
-	case "*executor.HashJoinExec":
-		return ruv2ExecutorMetric{level: 2, label: "HashJoinExec", useCells: false}, true
-	case "*executor.IndexLookUpJoin":
-		return ruv2ExecutorMetric{level: 2, label: "IndexLookUpJoin", useCells: true}, true
+	case "*executor.ExpandExec":
+		return ruv2ExecutorMetric{level: 2, label: "ExpandExec", useCells: false}, true
 	case "*executor.IndexLookUpExecutor":
 		return ruv2ExecutorMetric{level: 2, label: "IndexLookUpExecutor", useCells: false}, true
 	case "*executor.IndexReaderExecutor":
 		return ruv2ExecutorMetric{level: 2, label: "IndexReaderExecutor", useCells: false}, true
 	case "*executor.MemTableReaderExec":
 		return ruv2ExecutorMetric{level: 2, label: "MemTableReaderExec", useCells: false}, true
+	case "*executor.ProjectionExec":
+		return ruv2ExecutorMetric{level: 2, label: "ProjectionExec", useCells: true}, true
 	case "*executor.SelectionExec":
 		return ruv2ExecutorMetric{level: 2, label: "SelectionExec", useCells: false}, true
+	case "*executor.SelectLockExec":
+		return ruv2ExecutorMetric{level: 2, label: "SelectLockExec", useCells: true}, true
 	case "*executor.TableDualExec":
 		return ruv2ExecutorMetric{level: 2, label: "TableDualExec", useCells: false}, true
 	case "*executor.TableReaderExecutor":
 		return ruv2ExecutorMetric{level: 2, label: "TableReaderExecutor", useCells: false}, true
 	case "*executor.UnionScanExec":
 		return ruv2ExecutorMetric{level: 2, label: "UnionScanExec", useCells: false}, true
-	case "*executor.SelectLockExec":
-		return ruv2ExecutorMetric{level: 2, label: "SelectLockExec", useCells: true}, true
-	case "*executor.SortExec":
-		return ruv2ExecutorMetric{level: 3, label: "SortExec", useCells: true}, true
+	case "*windows.WindowExec", "*windows.PipelinedWindowExec", "*windows.OrderedWindowExec":
+		return ruv2ExecutorMetric{level: 2, label: "WindowExec", useCells: false}, true
+	case "*join.HashJoinV1Exec":
+		return ruv2ExecutorMetric{level: 2, label: "HashJoinV1Exec", useCells: false}, true
+	case "*join.HashJoinV2Exec":
+		return ruv2ExecutorMetric{level: 2, label: "HashJoinV2Exec", useCells: false}, true
+	case "*join.IndexLookUpJoin":
+		return ruv2ExecutorMetric{level: 2, label: "IndexLookUpJoin", useCells: true}, true
+	case "*join.IndexLookUpMergeJoin":
+		return ruv2ExecutorMetric{level: 2, label: "IndexLookUpMergeJoin", useCells: true}, true
+	case "*join.IndexNestedLoopHashJoin":
+		return ruv2ExecutorMetric{level: 2, label: "IndexNestedLoopHashJoin", useCells: true}, true
+	case "*join.MergeJoinExec":
+		return ruv2ExecutorMetric{level: 2, label: "MergeJoinExec", useCells: false}, true
+	case "*sortexec.TopNExec":
+		return ruv2ExecutorMetric{level: 2, label: "TopNExec", useCells: true}, true
 	case "*aggregate.StreamAggExec":
 		return ruv2ExecutorMetric{level: 3, label: "StreamAggExec", useCells: false}, true
+	case "*sortexec.SortExec":
+		return ruv2ExecutorMetric{level: 3, label: "SortExec", useCells: true}, true
 	default:
 		return ruv2ExecutorMetric{}, false
 	}

--- a/pkg/executor/internal/exec/executor_test.go
+++ b/pkg/executor/internal/exec/executor_test.go
@@ -69,3 +69,50 @@ func TestNextIOAccAddInputCountsRowsWithZeroCols(t *testing.T) {
 		require.True(t, needNextIOAcc(false, parentAcc, 1))
 	})
 }
+
+func TestRUV2ExecutorMetricByTypeIncludesConcreteExecutorTypes(t *testing.T) {
+	cases := map[string]ruv2ExecutorMetric{
+		"*aggregate.HashAggExec":        {level: 2, label: "HashAggExec", useCells: false},
+		"*aggregate.StreamAggExec":      {level: 3, label: "StreamAggExec", useCells: false},
+		"*executor.BatchPointGetExec":   {level: 1, label: "BatchPointGetExec", useCells: true},
+		"*executor.ExpandExec":          {level: 2, label: "ExpandExec", useCells: false},
+		"*executor.IndexLookUpExecutor": {level: 2, label: "IndexLookUpExecutor", useCells: false},
+		"*executor.IndexReaderExecutor": {level: 2, label: "IndexReaderExecutor", useCells: false},
+		"*executor.LimitExec":           {level: 1, label: "LimitExec", useCells: true},
+		"*executor.MemTableReaderExec":  {level: 2, label: "MemTableReaderExec", useCells: false},
+		"*executor.PointGetExecutor":    {level: 1, label: "PointGetExecutor", useCells: true},
+		"*executor.ProjectionExec":      {level: 2, label: "ProjectionExec", useCells: true},
+		"*executor.SelectLockExec":      {level: 2, label: "SelectLockExec", useCells: true},
+		"*executor.SelectionExec":       {level: 2, label: "SelectionExec", useCells: false},
+		"*executor.TableDualExec":       {level: 2, label: "TableDualExec", useCells: false},
+		"*executor.TableReaderExecutor": {level: 2, label: "TableReaderExecutor", useCells: false},
+		"*executor.UnionScanExec":       {level: 2, label: "UnionScanExec", useCells: false},
+		"*join.HashJoinV1Exec":          {level: 2, label: "HashJoinV1Exec", useCells: false},
+		"*join.HashJoinV2Exec":          {level: 2, label: "HashJoinV2Exec", useCells: false},
+		"*join.IndexLookUpJoin":         {level: 2, label: "IndexLookUpJoin", useCells: true},
+		"*join.IndexLookUpMergeJoin":    {level: 2, label: "IndexLookUpMergeJoin", useCells: true},
+		"*join.IndexNestedLoopHashJoin": {level: 2, label: "IndexNestedLoopHashJoin", useCells: true},
+		"*join.MergeJoinExec":           {level: 2, label: "MergeJoinExec", useCells: false},
+		"*sortexec.SortExec":            {level: 3, label: "SortExec", useCells: true},
+		"*sortexec.TopNExec":            {level: 2, label: "TopNExec", useCells: true},
+		"*windows.OrderedWindowExec":    {level: 2, label: "WindowExec", useCells: false},
+		"*windows.PipelinedWindowExec":  {level: 2, label: "WindowExec", useCells: false},
+		"*windows.WindowExec":           {level: 2, label: "WindowExec", useCells: false},
+	}
+
+	for typ, expected := range cases {
+		actual, ok := ruv2ExecutorMetricByType(typ)
+		require.True(t, ok, typ)
+		require.Equal(t, expected, actual)
+	}
+
+	for _, staleType := range []string{
+		"*executor.HashJoinExec",
+		"*executor.IndexLookUpJoin",
+		"*executor.SortExec",
+		"*executor.WindowExec",
+	} {
+		_, ok := ruv2ExecutorMetricByType(staleType)
+		require.False(t, ok, staleType)
+	}
+}

--- a/pkg/executor/replace.go
+++ b/pkg/executor/replace.go
@@ -196,6 +196,7 @@ func (e *ReplaceExec) exec(ctx context.Context, newRows [][]types.Datum) error {
 // Next implements the Executor Next interface.
 func (e *ReplaceExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.Reset()
+	e.recordRUV2RowsColMultiply = true
 	if e.collectRuntimeStatsEnabled() {
 		ctx = context.WithValue(ctx, autoid.AllocatorRuntimeStatsCtxKey, e.stats.AllocatorRuntimeStats)
 	}

--- a/pkg/executor/update.go
+++ b/pkg/executor/update.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"runtime/trace"
 	"slices"
 
@@ -364,17 +365,31 @@ func (e *UpdateExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		if e.collectRuntimeStatsEnabled() {
 			ctx = context.WithValue(ctx, autoid.AllocatorRuntimeStatsCtxKey, e.stats.AllocatorRuntimeStats)
 		}
-		numRows, err := e.updateRows(ctx)
+		numRows, rowsColMultiply, err := e.updateRows(ctx)
 		if err != nil {
 			return err
 		}
 		e.drained = true
 		e.Ctx().GetSessionVars().StmtCtx.AddRecordRows(uint64(numRows))
+		recordDMLRowsColMultiply2Metrics(e.Ctx().GetSessionVars(), rowsColMultiply, 1)
 	}
 	return nil
 }
 
-func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
+func (e *UpdateExec) rowsColMultiplyForPreparedRow() int64 {
+	var columnCount int64
+	for i, content := range e.tblColPosInfos {
+		if i >= len(e.tableUpdatable) || !e.tableUpdatable[i] || i >= len(e.changed) || e.changed[i] {
+			continue
+		}
+		if content.End > content.Start {
+			columnCount += int64(content.End - content.Start)
+		}
+	}
+	return columnCount
+}
+
+func (e *UpdateExec) updateRows(ctx context.Context) (int, int64, error) {
 	fields := exec.RetTypes(e.Children(0))
 	colsInfo := physicalop.GetUpdateColumnsInfo(e.tblID2table, e.tblColPosInfos, len(fields))
 	globalRowIdx := 0
@@ -391,8 +406,9 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 
 	txn, err := e.Ctx().Txn(true)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
+	var rowsColMultiply int64
 
 	if e.virtualAssignmentsOffset < len(e.OrderedList) {
 		e.assignmentsPerTable = make(map[int][]*expression.Assignment, 0)
@@ -413,7 +429,7 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 		e.memTracker.Consume(-memUsageOfChk)
 		err := exec.Next(ctx, e.Children(0), chk)
 		if err != nil {
-			return 0, err
+			return 0, 0, err
 		}
 
 		if chk.NumRows() == 0 {
@@ -440,16 +456,22 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 			datumRow := chunkRow.GetDatumRow(fields)
 			// precomputes handles
 			if err := e.prepare(datumRow); err != nil {
-				return 0, err
+				return 0, 0, err
+			}
+			rowColMultiply := e.rowsColMultiplyForPreparedRow()
+			if rowsColMultiply > math.MaxInt64-rowColMultiply {
+				rowsColMultiply = math.MaxInt64
+			} else {
+				rowsColMultiply += rowColMultiply
 			}
 			// compose non-generated columns
 			newRow, err := composeFunc(globalRowIdx, datumRow, colsInfo)
 			if err != nil {
-				return 0, err
+				return 0, 0, err
 			}
 			// merge non-generated columns
 			if err := e.mergeNonGenerated(datumRow, newRow); err != nil {
-				return 0, err
+				return 0, 0, err
 			}
 
 			if e.virtualAssignmentsOffset < len(e.OrderedList) {
@@ -459,14 +481,14 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 			if err := e.exec(
 				ctx, e.Children(0).Schema(),
 				globalRowIdx, datumRow, newRow, dupKeyCheck); err != nil {
-				return 0, err
+				return 0, 0, err
 			}
 			globalRowIdx++
 		}
 		totalNumRows += chk.NumRows()
 		chk = chunk.Renew(chk, e.MaxChunkSize())
 	}
-	return totalNumRows, nil
+	return totalNumRows, rowsColMultiply, nil
 }
 
 func handleUpdateError(sctx sessionctx.Context, colName ast.CIStr, colInfo *mmodel.ColumnInfo, rowIdx int, err error) error {

--- a/pkg/metrics/BUILD.bazel
+++ b/pkg/metrics/BUILD.bazel
@@ -61,7 +61,7 @@ go_test(
     ],
     embed = [":metrics"],
     flaky = True,
-    shard_count = 9,
+    shard_count = 6,
     deps = [
         "//pkg/parser/terror",
         "//pkg/statistics/handle/cache",

--- a/pkg/metrics/BUILD.bazel
+++ b/pkg/metrics/BUILD.bazel
@@ -61,7 +61,7 @@ go_test(
     ],
     embed = [":metrics"],
     flaky = True,
-    shard_count = 5,
+    shard_count = 9,
     deps = [
         "//pkg/parser/terror",
         "//pkg/statistics/handle/cache",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -337,6 +337,8 @@ func RegisterMetrics() {
 	prometheus.MustRegister(RUV2PlanDeriveStatsPaths)
 	prometheus.MustRegister(RUV2ResourceManagerReadCnt)
 	prometheus.MustRegister(RUV2ResourceManagerWriteCnt)
+	prometheus.MustRegister(RUV2WriteKeys)
+	prometheus.MustRegister(RUV2WriteSize)
 	prometheus.MustRegister(RUV2SessionParserTotal)
 	prometheus.MustRegister(RUV2TxnCnt)
 	prometheus.MustRegister(RUV2TiKVKVEngineCacheMiss)

--- a/pkg/metrics/metrics_internal_test.go
+++ b/pkg/metrics/metrics_internal_test.go
@@ -47,6 +47,45 @@ func countCollectedMetrics(collector prometheus.Collector) int {
 	return count
 }
 
+func TestRUV2ExecutorCounterReturnsCachedKnownLabels(t *testing.T) {
+	cases := []struct {
+		level    int
+		label    string
+		expected prometheus.Counter
+	}{
+		{1, "BatchPointGetExec", ruv2ExecutorL1BatchPointGetExec},
+		{1, "PointGetExecutor", ruv2ExecutorL1PointGetExecutor},
+		{1, "LimitExec", ruv2ExecutorL1LimitExec},
+		{2, "ExpandExec", ruv2ExecutorL2ExpandExec},
+		{2, "HashAggExec", ruv2ExecutorL2HashAggExec},
+		{2, "HashJoinExec", ruv2ExecutorL2HashJoinExec},
+		{2, "HashJoinV1Exec", ruv2ExecutorL2HashJoinV1Exec},
+		{2, "HashJoinV2Exec", ruv2ExecutorL2HashJoinV2Exec},
+		{2, "IndexLookUpJoin", ruv2ExecutorL2IndexLookUpJoin},
+		{2, "IndexLookUpMergeJoin", ruv2ExecutorL2IndexLookUpMergeJoin},
+		{2, "IndexNestedLoopHashJoin", ruv2ExecutorL2IndexNestedLoopHashJoin},
+		{2, "IndexLookUpExecutor", ruv2ExecutorL2IndexLookUpExec},
+		{2, "IndexReaderExecutor", ruv2ExecutorL2IndexReaderExec},
+		{2, "MemTableReaderExec", ruv2ExecutorL2MemTableReaderExec},
+		{2, "MergeJoinExec", ruv2ExecutorL2MergeJoinExec},
+		{2, "ProjectionExec", ruv2ExecutorL2ProjectionExec},
+		{2, "SelectionExec", ruv2ExecutorL2SelectionExec},
+		{2, "TableDualExec", ruv2ExecutorL2TableDualExec},
+		{2, "TableReaderExecutor", ruv2ExecutorL2TableReaderExec},
+		{2, "TopNExec", ruv2ExecutorL2TopNExec},
+		{2, "UnionScanExec", ruv2ExecutorL2UnionScanExec},
+		{2, "SelectLockExec", ruv2ExecutorL2SelectLockExec},
+		{2, "WindowExec", ruv2ExecutorL2WindowExec},
+		{3, "SortExec", ruv2ExecutorL3SortExec},
+		{3, "StreamAggExec", ruv2ExecutorL3StreamAggExec},
+	}
+
+	for _, tc := range cases {
+		require.NotNil(t, tc.expected, tc.label)
+		require.True(t, tc.expected == RUV2ExecutorCounter(tc.level, tc.label), tc.label)
+	}
+}
+
 func TestStmtSummaryMetricLabels(t *testing.T) {
 	InitStmtSummaryMetrics()
 	require.Equal(t, 0, countCollectedMetrics(StmtSummaryWindowRecordCount))

--- a/pkg/metrics/ru_v2.go
+++ b/pkg/metrics/ru_v2.go
@@ -30,6 +30,8 @@ var (
 	RUV2PlanDeriveStatsPaths    prometheus.Counter
 	RUV2ResourceManagerReadCnt  prometheus.Counter
 	RUV2ResourceManagerWriteCnt prometheus.Counter
+	RUV2WriteKeys               prometheus.Counter
+	RUV2WriteSize               prometheus.Counter
 	RUV2SessionParserTotal      prometheus.Counter
 	RUV2TxnCnt                  prometheus.Counter
 
@@ -47,17 +49,26 @@ var (
 	ruv2ExecutorL1PointGetExecutor  prometheus.Counter
 	ruv2ExecutorL1LimitExec         prometheus.Counter
 
-	ruv2ExecutorL2HashAggExec        prometheus.Counter
-	ruv2ExecutorL2HashJoinExec       prometheus.Counter
-	ruv2ExecutorL2IndexLookUpJoin    prometheus.Counter
-	ruv2ExecutorL2IndexLookUpExec    prometheus.Counter
-	ruv2ExecutorL2IndexReaderExec    prometheus.Counter
-	ruv2ExecutorL2MemTableReaderExec prometheus.Counter
-	ruv2ExecutorL2SelectionExec      prometheus.Counter
-	ruv2ExecutorL2TableDualExec      prometheus.Counter
-	ruv2ExecutorL2TableReaderExec    prometheus.Counter
-	ruv2ExecutorL2UnionScanExec      prometheus.Counter
-	ruv2ExecutorL2SelectLockExec     prometheus.Counter
+	ruv2ExecutorL2ExpandExec              prometheus.Counter
+	ruv2ExecutorL2HashAggExec             prometheus.Counter
+	ruv2ExecutorL2HashJoinExec            prometheus.Counter
+	ruv2ExecutorL2HashJoinV1Exec          prometheus.Counter
+	ruv2ExecutorL2HashJoinV2Exec          prometheus.Counter
+	ruv2ExecutorL2IndexLookUpJoin         prometheus.Counter
+	ruv2ExecutorL2IndexLookUpMergeJoin    prometheus.Counter
+	ruv2ExecutorL2IndexNestedLoopHashJoin prometheus.Counter
+	ruv2ExecutorL2IndexLookUpExec         prometheus.Counter
+	ruv2ExecutorL2IndexReaderExec         prometheus.Counter
+	ruv2ExecutorL2MemTableReaderExec      prometheus.Counter
+	ruv2ExecutorL2MergeJoinExec           prometheus.Counter
+	ruv2ExecutorL2ProjectionExec          prometheus.Counter
+	ruv2ExecutorL2SelectionExec           prometheus.Counter
+	ruv2ExecutorL2TableDualExec           prometheus.Counter
+	ruv2ExecutorL2TableReaderExec         prometheus.Counter
+	ruv2ExecutorL2TopNExec                prometheus.Counter
+	ruv2ExecutorL2UnionScanExec           prometheus.Counter
+	ruv2ExecutorL2SelectLockExec          prometheus.Counter
+	ruv2ExecutorL2WindowExec              prometheus.Counter
 
 	ruv2ExecutorL3SortExec      prometheus.Counter
 	ruv2ExecutorL3StreamAggExec prometheus.Counter
@@ -154,6 +165,24 @@ func InitRUV2Metrics() {
 		},
 	)
 
+	RUV2WriteKeys = metricscommon.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "ruv2",
+			Name:      "write_keys",
+			Help:      "Counter of commit write keys for RU v2.",
+		},
+	)
+
+	RUV2WriteSize = metricscommon.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "ruv2",
+			Name:      "write_size",
+			Help:      "Shadow counter of commit write size for RU v2.",
+		},
+	)
+
 	RUV2SessionParserTotal = metricscommon.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "tidb",
@@ -243,17 +272,26 @@ func initRUV2CachedLabelCounters() {
 	ruv2ExecutorL1PointGetExecutor = RUV2ExecutorL1.WithLabelValues("PointGetExecutor")
 	ruv2ExecutorL1LimitExec = RUV2ExecutorL1.WithLabelValues("LimitExec")
 
+	ruv2ExecutorL2ExpandExec = RUV2ExecutorL2.WithLabelValues("ExpandExec")
 	ruv2ExecutorL2HashAggExec = RUV2ExecutorL2.WithLabelValues("HashAggExec")
 	ruv2ExecutorL2HashJoinExec = RUV2ExecutorL2.WithLabelValues("HashJoinExec")
+	ruv2ExecutorL2HashJoinV1Exec = RUV2ExecutorL2.WithLabelValues("HashJoinV1Exec")
+	ruv2ExecutorL2HashJoinV2Exec = RUV2ExecutorL2.WithLabelValues("HashJoinV2Exec")
 	ruv2ExecutorL2IndexLookUpJoin = RUV2ExecutorL2.WithLabelValues("IndexLookUpJoin")
+	ruv2ExecutorL2IndexLookUpMergeJoin = RUV2ExecutorL2.WithLabelValues("IndexLookUpMergeJoin")
+	ruv2ExecutorL2IndexNestedLoopHashJoin = RUV2ExecutorL2.WithLabelValues("IndexNestedLoopHashJoin")
 	ruv2ExecutorL2IndexLookUpExec = RUV2ExecutorL2.WithLabelValues("IndexLookUpExecutor")
 	ruv2ExecutorL2IndexReaderExec = RUV2ExecutorL2.WithLabelValues("IndexReaderExecutor")
 	ruv2ExecutorL2MemTableReaderExec = RUV2ExecutorL2.WithLabelValues("MemTableReaderExec")
+	ruv2ExecutorL2MergeJoinExec = RUV2ExecutorL2.WithLabelValues("MergeJoinExec")
+	ruv2ExecutorL2ProjectionExec = RUV2ExecutorL2.WithLabelValues("ProjectionExec")
 	ruv2ExecutorL2SelectionExec = RUV2ExecutorL2.WithLabelValues("SelectionExec")
 	ruv2ExecutorL2TableDualExec = RUV2ExecutorL2.WithLabelValues("TableDualExec")
 	ruv2ExecutorL2TableReaderExec = RUV2ExecutorL2.WithLabelValues("TableReaderExecutor")
+	ruv2ExecutorL2TopNExec = RUV2ExecutorL2.WithLabelValues("TopNExec")
 	ruv2ExecutorL2UnionScanExec = RUV2ExecutorL2.WithLabelValues("UnionScanExec")
 	ruv2ExecutorL2SelectLockExec = RUV2ExecutorL2.WithLabelValues("SelectLockExec")
+	ruv2ExecutorL2WindowExec = RUV2ExecutorL2.WithLabelValues("WindowExec")
 
 	ruv2ExecutorL3SortExec = RUV2ExecutorL3.WithLabelValues("SortExec")
 	ruv2ExecutorL3StreamAggExec = RUV2ExecutorL3.WithLabelValues("StreamAggExec")
@@ -283,28 +321,46 @@ func RUV2ExecutorCounter(level int, label string) prometheus.Counter {
 		}
 	case 2:
 		switch label {
+		case "ExpandExec":
+			return ruv2ExecutorL2ExpandExec
 		case "HashAggExec":
 			return ruv2ExecutorL2HashAggExec
 		case "HashJoinExec":
 			return ruv2ExecutorL2HashJoinExec
+		case "HashJoinV1Exec":
+			return ruv2ExecutorL2HashJoinV1Exec
+		case "HashJoinV2Exec":
+			return ruv2ExecutorL2HashJoinV2Exec
 		case "IndexLookUpJoin":
 			return ruv2ExecutorL2IndexLookUpJoin
+		case "IndexLookUpMergeJoin":
+			return ruv2ExecutorL2IndexLookUpMergeJoin
+		case "IndexNestedLoopHashJoin":
+			return ruv2ExecutorL2IndexNestedLoopHashJoin
 		case "IndexLookUpExecutor":
 			return ruv2ExecutorL2IndexLookUpExec
 		case "IndexReaderExecutor":
 			return ruv2ExecutorL2IndexReaderExec
 		case "MemTableReaderExec":
 			return ruv2ExecutorL2MemTableReaderExec
+		case "MergeJoinExec":
+			return ruv2ExecutorL2MergeJoinExec
+		case "ProjectionExec":
+			return ruv2ExecutorL2ProjectionExec
 		case "SelectionExec":
 			return ruv2ExecutorL2SelectionExec
 		case "TableDualExec":
 			return ruv2ExecutorL2TableDualExec
 		case "TableReaderExecutor":
 			return ruv2ExecutorL2TableReaderExec
+		case "TopNExec":
+			return ruv2ExecutorL2TopNExec
 		case "UnionScanExec":
 			return ruv2ExecutorL2UnionScanExec
 		case "SelectLockExec":
 			return ruv2ExecutorL2SelectLockExec
+		case "WindowExec":
+			return ruv2ExecutorL2WindowExec
 		default:
 			return RUV2ExecutorL2.WithLabelValues(label)
 		}

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -482,12 +482,6 @@ type StatementContext struct {
 	// IsExplainAnalyzeDML is true if the statement is "explain analyze DML executors", before responding the explain
 	// results to the client, the transaction should be committed first. See issue #37373 for more details.
 	IsExplainAnalyzeDML bool
-	// InsertRowsAsRUV2Recorded tracks whether the statement-level insert-row RUv2 cost has already been
-	// applied to RUV2Metrics. This must stay idempotent because EXPLAIN ANALYZE INSERT snapshots RU before
-	// FinishExecuteStmt runs, while FinishExecuteStmt still needs to reuse the same accounting path for the
-	// final slow-log and resource-group reporting.
-	InsertRowsAsRUV2Recorded bool
-
 	// InHandleForeignKeyTrigger indicates currently are handling foreign key trigger.
 	InHandleForeignKeyTrigger bool
 

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -283,6 +283,7 @@ func ruv2WeightsFromConfig(cfg config.RUV2Config) execdetails.RUV2Weights {
 		PlanDeriveStatsPaths:    cfg.PlanDeriveStatsPaths,
 		ResourceManagerReadCnt:  cfg.ResourceManagerReadCnt,
 		ResourceManagerWriteCnt: cfg.ResourceManagerWriteCnt,
+		WriteKeys:               cfg.WriteKeys,
 		SessionParserTotal:      cfg.SessionParserTotal,
 		TxnCnt:                  cfg.TxnCnt,
 	}

--- a/pkg/sessionctx/variable/tests/session_test.go
+++ b/pkg/sessionctx/variable/tests/session_test.go
@@ -481,6 +481,7 @@ func TestSlowLogFormatIncludesTiFlashRUInRUV2Metrics(t *testing.T) {
 			PlanDeriveStatsPaths:    cfg.RUV2.PlanDeriveStatsPaths,
 			ResourceManagerReadCnt:  cfg.RUV2.ResourceManagerReadCnt,
 			ResourceManagerWriteCnt: cfg.RUV2.ResourceManagerWriteCnt,
+			WriteKeys:               cfg.RUV2.WriteKeys,
 			SessionParserTotal:      cfg.RUV2.SessionParserTotal,
 			TxnCnt:                  cfg.RUV2.TxnCnt,
 		}, variable.NewSessionVars(nil).RUV2Weights())

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -45,6 +45,7 @@ func defaultRUV2WeightsForTest() RUV2Weights {
 		PlanDeriveStatsPaths:    cfg.PlanDeriveStatsPaths,
 		ResourceManagerReadCnt:  cfg.ResourceManagerReadCnt,
 		ResourceManagerWriteCnt: cfg.ResourceManagerWriteCnt,
+		WriteKeys:               cfg.WriteKeys,
 		SessionParserTotal:      cfg.SessionParserTotal,
 		TxnCnt:                  cfg.TxnCnt,
 	}
@@ -382,6 +383,8 @@ func TestRUV2MetricsSnapshotCalculateRUValues(t *testing.T) {
 	metrics.AddPlanDeriveStatsPaths(23)
 	metrics.AddResourceManagerReadCnt(29)
 	metrics.AddResourceManagerWriteCnt(31)
+	metrics.AddWriteKeys(3)
+	metrics.AddWriteSize(66)
 	metrics.AddSessionParserTotal(37)
 	metrics.AddTxnCnt(41)
 	metrics.AddTiKVKVEngineCacheMiss(43)
@@ -397,10 +400,12 @@ func TestRUV2MetricsSnapshotCalculateRUValues(t *testing.T) {
 	tikvRU := float64(157258)
 	tiflashRU := float64(24680)
 	totalRU := metrics.TotalRU(weights, tikvRU, tiflashRU)
-	require.InEpsilon(t, 40.2906903357, tidbRU, 0.01)
+	require.InEpsilon(t, 42.2851783309, tidbRU, 0.01)
 	require.InEpsilon(t, 157258.0, tikvRU, 0.01)
 	require.InEpsilon(t, 24680.0, tiflashRU, 0.01)
-	require.InEpsilon(t, 181978.2906903357, totalRU, 0.01)
+	require.InEpsilon(t, 181980.2851783309, totalRU, 0.01)
+	require.Equal(t, int64(3), metrics.WriteKeys())
+	require.Equal(t, int64(66), metrics.WriteSize())
 
 	t.Run("zero scale stays zero", func(t *testing.T) {
 		zeroScaleWeights := weights
@@ -435,6 +440,34 @@ func TestRUV2MetricsSnapshotCalculateRUValues(t *testing.T) {
 		})
 		require.LessOrEqual(t, allocs, 1.0)
 	})
+}
+
+func TestUpdateRUV2MetricsFromCommitDetails(t *testing.T) {
+	metrics := NewRUV2Metrics()
+	weights := defaultRUV2WeightsForTest()
+	beforeRU := metrics.CalculateRUValues(weights)
+
+	UpdateRUV2MetricsFromCommitDetails(metrics, &util.CommitDetails{
+		WriteKeys: 3,
+		WriteSize: 66,
+	})
+
+	require.Equal(t, int64(3), metrics.WriteKeys())
+	require.Equal(t, int64(66), metrics.WriteSize())
+	require.InEpsilon(t, beforeRU+float64(3)*weights.WriteKeys*weights.RUScale, metrics.CalculateRUValues(weights), 0.01)
+
+	detail := FormatRUV2Metrics(metrics, weights, 0, 0)
+	require.Contains(t, detail, "write_keys:3")
+	require.Contains(t, detail, "write_size:66")
+
+	bypassed := NewRUV2Metrics()
+	bypassed.SetBypass(true)
+	UpdateRUV2MetricsFromCommitDetails(bypassed, &util.CommitDetails{
+		WriteKeys: 1,
+		WriteSize: 2,
+	})
+	require.Zero(t, bypassed.WriteKeys())
+	require.Zero(t, bypassed.WriteSize())
 }
 
 func TestRUV2MetricsSnapshotFreezesRUValues(t *testing.T) {

--- a/pkg/util/execdetails/ruv2_metrics.go
+++ b/pkg/util/execdetails/ruv2_metrics.go
@@ -45,6 +45,7 @@ type RUV2Weights struct {
 	PlanDeriveStatsPaths    float64
 	ResourceManagerReadCnt  float64
 	ResourceManagerWriteCnt float64
+	WriteKeys               float64
 	SessionParserTotal      float64
 	TxnCnt                  float64
 }
@@ -148,6 +149,19 @@ func SyncRUV2MetricsFromRUDetails(metrics *RUV2Metrics, ruDetails *tikvutil.RUDe
 	UpdateRUV2MetricsFromRUV2(metrics, ruDetails.DrainRUV2())
 }
 
+// UpdateRUV2MetricsFromCommitDetails adds commit write counters into RUv2 metrics.
+func UpdateRUV2MetricsFromCommitDetails(metrics *RUV2Metrics, commitDetails *tikvutil.CommitDetails) {
+	if metrics == nil || commitDetails == nil || metrics.Bypass() {
+		return
+	}
+	if commitDetails.WriteKeys != 0 {
+		metrics.AddWriteKeys(int64(commitDetails.WriteKeys))
+	}
+	if commitDetails.WriteSize != 0 {
+		metrics.AddWriteSize(int64(commitDetails.WriteSize))
+	}
+}
+
 // RUV2Metrics stores statement-level RUv2 metrics.
 type RUV2Metrics struct {
 	bypass atomic.Bool
@@ -177,6 +191,8 @@ type ruv2MetricsExtra struct {
 	planDeriveStatsPaths int64
 
 	resourceManagerWriteCnt int64
+	writeKeys               int64
+	writeSize               int64
 
 	tikvCoprocessorExecutorIterations int64
 	tikvCoprocessorResponseBytes      int64
@@ -303,7 +319,7 @@ func execL1KindForLabel(label string) execL1Kind {
 	}
 }
 
-// AddExecutorL5InsertRows records affected insert rows for RUv2 accounting.
+// AddExecutorL5InsertRows records insert rows multiplied by inserted column count for RUv2 accounting.
 func (m *RUV2Metrics) AddExecutorL5InsertRows(delta int64) {
 	if m.Bypass() {
 		return
@@ -364,6 +380,24 @@ func (m *RUV2Metrics) AddResourceManagerWriteCnt(delta int64) {
 	}
 	metrics.RUV2ResourceManagerWriteCnt.Add(float64(delta))
 	atomic.AddInt64(&m.ensureExtra().resourceManagerWriteCnt, delta)
+}
+
+// AddWriteKeys records commit write keys for RUv2 accounting.
+func (m *RUV2Metrics) AddWriteKeys(delta int64) {
+	if m.Bypass() {
+		return
+	}
+	metrics.RUV2WriteKeys.Add(float64(delta))
+	atomic.AddInt64(&m.ensureExtra().writeKeys, delta)
+}
+
+// AddWriteSize records commit write size for RUv2 shadow accounting.
+func (m *RUV2Metrics) AddWriteSize(delta int64) {
+	if m.Bypass() {
+		return
+	}
+	metrics.RUV2WriteSize.Add(float64(delta))
+	atomic.AddInt64(&m.ensureExtra().writeSize, delta)
 }
 
 // AddTiKVKVEngineCacheMiss records TiKV kv_engine_cache_miss counters from ExecDetailsV2.
@@ -644,6 +678,8 @@ func cloneRUV2MetricsExtra(dst, src *ruv2MetricsExtra) {
 	addRUV2FixedCounter(&dst.executorL5InsertRows, atomic.LoadInt64(&src.executorL5InsertRows))
 	addRUV2FixedCounter(&dst.planDeriveStatsPaths, atomic.LoadInt64(&src.planDeriveStatsPaths))
 	addRUV2FixedCounter(&dst.resourceManagerWriteCnt, atomic.LoadInt64(&src.resourceManagerWriteCnt))
+	addRUV2FixedCounter(&dst.writeKeys, atomic.LoadInt64(&src.writeKeys))
+	addRUV2FixedCounter(&dst.writeSize, atomic.LoadInt64(&src.writeSize))
 	addRUV2FixedCounter(&dst.tikvCoprocessorExecutorIterations, atomic.LoadInt64(&src.tikvCoprocessorExecutorIterations))
 	addRUV2FixedCounter(&dst.tikvCoprocessorResponseBytes, atomic.LoadInt64(&src.tikvCoprocessorResponseBytes))
 	addRUV2FixedCounter(&dst.tikvRaftstoreStoreWriteTriggerWB, atomic.LoadInt64(&src.tikvRaftstoreStoreWriteTriggerWB))
@@ -680,7 +716,7 @@ func (m *RUV2Metrics) ResultChunkCells() int64 {
 	return atomic.LoadInt64(&m.resultChunkCells)
 }
 
-// ExecutorL5InsertRows returns affected insert rows for RUv2 accounting.
+// ExecutorL5InsertRows returns insert rows multiplied by inserted column count for RUv2 accounting.
 func (m *RUV2Metrics) ExecutorL5InsertRows() int64 {
 	extra := m.loadExtra()
 	if extra == nil {
@@ -737,6 +773,24 @@ func (m *RUV2Metrics) ResourceManagerWriteCnt() int64 {
 		return 0
 	}
 	return atomic.LoadInt64(&extra.resourceManagerWriteCnt)
+}
+
+// WriteKeys returns commit write keys for RUv2 accounting.
+func (m *RUV2Metrics) WriteKeys() int64 {
+	extra := m.loadExtra()
+	if extra == nil {
+		return 0
+	}
+	return atomic.LoadInt64(&extra.writeKeys)
+}
+
+// WriteSize returns commit write size for RUv2 shadow accounting.
+func (m *RUV2Metrics) WriteSize() int64 {
+	extra := m.loadExtra()
+	if extra == nil {
+		return 0
+	}
+	return atomic.LoadInt64(&extra.writeSize)
 }
 
 // TiKVKVEngineCacheMiss returns TiKV kv_engine_cache_miss counters from ExecDetailsV2.
@@ -813,6 +867,8 @@ func (m *RUV2Metrics) IsZero() bool {
 			m.ExecutorL5InsertRows() == 0 &&
 			m.PlanDeriveStatsPaths() == 0 &&
 			m.ResourceManagerWriteCnt() == 0 &&
+			m.WriteKeys() == 0 &&
+			m.WriteSize() == 0 &&
 			m.TiKVCoprocessorExecutorIterations() == 0 &&
 			m.TiKVCoprocessorResponseBytes() == 0 &&
 			m.TiKVRaftstoreStoreWriteTriggerWB() == 0 &&
@@ -847,6 +903,7 @@ func (m *RUV2Metrics) calculateRUValuesWithWeights(weights RUV2Weights) (tidbRU 
 		executorL5InsertRows    int64
 		planDeriveStatsPaths    int64
 		resourceManagerWriteCnt int64
+		writeKeys               int64
 	)
 	if extra := m.loadExtra(); extra != nil {
 		executorL2 = sumRUV2ExtraLabelCounter(&extra.executorL2)
@@ -854,6 +911,7 @@ func (m *RUV2Metrics) calculateRUValuesWithWeights(weights RUV2Weights) (tidbRU 
 		executorL5InsertRows = atomic.LoadInt64(&extra.executorL5InsertRows)
 		planDeriveStatsPaths = atomic.LoadInt64(&extra.planDeriveStatsPaths)
 		resourceManagerWriteCnt = atomic.LoadInt64(&extra.resourceManagerWriteCnt)
+		writeKeys = atomic.LoadInt64(&extra.writeKeys)
 	}
 	tidbRUFloat :=
 		float64(m.ResultChunkCells())*weights.ResultChunkCells +
@@ -865,6 +923,7 @@ func (m *RUV2Metrics) calculateRUValuesWithWeights(weights RUV2Weights) (tidbRU 
 			float64(planDeriveStatsPaths)*weights.PlanDeriveStatsPaths +
 			float64(m.ResourceManagerReadCnt())*weights.ResourceManagerReadCnt +
 			float64(resourceManagerWriteCnt)*weights.ResourceManagerWriteCnt +
+			float64(writeKeys)*weights.WriteKeys +
 			float64(m.SessionParserTotal())*weights.SessionParserTotal +
 			float64(m.TxnCnt())*weights.TxnCnt
 
@@ -888,6 +947,8 @@ func FormatRUV2Summary(metrics *RUV2Metrics, weights RUV2Weights, tiKVRU, tiFlas
 		txnCnt                            int64
 		resourceManagerReadCnt            int64
 		resourceManagerWriteCnt           int64
+		writeKeys                         int64
+		writeSize                         int64
 		tiKVKVEngineCacheMiss             int64
 		tiKVCoprocessorExecutorIterations int64
 		tiKVCoprocessorResponseBytes      int64
@@ -906,6 +967,8 @@ func FormatRUV2Summary(metrics *RUV2Metrics, weights RUV2Weights, tiKVRU, tiFlas
 			executorL5InsertRows = atomic.LoadInt64(&extra.executorL5InsertRows)
 			planDeriveStatsPaths = atomic.LoadInt64(&extra.planDeriveStatsPaths)
 			resourceManagerWriteCnt = atomic.LoadInt64(&extra.resourceManagerWriteCnt)
+			writeKeys = atomic.LoadInt64(&extra.writeKeys)
+			writeSize = atomic.LoadInt64(&extra.writeSize)
 			tiKVCoprocessorExecutorIterations = atomic.LoadInt64(&extra.tikvCoprocessorExecutorIterations)
 			tiKVCoprocessorResponseBytes = atomic.LoadInt64(&extra.tikvCoprocessorResponseBytes)
 			tiKVRaftstoreStoreWriteTriggerWB = atomic.LoadInt64(&extra.tikvRaftstoreStoreWriteTriggerWB)
@@ -931,6 +994,8 @@ func FormatRUV2Summary(metrics *RUV2Metrics, weights RUV2Weights, tiKVRU, tiFlas
 		txnCnt == 0 &&
 		resourceManagerReadCnt == 0 &&
 		resourceManagerWriteCnt == 0 &&
+		writeKeys == 0 &&
+		writeSize == 0 &&
 		tiKVKVEngineCacheMiss == 0 &&
 		tiKVCoprocessorExecutorIterations == 0 &&
 		tiKVCoprocessorResponseBytes == 0 &&
@@ -979,6 +1044,8 @@ func FormatRUV2Summary(metrics *RUV2Metrics, weights RUV2Weights, tiKVRU, tiFlas
 	appendInt("txn_cnt", txnCnt)
 	appendInt("resource_manager_read_cnt", resourceManagerReadCnt)
 	appendInt("resource_manager_write_cnt", resourceManagerWriteCnt)
+	appendInt("write_keys", writeKeys)
+	appendInt("write_size", writeSize)
 	appendInt("tikv_kv_engine_cache_miss", tiKVKVEngineCacheMiss)
 	appendInt("tikv_coprocessor_executor_iterations", tiKVCoprocessorExecutorIterations)
 	appendInt("tikv_coprocessor_response_bytes", tiKVCoprocessorResponseBytes)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #68576

Problem Summary:

Cherry-pick #68578 to release-nextgen-202603.

### What changed and how does it work?

This cherry-picks merged commit 36ffa17e8876f442917bb27682e4d690a769e617 from master.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix RU v2 executor accounting for several executor types and DML row-column cost.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `write-keys` configuration parameter for RU v2 weight settings.
  * RU v2 metrics now track write keys and write size from transaction commits.

* **Improvements**
  * Enhanced RU v2 metric calculation for DML operations (INSERT, UPDATE, DELETE) using row-column multipliers.
  * Extended RU v2 executor type coverage for more accurate metric reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->