### PR TITLE
planner: guard max_min_eliminate against empty scalar aggregations

### DIFF
--- a/pkg/planner/core/rule/rule_max_min_eliminate.go
+++ b/pkg/planner/core/rule/rule_max_min_eliminate.go
@@ -226,6 +226,9 @@ func (a *MaxMinEliminator) eliminateMaxMin(p base.LogicalPlan) base.LogicalPlan 
 		if len(agg.GroupByItems) != 0 {
 			return agg
 		}
+		if len(agg.AggFuncs) == 0 {
+			return agg
+		}
 		// Make sure that all of the aggFuncs are Max or Min.
 		for _, aggFunc := range agg.AggFuncs {
 			if aggFunc.Name != ast.AggFuncMax && aggFunc.Name != ast.AggFuncMin {

--- a/pkg/planner/core/rule/rule_max_min_eliminate_test.go
+++ b/pkg/planner/core/rule/rule_max_min_eliminate_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rule
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
+	"github.com/pingcap/tidb/pkg/planner/util/coretestsdk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxMinEliminateSkipsEmptyScalarAgg(t *testing.T) {
+	sctx := coretestsdk.MockContext()
+	agg := logicalop.LogicalAggregation{}.Init(sctx, 0)
+	opt := &MaxMinEliminator{}
+
+	require.NotPanics(t, func() {
+		p, changed, err := opt.Optimize(context.Background(), agg)
+		require.NoError(t, err)
+		require.False(t, changed)
+		require.Same(t, agg, p)
+	})
+}

--- a/tests/integrationtest/r/planner/core/casetest/integration.result
+++ b/tests/integrationtest/r/planner/core/casetest/integration.result
@@ -509,6 +509,26 @@ HashJoin	root		inner join, equal:[eq(planner__core__casetest__integration.t.a, p
 │     └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
 └─TableReader(Probe)	root		data:TableFullScan
   └─TableFullScan	cop[tikv]	table:t	keep order:false, stats:pseudo
+drop table if exists t;
+create table t(a int);
+insert into t values (0), (1);
+set @@tidb_opt_enable_semi_join_rewrite = on;
+with c as (select * from t)
+select max(t.a)
+from t
+where exists (
+select /*+ SEMI_JOIN_REWRITE() */ 1
+from c
+where c.a < 1
+)
+and exists (
+select 1
+from c
+where c.a < 2
+);
+max(t.a)
+1
+set @@tidb_opt_enable_semi_join_rewrite = default;
 drop table if exists test;
 create table test(id int, value int);
 drop table if exists t;

--- a/tests/integrationtest/t/planner/core/casetest/integration.test
+++ b/tests/integrationtest/t/planner/core/casetest/integration.test
@@ -136,6 +136,26 @@ explain format='plan_tree' select * from t where exists (select /*+ SEMI_JOIN_RE
 explain format='plan_tree' select /*+ hash_join_build(t) */ * from t where exists (select /*+ SEMI_JOIN_REWRITE() */ 1 from t t1 join t t2 where t1.a = t2.a and t1.a = t.a);
 explain format='plan_tree' select /*+ hash_join_probe(t) */ * from t where exists (select /*+ SEMI_JOIN_REWRITE() */ 1 from t t1 join t t2 where t1.a = t2.a and t1.a = t.a);
 
+# TestSemiJoinRewriteWithCTEAndMultipleExists
+drop table if exists t;
+create table t(a int);
+insert into t values (0), (1);
+set @@tidb_opt_enable_semi_join_rewrite = on;
+with c as (select * from t)
+select max(t.a)
+from t
+where exists (
+  select /*+ SEMI_JOIN_REWRITE() */ 1
+  from c
+  where c.a < 1
+)
+and exists (
+  select 1
+  from c
+  where c.a < 2
+);
+set @@tidb_opt_enable_semi_join_rewrite = default;
+
 # TestDecorrelateLimitInSubquery
 drop table if exists test;
 create table test(id int, value int);


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB!
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->
### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".
For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->
Issue Number: close #69379

Problem Summary: `max_min_eliminate` may panic with `index out of range [0] with length 0` when it receives an empty scalar aggregation (`AggFuncs=[]`, `GroupByItems=[]`). This shape is expected to be reachable from `SEMI_JOIN_REWRITE` on some `EXISTS` subqueries. The rule currently assumes at least one aggregate function exists and dereferences `aggs[0]`, which turns this invalid intermediate shape into an optimizer crash.

### What changed and how does it work?
- Add an early return in `max_min_eliminate` for empty scalar aggregations, so the rule treats them as non-applicable input and returns them unchanged.
- Avoid passing an empty aggregate-function slice into `composeAggsByInnerJoin()`, which previously accessed `aggs[0]` without a length check.
- Add a rule-level regression test that constructs an empty `LogicalAggregation` directly and verifies `Optimize()` does not panic and keeps the original aggregation node unchanged.

### Check List
Tests <!-- At least one of them must be included. -->
- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note
<!-- compatibility change, improvement, bugfix, and new feature need a release note -->
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.
```release-note
Fix a panic in `max_min_eliminate` when the optimizer processes empty scalar aggregations.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of empty scalar aggregations during query optimization to prevent errors and ensure stable processing of edge-case queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->