### PR TITLE
executor: move MV log purge deletes out of pessimistic txn

### DIFF
--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -1252,12 +1252,13 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		batchSize = int64(variable.DefTiDBMLogPurgeBatchSize)
 	}
 	totalPurgeRows := int64(0)
-	safePurgeTSOReady := false
 	safePurgeTSO := uint64(0)
 	lockedLastPurgedTSO := uint64(0)
 	lockedLastPurgedTSOReady := false
 	purgeJobID := uint64(0)
 	purgeHistRunningInserted := false
+	txnStarted := false
+	txnFinished := false
 	defer func() {
 		if r := recover(); r != nil {
 			err = util.GetRecoverError(r)
@@ -1306,6 +1307,30 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 	)
 	sqlExec := purgeSctx.GetSQLExecutor()
 
+	deleteSctx, err := e.GetSysSession()
+	if err != nil {
+		return err
+	}
+	defer e.ReleaseSysSession(releaseCtx, deleteSctx)
+	deleteSessVars := deleteSctx.GetSessionVars()
+	restoreDeleteMaintenanceVars, err := applyMVMaintenanceSessionVars(
+		deleteSessVars,
+		targetMaintainMemQuota,
+		targetMaintainIsolationReadEngines,
+		isInternalSQL,
+	)
+	if err != nil {
+		return err
+	}
+	defer restoreDeleteMaintenanceVars()
+	failpoint.InjectCall("mvMaintainMemQuotaAppliedOnPurgeDeleteSession", deleteSessVars.MemQuotaQuery, targetMaintainMemQuota)
+	failpoint.InjectCall(
+		"mvMaintainIsolationReadEnginesAppliedOnPurgeDeleteSession",
+		variable.GetIsolationReadEnginesString(deleteSessVars),
+		targetMaintainIsolationReadEngines,
+	)
+	deleteSQLExec := deleteSctx.GetSQLExecutor()
+
 	histSctx, err := e.GetSysSession()
 	if err != nil {
 		return err
@@ -1326,9 +1351,20 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 	defer func() {
 		stopTaskMonitor()
 	}()
+	defer func() {
+		if !txnStarted || txnFinished {
+			return
+		}
+		_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
+		txnFinished = true
+	}()
 
 	finalizeFailure := func(purgeErr error) error {
 		purgeFailedReason, finalErr := taskCancelController.normalizeTaskFailure(purgeErr)
+		if txnStarted && !txnFinished {
+			_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
+			txnFinished = true
+		}
 		if !purgeHistRunningInserted {
 			return errors.Trace(finalErr)
 		}
@@ -1380,190 +1416,159 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		}
 	})
 
-	for {
-		var beginErr error
-		failpoint.Inject("mockPurgeMaterializedViewLogBeginErr", func(val failpoint.Value) {
-			if v, ok := val.(bool); ok && v {
-				beginErr = errors.New("mock purge begin error")
-			}
-		})
-		if beginErr != nil {
-			return finalizeFailure(beginErr)
+	var beginErr error
+	failpoint.Inject("mockPurgeMaterializedViewLogBeginErr", func(val failpoint.Value) {
+		if v, ok := val.(bool); ok && v {
+			beginErr = errors.New("mock purge begin error")
 		}
-		if _, err = sqlExec.ExecuteInternal(kctx, "BEGIN PESSIMISTIC"); err != nil {
-			return finalizeFailure(err)
+	})
+	if beginErr != nil {
+		return finalizeFailure(beginErr)
+	}
+	if _, err = sqlExec.ExecuteInternal(kctx, "BEGIN PESSIMISTIC"); err != nil {
+		return finalizeFailure(err)
+	}
+	txnStarted = true
+
+	lastPurgedTSO, hasLastPurgedTSO, err := acquireMaterializedViewLogPurgeLock(kctx, sqlExec, schemaName, s.Table.Name, mlogID)
+	if err != nil {
+		return finalizeFailure(err)
+	}
+	lockedLastPurgedTSO = lastPurgedTSO
+	lockedLastPurgedTSOReady = hasLastPurgedTSO
+
+	txn, err := purgeSctx.Txn(true)
+	if err != nil {
+		return finalizeFailure(err)
+	}
+	purgeStartTS := txn.StartTS()
+	failpoint.Inject("mockPurgeMaterializedViewLogZeroStartTS", func(val failpoint.Value) {
+		if v, ok := val.(bool); ok && v {
+			purgeStartTS = 0
 		}
+	})
+	if purgeStartTS == 0 {
+		return finalizeFailure(errors.New("purge materialized view log: invalid transaction start tso"))
+	}
+	safePurgeTSO = purgeStartTS
 
-		lastPurgedTSO, hasLastPurgedTSO, err := acquireMaterializedViewLogPurgeLock(kctx, sqlExec, schemaName, s.Table.Name, mlogID)
-		if err != nil {
-			_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
-			if isMLogPurgeLockConflict(err) && totalPurgeRows > 0 {
-				if histErr := finalizeSuccess(); histErr != nil {
-					e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
-						errors.Annotate(histErr, "purge materialized view log: purge committed but failed to finalize purge history"),
-					)
-				}
-				applyMVRefreshStmtResult(
-					e.Ctx().GetSessionVars().StmtCtx,
-					newMVRefreshStmtResultFromWriteCounts(0, 0, totalPurgeRows),
-				)
-				e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf(
-					"purge materialized view log on %s.%s stopped before deleting all eligible rows due to lock conflict after deleting %d rows; please retry later",
-					schemaName.O,
-					s.Table.Name.O,
-					totalPurgeRows,
-				))
-				return nil
-			}
-			return err
-		}
+	purgeJobID = purgeStartTS
+	if err := insertMLogPurgeHistRunning(
+		kctx,
+		histSQLExec,
+		purgeJobID,
+		mlogID,
+		schemaName.O,
+		baseTableMeta.Name.O,
+		purgeMethod,
+		histTime(purgeStart, histLoc),
+	); err != nil {
+		return finalizeFailure(err)
+	}
+	purgeHistRunningInserted = true
+	stopTaskMonitor, err = startMVTaskMonitor(
+		kctx,
+		e.GetSysSession,
+		func(sctx sessionctx.Context) {
+			e.ReleaseSysSession(releaseCtx, sctx)
+		},
+		taskCancelController,
+		fmt.Sprintf("mlog-purge-%d", purgeJobID),
+		func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) (bool, string, error) {
+			return readPurgeHistCancelRequest(watchCtx, watchSQLExec, purgeJobID, mlogID)
+		},
+		func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) error {
+			return updatePurgeHistHeartbeat(watchCtx, watchSQLExec, purgeJobID, mlogID)
+		},
+	)
+	if err != nil {
+		return finalizeFailure(err)
+	}
+	failpoint.Inject("pausePurgeMaterializedViewLogAfterInsertPurgeHistRunning", func() {})
 
-		var batchErr error
-		batchPurgeRows := int64(0)
-
-		// Calculate safe purge tso once at the first successful lock acquisition.
-		if !safePurgeTSOReady {
-			lockedLastPurgedTSO = lastPurgedTSO
-			lockedLastPurgedTSOReady = hasLastPurgedTSO
-
-			txn, err := purgeSctx.Txn(true)
-			if err != nil {
-				_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
-				return errors.Trace(err)
-			}
-			purgeStartTS := txn.StartTS()
-			failpoint.Inject("mockPurgeMaterializedViewLogZeroStartTS", func(val failpoint.Value) {
-				if v, ok := val.(bool); ok && v {
-					purgeStartTS = 0
-				}
-			})
-			if purgeStartTS == 0 {
-				_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
-				return finalizeFailure(errors.New("purge materialized view log: invalid transaction start tso"))
-			}
-			safePurgeTSO = purgeStartTS
-
-			if !purgeHistRunningInserted {
-				purgeJobID = purgeStartTS
-				if err := insertMLogPurgeHistRunning(
-					kctx,
-					histSQLExec,
-					purgeJobID,
-					mlogID,
-					schemaName.O,
-					baseTableMeta.Name.O,
-					purgeMethod,
-					histTime(purgeStart, histLoc),
-				); err != nil {
-					_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
-					return errors.Trace(err)
-				}
-				purgeHistRunningInserted = true
-				stopTaskMonitor, err = startMVTaskMonitor(
-					kctx,
-					e.GetSysSession,
-					func(sctx sessionctx.Context) {
-						e.ReleaseSysSession(releaseCtx, sctx)
-					},
-					taskCancelController,
-					fmt.Sprintf("mlog-purge-%d", purgeJobID),
-					func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) (bool, string, error) {
-						return readPurgeHistCancelRequest(watchCtx, watchSQLExec, purgeJobID, mlogID)
-					},
-					func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) error {
-						return updatePurgeHistHeartbeat(watchCtx, watchSQLExec, purgeJobID, mlogID)
-					},
-				)
-				if err != nil {
-					_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
-					return finalizeFailure(err)
-				}
-				failpoint.Inject("pausePurgeMaterializedViewLogAfterInsertPurgeHistRunning", func() {})
-			}
-
-			// Collect all dependent MV IDs (Public + in-building CREATE MATERIALIZED VIEW jobs).
-			publicMVIDs, buildingMVIDs, collectErr := collectDependentMViewIDsForMLogPurge(kctx, sqlExec, baseTableMeta, mlogID)
-			if collectErr != nil {
-				batchErr = collectErr
-			} else {
-				// If there are no dependent MVs, it is safe to purge up to the start tso of this transaction.
-				safePurgeTSO, batchErr = calcMaterializedViewLogSafePurgeTSO(
-					kctx,
-					sqlExec,
-					schemaName.O,
-					s.Table.Name.O,
-					purgeStartTS,
-					publicMVIDs,
-					buildingMVIDs,
-				)
-			}
-			safePurgeTSOReady = true
-		}
-
-		skipDeleteByCheckpoint := batchErr == nil && lockedLastPurgedTSOReady && lockedLastPurgedTSO >= safePurgeTSO
-		if batchErr == nil && !skipDeleteByCheckpoint && safePurgeTSO > 0 {
-			batchPurgeRows, batchErr = purgeMaterializedViewLogData(
+	publicMVIDs, buildingMVIDs, err := collectDependentMViewIDsForMLogPurge(kctx, sqlExec, baseTableMeta, mlogID)
+	if err != nil {
+		return finalizeFailure(err)
+	}
+	safePurgeTSO, err = calcMaterializedViewLogSafePurgeTSO(
+		kctx,
+		sqlExec,
+		schemaName.O,
+		s.Table.Name.O,
+		purgeStartTS,
+		publicMVIDs,
+		buildingMVIDs,
+	)
+	if err != nil {
+		return finalizeFailure(err)
+	}
+	skipDeleteByCheckpoint := lockedLastPurgedTSOReady && lockedLastPurgedTSO >= safePurgeTSO
+	if !skipDeleteByCheckpoint && safePurgeTSO > 0 {
+		for {
+			batchPurgeRows, batchErr := purgeMaterializedViewLogData(
 				kctx,
-				sqlExec,
-				purgeSctx.GetSessionVars(),
+				deleteSQLExec,
+				deleteSessVars,
 				schemaName.O,
 				mlogName.O,
 				safePurgeTSO,
 				batchSize,
 			)
-		}
-		if batchErr == nil && batchPurgeRows < batchSize {
-			nextTime, shouldUpdateNextTime, deriveErr := deriveRuntimeMaterializedScheduleNextTime(
-				kctx,
-				scheduleEvalSctx,
-				purgeSctx,
-				mlogInfo.PurgeStartWith,
-				mlogInfo.PurgeNext,
-				isInternalSQL,
-				mlogInfo.DefinitionSQLMode,
-				func() {
-					logRuntimeMaterializedViewLogPurgeNextTimeUpdateNull(schemaName.O, mlogName.O, mlogInfo.PurgeNext)
-				},
-			)
-			if deriveErr != nil {
-				batchErr = deriveErr
-			} else {
-				var lastPurgedTSOToPersist *uint64
-				if !skipDeleteByCheckpoint {
-					lastPurgedTSOToPersist = &safePurgeTSO
-				}
-				batchErr = updateMaterializedViewLogPurgeInfoOnSuccess(
-					kctx,
-					sqlExec,
-					mlogID,
-					lastPurgedTSOToPersist,
-					nextTime,
-					shouldUpdateNextTime,
-				)
+			totalPurgeRows += batchPurgeRows
+			failpoint.Inject("pausePurgeMaterializedViewLogAfterDeleteBatch", func() {})
+			if batchErr != nil {
+				return finalizeFailure(batchErr)
 			}
-		}
-		if batchErr != nil {
-			_, _ = sqlExec.ExecuteInternal(kctx, "ROLLBACK")
-			return finalizeFailure(batchErr)
-		}
-		if _, err = sqlExec.ExecuteInternal(kctx, "COMMIT"); err != nil {
-			return finalizeFailure(err)
-		}
-
-		totalPurgeRows += batchPurgeRows
-		if batchPurgeRows < batchSize {
-			if err := finalizeSuccess(); err != nil {
-				e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
-					errors.Annotate(err, "purge materialized view log: purge committed but failed to finalize purge history"),
-				)
+			if batchPurgeRows < batchSize {
+				break
 			}
-			applyMVRefreshStmtResult(
-				e.Ctx().GetSessionVars().StmtCtx,
-				newMVRefreshStmtResultFromWriteCounts(0, 0, totalPurgeRows),
-			)
-			return nil
 		}
 	}
+
+	nextTime, shouldUpdateNextTime, err := deriveRuntimeMaterializedScheduleNextTime(
+		kctx,
+		scheduleEvalSctx,
+		purgeSctx,
+		mlogInfo.PurgeStartWith,
+		mlogInfo.PurgeNext,
+		isInternalSQL,
+		mlogInfo.DefinitionSQLMode,
+		func() {
+			logRuntimeMaterializedViewLogPurgeNextTimeUpdateNull(schemaName.O, mlogName.O, mlogInfo.PurgeNext)
+		},
+	)
+	if err != nil {
+		return finalizeFailure(err)
+	}
+	var lastPurgedTSOToPersist *uint64
+	if !skipDeleteByCheckpoint {
+		lastPurgedTSOToPersist = &safePurgeTSO
+	}
+	if err = updateMaterializedViewLogPurgeInfoOnSuccess(
+		kctx,
+		sqlExec,
+		mlogID,
+		lastPurgedTSOToPersist,
+		nextTime,
+		shouldUpdateNextTime,
+	); err != nil {
+		return finalizeFailure(err)
+	}
+	if _, err = sqlExec.ExecuteInternal(kctx, "COMMIT"); err != nil {
+		return finalizeFailure(err)
+	}
+	txnFinished = true
+
+	if err := finalizeSuccess(); err != nil {
+		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
+			errors.Annotate(err, "purge materialized view log: purge committed but failed to finalize purge history"),
+		)
+	}
+	applyMVRefreshStmtResult(
+		e.Ctx().GetSessionVars().StmtCtx,
+		newMVRefreshStmtResultFromWriteCounts(0, 0, totalPurgeRows),
+	)
+	return nil
 }
 
 func calcMaterializedViewLogSafePurgeTSO(
@@ -1755,10 +1760,6 @@ func acquireMaterializedViewLogPurgeLock(
 	return rows[0].GetUint64(0), true, nil
 }
 
-func isMLogPurgeLockConflict(err error) bool {
-	return err != nil && errors.ErrorEqual(err, errMLogPurgeLockConflict)
-}
-
 func collectDependentMViewIDsForMLogPurge(
 	kctx context.Context,
 	sqlExec sqlexec.SQLExecutor,
@@ -1821,7 +1822,6 @@ func purgeMaterializedViewLogData(
 			failpoint.Return(int64(0), errors.New("mock purge mlog delete error"))
 		}
 	})
-
 	failpoint.Inject("mockPurgeMaterializedViewLogDeleteRows", func(val failpoint.Value) {
 		switch v := val.(type) {
 		case int:

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -1579,7 +1579,7 @@ func TestPurgeMaterializedViewLogBeginFailure(t *testing.T) {
 	err = tk.ExecToErr("purge materialized view log on t_purge_begin_fail")
 	require.ErrorContains(t, err, "mock purge begin error")
 
-	tk.MustQuery("select count(*) from `$mlog$t_purge_begin_fail`").Check(testkit.Rows("2"))
+	tk.MustQuery("select count(*) from `$mlog$t_purge_begin_fail`").Check(testkit.Rows("3"))
 	tk.MustQuery(fmt.Sprintf(
 		"select PURGE_STATUS, PURGE_ROWS, PURGE_ENDTIME is not null, PURGE_FAILED_REASON like '%%mock purge begin error%%' from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1",
 		mlogID,

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -1427,35 +1427,136 @@ func TestPurgeMaterializedViewLogFinalizeFailureUsesWithoutCancel(t *testing.T) 
 		Check(testkit.Rows("failed 1 1"))
 }
 
-func TestPurgeMaterializedViewLogLockConflictAfterPartialSuccess(t *testing.T) {
+func TestPurgeMaterializedViewLogDeleteErrorAfterPartialSuccess(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
-	tk.MustExec("create table t_purge_partial_conflict (id int primary key, v int)")
-	tk.MustExec("create materialized view log on t_purge_partial_conflict (id, v) purge next date_add(now(), interval 1 hour)")
-	tk.MustExec("insert into t_purge_partial_conflict values (1, 10), (2, 20), (3, 30)")
+	tk.MustExec("create table t_purge_partial_delete_err (id int primary key, v int)")
+	tk.MustExec("create materialized view log on t_purge_partial_delete_err (id, v) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("insert into t_purge_partial_delete_err values (1, 10), (2, 20), (3, 30)")
 
 	is := dom.InfoSchema()
-	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_partial_conflict"))
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_partial_delete_err"))
 	require.NoError(t, err)
 	mlogID := mlogTable.Meta().ID
 
 	tk.MustExec("set @@session.tidb_mlog_purge_batch_size = 1")
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockPurgeMaterializedViewLogLockConflict", "1*return(false)->return(true)"))
+	beforeNextTime := fmt.Sprint(tk.MustQuery(fmt.Sprintf("select NEXT_TIME from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).Rows()[0][0])
+	beforeLastPurgedTSO := tk.MustQuery(fmt.Sprintf("select LAST_PURGED_TSO is null from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID))
+	beforeLastPurgedTSO.Check(testkit.Rows("1"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockPurgeMaterializedViewLogDeleteErr", "1*return(false)->return(true)"))
 	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockPurgeMaterializedViewLogLockConflict"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockPurgeMaterializedViewLogDeleteErr"))
 	}()
 
-	tk.MustExec("purge materialized view log on t_purge_partial_conflict")
-	tk.MustQuery("show warnings").CheckContain("lock conflict after deleting 1 rows")
+	err = tk.ExecToErr("purge materialized view log on t_purge_partial_delete_err")
+	require.ErrorContains(t, err, "mock purge mlog delete error")
 
-	tk.MustQuery("select count(*) from `$mlog$t_purge_partial_conflict`").Check(testkit.Rows("2"))
-	tk.MustQuery(fmt.Sprintf("select PURGE_STATUS, PURGE_ROWS from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1", mlogID)).
-		Check(testkit.Rows("success 1"))
+	tk.MustQuery("select count(*) from `$mlog$t_purge_partial_delete_err`").Check(testkit.Rows("2"))
+	tk.MustQuery(fmt.Sprintf("select PURGE_STATUS, PURGE_ROWS, PURGE_FAILED_REASON like '%%mock purge mlog delete error%%' from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1", mlogID)).
+		Check(testkit.Rows("failed 1 1"))
+	tk.MustQuery(fmt.Sprintf("select LAST_PURGED_TSO is null, NEXT_TIME from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).
+		Check(testkit.Rows("1 " + beforeNextTime))
 }
 
-func TestPurgeMaterializedViewLogBeginFailureAfterPartialSuccess(t *testing.T) {
+func TestPurgeMaterializedViewLogManualCancelAfterPartialSuccess(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tkObserver := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tkObserver.MustExec("use test")
+
+	tk.MustExec("create table t_purge_partial_delete_cancel (id int primary key, v int)")
+	tk.MustExec("create materialized view log on t_purge_partial_delete_cancel (id, v) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("insert into t_purge_partial_delete_cancel values (1, 10), (2, 20), (3, 30)")
+
+	is := dom.InfoSchema()
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_partial_delete_cancel"))
+	require.NoError(t, err)
+	mlogID := mlogTable.Meta().ID
+
+	beforeNextTime := fmt.Sprint(tk.MustQuery(fmt.Sprintf("select NEXT_TIME from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).Rows()[0][0])
+	tk.MustExec("set @@session.tidb_mlog_purge_batch_size = 1")
+
+	pollIntervalFailpoint := "github.com/pingcap/tidb/pkg/executor/mockMVTaskMonitorPollInterval"
+	require.NoError(t, failpoint.Enable(pollIntervalFailpoint, "return(50)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable(pollIntervalFailpoint))
+	}()
+
+	pauseFailpoint := "github.com/pingcap/tidb/pkg/executor/pausePurgeMaterializedViewLogAfterDeleteBatch"
+	require.NoError(t, failpoint.Enable(pauseFailpoint, "pause"))
+	paused := true
+	defer func() {
+		if paused {
+			require.NoError(t, failpoint.Disable(pauseFailpoint))
+		}
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		tkPurge := testkit.NewTestKit(t, store)
+		tkPurge.MustExec("use test")
+		tkPurge.MustExec("set @@session.tidb_mlog_purge_batch_size = 1")
+		errCh <- tkPurge.ExecToErr("purge materialized view log on t_purge_partial_delete_cancel")
+	}()
+
+	require.Eventually(t, func() bool {
+		rows := tkObserver.MustQuery("select count(*) from `$mlog$t_purge_partial_delete_cancel`").Rows()
+		return fmt.Sprint(rows[0][0]) == "2"
+	}, 10*time.Second, 100*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		rows := tkObserver.MustQuery(fmt.Sprintf(
+			"select count(*) from mysql.tidb_mlog_purge_hist where MLOG_ID = %d and PURGE_STATUS = 'running'",
+			mlogID,
+		)).Rows()
+		return fmt.Sprint(rows[0][0]) == "1"
+	}, 10*time.Second, 100*time.Millisecond)
+
+	purgeJobID := fmt.Sprint(tkObserver.MustQuery(fmt.Sprintf(
+		"select PURGE_JOB_ID from mysql.tidb_mlog_purge_hist where MLOG_ID = %d and PURGE_STATUS = 'running' limit 1",
+		mlogID,
+	)).Rows()[0][0])
+	expectedMonitorName := fmt.Sprintf("mlog-purge-%s", purgeJobID)
+	cancelObservedCh := waitMVTaskCancelWatcherRequested(t, expectedMonitorName)
+
+	requester := "'partial_cancel_req'@'stage-d'"
+	tkObserver.MustExec(
+		`UPDATE mysql.tidb_mlog_purge_hist
+SET CANCEL_REQUESTED_AT = NOW(6),
+	CANCEL_REQUESTED_BY = ?
+WHERE MLOG_ID = ?
+  AND PURGE_STATUS = 'running'
+  AND CANCEL_REQUESTED_AT IS NULL`,
+		requester,
+		mlogID,
+	)
+
+	select {
+	case <-cancelObservedCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for purge task monitor to observe manual cancel request")
+	}
+
+	require.NoError(t, failpoint.Disable(pauseFailpoint))
+	paused = false
+
+	err = <-errCh
+	require.Error(t, err)
+	require.ErrorContains(t, err, "materialized view task canceled manually")
+
+	tkObserver.MustQuery("select count(*) from `$mlog$t_purge_partial_delete_cancel`").Check(testkit.Rows("2"))
+	tkObserver.MustQuery(fmt.Sprintf(
+		"select PURGE_STATUS, PURGE_ROWS, PURGE_FAILED_REASON from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1",
+		mlogID,
+	)).Check(testkit.Rows("failed 1 cancelled manually by " + requester))
+	tkObserver.MustQuery(fmt.Sprintf("select LAST_PURGED_TSO is null, NEXT_TIME from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).
+		Check(testkit.Rows("1 " + beforeNextTime))
+}
+
+func TestPurgeMaterializedViewLogBeginFailure(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -1470,7 +1571,7 @@ func TestPurgeMaterializedViewLogBeginFailureAfterPartialSuccess(t *testing.T) {
 	mlogID := mlogTable.Meta().ID
 
 	tk.MustExec("set @@session.tidb_mlog_purge_batch_size = 1")
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockPurgeMaterializedViewLogBeginErr", "1*return(false)->return(true)"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockPurgeMaterializedViewLogBeginErr", "return(true)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockPurgeMaterializedViewLogBeginErr"))
 	}()
@@ -1482,7 +1583,7 @@ func TestPurgeMaterializedViewLogBeginFailureAfterPartialSuccess(t *testing.T) {
 	tk.MustQuery(fmt.Sprintf(
 		"select PURGE_STATUS, PURGE_ROWS, PURGE_ENDTIME is not null, PURGE_FAILED_REASON like '%%mock purge begin error%%' from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1",
 		mlogID,
-	)).Check(testkit.Rows("failed 1 1 1"))
+	)).Check(testkit.Rows("failed 0 1 1"))
 }
 
 func TestPurgeMaterializedViewLogZeroStartTS(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what is changed
2. *: what is changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

Materialized view log purge currently performs batched MLOG deletes inside the same pessimistic transaction that owns the purge lock and updates purge metadata. Large deletes can keep the lock transaction open for longer than necessary. The old structure also made partial-delete failure handling harder to reason about because rows may already have been deleted while LAST_PURGED_TSO and NEXT_TIME must not be advanced unless the purge finishes normally.

### What changed and how does it work?

This PR refactors MLOG purge so that the pessimistic transaction is used for locking, safe purge TSO calculation, and metadata updates, while MLOG data deletion itself runs in a separate internal delete session with independent auto-commit statements.

The main behavior is:

- Acquire the MLOG purge lock once with `BEGIN PESSIMISTIC` and `SELECT ... FOR UPDATE NOWAIT`.
- Calculate the safe purge TSO once after the lock is held.
- Insert the running purge history row and start the task monitor before deleting data.
- Execute each MLOG delete batch through a separate internal delete session, outside the pessimistic lock transaction.
- If all delete batches finish normally, update LAST_PURGED_TSO and NEXT_TIME in the pessimistic transaction, commit it, and finalize purge history as success.
- If a delete batch, manual cancel, context cancel, or later metadata step fails after some rows have already been deleted, finalize purge history as failed with the actual PURGE_ROWS, and do not update LAST_PURGED_TSO or NEXT_TIME.
- Use a finalize context for rollback/finalization cleanup so cancellation does not prevent explicit cleanup after `BEGIN PESSIMISTIC`.
- Apply MV maintenance session variables to both the purge metadata session and the delete session.

The test changes cover partial-delete errors, manual cancel after partial success, begin failure, zero start tso, purge history finalization, and rollback/finalization behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Move materialized view log purge data deletion out of the pessimistic metadata transaction and keep partial-delete failures recorded as failed purge history with actual purged rows.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction rollback/commit safety during materialized view log purging, including clearer failure handling after partial progress.
  * Enhanced purge failure reporting to preserve remaining rows and record accurate purge history details when a delete step fails.
  * Updated purge scheduling behavior so timing metadata remains consistent after partial errors or cancellation.

* **New Features**
  * Added support for manually canceling in-progress purge operations, with correct cancellation failure tracking and preserved purge state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->