### PR TITLE
test: stabilize flaky TestGCWithPendingTxn

### DIFF
--- a/pkg/store/gcworker/gc_worker_test.go
+++ b/pkg/store/gcworker/gc_worker_test.go
@@ -2106,16 +2106,19 @@ func TestGCWithPendingTxn(t *testing.T) {
 	err = txn.LockKeys(ctx, lockCtx, k1)
 	require.NoError(t, err)
 
-	// Prepare to run gc with txn's startTS as the safepoint ts.
-	spkv := s.tikvStore.GetSafePointKV()
-	err = spkv.Put(fmt.Sprintf("%s/%s", infosync.ServerMinStartTSPath, "a"), strconv.FormatUint(txn.StartTS(), 10))
+	// Prepare to run GC with txn's startTS as the txn safe point.
+	gcStatesCli := s.pdClient.GetGCStatesClient(uint32(s.store.GetCodec().GetKeyspaceID()))
+	_, err = gcStatesCli.SetGCBarrier(ctx, "gcworker-test-pending-txn", txn.StartTS(), gc.TTLNeverExpire)
 	require.NoError(t, err)
-	//s.mustSetTiDBServiceSafePoint(t, txn.StartTS(), txn.StartTS())
+	t.Cleanup(func() {
+		_, err := gcStatesCli.DeleteGCBarrier(context.Background(), "gcworker-test-pending-txn")
+		require.NoError(t, err)
+	})
 	veryLong := gcDefaultLifeTime * 100
 	err = s.gcWorker.saveTime(gcLastRunTimeKey, oracle.GetTimeFromTS(s.mustAllocTs(t)).Add(-veryLong))
 	require.NoError(t, err)
 	s.gcWorker.lastFinish = time.Now().Add(-veryLong)
-	s.oracle.AddOffset(time.Minute * 10)
+	s.oracle.AddOffset(gcDefaultLifeTime + time.Minute)
 	err = s.gcWorker.saveValueToSysTable(gcEnableKey, booleanTrue)
 	require.NoError(t, err)
 
@@ -2131,12 +2134,10 @@ func TestGCWithPendingTxn(t *testing.T) {
 		err = errors.New("receive from s.gcWorker.done timeout")
 	}
 	require.NoError(t, err)
+	require.Equal(t, txn.StartTS(), s.loadTxnSafePoint(t))
 
 	err = txn.Commit(ctx)
-	// TODO: The mock implementation of PD doesn't put the data in the etcd or `SafePointKV`, making this test not
-	//   working for now. We need to fix this test after further refactor.
-	// require.NoError(t, err)
-	require.Error(t, err)
+	require.NoError(t, err)
 }
 
 func TestGCWithPendingTxn2(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69000

Problem Summary:
Flaky test `TestGCWithPendingTxn` in `pkg/store/gcworker` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Stale test setup used legacy SafePointKV and asserted a mock-artifact commit error instead of the GC barrier contract.

#### Fix

`SetGCBarrier` is the current mock PD API for pinning txn safe point at a pending txn, preserving the original GC safety intent.

#### Verification

Spec:
- target: `pkg/store/gcworker :: TestGCWithPendingTxn`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
build passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package_raw: SKIPPED
- build: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/store/gcworker -run '^TestGCWithPendingTxn$' -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #69000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced garbage collection test to use realistic safe-point barrier behavior, improving test reliability and production scenario coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->