### PR TITLE
statistics: update partition stats on drop schema

### DIFF
--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -1475,21 +1475,42 @@ func TestDropSchema(t *testing.T) {
 
 	tk.MustExec("use test")
 	tk.MustExec("create table t (c1 int)")
+	tk.MustExec(`
+		create table pt (c1 int)
+		partition by range (c1) (
+			partition p0 values less than (10),
+			partition p1 values less than (20)
+		)
+	`)
 	h := dom.StatsHandle()
 	tk.MustExec("insert into t values (1)")
-	tk.MustExec("flush stats_delta *.*")
+	tk.MustExec("insert into pt values (1), (11)")
+	tk.MustExec("analyze table t, pt")
 
 	is := dom.InfoSchema()
 	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := tbl.Meta()
+	partitionedTbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("pt"))
+	require.NoError(t, err)
+	partitionedTableInfo := partitionedTbl.Meta()
+	require.NotNil(t, partitionedTableInfo.Partition)
+	require.Len(t, partitionedTableInfo.Partition.Definitions, 2)
+	statsMetaVersion := func(tableID int64) string {
+		rows := tk.MustQuery(
+			"select version from mysql.stats_meta where table_id = ?",
+			tableID,
+		).Rows()
+		require.Len(t, rows, 1)
+		return rows[0][0].(string)
+	}
 	// Check the current stats meta version.
-	rows := tk.MustQuery(
-		"select version from mysql.stats_meta where table_id = ?",
-		tableInfo.ID,
-	).Rows()
-	require.Len(t, rows, 1)
-	version := rows[0][0].(string)
+	tableVersion := statsMetaVersion(tableInfo.ID)
+	partitionedGlobalVersion := statsMetaVersion(partitionedTableInfo.ID)
+	partitionVersions := make(map[int64]string, len(partitionedTableInfo.Partition.Definitions))
+	for _, def := range partitionedTableInfo.Partition.Definitions {
+		partitionVersions[def.ID] = statsMetaVersion(def.ID)
+	}
 
 	tk.MustExec("drop database test")
 
@@ -1499,12 +1520,11 @@ func TestDropSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the stats meta version after drop schema.
-	rows = tk.MustQuery(
-		"select version from mysql.stats_meta where table_id = ?",
-		tableInfo.ID,
-	).Rows()
-	require.Len(t, rows, 1)
-	require.NotEqual(t, version, rows[0][0].(string))
+	require.NotEqual(t, tableVersion, statsMetaVersion(tableInfo.ID))
+	require.NotEqual(t, partitionedGlobalVersion, statsMetaVersion(partitionedTableInfo.ID))
+	for _, def := range partitionedTableInfo.Partition.Definitions {
+		require.NotEqual(t, partitionVersions[def.ID], statsMetaVersion(def.ID))
+	}
 }
 
 func TestExchangePartition(t *testing.T) {

--- a/pkg/statistics/handle/ddl/subscriber.go
+++ b/pkg/statistics/handle/ddl/subscriber.go
@@ -265,7 +265,9 @@ func (h subscriber) handle(
 					)
 				}
 			}
-			// Try best effort to update the stats meta version for gc.
+			// Best effort: update the table stats meta version for GC.
+			// In static partition pruning mode, the underlying UPDATE is a no-op if
+			// the global table stats record does not exist.
 			if err := h.delayedDeleteStats4PhysicalID(ctx, sctx, table.ID); err != nil {
 				logutil.StatsLogger().Error(
 					"Failed to update stats meta version for gc",

--- a/pkg/statistics/handle/ddl/subscriber.go
+++ b/pkg/statistics/handle/ddl/subscriber.go
@@ -254,6 +254,17 @@ func (h subscriber) handle(
 		miniDBInfo := change.GetDropSchemaInfo()
 		intest.Assert(miniDBInfo != nil)
 		for _, table := range miniDBInfo.Tables {
+			// Partition stats are keyed by partition physical IDs, so update them separately for stats GC.
+			for _, partition := range table.Partitions {
+				if err := h.delayedDeleteStats4PhysicalID(ctx, sctx, partition.ID); err != nil {
+					logutil.StatsLogger().Error(
+						"Failed to update stats meta version for gc",
+						zap.Int64("partitionID", partition.ID),
+						zap.Int64("tableID", table.ID),
+						zap.Error(err),
+					)
+				}
+			}
 			// Try best effort to update the stats meta version for gc.
 			if err := h.delayedDeleteStats4PhysicalID(ctx, sctx, table.ID); err != nil {
 				logutil.StatsLogger().Error(


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:

1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->


### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69394

Problem Summary:

Partition stats could miss stats GC cleanup after dropping a schema.

### What changed and how does it work?

Update dropped partition physical IDs during DropSchema stats cleanup. Then the partition’s stats could be concurrently GCed.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that partition statistics might not be garbage collected after dropping a schema
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statistics cleanup when dropping a database, including partitioned tables.
  * Stats version updates now cover both whole tables and each partition, helping keep metadata consistent after schema removal.
  * Expanded test coverage to verify stats changes for partitioned and non-partitioned tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->