### PR TITLE
ddl, parser, mvservice: support ALERT ROWS for materialized view logs

### DIFF
--- a/docs/note/materialized_view/mv_log_purge.md
+++ b/docs/note/materialized_view/mv_log_purge.md
@@ -6,6 +6,15 @@ This document describes the current implementation and behavior of:
 PURGE MATERIALIZED VIEW LOG ON <base_table>
 ```
 
+and the MLog-side alert clause on `CREATE MATERIALIZED VIEW LOG`:
+
+```sql
+CREATE MATERIALIZED VIEW LOG ON <base_table>
+  (...)
+  [PURGE {IMMEDIATE | [START WITH expr] NEXT expr}]
+  [ALERT ROWS n]
+```
+
 It also records the design rationale and follow-up items for the refined MV/MLog system-table schema.
 
 ## Current status
@@ -217,6 +226,35 @@ Related dependency from `CREATE MATERIALIZED VIEW` side:
 
 - purge computes `safe_purge_tso` from `mysql.tidb_mview_refresh_info` of dependent MVs;
 - `CREATE MATERIALIZED VIEW` creates/upserts those refresh-info rows and also initializes their `NEXT_TIME` with the same create-time schedule rule style (create-time `START WITH`/`NEXT` derivation).
+
+## MLog accumulation alert threshold (`ALERT ROWS`)
+
+`CREATE MATERIALIZED VIEW LOG` can optionally persist an MLog accumulation alert threshold:
+
+```sql
+CREATE MATERIALIZED VIEW LOG ON t (c1, c2) ALERT ROWS 100000;
+```
+
+Semantics:
+
+1. `ALERT ROWS n` means: when the current MLog row count is strictly greater than `n`, the MLog is considered accumulated for monitoring.
+2. If the clause is omitted, runtime uses the default threshold `n = 1000000`.
+3. If user explicitly sets `ALERT ROWS 0`, alerting is disabled for this MLog.
+4. If user explicitly sets a negative value, `CREATE MATERIALIZED VIEW LOG` returns an error.
+
+Persistence / restore:
+
+- the original clause is stored in `TableInfo.MaterializedViewLog.LogAccumulationAlertRows`;
+- omitted clause is persisted as `NULL`/absent metadata and restored without `ALERT ROWS`;
+- explicit `0` is persisted and preserved by `SHOW CREATE TABLE`.
+
+Runtime observability:
+
+- MVService periodically scans every MLog tracked by `mysql.tidb_mlog_purge_info`;
+- for each MLog with alerting enabled, it checks the current physical MLog row count;
+- if the count is greater than the effective threshold, the MLog is reported into metric `tidb_mv_service_task_status{type="mvlog_accumulation"}`.
+
+This metric reports the number of MLogs currently exceeding their configured accumulation threshold, after TiDB-node ownership filtering, so the same MLog is not double-counted by multiple nodes.
 
 ## Error handling notes
 

--- a/docs/note/materialized_view/mv_log_purge.md
+++ b/docs/note/materialized_view/mv_log_purge.md
@@ -238,8 +238,8 @@ CREATE MATERIALIZED VIEW LOG ON t (c1, c2) ALERT ROWS 100000;
 Semantics:
 
 1. `ALERT ROWS n` means: when the current MLog row count is strictly greater than `n`, the MLog is considered accumulated for monitoring.
-2. If the clause is omitted, runtime uses the default threshold `n = 1000000`.
-3. If user explicitly sets `ALERT ROWS 0`, alerting is disabled for this MLog.
+2. If the clause is omitted, alerting is disabled by default.
+3. If user explicitly sets `ALERT ROWS 0`, alerting is also disabled for this MLog.
 4. If user explicitly sets a negative value, `CREATE MATERIALIZED VIEW LOG` returns an error.
 
 Persistence / restore:

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1164,6 +1164,10 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	var purgeMethod string
 	var purgeStartWith string
 	var purgeNext string
+	logAccumulationAlertRows, err := BuildMLogAccumulationAlertRows(s.AccumulationAlert)
+	if err != nil {
+		return err
+	}
 	if s.Purge != nil {
 		if s.Purge.Immediate {
 			return errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
@@ -1185,12 +1189,13 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 	}
 
 	mlogTableInfo.MaterializedViewLog = &model.MaterializedViewLogInfo{
-		BaseTableID:       baseTableID,
-		Columns:           s.Cols,
-		PurgeMethod:       purgeMethod,
-		PurgeStartWith:    purgeStartWith,
-		PurgeNext:         purgeNext,
-		DefinitionSQLMode: ctx.GetSessionVars().SQLMode,
+		BaseTableID:              baseTableID,
+		Columns:                  s.Cols,
+		PurgeMethod:              purgeMethod,
+		PurgeStartWith:           purgeStartWith,
+		PurgeNext:                purgeNext,
+		LogAccumulationAlertRows: logAccumulationAlertRows,
+		DefinitionSQLMode:        ctx.GetSessionVars().SQLMode,
 	}
 
 	involvingSchemas := []model.InvolvingSchemaInfo{

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -1353,6 +1353,19 @@ func buildMLogPurgeMeta(sctx sessionctx.Context, purge *ast.MLogPurgeClause) (me
 	return method, startWith, next, nil
 }
 
+// BuildMLogAccumulationAlertRows validates the ALERT ROWS clause and returns the persisted threshold.
+// nil means the CREATE statement did not specify ALERT ROWS.
+func BuildMLogAccumulationAlertRows(alert *ast.MLogAccumulationAlertClause) (*uint64, error) {
+	if alert == nil {
+		return nil, nil
+	}
+	if alert.Rows < 0 {
+		return nil, errors.Errorf("invalid ALERT ROWS value: %d (must be non-negative)", alert.Rows)
+	}
+	rows := uint64(alert.Rows)
+	return &rows, nil
+}
+
 func buildMViewRefreshMeta(sctx sessionctx.Context, refresh *ast.MViewRefreshClause) (method, startWith, next string, _ error) {
 	if refresh == nil {
 		return "FAST", "", "", nil

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -330,6 +330,10 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	var purgeMethod string
 	var purgeStartWith string
 	var purgeNext string
+	logAccumulationAlertRows, err := ddl.BuildMLogAccumulationAlertRows(s.AccumulationAlert)
+	if err != nil {
+		return err
+	}
 	if s.Purge != nil {
 		if s.Purge.Immediate {
 			return errors.New("PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
@@ -351,12 +355,13 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 	}
 
 	mlogTableInfo.MaterializedViewLog = &model.MaterializedViewLogInfo{
-		BaseTableID:       baseTable.ID,
-		Columns:           s.Cols,
-		PurgeMethod:       purgeMethod,
-		PurgeStartWith:    purgeStartWith,
-		PurgeNext:         purgeNext,
-		DefinitionSQLMode: ctx.GetSessionVars().SQLMode,
+		BaseTableID:              baseTable.ID,
+		Columns:                  s.Cols,
+		PurgeMethod:              purgeMethod,
+		PurgeStartWith:           purgeStartWith,
+		PurgeNext:                purgeNext,
+		LogAccumulationAlertRows: logAccumulationAlertRows,
+		DefinitionSQLMode:        ctx.GetSessionVars().SQLMode,
 	}
 	if err := d.CreateTableWithInfo(ctx, schemaName, mlogTableInfo, nil); err != nil {
 		return err

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -2125,14 +2125,17 @@ func fetchShowCreateTable4MaterializedViewLog(
 		buf.WriteString(" PURGE")
 		if strings.EqualFold(mlogInfo.PurgeMethod, "IMMEDIATE") {
 			buf.WriteString(" IMMEDIATE")
-			return
+		} else {
+			if mlogInfo.PurgeStartWith != "" {
+				fmt.Fprintf(buf, " START WITH %s", mlogInfo.PurgeStartWith)
+			}
+			if mlogInfo.PurgeNext != "" {
+				fmt.Fprintf(buf, " NEXT %s", mlogInfo.PurgeNext)
+			}
 		}
-		if mlogInfo.PurgeStartWith != "" {
-			fmt.Fprintf(buf, " START WITH %s", mlogInfo.PurgeStartWith)
-		}
-		if mlogInfo.PurgeNext != "" {
-			fmt.Fprintf(buf, " NEXT %s", mlogInfo.PurgeNext)
-		}
+	}
+	if mlogInfo.LogAccumulationAlertRows != nil {
+		fmt.Fprintf(buf, " ALERT ROWS %d", *mlogInfo.LogAccumulationAlertRows)
 	}
 }
 

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -88,7 +88,7 @@ func TestCreateMaterializedViewLogBasic(t *testing.T) {
 	tk.MustExec("create table t (a int, b int)")
 	expectedSQLMode := tk.Session().GetSessionVars().SQLMode
 
-	tk.MustExec("create materialized view log on t (a) purge start with cast('2026-01-02 03:04:05' as datetime) next cast('2026-01-02 03:14:05' as datetime)")
+	tk.MustExec("create materialized view log on t (a) purge start with cast('2026-01-02 03:04:05' as datetime) next cast('2026-01-02 03:14:05' as datetime) alert rows 1234")
 
 	// Physical table created.
 	tk.MustQuery("select count(*) from information_schema.tables where table_schema='test' and table_name='$mlog$t'").Check(testkit.Rows("1"))
@@ -112,6 +112,8 @@ func TestCreateMaterializedViewLogBasic(t *testing.T) {
 	require.Equal(t, "DEFERRED", mlogInfo.PurgeMethod)
 	require.Equal(t, "CAST('2026-01-02 03:04:05' AS DATETIME)", mlogInfo.PurgeStartWith)
 	require.Equal(t, "CAST('2026-01-02 03:14:05' AS DATETIME)", mlogInfo.PurgeNext)
+	require.NotNil(t, mlogInfo.LogAccumulationAlertRows)
+	require.Equal(t, uint64(1234), *mlogInfo.LogAccumulationAlertRows)
 	require.Equal(t, expectedSQLMode, mlogInfo.DefinitionSQLMode)
 
 	// Meta columns should exist on the log table.
@@ -442,7 +444,7 @@ func TestShowCreateMaterializedViewLog(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t_show_mlog (a int, b int)")
-	tk.MustExec("create materialized view log on t_show_mlog (a, b) shard_row_id_bits = 2 pre_split_regions = 2 purge start with cast('2026-01-02 03:04:05' as datetime) next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view log on t_show_mlog (a, b) shard_row_id_bits = 2 pre_split_regions = 2 purge start with cast('2026-01-02 03:04:05' as datetime) next date_add(now(), interval 1 hour) alert rows 2048")
 
 	rows := tk.MustQuery("show create materialized view log on t_show_mlog").Rows()
 	require.Len(t, rows, 1)
@@ -452,6 +454,7 @@ func TestShowCreateMaterializedViewLog(t *testing.T) {
 	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW LOG ON `t_show_mlog` (`a`, `b`)")
 	require.Contains(t, showCreate, "SHARD_ROW_ID_BITS = 2 PRE_SPLIT_REGIONS = 2")
 	require.Contains(t, showCreate, "PURGE START WITH CAST('2026-01-02 03:04:05' AS DATETIME) NEXT DATE_ADD(NOW(), INTERVAL 1 HOUR)")
+	require.Contains(t, showCreate, "ALERT ROWS 2048")
 
 	tk.MustExec("create user 'u_show_create_mlog'@'%'")
 	defer tk.MustExec("drop user 'u_show_create_mlog'@'%'")
@@ -521,6 +524,51 @@ func TestCreateMaterializedViewLogPurgeExprTypeValidation(t *testing.T) {
 	require.ErrorContains(t, err, "PURGE NEXT expression must return DATETIME/TIMESTAMP")
 
 	tk.MustExec("create materialized view log on t (a) purge start with now() next date_add(now(), interval 1 hour)")
+}
+
+func TestCreateMaterializedViewLogAccumulationAlert(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_alert_default (a int)")
+	tk.MustExec("create table t_alert_zero (a int)")
+	tk.MustExec("create table t_alert_custom (a int)")
+	tk.MustExec("create table t_alert_negative (a int)")
+
+	err := tk.ExecToErr("create materialized view log on t_alert_negative (a) alert rows -1")
+	require.ErrorContains(t, err, "invalid ALERT ROWS value: -1 (must be non-negative)")
+
+	tk.MustExec("create materialized view log on t_alert_default (a)")
+	tk.MustExec("create materialized view log on t_alert_zero (a) alert rows 0")
+	tk.MustExec("create materialized view log on t_alert_custom (a) alert rows 2048")
+
+	getMLogInfo := func(baseTable string) *metamodel.MaterializedViewLogInfo {
+		is := dom.InfoSchema()
+		mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$"+baseTable))
+		require.NoError(t, err)
+		require.NotNil(t, mlogTable.Meta().MaterializedViewLog)
+		return mlogTable.Meta().MaterializedViewLog
+	}
+
+	defaultInfo := getMLogInfo("t_alert_default")
+	require.Nil(t, defaultInfo.LogAccumulationAlertRows)
+	defaultRows, defaultEnabled := defaultInfo.EffectiveLogAccumulationAlertRows()
+	require.True(t, defaultEnabled)
+	require.Equal(t, metamodel.DefaultMaterializedViewLogAccumulationAlertRows, defaultRows)
+
+	zeroInfo := getMLogInfo("t_alert_zero")
+	require.NotNil(t, zeroInfo.LogAccumulationAlertRows)
+	require.Equal(t, uint64(0), *zeroInfo.LogAccumulationAlertRows)
+	zeroRows, zeroEnabled := zeroInfo.EffectiveLogAccumulationAlertRows()
+	require.False(t, zeroEnabled)
+	require.Equal(t, uint64(0), zeroRows)
+
+	customInfo := getMLogInfo("t_alert_custom")
+	require.NotNil(t, customInfo.LogAccumulationAlertRows)
+	require.Equal(t, uint64(2048), *customInfo.LogAccumulationAlertRows)
+	customRows, customEnabled := customInfo.EffectiveLogAccumulationAlertRows()
+	require.True(t, customEnabled)
+	require.Equal(t, uint64(2048), customRows)
 }
 
 func TestCreateMaterializedViewLogPurgeInfoNextTimeDerivation(t *testing.T) {

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -553,8 +553,8 @@ func TestCreateMaterializedViewLogAccumulationAlert(t *testing.T) {
 	defaultInfo := getMLogInfo("t_alert_default")
 	require.Nil(t, defaultInfo.LogAccumulationAlertRows)
 	defaultRows, defaultEnabled := defaultInfo.EffectiveLogAccumulationAlertRows()
-	require.True(t, defaultEnabled)
-	require.Equal(t, metamodel.DefaultMaterializedViewLogAccumulationAlertRows, defaultRows)
+	require.False(t, defaultEnabled)
+	require.Equal(t, uint64(0), defaultRows)
 
 	zeroInfo := getMLogInfo("t_alert_zero")
 	require.NotNil(t, zeroInfo.LogAccumulationAlertRows)

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -864,7 +864,7 @@ type MaterializedViewLogInfo struct {
 	PurgeNext string `json:"purge_next,omitempty"`
 
 	// LogAccumulationAlertRows is the user-specified threshold for emitting MV log accumulation alerts.
-	// nil means the CREATE statement did not specify ALERT ROWS and runtime uses the default threshold.
+	// nil means the CREATE statement did not specify ALERT ROWS and runtime keeps alerting disabled by default.
 	LogAccumulationAlertRows *uint64 `json:"log_accumulation_alert_rows,omitempty"`
 
 	// DefinitionSQLMode is the SQL mode captured from CREATE MATERIALIZED VIEW LOG session.
@@ -872,10 +872,6 @@ type MaterializedViewLogInfo struct {
 }
 
 const (
-	// DefaultMaterializedViewLogAccumulationAlertRows is the default runtime threshold used when
-	// CREATE MATERIALIZED VIEW LOG does not explicitly specify ALERT ROWS.
-	DefaultMaterializedViewLogAccumulationAlertRows uint64 = 1000000
-
 	// MaterializedViewLogTableNamePrefix is the prefix of the physical table name for a materialized view log.
 	MaterializedViewLogTableNamePrefix = "$mlog$"
 
@@ -908,12 +904,9 @@ func (i *MaterializedViewLogInfo) Clone() *MaterializedViewLogInfo {
 }
 
 // EffectiveLogAccumulationAlertRows returns the runtime threshold and whether alerting is enabled.
-// A nil configured threshold means using the default value; an explicit zero disables alerting.
+// A nil configured threshold keeps alerting disabled by default; an explicit zero also disables alerting.
 func (i *MaterializedViewLogInfo) EffectiveLogAccumulationAlertRows() (uint64, bool) {
-	if i == nil || i.LogAccumulationAlertRows == nil {
-		return DefaultMaterializedViewLogAccumulationAlertRows, true
-	}
-	if *i.LogAccumulationAlertRows == 0 {
+	if i == nil || i.LogAccumulationAlertRows == nil || *i.LogAccumulationAlertRows == 0 {
 		return 0, false
 	}
 	return *i.LogAccumulationAlertRows, true

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -863,11 +863,19 @@ type MaterializedViewLogInfo struct {
 	// PurgeNext is the expression string after "NEXT", stored in canonical SQL format.
 	PurgeNext string `json:"purge_next,omitempty"`
 
+	// LogAccumulationAlertRows is the user-specified threshold for emitting MV log accumulation alerts.
+	// nil means the CREATE statement did not specify ALERT ROWS and runtime uses the default threshold.
+	LogAccumulationAlertRows *uint64 `json:"log_accumulation_alert_rows,omitempty"`
+
 	// DefinitionSQLMode is the SQL mode captured from CREATE MATERIALIZED VIEW LOG session.
 	DefinitionSQLMode mysql.SQLMode `json:"definition_sql_mode"`
 }
 
 const (
+	// DefaultMaterializedViewLogAccumulationAlertRows is the default runtime threshold used when
+	// CREATE MATERIALIZED VIEW LOG does not explicitly specify ALERT ROWS.
+	DefaultMaterializedViewLogAccumulationAlertRows uint64 = 1000000
+
 	// MaterializedViewLogTableNamePrefix is the prefix of the physical table name for a materialized view log.
 	MaterializedViewLogTableNamePrefix = "$mlog$"
 
@@ -892,7 +900,23 @@ func (i *MaterializedViewLogInfo) Clone() *MaterializedViewLogInfo {
 	}
 	ni := *i
 	ni.Columns = append([]model.CIStr(nil), i.Columns...)
+	if i.LogAccumulationAlertRows != nil {
+		rows := *i.LogAccumulationAlertRows
+		ni.LogAccumulationAlertRows = &rows
+	}
 	return &ni
+}
+
+// EffectiveLogAccumulationAlertRows returns the runtime threshold and whether alerting is enabled.
+// A nil configured threshold means using the default value; an explicit zero disables alerting.
+func (i *MaterializedViewLogInfo) EffectiveLogAccumulationAlertRows() (uint64, bool) {
+	if i == nil || i.LogAccumulationAlertRows == nil {
+		return DefaultMaterializedViewLogAccumulationAlertRows, true
+	}
+	if *i.LogAccumulationAlertRows == 0 {
+		return 0, false
+	}
+	return *i.LogAccumulationAlertRows, true
 }
 
 // Some constants for sequence.

--- a/pkg/metrics/materialized_view.go
+++ b/pkg/metrics/materialized_view.go
@@ -31,13 +31,14 @@ const (
 	mvMetricTaskStatusTaskExecTimedOutRunning = "exec_timed_out_running"
 	mvMetricTaskStatusTaskExecBackpressureBlk = "exec_backpressure_blocked"
 
-	mvMetricTaskStatusMVTotal          = "mv_total"
-	mvMetricTaskStatusMVLogTotal       = "mvlog_total"
-	mvMetricTaskStatusMVRefreshRun     = "mv_refresh_running"
-	mvMetricTaskStatusMVLogPurgeRun    = "mvlog_purge_running"
-	mvMetricTaskStatusMVRefreshWarning = "mv_refresh_warning"
-	mvMetricTaskStatusMVRefreshOverdue = "mv_refresh_overdue"
-	mvMetricTaskStatusMVServicePanic   = "mv_service_panic"
+	mvMetricTaskStatusMVTotal           = "mv_total"
+	mvMetricTaskStatusMVLogTotal        = "mvlog_total"
+	mvMetricTaskStatusMVRefreshRun      = "mv_refresh_running"
+	mvMetricTaskStatusMVLogPurgeRun     = "mvlog_purge_running"
+	mvMetricTaskStatusMVRefreshWarning  = "mv_refresh_warning"
+	mvMetricTaskStatusMVRefreshOverdue  = "mv_refresh_overdue"
+	mvMetricTaskStatusMVLogAccumulation = "mvlog_accumulation"
+	mvMetricTaskStatusMVServicePanic    = "mv_service_panic"
 )
 
 // Metrics for materialized view service.
@@ -66,6 +67,7 @@ var (
 	MVServiceMVLogPurgeRunningGauge prometheus.Gauge
 	MVServiceMVRefreshWarningGauge  prometheus.Gauge
 	MVServiceMVRefreshOverdueGauge  prometheus.Gauge
+	MVServiceMVLogAccumulationGauge prometheus.Gauge
 	MVServicePanicGauge             prometheus.Gauge
 )
 
@@ -112,5 +114,6 @@ func InitMVMetrics() {
 	MVServiceMVLogPurgeRunningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVLogPurgeRun)
 	MVServiceMVRefreshWarningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVRefreshWarning)
 	MVServiceMVRefreshOverdueGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVRefreshOverdue)
+	MVServiceMVLogAccumulationGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVLogAccumulation)
 	MVServicePanicGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVServicePanic)
 }

--- a/pkg/mvservice/metrics_reporter.go
+++ b/pkg/mvservice/metrics_reporter.go
@@ -51,6 +51,7 @@ func (h *serviceHelper) reportMetrics(s *MVService) {
 	tidbmetrics.MVServiceMVLogPurgeRunningGauge.Set(float64(s.metrics.runningMVLogPurgeCount.Load()))
 	tidbmetrics.MVServiceMVRefreshWarningGauge.Set(float64(s.metrics.alertWarningCount.Load()))
 	tidbmetrics.MVServiceMVRefreshOverdueGauge.Set(float64(s.metrics.alertOverdueCount.Load()))
+	tidbmetrics.MVServiceMVLogAccumulationGauge.Set(float64(s.metrics.mvLogAccumulationCount.Load()))
 }
 
 // observeTaskDuration reports one task execution duration sample.

--- a/pkg/mvservice/mvservice_test.go
+++ b/pkg/mvservice/mvservice_test.go
@@ -1084,6 +1084,99 @@ func TestMVServiceMaybeLogRefreshAlertTasksSkipsCleanupWhenNotOwner(t *testing.T
 	require.Equal(t, int32(0), helper.syncRefreshAlertCalls.Load())
 }
 
+func TestMVServiceMaybeScanMVLogAccumulationAlertsFiltersUnownedTasks(t *testing.T) {
+	helper := &mockMVServiceHelper{
+		fetchAccumulationTasks: map[int64]*mvLogAccumulationTask{
+			101: {schemaName: "test", mlogName: "mlog_101", alertRows: 1000},
+			102: {schemaName: "test", mlogName: "mlog_102", alertRows: 1000},
+		},
+		fetchAccumulationRowCounts: map[int64]uint64{
+			101: 1500,
+			102: 2500,
+		},
+	}
+	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
+	defer svc.closeTaskExecutors()
+	setTaskOwnersForTest(svc, map[int64]uint32{
+		101: 10,
+		102: 30,
+	})
+
+	now := mvsNow()
+	svc.nextMVLogAccumulationScanMillis.Store(0)
+	svc.maybeScanMVLogAccumulationAlerts(now)
+	require.Equal(t, int32(1), helper.fetchAccumulationTaskCalls.Load())
+	require.Equal(t, int32(1), helper.fetchAccumulationRowCountCalls.Load())
+	require.Equal(t, []int64{101}, helper.lastAccumulationRowCountTaskIDs)
+	require.Equal(t, int64(1), svc.metrics.mvLogAccumulationCount.Load())
+
+	svc.maybeScanMVLogAccumulationAlerts(now.Add(mvLogAccumulationAlertScanInterval / 2))
+	require.Equal(t, int32(1), helper.fetchAccumulationTaskCalls.Load())
+
+	svc.nextMVLogAccumulationScanMillis.Store(0)
+	helper.fetchAccumulationTasks = map[int64]*mvLogAccumulationTask{
+		101: {schemaName: "test", mlogName: "mlog_101", alertRows: 1000},
+		102: {schemaName: "test", mlogName: "mlog_102", alertRows: 1000},
+	}
+	helper.fetchAccumulationRowCounts = map[int64]uint64{
+		101: 1800,
+		102: 2800,
+	}
+	svc.maybeScanMVLogAccumulationAlerts(now.Add(mvLogAccumulationAlertScanInterval))
+	require.Equal(t, int32(2), helper.fetchAccumulationTaskCalls.Load())
+	require.Equal(t, int32(2), helper.fetchAccumulationRowCountCalls.Load())
+	require.Equal(t, []int64{101}, helper.lastAccumulationRowCountTaskIDs)
+	require.Equal(t, int64(1), svc.metrics.mvLogAccumulationCount.Load())
+}
+
+func TestMVServiceMaybeScanMVLogAccumulationAlertsPreservesLastValueOnError(t *testing.T) {
+	helper := &mockMVServiceHelper{
+		fetchAccumulationTasks: map[int64]*mvLogAccumulationTask{
+			101: {schemaName: "test", mlogName: "mlog_101", alertRows: 1000},
+		},
+		fetchAccumulationRowCounts: map[int64]uint64{
+			101: 1500,
+		},
+	}
+	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
+	defer svc.closeTaskExecutors()
+	setTaskOwnersForTest(svc, map[int64]uint32{
+		101: 10,
+	})
+
+	now := mvsNow()
+	svc.nextMVLogAccumulationScanMillis.Store(0)
+	svc.maybeScanMVLogAccumulationAlerts(now)
+	require.Equal(t, int64(1), svc.metrics.mvLogAccumulationCount.Load())
+
+	helper.fetchAccumulationRowCountsErr = errors.New("mock accumulation scan failed")
+	svc.nextMVLogAccumulationScanMillis.Store(0)
+	svc.maybeScanMVLogAccumulationAlerts(now.Add(mvLogAccumulationAlertScanInterval))
+	require.Equal(t, int64(1), svc.metrics.mvLogAccumulationCount.Load())
+}
+
+func TestMVServiceMaybeScanMVLogAccumulationAlertsUsesStrictGreaterThan(t *testing.T) {
+	helper := &mockMVServiceHelper{
+		fetchAccumulationTasks: map[int64]*mvLogAccumulationTask{
+			101: {schemaName: "test", mlogName: "mlog_101", alertRows: 50},
+		},
+		fetchAccumulationRowCounts: map[int64]uint64{
+			101: 50,
+		},
+	}
+	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
+	defer svc.closeTaskExecutors()
+	setTaskOwnersForTest(svc, map[int64]uint32{
+		101: 10,
+	})
+
+	now := mvsNow()
+	svc.nextMVLogAccumulationScanMillis.Store(0)
+	svc.maybeScanMVLogAccumulationAlerts(now)
+	require.Equal(t, int64(0), svc.metrics.mvLogAccumulationCount.Load())
+	require.Equal(t, []int64{101}, helper.lastAccumulationRowCountTaskIDs)
+}
+
 func TestTaskQueueRingBufferFIFO(t *testing.T) {
 	var q taskQueue
 	mkReq := func(i int) taskRequest {
@@ -1198,6 +1291,40 @@ func (h *fullChainMVServiceHelper) LoadAllTiDBMVLogPurge(context.Context, basic.
 		}
 		logTask.orderTs = next.UnixMilli()
 		ret[id] = logTask
+	}
+	return ret, nil
+}
+
+func (h *fullChainMVServiceHelper) LoadAllTiDBMVLogAccumulationTasks(context.Context, basic.SessionPool) (map[int64]*mvLogAccumulationTask, error) {
+	h.fetchAccumulationTaskCalls.Add(1)
+	if h.fetchAccumulationTasksErr != nil {
+		return nil, h.fetchAccumulationTasksErr
+	}
+	if h.fetchAccumulationTasks == nil {
+		return map[int64]*mvLogAccumulationTask{}, nil
+	}
+	ret := make(map[int64]*mvLogAccumulationTask, len(h.fetchAccumulationTasks))
+	for id, task := range h.fetchAccumulationTasks {
+		if task == nil {
+			ret[id] = nil
+			continue
+		}
+		taskCopy := *task
+		ret[id] = &taskCopy
+	}
+	return ret, nil
+}
+
+func (h *fullChainMVServiceHelper) LoadTiDBMVLogAccumulationRowCounts(_ context.Context, _ basic.SessionPool, tasks map[int64]*mvLogAccumulationTask) (map[int64]uint64, error) {
+	h.fetchAccumulationRowCountCalls.Add(1)
+	if h.fetchAccumulationRowCountsErr != nil {
+		return nil, h.fetchAccumulationRowCountsErr
+	}
+	ret := make(map[int64]uint64, len(tasks))
+	for id := range tasks {
+		if rowCount, ok := h.fetchAccumulationRowCounts[id]; ok {
+			ret[id] = rowCount
+		}
 	}
 	return ret, nil
 }

--- a/pkg/mvservice/mvservice_test.go
+++ b/pkg/mvservice/mvservice_test.go
@@ -1105,10 +1105,12 @@ func TestMVServiceMaybeScanMVLogAccumulationAlertsFiltersUnownedTasks(t *testing
 	now := mvsNow()
 	svc.nextMVLogAccumulationScanMillis.Store(0)
 	svc.maybeScanMVLogAccumulationAlerts(now)
-	require.Equal(t, int32(1), helper.fetchAccumulationTaskCalls.Load())
-	require.Equal(t, int32(1), helper.fetchAccumulationRowCountCalls.Load())
+	require.Eventually(t, func() bool {
+		return helper.fetchAccumulationTaskCalls.Load() == 1 &&
+			helper.fetchAccumulationRowCountCalls.Load() == 1 &&
+			svc.metrics.mvLogAccumulationCount.Load() == 1
+	}, testEventuallyWait, testEventuallyTick)
 	require.Equal(t, []int64{101}, helper.lastAccumulationRowCountTaskIDs)
-	require.Equal(t, int64(1), svc.metrics.mvLogAccumulationCount.Load())
 
 	svc.maybeScanMVLogAccumulationAlerts(now.Add(mvLogAccumulationAlertScanInterval / 2))
 	require.Equal(t, int32(1), helper.fetchAccumulationTaskCalls.Load())
@@ -1123,10 +1125,12 @@ func TestMVServiceMaybeScanMVLogAccumulationAlertsFiltersUnownedTasks(t *testing
 		102: 2800,
 	}
 	svc.maybeScanMVLogAccumulationAlerts(now.Add(mvLogAccumulationAlertScanInterval))
-	require.Equal(t, int32(2), helper.fetchAccumulationTaskCalls.Load())
-	require.Equal(t, int32(2), helper.fetchAccumulationRowCountCalls.Load())
+	require.Eventually(t, func() bool {
+		return helper.fetchAccumulationTaskCalls.Load() == 2 &&
+			helper.fetchAccumulationRowCountCalls.Load() == 2 &&
+			svc.metrics.mvLogAccumulationCount.Load() == 1
+	}, testEventuallyWait, testEventuallyTick)
 	require.Equal(t, []int64{101}, helper.lastAccumulationRowCountTaskIDs)
-	require.Equal(t, int64(1), svc.metrics.mvLogAccumulationCount.Load())
 }
 
 func TestMVServiceMaybeScanMVLogAccumulationAlertsPreservesLastValueOnError(t *testing.T) {
@@ -1147,11 +1151,16 @@ func TestMVServiceMaybeScanMVLogAccumulationAlertsPreservesLastValueOnError(t *t
 	now := mvsNow()
 	svc.nextMVLogAccumulationScanMillis.Store(0)
 	svc.maybeScanMVLogAccumulationAlerts(now)
-	require.Equal(t, int64(1), svc.metrics.mvLogAccumulationCount.Load())
+	require.Eventually(t, func() bool {
+		return svc.metrics.mvLogAccumulationCount.Load() == 1
+	}, testEventuallyWait, testEventuallyTick)
 
 	helper.fetchAccumulationRowCountsErr = errors.New("mock accumulation scan failed")
 	svc.nextMVLogAccumulationScanMillis.Store(0)
 	svc.maybeScanMVLogAccumulationAlerts(now.Add(mvLogAccumulationAlertScanInterval))
+	require.Eventually(t, func() bool {
+		return helper.fetchAccumulationRowCountCalls.Load() == 2
+	}, testEventuallyWait, testEventuallyTick)
 	require.Equal(t, int64(1), svc.metrics.mvLogAccumulationCount.Load())
 }
 
@@ -1173,8 +1182,53 @@ func TestMVServiceMaybeScanMVLogAccumulationAlertsUsesStrictGreaterThan(t *testi
 	now := mvsNow()
 	svc.nextMVLogAccumulationScanMillis.Store(0)
 	svc.maybeScanMVLogAccumulationAlerts(now)
+	require.Eventually(t, func() bool {
+		return helper.fetchAccumulationRowCountCalls.Load() == 1
+	}, testEventuallyWait, testEventuallyTick)
 	require.Equal(t, int64(0), svc.metrics.mvLogAccumulationCount.Load())
 	require.Equal(t, []int64{101}, helper.lastAccumulationRowCountTaskIDs)
+}
+
+func TestMVServiceMaybeScanMVLogAccumulationAlertsAsyncAndNonOverlapping(t *testing.T) {
+	helper := &mockMVServiceHelper{
+		fetchAccumulationTasks: map[int64]*mvLogAccumulationTask{
+			101: {schemaName: "test", mlogName: "mlog_101", alertRows: 1000},
+		},
+		fetchAccumulationRowCounts: map[int64]uint64{
+			101: 1500,
+		},
+		accumulationRowCountEntered: make(chan struct{}, 2),
+		blockAccumulationRowCount:   make(chan struct{}),
+	}
+	svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
+	defer svc.closeTaskExecutors()
+	setTaskOwnersForTest(svc, map[int64]uint32{
+		101: 10,
+	})
+
+	now := mvsNow()
+	svc.nextMVLogAccumulationScanMillis.Store(0)
+	done := make(chan struct{})
+	go func() {
+		svc.maybeScanMVLogAccumulationAlerts(now)
+		close(done)
+	}()
+
+	waitForSignal(t, helper.accumulationRowCountEntered, testEventuallyWait)
+	waitForSignal(t, done, testEventuallyWait)
+	require.Equal(t, int64(0), svc.metrics.mvLogAccumulationCount.Load())
+
+	svc.nextMVLogAccumulationScanMillis.Store(0)
+	svc.maybeScanMVLogAccumulationAlerts(now.Add(mvLogAccumulationAlertScanInterval))
+	require.Equal(t, int32(1), helper.fetchAccumulationTaskCalls.Load())
+	require.Equal(t, int32(1), helper.fetchAccumulationRowCountCalls.Load())
+
+	close(helper.blockAccumulationRowCount)
+	require.Eventually(t, func() bool {
+		return svc.metrics.mvLogAccumulationCount.Load() == 1 &&
+			helper.fetchAccumulationTaskCalls.Load() == 1 &&
+			helper.fetchAccumulationRowCountCalls.Load() == 1
+	}, testEventuallyWait, testEventuallyTick)
 }
 
 func TestTaskQueueRingBufferFIFO(t *testing.T) {

--- a/pkg/mvservice/service.go
+++ b/pkg/mvservice/service.go
@@ -53,7 +53,8 @@ type MVService struct {
 	ctx                 context.Context
 	sch                 *ServerConsistentHash
 
-	nextRefreshAlertScanMillis atomic.Int64
+	nextRefreshAlertScanMillis      atomic.Int64
+	nextMVLogAccumulationScanMillis atomic.Int64
 
 	refreshExecutor                 *TaskExecutor
 	purgeExecutor                   *TaskExecutor
@@ -84,6 +85,7 @@ type MVService struct {
 		runningMVLogPurgeCount atomic.Int64
 		alertWarningCount      atomic.Int64
 		alertOverdueCount      atomic.Int64
+		mvLogAccumulationCount atomic.Int64
 	}
 
 	mvRefreshMu struct {
@@ -114,6 +116,7 @@ const (
 	defaultMVTaskRetryMax                = 120 * time.Second
 	manualCancelBackoffDelay             = 2 * time.Minute
 	mvRefreshAlertScanInterval           = 30 * time.Second
+	mvLogAccumulationAlertScanInterval   = 20 * time.Minute
 	maxNextScheduleTs                    = 9e18
 
 	defaultCHReplicas = 100
@@ -121,8 +124,9 @@ const (
 	mvTaskDurationTypeRefresh = "mv_refresh"
 	mvTaskDurationTypePurge   = "mvlog_purge"
 
-	mvFetchTypeMLogPurge    = "fetch_mlog"
-	mvFetchTypeMViewRefresh = "fetch_mviews"
+	mvFetchTypeMLogPurge        = "fetch_mlog"
+	mvFetchTypeMLogAccumulation = "fetch_mlog_accumulation"
+	mvFetchTypeMViewRefresh     = "fetch_mviews"
 
 	mvTaskDurationTypeHistoryGC = "history_gc"
 
@@ -360,6 +364,20 @@ func (t *MVService) maybeLogRefreshAlertTasks(now time.Time) {
 		return
 	}
 	t.logMVRefreshAlerts(alertTasks)
+}
+
+func (t *MVService) maybeScanMVLogAccumulationAlerts(now time.Time) {
+	nowMillis := now.UnixMilli()
+	if next := t.nextMVLogAccumulationScanMillis.Load(); next > nowMillis {
+		return
+	}
+	t.nextMVLogAccumulationScanMillis.Store(now.Add(mvLogAccumulationAlertScanInterval).UnixMilli())
+
+	alertedCount, err := t.fetchAllMVLogAccumulationAlerts()
+	if err != nil {
+		return
+	}
+	t.metrics.mvLogAccumulationCount.Store(int64(alertedCount))
 }
 
 func (t *MVService) collectRefreshAlertStates(now time.Time) ([]refreshAlertTask, int64, int64) {
@@ -948,6 +966,51 @@ func (t *MVService) fetchAllTiDBMVLogPurge() (map[int64]*mvLog, error) {
 	return newPending, nil
 }
 
+// fetchAllMVLogAccumulationAlerts counts MV logs whose row count exceeds the configured alert threshold.
+func (t *MVService) fetchAllMVLogAccumulationAlerts() (int, error) {
+	start := mvsNow()
+	result := mvDurationResultSuccess
+	defer func() {
+		t.mh.observeTaskDuration(mvFetchTypeMLogAccumulation, result, mvsSince(start))
+	}()
+
+	candidates, err := t.fetchAllTiDBMVLogAccumulationTasks()
+	if err != nil {
+		result = mvDurationResultFailed
+		return 0, err
+	}
+	rowCounts, err := t.mh.LoadTiDBMVLogAccumulationRowCounts(t.ctx, t.sysSessionPool, candidates)
+	if err != nil {
+		result = mvDurationResultFailed
+		fields := append(t.runtimeLogFields(), zap.Error(err))
+		logutil.BgLogger().Warn("fetch mvlog accumulation row counts failed", fields...)
+		return 0, err
+	}
+	alertedCount := 0
+	for mvLogID, rowCount := range rowCounts {
+		task, ok := candidates[mvLogID]
+		if !ok || task == nil {
+			continue
+		}
+		if rowCount > task.alertRows {
+			alertedCount++
+		}
+	}
+	return alertedCount, nil
+}
+
+// fetchAllTiDBMVLogAccumulationTasks fetches accumulation metadata and filters out tasks not owned by this node.
+func (t *MVService) fetchAllTiDBMVLogAccumulationTasks() (map[int64]*mvLogAccumulationTask, error) {
+	newPending, err := t.mh.LoadAllTiDBMVLogAccumulationTasks(t.ctx, t.sysSessionPool)
+	if err != nil {
+		fields := append(t.runtimeLogFields(), zap.Error(err))
+		logutil.BgLogger().Warn("fetch all mvlog accumulation tasks failed", fields...)
+		return nil, err
+	}
+	filterUnownedTasks(t.sch, newPending)
+	return newPending, nil
+}
+
 // fetchAllTiDBMVRefresh fetches refresh metadata and filters out tasks not owned by this node.
 func (t *MVService) fetchAllTiDBMVRefresh() (map[int64]*mv, error) {
 	start := mvsNow()
@@ -1166,6 +1229,7 @@ func (t *MVService) Run() {
 			t.mh.reportMetrics(t)
 			t.maybeGCOperationHistory(now)
 			t.maybeLogRefreshAlertTasks(now)
+			t.maybeScanMVLogAccumulationAlerts(now)
 			resetTimer(maintenanceTimer, t.basicInterval)
 		}
 

--- a/pkg/mvservice/service.go
+++ b/pkg/mvservice/service.go
@@ -375,7 +375,6 @@ func (t *MVService) maybeScanMVLogAccumulationAlerts(now time.Time) {
 	if !t.mvLogAccumulationScanRunning.CompareAndSwap(false, true) {
 		return
 	}
-	t.nextMVLogAccumulationScanMillis.Store(now.Add(mvLogAccumulationAlertScanInterval).UnixMilli())
 
 	go t.runMVLogAccumulationAlertScan()
 }
@@ -394,6 +393,7 @@ func (t *MVService) runMVLogAccumulationAlertScan() {
 		return
 	}
 	t.metrics.mvLogAccumulationCount.Store(int64(alertedCount))
+	t.nextMVLogAccumulationScanMillis.Store(mvsNow().Add(mvLogAccumulationAlertScanInterval).UnixMilli())
 }
 
 func (t *MVService) collectRefreshAlertStates(now time.Time) ([]refreshAlertTask, int64, int64) {

--- a/pkg/mvservice/service.go
+++ b/pkg/mvservice/service.go
@@ -72,6 +72,7 @@ type MVService struct {
 	nextHistoryGCAtMillis           atomic.Int64
 	historyGCRetryCount             atomic.Int64
 	historyGCRunning                atomic.Bool
+	mvLogAccumulationScanRunning    atomic.Bool
 
 	retryBaseDelayMillis atomic.Int64
 	retryMaxDelayMillis  atomic.Int64
@@ -371,7 +372,22 @@ func (t *MVService) maybeScanMVLogAccumulationAlerts(now time.Time) {
 	if next := t.nextMVLogAccumulationScanMillis.Load(); next > nowMillis {
 		return
 	}
+	if !t.mvLogAccumulationScanRunning.CompareAndSwap(false, true) {
+		return
+	}
 	t.nextMVLogAccumulationScanMillis.Store(now.Add(mvLogAccumulationAlertScanInterval).UnixMilli())
+
+	go t.runMVLogAccumulationAlertScan()
+}
+
+func (t *MVService) runMVLogAccumulationAlertScan() {
+	defer t.mvLogAccumulationScanRunning.Store(false)
+	defer func() {
+		if r := recover(); r != nil {
+			fields := append(t.runtimeLogFields(), zap.Any("panic", r), zap.ByteString("stack", debug.Stack()))
+			logutil.BgLogger().Error("MVService mvlog accumulation scan panicked", fields...)
+		}
+	}()
 
 	alertedCount, err := t.fetchAllMVLogAccumulationAlerts()
 	if err != nil {

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -335,6 +335,39 @@ func resolveMVIdentityByID(
 	return schemaName, mviewName, alertWarningSec, alertOverdueSec, true, nil
 }
 
+func resolveMVLogAccumulationAlertByID(
+	ctx context.Context,
+	sctx sessionctx.Context,
+	mvLogID int64,
+) (schemaName, mlogName string, alertRows uint64, enabled bool, found bool, err error) {
+	if mvLogID <= 0 {
+		return "", "", 0, false, false, errors.New("materialized view log id is invalid")
+	}
+	infoSchema := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	mLogTbl, ok := infoSchema.TableByID(ctx, mvLogID)
+	if !ok {
+		return "", "", 0, false, false, nil
+	}
+	mLogMeta := mLogTbl.Meta()
+	if mLogMeta == nil || mLogMeta.MaterializedViewLog == nil {
+		return "", "", 0, false, false, nil
+	}
+	alertRows, enabled = mLogMeta.MaterializedViewLog.EffectiveLogAccumulationAlertRows()
+	if !enabled {
+		return "", "", alertRows, false, true, nil
+	}
+	dbInfo, ok := infoSchema.SchemaByID(mLogMeta.DBID)
+	if !ok || dbInfo == nil {
+		return "", "", 0, false, false, nil
+	}
+	schemaName = dbInfo.Name.L
+	mlogName = mLogMeta.Name.L
+	if schemaName == "" || mlogName == "" {
+		return "", "", 0, false, false, nil
+	}
+	return schemaName, mlogName, alertRows, true, true, nil
+}
+
 // RefreshMV executes one incremental refresh round for a materialized view.
 //
 // It:
@@ -1302,6 +1335,91 @@ func (*serviceHelper) LoadAllTiDBMVLogPurge(ctx context.Context, sysSessionPool 
 		newPending[mvLogID] = l
 	}
 	return newPending, nil
+}
+
+// LoadAllTiDBMVLogAccumulationTasks loads all MV logs that have accumulation alerting enabled.
+func (*serviceHelper) LoadAllTiDBMVLogAccumulationTasks(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mvLogAccumulationTask, error) {
+	const fetchSQL = `SELECT MLOG_ID FROM mysql.tidb_mlog_purge_info`
+	se, err := sysSessionPool.Get()
+	if err != nil {
+		return nil, err
+	}
+	defer sysSessionPool.Put(se)
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
+	sctx := se.(sessionctx.Context)
+
+	rows, err := execRCRestrictedSQLWithSession(ctx, sctx, fetchSQL, nil)
+	if err != nil {
+		return nil, err
+	}
+	tasks := make(map[int64]*mvLogAccumulationTask)
+	for _, row := range rows {
+		if row.IsNull(0) {
+			continue
+		}
+		mvLogID := row.GetInt64(0)
+		if mvLogID <= 0 {
+			continue
+		}
+		schemaName, mlogName, alertRows, enabled, found, err := resolveMVLogAccumulationAlertByID(ctx, sctx, mvLogID)
+		if err != nil {
+			return nil, err
+		}
+		if !found || !enabled {
+			continue
+		}
+		tasks[mvLogID] = &mvLogAccumulationTask{
+			schemaName: schemaName,
+			mlogName:   mlogName,
+			alertRows:  alertRows,
+		}
+	}
+	return tasks, nil
+}
+
+// LoadTiDBMVLogAccumulationRowCounts loads the current row count for the specified MV log tasks.
+func (*serviceHelper) LoadTiDBMVLogAccumulationRowCounts(
+	ctx context.Context,
+	sysSessionPool basic.SessionPool,
+	tasks map[int64]*mvLogAccumulationTask,
+) (map[int64]uint64, error) {
+	const countSQL = `SELECT COUNT(*) FROM %n.%n`
+	if len(tasks) == 0 {
+		return map[int64]uint64{}, nil
+	}
+	se, err := sysSessionPool.Get()
+	if err != nil {
+		return nil, err
+	}
+	defer sysSessionPool.Put(se)
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
+	sctx := se.(sessionctx.Context)
+
+	rowCounts := make(map[int64]uint64, len(tasks))
+	for mvLogID, task := range tasks {
+		if task == nil {
+			continue
+		}
+		countRows, err := execRCRestrictedSQLWithSession(ctx, sctx, countSQL, []any{task.schemaName, task.mlogName})
+		if err != nil {
+			if infoschema.ErrTableNotExists.Equal(err) {
+				continue
+			}
+			return nil, err
+		}
+		if len(countRows) != 1 {
+			return nil, fmt.Errorf("unexpected COUNT(*) result length for mvlog accumulation: %d", len(countRows))
+		}
+		if countRows[0].IsNull(0) {
+			return nil, errors.New("unexpected NULL COUNT(*) result for mvlog accumulation")
+		}
+		rowCount := countRows[0].GetInt64(0)
+		if rowCount < 0 {
+			return nil, fmt.Errorf("unexpected negative COUNT(*) result for mvlog accumulation: %d", rowCount)
+		}
+		rowCounts[mvLogID] = uint64(rowCount)
+	}
+	return rowCounts, nil
 }
 
 // LoadAllTiDBMVRefresh loads all scheduled MV refresh tasks from metadata.

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -1383,7 +1383,7 @@ func (*serviceHelper) LoadTiDBMVLogAccumulationRowCounts(
 	sysSessionPool basic.SessionPool,
 	tasks map[int64]*mvLogAccumulationTask,
 ) (map[int64]uint64, error) {
-	const countSQL = `SELECT COUNT(*) FROM %n.%n`
+	const countSQL = `SELECT /*+ read_from_storage(tiflash[%n.%n]) */ COUNT(*) FROM %n.%n`
 	if len(tasks) == 0 {
 		return map[int64]uint64{}, nil
 	}
@@ -1394,13 +1394,21 @@ func (*serviceHelper) LoadTiDBMVLogAccumulationRowCounts(
 	defer sysSessionPool.Put(se)
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMVMaintenance)
 	sctx := se.(sessionctx.Context)
+	origDistSQLScanConcurrency := sctx.GetSessionVars().DistSQLScanConcurrency()
+	sctx.GetSessionVars().SetDistSQLScanConcurrency(1)
+	defer sctx.GetSessionVars().SetDistSQLScanConcurrency(origDistSQLScanConcurrency)
 
 	rowCounts := make(map[int64]uint64, len(tasks))
 	for mvLogID, task := range tasks {
 		if task == nil {
 			continue
 		}
-		countRows, err := execRCRestrictedSQLWithSession(ctx, sctx, countSQL, []any{task.schemaName, task.mlogName})
+		countRows, err := execRCRestrictedSQLWithSession(ctx, sctx, countSQL, []any{
+			task.schemaName,
+			task.mlogName,
+			task.schemaName,
+			task.mlogName,
+		})
 		if err != nil {
 			if infoschema.ErrTableNotExists.Equal(err) {
 				continue

--- a/pkg/mvservice/task_handler.go
+++ b/pkg/mvservice/task_handler.go
@@ -31,6 +31,12 @@ var (
 	errMVTaskCanceledManually         = errors.New("materialized view task canceled manually")
 )
 
+type mvLogAccumulationTask struct {
+	schemaName string
+	mlogName   string
+	alertRows  uint64
+}
+
 // MVTaskHandler defines all task operations needed by MVService.
 type MVTaskHandler interface {
 	RefreshMV(ctx context.Context, sysSessionPool basic.SessionPool, mvID int64) (nextRefresh time.Time, err error)
@@ -40,6 +46,8 @@ type MVTaskHandler interface {
 	SyncMVRefreshAlertStates(ctx context.Context, sysSessionPool basic.SessionPool, updatedAt time.Time, states []refreshAlertTask) error
 	CleanupStaleMVRefreshAlerts(ctx context.Context, sysSessionPool basic.SessionPool) error
 	LoadAllTiDBMVLogPurge(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mvLog, error)
+	LoadAllTiDBMVLogAccumulationTasks(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mvLogAccumulationTask, error)
+	LoadTiDBMVLogAccumulationRowCounts(ctx context.Context, sysSessionPool basic.SessionPool, tasks map[int64]*mvLogAccumulationTask) (map[int64]uint64, error)
 	LoadAllTiDBMVRefresh(ctx context.Context, sysSessionPool basic.SessionPool) (map[int64]*mv, error)
 	GetCurrentTSO(ctx context.Context, sysSessionPool basic.SessionPool) (uint64, error)
 	PurgeMVHistoryBeforeTSO(

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -48,7 +48,7 @@ import (
 const (
 	testSQLFetchMVLogPurge        = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) as NEXT_TIME_SEC, MLOG_ID FROM mysql.tidb_mlog_purge_info WHERE NEXT_TIME IS NOT NULL`
 	testSQLFetchMVLogAccumulation = `SELECT MLOG_ID FROM mysql.tidb_mlog_purge_info`
-	testSQLCountMVLogRows         = `SELECT COUNT(*) FROM %n.%n`
+	testSQLCountMVLogRows         = `SELECT /*+ read_from_storage(tiflash[%n.%n]) */ COUNT(*) FROM %n.%n`
 	testSQLFetchMVRefresh         = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) as NEXT_TIME_SEC, MVIEW_ID, LAST_SUCCESS_READ_TSO FROM mysql.tidb_mview_refresh_info WHERE NEXT_TIME IS NOT NULL`
 	testSQLRefreshMV              = `REFRESH MATERIALIZED VIEW %n.%n FAST`
 	testSQLFindMVNextTime         = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID = %? AND NEXT_TIME IS NOT NULL`
@@ -139,6 +139,7 @@ type recordingSessionContext struct {
 	execErrs                               map[string]error
 	executedRestrictedSQL                  []string
 	executedRestrictedArg                  [][]any
+	restrictedDistSQLScanConcurrency       []int
 	restrictedMaintainQuota                []int64
 	restrictedMaintainIsolationReadEngines []string
 	restrictedMaxThreads                   []int64
@@ -235,6 +236,7 @@ func (s *recordingSessionContext) ExecRestrictedSQL(_ context.Context, _ []sqlex
 	argsCopy := make([]any, len(args))
 	copy(argsCopy, args)
 	s.executedRestrictedArg = append(s.executedRestrictedArg, argsCopy)
+	s.restrictedDistSQLScanConcurrency = append(s.restrictedDistSQLScanConcurrency, s.GetSessionVars().DistSQLScanConcurrency())
 	s.restrictedMaintainQuota = append(s.restrictedMaintainQuota, s.GetSessionVars().MVMaintainMemQuota)
 	s.restrictedMaintainIsolationReadEngines = append(s.restrictedMaintainIsolationReadEngines, s.GetSessionVars().MVMaintainIsolationReadEngines)
 	s.restrictedMaxThreads = append(s.restrictedMaxThreads, s.GetSessionVars().TiFlashMaxThreads)
@@ -1655,6 +1657,7 @@ func TestServerHelperLoadAllTiDBMVLogAccumulationTasksSkipsDisabledByDefault(t *
 
 func TestServerHelperLoadTiDBMVLogAccumulationRowCounts(t *testing.T) {
 	se := newRecordingSessionContext()
+	se.GetSessionVars().SetDistSQLScanConcurrency(7)
 	se.restrictedRows[testSQLCountMVLogRows] = []chunk.Row{
 		chunk.MutRowFromDatums([]types.Datum{types.NewIntDatum(50)}).ToRow(),
 	}
@@ -1671,7 +1674,9 @@ func TestServerHelperLoadTiDBMVLogAccumulationRowCounts(t *testing.T) {
 	got, err := (&serviceHelper{}).LoadTiDBMVLogAccumulationRowCounts(context.Background(), pool, tasks)
 	require.NoError(t, err)
 	require.Equal(t, []string{testSQLCountMVLogRows}, se.executedRestrictedSQL)
-	require.Equal(t, []any{"test", "mlog1"}, se.executedRestrictedArg[0])
+	require.Equal(t, []any{"test", "mlog1", "test", "mlog1"}, se.executedRestrictedArg[0])
+	require.Equal(t, []int{1}, se.restrictedDistSQLScanConcurrency)
+	require.Equal(t, 7, se.GetSessionVars().DistSQLScanConcurrency())
 	require.Equal(t, map[int64]uint64{201: 50}, got)
 }
 

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -1624,19 +1624,19 @@ func TestServerHelperLoadAllTiDBMLogPurge(t *testing.T) {
 	require.Equal(t, expect202.UnixMilli(), l202.orderTs)
 }
 
-func TestServerHelperLoadAllTiDBMVLogAccumulationTasksDefaultThreshold(t *testing.T) {
+func TestServerHelperLoadAllTiDBMVLogAccumulationTasksSkipsDisabledByDefault(t *testing.T) {
 	se := newRecordingSessionContext()
 	se.restrictedRows[testSQLFetchMVLogAccumulation] = []chunk.Row{
 		chunk.MutRowFromDatums([]types.Datum{types.NewIntDatum(201)}).ToRow(),
 		chunk.MutRowFromDatums([]types.Datum{types.NewIntDatum(202)}).ToRow(),
 	}
 
-	baseTable, alertTable := buildMockMVBaseAndMVLogTables(101, 201, 101)
+	enabledBaseTable, enabledTable := buildMockMVBaseAndMVLogTables(101, 201, 101)
+	enabledRows := uint64(2048)
+	enabledTable.MaterializedViewLog.LogAccumulationAlertRows = &enabledRows
+
 	disabledBaseTable, disabledTable := buildMockMVBaseAndMVLogTables(102, 202, 102)
-	disabledTable.Name = pmodel.NewCIStr("mlog_disabled")
-	disabledRows := uint64(0)
-	disabledTable.MaterializedViewLog.LogAccumulationAlertRows = &disabledRows
-	withMockInfoSchema(t, baseTable, alertTable, disabledBaseTable, disabledTable)
+	withMockInfoSchema(t, enabledBaseTable, enabledTable, disabledBaseTable, disabledTable)
 
 	pool := recordingSessionPool{se: se}
 
@@ -1649,7 +1649,7 @@ func TestServerHelperLoadAllTiDBMVLogAccumulationTasksDefaultThreshold(t *testin
 	require.Equal(t, &mvLogAccumulationTask{
 		schemaName: "test",
 		mlogName:   "mlog1",
-		alertRows:  meta.DefaultMaterializedViewLogAccumulationAlertRows,
+		alertRows:  enabledRows,
 	}, got[int64(201)])
 }
 

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -432,6 +432,8 @@ type mockMVServiceHelper struct {
 	lastRefreshAlertAt              time.Time
 	lastRefreshAlertSync            []refreshAlertTask
 	lastAccumulationRowCountTaskIDs []int64
+	accumulationRowCountEntered     chan struct{}
+	blockAccumulationRowCount       chan struct{}
 
 	metricsMu          sync.Mutex
 	taskDurationCounts map[string]int
@@ -515,6 +517,15 @@ func (m *mockMVServiceHelper) LoadTiDBMVLogAccumulationRowCounts(_ context.Conte
 	m.fetchAccumulationRowCountCalls.Add(1)
 	if m.fetchAccumulationRowCountsErr != nil {
 		return nil, m.fetchAccumulationRowCountsErr
+	}
+	if m.accumulationRowCountEntered != nil {
+		select {
+		case m.accumulationRowCountEntered <- struct{}{}:
+		default:
+		}
+	}
+	if m.blockAccumulationRowCount != nil {
+		<-m.blockAccumulationRowCount
 	}
 	ids := make([]int64, 0, len(tasks))
 	ret := make(map[int64]uint64, len(tasks))

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -45,16 +46,18 @@ import (
 )
 
 const (
-	testSQLFetchMVLogPurge     = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) as NEXT_TIME_SEC, MLOG_ID FROM mysql.tidb_mlog_purge_info WHERE NEXT_TIME IS NOT NULL`
-	testSQLFetchMVRefresh      = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) as NEXT_TIME_SEC, MVIEW_ID, LAST_SUCCESS_READ_TSO FROM mysql.tidb_mview_refresh_info WHERE NEXT_TIME IS NOT NULL`
-	testSQLRefreshMV           = `REFRESH MATERIALIZED VIEW %n.%n FAST`
-	testSQLFindMVNextTime      = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID = %? AND NEXT_TIME IS NOT NULL`
-	testSQLLockMVNextTime      = `SELECT NEXT_TIME FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID = %? FOR UPDATE NOWAIT`
-	testSQLUpdateMVNextTime    = `UPDATE mysql.tidb_mview_refresh_info SET NEXT_TIME = %? WHERE MVIEW_ID = %?`
-	testSQLPurgeMVLog          = `PURGE MATERIALIZED VIEW LOG ON %n.%n`
-	testSQLFindPurgeNextTime   = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) FROM mysql.tidb_mlog_purge_info WHERE MLOG_ID = %? AND NEXT_TIME IS NOT NULL`
-	testSQLLockPurgeNextTime   = `SELECT NEXT_TIME FROM mysql.tidb_mlog_purge_info WHERE MLOG_ID = %? FOR UPDATE NOWAIT`
-	testSQLUpdatePurgeNextTime = `UPDATE mysql.tidb_mlog_purge_info SET NEXT_TIME = %? WHERE MLOG_ID = %?`
+	testSQLFetchMVLogPurge        = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) as NEXT_TIME_SEC, MLOG_ID FROM mysql.tidb_mlog_purge_info WHERE NEXT_TIME IS NOT NULL`
+	testSQLFetchMVLogAccumulation = `SELECT MLOG_ID FROM mysql.tidb_mlog_purge_info`
+	testSQLCountMVLogRows         = `SELECT COUNT(*) FROM %n.%n`
+	testSQLFetchMVRefresh         = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) as NEXT_TIME_SEC, MVIEW_ID, LAST_SUCCESS_READ_TSO FROM mysql.tidb_mview_refresh_info WHERE NEXT_TIME IS NOT NULL`
+	testSQLRefreshMV              = `REFRESH MATERIALIZED VIEW %n.%n FAST`
+	testSQLFindMVNextTime         = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID = %? AND NEXT_TIME IS NOT NULL`
+	testSQLLockMVNextTime         = `SELECT NEXT_TIME FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID = %? FOR UPDATE NOWAIT`
+	testSQLUpdateMVNextTime       = `UPDATE mysql.tidb_mview_refresh_info SET NEXT_TIME = %? WHERE MVIEW_ID = %?`
+	testSQLPurgeMVLog             = `PURGE MATERIALIZED VIEW LOG ON %n.%n`
+	testSQLFindPurgeNextTime      = `SELECT TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', NEXT_TIME) FROM mysql.tidb_mlog_purge_info WHERE MLOG_ID = %? AND NEXT_TIME IS NOT NULL`
+	testSQLLockPurgeNextTime      = `SELECT NEXT_TIME FROM mysql.tidb_mlog_purge_info WHERE MLOG_ID = %? FOR UPDATE NOWAIT`
+	testSQLUpdatePurgeNextTime    = `UPDATE mysql.tidb_mlog_purge_info SET NEXT_TIME = %? WHERE MLOG_ID = %?`
 )
 
 var (
@@ -389,10 +392,16 @@ type mockMVServiceHelper struct {
 	historyGCErr                      error
 	historyGCPanic                    bool
 	fetchLogs                         map[int64]*mvLog
+	fetchAccumulationTasks            map[int64]*mvLogAccumulationTask
+	fetchAccumulationRowCounts        map[int64]uint64
 	fetchViews                        map[int64]*mv
 	fetchLogsErr                      error
+	fetchAccumulationTasksErr         error
+	fetchAccumulationRowCountsErr     error
 	fetchViewsErr                     error
 	fetchLogsCalls                    atomic.Int32
+	fetchAccumulationTaskCalls        atomic.Int32
+	fetchAccumulationRowCountCalls    atomic.Int32
 	fetchViewCalls                    atomic.Int32
 	serverRefreshCalls                atomic.Int32
 	historyGCCalls                    atomic.Int32
@@ -419,9 +428,10 @@ type mockMVServiceHelper struct {
 	lastRefreshID int64
 	lastPurgeID   int64
 
-	syncRefreshAlertMu   sync.Mutex
-	lastRefreshAlertAt   time.Time
-	lastRefreshAlertSync []refreshAlertTask
+	syncRefreshAlertMu              sync.Mutex
+	lastRefreshAlertAt              time.Time
+	lastRefreshAlertSync            []refreshAlertTask
+	lastAccumulationRowCountTaskIDs []int64
 
 	metricsMu          sync.Mutex
 	taskDurationCounts map[string]int
@@ -491,6 +501,32 @@ func (m *mockMVServiceHelper) LoadAllTiDBMVLogPurge(context.Context, basic.Sessi
 		return nil, m.fetchLogsErr
 	}
 	return m.fetchLogs, nil
+}
+
+func (m *mockMVServiceHelper) LoadAllTiDBMVLogAccumulationTasks(context.Context, basic.SessionPool) (map[int64]*mvLogAccumulationTask, error) {
+	m.fetchAccumulationTaskCalls.Add(1)
+	if m.fetchAccumulationTasksErr != nil {
+		return nil, m.fetchAccumulationTasksErr
+	}
+	return m.fetchAccumulationTasks, nil
+}
+
+func (m *mockMVServiceHelper) LoadTiDBMVLogAccumulationRowCounts(_ context.Context, _ basic.SessionPool, tasks map[int64]*mvLogAccumulationTask) (map[int64]uint64, error) {
+	m.fetchAccumulationRowCountCalls.Add(1)
+	if m.fetchAccumulationRowCountsErr != nil {
+		return nil, m.fetchAccumulationRowCountsErr
+	}
+	ids := make([]int64, 0, len(tasks))
+	ret := make(map[int64]uint64, len(tasks))
+	for id := range tasks {
+		ids = append(ids, id)
+		if rowCount, ok := m.fetchAccumulationRowCounts[id]; ok {
+			ret[id] = rowCount
+		}
+	}
+	slices.Sort(ids)
+	m.lastAccumulationRowCountTaskIDs = ids
+	return ret, nil
 }
 
 func (m *mockMVServiceHelper) LoadAllTiDBMVRefresh(context.Context, basic.SessionPool) (map[int64]*mv, error) {
@@ -1575,6 +1611,57 @@ func TestServerHelperLoadAllTiDBMLogPurge(t *testing.T) {
 	expect202 := time.Unix(nextPurgeSec2, 0)
 	require.Equal(t, expect202, l202.nextPurge)
 	require.Equal(t, expect202.UnixMilli(), l202.orderTs)
+}
+
+func TestServerHelperLoadAllTiDBMVLogAccumulationTasksDefaultThreshold(t *testing.T) {
+	se := newRecordingSessionContext()
+	se.restrictedRows[testSQLFetchMVLogAccumulation] = []chunk.Row{
+		chunk.MutRowFromDatums([]types.Datum{types.NewIntDatum(201)}).ToRow(),
+		chunk.MutRowFromDatums([]types.Datum{types.NewIntDatum(202)}).ToRow(),
+	}
+
+	baseTable, alertTable := buildMockMVBaseAndMVLogTables(101, 201, 101)
+	disabledBaseTable, disabledTable := buildMockMVBaseAndMVLogTables(102, 202, 102)
+	disabledTable.Name = pmodel.NewCIStr("mlog_disabled")
+	disabledRows := uint64(0)
+	disabledTable.MaterializedViewLog.LogAccumulationAlertRows = &disabledRows
+	withMockInfoSchema(t, baseTable, alertTable, disabledBaseTable, disabledTable)
+
+	pool := recordingSessionPool{se: se}
+
+	got, err := (&serviceHelper{}).LoadAllTiDBMVLogAccumulationTasks(context.Background(), pool)
+	require.NoError(t, err)
+	require.Equal(t, []string{testSQLFetchMVLogAccumulation}, se.executedRestrictedSQL)
+	require.Len(t, se.executedRestrictedArg, 1)
+	require.Empty(t, se.executedRestrictedArg[0])
+	require.Len(t, got, 1)
+	require.Equal(t, &mvLogAccumulationTask{
+		schemaName: "test",
+		mlogName:   "mlog1",
+		alertRows:  meta.DefaultMaterializedViewLogAccumulationAlertRows,
+	}, got[int64(201)])
+}
+
+func TestServerHelperLoadTiDBMVLogAccumulationRowCounts(t *testing.T) {
+	se := newRecordingSessionContext()
+	se.restrictedRows[testSQLCountMVLogRows] = []chunk.Row{
+		chunk.MutRowFromDatums([]types.Datum{types.NewIntDatum(50)}).ToRow(),
+	}
+
+	pool := recordingSessionPool{se: se}
+	tasks := map[int64]*mvLogAccumulationTask{
+		201: {
+			schemaName: "test",
+			mlogName:   "mlog1",
+			alertRows:  50,
+		},
+	}
+
+	got, err := (&serviceHelper{}).LoadTiDBMVLogAccumulationRowCounts(context.Background(), pool, tasks)
+	require.NoError(t, err)
+	require.Equal(t, []string{testSQLCountMVLogRows}, se.executedRestrictedSQL)
+	require.Equal(t, []any{"test", "mlog1"}, se.executedRestrictedArg[0])
+	require.Equal(t, map[int64]uint64{201: 50}, got)
 }
 
 func TestServerHelperLoadAllTiDBMVRefresh(t *testing.T) {

--- a/pkg/mvservice/test_helpers_test.go
+++ b/pkg/mvservice/test_helpers_test.go
@@ -65,7 +65,19 @@ func setRefreshAlertCleanupOwnerForTest(svc *MVService, ownerHash uint32) {
 	})
 }
 
+func setTaskOwnersForTest(svc *MVService, taskHashes map[int64]uint32) {
+	overrides := make(map[string]uint32, len(taskHashes))
+	for id, hash := range taskHashes {
+		overrides[string(int64KeyToBinaryBytes(id))] = hash
+	}
+	setServiceHashOverridesForTest(svc, overrides)
+}
+
 func setServiceOwnersForTest(svc *MVService, ownerHashes map[string]uint32) {
+	setServiceHashOverridesForTest(svc, ownerHashes)
+}
+
+func setServiceHashOverridesForTest(svc *MVService, overrides map[string]uint32) {
 	svc.sch.mu.Lock()
 	svc.sch.ID = "nodeA"
 	svc.sch.chash.replicas = 1
@@ -75,7 +87,7 @@ func setServiceOwnersForTest(svc *MVService, ownerHashes map[string]uint32) {
 		mvHistoryGCOwnerKey:           10,
 		mvRefreshAlertCleanupOwnerKey: 10,
 	}
-	for key, hash := range ownerHashes {
+	for key, hash := range overrides {
 		mapping[key] = hash
 	}
 	svc.sch.chash.hashFunc = mustHash(mapping)

--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -1812,14 +1812,27 @@ func (n *MLogPurgeClause) Restore(ctx *format.RestoreCtx) error {
 	return nil
 }
 
+// MLogAccumulationAlertClause is the accumulation alert clause in CREATE MATERIALIZED VIEW LOG.
+type MLogAccumulationAlertClause struct {
+	Rows int64
+}
+
+// Restore implements Node interface.
+func (n *MLogAccumulationAlertClause) Restore(ctx *format.RestoreCtx) error {
+	ctx.WriteKeyWord("ALERT ROWS ")
+	ctx.WritePlainf("%d", n.Rows)
+	return nil
+}
+
 // CreateMaterializedViewLogStmt is a statement to create a materialized view log on a base table.
 type CreateMaterializedViewLogStmt struct {
 	ddlNode
 
-	Table   *TableName
-	Cols    []model.CIStr
-	Options []*TableOption
-	Purge   *MLogPurgeClause
+	Table             *TableName
+	Cols              []model.CIStr
+	Options           []*TableOption
+	Purge             *MLogPurgeClause
+	AccumulationAlert *MLogAccumulationAlertClause
 }
 
 // Restore implements Node interface.
@@ -1846,6 +1859,12 @@ func (n *CreateMaterializedViewLogStmt) Restore(ctx *format.RestoreCtx) error {
 		ctx.WritePlain(" ")
 		if err := n.Purge.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore CreateMaterializedViewLogStmt.Purge")
+		}
+	}
+	if n.AccumulationAlert != nil {
+		ctx.WritePlain(" ")
+		if err := n.AccumulationAlert.Restore(ctx); err != nil {
+			return errors.Annotate(err, "An error occurred while restore CreateMaterializedViewLogStmt.AccumulationAlert")
 		}
 	}
 	return nil

--- a/pkg/parser/keywords.go
+++ b/pkg/parser/keywords.go
@@ -263,6 +263,7 @@ var Keywords = []KeywordsType{
 	{"AFTER", false, "unreserved"},
 	{"AGAINST", false, "unreserved"},
 	{"AGO", false, "unreserved"},
+	{"ALERT", false, "unreserved"},
 	{"ALGORITHM", false, "unreserved"},
 	{"ALWAYS", false, "unreserved"},
 	{"ANY", false, "unreserved"},

--- a/pkg/parser/keywords_test.go
+++ b/pkg/parser/keywords_test.go
@@ -36,7 +36,7 @@ func TestKeywords(t *testing.T) {
 }
 
 func TestKeywordsLength(t *testing.T) {
-	require.Equal(t, 670, len(parser.Keywords))
+	require.Equal(t, 671, len(parser.Keywords))
 
 	reservedNr := 0
 	for _, kw := range parser.Keywords {

--- a/pkg/parser/misc.go
+++ b/pkg/parser/misc.go
@@ -165,6 +165,7 @@ var tokenMap = map[string]int{
 	"AFTER":                    after,
 	"AGAINST":                  against,
 	"AGO":                      ago,
+	"ALERT":                    alert,
 	"ALGORITHM":                algorithm,
 	"ALL":                      all,
 	"ALTER":                    alter,

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -318,6 +318,7 @@ import (
 	after                 "AFTER"
 	against               "AGAINST"
 	ago                   "AGO"
+	alert                 "ALERT"
 	algorithm             "ALGORITHM"
 	always                "ALWAYS"
 	any                   "ANY"
@@ -1446,6 +1447,8 @@ import (
 	MLogCreateOption                       "materialized view log create option"
 	MLogPurgeClauseOpt                     "materialized view log optional PURGE clause"
 	MLogPurgeClause                        "materialized view log PURGE clause"
+	MLogAccumulationAlertClauseOpt         "materialized view log optional ALERT ROWS clause"
+	MLogAccumulationAlertClause            "materialized view log ALERT ROWS clause"
 	MLogStartWithOpt                       "materialized view log START WITH option"
 	MLogNextOpt                            "materialized view log NEXT option"
 	AlterMaterializedViewAction            "ALTER MATERIALIZED VIEW action"
@@ -5425,14 +5428,15 @@ MViewNextOpt:
 	}
 
 CreateMaterializedViewLogStmt:
-	"CREATE" "MATERIALIZED" "VIEW" "LOG" "ON" TableName '(' ColumnList ')' MLogCreateOptionListOpt MLogPurgeClauseOpt
+	"CREATE" "MATERIALIZED" "VIEW" "LOG" "ON" TableName '(' ColumnList ')' MLogCreateOptionListOpt MLogPurgeClauseOpt MLogAccumulationAlertClauseOpt
 	{
 		opts := $10.(*mlogCreateOptions)
 		x := &ast.CreateMaterializedViewLogStmt{
-			Table:   $6.(*ast.TableName),
-			Cols:    $8.([]model.CIStr),
-			Options: opts.options,
-			Purge:   $11.(*ast.MLogPurgeClause),
+			Table:             $6.(*ast.TableName),
+			Cols:              $8.([]model.CIStr),
+			Options:           opts.options,
+			Purge:             $11.(*ast.MLogPurgeClause),
+			AccumulationAlert: $12.(*ast.MLogAccumulationAlertClause),
 		}
 		$$ = x
 	}
@@ -5516,6 +5520,22 @@ MLogPurgeClause:
 			startWith = $2.(ast.ExprNode)
 		}
 		$$ = &ast.MLogPurgeClause{Immediate: false, StartWith: startWith, Next: $4}
+	}
+
+MLogAccumulationAlertClauseOpt:
+	/* EMPTY */
+	{
+		$$ = (*ast.MLogAccumulationAlertClause)(nil)
+	}
+|	MLogAccumulationAlertClause
+	{
+		$$ = $1
+	}
+
+MLogAccumulationAlertClause:
+	"ALERT" "ROWS" SignedNum
+	{
+		$$ = &ast.MLogAccumulationAlertClause{Rows: $3.(int64)}
 	}
 
 MLogStartWithOpt:
@@ -7626,6 +7646,7 @@ UnReservedKeyword:
 |	"LASTVAL"
 |	"SETVAL"
 |	"AGO"
+|	"ALERT"
 |	"BACKUP"
 |	"BACKUPS"
 |	"CONCURRENCY"

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5421,6 +5421,16 @@ func TestMaterializedViewStatements(t *testing.T) {
 			"CREATE MATERIALIZED VIEW LOG ON `t` (`a`) PURGE NEXT 300",
 		},
 		{
+			"CREATE MATERIALIZED VIEW LOG ON t (a) ALERT ROWS 100",
+			true,
+			"CREATE MATERIALIZED VIEW LOG ON `t` (`a`) ALERT ROWS 100",
+		},
+		{
+			"CREATE MATERIALIZED VIEW LOG ON t (a) PURGE NEXT 300 ALERT ROWS -1",
+			true,
+			"CREATE MATERIALIZED VIEW LOG ON `t` (`a`) PURGE NEXT 300 ALERT ROWS -1",
+		},
+		{
 			"ALTER MATERIALIZED VIEW mv COMMENT = 'c2'",
 			true,
 			"ALTER MATERIALIZED VIEW `mv` COMMENT = 'c2'",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/18023

Problem Summary:
Support `ALERT ROWS n` in `CREATE MATERIALIZED VIEW LOG` and report MV log accumulation through MV service metrics.

### What changed and how does it work?

This PR adds `ALERT ROWS n` support to `CREATE MATERIALIZED VIEW LOG`.

The configured threshold is persisted in MLog metadata and restored by `SHOW CREATE MATERIALIZED VIEW LOG`. If the clause is omitted, accumulation alerting is disabled by default. `ALERT ROWS 0` also disables accumulation alerting, and negative values are rejected.

MV service now periodically scans MV logs(default 20 mins) and reports how many of them exceed their effective accumulation threshold through `tidb_mv_service_task_status{type="mvlog_accumulation"}`. To avoid duplicate work in multi-node deployments, row-count scanning is performed only on the owner node for each MLog.

Tests were added for parser coverage, DDL validation, show-create output, and MV service accumulation scanning.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ALERT ROWS` support to `CREATE MATERIALIZED VIEW LOG`, including validation (negative values rejected) and disable behavior (`ALERT ROWS 0` or omitted disables).
  * MV log accumulation alerts are now monitored via a dedicated runtime status/metric, and the configured threshold is shown in `SHOW CREATE MATERIALIZED VIEW LOG`.
* **Documentation**
  * Updated `PURGE MATERIALIZED VIEW LOG` docs to describe `ALERT ROWS n` semantics, defaults, persistence behavior, and monitoring.
* **Tests**
  * Expanded parser, MV log DDL/`SHOW CREATE`, and MVService alert scanning tests (including strict “greater than” triggering and concurrency/non-overlap).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->