### PR TITLE
lightning: stabilize error log checks

### DIFF
--- a/lightning/tests/lightning_config_max_error/run.sh
+++ b/lightning/tests/lightning_config_max_error/run.sh
@@ -87,9 +87,11 @@ check_contains "COUNT(*): ${remaining_row_count}"
 # import a fourth time
 run_sql 'DROP TABLE IF EXISTS lightning_task_info.conflict_records_v2'
 run_sql 'DROP VIEW IF EXISTS lightning_task_info.conflict_view'
-! run_lightning --backend local --config "${mydir}/ignore_config.toml"
+ignore_config_log="$TEST_DIR/${TEST_NAME}.ignore-config.log"
+rm -f "$ignore_config_log"
+! run_lightning --backend local --config "${mydir}/ignore_config.toml" --log-file "$ignore_config_log"
 [ $? -eq 0 ]
-tail -n 10 $TEST_DIR/lightning.log | grep "ERROR" | tail -n 1 | grep -Fq "[Lightning:Config:ErrInvalidConfig]conflict.strategy cannot be set to \\\"ignore\\\" when use tikv-importer.backend = \\\"local\\\""
+grep "ERROR" "$ignore_config_log" | grep -Fq "[Lightning:Config:ErrInvalidConfig]conflict.strategy cannot be set to \\\"ignore\\\" when use tikv-importer.backend = \\\"local\\\""
 
 # Check tidb backend record duplicate entry in conflict_records_v2 table
 run_sql 'DROP TABLE IF EXISTS lightning_task_info.conflict_records_v2'

--- a/lightning/tests/lightning_duplicate_resolution_error/run.sh
+++ b/lightning/tests/lightning_duplicate_resolution_error/run.sh
@@ -24,9 +24,11 @@ run_sql 'DROP TABLE IF EXISTS dup_resolve.a'
 run_sql 'DROP TABLE IF EXISTS lightning_task_info.conflict_error_v4'
 run_sql 'DROP VIEW IF EXISTS lightning_task_info.conflict_view'
 
-! run_lightning --backend local --config "${mydir}/config.toml"
+error_log="$TEST_DIR/${TEST_NAME}.error.log"
+rm -f "$error_log"
+! run_lightning --backend local --config "${mydir}/config.toml" --log-file "$error_log"
 [ $? -eq 0 ]
 
-tail -n 10 $TEST_DIR/lightning.log | grep "ERROR" | tail -n 1 | grep -Fq "[Lightning:Restore:ErrFoundDataConflictRecords]found data conflict records in table a, primary key is '3', row data is '(3, 3, \\\"3.csv\\\")'"
+grep "ERROR" "$error_log" | grep -Fq "[Lightning:Restore:ErrFoundDataConflictRecords]found data conflict records in table a, primary key is '3', row data is '(3, 3, \\\"3.csv\\\")'"
 
-check_not_contains "the whole procedure completed" $TEST_DIR/lightning.log
+check_not_contains "the whole procedure completed" "$error_log"

--- a/lightning/tests/lightning_duplicate_resolution_error_pk_multiple_files/run.sh
+++ b/lightning/tests/lightning_duplicate_resolution_error_pk_multiple_files/run.sh
@@ -24,9 +24,11 @@ run_sql 'DROP TABLE IF EXISTS dup_resolve.a'
 run_sql 'DROP TABLE IF EXISTS lightning_task_info.conflict_error_v4'
 run_sql 'DROP VIEW IF EXISTS lightning_task_info.conflict_view'
 
-! run_lightning --backend local --config "${mydir}/config.toml"
+error_log="$TEST_DIR/${TEST_NAME}.error.log"
+rm -f "$error_log"
+! run_lightning --backend local --config "${mydir}/config.toml" --log-file "$error_log"
 [ $? -eq 0 ]
 
-tail -n 10 $TEST_DIR/lightning.log | grep "ERROR" | tail -n 1 | grep -Fq "[Lightning:Restore:ErrFoundDataConflictRecords]found data conflict records in table a"
+grep "ERROR" "$error_log" | grep -Fq "[Lightning:Restore:ErrFoundDataConflictRecords]found data conflict records in table a"
 
-check_not_contains "the whole procedure completed" $TEST_DIR/lightning.log
+check_not_contains "the whole procedure completed" "$error_log"

--- a/lightning/tests/lightning_duplicate_resolution_error_uk_multiple_files/run.sh
+++ b/lightning/tests/lightning_duplicate_resolution_error_uk_multiple_files/run.sh
@@ -24,9 +24,11 @@ run_sql 'DROP TABLE IF EXISTS dup_resolve.a'
 run_sql 'DROP TABLE IF EXISTS lightning_task_info.conflict_error_v4'
 run_sql 'DROP VIEW IF EXISTS lightning_task_info.conflict_view'
 
-! run_lightning --backend local --config "${mydir}/config.toml"
+error_log="$TEST_DIR/${TEST_NAME}.error.log"
+rm -f "$error_log"
+! run_lightning --backend local --config "${mydir}/config.toml" --log-file "$error_log"
 [ $? -eq 0 ]
 
-tail -n 10 $TEST_DIR/lightning.log | grep "ERROR" | tail -n 1 | grep -Fq "[Lightning:Restore:ErrFoundIndexConflictRecords]found index conflict records in table a, index name is 'a.key_b', unique key is '[101]', primary key is '1'"
+grep "ERROR" "$error_log" | grep -Fq "[Lightning:Restore:ErrFoundIndexConflictRecords]found index conflict records in table a, index name is 'a.key_b', unique key is '[101]', primary key is '1'"
 
-check_not_contains "the whole procedure completed" $TEST_DIR/lightning.log
+check_not_contains "the whole procedure completed" "$error_log"

--- a/lightning/tests/lightning_duplicate_resolution_error_uk_multiple_files_multicol_index/run.sh
+++ b/lightning/tests/lightning_duplicate_resolution_error_uk_multiple_files_multicol_index/run.sh
@@ -24,9 +24,11 @@ run_sql 'DROP TABLE IF EXISTS dup_resolve.a'
 run_sql 'DROP TABLE IF EXISTS lightning_task_info.conflict_error_v4'
 run_sql 'DROP VIEW IF EXISTS lightning_task_info.conflict_view'
 
-! run_lightning --backend local --config "${mydir}/config.toml"
+error_log="$TEST_DIR/${TEST_NAME}.error.log"
+rm -f "$error_log"
+! run_lightning --backend local --config "${mydir}/config.toml" --log-file "$error_log"
 [ $? -eq 0 ]
 
-tail -n 10 $TEST_DIR/lightning.log | grep "ERROR" | tail -n 1 | grep -Fq "[Lightning:Restore:ErrFoundIndexConflictRecords]found index conflict records in table a, index name is 'a.key_bd', unique key is '[101 9]', primary key is '1'"
+grep "ERROR" "$error_log" | grep -Fq "[Lightning:Restore:ErrFoundIndexConflictRecords]found index conflict records in table a, index name is 'a.key_bd', unique key is '[101 9]', primary key is '1'"
 
-check_not_contains "the whole procedure completed" $TEST_DIR/lightning.log
+check_not_contains "the whole procedure completed" "$error_log"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69224

Problem Summary:

Some Lightning integration tests checked expected error messages only within the last 10 lines of `lightning.log`. The `lightning_duplicate_resolution_error_uk_multiple_files` case can fail even when Lightning emits the expected `ErrFoundIndexConflictRecords`, because trailing shutdown/client cleanup logs can push the last `ERROR` line outside that fixed window.

### What changed and how does it work?

This PR gives each expected-failure assertion a dedicated log file. Before the target `run_lightning` invocation, the test removes that file and passes it through `--log-file`; the assertion then checks the clean per-invocation log instead of the accumulated default `$TEST_DIR/lightning.log`.

This preserves the requirement that the expected text appears on an error log line, avoids dependence on shutdown log volume, and avoids matching stale errors from earlier `run_lightning` calls in the same test case.

The same pattern is updated in related duplicate-resolution/config error assertions under `lightning/tests`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

```bash
# Stale expected text in the default accumulated log should not satisfy the
# assertion when the clean per-invocation log does not contain the error.
tmp=$(mktemp -d); TEST_DIR="$tmp"; TEST_NAME=lightning_duplicate_resolution_error_uk_multiple_files; cat > "$TEST_DIR/lightning.log" <<'EOF'
[ERROR] stale default log has the expected [Lightning:Restore:ErrFoundIndexConflictRecords]found index conflict records in table a, index name is 'a.key_b', unique key is '[101]', primary key is '1'
EOF
error_log="$TEST_DIR/${TEST_NAME}.error.log"; rm -f "$error_log"; : > "$error_log"; if grep "ERROR" "$error_log" | grep -Fq "[Lightning:Restore:ErrFoundIndexConflictRecords]found index conflict records in table a, index name is 'a.key_b', unique key is '[101]', primary key is '1'"; then exit 1; fi

# A current-run error in the clean log should match even with more than 10 trailing INFO lines.
tmp=$(mktemp -d); TEST_DIR="$tmp"; TEST_NAME=lightning_duplicate_resolution_error_uk_multiple_files; error_log="$TEST_DIR/${TEST_NAME}.error.log"; rm -f "$error_log"; cat > "$error_log" <<'EOF'
[ERROR] [main.go:110] ["tidb lightning encountered error stack info"] [error="[Lightning:Restore:ErrFoundIndexConflictRecords]found index conflict records in table a, index name is 'a.key_b', unique key is '[101]', primary key is '1'"]
[INFO] cleanup 1
[INFO] cleanup 2
[INFO] cleanup 3
[INFO] cleanup 4
[INFO] cleanup 5
[INFO] cleanup 6
[INFO] cleanup 7
[INFO] cleanup 8
[INFO] cleanup 9
[INFO] cleanup 10
[INFO] cleanup 11
EOF
grep "ERROR" "$error_log" | grep -Fq "[Lightning:Restore:ErrFoundIndexConflictRecords]found index conflict records in table a, index name is 'a.key_b', unique key is '[101]', primary key is '1'"

bash -n lightning/tests/lightning_duplicate_resolution_error_uk_multiple_files/run.sh lightning/tests/lightning_duplicate_resolution_error_uk_multiple_files_multicol_index/run.sh lightning/tests/lightning_duplicate_resolution_error_pk_multiple_files/run.sh lightning/tests/lightning_duplicate_resolution_error/run.sh lightning/tests/lightning_config_max_error/run.sh
git diff --check
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated multiple Lightning test scripts to write output to dedicated per-test log files using `--log-file`, clearing any prior contents before each run.
  * Improved error validation by grepping for specific `ERROR` messages within the new per-test logs (including exact conflict/error text).
  * Adjusted “procedure completed” assertions to check the same dedicated error log instead of relying on shared logs or tailing the last lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->