### PR TITLE
objstore: use V4 signing for GCS PresignFile

### DIFF
--- a/pkg/objstore/BUILD.bazel
+++ b/pkg/objstore/BUILD.bazel
@@ -86,7 +86,7 @@ go_test(
     ],
     embed = [":objstore"],
     flaky = True,
-    shard_count = 46,
+    shard_count = 47,
     deps = [
         "//pkg/objstore/compressedio",
         "//pkg/objstore/objectio",

--- a/pkg/objstore/gcs.go
+++ b/pkg/objstore/gcs.go
@@ -410,8 +410,13 @@ func (s *GCSStorage) Rename(ctx context.Context, oldFileName, newFileName string
 // PresignFile implements storeapi.Storage interface.
 func (s *GCSStorage) PresignFile(ctx context.Context, fileName string, expire time.Duration) (string, error) {
 	object := s.objectName(fileName)
+	// Use V4 signing explicitly. The default (V2) can only sign with an in-process
+	// RSA private key, so it fails under ADC/workload-identity where signing must go
+	// through the IAM SignBlob API. V4 supports that flow. V4 caps expiry at 7 days,
+	// which is well above the current callers' needs.
 	opts := &storage.SignedURLOptions{
 		Method:  "GET",
+		Scheme:  storage.SigningSchemeV4,
 		Expires: time.Now().Add(expire),
 	}
 	url, err := s.GetBucketHandle().SignedURL(object, opts)

--- a/pkg/objstore/gcs_test.go
+++ b/pkg/objstore/gcs_test.go
@@ -18,6 +18,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	goerrors "errors"
 	"flag"
 	"fmt"
@@ -73,6 +76,45 @@ func prepareGCSStore(t *testing.T, bucketName string, accessRec *recording.Acces
 	})
 	require.NoError(t, err)
 	return server, stg
+}
+
+// TestGCSPresignFileUsesV4Signing is a regression test for PresignFile: it must
+// use V4 signing. The default (V2) scheme can only sign with an in-process RSA
+// private key, so it fails under ADC/workload-identity where signing must go
+// through the IAM SignBlob API. Only V4 supports that flow. The presence of the
+// V4 algorithm marker in the generated URL pins the scheme down.
+func TestGCSPresignFileUsesV4Signing(t *testing.T) {
+	require.True(t, intest.InTest)
+	ctx := context.Background()
+
+	bucketName := "presign-bucket"
+	server, err := fakestorage.NewServerWithOptions(fakestorage.Options{NoListener: true})
+	require.NoError(t, err)
+	server.CreateBucketWithOpts(fakestorage.CreateBucketOpts{Name: bucketName})
+
+	// SignedURL signs locally with a private key, so feed a minimal service
+	// account credential carrying a freshly generated RSA key. This keeps the
+	// test offline and independent of any real Google credentials.
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	saJSON := fmt.Sprintf(`{"type":"service_account","client_email":"signer@example.iam.gserviceaccount.com","private_key":%q,"token_uri":"https://oauth2.googleapis.com/token"}`, string(keyPEM))
+
+	gcs := &backuppb.GCS{
+		Bucket:          bucketName,
+		Prefix:          "a/b/",
+		CredentialsBlob: saJSON,
+	}
+	stg, err := NewGCSStorage(ctx, gcs, &storeapi.Options{
+		HTTPClient: server.HTTPClient(),
+	})
+	require.NoError(t, err)
+
+	signed, err := stg.PresignFile(ctx, "file.txt", time.Hour)
+	require.NoError(t, err)
+	require.Contains(t, signed, "X-Goog-Algorithm=GOOG4-RSA-SHA256")
 }
 
 func TestGCS(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69377

Problem Summary:

`GCSStorage.PresignFile` builds `storage.SignedURLOptions` without a `Scheme`, so it defaults to V2. V2 signing can only sign with an in-process RSA private key, so under ADC / GKE workload-identity (where signing must go through the IAM `SignBlob` API) `SignedURL` fails. In the plan-replayer path the error is swallowed as a warning and the presigned URL is silently dropped, so share links never get generated on those deployments.

### What changed and how does it work?

- Set `Scheme: storage.SigningSchemeV4` in `PresignFile`'s `SignedURLOptions`. V4 supports both local-private-key and IAM `SignBlob` signing, and is Google's recommended scheme. V4 caps expiry at 7 days, well above current callers' needs (plan replayer uses 1h).
- Added a regression test (`TestGCSPresignFileUsesV4Signing`) that feeds a freshly generated service-account RSA key so signing happens locally/offline, then asserts the generated URL carries the V4 marker `X-Goog-Algorithm=GOOG4-RSA-SHA256`. The test fails on the old V2 default and passes with V4.

### Check List

Tests

- [x] Unit test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix GCS presigned URL generation failing under Application Default Credentials / GKE workload identity by using V4 signing.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GCS presigned URLs now explicitly use V4 signing scheme to ensure consistent security compliance.

* **Tests**
  * Added regression test to verify presigned URL V4 signing implementation.

* **Chores**
  * Updated build test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->