### PR TITLE
store/copr: handle bucket version in store-batched cop

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -6556,13 +6556,13 @@ def go_deps():
         name = "com_github_pingcap_kvproto",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/pingcap/kvproto",
-        sha256 = "6992a6d98b88990b8e76ac58e62ff4a2df51ad32d71ff2a101818e75d4214b28",
-        strip_prefix = "github.com/pingcap/kvproto@v0.0.0-20260513130714-a164c29a1dce",
+        sha256 = "7249b3e829fe37da0689eda8cc00aa84f945b0bcf69d9b5fccb737ffd4b4dbc9",
+        strip_prefix = "github.com/pingcap/kvproto@v0.0.0-20260623054715-67de11ba82ef",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260513130714-a164c29a1dce.zip",
-            "http://ats.apps.svc/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260513130714-a164c29a1dce.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260513130714-a164c29a1dce.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260513130714-a164c29a1dce.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260623054715-67de11ba82ef.zip",
+            "http://ats.apps.svc/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260623054715-67de11ba82ef.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260623054715-67de11ba82ef.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260623054715-67de11ba82ef.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20260508054701-306e305bcf41
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/fn v1.0.0
-	github.com/pingcap/kvproto v0.0.0-20260513130714-a164c29a1dce
+	github.com/pingcap/kvproto v0.0.0-20260623054715-67de11ba82ef
 	github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9
 	github.com/pingcap/metering_sdk v0.0.0-20251110022152-dac449ac5389
 	github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5
@@ -193,6 +193,7 @@ require (
 	github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/goccy/go-reflect v1.2.0 // indirect
 	github.com/google/flatbuffers v2.0.8+incompatible // indirect
 	github.com/google/go-cmp v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -356,6 +356,7 @@ github.com/fsouza/fake-gcs-server v1.44.0/go.mod h1:M02aKoTv9Tnlf+gmWnTok1PWVCUH
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
 github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
@@ -782,6 +783,8 @@ github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17Xtb
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/kvproto v0.0.0-20260513130714-a164c29a1dce h1:OWuxbPLOH68b4KnTGrhKJi4MGIkfYFF0Y1j15ptGMKQ=
 github.com/pingcap/kvproto v0.0.0-20260513130714-a164c29a1dce/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260623054715-67de11ba82ef h1:JY2aHpU2uZVBrbdoROvQlakXnySWw4pLlqEdgVIk1xg=
+github.com/pingcap/kvproto v0.0.0-20260623054715-67de11ba82ef/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGamuWedx9LRm0nrHvsQRQiW8SxEs=

--- a/pkg/store/copr/BUILD.bazel
+++ b/pkg/store/copr/BUILD.bazel
@@ -92,7 +92,7 @@ go_test(
     embed = [":copr"],
     flaky = True,
     race = "on",
-    shard_count = 40,
+    shard_count = 42,
     deps = [
         "//pkg/kv",
         "//pkg/store/driver/backoff",
@@ -104,6 +104,7 @@ go_test(
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/coprocessor",
+        "@com_github_pingcap_kvproto//pkg/errorpb",
         "@com_github_pingcap_kvproto//pkg/metapb",
         "@com_github_pingcap_kvproto//pkg/mpp",
         "@com_github_stathat_consistent//:consistent",

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -332,11 +332,12 @@ func (r *copTask) ToPBBatchTasks() []*coprocessor.StoreBatchTask {
 	pbTasks := make([]*coprocessor.StoreBatchTask, 0, len(r.batchTaskList))
 	for _, task := range r.batchTaskList {
 		storeBatchTask := &coprocessor.StoreBatchTask{
-			RegionId:    task.region.GetRegionId(),
-			RegionEpoch: task.region.GetRegionEpoch(),
-			Peer:        task.peer,
-			Ranges:      task.region.GetRanges(),
-			TaskId:      task.task.taskID,
+			RegionId:       task.region.GetRegionId(),
+			RegionEpoch:    task.region.GetRegionEpoch(),
+			Peer:           task.peer,
+			Ranges:         task.region.GetRanges(),
+			TaskId:         task.task.taskID,
+			BucketsVersion: task.task.bucketsVer,
 		}
 		pbTasks = append(pbTasks, storeBatchTask)
 	}
@@ -2253,6 +2254,7 @@ func (worker *copIteratorWorker) handleBatchCopResponse(bo *Backoffer, rpcCtx *t
 			batchResp.RegionError = &errorpb.Error{}
 		})
 		if regionErr := getRegionError(bo.GetCtx(), batchResp); regionErr != nil {
+			worker.handleBatchBucketVersionNotMatch(bo, task, regionErr)
 			errStr := fmt.Sprintf("region_id:%v, region_ver:%v, store_type:%s, peer_addr:%s, error:%s",
 				task.region.GetID(), task.region.GetVer(), task.storeType.Name(), task.storeAddr, regionErr.String())
 			if err := bo.Backoff(tikv.BoRegionMiss(), errors.New(errStr)); err != nil {
@@ -2350,6 +2352,19 @@ func (worker *copIteratorWorker) handleBatchCopResponse(bo *Backoffer, rpcCtx *t
 		remainTasks = handler.build()
 	}
 	return batchRespList, remainTasks, nil
+}
+
+func (worker *copIteratorWorker) handleBatchBucketVersionNotMatch(bo *Backoffer, task *copTask, regionErr *errorpb.Error) {
+	bucketVersionNotMatch := regionErr.GetBucketVersionNotMatch()
+	if bucketVersionNotMatch == nil {
+		return
+	}
+	logutil.Logger(bo.GetCtx()).Debug("tikv reports `BucketVersionNotMatch` for batched cop task",
+		zap.Uint64("latest bucket version", bucketVersionNotMatch.GetVersion()),
+		zap.Uint64("request bucket version", task.bucketsVer),
+		zap.Uint64("regionID", task.region.GetID()))
+	childRPCCtx := &tikv.RPCContext{Region: task.region}
+	worker.store.GetRegionCache().OnBucketVersionNotMatch(childRPCCtx, bucketVersionNotMatch.GetVersion(), bucketVersionNotMatch.GetKeys())
 }
 
 func (worker *copIteratorWorker) handleLockErr(bo *Backoffer, lockErr *kvrpcpb.LockInfo, task *copTask) error {

--- a/pkg/store/copr/coprocessor_test.go
+++ b/pkg/store/copr/coprocessor_test.go
@@ -16,10 +16,12 @@ package copr
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/pingcap/kvproto/pkg/coprocessor"
+	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/store/driver/backoff"
 	"github.com/pingcap/tidb/pkg/util/paging"
@@ -986,4 +988,123 @@ func TestBatchStoreCoprOnlySendToLeader(t *testing.T) {
 	for _, task := range tasks {
 		require.Equal(t, task.busyThreshold, time.Second)
 	}
+}
+
+func TestStoreBatchTasksPreserveChildBucketsVersion(t *testing.T) {
+	mockClient, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
+	require.NoError(t, err)
+	defer func() {
+		pdClient.Close()
+		err = mockClient.Close()
+		require.NoError(t, err)
+	}()
+
+	_, regionIDs, _ := testutils.BootstrapWithMultiRegions(cluster, []byte("n"), []byte("x"))
+	cluster.SplitRegionBuckets(regionIDs[0], [][]byte{{}, {'n'}}, 101)
+	cluster.SplitRegionBuckets(regionIDs[1], [][]byte{{'n'}, {'x'}}, 202)
+	cluster.SplitRegionBuckets(regionIDs[2], [][]byte{{'x'}, {}}, 303)
+	pdCli := tikv.NewCodecPDClient(tikv.ModeTxn, pdClient)
+	defer pdCli.Close()
+
+	cache := NewRegionCache(tikv.NewRegionCache(pdCli))
+	defer cache.Close()
+	bo := backoff.NewBackofferWithVars(context.Background(), 3000, nil)
+
+	req := &kv.Request{StoreBatchSize: 3}
+	tasks, err := buildCopTasks(bo, buildCopRanges("a", "b", "o", "p", "y", "z"), &buildCopTaskOpt{
+		req:      req,
+		cache:    cache,
+		rowHints: []int{1, 1, 1},
+	})
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+
+	pbTasks := tasks[0].ToPBBatchTasks()
+	require.Len(t, pbTasks, 2)
+	versionByRegion := make(map[uint64]uint64, len(pbTasks))
+	for _, pbTask := range pbTasks {
+		versionByRegion[pbTask.GetRegionId()] = pbTask.GetBucketsVersion()
+	}
+	require.Equal(t, map[uint64]uint64{
+		regionIDs[1]: 202,
+		regionIDs[2]: 303,
+	}, versionByRegion)
+}
+
+func TestHandleBatchCopResponseUpdatesChildBucketsOnVersionNotMatch(t *testing.T) {
+	mockClient, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
+	require.NoError(t, err)
+	_, regionIDs, _ := testutils.BootstrapWithMultiRegions(cluster, []byte("m"))
+	cluster.SplitRegionBuckets(regionIDs[0], [][]byte{{}, {'m'}}, 7)
+	cluster.SplitRegionBuckets(regionIDs[1], [][]byte{{'m'}, {'n'}, {}}, 11)
+
+	tikvStore, err := tikv.NewTestTiKVStore(mockClient, pdClient, nil, nil, 0)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tikvStore.Close())
+	}()
+	copStore, err := NewStore(tikvStore, nil)
+	require.NoError(t, err)
+	defer copStore.Close()
+
+	cache := copStore.GetRegionCache()
+	bo := backoff.NewBackofferWithVars(context.Background(), 3000, nil)
+	req := &kv.Request{}
+
+	parentTasks, err := buildCopTasks(bo, buildCopRanges("a", "b"), &buildCopTaskOpt{
+		req:   req,
+		cache: cache,
+	})
+	require.NoError(t, err)
+	require.Len(t, parentTasks, 1)
+	childTasks, err := buildCopTasks(bo, buildCopRanges("n", "o"), &buildCopTaskOpt{
+		req:   req,
+		cache: cache,
+	})
+	require.NoError(t, err)
+	require.Len(t, childTasks, 1)
+	parentTask := parentTasks[0]
+	childTask := childTasks[0]
+	require.Equal(t, uint64(7), parentTask.bucketsVer)
+	require.Equal(t, uint64(11), childTask.bucketsVer)
+
+	childTask.taskID = 1
+	var storeBatchedNum atomic.Uint64
+	var storeBatchedFallbackNum atomic.Uint64
+	worker := &copIteratorWorker{
+		store:                   copStore,
+		req:                     req,
+		storeBatchedNum:         &storeBatchedNum,
+		storeBatchedFallbackNum: &storeBatchedFallbackNum,
+	}
+	parentRPCCtx := &tikv.RPCContext{
+		Region:        parentTask.region,
+		BucketVersion: parentTask.bucketsVer,
+	}
+	bucketKeys := [][]byte{[]byte("m"), []byte("n"), []byte{}}
+	resp := &coprocessor.Response{
+		BatchResponses: []*coprocessor.StoreBatchTaskResponse{
+			{
+				TaskId: childTask.taskID,
+				RegionError: &errorpb.Error{
+					BucketVersionNotMatch: &errorpb.BucketVersionNotMatch{
+						Version: 99,
+						Keys:    bucketKeys,
+					},
+				},
+			},
+		},
+	}
+
+	_, remains, err := worker.handleBatchCopResponse(bo, parentRPCCtx, resp, map[uint64]*batchedCopTask{
+		childTask.taskID: {task: childTask},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, remains)
+
+	loc, err := cache.LocateKey(bo.TiKVBackoffer(), []byte("n"))
+	require.NoError(t, err)
+	require.Equal(t, regionIDs[1], loc.Region.GetID())
+	require.Equal(t, uint64(99), loc.Buckets.GetVersion())
+	require.Equal(t, bucketKeys, loc.Buckets.GetKeys())
 }

--- a/pkg/store/copr/coprocessor_test.go
+++ b/pkg/store/copr/coprocessor_test.go
@@ -1081,7 +1081,7 @@ func TestHandleBatchCopResponseUpdatesChildBucketsOnVersionNotMatch(t *testing.T
 		Region:        parentTask.region,
 		BucketVersion: parentTask.bucketsVer,
 	}
-	bucketKeys := [][]byte{[]byte("m"), []byte("n"), []byte{}}
+	bucketKeys := [][]byte{[]byte("m"), []byte("n"), {}}
 	resp := &coprocessor.Response{
 		BatchResponses: []*coprocessor.StoreBatchTaskResponse{
 			{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68715

Problem Summary:

This backports #69085 to `release-nextgen-20251011`. The matching CSE/cloud-storage-engine side is tidbcloud/cloud-storage-engine#5240 on `cloud-engine` and tidbcloud/cloud-storage-engine#5347 on `release-nextgen-202603`.

Store-batched coprocessor groups child tasks by store, but the child tasks can belong to different regions. Before this change, each `StoreBatchTask` did not carry its own bucket version, and TiDB did not refresh region-cache bucket metadata when a batched child returned `BucketVersionNotMatch`.

This branch already has the corresponding kvproto change merged in pingcap/kvproto#1488, so this PR bumps `github.com/pingcap/kvproto` to `v0.0.0-20260623054715-67de11ba82ef`.

### What changed and how does it work?

- Set `StoreBatchTask.BucketsVersion` from each child `copTask.bucketsVer`.
- When a batched child response contains `BucketVersionNotMatch`, update the corresponding child region bucket metadata through `RegionCache.OnBucketVersionNotMatch` before rebuilding retry tasks.
- Add regression coverage for both per-child batch task serialization and bucket cache refresh from child region errors.
- Bump `github.com/pingcap/kvproto` to include pingcap/kvproto#1488.
- This is the TiDB-side pick; the full store-batched bucket-version fix also requires the matching CSE-side request-building change.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```sh
PATH=/usr/local/go/bin:$PATH GOWORK=off GOPROXY=https://proxy.golang.org,direct make bazel_prepare
PATH=/usr/local/go/bin:$PATH GOWORK=off GOPROXY=https://proxy.golang.org,direct make failpoint-enable && PATH=/usr/local/go/bin:$PATH GOWORK=off GOPROXY=https://proxy.golang.org,direct go test ./pkg/store/copr -run 'Test(StoreBatchTasksPreserveChildBucketsVersion|HandleBatchCopResponseUpdatesChildBucketsOnVersionNotMatch)$' -count=1; code=$?; PATH=/usr/local/go/bin:$PATH GOWORK=off make failpoint-disable; exit $code
PATH=/usr/local/go/bin:$PATH GOWORK=off GOPROXY=https://proxy.golang.org,direct make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix store-batched coprocessor requests using stale or wrong bucket versions for child tasks.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of bucket version mismatches for batched coprocessor responses, including better debug logging and updating bucket metadata so region cache behavior stays consistent during retries.

* **Tests**
  * Added coverage to ensure batched task conversions preserve child bucket versions.
  * Added coverage for updating child bucket metadata when a version mismatch error is returned in batch responses.

* **Chores**
  * Updated the kvproto dependency and related pinned artifacts.
  * Tweaked the COPR test configuration (shard count and dependencies).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
