### PR TITLE
executor: fix RUv2 DML written row accounting

### DIFF
--- a/pkg/executor/adapter_test.go
+++ b/pkg/executor/adapter_test.go
@@ -909,6 +909,15 @@ func TestInsertRowsColMultiplyRUV2SQLPath(t *testing.T) {
 	require.Equal(t, int64(4), runInsert("insert into t(a, c) values (3, 5), (4, 6)"))
 	require.Equal(t, int64(4), runInsert("insert into t(a, b) select a, b from src"))
 
+	tk.MustExec("create table ignore_t(a int primary key, b int)")
+	tk.MustExec("insert into ignore_t values (1, 1)")
+	require.Equal(t, int64(2), runInsert("insert ignore into ignore_t values (1, 10), (2, 20)"))
+
+	tk.MustExec("create table dup_update_t(a int primary key, b int)")
+	tk.MustExec("insert into dup_update_t values (1, 1)")
+	require.Equal(t, int64(0), runInsert("insert into dup_update_t values (1, 1) on duplicate key update b = values(b)"))
+	require.Equal(t, int64(2), runInsert("insert into dup_update_t values (1, 2) on duplicate key update b = values(b)"))
+
 	oldEnableBatchDML := vardef.EnableBatchDML.Load()
 	vardef.EnableBatchDML.Store(true)
 	defer vardef.EnableBatchDML.Store(oldEnableBatchDML)
@@ -948,6 +957,17 @@ func TestDMLRowsColMultiplyRUV2SQLPath(t *testing.T) {
 	require.Equal(t, int64(6), runDML("replace into t values (1, 2, 3), (2, 3, 4)"))
 	require.Equal(t, int64(6), runDML("update t set b = b + 10 where a in (1, 2)"))
 	require.Equal(t, int64(3), runDML("delete from t where a = 1"))
+
+	tk.MustExec("create table update_actual_t(a int primary key, b int unique)")
+	tk.MustExec("insert into update_actual_t values (1, 1), (2, 2)")
+	require.Equal(t, int64(0), runDML("update update_actual_t set b = b where a = 1"))
+	require.Equal(t, int64(0), runDML("update ignore update_actual_t set b = 1 where a = 2"))
+	require.Equal(t, int64(2), runDML("update update_actual_t set b = 3 where a = 2"))
+
+	tk.MustExec("create table replace_actual_t(a int primary key, b int)")
+	tk.MustExec("insert into replace_actual_t values (1, 1)")
+	require.Equal(t, int64(0), runDML("replace into replace_actual_t values (1, 1)"))
+	require.Equal(t, int64(2), runDML("replace into replace_actual_t values (1, 2)"))
 
 	tk.MustExec("create table multi_del_l(a int primary key)")
 	tk.MustExec("create table multi_del_r(a int primary key)")

--- a/pkg/executor/delete.go
+++ b/pkg/executor/delete.go
@@ -55,7 +55,7 @@ type DeleteExec struct {
 	ignoreErr bool
 }
 
-func addDeleteRowsColMultiply(total, delta int64) int64 {
+func addDMLRowsColMultiply(total, delta int64) int64 {
 	if delta <= 0 || total == math.MaxInt64 {
 		return total
 	}
@@ -168,7 +168,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			rowsColMultiply = addDeleteRowsColMultiply(rowsColMultiply, int64(columnCount))
+			rowsColMultiply = addDMLRowsColMultiply(rowsColMultiply, int64(columnCount))
 			rowCount++
 			datumRow = datumRow[:0]
 		}
@@ -286,7 +286,7 @@ func (e *DeleteExec) removeRowsInTblRowMap(ctx context.Context, tblRowMap tableR
 			if err != nil {
 				return false
 			}
-			rowsColMultiply = addDeleteRowsColMultiply(rowsColMultiply, int64(len(val.handleVal)))
+			rowsColMultiply = addDMLRowsColMultiply(rowsColMultiply, int64(len(val.handleVal)))
 			return true
 		})
 		if err != nil {

--- a/pkg/executor/explain_unit_test.go
+++ b/pkg/executor/explain_unit_test.go
@@ -54,11 +54,10 @@ func TestInsertRowsColMultiplyRUV2Metrics(t *testing.T) {
 
 	insertValues := &InsertValues{
 		BaseExecutor:              exec.NewBaseExecutor(ctx, nil, 0),
-		rowCount:                  4,
 		recordRUV2RowsColMultiply: true,
 		insertColumns:             make([]*table.Column, 3),
 	}
-	require.Equal(t, int64(12), insertValues.rowsColMultiply())
+	insertValues.addWrittenRowsColMultiply(4)
 
 	insertValues.recordRowsColMultiply2RUV2Metrics()
 	require.Equal(t, int64(12), ctx.GetSessionVars().RUV2Metrics.ExecutorL5InsertRows())
@@ -66,7 +65,7 @@ func TestInsertRowsColMultiplyRUV2Metrics(t *testing.T) {
 	insertValues.recordRowsColMultiply2RUV2Metrics()
 	require.Equal(t, int64(12), ctx.GetSessionVars().RUV2Metrics.ExecutorL5InsertRows())
 
-	insertValues.rowCount = 5
+	insertValues.addWrittenRowsColMultiply(1)
 	insertValues.recordRowsColMultiply2RUV2Metrics()
 	require.Equal(t, int64(15), ctx.GetSessionVars().RUV2Metrics.ExecutorL5InsertRows())
 }

--- a/pkg/executor/insert.go
+++ b/pkg/executor/insert.go
@@ -521,7 +521,7 @@ func (e *InsertExec) doDupRowUpdate(
 	}
 
 	newData := e.row4Update[:len(oldRow)]
-	_, ignored, err := updateRecord(
+	changed, ignored, err := updateRecord(
 		ctx, e.Ctx(),
 		handle, oldRow, newData,
 		0, generated, e.evalBuffer4Dup, errorHandler,
@@ -534,6 +534,9 @@ func (e *InsertExec) doDupRowUpdate(
 
 	if err != nil {
 		return errors.Trace(err)
+	}
+	if changed {
+		e.addWrittenRowsColMultiply(1)
 	}
 
 	if autoColIdx >= 0 {

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -60,6 +60,7 @@ type InsertValues struct {
 	maxRowsInBatch              uint64
 	lastInsertID                uint64
 	recordRUV2RowsColMultiply   bool
+	ruv2RowsColMultiply         int64
 	ruv2RecordedRowsColMultiply int64
 
 	SelectExec exec.Executor
@@ -101,24 +102,28 @@ type InsertValues struct {
 	ignoreErr bool
 }
 
-func (e *InsertValues) rowsColMultiply() int64 {
-	colCount := len(e.insertColumns)
-	if e.rowCount == 0 || colCount == 0 {
-		return 0
+func (e *InsertValues) addWrittenRowsColMultiply(rowCount int64) {
+	if !e.recordRUV2RowsColMultiply {
+		return
 	}
-
-	const maxInt64 = uint64(1<<63 - 1)
-	if e.rowCount > maxInt64/uint64(colCount) {
-		return int64(maxInt64)
+	colCount := int64(len(e.insertColumns))
+	if rowCount <= 0 || colCount <= 0 {
+		return
 	}
-	return int64(e.rowCount * uint64(colCount))
+	rowsColMultiply := int64(math.MaxInt64)
+	if rowCount > math.MaxInt64/colCount {
+		rowsColMultiply = math.MaxInt64
+	} else {
+		rowsColMultiply = rowCount * colCount
+	}
+	e.ruv2RowsColMultiply = addDMLRowsColMultiply(e.ruv2RowsColMultiply, rowsColMultiply)
 }
 
 func (e *InsertValues) recordRowsColMultiply2RUV2Metrics() {
 	if !e.recordRUV2RowsColMultiply {
 		return
 	}
-	current := e.rowsColMultiply()
+	current := e.ruv2RowsColMultiply
 	delta := current - e.ruv2RecordedRowsColMultiply
 	if delta <= 0 {
 		return
@@ -1482,6 +1487,7 @@ func (e *InsertValues) addRecordWithAutoIDHint(
 	if e.lastInsertID != 0 {
 		vars.SetLastInsertID(e.lastInsertID)
 	}
+	e.addWrittenRowsColMultiply(1)
 	if dupKeyCheck != table.DupKeyCheckSkip {
 		for _, fkc := range e.fkChecks {
 			err = fkc.insertRowNeedToCheck(vars.StmtCtx, row)

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -110,11 +110,9 @@ func (e *InsertValues) addWrittenRowsColMultiply(rowCount int64) {
 	if rowCount <= 0 || colCount <= 0 {
 		return
 	}
-	rowsColMultiply := int64(math.MaxInt64)
+	rowsColMultiply := rowCount * colCount
 	if rowCount > math.MaxInt64/colCount {
 		rowsColMultiply = math.MaxInt64
-	} else {
-		rowsColMultiply = rowCount * colCount
 	}
 	e.ruv2RowsColMultiply = addDMLRowsColMultiply(e.ruv2RowsColMultiply, rowsColMultiply)
 }

--- a/pkg/executor/update.go
+++ b/pkg/executor/update.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math"
 	"runtime/trace"
 	"slices"
 
@@ -257,7 +256,7 @@ func (e *UpdateExec) exec(
 	_ *expression.Schema,
 	rowIdx int, row, newData []types.Datum,
 	dupKeyCheck table.DupKeyCheckMode,
-) error {
+) (int64, error) {
 	defer trace.StartRegion(ctx, "UpdateExec").End()
 	bAssignFlag := make([]bool, len(e.assignFlag))
 	for i, flag := range e.assignFlag {
@@ -269,6 +268,7 @@ func (e *UpdateExec) exec(
 	}
 
 	var totalMemDelta int64
+	var rowsColMultiply int64
 	defer func() { e.memTracker.Consume(totalMemDelta) }()
 
 	for i, content := range e.tblColPosInfos {
@@ -300,7 +300,7 @@ func (e *UpdateExec) exec(
 
 		// Copy data from merge row to old and new rows
 		if err := e.mergeGenerated(row, newData, i, true); err != nil {
-			return errors.Trace(err)
+			return 0, errors.Trace(err)
 		}
 
 		// Update row
@@ -315,7 +315,7 @@ func (e *UpdateExec) exec(
 
 		// Copy data from new row to merge row
 		if err := e.mergeGenerated(row, newData, i, false); err != nil {
-			return errors.Trace(err)
+			return 0, errors.Trace(err)
 		}
 
 		if ignored {
@@ -329,22 +329,27 @@ func (e *UpdateExec) exec(
 				memDelta += int64(handle.ExtraMemSize())
 			}
 			totalMemDelta += memDelta
+			if changed {
+				rowsColMultiply = addDMLRowsColMultiply(rowsColMultiply, int64(content.End-content.Start))
+			}
 			continue
 		}
 
 		if kv.ErrKeyExists.Equal(err) || table.ErrCheckConstraintViolated.Equal(err) {
 			ec := e.Ctx().GetSessionVars().StmtCtx.ErrCtx()
 			if err = ec.HandleErrorWithAlias(kv.ErrKeyExists, err, err); err != nil {
-				return err
+				return 0, err
 			}
 			continue
 		}
-		return err
+		return 0, err
 	}
 	if txn, _ := e.Ctx().Txn(false); txn != nil {
-		return txn.MayFlush()
+		if err := txn.MayFlush(); err != nil {
+			return 0, err
+		}
 	}
-	return nil
+	return rowsColMultiply, nil
 }
 
 // unmatchedOuterRow checks the tableCols of a record to decide whether that record
@@ -374,19 +379,6 @@ func (e *UpdateExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		recordDMLRowsColMultiply2Metrics(e.Ctx().GetSessionVars(), rowsColMultiply, 1)
 	}
 	return nil
-}
-
-func (e *UpdateExec) rowsColMultiplyForPreparedRow() int64 {
-	var columnCount int64
-	for i, content := range e.tblColPosInfos {
-		if i >= len(e.tableUpdatable) || !e.tableUpdatable[i] || i >= len(e.changed) || e.changed[i] {
-			continue
-		}
-		if content.End > content.Start {
-			columnCount += int64(content.End - content.Start)
-		}
-	}
-	return columnCount
 }
 
 func (e *UpdateExec) updateRows(ctx context.Context) (int, int64, error) {
@@ -458,12 +450,6 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, int64, error) {
 			if err := e.prepare(datumRow); err != nil {
 				return 0, 0, err
 			}
-			rowColMultiply := e.rowsColMultiplyForPreparedRow()
-			if rowsColMultiply > math.MaxInt64-rowColMultiply {
-				rowsColMultiply = math.MaxInt64
-			} else {
-				rowsColMultiply += rowColMultiply
-			}
 			// compose non-generated columns
 			newRow, err := composeFunc(globalRowIdx, datumRow, colsInfo)
 			if err != nil {
@@ -478,11 +464,13 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, int64, error) {
 				e.evalBuffer.SetDatums(newRow...)
 			}
 
-			if err := e.exec(
+			rowColMultiply, err := e.exec(
 				ctx, e.Children(0).Schema(),
-				globalRowIdx, datumRow, newRow, dupKeyCheck); err != nil {
+				globalRowIdx, datumRow, newRow, dupKeyCheck)
+			if err != nil {
 				return 0, 0, err
 			}
+			rowsColMultiply = addDMLRowsColMultiply(rowsColMultiply, rowColMultiply)
 			globalRowIdx++
 		}
 		totalNumRows += chk.NumRows()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69135

Problem Summary:

RUv2 DML row-column accounting can count attempted rows instead of rows that are actually written. No-op updates, no-op duplicate-key updates, identical-row `REPLACE`, rows skipped by `UPDATE IGNORE`, and ignored duplicate rows from `INSERT IGNORE` can add non-zero L5 row-column cost.

### What changed and how does it work?

This PR moves RUv2 row-column accumulation to successful write points:

- INSERT/REPLACE increments the accumulator after `AddRecord` succeeds.
- INSERT ... ON DUPLICATE KEY UPDATE increments it only when the duplicate update changes a row.
- UPDATE accumulates row-column cost after `updateRecord` reports an actual row change.
- The shared row-column overflow helper is reused across DML paths.

Regression tests cover `INSERT IGNORE`, no-op `UPDATE`, skipped `UPDATE IGNORE`, no-op and written `INSERT ... ON DUPLICATE KEY UPDATE`, identical and written `REPLACE`, and a normal written update.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded coverage for `INSERT IGNORE`, `INSERT ... ON DUPLICATE KEY UPDATE`, `UPDATE`, and `REPLACE` DML behaviors.

* **Bug Fixes**
  * Improved accuracy of row/column multiplication metrics tracking during insert and update execution, including correct handling of duplicate-key updates and no-op cases.

* **Tests**
  * Added/adjusted SQL scenarios and metric assertions to validate expected row-count outcomes and RUV2-related calculations.

* **Refactor**
  * Consolidated and standardized internal DML metric accumulation used across insert/delete/update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->