### PR TITLE
executor: use `baseQuery` as build side for compare materialized view

### DIFF
--- a/docs/note/materialized_view/mv_compare.md
+++ b/docs/note/materialized_view/mv_compare.md
@@ -153,7 +153,7 @@ Diff categories:
 Implementation shape:
 
 1. Build `MV@S` and `Base@R` child executors.
-2. In `CompareMaterializedViewExec`, wire those two child executors into a full outer `HashJoinV1Exec`.
+2. In `CompareMaterializedViewExec`, wire those two child executors into a full outer `HashJoinV1Exec`, with `MV@S` as the probe/left side and `BaseQuery@R` as the build/right side.
 3. Consume hash-join output rows and classify them into:
    - matched-but-different -> `mview_differ`
    - base-only -> `mview_vacuum`
@@ -212,7 +212,8 @@ For grouped MV, this keeps compare semantics aligned with COMPLETE DELTA APPLY d
 2. Summary mode should still count differing rows accurately; it cannot stop after the first mismatch.
 3. Output-table mode should stream diff rows and avoid retaining full diff in memory.
 4. Output-table writes are batched to avoid a single very large transaction.
-5. The current design uses full-outer diff semantics for clarity and correctness. If a better execution strategy is introduced later, it should preserve the same compare semantics.
+5. The current hash-join wiring uses `BaseQuery@R` as the build side. For grouped MV definitions, the base query may already require aggregation state; building the join hash table from the base-query result lets that side finish before probing the MV scan, reducing active-stage overlap between base aggregation work and an additional MV-side build table.
+6. The current design uses full-outer diff semantics for clarity and correctness. If a better execution strategy is introduced later, it should preserve the same compare semantics.
 
 ## Code map (implementation landing)
 

--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -99,8 +99,8 @@ const (
 
 type compareMaterializedViewDiffLayout struct {
 	groupKeyOffsets       []int
-	leftMarkerColIdx      int
-	rightMarkerColIdx     int
+	mvMarkerColIdx        int
+	baseMarkerColIdx      int
 	payloadCompareColumns []mviewCompleteDeltaCompareColumn
 }
 
@@ -1391,7 +1391,7 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 	}
 	defer func() { _ = mvQueryExec.Close() }()
 
-	hashJoinExec := newCompareMaterializedViewHashJoinExec(e.Ctx(), baseQueryExec, mvQueryExec, layout.groupKeyOffsets, visibleCols)
+	hashJoinExec := newCompareMaterializedViewHashJoinExec(e.Ctx(), mvQueryExec, baseQueryExec, layout.groupKeyOffsets, visibleCols)
 	if err := exec.Open(ctx, hashJoinExec); err != nil {
 		_ = hashJoinExec.Close()
 		return err
@@ -1434,12 +1434,12 @@ func (e *CompareMaterializedViewExec) Next(ctx context.Context, req *chunk.Chunk
 			}
 		}
 
-		leftMarkerCol := joinResult.Column(layout.leftMarkerColIdx)
-		rightMarkerCol := joinResult.Column(layout.rightMarkerColIdx)
+		mvMarkerCol := joinResult.Column(layout.mvMarkerColIdx)
+		baseMarkerCol := joinResult.Column(layout.baseMarkerColIdx)
 		for rowIdx := 0; rowIdx < joinResult.NumRows(); rowIdx++ {
 			diffType := classifyCompareMaterializedViewRowDiff(
-				leftMarkerCol.IsNull(rowIdx),
-				rightMarkerCol.IsNull(rowIdx),
+				mvMarkerCol.IsNull(rowIdx),
+				baseMarkerCol.IsNull(rowIdx),
 				changedRows[rowIdx] != 0,
 			)
 			if diffType == "" {
@@ -1822,11 +1822,11 @@ func buildCompareMaterializedViewDiffLayout(
 	for _, offset := range diffMeta.GroupKeyMVOffsets {
 		groupKeySet[offset] = struct{}{}
 	}
-
+	// Schema: MView(probe) + BaseQuery(build)
 	layout := &compareMaterializedViewDiffLayout{
-		groupKeyOffsets:   append([]int(nil), diffMeta.GroupKeyMVOffsets...),
-		leftMarkerColIdx:  diffMeta.MarkerMVOffset,
-		rightMarkerColIdx: len(visibleCols) + diffMeta.MarkerMVOffset,
+		groupKeyOffsets:  append([]int(nil), diffMeta.GroupKeyMVOffsets...),
+		mvMarkerColIdx:   diffMeta.MarkerMVOffset,
+		baseMarkerColIdx: len(visibleCols) + diffMeta.MarkerMVOffset,
 	}
 	layout.payloadCompareColumns = make([]mviewCompleteDeltaCompareColumn, 0, len(visibleCols)-len(groupKeySet))
 	for offset, col := range visibleCols {
@@ -1886,11 +1886,11 @@ func newCompareMaterializedViewHashJoinExec(
 		buildCompareMaterializedViewOrdinalSlice(len(leftTypes)),
 		buildCompareMaterializedViewOrdinalSlice(len(rightTypes)),
 	}
-	// Compare always uses BaseQuery@R as the probe/left side and MV@S as the
+	// Compare uses MV@S as the probe/left side and BaseQuery@R as the
 	// build/right side. This matches the full outer hash join builder setup for
 	// build=right, probe=left:
-	// - unmatched build rows are (NULL-left, right), handled by RightOuterJoin;
-	// - unmatched probe rows are (left, NULL-right), handled by LeftOuterJoin.
+	// - unmatched build rows are (NULL-MV, base), handled by RightOuterJoin;
+	// - unmatched probe rows are (MV, NULL-base), handled by LeftOuterJoin.
 	fullJoinBuildJoiner := join.NewJoiner(
 		ctx,
 		logicalop.RightOuterJoin,
@@ -2033,12 +2033,12 @@ func buildCompareMaterializedViewOrdinalSlice(colCnt int) []int {
 	return ordinals
 }
 
-func classifyCompareMaterializedViewRowDiff(leftMissing, rightMissing, payloadChanged bool) string {
+func classifyCompareMaterializedViewRowDiff(mvMissing, baseMissing, payloadChanged bool) string {
 	switch {
-	case leftMissing:
-		return compareMaterializedViewExcessiveType
-	case rightMissing:
+	case mvMissing:
 		return compareMaterializedViewVacuumType
+	case baseMissing:
+		return compareMaterializedViewExcessiveType
 	case payloadChanged:
 		return compareMaterializedViewDifferType
 	default:
@@ -2144,7 +2144,8 @@ func (w *compareMaterializedViewOutputWriter) writeRow(ctx context.Context, row 
 	if err := w.ensureTxn(ctx); err != nil {
 		return err
 	}
-	useRight := diffType != compareMaterializedViewVacuumType
+	// Schema: MView(probe) + BaseQuery(build)
+	useRight := diffType == compareMaterializedViewVacuumType
 	for colIdx := 0; colIdx < w.mvColumnCount; colIdx++ {
 		sourceColIdx := colIdx
 		if useRight {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/18023

Problem Summary:
`COMPARE MATERIALIZED VIEW` previously used the base-query result as the hash-join probe side and the MV snapshot as the build side. For grouped MV definitions, the base query itself may need a large aggregation hash table before producing rows. Building the compare join from the MV side can make the MV-side join hash table overlap with the base-query aggregation work, increasing peak memory pressure.

### What changed and how does it work?
Use `baseQuery` as build side.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal implementation of materialized view comparison operations to improve resource efficiency by adjusting join operation ordering and diff classification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->