### PR TITLE
objstore: suppress skipped checksum validation warning logs

### DIFF
--- a/pkg/objstore/s3store/BUILD.bazel
+++ b/pkg/objstore/s3store/BUILD.bazel
@@ -79,9 +79,12 @@ go_test(
         "@com_github_aws_smithy_go//:smithy-go",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_kvproto//pkg/brpb",
+        "@com_github_pingcap_log//:log",
         "@com_github_prometheus_client_golang//prometheus/testutil",
         "@com_github_spf13_pflag//:pflag",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_mock//gomock",
+        "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zaptest/observer",
     ],
 )

--- a/pkg/objstore/s3store/s3_test.go
+++ b/pkg/objstore/s3store/s3_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/smithy-go"
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/log"
 	. "github.com/pingcap/tidb/pkg/objstore"
 	"github.com/pingcap/tidb/pkg/objstore/objectio"
 	"github.com/pingcap/tidb/pkg/objstore/recording"
@@ -45,6 +46,8 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 const bucketRegionHeader = "X-Amz-Bucket-Region"
@@ -1705,6 +1708,40 @@ func TestRetryError(t *testing.T) {
 	err = s.WriteFile(ctx, "reset", []byte(errString))
 	require.NoError(t, err)
 	require.Equal(t, count, int32(2))
+}
+
+func TestS3ReadFileSuppressesSkippedChecksumValidationLog(t *testing.T) {
+	core, observedLogs := observer.New(zap.WarnLevel)
+	restore := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{})
+	t.Cleanup(restore)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "ENABLED", r.Header.Get("X-Amz-Checksum-Mode"))
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("payload"))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	storage, err := NewS3Storage(ctx, &backuppb.S3{
+		Endpoint:        server.URL,
+		Bucket:          "test",
+		Prefix:          "prefix",
+		AccessKey:       "none",
+		SecretAccessKey: "none",
+		Provider:        "minio",
+		ForcePathStyle:  true,
+	}, &storeapi.Options{})
+	require.NoError(t, err)
+
+	data, err := storage.ReadFile(ctx, "object")
+	require.NoError(t, err)
+	require.Equal(t, []byte("payload"), data)
+
+	for _, entry := range observedLogs.All() {
+		require.NotContains(t, entry.Message, "Response has no supported checksum")
+	}
 }
 
 func TestS3ReadFileRetryable(t *testing.T) {

--- a/pkg/objstore/s3store/store.go
+++ b/pkg/objstore/s3store/store.go
@@ -121,6 +121,7 @@ func NewS3Storage(ctx context.Context, backend *backuppb.S3, opts *storeapi.Opti
 
 	s3Opts = append(s3Opts, func(o *s3.Options) {
 		o.Logger = newLogger(logger)
+		o.DisableLogOutputChecksumValidationSkipped = true
 		// These logs will be printed when log level is `DEBUG`.
 		o.ClientLogMode |= aws.LogRetries | aws.LogRequest | aws.LogResponse | aws.LogDeprecatedUsage
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62541

Problem Summary:

After the AWS SDK for Go v2 migration, the S3 client enables response checksum validation by default for supported operations. When TiDB reads from S3-compatible storage such as MinIO, the response may not include a checksum header supported by the AWS SDK. In that case, reads can still succeed, but the SDK may emit noisy warning logs like:

```text
Response has no supported checksum. Not validating response payload.
```

### What changed and how does it work?

This PR sets `DisableLogOutputChecksumValidationSkipped` on the AWS SDK v2 S3 client used by TiDB object storage.

This only suppresses the warning log emitted when the SDK skips response payload checksum validation because the response has no supported checksum. It does not change `ResponseChecksumValidation`, so checksum validation remains enabled when the SDK can actually validate a supported checksum.

A regression test uses a local S3-compatible HTTP endpoint that returns a successful object body without checksum headers. The test verifies the SDK default checksum mode is still active and the skipped-validation warning is not emitted.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```bash
make bazel_prepare
./tools/check/failpoint-go-test.sh pkg/objstore/s3store -run TestS3ReadFileSuppressesSkippedChecksumValidationLog -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Suppress noisy AWS SDK skipped checksum validation warning logs when reading from S3-compatible storage such as MinIO.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Suppressed unnecessary warning logs related to checksum validation during S3 file read operations.

* **Tests**
  * Added test coverage for S3 file read logging behavior.

* **Chores**
  * Updated build and test dependencies for the S3 storage module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->