### PR TITLE
security: pin GitHub Actions, container images, and Go commands by immutable digest

### DIFF
--- a/.github/workflows/bazel-build-crossbuild.yml
+++ b/.github/workflows/bazel-build-crossbuild.yml
@@ -17,7 +17,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Build Prepare
         uses: ./.github/actions/tidb_build
         with:

--- a/.github/workflows/bazel-build-crossbuild.yml
+++ b/.github/workflows/bazel-build-crossbuild.yml
@@ -18,6 +18,8 @@ jobs:
           - ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Build Prepare
         uses: ./.github/actions/tidb_build
         with:

--- a/.github/workflows/bazel-lint-crossbuild.yml
+++ b/.github/workflows/bazel-lint-crossbuild.yml
@@ -15,6 +15,8 @@ jobs:
           - ubuntu
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Build Prepare
         uses: ./.github/actions/tidb_build
         with:

--- a/.github/workflows/bazel-lint-crossbuild.yml
+++ b/.github/workflows/bazel-lint-crossbuild.yml
@@ -14,7 +14,7 @@ jobs:
           - macos
           - ubuntu
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Build Prepare
         uses: ./.github/actions/tidb_build
         with:

--- a/.github/workflows/check-bazel-prepare.yml
+++ b/.github/workflows/check-bazel-prepare.yml
@@ -16,19 +16,19 @@ jobs:
     name: Check Bazel Prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.25
           cache: false
       - name: Set up Bazelisk
-        uses: bazel-contrib/setup-bazel@0.16.0
+        uses: bazel-contrib/setup-bazel@8310a45e30297e76bc8fbae427fb6068efa01eb8 # 0.16.0
         with:
           bazelisk-cache: false
           repository-cache: false

--- a/.github/workflows/generate-bazel-files.yml
+++ b/.github/workflows/generate-bazel-files.yml
@@ -21,7 +21,7 @@ jobs:
     name: Generate Bazel Files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
@@ -97,7 +97,7 @@ jobs:
             ':(glob)**/*.bzl' \
             > bazel-artifact/bazel.patch
       - name: Upload Bazel Files Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bazel-files
           path: bazel-artifact/bazel.patch

--- a/.github/workflows/integration-test-compile-br.yml
+++ b/.github/workflows/integration-test-compile-br.yml
@@ -52,6 +52,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -67,6 +69,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5

--- a/.github/workflows/integration-test-compile-br.yml
+++ b/.github/workflows/integration-test-compile-br.yml
@@ -51,10 +51,10 @@ jobs:
         os: [macos-latest,  ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: 'go.mod'
 
@@ -66,10 +66,10 @@ jobs:
     name: Compile for FreeBSD job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/integration-test-dumpling.yml
+++ b/.github/workflows/integration-test-dumpling.yml
@@ -64,15 +64,15 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: "checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: "set up golang"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: 'go.mod'
       - name: "try to use build cache"
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cache/go-build
@@ -101,7 +101,7 @@ jobs:
           fi
       - name: "upload tidb log artifact"
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dumpling-tidb-log-${{ matrix.mysql_version }}
           path: /tmp/dumpling_test_result/tidb.log
@@ -109,4 +109,4 @@ jobs:
           retention-days: 7
       - name: "set up tmate session if necessary"
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.debug }}
-        uses: mxschmitt/action-tmate@v3
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3

--- a/.github/workflows/integration-test-dumpling.yml
+++ b/.github/workflows/integration-test-dumpling.yml
@@ -67,6 +67,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: "set up golang"
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:

--- a/.github/workflows/update-bazel-files.yml
+++ b/.github/workflows/update-bazel-files.yml
@@ -76,7 +76,7 @@ jobs:
           echo "Skip stale bazel update for PR #${{ steps.pr.outputs.pr_number }}."
       - name: Download Fork Bazel Files Artifact
         if: steps.pr.outputs.same_repo != 'true' && steps.pr.outputs.stale != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: bazel-files
           path: bazel-artifact
@@ -112,7 +112,7 @@ jobs:
           exit 1
       - name: Checkout PR branch
         if: steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.stale != 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: ${{ steps.pr.outputs.head_repo }}
           ref: ${{ steps.pr.outputs.head_ref }}
@@ -122,7 +122,7 @@ jobs:
           persist-credentials: false
       - name: Download Bazel Files Artifact
         if: steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.stale != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: bazel-files
           path: bazel-artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # production environment, please refer to https://github.com/PingCAP-QE/artifacts/blob/main/dockerfiles/cd/builders/tidb/Dockerfile.
 
 # Builder image
-FROM golang:1.25.10 as builder
+FROM golang:1.25.10@sha256:c138bff780910acf4254ab3a6f7ff0f64bbd841f27bd82bfa986fe122c109538 as builder
 WORKDIR /tidb
 
 COPY . .
@@ -27,7 +27,7 @@ ENV GOPROXY ${GOPROXY}
 RUN make server
 
 
-FROM quay.io/rockylinux/rockylinux:9-minimal
+FROM quay.io/rockylinux/rockylinux:9-minimal@sha256:c26c789bd9b2c9fd092109688dbac8bdab27e51651d8130d7e10220f8e07614a
 
 COPY --from=builder /tidb/bin/tidb-server /tidb-server
 

--- a/Dockerfile.enterprise
+++ b/Dockerfile.enterprise
@@ -14,7 +14,7 @@
 
 # The current dockerfile is only used for development purposes.
 # Builder image
-FROM golang:1.25.10 as builder
+FROM golang:1.25.10@sha256:c138bff780910acf4254ab3a6f7ff0f64bbd841f27bd82bfa986fe122c109538 as builder
 WORKDIR /tidb
 
 COPY . .
@@ -24,7 +24,7 @@ ENV GOPROXY ${GOPROXY}
 
 RUN make enterprise-server-build
 
-FROM quay.io/rockylinux/rockylinux:9-minimal
+FROM quay.io/rockylinux/rockylinux:9-minimal@sha256:c26c789bd9b2c9fd092109688dbac8bdab27e51651d8130d7e10220f8e07614a
 
 COPY --from=builder /tidb/bin/tidb-server /tidb-server
 

--- a/br/docker/Dockerfile
+++ b/br/docker/Dockerfile
@@ -1,5 +1,5 @@
 # For loading data to TiDB
-FROM golang:1.18.9-alpine as go-ycsb-builder
+FROM golang:1.18.9-alpine@sha256:0494a1050388f866e09e59540408ead2a2968953e7093f6bfb048317c5d1f70a as go-ycsb-builder
 WORKDIR /go/src/github.com/pingcap/
 
 RUN apk add --no-cache \
@@ -15,9 +15,9 @@ RUN git clone https://github.com/pingcap/go-ycsb.git --depth=1 && \
     make
 
 # For operating minio S3 compatible storage
-FROM minio/mc as mc-builder
+FROM minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727 as mc-builder
 
-FROM golang:1.18.9-alpine
+FROM golang:1.18.9-alpine@sha256:0494a1050388f866e09e59540408ead2a2968953e7093f6bfb048317c5d1f70a
 
 WORKDIR /go/src/github.com/pingcap/br
 COPY . .

--- a/build/jenkins_collect_coverage.sh
+++ b/build/jenkins_collect_coverage.sh
@@ -23,7 +23,7 @@ set -o pipefail
 coverage_report=./bazel-out/_coverage/_coverage_report.dat
 junit_report=./bazel.xml
 
-go install github.com/hawkingrei/bazel_collect@latest
+go install github.com/hawkingrei/bazel_collect@89393073f416d5a8106d4393d918c7f6d4d9e308
 mkdir -p test_coverage
 if [ -f "${coverage_report}" ]; then
     cp "${coverage_report}" ./coverage.dat

--- a/build/jenkins_unit_test.sh
+++ b/build/jenkins_unit_test.sh
@@ -23,7 +23,7 @@ set -o pipefail
 coverage_report=./bazel-out/_coverage/_coverage_report.dat
 junit_report=./bazel.xml
 
-go install github.com/hawkingrei/bazel_collect@latest
+go install github.com/hawkingrei/bazel_collect@89393073f416d5a8106d4393d918c7f6d4d9e308
 make bazel_ci_test
 EXIT_STATUS=$?
 # collect the junit and coverage report

--- a/build/jenkins_unit_test_ddlargsv1.sh
+++ b/build/jenkins_unit_test_ddlargsv1.sh
@@ -23,7 +23,7 @@ set -o pipefail
 coverage_report=./bazel-out/_coverage/_coverage_report.dat
 junit_report=./bazel.xml
 
-go install github.com/hawkingrei/bazel_collect@latest
+go install github.com/hawkingrei/bazel_collect@89393073f416d5a8106d4393d918c7f6d4d9e308
 make bazel_ci_test_ddlargsv1
 EXIT_STATUS=$?
 # collect the junit and coverage report

--- a/pkg/metrics/grafana/generate_json.sh
+++ b/pkg/metrics/grafana/generate_json.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+go install github.com/google/go-jsonnet/cmd/jsonnet@v0.22.0
 
 # ref https://github.com/grafana/grafonnet-lib/issues/338, use the forked 
 # repo which implements the addOverride and addTransformation funtion for 

--- a/pkg/metrics/nextgengrafana/generate_json.sh
+++ b/pkg/metrics/nextgengrafana/generate_json.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+go install github.com/google/go-jsonnet/cmd/jsonnet@v0.22.0
 
 # ref https://github.com/grafana/grafonnet-lib/issues/338, use the forked
 # repo which implements the addOverride and addTransformation funtion for

--- a/tests/globalkilltest/Dockerfile
+++ b/tests/globalkilltest/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rockylinux:9
+FROM rockylinux:9@sha256:d7be1c094cc5845ee815d4632fe377514ee6ebcf8efaed6892889657e5ddaaa6
 
 RUN dnf update -y && dnf groupinstall 'Development Tools' -y
 RUN dnf install procps-ng mysql -y

--- a/tools/patch-go/Dockerfile
+++ b/tools/patch-go/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:focal
+FROM ubuntu:focal@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214
 ADD build.sh /
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     sudo \


### PR DESCRIPTION
## Summary

Pin all external dependencies to immutable hashes/digests to address OpenSSF Scorecard Pinned-Dependencies warnings.

Issue Number: close #69216

## Changes

### GitHub Actions (pinned by commit SHA)
| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v6` | `@df4cb1c069e1874edd31b4311f1884172cec0e10` |
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-go` | `@v6` | `@4a3601121dd01d1626a1e23e37211e3254c1c06c` |
| `actions/setup-go` | `@v5` | `@40f1582b2485089dde7abd97c1529aa768e1baff` |
| `actions/cache` | `@v4` | `@0057852bfaa89a56745cba8c7296529d2fc39830` |
| `actions/upload-artifact` | `@v4` | `@ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/download-artifact` | `@v4` | `@d3f86a106a0bac45b974a628896c90dbdf5c8093` |
| `bazel-contrib/setup-bazel` | `@0.16.0` | `@8310a45e30297e76bc8fbae427fb6068efa01eb8` |
| `mxschmitt/action-tmate` | `@v3` | `@35b54afac29c97fb54faba5b513f8fbd1882f113` |

### Container images (pinned by sha256 digest)
| Image | Digest |
|-------|--------|
| `golang:1.25.10` | `@sha256:c138bff780910acf4254ab3a6f7ff0f64bbd841f27bd82bfa986fe122c109538` |
| `rockylinux:9-minimal` | `@sha256:c26c789bd9b2c9fd092109688dbac8bdab27e51651d8130d7e10220f8e07614a` |
| `golang:1.18.9-alpine` | `@sha256:0494a1050388f866e09e59540408ead2a2968953e7093f6bfb048317c5d1f70a` |
| `minio/mc` | `@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727` |
| `rockylinux:9` | `@sha256:d7be1c094cc5845ee815d4632fe377514ee6ebcf8efaed6892889657e5ddaaa6` |
| `ubuntu:focal` | `@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214` |

### Go commands (pinned to specific version/commit)
| Package | Before | After |
|---------|--------|-------|
| `hawkingrei/bazel_collect` | `@latest` | `@89393073f416d5a8106d4393d918c7f6d4d9e308` |
| `google/go-jsonnet/cmd/jsonnet` | `@latest` | `@v0.22.0` |

## Files changed (17)
- `.github/workflows/bazel-build-crossbuild.yml`
- `.github/workflows/bazel-lint-crossbuild.yml`
- `.github/workflows/check-bazel-prepare.yml`
- `.github/workflows/generate-bazel-files.yml`
- `.github/workflows/update-bazel-files.yml`
- `.github/workflows/integration-test-compile-br.yml`
- `.github/workflows/integration-test-dumpling.yml`
- `Dockerfile`
- `Dockerfile.enterprise`
- `br/docker/Dockerfile`
- `tests/globalkilltest/Dockerfile`
- `tools/patch-go/Dockerfile`
- `build/jenkins_collect_coverage.sh`
- `build/jenkins_unit_test.sh`
- `build/jenkins_unit_test_ddlargsv1.sh`
- `pkg/metrics/grafana/generate_json.sh`
- `pkg/metrics/nextgengrafana/generate_json.sh`

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

This is a security hardening change with no functional impact. All pinned references are the exact same versions that were previously referenced by mutable tags.

## Risk

Low. The pinned hashes correspond to the same versions that were already in use. If a hash becomes stale due to image rebuilds, the Dockerfile will fail to build with a clear error message rather than silently pulling a different version.

## Release note

```release-note
Pin all GitHub Actions, container images, and Go commands to immutable hashes/digests for improved supply chain security.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned external dependencies including GitHub Actions steps, Docker base images, Go packages, and build tools to specific versions across all build workflows and container configurations. This ensures reproducible builds across development and CI environments and improves supply chain security by preventing unintended changes from upstream updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->