### PR TITLE
server: bind listener before standby activation completes

### DIFF
--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -486,17 +486,9 @@ func main() {
 	}
 	svr := createServer(storage, dom)
 	if standbyController != nil {
-		// Bind the MySQL listening port before acknowledging the activation
-		// request. Otherwise the activation caller may receive the success
-		// response and connect to the port before svr.Run starts listening,
-		// hitting a connection error.
-		if lerr := svr.InitTiDBListener(); lerr != nil {
-			standbyController.EndStandby(lerr)
-			terror.MustNil(lerr)
-		}
-		standbyController.EndStandby(nil)
-
 		svr.StandbyController = standbyController
+		err = standbyController.PrepareForActivation(svr)
+		terror.MustNil(err)
 		svr.StandbyController.OnServerCreated(svr)
 	}
 	if deploymode.IsStarter() && config.GetGlobalConfig().KeyspaceActivateMode {
@@ -515,7 +507,8 @@ func main() {
 		close(exited)
 	})
 	topsql.SetupTopProfiling(keyspace.GetKeyspaceNameBytesBySettings(), svr, dom)
-	terror.MustNil(svr.Run(dom))
+	err = svr.Run(dom)
+	terror.MustNil(err)
 	<-exited
 	if err := syncLog(); err != nil {
 		// Log sync failure means shutdown did not finish cleanly, so keep

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -486,6 +486,14 @@ func main() {
 	}
 	svr := createServer(storage, dom)
 	if standbyController != nil {
+		// Bind the MySQL listening port before acknowledging the activation
+		// request. Otherwise the activation caller may receive the success
+		// response and connect to the port before svr.Run starts listening,
+		// hitting a connection error.
+		if lerr := svr.InitTiDBListener(); lerr != nil {
+			standbyController.EndStandby(lerr)
+			terror.MustNil(lerr)
+		}
 		standbyController.EndStandby(nil)
 
 		svr.StandbyController = standbyController

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -507,8 +507,7 @@ func main() {
 		close(exited)
 	})
 	topsql.SetupTopProfiling(keyspace.GetKeyspaceNameBytesBySettings(), svr, dom)
-	err = svr.Run(dom)
-	terror.MustNil(err)
+	terror.MustNil(svr.Run(dom))
 	<-exited
 	if err := syncLog(); err != nil {
 		// Log sync failure means shutdown did not finish cleanly, so keep

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -364,12 +364,7 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 	return s, nil
 }
 
-// InitTiDBListener binds the MySQL protocol listener (and socket) ahead of Run.
-// Standby activation calls it so the server only acknowledges the activation
-// request after the listening port is already accepting TCP connections,
-// avoiding a race where the activation requester connects to the port before it
-// exists. It is idempotent: Run skips re-initialization when the listeners are
-// already bound.
+// InitTiDBListener prepares the MySQL protocol listener before activation succeeds.
 func (s *Server) InitTiDBListener() error {
 	return s.initTiDBListener()
 }
@@ -377,8 +372,6 @@ func (s *Server) InitTiDBListener() error {
 func (s *Server) initTiDBListener() (err error) {
 	needTCPListener := s.cfg.Host != "" && (s.cfg.Port != 0 || RunInGoTest)
 	needUnixSocket := s.cfg.Socket != ""
-	// The listeners may have been pre-bound (e.g. before standby activation is
-	// acknowledged); never bind twice.
 	if (!needTCPListener || s.listener != nil) && (!needUnixSocket || s.socket != nil) &&
 		(s.listener != nil || s.socket != nil) {
 		return nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -364,8 +364,26 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 	return s, nil
 }
 
+// InitTiDBListener binds the MySQL protocol listener (and socket) ahead of Run.
+// Standby activation calls it so the server only acknowledges the activation
+// request after the listening port is already accepting TCP connections,
+// avoiding a race where the activation requester connects to the port before it
+// exists. It is idempotent: Run skips re-initialization when the listeners are
+// already bound.
+func (s *Server) InitTiDBListener() error {
+	return s.initTiDBListener()
+}
+
 func (s *Server) initTiDBListener() (err error) {
-	if s.cfg.Host != "" && (s.cfg.Port != 0 || RunInGoTest) {
+	needTCPListener := s.cfg.Host != "" && (s.cfg.Port != 0 || RunInGoTest)
+	needUnixSocket := s.cfg.Socket != ""
+	// The listeners may have been pre-bound (e.g. before standby activation is
+	// acknowledged); never bind twice.
+	if (!needTCPListener || s.listener != nil) && (!needUnixSocket || s.socket != nil) &&
+		(s.listener != nil || s.socket != nil) {
+		return nil
+	}
+	if needTCPListener && s.listener == nil {
 		addr := net.JoinHostPort(s.cfg.Host, strconv.Itoa(int(s.cfg.Port)))
 		tcpProto := "tcp"
 		if s.cfg.EnableTCP4Only {
@@ -380,7 +398,7 @@ func (s *Server) initTiDBListener() (err error) {
 		}
 	}
 
-	if s.cfg.Socket != "" {
+	if needUnixSocket && s.socket == nil {
 		if err := cleanupStaleSocket(s.cfg.Socket); err != nil {
 			return errors.Trace(err)
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -209,6 +209,30 @@ func TestSeverHealth(t *testing.T) {
 	require.True(t, server.health.Load(), "server should be healthy")
 }
 
+func TestInitTiDBListenerIsIdempotent(t *testing.T) {
+	originalRunInGoTest := RunInGoTest
+	RunInGoTest = true
+	t.Cleanup(func() {
+		RunInGoTest = originalRunInGoTest
+	})
+
+	cfg := util.NewTestConfig()
+	cfg.Port = 0
+	cfg.Status.ReportStatus = false
+	cfg.Socket = filepath.Join(t.TempDir(), "tidb.sock")
+	svr := NewTestServer(cfg)
+	t.Cleanup(svr.Close)
+
+	require.NoError(t, svr.initTiDBListener())
+	require.NotNil(t, svr.Listener())
+	require.NotNil(t, svr.Socket())
+	listenAddr := svr.Listener().Addr().String()
+
+	require.NoError(t, svr.initTiDBListener())
+	require.Equal(t, listenAddr, svr.Listener().Addr().String())
+	require.NotNil(t, svr.Socket())
+}
+
 func TestServerShutdownFlags(t *testing.T) {
 	svr := NewTestServer(util.NewTestConfig())
 	require.False(t, svr.GetForceShutdown())

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -53,6 +53,8 @@ func (*testStandbyController) Handler(*Server) (string, *http.ServeMux) {
 
 func (*testStandbyController) OnConnActive() {}
 
+func (*testStandbyController) PrepareForActivation(StandbyReadyServer) error { return nil }
+
 func (*testStandbyController) OnServerCreated(*Server) {}
 
 func (*testStandbyController) OnServerShutdown(StandbyShutdownServer) {}
@@ -259,6 +261,8 @@ func (c *mockStandbyController) Handler(_ *Server) (string, *http.ServeMux) {
 }
 
 func (c *mockStandbyController) OnConnActive() {}
+
+func (c *mockStandbyController) PrepareForActivation(StandbyReadyServer) error { return nil }
 
 func (c *mockStandbyController) OnServerCreated(_ *Server) {}
 

--- a/pkg/server/standby.go
+++ b/pkg/server/standby.go
@@ -29,10 +29,20 @@ type StandbyController interface {
 
 	// OnConnActive is called when a new connection is established or a connection successfully executes a command.
 	OnConnActive()
+	// PrepareForActivation makes the server ready to accept client connections and
+	// only then lets the activation API report success, avoiding a race where the
+	// activation caller connects before the listener is bound. It is called after
+	// the server is created and before the activation request is acknowledged.
+	PrepareForActivation(svr StandbyReadyServer) error
 	// OnServerCreated is called when the server is created.
 	OnServerCreated(svr *Server)
 	// OnServerShutdown is called when the server is going to shut down.
 	OnServerShutdown(svr StandbyShutdownServer)
+}
+
+// StandbyReadyServer is the server capability used before reporting activation success.
+type StandbyReadyServer interface {
+	InitTiDBListener() error
 }
 
 // StandbyShutdownServer is the server capability used by standby shutdown control.

--- a/pkg/server/tests/standby/standby_test.go
+++ b/pkg/server/tests/standby/standby_test.go
@@ -64,6 +64,12 @@ func (c *mockStandbyController) OnConnActive() {
 	c.connActiveCounter.Add(1)
 }
 
+func (c *mockStandbyController) PrepareForActivation(svr server.StandbyReadyServer) error {
+	err := svr.InitTiDBListener()
+	c.EndStandby(err)
+	return err
+}
+
 func (c *mockStandbyController) OnServerCreated(svr *server.Server) {
 }
 
@@ -91,6 +97,7 @@ func TestStandby(t *testing.T) {
 		svr.SetDomain(dom)
 		svr.StandbyController = standbyController
 		close(serverCreated)
+		require.NoError(t, standbyController.PrepareForActivation(svr))
 		err = svr.Run(nil)
 		require.NoError(t, err)
 	}()

--- a/pkg/standby/BUILD.bazel
+++ b/pkg/standby/BUILD.bazel
@@ -28,7 +28,7 @@ go_test(
     srcs = ["standby_test.go"],
     embed = [":standby"],
     flaky = True,
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         "//pkg/config",
         "//pkg/config/deploymode",

--- a/pkg/standby/standby.go
+++ b/pkg/standby/standby.go
@@ -558,6 +558,14 @@ func (c *LoadKeyspaceController) WaitForActivate() {
 	})
 }
 
+// PrepareForActivation binds the server listener and only then ends standby, so the
+// activation API reports success after the server is ready to accept connections.
+func (c *LoadKeyspaceController) PrepareForActivation(svr server.StandbyReadyServer) error {
+	err := svr.InitTiDBListener()
+	c.EndStandby(err)
+	return err
+}
+
 // EndStandby is used to notify the temp http server that the tidb server is ready or failed to init.
 func (c *LoadKeyspaceController) EndStandby(err error) {
 	c.endOnce.Do(func() {

--- a/pkg/standby/standby_test.go
+++ b/pkg/standby/standby_test.go
@@ -21,7 +21,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/deploymode"
@@ -35,6 +37,16 @@ type mockManagerClient struct {
 	calls     int
 	failures  int
 	gotReason string
+}
+
+type mockReadyServer struct {
+	called bool
+	err    error
+}
+
+func (s *mockReadyServer) InitTiDBListener() error {
+	s.called = true
+	return s.err
 }
 
 func (c *mockManagerClient) Free(_ context.Context, exitReason string) error {
@@ -52,14 +64,20 @@ func resetStandbyTestState(t *testing.T) {
 	mu.Lock()
 	oldState := state
 	oldActivateRequest := activateRequest
+	oldActivationTimeout := activationTimeout
+	oldActivateCh := activateCh
 	state = standbyState
 	activateRequest = ActivateRequest{}
+	activationTimeout = 0
+	activateCh = make(chan struct{}, 1)
 	mu.Unlock()
 
 	t.Cleanup(func() {
 		mu.Lock()
 		state = oldState
 		activateRequest = oldActivateRequest
+		activationTimeout = oldActivationTimeout
+		activateCh = oldActivateCh
 		mu.Unlock()
 	})
 }
@@ -99,6 +117,42 @@ func TestActivateRequiresKeyspaceName(t *testing.T) {
 	mux.ServeHTTP(resp, req)
 
 	require.Equal(t, http.StatusBadRequest, resp.Code)
+}
+
+func TestActivateWaitsUntilServerReady(t *testing.T) {
+	resetStandbyTestState(t)
+	controller := NewLoadKeyspaceController(nil)
+	_, mux := controller.Handler(nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/tidb-pool/activate", strings.NewReader(`{"keyspace_name":"ks"}`))
+	resp := httptest.NewRecorder()
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(done)
+		mux.ServeHTTP(resp, req)
+	}()
+
+	require.Eventually(t, func() bool {
+		mu.RLock()
+		defer mu.RUnlock()
+		return state == activatedState
+	}, time.Second, time.Millisecond*10)
+	select {
+	case <-done:
+		require.Fail(t, "activate request returned before server ready")
+	default:
+	}
+
+	readyServer := &mockReadyServer{}
+	require.NoError(t, controller.PrepareForActivation(readyServer))
+	wg.Wait()
+
+	require.True(t, readyServer.called)
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.JSONEq(t, `{"state":"activated","keyspace_name":"ks"}`, resp.Body.String())
 }
 
 func TestOnServerShutdownNoopOutsideStarter(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67765

Problem Summary:

In standby mode, the activation request can be acknowledged before `Server.Run` initializes the TiDB MySQL listener. A client that connects immediately after activation succeeds can hit `connection refused`.

### What changed and how does it work?

This PR pre-binds the TiDB MySQL listener before acknowledging standby activation success. `Server.Run` reuses the already-bound listener through an idempotent listener initialization path, so activation completion now means the MySQL listener has already been created.

The idempotent path handles both TCP listeners and Unix sockets independently, avoiding a second bind while still binding any configured listener that has not been created yet.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `PATH=/usr/local/go/bin:$PATH ./tools/check/failpoint-go-test.sh pkg/server -run TestInitTiDBListenerIsIdempotent`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a race where standby activation can succeed before TiDB's MySQL listener is ready.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved standby activation flow to perform a pre-activation readiness step before acknowledging activation, avoiding premature completion during startup.
  * Made TiDB listener initialization idempotent to prevent double-binding during repeated activation attempts.
* **Tests**
  * Added coverage to confirm listener initialization remains stable across multiple calls.
  * Added coverage to ensure activation requests wait until the server is ready before returning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->