### PR TITLE
planner: support semi join rewrite as an alternative logical plan

### DIFF
--- a/pkg/planner/core/casetest/correlated/correlated_test.go
+++ b/pkg/planner/core/casetest/correlated/correlated_test.go
@@ -130,7 +130,7 @@ func TestNaturalJoinWithCorrelatedSubquery(tt *testing.T) {
 			require.False(t, planContainsText(offPlan, "Apply"), strings.Join(offPlan, "\n"))
 
 			tk.MustExec("set @@tidb_opt_enable_alternative_logical_plans=on")
-			require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/planner/failIfAlternativeLogicalPlanRoundTriggered", fmt.Sprintf("return(%q)", sql)))
+			require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/planner/failIfAlternativeLogicalPlanRoundTriggered", fmt.Sprintf("return(%q)", "non-decorrelate:"+sql)))
 			err := tk.ExecToErr(sql)
 			stmtCtx := tk.Session().GetSessionVars().StmtCtx
 			require.True(t, stmtCtx.AlternativeLogicalPlanDecorrelatedApply)
@@ -154,7 +154,7 @@ func TestNaturalJoinWithCorrelatedSubquery(tt *testing.T) {
 			tk.MustExec("analyze table alt_skip_t1, alt_skip_t2")
 
 			sql := "select alt_skip_t1.a from alt_skip_t1 where exists (select 1 from alt_skip_t2 where alt_skip_t2.a = alt_skip_t1.a and alt_skip_t2.b > 0) order by alt_skip_t1.a"
-			require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/planner/failIfAlternativeLogicalPlanRoundTriggered", fmt.Sprintf("return(%q)", sql)))
+			require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/planner/failIfAlternativeLogicalPlanRoundTriggered", fmt.Sprintf("return(%q)", "non-decorrelate:"+sql)))
 			defer func() {
 				require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/planner/failIfAlternativeLogicalPlanRoundTriggered"))
 			}()

--- a/pkg/planner/core/casetest/rule/rule_outer_to_semi_join_test.go
+++ b/pkg/planner/core/casetest/rule/rule_outer_to_semi_join_test.go
@@ -102,5 +102,10 @@ func TestSemiJoinRewrite(t *testing.T) {
 		tk.MustHavePlan(`delete from t1 where t1.id in (select /*+ semi_join_rewrite() */ /* issue:58829 */ cast(id as char) from t2 where k=1)`, "IndexHashJoin")
 		tk.MustExec(`delete from t1 where t1.id in (select /*+ semi_join_rewrite() */ cast(id as char) from t2 where k=1)`)
 		tk.MustQuery(`select id from t1 order by id`).Check(testkit.Rows("2", "3"))
+
+		tk.MustExec(`insert into t1 values ("1")`)
+		tk.MustExec(`set @@tidb_opt_enable_alternative_logical_plans=on`)
+		tk.MustExec(`set @@tidb_opt_enable_semi_join_rewrite=off`)
+		tk.MustHavePlan(`delete from t1 where t1.id in (select /* issue:58829 */ cast(id as char) from t2 where k=1)`, "IndexHashJoin")
 	})
 }

--- a/pkg/planner/core/casetest/rule/testdata/correlate_suite_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/correlate_suite_out.json
@@ -274,13 +274,14 @@
         "SQL": "select * from t1 where b = 1 and exists (select 1 from t2 where t2.a = t1.a) limit 1",
         "Plan": [
           "Limit 1.00 root  offset:0, count:1",
-          "└─IndexHashJoin 1.00 root  semi join, inner:IndexReader, left side:TableReader, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
-          "  ├─TableReader(Build) 1.25 root  data:Selection",
-          "  │ └─Selection 1.25 cop[tikv]  eq(test.t1.b, 1), not(isnull(test.t1.a))",
-          "  │   └─TableFullScan 1251.25 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "  └─IndexReader(Probe) 1.56 root  index:Selection",
-          "    └─Selection 1.56 cop[tikv]  not(isnull(test.t2.a))",
-          "      └─IndexRangeScan 1.56 cop[tikv] table:t2, index:a(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo"
+          "└─IndexJoin 1.00 root  inner join, inner:StreamAgg, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
+          "  ├─TableReader(Build) 1.00 root  data:Selection",
+          "  │ └─Selection 1.00 cop[tikv]  eq(test.t1.b, 1), not(isnull(test.t1.a))",
+          "  │   └─TableFullScan 1001.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─StreamAgg(Probe) 1.00 root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "    └─IndexReader 1.00 root  index:Selection",
+          "      └─Selection 1.00 cop[tikv]  not(isnull(test.t2.a))",
+          "        └─IndexRangeScan 1.00 cop[tikv] table:t2, index:a(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:true, stats:pseudo"
         ],
         "Result": [
           "1 1"
@@ -327,13 +328,15 @@
       {
         "SQL": "select * from t1 where exists (select 1 from t2 where t2.a = t1.a)",
         "Plan": [
-          "IndexHashJoin 7992.00 root  semi join, inner:IndexReader, left side:TableReader, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
-          "├─TableReader(Build) 9990.00 root  data:Selection",
-          "│ └─Selection 9990.00 cop[tikv]  not(isnull(test.t1.a))",
-          "│   └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "└─IndexReader(Probe) 12487.50 root  index:Selection",
-          "  └─Selection 12487.50 cop[tikv]  not(isnull(test.t2.a))",
-          "    └─IndexRangeScan 12500.00 cop[tikv] table:t2, index:a(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo"
+          "IndexHashJoin 9990.00 root  inner join, inner:IndexLookUp, outer key:test.t2.a, inner key:test.t1.a, equal cond:eq(test.t2.a, test.t1.a)",
+          "├─StreamAgg(Build) 7992.00 root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─IndexReader 7992.00 root  index:StreamAgg",
+          "│   └─StreamAgg 7992.00 cop[tikv]  group by:test.t2.a, ",
+          "│     └─IndexFullScan 9990.00 cop[tikv] table:t2, index:a(a) keep order:true, stats:pseudo",
+          "└─IndexLookUp(Probe) 9990.00 root  ",
+          "  ├─Selection(Build) 9990.00 cop[tikv]  not(isnull(test.t1.a))",
+          "  │ └─IndexRangeScan 10000.00 cop[tikv] table:t1, index:a(a) range: decided by [eq(test.t1.a, test.t2.a)], keep order:false, stats:pseudo",
+          "  └─TableRowIDScan(Probe) 9990.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",

--- a/pkg/planner/core/casetest/rule/testdata/correlate_suite_xut.json
+++ b/pkg/planner/core/casetest/rule/testdata/correlate_suite_xut.json
@@ -274,13 +274,14 @@
         "SQL": "select * from t1 where b = 1 and exists (select 1 from t2 where t2.a = t1.a) limit 1",
         "Plan": [
           "Limit 1.00 root  offset:0, count:1",
-          "└─IndexHashJoin 1.00 root  semi join, inner:IndexReader, left side:TableReader, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
-          "  ├─TableReader(Build) 1.25 root  data:Selection",
-          "  │ └─Selection 1.25 cop[tikv]  eq(test.t1.b, 1), not(isnull(test.t1.a))",
-          "  │   └─TableFullScan 1251.25 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "  └─IndexReader(Probe) 1.56 root  index:Selection",
-          "    └─Selection 1.56 cop[tikv]  not(isnull(test.t2.a))",
-          "      └─IndexRangeScan 1.56 cop[tikv] table:t2, index:a(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo"
+          "└─IndexJoin 1.00 root  inner join, inner:StreamAgg, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
+          "  ├─TableReader(Build) 1.00 root  data:Selection",
+          "  │ └─Selection 1.00 cop[tikv]  eq(test.t1.b, 1), not(isnull(test.t1.a))",
+          "  │   └─TableFullScan 1001.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─StreamAgg(Probe) 1.00 root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "    └─IndexReader 1.00 root  index:Selection",
+          "      └─Selection 1.00 cop[tikv]  not(isnull(test.t2.a))",
+          "        └─IndexRangeScan 1.00 cop[tikv] table:t2, index:a(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:true, stats:pseudo"
         ],
         "Result": [
           "1 1"
@@ -327,13 +328,15 @@
       {
         "SQL": "select * from t1 where exists (select 1 from t2 where t2.a = t1.a)",
         "Plan": [
-          "IndexHashJoin 7992.00 root  semi join, inner:IndexReader, left side:TableReader, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
-          "├─TableReader(Build) 9990.00 root  data:Selection",
-          "│ └─Selection 9990.00 cop[tikv]  not(isnull(test.t1.a))",
-          "│   └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "└─IndexReader(Probe) 12487.50 root  index:Selection",
-          "  └─Selection 12487.50 cop[tikv]  not(isnull(test.t2.a))",
-          "    └─IndexRangeScan 12500.00 cop[tikv] table:t2, index:a(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo"
+          "IndexHashJoin 9990.00 root  inner join, inner:IndexLookUp, outer key:test.t2.a, inner key:test.t1.a, equal cond:eq(test.t2.a, test.t1.a)",
+          "├─StreamAgg(Build) 7992.00 root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─IndexReader 7992.00 root  index:StreamAgg",
+          "│   └─StreamAgg 7992.00 cop[tikv]  group by:test.t2.a, ",
+          "│     └─IndexFullScan 9990.00 cop[tikv] table:t2, index:a(a) keep order:true, stats:pseudo",
+          "└─IndexLookUp(Probe) 9990.00 root  ",
+          "  ├─Selection(Build) 9990.00 cop[tikv]  not(isnull(test.t1.a))",
+          "  │ └─IndexRangeScan 10000.00 cop[tikv] table:t1, index:a(a) range: decided by [eq(test.t1.a, test.t2.a)], keep order:false, stats:pseudo",
+          "  └─TableRowIDScan(Probe) 9990.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -5785,6 +5785,12 @@ func (b *PlanBuilder) buildSemiJoin(outerPlan, innerPlan base.LogicalPlan, onCon
 			joinPlan.JoinType = base.SemiJoin
 		}
 	}
+	if b.ctx.GetSessionVars().EnableAlternativeLogicalPlans &&
+		!forceRewrite &&
+		!b.ctx.GetSessionVars().EnableSemiJoinRewrite &&
+		joinPlan.JoinType == base.SemiJoin {
+		b.ctx.GetSessionVars().StmtCtx.MarkAlternativeLogicalPlanSemiJoinRewrite()
+	}
 	// Apply forces to choose hash join currently, so don't worry the hints will take effect if the semi join is in one apply.
 	joinPlan.SetPreferredJoinTypeAndOrder(b.TableHints())
 	// Make the session variable behave like the hint by setting the same prefer bit.

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -611,6 +611,12 @@ func shouldTryCorrelateRound(sessVars *variable.SessionVars) bool {
 		sessVars.StmtCtx.AlternativeLogicalPlanPreferCorrelate
 }
 
+func shouldTrySemiJoinRewriteRound(sessVars *variable.SessionVars) bool {
+	return sessVars.EnableAlternativeLogicalPlans &&
+		sessVars.StmtCtx.AlternativeLogicalPlanSemiJoinRewrite &&
+		!sessVars.EnableSemiJoinRewrite
+}
+
 // alternativeRound describes one alternative logical-plan round.
 // adjustFlag adjusts the optimization flags for the round.
 // enabled returns true when the round should be attempted.
@@ -627,6 +633,11 @@ type alternativeRound struct {
 // EnableCorrelateSubquery so setup/cleanup can share it without a closure
 // wrapper. Safe because optimize is single-threaded per session.
 var savedEnableCorrelateSubquery bool
+
+// savedEnableSemiJoinRewrite holds the pre-round value of
+// EnableSemiJoinRewrite so setup/cleanup can restore it after the
+// semi-join-rewrite round. Safe because optimize is single-threaded per session.
+var savedEnableSemiJoinRewrite bool
 
 // savedFTSLikeFallback holds the pre-round value of
 // AlternativeLogicalPlanFTSLikeFallback so the fts-like-fallback round's
@@ -655,6 +666,17 @@ var alternativeRounds = [...]alternativeRound{
 		},
 		cleanup: func(sv *variable.SessionVars) {
 			sv.EnableCorrelateSubquery = savedEnableCorrelateSubquery
+		},
+	},
+	{
+		name:    "semi-join-rewrite",
+		enabled: shouldTrySemiJoinRewriteRound,
+		setup: func(sv *variable.SessionVars) {
+			savedEnableSemiJoinRewrite = sv.EnableSemiJoinRewrite
+			sv.EnableSemiJoinRewrite = true
+		},
+		cleanup: func(sv *variable.SessionVars) {
+			sv.EnableSemiJoinRewrite = savedEnableSemiJoinRewrite
 		},
 	},
 	{

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -806,7 +806,8 @@ func optimize(ctx context.Context, sctx planctx.PlanContext, node *resolve.NodeW
 	for _, round := range enabledRounds {
 		restoreLogicalPlanBuildCtx(sessVars, initialLogicalPlanCtx)
 		failpoint.Inject("failIfAlternativeLogicalPlanRoundTriggered", func(val failpoint.Value) {
-			if testSQL, ok := val.(string); ok && testSQL == node.Node.OriginalText() {
+			if testRoundAndSQL, ok := val.(string); ok &&
+				testRoundAndSQL == round.name+":"+node.Node.OriginalText() {
 				failpoint.Return(nil, nil, 0, errors.New("unexpected alternative logical plan round"))
 			}
 		})

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -486,6 +486,9 @@ type StatementContext struct {
 	// build round encountered a non-correlated IN subquery eligible for the
 	// correlate-to-Apply alternative.
 	AlternativeLogicalPlanPreferCorrelate bool
+	// AlternativeLogicalPlanSemiJoinRewrite indicates whether the current logical
+	// build found a semi join that can try an additional SEMI_JOIN_REWRITE round.
+	AlternativeLogicalPlanSemiJoinRewrite bool
 	// AlternativeLogicalPlanFTSLikeFallback is a mode flag controlling how the
 	// expression rewriter handles MATCH...AGAINST in predicate contexts. When
 	// false (the default, matching Alt-disabled behavior) the rewriter emits
@@ -683,6 +686,7 @@ func (sc *StatementContext) ResetAlternativeLogicalPlanSignals() {
 	sc.AlternativeLogicalPlanFTSLikeFallback = false
 	sc.AlternativeLogicalPlanHasPredicateContextMatch = false
 	sc.AlternativeLogicalPlanPreferCorrelate = false
+	sc.AlternativeLogicalPlanSemiJoinRewrite = false
 }
 
 // MarkAlternativeLogicalPlanDecorrelatedApply records that at least one Apply has
@@ -708,6 +712,12 @@ func (sc *StatementContext) MarkAlternativeLogicalPlanOrderAwareJoinReorder() {
 // the correlate-to-Apply alternative.
 func (sc *StatementContext) MarkAlternativeLogicalPlanPreferCorrelate() {
 	sc.AlternativeLogicalPlanPreferCorrelate = true
+}
+
+// MarkAlternativeLogicalPlanSemiJoinRewrite records that the current first round
+// found a semi join that can try an extra SEMI_JOIN_REWRITE-based logical round.
+func (sc *StatementContext) MarkAlternativeLogicalPlanSemiJoinRewrite() {
+	sc.AlternativeLogicalPlanSemiJoinRewrite = true
 }
 
 // CtxID returns the context id of the statement


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67467

Problem Summary:

The optimizer can use `SEMI_JOIN_REWRITE` when it is forced by hint or session variable, but alternative logical plan search did not try that rewrite as a competing logical plan when alternative logical plans are enabled.

### What changed and how does it work?

This PR records when the first logical plan build sees a semi join that can try `SEMI_JOIN_REWRITE`, and adds an alternative logical-plan round that temporarily enables semi join rewrite for that build+optimize round. The new round follows the existing `alternativeRound` setup/cleanup pattern and restores `EnableSemiJoinRewrite` after the round finishes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for semi-join rewrite operations and updated expected query execution plans for correlated subquery cases.

* **Query Optimization**
  * Enhanced optimizer to evaluate alternative semi-join rewrite strategies when appropriate configuration flags are enabled, with updated plan selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->