### PR TITLE
tests: stabilize aggregate variance output

### DIFF
--- a/tests/integrationtest/t/executor/aggregate.test
+++ b/tests/integrationtest/t/executor/aggregate.test
@@ -640,7 +640,7 @@ insert into t values(1, 255, 6.8, 6.08, 1);
 #   Darwin arm64          : 1.1808222222222222
 #   Rocky Linux x86_64    : 1.180822222222222
 #   CI Linux x86_64 seen  : 1.1808222222222229
---replace_regex /^1\.180822222222222[29]$/1.180822222222222/
+--replace_regex /\b1\.180822222222222[29]\b/1.180822222222222/
 select variance(distinct b), variance(distinct c), variance(distinct d), variance(distinct e) from t group by a;
 insert into t values(2, 322, 0.8, 2.22, 6);
 --sorted_result

--- a/tests/integrationtest/t/executor/aggregate.test
+++ b/tests/integrationtest/t/executor/aggregate.test
@@ -632,12 +632,15 @@ select a, var_pop(distinct b), var_pop(distinct c), var_pop(distinct d), var_pop
 drop table t;
 create table t(a int, b bigint, c float, d double, e decimal);
 insert into t values(1, 1000, 6.8, 3.45, 8.3), (1, 3998, -3.4, 5.12, 9.3),(1, 288, 9.2, 6.08, 1);
-# On Mac arm64 floating point calculations slightly different than x86
+# On macOS arm64, floating point calculations can produce 1.1808222222222222 instead of the Linux x86_64 result.
 --replace_regex /1.1808222222222222/1.1808222222222229/
 select variance(b), variance(c), variance(d), variance(e) from t group by a;
 insert into t values(1, 255, 6.8, 6.08, 1);
-# On Mac arm64 floating point calculations slightly different than x86
---replace_regex /1.1808222222222222/1.1808222222222229/
+# Floating point accumulation order can produce last-bit differences:
+#   Darwin arm64          : 1.1808222222222222
+#   Rocky Linux x86_64    : 1.180822222222222
+#   CI Linux x86_64 seen  : 1.1808222222222229
+--replace_regex /^1\.180822222222222[29]$/1.180822222222222/
 select variance(distinct b), variance(distinct c), variance(distinct d), variance(distinct e) from t group by a;
 insert into t values(2, 322, 0.8, 2.22, 6);
 --sorted_result


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69282

Problem Summary:

The `executor/aggregate` integration test can fail on `variance(distinct ...)` because the distinct float aggregation result has last-bit differences across runs/environments. CI observed `1.1808222222222229`, while the recorded expected value is `1.180822222222222`.

### What changed and how does it work?

This PR updates the `executor/aggregate` integration test fixture to normalize the known last-bit variants for the affected `variance(distinct ...)` result to the recorded expected value.

It also documents the observed values:

```text
Darwin arm64          : 1.1808222222222222
Rocky Linux x86_64    : 1.180822222222222
CI Linux x86_64 seen  : 1.1808222222222229
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
  - `cd tests/integrationtest && ./run-tests.sh -r executor/aggregate`
- [x] Manual test (add detailed scripts or steps below)
  - `make lint`
  - `git diff --check`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated aggregation test validation rules to improve floating-point variance result consistency across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->