### PR TITLE
executor, mvservice: throttle materialized view log purge

### DIFF
--- a/pkg/domain/domain_sysvars.go
+++ b/pkg/domain/domain_sysvars.go
@@ -44,6 +44,8 @@ func (do *Domain) initDomainSysVars() {
 	variable.SetLowResolutionTSOUpdateInterval = do.setLowResolutionTSOUpdateInterval
 	setMVServiceTaskMaxConcurrencyFunc := do.setMVServiceTaskMaxConcurrency
 	variable.SetMVServiceTaskMaxConcurrency.Store(&setMVServiceTaskMaxConcurrencyFunc)
+	setMVServiceRefreshTaskConcurrencyRatioFunc := do.setMVServiceRefreshTaskConcurrencyRatio
+	variable.SetMVServiceRefreshTaskConcurrencyRatio.Store(&setMVServiceRefreshTaskConcurrencyRatioFunc)
 	setMVServiceTaskThresholdCPUFunc := do.setMVServiceTaskThresholdCPU
 	variable.SetMVServiceTaskThresholdCPU.Store(&setMVServiceTaskThresholdCPUFunc)
 	setMVServiceTaskThresholdMemoryFunc := do.setMVServiceTaskThresholdMemory
@@ -132,6 +134,13 @@ func (do *Domain) setMVServiceTaskMaxConcurrency(maxConcurrency int) {
 		return
 	}
 	do.mvService.SetTaskMaxConcurrency(maxConcurrency)
+}
+
+func (do *Domain) setMVServiceRefreshTaskConcurrencyRatio(ratio float64) {
+	if do.GetMVService() == nil {
+		return
+	}
+	do.mvService.SetRefreshTaskConcurrencyRatio(ratio)
 }
 
 func (do *Domain) setMVServiceTaskThresholdCPU(threshold float64) {

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -155,6 +155,7 @@ go_library(
         "//pkg/meta/autoid",
         "//pkg/meta/model",
         "//pkg/metrics",
+        "//pkg/mvservice",
         "//pkg/parser",
         "//pkg/parser/ast",
         "//pkg/parser/auth",

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/bits"
 	"strconv"
 	"strings"
@@ -36,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/mvservice"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
@@ -92,6 +94,11 @@ const (
 	mvTaskMonitorPollInterval       = 5 * time.Second
 	mvTaskHistHeartbeatInterval     = 10 * time.Minute
 	mvTaskMonitorSQLTimeout         = 5 * time.Second
+	mlogPurgeAdaptiveCountTimeout   = 30 * time.Second
+	mlogPurgeAdaptiveBatchWindow    = 200 * time.Millisecond
+	mlogPurgeAdaptiveMinBatchSize   = int64(2000)
+	mlogPurgeAdaptiveDeadlineBuffer = 10 * time.Second
+	mlogPurgeAdaptiveMaxBudget      = mvservice.DefaultMVPurgeTaskTimeout - mlogPurgeAdaptiveDeadlineBuffer
 )
 
 // PurgeMaterializedViewLogExec executes "PURGE MATERIALIZED VIEW LOG" as a utility-style statement.
@@ -121,6 +128,20 @@ type mvTaskCancelController struct {
 	mu        sync.Mutex
 	reason    mvTaskCancelReason
 	requester string
+}
+
+type mlogPurgeThrottleConfig struct {
+	minRate     float64
+	budgetRatio float64
+}
+
+type mlogPurgeThrottlePlan struct {
+	targetRate         float64
+	pendingRows        int64
+	effectiveBatchSize int64
+	minRate            float64
+	deadline           time.Time
+	noWaitStreak       int
 }
 
 func newMVTaskCancelController(parent context.Context) *mvTaskCancelController {
@@ -172,6 +193,16 @@ func (c *mvTaskCancelController) normalizeTaskFailure(taskErr error) (*string, e
 
 	failedReason := formatMVManualCancelFailureReason(requester)
 	return &failedReason, errMVTaskCanceledManually
+}
+
+func (c *mvTaskCancelController) isManualCancelRequested() bool {
+	if c == nil {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.reason == mvTaskCancelReasonManual
 }
 
 func formatMVManualCancelFailureReason(requester string) string {
@@ -1255,10 +1286,14 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 	safePurgeTSO := uint64(0)
 	lockedLastPurgedTSO := uint64(0)
 	lockedLastPurgedTSOReady := false
+	var lockedNextTime *time.Time
 	purgeJobID := uint64(0)
 	purgeHistRunningInserted := false
 	txnStarted := false
 	txnFinished := false
+	var throttlePlan *mlogPurgeThrottlePlan
+	effectiveBatchSize := batchSize
+	var deleteLoopStart time.Time
 	defer func() {
 		if r := recover(); r != nil {
 			err = util.GetRecoverError(r)
@@ -1331,6 +1366,23 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 	)
 	deleteSQLExec := deleteSctx.GetSQLExecutor()
 
+	countSctx, err := e.GetSysSession()
+	if err != nil {
+		return err
+	}
+	defer e.ReleaseSysSession(releaseCtx, countSctx)
+	countSessVars := countSctx.GetSessionVars()
+	restoreCountMaintenanceVars, err := applyMVMaintenanceSessionVars(
+		countSessVars,
+		targetMaintainMemQuota,
+		targetMaintainIsolationReadEngines,
+		isInternalSQL,
+	)
+	if err != nil {
+		return err
+	}
+	defer restoreCountMaintenanceVars()
+	countSQLExec := countSctx.GetSQLExecutor()
 	histSctx, err := e.GetSysSession()
 	if err != nil {
 		return err
@@ -1430,12 +1482,13 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 	}
 	txnStarted = true
 
-	lastPurgedTSO, hasLastPurgedTSO, err := acquireMaterializedViewLogPurgeLock(kctx, sqlExec, schemaName, s.Table.Name, mlogID)
+	lastPurgedTSO, hasLastPurgedTSO, nextTimeLocked, err := acquireMaterializedViewLogPurgeLock(kctx, sqlExec, schemaName, s.Table.Name, mlogID)
 	if err != nil {
 		return finalizeFailure(err)
 	}
 	lockedLastPurgedTSO = lastPurgedTSO
 	lockedLastPurgedTSOReady = hasLastPurgedTSO
+	lockedNextTime = nextTimeLocked
 
 	txn, err := purgeSctx.Txn(true)
 	if err != nil {
@@ -1451,7 +1504,6 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		return finalizeFailure(errors.New("purge materialized view log: invalid transaction start tso"))
 	}
 	safePurgeTSO = purgeStartTS
-
 	purgeJobID = purgeStartTS
 	if err := insertMLogPurgeHistRunning(
 		kctx,
@@ -1504,6 +1556,26 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 	}
 	skipDeleteByCheckpoint := lockedLastPurgedTSOReady && lockedLastPurgedTSO >= safePurgeTSO
 	if !skipDeleteByCheckpoint && safePurgeTSO > 0 {
+		throttlePlan = tryBuildMLogPurgeThrottlePlanBestEffort(
+			kctx,
+			e.Ctx().GetSessionVars(),
+			scheduleEvalSctx,
+			purgeSctx,
+			countSQLExec,
+			countSessVars,
+			mlogInfo,
+			isInternalSQL,
+			schemaName.O,
+			mlogName.O,
+			lockedLastPurgedTSO,
+			lockedLastPurgedTSOReady,
+			safePurgeTSO,
+			lockedNextTime,
+		)
+		if throttlePlan != nil {
+			effectiveBatchSize = throttlePlan.effectiveDeleteBatchSize(batchSize)
+		}
+		deleteLoopStart = time.Now()
 		for {
 			batchPurgeRows, batchErr := purgeMaterializedViewLogData(
 				kctx,
@@ -1511,16 +1583,38 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 				deleteSessVars,
 				schemaName.O,
 				mlogName.O,
+				lockedLastPurgedTSO,
+				lockedLastPurgedTSOReady,
 				safePurgeTSO,
-				batchSize,
+				effectiveBatchSize,
 			)
 			totalPurgeRows += batchPurgeRows
 			failpoint.Inject("pausePurgeMaterializedViewLogAfterDeleteBatch", func() {})
 			if batchErr != nil {
+				_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
+				txnFinished = true
 				return finalizeFailure(batchErr)
 			}
-			if batchPurgeRows < batchSize {
+			if batchPurgeRows < effectiveBatchSize {
 				break
+			}
+			if throttlePlan != nil {
+				if sleepErr := throttlePlan.maybeSleep(kctx, deleteLoopStart, totalPurgeRows); sleepErr != nil {
+					if taskCancelController.isManualCancelRequested() {
+						return finalizeFailure(sleepErr)
+					}
+					logutil.BgLogger().Warn(
+						"purge materialized view log: adaptive throttle sleep failed, fallback to unthrottled purge",
+						zap.String("schemaName", schemaName.O),
+						zap.String("tableName", mlogName.O),
+						zap.Uint64("safePurgeTSO", safePurgeTSO),
+						zap.Error(sleepErr),
+					)
+					throttlePlan = nil
+					effectiveBatchSize = batchSize
+				} else {
+					effectiveBatchSize = throttlePlan.effectiveDeleteBatchSize(batchSize)
+				}
 			}
 		}
 	}
@@ -1718,7 +1812,7 @@ func acquireMaterializedViewLogPurgeLock(
 	schemaName pmodel.CIStr,
 	baseTableName pmodel.CIStr,
 	mlogID int64,
-) (lastPurgedTSO uint64, hasLastPurgedTSO bool, _ error) {
+) (lastPurgedTSO uint64, hasLastPurgedTSO bool, nextTime *time.Time, _ error) {
 	forceConflict := false
 	failpoint.Inject("mockPurgeMaterializedViewLogLockConflict", func(val failpoint.Value) {
 		if v, ok := val.(bool); ok && v {
@@ -1726,7 +1820,7 @@ func acquireMaterializedViewLogPurgeLock(
 		}
 	})
 	if forceConflict {
-		return 0, false, errors.Annotatef(
+		return 0, false, nil, errors.Annotatef(
 			errMLogPurgeLockConflict,
 			"another purge is running for materialized view log on %s.%s, please retry later",
 			schemaName.O,
@@ -1735,11 +1829,11 @@ func acquireMaterializedViewLogPurgeLock(
 	}
 
 	// Acquire the mutual exclusion lock row for this MLOG_ID. NOWAIT ensures we fail fast if another purge is running.
-	lockSQL := sqlescape.MustEscapeSQL("SELECT LAST_PURGED_TSO FROM mysql.tidb_mlog_purge_info WHERE MLOG_ID = %? FOR UPDATE NOWAIT", mlogID)
+	lockSQL := sqlescape.MustEscapeSQL("SELECT LAST_PURGED_TSO, NEXT_TIME FROM mysql.tidb_mlog_purge_info WHERE MLOG_ID = %? FOR UPDATE NOWAIT", mlogID)
 	rows, err := sqlexec.ExecSQL(kctx, sqlExec, lockSQL)
 	if err != nil {
 		if storeerr.ErrLockAcquireFailAndNoWaitSet.Equal(err) {
-			return 0, false, errors.Annotatef(
+			return 0, false, nil, errors.Annotatef(
 				errMLogPurgeLockConflict,
 				"another purge is running for materialized view log on %s.%s, please retry later",
 				schemaName.O,
@@ -1747,17 +1841,24 @@ func acquireMaterializedViewLogPurgeLock(
 			)
 		}
 		if infoschema.ErrTableNotExists.Equal(err) {
-			return 0, false, errors.New("required system table mysql.tidb_mlog_purge_info does not exist")
+			return 0, false, nil, errors.New("required system table mysql.tidb_mlog_purge_info does not exist")
 		}
-		return 0, false, errors.Trace(err)
+		return 0, false, nil, errors.Trace(err)
 	}
 	if len(rows) == 0 {
-		return 0, false, errors.Errorf("mlog purge lock row does not exist for mlog id %d", mlogID)
+		return 0, false, nil, errors.Errorf("mlog purge lock row does not exist for mlog id %d", mlogID)
+	}
+	if !rows[0].IsNull(1) {
+		lockedNextTime, convErr := rows[0].GetTime(1).GoTime(time.UTC)
+		if convErr != nil {
+			return 0, false, nil, errors.Trace(convErr)
+		}
+		nextTime = &lockedNextTime
 	}
 	if rows[0].IsNull(0) {
-		return 0, false, nil
+		return 0, false, nextTime, nil
 	}
-	return rows[0].GetUint64(0), true, nil
+	return rows[0].GetUint64(0), true, nextTime, nil
 }
 
 func collectDependentMViewIDsForMLogPurge(
@@ -1814,6 +1915,8 @@ func purgeMaterializedViewLogData(
 	sessVars *variable.SessionVars,
 	schemaName string,
 	mlogName string,
+	lastPurgedTSO uint64,
+	hasLastPurgedTSO bool,
 	safePurgeTSO uint64,
 	batchSize int64,
 ) (int64, error) {
@@ -1831,15 +1934,29 @@ func purgeMaterializedViewLogData(
 		}
 	})
 
-	deleteSQL := sqlescape.MustEscapeSQL(
-		"DELETE /*+ read_from_storage(tiflash[%n.%n]) */ FROM %n.%n WHERE _tidb_commit_ts <= %? LIMIT %?",
-		schemaName,
-		mlogName,
-		schemaName,
-		mlogName,
-		safePurgeTSO,
-		batchSize,
-	)
+	var deleteSQL string
+	if hasLastPurgedTSO {
+		deleteSQL = sqlescape.MustEscapeSQL(
+			"DELETE /*+ read_from_storage(tiflash[%n.%n]) */ FROM %n.%n WHERE _tidb_commit_ts > %? AND _tidb_commit_ts <= %? LIMIT %?",
+			schemaName,
+			mlogName,
+			schemaName,
+			mlogName,
+			lastPurgedTSO,
+			safePurgeTSO,
+			batchSize,
+		)
+	} else {
+		deleteSQL = sqlescape.MustEscapeSQL(
+			"DELETE /*+ read_from_storage(tiflash[%n.%n]) */ FROM %n.%n WHERE _tidb_commit_ts <= %? LIMIT %?",
+			schemaName,
+			mlogName,
+			schemaName,
+			mlogName,
+			safePurgeTSO,
+			batchSize,
+		)
+	}
 	origInMaterializedViewMaintenance := sessVars.InMaterializedViewMaintenance
 	sessVars.InMaterializedViewMaintenance = true
 	defer func() {
@@ -1851,6 +1968,404 @@ func purgeMaterializedViewLogData(
 		return 0, errors.Trace(err)
 	}
 	return int64(sessVars.StmtCtx.AffectedRows()), nil
+}
+
+func loadMLogPurgeThrottleConfig(
+	kctx context.Context,
+	sessVars *variable.SessionVars,
+) (mlogPurgeThrottleConfig, error) {
+	if sessVars == nil {
+		return mlogPurgeThrottleConfig{}, errors.New("purge materialized view log: session vars is nil")
+	}
+	minRateStr, err := sessVars.GetSessionOrGlobalSystemVar(kctx, variable.TiDBMLogPurgeMinRate)
+	if err != nil {
+		return mlogPurgeThrottleConfig{}, errors.Trace(err)
+	}
+	minRate, err := strconv.ParseFloat(minRateStr, 64)
+	if err != nil {
+		return mlogPurgeThrottleConfig{}, errors.Trace(err)
+	}
+	budgetRatioStr, err := sessVars.GetSessionOrGlobalSystemVar(kctx, variable.TiDBMLogPurgeRateBudgetRatio)
+	if err != nil {
+		return mlogPurgeThrottleConfig{}, errors.Trace(err)
+	}
+	budgetRatio, err := strconv.ParseFloat(budgetRatioStr, 64)
+	if err != nil {
+		return mlogPurgeThrottleConfig{}, errors.Trace(err)
+	}
+	return mlogPurgeThrottleConfig{
+		minRate:     minRate,
+		budgetRatio: budgetRatio,
+	}, nil
+}
+
+func deriveMLogPurgeThrottleDeadline(
+	kctx context.Context,
+	evalSctx sessionctx.Context,
+	templateSctx sessionctx.Context,
+	mlogInfo *model.MaterializedViewLogInfo,
+	isInternalSQL bool,
+	schemaName string,
+	mlogName string,
+	fallbackNextTime *time.Time,
+) (*time.Time, error) {
+	failpoint.Inject("mockMLogPurgeAdaptiveDeadlineErr", func(val failpoint.Value) {
+		if v, ok := val.(bool); ok && v {
+			failpoint.Return(nil, errors.New("mock adaptive purge deadline error"))
+		}
+	})
+	var adaptiveDeadline *time.Time
+	now := time.Now().UTC()
+	if mlogPurgeAdaptiveMaxBudget > 0 {
+		plannedDeadline := now.Add(mlogPurgeAdaptiveMaxBudget)
+		adaptiveDeadline = &plannedDeadline
+	}
+	if isInternalSQL {
+		nextTime, shouldUpdateNextTime, err := deriveRuntimeMaterializedScheduleNextTime(
+			kctx,
+			evalSctx,
+			templateSctx,
+			mlogInfo.PurgeStartWith,
+			mlogInfo.PurgeNext,
+			true,
+			mlogInfo.DefinitionSQLMode,
+			func() {
+				logRuntimeMaterializedViewLogPurgeNextTimeUpdateNull(schemaName, mlogName, mlogInfo.PurgeNext)
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		if shouldUpdateNextTime && nextTime != nil {
+			parsedNextTime, parseErr := time.ParseInLocation(types.TimeFSPFormat, *nextTime, time.UTC)
+			if parseErr != nil {
+				return nil, errors.Trace(parseErr)
+			}
+			if adaptiveDeadline == nil || parsedNextTime.Before(*adaptiveDeadline) {
+				return &parsedNextTime, nil
+			}
+			return adaptiveDeadline, nil
+		}
+		return adaptiveDeadline, nil
+	}
+	if fallbackNextTime == nil {
+		return adaptiveDeadline, nil
+	}
+	if adaptiveDeadline == nil || fallbackNextTime.Before(*adaptiveDeadline) {
+		return fallbackNextTime, nil
+	}
+	return adaptiveDeadline, nil
+}
+
+func tryBuildMLogPurgeThrottlePlan(
+	kctx context.Context,
+	sqlExec sqlexec.SQLExecutor,
+	sessVars *variable.SessionVars,
+	schemaName string,
+	mlogName string,
+	lastPurgedTSO uint64,
+	hasLastPurgedTSO bool,
+	safePurgeTSO uint64,
+	nextTime *time.Time,
+	cfg mlogPurgeThrottleConfig,
+) *mlogPurgeThrottlePlan {
+	if safePurgeTSO == 0 || nextTime == nil {
+		return nil
+	}
+	now := time.Now().UTC()
+	if !nextTime.After(now) {
+		return nil
+	}
+	budget := time.Duration(float64(nextTime.Sub(now)) * cfg.budgetRatio)
+	if budget <= 0 {
+		return nil
+	}
+	pendingRows, err := countMLogPurgePendingRowsOnTiFlash(
+		kctx,
+		sqlExec,
+		sessVars,
+		schemaName,
+		mlogName,
+		lastPurgedTSO,
+		hasLastPurgedTSO,
+		safePurgeTSO,
+	)
+	if err != nil {
+		logutil.BgLogger().Warn(
+			"purge materialized view log: failed to build adaptive throttle plan, fallback to unthrottled purge",
+			zap.String("schemaName", schemaName),
+			zap.String("tableName", mlogName),
+			zap.Uint64("safePurgeTSO", safePurgeTSO),
+			zap.Error(err),
+		)
+		return nil
+	}
+	if pendingRows <= 0 {
+		return nil
+	}
+	targetRate := float64(pendingRows) / budget.Seconds()
+	if targetRate < cfg.minRate {
+		targetRate = cfg.minRate
+	}
+	effectiveBatchSize := calcMLogPurgeAdaptiveBatchSize(targetRate)
+	if effectiveBatchSize <= 0 {
+		effectiveBatchSize = mlogPurgeAdaptiveMinBatchSize
+	}
+	return &mlogPurgeThrottlePlan{
+		targetRate:         targetRate,
+		pendingRows:        pendingRows,
+		effectiveBatchSize: effectiveBatchSize,
+		minRate:            cfg.minRate,
+		deadline:           *nextTime,
+	}
+}
+
+func tryBuildMLogPurgeThrottlePlanBestEffort(
+	kctx context.Context,
+	sessVars *variable.SessionVars,
+	evalSctx sessionctx.Context,
+	templateSctx sessionctx.Context,
+	sqlExec sqlexec.SQLExecutor,
+	countSessVars *variable.SessionVars,
+	mlogInfo *model.MaterializedViewLogInfo,
+	isInternalSQL bool,
+	schemaName string,
+	mlogName string,
+	lastPurgedTSO uint64,
+	hasLastPurgedTSO bool,
+	safePurgeTSO uint64,
+	fallbackNextTime *time.Time,
+) *mlogPurgeThrottlePlan {
+	throttleCfg, err := loadMLogPurgeThrottleConfig(kctx, sessVars)
+	if err != nil {
+		logutil.BgLogger().Warn(
+			"purge materialized view log: failed to load adaptive throttle config, fallback to unthrottled purge",
+			zap.String("schemaName", schemaName),
+			zap.String("tableName", mlogName),
+			zap.Uint64("safePurgeTSO", safePurgeTSO),
+			zap.Error(err),
+		)
+		return nil
+	}
+	throttleDeadline, err := deriveMLogPurgeThrottleDeadline(
+		kctx,
+		evalSctx,
+		templateSctx,
+		mlogInfo,
+		isInternalSQL,
+		schemaName,
+		mlogName,
+		fallbackNextTime,
+	)
+	if err != nil {
+		logutil.BgLogger().Warn(
+			"purge materialized view log: failed to derive adaptive throttle deadline, fallback to unthrottled purge",
+			zap.String("schemaName", schemaName),
+			zap.String("tableName", mlogName),
+			zap.Uint64("safePurgeTSO", safePurgeTSO),
+			zap.Error(err),
+		)
+		return nil
+	}
+	return tryBuildMLogPurgeThrottlePlan(
+		kctx,
+		sqlExec,
+		countSessVars,
+		schemaName,
+		mlogName,
+		lastPurgedTSO,
+		hasLastPurgedTSO,
+		safePurgeTSO,
+		throttleDeadline,
+		throttleCfg,
+	)
+}
+
+func calcMLogPurgeAdaptiveBatchSize(targetRate float64) int64 {
+	if targetRate <= 0 {
+		return mlogPurgeAdaptiveMinBatchSize
+	}
+	effectiveBatchSize := int64(math.Ceil(targetRate * mlogPurgeAdaptiveBatchWindow.Seconds()))
+	if effectiveBatchSize < mlogPurgeAdaptiveMinBatchSize {
+		return mlogPurgeAdaptiveMinBatchSize
+	}
+	return effectiveBatchSize
+}
+
+func countMLogPurgePendingRowsOnTiFlash(
+	kctx context.Context,
+	sqlExec sqlexec.SQLExecutor,
+	sessVars *variable.SessionVars,
+	schemaName string,
+	mlogName string,
+	lastPurgedTSO uint64,
+	hasLastPurgedTSO bool,
+	safePurgeTSO uint64,
+) (int64, error) {
+	failpoint.Inject("mockMLogPurgeAdaptiveCountErr", func(val failpoint.Value) {
+		if v, ok := val.(bool); ok && v {
+			failpoint.Return(int64(0), errors.New("mock adaptive purge count error"))
+		}
+	})
+	if sessVars == nil {
+		return 0, errors.New("purge materialized view log: count session vars is nil")
+	}
+	restoreIsolation, err := setSessionVarWithRestore(sessVars, variable.TiDBIsolationReadEngines, kv.TiFlash.Name())
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	defer restoreIsolation()
+	restoreFallback, err := setSessionVarWithRestore(sessVars, variable.TiDBAllowFallbackToTiKV, "")
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	defer restoreFallback()
+	origInMaterializedViewMaintenance := sessVars.InMaterializedViewMaintenance
+	sessVars.InMaterializedViewMaintenance = true
+	defer func() {
+		sessVars.InMaterializedViewMaintenance = origInMaterializedViewMaintenance
+	}()
+
+	countCtx, cancel := context.WithTimeout(kctx, mlogPurgeAdaptiveCountTimeout)
+	defer cancel()
+
+	var countSQL string
+	if hasLastPurgedTSO {
+		countSQL = sqlescape.MustEscapeSQL(
+			"SELECT /*+ read_from_storage(tiflash[%n.%n]) */ COUNT(*) FROM %n.%n WHERE _tidb_commit_ts > %? AND _tidb_commit_ts <= %?",
+			schemaName,
+			mlogName,
+			schemaName,
+			mlogName,
+			lastPurgedTSO,
+			safePurgeTSO,
+		)
+	} else {
+		countSQL = sqlescape.MustEscapeSQL(
+			"SELECT /*+ read_from_storage(tiflash[%n.%n]) */ COUNT(*) FROM %n.%n WHERE _tidb_commit_ts <= %?",
+			schemaName,
+			mlogName,
+			schemaName,
+			mlogName,
+			safePurgeTSO,
+		)
+	}
+	rows, err := sqlexec.ExecSQL(countCtx, sqlExec, countSQL)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	if len(rows) == 0 || rows[0].IsNull(0) {
+		return 0, nil
+	}
+	return rows[0].GetInt64(0), nil
+}
+
+func setSessionVarWithRestore(
+	sessVars *variable.SessionVars,
+	varName string,
+	value string,
+) (func(), error) {
+	origin, err := sessVars.GetSessionOrGlobalSystemVar(context.Background(), varName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if origin == value {
+		return func() {}, nil
+	}
+	if err := sessVars.SetSystemVar(varName, value); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return func() {
+		if restoreErr := sessVars.SetSystemVar(varName, origin); restoreErr != nil {
+			logutil.BgLogger().Warn(
+				"purge materialized view log: failed to restore session variable after adaptive throttling",
+				zap.String("var", varName),
+				zap.String("origin", origin),
+				zap.String("current", value),
+				zap.Error(restoreErr),
+			)
+		}
+	}, nil
+}
+
+func (p *mlogPurgeThrottlePlan) maybeSleep(
+	kctx context.Context,
+	start time.Time,
+	totalDeletedRows int64,
+) error {
+	failpoint.Inject("mockMLogPurgeAdaptiveSleepErr", func(val failpoint.Value) {
+		if v, ok := val.(bool); ok && v {
+			failpoint.Return(errors.New("mock adaptive purge sleep error"))
+		}
+	})
+	if p == nil || p.targetRate <= 0 || totalDeletedRows <= 0 {
+		return nil
+	}
+	expectedElapsed := time.Duration(float64(totalDeletedRows) / p.targetRate * float64(time.Second))
+	actualElapsed := time.Since(start)
+	sleepFor := expectedElapsed - actualElapsed
+	failpoint.InjectCall("mvPurgeAdaptiveThrottleSleepComputed", totalDeletedRows, sleepFor)
+	if sleepFor <= 0 {
+		p.noWaitStreak++
+		return p.recalculateBatchSizeOnNoWait(totalDeletedRows)
+	}
+	p.noWaitStreak = 0
+	timer := time.NewTimer(sleepFor)
+	defer timer.Stop()
+	select {
+	case <-kctx.Done():
+		return errors.Trace(kctx.Err())
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (p *mlogPurgeThrottlePlan) recalculateBatchSizeOnNoWait(totalDeletedRows int64) error {
+	if p == nil {
+		return nil
+	}
+	if p.noWaitStreak < 2 {
+		return nil
+	}
+	if p.pendingRows <= 0 || p.deadline.IsZero() {
+		return nil
+	}
+	remainingRows := p.pendingRows - totalDeletedRows
+	if remainingRows <= 0 {
+		return nil
+	}
+	remainingBudget := time.Until(p.deadline)
+	if remainingBudget <= 0 {
+		return nil
+	}
+	newTargetRate := float64(remainingRows) / remainingBudget.Seconds()
+	if newTargetRate < p.minRate {
+		newTargetRate = p.minRate
+	}
+	newBatchSize := calcMLogPurgeAdaptiveBatchSize(newTargetRate)
+	if newBatchSize <= 0 {
+		newBatchSize = mlogPurgeAdaptiveMinBatchSize
+	}
+	p.targetRate = newTargetRate
+	p.effectiveBatchSize = newBatchSize
+	p.noWaitStreak = 0
+	return nil
+}
+
+func (p *mlogPurgeThrottlePlan) effectiveDeleteBatchSize(configuredBatchSize int64) int64 {
+	if p == nil || configuredBatchSize <= 0 {
+		return configuredBatchSize
+	}
+	effectiveBatchSize := p.effectiveBatchSize
+	if effectiveBatchSize <= 0 {
+		effectiveBatchSize = calcMLogPurgeAdaptiveBatchSize(p.targetRate)
+	}
+	if effectiveBatchSize > configuredBatchSize {
+		effectiveBatchSize = configuredBatchSize
+	}
+	p.effectiveBatchSize = effectiveBatchSize
+	failpoint.InjectCall("mvPurgeAdaptiveBatchSizeComputed", configuredBatchSize, effectiveBatchSize)
+	return effectiveBatchSize
 }
 
 func updateMaterializedViewLogPurgeInfoOnSuccess(

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -1613,6 +1613,73 @@ func TestPurgeMaterializedViewLogZeroStartTS(t *testing.T) {
 		Check(testkit.Rows("1"))
 }
 
+func TestPurgeMaterializedViewLogAdaptiveThrottleFallbackOnCountFailure(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_purge_adaptive_count_fail (id int primary key, v int)")
+	tk.MustExec("create materialized view log on t_purge_adaptive_count_fail (id, v) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("insert into t_purge_adaptive_count_fail values (1, 10), (2, 20), (3, 30)")
+	tk.MustExec("set @@session.tidb_mlog_purge_min_rate = 1")
+	tk.MustExec("set @@session.tidb_mlog_purge_rate_budget_ratio = 0.5")
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockMLogPurgeAdaptiveCountErr", "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockMLogPurgeAdaptiveCountErr"))
+	}()
+
+	tk.MustExec("purge materialized view log on t_purge_adaptive_count_fail")
+	require.Equal(t, uint64(3), tk.Session().AffectedRows())
+	tk.CheckLastMessage("Rows inserted: 0  Updated: 0  Deleted: 3")
+	tk.MustQuery("select count(*) from `$mlog$t_purge_adaptive_count_fail`").Check(testkit.Rows("0"))
+}
+
+func TestPurgeMaterializedViewLogAdaptiveThrottleFallbackOnDeadlineFailure(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_purge_adaptive_deadline_fail (id int primary key, v int)")
+	tk.MustExec("create materialized view log on t_purge_adaptive_deadline_fail (id, v) purge start with now() next date_add(now(), interval 1 hour)")
+	tk.MustExec("insert into t_purge_adaptive_deadline_fail values (1, 10), (2, 20), (3, 30)")
+	tk.MustExec("set @@session.tidb_mlog_purge_min_rate = 1")
+	tk.MustExec("set @@session.tidb_mlog_purge_rate_budget_ratio = 0.5")
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockMLogPurgeAdaptiveDeadlineErr", "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockMLogPurgeAdaptiveDeadlineErr"))
+	}()
+
+	tk.MustExec("purge materialized view log on t_purge_adaptive_deadline_fail")
+	require.Equal(t, uint64(3), tk.Session().AffectedRows())
+	tk.CheckLastMessage("Rows inserted: 0  Updated: 0  Deleted: 3")
+	tk.MustQuery("select count(*) from `$mlog$t_purge_adaptive_deadline_fail`").Check(testkit.Rows("0"))
+}
+
+func TestPurgeMaterializedViewLogAdaptiveThrottleFallbackOnSleepFailure(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_purge_adaptive_sleep_fail (id int primary key, v int)")
+	tk.MustExec("create materialized view log on t_purge_adaptive_sleep_fail (id, v) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("insert into t_purge_adaptive_sleep_fail values (1, 10), (2, 20), (3, 30)")
+	tk.MustExec("set @@session.tidb_mlog_purge_min_rate = 1")
+	tk.MustExec("set @@session.tidb_mlog_purge_rate_budget_ratio = 0.5")
+	tk.MustExec("set @@session.tidb_mlog_purge_batch_size = 1")
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockMLogPurgeAdaptiveSleepErr", "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockMLogPurgeAdaptiveSleepErr"))
+	}()
+
+	tk.MustExec("purge materialized view log on t_purge_adaptive_sleep_fail")
+	require.Equal(t, uint64(3), tk.Session().AffectedRows())
+	tk.CheckLastMessage("Rows inserted: 0  Updated: 0  Deleted: 3")
+	tk.MustQuery("select count(*) from `$mlog$t_purge_adaptive_sleep_fail`").Check(testkit.Rows("0"))
+}
+
 func TestPurgeMaterializedViewLogMissingPublicMViewRefreshRow(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/utils_test.go
+++ b/pkg/executor/utils_test.go
@@ -17,6 +17,7 @@ package executor
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/domain"
@@ -231,4 +232,78 @@ func TestUpdateMaterializedViewLogPurgeInfoOnSuccessMonotonicCheckpoint(t *testi
 
 	require.Contains(t, exec.calls[1].sql, "NEXT_TIME = %?")
 	require.Equal(t, []any{"2026-03-08 00:00:00", int64(123)}, exec.calls[1].args)
+}
+
+func TestMLogPurgeAdaptiveBatchSizeComputed(t *testing.T) {
+	plan := &mlogPurgeThrottlePlan{targetRate: 2000}
+	batch := plan.effectiveDeleteBatchSize(10000)
+	require.Equal(t, int64(2000), batch)
+
+	plan = &mlogPurgeThrottlePlan{targetRate: 100000}
+	batch = plan.effectiveDeleteBatchSize(10000)
+	require.Equal(t, int64(10000), batch)
+}
+
+func TestMLogPurgeAdaptiveBatchSizeReplannedAfterNoWait(t *testing.T) {
+	plan := &mlogPurgeThrottlePlan{
+		targetRate:         50000,
+		pendingRows:        100000,
+		effectiveBatchSize: 10000,
+		minRate:            1,
+		deadline:           time.Now().Add(30 * time.Second),
+		noWaitStreak:       1,
+	}
+
+	err := plan.maybeSleep(context.Background(), time.Now().Add(-3*time.Second), 98000)
+	require.NoError(t, err)
+	require.Equal(t, int64(2000), plan.effectiveBatchSize)
+	require.Zero(t, plan.noWaitStreak)
+	require.Less(t, plan.targetRate, float64(50000))
+}
+
+func TestMVTaskCancelControllerIsManualCancelRequested(t *testing.T) {
+	controller := newMVTaskCancelController(context.Background())
+	require.False(t, controller.isManualCancelRequested())
+
+	controller.requestManualCancelByRequester("'u'@'h'")
+	require.True(t, controller.isManualCancelRequested())
+}
+
+func TestDeriveMLogPurgeThrottleDeadline(t *testing.T) {
+	t.Run("respect hardcoded purge planning budget", func(t *testing.T) {
+		baseNow := time.Now().UTC()
+
+		deadline, err := deriveMLogPurgeThrottleDeadline(
+			context.Background(),
+			nil,
+			nil,
+			nil,
+			false,
+			"test",
+			"t",
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, deadline)
+		require.WithinDuration(t, baseNow.Add(mlogPurgeAdaptiveMaxBudget), *deadline, 2*time.Second)
+	})
+
+	t.Run("pick earlier between next time and hardcoded purge planning budget", func(t *testing.T) {
+		baseNow := time.Now().UTC()
+		nextTime := baseNow.Add(90 * time.Second)
+
+		deadline, err := deriveMLogPurgeThrottleDeadline(
+			context.Background(),
+			nil,
+			nil,
+			nil,
+			false,
+			"test",
+			"t",
+			&nextTime,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, deadline)
+		require.WithinDuration(t, nextTime, *deadline, time.Second)
+	})
 }

--- a/pkg/mvservice/metrics_reporter.go
+++ b/pkg/mvservice/metrics_reporter.go
@@ -32,16 +32,17 @@ func reportCounterDelta(counter interface{ Add(float64) }, last *int64, current 
 // reportMetrics flushes MVService runtime metrics into the metrics module.
 func (h *serviceHelper) reportMetrics(s *MVService) {
 	// Executor metrics
-	reportCounterDelta(tidbmetrics.MVTaskExecutorSubmittedCounter, &h.reportCache.submittedCount, s.executor.metrics.counters.submittedCount.Load())
-	reportCounterDelta(tidbmetrics.MVTaskExecutorFinishedCounter, &h.reportCache.finishedCount, s.executor.metrics.counters.finishedCount.Load())
-	reportCounterDelta(tidbmetrics.MVTaskExecutorFailedCounter, &h.reportCache.failedCount, s.executor.metrics.counters.failedCount.Load())
-	reportCounterDelta(tidbmetrics.MVTaskExecutorTimeoutCounter, &h.reportCache.timeoutCount, s.executor.metrics.counters.timeoutCount.Load())
-	reportCounterDelta(tidbmetrics.MVTaskExecutorRejectedCounter, &h.reportCache.rejectedCount, s.executor.metrics.counters.rejectedCount.Load())
-	reportCounterDelta(tidbmetrics.MVTaskExecutorBackpressureCounter, &h.reportCache.backpressureCount, s.executor.metrics.counters.backpressureCount.Load())
-	tidbmetrics.MVTaskExecutorRunningTaskGauge.Set(float64(s.executor.metrics.gauges.runningCount.Load()))
-	tidbmetrics.MVTaskExecutorWaitingTaskGauge.Set(float64(s.executor.metrics.gauges.waitingCount.Load()))
-	tidbmetrics.MVTaskExecutorTimedOutRunningTaskGauge.Set(float64(s.executor.metrics.gauges.timedOutRunningCount.Load()))
-	tidbmetrics.MVTaskExecutorBackpressureBlockedGauge.Set(float64(s.executor.metrics.gauges.backpressureBlocked.Load()))
+	executorMetrics := s.combinedTaskExecutorMetrics()
+	reportCounterDelta(tidbmetrics.MVTaskExecutorSubmittedCounter, &h.reportCache.submittedCount, executorMetrics.submittedCount)
+	reportCounterDelta(tidbmetrics.MVTaskExecutorFinishedCounter, &h.reportCache.finishedCount, executorMetrics.finishedCount)
+	reportCounterDelta(tidbmetrics.MVTaskExecutorFailedCounter, &h.reportCache.failedCount, executorMetrics.failedCount)
+	reportCounterDelta(tidbmetrics.MVTaskExecutorTimeoutCounter, &h.reportCache.timeoutCount, executorMetrics.timeoutCount)
+	reportCounterDelta(tidbmetrics.MVTaskExecutorRejectedCounter, &h.reportCache.rejectedCount, executorMetrics.rejectedCount)
+	reportCounterDelta(tidbmetrics.MVTaskExecutorBackpressureCounter, &h.reportCache.backpressureCount, executorMetrics.backpressureCount)
+	tidbmetrics.MVTaskExecutorRunningTaskGauge.Set(float64(executorMetrics.runningCount))
+	tidbmetrics.MVTaskExecutorWaitingTaskGauge.Set(float64(executorMetrics.waitingCount))
+	tidbmetrics.MVTaskExecutorTimedOutRunningTaskGauge.Set(float64(executorMetrics.timedOutRunningCount))
+	tidbmetrics.MVTaskExecutorBackpressureBlockedGauge.Set(float64(executorMetrics.backpressureBlocked))
 
 	// MVService metrics
 	tidbmetrics.MVServiceMVRefreshTotalGauge.Set(float64(s.metrics.mvCount.Load()))

--- a/pkg/mvservice/mvservice_test.go
+++ b/pkg/mvservice/mvservice_test.go
@@ -412,7 +412,9 @@ func TestNewMVServiceConfig(t *testing.T) {
 	t.Run("applied", func(t *testing.T) {
 		cfg := DefaultMVServiceConfig()
 		cfg.TaskMaxConcurrency = 3
-		cfg.TaskTimeout = 42 * time.Second
+		cfg.RefreshTaskConcurrencyRatio = 0.6
+		cfg.RefreshTaskTimeout = 42 * time.Second
+		cfg.PurgeTaskTimeout = 84 * time.Second
 		cfg.FetchInterval = 37 * time.Second
 		cfg.BasicInterval = 2 * time.Second
 		cfg.ServerRefreshInterval = 9 * time.Second
@@ -428,8 +430,12 @@ func TestNewMVServiceConfig(t *testing.T) {
 		}
 
 		svc := NewMVService(context.Background(), mockSessionPool{}, &mockMVServiceHelper{}, cfg)
-		require.Equal(t, cfg.TaskMaxConcurrency, int(svc.executor.maxConcurrency.Load()))
-		require.Equal(t, cfg.TaskTimeout, time.Duration(svc.executor.timeoutNanos.Load()))
+		refreshConcurrency, purgeConcurrency := splitTaskConcurrency(cfg.TaskMaxConcurrency, cfg.RefreshTaskConcurrencyRatio)
+		require.Equal(t, refreshConcurrency, int(svc.refreshExecutor.maxConcurrency.Load()))
+		require.Equal(t, purgeConcurrency, int(svc.purgeExecutor.maxConcurrency.Load()))
+		require.Equal(t, cfg.RefreshTaskConcurrencyRatio, svc.GetRefreshTaskConcurrencyRatio())
+		require.Equal(t, cfg.RefreshTaskTimeout, time.Duration(svc.refreshExecutor.timeoutNanos.Load()))
+		require.Equal(t, cfg.PurgeTaskTimeout, time.Duration(svc.purgeExecutor.timeoutNanos.Load()))
 
 		baseDelay, maxDelay := svc.retryDelayConfig()
 		require.Equal(t, cfg.RetryBaseDelay, baseDelay)
@@ -443,7 +449,8 @@ func TestNewMVServiceConfig(t *testing.T) {
 
 		backpressureCfg := svc.GetTaskBackpressureConfig()
 		require.Equal(t, cfg.TaskBackpressure, backpressureCfg)
-		require.NotNil(t, svc.executor.backpressure.Load())
+		require.NotNil(t, svc.refreshExecutor.backpressure.Load())
+		require.NotNil(t, svc.purgeExecutor.backpressure.Load())
 
 		require.Equal(t, cfg.FetchInterval, svc.fetchInterval())
 		require.Equal(t, cfg.BasicInterval, svc.basicInterval)
@@ -470,7 +477,9 @@ func TestNewMVServiceConfig(t *testing.T) {
 
 		backpressureCfg := svc.GetTaskBackpressureConfig()
 		require.Equal(t, cfg.TaskBackpressure, backpressureCfg)
-		require.Nil(t, svc.executor.backpressure.Load())
+		require.Equal(t, defaultMVRefreshTaskConcurrencyRatio, svc.GetRefreshTaskConcurrencyRatio())
+		require.Nil(t, svc.refreshExecutor.backpressure.Load())
+		require.Nil(t, svc.purgeExecutor.backpressure.Load())
 	})
 
 	t.Run("invalid_retry_panics", func(t *testing.T) {
@@ -523,12 +532,14 @@ func TestMVServiceUpdateConfigs(t *testing.T) {
 		require.Equal(t, 0.7, cfg.CPUThreshold)
 		require.Equal(t, 0.8, cfg.MemThreshold)
 		require.Equal(t, time.Second, cfg.Delay)
-		require.NotNil(t, svc.executor.backpressure.Load())
+		require.NotNil(t, svc.refreshExecutor.backpressure.Load())
+		require.NotNil(t, svc.purgeExecutor.backpressure.Load())
 
 		err = svc.SetTaskBackpressureConfig(TaskBackpressureConfig{})
 		require.NoError(t, err)
 		require.Equal(t, TaskBackpressureConfig{}, svc.GetTaskBackpressureConfig())
-		require.Nil(t, svc.executor.backpressure.Load())
+		require.Nil(t, svc.refreshExecutor.backpressure.Load())
+		require.Nil(t, svc.purgeExecutor.backpressure.Load())
 
 		err = svc.SetTaskBackpressureConfig(TaskBackpressureConfig{
 			CPUThreshold: -1,
@@ -557,6 +568,23 @@ func TestMVServiceUpdateConfigs(t *testing.T) {
 		require.Error(t, err)
 		err = svc.setRetryDelayConfig(10*time.Second, 2*time.Second)
 		require.Error(t, err)
+	})
+
+	t.Run("task_concurrency_split", func(t *testing.T) {
+		svc := NewMVService(context.Background(), mockSessionPool{}, &mockMVServiceHelper{}, DefaultMVServiceConfig())
+
+		svc.SetTaskMaxConcurrency(10)
+		svc.SetRefreshTaskConcurrencyRatio(0.6)
+		require.Equal(t, 6, int(svc.refreshExecutor.maxConcurrency.Load()))
+		require.Equal(t, 4, int(svc.purgeExecutor.maxConcurrency.Load()))
+
+		svc.SetRefreshTaskConcurrencyRatio(0.9)
+		require.Equal(t, 9, int(svc.refreshExecutor.maxConcurrency.Load()))
+		require.Equal(t, 1, int(svc.purgeExecutor.maxConcurrency.Load()))
+
+		svc.SetTaskMaxConcurrency(2)
+		require.Equal(t, 1, int(svc.refreshExecutor.maxConcurrency.Load()))
+		require.Equal(t, 1, int(svc.purgeExecutor.maxConcurrency.Load()))
 	})
 
 	t.Run("history_gc", func(t *testing.T) {
@@ -626,7 +654,7 @@ func TestMVServiceUpdateConfigs(t *testing.T) {
 
 func TestMVServiceCollectRefreshAlertTasksByAlertLevel(t *testing.T) {
 	svc := NewMVService(context.Background(), mockSessionPool{}, &mockMVServiceHelper{}, DefaultMVServiceConfig())
-	defer svc.executor.Close()
+	defer svc.closeTaskExecutors()
 
 	now := mvsNow()
 
@@ -684,7 +712,7 @@ func TestMVServiceCollectRefreshAlertTasksByAlertLevel(t *testing.T) {
 
 func TestMVServiceRefreshAlertScanInterval(t *testing.T) {
 	svc := NewMVService(context.Background(), mockSessionPool{}, &mockMVServiceHelper{}, DefaultMVServiceConfig())
-	defer svc.executor.Close()
+	defer svc.closeTaskExecutors()
 
 	now := mvsNow()
 
@@ -777,7 +805,7 @@ func TestMVServiceCollectRefreshAlertTasksDedupByLastSuccessReadTSO(t *testing.T
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			svc := NewMVService(context.Background(), mockSessionPool{}, &mockMVServiceHelper{}, DefaultMVServiceConfig())
-			defer svc.executor.Close()
+			defer svc.closeTaskExecutors()
 
 			task := tc.task
 			task.orderTs = task.nextRefresh.UnixMilli()
@@ -810,7 +838,7 @@ func TestMVServiceCollectRefreshAlertTasksDedupByLastSuccessReadTSO(t *testing.T
 
 func TestMVServiceMaybeLogRefreshAlertTasksSyncsAlertStates(t *testing.T) {
 	svc := NewMVService(context.Background(), mockSessionPool{}, &mockMVServiceHelper{}, DefaultMVServiceConfig())
-	defer svc.executor.Close()
+	defer svc.closeTaskExecutors()
 	setRefreshAlertCleanupOwnerForTest(svc, 10)
 
 	now := mvsNow()
@@ -892,7 +920,7 @@ func TestMVServiceMaybeLogRefreshAlertTasksSyncsAlertStates(t *testing.T) {
 func TestMVServiceMaybeLogRefreshAlertTasksCleansUpStaleRowsWithoutLocalPendingTasks(t *testing.T) {
 	helper := &mockMVServiceHelper{}
 	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
-	defer svc.executor.Close()
+	defer svc.closeTaskExecutors()
 	setRefreshAlertCleanupOwnerForTest(svc, 10)
 
 	now := mvsNow()
@@ -912,7 +940,7 @@ func TestMVServiceMaybeLogRefreshAlertTasksCleansUpStaleRowsWithoutLocalPendingT
 func TestMVServiceBuildMVRefreshTasksDoesNotClearRemovedAlertStates(t *testing.T) {
 	helper := &mockMVServiceHelper{}
 	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
-	defer svc.executor.Close()
+	defer svc.closeTaskExecutors()
 
 	now := mvsNow()
 	m := &mv{
@@ -931,7 +959,7 @@ func TestMVServiceBuildMVRefreshTasksDoesNotClearRemovedAlertStates(t *testing.T
 func TestMVServiceMaybeLogRefreshAlertTasksResyncsWhenLastSuccessReadTSOChanges(t *testing.T) {
 	helper := &mockMVServiceHelper{}
 	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
-	defer svc.executor.Close()
+	defer svc.closeTaskExecutors()
 
 	now := mvsNow()
 	task := &mv{
@@ -969,7 +997,7 @@ func TestMVServiceMaybeLogRefreshAlertTasksResyncsWhenLastSuccessReadTSOChanges(
 func TestMVServiceMaybeLogRefreshAlertTasksSkipsUnresolvedMetadata(t *testing.T) {
 	helper := &mockMVServiceHelper{}
 	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
-	defer svc.executor.Close()
+	defer svc.closeTaskExecutors()
 	setRefreshAlertCleanupOwnerForTest(svc, 10)
 
 	now := mvsNow()
@@ -1001,7 +1029,7 @@ func TestMVServiceMaybeLogRefreshAlertTasksSkipsUnresolvedMetadata(t *testing.T)
 func TestMVServiceBuildMVRefreshTasksDoesNotDeleteAlertsOnTemporaryMetadataMiss(t *testing.T) {
 	helper := &mockMVServiceHelper{}
 	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
-	defer svc.executor.Close()
+	defer svc.closeTaskExecutors()
 	setRefreshAlertCleanupOwnerForTest(svc, 10)
 
 	now := mvsNow()
@@ -1045,7 +1073,7 @@ func TestMVServiceBuildMVRefreshTasksDoesNotDeleteAlertsOnTemporaryMetadataMiss(
 func TestMVServiceMaybeLogRefreshAlertTasksSkipsCleanupWhenNotOwner(t *testing.T) {
 	helper := &mockMVServiceHelper{}
 	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
-	defer svc.executor.Close()
+	defer svc.closeTaskExecutors()
 	setRefreshAlertCleanupOwnerForTest(svc, 20)
 
 	now := mvsNow()
@@ -1349,9 +1377,9 @@ func TestMVServiceFullChainSimulation(t *testing.T) {
 		h.waitRefreshTask(1001)
 
 		require.Eventually(t, func() bool {
-			return h.svc.executor.metrics.counters.finishedCount.Load() == 2
+			return h.svc.combinedTaskExecutorMetrics().finishedCount == 2
 		}, testEventuallyWait, testEventuallyTick)
-		assertTaskExecutorMetrics(t, h.svc.executor, 2, 2, 0, 0, 0, 0, 0, 0)
+		assertCombinedTaskExecutorMetrics(t, h.svc, 2, 2, 0, 0, 0, 0, 0, 0)
 		require.Equal(t, 1, h.helper.taskDurationCount(mvTaskDurationTypeRefresh, mvDurationResultSuccess))
 		require.Equal(t, 1, h.helper.taskDurationCount(mvTaskDurationTypePurge, mvDurationResultSuccess))
 	})
@@ -1361,9 +1389,10 @@ func TestMVServiceFullChainSimulation(t *testing.T) {
 		h.helper.refreshErr = errors.New("refresh failed")
 		h.helper.purgeErr = errors.New("purge failed")
 
-		finishedBase := h.svc.executor.metrics.counters.finishedCount.Load()
-		failedBase := h.svc.executor.metrics.counters.failedCount.Load()
-		submittedBase := h.svc.executor.metrics.counters.submittedCount.Load()
+		baseMetrics := h.svc.combinedTaskExecutorMetrics()
+		finishedBase := baseMetrics.finishedCount
+		failedBase := baseMetrics.failedCount
+		submittedBase := baseMetrics.submittedCount
 		baseLogCalls, baseViewCalls := h.fetchCallCounts()
 
 		now := mvsNow()
@@ -1377,9 +1406,10 @@ func TestMVServiceFullChainSimulation(t *testing.T) {
 		h.waitPurgeTask(2002)
 		h.waitRefreshTask(1002)
 		require.Eventually(t, func() bool {
-			return h.svc.executor.metrics.counters.finishedCount.Load() >= finishedBase+2 &&
-				h.svc.executor.metrics.counters.failedCount.Load() >= failedBase+2 &&
-				h.svc.executor.metrics.counters.submittedCount.Load() >= submittedBase+2
+			metrics := h.svc.combinedTaskExecutorMetrics()
+			return metrics.finishedCount >= finishedBase+2 &&
+				metrics.failedCount >= failedBase+2 &&
+				metrics.submittedCount >= submittedBase+2
 		}, testEventuallyWait, testEventuallyTick)
 
 		h.helper.refreshErr = nil
@@ -1390,9 +1420,10 @@ func TestMVServiceFullChainSimulation(t *testing.T) {
 		h.waitPurgeTask(2002)
 		h.waitRefreshTask(1002)
 		require.Eventually(t, func() bool {
-			return h.svc.executor.metrics.counters.finishedCount.Load() >= finishedBase+4 &&
-				h.svc.executor.metrics.counters.failedCount.Load() >= failedBase+2 &&
-				h.svc.executor.metrics.counters.submittedCount.Load() >= submittedBase+4
+			metrics := h.svc.combinedTaskExecutorMetrics()
+			return metrics.finishedCount >= finishedBase+4 &&
+				metrics.failedCount >= failedBase+2 &&
+				metrics.submittedCount >= submittedBase+4
 		}, testEventuallyWait, testEventuallyTick)
 
 		require.Equal(t, 2, h.helper.taskDurationCount(mvTaskDurationTypeRefresh, mvDurationResultSuccess))
@@ -1469,6 +1500,24 @@ func assertTaskExecutorMetrics(
 	require.Equal(t, running, exec.metrics.gauges.runningCount.Load())
 	require.Equal(t, waiting, exec.metrics.gauges.waitingCount.Load())
 	require.Equal(t, timedOutRunning, exec.metrics.gauges.timedOutRunningCount.Load())
+}
+
+func assertCombinedTaskExecutorMetrics(
+	t *testing.T,
+	svc *MVService,
+	submitted, finished, failed, timeout, rejected int64,
+	running, waiting, timedOutRunning int64,
+) {
+	t.Helper()
+	metrics := svc.combinedTaskExecutorMetrics()
+	require.Equal(t, submitted, metrics.submittedCount)
+	require.Equal(t, finished, metrics.finishedCount)
+	require.Equal(t, failed, metrics.failedCount)
+	require.Equal(t, timeout, metrics.timeoutCount)
+	require.Equal(t, rejected, metrics.rejectedCount)
+	require.Equal(t, running, metrics.runningCount)
+	require.Equal(t, waiting, metrics.waitingCount)
+	require.Equal(t, timedOutRunning, metrics.timedOutRunningCount)
 }
 
 func waitForStart(t *testing.T, ch <-chan string, timeout time.Duration) string {

--- a/pkg/mvservice/service.go
+++ b/pkg/mvservice/service.go
@@ -55,9 +55,11 @@ type MVService struct {
 
 	nextRefreshAlertScanMillis atomic.Int64
 
-	executor *TaskExecutor
-	notifier Notifier
-	ddlDirty atomic.Bool
+	refreshExecutor                 *TaskExecutor
+	purgeExecutor                   *TaskExecutor
+	refreshTaskConcurrencyRatioBits atomic.Uint64
+	notifier                        Notifier
+	ddlDirty                        atomic.Bool
 
 	mh Helper
 
@@ -96,19 +98,23 @@ type MVService struct {
 	}
 }
 
+// DefaultMVRefreshTaskTimeout and DefaultMVPurgeTaskTimeout define the default
+// per-task timeout budget for MV refresh and MV log purge.
 const (
-	defaultMVTaskTimeout         = 5 * time.Minute
-	defaultMVFetchInterval       = 30 * time.Second
-	defaultMVBasicInterval       = time.Second
-	defaultServerRefreshInterval = 5 * time.Second
-	defaultMVHistoryGCInterval   = 20 * time.Minute
-	defaultMVHistoryGCRetention  = 365 * 24 * time.Hour
-	defaultMVHistoryGCMaxRecords = uint64(1000000)
-	defaultMVTaskRetryBase       = 10 * time.Second
-	defaultMVTaskRetryMax        = 120 * time.Second
-	manualCancelBackoffDelay     = 2 * time.Minute
-	mvRefreshAlertScanInterval   = 30 * time.Second
-	maxNextScheduleTs            = 9e18
+	DefaultMVRefreshTaskTimeout          = 5 * time.Minute
+	DefaultMVPurgeTaskTimeout            = 10 * time.Minute
+	defaultMVRefreshTaskConcurrencyRatio = 0.6
+	defaultMVFetchInterval               = 30 * time.Second
+	defaultMVBasicInterval               = time.Second
+	defaultServerRefreshInterval         = 5 * time.Second
+	defaultMVHistoryGCInterval           = 20 * time.Minute
+	defaultMVHistoryGCRetention          = 365 * 24 * time.Hour
+	defaultMVHistoryGCMaxRecords         = uint64(1000000)
+	defaultMVTaskRetryBase               = 10 * time.Second
+	defaultMVTaskRetryMax                = 120 * time.Second
+	manualCancelBackoffDelay             = 2 * time.Minute
+	mvRefreshAlertScanInterval           = 30 * time.Second
+	maxNextScheduleTs                    = 9e18
 
 	defaultCHReplicas = 100
 
@@ -180,12 +186,87 @@ type TaskBackpressureConfig struct {
 	Delay        time.Duration
 }
 
+type taskExecutorMetricsSnapshot struct {
+	submittedCount       int64
+	finishedCount        int64
+	failedCount          int64
+	timeoutCount         int64
+	rejectedCount        int64
+	backpressureCount    int64
+	runningCount         int64
+	waitingCount         int64
+	timedOutRunningCount int64
+	backpressureBlocked  int64
+}
+
+func snapshotTaskExecutorMetrics(exec *TaskExecutor) taskExecutorMetricsSnapshot {
+	if exec == nil {
+		return taskExecutorMetricsSnapshot{}
+	}
+	return taskExecutorMetricsSnapshot{
+		submittedCount:       exec.metrics.counters.submittedCount.Load(),
+		finishedCount:        exec.metrics.counters.finishedCount.Load(),
+		failedCount:          exec.metrics.counters.failedCount.Load(),
+		timeoutCount:         exec.metrics.counters.timeoutCount.Load(),
+		rejectedCount:        exec.metrics.counters.rejectedCount.Load(),
+		backpressureCount:    exec.metrics.counters.backpressureCount.Load(),
+		runningCount:         exec.metrics.gauges.runningCount.Load(),
+		waitingCount:         exec.metrics.gauges.waitingCount.Load(),
+		timedOutRunningCount: exec.metrics.gauges.timedOutRunningCount.Load(),
+		backpressureBlocked:  exec.metrics.gauges.backpressureBlocked.Load(),
+	}
+}
+
+func (m taskExecutorMetricsSnapshot) add(other taskExecutorMetricsSnapshot) taskExecutorMetricsSnapshot {
+	return taskExecutorMetricsSnapshot{
+		submittedCount:       m.submittedCount + other.submittedCount,
+		finishedCount:        m.finishedCount + other.finishedCount,
+		failedCount:          m.failedCount + other.failedCount,
+		timeoutCount:         m.timeoutCount + other.timeoutCount,
+		rejectedCount:        m.rejectedCount + other.rejectedCount,
+		backpressureCount:    m.backpressureCount + other.backpressureCount,
+		runningCount:         m.runningCount + other.runningCount,
+		waitingCount:         m.waitingCount + other.waitingCount,
+		timedOutRunningCount: m.timedOutRunningCount + other.timedOutRunningCount,
+		backpressureBlocked:  m.backpressureBlocked + other.backpressureBlocked,
+	}
+}
+
 func (m *mv) Less(other *mv) bool {
 	return m.orderTs < other.orderTs
 }
 
 func (m *mvLog) Less(other *mvLog) bool {
 	return m.orderTs < other.orderTs
+}
+
+func (t *MVService) combinedTaskExecutorMetrics() taskExecutorMetricsSnapshot {
+	return snapshotTaskExecutorMetrics(t.refreshExecutor).add(snapshotTaskExecutorMetrics(t.purgeExecutor))
+}
+
+func loadTaskExecutorWaitingCount(exec *TaskExecutor) int64 {
+	if exec == nil {
+		return 0
+	}
+	return exec.metrics.gauges.waitingCount.Load()
+}
+
+func (t *MVService) runTaskExecutors() {
+	if t.refreshExecutor != nil {
+		t.refreshExecutor.Run()
+	}
+	if t.purgeExecutor != nil {
+		t.purgeExecutor.Run()
+	}
+}
+
+func (t *MVService) closeTaskExecutors() {
+	if t.refreshExecutor != nil {
+		t.refreshExecutor.Close()
+	}
+	if t.purgeExecutor != nil {
+		t.purgeExecutor.Close()
+	}
 }
 
 // fetchExecTasks collects due tasks from both queues and marks them as running.
@@ -236,7 +317,7 @@ func (t *MVService) refreshMV(mvToRefresh []*mv) {
 	for _, task := range mvToRefresh {
 		mvTask := task
 		mviewID := mvTask.ID
-		t.executor.Submit("mv-refresh/"+strconv.FormatInt(mviewID, 10), func() error {
+		t.refreshExecutor.Submit("mv-refresh/"+strconv.FormatInt(mviewID, 10), func() error {
 			return t.executeRefreshTask(mvTask)
 		})
 	}
@@ -486,7 +567,7 @@ func (t *MVService) purgeMVLog(mvLogToPurge []*mvLog) {
 		return
 	}
 	for _, l := range mvLogToPurge {
-		t.executor.Submit("mvlog-purge/"+strconv.FormatInt(l.ID, 10), func() error {
+		t.purgeExecutor.Submit("mvlog-purge/"+strconv.FormatInt(l.ID, 10), func() error {
 			return t.executePurgeTask(l)
 		})
 	}
@@ -581,7 +662,7 @@ func (t *MVService) runtimeLogFields() []zap.Field {
 		zap.Int64("mvlog_count", t.metrics.mvLogCount.Load()),
 		zap.Int64("running_refresh_count", t.metrics.runningMVRefreshCount.Load()),
 		zap.Int64("running_purge_count", t.metrics.runningMVLogPurgeCount.Load()),
-		zap.Int64("waiting_count", t.executor.metrics.gauges.waitingCount.Load()),
+		zap.Int64("waiting_count", loadTaskExecutorWaitingCount(t.refreshExecutor)+loadTaskExecutorWaitingCount(t.purgeExecutor)),
 	}
 	return fields
 }
@@ -1062,14 +1143,14 @@ func (t *MVService) Run() {
 		t.mh.observeRunEvent(mvRunEventInitFailed)
 		return
 	}
-	t.executor.Run()
+	t.runTaskExecutors()
 	timer := mvsNewTimer(0)
 	maintenanceTimer := mvsNewTimer(t.basicInterval)
 
 	defer func() {
 		timer.Stop()
 		maintenanceTimer.Stop()
-		t.executor.Close()
+		t.closeTaskExecutors()
 		t.mh.reportMetrics(t)
 	}()
 

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -554,7 +554,128 @@ func applyMVMaintenanceSessionVarsFromGlobal(ctx context.Context, sessVars *vari
 		restoreMaintainMemQuota()
 		return nil, err
 	}
+	originPurgeBatchSize := sessVars.MLogPurgeBatchSize
+	targetPurgeBatchSize := originPurgeBatchSize
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiDBMLogPurgeBatchSize); ok {
+		targetPurgeBatchSize = variable.TidbOptInt(val, originPurgeBatchSize)
+	}
+	restorePurgeBatchSize, err := applyMVMaintenanceSessionVarBestEffort(
+		sessVars,
+		mvMaintenanceSessionVarApplySpec{
+			varName:     variable.TiDBMLogPurgeBatchSize,
+			originValue: strconv.Itoa(originPurgeBatchSize),
+			targetValue: strconv.Itoa(targetPurgeBatchSize),
+			onApplyError: func(err error) {
+				logutil.BgLogger().Warn(
+					"mv service: failed to apply purge batch size from global setting, fallback to current session value",
+					zap.String("var", variable.TiDBMLogPurgeBatchSize),
+					zap.Int("origin", originPurgeBatchSize),
+					zap.Int("target", targetPurgeBatchSize),
+					zap.Error(err),
+				)
+			},
+			onRestoreError: func(err error) {
+				logutil.BgLogger().Warn(
+					"mv service: failed to restore tidb_mlog_purge_batch_size after maintenance",
+					zap.Int("originPurgeBatchSize", originPurgeBatchSize),
+					zap.Int("currentPurgeBatchSize", targetPurgeBatchSize),
+					zap.Error(err),
+				)
+			},
+		},
+	)
+	if err != nil {
+		restoreIsolationReadEngines()
+		restoreMaintainMemQuota()
+		return nil, err
+	}
+	originPurgeMinRate := sessVars.MLogPurgeMinRate
+	targetPurgeMinRate := originPurgeMinRate
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiDBMLogPurgeMinRate); ok {
+		targetPurgeMinRate = variable.TidbOptInt(val, originPurgeMinRate)
+	}
+	restorePurgeMinRate, err := applyMVMaintenanceSessionVarBestEffort(
+		sessVars,
+		mvMaintenanceSessionVarApplySpec{
+			varName:     variable.TiDBMLogPurgeMinRate,
+			originValue: strconv.Itoa(originPurgeMinRate),
+			targetValue: strconv.Itoa(targetPurgeMinRate),
+			onApplyError: func(err error) {
+				logutil.BgLogger().Warn(
+					"mv service: failed to apply purge min rate from global setting, fallback to current session value",
+					zap.String("var", variable.TiDBMLogPurgeMinRate),
+					zap.Int("origin", originPurgeMinRate),
+					zap.Int("target", targetPurgeMinRate),
+					zap.Error(err),
+				)
+			},
+			onRestoreError: func(err error) {
+				logutil.BgLogger().Warn(
+					"mv service: failed to restore tidb_mlog_purge_min_rate after maintenance",
+					zap.Int("originPurgeMinRate", originPurgeMinRate),
+					zap.Int("currentPurgeMinRate", targetPurgeMinRate),
+					zap.Error(err),
+				)
+			},
+		},
+	)
+	if err != nil {
+		restorePurgeBatchSize()
+		restoreIsolationReadEngines()
+		restoreMaintainMemQuota()
+		return nil, err
+	}
+	originPurgeRateBudgetRatio := sessVars.MLogPurgeRateBudgetRatio
+	targetPurgeRateBudgetRatio := originPurgeRateBudgetRatio
+	if val, ok := getGlobalSystemVarBestEffort(ctx, sessVars, variable.TiDBMLogPurgeRateBudgetRatio); ok {
+		parsed, parseErr := strconv.ParseFloat(val, 64)
+		if parseErr != nil {
+			logutil.BgLogger().Warn(
+				"mv service: failed to parse global session var, fallback to current session value",
+				zap.String("var", variable.TiDBMLogPurgeRateBudgetRatio),
+				zap.String("value", val),
+				zap.Error(parseErr),
+			)
+		} else {
+			targetPurgeRateBudgetRatio = parsed
+		}
+	}
+	restorePurgeRateBudgetRatio, err := applyMVMaintenanceSessionVarBestEffort(
+		sessVars,
+		mvMaintenanceSessionVarApplySpec{
+			varName:     variable.TiDBMLogPurgeRateBudgetRatio,
+			originValue: strconv.FormatFloat(originPurgeRateBudgetRatio, 'f', -1, 64),
+			targetValue: strconv.FormatFloat(targetPurgeRateBudgetRatio, 'f', -1, 64),
+			onApplyError: func(err error) {
+				logutil.BgLogger().Warn(
+					"mv service: failed to apply purge rate budget ratio from global setting, fallback to current session value",
+					zap.String("var", variable.TiDBMLogPurgeRateBudgetRatio),
+					zap.Float64("origin", originPurgeRateBudgetRatio),
+					zap.Float64("target", targetPurgeRateBudgetRatio),
+					zap.Error(err),
+				)
+			},
+			onRestoreError: func(err error) {
+				logutil.BgLogger().Warn(
+					"mv service: failed to restore tidb_mlog_purge_rate_budget_ratio after maintenance",
+					zap.Float64("originPurgeRateBudgetRatio", originPurgeRateBudgetRatio),
+					zap.Float64("currentPurgeRateBudgetRatio", targetPurgeRateBudgetRatio),
+					zap.Error(err),
+				)
+			},
+		},
+	)
+	if err != nil {
+		restorePurgeMinRate()
+		restorePurgeBatchSize()
+		restoreIsolationReadEngines()
+		restoreMaintainMemQuota()
+		return nil, err
+	}
 	return func() {
+		restorePurgeRateBudgetRatio()
+		restorePurgeMinRate()
+		restorePurgeBatchSize()
 		restoreIsolationReadEngines()
 		restoreMaintainMemQuota()
 	}, nil

--- a/pkg/mvservice/service_settings.go
+++ b/pkg/mvservice/service_settings.go
@@ -17,6 +17,7 @@ package mvservice
 import (
 	"context"
 	"fmt"
+	"math"
 	"runtime"
 	"time"
 
@@ -25,8 +26,10 @@ import (
 
 // Config is the config for constructing MVService.
 type Config struct {
-	TaskMaxConcurrency int
-	TaskTimeout        time.Duration
+	TaskMaxConcurrency          int
+	RefreshTaskConcurrencyRatio float64
+	RefreshTaskTimeout          time.Duration
+	PurgeTaskTimeout            time.Duration
 
 	FetchInterval         time.Duration
 	BasicInterval         time.Duration
@@ -47,7 +50,9 @@ type Config struct {
 func DefaultMVServiceConfig() Config {
 	return Config{
 		TaskMaxConcurrency:           defaultMVTaskMaxConcurrency(),
-		TaskTimeout:                  defaultMVTaskTimeout,
+		RefreshTaskConcurrencyRatio:  defaultMVRefreshTaskConcurrencyRatio,
+		RefreshTaskTimeout:           DefaultMVRefreshTaskTimeout,
+		PurgeTaskTimeout:             DefaultMVPurgeTaskTimeout,
 		FetchInterval:                defaultMVFetchInterval,
 		BasicInterval:                defaultMVBasicInterval,
 		ServerRefreshInterval:        defaultServerRefreshInterval,
@@ -61,9 +66,9 @@ func DefaultMVServiceConfig() Config {
 
 func defaultMVTaskMaxConcurrency() int {
 	if maxProcs := runtime.GOMAXPROCS(0); maxProcs > 0 {
-		return maxProcs
+		return max(2, maxProcs)
 	}
-	return 1
+	return 2
 }
 
 // normalizeMVServiceConfig clamps invalid values to safe defaults.
@@ -72,8 +77,17 @@ func normalizeMVServiceConfig(cfg Config) Config {
 	if cfg.TaskMaxConcurrency <= 0 {
 		cfg.TaskMaxConcurrency = def.TaskMaxConcurrency
 	}
-	if cfg.TaskTimeout < 0 {
-		cfg.TaskTimeout = 0
+	if cfg.TaskMaxConcurrency < 2 {
+		cfg.TaskMaxConcurrency = 2
+	}
+	if cfg.RefreshTaskConcurrencyRatio <= 0 || cfg.RefreshTaskConcurrencyRatio >= 1 {
+		cfg.RefreshTaskConcurrencyRatio = def.RefreshTaskConcurrencyRatio
+	}
+	if cfg.RefreshTaskTimeout < 0 {
+		cfg.RefreshTaskTimeout = 0
+	}
+	if cfg.PurgeTaskTimeout < 0 {
+		cfg.PurgeTaskTimeout = 0
 	}
 	if cfg.FetchInterval <= 0 {
 		cfg.FetchInterval = def.FetchInterval
@@ -102,16 +116,40 @@ func normalizeMVServiceConfig(cfg Config) Config {
 	return cfg
 }
 
+func splitTaskConcurrency(total int, refreshRatio float64) (refresh, purge int) {
+	if total < 2 {
+		total = 2
+	}
+	if refreshRatio <= 0 || refreshRatio >= 1 {
+		refreshRatio = defaultMVRefreshTaskConcurrencyRatio
+	}
+	refresh = int(math.Round(float64(total) * refreshRatio))
+	if refresh < 1 {
+		refresh = 1
+	}
+	if refresh >= total {
+		refresh = total - 1
+	}
+	purge = total - refresh
+	if purge < 1 {
+		purge = 1
+		refresh = total - purge
+	}
+	return refresh, purge
+}
+
 // NewMVService creates a new MVService with the given helper and config.
 func NewMVService(ctx context.Context, se basic.SessionPool, helper Helper, cfg Config) *MVService {
 	if helper == nil || se == nil {
 		panic("invalid arguments")
 	}
 	cfg = normalizeMVServiceConfig(cfg)
+	refreshConcurrency, purgeConcurrency := splitTaskConcurrency(cfg.TaskMaxConcurrency, cfg.RefreshTaskConcurrencyRatio)
 	mgr := &MVService{
-		sysSessionPool: se,
-		sch:            NewServerConsistentHash(ctx, cfg.ServerConsistentHashReplicas, helper),
-		executor:       NewTaskExecutor(cfg.TaskMaxConcurrency, cfg.TaskTimeout),
+		sysSessionPool:  se,
+		sch:             NewServerConsistentHash(ctx, cfg.ServerConsistentHashReplicas, helper),
+		refreshExecutor: NewTaskExecutor(refreshConcurrency, cfg.RefreshTaskTimeout),
+		purgeExecutor:   NewTaskExecutor(purgeConcurrency, cfg.PurgeTaskTimeout),
 
 		notifier: NewNotifier(),
 		ctx:      ctx,
@@ -120,6 +158,7 @@ func NewMVService(ctx context.Context, se basic.SessionPool, helper Helper, cfg 
 		basicInterval:         cfg.BasicInterval,
 		serverRefreshInterval: cfg.ServerRefreshInterval,
 	}
+	mgr.refreshTaskConcurrencyRatioBits.Store(math.Float64bits(cfg.RefreshTaskConcurrencyRatio))
 	if err := mgr.setFetchInterval(cfg.FetchInterval); err != nil {
 		panic(fmt.Sprintf("invalid MV service fetch interval config: fetch_interval=%s err=%v",
 			cfg.FetchInterval, err))
@@ -149,12 +188,39 @@ func (t *MVService) SetTaskMaxConcurrency(maxConcurrency int) {
 	if maxConcurrency == 0 {
 		maxConcurrency = defaultMVTaskMaxConcurrency()
 	}
-	t.executor.setMaxConcurrency(maxConcurrency)
+	if maxConcurrency < 2 {
+		maxConcurrency = 2
+	}
+	refreshConcurrency, purgeConcurrency := splitTaskConcurrency(maxConcurrency, t.GetRefreshTaskConcurrencyRatio())
+	t.refreshExecutor.setMaxConcurrency(refreshConcurrency)
+	t.purgeExecutor.setMaxConcurrency(purgeConcurrency)
 }
 
-// SetTaskTimeout sets timeout for MV tasks.
-func (t *MVService) SetTaskTimeout(timeout time.Duration) {
-	t.executor.setTimeout(timeout)
+// SetRefreshTaskConcurrencyRatio sets the refresh-task share of total MV task concurrency.
+func (t *MVService) SetRefreshTaskConcurrencyRatio(ratio float64) {
+	if ratio <= 0 || ratio >= 1 {
+		ratio = defaultMVRefreshTaskConcurrencyRatio
+	}
+	t.refreshTaskConcurrencyRatioBits.Store(math.Float64bits(ratio))
+	total := int(t.refreshExecutor.maxConcurrency.Load() + t.purgeExecutor.maxConcurrency.Load())
+	if total < 2 {
+		total = defaultMVTaskMaxConcurrency()
+	}
+	refreshConcurrency, purgeConcurrency := splitTaskConcurrency(total, ratio)
+	t.refreshExecutor.setMaxConcurrency(refreshConcurrency)
+	t.purgeExecutor.setMaxConcurrency(purgeConcurrency)
+}
+
+// GetRefreshTaskConcurrencyRatio returns the configured refresh-task share.
+func (t *MVService) GetRefreshTaskConcurrencyRatio() float64 {
+	if t == nil {
+		return defaultMVRefreshTaskConcurrencyRatio
+	}
+	ratio := math.Float64frombits(t.refreshTaskConcurrencyRatioBits.Load())
+	if ratio <= 0 || ratio >= 1 {
+		return defaultMVRefreshTaskConcurrencyRatio
+	}
+	return ratio
 }
 
 // setFetchInterval sets metadata fetch interval.
@@ -248,7 +314,8 @@ func (t *MVService) GetTaskBackpressureConfig() TaskBackpressureConfig {
 
 // SetTaskBackpressureController sets the task backpressure controller.
 func (t *MVService) SetTaskBackpressureController(controller TaskBackpressureController) {
-	t.executor.SetBackpressureController(controller)
+	t.refreshExecutor.SetBackpressureController(controller)
+	t.purgeExecutor.SetBackpressureController(controller)
 }
 
 // historyGCInterval returns history GC interval.

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -148,6 +148,9 @@ type recordingSessionContext struct {
 	restrictedBatchSize                    []uint64
 	restrictedImportThreads                []int
 	restrictedImportDiskQuota              []string
+	restrictedMLogPurgeBatchSize           []int
+	restrictedMLogPurgeMinRate             []int
+	restrictedMLogPurgeRateBudgetRatio     []float64
 	restrictedRows                         map[string][]chunk.Row
 	restrictedErrs                         map[string]error
 	restrictedAffectedRows                 map[string][]uint64
@@ -241,6 +244,9 @@ func (s *recordingSessionContext) ExecRestrictedSQL(_ context.Context, _ []sqlex
 	s.restrictedBatchSize = append(s.restrictedBatchSize, s.GetSessionVars().TiFlashFineGrainedShuffleBatchSize)
 	s.restrictedImportThreads = append(s.restrictedImportThreads, s.GetSessionVars().MViewMaintainImportThreads)
 	s.restrictedImportDiskQuota = append(s.restrictedImportDiskQuota, s.GetSessionVars().MViewMaintainImportDiskQuota)
+	s.restrictedMLogPurgeBatchSize = append(s.restrictedMLogPurgeBatchSize, s.GetSessionVars().MLogPurgeBatchSize)
+	s.restrictedMLogPurgeMinRate = append(s.restrictedMLogPurgeMinRate, s.GetSessionVars().MLogPurgeMinRate)
+	s.restrictedMLogPurgeRateBudgetRatio = append(s.restrictedMLogPurgeRateBudgetRatio, s.GetSessionVars().MLogPurgeRateBudgetRatio)
 	if seq, ok := s.restrictedAffectedRows[sql]; ok {
 		pos := s.restrictedAffectedPos[sql]
 		if pos < len(seq) {
@@ -348,7 +354,7 @@ func TestLatestServerInfosByInstanceKeepsNewestDDLID(t *testing.T) {
 func waitExecutorFinishedCount(t *testing.T, svc *MVService, expected int64) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		return svc.executor.metrics.counters.finishedCount.Load() == expected
+		return svc.combinedTaskExecutorMetrics().finishedCount == expected
 	}, testEventuallyWait, testEventuallyTick)
 }
 
@@ -1091,7 +1097,7 @@ func TestMVServiceTaskResult(t *testing.T) {
 			svc.purgeMVLog([]*mvLog{l})
 
 			waitExecutorFinishedCount(t, svc, 1)
-			require.Equal(t, int64(0), svc.executor.metrics.counters.failedCount.Load())
+			require.Equal(t, int64(0), svc.purgeExecutor.metrics.counters.failedCount.Load())
 			require.Eventually(t, func() bool {
 				svc.mvLogPurgeMu.Lock()
 				_, ok := svc.mvLogPurgeMu.pending[l.ID]
@@ -1117,7 +1123,7 @@ func TestMVServiceTaskResult(t *testing.T) {
 			svc.purgeMVLog([]*mvLog{l})
 
 			waitExecutorFinishedCount(t, svc, 1)
-			require.Equal(t, int64(0), svc.executor.metrics.counters.failedCount.Load())
+			require.Equal(t, int64(0), svc.purgeExecutor.metrics.counters.failedCount.Load())
 
 			svc.mvLogPurgeMu.Lock()
 			item, ok := svc.mvLogPurgeMu.pending[l.ID]
@@ -1220,7 +1226,7 @@ func TestMVServiceTaskResult(t *testing.T) {
 			svc.refreshMV([]*mv{m})
 
 			waitExecutorFinishedCount(t, svc, 1)
-			require.Equal(t, int64(0), svc.executor.metrics.counters.failedCount.Load())
+			require.Equal(t, int64(0), svc.refreshExecutor.metrics.counters.failedCount.Load())
 			require.Eventually(t, func() bool {
 				svc.mvRefreshMu.Lock()
 				_, ok := svc.mvRefreshMu.pending[m.ID]
@@ -1246,7 +1252,7 @@ func TestMVServiceTaskResult(t *testing.T) {
 			svc.refreshMV([]*mv{m})
 
 			waitExecutorFinishedCount(t, svc, 1)
-			require.Equal(t, int64(0), svc.executor.metrics.counters.failedCount.Load())
+			require.Equal(t, int64(0), svc.refreshExecutor.metrics.counters.failedCount.Load())
 
 			svc.mvRefreshMu.Lock()
 			item, ok := svc.mvRefreshMu.pending[m.ID]
@@ -1462,7 +1468,8 @@ func TestRegisterMVServiceBootstrapAndDDLHandler(t *testing.T) {
 		MemThreshold: defaultBackpressureMemThreshold,
 		Delay:        defaultTaskBackpressureDelay,
 	}, svc.GetTaskBackpressureConfig())
-	require.NotNil(t, svc.executor.backpressure.Load())
+	require.NotNil(t, svc.refreshExecutor.backpressure.Load())
+	require.NotNil(t, svc.purgeExecutor.backpressure.Load())
 
 	createTable := notifier.NewCreateTableEvent(&meta.TableInfo{ID: 1})
 	require.NoError(t, gotHandler(context.Background(), nil, createTable))
@@ -2313,9 +2320,15 @@ func TestServerHelperPurgeMVLogUsesGlobalMaintainMemQuota(t *testing.T) {
 	vars.GlobalVarsAccessor = mockGlobalAccessor
 	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBMVMaintainMemQuota, "536870912"))
 	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBMVMaintainIsolationReadEngines, "tikv"))
+	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBMLogPurgeBatchSize, "4321"))
+	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBMLogPurgeMinRate, "8765"))
+	require.NoError(t, vars.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBMLogPurgeRateBudgetRatio, "0.75"))
 	require.NoError(t, vars.SetSystemVar(variable.TiDBMVMaintainMemQuota, "268435456"))
 	require.NoError(t, vars.SetSystemVar(variable.TiDBMVMaintainIsolationReadEngines, "tidb"))
 	require.NoError(t, vars.SetSystemVar(variable.TiDBIsolationReadEngines, "tidb"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMLogPurgeBatchSize, "1234"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMLogPurgeMinRate, "2345"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMLogPurgeRateBudgetRatio, "0.25"))
 
 	nextPurge, err := (&serviceHelper{}).PurgeMVLog(context.Background(), pool, 201)
 	require.NoError(t, err)
@@ -2323,9 +2336,15 @@ func TestServerHelperPurgeMVLogUsesGlobalMaintainMemQuota(t *testing.T) {
 	require.Equal(t, testExpectedPurgeMVLogSQL, se.executedRestrictedSQL)
 	require.Equal(t, []int64{536870912, 536870912}, se.restrictedMaintainQuota)
 	require.Equal(t, []string{"tikv", "tikv"}, se.restrictedMaintainIsolationReadEngines)
+	require.Equal(t, []int{4321, 4321}, se.restrictedMLogPurgeBatchSize)
+	require.Equal(t, []int{8765, 8765}, se.restrictedMLogPurgeMinRate)
+	require.Equal(t, []float64{0.75, 0.75}, se.restrictedMLogPurgeRateBudgetRatio)
 	require.Equal(t, int64(268435456), vars.MVMaintainMemQuota)
 	require.Equal(t, "tidb", variable.GetIsolationReadEnginesString(vars))
 	require.Equal(t, "tidb", vars.MVMaintainIsolationReadEngines)
+	require.Equal(t, 1234, vars.MLogPurgeBatchSize)
+	require.Equal(t, 2345, vars.MLogPurgeMinRate)
+	require.Equal(t, 0.25, vars.MLogPurgeRateBudgetRatio)
 }
 
 func TestServerHelperPurgeMVLogBestEffortWhenGlobalMaintainMemQuotaUnavailable(t *testing.T) {
@@ -2347,6 +2366,9 @@ func TestServerHelperPurgeMVLogBestEffortWhenGlobalMaintainMemQuotaUnavailable(t
 		getErrs: map[string]error{
 			variable.TiDBMVMaintainMemQuota:             errors.New("mock global read failure"),
 			variable.TiDBMVMaintainIsolationReadEngines: errors.New("mock global read failure"),
+			variable.TiDBMLogPurgeBatchSize:             errors.New("mock global read failure"),
+			variable.TiDBMLogPurgeMinRate:               errors.New("mock global read failure"),
+			variable.TiDBMLogPurgeRateBudgetRatio:       errors.New("mock global read failure"),
 		},
 		failAfter: map[string]int{
 			variable.TiDBMVMaintainIsolationReadEngines: 1,
@@ -2357,6 +2379,9 @@ func TestServerHelperPurgeMVLogBestEffortWhenGlobalMaintainMemQuotaUnavailable(t
 	}
 	require.NoError(t, vars.SetSystemVar(variable.TiDBMVMaintainMemQuota, "268435456"))
 	require.NoError(t, vars.SetSystemVar(variable.TiDBIsolationReadEngines, "tikv"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMLogPurgeBatchSize, "3456"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMLogPurgeMinRate, "4567"))
+	require.NoError(t, vars.SetSystemVar(variable.TiDBMLogPurgeRateBudgetRatio, "0.35"))
 
 	nextPurge, err := (&serviceHelper{}).PurgeMVLog(context.Background(), pool, 201)
 	require.NoError(t, err)
@@ -2364,9 +2389,15 @@ func TestServerHelperPurgeMVLogBestEffortWhenGlobalMaintainMemQuotaUnavailable(t
 	require.Equal(t, testExpectedPurgeMVLogSQL, se.executedRestrictedSQL)
 	require.Equal(t, []int64{268435456, 268435456}, se.restrictedMaintainQuota)
 	require.Equal(t, []string{"tidb", "tidb"}, se.restrictedMaintainIsolationReadEngines)
+	require.Equal(t, []int{3456, 3456}, se.restrictedMLogPurgeBatchSize)
+	require.Equal(t, []int{4567, 4567}, se.restrictedMLogPurgeMinRate)
+	require.Equal(t, []float64{0.35, 0.35}, se.restrictedMLogPurgeRateBudgetRatio)
 	require.Equal(t, int64(268435456), vars.MVMaintainMemQuota)
 	require.Equal(t, "tikv", variable.GetIsolationReadEnginesString(vars))
 	require.Equal(t, variable.GetSysVar(variable.TiDBMVMaintainIsolationReadEngines).Value, vars.MVMaintainIsolationReadEngines)
+	require.Equal(t, 3456, vars.MLogPurgeBatchSize)
+	require.Equal(t, 4567, vars.MLogPurgeMinRate)
+	require.Equal(t, 0.35, vars.MLogPurgeRateBudgetRatio)
 }
 
 func TestPurgeMVLogSkipWhenAutoPurge(t *testing.T) {

--- a/pkg/mvservice/test_helpers_test.go
+++ b/pkg/mvservice/test_helpers_test.go
@@ -45,9 +45,9 @@ func runMVServiceForTest(t *testing.T, svc *MVService, cancel context.CancelFunc
 func newRunningMVServiceForTest(t *testing.T, helper Helper) *MVService {
 	t.Helper()
 	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
-	svc.executor.Run()
+	svc.runTaskExecutors()
 	t.Cleanup(func() {
-		svc.executor.Close()
+		svc.closeTaskExecutors()
 	})
 	return svc
 }

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -767,9 +767,13 @@ type SessionVars struct {
 	// It will be used when using LOAD DATA or BatchInsert or BatchDelete is on.
 	DMLBatchSize int
 	// MLogPurgeBatchSize indicates the max rows deleted by one purge batch transaction.
-	MLogPurgeBatchSize  int
-	RetryLimit          int64
-	DisableTxnAutoRetry bool
+	MLogPurgeBatchSize int
+	// MLogPurgeMinRate indicates the minimum target delete rate for adaptive MV log purge throttling.
+	MLogPurgeMinRate int
+	// MLogPurgeRateBudgetRatio indicates the fraction of the current scheduling window that purge may spend deleting.
+	MLogPurgeRateBudgetRatio float64
+	RetryLimit               int64
+	DisableTxnAutoRetry      bool
 	*UserVars
 	// systems variables, don't modify it directly, use GetSystemVar/SetSystemVar method.
 	systems map[string]string
@@ -2324,6 +2328,8 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 	}
 	vars.DMLBatchSize = DefDMLBatchSize
 	vars.MLogPurgeBatchSize = DefTiDBMLogPurgeBatchSize
+	vars.MLogPurgeMinRate = DefTiDBMLogPurgeMinRate
+	vars.MLogPurgeRateBudgetRatio = DefTiDBMLogPurgeRateBudgetRatio
 	vars.AllowBatchCop = DefTiDBAllowBatchCop
 	vars.allowMPPExecution = DefTiDBAllowMPPExecution
 	vars.HashExchangeWithNewCollation = DefTiDBHashExchangeWithNewCollation

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2194,6 +2194,32 @@ var defaultSysVars = []*SysVar{
 		s.MLogPurgeBatchSize = int(TidbOptInt64(val, DefTiDBMLogPurgeBatchSize))
 		return nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBMLogPurgeMinRate, Value: strconv.Itoa(DefTiDBMLogPurgeMinRate), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxInt32, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
+		v, err := strconv.ParseUint(normalizedValue, 10, 64)
+		if err != nil {
+			return "", err
+		}
+		if v == 0 {
+			return normalizedValue, ErrWrongValueForVar.GenWithStackByArgs(TiDBMLogPurgeMinRate, originalValue)
+		}
+		return normalizedValue, nil
+	}, SetSession: func(s *SessionVars, val string) error {
+		s.MLogPurgeMinRate = int(TidbOptInt64(val, DefTiDBMLogPurgeMinRate))
+		return nil
+	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBMLogPurgeRateBudgetRatio, Value: strconv.FormatFloat(DefTiDBMLogPurgeRateBudgetRatio, 'f', -1, 64), Type: TypeFloat, MinValue: 0, MaxValue: 1, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
+		v, err := strconv.ParseFloat(originalValue, 64)
+		if err != nil {
+			return "", err
+		}
+		if v <= 0 || v > 1 {
+			return normalizedValue, ErrWrongValueForVar.GenWithStackByArgs(TiDBMLogPurgeRateBudgetRatio, originalValue)
+		}
+		return normalizedValue, nil
+	}, SetSession: func(s *SessionVars, val string) error {
+		s.MLogPurgeRateBudgetRatio = tidbOptFloat64(val, DefTiDBMLogPurgeRateBudgetRatio)
+		return nil
+	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBMaxChunkSize, Value: strconv.Itoa(DefMaxChunkSize), Type: TypeUnsigned, MinValue: maxChunkSizeLowerBound, MaxValue: math.MaxInt32, SetSession: func(s *SessionVars, val string) error {
 		s.MaxChunkSize = tidbOptPositiveInt32(val, DefMaxChunkSize)
 		return nil
@@ -2769,6 +2795,25 @@ var defaultSysVars = []*SysVar{
 			return err
 		}
 		if setter := SetMVServiceTaskMaxConcurrency.Load(); setter != nil {
+			(*setter)(val)
+		}
+		return nil
+	}},
+	{Scope: ScopeGlobal, Name: TiDBMViewTaskRefreshRatio, Value: strconv.FormatFloat(DefTiDBMViewTaskRefreshRatio, 'f', -1, 64), Type: TypeFloat, MinValue: 0, MaxValue: 1, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
+		val, err := strconv.ParseFloat(normalizedValue, 64)
+		if err != nil {
+			return "", err
+		}
+		if val <= 0 || val >= 1 {
+			return "", ErrWrongValueForVar.GenWithStackByArgs(TiDBMViewTaskRefreshRatio, originalValue)
+		}
+		return normalizedValue, nil
+	}, SetGlobal: func(_ context.Context, _ *SessionVars, s string) error {
+		val, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return err
+		}
+		if setter := SetMVServiceRefreshTaskConcurrencyRatio.Load(); setter != nil {
 			(*setter)(val)
 		}
 		return nil

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -1847,12 +1847,14 @@ func TestMVServiceGlobalSysVars(t *testing.T) {
 	mock := NewMockGlobalAccessor4Tests()
 
 	oldTaskMax := SetMVServiceTaskMaxConcurrency.Load()
+	oldRefreshRatio := SetMVServiceRefreshTaskConcurrencyRatio.Load()
 	oldCPU := SetMVServiceTaskThresholdCPU.Load()
 	oldMemory := SetMVServiceTaskThresholdMemory.Load()
 	oldRefreshHist := SetMVServiceMViewRefreshHistRetention.Load()
 	oldPurgeHist := SetMVServiceMLogPurgeHistRetention.Load()
 	defer func() {
 		SetMVServiceTaskMaxConcurrency.Store(oldTaskMax)
+		SetMVServiceRefreshTaskConcurrencyRatio.Store(oldRefreshRatio)
 		SetMVServiceTaskThresholdCPU.Store(oldCPU)
 		SetMVServiceTaskThresholdMemory.Store(oldMemory)
 		SetMVServiceMViewRefreshHistRetention.Store(oldRefreshHist)
@@ -1860,17 +1862,20 @@ func TestMVServiceGlobalSysVars(t *testing.T) {
 	}()
 
 	gotTaskMax := -1
+	gotRefreshRatio := -1.0
 	gotCPU := -1.0
 	gotMemory := -1.0
 	var gotRefreshHist time.Duration
 	var gotPurgeHist time.Duration
 
 	taskMaxFn := func(v int) { gotTaskMax = v }
+	refreshRatioFn := func(v float64) { gotRefreshRatio = v }
 	cpuFn := func(v float64) { gotCPU = v }
 	memoryFn := func(v float64) { gotMemory = v }
 	refreshHistFn := func(v time.Duration) { gotRefreshHist = v }
 	purgeHistFn := func(v time.Duration) { gotPurgeHist = v }
 	SetMVServiceTaskMaxConcurrency.Store(&taskMaxFn)
+	SetMVServiceRefreshTaskConcurrencyRatio.Store(&refreshRatioFn)
 	SetMVServiceTaskThresholdCPU.Store(&cpuFn)
 	SetMVServiceTaskThresholdMemory.Store(&memoryFn)
 	SetMVServiceMViewRefreshHistRetention.Store(&refreshHistFn)
@@ -1878,6 +1883,10 @@ func TestMVServiceGlobalSysVars(t *testing.T) {
 
 	require.NoError(t, mock.SetGlobalSysVar(context.Background(), TiDBMViewTaskMax, "0"))
 	require.Equal(t, 0, gotTaskMax)
+
+	require.NoError(t, mock.SetGlobalSysVar(context.Background(), TiDBMViewTaskRefreshRatio, "0.6"))
+	require.Equal(t, 0.6, gotRefreshRatio)
+	require.Error(t, mock.SetGlobalSysVar(context.Background(), TiDBMViewTaskRefreshRatio, "1"))
 
 	require.NoError(t, mock.SetGlobalSysVar(context.Background(), TiDBMViewTaskThresholdCPU, "0.7"))
 	require.Equal(t, 0.7, gotCPU)

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -139,6 +139,10 @@ const (
 
 	// TiDBMLogPurgeBatchSize is used to split PURGE MATERIALIZED VIEW LOG into multiple delete batches.
 	TiDBMLogPurgeBatchSize = "tidb_mlog_purge_batch_size"
+	// TiDBMLogPurgeMinRate controls the minimum target delete rate for adaptive MV log purge throttling.
+	TiDBMLogPurgeMinRate = "tidb_mlog_purge_min_rate"
+	// TiDBMLogPurgeRateBudgetRatio controls the fraction of the current scheduling window that purge may spend deleting.
+	TiDBMLogPurgeRateBudgetRatio = "tidb_mlog_purge_rate_budget_ratio"
 
 	// The following session variables controls the memory quota during query execution.
 
@@ -154,6 +158,8 @@ const (
 	TiDBMViewMaintainImportDiskQuota = "tidb_mview_maintain_import_disk_quota"
 	// TiDBMViewTaskMax controls the max concurrency of MV background tasks. 0 means using GOMAXPROCS.
 	TiDBMViewTaskMax = "tidb_mview_task_max"
+	// TiDBMViewTaskRefreshRatio controls the refresh-task share of MV background task concurrency.
+	TiDBMViewTaskRefreshRatio = "tidb_mview_task_refresh_ratio"
 	// TiDBMViewTaskThresholdCPU controls MV task backpressure CPU threshold.
 	TiDBMViewTaskThresholdCPU = "tidb_mview_task_threshold_cpu"
 	// TiDBMViewTaskThresholdMemory controls MV task backpressure memory threshold.
@@ -1361,7 +1367,9 @@ const (
 	DefMaxPagingSize                        = int(paging.MaxPagingSize)
 	DefMaxChunkSize                         = 1024
 	DefDMLBatchSize                         = 0
-	DefTiDBMLogPurgeBatchSize               = 100000
+	DefTiDBMLogPurgeBatchSize               = 10000
+	DefTiDBMLogPurgeMinRate                 = 2000
+	DefTiDBMLogPurgeRateBudgetRatio         = 0.5
 	DefMaxPreparedStmtCount                 = -1
 	DefWaitTimeout                          = 28800
 	DefTiDBMemQuotaApplyCache               = 32 << 20 // 32MB.
@@ -1506,6 +1514,7 @@ const (
 	DefTiDBMViewMaintainImportThreads                 = 0
 	DefTiDBMViewMaintainImportDiskQuota               = ""
 	DefTiDBMViewTaskMax                               = 0
+	DefTiDBMViewTaskRefreshRatio                      = 0.6
 	DefTiDBMViewTaskThresholdCPU                      = 0.8
 	DefTiDBMViewTaskThresholdMemory                   = 0.8
 	DefTiDBMViewRefreshHistTime                       = 168
@@ -1807,6 +1816,8 @@ var (
 	SetGlobalResourceControl atomic.Pointer[func(bool)]
 	// SetMVServiceTaskMaxConcurrency applies global tidb_mview_task_max to the local MV service.
 	SetMVServiceTaskMaxConcurrency atomic.Pointer[func(int)]
+	// SetMVServiceRefreshTaskConcurrencyRatio applies global tidb_mview_task_refresh_ratio to the local MV service.
+	SetMVServiceRefreshTaskConcurrencyRatio atomic.Pointer[func(float64)]
 	// SetMVServiceTaskThresholdCPU applies global tidb_mview_task_threshold_cpu to the local MV service.
 	SetMVServiceTaskThresholdCPU atomic.Pointer[func(float64)]
 	// SetMVServiceTaskThresholdMemory applies global tidb_mview_task_threshold_memory to the local MV service.

--- a/pkg/sessionctx/variable/varsutil_test.go
+++ b/pkg/sessionctx/variable/varsutil_test.go
@@ -534,6 +534,11 @@ func TestValidate(t *testing.T) {
 		{TiDBMVMaintainIsolationReadEngines, "", true},
 		{TiDBMVMaintainIsolationReadEngines, "tikv", false},
 		{TiDBMVMaintainIsolationReadEngines, "TiKV,tiflash", false},
+		{TiDBMLogPurgeMinRate, "0", true},
+		{TiDBMLogPurgeMinRate, "1", false},
+		{TiDBMLogPurgeRateBudgetRatio, "0", true},
+		{TiDBMLogPurgeRateBudgetRatio, "0.5", false},
+		{TiDBMLogPurgeRateBudgetRatio, "1.1", true},
 	}
 
 	for _, tc := range testCases {
@@ -560,6 +565,11 @@ func TestValidate(t *testing.T) {
 		{TiDBMVMaintainIsolationReadEngines, "", true},
 		{TiDBMVMaintainIsolationReadEngines, "tikv", false},
 		{TiDBMVMaintainIsolationReadEngines, "TiKV,tiflash", false},
+		{TiDBMLogPurgeMinRate, "0", true},
+		{TiDBMLogPurgeMinRate, "1", false},
+		{TiDBMLogPurgeRateBudgetRatio, "0", true},
+		{TiDBMLogPurgeRateBudgetRatio, "0.5", false},
+		{TiDBMLogPurgeRateBudgetRatio, "1.1", true},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:

Materialized view log purge may delete a large number of rows in one scheduled task. Without throttling, this can create resource spikes. However, if purge throttling is implemented on the same MV service executor used by refresh tasks, long-running or throttled purge jobs may also consume refresh execution slots and delay MV refresh.

Original cherry-picked PR: https://github.com/pingcap/tidb/pull/68193

### What changed and how does it work?

This PR adds adaptive throttling for materialized view log purge and separates the MV service execution capacity for refresh and purge:

- Add adaptive purge throttling for `PURGE MATERIALIZED VIEW LOG`.
- Add `tidb_mlog_purge_min_rate` to control the minimum target purge delete rate.
- Add `tidb_mlog_purge_rate_budget_ratio` to control how much of the current purge scheduling window may be spent deleting rows.
- Add a best-effort pending-row count and adaptive batch sizing before purge delete batches.
- Keep purge progress, affected rows, history finalization, manual cancel, and fallback behavior consistent when throttling metadata/count/deadline calculation fails.
- Split the MV service background task executor into independent refresh and purge executors.
- Add `tidb_mview_task_refresh_ratio` to control how much of `tidb_mview_task_max` is reserved for refresh tasks.
- Keep metrics, backpressure, timeout handling, service lifecycle, and tests updated for the split executors.

The executor split is intentional: purge throttling should reduce purge pressure without starving MV refresh tasks.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Add adaptive throttling for materialized view log purge and split MV refresh and purge background executors.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added system variables to control materialized view log purge behavior: `tidb_mlog_purge_min_rate`, `tidb_mlog_purge_rate_budget_ratio`, and `tidb_mlog_purge_batch_size`.
  * Added `tidb_mview_task_refresh_ratio` system variable to tune refresh task concurrency allocation.
  * Implemented adaptive throttling for materialized view log purge operations with automatic fallback to unthrottled mode.

* **Tests**
  * Added test coverage for adaptive purge throttling fallback scenarios and task lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->