### PR TITLE
test: stabilize flaky TestProcessStmtStatsData

### DIFF
--- a/pkg/util/topsql/reporter/reporter_test.go
+++ b/pkg/util/topsql/reporter/reporter_test.go
@@ -630,6 +630,12 @@ func TestProcessStmtStatsData(t *testing.T) {
 	restoreTicker := SetReportTickerIntervalSecondsForTest(3)
 	t.Cleanup(restoreTicker)
 	topsqlstate.GlobalState.MaxStatementCount.Store(3)
+	origNowFunc := nowFunc
+	// This test checks merge/eviction semantics, not wall-clock bucket boundaries.
+	nowFunc = func() time.Time {
+		return time.Unix(1781581027, 0)
+	}
+	t.Cleanup(func() { nowFunc = origNowFunc })
 
 	r := NewRemoteTopSQLReporter(mockPlanBinaryDecoderFunc, mockPlanBinaryCompressFunc)
 	r.Start()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69261

Problem Summary:
Flaky test `TestProcessStmtStatsData` in `pkg/util/topsql/reporter` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Async test input batches could cross a Unix-second boundary, while the assertions expected one fixed timestamp bucket.

#### Fix

Freezing `nowFunc` preserves the merge/eviction assertions and removes unrelated wall-clock timing from the test.

#### Verification

Spec:
- target: `pkg/util/topsql/reporter :: TestProcessStmtStatsData`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package: PASS
- failpoint_target: SKIPPED
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/util/topsql/reporter -run '^TestProcessStmtStatsData$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/util/topsql/reporter -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #69261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test determinism by fixing timestamp behavior in statement statistics processing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->