### PR TITLE
planner: check temporal FSP for plan cache params

### DIFF
--- a/pkg/planner/core/casetest/plancache/BUILD.bazel
+++ b/pkg/planner/core/casetest/plancache/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "//pkg/planner/core:plan_clone_utils.go",
     ],
     flaky = True,
-    shard_count = 46,
+    shard_count = 47,
     deps = [
         "//pkg/expression",
         "//pkg/infoschema",

--- a/pkg/planner/core/casetest/plancache/plan_cache_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_test.go
@@ -82,6 +82,52 @@ func TestDropPrepare(t *testing.T) {
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 }
 
+// TestPlanCacheTemporalParamFsp guards a correctness contract of the plan cache:
+// a temporal parameter's fractional-seconds precision (fsp) can be baked into
+// the cached plan's result type. Temporal values are rounded to that fsp at
+// evaluation time, so reusing a plan compiled for a datetime(0) param to serve a
+// datetime(6) param would round the value down to seconds and return a wrong
+// result. Hence the plan cache must treat a different temporal fsp as
+// type-incompatible.
+func TestPlanCacheTemporalParamFsp(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_enable_prepared_plan_cache=1")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int primary key, d0 datetime(0))")
+	tk.MustExec("insert into t values (1, null)") // d0 is NULL so the expressions return the param
+
+	for _, tc := range []struct {
+		name string
+		expr string
+	}{
+		{"ifnull", "ifnull(d0, ?)"},
+		{"if", "if(a = 0, d0, ?)"},
+		{"case", "case when a = 0 then d0 else ? end"},
+	} {
+		tk.MustExec("prepare st from 'select " + tc.expr + " from t where a = 1'")
+
+		// Prime the cache with a datetime(0) param: the result type fsp is fixed at 0.
+		tk.MustExec("set @p = cast('2024-01-01 12:34:56' as datetime(0))")
+		tk.MustQuery("execute st using @p")
+		tk.MustQuery("execute st using @p")
+		require.Equal(t, "1", tk.MustQuery("select @@last_plan_from_cache").Rows()[0][0],
+			tc.name+": statement should be plan-cacheable")
+
+		// Reuse with a datetime(6) param: the plan must NOT be reused, and the
+		// .789012 fraction must survive (a stale fsp=0 plan would round it away).
+		tk.MustExec("set @p = cast('2024-01-01 12:34:56.789012' as datetime(6))")
+		got := tk.MustQuery("execute st using @p").Rows()[0][0]
+		require.Equal(t, "0", tk.MustQuery("select @@last_plan_from_cache").Rows()[0][0],
+			tc.name+": cached plan must not be reused when the param fsp changes")
+		require.Equal(t, "2024-01-01 12:34:56.789012", got,
+			tc.name+": datetime(6) precision must be preserved")
+
+		tk.MustExec("deallocate prepare st")
+	}
+}
+
 func BenchmarkNewPlanCacheKey(b *testing.B) {
 	store := testkit.CreateMockStore(b)
 	tk := testkit.NewTestKit(b, store)

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -861,8 +861,9 @@ func checkTypesCompatibility4PC(expected, actual any) bool {
 		return false
 	}
 	for i := range tpsActual {
-		// We only use part of logic of `func (ft *FieldType) Equal(other *FieldType)` here because (1) only numeric and
-		// string types will show up here, and (2) we don't need flen and decimal to be matched exactly to use plan cache
+		// We only use part of the logic of `func (ft *FieldType) Equal(other *FieldType)` here:
+		// flen/decimal need not match exactly for most parameter types, but a few do need the
+		// extra checks below (decimal precision/scale, and the fsp of temporal types).
 		tpEqual := (tpsExpected[i].GetType() == tpsActual[i].GetType()) ||
 			(tpsExpected[i].GetType() == mysql.TypeVarchar && tpsActual[i].GetType() == mysql.TypeVarString) ||
 			(tpsExpected[i].GetType() == mysql.TypeVarString && tpsActual[i].GetType() == mysql.TypeVarchar)
@@ -874,6 +875,13 @@ func checkTypesCompatibility4PC(expected, actual any) bool {
 		// We can only use the plan when both Flen and Decimal should less equal than the cached one.
 		// We assume here that there is no correctness problem when the precision of the parameters is less than the precision of the parameters in the cache.
 		if tpEqual && tpsExpected[i].GetType() == mysql.TypeNewDecimal && !(tpsExpected[i].GetFlen() >= tpsActual[i].GetFlen() && tpsExpected[i].GetDecimal() >= tpsActual[i].GetDecimal()) {
+			return false
+		}
+		// Temporal types (datetime/timestamp/duration) carry fractional-seconds precision
+		// (fsp) in the Decimal field. A cached plan may bake a parameter's fsp into
+		// expression evaluation. Reusing it with a different current parameter fsp can
+		// round to the wrong precision, so require an exact fsp match here.
+		if tpEqual && types.IsTypeFractionable(tpsExpected[i].GetType()) && tpsExpected[i].GetDecimal() != tpsActual[i].GetDecimal() {
 			return false
 		}
 	}

--- a/tests/integrationtest/r/planner/core/plan_cache.result
+++ b/tests/integrationtest/r/planner/core/plan_cache.result
@@ -2835,3 +2835,126 @@ PREPARE stmt FROM 'SELECT a FROM t WHERE b=current_date()';
 EXECUTE stmt;
 a
 1
+set tidb_enable_prepared_plan_cache=1;
+set time_zone='+00:00';
+drop table if exists t_plan_cache_fsp;
+create table t_plan_cache_fsp (
+a int primary key,
+d0 datetime(0),
+ts0 timestamp(0) null,
+tm0 time(0)
+);
+insert into t_plan_cache_fsp values (1, null, null, null);
+select ifnull(d0, cast('2024-01-01 12:34:56.789012' as datetime(6))) as v from t_plan_cache_fsp where a = 1;
+v
+2024-01-01 12:34:56.789012
+prepare st_fsp from 'select ifnull(d0, ?) as v from t_plan_cache_fsp where a = 1';
+set @p = cast('2024-01-01 12:34:56' as datetime(0));
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+set @p = cast('2024-01-01 12:34:56.789012' as datetime(6));
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56.789012
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56.789012
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+set @p = cast('2024-01-01 12:34:56' as datetime(0));
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare st_fsp;
+prepare st_fsp from 'select if(a = 0, d0, ?) as v from t_plan_cache_fsp where a = 1';
+set @p = cast('2024-01-01 12:34:56' as datetime(0));
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+set @p = cast('2024-01-01 12:34:56.789012' as datetime(6));
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56.789012
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+deallocate prepare st_fsp;
+prepare st_fsp from 'select case when a = 0 then d0 else ? end as v from t_plan_cache_fsp where a = 1';
+set @p = cast('2024-01-01 12:34:56' as datetime(0));
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+set @p = cast('2024-01-01 12:34:56.789012' as datetime(6));
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56.789012
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+deallocate prepare st_fsp;
+prepare st_fsp from 'select ifnull(ts0, ?) as v from t_plan_cache_fsp where a = 1';
+set @p = timestamp '2024-01-01 12:34:56';
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+set @p = timestamp '2024-01-01 12:34:56.789012';
+execute st_fsp using @p;
+v
+2024-01-01 12:34:56.789012
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+deallocate prepare st_fsp;
+prepare st_fsp from 'select ifnull(tm0, ?) as v from t_plan_cache_fsp where a = 1';
+set @p = cast('12:34:56' as time(0));
+execute st_fsp using @p;
+v
+12:34:56
+execute st_fsp using @p;
+v
+12:34:56
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+set @p = cast('12:34:56.789012' as time(6));
+execute st_fsp using @p;
+v
+12:34:56.789012
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+deallocate prepare st_fsp;
+set time_zone=default;
+set tidb_enable_prepared_plan_cache=default;

--- a/tests/integrationtest/t/planner/core/plan_cache.test
+++ b/tests/integrationtest/t/planner/core/plan_cache.test
@@ -1795,3 +1795,73 @@ CREATE TABLE t (a int(11) DEFAULT NULL, b date DEFAULT NULL);
 INSERT INTO t VALUES (1, current_date());
 PREPARE stmt FROM 'SELECT a FROM t WHERE b=current_date()';
 EXECUTE stmt;
+
+# Temporal parameter fsp should be part of plan-cache parameter compatibility.
+set tidb_enable_prepared_plan_cache=1;
+set time_zone='+00:00';
+drop table if exists t_plan_cache_fsp;
+create table t_plan_cache_fsp (
+    a int primary key,
+    d0 datetime(0),
+    ts0 timestamp(0) null,
+    tm0 time(0)
+);
+insert into t_plan_cache_fsp values (1, null, null, null);
+
+select ifnull(d0, cast('2024-01-01 12:34:56.789012' as datetime(6))) as v from t_plan_cache_fsp where a = 1;
+prepare st_fsp from 'select ifnull(d0, ?) as v from t_plan_cache_fsp where a = 1';
+set @p = cast('2024-01-01 12:34:56' as datetime(0));
+execute st_fsp using @p;
+execute st_fsp using @p;
+select @@last_plan_from_cache;
+set @p = cast('2024-01-01 12:34:56.789012' as datetime(6));
+execute st_fsp using @p;
+select @@last_plan_from_cache;
+execute st_fsp using @p;
+select @@last_plan_from_cache;
+set @p = cast('2024-01-01 12:34:56' as datetime(0));
+execute st_fsp using @p;
+select @@last_plan_from_cache;
+deallocate prepare st_fsp;
+
+prepare st_fsp from 'select if(a = 0, d0, ?) as v from t_plan_cache_fsp where a = 1';
+set @p = cast('2024-01-01 12:34:56' as datetime(0));
+execute st_fsp using @p;
+execute st_fsp using @p;
+select @@last_plan_from_cache;
+set @p = cast('2024-01-01 12:34:56.789012' as datetime(6));
+execute st_fsp using @p;
+select @@last_plan_from_cache;
+deallocate prepare st_fsp;
+
+prepare st_fsp from 'select case when a = 0 then d0 else ? end as v from t_plan_cache_fsp where a = 1';
+set @p = cast('2024-01-01 12:34:56' as datetime(0));
+execute st_fsp using @p;
+execute st_fsp using @p;
+select @@last_plan_from_cache;
+set @p = cast('2024-01-01 12:34:56.789012' as datetime(6));
+execute st_fsp using @p;
+select @@last_plan_from_cache;
+deallocate prepare st_fsp;
+
+prepare st_fsp from 'select ifnull(ts0, ?) as v from t_plan_cache_fsp where a = 1';
+set @p = timestamp '2024-01-01 12:34:56';
+execute st_fsp using @p;
+execute st_fsp using @p;
+select @@last_plan_from_cache;
+set @p = timestamp '2024-01-01 12:34:56.789012';
+execute st_fsp using @p;
+select @@last_plan_from_cache;
+deallocate prepare st_fsp;
+
+prepare st_fsp from 'select ifnull(tm0, ?) as v from t_plan_cache_fsp where a = 1';
+set @p = cast('12:34:56' as time(0));
+execute st_fsp using @p;
+execute st_fsp using @p;
+select @@last_plan_from_cache;
+set @p = cast('12:34:56.789012' as time(6));
+execute st_fsp using @p;
+select @@last_plan_from_cache;
+deallocate prepare st_fsp;
+set time_zone=default;
+set tidb_enable_prepared_plan_cache=default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69449

Problem Summary:
Plan cache ignored temporal FSP when checking whether parameters are compatible. As a result, values like datetime(0) and datetime(6) could reuse the same cached plan and lose fractional-second precision.

### What changed and how does it work?
This change adds temporal FSP to the plan cache compatibility check. If two temporal parameters have different FSP, TiDB will not reuse the cached plan, which avoids precision loss.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Tightened prepared plan cache reuse rules for temporal parameters (`datetime`, `timestamp`, `time`) to prevent incorrect plan reuse when fractional-second precision differs, ensuring results preserve the expected fractional part.

* **Tests**
  * Added new coverage for prepared plan cache behavior across multiple control-flow expressions and temporal types with differing fractional-second precision.
  * Updated related test configuration to use an additional shard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->