### PR TITLE
lightning: disable PD router client for local imports

### DIFF
--- a/lightning/pkg/importer/import.go
+++ b/lightning/pkg/importer/import.go
@@ -71,6 +71,7 @@ import (
 	kvutil "github.com/tikv/client-go/v2/util"
 	pd "github.com/tikv/pd/client"
 	pdhttp "github.com/tikv/pd/client/http"
+	"github.com/tikv/pd/client/opt"
 	"github.com/tikv/pd/client/pkg/caller"
 	"github.com/tikv/pd/client/pkg/retry"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -383,7 +384,8 @@ func NewImportControllerWithPauser(
 		}
 
 		addrs := strings.Split(cfg.TiDB.PdAddr, ",")
-		pdCli, err = pd.NewClientWithAPIContext(ctx, apiContext, componentName, addrs, tls.ToPDSecurityOption(), ingestctrl.PDClientOptions()...)
+		pdClientOptions := append(ingestctrl.PDClientOptions(), opt.WithEnableRouterClient(false))
+		pdCli, err = pd.NewClientWithAPIContext(ctx, apiContext, componentName, addrs, tls.ToPDSecurityOption(), pdClientOptions...)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -448,6 +450,8 @@ func NewImportControllerWithPauser(
 			raftKV2SwitchModeDuration = cfg.Cron.SwitchMode.Duration
 		}
 		backendConfig := ingestctrl.NewBackendConfig(cfg, maxOpenFiles, p.KeyspaceName, p.ResourceGroupName, p.TaskType, raftKV2SwitchModeDuration)
+		// Use legacy PD region RPCs so newer Lightning can import into older clusters.
+		backendConfig.DisablePDClientRouterClient = true
 		backendObj, err = ingestctrl.NewBackend(ctx, tls, backendConfig, pdCliForTiKV)
 		if err != nil {
 			return nil, common.NormalizeOrWrapErr(common.ErrUnknown, err)

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -487,6 +487,8 @@ type BackendConfig struct {
 	ResourceGroupName         string
 	TaskType                  string
 	RaftKV2SwitchModeDuration time.Duration
+	// DisablePDClientRouterClient keeps region lookups on legacy PD RPCs.
+	DisablePDClientRouterClient bool
 	// whether disable automatic compactions of pebble db of engine.
 	// deduplicate pebble db is not affected by this option.
 	// see DisableAutomaticCompactions of pebble.Options for more details.
@@ -845,7 +847,11 @@ func (local *Backend) getTiKVClient(ctx context.Context) (*tikvclient.KVStore, e
 	// the lifecycle of input PD client, while the PD client inside this is
 	// managed outside.
 	apiContext := keyspace.BuildAPIContext(local.KeyspaceName)
-	pdCliForTiKV, err := newPDClient(ctx, apiContext, caller.Component("lightning-local-backend"), local.pdAddrs, pdSecurityOption(local.tls), PDClientOptions()...)
+	pdClientOptions := PDClientOptions()
+	if local.DisablePDClientRouterClient {
+		pdClientOptions = append(pdClientOptions, opt.WithEnableRouterClient(false))
+	}
+	pdCliForTiKV, err := newPDClient(ctx, apiContext, caller.Component("lightning-local-backend"), local.pdAddrs, pdSecurityOption(local.tls), pdClientOptions...)
 	if err != nil {
 		_ = spkv.Close()
 		return nil, common.ErrCreateKVClient.Wrap(err).GenWithStackByArgs()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67923

Problem Summary:

After PR #65743 upgraded `github.com/tikv/pd/client`, the PD router client became enabled by default. Standalone TiDB Lightning local import may then route `GetRegionByID` through `QueryRegion`, which older PD versions such as v8.5.6 do not support.

### What changed and how does it work?

Disable the PD router client only for standalone TiDB Lightning local imports, so region lookups keep using the legacy PD RPC path. Other local backend users keep the default PD client behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix TiDB Lightning compatibility with older PD versions during local imports.
```
