### PR TITLE
executor: add ExportTable plan node and executor stub for EXPORT TABLE

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -234,6 +234,8 @@ func (b *executorBuilder) build(p base.Plan) exec.Executor {
 		return b.buildInsert(v)
 	case *plannercore.ImportInto:
 		return b.buildImportInto(v)
+	case *plannercore.ExportTable:
+		return b.buildExportTable(v)
 	case *plannercore.LoadData:
 		return b.buildLoadData(v)
 	case *plannercore.LoadStats:
@@ -1113,6 +1115,22 @@ func (b *executorBuilder) buildImportInto(v *plannercore.ImportInto) exec.Execut
 	}
 
 	return executor
+}
+
+func (b *executorBuilder) buildExportTable(v *plannercore.ExportTable) exec.Executor {
+	// see buildImportInto for detail why we use the latest schema here.
+	latestIS := b.sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
+	tbl, ok := latestIS.TableByID(context.Background(), v.Table.TableInfo.ID)
+	if !ok {
+		b.err = errors.Errorf("Can not get table %d", v.Table.TableInfo.ID)
+		return nil
+	}
+	if !tbl.Meta().IsBaseTable() {
+		b.err = plannererrors.ErrNonUpdatableTable.GenWithStackByArgs(tbl.Meta().Name.O, "EXPORT")
+		return nil
+	}
+	base := exec.NewBaseExecutor(b.sctx, v.Schema(), v.ID())
+	return newExportTableExec(base, b.sctx, v, tbl)
 }
 
 func (b *executorBuilder) buildLoadData(v *plannercore.LoadData) exec.Executor {

--- a/pkg/executor/export_table.go
+++ b/pkg/executor/export_table.go
@@ -1,0 +1,158 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+	"strings"
+
+	"github.com/docker/go-units"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/executor/internal/exec"
+	plannercore "github.com/pingcap/tidb/pkg/planner/core"
+	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/table"
+	"github.com/pingcap/tidb/pkg/util/chunk"
+)
+
+const defaultExportFileSize = 256 * units.MiB
+
+// ExportTableExec is the executor for the EXPORT TABLE statement. It validates
+// the statement and its options; submitting the actual distributed export task
+// (pkg/dxf/export) is not wired up yet.
+type ExportTableExec struct {
+	exec.BaseExecutor
+
+	userSctx sessionctx.Context
+	plan     *plannercore.ExportTable
+	tbl      table.Table
+	done     bool
+}
+
+func newExportTableExec(b exec.BaseExecutor, userSctx sessionctx.Context,
+	plan *plannercore.ExportTable, tbl table.Table) *ExportTableExec {
+	return &ExportTableExec{
+		BaseExecutor: b,
+		userSctx:     userSctx,
+		plan:         plan,
+		tbl:          tbl,
+	}
+}
+
+type exportOptions struct {
+	fileSize int64
+	// thread is the task concurrency, which is also the per-subtask encoder
+	// count. 0 means auto.
+	thread            int
+	readersPerEncoder int
+	writersPerEncoder int
+	subtaskRegions    int
+	detached          bool
+}
+
+func (e *ExportTableExec) parseOptions() (*exportOptions, error) {
+	opts := &exportOptions{
+		fileSize: defaultExportFileSize,
+	}
+	evalCtx := e.userSctx.GetExprCtx().GetEvalCtx()
+	for _, opt := range e.plan.Options {
+		optAsInt64 := func() (int64, error) {
+			if opt.Value == nil {
+				return 0, errors.Errorf("option %s requires a value", opt.Name)
+			}
+			d, err := opt.Value.Eval(evalCtx, chunk.Row{})
+			if err != nil {
+				return 0, err
+			}
+			return d.ToInt64(evalCtx.TypeCtx())
+		}
+		switch opt.Name {
+		case "file_size":
+			if opt.Value == nil {
+				return nil, errors.Errorf("option file_size requires a value")
+			}
+			d, err := opt.Value.Eval(evalCtx, chunk.Row{})
+			if err != nil {
+				return nil, err
+			}
+			v, err := units.RAMInBytes(strings.TrimSpace(d.GetString()))
+			if err != nil || v <= 0 {
+				return nil, errors.Errorf("invalid file_size value %q", d.GetString())
+			}
+			opts.fileSize = v
+		case "thread":
+			v, err := optAsInt64()
+			if err != nil || v <= 0 || v > 256 {
+				return nil, errors.Errorf("invalid thread value")
+			}
+			opts.thread = int(v)
+		case "readers_per_encoder":
+			v, err := optAsInt64()
+			if err != nil || v <= 0 || v > 16 {
+				return nil, errors.Errorf("invalid readers_per_encoder value")
+			}
+			opts.readersPerEncoder = int(v)
+		case "writers_per_encoder":
+			v, err := optAsInt64()
+			if err != nil || v <= 0 || v > 16 {
+				return nil, errors.Errorf("invalid writers_per_encoder value")
+			}
+			opts.writersPerEncoder = int(v)
+		case "subtask_regions":
+			v, err := optAsInt64()
+			if err != nil || v <= 0 {
+				return nil, errors.Errorf("invalid subtask_regions value")
+			}
+			opts.subtaskRegions = int(v)
+		case "detached":
+			opts.detached = true
+		default:
+			return nil, errors.Errorf("unknown EXPORT TABLE option %s", opt.Name)
+		}
+	}
+	return opts, nil
+}
+
+func (e *ExportTableExec) validate() error {
+	if e.plan.Format != nil && strings.ToLower(*e.plan.Format) != "csv" {
+		return errors.Errorf("EXPORT TABLE only supports csv format now")
+	}
+	for _, col := range e.tbl.Meta().Columns {
+		if col.IsGenerated() && !col.GeneratedStored {
+			return errors.Errorf("EXPORT TABLE does not support virtual generated column %s", col.Name.O)
+		}
+	}
+	return nil
+}
+
+// Next implements the Executor Next interface.
+func (e *ExportTableExec) Next(_ context.Context, req *chunk.Chunk) error {
+	req.Reset()
+	if e.done {
+		return nil
+	}
+	e.done = true
+	if err := e.validate(); err != nil {
+		return err
+	}
+	if _, err := e.parseOptions(); err != nil {
+		return err
+	}
+	// TODO(export): submit the export DXF task (pkg/dxf/export) and report the
+	// job id/status. The execution path is not wired up in this PR.
+	return errors.Errorf("EXPORT TABLE is not supported yet")
+}
+
+var _ exec.Executor = (*ExportTableExec)(nil)

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -462,6 +462,17 @@ type ImportInto struct {
 	SelectPlan base.PhysicalPlan
 }
 
+// ExportTable represents an EXPORT TABLE plan.
+type ExportTable struct {
+	physicalop.SimpleSchemaProducer
+
+	Table   *resolve.TableNameW
+	Path    string
+	Format  *string
+	Options []*LoadDataOpt
+	Stmt    string
+}
+
 // LoadStats represents a load stats plan.
 type LoadStats struct {
 	physicalop.SimpleSchemaProducer

--- a/pkg/planner/core/initialize.go
+++ b/pkg/planner/core/initialize.go
@@ -32,6 +32,12 @@ func (p ImportInto) Init(ctx base.PlanContext) *ImportInto {
 	return &p
 }
 
+// Init initializes ExportTable.
+func (p ExportTable) Init(ctx base.PlanContext) *ExportTable {
+	p.Plan = baseimpl.NewBasePlan(ctx, "ExportTable", 0)
+	return &p
+}
+
 // Init initializes ScalarSubqueryEvalCtx
 func (p ScalarSubqueryEvalCtx) Init(ctx base.PlanContext, offset int) *ScalarSubqueryEvalCtx {
 	p.Plan = baseimpl.NewBasePlan(ctx, plancodec.TypeScalarSubQuery, offset)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #68984

Problem Summary:

Part of distributed single-table export (`EXPORT TABLE db.t TO 's3://...'`).
This PR wires the statement through the planner plan node, the executor
builder, and a stubbed executor, so the execution path exists end-to-end
inside `pkg/executor`. It does **not** touch the parser, so the new plan
node is not reachable from SQL yet; and it does **not** submit the
distributed export task. Splitting the parser and the DXF submission into
later PRs keeps each change small and reviewable.

### What changed and how does it work?

- `pkg/planner/core/common_plans.go`: add the `ExportTable` plan node
  (table, path, format, options).
- `pkg/planner/core/initialize.go`: add `ExportTable.Init`.
- `pkg/executor/builder.go`: add the `*plannercore.ExportTable` build case
  and `buildExportTable`, which resolves the table from the latest
  infoschema and rejects non-base tables.
- `pkg/executor/export_table.go` (new): `ExportTableExec` validates the
  statement (csv-only, no virtual generated columns) and parses options
  (`file_size`, `thread`, `readers_per_encoder`, `writers_per_encoder`,
  `subtask_regions`, `detached`). `Next` returns an "not supported yet"
  error because DXF task submission (`pkg/dxf/export`) is not wired up.

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > The new plan node is unreachable (no parser support) and the executor
  > is a stub that returns an unsupported error; behavior is exercised in
  > follow-up PRs that add the parser and DXF submission.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
