### PR TITLE
ddl, executor, mvservice: impl mv attribute mview_alert_refresh_failed and enhance mysql.tidb_mview_refresh_alert

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -116,5 +116,5 @@ func TestCheckSysTableCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(226), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(227), session.CurrentBootstrapVersion)
 }

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -50,6 +50,7 @@ import (
 const (
 	mviewAttrAlertWarning                                 = "mview_alert_warning"
 	mviewAttrAlertOverdue                                 = "mview_alert_overdue"
+	mviewAttrAlertRefreshFailed                           = "mview_alert_refresh_failed"
 	alterMaterializedScheduleInfoUpdateLockWaitTimeoutSec = int64(10)
 )
 
@@ -329,21 +330,22 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 	if err != nil {
 		return err
 	}
-	alertWarningSec, alertOverdueSec, err := parseMViewAttributes(s.Attributes)
+	alertWarningSec, alertOverdueSec, alertRefreshFailed, err := parseMViewAttributes(s.Attributes)
 	if err != nil {
 		return err
 	}
 	tzName, tzOffset := ddlutil.GetTimeZone(ctx)
 	mvTableInfo.MaterializedView = &model.MaterializedViewInfo{
-		BaseTableIDs:      []int64{baseTableID},
-		InitBuildState:    model.MVInitBuildBuilding,
-		SQLContent:        selectSQL,
-		RefreshMethod:     refreshMethod,
-		RefreshStartWith:  refreshStartWith,
-		RefreshNext:       refreshNext,
-		AlertWarningSec:   alertWarningSec,
-		AlertOverdueSec:   alertOverdueSec,
-		DefinitionSQLMode: ctx.GetSessionVars().SQLMode,
+		BaseTableIDs:       []int64{baseTableID},
+		InitBuildState:     model.MVInitBuildBuilding,
+		SQLContent:         selectSQL,
+		RefreshMethod:      refreshMethod,
+		RefreshStartWith:   refreshStartWith,
+		RefreshNext:        refreshNext,
+		AlertWarningSec:    alertWarningSec,
+		AlertOverdueSec:    alertOverdueSec,
+		AlertRefreshFailed: alertRefreshFailed,
+		DefinitionSQLMode:  ctx.GetSessionVars().SQLMode,
 		DefinitionTimeZone: model.TimeZoneLocation{
 			Name:   tzName,
 			Offset: tzOffset,
@@ -487,7 +489,7 @@ func (e *executor) AlterMaterializedView(ctx sessionctx.Context, s *ast.AlterMat
 				return err
 			}
 		case ast.AlterMaterializedViewActionAttributes:
-			if _, _, err := parseMViewAttributes(action.Attributes); err != nil {
+			if _, _, _, err := parseMViewAttributes(action.Attributes); err != nil {
 				return err
 			}
 		default:
@@ -738,7 +740,7 @@ func (e *executor) alterMaterializedViewAttributes(
 	mviewID int64,
 	attrs string,
 ) error {
-	alertWarningSec, alertOverdueSec, err := parseMViewAttributes(attrs)
+	alertWarningSec, alertOverdueSec, alertRefreshFailed, err := parseMViewAttributes(attrs)
 	if err != nil {
 		return err
 	}
@@ -755,8 +757,9 @@ func (e *executor) alterMaterializedViewAttributes(
 		SQLMode:        ctx.GetSessionVars().SQLMode,
 	}
 	args := &model.AlterMaterializedViewAttributesArgs{
-		AlertWarningSec: alertWarningSec,
-		AlertOverdueSec: alertOverdueSec,
+		AlertWarningSec:    alertWarningSec,
+		AlertOverdueSec:    alertOverdueSec,
+		AlertRefreshFailed: alertRefreshFailed,
 	}
 	return errors.Trace(e.doDDLJob2(ctx, job, args))
 }
@@ -957,12 +960,23 @@ func (e *executor) deleteMaterializedViewRefreshAlert(ctx sessionctx.Context, mv
 	}
 	defer releaseInternalSession()
 
-	_, err = ddlSess.Execute(kctx, buildDeleteMViewRefreshAlertSQL(mviewID), "alter-materialized-view-refresh-delete-alert")
+	clearSQL := sqlescape.MustEscapeSQL(
+		"UPDATE mysql.tidb_mview_refresh_alert SET ALERT_LEVEL = NULL, UPDATED_AT = NOW(6) WHERE MVIEW_ID = %? AND ALERT_LEVEL IS NOT NULL",
+		mviewID,
+	)
+	_, err = ddlSess.Execute(kctx, clearSQL, "alter-materialized-view-refresh-clear-alert-level")
 	failpoint.Inject("mockDeleteMaterializedViewRefreshAlertTableNotExists", func(val failpoint.Value) {
 		if val.(bool) {
 			err = infoschema.ErrTableNotExists.GenWithStackByArgs("mysql", "tidb_mview_refresh_alert")
 		}
 	})
+	if err == nil {
+		deleteSQL := sqlescape.MustEscapeSQL(
+			"DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID = %? AND REFRESH_FAILED IS NULL",
+			mviewID,
+		)
+		_, err = ddlSess.Execute(kctx, deleteSQL, "alter-materialized-view-refresh-delete-alert")
+	}
 	if err != nil {
 		return errors.Trace(convertMViewRefreshAlertTableNotExistsErr(
 			err,
@@ -1237,52 +1251,64 @@ func buildMViewRefreshMeta(sctx sessionctx.Context, refresh *ast.MViewRefreshCla
 	}
 }
 
-func parseMViewAttributes(attrs string) (alertWarningSec, alertOverdueSec int64, err error) {
+func parseMViewAttributes(attrs string) (alertWarningSec, alertOverdueSec int64, alertRefreshFailed bool, err error) {
 	attrs = strings.TrimSpace(attrs)
 	if attrs == "" {
-		return 0, 0, nil
+		return 0, 0, false, nil
 	}
 
-	seen := make(map[string]struct{}, 2)
+	seen := make(map[string]struct{}, 3)
 	for _, rawKV := range strings.Split(attrs, ",") {
 		kv := strings.TrimSpace(rawKV)
 		if kv == "" {
-			return 0, 0, errors.New("invalid ATTRIBUTES format: empty key-value pair")
+			return 0, 0, false, errors.New("invalid ATTRIBUTES format: empty key-value pair")
 		}
 		pos := strings.Index(kv, "=")
 		if pos <= 0 || pos >= len(kv)-1 {
-			return 0, 0, errors.Errorf("invalid ATTRIBUTES format: %q", kv)
+			return 0, 0, false, errors.Errorf("invalid ATTRIBUTES format: %q", kv)
 		}
 		key := strings.ToLower(strings.TrimSpace(kv[:pos]))
 		valStr := strings.TrimSpace(kv[pos+1:])
 		if key == "" || valStr == "" {
-			return 0, 0, errors.Errorf("invalid ATTRIBUTES format: %q", kv)
+			return 0, 0, false, errors.Errorf("invalid ATTRIBUTES format: %q", kv)
 		}
 		if _, ok := seen[key]; ok {
-			return 0, 0, errors.Errorf("duplicate ATTRIBUTES key: %s", key)
+			return 0, 0, false, errors.Errorf("duplicate ATTRIBUTES key: %s", key)
 		}
 		seen[key] = struct{}{}
 
-		val, convErr := strconv.ParseInt(valStr, 10, 64)
-		if convErr != nil || val < 0 {
-			return 0, 0, errors.Errorf("invalid ATTRIBUTES value for %s: %s (must be non-negative integer seconds)", key, valStr)
-		}
-
 		switch key {
 		case mviewAttrAlertWarning:
+			val, convErr := strconv.ParseInt(valStr, 10, 64)
+			if convErr != nil || val < 0 {
+				return 0, 0, false, errors.Errorf("invalid ATTRIBUTES value for %s: %s (must be non-negative integer seconds)", key, valStr)
+			}
 			alertWarningSec = val
 		case mviewAttrAlertOverdue:
+			val, convErr := strconv.ParseInt(valStr, 10, 64)
+			if convErr != nil || val < 0 {
+				return 0, 0, false, errors.Errorf("invalid ATTRIBUTES value for %s: %s (must be non-negative integer seconds)", key, valStr)
+			}
 			alertOverdueSec = val
+		case mviewAttrAlertRefreshFailed:
+			switch strings.ToLower(valStr) {
+			case "yes":
+				alertRefreshFailed = true
+			case "no":
+				alertRefreshFailed = false
+			default:
+				return 0, 0, false, errors.Errorf("invalid ATTRIBUTES value for %s: %s (must be yes or no)", key, valStr)
+			}
 		default:
-			return 0, 0, errors.Errorf("unsupported ATTRIBUTES key: %s", key)
+			return 0, 0, false, errors.Errorf("unsupported ATTRIBUTES key: %s", key)
 		}
 	}
 
 	if alertWarningSec > 0 && alertOverdueSec > 0 && alertWarningSec > alertOverdueSec {
-		return 0, 0, errors.Errorf("invalid ATTRIBUTES: %s (%d) must be less than or equal to %s (%d)",
+		return 0, 0, false, errors.Errorf("invalid ATTRIBUTES: %s (%d) must be less than or equal to %s (%d)",
 			mviewAttrAlertWarning, alertWarningSec, mviewAttrAlertOverdue, alertOverdueSec)
 	}
-	return alertWarningSec, alertOverdueSec, nil
+	return alertWarningSec, alertOverdueSec, alertRefreshFailed, nil
 }
 
 type mviewGroupByInfo struct {

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -1121,6 +1121,7 @@ func onAlterMaterializedViewAttributes(jobCtx *jobContext, job *model.Job, se *s
 	oldTblInfo := tblInfo.Clone()
 	tblInfo.MaterializedView.AlertWarningSec = args.AlertWarningSec
 	tblInfo.MaterializedView.AlertOverdueSec = args.AlertOverdueSec
+	tblInfo.MaterializedView.AlertRefreshFailed = args.AlertRefreshFailed
 
 	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1784,9 +1784,23 @@ func (do *Domain) StartMVService() error {
 	if do.GetMVService() == nil {
 		return errors.New("failed to register MV service")
 	}
-	do.wg.Run(do.mvService.Run, "mvService")
-	do.wg.Run(do.notifyMVSMetadataChange, "mvServiceNotify")
-	do.wg.Run(do.watchMVSMetaChange, "watchMVSMetaChange")
+	runMVServiceLoopWithRecover := func(loopName string, loop func()) {
+		do.wg.RunWithRecover(loop, func(r any) {
+			if r == nil {
+				return
+			}
+			logutil.BgLogger().Error("panic in MVService domain loop",
+				zap.String("loop", loopName),
+				zap.Any("panic", r),
+				zap.Stack("stack"),
+			)
+			metrics.PanicCounter.WithLabelValues(metrics.LabelDomain).Inc()
+			metrics.MVServicePanicGauge.Inc()
+		}, loopName)
+	}
+	runMVServiceLoopWithRecover("mvService", do.mvService.Run)
+	runMVServiceLoopWithRecover("mvServiceNotify", do.notifyMVSMetadataChange)
+	runMVServiceLoopWithRecover("watchMVSMetaChange", do.watchMVSMetaChange)
 	return nil
 }
 
@@ -1799,13 +1813,9 @@ func (do *Domain) watchMVSMetaChange() {
 	if do.etcdClient == nil {
 		return
 	}
-	watchCh := do.etcdClient.Watch(do.ctx, mvsDDLNotifyKey)
-	defer func() {
-		logutil.BgLogger().Info("watchMVSMetaChange exited.")
-	}()
-	defer util.Recover(metrics.LabelDomain, "watchMVSMetaChange", nil, false)
 
-	var count int
+	watchCh := do.etcdClient.Watch(do.ctx, mvsDDLNotifyKey)
+	count := 0
 	for {
 		ok := true
 		select {

--- a/pkg/executor/infoschema_cluster_table_test.go
+++ b/pkg/executor/infoschema_cluster_table_test.go
@@ -394,7 +394,7 @@ func TestTableStorageStats(t *testing.T) {
 	))
 	rows := tk.MustQuery("select TABLE_NAME from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql';").Rows()
 	result := 63
-	require.Len(t, rows, result)
+	require.Len(t, rows, result, len(rows))
 
 	// More tests about the privileges.
 	tk.MustExec("create user 'testuser'@'localhost'")

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -661,7 +661,7 @@ func TestColumnTable(t *testing.T) {
 		testkit.RowsWithSep("|",
 			"test|tbl1|col_2"))
 	tk.MustQuery(`select count(*) from information_schema.columns;`).Check(
-		testkit.RowsWithSep("|", "5028"))
+		testkit.RowsWithSep("|", "5029"))
 }
 
 func TestIndexUsageTable(t *testing.T) {

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -2811,6 +2811,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 	if err != nil {
 		return err
 	}
+	reportRefreshFailed := tblInfo.MaterializedView != nil && tblInfo.MaterializedView.AlertRefreshFailed
 	mviewID = tblInfo.ID
 	refreshHistRunningInserted := false
 	defer func() {
@@ -2831,6 +2832,8 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 			&refreshJobID,
 			taskCancelController,
 			refreshStart,
+			reportRefreshFailed,
+			isInternalSQL,
 			err,
 		)
 	}()
@@ -2943,6 +2946,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 			if refreshFailedReason != nil {
 				refreshErrMsg = *refreshFailedReason
 			}
+			reportMVRefreshFailed(finalizeCtx, histSQLExec, reportRefreshFailed, mviewID, schemaName.O, tblInfo.Name.O, refreshJobID, refreshMethod, isInternalSQL, refreshErrMsg)
 			histErr := observeMVRefreshStep(e.stepObserver, stepSet.finalizeHist, func() error {
 				refreshEndAt := time.Now()
 				return finalizeRefreshHistWithRetry(
@@ -2963,6 +2967,33 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 				return errors.Annotatef(histErr, "refresh materialized view: failed to finalize refresh history after error %v", finalErr)
 			}
 			return errors.Trace(finalErr)
+		}
+		finalizeSuccess := func(buildReadTSO uint64) {
+			if err := observeMVRefreshStep(e.stepObserver, stepSet.finalizeHist, func() error {
+				refreshEndAt := time.Now()
+				return finalizeRefreshHistWithRetry(
+					finalizeCtx,
+					histSQLExec,
+					refreshJobID,
+					mviewID,
+					refreshHistStatusSuccess,
+					&buildReadTSO,
+					nil,
+					histTime(refreshStart, histLoc),
+					histTime(refreshEndAt, histLoc),
+					nil,
+					nil,
+				)
+			}); err != nil {
+				e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
+					errors.Annotate(err, "refresh materialized view: refresh committed but failed to finalize refresh history"),
+				)
+			}
+			if alertErr := deleteRefreshAlertState(finalizeCtx, histSQLExec, mviewID); alertErr != nil {
+				e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
+					errors.Annotate(alertErr, "refresh materialized view: refresh committed but failed to delete refresh alert"),
+				)
+			}
 		}
 		stopTaskMonitor, err := startMVTaskMonitor(
 			kctx,
@@ -3003,26 +3034,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 			return finalizeFailure(err)
 		}
 		refreshStmtResult := captureMVRefreshStmtResult(sessVars)
-		if err := observeMVRefreshStep(e.stepObserver, stepSet.finalizeHist, func() error {
-			refreshEndAt := time.Now()
-			return finalizeRefreshHistWithRetry(
-				finalizeCtx,
-				histSQLExec,
-				refreshJobID,
-				mviewID,
-				refreshHistStatusSuccess,
-				&buildReadTSO,
-				nil,
-				histTime(refreshStart, histLoc),
-				histTime(refreshEndAt, histLoc),
-				nil,
-				nil,
-			)
-		}); err != nil {
-			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
-				errors.Annotate(err, "refresh materialized view: refresh committed but failed to finalize refresh history"),
-			)
-		}
+		finalizeSuccess(buildReadTSO)
 		applyMVRefreshStmtResult(e.Ctx().GetSessionVars().StmtCtx, refreshStmtResult)
 		return nil
 	}
@@ -3138,6 +3150,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 				txnTotalDur = time.Since(txnCommitStart)
 			}
 		}
+		reportMVRefreshFailed(finalizeCtx, histSQLExec, reportRefreshFailed, mviewID, schemaName.O, tblInfo.Name.O, refreshJobID, refreshMethod, isInternalSQL, refreshErrMsg)
 		histErr := observeMVRefreshStep(e.stepObserver, stepSet.finalizeHist, func() error {
 			refreshEndAt := time.Now()
 			return finalizeRefreshHistWithRetry(
@@ -3164,6 +3177,33 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 			return errors.Annotatef(rollbackErr, "refresh materialized view: rollback failed after error %v", finalErr)
 		}
 		return errors.Trace(finalErr)
+	}
+	finalizeSuccess := func(refreshReadTSO uint64, refreshCommitTSO *uint64, refreshRows *int64) {
+		if err := observeMVRefreshStep(e.stepObserver, stepSet.finalizeHist, func() error {
+			refreshEndAt := time.Now()
+			return finalizeRefreshHistWithRetry(
+				finalizeCtx,
+				histSQLExec,
+				refreshJobID,
+				mviewID,
+				refreshHistStatusSuccess,
+				&refreshReadTSO,
+				refreshCommitTSO,
+				histTime(refreshStart, histLoc),
+				histTime(refreshEndAt, histLoc),
+				refreshRows,
+				nil,
+			)
+		}); err != nil {
+			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
+				errors.Annotate(err, "refresh materialized view: refresh committed but failed to finalize refresh history"),
+			)
+		}
+		if alertErr := deleteRefreshAlertState(finalizeCtx, histSQLExec, mviewID); alertErr != nil {
+			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
+				errors.Annotate(alertErr, "refresh materialized view: refresh committed but failed to delete refresh alert"),
+			)
+		}
 	}
 	stopTaskMonitor, err := startMVTaskMonitor(
 		kctx,
@@ -3297,27 +3337,7 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		refreshCommitTSO = nil
 	}
 	applyMVRefreshStmtResult(e.Ctx().GetSessionVars().StmtCtx, refreshStmtResult)
-
-	if err := observeMVRefreshStep(e.stepObserver, stepSet.finalizeHist, func() error {
-		refreshEndAt := time.Now()
-		return finalizeRefreshHistWithRetry(
-			finalizeCtx,
-			histSQLExec,
-			refreshJobID,
-			mviewID,
-			refreshHistStatusSuccess,
-			&refreshReadTSO,
-			refreshCommitTSO,
-			histTime(refreshStart, histLoc),
-			histTime(refreshEndAt, histLoc),
-			refreshRows,
-			nil,
-		)
-	}); err != nil {
-		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(
-			errors.Annotate(err, "refresh materialized view: refresh committed but failed to finalize refresh history"),
-		)
-	}
+	finalizeSuccess(refreshReadTSO, refreshCommitTSO, refreshRows)
 	return nil
 }
 
@@ -4528,6 +4548,99 @@ const (
 	refreshHistStatusFailed  = "failed"
 )
 
+func markRefreshFailedAlertState(
+	kctx context.Context,
+	sqlExec sqlexec.SQLExecutor,
+	mviewID int64,
+	mvSchema string,
+	mvName string,
+) error {
+	_, err := sqlExec.ExecuteInternal(
+		kctx,
+		`INSERT INTO mysql.tidb_mview_refresh_alert (
+	MVIEW_ID,
+	MV_SCHEMA,
+	MV_NAME,
+	REFRESH_FAILED,
+	UPDATED_AT
+) VALUES (
+	%?,
+	%?,
+	%?,
+	'YES',
+	NOW(6)
+) ON DUPLICATE KEY UPDATE
+MV_SCHEMA = VALUES(MV_SCHEMA),
+MV_NAME = VALUES(MV_NAME),
+REFRESH_FAILED = VALUES(REFRESH_FAILED),
+UPDATED_AT = VALUES(UPDATED_AT)`,
+		mviewID,
+		mvSchema,
+		mvName,
+	)
+	if err != nil {
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return errors.New("refresh materialized view: required system table mysql.tidb_mview_refresh_alert does not exist")
+		}
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func reportMVRefreshFailed(
+	kctx context.Context,
+	sqlExec sqlexec.SQLExecutor,
+	reportRefreshFailed bool,
+	mviewID int64,
+	mvSchema string,
+	mvName string,
+	refreshJobID uint64,
+	refreshMethod string,
+	isInternalSQL bool,
+	refreshErrMsg string,
+) {
+	if !reportRefreshFailed {
+		return
+	}
+	if alertErr := markRefreshFailedAlertState(kctx, sqlExec, mviewID, mvSchema, mvName); alertErr != nil {
+		logutil.BgLogger().Warn("refresh materialized view: failed to mark refresh_failed alert",
+			zap.Int64("mviewID", mviewID),
+			zap.String("schema", mvSchema),
+			zap.String("mview", mvName),
+			zap.Uint64("refreshJobID", refreshJobID),
+			zap.Error(alertErr),
+		)
+	}
+	logutil.BgLogger().Error("Materialized_view_refresh_failed",
+		zap.Int64("mview_id", mviewID),
+		zap.String("schema", mvSchema),
+		zap.String("mview", mvName),
+		zap.Uint64("refresh_job_id", refreshJobID),
+		zap.String("refresh_method", refreshMethod),
+		zap.Bool("internal_sql", isInternalSQL),
+		zap.String("error", refreshErrMsg),
+	)
+}
+
+func deleteRefreshAlertState(
+	kctx context.Context,
+	sqlExec sqlexec.SQLExecutor,
+	mviewID int64,
+) error {
+	if _, err := sqlExec.ExecuteInternal(
+		kctx,
+		`DELETE FROM mysql.tidb_mview_refresh_alert
+WHERE MVIEW_ID = %?`,
+		mviewID,
+	); err != nil {
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return errors.New("refresh materialized view: required system table mysql.tidb_mview_refresh_alert does not exist")
+		}
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 func insertRefreshHistRunning(
 	kctx context.Context,
 	sqlExec sqlexec.SQLExecutor,
@@ -4598,6 +4711,11 @@ func insertRefreshHistFailed(
 	if refreshFailedReason != nil {
 		refreshFailedReasonArg = *refreshFailedReason
 	}
+	failpoint.Inject("mockInsertRefreshHistFailedError", func(val failpoint.Value) {
+		if shouldFail, ok := val.(bool); ok && shouldFail {
+			failpoint.Return(errors.New("mock insert failed refresh history error"))
+		}
+	})
 	insertSQL := `INSERT INTO mysql.tidb_mview_refresh_hist (
 	REFRESH_JOB_ID,
 	MVIEW_ID,
@@ -4660,6 +4778,8 @@ func (e *RefreshMaterializedViewExec) insertRefreshHistFailedFallback(
 	refreshJobID *uint64,
 	taskCancelController *mvTaskCancelController,
 	refreshStart time.Time,
+	reportRefreshFailed bool,
+	isInternalSQL bool,
 	refreshErr error,
 ) error {
 	refreshFailedReason, finalErr := taskCancelController.normalizeTaskFailure(refreshErr)
@@ -4682,6 +4802,7 @@ func (e *RefreshMaterializedViewExec) insertRefreshHistFailedFallback(
 	if refreshFailedReason != nil {
 		refreshErrMsg = *refreshFailedReason
 	}
+	reportMVRefreshFailed(kctx, histSQLExec, reportRefreshFailed, mviewID, mvSchema, mvName, *refreshJobID, refreshMethod, isInternalSQL, refreshErrMsg)
 	refreshEndAt := time.Now()
 	if err := insertRefreshHistFailed(
 		kctx,

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -1823,12 +1823,15 @@ func fetchShowCreateTable4MaterializedView(ctx sessionctx.Context, tb *model.Tab
 	if tb.PreSplitRegions > 0 {
 		fmt.Fprintf(buf, " PRE_SPLIT_REGIONS = %d", tb.PreSplitRegions)
 	}
-	attrPairs := make([]string, 0, 2)
+	attrPairs := make([]string, 0, 3)
 	if mvInfo.AlertWarningSec > 0 {
 		attrPairs = append(attrPairs, fmt.Sprintf("mview_alert_warning=%d", mvInfo.AlertWarningSec))
 	}
 	if mvInfo.AlertOverdueSec > 0 {
 		attrPairs = append(attrPairs, fmt.Sprintf("mview_alert_overdue=%d", mvInfo.AlertOverdueSec))
+	}
+	if mvInfo.AlertRefreshFailed {
+		attrPairs = append(attrPairs, "mview_alert_refresh_failed=yes")
 	}
 	if len(attrPairs) > 0 {
 		fmt.Fprintf(buf, " ATTRIBUTES='%s'", strings.Join(attrPairs, ","))

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -313,6 +313,7 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	tk.MustExec("drop materialized view mv_count_col")
 	tk.MustExec("drop materialized view mv_alert")
 	tk.MustExec("drop materialized view mv_alert_zero")
+	tk.MustExec("drop materialized view mv_alert_failed")
 	tk.MustExec("drop materialized view mv_upper_agg")
 	tk.MustExec("drop materialized view mv_alias")
 	tk.MustExec("drop materialized view mv_nullable")

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -116,6 +116,7 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 1 HOUR)", mvTable.Meta().MaterializedView.RefreshNext)
 	require.Equal(t, int64(0), mvTable.Meta().MaterializedView.AlertWarningSec)
 	require.Equal(t, int64(0), mvTable.Meta().MaterializedView.AlertOverdueSec)
+	require.False(t, mvTable.Meta().MaterializedView.AlertRefreshFailed)
 	expectedTZName, expectedTZOffset := ddlutil.GetTimeZone(tk.Session())
 	require.Equal(t, tk.Session().GetSessionVars().SQLMode, mvTable.Meta().MaterializedView.DefinitionSQLMode)
 	require.Equal(t, expectedTZName, mvTable.Meta().MaterializedView.DefinitionTimeZone.Name)
@@ -149,18 +150,26 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(300), mvAlertTable.Meta().MaterializedView.AlertWarningSec)
 	require.Equal(t, int64(600), mvAlertTable.Meta().MaterializedView.AlertOverdueSec)
-
+	require.False(t, mvAlertTable.Meta().MaterializedView.AlertRefreshFailed)
 	tk.MustExec("create materialized view mv_alert_zero (a, cnt) refresh fast attributes='mview_alert_warning=0,mview_alert_overdue=0' as select a, count(1) from t group by a")
 	is = dom.InfoSchema()
 	mvAlertZeroTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv_alert_zero"))
 	require.NoError(t, err)
 	require.Equal(t, int64(0), mvAlertZeroTable.Meta().MaterializedView.AlertWarningSec)
 	require.Equal(t, int64(0), mvAlertZeroTable.Meta().MaterializedView.AlertOverdueSec)
+	require.False(t, mvAlertZeroTable.Meta().MaterializedView.AlertRefreshFailed)
+	tk.MustExec("create materialized view mv_alert_failed (a, cnt) refresh fast attributes='mview_alert_refresh_failed=yes' as select a, count(1) from t group by a")
+	is = dom.InfoSchema()
+	mvAlertFailedTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv_alert_failed"))
+	require.NoError(t, err)
+	require.True(t, mvAlertFailedTable.Meta().MaterializedView.AlertRefreshFailed)
 
 	err = tk.ExecToErr("create materialized view mv_alert_bad_key (a, cnt) attributes='unknown=1' as select a, count(1) from t group by a")
 	require.ErrorContains(t, err, "unsupported ATTRIBUTES key")
 	err = tk.ExecToErr("create materialized view mv_alert_bad_value (a, cnt) attributes='mview_alert_warning=-1' as select a, count(1) from t group by a")
 	require.ErrorContains(t, err, "must be non-negative integer seconds")
+	err = tk.ExecToErr("create materialized view mv_alert_bad_failed (a, cnt) attributes='mview_alert_refresh_failed=maybe' as select a, count(1) from t group by a")
+	require.ErrorContains(t, err, "must be yes or no")
 	err = tk.ExecToErr("create materialized view mv_alert_bad_order (a, cnt) attributes='mview_alert_warning=600,mview_alert_overdue=300' as select a, count(1) from t group by a")
 	require.ErrorContains(t, err, "must be less than or equal")
 
@@ -777,12 +786,12 @@ func TestShowCreateMaterializedView(t *testing.T) {
 	require.Equal(t, "utf8mb4", rows[0][2])
 	require.Equal(t, "utf8mb4_bin", rows[0][3])
 
-	tk.MustExec("create materialized view mv_show_mv_attr (a, s, cnt) refresh fast attributes='mview_alert_warning=5,mview_alert_overdue=10' as select a, sum(b), count(1) from t_show_mv group by a")
+	tk.MustExec("create materialized view mv_show_mv_attr (a, s, cnt) refresh fast attributes='mview_alert_warning=5,mview_alert_overdue=10,mview_alert_refresh_failed=yes' as select a, sum(b), count(1) from t_show_mv group by a")
 	attrRows := tk.MustQuery("show create materialized view mv_show_mv_attr").Rows()
 	require.Len(t, attrRows, 1)
 	attrShowCreate, ok := attrRows[0][1].(string)
 	require.True(t, ok)
-	require.Contains(t, attrShowCreate, "ATTRIBUTES='mview_alert_warning=5,mview_alert_overdue=10'")
+	require.Contains(t, attrShowCreate, "ATTRIBUTES='mview_alert_warning=5,mview_alert_overdue=10,mview_alert_refresh_failed=yes'")
 
 	tk.MustExec("create materialized view mv_show_mv_attr_partial (a, s, cnt) refresh fast attributes='mview_alert_warning=0,mview_alert_overdue=10' as select a, sum(b), count(1) from t_show_mv group by a")
 	attrPartialRows := tk.MustQuery("show create materialized view mv_show_mv_attr_partial").Rows()
@@ -839,7 +848,7 @@ func TestAlterMaterializedViewAttributesUpdatesAlertThresholds(t *testing.T) {
 	tk.MustExec("create table t (a int not null, b int not null)")
 	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
 	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
-	tk.MustExec("create materialized view mv_attr (a, s, cnt) refresh fast next date_add(now(), interval 2 hour) attributes='mview_alert_warning=300,mview_alert_overdue=600' as select a, sum(b), count(1) from t group by a")
+	tk.MustExec("create materialized view mv_attr (a, s, cnt) refresh fast next date_add(now(), interval 2 hour) attributes='mview_alert_warning=300,mview_alert_overdue=600,mview_alert_refresh_failed=no' as select a, sum(b), count(1) from t group by a")
 
 	getMViewMeta := func() *model.MaterializedViewInfo {
 		is := dom.InfoSchema()
@@ -852,23 +861,28 @@ func TestAlterMaterializedViewAttributesUpdatesAlertThresholds(t *testing.T) {
 	mvInfo := getMViewMeta()
 	require.Equal(t, int64(300), mvInfo.AlertWarningSec)
 	require.Equal(t, int64(600), mvInfo.AlertOverdueSec)
+	require.False(t, mvInfo.AlertRefreshFailed)
 	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 2 HOUR)", mvInfo.RefreshNext)
 
-	tk.MustExec("alter materialized view mv_attr attributes='mview_alert_warning=5,mview_alert_overdue=5'")
+	tk.MustExec("alter materialized view mv_attr attributes='mview_alert_warning=5,mview_alert_overdue=5,mview_alert_refresh_failed=yes'")
 	mvInfo = getMViewMeta()
 	require.Equal(t, int64(5), mvInfo.AlertWarningSec)
 	require.Equal(t, int64(5), mvInfo.AlertOverdueSec)
+	require.True(t, mvInfo.AlertRefreshFailed)
 	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 2 HOUR)", mvInfo.RefreshNext)
 
 	tk.MustExec("alter materialized view mv_attr refresh next date_add(now(), interval 25 minute)")
-	tk.MustExec("alter materialized view mv_attr attributes='mview_alert_warning=10,mview_alert_overdue=20'")
+	tk.MustExec("alter materialized view mv_attr attributes='mview_alert_warning=10,mview_alert_overdue=20,mview_alert_refresh_failed=no'")
 	mvInfo = getMViewMeta()
 	require.Equal(t, int64(10), mvInfo.AlertWarningSec)
 	require.Equal(t, int64(20), mvInfo.AlertOverdueSec)
+	require.False(t, mvInfo.AlertRefreshFailed)
 	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 25 MINUTE)", mvInfo.RefreshNext)
 
 	err := tk.ExecToErr("alter materialized view mv_attr attributes='unknown=1'")
 	require.ErrorContains(t, err, "unsupported ATTRIBUTES key")
+	err = tk.ExecToErr("alter materialized view mv_attr attributes='mview_alert_refresh_failed=maybe'")
+	require.ErrorContains(t, err, "must be yes or no")
 	err = tk.ExecToErr("alter materialized view mv_attr attributes='mview_alert_warning=20,mview_alert_overdue=10'")
 	require.ErrorContains(t, err, "must be less than or equal")
 }
@@ -990,6 +1004,33 @@ func TestAlterMaterializedViewRefreshDisableScheduleClearsAlert(t *testing.T) {
 		Check(testkit.Rows("1"))
 	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d", mviewID)).
 		Check(testkit.Rows("0"))
+}
+
+func TestAlterMaterializedViewRefreshDisableSchedulePreservesRefreshFailedAlert(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 2 hour) as select a, sum(b), count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv"))
+	require.NoError(t, err)
+	mviewID := mvTable.Meta().ID
+
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MV_SCHEMA, MV_NAME, ALERT_LEVEL, REFRESH_FAILED, LAST_SUCCESS_TIME, UPDATED_AT) values (%d, 'test', 'mv', 'warning', 'YES', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		mviewID,
+	))
+
+	tk.MustExec("alter materialized view mv refresh")
+
+	tk.MustQuery(fmt.Sprintf("select NEXT_TIME is null from mysql.tidb_mview_refresh_info where MVIEW_ID = %d", mviewID)).
+		Check(testkit.Rows("1"))
+	tk.MustQuery(fmt.Sprintf("select ALERT_LEVEL is null, REFRESH_FAILED from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d", mviewID)).
+		Check(testkit.Rows("1 YES"))
 }
 
 func TestAlterMaterializedViewRefreshDisableScheduleIgnoresAlertDeleteFailure(t *testing.T) {

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -1593,6 +1593,99 @@ func TestMaterializedViewRefreshFastAsOfTimestampEarlyFailureWritesHistReadTSO(t
 	)).Check(testkit.Rows("failed 1 1 1 1 1 1"))
 }
 
+func TestMaterializedViewRefreshFailedAlertByAttribute(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set time_zone = '+00:00'")
+	tk.MustExec("create table t_mv_refresh_failed_alert (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_refresh_failed_alert values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_mv_refresh_failed_alert (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_refresh_failed_yes (a, s, cnt) refresh fast attributes='mview_alert_refresh_failed=yes' as select a, sum(b), count(1) from t_mv_refresh_failed_alert group by a")
+	tk.MustExec("create materialized view mv_refresh_failed_no (a, s, cnt) refresh fast attributes='mview_alert_refresh_failed=no' as select a, sum(b), count(1) from t_mv_refresh_failed_alert group by a")
+
+	mvYesIDRows := tk.MustQuery("select tidb_table_id from information_schema.tables where table_schema = 'test' and table_name = 'mv_refresh_failed_yes'").Rows()
+	require.Len(t, mvYesIDRows, 1)
+	mvYesID, err := strconv.ParseInt(fmt.Sprintf("%v", mvYesIDRows[0][0]), 10, 64)
+	require.NoError(t, err)
+	mvNoIDRows := tk.MustQuery("select tidb_table_id from information_schema.tables where table_schema = 'test' and table_name = 'mv_refresh_failed_no'").Rows()
+	require.Len(t, mvNoIDRows, 1)
+	mvNoID, err := strconv.ParseInt(fmt.Sprintf("%v", mvNoIDRows[0][0]), 10, 64)
+	require.NoError(t, err)
+
+	const failpointName = "github.com/pingcap/tidb/pkg/executor/mockRefreshMaterializedViewErrorBeforeInsertHist"
+	require.NoError(t, failpoint.Enable(failpointName, `return("mock refresh failed alert")`))
+	enabled := true
+	defer func() {
+		if enabled {
+			require.NoError(t, failpoint.Disable(failpointName))
+		}
+	}()
+
+	err = tk.ExecToErr("refresh materialized view mv_refresh_failed_yes fast")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "mock refresh failed alert")
+	err = tk.ExecToErr("refresh materialized view mv_refresh_failed_no fast")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "mock refresh failed alert")
+
+	tk.MustQuery(fmt.Sprintf(
+		"select REFRESH_FAILED, ALERT_LEVEL is null from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d",
+		mvYesID,
+	)).Check(testkit.Rows("YES 1"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d", mvNoID)).
+		Check(testkit.Rows("0"))
+
+	require.NoError(t, failpoint.Disable(failpointName))
+	enabled = false
+
+	tk.MustExec(fmt.Sprintf(
+		"update mysql.tidb_mview_refresh_alert set ALERT_LEVEL = 'warning' where MVIEW_ID = %d",
+		mvYesID,
+	))
+	tk.MustExec("refresh materialized view mv_refresh_failed_yes fast")
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d", mvYesID)).
+		Check(testkit.Rows("0"))
+}
+
+func TestMaterializedViewRefreshFallbackReportsAlertBeforeInsertHistFailure(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_refresh_failed_alert_fallback (a int not null, b int not null)")
+	tk.MustExec("insert into t_mv_refresh_failed_alert_fallback values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_mv_refresh_failed_alert_fallback (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_refresh_failed_alert_fallback (a, s, cnt) refresh fast attributes='mview_alert_refresh_failed=yes' as select a, sum(b), count(1) from t_mv_refresh_failed_alert_fallback group by a")
+
+	mvIDRows := tk.MustQuery("select tidb_table_id from information_schema.tables where table_schema = 'test' and table_name = 'mv_refresh_failed_alert_fallback'").Rows()
+	require.Len(t, mvIDRows, 1)
+	mvID, err := strconv.ParseInt(fmt.Sprintf("%v", mvIDRows[0][0]), 10, 64)
+	require.NoError(t, err)
+
+	const earlyRefreshFailpoint = "github.com/pingcap/tidb/pkg/executor/mockRefreshMaterializedViewErrorBeforeInsertHist"
+	require.NoError(t, failpoint.Enable(earlyRefreshFailpoint, `return("mock fallback refresh failed alert")`))
+	defer func() {
+		require.NoError(t, failpoint.Disable(earlyRefreshFailpoint))
+	}()
+	const insertHistFailpoint = "github.com/pingcap/tidb/pkg/executor/mockInsertRefreshHistFailedError"
+	require.NoError(t, failpoint.Enable(insertHistFailpoint, "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable(insertHistFailpoint))
+	}()
+
+	err = tk.ExecToErr("refresh materialized view mv_refresh_failed_alert_fallback fast")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to insert failed refresh history after error")
+	require.ErrorContains(t, err, "mock fallback refresh failed alert")
+
+	tk.MustQuery(fmt.Sprintf(
+		"select REFRESH_FAILED, ALERT_LEVEL is null from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d",
+		mvID,
+	)).Check(testkit.Rows("YES 1"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d", mvID)).
+		Check(testkit.Rows("0"))
+}
+
 func TestMaterializedViewRefreshFastAsOfTimestampDryRunUsesRefreshInfoWindow(t *testing.T) {
 	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
@@ -3281,6 +3374,40 @@ func TestMaterializedViewRefreshCompleteFailureKeepsRefreshInfoReadTSO(t *testin
 	reasonRow := tk.MustQuery(fmt.Sprintf("select REFRESH_FAILED_REASON from mysql.tidb_mview_refresh_hist where MVIEW_ID = %d order by REFRESH_JOB_ID desc limit 1", mviewID)).Rows()
 	require.Len(t, reasonRow, 1)
 	require.Contains(t, fmt.Sprintf("%v", reasonRow[0][0]), "Duplicate")
+}
+
+func TestMaterializedViewRefreshFailureReportsAlertBeforeFinalizeHistFailure(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) attributes='mview_alert_refresh_failed=yes' as select a, sum(b), count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv"))
+	require.NoError(t, err)
+	mviewID := mvTable.Meta().ID
+
+	tk.MustExec("create unique index idx_unique_s on mv (s)")
+	tk.MustExec("insert into t values (2, 8)")
+
+	const finalizeFailpoint = "github.com/pingcap/tidb/pkg/executor/mockFinalizeRefreshHistError"
+	require.NoError(t, failpoint.Enable(finalizeFailpoint, "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable(finalizeFailpoint))
+	}()
+
+	err = tk.ExecToErr("refresh materialized view mv complete delta apply")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to finalize refresh history after error")
+	require.ErrorContains(t, err, "Duplicate")
+
+	tk.MustQuery(fmt.Sprintf(
+		"select REFRESH_FAILED, ALERT_LEVEL is null from mysql.tidb_mview_refresh_alert where MVIEW_ID = %d",
+		mviewID,
+	)).Check(testkit.Rows("YES 1"))
 }
 
 func TestMaterializedViewRefreshCompleteWithConstraintCheckInPlacePessimisticOff(t *testing.T) {

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -744,15 +744,20 @@ func GetAlterMaterializedViewRefreshArgs(job *Job) (*AlterMaterializedViewRefres
 
 // AlterMaterializedViewAttributesArgs is the arguments for ActionAlterMaterializedViewAttributes ddl.
 type AlterMaterializedViewAttributesArgs struct {
-	AlertWarningSec int64 `json:"alert_warning_sec,omitempty"`
-	AlertOverdueSec int64 `json:"alert_overdue_sec,omitempty"`
+	AlertWarningSec    int64 `json:"alert_warning_sec,omitempty"`
+	AlertOverdueSec    int64 `json:"alert_overdue_sec,omitempty"`
+	AlertRefreshFailed bool  `json:"alert_refresh_failed,omitempty"`
 }
 
 func (a *AlterMaterializedViewAttributesArgs) getArgsV1(*Job) []any {
-	return []any{a.AlertWarningSec, a.AlertOverdueSec}
+	return []any{a.AlertWarningSec, a.AlertOverdueSec, a.AlertRefreshFailed}
 }
 
 func (a *AlterMaterializedViewAttributesArgs) decodeV1(job *Job) error {
+	if err := job.decodeArgs(&a.AlertWarningSec, &a.AlertOverdueSec, &a.AlertRefreshFailed); err == nil {
+		return nil
+	}
+	a.AlertRefreshFailed = false
 	return errors.Trace(job.decodeArgs(&a.AlertWarningSec, &a.AlertOverdueSec))
 }
 

--- a/pkg/meta/model/job_args_test.go
+++ b/pkg/meta/model/job_args_test.go
@@ -613,8 +613,9 @@ func TestGetAlterMaterializedViewRefreshArgs(t *testing.T) {
 
 func TestGetAlterMaterializedViewAttributesArgs(t *testing.T) {
 	inArgs := &AlterMaterializedViewAttributesArgs{
-		AlertWarningSec: 10,
-		AlertOverdueSec: 20,
+		AlertWarningSec:    10,
+		AlertOverdueSec:    20,
+		AlertRefreshFailed: true,
 	}
 	for _, v := range []JobVersion{JobVersion1, JobVersion2} {
 		j2 := &Job{}
@@ -623,6 +624,23 @@ func TestGetAlterMaterializedViewAttributesArgs(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, inArgs, args)
 	}
+
+	legacy := &AlterMaterializedViewAttributesArgs{
+		AlertWarningSec: 10,
+		AlertOverdueSec: 20,
+	}
+	legacyRawArgs, err := marshalArgs(JobVersion1, []any{legacy.AlertWarningSec, legacy.AlertOverdueSec})
+	require.NoError(t, err)
+	j := &Job{
+		Version: JobVersion1,
+		Type:    ActionAlterMaterializedViewAttributes,
+		RawArgs: legacyRawArgs,
+	}
+	args, err := GetAlterMaterializedViewAttributesArgs(j)
+	require.NoError(t, err)
+	require.Equal(t, legacy.AlertWarningSec, args.AlertWarningSec)
+	require.Equal(t, legacy.AlertOverdueSec, args.AlertOverdueSec)
+	require.False(t, args.AlertRefreshFailed)
 }
 
 func TestGetAlterMaterializedViewLogPurgeArgs(t *testing.T) {

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -801,6 +801,11 @@ type MaterializedViewInfo struct {
 	// for automatically scheduled MV refresh tasks. 0 means disabled.
 	AlertOverdueSec int64 `json:"alert_overdue_sec,omitempty"`
 
+	// AlertRefreshFailed controls whether refresh failures should be persisted into
+	// mysql.tidb_mview_refresh_alert and logged as Materialized_view_refresh_failed.
+	// false means disabled.
+	AlertRefreshFailed bool `json:"alert_refresh_failed,omitempty"`
+
 	// DefinitionSQLMode is the SQL mode captured from CREATE MATERIALIZED VIEW session.
 	DefinitionSQLMode mysql.SQLMode `json:"definition_sql_mode"`
 

--- a/pkg/metrics/materialized_view.go
+++ b/pkg/metrics/materialized_view.go
@@ -37,6 +37,7 @@ const (
 	mvMetricTaskStatusMVLogPurgeRun    = "mvlog_purge_running"
 	mvMetricTaskStatusMVRefreshWarning = "mv_refresh_warning"
 	mvMetricTaskStatusMVRefreshOverdue = "mv_refresh_overdue"
+	mvMetricTaskStatusMVServicePanic   = "mv_service_panic"
 )
 
 // Metrics for materialized view service.
@@ -65,6 +66,7 @@ var (
 	MVServiceMVLogPurgeRunningGauge prometheus.Gauge
 	MVServiceMVRefreshWarningGauge  prometheus.Gauge
 	MVServiceMVRefreshOverdueGauge  prometheus.Gauge
+	MVServicePanicGauge             prometheus.Gauge
 )
 
 // InitMVMetrics initializes metrics for materialized view service.
@@ -110,4 +112,5 @@ func InitMVMetrics() {
 	MVServiceMVLogPurgeRunningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVLogPurgeRun)
 	MVServiceMVRefreshWarningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVRefreshWarning)
 	MVServiceMVRefreshOverdueGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVRefreshOverdue)
+	MVServicePanicGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVServicePanic)
 }

--- a/pkg/mvservice/BUILD.bazel
+++ b/pkg/mvservice/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/util/sqlexec",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_tikv_client_go_v2//oracle",
+        "@com_github_twmb_murmur3//:murmur3",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/mvservice/consistenthash.go
+++ b/pkg/mvservice/consistenthash.go
@@ -15,9 +15,10 @@
 package mvservice
 
 import (
-	"hash/crc32"
 	"sort"
 	"strconv"
+
+	"github.com/twmb/murmur3"
 )
 
 // ConsistentHash is a consistent hashing ring.
@@ -42,7 +43,7 @@ func NewConsistentHash(replicas int) *ConsistentHash {
 	replicas = min(max(1, replicas), 200)
 	return &ConsistentHash{
 		data:     make(map[string][]virtualNode),
-		hashFunc: crc32.ChecksumIEEE,
+		hashFunc: murmur3.Sum32,
 		replicas: replicas,
 	}
 }

--- a/pkg/mvservice/mvservice_test.go
+++ b/pkg/mvservice/mvservice_test.go
@@ -1182,7 +1182,7 @@ func (h *fullChainMVServiceHelper) setPending(logs map[int64]time.Time, mvs map[
 	}
 }
 
-func (h *fullChainMVServiceHelper) loadAllTiDBMVLogPurge(context.Context, basic.SessionPool) (map[int64]*mvLog, error) {
+func (h *fullChainMVServiceHelper) LoadAllTiDBMVLogPurge(context.Context, basic.SessionPool) (map[int64]*mvLog, error) {
 	h.fetchLogsCalls.Add(1)
 	if h.fetchLogsErr != nil {
 		return nil, h.fetchLogsErr
@@ -1202,7 +1202,7 @@ func (h *fullChainMVServiceHelper) loadAllTiDBMVLogPurge(context.Context, basic.
 	return ret, nil
 }
 
-func (h *fullChainMVServiceHelper) loadAllTiDBMVRefresh(context.Context, basic.SessionPool) (map[int64]*mv, error) {
+func (h *fullChainMVServiceHelper) LoadAllTiDBMVRefresh(context.Context, basic.SessionPool) (map[int64]*mv, error) {
 	h.fetchViewCalls.Add(1)
 	if h.fetchViewsErr != nil {
 		return nil, h.fetchViewsErr

--- a/pkg/mvservice/service.go
+++ b/pkg/mvservice/service.go
@@ -130,12 +130,11 @@ const (
 	mvDurationResultFailed  = "failed"
 
 	mvRunEventInitFailed         = "init_failed"
-	mvRunEventRecoveredPanic     = "mv_service_panic"
 	mvRunEventServerChanged      = "server_changed"
 	mvRunEventServerRefreshError = "server_refresh_error"
 	mvRunEventFetchByDDL         = "fetch_meta_by_ddl"
 	mvRunEventFetchByInterval    = "fetch_meta_by_interval"
-	mvRunEventHistoryGCGetTSOErr = "get_tso_error"
+	mvRunEventGetTSOErr          = "get_tso_error"
 
 	mvHistoryGCOwnerKey = "gc-mv-op-hist"
 	// A single hash-ring owner performs stale refresh-alert cleanup to avoid
@@ -938,7 +937,7 @@ func (t *MVService) fetchAllTiDBMVLogPurge() (map[int64]*mvLog, error) {
 		t.mh.observeTaskDuration(mvFetchTypeMLogPurge, result, mvsSince(start))
 	}()
 
-	newPending, err := t.mh.loadAllTiDBMVLogPurge(t.ctx, t.sysSessionPool)
+	newPending, err := t.mh.LoadAllTiDBMVLogPurge(t.ctx, t.sysSessionPool)
 	if err != nil {
 		result = mvDurationResultFailed
 		fields := append(t.runtimeLogFields(), zap.Error(err))
@@ -957,7 +956,7 @@ func (t *MVService) fetchAllTiDBMVRefresh() (map[int64]*mv, error) {
 		t.mh.observeTaskDuration(mvFetchTypeMViewRefresh, result, mvsSince(start))
 	}()
 
-	newPending, err := t.mh.loadAllTiDBMVRefresh(t.ctx, t.sysSessionPool)
+	newPending, err := t.mh.LoadAllTiDBMVRefresh(t.ctx, t.sysSessionPool)
 	if err != nil {
 		result = mvDurationResultFailed
 		fields := append(t.runtimeLogFields(), zap.Error(err))
@@ -1031,7 +1030,6 @@ func (t *MVService) runGCOperationHistory(now time.Time, historyGCInterval time.
 		if r := recover(); r != nil {
 			result = mvDurationResultFailed
 			t.scheduleHistoryGCFailure(now, historyGCInterval)
-			t.mh.observeRunEvent(mvRunEventRecoveredPanic)
 			fields := append(t.runtimeLogFields(), zap.Any("panic", r), zap.ByteString("stack", debug.Stack()))
 			logutil.BgLogger().Error("MVService history GC panicked", fields...)
 		}
@@ -1041,7 +1039,7 @@ func (t *MVService) runGCOperationHistory(now time.Time, historyGCInterval time.
 	if err != nil {
 		result = mvDurationResultFailed
 		t.scheduleHistoryGCFailure(now, historyGCInterval)
-		t.mh.observeRunEvent(mvRunEventHistoryGCGetTSOErr)
+		t.mh.observeRunEvent(mvRunEventGetTSOErr)
 		fields := append(t.runtimeLogFields(), zap.Error(err))
 		logutil.BgLogger().Warn("get current tso failed when GC MV/MVLOG operation history", fields...)
 		return
@@ -1132,13 +1130,6 @@ func (t *MVService) NotifyDDLChange() {
 // Run is the main scheduler loop for MVService.
 // It refreshes server topology, fetches metadata, dispatches due tasks, and reports metrics.
 func (t *MVService) Run() {
-	defer func() {
-		if r := recover(); r != nil {
-			t.mh.observeRunEvent(mvRunEventRecoveredPanic)
-			fields := append(t.runtimeLogFields(), zap.Any("panic", r), zap.ByteString("stack", debug.Stack()))
-			logutil.BgLogger().Error("MVService panicked", fields...)
-		}
-	}()
 	if !t.sch.init() {
 		t.mh.observeRunEvent(mvRunEventInitFailed)
 		return

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -112,16 +112,30 @@ func (*serviceHelper) serverFilter(s serverInfo) bool {
 	return true
 }
 
-func buildDeleteMVRefreshAlertSQL(mviewIDs []int64) string {
-	var sql strings.Builder
-	sql.WriteString("DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID IN (")
+func appendMViewIDInCondition(sql *strings.Builder, mviewIDs []int64) {
+	sql.WriteString("(")
 	for i, mviewID := range mviewIDs {
 		if i > 0 {
 			sql.WriteString(",")
 		}
-		sqlescape.MustFormatSQL(&sql, "%?", mviewID)
+		sqlescape.MustFormatSQL(sql, "%?", mviewID)
 	}
 	sql.WriteString(")")
+}
+
+func buildDeleteResolvedMVRefreshAlertSQL(mviewIDs []int64) string {
+	var sql strings.Builder
+	sql.WriteString("DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID IN ")
+	appendMViewIDInCondition(&sql, mviewIDs)
+	sql.WriteString(" AND REFRESH_FAILED IS NULL")
+	return sql.String()
+}
+
+func buildClearResolvedMVRefreshAlertLevelSQL(updatedAt time.Time, mviewIDs []int64) string {
+	var sql strings.Builder
+	sqlescape.MustFormatSQL(&sql, "UPDATE mysql.tidb_mview_refresh_alert SET ALERT_LEVEL = NULL, UPDATED_AT = %? WHERE MVIEW_ID IN ", updatedAt.Round(0))
+	appendMViewIDInCondition(&sql, mviewIDs)
+	sql.WriteString(" AND REFRESH_FAILED IS NOT NULL AND ALERT_LEVEL IS NOT NULL")
 	return sql.String()
 }
 
@@ -167,7 +181,14 @@ func buildCleanupStaleMVRefreshAlertSQL() string {
 	return `DELETE a
 FROM mysql.tidb_mview_refresh_alert AS a
 LEFT JOIN mysql.tidb_mview_refresh_info AS i ON a.MVIEW_ID = i.MVIEW_ID
-WHERE i.MVIEW_ID IS NULL OR i.NEXT_TIME IS NULL`
+WHERE i.MVIEW_ID IS NULL OR (a.ALERT_LEVEL IS NULL AND a.REFRESH_FAILED IS NULL)`
+}
+
+func buildClearDisabledMVRefreshAlertLevelSQL() string {
+	return `UPDATE mysql.tidb_mview_refresh_alert AS a
+JOIN mysql.tidb_mview_refresh_info AS i ON a.MVIEW_ID = i.MVIEW_ID
+SET a.ALERT_LEVEL = NULL, a.UPDATED_AT = NOW(6)
+WHERE i.NEXT_TIME IS NULL AND a.ALERT_LEVEL IS NOT NULL`
 }
 
 func (*serviceHelper) SyncMVRefreshAlertStates(
@@ -188,7 +209,7 @@ func (*serviceHelper) SyncMVRefreshAlertStates(
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
 	sctx := se.(sessionctx.Context)
 
-	deleteIDs := make([]int64, 0, len(states))
+	resolvedIDs := make([]int64, 0, len(states))
 	upsertStates := make([]refreshAlertTask, 0, len(states))
 	for _, state := range states {
 		if state.mviewID <= 0 {
@@ -198,15 +219,19 @@ func (*serviceHelper) SyncMVRefreshAlertStates(
 			continue
 		}
 		if state.alertLevel == "" {
-			deleteIDs = append(deleteIDs, state.mviewID)
+			resolvedIDs = append(resolvedIDs, state.mviewID)
 			continue
 		}
 		upsertStates = append(upsertStates, state)
 	}
 
-	for start := 0; start < len(deleteIDs); start += refreshAlertWriteBatchSize {
-		end := min(start+refreshAlertWriteBatchSize, len(deleteIDs))
-		if _, err := execRCRestrictedSQLWithSession(ctx, sctx, buildDeleteMVRefreshAlertSQL(deleteIDs[start:end]), nil); err != nil {
+	for start := 0; start < len(resolvedIDs); start += refreshAlertWriteBatchSize {
+		end := min(start+refreshAlertWriteBatchSize, len(resolvedIDs))
+		ids := resolvedIDs[start:end]
+		if _, err := execRCRestrictedSQLWithSession(ctx, sctx, buildDeleteResolvedMVRefreshAlertSQL(ids), nil); err != nil {
+			return err
+		}
+		if _, err := execRCRestrictedSQLWithSession(ctx, sctx, buildClearResolvedMVRefreshAlertLevelSQL(updatedAt, ids), nil); err != nil {
 			return err
 		}
 	}
@@ -224,6 +249,9 @@ func (*serviceHelper) CleanupStaleMVRefreshAlerts(
 	sysSessionPool basic.SessionPool,
 ) error {
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
+	if _, err := execRCRestrictedSQLWithSessionPool(ctx, sysSessionPool, buildClearDisabledMVRefreshAlertLevelSQL(), nil); err != nil {
+		return err
+	}
 	_, err := execRCRestrictedSQLWithSessionPool(ctx, sysSessionPool, buildCleanupStaleMVRefreshAlertSQL(), nil)
 	return err
 }
@@ -1267,8 +1295,8 @@ func purgeMVHistoryByCountLimitInBatches(
 	return nil
 }
 
-// loadAllTiDBMVLogPurge loads all scheduled MV log purge tasks from metadata.
-func (*serviceHelper) loadAllTiDBMVLogPurge(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mvLog, error) {
+// LoadAllTiDBMVLogPurge loads all scheduled MV log purge tasks from metadata.
+func (*serviceHelper) LoadAllTiDBMVLogPurge(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mvLog, error) {
 	const sql = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) as NEXT_TIME_SEC, MLOG_ID FROM mysql.tidb_mlog_purge_info WHERE NEXT_TIME IS NOT NULL`
 	rows, err := execRCRestrictedSQLWithSessionPool(ctx, sysSessionPool, sql, nil)
 	if err != nil {
@@ -1294,8 +1322,8 @@ func (*serviceHelper) loadAllTiDBMVLogPurge(ctx context.Context, sysSessionPool 
 	return newPending, nil
 }
 
-// loadAllTiDBMVRefresh loads all scheduled MV refresh tasks from metadata.
-func (*serviceHelper) loadAllTiDBMVRefresh(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mv, error) {
+// LoadAllTiDBMVRefresh loads all scheduled MV refresh tasks from metadata.
+func (*serviceHelper) LoadAllTiDBMVRefresh(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mv, error) {
 	const sql = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) as NEXT_TIME_SEC, MVIEW_ID, LAST_SUCCESS_READ_TSO FROM mysql.tidb_mview_refresh_info WHERE NEXT_TIME IS NOT NULL`
 	se, err := sysSessionPool.Get()
 	if err != nil {

--- a/pkg/mvservice/task_handler.go
+++ b/pkg/mvservice/task_handler.go
@@ -39,8 +39,8 @@ type MVTaskHandler interface {
 	TryBackoffPurgeManualCancel(ctx context.Context, sysSessionPool basic.SessionPool, mvLogID int64, nextPurge time.Time) (applied bool, appliedNext time.Time, err error)
 	SyncMVRefreshAlertStates(ctx context.Context, sysSessionPool basic.SessionPool, updatedAt time.Time, states []refreshAlertTask) error
 	CleanupStaleMVRefreshAlerts(ctx context.Context, sysSessionPool basic.SessionPool) error
-	loadAllTiDBMVLogPurge(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mvLog, error)
-	loadAllTiDBMVRefresh(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mv, error)
+	LoadAllTiDBMVLogPurge(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mvLog, error)
+	LoadAllTiDBMVRefresh(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mv, error)
 	GetCurrentTSO(ctx context.Context, sysSessionPool basic.SessionPool) (uint64, error)
 	PurgeMVHistoryBeforeTSO(
 		ctx context.Context,

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -485,7 +485,7 @@ func (m *mockMVServiceHelper) CleanupStaleMVRefreshAlerts(_ context.Context, _ b
 	return m.cleanupStaleRefreshAlertErr
 }
 
-func (m *mockMVServiceHelper) loadAllTiDBMVLogPurge(context.Context, basic.SessionPool) (map[int64]*mvLog, error) {
+func (m *mockMVServiceHelper) LoadAllTiDBMVLogPurge(context.Context, basic.SessionPool) (map[int64]*mvLog, error) {
 	m.fetchLogsCalls.Add(1)
 	if m.fetchLogsErr != nil {
 		return nil, m.fetchLogsErr
@@ -493,7 +493,7 @@ func (m *mockMVServiceHelper) loadAllTiDBMVLogPurge(context.Context, basic.Sessi
 	return m.fetchLogs, nil
 }
 
-func (m *mockMVServiceHelper) loadAllTiDBMVRefresh(context.Context, basic.SessionPool) (map[int64]*mv, error) {
+func (m *mockMVServiceHelper) LoadAllTiDBMVRefresh(context.Context, basic.SessionPool) (map[int64]*mv, error) {
 	m.fetchViewCalls.Add(1)
 	if m.fetchViewsErr != nil {
 		return nil, m.fetchViewsErr
@@ -854,7 +854,7 @@ func TestMVServiceMaybeGCMVHistorySkipsWhenNotOwner(t *testing.T) {
 
 	svc.maybeGCOperationHistory(mvsNow())
 	require.Equal(t, int32(0), helper.historyGCCalls.Load())
-	require.Equal(t, 0, helper.runEventCount(mvRunEventHistoryGCGetTSOErr))
+	require.Equal(t, 0, helper.runEventCount(mvRunEventGetTSOErr))
 	require.Equal(t, 0, helper.taskDurationCount(mvTaskDurationTypeHistoryGC, mvDurationResultSuccess))
 	require.Equal(t, 0, helper.taskDurationCount(mvTaskDurationTypeHistoryGC, mvDurationResultFailed))
 	require.Equal(t, int64(0), svc.historyGCRetryCount.Load())
@@ -889,7 +889,7 @@ func TestMVServiceMaybeGCMVHistoryReportsMetrics(t *testing.T) {
 		svc.maybeGCOperationHistory(mvsNow())
 		require.Equal(t, int32(0), helper.historyGCCalls.Load())
 		require.Eventually(t, func() bool {
-			return helper.runEventCount(mvRunEventHistoryGCGetTSOErr) > 0
+			return helper.runEventCount(mvRunEventGetTSOErr) > 0
 		}, testEventuallyWait, testEventuallyTick)
 		require.Eventually(t, func() bool {
 			return helper.taskDurationCount(mvTaskDurationTypeHistoryGC, mvDurationResultFailed) > 0
@@ -927,7 +927,7 @@ func TestMVServiceMaybeGCMVHistoryReportsMetrics(t *testing.T) {
 		svc.maybeGCOperationHistory(startAt)
 		require.Equal(t, int32(0), helper.historyGCCalls.Load())
 		require.Eventually(t, func() bool {
-			return helper.runEventCount(mvRunEventHistoryGCGetTSOErr) > 0
+			return helper.runEventCount(mvRunEventGetTSOErr) > 0
 		}, testEventuallyWait, testEventuallyTick)
 
 		helper.currentTSOErr = nil
@@ -973,9 +973,6 @@ func TestMVServiceMaybeGCMVHistoryReportsMetrics(t *testing.T) {
 		setHistoryGCOwnerForTest(svc, 5)
 
 		svc.maybeGCOperationHistory(mvsNow())
-		require.Eventually(t, func() bool {
-			return helper.runEventCount(mvRunEventRecoveredPanic) > 0
-		}, testEventuallyWait, testEventuallyTick)
 		require.Eventually(t, func() bool {
 			return helper.taskDurationCount(mvTaskDurationTypeHistoryGC, mvDurationResultFailed) > 0
 		}, testEventuallyWait, testEventuallyTick)
@@ -1562,7 +1559,7 @@ func TestServerHelperLoadAllTiDBMLogPurge(t *testing.T) {
 	}
 	pool := recordingSessionPool{se: se}
 
-	got, err := (&serviceHelper{}).loadAllTiDBMVLogPurge(context.Background(), pool)
+	got, err := (&serviceHelper{}).LoadAllTiDBMVLogPurge(context.Background(), pool)
 	require.NoError(t, err)
 	require.Equal(t, []string{testSQLFetchMVLogPurge}, se.executedRestrictedSQL)
 	require.Len(t, got, 2)
@@ -1614,7 +1611,7 @@ func TestServerHelperLoadAllTiDBMVRefresh(t *testing.T) {
 	}
 	pool := recordingSessionPool{se: se}
 
-	got, err := (&serviceHelper{}).loadAllTiDBMVRefresh(context.Background(), pool)
+	got, err := (&serviceHelper{}).LoadAllTiDBMVRefresh(context.Background(), pool)
 	require.NoError(t, err)
 	require.Equal(t, []string{testSQLFetchMVRefresh}, se.executedRestrictedSQL)
 	require.Len(t, got, 2)
@@ -2673,13 +2670,38 @@ func TestServerHelperSyncMVRefreshAlertStates(t *testing.T) {
 	require.NoError(t, err)
 	upsertSQL := buildUpsertMVRefreshAlertSQL(now, []refreshAlertTask{states[0], states[1], states[5]})
 	require.Equal(t, []string{
-		buildDeleteMVRefreshAlertSQL([]int64{103}),
+		buildDeleteResolvedMVRefreshAlertSQL([]int64{103}),
+		buildClearResolvedMVRefreshAlertLevelSQL(now, []int64{103}),
 		upsertSQL,
 	}, se.executedRestrictedSQL)
+	require.Len(t, se.executedRestrictedArg, 3)
 	require.Contains(t, upsertSQL, "'mv_no_success', 'warning', NULL,")
-	require.Len(t, se.executedRestrictedArg, 2)
 	require.Empty(t, se.executedRestrictedArg[0])
 	require.Empty(t, se.executedRestrictedArg[1])
+	require.Empty(t, se.executedRestrictedArg[2])
+}
+
+func TestBuildResolvedMVRefreshAlertSQL(t *testing.T) {
+	installMockTimeForTest(t)
+
+	now := mvsNow().Round(0)
+	ids := []int64{103, 104}
+
+	require.Equal(t,
+		"DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID IN (103,104) AND REFRESH_FAILED IS NULL",
+		buildDeleteResolvedMVRefreshAlertSQL(ids),
+	)
+	require.Equal(t,
+		"UPDATE mysql.tidb_mview_refresh_alert SET ALERT_LEVEL = NULL, UPDATED_AT = '"+now.Format("2006-01-02 15:04:05")+"' WHERE MVIEW_ID IN (103,104) AND REFRESH_FAILED IS NOT NULL AND ALERT_LEVEL IS NOT NULL",
+		buildClearResolvedMVRefreshAlertLevelSQL(now, ids),
+	)
+	require.Equal(t,
+		`UPDATE mysql.tidb_mview_refresh_alert AS a
+JOIN mysql.tidb_mview_refresh_info AS i ON a.MVIEW_ID = i.MVIEW_ID
+SET a.ALERT_LEVEL = NULL, a.UPDATED_AT = NOW(6)
+WHERE i.NEXT_TIME IS NULL AND a.ALERT_LEVEL IS NOT NULL`,
+		buildClearDisabledMVRefreshAlertLevelSQL(),
+	)
 }
 
 func TestServerHelperCleanupStaleMVRefreshAlerts(t *testing.T) {
@@ -2688,9 +2710,10 @@ func TestServerHelperCleanupStaleMVRefreshAlerts(t *testing.T) {
 
 	err := (&serviceHelper{}).CleanupStaleMVRefreshAlerts(context.Background(), pool)
 	require.NoError(t, err)
-	require.Equal(t, []string{buildCleanupStaleMVRefreshAlertSQL()}, se.executedRestrictedSQL)
-	require.Len(t, se.executedRestrictedArg, 1)
+	require.Equal(t, []string{buildClearDisabledMVRefreshAlertLevelSQL(), buildCleanupStaleMVRefreshAlertSQL()}, se.executedRestrictedSQL)
+	require.Len(t, se.executedRestrictedArg, 2)
 	require.Empty(t, se.executedRestrictedArg[0])
+	require.Empty(t, se.executedRestrictedArg[1])
 }
 
 func TestServerHelperTryBackoffPurgeManualCancel(t *testing.T) {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5365,6 +5365,11 @@ func TestMaterializedViewStatements(t *testing.T) {
 			"CREATE MATERIALIZED VIEW `mv` (`a`) ATTRIBUTES='mview_alert_warning=300,mview_alert_overdue=600' AS SELECT 1",
 		},
 		{
+			"CREATE MATERIALIZED VIEW mv (a) ATTRIBUTES='mview_alert_warning=300,mview_alert_overdue=600,mview_alert_refresh_failed=yes' AS SELECT 1",
+			true,
+			"CREATE MATERIALIZED VIEW `mv` (`a`) ATTRIBUTES='mview_alert_warning=300,mview_alert_overdue=600,mview_alert_refresh_failed=yes' AS SELECT 1",
+		},
+		{
 			"CREATE MATERIALIZED VIEW mv (a) REFRESH FAST ATTRIBUTES='mview_alert_warning=300' AS SELECT 1",
 			true,
 			"CREATE MATERIALIZED VIEW `mv` (`a`) REFRESH FAST ATTRIBUTES='mview_alert_warning=300' AS SELECT 1",
@@ -5428,6 +5433,16 @@ func TestMaterializedViewStatements(t *testing.T) {
 			"ALTER MATERIALIZED VIEW mv ATTRIBUTES='mview_alert_warning=5,mview_alert_overdue=5'",
 			true,
 			"ALTER MATERIALIZED VIEW `mv` ATTRIBUTES='mview_alert_warning=5,mview_alert_overdue=5'",
+		},
+		{
+			"ALTER MATERIALIZED VIEW mv ATTRIBUTES='mview_alert_warning=5,mview_alert_overdue=5,mview_alert_refresh_failed=no'",
+			true,
+			"ALTER MATERIALIZED VIEW `mv` ATTRIBUTES='mview_alert_warning=5,mview_alert_overdue=5,mview_alert_refresh_failed=no'",
+		},
+		{
+			"ALTER MATERIALIZED VIEW mv REFRESH NEXT 300, ATTRIBUTES='mview_alert_warning=5,mview_alert_overdue=10'",
+			true,
+			"ALTER MATERIALIZED VIEW `mv` REFRESH NEXT 300, ATTRIBUTES='mview_alert_warning=5,mview_alert_overdue=10'",
 		},
 		{
 			"ALTER MATERIALIZED VIEW LOG ON t PURGE IMMEDIATE",

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -808,7 +808,8 @@ const (
 		MVIEW_ID bigint NOT NULL,
 		MV_SCHEMA varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
 		MV_NAME varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
-		ALERT_LEVEL varchar(16) NOT NULL,
+		ALERT_LEVEL varchar(16) DEFAULT NULL,
+		REFRESH_FAILED varchar(3) DEFAULT NULL,
 		LAST_SUCCESS_TIME datetime(6) DEFAULT NULL,
 		UPDATED_AT datetime(6) DEFAULT NULL,
 		PRIMARY KEY(MVIEW_ID))`
@@ -1305,12 +1306,16 @@ const (
 	// Add REFRESH_COMMIT_TSO and lookup index to MV refresh history table.
 	version226 = 226
 
-	// next version should start with 239
+	// version 227
+	// Add REFRESH_FAILED and allow NULL ALERT_LEVEL in MV refresh alert table.
+	version227 = 227
+
+	// next version should start with 228
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version226
+var currentBootstrapVersion int64 = version227
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -1492,6 +1497,7 @@ var (
 		upgradeToVer224,
 		upgradeToVer225,
 		upgradeToVer226,
+		upgradeToVer227,
 	}
 )
 
@@ -3429,6 +3435,14 @@ func upgradeToVer226(s sessiontypes.Session, ver int64) {
 	}
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mview_refresh_hist ADD COLUMN `REFRESH_COMMIT_TSO` bigint unsigned DEFAULT NULL AFTER `REFRESH_READ_TSO`", infoschema.ErrColumnExists)
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mview_refresh_hist ADD INDEX idx_mv_name_commit_tso (MV_SCHEMA, MV_NAME, REFRESH_COMMIT_TSO)", dbterror.ErrDupKeyName)
+}
+
+func upgradeToVer227(s sessiontypes.Session, ver int64) {
+	if ver >= version227 {
+		return
+	}
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mview_refresh_alert MODIFY COLUMN `ALERT_LEVEL` varchar(16) DEFAULT NULL")
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mview_refresh_alert ADD COLUMN `REFRESH_FAILED` varchar(3) DEFAULT NULL AFTER `ALERT_LEVEL`", infoschema.ErrColumnExists)
 }
 
 // initGlobalVariableIfNotExists initialize a global variable with specific val if it does not exist.

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1310,7 +1310,7 @@ const (
 	// Add REFRESH_FAILED and allow NULL ALERT_LEVEL in MV refresh alert table.
 	version227 = 227
 
-	// next version should start with 228
+	// next version should start with 239
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.

--- a/pkg/session/bootstraptest/mview_systable_test.go
+++ b/pkg/session/bootstraptest/mview_systable_test.go
@@ -104,6 +104,10 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 		Check(testkit.Rows("utf8mb4_general_ci", "utf8mb4_general_ci"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name='ALERT_LEVEL'").
 		Check(testkit.Rows("varchar(16)"))
+	tk.MustQuery("select is_nullable from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name='ALERT_LEVEL'").
+		Check(testkit.Rows("YES"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name='REFRESH_FAILED'").
+		Check(testkit.Rows("varchar(3)"))
 	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name in ('LAST_SUCCESS_TIME', 'UPDATED_AT') order by column_name").
 		Check(testkit.Rows("6", "6"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and index_name='PRIMARY' order by seq_in_index").
@@ -398,13 +402,17 @@ func TestUpgradeToVer224MaterializedViewHistoryDurationIndexesAndAlertTable(t *t
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and index_name='PRIMARY' order by seq_in_index").
 		Check(testkit.Rows("mview_id"))
 	tk.MustQuery("select lower(column_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' order by ordinal_position").
-		Check(testkit.Rows("mview_id", "mv_schema", "mv_name", "alert_level", "last_success_time", "updated_at"))
+		Check(testkit.Rows("mview_id", "mv_schema", "mv_name", "alert_level", "refresh_failed", "last_success_time", "updated_at"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name in ('MV_SCHEMA', 'MV_NAME') order by column_name").
 		Check(testkit.Rows("varchar(64)", "varchar(64)"))
 	tk.MustQuery("select lower(collation_name) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name in ('MV_SCHEMA', 'MV_NAME') order by column_name").
 		Check(testkit.Rows("utf8mb4_general_ci", "utf8mb4_general_ci"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name='ALERT_LEVEL'").
 		Check(testkit.Rows("varchar(16)"))
+	tk.MustQuery("select is_nullable from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name='ALERT_LEVEL'").
+		Check(testkit.Rows("YES"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name='REFRESH_FAILED'").
+		Check(testkit.Rows("varchar(3)"))
 	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mview_refresh_alert' and column_name in ('LAST_SUCCESS_TIME', 'UPDATED_AT') order by column_name").
 		Check(testkit.Rows("6", "6"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_refresh_duration_sec' order by seq_in_index").


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref #18023

Problem Summary:
Cherry-pick of pingcap/tidb#68249 into the 8.5 materialized view release branch.

Original PR: pingcap/tidb#68249

### What changed and how does it work?
This PR adds the `mview_alert_refresh_failed` MV attribute and updates `mysql.tidb_mview_refresh_alert` so failed alert state can be tracked separately from resolved alerts.

### Check List

Tests <!-- At least one of them must be included. -->
- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > - PR is a release-branch cherry-pick of an already-reviewed upstream change; no additional local validation was run in this turn.

Side effects
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `mview_alert_refresh_failed` materialized-view attribute (`yes`/`no`) to control whether refresh failures are recorded and surfaced in alerts.
  * `SHOW CREATE MATERIALIZED VIEW` and `ALTER MATERIALIZED VIEW ... ATTRIBUTES` now expose and honor the setting.

* **Bug Fixes**
  * Improved refresh-failure alert handling: failures can be reported before refresh history is written, resolved alerts are cleared correctly, and disabled refresh scheduling now preserves the failure alert state as intended.

* **Chores**
  * Updated system-table schema to support `refresh_failed` and a nullable alert level.

* **Tests**
  * Expanded DDL, executor, and refresh-alert test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->