### PR TITLE
sem: make import external ID rule a no-op

### DIFF
--- a/pkg/util/sem/compat/sem_integration_test.go
+++ b/pkg/util/sem/compat/sem_integration_test.go
@@ -42,17 +42,17 @@ func TestRestrictedSQL(t *testing.T) {
 	tk.MustExec("GRANT ALL PRIVILEGES ON *.* TO semuser")
 	tk.MustExec("GRANT RESTRICTED_SQL_ADMIN ON *.* TO semuser")
 
-	t.Run("IMPORT INTO with external-id is not allowed", func(t *testing.T) {
+	t.Run("IMPORT INTO with external-id is not restricted by SQL rule", func(t *testing.T) {
 		tk := testkit.NewTestKit(t, store)
 
 		require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "nobodyuser", Hostname: "localhost"}, nil, nil, nil))
 		t.Cleanup(func() {
 			require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil, nil))
 		})
-		tk.MustContainErrMsg("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=abc'", "is not supported when security enhanced mode is enabled")
-
-		require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "semuser", Hostname: "localhost"}, nil, nil, nil))
 		if kerneltype.IsNextGen() {
+			tk.MustContainErrMsg("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=allowed'", "IMPORT INTO with explicit external ID")
+
+			require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "semuser", Hostname: "localhost"}, nil, nil, nil))
 			tk.MustContainErrMsg("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=allowed'", "IMPORT INTO with explicit external ID")
 			tk.MustQuery("select * from test.t").Check(testkit.Rows())
 			return
@@ -65,6 +65,8 @@ func TestRestrictedSQL(t *testing.T) {
 			require.Equal(t, "allowed", u.Query().Get(s3like.S3ExternalID))
 			panic("FAIL IT, AS WE CANNOT RUN IT HERE")
 		})
+		tk.MustExec("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=allowed'")
+		require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "semuser", Hostname: "localhost"}, nil, nil, nil))
 		tk.MustExec("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=allowed'")
 		tk.MustQuery("select * from test.t").Check(testkit.Rows())
 	})

--- a/pkg/util/sem/v2/BUILD.bazel
+++ b/pkg/util/sem/v2/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/objstore",
-        "//pkg/objstore/s3like",
         "//pkg/parser/ast",
         "//pkg/parser/mysql",
         "//pkg/sessionctx/vardef",

--- a/pkg/util/sem/v2/sql_rule.go
+++ b/pkg/util/sem/v2/sql_rule.go
@@ -84,7 +84,7 @@ var AlterTableAttributesRule SQLRule = func(stmt ast.StmtNode) bool {
 
 // ImportWithExternalIDRule SQLRule is kept for compatibility with existing SEM configs.
 // Import external ID checks are handled outside the restricted SQL rule list.
-var ImportWithExternalIDRule SQLRule = func(stmt ast.StmtNode) bool {
+var ImportWithExternalIDRule SQLRule = func(_ ast.StmtNode) bool {
 	return false
 }
 

--- a/pkg/util/sem/v2/sql_rule.go
+++ b/pkg/util/sem/v2/sql_rule.go
@@ -16,10 +16,8 @@ package sem
 
 import (
 	"net/url"
-	"strings"
 
 	"github.com/pingcap/tidb/pkg/objstore"
-	"github.com/pingcap/tidb/pkg/objstore/s3like"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 )
 
@@ -84,27 +82,9 @@ var AlterTableAttributesRule SQLRule = func(stmt ast.StmtNode) bool {
 	return false
 }
 
-// ImportWithExternalIDRule SQLRule returns true if the SQL statement is related to importing data with an external ID.
+// ImportWithExternalIDRule SQLRule is kept for compatibility with existing SEM configs.
+// Import external ID checks are handled outside the restricted SQL rule list.
 var ImportWithExternalIDRule SQLRule = func(stmt ast.StmtNode) bool {
-	switch importStmt := stmt.(type) {
-	case *ast.ImportIntoStmt:
-		u, err := url.Parse(importStmt.Path)
-		if err != nil {
-			return false
-		}
-		if objstore.IsS3Like(u) {
-			values := u.Query()
-			for k := range values {
-				lowerK := strings.ToLower(k)
-				if lowerK == s3like.S3ExternalID {
-					return true
-				}
-			}
-		}
-	default:
-		return false
-	}
-
 	return false
 }
 

--- a/pkg/util/sem/v2/sql_rule_test.go
+++ b/pkg/util/sem/v2/sql_rule_test.go
@@ -53,7 +53,7 @@ func TestSQLRules(t *testing.T) {
 		{
 			rule:     ImportWithExternalIDRule,
 			stmt:     "IMPORT INTO xxxx FROM 's3://xxx/xxx?external-id=xxx'",
-			expected: true,
+			expected: false,
 		},
 		{
 			rule:     SelectIntoFileRule,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60418, ref #61582

Problem Summary:

after https://github.com/pingcap/tidb/pull/69045, we allow user to set external-id equal to the target value, but the SEM v2 `import_with_external_id` SQL rule still rejects `IMPORT INTO` statements that contain an explicit S3 external ID. The external ID behavior should not be controlled by the restricted SQL rule list anymore; the rule name is only kept so existing SEM configs remain valid.

### What changed and how does it work?

This PR makes `ImportWithExternalIDRule` always return `false`.

The rule remains registered in SEM v2 so existing configs that include `import_with_external_id` continue to parse successfully. The actual import external ID checks remain outside the restricted SQL rule list. In next-gen mode, explicit external IDs are still rejected by the SEM-enabled import path, while classic mode no longer blocks them through this compatibility rule.

`make bazel_prepare` was run because the Go import section changed; it removed the now-unused `//pkg/objstore/s3like` dependency from `pkg/util/sem/v2/BUILD.bazel`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

with below SEM config
```json
{
  "tidb_version":"v0.0.0",
  "restricted_sql": {
    "rule": [
      "import_with_external_id"
    ]
  }
}
```
```sql
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| tidb_version()                                                                                                                                                                                                                                                                                                             |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Release Version: CLOUD.202606.0-c593c9a780
Edition: Community
Git Commit Hash: c593c9a7801c2d93d1505497e5d6dacddd7acca6
Git Branch: codex/sem-import-external-id-noop
UTC Build Time: 2026-06-15 08:11:47
GoVersion: go1.25.10
Race Enabled: false
Check Table Before Drop: false
Store: tikv
Kernel Type: Next Generation |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql> create table t(id int);
Query OK, 0 rows affected (0.07 sec)
```
now explicit external-id equals to target value is allowed
```sql
mysql> import into t from 's3://mybucket/a.csv?access-key=minioadmin&secret-access-key=minioadmin&endpoint=http%3a%2f%2f0.0.0.0%3a9000&external-id=SYSTEM';
+--------+-----------+------------------------------------------------------------------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+----------------------------+----------+-------------------------+---------------------+-----------------------+----------------+--------------+
| Job_ID | Group_Key | Data_Source                                                                                                            | Target_Table | Table_ID | Phase | Status   | Source_File_Size | Imported_Rows | Result_Message | Create_Time                | Start_Time                 | End_Time                   | Created_By | Last_Update_Time           | Cur_Step | Cur_Step_Processed_Size | Cur_Step_Total_Size | Cur_Step_Progress_Pct | Cur_Step_Speed | Cur_Step_ETA |
+--------+-----------+------------------------------------------------------------------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+----------------------------+----------+-------------------------+---------------------+-----------------------+----------------+--------------+
|      1 | NULL      | s3://mybucket/a.csv?access-key=xxxxxx&endpoint=http%3A%2F%2F0.0.0.0%3A9000&external-id=SYSTEM&secret-access-key=xxxxxx | `test`.`t`   |        7 |       | finished | 180B             |            18 |                | 2026-06-15 16:15:05.641694 | 2026-06-15 16:15:06.169008 | 2026-06-15 16:15:11.687274 | root@%     | 2026-06-15 16:15:11.687274 | NULL     | NULL                    | NULL                | NULL                  | NULL           | NULL         |
+--------+-----------+------------------------------------------------------------------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+----------------------------+----------+-------------------------+---------------------+-----------------------+----------------+--------------+
1 row in set (6.38 sec)
```
explicit external-id not equals to target value is disallowed
```sql
mysql> import into t from 's3://mybucket/a.csv?access-key=minioadmin&secret-access-key=minioadmin&endpoint=http%3a%2f%2f0.0.0.0%3a9000&external-id=SYSTEMa';
ERROR 8132 (HY000): Feature 'IMPORT INTO with explicit external ID' is not supported when security enhanced mode is enabled
```
without external-id:
```sql
mysql> import into t from 's3://mybucket/a.csv?access-key=minioadmin&secret-access-key=minioadmin&endpoint=http%3a%2f%2f0.0.0.0%3a9000';
ERROR 8173 (HY000): PreCheck failed: target table is not empty
mysql> truncate table t;
Query OK, 0 rows affected (0.06 sec)

mysql> import into t from 's3://mybucket/a.csv?access-key=minioadmin&secret-access-key=minioadmin&endpoint=http%3a%2f%2f0.0.0.0%3a9000';
+--------+-----------+------------------------------------------------------------------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+----------------------------+----------+-------------------------+---------------------+-----------------------+----------------+--------------+
| Job_ID | Group_Key | Data_Source                                                                                                            | Target_Table | Table_ID | Phase | Status   | Source_File_Size | Imported_Rows | Result_Message | Create_Time                | Start_Time                 | End_Time                   | Created_By | Last_Update_Time           | Cur_Step | Cur_Step_Processed_Size | Cur_Step_Total_Size | Cur_Step_Progress_Pct | Cur_Step_Speed | Cur_Step_ETA |
+--------+-----------+------------------------------------------------------------------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+----------------------------+----------+-------------------------+---------------------+-----------------------+----------------+--------------+
|      2 | NULL      | s3://mybucket/a.csv?access-key=xxxxxx&endpoint=http%3A%2F%2F0.0.0.0%3A9000&external-id=SYSTEM&secret-access-key=xxxxxx | `test`.`t`   |        9 |       | finished | 180B             |            18 |                | 2026-06-15 16:15:25.121115 | 2026-06-15 16:15:25.634905 | 2026-06-15 16:15:30.652145 | root@%     | 2026-06-15 16:15:30.652145 | NULL     | NULL                    | NULL                | NULL                  | NULL           | NULL         |
+--------+-----------+------------------------------------------------------------------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+----------------------------+----------+-------------------------+---------------------+-----------------------+----------------+--------------+
1 row in set (5.75 sec)
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit tests:

```bash
go test -run TestSQLRules -tags=intest,deadlock
./tools/check/failpoint-go-test.sh pkg/util/sem/compat -run TestRestrictedSQL
./tools/check/failpoint-go-test.sh pkg/util/sem/compat -run TestRestrictedSQL -tags=intest,deadlock,nextgen
```

Manual tests:

```bash
make bazel_prepare
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Updated security-enhanced mode coverage for `IMPORT INTO` privilege restrictions, adjusting expected outcomes for statements with `EXTERNAL-ID` and refining authentication/cleanup steps in the test flow.

* **Refactor**
  * Updated the SQL rule that governs `IMPORT` with `EXTERNAL-ID` to act as a compatibility stub, with external-ID checks handled through other logic.

* **Build/Config**
  * Tweaked internal module build dependencies related to the SQL rules implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->