### PR TITLE
test: stabilize flaky TestJobOrchestratorRecordSubmissionGetsFreshGraceTimeout

### DIFF
--- a/lightning/pkg/importinto/job_orchestrator_test.go
+++ b/lightning/pkg/importinto/job_orchestrator_test.go
@@ -470,12 +470,12 @@ func TestJobOrchestratorRecordSubmissionGetsFreshGraceTimeout(t *testing.T) {
 	mockCpMgr.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(func(updateCtx context.Context, cp *importinto.TableCheckpoint) error {
 		updateCtxDone = observeContextDone(updateCtx)
 		close(updateStarted)
-		<-allowUpdateReturn
 		select {
 		case <-updateCtx.Done():
 			return updateCtx.Err()
 		default:
 		}
+		<-allowUpdateReturn
 		require.Equal(t, common.UniqueTable("db", "t1"), cp.TableName)
 		require.Equal(t, int64(1), cp.JobID)
 		require.Equal(t, importinto.CheckpointStatusRunning, cp.Status)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68204

Problem Summary:
Flaky test `TestJobOrchestratorRecordSubmissionGetsFreshGraceTimeout` in `lightning/pkg/importinto` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The test’s mock could convert scheduler delay after observation into a checkpoint record deadline error, triggering cleanup not expected by the test.

#### Fix

Moving the release wait after the context-alive check verifies the intended contract before blocking and removes the post-observation race.

#### Verification

Spec:
- target: `lightning/pkg/importinto :: TestJobOrchestratorRecordSubmissionGetsFreshGraceTimeout`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
timing_repro passed.
target_flaky passed.
package passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: PASS
- target_flaky: PASS
- package: PASS
- build: PASS
- lint: PASS

Commands:
- `tools/check/failpoint-go-test.sh lightning/pkg/importinto -json -run '^TestJobOrchestratorRecordSubmissionGetsFreshGraceTimeout$' -count=1 -timeout=10s`
- `go test -json -tags=intest,deadlock ./lightning/pkg/importinto -run '^TestJobOrchestratorRecordSubmissionGetsFreshGraceTimeout$' -count=1`
- `go test -json -tags=intest,deadlock ./lightning/pkg/importinto -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test logic for job orchestrator context cancellation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->