### PR TITLE
test: stabilize flaky TestIssue40135Ver2

### DIFF
--- a/pkg/ddl/tests/partition/db_partition_test.go
+++ b/pkg/ddl/tests/partition/db_partition_test.go
@@ -2894,21 +2894,29 @@ func TestIssue40135Ver2(t *testing.T) {
 
 	tk.MustExec("CREATE TABLE t40135 ( a int DEFAULT NULL, b varchar(32) DEFAULT 'md', c varchar(255), index(a)) PARTITION BY HASH (a) PARTITIONS 6")
 	tk.MustExec("insert into t40135 values (1, 'md', '1-md'), (2, 'ma','2-ma'), (3, 'md','3-md'), (4, 'ma','4-ma'), (5, 'md','5-md'), (6, 'ma','6-ma')")
-	one := true
+	tbl := external.GetTableByName(t, tk, "test", "t40135")
+	tableID := tbl.Meta().ID
+	var startAlterOnce sync.Once
+	var deleteOnce sync.Once
 	var checkErr error
 	var wg sync.WaitGroup
 	wg.Add(1)
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeRunOneJobStep", func(job *model.Job) {
+		// beforeRunOneJobStep is global, so keep this hook on the target DDL job.
+		if job.Type != model.ActionModifyColumn || job.TableID != tableID {
+			return
+		}
 		if job.SchemaState == model.StateDeleteOnly {
-			tk3.MustExec("delete from t40135 where a = 1")
+			deleteOnce.Do(func() {
+				tk3.MustExec("delete from t40135 where a = 1")
+			})
 		}
-		if one {
-			one = false
+		startAlterOnce.Do(func() {
 			go func() {
+				defer wg.Done()
 				_, checkErr = tk1.Exec("alter table t40135 modify column a int NULL")
-				wg.Done()
 			}()
-		}
+		})
 	})
 	tk.MustExec("alter table t40135 modify column a bigint NULL DEFAULT '6243108' FIRST")
 	wg.Wait()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68207

Problem Summary:
Flaky test `TestIssue40135Ver2` in `pkg/ddl/tests/partition` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

A global DDL failpoint was treated as test-local, allowing unrelated DDL job steps to consume the hook before the intended partition-column ALTER.

#### Fix

Filtering by target table ID and modify-column action makes the hook observe only the intended DDL boundary while preserving the concurrent ALTER/DML scenario.

#### Verification

Spec:
- target: `pkg/ddl/tests/partition :: TestIssue40135Ver2`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `WRAPPED_GO_TEST`
- wrapper: `./tools/check/failpoint-go-test.sh`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package_surface passed.
build passed.
lint passed.

Gate checklist:
- timing_only_repro: SKIPPED
- target_flaky: PASS
- package_surface: PASS
- build: PASS
- lint: PASS
- ci: SKIPPED

Commands:
- `./tools/check/failpoint-go-test.sh pkg/ddl/tests/partition -json -run '^TestIssue40135Ver2$' -count=1`
- `./tools/check/failpoint-go-test.sh pkg/ddl/tests/partition -json -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved concurrency handling and synchronization mechanisms in partition-related test scenarios.
  * Enhanced test reliability for concurrent database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->