### PR TITLE
ddl: avoid the upgrade of column type from TEXT to MEDIUMTEXT in MLog internal table

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1130,8 +1130,7 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 		if err := CheckMaterializedViewLogColumnSupported(baseCol); err != nil {
 			return err
 		}
-		ft := baseCol.FieldType
-		ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
+		ft := FieldTypeForMaterializedViewLogColumn(baseCol)
 		colDefs = append(colDefs, &ast.ColumnDef{
 			Name: &ast.ColumnName{Name: c},
 			Tp:   &ft,
@@ -1237,6 +1236,21 @@ func (e *executor) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast.Crea
 		scatterScope = val
 	}
 	return errors.Trace(e.createTableWithInfoPost(ctx, mlogTableInfo, jobW.SchemaID, scatterScope))
+}
+
+// FieldTypeForMaterializedViewLogColumn returns the field type used to copy a
+// base table column into a materialized view log table.
+func FieldTypeForMaterializedViewLogColumn(baseCol *model.ColumnInfo) types.FieldType {
+	ft := *baseCol.FieldType.Clone()
+	ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
+	normalizeMaterializedViewLogBlobFlen(&ft)
+	return ft
+}
+
+func normalizeMaterializedViewLogBlobFlen(ft *types.FieldType) {
+	if ft.GetType() == mysql.TypeBlob && ft.GetFlen() == blobMaxLength {
+		ft.SetFlen(types.UnspecifiedLength)
+	}
 }
 
 // CheckMaterializedViewLogColumnSupported validates whether a base table column

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -703,8 +703,7 @@ func (e *executor) addMaterializedViewLogColumn(
 	baseCol *model.ColumnInfo,
 	afterCol pmodel.CIStr,
 ) error {
-	ft := *baseCol.FieldType.Clone()
-	ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
+	ft := FieldTypeForMaterializedViewLogColumn(baseCol)
 	spec := &ast.AlterTableSpec{
 		Tp: ast.AlterTableAddColumns,
 		NewColumns: []*ast.ColumnDef{{

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -290,8 +290,7 @@ func (d *SchemaTracker) CreateMaterializedViewLog(ctx sessionctx.Context, s *ast
 		if err := ddl.CheckMaterializedViewLogColumnSupported(baseCol); err != nil {
 			return err
 		}
-		ft := baseCol.FieldType
-		ft.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.MultipleKeyFlag | mysql.AutoIncrementFlag | mysql.OnUpdateNowFlag)
+		ft := ddl.FieldTypeForMaterializedViewLogColumn(baseCol)
 		colDefs = append(colDefs, &ast.ColumnDef{
 			Name: &ast.ColumnName{Name: c},
 			Tp:   &ft,

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -189,6 +189,21 @@ func TestCreateMaterializedViewLogRejectUnsupportedColumns(t *testing.T) {
 	tk.MustExec("create materialized view log on t_untracked_unsupported (id)")
 }
 
+func TestCreateMaterializedViewLogPreservesTextColumnTypes(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_text_types (id bigint not null primary key, c_tiny tinytext, c_text text, c_medium mediumtext, c_long longtext)")
+	tk.MustExec("create materialized view log on t_text_types (id, c_tiny, c_text, c_medium, c_long)")
+
+	showCreate := tk.MustQuery("show create table `$mlog$t_text_types`").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "  `c_tiny` tinytext DEFAULT NULL")
+	require.Contains(t, showCreate, "  `c_text` text DEFAULT NULL")
+	require.Contains(t, showCreate, "  `c_medium` mediumtext DEFAULT NULL")
+	require.Contains(t, showCreate, "  `c_long` longtext DEFAULT NULL")
+}
+
 // TestAlterMaterializedViewLogAddColumnBasic verifies that ADD COLUMN updates
 // mlog metadata, backfills old log rows with mlog defaults, and records future
 // changes only when newly tracked columns are touched.
@@ -229,6 +244,7 @@ func TestAlterMaterializedViewLogAddColumnBasic(t *testing.T) {
 	require.Equal(t, " ", fmt.Sprint(colByName["s"].GetOriginDefaultValue()))
 	require.Equal(t, "0000-00-00", fmt.Sprint(colByName["d"].GetOriginDefaultValue()))
 	require.Equal(t, " ", fmt.Sprint(colByName["note"].GetOriginDefaultValue()))
+	require.Equal(t, mysql.TypeBlob, colByName["note"].GetType())
 
 	tk.MustQuery("select n, hex(s), cast(d as char), hex(note), `_MLOG$_DML_TYPE`, `_MLOG$_OLD_NEW` from `$mlog$t_add_mlog_col`").
 		Check(testkit.Rows("0 20 0000-00-00 20 I 1"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66754

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that MLog internal table upgrades TEXT column to MEDIUMTEXT
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved materialized view log table schema generation to preserve base table column types more accurately, including correct handling for text types and edge-case `BLOB` sizing, and ensuring appropriate `DEFAULT NULL` declarations.

* **Tests**
  * Added coverage to verify `tinytext/text/mediumtext/longtext` columns are retained in the materialized view log schema.
  * Extended existing tests to confirm newly added tracked columns produce the expected `BLOB` type in the log table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->