### PR TITLE
planner: fall back to index stats when col has no stats

### DIFF
--- a/pkg/planner/cardinality/BUILD.bazel
+++ b/pkg/planner/cardinality/BUILD.bazel
@@ -58,7 +58,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":cardinality"],
     flaky = True,
-    shard_count = 49,
+    shard_count = 50,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -37,7 +37,8 @@ import (
 )
 
 // GetRowCountByIndexRanges estimates the row count by a slice of Range.
-// idxCols used when index statistics are invalid, because coll may not have index info, can be nil whenever index statistics are valid.
+// idxCols is used when index statistics are invalid (coll may not have index info), and to recognize
+// virtual columns inside expBackoffEstimation. It can be nil, in which case both usages are skipped.
 func GetRowCountByIndexRanges(sctx planctx.PlanContext, coll *statistics.HistColl, idxID int64, indexRanges []*ranger.Range, idxCols []*expression.Column) (result statistics.RowEstimate, err error) {
 	var count, maxCount float64
 	sc := sctx.GetSessionVars().StmtCtx
@@ -70,7 +71,7 @@ func GetRowCountByIndexRanges(sctx planctx.PlanContext, coll *statistics.HistCol
 		count, err = getIndexRowCountForStatsV1(sctx, coll, idxID, indexRanges)
 		result = statistics.DefaultRowEst(count)
 	} else {
-		result, err = getIndexRowCountForStatsV2(sctx, idx, coll, indexRanges, realtimeCnt, modifyCount)
+		result, err = getIndexRowCountForStatsV2(sctx, idx, coll, indexRanges, idxCols, realtimeCnt, modifyCount)
 	}
 	return result, errors.Trace(err)
 }
@@ -94,7 +95,7 @@ func getIndexRowCountForStatsV1(sctx planctx.PlanContext, coll *statistics.HistC
 		// values in this case.
 		if rangePosition == 0 || isSingleColIdxNullRange(idx, ran) {
 			realtimeCnt, modifyCount := coll.GetScaledRealtimeAndModifyCnt(idx)
-			rowEstimate, err := getIndexRowCountForStatsV2(sctx, idx, nil, []*ranger.Range{ran}, realtimeCnt, modifyCount)
+			rowEstimate, err := getIndexRowCountForStatsV2(sctx, idx, nil, []*ranger.Range{ran}, nil, realtimeCnt, modifyCount)
 			count := rowEstimate.Est
 			if err != nil {
 				return 0, errors.Trace(err)
@@ -191,7 +192,7 @@ func isSingleColIdxNullRange(idx *statistics.Index, ran *ranger.Range) bool {
 }
 
 // It uses the modifyCount to validate, and realtimeRowCount to adjust the influence of modifications on the table.
-func getIndexRowCountForStatsV2(sctx planctx.PlanContext, idx *statistics.Index, coll *statistics.HistColl, indexRanges []*ranger.Range, realtimeRowCount, modifyCount int64) (totalCount statistics.RowEstimate, err error) {
+func getIndexRowCountForStatsV2(sctx planctx.PlanContext, idx *statistics.Index, coll *statistics.HistColl, indexRanges []*ranger.Range, idxCols []*expression.Column, realtimeRowCount, modifyCount int64) (totalCount statistics.RowEstimate, err error) {
 	sc := sctx.GetSessionVars().StmtCtx
 	isSingleColIdx := len(idx.Info.Columns) == 1
 	for _, indexRange := range indexRanges {
@@ -250,7 +251,7 @@ func getIndexRowCountForStatsV2(sctx planctx.PlanContext, idx *statistics.Index,
 		// If the first column's range is point.
 		if rangePosition := getOrdinalOfRangeCond(sc, indexRange); rangePosition > 0 && idx.StatsVer >= statistics.Version2 && coll != nil {
 			var expBackoffSel, minSel, maxSel float64
-			expBackoffSel, minSel, maxSel, expBackoffSuccess, err = expBackoffEstimation(sctx, idx, coll, indexRange)
+			expBackoffSel, minSel, maxSel, expBackoffSuccess, err = expBackoffEstimation(sctx, idx, coll, indexRange, idxCols)
 			if err != nil {
 				return statistics.DefaultRowEst(0), err
 			}
@@ -439,7 +440,7 @@ func equalRowCountOnIndex(sctx planctx.PlanContext, idx *statistics.Index, b []b
 }
 
 // expBackoffEstimation estimate the multi-col cases following the Exponential Backoff. See comment below for details.
-func expBackoffEstimation(sctx planctx.PlanContext, idx *statistics.Index, coll *statistics.HistColl, indexRange *ranger.Range) (sel float64, minSel float64, maxSel float64, success bool, err error) {
+func expBackoffEstimation(sctx planctx.PlanContext, idx *statistics.Index, coll *statistics.HistColl, indexRange *ranger.Range, idxCols []*expression.Column) (sel float64, minSel float64, maxSel float64, success bool, err error) {
 	tmpRan := []*ranger.Range{
 		{
 			LowVal:    make([]types.Datum, 1),
@@ -504,6 +505,16 @@ func expBackoffEstimation(sctx planctx.PlanContext, idx *statistics.Index, coll 
 			}
 		}
 		if !foundStats {
+			// A virtual column never has column statistics, so skipping it would
+			// drop what may be the most selective column of the index. Fall back
+			// to the index-stats-based estimation instead, provided the index has
+			// statistics. See https://github.com/pingcap/tidb/issues/69134.
+			// Any other column lacking statistics keeps the existing behavior:
+			// skip it and estimate from the remaining columns.
+			if i < len(idxCols) && idxCols[i] != nil && idxCols[i].VirtualExpr != nil &&
+				(idx.Histogram.Len() > 0 || idx.TopN.Num() > 0) {
+				return 0, 0, 0, false, nil
+			}
 			continue
 		}
 		singleColumnEstResults = append(singleColumnEstResults, selectivity)

--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -39,6 +39,8 @@ import (
 // GetRowCountByIndexRanges estimates the row count by a slice of Range.
 // idxCols is used when index statistics are invalid (coll may not have index info), and to recognize
 // virtual columns inside expBackoffEstimation. It can be nil, in which case both usages are skipped.
+// When exp-backoff cannot estimate a virtual column, prefer the composite-index estimate as a fallback.
+// This may improve estimation but remains subject to encoded index histogram interpolation accuracy.
 func GetRowCountByIndexRanges(sctx planctx.PlanContext, coll *statistics.HistColl, idxID int64, indexRanges []*ranger.Range, idxCols []*expression.Column) (result statistics.RowEstimate, err error) {
 	var count, maxCount float64
 	sc := sctx.GetSessionVars().StmtCtx

--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -189,7 +189,7 @@ func Selectivity(
 			if err != nil {
 				return 0, errors.Trace(err)
 			}
-			countResult, err := GetRowCountByIndexRanges(ctx, coll, id, ranges, nil)
+			countResult, err := GetRowCountByIndexRanges(ctx, coll, id, ranges, idxCols)
 			if err != nil {
 				return 0, errors.Trace(err)
 			}

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -752,6 +752,44 @@ func TestIssue57948(t *testing.T) {
 	testKit.MustQuery("explain format='brief' select * from t where b = 5").CheckContain("idxb(b)")
 }
 
+func TestVirtualColumnIndexEstimation(t *testing.T) {
+	// A composite index whose last column is a virtual generated column. Virtual
+	// columns have no column statistics, so the exponential backoff estimation
+	// would skip the most selective column and heavily over-estimate the row
+	// count. Verify that estimation falls back to the index statistics instead.
+	// See https://github.com/pingcap/tidb/issues/69134.
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@global.tidb_enable_auto_analyze='OFF'")
+	tk.MustExec("create table t(a int, b int, c int, d int as (c + 1) virtual, index iabd(a, b, d))")
+	// a and b are low-selectivity columns (5 distinct values each), d is highly selective.
+	tk.MustExec("insert into t(a, b, c) select mod(x.a, 5), mod(x.a, 5), x.a from (with recursive x as (select 1 as a union all select a + 1 from x where a < 500) select a from x) as x")
+	// Use few buckets so the multi-column histogram upper bound cannot mask the
+	// exponential backoff over-estimation.
+	tk.MustExec("analyze table t with 8 buckets, 0 topn")
+	rows := tk.MustQuery("explain analyze format='brief' select * from t use index(iabd) where a = 1 and b = 1 and d > 447").Rows()
+	estRows, err := strconv.ParseFloat(rows[0][1].(string), 64)
+	require.NoError(t, err)
+	actRows, err := strconv.ParseFloat(rows[0][2].(string), 64)
+	require.NoError(t, err)
+	require.Equal(t, float64(10), actRows)
+	// Exponential backoff using only a and b would estimate ~45 rows.
+	require.Less(t, estRows, 25.0)
+
+	// Control case: identical data, but d is a real (non-virtual) column excluded
+	// from analyze, so it has no column stats. The exp-backoff estimate from the
+	// remaining columns (clamped by the index histogram upper bound to ~16 rows)
+	// must be kept, not abandoned for the raw index-stats estimate (~2 rows).
+	tk.MustExec("create table t2(a int, b int, c int, d int, index iabd(a, b, d))")
+	tk.MustExec("insert into t2 select a, b, c, d from t")
+	tk.MustExec("analyze table t2 columns a, b with 8 buckets, 0 topn")
+	rows = tk.MustQuery("explain analyze format='brief' select * from t2 use index(iabd) where a = 1 and b = 1 and d > 447").Rows()
+	estRows, err = strconv.ParseFloat(rows[0][1].(string), 64)
+	require.NoError(t, err)
+	require.Greater(t, estRows, 10.0)
+}
+
 func TestNewIndexWithColumnStats(t *testing.T) {
 	// Test two identical tables where one has no statistics at all, and the other only has column statistics but no index statistics
 	// Test that we supplement index estimation with column stats if there are no index stats available

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -766,8 +766,13 @@ func TestVirtualColumnIndexEstimation(t *testing.T) {
 	// a and b are low-selectivity columns (5 distinct values each), d is highly selective.
 	tk.MustExec("insert into t(a, b, c) select mod(x.a, 5), mod(x.a, 5), x.a from (with recursive x as (select 1 as a union all select a + 1 from x where a < 500) select a from x) as x")
 	// Use few buckets so the multi-column histogram upper bound cannot mask the
-	// exponential backoff over-estimation.
+	// exponential backoff over-estimation. Pin analyze version 2 so the test
+	// always exercises the stats-v2 estimation path.
+	tk.MustExec("set @@session.tidb_analyze_version=2")
 	tk.MustExec("analyze table t with 8 buckets, 0 topn")
+	// Confirm index iabd statistics were actually built before relying on the
+	// row-count comparisons below.
+	require.NotEmpty(t, tk.MustQuery("show stats_histograms where db_name = 'test' and table_name = 't' and column_name = 'iabd' and is_index = 1").Rows())
 	rows := tk.MustQuery("explain analyze format='brief' select * from t use index(iabd) where a = 1 and b = 1 and d > 447").Rows()
 	estRows, err := strconv.ParseFloat(rows[0][1].(string), 64)
 	require.NoError(t, err)
@@ -783,7 +788,11 @@ func TestVirtualColumnIndexEstimation(t *testing.T) {
 	// must be kept, not abandoned for the raw index-stats estimate (~2 rows).
 	tk.MustExec("create table t2(a int, b int, c int, d int, index iabd(a, b, d))")
 	tk.MustExec("insert into t2 select a, b, c, d from t")
+	tk.MustExec("set @@session.tidb_analyze_version=2")
 	tk.MustExec("analyze table t2 columns a, b with 8 buckets, 0 topn")
+	// Confirm index iabd statistics were actually built before relying on the
+	// row-count comparison below.
+	require.NotEmpty(t, tk.MustQuery("show stats_histograms where db_name = 'test' and table_name = 't2' and column_name = 'iabd' and is_index = 1").Rows())
 	rows = tk.MustQuery("explain analyze format='brief' select * from t2 use index(iabd) where a = 1 and b = 1 and d > 447").Rows()
 	estRows, err = strconv.ParseFloat(rows[0][1].(string), 64)
 	require.NoError(t, err)


### PR DESCRIPTION
For a composite index containing a virtual column, the exponential backoff estimation skipped the virtual column because it can never have column statistics, which heavily over-estimates the row count when that column is highly selective. Fall back to the index-stats-based estimation instead, provided the index has statistics. Columns missing statistics for any other reason keep the existing exp-backoff behavior.

Close #69134

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69134 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cardinality and row-count estimation for index ranges that include virtual generated columns, preventing over-estimation and producing more accurate query plans.

* **Tests**
  * Added coverage for virtual-column index estimation to verify correct behavior in both virtual-column fallback and non-virtual control scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->