### PR TITLE
test: stabilize flaky TestPrepareCacheChangingParamType

### DIFF
--- a/pkg/planner/core/tests/prepare/prepare_test.go
+++ b/pkg/planner/core/tests/prepare/prepare_test.go
@@ -318,6 +318,7 @@ func randValue(tk *testkit.TestKit, tbl, col, dtype, rtype string) string {
 func TestPrepareCacheChangingParamType(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
+	t.Cleanup(tk.Session().Close)
 	tk.MustExec(`set tidb_enable_prepared_plan_cache=1`)
 
 	tk.MustExec(`use test`)
@@ -462,8 +463,9 @@ func TestPrepareOverMaxPreparedStmtCount(t *testing.T) {
 
 	// test change global limit and make it affected in test session.
 	tk.MustQuery("select @@max_prepared_stmt_count").Check(testkit.Rows("-1"))
-	tk.MustExec("set @@global.max_prepared_stmt_count = 2")
-	tk.MustQuery("select @@global.max_prepared_stmt_count").Check(testkit.Rows("2"))
+	maxPreparedStmtCount := deallocPrepared + 2
+	tk.MustExec(fmt.Sprintf("set @@global.max_prepared_stmt_count = %d", maxPreparedStmtCount))
+	tk.MustQuery("select @@global.max_prepared_stmt_count").Check(testkit.Rows(strconv.Itoa(maxPreparedStmtCount)))
 
 	// test close session to give up all prepared stmt
 	tk.MustExec(`prepare stmt2 from "select 1"`)
@@ -474,10 +476,10 @@ func TestPrepareOverMaxPreparedStmtCount(t *testing.T) {
 
 	// test meet max limit.
 	tk.RefreshSession()
-	tk.MustQuery("select @@max_prepared_stmt_count").Check(testkit.Rows("2"))
+	tk.MustQuery("select @@max_prepared_stmt_count").Check(testkit.Rows(strconv.Itoa(maxPreparedStmtCount)))
 	for i := 1; ; i++ {
 		prePrepared = readGaugeInt(metrics.PreparedStmtGauge)
-		if prePrepared >= 2 {
+		if prePrepared >= maxPreparedStmtCount {
 			tk.MustGetErrCode(`prepare stmt`+strconv.Itoa(i)+` from "select 1"`, errno.ErrMaxPreparedStmtCountReached)
 			break
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68143

Problem Summary:
Flaky test `TestPrepareCacheChangingParamType` in `pkg/planner/core/tests/prepare` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Prepared statements from prior tests could remain in the process-wide gauge, while the max-count test assumed a fixed clean baseline.

#### Fix

Closing the target session releases its prepared statements, and sizing the max-count test from the current gauge preserves the assertion without test-order coupling.

#### Verification

Spec:
- target: `pkg/planner/core/tests/prepare :: TestPrepareCacheChangingParamType`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target-flaky passed.
order-repro passed.
package passed.
build passed.
lint passed.

Gate checklist:
- target-flaky: PASS
- order-repro: PASS
- package: PASS
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/planner/core/tests/prepare -run '^TestPrepareCacheChangingParamType$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/planner/core/tests/prepare -run '^(TestPrepareCacheChangingParamType|TestPrepareOverMaxPreparedStmtCount)$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/planner/core/tests/prepare -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by dynamically computing configuration values instead of relying on fixed assumptions.
  * Enhanced cleanup procedures for session management in prepared statement tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->