### PR TITLE
lightning: strip s3 external id from import sql params

### DIFF
--- a/lightning/pkg/importinto/BUILD.bazel
+++ b/lightning/pkg/importinto/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/lightning/config",
         "//pkg/lightning/log",
         "//pkg/objstore",
+        "//pkg/objstore/s3like",
         "//pkg/parser/ast",
         "//pkg/util/mathutil",
         "@com_github_docker_go_units//:go-units",

--- a/lightning/pkg/importinto/importer.go
+++ b/lightning/pkg/importinto/importer.go
@@ -75,16 +75,28 @@ func WithOrchestrator(orchestrator JobOrchestrator) ImporterOption {
 	}
 }
 
+// WithStripS3ExternalIDForImportSQL strips explicit S3 external ID from IMPORT INTO
+// SQL resource parameters. The original source directory is kept unchanged for
+// Lightning's own storage access. Enable it only for callers that need to keep
+// compatibility with older IMPORT INTO planners that reject explicit S3 external ID;
+// newer planners can accept an explicit external ID matching the target value.
+func WithStripS3ExternalIDForImportSQL() ImporterOption {
+	return func(i *Importer) {
+		i.stripS3ExternalIDForImportSQL = true
+	}
+}
+
 // Importer is the implementation of LightningImporter for the 'import into' backend.
 type Importer struct {
-	cfg             *config.Config
-	db              *sql.DB
-	sdk             importsdk.SDK
-	logger          log.Logger
-	cpMgr           CheckpointManager
-	orchestrator    JobOrchestrator
-	groupKey        string
-	progressUpdater ProgressUpdater
+	cfg                           *config.Config
+	db                            *sql.DB
+	sdk                           importsdk.SDK
+	logger                        log.Logger
+	cpMgr                         CheckpointManager
+	orchestrator                  JobOrchestrator
+	groupKey                      string
+	progressUpdater               ProgressUpdater
+	stripS3ExternalIDForImportSQL bool
 }
 
 // NewImporter creates a new Importer.
@@ -149,7 +161,11 @@ func NewImporter(
 }
 
 func (i *Importer) buildOrchestrator() JobOrchestrator {
-	submitter := NewJobSubmitter(i.sdk, i.cfg, i.groupKey, i.logger.With(zap.String("component", "submitter")))
+	jobSubmitterOpts := make([]JobSubmitterOption, 0, 1)
+	if i.stripS3ExternalIDForImportSQL {
+		jobSubmitterOpts = append(jobSubmitterOpts, WithJobSubmitterStripS3ExternalIDForImportSQL())
+	}
+	submitter := NewJobSubmitter(i.sdk, i.cfg, i.groupKey, i.logger.With(zap.String("component", "submitter")), jobSubmitterOpts...)
 
 	return NewJobOrchestrator(OrchestratorConfig{
 		Submitter:         submitter,

--- a/lightning/pkg/importinto/job_submitter.go
+++ b/lightning/pkg/importinto/job_submitter.go
@@ -22,6 +22,8 @@ import (
 	"github.com/pingcap/tidb/pkg/importsdk"
 	"github.com/pingcap/tidb/pkg/lightning/config"
 	"github.com/pingcap/tidb/pkg/lightning/log"
+	"github.com/pingcap/tidb/pkg/objstore"
+	"github.com/pingcap/tidb/pkg/objstore/s3like"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"go.uber.org/zap"
 )
@@ -41,20 +43,40 @@ type JobSubmitter interface {
 
 // DefaultJobSubmitter is the default implementation of JobSubmitter.
 type DefaultJobSubmitter struct {
-	sdk      importsdk.SDK
-	config   *config.Config
-	groupKey string
-	logger   log.Logger
+	sdk                           importsdk.SDK
+	config                        *config.Config
+	groupKey                      string
+	logger                        log.Logger
+	stripS3ExternalIDForImportSQL bool
+}
+
+// JobSubmitterOption is a function that configures the JobSubmitter.
+type JobSubmitterOption func(*DefaultJobSubmitter)
+
+// WithJobSubmitterStripS3ExternalIDForImportSQL strips explicit S3 external ID
+// from IMPORT INTO SQL resource parameters. The original source directory is
+// kept unchanged for Lightning's own storage access. Enable it only for callers
+// that need to keep compatibility with older IMPORT INTO planners that reject
+// explicit S3 external ID; newer planners can accept an explicit external ID
+// matching the target value.
+func WithJobSubmitterStripS3ExternalIDForImportSQL() JobSubmitterOption {
+	return func(s *DefaultJobSubmitter) {
+		s.stripS3ExternalIDForImportSQL = true
+	}
 }
 
 // NewJobSubmitter creates a new job submitter.
-func NewJobSubmitter(sdk importsdk.SDK, cfg *config.Config, groupKey string, logger log.Logger) JobSubmitter {
-	return &DefaultJobSubmitter{
+func NewJobSubmitter(sdk importsdk.SDK, cfg *config.Config, groupKey string, logger log.Logger, opts ...JobSubmitterOption) JobSubmitter {
+	submitter := &DefaultJobSubmitter{
 		sdk:      sdk,
 		config:   cfg,
 		groupKey: groupKey,
 		logger:   logger,
 	}
+	for _, opt := range opts {
+		opt(submitter)
+	}
+	return submitter
 }
 
 // SubmitTable submits an import job for a single table.
@@ -128,11 +150,34 @@ func (s *DefaultJobSubmitter) buildImportOptions(tableMeta *importsdk.TableMeta)
 	if cfg.Mydumper.SourceDir != "" {
 		u, err := url.Parse(cfg.Mydumper.SourceDir)
 		if err == nil {
-			opts.ResourceParameters = u.RawQuery
+			opts.ResourceParameters = buildResourceParametersForImportSQL(u, s.stripS3ExternalIDForImportSQL)
 		}
 	}
 
 	return opts
+}
+
+func buildResourceParametersForImportSQL(u *url.URL, stripS3ExternalID bool) string {
+	if !(stripS3ExternalID && objstore.IsS3Like(u)) {
+		return u.RawQuery
+	}
+
+	values := u.Query()
+	if !stripS3ExternalIDResourceParameters(values) {
+		return u.RawQuery
+	}
+	return values.Encode()
+}
+
+func stripS3ExternalIDResourceParameters(values url.Values) bool {
+	stripped := false
+	for key := range values {
+		if objstore.NormalizeQueryParameterKey(key) == s3like.S3ExternalID {
+			delete(values, key)
+			stripped = true
+		}
+	}
+	return stripped
 }
 
 func generateImportSQLForLog(tableMeta *importsdk.TableMeta, options *importsdk.ImportOptions) (string, error) {

--- a/lightning/pkg/importinto/job_submitter_test.go
+++ b/lightning/pkg/importinto/job_submitter_test.go
@@ -29,11 +29,28 @@ import (
 )
 
 func TestJobSubmitterSubmitTable(t *testing.T) {
+	const (
+		s3SourceDirWithExternalID  = "s3://bucket/path?role-arn=arn&external-id=remove&External_ID=remove-too&external%5Fid=remove-encoded&region=us-east-1&endpoint=http%3A%2F%2Fminio%3A9000"
+		s3ResourceParameters       = "endpoint=http%3A%2F%2Fminio%3A9000&region=us-east-1&role-arn=arn"
+		ossSourceDirWithExternalID = "oss://bucket/path?external-id=remove&role-arn=arn&region=us-east-1"
+		ossResourceParameters      = "region=us-east-1&role-arn=arn"
+		gcsSourceDir               = "gcs://bucket/path?external-id=keep&external_id=keep-too&region=us-east-1"
+	)
+
+	s3Cfg := config.NewConfig()
+	s3Cfg.Mydumper.SourceDir = s3SourceDirWithExternalID
+	ossCfg := config.NewConfig()
+	ossCfg.Mydumper.SourceDir = ossSourceDirWithExternalID
+	gcsCfg := config.NewConfig()
+	gcsCfg.Mydumper.SourceDir = gcsSourceDir
+
 	tests := []struct {
-		name      string
-		tableMeta *importsdk.TableMeta
-		setup     func(mockSDK *sdkmock.MockSDK)
-		wantErr   bool
+		name                string
+		tableMeta           *importsdk.TableMeta
+		cfg                 *config.Config
+		setup               func(t *testing.T, mockSDK *sdkmock.MockSDK)
+		wantErr             bool
+		jobSubmitterOptions []importinto.JobSubmitterOption
 	}{
 		{
 			name: "successful submission",
@@ -41,7 +58,7 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 				Database: "db",
 				Table:    "t1",
 			},
-			setup: func(mockSDK *sdkmock.MockSDK) {
+			setup: func(_ *testing.T, mockSDK *sdkmock.MockSDK) {
 				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).Return("IMPORT INTO ...", nil)
 				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
 			},
@@ -52,7 +69,7 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 				Database: "db",
 				Table:    "t1",
 			},
-			setup: func(mockSDK *sdkmock.MockSDK) {
+			setup: func(_ *testing.T, mockSDK *sdkmock.MockSDK) {
 				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).Return("", errors.New("gen error"))
 			},
 			wantErr: true,
@@ -63,11 +80,81 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 				Database: "db",
 				Table:    "t1",
 			},
-			setup: func(mockSDK *sdkmock.MockSDK) {
+			setup: func(_ *testing.T, mockSDK *sdkmock.MockSDK) {
 				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).Return("IMPORT INTO ...", nil)
 				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(0), errors.New("submit error"))
 			},
 			wantErr: true,
+		},
+		{
+			name: "keep s3 external id unless nextgen sem is enabled",
+			tableMeta: &importsdk.TableMeta{
+				Database: "db",
+				Table:    "t1",
+			},
+			cfg: s3Cfg,
+			setup: func(t *testing.T, mockSDK *sdkmock.MockSDK) {
+				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ *importsdk.TableMeta, opts *importsdk.ImportOptions) (string, error) {
+						require.Equal(t, "role-arn=arn&external-id=remove&External_ID=remove-too&external%5Fid=remove-encoded&region=us-east-1&endpoint=http%3A%2F%2Fminio%3A9000", opts.ResourceParameters)
+						require.Equal(t, s3SourceDirWithExternalID, s3Cfg.Mydumper.SourceDir)
+						return "IMPORT INTO ...", nil
+					})
+				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
+			},
+		},
+		{
+			name:                "sanitize s3 external id when enabled for import sql resource parameters",
+			jobSubmitterOptions: []importinto.JobSubmitterOption{importinto.WithJobSubmitterStripS3ExternalIDForImportSQL()},
+			tableMeta: &importsdk.TableMeta{
+				Database: "db",
+				Table:    "t1",
+			},
+			cfg: s3Cfg,
+			setup: func(t *testing.T, mockSDK *sdkmock.MockSDK) {
+				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ *importsdk.TableMeta, opts *importsdk.ImportOptions) (string, error) {
+						require.Equal(t, s3ResourceParameters, opts.ResourceParameters)
+						require.Equal(t, s3SourceDirWithExternalID, s3Cfg.Mydumper.SourceDir)
+						return "IMPORT INTO ...", nil
+					})
+				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
+			},
+		},
+		{
+			name:                "sanitize oss external id as s3 like resource parameters",
+			jobSubmitterOptions: []importinto.JobSubmitterOption{importinto.WithJobSubmitterStripS3ExternalIDForImportSQL()},
+			tableMeta: &importsdk.TableMeta{
+				Database: "db",
+				Table:    "t1",
+			},
+			cfg: ossCfg,
+			setup: func(t *testing.T, mockSDK *sdkmock.MockSDK) {
+				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ *importsdk.TableMeta, opts *importsdk.ImportOptions) (string, error) {
+						require.Equal(t, ossResourceParameters, opts.ResourceParameters)
+						require.Equal(t, ossSourceDirWithExternalID, ossCfg.Mydumper.SourceDir)
+						return "IMPORT INTO ...", nil
+					})
+				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
+			},
+		},
+		{
+			name: "keep non s3 resource parameters unchanged",
+			tableMeta: &importsdk.TableMeta{
+				Database: "db",
+				Table:    "t1",
+			},
+			cfg: gcsCfg,
+			setup: func(t *testing.T, mockSDK *sdkmock.MockSDK) {
+				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ *importsdk.TableMeta, opts *importsdk.ImportOptions) (string, error) {
+						require.Equal(t, "external-id=keep&external_id=keep-too&region=us-east-1", opts.ResourceParameters)
+						require.Equal(t, gcsSourceDir, gcsCfg.Mydumper.SourceDir)
+						return "IMPORT INTO ...", nil
+					})
+				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
+			},
 		},
 	}
 
@@ -77,9 +164,13 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 			defer ctrl.Finish()
 			mockSDK := sdkmock.NewMockSDK(ctrl)
 			groupKey := "g1"
-			submitter := importinto.NewJobSubmitter(mockSDK, config.NewConfig(), groupKey, log.L())
+			cfg := tt.cfg
+			if cfg == nil {
+				cfg = config.NewConfig()
+			}
+			submitter := importinto.NewJobSubmitter(mockSDK, cfg, groupKey, log.L(), tt.jobSubmitterOptions...)
 
-			tt.setup(mockSDK)
+			tt.setup(t, mockSDK)
 			job, err := submitter.SubmitTable(context.Background(), tt.tableMeta)
 			if tt.wantErr {
 				require.Error(t, err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #60418

Related TiFlow issue: pingcap/tiflow#12699

Problem Summary:

TiDB Lightning import-into uses `Mydumper.SourceDir` both to access the external storage and to build the `IMPORT INTO` SQL resource parameters.

When an S3 source uses `role-arn` and its role trust policy requires `sts:ExternalId`, Lightning must keep the explicit external ID in `SourceDir` for its own S3 access. But before pingcap/tidb#69045 is available in downstream users, passing an explicit `external-id` to IMPORT INTO can be rejected by the planner.

### What changed and how does it work?

Keep `cfg.Mydumper.SourceDir` unchanged for Lightning storage access.

When building IMPORT INTO options, strip only explicit S3 external ID query parameters from the resource parameters used in the submitted SQL:

- remove `external-id` / `external_id` and normalized variants;
- preserve other query parameters such as `role-arn`, `region`, and `endpoint`;
- keep non-S3 resource parameters unchanged.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a TiDB Lightning import-into issue where S3 external ID could be passed to IMPORT INTO SQL instead of only being used for Lightning storage access.
```

### Tests

- `./tools/check/failpoint-go-test.sh lightning/pkg/importinto -run TestJobSubmitterSubmitTable -count=1`
- `./tools/check/failpoint-go-test.sh lightning/pkg/importinto -count=1`
- `git diff --check`
- `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IMPORT INTO SQL behavior for S3/OSS-like sources by optionally sanitizing resource parameters: when the nextgen SEM toggle is active, the external-id is removed while preserving other parameters and keeping the original source path unchanged.

* **Tests**
  * Expanded unit coverage for resource-parameter sanitization across S3/OSS-like and non-S3 inputs, and updated the test harness to allow per-case configuration and a new setup callback signature.

* **Chores**
  * Updated Bazel dependencies to support the new sanitization logic and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
