### PR TITLE
tests: enable shared lock RealTiKV tests on next-gen

### DIFF
--- a/tests/realtikvtest/txntest/shared_lock_test.go
+++ b/tests/realtikvtest/txntest/shared_lock_test.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/tests/realtikvtest"
 	"github.com/stretchr/testify/require"
 )
@@ -35,9 +35,6 @@ func prepareForeignKeyTables(tk *testkit.TestKit) {
 func TestSharedLockBlockedByExclusiveLock(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
-	}
-	if kerneltype.IsNextGen() {
-		t.Skip("does not support shared lock in next-gen TiKV")
 	}
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
@@ -97,9 +94,6 @@ func TestSharedLockBlockExclusiveLock(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
-	if kerneltype.IsNextGen() {
-		t.Skip("does not support shared lock in next-gen TiKV")
-	}
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 
@@ -155,9 +149,6 @@ func TestSharedLockBlockExclusiveLock(t *testing.T) {
 func TestSharedLockChildTableConflict(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
-	}
-	if kerneltype.IsNextGen() {
-		t.Skip("does not support shared lock in next-gen TiKV")
 	}
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
@@ -263,9 +254,6 @@ func TestSharedLockCascadeUpdateExplicitPessimisticTxn(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
-	if kerneltype.IsNextGen() {
-		t.Skip("does not support shared lock in next-gen TiKV")
-	}
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 
@@ -302,9 +290,6 @@ func TestSharedLockCascadeUpdateExplicitPessimisticTxn(t *testing.T) {
 func TestSharedLockLockView(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
-	}
-	if kerneltype.IsNextGen() {
-		t.Skip("does not support shared lock in next-gen TiKV")
 	}
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
@@ -398,4 +383,85 @@ func TestSharedLockLockView(t *testing.T) {
 
 	tk1.MustExec("commit")
 	require.NoError(t, <-exclusiveLockDoneCh)
+}
+
+func TestSharedLockDataLockWaitsFromStorageWaitTable(t *testing.T) {
+	if !*realtikvtest.WithRealTiKV {
+		t.Skip("requires real TiKV")
+	}
+
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	testTk := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+	tk2.MustExec("use test")
+	testTk.MustExec("use test")
+	tk1.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk1.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
+	tk2.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk2.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
+
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/dataLockWaitsSkipResolvingLocks", "return(true)")
+	prepareForeignKeyTables(tk1)
+
+	conn2 := tk2.MustQuery("select connection_id()").Rows()[0][0].(string)
+
+	tk1.MustExec("begin pessimistic")
+	tk1.MustExec("select * from parent where id=1 for update")
+	insertDoneCh := make(chan error, 1)
+	insertDone := false
+	t.Cleanup(func() {
+		_, _ = tk1.Exec("rollback")
+		if !insertDone {
+			select {
+			case <-insertDoneCh:
+			case <-time.After(time.Second):
+			}
+		}
+	})
+
+	tk2.MustExec("begin pessimistic")
+	conn2TxnID := tk2.Session().TxnInfo().StartTS
+	go func() {
+		_, err := tk2.Exec("insert into child values (1, 1)")
+		if err == nil {
+			_, err = tk2.Exec("commit")
+		}
+		insertDoneCh <- err
+	}()
+
+	var (
+		insertErr            error
+		insertFinishedEarly  bool
+		waitingTxnAndSession [][]any
+	)
+	require.Eventually(t, func() bool {
+		select {
+		case insertErr = <-insertDoneCh:
+			insertDone = true
+			insertFinishedEarly = true
+			return true
+		default:
+		}
+
+		waitingTxnAndSession = testTk.MustQuery(fmt.Sprintf(
+			"select TRX_ID, SESSION_ID from INFORMATION_SCHEMA.DATA_LOCK_WAITS as l left join INFORMATION_SCHEMA.TIDB_TRX as trx on l.trx_id = trx.id where l.trx_id = %d and trx.session_id = %s",
+			conn2TxnID, conn2,
+		)).Rows()
+		return len(waitingTxnAndSession) > 0
+	}, 10*time.Second, 100*time.Millisecond)
+	require.Falsef(t, insertFinishedEarly, "insert should be blocked before DATA_LOCK_WAITS row is observed, err: %v", insertErr)
+	require.Len(t, waitingTxnAndSession, 1)
+	waitingTxnID := waitingTxnAndSession[0][0].(string)
+	sessionID := waitingTxnAndSession[0][1].(string)
+	require.Equal(t, waitingTxnID, fmt.Sprintf("%d", conn2TxnID))
+	require.Equal(t, sessionID, conn2)
+
+	tk1.MustExec("commit")
+	insertErr = <-insertDoneCh
+	insertDone = true
+	require.NoError(t, insertErr)
+	tk1.MustQuery("select * from child").Check(testkit.Rows("1 1"))
 }

--- a/tests/realtikvtest/txntest/shared_lock_test.go
+++ b/tests/realtikvtest/txntest/shared_lock_test.go
@@ -79,6 +79,8 @@ func TestForeignKeySharedLockPessimisticReverseReferenceOrder(t *testing.T) {
 	tk2.MustExec("use test")
 	tk1.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
 	tk2.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk1.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
+	tk2.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 
 	prepareForeignKeyTables(tk1)
 

--- a/tests/realtikvtest/txntest/shared_lock_test.go
+++ b/tests/realtikvtest/txntest/shared_lock_test.go
@@ -32,6 +32,73 @@ func prepareForeignKeyTables(tk *testkit.TestKit) {
 	tk.MustExec("insert into parent values (1), (2)")
 }
 
+func TestForeignKeySharedLockOptimisticReverseReferenceOrder(t *testing.T) {
+	if !*realtikvtest.WithRealTiKV {
+		t.Skip("requires real TiKV")
+	}
+
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+	tk2.MustExec("use test")
+	tk1.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk2.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+
+	prepareForeignKeyTables(tk1)
+
+	// Foreign-key shared locks do not support optimistic transactions. The checks below reference
+	// parent rows in reverse orders, so the second optimistic transaction should fail at commit
+	// time with a write conflict.
+	tk1.MustExec("begin optimistic")
+	tk2.MustExec("begin optimistic")
+
+	tk1.MustExec("insert into child values (1, 1)")
+	tk2.MustExec("insert into child values (3, 2)")
+
+	tk1.MustExec("insert into child values (2, 2)")
+	tk2.MustExec("insert into child values (4, 1)")
+
+	tk1.MustExec("commit")
+	err := tk2.ExecToErr("commit")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Write conflict")
+
+	tk1.MustQuery("select * from child order by id").Check(testkit.Rows("1 1", "2 2"))
+}
+
+func TestForeignKeySharedLockPessimisticReverseReferenceOrder(t *testing.T) {
+	if !*realtikvtest.WithRealTiKV {
+		t.Skip("requires real TiKV")
+	}
+
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+	tk2.MustExec("use test")
+	tk1.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk2.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+
+	prepareForeignKeyTables(tk1)
+
+	// Pessimistic transactions can acquire compatible foreign-key shared locks, so the same
+	// reverse reference order should let both transactions commit.
+	tk1.MustExec("begin pessimistic")
+	tk2.MustExec("begin pessimistic")
+
+	tk1.MustExec("insert into child values (1, 1)")
+	tk2.MustExec("insert into child values (3, 2)")
+
+	tk1.MustExec("insert into child values (2, 2)")
+	tk2.MustExec("insert into child values (4, 1)")
+
+	tk1.MustExec("commit")
+	tk2.MustExec("commit")
+
+	tk1.MustQuery("select * from child order by id").Check(testkit.Rows("1 1", "2 2", "3 2", "4 1"))
+}
+
 func TestSharedLockBlockedByExclusiveLock(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
@@ -413,11 +480,17 @@ func TestSharedLockDataLockWaitsFromStorageWaitTable(t *testing.T) {
 	insertDoneCh := make(chan error, 1)
 	insertDone := false
 	t.Cleanup(func() {
-		_, _ = tk1.Exec("rollback")
+		if _, err := tk1.Exec("rollback"); err != nil {
+			t.Errorf("rollback blocker transaction: %v", err)
+		}
 		if !insertDone {
 			select {
-			case <-insertDoneCh:
+			case err := <-insertDoneCh:
+				if err != nil {
+					t.Errorf("insert goroutine failed after rolling back blocker transaction: %v", err)
+				}
 			case <-time.After(time.Second):
+				t.Errorf("insert goroutine did not finish after rolling back blocker transaction")
 			}
 		}
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #69236

Problem Summary:

Next-gen TiKV now supports shared lock, but several RealTiKV shared-lock tests were still skipped on next-gen clusters.

### What changed and how does it work?

- Remove the next-gen skip from existing shared-lock RealTiKV tests.
- Add shared-lock `DATA_LOCK_WAITS` coverage for the TiKV storage wait-table path.
- Add foreign-key shared-lock coverage for reverse parent-row reference order:
  - optimistic transactions are expected to fail at commit time with a write conflict;
  - pessimistic transactions are expected to commit because foreign-key shared locks are compatible.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validated locally:

```bash
tests/realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh ./tools/check/failpoint-go-test.sh tests/realtikvtest/txntest -tags=intest,nextgen -run '^TestSharedLock.*$' -count=1 -timeout 240s -args -with-real-tikv
tests/realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh go test ./tests/realtikvtest/txntest -run 'TestForeignKeySharedLock(Optimistic|Pessimistic)ReverseReferenceOrder' -tags=intest,nextgen -with-real-tikv -timeout 10m
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Expanded real-TiKV shared-lock testing for foreign-key behavior, including reverse parent-row reference ordering under both optimistic and pessimistic transactions.
  * Added a lock-wait visibility test that enables a failpoint, runs concurrent conflicting transactions, verifies entries in `INFORMATION_SCHEMA.DATA_LOCK_WAITS`, and confirms the blocked operation eventually completes after the blocker commits.
  * Simplified shared-lock real-TiKV gating by removing version-specific conditional skips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->