### PR TITLE
dxf: derive current keyspace when acquiring task runtime

### DIFF
--- a/pkg/dxf/framework/dxfutil/util.go
+++ b/pkg/dxf/framework/dxfutil/util.go
@@ -29,6 +29,8 @@ type sessionProvider interface {
 }
 
 // AcquireTaskRuntime returns a runtime view for the task keyspace and a release function.
+// The sessionProvider must supply sessions whose store keyspace is the current node's keyspace;
+// this is used to detect whether the task belongs to a different keyspace.
 // Callers must call the release function when the returned runtime is no longer used.
 func AcquireTaskRuntime(
 	sessionProvider sessionProvider,
@@ -84,7 +86,7 @@ func CheckTaskRuntime(runtime sqlsvrapi.Runtime, taskKS string) error {
 	return nil
 }
 
-// GenHolderID generate holder ID for a task.
+// GenHolderID generates a holder ID for the given DXF component and task ID.
 func GenHolderID(component string, taskID int64) string {
 	return fmt.Sprintf("DXF/%s/%d", component, taskID)
 }

--- a/pkg/dxf/framework/dxfutil/util.go
+++ b/pkg/dxf/framework/dxfutil/util.go
@@ -32,12 +32,12 @@ type sessionProvider interface {
 // Callers must call the release function when the returned runtime is no longer used.
 func AcquireTaskRuntime(
 	sessionProvider sessionProvider,
-	currentKS string,
 	taskKS string,
 	holderID string,
 ) (sqlsvrapi.Runtime, func(), error) {
 	var taskRuntime sqlsvrapi.Runtime
 	if err := sessionProvider.WithNewSession(func(se sessionctx.Context) error {
+		currentKS := se.GetStore().GetKeyspace()
 		sqlServer := se.GetSQLServer()
 		if taskKS != currentKS {
 			var err2 error
@@ -82,4 +82,9 @@ func CheckTaskRuntime(runtime sqlsvrapi.Runtime, taskKS string) error {
 		return err
 	}
 	return nil
+}
+
+// GenHolderID generate holder ID for a task.
+func GenHolderID(component string, taskID int64) string {
+	return fmt.Sprintf("DXF/%s/%d", component, taskID)
 }

--- a/pkg/dxf/framework/dxfutil/util_test.go
+++ b/pkg/dxf/framework/dxfutil/util_test.go
@@ -74,8 +74,9 @@ func (p *taskSessionProvider) WithNewSession(fn func(se sessionctx.Context) erro
 	return fn(p.se)
 }
 
-func newTaskSessionProvider(server *sqlsvrapimock.MockServer) *taskSessionProvider {
+func newTaskSessionProvider(server *sqlsvrapimock.MockServer, currentKS string) *taskSessionProvider {
 	se := utilmock.NewContext()
+	se.Store = &storeWithKeyspace{keyspace: currentKS}
 	se.BindDomainAndSchValidator(server, nil)
 	return &taskSessionProvider{se: se}
 }
@@ -91,8 +92,7 @@ func TestAcquireTaskRuntime(t *testing.T) {
 		server.EXPECT().GetRuntime().Return(runtime)
 
 		gotRuntime, releaseRuntime, err := AcquireTaskRuntime(
-			newTaskSessionProvider(server),
-			"task_ks",
+			newTaskSessionProvider(server, "task_ks"),
 			"task_ks",
 			"holder",
 		)
@@ -112,8 +112,7 @@ func TestAcquireTaskRuntime(t *testing.T) {
 		server.EXPECT().AcquireKSRuntime("task_ks", "holder").Return(runtimeHandle, nil)
 
 		gotRuntime, releaseRuntime, err := AcquireTaskRuntime(
-			newTaskSessionProvider(server),
-			"current_ks",
+			newTaskSessionProvider(server, "current_ks"),
 			"task_ks",
 			"holder",
 		)
@@ -132,8 +131,7 @@ func TestAcquireTaskRuntime(t *testing.T) {
 		server.EXPECT().AcquireKSRuntime("task_ks", "holder").Return(nil, runtimeErr)
 
 		gotRuntime, releaseRuntime, err := AcquireTaskRuntime(
-			newTaskSessionProvider(server),
-			"current_ks",
+			newTaskSessionProvider(server, "current_ks"),
 			"task_ks",
 			"holder",
 		)
@@ -147,7 +145,6 @@ func TestAcquireTaskRuntime(t *testing.T) {
 
 		gotRuntime, releaseRuntime, err := AcquireTaskRuntime(
 			&taskSessionProvider{err: sessionErr},
-			"current_ks",
 			"task_ks",
 			"holder",
 		)

--- a/pkg/dxf/framework/scheduler/BUILD.bazel
+++ b/pkg/dxf/framework/scheduler/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//pkg/domain/sqlsvrapi",
         "//pkg/domain/sqlsvrapi/mock",
         "//pkg/dxf/framework/dxfmetric",
+        "//pkg/dxf/framework/dxfutil",
         "//pkg/dxf/framework/handle",
         "//pkg/dxf/framework/mock",
         "//pkg/dxf/framework/proto",

--- a/pkg/dxf/framework/scheduler/scheduler_manager.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager.go
@@ -16,7 +16,6 @@ package scheduler
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"time"
 
@@ -352,8 +351,8 @@ func (sm *Manager) startScheduler(basicTask *proto.TaskBase, allocateSlots bool,
 		return
 	}
 
-	holderID := fmt.Sprintf("DXF/scheduler/%d", task.ID)
-	taskRuntime, releaseFn, err := dxfutil.AcquireTaskRuntime(sm.taskMgr, sm.store.GetKeyspace(), task.Keyspace, holderID)
+	holderID := dxfutil.GenHolderID("scheduler", task.ID)
+	taskRuntime, releaseFn, err := dxfutil.AcquireTaskRuntime(sm.taskMgr, task.Keyspace, holderID)
 	if err != nil {
 		sm.logger.Warn("acquire task runtime failed", zap.Int64("task-id", basicTask.ID),
 			zap.String("task-key", basicTask.Key), zap.Error(err))

--- a/pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go
@@ -72,8 +72,10 @@ func expectRuntimeFromNewSession(ctrl *gomock.Controller, taskMgr *mock.MockTask
 	server := sqlsvrapimock.NewMockServer(ctrl)
 	server.EXPECT().GetRuntime().Return(runtime).AnyTimes()
 	taskMgr.EXPECT().WithNewSession(gomock.Any()).DoAndReturn(func(fn func(sessionctx.Context) error) error {
+		se := utilmock.NewContext()
+		se.Store = runtime.Store()
 		return fn(&sessionWithSQLServer{
-			Context: utilmock.NewContext(),
+			Context: se,
 			server:  server,
 		})
 	}).AnyTimes()
@@ -265,7 +267,9 @@ func newCrossKeyspaceStartCase(t *testing.T, taskID int64, taskKey string) *cros
 	server := sqlsvrapimock.NewMockServer(ctrl)
 	taskMgr.EXPECT().GetTaskByID(gomock.Any(), task.ID).Return(task, nil)
 	taskMgr.EXPECT().WithNewSession(gomock.Any()).DoAndReturn(func(fn func(sessionctx.Context) error) error {
-		return fn(&sessionWithSQLServer{Context: utilmock.NewContext(), server: server})
+		se := utilmock.NewContext()
+		se.Store = manager.store
+		return fn(&sessionWithSQLServer{Context: se, server: server})
 	})
 
 	return &crossKeyspaceStartCase{

--- a/pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go
@@ -16,7 +16,6 @@ package scheduler
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -25,6 +24,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/domain/sqlsvrapi"
 	sqlsvrapimock "github.com/pingcap/tidb/pkg/domain/sqlsvrapi/mock"
+	"github.com/pingcap/tidb/pkg/dxf/framework/dxfutil"
 	"github.com/pingcap/tidb/pkg/dxf/framework/mock"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	mockScheduler "github.com/pingcap/tidb/pkg/dxf/framework/scheduler/mock"
@@ -73,6 +73,7 @@ func expectRuntimeFromNewSession(ctrl *gomock.Controller, taskMgr *mock.MockTask
 	server.EXPECT().GetRuntime().Return(runtime).AnyTimes()
 	taskMgr.EXPECT().WithNewSession(gomock.Any()).DoAndReturn(func(fn func(sessionctx.Context) error) error {
 		se := utilmock.NewContext()
+		// Match the mock session store to the runtime so AcquireTaskRuntime takes the local-runtime path.
 		se.Store = runtime.Store()
 		return fn(&sessionWithSQLServer{
 			Context: se,
@@ -290,7 +291,7 @@ func (tc *crossKeyspaceStartCase) expectRuntimeAcquiredAndReleased() *sqlsvrapim
 }
 
 func (tc *crossKeyspaceStartCase) holderID() string {
-	return fmt.Sprintf("DXF/scheduler/%d", tc.task.ID)
+	return dxfutil.GenHolderID("scheduler", tc.task.ID)
 }
 
 func TestStartSchedulerCrossKeyspaceRuntime(t *testing.T) {

--- a/pkg/dxf/framework/taskexecutor/BUILD.bazel
+++ b/pkg/dxf/framework/taskexecutor/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
     deps = [
         "//pkg/domain/sqlsvrapi",
         "//pkg/domain/sqlsvrapi/mock",
+        "//pkg/dxf/framework/dxfutil",
         "//pkg/dxf/framework/mock",
         "//pkg/dxf/framework/mock/execute",
         "//pkg/dxf/framework/proto",

--- a/pkg/dxf/framework/taskexecutor/manager.go
+++ b/pkg/dxf/framework/taskexecutor/manager.go
@@ -16,7 +16,6 @@ package taskexecutor
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -331,8 +330,8 @@ func (m *Manager) startTaskExecutor(taskBase *proto.TaskBase) (executorStarted b
 		}
 	}()
 
-	holderID := fmt.Sprintf("DXF/executor/%d", task.ID)
-	taskRuntime, releaseFn, err := dxfutil.AcquireTaskRuntime(m.taskTable, m.store.GetKeyspace(), task.Keyspace, holderID)
+	holderID := dxfutil.GenHolderID("executor", task.ID)
+	taskRuntime, releaseFn, err := dxfutil.AcquireTaskRuntime(m.taskTable, task.Keyspace, holderID)
 	if err != nil {
 		m.logger.Warn("acquire task runtime failed", zap.Int64("task-id", taskBase.ID),
 			zap.String("task-key", taskBase.Key), zap.Error(err))

--- a/pkg/dxf/framework/taskexecutor/manager_test.go
+++ b/pkg/dxf/framework/taskexecutor/manager_test.go
@@ -68,8 +68,10 @@ func expectRuntimeFromNewSession(ctrl *gomock.Controller, taskTable *mock.MockTa
 	server := sqlsvrapimock.NewMockServer(ctrl)
 	server.EXPECT().GetRuntime().Return(runtime).AnyTimes()
 	taskTable.EXPECT().WithNewSession(gomock.Any()).DoAndReturn(func(fn func(sessionctx.Context) error) error {
+		se := utilmock.NewContext()
+		se.Store = runtime.Store()
 		return fn(&sessionWithSQLServer{
-			Context: utilmock.NewContext(),
+			Context: se,
 			server:  server,
 		})
 	}).AnyTimes()
@@ -224,7 +226,9 @@ func newCrossKeyspaceStartCase(t *testing.T, taskID int64, taskKey string) *cros
 	server := sqlsvrapimock.NewMockServer(ctrl)
 	taskTable.EXPECT().GetTaskByID(gomock.Any(), task.ID).Return(task, nil)
 	taskTable.EXPECT().WithNewSession(gomock.Any()).DoAndReturn(func(fn func(sessionctx.Context) error) error {
-		return fn(&sessionWithSQLServer{Context: utilmock.NewContext(), server: server})
+		se := utilmock.NewContext()
+		se.Store = m.store
+		return fn(&sessionWithSQLServer{Context: se, server: server})
 	})
 
 	return &crossKeyspaceStartCase{
@@ -685,7 +689,9 @@ func TestStartTaskExecutorResolveTaskRuntimeFromTaskKeyspace(t *testing.T) {
 	})
 	mockTaskTable.EXPECT().GetTaskByID(gomock.Any(), task.ID).Return(task, nil)
 	mockTaskTable.EXPECT().WithNewSession(gomock.Any()).DoAndReturn(func(fn func(sessionctx.Context) error) error {
-		return fn(&sessionWithSQLServer{Context: utilmock.NewContext(), server: server})
+		se := utilmock.NewContext()
+		se.Store = m.store
+		return fn(&sessionWithSQLServer{Context: se, server: server})
 	})
 	mockExecutor.EXPECT().Init(gomock.Any()).Return(nil)
 	runCh := make(chan struct{})
@@ -736,7 +742,9 @@ func TestStartTaskExecutorResolveTaskRuntimeError(t *testing.T) {
 
 	mockTaskTable.EXPECT().GetTaskByID(gomock.Any(), task.ID).Return(task, nil)
 	mockTaskTable.EXPECT().WithNewSession(gomock.Any()).DoAndReturn(func(fn func(sessionctx.Context) error) error {
-		return fn(&sessionWithSQLServer{Context: utilmock.NewContext(), server: server})
+		se := utilmock.NewContext()
+		se.Store = m.store
+		return fn(&sessionWithSQLServer{Context: se, server: server})
 	})
 
 	require.False(t, m.startTaskExecutor(&task.TaskBase))

--- a/pkg/dxf/framework/taskexecutor/manager_test.go
+++ b/pkg/dxf/framework/taskexecutor/manager_test.go
@@ -17,12 +17,12 @@ package taskexecutor
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/domain/sqlsvrapi"
 	sqlsvrapimock "github.com/pingcap/tidb/pkg/domain/sqlsvrapi/mock"
+	"github.com/pingcap/tidb/pkg/dxf/framework/dxfutil"
 	"github.com/pingcap/tidb/pkg/dxf/framework/mock"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
@@ -249,7 +249,7 @@ func (tc *crossKeyspaceStartCase) expectRuntimeAcquiredAndReleased() *sqlsvrapim
 }
 
 func (tc *crossKeyspaceStartCase) holderID() string {
-	return fmt.Sprintf("DXF/executor/%d", tc.task.ID)
+	return dxfutil.GenHolderID("executor", tc.task.ID)
 }
 
 func TestStartTaskExecutorCrossKeyspaceRuntime(t *testing.T) {
@@ -679,7 +679,7 @@ func TestStartTaskExecutorResolveTaskRuntimeFromTaskKeyspace(t *testing.T) {
 	runtimeHandle := newRuntimeHandle(ctrl, taskStore)
 	runtimeHandle.EXPECT().Release()
 	server := sqlsvrapimock.NewMockServer(ctrl)
-	server.EXPECT().AcquireKSRuntime(taskKS, "DXF/executor/1").Return(runtimeHandle, nil)
+	server.EXPECT().AcquireKSRuntime(taskKS, dxfutil.GenHolderID("executor", task.ID)).Return(runtimeHandle, nil)
 
 	mockExecutor := mock.NewMockTaskExecutor(ctrl)
 	var gotStore kv.Storage
@@ -733,7 +733,7 @@ func TestStartTaskExecutorResolveTaskRuntimeError(t *testing.T) {
 
 	runtimeErr := errors.New("ks runtime not found")
 	server := sqlsvrapimock.NewMockServer(ctrl)
-	server.EXPECT().AcquireKSRuntime(taskKS, "DXF/executor/2").Return(nil, runtimeErr)
+	server.EXPECT().AcquireKSRuntime(taskKS, dxfutil.GenHolderID("executor", task.ID)).Return(nil, runtimeErr)
 	factoryCalled := false
 	RegisterTaskType(task.Type, func(context.Context, *proto.Task, Param) TaskExecutor {
 		factoryCalled = true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #69182

Problem Summary:

DXF scheduler and taskexecutor runtime acquisition used the manager store keyspace as the current keyspace. When a task session is created for the runtime lookup, the actual current keyspace should come from that session's store so cross-keyspace runtime acquisition is based on the session that is doing the lookup.

### What changed and how does it work?

- Derive the current keyspace inside `dxfutil.AcquireTaskRuntime` from `se.GetStore().GetKeyspace()`.
- Remove the current-keyspace parameter from scheduler and taskexecutor call sites.
- Add a shared `dxfutil.GenHolderID` helper for scheduler and executor runtime holder IDs.
- Update DXF runtime acquisition tests so mocked sessions expose the expected keyspace store.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test commands:

```bash
make bazel_prepare
go test -run TestAcquireTaskRuntime -tags=intest,deadlock -count=1 ./pkg/dxf/framework/dxfutil
./tools/check/failpoint-go-test.sh pkg/dxf/framework/scheduler -run TestStartSchedulerCrossKeyspaceRuntime -count=1
./tools/check/failpoint-go-test.sh pkg/dxf/framework/taskexecutor -run 'TestStartTaskExecutor(CrossKeyspaceRuntime|ResolveTaskRuntime(FromTaskKeyspace|Error))' -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task runtime acquisition now derives “current keyspace” from the active session to select the correct runtime automatically.
  * Introduced a standardized holder ID format for task runtime acquisition across scheduler and executor flows.

* **Bug Fixes**
  * Improved cross-keyspace runtime selection to better align task execution with the active session context.
  * Updated scheduler and task-executor runtime acquisition to use the standardized holder ID generation consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->