### PR TITLE
pkg/ddl, pkg/executor, pkg/mvservice: fix MV privilege check and refactor execution vars

### DIFF
--- a/pkg/ddl/backfilling_test.go
+++ b/pkg/ddl/backfilling_test.go
@@ -285,7 +285,11 @@ func TestCreateMaterializedViewBuildSessionMVMaintenance(t *testing.T) {
 		Location:          &model.TimeZoneLocation{Name: "UTC"},
 		ResourceGroupName: "default",
 	}
-	restore, err := initCreateMaterializedViewBuildSession(sctx, reorgMeta, sctx.GetSessionVars().CurrentDB)
+	job := &model.Job{
+		ReorgMeta:   reorgMeta,
+		SessionVars: make(map[string]string),
+	}
+	restore, err := initCreateMaterializedViewBuildSession(sctx, job, sctx.GetSessionVars().CurrentDB)
 	require.NoError(t, err)
 	require.True(t, sctx.GetSessionVars().InMaterializedViewMaintenance)
 

--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -615,13 +615,7 @@ func buildCreateMaterializedViewImportSQL(schemaName string, mvTblInfo *model.Ta
 	// Build uses current visible data of the source query directly.
 	selectSQL := mvTblInfo.MaterializedView.SQLContent
 	prefix := sqlescape.MustEscapeSQL("IMPORT INTO %n.%n FROM ", schemaName, mvTblInfo.Name.O)
-	options := []string{"disable_precheck"}
-	if threadCnt > 0 {
-		options = append(options, fmt.Sprintf("thread=%d", threadCnt))
-	}
-	if diskQuota != "" {
-		options = append(options, sqlescape.MustEscapeSQL("disk_quota=%?", diskQuota))
-	}
+	options := BuildMViewImportIntoOptions(threadCnt, diskQuota)
 	return prefix + "(" + selectSQL + ") WITH " + strings.Join(options, ", "), nil
 }
 
@@ -679,24 +673,55 @@ func (w *worker) hasCreateMaterializedViewBuildRows(ctx context.Context, schemaN
 	return len(rows) > 0, nil
 }
 
-func initCreateMaterializedViewBuildSession(sessCtx sessionctx.Context, reorgMeta *model.DDLReorgMeta, currentDB string) (func(), error) {
-	if reorgMeta == nil {
+func initCreateMaterializedViewBuildSession(sessCtx sessionctx.Context, job *model.Job, currentDB string) (func(), error) {
+	if job == nil || job.ReorgMeta == nil {
 		return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("create materialized view: missing reorg metadata")
 	}
 	restore := restoreSessCtx(sessCtx)
 	origInMaterializedViewMaintenance := sessCtx.GetSessionVars().InMaterializedViewMaintenance
 	origCurrentDB := sessCtx.GetSessionVars().CurrentDB
-	if err := initSessCtx(sessCtx, reorgMeta); err != nil {
+	if err := initSessCtx(sessCtx, job.ReorgMeta); err != nil {
 		// initSessCtx may mutate session vars before returning error (for example invalid timezone).
 		// Restore immediately to avoid leaking partial state into the pooled session.
 		restore(sessCtx)
 		return nil, errors.Trace(err)
 	}
+	targetExecutionVars, err := MViewExecutionSessionVarsFromJob(job, sessCtx.GetSessionVars())
+	if err != nil {
+		restore(sessCtx)
+		return nil, errors.Trace(err)
+	}
+	restoreExecutionVars, err := ApplyMViewExecutionSessionVars(sessCtx.GetSessionVars(), targetExecutionVars)
+	if err != nil {
+		restore(sessCtx)
+		return nil, err
+	}
 	sessCtx.GetSessionVars().CurrentDB = currentDB
 	// MV init build should follow the same TiFlash strict-mode bypass path as MV refresh.
 	// Also marks the session as MV maintenance context so writes bypass the explicit-DML guard.
 	sessCtx.GetSessionVars().InMaterializedViewMaintenance = true
+	failpoint.InjectCall("createMaterializedViewBuildMaintainMemQuotaApplied", sessCtx.GetSessionVars().MemQuotaQuery)
+	failpoint.InjectCall(
+		"createMaterializedViewBuildTiFlashSessionVarsApplied",
+		sessCtx.GetSessionVars().TiFlashMaxThreads,
+		sessCtx.GetSessionVars().TiFlashFineGrainedShuffleStreamCount,
+		sessCtx.GetSessionVars().TiFlashFineGrainedShuffleBatchSize,
+	)
+	failpoint.InjectCall(
+		"createMaterializedViewBuildTiFlashSpillSessionVarsApplied",
+		sessCtx.GetSessionVars().TiFlashMaxBytesBeforeExternalJoin,
+		sessCtx.GetSessionVars().TiFlashMaxBytesBeforeExternalGroupBy,
+		sessCtx.GetSessionVars().TiFlashMaxBytesBeforeExternalSort,
+		sessCtx.GetSessionVars().TiFlashMaxQueryMemoryPerNode,
+		sessCtx.GetSessionVars().TiFlashQuerySpillRatio,
+	)
+	failpoint.InjectCall(
+		"createMaterializedViewBuildImportSessionVarsApplied",
+		sessCtx.GetSessionVars().MViewMaintainImportThreads,
+		sessCtx.GetSessionVars().MViewMaintainImportDiskQuota,
+	)
 	return func() {
+		restoreExecutionVars()
 		restore(sessCtx)
 		sessCtx.GetSessionVars().InMaterializedViewMaintenance = origInMaterializedViewMaintenance
 		sessCtx.GetSessionVars().CurrentDB = origCurrentDB
@@ -717,7 +742,7 @@ func (w *worker) buildCreateMaterializedViewDataByImport(ctx context.Context, jo
 	if err != nil {
 		return errors.Trace(err)
 	}
-	restoreSess, err := initCreateMaterializedViewBuildSession(sessCtx, job.ReorgMeta, job.SchemaName)
+	restoreSess, err := initCreateMaterializedViewBuildSession(sessCtx, job, job.SchemaName)
 	if err != nil {
 		w.sessPool.Put(sessCtx)
 		return errors.Trace(err)
@@ -729,13 +754,7 @@ func (w *worker) buildCreateMaterializedViewDataByImport(ctx context.Context, jo
 
 	ddlSess := sess.NewSession(sessCtx)
 	threadCnt := sessCtx.GetSessionVars().MViewMaintainImportThreads
-	if val, ok := job.GetSessionVars(variable.TiDBMViewMaintainImportThreads); ok {
-		threadCnt = variable.TidbOptInt(val, threadCnt)
-	}
 	diskQuota := sessCtx.GetSessionVars().MViewMaintainImportDiskQuota
-	if val, ok := job.GetSessionVars(variable.TiDBMViewMaintainImportDiskQuota); ok {
-		diskQuota = val
-	}
 	buildSQL, err := buildCreateMaterializedViewImportSQL(job.SchemaName, mvTblInfo, threadCnt, diskQuota)
 	if err != nil {
 		return errors.Trace(err)
@@ -759,7 +778,7 @@ func (w *worker) buildCreateMaterializedViewDataByInsert(ctx context.Context, jo
 	if err != nil {
 		return errors.Trace(err)
 	}
-	restoreSess, err := initCreateMaterializedViewBuildSession(sessCtx, job.ReorgMeta, job.SchemaName)
+	restoreSess, err := initCreateMaterializedViewBuildSession(sessCtx, job, job.SchemaName)
 	if err != nil {
 		w.sessPool.Put(sessCtx)
 		return errors.Trace(err)

--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -727,6 +727,18 @@ func TestBuildCreateMaterializedViewImportSQLDiskQuota(t *testing.T) {
 	require.Contains(t, sql, "WITH disable_precheck, disk_quota='100gib'")
 }
 
+func TestBuildCreateMaterializedViewImportSQLThreadAndDiskQuota(t *testing.T) {
+	mvTblInfo := &model.TableInfo{
+		Name: pmodel.NewCIStr("mv"),
+		MaterializedView: &model.MaterializedViewInfo{
+			SQLContent: "select a, count(1) from t group by a",
+		},
+	}
+	sql, err := buildCreateMaterializedViewImportSQL("test", mvTblInfo, 12, "64gib")
+	require.NoError(t, err)
+	require.Contains(t, sql, "WITH disable_precheck, thread=12, disk_quota='64gib'")
+}
+
 func TestNormalizeMVDefinitionHintDBNames(t *testing.T) {
 	p := parser.New()
 	stmt, err := p.ParseOneStmt("select /*+ read_from_storage(tiflash[src]) hash_join_probe(src) */ a, count(1) from t src group by a", "", "")

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -854,13 +854,33 @@ type alterMaterializedScheduleInfoNextTimeUpdateSpec struct {
 	tableNotExistsErrConverter func(error) error
 }
 
+func (e *executor) newInternalMaterializedScheduleInfoUpdateSession(fallbackCtx sessionctx.Context) (*sess.Session, func(), error) {
+	if e.sessPool == nil {
+		return sess.NewSession(fallbackCtx), func() {}, nil
+	}
+	internalCtx, err := e.sessPool.Get()
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return sess.NewSession(internalCtx), func() {
+		e.sessPool.Put(internalCtx)
+	}, nil
+}
+
 func (e *executor) bestEffortUpdateMaterializedScheduleInfoNextTime(
 	ctx sessionctx.Context,
 	spec alterMaterializedScheduleInfoNextTimeUpdateSpec,
 	nextTime *string,
 ) error {
 	kctx := kv.WithInternalSourceType(e.ctx, kv.InternalTxnDDL)
-	ddlSess := sess.NewSession(ctx)
+	// The outer ALTER MATERIALIZED VIEW / LOG statement is privilege-checked on the target
+	// MV/base table only. The follow-up NEXT_TIME update touches mysql.* system tables and must
+	// therefore run on a true DDL internal session instead of reusing the caller session.
+	ddlSess, releaseInternalSession, err := e.newInternalMaterializedScheduleInfoUpdateSession(ctx)
+	if err != nil {
+		return err
+	}
+	defer releaseInternalSession()
 	if err := ddlSess.BeginPessimistic(kctx); err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -52,6 +52,143 @@ const (
 	alterMaterializedScheduleInfoUpdateLockWaitTimeoutSec = int64(10)
 )
 
+// ApplyMViewExecutionSessionVars applies MV execution vars onto a session and returns a restore closure.
+func ApplyMViewExecutionSessionVars(sessVars *variable.SessionVars, target variable.MViewExecutionSessionVars) (func(), error) {
+	return applyMViewExecutionSessionVars(sessVars, target, false)
+}
+
+// ApplyMViewExecutionSessionVarsBestEffort applies MV execution vars onto a session and falls back
+// to the session's current value for any individual variable that fails to apply.
+func ApplyMViewExecutionSessionVarsBestEffort(sessVars *variable.SessionVars, target variable.MViewExecutionSessionVars) (func(), error) {
+	return applyMViewExecutionSessionVars(sessVars, target, true)
+}
+
+func applyMViewExecutionSessionVars(
+	sessVars *variable.SessionVars,
+	target variable.MViewExecutionSessionVars,
+	bestEffort bool,
+) (func(), error) {
+	return variable.ApplyMViewExecutionSessionVarsWithConfig(
+		sessVars,
+		target,
+		variable.MViewExecutionSessionVarsApplyConfig{
+			MaintainMemQuotaVarName: variable.TiDBMemQuotaQuery,
+			CaptureAppliedVars:      variable.CaptureAppliedMViewExecutionSessionVars,
+			BestEffort:              bestEffort,
+			InjectApplyError:        maybeMockMViewExecutionSessionVarApplyError,
+			OnApplyError: func(name, value string, err error) {
+				logutil.DDLLogger().Warn(
+					"mv execution: failed to apply session var, fallback to current session value",
+					zap.String("var", name),
+					zap.String("value", value),
+					zap.Error(err),
+				)
+			},
+			OnRestoreError: func(name, originValue, currentValue string, err error) {
+				logutil.DDLLogger().Warn(
+					"mv execution: failed to restore session var",
+					zap.String("var", name),
+					zap.String("origin", originValue),
+					zap.String("current", currentValue),
+					zap.Error(err),
+				)
+			},
+		},
+	)
+}
+
+func maybeMockMViewExecutionSessionVarApplyError(varName string) error {
+	var err error
+	failpoint.Inject("mockMViewExecutionSessionVarApplyError", func(val failpoint.Value) {
+		targetVar, ok := val.(string)
+		if ok && targetVar == varName {
+			err = errors.Errorf("mock mv execution session var apply error: %s", varName)
+		}
+	})
+	return err
+}
+
+// AddMViewExecutionSessionVarsToJob snapshots MV execution vars into the DDL job.
+func AddMViewExecutionSessionVarsToJob(job *model.Job, sessVars *variable.SessionVars) {
+	if job == nil || sessVars == nil {
+		return
+	}
+	if job.SessionVars == nil {
+		job.SessionVars = make(map[string]string)
+	}
+	target := variable.CaptureMViewExecutionSessionVars(sessVars)
+	job.AddSessionVars(variable.TiDBMVMaintainMemQuota, strconv.FormatInt(target.MaintainMemQuota, 10))
+	job.AddSessionVars(variable.TiDBMaxTiFlashThreads, strconv.FormatInt(target.TiFlashMaxThreads, 10))
+	job.AddSessionVars(variable.TiDBMaxBytesBeforeTiFlashExternalJoin, strconv.FormatInt(target.TiFlashMaxBytesBeforeExtJoin, 10))
+	job.AddSessionVars(variable.TiDBMaxBytesBeforeTiFlashExternalGroupBy, strconv.FormatInt(target.TiFlashMaxBytesBeforeExtAgg, 10))
+	job.AddSessionVars(variable.TiDBMaxBytesBeforeTiFlashExternalSort, strconv.FormatInt(target.TiFlashMaxBytesBeforeExtSort, 10))
+	job.AddSessionVars(variable.TiFlashMemQuotaQueryPerNode, strconv.FormatInt(target.TiFlashMemQuotaQueryPerNode, 10))
+	job.AddSessionVars(variable.TiFlashQuerySpillRatio, strconv.FormatFloat(target.TiFlashQuerySpillRatio, 'f', -1, 64))
+	job.AddSessionVars(variable.TiFlashFineGrainedShuffleStreamCount, strconv.FormatInt(target.FineGrainedStreamCount, 10))
+	job.AddSessionVars(variable.TiFlashFineGrainedShuffleBatchSize, strconv.FormatUint(target.FineGrainedBatchSize, 10))
+	job.AddSessionVars(variable.TiDBMViewMaintainImportThreads, strconv.Itoa(target.ImportThreads))
+	job.AddSessionVars(variable.TiDBMViewMaintainImportDiskQuota, target.ImportDiskQuota)
+}
+
+// MViewExecutionSessionVarsFromJob reconstructs MV execution vars from a DDL job.
+func MViewExecutionSessionVarsFromJob(job *model.Job, defaultSessVars *variable.SessionVars) (variable.MViewExecutionSessionVars, error) {
+	target := variable.CaptureAppliedMViewExecutionSessionVars(defaultSessVars)
+	if job == nil {
+		return target, nil
+	}
+
+	if val, ok := job.GetSessionVars(variable.TiDBMVMaintainMemQuota); ok {
+		target.MaintainMemQuota = variable.TidbOptInt64(val, target.MaintainMemQuota)
+	}
+	if val, ok := job.GetSessionVars(variable.TiDBMaxTiFlashThreads); ok {
+		target.TiFlashMaxThreads = variable.TidbOptInt64(val, target.TiFlashMaxThreads)
+	}
+	if val, ok := job.GetSessionVars(variable.TiDBMaxBytesBeforeTiFlashExternalJoin); ok {
+		target.TiFlashMaxBytesBeforeExtJoin = variable.TidbOptInt64(val, target.TiFlashMaxBytesBeforeExtJoin)
+	}
+	if val, ok := job.GetSessionVars(variable.TiDBMaxBytesBeforeTiFlashExternalGroupBy); ok {
+		target.TiFlashMaxBytesBeforeExtAgg = variable.TidbOptInt64(val, target.TiFlashMaxBytesBeforeExtAgg)
+	}
+	if val, ok := job.GetSessionVars(variable.TiDBMaxBytesBeforeTiFlashExternalSort); ok {
+		target.TiFlashMaxBytesBeforeExtSort = variable.TidbOptInt64(val, target.TiFlashMaxBytesBeforeExtSort)
+	}
+	if val, ok := job.GetSessionVars(variable.TiFlashMemQuotaQueryPerNode); ok {
+		target.TiFlashMemQuotaQueryPerNode = variable.TidbOptInt64(val, target.TiFlashMemQuotaQueryPerNode)
+	}
+	if val, ok := job.GetSessionVars(variable.TiFlashQuerySpillRatio); ok {
+		ratio, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return variable.MViewExecutionSessionVars{}, errors.Annotatef(err, "invalid %s", variable.TiFlashQuerySpillRatio)
+		}
+		target.TiFlashQuerySpillRatio = ratio
+	}
+	if val, ok := job.GetSessionVars(variable.TiFlashFineGrainedShuffleStreamCount); ok {
+		target.FineGrainedStreamCount = variable.TidbOptInt64(val, target.FineGrainedStreamCount)
+	}
+	if val, ok := job.GetSessionVars(variable.TiFlashFineGrainedShuffleBatchSize); ok {
+		target.FineGrainedBatchSize = uint64(variable.TidbOptInt64(val, int64(target.FineGrainedBatchSize)))
+	}
+	if val, ok := job.GetSessionVars(variable.TiDBMViewMaintainImportThreads); ok {
+		target.ImportThreads = variable.TidbOptInt(val, target.ImportThreads)
+	}
+	if val, ok := job.GetSessionVars(variable.TiDBMViewMaintainImportDiskQuota); ok {
+		target.ImportDiskQuota = val
+	}
+	return target, nil
+}
+
+// BuildMViewImportIntoOptions builds the WITH options shared by MV IMPORT INTO execution.
+func BuildMViewImportIntoOptions(importThreads int, importDiskQuota string) []string {
+	options := []string{"disable_precheck"}
+	if importThreads > 0 {
+		options = append(options, fmt.Sprintf("thread=%d", importThreads))
+	}
+	if importDiskQuota != "" {
+		options = append(options, sqlescape.MustEscapeSQL("disk_quota=%?", importDiskQuota))
+	}
+	return options
+}
+
 func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateMaterializedViewStmt) error {
 	is := e.infoCache.GetLatest()
 	schemaName := s.ViewName.Schema
@@ -228,8 +365,7 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 		return err
 	}
 	job.AddSessionVars(variable.TiDBScatterRegion, getScatterScopeFromSessionctx(ctx))
-	job.AddSessionVars(variable.TiDBMViewMaintainImportThreads, strconv.Itoa(ctx.GetSessionVars().MViewMaintainImportThreads))
-	job.AddSessionVars(variable.TiDBMViewMaintainImportDiskQuota, ctx.GetSessionVars().MViewMaintainImportDiskQuota)
+	AddMViewExecutionSessionVarsToJob(job, ctx.GetSessionVars())
 	jobW := NewJobWrapperWithArgs(job, &model.CreateMaterializedViewArgs{
 		TableInfo:    mvTableInfo,
 		MLogTableIDs: []int64{mlogTable.Meta().ID},

--- a/pkg/executor/executor_pkg_test.go
+++ b/pkg/executor/executor_pkg_test.go
@@ -25,6 +25,7 @@ import (
 	"unsafe"
 
 	"github.com/hashicorp/go-version"
+	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/executor/aggfuncs"
@@ -157,6 +158,24 @@ func TestMViewCompleteDeltaApplyOpenValidatesMappingsBeforeOpeningChild(t *testi
 	err := applyExec.Open(context.Background())
 	require.ErrorContains(t, err, "writable input col id 1")
 	require.False(t, child.opened)
+}
+
+func TestBuildMVRefreshOutOfPlaceBuildSQLImportOptions(t *testing.T) {
+	tblInfo := &model.TableInfo{
+		Name: pmodel.NewCIStr("mv"),
+		MaterializedView: &model.MaterializedViewInfo{
+			SQLContent: "select a, count(1) from t group by a",
+		},
+	}
+
+	sql, err := buildMVRefreshOutOfPlaceBuildSQL("test", "__mv_shadow_1", tblInfo, "TiKV", 12, "64gib")
+	require.NoError(t, err)
+	require.Contains(t, sql, "IMPORT INTO `test`.`__mv_shadow_1` FROM (")
+	require.Contains(t, sql, "WITH "+strings.Join(ddl.BuildMViewImportIntoOptions(12, "64gib"), ", "))
+
+	sql, err = buildMVRefreshOutOfPlaceBuildSQL("test", "__mv_shadow_1", tblInfo, kv.TiDB.Name(), 12, "64gib")
+	require.NoError(t, err)
+	require.Equal(t, "INSERT INTO `test`.`__mv_shadow_1` select a, count(1) from t group by a", sql)
 }
 
 func TestMarkMViewCompleteDeltaTouchedRowsByColumnStringUsesBinaryCompare(t *testing.T) {

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1884,12 +1884,12 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 	sqlExec := refreshSctx.GetSQLExecutor()
 	sessVars := refreshSctx.GetSessionVars()
 	refreshExecutionVars := captureRefreshExecutionSessionVars(e.Ctx().GetSessionVars())
-	restoreRefreshExecutionVars, err := applyRefreshExecutionSessionVars(sessVars, refreshExecutionVars)
+	restoreRefreshExecutionVars, err := applyRefreshExecutionSessionVars(sessVars, refreshExecutionVars, isInternalSQL)
 	if err != nil {
 		return err
 	}
 	defer restoreRefreshExecutionVars()
-	failpoint.InjectCall("mvMaintainMemQuotaAppliedOnRefreshSession", sessVars.MemQuotaQuery, refreshExecutionVars.maintainMemQuota)
+	failpoint.InjectCall("mvMaintainMemQuotaAppliedOnRefreshSession", sessVars.MemQuotaQuery, refreshExecutionVars.MaintainMemQuota)
 
 	restoreSessVars, err := initRefreshMaterializedViewSession(sessVars, tblInfo.MaterializedView)
 	if err != nil {
@@ -2273,7 +2273,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedViewCompleteOutO
 	stepSet mvRefreshStepSet,
 	expectedLastSuccessReadTSO uint64,
 	expectedLastSuccessReadTSONull bool,
-	refreshExecutionVars refreshExecutionSessionVars,
+	targetExecutionVars variable.MViewExecutionSessionVars,
 ) (buildReadTSO uint64, err error) {
 	if err := kctx.Err(); err != nil {
 		return 0, err
@@ -2285,12 +2285,31 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedViewCompleteOutO
 	defer e.ReleaseSysSession(releaseCtx, buildSctx)
 
 	buildSessVars := buildSctx.GetSessionVars()
-	restoreBuildRefreshExecutionVars, err := applyRefreshExecutionSessionVars(buildSessVars, refreshExecutionVars)
+	restoreBuildExecutionVars, err := applyRefreshExecutionSessionVars(buildSessVars, targetExecutionVars, isInternalSQL)
 	if err != nil {
 		return 0, err
 	}
-	defer restoreBuildRefreshExecutionVars()
-	failpoint.InjectCall("mvMaintainMemQuotaAppliedOnRefreshOutOfPlaceBuildSession", buildSessVars.MemQuotaQuery, refreshExecutionVars.maintainMemQuota)
+	defer restoreBuildExecutionVars()
+	failpoint.InjectCall("mvMaintainMemQuotaAppliedOnRefreshOutOfPlaceBuildSession", buildSessVars.MemQuotaQuery, targetExecutionVars.MaintainMemQuota)
+	failpoint.InjectCall(
+		"refreshMaterializedViewOutOfPlaceBuildTiFlashSessionVarsApplied",
+		buildSessVars.TiFlashMaxThreads,
+		buildSessVars.TiFlashFineGrainedShuffleStreamCount,
+		buildSessVars.TiFlashFineGrainedShuffleBatchSize,
+	)
+	failpoint.InjectCall(
+		"refreshMaterializedViewOutOfPlaceBuildTiFlashSpillSessionVarsApplied",
+		buildSessVars.TiFlashMaxBytesBeforeExternalJoin,
+		buildSessVars.TiFlashMaxBytesBeforeExternalGroupBy,
+		buildSessVars.TiFlashMaxBytesBeforeExternalSort,
+		buildSessVars.TiFlashMaxQueryMemoryPerNode,
+		buildSessVars.TiFlashQuerySpillRatio,
+	)
+	failpoint.InjectCall(
+		"refreshMaterializedViewOutOfPlaceBuildImportSessionVarsApplied",
+		buildSessVars.MViewMaintainImportThreads,
+		buildSessVars.MViewMaintainImportDiskQuota,
+	)
 
 	restoreBuildSessVars, err := initRefreshMaterializedViewSession(buildSessVars, tblInfo.MaterializedView)
 	if err != nil {
@@ -2371,7 +2390,14 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedViewCompleteOutO
 			zap.String("method", buildMethod),
 		)
 
-		buildSQL, buildErr := buildMVRefreshOutOfPlaceBuildSQL(schemaName.O, shadowTableName, tblInfo, storeName)
+		buildSQL, buildErr := buildMVRefreshOutOfPlaceBuildSQL(
+			schemaName.O,
+			shadowTableName,
+			tblInfo,
+			storeName,
+			targetExecutionVars.ImportThreads,
+			targetExecutionVars.ImportDiskQuota,
+		)
 		if buildErr != nil {
 			return buildErr
 		}
@@ -2476,102 +2502,52 @@ func applyMVMaintenanceMemQuota(sessVars *variable.SessionVars, targetMemQuota i
 	}, nil
 }
 
-type refreshExecutionSessionVars struct {
-	maintainMemQuota       int64
-	tiFlashMaxThreads      int64
-	fineGrainedStreamCount int64
-	fineGrainedBatchSize   uint64
+func captureRefreshExecutionSessionVars(sessVars *variable.SessionVars) variable.MViewExecutionSessionVars {
+	return variable.CaptureMViewExecutionSessionVars(sessVars)
 }
 
-func captureRefreshExecutionSessionVars(sessVars *variable.SessionVars) refreshExecutionSessionVars {
-	return refreshExecutionSessionVars{
-		maintainMemQuota:       sessVars.MVMaintainMemQuota,
-		tiFlashMaxThreads:      sessVars.TiFlashMaxThreads,
-		fineGrainedStreamCount: sessVars.TiFlashFineGrainedShuffleStreamCount,
-		fineGrainedBatchSize:   sessVars.TiFlashFineGrainedShuffleBatchSize,
-	}
-}
+func applyRefreshExecutionSessionVars(sessVars *variable.SessionVars, target variable.MViewExecutionSessionVars, bestEffort bool) (func(), error) {
+	var injectedErr error
+	failpoint.Inject("mockRefreshExecutionSessionVarsApplyError", func() {
+		injectedErr = errors.New("mock refresh execution session vars apply error")
+	})
 
-func captureAppliedRefreshExecutionSessionVars(sessVars *variable.SessionVars) refreshExecutionSessionVars {
-	return refreshExecutionSessionVars{
-		maintainMemQuota:       sessVars.MemQuotaQuery,
-		tiFlashMaxThreads:      sessVars.TiFlashMaxThreads,
-		fineGrainedStreamCount: sessVars.TiFlashFineGrainedShuffleStreamCount,
-		fineGrainedBatchSize:   sessVars.TiFlashFineGrainedShuffleBatchSize,
+	var (
+		restore func()
+		err     error
+	)
+	if injectedErr != nil {
+		err = injectedErr
+	} else if bestEffort {
+		restore, err = ddl.ApplyMViewExecutionSessionVarsBestEffort(sessVars, target)
+	} else {
+		restore, err = ddl.ApplyMViewExecutionSessionVars(sessVars, target)
 	}
-}
-
-func applyRefreshExecutionSessionVars(sessVars *variable.SessionVars, target refreshExecutionSessionVars) (func(), error) {
-	if sessVars == nil {
-		return nil, errors.New("mv maintenance: session vars is nil")
-	}
-
-	origin := captureAppliedRefreshExecutionSessionVars(sessVars)
-	if origin != target {
-		if err := sessVars.SetSystemVar(variable.TiDBMemQuotaQuery, strconv.FormatInt(target.maintainMemQuota, 10)); err != nil {
-			return nil, errors.Annotate(err, "mv maintenance: failed to apply tidb_mv_maintain_mem_quota to tidb_mem_quota_query")
+	if err != nil {
+		if !bestEffort {
+			return nil, err
 		}
-		if err := sessVars.SetSystemVar(variable.TiDBMaxTiFlashThreads, strconv.FormatInt(target.tiFlashMaxThreads, 10)); err != nil {
-			restoreRefreshExecutionSessionVars(sessVars, origin, captureAppliedRefreshExecutionSessionVars(sessVars))
-			return nil, errors.Annotate(err, "mv maintenance: failed to apply tidb_max_tiflash_threads on refresh session")
-		}
-		if err := sessVars.SetSystemVar(variable.TiFlashFineGrainedShuffleStreamCount, strconv.FormatInt(target.fineGrainedStreamCount, 10)); err != nil {
-			restoreRefreshExecutionSessionVars(sessVars, origin, captureAppliedRefreshExecutionSessionVars(sessVars))
-			return nil, errors.Annotate(err, "mv maintenance: failed to apply tiflash_fine_grained_shuffle_stream_count on refresh session")
-		}
-		if err := sessVars.SetSystemVar(variable.TiFlashFineGrainedShuffleBatchSize, strconv.FormatUint(target.fineGrainedBatchSize, 10)); err != nil {
-			restoreRefreshExecutionSessionVars(sessVars, origin, captureAppliedRefreshExecutionSessionVars(sessVars))
-			return nil, errors.Annotate(err, "mv maintenance: failed to apply tiflash_fine_grained_shuffle_batch_size on refresh session")
-		}
+		logutil.BgLogger().Warn(
+			"refresh materialized view: failed to apply execution session vars, fallback to internal session defaults",
+			zap.Error(err),
+		)
+		return func() {}, nil
 	}
 	failpoint.InjectCall(
 		"refreshMaterializedViewTiFlashSessionVarsApplied",
-		target.tiFlashMaxThreads,
-		target.fineGrainedStreamCount,
-		target.fineGrainedBatchSize,
+		sessVars.TiFlashMaxThreads,
+		sessVars.TiFlashFineGrainedShuffleStreamCount,
+		sessVars.TiFlashFineGrainedShuffleBatchSize,
 	)
-
-	return func() {
-		if origin == target {
-			return
-		}
-		restoreRefreshExecutionSessionVars(sessVars, origin, target)
-	}, nil
-}
-
-func restoreRefreshExecutionSessionVars(sessVars *variable.SessionVars, origin, current refreshExecutionSessionVars) {
-	if err := sessVars.SetSystemVar(variable.TiDBMemQuotaQuery, strconv.FormatInt(origin.maintainMemQuota, 10)); err != nil {
-		logutil.BgLogger().Warn(
-			"mv maintenance: failed to restore tidb_mem_quota_query on refresh session",
-			zap.Int64("originMemQuotaQuery", origin.maintainMemQuota),
-			zap.Int64("currentMemQuotaQuery", current.maintainMemQuota),
-			zap.Error(err),
-		)
-	}
-	if err := sessVars.SetSystemVar(variable.TiDBMaxTiFlashThreads, strconv.FormatInt(origin.tiFlashMaxThreads, 10)); err != nil {
-		logutil.BgLogger().Warn(
-			"mv maintenance: failed to restore tidb_max_tiflash_threads on refresh session",
-			zap.Int64("originMaxThreads", origin.tiFlashMaxThreads),
-			zap.Int64("currentMaxThreads", current.tiFlashMaxThreads),
-			zap.Error(err),
-		)
-	}
-	if err := sessVars.SetSystemVar(variable.TiFlashFineGrainedShuffleStreamCount, strconv.FormatInt(origin.fineGrainedStreamCount, 10)); err != nil {
-		logutil.BgLogger().Warn(
-			"mv maintenance: failed to restore tiflash_fine_grained_shuffle_stream_count on refresh session",
-			zap.Int64("originFineGrainedStreamCount", origin.fineGrainedStreamCount),
-			zap.Int64("currentFineGrainedStreamCount", current.fineGrainedStreamCount),
-			zap.Error(err),
-		)
-	}
-	if err := sessVars.SetSystemVar(variable.TiFlashFineGrainedShuffleBatchSize, strconv.FormatUint(origin.fineGrainedBatchSize, 10)); err != nil {
-		logutil.BgLogger().Warn(
-			"mv maintenance: failed to restore tiflash_fine_grained_shuffle_batch_size on refresh session",
-			zap.Uint64("originFineGrainedBatchSize", origin.fineGrainedBatchSize),
-			zap.Uint64("currentFineGrainedBatchSize", current.fineGrainedBatchSize),
-			zap.Error(err),
-		)
-	}
+	failpoint.InjectCall(
+		"refreshMaterializedViewTiFlashSpillSessionVarsApplied",
+		sessVars.TiFlashMaxBytesBeforeExternalJoin,
+		sessVars.TiFlashMaxBytesBeforeExternalGroupBy,
+		sessVars.TiFlashMaxBytesBeforeExternalSort,
+		sessVars.TiFlashMaxQueryMemoryPerNode,
+		sessVars.TiFlashQuerySpillRatio,
+	)
+	return restore, nil
 }
 
 func buildMVRefreshShadowTableName(mviewID int64) string {
@@ -2603,6 +2579,8 @@ func buildMVRefreshOutOfPlaceBuildSQL(
 	shadowTableName string,
 	tblInfo *model.TableInfo,
 	storeName string,
+	importThreads int,
+	importDiskQuota string,
 ) (string, error) {
 	if tblInfo.MaterializedView == nil || len(tblInfo.MaterializedView.SQLContent) == 0 {
 		return "", errors.New("refresh materialized view: invalid select sql")
@@ -2610,7 +2588,8 @@ func buildMVRefreshOutOfPlaceBuildSQL(
 	selectSQL := tblInfo.MaterializedView.SQLContent
 	if shouldUseImportIntoForMVRefreshOutOfPlace(storeName) {
 		prefix := sqlescape.MustEscapeSQL("IMPORT INTO %n.%n FROM ", schemaName, shadowTableName)
-		return prefix + "(" + selectSQL + ") WITH disable_precheck", nil
+		options := ddl.BuildMViewImportIntoOptions(importThreads, importDiskQuota)
+		return prefix + "(" + selectSQL + ") WITH " + strings.Join(options, ", "), nil
 	}
 	prefix := sqlescape.MustEscapeSQL("INSERT INTO %n.%n ", schemaName, shadowTableName)
 	return prefix + selectSQL, nil

--- a/pkg/executor/mv_refresh_observability.go
+++ b/pkg/executor/mv_refresh_observability.go
@@ -407,11 +407,14 @@ func (e *RefreshMaterializedViewDryRunExec) buildOutOfPlaceRefreshPlanRows(ctx c
 
 	// Dry run explains the out-of-place load as a write statement shape (INSERT/IMPORT). We bind the
 	// target table name to the existing MV table because shadow table is not created in dry run mode.
+	targetExecutionVars := captureRefreshExecutionSessionVars(e.Ctx().GetSessionVars())
 	loadSQL, err := buildMVRefreshOutOfPlaceBuildSQL(
 		schemaName.O,
 		refreshStmt.ViewName.Name.O,
 		tblInfo,
 		e.Ctx().GetStore().Name(),
+		targetExecutionVars.ImportThreads,
+		targetExecutionVars.ImportDiskQuota,
 	)
 	if err != nil {
 		return nil, err
@@ -426,7 +429,10 @@ func (e *RefreshMaterializedViewDryRunExec) renderPlanRowsForInternalStmt(ctx co
 	}
 	defer e.ReleaseSysSession(ctx, internalSctx)
 
-	restore := enableMVRefreshObserveMaintenanceFlags(internalSctx)
+	restore, err := e.prepareMVRefreshObserveInternalSession(internalSctx)
+	if err != nil {
+		return nil, err
+	}
 	defer restore()
 
 	txnPreparer, ok := internalSctx.(interface {
@@ -473,7 +479,10 @@ func (e *RefreshMaterializedViewDryRunExec) renderPlanRowsForInternalSQL(ctx con
 	}
 	defer e.ReleaseSysSession(ctx, internalSctx)
 
-	restore := enableMVRefreshObserveMaintenanceFlags(internalSctx)
+	restore, err := e.prepareMVRefreshObserveInternalSession(internalSctx)
+	if err != nil {
+		return nil, err
+	}
 	defer restore()
 
 	planSQL := fmt.Sprintf("EXPLAIN FORMAT='%s' %s", types.ExplainFormatBrief, sql)
@@ -775,6 +784,22 @@ func enableMVRefreshObserveMaintenanceFlags(sctx sessionctx.Context) func() {
 		sessVars.InRestrictedSQL = origRestricted
 		sessVars.InMaterializedViewMaintenance = origMaintenance
 	}
+}
+
+func (e *RefreshMaterializedViewDryRunExec) prepareMVRefreshObserveInternalSession(sctx sessionctx.Context) (func(), error) {
+	restoreExecutionVars, err := applyRefreshExecutionSessionVars(
+		sctx.GetSessionVars(),
+		captureRefreshExecutionSessionVars(e.Ctx().GetSessionVars()),
+		false,
+	)
+	if err != nil {
+		return nil, err
+	}
+	restoreObserve := enableMVRefreshObserveMaintenanceFlags(sctx)
+	return func() {
+		restoreObserve()
+		restoreExecutionVars()
+	}, nil
 }
 
 func cloneRefreshMaterializedViewStmt(stmt *ast.RefreshMaterializedViewStmt) *ast.RefreshMaterializedViewStmt {

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -30,6 +30,7 @@ import (
 	ddlutil "github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
@@ -902,6 +903,40 @@ func TestAlterMaterializedViewRefreshUpdatesMetaAndNextTime(t *testing.T) {
 
 	tk.MustExec("drop materialized view mv")
 	tk.MustExec("drop materialized view log on t")
+}
+
+func TestAlterMaterializedViewRefreshUpdatesNextTimeWithAlterPrivilegeOnly(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 2 hour) as select a, sum(b), count(1) from t group by a")
+	tk.MustExec("create user 'mv_alter_refresh_u'@'%' identified by ''")
+	defer tk.MustExec("drop user 'mv_alter_refresh_u'@'%'")
+	tk.MustExec("grant alter on test.mv to 'mv_alter_refresh_u'@'%'")
+
+	getMViewMeta := func() (int64, *model.MaterializedViewInfo) {
+		is := dom.InfoSchema()
+		mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv"))
+		require.NoError(t, err)
+		require.NotNil(t, mvTable.Meta().MaterializedView)
+		return mvTable.Meta().ID, mvTable.Meta().MaterializedView
+	}
+
+	tkUser := testkit.NewTestKit(t, store)
+	require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "mv_alter_refresh_u", Hostname: "%"}, nil, nil, nil))
+	tkUser.MustExec("alter materialized view test.mv refresh next date_add(now(), interval 25 minute)")
+
+	mviewID, mvInfo := getMViewMeta()
+	require.Equal(t, "FAST", mvInfo.RefreshMethod)
+	require.Equal(t, "", mvInfo.RefreshStartWith)
+	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 25 MINUTE)", mvInfo.RefreshNext)
+	tk.MustQuery(fmt.Sprintf(
+		"select NEXT_TIME is not null, NEXT_TIME > UTC_TIMESTAMP() + interval 15 minute, NEXT_TIME < UTC_TIMESTAMP() + interval 1 hour from mysql.tidb_mview_refresh_info where MVIEW_ID = %d",
+		mviewID,
+	)).Check(testkit.Rows("1 1 1"))
 }
 
 func TestAlterMaterializedViewRefreshBestEffortInfoUpdateWarning(t *testing.T) {

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -364,6 +364,41 @@ func TestAlterMaterializedViewLogPurgeUpdatesMetaAndNextTime(t *testing.T) {
 	tk.MustExec("drop materialized view log on t")
 }
 
+func TestAlterMaterializedViewLogPurgeUpdatesNextTimeWithAlterPrivilegeOnly(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int, b int)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 2 hour)")
+	tk.MustExec("create user 'mv_alter_purge_u'@'%' identified by ''")
+	defer tk.MustExec("drop user 'mv_alter_purge_u'@'%'")
+	tk.MustExec("grant alter on test.t to 'mv_alter_purge_u'@'%'")
+
+	getMLogMeta := func() (int64, string, string, string) {
+		is := dom.InfoSchema()
+		mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t"))
+		require.NoError(t, err)
+		require.NotNil(t, mlogTable.Meta().MaterializedViewLog)
+		return mlogTable.Meta().ID,
+			mlogTable.Meta().MaterializedViewLog.PurgeMethod,
+			mlogTable.Meta().MaterializedViewLog.PurgeStartWith,
+			mlogTable.Meta().MaterializedViewLog.PurgeNext
+	}
+
+	tkUser := testkit.NewTestKit(t, store)
+	require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "mv_alter_purge_u", Hostname: "%"}, nil, nil, nil))
+	tkUser.MustExec("alter materialized view log on test.t purge next date_add(now(), interval 25 minute)")
+
+	mlogID, purgeMethod, purgeStartWith, purgeNext := getMLogMeta()
+	require.Equal(t, "DEFERRED", purgeMethod)
+	require.Equal(t, "", purgeStartWith)
+	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 25 MINUTE)", purgeNext)
+	tk.MustQuery(fmt.Sprintf(
+		"select NEXT_TIME is not null, NEXT_TIME > UTC_TIMESTAMP() + interval 15 minute, NEXT_TIME < UTC_TIMESTAMP() + interval 1 hour from mysql.tidb_mlog_purge_info where MLOG_ID = %d",
+		mlogID,
+	)).Check(testkit.Rows("1 1 1"))
+}
+
 func TestAlterMaterializedViewLogPurgeBestEffortInfoUpdateWarning(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -73,30 +73,190 @@ func requireRefreshTiFlashSessionVarsApplied(
 	t *testing.T,
 	refresh func(),
 	expectedMaxThreads int64,
+	expectedMaxBytesBeforeExternalJoin int64,
+	expectedMaxBytesBeforeExternalGroupBy int64,
+	expectedMaxBytesBeforeExternalSort int64,
+	expectedMemQuotaQueryPerNode int64,
+	expectedQuerySpillRatio float64,
 	expectedFineGrainedStreamCount int64,
 	expectedFineGrainedBatchSize uint64,
 ) {
 	t.Helper()
 
-	applied := false
+	sessionVarsApplied := false
 	var gotMaxThreads int64
+	spillVarsApplied := false
+	var gotMaxBytesBeforeExternalJoin int64
+	var gotMaxBytesBeforeExternalGroupBy int64
+	var gotMaxBytesBeforeExternalSort int64
+	var gotMemQuotaQueryPerNode int64
+	var gotQuerySpillRatio float64
 	var gotFineGrainedStreamCount int64
 	var gotFineGrainedBatchSize uint64
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/refreshMaterializedViewTiFlashSessionVarsApplied",
 		func(maxThreads int64, fineGrainedStreamCount int64, fineGrainedBatchSize uint64) {
-			applied = true
+			sessionVarsApplied = true
 			gotMaxThreads = maxThreads
 			gotFineGrainedStreamCount = fineGrainedStreamCount
 			gotFineGrainedBatchSize = fineGrainedBatchSize
 		},
 	)
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/refreshMaterializedViewTiFlashSpillSessionVarsApplied",
+		func(maxBytesBeforeExternalJoin int64, maxBytesBeforeExternalGroupBy int64, maxBytesBeforeExternalSort int64, memQuotaQueryPerNode int64, querySpillRatio float64) {
+			spillVarsApplied = true
+			gotMaxBytesBeforeExternalJoin = maxBytesBeforeExternalJoin
+			gotMaxBytesBeforeExternalGroupBy = maxBytesBeforeExternalGroupBy
+			gotMaxBytesBeforeExternalSort = maxBytesBeforeExternalSort
+			gotMemQuotaQueryPerNode = memQuotaQueryPerNode
+			gotQuerySpillRatio = querySpillRatio
+		},
+	)
 
 	refresh()
 
-	require.True(t, applied)
+	require.True(t, sessionVarsApplied)
+	require.True(t, spillVarsApplied)
 	require.Equal(t, expectedMaxThreads, gotMaxThreads)
+	require.Equal(t, expectedMaxBytesBeforeExternalJoin, gotMaxBytesBeforeExternalJoin)
+	require.Equal(t, expectedMaxBytesBeforeExternalGroupBy, gotMaxBytesBeforeExternalGroupBy)
+	require.Equal(t, expectedMaxBytesBeforeExternalSort, gotMaxBytesBeforeExternalSort)
+	require.Equal(t, expectedMemQuotaQueryPerNode, gotMemQuotaQueryPerNode)
+	require.Equal(t, expectedQuerySpillRatio, gotQuerySpillRatio)
 	require.Equal(t, expectedFineGrainedStreamCount, gotFineGrainedStreamCount)
 	require.Equal(t, expectedFineGrainedBatchSize, gotFineGrainedBatchSize)
+}
+
+func requireTiFlashSessionVarsAppliedWithFailpoint(
+	t *testing.T,
+	failpointName string,
+	spillFailpointName string,
+	refresh func(),
+	expectedMaxThreads int64,
+	expectedMaxBytesBeforeExternalJoin int64,
+	expectedMaxBytesBeforeExternalGroupBy int64,
+	expectedMaxBytesBeforeExternalSort int64,
+	expectedMemQuotaQueryPerNode int64,
+	expectedQuerySpillRatio float64,
+	expectedFineGrainedStreamCount int64,
+	expectedFineGrainedBatchSize uint64,
+) {
+	t.Helper()
+
+	sessionVarsApplied := false
+	var gotMaxThreads int64
+	spillVarsApplied := false
+	var gotMaxBytesBeforeExternalJoin int64
+	var gotMaxBytesBeforeExternalGroupBy int64
+	var gotMaxBytesBeforeExternalSort int64
+	var gotMemQuotaQueryPerNode int64
+	var gotQuerySpillRatio float64
+	var gotFineGrainedStreamCount int64
+	var gotFineGrainedBatchSize uint64
+	testfailpoint.EnableCall(t, failpointName, func(maxThreads int64, fineGrainedStreamCount int64, fineGrainedBatchSize uint64) {
+		sessionVarsApplied = true
+		gotMaxThreads = maxThreads
+		gotFineGrainedStreamCount = fineGrainedStreamCount
+		gotFineGrainedBatchSize = fineGrainedBatchSize
+	})
+	testfailpoint.EnableCall(t, spillFailpointName, func(maxBytesBeforeExternalJoin int64, maxBytesBeforeExternalGroupBy int64, maxBytesBeforeExternalSort int64, memQuotaQueryPerNode int64, querySpillRatio float64) {
+		spillVarsApplied = true
+		gotMaxBytesBeforeExternalJoin = maxBytesBeforeExternalJoin
+		gotMaxBytesBeforeExternalGroupBy = maxBytesBeforeExternalGroupBy
+		gotMaxBytesBeforeExternalSort = maxBytesBeforeExternalSort
+		gotMemQuotaQueryPerNode = memQuotaQueryPerNode
+		gotQuerySpillRatio = querySpillRatio
+	})
+
+	refresh()
+
+	require.True(t, sessionVarsApplied)
+	require.True(t, spillVarsApplied)
+	require.Equal(t, expectedMaxThreads, gotMaxThreads)
+	require.Equal(t, expectedMaxBytesBeforeExternalJoin, gotMaxBytesBeforeExternalJoin)
+	require.Equal(t, expectedMaxBytesBeforeExternalGroupBy, gotMaxBytesBeforeExternalGroupBy)
+	require.Equal(t, expectedMaxBytesBeforeExternalSort, gotMaxBytesBeforeExternalSort)
+	require.Equal(t, expectedMemQuotaQueryPerNode, gotMemQuotaQueryPerNode)
+	require.Equal(t, expectedQuerySpillRatio, gotQuerySpillRatio)
+	require.Equal(t, expectedFineGrainedStreamCount, gotFineGrainedStreamCount)
+	require.Equal(t, expectedFineGrainedBatchSize, gotFineGrainedBatchSize)
+}
+
+func requireImportSessionVarsAppliedWithFailpoint(
+	t *testing.T,
+	failpointName string,
+	run func(),
+	expectedImportThreads int,
+	expectedImportDiskQuota string,
+) {
+	t.Helper()
+
+	applied := false
+	gotImportThreads := 0
+	gotImportDiskQuota := ""
+	testfailpoint.EnableCall(t, failpointName, func(importThreads int, importDiskQuota string) {
+		applied = true
+		gotImportThreads = importThreads
+		gotImportDiskQuota = importDiskQuota
+	})
+
+	run()
+
+	require.True(t, applied)
+	require.Equal(t, expectedImportThreads, gotImportThreads)
+	require.Equal(t, expectedImportDiskQuota, gotImportDiskQuota)
+}
+
+func prepareRefreshTiFlashSessionVarsForTest(t *testing.T, tk *testkit.TestKit) {
+	t.Helper()
+
+	tk.MustExec(fmt.Sprintf("set @@global.%s = 2", variable.TiDBMaxTiFlashThreads))
+	tk.MustExec(fmt.Sprintf("set @@global.%s = 111", variable.TiDBMaxBytesBeforeTiFlashExternalJoin))
+	tk.MustExec(fmt.Sprintf("set @@global.%s = 222", variable.TiDBMaxBytesBeforeTiFlashExternalGroupBy))
+	tk.MustExec(fmt.Sprintf("set @@global.%s = 333", variable.TiDBMaxBytesBeforeTiFlashExternalSort))
+	tk.MustExec(fmt.Sprintf("set @@global.%s = 444", variable.TiFlashMemQuotaQueryPerNode))
+	tk.MustExec(fmt.Sprintf("set @@global.%s = 0.25", variable.TiFlashQuerySpillRatio))
+	tk.MustExec(fmt.Sprintf("set @@global.%s = 4", variable.TiFlashFineGrainedShuffleStreamCount))
+	tk.MustExec(fmt.Sprintf("set @@global.%s = 1024", variable.TiFlashFineGrainedShuffleBatchSize))
+	tk.MustExec(fmt.Sprintf("set @@global.%s = 3", variable.TiDBMViewMaintainImportThreads))
+	tk.MustExec(fmt.Sprintf("set @@global.%s = '32gib'", variable.TiDBMViewMaintainImportDiskQuota))
+	t.Cleanup(func() {
+		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiDBMaxTiFlashThreads, variable.DefTiFlashMaxThreads))
+		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiDBMaxBytesBeforeTiFlashExternalJoin, variable.DefTiFlashMaxBytesBeforeExternalJoin))
+		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiDBMaxBytesBeforeTiFlashExternalGroupBy, variable.DefTiFlashMaxBytesBeforeExternalGroupBy))
+		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiDBMaxBytesBeforeTiFlashExternalSort, variable.DefTiFlashMaxBytesBeforeExternalSort))
+		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiFlashMemQuotaQueryPerNode, variable.DefTiFlashMemQuotaQueryPerNode))
+		tk.MustExec(fmt.Sprintf("set @@global.%s = %s", variable.TiFlashQuerySpillRatio, strconv.FormatFloat(variable.DefTiFlashQuerySpillRatio, 'f', -1, 64)))
+		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiFlashFineGrainedShuffleStreamCount, variable.DefTiFlashFineGrainedShuffleStreamCount))
+		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiFlashFineGrainedShuffleBatchSize, variable.DefTiFlashFineGrainedShuffleBatchSize))
+		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiDBMViewMaintainImportThreads, variable.DefTiDBMViewMaintainImportThreads))
+		tk.MustExec(fmt.Sprintf("set @@global.%s = ''", variable.TiDBMViewMaintainImportDiskQuota))
+	})
+
+	tk.MustExec(fmt.Sprintf("set @@session.%s = 8", variable.TiDBMaxTiFlashThreads))
+	tk.MustExec(fmt.Sprintf("set @@session.%s = 101", variable.TiDBMaxBytesBeforeTiFlashExternalJoin))
+	tk.MustExec(fmt.Sprintf("set @@session.%s = 202", variable.TiDBMaxBytesBeforeTiFlashExternalGroupBy))
+	tk.MustExec(fmt.Sprintf("set @@session.%s = 303", variable.TiDBMaxBytesBeforeTiFlashExternalSort))
+	tk.MustExec(fmt.Sprintf("set @@session.%s = 404", variable.TiFlashMemQuotaQueryPerNode))
+	tk.MustExec(fmt.Sprintf("set @@session.%s = 0.75", variable.TiFlashQuerySpillRatio))
+	tk.MustExec(fmt.Sprintf("set @@session.%s = 16", variable.TiFlashFineGrainedShuffleStreamCount))
+	tk.MustExec(fmt.Sprintf("set @@session.%s = 4096", variable.TiFlashFineGrainedShuffleBatchSize))
+	tk.MustExec(fmt.Sprintf("set @@session.%s = 12", variable.TiDBMViewMaintainImportThreads))
+	tk.MustExec(fmt.Sprintf("set @@session.%s = '64gib'", variable.TiDBMViewMaintainImportDiskQuota))
+}
+
+func requireCurrentSessionTiFlashSessionVarsRestored(t *testing.T, sessVars *variable.SessionVars) {
+	t.Helper()
+
+	require.Equal(t, int64(8), sessVars.TiFlashMaxThreads)
+	require.Equal(t, int64(101), sessVars.TiFlashMaxBytesBeforeExternalJoin)
+	require.Equal(t, int64(202), sessVars.TiFlashMaxBytesBeforeExternalGroupBy)
+	require.Equal(t, int64(303), sessVars.TiFlashMaxBytesBeforeExternalSort)
+	require.Equal(t, int64(404), sessVars.TiFlashMaxQueryMemoryPerNode)
+	require.Equal(t, float64(0.75), sessVars.TiFlashQuerySpillRatio)
+	require.Equal(t, int64(16), sessVars.TiFlashFineGrainedShuffleStreamCount)
+	require.Equal(t, uint64(4096), sessVars.TiFlashFineGrainedShuffleBatchSize)
+	require.Equal(t, 12, sessVars.MViewMaintainImportThreads)
+	require.Equal(t, "64gib", sessVars.MViewMaintainImportDiskQuota)
 }
 
 func requireRowsContainAnyPrefix(t *testing.T, rows [][]any, prefixes ...string) {
@@ -335,28 +495,12 @@ func TestMaterializedViewRefreshManualSQLUsesCurrentSessionTiFlashSessionVars(t 
 	tk.MustExec("insert into t_mv_refresh_tiflash_vars values (1, 10), (2, 20)")
 	tk.MustExec("create materialized view log on t_mv_refresh_tiflash_vars (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_mv_refresh_tiflash_vars (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t_mv_refresh_tiflash_vars group by a")
-	tk.MustExec(fmt.Sprintf("set @@global.%s = 2", variable.TiDBMaxTiFlashThreads))
-	tk.MustExec(fmt.Sprintf("set @@global.%s = 4", variable.TiFlashFineGrainedShuffleStreamCount))
-	tk.MustExec(fmt.Sprintf("set @@global.%s = 1024", variable.TiFlashFineGrainedShuffleBatchSize))
-	t.Cleanup(func() {
-		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiDBMaxTiFlashThreads, variable.DefTiFlashMaxThreads))
-		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiFlashFineGrainedShuffleStreamCount, variable.DefTiFlashFineGrainedShuffleStreamCount))
-		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiFlashFineGrainedShuffleBatchSize, variable.DefTiFlashFineGrainedShuffleBatchSize))
-	})
-
-	tk.MustExec(fmt.Sprintf("set @@session.%s = 8", variable.TiDBMaxTiFlashThreads))
-	tk.MustExec(fmt.Sprintf("set @@session.%s = 16", variable.TiFlashFineGrainedShuffleStreamCount))
-	tk.MustExec(fmt.Sprintf("set @@session.%s = 4096", variable.TiFlashFineGrainedShuffleBatchSize))
+	prepareRefreshTiFlashSessionVarsForTest(t, tk)
 
 	requireRefreshTiFlashSessionVarsApplied(t, func() {
 		tk.MustExec("refresh materialized view mv_mv_refresh_tiflash_vars complete")
-	}, int64(8), int64(16), uint64(4096))
-	tk.MustQuery(fmt.Sprintf(
-		"select @@session.%s, @@session.%s, @@session.%s",
-		variable.TiDBMaxTiFlashThreads,
-		variable.TiFlashFineGrainedShuffleStreamCount,
-		variable.TiFlashFineGrainedShuffleBatchSize,
-	)).Check(testkit.Rows("8 16 4096"))
+	}, int64(8), int64(101), int64(202), int64(303), int64(404), float64(0.75), int64(16), uint64(4096))
+	requireCurrentSessionTiFlashSessionVarsRestored(t, tk.Session().GetSessionVars())
 }
 
 func TestMaterializedViewRefreshInternalSQLUsesCurrentSessionTiFlashSessionVars(t *testing.T) {
@@ -367,28 +511,227 @@ func TestMaterializedViewRefreshInternalSQLUsesCurrentSessionTiFlashSessionVars(
 	tk.MustExec("insert into t_mv_refresh_tiflash_vars values (1, 10), (2, 20)")
 	tk.MustExec("create materialized view log on t_mv_refresh_tiflash_vars (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_mv_refresh_tiflash_vars (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t_mv_refresh_tiflash_vars group by a")
-	tk.MustExec(fmt.Sprintf("set @@global.%s = 2", variable.TiDBMaxTiFlashThreads))
-	tk.MustExec(fmt.Sprintf("set @@global.%s = 4", variable.TiFlashFineGrainedShuffleStreamCount))
-	tk.MustExec(fmt.Sprintf("set @@global.%s = 1024", variable.TiFlashFineGrainedShuffleBatchSize))
-	t.Cleanup(func() {
-		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiDBMaxTiFlashThreads, variable.DefTiFlashMaxThreads))
-		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiFlashFineGrainedShuffleStreamCount, variable.DefTiFlashFineGrainedShuffleStreamCount))
-		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiFlashFineGrainedShuffleBatchSize, variable.DefTiFlashFineGrainedShuffleBatchSize))
-	})
-
-	tk.MustExec(fmt.Sprintf("set @@session.%s = 8", variable.TiDBMaxTiFlashThreads))
-	tk.MustExec(fmt.Sprintf("set @@session.%s = 16", variable.TiFlashFineGrainedShuffleStreamCount))
-	tk.MustExec(fmt.Sprintf("set @@session.%s = 4096", variable.TiFlashFineGrainedShuffleBatchSize))
+	prepareRefreshTiFlashSessionVarsForTest(t, tk)
 
 	requireRefreshTiFlashSessionVarsApplied(t, func() {
 		mustExecInternal(t, tk, "refresh materialized view mv_mv_refresh_tiflash_vars complete")
-	}, int64(8), int64(16), uint64(4096))
-	tk.MustQuery(fmt.Sprintf(
-		"select @@session.%s, @@session.%s, @@session.%s",
-		variable.TiDBMaxTiFlashThreads,
-		variable.TiFlashFineGrainedShuffleStreamCount,
-		variable.TiFlashFineGrainedShuffleBatchSize,
-	)).Check(testkit.Rows("8 16 4096"))
+	}, int64(8), int64(101), int64(202), int64(303), int64(404), float64(0.75), int64(16), uint64(4096))
+	requireCurrentSessionTiFlashSessionVarsRestored(t, tk.Session().GetSessionVars())
+}
+
+func TestMaterializedViewRefreshManualSQLFailsWhenApplyExecutionSessionVarsFails(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_refresh_apply_vars_manual (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_refresh_apply_vars_manual values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_mv_refresh_apply_vars_manual (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_mv_refresh_apply_vars_manual (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_mv_refresh_apply_vars_manual group by a")
+
+	failpointName := "github.com/pingcap/tidb/pkg/executor/mockRefreshExecutionSessionVarsApplyError"
+	require.NoError(t, failpoint.Enable(failpointName, "return(true)"))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable(failpointName))
+	})
+
+	err := tk.ExecToErr("refresh materialized view mv_mv_refresh_apply_vars_manual complete")
+	require.ErrorContains(t, err, "mock refresh execution session vars apply error")
+}
+
+func TestMaterializedViewRefreshInternalSQLFallsBackWhenApplyExecutionSessionVarsFails(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_refresh_apply_vars_internal (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_refresh_apply_vars_internal values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_mv_refresh_apply_vars_internal (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_mv_refresh_apply_vars_internal (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_mv_refresh_apply_vars_internal group by a")
+
+	failpointName := "github.com/pingcap/tidb/pkg/executor/mockRefreshExecutionSessionVarsApplyError"
+	require.NoError(t, failpoint.Enable(failpointName, "return(true)"))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable(failpointName))
+	})
+
+	tk.MustExec("insert into t_mv_refresh_apply_vars_internal values (3, 30)")
+	mustExecInternal(t, tk, "refresh materialized view mv_mv_refresh_apply_vars_internal complete")
+	tk.MustQuery("select * from mv_mv_refresh_apply_vars_internal order by a").Check(testkit.Rows("1 10 1", "2 20 1", "3 30 1"))
+}
+
+func TestMaterializedViewRefreshManualSQLFailsWhenSingleExecutionSessionVarApplyFails(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_refresh_single_apply_var_manual (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_refresh_single_apply_var_manual values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_mv_refresh_single_apply_var_manual (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_mv_refresh_single_apply_var_manual (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_mv_refresh_single_apply_var_manual group by a")
+	prepareRefreshTiFlashSessionVarsForTest(t, tk)
+
+	failpointName := "github.com/pingcap/tidb/pkg/ddl/mockMViewExecutionSessionVarApplyError"
+	require.NoError(t, failpoint.Enable(failpointName, fmt.Sprintf("return(%q)", variable.TiDBMaxTiFlashThreads)))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable(failpointName))
+	})
+
+	err := tk.ExecToErr("refresh materialized view mv_mv_refresh_single_apply_var_manual complete")
+	require.ErrorContains(t, err, variable.TiDBMaxTiFlashThreads)
+}
+
+func TestMaterializedViewRefreshInternalSQLFallsBackPerVarWhenExecutionSessionVarApplyFails(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_refresh_single_apply_var_internal (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_refresh_single_apply_var_internal values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_mv_refresh_single_apply_var_internal (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_mv_refresh_single_apply_var_internal (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_mv_refresh_single_apply_var_internal group by a")
+	prepareRefreshTiFlashSessionVarsForTest(t, tk)
+
+	failpointName := "github.com/pingcap/tidb/pkg/ddl/mockMViewExecutionSessionVarApplyError"
+	require.NoError(t, failpoint.Enable(failpointName, fmt.Sprintf("return(%q)", variable.TiDBMaxTiFlashThreads)))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable(failpointName))
+	})
+
+	tk.MustExec("insert into t_mv_refresh_single_apply_var_internal values (3, 30)")
+	requireRefreshTiFlashSessionVarsApplied(t, func() {
+		mustExecInternal(t, tk, "refresh materialized view mv_mv_refresh_single_apply_var_internal complete")
+	}, int64(variable.DefTiFlashMaxThreads), int64(101), int64(202), int64(303), int64(404), float64(0.75), int64(16), uint64(4096))
+	tk.MustQuery("select * from mv_mv_refresh_single_apply_var_internal order by a").Check(testkit.Rows("1 10 1", "2 20 1", "3 30 1"))
+	requireCurrentSessionTiFlashSessionVarsRestored(t, tk.Session().GetSessionVars())
+}
+
+func TestMaterializedViewRefreshInternalSQLOutOfPlaceFallsBackWhenApplyExecutionSessionVarsFails(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_refresh_apply_vars_internal_oop (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_refresh_apply_vars_internal_oop values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_mv_refresh_apply_vars_internal_oop (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_mv_refresh_apply_vars_internal_oop (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_mv_refresh_apply_vars_internal_oop group by a")
+
+	failpointName := "github.com/pingcap/tidb/pkg/executor/mockRefreshExecutionSessionVarsApplyError"
+	require.NoError(t, failpoint.Enable(failpointName, "return(true)"))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable(failpointName))
+	})
+
+	tk.MustExec("insert into t_mv_refresh_apply_vars_internal_oop values (3, 30)")
+	mustExecInternal(t, tk, "refresh materialized view mv_mv_refresh_apply_vars_internal_oop complete out of place")
+	tk.MustQuery("select * from mv_mv_refresh_apply_vars_internal_oop order by a").Check(testkit.Rows("1 10 1", "2 20 1", "3 30 1"))
+}
+
+func TestMaterializedViewRefreshInternalSQLOutOfPlaceFallsBackPerVarWhenExecutionSessionVarApplyFails(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_refresh_single_apply_var_internal_oop (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_refresh_single_apply_var_internal_oop values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_mv_refresh_single_apply_var_internal_oop (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_mv_refresh_single_apply_var_internal_oop (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_mv_refresh_single_apply_var_internal_oop group by a")
+	prepareRefreshTiFlashSessionVarsForTest(t, tk)
+
+	failpointName := "github.com/pingcap/tidb/pkg/ddl/mockMViewExecutionSessionVarApplyError"
+	require.NoError(t, failpoint.Enable(failpointName, fmt.Sprintf("return(%q)", variable.TiDBMaxTiFlashThreads)))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable(failpointName))
+	})
+
+	tk.MustExec("insert into t_mv_refresh_single_apply_var_internal_oop values (3, 30)")
+	requireTiFlashSessionVarsAppliedWithFailpoint(
+		t,
+		"github.com/pingcap/tidb/pkg/executor/refreshMaterializedViewOutOfPlaceBuildTiFlashSessionVarsApplied",
+		"github.com/pingcap/tidb/pkg/executor/refreshMaterializedViewOutOfPlaceBuildTiFlashSpillSessionVarsApplied",
+		func() {
+			mustExecInternal(t, tk, "refresh materialized view mv_mv_refresh_single_apply_var_internal_oop complete out of place")
+		},
+		int64(variable.DefTiFlashMaxThreads), int64(101), int64(202), int64(303), int64(404), float64(0.75), int64(16), uint64(4096),
+	)
+	tk.MustQuery("select * from mv_mv_refresh_single_apply_var_internal_oop order by a").Check(testkit.Rows("1 10 1", "2 20 1", "3 30 1"))
+	requireCurrentSessionTiFlashSessionVarsRestored(t, tk.Session().GetSessionVars())
+}
+
+func TestMaterializedViewRefreshOutOfPlaceUsesCurrentSessionTiFlashSessionVars(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_refresh_oop_tiflash_vars (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_refresh_oop_tiflash_vars values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_mv_refresh_oop_tiflash_vars (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_mv_refresh_oop_tiflash_vars (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t_mv_refresh_oop_tiflash_vars group by a")
+	prepareRefreshTiFlashSessionVarsForTest(t, tk)
+
+	failpointName := "github.com/pingcap/tidb/pkg/executor/refreshMaterializedViewOutOfPlaceBuildTiFlashSessionVarsApplied"
+	spillFailpointName := "github.com/pingcap/tidb/pkg/executor/refreshMaterializedViewOutOfPlaceBuildTiFlashSpillSessionVarsApplied"
+	importFailpointName := "github.com/pingcap/tidb/pkg/executor/refreshMaterializedViewOutOfPlaceBuildImportSessionVarsApplied"
+	requireImportSessionVarsAppliedWithFailpoint(t, importFailpointName, func() {
+		requireTiFlashSessionVarsAppliedWithFailpoint(t, failpointName, spillFailpointName, func() {
+			tk.MustExec("refresh materialized view mv_mv_refresh_oop_tiflash_vars complete out of place")
+		}, int64(8), int64(101), int64(202), int64(303), int64(404), float64(0.75), int64(16), uint64(4096))
+	}, 12, "64gib")
+
+	tk.MustExec("insert into t_mv_refresh_oop_tiflash_vars values (3, 30)")
+	requireImportSessionVarsAppliedWithFailpoint(t, importFailpointName, func() {
+		requireTiFlashSessionVarsAppliedWithFailpoint(t, failpointName, spillFailpointName, func() {
+			mustExecInternal(t, tk, "refresh materialized view mv_mv_refresh_oop_tiflash_vars complete out of place")
+		}, int64(8), int64(101), int64(202), int64(303), int64(404), float64(0.75), int64(16), uint64(4096))
+	}, 12, "64gib")
+	requireCurrentSessionTiFlashSessionVarsRestored(t, tk.Session().GetSessionVars())
+}
+
+func TestCreateMaterializedViewInitBuildUsesCurrentSessionExecutionSessionVars(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_create_build_vars (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_create_build_vars values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_mv_create_build_vars (a, b)")
+	prepareRefreshTiFlashSessionVarsForTest(t, tk)
+	tk.MustExec("set @@session.tidb_mem_quota_query = 1073741824")
+	tk.MustExec("set @@global.tidb_mv_maintain_mem_quota = 536870912")
+	tk.MustExec("set @@session.tidb_mv_maintain_mem_quota = 268435456")
+	t.Cleanup(func() {
+		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiDBMVMaintainMemQuota, 2*1024*1024*1024))
+	})
+
+	memQuotaApplied := false
+	gotMemQuotaQuery := int64(0)
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/createMaterializedViewBuildMaintainMemQuotaApplied", func(memQuotaQuery int64) {
+		memQuotaApplied = true
+		gotMemQuotaQuery = memQuotaQuery
+	})
+	importFailpointName := "github.com/pingcap/tidb/pkg/ddl/createMaterializedViewBuildImportSessionVarsApplied"
+	tiflashFailpointName := "github.com/pingcap/tidb/pkg/ddl/createMaterializedViewBuildTiFlashSessionVarsApplied"
+	spillFailpointName := "github.com/pingcap/tidb/pkg/ddl/createMaterializedViewBuildTiFlashSpillSessionVarsApplied"
+
+	requireImportSessionVarsAppliedWithFailpoint(t, importFailpointName, func() {
+		requireTiFlashSessionVarsAppliedWithFailpoint(t, tiflashFailpointName, spillFailpointName, func() {
+			tk.MustExec("create materialized view mv_mv_create_build_vars (a, s, cnt) refresh fast as select a, sum(b), count(1) from t_mv_create_build_vars group by a")
+		}, int64(8), int64(101), int64(202), int64(303), int64(404), float64(0.75), int64(16), uint64(4096))
+	}, 12, "64gib")
+	require.True(t, memQuotaApplied)
+	require.Equal(t, int64(268435456), gotMemQuotaQuery)
+	requireCurrentSessionTiFlashSessionVarsRestored(t, tk.Session().GetSessionVars())
+	require.Equal(t, int64(268435456), tk.Session().GetSessionVars().MVMaintainMemQuota)
+	require.Equal(t, int64(1073741824), tk.Session().GetSessionVars().MemQuotaQuery)
+	tk.MustQuery("select * from mv_mv_create_build_vars order by a").Check(testkit.Rows("1 10 1", "2 20 1"))
+}
+
+func TestMaterializedViewRefreshDryRunUsesCurrentSessionTiFlashSessionVars(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_refresh_dry_run_tiflash_vars (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_refresh_dry_run_tiflash_vars values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_mv_refresh_dry_run_tiflash_vars (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_mv_refresh_dry_run_tiflash_vars (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t_mv_refresh_dry_run_tiflash_vars group by a")
+	prepareRefreshTiFlashSessionVarsForTest(t, tk)
+
+	requireRefreshTiFlashSessionVarsApplied(t, func() {
+		tk.MustQuery("refresh materialized view mv_mv_refresh_dry_run_tiflash_vars complete delta apply dry run").Rows()
+	}, int64(8), int64(101), int64(202), int64(303), int64(404), float64(0.75), int64(16), uint64(4096))
+	requireCurrentSessionTiFlashSessionVarsRestored(t, tk.Session().GetSessionVars())
 }
 
 func TestMaterializedViewRefreshOutOfPlaceUsesCurrentSessionTiFlashSessionVars(t *testing.T) {

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -734,39 +734,6 @@ func TestMaterializedViewRefreshDryRunUsesCurrentSessionTiFlashSessionVars(t *te
 	requireCurrentSessionTiFlashSessionVarsRestored(t, tk.Session().GetSessionVars())
 }
 
-func TestMaterializedViewRefreshOutOfPlaceUsesCurrentSessionTiFlashSessionVars(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t_mv_refresh_tiflash_vars_oop (a int not null, b int not null)")
-	tk.MustExec("insert into t_mv_refresh_tiflash_vars_oop values (1, 10), (2, 20)")
-	tk.MustExec("create materialized view log on t_mv_refresh_tiflash_vars_oop (a, b) purge next date_add(now(), interval 1 hour)")
-	tk.MustExec("create materialized view mv_mv_refresh_tiflash_vars_oop (a, s, cnt) refresh fast next now() as select a, sum(b), count(1) from t_mv_refresh_tiflash_vars_oop group by a")
-	tk.MustExec(fmt.Sprintf("set @@global.%s = 2", variable.TiDBMaxTiFlashThreads))
-	tk.MustExec(fmt.Sprintf("set @@global.%s = 4", variable.TiFlashFineGrainedShuffleStreamCount))
-	tk.MustExec(fmt.Sprintf("set @@global.%s = 1024", variable.TiFlashFineGrainedShuffleBatchSize))
-	t.Cleanup(func() {
-		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiDBMaxTiFlashThreads, variable.DefTiFlashMaxThreads))
-		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiFlashFineGrainedShuffleStreamCount, variable.DefTiFlashFineGrainedShuffleStreamCount))
-		tk.MustExec(fmt.Sprintf("set @@global.%s = %d", variable.TiFlashFineGrainedShuffleBatchSize, variable.DefTiFlashFineGrainedShuffleBatchSize))
-	})
-
-	tk.MustExec(fmt.Sprintf("set @@session.%s = 8", variable.TiDBMaxTiFlashThreads))
-	tk.MustExec(fmt.Sprintf("set @@session.%s = 16", variable.TiFlashFineGrainedShuffleStreamCount))
-	tk.MustExec(fmt.Sprintf("set @@session.%s = 4096", variable.TiFlashFineGrainedShuffleBatchSize))
-	tk.MustExec("insert into t_mv_refresh_tiflash_vars_oop values (3, 30)")
-
-	requireRefreshTiFlashSessionVarsApplied(t, func() {
-		tk.MustExec("refresh materialized view mv_mv_refresh_tiflash_vars_oop complete out of place")
-	}, int64(8), int64(16), uint64(4096))
-	tk.MustQuery(fmt.Sprintf(
-		"select @@session.%s, @@session.%s, @@session.%s",
-		variable.TiDBMaxTiFlashThreads,
-		variable.TiFlashFineGrainedShuffleStreamCount,
-		variable.TiFlashFineGrainedShuffleBatchSize,
-	)).Check(testkit.Rows("8 16 4096"))
-}
-
 func TestMaterializedViewRefreshNextTimeOnlyUpdatesForInternalSQL(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -260,11 +260,17 @@ func (*serviceHelper) RefreshMV(ctx context.Context, sysSessionPool basic.Sessio
 	return nextRefresh, nil
 }
 
-type refreshSessionVars struct {
-	maintainMemQuota       int64
-	tiFlashMaxThreads      int64
-	fineGrainedStreamCount int64
-	fineGrainedBatchSize   uint64
+func getGlobalSystemVarBestEffort(ctx context.Context, sessVars *variable.SessionVars, varName string) (string, bool) {
+	val, err := sessVars.GetGlobalSystemVar(ctx, varName)
+	if err != nil {
+		logutil.BgLogger().Warn(
+			"mv service: failed to read global session var, fallback to current session value",
+			zap.String("var", varName),
+			zap.Error(err),
+		)
+		return "", false
+	}
+	return val, true
 }
 
 func applyMVRefreshSessionVarsFromGlobal(ctx context.Context, sessVars *variable.SessionVars) (func(), error) {
@@ -272,34 +278,49 @@ func applyMVRefreshSessionVarsFromGlobal(ctx context.Context, sessVars *variable
 		return nil, errors.New("mv service: session vars is nil")
 	}
 
-	maintainMemQuotaVal, err := sessVars.GetGlobalSystemVar(ctx, variable.TiDBMVMaintainMemQuota)
-	if err != nil {
-		return nil, fmt.Errorf("mv service: failed to read global tidb_mv_maintain_mem_quota: %w", err)
+	target := variable.CaptureMViewExecutionSessionVars(sessVars)
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiDBMVMaintainMemQuota); ok {
+		target.MaintainMemQuota = variable.TidbOptInt64(val, target.MaintainMemQuota)
 	}
-	maxThreadsVal, err := sessVars.GetGlobalSystemVar(ctx, variable.TiDBMaxTiFlashThreads)
-	if err != nil {
-		return nil, fmt.Errorf("mv service: failed to read global tidb_max_tiflash_threads: %w", err)
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiDBMaxTiFlashThreads); ok {
+		target.TiFlashMaxThreads = variable.TidbOptInt64(val, target.TiFlashMaxThreads)
 	}
-	fineGrainedStreamCountVal, err := sessVars.GetGlobalSystemVar(ctx, variable.TiFlashFineGrainedShuffleStreamCount)
-	if err != nil {
-		return nil, fmt.Errorf("mv service: failed to read global tiflash_fine_grained_shuffle_stream_count: %w", err)
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiDBMaxBytesBeforeTiFlashExternalJoin); ok {
+		target.TiFlashMaxBytesBeforeExtJoin = variable.TidbOptInt64(val, target.TiFlashMaxBytesBeforeExtJoin)
 	}
-	fineGrainedBatchSizeVal, err := sessVars.GetGlobalSystemVar(ctx, variable.TiFlashFineGrainedShuffleBatchSize)
-	if err != nil {
-		return nil, fmt.Errorf("mv service: failed to read global tiflash_fine_grained_shuffle_batch_size: %w", err)
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiDBMaxBytesBeforeTiFlashExternalGroupBy); ok {
+		target.TiFlashMaxBytesBeforeExtAgg = variable.TidbOptInt64(val, target.TiFlashMaxBytesBeforeExtAgg)
 	}
-
-	target := refreshSessionVars{
-		maintainMemQuota:  variable.TidbOptInt64(maintainMemQuotaVal, variable.DefTiDBMVMaintainMemQuota),
-		tiFlashMaxThreads: variable.TidbOptInt64(maxThreadsVal, variable.DefTiFlashMaxThreads),
-		fineGrainedStreamCount: variable.TidbOptInt64(
-			fineGrainedStreamCountVal,
-			variable.DefTiFlashFineGrainedShuffleStreamCount,
-		),
-		fineGrainedBatchSize: uint64(variable.TidbOptInt64(
-			fineGrainedBatchSizeVal,
-			variable.DefTiFlashFineGrainedShuffleBatchSize,
-		)),
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiDBMaxBytesBeforeTiFlashExternalSort); ok {
+		target.TiFlashMaxBytesBeforeExtSort = variable.TidbOptInt64(val, target.TiFlashMaxBytesBeforeExtSort)
+	}
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiFlashMemQuotaQueryPerNode); ok {
+		target.TiFlashMemQuotaQueryPerNode = variable.TidbOptInt64(val, target.TiFlashMemQuotaQueryPerNode)
+	}
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiFlashQuerySpillRatio); ok {
+		querySpillRatio, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			logutil.BgLogger().Warn(
+				"mv service: failed to parse global session var, fallback to current session value",
+				zap.String("var", variable.TiFlashQuerySpillRatio),
+				zap.String("value", val),
+				zap.Error(err),
+			)
+		} else {
+			target.TiFlashQuerySpillRatio = querySpillRatio
+		}
+	}
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiFlashFineGrainedShuffleStreamCount); ok {
+		target.FineGrainedStreamCount = variable.TidbOptInt64(val, target.FineGrainedStreamCount)
+	}
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiFlashFineGrainedShuffleBatchSize); ok {
+		target.FineGrainedBatchSize = uint64(variable.TidbOptInt64(val, int64(target.FineGrainedBatchSize)))
+	}
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiDBMViewMaintainImportThreads); ok {
+		target.ImportThreads = variable.TidbOptInt(val, target.ImportThreads)
+	}
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiDBMViewMaintainImportDiskQuota); ok {
+		target.ImportDiskQuota = val
 	}
 	return applyRefreshSessionVars(sessVars, target)
 }
@@ -309,18 +330,23 @@ func applyMVMaintainMemQuotaFromGlobal(ctx context.Context, sessVars *variable.S
 		return nil, errors.New("mv service: session vars is nil")
 	}
 
-	maintainMemQuotaVal, err := sessVars.GetGlobalSystemVar(ctx, variable.TiDBMVMaintainMemQuota)
-	if err != nil {
-		return nil, fmt.Errorf("mv service: failed to read global tidb_mv_maintain_mem_quota: %w", err)
-	}
-	targetMaintainMemQuota := variable.TidbOptInt64(maintainMemQuotaVal, variable.DefTiDBMVMaintainMemQuota)
 	originMaintainMemQuota := sessVars.MVMaintainMemQuota
+	targetMaintainMemQuota := originMaintainMemQuota
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiDBMVMaintainMemQuota); ok {
+		targetMaintainMemQuota = variable.TidbOptInt64(val, originMaintainMemQuota)
+	}
 	if originMaintainMemQuota == targetMaintainMemQuota {
 		return func() {}, nil
 	}
 
 	if err := sessVars.SetSystemVar(variable.TiDBMVMaintainMemQuota, strconv.FormatInt(targetMaintainMemQuota, 10)); err != nil {
-		return nil, fmt.Errorf("mv service: failed to apply tidb_mv_maintain_mem_quota on maintenance session: %w", err)
+		logutil.BgLogger().Warn(
+			"mv service: failed to apply maintenance session var from global setting, fallback to current session value",
+			zap.String("var", variable.TiDBMVMaintainMemQuota),
+			zap.Int64("value", targetMaintainMemQuota),
+			zap.Error(err),
+		)
+		return func() {}, nil
 	}
 	return func() {
 		if err := sessVars.SetSystemVar(variable.TiDBMVMaintainMemQuota, strconv.FormatInt(originMaintainMemQuota, 10)); err != nil {
@@ -334,79 +360,33 @@ func applyMVMaintainMemQuotaFromGlobal(ctx context.Context, sessVars *variable.S
 	}, nil
 }
 
-func captureRefreshSessionVars(sessVars *variable.SessionVars) refreshSessionVars {
-	return refreshSessionVars{
-		maintainMemQuota:       sessVars.MVMaintainMemQuota,
-		tiFlashMaxThreads:      sessVars.TiFlashMaxThreads,
-		fineGrainedStreamCount: sessVars.TiFlashFineGrainedShuffleStreamCount,
-		fineGrainedBatchSize:   sessVars.TiFlashFineGrainedShuffleBatchSize,
-	}
-}
-
-func applyRefreshSessionVars(sessVars *variable.SessionVars, target refreshSessionVars) (func(), error) {
-	if sessVars == nil {
-		return nil, errors.New("mv service: session vars is nil")
-	}
-
-	origin := captureRefreshSessionVars(sessVars)
-	if origin == target {
-		return func() {}, nil
-	}
-
-	if err := sessVars.SetSystemVar(variable.TiDBMVMaintainMemQuota, strconv.FormatInt(target.maintainMemQuota, 10)); err != nil {
-		return nil, fmt.Errorf("mv service: failed to apply tidb_mv_maintain_mem_quota on refresh session: %w", err)
-	}
-	if err := sessVars.SetSystemVar(variable.TiDBMaxTiFlashThreads, strconv.FormatInt(target.tiFlashMaxThreads, 10)); err != nil {
-		restoreRefreshSessionVars(sessVars, origin, captureRefreshSessionVars(sessVars))
-		return nil, fmt.Errorf("mv service: failed to apply tidb_max_tiflash_threads on refresh session: %w", err)
-	}
-	if err := sessVars.SetSystemVar(variable.TiFlashFineGrainedShuffleStreamCount, strconv.FormatInt(target.fineGrainedStreamCount, 10)); err != nil {
-		restoreRefreshSessionVars(sessVars, origin, captureRefreshSessionVars(sessVars))
-		return nil, fmt.Errorf("mv service: failed to apply tiflash_fine_grained_shuffle_stream_count on refresh session: %w", err)
-	}
-	if err := sessVars.SetSystemVar(variable.TiFlashFineGrainedShuffleBatchSize, strconv.FormatUint(target.fineGrainedBatchSize, 10)); err != nil {
-		restoreRefreshSessionVars(sessVars, origin, captureRefreshSessionVars(sessVars))
-		return nil, fmt.Errorf("mv service: failed to apply tiflash_fine_grained_shuffle_batch_size on refresh session: %w", err)
-	}
-
-	return func() {
-		restoreRefreshSessionVars(sessVars, origin, target)
-	}, nil
-}
-
-func restoreRefreshSessionVars(sessVars *variable.SessionVars, origin, current refreshSessionVars) {
-	if err := sessVars.SetSystemVar(variable.TiDBMVMaintainMemQuota, strconv.FormatInt(origin.maintainMemQuota, 10)); err != nil {
-		logutil.BgLogger().Warn(
-			"mv service: failed to restore tidb_mv_maintain_mem_quota after refresh",
-			zap.Int64("originMaintainMemQuota", origin.maintainMemQuota),
-			zap.Int64("currentMaintainMemQuota", current.maintainMemQuota),
-			zap.Error(err),
-		)
-	}
-	if err := sessVars.SetSystemVar(variable.TiDBMaxTiFlashThreads, strconv.FormatInt(origin.tiFlashMaxThreads, 10)); err != nil {
-		logutil.BgLogger().Warn(
-			"mv service: failed to restore tidb_max_tiflash_threads after refresh",
-			zap.Int64("originMaxThreads", origin.tiFlashMaxThreads),
-			zap.Int64("currentMaxThreads", current.tiFlashMaxThreads),
-			zap.Error(err),
-		)
-	}
-	if err := sessVars.SetSystemVar(variable.TiFlashFineGrainedShuffleStreamCount, strconv.FormatInt(origin.fineGrainedStreamCount, 10)); err != nil {
-		logutil.BgLogger().Warn(
-			"mv service: failed to restore tiflash_fine_grained_shuffle_stream_count after refresh",
-			zap.Int64("originFineGrainedStreamCount", origin.fineGrainedStreamCount),
-			zap.Int64("currentFineGrainedStreamCount", current.fineGrainedStreamCount),
-			zap.Error(err),
-		)
-	}
-	if err := sessVars.SetSystemVar(variable.TiFlashFineGrainedShuffleBatchSize, strconv.FormatUint(origin.fineGrainedBatchSize, 10)); err != nil {
-		logutil.BgLogger().Warn(
-			"mv service: failed to restore tiflash_fine_grained_shuffle_batch_size after refresh",
-			zap.Uint64("originFineGrainedBatchSize", origin.fineGrainedBatchSize),
-			zap.Uint64("currentFineGrainedBatchSize", current.fineGrainedBatchSize),
-			zap.Error(err),
-		)
-	}
+func applyRefreshSessionVars(sessVars *variable.SessionVars, target variable.MViewExecutionSessionVars) (func(), error) {
+	return variable.ApplyMViewExecutionSessionVarsWithConfig(
+		sessVars,
+		target,
+		variable.MViewExecutionSessionVarsApplyConfig{
+			MaintainMemQuotaVarName: variable.TiDBMVMaintainMemQuota,
+			CaptureAppliedVars:      variable.CaptureMViewExecutionSessionVars,
+			BestEffort:              true,
+			OnApplyError: func(name, value string, err error) {
+				logutil.BgLogger().Warn(
+					"mv service: failed to apply refresh session var from global setting, fallback to current session value",
+					zap.String("var", name),
+					zap.String("value", value),
+					zap.Error(err),
+				)
+			},
+			OnRestoreError: func(name, originValue, currentValue string, err error) {
+				logutil.BgLogger().Warn(
+					"mv service: failed to restore refresh session var after refresh",
+					zap.String("var", name),
+					zap.String("origin", originValue),
+					zap.String("current", currentValue),
+					zap.Error(err),
+				)
+			},
+		},
+	)
 }
 
 // PurgeMVLog runs one auto-purge round for the specified MV log ID.

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -88,18 +88,41 @@ func (recordingSessionPool) Close()                         {}
 
 type recordingSessionContext struct {
 	*mock.Context
-	executedSQL             []string
-	execErrs                map[string]error
-	executedRestrictedSQL   []string
-	executedRestrictedArg   [][]any
-	restrictedMaintainQuota []int64
-	restrictedMaxThreads    []int64
-	restrictedStreamCount   []int64
-	restrictedBatchSize     []uint64
-	restrictedRows          map[string][]chunk.Row
-	restrictedErrs          map[string]error
-	restrictedAffectedRows  map[string][]uint64
-	restrictedAffectedPos   map[string]int
+	executedSQL                          []string
+	execErrs                             map[string]error
+	executedRestrictedSQL                []string
+	executedRestrictedArg                [][]any
+	restrictedMaintainQuota              []int64
+	restrictedMaxThreads                 []int64
+	restrictedMaxBytesBeforeExternalJoin []int64
+	restrictedMaxBytesBeforeExternalAgg  []int64
+	restrictedMaxBytesBeforeExternalSort []int64
+	restrictedMemQuotaQueryPerNode       []int64
+	restrictedQuerySpillRatio            []float64
+	restrictedStreamCount                []int64
+	restrictedBatchSize                  []uint64
+	restrictedImportThreads              []int
+	restrictedImportDiskQuota            []string
+	restrictedRows                       map[string][]chunk.Row
+	restrictedErrs                       map[string]error
+	restrictedAffectedRows               map[string][]uint64
+	restrictedAffectedPos                map[string]int
+}
+
+type faultyGlobalAccessor struct {
+	*variable.MockGlobalAccessor
+	getErrs map[string]error
+	getVals map[string]string
+}
+
+func (a *faultyGlobalAccessor) GetGlobalSysVar(name string) (string, error) {
+	if err, ok := a.getErrs[name]; ok {
+		return "", err
+	}
+	if val, ok := a.getVals[name]; ok {
+		return val, nil
+	}
+	return a.MockGlobalAccessor.GetGlobalSysVar(name)
 }
 
 type mockCurrentVersionStore struct {
@@ -149,8 +172,15 @@ func (s *recordingSessionContext) ExecRestrictedSQL(_ context.Context, _ []sqlex
 	s.executedRestrictedArg = append(s.executedRestrictedArg, argsCopy)
 	s.restrictedMaintainQuota = append(s.restrictedMaintainQuota, s.GetSessionVars().MVMaintainMemQuota)
 	s.restrictedMaxThreads = append(s.restrictedMaxThreads, s.GetSessionVars().TiFlashMaxThreads)
+	s.restrictedMaxBytesBeforeExternalJoin = append(s.restrictedMaxBytesBeforeExternalJoin, s.GetSessionVars().TiFlashMaxBytesBeforeExternalJoin)
+	s.restrictedMaxBytesBeforeExternalAgg = append(s.restrictedMaxBytesBeforeExternalAgg, s.GetSessionVars().TiFlashMaxBytesBeforeExternalGroupBy)
+	s.restrictedMaxBytesBeforeExternalSort = append(s.restrictedMaxBytesBeforeExternalSort, s.GetSessionVars().TiFlashMaxBytesBeforeExternalSort)
+	s.restrictedMemQuotaQueryPerNode = append(s.restrictedMemQuotaQueryPerNode, s.GetSessionVars().TiFlashMaxQueryMemoryPerNode)
+	s.restrictedQuerySpillRatio = append(s.restrictedQuerySpillRatio, s.GetSessionVars().TiFlashQuerySpillRatio)
 	s.restrictedStreamCount = append(s.restrictedStreamCount, s.GetSessionVars().TiFlashFineGrainedShuffleStreamCount)
 	s.restrictedBatchSize = append(s.restrictedBatchSize, s.GetSessionVars().TiFlashFineGrainedShuffleBatchSize)
+	s.restrictedImportThreads = append(s.restrictedImportThreads, s.GetSessionVars().MViewMaintainImportThreads)
+	s.restrictedImportDiskQuota = append(s.restrictedImportDiskQuota, s.GetSessionVars().MViewMaintainImportDiskQuota)
 	if seq, ok := s.restrictedAffectedRows[sql]; ok {
 		pos := s.restrictedAffectedPos[sql]
 		if pos < len(seq) {
@@ -1733,12 +1763,26 @@ func TestServerHelperRefreshMVUsesGlobalRefreshSessionVars(t *testing.T) {
 	vars.GlobalVarsAccessor = mockGlobalAccessor
 	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBMVMaintainMemQuota, "536870912"))
 	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBMaxTiFlashThreads, "8"))
+	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBMaxBytesBeforeTiFlashExternalJoin, "111"))
+	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBMaxBytesBeforeTiFlashExternalGroupBy, "222"))
+	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBMaxBytesBeforeTiFlashExternalSort, "333"))
+	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiFlashMemQuotaQueryPerNode, "444"))
+	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiFlashQuerySpillRatio, "0.25"))
 	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiFlashFineGrainedShuffleStreamCount, "16"))
 	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiFlashFineGrainedShuffleBatchSize, "4096"))
+	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBMViewMaintainImportThreads, "12"))
+	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBMViewMaintainImportDiskQuota, "64gib"))
 	require.NoError(t, vars.SetSystemVar(variable.TiDBMVMaintainMemQuota, "268435456"))
 	require.NoError(t, vars.SetSystemVar(variable.TiDBMaxTiFlashThreads, "2"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMaxBytesBeforeTiFlashExternalJoin, "101"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMaxBytesBeforeTiFlashExternalGroupBy, "202"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMaxBytesBeforeTiFlashExternalSort, "303"))
+	require.NoError(t, vars.SetSystemVar(variable.TiFlashMemQuotaQueryPerNode, "404"))
+	require.NoError(t, vars.SetSystemVar(variable.TiFlashQuerySpillRatio, "0.75"))
 	require.NoError(t, vars.SetSystemVar(variable.TiFlashFineGrainedShuffleStreamCount, "4"))
 	require.NoError(t, vars.SetSystemVar(variable.TiFlashFineGrainedShuffleBatchSize, "1024"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMViewMaintainImportThreads, "3"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMViewMaintainImportDiskQuota, "8gib"))
 
 	nextRefresh, err := (&serviceHelper{}).RefreshMV(context.Background(), pool, 101)
 	require.NoError(t, err)
@@ -1749,12 +1793,108 @@ func TestServerHelperRefreshMVUsesGlobalRefreshSessionVars(t *testing.T) {
 	}, se.executedRestrictedSQL)
 	require.Equal(t, []int64{536870912, 536870912}, se.restrictedMaintainQuota)
 	require.Equal(t, []int64{8, 8}, se.restrictedMaxThreads)
+	require.Equal(t, []int64{111, 111}, se.restrictedMaxBytesBeforeExternalJoin)
+	require.Equal(t, []int64{222, 222}, se.restrictedMaxBytesBeforeExternalAgg)
+	require.Equal(t, []int64{333, 333}, se.restrictedMaxBytesBeforeExternalSort)
+	require.Equal(t, []int64{444, 444}, se.restrictedMemQuotaQueryPerNode)
+	require.Equal(t, []float64{0.25, 0.25}, se.restrictedQuerySpillRatio)
 	require.Equal(t, []int64{16, 16}, se.restrictedStreamCount)
 	require.Equal(t, []uint64{4096, 4096}, se.restrictedBatchSize)
+	require.Equal(t, []int{12, 12}, se.restrictedImportThreads)
+	require.Equal(t, []string{"64gib", "64gib"}, se.restrictedImportDiskQuota)
 	require.Equal(t, int64(268435456), vars.MVMaintainMemQuota)
 	require.Equal(t, int64(2), vars.TiFlashMaxThreads)
+	require.Equal(t, int64(101), vars.TiFlashMaxBytesBeforeExternalJoin)
+	require.Equal(t, int64(202), vars.TiFlashMaxBytesBeforeExternalGroupBy)
+	require.Equal(t, int64(303), vars.TiFlashMaxBytesBeforeExternalSort)
+	require.Equal(t, int64(404), vars.TiFlashMaxQueryMemoryPerNode)
+	require.Equal(t, float64(0.75), vars.TiFlashQuerySpillRatio)
 	require.Equal(t, int64(4), vars.TiFlashFineGrainedShuffleStreamCount)
 	require.Equal(t, uint64(1024), vars.TiFlashFineGrainedShuffleBatchSize)
+	require.Equal(t, 3, vars.MViewMaintainImportThreads)
+	require.Equal(t, "8gib", vars.MViewMaintainImportDiskQuota)
+}
+
+func TestServerHelperRefreshMVBestEffortWhenGlobalSessionVarsUnavailable(t *testing.T) {
+	installMockTimeForTest(t)
+
+	se := newRecordingSessionContext()
+	expectedNextRefresh := mvsNow().Add(time.Minute).Round(0)
+	se.restrictedRows[testSQLFindMVNextTime] = []chunk.Row{
+		chunk.MutRowFromDatums([]types.Datum{
+			types.NewIntDatum(expectedNextRefresh.Unix()),
+		}).ToRow(),
+	}
+	mvTable := &meta.TableInfo{
+		ID:    101,
+		Name:  pmodel.NewCIStr("mv1"),
+		State: meta.StatePublic,
+	}
+	withMockInfoSchema(t, mvTable)
+	pool := recordingSessionPool{se: se}
+
+	vars := se.GetSessionVars()
+	baseAccessor := variable.NewMockGlobalAccessor4Tests()
+	baseAccessor.SessionVars = vars
+	vars.GlobalVarsAccessor = &faultyGlobalAccessor{
+		MockGlobalAccessor: baseAccessor,
+		getErrs: map[string]error{
+			variable.TiDBMaxTiFlashThreads: errors.New("mock global read failure"),
+		},
+		getVals: map[string]string{
+			variable.TiDBMVMaintainMemQuota:                   "536870912",
+			variable.TiDBMaxBytesBeforeTiFlashExternalJoin:    "111",
+			variable.TiDBMaxBytesBeforeTiFlashExternalGroupBy: "222",
+			variable.TiDBMaxBytesBeforeTiFlashExternalSort:    "333",
+			variable.TiFlashMemQuotaQueryPerNode:              "444",
+			variable.TiFlashQuerySpillRatio:                   "not-a-float",
+			variable.TiFlashFineGrainedShuffleStreamCount:     "16",
+			variable.TiFlashFineGrainedShuffleBatchSize:       "4096",
+			variable.TiDBMViewMaintainImportThreads:           "12",
+			variable.TiDBMViewMaintainImportDiskQuota:         "bad-quota",
+		},
+	}
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMVMaintainMemQuota, "268435456"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMaxTiFlashThreads, "2"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMaxBytesBeforeTiFlashExternalJoin, "101"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMaxBytesBeforeTiFlashExternalGroupBy, "202"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMaxBytesBeforeTiFlashExternalSort, "303"))
+	require.NoError(t, vars.SetSystemVar(variable.TiFlashMemQuotaQueryPerNode, "404"))
+	require.NoError(t, vars.SetSystemVar(variable.TiFlashQuerySpillRatio, "0.75"))
+	require.NoError(t, vars.SetSystemVar(variable.TiFlashFineGrainedShuffleStreamCount, "4"))
+	require.NoError(t, vars.SetSystemVar(variable.TiFlashFineGrainedShuffleBatchSize, "1024"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMViewMaintainImportThreads, "3"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMViewMaintainImportDiskQuota, "8gib"))
+
+	nextRefresh, err := (&serviceHelper{}).RefreshMV(context.Background(), pool, 101)
+	require.NoError(t, err)
+	require.Equal(t, expectedNextRefresh.Unix(), nextRefresh.Unix())
+	require.Equal(t, []string{
+		testSQLRefreshMV,
+		testSQLFindMVNextTime,
+	}, se.executedRestrictedSQL)
+	require.Equal(t, []int64{536870912, 536870912}, se.restrictedMaintainQuota)
+	require.Equal(t, []int64{2, 2}, se.restrictedMaxThreads)
+	require.Equal(t, []int64{111, 111}, se.restrictedMaxBytesBeforeExternalJoin)
+	require.Equal(t, []int64{222, 222}, se.restrictedMaxBytesBeforeExternalAgg)
+	require.Equal(t, []int64{333, 333}, se.restrictedMaxBytesBeforeExternalSort)
+	require.Equal(t, []int64{444, 444}, se.restrictedMemQuotaQueryPerNode)
+	require.Equal(t, []float64{0.75, 0.75}, se.restrictedQuerySpillRatio)
+	require.Equal(t, []int64{16, 16}, se.restrictedStreamCount)
+	require.Equal(t, []uint64{4096, 4096}, se.restrictedBatchSize)
+	require.Equal(t, []int{12, 12}, se.restrictedImportThreads)
+	require.Equal(t, []string{"8gib", "8gib"}, se.restrictedImportDiskQuota)
+	require.Equal(t, int64(268435456), vars.MVMaintainMemQuota)
+	require.Equal(t, int64(2), vars.TiFlashMaxThreads)
+	require.Equal(t, int64(101), vars.TiFlashMaxBytesBeforeExternalJoin)
+	require.Equal(t, int64(202), vars.TiFlashMaxBytesBeforeExternalGroupBy)
+	require.Equal(t, int64(303), vars.TiFlashMaxBytesBeforeExternalSort)
+	require.Equal(t, int64(404), vars.TiFlashMaxQueryMemoryPerNode)
+	require.Equal(t, float64(0.75), vars.TiFlashQuerySpillRatio)
+	require.Equal(t, int64(4), vars.TiFlashFineGrainedShuffleStreamCount)
+	require.Equal(t, uint64(1024), vars.TiFlashFineGrainedShuffleBatchSize)
+	require.Equal(t, 3, vars.MViewMaintainImportThreads)
+	require.Equal(t, "8gib", vars.MViewMaintainImportDiskQuota)
 }
 
 func TestServerHelperRefreshMVDeletedWhenNextTimeNotFound(t *testing.T) {
@@ -1852,6 +1992,36 @@ func TestServerHelperPurgeMVLogUsesGlobalMaintainMemQuota(t *testing.T) {
 	require.False(t, nextPurge.IsZero())
 	require.Equal(t, testExpectedPurgeMVLogSQL, se.executedRestrictedSQL)
 	require.Equal(t, []int64{536870912, 536870912}, se.restrictedMaintainQuota)
+	require.Equal(t, int64(268435456), vars.MVMaintainMemQuota)
+}
+
+func TestServerHelperPurgeMVLogBestEffortWhenGlobalMaintainMemQuotaUnavailable(t *testing.T) {
+	installMockTimeForTest(t)
+	se := newRecordingSessionContext()
+	nextTimeRows := []chunk.Row{
+		chunk.MutRowFromDatums([]types.Datum{
+			types.NewIntDatum(mvsNow().Add(time.Minute).Unix()),
+		}).ToRow(),
+	}
+	setupPurgeMVLogMetaForTest(t, se, nextTimeRows)
+
+	pool := recordingSessionPool{se: se}
+	vars := se.GetSessionVars()
+	baseAccessor := variable.NewMockGlobalAccessor4Tests()
+	baseAccessor.SessionVars = vars
+	vars.GlobalVarsAccessor = &faultyGlobalAccessor{
+		MockGlobalAccessor: baseAccessor,
+		getErrs: map[string]error{
+			variable.TiDBMVMaintainMemQuota: errors.New("mock global read failure"),
+		},
+	}
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMVMaintainMemQuota, "268435456"))
+
+	nextPurge, err := (&serviceHelper{}).PurgeMVLog(context.Background(), pool, 201)
+	require.NoError(t, err)
+	require.False(t, nextPurge.IsZero())
+	require.Equal(t, testExpectedPurgeMVLogSQL, se.executedRestrictedSQL)
+	require.Equal(t, []int64{268435456, 268435456}, se.restrictedMaintainQuota)
 	require.Equal(t, int64(268435456), vars.MVMaintainMemQuota)
 }
 

--- a/pkg/sessionctx/variable/variable.go
+++ b/pkg/sessionctx/variable/variable.go
@@ -27,6 +27,224 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+// MViewExecutionSessionVars captures the execution-scoped session variables shared by MV build,
+// refresh, and mvservice maintenance orchestration.
+type MViewExecutionSessionVars struct {
+	MaintainMemQuota             int64
+	TiFlashMaxThreads            int64
+	TiFlashMaxBytesBeforeExtJoin int64
+	TiFlashMaxBytesBeforeExtAgg  int64
+	TiFlashMaxBytesBeforeExtSort int64
+	TiFlashMemQuotaQueryPerNode  int64
+	TiFlashQuerySpillRatio       float64
+	FineGrainedStreamCount       int64
+	FineGrainedBatchSize         uint64
+	ImportThreads                int
+	ImportDiskQuota              string
+}
+
+// MViewExecutionSessionVarsApplyConfig describes how MV execution vars should be applied onto a
+// session. The caller chooses which mem-quota sysvar should receive MaintainMemQuota and how apply
+// / restore errors should be reported.
+type MViewExecutionSessionVarsApplyConfig struct {
+	MaintainMemQuotaVarName string
+	CaptureAppliedVars      func(*SessionVars) MViewExecutionSessionVars
+	BestEffort              bool
+	InjectApplyError        func(string) error
+	OnApplyError            func(name, value string, err error)
+	OnRestoreError          func(name, originValue, currentValue string, err error)
+}
+
+type mViewExecutionSessionVarAssignment struct {
+	name           string
+	value          string
+	failureMessage string
+}
+
+// CaptureMViewExecutionSessionVars captures the user-facing MV execution knobs that should be
+// inherited by a later MV build/refresh job.
+func CaptureMViewExecutionSessionVars(sessVars *SessionVars) MViewExecutionSessionVars {
+	if sessVars == nil {
+		return MViewExecutionSessionVars{}
+	}
+	return MViewExecutionSessionVars{
+		MaintainMemQuota:             sessVars.MVMaintainMemQuota,
+		TiFlashMaxThreads:            sessVars.TiFlashMaxThreads,
+		TiFlashMaxBytesBeforeExtJoin: sessVars.TiFlashMaxBytesBeforeExternalJoin,
+		TiFlashMaxBytesBeforeExtAgg:  sessVars.TiFlashMaxBytesBeforeExternalGroupBy,
+		TiFlashMaxBytesBeforeExtSort: sessVars.TiFlashMaxBytesBeforeExternalSort,
+		TiFlashMemQuotaQueryPerNode:  sessVars.TiFlashMaxQueryMemoryPerNode,
+		TiFlashQuerySpillRatio:       sessVars.TiFlashQuerySpillRatio,
+		FineGrainedStreamCount:       sessVars.TiFlashFineGrainedShuffleStreamCount,
+		FineGrainedBatchSize:         sessVars.TiFlashFineGrainedShuffleBatchSize,
+		ImportThreads:                sessVars.MViewMaintainImportThreads,
+		ImportDiskQuota:              sessVars.MViewMaintainImportDiskQuota,
+	}
+}
+
+// CaptureAppliedMViewExecutionSessionVars captures the execution-related values that are currently
+// in effect on a session after MV execution vars have been applied to tidb_mem_quota_query.
+func CaptureAppliedMViewExecutionSessionVars(sessVars *SessionVars) MViewExecutionSessionVars {
+	if sessVars == nil {
+		return MViewExecutionSessionVars{}
+	}
+	return MViewExecutionSessionVars{
+		MaintainMemQuota:             sessVars.MemQuotaQuery,
+		TiFlashMaxThreads:            sessVars.TiFlashMaxThreads,
+		TiFlashMaxBytesBeforeExtJoin: sessVars.TiFlashMaxBytesBeforeExternalJoin,
+		TiFlashMaxBytesBeforeExtAgg:  sessVars.TiFlashMaxBytesBeforeExternalGroupBy,
+		TiFlashMaxBytesBeforeExtSort: sessVars.TiFlashMaxBytesBeforeExternalSort,
+		TiFlashMemQuotaQueryPerNode:  sessVars.TiFlashMaxQueryMemoryPerNode,
+		TiFlashQuerySpillRatio:       sessVars.TiFlashQuerySpillRatio,
+		FineGrainedStreamCount:       sessVars.TiFlashFineGrainedShuffleStreamCount,
+		FineGrainedBatchSize:         sessVars.TiFlashFineGrainedShuffleBatchSize,
+		ImportThreads:                sessVars.MViewMaintainImportThreads,
+		ImportDiskQuota:              sessVars.MViewMaintainImportDiskQuota,
+	}
+}
+
+// ApplyMViewExecutionSessionVarsWithConfig applies MV execution vars onto a session and returns a
+// restore closure. In best-effort mode, individual apply failures fall back to the session's
+// current value for that variable while keeping successfully applied variables in effect.
+func ApplyMViewExecutionSessionVarsWithConfig(
+	sessVars *SessionVars,
+	target MViewExecutionSessionVars,
+	cfg MViewExecutionSessionVarsApplyConfig,
+) (func(), error) {
+	if sessVars == nil {
+		return nil, errors.New("mv execution: session vars is nil")
+	}
+
+	captureApplied := cfg.CaptureAppliedVars
+	if captureApplied == nil {
+		captureApplied = CaptureMViewExecutionSessionVars
+	}
+	maintainMemQuotaVarName := cfg.MaintainMemQuotaVarName
+	if maintainMemQuotaVarName == "" {
+		maintainMemQuotaVarName = TiDBMVMaintainMemQuota
+	}
+
+	origin := captureApplied(sessVars)
+	if origin == target {
+		return func() {}, nil
+	}
+
+	for _, assignment := range buildMViewExecutionSessionVarAssignments(target, maintainMemQuotaVarName) {
+		err := error(nil)
+		if cfg.InjectApplyError != nil {
+			err = cfg.InjectApplyError(assignment.name)
+		}
+		if err == nil {
+			err = sessVars.SetSystemVar(assignment.name, assignment.value)
+		}
+		if err == nil {
+			continue
+		}
+		if !cfg.BestEffort {
+			restoreMViewExecutionSessionVars(
+				sessVars,
+				origin,
+				captureApplied(sessVars),
+				maintainMemQuotaVarName,
+				cfg.OnRestoreError,
+			)
+			return nil, errors.Annotate(err, assignment.failureMessage)
+		}
+		if cfg.OnApplyError != nil {
+			cfg.OnApplyError(assignment.name, assignment.value, err)
+		}
+	}
+
+	applied := captureApplied(sessVars)
+	return func() {
+		restoreMViewExecutionSessionVars(
+			sessVars,
+			origin,
+			applied,
+			maintainMemQuotaVarName,
+			cfg.OnRestoreError,
+		)
+	}, nil
+}
+
+func buildMViewExecutionSessionVarAssignments(
+	target MViewExecutionSessionVars,
+	maintainMemQuotaVarName string,
+) []mViewExecutionSessionVarAssignment {
+	return []mViewExecutionSessionVarAssignment{
+		{
+			name:           maintainMemQuotaVarName,
+			value:          strconv.FormatInt(target.MaintainMemQuota, 10),
+			failureMessage: "mv execution: failed to apply maintain mem quota",
+		},
+		{
+			name:           TiDBMaxTiFlashThreads,
+			value:          strconv.FormatInt(target.TiFlashMaxThreads, 10),
+			failureMessage: "mv execution: failed to apply tidb_max_tiflash_threads",
+		},
+		{
+			name:           TiDBMaxBytesBeforeTiFlashExternalJoin,
+			value:          strconv.FormatInt(target.TiFlashMaxBytesBeforeExtJoin, 10),
+			failureMessage: "mv execution: failed to apply tidb_max_bytes_before_tiflash_external_join",
+		},
+		{
+			name:           TiDBMaxBytesBeforeTiFlashExternalGroupBy,
+			value:          strconv.FormatInt(target.TiFlashMaxBytesBeforeExtAgg, 10),
+			failureMessage: "mv execution: failed to apply tidb_max_bytes_before_tiflash_external_group_by",
+		},
+		{
+			name:           TiDBMaxBytesBeforeTiFlashExternalSort,
+			value:          strconv.FormatInt(target.TiFlashMaxBytesBeforeExtSort, 10),
+			failureMessage: "mv execution: failed to apply tidb_max_bytes_before_tiflash_external_sort",
+		},
+		{
+			name:           TiFlashMemQuotaQueryPerNode,
+			value:          strconv.FormatInt(target.TiFlashMemQuotaQueryPerNode, 10),
+			failureMessage: "mv execution: failed to apply tiflash_mem_quota_query_per_node",
+		},
+		{
+			name:           TiFlashQuerySpillRatio,
+			value:          strconv.FormatFloat(target.TiFlashQuerySpillRatio, 'f', -1, 64),
+			failureMessage: "mv execution: failed to apply tiflash_query_spill_ratio",
+		},
+		{
+			name:           TiFlashFineGrainedShuffleStreamCount,
+			value:          strconv.FormatInt(target.FineGrainedStreamCount, 10),
+			failureMessage: "mv execution: failed to apply tiflash_fine_grained_shuffle_stream_count",
+		},
+		{
+			name:           TiFlashFineGrainedShuffleBatchSize,
+			value:          strconv.FormatUint(target.FineGrainedBatchSize, 10),
+			failureMessage: "mv execution: failed to apply tiflash_fine_grained_shuffle_batch_size",
+		},
+		{
+			name:           TiDBMViewMaintainImportThreads,
+			value:          strconv.Itoa(target.ImportThreads),
+			failureMessage: "mv execution: failed to apply tidb_mview_maintain_import_threads",
+		},
+		{
+			name:           TiDBMViewMaintainImportDiskQuota,
+			value:          target.ImportDiskQuota,
+			failureMessage: "mv execution: failed to apply tidb_mview_maintain_import_disk_quota",
+		},
+	}
+}
+
+func restoreMViewExecutionSessionVars(
+	sessVars *SessionVars,
+	origin, current MViewExecutionSessionVars,
+	maintainMemQuotaVarName string,
+	onRestoreError func(name, originValue, currentValue string, err error),
+) {
+	originAssignments := buildMViewExecutionSessionVarAssignments(origin, maintainMemQuotaVarName)
+	currentAssignments := buildMViewExecutionSessionVarAssignments(current, maintainMemQuotaVarName)
+	for idx, assignment := range originAssignments {
+		if err := sessVars.SetSystemVar(assignment.name, assignment.value); err != nil && onRestoreError != nil {
+			onRestoreError(assignment.name, assignment.value, currentAssignments[idx].value, err)
+		}
+	}
+}
+
 // ScopeFlag is for system variable whether can be changed in global/session dynamically or not.
 type ScopeFlag uint8
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

This PR backports two MV-related changes to the release materialized view branch:

1. Fix privilege checking for altering materialized view and materialized view log schedule next time.
2. Refactor MV execution session variable handling and propagate execution variables consistently for MV init build and complete out-of-place import.

### What changed and how does it work?

This PR fixes the privilege check path for `ALTER MATERIALIZED VIEW ... REFRESH` and `ALTER MATERIALIZED VIEW LOG ... PURGE` schedule changes so the DDL validates privileges against the correct object and operation.

It also refactors MV maintenance execution variable handling into shared helper logic. User-triggered MV operations inherit the relevant execution session variables from the user session, while MV service background jobs derive them from global variables. The same execution variable propagation is applied to MV init build and complete out-of-place import, so these internal sessions use consistent memory quota, TiFlash, spill, and import-related settings.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix privilege checking for MV schedule changes and make MV maintenance execution session variable propagation consistent.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive materialized-view execution session variable support and apply/restore helpers.
  * Import tuning exposed: import threads and disk-quota options now customizable and used by refresh/create flows.
  * Internal session handling improved for refresh scheduling and observe operations.

* **Bug Fixes**
  * Session-var application switched to best-effort mode to avoid hard failures when globals are unavailable.

* **Tests**
  * Expanded and added tests covering import options, refresh paths, privilege cases, and best-effort behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->