### PR TITLE
session: repair bootstrap version conflict when upgrading from v8.5.5 hotfix branches

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -395,7 +395,7 @@ func TestCheckPrivilegeTableRowsCollateCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(231), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(232), session.CurrentBootstrapVersion)
 }
 
 func TestIsStatsTemporaryTable(t *testing.T) {

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1294,6 +1294,23 @@ const (
 	// Add Max_user_connections to mysql.user.
 	version231 = 231
 
+	// version 232
+	// Repair upgrades from the v8.5.5 hotfix family back to upstream
+	// `release-8.5`. Those branches reused version224/225 for other DDLs, so
+	// clusters reach >= 224 without the upstream version224/225 schema and
+	// bootstrap then skips it as "already applied":
+	//   - release-8.5-20260323-v8.5.5 (stops at 225): in this branch version224
+	//     adds runaway watch indexes and version225 adds `Max_user_connections`,
+	//     so upstream `max_node_count` (version224) and `i_user` indexes
+	//     (version225) are both missing.
+	//   - release-8.5-20260527-v8.5.5 (stops at 224, no version225): in this
+	//     branch version224 adds `i_user` indexes, so `max_node_count` is
+	//     missing; `i_user` already exists.
+	// version232 re-applies the version224/225 DDLs; `doReentrantDDL`
+	// ignores `ErrColumnExists`/`ErrDupKeyName`, so already-present schema is a
+	// no-op (e.g. `i_user` on release-8.5-20260527-v8.5.5).
+	version232 = 232
+
 	// ...
 	// [version231, version238] is the version range reserved for patches of 8.5.x
 	// ...
@@ -1303,7 +1320,7 @@ const (
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version231
+var currentBootstrapVersion int64 = version232
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -1490,6 +1507,7 @@ var (
 		upgradeToVer229,
 		upgradeToVer230,
 		upgradeToVer231,
+		upgradeToVer232,
 	}
 )
 
@@ -3366,19 +3384,18 @@ func upgradeToVer223(s sessiontypes.Session, ver int64) {
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_global_task_history ADD COLUMN modify_params json AFTER `error`;", infoschema.ErrColumnExists)
 }
 
-func upgradeToVer224(s sessiontypes.Session, ver int64) {
-	if ver >= version224 {
-		return
-	}
+// addMaxNodeCountColumns adds the `max_node_count` column to both global task
+// tables. Shared by upgradeToVer224 and upgradeToVer232 (the latter re-applies it
+// for clusters that skipped upstream version224).
+func addMaxNodeCountColumns(s sessiontypes.Session) {
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_global_task ADD COLUMN max_node_count INT DEFAULT 0 AFTER `modify_params`;", infoschema.ErrColumnExists)
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_global_task_history ADD COLUMN max_node_count INT DEFAULT 0 AFTER `modify_params`;", infoschema.ErrColumnExists)
 }
 
-func upgradeToVer225(s sessiontypes.Session, ver int64) {
-	if ver >= version225 {
-		return
-	}
-
+// addIUserIndexes adds the `i_user` index to the seven privilege tables. Shared
+// by upgradeToVer225 and upgradeToVer232 (the latter re-applies it for clusters
+// that skipped upstream version225).
+func addIUserIndexes(s sessiontypes.Session) {
 	doReentrantDDL(s, "ALTER TABLE mysql.user ADD INDEX i_user (user)", dbterror.ErrDupKeyName)
 	doReentrantDDL(s, "ALTER TABLE mysql.global_priv ADD INDEX i_user (user)", dbterror.ErrDupKeyName)
 	doReentrantDDL(s, "ALTER TABLE mysql.db ADD INDEX i_user (user)", dbterror.ErrDupKeyName)
@@ -3386,6 +3403,20 @@ func upgradeToVer225(s sessiontypes.Session, ver int64) {
 	doReentrantDDL(s, "ALTER TABLE mysql.columns_priv ADD INDEX i_user (user)", dbterror.ErrDupKeyName)
 	doReentrantDDL(s, "ALTER TABLE mysql.global_grants ADD INDEX i_user (user)", dbterror.ErrDupKeyName)
 	doReentrantDDL(s, "ALTER TABLE mysql.default_roles ADD INDEX i_user (user)", dbterror.ErrDupKeyName)
+}
+
+func upgradeToVer224(s sessiontypes.Session, ver int64) {
+	if ver >= version224 {
+		return
+	}
+	addMaxNodeCountColumns(s)
+}
+
+func upgradeToVer225(s sessiontypes.Session, ver int64) {
+	if ver >= version225 {
+		return
+	}
+	addIUserIndexes(s)
 }
 
 // writeClusterID writes cluster id into mysql.tidb
@@ -3487,6 +3518,24 @@ func upgradeToVer231(s sessiontypes.Session, ver int64) {
 	}
 
 	doReentrantDDL(s, "ALTER TABLE mysql.user ADD COLUMN IF NOT EXISTS `Max_user_connections` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `Password_lifetime`")
+}
+
+func upgradeToVer232(s sessiontypes.Session, ver int64) {
+	if ver >= version232 {
+		return
+	}
+
+	// Re-apply the upstream version224/225 DDLs that the v8.5.5 hotfix branches
+	// skipped. We call the shared helpers directly rather than upgradeToVer224/
+	// upgradeToVer225: those guard on `ver >= version224/225`, but `ver` here is
+	// the pre-upgrade version (e.g. 225 for release-8.5-20260323-v8.5.5, 224 for
+	// release-8.5-20260527-v8.5.5), so the guards would short-circuit and skip
+	// the repair — the exact bug this version fixes. The helpers have no such
+	// guard; doReentrantDDL ignores ErrColumnExists/ErrDupKeyName, so
+	// already-present schema (e.g. i_user on release-8.5-20260527-v8.5.5) is a
+	// no-op.
+	addMaxNodeCountColumns(s)
+	addIUserIndexes(s)
 }
 
 // initGlobalVariableIfNotExists initialize a global variable with specific val if it does not exist.

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -2891,3 +2891,78 @@ func TestTiDBUpgradeToVer230(t *testing.T) {
 	createWatchDoneSQL = getTableCreateSQLFn(seCurVer, "tidb_runaway_watch_done")
 	require.Contains(t, createWatchDoneSQL, "idx_done_time")
 }
+
+// TestTiDBUpgradeToVer232 verifies version232 repairs the v8.5.5 hotfix family
+// upgrade (see the version232 comment in bootstrap.go). It exercises the
+// release-8.5-20260323-v8.5.5 case, where both `max_node_count` and `i_user`
+// indexes are missing; the release-8.5-20260527-v8.5.5 case (only
+// `max_node_count` missing, `i_user` already present) is covered by the same
+// re-apply plus `ErrDupKeyName`/`ErrColumnExists` tolerance.
+func TestTiDBUpgradeToVer232(t *testing.T) {
+	ctx := context.Background()
+	store, dom := CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	getTableCreateSQLFn := func(se sessiontypes.Session, tableName string) string {
+		res := MustExecToRecodeSet(t, se, fmt.Sprintf("show create table mysql.%s", tableName))
+		chk := res.NewChunk(nil)
+		err := res.Next(ctx, chk)
+		require.NoError(t, err)
+		require.Equal(t, 1, chk.NumRows())
+		return string(chk.GetRow(0).GetBytes(1))
+	}
+
+	// Simulate the 0323 final state: version225 applied, but `max_node_count`
+	// and `i_user` indexes were never created (0323 reused version224/225 for
+	// other DDLs).
+	ver225 := version225
+	seV225 := CreateSessionAndSetID(t, store)
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	err = m.FinishBootstrap(int64(ver225))
+	require.NoError(t, err)
+	revertVersionAndVariables(t, seV225, ver225)
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+	unsetStoreBootstrapped(store.UUID())
+
+	// Drop `max_node_count` (upstream version224 DDL, skipped on both 0323 and 0527).
+	seV225.SetValue(sessionctx.Initing, true)
+	seV225.GetSessionVars().SQLMode = 0
+	mustExecute(seV225, "ALTER TABLE mysql.tidb_global_task DROP COLUMN max_node_count")
+	mustExecute(seV225, "ALTER TABLE mysql.tidb_global_task_history DROP COLUMN max_node_count")
+	createTaskSQL := getTableCreateSQLFn(seV225, "tidb_global_task")
+	require.NotContains(t, createTaskSQL, "max_node_count")
+
+	// Drop all `i_user` indexes (upstream version225 DDL, skipped on 0323).
+	privTables := []string{"user", "global_priv", "db", "tables_priv", "columns_priv", "global_grants", "default_roles"}
+	for _, tbl := range privTables {
+		mustExecute(seV225, fmt.Sprintf("ALTER TABLE mysql.%s DROP INDEX i_user", tbl))
+		createSQL := getTableCreateSQLFn(seV225, tbl)
+		require.NotContains(t, createSQL, "i_user")
+	}
+
+	// Upgrade to current version; version232 should repair the missing column
+	// and indexes.
+	dom.Close()
+	domCurVer, err := BootstrapSession(store)
+	require.NoError(t, err)
+	defer domCurVer.Close()
+	seCurVer := CreateSessionAndSetID(t, store)
+	ver, err := getBootstrapVersion(seCurVer)
+	require.NoError(t, err)
+	require.Equal(t, currentBootstrapVersion, ver)
+
+	// Verify `max_node_count` has been re-added.
+	createTaskSQL = getTableCreateSQLFn(seCurVer, "tidb_global_task")
+	require.Contains(t, createTaskSQL, "max_node_count")
+	createTaskHistorySQL := getTableCreateSQLFn(seCurVer, "tidb_global_task_history")
+	require.Contains(t, createTaskHistorySQL, "max_node_count")
+
+	// Verify all `i_user` indexes have been re-added.
+	for _, tbl := range privTables {
+		createSQL := getTableCreateSQLFn(seCurVer, tbl)
+		require.Contains(t, createSQL, "i_user")
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69309

Problem Summary:

The v8.5.5 customer hotfix branches reused bootstrap `version224`/`version225` for different DDLs than upstream `release-8.5`, so clusters bootstrapped on them reach version >= 224 without the upstream `version224`/`version225` schema, and bootstrap then skips those DDLs as "already applied":

- `release-8.5-20260323-v8.5.5` (stops at version225): `version224` = runaway watch indexes, `version225` = `Max_user_connections` -> both `max_node_count` and `i_user` indexes missing.
- `release-8.5-20260527-v8.5.5` (stops at version224, no version225): `version224` = `i_user` indexes -> `max_node_count` missing; `i_user` already present.

In upstream `release-8.5`, `version224` adds the `max_node_count` column on `mysql.tidb_global_task`/`mysql.tidb_global_task_history` and `version225` adds `i_user` indexes on 7 privilege tables. The missing `max_node_count` breaks disttask SQL (`TaskColumns`/`InsertTaskColumns` report unknown column), and the missing `i_user` indexes degrade privilege lookups.

### What changed and how does it work?

Add bootstrap `version232` that re-applies the two skipped DDL groups idempotently via `doReentrantDDL`:
- `max_node_count` column on `mysql.tidb_global_task`/`mysql.tidb_global_task_history` (upstream `version224`) — missing on both branches above.
- `i_user` indexes on 7 privilege tables (upstream `version225`) — missing on 0323; already present on 0527.

`doReentrantDDL` ignores `ErrColumnExists`/`ErrDupKeyName`, so this is a safe no-op for clusters that already have the column/indexes (pure upstream `release-8.5` clusters, and 0527 where `i_user` is already built into the table definitions). This follows the same repair pattern as `version227` (PR #66993), which fixed an analogous conflict for the `release-8.5-20250606-v8.5.2` branch.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

#### Manual test: tiup playground upgrade matrix

Verified on macOS arm64 with `tiup playground` (1 PD + 1 TiKV + 1 TiDB, `--without-monitor`). For each scenario a cluster was bootstrapped with the old TiDB binary, then the TiDB process alone was swapped for the binary built from this PR (same PD/TiKV and data dir), and the upgrade was driven by the normal bootstrap path. `tidb_server_version` is read from `mysql.tidb`; `max_node_count`/`i_user` presence from `information_schema`. Re-run after the helper refactor (commit `99eaac9a52`); results match the pre-refactor run.

Old binaries: `v8.5.5` and `v8.5.6` from the tiup mirror; `release-8.5-20260323-v8.5.5` and `release-8.5-20260527-v8.5.5` built locally from their branch heads (`currentBootstrapVersion` 225, 224 and 223 respectively).

| Scenario | Old ver | `max_node_count` before | `i_user` (7 tables) before | `max_node_count` after | `i_user` after | Final ver | Upgrade-log evidence |
|---|---|---|---|---|---|---|---|
| A. `v8.5.6` -> PR | 227 | YES | YES | YES (unchanged) | YES (unchanged) | 232 | all 9 DDLs hit `Duplicate column`/`Duplicate key name` and were ignored (no-op) |
| B. release-8.5-20260323-v8.5.5 -> PR | 225 | NO | NO | YES (re-added) | YES (re-added) | 232 | 9 DDLs all executed as real `add column`/`add index` jobs, 0 duplicate, 0 fatal |
| C. release-8.5-20260527-v8.5.5 -> PR | 224 | NO | YES | YES (re-added) | YES (no-op) | 232 | `max_node_count` real add (0 duplicate); `i_user` all `Duplicate key name` ignored (no-op); 0 fatal |
| D. `v8.5.5` -> PR | 223 | NO | NO | YES (re-added) | YES (re-added) | 232 | upstream `version224`/`225` do the real `add column`/`add index`; `version232` then re-runs the same helpers and all 9 hit `Duplicate` (no-op); 0 fatal |

Additional checks after upgrade in every scenario:
- `SELECT max_node_count FROM mysql.tidb_global_task LIMIT 1` succeeds (this is the disttask `TaskColumns`/`InsertTaskColumns` column that previously raised "unknown column").
- `SELECT user FROM mysql.user USE INDEX (i_user) LIMIT 1` succeeds.
- Schema the hotfix branches already created is preserved: release-8.5-20260323-v8.5.5 keeps its runaway watch indexes (`idx_start_time`/`idx_done_time`) and `Max_user_connections`; release-8.5-20260527-v8.5.5 keeps its `i_user` indexes. No pre-existing schema is dropped or altered.
- On release-8.5-20260527-v8.5.5, the upstream `version230` (runaway indexes) and `version231` (`Max_user_connections`) also run during the same upgrade (224 -> 232) and are applied, confirming the full upgrade path is consistent alongside the version232 repair.
- Scenario D (`v8.5.5`, stops at 223 with no `version224`/`225`) confirms a stock release upgrades cleanly to 232: the upstream `version224`/`225` apply the missing schema first, then `version232`'s re-apply is a harmless no-op — so the shared-helper refactor behaves correctly whether the schema was created by `version224`/`225` themselves or re-applied by `version232`.

Unit test `TestTiDBUpgradeToVer232` (exercises the release-8.5-20260323-v8.5.5 case) passes with `go1.25.10`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a bootstrap version conflict that breaks the distributed task framework and degrades privilege lookups when upgrading from v8.5.5 customer hotfix branches (`release-8.5-20260323-v8.5.5`, `release-8.5-20260527-v8.5.5`) to upstream `release-8.5`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new bootstrap upgrade step (version232) to automatically repair missing schema elements during system version transitions.
* **Bug Fixes**
  * Fixes schema drift that could leave `max_node_count` columns and `i_user` indexes missing from global task and privilege tables after specific upgrade paths.
* **Tests**
  * Added a bootstrap upgrade test that simulates missing `max_node_count` and `i_user` entries and verifies they’re restored.
  * Updated a system table incremental restore test expectation to reflect version232.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


