### PR TITLE
test: stabilize flaky TestRcWaitTSInSlowLog

### DIFF
--- a/pkg/sessiontxn/txn_rc_tso_optimize_test.go
+++ b/pkg/sessiontxn/txn_rc_tso_optimize_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/expression"
@@ -26,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessiontxn/isolation"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/oracle"
 )
 
 func TestRcTSOCmdCountForPrepareExecuteNormal(t *testing.T) {
@@ -786,6 +788,7 @@ func TestConflictErrorsUseRcWriteCheckTs(t *testing.T) {
 
 func TestRcWaitTSInSlowLog(t *testing.T) {
 	store := testkit.CreateMockStore(t)
+	setOracleFutureDelay(t, store, time.Millisecond)
 	tk := testkit.NewTestKit(t, store)
 
 	tk.MustExec("set global transaction_isolation = 'READ-COMMITTED'")
@@ -802,13 +805,49 @@ func TestRcWaitTSInSlowLog(t *testing.T) {
 	sctx.SetValue(sessiontxn.TsoRequestCount, 0)
 
 	tk.MustExec("begin pessimistic")
-	waitTs1 := sctx.GetSessionVars().DurationWaitTS
 	tk.MustExec("update t1 set id3 = id3 + 10 where id1 = 1")
-	waitTs2 := sctx.GetSessionVars().DurationWaitTS
+	pointUpdateWaitTS := sctx.GetSessionVars().DurationWaitTS
 	tk.MustExec("update t1 set id3 = id3 + 10 where id1 > 3 and id1 < 6")
-	waitTs3 := sctx.GetSessionVars().DurationWaitTS
+	rangeUpdateWaitTS := sctx.GetSessionVars().DurationWaitTS
 	tk.MustExec("commit")
-	require.NotEqual(t, waitTs1, waitTs2)
-	require.NotEqual(t, waitTs1, waitTs2)
-	require.NotEqual(t, waitTs2, waitTs3)
+	require.Greater(t, pointUpdateWaitTS, time.Duration(0))
+	require.Greater(t, rangeUpdateWaitTS, time.Duration(0))
+}
+
+type oracleSetter interface {
+	GetOracle() oracle.Oracle
+	SetOracle(oracle.Oracle)
+}
+
+func setOracleFutureDelay(t *testing.T, store any, delay time.Duration) {
+	storage, ok := store.(oracleSetter)
+	require.True(t, ok)
+	originalOracle := storage.GetOracle()
+	storage.SetOracle(delayedOracle{Oracle: originalOracle, delay: delay})
+	t.Cleanup(func() {
+		storage.SetOracle(originalOracle)
+	})
+}
+
+type delayedOracle struct {
+	oracle.Oracle
+	delay time.Duration
+}
+
+func (o delayedOracle) GetTimestampAsync(ctx context.Context, opt *oracle.Option) oracle.Future {
+	return delayedOracleFuture{Future: o.Oracle.GetTimestampAsync(ctx, opt), delay: o.delay}
+}
+
+func (o delayedOracle) GetLowResolutionTimestampAsync(ctx context.Context, opt *oracle.Option) oracle.Future {
+	return delayedOracleFuture{Future: o.Oracle.GetLowResolutionTimestampAsync(ctx, opt), delay: o.delay}
+}
+
+type delayedOracleFuture struct {
+	oracle.Future
+	delay time.Duration
+}
+
+func (f delayedOracleFuture) Wait() (uint64, error) {
+	time.Sleep(f.delay)
+	return f.Future.Wait()
 }

--- a/pkg/sessiontxn/txn_rc_tso_optimize_test.go
+++ b/pkg/sessiontxn/txn_rc_tso_optimize_test.go
@@ -788,7 +788,7 @@ func TestConflictErrorsUseRcWriteCheckTs(t *testing.T) {
 
 func TestRcWaitTSInSlowLog(t *testing.T) {
 	store := testkit.CreateMockStore(t)
-	setOracleFutureDelay(t, store, time.Millisecond)
+	oracleWithDelay := setOracleFutureDelay(t, store, time.Millisecond)
 	tk := testkit.NewTestKit(t, store)
 
 	tk.MustExec("set global transaction_isolation = 'READ-COMMITTED'")
@@ -807,11 +807,13 @@ func TestRcWaitTSInSlowLog(t *testing.T) {
 	tk.MustExec("begin pessimistic")
 	tk.MustExec("update t1 set id3 = id3 + 10 where id1 = 1")
 	pointUpdateWaitTS := sctx.GetSessionVars().DurationWaitTS
+	secondDelay := pointUpdateWaitTS + time.Millisecond
+	oracleWithDelay.delay = secondDelay
 	tk.MustExec("update t1 set id3 = id3 + 10 where id1 > 3 and id1 < 6")
 	rangeUpdateWaitTS := sctx.GetSessionVars().DurationWaitTS
 	tk.MustExec("commit")
 	require.Greater(t, pointUpdateWaitTS, time.Duration(0))
-	require.Greater(t, rangeUpdateWaitTS, time.Duration(0))
+	require.GreaterOrEqual(t, rangeUpdateWaitTS, secondDelay)
 }
 
 type oracleSetter interface {
@@ -819,14 +821,16 @@ type oracleSetter interface {
 	SetOracle(oracle.Oracle)
 }
 
-func setOracleFutureDelay(t *testing.T, store any, delay time.Duration) {
+func setOracleFutureDelay(t *testing.T, store any, delay time.Duration) *delayedOracle {
 	storage, ok := store.(oracleSetter)
 	require.True(t, ok)
 	originalOracle := storage.GetOracle()
-	storage.SetOracle(delayedOracle{Oracle: originalOracle, delay: delay})
+	oracleWithDelay := &delayedOracle{Oracle: originalOracle, delay: delay}
+	storage.SetOracle(oracleWithDelay)
 	t.Cleanup(func() {
 		storage.SetOracle(originalOracle)
 	})
+	return oracleWithDelay
 }
 
 type delayedOracle struct {

--- a/pkg/sessiontxn/txn_rc_tso_optimize_test.go
+++ b/pkg/sessiontxn/txn_rc_tso_optimize_test.go
@@ -805,6 +805,7 @@ func TestRcWaitTSInSlowLog(t *testing.T) {
 	sctx.SetValue(sessiontxn.TsoRequestCount, 0)
 
 	tk.MustExec("begin pessimistic")
+	sctx.GetSessionVars().DurationWaitTS = 0
 	tk.MustExec("update t1 set id3 = id3 + 10 where id1 = 1")
 	pointUpdateWaitTS := sctx.GetSessionVars().DurationWaitTS
 	secondDelay := pointUpdateWaitTS + time.Millisecond
@@ -812,7 +813,7 @@ func TestRcWaitTSInSlowLog(t *testing.T) {
 	tk.MustExec("update t1 set id3 = id3 + 10 where id1 > 3 and id1 < 6")
 	rangeUpdateWaitTS := sctx.GetSessionVars().DurationWaitTS
 	tk.MustExec("commit")
-	require.Greater(t, pointUpdateWaitTS, time.Duration(0))
+	require.Greater(t, pointUpdateWaitTS, time.Millisecond)
 	require.GreaterOrEqual(t, rangeUpdateWaitTS, secondDelay)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69025

Problem Summary:
Flaky test `TestRcWaitTSInSlowLog` in `pkg/sessiontxn` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The test used unstable relative duration inequality to prove slow-log wait accounting, but the valid contract is that each waited statement records a positive wait.

#### Fix

A delayed test oracle makes the wait observable, and positive assertions check the intended behavior without depending on scheduler timing.

#### Verification

Spec:
- target: `pkg/sessiontxn :: TestRcWaitTSInSlowLog`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: failed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky_exact passed.
failpoint_target passed.

Gate checklist:
- target_flaky_exact: PASS
- failpoint_target: PASS
- raw_package_runtime: SKIPPED
- build: BLOCKED
- lint: BLOCKED
- bazel_prepare: BLOCKED

Commands:
- `go test -json -tags=intest,deadlock ./pkg/sessiontxn -run '^TestRcWaitTSInSlowLog$' -count=1`
- `./tools/check/failpoint-go-test.sh pkg/sessiontxn -run '^TestRcWaitTSInSlowLog$' -count=1`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #69025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for timestamp wait-time reporting in slow logs.
  * Improved validation of wait durations across point and range updates under delayed timestamp responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->