### PR TITLE
lightning: disable PD router client for local imports

### DIFF
--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -126,7 +126,7 @@ go_test(
     ],
     embed = [":task"],
     flaky = True,
-    shard_count = 47,
+    shard_count = 49,
     deps = [
         "//br/pkg/backup",
         "//br/pkg/config",

--- a/br/pkg/task/operator/BUILD.bazel
+++ b/br/pkg/task/operator/BUILD.bazel
@@ -79,7 +79,7 @@ go_test(
         "//br/pkg/task",
         "//pkg/objstore",
         "//pkg/objstore/storeapi",
-        "@com_github_stretchr_testify//require",
         "@com_github_spf13_pflag//:pflag",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/lightning/pkg/importer/BUILD.bazel
+++ b/lightning/pkg/importer/BUILD.bazel
@@ -96,6 +96,7 @@ go_library(
         "@com_github_tikv_client_go_v2//util",
         "@com_github_tikv_pd_client//:client",
         "@com_github_tikv_pd_client//http",
+        "@com_github_tikv_pd_client//opt",
         "@com_github_tikv_pd_client//pkg/caller",
         "@com_github_tikv_pd_client//pkg/retry",
         "@io_etcd_go_etcd_client_v3//:client",

--- a/lightning/pkg/importer/import.go
+++ b/lightning/pkg/importer/import.go
@@ -384,6 +384,7 @@ func NewImportControllerWithPauser(
 		}
 
 		addrs := strings.Split(cfg.TiDB.PdAddr, ",")
+		// Disable router QueryRegion streams so newer Lightning can import into older PD clusters.
 		pdClientOptions := append(ingestctrl.PDClientOptions(), opt.WithEnableRouterClient(false))
 		pdCli, err = pd.NewClientWithAPIContext(ctx, apiContext, componentName, addrs, tls.ToPDSecurityOption(), pdClientOptions...)
 		if err != nil {
@@ -1212,7 +1213,10 @@ const (
 func (rc *Controller) keepPauseGCForDupeRes(ctx context.Context) (<-chan struct{}, error) {
 	tlsOpt := rc.tls.ToPDSecurityOption()
 	addrs := strings.Split(rc.cfg.TiDB.PdAddr, ",")
-	pdCli, err := pd.NewClientWithAPIContext(ctx, rc.apiContext, componentName, addrs, tlsOpt)
+	// Disable router QueryRegion streams for older PD clusters during duplicate resolution.
+	pdCli, err := pd.NewClientWithAPIContext(
+		ctx, rc.apiContext, componentName, addrs, tlsOpt, opt.WithEnableRouterClient(false),
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/lightning/pkg/importer/import.go
+++ b/lightning/pkg/importer/import.go
@@ -71,6 +71,7 @@ import (
 	kvutil "github.com/tikv/client-go/v2/util"
 	pd "github.com/tikv/pd/client"
 	pdhttp "github.com/tikv/pd/client/http"
+	"github.com/tikv/pd/client/opt"
 	"github.com/tikv/pd/client/pkg/caller"
 	"github.com/tikv/pd/client/pkg/retry"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -383,7 +384,8 @@ func NewImportControllerWithPauser(
 		}
 
 		addrs := strings.Split(cfg.TiDB.PdAddr, ",")
-		pdCli, err = pd.NewClientWithAPIContext(ctx, apiContext, componentName, addrs, tls.ToPDSecurityOption(), ingestctrl.PDClientOptions()...)
+		pdClientOptions := append(ingestctrl.PDClientOptions(), opt.WithEnableRouterClient(false))
+		pdCli, err = pd.NewClientWithAPIContext(ctx, apiContext, componentName, addrs, tls.ToPDSecurityOption(), pdClientOptions...)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -448,6 +450,8 @@ func NewImportControllerWithPauser(
 			raftKV2SwitchModeDuration = cfg.Cron.SwitchMode.Duration
 		}
 		backendConfig := ingestctrl.NewBackendConfig(cfg, maxOpenFiles, p.KeyspaceName, p.ResourceGroupName, p.TaskType, raftKV2SwitchModeDuration)
+		// Use legacy PD region RPCs so newer Lightning can import into older clusters.
+		backendConfig.DisablePDClientRouterClient = true
 		backendObj, err = ingestctrl.NewBackend(ctx, tls, backendConfig, pdCliForTiKV)
 		if err != nil {
 			return nil, common.NormalizeOrWrapErr(common.ErrUnknown, err)

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -487,7 +487,7 @@ type BackendConfig struct {
 	ResourceGroupName         string
 	TaskType                  string
 	RaftKV2SwitchModeDuration time.Duration
-	// DisablePDClientRouterClient keeps region lookups on legacy PD RPCs.
+	// DisablePDClientRouterClient uses legacy PD region RPCs for callers that must work with older PD clusters.
 	DisablePDClientRouterClient bool
 	// whether disable automatic compactions of pebble db of engine.
 	// deduplicate pebble db is not affected by this option.

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -487,6 +487,8 @@ type BackendConfig struct {
 	ResourceGroupName         string
 	TaskType                  string
 	RaftKV2SwitchModeDuration time.Duration
+	// DisablePDClientRouterClient keeps region lookups on legacy PD RPCs.
+	DisablePDClientRouterClient bool
 	// whether disable automatic compactions of pebble db of engine.
 	// deduplicate pebble db is not affected by this option.
 	// see DisableAutomaticCompactions of pebble.Options for more details.
@@ -845,7 +847,11 @@ func (local *Backend) getTiKVClient(ctx context.Context) (*tikvclient.KVStore, e
 	// the lifecycle of input PD client, while the PD client inside this is
 	// managed outside.
 	apiContext := keyspace.BuildAPIContext(local.KeyspaceName)
-	pdCliForTiKV, err := newPDClient(ctx, apiContext, caller.Component("lightning-local-backend"), local.pdAddrs, pdSecurityOption(local.tls), PDClientOptions()...)
+	pdClientOptions := PDClientOptions()
+	if local.DisablePDClientRouterClient {
+		pdClientOptions = append(pdClientOptions, opt.WithEnableRouterClient(false))
+	}
+	pdCliForTiKV, err := newPDClient(ctx, apiContext, caller.Component("lightning-local-backend"), local.pdAddrs, pdSecurityOption(local.tls), pdClientOptions...)
 	if err != nil {
 		_ = spkv.Close()
 		return nil, common.ErrCreateKVClient.Wrap(err).GenWithStackByArgs()

--- a/pkg/ingestor/ingestctrl/local_test.go
+++ b/pkg/ingestor/ingestctrl/local_test.go
@@ -2475,6 +2475,7 @@ func TestGetDupeControllerInitializesTiKVClientLazily(t *testing.T) {
 		pdClientCalls++
 		require.Equal(t, pd.NewAPIContextV1(), apiContext)
 		option := opt.NewOption()
+		option.SetEnableRouterClient(true)
 		for _, clientOpt := range opts {
 			clientOpt(option)
 		}
@@ -2513,6 +2514,28 @@ func TestGetDupeControllerInitializesTiKVClientLazily(t *testing.T) {
 	require.Equal(t, 1, rpcClientCalls)
 	require.Equal(t, 1, kvStoreCalls)
 	require.False(t, routerClientEnabled)
+	require.False(t, inputPDCli.closed)
+	require.True(t, tikvPDCli.closed)
+	require.Nil(t, b.tikvCli)
+
+	pdClientCalls, safePointKVCalls, rpcClientCalls, kvStoreCalls = 0, 0, 0, 0
+	routerClientEnabled = false
+	inputPDCli = &mockPdClient{}
+	tikvPDCli = &mockPdClient{}
+	b = &Backend{
+		pdCli:     inputPDCli,
+		pdAddrs:   []string{"127.0.0.1:2379"},
+		tls:       &common.TLS{},
+		tikvCodec: keyspace.CodecV1,
+	}
+	dupeController, err = b.GetDupeController(context.Background(), 1, nil)
+	require.Nil(t, dupeController)
+	require.ErrorContains(t, err, "mock kv store error")
+	require.Equal(t, 1, pdClientCalls)
+	require.Equal(t, 1, safePointKVCalls)
+	require.Equal(t, 1, rpcClientCalls)
+	require.Equal(t, 1, kvStoreCalls)
+	require.True(t, routerClientEnabled)
 	require.False(t, inputPDCli.closed)
 	require.True(t, tikvPDCli.closed)
 	require.Nil(t, b.tikvCli)

--- a/pkg/ingestor/ingestctrl/local_test.go
+++ b/pkg/ingestor/ingestctrl/local_test.go
@@ -2468,11 +2468,17 @@ func TestGetDupeControllerInitializesTiKVClientLazily(t *testing.T) {
 	}()
 
 	var pdClientCalls, safePointKVCalls, rpcClientCalls, kvStoreCalls int
+	var routerClientEnabled bool
 	inputPDCli := &mockPdClient{}
 	tikvPDCli := &mockPdClient{}
-	newPDClient = func(_ context.Context, apiContext pd.APIContext, _ caller.Component, _ []string, _ pd.SecurityOption, _ ...opt.ClientOption) (pd.Client, error) {
+	newPDClient = func(_ context.Context, apiContext pd.APIContext, _ caller.Component, _ []string, _ pd.SecurityOption, opts ...opt.ClientOption) (pd.Client, error) {
 		pdClientCalls++
 		require.Equal(t, pd.NewAPIContextV1(), apiContext)
+		option := opt.NewOption()
+		for _, clientOpt := range opts {
+			clientOpt(option)
+		}
+		routerClientEnabled = option.GetEnableRouterClient()
 		return tikvPDCli, nil
 	}
 	newEtcdSafePointKV = func(_ []string, _ *tls.Config, _ ...tikv.SafePointKVOpt) (tikv.SafePointKV, error) {
@@ -2494,6 +2500,9 @@ func TestGetDupeControllerInitializesTiKVClientLazily(t *testing.T) {
 		pdAddrs:   []string{"127.0.0.1:2379"},
 		tls:       &common.TLS{},
 		tikvCodec: keyspace.CodecV1,
+		BackendConfig: BackendConfig{
+			DisablePDClientRouterClient: true,
+		},
 	}
 
 	dupeController, err := b.GetDupeController(context.Background(), 1, nil)
@@ -2503,6 +2512,7 @@ func TestGetDupeControllerInitializesTiKVClientLazily(t *testing.T) {
 	require.Equal(t, 1, safePointKVCalls)
 	require.Equal(t, 1, rpcClientCalls)
 	require.Equal(t, 1, kvStoreCalls)
+	require.False(t, routerClientEnabled)
 	require.False(t, inputPDCli.closed)
 	require.True(t, tikvPDCli.closed)
 	require.Nil(t, b.tikvCli)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67923

Problem Summary:

After PR #65743 upgraded `github.com/tikv/pd/client`, the PD router client became enabled by default. Standalone TiDB Lightning local import may then route `GetRegionByID` through `QueryRegion`, which older PD versions such as v8.5.6 do not support.

### What changed and how does it work?

Disable the PD router client only for standalone TiDB Lightning local imports, so region lookups keep using the legacy PD RPC path. Other local backend users keep the default PD client behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - TiDB Lightning local backend import into a v8.5.6 cluster succeeded without `QueryRegion` errors.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix TiDB Lightning compatibility with older PD versions during local imports.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TiKV import compatibility for older clusters by adding a setting to disable PD router-client behavior and use legacy PD region lookup behavior during startup and duplicate-resolution GC.
* **Tests**
  * Expanded coverage to verify the PD client is created with the correct router-client enablement based on the new configuration.
* **Chores**
  * Updated Bazel test settings and dependencies to keep the test suite configuration current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->