### PR TITLE
pkg/mvservice, pkg/session: add MV alert table and history cleanup

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -116,5 +116,5 @@ func TestCheckSysTableCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(223), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(225), session.CurrentBootstrapVersion)
 }

--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -596,6 +596,15 @@ func (w *worker) rollbackCreateMaterializedView(jobCtx *jobContext, job *model.J
 	if err := w.deleteCreateMaterializedViewRefreshInfo(jobCtx, job.TableID); err != nil {
 		return ver, errors.Trace(err)
 	}
+	if err := w.deleteCreateMaterializedViewRefreshAlert(jobCtx, job.TableID); err != nil {
+		logutil.DDLLogger().Warn(
+			"create materialized view rollback: failed to delete refresh alert",
+			zap.String("schemaName", job.SchemaName),
+			zap.String("tableName", mvTblInfo.Name.O),
+			zap.Int64("mviewID", job.TableID),
+			zap.Error(err),
+		)
+	}
 
 	job.State = model.JobStateRollbackDone
 	job.SchemaState = model.StateNone
@@ -1012,6 +1021,25 @@ func (w *worker) deleteCreateMaterializedViewRefreshInfo(jobCtx *jobContext, mvi
 			err = infoschema.ErrTableNotExists.GenWithStackByArgs("mysql", "tidb_mview_refresh_info")
 		}
 	})
+	if infoschema.ErrTableNotExists.Equal(err) {
+		return nil
+	}
+	return errors.Trace(err)
+}
+
+func (w *worker) deleteCreateMaterializedViewRefreshAlert(jobCtx *jobContext, mviewID int64) error {
+	ctx := jobCtx.stepCtx
+	if ctx == nil {
+		ctx = w.workCtx
+	}
+	deleteSQL := sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID = %?", mviewID)
+	var err error
+	failpoint.Inject("mockDeleteCreateMaterializedViewRefreshAlertErr", func(val failpoint.Value) {
+		err = errors.New(val.(string))
+	})
+	if err == nil {
+		_, err = w.sess.Execute(ctx, deleteSQL, "mview-refresh-alert-delete")
+	}
 	if infoschema.ErrTableNotExists.Equal(err) {
 		return nil
 	}

--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -1028,17 +1028,12 @@ func (w *worker) deleteCreateMaterializedViewRefreshInfo(jobCtx *jobContext, mvi
 }
 
 func (w *worker) deleteCreateMaterializedViewRefreshAlert(jobCtx *jobContext, mviewID int64) error {
-	ctx := jobCtx.stepCtx
-	if ctx == nil {
-		ctx = w.workCtx
-	}
-	deleteSQL := sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID = %?", mviewID)
 	var err error
 	failpoint.Inject("mockDeleteCreateMaterializedViewRefreshAlertErr", func(val failpoint.Value) {
 		err = errors.New(val.(string))
 	})
 	if err == nil {
-		_, err = w.sess.Execute(ctx, deleteSQL, "mview-refresh-alert-delete")
+		err = w.executeDeleteMViewRefreshAlert(jobCtx, mviewID, "mview-refresh-alert-delete")
 	}
 	if infoschema.ErrTableNotExists.Equal(err) {
 		return nil

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -707,7 +707,22 @@ func (e *executor) alterMaterializedViewRefresh(
 	if !shouldUpdateNextTime {
 		return nil
 	}
-	return errors.Trace(e.updateMaterializedViewRefreshInfoNextTime(ctx, mviewID, nextTime))
+	updated, err := e.updateMaterializedViewRefreshInfoNextTime(ctx, mviewID, nextTime)
+	if err != nil {
+		return err
+	}
+	if updated && nextTime == nil {
+		if err := e.deleteMaterializedViewRefreshAlert(ctx, mviewID); err != nil {
+			logutil.DDLLogger().Warn(
+				"alter materialized view refresh: failed to delete refresh alert after disabling schedule",
+				zap.String("schemaName", schemaName.O),
+				zap.String("tableName", viewName.O),
+				zap.Int64("mviewID", mviewID),
+				zap.Error(err),
+			)
+		}
+	}
+	return nil
 }
 
 func (e *executor) alterMaterializedViewAttributes(
@@ -914,8 +929,8 @@ func (e *executor) updateMaterializedViewRefreshInfoNextTime(
 	ctx sessionctx.Context,
 	mviewID int64,
 	nextTime *string,
-) error {
-	return errors.Trace(e.bestEffortUpdateMaterializedScheduleInfoNextTime(
+) (bool, error) {
+	return e.bestEffortUpdateMaterializedScheduleInfoNextTime(
 		ctx,
 		alterMaterializedScheduleInfoNextTimeUpdateSpec{
 			operation:                  "alter materialized view refresh",
@@ -926,12 +941,40 @@ func (e *executor) updateMaterializedViewRefreshInfoNextTime(
 			tableNotExistsErrConverter: convertAlterMaterializedViewRefreshInfoTableNotExistsErr,
 		},
 		nextTime,
-	))
+	)
+}
+
+func (e *executor) deleteMaterializedViewRefreshAlert(ctx sessionctx.Context, mviewID int64) error {
+	kctx := kv.WithInternalSourceType(e.ctx, kv.InternalTxnDDL)
+	ddlSess, releaseInternalSession, err := e.newInternalMaterializedScheduleInfoUpdateSession(ctx)
+	if err != nil {
+		return err
+	}
+	defer releaseInternalSession()
+
+	deleteSQL := sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID = %?", mviewID)
+	_, err = ddlSess.Execute(kctx, deleteSQL, "alter-materialized-view-refresh-delete-alert")
+	failpoint.Inject("mockDeleteMaterializedViewRefreshAlertTableNotExists", func(val failpoint.Value) {
+		if val.(bool) {
+			err = infoschema.ErrTableNotExists.GenWithStackByArgs("mysql", "tidb_mview_refresh_alert")
+		}
+	})
+	if err != nil {
+		return errors.Trace(convertAlterMaterializedViewRefreshAlertTableNotExistsErr(err))
+	}
+	return nil
 }
 
 func convertAlterMaterializedViewRefreshInfoTableNotExistsErr(err error) error {
 	if infoschema.ErrTableNotExists.Equal(err) {
 		return errors.New("alter materialized view refresh: required system table mysql.tidb_mview_refresh_info does not exist")
+	}
+	return err
+}
+
+func convertAlterMaterializedViewRefreshAlertTableNotExistsErr(err error) error {
+	if infoschema.ErrTableNotExists.Equal(err) {
+		return errors.New("alter materialized view refresh: required system table mysql.tidb_mview_refresh_alert does not exist")
 	}
 	return err
 }
@@ -969,7 +1012,7 @@ func (e *executor) updateMaterializedViewLogPurgeInfoNextTime(
 	mlogID int64,
 	nextTime *string,
 ) error {
-	return errors.Trace(e.bestEffortUpdateMaterializedScheduleInfoNextTime(
+	_, err := e.bestEffortUpdateMaterializedScheduleInfoNextTime(
 		ctx,
 		alterMaterializedScheduleInfoNextTimeUpdateSpec{
 			operation:                  "alter materialized view log purge",
@@ -980,7 +1023,8 @@ func (e *executor) updateMaterializedViewLogPurgeInfoNextTime(
 			tableNotExistsErrConverter: convertAlterMaterializedViewLogPurgeInfoTableNotExistsErr,
 		},
 		nextTime,
-	))
+	)
+	return errors.Trace(err)
 }
 
 type alterMaterializedScheduleInfoNextTimeUpdateSpec struct {
@@ -1009,18 +1053,18 @@ func (e *executor) bestEffortUpdateMaterializedScheduleInfoNextTime(
 	ctx sessionctx.Context,
 	spec alterMaterializedScheduleInfoNextTimeUpdateSpec,
 	nextTime *string,
-) error {
+) (bool, error) {
 	kctx := kv.WithInternalSourceType(e.ctx, kv.InternalTxnDDL)
 	// The outer ALTER MATERIALIZED VIEW / LOG statement is privilege-checked on the target
 	// MV/base table only. The follow-up NEXT_TIME update touches mysql.* system tables and must
 	// therefore run on a true DDL internal session instead of reusing the caller session.
 	ddlSess, releaseInternalSession, err := e.newInternalMaterializedScheduleInfoUpdateSession(ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer releaseInternalSession()
 	if err := ddlSess.BeginPessimistic(kctx); err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 	committed := false
 	defer func() {
@@ -1039,12 +1083,12 @@ func (e *executor) bestEffortUpdateMaterializedScheduleInfoNextTime(
 	if err != nil {
 		if isAlterMaterializedScheduleInfoUpdateLockContentionErr(err) {
 			appendAlterMaterializedScheduleInfoUpdateWarning(ctx, spec)
-			return nil
+			return false, nil
 		}
-		return errors.Trace(spec.tableNotExistsErrConverter(err))
+		return false, errors.Trace(spec.tableNotExistsErrConverter(err))
 	}
 	if len(rows) == 0 {
-		return errors.New(spec.rowMissingErr)
+		return false, errors.New(spec.rowMissingErr)
 	}
 
 	var nextTimeArg any
@@ -1059,19 +1103,19 @@ func (e *executor) bestEffortUpdateMaterializedScheduleInfoNextTime(
 	if _, err := ddlSess.Execute(kctx, updateSQL, spec.operation+"-update-next-time", nextTimeArg, spec.objectID); err != nil {
 		if isAlterMaterializedScheduleInfoUpdateLockContentionErr(err) {
 			appendAlterMaterializedScheduleInfoUpdateWarning(ctx, spec)
-			return nil
+			return false, nil
 		}
-		return errors.Trace(spec.tableNotExistsErrConverter(err))
+		return false, errors.Trace(spec.tableNotExistsErrConverter(err))
 	}
 	if err := ddlSess.Commit(kctx); err != nil {
 		if isAlterMaterializedScheduleInfoUpdateLockContentionErr(err) {
 			appendAlterMaterializedScheduleInfoUpdateWarning(ctx, spec)
-			return nil
+			return false, nil
 		}
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 	committed = true
-	return nil
+	return true, nil
 }
 
 func isAlterMaterializedScheduleInfoUpdateLockContentionErr(err error) bool {

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -952,17 +952,23 @@ func (e *executor) deleteMaterializedViewRefreshAlert(ctx sessionctx.Context, mv
 	}
 	defer releaseInternalSession()
 
-	deleteSQL := sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID = %?", mviewID)
-	_, err = ddlSess.Execute(kctx, deleteSQL, "alter-materialized-view-refresh-delete-alert")
+	_, err = ddlSess.Execute(kctx, buildDeleteMViewRefreshAlertSQL(mviewID), "alter-materialized-view-refresh-delete-alert")
 	failpoint.Inject("mockDeleteMaterializedViewRefreshAlertTableNotExists", func(val failpoint.Value) {
 		if val.(bool) {
 			err = infoschema.ErrTableNotExists.GenWithStackByArgs("mysql", "tidb_mview_refresh_alert")
 		}
 	})
 	if err != nil {
-		return errors.Trace(convertAlterMaterializedViewRefreshAlertTableNotExistsErr(err))
+		return errors.Trace(convertMViewRefreshAlertTableNotExistsErr(
+			err,
+			errors.New("alter materialized view refresh: required system table mysql.tidb_mview_refresh_alert does not exist"),
+		))
 	}
 	return nil
+}
+
+func buildDeleteMViewRefreshAlertSQL(mviewID int64) string {
+	return sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID = %?", mviewID)
 }
 
 func convertAlterMaterializedViewRefreshInfoTableNotExistsErr(err error) error {
@@ -972,9 +978,9 @@ func convertAlterMaterializedViewRefreshInfoTableNotExistsErr(err error) error {
 	return err
 }
 
-func convertAlterMaterializedViewRefreshAlertTableNotExistsErr(err error) error {
+func convertMViewRefreshAlertTableNotExistsErr(err error, tableMissingErr error) error {
 	if infoschema.ErrTableNotExists.Equal(err) {
-		return errors.New("alter materialized view refresh: required system table mysql.tidb_mview_refresh_alert does not exist")
+		return tableMissingErr
 	}
 	return err
 }

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -20,12 +20,14 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/label"
+	"github.com/pingcap/tidb/pkg/ddl/logutil"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"go.uber.org/zap"
 )
 
 func onCreateSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
@@ -213,6 +215,15 @@ func (w *worker) onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ 
 			if tblInfo.MaterializedView != nil {
 				if err = w.deleteCreateMaterializedViewRefreshInfo(jobCtx, tblInfo.ID); err != nil {
 					return ver, errors.Trace(err)
+				}
+				if err = w.deleteCreateMaterializedViewRefreshAlert(jobCtx, tblInfo.ID); err != nil {
+					logutil.DDLLogger().Warn(
+						"drop schema: failed to delete materialized view refresh alert",
+						zap.String("schemaName", job.SchemaName),
+						zap.String("tableName", tblInfo.Name.O),
+						zap.Int64("mviewID", tblInfo.ID),
+						zap.Error(err),
+					)
 				}
 			}
 			if tblInfo.MaterializedViewLog != nil {

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -131,6 +131,15 @@ func (w *worker) onDropTableOrView(jobCtx *jobContext, job *model.Job) (ver int6
 			if err = w.deleteCreateMaterializedViewRefreshInfo(jobCtx, job.TableID); err != nil {
 				return ver, errors.Trace(err)
 			}
+			if err = w.deleteCreateMaterializedViewRefreshAlert(jobCtx, job.TableID); err != nil {
+				logutil.DDLLogger().Warn(
+					"drop table/view: failed to delete materialized view refresh alert",
+					zap.String("schemaName", job.SchemaName),
+					zap.String("tableName", tblInfo.Name.O),
+					zap.Int64("mviewID", job.TableID),
+					zap.Error(err),
+				)
+			}
 		}
 		if tblInfo.MaterializedViewLog != nil {
 			if err = w.deleteMaterializedViewLogPurgeInfo(jobCtx, job.TableID); err != nil {
@@ -1267,6 +1276,14 @@ func (w *worker) onRefreshMaterializedViewCompleteOutOfPlaceCutover(jobCtx *jobC
 	failpoint.Inject("mockMViewRefreshOutOfPlaceCutoverAfterMigrateRefreshInfoError", func() {
 		failpoint.Return(ver, errors.New("mock refresh materialized view complete OUT OF PLACE cutover error after migrating refresh info"))
 	})
+	if err := w.deleteMViewRefreshAlertForOutOfPlaceCutover(jobCtx, args.OldMViewID); err != nil {
+		logutil.DDLLogger().Warn(
+			"refresh materialized view complete OUT OF PLACE cutover: failed to delete stale refresh alert",
+			zap.Int64("oldMViewID", args.OldMViewID),
+			zap.Int64("shadowTableID", args.ShadowTableID),
+			zap.Error(err),
+		)
+	}
 
 	if err := jobCtx.metaMut.DropTableOrView(job.SchemaID, args.OldMViewID); err != nil {
 		return ver, errors.Trace(err)
@@ -1456,10 +1473,36 @@ func (w *worker) migrateMViewRefreshInfoForOutOfPlaceCutover(
 	return nil
 }
 
+func (w *worker) deleteMViewRefreshAlertForOutOfPlaceCutover(jobCtx *jobContext, oldMViewID int64) error {
+	ctx := jobCtx.stepCtx
+	if ctx == nil {
+		ctx = w.workCtx
+	}
+	_, err := w.sess.Execute(
+		ctx,
+		"DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID = %?",
+		"mview-refresh-cutover-delete-refresh-alert",
+		oldMViewID,
+	)
+	if err != nil {
+		return errors.Trace(convertMViewRefreshAlertTableNotExistsErrOnOutOfPlaceCutover(err))
+	}
+	return nil
+}
+
 func convertMViewRefreshInfoTableNotExistsErrOnOutOfPlaceCutover(err error) error {
 	if infoschema.ErrTableNotExists.Equal(err) {
 		return dbterror.ErrInvalidDDLJob.GenWithStackByArgs(
 			"refresh materialized view complete OUT OF PLACE cutover: required system table mysql.tidb_mview_refresh_info does not exist",
+		)
+	}
+	return err
+}
+
+func convertMViewRefreshAlertTableNotExistsErrOnOutOfPlaceCutover(err error) error {
+	if infoschema.ErrTableNotExists.Equal(err) {
+		return dbterror.ErrInvalidDDLJob.GenWithStackByArgs(
+			"refresh materialized view complete OUT OF PLACE cutover: required system table mysql.tidb_mview_refresh_alert does not exist",
 		)
 	}
 	return err

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -1474,35 +1474,35 @@ func (w *worker) migrateMViewRefreshInfoForOutOfPlaceCutover(
 }
 
 func (w *worker) deleteMViewRefreshAlertForOutOfPlaceCutover(jobCtx *jobContext, oldMViewID int64) error {
+	err := w.executeDeleteMViewRefreshAlert(jobCtx, oldMViewID, "mview-refresh-cutover-delete-refresh-alert")
+	if err != nil {
+		return errors.Trace(convertMViewRefreshAlertTableNotExistsErr(
+			err,
+			dbterror.ErrInvalidDDLJob.GenWithStackByArgs(
+				"refresh materialized view complete OUT OF PLACE cutover: required system table mysql.tidb_mview_refresh_alert does not exist",
+			),
+		))
+	}
+	return nil
+}
+
+func (w *worker) executeDeleteMViewRefreshAlert(jobCtx *jobContext, mviewID int64, resourceGroupTag string) error {
 	ctx := jobCtx.stepCtx
 	if ctx == nil {
 		ctx = w.workCtx
 	}
 	_, err := w.sess.Execute(
 		ctx,
-		"DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID = %?",
-		"mview-refresh-cutover-delete-refresh-alert",
-		oldMViewID,
+		buildDeleteMViewRefreshAlertSQL(mviewID),
+		resourceGroupTag,
 	)
-	if err != nil {
-		return errors.Trace(convertMViewRefreshAlertTableNotExistsErrOnOutOfPlaceCutover(err))
-	}
-	return nil
+	return err
 }
 
 func convertMViewRefreshInfoTableNotExistsErrOnOutOfPlaceCutover(err error) error {
 	if infoschema.ErrTableNotExists.Equal(err) {
 		return dbterror.ErrInvalidDDLJob.GenWithStackByArgs(
 			"refresh materialized view complete OUT OF PLACE cutover: required system table mysql.tidb_mview_refresh_info does not exist",
-		)
-	}
-	return err
-}
-
-func convertMViewRefreshAlertTableNotExistsErrOnOutOfPlaceCutover(err error) error {
-	if infoschema.ErrTableNotExists.Equal(err) {
-		return dbterror.ErrInvalidDDLJob.GenWithStackByArgs(
-			"refresh materialized view complete OUT OF PLACE cutover: required system table mysql.tidb_mview_refresh_alert does not exist",
 		)
 	}
 	return err

--- a/pkg/executor/importer/importer_testkit_test.go
+++ b/pkg/executor/importer/importer_testkit_test.go
@@ -349,7 +349,7 @@ func TestProcessChunkWith(t *testing.T) {
 		require.NoError(t, err)
 		checksumMap := checksum.GetInnerChecksums()
 		require.Len(t, checksumMap, 1)
-		require.Equal(t, verify.MakeKVChecksum(111, 3, 17741217610264676959), *checksumMap[verify.DataKVGroupID])
+		require.Equal(t, verify.MakeKVChecksum(111, 3, 17084019350544669372), *checksumMap[verify.DataKVGroupID])
 	})
 }
 

--- a/pkg/executor/infoschema_cluster_table_test.go
+++ b/pkg/executor/infoschema_cluster_table_test.go
@@ -393,7 +393,7 @@ func TestTableStorageStats(t *testing.T) {
 		"test 2",
 	))
 	rows := tk.MustQuery("select TABLE_NAME from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql';").Rows()
-	result := 62
+	result := 63
 	require.Len(t, rows, result)
 
 	// More tests about the privileges.

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -913,22 +913,22 @@ func TestInfoSchemaDDLJobs(t *testing.T) {
 	tk2 := testkit.NewTestKit(t, store)
 	tk2.MustQuery(`SELECT JOB_ID, JOB_TYPE, SCHEMA_STATE, SCHEMA_ID, TABLE_ID, table_name, STATE
 					   FROM information_schema.ddl_jobs WHERE table_name = "t1";`).Check(testkit.RowsWithSep("|",
-		"139|add index|public|132|137|t1|synced",
-		"138|create table|public|132|137|t1|synced",
-		"125|add index|public|118|123|t1|synced",
-		"124|create table|public|118|123|t1|synced",
+		"141|add index|public|134|139|t1|synced",
+		"140|create table|public|134|139|t1|synced",
+		"127|add index|public|120|125|t1|synced",
+		"126|create table|public|120|125|t1|synced",
 	))
 	tk2.MustQuery(`SELECT JOB_ID, JOB_TYPE, SCHEMA_STATE, SCHEMA_ID, TABLE_ID, table_name, STATE
 					   FROM information_schema.ddl_jobs WHERE db_name = "d1" and JOB_TYPE LIKE "add index%%";`).Check(testkit.RowsWithSep("|",
-		"145|add index|public|132|143|t3|synced",
-		"142|add index|public|132|140|t2|synced",
-		"139|add index|public|132|137|t1|synced",
-		"136|add index|public|132|134|t0|synced",
+		"147|add index|public|134|145|t3|synced",
+		"144|add index|public|134|142|t2|synced",
+		"141|add index|public|134|139|t1|synced",
+		"138|add index|public|134|136|t0|synced",
 	))
 	tk2.MustQuery(`SELECT JOB_ID, JOB_TYPE, SCHEMA_STATE, SCHEMA_ID, TABLE_ID, table_name, STATE
 					   FROM information_schema.ddl_jobs WHERE db_name = "d0" and table_name = "t3";`).Check(testkit.RowsWithSep("|",
-		"131|add index|public|118|129|t3|synced",
-		"130|create table|public|118|129|t3|synced",
+		"133|add index|public|120|131|t3|synced",
+		"132|create table|public|120|131|t3|synced",
 	))
 	tk2.MustQuery(`SELECT JOB_ID, JOB_TYPE, SCHEMA_STATE, SCHEMA_ID, TABLE_ID, table_name, STATE
 						FROM information_schema.ddl_jobs WHERE state = "running";`).Check(testkit.Rows())
@@ -939,15 +939,15 @@ func TestInfoSchemaDDLJobs(t *testing.T) {
 		if job.SchemaState == model.StateWriteOnly && loaded.CompareAndSwap(false, true) {
 			tk2.MustQuery(`SELECT JOB_ID, JOB_TYPE, SCHEMA_STATE, SCHEMA_ID, TABLE_ID, table_name, STATE
 				   FROM information_schema.ddl_jobs WHERE table_name = "t0" and state = "running";`).Check(testkit.RowsWithSep("|",
-				"146 add index write only 118 120 t0 running",
+				"148 add index write only 120 122 t0 running",
 			))
 			tk2.MustQuery(`SELECT JOB_ID, JOB_TYPE, SCHEMA_STATE, SCHEMA_ID, TABLE_ID, table_name, STATE
 				   FROM information_schema.ddl_jobs WHERE db_name = "d0" and state = "running";`).Check(testkit.RowsWithSep("|",
-				"146 add index write only 118 120 t0 running",
+				"148 add index write only 120 122 t0 running",
 			))
 			tk2.MustQuery(`SELECT JOB_ID, JOB_TYPE, SCHEMA_STATE, SCHEMA_ID, TABLE_ID, table_name, STATE
 				   FROM information_schema.ddl_jobs WHERE state = "running";`).Check(testkit.RowsWithSep("|",
-				"146 add index write only 118 120 t0 running",
+				"148 add index write only 120 122 t0 running",
 			))
 		}
 	})
@@ -963,8 +963,8 @@ func TestInfoSchemaDDLJobs(t *testing.T) {
 	tk.MustExec("create table test2.t1(id int)")
 	tk.MustQuery(`SELECT JOB_ID, JOB_TYPE, SCHEMA_STATE, SCHEMA_ID, TABLE_ID, table_name, STATE
 					   FROM information_schema.ddl_jobs WHERE db_name = "test2" and table_name = "t1"`).Check(testkit.RowsWithSep("|",
-		"155|create table|public|152|154|t1|synced",
-		"150|create table|public|147|149|t1|synced",
+		"157|create table|public|154|156|t1|synced",
+		"152|create table|public|149|151|t1|synced",
 	))
 
 	// Test explain output, since the output may change in future.

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -661,7 +661,7 @@ func TestColumnTable(t *testing.T) {
 		testkit.RowsWithSep("|",
 			"test|tbl1|col_2"))
 	tk.MustQuery(`select count(*) from information_schema.columns;`).Check(
-		testkit.RowsWithSep("|", "5025"))
+		testkit.RowsWithSep("|", "5027"))
 }
 
 func TestIndexUsageTable(t *testing.T) {

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -661,7 +661,7 @@ func TestColumnTable(t *testing.T) {
 		testkit.RowsWithSep("|",
 			"test|tbl1|col_2"))
 	tk.MustQuery(`select count(*) from information_schema.columns;`).Check(
-		testkit.RowsWithSep("|", "5019"))
+		testkit.RowsWithSep("|", "5025"))
 }
 
 func TestIndexUsageTable(t *testing.T) {
@@ -708,7 +708,7 @@ func TestIndexUsageTable(t *testing.T) {
 		testkit.RowsWithSep("|",
 			"test|idt2|idx_4"))
 	tk.MustQuery(`select count(*) from information_schema.tidb_index_usage;`).Check(
-		testkit.RowsWithSep("|", "90"))
+		testkit.RowsWithSep("|", "92"))
 
 	tk.MustQuery(`select TABLE_SCHEMA, TABLE_NAME, INDEX_NAME from information_schema.tidb_index_usage
 				where TABLE_SCHEMA = 'test1';`).Check(testkit.Rows())

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -88,7 +88,9 @@ const (
 	mvRefreshAdvisoryLockTimeoutSec = int64(1)
 	mvRefreshShadowTablePrefix      = "__mv_shadow_"
 	mvRefreshImportIntoStoreName    = "TiKV"
-	mvTaskCancelWatchPollInterval   = 5 * time.Second
+	mvTaskMonitorPollInterval       = 5 * time.Second
+	mvTaskHistHeartbeatInterval     = 10 * time.Minute
+	mvTaskMonitorSQLTimeout         = 5 * time.Second
 )
 
 // PurgeMaterializedViewLogExec executes "PURGE MATERIALIZED VIEW LOG" as a utility-style statement.
@@ -198,43 +200,64 @@ func formatMVManualCancelRequester(user *auth.UserIdentity) string {
 }
 
 type mvTaskCancelPoller func(context.Context, sqlexec.SQLExecutor) (requested bool, requester string, err error)
+type mvTaskHeartbeatWriter func(context.Context, sqlexec.SQLExecutor) error
 
-func startMVTaskCancelWatcher(
+func startMVTaskMonitor(
 	taskCtx context.Context,
 	getSysSession func() (sessionctx.Context, error),
 	releaseWatchSession func(sessionctx.Context),
 	taskCancelController *mvTaskCancelController,
-	watchName string,
+	monitorName string,
 	poller mvTaskCancelPoller,
+	heartbeatWriter mvTaskHeartbeatWriter,
 ) (func(), error) {
 	if taskCancelController == nil {
-		return func() {}, errors.New("mv task cancel watcher: task cancel controller is nil")
+		return func() {}, errors.New("mv task monitor: task cancel controller is nil")
 	}
 
-	watchSctx, err := getSysSession()
+	monitorSctx, err := getSysSession()
 	if err != nil {
 		return func() {}, err
 	}
 
-	watcherCtx, stopWatcher := context.WithCancel(taskCtx)
-	watcherDone := make(chan struct{})
+	monitorCtx, stopMonitor := context.WithCancel(taskCtx)
+	monitorDone := make(chan struct{})
 	go func() {
-		defer close(watcherDone)
-		defer releaseWatchSession(watchSctx)
+		defer close(monitorDone)
+		defer releaseWatchSession(monitorSctx)
 
-		sqlExec := watchSctx.GetSQLExecutor()
-		ticker := time.NewTicker(getMVTaskCancelWatchPollInterval())
+		sqlExec := monitorSctx.GetSQLExecutor()
+		ticker := time.NewTicker(getMVTaskMonitorPollInterval())
 		defer ticker.Stop()
+		nextHeartbeatAt := time.Now().Add(getMVTaskHistHeartbeatInterval())
 
 		for {
-			requested, requester, err := poller(watcherCtx, sqlExec)
-			failpoint.InjectCall("mvTaskCancelWatcherPolled", watchName)
+			if heartbeatWriter != nil && !time.Now().Before(nextHeartbeatAt) {
+				heartbeatCtx, cancelHeartbeat := context.WithTimeout(monitorCtx, getMVTaskMonitorSQLTimeout())
+				err := heartbeatWriter(heartbeatCtx, sqlExec)
+				cancelHeartbeat()
+				nextHeartbeatAt = time.Now().Add(getMVTaskHistHeartbeatInterval())
+				if err != nil {
+					if monitorCtx.Err() != nil {
+						return
+					}
+					logutil.BgLogger().Warn("materialized view task heartbeat failed",
+						zap.String("monitor", monitorName),
+						zap.Error(err),
+					)
+				}
+			}
+
+			pollCtx, cancelPoll := context.WithTimeout(monitorCtx, getMVTaskMonitorSQLTimeout())
+			requested, requester, err := poller(pollCtx, sqlExec)
+			cancelPoll()
+			failpoint.InjectCall("mvTaskMonitorPolled", monitorName)
 			if err != nil {
-				if watcherCtx.Err() != nil {
+				if monitorCtx.Err() != nil {
 					return
 				}
-				logutil.BgLogger().Warn("materialized view task cancel watcher poll failed",
-					zap.String("watch", watchName),
+				logutil.BgLogger().Warn("materialized view task monitor cancel poll failed",
+					zap.String("monitor", monitorName),
 					zap.Error(err),
 				)
 			} else if requested {
@@ -244,7 +267,7 @@ func startMVTaskCancelWatcher(
 			}
 
 			select {
-			case <-watcherCtx.Done():
+			case <-monitorCtx.Done():
 				return
 			case <-ticker.C:
 			}
@@ -252,14 +275,14 @@ func startMVTaskCancelWatcher(
 	}()
 
 	return func() {
-		stopWatcher()
-		<-watcherDone
+		stopMonitor()
+		<-monitorDone
 	}, nil
 }
 
-func getMVTaskCancelWatchPollInterval() time.Duration {
-	interval := mvTaskCancelWatchPollInterval
-	failpoint.Inject("mockMVTaskCancelWatchPollInterval", func(val failpoint.Value) {
+func getMVTaskMonitorPollInterval() time.Duration {
+	interval := mvTaskMonitorPollInterval
+	failpoint.Inject("mockMVTaskMonitorPollInterval", func(val failpoint.Value) {
 		switch v := val.(type) {
 		case int:
 			interval = time.Duration(v) * time.Millisecond
@@ -268,6 +291,32 @@ func getMVTaskCancelWatchPollInterval() time.Duration {
 		}
 	})
 	return interval
+}
+
+func getMVTaskHistHeartbeatInterval() time.Duration {
+	interval := mvTaskHistHeartbeatInterval
+	failpoint.Inject("mockMVTaskHistHeartbeatInterval", func(val failpoint.Value) {
+		switch v := val.(type) {
+		case int:
+			interval = time.Duration(v) * time.Millisecond
+		case int64:
+			interval = time.Duration(v) * time.Millisecond
+		}
+	})
+	return interval
+}
+
+func getMVTaskMonitorSQLTimeout() time.Duration {
+	timeout := mvTaskMonitorSQLTimeout
+	failpoint.Inject("mockMVTaskMonitorSQLTimeout", func(val failpoint.Value) {
+		switch v := val.(type) {
+		case int:
+			timeout = time.Duration(v) * time.Millisecond
+		case int64:
+			timeout = time.Duration(v) * time.Millisecond
+		}
+	})
+	return timeout
 }
 
 func readRefreshHistCancelRequest(
@@ -376,6 +425,56 @@ WHERE PURGE_JOB_ID = %?
 		return false, errors.Trace(err)
 	}
 	return sctx.GetSessionVars().StmtCtx.AffectedRows() > 0, nil
+}
+
+func updateRefreshHistHeartbeat(
+	kctx context.Context,
+	sqlExec sqlexec.SQLExecutor,
+	refreshJobID uint64,
+	mviewID int64,
+) error {
+	_, err := sqlExec.ExecuteInternal(
+		kctx,
+		`UPDATE mysql.tidb_mview_refresh_hist
+SET LAST_HEARTBEAT_AT = NOW(6)
+WHERE REFRESH_JOB_ID = %?
+  AND MVIEW_ID = %?
+  AND REFRESH_STATUS = 'running'`,
+		refreshJobID,
+		mviewID,
+	)
+	if err != nil {
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return errors.New("refresh materialized view: required system table mysql.tidb_mview_refresh_hist does not exist")
+		}
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func updatePurgeHistHeartbeat(
+	kctx context.Context,
+	sqlExec sqlexec.SQLExecutor,
+	purgeJobID uint64,
+	mlogID int64,
+) error {
+	_, err := sqlExec.ExecuteInternal(
+		kctx,
+		`UPDATE mysql.tidb_mlog_purge_hist
+SET LAST_HEARTBEAT_AT = NOW(6)
+WHERE PURGE_JOB_ID = %?
+  AND MLOG_ID = %?
+  AND PURGE_STATUS = 'running'`,
+		purgeJobID,
+		mlogID,
+	)
+	if err != nil {
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return errors.New("required system table mysql.tidb_mlog_purge_hist does not exist")
+		}
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 func checkCancelMaterializedViewJobPrivilege(
@@ -1211,9 +1310,9 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		}
 		defer e.ReleaseSysSession(releaseCtx, scheduleEvalSctx)
 	}
-	stopCancelWatcher := func() {}
+	stopTaskMonitor := func() {}
 	defer func() {
-		stopCancelWatcher()
+		stopTaskMonitor()
 	}()
 
 	finalizeFailure := func(purgeErr error) error {
@@ -1348,7 +1447,7 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 					return errors.Trace(err)
 				}
 				purgeHistRunningInserted = true
-				stopCancelWatcher, err = startMVTaskCancelWatcher(
+				stopTaskMonitor, err = startMVTaskMonitor(
 					kctx,
 					e.GetSysSession,
 					func(sctx sessionctx.Context) {
@@ -1358,6 +1457,9 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 					fmt.Sprintf("mlog-purge-%d", purgeJobID),
 					func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) (bool, string, error) {
 						return readPurgeHistCancelRequest(watchCtx, watchSQLExec, purgeJobID, mlogID)
+					},
+					func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) error {
+						return updatePurgeHistHeartbeat(watchCtx, watchSQLExec, purgeJobID, mlogID)
 					},
 				)
 				if err != nil {
@@ -1825,8 +1927,10 @@ func insertMLogPurgeHistRunning(
 		PURGE_METHOD,
 		PURGE_TIME,
 		PURGE_ROWS,
-		PURGE_STATUS
+		PURGE_STATUS,
+		LAST_HEARTBEAT_AT
 	) VALUES (
+		%?,
 		%?,
 		%?,
 		%?,
@@ -1847,6 +1951,7 @@ func insertMLogPurgeHistRunning(
 		purgeStartAt,
 		int64(0),
 		purgeHistStatusRunning,
+		purgeStartAt,
 	)
 	if err != nil {
 		if infoschema.ErrTableNotExists.Equal(err) {
@@ -2326,7 +2431,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 			}
 			return errors.Trace(finalErr)
 		}
-		stopCancelWatcher, err := startMVTaskCancelWatcher(
+		stopTaskMonitor, err := startMVTaskMonitor(
 			kctx,
 			e.GetSysSession,
 			func(sctx sessionctx.Context) {
@@ -2337,11 +2442,14 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 			func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) (bool, string, error) {
 				return readRefreshHistCancelRequest(watchCtx, watchSQLExec, refreshJobID, mviewID)
 			},
+			func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) error {
+				return updateRefreshHistHeartbeat(watchCtx, watchSQLExec, refreshJobID, mviewID)
+			},
 		)
 		if err != nil {
 			return finalizeFailure(err)
 		}
-		defer stopCancelWatcher()
+		defer stopTaskMonitor()
 		failpoint.InjectCall("refreshMaterializedViewAfterInsertRefreshHistRunning")
 		failpoint.Inject("pauseRefreshMaterializedViewAfterInsertRefreshHistRunning", func() {})
 
@@ -2522,7 +2630,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		}
 		return errors.Trace(finalErr)
 	}
-	stopCancelWatcher, err := startMVTaskCancelWatcher(
+	stopTaskMonitor, err := startMVTaskMonitor(
 		kctx,
 		e.GetSysSession,
 		func(sctx sessionctx.Context) {
@@ -2533,11 +2641,14 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) (bool, string, error) {
 			return readRefreshHistCancelRequest(watchCtx, watchSQLExec, refreshJobID, mviewID)
 		},
+		func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) error {
+			return updateRefreshHistHeartbeat(watchCtx, watchSQLExec, refreshJobID, mviewID)
+		},
 	)
 	if err != nil {
 		return finalizeFailure(err)
 	}
-	defer stopCancelWatcher()
+	defer stopTaskMonitor()
 
 	failpoint.InjectCall("refreshMaterializedViewAfterInsertRefreshHistRunning")
 	failpoint.Inject("pauseRefreshMaterializedViewAfterInsertRefreshHistRunning", func() {})
@@ -3805,8 +3916,10 @@ func insertRefreshHistRunning(
 	MV_NAME,
 	REFRESH_METHOD,
 	REFRESH_TIME,
-	REFRESH_STATUS
+	REFRESH_STATUS,
+	LAST_HEARTBEAT_AT
 ) VALUES (
+	%?,
 	%?,
 	%?,
 	%?,
@@ -3825,6 +3938,7 @@ func insertRefreshHistRunning(
 		refreshMethod,
 		refreshStartAt,
 		refreshHistStatusRunning,
+		refreshStartAt,
 	); err != nil {
 		if infoschema.ErrTableNotExists.Equal(err) {
 			return errors.New("refresh materialized view: required system table mysql.tidb_mview_refresh_hist does not exist")

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -262,7 +262,7 @@ func startMVTaskMonitor(
 				)
 			} else if requested {
 				taskCancelController.requestManualCancelByRequester(requester)
-				failpoint.InjectCall("mvTaskCancelWatcherRequested", watchName)
+				failpoint.InjectCall("mvTaskCancelWatcherRequested", monitorName)
 				return
 			}
 

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -963,6 +963,67 @@ func TestAlterMaterializedViewRefreshUpdatesNextTimeWithAlterPrivilegeOnly(t *te
 	)).Check(testkit.Rows("1 1 1"))
 }
 
+func TestAlterMaterializedViewRefreshDisableScheduleClearsAlert(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 2 hour) as select a, sum(b), count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv"))
+	require.NoError(t, err)
+	mviewID := mvTable.Meta().ID
+
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MV_SCHEMA, MV_NAME, ALERT_LEVEL, LAST_SUCCESS_TIME, UPDATED_AT) values (%d, 'test', 'mv', 'warning', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		mviewID,
+	))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d", mviewID)).
+		Check(testkit.Rows("1"))
+
+	tk.MustExec("alter materialized view mv refresh")
+
+	tk.MustQuery(fmt.Sprintf("select NEXT_TIME is null from mysql.tidb_mview_refresh_info where MVIEW_ID = %d", mviewID)).
+		Check(testkit.Rows("1"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d", mviewID)).
+		Check(testkit.Rows("0"))
+}
+
+func TestAlterMaterializedViewRefreshDisableScheduleIgnoresAlertDeleteFailure(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 2 hour) as select a, sum(b), count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv"))
+	require.NoError(t, err)
+	mviewID := mvTable.Meta().ID
+
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MV_SCHEMA, MV_NAME, ALERT_LEVEL, LAST_SUCCESS_TIME, UPDATED_AT) values (%d, 'test', 'mv', 'warning', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		mviewID,
+	))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d", mviewID)).
+		Check(testkit.Rows("1"))
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockDeleteMaterializedViewRefreshAlertTableNotExists", "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockDeleteMaterializedViewRefreshAlertTableNotExists"))
+	}()
+
+	tk.MustExec("alter materialized view mv refresh")
+
+	tk.MustQuery(fmt.Sprintf("select NEXT_TIME is null from mysql.tidb_mview_refresh_info where MVIEW_ID = %d", mviewID)).
+		Check(testkit.Rows("1"))
+}
+
 func TestAlterMaterializedViewRefreshBestEffortInfoUpdateWarning(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
@@ -1686,12 +1747,125 @@ func TestDropDatabaseCleansMaterializedViewAndLogInfo(t *testing.T) {
 		Check(testkit.Rows("1"))
 	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogID)).
 		Check(testkit.Rows("1"))
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MV_SCHEMA, MV_NAME, ALERT_LEVEL, LAST_SUCCESS_TIME, UPDATED_AT) values (%d, '%s', 'mv', 'overdue', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		mvID,
+		dbName,
+	))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).
+		Check(testkit.Rows("1"))
 
 	tk.MustExec("drop database " + dbName)
 	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).
 		Check(testkit.Rows("0"))
 	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogID)).
 		Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).
+		Check(testkit.Rows("0"))
+}
+
+func TestDropMaterializedViewCleansRefreshAlert(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv"))
+	require.NoError(t, err)
+	mvID := mvTable.Meta().ID
+
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MV_SCHEMA, MV_NAME, ALERT_LEVEL, LAST_SUCCESS_TIME, UPDATED_AT) values (%d, 'test', 'mv', 'warning', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		mvID,
+	))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).
+		Check(testkit.Rows("1"))
+
+	tk.MustExec("drop materialized view mv")
+
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).
+		Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).
+		Check(testkit.Rows("0"))
+
+	tk.MustExec("drop materialized view log on t")
+}
+
+func TestDropDatabaseIgnoresRefreshAlertDeleteFailure(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	const dbName = "mv_drop_db_alert_delete_fail"
+	tk.MustExec("drop database if exists " + dbName)
+	tk.MustExec("create database " + dbName)
+	tk.MustExec("use " + dbName)
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr(dbName), pmodel.NewCIStr("mv"))
+	require.NoError(t, err)
+	mvID := mvTable.Meta().ID
+
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MV_SCHEMA, MV_NAME, ALERT_LEVEL, LAST_SUCCESS_TIME, UPDATED_AT) values (%d, '%s', 'mv', 'overdue', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		mvID,
+		dbName,
+	))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).
+		Check(testkit.Rows("1"))
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockDeleteCreateMaterializedViewRefreshAlertErr", `return("mock drop schema alert delete error")`))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockDeleteCreateMaterializedViewRefreshAlertErr"))
+	}()
+
+	tk.MustExec("drop database " + dbName)
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).
+		Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).
+		Check(testkit.Rows("1"))
+}
+
+func TestDropMaterializedViewIgnoresRefreshAlertDeleteFailure(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv"))
+	require.NoError(t, err)
+	mvID := mvTable.Meta().ID
+
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MV_SCHEMA, MV_NAME, ALERT_LEVEL, LAST_SUCCESS_TIME, UPDATED_AT) values (%d, 'test', 'mv', 'warning', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		mvID,
+	))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).
+		Check(testkit.Rows("1"))
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockDeleteCreateMaterializedViewRefreshAlertErr", `return("mock drop table alert delete error")`))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockDeleteCreateMaterializedViewRefreshAlertErr"))
+	}()
+
+	tk.MustExec("drop materialized view mv")
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).
+		Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).
+		Check(testkit.Rows("1"))
+
+	tk.MustExec("drop materialized view log on t")
 }
 
 func TestCreateMaterializedViewRetryAfterUpsertFailure(t *testing.T) {
@@ -1703,14 +1877,17 @@ func TestCreateMaterializedViewRetryAfterUpsertFailure(t *testing.T) {
 	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockUpsertCreateMaterializedViewRefreshInfoTableNotExists", "1*return(true)"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockDeleteCreateMaterializedViewRefreshAlertErr", `return("mock rollback alert delete error")`))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockUpsertCreateMaterializedViewRefreshInfoTableNotExists"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockDeleteCreateMaterializedViewRefreshAlertErr"))
 	}()
 
 	err := tk.ExecToErr("create materialized view mv_retry (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
 	require.Error(t, err)
 	require.ErrorContains(t, err, "tidb_mview_refresh_info")
 	require.NotContains(t, err.Error(), "Information schema is changed")
+	require.NotContains(t, err.Error(), "mock rollback alert delete error")
 	tk.MustQuery("show tables like 'mv_retry'").Check(testkit.Rows())
 
 	tk.MustExec("create materialized view mv_retry (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -740,7 +740,7 @@ func TestPurgeMaterializedViewLogCancelWatcherUsesHistRequest(t *testing.T) {
 	require.NoError(t, err)
 	mlogID := mlogTable.Meta().ID
 
-	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskCancelWatchPollInterval"
+	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskMonitorPollInterval"
 	require.NoError(t, failpoint.Enable(pollIntervalFailpoint, "return(50)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable(pollIntervalFailpoint))
@@ -828,7 +828,7 @@ func TestCancelMaterializedViewLogPurgeJob(t *testing.T) {
 	require.NoError(t, err)
 	mlogID := mlogTable.Meta().ID
 
-	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskCancelWatchPollInterval"
+	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskMonitorPollInterval"
 	require.NoError(t, failpoint.Enable(pollIntervalFailpoint, "return(50)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable(pollIntervalFailpoint))
@@ -901,6 +901,86 @@ func TestCancelMaterializedViewLogPurgeJob(t *testing.T) {
 	)).Rows()
 	require.Len(t, reasonRows, 1)
 	require.Equal(t, "cancelled manually by 'mv_purge_cancel_u'@'%'", fmt.Sprint(reasonRows[0][0]))
+}
+
+func TestPurgeMaterializedViewLogRunningHistHeartbeat(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_purge_heartbeat (id int primary key, v int)")
+	tk.MustExec("create materialized view log on t_purge_heartbeat (id, v) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("insert into t_purge_heartbeat values (1, 10), (2, 20)")
+
+	is := dom.InfoSchema()
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_heartbeat"))
+	require.NoError(t, err)
+	mlogID := mlogTable.Meta().ID
+
+	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskMonitorPollInterval"
+	require.NoError(t, failpoint.Enable(pollIntervalFailpoint, "return(50)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable(pollIntervalFailpoint))
+	}()
+	heartbeatIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskHistHeartbeatInterval"
+	require.NoError(t, failpoint.Enable(heartbeatIntervalFailpoint, "return(50)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable(heartbeatIntervalFailpoint))
+	}()
+
+	pauseFailpoint := "github.com/pingcap/tidb/pkg/executor/pausePurgeMaterializedViewLogAfterInsertPurgeHistRunning"
+	require.NoError(t, failpoint.Enable(pauseFailpoint, "pause"))
+	paused := true
+	defer func() {
+		if paused {
+			require.NoError(t, failpoint.Disable(pauseFailpoint))
+		}
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		tkPurge := testkit.NewTestKit(t, store)
+		tkPurge.MustExec("use test")
+		errCh <- tkPurge.ExecToErr("purge materialized view log on t_purge_heartbeat")
+	}()
+
+	var firstHeartbeat string
+	require.Eventually(t, func() bool {
+		rows := tk.MustQuery(fmt.Sprintf(
+			"select cast(LAST_HEARTBEAT_AT as char) from mysql.tidb_mlog_purge_hist where MLOG_ID = %d and PURGE_STATUS = 'running' order by PURGE_JOB_ID desc limit 1",
+			mlogID,
+		)).Rows()
+		if len(rows) == 0 || rows[0][0] == nil {
+			return false
+		}
+		firstHeartbeat = fmt.Sprint(rows[0][0])
+		return firstHeartbeat != ""
+	}, 10*time.Second, 100*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		rows := tk.MustQuery(fmt.Sprintf(
+			"select cast(LAST_HEARTBEAT_AT as char) from mysql.tidb_mlog_purge_hist where MLOG_ID = %d and PURGE_STATUS = 'running' order by PURGE_JOB_ID desc limit 1",
+			mlogID,
+		)).Rows()
+		if len(rows) == 0 || rows[0][0] == nil {
+			return false
+		}
+		return fmt.Sprint(rows[0][0]) != firstHeartbeat
+	}, 10*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, failpoint.Disable(pauseFailpoint))
+	paused = false
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for purge to finish")
+	}
+
+	tk.MustQuery(fmt.Sprintf(
+		"select PURGE_STATUS, LAST_HEARTBEAT_AT is not null from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1",
+		mlogID,
+	)).Check(testkit.Rows("success 1"))
 }
 
 func TestPurgeMaterializedViewLogLockRowMissing(t *testing.T) {

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -1988,8 +1988,8 @@ func TestMaterializedViewRefreshCompleteRunningHistLifecycle(t *testing.T) {
 		t.Fatal("timeout waiting for refresh to persist running history row")
 	}
 
-	tk.MustQuery(fmt.Sprintf("select REFRESH_STATUS, REFRESH_METHOD, REFRESH_ENDTIME is null, REFRESH_READ_TSO is null, REFRESH_FAILED_REASON is null from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d order by REFRESH_JOB_ID desc limit 1", mviewID)).
-		Check(testkit.Rows("running complete delta apply manual 1 1 1"))
+	tk.MustQuery(fmt.Sprintf("select REFRESH_STATUS, REFRESH_METHOD, REFRESH_ENDTIME is null, REFRESH_READ_TSO is null, REFRESH_FAILED_REASON is null, LAST_HEARTBEAT_AT is not null from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d order by REFRESH_JOB_ID desc limit 1", mviewID)).
+		Check(testkit.Rows("running complete delta apply manual 1 1 1 1"))
 
 	close(pauseCh)
 
@@ -2002,6 +2002,89 @@ func TestMaterializedViewRefreshCompleteRunningHistLifecycle(t *testing.T) {
 
 	tk.MustQuery(fmt.Sprintf("select REFRESH_STATUS, REFRESH_METHOD, REFRESH_ENDTIME is not null, REFRESH_READ_TSO > 0, REFRESH_FAILED_REASON is null from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d order by REFRESH_JOB_ID desc limit 1", mviewID)).
 		Check(testkit.Rows("success complete delta apply manual 1 1 1"))
+}
+
+func TestMaterializedViewRefreshRunningHistHeartbeat(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv"))
+	require.NoError(t, err)
+	mviewID := mvTable.Meta().ID
+
+	tk.MustExec("insert into t values (2, 3), (3, 4)")
+
+	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskMonitorPollInterval"
+	require.NoError(t, failpoint.Enable(pollIntervalFailpoint, "return(50)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable(pollIntervalFailpoint))
+	}()
+	heartbeatIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskHistHeartbeatInterval"
+	require.NoError(t, failpoint.Enable(heartbeatIntervalFailpoint, "return(50)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable(heartbeatIntervalFailpoint))
+	}()
+
+	pauseFailpoint := "github.com/pingcap/tidb/pkg/executor/pauseRefreshMaterializedViewAfterInsertRefreshHistRunning"
+	require.NoError(t, failpoint.Enable(pauseFailpoint, "pause"))
+	paused := true
+	defer func() {
+		if paused {
+			require.NoError(t, failpoint.Disable(pauseFailpoint))
+		}
+	}()
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		tkRefresh := testkit.NewTestKit(t, store)
+		tkRefresh.MustExec("use test")
+		refreshDone <- tkRefresh.ExecToErr("refresh materialized view mv complete")
+	}()
+
+	var firstHeartbeat string
+	require.Eventually(t, func() bool {
+		rows := tk.MustQuery(fmt.Sprintf(
+			"select cast(LAST_HEARTBEAT_AT as char) from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d and REFRESH_STATUS = 'running' order by REFRESH_JOB_ID desc limit 1",
+			mviewID,
+		)).Rows()
+		if len(rows) == 0 || rows[0][0] == nil {
+			return false
+		}
+		firstHeartbeat = fmt.Sprint(rows[0][0])
+		return firstHeartbeat != ""
+	}, 10*time.Second, 100*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		rows := tk.MustQuery(fmt.Sprintf(
+			"select cast(LAST_HEARTBEAT_AT as char) from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d and REFRESH_STATUS = 'running' order by REFRESH_JOB_ID desc limit 1",
+			mviewID,
+		)).Rows()
+		if len(rows) == 0 || rows[0][0] == nil {
+			return false
+		}
+		return fmt.Sprint(rows[0][0]) != firstHeartbeat
+	}, 10*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, failpoint.Disable(pauseFailpoint))
+	paused = false
+
+	select {
+	case err := <-refreshDone:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for refresh to finish")
+	}
+
+	tk.MustQuery(fmt.Sprintf(
+		"select REFRESH_STATUS, LAST_HEARTBEAT_AT is not null from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d order by REFRESH_JOB_ID desc limit 1",
+		mviewID,
+	)).Check(testkit.Rows("success 1"))
 }
 
 func TestMaterializedViewRefreshCompleteReadTSOSnapshotMatchesMV(t *testing.T) {
@@ -2722,7 +2805,7 @@ func TestMaterializedViewRefreshCompleteOutOfPlaceCancelWatcherStopsBeforeCreate
 	require.NoError(t, err)
 	mviewID := mvTable.Meta().ID
 
-	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskCancelWatchPollInterval"
+	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskMonitorPollInterval"
 	require.NoError(t, failpoint.Enable(pollIntervalFailpoint, "return(50)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable(pollIntervalFailpoint))
@@ -3017,7 +3100,7 @@ func TestMaterializedViewRefreshCancelWatcherUsesHistRequest(t *testing.T) {
 	require.NoError(t, err)
 	mviewID := mvTable.Meta().ID
 
-	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskCancelWatchPollInterval"
+	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskMonitorPollInterval"
 	require.NoError(t, failpoint.Enable(pollIntervalFailpoint, "return(50)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable(pollIntervalFailpoint))
@@ -3106,7 +3189,7 @@ func TestCancelMaterializedViewRefreshJob(t *testing.T) {
 	require.NoError(t, err)
 	mviewID := mvTable.Meta().ID
 
-	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskCancelWatchPollInterval"
+	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskMonitorPollInterval"
 	require.NoError(t, failpoint.Enable(pollIntervalFailpoint, "return(50)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable(pollIntervalFailpoint))
@@ -3198,15 +3281,15 @@ func TestMaterializedViewRefreshCancelWatcherStopsAfterTaskFinish(t *testing.T) 
 	tk.MustExec("create materialized view log on t_refresh_cancel_watch_stop (a, b) purge next date_add(now(), interval 1 hour)")
 	tk.MustExec("create materialized view mv_refresh_cancel_watch_stop (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_refresh_cancel_watch_stop group by a")
 
-	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskCancelWatchPollInterval"
+	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskMonitorPollInterval"
 	require.NoError(t, failpoint.Enable(pollIntervalFailpoint, "return(50)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable(pollIntervalFailpoint))
 	}()
 
 	var pollCount atomic.Int32
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/mvTaskCancelWatcherPolled", func(watchName string) {
-		if strings.HasPrefix(watchName, "refresh-") {
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/mvTaskMonitorPolled", func(monitorName string) {
+		if strings.HasPrefix(monitorName, "refresh-") {
 			pollCount.Add(1)
 		}
 	})

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -2044,7 +2044,7 @@ func TestMaterializedViewRefreshRunningHistHeartbeat(t *testing.T) {
 	go func() {
 		tkRefresh := testkit.NewTestKit(t, store)
 		tkRefresh.MustExec("use test")
-		refreshDone <- tkRefresh.ExecToErr("refresh materialized view mv complete")
+		refreshDone <- tkRefresh.ExecToErr("refresh materialized view mv complete delta apply")
 	}()
 
 	var firstHeartbeat string

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -2511,6 +2511,12 @@ func TestMaterializedViewRefreshCompleteOutOfPlaceCutoverBasic(t *testing.T) {
 	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv"))
 	require.NoError(t, err)
 	oldMViewID := mvTable.Meta().ID
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MV_SCHEMA, MV_NAME, ALERT_LEVEL, LAST_SUCCESS_TIME, UPDATED_AT) values (%d, 'test', 'mv', 'warning', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		oldMViewID,
+	))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d", oldMViewID)).
+		Check(testkit.Rows("1"))
 
 	tk.MustExec("insert into t values (2, 3), (3, 4)")
 	tk.MustExec("refresh materialized view mv complete out of place")
@@ -2529,6 +2535,8 @@ func TestMaterializedViewRefreshCompleteOutOfPlaceCutoverBasic(t *testing.T) {
 	require.NotContains(t, baseTable.Meta().MaterializedViewBase.MViewIDs, oldMViewID)
 
 	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where MVIEW_ID = %d", oldMViewID)).
+		Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d", oldMViewID)).
 		Check(testkit.Rows("0"))
 	tk.MustQuery(fmt.Sprintf("select LAST_SUCCESS_READ_TSO > 0 from mysql.tidb_mview_refresh_info where MVIEW_ID = %d", newMViewID)).
 		Check(testkit.Rows("1"))

--- a/pkg/mvservice/BUILD.bazel
+++ b/pkg/mvservice/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/disttask",
         "//pkg/util/logutil",
         "//pkg/util/memory",
+        "//pkg/util/sqlescape",
         "//pkg/util/sqlexec",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_tikv_client_go_v2//oracle",

--- a/pkg/mvservice/mvservice_test.go
+++ b/pkg/mvservice/mvservice_test.go
@@ -573,7 +573,7 @@ func TestMVServiceUpdateConfigs(t *testing.T) {
 		err = svc.SetMLogPurgeHistRetention(20 * 24 * time.Hour)
 		require.NoError(t, err)
 		interval = svc.historyGCInterval()
-		require.Equal(t, time.Hour, interval)
+		require.Equal(t, 20*time.Minute, interval)
 		mviewRefreshRetention, mlogPurgeRetention = svc.historyGCRetentionConfig()
 		require.Equal(t, 10*24*time.Hour, mviewRefreshRetention)
 		require.Equal(t, 20*24*time.Hour, mlogPurgeRetention)

--- a/pkg/mvservice/mvservice_test.go
+++ b/pkg/mvservice/mvservice_test.go
@@ -808,6 +808,254 @@ func TestMVServiceCollectRefreshAlertTasksDedupByLastSuccessReadTSO(t *testing.T
 	}
 }
 
+func TestMVServiceMaybeLogRefreshAlertTasksSyncsAlertStates(t *testing.T) {
+	svc := NewMVService(context.Background(), mockSessionPool{}, &mockMVServiceHelper{}, DefaultMVServiceConfig())
+	defer svc.executor.Close()
+	setRefreshAlertCleanupOwnerForTest(svc, 10)
+
+	now := mvsNow()
+
+	svc.mvRefreshMu.Lock()
+	if svc.mvRefreshMu.pending == nil {
+		svc.mvRefreshMu.pending = make(map[int64]mvItem)
+	}
+	warnTask := &mv{
+		ID:                 301,
+		schemaName:         "test",
+		mviewName:          "mv_warn",
+		nextRefresh:        now.Add(-2 * time.Minute),
+		lastSuccessReadTSO: 12345,
+		lastSuccessTime:    now.Add(-40 * time.Second),
+		alertWarningSec:    30,
+		alertOverdueSec:    120,
+	}
+	warnTask.orderTs = warnTask.nextRefresh.UnixMilli()
+	svc.mvRefreshMu.pending[warnTask.ID] = svc.mvRefreshMu.prio.Push(warnTask)
+
+	overdueTask := &mv{
+		ID:                 302,
+		schemaName:         "test",
+		mviewName:          "mv_overdue",
+		nextRefresh:        now.Add(-2 * time.Minute),
+		lastSuccessReadTSO: 22345,
+		lastSuccessTime:    now.Add(-90 * time.Second),
+		alertWarningSec:    30,
+		alertOverdueSec:    60,
+	}
+	overdueTask.orderTs = overdueTask.nextRefresh.UnixMilli()
+	svc.mvRefreshMu.pending[overdueTask.ID] = svc.mvRefreshMu.prio.Push(overdueTask)
+
+	healthyTask := &mv{
+		ID:                 303,
+		schemaName:         "test",
+		mviewName:          "mv_healthy",
+		nextRefresh:        now.Add(-2 * time.Minute),
+		lastSuccessReadTSO: 32345,
+		lastSuccessTime:    now.Add(-10 * time.Second),
+		alertWarningSec:    30,
+		alertOverdueSec:    60,
+	}
+	healthyTask.orderTs = healthyTask.nextRefresh.UnixMilli()
+	svc.mvRefreshMu.pending[healthyTask.ID] = svc.mvRefreshMu.prio.Push(healthyTask)
+	svc.mvRefreshMu.Unlock()
+
+	svc.nextRefreshAlertScanMillis.Store(0)
+	svc.maybeLogRefreshAlertTasks(now)
+
+	helper := svc.mh.(*mockMVServiceHelper)
+	require.Equal(t, int32(1), helper.syncRefreshAlertCalls.Load())
+	require.Equal(t, int64(1), svc.metrics.alertWarningCount.Load())
+	require.Equal(t, int64(1), svc.metrics.alertOverdueCount.Load())
+
+	helper.syncRefreshAlertMu.Lock()
+	syncedAt := helper.lastRefreshAlertAt
+	synced := append([]refreshAlertTask(nil), helper.lastRefreshAlertSync...)
+	helper.syncRefreshAlertMu.Unlock()
+
+	require.True(t, syncedAt.Equal(now))
+	require.Len(t, synced, 3)
+
+	byID := make(map[int64]refreshAlertTask, len(synced))
+	for _, state := range synced {
+		byID[state.mviewID] = state
+	}
+	require.Equal(t, mvRefreshAlertLevelWarning, byID[301].alertLevel)
+	require.Equal(t, mvRefreshAlertLevelOverdue, byID[302].alertLevel)
+	require.Empty(t, byID[303].alertLevel)
+
+	svc.nextRefreshAlertScanMillis.Store(0)
+	svc.maybeLogRefreshAlertTasks(now)
+	require.Equal(t, int32(1), helper.syncRefreshAlertCalls.Load())
+	require.Equal(t, int32(2), helper.cleanupStaleRefreshAlertCalls.Load())
+}
+
+func TestMVServiceMaybeLogRefreshAlertTasksCleansUpStaleRowsWithoutLocalPendingTasks(t *testing.T) {
+	helper := &mockMVServiceHelper{}
+	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
+	defer svc.executor.Close()
+	setRefreshAlertCleanupOwnerForTest(svc, 10)
+
+	now := mvsNow()
+
+	svc.nextRefreshAlertScanMillis.Store(0)
+	svc.maybeLogRefreshAlertTasks(now)
+	require.Equal(t, int32(1), helper.cleanupStaleRefreshAlertCalls.Load())
+	require.Equal(t, int32(0), helper.syncRefreshAlertCalls.Load())
+
+	svc.maybeLogRefreshAlertTasks(now.Add(mvRefreshAlertScanInterval / 2))
+	require.Equal(t, int32(1), helper.cleanupStaleRefreshAlertCalls.Load())
+
+	svc.maybeLogRefreshAlertTasks(now.Add(mvRefreshAlertScanInterval))
+	require.Equal(t, int32(2), helper.cleanupStaleRefreshAlertCalls.Load())
+}
+
+func TestMVServiceBuildMVRefreshTasksDoesNotClearRemovedAlertStates(t *testing.T) {
+	helper := &mockMVServiceHelper{}
+	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
+	defer svc.executor.Close()
+
+	now := mvsNow()
+	m := &mv{
+		ID:          401,
+		nextRefresh: now.Add(time.Minute),
+	}
+	m.orderTs = m.nextRefresh.UnixMilli()
+
+	svc.buildMVRefreshTasks(map[int64]*mv{m.ID: m})
+	require.Equal(t, int32(0), helper.syncRefreshAlertCalls.Load())
+
+	svc.buildMVRefreshTasks(map[int64]*mv{})
+	require.Equal(t, int32(0), helper.syncRefreshAlertCalls.Load())
+}
+
+func TestMVServiceMaybeLogRefreshAlertTasksResyncsWhenLastSuccessReadTSOChanges(t *testing.T) {
+	helper := &mockMVServiceHelper{}
+	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
+	defer svc.executor.Close()
+
+	now := mvsNow()
+	task := &mv{
+		ID:                 501,
+		schemaName:         "test",
+		mviewName:          "mv_warn",
+		nextRefresh:        now.Add(-2 * time.Minute),
+		lastSuccessReadTSO: 12345,
+		lastSuccessTime:    now.Add(-40 * time.Second),
+		alertWarningSec:    30,
+	}
+	task.orderTs = task.nextRefresh.UnixMilli()
+
+	svc.mvRefreshMu.Lock()
+	if svc.mvRefreshMu.pending == nil {
+		svc.mvRefreshMu.pending = make(map[int64]mvItem)
+	}
+	svc.mvRefreshMu.pending[task.ID] = svc.mvRefreshMu.prio.Push(task)
+	svc.mvRefreshMu.Unlock()
+
+	svc.nextRefreshAlertScanMillis.Store(0)
+	svc.maybeLogRefreshAlertTasks(now)
+	require.Equal(t, int32(1), helper.syncRefreshAlertCalls.Load())
+
+	svc.mvRefreshMu.Lock()
+	task.lastSuccessReadTSO = 22345
+	task.lastSuccessTime = now.Add(-35 * time.Second)
+	svc.mvRefreshMu.Unlock()
+
+	svc.nextRefreshAlertScanMillis.Store(0)
+	svc.maybeLogRefreshAlertTasks(now)
+	require.Equal(t, int32(2), helper.syncRefreshAlertCalls.Load())
+}
+
+func TestMVServiceMaybeLogRefreshAlertTasksSkipsUnresolvedMetadata(t *testing.T) {
+	helper := &mockMVServiceHelper{}
+	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
+	defer svc.executor.Close()
+	setRefreshAlertCleanupOwnerForTest(svc, 10)
+
+	now := mvsNow()
+	task := &mv{
+		ID:                 601,
+		nextRefresh:        now.Add(-2 * time.Minute),
+		lastSuccessReadTSO: 12345,
+		lastSuccessTime:    now.Add(-40 * time.Second),
+		alertWarningSec:    30,
+		metadataUnresolved: true,
+	}
+	task.orderTs = task.nextRefresh.UnixMilli()
+
+	svc.mvRefreshMu.Lock()
+	if svc.mvRefreshMu.pending == nil {
+		svc.mvRefreshMu.pending = make(map[int64]mvItem)
+	}
+	svc.mvRefreshMu.pending[task.ID] = svc.mvRefreshMu.prio.Push(task)
+	svc.mvRefreshMu.Unlock()
+
+	svc.nextRefreshAlertScanMillis.Store(0)
+	svc.maybeLogRefreshAlertTasks(now)
+	require.Equal(t, int32(0), helper.syncRefreshAlertCalls.Load())
+	require.Equal(t, int32(1), helper.cleanupStaleRefreshAlertCalls.Load())
+	require.Equal(t, int64(0), svc.metrics.alertWarningCount.Load())
+	require.Equal(t, int64(0), svc.metrics.alertOverdueCount.Load())
+}
+
+func TestMVServiceBuildMVRefreshTasksDoesNotDeleteAlertsOnTemporaryMetadataMiss(t *testing.T) {
+	helper := &mockMVServiceHelper{}
+	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
+	defer svc.executor.Close()
+	setRefreshAlertCleanupOwnerForTest(svc, 10)
+
+	now := mvsNow()
+	existing := &mv{
+		ID:                     602,
+		nextRefresh:            now.Add(-2 * time.Minute),
+		schemaName:             "test",
+		mviewName:              "mv",
+		lastSuccessReadTSO:     12345,
+		lastSuccessTime:        now.Add(-40 * time.Second),
+		alertWarningSec:        30,
+		lastSyncedAlertLevel:   mvRefreshAlertLevelWarning,
+		lastSyncedAlertReadTSO: 12345,
+		alertStateInitialized:  true,
+	}
+	existing.orderTs = existing.nextRefresh.UnixMilli()
+
+	svc.mvRefreshMu.Lock()
+	if svc.mvRefreshMu.pending == nil {
+		svc.mvRefreshMu.pending = make(map[int64]mvItem)
+	}
+	svc.mvRefreshMu.pending[existing.ID] = svc.mvRefreshMu.prio.Push(existing)
+	svc.mvRefreshMu.Unlock()
+
+	svc.buildMVRefreshTasks(map[int64]*mv{
+		existing.ID: {
+			ID:                 existing.ID,
+			nextRefresh:        existing.nextRefresh,
+			lastSuccessReadTSO: existing.lastSuccessReadTSO,
+			lastSuccessTime:    existing.lastSuccessTime,
+			metadataUnresolved: true,
+		},
+	})
+
+	svc.nextRefreshAlertScanMillis.Store(0)
+	svc.maybeLogRefreshAlertTasks(now)
+	require.Equal(t, int32(0), helper.syncRefreshAlertCalls.Load())
+	require.Equal(t, int32(1), helper.cleanupStaleRefreshAlertCalls.Load())
+}
+
+func TestMVServiceMaybeLogRefreshAlertTasksSkipsCleanupWhenNotOwner(t *testing.T) {
+	helper := &mockMVServiceHelper{}
+	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
+	defer svc.executor.Close()
+	setRefreshAlertCleanupOwnerForTest(svc, 20)
+
+	now := mvsNow()
+
+	svc.nextRefreshAlertScanMillis.Store(0)
+	svc.maybeLogRefreshAlertTasks(now)
+	require.Equal(t, int32(0), helper.cleanupStaleRefreshAlertCalls.Load())
+	require.Equal(t, int32(0), helper.syncRefreshAlertCalls.Load())
+}
+
 func TestTaskQueueRingBufferFIFO(t *testing.T) {
 	var q taskQueue
 	mkReq := func(i int) taskRequest {
@@ -970,6 +1218,14 @@ func (*fullChainMVServiceHelper) TryBackoffRefreshManualCancel(context.Context, 
 
 func (*fullChainMVServiceHelper) TryBackoffPurgeManualCancel(context.Context, basic.SessionPool, int64, time.Time) (bool, time.Time, error) {
 	return false, time.Time{}, nil
+}
+
+func (*fullChainMVServiceHelper) SyncMVRefreshAlertStates(context.Context, basic.SessionPool, time.Time, []refreshAlertTask) error {
+	return nil
+}
+
+func (*fullChainMVServiceHelper) CleanupStaleMVRefreshAlerts(context.Context, basic.SessionPool) error {
+	return nil
 }
 
 func pendingTaskCounts(svc *MVService) (mvLogCount int, mvCount int) {

--- a/pkg/mvservice/service.go
+++ b/pkg/mvservice/service.go
@@ -101,8 +101,9 @@ const (
 	defaultMVFetchInterval       = 30 * time.Second
 	defaultMVBasicInterval       = time.Second
 	defaultServerRefreshInterval = 5 * time.Second
-	defaultMVHistoryGCInterval   = time.Hour
+	defaultMVHistoryGCInterval   = 20 * time.Minute
 	defaultMVHistoryGCRetention  = 365 * 24 * time.Hour
+	defaultMVHistoryGCMaxRecords = uint64(1000000)
 	defaultMVTaskRetryBase       = 10 * time.Second
 	defaultMVTaskRetryMax        = 120 * time.Second
 	manualCancelBackoffDelay     = 2 * time.Minute
@@ -474,7 +475,7 @@ func (t *MVService) logMVRefreshAlerts(alertTasks []refreshAlertTask) {
 		if task.overdue {
 			logutil.BgLogger().Error("Materialized_view_refresh_time_overdue", fields...)
 		} else {
-			logutil.BgLogger().Warn("Materialized_view_refresh_time_warning", fields...)
+			logutil.BgLogger().Error("Materialized_view_refresh_time_warning", fields...)
 		}
 	}
 }
@@ -964,13 +965,21 @@ func (t *MVService) runGCOperationHistory(now time.Time, historyGCInterval time.
 		logutil.BgLogger().Warn("get current tso failed when GC MV/MVLOG operation history", fields...)
 		return
 	}
-	if err := t.mh.PurgeMVHistoryBeforeTSO(t.ctx, t.sysSessionPool, currentTSO, mviewRefreshRetention, mlogPurgeRetention); err != nil {
+	if err := t.mh.PurgeMVHistoryBeforeTSO(
+		t.ctx,
+		t.sysSessionPool,
+		currentTSO,
+		mviewRefreshRetention,
+		mlogPurgeRetention,
+	); err != nil {
 		result = mvDurationResultFailed
 		t.scheduleHistoryGCFailure(now, historyGCInterval)
 		fields := append(t.runtimeLogFields(),
 			zap.Uint64("current_tso", currentTSO),
 			zap.Duration("mview_refresh_hist_retention", mviewRefreshRetention),
 			zap.Duration("mlog_purge_hist_retention", mlogPurgeRetention),
+			zap.Uint64("mview_refresh_hist_max_records", defaultMVHistoryGCMaxRecords),
+			zap.Uint64("mlog_purge_hist_max_records", defaultMVHistoryGCMaxRecords),
 			zap.Error(err),
 		)
 		logutil.BgLogger().Warn("GC MV/MVLOG operation history failed", fields...)

--- a/pkg/mvservice/service.go
+++ b/pkg/mvservice/service.go
@@ -16,6 +16,7 @@ package mvservice
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime/debug"
 	"strconv"
@@ -130,8 +131,13 @@ const (
 	mvRunEventHistoryGCGetTSOErr = "get_tso_error"
 
 	mvHistoryGCOwnerKey = "gc-mv-op-hist"
+	// A single hash-ring owner performs stale refresh-alert cleanup to avoid
+	// repeating the same global delete on every TiDB node.
+	mvRefreshAlertCleanupOwnerKey = "gc-mv-refresh-alert"
 
-	historyGCRetryMaxAttempts = 8
+	historyGCRetryMaxAttempts  = 8
+	mvRefreshAlertLevelWarning = "warning"
+	mvRefreshAlertLevelOverdue = "overdue"
 )
 
 type mv struct {
@@ -140,13 +146,18 @@ type mv struct {
 	schemaName  string
 	mviewName   string
 
+	metadataUnresolved bool
+
 	lastSuccessReadTSO uint64
 	lastSuccessTime    time.Time
 	alertWarningSec    int64
 	alertOverdueSec    int64
 	// Suppress repeated overdue logs for the same lastSuccessReadTSO.
-	lastLoggedWarningTSO uint64
-	lastLoggedOverdueTSO uint64
+	lastLoggedWarningTSO   uint64
+	lastLoggedOverdueTSO   uint64
+	lastSyncedAlertLevel   string
+	lastSyncedAlertReadTSO uint64
+	alertStateInitialized  bool
 
 	orderTs    int64 // unix timestamp in milliseconds
 	retryCount atomic.Int64
@@ -231,20 +242,23 @@ func (t *MVService) refreshMV(mvToRefresh []*mv) {
 }
 
 type refreshAlertTask struct {
-	mviewID         int64
-	schemaName      string
-	mviewName       string
-	nextRefresh     time.Time
-	lastSuccessTime time.Time
-	alertWarningSec int64
-	alertOverdueSec int64
-	retryCount      int64
-	taskState       string
-	overdue         bool
+	mviewID            int64
+	schemaName         string
+	mviewName          string
+	nextRefresh        time.Time
+	metadataUnresolved bool
+	lastSuccessTime    time.Time
+	lastSuccessReadTSO uint64
+	alertWarningSec    int64
+	alertOverdueSec    int64
+	retryCount         int64
+	taskState          string
+	overdue            bool
+	alertLevel         string
 }
 
-// maybeLogRefreshAlertTasks scans pending refresh tasks and logs warning/overdue alerts.
-// The scan runs on maintenance ticks and is rate-limited by mvRefreshAlertScanInterval.
+// maybeLogRefreshAlertTasks scans pending refresh tasks, persists alert states, and logs warning/overdue alerts.
+// The scan runs on maintenanceTick and is rate-limited by mvRefreshAlertScanInterval.
 func (t *MVService) maybeLogRefreshAlertTasks(now time.Time) {
 	nowMillis := now.UnixMilli()
 	if next := t.nextRefreshAlertScanMillis.Load(); next > nowMillis {
@@ -252,13 +266,81 @@ func (t *MVService) maybeLogRefreshAlertTasks(now time.Time) {
 	}
 	t.nextRefreshAlertScanMillis.Store(now.Add(mvRefreshAlertScanInterval).UnixMilli())
 
-	alertTasks, warningCount, overdueCount := t.collectRefreshAlertTasks(now)
+	alertStates, warningCount, overdueCount := t.collectRefreshAlertStates(now)
 	t.metrics.alertWarningCount.Store(warningCount)
 	t.metrics.alertOverdueCount.Store(overdueCount)
+	if t.syncRefreshAlertStates(now, alertStates) {
+		t.markRefreshAlertStatesSynced(alertStates)
+	}
+	t.cleanupStaleRefreshAlerts()
+
+	alertTasks, _, _ := t.collectRefreshAlertTasks(now)
 	if len(alertTasks) == 0 {
 		return
 	}
 	t.logMVRefreshAlerts(alertTasks)
+}
+
+func (t *MVService) collectRefreshAlertStates(now time.Time) ([]refreshAlertTask, int64, int64) {
+	t.mvRefreshMu.Lock()
+	defer t.mvRefreshMu.Unlock()
+
+	alertStates := make([]refreshAlertTask, 0, len(t.mvRefreshMu.pending))
+	var warningCount int64
+	var overdueCount int64
+	for mviewID, item := range t.mvRefreshMu.pending {
+		if item.Value == nil || item.Value.nextRefresh.IsZero() || item.Value.metadataUnresolved {
+			continue
+		}
+		alertLevel := classifyRefreshAlertLevel(now, item.Value.lastSuccessTime, item.Value.alertWarningSec, item.Value.alertOverdueSec)
+		switch alertLevel {
+		case mvRefreshAlertLevelOverdue:
+			overdueCount++
+		case mvRefreshAlertLevelWarning:
+			warningCount++
+		}
+		if item.Value.alertStateInitialized &&
+			item.Value.lastSyncedAlertLevel == alertLevel &&
+			item.Value.lastSyncedAlertReadTSO == item.Value.lastSuccessReadTSO {
+			continue
+		}
+		taskState := "queued"
+		if item.Value.orderTs == maxNextScheduleTs {
+			taskState = "running"
+		}
+		alertStates = append(alertStates, refreshAlertTask{
+			mviewID:            mviewID,
+			schemaName:         item.Value.schemaName,
+			mviewName:          item.Value.mviewName,
+			nextRefresh:        item.Value.nextRefresh,
+			lastSuccessTime:    item.Value.lastSuccessTime,
+			lastSuccessReadTSO: item.Value.lastSuccessReadTSO,
+			alertWarningSec:    item.Value.alertWarningSec,
+			alertOverdueSec:    item.Value.alertOverdueSec,
+			retryCount:         item.Value.retryCount.Load(),
+			taskState:          taskState,
+			overdue:            alertLevel == mvRefreshAlertLevelOverdue,
+			alertLevel:         alertLevel,
+		})
+	}
+	return alertStates, warningCount, overdueCount
+}
+
+func (t *MVService) markRefreshAlertStatesSynced(states []refreshAlertTask) {
+	if len(states) == 0 {
+		return
+	}
+	t.mvRefreshMu.Lock()
+	defer t.mvRefreshMu.Unlock()
+	for _, state := range states {
+		item, ok := t.mvRefreshMu.pending[state.mviewID]
+		if !ok || item.Value == nil {
+			continue
+		}
+		item.Value.lastSyncedAlertLevel = state.alertLevel
+		item.Value.lastSyncedAlertReadTSO = state.lastSuccessReadTSO
+		item.Value.alertStateInitialized = true
+	}
 }
 
 func (t *MVService) collectRefreshAlertTasks(now time.Time) ([]refreshAlertTask, int64, int64) {
@@ -269,25 +351,15 @@ func (t *MVService) collectRefreshAlertTasks(now time.Time) ([]refreshAlertTask,
 	var warningCount int64
 	var overdueCount int64
 	for mviewID, item := range t.mvRefreshMu.pending {
-		if item.Value == nil || item.Value.nextRefresh.IsZero() {
+		if item.Value == nil || item.Value.nextRefresh.IsZero() || item.Value.metadataUnresolved {
 			continue
 		}
 		lastSuccessTime := item.Value.lastSuccessTime
-		if lastSuccessTime.IsZero() {
+		alertLevel := classifyRefreshAlertLevel(now, lastSuccessTime, item.Value.alertWarningSec, item.Value.alertOverdueSec)
+		if alertLevel == "" {
 			continue
 		}
-		if now.Before(lastSuccessTime) {
-			continue
-		}
-		overdueDuration := now.Sub(lastSuccessTime)
-		overdue := false
-		if item.Value.alertOverdueSec > 0 && overdueDuration >= time.Duration(item.Value.alertOverdueSec)*time.Second {
-			overdue = true
-		} else if item.Value.alertWarningSec > 0 && overdueDuration >= time.Duration(item.Value.alertWarningSec)*time.Second {
-			overdue = false
-		} else {
-			continue
-		}
+		overdue := alertLevel == mvRefreshAlertLevelOverdue
 		if overdue {
 			overdueCount++
 		} else {
@@ -312,19 +384,77 @@ func (t *MVService) collectRefreshAlertTasks(now time.Time) ([]refreshAlertTask,
 			taskState = "running"
 		}
 		alertTasks = append(alertTasks, refreshAlertTask{
-			mviewID:         mviewID,
-			schemaName:      item.Value.schemaName,
-			mviewName:       item.Value.mviewName,
-			nextRefresh:     item.Value.nextRefresh,
-			lastSuccessTime: lastSuccessTime,
-			alertWarningSec: item.Value.alertWarningSec,
-			alertOverdueSec: item.Value.alertOverdueSec,
-			retryCount:      item.Value.retryCount.Load(),
-			taskState:       taskState,
-			overdue:         overdue,
+			mviewID:            mviewID,
+			schemaName:         item.Value.schemaName,
+			mviewName:          item.Value.mviewName,
+			nextRefresh:        item.Value.nextRefresh,
+			lastSuccessTime:    lastSuccessTime,
+			lastSuccessReadTSO: item.Value.lastSuccessReadTSO,
+			alertWarningSec:    item.Value.alertWarningSec,
+			alertOverdueSec:    item.Value.alertOverdueSec,
+			retryCount:         item.Value.retryCount.Load(),
+			taskState:          taskState,
+			overdue:            overdue,
+			alertLevel:         alertLevel,
 		})
 	}
 	return alertTasks, warningCount, overdueCount
+}
+
+func classifyRefreshAlertLevel(now time.Time, lastSuccessTime time.Time, alertWarningSec, alertOverdueSec int64) string {
+	if lastSuccessTime.IsZero() || now.Before(lastSuccessTime) {
+		return ""
+	}
+	overdueDuration := now.Sub(lastSuccessTime)
+	if alertOverdueSec > 0 && overdueDuration >= time.Duration(alertOverdueSec)*time.Second {
+		return mvRefreshAlertLevelOverdue
+	}
+	if alertWarningSec > 0 && overdueDuration >= time.Duration(alertWarningSec)*time.Second {
+		return mvRefreshAlertLevelWarning
+	}
+	return ""
+}
+
+func (t *MVService) syncRefreshAlertStates(updatedAt time.Time, states []refreshAlertTask) bool {
+	if len(states) == 0 {
+		return true
+	}
+	if err := t.mh.SyncMVRefreshAlertStates(t.ctx, t.sysSessionPool, updatedAt, states); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return false
+		}
+		fields := append(
+			t.runtimeLogFields(),
+			zap.Int("alert_state_count", len(states)),
+			zap.Time("updated_at", updatedAt),
+			zap.Error(err),
+		)
+		logutil.BgLogger().Warn("sync mv refresh alert states failed", fields...)
+		return false
+	}
+	return true
+}
+
+func (t *MVService) cleanupStaleRefreshAlerts() {
+	if !t.isRefreshAlertCleanupOwner() {
+		return
+	}
+	if err := t.mh.CleanupStaleMVRefreshAlerts(t.ctx, t.sysSessionPool); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		}
+		fields := append(t.runtimeLogFields(), zap.Error(err))
+		logutil.BgLogger().Warn("cleanup stale mv refresh alerts failed", fields...)
+	}
+}
+
+func (t *MVService) isRefreshAlertCleanupOwner() bool {
+	t.sch.mu.RLock()
+	defer t.sch.mu.RUnlock()
+	if t.sch.ID == "" || len(t.sch.servers) == 0 {
+		return false
+	}
+	return t.sch.chash.GetNode([]byte(mvRefreshAlertCleanupOwnerKey)) == t.sch.ID
 }
 
 // logMVRefreshAlerts logs refresh alert task details with warning/overdue levels.
@@ -671,12 +801,15 @@ func (t *MVService) buildMVRefreshTasks(newPending map[int64]*mv) {
 	}
 	for id, nm := range newPending {
 		if om, ok := t.mvRefreshMu.pending[id]; ok {
-			om.Value.schemaName = nm.schemaName
-			om.Value.mviewName = nm.mviewName
+			om.Value.metadataUnresolved = nm.metadataUnresolved
+			if !nm.metadataUnresolved {
+				om.Value.schemaName = nm.schemaName
+				om.Value.mviewName = nm.mviewName
+				om.Value.alertWarningSec = nm.alertWarningSec
+				om.Value.alertOverdueSec = nm.alertOverdueSec
+			}
 			om.Value.lastSuccessReadTSO = nm.lastSuccessReadTSO
 			om.Value.lastSuccessTime = nm.lastSuccessTime
-			om.Value.alertWarningSec = nm.alertWarningSec
-			om.Value.alertOverdueSec = nm.alertOverdueSec
 			changed := om.Value.nextRefresh != nm.nextRefresh
 			om.Value.nextRefresh = nm.nextRefresh
 			if om.Value.orderTs != maxNextScheduleTs { // not running

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -139,6 +139,10 @@ UPDATED_AT
 		if i > 0 {
 			sql.WriteString(",")
 		}
+		var lastSuccessTime any
+		if !state.lastSuccessTime.IsZero() {
+			lastSuccessTime = state.lastSuccessTime.Round(0)
+		}
 		sqlescape.MustFormatSQL(
 			&sql,
 			"(%?, %?, %?, %?, %?, %?)",
@@ -146,7 +150,7 @@ UPDATED_AT
 			state.schemaName,
 			state.mviewName,
 			state.alertLevel,
-			state.lastSuccessTime.Round(0),
+			lastSuccessTime,
 			updatedAt.Round(0),
 		)
 	}

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -45,8 +45,12 @@ import (
 )
 
 const (
-	historyGCDeleteBatchSize   = 10000
-	refreshAlertWriteBatchSize = 128
+	historyGCDeleteBatchSize        = 10000
+	refreshAlertWriteBatchSize      = 128
+	mvHistoryHeartbeatTimeout       = 24 * time.Hour
+	mvHistoryOrphanedStatus         = "orphaned"
+	mvRefreshHistoryOrphanedReason  = "task heartbeat expired before refresh history finalize"
+	mvLogPurgeHistoryOrphanedReason = "task heartbeat expired before purge history finalize"
 )
 
 type serviceHelper struct {
@@ -893,6 +897,34 @@ func (*serviceHelper) PurgeMVHistoryBeforeTSO(
 	mviewRefreshRetention time.Duration,
 	mlogPurgeRetention time.Duration,
 ) error {
+	markStaleMVRefreshHistOrphanedSQL := fmt.Sprintf(
+		`UPDATE mysql.tidb_mview_refresh_hist
+SET REFRESH_STATUS = '%s',
+	REFRESH_ENDTIME = IFNULL(REFRESH_ENDTIME, NOW(6)),
+	REFRESH_DURATION_SEC = IFNULL(REFRESH_DURATION_SEC, CASE WHEN REFRESH_TIME IS NULL THEN NULL ELSE TIMESTAMPDIFF(MICROSECOND, REFRESH_TIME, NOW(6)) / 1000000.0 END),
+	REFRESH_FAILED_REASON = IFNULL(REFRESH_FAILED_REASON, '%s')
+WHERE REFRESH_STATUS = 'running'
+  AND COALESCE(LAST_HEARTBEAT_AT, REFRESH_TIME) < %%?
+ORDER BY REFRESH_JOB_ID
+LIMIT %d`,
+		mvHistoryOrphanedStatus,
+		mvRefreshHistoryOrphanedReason,
+		historyGCDeleteBatchSize,
+	)
+	markStaleMVLogPurgeHistOrphanedSQL := fmt.Sprintf(
+		`UPDATE mysql.tidb_mlog_purge_hist
+SET PURGE_STATUS = '%s',
+	PURGE_ENDTIME = IFNULL(PURGE_ENDTIME, NOW(6)),
+	PURGE_DURATION_SEC = IFNULL(PURGE_DURATION_SEC, CASE WHEN PURGE_TIME IS NULL THEN NULL ELSE TIMESTAMPDIFF(MICROSECOND, PURGE_TIME, NOW(6)) / 1000000.0 END),
+	PURGE_FAILED_REASON = IFNULL(PURGE_FAILED_REASON, '%s')
+WHERE PURGE_STATUS = 'running'
+  AND COALESCE(LAST_HEARTBEAT_AT, PURGE_TIME) < %%?
+ORDER BY PURGE_JOB_ID
+LIMIT %d`,
+		mvHistoryOrphanedStatus,
+		mvLogPurgeHistoryOrphanedReason,
+		historyGCDeleteBatchSize,
+	)
 	deleteMVRefreshHistSQL := fmt.Sprintf(
 		`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID < %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
 		historyGCDeleteBatchSize,
@@ -924,6 +956,10 @@ func (*serviceHelper) PurgeMVHistoryBeforeTSO(
 		}
 		return cutoffTSO
 	}
+	calcHeartbeatCutoffTime := func(timeout time.Duration) time.Time {
+		cutoffPhysical := max(oracle.ExtractPhysical(currentTSO)-int64(timeout/time.Millisecond), 0)
+		return oracle.GetTimeFromTS(oracle.ComposeTS(cutoffPhysical, 0))
+	}
 
 	se, err := sysSessionPool.Get()
 	if err != nil {
@@ -935,11 +971,17 @@ func (*serviceHelper) PurgeMVHistoryBeforeTSO(
 	sctx := se.(sessionctx.Context)
 
 	var purgeErrs []error
+	if err := reconcileMVHistoryRunningRowsInBatches(ctx, sctx, markStaleMVRefreshHistOrphanedSQL, calcHeartbeatCutoffTime(mvHistoryHeartbeatTimeout)); err != nil {
+		purgeErrs = append(purgeErrs, fmt.Errorf("reconcile stale mview refresh history running rows failed: %w", err))
+	}
 	if err := purgeMVHistoryInBatches(ctx, sctx, deleteMVRefreshHistSQL, calcCutoffTSO(mviewRefreshRetention)); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("purge mview refresh history by retention failed: %w", err))
 	}
 	if err := purgeMVHistoryByCountLimit(ctx, sctx, countMVRefreshHistSQL, deleteMVRefreshHistByCountSQL, defaultMVHistoryGCMaxRecords); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("purge mview refresh history by count limit failed: %w", err))
+	}
+	if err := reconcileMVHistoryRunningRowsInBatches(ctx, sctx, markStaleMVLogPurgeHistOrphanedSQL, calcHeartbeatCutoffTime(mvHistoryHeartbeatTimeout)); err != nil {
+		purgeErrs = append(purgeErrs, fmt.Errorf("reconcile stale mlog purge history running rows failed: %w", err))
 	}
 	if err := purgeMVHistoryInBatches(ctx, sctx, deleteMVLogPurgeHistSQL, calcCutoffTSO(mlogPurgeRetention)); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("purge mlog purge history by retention failed: %w", err))
@@ -951,6 +993,18 @@ func (*serviceHelper) PurgeMVHistoryBeforeTSO(
 		return errors.Join(purgeErrs...)
 	}
 	return nil
+}
+
+func reconcileMVHistoryRunningRowsInBatches(ctx context.Context, sctx sessionctx.Context, sql string, cutoffTime time.Time) error {
+	for {
+		if _, err := execRCRestrictedSQLWithSession(ctx, sctx, sql, []any{cutoffTime}); err != nil {
+			return err
+		}
+		affectedRows := sctx.GetSessionVars().StmtCtx.AffectedRows()
+		if affectedRows < uint64(historyGCDeleteBatchSize) {
+			return nil
+		}
+	}
 }
 
 func purgeMVHistoryInBatches(ctx context.Context, sctx sessionctx.Context, sql string, cutoffTSO uint64) error {

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -897,7 +897,7 @@ func (*serviceHelper) PurgeMVHistoryBeforeTSO(
 	mviewRefreshRetention time.Duration,
 	mlogPurgeRetention time.Duration,
 ) error {
-	markStaleMVRefreshHistOrphanedSQL := fmt.Sprintf(
+	markRefreshHistoryRunningRowsOrphanedSQL := fmt.Sprintf(
 		`UPDATE mysql.tidb_mview_refresh_hist
 SET REFRESH_STATUS = '%s',
 	REFRESH_ENDTIME = IFNULL(REFRESH_ENDTIME, NOW(6)),
@@ -911,7 +911,7 @@ LIMIT %d`,
 		mvRefreshHistoryOrphanedReason,
 		historyGCDeleteBatchSize,
 	)
-	markStaleMVLogPurgeHistOrphanedSQL := fmt.Sprintf(
+	markLogPurgeHistoryRunningRowsOrphanedSQL := fmt.Sprintf(
 		`UPDATE mysql.tidb_mlog_purge_hist
 SET PURGE_STATUS = '%s',
 	PURGE_ENDTIME = IFNULL(PURGE_ENDTIME, NOW(6)),
@@ -925,23 +925,23 @@ LIMIT %d`,
 		mvLogPurgeHistoryOrphanedReason,
 		historyGCDeleteBatchSize,
 	)
-	deleteMVRefreshHistSQL := fmt.Sprintf(
+	deleteRefreshHistoryByCutoffTSOSQL := fmt.Sprintf(
 		`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID < %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
 		historyGCDeleteBatchSize,
 	)
-	deleteMVLogPurgeHistSQL := fmt.Sprintf(
+	deleteLogPurgeHistoryByCutoffTSOSQL := fmt.Sprintf(
 		`DELETE FROM mysql.tidb_mlog_purge_hist WHERE (PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running') AND PURGE_JOB_ID < %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
 		historyGCDeleteBatchSize,
 	)
-	const countMVRefreshHistSQL = `SELECT COUNT(*), MIN(REFRESH_JOB_ID) FROM mysql.tidb_mview_refresh_hist`
-	const countMVLogPurgeHistSQL = `SELECT COUNT(*), MIN(PURGE_JOB_ID) FROM mysql.tidb_mlog_purge_hist`
-	deleteMVRefreshHistByCountSQL := func(limit uint64) string {
+	const countRefreshHistorySQL = `SELECT COUNT(*), MIN(REFRESH_JOB_ID) FROM mysql.tidb_mview_refresh_hist`
+	const countLogPurgeHistorySQL = `SELECT COUNT(*), MIN(PURGE_JOB_ID) FROM mysql.tidb_mlog_purge_hist`
+	deleteRefreshHistoryByCountLimitSQL := func(limit uint64) string {
 		return fmt.Sprintf(
 			`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID >= %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
 			limit,
 		)
 	}
-	deleteMVLogPurgeHistByCountSQL := func(limit uint64) string {
+	deleteLogPurgeHistoryByCountLimitSQL := func(limit uint64) string {
 		return fmt.Sprintf(
 			`DELETE FROM mysql.tidb_mlog_purge_hist WHERE (PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running') AND PURGE_JOB_ID >= %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
 			limit,
@@ -971,22 +971,22 @@ LIMIT %d`,
 	sctx := se.(sessionctx.Context)
 
 	var purgeErrs []error
-	if err := reconcileMVHistoryRunningRowsInBatches(ctx, sctx, markStaleMVRefreshHistOrphanedSQL, calcHeartbeatCutoffTime(mvHistoryHeartbeatTimeout)); err != nil {
+	if err := reconcileMVHistoryRunningRowsInBatches(ctx, sctx, markRefreshHistoryRunningRowsOrphanedSQL, calcHeartbeatCutoffTime(mvHistoryHeartbeatTimeout)); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("reconcile stale mview refresh history running rows failed: %w", err))
 	}
-	if err := purgeMVHistoryInBatches(ctx, sctx, deleteMVRefreshHistSQL, calcCutoffTSO(mviewRefreshRetention)); err != nil {
+	if err := purgeMVHistoryByCutoffTSOInBatches(ctx, sctx, deleteRefreshHistoryByCutoffTSOSQL, calcCutoffTSO(mviewRefreshRetention)); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("purge mview refresh history by retention failed: %w", err))
 	}
-	if err := purgeMVHistoryByCountLimit(ctx, sctx, countMVRefreshHistSQL, deleteMVRefreshHistByCountSQL, defaultMVHistoryGCMaxRecords); err != nil {
+	if err := purgeMVHistoryByCountLimitInBatches(ctx, sctx, countRefreshHistorySQL, deleteRefreshHistoryByCountLimitSQL, defaultMVHistoryGCMaxRecords); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("purge mview refresh history by count limit failed: %w", err))
 	}
-	if err := reconcileMVHistoryRunningRowsInBatches(ctx, sctx, markStaleMVLogPurgeHistOrphanedSQL, calcHeartbeatCutoffTime(mvHistoryHeartbeatTimeout)); err != nil {
+	if err := reconcileMVHistoryRunningRowsInBatches(ctx, sctx, markLogPurgeHistoryRunningRowsOrphanedSQL, calcHeartbeatCutoffTime(mvHistoryHeartbeatTimeout)); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("reconcile stale mlog purge history running rows failed: %w", err))
 	}
-	if err := purgeMVHistoryInBatches(ctx, sctx, deleteMVLogPurgeHistSQL, calcCutoffTSO(mlogPurgeRetention)); err != nil {
+	if err := purgeMVHistoryByCutoffTSOInBatches(ctx, sctx, deleteLogPurgeHistoryByCutoffTSOSQL, calcCutoffTSO(mlogPurgeRetention)); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("purge mlog purge history by retention failed: %w", err))
 	}
-	if err := purgeMVHistoryByCountLimit(ctx, sctx, countMVLogPurgeHistSQL, deleteMVLogPurgeHistByCountSQL, defaultMVHistoryGCMaxRecords); err != nil {
+	if err := purgeMVHistoryByCountLimitInBatches(ctx, sctx, countLogPurgeHistorySQL, deleteLogPurgeHistoryByCountLimitSQL, defaultMVHistoryGCMaxRecords); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("purge mlog purge history by count limit failed: %w", err))
 	}
 	if len(purgeErrs) > 0 {
@@ -1007,7 +1007,7 @@ func reconcileMVHistoryRunningRowsInBatches(ctx context.Context, sctx sessionctx
 	}
 }
 
-func purgeMVHistoryInBatches(ctx context.Context, sctx sessionctx.Context, sql string, cutoffTSO uint64) error {
+func purgeMVHistoryByCutoffTSOInBatches(ctx context.Context, sctx sessionctx.Context, sql string, cutoffTSO uint64) error {
 	for {
 		if _, err := execRCRestrictedSQLWithSession(ctx, sctx, sql, []any{cutoffTSO}); err != nil {
 			return err
@@ -1019,7 +1019,7 @@ func purgeMVHistoryInBatches(ctx context.Context, sctx sessionctx.Context, sql s
 	}
 }
 
-func purgeMVHistoryByCountLimit(
+func purgeMVHistoryByCountLimitInBatches(
 	ctx context.Context,
 	sctx sessionctx.Context,
 	countSQL string,

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -894,13 +894,27 @@ func (*serviceHelper) PurgeMVHistoryBeforeTSO(
 	mlogPurgeRetention time.Duration,
 ) error {
 	deleteMVRefreshHistSQL := fmt.Sprintf(
-		`DELETE FROM mysql.tidb_mview_refresh_hist WHERE REFRESH_JOB_ID < %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
+		`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID < %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
 		historyGCDeleteBatchSize,
 	)
 	deleteMVLogPurgeHistSQL := fmt.Sprintf(
-		`DELETE FROM mysql.tidb_mlog_purge_hist WHERE PURGE_JOB_ID < %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
+		`DELETE FROM mysql.tidb_mlog_purge_hist WHERE (PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running') AND PURGE_JOB_ID < %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
 		historyGCDeleteBatchSize,
 	)
+	const countMVRefreshHistSQL = `SELECT COUNT(*), MIN(REFRESH_JOB_ID) FROM mysql.tidb_mview_refresh_hist`
+	const countMVLogPurgeHistSQL = `SELECT COUNT(*), MIN(PURGE_JOB_ID) FROM mysql.tidb_mlog_purge_hist`
+	deleteMVRefreshHistByCountSQL := func(limit uint64) string {
+		return fmt.Sprintf(
+			`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID >= %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
+			limit,
+		)
+	}
+	deleteMVLogPurgeHistByCountSQL := func(limit uint64) string {
+		return fmt.Sprintf(
+			`DELETE FROM mysql.tidb_mlog_purge_hist WHERE (PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running') AND PURGE_JOB_ID >= %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
+			limit,
+		)
+	}
 
 	calcCutoffTSO := func(retention time.Duration) uint64 {
 		cutoffTSO := currentTSO
@@ -920,10 +934,23 @@ func (*serviceHelper) PurgeMVHistoryBeforeTSO(
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
 	sctx := se.(sessionctx.Context)
 
+	var purgeErrs []error
 	if err := purgeMVHistoryInBatches(ctx, sctx, deleteMVRefreshHistSQL, calcCutoffTSO(mviewRefreshRetention)); err != nil {
-		return err
+		purgeErrs = append(purgeErrs, fmt.Errorf("purge mview refresh history by retention failed: %w", err))
 	}
-	return purgeMVHistoryInBatches(ctx, sctx, deleteMVLogPurgeHistSQL, calcCutoffTSO(mlogPurgeRetention))
+	if err := purgeMVHistoryByCountLimit(ctx, sctx, countMVRefreshHistSQL, deleteMVRefreshHistByCountSQL, defaultMVHistoryGCMaxRecords); err != nil {
+		purgeErrs = append(purgeErrs, fmt.Errorf("purge mview refresh history by count limit failed: %w", err))
+	}
+	if err := purgeMVHistoryInBatches(ctx, sctx, deleteMVLogPurgeHistSQL, calcCutoffTSO(mlogPurgeRetention)); err != nil {
+		purgeErrs = append(purgeErrs, fmt.Errorf("purge mlog purge history by retention failed: %w", err))
+	}
+	if err := purgeMVHistoryByCountLimit(ctx, sctx, countMVLogPurgeHistSQL, deleteMVLogPurgeHistByCountSQL, defaultMVHistoryGCMaxRecords); err != nil {
+		purgeErrs = append(purgeErrs, fmt.Errorf("purge mlog purge history by count limit failed: %w", err))
+	}
+	if len(purgeErrs) > 0 {
+		return errors.Join(purgeErrs...)
+	}
+	return nil
 }
 
 func purgeMVHistoryInBatches(ctx context.Context, sctx sessionctx.Context, sql string, cutoffTSO uint64) error {
@@ -936,6 +963,50 @@ func purgeMVHistoryInBatches(ctx context.Context, sctx sessionctx.Context, sql s
 			return nil
 		}
 	}
+}
+
+func purgeMVHistoryByCountLimit(
+	ctx context.Context,
+	sctx sessionctx.Context,
+	countSQL string,
+	deleteSQL func(limit uint64) string,
+	maxRecords uint64,
+) error {
+	if maxRecords == 0 {
+		return nil
+	}
+	rows, err := execRCRestrictedSQLWithSession(ctx, sctx, countSQL, nil)
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 || rows[0].IsNull(0) {
+		return nil
+	}
+	totalCount := rows[0].GetInt64(0)
+	if totalCount <= 0 || rows[0].IsNull(1) {
+		return nil
+	}
+	totalCountUint := uint64(totalCount)
+	if totalCountUint <= maxRecords {
+		return nil
+	}
+	minJobID := rows[0].GetUint64(1)
+	remainingDelete := totalCountUint - maxRecords
+	for remainingDelete > 0 {
+		batchSize := remainingDelete
+		if batchSize > uint64(historyGCDeleteBatchSize) {
+			batchSize = uint64(historyGCDeleteBatchSize)
+		}
+		if _, err := execRCRestrictedSQLWithSession(ctx, sctx, deleteSQL(batchSize), []any{minJobID}); err != nil {
+			return err
+		}
+		affectedRows := sctx.GetSessionVars().StmtCtx.AffectedRows()
+		if affectedRows == 0 || affectedRows < batchSize {
+			return nil
+		}
+		remainingDelete -= affectedRows
+	}
+	return nil
 }
 
 // loadAllTiDBMVLogPurge loads all scheduled MV log purge tasks from metadata.

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	disttaskutil "github.com/pingcap/tidb/pkg/util/disttask"
 	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/pingcap/tidb/pkg/util/sqlescape"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tikv/client-go/v2/oracle"
@@ -44,7 +45,8 @@ import (
 )
 
 const (
-	historyGCDeleteBatchSize = 10000
+	historyGCDeleteBatchSize   = 10000
+	refreshAlertWriteBatchSize = 128
 )
 
 type serviceHelper struct {
@@ -104,6 +106,118 @@ func newServiceHelper() *serviceHelper {
 
 func (*serviceHelper) serverFilter(s serverInfo) bool {
 	return true
+}
+
+func buildDeleteMVRefreshAlertSQL(mviewIDs []int64) string {
+	var sql strings.Builder
+	sql.WriteString("DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID IN (")
+	for i, mviewID := range mviewIDs {
+		if i > 0 {
+			sql.WriteString(",")
+		}
+		sqlescape.MustFormatSQL(&sql, "%?", mviewID)
+	}
+	sql.WriteString(")")
+	return sql.String()
+}
+
+func buildUpsertMVRefreshAlertSQL(updatedAt time.Time, states []refreshAlertTask) string {
+	var sql strings.Builder
+	sql.WriteString(`INSERT INTO mysql.tidb_mview_refresh_alert (
+MVIEW_ID,
+MV_SCHEMA,
+MV_NAME,
+ALERT_LEVEL,
+LAST_SUCCESS_TIME,
+UPDATED_AT
+) VALUES `)
+	for i, state := range states {
+		if i > 0 {
+			sql.WriteString(",")
+		}
+		sqlescape.MustFormatSQL(
+			&sql,
+			"(%?, %?, %?, %?, %?, %?)",
+			state.mviewID,
+			state.schemaName,
+			state.mviewName,
+			state.alertLevel,
+			state.lastSuccessTime.Round(0),
+			updatedAt.Round(0),
+		)
+	}
+	sql.WriteString(` ON DUPLICATE KEY UPDATE
+MV_SCHEMA = VALUES(MV_SCHEMA),
+MV_NAME = VALUES(MV_NAME),
+ALERT_LEVEL = VALUES(ALERT_LEVEL),
+LAST_SUCCESS_TIME = VALUES(LAST_SUCCESS_TIME),
+UPDATED_AT = VALUES(UPDATED_AT)`)
+	return sql.String()
+}
+
+func buildCleanupStaleMVRefreshAlertSQL() string {
+	return `DELETE a
+FROM mysql.tidb_mview_refresh_alert AS a
+LEFT JOIN mysql.tidb_mview_refresh_info AS i ON a.MVIEW_ID = i.MVIEW_ID
+WHERE i.MVIEW_ID IS NULL OR i.NEXT_TIME IS NULL`
+}
+
+func (*serviceHelper) SyncMVRefreshAlertStates(
+	ctx context.Context,
+	sysSessionPool basic.SessionPool,
+	updatedAt time.Time,
+	states []refreshAlertTask,
+) error {
+	if len(states) == 0 {
+		return nil
+	}
+	se, err := sysSessionPool.Get()
+	if err != nil {
+		return err
+	}
+	defer sysSessionPool.Put(se)
+
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
+	sctx := se.(sessionctx.Context)
+
+	deleteIDs := make([]int64, 0, len(states))
+	upsertStates := make([]refreshAlertTask, 0, len(states))
+	for _, state := range states {
+		if state.mviewID <= 0 {
+			continue
+		}
+		if state.metadataUnresolved {
+			continue
+		}
+		if state.alertLevel == "" {
+			deleteIDs = append(deleteIDs, state.mviewID)
+			continue
+		}
+		upsertStates = append(upsertStates, state)
+	}
+
+	for start := 0; start < len(deleteIDs); start += refreshAlertWriteBatchSize {
+		end := min(start+refreshAlertWriteBatchSize, len(deleteIDs))
+		if _, err := execRCRestrictedSQLWithSession(ctx, sctx, buildDeleteMVRefreshAlertSQL(deleteIDs[start:end]), nil); err != nil {
+			return err
+		}
+	}
+	for start := 0; start < len(upsertStates); start += refreshAlertWriteBatchSize {
+		end := min(start+refreshAlertWriteBatchSize, len(upsertStates))
+		if _, err := execRCRestrictedSQLWithSession(ctx, sctx, buildUpsertMVRefreshAlertSQL(updatedAt, upsertStates[start:end]), nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (*serviceHelper) CleanupStaleMVRefreshAlerts(
+	ctx context.Context,
+	sysSessionPool basic.SessionPool,
+) error {
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
+	_, err := execRCRestrictedSQLWithSessionPool(ctx, sysSessionPool, buildCleanupStaleMVRefreshAlertSQL(), nil)
+	return err
 }
 
 func (*serviceHelper) getServerInfo() (serverInfo, error) {
@@ -896,6 +1010,8 @@ func (*serviceHelper) loadAllTiDBMVRefresh(ctx context.Context, sysSessionPool b
 			m.mviewName = mviewName
 			m.alertWarningSec = alertWarningSec
 			m.alertOverdueSec = alertOverdueSec
+		} else {
+			m.metadataUnresolved = true
 		}
 		m.orderTs = m.nextRefresh.UnixMilli()
 		newPending[mvID] = m

--- a/pkg/mvservice/service_settings.go
+++ b/pkg/mvservice/service_settings.go
@@ -308,8 +308,8 @@ func deriveHistoryGCInterval(mviewRefreshRetention, mlogPurgeRetention time.Dura
 	if interval < time.Second {
 		return time.Second
 	}
-	if interval > time.Hour {
-		return time.Hour
+	if interval > defaultMVHistoryGCInterval {
+		return defaultMVHistoryGCInterval
 	}
 	return interval
 }

--- a/pkg/mvservice/task_handler.go
+++ b/pkg/mvservice/task_handler.go
@@ -37,6 +37,8 @@ type MVTaskHandler interface {
 	PurgeMVLog(ctx context.Context, sysSessionPool basic.SessionPool, mvLogID int64) (nextPurge time.Time, err error)
 	TryBackoffRefreshManualCancel(ctx context.Context, sysSessionPool basic.SessionPool, mvID int64, nextRefresh time.Time) (applied bool, appliedNext time.Time, err error)
 	TryBackoffPurgeManualCancel(ctx context.Context, sysSessionPool basic.SessionPool, mvLogID int64, nextPurge time.Time) (applied bool, appliedNext time.Time, err error)
+	SyncMVRefreshAlertStates(ctx context.Context, sysSessionPool basic.SessionPool, updatedAt time.Time, states []refreshAlertTask) error
+	CleanupStaleMVRefreshAlerts(ctx context.Context, sysSessionPool basic.SessionPool) error
 	loadAllTiDBMVLogPurge(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mvLog, error)
 	loadAllTiDBMVRefresh(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mv, error)
 	GetCurrentTSO(ctx context.Context, sysSessionPool basic.SessionPool) (uint64, error)

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -59,18 +59,34 @@ const (
 
 var (
 	testSQLDeleteMVRefreshHistBeforeTSO = fmt.Sprintf(
-		`DELETE FROM mysql.tidb_mview_refresh_hist WHERE REFRESH_JOB_ID < %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
+		`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID < %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
 		historyGCDeleteBatchSize,
 	)
 	testSQLDeleteMVLogPurgeHistBeforeTSO = fmt.Sprintf(
-		`DELETE FROM mysql.tidb_mlog_purge_hist WHERE PURGE_JOB_ID < %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
+		`DELETE FROM mysql.tidb_mlog_purge_hist WHERE (PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running') AND PURGE_JOB_ID < %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
 		historyGCDeleteBatchSize,
 	)
-	testExpectedPurgeMVLogSQL = []string{
+	testSQLCountMVRefreshHist  = `SELECT COUNT(*), MIN(REFRESH_JOB_ID) FROM mysql.tidb_mview_refresh_hist`
+	testSQLCountMVLogPurgeHist = `SELECT COUNT(*), MIN(PURGE_JOB_ID) FROM mysql.tidb_mlog_purge_hist`
+	testExpectedPurgeMVLogSQL  = []string{
 		testSQLPurgeMVLog,
 		testSQLFindPurgeNextTime,
 	}
 )
+
+func testSQLDeleteMVRefreshHistByCount(limit uint64) string {
+	return fmt.Sprintf(
+		`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID >= %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
+		limit,
+	)
+}
+
+func testSQLDeleteMVLogPurgeHistByCount(limit uint64) string {
+	return fmt.Sprintf(
+		`DELETE FROM mysql.tidb_mlog_purge_hist WHERE (PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running') AND PURGE_JOB_ID >= %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
+		limit,
+	)
+}
 
 type mockSessionPool struct{}
 
@@ -347,6 +363,8 @@ type mockMVServiceHelper struct {
 	cleanupStaleRefreshAlertCalls     atomic.Int32
 	syncRefreshAlertErr               error
 	cleanupStaleRefreshAlertErr       error
+	lastMViewHistoryGCMaxRecords      atomic.Uint64
+	lastMLogHistoryGCMaxRecords       atomic.Uint64
 
 	lastRefreshID int64
 	lastPurgeID   int64
@@ -457,6 +475,8 @@ func (m *mockMVServiceHelper) PurgeMVHistoryBeforeTSO(
 	m.lastHistoryGCCurrentTSO.Store(currentTSO)
 	m.lastMViewHistoryGCRetention.Store(int64(mviewRefreshRetention))
 	m.lastMLogHistoryGCRetention.Store(int64(mlogPurgeRetention))
+	m.lastMViewHistoryGCMaxRecords.Store(defaultMVHistoryGCMaxRecords)
+	m.lastMLogHistoryGCMaxRecords.Store(defaultMVHistoryGCMaxRecords)
 	return m.historyGCErr
 }
 
@@ -763,6 +783,8 @@ func TestMVServiceMaintenanceTimerTriggersHistoryGC(t *testing.T) {
 	require.Equal(t, helper.currentTSO, helper.lastHistoryGCCurrentTSO.Load())
 	require.Equal(t, int64(defaultMVHistoryGCRetention), helper.lastMViewHistoryGCRetention.Load())
 	require.Equal(t, int64(defaultMVHistoryGCRetention), helper.lastMLogHistoryGCRetention.Load())
+	require.Equal(t, defaultMVHistoryGCMaxRecords, helper.lastMViewHistoryGCMaxRecords.Load())
+	require.Equal(t, defaultMVHistoryGCMaxRecords, helper.lastMLogHistoryGCMaxRecords.Load())
 	require.Eventually(t, func() bool {
 		return helper.taskDurationCount(mvTaskDurationTypeHistoryGC, mvDurationResultSuccess) > 0
 	}, testEventuallyWait, testEventuallyTick)
@@ -1594,28 +1616,50 @@ func TestServerHelperGetCurrentTSOInvalidVersion(t *testing.T) {
 func TestServerHelperPurgeMVHistoryBeforeTSO(t *testing.T) {
 	installMockTimeForTest(t)
 
-	buildExpectedSQL := func(refreshExec, purgeExec int) []string {
-		sqls := make([]string, 0, refreshExec+purgeExec)
+	buildExpectedSQL := func(
+		refreshExec, purgeExec int,
+		refreshCountCapLimits, purgeCountCapLimits []uint64,
+	) []string {
+		sqls := make([]string, 0, refreshExec+purgeExec+len(refreshCountCapLimits)+len(purgeCountCapLimits)+2)
 		for i := 0; i < refreshExec; i++ {
 			sqls = append(sqls, testSQLDeleteMVRefreshHistBeforeTSO)
 		}
+		sqls = append(sqls, testSQLCountMVRefreshHist)
+		for _, limit := range refreshCountCapLimits {
+			sqls = append(sqls, testSQLDeleteMVRefreshHistByCount(limit))
+		}
 		for i := 0; i < purgeExec; i++ {
 			sqls = append(sqls, testSQLDeleteMVLogPurgeHistBeforeTSO)
+		}
+		sqls = append(sqls, testSQLCountMVLogPurgeHist)
+		for _, limit := range purgeCountCapLimits {
+			sqls = append(sqls, testSQLDeleteMVLogPurgeHistByCount(limit))
 		}
 		return sqls
 	}
 
 	testCases := []struct {
-		name                  string
-		currentTSO            uint64
-		mviewRetention        time.Duration
-		mlogRetention         time.Duration
-		refreshAffectedRows   []uint64
-		purgeAffectedRows     []uint64
-		expectRefreshExec     int
-		expectPurgeExec       int
-		assertArgsAreEqualTSO bool
-		assertArgsNotEqual    bool
+		name                     string
+		currentTSO               uint64
+		mviewRetention           time.Duration
+		mlogRetention            time.Duration
+		refreshTimeAffectedRows  []uint64
+		purgeTimeAffectedRows    []uint64
+		refreshCountRows         []chunk.Row
+		purgeCountRows           []chunk.Row
+		refreshTimeErr           error
+		refreshCountErr          error
+		purgeTimeErr             error
+		purgeCountErr            error
+		expectRefreshExec        int
+		expectPurgeExec          int
+		expectRefreshCountCap    []uint64
+		expectPurgeCountCap      []uint64
+		refreshCountAffectedRows []uint64
+		purgeCountAffectedRows   []uint64
+		assertArgsAreEqualTSO    bool
+		assertArgsNotEqual       bool
+		expectErrContains        []string
 	}{
 		{
 			name:                  "zero_retention",
@@ -1640,14 +1684,14 @@ func TestServerHelperPurgeMVHistoryBeforeTSO(t *testing.T) {
 			currentTSO:     987654321,
 			mviewRetention: 0,
 			mlogRetention:  0,
-			refreshAffectedRows: []uint64{
+			refreshTimeAffectedRows: []uint64{
 				uint64(historyGCDeleteBatchSize),
 				uint64(historyGCDeleteBatchSize),
 				1,
 			},
-			purgeAffectedRows: []uint64{0},
-			expectRefreshExec: 3,
-			expectPurgeExec:   1,
+			purgeTimeAffectedRows: []uint64{0},
+			expectRefreshExec:     3,
+			expectPurgeExec:       1,
 		},
 		{
 			name:              "batch_delete_no_max_batches",
@@ -1656,6 +1700,65 @@ func TestServerHelperPurgeMVHistoryBeforeTSO(t *testing.T) {
 			mlogRetention:     0,
 			expectRefreshExec: 26,
 			expectPurgeExec:   1,
+		},
+		{
+			name:           "count_cap_delete_budget",
+			currentTSO:     987654321,
+			mviewRetention: 0,
+			mlogRetention:  0,
+			refreshCountRows: []chunk.Row{
+				chunk.MutRowFromDatums([]types.Datum{
+					types.NewIntDatum(int64(defaultMVHistoryGCMaxRecords + historyGCDeleteBatchSize + 5)),
+					types.NewUintDatum(500),
+				}).ToRow(),
+			},
+			purgeCountRows: []chunk.Row{
+				chunk.MutRowFromDatums([]types.Datum{
+					types.NewIntDatum(int64(defaultMVHistoryGCMaxRecords + 8)),
+					types.NewUintDatum(900),
+				}).ToRow(),
+			},
+			refreshTimeAffectedRows:  []uint64{0},
+			purgeTimeAffectedRows:    []uint64{0},
+			expectRefreshExec:        1,
+			expectPurgeExec:          1,
+			expectRefreshCountCap:    []uint64{uint64(historyGCDeleteBatchSize), 5},
+			expectPurgeCountCap:      []uint64{8},
+			refreshCountAffectedRows: []uint64{uint64(historyGCDeleteBatchSize), 5},
+			purgeCountAffectedRows:   []uint64{8},
+		},
+		{
+			name:                    "count_cap_under_limit",
+			currentTSO:              987654321,
+			mviewRetention:          0,
+			mlogRetention:           0,
+			refreshTimeAffectedRows: []uint64{0},
+			purgeTimeAffectedRows:   []uint64{0},
+			refreshCountRows: []chunk.Row{
+				chunk.MutRowFromDatums([]types.Datum{
+					types.NewIntDatum(int64(defaultMVHistoryGCMaxRecords)),
+					types.NewUintDatum(500),
+				}).ToRow(),
+			},
+			purgeCountRows: []chunk.Row{
+				chunk.MutRowFromDatums([]types.Datum{
+					types.NewIntDatum(int64(defaultMVHistoryGCMaxRecords - 1)),
+					types.NewUintDatum(900),
+				}).ToRow(),
+			},
+			expectRefreshExec: 1,
+			expectPurgeExec:   1,
+		},
+		{
+			name:                  "continue_after_refresh_retention_error",
+			currentTSO:            987654321,
+			mviewRetention:        0,
+			mlogRetention:         0,
+			refreshTimeErr:        errors.New("refresh retention gc failed"),
+			purgeTimeAffectedRows: []uint64{0},
+			expectRefreshExec:     1,
+			expectPurgeExec:       1,
+			expectErrContains:     []string{"purge mview refresh history by retention failed", "refresh retention gc failed"},
 		},
 	}
 
@@ -1671,12 +1774,36 @@ func TestServerHelperPurgeMVHistoryBeforeTSO(t *testing.T) {
 				se.restrictedAffectedRows[testSQLDeleteMVRefreshHistBeforeTSO] = append(refreshAffected, 1)
 				se.restrictedAffectedRows[testSQLDeleteMVLogPurgeHistBeforeTSO] = []uint64{0}
 			} else {
-				if len(tc.refreshAffectedRows) > 0 {
-					se.restrictedAffectedRows[testSQLDeleteMVRefreshHistBeforeTSO] = tc.refreshAffectedRows
+				if len(tc.refreshTimeAffectedRows) > 0 {
+					se.restrictedAffectedRows[testSQLDeleteMVRefreshHistBeforeTSO] = tc.refreshTimeAffectedRows
 				}
-				if len(tc.purgeAffectedRows) > 0 {
-					se.restrictedAffectedRows[testSQLDeleteMVLogPurgeHistBeforeTSO] = tc.purgeAffectedRows
+				if len(tc.purgeTimeAffectedRows) > 0 {
+					se.restrictedAffectedRows[testSQLDeleteMVLogPurgeHistBeforeTSO] = tc.purgeTimeAffectedRows
 				}
+			}
+			for i, limit := range tc.expectRefreshCountCap {
+				se.restrictedAffectedRows[testSQLDeleteMVRefreshHistByCount(limit)] = []uint64{tc.refreshCountAffectedRows[i]}
+			}
+			for i, limit := range tc.expectPurgeCountCap {
+				se.restrictedAffectedRows[testSQLDeleteMVLogPurgeHistByCount(limit)] = []uint64{tc.purgeCountAffectedRows[i]}
+			}
+			if tc.refreshCountRows != nil {
+				se.restrictedRows[testSQLCountMVRefreshHist] = tc.refreshCountRows
+			}
+			if tc.purgeCountRows != nil {
+				se.restrictedRows[testSQLCountMVLogPurgeHist] = tc.purgeCountRows
+			}
+			if tc.refreshTimeErr != nil {
+				se.restrictedErrs[testSQLDeleteMVRefreshHistBeforeTSO] = tc.refreshTimeErr
+			}
+			if tc.refreshCountErr != nil {
+				se.restrictedErrs[testSQLCountMVRefreshHist] = tc.refreshCountErr
+			}
+			if tc.purgeTimeErr != nil {
+				se.restrictedErrs[testSQLDeleteMVLogPurgeHistBeforeTSO] = tc.purgeTimeErr
+			}
+			if tc.purgeCountErr != nil {
+				se.restrictedErrs[testSQLCountMVLogPurgeHist] = tc.purgeCountErr
 			}
 			pool := recordingSessionPool{se: se}
 
@@ -1687,19 +1814,83 @@ func TestServerHelperPurgeMVHistoryBeforeTSO(t *testing.T) {
 				tc.mviewRetention,
 				tc.mlogRetention,
 			)
-			require.NoError(t, err)
-			require.Equal(t, buildExpectedSQL(tc.expectRefreshExec, tc.expectPurgeExec), se.executedRestrictedSQL)
-			require.Len(t, se.executedRestrictedArg, tc.expectRefreshExec+tc.expectPurgeExec)
+			if len(tc.expectErrContains) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, msg := range tc.expectErrContains {
+					require.ErrorContains(t, err, msg)
+				}
+			}
+			require.Equal(t, buildExpectedSQL(
+				tc.expectRefreshExec,
+				tc.expectPurgeExec,
+				tc.expectRefreshCountCap,
+				tc.expectPurgeCountCap,
+			), se.executedRestrictedSQL)
+			require.Len(t, se.executedRestrictedArg, len(se.executedRestrictedSQL))
 
+			purgeTimeArgPos := tc.expectRefreshExec + len(tc.expectRefreshCountCap) + 1
 			if tc.assertArgsAreEqualTSO {
 				require.Equal(t, []any{tc.currentTSO}, se.executedRestrictedArg[0])
-				require.Equal(t, []any{tc.currentTSO}, se.executedRestrictedArg[tc.expectRefreshExec])
+				require.Equal(t, []any{tc.currentTSO}, se.executedRestrictedArg[purgeTimeArgPos])
 			}
 			if tc.assertArgsNotEqual {
-				require.NotEqual(t, se.executedRestrictedArg[0][0], se.executedRestrictedArg[tc.expectRefreshExec][0])
+				require.NotEqual(t, se.executedRestrictedArg[0][0], se.executedRestrictedArg[purgeTimeArgPos][0])
+			}
+			require.Empty(t, se.executedRestrictedArg[tc.expectRefreshExec])
+			argBase := tc.expectRefreshExec + 1
+			if len(tc.refreshCountRows) > 0 {
+				minJobID := tc.refreshCountRows[0].GetUint64(1)
+				for i := range tc.expectRefreshCountCap {
+					require.Equal(t, []any{minJobID}, se.executedRestrictedArg[argBase+i])
+				}
+			}
+			countPos := purgeTimeArgPos + tc.expectPurgeExec
+			require.Empty(t, se.executedRestrictedArg[countPos])
+			if len(tc.purgeCountRows) > 0 {
+				minJobID := tc.purgeCountRows[0].GetUint64(1)
+				for i := range tc.expectPurgeCountCap {
+					require.Equal(t, []any{minJobID}, se.executedRestrictedArg[countPos+1+i])
+				}
 			}
 		})
 	}
+}
+
+func TestServerHelperPurgeMVHistoryBeforeTSOTreatsNullStatusAsDeletable(t *testing.T) {
+	installMockTimeForTest(t)
+
+	se := newRecordingSessionContext()
+	se.restrictedAffectedRows[testSQLDeleteMVRefreshHistBeforeTSO] = []uint64{0}
+	se.restrictedAffectedRows[testSQLDeleteMVLogPurgeHistBeforeTSO] = []uint64{0}
+	se.restrictedRows[testSQLCountMVRefreshHist] = []chunk.Row{
+		chunk.MutRowFromDatums([]types.Datum{
+			types.NewIntDatum(int64(defaultMVHistoryGCMaxRecords)),
+			types.NewUintDatum(500),
+		}).ToRow(),
+	}
+	se.restrictedRows[testSQLCountMVLogPurgeHist] = []chunk.Row{
+		chunk.MutRowFromDatums([]types.Datum{
+			types.NewIntDatum(int64(defaultMVHistoryGCMaxRecords)),
+			types.NewUintDatum(900),
+		}).ToRow(),
+	}
+
+	err := (&serviceHelper{}).PurgeMVHistoryBeforeTSO(
+		context.Background(),
+		recordingSessionPool{se: se},
+		987654321,
+		0,
+		0,
+	)
+	require.NoError(t, err)
+	require.Contains(t, se.executedRestrictedSQL, testSQLDeleteMVRefreshHistBeforeTSO)
+	require.Contains(t, se.executedRestrictedSQL, testSQLDeleteMVLogPurgeHistBeforeTSO)
+	require.Contains(t, testSQLDeleteMVRefreshHistBeforeTSO, "REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running'")
+	require.Contains(t, testSQLDeleteMVLogPurgeHistBeforeTSO, "PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running'")
+	require.Contains(t, testSQLDeleteMVRefreshHistByCount(1), "REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running'")
+	require.Contains(t, testSQLDeleteMVLogPurgeHistByCount(1), "PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running'")
 }
 
 func TestServerHelperRefreshMVDeletedWhenMetaNotFound(t *testing.T) {

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -58,6 +58,34 @@ const (
 )
 
 var (
+	testSQLMarkStaleMVRefreshHistOrphaned = fmt.Sprintf(
+		`UPDATE mysql.tidb_mview_refresh_hist
+SET REFRESH_STATUS = '%s',
+	REFRESH_ENDTIME = IFNULL(REFRESH_ENDTIME, NOW(6)),
+	REFRESH_DURATION_SEC = IFNULL(REFRESH_DURATION_SEC, CASE WHEN REFRESH_TIME IS NULL THEN NULL ELSE TIMESTAMPDIFF(MICROSECOND, REFRESH_TIME, NOW(6)) / 1000000.0 END),
+	REFRESH_FAILED_REASON = IFNULL(REFRESH_FAILED_REASON, '%s')
+WHERE REFRESH_STATUS = 'running'
+  AND COALESCE(LAST_HEARTBEAT_AT, REFRESH_TIME) < %%?
+ORDER BY REFRESH_JOB_ID
+LIMIT %d`,
+		mvHistoryOrphanedStatus,
+		mvRefreshHistoryOrphanedReason,
+		historyGCDeleteBatchSize,
+	)
+	testSQLMarkStaleMVLogPurgeHistOrphaned = fmt.Sprintf(
+		`UPDATE mysql.tidb_mlog_purge_hist
+SET PURGE_STATUS = '%s',
+	PURGE_ENDTIME = IFNULL(PURGE_ENDTIME, NOW(6)),
+	PURGE_DURATION_SEC = IFNULL(PURGE_DURATION_SEC, CASE WHEN PURGE_TIME IS NULL THEN NULL ELSE TIMESTAMPDIFF(MICROSECOND, PURGE_TIME, NOW(6)) / 1000000.0 END),
+	PURGE_FAILED_REASON = IFNULL(PURGE_FAILED_REASON, '%s')
+WHERE PURGE_STATUS = 'running'
+  AND COALESCE(LAST_HEARTBEAT_AT, PURGE_TIME) < %%?
+ORDER BY PURGE_JOB_ID
+LIMIT %d`,
+		mvHistoryOrphanedStatus,
+		mvLogPurgeHistoryOrphanedReason,
+		historyGCDeleteBatchSize,
+	)
 	testSQLDeleteMVRefreshHistBeforeTSO = fmt.Sprintf(
 		`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID < %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
 		historyGCDeleteBatchSize,
@@ -1620,7 +1648,8 @@ func TestServerHelperPurgeMVHistoryBeforeTSO(t *testing.T) {
 		refreshExec, purgeExec int,
 		refreshCountCapLimits, purgeCountCapLimits []uint64,
 	) []string {
-		sqls := make([]string, 0, refreshExec+purgeExec+len(refreshCountCapLimits)+len(purgeCountCapLimits)+2)
+		sqls := make([]string, 0, refreshExec+purgeExec+len(refreshCountCapLimits)+len(purgeCountCapLimits)+4)
+		sqls = append(sqls, testSQLMarkStaleMVRefreshHistOrphaned)
 		for i := 0; i < refreshExec; i++ {
 			sqls = append(sqls, testSQLDeleteMVRefreshHistBeforeTSO)
 		}
@@ -1628,6 +1657,7 @@ func TestServerHelperPurgeMVHistoryBeforeTSO(t *testing.T) {
 		for _, limit := range refreshCountCapLimits {
 			sqls = append(sqls, testSQLDeleteMVRefreshHistByCount(limit))
 		}
+		sqls = append(sqls, testSQLMarkStaleMVLogPurgeHistOrphaned)
 		for i := 0; i < purgeExec; i++ {
 			sqls = append(sqls, testSQLDeleteMVLogPurgeHistBeforeTSO)
 		}
@@ -1765,6 +1795,8 @@ func TestServerHelperPurgeMVHistoryBeforeTSO(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			se := newRecordingSessionContext()
+			se.restrictedAffectedRows[testSQLMarkStaleMVRefreshHistOrphaned] = []uint64{0}
+			se.restrictedAffectedRows[testSQLMarkStaleMVLogPurgeHistOrphaned] = []uint64{0}
 			if tc.name == "batch_delete_no_max_batches" {
 				const extraBatches = 25
 				refreshAffected := make([]uint64, extraBatches)
@@ -1830,16 +1862,21 @@ func TestServerHelperPurgeMVHistoryBeforeTSO(t *testing.T) {
 			), se.executedRestrictedSQL)
 			require.Len(t, se.executedRestrictedArg, len(se.executedRestrictedSQL))
 
-			purgeTimeArgPos := tc.expectRefreshExec + len(tc.expectRefreshCountCap) + 1
+			refreshRetentionArgPos := 1
+			purgeOrphanArgPos := tc.expectRefreshExec + len(tc.expectRefreshCountCap) + 2
+			purgeTimeArgPos := purgeOrphanArgPos + 1
 			if tc.assertArgsAreEqualTSO {
-				require.Equal(t, []any{tc.currentTSO}, se.executedRestrictedArg[0])
+				require.Len(t, se.executedRestrictedArg[0], 1)
+				require.Len(t, se.executedRestrictedArg[purgeOrphanArgPos], 1)
+				require.Equal(t, se.executedRestrictedArg[0][0], se.executedRestrictedArg[purgeOrphanArgPos][0])
+				require.Equal(t, []any{tc.currentTSO}, se.executedRestrictedArg[refreshRetentionArgPos])
 				require.Equal(t, []any{tc.currentTSO}, se.executedRestrictedArg[purgeTimeArgPos])
 			}
 			if tc.assertArgsNotEqual {
-				require.NotEqual(t, se.executedRestrictedArg[0][0], se.executedRestrictedArg[purgeTimeArgPos][0])
+				require.NotEqual(t, se.executedRestrictedArg[refreshRetentionArgPos][0], se.executedRestrictedArg[purgeTimeArgPos][0])
 			}
-			require.Empty(t, se.executedRestrictedArg[tc.expectRefreshExec])
-			argBase := tc.expectRefreshExec + 1
+			require.Empty(t, se.executedRestrictedArg[tc.expectRefreshExec+1])
+			argBase := tc.expectRefreshExec + 2
 			if len(tc.refreshCountRows) > 0 {
 				minJobID := tc.refreshCountRows[0].GetUint64(1)
 				for i := range tc.expectRefreshCountCap {
@@ -1891,6 +1928,52 @@ func TestServerHelperPurgeMVHistoryBeforeTSOTreatsNullStatusAsDeletable(t *testi
 	require.Contains(t, testSQLDeleteMVLogPurgeHistBeforeTSO, "PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running'")
 	require.Contains(t, testSQLDeleteMVRefreshHistByCount(1), "REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running'")
 	require.Contains(t, testSQLDeleteMVLogPurgeHistByCount(1), "PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running'")
+}
+
+func TestServerHelperPurgeMVHistoryBeforeTSOReconcilesStaleRunningHistRows(t *testing.T) {
+	installMockTimeForTest(t)
+
+	currentTSO := oracle.ComposeTS(int64(36*time.Hour/time.Millisecond), 0)
+	expectedCutoffTime := oracle.GetTimeFromTS(oracle.ComposeTS(int64(12*time.Hour/time.Millisecond), 0))
+
+	se := newRecordingSessionContext()
+	se.restrictedAffectedRows[testSQLMarkStaleMVRefreshHistOrphaned] = []uint64{2}
+	se.restrictedAffectedRows[testSQLMarkStaleMVLogPurgeHistOrphaned] = []uint64{1}
+	se.restrictedAffectedRows[testSQLDeleteMVRefreshHistBeforeTSO] = []uint64{0}
+	se.restrictedAffectedRows[testSQLDeleteMVLogPurgeHistBeforeTSO] = []uint64{0}
+	se.restrictedRows[testSQLCountMVRefreshHist] = []chunk.Row{
+		chunk.MutRowFromDatums([]types.Datum{
+			types.NewIntDatum(int64(defaultMVHistoryGCMaxRecords)),
+			types.NewUintDatum(500),
+		}).ToRow(),
+	}
+	se.restrictedRows[testSQLCountMVLogPurgeHist] = []chunk.Row{
+		chunk.MutRowFromDatums([]types.Datum{
+			types.NewIntDatum(int64(defaultMVHistoryGCMaxRecords)),
+			types.NewUintDatum(900),
+		}).ToRow(),
+	}
+
+	err := (&serviceHelper{}).PurgeMVHistoryBeforeTSO(
+		context.Background(),
+		recordingSessionPool{se: se},
+		currentTSO,
+		0,
+		0,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		testSQLMarkStaleMVRefreshHistOrphaned,
+		testSQLDeleteMVRefreshHistBeforeTSO,
+		testSQLCountMVRefreshHist,
+		testSQLMarkStaleMVLogPurgeHistOrphaned,
+		testSQLDeleteMVLogPurgeHistBeforeTSO,
+		testSQLCountMVLogPurgeHist,
+	}, se.executedRestrictedSQL)
+	require.Equal(t, []any{expectedCutoffTime}, se.executedRestrictedArg[0])
+	require.Equal(t, []any{currentTSO}, se.executedRestrictedArg[1])
+	require.Equal(t, []any{expectedCutoffTime}, se.executedRestrictedArg[3])
+	require.Equal(t, []any{currentTSO}, se.executedRestrictedArg[4])
 }
 
 func TestServerHelperRefreshMVDeletedWhenMetaNotFound(t *testing.T) {

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -2582,14 +2582,22 @@ func TestServerHelperSyncMVRefreshAlertStates(t *testing.T) {
 		{
 			mviewID: 0,
 		},
+		{
+			mviewID:    105,
+			schemaName: "test",
+			mviewName:  "mv_no_success",
+			alertLevel: mvRefreshAlertLevelWarning,
+		},
 	}
 
 	err := (&serviceHelper{}).SyncMVRefreshAlertStates(context.Background(), pool, now, states)
 	require.NoError(t, err)
+	upsertSQL := buildUpsertMVRefreshAlertSQL(now, []refreshAlertTask{states[0], states[1], states[5]})
 	require.Equal(t, []string{
 		buildDeleteMVRefreshAlertSQL([]int64{103}),
-		buildUpsertMVRefreshAlertSQL(now, states[:2]),
+		upsertSQL,
 	}, se.executedRestrictedSQL)
+	require.Contains(t, upsertSQL, "'mv_no_success', 'warning', NULL,")
 	require.Len(t, se.executedRestrictedArg, 2)
 	require.Empty(t, se.executedRestrictedArg[0])
 	require.Empty(t, se.executedRestrictedArg[1])

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -343,9 +343,17 @@ type mockMVServiceHelper struct {
 	lastHistoryGCCurrentTSO           atomic.Uint64
 	lastMViewHistoryGCRetention       atomic.Int64
 	lastMLogHistoryGCRetention        atomic.Int64
+	syncRefreshAlertCalls             atomic.Int32
+	cleanupStaleRefreshAlertCalls     atomic.Int32
+	syncRefreshAlertErr               error
+	cleanupStaleRefreshAlertErr       error
 
 	lastRefreshID int64
 	lastPurgeID   int64
+
+	syncRefreshAlertMu   sync.Mutex
+	lastRefreshAlertAt   time.Time
+	lastRefreshAlertSync []refreshAlertTask
 
 	metricsMu          sync.Mutex
 	taskDurationCounts map[string]int
@@ -393,6 +401,20 @@ func (m *mockMVServiceHelper) TryBackoffPurgeManualCancel(_ context.Context, _ b
 		m.purgeManualCancelBackoffNext = next
 	}
 	return m.purgeManualCancelBackoffApplied, m.purgeManualCancelBackoffNext, m.purgeManualCancelBackoffErr
+}
+
+func (m *mockMVServiceHelper) SyncMVRefreshAlertStates(_ context.Context, _ basic.SessionPool, updatedAt time.Time, states []refreshAlertTask) error {
+	m.syncRefreshAlertCalls.Add(1)
+	m.syncRefreshAlertMu.Lock()
+	defer m.syncRefreshAlertMu.Unlock()
+	m.lastRefreshAlertAt = updatedAt
+	m.lastRefreshAlertSync = append(m.lastRefreshAlertSync[:0], states...)
+	return m.syncRefreshAlertErr
+}
+
+func (m *mockMVServiceHelper) CleanupStaleMVRefreshAlerts(_ context.Context, _ basic.SessionPool) error {
+	m.cleanupStaleRefreshAlertCalls.Add(1)
+	return m.cleanupStaleRefreshAlertErr
 }
 
 func (m *mockMVServiceHelper) loadAllTiDBMVLogPurge(context.Context, basic.SessionPool) (map[int64]*mvLog, error) {
@@ -2253,6 +2275,61 @@ func TestServerHelperTryBackoffRefreshManualCancel(t *testing.T) {
 		require.Equal(t, []string{"BEGIN PESSIMISTIC", "ROLLBACK"}, se.executedSQL)
 		require.Equal(t, []string{testSQLLockMVNextTime}, se.executedRestrictedSQL)
 	})
+}
+
+func TestServerHelperSyncMVRefreshAlertStates(t *testing.T) {
+	installMockTimeForTest(t)
+
+	now := mvsNow().Round(0)
+	se := newRecordingSessionContext()
+	pool := recordingSessionPool{se: se}
+	states := []refreshAlertTask{
+		{
+			mviewID:         101,
+			schemaName:      "test",
+			mviewName:       "mv_warn",
+			lastSuccessTime: now.Add(-time.Minute),
+			alertLevel:      mvRefreshAlertLevelWarning,
+		},
+		{
+			mviewID:         102,
+			schemaName:      "test",
+			mviewName:       "mv_overdue",
+			lastSuccessTime: now.Add(-2 * time.Minute),
+			alertLevel:      mvRefreshAlertLevelOverdue,
+		},
+		{
+			mviewID: 103,
+		},
+		{
+			mviewID:            104,
+			metadataUnresolved: true,
+		},
+		{
+			mviewID: 0,
+		},
+	}
+
+	err := (&serviceHelper{}).SyncMVRefreshAlertStates(context.Background(), pool, now, states)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		buildDeleteMVRefreshAlertSQL([]int64{103}),
+		buildUpsertMVRefreshAlertSQL(now, states[:2]),
+	}, se.executedRestrictedSQL)
+	require.Len(t, se.executedRestrictedArg, 2)
+	require.Empty(t, se.executedRestrictedArg[0])
+	require.Empty(t, se.executedRestrictedArg[1])
+}
+
+func TestServerHelperCleanupStaleMVRefreshAlerts(t *testing.T) {
+	se := newRecordingSessionContext()
+	pool := recordingSessionPool{se: se}
+
+	err := (&serviceHelper{}).CleanupStaleMVRefreshAlerts(context.Background(), pool)
+	require.NoError(t, err)
+	require.Equal(t, []string{buildCleanupStaleMVRefreshAlertSQL()}, se.executedRestrictedSQL)
+	require.Len(t, se.executedRestrictedArg, 1)
+	require.Empty(t, se.executedRestrictedArg[0])
 }
 
 func TestServerHelperTryBackoffPurgeManualCancel(t *testing.T) {

--- a/pkg/mvservice/test_helpers_test.go
+++ b/pkg/mvservice/test_helpers_test.go
@@ -53,14 +53,32 @@ func newRunningMVServiceForTest(t *testing.T, helper Helper) *MVService {
 }
 
 func setHistoryGCOwnerForTest(svc *MVService, ownerHash uint32) {
-	svc.nextHistoryGCAtMillis.Store(0)
-	svc.sch.mu.Lock()
-	svc.sch.ID = "nodeA"
-	svc.sch.chash.hashFunc = mustHash(map[string]uint32{
-		"nodeA#0":           10,
-		"nodeB#0":           30,
+	setServiceOwnersForTest(svc, map[string]uint32{
 		mvHistoryGCOwnerKey: ownerHash,
 	})
+	svc.nextHistoryGCAtMillis.Store(0)
+}
+
+func setRefreshAlertCleanupOwnerForTest(svc *MVService, ownerHash uint32) {
+	setServiceOwnersForTest(svc, map[string]uint32{
+		mvRefreshAlertCleanupOwnerKey: ownerHash,
+	})
+}
+
+func setServiceOwnersForTest(svc *MVService, ownerHashes map[string]uint32) {
+	svc.sch.mu.Lock()
+	svc.sch.ID = "nodeA"
+	svc.sch.chash.replicas = 1
+	mapping := map[string]uint32{
+		"nodeA#0":                     10,
+		"nodeB#0":                     30,
+		mvHistoryGCOwnerKey:           10,
+		mvRefreshAlertCleanupOwnerKey: 10,
+	}
+	for key, hash := range ownerHashes {
+		mapping[key] = hash
+	}
+	svc.sch.chash.hashFunc = mustHash(mapping)
 	svc.sch.servers = map[string]serverInfo{
 		"nodeA": {ID: "nodeA"},
 		"nodeB": {ID: "nodeB"},

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -792,6 +792,7 @@ const (
 		REFRESH_FAILED_REASON text DEFAULT NULL,
 		CANCEL_REQUESTED_AT datetime(6) DEFAULT NULL,
 		CANCEL_REQUESTED_BY varchar(512) DEFAULT NULL,
+		LAST_HEARTBEAT_AT datetime(6) DEFAULT NULL,
 		PRIMARY KEY(REFRESH_JOB_ID),
 		KEY idx_mview_time (MVIEW_ID, REFRESH_TIME),
 		KEY idx_mv_name_time (MV_SCHEMA, MV_NAME, REFRESH_TIME),
@@ -825,6 +826,7 @@ const (
 		PURGE_FAILED_REASON text DEFAULT NULL,
 		CANCEL_REQUESTED_AT datetime(6) DEFAULT NULL,
 		CANCEL_REQUESTED_BY varchar(512) DEFAULT NULL,
+		LAST_HEARTBEAT_AT datetime(6) DEFAULT NULL,
 		PRIMARY KEY(PURGE_JOB_ID),
 		KEY idx_mlog_time (MLOG_ID, PURGE_TIME),
 		KEY idx_table_name_time (BASE_TABLE_SCHEMA, BASE_TABLE_NAME, PURGE_TIME),
@@ -1293,12 +1295,16 @@ const (
 	// Add MV refresh alert table and duration indexes to MV refresh/purge history tables.
 	version224 = 224
 
+	// version 225
+	// Add LAST_HEARTBEAT_AT to MV refresh/purge history tables.
+	version225 = 225
+
 	// next version should start with 239
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version224
+var currentBootstrapVersion int64 = version225
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -1478,6 +1484,7 @@ var (
 		upgradeToVer222,
 		upgradeToVer223,
 		upgradeToVer224,
+		upgradeToVer225,
 	}
 )
 
@@ -3399,6 +3406,14 @@ func upgradeToVer224(s sessiontypes.Session, ver int64) {
 	doReentrantDDL(s, CreateTiDBMViewRefreshAlertTable)
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mview_refresh_hist ADD INDEX idx_refresh_duration_sec (REFRESH_DURATION_SEC)", dbterror.ErrDupKeyName)
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mlog_purge_hist ADD INDEX idx_purge_duration_sec (PURGE_DURATION_SEC)", dbterror.ErrDupKeyName)
+}
+
+func upgradeToVer225(s sessiontypes.Session, ver int64) {
+	if ver >= version225 {
+		return
+	}
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mview_refresh_hist ADD COLUMN `LAST_HEARTBEAT_AT` datetime(6) DEFAULT NULL AFTER `CANCEL_REQUESTED_BY`", infoschema.ErrColumnExists)
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mlog_purge_hist ADD COLUMN `LAST_HEARTBEAT_AT` datetime(6) DEFAULT NULL AFTER `CANCEL_REQUESTED_BY`", infoschema.ErrColumnExists)
 }
 
 // initGlobalVariableIfNotExists initialize a global variable with specific val if it does not exist.

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -796,8 +796,19 @@ const (
 		KEY idx_mview_time (MVIEW_ID, REFRESH_TIME),
 		KEY idx_mv_name_time (MV_SCHEMA, MV_NAME, REFRESH_TIME),
 		KEY idx_mview_status (MVIEW_ID, REFRESH_STATUS, REFRESH_TIME),
+		KEY idx_refresh_duration_sec (REFRESH_DURATION_SEC),
 		KEY idx_refresh_time (REFRESH_TIME),
 		KEY idx_refresh_status (REFRESH_STATUS, REFRESH_TIME))`
+
+	// CreateTiDBMViewRefreshAlertTable is a table to store the current refresh alert level for each materialized view.
+	CreateTiDBMViewRefreshAlertTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mview_refresh_alert (
+		MVIEW_ID bigint NOT NULL,
+		MV_SCHEMA varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		MV_NAME varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		ALERT_LEVEL varchar(16) NOT NULL,
+		LAST_SUCCESS_TIME datetime(6) DEFAULT NULL,
+		UPDATED_AT datetime(6) DEFAULT NULL,
+		PRIMARY KEY(MVIEW_ID))`
 
 	// CreateTiDBMLogPurgeHistTable is a table to store mlog purge history.
 	CreateTiDBMLogPurgeHistTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mlog_purge_hist (
@@ -818,6 +829,7 @@ const (
 		KEY idx_mlog_time (MLOG_ID, PURGE_TIME),
 		KEY idx_table_name_time (BASE_TABLE_SCHEMA, BASE_TABLE_NAME, PURGE_TIME),
 		KEY idx_mlog_status (MLOG_ID, PURGE_STATUS, PURGE_TIME),
+		KEY idx_purge_duration_sec (PURGE_DURATION_SEC),
 		KEY idx_purge_time (PURGE_TIME),
 		KEY idx_purge_status (PURGE_STATUS, PURGE_TIME))`
 )
@@ -1277,12 +1289,16 @@ const (
 	// Add time-oriented indexes, object schema/name snapshots, and duration columns to MV refresh/purge history tables.
 	version223 = 223
 
+	// version 224
+	// Add MV refresh alert table and duration indexes to MV refresh/purge history tables.
+	version224 = 224
+
 	// next version should start with 239
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version223
+var currentBootstrapVersion int64 = version224
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -1461,6 +1477,7 @@ var (
 		upgradeToVer221,
 		upgradeToVer222,
 		upgradeToVer223,
+		upgradeToVer224,
 	}
 )
 
@@ -3375,6 +3392,15 @@ func upgradeToVer223(s sessiontypes.Session, ver int64) {
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mlog_purge_hist ADD INDEX idx_purge_time (PURGE_TIME)", dbterror.ErrDupKeyName)
 }
 
+func upgradeToVer224(s sessiontypes.Session, ver int64) {
+	if ver >= version224 {
+		return
+	}
+	doReentrantDDL(s, CreateTiDBMViewRefreshAlertTable)
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mview_refresh_hist ADD INDEX idx_refresh_duration_sec (REFRESH_DURATION_SEC)", dbterror.ErrDupKeyName)
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mlog_purge_hist ADD INDEX idx_purge_duration_sec (PURGE_DURATION_SEC)", dbterror.ErrDupKeyName)
+}
+
 // initGlobalVariableIfNotExists initialize a global variable with specific val if it does not exist.
 func initGlobalVariableIfNotExists(s sessiontypes.Session, name string, val any) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
@@ -3525,11 +3551,12 @@ func doDDLWorks(s sessiontypes.Session) {
 	mustExecute(s, CreateIndexAdvisorTable)
 	// create mysql.tidb_kernel_options
 	mustExecute(s, CreateKernelOptionsTable)
-	// create mysql.tidb_mview_refresh_info/mysql.tidb_mlog_purge_info/mysql.tidb_mview_refresh_hist/mysql.tidb_mlog_purge_hist
+	// create mysql.tidb_mview_refresh_info/mysql.tidb_mlog_purge_info/mysql.tidb_mview_refresh_hist/mysql.tidb_mlog_purge_hist/mysql.tidb_mview_refresh_alert
 	mustExecute(s, CreateTiDBMViewRefreshInfoTable)
 	mustExecute(s, CreateTiDBMLogPurgeInfoTable)
 	mustExecute(s, CreateTiDBMViewRefreshHistTable)
 	mustExecute(s, CreateTiDBMLogPurgeHistTable)
+	mustExecute(s, CreateTiDBMViewRefreshAlertTable)
 }
 
 // doBootstrapSQLFile executes SQL commands in a file as the last stage of bootstrap.

--- a/pkg/session/bootstraptest/BUILD.bazel
+++ b/pkg/session/bootstraptest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "mview_systable_test.go",
     ],
     flaky = True,
-    shard_count = 17,
+    shard_count = 18,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/session/bootstraptest/BUILD.bazel
+++ b/pkg/session/bootstraptest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "mview_systable_test.go",
     ],
     flaky = True,
-    shard_count = 16,
+    shard_count = 17,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/session/bootstraptest/mview_systable_test.go
+++ b/pkg/session/bootstraptest/mview_systable_test.go
@@ -34,6 +34,7 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 		"tidb_mview_refresh_info",
 		"tidb_mlog_purge_info",
 		"tidb_mview_refresh_hist",
+		"tidb_mview_refresh_alert",
 		"tidb_mlog_purge_hist",
 	} {
 		tk.MustQuery("select count(*) from information_schema.tables where table_schema='mysql' and table_name='" + tbl + "'").Check(testkit.Rows("1"))
@@ -63,6 +64,8 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 		Check(testkit.Rows("mv_schema", "mv_name", "refresh_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_mview_status' order by seq_in_index").
 		Check(testkit.Rows("mview_id", "refresh_status", "refresh_time"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_refresh_duration_sec' order by seq_in_index").
+		Check(testkit.Rows("refresh_duration_sec"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_refresh_time' order by seq_in_index").
 		Check(testkit.Rows("refresh_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_refresh_status' order by seq_in_index").
@@ -87,6 +90,16 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 		Check(testkit.Rows("6"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='CANCEL_REQUESTED_BY'").
 		Check(testkit.Rows("varchar(512)"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and index_name='PRIMARY' order by seq_in_index").
+		Check(testkit.Rows("mview_id"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name in ('MV_SCHEMA', 'MV_NAME') order by column_name").
+		Check(testkit.Rows("varchar(64)", "varchar(64)"))
+	tk.MustQuery("select lower(collation_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name in ('MV_SCHEMA', 'MV_NAME') order by column_name").
+		Check(testkit.Rows("utf8mb4_general_ci", "utf8mb4_general_ci"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name='ALERT_LEVEL'").
+		Check(testkit.Rows("varchar(16)"))
+	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name in ('LAST_SUCCESS_TIME', 'UPDATED_AT') order by column_name").
+		Check(testkit.Rows("6", "6"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='PRIMARY' order by seq_in_index").
 		Check(testkit.Rows("purge_job_id"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='idx_mlog_time' order by seq_in_index").
@@ -95,6 +108,8 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 		Check(testkit.Rows("base_table_schema", "base_table_name", "purge_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='idx_mlog_status' order by seq_in_index").
 		Check(testkit.Rows("mlog_id", "purge_status", "purge_time"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='idx_purge_duration_sec' order by seq_in_index").
+		Check(testkit.Rows("purge_duration_sec"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='idx_purge_time' order by seq_in_index").
 		Check(testkit.Rows("purge_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='idx_purge_status' order by seq_in_index").
@@ -267,6 +282,8 @@ func TestUpgradeToVer223MaterializedViewHistoryColumnsAndIndexes(t *testing.T) {
 		Check(testkit.Rows("mview_id", "refresh_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_mv_name_time' order by seq_in_index").
 		Check(testkit.Rows("mv_schema", "mv_name", "refresh_time"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_refresh_duration_sec' order by seq_in_index").
+		Check(testkit.Rows("refresh_duration_sec"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_refresh_time' order by seq_in_index").
 		Check(testkit.Rows("refresh_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and ordinal_position between 2 and 8 order by ordinal_position").
@@ -281,12 +298,103 @@ func TestUpgradeToVer223MaterializedViewHistoryColumnsAndIndexes(t *testing.T) {
 		Check(testkit.Rows("mlog_id", "purge_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='idx_table_name_time' order by seq_in_index").
 		Check(testkit.Rows("base_table_schema", "base_table_name", "purge_time"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='idx_purge_duration_sec' order by seq_in_index").
+		Check(testkit.Rows("purge_duration_sec"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='idx_purge_time' order by seq_in_index").
 		Check(testkit.Rows("purge_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and ordinal_position between 2 and 8 order by ordinal_position").
 		Check(testkit.Rows("mlog_id", "base_table_schema", "base_table_name", "purge_method", "purge_time", "purge_endtime", "purge_duration_sec"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='PURGE_DURATION_SEC'").
 		Check(testkit.Rows("decimal(18,6)"))
+}
+
+func TestUpgradeToVer224MaterializedViewHistoryDurationIndexesAndAlertTable(t *testing.T) {
+	ctx := context.Background()
+	store, dom := session.CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	seV223 := session.CreateSessionAndSetID(t, store)
+
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	require.NoError(t, m.FinishBootstrap(int64(223)))
+	require.NoError(t, txn.Commit(ctx))
+
+	revertVersionAndVariables(t, seV223, 223)
+	session.MustExec(t, seV223, "drop table if exists mysql.tidb_mview_refresh_hist, mysql.tidb_mview_refresh_alert, mysql.tidb_mlog_purge_hist")
+	session.MustExec(t, seV223, `create table mysql.tidb_mview_refresh_hist (
+		REFRESH_JOB_ID bigint unsigned NOT NULL,
+		MVIEW_ID bigint NOT NULL,
+		MV_SCHEMA varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		MV_NAME varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		REFRESH_METHOD varchar(32) NOT NULL,
+		REFRESH_TIME datetime(6) DEFAULT NULL,
+		REFRESH_ENDTIME datetime(6) DEFAULT NULL,
+		REFRESH_DURATION_SEC decimal(18,6) DEFAULT NULL,
+		REFRESH_STATUS varchar(16) DEFAULT NULL,
+		REFRESH_ROWS bigint DEFAULT NULL,
+		REFRESH_READ_TSO bigint unsigned DEFAULT NULL,
+		REFRESH_FAILED_REASON text DEFAULT NULL,
+		CANCEL_REQUESTED_AT datetime(6) DEFAULT NULL,
+		CANCEL_REQUESTED_BY varchar(512) DEFAULT NULL,
+		PRIMARY KEY(REFRESH_JOB_ID),
+		KEY idx_mview_time (MVIEW_ID, REFRESH_TIME),
+		KEY idx_mv_name_time (MV_SCHEMA, MV_NAME, REFRESH_TIME),
+		KEY idx_mview_status (MVIEW_ID, REFRESH_STATUS, REFRESH_TIME),
+		KEY idx_refresh_time (REFRESH_TIME),
+		KEY idx_refresh_status (REFRESH_STATUS, REFRESH_TIME))`)
+	session.MustExec(t, seV223, `create table mysql.tidb_mlog_purge_hist (
+		PURGE_JOB_ID bigint unsigned NOT NULL,
+		MLOG_ID bigint NOT NULL,
+		BASE_TABLE_SCHEMA varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		BASE_TABLE_NAME varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		PURGE_METHOD varchar(32) NOT NULL,
+		PURGE_TIME datetime(6) DEFAULT NULL,
+		PURGE_ENDTIME datetime(6) DEFAULT NULL,
+		PURGE_DURATION_SEC decimal(18,6) DEFAULT NULL,
+		PURGE_ROWS bigint NOT NULL,
+		PURGE_STATUS varchar(16) DEFAULT NULL,
+		PURGE_FAILED_REASON text DEFAULT NULL,
+		CANCEL_REQUESTED_AT datetime(6) DEFAULT NULL,
+		CANCEL_REQUESTED_BY varchar(512) DEFAULT NULL,
+		PRIMARY KEY(PURGE_JOB_ID),
+		KEY idx_mlog_time (MLOG_ID, PURGE_TIME),
+		KEY idx_table_name_time (BASE_TABLE_SCHEMA, BASE_TABLE_NAME, PURGE_TIME),
+		KEY idx_mlog_status (MLOG_ID, PURGE_STATUS, PURGE_TIME),
+		KEY idx_purge_time (PURGE_TIME),
+		KEY idx_purge_status (PURGE_STATUS, PURGE_TIME))`)
+	session.MustExec(t, seV223, "commit")
+
+	session.UnsetStoreBootstrapped(store.UUID())
+	ver, err := session.GetBootstrapVersion(seV223)
+	require.NoError(t, err)
+	require.Equal(t, int64(223), ver)
+
+	dom.Close()
+	domUpgraded, err := session.BootstrapSession(store)
+	require.NoError(t, err)
+	defer domUpgraded.Close()
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustQuery("select count(*) from information_schema.tables where table_schema='mysql' and table_name='tidb_mview_refresh_alert'").
+		Check(testkit.Rows("1"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and index_name='PRIMARY' order by seq_in_index").
+		Check(testkit.Rows("mview_id"))
+	tk.MustQuery("select lower(column_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' order by ordinal_position").
+		Check(testkit.Rows("mview_id", "mv_schema", "mv_name", "alert_level", "last_success_time", "updated_at"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name in ('MV_SCHEMA', 'MV_NAME') order by column_name").
+		Check(testkit.Rows("varchar(64)", "varchar(64)"))
+	tk.MustQuery("select lower(collation_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name in ('MV_SCHEMA', 'MV_NAME') order by column_name").
+		Check(testkit.Rows("utf8mb4_general_ci", "utf8mb4_general_ci"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name='ALERT_LEVEL'").
+		Check(testkit.Rows("varchar(16)"))
+	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name in ('LAST_SUCCESS_TIME', 'UPDATED_AT') order by column_name").
+		Check(testkit.Rows("6", "6"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_refresh_duration_sec' order by seq_in_index").
+		Check(testkit.Rows("refresh_duration_sec"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='idx_purge_duration_sec' order by seq_in_index").
+		Check(testkit.Rows("purge_duration_sec"))
 }
 
 func TestUpgradeToVer222MaterializedViewHistoryCancelRequestColumns(t *testing.T) {

--- a/pkg/session/bootstraptest/mview_systable_test.go
+++ b/pkg/session/bootstraptest/mview_systable_test.go
@@ -90,6 +90,8 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 		Check(testkit.Rows("6"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='CANCEL_REQUESTED_BY'").
 		Check(testkit.Rows("varchar(512)"))
+	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='LAST_HEARTBEAT_AT'").
+		Check(testkit.Rows("6"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and index_name='PRIMARY' order by seq_in_index").
 		Check(testkit.Rows("mview_id"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name in ('MV_SCHEMA', 'MV_NAME') order by column_name").
@@ -143,6 +145,8 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 	require.False(t, refreshInfoMeta.IsCommonHandle)
 	require.Len(t, refreshInfoMeta.Columns, 3)
 	require.Equal(t, "MVIEW_ID", refreshInfoMeta.Columns[0].Name.O)
+	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='LAST_HEARTBEAT_AT'").
+		Check(testkit.Rows("6"))
 }
 
 func TestUpgradeToVer221MaterializedViewSystemTables(t *testing.T) {
@@ -395,6 +399,10 @@ func TestUpgradeToVer224MaterializedViewHistoryDurationIndexesAndAlertTable(t *t
 		Check(testkit.Rows("refresh_duration_sec"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='idx_purge_duration_sec' order by seq_in_index").
 		Check(testkit.Rows("purge_duration_sec"))
+	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='LAST_HEARTBEAT_AT'").
+		Check(testkit.Rows("6"))
+	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='LAST_HEARTBEAT_AT'").
+		Check(testkit.Rows("6"))
 }
 
 func TestUpgradeToVer222MaterializedViewHistoryCancelRequestColumns(t *testing.T) {
@@ -458,4 +466,81 @@ func TestUpgradeToVer222MaterializedViewHistoryCancelRequestColumns(t *testing.T
 		Check(testkit.Rows("varchar(512)"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='CANCEL_REQUESTED_BY'").
 		Check(testkit.Rows("varchar(512)"))
+}
+
+func TestUpgradeToVer224MaterializedViewHistoryHeartbeatColumns(t *testing.T) {
+	ctx := context.Background()
+	store, dom := session.CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	seV224 := session.CreateSessionAndSetID(t, store)
+
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	require.NoError(t, m.FinishBootstrap(int64(224)))
+	require.NoError(t, txn.Commit(ctx))
+
+	revertVersionAndVariables(t, seV224, 224)
+	session.MustExec(t, seV224, "drop table if exists mysql.tidb_mview_refresh_hist, mysql.tidb_mlog_purge_hist")
+	session.MustExec(t, seV224, `create table mysql.tidb_mview_refresh_hist (
+		REFRESH_JOB_ID bigint unsigned NOT NULL,
+		MVIEW_ID bigint NOT NULL,
+		MV_SCHEMA varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		MV_NAME varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		REFRESH_METHOD varchar(32) NOT NULL,
+		REFRESH_TIME datetime(6) DEFAULT NULL,
+		REFRESH_ENDTIME datetime(6) DEFAULT NULL,
+		REFRESH_DURATION_SEC decimal(18,6) DEFAULT NULL,
+		REFRESH_STATUS varchar(16) DEFAULT NULL,
+		REFRESH_ROWS bigint DEFAULT NULL,
+		REFRESH_READ_TSO bigint unsigned DEFAULT NULL,
+		REFRESH_FAILED_REASON text DEFAULT NULL,
+		CANCEL_REQUESTED_AT datetime(6) DEFAULT NULL,
+		CANCEL_REQUESTED_BY varchar(512) DEFAULT NULL,
+		PRIMARY KEY(REFRESH_JOB_ID),
+		KEY idx_mview_time (MVIEW_ID, REFRESH_TIME),
+		KEY idx_mv_name_time (MV_SCHEMA, MV_NAME, REFRESH_TIME),
+		KEY idx_mview_status (MVIEW_ID, REFRESH_STATUS, REFRESH_TIME),
+		KEY idx_refresh_duration_sec (REFRESH_DURATION_SEC),
+		KEY idx_refresh_time (REFRESH_TIME),
+		KEY idx_refresh_status (REFRESH_STATUS, REFRESH_TIME))`)
+	session.MustExec(t, seV224, `create table mysql.tidb_mlog_purge_hist (
+		PURGE_JOB_ID bigint unsigned NOT NULL,
+		MLOG_ID bigint NOT NULL,
+		BASE_TABLE_SCHEMA varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		BASE_TABLE_NAME varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		PURGE_METHOD varchar(32) NOT NULL,
+		PURGE_TIME datetime(6) DEFAULT NULL,
+		PURGE_ENDTIME datetime(6) DEFAULT NULL,
+		PURGE_DURATION_SEC decimal(18,6) DEFAULT NULL,
+		PURGE_ROWS bigint NOT NULL,
+		PURGE_STATUS varchar(16) DEFAULT NULL,
+		PURGE_FAILED_REASON text DEFAULT NULL,
+		CANCEL_REQUESTED_AT datetime(6) DEFAULT NULL,
+		CANCEL_REQUESTED_BY varchar(512) DEFAULT NULL,
+		PRIMARY KEY(PURGE_JOB_ID),
+		KEY idx_mlog_time (MLOG_ID, PURGE_TIME),
+		KEY idx_table_name_time (BASE_TABLE_SCHEMA, BASE_TABLE_NAME, PURGE_TIME),
+		KEY idx_mlog_status (MLOG_ID, PURGE_STATUS, PURGE_TIME),
+		KEY idx_purge_duration_sec (PURGE_DURATION_SEC),
+		KEY idx_purge_time (PURGE_TIME),
+		KEY idx_purge_status (PURGE_STATUS, PURGE_TIME))`)
+	session.MustExec(t, seV224, "commit")
+
+	session.UnsetStoreBootstrapped(store.UUID())
+	ver, err := session.GetBootstrapVersion(seV224)
+	require.NoError(t, err)
+	require.Equal(t, int64(224), ver)
+
+	dom.Close()
+	domUpgraded, err := session.BootstrapSession(store)
+	require.NoError(t, err)
+	defer domUpgraded.Close()
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='LAST_HEARTBEAT_AT'").
+		Check(testkit.Rows("6"))
+	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='LAST_HEARTBEAT_AT'").
+		Check(testkit.Rows("6"))
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

This PR improves MV service observability and history table maintenance:

1. Add a system table to persist MV refresh alert state.
2. Clean orphaned MV refresh and MV log purge history rows after the corresponding MV/MV log metadata no longer exists.
3. Add bounded cleanup for MV history tables when they grow beyond 1,000,000 rows.

### What changed and how does it work?

This PR adds `mysql.tidb_mview_refresh_alert` and related bootstrap/upgrade coverage. MV refresh alert state is persisted by MV ID together with MV schema/name, alert level, last success time, and update time. DDL and MV service paths clean alert rows when an MV is no longer scheduled or no longer exists, so stale alert state does not remain after metadata changes.

It also adds periodic cleanup for orphaned rows in `mysql.tidb_mview_refresh_hist` and `mysql.tidb_mlog_purge_hist`. MV service records a heartbeat timestamp and uses it to avoid multiple TiDB nodes doing the same cleanup work concurrently. The cleanup removes history rows whose MV/MV log metadata has disappeared, preventing stale rows from polluting history queries after DROP or complete out-of-place ID changes.

Finally, MV service now enforces a fixed upper bound for history table size. When refresh or purge history exceeds 1,000,000 rows, old rows are deleted in batches to keep the tables bounded while preserving recent records.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add MV refresh alert persistence and bounded cleanup for MV refresh and MV log purge history tables.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added persistent materialized view refresh alert tracking with centralized alert-state sync and improved alert classification.
  * Added `LAST_HEARTBEAT_AT` timestamps to refresh and purge history for more reliable monitoring of “running” jobs.

* **Bug Fixes**
  * Improved cleanup during `ALTER … REFRESH` disable and drop flows: refresh alert rows are removed best-effort and failures no longer block operations.
  * Refresh schedule updates now also clear associated alert state, including out-of-place cutovers.

* **Tests/Chores**
  * Expanded and adjusted system-table, scheduling/cleanup, heartbeat, and maintenance/GC test coverage to match the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->