### PR TITLE
br: report repair index instead of rebuilding it

### DIFF
--- a/br/pkg/restore/log_client/BUILD.bazel
+++ b/br/pkg/restore/log_client/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/codec",
         "//pkg/util/redact",
+        "//pkg/util/sqlescape",
         "@com_github_docker_go_units//:go-units",
         "@com_github_fatih_color//:color",
         "@com_github_gogo_protobuf//proto",

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -70,6 +70,7 @@ import (
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	tidbutil "github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/sqlescape"
 	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/tikv"
 	kvutil "github.com/tikv/client-go/v2/util"
@@ -1709,6 +1710,7 @@ const (
 	alterTableAddPrimaryFormat     = "ALTER TABLE %%n.%%n ADD PRIMARY KEY (%s) NONCLUSTERED"
 	alterTableAddForeignKeyFormat  = "ALTER TABLE %%n.%%n ADD CONSTRAINT %%n FOREIGN KEY (%s) REFERENCES %%n.%%n (%s)"
 	alterTableDropForeignKeyFormat = "ALTER TABLE %n.%n DROP FOREIGN KEY %n"
+	repairIngestIndexSQLFile       = "add-index.sql"
 )
 
 func (rc *LogClient) generateRepairIngestIndexSQLs(
@@ -1730,7 +1732,11 @@ func (rc *LogClient) generateRepairIngestIndexSQLs(
 			}
 			sqls = checkpointSQLs.SQLs
 			fkSqls = checkpointSQLs.FKSQLs
-			log.Info("load ingest index repair sqls from checkpoint", zap.String("category", "ingest"), zap.Reflect("sqls", sqls))
+			log.Info("load ingest index repair sqls from checkpoint",
+				zap.String("category", "ingest"),
+				zap.Int("index-sql-count", len(sqls)),
+				zap.Int("foreign-key-sql-count", len(fkSqls)),
+				zap.Reflect("sqls", sqls))
 			return sqls, fkSqls, true, nil
 		}
 	}
@@ -1832,6 +1838,10 @@ func (rc *LogClient) generateRepairIngestIndexSQLs(
 	}); err != nil {
 		return sqls, fkSqls, false, errors.Trace(err)
 	}
+	log.Info("generated ingest index repair sqls",
+		zap.String("category", "ingest"),
+		zap.Int("index-sql-count", len(sqls)),
+		zap.Int("foreign-key-sql-count", len(fkSqls)))
 
 	if rc.useCheckpoint && len(sqls) > 0 {
 		if err := logCheckpointMetaManager.SaveCheckpointIngestIndexRepairSQLs(ctx, &checkpoint.CheckpointIngestIndexRepairSQLs{
@@ -1844,12 +1854,61 @@ func (rc *LogClient) generateRepairIngestIndexSQLs(
 	return sqls, fkSqls, false, nil
 }
 
-// RepairIngestIndex drops the indexes from IngestRecorder and re-add them.
+func writeRepairIngestIndexSQLFile(
+	ctx context.Context,
+	storage storeapi.Storage,
+	sqls []checkpoint.CheckpointIngestIndexRepairSQL,
+	fkSqls []checkpoint.CheckpointForeignKeyUpdateSQL,
+) error {
+	if storage == nil {
+		return nil
+	}
+
+	var builder strings.Builder
+	sqlCount := 0
+	builder.WriteString("-- SQLs for rebuilding indexes skipped by PITR restore.\n")
+	builder.WriteString("-- Execute them manually after restore if you need these indexes and foreign keys.\n")
+	for _, sql := range sqls {
+		if sql.IndexRepaired {
+			continue
+		}
+		if err := sqlescape.FormatSQL(&builder, sql.AddSQL, sql.AddArgs...); err != nil {
+			return errors.Trace(err)
+		}
+		builder.WriteString(";\n")
+		sqlCount++
+	}
+	for _, fk := range fkSqls {
+		if fk.ForeignKeyUpdated {
+			continue
+		}
+		if err := sqlescape.FormatSQL(&builder, fk.AddSQL, fk.AddArgs...); err != nil {
+			return errors.Trace(err)
+		}
+		builder.WriteString(";\n")
+		sqlCount++
+	}
+	if sqlCount == 0 {
+		log.Info("no repair ingest index sqls need to be written to external storage")
+		return nil
+	}
+	if err := storage.WriteFile(ctx, repairIngestIndexSQLFile, []byte(builder.String())); err != nil {
+		return errors.Trace(err)
+	}
+	log.Info("write repair ingest index sqls to external storage",
+		zap.String("file", repairIngestIndexSQLFile),
+		zap.Int("sql-count", sqlCount))
+	return nil
+}
+
+// RepairIngestIndex drops the indexes from IngestRecorder and re-adds them,
+// or writes the add-index SQLs to external storage when addIndexSQLStorage is set.
 func (rc *LogClient) RepairIngestIndex(
 	ctx context.Context,
 	ingestRecorder *ingestrec.IngestRecorder,
 	logCheckpointMetaManager checkpoint.LogMetaManagerT,
 	g glue.Glue,
+	addIndexSQLStorage storeapi.Storage,
 ) error {
 	sqls, fkSqls, fromCheckpoint, err := rc.generateRepairIngestIndexSQLs(ctx, ingestRecorder, logCheckpointMetaManager)
 	if err != nil {
@@ -1974,6 +2033,10 @@ func (rc *LogClient) RepairIngestIndex(
 					return errors.Trace(err)
 				}
 			}
+			if addIndexSQLStorage != nil {
+				w.Increment()
+				return nil
+			}
 			failpoint.Inject("failed-before-create-ingest-index", func(v failpoint.Value) {
 				if v != nil && v.(bool) {
 					failpoint.Return(errors.New("failed before create ingest index"))
@@ -1989,6 +2052,12 @@ func (rc *LogClient) RepairIngestIndex(
 	}
 	if err := eg.Wait(); err != nil {
 		return errors.Trace(err)
+	}
+	if addIndexSQLStorage != nil {
+		if err := writeRepairIngestIndexSQLFile(ctx, addIndexSQLStorage, sqls, fkSqls); err != nil {
+			return errors.Trace(err)
+		}
+		return nil
 	}
 	eg, ectx = errgroup.WithContext(ctx)
 	for _, fk := range fkSqls {

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -1735,8 +1735,7 @@ func (rc *LogClient) generateRepairIngestIndexSQLs(
 			log.Info("load ingest index repair sqls from checkpoint",
 				zap.String("category", "ingest"),
 				zap.Int("index-sql-count", len(sqls)),
-				zap.Int("foreign-key-sql-count", len(fkSqls)),
-				zap.Reflect("sqls", sqls))
+				zap.Int("foreign-key-sql-count", len(fkSqls)))
 			return sqls, fkSqls, true, nil
 		}
 	}

--- a/br/pkg/restore/log_client/client_test.go
+++ b/br/pkg/restore/log_client/client_test.go
@@ -2265,7 +2265,7 @@ func TestRepairIngestIndex(t *testing.T) {
 			"test", "repair_index_t1", tableInfo.ID, indexIDi2, "i2", "a",
 			json.RawMessage(fmt.Sprintf("[%d, false, [], false]", indexIDi2)),
 		), false))
-		require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, nil, g))
+		require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, nil, g, nil))
 		infoschema = s.Mock.InfoSchema()
 		table2, err := infoschema.TableByName(ctx, ast.NewCIStr("test"), ast.NewCIStr("repair_index_t1"))
 		require.NoError(t, err)
@@ -2283,6 +2283,106 @@ func TestRepairIngestIndex(t *testing.T) {
 		}
 		require.Equal(t, 2, existsCount)
 	}
+}
+
+func TestRepairIngestIndexOutputAddIndexSQL(t *testing.T) {
+	s := utiltest.CreateRestoreSchemaSuite(t)
+	tk := testkit.NewTestKit(t, s.Mock.Storage)
+	tk.MustExec("CREATE TABLE test.repair_index_export_t(id int, a int, b int, key i1(id), unique key i2(a));")
+	g := gluetidb.New()
+	ctx := context.Background()
+	client := logclient.TEST_NewLogClient(123, 1, 2, 1, s.Mock.Domain, fakeSession{})
+	client.SetUseCheckpoint()
+
+	fakeJob := func(
+		schemaName string,
+		tableName string,
+		tableID int64,
+		indexID int64,
+		indexName string,
+		columnName string,
+		args json.RawMessage,
+	) *model.Job {
+		return &model.Job{
+			Version:    model.JobVersion1,
+			SchemaName: schemaName,
+			TableName:  tableName,
+			TableID:    tableID,
+			Type:       model.ActionAddIndex,
+			State:      model.JobStateSynced,
+			RowCount:   100,
+			RawArgs:    args,
+			ReorgMeta: &model.DDLReorgMeta{
+				ReorgTp: model.ReorgTypeIngest,
+			},
+			BinlogInfo: &model.HistoryInfo{
+				TableInfo: &model.TableInfo{
+					Indices: []*model.IndexInfo{
+						{
+							ID:   indexID,
+							Name: ast.NewCIStr(indexName),
+							Columns: []*model.IndexColumn{{
+								Name: ast.NewCIStr(columnName),
+							}},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	infoSchema := s.Mock.InfoSchema()
+	table, err := infoSchema.TableByName(ctx, ast.NewCIStr("test"), ast.NewCIStr("repair_index_export_t"))
+	require.NoError(t, err)
+	tableInfo := table.Meta()
+	var indexIDi1, indexIDi2 int64
+	for _, indexInfo := range tableInfo.Indices {
+		switch indexInfo.Name.L {
+		case "i1":
+			indexIDi1 = indexInfo.ID
+		case "i2":
+			indexIDi2 = indexInfo.ID
+		}
+	}
+	require.NotZero(t, indexIDi1)
+	require.NotZero(t, indexIDi2)
+
+	ingestRecorder := ingestrec.New()
+	require.NoError(t, ingestRecorder.TryAddJob(fakeJob(
+		"test", "repair_index_export_t", tableInfo.ID, indexIDi1, "i1", "id",
+		json.RawMessage(fmt.Sprintf("[%d, false, [], false]", indexIDi1)),
+	), false))
+	require.NoError(t, ingestRecorder.TryAddJob(fakeJob(
+		"test", "repair_index_export_t", tableInfo.ID, indexIDi2, "i2", "a",
+		json.RawMessage(fmt.Sprintf("[%d, false, [], false]", indexIDi2)),
+	), false))
+
+	checkpointStorage, err := objstore.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+	logStorageMetaManager := checkpoint.NewLogStorageMetaManager(checkpointStorage, nil, 123, "test", 1)
+	sqlStorage, err := objstore.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g, sqlStorage))
+
+	repairSQLs, err := logStorageMetaManager.LoadCheckpointIngestIndexRepairSQLs(ctx)
+	require.NoError(t, err)
+	require.Len(t, repairSQLs.SQLs, 2)
+
+	infoSchema = s.Mock.InfoSchema()
+	table, err = infoSchema.TableByName(ctx, ast.NewCIStr("test"), ast.NewCIStr("repair_index_export_t"))
+	require.NoError(t, err)
+	indexNames := make(map[string]struct{})
+	for _, indexInfo := range table.Meta().Indices {
+		indexNames[indexInfo.Name.L] = struct{}{}
+	}
+	require.NotContains(t, indexNames, "i1")
+	require.NotContains(t, indexNames, "i2")
+
+	data, err := sqlStorage.ReadFile(ctx, "add-index.sql")
+	require.NoError(t, err)
+	sqlText := string(data)
+	require.Contains(t, sqlText, "ALTER TABLE `test`.`repair_index_export_t` ADD INDEX `i1`(`id`) USING BTREE VISIBLE LOCAL;")
+	require.Contains(t, sqlText, "ALTER TABLE `test`.`repair_index_export_t` ADD UNIQUE KEY `i2`(`a`) USING BTREE VISIBLE LOCAL;")
 }
 
 func TestRepairIngestIndexFromCheckpoint(t *testing.T) {
@@ -2355,7 +2455,7 @@ func TestRepairIngestIndexFromCheckpoint(t *testing.T) {
 		},
 	}))
 	ingestRecorder := ingestrec.New()
-	require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, logCheckpointMetaManager, g))
+	require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, logCheckpointMetaManager, g, nil))
 	infoschema = s.Mock.InfoSchema()
 	table2, err := infoschema.TableByName(ctx, ast.NewCIStr("test"), ast.NewCIStr("repair_index_t1"))
 	require.NoError(t, err)
@@ -2445,7 +2545,7 @@ func TestRepairIngestIndexWithForeignKey(t *testing.T) {
 			"test", "parent", parentTableInfo.ID, parentTableIndexI2.ID, "i2", "id",
 			json.RawMessage(fmt.Sprintf("[%d, false, [], false]", parentTableIndexI2.ID)),
 		), false))
-		require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g))
+		require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g, nil))
 		infoSchema = s.Mock.InfoSchema()
 		newChildTableInfo, err := infoSchema.TableInfoByName(ast.NewCIStr("test"), ast.NewCIStr("child"))
 		require.NoError(t, err)
@@ -2482,7 +2582,7 @@ func TestRepairIngestIndexWithForeignKey(t *testing.T) {
 		parentTableIndexI2 := parentTableInfo.Indices[0]
 
 		ingestRecorder := ingestrec.New()
-		require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g))
+		require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g, nil))
 		infoSchema = s.Mock.InfoSchema()
 		newChildTableInfo, err := infoSchema.TableInfoByName(ast.NewCIStr("test"), ast.NewCIStr("child"))
 		require.NoError(t, err)
@@ -2518,21 +2618,21 @@ func TestRepairIngestIndexWithForeignKey(t *testing.T) {
 			"test", "parent", parentTableInfo.ID, parentTableIndexI2.ID, "i2", "id",
 			json.RawMessage(fmt.Sprintf("[%d, false, [], false]", parentTableIndexI2.ID)),
 		), false))
-		require.Error(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g))
+		require.Error(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g, nil))
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/restore/log_client/failed-before-repair-ingest-index"))
 		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/restore/log_client/failed-before-create-ingest-index", `return(true)`))
 		defer func() {
 			failpoint.Disable("github.com/pingcap/tidb/br/pkg/restore/log_client/failed-before-create-ingest-index")
 		}()
-		require.Error(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g))
+		require.Error(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g, nil))
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/restore/log_client/failed-before-create-ingest-index"))
 		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/restore/log_client/failed-after-repair-ingest-index", `return(true)`))
 		defer func() {
 			failpoint.Disable("github.com/pingcap/tidb/br/pkg/restore/log_client/failed-after-repair-ingest-index")
 		}()
-		require.Error(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g))
+		require.Error(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g, nil))
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/restore/log_client/failed-after-repair-ingest-index"))
-		require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g))
+		require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g, nil))
 
 		infoSchema = s.Mock.InfoSchema()
 		newChildTableInfo, err := infoSchema.TableInfoByName(ast.NewCIStr("test"), ast.NewCIStr("child"))

--- a/br/pkg/restore/log_client/client_test.go
+++ b/br/pkg/restore/log_client/client_test.go
@@ -2360,6 +2360,7 @@ func TestRepairIngestIndexOutputAddIndexSQL(t *testing.T) {
 	checkpointStorage, err := objstore.NewLocalStorage(t.TempDir())
 	require.NoError(t, err)
 	logStorageMetaManager := checkpoint.NewLogStorageMetaManager(checkpointStorage, nil, 123, "test", 1)
+	defer logStorageMetaManager.Close()
 	sqlStorage, err := objstore.NewLocalStorage(t.TempDir())
 	require.NoError(t, err)
 	require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, logStorageMetaManager, g, sqlStorage))

--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -126,7 +126,7 @@ go_test(
     ],
     embed = [":task"],
     flaky = True,
-    shard_count = 46,
+    shard_count = 47,
     deps = [
         "//br/pkg/backup",
         "//br/pkg/config",

--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -126,7 +126,7 @@ go_test(
     ],
     embed = [":task"],
     flaky = True,
-    shard_count = 45,
+    shard_count = 46,
     deps = [
         "//br/pkg/backup",
         "//br/pkg/config",
@@ -164,6 +164,7 @@ go_test(
         "@com_github_pingcap_kvproto//pkg/brpb",
         "@com_github_pingcap_kvproto//pkg/encryptionpb",
         "@com_github_pingcap_kvproto//pkg/metapb",
+        "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_pflag//:pflag",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -928,7 +928,7 @@ func ReadBackupMeta(
 // if need to log, return its zap field. Or return a field with hidden value.
 func flagToZapField(f *pflag.Flag) zap.Field {
 	switch f.Name {
-	case flagStorage, FlagStreamFullBackupStorage:
+	case flagStorage, FlagStreamFullBackupStorage, FlagPiTRAddIndexSQLStorage, flagCheckpointStorage:
 		hiddenQuery, err := url.Parse(f.Value.String())
 		if err != nil {
 			return zap.String(f.Name, "<invalid URI>")

--- a/br/pkg/task/common_test.go
+++ b/br/pkg/task/common_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pingcap/tidb/pkg/objstore"
 	"github.com/pingcap/tidb/pkg/objstore/s3like"
 	filter "github.com/pingcap/tidb/pkg/util/table-filter"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 )
@@ -59,6 +60,12 @@ func TestUrlNoQuery(t *testing.T) {
 			expectedValue: "s3://bucket/prefix/",
 		},
 		{
+			inputName:     FlagPiTRAddIndexSQLStorage,
+			expectedName:  "pitr-add-index-sql-storage",
+			inputValue:    "s3://bucket/pitr/add-index?access-key=1&secret-key=2",
+			expectedValue: "s3://bucket/pitr/add-index",
+		},
+		{
 			inputName:     flagFullBackupCipherKey,
 			expectedName:  "crypter.key",
 			inputValue:    "537570657253656372657456616C7565",
@@ -97,6 +104,16 @@ func TestUrlNoQuery(t *testing.T) {
 		}
 		require.Equal(t, tc.expectedValue, field.String, `test-case [%s="%s"]`, tc.expectedName, tc.expectedValue)
 	}
+}
+
+func TestParseStreamRestoreFlagsPiTRAddIndexSQLStorage(t *testing.T) {
+	command := &cobra.Command{}
+	DefineStreamRestoreFlags(command)
+	require.NoError(t, command.Flags().Set(FlagPiTRAddIndexSQLStorage, "local:///tmp/pitr-add-index"))
+
+	cfg := RestoreConfig{}
+	require.NoError(t, cfg.ParseStreamRestoreFlags(command.Flags()))
+	require.Equal(t, "local:///tmp/pitr-add-index", cfg.PiTRAddIndexSQLStorage)
 }
 
 func TestTiDBConfigUnchanged(t *testing.T) {

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -116,6 +116,8 @@ const (
 	FlagStreamRestoreTS = "restored-ts"
 	// FlagStreamFullBackupStorage is used for log restore, represents the full backup storage.
 	FlagStreamFullBackupStorage = "full-backup-storage"
+	// FlagPiTRAddIndexSQLStorage is used for PITR to output add index SQLs instead of rebuilding indexes.
+	FlagPiTRAddIndexSQLStorage = "pitr-add-index-sql-storage"
 	// FlagPiTRBatchCount and FlagPiTRBatchSize are used for restore log with batch method.
 	FlagPiTRBatchCount  = "pitr-batch-count"
 	FlagPiTRBatchSize   = "pitr-batch-size"
@@ -284,6 +286,9 @@ type RestoreConfig struct {
 	// if it is empty, directly take restoring log justly.
 	FullBackupStorage string `json:"full-backup-storage" toml:"full-backup-storage"`
 
+	// PiTRAddIndexSQLStorage is the external storage used to output add index SQLs instead of rebuilding indexes.
+	PiTRAddIndexSQLStorage string `json:"pitr-add-index-sql-storage" toml:"pitr-add-index-sql-storage"`
+
 	// AllowPITRFromIncremental indicates whether this restore should enter a compatibility mode for incremental restore.
 	// In this restore mode, the restore will not perform timestamp rewrite on the incremental data.
 	AllowPITRFromIncremental bool `json:"allow-pitr-from-incremental" toml:"allow-pitr-from-incremental"`
@@ -409,6 +414,8 @@ func DefineStreamRestoreFlags(command *cobra.Command) {
 		"support TSO or datetime, e.g. '400036290571534337' or '2018-05-11 01:42:23+0800'")
 	command.Flags().String(FlagStreamFullBackupStorage, "", "specify the backup full storage. "+
 		"fill it if want restore full backup before restore log.")
+	command.Flags().String(FlagPiTRAddIndexSQLStorage, "", "specify the external storage url where PITR add index SQLs are saved. "+
+		"When set, PITR drops incomplete indexes but does not rebuild them automatically; the SQLs are written to add-index.sql under this storage.")
 	command.Flags().Uint32(FlagPiTRBatchCount, defaultPiTRBatchCount, "specify the batch count to restore log.")
 	command.Flags().Uint32(FlagPiTRBatchSize, defaultPiTRBatchSize, "specify the batch size to retore log.")
 	command.Flags().Uint32(FlagPiTRConcurrency, defaultPiTRConcurrency, "specify the concurrency to restore log.")
@@ -435,6 +442,9 @@ func (cfg *RestoreConfig) ParseStreamRestoreFlags(flags *pflag.FlagSet) error {
 	cfg.IsRestoredTSUserSpecified = flags.Changed(FlagStreamRestoreTS)
 
 	if cfg.FullBackupStorage, err = flags.GetString(FlagStreamFullBackupStorage); err != nil {
+		return errors.Trace(err)
+	}
+	if cfg.PiTRAddIndexSQLStorage, err = flags.GetString(FlagPiTRAddIndexSQLStorage); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1339,6 +1339,14 @@ func RunStreamRestore(
 	if err != nil {
 		return errors.Trace(err)
 	}
+	// index ingestion is not captured by regular log backup, so we need to manually ingest again
+	var addIndexSQLStorage storeapi.Storage
+	if shouldOpenPiTRAddIndexSQLStorage(cfg) {
+		_, addIndexSQLStorage, err = GetStorage(ctx, cfg.PiTRAddIndexSQLStorage, &cfg.Config)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
 
 	// if not set by user, restore to the max TS available
 	if cfg.RestoreTS == 0 {
@@ -1476,6 +1484,7 @@ func RunStreamRestore(
 		tableMappingManager: metaInfoProcessor.GetTableMappingManager(),
 		logClient:           logClient,
 		ddlFiles:            ddlFiles,
+		addIndexSQLStorage:  addIndexSQLStorage,
 	}
 	if err := restoreStream(ctx, mgr, g, logRestoreConfig); err != nil {
 		return errors.Trace(err)
@@ -1489,6 +1498,11 @@ type LogRestoreConfig struct {
 	tableMappingManager *stream.TableMappingManager
 	logClient           *logclient.LogClient
 	ddlFiles            []logclient.Log
+	addIndexSQLStorage  storeapi.Storage
+}
+
+func shouldOpenPiTRAddIndexSQLStorage(cfg *RestoreConfig) bool {
+	return len(cfg.PiTRAddIndexSQLStorage) > 0 && cfg.RestorePhase != 1
 }
 
 // restoreStream starts the log restore
@@ -1826,15 +1840,7 @@ func restoreStream(
 		return errors.Annotate(err, "failed to insert rows into gc_delete_range")
 	}
 
-	// index ingestion is not captured by regular log backup, so we need to manually ingest again
-	var addIndexSQLStorage storeapi.Storage
-	if len(cfg.PiTRAddIndexSQLStorage) > 0 {
-		_, addIndexSQLStorage, err = GetStorage(ctx, cfg.PiTRAddIndexSQLStorage, &cfg.Config)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	if err = client.RepairIngestIndex(ctx, ingestRecorder, cfg.logCheckpointMetaManager, g, addIndexSQLStorage); err != nil {
+	if err = client.RepairIngestIndex(ctx, ingestRecorder, cfg.logCheckpointMetaManager, g, cfg.addIndexSQLStorage); err != nil {
 		return errors.Annotate(err, "failed to repair ingest index")
 	}
 

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1827,7 +1827,14 @@ func restoreStream(
 	}
 
 	// index ingestion is not captured by regular log backup, so we need to manually ingest again
-	if err = client.RepairIngestIndex(ctx, ingestRecorder, cfg.logCheckpointMetaManager, g); err != nil {
+	var addIndexSQLStorage storeapi.Storage
+	if len(cfg.PiTRAddIndexSQLStorage) > 0 {
+		_, addIndexSQLStorage, err = GetStorage(ctx, cfg.PiTRAddIndexSQLStorage, &cfg.Config)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if err = client.RepairIngestIndex(ctx, ingestRecorder, cfg.logCheckpointMetaManager, g, addIndexSQLStorage); err != nil {
 		return errors.Annotate(err, "failed to repair ingest index")
 	}
 

--- a/br/pkg/task/stream_test.go
+++ b/br/pkg/task/stream_test.go
@@ -42,6 +42,49 @@ func TestShiftTS(t *testing.T) {
 	require.Equal(t, delta, streamShiftDuration)
 }
 
+func TestShouldOpenPiTRAddIndexSQLStorage(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  RestoreConfig
+		want bool
+	}{
+		{
+			name: "empty storage",
+			cfg:  RestoreConfig{},
+			want: false,
+		},
+		{
+			name: "full flow opens storage",
+			cfg: RestoreConfig{
+				PiTRAddIndexSQLStorage: "local:///tmp/pitr-add-index",
+			},
+			want: true,
+		},
+		{
+			name: "phase 1 does not open storage",
+			cfg: RestoreConfig{
+				PiTRAddIndexSQLStorage: "local:///tmp/pitr-add-index",
+				RestorePhase:           1,
+			},
+			want: false,
+		},
+		{
+			name: "phase 2 opens storage",
+			cfg: RestoreConfig{
+				PiTRAddIndexSQLStorage: "local:///tmp/pitr-add-index",
+				RestorePhase:           2,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldOpenPiTRAddIndexSQLStorage(&tt.cfg))
+		})
+	}
+}
+
 func TestCheckLogRange(t *testing.T) {
 	cases := []struct {
 		restoreFrom uint64


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69313

Problem Summary:
If there are too many indexes to be repaired, the RTO will be affected much.
### What changed and how does it work?
BR provides a new parameter pitr-add-index-sql-storage to output the repair SQL.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--pitr-add-index-sql-storage` to point-in-time recovery, generating SQL to rebuild skipped indexes/foreign keys into external storage (e.g., `add-index.sql`) instead of running those repairs automatically.

* **Behavior Updates**
  * Improved restore progress and checkpoint logging with clearer structured counts for generated index/foreign-key SQL items.

* **Tests**
  * Updated ingest-index repair tests and added coverage for correct SQL output in checkpoint mode, including additional failure-stage checks.
  * Added unit tests for the new flag parsing and restore-phase gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->