### PR TITLE
mvservice: improve logging messages and update backoff handling in MV service tasks

### DIFF
--- a/pkg/mvservice/service.go
+++ b/pkg/mvservice/service.go
@@ -679,7 +679,7 @@ func (t *MVService) handleRefreshTaskResult(m *mv, nextRefresh time.Time, err er
 					zap.Time("manual_cancel_backoff_at", nextRetryAt),
 					zap.Error(backoffErr),
 				)
-				logutil.BgLogger().Warn("refresh MV manual cancel backoff persist failed, forcing metadata refetch", fields...)
+				logutil.BgLogger().Warn("refresh MV manual cancel backoff persist failed", fields...)
 			}
 			if applied {
 				if appliedNext.IsZero() {
@@ -689,8 +689,7 @@ func (t *MVService) handleRefreshTaskResult(m *mv, nextRefresh time.Time, err er
 				t.rescheduleMVSuccess(m, appliedNext)
 				return
 			}
-			t.lastMetaFetchMillis.Store(0)
-			t.removeMVTask(m)
+			t.rescheduleMV(m, nextRetryAt.UnixMilli())
 			return
 		}
 		retryCount := m.retryCount.Add(1)
@@ -729,7 +728,7 @@ func (t *MVService) handlePurgeTaskResult(l *mvLog, nextPurge time.Time, err err
 					zap.Time("manual_cancel_backoff_at", nextRetryAt),
 					zap.Error(backoffErr),
 				)
-				logutil.BgLogger().Warn("purge MV log manual cancel backoff persist failed, forcing metadata refetch", fields...)
+				logutil.BgLogger().Warn("purge MV log manual cancel backoff persist failed", fields...)
 			}
 			if applied {
 				if appliedNext.IsZero() {
@@ -739,8 +738,7 @@ func (t *MVService) handlePurgeTaskResult(l *mvLog, nextPurge time.Time, err err
 				t.rescheduleMVLogSuccess(l, appliedNext)
 				return
 			}
-			t.lastMetaFetchMillis.Store(0)
-			t.removeMVLogTask(l)
+			t.rescheduleMVLog(l, nextRetryAt.UnixMilli())
 			return
 		}
 		retryCount := l.retryCount.Add(1)

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -1184,16 +1184,18 @@ func TestMVServiceTaskResult(t *testing.T) {
 			}, testEventuallyWait, testEventuallyTick)
 		})
 
-		t.Run("manual_cancel_without_persist_forces_refetch", func(t *testing.T) {
+		t.Run("manual_cancel_without_persist_uses_local_backoff", func(t *testing.T) {
 			helper := &mockMVServiceHelper{
 				purgeErr: errMVTaskCanceledManually,
 			}
 			svc := newRunningMVServiceForTest(t, helper)
-			svc.lastMetaFetchMillis.Store(mvsNow().UnixMilli())
+			now := mvsNow()
+			svc.lastMetaFetchMillis.Store(now.UnixMilli())
+			expectedNext := now.Add(manualCancelBackoffDelay)
 
 			l := &mvLog{
 				ID:        306,
-				nextPurge: mvsNow().Add(-time.Minute).Round(0),
+				nextPurge: now.Add(-time.Minute).Round(0),
 			}
 			svc.buildMVLogPurgeTasks(map[int64]*mvLog{l.ID: l})
 			svc.purgeMVLog([]*mvLog{l})
@@ -1201,12 +1203,13 @@ func TestMVServiceTaskResult(t *testing.T) {
 			waitExecutorFinishedCount(t, svc, 1)
 			require.Equal(t, int32(1), helper.purgeManualCancelBackoffCalls.Load())
 			require.Equal(t, int64(0), l.retryCount.Load())
-			require.Equal(t, int64(0), svc.lastMetaFetchMillis.Load())
+			require.Equal(t, now.UnixMilli(), svc.lastMetaFetchMillis.Load())
 
 			svc.mvLogPurgeMu.Lock()
-			_, ok := svc.mvLogPurgeMu.pending[l.ID]
+			item, ok := svc.mvLogPurgeMu.pending[l.ID]
 			svc.mvLogPurgeMu.Unlock()
-			require.False(t, ok)
+			require.True(t, ok)
+			require.Equal(t, expectedNext.UnixMilli(), item.Value.orderTs)
 		})
 	})
 
@@ -1313,16 +1316,18 @@ func TestMVServiceTaskResult(t *testing.T) {
 			}, testEventuallyWait, testEventuallyTick)
 		})
 
-		t.Run("manual_cancel_without_persist_forces_refetch", func(t *testing.T) {
+		t.Run("manual_cancel_without_persist_uses_local_backoff", func(t *testing.T) {
 			helper := &mockMVServiceHelper{
 				refreshErr: errMVTaskCanceledManually,
 			}
 			svc := newRunningMVServiceForTest(t, helper)
-			svc.lastMetaFetchMillis.Store(mvsNow().UnixMilli())
+			now := mvsNow()
+			svc.lastMetaFetchMillis.Store(now.UnixMilli())
+			expectedNext := now.Add(manualCancelBackoffDelay)
 
 			m := &mv{
 				ID:          404,
-				nextRefresh: mvsNow().Add(-time.Minute).Round(0),
+				nextRefresh: now.Add(-time.Minute).Round(0),
 			}
 			svc.buildMVRefreshTasks(map[int64]*mv{m.ID: m})
 			svc.refreshMV([]*mv{m})
@@ -1330,12 +1335,13 @@ func TestMVServiceTaskResult(t *testing.T) {
 			waitExecutorFinishedCount(t, svc, 1)
 			require.Equal(t, int32(1), helper.refreshManualCancelBackoffCalls.Load())
 			require.Equal(t, int64(0), m.retryCount.Load())
-			require.Equal(t, int64(0), svc.lastMetaFetchMillis.Load())
+			require.Equal(t, now.UnixMilli(), svc.lastMetaFetchMillis.Load())
 
 			svc.mvRefreshMu.Lock()
-			_, ok := svc.mvRefreshMu.pending[m.ID]
+			item, ok := svc.mvRefreshMu.pending[m.ID]
 			svc.mvRefreshMu.Unlock()
-			require.False(t, ok)
+			require.True(t, ok)
+			require.Equal(t, expectedNext.UnixMilli(), item.Value.orderTs)
 		})
 	})
 }


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: ref #xxx

Problem Summary:

When a manually canceled MV refresh or MV log purge task fails to persist its backoff metadata, MVService used to clear `lastMetaFetchMillis` and remove the local task, forcing a metadata refetch. This could unnecessarily affect the global metadata fetch cadence instead of applying the manual-cancel cooldown only to the current task.

### What changed and how does it work?

This PR changes the manual-cancel fallback path to keep the current task in the local scheduler and reschedule it to `now + manualCancelBackoffDelay`.

It also updates the related task result tests to verify that:
- `lastMetaFetchMillis` is not reset.
- the canceled task remains in the local queue.
- the task `orderTs` is moved to the manual-cancel backoff time.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test:

```bash
go test -run TestMVServiceTaskResult -tags=intest,deadlock ./pkg/mvservice
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced manual cancellation backoff handling for refresh and purge tasks. Tasks are now properly rescheduled with appropriate backoff delays when cancellations occur without persistence, improving reliability and reducing unnecessary refetch operations.

* **Tests**
  * Updated test cases to verify improved backoff scheduling behavior for task cancellations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->