### PR TITLE
types: avoid uint32 overflow when validating vector length

### DIFF
--- a/pkg/types/vector.go
+++ b/pkg/types/vector.go
@@ -201,8 +201,12 @@ func PeekBytesAsVectorFloat32(b []byte) (n int, err error) {
 	}
 
 	elements := binary.LittleEndian.Uint32(b)
-	totalDataSize := elements*4 + 4
-	if len(b) < int(totalDataSize) {
+	// Compute the size in uint64 so a large element count cannot wrap the
+	// uint32 multiplication and slip past the length check below. Otherwise a
+	// crafted header could report a tiny size while Len()/Elements() still
+	// trust the oversized dimension and read out of bounds.
+	totalDataSize := uint64(elements)*4 + 4
+	if uint64(len(b)) < totalDataSize {
 		err = errors.Errorf("bad VectorFloat32 value (len=%d, expected=%d)", len(b), totalDataSize)
 		return
 	}

--- a/pkg/types/vector.go
+++ b/pkg/types/vector.go
@@ -201,10 +201,6 @@ func PeekBytesAsVectorFloat32(b []byte) (n int, err error) {
 	}
 
 	elements := binary.LittleEndian.Uint32(b)
-	// Compute the size in uint64 so a large element count cannot wrap the
-	// uint32 multiplication and slip past the length check below. Otherwise a
-	// crafted header could report a tiny size while Len()/Elements() still
-	// trust the oversized dimension and read out of bounds.
 	totalDataSize := uint64(elements)*4 + 4
 	if uint64(len(b)) < totalDataSize {
 		err = errors.Errorf("bad VectorFloat32 value (len=%d, expected=%d)", len(b), totalDataSize)

--- a/pkg/types/vector_test.go
+++ b/pkg/types/vector_test.go
@@ -170,3 +170,17 @@ func TestVectorSerialize(t *testing.T) {
 	}, remaining)
 	require.True(t, v3.IsZeroValue())
 }
+
+func TestVectorDeserializeOverflow(t *testing.T) {
+	// 0x40000000 elements overflows the uint32 size computation
+	// (0x40000000*4 + 4 wraps to 4), so without the uint64 check the header
+	// is accepted with a 4-byte buffer and Len() reports a huge dimension
+	// that Elements() would read out of bounds.
+	b := []byte{0x00, 0x00, 0x00, 0x40}
+	_, err := types.PeekBytesAsVectorFloat32(b)
+	require.Error(t, err)
+
+	v, _, err := types.ZeroCopyDeserializeVectorFloat32(b)
+	require.Error(t, err)
+	require.True(t, v.IsZeroValue())
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69145

Problem Summary:

`PeekBytesAsVectorFloat32` works out the expected size of a serialised vector with `elements*4 + 4`, where `elements` is a `uint32` read straight from the start of the buffer. When the declared element count is large that multiplication wraps around in `uint32`, so the computed size comes out tiny and the `len(b) < totalDataSize` check passes for a buffer that is far too short. The deserialised `VectorFloat32` then keeps the oversized count in its header, and because `Len()` trusts that header while `Elements()` builds an `unsafe.Slice` of that many float32s over the small backing buffer, anything that walks the elements (String(), distance functions and so on) reads well past the end of the slice. For example a 4 byte input `00 00 00 40` decodes to `0x40000000` elements: `0x40000000*4 + 4` wraps to 4, the value is accepted, and `Len()` reports just over a billion dimensions backed by 4 bytes.

### What changed and how does it work?

The size is now computed and compared in `uint64`, so an oversized declared length can no longer wrap and is rejected by the existing length check before any vector is constructed. A regression test covers the crafted overflow header.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a possible out-of-bounds read when deserialising a malformed VECTOR value whose declared length overflows the size calculation
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a vulnerability in vector deserialization where crafted input could bypass validation and cause unsafe memory access; validation now correctly handles oversized/overflow cases.
* **Tests**
  * Added a test covering the overflow scenario to ensure invalid inputs are detected and rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

