### PR TITLE
tests: fix import into mock data size flake

### DIFF
--- a/tests/realtikvtest/importintotest/import_into_test.go
+++ b/tests/realtikvtest/importintotest/import_into_test.go
@@ -1401,17 +1401,28 @@ func (s *mockGCSSuite) TestImportIntoWithMockDataSize() {
 	setAmplifyFactorFn(2)
 	defer setAmplifyFactorFn(1)
 	s.tk.MustExec("create table t (a int, b int);")
-	checkResourceParamFn := func(thread, maxNode int) {
+	checkResourceParamFn := func(jobID int64, thread, maxNode int) {
+		taskKey := importinto.TaskKey(jobID)
+		taskRows := s.tk.MustQuery(`
+			with global_tasks as (
+				select id, max_node_count from mysql.tidb_global_task where task_key = ?
+				union all
+				select id, max_node_count from mysql.tidb_global_task_history where task_key = ?
+			)
+			select id, max_node_count from global_tasks
+			`, taskKey, taskKey).Rows()
+		require.Len(s.T(), taskRows, 1)
+		taskID := taskRows[0][0].(string)
+		require.Equal(s.T(), fmt.Sprintf("%d", maxNode), taskRows[0][1].(string))
+
 		s.tk.MustQuery(`
-		with
-		all_subtasks as (table mysql.tidb_background_subtask union table mysql.tidb_background_subtask_history order by end_time desc limit 1)
-		select concurrency from all_subtasks
-		`).Check(testkit.Rows(fmt.Sprintf("%d", thread)))
-		s.tk.MustQuery(`
-		with
-		global_tasks as (table mysql.tidb_global_task union table mysql.tidb_global_task_history order by end_time desc limit 1)
-		select max_node_count from global_tasks
-		`).Check(testkit.Rows(fmt.Sprintf("%d", maxNode)))
+			with all_subtasks as (
+				select id, concurrency, end_time from mysql.tidb_background_subtask where task_key = ?
+				union all
+				select id, concurrency, end_time from mysql.tidb_background_subtask_history where task_key = ?
+			)
+			select concurrency from all_subtasks order by end_time desc, id desc limit 1
+			`, taskID, taskID).Check(testkit.Rows(fmt.Sprintf("%d", thread)))
 	}
 	testCases := []struct {
 		tblName    string
@@ -1430,9 +1441,12 @@ func (s *mockGCSSuite) TestImportIntoWithMockDataSize() {
 			s.tk.MustExec("create table import_into." + tc.tblName + " (a int, b int);")
 			testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/importer/amplifyRealSize", fmt.Sprintf("return(%d)", tc.factor))
 			sql := fmt.Sprintf(`IMPORT INTO import_into.%s FROM 'gs://mock-datasize-test/t.csv?endpoint=%s'`, tc.tblName, gcsEndpoint)
-			s.tk.MustQuery(sql)
+			rows := s.tk.MustQuery(sql).Rows()
+			require.Len(t, rows, 1)
+			jobID, err := strconv.ParseInt(rows[0][fmap["JobID"]].(string), 10, 64)
+			require.NoError(t, err)
 			s.tk.MustQuery("SELECT * FROM import_into." + tc.tblName + ";").Check(testkit.Rows("1 1", "2 2"))
-			checkResourceParamFn(tc.threadCnt, tc.maxNodeCnt)
+			checkResourceParamFn(jobID, tc.threadCnt, tc.maxNodeCnt)
 		})
 	}
 
@@ -1441,10 +1455,13 @@ func (s *mockGCSSuite) TestImportIntoWithMockDataSize() {
 		s.tk.MustExec("create table import_into.t_files(a int, b int);")
 		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/importer/amplifyRealSize", fmt.Sprintf("return(%d)", 10*units.GiB))
 		sql := fmt.Sprintf(`IMPORT INTO import_into.t_files FROM 'gs://mock-datasize-test/*.csv?endpoint=%s'`, gcsEndpoint)
-		s.tk.MustQuery(sql)
+		rows := s.tk.MustQuery(sql).Rows()
+		require.Len(t, rows, 1)
+		jobID, err := strconv.ParseInt(rows[0][fmap["JobID"]].(string), 10, 64)
+		require.NoError(t, err)
 		s.tk.MustQuery("SELECT * FROM import_into.t_files;").Sort().Check(testkit.Rows(
 			"1 1", "2 2", "3 3", "4 4", "5 5"))
-		checkResourceParamFn(7, 1)
+		checkResourceParamFn(jobID, 7, 1)
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69441

Problem Summary:

`TestImportIntoWithMockDataSize` asserted import task resource metadata by reading the newest row from task/subtask active and history tables globally. In realcluster CI, another task row can be the newest row, causing flaky mismatches in `max_node_count` or subtask `concurrency` even when the import task itself used the expected resource parameters.

### What changed and how does it work?

The test now captures the `JobID` returned by each `IMPORT INTO`, derives the import task key with `importinto.TaskKey(jobID)`, and looks up the matching task row from `mysql.tidb_global_task` and `mysql.tidb_global_task_history`.

After finding the exact task ID, the subtask assertion reads only subtasks for that task from `mysql.tidb_background_subtask` and `mysql.tidb_background_subtask_history`. This keeps the resource metadata assertion intact while avoiding races with unrelated latest task rows.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:

```bash
go test ./tests/realtikvtest/importintotest -run '^$' -tags=intest,deadlock,nextgen -count=1
go test ./tests/realtikvtest/importintotest -run '^$' -tags=intest,deadlock -count=1
NEXT_GEN=1 go test ./tests/realtikvtest/importintotest -run "^TestImportInto$/^TestImportIntoWithMockDataSize$" -tags=intest,deadlock,nextgen -count=1 -timeout 15m -args -with-real-tikv
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved import verification to check resource settings per job, making the test coverage more precise.
  * Added validation that each import run returns the expected job result and row count before checking concurrency settings.
  * Extended the same verification flow to cover both single-table cases and multi-file imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->