### PR TITLE
planner: support COALESCE in plan cache

### DIFF
--- a/pkg/expression/function_traits.go
+++ b/pkg/expression/function_traits.go
@@ -36,7 +36,6 @@ var UnCacheableFunctions = map[string]struct{}{
 	ast.JSONExtract:      {}, // cannot pass TestFuncJSON
 	ast.JSONObject:       {},
 	ast.JSONArray:        {},
-	ast.Coalesce:         {},
 	ast.Convert:          {},
 	ast.TimeLiteral:      {},
 	ast.DateLiteral:      {},

--- a/tests/integrationtest/r/planner/core/plan_cache.result
+++ b/tests/integrationtest/r/planner/core/plan_cache.result
@@ -2835,3 +2835,71 @@ PREPARE stmt FROM 'SELECT a FROM t WHERE b=current_date()';
 EXECUTE stmt;
 a
 1
+drop table if exists t_plan_cache_coalesce;
+create table t_plan_cache_coalesce (a int primary key, b int, key(b));
+insert into t_plan_cache_coalesce values (1, null), (2, 20);
+prepare st_coalesce_expr from 'select a, coalesce(b, ?) from t_plan_cache_coalesce where a = coalesce(?, 1)';
+set @fallback=100, @key=1;
+execute st_coalesce_expr using @fallback, @key;
+a	coalesce(b, ?)
+1	100
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+set @fallback=200, @key=2;
+execute st_coalesce_expr using @fallback, @key;
+a	coalesce(b, ?)
+2	20
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare st_coalesce_expr;
+drop table if exists t_plan_cache_coalesce_outer, t_plan_cache_coalesce_inner;
+create table t_plan_cache_coalesce_outer (a int primary key);
+create table t_plan_cache_coalesce_inner (a int primary key, b int);
+insert into t_plan_cache_coalesce_outer values (1), (2);
+insert into t_plan_cache_coalesce_inner values (2, 5);
+prepare st_coalesce_left_join from 'select o.a, i.b from t_plan_cache_coalesce_outer o left join t_plan_cache_coalesce_inner i on o.a = i.a where coalesce(i.b, ?) > 0 order by o.a';
+set @fallback=0;
+execute st_coalesce_left_join using @fallback;
+a	b
+2	5
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+set @fallback=1;
+execute st_coalesce_left_join using @fallback;
+a	b
+1	NULL
+2	5
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare st_coalesce_left_join;
+set tidb_enable_non_prepared_plan_cache=1;
+select a, coalesce(b, 100) from t_plan_cache_coalesce where a = coalesce(1, a);
+a	coalesce(b, 100)
+1	100
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+select a, coalesce(b, 100) from t_plan_cache_coalesce where a = coalesce(2, a);
+a	coalesce(b, 100)
+2	20
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+select o.a, i.b from t_plan_cache_coalesce_outer o left join t_plan_cache_coalesce_inner i on o.a = i.a where coalesce(i.b, 0) > 0 order by o.a;
+a	b
+2	5
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+select o.a, i.b from t_plan_cache_coalesce_outer o left join t_plan_cache_coalesce_inner i on o.a = i.a where coalesce(i.b, 1) > 0 order by o.a;
+a	b
+1	NULL
+2	5
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+set tidb_enable_non_prepared_plan_cache=default;

--- a/tests/integrationtest/t/planner/core/plan_cache.test
+++ b/tests/integrationtest/t/planner/core/plan_cache.test
@@ -1795,3 +1795,43 @@ CREATE TABLE t (a int(11) DEFAULT NULL, b date DEFAULT NULL);
 INSERT INTO t VALUES (1, current_date());
 PREPARE stmt FROM 'SELECT a FROM t WHERE b=current_date()';
 EXECUTE stmt;
+
+# TestPlanCacheCoalesce
+drop table if exists t_plan_cache_coalesce;
+create table t_plan_cache_coalesce (a int primary key, b int, key(b));
+insert into t_plan_cache_coalesce values (1, null), (2, 20);
+
+prepare st_coalesce_expr from 'select a, coalesce(b, ?) from t_plan_cache_coalesce where a = coalesce(?, 1)';
+set @fallback=100, @key=1;
+execute st_coalesce_expr using @fallback, @key;
+select @@last_plan_from_cache;
+set @fallback=200, @key=2;
+execute st_coalesce_expr using @fallback, @key;
+select @@last_plan_from_cache;
+deallocate prepare st_coalesce_expr;
+
+drop table if exists t_plan_cache_coalesce_outer, t_plan_cache_coalesce_inner;
+create table t_plan_cache_coalesce_outer (a int primary key);
+create table t_plan_cache_coalesce_inner (a int primary key, b int);
+insert into t_plan_cache_coalesce_outer values (1), (2);
+insert into t_plan_cache_coalesce_inner values (2, 5);
+prepare st_coalesce_left_join from 'select o.a, i.b from t_plan_cache_coalesce_outer o left join t_plan_cache_coalesce_inner i on o.a = i.a where coalesce(i.b, ?) > 0 order by o.a';
+set @fallback=0;
+execute st_coalesce_left_join using @fallback;
+select @@last_plan_from_cache;
+set @fallback=1;
+execute st_coalesce_left_join using @fallback;
+select @@last_plan_from_cache;
+deallocate prepare st_coalesce_left_join;
+
+set tidb_enable_non_prepared_plan_cache=1;
+select a, coalesce(b, 100) from t_plan_cache_coalesce where a = coalesce(1, a);
+select @@last_plan_from_cache;
+select a, coalesce(b, 100) from t_plan_cache_coalesce where a = coalesce(2, a);
+select @@last_plan_from_cache;
+
+select o.a, i.b from t_plan_cache_coalesce_outer o left join t_plan_cache_coalesce_inner i on o.a = i.a where coalesce(i.b, 0) > 0 order by o.a;
+select @@last_plan_from_cache;
+select o.a, i.b from t_plan_cache_coalesce_outer o left join t_plan_cache_coalesce_inner i on o.a = i.a where coalesce(i.b, 1) > 0 order by o.a;
+select @@last_plan_from_cache;
+set tidb_enable_non_prepared_plan_cache=default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:
COALESCE is listed in expression.UnCacheableFunctions, so any statement containing COALESCE (prepared or non-prepared) is excluded from the plan cache and loses the performance benefit.

### What changed and how does it work?
Remove ast.Coalesce from expression.UnCacheableFunctions so statements with COALESCE become plan-cacheable. COALESCE infers its result type from its arguments, and the plan-cache parameter type-compatibility check (checkTypesCompatibility4PC) already guards parameter type changes, so a reused cached plan stays correct. Added integration tests covering both the prepared path (scalar param and a left-join predicate) and the non-prepared path, asserting first-miss then cache-hit.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Query Performance**
  * Improved caching efficiency for COALESCE expressions in queries
  * Updated caching behavior for JSON-related functions

* **Tests**
  * Added test coverage for COALESCE expression caching behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->