### PR TITLE
dxf: expose coprocessor worker required count in schedule status

### DIFF
--- a/pkg/dxf/framework/handle/status.go
+++ b/pkg/dxf/framework/handle/status.go
@@ -71,7 +71,10 @@ func GetScheduleStatus(ctx context.Context) (*schstatus.Status, error) {
 			// currently, we expect same mount of TiKV worker as TiDB worker.
 			RequiredCount: requiredNodes,
 		},
-		Flags: flags,
+		// CoprocessorWorker is a placeholder for now: it always reports 0 until the
+		// control plane starts consuming it and per-task-type sizing is added.
+		CoprocessorWorker: schstatus.NodeGroup{},
+		Flags:             flags,
 	}
 	return status, nil
 }

--- a/pkg/dxf/framework/schstatus/status.go
+++ b/pkg/dxf/framework/schstatus/status.go
@@ -46,7 +46,8 @@ type Node struct {
 	IsOwner bool `json:"is_owner,omitempty"`
 }
 
-// NodeGroup represents the resource status of TiDB or TiKV worker node group.
+// NodeGroup represents the resource status of a worker node group (TiDB, TiKV,
+// or coprocessor worker).
 type NodeGroup struct {
 	// CPUCount is the number of CPUs available for the node.
 	CPUCount int `json:"cpu_count,omitempty"`
@@ -95,6 +96,11 @@ type Status struct {
 	TaskQueue  TaskQueue `json:"task_queue,omitempty"`
 	TiDBWorker NodeGroup `json:"tidb_worker,omitempty"`
 	TiKVWorker NodeGroup `json:"tikv_worker,omitempty"`
+	// CoprocessorWorker reports the coprocessor worker requirement, used by tasks
+	// that scale coprocessor workers (together with TiDB workers) independently of
+	// TiKV workers. It is a placeholder for now and reports 0 until the control
+	// plane consumes it and per-task-type sizing lands.
+	CoprocessorWorker NodeGroup `json:"coprocessor_worker,omitempty"`
 	// Flags is a map of flags, we only have one type of flag right now.
 	// PauseScaleInFlag is the flag to notify the cluster controller to pause the
 	// scale-in action of the workers. as the schedule and scale-in/out operations


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68984

Problem Summary:

The DXF schedule status (`GET /dxf/schedule/status`) currently exposes a single required-node number, surfaced into both `tidb_worker` and `tikv_worker` (the control plane scales tidb-worker and tikv-worker together off it). Some tasks — e.g. the upcoming distributed `EXPORT TABLE` (#68984), which reads via the coprocessor — need to scale **coprocessor-worker + tidb-worker** but **not tikv-worker**. To support that without a flag-day change, we first need a separate field for the coprocessor-worker requirement.

### What changed and how does it work?

Add a `CoprocessorWorker NodeGroup` to `schstatus.Status` (JSON `coprocessor_worker`), and populate it in `handle.GetScheduleStatus`.

This is the first, non-breaking step of a gradual migration:

- For now `coprocessor_worker` is a **placeholder reporting `0`**.
- The existing `tidb_worker` / `tikv_worker` fields and their values are **unchanged**, so current control-plane behavior is unaffected.
- Once the control plane consumes the new field and per-task-type sizing is added (export needs coprocessor workers; IMPORT INTO / ADD INDEX need tikv workers), the real value will be filled in and the old field semantics adjusted — in follow-up PRs.

No behavior change today beyond an additional always-zero field in the status JSON.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > Additive placeholder field that always reports 0; no logic to exercise yet. A meaningful test will accompany the follow-up PR that computes the real per-task-type value.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Improvements**
  * Added framework support for coprocessor worker status monitoring alongside existing TiDB and TiKV worker tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->