### PR TITLE
mvservice: improve manual cancel backoff handling

### DIFF
--- a/pkg/mvservice/service.go
+++ b/pkg/mvservice/service.go
@@ -679,7 +679,7 @@ func (t *MVService) handleRefreshTaskResult(m *mv, nextRefresh time.Time, err er
 					zap.Time("manual_cancel_backoff_at", nextRetryAt),
 					zap.Error(backoffErr),
 				)
-				logutil.BgLogger().Warn("refresh MV manual cancel backoff persist failed, forcing metadata refetch", fields...)
+				logutil.BgLogger().Warn("refresh MV manual cancel backoff persist failed", fields...)
 			}
 			if applied {
 				if appliedNext.IsZero() {
@@ -689,8 +689,7 @@ func (t *MVService) handleRefreshTaskResult(m *mv, nextRefresh time.Time, err er
 				t.rescheduleMVSuccess(m, appliedNext)
 				return
 			}
-			t.lastMetaFetchMillis.Store(0)
-			t.removeMVTask(m)
+			t.rescheduleMV(m, nextRetryAt.UnixMilli())
 			return
 		}
 		retryCount := m.retryCount.Add(1)
@@ -729,7 +728,7 @@ func (t *MVService) handlePurgeTaskResult(l *mvLog, nextPurge time.Time, err err
 					zap.Time("manual_cancel_backoff_at", nextRetryAt),
 					zap.Error(backoffErr),
 				)
-				logutil.BgLogger().Warn("purge MV log manual cancel backoff persist failed, forcing metadata refetch", fields...)
+				logutil.BgLogger().Warn("purge MV log manual cancel backoff persist failed", fields...)
 			}
 			if applied {
 				if appliedNext.IsZero() {
@@ -739,8 +738,7 @@ func (t *MVService) handlePurgeTaskResult(l *mvLog, nextPurge time.Time, err err
 				t.rescheduleMVLogSuccess(l, appliedNext)
 				return
 			}
-			t.lastMetaFetchMillis.Store(0)
-			t.removeMVLogTask(l)
+			t.rescheduleMVLog(l, nextRetryAt.UnixMilli())
 			return
 		}
 		retryCount := l.retryCount.Add(1)

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -1184,16 +1184,18 @@ func TestMVServiceTaskResult(t *testing.T) {
 			}, testEventuallyWait, testEventuallyTick)
 		})
 
-		t.Run("manual_cancel_without_persist_forces_refetch", func(t *testing.T) {
+		t.Run("manual_cancel_without_persist_uses_local_backoff", func(t *testing.T) {
 			helper := &mockMVServiceHelper{
 				purgeErr: errMVTaskCanceledManually,
 			}
 			svc := newRunningMVServiceForTest(t, helper)
-			svc.lastMetaFetchMillis.Store(mvsNow().UnixMilli())
+			now := mvsNow()
+			svc.lastMetaFetchMillis.Store(now.UnixMilli())
+			expectedNext := now.Add(manualCancelBackoffDelay)
 
 			l := &mvLog{
 				ID:        306,
-				nextPurge: mvsNow().Add(-time.Minute).Round(0),
+				nextPurge: now.Add(-time.Minute).Round(0),
 			}
 			svc.buildMVLogPurgeTasks(map[int64]*mvLog{l.ID: l})
 			svc.purgeMVLog([]*mvLog{l})
@@ -1201,12 +1203,13 @@ func TestMVServiceTaskResult(t *testing.T) {
 			waitExecutorFinishedCount(t, svc, 1)
 			require.Equal(t, int32(1), helper.purgeManualCancelBackoffCalls.Load())
 			require.Equal(t, int64(0), l.retryCount.Load())
-			require.Equal(t, int64(0), svc.lastMetaFetchMillis.Load())
+			require.Equal(t, now.UnixMilli(), svc.lastMetaFetchMillis.Load())
 
 			svc.mvLogPurgeMu.Lock()
-			_, ok := svc.mvLogPurgeMu.pending[l.ID]
+			item, ok := svc.mvLogPurgeMu.pending[l.ID]
 			svc.mvLogPurgeMu.Unlock()
-			require.False(t, ok)
+			require.True(t, ok)
+			require.Equal(t, expectedNext.UnixMilli(), item.Value.orderTs)
 		})
 	})
 
@@ -1313,16 +1316,18 @@ func TestMVServiceTaskResult(t *testing.T) {
 			}, testEventuallyWait, testEventuallyTick)
 		})
 
-		t.Run("manual_cancel_without_persist_forces_refetch", func(t *testing.T) {
+		t.Run("manual_cancel_without_persist_uses_local_backoff", func(t *testing.T) {
 			helper := &mockMVServiceHelper{
 				refreshErr: errMVTaskCanceledManually,
 			}
 			svc := newRunningMVServiceForTest(t, helper)
-			svc.lastMetaFetchMillis.Store(mvsNow().UnixMilli())
+			now := mvsNow()
+			svc.lastMetaFetchMillis.Store(now.UnixMilli())
+			expectedNext := now.Add(manualCancelBackoffDelay)
 
 			m := &mv{
 				ID:          404,
-				nextRefresh: mvsNow().Add(-time.Minute).Round(0),
+				nextRefresh: now.Add(-time.Minute).Round(0),
 			}
 			svc.buildMVRefreshTasks(map[int64]*mv{m.ID: m})
 			svc.refreshMV([]*mv{m})
@@ -1330,12 +1335,13 @@ func TestMVServiceTaskResult(t *testing.T) {
 			waitExecutorFinishedCount(t, svc, 1)
 			require.Equal(t, int32(1), helper.refreshManualCancelBackoffCalls.Load())
 			require.Equal(t, int64(0), m.retryCount.Load())
-			require.Equal(t, int64(0), svc.lastMetaFetchMillis.Load())
+			require.Equal(t, now.UnixMilli(), svc.lastMetaFetchMillis.Load())
 
 			svc.mvRefreshMu.Lock()
-			_, ok := svc.mvRefreshMu.pending[m.ID]
+			item, ok := svc.mvRefreshMu.pending[m.ID]
 			svc.mvRefreshMu.Unlock()
-			require.False(t, ok)
+			require.True(t, ok)
+			require.Equal(t, expectedNext.UnixMilli(), item.Value.orderTs)
 		})
 	})
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:

This PR ports the mvservice refinement from #69238 to the materialized view release branch. When persisting the manual-cancel backoff for MV refresh or MV log purge fails, the service should not force a metadata refetch and remove the local task. It can keep the task locally scheduled with the manual-cancel backoff time.

Original PR: #69238

### What changed and how does it work?

- Update MV refresh task result handling so manual-cancel backoff persist failure keeps a local backoff schedule instead of forcing metadata refetch.
- Update MV log purge task result handling with the same local backoff behavior.
- Adjust mvservice unit tests to verify the task remains pending with the expected backoff timestamp.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test:

```bash
go test ./pkg/mvservice -run '^TestMVServiceTaskResult$' -tags=intest,deadlock -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized manual-cancel behavior for MV refresh and purge tasks. Tasks now reschedule using local backoff instead of being cleared and forcing metadata rebuilds.

* **Tests**
  * Updated test cases to reflect new manual-cancel backoff behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->