### PR TITLE
ddl: Truncate mlog name when the table name length exceeds the maximum length

### DIFF
--- a/pkg/ddl/mv_index_test.go
+++ b/pkg/ddl/mv_index_test.go
@@ -21,8 +21,11 @@ import (
 
 	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	pmodel "github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMultiValuedIndexOnlineDDL(t *testing.T) {
@@ -71,4 +74,33 @@ func TestMultiValuedIndexOnlineDDL(t *testing.T) {
 	tk.MustExec("insert into t values (1, '[1,2,3]');")
 	tk.MustExec("insert into t values (2, '[2,3]');")
 	tk.MustGetErrCode("alter table t add unique index idx((cast(a as signed array)));", errno.ErrDupEntry)
+}
+
+func TestCreateMaterializedViewLogTruncatesLongPhysicalName(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	baseName := strings.Repeat("t", mysql.MaxTableNameLength)
+	mlogName := model.MaterializedViewLogTableName(pmodel.NewCIStr(baseName)).O
+	expectedMLogName := model.MaterializedViewLogTableNamePrefix +
+		strings.Repeat("t", mysql.MaxTableNameLength-len([]rune(model.MaterializedViewLogTableNamePrefix)))
+	require.Equal(t, mysql.MaxTableNameLength, len([]rune(mlogName)))
+	require.Equal(t, expectedMLogName, mlogName)
+
+	tk.MustExec(fmt.Sprintf("drop table if exists `%s`", baseName))
+	tk.MustExec(fmt.Sprintf("drop table if exists `%s`", mlogName))
+	tk.MustExec(fmt.Sprintf("create table `%s` (id int primary key)", baseName))
+	tk.MustExec(fmt.Sprintf("create materialized view log on `%s` (id)", baseName))
+
+	tk.MustQuery(fmt.Sprintf("select table_name from information_schema.tables where table_schema = database() and table_name = '%s'", mlogName)).
+		Check(testkit.Rows(mlogName))
+
+	tk.MustExec(fmt.Sprintf("insert into `%s` values (1)", baseName))
+	tk.MustQuery(fmt.Sprintf("select id, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `%s`", mlogName)).
+		Check(testkit.Rows("1 I 1"))
+
+	tk.MustExec(fmt.Sprintf("drop materialized view log on `%s`", baseName))
+	tk.MustQuery(fmt.Sprintf("select table_name from information_schema.tables where table_schema = database() and table_name = '%s'", mlogName)).
+		Check(testkit.Rows())
 }

--- a/pkg/ddl/schematracker/BUILD.bazel
+++ b/pkg/ddl/schematracker/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//pkg/parser",
         "//pkg/parser/ast",
         "//pkg/parser/model",
+        "//pkg/parser/mysql",
         "//pkg/planner/core/resolve",
         "//pkg/sessionctx",
         "//pkg/util/chunk",

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -21,7 +21,6 @@ package schematracker
 import (
 	"context"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl"
@@ -254,9 +253,6 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	}
 
 	mlogNameCIStr := model.MaterializedViewLogTableName(baseTable.Name)
-	if utf8.RuneCountInString(mlogNameCIStr.L) > mysql.MaxTableNameLength {
-		return dbterror.ErrTooLongIdent.GenWithStackByArgs(mlogNameCIStr)
-	}
 	if _, err := d.TableByName(context.Background(), schemaName, mlogNameCIStr); err == nil {
 		return infoschema.ErrTableExists.GenWithStackByArgs(ast.Ident{Schema: schemaName, Name: mlogNameCIStr})
 	} else if !infoschema.ErrTableNotExists.Equal(err) {

--- a/pkg/ddl/schematracker/dm_tracker_test.go
+++ b/pkg/ddl/schematracker/dm_tracker_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/ddl/schematracker"
@@ -32,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -575,4 +577,24 @@ func TestCreateMaterializedViewLogScheduleExprTypeCheck(t *testing.T) {
 
 	err = tracker.CreateMaterializedViewLog(sctx, parseStmt("create materialized view log on test.t (a) purge start with now() next 1"))
 	require.ErrorContains(t, err, "PURGE NEXT expression must return DATETIME/TIMESTAMP")
+}
+
+func TestCreateMaterializedViewLogTruncatesLongPhysicalName(t *testing.T) {
+	tracker := schematracker.NewSchemaTracker(2)
+	tracker.CreateTestDB(nil)
+	baseName := strings.Repeat("t", mysql.MaxTableNameLength)
+	execCreate(t, tracker, fmt.Sprintf("create table test.`%s` (a int)", baseName))
+
+	sctx := mock.NewContext()
+	p := parser.New()
+	stmt, err := p.ParseOneStmt(fmt.Sprintf("create materialized view log on test.`%s` (a)", baseName), "", "")
+	require.NoError(t, err)
+
+	err = tracker.CreateMaterializedViewLog(sctx, stmt.(*ast.CreateMaterializedViewLogStmt))
+	require.NoError(t, err)
+
+	mlogName := model.MaterializedViewLogTableName(pmodel.NewCIStr(baseName))
+	require.Equal(t, mysql.MaxTableNameLength, len([]rune(mlogName.O)))
+	mlogInfo := mustTableByName(t, tracker, "test", mlogName.O)
+	require.NotNil(t, mlogInfo.MaterializedViewLog)
 }

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -882,7 +882,12 @@ const (
 
 // MaterializedViewLogTableName returns the physical materialized view log table name for a base table.
 func MaterializedViewLogTableName(baseTableName model.CIStr) model.CIStr {
-	return model.NewCIStr(MaterializedViewLogTableNamePrefix + baseTableName.O)
+	baseTableNameRunes := []rune(baseTableName.O)
+	maxBaseTableNameLength := mysql.MaxTableNameLength - len([]rune(MaterializedViewLogTableNamePrefix))
+	if len(baseTableNameRunes) > maxBaseTableNameLength {
+		baseTableNameRunes = baseTableNameRunes[:maxBaseTableNameLength]
+	}
+	return model.NewCIStr(MaterializedViewLogTableNamePrefix + string(baseTableNameRunes))
 }
 
 // Clone clones MaterializedViewLogInfo.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69220

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Materialized view log table names are now properly truncated to respect MySQL's maximum table name length limits when creating logs for tables with long names.

* **Tests**
  * Added tests to verify that materialized view log table names are correctly truncated and that the log tables are properly created and removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->