### PR TITLE
deps: bump client-go for RegionNotFound fix

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -7246,13 +7246,13 @@ def go_deps():
         build_tags = ["intest"],
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sha256 = "73c18ad4202fcff9162e420356f47b0033acc78f685fe5d85ae96ab2bedcfb7d",
-        strip_prefix = "github.com/tikv/client-go/v2@v2.0.8-0.20260610031342-e999c1f9c7c3",
+        sha256 = "02fee4921f004ad072221f634c7b245226ded1807401affa0921358e95553c6f",
+        strip_prefix = "github.com/tikv/client-go/v2@v2.0.8-0.20260615130046-a2b634d170d9",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260610031342-e999c1f9c7c3.zip",
-            "http://ats.apps.svc/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260610031342-e999c1f9c7c3.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260610031342-e999c1f9c7c3.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260610031342-e999c1f9c7c3.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260615130046-a2b634d170d9.zip",
+            "http://ats.apps.svc/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260615130046-a2b634d170d9.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260615130046-a2b634d170d9.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20260615130046-a2b634d170d9.zip",
         ],
     )
     go_repository(

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -641,8 +641,8 @@ func TestCheckPointLagged(t *testing.T) {
 	c.advanceClusterTimeBy(3 * time.Minute)
 	require.ErrorContains(t, adv.OnTick(ctx), "lagged too large")
 	// after some times, the isPaused will be set and ticks are skipped
-	require.Eventually(t, func() bool {
-		return assert.NoError(t, adv.OnTick(ctx))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, adv.OnTick(ctx))
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
@@ -665,18 +665,20 @@ func TestCheckPointResume(t *testing.T) {
 	require.NoError(t, adv.OnTick(ctx))
 	c.advanceClusterTimeBy(2 * time.Minute)
 	require.ErrorContains(t, adv.OnTick(ctx), "lagged too large")
-	require.Eventually(t, func() bool {
-		return assert.NoError(t, adv.OnTick(ctx))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, adv.OnTick(ctx))
 	}, 5*time.Second, 100*time.Millisecond)
 	//now the checkpoint issue is fixed and resumed
 	c.advanceCheckpointBy(1 * time.Minute)
 	env.ResumeTask(ctx)
-	require.Eventually(t, func() bool {
-		return assert.NoError(t, adv.OnTick(ctx))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, adv.OnTick(ctx))
 	}, 5*time.Second, 100*time.Millisecond)
 	//with time passed, the checkpoint will exceed the limit again
 	c.advanceClusterTimeBy(2 * time.Minute)
-	require.ErrorContains(t, adv.OnTick(ctx), "lagged too large")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ErrorContains(c, adv.OnTick(ctx), "lagged too large")
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
 func TestUnregisterAfterPause(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tdakkota/asciicheck v0.2.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.8-0.20260610031342-e999c1f9c7c3
+	github.com/tikv/client-go/v2 v2.0.8-0.20260615130046-a2b634d170d9
 	github.com/tikv/pd/client v0.0.0-20260609141937-b01426f6b08b
 	github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a
 	github.com/twmb/murmur3 v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -811,8 +811,8 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJf
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW93SG+q0F8KI+yFrcIDT4c/RNoc4=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
-github.com/tikv/client-go/v2 v2.0.8-0.20260610031342-e999c1f9c7c3 h1:NRSdcA2eUgZpxMkjl38+QCKfTPObyHd01mJfC0BtGdw=
-github.com/tikv/client-go/v2 v2.0.8-0.20260610031342-e999c1f9c7c3/go.mod h1:YPzsPK+ddC0f0f2WHNfLJb5qM/glF1XSR/HUQvuS4yA=
+github.com/tikv/client-go/v2 v2.0.8-0.20260615130046-a2b634d170d9 h1:QqAqswvU8jg2wN0Jg45KOymElrz09aAP/1wZft41NXI=
+github.com/tikv/client-go/v2 v2.0.8-0.20260615130046-a2b634d170d9/go.mod h1:YPzsPK+ddC0f0f2WHNfLJb5qM/glF1XSR/HUQvuS4yA=
 github.com/tikv/pd/client v0.0.0-20260609141937-b01426f6b08b h1:F5B0hA1WnmrOXP+ix1j17mjIl6XWnVr9GWJW/H9Ip6Q=
 github.com/tikv/pd/client v0.0.0-20260609141937-b01426f6b08b/go.mod h1:KtMhV0wfNF4KGgeQSRacPAXVqjAKuLtqAaHEHhUhhUc=
 github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a h1:A6uKudFIfAEpoPdaal3aSqGxBzLyU8TqyXImLwo6dIo=

--- a/pkg/executor/test/simpletest/BUILD.bazel
+++ b/pkg/executor/test/simpletest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 13,
+    shard_count = 14,
     deps = [
         "//pkg/config",
         "//pkg/errno",

--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -261,6 +261,7 @@ go_test(
         "preprocess_test.go",
         "rule_generate_column_substitute_test.go",
         "rule_join_reorder_dp_test.go",
+        "rule_join_reorder_greedy_test.go",
         "runtime_filter_generator_test.go",
         "stats_test.go",
         "stringer_test.go",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69197, ref https://github.com/tikv/client-go/issues/1892

Problem Summary:

TiDB release-8.5 needs the tikv/client-go tidb-8.5 backport for tikv/client-go#1916 / #2004. The fix hard-invalidates stale Region cache entries on RegionNotFound while still allowing the current request to retry on the leader.

### What changed and how does it work?

Bump `github.com/tikv/client-go/v2` to `v2.0.8-0.20260615130046-a2b634d170d9`, which includes tikv/client-go#2004.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands run:

```sh
go test -tags intest ./pkg/kv
go test -tags intest ./pkg/store/copr -run '^$'
make bazel_prepare
make bazel_mirror_upload
```

Note: `make bazel_prepare` and `make bazel_mirror_upload` were run on the internal machine `root@10.2.12.124`; the new client-go module zip was verified from `bazel-cache.pingcap.net`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that stale Region cache entries could continue to be used after RegionNotFound errors.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the TiKV client-go dependency to the latest pinned revision.
* **Tests**
  * Increased the sharding level for a simple executor test to improve coverage.
  * Expanded planner core test coverage by adding a new greedy rule join reorder test.
  * Improved checkpoint-related test assertions to capture failures more clearly while preserving the same timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

