### PR TITLE
resourcegroup: add AfterExecutor to record runaway queries missed by in-flight detection

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1621,6 +1621,14 @@ func (a *ExecStmt) FinishExecuteStmt(txnTS uint64, err error, hasMoreResults boo
 	a.checkPlanReplayerCapture(txnTS)
 
 	sessVars := a.Ctx.GetSessionVars()
+	// Final runaway deadline check. Execution has fully finished here, so this
+	// catches queries that exceeded EXEC_ELAPSED without re-entering the
+	// coprocessor path after the deadline and finished before the expensive-query
+	// handler's poll sampled them. It is a no-op if an earlier path already marked
+	// the query.
+	if sessVars.StmtCtx.RunawayChecker != nil {
+		sessVars.StmtCtx.RunawayChecker.AfterExecutor()
+	}
 	sessVars.StmtCtx.ExecRetryCount += uint64(a.retryCount)
 	execDetail := sessVars.StmtCtx.GetExecDetails()
 	// Attach commit/lockKeys runtime stats to executor runtime stats.

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1626,6 +1626,11 @@ func (a *ExecStmt) FinishExecuteStmt(txnTS uint64, err error, hasMoreResults boo
 	// coprocessor path after the deadline and finished before the expensive-query
 	// handler's poll sampled them. It is a no-op if an earlier path already marked
 	// the query.
+	//
+	// This covers all statement-completion paths except the detached server-side
+	// cursor path (`execStmtResult.TryDetach`), which finishes without calling
+	// `FinishExecuteStmt`; that path runs the same check in
+	// `staticrecordset.cursorRecordSet.Close` instead.
 	if sessVars.StmtCtx.RunawayChecker != nil {
 		sessVars.StmtCtx.RunawayChecker.AfterExecutor()
 	}

--- a/pkg/executor/staticrecordset/BUILD.bazel
+++ b/pkg/executor/staticrecordset/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/executor/internal/exec",
         "//pkg/planner/core/resolve",
+        "//pkg/resourcegroup",
         "//pkg/session/cursor",
         "//pkg/util",
         "//pkg/util/chunk",
@@ -27,9 +28,10 @@ go_test(
     timeout = "short",
     srcs = ["integration_test.go"],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/ddl",
+        "//pkg/parser/auth",
         "//pkg/parser/mysql",
         "//pkg/session/cursor",
         "//pkg/testkit",

--- a/pkg/executor/staticrecordset/cursorrecordset.go
+++ b/pkg/executor/staticrecordset/cursorrecordset.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
+	"github.com/pingcap/tidb/pkg/resourcegroup"
 	"github.com/pingcap/tidb/pkg/session/cursor"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
@@ -30,6 +31,11 @@ var _ sqlexec.RecordSet = &cursorRecordSet{}
 type cursorRecordSet struct {
 	cursor    cursor.Handle
 	recordSet sqlexec.RecordSet
+	// runawayChecker performs the final runaway deadline check when the cursor is
+	// closed. The detached server-side cursor path finishes without going through
+	// `ExecStmt.FinishExecuteStmt`, so this is where its post-execution check runs.
+	// It may be nil when resource control is disabled.
+	runawayChecker resourcegroup.RunawayChecker
 }
 
 func (c *cursorRecordSet) Fields() []*resolve.ResultField {
@@ -45,6 +51,11 @@ func (c *cursorRecordSet) NewChunk(alloc chunk.Allocator) *chunk.Chunk {
 }
 
 func (c *cursorRecordSet) Close() error {
+	// Final runaway deadline check for the detached cursor. It is a no-op if an
+	// in-flight path already marked the query during fetches.
+	if c.runawayChecker != nil {
+		c.runawayChecker.AfterExecutor()
+	}
 	c.cursor.Close()
 	return c.recordSet.Close()
 }
@@ -55,7 +66,9 @@ func (c *cursorRecordSet) GetExecutor4Test() any {
 }
 
 // WrapRecordSetWithCursor wraps a record set with a cursor handle. The cursor handle will be closed
-// automatically when the record set is closed
-func WrapRecordSetWithCursor(cursor cursor.Handle, recordSet sqlexec.RecordSet) sqlexec.RecordSet {
-	return &cursorRecordSet{cursor: cursor, recordSet: recordSet}
+// automatically when the record set is closed. The runawayChecker (which may be nil) runs the final
+// runaway deadline check on close, since the detached cursor path does not reach
+// `ExecStmt.FinishExecuteStmt`.
+func WrapRecordSetWithCursor(cursor cursor.Handle, recordSet sqlexec.RecordSet, runawayChecker resourcegroup.RunawayChecker) sqlexec.RecordSet {
+	return &cursorRecordSet{cursor: cursor, recordSet: recordSet, runawayChecker: runawayChecker}
 }

--- a/pkg/executor/staticrecordset/integration_test.go
+++ b/pkg/executor/staticrecordset/integration_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/ddl"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/session/cursor"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -187,6 +188,49 @@ func TestCursorWillBeClosed(t *testing.T) {
 		require.Fail(t, "cursor should be closed")
 		return false
 	})
+}
+
+// TestDetachedCursorRecordsRunawayOnClose verifies that a query overrunning EXEC_ELAPSED on the
+// detached server-side cursor path is still recorded. This path finishes without reaching
+// `ExecStmt.FinishExecuteStmt`, so the final runaway check runs in `cursorRecordSet.Close` instead.
+// The query's only coprocessor request is issued (and observed by the in-flight paths) before the
+// deadline, and no further request is issued afterwards, so the close-time check is the only thing
+// that can record it.
+func TestDetachedCursorRecordsRunawayOnClose(t *testing.T) {
+	// Use a longer expired duration to avoid the record being deleted before it can be observed.
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC", `return(2500)`))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC"))
+	}()
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "localhost"}, nil, nil, nil))
+
+	tk.MustExec("set global tidb_enable_resource_control='on'")
+	tk.MustExec("use test")
+	tk.MustExec("create table t(id int)")
+	tk.MustExec("insert into t values (1), (2), (3)")
+	// EXEC_ELAPSED is large enough that the query's coprocessor request during execution does not
+	// trip the in-flight detection; the deadline is then crossed by the sleep before close.
+	tk.MustExec("create resource group rg1 RU_PER_SEC=1000 QUERY_LIMIT=(EXEC_ELAPSED='500ms' ACTION=DRYRUN)")
+
+	tk.Session().GetSessionVars().SetStatusFlag(mysql.ServerStatusCursorExists, true)
+
+	rs, err := tk.Exec("select /*+ resource_group(rg1) */ * from t")
+	require.NoError(t, err)
+	drs := rs.(sqlexec.DetachableRecordSet)
+	srs, ok, err := drs.TryDetach()
+	require.True(t, ok)
+	require.NoError(t, err)
+
+	// Cross the deadline while the cursor is open and idle (no further coprocessor request).
+	time.Sleep(700 * time.Millisecond)
+
+	// Closing the detached cursor must run the final runaway check and record the query.
+	require.NoError(t, srs.Close())
+
+	tk.EventuallyMustQueryAndCheck("select SQL_NO_CACHE resource_group_name, match_type from mysql.tidb_runaway_queries", nil,
+		testkit.Rows("rg1 identify"), 5*time.Second, 100*time.Millisecond)
 }
 
 func TestCursorWillBlockMinStartTS(t *testing.T) {

--- a/pkg/resourcegroup/checker.go
+++ b/pkg/resourcegroup/checker.go
@@ -38,6 +38,8 @@ type RunawayChecker interface {
 	CheckAction() rmpb.RunawayAction
 	// CheckRuleKillAction checks whether the query should be killed according to the group settings.
 	CheckRuleKillAction() (string, bool)
+	// AfterExecutor checks whether the query exceeded its time-based threshold once execution has finished.
+	AfterExecutor()
 }
 
 // ConsumptionReporter is used to report raw resource consumptions.

--- a/pkg/resourcegroup/runaway/BUILD.bazel
+++ b/pkg/resourcegroup/runaway/BUILD.bazel
@@ -53,7 +53,7 @@ go_test(
     ],
     embed = [":runaway"],
     flaky = True,
-    shard_count = 26,
+    shard_count = 27,
     deps = [
         "//pkg/ddl",
         "//pkg/infoschema",

--- a/pkg/resourcegroup/runaway/checker.go
+++ b/pkg/resourcegroup/runaway/checker.go
@@ -257,6 +257,31 @@ func (r *Checker) CheckRuleKillAction() (string, bool) {
 	return "", false
 }
 
+// AfterExecutor checks whether the query exceeded its time-based threshold once
+// execution has finished. It is the final time-based detection path: the
+// in-flight paths (`BeforeCopRequest` on cop dispatch and `CheckThresholds` on
+// cop response) only fire while coprocessor requests are being issued, and the
+// expensive-query handler only samples the query on a coarse 100ms tick. A query
+// that overruns `EXEC_ELAPSED` after its last coprocessor request, and finishes
+// before the next tick, is missed by all of them. Checking once at completion
+// guarantees such a query is still marked and recorded.
+//
+// This only records the runaway; it cannot interrupt a query that has already
+// finished. The `markedByIdentifyInRunawaySettings` CAS in
+// `markRunawayByIdentifyInRunawaySettings` makes it a no-op when an earlier path
+// already marked the query.
+func (r *Checker) AfterExecutor() {
+	if r == nil || r.settings == nil || r.isMarkedByIdentifyInRunawaySettings() {
+		return
+	}
+	now := time.Now()
+	exceedCause := r.exceedsThresholds(now, nil, 0)
+	if exceedCause == "" {
+		return
+	}
+	r.markRunawayByIdentifyInRunawaySettings(&now, exceedCause)
+}
+
 func (r *Checker) markQuarantine(now *time.Time, exceedCause string) {
 	if r.settings == nil || r.settings.Watch == nil {
 		return

--- a/pkg/resourcegroup/runaway/checker_test.go
+++ b/pkg/resourcegroup/runaway/checker_test.go
@@ -280,6 +280,55 @@ func TestNilCheckerSafety(t *testing.T) {
 
 	assert.NoError(t, c.CheckThresholds(nil, 0, nil))
 	c.ResetTotalProcessedKeys() // should not panic
+	c.AfterExecutor()           // should not panic
+}
+
+func TestAfterExecutor(t *testing.T) {
+	newCheckerWithDeadline := func(action rmpb.RunawayAction, deadline time.Time) (*Checker, *Manager) {
+		m := &Manager{runawayQueriesChan: make(chan *Record, 10)}
+		c := &Checker{
+			manager:           m,
+			resourceGroupName: "rg_after_executor",
+			deadline:          deadline,
+			settings: &rmpb.RunawaySettings{
+				Action: action,
+				Rule:   &rmpb.RunawayRule{ExecElapsedTimeMs: 1},
+			},
+		}
+		return c, m
+	}
+
+	t.Run("NilSettings", func(t *testing.T) {
+		c := &Checker{deadline: time.Now().Add(-time.Second)}
+		c.AfterExecutor()
+		assert.False(t, c.markedByIdentifyInRunawaySettings.Load())
+	})
+
+	// The query overran the deadline but was never caught by an in-flight path
+	// (BeforeCopRequest / CheckThresholds) or the expensive-query poll. AfterExecutor
+	// must record it at completion. This is the core gap the method closes.
+	t.Run("DeadlineExceededMarksRunaway", func(t *testing.T) {
+		c, m := newCheckerWithDeadline(rmpb.RunawayAction_DryRun, time.Now().Add(-time.Second))
+		c.AfterExecutor()
+		assert.True(t, c.markedByIdentifyInRunawaySettings.Load())
+		assert.Equal(t, 1, len(m.runawayQueriesChan))
+	})
+
+	t.Run("DeadlineNotExceeded", func(t *testing.T) {
+		c, m := newCheckerWithDeadline(rmpb.RunawayAction_DryRun, time.Now().Add(time.Hour))
+		c.AfterExecutor()
+		assert.False(t, c.markedByIdentifyInRunawaySettings.Load())
+		assert.Equal(t, 0, len(m.runawayQueriesChan))
+	})
+
+	// When an earlier path already marked the query, the CAS makes AfterExecutor a
+	// no-op so no duplicate record is enqueued.
+	t.Run("AlreadyMarkedIsNoop", func(t *testing.T) {
+		c, m := newCheckerWithDeadline(rmpb.RunawayAction_DryRun, time.Now().Add(-time.Second))
+		c.markedByIdentifyInRunawaySettings.Store(true)
+		c.AfterExecutor()
+		assert.Equal(t, 0, len(m.runawayQueriesChan))
+	})
 }
 
 func TestCheckThresholds(t *testing.T) {

--- a/pkg/resourcegroup/tests/BUILD.bazel
+++ b/pkg/resourcegroup/tests/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     srcs = ["resource_group_test.go"],
     flaky = True,
     race = "on",
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//pkg/ddl/resourcegroup",
         "//pkg/domain",

--- a/pkg/resourcegroup/tests/resource_group_test.go
+++ b/pkg/resourcegroup/tests/resource_group_test.go
@@ -474,6 +474,41 @@ func TestResourceGroupRunawayExceedTiDBSide(t *testing.T) {
 		nil, maxWaitDuration, tryInterval)
 }
 
+// TestResourceGroupRunawayRecordedAtCompletion verifies the post-execution recording path
+// (`Checker.AfterExecutor`, invoked from `ExecStmt.FinishExecuteStmt`). The query overruns
+// EXEC_ELAPSED entirely on the TiDB side (`sleep`) after its only coprocessor request, and the
+// expensive-query handler is deliberately not started, so neither the in-flight cop paths nor the
+// background poll can record it. The record must therefore be produced solely at statement
+// completion.
+func TestResourceGroupRunawayRecordedAtCompletion(t *testing.T) {
+	// Use a longer expired duration to avoid the record being deleted too fast, 2500 means 2.5 seconds.
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC", `return(2500)`))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC"))
+	}()
+	// Intentionally do NOT start the expensive-query handler poll, so AfterExecutor is the only
+	// path that can record the query at completion.
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "localhost"}, nil, nil, nil))
+
+	tk.MustExec("set global tidb_enable_resource_control='on'")
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int)")
+	tk.MustExec("insert into t values(1)")
+	// DRYRUN only records; the query completes normally so it never re-enters the cop path after
+	// the deadline.
+	tk.MustExec("create resource group rg1 RU_PER_SEC=1000 QUERY_LIMIT=(EXEC_ELAPSED='50ms' ACTION=DRYRUN)")
+
+	runawayQuery := "select /*+ resource_group(rg1) */ sleep(1) from t"
+	tk.MustQuery(runawayQuery).Check(testkit.Rows("0"))
+
+	tryInterval := time.Millisecond * 100
+	maxWaitDuration := time.Second * 5
+	tk.EventuallyMustQueryAndCheck("select SQL_NO_CACHE resource_group_name, sample_sql, match_type from mysql.tidb_runaway_queries", nil,
+		testkit.Rows(fmt.Sprintf("rg1 %s identify", runawayQuery)), maxWaitDuration, tryInterval)
+}
+
 func TestRunawayRecordFlushLoopAddAndFlush(t *testing.T) {
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC", `return(20000)`))
 	defer func() {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3124,7 +3124,9 @@ func (rs *execStmtResult) TryDetach() (sqlexec.RecordSet, bool, error) {
 	cursorHandle := rs.se.GetCursorTracker().NewCursor(
 		cursor.State{StartTS: rs.se.GetSessionVars().TxnCtx.StartTS},
 	)
-	crs := staticrecordset.WrapRecordSetWithCursor(cursorHandle, detachedRS)
+	// Pass the runaway checker so the final deadline check runs when the cursor is
+	// closed: this detached path finishes without reaching `ExecStmt.FinishExecuteStmt`.
+	crs := staticrecordset.WrapRecordSetWithCursor(cursorHandle, detachedRS, rs.se.GetSessionVars().StmtCtx.RunawayChecker)
 
 	// Now, a transaction is not needed for the detached record set, so we commit the transaction and cleanup
 	// the session state.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #69254

Problem Summary:

Time-based (`EXEC_ELAPSED`) runaway query detection intermittently misses queries that exceed the deadline. A query that stops issuing coprocessor requests before its deadline, and finishes shortly after, may never have its configured action applied (e.g. a `DRYRUN` query is only sometimes recorded in `mysql.tidb_runaway_queries`; a `KILL` query is only sometimes killed).

The root cause is a coverage gap between the detection paths:

- `Checker.BeforeCopRequest` only runs before each coprocessor request is dispatched. If the last cop request is dispatched before the deadline, this path never observes the overrun.
- `Checker.CheckThresholds` only runs on coprocessor responses and early-returns unless the action is `Kill`.
- `Checker.CheckRuleKillAction`, driven by the expensive-query handler, samples the query only on a coarse 100ms tick. A query that overruns by less than ~one tick interval usually finishes before being sampled.

So once a query stops issuing coprocessor requests after the deadline, the only remaining enforcement is the 100ms background poll, making detection timing-dependent and non-deterministic.

### What changed and how does it work?

Add `AfterExecutor()` to the `RunawayChecker` interface and implement it on `Checker`. It runs once at statement completion, reusing the existing `exceedsThresholds` and CAS-guarded `markRunawayByIdentifyInRunawaySettings` helpers, so it is a no-op when an earlier path already marked the query.

It is called from `ExecStmt.FinishExecuteStmt` (`pkg/executor/adapter.go`), which all statement-completion paths reach (no-result statements, result-set `SELECT`s, and `PointGet`) except the detached server-side cursor path (`execStmtResult.TryDetach`); that path finishes without `FinishExecuteStmt`, so it runs the same check from `staticrecordset`'s `cursorRecordSet.Close`. Both call sites are guarded by a `RunawayChecker != nil` check since the field is a nil interface when resource control is disabled.

This is a recording/observability fix: it guarantees that any query exceeding `EXEC_ELAPSED` is recorded at completion regardless of coprocessor or ticker timing, closing the gap for `DRYRUN` (and the record side of `CoolDown`/`SwitchGroup`). It does not change action enforcement: because execution has already finished when it runs, it cannot interrupt the query, so for `KILL` it only restores a consistent post-hoc record. Truly preempting an overrunning query (the enforcement side of #69254) requires periodic deadline checks inside the executor operators, which is a larger change tracked separately. Note that in-flight detection still applies to the detached cursor across fetches, so `KILL`/`CoolDown` continue to act on server-side work there.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
Reproduced using local tiup and validated the fix (steps outlined in #69254 )
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where time-based (EXEC_ELAPSED) resource group runaway queries were intermittently not detected when a query exceeded its deadline without issuing further coprocessor requests.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runaway query detection so time-limit violations are now recorded reliably even when execution ends through detached or cursor-based paths.
  * Closing a detached cursor now triggers the final deadline check, helping ensure overdue queries are captured consistently.

* **Tests**
  * Added coverage for runaway recording at completion and for detached cursor close behavior.
  * Updated existing safety checks to verify the new end-of-execution path behaves correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->