### PR TITLE
tests: add starter realtikv target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -806,11 +806,11 @@ bazel_sessiontest: failpoint-enable bazel_ci_simple_prepare
 	bazel $(BAZEL_GLOBAL_CONFIG) test $(BAZEL_CMD_CONFIG) --test_arg=-with-real-tikv --define gotags=$(REAL_TIKV_TEST_TAGS) --jobs=1 \
 		-- //tests/realtikvtest/sessiontest/...
 
-.PHONY: bazel_startertest
-bazel_startertest: failpoint-enable bazel_ci_simple_prepare
+.PHONY: startertest
+startertest: failpoint-enable bazel_ci_simple_prepare
 	# Starter mode needs an external tidb-server process, so this wrapper
 	# intentionally invokes the starter shell runner instead of bazel test.
-	STARTER_RUN_EXIT_WAIT_TEST=1 tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh --under-cluster startertest 40m -count=1
+	STARTER_KEYSPACE_NAME=startertest STARTER_RUN_EXIT_WAIT_TEST=1 tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh --under-cluster startertest 40m -count=1
 
 .PHONY: bazel_statisticstest
 bazel_statisticstest: failpoint-enable bazel_ci_simple_prepare

--- a/tests/realtikvtest/scripts/next-gen/README.md
+++ b/tests/realtikvtest/scripts/next-gen/README.md
@@ -67,12 +67,15 @@ This script runs external starter-mode tests against a real `tidb-server`
 process. It first reuses `bootstrap-test-with-cluster.sh` to start PD, TiKV,
 TiKV-Worker, and MinIO. Then it starts `bin/tidb-server` with
 `deploy-mode = "starter"` and runs Go tests through the MySQL protocol and
-status HTTP APIs. By default, the script prepares a non-`SYSTEM` keyspace,
-starts TiDB in standby mode, activates the configured keyspace through
-`/tidb-pool/activate`, and then runs the tests against the activated external
-server. For the default `startertest` run, the script also runs a final
-destructive phase that verifies graceful exit waits for held client connections
-before shutting down the external `tidb-server`.
+status HTTP APIs. The standard `startertest` Makefile target runs against a
+non-`SYSTEM` keyspace. For a non-`SYSTEM` target keyspace, the script first
+bootstraps the shared `SYSTEM` keyspace with a no-op starter server, then
+creates the target keyspace through the PD keyspace API. It then starts TiDB in
+standby mode, activates the configured keyspace through `/tidb-pool/activate`,
+and runs the tests against the activated external server. For the default
+`startertest` run, the script also runs a final destructive phase that verifies
+graceful exit waits for held client connections before shutting down the
+external `tidb-server`.
 
 This script is an independent direct entry point and is not part of generic
 `run-tests.sh` suite discovery. For the standard next-gen RealTiKV CI flow, use
@@ -119,11 +122,11 @@ Useful environment variables:
   external server (default: `localhost:19000`)
 - `STARTER_KEYSPACE_NAME`: Starter keyspace activated by the script
   (default: `SYSTEM`)
-- `STARTER_PREPARE_KEYSPACE`: Whether to bootstrap `SYSTEM` and create
-  `STARTER_KEYSPACE_NAME` before starting the tested starter server when the
-  keyspace is not `SYSTEM` (default: `1`)
+- `STARTER_PREPARE_KEYSPACE`: Whether to bootstrap the shared `SYSTEM` keyspace
+  and create a non-`SYSTEM` `STARTER_KEYSPACE_NAME` before starting the tested
+  starter server (default: `1`)
 - `STARTER_KEYSPACE_CREATE_BODY`: Optional custom request body for creating
-  `STARTER_KEYSPACE_NAME` through the PD keyspace API
+  a non-`SYSTEM` `STARTER_KEYSPACE_NAME` through the PD keyspace API
 - `STARTER_SYSTEM_BOOTSTRAP_TIMEOUT`: Timeout for the no-op `SYSTEM` bootstrap
   phase before creating a non-`SYSTEM` keyspace (default: `2m`)
 - `STARTER_STANDBY_MODE`: Whether to start in standby mode and activate before

--- a/tests/realtikvtest/scripts/next-gen/README.md
+++ b/tests/realtikvtest/scripts/next-gen/README.md
@@ -67,20 +67,21 @@ This script runs external starter-mode tests against a real `tidb-server`
 process. It first reuses `bootstrap-test-with-cluster.sh` to start PD, TiKV,
 TiKV-Worker, and MinIO. Then it starts `bin/tidb-server` with
 `deploy-mode = "starter"` and runs Go tests through the MySQL protocol and
-status HTTP APIs. By default, the script starts TiDB in standby mode, activates
-the configured keyspace through `/tidb-pool/activate`, and then runs the tests
-against the activated external server. For the default `startertest` run, the
-script also runs a final destructive phase that verifies graceful exit waits for
-held client connections before shutting down the external `tidb-server`.
+status HTTP APIs. By default, the script prepares a non-`SYSTEM` keyspace,
+starts TiDB in standby mode, activates the configured keyspace through
+`/tidb-pool/activate`, and then runs the tests against the activated external
+server. For the default `startertest` run, the script also runs a final
+destructive phase that verifies graceful exit waits for held client connections
+before shutting down the external `tidb-server`.
 
 This script is an independent direct entry point and is not part of generic
 `run-tests.sh` suite discovery. For the standard next-gen RealTiKV CI flow, use
-the `bazel_startertest` Makefile wrapper through `run-tests.sh`; that wrapper
+the `startertest` Makefile target through `run-tests.sh`; that target
 intentionally calls this shell runner because starter coverage needs an external
 `tidb-server` process:
 
 ```bash
-tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_startertest
+tests/realtikvtest/scripts/next-gen/run-tests.sh startertest
 ```
 
 When `TIDB_SERVER_BIN` is not set, the script builds `bin/tidb-server` from the
@@ -118,6 +119,13 @@ Useful environment variables:
   external server (default: `localhost:19000`)
 - `STARTER_KEYSPACE_NAME`: Starter keyspace activated by the script
   (default: `SYSTEM`)
+- `STARTER_PREPARE_KEYSPACE`: Whether to bootstrap `SYSTEM` and create
+  `STARTER_KEYSPACE_NAME` before starting the tested starter server when the
+  keyspace is not `SYSTEM` (default: `1`)
+- `STARTER_KEYSPACE_CREATE_BODY`: Optional custom request body for creating
+  `STARTER_KEYSPACE_NAME` through the PD keyspace API
+- `STARTER_SYSTEM_BOOTSTRAP_TIMEOUT`: Timeout for the no-op `SYSTEM` bootstrap
+  phase before creating a non-`SYSTEM` keyspace (default: `2m`)
 - `STARTER_STANDBY_MODE`: Whether to start in standby mode and activate before
   running tests (default: `1`; set to `0` to start directly with
   `-keyspace-name`)
@@ -135,8 +143,8 @@ Useful environment variables:
   `tidb-server` (default: `120`)
 - `STARTER_RUN_EXIT_WAIT_TEST`: Whether to run the final destructive
   graceful-exit wait test. By default it runs only for `startertest` when no
-  extra `go test` arguments are passed. The `bazel_startertest` Makefile wrapper
-  sets this to `1` explicitly because it passes `-count=1`.
+  extra `go test` arguments are passed. The `startertest` Makefile target sets
+  this to `1` explicitly because it passes `-count=1`.
 - `STARTER_EXIT_WAIT_TEST_TIMEOUT`: Timeout for the final destructive
   graceful-exit wait test (default: `2m`)
 - `STARTER_TIDB_PORT` / `STARTER_TIDB_STATUS_PORT`: Preferred starting ports

--- a/tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh
@@ -85,6 +85,18 @@ function is_true() {
     esac
 }
 
+function json_escape() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\b'/\\b}"
+    value="${value//$'\f'/\\f}"
+    value="${value//$'\n'/\\n}"
+    value="${value//$'\r'/\\r}"
+    value="${value//$'\t'/\\t}"
+    printf "%s" "${value}"
+}
+
 function is_system_keyspace() {
     local value
     value="$(printf "%s" "$1" | tr '[:lower:]' '[:upper:]')"
@@ -97,7 +109,7 @@ function create_starter_keyspace() {
     local keyspace_create_body="${STARTER_KEYSPACE_CREATE_BODY:-}"
 
     if [[ -z "${keyspace_create_body}" ]]; then
-        keyspace_create_body="$(printf '{"name":"%s","config":{}}' "${keyspace_name}")"
+        keyspace_create_body="$(printf '{"name":"%s","config":{}}' "$(json_escape "${keyspace_name}")")"
     fi
 
     echo "Creating starter keyspace ${keyspace_name} via ${pd_status_url}/pd/api/v2/keyspaces"
@@ -146,13 +158,18 @@ function activate_starter_server() {
     local activate_err_file="${response_file}.err"
     local activate_rc_file="${response_file}.rc"
     local activate_body
+    local escaped_keyspace_name
+    local escaped_export_id
+
+    escaped_keyspace_name="$(json_escape "${keyspace_name}")"
+    escaped_export_id="$(json_escape "${export_id}")"
 
     if [[ -n "${metadata_json}" ]]; then
         activate_body="$(printf '{"keyspace_name":"%s","export_id":"%s","max_idle_seconds":%s,"metadata":%s,"tidb_enable_ddl":true,"run_auto_analyze":true}' \
-            "${keyspace_name}" "${export_id}" "${max_idle_seconds}" "${metadata_json}")"
+            "${escaped_keyspace_name}" "${escaped_export_id}" "${max_idle_seconds}" "${metadata_json}")"
     else
         activate_body="$(printf '{"keyspace_name":"%s","export_id":"%s","max_idle_seconds":%s,"tidb_enable_ddl":true,"run_auto_analyze":true}' \
-            "${keyspace_name}" "${export_id}" "${max_idle_seconds}")"
+            "${escaped_keyspace_name}" "${escaped_export_id}" "${max_idle_seconds}")"
     fi
 
     echo "Activating external starter tidb-server for keyspace ${keyspace_name}, export ID ${export_id}"

--- a/tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh
@@ -85,6 +85,54 @@ function is_true() {
     esac
 }
 
+function is_system_keyspace() {
+    local value
+    value="$(printf "%s" "$1" | tr '[:lower:]' '[:upper:]')"
+    [[ "${value}" == "SYSTEM" ]]
+}
+
+function create_starter_keyspace() {
+    local pd_status_url="$1"
+    local keyspace_name="$2"
+    local keyspace_create_body="${STARTER_KEYSPACE_CREATE_BODY:-}"
+
+    if [[ -z "${keyspace_create_body}" ]]; then
+        keyspace_create_body="$(printf '{"name":"%s","config":{}}' "${keyspace_name}")"
+    fi
+
+    echo "Creating starter keyspace ${keyspace_name} via ${pd_status_url}/pd/api/v2/keyspaces"
+    curl -fsS -X POST "${pd_status_url}/pd/api/v2/keyspaces" \
+        -H "Content-Type: application/json" \
+        -d "${keyspace_create_body}"
+    echo
+}
+
+function prepare_starter_keyspace() {
+    local keyspace_name="$1"
+    local pd_status_url="$2"
+    local tidb_server_bin="$3"
+    local self_dir="$4"
+
+    if is_system_keyspace "${keyspace_name}"; then
+        return 0
+    fi
+    if ! is_true "${STARTER_PREPARE_KEYSPACE:-1}"; then
+        return 0
+    fi
+
+    echo "Bootstrapping SYSTEM keyspace before creating starter keyspace ${keyspace_name}"
+    TIDB_SERVER_BIN="${tidb_server_bin}" \
+        STARTER_KEYSPACE_NAME=SYSTEM \
+        STARTER_PREPARE_KEYSPACE=0 \
+        STARTER_STANDBY_MODE=0 \
+        STARTER_KEYSPACE_OBSERVABILITY=0 \
+        STARTER_RUN_EXIT_WAIT_TEST=0 \
+        "${self_dir}/run-starter-tests-with-server.sh" \
+            --under-cluster startertest "${STARTER_SYSTEM_BOOTSTRAP_TIMEOUT:-2m}" -run "^$"
+
+    create_starter_keyspace "${pd_status_url}" "${keyspace_name}"
+}
+
 function activate_starter_server() {
     local status_url="$1"
     local tidb_pid="$2"
@@ -221,6 +269,8 @@ function run_under_cluster() {
         pd_status_url="http://${pd_status_url}"
     fi
     local tikv_worker_url="${STARTER_TIKV_WORKER_URL:-localhost:19000}"
+
+    prepare_starter_keyspace "${keyspace_name}" "${pd_status_url}" "${tidb_server_bin}" "${self_dir}"
 
     cat > "${config_file}" <<EOF
 deploy-mode = "starter"

--- a/tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh
@@ -313,7 +313,8 @@ slow-log-field = "Keyspace_meta_project"
 stmt-log-field = "project"
 required = true
 EOF
-        activate_metadata_json="$(printf '{"tenant":"%s","project":"%s"}' "${keyspace_meta_tenant}" "${keyspace_meta_project}")"
+        activate_metadata_json="$(printf '{"tenant":"%s","project":"%s"}' \
+            "$(json_escape "${keyspace_meta_tenant}")" "$(json_escape "${keyspace_meta_project}")")"
     fi
 
     local tidb_server_args=(

--- a/tests/realtikvtest/scripts/next-gen/run-tests.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-tests.sh
@@ -22,6 +22,14 @@ function main() {
     local make_test_task="$1"
 
     local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+
+    # TEMPORARY PR validation: route one existing next-gen CI slot to
+    # startertest until the CI repo change invokes startertest directly.
+    if [[ "${make_test_task}" == "bazel_sessiontest" ]]; then
+        echo "Temporary startertest validation: replacing bazel_sessiontest with startertest"
+        make_test_task="startertest"
+    fi
+
     "${self_dir}/bootstrap-test-with-cluster.sh" make ${make_test_task}
 }
 

--- a/tests/realtikvtest/scripts/next-gen/run-tests.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-tests.sh
@@ -22,14 +22,6 @@ function main() {
     local make_test_task="$1"
 
     local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
-
-    # TEMPORARY PR validation: route one existing next-gen CI slot to
-    # startertest until the CI repo change invokes startertest directly.
-    if [[ "${make_test_task}" == "bazel_sessiontest" ]]; then
-        echo "Temporary startertest validation: replacing bazel_sessiontest with startertest"
-        make_test_task="startertest"
-    fi
-
     "${self_dir}/bootstrap-test-with-cluster.sh" make ${make_test_task}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67765 

**Problem Summary**
The next-gen RealTiKV CI needs coverage for starter deployment mode, especially starter keyspace activation and external starter server behavior. The existing RealTiKV matrix only covered Bazel-based suites and did not provide a clean starter-specific entry point. Earlier wiring also required CI-side special handling to bootstrap the `SYSTEM` keyspace and create the target starter keyspace before running the tests, which made the CI pipeline understand too much TiDB starter setup detail.

**What Changed And How Does It Work**
This change adds a dedicated `startertest` RealTiKV test target in TiDB and moves starter keyspace preparation into the TiDB-side runner.

The new `startertest` Makefile target runs `tests/realtikvtest/scripts/next-gen/run-starter-tests-with-server.sh` with `STARTER_KEYSPACE_NAME=startertest`, so the test name now reflects that this is a Go-based starter test rather than a Bazel suite.

The starter runner now prepares non-`SYSTEM` keyspaces automatically. When `STARTER_KEYSPACE_NAME` is not `SYSTEM`, it first starts a no-op starter server on `SYSTEM` to bootstrap shared system state, then creates the requested keyspace through the PD keyspace API, and finally starts the real starter server for that keyspace and runs `go test ./tests/realtikvtest/startertest`.

With this, the CI pipeline can simply add `tests/realtikvtest/scripts/next-gen/run-tests.sh startertest` to the next-gen RealTiKV matrix, while the TiDB test runner owns all starter-specific setup details.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated starter test docs and examples; added environment variables to control starter keyspace creation, bootstrap timeout, and run/exit behavior.

* **Build & Testing**
  * Renamed the starter test make target for consistency.
  * Test flow can now prepare/create a starter keyspace before server startup.
  * Activation payloads and metadata values are now JSON-escaped for safer handling of special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->