### PR TITLE
statistics: fix stats for added virtual generated columns

### DIFF
--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -386,6 +386,28 @@ func TestDDLHistogram(t *testing.T) {
 	rs.Check(testkit.Rows("0"))
 	rs = testKit.MustQuery("select count(*) from mysql.stats_top_n where table_id = ? and hist_id = 1 and is_index = 1", tableInfo.ID)
 	rs.Check(testkit.Rows("2"))
+
+	// Isolate the virtual-column regression from earlier buffered DDL events.
+	for len(h.DDLEventCh()) > 0 {
+		<-h.DDLEventCh()
+	}
+	testKit.MustExec("alter table t add column c_vir int generated always as (c1 + c2) virtual")
+	err = statstestutil.HandleNextDDLEventWithTxn(h)
+	require.NoError(t, err)
+	is = do.InfoSchema()
+	require.Nil(t, h.Update(context.Background(), is))
+	tbl, err = is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tableInfo = tbl.Meta()
+	statsTbl = do.StatsHandle().GetPhysicalTableStats(tableInfo.ID, tableInfo)
+	virtualCol := tableInfo.FindPublicColumnByName("c_vir")
+	require.NotNil(t, virtualCol)
+	require.False(t, statsTbl.ColAndIdxExistenceMap.HasAnalyzed(virtualCol.ID, false))
+	if colStats := statsTbl.GetCol(virtualCol.ID); colStats != nil {
+		require.False(t, colStats.IsStatsInitialized())
+	}
+	testKit.MustQuery("select distinct_count, null_count, stats_ver from mysql.stats_histograms where table_id = ? and is_index = 0 and hist_id = ?", tableInfo.ID, virtualCol.ID).
+		Check(testkit.Rows("0 0 0"))
 }
 
 func TestDDLPartition(t *testing.T) {

--- a/pkg/statistics/handle/storage/save.go
+++ b/pkg/statistics/handle/storage/save.go
@@ -439,6 +439,24 @@ func InsertColStats2KV(
 	count := req.GetRow(0).GetInt64(0)
 	hasStatsUpdate := false
 	for _, colInfo := range colInfos {
+		if colInfo.IsVirtualGenerated() {
+			// Virtual generated columns do not have column stats. Keep the
+			// same zero placeholder shape as the create-table stats path.
+			if _, err = util.ExecWithCtx(
+				ctx, sctx,
+				`insert ignore into mysql.stats_histograms
+					(version, table_id, is_index, hist_id, distinct_count, null_count)
+				values (%?, %?, 0, %?, 0, 0)`,
+				startTS, physicalID, colInfo.ID,
+			); err != nil {
+				return 0, errors.Trace(err)
+			}
+			if sctx.GetSessionVars().StmtCtx.AffectedRows() > 0 {
+				hasStatsUpdate = true
+			}
+			continue
+		}
+
 		value, err := table.GetColOriginDefaultValue(sctx.GetExprCtx(), colInfo)
 		if err != nil {
 			return 0, errors.Trace(err)

--- a/pkg/statistics/handle/storage/save.go
+++ b/pkg/statistics/handle/storage/save.go
@@ -442,6 +442,9 @@ func InsertColStats2KV(
 		if colInfo.IsVirtualGenerated() {
 			// Virtual generated columns do not have column stats. Keep the
 			// same zero placeholder shape as the create-table stats path.
+			// Analyze-skipped columns are real stored columns, so their
+			// default/null handling needs a separate decision.
+			// TODO: define add-column stats behavior for analyze-skipped columns.
 			if _, err = util.ExecWithCtx(
 				ctx, sctx,
 				`insert ignore into mysql.stats_histograms


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69160

Problem Summary: statistics: fix stats for added virtual generated columns

### What changed and how does it work?

When adding a virtual generated column with `ALTER TABLE ADD COLUMN`, TiDB initialized its stats histogram row like a normal nullable column, which could set `null_count` to the table row count. This was inconsistent with `CREATE TABLE`, where virtual generated columns use zero placeholder stats.


For virtual generated columns only, `ALTER TABLE ADD COLUMN` now inserts a zero placeholder row into `mysql.stats_histograms` with `distinct_count = 0` and `null_count = 0`, matching create-table behavior.

A regression case was added to cover the DDL stats update path.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test ensuring virtual generated columns are handled correctly and their histogram entries remain uninitialized (distinct/null counts and version remain `0`).

* **Bug Fixes**
  * Updated column statistics saving to detect virtual generated columns and skip the normal statistics insertion flow, inserting placeholder histogram rows instead to prevent unnecessary or incorrect statistics computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->