### PR TITLE
ddl: make schema tracker expression columns public

### DIFF
--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -3935,6 +3935,12 @@ func renameIndexes(tblInfo *model.TableInfo, from, to ast.CIStr) {
 			idx.Name.L = strings.Replace(idx.Name.L, from.L, to.L, 1)
 			idx.Name.O = strings.Replace(idx.Name.O, from.O, to.O, 1)
 		}
+	}
+	renameExpressionIndexColumnRefs(tblInfo, from, to)
+}
+
+func renameExpressionIndexColumnRefs(tblInfo *model.TableInfo, from, to ast.CIStr) {
+	for _, idx := range tblInfo.Indices {
 		for _, col := range idx.Columns {
 			originalCol := tblInfo.Columns[col.Offset]
 			if originalCol.Hidden && getExpressionIndexOriginName(col.Name) == from.O {
@@ -3943,6 +3949,12 @@ func renameIndexes(tblInfo *model.TableInfo, from, to ast.CIStr) {
 			}
 		}
 	}
+}
+
+// RenameExpressionIndexColumns renames the hidden columns backing an expression index and their index references.
+func RenameExpressionIndexColumns(tblInfo *model.TableInfo, from, to ast.CIStr) {
+	renameExpressionIndexColumnRefs(tblInfo, from, to)
+	renameHiddenColumns(tblInfo, from, to)
 }
 
 func renameHiddenColumns(tblInfo *model.TableInfo, from, to ast.CIStr) {

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -3951,7 +3951,8 @@ func renameExpressionIndexColumnRefs(tblInfo *model.TableInfo, from, to ast.CISt
 	}
 }
 
-// RenameExpressionIndexColumns renames the hidden columns backing an expression index and their index references.
+// RenameExpressionIndexColumns renames hidden column definitions in tblInfo and their column-name
+// entries in each index column list. It does not rename the index itself.
 func RenameExpressionIndexColumns(tblInfo *model.TableInfo, from, to ast.CIStr) {
 	renameExpressionIndexColumnRefs(tblInfo, from, to)
 	renameHiddenColumns(tblInfo, from, to)

--- a/pkg/ddl/schematracker/BUILD.bazel
+++ b/pkg/ddl/schematracker/BUILD.bazel
@@ -50,7 +50,7 @@ go_test(
     ],
     embed = [":schematracker"],
     flaky = True,
-    shard_count = 15,
+    shard_count = 16,
     deps = [
         "//pkg/executor",
         "//pkg/infoschema",

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -418,6 +418,7 @@ func (d *SchemaTracker) createIndex(
 	}
 	for _, hiddenCol := range hiddenCols {
 		colInfo := ddl.InitAndAddColumnToTable(tblInfo, hiddenCol)
+		// Mark the hidden column public to match the metadata produced by executing ADD INDEX.
 		colInfo.State = model.StatePublic
 	}
 

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -417,7 +417,8 @@ func (d *SchemaTracker) createIndex(
 		return err
 	}
 	for _, hiddenCol := range hiddenCols {
-		ddl.InitAndAddColumnToTable(tblInfo, hiddenCol)
+		colInfo := ddl.InitAndAddColumnToTable(tblInfo, hiddenCol)
+		colInfo.State = model.StatePublic
 	}
 
 	indexInfo, err := ddl.BuildIndexInfo(

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -418,8 +418,6 @@ func (d *SchemaTracker) createIndex(
 	}
 	for _, hiddenCol := range hiddenCols {
 		colInfo := ddl.InitAndAddColumnToTable(tblInfo, hiddenCol)
-		// The schema tracker applies finished DDLs directly, so hidden columns
-		// created for expression indexes must be public immediately.
 		colInfo.State = model.StatePublic
 	}
 

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -418,6 +418,8 @@ func (d *SchemaTracker) createIndex(
 	}
 	for _, hiddenCol := range hiddenCols {
 		colInfo := ddl.InitAndAddColumnToTable(tblInfo, hiddenCol)
+		// The schema tracker applies finished DDLs directly, so hidden columns
+		// created for expression indexes must be public immediately.
 		colInfo.State = model.StatePublic
 	}
 

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -754,9 +754,37 @@ func (d *SchemaTracker) renameIndex(_ sessionctx.Context, ident ast.Ident, spec 
 	if err != nil {
 		return err
 	}
+	renameExpressionIndexColumns(tblInfo, spec.FromKey, spec.ToKey)
 	idx := tblInfo.FindIndexByName(spec.FromKey.L)
 	idx.Name = spec.ToKey
 	return nil
+}
+
+func renameExpressionIndexColumns(tblInfo *model.TableInfo, from, to ast.CIStr) {
+	for _, idx := range tblInfo.Indices {
+		for _, idxCol := range idx.Columns {
+			col := tblInfo.Columns[idxCol.Offset]
+			if col.Hidden && expressionIndexOriginName(idxCol.Name) == from.O {
+				idxCol.Name.L = strings.Replace(idxCol.Name.L, from.L, to.L, 1)
+				idxCol.Name.O = strings.Replace(idxCol.Name.O, from.O, to.O, 1)
+			}
+		}
+	}
+	for _, col := range tblInfo.Columns {
+		if col.Hidden && expressionIndexOriginName(col.Name) == from.O {
+			col.Name.L = strings.Replace(col.Name.L, from.L, to.L, 1)
+			col.Name.O = strings.Replace(col.Name.O, from.O, to.O, 1)
+		}
+	}
+}
+
+func expressionIndexOriginName(name ast.CIStr) string {
+	columnName := strings.TrimPrefix(name.O, "_V$_")
+	pos := strings.LastIndex(columnName, "_")
+	if pos == -1 {
+		return columnName
+	}
+	return columnName[:pos]
 }
 
 // addTablePartitions is used by AlterTable.

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -754,37 +754,10 @@ func (d *SchemaTracker) renameIndex(_ sessionctx.Context, ident ast.Ident, spec 
 	if err != nil {
 		return err
 	}
-	renameExpressionIndexColumns(tblInfo, spec.FromKey, spec.ToKey)
+	ddl.RenameExpressionIndexColumns(tblInfo, spec.FromKey, spec.ToKey)
 	idx := tblInfo.FindIndexByName(spec.FromKey.L)
 	idx.Name = spec.ToKey
 	return nil
-}
-
-func renameExpressionIndexColumns(tblInfo *model.TableInfo, from, to ast.CIStr) {
-	for _, idx := range tblInfo.Indices {
-		for _, idxCol := range idx.Columns {
-			col := tblInfo.Columns[idxCol.Offset]
-			if col.Hidden && expressionIndexOriginName(idxCol.Name) == from.O {
-				idxCol.Name.L = strings.Replace(idxCol.Name.L, from.L, to.L, 1)
-				idxCol.Name.O = strings.Replace(idxCol.Name.O, from.O, to.O, 1)
-			}
-		}
-	}
-	for _, col := range tblInfo.Columns {
-		if col.Hidden && expressionIndexOriginName(col.Name) == from.O {
-			col.Name.L = strings.Replace(col.Name.L, from.L, to.L, 1)
-			col.Name.O = strings.Replace(col.Name.O, from.O, to.O, 1)
-		}
-	}
-}
-
-func expressionIndexOriginName(name ast.CIStr) string {
-	columnName := strings.TrimPrefix(name.O, "_V$_")
-	pos := strings.LastIndex(columnName, "_")
-	if pos == -1 {
-		return columnName
-	}
-	return columnName[:pos]
 }
 
 // addTablePartitions is used by AlterTable.

--- a/pkg/ddl/schematracker/dm_tracker_test.go
+++ b/pkg/ddl/schematracker/dm_tracker_test.go
@@ -299,11 +299,14 @@ func TestCreateTableWithIndex(t *testing.T) {
 
 	sql = "alter table test.t rename index idx_1 to idx_1_1"
 	execAlter(t, tracker, sql)
+	sql = "alter table test.t add index idx_1 ((cast(col_1 as char(64) array)))"
+	execAlter(t, tracker, sql)
 
 	tblInfo := mustTableByName(t, tracker, "test", "t")
 	expected := "CREATE TABLE `t` (\n" +
 		"  `col_1` json DEFAULT NULL,\n" +
-		"  KEY `idx_1_1` ((cast(`col_1` as char(64) array)))\n" +
+		"  KEY `idx_1_1` ((cast(`col_1` as char(64) array))),\n" +
+		"  KEY `idx_1` ((cast(`col_1` as char(64) array)))\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"
 	checkShowCreateTable(t, tblInfo, expected)
 }

--- a/pkg/ddl/schematracker/dm_tracker_test.go
+++ b/pkg/ddl/schematracker/dm_tracker_test.go
@@ -103,10 +103,90 @@ func execAlter(t *testing.T, tracker schematracker.SchemaTracker, sql string) {
 	require.NoError(t, err)
 }
 
+func execDDL(t *testing.T, tracker schematracker.SchemaTracker, sql string) {
+	ctx := context.Background()
+	sctx := mock.NewContext()
+	p := parser.New()
+	stmt, err := p.ParseOneStmt(sql, "", "")
+	require.NoError(t, err)
+	switch stmt := stmt.(type) {
+	case *ast.CreateTableStmt:
+		err = tracker.CreateTable(sctx, stmt)
+	case *ast.AlterTableStmt:
+		err = tracker.AlterTable(ctx, sctx, stmt)
+	case *ast.CreateIndexStmt:
+		err = tracker.CreateIndex(sctx, stmt)
+	default:
+		require.Failf(t, "unsupported DDL", "%T", stmt)
+	}
+	require.NoError(t, err)
+}
+
 func mustTableByName(t *testing.T, tracker schematracker.SchemaTracker, schema, table string) *model.TableInfo {
 	tblInfo, err := tracker.TableByName(context.Background(), ast.NewCIStr(schema), ast.NewCIStr(table))
 	require.NoError(t, err)
 	return tblInfo
+}
+
+func requireExpressionIndexHiddenColumnsPublic(t *testing.T, tblInfo *model.TableInfo) {
+	t.Helper()
+
+	found := false
+	for _, idx := range tblInfo.Indices {
+		if idx.State != model.StatePublic {
+			continue
+		}
+		for _, idxCol := range idx.Columns {
+			col := tblInfo.Columns[idxCol.Offset]
+			if !col.Hidden || !col.IsGenerated() {
+				continue
+			}
+			found = true
+			require.Equal(t, model.StatePublic, col.State)
+		}
+	}
+	require.True(t, found)
+}
+
+func TestExpressionIndexHiddenColumnState(t *testing.T) {
+	cases := []struct {
+		name string
+		ddls []string
+	}{
+		{
+			name: "create table",
+			ddls: []string{
+				"create table test.t (id int primary key, name varchar(64), unique key uk_lower_name ((lower(name))))",
+			},
+		},
+		{
+			name: "create index",
+			ddls: []string{
+				"create table test.t (id int primary key, name varchar(64))",
+				"create unique index uk_lower_name on test.t ((lower(name)))",
+			},
+		},
+		{
+			name: "alter table add index",
+			ddls: []string{
+				"create table test.t (id int primary key, name varchar(64))",
+				"alter table test.t add unique key uk_lower_name ((lower(name)))",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := schematracker.NewSchemaTracker(2)
+			tracker.CreateTestDB(nil)
+			for _, ddl := range tc.ddls {
+				execDDL(t, tracker, ddl)
+			}
+
+			tblInfo := mustTableByName(t, tracker, "test", "t")
+			requireExpressionIndexHiddenColumnsPublic(t, tblInfo)
+		})
+	}
 }
 
 func TestAlterPK(t *testing.T) {

--- a/pkg/ddl/schematracker/dm_tracker_test.go
+++ b/pkg/ddl/schematracker/dm_tracker_test.go
@@ -104,17 +104,18 @@ func execAlter(t *testing.T, tracker schematracker.SchemaTracker, sql string) {
 }
 
 func execDDL(t *testing.T, tracker schematracker.SchemaTracker, sql string) {
-	ctx := context.Background()
-	sctx := mock.NewContext()
 	p := parser.New()
 	stmt, err := p.ParseOneStmt(sql, "", "")
 	require.NoError(t, err)
 	switch stmt := stmt.(type) {
 	case *ast.CreateTableStmt:
-		err = tracker.CreateTable(sctx, stmt)
+		execCreate(t, tracker, sql)
+		return
 	case *ast.AlterTableStmt:
-		err = tracker.AlterTable(ctx, sctx, stmt)
+		execAlter(t, tracker, sql)
+		return
 	case *ast.CreateIndexStmt:
+		sctx := mock.NewContext()
 		err = tracker.CreateIndex(sctx, stmt)
 	default:
 		require.Failf(t, "unsupported DDL", "%T", stmt)
@@ -145,7 +146,7 @@ func requireExpressionIndexHiddenColumnsPublic(t *testing.T, tblInfo *model.Tabl
 			require.Equal(t, model.StatePublic, col.State)
 		}
 	}
-	require.True(t, found)
+	require.True(t, found, "table %s should contain at least one public expression index hidden column", tblInfo.Name.O)
 }
 
 func TestExpressionIndexHiddenColumnState(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69323, ref https://github.com/pingcap/tiflow/issues/12696

Problem Summary:

DM uses `pkg/ddl/schematracker` to replay completed DDLs and then consumes the tracked `TableInfo`. For expression indexes, the tracker could build `TableInfo` that violates TiDB's schema invariant: **all public columns should appear before non-public columns**.

For example, after replaying an expression-index DDL and a later `ADD COLUMN`, DM could see a `TableInfo.Columns` layout like:

```text
id                  offset=0 state=public
name                offset=1 state=public
hidden lower(name)  offset=2 state=none
payload             offset=3 state=public
```

The hidden expression-index column should not remain non-public in this final tracked schema.

The tracker also missed the hidden column metadata when handling `RENAME INDEX`, so the tracked schema could keep stale expression-index backing column names and diverge from TiDB's real DDL result.

### What changed and how does it work?

Mark hidden generated columns created for expression indexes as public immediately in the schema tracker.

Reuse TiDB's expression-index rename helper when the schema tracker handles `RENAME INDEX`, so both the hidden columns and index column references are renamed consistently.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix schema tracker inconsistencies for expression-index hidden generated columns.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expression-index rename handling so underlying generated hidden columns and their expression references stay consistent.
  * Ensured generated hidden columns for expression indexes are set to an available/public state for more reliable DDL behavior.
* **Tests**
  * Added coverage for expression index hidden-column state across create/alter flows.
  * Extended expected outputs to reflect additional expression index changes.
  * Updated test sharding configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
