### PR TITLE
br: remove crr prefix parameter of restore and advancer

### DIFF
--- a/br/pkg/stream/crr/config/config.go
+++ b/br/pkg/stream/crr/config/config.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	flagTaskName                = "task-name"
-	flagStateStorageSubDir      = "state-storage-sub-dir"
 	flagRetryInterval           = "retry-interval"
 	flagCalcPollInterval        = "calc.poll-interval"
 	flagCalcMetaReadConcurrency = "calc.meta-read-concurrency"
@@ -30,7 +29,6 @@ const (
 
 type Config struct {
 	service.Config
-	StateStorageSubDir string
 }
 
 func DefaultConfig() Config {
@@ -48,11 +46,6 @@ func DefaultConfig() Config {
 func DefineFlags(flags *pflag.FlagSet) {
 	defaults := DefaultConfig()
 	flags.String(flagTaskName, "", "The name of the upstream log backup task.")
-	flags.String(
-		flagStateStorageSubDir,
-		defaults.StateStorageSubDir,
-		"The relative subdirectory under the selected replication status storage used to persist CRR resume state.",
-	)
 	flags.Duration(
 		flagRetryInterval,
 		defaults.RetryInterval,
@@ -75,10 +68,6 @@ func (cfg *Config) Parse(flags *pflag.FlagSet) error {
 
 	var err error
 	cfg.TaskName, err = flags.GetString(flagTaskName)
-	if err != nil {
-		return err
-	}
-	cfg.StateStorageSubDir, err = flags.GetString(flagStateStorageSubDir)
 	if err != nil {
 		return err
 	}

--- a/br/pkg/stream/crr/config/config_test.go
+++ b/br/pkg/stream/crr/config/config_test.go
@@ -37,7 +37,6 @@ func TestParse(t *testing.T) {
 	crrconfig.DefineFlags(flags)
 	require.NoError(t, flags.Parse([]string{
 		"--task-name", "task",
-		"--state-storage-sub-dir", "state/subdir",
 		"--retry-interval", "7s",
 		"--calc.poll-interval", "3s",
 		"--calc.meta-read-concurrency", "9",
@@ -46,7 +45,6 @@ func TestParse(t *testing.T) {
 	cfg := crrconfig.Config{}
 	require.NoError(t, cfg.Parse(flags))
 	require.Equal(t, "task", cfg.TaskName)
-	require.Equal(t, "state/subdir", cfg.StateStorageSubDir)
 	require.Equal(t, 7*time.Second, cfg.RetryInterval)
 	require.Equal(t, 3*time.Second, cfg.PollInterval)
 	require.Equal(t, 9, cfg.MetaReadConcurrency)

--- a/br/pkg/stream/crr/service/service_test.go
+++ b/br/pkg/stream/crr/service/service_test.go
@@ -583,61 +583,7 @@ func TestStatusStorePreservesFailureStoreCountAndTracksZeroAliveStores(t *testin
 }
 
 func TestGetStatusFileName(t *testing.T) {
-	testCases := []struct {
-		name      string
-		subDir    string
-		expect    string
-		errSubstr string
-	}{
-		{
-			name:   "valid subdir",
-			subDir: "state/subdir",
-			expect: "state/subdir/resume-state.json",
-		},
-		{
-			name:   "leading and trailing slashes",
-			subDir: "/state/subdir/",
-			expect: "state/subdir/resume-state.json",
-		},
-		{
-			name:   "clean dot segments",
-			subDir: "state/./subdir/../subdir2",
-			expect: "state/subdir2/resume-state.json",
-		},
-		{
-			name:      "empty subdir",
-			subDir:    "",
-			errSubstr: "must not be empty",
-		},
-		{
-			name:      "only slash",
-			subDir:    "/",
-			errSubstr: "must not be empty",
-		},
-		{
-			name:      "parent directory",
-			subDir:    "../state",
-			errSubstr: "must stay within selected storage",
-		},
-		{
-			name:      "clean to parent directory",
-			subDir:    "state/../../escape",
-			errSubstr: "must stay within selected storage",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual, err := GetStatusFileName(tc.subDir)
-			if tc.errSubstr != "" {
-				require.Error(t, err)
-				require.ErrorContains(t, err, tc.errSubstr)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tc.expect, actual)
-		})
-	}
+	require.Equal(t, "crr-checkpoint/resume-state.json", GetStatusFileName())
 }
 
 func TestServiceRegisterPanicsOnNilMux(t *testing.T) {

--- a/br/pkg/stream/crr/service/status.go
+++ b/br/pkg/stream/crr/service/status.go
@@ -15,10 +15,7 @@
 package service
 
 import (
-	"fmt"
 	"maps"
-	"path"
-	"strings"
 	"sync"
 	"time"
 
@@ -34,26 +31,12 @@ const (
 	stateStopped  = "stopped"
 
 	phaseIdle = "idle"
+
+	statusFileName = "crr-checkpoint/resume-state.json"
 )
 
-func normalizeStorageSubDir(subDir string) (string, error) {
-	trimmed := strings.Trim(subDir, "/")
-	if trimmed == "" {
-		return "", fmt.Errorf("state storage subdir must not be empty")
-	}
-	cleaned := path.Clean(trimmed)
-	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
-		return "", fmt.Errorf("state storage subdir must stay within selected storage, got %q", subDir)
-	}
-	return cleaned, nil
-}
-
-func GetStatusFileName(subDir string) (string, error) {
-	normalizedSubDir, err := normalizeStorageSubDir(subDir)
-	if err != nil {
-		return "", err
-	}
-	return path.Join(normalizedSubDir, "resume-state.json"), nil
+func GetStatusFileName() string {
+	return statusFileName
 }
 
 // StatusStatistic summarizes the current round's file-related work.

--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -126,7 +126,7 @@ go_test(
     ],
     embed = [":task"],
     flaky = True,
-    shard_count = 45,
+    shard_count = 47,
     deps = [
         "//br/pkg/backup",
         "//br/pkg/config",

--- a/br/pkg/task/operator/BUILD.bazel
+++ b/br/pkg/task/operator/BUILD.bazel
@@ -74,8 +74,10 @@ go_test(
     shard_count = 3,
     deps = [
         "//br/pkg/metautil",
+        "//br/pkg/task",
         "//pkg/objstore",
         "//pkg/objstore/storeapi",
         "@com_github_stretchr_testify//require",
+        "@com_github_spf13_pflag//:pflag",
     ],
 )

--- a/br/pkg/task/operator/config.go
+++ b/br/pkg/task/operator/config.go
@@ -237,8 +237,8 @@ type CRRCheckpointConfig struct {
 func DefineFlagsForCRRCheckpointConfig(flags *pflag.FlagSet) {
 	crrconfig.DefineFlags(flags)
 	flags.String(flagUpstreamStorage, "", "The upstream log backup storage URI.")
-	flags.String(flagDownstreamStorage, "", "The downstream replicated storage URI. Optional when the upstream storage can confirm object sync directly, such as AWS S3.")
-	flags.Bool(flagCheckSyncedFromDownstreamStorage, false, "Check object sync by file existence on downstream storage. Only when this flag is enabled will BR use --downstream-storage to confirm replication success.")
+	flags.String(flagDownstreamStorage, "", "The downstream replicated log backup storage URI.")
+	flags.Bool(flagCheckSyncedFromDownstreamStorage, false, "Check object sync by file existence on downstream storage.")
 }
 
 func (cfg *CRRCheckpointConfig) ParseFromFlags(flags *pflag.FlagSet) error {
@@ -269,6 +269,9 @@ func (cfg *CRRCheckpointConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 	}
 	if cfg.UpstreamStorage == "" {
 		return errors.Annotatef(berrors.ErrInvalidArgument, "missing required flag --%s", flagUpstreamStorage)
+	}
+	if cfg.DownstreamStorage == "" {
+		return errors.Annotatef(berrors.ErrInvalidArgument, "missing required flag --%s", flagDownstreamStorage)
 	}
 	return nil
 }

--- a/br/pkg/task/operator/crr_checkpoint.go
+++ b/br/pkg/task/operator/crr_checkpoint.go
@@ -107,16 +107,7 @@ func NewCRRCheckpointService(
 	if downstreamStorage != nil {
 		resumeStateStorage = downstreamStorage
 	}
-	stateStore, err := buildResumeStateStore(resumeStateStorage, cfg.CRRConfig.StateStorageSubDir)
-	if err != nil {
-		if downstreamStorage != nil {
-			downstreamStorage.Close()
-		}
-		upstreamStorage.Close()
-		closeEtcdClient(etcdCli)
-		mgr.Close()
-		return nil, nil, err
-	}
+	stateStore := buildResumeStateStore(resumeStateStorage)
 	svc, err := service.New(
 		service.Deps{
 			PD:       env,
@@ -192,19 +183,11 @@ type storageResumeStateStore struct {
 
 func buildResumeStateStore(
 	storage storeapi.Storage,
-	subDir string,
-) (service.ResumeStateStore, error) {
-	if subDir == "" {
-		return nil, nil
-	}
-	path, err := service.GetStatusFileName(subDir)
-	if err != nil {
-		return nil, err
-	}
+) service.ResumeStateStore {
 	return &storageResumeStateStore{
 		storage: storage,
-		path:    path,
-	}, nil
+		path:    service.GetStatusFileName(),
+	}
 }
 
 func (s *storageResumeStateStore) LoadState(ctx context.Context) (*service.PersistentState, error) {

--- a/br/pkg/task/operator/crr_checkpoint.go
+++ b/br/pkg/task/operator/crr_checkpoint.go
@@ -49,9 +49,17 @@ func NewCRRCheckpointService(
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := checkCRRUpstreamStorage(ctx, upstreamStorage); err != nil {
+	if err := checkCRRExternalStorage(ctx, upstreamStorage, "upstream"); err != nil {
 		upstreamStorage.Close()
 		return nil, nil, err
+	}
+	_, downstreamStorage, err := task.GetStorage(ctx, cfg.DownstreamStorage, &cfg.Config)
+	if err != nil {
+		upstreamStorage.Close()
+		return nil, nil, err
+	}
+	if err := checkCRRExternalStorage(ctx, downstreamStorage, "downstream"); err != nil {
+		log.Warn("failed to check the downstream storage", zap.Error(err))
 	}
 
 	mgr, err := task.NewMgr(
@@ -67,25 +75,16 @@ func NewCRRCheckpointService(
 	)
 	if err != nil {
 		upstreamStorage.Close()
+		downstreamStorage.Close()
 		return nil, nil, err
 	}
 
 	etcdCli, err := dialEtcdWithCfg(ctx, cfg.Config)
 	if err != nil {
 		upstreamStorage.Close()
+		downstreamStorage.Close()
 		mgr.Close()
 		return nil, nil, err
-	}
-
-	var downstreamStorage storeapi.Storage
-	if cfg.DownstreamStorage != "" {
-		_, downstreamStorage, err = task.GetStorage(ctx, cfg.DownstreamStorage, &cfg.Config)
-		if err != nil {
-			upstreamStorage.Close()
-			closeEtcdClient(etcdCli)
-			mgr.Close()
-			return nil, nil, err
-		}
 	}
 
 	env := streamhelper.CliEnv(mgr.StoreManager, mgr.GetStore(), etcdCli)
@@ -95,19 +94,13 @@ func NewCRRCheckpointService(
 		cfg.CheckSyncedFromDownstreamStorage,
 	)
 	if err != nil {
-		if downstreamStorage != nil {
-			downstreamStorage.Close()
-		}
+		downstreamStorage.Close()
 		upstreamStorage.Close()
 		closeEtcdClient(etcdCli)
 		mgr.Close()
 		return nil, nil, err
 	}
-	resumeStateStorage := upstreamStorage
-	if downstreamStorage != nil {
-		resumeStateStorage = downstreamStorage
-	}
-	stateStore := buildResumeStateStore(resumeStateStorage)
+	stateStore := buildResumeStateStore(downstreamStorage)
 	svc, err := service.New(
 		service.Deps{
 			PD:       env,
@@ -126,9 +119,7 @@ func NewCRRCheckpointService(
 		},
 	)
 	if err != nil {
-		if downstreamStorage != nil {
-			downstreamStorage.Close()
-		}
+		downstreamStorage.Close()
 		upstreamStorage.Close()
 		closeEtcdClient(etcdCli)
 		mgr.Close()
@@ -136,9 +127,7 @@ func NewCRRCheckpointService(
 	}
 
 	cleanup := func() {
-		if downstreamStorage != nil {
-			downstreamStorage.Close()
-		}
+		downstreamStorage.Close()
 		upstreamStorage.Close()
 		closeEtcdClient(etcdCli)
 		mgr.Close()
@@ -146,15 +135,15 @@ func NewCRRCheckpointService(
 	return svc, cleanup, nil
 }
 
-func checkCRRUpstreamStorage(ctx context.Context, storage storeapi.Storage) error {
+func checkCRRExternalStorage(ctx context.Context, storage storeapi.Storage, source string) error {
 	exists, err := storage.FileExists(ctx, metautil.LockFile)
 	if err != nil {
-		return errors.Annotatef(err, "error occurred when checking %s file in upstream storage", metautil.LockFile)
+		return errors.Annotatef(err, "error occurred when checking %s file in %s storage", metautil.LockFile, source)
 	}
 	if !exists {
 		return errors.Annotatef(berrors.ErrInvalidArgument,
-			"upstream storage %s is not a log backup directory because %s does not exist",
-			storage.URI(), metautil.LockFile,
+			"%s storage %s is not a log backup directory because %s does not exist",
+			source, storage.URI(), metautil.LockFile,
 		)
 	}
 	return nil
@@ -172,7 +161,7 @@ func buildObjectSyncChecker(
 		return upstreamChecker, nil
 	}
 	return nil, fmt.Errorf(
-		"upstream storage cannot check object sync; to confirm replication from downstream storage, provide --downstream-storage and enable --check-synced-from-downstream-storage",
+		"upstream storage cannot check object sync; to confirm replication by downstream storage existence, enable --check-synced-from-downstream-storage",
 	)
 }
 

--- a/br/pkg/task/operator/crr_checkpoint_test.go
+++ b/br/pkg/task/operator/crr_checkpoint_test.go
@@ -20,8 +20,10 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/br/pkg/metautil"
+	"github.com/pingcap/tidb/br/pkg/task"
 	"github.com/pingcap/tidb/pkg/objstore"
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,8 +38,19 @@ func (s syncedStorage) FileSynced(context.Context, string) (bool, error) {
 
 func TestNewCRRCheckpointServiceRejectsNonLogBackupUpstream(t *testing.T) {
 	ctx := context.Background()
+	flags := pflag.NewFlagSet("crr-checkpoint", pflag.ContinueOnError)
+	task.DefineCommonFlags(flags)
+	DefineFlagsForCRRCheckpointConfig(flags)
+	require.NoError(t, flags.Set(flagTaskName, "test-task"))
+	require.NoError(t, flags.Set(flagUpstreamStorage, "local://"+filepath.ToSlash(t.TempDir())))
+
+	parseCfg := CRRCheckpointConfig{}
+	err := parseCfg.ParseFromFlags(flags)
+	require.ErrorContains(t, err, "missing required flag --downstream-storage")
+
 	cfg := CRRCheckpointConfig{
-		UpstreamStorage: "local://" + filepath.ToSlash(t.TempDir()),
+		UpstreamStorage:   "local://" + filepath.ToSlash(t.TempDir()),
+		DownstreamStorage: "local://" + filepath.ToSlash(t.TempDir()),
 	}
 	cfg.CRRConfig.TaskName = "test-task"
 
@@ -59,12 +72,21 @@ func TestCheckCRRUpstreamStorage(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "crr-checkpoint/resume-state.json", storageStore.path)
 
-	err = checkCRRUpstreamStorage(ctx, upstream)
+	err = checkCRRExternalStorage(ctx, upstream, "upstream")
 	require.ErrorContains(t, err, "is not a log backup directory")
+	require.ErrorContains(t, err, "upstream storage")
 	require.ErrorContains(t, err, metautil.LockFile)
 
 	require.NoError(t, upstream.WriteFile(ctx, metautil.LockFile, nil))
-	require.NoError(t, checkCRRUpstreamStorage(ctx, upstream))
+	require.NoError(t, checkCRRExternalStorage(ctx, upstream, "upstream"))
+
+	downstream, err := objstore.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(downstream.Close)
+
+	err = checkCRRExternalStorage(ctx, downstream, "downstream")
+	require.ErrorContains(t, err, "is not a log backup directory")
+	require.ErrorContains(t, err, "downstream storage")
 }
 
 func TestBuildObjectSyncChecker(t *testing.T) {

--- a/br/pkg/task/operator/crr_checkpoint_test.go
+++ b/br/pkg/task/operator/crr_checkpoint_test.go
@@ -54,6 +54,11 @@ func TestCheckCRRUpstreamStorage(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(upstream.Close)
 
+	stateStore := buildResumeStateStore(upstream)
+	storageStore, ok := stateStore.(*storageResumeStateStore)
+	require.True(t, ok)
+	require.Equal(t, "crr-checkpoint/resume-state.json", storageStore.path)
+
 	err = checkCRRUpstreamStorage(ctx, upstream)
 	require.ErrorContains(t, err, "is not a log backup directory")
 	require.ErrorContains(t, err, metautil.LockFile)

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -107,8 +107,6 @@ const (
 	// FlagWaitTiFlashReady represents whether wait tiflash replica ready after table restored and checksumed.
 	FlagWaitTiFlashReady = "wait-tiflash-ready"
 
-	// FlagFromReplicationStorage is used for PITR from the replication external storage
-	FlagReplicationStatusSubPrefix = "replication-status-sub-prefix"
 	// FlagRestorePhase is used for the restore phase of PITR
 	FlagRestorePhase = "restore-phase"
 	// FlagStreamStartTS and FlagStreamRestoreTS is used for log restore timestamp range.
@@ -318,11 +316,9 @@ type RestoreConfig struct {
 	RestoreStartTS      uint64                      `json:"-" toml:"-"`
 	tableMappingManager *stream.TableMappingManager `json:"-" toml:"-"`
 
-	// for PITR from the replication external storage
-	ReplicationStatusSubPrefix string `json:"replication-status-sub-prefix" toml:"replication-status-sub-prefix"`
-	RestorePhase               uint64 `json:"restore-phase" toml:"restore-phase"`
-	FromReplicationStorage     bool   `json:"-" toml:"-"`
-	RestoreInPhase             bool   `json:"-" toml:"-"`
+	// for phased PITR restore
+	RestorePhase   uint64 `json:"restore-phase" toml:"restore-phase"`
+	RestoreInPhase bool   `json:"-" toml:"-"`
 
 	// for ebs-based restore
 	FullBackupType      FullBackupType        `json:"full-backup-type" toml:"full-backup-type"`
@@ -387,7 +383,6 @@ func DefineRestoreFlags(flags *pflag.FlagSet) {
 	_ = flags.MarkHidden(flagUseCheckpoint)
 
 	flags.String(flagCheckpointStorage, "", "specify the external storage url where checkpoint data is saved, eg, s3://bucket/path/prefix")
-	flags.String(FlagReplicationStatusSubPrefix, "", "specify the sub prefix of the replication status")
 	flags.Uint64(FlagRestorePhase, 0, "specify the phase of the restore, 1 for full restore, 2 for log restore")
 
 	flags.Bool(FlagWaitTiFlashReady, false, "whether wait tiflash replica ready if tiflash exists")
@@ -543,10 +538,6 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet, skipCommonConfig 
 	if err != nil {
 		return errors.Annotatef(err, "failed to get flag %s", flagAllowPITRFromIncremental)
 	}
-	cfg.ReplicationStatusSubPrefix, err = flags.GetString(FlagReplicationStatusSubPrefix)
-	if err != nil {
-		return errors.Annotatef(err, "failed to get flag %s", FlagReplicationStatusSubPrefix)
-	}
 	cfg.RestorePhase, err = flags.GetUint64(FlagRestorePhase)
 	if err != nil {
 		return errors.Annotatef(err, "failed to get flag %s", FlagRestorePhase)
@@ -560,7 +551,6 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet, skipCommonConfig 
 		return errors.Annotatef(berrors.ErrInvalidArgument, "%v requires %s to be enabled",
 			FlagRestorePhase, flagUseCheckpoint)
 	}
-	cfg.FromReplicationStorage = flags.Changed(FlagReplicationStatusSubPrefix) || len(cfg.ReplicationStatusSubPrefix) > 0
 
 	if flags.Lookup(flagFullBackupType) != nil {
 		// for restore full only
@@ -2776,7 +2766,7 @@ func RunRestoreAbort(c context.Context, g glue.Glue, cmdName string, cfg *Restor
 			if err != nil {
 				return errors.Trace(err)
 			}
-			logInfo, err := getLogInfoFromStorage(ctx, s, cfg.CheckRequirements, cfg.FromReplicationStorage, cfg.ReplicationStatusSubPrefix)
+			logInfo, err := getLogInfoFromStorage(ctx, s, cfg.CheckRequirements)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -90,6 +90,8 @@ const (
 	flagGCSafePointTTS     = "gc-ttl"
 	flagMessage            = "message"
 
+	resumeStateFileName = "crr-checkpoint/resume-state.json"
+
 	truncateLockPath   = "truncating.lock"
 	hintOnTruncateLock = "There might be another truncate task running, or a truncate task that didn't exit properly. " +
 		"You may check the metadata and continue by wait other task finish or manually delete the lock file " + truncateLockPath + " at the external storage."
@@ -1335,7 +1337,7 @@ func RunStreamRestore(
 	if err != nil {
 		return errors.Trace(err)
 	}
-	logInfo, err := getLogInfoFromStorage(ctx, s, cfg.CheckRequirements, cfg.FromReplicationStorage, cfg.ReplicationStatusSubPrefix)
+	logInfo, err := getLogInfoFromStorage(ctx, s, cfg.CheckRequirements)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1965,15 +1967,13 @@ func getLogInfo(
 	if err != nil {
 		return backupLogInfo{}, errors.Trace(err)
 	}
-	return getLogInfoFromStorage(ctx, s, cfg.CheckRequirements, false, "")
+	return getLogInfoFromStorage(ctx, s, cfg.CheckRequirements)
 }
 
 func getLogInfoFromStorage(
 	ctx context.Context,
 	s storeapi.Storage,
 	checkRequirements bool,
-	fromReplicationStorage bool,
-	replicationStatusSubPrefix string,
 ) (backupLogInfo, error) {
 	// logStartTS: Get log start ts from backupmeta file.
 	metaData, err := s.ReadFile(ctx, metautil.MetaFile)
@@ -2006,19 +2006,9 @@ func getLogInfoFromStorage(
 	logMinTS := max(logStartTS, truncateTS)
 
 	// get max global resolved ts from metas.
-	var logMaxTS uint64
-	if fromReplicationStorage {
-		ts, err := getGlobalCheckpointFromReplicationStorage(ctx, s, replicationStatusSubPrefix)
-		if err != nil {
-			return backupLogInfo{}, errors.Trace(err)
-		}
-		logMaxTS = ts
-	} else {
-		ts, err := getGlobalCheckpointFromStorage(ctx, s)
-		if err != nil {
-			return backupLogInfo{}, errors.Trace(err)
-		}
-		logMaxTS = ts
+	logMaxTS, err := getMaxRecoverableCheckpointFromStorage(ctx, s)
+	if err != nil {
+		return backupLogInfo{}, errors.Trace(err)
 	}
 	logMaxTS = max(logMinTS, logMaxTS)
 
@@ -2048,21 +2038,39 @@ func getGlobalCheckpointFromStorage(ctx context.Context, s storeapi.Storage) (ui
 	return globalCheckPointTS, errors.Trace(err)
 }
 
-func getGlobalCheckpointFromReplicationStorage(ctx context.Context, s storeapi.Storage, replicationStatusSubPrefix string) (uint64, error) {
-	// parse the replication status
-	statusFileName, err := service.GetStatusFileName(replicationStatusSubPrefix)
+func getMaxRecoverableCheckpointFromStorage(ctx context.Context, s storeapi.Storage) (uint64, error) {
+	ts, exists, err := getCheckpointFromResumeState(ctx, s)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
-	statusContent, err := s.ReadFile(ctx, statusFileName)
+	if exists {
+		return ts, nil
+	}
+	return getGlobalCheckpointFromStorage(ctx, s)
+}
+
+// PersistentState captures the calculator progress needed to resume after restart.
+type PersistentState struct {
+	LastCheckpoint uint64 `json:"last_checkpoint"`
+}
+
+func getCheckpointFromResumeState(ctx context.Context, s storeapi.Storage) (uint64, bool, error) {
+	exists, err := s.FileExists(ctx, resumeStateFileName)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, false, errors.Trace(err)
+	}
+	if !exists {
+		return 0, false, nil
+	}
+	statusContent, err := s.ReadFile(ctx, resumeStateFileName)
+	if err != nil {
+		return 0, true, errors.Trace(err)
 	}
 	var state service.PersistentState
 	if err := json.Unmarshal(statusContent, &state); err != nil {
-		return 0, fmt.Errorf("decode persisted resume state %s: %w", statusFileName, err)
+		return 0, true, fmt.Errorf("decode persisted resume state %s: %w", resumeStateFileName, err)
 	}
-	return state.LastCheckpoint, nil
+	return state.LastCheckpoint, true, nil
 }
 
 // getFullBackupTS gets the snapshot-ts of full backup

--- a/br/pkg/task/stream_test.go
+++ b/br/pkg/task/stream_test.go
@@ -175,6 +175,51 @@ func TestGetGlobalCheckpointFromStorage(t *testing.T) {
 	require.Equal(t, ts, uint64(99))
 }
 
+func TestGetMaxRecoverableCheckpointFromStoragePrefersResumeState(t *testing.T) {
+	ctx := context.Background()
+	tmpdir := t.TempDir()
+	s, err := objstore.NewLocalStorage(tmpdir)
+	require.Nil(t, err)
+
+	err = fakeCheckpointFiles(ctx, tmpdir, []fakeGlobalCheckPoint{
+		{
+			storeID:          1,
+			globalCheckpoint: 99,
+		},
+	})
+	require.Nil(t, err)
+
+	err = s.WriteFile(ctx, resumeStateFileName, []byte(`{"last_checkpoint":88}`))
+	require.Nil(t, err)
+
+	ts, err := getMaxRecoverableCheckpointFromStorage(ctx, s)
+	require.Nil(t, err)
+	require.Equal(t, uint64(88), ts)
+}
+
+func TestGetMaxRecoverableCheckpointFromStorageFallbackToGlobalCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	tmpdir := t.TempDir()
+	s, err := objstore.NewLocalStorage(tmpdir)
+	require.Nil(t, err)
+
+	err = fakeCheckpointFiles(ctx, tmpdir, []fakeGlobalCheckPoint{
+		{
+			storeID:          1,
+			globalCheckpoint: 98,
+		},
+		{
+			storeID:          2,
+			globalCheckpoint: 99,
+		},
+	})
+	require.Nil(t, err)
+
+	ts, err := getMaxRecoverableCheckpointFromStorage(ctx, s)
+	require.Nil(t, err)
+	require.Equal(t, uint64(99), ts)
+}
+
 func TestGetLogRangeWithFullBackupDir(t *testing.T) {
 	var fullBackupTS uint64 = 123456
 	testDir := t.TempDir()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67416

Problem Summary:
fix the crr prefix to make things simple.
### What changed and how does it work?
remove the crr prefix parameter and fix it.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--wait-tiflash-ready` flag for restore operations
  * Added support for phased restore operations
* **Removals**
  * Removed `--state-storage-sub-dir` and `--replication-status-sub-prefix` configuration flags
* **Improvements**
  * Improved stream/PiTR restore checkpoint recovery by preferring persisted resume progress when available
  * Strengthened CRR checkpoint behavior by validating and requiring downstream storage for restore/checkpoint workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->