### PR TITLE
planner: prototype depth-muted ordering-ratio for correlated probes (WIP)

### DIFF
--- a/pkg/planner/cardinality/BUILD.bazel
+++ b/pkg/planner/cardinality/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "exponential_test.go",
         "main_test.go",
         "ndv_test.go",
+        "proto69092_test.go",
         "row_size_test.go",
         "selectivity_test.go",
     ],

--- a/pkg/planner/cardinality/exponential.go
+++ b/pkg/planner/cardinality/exponential.go
@@ -52,3 +52,29 @@ func ApplyExponentialBackoff(sortedValues []float64, lowerBound, upperBound floa
 	// Apply bounds
 	return math.Max(lowerBound, math.Min(result, upperBound))
 }
+
+// OrderingRatioForProbeLevel mutes the find-first-row optimism ratio (the session
+// variable tidb_opt_ordering_index_selectivity_ratio) for a correlated scan that
+// sits at the given probe level in a nested-loop hierarchy.
+//
+// The base ratio r expresses how much of the surplus scan range we assume to read
+// before the first qualifying row is found (small r = optimistic, "found early").
+// In a nest of correlated probes that optimism compounds multiplicatively across
+// levels, so a constant r collapses to r^depth and becomes wildly over-optimistic
+// the deeper we go. To counter that, the per-level effective ratio backs off toward
+// 1 (full scan, no optimism) using the same exponential-backoff weighting that
+// ApplyExponentialBackoff uses for stacked uncertain factors:
+//
+//	r_eff(level) = r ^ (1 / 2^(level-1))
+//	level 1 -> r        (original optimism, single-table behavior preserved)
+//	level 2 -> sqrt(r)
+//	level 3 -> r^(1/4)
+//	... -> 1 (full scan)
+//
+// level <= 1 returns r unchanged. r must be in (0, 1]; callers gate on r > 0.
+func OrderingRatioForProbeLevel(r float64, level int) float64 {
+	if level <= 1 || r <= 0 {
+		return r
+	}
+	return math.Pow(r, 1/math.Exp2(float64(level-1)))
+}

--- a/pkg/planner/cardinality/proto69092_test.go
+++ b/pkg/planner/cardinality/proto69092_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cardinality_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/planner/cardinality"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProto69092ExpBackoffSchedule pins the per-level exponential-backoff ratio.
+func TestProto69092ExpBackoffSchedule(t *testing.T) {
+	r := 0.01
+	require.InDelta(t, 0.01, cardinality.OrderingRatioForProbeLevel(r, 0), 1e-9)  // not under a probe
+	require.InDelta(t, 0.01, cardinality.OrderingRatioForProbeLevel(r, 1), 1e-9)  // outermost
+	require.InDelta(t, 0.10, cardinality.OrderingRatioForProbeLevel(r, 2), 1e-9)   // r^(1/2)
+	require.InDelta(t, 0.3162, cardinality.OrderingRatioForProbeLevel(r, 3), 1e-3) // r^(1/4)
+	require.InDelta(t, 0.5623, cardinality.OrderingRatioForProbeLevel(r, 4), 1e-3) // r^(1/8)
+}
+
+// TestProto69092InnerProbeTrace traces the inner-probe penalty across nesting depth.
+// Driver d joins big1 (level-1 inner) which joins big2 (level-2 inner); both inner
+// scans access by an indexed join key and carry a residual filter (the surplus the
+// ratio works on). We compare plan cost with the ratio disabled vs enabled.
+func TestProto69092InnerProbeTrace(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists d, big1, big2")
+	// d: small driver.
+	tk.MustExec("create table d(id int primary key, fk int)")
+	// big1/big2: join key jk (indexed, non-unique → fanout), filter column f.
+	tk.MustExec("create table big1(id int primary key, jk int, f int, g int, index ijk(jk))")
+	tk.MustExec("create table big2(id int primary key, jk int, f int, index ijk(jk))")
+
+	tk.MustExec("insert into d values (1,1),(2,2),(3,3),(4,4),(5,5)")
+	tk.MustExec("insert into big1(id,jk,f,g) values (1,1,1,1),(2,1,2,1),(3,2,1,2),(4,2,2,2),(5,3,1,3),(6,3,2,3),(7,4,1,4),(8,4,2,4),(9,5,1,5),(10,5,2,5)")
+	for i := 0; i < 6; i++ {
+		tk.MustExec("insert into big1(id,jk,f,g) select id+(select max(id) from big1),jk,f,g from big1")
+	}
+	tk.MustExec("insert into big2(id,jk,f) select id,jk,f from big1")
+	tk.MustExec("analyze table d, big1, big2")
+	require.NoError(t, dom.StatsHandle().Update(context.Background(), dom.InfoSchema()))
+
+	dump := func(tag, q string) [][]any {
+		rows := tk.MustQuery(q).Rows()
+		t.Logf("==== plan (%s) ====", tag)
+		out := make([][]any, len(rows))
+		for i, row := range rows {
+			out[i] = row
+			t.Logf("%-40s estRows=%-12s estCost=%-14s task=%-8s access=%v",
+				fmt.Sprint(row[0]), fmt.Sprint(row[1]), fmt.Sprint(row[2]), fmt.Sprint(row[3]), row[5])
+		}
+		return out
+	}
+	// For big2, return (matching estRows from its IndexLookUp, access estRows from its
+	// IndexRangeScan). The IndexLookUp appears just above its IndexRangeScan child in the
+	// EXPLAIN tree, so the most-recent IndexLookUp before big2's IndexRangeScan is big2's.
+	big2LookupAndAccess := func(rows [][]any) (lookup, access float64) {
+		lookup, access = -1, -1
+		lastLookup := -1.0
+		for _, row := range rows {
+			op := fmt.Sprint(row[0])
+			estRows, _ := strconv.ParseFloat(fmt.Sprint(row[1]), 64)
+			if strings.Contains(op, "IndexLookUp") {
+				lastLookup = estRows
+			}
+			if strings.Contains(op, "IndexRangeScan") && strings.Contains(fmt.Sprint(row[5]), "big2.jk") {
+				lookup, access = lastLookup, estRows
+			}
+		}
+		return lookup, access
+	}
+	impliedRatio := func(base, on, access float64) float64 {
+		if access <= base {
+			return 0
+		}
+		return (on - base) / (access - base)
+	}
+
+	// Query A: plain nested join. big2 is the index-join inner at probe level 1 (r_eff=0.01).
+	qA := "explain format=verbose select /*+ inl_join(big1), inl_join(big2) */ d.id " +
+		"from d join big1 on d.fk = big1.jk join big2 on big1.g = big2.jk " +
+		"where big1.f = 1 and big2.f = 1"
+	// Query B: EXISTS body is a join, kept correlated (NO_DECORRELATE) so it becomes an
+	// Apply whose probe is the index join. big2 is then the index-join inner UNDER the
+	// apply → probe level 2 (r_eff=sqrt(0.01)=0.1), i.e. the two-EXISTS-style nesting.
+	qB := "explain format=verbose select d.id from d where exists (" +
+		"select /*+ NO_DECORRELATE(), INL_JOIN(big2) */ 1 from big1 join big2 on big1.g = big2.jk " +
+		"where big1.jk = d.fk and big1.f = 1 and big2.f = 1)"
+
+	tk.MustExec("set @@session.tidb_opt_ordering_index_selectivity_ratio = 0")
+	baseA, accessA := big2LookupAndAccess(dump("A plain-join, ratio=0", qA))
+	baseB, accessB := big2LookupAndAccess(dump("B exists/apply, ratio=0", qB))
+	tk.MustExec("set @@session.tidb_opt_ordering_index_selectivity_ratio = 0.01")
+	onA, _ := big2LookupAndAccess(dump("A plain-join, ratio=0.01 (big2 @ level 1)", qA))
+	onB, _ := big2LookupAndAccess(dump("B exists/apply, ratio=0.01 (big2 @ level 2)", qB))
+
+	rA := impliedRatio(baseA, onA, accessA)
+	rB := impliedRatio(baseB, onB, accessB)
+	t.Logf("big2 inner-probe penalty (base ratio r=0.01):")
+	t.Logf("  level 1 (plain join):  lookup %.2f->%.2f  access=%.0f  implied r_eff=%.4f (expect 0.0100)", baseA, onA, accessA, rA)
+	t.Logf("  level 2 (under apply): lookup %.2f->%.2f  access=%.0f  implied r_eff=%.4f (expect 0.1000)", baseB, onB, accessB, rB)
+	require.InDelta(t, 0.01, rA, 1e-4, "level-1 effective ratio should equal the base ratio")
+	require.InDelta(t, 0.10, rB, 1e-3, "level-2 effective ratio should be sqrt(base) = exp-backoff muting")
+}

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -299,15 +299,19 @@ func constructIndexJoinStatic(
 	}
 	chReqProps := make([]*property.PhysicalProperty, 2)
 	chReqProps[outerIdx] = &property.PhysicalProperty{TaskTp: property.RootTaskType,
-		ExpectedCnt:       physicalop.CalcChildExpectedCnt(p.SCtx(), prop, outerStats.RowCount, p.StatsInfo().RowCount),
-		SortItems:         prop.SortItems,
-		CTEProducerStatus: prop.CTEProducerStatus,
-		NoCopPushDown:     prop.NoCopPushDown,
+		ExpectedCnt:          physicalop.CalcChildExpectedCnt(p.SCtx(), prop, outerStats.RowCount, p.StatsInfo().RowCount),
+		SortItems:            prop.SortItems,
+		CTEProducerStatus:    prop.CTEProducerStatus,
+		NoCopPushDown:        prop.NoCopPushDown,
+		CorrelatedProbeLevel: prop.CorrelatedProbeLevel,
 	}
 
 	// inner side should pass down the indexJoinProp, which contains the runtime constant inner key, which is used to build the underlying index/pk range.
+	// The inner side is a correlated nested-loop probe, so bump the probe level: a leaf
+	// scan under it mutes its find-first-row optimism according to this depth.
 	chReqProps[1-outerIdx] = &property.PhysicalProperty{TaskTp: property.RootTaskType, ExpectedCnt: math.MaxFloat64,
-		CTEProducerStatus: prop.CTEProducerStatus, IndexJoinProp: indexJoinProp, NoCopPushDown: prop.NoCopPushDown}
+		CTEProducerStatus: prop.CTEProducerStatus, IndexJoinProp: indexJoinProp, NoCopPushDown: prop.NoCopPushDown,
+		CorrelatedProbeLevel: prop.CorrelatedProbeLevel + 1}
 
 	// Some runtime details depend on the indexJoinInfo produced by the inner side,
 	// so we defer them to completePhysicalIndexJoin after the inner task is built.
@@ -701,9 +705,9 @@ func buildDataSource2IndexScanByIndexJoinProp(
 	rangeInfo, maxOneRow := indexJoinPathGetRangeInfoAndMaxOneRow(ds.SCtx(), prop.IndexJoinProp.OuterJoinKeys, indexJoinResult)
 	var innerTask base.Task
 	if !prop.IsSortItemEmpty() && matchProperty(ds, indexJoinResult.chosenPath, prop) == property.PropMatched {
-		innerTask = constructDS2IndexScanTask(ds, indexJoinResult.chosenPath, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.idxOff2KeyOff, rangeInfo, true, prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+		innerTask = constructDS2IndexScanTask(ds, indexJoinResult.chosenPath, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.idxOff2KeyOff, rangeInfo, true, prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow, prop.CorrelatedProbeLevel)
 	} else {
-		innerTask = constructDS2IndexScanTask(ds, indexJoinResult.chosenPath, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.idxOff2KeyOff, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+		innerTask = constructDS2IndexScanTask(ds, indexJoinResult.chosenPath, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.idxOff2KeyOff, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow, prop.CorrelatedProbeLevel)
 	}
 	// since there is a possibility that inner task can't be built and the returned value is nil, we just return base.InvalidTask.
 	if innerTask == nil {
@@ -751,9 +755,9 @@ func buildDataSource2TableScanByIndexJoinProp(
 		// construct the inner task with chosen path and ranges, note: it only for this leaf datasource.
 		// like the normal way, we need to check whether the chosen path is matched with the prop, if so, we will set the `keepOrder` to true.
 		if matchProperty(ds, indexJoinResult.chosenPath, prop) == property.PropMatched {
-			innerTask = constructDS2TableScanTask(ds, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.chosenAccess, rangeInfo, true, !prop.IsSortItemEmpty() && prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+			innerTask = constructDS2TableScanTask(ds, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.chosenAccess, rangeInfo, true, !prop.IsSortItemEmpty() && prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow, prop.CorrelatedProbeLevel)
 		} else {
-			innerTask = constructDS2TableScanTask(ds, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.chosenAccess, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+			innerTask = constructDS2TableScanTask(ds, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.chosenAccess, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow, prop.CorrelatedProbeLevel)
 		}
 		ranges = indexJoinResult.chosenRanges
 	} else {
@@ -772,9 +776,9 @@ func buildDataSource2TableScanByIndexJoinProp(
 		maxOneRow := true
 		rangeInfo := indexJoinIntPKRangeInfo(ds.SCtx().GetExprCtx().GetEvalCtx(), newOuterJoinKeys)
 		if !prop.IsSortItemEmpty() && matchProperty(ds, chosenPath, prop) == property.PropMatched {
-			innerTask = constructDS2TableScanTask(ds, localRanges, ds.PushedDownConds, nil, rangeInfo, true, prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+			innerTask = constructDS2TableScanTask(ds, localRanges, ds.PushedDownConds, nil, rangeInfo, true, prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow, prop.CorrelatedProbeLevel)
 		} else {
-			innerTask = constructDS2TableScanTask(ds, localRanges, ds.PushedDownConds, nil, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+			innerTask = constructDS2TableScanTask(ds, localRanges, ds.PushedDownConds, nil, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow, prop.CorrelatedProbeLevel)
 		}
 	}
 	// since there is a possibility that inner task can't be built and the returned value is nil, we just return base.InvalidTask.
@@ -820,6 +824,26 @@ func completeIndexJoinFeedBackInfo(innerTask *physicalop.CopTask, indexJoinResul
 	innerTask.IndexJoinInfo = info
 }
 
+// adjustInnerRowCountByProbeLevel inflates an index-join inner scan estimate to mute
+// find-first-row optimism according to how deep the scan sits in a correlated probe
+// hierarchy. The surplus (countAfterAccess - rowCount) is the range we may scan before
+// the first qualifying row; we add back a fraction of it given by the per-level
+// exponential-backoff ratio, so the optimism does not compound multiplicatively across
+// nested probes. A no-op when not under a correlated probe (probeLevel <= 0), when the
+// ratio is disabled, when there is no filtering surplus, or when there are no residual
+// filters outside the access range.
+func adjustInnerRowCountByProbeLevel(sctx base.PlanContext, rowCount, countAfterAccess float64, probeLevel int, hasFilters bool) float64 {
+	if probeLevel <= 0 || !hasFilters || countAfterAccess <= rowCount {
+		return rowCount
+	}
+	r := sctx.GetSessionVars().OptOrderingIdxSelRatio
+	if r <= 0 {
+		return rowCount
+	}
+	rEff := cardinality.OrderingRatioForProbeLevel(r, probeLevel)
+	return rowCount + (countAfterAccess-rowCount)*rEff
+}
+
 // constructDS2TableScanTask constructs the inner table scan task for index join.
 func constructDS2TableScanTask(
 	ds *logicalop.DataSource,
@@ -831,6 +855,7 @@ func constructDS2TableScanTask(
 	desc bool,
 	rowCount float64,
 	maxOneRow bool,
+	probeLevel int,
 ) base.Task {
 	// If `ds.TableInfo.GetPartitionInfo() != nil`,
 	// it means the data source is a partition table reader.
@@ -877,6 +902,10 @@ func constructDS2TableScanTask(
 	if maxOneRow {
 		finalRowCount = math.Min(1.0, countAfterAccess)
 	}
+	// PROTOTYPE: mute find-first-row optimism by correlated probe depth. The surplus
+	// between the access count and the (limit/unique) reduced estimate models rows we
+	// may scan before the first qualifying row; deeper probes trust that optimism less.
+	finalRowCount = adjustInnerRowCountByProbeLevel(ds.SCtx(), finalRowCount, countAfterAccess, probeLevel, len(ts.FilterCondition) > 0)
 	ts.SetStats(&property.StatsInfo{
 		RowCount:     finalRowCount,
 		StatsVersion: ds.StatsInfo().StatsVersion,
@@ -1028,6 +1057,7 @@ func constructDS2IndexScanTask(
 	desc bool,
 	rowCount float64,
 	maxOneRow bool,
+	probeLevel int,
 ) base.Task {
 	// If `ds.TableInfo.GetPartitionInfo() != nil`,
 	// it means the data source is a partition table reader.
@@ -1197,6 +1227,10 @@ func constructDS2IndexScanTask(
 	if usedStats != nil && usedStats.GetUsedInfo(is.PhysicalTableID) != nil {
 		is.UsedStatsInfo = usedStats.GetUsedInfo(is.PhysicalTableID)
 	}
+	// PROTOTYPE: mute find-first-row optimism by correlated probe depth. The surplus
+	// between the access count and the matching estimate models rows scanned before the
+	// first qualifying row; deeper probes trust that optimism less.
+	rowCount = adjustInnerRowCountByProbeLevel(ds.SCtx(), rowCount, tmpPath.CountAfterAccess, probeLevel, true)
 	finalStats := ds.TableStats.ScaleByExpectCnt(ds.SCtx().GetSessionVars(), rowCount)
 	cop.RootTaskConds = append(cop.RootTaskConds, rootTaskIndexConds...)
 	cop.RootTaskConds = append(cop.RootTaskConds, rootTaskTblConds...)
@@ -2307,8 +2341,10 @@ func exhaustPhysicalPlans4LogicalApply(super base.LogicalPlan, prop *property.Ph
 	}.Init(la.SCtx(),
 		la.StatsInfo().ScaleByExpectCnt(la.SCtx().GetSessionVars(), prop.ExpectedCnt),
 		la.QueryBlockOffset(),
-		&property.PhysicalProperty{ExpectedCnt: outerExpectedCnt, SortItems: prop.SortItems, CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: true},
-		&property.PhysicalProperty{ExpectedCnt: math.MaxFloat64, CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: prop.NoCopPushDown})
+		// Outer/build side keeps the ambient probe level; the inner/probe side is a
+		// correlated nested-loop probe, so bump the level for scans underneath it.
+		&property.PhysicalProperty{ExpectedCnt: outerExpectedCnt, SortItems: prop.SortItems, CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: true, CorrelatedProbeLevel: prop.CorrelatedProbeLevel},
+		&property.PhysicalProperty{ExpectedCnt: math.MaxFloat64, CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: prop.NoCopPushDown, CorrelatedProbeLevel: prop.CorrelatedProbeLevel + 1})
 	apply.SetSchema(la.Schema())
 	return []base.PhysicalPlan{apply}, true, nil
 }

--- a/pkg/planner/core/operator/physicalop/physical_limit.go
+++ b/pkg/planner/core/operator/physicalop/physical_limit.go
@@ -64,7 +64,8 @@ func ExhaustPhysicalPlans4LogicalLimit(p *logicalop.LogicalLimit, prop *property
 	ret := make([]base.PhysicalPlan, 0, len(allTaskTypes))
 	for _, tp := range allTaskTypes {
 		resultProp := &property.PhysicalProperty{TaskTp: tp, ExpectedCnt: float64(p.Count + p.Offset),
-			CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: prop.NoCopPushDown}
+			CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: prop.NoCopPushDown,
+			CorrelatedProbeLevel: prop.CorrelatedProbeLevel}
 		limit := PhysicalLimit{
 			Offset:      p.Offset,
 			Count:       p.Count,
@@ -205,7 +206,8 @@ func getPhysLimits(lt *logicalop.LogicalTopN, prop *property.PhysicalProperty) [
 	ret := make([]base.PhysicalPlan, 0, len(allTaskTypes))
 	for _, tp := range allTaskTypes {
 		resultProp := &property.PhysicalProperty{TaskTp: tp, ExpectedCnt: float64(lt.Count + lt.Offset), SortItems: p.SortItems,
-			CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: prop.NoCopPushDown}
+			CTEProducerStatus: prop.CTEProducerStatus, NoCopPushDown: prop.NoCopPushDown,
+			CorrelatedProbeLevel: prop.CorrelatedProbeLevel}
 		limit := PhysicalLimit{
 			Count:       lt.Count,
 			Offset:      lt.Offset,

--- a/pkg/planner/property/physical_property.go
+++ b/pkg/planner/property/physical_property.go
@@ -330,6 +330,16 @@ type PhysicalProperty struct {
 	// partial paths of IndexMerge.
 	// Currently only set when TopN is directly above a DataSource.
 	AdvisorySortItems []SortItem
+
+	// CorrelatedProbeLevel records how many correlated nested-loop probe boundaries
+	// (Apply probe sides and IndexJoin inner sides) enclose this required property.
+	// 0 means "not under any correlated probe" (the common, single-table case).
+	// It is incremented each time a required property is pushed into a correlated
+	// probe child, so a leaf scan can tell its depth in the probing hierarchy and
+	// mute the find-first-row optimism (OptOrderingIdxSelRatio) accordingly: the
+	// deeper the probe, the less we can trust that the first qualifying row is found
+	// early, because that optimism compounds multiplicatively across nesting levels.
+	CorrelatedProbeLevel int
 }
 
 // PartialOrderInfo records information needed for partial order optimization.
@@ -700,6 +710,11 @@ func (p *PhysicalProperty) HashCode() []byte {
 			p.hashcode = codec.EncodeInt(p.hashcode, 0)
 		}
 	}
+	// encode CorrelatedProbeLevel only when non-zero, so single-table properties
+	// keep their previous hashcode and existing plan testdata is unaffected.
+	if p.CorrelatedProbeLevel > 0 {
+		p.hashcode = codec.EncodeInt(p.hashcode, int64(p.CorrelatedProbeLevel))
+	}
 	return p.hashcode
 }
 
@@ -722,6 +737,7 @@ func (p *PhysicalProperty) CloneEssentialFields() *PhysicalProperty {
 		NoCopPushDown:         p.NoCopPushDown,
 		PartialOrderInfo:      p.PartialOrderInfo, // Copy PartialOrderInfo for TopN partial order optimization
 		AdvisorySortItems:     p.AdvisorySortItems,
+		CorrelatedProbeLevel:  p.CorrelatedProbeLevel, // preserve probe depth through pass-through operators
 		// we default not to clone basic indexJoinProp by default.
 		// and only call admitIndexJoinProp to inherit the indexJoinProp for special pattern operators.
 	}


### PR DESCRIPTION
Prototype for issue #69092 (correlated Apply beating MPP hash join due to underestimated nested-loop work). Mutes the find-first-row optimism ratio (tidb_opt_ordering_index_selectivity_ratio) by correlated-probe depth so it does not compound multiplicatively across nested EXISTS/Apply/IndexJoin levels.

- property: add CorrelatedProbeLevel to PhysicalProperty (hashcode-encoded only when >0 so single-table plans are unaffected; preserved in CloneEssentialFields).
- cardinality: OrderingRatioForProbeLevel(r, level) = r^(1/2^(level-1)), mirroring the existing ApplyExponentialBackoff weighting (level 1 -> r, level 2 -> sqrt(r), ... -> 1/full scan).
- exhaust_physical_plans: increment the probe level at the Apply and IndexJoin inner boundaries; wire the ratio into constructDS2Index/TableScanTask, where it was previously unreachable, via adjustInnerRowCountByProbeLevel.
- physical_limit: forward the probe level through Limit/TopN child props (the EXISTS implicit limit otherwise resets it).
- test: proto69092_test.go traces the per-level penalty (level 1 r_eff=0.01, level 2 r_eff=0.10) on an index-join inner probe under an Apply.

Prototype only: depth still leaks to 0 at other prop-synthesizing operators (Projection/Selection/Aggregation/Window), and the ratio remains orthogonal to the dominant CountAfterAccess fanout underestimate. Not PR-ready.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced cardinality estimation for correlated nested-loop queries with exponential backoff scheduling
  * Improved row count estimates for index-join operations based on probe nesting depth
  * More accurate query plans for complex correlated subqueries

* **Tests**
  * Added comprehensive tests validating exponential backoff behavior and nested probe optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->