### PR TITLE
executor, session: guard fast refresh against hazardous mlog purge

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -116,5 +116,5 @@ func TestCheckSysTableCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(227), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(228), session.CurrentBootstrapVersion)
 }

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -661,7 +661,7 @@ func TestColumnTable(t *testing.T) {
 		testkit.RowsWithSep("|",
 			"test|tbl1|col_2"))
 	tk.MustQuery(`select count(*) from information_schema.columns;`).Check(
-		testkit.RowsWithSep("|", "5029"))
+		testkit.RowsWithSep("|", "5030"))
 }
 
 func TestIndexUsageTable(t *testing.T) {

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -88,6 +88,7 @@ const (
 	purgeHistStatusRunning          = "running"
 	purgeHistStatusSuccess          = "success"
 	purgeHistStatusFailed           = "failed"
+	purgeHistStatusOrphaned         = "orphaned"
 	mvRefreshAdvisoryLockTimeoutSec = int64(1)
 	mvRefreshShadowTablePrefix      = "__mv_shadow_"
 	mvRefreshImportIntoStoreName    = "TiKV"
@@ -1505,39 +1506,6 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 	}
 	safePurgeTSO = purgeStartTS
 	purgeJobID = purgeStartTS
-	if err := insertMLogPurgeHistRunning(
-		kctx,
-		histSQLExec,
-		purgeJobID,
-		mlogID,
-		schemaName.O,
-		baseTableMeta.Name.O,
-		purgeMethod,
-		histTime(purgeStart, histLoc),
-	); err != nil {
-		return finalizeFailure(err)
-	}
-	purgeHistRunningInserted = true
-	stopTaskMonitor, err = startMVTaskMonitor(
-		kctx,
-		e.GetSysSession,
-		func(sctx sessionctx.Context) {
-			e.ReleaseSysSession(releaseCtx, sctx)
-		},
-		taskCancelController,
-		fmt.Sprintf("mlog-purge-%d", purgeJobID),
-		func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) (bool, string, error) {
-			return readPurgeHistCancelRequest(watchCtx, watchSQLExec, purgeJobID, mlogID)
-		},
-		func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) error {
-			return updatePurgeHistHeartbeat(watchCtx, watchSQLExec, purgeJobID, mlogID)
-		},
-	)
-	if err != nil {
-		return finalizeFailure(err)
-	}
-	failpoint.Inject("pausePurgeMaterializedViewLogAfterInsertPurgeHistRunning", func() {})
-
 	publicMVIDs, buildingMVIDs, err := collectDependentMViewIDsForMLogPurge(kctx, sqlExec, baseTableMeta, mlogID)
 	if err != nil {
 		return finalizeFailure(err)
@@ -1554,66 +1522,118 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 	if err != nil {
 		return finalizeFailure(err)
 	}
-	skipDeleteByCheckpoint := lockedLastPurgedTSOReady && lockedLastPurgedTSO >= safePurgeTSO
-	if !skipDeleteByCheckpoint && safePurgeTSO > 0 {
-		throttlePlan = tryBuildMLogPurgeThrottlePlanBestEffort(
+
+	purgeCutoffFenceTSO := uint64(0)
+	if lockedLastPurgedTSOReady {
+		purgeCutoffFenceTSO = lockedLastPurgedTSO
+	}
+	latestRecordedCutoffTSO, hasLatestRecordedCutoffTSO, err := readLatestMLogPurgeCutoffFenceTSO(kctx, histSQLExec, mlogID)
+	if err != nil {
+		return finalizeFailure(err)
+	}
+	if hasLatestRecordedCutoffTSO && latestRecordedCutoffTSO > purgeCutoffFenceTSO {
+		purgeCutoffFenceTSO = latestRecordedCutoffTSO
+	}
+	// Do not write a lower PURGE_CUTOFF_TSO. This keeps the per-MLOG cutoff
+	// fence monotonic with PURGE_JOB_ID, which the FAST refresh integrity check
+	// depends on when it reads the latest hazardous purge history row.
+	skipPurgeByCutoffFence := safePurgeTSO < purgeCutoffFenceTSO
+	skipDeleteByCheckpoint := false
+	if !skipPurgeByCutoffFence {
+		if err := insertMLogPurgeHistRunning(
 			kctx,
-			e.Ctx().GetSessionVars(),
-			scheduleEvalSctx,
-			purgeSctx,
-			countSQLExec,
-			countSessVars,
-			mlogInfo,
-			isInternalSQL,
+			histSQLExec,
+			purgeJobID,
+			mlogID,
 			schemaName.O,
-			mlogName.O,
-			lockedLastPurgedTSO,
-			lockedLastPurgedTSOReady,
+			baseTableMeta.Name.O,
+			purgeMethod,
 			safePurgeTSO,
-			lockedNextTime,
-		)
-		if throttlePlan != nil {
-			effectiveBatchSize = throttlePlan.effectiveDeleteBatchSize(batchSize)
+			histTime(purgeStart, histLoc),
+		); err != nil {
+			return finalizeFailure(err)
 		}
-		deleteLoopStart = time.Now()
-		for {
-			batchPurgeRows, batchErr := purgeMaterializedViewLogData(
+		purgeHistRunningInserted = true
+		stopTaskMonitor, err = startMVTaskMonitor(
+			kctx,
+			e.GetSysSession,
+			func(sctx sessionctx.Context) {
+				e.ReleaseSysSession(releaseCtx, sctx)
+			},
+			taskCancelController,
+			fmt.Sprintf("mlog-purge-%d", purgeJobID),
+			func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) (bool, string, error) {
+				return readPurgeHistCancelRequest(watchCtx, watchSQLExec, purgeJobID, mlogID)
+			},
+			func(watchCtx context.Context, watchSQLExec sqlexec.SQLExecutor) error {
+				return updatePurgeHistHeartbeat(watchCtx, watchSQLExec, purgeJobID, mlogID)
+			},
+		)
+		if err != nil {
+			return finalizeFailure(err)
+		}
+		failpoint.Inject("pausePurgeMaterializedViewLogAfterInsertPurgeHistRunning", func() {})
+		skipDeleteByCheckpoint = lockedLastPurgedTSOReady && lockedLastPurgedTSO >= safePurgeTSO
+		if !skipDeleteByCheckpoint && safePurgeTSO > 0 {
+			throttlePlan = tryBuildMLogPurgeThrottlePlanBestEffort(
 				kctx,
-				deleteSQLExec,
-				deleteSessVars,
+				e.Ctx().GetSessionVars(),
+				scheduleEvalSctx,
+				purgeSctx,
+				countSQLExec,
+				countSessVars,
+				mlogInfo,
+				isInternalSQL,
 				schemaName.O,
 				mlogName.O,
 				lockedLastPurgedTSO,
 				lockedLastPurgedTSOReady,
 				safePurgeTSO,
-				effectiveBatchSize,
+				lockedNextTime,
 			)
-			totalPurgeRows += batchPurgeRows
-			failpoint.Inject("pausePurgeMaterializedViewLogAfterDeleteBatch", func() {})
-			if batchErr != nil {
-				_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
-				txnFinished = true
-				return finalizeFailure(batchErr)
-			}
-			if batchPurgeRows < effectiveBatchSize {
-				break
-			}
 			if throttlePlan != nil {
-				if sleepErr := throttlePlan.maybeSleep(kctx, deleteLoopStart, totalPurgeRows); sleepErr != nil {
-					if taskCancelController.isManualCancelRequested() {
-						return finalizeFailure(sleepErr)
+				effectiveBatchSize = throttlePlan.effectiveDeleteBatchSize(batchSize)
+			}
+			deleteLoopStart = time.Now()
+			for {
+				batchPurgeRows, batchErr := purgeMaterializedViewLogData(
+					kctx,
+					deleteSQLExec,
+					deleteSessVars,
+					schemaName.O,
+					mlogName.O,
+					lockedLastPurgedTSO,
+					lockedLastPurgedTSOReady,
+					safePurgeTSO,
+					effectiveBatchSize,
+				)
+				totalPurgeRows += batchPurgeRows
+				failpoint.Inject("pausePurgeMaterializedViewLogAfterDeleteBatch", func() {})
+				if batchErr != nil {
+					_, _ = sqlExec.ExecuteInternal(finalizeCtx, "ROLLBACK")
+					txnFinished = true
+					return finalizeFailure(batchErr)
+				}
+				if batchPurgeRows < effectiveBatchSize {
+					break
+				}
+				if throttlePlan != nil {
+					if sleepErr := throttlePlan.maybeSleep(kctx, deleteLoopStart, totalPurgeRows); sleepErr != nil {
+						if taskCancelController.isManualCancelRequested() {
+							return finalizeFailure(sleepErr)
+						}
+						logutil.BgLogger().Warn(
+							"purge materialized view log: adaptive throttle sleep failed, fallback to unthrottled purge",
+							zap.String("schemaName", schemaName.O),
+							zap.String("tableName", mlogName.O),
+							zap.Uint64("safePurgeTSO", safePurgeTSO),
+							zap.Error(sleepErr),
+						)
+						throttlePlan = nil
+						effectiveBatchSize = batchSize
+					} else {
+						effectiveBatchSize = throttlePlan.effectiveDeleteBatchSize(batchSize)
 					}
-					logutil.BgLogger().Warn(
-						"purge materialized view log: adaptive throttle sleep failed, fallback to unthrottled purge",
-						zap.String("schemaName", schemaName.O),
-						zap.String("tableName", mlogName.O),
-						zap.Uint64("safePurgeTSO", safePurgeTSO),
-						zap.Error(sleepErr),
-					)
-					throttlePlan = nil
-					effectiveBatchSize = batchSize
-				} else {
-					effectiveBatchSize = throttlePlan.effectiveDeleteBatchSize(batchSize)
 				}
 			}
 		}
@@ -1635,7 +1655,7 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		return finalizeFailure(err)
 	}
 	var lastPurgedTSOToPersist *uint64
-	if !skipDeleteByCheckpoint {
+	if !skipPurgeByCutoffFence && !skipDeleteByCheckpoint {
 		lastPurgedTSOToPersist = &safePurgeTSO
 	}
 	if err = updateMaterializedViewLogPurgeInfoOnSuccess(
@@ -2444,6 +2464,7 @@ func insertMLogPurgeHistRunning(
 	baseTableSchema string,
 	baseTableName string,
 	purgeMethod string,
+	purgeCutoffTSO uint64,
 	purgeStartAt time.Time,
 ) error {
 	insertSQL := `INSERT INTO mysql.tidb_mlog_purge_hist (
@@ -2455,8 +2476,10 @@ func insertMLogPurgeHistRunning(
 		PURGE_TIME,
 		PURGE_ROWS,
 		PURGE_STATUS,
+		PURGE_CUTOFF_TSO,
 		LAST_HEARTBEAT_AT
 	) VALUES (
+		%?,
 		%?,
 		%?,
 		%?,
@@ -2478,6 +2501,7 @@ func insertMLogPurgeHistRunning(
 		purgeStartAt,
 		int64(0),
 		purgeHistStatusRunning,
+		purgeCutoffTSO,
 		purgeStartAt,
 	)
 	if err != nil {
@@ -3094,10 +3118,30 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		applyMVRefreshStmtResult(e.Ctx().GetSessionVars().StmtCtx, newMVRefreshStmtResultFromWriteCounts(0, 0, 0))
 		return nil
 	}
+	histSctx, err := e.GetSysSession()
+	if err != nil {
+		return err
+	}
+	defer e.ReleaseSysSession(releaseCtx, histSctx)
+	histSQLExec := histSctx.GetSQLExecutor()
+	histLoc := histSctx.GetSessionVars().Location()
+
 	boundedFastRefresh := refreshMode == ast.RefreshMaterializedViewModeFast &&
 		!lockedReadTSONull &&
 		targetRefreshReadTSO > 0 &&
 		targetRefreshReadTSO > lockedReadTSO
+	if refreshMode == ast.RefreshMaterializedViewModeFast && !lockedReadTSONull {
+		// Read purge metadata through an internal session so this precheck sees latest committed state
+		// instead of the refresh transaction's repeatable-read startTS snapshot.
+		//
+		// This is still a best-effort guard rather than a strict serialization point with future purge.
+		// In theory, a concurrently-started purge should still be safe because purge computes safePurgeTSO
+		// from persisted LAST_SUCCESS_READ_TSO, which does not advance until this refresh commits.
+		is := e.Ctx().GetDomainInfoSchema().(infoschema.InfoSchema)
+		if err := checkFastRefreshMLogIntegrity(kctx, histSQLExec, is, schemaName, tblInfo, lockedReadTSO); err != nil {
+			return err
+		}
+	}
 
 	txn, err := refreshSctx.Txn(true)
 	if err != nil {
@@ -3108,14 +3152,6 @@ func (e *RefreshMaterializedViewExec) executeRefreshMaterializedView(kctx contex
 		return errors.New("refresh materialized view: invalid transaction start tso")
 	}
 	refreshJobID = startTS
-
-	histSctx, err := e.GetSysSession()
-	if err != nil {
-		return err
-	}
-	defer e.ReleaseSysSession(releaseCtx, histSctx)
-	histSQLExec := histSctx.GetSQLExecutor()
-	histLoc := histSctx.GetSessionVars().Location()
 
 	if err := observeMVRefreshStep(e.stepObserver, stepSet.insertHistRunning, func() error {
 		return insertRefreshHistRunning(
@@ -3973,6 +4009,38 @@ func (e *RefreshMaterializedViewExec) resolveRefreshMaterializedViewTarget(
 	return schemaName, tblInfo, nil
 }
 
+func resolveRefreshMaterializedViewLogInfo(
+	is infoschema.InfoSchema,
+	schemaName pmodel.CIStr,
+	tblInfo *model.TableInfo,
+) (int64, error) {
+	if tblInfo == nil || tblInfo.MaterializedView == nil {
+		return 0, errors.New("refresh materialized view: target is not a materialized view")
+	}
+	if len(tblInfo.MaterializedView.BaseTableIDs) != 1 {
+		return 0, errors.New("refresh materialized view: fast refresh requires exactly one base table")
+	}
+
+	baseTableID := tblInfo.MaterializedView.BaseTableIDs[0]
+	baseTable, ok := is.TableByID(context.Background(), baseTableID)
+	if !ok {
+		return 0, errors.Errorf("refresh materialized view: cannot resolve base table %d for materialized view %s.%s", baseTableID, schemaName.O, tblInfo.Name.O)
+	}
+	baseTableInfo := baseTable.Meta()
+	if baseTableInfo.MaterializedViewBase == nil {
+		return 0, errors.Errorf("refresh materialized view: base table %d is missing materialized view base metadata", baseTableID)
+	}
+	mlogID := baseTableInfo.MaterializedViewBase.MLogID
+	if mlogID == 0 {
+		return 0, errors.Errorf(
+			"refresh materialized view: materialized view log does not exist for base table %s.%s",
+			schemaName.O,
+			baseTableInfo.Name.O,
+		)
+	}
+	return mlogID, nil
+}
+
 func checkRefreshMaterializedViewReady(schemaName pmodel.CIStr, tblInfo *model.TableInfo) error {
 	if tblInfo == nil || tblInfo.MaterializedView == nil {
 		return nil
@@ -4108,6 +4176,140 @@ func readRefreshInfoReadTSO(
 		readTSO = recheckRow.GetUint64(0)
 	}
 	return readTSO, readTSONull, nil
+}
+
+func readMLogPurgeInfoLastPurgedTSO(
+	kctx context.Context,
+	sqlExec sqlexec.SQLExecutor,
+	mlogID int64,
+) (lastPurgedTSO uint64, hasLastPurgedTSO bool, err error) {
+	rows, err := sqlexec.ExecSQL(
+		kctx,
+		sqlExec,
+		"SELECT LAST_PURGED_TSO FROM mysql.tidb_mlog_purge_info WHERE MLOG_ID = %?",
+		mlogID,
+	)
+	if err != nil {
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return 0, false, errors.New("refresh materialized view: required system table mysql.tidb_mlog_purge_info does not exist")
+		}
+		return 0, false, errors.Trace(err)
+	}
+	if len(rows) == 0 {
+		return 0, false, errors.Errorf("refresh materialized view: mlog purge info row missing for mlog id %d", mlogID)
+	}
+	if rows[0].IsNull(0) {
+		return 0, false, nil
+	}
+	return rows[0].GetUint64(0), true, nil
+}
+
+func readLatestMLogPurgeCutoffFenceTSO(
+	kctx context.Context,
+	sqlExec sqlexec.SQLExecutor,
+	mlogID int64,
+) (purgeCutoffTSO uint64, hasCutoff bool, err error) {
+	rows, err := sqlexec.ExecSQL(
+		kctx,
+		sqlExec,
+		`SELECT PURGE_CUTOFF_TSO
+FROM mysql.tidb_mlog_purge_hist
+WHERE MLOG_ID = %?
+  AND PURGE_CUTOFF_TSO IS NOT NULL
+ORDER BY PURGE_JOB_ID DESC
+LIMIT 1`,
+		mlogID,
+	)
+	if err != nil {
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return 0, false, errors.New("purge materialized view log: required system table mysql.tidb_mlog_purge_hist does not exist")
+		}
+		return 0, false, errors.Trace(err)
+	}
+	if len(rows) == 0 || rows[0].IsNull(0) {
+		return 0, false, nil
+	}
+	return rows[0].GetUint64(0), true, nil
+}
+
+// readLatestHazardousMLogPurgeCutoffTSO relies on purge-side monotonic cutoff
+// enforcement: purge skips before writing history if its newly computed
+// safePurgeTSO is lower than the latest recorded non-NULL PURGE_CUTOFF_TSO.
+func readLatestHazardousMLogPurgeCutoffTSO(
+	kctx context.Context,
+	sqlExec sqlexec.SQLExecutor,
+	mlogID int64,
+) (purgeCutoffTSO uint64, hasHazard bool, err error) {
+	rows, err := sqlexec.ExecSQL(
+		kctx,
+		sqlExec,
+		`SELECT PURGE_CUTOFF_TSO
+FROM mysql.tidb_mlog_purge_hist
+WHERE MLOG_ID = %?
+  AND (
+    PURGE_STATUS = %?
+    OR PURGE_STATUS = %?
+    OR PURGE_ROWS > 0
+  )
+ORDER BY PURGE_JOB_ID DESC
+LIMIT 1`,
+		mlogID,
+		purgeHistStatusRunning,
+		purgeHistStatusOrphaned,
+	)
+	if err != nil {
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return 0, false, errors.New("refresh materialized view: required system table mysql.tidb_mlog_purge_hist does not exist")
+		}
+		return 0, false, errors.Trace(err)
+	}
+	if len(rows) == 0 || rows[0].IsNull(0) {
+		return 0, false, nil
+	}
+	return rows[0].GetUint64(0), true, nil
+}
+
+func checkFastRefreshMLogIntegrity(
+	kctx context.Context,
+	sqlExec sqlexec.SQLExecutor,
+	is infoschema.InfoSchema,
+	schemaName pmodel.CIStr,
+	tblInfo *model.TableInfo,
+	lastSuccessfulRefreshReadTSO uint64,
+) error {
+	if lastSuccessfulRefreshReadTSO == 0 {
+		return nil
+	}
+
+	mlogID, err := resolveRefreshMaterializedViewLogInfo(is, schemaName, tblInfo)
+	if err != nil {
+		return err
+	}
+
+	lastPurgedTSO, hasLastPurgedTSO, err := readMLogPurgeInfoLastPurgedTSO(kctx, sqlExec, mlogID)
+	if err != nil {
+		return err
+	}
+	latestHazardCutoffTSO, hasLatestHazardCutoffTSO, err := readLatestHazardousMLogPurgeCutoffTSO(kctx, sqlExec, mlogID)
+	if err != nil {
+		return err
+	}
+
+	hazardTSO := uint64(0)
+	if hasLastPurgedTSO {
+		hazardTSO = lastPurgedTSO
+	}
+	if hasLatestHazardCutoffTSO && latestHazardCutoffTSO > hazardTSO {
+		hazardTSO = latestHazardCutoffTSO
+	}
+	if hazardTSO > lastSuccessfulRefreshReadTSO {
+		return errors.Errorf(
+			"refresh materialized view fast: materialized view log may have been purged beyond LAST_SUCCESS_READ_TSO (hazard tso %d, LAST_SUCCESS_READ_TSO %d)",
+			hazardTSO,
+			lastSuccessfulRefreshReadTSO,
+		)
+	}
+	return nil
 }
 
 func executeRefreshMaterializedViewDataChanges(

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -1196,6 +1196,11 @@ func TestPurgeMaterializedViewLogBatchDelete(t *testing.T) {
 			"from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1",
 		mlogID,
 	)).Check(testkit.Rows("success 5 1 1"))
+	tk.MustQuery(fmt.Sprintf(
+		"select PURGE_CUTOFF_TSO is not null, PURGE_CUTOFF_TSO >= %d from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1",
+		maxCommitTS,
+		mlogID,
+	)).Check(testkit.Rows("1 1"))
 	tk.MustQuery(fmt.Sprintf("select BASE_TABLE_SCHEMA, BASE_TABLE_NAME from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1", mlogID)).
 		Check(testkit.Rows("test t_purge_batch_delete"))
 	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_hist where BASE_TABLE_SCHEMA = 'TEST' and BASE_TABLE_NAME = 'T_PURGE_BATCH_DELETE' and MLOG_ID = %d", mlogID)).
@@ -1244,6 +1249,54 @@ func TestPurgeMaterializedViewLogLastPurgedTSOShortCircuit(t *testing.T) {
 		Check(testkit.Rows("success 0"))
 	tk.MustQuery(fmt.Sprintf("select LAST_PURGED_TSO from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).
 		Check(testkit.Rows(fmt.Sprintf("%d", maxCommitTS)))
+}
+
+func TestPurgeMaterializedViewLogSkipsWhenCutoffFenceWouldGoBackward(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_purge_cutoff_fence (a int not null, b int)")
+	tk.MustExec("create materialized view log on t_purge_cutoff_fence (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_purge_cutoff_fence (a, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, count(1) from t_purge_cutoff_fence group by a")
+	tk.MustExec("insert into t_purge_cutoff_fence values (1, 10), (1, 20), (2, 30)")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("mv_purge_cutoff_fence"))
+	require.NoError(t, err)
+	mvID := mvTable.Meta().ID
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_cutoff_fence"))
+	require.NoError(t, err)
+	mlogID := mlogTable.Meta().ID
+
+	maxCommitTS, err := strconv.ParseUint(fmt.Sprint(tk.MustQuery("select max(_tidb_commit_ts) from `$mlog$t_purge_cutoff_fence`").Rows()[0][0]), 10, 64)
+	require.NoError(t, err)
+	tk.MustExec(fmt.Sprintf("update mysql.tidb_mview_refresh_info set LAST_SUCCESS_READ_TSO = %d where MVIEW_ID = %d", maxCommitTS, mvID))
+
+	cutoffFenceTSO := maxCommitTS + 1000
+	tk.MustExec(fmt.Sprintf(
+		`insert into mysql.tidb_mlog_purge_hist (
+			PURGE_JOB_ID, MLOG_ID, BASE_TABLE_SCHEMA, BASE_TABLE_NAME, PURGE_METHOD,
+			PURGE_TIME, PURGE_ROWS, PURGE_STATUS, PURGE_CUTOFF_TSO, LAST_HEARTBEAT_AT
+		) values (
+			%[1]d, %[2]d, 'test', 't_purge_cutoff_fence', 'manual',
+			now(6), 0, 'success', %[1]d, now(6)
+		)`,
+		cutoffFenceTSO,
+		mlogID,
+	))
+
+	tk.MustExec("purge materialized view log on t_purge_cutoff_fence")
+	require.Equal(t, uint64(0), tk.Session().AffectedRows())
+	tk.CheckLastMessage("Rows inserted: 0  Updated: 0  Deleted: 0")
+
+	tk.MustQuery("select count(*) from `$mlog$t_purge_cutoff_fence`").Check(testkit.Rows("3"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_hist where MLOG_ID = %d", mlogID)).
+		Check(testkit.Rows("1"))
+	tk.MustQuery(fmt.Sprintf("select PURGE_CUTOFF_TSO from mysql.tidb_mlog_purge_hist where MLOG_ID = %d order by PURGE_JOB_ID desc limit 1", mlogID)).
+		Check(testkit.Rows(fmt.Sprintf("%d", cutoffFenceTSO)))
+	tk.MustQuery(fmt.Sprintf("select LAST_PURGED_TSO is null from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).
+		Check(testkit.Rows("1"))
 }
 
 func TestPurgeMaterializedViewLogDeleteErrorNoDirtyWrite(t *testing.T) {

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -1593,6 +1593,116 @@ func TestMaterializedViewRefreshFastAsOfTimestampEarlyFailureWritesHistReadTSO(t
 	)).Check(testkit.Rows("failed 1 1 1 1 1 1"))
 }
 
+func TestMaterializedViewFastRefreshRejectsHazardousPurgeHist(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_refresh_purge_guard (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on t_refresh_purge_guard (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_refresh_purge_guard (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_refresh_purge_guard group by a")
+	tk.MustExec("insert into t_refresh_purge_guard values (1, 10), (2, 20)")
+	tk.MustExec("refresh materialized view mv_refresh_purge_guard fast")
+	tk.MustExec("insert into t_refresh_purge_guard values (3, 30)")
+
+	mvIDRows := tk.MustQuery("select tidb_table_id from information_schema.tables where table_schema = 'test' and table_name = 'mv_refresh_purge_guard'").Rows()
+	require.Len(t, mvIDRows, 1)
+	mvID, err := strconv.ParseInt(fmt.Sprintf("%v", mvIDRows[0][0]), 10, 64)
+	require.NoError(t, err)
+
+	mlogIDRows := tk.MustQuery("select tidb_table_id from information_schema.tables where table_schema = 'test' and table_name = '$mlog$t_refresh_purge_guard'").Rows()
+	require.Len(t, mlogIDRows, 1)
+	mlogID, err := strconv.ParseInt(fmt.Sprintf("%v", mlogIDRows[0][0]), 10, 64)
+	require.NoError(t, err)
+
+	lastSuccessRows := tk.MustQuery(fmt.Sprintf("select LAST_SUCCESS_READ_TSO from mysql.tidb_mview_refresh_info where MVIEW_ID = %d", mvID)).Rows()
+	require.Len(t, lastSuccessRows, 1)
+	lastSuccessReadTSO, err := strconv.ParseUint(fmt.Sprintf("%v", lastSuccessRows[0][0]), 10, 64)
+	require.NoError(t, err)
+
+	tk.MustExec(fmt.Sprintf("update mysql.tidb_mlog_purge_info set LAST_PURGED_TSO = %d where MLOG_ID = %d", lastSuccessReadTSO, mlogID))
+	tk.MustExec(fmt.Sprintf(
+		`insert into mysql.tidb_mlog_purge_hist (
+			PURGE_JOB_ID, MLOG_ID, BASE_TABLE_SCHEMA, BASE_TABLE_NAME, PURGE_METHOD,
+			PURGE_TIME, PURGE_ROWS, PURGE_STATUS, PURGE_CUTOFF_TSO, LAST_HEARTBEAT_AT
+		) values (
+			%[1]d, %[2]d, 'test', 't_refresh_purge_guard', 'manual',
+			now(6), 0, 'running', %[3]d, now(6)
+		)`,
+		lastSuccessReadTSO+1000,
+		mlogID,
+		lastSuccessReadTSO+1,
+	))
+
+	err = tk.ExecToErr("refresh materialized view mv_refresh_purge_guard fast")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "materialized view log may have been purged beyond LAST_SUCCESS_READ_TSO")
+
+	tk.MustQuery(fmt.Sprintf("select LAST_SUCCESS_READ_TSO from mysql.tidb_mview_refresh_info where MVIEW_ID = %d", mvID)).
+		Check(testkit.Rows(fmt.Sprintf("%d", lastSuccessReadTSO)))
+
+	const afterBeginFailpoint = "github.com/pingcap/tidb/pkg/executor/refreshMaterializedViewAfterBegin"
+	pauseCh := make(chan struct{})
+	hitCh := make(chan struct{})
+	require.NoError(t, failpoint.EnableCall(afterBeginFailpoint, func() {
+		select {
+		case <-hitCh:
+		default:
+			close(hitCh)
+		}
+		<-pauseCh
+	}))
+	defer func() {
+		select {
+		case <-pauseCh:
+		default:
+			close(pauseCh)
+		}
+		require.NoError(t, failpoint.Disable(afterBeginFailpoint))
+	}()
+
+	tk.MustExec(fmt.Sprintf("delete from mysql.tidb_mlog_purge_hist where MLOG_ID = %d", mlogID))
+	tk.MustExec(fmt.Sprintf("update mysql.tidb_mlog_purge_info set LAST_PURGED_TSO = %d where MLOG_ID = %d", lastSuccessReadTSO, mlogID))
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		tkRefresh := testkit.NewTestKit(t, store)
+		tkRefresh.MustExec("use test")
+		refreshDone <- tkRefresh.ExecToErr("refresh materialized view mv_refresh_purge_guard fast")
+	}()
+
+	select {
+	case <-hitCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for refresh to reach failpoint")
+	}
+
+	tkConcurrent := testkit.NewTestKit(t, store)
+	tkConcurrent.MustExec("use test")
+	tkConcurrent.MustExec(fmt.Sprintf(
+		`insert into mysql.tidb_mlog_purge_hist (
+			PURGE_JOB_ID, MLOG_ID, BASE_TABLE_SCHEMA, BASE_TABLE_NAME, PURGE_METHOD,
+			PURGE_TIME, PURGE_ROWS, PURGE_STATUS, PURGE_CUTOFF_TSO, LAST_HEARTBEAT_AT
+		) values (
+			%[1]d, %[2]d, 'test', 't_refresh_purge_guard', 'manual',
+			now(6), 0, 'running', %[3]d, now(6)
+		)`,
+		lastSuccessReadTSO+2000,
+		mlogID,
+		lastSuccessReadTSO+1,
+	))
+
+	close(pauseCh)
+
+	select {
+	case err = <-refreshDone:
+		require.Error(t, err)
+		require.ErrorContains(t, err, "materialized view log may have been purged beyond LAST_SUCCESS_READ_TSO")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for refresh to finish")
+	}
+}
+
 func TestMaterializedViewRefreshFailedAlertByAttribute(t *testing.T) {
 	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -826,6 +826,7 @@ const (
 		PURGE_DURATION_SEC decimal(18,6) DEFAULT NULL,
 		PURGE_ROWS bigint NOT NULL,
 		PURGE_STATUS varchar(16) DEFAULT NULL,
+		PURGE_CUTOFF_TSO bigint unsigned DEFAULT NULL,
 		PURGE_FAILED_REASON text DEFAULT NULL,
 		CANCEL_REQUESTED_AT datetime(6) DEFAULT NULL,
 		CANCEL_REQUESTED_BY varchar(512) DEFAULT NULL,
@@ -1310,12 +1311,16 @@ const (
 	// Add REFRESH_FAILED and allow NULL ALERT_LEVEL in MV refresh alert table.
 	version227 = 227
 
-	// next version should start with 239
+	// version 228
+	// Add PURGE_CUTOFF_TSO to MV log purge history table.
+	version228 = 228
+
+	// next version should start with 229
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version227
+var currentBootstrapVersion int64 = version228
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -1498,6 +1503,7 @@ var (
 		upgradeToVer225,
 		upgradeToVer226,
 		upgradeToVer227,
+		upgradeToVer228,
 	}
 )
 
@@ -3443,6 +3449,13 @@ func upgradeToVer227(s sessiontypes.Session, ver int64) {
 	}
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mview_refresh_alert MODIFY COLUMN `ALERT_LEVEL` varchar(16) DEFAULT NULL")
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mview_refresh_alert ADD COLUMN `REFRESH_FAILED` varchar(3) DEFAULT NULL AFTER `ALERT_LEVEL`", infoschema.ErrColumnExists)
+}
+
+func upgradeToVer228(s sessiontypes.Session, ver int64) {
+	if ver >= version228 {
+		return
+	}
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mlog_purge_hist ADD COLUMN `PURGE_CUTOFF_TSO` bigint unsigned DEFAULT NULL AFTER `PURGE_STATUS`", infoschema.ErrColumnExists)
 }
 
 // initGlobalVariableIfNotExists initialize a global variable with specific val if it does not exist.

--- a/pkg/session/bootstraptest/BUILD.bazel
+++ b/pkg/session/bootstraptest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "mview_systable_test.go",
     ],
     flaky = True,
-    shard_count = 19,
+    shard_count = 20,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/session/bootstraptest/mview_systable_test.go
+++ b/pkg/session/bootstraptest/mview_systable_test.go
@@ -138,6 +138,8 @@ func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
 		Check(testkit.Rows("mlog_id", "base_table_schema", "base_table_name", "purge_method", "purge_time", "purge_endtime", "purge_duration_sec"))
 	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='PURGE_DURATION_SEC'").
 		Check(testkit.Rows("decimal(18,6)"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='PURGE_CUTOFF_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
 	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name in ('PURGE_TIME', 'PURGE_ENDTIME') order by column_name").
 		Check(testkit.Rows("6", "6"))
 	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='CANCEL_REQUESTED_AT'").
@@ -423,6 +425,8 @@ func TestUpgradeToVer224MaterializedViewHistoryDurationIndexesAndAlertTable(t *t
 		Check(testkit.Rows("6"))
 	tk.MustQuery("select datetime_precision from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='LAST_HEARTBEAT_AT'").
 		Check(testkit.Rows("6"))
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='PURGE_CUTOFF_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
 }
 
 func TestUpgradeToVer222MaterializedViewHistoryCancelRequestColumns(t *testing.T) {
@@ -620,4 +624,58 @@ func TestUpgradeToVer226MaterializedViewRefreshCommitTSO(t *testing.T) {
 		Check(testkit.Rows("bigint(20) unsigned"))
 	tk.MustQuery("select lower(column_name) from information_schema.statistics where table_schema='mysql' and table_name='tidb_mview_refresh_hist' and index_name='idx_mv_name_commit_tso' order by seq_in_index").
 		Check(testkit.Rows("mv_schema", "mv_name", "refresh_commit_tso"))
+}
+
+func TestUpgradeToVer228MaterializedViewLogPurgeCutoffTSO(t *testing.T) {
+	ctx := context.Background()
+	store, dom := session.CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	seV227 := session.CreateSessionAndSetID(t, store)
+
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	require.NoError(t, m.FinishBootstrap(int64(227)))
+	require.NoError(t, txn.Commit(ctx))
+
+	revertVersionAndVariables(t, seV227, 227)
+	session.MustExec(t, seV227, "drop table if exists mysql.tidb_mlog_purge_hist")
+	session.MustExec(t, seV227, `create table mysql.tidb_mlog_purge_hist (
+		PURGE_JOB_ID bigint unsigned NOT NULL,
+		MLOG_ID bigint NOT NULL,
+		BASE_TABLE_SCHEMA varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		BASE_TABLE_NAME varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		PURGE_METHOD varchar(32) NOT NULL,
+		PURGE_TIME datetime(6) DEFAULT NULL,
+		PURGE_ENDTIME datetime(6) DEFAULT NULL,
+		PURGE_DURATION_SEC decimal(18,6) DEFAULT NULL,
+		PURGE_ROWS bigint NOT NULL,
+		PURGE_STATUS varchar(16) DEFAULT NULL,
+		PURGE_FAILED_REASON text DEFAULT NULL,
+		CANCEL_REQUESTED_AT datetime(6) DEFAULT NULL,
+		CANCEL_REQUESTED_BY varchar(512) DEFAULT NULL,
+		LAST_HEARTBEAT_AT datetime(6) DEFAULT NULL,
+		PRIMARY KEY(PURGE_JOB_ID),
+		KEY idx_mlog_time (MLOG_ID, PURGE_TIME),
+		KEY idx_table_name_time (BASE_TABLE_SCHEMA, BASE_TABLE_NAME, PURGE_TIME),
+		KEY idx_mlog_status (MLOG_ID, PURGE_STATUS, PURGE_TIME),
+		KEY idx_purge_duration_sec (PURGE_DURATION_SEC),
+		KEY idx_purge_time (PURGE_TIME),
+		KEY idx_purge_status (PURGE_STATUS, PURGE_TIME))`)
+	session.MustExec(t, seV227, "commit")
+
+	session.UnsetStoreBootstrapped(store.UUID())
+	ver, err := session.GetBootstrapVersion(seV227)
+	require.NoError(t, err)
+	require.Equal(t, int64(227), ver)
+
+	dom.Close()
+	domUpgraded, err := session.BootstrapSession(store)
+	require.NoError(t, err)
+	defer domUpgraded.Close()
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustQuery("select lower(column_type) from information_schema.columns where table_schema='mysql' and table_name='tidb_mlog_purge_hist' and column_name='PURGE_CUTOFF_TSO'").
+		Check(testkit.Rows("bigint(20) unsigned"))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:

This PR backports the fix from original PR #68514 to `feature/release-8.5-materialized-view`.

Fast refresh can miss required materialized view log rows if a purge has already deleted them but the purge metadata visible through `LAST_PURGED_TSO` has not advanced yet.

### What changed and how does it work?

This PR carries the same fix as original PR #68514 on the MV release branch.

- Record `PURGE_CUTOFF_TSO` in `mysql.tidb_mlog_purge_hist` when mlog purge starts.
- Keep the per-MLog purge cutoff fence monotonic so later integrity checks can rely on the latest hazardous purge history row.
- Treat running, orphaned, and partially-deleted purge histories as hazardous.
- Reject fast refresh when the hazard cutoff is ahead of `LAST_SUCCESS_READ_TSO`.
- Add bootstrap upgrade coverage for the new system-table column.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fast refresh now rejects execution when recent or in-flight materialized view log purge may have already removed required log rows.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added materialized view log purge safety checks by tracking cutoff-fence metadata to protect fast-refresh.
  * Fast-refresh now blocks when purge history indicates the log may have been purged beyond the last safe point.
* **Bug Fixes**
  * Adjusted information schema expectations in the column-count test.
* **Tests**
  * Added coverage for purge skipping when the cutoff fence would move backward.
  * Added coverage for fast-refresh rejection under hazardous purge history scenarios.
* **Chores**
  * Extended system table schema/versioning to include new purge cutoff timestamp metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->