### PR TITLE
variable: allow max_execution_time for DML by switch

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -677,11 +677,11 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		if a.Ctx.GetSessionVars().StmtCtx.StmtType == "" {
 			a.Ctx.GetSessionVars().StmtCtx.StmtType = stmtctx.GetStmtLabel(ctx, a.StmtNode)
 		}
-		// Since maxExecutionTime is used only for SELECT statements, here we limit its scope.
-		if !a.Ctx.GetSessionVars().StmtCtx.InSelectStmt {
-			maxExecutionTime = 0
-		}
 		pi.SetProcessInfo(sql, execStartTime, cmd, maxExecutionTime)
+	}
+	if err = checkMaxExecutionTimeExceeded(sctx); err != nil {
+		terror.Log(exec.Close(e))
+		return nil, err
 	}
 
 	breakpoint.Inject(a.Ctx, sessiontxn.BreakPointBeforeExecutorFirstRun)

--- a/pkg/executor/select.go
+++ b/pkg/executor/select.go
@@ -346,11 +346,11 @@ func newLockCtx(sctx sessionctx.Context, lockWaitTime int64, numKeys int, inShar
 	lockCtx.LockExpired = &seVars.TxnCtx.LockExpire
 	lockCtx.InShareMode = inSharedMode
 
-	// Set max_execution_time deadline for SELECT statements
-	maxExectionTime := seVars.GetMaxExecutionTime()
-	if maxExectionTime > 0 {
+	// Set max_execution_time deadline when it applies to the current statement.
+	maxExecutionTime := seVars.GetMaxExecutionTime()
+	if maxExecutionTime > 0 {
 		if processInfo := sctx.ShowProcess(); processInfo != nil {
-			maxExecTimeMs := time.Duration(maxExectionTime) * time.Millisecond
+			maxExecTimeMs := time.Duration(maxExecutionTime) * time.Millisecond
 			lockCtx.MaxExecutionDeadline = processInfo.Time.Add(maxExecTimeMs)
 		}
 	}

--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -1105,6 +1105,50 @@ func TestConnExecutionTimeout(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestConnExecutionTimeoutForDML(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+
+	tk := testkit.NewTestKit(t, store)
+
+	connID := uint64(1)
+	tk.Session().SetConnectionID(connID)
+	tc := &TiDBContext{
+		Session: tk.Session(),
+		stmts:   make(map[int]*TiDBStatement),
+	}
+	cc := &clientConn{
+		connectionID: connID,
+		server: &Server{
+			capability: defaultCapability,
+		},
+		alloc:      arena.NewAllocator(32 * 1024),
+		chunkAlloc: chunk.NewAllocator(),
+	}
+	cc.SetCtx(tc)
+	srv := &Server{
+		clients: map[uint64]*clientConn{
+			connID: cc,
+		},
+		dom: dom,
+	}
+	handle := dom.ExpensiveQueryHandle().SetSessionManager(srv)
+	go handle.Run()
+
+	tk.MustExec("use test;")
+	tk.MustExec("CREATE TABLE dmlTimeout (id bigint PRIMARY KEY, v int)")
+	for i := range 3 {
+		tk.MustExec("insert into dmlTimeout values(?, ?)", i, i)
+	}
+
+	tk.MustExec("set @@max_execution_time = 500;")
+	tk.MustExec("update dmlTimeout set v = v + 1 where id < 2 and sleep(1);")
+
+	tk.MustExec("set @@tidb_enable_max_execution_time_for_dml = 1;")
+	err := tk.ExecToErr("update dmlTimeout set v = v + 1 where id < 3 and sleep(1);")
+	require.Error(t, err)
+	require.Equal(t, "[executor:3024]Query execution was interrupted, maximum statement execution time exceeded", err.Error())
+}
+
 func TestShutDown(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 

--- a/pkg/session/sessmgr/processinfo.go
+++ b/pkg/session/sessmgr/processinfo.go
@@ -74,8 +74,8 @@ type ProcessInfo struct {
 	OOMAlarmVariablesInfo OOMAlarmVariablesInfo
 	ID                    uint64
 	CurTxnStartTS         uint64
-	// MaxExecutionTime is the timeout for select statement, in milliseconds.
-	// If the query takes too long, kill it.
+	// MaxExecutionTime is the timeout for the current statement, in milliseconds.
+	// If the statement takes too long, kill it.
 	MaxExecutionTime uint64
 	State            uint16
 	Command          byte

--- a/pkg/session/test/variable/variable_test.go
+++ b/pkg/session/test/variable/variable_test.go
@@ -324,14 +324,29 @@ func TestMaxExecutionTime(t *testing.T) {
 	tk.MustQuery("select @@global.MAX_EXECUTION_TIME;").Check(testkit.Rows("300"))
 	tk.MustQuery("select @@MAX_EXECUTION_TIME;").Check(testkit.Rows("150"))
 
-	// max_execution_time should be 0 if in non-select statement
+	// max_execution_time should be 0 for non-SELECT statements by default.
 	tk.MustExec("update MaxExecTime set age = age + 1 where id = 1000;")
 	require.Equal(t, uint64(0), tk.Session().GetSessionVars().GetMaxExecutionTime())
 	tk.MustExec("update /*+ MAX_EXECUTION_TIME(10000) */ MaxExecTime set age = age + 1 where id = 1000;")
-	// hint works, maybe we should just ignore this hint in non-select statement?
+	// The hint is parsed for non-SELECT statements, but MaxExecutionTime is still 0
+	// until tidb_enable_max_execution_time_for_dml is enabled.
 	require.Equal(t, uint64(10000), tk.Session().GetSessionVars().StmtCtx.MaxExecutionTime)
-	// but MaxExecutionTime is still 0
 	require.Equal(t, uint64(0), tk.Session().GetSessionVars().GetMaxExecutionTime())
+
+	tk.MustQuery("select @@tidb_enable_max_execution_time_for_dml;").Check(testkit.Rows("0"))
+	tk.MustQuery("select @@global.tidb_enable_max_execution_time_for_dml;").Check(testkit.Rows("0"))
+	tk.MustExec("set @@tidb_enable_max_execution_time_for_dml = 1;")
+	tk.MustExec("update MaxExecTime set age = age + 1 where id = 1000;")
+	require.Equal(t, uint64(150), tk.Session().GetSessionVars().GetMaxExecutionTime())
+	tk.MustExec("update /*+ MAX_EXECUTION_TIME(10000) */ MaxExecTime set age = age + 1 where id = 1000;")
+	require.Equal(t, uint64(10000), tk.Session().GetSessionVars().GetMaxExecutionTime())
+	tk.MustExec("set @@tidb_enable_max_execution_time_for_dml = 0;")
+	tk.MustExec("set @@global.tidb_enable_max_execution_time_for_dml = 1;")
+	tk2 := testkit.NewTestKit(t, store)
+	tk2.MustExec("use test")
+	tk2.MustQuery("select @@tidb_enable_max_execution_time_for_dml;").Check(testkit.Rows("1"))
+	tk.MustExec("set @@tidb_enable_max_execution_time_for_dml = 0;")
+	tk.MustExec("set @@global.tidb_enable_max_execution_time_for_dml = 0;")
 
 	tk.MustExec("set @@global.MAX_EXECUTION_TIME = 0;")
 	tk.MustExec("set @@MAX_EXECUTION_TIME = 0;")

--- a/pkg/sessionctx/vardef/sysvar.go
+++ b/pkg/sessionctx/vardef/sysvar.go
@@ -308,6 +308,8 @@ const (
 	TxnIsolationOneShot = "tx_isolation_one_shot"
 	// MaxExecutionTime is the name of the 'max_execution_time' system variable.
 	MaxExecutionTime = "max_execution_time"
+	// TiDBEnableMaxExecutionTimeForDML is the name of the 'tidb_enable_max_execution_time_for_dml' system variable.
+	TiDBEnableMaxExecutionTimeForDML = "tidb_enable_max_execution_time_for_dml"
 	// TiDBMaxKeysRead is the name of the 'tidb_max_keys_read' system variable.
 	TiDBMaxKeysRead = "tidb_max_keys_read"
 	// TiKVClientReadTimeout is the name of the 'tikv_client_read_timeout' system variable.

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1659,6 +1659,7 @@ const (
 	DefTiDBGCMaxWaitTime                              = 24 * 60 * 60
 	DefMaxAllowedPacket                        uint64 = config.DefMaxAllowedPacket
 	DefTiDBEnableBatchDML                             = false
+	DefTiDBEnableMaxExecutionTimeForDML               = false
 	DefTiDBMemQuotaQuery                              = memory.DefMemQuotaQuery // 1GB
 	DefTiDBStatsCacheMemQuota                         = 0
 	MaxTiDBStatsCacheMemQuota                         = 1024 * 1024 * 1024 * 1024 // 1TB

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1302,10 +1302,13 @@ type SessionVars struct {
 	// Do not use it directly, use the `UseLowResolutionTSO` method below.
 	lowResolutionTSO bool
 
-	// MaxExecutionTime is the timeout for select statement, in milliseconds.
+	// MaxExecutionTime is the timeout for statements that max_execution_time applies to, in milliseconds.
 	// If the value is 0, timeouts are not enabled.
 	// See https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_execution_time
 	MaxExecutionTime uint64
+
+	// EnableMaxExecutionTimeForDML controls whether max_execution_time also applies to DML statements.
+	EnableMaxExecutionTimeForDML bool
 
 	// MaxKeysRead is the maximum number of storage engine keys that a SELECT statement
 	// may examine. 0 means unlimited. Only applies to SELECT statements.
@@ -3728,17 +3731,24 @@ func (s *SessionVars) GetRuntimeFilterMode() RuntimeFilterMode {
 	return s.runtimeFilterMode
 }
 
-// GetMaxExecutionTime get the max execution timeout value for select statement.
+// GetMaxExecutionTime get the max execution timeout value for the current statement.
 // Make sure this function is called after s.StmtCtx is already set, otherwise it will always return 0
 func (s *SessionVars) GetMaxExecutionTime() uint64 {
-	// Since maxExecutionTime is used only for SELECT statements, here we limit its scope.
-	if !s.StmtCtx.InSelectStmt {
+	if !s.maxExecutionTimeAppliesToCurrentStmt() {
 		return 0
 	}
 	if s.StmtCtx.HasMaxExecutionTime {
 		return s.StmtCtx.MaxExecutionTime
 	}
 	return s.MaxExecutionTime
+}
+
+func (s *SessionVars) maxExecutionTimeAppliesToCurrentStmt() bool {
+	if s.StmtCtx.InSelectStmt {
+		return true
+	}
+	return s.EnableMaxExecutionTimeForDML &&
+		(s.StmtCtx.InInsertStmt || s.StmtCtx.InUpdateStmt || s.StmtCtx.InDeleteStmt)
 }
 
 // GetTiKVClientReadTimeout returns readonly kv request timeout, prefer query hint over session variable

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1952,6 +1952,15 @@ var defaultSysVars = []*SysVar{
 			return nil
 		}},
 	{
+		Scope: vardef.ScopeGlobal | vardef.ScopeSession,
+		Name:  vardef.TiDBEnableMaxExecutionTimeForDML,
+		Value: BoolToOnOff(vardef.DefTiDBEnableMaxExecutionTimeForDML),
+		Type:  vardef.TypeBool,
+		SetSession: func(s *SessionVars, val string) error {
+			s.EnableMaxExecutionTimeForDML = TiDBOptOn(val)
+			return nil
+		}},
+	{
 		Scope:                   vardef.ScopeGlobal | vardef.ScopeSession,
 		Name:                    vardef.TiDBMaxKeysRead,
 		Value:                   "0",

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -133,6 +133,20 @@ func TestMaxExecutionTime(t *testing.T) {
 
 	require.Nil(t, sv.SetSessionFromHook(vars, "99999")) // sets
 	require.Equal(t, uint64(99999), vars.MaxExecutionTime)
+
+	vars.StmtCtx.InUpdateStmt = true
+	require.Equal(t, uint64(0), vars.GetMaxExecutionTime())
+
+	enableDML := GetSysVar(vardef.TiDBEnableMaxExecutionTimeForDML)
+	require.NotNil(t, enableDML)
+	require.Equal(t, vardef.Off, enableDML.Value)
+	require.NoError(t, enableDML.SetSessionFromHook(vars, vardef.On))
+	require.True(t, vars.EnableMaxExecutionTimeForDML)
+	require.Equal(t, uint64(99999), vars.GetMaxExecutionTime())
+
+	vars.StmtCtx.InUpdateStmt = false
+	vars.StmtCtx.InSelectStmt = true
+	require.Equal(t, uint64(99999), vars.GetMaxExecutionTime())
 }
 
 func TestTiDBMaxKeysRead(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69207

Problem Summary:

`max_execution_time` is currently scoped to SELECT statements. This preserves the behavior introduced in v6.4.0, but it also means long-running INSERT/UPDATE/DELETE statements cannot be bounded by the same timeout control.

This PR adds an opt-in TiDB switch so operators can make DML respect the existing `max_execution_time` value without changing the default behavior for existing clusters.

### What changed and how does it work?

Add a new system variable:

```sql
tidb_enable_max_execution_time_for_dml
```

Properties:

- Scope: `GLOBAL | SESSION`
- Type: boolean
- Default: `OFF`

Behavior:

- When `tidb_enable_max_execution_time_for_dml = OFF`, the current behavior is unchanged: `max_execution_time` applies to SELECT statements.
- When `tidb_enable_max_execution_time_for_dml = ON`, `max_execution_time` and the `MAX_EXECUTION_TIME()` hint also apply to INSERT/UPDATE/DELETE statements.

Implementation details:

- Generalize `SessionVars.GetMaxExecutionTime()` so SELECT remains unchanged, and DML returns the session or hint timeout only when the new switch is enabled.
- Keep `ProcessInfo.MaxExecutionTime` populated for DML when the switch is enabled, so the existing expensive-query timeout checker can interrupt long DML statements.
- Add an elapsed-time check after executor build so a statement that already exceeded `max_execution_time` before executor open can fail fast.
- Update lock context deadline setup to use the generalized `GetMaxExecutionTime()` behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Support applying `max_execution_time` to DML statements when `tidb_enable_max_execution_time_for_dml` is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `tidb_enable_max_execution_time_for_dml` system variable to control execution time limits for DML statements (INSERT, UPDATE, DELETE operations)
  * Extended `max_execution_time` timeout enforcement to apply to DML statements when this feature is enabled; disabled by default for backward compatibility

* **Tests**
  * Added test coverage for DML statement execution timeout enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->