### PR TITLE
planner: exclude stats version from plan cache key for simple plans

### DIFF
--- a/pkg/planner/core/casetest/plancache/BUILD.bazel
+++ b/pkg/planner/core/casetest/plancache/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "//pkg/planner/core:plan_clone_utils.go",
     ],
     flaky = True,
-    shard_count = 46,
+    shard_count = 47,
     deps = [
         "//pkg/expression",
         "//pkg/infoschema",

--- a/pkg/planner/core/casetest/plancache/BUILD.bazel
+++ b/pkg/planner/core/casetest/plancache/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "//pkg/planner/core:plan_clone_utils.go",
     ],
     flaky = True,
-    shard_count = 47,
+    shard_count = 48,
     deps = [
         "//pkg/expression",
         "//pkg/infoschema",
@@ -38,6 +38,7 @@ go_test(
         "//pkg/sessionctx",
         "//pkg/sessionctx/variable",
         "//pkg/sessiontxn",
+        "//pkg/statistics/asyncload",
         "//pkg/testkit",
         "//pkg/testkit/testdata",
         "//pkg/testkit/testmain",

--- a/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
@@ -2147,3 +2147,75 @@ func TestPlanCacheSkipStatsOnBinding(t *testing.T) {
 
 	tk.MustExec(`drop binding for select * from t where b=1`)
 }
+
+// TestPlanCacheStatsIndependentPlansSurviveAnalyze verifies that plans whose shape can
+// never be affected by statistics (PointGet, BatchPointGet, INSERT ... VALUES) exclude
+// the stats version from their plan cache key, so ANALYZE does not invalidate their
+// cached entries. Stats-dependent plans must still be invalidated, and a schema change
+// must reset the classification so invalidation resumes if the plan shape changes.
+func TestPlanCacheStatsIndependentPlansSurviveAnalyze(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`create table t (a int primary key, b int, unique key idx_b(b))`)
+	tk.MustExec(`insert into t values (1,1),(2,2),(3,3)`)
+	tk.MustExec(`set @@tidb_plan_cache_invalidation_on_fresh_stats = ON`)
+
+	// -- PointGet on the primary key: ANALYZE must NOT bust the cache. --
+	tk.MustExec(`prepare st_point from 'select * from t where a = ?'`)
+	tk.MustExec(`set @v1=1, @v2=2`)
+	tk.MustQuery(`execute st_point using @v1`).Check(testkit.Rows("1 1"))
+	tk.MustQuery(`execute st_point using @v1`).Check(testkit.Rows("1 1"))
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	tk.MustExec(`analyze table t`)
+	tk.MustQuery(`execute st_point using @v1`).Check(testkit.Rows("1 1"))
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+	// -- BatchPointGet: ANALYZE must NOT bust the cache. --
+	tk.MustExec(`prepare st_batch from 'select * from t where a in (?, ?)'`)
+	tk.MustQuery(`execute st_batch using @v1, @v2`).Sort().Check(testkit.Rows("1 1", "2 2"))
+	tk.MustQuery(`execute st_batch using @v1, @v2`).Sort().Check(testkit.Rows("1 1", "2 2"))
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	tk.MustExec(`analyze table t`)
+	tk.MustQuery(`execute st_batch using @v1, @v2`).Sort().Check(testkit.Rows("1 1", "2 2"))
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+	// -- INSERT ... VALUES: ANALYZE must NOT bust the cache. --
+	tk.MustExec(`prepare st_insert from 'insert into t values (?, ?)'`)
+	tk.MustExec(`set @i1=101, @i2=102, @i3=103`)
+	tk.MustExec(`execute st_insert using @i1, @i1`)
+	tk.MustExec(`execute st_insert using @i2, @i2`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	tk.MustExec(`analyze table t`)
+	tk.MustExec(`execute st_insert using @i3, @i3`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+	// -- Control: a stats-dependent range query must still be invalidated by ANALYZE. --
+	tk.MustExec(`prepare st_range from 'select * from t where b >= ?'`)
+	tk.MustExec(`set @r=100`)
+	tk.MustQuery(`execute st_range using @r`).Sort().Check(testkit.Rows("101 101", "102 102", "103 103"))
+	tk.MustQuery(`execute st_range using @r`).Sort().Check(testkit.Rows("101 101", "102 102", "103 103"))
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	tk.MustExec(`analyze table t`)
+	tk.MustQuery(`execute st_range using @r`).Sort().Check(testkit.Rows("101 101", "102 102", "103 103"))
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+
+	// -- Schema change resets the classification: a point get on a unique key that is
+	// later dropped becomes a stats-dependent scan, and ANALYZE must invalidate again. --
+	tk.MustExec(`prepare st_upoint from 'select * from t where b = ?'`)
+	tk.MustQuery(`execute st_upoint using @v1`).Check(testkit.Rows("1 1"))
+	tk.MustQuery(`execute st_upoint using @v1`).Check(testkit.Rows("1 1"))
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	tk.MustExec(`analyze table t`)
+	tk.MustQuery(`execute st_upoint using @v1`).Check(testkit.Rows("1 1"))
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1")) // survives while it is a point get
+	tk.MustExec(`alter table t drop index idx_b`)
+	tk.MustQuery(`execute st_upoint using @v1`).Check(testkit.Rows("1 1")) // schema changed → replan as a scan
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+	tk.MustQuery(`execute st_upoint using @v1`).Check(testkit.Rows("1 1"))
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	tk.MustExec(`analyze table t`)
+	tk.MustQuery(`execute st_upoint using @v1`).Check(testkit.Rows("1 1"))
+	// The plan is stats-dependent again, so ANALYZE busts the cache.
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+}

--- a/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
@@ -2245,6 +2245,7 @@ func TestPlanCacheStatsIndependentSkipsStatsLoad(t *testing.T) {
 	// (the path that triggers stats loading), flush the cache to force that replan, and
 	// drain any async-load items registered for this table so far.
 	tk.MustExec(`set @@tidb_opt_fix_control = "52592:ON"`)
+	defer tk.MustExec(`set @@tidb_opt_fix_control = ""`)
 	tk.MustExec(`admin flush session plan_cache`)
 	for _, item := range asyncload.AsyncLoadHistogramNeededItems.AllItems() {
 		if fmt.Sprintf("%d", item.TableID) == tblID {

--- a/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/session/sessmgr"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/statistics/asyncload"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
 	"github.com/pingcap/tidb/pkg/types"
@@ -2217,5 +2218,53 @@ func TestPlanCacheStatsIndependentPlansSurviveAnalyze(t *testing.T) {
 	tk.MustExec(`analyze table t`)
 	tk.MustQuery(`execute st_upoint using @v1`).Check(testkit.Rows("1 1"))
 	// The plan is stats-dependent again, so ANALYZE busts the cache.
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+}
+
+// TestPlanCacheStatsIndependentSkipsStatsLoad verifies that replanning a statement whose
+// plan is known to be stats-independent does not trigger synchronous or asynchronous
+// statistics loading, and that the classification is re-derived in both directions when
+// a planning input outside the cache key (here fix control 52592, which disables the
+// point-get fast path) changes the plan shape to a stats-dependent one.
+func TestPlanCacheStatsIndependentSkipsStatsLoad(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`create table tsl (a int primary key, b int)`)
+	tk.MustExec(`insert into tsl values (1,1),(2,2),(3,3)`)
+	tblID := tk.MustQuery(`select tidb_table_id from information_schema.tables where table_schema='test' and table_name='tsl'`).Rows()[0][0].(string)
+
+	tk.MustExec(`prepare st from 'select * from tsl where a = ?'`)
+	tk.MustExec(`set @v=1`)
+	// First execution: point get via the fast path, classified stats-independent when
+	// stored. The classification is not known during its own optimization, so no skip yet.
+	tk.MustQuery(`execute st using @v`).Check(testkit.Rows("1 1"))
+	require.False(t, tk.Session().GetSessionVars().StmtCtx.SkipStatsLoad)
+
+	// Disable the point-get fast path so the next replan goes through the full optimizer
+	// (the path that triggers stats loading), flush the cache to force that replan, and
+	// drain any async-load items registered for this table so far.
+	tk.MustExec(`set @@tidb_opt_fix_control = "52592:ON"`)
+	tk.MustExec(`admin flush session plan_cache`)
+	for _, item := range asyncload.AsyncLoadHistogramNeededItems.AllItems() {
+		if fmt.Sprintf("%d", item.TableID) == tblID {
+			asyncload.AsyncLoadHistogramNeededItems.Delete(item.TableItemID)
+		}
+	}
+	tk.MustQuery(`execute st using @v`).Check(testkit.Rows("1 1"))
+	// The replan ran under the stats-independent classification: the full optimizer must
+	// skip stats loading entirely and register no async-load items for this table.
+	require.True(t, tk.Session().GetSessionVars().StmtCtx.SkipStatsLoad)
+	for _, item := range asyncload.AsyncLoadHistogramNeededItems.AllItems() {
+		require.NotEqual(t, tblID, fmt.Sprintf("%d", item.TableID))
+	}
+
+	// With the fast path disabled, the full optimizer produced a stats-dependent plan (a
+	// range scan), so the classification must have flipped back when it was stored: the
+	// entry is reachable under the stats-inclusive key and ANALYZE invalidates it again.
+	tk.MustQuery(`execute st using @v`).Check(testkit.Rows("1 1"))
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	tk.MustExec(`analyze table tsl`)
+	tk.MustQuery(`execute st using @v`).Check(testkit.Rows("1 1"))
 	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
 }

--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -389,6 +389,12 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 
 	core_metrics.GetPlanCacheMissCounter(isNonPrepared).Inc()
 	nodeW := resolve.NewNodeWWithCtx(stmtAst.Stmt, stmt.ResolveCtx)
+	if stmt.statsIndependent {
+		// The plan is known to be stats-independent from a previous execution, so this
+		// replanning (e.g. after cache eviction) cannot be influenced by statistics:
+		// don't trigger any sync/async stats loading for it.
+		stmtCtx.SkipStatsLoad = true
+	}
 	p, names, err := OptimizeAstNodeNoCache(ctx, sctx, nodeW, is)
 	if err != nil {
 		return nil, nil, err
@@ -403,13 +409,16 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 
 	// put this plan into the plan cache.
 	if stmtCtx.UseCache() {
-		if !stmt.statsIndependent && isPlanStatsIndependent(p, stmt.hasSubquery) {
-			// This plan's shape can never be affected by statistics, so exclude the stats
-			// version from its cache key: ANALYZE then no longer invalidates this entry.
-			// The key computed before optimization included the stats version hash, so it
-			// must be recomputed now that the flag is set. This happens at most once per
-			// statement (until a schema change resets the flag in planCachePreprocess).
-			stmt.statsIndependent = true
+		if statsIndependent := isPlanStatsIndependent(p, stmt.hasSubquery); statsIndependent != stmt.statsIndependent {
+			// Re-derive the stats-independent classification from the plan we just built,
+			// in both directions. A stats-independent plan excludes the stats version from
+			// its cache key, so ANALYZE no longer invalidates its entry. The reverse
+			// transition matters for correctness: planning inputs that are not part of the
+			// cache key (e.g. tidb_opt_fix_control) can turn a formerly stats-independent
+			// statement into a stats-dependent plan, which must get the stats version back
+			// into its key so ANALYZE invalidates it again. The key computed before
+			// optimization used the old classification, so it must be recomputed.
+			stmt.statsIndependent = statsIndependent
 			var cacheable bool
 			cacheKey, binding, cacheable, _, err = newPlanCacheKeyWithMatchedBinding(sctx, stmt, nil, false)
 			if err != nil {

--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -157,6 +157,10 @@ func planCachePreprocess(ctx context.Context, sctx sessionctx.Context, isNonPrep
 		// schema version like prepared plan cache key
 		stmt.PointGet.Executor = nil
 		stmt.PointGet.ColumnInfos = nil
+		// The plan shape may change under the new schema (e.g. a unique index was
+		// dropped, turning a point get into a stats-dependent scan), so the
+		// stats-independent classification must be re-derived from the new plan.
+		stmt.statsIndependent = false
 		// If the schema version has changed we need to preprocess it again,
 		// if this time it failed, the real reason for the error is schema changed.
 		// Example:
@@ -256,6 +260,26 @@ func GetPlanFromPlanCache(ctx context.Context, sctx sessionctx.Context,
 	paramTypes := parseParamTypes(sctx, params)
 	if stmtCtx.UseCache() {
 		plan, outputCols, stmtHints, hit := lookupPlanCache(ctx, sctx, cacheKey, paramTypes)
+		if !hit && !stmt.statsIndependent {
+			// A stats-independent plan for this statement may have been stored under a
+			// statsIndependent=true key, either by another session (instance plan cache)
+			// or by this statement before a stats update. Probe that key as well: a hit
+			// implies the plan is stats-independent, because such keys are only written
+			// when the stored plan was classified so (see the statsIndependent byte in
+			// newPlanCacheKeyWithMatchedBinding) and key equality means all other planning
+			// inputs match. On a miss the flag is re-derived from the new plan in
+			// generateNewPlan.
+			stmt.statsIndependent = true
+			probeKey, _, probeCacheable, _, probeErr := newPlanCacheKeyWithMatchedBinding(sctx, stmt, matchedBinding, bindingMatched)
+			if probeErr == nil && probeCacheable {
+				plan, outputCols, stmtHints, hit = lookupPlanCache(ctx, sctx, probeKey, paramTypes)
+			}
+			if hit {
+				cacheKey = probeKey
+			} else {
+				stmt.statsIndependent = false
+			}
+		}
 		skipPrivCheck := stmt.PointGet.Executor != nil // this case is specially handled
 		if hit && instancePlanCacheEnabled(ctx) {
 			plan, hit = clonePlanForInstancePlanCache(ctx, sctx, stmt, plan)
@@ -379,6 +403,22 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 
 	// put this plan into the plan cache.
 	if stmtCtx.UseCache() {
+		if !stmt.statsIndependent && isPlanStatsIndependent(p, stmt.hasSubquery) {
+			// This plan's shape can never be affected by statistics, so exclude the stats
+			// version from its cache key: ANALYZE then no longer invalidates this entry.
+			// The key computed before optimization included the stats version hash, so it
+			// must be recomputed now that the flag is set. This happens at most once per
+			// statement (until a schema change resets the flag in planCachePreprocess).
+			stmt.statsIndependent = true
+			var cacheable bool
+			cacheKey, binding, cacheable, _, err = newPlanCacheKeyWithMatchedBinding(sctx, stmt, nil, false)
+			if err != nil {
+				return nil, nil, err
+			}
+			// The key was cacheable before optimization with the same inputs, so it must
+			// still be cacheable here.
+			intest.Assert(cacheable)
+		}
 		stmt.NormalizedPlan, stmt.PlanDigest = NormalizePlan(p)
 		cached := NewPlanCacheValue(sctx, stmt, cacheKey, binding, p, names, paramTypes, &stmtCtx.StmtHints)
 		stmtCtx.SetPlan(p)
@@ -400,6 +440,26 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 	}
 	sessVars.FoundInPlanCache = false
 	return p, names, err
+}
+
+// isPlanStatsIndependent reports whether this plan's shape can never be affected by
+// statistics changes. PointGet and BatchPointGet are chosen by deterministic rules
+// (a full match on the primary key or a unique key) rather than by cost, and
+// INSERT ... VALUES involves no access-path decision at all. Plans containing
+// subqueries are excluded because subquery plans are chosen by cost. For qualifying
+// plans the stats version hash is excluded from the plan cache key, so ANALYZE
+// doesn't needlessly invalidate their cached entries.
+func isPlanStatsIndependent(p base.Plan, hasSubquery bool) bool {
+	if hasSubquery {
+		return false
+	}
+	switch x := p.(type) {
+	case *physicalop.PointGetPlan, *physicalop.BatchPointGetPlan:
+		return true
+	case *physicalop.Insert:
+		return x.SelectPlan == nil
+	}
+	return false
 }
 
 // checkPreparedPriv checks the privilege of the prepared statement

--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -260,15 +260,21 @@ func GetPlanFromPlanCache(ctx context.Context, sctx sessionctx.Context,
 	paramTypes := parseParamTypes(sctx, params)
 	if stmtCtx.UseCache() {
 		plan, outputCols, stmtHints, hit := lookupPlanCache(ctx, sctx, cacheKey, paramTypes)
-		if !hit && !stmt.statsIndependent {
-			// A stats-independent plan for this statement may have been stored under a
-			// statsIndependent=true key, either by another session (instance plan cache)
-			// or by this statement before a stats update. Probe that key as well: a hit
-			// implies the plan is stats-independent, because such keys are only written
-			// when the stored plan was classified so (see the statsIndependent byte in
-			// newPlanCacheKeyWithMatchedBinding) and key equality means all other planning
-			// inputs match. On a miss the flag is re-derived from the new plan in
-			// generateNewPlan.
+		if !hit && !stmt.statsIndependent && instancePlanCacheEnabled(ctx) && couldBeStatsIndependent(stmt) {
+			// Another session may have stored a stats-independent plan for this statement
+			// under a statsIndependent=true key in the shared instance plan cache. Probe
+			// that key as well: a hit implies the plan is stats-independent, because such
+			// keys are only written when the stored plan was classified so (see the
+			// statsIndependent byte in newPlanCacheKeyWithMatchedBinding) and key equality
+			// means all other planning inputs match. On a miss the flag is re-derived from
+			// the new plan in generateNewPlan.
+			//
+			// The extra key build and lookup are only paid on a miss (where they are
+			// dwarfed by the replan that follows), and only when adoption is possible at
+			// all: the session-level cache needs no probe since this statement's own flag
+			// already tracks everything this session stored, and couldBeStatsIndependent
+			// rules out statements that can never classify, so post-ANALYZE misses of
+			// ordinary stats-dependent queries don't probe.
 			stmt.statsIndependent = true
 			probeKey, _, probeCacheable, _, probeErr := newPlanCacheKeyWithMatchedBinding(sctx, stmt, matchedBinding, bindingMatched)
 			if probeErr == nil && probeCacheable {
@@ -449,6 +455,24 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 	}
 	sessVars.FoundInPlanCache = false
 	return p, names, err
+}
+
+// couldBeStatsIndependent cheaply rules out statements whose plan can never be classified
+// stats-independent, so the probe lookup in GetPlanFromPlanCache is only paid for actual
+// candidates. It must stay a superset of isPlanStatsIndependent: PointGet/BatchPointGet
+// roots only arise from single-table SELECTs without LIMIT, Insert without SelectPlan only
+// from INSERT ... VALUES, and subqueries disqualify classification entirely.
+func couldBeStatsIndependent(stmt *PlanCacheStmt) bool {
+	if stmt.hasSubquery || len(stmt.limits) > 0 || len(stmt.tables) != 1 {
+		return false
+	}
+	switch x := stmt.PreparedAst.Stmt.(type) {
+	case *ast.SelectStmt:
+		return true
+	case *ast.InsertStmt:
+		return x.Select == nil
+	}
+	return false
 }
 
 // isPlanStatsIndependent reports whether this plan's shape can never be affected by

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -391,13 +391,17 @@ func newPlanCacheKeyWithMatchedBinding(
 	hashLen += 8 + 8 + 1 + 8 + 4 /*len(kv.TiDB.Name())*/ + 4 /*len(kv.TiKV.Name())*/ + 7 /*len(kv.TiFlash.Name())*/ + 8
 	// binding + connCharset + connCollation + inRestrictedSQL + readOnly + superReadOnly + exprPushdownBlacklistReloadTimeStamp + hasSubquery + foreignKeyChecks
 	hashLen += len(binding) + len(connCharset) + len(connCollation) + 3 + 8 + 2
+	// statsIndependent
+	hashLen++
 	if len(stmt.limits) > 0 {
 		// '|' + each limit count/offset takes 8 bytes + '|'
 		hashLen += 2 + len(stmt.limits)*2*8
 	}
-	if vars.PlanCacheInvalidationOnFreshStats && (binding == "" || !vars.PlanCacheSkipStatsOnBinding) {
-		// statsVerHash: skipped when a binding is matched and PlanCacheSkipStatsOnBinding is on,
-		// because a binding pins the plan via hints so stats changes cannot alter the chosen plan.
+	if vars.PlanCacheInvalidationOnFreshStats && !stmt.statsIndependent && (binding == "" || !vars.PlanCacheSkipStatsOnBinding) {
+		// statsVerHash: skipped when the cached plan is stats-independent (PointGet,
+		// BatchPointGet, INSERT ... VALUES), or when a binding is matched and
+		// PlanCacheSkipStatsOnBinding is on, because in both cases stats changes
+		// cannot alter the chosen plan.
 		hashLen += 8
 	}
 	// dirty tables
@@ -471,9 +475,18 @@ func newPlanCacheKeyWithMatchedBinding(
 		hash = append(hash, '|')
 	}
 
-	// stats ver can affect cached plan, unless a binding is active and PlanCacheSkipStatsOnBinding
-	// is enabled — a binding pins the plan via hints, so stats changes cannot alter the chosen plan.
-	if vars.PlanCacheInvalidationOnFreshStats && (binding == "" || !vars.PlanCacheSkipStatsOnBinding) {
+	// The statsIndependent byte partitions the key space: entries whose stats version hash
+	// is omitted because the plan is stats-independent (see isPlanStatsIndependent) must not
+	// collide with entries whose hash is absent for any other reason (a binding with
+	// PlanCacheSkipStatsOnBinding, or PlanCacheInvalidationOnFreshStats being off), since
+	// the probe in GetPlanFromPlanCache infers stats-independence from a hit on this key.
+	hash = append(hash, bool2Byte(stmt.statsIndependent))
+
+	// stats ver can affect cached plan, unless the plan is stats-independent (its shape can
+	// never change with statistics, see isPlanStatsIndependent), or a binding is active and
+	// PlanCacheSkipStatsOnBinding is enabled — a binding pins the plan via hints, so stats
+	// changes cannot alter the chosen plan.
+	if vars.PlanCacheInvalidationOnFreshStats && !stmt.statsIndependent && (binding == "" || !vars.PlanCacheSkipStatsOnBinding) {
 		var statsVerHash uint64
 		for _, t := range stmt.tables {
 			statsVerHash += getLatestVersionFromStatsTable(sctx, t.Meta(), t.Meta().ID) // use '+' as the hash function for simplicity
@@ -757,6 +770,14 @@ type PlanCacheStmt struct {
 	limits      []*ast.Limit
 	hasSubquery bool
 	tables      []table.Table // to capture table stats changes
+
+	// statsIndependent indicates that the plan generated for this statement cannot be
+	// affected by statistics changes (e.g. PointGet/BatchPointGet or INSERT ... VALUES),
+	// so the stats version hash is excluded from its plan cache key and ANALYZE won't
+	// invalidate its cached plan. It is set when such a plan is put into the cache and
+	// must be reset whenever the schema version changes, since a schema change (e.g.
+	// dropping an index) can change the plan shape into a stats-dependent one.
+	statsIndependent bool
 
 	NormalizedSQL       string
 	NormalizedPlan      string

--- a/pkg/planner/core/rule/rule_collect_plan_stats.go
+++ b/pkg/planner/core/rule/rule_collect_plan_stats.go
@@ -46,6 +46,12 @@ func (c *CollectPredicateColumnsPoint) Optimize(_ context.Context, plan base.Log
 	planChanged := false
 	intest.Assert(!plan.SCtx().GetSessionVars().InRestrictedSQL ||
 		(plan.SCtx().GetSessionVars().InternalSQLScanUserTable && plan.SCtx().GetSessionVars().InRestrictedSQL), "CollectPredicateColumnsPoint should not be called in restricted SQL mode")
+	if plan.SCtx().GetSessionVars().StmtCtx.SkipStatsLoad {
+		// The plan for this statement is known to be stats-independent (e.g. a point get):
+		// statistics cannot affect it, so don't collect columns or trigger stats loading,
+		// matching the behavior of plans built through the fast path.
+		return plan, planChanged, nil
+	}
 	syncWait := plan.SCtx().GetSessionVars().StatsLoadSyncWait.Load()
 	syncLoadEnabled := syncWait > 0
 	predicateColumns, visitedPhysTblIDs, tid2pids, opNum := CollectColumnStatsUsage(plan)
@@ -321,6 +327,11 @@ func (SyncWaitStatsLoadPoint) Optimize(_ context.Context, plan base.LogicalPlan)
 	intest.Assert(!plan.SCtx().GetSessionVars().InRestrictedSQL ||
 		(plan.SCtx().GetSessionVars().InRestrictedSQL && plan.SCtx().GetSessionVars().InternalSQLScanUserTable), "SyncWaitStatsLoadPoint should not be called in restricted SQL mode")
 	if plan.SCtx().GetSessionVars().StmtCtx.IsSyncStatsFailed {
+		return plan, planChanged, nil
+	}
+	if plan.SCtx().GetSessionVars().StmtCtx.SkipStatsLoad {
+		// Stats-independent plan: CollectPredicateColumnsPoint requested nothing, so
+		// there is nothing to wait for.
 		return plan, planChanged, nil
 	}
 	err := SyncWaitStatsLoad(plan)

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -468,6 +468,11 @@ type StatementContext struct {
 	usedStatsInfo atomic.Pointer[UsedStatsInfo]
 	// IsSyncStatsFailed indicates whether any failure happened during sync stats
 	IsSyncStatsFailed bool
+	// SkipStatsLoad indicates the planner should not trigger synchronous or asynchronous
+	// statistics loading for this statement: its cached plan classification proved that
+	// statistics cannot affect the chosen plan (e.g. PointGet, BatchPointGet, or
+	// INSERT ... VALUES; see PlanCacheStmt.statsIndependent).
+	SkipStatsLoad bool
 	// UseDynamicPruneMode indicates whether use UseDynamicPruneMode in query stmt
 	UseDynamicPruneMode bool
 	// ColRefFromPlan mark the column ref used by assignment in update statement.

--- a/pkg/statistics/column.go
+++ b/pkg/statistics/column.go
@@ -144,6 +144,7 @@ func ColumnStatsIsInvalid(colStats *Column, sctx planctx.PlanContext, histColl *
 		isNonInternalColumnID := cid > 0
 		if (colStats == nil || !colStats.IsStatsInitialized() || colStats.IsLoadNeeded()) &&
 			stmtctx != nil &&
+			!stmtctx.SkipStatsLoad &&
 			isNonInternalColumnID &&
 			!histColl.CanNotTriggerLoad {
 			asyncload.AsyncLoadHistogramNeededItems.Insert(model.TableItemID{

--- a/pkg/statistics/index.go
+++ b/pkg/statistics/index.go
@@ -124,7 +124,8 @@ func IndexStatsIsInvalid(sctx planctx.PlanContext, idxStats *Index, coll *HistCo
 	var totalCount float64
 	// If the given index statistics is nil or we found that the index's statistics hasn't been fully loaded, we add this index to NeededItems.
 	// Also, we need to check that this HistColl has its physical ID and it is permitted to trigger the stats loading.
-	if (idxStats == nil || !idxStats.IsFullLoad()) && !coll.CanNotTriggerLoad && !sctx.GetSessionVars().InRestrictedSQL {
+	if (idxStats == nil || !idxStats.IsFullLoad()) && !coll.CanNotTriggerLoad &&
+		!sctx.GetSessionVars().InRestrictedSQL && !sctx.GetSessionVars().StmtCtx.SkipStatsLoad {
 		asyncload.AsyncLoadHistogramNeededItems.Insert(model.TableItemID{
 			TableID:          coll.PhysicalID,
 			ID:               cid,


### PR DESCRIPTION
PointGet, BatchPointGet, and INSERT ... VALUES plans are chosen by deterministic rules rather than cost, so statistics changes can never alter their shape. Including the stats version hash in their plan cache key only causes ANALYZE to needlessly invalidate their cached entries and forces a replan on the next execution of every such statement.

Classify the plan when it is stored into the cache, record the result on PlanCacheStmt, and exclude the stats version hash from the key for classified statements. A statsIndependent byte in the key partitions these entries from entries whose stats hash is absent for other reasons (skip-stats-on-binding, invalidation disabled), and a probe lookup on miss lets other sessions sharing the instance plan cache adopt the classification without an extra replan. A schema version change resets the classification since the plan shape may change under the new schema.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plan cache now preserves plans whose shape isn't affected by statistics across ANALYZE and correctly reclassifies them when schema or plan-shape changes make them stats-dependent.
  * Planner avoids unnecessary synchronous and asynchronous statistics loading for plans proven unaffected by stats, improving planning performance and reducing background work.

* **Tests**
  * Added regression tests verifying plan-cache preservation, stats-load skipping, and correct behavior after schema changes and planning-path changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->