### PR TITLE
lightning, importinto: add external ID compatibility flag

### DIFF
--- a/lightning/pkg/importinto/importer.go
+++ b/lightning/pkg/importinto/importer.go
@@ -163,7 +163,7 @@ func NewImporter(
 func (i *Importer) buildOrchestrator() JobOrchestrator {
 	jobSubmitterOpts := make([]JobSubmitterOption, 0, 1)
 	if i.stripS3ExternalIDForImportSQL {
-		jobSubmitterOpts = append(jobSubmitterOpts, WithJobSubmitterStripS3ExternalIDForImportSQL())
+		jobSubmitterOpts = append(jobSubmitterOpts, WithJobSubmitterStripS3ExternalIDForImportSQL(true))
 	}
 	submitter := NewJobSubmitter(i.sdk, i.cfg, i.groupKey, i.logger.With(zap.String("component", "submitter")), jobSubmitterOpts...)
 

--- a/lightning/pkg/importinto/job_submitter.go
+++ b/lightning/pkg/importinto/job_submitter.go
@@ -59,9 +59,9 @@ type JobSubmitterOption func(*DefaultJobSubmitter)
 // that need to keep compatibility with older IMPORT INTO planners that reject
 // explicit S3 external ID; newer planners can accept an explicit external ID
 // matching the target value.
-func WithJobSubmitterStripS3ExternalIDForImportSQL() JobSubmitterOption {
+func WithJobSubmitterStripS3ExternalIDForImportSQL(strip bool) JobSubmitterOption {
 	return func(s *DefaultJobSubmitter) {
-		s.stripS3ExternalIDForImportSQL = true
+		s.stripS3ExternalIDForImportSQL = strip
 	}
 }
 
@@ -73,6 +73,7 @@ func NewJobSubmitter(sdk importsdk.SDK, cfg *config.Config, groupKey string, log
 		groupKey: groupKey,
 		logger:   logger,
 	}
+	WithJobSubmitterStripS3ExternalIDForImportSQL(cfg.TikvImporter.StripS3ExternalIDForImportSQL)(submitter)
 	for _, opt := range opts {
 		opt(submitter)
 	}

--- a/lightning/pkg/importinto/job_submitter_test.go
+++ b/lightning/pkg/importinto/job_submitter_test.go
@@ -39,6 +39,9 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 
 	s3Cfg := config.NewConfig()
 	s3Cfg.Mydumper.SourceDir = s3SourceDirWithExternalID
+	s3CfgWithStrip := config.NewConfig()
+	s3CfgWithStrip.Mydumper.SourceDir = s3SourceDirWithExternalID
+	s3CfgWithStrip.TikvImporter.StripS3ExternalIDForImportSQL = true
 	ossCfg := config.NewConfig()
 	ossCfg.Mydumper.SourceDir = ossSourceDirWithExternalID
 	gcsCfg := config.NewConfig()
@@ -105,7 +108,7 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 		},
 		{
 			name:                "sanitize s3 external id when enabled for import sql resource parameters",
-			jobSubmitterOptions: []importinto.JobSubmitterOption{importinto.WithJobSubmitterStripS3ExternalIDForImportSQL()},
+			jobSubmitterOptions: []importinto.JobSubmitterOption{importinto.WithJobSubmitterStripS3ExternalIDForImportSQL(true)},
 			tableMeta: &importsdk.TableMeta{
 				Database: "db",
 				Table:    "t1",
@@ -122,8 +125,25 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 			},
 		},
 		{
+			name: "sanitize s3 external id when config flag is enabled",
+			tableMeta: &importsdk.TableMeta{
+				Database: "db",
+				Table:    "t1",
+			},
+			cfg: s3CfgWithStrip,
+			setup: func(t *testing.T, mockSDK *sdkmock.MockSDK) {
+				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ *importsdk.TableMeta, opts *importsdk.ImportOptions) (string, error) {
+						require.Equal(t, s3ResourceParameters, opts.ResourceParameters)
+						require.Equal(t, s3SourceDirWithExternalID, s3CfgWithStrip.Mydumper.SourceDir)
+						return "IMPORT INTO ...", nil
+					})
+				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
+			},
+		},
+		{
 			name:                "sanitize oss external id as s3 like resource parameters",
-			jobSubmitterOptions: []importinto.JobSubmitterOption{importinto.WithJobSubmitterStripS3ExternalIDForImportSQL()},
+			jobSubmitterOptions: []importinto.JobSubmitterOption{importinto.WithJobSubmitterStripS3ExternalIDForImportSQL(true)},
 			tableMeta: &importsdk.TableMeta{
 				Database: "db",
 				Table:    "t1",

--- a/pkg/lightning/config/config.go
+++ b/pkg/lightning/config/config.go
@@ -1118,6 +1118,15 @@ type TikvImporter struct {
 	KeyspaceName      string `toml:"keyspace-name" json:"keyspace-name"`
 	AddIndexBySQL     bool   `toml:"add-index-by-sql" json:"add-index-by-sql"`
 
+	// StripS3ExternalIDForImportSQL strips explicit S3 external ID from
+	// generated IMPORT INTO SQL resource parameters while keeping the original
+	// source path unchanged for Lightning storage access. This compatibility flag
+	// is only for callers that need to work with older IMPORT INTO planners that
+	// reject explicit S3 external ID.
+	// Deprecated: remove this flag after downstream callers no longer need to
+	// keep compatibility with those older planners.
+	StripS3ExternalIDForImportSQL bool `toml:"-" json:"-"`
+
 	EngineMemCacheSize      ByteSize `toml:"engine-mem-cache-size" json:"engine-mem-cache-size"`
 	LocalWriterMemCacheSize ByteSize `toml:"local-writer-mem-cache-size" json:"local-writer-mem-cache-size"`
 	StoreWriteBWLimit       ByteSize `toml:"store-write-bwlimit" json:"store-write-bwlimit"`


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60418

Related TiFlow issue: pingcap/tiflow#12699

Problem Summary:

pingcap/tidb#69147 added import-into logic that can strip explicit S3 external ID from IMPORT INTO SQL resource parameters while keeping the original Lightning source path unchanged for storage access.

DM needs to enable that compatibility behavior through the existing Lightning config flow, without bypassing Lightning server/import-into execution.

### What changed and how does it work?

- Add `TikvImporter.StripS3ExternalIDForImportSQL` as an internal compatibility flag (`toml:"-" json:"-"`). The comment states it is only for compatibility with older IMPORT INTO planners and should be deprecated/removed later.
- Let `WithJobSubmitterStripS3ExternalIDForImportSQL` accept a boolean, so both explicit options and config-derived behavior write the same field through the same option path.
- `NewJobSubmitter` applies `WithJobSubmitterStripS3ExternalIDForImportSQL(cfg.TikvImporter.StripS3ExternalIDForImportSQL)`, reusing the existing import-into resource-parameter stripping logic.
- Add coverage for enabling the strip behavior through the config flag.

This keeps `Mydumper.SourceDir` unchanged for Lightning storage access. Only the IMPORT INTO SQL resource parameters are sanitized when the compatibility flag is enabled.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Tested with:

- `./tools/check/failpoint-go-test.sh lightning/pkg/importinto -run TestJobSubmitterSubmitTable`
- `make bazel_prepare`
- `git diff --check`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a (deprecated) `StripS3ExternalIDForImportSQL` option to the TikvImporter configuration to control whether S3 external IDs are stripped during IMPORT INTO SQL generation for compatibility.

* **Tests**
  * Updated/added coverage to confirm that when the option is enabled, import SQL generation uses sanitized S3 resource parameters while preserving the original `SourceDir` value containing the external ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->