### PR TITLE
executor, planner: improve plan replayer dump URL output

### DIFF
--- a/pkg/domain/plan_replayer_dump.go
+++ b/pkg/domain/plan_replayer_dump.go
@@ -440,9 +440,6 @@ func setTaskPresignedURL(ctx context.Context, task *PlanReplayerDumpTask) {
 const (
 	// PlanReplayerPresignExpire is how long a plan replayer presigned download URL stays valid.
 	PlanReplayerPresignExpire = time.Hour
-	// PlanReplayerPresignExpireDesc is the human-readable form of PlanReplayerPresignExpire shown
-	// to users. It MUST be kept in sync with PlanReplayerPresignExpire.
-	PlanReplayerPresignExpireDesc = "1 hour"
 )
 
 func getPresignedURL(ctx context.Context, task *PlanReplayerDumpTask) (string, error) {

--- a/pkg/domain/plan_replayer_dump.go
+++ b/pkg/domain/plan_replayer_dump.go
@@ -437,12 +437,20 @@ func setTaskPresignedURL(ctx context.Context, task *PlanReplayerDumpTask) {
 	task.PresignedURL = url
 }
 
+const (
+	// PlanReplayerPresignExpire is how long a plan replayer presigned download URL stays valid.
+	PlanReplayerPresignExpire = time.Hour
+	// PlanReplayerPresignExpireDesc is the human-readable form of PlanReplayerPresignExpire shown
+	// to users. It MUST be kept in sync with PlanReplayerPresignExpire.
+	PlanReplayerPresignExpireDesc = "1 hour"
+)
+
 func getPresignedURL(ctx context.Context, task *PlanReplayerDumpTask) (string, error) {
 	storage, err := extstore.GetGlobalExtStorage(ctx)
 	if err != nil {
 		return "", err
 	}
-	return storage.PresignFile(ctx, filepath.Join(replayer.GetPlanReplayerDirName(), task.FileName), 1*time.Hour)
+	return storage.PresignFile(ctx, filepath.Join(replayer.GetPlanReplayerDirName(), task.FileName), PlanReplayerPresignExpire)
 }
 
 func dumpSQLMeta(zw *zip.Writer, task *PlanReplayerDumpTask) error {

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -140,7 +140,7 @@ func appendPlanReplayerDumpResult(req *chunk.Chunk, token string) {
 	if isPlanReplayerDownloadURL(token) {
 		rows := [][2]string{
 			{"Download URL", token},
-			{"Expires in", domain.PlanReplayerPresignExpireDesc},
+			{"Expires in", domain.PlanReplayerPresignExpire.String()},
 			{"Browser", "Open the Download URL directly before it expires"},
 			{"curl", fmt.Sprintf("curl -L '%s' -o plan_replayer.zip", token)},
 			{"Note", "If the URL expires, rerun PLAN REPLAYER DUMP to get a new one"},

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -132,11 +132,15 @@ func (e *PlanReplayerExec) Next(ctx context.Context, req *chunk.Chunk) (err erro
 	return nil
 }
 
+// appendPlanReplayerDumpResult renders the `PLAN REPLAYER DUMP` result as Item/Value rows.
+// When the token is a presigned download URL (remote object storage on TiDB Cloud), the result
+// carries usage guidance plus the URL's validity window; otherwise it is the raw file token used
+// to fetch the dump from local storage.
 func appendPlanReplayerDumpResult(req *chunk.Chunk, token string) {
 	if isPlanReplayerDownloadURL(token) {
 		rows := [][2]string{
 			{"Download URL", token},
-			{"Expires in", "1 hour"},
+			{"Expires in", domain.PlanReplayerPresignExpireDesc},
 			{"Browser", "Open the Download URL directly before it expires"},
 			{"curl", fmt.Sprintf("curl -L '%s' -o plan_replayer.zip", token)},
 			{"Note", "If the URL expires, rerun PLAN REPLAYER DUMP to get a new one"},
@@ -151,6 +155,9 @@ func appendPlanReplayerDumpResult(req *chunk.Chunk, token string) {
 	req.AppendString(1, token)
 }
 
+// isPlanReplayerDownloadURL reports whether token is a presigned download URL rather than a local
+// file token. Local/in-memory storage backends return a bare file name from PresignFile, so an
+// http(s) scheme with a host is what distinguishes a real download URL.
 func isPlanReplayerDownloadURL(token string) bool {
 	u, err := url.Parse(token)
 	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 
@@ -126,9 +127,33 @@ func (e *PlanReplayerExec) Next(ctx context.Context, req *chunk.Chunk) (err erro
 	if err != nil {
 		return err
 	}
-	req.AppendString(0, e.Ctx().GetSessionVars().LastPlanReplayerToken)
+	appendPlanReplayerDumpResult(req, e.Ctx().GetSessionVars().LastPlanReplayerToken)
 	e.endFlag = true
 	return nil
+}
+
+func appendPlanReplayerDumpResult(req *chunk.Chunk, token string) {
+	if isPlanReplayerDownloadURL(token) {
+		rows := [][2]string{
+			{"Download URL", token},
+			{"Expires in", "1 hour"},
+			{"Browser", "Open the Download URL directly before it expires"},
+			{"curl", fmt.Sprintf("curl -L '%s' -o plan_replayer.zip", token)},
+			{"Note", "If the URL expires, rerun PLAN REPLAYER DUMP to get a new one"},
+		}
+		for _, row := range rows {
+			req.AppendString(0, row[0])
+			req.AppendString(1, row[1])
+		}
+		return
+	}
+	req.AppendString(0, "File token")
+	req.AppendString(1, token)
+}
+
+func isPlanReplayerDownloadURL(token string) bool {
+	u, err := url.Parse(token)
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
 }
 
 func (e *PlanReplayerExec) removeCaptureTask(ctx context.Context) error {

--- a/pkg/executor/test/planreplayer/BUILD.bazel
+++ b/pkg/executor/test/planreplayer/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "plan_replayer_test.go",
     ],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/config",
         "//pkg/meta/autoid",

--- a/pkg/executor/test/planreplayer/BUILD.bazel
+++ b/pkg/executor/test/planreplayer/BUILD.bazel
@@ -12,9 +12,9 @@ go_test(
     deps = [
         "//pkg/config",
         "//pkg/meta/autoid",
+        "//pkg/objstore/storeapi",
         "//pkg/planner/extstore",
         "//pkg/testkit",
-        "//pkg/testkit/testdata",
         "//pkg/testkit/testsetup",
         "//pkg/util/replayer",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/pkg/executor/test/planreplayer/plan_replayer_test.go
+++ b/pkg/executor/test/planreplayer/plan_replayer_test.go
@@ -302,7 +302,7 @@ func TestPlanReplayerDumpPresignedURLOutput(t *testing.T) {
 	tk.MustExec("create table t_presign(a int)")
 	tk.MustQuery("plan replayer dump explain select * from t_presign").Check(testkit.RowsWithSep("|",
 		"Download URL|"+presignedURL,
-		"Expires in|1 hour",
+		"Expires in|1h0m0s",
 		"Browser|Open the Download URL directly before it expires",
 		"curl|curl -L '"+presignedURL+"' -o plan_replayer.zip",
 		"Note|If the URL expires, rerun PLAN REPLAYER DUMP to get a new one",

--- a/pkg/executor/test/planreplayer/plan_replayer_test.go
+++ b/pkg/executor/test/planreplayer/plan_replayer_test.go
@@ -23,12 +23,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/pingcap/tidb/pkg/planner/extstore"
 	"github.com/pingcap/tidb/pkg/testkit"
-	"github.com/pingcap/tidb/pkg/testkit/testdata"
 	"github.com/pingcap/tidb/pkg/util/replayer"
 	"github.com/stretchr/testify/require"
 )
@@ -56,6 +57,25 @@ func checkFileName(s string) bool {
 		}
 	}
 	return false
+}
+
+type planReplayerPresignStorage struct {
+	storeapi.Storage
+	url string
+}
+
+func (s planReplayerPresignStorage) PresignFile(context.Context, string, time.Duration) (string, error) {
+	return s.url, nil
+}
+
+func requirePlanReplayerFileToken(t *testing.T, rows [][]any) string {
+	require.Len(t, rows, 1)
+	require.Len(t, rows[0], 2)
+	require.Equal(t, "File token", rows[0][0])
+	token, ok := rows[0][1].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, token)
+	return token
 }
 
 func TestPlanReplayer(t *testing.T) {
@@ -209,9 +229,9 @@ func TestPlanReplayerDumpSingle(t *testing.T) {
 	tk.MustExec("drop table if exists t_dump_single")
 	tk.MustExec("create table t_dump_single(a int)")
 	res := tk.MustQuery("plan replayer dump explain select * from t_dump_single")
-	path := testdata.ConvertRowsToStrings(res.Rows())
+	fileName := requirePlanReplayerFileToken(t, res.Rows())
 
-	filePath := filepath.Join(replayer.GetPlanReplayerDirName(), path[0])
+	filePath := filepath.Join(replayer.GetPlanReplayerDirName(), fileName)
 	fileReader, err := storage.Open(ctx, filePath, nil)
 	require.NoError(t, err)
 	defer fileReader.Close()
@@ -246,12 +266,11 @@ func TestExplainExploreReplayer(t *testing.T) {
 	tk.MustExec("analyze table t_explain_explore_replayer")
 	tk.MustExec("create global binding using select * from test.t_explain_explore_replayer where b=1")
 	res := tk.MustQuery("plan replayer dump explain select * from test.t_explain_explore_replayer where b=1")
-	path := testdata.ConvertRowsToStrings(res.Rows())
-	require.Len(t, path, 1)
+	fileName := requirePlanReplayerFileToken(t, res.Rows())
 
 	loadStore := testkit.CreateMockStore(t)
 	loadTK := testkit.NewTestKit(t, loadStore)
-	replayerPath := filepath.Join(tempDir, replayer.GetPlanReplayerDirName(), path[0])
+	replayerPath := filepath.Join(tempDir, replayer.GetPlanReplayerDirName(), fileName)
 	replayerPath = strings.ReplaceAll(replayerPath, "'", "''")
 	for range 2 {
 		rows := loadTK.MustQuery(fmt.Sprintf("explain explore replayer '%s'", replayerPath)).Rows()
@@ -260,6 +279,35 @@ func TestExplainExploreReplayer(t *testing.T) {
 			require.NotEmpty(t, row[3])
 		}
 	}
+}
+
+func TestPlanReplayerDumpPresignedURLOutput(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	storage, err := extstore.NewExtStorage(ctx, "file://"+tempDir, "")
+	require.NoError(t, err)
+	const presignedURL = "https://example.com/replayer.zip?X-Amz-Expires=3600&X-Amz-Signature=test"
+	extstore.SetGlobalExtStorageForTest(planReplayerPresignStorage{
+		Storage: storage,
+		url:     presignedURL,
+	})
+	defer func() {
+		extstore.SetGlobalExtStorageForTest(nil)
+		storage.Close()
+	}()
+
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_presign(a int)")
+	tk.MustQuery("plan replayer dump explain select * from t_presign").Check(testkit.RowsWithSep("|",
+		"Download URL|"+presignedURL,
+		"Expires in|1 hour",
+		"Browser|Open the Download URL directly before it expires",
+		"curl|curl -L '"+presignedURL+"' -o plan_replayer.zip",
+		"Note|If the URL expires, rerun PLAN REPLAYER DUMP to get a new one",
+	))
+	require.Equal(t, presignedURL, tk.Session().GetSessionVars().LastPlanReplayerToken)
 }
 
 func TestPlanReplayerDumpMultipleError(t *testing.T) {
@@ -341,10 +389,9 @@ func TestPlanReplayerDumpMultiple(t *testing.T) {
 	}
 	sqlCmd := "plan replayer dump explain (" + strings.Join(stmts, ", ") + ")"
 	res := tk.MustQuery(sqlCmd)
-	path := testdata.ConvertRowsToStrings(res.Rows())
-	require.Len(t, path, 1)
+	fileName := requirePlanReplayerFileToken(t, res.Rows())
 
-	filePath := filepath.Join(replayer.GetPlanReplayerDirName(), path[0])
+	filePath := filepath.Join(replayer.GetPlanReplayerDirName(), fileName)
 	fileReader, err := storage.Open(ctx, filePath, nil)
 	require.NoError(t, err)
 	defer fileReader.Close()

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -6143,8 +6143,9 @@ func (b *PlanBuilder) buildPlanReplayer(pc *ast.PlanReplayerStmt) base.Plan {
 		p.HistoricalStatsTS = calcTSForPlanReplayer(b.ctx, pc.HistoricalStatsInfo.TsExpr)
 	}
 
-	schema := newColumnsWithNames(1)
-	schema.Append(buildColumnWithName("", "File_token", mysql.TypeVarchar, 128))
+	schema := newColumnsWithNames(2)
+	schema.Append(buildColumnWithName("", "Item", mysql.TypeVarchar, 32))
+	schema.Append(buildColumnWithName("", "Value", mysql.TypeVarchar, mysql.MaxBlobWidth))
 	p.SetSchema(schema.col2Schema())
 	p.SetOutputNames(schema.names)
 	return p

--- a/pkg/server/handler/optimizor/plan_replayer_test.go
+++ b/pkg/server/handler/optimizor/plan_replayer_test.go
@@ -94,6 +94,16 @@ func requirePlanReplayerFileTokenFromRows(t *testing.T, rows *sql.Rows) string {
 	return filename
 }
 
+func requirePlanReplayerFileTokenFromResult(t *testing.T, rows [][]any) string {
+	require.Len(t, rows, 1)
+	require.Len(t, rows[0], 2)
+	require.Equal(t, "File token", rows[0][0])
+	filename, ok := rows[0][1].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, filename)
+	return filename
+}
+
 func requireSingleStringFromRows(t *testing.T, rows *sql.Rows) string {
 	require.True(t, rows.Next(), "unexpected data")
 	var value string
@@ -986,9 +996,9 @@ func TestDumpPlanReplayerAPIWithHistoryStats(t *testing.T) {
 	query := "select * from t where a > 1"
 
 	// 2-1. specify time1 to get the plan replayer
-	filename1 := tk.MustQuery(
+	filename1 := requirePlanReplayerFileTokenFromResult(t, tk.MustQuery(
 		fmt.Sprintf(template, strconv.FormatUint(ts1, 10), query),
-	).Rows()[0][0].(string)
+	).Rows())
 	zip1 := fetchZipFromPlanReplayerAPI(t, client, filename1)
 	jsonTbls1, metas1, errMsg1 := getInfoFromPlanReplayerZip(t, zip1)
 
@@ -1009,9 +1019,9 @@ func TestDumpPlanReplayerAPIWithHistoryStats(t *testing.T) {
 	require.Equal(t, []string{"Historical stats for test.t are unavailable, fallback to latest stats", ""}, errMsg1)
 
 	// 2-2. specify time2 to get the plan replayer
-	filename2 := tk.MustQuery(
+	filename2 := requirePlanReplayerFileTokenFromResult(t, tk.MustQuery(
 		fmt.Sprintf(template, time2.Format("2006-01-02 15:04:05.000000"), query),
-	).Rows()[0][0].(string)
+	).Rows())
 	zip2 := fetchZipFromPlanReplayerAPI(t, client, filename2)
 	jsonTbls2, metas2, errMsg2 := getInfoFromPlanReplayerZip(t, zip2)
 
@@ -1033,9 +1043,9 @@ func TestDumpPlanReplayerAPIWithHistoryStats(t *testing.T) {
 	require.Empty(t, errMsg2)
 
 	// 2-3. specify time3 to get the plan replayer
-	filename3 := tk.MustQuery(
+	filename3 := requirePlanReplayerFileTokenFromResult(t, tk.MustQuery(
 		fmt.Sprintf(template, time3.Format("2006-01-02T15:04:05.000000Z07:00"), query),
-	).Rows()[0][0].(string)
+	).Rows())
 	zip3 := fetchZipFromPlanReplayerAPI(t, client, filename3)
 	jsonTbls3, metas3, errMsg3 := getInfoFromPlanReplayerZip(t, zip3)
 

--- a/pkg/server/handler/optimizor/plan_replayer_test.go
+++ b/pkg/server/handler/optimizor/plan_replayer_test.go
@@ -84,6 +84,24 @@ var expectedFilesInReplayerForCapture = []string{
 	"variables.toml",
 }
 
+func requirePlanReplayerFileTokenFromRows(t *testing.T, rows *sql.Rows) string {
+	require.True(t, rows.Next(), "unexpected data")
+	var item, filename string
+	require.NoError(t, rows.Scan(&item, &filename))
+	require.Equal(t, "File token", item)
+	require.NotEmpty(t, filename)
+	require.NoError(t, rows.Close())
+	return filename
+}
+
+func requireSingleStringFromRows(t *testing.T, rows *sql.Rows) string {
+	require.True(t, rows.Next(), "unexpected data")
+	var value string
+	require.NoError(t, rows.Scan(&value))
+	require.NoError(t, rows.Close())
+	return value
+}
+
 func prepareServerAndClientForTest(t *testing.T, store kv.Storage, dom *domain.Domain) (srv *server.Server, client *testserverclient.TestServerClient) {
 	driver := server.NewTiDBDriver(store)
 	client = testserverclient.NewTestServerClient()
@@ -273,10 +291,7 @@ func TestPlanReplayerLoadWithSemicolonInColumnComment(t *testing.T) {
 	tk.MustExec("create table t(k1 int, k2 int comment 'xx;xxx')")
 	tk.MustExec("analyze table t")
 	rows := tk.MustQuery("plan replayer dump explain select * from t")
-	require.True(t, rows.Next(), "unexpected data")
-	var filename string
-	require.NoError(t, rows.Scan(&filename))
-	require.NoError(t, rows.Close())
+	filename := requirePlanReplayerFileTokenFromRows(t, rows)
 
 	resp, err := client.FetchStatus(filepath.Join("/plan_replayer/dump/", filename))
 	require.NoError(t, err)
@@ -348,15 +363,9 @@ func prepareData4PlanReplayer(t *testing.T, client *testserverclient.TestServerC
 	tk.MustExec("flush stats_delta *.*")
 	tk.MustExec("analyze table tt")
 	rows := tk.MustQuery("plan replayer dump explain select * from t")
-	require.True(t, rows.Next(), "unexpected data")
-	var filename string
-	require.NoError(t, rows.Scan(&filename))
-	require.NoError(t, rows.Close())
+	filename := requirePlanReplayerFileTokenFromRows(t, rows)
 	rows = tk.MustQuery("select @@tidb_last_plan_replayer_token")
-	require.True(t, rows.Next(), "unexpected data")
-	var filename2 string
-	require.NoError(t, rows.Scan(&filename2))
-	require.NoError(t, rows.Close())
+	filename2 := requireSingleStringFromRows(t, rows)
 	require.Equal(t, filename, filename2)
 
 	tk.MustExec("plan replayer capture 'e5796985ccafe2f71126ed6c0ac939ffa015a8c0744a24b7aee6d587103fd2f7' '*'")
@@ -600,15 +609,9 @@ func prepareData4Issue43192(t *testing.T, client *testserverclient.TestServerCli
 	require.NoError(t, err)
 	tk.MustExec("create global binding for select a, b from t where a in (1, 2, 3) using select a, b from t use index (ib) where a in (1, 2, 3)")
 	rows := tk.MustQuery("plan replayer dump explain select a, b from t where a in (1, 2, 3)")
-	require.True(t, rows.Next(), "unexpected data")
-	var filename string
-	require.NoError(t, rows.Scan(&filename))
-	require.NoError(t, rows.Close())
+	filename := requirePlanReplayerFileTokenFromRows(t, rows)
 	rows = tk.MustQuery("select @@tidb_last_plan_replayer_token")
-	require.True(t, rows.Next(), "unexpected data")
-	var token string
-	require.NoError(t, rows.Scan(&token))
-	require.NoError(t, rows.Close())
+	token := requireSingleStringFromRows(t, rows)
 	require.Equal(t, filename, token)
 
 	// Cleanup the binding created for dumping to avoid interference when the same server later loads the replayer file.
@@ -673,12 +676,9 @@ func prepareData4Issue56458(t *testing.T, client *testserverclient.TestServerCli
 	tk.MustExec(`SET FOREIGN_KEY_CHECKS = 1;`)
 	tk.MustExec("create global binding for select a, b from t where a in (1, 2, 3) using select a, b from t use index (ib) where a in (1, 2, 3)")
 	rows := tk.MustQuery("plan replayer dump explain select a, b from t where a in (1, 2, 3)")
-	require.True(t, rows.Next(), "unexpected data")
-	var filename string
-	require.NoError(t, rows.Scan(&filename))
-	require.NoError(t, rows.Close())
+	filename := requirePlanReplayerFileTokenFromRows(t, rows)
 	rows = tk.MustQuery("select @@tidb_last_plan_replayer_token")
-	require.True(t, rows.Next(), "unexpected data")
+	require.Equal(t, filename, requireSingleStringFromRows(t, rows))
 	return filename
 }
 
@@ -735,12 +735,9 @@ JOIN test_table t2 ON t1.id = t2.id;
 		}()
 	}
 	rows := tk.MustQuery("plan replayer dump explain SELECT t1.id, IFNULL(t1.value1, 0) AS value1, IFNULL(t2.value2, 0) AS value2 FROM test_table t1 JOIN test_table t2 ON t1.id = t2.id;")
-	require.True(t, rows.Next(), "unexpected data")
-	var filename string
-	require.NoError(t, rows.Scan(&filename))
-	require.NoError(t, rows.Close())
+	filename := requirePlanReplayerFileTokenFromRows(t, rows)
 	rows = tk.MustQuery("select @@tidb_last_plan_replayer_token")
-	require.True(t, rows.Next(), "unexpected data")
+	require.Equal(t, filename, requireSingleStringFromRows(t, rows))
 	return filename
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69438

Problem Summary:

In TiDB Cloud, `PLAN REPLAYER DUMP` may return a presigned download URL, but the old result only showed it as `File_token`. Users were not told that the URL can be opened directly, used with curl, or that it expires after 1 hour.

### What changed and how does it work?

This PR changes the `PLAN REPLAYER DUMP` result to a two-column `Item` / `Value` output.

When the dump token is an HTTP(S) presigned URL, TiDB returns:

- the download URL
- the expiration duration
- browser usage guidance
- a curl command
- a note to rerun `PLAN REPLAYER DUMP` after expiration

When the token is not a URL, for example local storage, TiDB still returns the generated file token in the new table format. The `@@tidb_last_plan_replayer_token` session variable keeps its original raw token value.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test commands:

```bash
PATH=/usr/local/go/bin:/home/zhouzemin/.local/go/bin:$PATH ./tools/check/failpoint-go-test.sh pkg/executor/test/planreplayer -run 'Test(ExplainExploreReplayer|PlanReplayerDump(PresignedURLOutput|Single|Multiple))$' -count=1
PATH=/usr/local/go/bin:/home/zhouzemin/.local/go/bin:$PATH ./tools/check/failpoint-go-test.sh pkg/server/handler/optimizor -run TestPlanReplayerLoadWithSemicolonInColumnComment -count=1
PATH=/usr/local/go/bin:/home/zhouzemin/.local/bin:/usr/bin:/bin:$PATH GOENV=off GOROOT= make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Change the `PLAN REPLAYER DUMP` result from a single `File_token` column to a two-column `Item`/`Value` output. When the dump is stored in remote object storage and returns a presigned download URL, the result now shows the download URL, its validity window, and usage guidance. This is a breaking change for all deployments (including on-prem): tooling that reads the dump result by column position or by the `File_token` column name should switch to the `@@tidb_last_plan_replayer_token` session variable, which still returns the raw token unchanged.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `PLAN REPLAYER DUMP` output for HTTP(S) tokens to show the download URL, “Expires in” timing, browser instructions, a sample `curl` command, and a rerun-after-expiry note.
* **Bug Fixes**
  * Improved plan replayer token rendering so HTTP(S) URL tokens use the richer download view, while other tokens remain shown as “File token”.
* **Tests**
  * Updated and expanded plan replayer tests to validate presigned URL output, including new/updated result-extraction helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

