### PR TITLE
test: stabilize flaky TestOwnerDropped

### DIFF
--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -682,7 +682,7 @@ func (c *CheckpointAdvancer) subscribeTick(ctx context.Context) error {
 	if c.subscriber == nil {
 		return nil
 	}
-	failpoint.Inject("get_subscriber", nil)
+	failpoint.InjectCall("get_subscriber")
 	if err := c.subscriber.UpdateStoreTopology(ctx); err != nil {
 		log.Warn("Error when updating store topology.",
 			zap.String("category", "log backup advancer"), logutil.ShortError(err))

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -949,7 +949,6 @@ func TestOwnerDropped(t *testing.T) {
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	installSubscribeSupport(c)
 	env := newTestEnv(c, t)
-	fp := "github.com/pingcap/tidb/br/pkg/streamhelper/get_subscriber"
 	defer func() {
 		if t.Failed() {
 			fmt.Println(c)
@@ -960,18 +959,11 @@ func TestOwnerDropped(t *testing.T) {
 	adv.OnStart(ctx)
 	adv.SpawnSubscriptionHandler(ctx)
 	require.NoError(t, adv.OnTick(ctx))
-	failpoint.Enable(fp, "pause")
-	ch := make(chan struct{})
-	go func() {
-		defer close(ch)
-		require.NoError(t, adv.OnTick(ctx))
-	}()
 	adv.OnStop()
-	failpoint.Disable(fp)
+	require.False(t, adv.HasSubscriptions())
 
 	cp := c.advanceCheckpoints()
-	c.flushAll()
-	<-ch
+	require.NoError(t, adv.OnTick(ctx))
 	adv.WithCheckpoints(func(vsf *spans.ValueSortedFull) {
 		// Advancer will manually poll the checkpoint...
 		require.Equal(t, vsf.MinValue(), cp)

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -949,6 +949,7 @@ func TestOwnerDropped(t *testing.T) {
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	installSubscribeSupport(c)
 	env := newTestEnv(c, t)
+	fp := "github.com/pingcap/tidb/br/pkg/streamhelper/get_subscriber"
 	defer func() {
 		if t.Failed() {
 			fmt.Println(c)
@@ -959,7 +960,69 @@ func TestOwnerDropped(t *testing.T) {
 	adv.OnStart(ctx)
 	adv.SpawnSubscriptionHandler(ctx)
 	require.NoError(t, adv.OnTick(ctx))
-	adv.OnStop()
+	require.True(t, adv.HasSubscriptions())
+
+	enterSubscribeTick := make(chan struct{})
+	releaseSubscribeTick := make(chan struct{})
+	var enterSubscribe sync.Once
+	var cleanup sync.Once
+	require.NoError(t, failpoint.EnableCall(fp, func() {
+		enterSubscribe.Do(func() {
+			close(enterSubscribeTick)
+		})
+		<-releaseSubscribeTick
+	}))
+	releaseHook := func() {
+		cleanup.Do(func() {
+			close(releaseSubscribeTick)
+			require.NoError(t, failpoint.Disable(fp))
+		})
+	}
+	defer func() {
+		releaseHook()
+	}()
+
+	tickDone := make(chan error, 1)
+	go func() {
+		tickDone <- adv.OnTick(ctx)
+	}()
+
+	select {
+	case <-enterSubscribeTick:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for in-flight OnTick to enter subscribeTick")
+	}
+
+	stopStarted := make(chan struct{})
+	stopDone := make(chan struct{})
+	go func() {
+		close(stopStarted)
+		adv.OnStop()
+		close(stopDone)
+	}()
+
+	<-stopStarted
+	select {
+	case <-stopDone:
+		t.Fatal("OnStop returned before subscribeTick was released")
+	default:
+	}
+
+	releaseHook()
+
+	select {
+	case err := <-tickDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for in-flight OnTick to finish")
+	}
+
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for OnStop to finish")
+	}
+
 	require.False(t, adv.HasSubscriptions())
 
 	cp := c.advanceCheckpoints()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67556

Problem Summary:
Flaky test `TestOwnerDropped` in `br/pkg/streamhelper` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The flaky was caused by test synchronization that paused a tick and then blocked cleanup behind the same tick, not by a current product bug.

#### Fix

Synchronous `OnStop` plus `HasSubscriptions` assertion deterministically covers owner-dropped-before-manual-poll behavior without the deadlock-prone pause.

#### Verification

Spec:
- target: `br/pkg/streamhelper :: TestOwnerDropped`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
build passed.
lint passed.

Gate checklist:
- target_flaky: PASS
- failpoint_target: SKIPPED
- package_raw: SKIPPED
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./br/pkg/streamhelper -run '^TestOwnerDropped$' -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

This release includes internal reliability improvements with no user-facing behavior changes.

* **Tests**
  * Reworked subscription-handling verification to deterministically coordinate stop behavior and validate that subscriptions are correctly cleared after stopping.
  * Updated failpoint handling in the test path to use a more precise call-based interception during subscriber initialization/updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->