### PR TITLE
importinto/ingestor: improve error logging

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -638,7 +638,7 @@ found data conflict records in table %s, primary key is '%s', row data is '%s'
 
 ["Lightning:Restore:ErrFoundDuplicateKey"]
 error = '''
-found duplicate key '%s', value '%s'
+found duplicate key '%x', value '%x'
 '''
 
 ["Lightning:Restore:ErrFoundIndexConflictRecords"]

--- a/pkg/dxf/importinto/encode_and_sort_operator.go
+++ b/pkg/dxf/importinto/encode_and_sort_operator.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/execute"
 	"github.com/pingcap/tidb/pkg/dxf/operator"
@@ -182,12 +183,12 @@ func (w *chunkWorker) Close() error {
 		// Note: we cannot ignore close error as we're writing to S3 or GCS.
 		// ignore error might cause data loss. below too.
 		if _, err := w.dataWriter.Close(closeCtx); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 	}
 	if w.indexWriter != nil {
 		if _, err := w.indexWriter.Close(closeCtx); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 	}
 

--- a/pkg/dxf/importinto/scheduler.go
+++ b/pkg/dxf/importinto/scheduler.go
@@ -402,6 +402,9 @@ func (sch *importScheduler) OnNextSubtasksBatch(
 		zap.String("curr-step", proto.Step2Str(task.Type, task.Step)),
 		zap.String("next-step", proto.Step2Str(task.Type, nextStep)),
 		zap.Int("node-count", nodeCnt),
+		zap.String("db-name", taskMeta.Plan.DBName),
+		zap.String("table-name", taskMeta.Plan.TableInfo.Name.O),
+		zap.Int64("db-id", taskMeta.Plan.DBID),
 		zap.Int64("table-id", taskMeta.Plan.TableInfo.ID),
 	)
 	logger.Info("on next subtasks batch")

--- a/pkg/dxf/importinto/task_executor.go
+++ b/pkg/dxf/importinto/task_executor.go
@@ -237,7 +237,7 @@ func (s *importStepExecutor) RunSubtask(ctx context.Context, subtask *proto.Subt
 		objStore                  storeapi.Storage
 	)
 	defer func() {
-		task.End(zapcore.ErrorLevel, err, zap.Int64("data-kv-files", dataKVFiles.Load()),
+		task.End2(zapcore.ErrorLevel, err, zap.Int64("data-kv-files", dataKVFiles.Load()),
 			zap.Int64("index-kv-files", indexKVFiles.Load()),
 			zap.Stringer("obj-store-access", accessRec))
 	}()
@@ -487,7 +487,7 @@ func (m *mergeSortStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 	logger := m.logger.With(zap.Int64("subtask-id", subtask.ID), zap.String("kv-group", sm.KVGroup))
 	task := log.BeginTask(logger, "run subtask")
 	defer func() {
-		task.End(zapcore.ErrorLevel, err, zap.Stringer("obj-store-access", accessRec))
+		task.End2(zapcore.ErrorLevel, err, zap.Stringer("obj-store-access", accessRec))
 	}()
 
 	var mu sync.Mutex
@@ -711,7 +711,7 @@ func (e *writeAndIngestStepExecutor) RunSubtask(ctx context.Context, subtask *pr
 		zap.String("kv-group", sm.KVGroup))
 	task := log.BeginTask(logger, "run subtask")
 	defer func() {
-		task.End(zapcore.ErrorLevel, err, zap.Stringer("obj-store-access", accessRec))
+		task.End2(zapcore.ErrorLevel, err, zap.Stringer("obj-store-access", accessRec))
 	}()
 
 	_, engineUUID := backend.MakeUUID("", subtask.ID)
@@ -901,7 +901,7 @@ func (e *importExecutor) GetStepExecutor(task *proto.Task) (execute.StepExecutor
 	if err := json.Unmarshal(task.Meta, &taskMeta); err != nil {
 		return nil, errors.Trace(err)
 	}
-	logger := logutil.BgLogger().With(
+	logger := logutil.ErrVerboseLogger().With(
 		zap.Int64("task-id", task.ID),
 		zap.String("task-key", task.Key),
 		zap.String("step", proto.Step2Str(task.Type, task.Step)),

--- a/pkg/ingestor/globalsort/engine_test.go
+++ b/pkg/ingestor/globalsort/engine_test.go
@@ -352,7 +352,7 @@ func TestEngineOnDup(t *testing.T) {
 		dataFiles, statFiles := prepareKVFiles(t, store, contents)
 		extEngine := getEngineFn(store, onDup, dataFiles, statFiles)
 		loadDataCh := make(chan engineapi.DataAndRanges, 4)
-		require.ErrorContains(t, extEngine.LoadIngestData(ctx, loadDataCh), "[Lightning:Restore:ErrFoundDuplicateKey]found duplicate key '\x01', value 'aa'")
+		require.ErrorContains(t, extEngine.LoadIngestData(ctx, loadDataCh), "[Lightning:Restore:ErrFoundDuplicateKey]found duplicate key '01', value '6161'")
 		t.Cleanup(func() {
 			require.NoError(t, extEngine.Close())
 		})

--- a/pkg/ingestor/ingestctrl/duplicate_test.go
+++ b/pkg/ingestor/ingestctrl/duplicate_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/ingestor/ingestctrl"
@@ -251,6 +252,17 @@ func TestRetrieveKeyAndValueFromErrFoundDuplicateKeys(t *testing.T) {
 
 	originalErr := common.ErrFoundDuplicateKeys.FastGenByArgs(data1RowKey, data1RowValue)
 	rawKey, rawValue, err := ingestctrl.RetrieveKeyAndValueFromErrFoundDuplicateKeys(originalErr)
+	require.NoError(t, err)
+	require.Equal(t, data1RowKey, rawKey)
+	require.Equal(t, data1RowValue, rawValue)
+
+	originalMode := errors.RedactLogEnabled.Load()
+	t.Cleanup(func() { errors.RedactLogEnabled.Store(originalMode) })
+	errors.RedactLogEnabled.Store(errors.RedactLogEnable)
+
+	// ErrFoundDuplicateKeys carries raw KV bytes for downstream duplicate decoding.
+	originalErr = common.ErrFoundDuplicateKeys.FastGenByArgs(data1RowKey, data1RowValue)
+	rawKey, rawValue, err = ingestctrl.RetrieveKeyAndValueFromErrFoundDuplicateKeys(originalErr)
 	require.NoError(t, err)
 	require.Equal(t, data1RowKey, rawKey)
 	require.Equal(t, data1RowValue, rawValue)

--- a/pkg/lightning/common/errors.go
+++ b/pkg/lightning/common/errors.go
@@ -104,7 +104,7 @@ var (
 	ErrTableIsChecksuming   = errors.Normalize("table '%s' is checksuming", errors.RFCCodeText("Lightning:Restore:ErrTableIsChecksuming"))
 	ErrResolveDuplicateRows = errors.Normalize("resolve duplicate rows error on table '%s'", errors.RFCCodeText("Lightning:Restore:ErrResolveDuplicateRows"))
 	// ErrFoundDuplicateKeys shoud be replaced with ErrFoundDataConflictRecords and ErrFoundIndexConflictRecords (TODO)
-	ErrFoundDuplicateKeys        = errors.Normalize("found duplicate key '%s', value '%s'", errors.RFCCodeText("Lightning:Restore:ErrFoundDuplicateKey"))
+	ErrFoundDuplicateKeys        = errors.Normalize("found duplicate key '%x', value '%x'", errors.RFCCodeText("Lightning:Restore:ErrFoundDuplicateKey"), errors.RedactArgs([]int{1}))
 	ErrAddIndexFailed            = errors.Normalize("add index on table %s failed", errors.RFCCodeText("Lightning:Restore:ErrAddIndexFailed"))
 	ErrDropIndexFailed           = errors.Normalize("drop index %s on table %s failed", errors.RFCCodeText("Lightning:Restore:ErrDropIndexFailed"))
 	ErrFoundDataConflictRecords  = errors.Normalize("found data conflict records in table %s, primary key is '%s', row data is '%s'", errors.RFCCodeText("Lightning:Restore:ErrFoundDataConflictRecords"))

--- a/pkg/lightning/common/errors.go
+++ b/pkg/lightning/common/errors.go
@@ -104,7 +104,7 @@ var (
 	ErrTableIsChecksuming   = errors.Normalize("table '%s' is checksuming", errors.RFCCodeText("Lightning:Restore:ErrTableIsChecksuming"))
 	ErrResolveDuplicateRows = errors.Normalize("resolve duplicate rows error on table '%s'", errors.RFCCodeText("Lightning:Restore:ErrResolveDuplicateRows"))
 	// ErrFoundDuplicateKeys shoud be replaced with ErrFoundDataConflictRecords and ErrFoundIndexConflictRecords (TODO)
-	ErrFoundDuplicateKeys        = errors.Normalize("found duplicate key '%x', value '%x'", errors.RFCCodeText("Lightning:Restore:ErrFoundDuplicateKey"), errors.RedactArgs([]int{1}))
+	ErrFoundDuplicateKeys        = errors.Normalize("found duplicate key '%x', value '%x'", errors.RFCCodeText("Lightning:Restore:ErrFoundDuplicateKey"))
 	ErrAddIndexFailed            = errors.Normalize("add index on table %s failed", errors.RFCCodeText("Lightning:Restore:ErrAddIndexFailed"))
 	ErrDropIndexFailed           = errors.Normalize("drop index %s on table %s failed", errors.RFCCodeText("Lightning:Restore:ErrDropIndexFailed"))
 	ErrFoundDataConflictRecords  = errors.Normalize("found data conflict records in table %s, primary key is '%s', row data is '%s'", errors.RFCCodeText("Lightning:Restore:ErrFoundDataConflictRecords"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #66019

Problem Summary:

IMPORT INTO logging did not include enough DB/table context when scheduling subtasks, and duplicate-key errors could print binary key/value bytes as strings. so binary data might be printed as unicode replacement char \0xFFFD.
The duplicate-key error is also used as an internal carrier of raw KV bytes, so it must not mutate its stored arguments under log redaction; otherwise DDL/global-sort duplicate errors can fail to convert back to the user-facing `[kv:1062]Duplicate entry ...` format.

### What changed and how does it work?

This PR improves IMPORT INTO log output by:

- adding database and table names, database ID, and table ID to the scheduler's "on next subtasks batch" log;
- using verbose error logging for import step executors so `errorVerbose` includes traced stack details;
- tracing writer close errors in the encode-and-sort chunk worker;
- formatting duplicate-key key/value bytes as hex while preserving the raw key/value error arguments for downstream duplicate decoding.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

tested manually, as we only change logs, we can see the db/table name/id is printed when schedule.
in ErrFoundDuplicateKey error the key/value is printed as hex(previously it's printed as string, so binary data might be printed as unicode replacement char `\0xFFFD`). The raw key/value arguments are intentionally preserved so DDL can still decode duplicate keys and produce the SQL duplicate-entry error; redaction of the user-facing duplicate entry happens after conversion to `kv.ErrKeyExists`.

```log
[2026/06/16 17:33:45.917 +08:00] [INFO] [scheduler.go:410] ["on next subtasks batch"] [keyspaceName=SYSTEM] [task-id=5] [task-key=SYSTEM/ImportInto/5] [curr-step=prepared] [next-step=encode] [node-count=1] [db-name=test] [table-name=t] [db-id=5] [table-id=10]

[Lightning:Restore:ErrFoundDuplicateKey]found duplicate key '01', value '6161'
```

Local validation:

```bash
make bazel_prepare
./tools/check/failpoint-go-test.sh pkg/dxf/importinto -run '^$' -count=1
./tools/check/failpoint-go-test.sh pkg/lightning/common -run '^$' -count=1
./tools/check/failpoint-go-test.sh pkg/ingestor/globalsort -run 'TestEngineOnDup/on_duplicate_error' -count=1
./tools/check/failpoint-go-test.sh pkg/ingestor/globalsort -run '^TestEngineOnDup$' -count=1
./tools/check/failpoint-go-test.sh pkg/ingestor/ingestctrl -run TestRetrieveKeyAndValueFromErrFoundDuplicateKeys -count=1
./tools/check/failpoint-go-test.sh pkg/lightning/common -run TestErrCastValueRedact -count=1
./tools/check/failpoint-go-test.sh pkg/ingestor/globalsort -run TestEngineOnDup -count=1
git diff --check
make lint
```

Attempted but not verified locally because local ingest backfill is unavailable due to `/tmp` disk quota:

```bash
go test -run 'TestGlobalSortDuplicateErrMsg/varchar_index' -count=1 -tags=intest,deadlock ./tests/realtikvtest/addindextest2/...
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error stack/context preservation when closing import resources.
  * Updated duplicate-key error formatting to use hexadecimal representations, matching the serialized output.
* **Chores**
  * Enhanced task logs with additional database/table metadata.
  * Refined end-of-task structured logging for clearer observability.
* **Tests**
  * Updated globalsort duplicate-key expectations for the new serialized format.
  * Added test coverage to ensure duplicate-key raw KV arguments remain correct under log redaction mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->