### PR TITLE
ddl, executor: cherry-pick MV log DDL enhancements

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -257,6 +257,7 @@ go_test(
         "job_worker_test.go",
         "main_test.go",
         "metabuild_test.go",
+        "modify_column_mv_usage_test.go",
         "modify_column_test.go",
         "multi_schema_change_test.go",
         "mv_index_test.go",

--- a/pkg/ddl/add_column.go
+++ b/pkg/ddl/add_column.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/exprctx"
 	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/autoid"
 	"github.com/pingcap/tidb/pkg/meta/metabuild"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -78,7 +79,17 @@ func (w *worker) onAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err
 		}
 		return ver, errors.Trace(err)
 	}
+	if err = refreshMLogAddedColumnFromBase(jobCtx.metaMut, job, tblInfo, columnInfo, colFromArgs); err != nil {
+		job.State = model.JobStateCancelled
+		return ver, errors.Trace(err)
+	}
 	if columnInfo == nil {
+		if tblInfo.MaterializedViewLog != nil {
+			if err = setMLogAddedColumnOriginDefault(colFromArgs); err != nil {
+				job.State = model.JobStateCancelled
+				return ver, errors.Trace(err)
+			}
+		}
 		columnInfo = InitAndAddColumnToTable(tblInfo, colFromArgs)
 		logutil.DDLLogger().Info("run add column job", zap.Stringer("job", job), zap.Reflect("columnInfo", *columnInfo))
 		if err = checkAddColumnTooManyColumns(len(tblInfo.Columns)); err != nil {
@@ -126,6 +137,7 @@ func (w *worker) onAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err
 		}
 		tblInfo.MoveColumnInfo(columnInfo.Offset, offset)
 		columnInfo.State = model.StatePublic
+		syncMLogColumnsAfterAddColumn(tblInfo)
 		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != columnInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
@@ -143,6 +155,98 @@ func (w *worker) onAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err
 	}
 
 	return ver, errors.Trace(err)
+}
+
+func refreshMLogAddedColumnFromBase(
+	t *meta.Mutator,
+	job *model.Job,
+	mlogTblInfo *model.TableInfo,
+	columnInfo *model.ColumnInfo,
+	colFromArgs *model.ColumnInfo,
+) error {
+	if mlogTblInfo == nil || mlogTblInfo.MaterializedViewLog == nil || colFromArgs == nil {
+		return nil
+	}
+	if columnInfo != nil {
+		switch columnInfo.State {
+		case model.StateNone, model.StateDeleteOnly, model.StateWriteOnly:
+		default:
+			return nil
+		}
+	}
+
+	baseTblInfo, err := t.GetTable(job.SchemaID, mlogTblInfo.MaterializedViewLog.BaseTableID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if baseTblInfo == nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			"ALTER MATERIALIZED VIEW LOG with invalid base table metadata",
+		)
+	}
+	baseCol := model.FindColumnInfo(baseTblInfo.Columns, colFromArgs.Name.L)
+	if baseCol == nil || baseCol.State != model.StatePublic {
+		return infoschema.ErrColumnNotExists.GenWithStackByArgs(colFromArgs.Name, baseTblInfo.Name)
+	}
+
+	ft := *baseCol.FieldType.Clone()
+	ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
+	colFromArgs.FieldType = ft
+	return nil
+}
+
+func setMLogAddedColumnOriginDefault(colInfo *model.ColumnInfo) error {
+	if colInfo == nil {
+		return nil
+	}
+	if !mysql.HasNotNullFlag(colInfo.GetFlag()) {
+		return nil
+	}
+
+	if useSingleSpaceDefaultForMLogStringColumn(colInfo) {
+		return colInfo.SetOriginDefaultValue(" ")
+	}
+	if colInfo.GetOriginDefaultValue() != nil {
+		return nil
+	}
+	originDefault, err := generateOriginDefaultValue(colInfo, nil, true)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return colInfo.SetOriginDefaultValue(originDefault)
+}
+
+func useSingleSpaceDefaultForMLogStringColumn(colInfo *model.ColumnInfo) bool {
+	if colInfo.GetCharset() == charset.CharsetBin {
+		return false
+	}
+	switch colInfo.GetType() {
+	case mysql.TypeString, mysql.TypeVarchar, mysql.TypeVarString,
+		mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
+		return true
+	default:
+		return false
+	}
+}
+
+func syncMLogColumnsAfterAddColumn(tblInfo *model.TableInfo) {
+	if tblInfo == nil || tblInfo.MaterializedViewLog == nil {
+		return
+	}
+	trackedCols := make([]pmodel.CIStr, 0, len(tblInfo.Columns))
+	for _, col := range tblInfo.Columns {
+		if col.State != model.StatePublic || isMLogMetaColumnName(col.Name.L) {
+			continue
+		}
+		trackedCols = append(trackedCols, col.Name)
+	}
+	tblInfo.MaterializedViewLog.Columns = trackedCols
+}
+
+func isMLogMetaColumnName(name string) bool {
+	return name == strings.ToLower(model.MaterializedViewLogDMLTypeColumnName) ||
+		name == strings.ToLower(model.MaterializedViewLogOldNewColumnName)
 }
 
 func checkAndCreateNewColumn(ctx sessionctx.Context, ti ast.Ident, schema *model.DBInfo, spec *ast.AlterTableSpec, t table.Table, specNewColumn *ast.ColumnDef) (*table.Column, error) {

--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -253,6 +253,12 @@ func checkDropColumn(jobCtx *jobContext, job *model.Job) (*model.TableInfo, *mod
 		job.State = model.JobStateCancelled
 		return nil, nil, nil, ifExists, dbterror.ErrCantDropFieldOrKey.GenWithStack("column %s doesn't exist", colName)
 	}
+	if colInfo.State == model.StatePublic {
+		if err = checkDropColumnWithMLogBaseConstraint(jobCtx.metaMut, job.SchemaID, tblInfo, colName); err != nil {
+			job.State = model.JobStateCancelled
+			return nil, nil, nil, false, errors.Trace(err)
+		}
+	}
 	if err = isDroppableColumn(tblInfo, colName); err != nil {
 		job.State = model.JobStateCancelled
 		return nil, nil, nil, false, errors.Trace(err)
@@ -265,6 +271,32 @@ func checkDropColumn(jobCtx *jobContext, job *model.Job) (*model.TableInfo, *mod
 	}
 	idxInfos := listIndicesWithColumn(colName.L, tblInfo.Indices)
 	return tblInfo, colInfo, idxInfos, false, nil
+}
+
+func checkDropColumnWithMLogBaseConstraint(
+	t *meta.Mutator,
+	schemaID int64,
+	tblInfo *model.TableInfo,
+	colName pmodel.CIStr,
+) error {
+	if tblInfo.MaterializedViewBase == nil || tblInfo.MaterializedViewBase.MLogID == 0 {
+		return nil
+	}
+
+	mlogTblInfo, err := t.GetTable(schemaID, tblInfo.MaterializedViewBase.MLogID)
+	if err != nil || mlogTblInfo == nil || mlogTblInfo.MaterializedViewLog == nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			"ALTER TABLE on base table with invalid materialized view log metadata",
+		)
+	}
+	for _, mlogCol := range mlogTblInfo.MaterializedViewLog.Columns {
+		if mlogCol.L == colName.L {
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				fmt.Sprintf("ALTER TABLE on base table column %s referenced by materialized view log", colName.L),
+			)
+		}
+	}
+	return nil
 }
 
 func isDroppableColumn(tblInfo *model.TableInfo, colName pmodel.CIStr) error {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -2444,6 +2444,9 @@ func (e *executor) multiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info 
 	}
 
 	var involvingSchemaInfo []model.InvolvingSchemaInfo
+	if mlogInvolving := buildMaterializedViewLogBaseInvolvingSchemaInfo(e.ctx, e.infoCache.GetLatest(), schema.Name.L, t.Meta()); len(mlogInvolving) > 0 {
+		involvingSchemaInfo = append(involvingSchemaInfo, mlogInvolving...)
+	}
 	for _, j := range subJobs {
 		if j.Type == model.ActionAddForeignKey {
 			ref := j.JobArgs.(*model.AddForeignKeyArgs).FkInfo
@@ -2664,6 +2667,9 @@ func (e *executor) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.Alt
 		BinlogInfo:     &model.HistoryInfo{},
 		CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
 		SQLMode:        ctx.GetSessionVars().SQLMode,
+	}
+	if involving := buildMaterializedViewLogInvolvingSchemaInfo(e.ctx, e.infoCache.GetLatest(), schema.Name.L, tbInfo); len(involving) > 0 {
+		job.InvolvingSchemaInfo = involving
 	}
 
 	args := &model.TableColumnArgs{

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1918,7 +1918,7 @@ func isAlterTableOnlyIndexOperations(specs []*ast.AlterTableSpec) bool {
 	}
 	for _, spec := range specs {
 		switch spec.Tp {
-		case ast.AlterTableDropIndex, ast.AlterTableRenameIndex, ast.AlterTableIndexInvisible:
+		case ast.AlterTableDropIndex, ast.AlterTableDropPrimaryKey, ast.AlterTableRenameIndex, ast.AlterTableIndexInvisible:
 		case ast.AlterTableAddConstraint:
 			if spec.Constraint == nil {
 				return false

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1893,6 +1893,25 @@ func isAlterTiFlashReplica(specs []*ast.AlterTableSpec) bool {
 	return len(specs) == 1 && specs[0].Tp == ast.AlterTableSetTiFlashReplica
 }
 
+func isAlterTableOnlyExchangePartition(specs []*ast.AlterTableSpec) bool {
+	return len(specs) == 1 && specs[0].Tp == ast.AlterTableExchangePartition
+}
+
+func isAlterTableOnlyAddColumnsAtEnd(specs []*ast.AlterTableSpec) bool {
+	if len(specs) == 0 {
+		return false
+	}
+	for _, spec := range specs {
+		if spec.Tp != ast.AlterTableAddColumns {
+			return false
+		}
+		if spec.Position != nil && spec.Position.Tp != ast.ColumnPositionNone {
+			return false
+		}
+	}
+	return true
+}
+
 func isAlterTableOnlyIndexOperations(specs []*ast.AlterTableSpec) bool {
 	if len(specs) == 0 {
 		return false
@@ -1914,6 +1933,31 @@ func isAlterTableOnlyIndexOperations(specs []*ast.AlterTableSpec) bool {
 		}
 	}
 	return true
+}
+
+func checkAlterTableOnlyNonRenamingModifyOrChangeColumns(specs []*ast.AlterTableSpec, op string) error {
+	if len(specs) == 0 {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf("%s on base table with materialized view dependencies only supports no-reorg compatible type changes", op),
+		)
+	}
+	for _, spec := range specs {
+		switch spec.Tp {
+		case ast.AlterTableModifyColumn:
+		case ast.AlterTableChangeColumn:
+			if len(spec.NewColumns) != 1 || spec.OldColumnName == nil || spec.NewColumns[0] == nil ||
+				spec.NewColumns[0].Name == nil || spec.OldColumnName.Name.L != spec.NewColumns[0].Name.Name.L {
+				return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+					"CHANGE COLUMN on base table with materialized view dependencies does not support renaming",
+				)
+			}
+		default:
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				fmt.Sprintf("%s on base table with materialized view dependencies only supports no-reorg compatible type changes", op),
+			)
+		}
+	}
+	return nil
 }
 
 func collectAlterTableSpecAffectedColumns(spec *ast.AlterTableSpec) []string {
@@ -1976,6 +2020,11 @@ func checkAlterTableBaseTableMLogColumnConstraints(
 				fmt.Sprintf("%s on base table columns referenced by materialized view log", op),
 			)
 		}
+		// Tracked MLog columns may be modified via MODIFY/CHANGE COLUMN; detailed validation and
+		// related table schema updates are handled in GetModifiableColumnJob.
+		if spec.Tp == ast.AlterTableModifyColumn || spec.Tp == ast.AlterTableChangeColumn {
+			continue
+		}
 		for _, colName := range collectAlterTableSpecAffectedColumns(spec) {
 			if _, ok := mlogCols[colName]; !ok {
 				continue
@@ -2014,6 +2063,11 @@ func checkAlterTableMaterializedViewConstraints(
 	specs []*ast.AlterTableSpec,
 	op string,
 ) error {
+	if isAlterTableOnlyExchangePartition(specs) {
+		// EXCHANGE PARTITION needs both table roles for precise materialized-view checks.
+		return nil
+	}
+
 	if tblInfo.MaterializedViewLog != nil {
 		// MATERIALIZED VIEW LOG table only allows ALTER TABLE ... SET TIFLASH REPLICA for now.
 		if isAlterTiFlashReplica(specs) {
@@ -2032,6 +2086,18 @@ func checkAlterTableMaterializedViewConstraints(
 
 	if err := checkProtectedMaterializedViewShadowConstraint(sv, tblInfo, op); err != nil {
 		return err
+	}
+
+	// Base table with dependent MV:
+	// allow safe ADD COLUMN at end, index operations, and TiFlash replica.
+	// For MODIFY/CHANGE COLUMN, detailed MV/MLog validation (including no-reorg compatibility) is done in GetModifiableColumnJob.
+	if tblInfo.MaterializedViewBase != nil && len(tblInfo.MaterializedViewBase.MViewIDs) > 0 {
+		if isAlterTiFlashReplica(specs) || isAlterTableOnlyIndexOperations(specs) || isAlterTableOnlyAddColumnsAtEnd(specs) {
+			return nil
+		}
+		if err := checkAlterTableOnlyNonRenamingModifyOrChangeColumns(specs, op); err != nil {
+			return err
+		}
 	}
 
 	return checkAlterTableBaseTableMLogColumnConstraints(ctx, is, tblInfo, specs, op)
@@ -2443,14 +2509,14 @@ func (e *executor) multiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info 
 		return errors.Trace(err)
 	}
 
-	var involvingSchemaInfo []model.InvolvingSchemaInfo
+	involvingSchemaInfo := appendInvolvingSchemaInfo(nil, info.InvolvingSchemaInfo...)
 	if mlogInvolving := buildMaterializedViewLogBaseInvolvingSchemaInfo(e.ctx, e.infoCache.GetLatest(), schema.Name.L, t.Meta()); len(mlogInvolving) > 0 {
-		involvingSchemaInfo = append(involvingSchemaInfo, mlogInvolving...)
+		involvingSchemaInfo = appendInvolvingSchemaInfo(involvingSchemaInfo, mlogInvolving...)
 	}
 	for _, j := range subJobs {
 		if j.Type == model.ActionAddForeignKey {
 			ref := j.JobArgs.(*model.AddForeignKeyArgs).FkInfo
-			involvingSchemaInfo = append(involvingSchemaInfo, model.InvolvingSchemaInfo{
+			involvingSchemaInfo = appendInvolvingSchemaInfo(involvingSchemaInfo, model.InvolvingSchemaInfo{
 				Database: ref.RefSchema.L,
 				Table:    ref.RefTable.L,
 				Mode:     model.SharedInvolving,
@@ -2459,7 +2525,7 @@ func (e *executor) multiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info 
 	}
 
 	if len(involvingSchemaInfo) > 0 {
-		involvingSchemaInfo = append(involvingSchemaInfo, model.InvolvingSchemaInfo{
+		involvingSchemaInfo = appendInvolvingSchemaInfo(involvingSchemaInfo, model.InvolvingSchemaInfo{
 			Database: schema.Name.L,
 			Table:    t.Meta().Name.L,
 		})
@@ -4868,6 +4934,9 @@ func checkTableMaterializedViewConstraintsWithOptions(
 	op string,
 	allowMVTable bool,
 ) error {
+	if tblInfo.MaterializedViewLog != nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on materialized view log table", op))
+	}
 	if !allowMVTable && tblInfo.MaterializedView != nil {
 		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on materialized view table", op))
 	}
@@ -4877,6 +4946,10 @@ func checkTableMaterializedViewConstraintsWithOptions(
 	if tblInfo.MaterializedViewBase != nil &&
 		len(tblInfo.MaterializedViewBase.MViewIDs) > 0 {
 		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on base table with materialized view dependencies", op))
+	}
+	if tblInfo.MaterializedViewBase != nil &&
+		tblInfo.MaterializedViewBase.MLogID != 0 {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on base table with materialized view log", op))
 	}
 	return nil
 }
@@ -5314,6 +5387,9 @@ func (e *executor) createVectorIndex(ctx sessionctx.Context, ti ast.Ident, index
 	}
 
 	tblInfo := t.Meta()
+	if err := checkIndexOperationMaterializedViewConstraints(ctx.GetSessionVars(), tblInfo, "CREATE INDEX"); err != nil {
+		return errors.Trace(err)
+	}
 	if err := checkTableTypeForVectorIndex(tblInfo); err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -574,20 +574,53 @@ func (e *executor) AlterMaterializedViewLog(ctx sessionctx.Context, s *ast.Alter
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName.O, mlogName, "MATERIALIZED VIEW LOG")
 	}
 
-	// TODO: split ALTER MATERIALIZED VIEW LOG into per-action handlers and
-	// dedicated DDL job args when schema-changing actions (for example column
-	// add/drop) are supported.
+	addColumnActionCount := 0
+	for _, action := range s.Actions {
+		if action.Tp == ast.AlterMaterializedViewLogActionAddColumn {
+			addColumnActionCount++
+		}
+	}
+	if addColumnActionCount > 1 {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("ALTER MATERIALIZED VIEW LOG with multiple ADD COLUMN actions")
+	}
+
+	baseColMap := make(map[string]*model.ColumnInfo, len(baseTable.Meta().Columns))
+	for _, col := range baseTable.Meta().Columns {
+		if col.State != model.StatePublic {
+			continue
+		}
+		baseColMap[col.Name.L] = col
+	}
+	mlogColSet := make(map[string]struct{}, len(mlogTable.Meta().Columns)+len(s.Actions))
+	for _, col := range mlogTable.Meta().Columns {
+		mlogColSet[col.Name.L] = struct{}{}
+	}
 	for _, action := range s.Actions {
 		switch action.Tp {
 		case ast.AlterMaterializedViewLogActionPurge:
 			if _, _, _, err := buildMLogPurgeMeta(ctx, action.Purge); err != nil {
 				return err
 			}
+		case ast.AlterMaterializedViewLogActionAddColumn:
+			for _, col := range action.Cols {
+				if _, exists := mlogColSet[col.L]; exists {
+					return infoschema.ErrColumnExists.GenWithStackByArgs(col.O)
+				}
+				if baseColMap[col.L] == nil {
+					return infoschema.ErrColumnNotExists.GenWithStackByArgs(col.O, s.Table.Name.O)
+				}
+				mlogColSet[col.L] = struct{}{}
+			}
 		default:
 			return errors.Errorf("unknown alter materialized view log action type: %d", action.Tp)
 		}
 	}
 
+	lastTrackedCol := pmodel.CIStr{}
+	mlogInfo := mlogTable.Meta().MaterializedViewLog
+	if len(mlogInfo.Columns) > 0 {
+		lastTrackedCol = mlogInfo.Columns[len(mlogInfo.Columns)-1]
+	}
 	for _, action := range s.Actions {
 		switch action.Tp {
 		case ast.AlterMaterializedViewLogActionPurge:
@@ -601,11 +634,117 @@ func (e *executor) AlterMaterializedViewLog(ctx sessionctx.Context, s *ast.Alter
 			); err != nil {
 				return err
 			}
+		case ast.AlterMaterializedViewLogActionAddColumn:
+			baseCols := make([]*model.ColumnInfo, 0, len(action.Cols))
+			for _, col := range action.Cols {
+				baseCols = append(baseCols, baseColMap[col.L])
+			}
+			if err := e.addMaterializedViewLogColumns(ctx, schemaName, mlogName, baseCols, lastTrackedCol); err != nil {
+				return err
+			}
+			if len(action.Cols) > 0 {
+				lastTrackedCol = action.Cols[len(action.Cols)-1]
+			}
 		default:
 			return errors.Errorf("unknown alter materialized view log action type: %d", action.Tp)
 		}
 	}
 	return nil
+}
+
+func (e *executor) addMaterializedViewLogColumns(
+	ctx sessionctx.Context,
+	schemaName pmodel.CIStr,
+	mlogName pmodel.CIStr,
+	baseCols []*model.ColumnInfo,
+	afterCol pmodel.CIStr,
+) error {
+	if len(baseCols) == 0 {
+		return nil
+	}
+	if len(baseCols) == 1 {
+		return e.addMaterializedViewLogColumn(ctx, schemaName, mlogName, baseCols[0], afterCol)
+	}
+
+	stmtCtx := ctx.GetSessionVars().StmtCtx
+	originalMultiSchemaInfo := stmtCtx.MultiSchemaInfo
+	stmtCtx.MultiSchemaInfo = model.NewMultiSchemaInfo()
+	defer func() {
+		stmtCtx.MultiSchemaInfo = originalMultiSchemaInfo
+	}()
+
+	// Each sub-job inserts after the same existing tracked column. Submit them in
+	// reverse so the final public column order matches the ADD COLUMN list.
+	for i := len(baseCols) - 1; i >= 0; i-- {
+		if err := e.addMaterializedViewLogColumn(ctx, schemaName, mlogName, baseCols[i], afterCol); err != nil {
+			return err
+		}
+	}
+
+	info := stmtCtx.MultiSchemaInfo
+	stmtCtx.MultiSchemaInfo = originalMultiSchemaInfo
+	return e.multiSchemaChange(ctx, ast.Ident{Schema: schemaName, Name: mlogName}, info)
+}
+
+func (e *executor) addMaterializedViewLogColumn(
+	ctx sessionctx.Context,
+	schemaName pmodel.CIStr,
+	mlogName pmodel.CIStr,
+	baseCol *model.ColumnInfo,
+	afterCol pmodel.CIStr,
+) error {
+	ft := *baseCol.FieldType.Clone()
+	ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
+	spec := &ast.AlterTableSpec{
+		Tp: ast.AlterTableAddColumns,
+		NewColumns: []*ast.ColumnDef{{
+			Name: &ast.ColumnName{Name: baseCol.Name},
+			Tp:   &ft,
+		}},
+		Position: &ast.ColumnPosition{Tp: ast.ColumnPositionFirst},
+	}
+	if afterCol.L != "" {
+		spec.Position = &ast.ColumnPosition{
+			Tp:             ast.ColumnPositionAfter,
+			RelativeColumn: &ast.ColumnName{Name: afterCol},
+		}
+	}
+	return e.AddColumn(ctx, ast.Ident{Schema: schemaName, Name: mlogName}, spec)
+}
+
+func buildMaterializedViewLogInvolvingSchemaInfo(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	schemaName string,
+	mlogInfo *model.TableInfo,
+) []model.InvolvingSchemaInfo {
+	if mlogInfo == nil || mlogInfo.MaterializedViewLog == nil {
+		return nil
+	}
+	involving := []model.InvolvingSchemaInfo{{
+		Database: schemaName,
+		Table:    mlogInfo.Name.L,
+	}}
+	return append(involving, buildMaterializedViewLogBaseInvolvingSchemaInfo(ctx, is, schemaName, mlogInfo)...)
+}
+
+func buildMaterializedViewLogBaseInvolvingSchemaInfo(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	schemaName string,
+	mlogInfo *model.TableInfo,
+) []model.InvolvingSchemaInfo {
+	if is == nil || mlogInfo == nil || mlogInfo.MaterializedViewLog == nil {
+		return nil
+	}
+	baseTable, ok := is.TableByID(ctx, mlogInfo.MaterializedViewLog.BaseTableID)
+	if !ok {
+		return nil
+	}
+	return []model.InvolvingSchemaInfo{{
+		Database: schemaName,
+		Table:    baseTable.Meta().Name.L,
+	}}
 }
 
 func (e *executor) alterMaterializedViewLogPurge(

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/format"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	parser_types "github.com/pingcap/tidb/pkg/parser/types"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
@@ -516,7 +517,15 @@ func finishModifyColumnWithoutReorg(
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
-	ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true, childTableInfos...)
+
+	mvRelatedInfos, err := buildMaterializedViewRelatedTableInfoForModifyColumn(jobCtx, tblInfo, oldCol, newCol)
+	if err != nil {
+		job.State = model.JobStateRollingback
+		return ver, errors.Trace(err)
+	}
+	multiInfos := append(childTableInfos, mvRelatedInfos...)
+
+	ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true, multiInfos...)
 	if err != nil {
 		// Modified the type definition of 'null' to 'not null' before this, so rollBack the job when an error occurs.
 		job.State = model.JobStateRollingback
@@ -527,6 +536,197 @@ func finishModifyColumnWithoutReorg(
 	// For those column-type-change type which doesn't need reorg data, we should also mock the job args for delete range.
 	job.FillFinishedArgs(&model.ModifyColumnArgs{})
 	return ver, nil
+}
+
+func buildMaterializedViewRelatedTableInfoForModifyColumn(
+	jobCtx *jobContext,
+	baseTblInfo *model.TableInfo,
+	oldCol *model.ColumnInfo,
+	newCol *model.ColumnInfo,
+) ([]schemaIDAndTableInfo, error) {
+	baseInfo := baseTblInfo.MaterializedViewBase
+	if baseInfo == nil {
+		return nil, nil
+	}
+
+	is := jobCtx.infoCache.GetLatest()
+	var relatedInfos []schemaIDAndTableInfo
+
+	// Materialized view log.
+	if baseInfo.MLogID != 0 {
+		mlogInfoFromIS, ok := is.TableInfoByID(baseInfo.MLogID)
+		if !ok {
+			return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: materialized view log table not found")
+		}
+		mlogDB, ok := infoschema.SchemaByTable(is, mlogInfoFromIS)
+		if !ok {
+			return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: materialized view log schema not found")
+		}
+		// baseInfo only stores the MLog table ID. Resolve its schema ID from InfoSchema,
+		// then load the mutable TableInfo from meta so the metadata change can be persisted.
+		mlogTblInfo, err := getTableInfo(jobCtx.metaMut, baseInfo.MLogID, mlogDB.ID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if err := validateMaterializedViewLogInfoForModifyColumn(baseTblInfo, mlogTblInfo); err != nil {
+			return nil, err
+		}
+		mlogCol, columnIsTracked, err := trackedMaterializedViewLogColumnForModifyColumn(mlogTblInfo, oldCol.Name.L)
+		if err != nil {
+			return nil, err
+		}
+		if columnIsTracked {
+			newFieldType, err := validateMaterializedViewLogColumnTypeForModifyColumn("MODIFY COLUMN", mlogTblInfo, mlogCol, newCol)
+			if err != nil {
+				return nil, err
+			}
+			mlogCol.FieldType = newFieldType
+			relatedInfos = append(relatedInfos, schemaIDAndTableInfo{schemaID: mlogDB.ID, tblInfo: mlogTblInfo})
+		}
+	}
+
+	// Dependent materialized views.
+	if len(baseInfo.MViewIDs) == 0 {
+		return relatedInfos, nil
+	}
+	for _, mvID := range baseInfo.MViewIDs {
+		mvInfoFromIS, ok := is.TableInfoByID(mvID)
+		if !ok {
+			return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: dependent materialized view table not found")
+		}
+		mvDB, ok := infoschema.SchemaByTable(is, mvInfoFromIS)
+		if !ok {
+			return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: dependent materialized view schema not found")
+		}
+		mvTblInfo, err := getTableInfo(jobCtx.metaMut, mvID, mvDB.ID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		usage, err := validateDependentMaterializedViewModifyColumn("MODIFY COLUMN", baseTblInfo, mvTblInfo, oldCol, newCol)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(usage.directOutputOffsets) == 0 {
+			continue
+		}
+
+		changed := false
+		for _, off := range usage.directOutputOffsets {
+			mvOldCol := mvTblInfo.Columns[off]
+			mvOldCol.FieldType = fieldTypeForMVRelatedColumn(mvOldCol, newCol)
+			changed = true
+		}
+		if changed {
+			relatedInfos = append(relatedInfos, schemaIDAndTableInfo{schemaID: mvDB.ID, tblInfo: mvTblInfo})
+		}
+	}
+	return relatedInfos, nil
+}
+
+func validateMaterializedViewLogInfoForModifyColumn(baseTblInfo, mlogTblInfo *model.TableInfo) error {
+	if mlogTblInfo.MaterializedViewLog == nil || mlogTblInfo.MaterializedViewLog.BaseTableID != baseTblInfo.ID {
+		return dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: invalid materialized view log metadata")
+	}
+	return nil
+}
+
+func trackedMaterializedViewLogColumnForModifyColumn(
+	mlogTblInfo *model.TableInfo,
+	colNameL string,
+) (*model.ColumnInfo, bool, error) {
+	columnIsTracked := false
+	for _, c := range mlogTblInfo.MaterializedViewLog.Columns {
+		if c.L == colNameL {
+			columnIsTracked = true
+			break
+		}
+	}
+	if !columnIsTracked {
+		return nil, false, nil
+	}
+
+	mlogCol := model.FindColumnInfo(mlogTblInfo.Columns, colNameL)
+	if mlogCol == nil {
+		return nil, true, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: materialized view log column not found")
+	}
+	return mlogCol, true, nil
+}
+
+func validateMaterializedViewLogColumnTypeForModifyColumn(
+	op string,
+	mlogTblInfo *model.TableInfo,
+	mlogCol *model.ColumnInfo,
+	newCol *model.ColumnInfo,
+) (parser_types.FieldType, error) {
+	newFieldType := fieldTypeForMVRelatedColumn(mlogCol, newCol)
+	mlogNewCol := mlogCol.Clone()
+	mlogNewCol.FieldType = newFieldType
+	if !noReorgDataStrict(mlogTblInfo, mlogCol, mlogNewCol) {
+		return newFieldType, dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf("%s on base table with materialized view log only supports no-reorg compatible type changes", op),
+		)
+	}
+	return newFieldType, nil
+}
+
+func validateDependentMaterializedViewModifyColumn(
+	op string,
+	baseTblInfo *model.TableInfo,
+	mvTblInfo *model.TableInfo,
+	oldCol *model.ColumnInfo,
+	newCol *model.ColumnInfo,
+) (*mvColumnUsage, error) {
+	if mvTblInfo.MaterializedView == nil || len(mvTblInfo.MaterializedView.SQLContent) == 0 {
+		return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: invalid materialized view metadata")
+	}
+	if len(mvTblInfo.MaterializedView.BaseTableIDs) != 1 || mvTblInfo.MaterializedView.BaseTableIDs[0] != baseTblInfo.ID {
+		return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: dependent materialized view base table mismatch")
+	}
+
+	mvSel, err := parseSelectFromSQL(mvTblInfo.MaterializedView.SQLContent)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	usage, err := analyzeMVColumnUsage(mvSel, oldCol.Name.L)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if usage.unsupportedReason != "" {
+		return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf("%s on base table with materialized view dependencies does not support modifying columns used in %s", op, usage.unsupportedReason),
+		)
+	}
+	if len(usage.directOutputOffsets) == 0 {
+		if usage.isGroupKey {
+			return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				fmt.Sprintf("%s on base table with materialized view dependencies does not support modifying columns used only as group keys", op),
+			)
+		}
+		return usage, nil
+	}
+	if mvSel.Fields == nil || len(mvTblInfo.Columns) != len(mvSel.Fields.Fields) {
+		return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: materialized view output schema mismatch")
+	}
+
+	if usage.isGroupKey && (oldCol.FieldType.GetCharset() != newCol.FieldType.GetCharset() ||
+		oldCol.FieldType.GetCollate() != newCol.FieldType.GetCollate() ||
+		mysql.HasNotNullFlag(oldCol.GetFlag()) != mysql.HasNotNullFlag(newCol.GetFlag())) {
+		return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf("%s on base table with materialized view dependencies does not support changing charset/collation/nullability of group keys", op),
+		)
+	}
+
+	for _, off := range usage.directOutputOffsets {
+		mvOldCol := mvTblInfo.Columns[off]
+		mvNewCol := mvOldCol.Clone()
+		mvNewCol.FieldType = fieldTypeForMVRelatedColumn(mvOldCol, newCol)
+		if !noReorgDataStrict(mvTblInfo, mvOldCol, mvNewCol) {
+			return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				fmt.Sprintf("%s on base table with materialized view dependencies only supports no-reorg compatible type changes for direct output columns", op),
+			)
+		}
+	}
+	return usage, nil
 }
 
 // doModifyColumnNoCheck updates the column information and reorders all columns. It does not support modifying column data.
@@ -1586,6 +1786,9 @@ func GetModifiableColumnJob(
 		return nil, errors.Trace(err)
 	}
 	mayNeedChangeColData := !noReorgDataStrict(t.Meta(), col.ColumnInfo, newCol.ColumnInfo)
+	if err := validateMaterializedViewBaseModifyColumn(ctx, is, t, col.ColumnInfo, newCol.ColumnInfo, spec, mayNeedChangeColData); err != nil {
+		return nil, errors.Trace(err)
+	}
 	if mayNeedChangeColData {
 		if err = isGeneratedRelatedColumn(t.Meta(), newCol.ColumnInfo, col.ColumnInfo); err != nil {
 			return nil, errors.Trace(err)
@@ -1765,6 +1968,9 @@ func GetModifiableColumnJob(
 		SQLMode:        sctx.GetSessionVars().SQLMode,
 		SessionVars:    make(map[string]string),
 	}
+	if involving := buildInvolvingSchemaInfoForMaterializedViewBaseModifyColumn(is, schema, t.Meta()); len(involving) > 0 {
+		job.InvolvingSchemaInfo = involving
+	}
 	err = initJobReorgMetaFromVariables(job, sctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1777,6 +1983,334 @@ func GetModifiableColumnJob(
 		NewShardBits:  newAutoRandBits,
 	}
 	return NewJobWrapperWithArgs(job, args, false), nil
+}
+
+func buildInvolvingSchemaInfoForMaterializedViewBaseModifyColumn(
+	is infoschema.InfoSchema,
+	schema *model.DBInfo,
+	baseTblInfo *model.TableInfo,
+) []model.InvolvingSchemaInfo {
+	if is == nil || baseTblInfo == nil || schema == nil {
+		return nil
+	}
+	baseInfo := baseTblInfo.MaterializedViewBase
+	if baseInfo == nil || (baseInfo.MLogID == 0 && len(baseInfo.MViewIDs) == 0) {
+		return nil
+	}
+
+	involving := make([]model.InvolvingSchemaInfo, 0, 2+len(baseInfo.MViewIDs))
+	seen := make(map[string]struct{}, 2+len(baseInfo.MViewIDs))
+	addTable := func(dbName, tableName string) {
+		if dbName == "" || tableName == "" {
+			return
+		}
+		key := dbName + "\x00" + tableName
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		involving = append(involving, model.InvolvingSchemaInfo{Database: dbName, Table: tableName})
+	}
+
+	addTable(schema.Name.L, baseTblInfo.Name.L)
+
+	if baseInfo.MLogID != 0 {
+		mlogMeta, ok := is.TableInfoByID(baseInfo.MLogID)
+		if ok {
+			mlogDB, ok := infoschema.SchemaByTable(is, mlogMeta)
+			if ok {
+				addTable(mlogDB.Name.L, mlogMeta.Name.L)
+			}
+		}
+	}
+
+	for _, mvID := range baseInfo.MViewIDs {
+		if mvID == 0 {
+			continue
+		}
+		mvMeta, ok := is.TableInfoByID(mvID)
+		if !ok {
+			continue
+		}
+		mvDB, ok := infoschema.SchemaByTable(is, mvMeta)
+		if !ok {
+			continue
+		}
+		addTable(mvDB.Name.L, mvMeta.Name.L)
+	}
+	return involving
+}
+
+func validateMaterializedViewBaseModifyColumn(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	baseTbl table.Table,
+	oldCol *model.ColumnInfo,
+	newCol *model.ColumnInfo,
+	spec *ast.AlterTableSpec,
+	mayNeedChangeColData bool,
+) error {
+	// schematracker calls ddl.GetModifiableColumnJob with is == nil in some paths.
+	// MV/MLog validation relies on looking up related table infos from InfoSchema.
+	if is == nil {
+		return nil
+	}
+
+	baseInfo := baseTbl.Meta().MaterializedViewBase
+	if baseInfo == nil {
+		return nil
+	}
+
+	hasDependentMV := len(baseInfo.MViewIDs) > 0
+	hasMLog := baseInfo.MLogID != 0
+	if !hasDependentMV && !hasMLog {
+		return nil
+	}
+
+	op := "ALTER TABLE"
+	switch spec.Tp {
+	case ast.AlterTableModifyColumn:
+		op = "MODIFY COLUMN"
+	case ast.AlterTableChangeColumn:
+		op = "CHANGE COLUMN"
+	}
+
+	var mlogTblInfo *model.TableInfo
+	var mlogCol *model.ColumnInfo
+	var err error
+	columnIsTrackedByMLog := false
+	if hasMLog {
+		mlogTbl, ok := is.TableByID(ctx, baseInfo.MLogID)
+		if !ok {
+			return dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: materialized view log table not found")
+		}
+		mlogTblInfo = mlogTbl.Meta()
+		if err := validateMaterializedViewLogInfoForModifyColumn(baseTbl.Meta(), mlogTblInfo); err != nil {
+			return err
+		}
+		mlogCol, columnIsTrackedByMLog, err = trackedMaterializedViewLogColumnForModifyColumn(mlogTblInfo, oldCol.Name.L)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Column rename is not supported for MV-related base tables, and for tracked MLog columns.
+	// Keep existing behavior for untracked columns on MLog-only base tables.
+	if oldCol.Name.L != newCol.Name.L {
+		if hasDependentMV {
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				"CHANGE COLUMN on base table with materialized view dependencies does not support renaming",
+			)
+		}
+		if columnIsTrackedByMLog {
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				"CHANGE COLUMN on base table with materialized view log does not support renaming tracked columns",
+			)
+		}
+		return nil
+	}
+
+	// NULL -> NOT NULL on tracked MLog columns is unsafe because historical rows already stored in the
+	// materialized view log can still contain NULL values (for example, old row images of UPDATE).
+	// Changing the log column metadata to NOT NULL would break SQL NULL semantics on those existing rows.
+	if columnIsTrackedByMLog && isNullToNotNullChange(oldCol, newCol) {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+			fmt.Sprintf("%s on base table with materialized view log does not support changing tracked columns from NULL to NOT NULL", op),
+		)
+	}
+
+	// Base table with dependent MV: only allow no-reorg compatible type changes.
+	// Base table with only MLog: keep existing behavior for untracked columns; tracked columns require no-reorg in phase 1.
+	if mayNeedChangeColData {
+		if hasDependentMV {
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				fmt.Sprintf("%s on base table with materialized view dependencies only supports no-reorg compatible type changes", op),
+			)
+		}
+		if columnIsTrackedByMLog {
+			return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(
+				fmt.Sprintf("%s on base table with materialized view log only supports no-reorg compatible type changes for tracked columns", op),
+			)
+		}
+		return nil
+	}
+
+	// MLog tracked column: validate the MLog physical column can also be updated in a no-reorg compatible way.
+	if columnIsTrackedByMLog {
+		if _, err := validateMaterializedViewLogColumnTypeForModifyColumn(op, mlogTblInfo, mlogCol, newCol); err != nil {
+			return err
+		}
+	}
+
+	// No dependent MV: done.
+	if !hasDependentMV {
+		return nil
+	}
+
+	// Dependent MV: validate each dependent MV SQL can tolerate the base column metadata change.
+	for _, mvID := range baseInfo.MViewIDs {
+		mvTbl, ok := is.TableByID(ctx, mvID)
+		if !ok {
+			return dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: dependent materialized view table not found")
+		}
+		mvTblInfo := mvTbl.Meta()
+		if _, err := validateDependentMaterializedViewModifyColumn(op, baseTbl.Meta(), mvTblInfo, oldCol, newCol); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+type mvColumnUsage struct {
+	directOutputOffsets []int
+	isGroupKey          bool
+	unsupportedReason   string
+}
+
+func fieldTypeForMVRelatedColumn(oldRelatedCol *model.ColumnInfo, baseNewCol *model.ColumnInfo) parser_types.FieldType {
+	newFieldType := baseNewCol.FieldType
+	// Preserve key-related flags on the related table column, but still apply the base column's type attributes.
+	keyFlags := oldRelatedCol.FieldType.GetFlag() & (mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag)
+	newFieldType.DelFlag(
+		mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag |
+			mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag | mysql.PreventNullInsertFlag | mysql.GeneratedColumnFlag,
+	)
+	newFieldType.AddFlag(keyFlags)
+	return newFieldType
+}
+
+func parseSelectFromSQL(sql string) (*ast.SelectStmt, error) {
+	stmts, _, err := parser.New().ParseSQL(sql)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(stmts) != 1 {
+		return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: invalid materialized view select sql")
+	}
+	sel, ok := stmts[0].(*ast.SelectStmt)
+	if !ok {
+		return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("modify column: materialized view definition is not a SELECT statement")
+	}
+	return sel, nil
+}
+
+func analyzeMVColumnUsage(sel *ast.SelectStmt, colNameL string) (*mvColumnUsage, error) {
+	usage := &mvColumnUsage{}
+	if sel == nil || sel.Fields == nil {
+		return usage, nil
+	}
+	directOutputSet := make(map[int]struct{})
+	aliasToOffset := make(map[string]int)
+	// SELECT list: only allow direct column reference as the root expression.
+	for i, f := range sel.Fields.Fields {
+		if f == nil {
+			continue
+		}
+		if f.AsName.L != "" {
+			if _, ok := aliasToOffset[f.AsName.L]; !ok {
+				aliasToOffset[f.AsName.L] = i
+			}
+		}
+		if f.WildCard != nil {
+			usage.unsupportedReason = "SELECT *"
+			return usage, nil
+		}
+		if f.Expr == nil {
+			continue
+		}
+		if colExpr, ok := f.Expr.(*ast.ColumnNameExpr); ok && colExpr.Name != nil && colExpr.Name.Name.L == colNameL {
+			usage.directOutputOffsets = append(usage.directOutputOffsets, i)
+			directOutputSet[i] = struct{}{}
+			continue
+		}
+		if exprContainsColumnRef(f.Expr, colNameL) {
+			usage.unsupportedReason = "non-direct SELECT expressions"
+			return usage, nil
+		}
+	}
+
+	if sel.Where != nil && exprContainsColumnRef(sel.Where, colNameL) {
+		usage.unsupportedReason = "WHERE clause"
+		return usage, nil
+	}
+	if sel.Having != nil && sel.Having.Expr != nil && exprContainsColumnRef(sel.Having.Expr, colNameL) {
+		usage.unsupportedReason = "HAVING clause"
+		return usage, nil
+	}
+	if sel.OrderBy != nil {
+		for _, item := range sel.OrderBy.Items {
+			if item != nil && item.Expr != nil && exprContainsColumnRef(item.Expr, colNameL) {
+				usage.unsupportedReason = "ORDER BY clause"
+				return usage, nil
+			}
+		}
+	}
+
+	// GROUP BY: remember direct group key references; reject complex expressions.
+	if sel.GroupBy != nil {
+		for _, item := range sel.GroupBy.Items {
+			if item == nil || item.Expr == nil {
+				continue
+			}
+			// GROUP BY ordinal (e.g. GROUP BY 1).
+			if expr, ok := item.Expr.(*ast.PositionExpr); ok && expr.N > 0 {
+				off := expr.N - 1
+				if _, ok := directOutputSet[off]; ok {
+					usage.isGroupKey = true
+					continue
+				}
+			}
+			if colExpr, ok := item.Expr.(*ast.ColumnNameExpr); ok && colExpr.Name != nil && colExpr.Name.Name.L == colNameL {
+				usage.isGroupKey = true
+				continue
+			}
+			// GROUP BY output alias (e.g. GROUP BY k where SELECT a AS k).
+			if colExpr, ok := item.Expr.(*ast.ColumnNameExpr); ok && colExpr.Name != nil &&
+				colExpr.Name.Schema.L == "" && colExpr.Name.Table.L == "" {
+				if off, ok := aliasToOffset[colExpr.Name.Name.L]; ok {
+					if _, ok := directOutputSet[off]; ok {
+						usage.isGroupKey = true
+						continue
+					}
+				}
+			}
+			if exprContainsColumnRef(item.Expr, colNameL) {
+				usage.unsupportedReason = "GROUP BY expressions"
+				return usage, nil
+			}
+		}
+	}
+	return usage, nil
+}
+
+type columnNameExprFinder struct {
+	colNameL string
+	found    bool
+}
+
+func (v *columnNameExprFinder) Enter(n ast.Node) (ast.Node, bool) {
+	if v.found {
+		return n, true
+	}
+	expr, ok := n.(*ast.ColumnNameExpr)
+	if ok && expr.Name != nil && expr.Name.Name.L == v.colNameL {
+		v.found = true
+		return n, true
+	}
+	return n, false
+}
+
+func (v *columnNameExprFinder) Leave(n ast.Node) (ast.Node, bool) {
+	return n, !v.found
+}
+
+func exprContainsColumnRef(expr ast.ExprNode, colNameL string) bool {
+	if expr == nil {
+		return false
+	}
+	finder := &columnNameExprFinder{colNameL: colNameL}
+	_, _ = expr.Accept(finder)
+	return finder.found
 }
 
 // noReorgDataStrict is a strong check to decide whether we need to change the column data.

--- a/pkg/ddl/modify_column_mv_usage_test.go
+++ b/pkg/ddl/modify_column_mv_usage_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	parser_types "github.com/pingcap/tidb/pkg/parser/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeMVColumnUsageGroupByAlias(t *testing.T) {
+	sel, err := parseSelectFromSQL("select a as k, count(1) from t group by k")
+	require.NoError(t, err)
+
+	usage, err := analyzeMVColumnUsage(sel, "a")
+	require.NoError(t, err)
+	require.Empty(t, usage.unsupportedReason)
+	require.Equal(t, []int{0}, usage.directOutputOffsets)
+	require.True(t, usage.isGroupKey)
+}
+
+func TestAnalyzeMVColumnUsageWhereReferenceUnsupported(t *testing.T) {
+	sel, err := parseSelectFromSQL("select a, count(1) from t where b > 0 group by a")
+	require.NoError(t, err)
+
+	usage, err := analyzeMVColumnUsage(sel, "b")
+	require.NoError(t, err)
+	require.Equal(t, "WHERE clause", usage.unsupportedReason)
+	require.Empty(t, usage.directOutputOffsets)
+	require.False(t, usage.isGroupKey)
+}
+
+func TestFieldTypeForMVRelatedColumnClearsBaseOnlyFlags(t *testing.T) {
+	oldRelatedFT := parser_types.NewFieldType(mysql.TypeLong)
+	oldRelatedFT.AddFlag(mysql.UniqueKeyFlag)
+	oldRelatedCol := &model.ColumnInfo{FieldType: *oldRelatedFT}
+
+	baseNewFT := parser_types.NewFieldType(mysql.TypeLonglong)
+	baseNewFT.AddFlag(mysql.NotNullFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag |
+		mysql.PreventNullInsertFlag | mysql.GeneratedColumnFlag | mysql.PriKeyFlag)
+	baseNewCol := &model.ColumnInfo{FieldType: *baseNewFT}
+
+	newFieldType := fieldTypeForMVRelatedColumn(oldRelatedCol, baseNewCol)
+	require.True(t, mysql.HasNotNullFlag(newFieldType.GetFlag()))
+	require.True(t, mysql.HasUniKeyFlag(newFieldType.GetFlag()))
+	require.False(t, mysql.HasPriKeyFlag(newFieldType.GetFlag()))
+	require.False(t, mysql.HasAutoIncrementFlag(newFieldType.GetFlag()))
+	require.False(t, mysql.HasOnUpdateNowFlag(newFieldType.GetFlag()))
+	require.False(t, mysql.HasPreventNullInsertFlag(newFieldType.GetFlag()))
+	require.Zero(t, newFieldType.GetFlag()&mysql.GeneratedColumnFlag)
+}
+
+func TestAnalyzeMVColumnUsageGroupByOrdinal(t *testing.T) {
+	sel, err := parseSelectFromSQL("select a, count(1) from t group by 1")
+	require.NoError(t, err)
+
+	usage, err := analyzeMVColumnUsage(sel, "a")
+	require.NoError(t, err)
+	require.Empty(t, usage.unsupportedReason)
+	require.Equal(t, []int{0}, usage.directOutputOffsets)
+	require.True(t, usage.isGroupKey)
+}

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -123,13 +123,15 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 			// job except AddForeignKey which is handled separately in the first loop.
 			// so this diff is enough, but it wound be better to accumulate all the diffs,
 			// and then merge them into a single diff.
-			if err = metaMut.SetSchemaDiff(&model.SchemaDiff{
+			diff := &model.SchemaDiff{
 				Version:        ver,
 				Type:           job.Type,
 				TableID:        job.TableID,
 				SchemaID:       job.SchemaID,
 				SubActionTypes: actionTypes,
-			}); err != nil {
+			}
+			SetSchemaDiffForMultiInfos(diff, collectAffectedTableInfosFromInvolving(jobCtx, job)...)
+			if err = metaMut.SetSchemaDiff(diff); err != nil {
 				return ver, err
 			}
 		}
@@ -148,6 +150,36 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 		return ver, err
 	}
 	return finishMultiSchemaJob(job, metaMut)
+}
+
+func collectAffectedTableInfosFromInvolving(jobCtx *jobContext, job *model.Job) []schemaIDAndTableInfo {
+	is := jobCtx.infoCache.GetLatest()
+	ctx := jobCtx.stepCtx
+	if ctx == nil {
+		ctx = jobCtx.ctx
+	}
+	seen := map[int64]struct{}{job.TableID: {}}
+	infos := make([]schemaIDAndTableInfo, 0)
+	for _, involving := range job.GetInvolvingSchemaInfo() {
+		if involving.Database == "" || involving.Table == "" || involving.Table == model.InvolvingAll {
+			continue
+		}
+		schema, ok := is.SchemaByName(pmodel.NewCIStr(involving.Database))
+		if !ok {
+			continue
+		}
+		tbl, err := is.TableByName(ctx, pmodel.NewCIStr(involving.Database), pmodel.NewCIStr(involving.Table))
+		if err != nil {
+			continue
+		}
+		tblID := tbl.Meta().ID
+		if _, ok := seen[tblID]; ok {
+			continue
+		}
+		seen[tblID] = struct{}{}
+		infos = append(infos, schemaIDAndTableInfo{schemaID: schema.ID, tblInfo: tbl.Meta()})
+	}
+	return infos
 }
 
 func handleRevertibleException(job *model.Job, subJob *model.SubJob, err *terror.Error) {
@@ -188,21 +220,46 @@ func appendToSubJobs(m *model.MultiSchemaInfo, jobW *JobWrapper) error {
 	if err != nil {
 		return err
 	}
+	m.InvolvingSchemaInfo = appendInvolvingSchemaInfo(m.InvolvingSchemaInfo, jobW.Job.InvolvingSchemaInfo...)
 	var reorgTp model.ReorgType
 	if jobW.ReorgMeta != nil {
 		reorgTp = jobW.ReorgMeta.ReorgTp
 	}
 	m.SubJobs = append(m.SubJobs, &model.SubJob{
-		Type:        jobW.Type,
-		JobArgs:     jobW.JobArgs,
-		RawArgs:     jobW.RawArgs,
-		SchemaState: jobW.SchemaState,
-		SnapshotVer: jobW.SnapshotVer,
-		Revertible:  true,
-		CtxVars:     jobW.CtxVars,
-		ReorgTp:     reorgTp,
+		Type:                jobW.Type,
+		JobArgs:             jobW.JobArgs,
+		RawArgs:             jobW.RawArgs,
+		SchemaState:         jobW.SchemaState,
+		SnapshotVer:         jobW.SnapshotVer,
+		Revertible:          true,
+		CtxVars:             jobW.CtxVars,
+		ReorgTp:             reorgTp,
+		InvolvingSchemaInfo: jobW.Job.InvolvingSchemaInfo,
 	})
 	return nil
+}
+
+func appendInvolvingSchemaInfo(dst []model.InvolvingSchemaInfo, src ...model.InvolvingSchemaInfo) []model.InvolvingSchemaInfo {
+	for _, info := range src {
+		found := false
+		for i := range dst {
+			if dst[i].Database != info.Database ||
+				dst[i].Table != info.Table ||
+				dst[i].Policy != info.Policy ||
+				dst[i].ResourceGroup != info.ResourceGroup {
+				continue
+			}
+			if dst[i].Mode == model.SharedInvolving && info.Mode == model.ExclusiveInvolving {
+				dst[i].Mode = model.ExclusiveInvolving
+			}
+			found = true
+			break
+		}
+		if !found {
+			dst = append(dst, info)
+		}
+	}
+	return dst
 }
 
 func fillMultiSchemaInfo(info *model.MultiSchemaInfo, job *JobWrapper) error {

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl"
 	ddlsess "github.com/pingcap/tidb/pkg/ddl/session"
 	ddlutil "github.com/pingcap/tidb/pkg/ddl/util"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/auth"
@@ -73,6 +75,14 @@ func TestCreateMaterializedViewLogRejectsDuplicateColumns(t *testing.T) {
 
 	err := tk.ExecToErr("create materialized view log on t_dup (id, id)")
 	require.ErrorContains(t, err, "Duplicate column name")
+}
+
+func involvingSchemaInfoSet(involving []model.InvolvingSchemaInfo) map[string]struct{} {
+	got := make(map[string]struct{}, len(involving))
+	for _, info := range involving {
+		got[info.Database+"\x00"+info.Table] = struct{}{}
+	}
+	return got
 }
 
 func TestMaterializedViewDDLBasic(t *testing.T) {
@@ -239,6 +249,91 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	tk.MustExec("create materialized view mv_alias (a, c) as select x.a, count(1) from t x where x.b > 0 group by x.a")
 	tk.MustQuery("select a, c from mv_alias order by a").Check(testkit.Rows("1 2", "2 1"))
 
+	// Direct output column with output alias should be tracked by SELECT list offset (not by output column name).
+	tk.MustExec("create materialized view mv_out_alias (k, cnt) as select a as k, count(1) from t group by a")
+	tk.MustQuery("select k, cnt from mv_out_alias order by k").Check(testkit.Rows("1 2", "2 1"))
+
+	// Non-renaming CHANGE COLUMN should follow the same no-reorg metadata sync path as MODIFY COLUMN.
+	tk.MustExec("create table t_change_ok (a int not null, b int not null)")
+	tk.MustExec("insert into t_change_ok values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t_change_ok (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_change_ok (a, cnt) as select a, count(1) from t_change_ok group by a")
+	tk.MustExec("alter table t_change_ok change column a a bigint not null")
+	showCreate = tk.MustQuery("show create table t_change_ok").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "`a` bigint")
+	showCreate = tk.MustQuery("show create table `$mlog$t_change_ok`").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "`a` bigint")
+	showCreate = tk.MustQuery("show create table mv_change_ok").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "`a` bigint")
+	tk.MustQuery("select a, cnt from mv_change_ok order by a").Check(testkit.Rows("1 1", "2 1"))
+	tk.MustExec("drop materialized view mv_change_ok")
+	tk.MustExec("drop materialized view log on t_change_ok")
+	tk.MustExec("drop table t_change_ok")
+
+	// A column referenced by WHERE is rejected in phase 1 because predicate semantics may change.
+	tk.MustExec("create table t_where_ref (a int not null, b int not null)")
+	tk.MustExec("insert into t_where_ref values (1, 10), (2, -1)")
+	tk.MustExec("create materialized view log on t_where_ref (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_where_ref (a, cnt) as select a, count(1) from t_where_ref where b > 0 group by a")
+	err = tk.ExecToErr("alter table t_where_ref modify column b bigint not null")
+	require.ErrorContains(t, err, "does not support modifying columns used in WHERE clause")
+	tk.MustExec("drop materialized view mv_where_ref")
+	tk.MustExec("drop materialized view log on t_where_ref")
+	tk.MustExec("drop table t_where_ref")
+
+	// Base table with dependent MV: allow restricted no-reorg MODIFY/CHANGE COLUMN, update dependent MV/MLog metadata.
+	err = tk.ExecToErr("alter table t change column a a2 bigint")
+	require.ErrorContains(t, err, "does not support renaming")
+
+	tk.MustExec("alter table t modify column a bigint not null")
+
+	var historyJob *model.Job
+	require.NoError(t, kv.RunInNewTxn(context.Background(), store, false, func(ctx context.Context, txn kv.Transaction) error {
+		m := meta.NewMutator(txn)
+		jobs, err := ddl.GetLastNHistoryDDLJobs(m, 32)
+		if err != nil {
+			return err
+		}
+		for _, job := range jobs {
+			if job.Type == model.ActionModifyColumn && job.TableID == baseTable.Meta().ID {
+				historyJob = job
+				return nil
+			}
+		}
+		return nil
+	}))
+	require.NotNil(t, historyJob)
+	involving := historyJob.GetInvolvingSchemaInfo()
+	wantInvolving := map[string]struct{}{
+		"test\x00t":               {},
+		"test\x00$mlog$t":         {},
+		"test\x00mv":              {},
+		"test\x00mv_count_col":    {},
+		"test\x00mv_upper_agg":    {},
+		"test\x00mv_alias":        {},
+		"test\x00mv_out_alias":    {},
+		"test\x00mv_alert":        {},
+		"test\x00mv_alert_zero":   {},
+		"test\x00mv_alert_failed": {},
+	}
+	require.Equal(t, wantInvolving, involvingSchemaInfoSet(involving))
+
+	showCreate = tk.MustQuery("show create table t").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "`a` bigint")
+	showCreate = tk.MustQuery("show create table `$mlog$t`").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "`a` bigint")
+	showCreate = tk.MustQuery("show create table mv").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "`a` bigint")
+	showCreate = tk.MustQuery("show create table mv_alias").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "`a` bigint")
+	showCreate = tk.MustQuery("show create table mv_out_alias").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "`k` bigint")
+	tk.MustQuery("select a, s, cnt from mv order by a").Check(testkit.Rows("1 15 2", "2 7 1"))
+
+	// Reorg-required or MV-dependent modifying should still be rejected.
+	err = tk.ExecToErr("alter table t modify column b bigint")
+	require.ErrorContains(t, err, "does not support modifying columns used in non-direct SELECT expressions")
+
 	// MV LOG must contain all referenced columns.
 	tk.MustExec("create table t_mlog_missing (a int not null, b int not null)")
 	tk.MustExec("create materialized view log on t_mlog_missing (a) purge next date_add(now(), interval 1 hour)")
@@ -289,7 +384,7 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	tk.MustExec("alter table t add column c int")
 	tk.MustExec("alter table t add index idx_base_c_alter (c)")
 	err = tk.ExecToErr("alter table t modify column a bigint")
-	require.ErrorContains(t, err, "referenced by materialized view log")
+	require.ErrorContains(t, err, "does not support changing charset/collation/nullability of group keys")
 	tk.MustExec("alter table t drop index idx_base_c_alter")
 	tk.MustExec("alter table mv add index idx_mv_s_alter (s)")
 	tk.MustExec("alter table mv drop index idx_mv_s_alter")
@@ -316,6 +411,7 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	tk.MustExec("drop materialized view mv_alert_failed")
 	tk.MustExec("drop materialized view mv_upper_agg")
 	tk.MustExec("drop materialized view mv_alias")
+	tk.MustExec("drop materialized view mv_out_alias")
 	tk.MustExec("drop materialized view mv_nullable")
 	tk.MustExec("drop materialized view mv_sum_nullable")
 	tk.MustExec("drop materialized view mv_sum_nullable_dup_cnt")
@@ -337,6 +433,49 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	baseTable, err = is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 	require.NoError(t, err)
 	require.True(t, baseTable.Meta().MaterializedViewBase == nil || (baseTable.Meta().MaterializedViewBase.MLogID == 0 && len(baseTable.Meta().MaterializedViewBase.MViewIDs) == 0))
+}
+
+func TestMaterializedViewBaseModifyColumnMultiSchemaInvolvingSchemaInfo(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_multi_schema (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on t_multi_schema (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_multi_schema (a, b, cnt) as select a, b, count(1) from t_multi_schema group by a, b")
+	tk.MustExec("alter table t_multi_schema modify column a bigint not null, modify column b bigint not null")
+
+	var historyJob *model.Job
+	require.NoError(t, kv.RunInNewTxn(context.Background(), store, false, func(ctx context.Context, txn kv.Transaction) error {
+		m := meta.NewMutator(txn)
+		jobs, err := ddl.GetLastNHistoryDDLJobs(m, 16)
+		if err != nil {
+			return err
+		}
+		for _, job := range jobs {
+			if job.Type == model.ActionMultiSchemaChange && job.TableName == "t_multi_schema" {
+				historyJob = job
+				return nil
+			}
+		}
+		return nil
+	}))
+	require.NotNil(t, historyJob)
+	require.Equal(t, map[string]struct{}{
+		"test\x00t_multi_schema":       {},
+		"test\x00$mlog$t_multi_schema": {},
+		"test\x00mv_multi_schema":      {},
+	}, involvingSchemaInfoSet(historyJob.GetInvolvingSchemaInfo()))
+
+	showCreate := tk.MustQuery("show create table t_multi_schema").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "`a` bigint")
+	require.Contains(t, showCreate, "`b` bigint")
+	showCreate = tk.MustQuery("show create table `$mlog$t_multi_schema`").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "`a` bigint")
+	require.Contains(t, showCreate, "`b` bigint")
+	showCreate = tk.MustQuery("show create table mv_multi_schema").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "`a` bigint")
+	require.Contains(t, showCreate, "`b` bigint")
 }
 
 func TestCreateMaterializedViewHistoryJobSchemaVersion(t *testing.T) {

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/kv"
+	metamodel "github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/auth"
@@ -43,6 +44,15 @@ import (
 
 func mustExecInternal(t *testing.T, tk *testkit.TestKit, sql string) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnMVMaintenance)
+	vars := tk.Session().GetSessionVars()
+	origMaint := vars.InMaterializedViewMaintenance
+	origRestr := vars.InRestrictedSQL
+	vars.InMaterializedViewMaintenance = true
+	vars.InRestrictedSQL = true
+	defer func() {
+		vars.InMaterializedViewMaintenance = origMaint
+		vars.InRestrictedSQL = origRestr
+	}()
 	rs, err := tk.Session().ExecuteInternal(ctx, sql)
 	require.NoError(t, err)
 	require.Nil(t, rs)
@@ -139,6 +149,221 @@ func TestCreateMaterializedViewLogBasic(t *testing.T) {
 
 	// Duplicated MV LOG should fail (same derived table name).
 	tk.MustGetErrMsg("create materialized view log on t (a)", "[schema:1050]Table 'test.$mlog$t' already exists")
+}
+
+// TestAlterMaterializedViewLogAddColumnBasic verifies that ADD COLUMN updates
+// mlog metadata, backfills old log rows with mlog defaults, and records future
+// changes only when newly tracked columns are touched.
+func TestAlterMaterializedViewLogAddColumnBasic(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_add_mlog_col (id int not null, n int not null, s varchar(10) not null, d date not null, note text not null, untouched int)")
+	tk.MustExec("create materialized view log on t_add_mlog_col (id)")
+	tk.MustExec("insert into t_add_mlog_col values (1, 7, 'old', '2026-01-02', 'memo', 100)")
+
+	tk.MustExec("alter materialized view log on t_add_mlog_col add column (n, s, d, note)")
+
+	is := dom.InfoSchema()
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_add_mlog_col"))
+	require.NoError(t, err)
+	mlogInfo := mlogTable.Meta().MaterializedViewLog
+	require.NotNil(t, mlogInfo)
+	require.Equal(t, []pmodel.CIStr{
+		pmodel.NewCIStr("id"),
+		pmodel.NewCIStr("n"),
+		pmodel.NewCIStr("s"),
+		pmodel.NewCIStr("d"),
+		pmodel.NewCIStr("note"),
+	}, mlogInfo.Columns)
+
+	colNames := make([]string, 0, len(mlogTable.Meta().Columns))
+	colByName := make(map[string]*metamodel.ColumnInfo, len(mlogTable.Meta().Columns))
+	for _, col := range mlogTable.Meta().Columns {
+		colNames = append(colNames, col.Name.O)
+		colByName[col.Name.L] = col
+	}
+	require.Equal(t, []string{"id", "n", "s", "d", "note", "_MLOG$_DML_TYPE", "_MLOG$_OLD_NEW"}, colNames)
+	for _, name := range []string{"n", "s", "d", "note"} {
+		require.True(t, mysql.HasNotNullFlag(colByName[name].GetFlag()))
+	}
+	require.Equal(t, "0", fmt.Sprint(colByName["n"].GetOriginDefaultValue()))
+	require.Equal(t, " ", fmt.Sprint(colByName["s"].GetOriginDefaultValue()))
+	require.Equal(t, "0000-00-00", fmt.Sprint(colByName["d"].GetOriginDefaultValue()))
+	require.Equal(t, " ", fmt.Sprint(colByName["note"].GetOriginDefaultValue()))
+
+	tk.MustQuery("select n, hex(s), cast(d as char), hex(note), `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t_add_mlog_col`").
+		Check(testkit.Rows("0 20 0000-00-00 20 I 1"))
+
+	showCreate := tk.MustQuery("show create materialized view log on t_add_mlog_col").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW LOG ON `t_add_mlog_col` (`id`, `n`, `s`, `d`, `note`)")
+
+	mustExecInternal(t, tk, "delete from `$mlog$t_add_mlog_col`")
+	tk.MustExec("update t_add_mlog_col set untouched = 101 where id = 1")
+	tk.MustQuery("select * from `$mlog$t_add_mlog_col`").Check(testkit.Rows())
+
+	tk.MustExec("update t_add_mlog_col set s = 'new' where id = 1")
+	tk.MustQuery("select id, n, s, cast(d as char), note, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t_add_mlog_col`").Sort().
+		Check(testkit.Rows(
+			"1 7 new 2026-01-02 memo U 1",
+			"1 7 old 2026-01-02 memo U -1",
+		))
+
+	tk.MustExec("create table t_add_mlog_atomic (id int, b int, c int)")
+	tk.MustExec("create materialized view log on t_add_mlog_atomic (id)")
+	cancelTK := testkit.NewTestKit(t, store)
+	cancelTK.MustExec("use test")
+	cancelTriggered := atomic.Bool{}
+	cancelDone := make(chan error, 1)
+	require.NoError(t, failpoint.EnableCall("github.com/pingcap/tidb/pkg/ddl/onJobUpdated", func(job *metamodel.Job) {
+		if !cancelTriggered.CompareAndSwap(false, true) {
+			return
+		}
+		if job.Type != metamodel.ActionMultiSchemaChange ||
+			job.SchemaName != "test" ||
+			job.TableName != "$mlog$t_add_mlog_atomic" ||
+			job.MultiSchemaInfo == nil ||
+			len(job.MultiSchemaInfo.SubJobs) != 2 ||
+			job.MultiSchemaInfo.SubJobs[1].SchemaState != metamodel.StateWriteReorganization {
+			cancelTriggered.Store(false)
+			return
+		}
+		errs, err := ddl.CancelJobs(context.Background(), cancelTK.Session(), []int64{job.ID})
+		if len(errs) > 0 && errs[0] != nil {
+			cancelDone <- errs[0]
+			return
+		}
+		cancelDone <- err
+	}))
+	err = tk.ExecToErr("alter materialized view log on t_add_mlog_atomic add column (b, c)")
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/onJobUpdated"))
+	require.ErrorContains(t, err, "Cancelled DDL job")
+	select {
+	case cancelErr := <-cancelDone:
+		require.NoError(t, cancelErr)
+	default:
+		require.FailNow(t, "expected mlog multi-column add cancellation")
+	}
+	showCreate = tk.MustQuery("show create materialized view log on t_add_mlog_atomic").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW LOG ON `t_add_mlog_atomic` (`id`)")
+	require.NotContains(t, showCreate, "`b`")
+	require.NotContains(t, showCreate, "`c`")
+}
+
+// TestAlterMaterializedViewLogAddColumnDefaultSemantics verifies the default
+// values used for existing mlog rows when ADD COLUMN tracks nullable columns,
+// enum/set columns, and not-null string columns.
+func TestAlterMaterializedViewLogAddColumnDefaultSemantics(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	// This table covers the mlog backfill defaults that differ from normal AddColumn:
+	// nullable columns should keep NULL for old mlog rows, enum/set should use the
+	// regular TiDB default semantics, and not-null string columns should use a
+	// single-space placeholder required by materialized view log history rows.
+	tk.MustExec("create table t_add_mlog_defaults (" +
+		"id int," +
+		"nullable_varchar varchar(10)," +
+		"nullable_text text," +
+		"nn_enum enum('a','b') not null," +
+		"nn_set set('x','y') not null," +
+		"nullable_enum enum('a','b')," +
+		"nullable_set set('x','y')," +
+		"nn_varchar varchar(10) not null," +
+		"nn_text text not null)")
+	tk.MustExec("create materialized view log on t_add_mlog_defaults (id)")
+	tk.MustExec("insert into t_add_mlog_defaults values (1, null, null, 'b', 'x', null, null, 'old', 'memo')")
+
+	tk.MustExec("alter materialized view log on t_add_mlog_defaults add column (" +
+		"nullable_varchar, nullable_text, nn_enum, nn_set, nullable_enum, nullable_set, nn_varchar, nn_text)")
+
+	// The existing INSERT log row is historical data. It should not read current
+	// base-table values for newly tracked columns; it should only expose the
+	// metadata default chosen for old mlog rows.
+	tk.MustQuery("select " +
+		"nullable_varchar is null, nullable_text is null, " +
+		"cast(nn_enum as char), cast(nn_set as char), " +
+		"nullable_enum is null, nullable_set is null, " +
+		"hex(nn_varchar), hex(nn_text), `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` " +
+		"from `$mlog$t_add_mlog_defaults`").
+		Check(testkit.Rows("1 1 a  1 1 20 20 I 1"))
+}
+
+// TestAlterMaterializedViewLogAddColumnRejectsInvalidColumns verifies that ADD
+// COLUMN rejects duplicate tracked columns, duplicate names in one statement,
+// missing base columns, and reserved mlog metadata columns.
+func TestAlterMaterializedViewLogAddColumnRejectsInvalidColumns(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_add_mlog_invalid (a int, b int, c int)")
+	tk.MustExec("create materialized view log on t_add_mlog_invalid (a)")
+
+	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (a)", errno.ErrDupFieldName)
+	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (b, b)", errno.ErrDupFieldName)
+	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (missing_col)", errno.ErrBadField)
+	tk.MustGetErrCode("alter materialized view log on t_add_mlog_invalid add column (`_MLOG$_DML_TYPE`)", errno.ErrDupFieldName)
+	tk.MustGetErrMsg(
+		"alter materialized view log on t_add_mlog_invalid add column (b), add column (c)",
+		"[ddl:8200]Unsupported ALTER MATERIALIZED VIEW LOG with multiple ADD COLUMN actions",
+	)
+}
+
+// TestAlterMaterializedViewLogAddColumnPrivilege verifies that ADD COLUMN
+// requires ALTER privilege on the mlog table and SELECT privilege on the base
+// table.
+func TestAlterMaterializedViewLogAddColumnPrivilege(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_add_mlog_priv (a int, b int)")
+	tk.MustExec("create materialized view log on t_add_mlog_priv (a)")
+	tk.MustExec("create user 'u_add_mlog_no_select'@'%'")
+	tk.MustExec("create user 'u_add_mlog_ok'@'%'")
+	defer tk.MustExec("drop user 'u_add_mlog_no_select'@'%'")
+	defer tk.MustExec("drop user 'u_add_mlog_ok'@'%'")
+
+	tk.MustExec("grant alter on test.`$mlog$t_add_mlog_priv` to 'u_add_mlog_no_select'@'%'")
+	tkNoSelect := testkit.NewTestKit(t, store)
+	require.NoError(t, tkNoSelect.Session().Auth(&auth.UserIdentity{Username: "u_add_mlog_no_select", Hostname: "%"}, nil, nil, nil))
+	err := tkNoSelect.ExecToErr("alter materialized view log on test.t_add_mlog_priv add column (b)")
+	require.ErrorContains(t, err, "SELECT command denied")
+
+	tk.MustExec("grant alter on test.`$mlog$t_add_mlog_priv` to 'u_add_mlog_ok'@'%'")
+	tk.MustExec("grant select on test.t_add_mlog_priv to 'u_add_mlog_ok'@'%'")
+	tkOK := testkit.NewTestKit(t, store)
+	require.NoError(t, tkOK.Session().Auth(&auth.UserIdentity{Username: "u_add_mlog_ok", Hostname: "%"}, nil, nil, nil))
+	tkOK.MustExec("alter materialized view log on test.t_add_mlog_priv add column (b)")
+}
+
+// TestAlterMaterializedViewLogAddColumnSupportsNewMaterializedView verifies
+// that a fast-refresh materialized view can be created and refreshed after its
+// referenced base column is added to the materialized view log.
+func TestAlterMaterializedViewLogAddColumnSupportsNewMaterializedView(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_add_mlog_mv (a int not null, b int not null, c int not null)")
+	tk.MustExec("insert into t_add_mlog_mv values (1, 10, 100), (1, 20, 200), (2, 30, 300)")
+	tk.MustExec("create materialized view log on t_add_mlog_mv (a, b)")
+
+	err := tk.ExecToErr("create materialized view mv_add_mlog_col_before (a, s, cnt) refresh fast as select a, sum(c), count(1) from t_add_mlog_mv group by a")
+	require.ErrorContains(t, err, "materialized view log does not contain column c")
+
+	tk.MustExec("alter materialized view log on t_add_mlog_mv add column (c)")
+	tk.MustExec("create materialized view mv_add_mlog_col_after (a, s, cnt) refresh fast as select a, sum(c), count(1) from t_add_mlog_mv group by a")
+	tk.MustQuery("select a, s, cnt from mv_add_mlog_col_after order by a").Check(testkit.Rows(
+		"1 300 2",
+		"2 300 1",
+	))
+
+	tk.MustExec("update t_add_mlog_mv set c = 150 where a = 1 and b = 10")
+	tk.MustExec("insert into t_add_mlog_mv values (2, 40, 400)")
+	tk.MustExec("refresh materialized view mv_add_mlog_col_after fast")
+	tk.MustQuery("select a, s, cnt from mv_add_mlog_col_after order by a").Check(testkit.Rows(
+		"1 350 2",
+		"2 700 2",
+	))
 }
 
 func TestCreateMaterializedViewLogPrivilege(t *testing.T) {

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -994,18 +994,15 @@ func TestTruncateOrdinaryTableStillWorks(t *testing.T) {
 	tk.MustQuery("select count(*) from t_normal_truncate").Check(testkit.Rows("0"))
 }
 
-func TestDropMaterializedViewLogTableAfterBaseDropped(t *testing.T) {
+func TestDropMaterializedViewLogBeforeBaseTable(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
-	tk.MustExec("drop table if exists `$mlog$t_drop_seq`")
-	tk.MustExec("drop table if exists t_drop_seq")
-
 	tk.MustExec("create table t_drop_seq (a int)")
 	tk.MustExec("create materialized view log on t_drop_seq (a)")
+	tk.MustExec("drop materialized view log on t_drop_seq")
 	tk.MustExec("drop table if exists t_drop_seq")
-	tk.MustExec("drop table if exists `$mlog$t_drop_seq`")
 }
 
 func TestDropMaterializedViewLogRemovesPurgeState(t *testing.T) {

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -921,15 +921,32 @@ func TestMaterializedViewRelatedTablesDDLRejected(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t_ddl_mv (a int not null, b int)")
 	tk.MustExec("create materialized view log on t_ddl_mv (a, b)")
+
+	err := tk.ExecToErr("drop table t_ddl_mv")
+	require.ErrorContains(t, err, "DROP TABLE on base table with materialized view log")
+	err = tk.ExecToErr("rename table t_ddl_mv to t_ddl_mv2")
+	require.ErrorContains(t, err, "RENAME TABLE on base table with materialized view log")
+	err = tk.ExecToErr("drop table `$mlog$t_ddl_mv`")
+	require.ErrorContains(t, err, "DROP TABLE on materialized view log table")
+	err = tk.ExecToErr("rename table `$mlog$t_ddl_mv` to `$mlog$t_ddl_mv2`")
+	require.ErrorContains(t, err, "RENAME TABLE on materialized view log table")
+
 	tk.MustExec("create materialized view mv_ddl_mv (a, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, count(1) from t_ddl_mv group by a")
 
 	tk.MustExec("alter table t_ddl_mv add column c int")
-	err := tk.ExecToErr("alter table t_ddl_mv modify column a bigint")
-	require.ErrorContains(t, err, "referenced by materialized view log")
+	err = tk.ExecToErr("alter table t_ddl_mv modify column a bigint")
+	require.ErrorContains(t, err, "does not support changing charset/collation/nullability of group keys")
 	err = tk.ExecToErr("drop table t_ddl_mv")
 	require.ErrorContains(t, err, "DROP TABLE on base table with materialized view dependencies")
 	err = tk.ExecToErr("rename table t_ddl_mv to t_ddl_mv2")
 	require.ErrorContains(t, err, "RENAME TABLE on base table with materialized view dependencies")
+
+	// Restricted MODIFY/CHANGE COLUMN should be allowed at ALTER TABLE entry, but still rejected on reorg/renaming.
+	tk.MustExec("alter table t_ddl_mv modify column b bigint")
+	err = tk.ExecToErr("alter table t_ddl_mv modify column b smallint")
+	require.ErrorContains(t, err, "only supports no-reorg compatible type changes")
+	err = tk.ExecToErr("alter table t_ddl_mv change column b b2 bigint")
+	require.ErrorContains(t, err, "does not support renaming")
 
 	err = tk.ExecToErr("alter table mv_ddl_mv add column x int")
 	require.ErrorContains(t, err, "ALTER TABLE on materialized view table")
@@ -947,6 +964,8 @@ func TestMaterializedViewRelatedTablesDDLRejected(t *testing.T) {
 	err = tk.ExecToErr("alter table `$mlog$t_ddl_mv` add column c int")
 	require.ErrorContains(t, err, "ALTER TABLE on materialized view log table")
 	err = tk.ExecToErr("create index idx_mlog_b_create on `$mlog$t_ddl_mv`(b)")
+	require.ErrorContains(t, err, "CREATE INDEX on materialized view log table")
+	err = tk.ExecToErr("create vector index idx_mlog_vec_create on `$mlog$t_ddl_mv` ((vec_cosine_distance(b))) using hnsw")
 	require.ErrorContains(t, err, "CREATE INDEX on materialized view log table")
 	err = tk.ExecToErr("drop index idx_mlog_b_create on `$mlog$t_ddl_mv`")
 	require.ErrorContains(t, err, "DROP INDEX on materialized view log table")

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -595,6 +595,7 @@ func TestMaterializedViewRefreshFastAsOfTimestampNoOpStatementResult(t *testing.
 	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
+	tk.MustExec("set time_zone = '+00:00'")
 	tk.MustExec("create table t_mv_refresh_result_noop (a int primary key, b int not null)")
 	tk.MustExec("insert into t_mv_refresh_result_noop values (1, 10), (2, 20)")
 	tk.MustExec("create materialized view log on t_mv_refresh_result_noop (a, b) purge next date_add(now(), interval 1 hour)")
@@ -605,18 +606,22 @@ func TestMaterializedViewRefreshFastAsOfTimestampNoOpStatementResult(t *testing.
 	mvID, err := strconv.ParseInt(fmt.Sprintf("%v", mvIDRow[0][0]), 10, 64)
 	require.NoError(t, err)
 
-	lastSuccessTSORow := tk.MustQuery(fmt.Sprintf(
-		"select LAST_SUCCESS_READ_TSO from mysql.tidb_mview_refresh_info where MVIEW_ID = %d",
+	targetTime := time.Now().UTC().Add(50 * time.Millisecond).Truncate(time.Millisecond)
+	sleepUntilTarget := time.Until(targetTime.Add(20 * time.Millisecond))
+	if sleepUntilTarget > 0 {
+		time.Sleep(sleepUntilTarget)
+	}
+	targetTSO := oracle.GoTimeToTS(targetTime)
+	mustSetMockGCSafePoint(t, tk, targetTime.Add(-time.Hour))
+	tk.MustExec(fmt.Sprintf(
+		"update mysql.tidb_mview_refresh_info set LAST_SUCCESS_READ_TSO = %d where MVIEW_ID = %d",
+		targetTSO,
 		mvID,
-	)).Rows()
-	require.Len(t, lastSuccessTSORow, 1)
-	lastSuccessTSO, err := strconv.ParseUint(fmt.Sprintf("%v", lastSuccessTSORow[0][0]), 10, 64)
-	require.NoError(t, err)
-	require.NotZero(t, lastSuccessTSO)
+	))
 
 	tk.MustExec(fmt.Sprintf(
-		"refresh materialized view mv_refresh_result_noop fast as of timestamp TIDB_PARSE_TSO(%d)",
-		lastSuccessTSO,
+		"refresh materialized view mv_refresh_result_noop fast as of timestamp '%s'",
+		targetTime.Format("2006-01-02 15:04:05.000"),
 	))
 	requireRefreshMVStatementResult(t, tk, 0, 0, 0)
 	tk.MustQuery(fmt.Sprintf(

--- a/pkg/executor/test/writetest/BUILD.bazel
+++ b/pkg/executor/test/writetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "write_test.go",
     ],
     flaky = True,
-    shard_count = 47,
+    shard_count = 49,
     deps = [
         "//pkg/config",
         "//pkg/errctx",

--- a/pkg/executor/test/writetest/BUILD.bazel
+++ b/pkg/executor/test/writetest/BUILD.bazel
@@ -9,10 +9,11 @@ go_test(
         "write_test.go",
     ],
     flaky = True,
-    shard_count = 46,
+    shard_count = 47,
     deps = [
         "//pkg/config",
         "//pkg/errctx",
+        "//pkg/errno",
         "//pkg/executor",
         "//pkg/kv",
         "//pkg/lightning/mydump",

--- a/pkg/executor/test/writetest/mview_log_write_test.go
+++ b/pkg/executor/test/writetest/mview_log_write_test.go
@@ -134,7 +134,7 @@ func TestMLogInsert(t *testing.T) {
 	))
 
 	// Partial-column insert with DEFAULT value.
-	tk.MustExec("drop table if exists `$mlog$t`")
+	tk.MustExec("drop materialized view log on t")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a int primary key, b int, c int default 99)")
 	tk.MustExec("create materialized view log on t (a, b, c)")
@@ -872,40 +872,36 @@ func TestMLogPrunedColumns(t *testing.T) {
 	tk.MustExec("use test")
 
 	t.Run("delete", func(t *testing.T) {
-		tk.MustExec("drop table if exists `$mlog$t`")
-		tk.MustExec("drop table if exists t")
-		tk.MustExec("create table t (a int, b int)")
-		tk.MustExec("create materialized view log on t (a, b)")
-		tk.MustExec("insert into t values (1,10)")
-		execAsMViewMaintenance(tk, "delete from `$mlog$t`")
+		tk.MustExec("create table t_mlog_pruned_delete (a int, b int)")
+		tk.MustExec("create materialized view log on t_mlog_pruned_delete (a, b)")
+		tk.MustExec("insert into t_mlog_pruned_delete values (1,10)")
+		execAsMViewMaintenance(tk, "delete from `$mlog$t_mlog_pruned_delete`")
 
 		// Delete normally can prune non-handle/index columns, but mlog RemoveRecord reads
 		// tracked columns by base offsets; pruning them would make mlog writing fail.
-		tk.MustExec("delete from t where b=10")
+		tk.MustExec("delete from t_mlog_pruned_delete where b=10")
 
-		tk.MustQuery("select a, b from t").Check(testkit.Rows())
+		tk.MustQuery("select a, b from t_mlog_pruned_delete").Check(testkit.Rows())
 		tk.MustQuery(
-			"select a, b, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`",
+			"select a, b, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t_mlog_pruned_delete`",
 		).Check(testkit.Rows(
 			"1 10 D -1",
 		))
 	})
 
 	t.Run("update", func(t *testing.T) {
-		tk.MustExec("drop table if exists `$mlog$t`")
-		tk.MustExec("drop table if exists t")
-		tk.MustExec("create table t (a int, b int)")
-		tk.MustExec("create materialized view log on t (a, b)")
-		tk.MustExec("insert into t values (1,10)")
-		execAsMViewMaintenance(tk, "delete from `$mlog$t`")
+		tk.MustExec("create table t_mlog_pruned_update (a int, b int)")
+		tk.MustExec("create materialized view log on t_mlog_pruned_update (a, b)")
+		tk.MustExec("insert into t_mlog_pruned_update values (1,10)")
+		execAsMViewMaintenance(tk, "delete from `$mlog$t_mlog_pruned_update`")
 
 		// Even if only column b is updated, UpdateRecord still needs full writable row data.
 		// If update column pruning drops tracked columns, mlog writing would fail.
-		tk.MustExec("update t set b=11 where b=10")
+		tk.MustExec("update t_mlog_pruned_update set b=11 where b=10")
 
-		tk.MustQuery("select a, b from t").Check(testkit.Rows("1 11"))
+		tk.MustQuery("select a, b from t_mlog_pruned_update").Check(testkit.Rows("1 11"))
 		tk.MustQuery(
-			"select a, b, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`",
+			"select a, b, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t_mlog_pruned_update`",
 		).Sort().Check(testkit.Rows(
 			"1 10 U -1",
 			"1 11 U 1",

--- a/pkg/executor/test/writetest/mview_log_write_test.go
+++ b/pkg/executor/test/writetest/mview_log_write_test.go
@@ -740,6 +740,12 @@ func TestMLogSkipUntrackedColumns(t *testing.T) {
 	// mlog tracks (a, b); c is untracked.
 	tk.MustExec("create materialized view log on t (a, b)")
 
+	// Modifying an untracked column should not affect the mlog physical table.
+	showBefore := tk.MustQuery("show create table `$mlog$t`").Rows()[0][1].(string)
+	tk.MustExec("alter table t modify column c bigint")
+	showAfter := tk.MustQuery("show create table `$mlog$t`").Rows()[0][1].(string)
+	require.Equal(t, showBefore, showAfter)
+
 	// Updating an untracked column should not produce any mlog entry.
 	tk.MustExec("update t set c=2000 where a=1")
 	tk.MustQuery("select * from `$mlog$t`").Check(testkit.Rows())
@@ -815,6 +821,49 @@ func TestMLogTrackedReferenceTypes(t *testing.T) {
 		"alpha v1 12.34 7061796C6F616431 U -1",
 		"beta v2 56.78 7061796C6F616432 U 1",
 	))
+
+	// No-reorg modify on a tracked column should also update the mlog physical column type.
+	showBefore := tk.MustQuery("show create table `$mlog$t`").Rows()[0][1].(string)
+	require.Contains(t, showBefore, "`s` varchar(20)")
+	tk.MustExec("alter table t modify column s varchar(40)")
+	showAfter := tk.MustQuery("show create table `$mlog$t`").Rows()[0][1].(string)
+	require.Contains(t, showAfter, "`s` varchar(40)")
+
+	// Existing mlog rows are still readable after the type change.
+	tk.MustQuery(
+		"select s, json_unquote(json_extract(j, '$.k')), d, hex(b), `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`",
+	).Sort().Check(testkit.Rows(
+		"alpha v1 12.34 7061796C6F616431 U -1",
+		"beta v2 56.78 7061796C6F616432 U 1",
+	))
+
+	execAsMViewMaintenance(tk, "delete from `$mlog$t`")
+	tk.MustExec(`update t set s='gamma' where id=1`)
+	tk.MustQuery(
+		"select s, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`",
+	).Sort().Check(testkit.Rows(
+		"beta U -1",
+		"gamma U 1",
+	))
+
+	// Reorg-required modify should be rejected for tracked columns on mlog-only base tables.
+	err := tk.ExecToErr("alter table t modify column s varchar(5)")
+	require.ErrorContains(t, err, "only supports no-reorg compatible type changes for tracked columns")
+}
+
+func TestMLogTrackedNullToNotNullChangeRejected(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t (id int primary key, g int not null, c int)")
+	tk.MustExec("create materialized view log on t (g, c)")
+
+	tk.MustExec("insert into t values (1, 1, null)")
+	tk.MustExec("update t set c = 10 where id = 1")
+
+	err := tk.ExecToErr("alter table t modify column c bigint not null")
+	require.ErrorContains(t, err, "does not support changing tracked columns from NULL to NOT NULL")
 }
 
 func TestMLogPrunedColumns(t *testing.T) {

--- a/pkg/executor/test/writetest/mview_log_write_test.go
+++ b/pkg/executor/test/writetest/mview_log_write_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/lightning/mydump"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -904,6 +905,137 @@ func TestMLogOnlineDDLAddUntrackedColumn(t *testing.T) {
 		"1 0 10 101",
 		"2 0 20 200",
 	))
+}
+
+// TestMLogAddColumnRejectsNonPublicBaseColumn verifies that ALTER MATERIALIZED
+// VIEW LOG only accepts public base-table columns. A column being added by
+// concurrent online DDL is visible in metadata before it becomes public, and mlog
+// tracking must reject it until the base DDL finishes.
+func TestMLogAddColumnRejectsNonPublicBaseColumn(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@global.tidb_enable_metadata_lock=0")
+
+	tk.MustExec("create table t (id int primary key, tracked int)")
+	tk.MustExec("create materialized view log on t (id)")
+
+	tkDDL := testkit.NewTestKit(t, store)
+	tkDDL.MustExec("use test")
+	ctrl := startDDLPausedAtFailpoint(
+		t,
+		tkDDL,
+		addColumnStateWriteReorgFailpoint,
+		"alter table t add column added int default 0",
+	)
+	defer ctrl.releaseAndWaitFinish(t)
+
+	ctrl.waitUntilPaused(t, "base-table add-column write-reorg")
+
+	// The base column is non-public while ADD COLUMN is paused, so the mlog
+	// should treat it as unavailable instead of adding a transient column.
+	tk.MustGetErrCode("alter materialized view log on t add column (added)", errno.ErrBadField)
+
+	ctrl.releaseAndWaitFinish(t)
+
+	// Once the base ADD COLUMN completes, the same column is public and can be
+	// tracked by the mlog normally.
+	tk.MustExec("alter materialized view log on t add column (added)")
+	rows := tk.MustQuery("show create materialized view log on t").Rows()
+	require.Len(t, rows, 1)
+	showCreate, ok := rows[0][1].(string)
+	require.True(t, ok)
+	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW LOG ON `t` (`id`, `added`)")
+}
+
+// TestMLogOnlineDDLAddTrackedColumn verifies mlog writes while ADD COLUMN is in
+// progress: before the new mlog column is public, writes still use the old
+// tracked-column set; after it is public, the new tracked column participates in
+// update logging.
+func TestMLogOnlineDDLAddTrackedColumn(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@global.tidb_enable_metadata_lock=0")
+
+	tk.MustExec("create table t (id int primary key, tracked int, added int, untracked int)")
+	tk.MustExec("create materialized view log on t (id, tracked)")
+	tk.MustExec("insert into t values (1, 10, 100, 1000)")
+	execAsMViewMaintenance(tk, "delete from `$mlog$t`")
+
+	tkDDL := testkit.NewTestKit(t, store)
+	tkDDL.MustExec("use test")
+	ctrl := startDDLPausedAtFailpoint(
+		t,
+		tkDDL,
+		addColumnStateWriteReorgFailpoint,
+		"alter materialized view log on t add column (added)",
+	)
+	defer ctrl.releaseAndWaitFinish(t)
+
+	ctrl.waitUntilPaused(t, "mlog add-column write-reorg")
+
+	// The new mlog column is not public yet, so mlog writing should continue with the
+	// previous tracked column set instead of treating the transient metadata as corrupt.
+	tk.MustExec("update t set tracked = 11 where id = 1")
+	tk.MustQuery(
+		"select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`",
+	).Sort().Check(testkit.Rows(
+		"1 10 U -1",
+		"1 11 U 1",
+	))
+
+	ctrl.releaseAndWaitFinish(t)
+
+	execAsMViewMaintenance(tk, "delete from `$mlog$t`")
+	tk.MustExec("update t set untracked = 1001 where id = 1")
+	tk.MustQuery("select * from `$mlog$t`").Check(testkit.Rows())
+
+	tk.MustExec("update t set added = 101 where id = 1")
+	tk.MustQuery(
+		"select id, tracked, added, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`",
+	).Sort().Check(testkit.Rows(
+		"1 11 100 U -1",
+		"1 11 101 U 1",
+	))
+
+	tk.MustExec("create table t_drop_race (id int primary key, tracked int, added int)")
+	tk.MustExec("create materialized view log on t_drop_race (id)")
+	tkDDL2 := testkit.NewTestKit(t, store)
+	tkDDL2.MustExec("use test")
+	ctrl2 := startDDLPausedAtFailpoint(
+		t,
+		tkDDL2,
+		addColumnStateWriteReorgFailpoint,
+		"alter materialized view log on t_drop_race add column (added)",
+	)
+	defer ctrl2.releaseAndWaitFinish(t)
+	ctrl2.waitUntilPaused(t, "mlog add-column write-reorg before base drop")
+
+	tkDrop := testkit.NewTestKit(t, store)
+	tkDrop.MustExec("use test")
+	dropDone := make(chan error, 1)
+	go func() {
+		dropDone <- tkDrop.ExecToErr("alter table t_drop_race drop column added")
+	}()
+	select {
+	case err := <-dropDone:
+		require.FailNow(t, "base drop column finished before mlog add completed", "err=%v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	ctrl2.releaseAndWaitFinish(t)
+	select {
+	case err := <-dropDone:
+		require.ErrorContains(t, err, "referenced by materialized view log")
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "timed out waiting base drop column to finish")
+	}
+	rows := tk.MustQuery("show create materialized view log on t_drop_race").Rows()
+	require.Len(t, rows, 1)
+	showCreate, ok := rows[0][1].(string)
+	require.True(t, ok)
+	require.Contains(t, showCreate, "CREATE MATERIALIZED VIEW LOG ON `t_drop_race` (`id`, `added`)")
 }
 
 func TestMLogOnlineDDLDropUntrackedColumn(t *testing.T) {

--- a/pkg/meta/model/job.go
+++ b/pkg/meta/model/job.go
@@ -923,23 +923,24 @@ func (job *Job) ClearDecodedArgs() {
 // SubJob is a representation of one DDL schema change. A Job may contain zero
 // (when multi-schema change is not applicable) or more SubJobs.
 type SubJob struct {
-	Type         ActionType `json:"type"`
-	JobArgs      JobArgs    `json:"-"`
-	args         []any
-	RawArgs      json.RawMessage `json:"raw_args"`
-	SchemaState  SchemaState     `json:"schema_state"`
-	SnapshotVer  uint64          `json:"snapshot_ver"`
-	RealStartTS  uint64          `json:"real_start_ts"`
-	Revertible   bool            `json:"revertible"`
-	State        JobState        `json:"state"`
-	RowCount     int64           `json:"row_count"`
-	Warning      *terror.Error   `json:"warning"`
-	CtxVars      []any           `json:"-"`
-	SchemaVer    int64           `json:"schema_version"`
-	ReorgTp      ReorgType       `json:"reorg_tp"`
-	ReorgStage   ReorgStage      `json:"reorg_stage"`
-	NeedAnalyze  bool            `json:"need_analyze"`
-	AnalyzeState int8            `json:"analyze_state"`
+	Type                ActionType `json:"type"`
+	JobArgs             JobArgs    `json:"-"`
+	args                []any
+	RawArgs             json.RawMessage       `json:"raw_args"`
+	SchemaState         SchemaState           `json:"schema_state"`
+	SnapshotVer         uint64                `json:"snapshot_ver"`
+	RealStartTS         uint64                `json:"real_start_ts"`
+	Revertible          bool                  `json:"revertible"`
+	State               JobState              `json:"state"`
+	RowCount            int64                 `json:"row_count"`
+	Warning             *terror.Error         `json:"warning"`
+	CtxVars             []any                 `json:"-"`
+	SchemaVer           int64                 `json:"schema_version"`
+	ReorgTp             ReorgType             `json:"reorg_tp"`
+	ReorgStage          ReorgStage            `json:"reorg_stage"`
+	NeedAnalyze         bool                  `json:"need_analyze"`
+	AnalyzeState        int8                  `json:"analyze_state"`
+	InvolvingSchemaInfo []InvolvingSchemaInfo `json:"involving_schema_info,omitempty"`
 }
 
 // IsNormal returns true if the sub-job is normally running.
@@ -984,38 +985,39 @@ func (sub *SubJob) ToProxyJob(parentJob *Job, seq int) Job {
 		reorgMeta.AnalyzeState = sub.AnalyzeState
 	}
 	return Job{
-		Version:         parentJob.Version,
-		ID:              parentJob.ID,
-		Type:            sub.Type,
-		SchemaID:        parentJob.SchemaID,
-		TableID:         parentJob.TableID,
-		SchemaName:      parentJob.SchemaName,
-		State:           sub.State,
-		Warning:         sub.Warning,
-		Error:           nil,
-		ErrorCount:      0,
-		RowCount:        sub.RowCount,
-		Mu:              sync.Mutex{},
-		CtxVars:         sub.CtxVars,
-		args:            sub.args,
-		RawArgs:         sub.RawArgs,
-		SchemaState:     sub.SchemaState,
-		SnapshotVer:     sub.SnapshotVer,
-		RealStartTS:     sub.RealStartTS,
-		StartTS:         parentJob.StartTS,
-		DependencyID:    parentJob.DependencyID,
-		Query:           parentJob.Query,
-		BinlogInfo:      parentJob.BinlogInfo,
-		ReorgMeta:       reorgMeta,
-		MultiSchemaInfo: &MultiSchemaInfo{Revertible: sub.Revertible, Seq: int32(seq), NeedAnalyze: sub.NeedAnalyze},
-		Priority:        parentJob.Priority,
-		SeqNum:          parentJob.SeqNum,
-		Charset:         parentJob.Charset,
-		Collate:         parentJob.Collate,
-		AdminOperator:   parentJob.AdminOperator,
-		TraceInfo:       parentJob.TraceInfo,
-		SQLMode:         parentJob.SQLMode,
-		SessionVars:     parentJob.SessionVars,
+		Version:             parentJob.Version,
+		ID:                  parentJob.ID,
+		Type:                sub.Type,
+		SchemaID:            parentJob.SchemaID,
+		TableID:             parentJob.TableID,
+		SchemaName:          parentJob.SchemaName,
+		State:               sub.State,
+		Warning:             sub.Warning,
+		Error:               nil,
+		ErrorCount:          0,
+		RowCount:            sub.RowCount,
+		Mu:                  sync.Mutex{},
+		CtxVars:             sub.CtxVars,
+		args:                sub.args,
+		RawArgs:             sub.RawArgs,
+		SchemaState:         sub.SchemaState,
+		SnapshotVer:         sub.SnapshotVer,
+		RealStartTS:         sub.RealStartTS,
+		StartTS:             parentJob.StartTS,
+		DependencyID:        parentJob.DependencyID,
+		Query:               parentJob.Query,
+		BinlogInfo:          parentJob.BinlogInfo,
+		ReorgMeta:           reorgMeta,
+		MultiSchemaInfo:     &MultiSchemaInfo{Revertible: sub.Revertible, Seq: int32(seq), NeedAnalyze: sub.NeedAnalyze},
+		Priority:            parentJob.Priority,
+		SeqNum:              parentJob.SeqNum,
+		Charset:             parentJob.Charset,
+		Collate:             parentJob.Collate,
+		AdminOperator:       parentJob.AdminOperator,
+		TraceInfo:           parentJob.TraceInfo,
+		SQLMode:             parentJob.SQLMode,
+		SessionVars:         parentJob.SessionVars,
+		InvolvingSchemaInfo: sub.InvolvingSchemaInfo,
 	}
 }
 
@@ -1030,6 +1032,7 @@ func (sub *SubJob) FromProxyJob(proxyJob *Job, ver int64) {
 	sub.Warning = proxyJob.Warning
 	sub.RowCount = proxyJob.RowCount
 	sub.SchemaVer = ver
+	sub.InvolvingSchemaInfo = proxyJob.InvolvingSchemaInfo
 	if proxyJob.ReorgMeta != nil {
 		sub.ReorgTp = proxyJob.ReorgMeta.ReorgTp
 		sub.ReorgStage = proxyJob.ReorgMeta.Stage
@@ -1077,6 +1080,8 @@ type MultiSchemaInfo struct {
 
 	RelativeColumns []model.CIStr `json:"-"`
 	PositionColumns []model.CIStr `json:"-"`
+
+	InvolvingSchemaInfo []InvolvingSchemaInfo `json:"-"`
 }
 
 // AddForeignKeyInfo contains foreign key information.

--- a/pkg/meta/model/job_test.go
+++ b/pkg/meta/model/job_test.go
@@ -328,7 +328,7 @@ func TestJobSize(t *testing.T) {
 - SubJob.ToProxyJob()
 `
 	require.Equal(t, 408, int(unsafe.Sizeof(Job{})), msg)
-	require.Equal(t, 160, int(unsafe.Sizeof(SubJob{})), msg)
+	require.Equal(t, 184, int(unsafe.Sizeof(SubJob{})), msg)
 }
 
 func TestBackfillMetaCodec(t *testing.T) {

--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -2032,13 +2032,15 @@ type AlterMaterializedViewLogAction struct {
 	node
 	Tp    AlterMaterializedViewLogActionType
 	Purge *MLogPurgeClause
+	// Cols contains the base-table column names involved in an ADD COLUMN action.
+	Cols []model.CIStr
 }
 
 type AlterMaterializedViewLogActionType int
 
 const (
-	// TODO: support column-level ALTER MATERIALIZED VIEW LOG actions.
 	AlterMaterializedViewLogActionPurge AlterMaterializedViewLogActionType = iota
+	AlterMaterializedViewLogActionAddColumn
 )
 
 // Restore implements Node interface.
@@ -2049,6 +2051,17 @@ func (n *AlterMaterializedViewLogAction) Restore(ctx *format.RestoreCtx) error {
 			return nil
 		}
 		return n.Purge.Restore(ctx)
+	case AlterMaterializedViewLogActionAddColumn:
+		ctx.WriteKeyWord("ADD COLUMN ")
+		ctx.WritePlain("(")
+		for i, col := range n.Cols {
+			if i > 0 {
+				ctx.WritePlain(", ")
+			}
+			ctx.WriteName(col.O)
+		}
+		ctx.WritePlain(")")
+		return nil
 	default:
 		return nil
 	}

--- a/pkg/parser/ast/ddl_test.go
+++ b/pkg/parser/ast/ddl_test.go
@@ -49,6 +49,8 @@ func TestDDLVisitorCover(t *testing.T) {
 		{&CreateMaterializedViewLogStmt{Table: &TableName{}, Purge: &MLogPurgeClause{Immediate: true}}, 0, 0},
 		{&AlterMaterializedViewStmt{ViewName: &TableName{}, Actions: []*AlterMaterializedViewAction{{Tp: AlterMaterializedViewActionComment}}}, 0, 0},
 		{&AlterMaterializedViewLogStmt{Table: &TableName{}, Actions: []*AlterMaterializedViewLogAction{{Tp: AlterMaterializedViewLogActionPurge, Purge: &MLogPurgeClause{Immediate: true}}}}, 0, 0},
+		// Covers AST visitor traversal for ALTER MATERIALIZED VIEW LOG ADD COLUMN.
+		{&AlterMaterializedViewLogStmt{Table: &TableName{}, Actions: []*AlterMaterializedViewLogAction{{Tp: AlterMaterializedViewLogActionAddColumn}}}, 0, 0},
 		{&DropMaterializedViewStmt{ViewName: &TableName{}}, 0, 0},
 		{&DropMaterializedViewLogStmt{Table: &TableName{}}, 0, 0},
 		{&AlterTableSpec{}, 0, 0},

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -5571,6 +5571,10 @@ AlterMaterializedViewLogAction:
 	{
 		$$ = &ast.AlterMaterializedViewLogAction{Tp: ast.AlterMaterializedViewLogActionPurge, Purge: $1.(*ast.MLogPurgeClause)}
 	}
+|	"ADD" ColumnKeywordOpt '(' ColumnList ')'
+	{
+		$$ = &ast.AlterMaterializedViewLogAction{Tp: ast.AlterMaterializedViewLogActionAddColumn, Cols: $4.([]model.CIStr)}
+	}
 
 DropMaterializedViewStmt:
 	"DROP" "MATERIALIZED" "VIEW" TableName

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1296,6 +1296,8 @@ func TestDBAStmt(t *testing.T) {
 		// for show create materialized view log
 		{"show create materialized view log on test.t", true, "SHOW CREATE MATERIALIZED VIEW LOG ON `test`.`t`"},
 		{"show create materialized view log on t", true, "SHOW CREATE MATERIALIZED VIEW LOG ON `t`"},
+		// Covers parsing and restoring ALTER MATERIALIZED VIEW LOG ADD COLUMN.
+		{"alter materialized view log on test.t add column (a, b)", true, "ALTER MATERIALIZED VIEW LOG ON `test`.`t` ADD COLUMN (`a`, `b`)"},
 		// for show materialized views
 		{"show materialized views", true, "SHOW MATERIALIZED VIEWS"},
 		{"show materialized views from test", true, "SHOW MATERIALIZED VIEWS IN `test`"},

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -6286,13 +6286,20 @@ func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (base.Plan
 			return nil, plannererrors.ErrNoDB
 		}
 		mlogName := b.materializedViewLogNameForBaseTable(ctx, dbName, v.Table.Name)
-		// TODO: add action-specific privilege checks for ALTER MATERIALIZED VIEW LOG
-		// (for example base-table SELECT for future column-level actions).
+		var selectAuthErr error
 		if b.ctx.GetSessionVars().User != nil {
+			selectAuthErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SELECT", b.ctx.GetSessionVars().User.AuthUsername,
+				b.ctx.GetSessionVars().User.AuthHostname, v.Table.Name.L)
 			authErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("ALTER", b.ctx.GetSessionVars().User.AuthUsername,
 				b.ctx.GetSessionVars().User.AuthHostname, mlogName.L)
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.AlterPriv, dbName, mlogName.L, "", authErr)
+		for _, action := range v.Actions {
+			if action.Tp == ast.AlterMaterializedViewLogActionAddColumn {
+				b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, dbName, v.Table.Name.L, "", selectAuthErr)
+				break
+			}
+		}
 	case *ast.OptimizeTableStmt:
 		return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStack("OPTIMIZE TABLE is not supported")
 	}

--- a/pkg/table/tables/mview_log.go
+++ b/pkg/table/tables/mview_log.go
@@ -61,7 +61,12 @@ const (
 )
 
 func validateMLogMetaColumn(mlogMeta *model.TableInfo) error {
-	cols := mlogMeta.Columns
+	cols := make([]*model.ColumnInfo, 0, len(mlogMeta.Columns))
+	for _, col := range mlogMeta.Columns {
+		if col.State == model.StatePublic {
+			cols = append(cols, col)
+		}
+	}
 	trackedCols := mlogMeta.MaterializedViewLog.Columns
 	expectedLen := len(trackedCols) + 2
 	if len(cols) != expectedLen {

--- a/tests/integrationtest/r/executor/mview_log_dml.result
+++ b/tests/integrationtest/r/executor/mview_log_dml.result
@@ -26,8 +26,8 @@ delete from t where id=1;
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 id	uk	v	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 1	10	101	D	-1
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (id int primary key, uk int unique, v int);
 insert into t values (1,10,100), (2,20,200);
 create materialized view log on t (id, uk, v);
@@ -37,8 +37,8 @@ id	uk	v	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 1	10	100	U	-1
 1	20	999	U	1
 2	20	200	U	-1
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (id int primary key, uk int unique, v int);
 insert into t values (1,10,100);
 create materialized view log on t (id, uk, v);
@@ -50,8 +50,8 @@ id	uk	v
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 id	uk	v	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 3	30	333	I	1
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (id int primary key, v int);
 insert into t values (1, 100);
 create materialized view log on t (id, v);
@@ -60,8 +60,8 @@ select id, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, v,
 id	v	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 1	100	U	-1
 2	100	U	1
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (id int primary key, uk int unique, v int);
 insert into t values (1, 10, 100);
 create materialized view log on t (id, uk, v);
@@ -80,8 +80,8 @@ select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id
 id	uk	v	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 1	10	101	U	-1
 3	10	200	U	1
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (id int primary key, tracked int, untracked int);
 create materialized view log on t (id, tracked);
 insert into t values (1, 10, 100);
@@ -103,8 +103,8 @@ id	tracked	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 1	10	U	-1
 1	11	U	1
 2	20	I	1
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (id int primary key, tracked int, untracked int);
 create materialized view log on t (id, tracked);
 alter table t drop column tracked;
@@ -118,7 +118,8 @@ id	tracked	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 1	10	U	-1
 1	11	D	-1
 1	11	U	1
-drop table if exists t, `$mlog$t`;
+drop materialized view log on t;
+drop table if exists t;
 create table t(a int);
 create materialized view log on t (a);
 insert into t values (1);
@@ -142,8 +143,8 @@ _tidb_rowid	a	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
 3	2	U	1
 4	2	I	1
 5	3	I	1
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int);
 create materialized view log on t (a, b);
 insert into `$mlog$t` values (1, 2, 'I', 1);
@@ -164,8 +165,8 @@ delete from `$mlog$t` where _tidb_rowid in (1, 2);
 Error 1288 (HY000): The target table $mlog$t of the DELETE is not updatable
 select * from `$mlog$t`;
 a	b	_MLOG$_DML_TYPE	_MLOG$_OLD_NEW
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int not null);
 create materialized view log on t (a, b);
 create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
@@ -186,8 +187,8 @@ Error 1288 (HY000): The target table v of the UPDATE is not updatable
 delete from v where a in (1, 2);
 Error 1288 (HY000): The target table v of the DELETE is not updatable
 drop materialized view v;
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int);
 create materialized view log on t (a, b);
 prepare stmt_ins from 'insert into `$mlog$t` values (?, ?, ?, ?)';
@@ -196,8 +197,8 @@ prepare stmt_upd from 'update `$mlog$t` set a=?';
 Error 1288 (HY000): The target table $mlog$t of the UPDATE is not updatable
 prepare stmt_del from 'delete from `$mlog$t` where a=?';
 Error 1288 (HY000): The target table $mlog$t of the DELETE is not updatable
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int not null);
 create materialized view log on t (a, b);
 create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
@@ -208,32 +209,33 @@ Error 1288 (HY000): The target table v of the UPDATE is not updatable
 prepare stmt_del from 'delete from v where a=?';
 Error 1288 (HY000): The target table v of the DELETE is not updatable
 drop materialized view v;
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int);
 create materialized view log on t (a, b);
 load data local infile '/nonexistent.csv' into table `$mlog$t` fields terminated by ',';
 Error 1288 (HY000): The target table $mlog$t of the LOAD is not updatable
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int not null);
 create materialized view log on t (a, b);
 create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
 load data local infile '/nonexistent.csv' into table v fields terminated by ',';
 Error 1288 (HY000): The target table v of the LOAD is not updatable
 drop materialized view v;
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int);
 create materialized view log on t (a, b);
 import into `$mlog$t` from '/nonexistent.csv';
 Error 1288 (HY000): The target table $mlog$t of the IMPORT is not updatable
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int not null);
 create materialized view log on t (a, b);
 create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
 import into v from '/nonexistent.csv';
 Error 1288 (HY000): The target table v of the IMPORT is not updatable
 drop materialized view v;
-drop table if exists t, `$mlog$t`;
+drop materialized view log on t;
+drop table if exists t;

--- a/tests/integrationtest/r/expression/issues.result
+++ b/tests/integrationtest/r/expression/issues.result
@@ -3170,15 +3170,15 @@ set sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DAT
 insert into table_20220419(lastLoginDate) select lastLoginDate from table_20220419;
 Error 1292 (22007): Incorrect datetime value: '0000-00-00 00:00:00'
 set sql_mode=default;
-drop table if exists test.t;
-create table test.t (a varchar(10), b tinyint(1));
-insert into test.t values ("abc", 1);
-select * from test.t where (a, b) in (('a', 1), (null, 0));
+drop table if exists test.t_issue49015;
+create table test.t_issue49015 (a varchar(10), b tinyint(1));
+insert into test.t_issue49015 values ("abc", 1);
+select * from test.t_issue49015 where (a, b) in (('a', 1), (null, 0));
 a	b
-update test.t set b = 0 where (a, b) in (('a', 1), (null, 0));
+update test.t_issue49015 set b = 0 where (a, b) in (('a', 1), (null, 0));
 SHOW WARNINGS;
 Level	Code	Message
-drop table if exists test.t;
+drop table if exists test.t_issue49015;
 create table if not exists test.ast (i varchar(20));
 create table if not exists test.acc (j varchar(20), k varchar(20), l varchar(20), m varchar(20));
 explain format='brief' with t as(select i, (case when b.j = '20001' then b.l else b.k end) an from test.ast a inner join test.acc b on (a.i = b.m) and a.i = 'astp2019121731703151'), t1 as (select i, group_concat(an order by an separator '; ') an from t group by i) select * from t1;
@@ -3193,18 +3193,18 @@ Projection	8.00	root		test.ast.i, Column#38
       └─TableReader(Probe)	10.00	root		data:Selection
         └─Selection	10.00	cop[tikv]		eq("astp2019121731703151", test.acc.m)
           └─TableFullScan	10000.00	cop[tikv]	table:b	keep order:false, stats:pseudo
-drop table if exists test.t;
-create table test.t (a int);
-insert into test.t values(0),(20015),(20100);
-select date_add(a, interval 12345 DAY_HOUR) from test.t;
+drop table if exists test.t_issue56460;
+create table test.t_issue56460 (a int);
+insert into test.t_issue56460 values(0),(20015),(20100);
+select date_add(a, interval 12345 DAY_HOUR) from test.t_issue56460;
 date_add(a, interval 12345 DAY_HOUR)
 NULL
 NULL
 NULL
-drop table if exists test.t;
-create table test.t(f1 char(1));
-insert into test.t values ('a'),('b'),('1');
-select (cast(f1 as float) = 1) or (cast(f1 as float) = 2) from test.t;
+drop table if exists test.t_issue56460;
+create table test.t_issue56481(f1 char(1));
+insert into test.t_issue56481 values ('a'),('b'),('1');
+select (cast(f1 as float) = 1) or (cast(f1 as float) = 2) from test.t_issue56481;
 (cast(f1 as float) = 1) or (cast(f1 as float) = 2)
 0
 0
@@ -3215,7 +3215,7 @@ Warning	1292	Truncated incorrect DOUBLE value: 'a'
 Warning	1292	Truncated incorrect DOUBLE value: 'a'
 Warning	1292	Truncated incorrect DOUBLE value: 'b'
 Warning	1292	Truncated incorrect DOUBLE value: 'b'
-select (cast(f1 as float) != 1) and (cast(f1 as float) != 2) from test.t;
+select (cast(f1 as float) != 1) and (cast(f1 as float) != 2) from test.t_issue56481;
 (cast(f1 as float) != 1) and (cast(f1 as float) != 2)
 1
 1
@@ -3226,10 +3226,10 @@ Warning	1292	Truncated incorrect DOUBLE value: 'a'
 Warning	1292	Truncated incorrect DOUBLE value: 'a'
 Warning	1292	Truncated incorrect DOUBLE value: 'b'
 Warning	1292	Truncated incorrect DOUBLE value: 'b'
-DROP TABLE IF EXISTS test.t;
-CREATE TABLE test.t (id bigint(11) UNSIGNED PRIMARY KEY);
-INSERT INTO test.t VALUES (1234567890123456);
-SELECT IFNULL(id, 'abcdef') FROM test.t;
+DROP TABLE IF EXISTS test.t_issue56481;
+CREATE TABLE test.t_issue56462 (id bigint(11) UNSIGNED PRIMARY KEY);
+INSERT INTO test.t_issue56462 VALUES (1234567890123456);
+SELECT IFNULL(id, 'abcdef') FROM test.t_issue56462;
 IFNULL(id, 'abcdef')
 1234567890123456
 drop table if exists lrr_test;
@@ -3242,14 +3242,14 @@ execute stmt using @a,@b;
 COL1	COL3	COL1	COL3
 -2	2295421130981788987	-2	2295421130981788987
 use test;
-drop table if exists t;
-create table t(a int);
-insert into t values (1), (2), (3), (4), (5);
-explain format=brief select * from t where a in (1, 1, 1, 1, 1, 2);
+drop table if exists t_issue61246;
+create table t_issue61246(a int);
+insert into t_issue61246 values (1), (2), (3), (4), (5);
+explain format=brief select * from t_issue61246 where a in (1, 1, 1, 1, 1, 2);
 id	estRows	task	access object	operator info
 TableReader	20.00	root		data:Selection
-└─Selection	20.00	cop[tikv]		in(test.t.a, 1, 2)
-  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─Selection	20.00	cop[tikv]		in(test.t_issue61246.a, 1, 2)
+  └─TableFullScan	10000.00	cop[tikv]	table:t_issue61246	keep order:false, stats:pseudo
 create table t_str(s varchar(10));
 insert into t_str values ('test');
 explain format=brief select * from t_str where s in ('a', 'a', 'a', 'b', 'a');
@@ -3264,11 +3264,11 @@ id	estRows	task	access object	operator info
 TableReader	20.00	root		data:Selection
 └─Selection	20.00	cop[tikv]		in(test.t_dec.d, 1.5, 2.5)
   └─TableFullScan	10000.00	cop[tikv]	table:t_dec	keep order:false, stats:pseudo
-explain format=brief select * from t where a in (1, NULL, NULL, NULL, 2);
+explain format=brief select * from t_issue61246 where a in (1, NULL, NULL, NULL, 2);
 id	estRows	task	access object	operator info
 TableReader	20.00	root		data:Selection
-└─Selection	20.00	cop[tikv]		in(test.t.a, 1, NULL, 2)
-  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─Selection	20.00	cop[tikv]		in(test.t_issue61246.a, 1, NULL, 2)
+  └─TableFullScan	10000.00	cop[tikv]	table:t_issue61246	keep order:false, stats:pseudo
 create table t_date(dt date);
 insert into t_date values ('2023-01-01'), ('2023-01-02');
 explain format=brief select * from t_date where dt in
@@ -3277,7 +3277,7 @@ id	estRows	task	access object	operator info
 TableReader	20.00	root		data:Selection
 └─Selection	20.00	cop[tikv]		in(test.t_date.dt, 2023-01-01 00:00:00.000000, 2023-01-02 00:00:00.000000)
   └─TableFullScan	10000.00	cop[tikv]	table:t_date	keep order:false, stats:pseudo
-select * from t where a in (1, 1, 1, 1, 2);
+select * from t_issue61246 where a in (1, 1, 1, 1, 2);
 a
 1
 2
@@ -3287,7 +3287,7 @@ select * from t_dec where d in (1.5, 1.5, 2.5, 1.5);
 d
 1.50
 2.50
-select * from t where a in (1, NULL, NULL, NULL, 2);
+select * from t_issue61246 where a in (1, NULL, NULL, NULL, 2);
 a
 1
 2

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -759,21 +759,21 @@ KEY `idx_65` (`col_36`(5))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 with cte_192 ( col_1101,col_1102,col_1103,col_1104 ) AS ( select  /*+ use_index_merge( tl6e913fb9 ) */   replace( tl6e913fb9.col_36 , tl6e913fb9.col_36 , tl6e913fb9.col_36 ) as r0 , space( 0 ) as r1 , min( distinct  tl6e913fb9.col_36 ) as r2 , count( distinct  tl6e913fb9.col_36 ) as r3 from tl6e913fb9 where tl6e913fb9.col_36 between 'n92ok$B%W#UU%O' and '()c=KVQ=T%-vzGJ' and tl6e913fb9.col_36 in ( 'T+kf' ,'Lvluod2H' ,'3#Omx@pC^fFkeH' ,'=b$z' ) group by tl6e913fb9.col_36  having tl6e913fb9.col_36 = 'xjV@' or IsNull( tl6e913fb9.col_36 ) ) ( select 1,col_1101,col_1102,col_1103,col_1104 from cte_192 where not( IsNull( cte_192.col_1102 ) ) order by 1,2,3,4,5 limit 72850972 );
 1	col_1101	col_1102	col_1103	col_1104
-drop table if exists t;
-create table t(a int, primary key (a));
-insert into t values(1), (2);
-select * from t t1 left join t t2 on t1.a=t2.a limit 1, 1;
+drop table if exists t_issue59926;
+create table t_issue59926(a int, primary key (a));
+insert into t_issue59926 values(1), (2);
+select * from t_issue59926 t1 left join t_issue59926 t2 on t1.a=t2.a limit 1, 1;
 a	a
 2	2
-explain select * from t t1 left join t t2 on t1.a=t2.a limit 1, 1;
+explain select * from t_issue59926 t1 left join t_issue59926 t2 on t1.a=t2.a limit 1, 1;
 id	estRows	task	access object	operator info
-IndexJoin_15	1.25	root		left outer join, inner:TableReader_12, outer key:test.t.a, inner key:test.t.a, equal cond:eq(test.t.a, test.t.a)
+IndexJoin_15	1.25	root		left outer join, inner:TableReader_12, outer key:test.t_issue59926.a, inner key:test.t_issue59926.a, equal cond:eq(test.t_issue59926.a, test.t_issue59926.a)
 ├─Limit_22(Build)	1.00	root		offset:1, count:1
 │ └─TableReader_26	2.00	root		data:Limit_25
 │   └─Limit_25	2.00	cop[tikv]		offset:0, count:2
 │     └─TableFullScan_24	2.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 └─TableReader_12(Probe)	1.00	root		data:TableRangeScan_11
-  └─TableRangeScan_11	1.00	cop[tikv]	table:t2	range: decided by [test.t.a], keep order:false, stats:pseudo
+  └─TableRangeScan_11	1.00	cop[tikv]	table:t2	range: decided by [test.t_issue59926.a], keep order:false, stats:pseudo
 drop table if exists t1, t2;
 create table t1(a int, b int, index idx(a, b));
 create table t2(a int, b int, index idx(a));
@@ -797,113 +797,113 @@ MergeJoin_8	12475.01	root		inner join, left key:test.t1.a, test.t1.b, right key:
 └─IndexReader_39(Probe)	9980.01	root		index:Selection_38
   └─Selection_38	9980.01	cop[tikv]		not(isnull(test.t1.b))
     └─IndexFullScan_37	9990.00	cop[tikv]	table:t1, index:idx(a, b)	keep order:true, stats:pseudo
-drop table if exists t, t1;
-create table t(a int);
+drop table if exists t_issue59926, t1;
+create table t_issue59762(a int);
 create table t1(a int primary key, b int, index idx(b));
-insert into t values(1), (2), (123);
+insert into t_issue59762 values(1), (2), (123);
 insert into t1 values(2, 123), (123, 2);
 set tidb_opt_fix_control='44855:on';
-explain select /*+ inl_join(t1), use_index(t1, idx) */ * from t join t1 on t.a = t1.a and t1.b = 123;
+explain select /*+ inl_join(t1), use_index(t1, idx) */ * from t_issue59762 join t1 on t_issue59762.a = t1.a and t1.b = 123;
 id	estRows	task	access object	operator info
-Projection_9	12.50	root		test.t.a, test.t1.a, test.t1.b
-└─IndexJoin_12	12.50	root		inner join, inner:IndexReader_11, outer key:test.t.a, inner key:test.t1.a, equal cond:eq(test.t.a, test.t1.a)
+Projection_9	12.50	root		test.t_issue59762.a, test.t1.a, test.t1.b
+└─IndexJoin_12	12.50	root		inner join, inner:IndexReader_11, outer key:test.t_issue59762.a, inner key:test.t1.a, equal cond:eq(test.t_issue59762.a, test.t1.a)
   ├─TableReader_20(Build)	9990.00	root		data:Selection_19
-  │ └─Selection_19	9990.00	cop[tikv]		not(isnull(test.t.a))
-  │   └─TableFullScan_18	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  │ └─Selection_19	9990.00	cop[tikv]		not(isnull(test.t_issue59762.a))
+  │   └─TableFullScan_18	10000.00	cop[tikv]	table:t_issue59762	keep order:false, stats:pseudo
   └─IndexReader_11(Probe)	12.50	root		index:IndexRangeScan_10
-    └─IndexRangeScan_10	12.50	cop[tikv]	table:t1, index:idx(b)	range: decided by [eq(test.t1.a, test.t.a) eq(test.t1.b, 123)], keep order:false, stats:pseudo
-select /*+ inl_join(t1), use_index(t1, idx) */ * from t join t1 on t.a = t1.a and t1.b = 123;
+    └─IndexRangeScan_10	12.50	cop[tikv]	table:t1, index:idx(b)	range: decided by [eq(test.t1.a, test.t_issue59762.a) eq(test.t1.b, 123)], keep order:false, stats:pseudo
+select /*+ inl_join(t1), use_index(t1, idx) */ * from t_issue59762 join t1 on t_issue59762.a = t1.a and t1.b = 123;
 a	a	b
 2	2	123
-drop table if exists t;
-create table t (id int unique key, c int);
-insert into t values (1, 10);
-insert into t values (2, 20);
-insert into t values (3, 30);
-select _tidb_rowid from t where id in (1, 2, 3);
+drop table if exists t_issue59762;
+create table t_issue58581 (id int unique key, c int);
+insert into t_issue58581 values (1, 10);
+insert into t_issue58581 values (2, 20);
+insert into t_issue58581 values (3, 30);
+select _tidb_rowid from t_issue58581 where id in (1, 2, 3);
 _tidb_rowid
 1
 2
 3
-drop table if exists t;
-create table t(a int, b int, c int, primary key(a,b), key ib(b));
-explain format = brief select * from t use index (ib) where a = 1 and b = 1;
+drop table if exists t_issue58581;
+create table t_issue59427(a int, b int, c int, primary key(a,b), key ib(b));
+explain format = brief select * from t_issue59427 use index (ib) where a = 1 and b = 1;
 id	estRows	task	access object	operator info
 IndexLookUp	1.00	root		
-├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
-└─Selection(Probe)	1.00	cop[tikv]		eq(test.t.a, 1)
-  └─TableRowIDScan	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-explain format = brief select /*+ use_index(t, ib) */ * from t where a = 1 and b = 1;
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t_issue59427, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
+└─Selection(Probe)	1.00	cop[tikv]		eq(test.t_issue59427.a, 1)
+  └─TableRowIDScan	10.00	cop[tikv]	table:t_issue59427	keep order:false, stats:pseudo
+explain format = brief select /*+ use_index(t_issue59427, ib) */ * from t_issue59427 where a = 1 and b = 1;
 id	estRows	task	access object	operator info
 IndexLookUp	1.00	root		
-├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
-└─Selection(Probe)	1.00	cop[tikv]		eq(test.t.a, 1)
-  └─TableRowIDScan	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-explain format = brief select * from t as tt use index (ib) where a = 1 and b = 1;
-id	estRows	task	access object	operator info
-IndexLookUp	1.00	root		
-├─IndexRangeScan(Build)	10.00	cop[tikv]	table:tt, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
-└─Selection(Probe)	1.00	cop[tikv]		eq(test.t.a, 1)
-  └─TableRowIDScan	10.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
-explain format = brief select /*+ use_index(tt, ib) */ * from t as tt where a = 1 and b = 1;
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t_issue59427, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
+└─Selection(Probe)	1.00	cop[tikv]		eq(test.t_issue59427.a, 1)
+  └─TableRowIDScan	10.00	cop[tikv]	table:t_issue59427	keep order:false, stats:pseudo
+explain format = brief select * from t_issue59427 as tt use index (ib) where a = 1 and b = 1;
 id	estRows	task	access object	operator info
 IndexLookUp	1.00	root		
 ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:tt, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
-└─Selection(Probe)	1.00	cop[tikv]		eq(test.t.a, 1)
+└─Selection(Probe)	1.00	cop[tikv]		eq(test.t_issue59427.a, 1)
   └─TableRowIDScan	10.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
-explain format = brief update t use index (ib) set c = 1 where a = 1 and b = 1;
+explain format = brief select /*+ use_index(tt, ib) */ * from t_issue59427 as tt where a = 1 and b = 1;
+id	estRows	task	access object	operator info
+IndexLookUp	1.00	root		
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:tt, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
+└─Selection(Probe)	1.00	cop[tikv]		eq(test.t_issue59427.a, 1)
+  └─TableRowIDScan	10.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+explain format = brief update t_issue59427 use index (ib) set c = 1 where a = 1 and b = 1;
 id	estRows	task	access object	operator info
 Update	N/A	root		N/A
 └─IndexLookUp	1.00	root		
-  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
-  └─Selection(Probe)	1.00	cop[tikv]		eq(test.t.a, 1)
-    └─TableRowIDScan	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-explain format = brief update /*+ use_index(t, ib) */ t set c = 1 where a = 1 and b = 1;
+  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t_issue59427, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
+  └─Selection(Probe)	1.00	cop[tikv]		eq(test.t_issue59427.a, 1)
+    └─TableRowIDScan	10.00	cop[tikv]	table:t_issue59427	keep order:false, stats:pseudo
+explain format = brief update /*+ use_index(t_issue59427, ib) */ t_issue59427 set c = 1 where a = 1 and b = 1;
 id	estRows	task	access object	operator info
 Update	N/A	root		N/A
 └─IndexLookUp	1.00	root		
-  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
-  └─Selection(Probe)	1.00	cop[tikv]		eq(test.t.a, 1)
-    └─TableRowIDScan	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-explain format = brief delete from t use index (ib) where a = 1 and b = 1;
+  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t_issue59427, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
+  └─Selection(Probe)	1.00	cop[tikv]		eq(test.t_issue59427.a, 1)
+    └─TableRowIDScan	10.00	cop[tikv]	table:t_issue59427	keep order:false, stats:pseudo
+explain format = brief delete from t_issue59427 use index (ib) where a = 1 and b = 1;
 id	estRows	task	access object	operator info
 Delete	N/A	root		N/A
 └─IndexLookUp	1.00	root		
-  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
-  └─Selection(Probe)	1.00	cop[tikv]		eq(test.t.a, 1)
-    └─TableRowIDScan	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-explain format = brief delete /*+ use_index(t, ib) */ from t where a = 1 and b = 1;
+  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t_issue59427, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
+  └─Selection(Probe)	1.00	cop[tikv]		eq(test.t_issue59427.a, 1)
+    └─TableRowIDScan	10.00	cop[tikv]	table:t_issue59427	keep order:false, stats:pseudo
+explain format = brief delete /*+ use_index(t_issue59427, ib) */ from t_issue59427 where a = 1 and b = 1;
 id	estRows	task	access object	operator info
 Delete	N/A	root		N/A
 └─IndexLookUp	1.00	root		
-  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
-  └─Selection(Probe)	1.00	cop[tikv]		eq(test.t.a, 1)
-    └─TableRowIDScan	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t_issue59427, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
+  └─Selection(Probe)	1.00	cop[tikv]		eq(test.t_issue59427.a, 1)
+    └─TableRowIDScan	10.00	cop[tikv]	table:t_issue59427	keep order:false, stats:pseudo
 create database if not exists test_59427;
-create table test_59427.t(a int, b int, c int, primary key(a,b), key ib(b));
-explain format = brief select * from test_59427.t use index (ib) where a = 1 and b = 1;
+create table test_59427.t_issue59427(a int, b int, c int, primary key(a,b), key ib(b));
+explain format = brief select * from test_59427.t_issue59427 use index (ib) where a = 1 and b = 1;
 id	estRows	task	access object	operator info
 IndexLookUp	1.00	root		
-├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
-└─Selection(Probe)	1.00	cop[tikv]		eq(test_59427.t.a, 1)
-  └─TableRowIDScan	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-explain format = brief select /*+ use_index(test_59427.t, ib) */ * from test_59427.t where a = 1 and b = 1;
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t_issue59427, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
+└─Selection(Probe)	1.00	cop[tikv]		eq(test_59427.t_issue59427.a, 1)
+  └─TableRowIDScan	10.00	cop[tikv]	table:t_issue59427	keep order:false, stats:pseudo
+explain format = brief select /*+ use_index(test_59427.t_issue59427, ib) */ * from test_59427.t_issue59427 where a = 1 and b = 1;
 id	estRows	task	access object	operator info
 IndexLookUp	1.00	root		
-├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
-└─Selection(Probe)	1.00	cop[tikv]		eq(test_59427.t.a, 1)
-  └─TableRowIDScan	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-explain format = brief select * from test_59427.t as tt use index (ib) where a = 1 and b = 1;
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t_issue59427, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
+└─Selection(Probe)	1.00	cop[tikv]		eq(test_59427.t_issue59427.a, 1)
+  └─TableRowIDScan	10.00	cop[tikv]	table:t_issue59427	keep order:false, stats:pseudo
+explain format = brief select * from test_59427.t_issue59427 as tt use index (ib) where a = 1 and b = 1;
 id	estRows	task	access object	operator info
 IndexLookUp	1.00	root		
 ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:tt, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
-└─Selection(Probe)	1.00	cop[tikv]		eq(test_59427.t.a, 1)
+└─Selection(Probe)	1.00	cop[tikv]		eq(test_59427.t_issue59427.a, 1)
   └─TableRowIDScan	10.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
-explain format = brief select /*+ use_index(test_59427.tt, ib) */ * from test_59427.t as tt where a = 1 and b = 1;
+explain format = brief select /*+ use_index(test_59427.tt, ib) */ * from test_59427.t_issue59427 as tt where a = 1 and b = 1;
 id	estRows	task	access object	operator info
 IndexLookUp	1.00	root		
 ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:tt, index:ib(b)	range:[1,1], keep order:false, stats:pseudo
-└─Selection(Probe)	1.00	cop[tikv]		eq(test_59427.t.a, 1)
+└─Selection(Probe)	1.00	cop[tikv]		eq(test_59427.t_issue59427.a, 1)
   └─TableRowIDScan	10.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
 drop database if exists test_59427;
 drop table if exists t1,t2,t3,t4,t5;

--- a/tests/integrationtest/t/executor/mview_log_dml.test
+++ b/tests/integrationtest/t/executor/mview_log_dml.test
@@ -27,8 +27,8 @@ delete from t where id=1;
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 
 # REPLACE
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (id int primary key, uk int unique, v int);
 insert into t values (1,10,100), (2,20,200);
 create materialized view log on t (id, uk, v);
@@ -37,8 +37,8 @@ replace into t values (1,20,999);
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 
 # LOAD DATA
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (id int primary key, uk int unique, v int);
 insert into t values (1,10,100);
 create materialized view log on t (id, uk, v);
@@ -48,8 +48,8 @@ select id, uk, v from t order by id;
 select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 
 # Handle-changed UPDATE (primary key change)
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (id int primary key, v int);
 insert into t values (1, 100);
 create materialized view log on t (id, v);
@@ -58,8 +58,8 @@ update t set id = 2 where id = 1;
 select id, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 
 # IODKU without primary key change
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (id int primary key, uk int unique, v int);
 insert into t values (1, 10, 100);
 create materialized view log on t (id, uk, v);
@@ -77,8 +77,8 @@ select id, uk, v, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id
 
 # DDL on non-tracked columns keeps mlog usable
 
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (id int primary key, tracked int, untracked int);
 create materialized view log on t (id, tracked);
 insert into t values (1, 10, 100);
@@ -98,8 +98,8 @@ select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by 
 
 # DDL on tracked columns is rejected up-front and mlog remains usable
 
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (id int primary key, tracked int, untracked int);
 create materialized view log on t (id, tracked);
 --error 8200
@@ -110,7 +110,8 @@ delete from t where id = 1;
 select id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t` order by id, tracked, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW`;
 
 # Test for issue #66245, the mlog table should not use the base table's auto-increment id by mistake.
-drop table if exists t, `$mlog$t`;
+drop materialized view log on t;
+drop table if exists t;
 create table t(a int);
 create materialized view log on t (a);
 insert into t values (1);
@@ -122,8 +123,8 @@ select _tidb_rowid, a from t;
 select _tidb_rowid, a, `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t`;
 
 # Explicit DML on mlog table should be rejected
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int);
 create materialized view log on t (a, b);
 --error 1288
@@ -147,8 +148,8 @@ delete from `$mlog$t` where _tidb_rowid in (1, 2);
 select * from `$mlog$t`;
 
 # Explicit DML on materialized view table should be rejected
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int not null);
 create materialized view log on t (a, b);
 create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
@@ -173,8 +174,8 @@ delete from v where a in (1, 2);
 drop materialized view v;
 
 # Prepared DML on mlog table should be rejected
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int);
 create materialized view log on t (a, b);
 --error 1288
@@ -185,8 +186,8 @@ prepare stmt_upd from 'update `$mlog$t` set a=?';
 prepare stmt_del from 'delete from `$mlog$t` where a=?';
 
 # Prepared DML on materialized view table should be rejected
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int not null);
 create materialized view log on t (a, b);
 create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
@@ -199,16 +200,16 @@ prepare stmt_del from 'delete from v where a=?';
 drop materialized view v;
 
 # LOAD DATA on mlog table should be rejected
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int);
 create materialized view log on t (a, b);
 --error 1288
 load data local infile '/nonexistent.csv' into table `$mlog$t` fields terminated by ',';
 
 # LOAD DATA on materialized view table should be rejected
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int not null);
 create materialized view log on t (a, b);
 create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
@@ -217,16 +218,16 @@ load data local infile '/nonexistent.csv' into table v fields terminated by ',';
 drop materialized view v;
 
 # IMPORT INTO on mlog table should be rejected
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int);
 create materialized view log on t (a, b);
 --error 1288
 import into `$mlog$t` from '/nonexistent.csv';
 
 # IMPORT INTO on materialized view table should be rejected
+drop materialized view log on t;
 drop table if exists t;
-drop table if exists `$mlog$t`;
 create table t (a int primary key, b int not null);
 create materialized view log on t (a, b);
 create materialized view v (a, s, cnt) as select a, sum(b), count(1) from t group by a;
@@ -235,4 +236,5 @@ import into v from '/nonexistent.csv';
 drop materialized view v;
 
 # clean up
-drop table if exists t, `$mlog$t`;
+drop materialized view log on t;
+drop table if exists t;

--- a/tests/integrationtest/t/expression/issues.test
+++ b/tests/integrationtest/t/expression/issues.test
@@ -2149,39 +2149,39 @@ insert into table_20220419(lastLoginDate) select lastLoginDate from table_202204
 set sql_mode=default;
 
 # TestIssue49015
-drop table if exists test.t;
-create table test.t (a varchar(10), b tinyint(1));
-insert into test.t values ("abc", 1);
-select * from test.t where (a, b) in (('a', 1), (null, 0));
-update test.t set b = 0 where (a, b) in (('a', 1), (null, 0));
+drop table if exists test.t_issue49015;
+create table test.t_issue49015 (a varchar(10), b tinyint(1));
+insert into test.t_issue49015 values ("abc", 1);
+select * from test.t_issue49015 where (a, b) in (('a', 1), (null, 0));
+update test.t_issue49015 set b = 0 where (a, b) in (('a', 1), (null, 0));
 SHOW WARNINGS;
 
 # TestIssue49986
-drop table if exists test.t;
+drop table if exists test.t_issue49015;
 create table if not exists test.ast (i varchar(20));
 create table if not exists test.acc (j varchar(20), k varchar(20), l varchar(20), m varchar(20));
 explain format='brief' with t as(select i, (case when b.j = '20001' then b.l else b.k end) an from test.ast a inner join test.acc b on (a.i = b.m) and a.i = 'astp2019121731703151'), t1 as (select i, group_concat(an order by an separator '; ') an from t group by i) select * from t1;
 
 # TestIssue56460
-drop table if exists test.t;
-create table test.t (a int);
-insert into test.t values(0),(20015),(20100);
-select date_add(a, interval 12345 DAY_HOUR) from test.t;
+drop table if exists test.t_issue56460;
+create table test.t_issue56460 (a int);
+insert into test.t_issue56460 values(0),(20015),(20100);
+select date_add(a, interval 12345 DAY_HOUR) from test.t_issue56460;
 
 # TestIssue56481
-drop table if exists test.t;
-create table test.t(f1 char(1));
-insert into test.t values ('a'),('b'),('1');
-select (cast(f1 as float) = 1) or (cast(f1 as float) = 2) from test.t;
+drop table if exists test.t_issue56460;
+create table test.t_issue56481(f1 char(1));
+insert into test.t_issue56481 values ('a'),('b'),('1');
+select (cast(f1 as float) = 1) or (cast(f1 as float) = 2) from test.t_issue56481;
 SHOW WARNINGS;
-select (cast(f1 as float) != 1) and (cast(f1 as float) != 2) from test.t;
+select (cast(f1 as float) != 1) and (cast(f1 as float) != 2) from test.t_issue56481;
 SHOW WARNINGS;
 
 # TestIssue56462
-DROP TABLE IF EXISTS test.t;
-CREATE TABLE test.t (id bigint(11) UNSIGNED PRIMARY KEY);
-INSERT INTO test.t VALUES (1234567890123456);
-SELECT IFNULL(id, 'abcdef') FROM test.t;
+DROP TABLE IF EXISTS test.t_issue56481;
+CREATE TABLE test.t_issue56462 (id bigint(11) UNSIGNED PRIMARY KEY);
+INSERT INTO test.t_issue56462 VALUES (1234567890123456);
+SELECT IFNULL(id, 'abcdef') FROM test.t_issue56462;
 
 # TestIssue56772
 drop table if exists lrr_test;
@@ -2195,11 +2195,11 @@ execute stmt using @a,@b;
 # TestIssue61246
 # Test for duplicate constant values in IN expressions
 use test;
-drop table if exists t;
-create table t(a int);
-insert into t values (1), (2), (3), (4), (5);
+drop table if exists t_issue61246;
+create table t_issue61246(a int);
+insert into t_issue61246 values (1), (2), (3), (4), (5);
 
-explain format=brief select * from t where a in (1, 1, 1, 1, 1, 2);
+explain format=brief select * from t_issue61246 where a in (1, 1, 1, 1, 1, 2);
 
 create table t_str(s varchar(10));
 insert into t_str values ('test');
@@ -2209,15 +2209,15 @@ create table t_dec(d decimal(10,2));
 insert into t_dec values (1.5), (2.5);
 explain format=brief select * from t_dec where d in (1.5, 1.5, 2.5, 1.5);
 
-explain format=brief select * from t where a in (1, NULL, NULL, NULL, 2);
+explain format=brief select * from t_issue61246 where a in (1, NULL, NULL, NULL, 2);
 
 create table t_date(dt date);
 insert into t_date values ('2023-01-01'), ('2023-01-02');
 explain format=brief select * from t_date where dt in 
   ('2023-01-01', '2023-01-01', '2023-01-02');
 
-select * from t where a in (1, 1, 1, 1, 2);
+select * from t_issue61246 where a in (1, 1, 1, 1, 2);
 select * from t_str where s in ('a', 'a', 'a', 'b', 'a');
 select * from t_dec where d in (1.5, 1.5, 2.5, 1.5);
-select * from t where a in (1, NULL, NULL, NULL, 2);
+select * from t_issue61246 where a in (1, NULL, NULL, NULL, 2);
 select * from t_date where dt in ('2023-01-01', '2023-01-01', '2023-01-02');

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -529,13 +529,13 @@ CREATE TABLE `tl6e913fb9` (
 with cte_192 ( col_1101,col_1102,col_1103,col_1104 ) AS ( select  /*+ use_index_merge( tl6e913fb9 ) */   replace( tl6e913fb9.col_36 , tl6e913fb9.col_36 , tl6e913fb9.col_36 ) as r0 , space( 0 ) as r1 , min( distinct  tl6e913fb9.col_36 ) as r2 , count( distinct  tl6e913fb9.col_36 ) as r3 from tl6e913fb9 where tl6e913fb9.col_36 between 'n92ok$B%W#UU%O' and '()c=KVQ=T%-vzGJ' and tl6e913fb9.col_36 in ( 'T+kf' ,'Lvluod2H' ,'3#Omx@pC^fFkeH' ,'=b$z' ) group by tl6e913fb9.col_36  having tl6e913fb9.col_36 = 'xjV@' or IsNull( tl6e913fb9.col_36 ) ) ( select 1,col_1101,col_1102,col_1103,col_1104 from cte_192 where not( IsNull( cte_192.col_1102 ) ) order by 1,2,3,4,5 limit 72850972 );
 
 # TestIssue59926
-drop table if exists t;
-create table t(a int, primary key (a));
-insert into t values(1), (2);
+drop table if exists t_issue59926;
+create table t_issue59926(a int, primary key (a));
+insert into t_issue59926 values(1), (2);
 # safe to directly compare the output since the data is stored in one region. so the output is ordered in fact
-select * from t t1 left join t t2 on t1.a=t2.a limit 1, 1;
+select * from t_issue59926 t1 left join t_issue59926 t2 on t1.a=t2.a limit 1, 1;
 # the limit is push down across the join node
-explain select * from t t1 left join t t2 on t1.a=t2.a limit 1, 1;
+explain select * from t_issue59926 t1 left join t_issue59926 t2 on t1.a=t2.a limit 1, 1;
 
 # TestIssue20710
 drop table if exists t1, t2;
@@ -545,40 +545,40 @@ explain select /*+ merge_join(t1) */ * from t1 join t2 on t1.a=t2.a and t2.b=t1.
 explain select /*+ no_hash_join(t1), no_index_join(t1,t2), no_index_hash_join(t1,t2) */ * from t1 join t2 on t1.a=t2.a and t2.b=t1.b;
 
 # TestIssue59762
-drop table if exists t, t1;
-create table t(a int);
+drop table if exists t_issue59926, t1;
+create table t_issue59762(a int);
 create table t1(a int primary key, b int, index idx(b));
-insert into t values(1), (2), (123);
+insert into t_issue59762 values(1), (2), (123);
 insert into t1 values(2, 123), (123, 2);
 set tidb_opt_fix_control='44855:on';
-explain select /*+ inl_join(t1), use_index(t1, idx) */ * from t join t1 on t.a = t1.a and t1.b = 123;
-select /*+ inl_join(t1), use_index(t1, idx) */ * from t join t1 on t.a = t1.a and t1.b = 123;
+explain select /*+ inl_join(t1), use_index(t1, idx) */ * from t_issue59762 join t1 on t_issue59762.a = t1.a and t1.b = 123;
+select /*+ inl_join(t1), use_index(t1, idx) */ * from t_issue59762 join t1 on t_issue59762.a = t1.a and t1.b = 123;
 
 # TestIssue58581
-drop table if exists t;
-create table t (id int unique key, c int);
-insert into t values (1, 10);
-insert into t values (2, 20);
-insert into t values (3, 30);
-select _tidb_rowid from t where id in (1, 2, 3);
+drop table if exists t_issue59762;
+create table t_issue58581 (id int unique key, c int);
+insert into t_issue58581 values (1, 10);
+insert into t_issue58581 values (2, 20);
+insert into t_issue58581 values (3, 30);
+select _tidb_rowid from t_issue58581 where id in (1, 2, 3);
 
 # TestIssue59427
-drop table if exists t;
-create table t(a int, b int, c int, primary key(a,b), key ib(b));
-explain format = brief select * from t use index (ib) where a = 1 and b = 1;
-explain format = brief select /*+ use_index(t, ib) */ * from t where a = 1 and b = 1;
-explain format = brief select * from t as tt use index (ib) where a = 1 and b = 1;
-explain format = brief select /*+ use_index(tt, ib) */ * from t as tt where a = 1 and b = 1;
-explain format = brief update t use index (ib) set c = 1 where a = 1 and b = 1;
-explain format = brief update /*+ use_index(t, ib) */ t set c = 1 where a = 1 and b = 1;
-explain format = brief delete from t use index (ib) where a = 1 and b = 1;
-explain format = brief delete /*+ use_index(t, ib) */ from t where a = 1 and b = 1;
+drop table if exists t_issue58581;
+create table t_issue59427(a int, b int, c int, primary key(a,b), key ib(b));
+explain format = brief select * from t_issue59427 use index (ib) where a = 1 and b = 1;
+explain format = brief select /*+ use_index(t_issue59427, ib) */ * from t_issue59427 where a = 1 and b = 1;
+explain format = brief select * from t_issue59427 as tt use index (ib) where a = 1 and b = 1;
+explain format = brief select /*+ use_index(tt, ib) */ * from t_issue59427 as tt where a = 1 and b = 1;
+explain format = brief update t_issue59427 use index (ib) set c = 1 where a = 1 and b = 1;
+explain format = brief update /*+ use_index(t_issue59427, ib) */ t_issue59427 set c = 1 where a = 1 and b = 1;
+explain format = brief delete from t_issue59427 use index (ib) where a = 1 and b = 1;
+explain format = brief delete /*+ use_index(t_issue59427, ib) */ from t_issue59427 where a = 1 and b = 1;
 create database if not exists test_59427;
-create table test_59427.t(a int, b int, c int, primary key(a,b), key ib(b));
-explain format = brief select * from test_59427.t use index (ib) where a = 1 and b = 1;
-explain format = brief select /*+ use_index(test_59427.t, ib) */ * from test_59427.t where a = 1 and b = 1;
-explain format = brief select * from test_59427.t as tt use index (ib) where a = 1 and b = 1;
-explain format = brief select /*+ use_index(test_59427.tt, ib) */ * from test_59427.t as tt where a = 1 and b = 1;
+create table test_59427.t_issue59427(a int, b int, c int, primary key(a,b), key ib(b));
+explain format = brief select * from test_59427.t_issue59427 use index (ib) where a = 1 and b = 1;
+explain format = brief select /*+ use_index(test_59427.t_issue59427, ib) */ * from test_59427.t_issue59427 where a = 1 and b = 1;
+explain format = brief select * from test_59427.t_issue59427 as tt use index (ib) where a = 1 and b = 1;
+explain format = brief select /*+ use_index(test_59427.tt, ib) */ * from test_59427.t_issue59427 as tt where a = 1 and b = 1;
 drop database if exists test_59427;
 
 # TestIssue60692


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

This PR cherry-picks two materialized view DDL enhancements to the release materialized view branch:

- Cherry-pick #69016: support adding columns to materialized view logs.
- Cherry-pick #68482: support no-reorg compatible type changes for MV base-table columns tracked by materialized view logs.

### What changed and how does it work?

This PR includes the following DDL enhancements:

- Allow `ALTER MATERIALIZED VIEW LOG ... ADD COLUMN` to add tracked columns to an existing materialized view log, including parser, planner, DDL, executor, and write-path support.
- Allow no-reorg compatible `ALTER TABLE ... MODIFY COLUMN` type changes on base-table columns tracked by materialized view logs, while still rejecting incompatible/reorg-required changes and NULL-to-NOT-NULL changes that are unsafe for tracked log columns.
- Add/adjust tests for materialized view log DDL and write behavior, plus the required Bazel test metadata update.

Original PRs:

- https://github.com/pingcap/tidb/pull/69016
- https://github.com/pingcap/tidb/pull/68482

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support adding columns to materialized view logs and no-reorg compatible type changes for MV base-table columns tracked by materialized view logs.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `ALTER MATERIALIZED VIEW LOG` now supports `ADD COLUMN`, with automatic tracking of newly added base columns and synchronized MV-log metadata.

* **Bug Fixes**
  * Strengthened DDL compatibility and safety checks for materialized view bases and MV logs, including preventing unsupported drops/modifications, enforcing safer `MODIFY/CHANGE` rules, and adding stricter validation for related operations like index creation.
  * Improved privilege validation to match the specific MV-log action being performed.

* **Tests**
  * Added and expanded unit and integration coverage for MV-log `ADD COLUMN`, write-path behavior, default/backfill semantics, multi-schema involving-schema history, and new rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->