### PR TITLE
test: stabilize flaky TestMainBackupLoop

### DIFF
--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -493,6 +493,9 @@ func TestMainBackupLoop(t *testing.T) {
 		res = append(res, ranges[len(ranges)-1].EndKey)
 		return res
 	}
+	storeIDForSplit := func(i int) uint64 {
+		return stores[i%len(stores)].GetId()
+	}
 
 	// Case #1: normal case
 	ranges := []rtree.KeyRange{
@@ -507,9 +510,9 @@ func TestMainBackupLoop(t *testing.T) {
 	mockBackupResponses := make(map[uint64][]*backup.ResponseAndStore)
 	splitKeys := splitRangesFn(ranges, 10)
 	for i := range len(splitKeys) - 1 {
-		randStoreID := uint64(rand.Int()%len(stores) + 1)
-		mockBackupResponses[randStoreID] = append(mockBackupResponses[randStoreID], &backup.ResponseAndStore{
-			StoreID: randStoreID,
+		storeID := storeIDForSplit(i)
+		mockBackupResponses[storeID] = append(mockBackupResponses[storeID], &backup.ResponseAndStore{
+			StoreID: storeID,
 			Resp: &backuppb.BackupResponse{
 				StartKey: splitKeys[i],
 				EndKey:   splitKeys[i+1],
@@ -549,9 +552,9 @@ func TestMainBackupLoop(t *testing.T) {
 	splitKeys = splitRangesFn(ranges, 10)
 	// range is not complete
 	for i := range len(splitKeys) - 2 {
-		randStoreID := uint64(rand.Int()%len(stores) + 1)
-		mockBackupResponses[randStoreID] = append(mockBackupResponses[randStoreID], &backup.ResponseAndStore{
-			StoreID: randStoreID,
+		storeID := storeIDForSplit(i)
+		mockBackupResponses[storeID] = append(mockBackupResponses[storeID], &backup.ResponseAndStore{
+			StoreID: storeID,
 			Resp: &backuppb.BackupResponse{
 				StartKey: splitKeys[i],
 				EndKey:   splitKeys[i+1],
@@ -593,9 +596,9 @@ func TestMainBackupLoop(t *testing.T) {
 	clear(mockBackupResponses)
 	splitKeys = splitRangesFn(ranges, 10)
 	for i := range len(splitKeys) - 1 {
-		randStoreID := uint64(rand.Int()%len(stores) + 1)
-		mockBackupResponses[randStoreID] = append(mockBackupResponses[randStoreID], &backup.ResponseAndStore{
-			StoreID: randStoreID,
+		storeID := storeIDForSplit(i)
+		mockBackupResponses[storeID] = append(mockBackupResponses[storeID], &backup.ResponseAndStore{
+			StoreID: storeID,
 			Resp: &backuppb.BackupResponse{
 				StartKey: splitKeys[i],
 				EndKey:   splitKeys[i+1],
@@ -652,9 +655,9 @@ func TestMainBackupLoop(t *testing.T) {
 	clear(mockBackupResponses)
 	splitKeys = splitRangesFn(ranges, 10)
 	for i := range len(splitKeys) - 1 {
-		randStoreID := uint64(rand.Int()%len(stores) + 1)
-		mockBackupResponses[randStoreID] = append(mockBackupResponses[randStoreID], &backup.ResponseAndStore{
-			StoreID: randStoreID,
+		storeID := storeIDForSplit(i)
+		mockBackupResponses[storeID] = append(mockBackupResponses[storeID], &backup.ResponseAndStore{
+			StoreID: storeID,
 			Resp: &backuppb.BackupResponse{
 				StartKey: splitKeys[i],
 				EndKey:   splitKeys[i+1],
@@ -705,9 +708,9 @@ func TestMainBackupLoop(t *testing.T) {
 	clear(mockBackupResponses)
 	splitKeys = splitRangesFn(ranges, 10)
 	for i := range len(splitKeys) - 1 {
-		randStoreID := uint64(rand.Int()%len(stores) + 1)
-		mockBackupResponses[randStoreID] = append(mockBackupResponses[randStoreID], &backup.ResponseAndStore{
-			StoreID: randStoreID,
+		storeID := storeIDForSplit(i)
+		mockBackupResponses[storeID] = append(mockBackupResponses[storeID], &backup.ResponseAndStore{
+			StoreID: storeID,
 			Resp: &backuppb.BackupResponse{
 				StartKey: splitKeys[i],
 				EndKey:   splitKeys[i+1],


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68203

Problem Summary:
Flaky test `TestMainBackupLoop` in `br/pkg/backup` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Random mock response assignment could leave a live store with no responses, causing the mock sender and RunLoop to wait until timeout.

#### Fix

Deterministic round-robin assignment keeps both mock stores participating in every subcase and removes the invalid empty-live-store setup.

#### Verification

Spec:
- target: `br/pkg/backup :: TestMainBackupLoop`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
build passed.

Gate checklist:
- target_flaky: PASS
- package_raw: SKIPPED
- package_failpoint: SKIPPED
- build: PASS

Commands:
- `go test -json -tags=intest,deadlock ./br/pkg/backup -run '^TestMainBackupLoop$' -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability by using deterministic round-robin mapping for backup responses instead of random selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->