### PR TITLE
executor: guard recordSet after result set finish

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -187,7 +187,14 @@ func (a *recordSet) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 	}
 	ctx = inheritStmtRUV2Context(ctx, a.stmt)
 
-	err = a.stmt.next(ctx, a.executor, req)
+	e := a.executor
+	if e == nil {
+		err = exeerrors.ErrQueryInterrupted.GenWithStackByArgs()
+		a.lastErrs = append(a.lastErrs, err)
+		return err
+	}
+
+	err = a.stmt.next(ctx, e, req)
 	if err != nil {
 		a.lastErrs = append(a.lastErrs, err)
 		return err
@@ -212,19 +219,49 @@ func inheritStmtRUV2Context(ctx context.Context, stmt *ExecStmt) context.Context
 	return execdetails.ContextWithInheritedRUV2Details(ctx, stmt.GoCtx)
 }
 
-// NewChunk create a chunk base on top-level executor's exec.NewFirstChunk().
+func (a *recordSet) chunkConfig() ([]*types.FieldType, int, int) {
+	if a.executor != nil {
+		return a.executor.RetFieldTypes(), a.executor.InitCap(), a.executor.MaxChunkSize()
+	}
+	var fields []*types.FieldType
+	if a.schema != nil {
+		fields = make([]*types.FieldType, 0, a.schema.Len())
+		for _, col := range a.schema.Columns {
+			fields = append(fields, col.RetType)
+		}
+	}
+	if a.stmt == nil || a.stmt.Ctx == nil {
+		return fields, vardef.DefInitChunkSize, vardef.DefMaxChunkSize
+	}
+	sessVars := a.stmt.Ctx.GetSessionVars()
+	return fields, sessVars.InitChunkSize, sessVars.MaxChunkSize
+}
+
+// NewChunk creates a chunk based on the top-level executor's result schema.
 func (a *recordSet) NewChunk(alloc chunk.Allocator) *chunk.Chunk {
-	if alloc == nil {
-		return exec.NewFirstChunk(a.executor)
+	e := a.executor
+	if e == nil {
+		fields, initCap, maxChunkSize := a.chunkConfig()
+		if alloc == nil {
+			return chunk.New(fields, initCap, maxChunkSize)
+		}
+		return alloc.Alloc(fields, initCap, maxChunkSize)
 	}
 
-	return alloc.Alloc(a.executor.RetFieldTypes(), a.executor.InitCap(), a.executor.MaxChunkSize())
+	if alloc == nil {
+		return exec.NewFirstChunk(e)
+	}
+
+	return alloc.Alloc(e.RetFieldTypes(), e.InitCap(), e.MaxChunkSize())
 }
 
 func (a *recordSet) Finish() error {
 	var err error
 	a.once.Do(func() {
-		err = exec.Close(a.executor)
+		if a.executor != nil {
+			err = exec.Close(a.executor)
+			a.executor = nil
+		}
 		cteErr := resetCTEStorageMap(a.stmt.Ctx)
 		if cteErr != nil {
 			logutil.BgLogger().Error("got error when reset cte storage, should check if the spill disk file deleted or not", zap.Error(cteErr))
@@ -232,7 +269,6 @@ func (a *recordSet) Finish() error {
 		if err == nil {
 			err = cteErr
 		}
-		a.executor = nil
 		if a.stmt != nil {
 			status := a.stmt.Ctx.GetSessionVars().SQLKiller.GetKillSignal()
 			inWriteResultSet := a.stmt.Ctx.GetSessionVars().SQLKiller.InWriteResultSet.Load()

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -219,11 +219,10 @@ func inheritStmtRUV2Context(ctx context.Context, stmt *ExecStmt) context.Context
 	return execdetails.ContextWithInheritedRUV2Details(ctx, stmt.GoCtx)
 }
 
-func (a *recordSet) chunkConfig() ([]*types.FieldType, int, int) {
+func (a *recordSet) chunkConfig() (fields []*types.FieldType, initCap int, maxChunkSize int) {
 	if a.executor != nil {
 		return a.executor.RetFieldTypes(), a.executor.InitCap(), a.executor.MaxChunkSize()
 	}
-	var fields []*types.FieldType
 	if a.schema != nil {
 		fields = make([]*types.FieldType, 0, a.schema.Len())
 		for _, col := range a.schema.Columns {

--- a/pkg/executor/adapter_internal_test.go
+++ b/pkg/executor/adapter_internal_test.go
@@ -24,9 +24,14 @@ import (
 	"github.com/pingcap/kvproto/pkg/meta_storagepb"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/auth"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/pingcap/tidb/pkg/util/topsql"
@@ -115,6 +120,34 @@ func newExecStmtWithStmtStatsForTest(goCtx context.Context, t *testing.T) (*Exec
 		},
 		GoCtx: goCtx,
 	}, stats
+}
+
+func newFinishedRecordSetForTest() *recordSet {
+	ft := types.NewFieldType(mysql.TypeLonglong)
+	return &recordSet{
+		schema: expression.NewSchema(&expression.Column{RetType: ft}),
+		stmt:   &ExecStmt{Ctx: mock.NewContext()},
+	}
+}
+
+func TestRecordSetNewChunkAfterFinish(t *testing.T) {
+	rs := newFinishedRecordSetForTest()
+
+	req := rs.NewChunk(nil)
+	require.NotNil(t, req)
+	require.Equal(t, 1, req.NumCols())
+
+	req = rs.NewChunk(chunk.NewAllocator())
+	require.NotNil(t, req)
+	require.Equal(t, 1, req.NumCols())
+}
+
+func TestRecordSetNextAfterFinish(t *testing.T) {
+	rs := newFinishedRecordSetForTest()
+
+	err := rs.Next(context.Background(), chunk.NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, 1))
+	require.Error(t, err)
+	require.True(t, exeerrors.ErrQueryInterrupted.Equal(err), err)
 }
 
 func ruKeyForStmt(t *testing.T, stmt *ExecStmt) stmtstats.RUKey {

--- a/pkg/server/internal/resultset/resultset.go
+++ b/pkg/server/internal/resultset/resultset.go
@@ -59,8 +59,8 @@ type tidbResultSet struct {
 	preparedStmt *core.PlanCacheStmt
 	cursorRUV2   *CursorRUV2Tracker
 	columns      []*column.Info
-	// finishLock is a mutex used to synchronize access to the `Next`,`Finish` and `Close` functions of the adapter.
-	// It ensures that only one goroutine can access the `Next`,`Finish` and `Close` functions at a time, preventing race conditions.
+	// finishLock is a mutex used to synchronize access to the `NewChunk`, `Next`, `Finish` and `Close` functions of the adapter.
+	// It ensures that only one goroutine can access the result set lifecycle at a time, preventing race conditions.
 	// When we terminate the current SQL externally (e.g., kill query), an additional goroutine would be used to call the `Finish` function.
 	finishLock sync.Mutex
 	closed     int32
@@ -177,6 +177,8 @@ func ReportCursorRUV2Delta(rs ResultSet, resultChunkCellsDelta int64) {
 }
 
 func (trs *tidbResultSet) NewChunk(alloc chunk.Allocator) *chunk.Chunk {
+	trs.finishLock.Lock()
+	defer trs.finishLock.Unlock()
 	return trs.recordSet.NewChunk(alloc)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69352 and #64618

**Problem Summary**

`KILL` or an abnormal query abort can call `FinishResultSet()` while `writeResultSet()` is still allocating or fetching result chunks. `recordSet.Finish()` closes the executor and clears `recordSet.executor`, so a later `NewChunk()` or `Next()` may dereference a nil executor and log an internal panic/recover.

**What changed and how does it work**

Guard `recordSet` against the finished state. `NewChunk()` now falls back to the cached result schema and session chunk settings when the executor has already been cleared, and `Next()` returns `ErrQueryInterrupted` instead of calling `exec.Next()` with a nil executor. `tidbResultSet.NewChunk()` is also synchronized with `Finish()`, `Next()`, and `Close()` via the existing lifecycle lock, so chunk allocation cannot race with result set finishing.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted queries by ensuring consistent interruption errors are returned during result set iteration.
  * Strengthened lifecycle and concurrency safety for result sets by improving synchronization across chunk creation and teardown.

* **Tests**
  * Added unit tests covering result set behavior after it is finished, including chunk creation and correct interruption error handling on subsequent iteration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->