### PR TITLE
test: stabilize flaky TestKVEncoderCastErrorMessage

### DIFF
--- a/pkg/executor/importer/kv_encode_test.go
+++ b/pkg/executor/importer/kv_encode_test.go
@@ -21,9 +21,11 @@ import (
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/lightning/backend/encode"
 	"github.com/pingcap/tidb/pkg/lightning/log"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/session"
+	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/types"
@@ -89,15 +91,24 @@ func TestKVEncoderForDupResolve(t *testing.T) {
 }
 
 func TestKVEncoderCastErrorMessage(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t(c1 tinyint)")
-
-	do, err := session.GetDomain(store)
-	require.NoError(t, err)
-	table, err := do.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
-	require.NoError(t, err)
+	fieldType := types.NewFieldType(mysql.TypeTiny)
+	fieldType.SetFlen(4)
+	tableInfo := &model.TableInfo{
+		ID:    1,
+		Name:  ast.NewCIStr("t"),
+		State: model.StatePublic,
+		Columns: []*model.ColumnInfo{
+			{
+				ID:        1,
+				Name:      ast.NewCIStr("c1"),
+				Offset:    0,
+				State:     model.StatePublic,
+				FieldType: *fieldType,
+			},
+		},
+	}
+	table := tables.MockTableFromMeta(tableInfo)
+	require.NotNil(t, table)
 
 	encodeCfg := &encode.EncodingConfig{
 		Table:  table,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68374

Problem Summary:
Flaky test `TestKVEncoderCastErrorMessage` in `pkg/executor/importer` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Full mock-store/domain setup was unnecessary for the target cast-error assertion and created the timing window.

#### Fix

Direct table metadata preserves the same encoder/cast path while removing unrelated DDL/bootstrap work.

#### Verification

Spec:
- target: `pkg/executor/importer :: TestKVEncoderCastErrorMessage`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_exact passed.
build passed.

Gate checklist:
- target_exact: PASS
- timing_repro: SKIPPED
- package_failpoint: SKIPPED
- build: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/executor/importer -run '^TestKVEncoderCastErrorMessage$' -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test infrastructure for KV encoder error handling validation.

**Note:** This release contains internal testing improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->