### PR TITLE
ddl, executor: reject truncating mview-related tables with mlog guards

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -4801,6 +4801,9 @@ func (e *executor) TruncateTable(ctx sessionctx.Context, ti ast.Ident) error {
 	if tblInfo.MaterializedViewLog != nil {
 		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("TRUNCATE TABLE on materialized view log table")
 	}
+	if tblInfo.MaterializedViewBase != nil && tblInfo.MaterializedViewBase.MLogID != 0 {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("TRUNCATE TABLE on base table with materialized view log")
+	}
 	if err := checkTableMaterializedViewConstraints(ctx.GetSessionVars(), tblInfo, "TRUNCATE TABLE"); err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -143,3 +143,15 @@ func TestImportIntoChildSessionInheritsMaintenanceFlag(t *testing.T) {
 	require.True(t, invoked)
 	require.True(t, childMaintenance)
 }
+
+func TestImportIntoRejectsMaterializedViewLogBaseTable(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table src (a int)")
+	tk.MustExec("create table dst (a int)")
+	tk.MustExec("create materialized view log on dst (a)")
+
+	err := tk.ExecToErr("import into dst from select * from src with disable_precheck")
+	require.ErrorContains(t, err, "IMPORT INTO on tables with materialized view log")
+}

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -540,16 +540,22 @@ func TestTruncateMaterializedViewRelatedTablesRejected(t *testing.T) {
 	tk.MustExec("create table t_truncate_mv (a int not null, b int)")
 	tk.MustExec("create materialized view log on t_truncate_mv (a, b)")
 
+	err := tk.ExecToErr("truncate table t_truncate_mv")
+	require.ErrorContains(t, err, "TRUNCATE TABLE on base table with materialized view log")
+
+	err = tk.ExecToErr("truncate table `$mlog$t_truncate_mv`")
+	require.ErrorContains(t, err, "TRUNCATE TABLE on materialized view log table")
+
 	tk.MustExec("create materialized view mv_truncate_mv (a, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, count(1) from t_truncate_mv group by a")
 
-	err := tk.ExecToErr("truncate table mv_truncate_mv")
+	err = tk.ExecToErr("truncate table mv_truncate_mv")
 	require.ErrorContains(t, err, "TRUNCATE TABLE on materialized view table")
 
 	err = tk.ExecToErr("truncate table `$mlog$t_truncate_mv`")
 	require.ErrorContains(t, err, "TRUNCATE TABLE on materialized view log table")
 
 	err = tk.ExecToErr("truncate table t_truncate_mv")
-	require.ErrorContains(t, err, "TRUNCATE TABLE on base table with materialized view dependencies")
+	require.ErrorContains(t, err, "TRUNCATE TABLE on base table with materialized view log")
 }
 
 func TestMaterializedViewRelatedTablesDDLRejected(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:

This PR backports the fix from original PR #68556 to `feature/release-8.5-materialized-view`.

Base tables that already have a materialized view log could still be truncated when no materialized view dependency existed yet. This should be rejected because the base table is already tied to the materialized view log metadata and log table.

The truncate behavior around materialized view log tables should also be covered in the same mlog-only state, so `TRUNCATE TABLE` on the physical mlog table is explicitly locked down before any materialized view exists.

### What changed and how does it work?

This PR carries the same fix as original PR #68556 on the MV release branch.

- Reject `TRUNCATE TABLE` when the target base table already has an mlog, returning `TRUNCATE TABLE on base table with materialized view log`.
- Keep `TRUNCATE TABLE` on the physical materialized view log table rejected in the mlog-only state.
- Keep regression coverage for `IMPORT INTO ... WITH disable_precheck` on a base table with materialized view log.

Regression coverage in this branch includes:

- `TRUNCATE TABLE` on an mlog-only base table before any materialized view exists.
- `TRUNCATE TABLE` on the physical materialized view log table before any materialized view exists.
- `TRUNCATE TABLE` on a base table after a materialized view exists, using the materialized view log guard.
- `IMPORT INTO ... WITH disable_precheck` on a base table with a materialized view log.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Disallow truncating tables associated with materialized view logs.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TRUNCATE TABLE operations on base tables with materialized view logs are now rejected with appropriate error messages
  * IMPORT INTO operations on tables with materialized view logs are now rejected to prevent invalid operations

* **Tests**
  * Added test coverage for materialized view log constraint validation
  * Enhanced test coverage for truncation rejection on base tables with materialized view logs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->