### PR TITLE
ddl, parser: support IF EXISTS for dropping materialized views

### DIFF
--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -408,17 +408,25 @@ func (e *executor) DropMaterializedView(ctx sessionctx.Context, s *ast.DropMater
 		s.ViewName.Schema = schemaName
 	}
 	if _, ok := is.SchemaByName(schemaName); !ok {
+		if s.IfExists {
+			appendDropMaterializedViewNotExistsNote(ctx, schemaName, s.ViewName.Name)
+			return nil
+		}
 		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
 	}
 	tbl, err := is.TableByName(e.ctx, schemaName, s.ViewName.Name)
 	if err != nil {
+		if s.IfExists && infoschema.ErrTableNotExists.Equal(err) {
+			appendDropMaterializedViewNotExistsNote(ctx, schemaName, s.ViewName.Name)
+			return nil
+		}
 		return err
 	}
 	if tbl.Meta().MaterializedView == nil {
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName.O, s.ViewName.Name, "MATERIALIZED VIEW")
 	}
 
-	dropStmt := &ast.DropTableStmt{Tables: []*ast.TableName{{Schema: schemaName, Name: s.ViewName.Name}}}
+	dropStmt := &ast.DropTableStmt{IfExists: s.IfExists, Tables: []*ast.TableName{{Schema: schemaName, Name: s.ViewName.Name}}}
 	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, tableObject, true)
 }
 
@@ -447,6 +455,10 @@ func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMa
 	mlogName := model.MaterializedViewLogTableName(baseTable.Meta().Name)
 	mlogTable, err := is.TableByName(e.ctx, schemaName, mlogName)
 	if err != nil {
+		if s.IfExists && infoschema.ErrTableNotExists.Equal(err) {
+			appendDropMaterializedViewNotExistsNote(ctx, schemaName, mlogName)
+			return nil
+		}
 		return err
 	}
 	if mlogTable.Meta().MaterializedViewLog == nil || mlogTable.Meta().MaterializedViewLog.BaseTableID != baseTableID {
@@ -462,8 +474,14 @@ func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMa
 	// validation rejects stale executor pre-check under concurrent CREATE MATERIALIZED VIEW.
 	failpoint.Inject("pauseDropMaterializedViewLogAfterCheck", func() {})
 
-	dropStmt := &ast.DropTableStmt{Tables: []*ast.TableName{{Schema: schemaName, Name: mlogName}}}
+	dropStmt := &ast.DropTableStmt{IfExists: s.IfExists, Tables: []*ast.TableName{{Schema: schemaName, Name: mlogName}}}
 	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, tableObject, true)
+}
+
+func appendDropMaterializedViewNotExistsNote(ctx sessionctx.Context, schemaName, tableName pmodel.CIStr) {
+	ctx.GetSessionVars().StmtCtx.AppendNote(infoschema.ErrTableDropExists.FastGenByArgs(
+		ast.Ident{Schema: schemaName, Name: tableName}.String(),
+	))
 }
 
 func (e *executor) AlterMaterializedView(ctx sessionctx.Context, s *ast.AlterMaterializedViewStmt) error {

--- a/pkg/ddl/schematracker/BUILD.bazel
+++ b/pkg/ddl/schematracker/BUILD.bazel
@@ -49,7 +49,7 @@ go_test(
     ],
     embed = [":schematracker"],
     flaky = True,
-    shard_count = 18,
+    shard_count = 19,
     deps = [
         "//pkg/executor",
         "//pkg/infoschema",

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -77,6 +77,39 @@ func TestCreateMaterializedViewLogRejectsDuplicateColumns(t *testing.T) {
 	require.ErrorContains(t, err, "Duplicate column name")
 }
 
+func TestDropMaterializedViewIfExists(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop materialized view if exists missing_mv")
+	tk.MustExec("drop materialized view if exists missing_schema.missing_mv")
+
+	err := tk.ExecToErr("drop materialized view log if exists on missing_base")
+	require.ErrorContains(t, err, "Table 'test.missing_base' doesn't exist")
+	err = tk.ExecToErr("drop materialized view log if exists on missing_schema.missing_base")
+	require.ErrorContains(t, err, "Table 'missing_schema.missing_base' doesn't exist")
+
+	tk.MustExec("create table t_drop_if_exists (a int not null)")
+	tk.MustExec("create table t_no_mlog_drop_if_exists (a int not null)")
+	tk.MustExec("create materialized view log on t_drop_if_exists (a)")
+	tk.MustExec("create materialized view mv_drop_if_exists (a, cnt) as select a, count(1) from t_drop_if_exists group by a")
+
+	err = tk.ExecToErr("drop materialized view if exists t_drop_if_exists")
+	require.ErrorContains(t, err, "is not MATERIALIZED VIEW")
+
+	tk.MustExec("drop materialized view if exists mv_drop_if_exists")
+	tk.MustExec("drop materialized view if exists mv_drop_if_exists")
+
+	tk.MustExec("create view v_drop_if_exists as select * from t_drop_if_exists")
+	err = tk.ExecToErr("drop materialized view log if exists on v_drop_if_exists")
+	require.ErrorContains(t, err, "is not BASE TABLE")
+
+	tk.MustExec("drop materialized view log if exists on t_no_mlog_drop_if_exists")
+	tk.MustExec("drop materialized view log if exists on t_drop_if_exists")
+	tk.MustExec("drop materialized view log if exists on t_drop_if_exists")
+}
+
 func involvingSchemaInfoSet(involving []model.InvolvingSchemaInfo) map[string]struct{} {
 	got := make(map[string]struct{}, len(involving))
 	for _, info := range involving {

--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -2166,12 +2166,16 @@ func (n *AlterMaterializedViewLogStmt) Accept(v Visitor) (Node, bool) {
 type DropMaterializedViewStmt struct {
 	ddlNode
 
+	IfExists bool
 	ViewName *TableName
 }
 
 // Restore implements Node interface.
 func (n *DropMaterializedViewStmt) Restore(ctx *format.RestoreCtx) error {
 	ctx.WriteKeyWord("DROP MATERIALIZED VIEW ")
+	if n.IfExists {
+		ctx.WriteKeyWord("IF EXISTS ")
+	}
 	return n.ViewName.Restore(ctx)
 }
 
@@ -2196,12 +2200,17 @@ func (n *DropMaterializedViewStmt) Accept(v Visitor) (Node, bool) {
 type DropMaterializedViewLogStmt struct {
 	ddlNode
 
-	Table *TableName
+	IfExists bool
+	Table    *TableName
 }
 
 // Restore implements Node interface.
 func (n *DropMaterializedViewLogStmt) Restore(ctx *format.RestoreCtx) error {
-	ctx.WriteKeyWord("DROP MATERIALIZED VIEW LOG ON ")
+	ctx.WriteKeyWord("DROP MATERIALIZED VIEW LOG ")
+	if n.IfExists {
+		ctx.WriteKeyWord("IF EXISTS ")
+	}
+	ctx.WriteKeyWord("ON ")
 	return n.Table.Restore(ctx)
 }
 

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -5612,11 +5612,15 @@ DropMaterializedViewStmt:
 	{
 		$$ = &ast.DropMaterializedViewStmt{ViewName: $4.(*ast.TableName)}
 	}
+|	"DROP" "MATERIALIZED" "VIEW" "IF" "EXISTS" TableName
+	{
+		$$ = &ast.DropMaterializedViewStmt{IfExists: true, ViewName: $6.(*ast.TableName)}
+	}
 
 DropMaterializedViewLogStmt:
-	"DROP" "MATERIALIZED" "VIEW" "LOG" "ON" TableName
+	"DROP" "MATERIALIZED" "VIEW" "LOG" IfExists "ON" TableName
 	{
-		$$ = &ast.DropMaterializedViewLogStmt{Table: $6.(*ast.TableName)}
+		$$ = &ast.DropMaterializedViewLogStmt{IfExists: $5.(bool), Table: $7.(*ast.TableName)}
 	}
 
 PurgeMaterializedViewLogStmt:

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5501,9 +5501,19 @@ func TestMaterializedViewStatements(t *testing.T) {
 			"DROP MATERIALIZED VIEW `mv`",
 		},
 		{
+			"DROP MATERIALIZED VIEW IF EXISTS mv",
+			true,
+			"DROP MATERIALIZED VIEW IF EXISTS `mv`",
+		},
+		{
 			"DROP MATERIALIZED VIEW LOG ON t",
 			true,
 			"DROP MATERIALIZED VIEW LOG ON `t`",
+		},
+		{
+			"DROP MATERIALIZED VIEW LOG IF EXISTS ON t",
+			true,
+			"DROP MATERIALIZED VIEW LOG IF EXISTS ON `t`",
 		},
 		{
 			"PURGE MATERIALIZED VIEW LOG ON t",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66818

Problem Summary:

`DROP MATERIALIZED VIEW` and `DROP MATERIALIZED VIEW LOG` did not support `IF EXISTS`, so users could not write idempotent cleanup DDL for materialized views and materialized view logs.

### What changed and how does it work?

This PR adds parser, AST restore, and DDL execution support for:

- `DROP MATERIALIZED VIEW IF EXISTS <mv>`
- `DROP MATERIALIZED VIEW LOG IF EXISTS ON <base_table>`

The behavior is:

- `DROP MATERIALIZED VIEW IF EXISTS` ignores missing materialized views and appends a note, while still rejecting existing objects that are not materialized views.
- `DROP MATERIALIZED VIEW LOG IF EXISTS ON` ignores a missing mlog only when the base table exists, while still reporting an error if the base table itself does not exist or is not a base table.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Executed locally:

- `make parser`
- `go test -run '^TestMaterializedViewStatements$' -count=1` in `pkg/parser`
- `make parser_yacc`
- `git diff --check`
- `make bazel_lint_changed`
- `make bazel_prepare`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support `IF EXISTS` for `DROP MATERIALIZED VIEW` and `DROP MATERIALIZED VIEW LOG`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `IF EXISTS` support for `DROP MATERIALIZED VIEW`, enabling idempotent drops without errors when the view is missing.
  * Added `IF EXISTS` support for `DROP MATERIALIZED VIEW LOG` (including the `IF EXISTS` placement before `ON`).

* **Bug Fixes**
  * Improved error handling so missing schema/table cases are suppressed appropriately when `IF EXISTS` is used, and drop statements consistently propagate the option.

* **Tests**
  * Added new DDL executor coverage for `DROP MATERIALIZED VIEW/LOG IF EXISTS` plus expanded parser and statement test matrices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->