### PR TITLE
parser, ddl: allow clearing materialized view log purge schedule

### DIFF
--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -744,17 +744,15 @@ func TestAlterMaterializedViewLogPurgeUpdatesMetaAndNextTime(t *testing.T) {
 		mlogID,
 	)).Check(testkit.Rows("1 1 1"))
 
-	/*
-		tk.MustExec("alter materialized view log on t purge")
-		_, purgeMethod, purgeStartWith, purgeNext = getMLogMeta()
-		require.Equal(t, "DEFERRED", purgeMethod)
-		require.Equal(t, "", purgeStartWith)
-		require.Equal(t, "", purgeNext)
-		tk.MustQuery(fmt.Sprintf(
-			"select NEXT_TIME is null from mysql.tidb_mlog_purge_info where MLOG_ID = %d",
-			mlogID,
-		)).Check(testkit.Rows("1"))
-	*/
+	tk.MustExec("alter materialized view log on t purge")
+	_, purgeMethod, purgeStartWith, purgeNext = getMLogMeta()
+	require.Equal(t, "DEFERRED", purgeMethod)
+	require.Equal(t, "", purgeStartWith)
+	require.Equal(t, "", purgeNext)
+	tk.MustQuery(fmt.Sprintf(
+		"select NEXT_TIME is null from mysql.tidb_mlog_purge_info where MLOG_ID = %d",
+		mlogID,
+	)).Check(testkit.Rows("1"))
 
 	err := tk.ExecToErr("alter materialized view log on t purge immediate")
 	require.ErrorContains(t, err, "PURGE IMMEDIATE is not supported for ALTER MATERIALIZED VIEW LOG")
@@ -762,7 +760,7 @@ func TestAlterMaterializedViewLogPurgeUpdatesMetaAndNextTime(t *testing.T) {
 	_, purgeMethod, purgeStartWith, purgeNext = getMLogMeta()
 	require.Equal(t, "DEFERRED", purgeMethod)
 	require.Equal(t, "", purgeStartWith)
-	require.Equal(t, "DATE_ADD(NOW(), INTERVAL 25 MINUTE)", purgeNext)
+	require.Equal(t, "", purgeNext)
 
 	tk.MustExec("drop materialized view log on t")
 }

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -1445,6 +1445,7 @@ import (
 	MLogCreateOption                       "materialized view log create option"
 	MLogPurgeClauseOpt                     "materialized view log optional PURGE clause"
 	MLogPurgeClause                        "materialized view log PURGE clause"
+	AlterMLogPurgeClause                   "ALTER materialized view log PURGE clause"
 	MLogAccumulationAlertClauseOpt         "materialized view log optional ALERT ROWS clause"
 	MLogAccumulationAlertClause            "materialized view log ALERT ROWS clause"
 	MLogStartWithOpt                       "materialized view log START WITH option"
@@ -5587,13 +5588,23 @@ AlterMaterializedViewLogActionList:
 	}
 
 AlterMaterializedViewLogAction:
-	MLogPurgeClause
+	AlterMLogPurgeClause
 	{
 		$$ = &ast.AlterMaterializedViewLogAction{Tp: ast.AlterMaterializedViewLogActionPurge, Purge: $1.(*ast.MLogPurgeClause)}
 	}
 |	"ADD" ColumnKeywordOpt '(' ColumnList ')'
 	{
 		$$ = &ast.AlterMaterializedViewLogAction{Tp: ast.AlterMaterializedViewLogActionAddColumn, Cols: $4.([]model.CIStr)}
+	}
+
+AlterMLogPurgeClause:
+	MLogPurgeClause
+	{
+		$$ = $1
+	}
+|	"PURGE"
+	{
+		$$ = &ast.MLogPurgeClause{}
 	}
 
 DropMaterializedViewStmt:

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5477,8 +5477,8 @@ func TestMaterializedViewStatements(t *testing.T) {
 		},
 		{
 			"ALTER MATERIALIZED VIEW LOG ON t PURGE",
-			false,
-			"",
+			true,
+			"ALTER MATERIALIZED VIEW LOG ON `t` PURGE",
 		},
 		{
 			"ALTER MATERIALIZED VIEW LOG ON t PURGE START WITH now()",
@@ -5633,6 +5633,8 @@ func TestMaterializedViewCreateRefreshOnClauseSyntax(t *testing.T) {
 func TestMaterializedViewLogCreatePurgeClauseSyntax(t *testing.T) {
 	p := parser.New()
 	_, err := p.ParseOneStmt("CREATE MATERIALIZED VIEW LOG ON t (a) PURGE START WITH now()", "", "")
+	require.Error(t, err)
+	_, err = p.ParseOneStmt("CREATE MATERIALIZED VIEW LOG ON t (a) PURGE", "", "")
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:

`CREATE MATERIALIZED VIEW LOG` can omit the purge schedule entirely, but `ALTER MATERIALIZED VIEW LOG` could not clear an existing `PURGE START WITH` / `PURGE NEXT` schedule because bare `ALTER MATERIALIZED VIEW LOG ... PURGE` was rejected by the parser.

### What changed and how does it work?

This PR adds an ALTER-specific materialized view log purge grammar so `ALTER MATERIALIZED VIEW LOG ON t PURGE` is accepted without relaxing the `CREATE MATERIALIZED VIEW LOG ... PURGE` grammar.

The existing DDL execution path already supports an empty purge clause by persisting `DEFERRED` with empty `PurgeStartWith` and `PurgeNext`, and then recalculating `mysql.tidb_mlog_purge_info.NEXT_TIME` to `NULL`.

The tests cover:

- parsing and restoring `ALTER MATERIALIZED VIEW LOG ON t PURGE`;
- keeping bare `CREATE MATERIALIZED VIEW LOG ... PURGE` invalid;
- clearing mlog purge metadata and `NEXT_TIME` through ALTER.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands run:

```bash
make -C pkg/parser -B parser.go
go test -run "^(TestMaterializedViewStatements|TestMaterializedViewLogCreatePurgeClauseSyntax)$" -tags=intest,deadlock -count=1
go test ./pkg/executor/test/ddl -run "^TestAlterMaterializedViewLogPurgeUpdatesMetaAndNextTime$" -tags=intest,deadlock -count=1
make bazel_lint_changed
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Support clearing materialized view log purge schedules by using `ALTER MATERIALIZED VIEW LOG ... PURGE`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `ALTER MATERIALIZED VIEW LOG ... PURGE` syntax to clear purge metadata and reset timing information.

* **Tests**
  * Updated tests to verify proper metadata handling when executing purge operations on materialized view logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->