### PR TITLE
test: stabilize flaky TestSelectWhereInvalidDSTTime

### DIFF
--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -877,9 +877,10 @@ func TestSelectWhereInvalidDSTTime(t *testing.T) {
 
 	// Compares as TIMESTAMP; the range is converted to TIMESTAMP by current TIME_ZONE,
 	// and then compared with the row which is TIMESTAMP.
-	tk.MustExec("alter table t add index idx_ts(ts)")
-	tk.MustQuery(`select *, unix_timestamp(ts) from t where ts between '2025-03-30 02:30:00' AND '2025-03-30 03:00:00'`).Check(testkit.Rows("3 2025-03-30 03:00:00 1743296400", "4 2025-03-30 03:00:00 1743296400"))
-	explain = tk.MustQuery(`explain select *, unix_timestamp(ts) from t where ts between '2025-03-30 02:30:00' AND '2025-03-30 03:00:00'`)
+	tk.MustExec("create table t_idx (id int, ts timestamp, index idx_ts(ts))")
+	tk.MustExec("insert into t_idx select * from t")
+	tk.MustQuery(`select *, unix_timestamp(ts) from t_idx where ts between '2025-03-30 02:30:00' AND '2025-03-30 03:00:00'`).Check(testkit.Rows("3 2025-03-30 03:00:00 1743296400", "4 2025-03-30 03:00:00 1743296400"))
+	explain = tk.MustQuery(`explain select *, unix_timestamp(ts) from t_idx where ts between '2025-03-30 02:30:00' AND '2025-03-30 03:00:00'`)
 	explain.MultiCheckContain([]string{"IndexLookUp", "range:[2025-03-30 03:00:00,2025-03-30 03:00:00]"})
 	explain.CheckNotContain("02:30:00")
 	// Why 3 warnings?!?


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68291

Problem Summary:
Flaky test `TestSelectWhereInvalidDSTTime` in `pkg/executor/test/simpletest` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Unnecessary ALTER TABLE ADD INDEX exposed the test to DDL reorg timing/resource-pressure flakiness.

#### Fix

The indexed-path assertion only needs an indexed table, not online index creation.

#### Verification

Spec:
- target: `pkg/executor/test/simpletest :: TestSelectWhereInvalidDSTTime`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
ddl_timing_repro passed.
target_flaky passed.
package_scope passed.
build passed.

Gate checklist:
- ddl_timing_repro: PASS
- target_flaky: PASS
- package_scope: PASS
- build: PASS

Commands:
- `timeout 30s env GO_FAILPOINTS='github.com/pingcap/tidb/pkg/ddl/create-index-stuck-before-ddlhistory=return("/tmp/tidb-flakyfixer-add-index-stuck")' go test -v -tags=intest,deadlock ./pkg/executor/test/simpletest -run '^TestSelectWhereInvalidDSTTime$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/executor/test/simpletest -run '^TestSelectWhereInvalidDSTTime$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/executor/test/simpletest -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test structure for time-based query validation to use a separate indexed table for improved test isolation and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->