### PR TITLE
planner, executor: rename MV delta sides

### DIFF
--- a/docs/note/materialized_view/mv_refresh.md
+++ b/docs/note/materialized_view/mv_refresh.md
@@ -820,40 +820,40 @@ High-level algorithm:
 Example diff-shaping SQL (simplified):
 
 ```sql
-WITH q AS (
-    -- Full MV definition result; map selected marker column to q_marker
-    SELECT k1, k2, <mv_marker_col> AS q_marker, v1, v2
-    FROM (<mv_definition_sql>) q0
+WITH recomputed AS (
+    -- Full MV definition result; map selected marker column to recomputed_marker
+    SELECT k1, k2, <mv_marker_col> AS recomputed_marker, v1, v2
+    FROM (<mv_definition_sql>) recomputed0
 ),
-m AS (
-    -- Current MV data; map same marker column to m_marker
-    SELECT k1, k2, <mv_marker_col> AS m_marker, v1, v2
+current AS (
+    -- Current MV data; map same marker column to current_marker
+    SELECT k1, k2, <mv_marker_col> AS current_marker, v1, v2
     FROM <mv_table>
 )
 SELECT
     CASE
-        WHEN m.m_marker IS NULL THEN 'I'
-        WHEN q.q_marker IS NULL THEN 'D'
+        WHEN current.current_marker IS NULL THEN 'I'
+        WHEN recomputed.recomputed_marker IS NULL THEN 'D'
         ELSE 'U'
     END AS diff_op,
-    COALESCE(q.k1, m.k1) AS k1,
-    COALESCE(q.k2, m.k2) AS k2,
-    q.v1 AS new_v1, q.v2 AS new_v2,
-    m.v1 AS old_v1, m.v2 AS old_v2
-FROM q
-FULL OUTER JOIN m
-  ON q.k1 = m.k1
- AND q.k2 = m.k2
+    COALESCE(recomputed.k1, current.k1) AS k1,
+    COALESCE(recomputed.k2, current.k2) AS k2,
+    recomputed.v1 AS new_v1, recomputed.v2 AS new_v2,
+    current.v1 AS old_v1, current.v2 AS old_v2
+FROM recomputed
+FULL OUTER JOIN current
+  ON recomputed.k1 = current.k1
+ AND recomputed.k2 = current.k2
 WHERE
-      q.q_marker IS NULL
-   OR m.m_marker IS NULL
-   OR NOT (q.v1 <=> m.v1 AND q.v2 <=> m.v2);
+      recomputed.recomputed_marker IS NULL
+   OR current.current_marker IS NULL
+   OR NOT (recomputed.v1 <=> current.v1 AND recomputed.v2 <=> current.v2);
 ```
 
-In the SQL sketch above, `q_marker` / `m_marker` are logical aliases used to express
+In the SQL sketch above, `recomputed_marker` / `current_marker` are logical aliases used to express
 side-missing detection and `diff_op` derivation. They do not have to remain as standalone
 output columns in the final planner-executor layout; the chosen marker can be read from
-the `Q` / `M` row image via explicit metadata.
+the recomputed / current row image via explicit metadata.
 
 #### Join and diff rules
 
@@ -865,9 +865,9 @@ the `Q` / `M` row image via explicit metadata.
 2. Payload equality check should use null-safe comparison (`<=>`) per column.
 3. Side-missing detection should use one deterministic marker column from MV schema:
    - pick the first visible `NOT NULL` column from MV `TableInfo.Columns` (stable column order);
-   - map this column as logical aliases `q_marker` / `m_marker` in diff SQL;
-   - `q_marker IS NULL` => row missing on query side (`DELETE`);
-   - `m_marker IS NULL` => row missing on MV side (`INSERT`).
+   - map this column as logical aliases `recomputed_marker` / `current_marker` in diff SQL;
+   - `recomputed_marker IS NULL` => row missing on recomputed side (`DELETE`);
+   - `current_marker IS NULL` => row missing on current MV side (`INSERT`).
 
 This avoids relying on key-column `IS NULL` checks and does not bind design
 to any specific aggregate output column.
@@ -910,16 +910,16 @@ For operator input layout, keep it explicit and stable (planner-executor contrac
 Additional layout metadata stays explicit even when columns are reused:
 
 1. marker selection is tracked by MV-column offset, so side-missing diagnostics can read the chosen
-   marker from the `M` / `Q` row image instead of projecting `q_marker` / `m_marker` twice;
-2. `MHandleCols` may either point to old-row-image columns (for PK/common handle) or to the optional
+   marker from the current / recomputed row image instead of projecting `recomputed_marker` / `current_marker` twice;
+2. `CurrentHandleCols` may either point to old-row-image columns (for PK/common handle) or to the optional
    extra `_tidb_rowid` column.
 
 `diff_op` should be generated in diff-source projection (instead of re-evaluating marker logic in sink):
 
 ```sql
 CASE
-  WHEN m_marker IS NULL THEN 1  -- INSERT
-  WHEN q_marker IS NULL THEN 2  -- DELETE
+  WHEN current_marker IS NULL THEN 1  -- INSERT
+  WHEN recomputed_marker IS NULL THEN 2  -- DELETE
   ELSE 3                        -- UPDATE
 END AS diff_op
 ```
@@ -934,7 +934,7 @@ Use integer op code (for example `TINYINT`) instead of string op code to keep ex
 
 Note on diff filtering:
 
-1. Keep existing diff filter (`q_marker IS NULL OR m_marker IS NULL OR payload_changed`) in `WHERE`.
+1. Keep existing diff filter (`recomputed_marker IS NULL OR current_marker IS NULL OR payload_changed`) in `WHERE`.
 2. Do not rely on select-field alias visibility in the same query block `WHERE`.
 3. If filtering by `diff_op` is needed, wrap one extra projection/query layer.
 
@@ -946,19 +946,19 @@ Recommended root sink-plan contract (`MViewCompleteDeltaApply` style):
 2. `MarkerMVOffset`: which MV column is used as the side-missing marker.
 3. `GroupKeyMVOffsets`: GROUP BY key offsets in MV column order; sink uses them to skip
    redundant update comparisons on join-equal key columns.
-4. `MHandleCols`: physical locator columns built from `M` side (used by `DELETE` and `UPDATE`,
+4. `CurrentHandleCols`: physical locator columns built from current side (used by `DELETE` and `UPDATE`,
    and intentionally separate from the diff-join key).
-5. `MRowInputColIDs` / `QRowInputColIDs`: full old/new row-image mappings in MV column order.
+5. `CurrentRowInputColIDs` / `RecomputedRowInputColIDs`: full old/new row-image mappings in MV column order.
 
 Writable input mappings should be derived in executor from `TargetTable.WritableCols()` plus
-`MRowInputColIDs` / `QRowInputColIDs`, instead of being persisted in planner contract. This keeps
+`CurrentRowInputColIDs` / `RecomputedRowInputColIDs`, instead of being persisted in planner contract. This keeps
 complete delta apply aligned with fast-refresh writer ownership.
 
 Per-row operation behavior in sink executor:
 
-1. `diff_op = 1` (`INSERT`): write `Q` row image via `AddRecord`.
-2. `diff_op = 2` (`DELETE`): build handle from `MHandleCols`, remove `M` old row via `RemoveRecord`.
-3. `diff_op = 3` (`UPDATE`): build handle from `MHandleCols`, update from `M` old row to `Q` new row via `UpdateRecord`.
+1. `diff_op = 1` (`INSERT`): write recomputed row image via `AddRecord`.
+2. `diff_op = 2` (`DELETE`): build handle from `CurrentHandleCols`, remove current old row via `RemoveRecord`.
+3. `diff_op = 3` (`UPDATE`): build handle from `CurrentHandleCols`, update from current old row to recomputed new row via `UpdateRecord`.
 
 Current write strategy:
 

--- a/docs/note/materialized_view/mv_refresh.md
+++ b/docs/note/materialized_view/mv_refresh.md
@@ -805,12 +805,12 @@ Use one `FULL OUTER JOIN`-based diff source query, then let one dedicated sink o
 
 High-level algorithm:
 
-1. Build query-side full result (`Q`) from MV definition SQL.
-2. Full-outer-join `Q` with current MV table (`M`) by the `GROUP BY` key
+1. Build recomputed full result from MV definition SQL.
+2. Full-outer-join the recomputed result with the current MV table by the `GROUP BY` key
    (which is the logical row identity in this refresh mode).
 3. Keep only changed rows:
-   - `Q-only` => `INSERT`
-   - `M-only` => `DELETE`
+   - recomputed-only => `INSERT`
+   - current-only => `DELETE`
    - both exist but payload differs => `UPDATE`
 4. Output one diff stream (`FOJ + Selection`) and feed it directly into a dedicated MV-apply sink operator.
    - this operator executes per-row `INSERT` / `UPDATE` / `DELETE` on target MV table in the same transaction.
@@ -904,8 +904,8 @@ For operator input layout, keep it explicit and stable (planner-executor contrac
 
 1. row-op column (`diff_op`);
 2. optional extra handle column (`_tidb_rowid`) only when MV uses extra row-id handle;
-3. old row image (`M`) columns for delete/update old values;
-4. new row image (`Q`) columns for insert/update new values.
+3. current row image columns for delete/update old values;
+4. recomputed row image columns for insert/update new values.
 
 Additional layout metadata stays explicit even when columns are reused:
 

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -1437,7 +1437,7 @@ func (b *executorBuilder) buildMViewCompleteDeltaApply(v *plannercore.MViewCompl
 		b.err = errors.Errorf("MViewCompleteDeltaApply target table id %d not found in infoschema", v.MVTableID)
 		return nil
 	}
-	if v.MHandleCols == nil {
+	if v.CurrentHandleCols == nil {
 		b.err = errors.New("MViewCompleteDeltaApply target handle cols is nil")
 		return nil
 	}
@@ -1446,37 +1446,37 @@ func (b *executorBuilder) buildMViewCompleteDeltaApply(v *plannercore.MViewCompl
 		b.err = errors.Errorf("MViewCompleteDeltaApply target public column count %d != plan MV column count %d", len(publicCols), v.MVColumnCount)
 		return nil
 	}
-	for i := 0; i < v.MHandleCols.NumCols(); i++ {
-		handleInputIdx := v.MHandleCols.GetCol(i).Index
+	for i := 0; i < v.CurrentHandleCols.NumCols(); i++ {
+		handleInputIdx := v.CurrentHandleCols.GetCol(i).Index
 		if handleInputIdx < 0 || handleInputIdx >= len(sourceFieldTypes) {
 			b.err = errors.Errorf("MViewCompleteDeltaApply handle col index %d out of source range [0,%d)", handleInputIdx, len(sourceFieldTypes))
 			return nil
 		}
 	}
 
-	mWritableInputColIDs, err := buildMViewCompleteDeltaWritableInputColIDs(mvTable, v.MRowInputColIDs)
+	currentWritableInputColIDs, err := buildMViewCompleteDeltaWritableInputColIDs(mvTable, v.CurrentRowInputColIDs)
 	if err != nil {
 		b.err = err
 		return nil
 	}
-	qWritableInputColIDs, err := buildMViewCompleteDeltaWritableInputColIDs(mvTable, v.QRowInputColIDs)
+	recomputedWritableInputColIDs, err := buildMViewCompleteDeltaWritableInputColIDs(mvTable, v.RecomputedRowInputColIDs)
 	if err != nil {
 		b.err = err
 		return nil
 	}
-	if err := validateMViewCompleteDeltaWritableInputColTypes(mvTable, sourceFieldTypes, mWritableInputColIDs); err != nil {
+	if err := validateMViewCompleteDeltaWritableInputColTypes(mvTable, sourceFieldTypes, currentWritableInputColIDs); err != nil {
 		b.err = err
 		return nil
 	}
-	if err := validateMViewCompleteDeltaWritableInputColTypes(mvTable, sourceFieldTypes, qWritableInputColIDs); err != nil {
+	if err := validateMViewCompleteDeltaWritableInputColTypes(mvTable, sourceFieldTypes, recomputedWritableInputColIDs); err != nil {
 		b.err = err
 		return nil
 	}
-	compareWritableIdxes, mCompareInputColIDs, qCompareInputColIDs, err := buildMViewCompleteDeltaCompareMappings(
+	compareWritableIdxes, currentCompareInputColIDs, recomputedCompareInputColIDs, err := buildMViewCompleteDeltaCompareMappings(
 		mvTable,
 		v.GroupKeyMVOffsets,
-		mWritableInputColIDs,
-		qWritableInputColIDs,
+		currentWritableInputColIDs,
+		recomputedWritableInputColIDs,
 	)
 	if err != nil {
 		b.err = err
@@ -1484,15 +1484,15 @@ func (b *executorBuilder) buildMViewCompleteDeltaApply(v *plannercore.MViewCompl
 	}
 
 	return &MViewCompleteDeltaApplyExec{
-		BaseExecutor:         exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), sourceExec),
-		TargetTable:          mvTable,
-		TargetHandleCols:     v.MHandleCols,
-		OpColID:              v.OpColID,
-		MWritableInputColIDs: append([]int(nil), mWritableInputColIDs...),
-		QWritableInputColIDs: append([]int(nil), qWritableInputColIDs...),
-		CompareWritableIdxes: append([]int(nil), compareWritableIdxes...),
-		MCompareInputColIDs:  append([]int(nil), mCompareInputColIDs...),
-		QCompareInputColIDs:  append([]int(nil), qCompareInputColIDs...),
+		BaseExecutor:                  exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), sourceExec),
+		TargetTable:                   mvTable,
+		TargetHandleCols:              v.CurrentHandleCols,
+		OpColID:                       v.OpColID,
+		CurrentWritableInputColIDs:    append([]int(nil), currentWritableInputColIDs...),
+		RecomputedWritableInputColIDs: append([]int(nil), recomputedWritableInputColIDs...),
+		CompareWritableIdxes:          append([]int(nil), compareWritableIdxes...),
+		CurrentCompareInputColIDs:     append([]int(nil), currentCompareInputColIDs...),
+		RecomputedCompareInputColIDs:  append([]int(nil), recomputedCompareInputColIDs...),
 	}
 }
 
@@ -1581,17 +1581,17 @@ func validateMViewCompleteDeltaWritableInputColTypes(
 func buildMViewCompleteDeltaCompareMappings(
 	target table.Table,
 	groupKeyMVOffsets []int,
-	mWritableInputColIDs []int,
-	qWritableInputColIDs []int,
+	currentWritableInputColIDs []int,
+	recomputedWritableInputColIDs []int,
 ) ([]int, []int, []int, error) {
 	if target == nil {
 		return nil, nil, nil, errors.New("MViewCompleteDeltaApply target table is nil")
 	}
-	if len(mWritableInputColIDs) != len(qWritableInputColIDs) {
+	if len(currentWritableInputColIDs) != len(recomputedWritableInputColIDs) {
 		return nil, nil, nil, errors.Errorf(
-			"MViewCompleteDeltaApply writable input mapping length mismatch: M=%d Q=%d",
-			len(mWritableInputColIDs),
-			len(qWritableInputColIDs),
+			"MViewCompleteDeltaApply writable input mapping length mismatch: current=%d recomputed=%d",
+			len(currentWritableInputColIDs),
+			len(recomputedWritableInputColIDs),
 		)
 	}
 	publicCols := target.Cols()
@@ -1617,8 +1617,8 @@ func buildMViewCompleteDeltaCompareMappings(
 	}
 
 	compareWritableIdxes := make([]int, 0, len(writableCols))
-	mCompareInputColIDs := make([]int, 0, len(writableCols))
-	qCompareInputColIDs := make([]int, 0, len(writableCols))
+	currentCompareInputColIDs := make([]int, 0, len(writableCols))
+	recomputedCompareInputColIDs := make([]int, 0, len(writableCols))
 	for writableIdx, col := range writableCols {
 		if col == nil {
 			return nil, nil, nil, errors.Errorf("MViewCompleteDeltaApply target writable column at offset %d is nil", writableIdx)
@@ -1635,10 +1635,10 @@ func buildMViewCompleteDeltaCompareMappings(
 			continue
 		}
 		compareWritableIdxes = append(compareWritableIdxes, writableIdx)
-		mCompareInputColIDs = append(mCompareInputColIDs, mWritableInputColIDs[writableIdx])
-		qCompareInputColIDs = append(qCompareInputColIDs, qWritableInputColIDs[writableIdx])
+		currentCompareInputColIDs = append(currentCompareInputColIDs, currentWritableInputColIDs[writableIdx])
+		recomputedCompareInputColIDs = append(recomputedCompareInputColIDs, recomputedWritableInputColIDs[writableIdx])
 	}
-	return compareWritableIdxes, mCompareInputColIDs, qCompareInputColIDs, nil
+	return compareWritableIdxes, currentCompareInputColIDs, recomputedCompareInputColIDs, nil
 }
 
 // buildTrace builds a TraceExec for future executing. This method will be called

--- a/pkg/executor/executor_pkg_test.go
+++ b/pkg/executor/executor_pkg_test.go
@@ -156,11 +156,11 @@ func TestMViewCompleteDeltaApplyOpenValidatesMappingsBeforeOpeningChild(t *testi
 		BaseExecutor: exec.NewBaseExecutor(sctx, childSchema, 0),
 	}
 	applyExec := &MViewCompleteDeltaApplyExec{
-		BaseExecutor:         exec.NewBaseExecutor(sctx, nil, 0, child),
-		TargetTable:          targetTbl,
-		TargetHandleCols:     plannerutil.NewIntHandleCols(&expression.Column{Index: 0, RetType: targetTp}),
-		MWritableInputColIDs: []int{1},
-		QWritableInputColIDs: []int{0},
+		BaseExecutor:                  exec.NewBaseExecutor(sctx, nil, 0, child),
+		TargetTable:                   targetTbl,
+		TargetHandleCols:              plannerutil.NewIntHandleCols(&expression.Column{Index: 0, RetType: targetTp}),
+		CurrentWritableInputColIDs:    []int{1},
+		RecomputedWritableInputColIDs: []int{0},
 	}
 
 	err := applyExec.Open(context.Background())

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -98,10 +98,10 @@ const (
 )
 
 type compareMaterializedViewDiffLayout struct {
-	groupKeyOffsets       []int
-	mvMarkerColIdx        int
-	baseMarkerColIdx      int
-	payloadCompareColumns []mviewCompleteDeltaCompareColumn
+	groupKeyOffsets        []int
+	currentMarkerColIdx    int
+	recomputedMarkerColIdx int
+	payloadCompareColumns  []mviewCompleteDeltaCompareColumn
 }
 
 type compareMaterializedViewRecordSetExec struct {
@@ -758,12 +758,12 @@ type MViewCompleteDeltaApplyExec struct {
 	TargetHandleCols plannerutil.HandleCols
 	OpColID          int
 
-	MWritableInputColIDs []int
-	QWritableInputColIDs []int
+	CurrentWritableInputColIDs    []int
+	RecomputedWritableInputColIDs []int
 
-	CompareWritableIdxes []int
-	MCompareInputColIDs  []int
-	QCompareInputColIDs  []int
+	CompareWritableIdxes         []int
+	CurrentCompareInputColIDs    []int
+	RecomputedCompareInputColIDs []int
 
 	writableFieldTypes []*types.FieldType
 	compareColumns     []mviewCompleteDeltaCompareColumn
@@ -783,11 +783,11 @@ type MViewCompleteDeltaApplyExec struct {
 }
 
 type mviewCompleteDeltaCompareColumn struct {
-	writableIdx int
-	mInputColID int
-	qInputColID int
-	fieldType   *types.FieldType
-	notNull     bool
+	writableIdx          int
+	currentInputColID    int
+	recomputedInputColID int
+	fieldType            *types.FieldType
+	notNull              bool
 }
 
 type mviewCompleteDeltaApplyWriterStats struct {
@@ -960,10 +960,10 @@ func (e *MViewCompleteDeltaApplyExec) Open(ctx context.Context) error {
 		return errors.New("MViewCompleteDeltaApply child executor is nil")
 	}
 	childTypes := child.RetFieldTypes()
-	if err := validateMViewCompleteDeltaWritableInputColTypes(e.TargetTable, childTypes, e.MWritableInputColIDs); err != nil {
+	if err := validateMViewCompleteDeltaWritableInputColTypes(e.TargetTable, childTypes, e.CurrentWritableInputColIDs); err != nil {
 		return err
 	}
-	if err := validateMViewCompleteDeltaWritableInputColTypes(e.TargetTable, childTypes, e.QWritableInputColIDs); err != nil {
+	if err := validateMViewCompleteDeltaWritableInputColTypes(e.TargetTable, childTypes, e.RecomputedWritableInputColIDs); err != nil {
 		return err
 	}
 
@@ -1174,12 +1174,12 @@ func (e *MViewCompleteDeltaApplyExec) collectChunkUpdateRows(ops []int64) (int, 
 }
 
 func (e *MViewCompleteDeltaApplyExec) initCompareColumns(inputColCount int) error {
-	if len(e.MCompareInputColIDs) != len(e.CompareWritableIdxes) || len(e.QCompareInputColIDs) != len(e.CompareWritableIdxes) {
+	if len(e.CurrentCompareInputColIDs) != len(e.CompareWritableIdxes) || len(e.RecomputedCompareInputColIDs) != len(e.CompareWritableIdxes) {
 		return errors.Errorf(
-			"MViewCompleteDeltaApply compare mapping length mismatch (compare=%d, M=%d, Q=%d)",
+			"MViewCompleteDeltaApply compare mapping length mismatch (compare=%d, current=%d, recomputed=%d)",
 			len(e.CompareWritableIdxes),
-			len(e.MCompareInputColIDs),
-			len(e.QCompareInputColIDs),
+			len(e.CurrentCompareInputColIDs),
+			len(e.RecomputedCompareInputColIDs),
 		)
 	}
 	if cap(e.compareColumns) >= len(e.CompareWritableIdxes) {
@@ -1195,29 +1195,29 @@ func (e *MViewCompleteDeltaApplyExec) initCompareColumns(inputColCount int) erro
 				len(e.writableFieldTypes),
 			)
 		}
-		mInputColID := e.MCompareInputColIDs[compareIdx]
-		if mInputColID < 0 || mInputColID >= inputColCount {
+		currentInputColID := e.CurrentCompareInputColIDs[compareIdx]
+		if currentInputColID < 0 || currentInputColID >= inputColCount {
 			return errors.Errorf(
-				"MViewCompleteDeltaApply M compare input col id %d out of source range [0,%d)",
-				mInputColID,
+				"MViewCompleteDeltaApply current compare input col id %d out of source range [0,%d)",
+				currentInputColID,
 				inputColCount,
 			)
 		}
-		qInputColID := e.QCompareInputColIDs[compareIdx]
-		if qInputColID < 0 || qInputColID >= inputColCount {
+		recomputedInputColID := e.RecomputedCompareInputColIDs[compareIdx]
+		if recomputedInputColID < 0 || recomputedInputColID >= inputColCount {
 			return errors.Errorf(
-				"MViewCompleteDeltaApply Q compare input col id %d out of source range [0,%d)",
-				qInputColID,
+				"MViewCompleteDeltaApply recomputed compare input col id %d out of source range [0,%d)",
+				recomputedInputColID,
 				inputColCount,
 			)
 		}
 		fieldType := e.writableFieldTypes[writableIdx]
 		e.compareColumns[compareIdx] = mviewCompleteDeltaCompareColumn{
-			writableIdx: writableIdx,
-			mInputColID: mInputColID,
-			qInputColID: qInputColID,
-			fieldType:   fieldType,
-			notNull:     mysql.HasNotNullFlag(fieldType.GetFlag()),
+			writableIdx:          writableIdx,
+			currentInputColID:    currentInputColID,
+			recomputedInputColID: recomputedInputColID,
+			fieldType:            fieldType,
+			notNull:              mysql.HasNotNullFlag(fieldType.GetFlag()),
 		}
 	}
 	return nil
@@ -1244,8 +1244,8 @@ func (e *MViewCompleteDeltaApplyExec) markChunkUpdateTouchedColumns(input *chunk
 			e.updateTouchedBitmap,
 			e.updateTouchedStride,
 			compareIdx,
-			input.Column(compareCol.mInputColID),
-			input.Column(compareCol.qInputColID),
+			input.Column(compareCol.currentInputColID),
+			input.Column(compareCol.recomputedInputColID),
 			compareCol.fieldType,
 			compareCol.notNull,
 			"COMPLETE DELTA APPLY",
@@ -1257,25 +1257,25 @@ func (e *MViewCompleteDeltaApplyExec) markChunkUpdateTouchedColumns(input *chunk
 }
 
 func (e *MViewCompleteDeltaApplyExec) buildDeleteRow(row chunk.Row) {
-	for writableIdx, colID := range e.MWritableInputColIDs {
+	for writableIdx, colID := range e.CurrentWritableInputColIDs {
 		row.DatumWithBuffer(colID, e.writableFieldTypes[writableIdx], &e.oldRow[writableIdx])
 	}
 }
 
 func (e *MViewCompleteDeltaApplyExec) buildInsertRow(row chunk.Row) {
-	for writableIdx, colID := range e.QWritableInputColIDs {
+	for writableIdx, colID := range e.RecomputedWritableInputColIDs {
 		row.DatumWithBuffer(colID, e.writableFieldTypes[writableIdx], &e.newRow[writableIdx])
 	}
 }
 
 func (e *MViewCompleteDeltaApplyExec) buildUpdateRows(row chunk.Row) {
-	for writableIdx, colID := range e.MWritableInputColIDs {
+	for writableIdx, colID := range e.CurrentWritableInputColIDs {
 		row.DatumWithBuffer(colID, e.writableFieldTypes[writableIdx], &e.oldRow[writableIdx])
 	}
 	copy(e.newRow, e.oldRow)
 	// `newRow` starts from the old row image and only patches columns marked touched for this UPDATE row.
 	for _, writableIdx := range e.currTouchedIdxes {
-		row.DatumWithBuffer(e.QWritableInputColIDs[writableIdx], e.writableFieldTypes[writableIdx], &e.newRow[writableIdx])
+		row.DatumWithBuffer(e.RecomputedWritableInputColIDs[writableIdx], e.writableFieldTypes[writableIdx], &e.newRow[writableIdx])
 	}
 }
 
@@ -1378,20 +1378,20 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 		}()
 	}
 
-	baseQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, lastSuccessReadTSO, tblInfo.MaterializedView, tblInfo.MaterializedView.SQLContent)
+	recomputedQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, lastSuccessReadTSO, tblInfo.MaterializedView, tblInfo.MaterializedView.SQLContent)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = baseQueryExec.Close() }()
+	defer func() { _ = recomputedQueryExec.Close() }()
 
-	mvQuerySQL := buildCompareMaterializedViewSelectSQL(schemaName, tblInfo.Name, visibleCols)
-	mvQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, compareSnapshotTS, tblInfo.MaterializedView, mvQuerySQL)
+	currentMVQuerySQL := buildCompareMaterializedViewSelectSQL(schemaName, tblInfo.Name, visibleCols)
+	currentQueryExec, err := e.openCompareMaterializedViewQueryExec(ctx, compareSnapshotTS, tblInfo.MaterializedView, currentMVQuerySQL)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = mvQueryExec.Close() }()
+	defer func() { _ = currentQueryExec.Close() }()
 
-	hashJoinExec := newCompareMaterializedViewHashJoinExec(e.Ctx(), mvQueryExec, baseQueryExec, layout.groupKeyOffsets, visibleCols)
+	hashJoinExec := newCompareMaterializedViewHashJoinExec(e.Ctx(), currentQueryExec, recomputedQueryExec, layout.groupKeyOffsets, visibleCols)
 	if err := exec.Open(ctx, hashJoinExec); err != nil {
 		_ = hashJoinExec.Close()
 		return err
@@ -1424,8 +1424,8 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 				changedRows,
 				1,
 				0,
-				joinResult.Column(compareCol.mInputColID),
-				joinResult.Column(compareCol.qInputColID),
+				joinResult.Column(compareCol.currentInputColID),
+				joinResult.Column(compareCol.recomputedInputColID),
 				compareCol.fieldType,
 				compareCol.notNull,
 				"COMPARE MATERIALIZED VIEW",
@@ -1434,12 +1434,12 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 			}
 		}
 
-		mvMarkerCol := joinResult.Column(layout.mvMarkerColIdx)
-		baseMarkerCol := joinResult.Column(layout.baseMarkerColIdx)
+		currentMarkerCol := joinResult.Column(layout.currentMarkerColIdx)
+		recomputedMarkerCol := joinResult.Column(layout.recomputedMarkerColIdx)
 		for rowIdx := 0; rowIdx < joinResult.NumRows(); rowIdx++ {
 			diffType := classifyCompareMaterializedViewRowDiff(
-				mvMarkerCol.IsNull(rowIdx),
-				baseMarkerCol.IsNull(rowIdx),
+				currentMarkerCol.IsNull(rowIdx),
+				recomputedMarkerCol.IsNull(rowIdx),
 				changedRows[rowIdx] != 0,
 			)
 			if diffType == "" {
@@ -1822,11 +1822,11 @@ func buildCompareMaterializedViewDiffLayout(
 	for _, offset := range diffMeta.GroupKeyMVOffsets {
 		groupKeySet[offset] = struct{}{}
 	}
-	// Schema: MView(probe) + BaseQuery(build)
+	// Schema: current MV rows (probe/left) + recomputed base-query rows (build/right).
 	layout := &compareMaterializedViewDiffLayout{
-		groupKeyOffsets:  append([]int(nil), diffMeta.GroupKeyMVOffsets...),
-		mvMarkerColIdx:   diffMeta.MarkerMVOffset,
-		baseMarkerColIdx: len(visibleCols) + diffMeta.MarkerMVOffset,
+		groupKeyOffsets:        append([]int(nil), diffMeta.GroupKeyMVOffsets...),
+		currentMarkerColIdx:    diffMeta.MarkerMVOffset,
+		recomputedMarkerColIdx: len(visibleCols) + diffMeta.MarkerMVOffset,
 	}
 	layout.payloadCompareColumns = make([]mviewCompleteDeltaCompareColumn, 0, len(visibleCols)-len(groupKeySet))
 	for offset, col := range visibleCols {
@@ -1834,10 +1834,10 @@ func buildCompareMaterializedViewDiffLayout(
 			continue
 		}
 		layout.payloadCompareColumns = append(layout.payloadCompareColumns, mviewCompleteDeltaCompareColumn{
-			mInputColID: offset,
-			qInputColID: len(visibleCols) + offset,
-			fieldType:   &col.FieldType,
-			notNull:     mysql.HasNotNullFlag(col.GetFlag()),
+			currentInputColID:    offset,
+			recomputedInputColID: len(visibleCols) + offset,
+			fieldType:            &col.FieldType,
+			notNull:              mysql.HasNotNullFlag(col.GetFlag()),
 		})
 	}
 	return layout, nil
@@ -1886,11 +1886,11 @@ func newCompareMaterializedViewHashJoinExec(
 		buildCompareMaterializedViewOrdinalSlice(len(leftTypes)),
 		buildCompareMaterializedViewOrdinalSlice(len(rightTypes)),
 	}
-	// Compare uses MV@S as the probe/left side and BaseQuery@R as the
-	// build/right side. This matches the full outer hash join builder setup for
-	// build=right, probe=left:
-	// - unmatched build rows are (NULL-MV, base), handled by RightOuterJoin;
-	// - unmatched probe rows are (MV, NULL-base), handled by LeftOuterJoin.
+	// Compare uses current MV rows as the probe/left side and recomputed
+	// base-query rows as the build/right side. This matches the full outer hash
+	// join builder setup for build=right, probe=left:
+	// - unmatched build rows are (NULL-current, recomputed), handled by RightOuterJoin;
+	// - unmatched probe rows are (current, NULL-recomputed), handled by LeftOuterJoin.
 	fullJoinBuildJoiner := join.NewJoiner(
 		ctx,
 		logicalop.RightOuterJoin,
@@ -2033,12 +2033,12 @@ func buildCompareMaterializedViewOrdinalSlice(colCnt int) []int {
 	return ordinals
 }
 
-func classifyCompareMaterializedViewRowDiff(mvMissing, baseMissing, payloadChanged bool) string {
+func classifyCompareMaterializedViewRowDiff(currentMissing, recomputedMissing, payloadChanged bool) string {
 	switch {
-	case mvMissing:
-		return compareMaterializedViewVacuumType
-	case baseMissing:
+	case recomputedMissing:
 		return compareMaterializedViewExcessiveType
+	case currentMissing:
+		return compareMaterializedViewVacuumType
 	case payloadChanged:
 		return compareMaterializedViewDifferType
 	default:
@@ -2144,7 +2144,7 @@ func (w *compareMaterializedViewOutputWriter) writeRow(ctx context.Context, row 
 	if err := w.ensureTxn(ctx); err != nil {
 		return err
 	}
-	// Schema: MView(probe) + BaseQuery(build)
+	// Schema: current MV rows (probe/left) + recomputed base-query rows (build/right).
 	useRight := diffType == compareMaterializedViewVacuumType
 	for colIdx := 0; colIdx < w.mvColumnCount; colIdx++ {
 		sourceColIdx := colIdx

--- a/pkg/planner/core/casetest/mview/mv_refresh_test.go
+++ b/pkg/planner/core/casetest/mview/mv_refresh_test.go
@@ -727,13 +727,13 @@ func TestBuildRefreshMViewCompleteDeltaApplyPlan(t *testing.T) {
 	require.Equal(t, 0, applyPlan.OpColID)
 	require.Equal(t, 0, applyPlan.MarkerMVOffset)
 	require.Equal(t, []int{0}, applyPlan.GroupKeyMVOffsets)
-	require.Equal(t, []int{1, 2}, applyPlan.MRowInputColIDs)
-	require.Equal(t, []int{3, 4}, applyPlan.QRowInputColIDs)
-	require.Equal(t, 1, applyPlan.MHandleCols.NumCols())
-	require.Equal(t, 1, applyPlan.MHandleCols.GetCol(0).Index)
+	require.Equal(t, []int{1, 2}, applyPlan.CurrentRowInputColIDs)
+	require.Equal(t, []int{3, 4}, applyPlan.RecomputedRowInputColIDs)
+	require.Equal(t, 1, applyPlan.CurrentHandleCols.NumCols())
+	require.Equal(t, 1, applyPlan.CurrentHandleCols.GetCol(0).Index)
 	require.Equal(
 		t,
-		"op_offset:0, m_marker_offset:1, q_marker_offset:3, m_group_keys_offset:[1], q_group_keys_offset:[3], m_handle_offset:[1], m_row_offset:[1,2], q_row_offset:[3,4]",
+		"op_offset:0, current_marker_offset:1, recomputed_marker_offset:3, current_group_keys_offset:[1], recomputed_group_keys_offset:[3], current_handle_offset:[1], current_row_offset:[1,2], recomputed_row_offset:[3,4]",
 		applyPlan.ExplainInfo(),
 	)
 }
@@ -863,14 +863,14 @@ func TestBuildRefreshMViewCompleteDeltaApplyPlanNullableGroupKey(t *testing.T) {
 	require.Equal(t, 0, applyPlan.OpColID)
 	require.Equal(t, 1, applyPlan.MarkerMVOffset)
 	require.Equal(t, []int{0}, applyPlan.GroupKeyMVOffsets)
-	require.Equal(t, []int{2, 3}, applyPlan.MRowInputColIDs)
-	require.Equal(t, []int{4, 5}, applyPlan.QRowInputColIDs)
-	require.Equal(t, 1, applyPlan.MHandleCols.NumCols())
-	require.Equal(t, int64(model.ExtraHandleID), applyPlan.MHandleCols.GetCol(0).ID)
-	require.Equal(t, 1, applyPlan.MHandleCols.GetCol(0).Index)
+	require.Equal(t, []int{2, 3}, applyPlan.CurrentRowInputColIDs)
+	require.Equal(t, []int{4, 5}, applyPlan.RecomputedRowInputColIDs)
+	require.Equal(t, 1, applyPlan.CurrentHandleCols.NumCols())
+	require.Equal(t, int64(model.ExtraHandleID), applyPlan.CurrentHandleCols.GetCol(0).ID)
+	require.Equal(t, 1, applyPlan.CurrentHandleCols.GetCol(0).Index)
 	require.Equal(
 		t,
-		"op_offset:0, m_marker_offset:3, q_marker_offset:5, m_group_keys_offset:[2], q_group_keys_offset:[4], m_handle_offset:[1], m_row_offset:[2,3], q_row_offset:[4,5]",
+		"op_offset:0, current_marker_offset:3, recomputed_marker_offset:5, current_group_keys_offset:[2], recomputed_group_keys_offset:[4], current_handle_offset:[1], current_row_offset:[2,3], recomputed_row_offset:[4,5]",
 		applyPlan.ExplainInfo(),
 	)
 }

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -736,25 +736,25 @@ type MViewCompleteDeltaApply struct {
 	MarkerMVOffset int
 	// GroupKeyMVOffsets stores GROUP BY key offsets in MV column order.
 	GroupKeyMVOffsets []int `plan-cache-clone:"shallow"`
-	// MHandleCols contains physical locator columns from the current-MV side.
-	MHandleCols util.HandleCols `plan-cache-clone:"shallow"`
-	// MRowInputColIDs and QRowInputColIDs store the full old/new row-image input layout in MV column order.
-	MRowInputColIDs []int `plan-cache-clone:"shallow"`
-	QRowInputColIDs []int `plan-cache-clone:"shallow"`
+	// CurrentHandleCols contains physical locator columns from the current-MV side.
+	CurrentHandleCols util.HandleCols `plan-cache-clone:"shallow"`
+	// CurrentRowInputColIDs and RecomputedRowInputColIDs store the full old/new row-image input layout in MV column order.
+	CurrentRowInputColIDs    []int `plan-cache-clone:"shallow"`
+	RecomputedRowInputColIDs []int `plan-cache-clone:"shallow"`
 }
 
 // ExplainInfo returns the key sink mapping metadata for complete delta MV apply.
 func (p *MViewCompleteDeltaApply) ExplainInfo() string {
 	return fmt.Sprintf(
-		"op_offset:%d, m_marker_offset:%d, q_marker_offset:%d, m_group_keys_offset:%s, q_group_keys_offset:%s, m_handle_offset:%s, m_row_offset:%s, q_row_offset:%s",
+		"op_offset:%d, current_marker_offset:%d, recomputed_marker_offset:%d, current_group_keys_offset:%s, recomputed_group_keys_offset:%s, current_handle_offset:%s, current_row_offset:%s, recomputed_row_offset:%s",
 		p.OpColID,
-		inputOffsetAtMVOffset(p.MRowInputColIDs, p.MarkerMVOffset),
-		inputOffsetAtMVOffset(p.QRowInputColIDs, p.MarkerMVOffset),
-		formatMViewDeltaMergeOffsets(inputOffsetsAtMVOffsets(p.MRowInputColIDs, p.GroupKeyMVOffsets)),
-		formatMViewDeltaMergeOffsets(inputOffsetsAtMVOffsets(p.QRowInputColIDs, p.GroupKeyMVOffsets)),
-		formatHandleColsInputOffsets(p.MHandleCols),
-		formatMViewDeltaMergeOffsets(p.MRowInputColIDs),
-		formatMViewDeltaMergeOffsets(p.QRowInputColIDs),
+		inputOffsetAtMVOffset(p.CurrentRowInputColIDs, p.MarkerMVOffset),
+		inputOffsetAtMVOffset(p.RecomputedRowInputColIDs, p.MarkerMVOffset),
+		formatMViewDeltaMergeOffsets(inputOffsetsAtMVOffsets(p.CurrentRowInputColIDs, p.GroupKeyMVOffsets)),
+		formatMViewDeltaMergeOffsets(inputOffsetsAtMVOffsets(p.RecomputedRowInputColIDs, p.GroupKeyMVOffsets)),
+		formatHandleColsInputOffsets(p.CurrentHandleCols),
+		formatMViewDeltaMergeOffsets(p.CurrentRowInputColIDs),
+		formatMViewDeltaMergeOffsets(p.RecomputedRowInputColIDs),
 	)
 }
 
@@ -799,8 +799,8 @@ func (p *MViewCompleteDeltaApply) MemoryUsage() (sum int64) {
 
 	sum = p.baseSchemaProducer.MemoryUsage() + size.SizeOfInterface*2 + size.SizeOfInt64 + size.SizeOfInt*3 + size.SizeOfSlice*3
 	sum += int64(cap(p.GroupKeyMVOffsets)) * size.SizeOfInt
-	sum += int64(cap(p.MRowInputColIDs)) * size.SizeOfInt
-	sum += int64(cap(p.QRowInputColIDs)) * size.SizeOfInt
+	sum += int64(cap(p.CurrentRowInputColIDs)) * size.SizeOfInt
+	sum += int64(cap(p.RecomputedRowInputColIDs)) * size.SizeOfInt
 	if p.Source != nil {
 		sum += p.Source.MemoryUsage()
 	}

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4144,15 +4144,15 @@ func (b *PlanBuilder) buildRefreshMaterializedViewImplement(ctx context.Context,
 			return nil, err
 		}
 		return MViewCompleteDeltaApply{
-			Source:            sourcePlan,
-			MVTableID:         mvInfo.ID,
-			MVColumnCount:     diffRes.MVColumnCount,
-			OpColID:           diffRes.OpColOffset,
-			MarkerMVOffset:    diffRes.MarkerMVOffset,
-			GroupKeyMVOffsets: append([]int(nil), diffRes.GroupKeyMVOffsets...),
-			MHandleCols:       diffRes.MHandleCols,
-			MRowInputColIDs:   append([]int(nil), diffRes.MRowOffsets...),
-			QRowInputColIDs:   append([]int(nil), diffRes.QRowOffsets...),
+			Source:                   sourcePlan,
+			MVTableID:                mvInfo.ID,
+			MVColumnCount:            diffRes.MVColumnCount,
+			OpColID:                  diffRes.OpColOffset,
+			MarkerMVOffset:           diffRes.MarkerMVOffset,
+			GroupKeyMVOffsets:        append([]int(nil), diffRes.GroupKeyMVOffsets...),
+			CurrentHandleCols:        diffRes.CurrentHandleCols,
+			CurrentRowInputColIDs:    append([]int(nil), diffRes.CurrentRowOffsets...),
+			RecomputedRowInputColIDs: append([]int(nil), diffRes.RecomputedRowOffsets...),
 		}.Init(b.ctx), nil
 	default:
 		return nil, errors.Errorf("RefreshMaterializedViewImplementStmt: unsupported mode %s", mode.String())

--- a/pkg/planner/mview/mview.go
+++ b/pkg/planner/mview/mview.go
@@ -45,12 +45,12 @@ const (
 	deltaCntStarName = "__mview_delta_cnt_star"
 	mvRowIDName      = "__mview_mv_rowid"
 
-	diffQueryAlias   = "__mvd_q"
-	diffMVTableAlias = "__mvd_m"
-	diffOpColName    = "__mvd_op"
-	diffHandlePrefix = "__mvd_h_"
-	diffOldRowPrefix = "__mvd_o_"
-	diffNewRowPrefix = "__mvd_n_"
+	diffRecomputedAlias = "__mvd_recomputed"
+	diffCurrentAlias    = "__mvd_current"
+	diffOpColName       = "__mvd_op"
+	diffHandlePrefix    = "__mvd_h_"
+	diffOldRowPrefix    = "__mvd_o_"
+	diffNewRowPrefix    = "__mvd_n_"
 )
 
 // HasVisibleIndexWithPrefixCoveringColumns reports whether the base table has a usable key layout
@@ -1451,7 +1451,7 @@ func buildMLogDeltaSelect(
 //	 AND ...
 //
 // Nullable MV group keys keep null-safe equality (<=>) so NULL-group semantics stay consistent
-// with GROUP BY. When the MV-side group key is NOT NULL, regular equality (=) is equivalent.
+// with GROUP BY. When the current-side group key is NOT NULL, regular equality (=) is equivalent.
 // Delta is placed on the left side so every changed group survives even when MV row does not exist yet.
 func buildMergeSourceSelect(
 	dbName pmodel.CIStr,
@@ -2084,19 +2084,19 @@ func ifExpr(cond, trueExpr, falseExpr ast.ExprNode) *ast.FuncCallExpr {
 //
 //	SELECT
 //	  <diff op>,
-//	  [M._tidb_rowid AS <rowid handle>],
-//	  M.<all MV columns as old row image>,
-//	  Q.<all MV columns as new row image>
-//	FROM (<MV definition SQL>) AS Q
-//	FULL OUTER JOIN <mv table> AS M
-//	  ON Q.<group_key_1> [= | <=>] M.<group_key_1>
+//	  [current._tidb_rowid AS <rowid handle>],
+//	  current.<all MV columns as current row image>,
+//	  recomputed.<all MV columns as recomputed row image>
+//	FROM (<MV definition SQL>) AS recomputed
+//	FULL OUTER JOIN <mv table> AS current
+//	  ON recomputed.<group_key_1> [= | <=>] current.<group_key_1>
 //	 AND ...
-//	WHERE Q.<marker_col> IS NULL
-//	   OR M.<marker_col> IS NULL
+//	WHERE recomputed.<marker_col> IS NULL
+//	   OR current.<marker_col> IS NULL
 //	   OR NOT <old/new payload equality>
 //
 // The diff op classifies each row as INSERT, DELETE, or UPDATE. The executor consumes the fixed
-// output layout together with the M/Q offset metadata to apply the delta to the MV table.
+// output layout together with the current/recomputed offset metadata to apply the delta to the MV table.
 func BuildCompleteDiffSource(
 	sctx planctx.PlanContext,
 	is infoschema.InfoSchema,
@@ -2158,13 +2158,13 @@ func BuildCompleteDiffSource(
 		return nil, err
 	}
 
-	qSource := &ast.TableSource{
+	recomputedSource := &ast.TableSource{
 		Source: mvSel,
-		AsName: pmodel.NewCIStr(diffQueryAlias),
+		AsName: pmodel.NewCIStr(diffRecomputedAlias),
 	}
-	mSource := &ast.TableSource{
+	currentSource := &ast.TableSource{
 		Source: &ast.TableName{Schema: dbName, Name: mv.Name},
-		AsName: pmodel.NewCIStr(diffMVTableAlias),
+		AsName: pmodel.NewCIStr(diffCurrentAlias),
 	}
 
 	var joinCond ast.ExprNode
@@ -2179,8 +2179,8 @@ func BuildCompleteDiffSource(
 			joinCond,
 			binary(
 				op,
-				qualColExpr(diffQueryAlias, colName),
-				qualColExpr(diffMVTableAlias, colName),
+				qualColExpr(diffRecomputedAlias, colName),
+				qualColExpr(diffCurrentAlias, colName),
 			),
 		)
 	}
@@ -2188,22 +2188,22 @@ func BuildCompleteDiffSource(
 		return nil, errors.Errorf("materialized view %s has empty join condition", mv.Name.O)
 	}
 	join := &ast.Join{
-		Left:  qSource,
-		Right: mSource,
+		Left:  recomputedSource,
+		Right: currentSource,
 		Tp:    ast.FullJoin,
 		On:    &ast.OnCondition{Expr: joinCond},
 	}
 
-	qMarkerExpr := qualColExpr(diffQueryAlias, markerCol.Name.O)
-	mMarkerExpr := qualColExpr(diffMVTableAlias, markerCol.Name.O)
+	recomputedMarkerExpr := qualColExpr(diffRecomputedAlias, markerCol.Name.O)
+	currentMarkerExpr := qualColExpr(diffCurrentAlias, markerCol.Name.O)
 
-	payloadEq := buildCompleteDiffPayloadEqExpr(mv, groupKeySet, diffQueryAlias, diffMVTableAlias)
+	payloadEq := buildCompleteDiffPayloadEqExpr(mv, groupKeySet, diffRecomputedAlias, diffCurrentAlias)
 	if payloadEq == nil {
 		payloadEq = ast.NewValueExpr(int64(1), "", "")
 	}
 	payloadChanged := &ast.UnaryOperationExpr{Op: opcode.Not, V: payloadEq}
 	whereExpr := orExpr(
-		orExpr(&ast.IsNullExpr{Expr: qMarkerExpr}, &ast.IsNullExpr{Expr: mMarkerExpr}),
+		orExpr(&ast.IsNullExpr{Expr: recomputedMarkerExpr}, &ast.IsNullExpr{Expr: currentMarkerExpr}),
 		payloadChanged,
 	)
 
@@ -2212,14 +2212,14 @@ func BuildCompleteDiffSource(
 	if useRowID {
 		fields = make([]*ast.SelectField, 0, 2+len(mv.Columns)*2)
 	}
-	diffOpExpr := buildCompleteDiffOpExpr(qMarkerExpr, mMarkerExpr)
+	diffOpExpr := buildCompleteDiffOpExpr(recomputedMarkerExpr, currentMarkerExpr)
 	fields = append(fields, &ast.SelectField{Expr: diffOpExpr, AsName: pmodel.NewCIStr(diffOpColName)})
 
 	rowIDHandleOffset := -1
 	if useRowID {
 		rowIDHandleOffset = len(fields)
 		fields = append(fields, &ast.SelectField{
-			Expr:   qualColExpr(diffMVTableAlias, model.ExtraHandleName.O),
+			Expr:   qualColExpr(diffCurrentAlias, model.ExtraHandleName.O),
 			AsName: pmodel.NewCIStr(diffHandlePrefix + model.ExtraHandleName.O),
 		})
 	}
@@ -2228,7 +2228,7 @@ func BuildCompleteDiffSource(
 	for i, col := range mv.Columns {
 		offset := len(fields)
 		fields = append(fields, &ast.SelectField{
-			Expr:   qualColExpr(diffMVTableAlias, col.Name.O),
+			Expr:   qualColExpr(diffCurrentAlias, col.Name.O),
 			AsName: pmodel.NewCIStr(diffOldRowPrefix + col.Name.O),
 		})
 		currentRowOffsets[i] = offset
@@ -2238,7 +2238,7 @@ func BuildCompleteDiffSource(
 	for i, col := range mv.Columns {
 		offset := len(fields)
 		fields = append(fields, &ast.SelectField{
-			Expr:   qualColExpr(diffQueryAlias, col.Name.O),
+			Expr:   qualColExpr(diffRecomputedAlias, col.Name.O),
 			AsName: pmodel.NewCIStr(diffNewRowPrefix + col.Name.O),
 		})
 		recomputedRowOffsets[i] = offset
@@ -2254,8 +2254,8 @@ func BuildCompleteDiffSource(
 		From:   &ast.TableRefsClause{TableRefs: join},
 		Where:  whereExpr,
 		TableHints: []*ast.TableOptimizerHint{
-			buildReadFromStorageTiFlashHint(dbName, pmodel.NewCIStr(diffMVTableAlias)),
-			buildHashJoinProbeHint(dbName, pmodel.NewCIStr(diffMVTableAlias)),
+			buildReadFromStorageTiFlashHint(dbName, pmodel.NewCIStr(diffCurrentAlias)),
+			buildHashJoinProbeHint(dbName, pmodel.NewCIStr(diffCurrentAlias)),
 		},
 	}
 
@@ -2294,7 +2294,7 @@ func pickCompleteDiffMarkerColumn(mv *model.TableInfo) (int, *model.ColumnInfo, 
 
 func buildCompleteDiffHandleCols(
 	mv *model.TableInfo,
-	mRowOffsets []int,
+	currentRowOffsets []int,
 	rowIDHandleOffset int,
 ) (plannerutil.HandleCols, error) {
 	if mv == nil {
@@ -2306,13 +2306,13 @@ func buildCompleteDiffHandleCols(
 		if pkCol == nil {
 			return nil, errors.Errorf("mv table %s has PKIsHandle but no primary key column", mv.Name.O)
 		}
-		if pkCol.Offset < 0 || pkCol.Offset >= len(mRowOffsets) {
+		if pkCol.Offset < 0 || pkCol.Offset >= len(currentRowOffsets) {
 			return nil, errors.Errorf("mv table %s primary key column offset %d is invalid", mv.Name.O, pkCol.Offset)
 		}
 		return plannerutil.NewIntHandleCols(&expression.Column{
 			ID:      pkCol.ID,
 			RetType: &pkCol.FieldType,
-			Index:   mRowOffsets[pkCol.Offset],
+			Index:   currentRowOffsets[pkCol.Offset],
 		}), nil
 	case mv.IsCommonHandle:
 		pkIdx := tables.FindPrimaryIndex(mv)
@@ -2328,7 +2328,7 @@ func buildCompleteDiffHandleCols(
 			cols = append(cols, &expression.Column{
 				ID:      col.ID,
 				RetType: &col.FieldType,
-				Index:   mRowOffsets[idxCol.Offset],
+				Index:   currentRowOffsets[idxCol.Offset],
 			})
 		}
 		return plannerutil.NewCommonHandlesColsWithoutColsAlign(mv, pkIdx, cols), nil
@@ -2347,17 +2347,17 @@ func buildCompleteDiffHandleCols(
 
 // buildCompleteDiffOpExpr builds the diff-op expression consumed by MViewCompleteDeltaApplyExec.
 // The marker column is a visible NOT NULL MV column. If the marker is NULL on one side after the
-// full outer join, that side is missing: M missing means INSERT, Q missing means DELETE. If both
-// sides exist but payload columns differ, the row is UPDATE.
-func buildCompleteDiffOpExpr(qMarkerExpr, mMarkerExpr ast.ExprNode) ast.ExprNode {
+// full outer join, that side is missing: current missing means INSERT, recomputed missing means
+// DELETE. If both sides exist but payload columns differ, the row is UPDATE.
+func buildCompleteDiffOpExpr(recomputedMarkerExpr, currentMarkerExpr ast.ExprNode) ast.ExprNode {
 	return &ast.CaseExpr{
 		WhenClauses: []*ast.WhenClause{
 			{
-				Expr:   &ast.IsNullExpr{Expr: mMarkerExpr},
+				Expr:   &ast.IsNullExpr{Expr: currentMarkerExpr},
 				Result: ast.NewValueExpr(int64(1), "", ""),
 			},
 			{
-				Expr:   &ast.IsNullExpr{Expr: qMarkerExpr},
+				Expr:   &ast.IsNullExpr{Expr: recomputedMarkerExpr},
 				Result: ast.NewValueExpr(int64(2), "", ""),
 			},
 		},
@@ -2365,15 +2365,15 @@ func buildCompleteDiffOpExpr(qMarkerExpr, mMarkerExpr ast.ExprNode) ast.ExprNode
 	}
 }
 
-// buildCompleteDiffPayloadEqExpr compares non-group-key payload columns between Q and M.
+// buildCompleteDiffPayloadEqExpr compares non-group-key payload columns between recomputed and current sides.
 // Group-key columns are excluded because they are already used by the full outer join condition.
 // Nullable columns use NULL-safe equality; NOT NULL columns use normal equality to keep the
 // generated expression simpler.
 func buildCompleteDiffPayloadEqExpr(
 	mv *model.TableInfo,
 	groupKeySet map[int]struct{},
-	qAlias string,
-	mAlias string,
+	recomputedAlias string,
+	currentAlias string,
 ) ast.ExprNode {
 	if mv == nil {
 		return nil
@@ -2391,7 +2391,7 @@ func buildCompleteDiffPayloadEqExpr(
 		if mysql.HasNotNullFlag(col.GetFlag()) {
 			op = opcode.EQ
 		}
-		eq := binary(op, qualColExpr(qAlias, colName), qualColExpr(mAlias, colName))
+		eq := binary(op, qualColExpr(recomputedAlias, colName), qualColExpr(currentAlias, colName))
 		expr = andExpr(expr, eq)
 	}
 	return expr

--- a/pkg/planner/mview/mview.go
+++ b/pkg/planner/mview/mview.go
@@ -130,17 +130,17 @@ type BuildResult struct {
 // result, compares it with current MV rows, and applies only the row-level INSERT/DELETE/UPDATE
 // delta instead of replacing the whole MV table.
 //
-// In the generated diff-source SELECT, Q means the recomputed query result side and M means the
-// current materialized-view table side.
+// In the generated diff-source SELECT, the recomputed side means the freshly recomputed MV definition
+// result and the current side means the current materialized-view table content.
 // Row layout of DiffSourceSelect output is fixed:
 //  1. diff_op
 //  2. optional _tidb_rowid handle column when MV uses extra row-id handle
-//  3. old row image (M/current MV side, MV column order)
-//  4. new row image (Q/recomputed query side, MV column order)
+//  3. old row image (current side, MV column order)
+//  4. new row image (recomputed side, MV column order)
 //
 // MarkerMVOffset identifies which MV column is used as the side-missing marker.
 // The marker value is read from the old/new row image instead of being projected separately.
-// MHandleCols may point either to old-row-image columns (PK/common handle) or the optional row-id column.
+// CurrentHandleCols may point either to old-row-image columns (PK/common handle) or the optional row-id column.
 type CompleteDiffBuildResult struct {
 	DiffSourceSelect *ast.SelectStmt
 	// SourceColumnCount is the expected number of output columns of DiffSourceSelect after optimization.
@@ -149,12 +149,12 @@ type CompleteDiffBuildResult struct {
 	MVTableID     int64
 	MVColumnCount int
 
-	OpColOffset       int
-	MarkerMVOffset    int
-	GroupKeyMVOffsets []int
-	MHandleCols       plannerutil.HandleCols
-	MRowOffsets       []int
-	QRowOffsets       []int
+	OpColOffset          int
+	MarkerMVOffset       int
+	GroupKeyMVOffsets    []int
+	CurrentHandleCols    plannerutil.HandleCols
+	CurrentRowOffsets    []int
+	RecomputedRowOffsets []int
 }
 
 // ValidateSourceLayout validates output layout metadata against a concrete schema length (if provided).
@@ -179,11 +179,11 @@ func (r *CompleteDiffBuildResult) ValidateSourceLayout(schemaLen int) error {
 		)
 	}
 	expected := 1 + r.MVColumnCount*2
-	if r.MHandleCols == nil {
-		return errors.New("complete diff build result: MHandleCols is nil")
+	if r.CurrentHandleCols == nil {
+		return errors.New("complete diff build result: CurrentHandleCols is nil")
 	}
-	for i := 0; i < r.MHandleCols.NumCols(); i++ {
-		col := r.MHandleCols.GetCol(i)
+	for i := 0; i < r.CurrentHandleCols.NumCols(); i++ {
+		col := r.CurrentHandleCols.GetCol(i)
 		if col != nil && col.ID == model.ExtraHandleID {
 			expected++
 			break
@@ -210,32 +210,32 @@ func (r *CompleteDiffBuildResult) ValidateSourceLayout(schemaLen int) error {
 			return errors.Errorf("complete diff build result: invalid GroupKeyMVOffsets[%d]=%d", i, off)
 		}
 	}
-	if len(r.MRowOffsets) != r.MVColumnCount {
+	if len(r.CurrentRowOffsets) != r.MVColumnCount {
 		return errors.Errorf(
-			"complete diff build result: MRowOffsets length %d != MVColumnCount %d",
-			len(r.MRowOffsets),
+			"complete diff build result: CurrentRowOffsets length %d != MVColumnCount %d",
+			len(r.CurrentRowOffsets),
 			r.MVColumnCount,
 		)
 	}
-	for i, off := range r.MRowOffsets {
+	for i, off := range r.CurrentRowOffsets {
 		if off < 0 || off >= r.SourceColumnCount {
-			return errors.Errorf("complete diff build result: invalid MRowOffsets[%d]=%d", i, off)
+			return errors.Errorf("complete diff build result: invalid CurrentRowOffsets[%d]=%d", i, off)
 		}
 	}
-	if len(r.QRowOffsets) != r.MVColumnCount {
+	if len(r.RecomputedRowOffsets) != r.MVColumnCount {
 		return errors.Errorf(
-			"complete diff build result: QRowOffsets length %d != MVColumnCount %d",
-			len(r.QRowOffsets),
+			"complete diff build result: RecomputedRowOffsets length %d != MVColumnCount %d",
+			len(r.RecomputedRowOffsets),
 			r.MVColumnCount,
 		)
 	}
-	for i, off := range r.QRowOffsets {
+	for i, off := range r.RecomputedRowOffsets {
 		if off < 0 || off >= r.SourceColumnCount {
-			return errors.Errorf("complete diff build result: invalid QRowOffsets[%d]=%d", i, off)
+			return errors.Errorf("complete diff build result: invalid RecomputedRowOffsets[%d]=%d", i, off)
 		}
 	}
-	for i := 0; i < r.MHandleCols.NumCols(); i++ {
-		col := r.MHandleCols.GetCol(i)
+	for i := 0; i < r.CurrentHandleCols.NumCols(); i++ {
+		col := r.CurrentHandleCols.GetCol(i)
 		if col == nil {
 			return errors.Errorf("complete diff build result: handle column %d is nil", i)
 		}
@@ -2224,27 +2224,27 @@ func BuildCompleteDiffSource(
 		})
 	}
 
-	mRowOffsets := make([]int, len(mv.Columns))
+	currentRowOffsets := make([]int, len(mv.Columns))
 	for i, col := range mv.Columns {
 		offset := len(fields)
 		fields = append(fields, &ast.SelectField{
 			Expr:   qualColExpr(diffMVTableAlias, col.Name.O),
 			AsName: pmodel.NewCIStr(diffOldRowPrefix + col.Name.O),
 		})
-		mRowOffsets[i] = offset
+		currentRowOffsets[i] = offset
 	}
 
-	qRowOffsets := make([]int, len(mv.Columns))
+	recomputedRowOffsets := make([]int, len(mv.Columns))
 	for i, col := range mv.Columns {
 		offset := len(fields)
 		fields = append(fields, &ast.SelectField{
 			Expr:   qualColExpr(diffQueryAlias, col.Name.O),
 			AsName: pmodel.NewCIStr(diffNewRowPrefix + col.Name.O),
 		})
-		qRowOffsets[i] = offset
+		recomputedRowOffsets[i] = offset
 	}
 
-	handleColsMeta, err := buildCompleteDiffHandleCols(mv, mRowOffsets, rowIDHandleOffset)
+	currentHandleCols, err := buildCompleteDiffHandleCols(mv, currentRowOffsets, rowIDHandleOffset)
 	if err != nil {
 		return nil, err
 	}
@@ -2260,16 +2260,16 @@ func BuildCompleteDiffSource(
 	}
 
 	res := &CompleteDiffBuildResult{
-		DiffSourceSelect:  diffSel,
-		SourceColumnCount: len(fields),
-		MVTableID:         mv.ID,
-		MVColumnCount:     len(mv.Columns),
-		OpColOffset:       0,
-		MarkerMVOffset:    markerOffset,
-		GroupKeyMVOffsets: append([]int(nil), groupKeyOffsets...),
-		MHandleCols:       handleColsMeta,
-		MRowOffsets:       mRowOffsets,
-		QRowOffsets:       qRowOffsets,
+		DiffSourceSelect:     diffSel,
+		SourceColumnCount:    len(fields),
+		MVTableID:            mv.ID,
+		MVColumnCount:        len(mv.Columns),
+		OpColOffset:          0,
+		MarkerMVOffset:       markerOffset,
+		GroupKeyMVOffsets:    append([]int(nil), groupKeyOffsets...),
+		CurrentHandleCols:    currentHandleCols,
+		CurrentRowOffsets:    currentRowOffsets,
+		RecomputedRowOffsets: recomputedRowOffsets,
 	}
 	if err := res.ValidateSourceLayout(0); err != nil {
 		return nil, err

--- a/pkg/planner/mview/mview_test.go
+++ b/pkg/planner/mview/mview_test.go
@@ -41,10 +41,10 @@ import (
 )
 
 const (
-	deltaTableAlias = "delta"
-	mvTableAlias    = "mv"
-	diffQAlias      = "__mvd_q"
-	diffMAlias      = "__mvd_m"
+	deltaTableAlias     = "delta"
+	mvTableAlias        = "mv"
+	diffRecomputedAlias = "__mvd_recomputed"
+	diffCurrentAlias    = "__mvd_current"
 
 	deltaCntStarName = "__mview_delta_cnt_star"
 )
@@ -1197,12 +1197,12 @@ func TestBuildCompleteDiffSourceLayout(t *testing.T) {
 	require.Equal(t, hint.HintReadFromStorage, storageHint.HintName.L)
 	require.Equal(t, hint.HintTiFlash, storageHint.HintData.(pmodel.CIStr).L)
 	require.Len(t, storageHint.Tables, 1)
-	require.Equal(t, diffMAlias, storageHint.Tables[0].TableName.L)
+	require.Equal(t, diffCurrentAlias, storageHint.Tables[0].TableName.L)
 	require.Equal(t, item.DBName.L, storageHint.Tables[0].DBName.L)
 	probeHint := res.DiffSourceSelect.TableHints[1]
 	require.Equal(t, hint.HintHashJoinProbe, probeHint.HintName.L)
 	require.Len(t, probeHint.Tables, 1)
-	require.Equal(t, diffMAlias, probeHint.Tables[0].TableName.L)
+	require.Equal(t, diffCurrentAlias, probeHint.Tables[0].TableName.L)
 	require.Equal(t, item.DBName.L, probeHint.Tables[0].DBName.L)
 	sctx.GetSessionVars().EnableFullOuterJoin = true
 	plan, _, err := optimizeForTest(sctx, is)(context.Background(), res.DiffSourceSelect)
@@ -1230,8 +1230,8 @@ func TestBuildCompleteDiffSourceLayout(t *testing.T) {
 	require.Len(t, joinPredicates, 1)
 	leftTable, leftCol := columnNameRef(t, joinPredicates[0].L)
 	rightTable, rightCol := columnNameRef(t, joinPredicates[0].R)
-	require.Equal(t, diffQAlias, leftTable)
-	require.Equal(t, diffMAlias, rightTable)
+	require.Equal(t, diffRecomputedAlias, leftTable)
+	require.Equal(t, diffCurrentAlias, rightTable)
 	require.Equal(t, leftCol, rightCol)
 	require.Equal(t, "a", rightCol)
 	require.Equal(t, opcode.EQ, joinPredicates[0].Op)
@@ -1291,8 +1291,8 @@ func TestBuildCompleteDiffSourceNullableGroupKeyUsesNullEQ(t *testing.T) {
 	require.Len(t, joinPredicates, 1)
 	leftTable, leftCol := columnNameRef(t, joinPredicates[0].L)
 	rightTable, rightCol := columnNameRef(t, joinPredicates[0].R)
-	require.Equal(t, diffQAlias, leftTable)
-	require.Equal(t, diffMAlias, rightTable)
+	require.Equal(t, diffRecomputedAlias, leftTable)
+	require.Equal(t, diffCurrentAlias, rightTable)
 	require.Equal(t, leftCol, rightCol)
 	require.Equal(t, "a", rightCol)
 	require.Equal(t, opcode.NullEQ, joinPredicates[0].Op)
@@ -1555,8 +1555,8 @@ func collectPayloadComparisonOps(t *testing.T, expr ast.ExprNode) map[string]opc
 			if x.Op == opcode.NullEQ || x.Op == opcode.EQ {
 				leftTable, leftCol := columnNameRef(t, x.L)
 				rightTable, rightCol := columnNameRef(t, x.R)
-				require.Equal(t, diffQAlias, leftTable)
-				require.Equal(t, diffMAlias, rightTable)
+				require.Equal(t, diffRecomputedAlias, leftTable)
+				require.Equal(t, diffCurrentAlias, rightTable)
 				require.Equal(t, leftCol, rightCol)
 				ops[rightCol] = x.Op
 			}

--- a/pkg/planner/mview/mview_test.go
+++ b/pkg/planner/mview/mview_test.go
@@ -1215,12 +1215,12 @@ func TestBuildCompleteDiffSourceLayout(t *testing.T) {
 	require.Equal(t, len(mv.Columns), res.MVColumnCount)
 	require.Equal(t, 0, res.OpColOffset)
 	require.Equal(t, 0, res.MarkerMVOffset)
-	require.Equal(t, 1, res.MHandleCols.NumCols())
-	require.Len(t, res.MRowOffsets, len(mv.Columns))
-	require.Len(t, res.QRowOffsets, len(mv.Columns))
+	require.Equal(t, 1, res.CurrentHandleCols.NumCols())
+	require.Len(t, res.CurrentRowOffsets, len(mv.Columns))
+	require.Len(t, res.RecomputedRowOffsets, len(mv.Columns))
 	require.Equal(t, 1+2*len(mv.Columns), res.SourceColumnCount)
 	require.NoError(t, res.ValidateSourceLayout(res.SourceColumnCount))
-	require.Equal(t, res.MRowOffsets[0], res.MHandleCols.GetCol(0).Index)
+	require.Equal(t, res.CurrentRowOffsets[0], res.CurrentHandleCols.GetCol(0).Index)
 
 	join := res.DiffSourceSelect.From.TableRefs
 	require.NotNil(t, join)
@@ -1281,8 +1281,8 @@ func TestBuildCompleteDiffSourceNullableGroupKeyUsesNullEQ(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, 1, res.MarkerMVOffset)
-	require.Equal(t, 1, res.MHandleCols.NumCols())
-	require.Equal(t, 1, res.MHandleCols.GetCol(0).Index)
+	require.Equal(t, 1, res.CurrentHandleCols.NumCols())
+	require.Equal(t, 1, res.CurrentHandleCols.GetCol(0).Index)
 	require.Equal(t, 1+1+2*len(mv.Columns), res.SourceColumnCount)
 	require.NotNil(t, res.DiffSourceSelect.From)
 	require.NotNil(t, res.DiffSourceSelect.From.TableRefs)
@@ -1355,10 +1355,10 @@ func TestBuildCompleteDiffSourceCommonHandleReusesOldRowImage(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, 1+2*len(mv.Columns), res.SourceColumnCount)
-	require.Equal(t, 2, res.MHandleCols.NumCols())
+	require.Equal(t, 2, res.CurrentHandleCols.NumCols())
 	require.NoError(t, res.ValidateSourceLayout(res.SourceColumnCount))
-	require.Equal(t, res.MRowOffsets[1], res.MHandleCols.GetCol(0).Index)
-	require.Equal(t, res.MRowOffsets[0], res.MHandleCols.GetCol(1).Index)
+	require.Equal(t, res.CurrentRowOffsets[1], res.CurrentHandleCols.GetCol(0).Index)
+	require.Equal(t, res.CurrentRowOffsets[0], res.CurrentHandleCols.GetCol(1).Index)
 }
 
 func TestBuildCompleteDiffSourceExtraHandleKeepsRowIDProjection(t *testing.T) {
@@ -1401,11 +1401,11 @@ func TestBuildCompleteDiffSourceExtraHandleKeepsRowIDProjection(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, 2+2*len(mv.Columns), res.SourceColumnCount)
-	require.Equal(t, 1, res.MHandleCols.NumCols())
+	require.Equal(t, 1, res.CurrentHandleCols.NumCols())
 	require.NoError(t, res.ValidateSourceLayout(res.SourceColumnCount))
-	require.Equal(t, int64(model.ExtraHandleID), res.MHandleCols.GetCol(0).ID)
-	require.Equal(t, 1, res.MHandleCols.GetCol(0).Index)
-	require.NotContains(t, res.MRowOffsets, res.MHandleCols.GetCol(0).Index)
+	require.Equal(t, int64(model.ExtraHandleID), res.CurrentHandleCols.GetCol(0).ID)
+	require.Equal(t, 1, res.CurrentHandleCols.GetCol(0).Index)
+	require.NotContains(t, res.CurrentRowOffsets, res.CurrentHandleCols.GetCol(0).Index)
 }
 
 func findIndexJoinPlan(plan corebase.PhysicalPlan) *core.PhysicalIndexJoin {

--- a/tests/integrationtest/r/executor/mview_privilege.result
+++ b/tests/integrationtest/r/executor/mview_privilege.result
@@ -191,7 +191,7 @@ refresh steps
 [S02 LOCK_REFRESH_INFO]
 [S03 INSERT_HIST_RUNNING]
 [S04 DATA_CHANGE_COMPLETE_DELTA_APPLY]
-  MViewCompleteDeltaApply | estRows:N/A | task:root | op_offset:0, m_marker_offset:1, q_marker_offset:4, m_group_keys_offset:[1], q_group_keys_offset:[4], m_handle_offset:[1], m_row_offset:[1,2,3], q_row_offset:[4,5,6]
+  MViewCompleteDeltaApply | estRows:N/A | task:root | op_offset:0, current_marker_offset:1, recomputed_marker_offset:4, current_group_keys_offset:[1], recomputed_group_keys_offset:[4], current_handle_offset:[1], current_row_offset:[1,2,3], recomputed_row_offset:[4,5,6]
   └─Projection | estRows:8000.00 | task:root | case(isnull(mview_privilege_test.mv.a), 1, isnull(mview_privilege_test.t.a), 2, 3)->Column#11, mview_privilege_test.mv.a, mview_privilege_test.mv.s, mview_privilege_test.mv.cnt, mview_privilege_test.t.a, Column#5, Column#6
     └─Selection | estRows:8000.00 | task:root | or(isnull(mview_privilege_test.t.a), or(isnull(mview_privilege_test.mv.a), not(and(nulleq(Column#5, mview_privilege_test.mv.s), eq(Column#6, mview_privilege_test.mv.cnt)))))
       └─HashJoin | estRows:10000.00 | task:root | full outer join, equal:[eq(mview_privilege_test.t.a, mview_privilege_test.mv.a)]

--- a/tests/integrationtest/r/executor/mview_privilege.result
+++ b/tests/integrationtest/r/executor/mview_privilege.result
@@ -200,7 +200,7 @@ refresh steps
         │   └─HashAgg | estRows:8000.00 | task:cop[tikv] | group by:mview_privilege_test.t.a, funcs:sum(mview_privilege_test.t.b)->Column#13, funcs:count(1)->Column#14
         │     └─TableFullScan | estRows:10000.00 | task:cop[tikv] | table:t | keep order:false, stats:pseudo
         └─TableReader(Probe) | estRows:10000.00 | task:root | data:TableFullScan_19
-          └─TableFullScan | estRows:10000.00 | task:cop[tikv] | table:__mvd_m | keep order:false, stats:pseudo
+          └─TableFullScan | estRows:10000.00 | task:cop[tikv] | table:__mvd_current | keep order:false, stats:pseudo
 [S05 PERSIST_REFRESH_INFO]
 [S06 TXN_COMMIT]
 [S07 FINALIZE_HIST]


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

The MV complete-delta / compare code used short side names like `M` and `Q`. These names are easy to confuse when reading planner contracts, executor mappings, test output, and design notes.

### What changed and how does it work?

This PR renames the MV diff-side terminology without changing behavior:

- Rename the current MV-table side from `M` to `current` in planner and executor metadata.
- Rename the recomputed MV-definition-result side from `Q` to `recomputed`.
- Update complete-delta apply mappings, compare-MV diff layout names, explain/test expectations, and MV refresh design notes to use the clearer terminology.

The intended semantics stay the same:

- `current` is the existing MV table content.
- `recomputed` is the fresh result of evaluating the MV definition.
- Complete delta apply still deletes/updates by current-side handles and inserts/updates with recomputed-side row images.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual validation:

- `git diff --check HEAD~1..HEAD`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

The user-visible effect is limited to internal EXPLAIN / dry-run text and documentation terminology for the unreleased MV feature branch.

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated materialized view refresh “complete delta apply” design notes to use “current vs recomputed” terminology, including revised marker names, join/diff rules, and SQL layout examples.

* **Refactor**
  * Renamed and rewired complete-delta-apply planning/execution plumbing to consistently use separate “current” and “recomputed” handle/row-image/compare inputs, with diff operation classification driven by marker presence.

* **Tests**
  * Updated unit and integration expectations for revised plan field names, marker/offset labels, validation messages, and generated operator output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->