### PR TITLE
ddl: allow comment-only modify on materialized view base columns

### DIFF
--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -101,6 +101,39 @@ func isNullToNotNullChange(oldCol, newCol *model.ColumnInfo) bool {
 	return !mysql.HasNotNullFlag(oldCol.GetFlag()) && mysql.HasNotNullFlag(newCol.GetFlag())
 }
 
+func isColumnCommentOnlyChange(oldCol, newCol *model.ColumnInfo) bool {
+	if oldCol == nil || newCol == nil || oldCol.Comment == newCol.Comment {
+		return false
+	}
+	return oldCol.ID == newCol.ID &&
+		oldCol.Name == newCol.Name &&
+		oldCol.Offset == newCol.Offset &&
+		oldCol.State == newCol.State &&
+		oldCol.Version == newCol.Version &&
+		oldCol.Hidden == newCol.Hidden &&
+		oldCol.GeneratedExprString == newCol.GeneratedExprString &&
+		oldCol.GeneratedStored == newCol.GeneratedStored &&
+		oldCol.DefaultIsExpr == newCol.DefaultIsExpr &&
+		oldCol.ChangingFieldType == nil &&
+		newCol.ChangingFieldType == nil &&
+		oldCol.ChangeStateInfo == nil &&
+		newCol.ChangeStateInfo == nil &&
+		oldCol.FieldType.Equals(&newCol.FieldType) &&
+		columnDependencesEqual(oldCol.Dependences, newCol.Dependences)
+}
+
+func columnDependencesEqual(a, b map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // getModifyColumnType gets the modify column type.
 //  1. ModifyTypeNoReorg: The range of new type is a superset of the old type
 //  2. ModifyTypeNoReorgWithCheck: The range of new type is a subset of the old type, but we are running in strict SQL mode.
@@ -546,6 +579,9 @@ func buildMaterializedViewRelatedTableInfoForModifyColumn(
 ) ([]schemaIDAndTableInfo, error) {
 	baseInfo := baseTblInfo.MaterializedViewBase
 	if baseInfo == nil {
+		return nil, nil
+	}
+	if isColumnCommentOnlyChange(oldCol, newCol) {
 		return nil, nil
 	}
 
@@ -2064,6 +2100,9 @@ func validateMaterializedViewBaseModifyColumn(
 	hasDependentMV := len(baseInfo.MViewIDs) > 0
 	hasMLog := baseInfo.MLogID != 0
 	if !hasDependentMV && !hasMLog {
+		return nil
+	}
+	if isColumnCommentOnlyChange(oldCol, newCol) {
 		return nil
 	}
 

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -102,36 +103,13 @@ func isNullToNotNullChange(oldCol, newCol *model.ColumnInfo) bool {
 }
 
 func isColumnCommentOnlyChange(oldCol, newCol *model.ColumnInfo) bool {
-	if oldCol == nil || newCol == nil || oldCol.Comment == newCol.Comment {
+	if oldCol == nil || newCol == nil {
 		return false
 	}
-	return oldCol.ID == newCol.ID &&
-		oldCol.Name == newCol.Name &&
-		oldCol.Offset == newCol.Offset &&
-		oldCol.State == newCol.State &&
-		oldCol.Version == newCol.Version &&
-		oldCol.Hidden == newCol.Hidden &&
-		oldCol.GeneratedExprString == newCol.GeneratedExprString &&
-		oldCol.GeneratedStored == newCol.GeneratedStored &&
-		oldCol.DefaultIsExpr == newCol.DefaultIsExpr &&
-		oldCol.ChangingFieldType == nil &&
-		newCol.ChangingFieldType == nil &&
-		oldCol.ChangeStateInfo == nil &&
-		newCol.ChangeStateInfo == nil &&
-		oldCol.FieldType.Equals(&newCol.FieldType) &&
-		columnDependencesEqual(oldCol.Dependences, newCol.Dependences)
-}
-
-func columnDependencesEqual(a, b map[string]struct{}) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k := range a {
-		if _, ok := b[k]; !ok {
-			return false
-		}
-	}
-	return true
+	oldClone := oldCol.Clone()
+	newClone := newCol.Clone()
+	newClone.Comment = oldClone.Comment
+	return reflect.DeepEqual(oldClone, newClone)
 }
 
 // getModifyColumnType gets the modify column type.

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -366,6 +366,8 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	// Reorg-required or MV-dependent modifying should still be rejected.
 	err = tk.ExecToErr("alter table t modify column b bigint")
 	require.ErrorContains(t, err, "does not support modifying columns used in non-direct SELECT expressions")
+	tk.MustExec("alter table t modify column b int not null comment 'comment-only change'")
+	tk.MustQuery("select column_comment from information_schema.columns where table_schema = 'test' and table_name = 't' and column_name = 'b'").Check(testkit.Rows("comment-only change"))
 
 	// MV LOG must contain all referenced columns.
 	tk.MustExec("create table t_mlog_missing (a int not null, b int not null)")

--- a/pkg/executor/test/ddl/materialized_view_ddl_test.go
+++ b/pkg/executor/test/ddl/materialized_view_ddl_test.go
@@ -368,6 +368,7 @@ func TestMaterializedViewDDLBasic(t *testing.T) {
 	require.ErrorContains(t, err, "does not support modifying columns used in non-direct SELECT expressions")
 	tk.MustExec("alter table t modify column b int not null comment 'comment-only change'")
 	tk.MustQuery("select column_comment from information_schema.columns where table_schema = 'test' and table_name = 't' and column_name = 'b'").Check(testkit.Rows("comment-only change"))
+	tk.MustExec("alter table t modify column b int not null comment 'comment-only change'")
 
 	// MV LOG must contain all referenced columns.
 	tk.MustExec("create table t_mlog_missing (a int not null, b int not null)")

--- a/pkg/executor/test/writetest/BUILD.bazel
+++ b/pkg/executor/test/writetest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "write_test.go",
     ],
     flaky = True,
-    shard_count = 49,
+    shard_count = 50,
     deps = [
         "//pkg/config",
         "//pkg/errctx",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66836

Problem Summary:

A comment-only `ALTER TABLE ... MODIFY COLUMN` on a base table column referenced by a materialized view log and dependent materialized views can be rejected by the materialized-view dependency validation. The validation treats references such as `SUM(col)` as unsupported non-direct SELECT expressions even when the column type and query semantics are unchanged.

### What changed and how does it work?

This PR detects comment-only column metadata changes before materialized-view and materialized-view-log dependency validation.

If the old and new column metadata differ only by `ColumnInfo.Comment`, TiDB now skips MV/MLog semantic validation and avoids unnecessary related-table metadata updates. Other column changes still go through the existing MV/MLog validation path.

A regression test is added to cover a base table column used inside `SUM(col)` in a dependent materialized view, where `MODIFY COLUMN ... COMMENT ...` should succeed while real type changes remain rejected.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Executed locally:

- `go test ./pkg/executor/test/ddl -run '^TestMaterializedViewDDLBasic$' -tags=intest,deadlock -count=1`
- `git diff --check`
- `make bazel_lint_changed`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that a comment-only column modification on a materialized-view base table could be incorrectly rejected.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Comment-only `ALTER TABLE ... MODIFY COLUMN` changes (type/nullability unchanged, comment updated) are now handled correctly for materialized view related validation, so column comment edits no longer fail.
  * Updated column comments persist and are reflected in `information_schema.columns.column_comment`.

* **Tests**
  * Expanded materialized view DDL test coverage to confirm comment-only column modifications succeed, persist, and can be re-applied.
  * Updated write test suite sharding configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->