### PR TITLE
executor, session: record MV refresh commit TSO

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -6972,13 +6972,13 @@ def go_deps():
         name = "com_github_tikv_client_go_v2",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sha256 = "f3a61ebb5bf510131ada5d6db97008667d4c7fb9dd0366eacfc7c95d35c41c2d",
-        strip_prefix = "github.com/tikv/client-go/v2@v2.0.8-0.20260113054240-c88e82cf2927",
+        sha256 = "5456f3157cb6216618efc4127055b06af2b37e9ff4b41d36c86ab2b1b3b0c8a5",
+        strip_prefix = "github.com/tikv/client-go/v2@v2.0.8-0.20260427083733-3c3fc836b1c3",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260113054240-c88e82cf2927.zip",
-            "http://ats.apps.svc/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260113054240-c88e82cf2927.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260113054240-c88e82cf2927.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260113054240-c88e82cf2927.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260427083733-3c3fc836b1c3.zip",
+            "http://ats.apps.svc/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260427083733-3c3fc836b1c3.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260427083733-3c3fc836b1c3.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260427083733-3c3fc836b1c3.zip",
         ],
     )
     go_repository(

--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -116,5 +116,5 @@ func TestCheckSysTableCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(225), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(226), session.CurrentBootstrapVersion)
 }

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/tdakkota/asciicheck v0.2.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.8-0.20260113054240-c88e82cf2927
+	github.com/tikv/client-go/v2 v2.0.8-0.20260427083733-3c3fc836b1c3
 	github.com/tikv/pd/client v0.0.0-20250901062501-1646b924d286
 	github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a
 	github.com/twmb/murmur3 v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -826,8 +826,8 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJf
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW93SG+q0F8KI+yFrcIDT4c/RNoc4=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
-github.com/tikv/client-go/v2 v2.0.8-0.20260113054240-c88e82cf2927 h1:lCRKPcF7jYgovVZ2f+DYqOlS4gtVmj6O7bG4J/KXjC4=
-github.com/tikv/client-go/v2 v2.0.8-0.20260113054240-c88e82cf2927/go.mod h1:DrneTzlX66kdfl59PMdaHpeJWzyXXNClNqzhi71AvXc=
+github.com/tikv/client-go/v2 v2.0.8-0.20260427083733-3c3fc836b1c3 h1:K5efKdn6pJmV29QZBDsJgBqj4M2WcqQVLFMpwY4BJ7Y=
+github.com/tikv/client-go/v2 v2.0.8-0.20260427083733-3c3fc836b1c3/go.mod h1:DrneTzlX66kdfl59PMdaHpeJWzyXXNClNqzhi71AvXc=
 github.com/tikv/pd/client v0.0.0-20250901062501-1646b924d286 h1:TBrJ7eyjLfI6xc7rr348sTKPUa96ZUWmfSonqLP0vVM=
 github.com/tikv/pd/client v0.0.0-20250901062501-1646b924d286/go.mod h1:kuIEDRLck7LGHiqKYrQR3fNiK06trLmmK02s4r99iWU=
 github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a h1:A6uKudFIfAEpoPdaal3aSqGxBzLyU8TqyXImLwo6dIo=

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -661,7 +661,7 @@ func TestColumnTable(t *testing.T) {
 		testkit.RowsWithSep("|",
 			"test|tbl1|col_2"))
 	tk.MustQuery(`select count(*) from information_schema.columns;`).Check(
-		testkit.RowsWithSep("|", "5027"))
+		testkit.RowsWithSep("|", "5028"))
 }
 
 func TestIndexUsageTable(t *testing.T) {
@@ -708,7 +708,7 @@ func TestIndexUsageTable(t *testing.T) {
 		testkit.RowsWithSep("|",
 			"test|idt2|idx_4"))
 	tk.MustQuery(`select count(*) from information_schema.tidb_index_usage;`).Check(
-		testkit.RowsWithSep("|", "92"))
+		testkit.RowsWithSep("|", "93"))
 
 	tk.MustQuery(`select TABLE_SCHEMA, TABLE_NAME, INDEX_NAME from information_schema.tidb_index_usage
 				where TABLE_SCHEMA = 'test1';`).Check(testkit.Rows())

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -17,6 +17,7 @@ package executor
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/bits"
 	"strconv"
@@ -2436,6 +2437,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 					mviewID,
 					refreshHistStatusFailed,
 					refreshHistFailedReadTSO,
+					nil,
 					histTime(refreshStart, histLoc),
 					histTime(refreshEndAt, histLoc),
 					nil,
@@ -2495,6 +2497,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 				mviewID,
 				refreshHistStatusSuccess,
 				&buildReadTSO,
+				nil,
 				histTime(refreshStart, histLoc),
 				histTime(refreshEndAt, histLoc),
 				nil,
@@ -2629,6 +2632,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 				mviewID,
 				refreshHistStatusFailed,
 				refreshHistFailedReadTSO,
+				nil,
 				histTime(refreshStart, histLoc),
 				histTime(refreshEndAt, histLoc),
 				nil,
@@ -2770,6 +2774,13 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 	if txnCommitTimerStarted && txnTotalDur == 0 {
 		txnTotalDur = time.Since(txnCommitStart)
 	}
+	refreshCommitTSO, err := getSessionLastTxnCommitTSO(refreshSctx)
+	if err != nil {
+		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
+			errors.Annotate(err, "refresh materialized view: refresh committed but failed to capture refresh commit tso"),
+		)
+		refreshCommitTSO = nil
+	}
 	applyMVRefreshStmtResult(e.Ctx().GetSessionVars().StmtCtx, refreshStmtResult)
 
 	if err := observeMVRefreshStep(e.stepObserver, stepSet.finalizeHist, func() error {
@@ -2781,6 +2792,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 			mviewID,
 			refreshHistStatusSuccess,
 			&refreshReadTSO,
+			refreshCommitTSO,
 			histTime(refreshStart, histLoc),
 			histTime(refreshEndAt, histLoc),
 			refreshRows,
@@ -4181,6 +4193,7 @@ func finalizeRefreshHistWithRetry(
 	mviewID int64,
 	refreshStatus string,
 	refreshReadTSO *uint64,
+	refreshCommitTSO *uint64,
 	refreshStartAt time.Time,
 	refreshEndAt time.Time,
 	refreshRows *int64,
@@ -4193,6 +4206,7 @@ func finalizeRefreshHistWithRetry(
 		mviewID,
 		refreshStatus,
 		refreshReadTSO,
+		refreshCommitTSO,
 		refreshStartAt,
 		refreshEndAt,
 		refreshRows,
@@ -4208,6 +4222,7 @@ func finalizeRefreshHistWithRetry(
 		mviewID,
 		refreshStatus,
 		refreshReadTSO,
+		refreshCommitTSO,
 		refreshStartAt,
 		refreshEndAt,
 		refreshRows,
@@ -4233,6 +4248,7 @@ func finalizeRefreshHist(
 	mviewID int64,
 	refreshStatus string,
 	refreshReadTSO *uint64,
+	refreshCommitTSO *uint64,
 	refreshStartAt time.Time,
 	refreshEndAt time.Time,
 	refreshRows *int64,
@@ -4247,6 +4263,10 @@ func finalizeRefreshHist(
 	var refreshReadTSOArg any
 	if refreshReadTSO != nil {
 		refreshReadTSOArg = *refreshReadTSO
+	}
+	var refreshCommitTSOArg any
+	if refreshCommitTSO != nil {
+		refreshCommitTSOArg = *refreshCommitTSO
 	}
 	var refreshRowsArg any
 	if refreshRows != nil {
@@ -4263,6 +4283,7 @@ SET
 	REFRESH_ROWS = %?,
 	REFRESH_DURATION_SEC = %?,
 	REFRESH_READ_TSO = %?,
+	REFRESH_COMMIT_TSO = %?,
 	REFRESH_FAILED_REASON = %?
 WHERE REFRESH_JOB_ID = %?
   AND MVIEW_ID = %?`
@@ -4274,6 +4295,7 @@ WHERE REFRESH_JOB_ID = %?
 		refreshRowsArg,
 		formatDurationSecondsBetween(refreshStartAt, refreshEndAt),
 		refreshReadTSOArg,
+		refreshCommitTSOArg,
 		refreshFailedReasonArg,
 		refreshJobID,
 		mviewID,
@@ -4284,4 +4306,31 @@ WHERE REFRESH_JOB_ID = %?
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+type lastTxnCommitTSInfo struct {
+	CommitTS uint64 `json:"commit_ts"`
+	ErrMsg   string `json:"error,omitempty"`
+}
+
+func getSessionLastTxnCommitTSO(sctx sessionctx.Context) (*uint64, error) {
+	if sctx == nil || sctx.GetSessionVars() == nil {
+		return nil, errors.New("refresh materialized view: session vars are nil")
+	}
+	lastTxnInfo := sctx.GetSessionVars().LastTxnInfo
+	if len(lastTxnInfo) == 0 {
+		return nil, errors.New("refresh materialized view: last transaction info is empty")
+	}
+	var txnInfo lastTxnCommitTSInfo
+	if err := json.Unmarshal([]byte(lastTxnInfo), &txnInfo); err != nil {
+		return nil, errors.Annotate(err, "refresh materialized view: invalid last transaction info")
+	}
+	if txnInfo.CommitTS == 0 {
+		if txnInfo.ErrMsg != "" {
+			return nil, errors.Errorf("refresh materialized view: last transaction info reports error %s", txnInfo.ErrMsg)
+		}
+		return nil, errors.New("refresh materialized view: last transaction info missing commit tso")
+	}
+	commitTSO := txnInfo.CommitTS
+	return &commitTSO, nil
 }

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -424,6 +424,66 @@ func makeMaterializedViewRefreshResultStale(t *testing.T, tk *testkit.TestKit) {
 	tk.MustExec("insert into t_mv_refresh_result values (3, 30)")
 }
 
+func requireRefreshInfoSnapshotMatchesLatestSuccessHist(t *testing.T, tk *testkit.TestKit, schema, view string) {
+	t.Helper()
+
+	histRows := tk.MustQuery(fmt.Sprintf(
+		"select REFRESH_READ_TSO, REFRESH_COMMIT_TSO from mysql.tidb_mview_refresh_hist where MV_SCHEMA = '%s' and MV_NAME = '%s' and REFRESH_STATUS = 'success' order by REFRESH_JOB_ID desc limit 1",
+		schema,
+		view,
+	)).Rows()
+	require.Len(t, histRows, 1)
+	refreshReadTSO, err := strconv.ParseUint(fmt.Sprintf("%v", histRows[0][0]), 10, 64)
+	require.NoError(t, err)
+	refreshCommitTSO, err := strconv.ParseUint(fmt.Sprintf("%v", histRows[0][1]), 10, 64)
+	require.NoError(t, err)
+	require.NotZero(t, refreshReadTSO)
+	require.NotZero(t, refreshCommitTSO)
+
+	// MockTiKV tests need a GC safe point before enabling stale reads.
+	mustSetMockGCSafePoint(t, tk, time.Now().Add(-time.Hour))
+	tk.MustExec("set @@tidb_snapshot = '" + strconv.FormatUint(refreshCommitTSO, 10) + "'")
+	defer tk.MustExec("set @@tidb_snapshot = ''")
+
+	tk.MustQuery(fmt.Sprintf(
+		"select r.LAST_SUCCESS_READ_TSO from information_schema.tables t join mysql.tidb_mview_refresh_info r on t.tidb_table_id = r.MVIEW_ID where t.table_schema = '%s' and t.table_name = '%s'",
+		schema,
+		view,
+	)).Check(testkit.Rows(strconv.FormatUint(refreshReadTSO, 10)))
+}
+
+func requireRefreshInfoSnapshotMatchesHistAtCommitTSO(
+	t *testing.T,
+	tk *testkit.TestKit,
+	schema string,
+	view string,
+	refreshCommitTSO uint64,
+) {
+	t.Helper()
+
+	histRows := tk.MustQuery(fmt.Sprintf(
+		"select REFRESH_READ_TSO from mysql.tidb_mview_refresh_hist where MV_SCHEMA = '%s' and MV_NAME = '%s' and REFRESH_STATUS = 'success' and REFRESH_COMMIT_TSO = %d",
+		schema,
+		view,
+		refreshCommitTSO,
+	)).Rows()
+	require.Len(t, histRows, 1)
+	refreshReadTSO, err := strconv.ParseUint(fmt.Sprintf("%v", histRows[0][0]), 10, 64)
+	require.NoError(t, err)
+	require.NotZero(t, refreshReadTSO)
+
+	// MockTiKV tests need a GC safe point before enabling stale reads.
+	mustSetMockGCSafePoint(t, tk, time.Now().Add(-time.Hour))
+	tk.MustExec("set @@tidb_snapshot = '" + strconv.FormatUint(refreshCommitTSO, 10) + "'")
+	defer tk.MustExec("set @@tidb_snapshot = ''")
+
+	tk.MustQuery(fmt.Sprintf(
+		"select r.LAST_SUCCESS_READ_TSO from information_schema.tables t join mysql.tidb_mview_refresh_info r on t.tidb_table_id = r.MVIEW_ID where t.table_schema = '%s' and t.table_name = '%s'",
+		schema,
+		view,
+	)).Check(testkit.Rows(strconv.FormatUint(refreshReadTSO, 10)))
+}
+
 func TestMaterializedViewRefreshCompleteBasic(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
@@ -471,9 +531,9 @@ func TestMaterializedViewRefreshCompleteBasic(t *testing.T) {
 	tk.MustQuery(fmt.Sprintf(
 		"select REFRESH_STATUS, REFRESH_METHOD = 'complete delta apply manual', REFRESH_ENDTIME is not null, REFRESH_ROWS is null, "+
 			"REFRESH_DURATION_SEC = cast(timestampdiff(microsecond, REFRESH_TIME, REFRESH_ENDTIME) as decimal(18,6)) / 1000000, REFRESH_DURATION_SEC >= 0, "+
-			"REFRESH_READ_TSO > 0, REFRESH_FAILED_REASON is null from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d",
+			"REFRESH_READ_TSO > 0, REFRESH_COMMIT_TSO > REFRESH_READ_TSO, REFRESH_FAILED_REASON is null from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d",
 		mviewID,
-	)).Check(testkit.Rows("success 1 1 1 1 1 1 1"))
+	)).Check(testkit.Rows("success 1 1 1 1 1 1 1 1"))
 }
 
 func TestMaterializedViewRefreshFastStatementResult(t *testing.T) {
@@ -485,6 +545,14 @@ func TestMaterializedViewRefreshFastStatementResult(t *testing.T) {
 	requireRefreshMVStatementResult(t, tk, 1, 1, 1)
 	require.Equal(t, 3.0, readAffectedRowsMetricValue(t, "RefreshMV")-beforeRefreshMV)
 	tk.MustQuery("select * from mv_refresh_result order by a").Check(testkit.Rows("1 11 1", "3 30 1"))
+}
+
+func TestMaterializedViewRefreshFastCommitTSOSnapshotMatchesRefreshInfo(t *testing.T) {
+	tk := setupMaterializedViewRefreshStatementResultTest(t)
+	makeMaterializedViewRefreshResultStale(t, tk)
+
+	tk.MustExec("refresh materialized view mv_refresh_result fast")
+	requireRefreshInfoSnapshotMatchesLatestSuccessHist(t, tk, "test", "mv_refresh_result")
 }
 
 func TestMaterializedViewRefreshFastAsOfTimestampStatementResult(t *testing.T) {
@@ -504,6 +572,24 @@ func TestMaterializedViewRefreshFastAsOfTimestampStatementResult(t *testing.T) {
 	))
 	requireRefreshMVStatementResult(t, tk, 1, 1, 1)
 	tk.MustQuery("select * from mv_refresh_result order by a").Check(testkit.Rows("1 11 1", "3 30 1"))
+}
+
+func TestMaterializedViewRefreshFastAsOfTimestampCommitTSOSnapshotMatchesRefreshInfo(t *testing.T) {
+	tk := setupMaterializedViewRefreshStatementResultTest(t)
+	tk.MustExec("set time_zone = '+00:00'")
+	makeMaterializedViewRefreshResultStale(t, tk)
+	targetTime := time.Now().UTC().Add(50 * time.Millisecond).Truncate(time.Millisecond)
+	sleepUntilTarget := time.Until(targetTime.Add(20 * time.Millisecond))
+	if sleepUntilTarget > 0 {
+		time.Sleep(sleepUntilTarget)
+	}
+	mustSetMockGCSafePoint(t, tk, targetTime.Add(-time.Hour))
+
+	tk.MustExec(fmt.Sprintf(
+		"refresh materialized view mv_refresh_result fast as of timestamp '%s'",
+		targetTime.Format("2006-01-02 15:04:05.000"),
+	))
+	requireRefreshInfoSnapshotMatchesLatestSuccessHist(t, tk, "test", "mv_refresh_result")
 }
 
 func TestMaterializedViewRefreshFastAsOfTimestampNoOpStatementResult(t *testing.T) {
@@ -549,6 +635,14 @@ func TestMaterializedViewRefreshCompleteDeltaApplyStatementResult(t *testing.T) 
 	tk.MustQuery("select * from mv_refresh_result order by a").Check(testkit.Rows("1 11 1", "3 30 1"))
 }
 
+func TestMaterializedViewRefreshCompleteDeltaApplyCommitTSOSnapshotMatchesRefreshInfo(t *testing.T) {
+	tk := setupMaterializedViewRefreshStatementResultTest(t)
+	makeMaterializedViewRefreshResultStale(t, tk)
+
+	tk.MustExec("refresh materialized view mv_refresh_result complete delta apply")
+	requireRefreshInfoSnapshotMatchesLatestSuccessHist(t, tk, "test", "mv_refresh_result")
+}
+
 func TestMaterializedViewRefreshCompleteInPlaceStatementResult(t *testing.T) {
 	tk := setupMaterializedViewRefreshStatementResultTest(t)
 	makeMaterializedViewRefreshResultStale(t, tk)
@@ -558,6 +652,14 @@ func TestMaterializedViewRefreshCompleteInPlaceStatementResult(t *testing.T) {
 	tk.MustQuery("select * from mv_refresh_result order by a").Check(testkit.Rows("1 11 1", "3 30 1"))
 }
 
+func TestMaterializedViewRefreshCompleteInPlaceCommitTSOSnapshotMatchesRefreshInfo(t *testing.T) {
+	tk := setupMaterializedViewRefreshStatementResultTest(t)
+	makeMaterializedViewRefreshResultStale(t, tk)
+
+	tk.MustExec("refresh materialized view mv_refresh_result complete in place")
+	requireRefreshInfoSnapshotMatchesLatestSuccessHist(t, tk, "test", "mv_refresh_result")
+}
+
 func TestMaterializedViewRefreshCompleteOutOfPlaceStatementResult(t *testing.T) {
 	tk := setupMaterializedViewRefreshStatementResultTest(t)
 	makeMaterializedViewRefreshResultStale(t, tk)
@@ -565,6 +667,46 @@ func TestMaterializedViewRefreshCompleteOutOfPlaceStatementResult(t *testing.T) 
 	tk.MustExec("refresh materialized view mv_refresh_result complete out of place")
 	requireRefreshMVStatementResult(t, tk, 2, 0, 0)
 	tk.MustQuery("select * from mv_refresh_result order by a").Check(testkit.Rows("1 11 1", "3 30 1"))
+}
+
+func TestMaterializedViewRefreshCompleteOutOfPlacePreservesPreviousCommitTSOSnapshot(t *testing.T) {
+	tk := setupMaterializedViewRefreshStatementResultTest(t)
+
+	beforeCutoverMViewIDRows := tk.MustQuery(
+		"select tidb_table_id from information_schema.tables where table_schema = 'test' and table_name = 'mv_refresh_result'",
+	).Rows()
+	require.Len(t, beforeCutoverMViewIDRows, 1)
+	beforeCutoverMViewID, err := strconv.ParseInt(fmt.Sprintf("%v", beforeCutoverMViewIDRows[0][0]), 10, 64)
+	require.NoError(t, err)
+
+	makeMaterializedViewRefreshResultStale(t, tk)
+	tk.MustExec("refresh materialized view mv_refresh_result fast")
+
+	previousRefreshRows := tk.MustQuery("select REFRESH_COMMIT_TSO from mysql.tidb_mview_refresh_hist where MV_SCHEMA = 'test' and MV_NAME = 'mv_refresh_result' and REFRESH_STATUS = 'success' order by REFRESH_JOB_ID desc limit 1").Rows()
+	require.Len(t, previousRefreshRows, 1)
+	previousRefreshCommitTSO, err := strconv.ParseUint(fmt.Sprintf("%v", previousRefreshRows[0][0]), 10, 64)
+	require.NoError(t, err)
+	require.NotZero(t, previousRefreshCommitTSO)
+
+	tk.MustExec("update t_mv_refresh_result set b = 12 where a = 1")
+	tk.MustExec("insert into t_mv_refresh_result values (4, 40)")
+	tk.MustExec("refresh materialized view mv_refresh_result complete out of place")
+
+	afterCutoverMViewIDRows := tk.MustQuery(
+		"select tidb_table_id from information_schema.tables where table_schema = 'test' and table_name = 'mv_refresh_result'",
+	).Rows()
+	require.Len(t, afterCutoverMViewIDRows, 1)
+	afterCutoverMViewID, err := strconv.ParseInt(fmt.Sprintf("%v", afterCutoverMViewIDRows[0][0]), 10, 64)
+	require.NoError(t, err)
+	require.NotEqual(t, beforeCutoverMViewID, afterCutoverMViewID)
+
+	requireRefreshInfoSnapshotMatchesHistAtCommitTSO(
+		t,
+		tk,
+		"test",
+		"mv_refresh_result",
+		previousRefreshCommitTSO,
+	)
 }
 
 func TestProfileMaterializedViewRefreshStepRuntime(t *testing.T) {

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -789,6 +789,7 @@ const (
 		REFRESH_STATUS varchar(16) DEFAULT NULL,
 		REFRESH_ROWS bigint DEFAULT NULL,
 		REFRESH_READ_TSO bigint unsigned DEFAULT NULL,
+		REFRESH_COMMIT_TSO bigint unsigned DEFAULT NULL,
 		REFRESH_FAILED_REASON text DEFAULT NULL,
 		CANCEL_REQUESTED_AT datetime(6) DEFAULT NULL,
 		CANCEL_REQUESTED_BY varchar(512) DEFAULT NULL,
@@ -796,6 +797,7 @@ const (
 		PRIMARY KEY(REFRESH_JOB_ID),
 		KEY idx_mview_time (MVIEW_ID, REFRESH_TIME),
 		KEY idx_mv_name_time (MV_SCHEMA, MV_NAME, REFRESH_TIME),
+		KEY idx_mv_name_commit_tso (MV_SCHEMA, MV_NAME, REFRESH_COMMIT_TSO),
 		KEY idx_mview_status (MVIEW_ID, REFRESH_STATUS, REFRESH_TIME),
 		KEY idx_refresh_duration_sec (REFRESH_DURATION_SEC),
 		KEY idx_refresh_time (REFRESH_TIME),
@@ -1299,12 +1301,16 @@ const (
 	// Add LAST_HEARTBEAT_AT to MV refresh/purge history tables.
 	version225 = 225
 
+	// version 226
+	// Add REFRESH_COMMIT_TSO and lookup index to MV refresh history table.
+	version226 = 226
+
 	// next version should start with 239
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version225
+var currentBootstrapVersion int64 = version226
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -1485,6 +1491,7 @@ var (
 		upgradeToVer223,
 		upgradeToVer224,
 		upgradeToVer225,
+		upgradeToVer226,
 	}
 )
 
@@ -3414,6 +3421,14 @@ func upgradeToVer225(s sessiontypes.Session, ver int64) {
 	}
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mview_refresh_hist ADD COLUMN `LAST_HEARTBEAT_AT` datetime(6) DEFAULT NULL AFTER `CANCEL_REQUESTED_BY`", infoschema.ErrColumnExists)
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mlog_purge_hist ADD COLUMN `LAST_HEARTBEAT_AT` datetime(6) DEFAULT NULL AFTER `CANCEL_REQUESTED_BY`", infoschema.ErrColumnExists)
+}
+
+func upgradeToVer226(s sessiontypes.Session, ver int64) {
+	if ver >= version226 {
+		return
+	}
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mview_refresh_hist ADD COLUMN `REFRESH_COMMIT_TSO` bigint unsigned DEFAULT NULL AFTER `REFRESH_READ_TSO`", infoschema.ErrColumnExists)
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mview_refresh_hist ADD INDEX idx_mv_name_commit_tso (MV_SCHEMA, MV_NAME, REFRESH_COMMIT_TSO)", dbterror.ErrDupKeyName)
 }
 
 // initGlobalVariableIfNotExists initialize a global variable with specific val if it does not exist.

--- a/pkg/session/bootstraptest/BUILD.bazel
+++ b/pkg/session/bootstraptest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "mview_systable_test.go",
     ],
     flaky = True,
-    shard_count = 18,
+    shard_count = 19,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/session/bootstraptest/mview_systable_test.go
+++ b/pkg/session/bootstraptest/mview_systable_test.go
@@ -62,6 +62,8 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 		Check(testkit.Rows("mview_id", "refresh_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_mv_name_time' order by seq_in_index").
 		Check(testkit.Rows("mv_schema", "mv_name", "refresh_time"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_mv_name_commit_tso' order by seq_in_index").
+		Check(testkit.Rows("mv_schema", "mv_name", "refresh_commit_tso"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_mview_status' order by seq_in_index").
 		Check(testkit.Rows("mview_id", "refresh_status", "refresh_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_refresh_duration_sec' order by seq_in_index").
@@ -79,6 +81,8 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 	tk.MustQuery("select lower(collation_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name in ('MV_SCHEMA', 'MV_NAME') order by column_name").
 		Check(testkit.Rows("utf8mb4_general_ci", "utf8mb4_general_ci"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_READ_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_COMMIT_TSO'").
 		Check(testkit.Rows("bigint(20) unsigned"))
 	tk.MustQuery("select lower(column_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and ordinal_position between 2 and 8 order by ordinal_position").
 		Check(testkit.Rows("mview_id", "mv_schema", "mv_name", "refresh_method", "refresh_time", "refresh_endtime", "refresh_duration_sec"))
@@ -197,6 +201,10 @@ func TestUpgradeToVer221MaterializedViewSystemTables(t *testing.T) {
 		Check(testkit.Rows("utf8mb4_general_ci", "utf8mb4_general_ci"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_READ_TSO'").
 		Check(testkit.Rows("bigint(20) unsigned"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_COMMIT_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_mv_name_commit_tso' order by seq_in_index").
+		Check(testkit.Rows("mv_schema", "mv_name", "refresh_commit_tso"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_DURATION_SEC'").
 		Check(testkit.Rows("decimal(18,6)"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='PURGE_JOB_ID'").
@@ -286,6 +294,8 @@ func TestUpgradeToVer223MaterializedViewHistoryColumnsAndIndexes(t *testing.T) {
 		Check(testkit.Rows("mview_id", "refresh_time"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_mv_name_time' order by seq_in_index").
 		Check(testkit.Rows("mv_schema", "mv_name", "refresh_time"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_mv_name_commit_tso' order by seq_in_index").
+		Check(testkit.Rows("mv_schema", "mv_name", "refresh_commit_tso"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_refresh_duration_sec' order by seq_in_index").
 		Check(testkit.Rows("refresh_duration_sec"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_refresh_time' order by seq_in_index").
@@ -294,6 +304,8 @@ func TestUpgradeToVer223MaterializedViewHistoryColumnsAndIndexes(t *testing.T) {
 		Check(testkit.Rows("mview_id", "mv_schema", "mv_name", "refresh_method", "refresh_time", "refresh_endtime", "refresh_duration_sec"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_DURATION_SEC'").
 		Check(testkit.Rows("decimal(18,6)"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_COMMIT_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name in ('BASE_TABLE_SCHEMA', 'BASE_TABLE_NAME') order by column_name").
 		Check(testkit.Rows("varchar(64)", "varchar(64)"))
 	tk.MustQuery("select lower(collation_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name in ('BASE_TABLE_SCHEMA', 'BASE_TABLE_NAME') order by column_name").
@@ -543,4 +555,61 @@ func TestUpgradeToVer224MaterializedViewHistoryHeartbeatColumns(t *testing.T) {
 		Check(testkit.Rows("6"))
 	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='LAST_HEARTBEAT_AT'").
 		Check(testkit.Rows("6"))
+}
+
+func TestUpgradeToVer226MaterializedViewRefreshCommitTSO(t *testing.T) {
+	ctx := context.Background()
+	store, dom := session.CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	seV225 := session.CreateSessionAndSetID(t, store)
+
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	require.NoError(t, m.FinishBootstrap(int64(225)))
+	require.NoError(t, txn.Commit(ctx))
+
+	revertVersionAndVariables(t, seV225, 225)
+	session.MustExec(t, seV225, "drop table if exists mysql.tidb_mview_refresh_hist")
+	session.MustExec(t, seV225, `create table mysql.tidb_mview_refresh_hist (
+		REFRESH_JOB_ID bigint unsigned NOT NULL,
+		MVIEW_ID bigint NOT NULL,
+		MV_SCHEMA varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		MV_NAME varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		REFRESH_METHOD varchar(32) NOT NULL,
+		REFRESH_TIME datetime(6) DEFAULT NULL,
+		REFRESH_ENDTIME datetime(6) DEFAULT NULL,
+		REFRESH_DURATION_SEC decimal(18,6) DEFAULT NULL,
+		REFRESH_STATUS varchar(16) DEFAULT NULL,
+		REFRESH_ROWS bigint DEFAULT NULL,
+		REFRESH_READ_TSO bigint unsigned DEFAULT NULL,
+		REFRESH_FAILED_REASON text DEFAULT NULL,
+		CANCEL_REQUESTED_AT datetime(6) DEFAULT NULL,
+		CANCEL_REQUESTED_BY varchar(512) DEFAULT NULL,
+		LAST_HEARTBEAT_AT datetime(6) DEFAULT NULL,
+		PRIMARY KEY(REFRESH_JOB_ID),
+		KEY idx_mview_time (MVIEW_ID, REFRESH_TIME),
+		KEY idx_mv_name_time (MV_SCHEMA, MV_NAME, REFRESH_TIME),
+		KEY idx_mview_status (MVIEW_ID, REFRESH_STATUS, REFRESH_TIME),
+		KEY idx_refresh_duration_sec (REFRESH_DURATION_SEC),
+		KEY idx_refresh_time (REFRESH_TIME),
+		KEY idx_refresh_status (REFRESH_STATUS, REFRESH_TIME))`)
+	session.MustExec(t, seV225, "commit")
+
+	session.UnsetStoreBootstrapped(store.UUID())
+	ver, err := session.GetBootstrapVersion(seV225)
+	require.NoError(t, err)
+	require.Equal(t, int64(225), ver)
+
+	dom.Close()
+	domUpgraded, err := session.BootstrapSession(store)
+	require.NoError(t, err)
+	defer domUpgraded.Close()
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and column_name='REFRESH_COMMIT_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
+	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_mv_name_commit_tso' order by seq_in_index").
+		Check(testkit.Rows("mv_schema", "mv_name", "refresh_commit_tso"))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

Materialized view refresh history already records `REFRESH_READ_TSO`, but it does not record the transaction commit TSO that publishes the refresh result and the corresponding `mysql.tidb_mview_refresh_info` update.

This makes it hard to correlate one successful refresh history row with the exact snapshot where the refresh metadata became visible. The gap is especially relevant for complete out-of-place refresh, because cutover changes the physical MV table ID while older refresh history still needs to describe the state that was published by an earlier refresh transaction.

### What changed and how does it work?

This PR records the commit TSO for successful materialized view refreshes:

- Adds `REFRESH_COMMIT_TSO bigint unsigned DEFAULT NULL` to `mysql.tidb_mview_refresh_hist`.
- Adds `idx_mv_name_commit_tso (MV_SCHEMA, MV_NAME, REFRESH_COMMIT_TSO)` for looking up refresh history by MV name and commit TSO.
- Bumps the bootstrap version to add the new column and index during upgrade.
- Updates refresh history finalization to write `REFRESH_COMMIT_TSO` for successful refreshes.
- Reads the latest committed transaction info from the refresh session after the refresh transaction commits, and stores the commit TSO when available.
- Keeps failure paths with `REFRESH_COMMIT_TSO = NULL`, because no successful refresh result was published.
- Updates the MV refresh history system table bootstrap tests and upgrade tests.
- Adds snapshot regression tests to verify that the refresh-info row observed at `REFRESH_COMMIT_TSO` matches the `REFRESH_READ_TSO` recorded by the same successful refresh history row.
- Covers fast refresh, fast refresh as-of timestamp, complete delta apply, complete in-place, and complete out-of-place scenarios.
- Updates `github.com/tikv/client-go/v2` to a version that exposes commit TSO in the transaction info used by TiDB.

With this change, each successful refresh history row can identify both:

- `REFRESH_READ_TSO`: the snapshot used to read source data for the refresh.
- `REFRESH_COMMIT_TSO`: the snapshot where the refresh metadata/result was committed and became visible.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test coverage added/updated for:

- MV refresh history table bootstrap schema containing `REFRESH_COMMIT_TSO`.
- Upgrade from bootstrap version 225 to version 226 adding `REFRESH_COMMIT_TSO` and `idx_mv_name_commit_tso`.
- Successful complete refresh history recording `REFRESH_COMMIT_TSO > REFRESH_READ_TSO`.
- Fast refresh commit-TSO snapshot matching `mysql.tidb_mview_refresh_info`.
- Fast refresh as-of timestamp commit-TSO snapshot matching `mysql.tidb_mview_refresh_info`.
- Complete delta apply refresh commit-TSO snapshot matching `mysql.tidb_mview_refresh_info`.
- Complete in-place refresh commit-TSO snapshot matching `mysql.tidb_mview_refresh_info`.
- Complete out-of-place refresh preserving the previous refresh commit-TSO snapshot semantics across cutover.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Record `REFRESH_COMMIT_TSO` in materialized view refresh history for successful refreshes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Materialized view refresh operations now track commit timestamps to ensure consistent snapshots across different refresh methods (FAST, COMPLETE variants).

* **Tests**
  * Added comprehensive tests validating snapshot behavior for materialized view refresh across various refresh modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->