### PR TITLE
planner: avoid mutating cached histogram bounds

### DIFF
--- a/pkg/planner/cardinality/BUILD.bazel
+++ b/pkg/planner/cardinality/BUILD.bazel
@@ -58,7 +58,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":cardinality"],
     flaky = True,
-    shard_count = 49,
+    shard_count = 50,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -997,8 +997,11 @@ func GetSelectivityByFilter(sctx planctx.PlanContext, coll *statistics.HistColl,
 	// The buckets lower bounds are used as random samples and are regarded equally.
 	if hist != nil && histTotalCnt > 0 {
 		selected = selected[:0]
-		// VectorizedFilter mutates the input chunk's selection during evaluation.
-		// Keep the cached histogram bounds immutable by evaluating on a shallow chunk copy.
+		// hist.Bounds is a stats-cache chunk that can be shared by planner sessions.
+		// VectorizedFilter reads the input chunk's existing Sel as a caller mask
+		// and also rewrites Sel while evaluating the filter. Use a shallow chunk
+		// header copy so the bound column data is reused, but the evaluation owns
+		// its Sel state; then clear that Sel to sample all histogram bounds.
 		histBounds := hist.Bounds.Prune([]int{0})
 		histBounds.SetSel(nil)
 		selected, err = expression.VectorizedFilter(sctx.GetExprCtx().GetEvalCtx(), vecEnabled, []expression.Expression{filters}, chunk.NewIterator4Chunk(histBounds), selected)

--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -997,7 +997,11 @@ func GetSelectivityByFilter(sctx planctx.PlanContext, coll *statistics.HistColl,
 	// The buckets lower bounds are used as random samples and are regarded equally.
 	if hist != nil && histTotalCnt > 0 {
 		selected = selected[:0]
-		selected, err = expression.VectorizedFilter(sctx.GetExprCtx().GetEvalCtx(), vecEnabled, []expression.Expression{filters}, chunk.NewIterator4Chunk(hist.Bounds), selected)
+		// VectorizedFilter mutates the input chunk's selection during evaluation.
+		// Keep the cached histogram bounds immutable by evaluating on a shallow chunk copy.
+		histBounds := hist.Bounds.Prune([]int{0})
+		histBounds.SetSel(nil)
+		selected, err = expression.VectorizedFilter(sctx.GetExprCtx().GetEvalCtx(), vecEnabled, []expression.Expression{filters}, chunk.NewIterator4Chunk(histBounds), selected)
 		if err != nil {
 			return false, 0, err
 		}

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -1389,12 +1389,14 @@ func TestStringMatchSelectivityDoesNotRestoreTransientHistogramBoundsSelection(t
 
 	// Simulate a concurrent VecEvalBool call that temporarily narrowed the
 	// shared cached histogram bounds chunk to unrelated rows.
-	colStats.Bounds.SetSel([]int{4, 5})
+	transientSel := []int{4, 5}
+	colStats.Bounds.SetSel(transientSel)
 
 	ok, selectivity, err := cardinality.GetSelectivityByFilter(sctx, coll, filter)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.InEpsilon(t, 2.0/3.0, selectivity, 1e-12)
+	require.Equal(t, transientSel, colStats.Bounds.Sel())
 }
 
 func getTableReaderEstRows(t *testing.T, tk *testkit.TestKit, query string) float64 {

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
@@ -1345,6 +1346,55 @@ func TestDefaultStringMatchSelectivityZeroImprovesLikeEstimation(t *testing.T) {
 
 	// The default estimate is 0.8 * 100 = 80, while the topN assisted estimate should be around 5, which is much closer to the actual row count.
 	require.Less(t, math.Abs(topNAssistedEstimate-actualRows), math.Abs(defaultEstimate-actualRows))
+}
+
+func TestStringMatchSelectivityDoesNotRestoreTransientHistogramBoundsSelection(t *testing.T) {
+	sctx := mock.NewContext()
+	sctx.GetSessionVars().EnableVectorizedExpression = true
+
+	tp := types.NewFieldType(mysql.TypeVarchar)
+	hist := statistics.NewHistogram(1, 6, 0, 0, tp, 3, 0)
+	appendBucket := func(lower, upper string, count, repeat int64) {
+		lowerDatum := types.NewStringDatum(lower)
+		upperDatum := types.NewStringDatum(upper)
+		hist.AppendBucket(&lowerDatum, &upperDatum, count, repeat)
+	}
+	appendBucket("BRASS", "BRASS", 2, 1)
+	appendBucket("IRON", "IRON", 4, 1)
+	appendBucket("STEEL", "STEEL", 6, 1)
+
+	colStats := &statistics.Column{
+		Info: &model.ColumnInfo{
+			ID:        1,
+			Name:      ast.NewCIStr("a"),
+			FieldType: *tp,
+		},
+		Histogram:         *hist,
+		TopN:              &statistics.TopN{},
+		StatsLoadedStatus: statistics.NewStatsFullLoadStatus(),
+		StatsVer:          statistics.Version2,
+	}
+	coll := statistics.NewHistColl(1, 6, 0, 1, 0)
+	coll.SetCol(1, colStats)
+
+	filter, err := expression.NewFunction(
+		sctx,
+		ast.Like,
+		types.NewFieldType(mysql.TypeLonglong),
+		&expression.Column{UniqueID: 1, RetType: tp},
+		&expression.Constant{Value: types.NewStringDatum("%R%"), RetType: tp},
+		&expression.Constant{Value: types.NewIntDatum('\\'), RetType: types.NewFieldType(mysql.TypeLonglong)},
+	)
+	require.NoError(t, err)
+
+	// Simulate a concurrent VecEvalBool call that temporarily narrowed the
+	// shared cached histogram bounds chunk to unrelated rows.
+	colStats.Bounds.SetSel([]int{4, 5})
+
+	ok, selectivity, err := cardinality.GetSelectivityByFilter(sctx, coll, filter)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.InEpsilon(t, 2.0/3.0, selectivity, 1e-12)
 }
 
 func getTableReaderEstRows(t *testing.T, tk *testkit.TestKit, query string) float64 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69446

Problem Summary:

After `tidb_default_string_match_selectivity` defaults to `0`, LIKE predicates use sampling-based selectivity estimation by default. The histogram path passed cached `hist.Bounds` directly to `expression.VectorizedFilter`. The vectorized evaluation path reads and rewrites the input chunk `Sel`, so concurrent planner sessions can leave a transient selection vector on the shared stats-cache histogram bounds chunk.

### What changed and how does it work?

This PR evaluates LIKE histogram samples through a shallow copy of the histogram bounds chunk:

- use `hist.Bounds.Prune([]int{0})` to create a new chunk header while reusing the bounds column data;
- clear the copied chunk `Sel` before evaluation so all histogram bounds are sampled;
- keep vectorized expression evaluation from mutating the cached `hist.Bounds` chunk state.

The regression test constructs an in-memory histogram, simulates a transient cached bounds `Sel`, and verifies that LIKE sampling still estimates from all bounds and preserves the original cached `Sel`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a potential panic caused by concurrent LIKE selectivity estimation mutating cached histogram bounds.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selectivity estimation for histogram-based string matching, making results more reliable when vectorized evaluation is used.
  * Prevented temporary histogram selection state from being overwritten during filtering, avoiding incorrect behavior in concurrent or repeated estimates.
* **Tests**
  * Added coverage for string-match selectivity to verify histogram state remains stable after estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->