### PR TITLE
test: stabilize flaky TestIntegrationCopCache

### DIFF
--- a/pkg/executor/copr_cache_test.go
+++ b/pkg/executor/copr_cache_test.go
@@ -18,9 +18,12 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
-	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/coprocessor"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -30,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/testutils"
 	"github.com/tikv/client-go/v2/tikv"
+	"github.com/tikv/client-go/v2/tikvrpc"
 )
 
 func TestIntegrationCopCache(t *testing.T) {
@@ -37,7 +41,10 @@ func TestIntegrationCopCache(t *testing.T) {
 	config.StoreGlobalConfig(config.NewConfig())
 	defer config.StoreGlobalConfig(originConfig)
 
-	cli := &testkit.RegionProperityClient{}
+	cli := &copCacheTestClient{
+		RegionProperityClient: &testkit.RegionProperityClient{},
+		cacheVersion:          123,
+	}
 	hijackClient := func(c tikv.Client) tikv.Client {
 		cli.Client = c
 		return cli
@@ -66,11 +73,7 @@ func TestIntegrationCopCache(t *testing.T) {
 	}
 	cluster.SplitKeys(tableStart, tableStartPrefixNext, 6)
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/cophandler/mockCopCacheInUnistore", `return(123)`))
-	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/cophandler/mockCopCacheInUnistore"))
-	}()
-
+	cli.enableCopCacheMock.Store(true)
 	rows := tk.MustQuery("explain analyze select * from t where t.a < 10").Rows()
 	require.Equal(t, "9", rows[0][2])
 	require.Contains(t, rows[0][5], "cop_task: {num: 5")
@@ -86,10 +89,58 @@ func TestIntegrationCopCache(t *testing.T) {
 	require.Greater(t, hitRatio, float64(0))
 
 	// Test for cop cache disabled.
+	cli.enableCopCacheMock.Store(false)
 	cfg := config.NewConfig()
 	cfg.TiKVClient.CoprCache.CapacityMB = 0
 	config.StoreGlobalConfig(cfg)
 	rows = tk.MustQuery("explain analyze select * from t where t.a < 10").Rows()
 	require.Equal(t, "9", rows[0][2])
 	require.Contains(t, rows[0][5], "copr_cache: disabled")
+}
+
+type copCacheTestClient struct {
+	*testkit.RegionProperityClient
+	cacheVersion       uint64
+	enableCopCacheMock atomic.Bool
+}
+
+func (c *copCacheTestClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
+	if req.Type != tikvrpc.CmdCop {
+		return c.RegionProperityClient.SendRequest(ctx, addr, req, timeout)
+	}
+
+	copReq := req.Cop()
+	if !c.enableCopCacheMock.Load() || copReq == nil || !copReq.IsCacheEnabled {
+		return c.RegionProperityClient.SendRequest(ctx, addr, req, timeout)
+	}
+	if copReq.CacheIfMatchVersion == c.cacheVersion {
+		return &tikvrpc.Response{Resp: &coprocessor.Response{
+			IsCacheHit:       true,
+			CacheLastVersion: c.cacheVersion,
+		}}, nil
+	}
+
+	resp, err := c.RegionProperityClient.SendRequest(ctx, addr, req, timeout)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	copResp, ok := resp.Resp.(*coprocessor.Response)
+	if !ok {
+		return resp, err
+	}
+	// Keep the cop-cache behavior local to this test instead of depending on
+	// source-rewritten failpoints in the mock store.
+	copResp.CanBeCached = true
+	copResp.CacheLastVersion = c.cacheVersion
+	if copResp.ExecDetailsV2 != nil {
+		if copResp.ExecDetailsV2.TimeDetailV2 == nil {
+			copResp.ExecDetailsV2.TimeDetailV2 = &kvrpcpb.TimeDetailV2{}
+		}
+		copResp.ExecDetailsV2.TimeDetailV2.ProcessWallTimeNs = uint64((500 * time.Millisecond).Nanoseconds())
+	}
+	if copResp.ExecDetails == nil {
+		copResp.ExecDetails = &kvrpcpb.ExecDetails{}
+	}
+	copResp.ExecDetails.TimeDetail = &kvrpcpb.TimeDetail{ProcessWallTimeMs: 500}
+	return resp, err
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68940

Problem Summary:
Flaky test `TestIntegrationCopCache` in `pkg/executor` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TestIntegrationCopCache relied on external failpoint-rewritten cop-cache responses instead of owning its cache response setup.

#### Fix

The scoped test client supplies cacheable/cache-hit responses directly for this test while leaving product code unchanged.

#### Verification

Spec:
- target: `pkg/executor :: TestIntegrationCopCache`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: failed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky_raw passed.

Gate checklist:
- target_flaky_raw: PASS
- failpoint_target: SKIPPED
- package_raw: SKIPPED
- bazel_prepare: FAIL
- build: BLOCKED
- lint: BLOCKED

Commands:
- `go test -json -tags=intest,deadlock ./pkg/executor -run '^TestIntegrationCopCache$' -count=1`
- `make bazel_prepare`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68940

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cop-cache integration test reliability and determinism for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->