### PR TITLE
ingest: release unsent jobs when generateAndSendJob is canceled

### DIFF
--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1220,9 +1220,10 @@ func (local *Backend) generateAndSendJob(
 						}
 						return err
 					}
-					// we need to increase the ref count before sending jobs to
-					// jobToWorkerCh, in case some job finished quickly and decrease
-					// the ref count to zero and cause the data being released.
+					// All jobs must be ref'd before sending any job to jobToWorkerCh.
+					// Jobs run asynchronously after they are sent. If an earlier job finishes
+					// before later jobs increase their refs, the ingest data can be released
+					// when its ref count drops to zero.
 					for _, job := range jobs {
 						job.ref(jobWg)
 					}

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1226,11 +1226,13 @@ func (local *Backend) generateAndSendJob(
 					for _, job := range jobs {
 						job.ref(jobWg)
 					}
-					for _, job := range jobs {
+					for i, job := range jobs {
 						select {
 						case <-egCtx.Done():
-							// this job is not put into jobToWorkerCh
-							job.done(jobWg)
+							for _, unsentJob := range jobs[i:] {
+								// These jobs are not put into jobToWorkerCh.
+								unsentJob.done(jobWg)
+							}
 							// if the context is canceled, it means worker has error.
 							return nil
 						case jobToWorkerCh <- job:

--- a/pkg/ingestor/ingestctrl/local_test.go
+++ b/pkg/ingestor/ingestctrl/local_test.go
@@ -2937,6 +2937,78 @@ func TestRefAllJobsBeforeSending(t *testing.T) {
 	require.True(t, data.GetRefCount() == 0, "ref count should be 0 after all jobs are done")
 }
 
+func TestGenerateAndSendJobDoneAllRefedJobsOnCancel(t *testing.T) {
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ingestor/ingestctrl/fakeRegionJobs", "return()")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	local := &Backend{}
+	local.WorkerConcurrency.Store(1)
+
+	data := &refCountIngestData{
+		mockIngestData: mockIngestData{
+			{[]byte("b"), []byte("b")},
+			{[]byte("c"), []byte("c")},
+			{[]byte("d"), []byte("d")},
+			{[]byte("e"), []byte("e")},
+		},
+	}
+	jobs := []*regionJob{
+		{keyRange: engineapi.Range{Start: []byte("a"), End: []byte("b")}, ingestData: data, region: dummyRegionInfo},
+		{keyRange: engineapi.Range{Start: []byte("b"), End: []byte("c")}, ingestData: data, region: dummyRegionInfo},
+		{keyRange: engineapi.Range{Start: []byte("c"), End: []byte("d")}, ingestData: data, region: dummyRegionInfo},
+		{keyRange: engineapi.Range{Start: []byte("d"), End: []byte("e")}, ingestData: data, region: dummyRegionInfo},
+	}
+	jobRange := engineapi.Range{Start: []byte("a"), End: []byte("e")}
+	fakeRegionJobs = map[[2]string]struct {
+		jobs []*regionJob
+		err  error
+	}{
+		{"a", "e"}: {
+			jobs: jobs,
+		},
+	}
+	t.Cleanup(func() {
+		fakeRegionJobs = nil
+	})
+
+	mockEngine := &mockEngineWithData{
+		data:   data,
+		ranges: []engineapi.Range{jobRange},
+	}
+	jobToWorkerCh := make(chan *regionJob)
+	var jobWg sync.WaitGroup
+	firstJobDone := make(chan struct{})
+
+	go func() {
+		job := <-jobToWorkerCh
+		job.done(&jobWg)
+		cancel()
+		close(firstJobDone)
+	}()
+
+	err := local.generateAndSendJob(ctx, mockEngine, int64(config.SplitRegionSize), int64(config.SplitRegionKeys), jobToWorkerCh, &jobWg)
+	require.NoError(t, err)
+	<-firstJobDone
+
+	waitDone := make(chan struct{})
+	go func() {
+		jobWg.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+	case <-time.After(3 * time.Second):
+		for _, job := range jobs[2:] {
+			job.done(&jobWg)
+		}
+		<-waitDone
+		require.Fail(t, "jobWg.Wait should finish after generateAndSendJob returns", "ref'd jobs after the canceled send path must all be marked done")
+	}
+	require.Equal(t, int64(0), data.GetRefCount())
+}
+
 // mockEngineWithData is a mock engine that implements engineapi.Engine
 type mockEngineWithData struct {
 	data   engineapi.IngestData

--- a/pkg/ingestor/ingestctrl/local_test.go
+++ b/pkg/ingestor/ingestctrl/local_test.go
@@ -2993,7 +2993,7 @@ func TestGenerateAndSendJobDoneAllRefedJobsOnCancel(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return data.GetRefCount() == 0
-	}, 3*time.Second, 10*time.Millisecond, "ref'd jobs after the canceled send path must all be marked done")
+	}, 10*time.Second, 10*time.Millisecond, "ref'd jobs after the canceled send path must all be marked done")
 	jobWg.Wait()
 	require.Equal(t, int64(0), data.GetRefCount())
 }

--- a/pkg/ingestor/ingestctrl/local_test.go
+++ b/pkg/ingestor/ingestctrl/local_test.go
@@ -2991,31 +2991,10 @@ func TestGenerateAndSendJobDoneAllRefedJobsOnCancel(t *testing.T) {
 	require.NoError(t, err)
 	<-firstJobDone
 
-	waitDone := make(chan struct{})
-	go func() {
-		jobWg.Wait()
-		close(waitDone)
-	}()
-
-	cleanupLeakedJobs := true
-	defer func() {
-		if !cleanupLeakedJobs {
-			return
-		}
-		for _, job := range jobs[2:] {
-			job.done(&jobWg)
-		}
-		<-waitDone
-	}()
 	require.Eventually(t, func() bool {
-		select {
-		case <-waitDone:
-			return true
-		default:
-			return false
-		}
+		return data.GetRefCount() == 0
 	}, 3*time.Second, 10*time.Millisecond, "ref'd jobs after the canceled send path must all be marked done")
-	cleanupLeakedJobs = false
+	jobWg.Wait()
 	require.Equal(t, int64(0), data.GetRefCount())
 }
 

--- a/pkg/ingestor/ingestctrl/local_test.go
+++ b/pkg/ingestor/ingestctrl/local_test.go
@@ -2997,15 +2997,25 @@ func TestGenerateAndSendJobDoneAllRefedJobsOnCancel(t *testing.T) {
 		close(waitDone)
 	}()
 
-	select {
-	case <-waitDone:
-	case <-time.After(3 * time.Second):
+	cleanupLeakedJobs := true
+	defer func() {
+		if !cleanupLeakedJobs {
+			return
+		}
 		for _, job := range jobs[2:] {
 			job.done(&jobWg)
 		}
 		<-waitDone
-		require.Fail(t, "jobWg.Wait should finish after generateAndSendJob returns", "ref'd jobs after the canceled send path must all be marked done")
-	}
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-waitDone:
+			return true
+		default:
+			return false
+		}
+	}, 3*time.Second, 10*time.Millisecond, "ref'd jobs after the canceled send path must all be marked done")
+	cleanupLeakedJobs = false
 	require.Equal(t, int64(0), data.GetRefCount())
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69240

Problem Summary:

PR #64767 changed `generateAndSendJob` to ref all generated region jobs before sending any of them to `jobToWorkerCh`. That protects shared ingest data from being cleaned too early, but it left a cancellation gap: if the context is canceled after one job is sent and before the remaining jobs in the same slice are sent, only the current unsent job is marked done. Later jobs were already refed but are never handed to a downstream owner and never marked done, so `jobWg.Wait()` can block forever and keep `RunSubtask` stuck.

### What changed and how does it work?

When `generateAndSendJob` observes context cancellation in the send loop, it now marks every remaining unsent job in `jobs[i:]` as done before returning. Jobs before `i` were already sent to `jobToWorkerCh` and remain owned by downstream components. The current job and later jobs were not sent, so the generator must balance their earlier refs locally.

The new unit test reproduces the stuck path by sending the first generated job, canceling the context, and asserting that `jobWg.Wait()` still finishes after `generateAndSendJob` returns.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/ingestor/ingestctrl -run TestGenerateAndSendJobDoneAllRefedJobsOnCancel -count=1` failed before the fix with `jobWg.Wait should finish after generateAndSendJob returns`.
  - `./tools/check/failpoint-go-test.sh pkg/ingestor/ingestctrl -run 'Test(GenerateAndSendJobDoneAllRefedJobsOnCancel|RefAllJobsBeforeSending)$' -count=1`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug that could cause IMPORT INTO or related local backend ingest tasks to hang after job generation was canceled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job cancellation handling to keep internal accounting consistent when cancellation happens mid-dispatch, ensuring all pending jobs are treated as completed.
* **Tests**
  * Added a new test covering the cancellation edge case where only the first job is received before cancellation, verifying accounting completes correctly and all ref-counted jobs are finalized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->