### PR TITLE
test: stabilize flaky TestDomainAdvancedSessionPoolInternalSessionRegistry

### DIFF
--- a/pkg/session/syssession/session_integration_test.go
+++ b/pkg/session/syssession/session_integration_test.go
@@ -17,6 +17,7 @@ package syssession_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -30,6 +31,10 @@ import (
 
 func TestDomainAdvancedSessionPoolInternalSessionRegistry(t *testing.T) {
 	_, do := testkit.CreateMockStoreAndDomain(t)
+	// Stop TTLJobManager to avoid unrelated job scheduling reusing the same domain session pool.
+	do.TTLJobManager().Stop()
+	require.NoError(t, do.TTLJobManager().WaitStopped(context.Background(), time.Minute))
+
 	p := do.AdvancedSysSessionPool()
 	require.NotNil(t, p)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68190

Problem Summary:
Flaky test `TestDomainAdvancedSessionPoolInternalSessionRegistry` in `pkg/session/syssession` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The test observed a transient registry state after returning a pooled session while TTL background work could legitimately reborrow and re-register that same session.

#### Fix

Stopping TTLJobManager removes unrelated domain pool borrowers without weakening the registry assertions under test.

#### Verification

Spec:
- target: `pkg/session/syssession :: TestDomainAdvancedSessionPoolInternalSessionRegistry`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: failed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package_raw: FAIL
- failpoint_target: SKIPPED
- build: BLOCKED
- ci: BLOCKED

Commands:
- `go test -json -tags=intest,deadlock ./pkg/session/syssession -run '^TestDomainAdvancedSessionPoolInternalSessionRegistry$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/session/syssession -count=1`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for session pool management by ensuring proper cleanup of background job managers during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->