### PR TITLE
[WIP] *: support auto analyze worker

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore.go
+++ b/br/pkg/restore/snap_client/systable_restore.go
@@ -94,6 +94,10 @@ var unRecoverableTable = map[string]map[string]struct{}{
 		"analyze_jobs": {},
 		// Table ID is recorded in the column `table_id` so that the table cannot be recovered simply.
 		"analyze_options": {},
+		// Table ID is recorded in the column `table_id`, and queued or historical
+		// auto analyze tasks do not need to be recovered.
+		"auto_analyze_tasks":         {},
+		"auto_analyze_tasks_history": {},
 		// Distributed eXecution Framework
 		// Records the tidb node information, no need to recovered.
 		"dist_framework_meta":             {},

--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -393,7 +393,7 @@ func TestCheckPrivilegeTableRowsCollateCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(261), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(262), session.CurrentBootstrapVersion)
 }
 
 func TestIsStatsTemporaryTable(t *testing.T) {

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -343,6 +343,7 @@ func closeExternalWorkloadManager(mgr extworkload.Manager) {
 	if mgr == nil {
 		return
 	}
+	defer extworkload.ClearManager(mgr)
 	if err := mgr.Close(); err != nil {
 		logutil.BgLogger().Warn("failed to close external workload manager", zap.Error(err))
 	}
@@ -482,6 +483,7 @@ func main() {
 	repository.SetupRepository(dom)
 	if deploymode.IsStarter() {
 		externalWorkloadManager := initExternalWorkloadManager(context.Background(), storage)
+		extworkload.InstallManager(externalWorkloadManager)
 		defer closeExternalWorkloadManager(externalWorkloadManager)
 	}
 	svr := createServer(storage, dom)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -893,12 +893,14 @@ type Performance struct {
 	AnalyzePartitionConcurrencyQuota  uint `toml:"analyze-partition-concurrency-quota" json:"analyze-partition-concurrency-quota"`
 	PlanReplayerDumpWorkerConcurrency uint `toml:"plan-replayer-dump-worker-concurrency" json:"plan-replayer-dump-worker-concurrency"`
 	EnableStatsCacheMemQuota          bool `toml:"enable-stats-cache-mem-quota" json:"enable-stats-cache-mem-quota"`
+	// RunAutoAnalyze disables auto analyze when explicitly set to false. When true,
+	// auto analyze follows the tidb_enable_auto_analyze system variable.
+	RunAutoAnalyze bool `toml:"run-auto-analyze" json:"run-auto-analyze"`
 	// The following items are deprecated. We need to keep them here temporarily
 	// to support the upgrade process. They can be removed in future.
 
-	// CommitterConcurrency, RunAutoAnalyze unused since bootstrap v90
-	CommitterConcurrency int  `toml:"committer-concurrency" json:"committer-concurrency"`
-	RunAutoAnalyze       bool `toml:"run-auto-analyze" json:"run-auto-analyze"`
+	// CommitterConcurrency unused since bootstrap v90.
+	CommitterConcurrency int `toml:"committer-concurrency" json:"committer-concurrency"`
 
 	// ForcePriority, MemoryUsageAlarmRatio are deprecated.
 	ForcePriority         string  `toml:"force-priority" json:"force-priority"`
@@ -1373,7 +1375,6 @@ var removedConfig = map[string]struct{}{
 	"log.query-log-max-len":              {},
 	"performance.committer-concurrency":  {},
 	"experimental.enable-global-kill":    {},
-	"performance.run-auto-analyze":       {}, // use tidb_enable_auto_analyze
 	// use tidb_enable_prepared_plan_cache, tidb_prepared_plan_cache_size and tidb_prepared_plan_cache_memory_guard_ratio
 	"prepared-plan-cache.enabled":            {},
 	"prepared-plan-cache.capacity":           {},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -926,7 +926,7 @@ allow-expression-index = false
 [isolation-read]
 # engines means allow the tidb server read data from which types of engines. options: "tikv", "tiflash", "tidb".
 engines = ["tikv", "tiflash", "tidb"]
-		`, errors.New("The following configuration options are no longer supported in this version of TiDB. Check the release notes for more information: check-mb4-value-in-utf8, enable-batch-dml, instance.tidb_memory_usage_alarm_ratio, log.enable-slow-log, log.expensive-threshold, log.query-log-max-len, log.record-plan-in-slow-log, log.slow-threshold, lower-case-table-names, mem-quota-query, oom-action, performance.committer-concurrency, performance.feedback-probability, performance.force-priority, performance.memory-usage-alarm-ratio, performance.query-feedback-limit, performance.run-auto-analyze, prepared-plan-cache.capacity, prepared-plan-cache.enabled, prepared-plan-cache.memory-guard-ratio")},
+		`, errors.New("The following configuration options are no longer supported in this version of TiDB. Check the release notes for more information: check-mb4-value-in-utf8, enable-batch-dml, instance.tidb_memory_usage_alarm_ratio, log.enable-slow-log, log.expensive-threshold, log.query-log-max-len, log.record-plan-in-slow-log, log.slow-threshold, lower-case-table-names, mem-quota-query, oom-action, performance.committer-concurrency, performance.feedback-probability, performance.force-priority, performance.memory-usage-alarm-ratio, performance.query-feedback-limit, prepared-plan-cache.capacity, prepared-plan-cache.enabled, prepared-plan-cache.memory-guard-ratio")},
 	}
 
 	for _, test := range configTest {

--- a/pkg/domain/BUILD.bazel
+++ b/pkg/domain/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//pkg/dxf/framework/storage",
         "//pkg/dxf/framework/taskexecutor",
         "//pkg/errno",
+        "//pkg/extworkload",
         "//pkg/infoschema",
         "//pkg/infoschema/issyncer",
         "//pkg/infoschema/isvalidator",
@@ -154,7 +155,7 @@ go_test(
     ],
     embed = [":domain"],
     flaky = True,
-    shard_count = 30,
+    shard_count = 31,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -56,6 +56,7 @@ import (
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor"
 	"github.com/pingcap/tidb/pkg/errno"
+	"github.com/pingcap/tidb/pkg/extworkload"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/infoschema/issyncer"
 	"github.com/pingcap/tidb/pkg/infoschema/isvalidator"
@@ -2316,10 +2317,35 @@ func (do *Domain) autoAnalyzeWorker() {
 	defer util.Recover(metrics.LabelDomain, "autoAnalyzeWorker", nil, false)
 	statsHandle := do.StatsHandle()
 	analyzeTicker := time.NewTicker(do.statsLease)
+	var autoAnalyzeWorkerOwner owner.Manager
 	defer func() {
 		analyzeTicker.Stop()
+		if autoAnalyzeWorkerOwner != nil {
+			autoAnalyzeWorkerOwner.Close()
+		}
 		statslogutil.StatsLogger().Info("autoAnalyzeWorker exited.")
 	}()
+
+	getAutoAnalyzeOwner := func() owner.Manager {
+		mgr := extworkload.GetManager()
+		if extworkload.IsEnabled(mgr) && !extworkload.IsMaster(mgr) && !extworkload.IsAutoAnalyzeWorker(mgr) {
+			return nil
+		}
+		if !extworkload.IsAutoAnalyzeWorker(mgr) {
+			return do.statsOwner
+		}
+		if autoAnalyzeWorkerOwner != nil {
+			return autoAnalyzeWorkerOwner
+		}
+		autoAnalyzeWorkerOwner = do.NewOwnerManager(handle.AutoAnalyzeExecutorPrompt, handle.AutoAnalyzeExecutorOwnerKey)
+		if err := autoAnalyzeWorkerOwner.CampaignOwner(10); err != nil {
+			logutil.BgLogger().Warn("campaign auto analyze worker owner failed", zap.Error(err))
+			autoAnalyzeWorkerOwner.Close()
+			autoAnalyzeWorkerOwner = nil
+		}
+		return autoAnalyzeWorkerOwner
+	}
+
 	for {
 		select {
 		case <-analyzeTicker.C:
@@ -2339,9 +2365,10 @@ func (do *Domain) autoAnalyzeWorker() {
 			// the probability of this happening is very high that the ticker condition and exist condition will be met
 			// at the same time.
 			// This causes the auto analyze task to be triggered all the time and block the shutdown of tidb.
-			if vardef.RunAutoAnalyze.Load() && !do.stopAutoAnalyze.Load() && do.statsOwner.IsOwner() {
+			autoAnalyzeOwner := getAutoAnalyzeOwner()
+			if shouldRunAutoAnalyze() && !do.stopAutoAnalyze.Load() && autoAnalyzeOwner != nil && autoAnalyzeOwner.IsOwner() {
 				statsHandle.HandleAutoAnalyze()
-			} else if !vardef.RunAutoAnalyze.Load() || !do.statsOwner.IsOwner() {
+			} else if !shouldRunAutoAnalyze() || autoAnalyzeOwner == nil || !autoAnalyzeOwner.IsOwner() {
 				// Once the auto analyze is disabled or this instance is not the owner,
 				// we close the priority queue to release resources.
 				// This would guarantee that when auto analyze is re-enabled or this instance becomes the owner again,
@@ -2352,6 +2379,10 @@ func (do *Domain) autoAnalyzeWorker() {
 			return
 		}
 	}
+}
+
+func shouldRunAutoAnalyze() bool {
+	return config.GetGlobalConfig().Performance.RunAutoAnalyze && vardef.RunAutoAnalyze.Load()
 }
 
 // analyzeJobsCleanupWorker is a background worker that periodically performs two main tasks:

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2326,12 +2326,21 @@ func (do *Domain) autoAnalyzeWorker() {
 		statslogutil.StatsLogger().Info("autoAnalyzeWorker exited.")
 	}()
 
+	closeAutoAnalyzeWorkerOwner := func() {
+		if autoAnalyzeWorkerOwner != nil {
+			autoAnalyzeWorkerOwner.Close()
+			autoAnalyzeWorkerOwner = nil
+		}
+	}
+
 	getAutoAnalyzeOwner := func() owner.Manager {
 		mgr := extworkload.GetManager()
 		if extworkload.IsEnabled(mgr) && !extworkload.IsMaster(mgr) && !extworkload.IsAutoAnalyzeWorker(mgr) {
+			closeAutoAnalyzeWorkerOwner()
 			return nil
 		}
 		if !extworkload.IsAutoAnalyzeWorker(mgr) {
+			closeAutoAnalyzeWorkerOwner()
 			return do.statsOwner
 		}
 		if autoAnalyzeWorkerOwner != nil {

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/domain/serverinfo"
@@ -214,6 +215,31 @@ func TestStatWorkRecoverFromPanic(t *testing.T) {
 	dom.Close()
 	isClose = dom.isClose()
 	require.True(t, isClose)
+}
+
+func TestRunAutoAnalyzeConfigFlag(t *testing.T) {
+	origCfg := config.GetGlobalConfig()
+	newCfg := *origCfg
+	config.StoreGlobalConfig(&newCfg)
+	defer config.StoreGlobalConfig(origCfg)
+
+	origSysVar := vardef.RunAutoAnalyze.Load()
+	defer vardef.RunAutoAnalyze.Store(origSysVar)
+
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Performance.RunAutoAnalyze = false
+	})
+	vardef.RunAutoAnalyze.Store(true)
+	require.False(t, shouldRunAutoAnalyze())
+
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Performance.RunAutoAnalyze = true
+	})
+	vardef.RunAutoAnalyze.Store(false)
+	require.False(t, shouldRunAutoAnalyze())
+
+	vardef.RunAutoAnalyze.Store(true)
+	require.True(t, shouldRunAutoAnalyze())
 }
 
 // ETCD use ip:port as unix socket address, however this address is invalid on windows.

--- a/pkg/extworkload/BUILD.bazel
+++ b/pkg/extworkload/BUILD.bazel
@@ -30,7 +30,7 @@ go_test(
     ],
     embed = [":extworkload"],
     flaky = True,
-    shard_count = 6,
+    shard_count = 7,
     deps = [
         "//pkg/config",
         "//pkg/extworkload/client",

--- a/pkg/extworkload/util.go
+++ b/pkg/extworkload/util.go
@@ -14,7 +14,40 @@
 
 package extworkload
 
-import "github.com/pingcap/tidb/pkg/config"
+import (
+	"sync"
+
+	"github.com/pingcap/tidb/pkg/config"
+)
+
+var globalManager struct {
+	sync.RWMutex
+	mgr Manager
+}
+
+// InstallManager makes the process-wide external workload manager visible to
+// components that need role-dependent behavior after bootstrap.
+func InstallManager(m Manager) {
+	globalManager.Lock()
+	defer globalManager.Unlock()
+	globalManager.mgr = m
+}
+
+// GetManager returns the process-wide external workload manager, if any.
+func GetManager() Manager {
+	globalManager.RLock()
+	defer globalManager.RUnlock()
+	return globalManager.mgr
+}
+
+// ClearManager clears the process-wide manager if it still points at m.
+func ClearManager(m Manager) {
+	globalManager.Lock()
+	defer globalManager.Unlock()
+	if globalManager.mgr == m {
+		globalManager.mgr = nil
+	}
+}
 
 // IsEnabled reports whether a Manager is present.
 func IsEnabled(m Manager) bool { return m != nil }

--- a/pkg/extworkload/util_test.go
+++ b/pkg/extworkload/util_test.go
@@ -61,7 +61,12 @@ func TestRolePredicatesDedicated(t *testing.T) {
 }
 
 func TestGlobalManager(t *testing.T) {
-	ClearManager(GetManager())
+	initial := GetManager()
+	t.Cleanup(func() {
+		InstallManager(initial)
+	})
+
+	InstallManager(nil)
 	require.Nil(t, GetManager())
 
 	master := &stubManager{role: config.RoleMaster}

--- a/pkg/extworkload/util_test.go
+++ b/pkg/extworkload/util_test.go
@@ -59,3 +59,23 @@ func TestRolePredicatesDedicated(t *testing.T) {
 		})
 	}
 }
+
+func TestGlobalManager(t *testing.T) {
+	ClearManager(GetManager())
+	require.Nil(t, GetManager())
+
+	master := &stubManager{role: config.RoleMaster}
+	worker := &stubManager{role: config.RoleAutoAnalyzeWorker}
+
+	InstallManager(master)
+	require.Same(t, master, GetManager())
+
+	ClearManager(worker)
+	require.Same(t, master, GetManager())
+
+	InstallManager(worker)
+	require.Same(t, worker, GetManager())
+
+	ClearManager(worker)
+	require.Nil(t, GetManager())
+}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -189,6 +189,9 @@ const (
 	BaseNextGenBootTableVersion NextGenBootTableVersion = 1
 	// MaskingPolicyNextGenBootTableVersion adds mysql.tidb_masking_policy.
 	MaskingPolicyNextGenBootTableVersion NextGenBootTableVersion = 2
+	// AutoAnalyzeTasksNextGenBootTableVersion adds mysql.auto_analyze_tasks and
+	// mysql.auto_analyze_tasks_history.
+	AutoAnalyzeTasksNextGenBootTableVersion NextGenBootTableVersion = 3
 )
 
 // DDLTableVersion is to display ddl related table versions

--- a/pkg/meta/metadef/system.go
+++ b/pkg/meta/metadef/system.go
@@ -156,6 +156,10 @@ const (
 	TiDBSoftDeleteTableStatusTableID = ReservedGlobalIDUpperBound - 61
 	// TiDBMaskingPolicyTableID is the table ID of `tidb_masking_policy`.
 	TiDBMaskingPolicyTableID = ReservedGlobalIDUpperBound - 62
+	// AutoAnalyzeTasksTableID is the table ID of `auto_analyze_tasks`.
+	AutoAnalyzeTasksTableID = ReservedGlobalIDUpperBound - 63
+	// AutoAnalyzeTasksHistoryTableID is the table ID of `auto_analyze_tasks_history`.
+	AutoAnalyzeTasksHistoryTableID = ReservedGlobalIDUpperBound - 64
 )
 
 // IsReservedID checks if the given ID is a reserved global ID.

--- a/pkg/meta/metadef/system_tables_def.go
+++ b/pkg/meta/metadef/system_tables_def.go
@@ -463,15 +463,16 @@ const (
 		version bigint(64) UNSIGNED NOT NULL DEFAULT 0,
 		PRIMARY KEY (table_id) CLUSTERED);`
 
-	// CreateAutoAnalyzeTasks stores auto analyze tasks scheduled for external workers.
-	CreateAutoAnalyzeTasks = `CREATE TABLE IF NOT EXISTS mysql.auto_analyze_tasks (
+	// CreateAutoAnalyzeTasksTable stores auto analyze tasks scheduled for external workers.
+	CreateAutoAnalyzeTasksTable = `CREATE TABLE IF NOT EXISTS mysql.auto_analyze_tasks (
 		id BIGINT(64) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
 		table_id BIGINT(64) NOT NULL,
-		start_time BIGINT(64)
+		start_time BIGINT(64),
+		KEY idx_auto_analyze_tasks_table_id (table_id)
 	);`
 
-	// CreateAutoAnalyzeTasksHistory stores finished auto analyze tasks.
-	CreateAutoAnalyzeTasksHistory = `CREATE TABLE IF NOT EXISTS mysql.auto_analyze_tasks_history (
+	// CreateAutoAnalyzeTasksHistoryTable stores finished auto analyze tasks.
+	CreateAutoAnalyzeTasksHistoryTable = `CREATE TABLE IF NOT EXISTS mysql.auto_analyze_tasks_history (
 		id BIGINT(64) UNSIGNED PRIMARY KEY,
 		table_id BIGINT(64) NOT NULL,
 		analyzed BOOLEAN NOT NULL DEFAULT FALSE,

--- a/pkg/meta/metadef/system_tables_def.go
+++ b/pkg/meta/metadef/system_tables_def.go
@@ -463,6 +463,24 @@ const (
 		version bigint(64) UNSIGNED NOT NULL DEFAULT 0,
 		PRIMARY KEY (table_id) CLUSTERED);`
 
+	// CreateAutoAnalyzeTasks stores auto analyze tasks scheduled for external workers.
+	CreateAutoAnalyzeTasks = `CREATE TABLE IF NOT EXISTS mysql.auto_analyze_tasks (
+		id BIGINT(64) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+		table_id BIGINT(64) NOT NULL,
+		start_time BIGINT(64)
+	);`
+
+	// CreateAutoAnalyzeTasksHistory stores finished auto analyze tasks.
+	CreateAutoAnalyzeTasksHistory = `CREATE TABLE IF NOT EXISTS mysql.auto_analyze_tasks_history (
+		id BIGINT(64) UNSIGNED PRIMARY KEY,
+		table_id BIGINT(64) NOT NULL,
+		analyzed BOOLEAN NOT NULL DEFAULT FALSE,
+		statement TEXT,
+		err TEXT,
+		start_time BIGINT(64),
+		end_time BIGINT(64)
+	);`
+
 	// CreatePasswordHistoryTable is a table save history passwd.
 	CreatePasswordHistoryTable = `CREATE TABLE  IF NOT EXISTS mysql.password_history (
          Host char(255)  NOT NULL DEFAULT '',

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -329,8 +329,8 @@ var (
 		{ID: metadef.IndexAdvisorResultsTableID, Name: "index_advisor_results", SQL: metadef.CreateIndexAdvisorResultsTable},
 		{ID: metadef.TiDBKernelOptionsTableID, Name: "tidb_kernel_options", SQL: metadef.CreateTiDBKernelOptionsTable},
 		{ID: metadef.TiDBWorkloadValuesTableID, Name: "tidb_workload_values", SQL: metadef.CreateTiDBWorkloadValuesTable},
-		{ID: metadef.AutoAnalyzeTasksTableID, Name: "auto_analyze_tasks", SQL: metadef.CreateAutoAnalyzeTasks},
-		{ID: metadef.AutoAnalyzeTasksHistoryTableID, Name: "auto_analyze_tasks_history", SQL: metadef.CreateAutoAnalyzeTasksHistory},
+		{ID: metadef.AutoAnalyzeTasksTableID, Name: "auto_analyze_tasks", SQL: metadef.CreateAutoAnalyzeTasksTable},
+		{ID: metadef.AutoAnalyzeTasksHistoryTableID, Name: "auto_analyze_tasks_history", SQL: metadef.CreateAutoAnalyzeTasksHistoryTable},
 	}
 	// systemTablesOfMaskingPolicyNextGenVersion contains system tables introduced in
 	// the masking-policy bootstrap version.

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -329,6 +329,8 @@ var (
 		{ID: metadef.IndexAdvisorResultsTableID, Name: "index_advisor_results", SQL: metadef.CreateIndexAdvisorResultsTable},
 		{ID: metadef.TiDBKernelOptionsTableID, Name: "tidb_kernel_options", SQL: metadef.CreateTiDBKernelOptionsTable},
 		{ID: metadef.TiDBWorkloadValuesTableID, Name: "tidb_workload_values", SQL: metadef.CreateTiDBWorkloadValuesTable},
+		{ID: metadef.AutoAnalyzeTasksTableID, Name: "auto_analyze_tasks", SQL: metadef.CreateAutoAnalyzeTasks},
+		{ID: metadef.AutoAnalyzeTasksHistoryTableID, Name: "auto_analyze_tasks_history", SQL: metadef.CreateAutoAnalyzeTasksHistory},
 	}
 	// systemTablesOfMaskingPolicyNextGenVersion contains system tables introduced in
 	// the masking-policy bootstrap version.

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -329,13 +329,17 @@ var (
 		{ID: metadef.IndexAdvisorResultsTableID, Name: "index_advisor_results", SQL: metadef.CreateIndexAdvisorResultsTable},
 		{ID: metadef.TiDBKernelOptionsTableID, Name: "tidb_kernel_options", SQL: metadef.CreateTiDBKernelOptionsTable},
 		{ID: metadef.TiDBWorkloadValuesTableID, Name: "tidb_workload_values", SQL: metadef.CreateTiDBWorkloadValuesTable},
-		{ID: metadef.AutoAnalyzeTasksTableID, Name: "auto_analyze_tasks", SQL: metadef.CreateAutoAnalyzeTasksTable},
-		{ID: metadef.AutoAnalyzeTasksHistoryTableID, Name: "auto_analyze_tasks_history", SQL: metadef.CreateAutoAnalyzeTasksHistoryTable},
 	}
 	// systemTablesOfMaskingPolicyNextGenVersion contains system tables introduced in
 	// the masking-policy bootstrap version.
 	systemTablesOfMaskingPolicyNextGenVersion = []TableBasicInfo{
 		{ID: metadef.TiDBMaskingPolicyTableID, Name: "tidb_masking_policy", SQL: metadef.CreateTiDBMaskingPolicyTable},
+	}
+	// systemTablesOfAutoAnalyzeTasksNextGenVersion contains system tables introduced
+	// in the auto-analyze-tasks bootstrap version.
+	systemTablesOfAutoAnalyzeTasksNextGenVersion = []TableBasicInfo{
+		{ID: metadef.AutoAnalyzeTasksTableID, Name: "auto_analyze_tasks", SQL: metadef.CreateAutoAnalyzeTasksTable},
+		{ID: metadef.AutoAnalyzeTasksHistoryTableID, Name: "auto_analyze_tasks_history", SQL: metadef.CreateAutoAnalyzeTasksHistoryTable},
 	}
 )
 
@@ -356,6 +360,9 @@ var versionedBootstrapSchemas = []versionedBootstrapSchema{
 	}},
 	{ver: meta.MaskingPolicyNextGenBootTableVersion, databases: []DatabaseBasicInfo{
 		{ID: metadef.SystemDatabaseID, Name: mysql.SystemDB, Tables: systemTablesOfMaskingPolicyNextGenVersion},
+	}},
+	{ver: meta.AutoAnalyzeTasksNextGenBootTableVersion, databases: []DatabaseBasicInfo{
+		{ID: metadef.SystemDatabaseID, Name: mysql.SystemDB, Tables: systemTablesOfAutoAnalyzeTasksNextGenVersion},
 	}},
 }
 

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -53,7 +53,7 @@ import (
 )
 
 func TestMySQLDBTables(t *testing.T) {
-	require.Len(t, systemTablesOfBaseNextGenVersion, 52, "DO NOT CHANGE IT")
+	require.Len(t, systemTablesOfBaseNextGenVersion, 54, "DO NOT CHANGE IT")
 	for _, verBoot := range versionedBootstrapSchemas {
 		for _, schInfo := range verBoot.databases {
 			testTableBasicInfoSlice(t, schInfo.Tables, "IF NOT EXISTS mysql.%s (")

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -53,7 +53,7 @@ import (
 )
 
 func TestMySQLDBTables(t *testing.T) {
-	require.Len(t, systemTablesOfBaseNextGenVersion, 54, "DO NOT CHANGE IT")
+	require.Len(t, systemTablesOfBaseNextGenVersion, 52, "DO NOT CHANGE IT")
 	for _, verBoot := range versionedBootstrapSchemas {
 		for _, schInfo := range verBoot.databases {
 			testTableBasicInfoSlice(t, schInfo.Tables, "IF NOT EXISTS mysql.%s (")

--- a/pkg/session/test/meta/session_test.go
+++ b/pkg/session/test/meta/session_test.go
@@ -276,5 +276,5 @@ func TestNextgenBootstrap(t *testing.T) {
 		}
 	}
 	require.EqualValues(t, 2, reservedSchemaCnt)
-	require.EqualValues(t, 60, reservedTableCnt)
+	require.EqualValues(t, 62, reservedTableCnt)
 }

--- a/pkg/session/upgrade_backfill_test.go
+++ b/pkg/session/upgrade_backfill_test.go
@@ -154,3 +154,48 @@ func TestUpgradeToVer261BackfillsDefaultStringMatchSelectivity(t *testing.T) {
 	require.Equal(t, "0.8", chk.GetRow(0).GetString(0))
 	require.NoError(t, res.Close())
 }
+
+func TestUpgradeToVer262CreatesAutoAnalyzeTaskTables(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
+	}
+
+	ctx := context.Background()
+	store, dom := CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	seV261 := CreateSessionAndSetID(t, store)
+	MustExec(t, seV261, "drop table mysql.auto_analyze_tasks_history")
+	MustExec(t, seV261, "drop table mysql.auto_analyze_tasks")
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	err = m.FinishBootstrap(int64(version261))
+	require.NoError(t, err)
+	RevertVersionAndVariables(t, seV261, version261)
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+	store.SetOption(StoreBootstrappedKey, nil)
+
+	dom.Close()
+	domCurVer, err := BootstrapSession(store)
+	require.NoError(t, err)
+	defer domCurVer.Close()
+
+	seCurVer := CreateSessionAndSetID(t, store)
+	ver, err := GetBootstrapVersion(seCurVer)
+	require.NoError(t, err)
+	require.Equal(t, currentBootstrapVersion, ver)
+
+	res := MustExecToRecodeSet(t, seCurVer, "select count(*) from mysql.auto_analyze_tasks")
+	chk := res.NewChunk(nil)
+	require.NoError(t, res.Next(ctx, chk))
+	require.Equal(t, int64(0), chk.GetRow(0).GetInt64(0))
+	require.NoError(t, res.Close())
+
+	res = MustExecToRecodeSet(t, seCurVer, "select count(*) from mysql.auto_analyze_tasks_history")
+	chk = res.NewChunk(nil)
+	require.NoError(t, res.Next(ctx, chk))
+	require.Equal(t, int64(0), chk.GetRow(0).GetInt64(0))
+	require.NoError(t, res.Close())
+}

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -2145,6 +2145,6 @@ func upgradeToVer261(s sessionapi.Session, _ int64) {
 }
 
 func upgradeToVer262(s sessionapi.Session, _ int64) {
-	doReentrantDDL(s, metadef.CreateAutoAnalyzeTasks)
-	doReentrantDDL(s, metadef.CreateAutoAnalyzeTasksHistory)
+	doReentrantDDL(s, metadef.CreateAutoAnalyzeTasksTable)
+	doReentrantDDL(s, metadef.CreateAutoAnalyzeTasksHistoryTable)
 }

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -507,6 +507,9 @@ const (
 	// Backfill tidb_default_string_match_selectivity for upgraded clusters where the row in
 	// mysql.global_variables was never materialized when the variable was introduced.
 	version261 = 261
+
+	// version262 adds mysql.auto_analyze_tasks and mysql.auto_analyze_tasks_history.
+	version262 = 262
 )
 
 // versionedUpgradeFunction is a struct that holds the upgrade function related
@@ -520,7 +523,7 @@ type versionedUpgradeFunction struct {
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version261
+var currentBootstrapVersion int64 = version262
 
 var (
 	// this list must be ordered by version in ascending order, and the function
@@ -706,6 +709,7 @@ var (
 		{version: version259, fn: upgradeToVer259},
 		{version: version260, fn: upgradeToVer260},
 		{version: version261, fn: upgradeToVer261},
+		{version: version262, fn: upgradeToVer262},
 	}
 )
 
@@ -2138,4 +2142,9 @@ func upgradeToVer260(s sessionapi.Session, _ int64) {
 func upgradeToVer261(s sessionapi.Session, _ int64) {
 	// the prior default behavior is "0.8", keep it for compatibility for old clusters.
 	initGlobalVariableIfNotExists(s, vardef.TiDBDefaultStrMatchSelectivity, "0.8")
+}
+
+func upgradeToVer262(s sessionapi.Session, _ int64) {
+	doReentrantDDL(s, metadef.CreateAutoAnalyzeTasks)
+	doReentrantDDL(s, metadef.CreateAutoAnalyzeTasksHistory)
 }

--- a/pkg/statistics/BUILD.bazel
+++ b/pkg/statistics/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "analyze.go",
         "analyze_jobs.go",
+        "autoanalyze_jobs.go",
         "builder.go",
         "cmsketch.go",
         "cmsketch_util.go",

--- a/pkg/statistics/autoanalyze_jobs.go
+++ b/pkg/statistics/autoanalyze_jobs.go
@@ -21,6 +21,5 @@ type AutoAnalyzeTask struct {
 	ID        uint64
 	TableID   int64
 	StartTime int64
-	EndTime   int64
 	Analyzed  bool
 }

--- a/pkg/statistics/autoanalyze_jobs.go
+++ b/pkg/statistics/autoanalyze_jobs.go
@@ -1,0 +1,26 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics
+
+// AutoAnalyzeTask represents one auto analyze task stored in mysql.auto_analyze_tasks.
+type AutoAnalyzeTask struct {
+	ID        uint64
+	TableID   int64
+	Analyzed  bool
+	Statement string
+	Err       string
+	StartTime int64
+	EndTime   int64
+}

--- a/pkg/statistics/autoanalyze_jobs.go
+++ b/pkg/statistics/autoanalyze_jobs.go
@@ -16,11 +16,11 @@ package statistics
 
 // AutoAnalyzeTask represents one auto analyze task stored in mysql.auto_analyze_tasks.
 type AutoAnalyzeTask struct {
-	ID        uint64
-	TableID   int64
-	Analyzed  bool
 	Statement string
 	Err       string
+	ID        uint64
+	TableID   int64
 	StartTime int64
 	EndTime   int64
+	Analyzed  bool
 }

--- a/pkg/statistics/handle/autoanalyze/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/BUILD.bazel
@@ -44,7 +44,7 @@ go_test(
     timeout = "short",
     srcs = ["autoanalyze_test.go"],
     flaky = True,
-    shard_count = 17,
+    shard_count = 18,
     deps = [
         ":autoanalyze",
         "//pkg/config",

--- a/pkg/statistics/handle/autoanalyze/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/BUILD.bazel
@@ -2,12 +2,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "autoanalyze",
-    srcs = ["autoanalyze.go"],
+    srcs = [
+        "autoanalyze.go",
+        "autoanalyze_worker.go",
+    ],
     importpath = "github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ddl/notifier",
         "//pkg/domain/infosync",
+        "//pkg/extworkload",
         "//pkg/infoschema",
         "//pkg/meta/metadef",
         "//pkg/meta/model",
@@ -40,12 +44,14 @@ go_test(
     timeout = "short",
     srcs = ["autoanalyze_test.go"],
     flaky = True,
-    shard_count = 14,
+    shard_count = 17,
     deps = [
         ":autoanalyze",
+        "//pkg/config",
         "//pkg/domain",
         "//pkg/domain/infosync",
         "//pkg/domain/serverinfo",
+        "//pkg/extworkload",
         "//pkg/keyspace",
         "//pkg/parser/ast",
         "//pkg/parser/mysql",
@@ -64,6 +70,7 @@ go_test(
         "//pkg/util/mock",
         "//pkg/util/sqlexec/mock",
         "@com_github_pingcap_failpoint//:failpoint",
+        "@com_github_pingcap_kvproto//pkg/keyspacepb",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//oracle",
         "@org_uber_go_mock//gomock",

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
+	"github.com/pingcap/tidb/pkg/extworkload"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/metadef"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -336,6 +337,49 @@ func (sa *statsAnalyze) handleAutoAnalyze(sctx sessionctx.Context) bool {
 			)
 		}
 	}()
+	mgr := extworkload.GetManager()
+	if extworkload.IsEnabled(mgr) {
+		parameters := exec.GetAutoAnalyzeParameters(sctx)
+		autoAnalyzeRatio := exec.ParseAutoAnalyzeRatio(parameters[vardef.TiDBAutoAnalyzeRatio])
+		start, end, ok := checkAutoAnalyzeWindow(parameters)
+		if !ok {
+			return false
+		}
+
+		pruneMode := variable.PartitionPruneMode(sctx.GetSessionVars().PartitionPruneMode.Load())
+		lockedTables, err := lockstats.QueryLockedTables(statsutil.StatsCtx, sctx)
+		if err != nil {
+			statslogutil.StatsLogger().Warn(
+				"check table lock failed",
+				zap.Error(err),
+			)
+			return false
+		}
+
+		if extworkload.IsAutoAnalyzeWorker(mgr) {
+			return loadAutoAnalyzeTaskAndExecute(
+				sctx,
+				sa.statsHandle,
+				sa.sysProcTracker,
+				sctx.GetLatestInfoSchema().(infoschema.InfoSchema),
+				autoAnalyzeRatio,
+				pruneMode,
+				lockedTables,
+			)
+		}
+		if extworkload.IsMaster(mgr) {
+			return randomPickOneTableAndRegisterAutoAnalyzeTask(
+				sctx,
+				sa.statsHandle,
+				autoAnalyzeRatio,
+				lockedTables,
+				start,
+				end,
+			)
+		}
+		return false
+	}
+
 	if vardef.EnableAutoAnalyzePriorityQueue.Load() {
 		// During the test, we need to fetch all DML changes before analyzing the highest priority tables.
 		if intest.InTest {
@@ -467,58 +511,112 @@ func RandomPickOneTableAndTryAutoAnalyze(
 				continue
 			}
 
-			pi := tblInfo.GetPartitionInfo()
-			// No partitions, analyze the whole table.
-			if pi == nil {
-				statsTbl, found := statsHandle.GetNonPseudoPhysicalTableStats(tblInfo.ID)
-				if !found {
-					continue
-				}
-
-				sql := "analyze table %n.%n"
-				analyzed := tryAutoAnalyzeTable(sctx, statsHandle, sysProcTracker, tblInfo, statsTbl, autoAnalyzeRatio, sql, db, tblInfo.Name.O)
-				if analyzed {
-					// analyze one table at a time to let it get the freshest parameters.
-					// others will be analyzed next round which is just 3s later.
-					return true
-				}
-				continue
-			}
-			// Only analyze the partition that has not been locked.
-			partitionDefs := make([]model.PartitionDefinition, 0, len(pi.Definitions))
-			for _, def := range pi.Definitions {
-				if _, ok := lockedTables[def.ID]; !ok {
-					partitionDefs = append(partitionDefs, def)
-				}
-			}
-			partitionStats := getPartitionStats(statsHandle, partitionDefs)
-			if pruneMode == variable.Dynamic {
-				analyzed := tryAutoAnalyzePartitionTableInDynamicMode(
-					sctx,
-					statsHandle,
-					sysProcTracker,
-					tblInfo,
-					partitionDefs,
-					partitionStats,
-					db,
-					autoAnalyzeRatio,
-				)
-				if analyzed {
-					return true
-				}
-				continue
-			}
-			for _, def := range partitionDefs {
-				sql := "analyze table %n.%n partition %n"
-				statsTbl := partitionStats[def.ID]
-				analyzed := tryAutoAnalyzeTable(sctx, statsHandle, sysProcTracker, tblInfo, statsTbl, autoAnalyzeRatio, sql, db, tblInfo.Name.O, def.Name.O)
-				if analyzed {
-					return true
-				}
+			if checkAndRunAnalyze(sctx, statsHandle, sysProcTracker, tblInfo, db, pruneMode, lockedTables, autoAnalyzeRatio) {
+				return true
 			}
 		}
 	}
 
+	return false
+}
+
+func randomPickOneTableAndRegisterAutoAnalyzeTask(
+	sctx sessionctx.Context,
+	statsHandle statstypes.StatsHandle,
+	autoAnalyzeRatio float64,
+	lockedTables map[int64]struct{},
+	start, end time.Time,
+) bool {
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
+	dbs := infoschema.AllSchemaNames(is)
+	rd := rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec G404
+	rd.Shuffle(len(dbs), func(i, j int) {
+		dbs[i], dbs[j] = dbs[j], dbs[i]
+	})
+
+	for _, db := range dbs {
+		if metadef.IsMemOrSysDB(strings.ToLower(db)) {
+			continue
+		}
+
+		tbls, err := is.SchemaTableInfos(context.Background(), ast.NewCIStr(db))
+		terror.Log(err)
+		rd.Shuffle(len(tbls), func(i, j int) {
+			tbls[i], tbls[j] = tbls[j], tbls[i]
+		})
+
+		for _, tblInfo := range tbls {
+			if !timeutil.WithinDayTimePeriod(start, end, time.Now()) {
+				return false
+			}
+			if _, ok := lockedTables[tblInfo.ID]; ok {
+				continue
+			}
+			if tblInfo.IsView() {
+				continue
+			}
+
+			registered, err := checkAndRegisterAutoAnalyze(statsHandle, tblInfo, autoAnalyzeRatio)
+			if err != nil {
+				statslogutil.StatsLogger().Error("register auto analyze task failed", zap.Error(err))
+				return false
+			}
+			if registered {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// checkAndRunAnalyze checks and runs analyze for one table.
+func checkAndRunAnalyze(
+	sctx sessionctx.Context,
+	statsHandle statstypes.StatsHandle,
+	sysProcTracker sysproctrack.Tracker,
+	tblInfo *model.TableInfo,
+	db string,
+	pruneMode variable.PartitionPruneMode,
+	lockedTables map[int64]struct{},
+	autoAnalyzeRatio float64,
+) bool {
+	pi := tblInfo.GetPartitionInfo()
+	if pi == nil {
+		statsTbl, found := statsHandle.GetNonPseudoPhysicalTableStats(tblInfo.ID)
+		if !found {
+			return false
+		}
+
+		sql := "analyze table %n.%n"
+		return tryAutoAnalyzeTable(sctx, statsHandle, sysProcTracker, tblInfo, statsTbl, autoAnalyzeRatio, sql, db, tblInfo.Name.O)
+	}
+
+	partitionDefs := make([]model.PartitionDefinition, 0, len(pi.Definitions))
+	for _, def := range pi.Definitions {
+		if _, ok := lockedTables[def.ID]; !ok {
+			partitionDefs = append(partitionDefs, def)
+		}
+	}
+	partitionStats := getPartitionStats(statsHandle, partitionDefs)
+	if pruneMode == variable.Dynamic {
+		return tryAutoAnalyzePartitionTableInDynamicMode(
+			sctx,
+			statsHandle,
+			sysProcTracker,
+			tblInfo,
+			partitionDefs,
+			partitionStats,
+			db,
+			autoAnalyzeRatio,
+		)
+	}
+	for _, def := range partitionDefs {
+		sql := "analyze table %n.%n partition %n"
+		statsTbl := partitionStats[def.ID]
+		if tryAutoAnalyzeTable(sctx, statsHandle, sysProcTracker, tblInfo, statsTbl, autoAnalyzeRatio, sql, db, tblInfo.Name.O, def.Name.O) {
+			return true
+		}
+	}
 	return false
 }
 
@@ -619,6 +717,9 @@ func NeedAnalyzeTable(tbl *statistics.Table, autoAnalyzeRatio float64) (bool, st
 	// Auto analyze is disabled.
 	if autoAnalyzeRatio == 0 {
 		return false, ""
+	}
+	if extworkload.IsAutoAnalyzeWorker(extworkload.GetManager()) {
+		return true, "auto-analyze worker"
 	}
 	// No need to analyze it.
 	tblCnt := float64(tbl.RealtimeCount)

--- a/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
@@ -18,14 +18,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/domain/serverinfo"
+	"github.com/pingcap/tidb/pkg/extworkload"
 	"github.com/pingcap/tidb/pkg/keyspace"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -54,6 +58,55 @@ func WrapAsSCtx(exec *mock.MockRestrictedSQLExecutor) sessionctx.Context {
 	sctx := mockexec.NewContext()
 	sctx.SetValue(mock.RestrictedSQLExecutorKey{}, exec)
 	return sctx
+}
+
+type fakeExternalWorkloadManager struct {
+	role       config.ExternalWorkloadRole
+	registered []uint64
+	recycled   []uint64
+}
+
+func (m *fakeExternalWorkloadManager) Close() error { return nil }
+
+func (m *fakeExternalWorkloadManager) Role() config.ExternalWorkloadRole { return m.role }
+
+func (*fakeExternalWorkloadManager) Meta() *keyspacepb.KeyspaceMeta { return nil }
+
+func (*fakeExternalWorkloadManager) InitializeGCV2(context.Context) error { return nil }
+
+func (*fakeExternalWorkloadManager) AbortGCV2(context.Context) error { return nil }
+
+func (*fakeExternalWorkloadManager) RegisterGCV2(context.Context, uint64, int64) error { return nil }
+
+func (*fakeExternalWorkloadManager) RecycleGCV2(context.Context, uint64) error { return nil }
+
+func (*fakeExternalWorkloadManager) UpdateGCLifeTime(context.Context, int64) error { return nil }
+
+func (*fakeExternalWorkloadManager) RegisterTTLTask(context.Context, int64, bool) error { return nil }
+
+func (*fakeExternalWorkloadManager) DeleteTTLTableInfo(context.Context, int64) error { return nil }
+
+func (*fakeExternalWorkloadManager) RecycleTTLTask(context.Context, uint64) error { return nil }
+
+func (*fakeExternalWorkloadManager) UpdateTTLJobEnable(context.Context, bool) error { return nil }
+
+func (m *fakeExternalWorkloadManager) RegisterAutoAnalyze(_ context.Context, taskID uint64) error {
+	m.registered = append(m.registered, taskID)
+	return nil
+}
+
+func (m *fakeExternalWorkloadManager) RecycleAutoAnalyze(_ context.Context, taskID uint64) error {
+	m.recycled = append(m.recycled, taskID)
+	return nil
+}
+
+func installExternalWorkloadManagerForTest(t *testing.T, mgr extworkload.Manager) {
+	t.Helper()
+	extworkload.ClearManager(extworkload.GetManager())
+	extworkload.InstallManager(mgr)
+	t.Cleanup(func() {
+		extworkload.ClearManager(mgr)
+	})
 }
 
 func TestEnableAutoAnalyzePriorityQueue(t *testing.T) {
@@ -281,6 +334,27 @@ func TestNeedAnalyzeTable(t *testing.T) {
 	}
 }
 
+func TestAutoAnalyzeWorkerTrustsRegisteredTask(t *testing.T) {
+	statsTbl := &statistics.Table{
+		HistColl:           *statistics.NewHistCollWithColsAndIdxs(0, 100, 1, nil, nil),
+		LastAnalyzeVersion: 1,
+	}
+	needAnalyze, reason := autoanalyze.NeedAnalyzeTable(statsTbl, 0.8)
+	require.False(t, needAnalyze)
+	require.Empty(t, reason)
+
+	mgr := &fakeExternalWorkloadManager{role: config.RoleAutoAnalyzeWorker}
+	installExternalWorkloadManagerForTest(t, mgr)
+
+	needAnalyze, reason = autoanalyze.NeedAnalyzeTable(statsTbl, 0.8)
+	require.True(t, needAnalyze)
+	require.Equal(t, "auto-analyze worker", reason)
+
+	needAnalyze, reason = autoanalyze.NeedAnalyzeTable(statsTbl, 0)
+	require.False(t, needAnalyze)
+	require.Empty(t, reason)
+}
+
 func TestAutoAnalyzeSkipColumnTypes(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
@@ -337,6 +411,60 @@ func TestAutoAnalyzeOnEmptyTable(t *testing.T) {
 	tk.MustExec("set global tidb_auto_analyze_start_time='00:00 +0000'")
 	tk.MustExec("set global tidb_auto_analyze_end_time='23:59 +0000'")
 	require.True(t, dom.StatsHandle().HandleAutoAnalyze())
+}
+
+func TestExternalWorkloadMasterRegistersAutoAnalyzeTask(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("insert into t values (1)")
+
+	h := dom.StatsHandle()
+	require.NoError(t, statstestutil.HandleNextDDLEventWithTxn(h))
+	tk.MustExec("flush stats_delta *.*")
+	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+
+	originMinCnt := statistics.AutoAnalyzeMinCnt
+	statistics.AutoAnalyzeMinCnt = 0
+	defer func() {
+		statistics.AutoAnalyzeMinCnt = originMinCnt
+	}()
+
+	oriStart := tk.MustQuery("select @@tidb_auto_analyze_start_time").Rows()[0][0].(string)
+	oriEnd := tk.MustQuery("select @@tidb_auto_analyze_end_time").Rows()[0][0].(string)
+	defer func() {
+		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_start_time='%v'", oriStart))
+		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_end_time='%v'", oriEnd))
+	}()
+	tk.MustExec("set global tidb_auto_analyze_start_time='00:00 +0000'")
+	tk.MustExec("set global tidb_auto_analyze_end_time='23:59 +0000'")
+
+	mgr := &fakeExternalWorkloadManager{role: config.RoleMaster}
+	installExternalWorkloadManagerForTest(t, mgr)
+
+	require.True(t, h.HandleAutoAnalyze())
+	rows := tk.MustQuery("select id from mysql.auto_analyze_tasks").Rows()
+	require.Len(t, rows, 1)
+	taskID, err := strconv.ParseUint(rows[0][0].(string), 10, 64)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{taskID}, mgr.registered)
+}
+
+func TestExternalWorkloadAutoAnalyzeWorkerFinishesMissingTableTask(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("insert into mysql.auto_analyze_tasks(id, table_id, start_time) values (100, 123456789, 10)")
+
+	mgr := &fakeExternalWorkloadManager{role: config.RoleAutoAnalyzeWorker}
+	installExternalWorkloadManagerForTest(t, mgr)
+
+	require.False(t, dom.StatsHandle().HandleAutoAnalyze())
+	require.Equal(t, []uint64{uint64(100)}, mgr.recycled)
+	tk.MustQuery("select count(*) from mysql.auto_analyze_tasks").Check(testkit.Rows("0"))
+	tk.MustQuery("select table_id, analyzed, err from mysql.auto_analyze_tasks_history where id = 100").Check(
+		testkit.Rows("123456789 0 table not found"),
+	)
 }
 
 func TestAutoAnalyzeOutOfSpecifiedTime(t *testing.T) {

--- a/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
@@ -467,6 +467,26 @@ func TestExternalWorkloadAutoAnalyzeWorkerFinishesMissingTableTask(t *testing.T)
 	)
 }
 
+func TestFinishAutoAnalyzeTaskKeepsTaskWhenHistoryInsertFails(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("insert into mysql.auto_analyze_tasks(id, table_id, start_time) values (200, 888, 10)")
+	tk.MustExec("insert into mysql.auto_analyze_tasks_history(id, table_id, analyzed, statement, err, start_time, end_time) " +
+		"values (200, 888, true, '', '', 10, 11)")
+
+	mgr := &fakeExternalWorkloadManager{role: config.RoleAutoAnalyzeWorker}
+	installExternalWorkloadManagerForTest(t, mgr)
+
+	err := dom.StatsHandle().FinishAutoAnalyzeTask(&statistics.AutoAnalyzeTask{
+		ID:        200,
+		TableID:   888,
+		StartTime: 10,
+	})
+	require.Error(t, err)
+	tk.MustQuery("select count(*) from mysql.auto_analyze_tasks where id = 200").Check(testkit.Rows("1"))
+	tk.MustQuery("select count(*) from mysql.auto_analyze_tasks_history where id = 200").Check(testkit.Rows("1"))
+}
+
 func TestAutoAnalyzeOutOfSpecifiedTime(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
@@ -483,6 +483,7 @@ func TestFinishAutoAnalyzeTaskKeepsTaskWhenHistoryInsertFails(t *testing.T) {
 		StartTime: 10,
 	})
 	require.Error(t, err)
+	require.Empty(t, mgr.recycled)
 	tk.MustQuery("select count(*) from mysql.auto_analyze_tasks where id = 200").Check(testkit.Rows("1"))
 	tk.MustQuery("select count(*) from mysql.auto_analyze_tasks_history where id = 200").Check(testkit.Rows("1"))
 }

--- a/pkg/statistics/handle/autoanalyze/autoanalyze_worker.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze_worker.go
@@ -211,12 +211,12 @@ func getAutoAnalyzeTask(sctx sessionctx.Context) (*statistics.AutoAnalyzeTask, e
 
 // FinishAutoAnalyzeTask moves one finished task to history and recycles it from the external workload controller.
 func (sa *statAutoAnalyzeWorker) FinishAutoAnalyzeTask(task *statistics.AutoAnalyzeTask) error {
-	if err := recycleAutoAnalyzeTask(task.ID); err != nil {
-		return errors.Trace(err)
-	}
 	if err := statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		return finishAutoAnalyzeTask(sctx, task)
 	}, statsutil.FlagWrapTxn); err != nil {
+		return errors.Trace(err)
+	}
+	if err := recycleAutoAnalyzeTask(task.ID); err != nil {
 		return errors.Trace(err)
 	}
 	statslogutil.StatsLogger().Info("finished an auto analyze task",

--- a/pkg/statistics/handle/autoanalyze/autoanalyze_worker.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze_worker.go
@@ -36,6 +36,7 @@ import (
 // autoAnalyzeRegInterval is the minimum interval between two auto analyze registrations.
 const (
 	autoAnalyzeRegInterval = 15 * time.Minute
+	autoAnalyzeMgrTimeout  = 10 * time.Second
 	insertAutoAnalyzeTask  = "INSERT INTO mysql.auto_analyze_tasks(table_id, start_time) VALUES(%?, %?)"
 	getAutoAnalyzeJobID    = "SELECT LAST_INSERT_ID()"
 	getAutoAnalyzeJob      = "SELECT id, table_id, start_time FROM mysql.auto_analyze_tasks ORDER BY RAND() LIMIT 1"
@@ -47,12 +48,11 @@ const (
 
 // statAutoAnalyzeWorker manages auto-analyze tasks for external auto-analyze workers.
 type statAutoAnalyzeWorker struct {
-	sync.Mutex
-	statsHandle statstypes.StatsHandle
-
+	statsHandle                 statstypes.StatsHandle
 	autoAnalyzeTaskRegistration sync.Map
 	lastExecutedAutoAnalyzeSQL  string
-	lastAutoAnalyzeSuccessful   bool
+	sync.Mutex
+	lastAutoAnalyzeSuccessful bool
 }
 
 // NewStatAutoAnalyzeWorker creates a new StatsAutoAnalyzeWorker.
@@ -99,7 +99,9 @@ func (sa *statAutoAnalyzeWorker) RegisterAutoAnalyzeTask(tableID int64, reason s
 		if mgr == nil {
 			return errors.New("external workload manager is not installed")
 		}
-		err = mgr.RegisterAutoAnalyze(context.Background(), taskID)
+		ctx, cancel := context.WithTimeout(context.Background(), autoAnalyzeMgrTimeout)
+		defer cancel()
+		err = mgr.RegisterAutoAnalyze(ctx, taskID)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -144,7 +146,9 @@ func recycleAutoAnalyzeTask(taskID uint64) error {
 	if mgr == nil {
 		return errors.New("external workload manager is not installed")
 	}
-	return mgr.RecycleAutoAnalyze(context.Background(), taskID)
+	ctx, cancel := context.WithTimeout(context.Background(), autoAnalyzeMgrTimeout)
+	defer cancel()
+	return mgr.RecycleAutoAnalyze(ctx, taskID)
 }
 
 func getAutoAnalyzeTaskWithTableID(sctx sessionctx.Context, tableID int64) (*statistics.AutoAnalyzeTask, error) {
@@ -212,7 +216,7 @@ func (sa *statAutoAnalyzeWorker) FinishAutoAnalyzeTask(task *statistics.AutoAnal
 	}
 	if err := statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		return finishAutoAnalyzeTask(sctx, task)
-	}); err != nil {
+	}, statsutil.FlagWrapTxn); err != nil {
 		return errors.Trace(err)
 	}
 	statslogutil.StatsLogger().Info("finished an auto analyze task",

--- a/pkg/statistics/handle/autoanalyze/autoanalyze_worker.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze_worker.go
@@ -1,0 +1,356 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autoanalyze
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/extworkload"
+	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/sysproctrack"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/statistics"
+	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
+	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
+	statsutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
+	"go.uber.org/zap"
+)
+
+// autoAnalyzeRegInterval is the minimum interval between two auto analyze registrations.
+const (
+	autoAnalyzeRegInterval = 15 * time.Minute
+	insertAutoAnalyzeTask  = "INSERT INTO mysql.auto_analyze_tasks(table_id, start_time) VALUES(%?, %?)"
+	getAutoAnalyzeJobID    = "SELECT LAST_INSERT_ID()"
+	getAutoAnalyzeJob      = "SELECT id, table_id, start_time FROM mysql.auto_analyze_tasks ORDER BY RAND() LIMIT 1"
+	getAutoAnalyzeJobByTbl = "SELECT id, table_id, start_time FROM mysql.auto_analyze_tasks WHERE table_id = %?"
+	deleteAutoAnalyzeJob   = "DELETE FROM mysql.auto_analyze_tasks WHERE id = %?"
+	insertAutoAnalyzeHist  = "INSERT INTO mysql.auto_analyze_tasks_history(id, table_id, analyzed, " +
+		"statement, err, start_time, end_time) VALUES (%?, %?, %?, %?, %?, %?, %?)"
+)
+
+// statAutoAnalyzeWorker manages auto-analyze tasks for external auto-analyze workers.
+type statAutoAnalyzeWorker struct {
+	sync.Mutex
+	statsHandle statstypes.StatsHandle
+
+	autoAnalyzeTaskRegistration sync.Map
+	lastExecutedAutoAnalyzeSQL  string
+	lastAutoAnalyzeSuccessful   bool
+}
+
+// NewStatAutoAnalyzeWorker creates a new StatsAutoAnalyzeWorker.
+func NewStatAutoAnalyzeWorker(statsHandle statstypes.StatsHandle) statstypes.StatsAutoAnalyzeWorker {
+	return &statAutoAnalyzeWorker{statsHandle: statsHandle}
+}
+
+// RegisterAutoAnalyzeTask registers one auto-analyze task in TiDB and in the external workload controller.
+func (sa *statAutoAnalyzeWorker) RegisterAutoAnalyzeTask(tableID int64, reason string) (err error) {
+	now := time.Now()
+	value, ok := sa.autoAnalyzeTaskRegistration.Load(tableID)
+	if ok {
+		lastRegistered, ok := value.(time.Time)
+		if ok && now.Sub(lastRegistered) < autoAnalyzeRegInterval {
+			statslogutil.StatsLogger().Debug("skip registering an auto analyze task",
+				zap.Int64("table-id", tableID),
+				zap.Duration("min-registration-interval", autoAnalyzeRegInterval),
+				zap.Time("last-registered", lastRegistered),
+				zap.Time("now", now),
+			)
+			return nil
+		}
+	}
+
+	var (
+		taskID             uint64
+		registeredToWorker bool
+		existingTask       *statistics.AutoAnalyzeTask
+	)
+	err = statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
+		existingTask, err = getAutoAnalyzeTaskWithTableID(sctx, tableID)
+		if err != nil {
+			return err
+		}
+		if existingTask != nil {
+			return nil
+		}
+
+		taskID, err = insertAutoAnalyzeJob(sctx, tableID, now.Unix())
+		if err != nil {
+			return err
+		}
+		mgr := extworkload.GetManager()
+		if mgr == nil {
+			return errors.New("external workload manager is not installed")
+		}
+		err = mgr.RegisterAutoAnalyze(context.Background(), taskID)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		registeredToWorker = true
+		return nil
+	}, statsutil.FlagWrapTxn)
+	if err != nil {
+		if registeredToWorker {
+			rollbackErr := recycleAutoAnalyzeTask(taskID)
+			if rollbackErr != nil {
+				statslogutil.StatsLogger().Warn("failed to rollback auto analyze task registration",
+					zap.Uint64("task-id", taskID),
+					zap.Int64("table-id", tableID),
+					zap.Error(rollbackErr),
+				)
+			}
+		}
+		return errors.Trace(err)
+	}
+	if existingTask != nil {
+		statslogutil.StatsLogger().Info("skip registering an auto analyze task, task already exists",
+			zap.Int64("table-id", tableID),
+			zap.Uint64("task-id", existingTask.ID),
+			zap.Int64("start-time", existingTask.StartTime),
+			zap.String("reason", reason),
+		)
+		sa.autoAnalyzeTaskRegistration.Store(tableID, now)
+		return nil
+	}
+
+	sa.autoAnalyzeTaskRegistration.Store(tableID, now)
+	statslogutil.StatsLogger().Info("registered an auto analyze task",
+		zap.Int64("table-id", tableID),
+		zap.Uint64("task-id", taskID),
+		zap.String("reason", reason),
+	)
+	return nil
+}
+
+func recycleAutoAnalyzeTask(taskID uint64) error {
+	mgr := extworkload.GetManager()
+	if mgr == nil {
+		return errors.New("external workload manager is not installed")
+	}
+	return mgr.RecycleAutoAnalyze(context.Background(), taskID)
+}
+
+func getAutoAnalyzeTaskWithTableID(sctx sessionctx.Context, tableID int64) (*statistics.AutoAnalyzeTask, error) {
+	rows, _, err := statsutil.ExecRows(sctx, getAutoAnalyzeJobByTbl, tableID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return &statistics.AutoAnalyzeTask{
+		ID:        rows[0].GetUint64(0),
+		TableID:   rows[0].GetInt64(1),
+		StartTime: rows[0].GetInt64(2),
+	}, nil
+}
+
+func insertAutoAnalyzeJob(sctx sessionctx.Context, tableID int64, startTime int64) (uint64, error) {
+	_, _, err := statsutil.ExecRows(sctx, insertAutoAnalyzeTask, tableID, startTime)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	rows, _, err := statsutil.ExecRows(sctx, getAutoAnalyzeJobID)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	return rows[0].GetUint64(0), nil
+}
+
+// GetAutoAnalyzeTask returns one pending auto-analyze task.
+func (sa *statAutoAnalyzeWorker) GetAutoAnalyzeTask() (*statistics.AutoAnalyzeTask, error) {
+	var (
+		task *statistics.AutoAnalyzeTask
+		err  error
+	)
+	err = statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
+		task, err = getAutoAnalyzeTask(sctx)
+		return err
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return task, nil
+}
+
+func getAutoAnalyzeTask(sctx sessionctx.Context) (*statistics.AutoAnalyzeTask, error) {
+	rows, _, err := statsutil.ExecRows(sctx, getAutoAnalyzeJob)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return &statistics.AutoAnalyzeTask{
+		ID:        rows[0].GetUint64(0),
+		TableID:   rows[0].GetInt64(1),
+		StartTime: rows[0].GetInt64(2),
+	}, nil
+}
+
+// FinishAutoAnalyzeTask moves one finished task to history and recycles it from the external workload controller.
+func (sa *statAutoAnalyzeWorker) FinishAutoAnalyzeTask(task *statistics.AutoAnalyzeTask) error {
+	if err := recycleAutoAnalyzeTask(task.ID); err != nil {
+		return errors.Trace(err)
+	}
+	if err := statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
+		return finishAutoAnalyzeTask(sctx, task)
+	}); err != nil {
+		return errors.Trace(err)
+	}
+	statslogutil.StatsLogger().Info("finished an auto analyze task",
+		zap.Uint64("task-id", task.ID),
+		zap.Int64("table-id", task.TableID),
+	)
+	return nil
+}
+
+func finishAutoAnalyzeTask(sctx sessionctx.Context, task *statistics.AutoAnalyzeTask) error {
+	_, _, err := statsutil.ExecRows(sctx, deleteAutoAnalyzeJob, task.ID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	_, _, err = statsutil.ExecRows(sctx, insertAutoAnalyzeHist,
+		task.ID, task.TableID, task.Analyzed, task.Statement, task.Err, task.StartTime, time.Now().Unix())
+	return errors.Trace(err)
+}
+
+// UpdateLastExecution records the latest auto analyze execution status.
+func (sa *statAutoAnalyzeWorker) UpdateLastExecution(success bool, sql string) {
+	sa.Lock()
+	defer sa.Unlock()
+	sa.lastAutoAnalyzeSuccessful = success
+	sa.lastExecutedAutoAnalyzeSQL = sql
+}
+
+// GetLastExecution returns the latest auto analyze execution status.
+func (sa *statAutoAnalyzeWorker) GetLastExecution() (success bool, sql string) {
+	sa.Lock()
+	defer sa.Unlock()
+	return sa.lastAutoAnalyzeSuccessful, sa.lastExecutedAutoAnalyzeSQL
+}
+
+// loadAutoAnalyzeTaskAndExecute loads one auto analyze task from mysql.auto_analyze_tasks and executes it.
+func loadAutoAnalyzeTaskAndExecute(
+	sctx sessionctx.Context,
+	statsHandle statstypes.StatsHandle,
+	sysProcTracker sysproctrack.Tracker,
+	is infoschema.InfoSchema,
+	autoAnalyzeRatio float64,
+	pruneMode variable.PartitionPruneMode,
+	lockedTables map[int64]struct{},
+) bool {
+	statsHandle.UpdateLastExecution(false, "")
+
+	task, err := statsHandle.GetAutoAnalyzeTask()
+	if err != nil {
+		statslogutil.StatsLogger().Error("get auto analyze task failed", zap.Error(err))
+		return false
+	}
+	if task == nil {
+		return false
+	}
+
+	tbl, exist := is.TableByID(context.Background(), task.TableID)
+	if !exist {
+		statslogutil.StatsLogger().Error("auto analyze table not found", zap.Int64("table-id", task.TableID))
+		task.Err = "table not found"
+		finishTaskWithLog(statsHandle, task)
+		return false
+	}
+	tblInfo := tbl.Meta()
+	dbInfo, exist := is.SchemaByID(tblInfo.DBID)
+	if !exist {
+		statslogutil.StatsLogger().Error("auto analyze database not found", zap.Int64("table-id", task.TableID))
+		task.Err = "database not found"
+		finishTaskWithLog(statsHandle, task)
+		return false
+	}
+	if _, ok := lockedTables[tblInfo.ID]; ok {
+		statslogutil.StatsLogger().Warn("table is locked, wait for next tick", zap.Int64("table-id", tblInfo.ID))
+		return false
+	}
+
+	analyzed := false
+	if checkAndRunAnalyze(sctx, statsHandle, sysProcTracker, tblInfo, dbInfo.Name.O, pruneMode, lockedTables, autoAnalyzeRatio) {
+		task.Analyzed, task.Statement = statsHandle.GetLastExecution()
+		analyzed = true
+	}
+	finishTaskWithLog(statsHandle, task)
+	return analyzed
+}
+
+func finishTaskWithLog(statsHandle statstypes.StatsHandle, task *statistics.AutoAnalyzeTask) {
+	if err := statsHandle.FinishAutoAnalyzeTask(task); err != nil {
+		statslogutil.StatsLogger().Error("finish auto analyze task failed", zap.Error(err))
+	}
+}
+
+// checkAndRegisterAutoAnalyze checks whether the table needs analysis and registers a task when it does.
+func checkAndRegisterAutoAnalyze(
+	statsHandle statstypes.StatsHandle,
+	tblInfo *model.TableInfo,
+	autoAnalyzeRatio float64,
+) (bool, error) {
+	pi := tblInfo.GetPartitionInfo()
+	if pi == nil {
+		statsTbl, found := statsHandle.GetNonPseudoPhysicalTableStats(tblInfo.ID)
+		if !found {
+			return false, nil
+		}
+		if needAnalyze, reason := checkNeedAnalyze(tblInfo, statsTbl, autoAnalyzeRatio); needAnalyze {
+			return true, statsHandle.RegisterAutoAnalyzeTask(tblInfo.ID, reason)
+		}
+		return false, nil
+	}
+
+	for _, def := range pi.Definitions {
+		statsTbl, found := statsHandle.GetNonPseudoPhysicalTableStats(def.ID)
+		if !found {
+			continue
+		}
+		if needAnalyze, reason := checkNeedAnalyze(tblInfo, statsTbl, autoAnalyzeRatio); needAnalyze {
+			return true, statsHandle.RegisterAutoAnalyzeTask(tblInfo.ID, reason)
+		}
+	}
+	return false, nil
+}
+
+func checkNeedAnalyze(
+	tblInfo *model.TableInfo,
+	statsTbl *statistics.Table,
+	autoAnalyzeRatio float64,
+) (bool, string) {
+	if statsTbl == nil || statsTbl.Pseudo || statsTbl.RealtimeCount < statistics.AutoAnalyzeMinCnt {
+		return false, ""
+	}
+	if needAnalyze, reason := NeedAnalyzeTable(statsTbl, autoAnalyzeRatio); needAnalyze {
+		return true, reason
+	}
+	for _, idx := range tblInfo.Indices {
+		if idxStats := statsTbl.GetIdx(idx.ID); idxStats == nil &&
+			!statsTbl.ColAndIdxExistenceMap.HasAnalyzed(idx.ID, true) &&
+			idx.State == model.StatePublic &&
+			!idx.IsColumnarIndex() {
+			return true, "new index"
+		}
+	}
+	return false, ""
+}

--- a/pkg/statistics/handle/autoanalyze/exec/exec.go
+++ b/pkg/statistics/handle/autoanalyze/exec/exec.go
@@ -68,11 +68,11 @@ func AutoAnalyze(
 	_, _, err := RunAnalyzeStmt(sctx, statsHandle, sysProcTracker, statsVer, needVersionRewriteWarn, sql, params...)
 	dur := time.Since(startTime)
 	metrics.AutoAnalyzeHistogram.Observe(dur.Seconds())
+	escaped, err1 := sqlescape.EscapeSQL(sql, params...)
+	if err1 != nil {
+		escaped = ""
+	}
 	if err != nil {
-		escaped, err1 := sqlescape.EscapeSQL(sql, params...)
-		if err1 != nil {
-			escaped = ""
-		}
 		statslogutil.StatsErrVerboseSampleLogger().Error(
 			"auto analyze failed",
 			zap.String("sql", escaped),
@@ -80,9 +80,11 @@ func AutoAnalyze(
 			zap.Error(err),
 		)
 		metrics.AutoAnalyzeCounter.WithLabelValues("failed").Inc()
+		statsHandle.UpdateLastExecution(false, escaped)
 		return false
 	}
 	metrics.AutoAnalyzeCounter.WithLabelValues("succ").Inc()
+	statsHandle.UpdateLastExecution(true, escaped)
 	return true
 }
 

--- a/pkg/statistics/handle/handle.go
+++ b/pkg/statistics/handle/handle.go
@@ -50,6 +50,10 @@ const (
 	StatsOwnerKey = "/tidb/stats/owner"
 	// StatsPrompt is the prompt for stats owner manager.
 	StatsPrompt = "stats"
+	// AutoAnalyzeExecutorOwnerKey is the auto-analyze worker owner path saved to etcd.
+	AutoAnalyzeExecutorOwnerKey = "/tidb/stats/auto-analyze/owner"
+	// AutoAnalyzeExecutorPrompt is the prompt for auto-analyze worker owner manager.
+	AutoAnalyzeExecutorPrompt = "auto-analyze"
 )
 
 // AttachStatsCollector attaches the stats collector for the session.
@@ -91,6 +95,9 @@ type Handle struct {
 
 	// StatsAnalyze is used to handle auto-analyze and manage analyze jobs.
 	types.StatsAnalyze
+
+	// StatsAutoAnalyzeWorker is used to manage external auto-analyze worker tasks.
+	types.StatsAutoAnalyzeWorker
 
 	// StatsSyncLoad is used to load stats syncly.
 	types.StatsSyncLoad
@@ -168,6 +175,7 @@ func NewHandle(
 	handle.StatsCache = statsCache
 	handle.StatsHistory = history.NewStatsHistory(handle)
 	handle.StatsUsage = usage.NewStatsUsageImpl(handle)
+	handle.StatsAutoAnalyzeWorker = autoanalyze.NewStatAutoAnalyzeWorker(handle)
 	handle.StatsAnalyze = autoanalyze.NewStatsAnalyze(ctx, handle, tracker, ddlNotifier)
 	handle.StatsSyncLoad = syncload.NewStatsSyncLoad(handle)
 	handle.StatsGlobal = globalstats.NewStatsGlobal(handle)

--- a/pkg/statistics/handle/handletest/initstats/init_stats_test.go
+++ b/pkg/statistics/handle/handletest/initstats/init_stats_test.go
@@ -266,7 +266,7 @@ func testConcurrentlyInitStats(t *testing.T) {
 	}
 	maxID := maxPhysicalTableID(h, is)
 	if kerneltype.IsClassic() {
-		require.Equal(t, int64(132), maxID)
+		require.Equal(t, int64(136), maxID)
 	} else {
 		// In next-gen, the table ID is different from classic because the system table IDs and the regular table IDs are different,
 		// so the next-gen table ID will be ahead of the classic table ID.

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -198,6 +198,24 @@ type StatsAnalyze interface {
 	Close()
 }
 
+// StatsAutoAnalyzeWorker is used to manage auto-analyze tasks for external workers.
+type StatsAutoAnalyzeWorker interface {
+	// RegisterAutoAnalyzeTask registers an auto-analyze task for the target table.
+	RegisterAutoAnalyzeTask(tableID int64, reason string) error
+
+	// GetAutoAnalyzeTask returns one pending auto-analyze task.
+	GetAutoAnalyzeTask() (*statistics.AutoAnalyzeTask, error)
+
+	// FinishAutoAnalyzeTask moves a task to history and recycles it from the external controller.
+	FinishAutoAnalyzeTask(task *statistics.AutoAnalyzeTask) error
+
+	// UpdateLastExecution records the latest auto analyze execution result.
+	UpdateLastExecution(success bool, sql string)
+
+	// GetLastExecution returns the latest auto analyze execution result.
+	GetLastExecution() (success bool, sql string)
+}
+
 // CacheUpdate encapsulates changes to be made to the stats cache
 type CacheUpdate struct {
 	Updated []*statistics.Table
@@ -519,6 +537,9 @@ type StatsHandle interface {
 
 	// StatsAnalyze is used to handle auto-analyze and manage analyze jobs.
 	StatsAnalyze
+
+	// StatsAutoAnalyzeWorker is used to manage external auto-analyze worker tasks.
+	StatsAutoAnalyzeWorker
 
 	// StatsCache is used to manage all table statistics in memory.
 	StatsCache


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67765 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `mysql.auto_analyze_tasks` and `mysql.auto_analyze_tasks_history` system tables.
  * Auto-analyze can now register, execute, and recycle tasks via an external workload manager when enabled.
* **Bug Fixes**
  * Auto-analyze scheduling now more strictly respects both the global config and runtime switch.
  * Removed config key detection for `performance.run-auto-analyze` so it’s no longer flagged as removed.
* **Chores**
  * Extended bootstrap/upgrade to create the new tables (next-gen bootstrap version 262).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->