### PR TITLE
server: recover panic during clientConn Close function (#63992)

### DIFF
--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -96,6 +96,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessiontxn"
 	storeerr "github.com/pingcap/tidb/pkg/store/driver/error"
 	"github.com/pingcap/tidb/pkg/tablecodec"
+	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/arena"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
@@ -1048,10 +1049,13 @@ func (cc *clientConn) Run(ctx context.Context) {
 			terror.Log(err)
 			metrics.PanicCounter.WithLabelValues(metrics.LabelSession).Inc()
 		}
-		if cc.getStatus() != connStatusShutdown {
-			err := cc.Close()
-			terror.Log(err)
-		}
+		util.WithRecovery(
+			func() {
+				if cc.getStatus() != connStatusShutdown {
+					err := cc.Close()
+					terror.Log(err)
+				}
+			}, nil)
 
 		close(cc.quit)
 	}()


### PR DESCRIPTION
This is a manual cherry-pick of #63992 to `release-8.5-20250925-v8.5.3`.

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/63956

Problem Summary:

### What changed and how does it work?

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
create table t(id int);
begin;
insert into t values(1);
insert into t select * from t;
insert into t select * from t;
insert into t select * from t;
insert into t select * from t;
insert into t select * from t;
insert into t select * from t;

Another session:
tidb> show processlist;
+---------+------+-----------------+------+---------+------+----------------------------+------------------+
| Id      | User | Host            | db   | Command | Time | State                      | Info             |
+---------+------+-----------------+------+---------+------+----------------------------+------------------+
| 2097158 | root | 127.0.0.1:47748 | test | Sleep   |    5 | in transaction; autocommit | NULL             |
| 2097156 | root | 127.0.0.1:52588 | NULL | Query   |    0 | autocommit                 | show processlist |
+---------+------+-----------------+------+---------+------+----------------------------+------------------+
2 rows in set (0.00 sec)

tidb> kill query 2097158;
Query OK, 0 rows affected (0.00 sec)

And tidb not crash.
```

### Release note

```release-note
Fixed the issue where manually killing a connection executing a transaction could cause tidb crash.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling for server connection management during panic recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->