### PR TITLE
test: stabilize flaky TestIssue54335

### DIFF
--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -2596,10 +2596,23 @@ func TestIssue54335(t *testing.T) {
 		session.MustExec(t, se, "insert into testTable2 select * from testTable2")
 	}
 
+	// handleQuery bypasses dispatch's per-request cleanup, so mirror it here.
+	runQuery := func(sql string) error {
+		defer func() {
+			cc.ctx.SetProcessInfo("", time.Now(), mysql.ComSleep, 0)
+			cc.ctx.GetSessionVars().SQLKiller.Reset()
+		}()
+		return cc.handleQuery(context.Background(), sql)
+	}
+
+	_ = runQuery("select /*+ MAX_EXECUTION_TIME(1)*/  * FROM testTable2;")
+	time.Sleep(150 * time.Millisecond)
+	require.Zero(t, cc.ctx.GetSessionVars().SQLKiller.GetKillSignal())
+
 	times := 100
 	for ; times > 0; times-- {
 		// Test with -race
-		_ = cc.handleQuery(context.Background(), "select /*+ MAX_EXECUTION_TIME(1)*/  * FROM testTable2;")
+		_ = runQuery("select /*+ MAX_EXECUTION_TIME(1)*/  * FROM testTable2;")
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67558

Problem Summary:
Flaky test `TestIssue54335` in `pkg/server` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Direct `handleQuery` in `TestIssue54335` skipped dispatch cleanup and left stale max-exec process info that could trigger async kills after the query returned.

#### Fix

Mirroring dispatch cleanup in the direct-call test harness preserves the stress intent while preventing stale cross-query kill state.

#### Verification

Spec:
- target: `pkg/server :: TestIssue54335`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
build passed.

Gate checklist:
- stale_state_diagnostic: SKIPPED
- target_flaky: PASS
- package_context: SKIPPED
- build: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/server -run '^TestIssue54335$' -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by ensuring proper cleanup of internal state between query executions, preventing state accumulation that could affect subsequent test iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->