### PR TITLE
test: stabilize flaky TestStorageEnginesInSlowQuery

### DIFF
--- a/pkg/executor/slow_query_sql_test.go
+++ b/pkg/executor/slow_query_sql_test.go
@@ -465,7 +465,8 @@ func TestWarningsInSlowQuery(t *testing.T) {
 func checkStorageEngines(t *testing.T, tk *testkit.TestKit, where, expected string) {
 	t.Helper()
 	tk.EventuallyMustQueryAndCheck(
-		"select storage_from_kv, storage_from_mpp from information_schema.slow_query where "+where,
+		"select storage_from_kv, storage_from_mpp from information_schema.slow_query where ("+where+") "+
+			"and query not like '%information_schema.slow_query%'",
 		nil, testkit.Rows(expected), 2*time.Second, 50*time.Millisecond)
 }
 
@@ -525,6 +526,13 @@ func TestStorageEnginesInSlowQuery(t *testing.T) {
 	query := "select a from t_pointget where a = 1"
 	tk.MustHavePlan(query, "Point_Get")
 	tk.MustExec(query)
+	// Simulate one retry of checkStorageEngines. With threshold 0, slow_query
+	// inspection statements are themselves slow-logged and can match broad
+	// predicates like the point-get predicate below.
+	tk.MustQuery("select storage_from_kv, storage_from_mpp from information_schema.slow_query where query like 'select%t_pointget%;'")
+	tk.EventuallyMustQueryAndCheck(
+		"select count(*) > 0 from information_schema.slow_query where query like '%information_schema.slow_query%t_pointget%;'",
+		nil, testkit.Rows("1"), 2*time.Second, 50*time.Millisecond)
 	checkStorageEngines(t, tk, "query like 'select%t_pointget%;'", "1 0")
 
 	// Index readers should register as reading from TiKV


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/66727

Problem Summary:
Flaky test `TestStorageEnginesInSlowQuery` in `pkg/executor` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Slow-query inspection queries were logged and matched by broad predicates, adding false storage-engine rows to the test’s expected user-query results.

#### Fix

Filtering out information_schema.slow_query inspection rows preserves the assertion target while the seeded retry proves the contamination path.

#### Verification

Spec:
- target: `pkg/executor :: TestStorageEnginesInSlowQuery`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: failed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky_json passed.
timing_seeded_repro passed.

Gate checklist:
- target_flaky_json: PASS
- timing_seeded_repro: PASS
- package_raw_harness_advisory: SKIPPED
- build: BLOCKED
- lint: BLOCKED

Commands:
- `go test -json -tags=intest,deadlock ./pkg/executor -run '^TestStorageEnginesInSlowQuery$' -count=1`
- `go test -tags=intest,deadlock ./pkg/executor -run '^TestStorageEnginesInSlowQuery$' -count=1`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #66727

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved slow-query test reliability by refining SQL inspection logic to prevent false positives.
  * Enhanced point-get test case with retry simulation to better validate slow-query logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->