### PR TITLE
types, statistics: handle zero timestamp stats scalarization

### DIFF
--- a/.agents/skills/tidb-test-guidelines/references/statistics-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/statistics-case-map.md
@@ -18,7 +18,7 @@
 - `pkg/statistics/integration_test.go` - statistics: Tests change ver to 2 behavior.
 - `pkg/statistics/main_test.go` - Configures default goleak settings and registers testdata.
 - `pkg/statistics/sample_test.go` - statistics: Tests weighted sampling.
-- `pkg/statistics/scalar_test.go` - statistics: Tests calc fraction.
+- `pkg/statistics/scalar_test.go` - statistics: Tests calc fraction and scalar conversion for zero TIMESTAMP.
 - `pkg/statistics/statistics_test.go` - statistics: Tests merge histogram.
 - `pkg/statistics/table_test.go` - statistics: Tests clone col and idx existence map.
 

--- a/.agents/skills/tidb-test-guidelines/references/statistics-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/statistics-case-map.md
@@ -18,7 +18,7 @@
 - `pkg/statistics/integration_test.go` - statistics: Tests change ver to 2 behavior.
 - `pkg/statistics/main_test.go` - Configures default goleak settings and registers testdata.
 - `pkg/statistics/sample_test.go` - statistics: Tests weighted sampling.
-- `pkg/statistics/scalar_test.go` - statistics: Tests calc fraction and scalar conversion for zero TIMESTAMP.
+- `pkg/statistics/scalar_test.go` - statistics: Tests calc fraction, scalar conversion, and out-of-range estimates for zero TIMESTAMP bounds.
 - `pkg/statistics/statistics_test.go` - statistics: Tests merge histogram.
 - `pkg/statistics/table_test.go` - statistics: Tests clone col and idx existence map.
 

--- a/.agents/skills/tidb-test-guidelines/references/statistics-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/statistics-case-map.md
@@ -18,7 +18,7 @@
 - `pkg/statistics/integration_test.go` - statistics: Tests change ver to 2 behavior.
 - `pkg/statistics/main_test.go` - Configures default goleak settings and registers testdata.
 - `pkg/statistics/sample_test.go` - statistics: Tests weighted sampling.
-- `pkg/statistics/scalar_test.go` - statistics: Tests calc fraction, scalar conversion, and out-of-range estimates for zero TIMESTAMP bounds.
+- `pkg/statistics/scalar_test.go` - statistics: Tests calc fraction, scalar conversion, and out-of-range estimates for zero/out-of-range TIMESTAMP bounds.
 - `pkg/statistics/statistics_test.go` - statistics: Tests merge histogram.
 - `pkg/statistics/table_test.go` - statistics: Tests clone col and idx existence map.
 

--- a/.agents/skills/tidb-test-guidelines/references/types-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/types-case-map.md
@@ -33,7 +33,7 @@
 - `pkg/types/mydecimal_test.go` - Tests from int.
 - `pkg/types/overflow_test.go` - Tests add.
 - `pkg/types/set_test.go` - Tests set.
-- `pkg/types/time_test.go` - Tests time encoding.
+- `pkg/types/time_test.go` - Tests time encoding and TIMESTAMP subtraction log handling.
 - `pkg/types/vector_test.go` - Tests vector endianness.
 
 ## pkg/types/parser_driver

--- a/pkg/statistics/BUILD.bazel
+++ b/pkg/statistics/BUILD.bazel
@@ -81,7 +81,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":statistics"],
     flaky = True,
-    shard_count = 44,
+    shard_count = 45,
     deps = [
         "//pkg/config",
         "//pkg/meta/model",
@@ -108,7 +108,10 @@ go_test(
         "//pkg/util/sqlexec",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
+        "@com_github_pingcap_log//:log",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
+        "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zaptest/observer",
     ],
 )

--- a/pkg/statistics/scalar.go
+++ b/pkg/statistics/scalar.go
@@ -68,17 +68,7 @@ func convertDatumToScalar(value *types.Datum, commonPfxLen int) float64 {
 		}
 		return scalar
 	case types.KindMysqlTime:
-		valueTime := value.GetMysqlTime()
-		var minTime types.Time
-		switch valueTime.Type() {
-		case mysql.TypeDate:
-			minTime = types.NewTime(types.MinDatetime, mysql.TypeDate, types.DefaultFsp)
-		case mysql.TypeDatetime:
-			minTime = types.NewTime(types.MinDatetime, mysql.TypeDatetime, types.DefaultFsp)
-		case mysql.TypeTimestamp:
-			minTime = types.MinTimestamp
-		}
-		return float64(valueTime.Sub(UTCWithAllowInvalidDateCtx, &minTime).Duration)
+		return convertMysqlTimeToScalar(value.GetMysqlTime())
 	case types.KindString, types.KindBytes:
 		bytes := value.GetBytes()
 		if len(bytes) <= commonPfxLen {
@@ -93,6 +83,25 @@ func convertDatumToScalar(value *types.Datum, commonPfxLen int) float64 {
 		// do not know how to convert
 		return 0
 	}
+}
+
+func convertMysqlTimeToScalar(valueTime types.Time) float64 {
+	var minTime types.Time
+	switch valueTime.Type() {
+	case mysql.TypeDate:
+		minTime = types.NewTime(types.MinDatetime, mysql.TypeDate, types.DefaultFsp)
+	case mysql.TypeDatetime:
+		minTime = types.NewTime(types.MinDatetime, mysql.TypeDatetime, types.DefaultFsp)
+	case mysql.TypeTimestamp:
+		minTime = types.MinTimestamp
+		if valueTime.Compare(types.MinTimestamp) < 0 {
+			// Relaxed SQL modes can store zero or before-min TIMESTAMP values, but they
+			// are outside the legal TIMESTAMP range. Keep them adjacent to the valid
+			// range so scalar estimation stays finite and ordered.
+			return -1
+		}
+	}
+	return float64(valueTime.Sub(UTCWithAllowInvalidDateCtx, &minTime).Duration)
 }
 
 // PreCalculateScalar converts the lower and upper to scalar. When the datum type is KindString or KindBytes, we also

--- a/pkg/statistics/scalar.go
+++ b/pkg/statistics/scalar.go
@@ -95,13 +95,13 @@ func convertMysqlTimeToScalar(valueTime types.Time) float64 {
 	case mysql.TypeTimestamp:
 		minTime = types.MinTimestamp
 		if valueTime.Compare(types.MinTimestamp) < 0 {
-			// Relaxed SQL modes can leave zero TIMESTAMP values in stats. The
-			// old scalar path subtracted MinTimestamp (1970-01-01 00:00:01) from
-			// a zero TIMESTAMP; GoTime normalizes the zero value to -0001-11-30,
-			// and the subtraction saturates to math.MinInt64 ns. That creates an
-			// artificial huge distance from normal TIMESTAMP values and skews
-			// fraction/out-of-range estimates, so keep before-min values finite
-			// and just before the legal TIMESTAMP range.
+			// Relaxed SQL modes can leave zero TIMESTAMP values in stats. If we
+			// subtract MinTimestamp (1970-01-01 00:00:01) from such a value
+			// directly, GoTime normalizes zero TIMESTAMP to -0001-11-30 and the
+			// subtraction saturates to math.MinInt64 ns. That artificial huge
+			// distance from normal TIMESTAMP values would skew fraction and
+			// out-of-range estimates, so keep before-min values finite and just
+			// before the legal TIMESTAMP range.
 			return -1
 		}
 		if valueTime.Compare(types.MaxTimestamp) > 0 {

--- a/pkg/statistics/scalar.go
+++ b/pkg/statistics/scalar.go
@@ -85,6 +85,11 @@ func convertDatumToScalar(value *types.Datum, commonPfxLen int) float64 {
 	}
 }
 
+// convertMysqlTimeToScalar maps a types.Time to the float64 scalar used for
+// histogram fraction and out-of-range estimation. The scalar is the duration
+// from the type's minimum bound (MinDatetime for date/datetime, MinTimestamp
+// for timestamp). TIMESTAMP values outside the legal range are clamped just
+// outside the valid scalar range so estimates stay finite and ordered.
 func convertMysqlTimeToScalar(valueTime types.Time) float64 {
 	var minTime types.Time
 	switch valueTime.Type() {
@@ -101,14 +106,17 @@ func convertMysqlTimeToScalar(valueTime types.Time) float64 {
 			// subtraction saturates to math.MinInt64 ns. That artificial huge
 			// distance from normal TIMESTAMP values would skew fraction and
 			// out-of-range estimates, so keep before-min values finite and just
-			// before the legal TIMESTAMP range.
+			// before the legal TIMESTAMP range. All before-min values collapse to
+			// the same -1; this is acceptable since they are invalid/zero values
+			// and calcFraction treats value <= lower as 0.
 			return -1
 		}
 		if valueTime.Compare(types.MaxTimestamp) > 0 {
 			// Historical stats may also contain above-max TIMESTAMP bounds. Put
 			// them just after the legal maximum. maxScalar + 1 is not enough here:
 			// at this magnitude float64 rounds it back to maxScalar, collapsing a
-			// [MaxTimestamp, after-max] bucket into a zero-width interval.
+			// [MaxTimestamp, after-max] bucket into a zero-width interval, so use
+			// Nextafter to advance by a single ULP.
 			maxTimestamp := types.MaxTimestamp
 			maxScalar := float64(maxTimestamp.Sub(UTCWithAllowInvalidDateCtx, &minTime).Duration)
 			return math.Nextafter(maxScalar, math.Inf(1))

--- a/pkg/statistics/scalar.go
+++ b/pkg/statistics/scalar.go
@@ -95,10 +95,15 @@ func convertMysqlTimeToScalar(valueTime types.Time) float64 {
 	case mysql.TypeTimestamp:
 		minTime = types.MinTimestamp
 		if valueTime.Compare(types.MinTimestamp) < 0 {
-			// Relaxed SQL modes can store zero or before-min TIMESTAMP values, but they
-			// are outside the legal TIMESTAMP range. Keep them adjacent to the valid
-			// range so scalar estimation stays finite and ordered.
+			// Relaxed SQL modes can leave zero TIMESTAMP values in stats, and
+			// historical stats may also contain out-of-range bounds. Keep values
+			// outside the legal range adjacent to the valid range so scalar
+			// estimation stays finite and ordered.
 			return -1
+		}
+		if valueTime.Compare(types.MaxTimestamp) > 0 {
+			maxTimestamp := types.MaxTimestamp
+			return float64(maxTimestamp.Sub(UTCWithAllowInvalidDateCtx, &minTime).Duration) + 1
 		}
 	}
 	return float64(valueTime.Sub(UTCWithAllowInvalidDateCtx, &minTime).Duration)

--- a/pkg/statistics/scalar.go
+++ b/pkg/statistics/scalar.go
@@ -95,11 +95,13 @@ func convertMysqlTimeToScalar(valueTime types.Time) float64 {
 	case mysql.TypeTimestamp:
 		minTime = types.MinTimestamp
 		if valueTime.Compare(types.MinTimestamp) < 0 {
-			// Relaxed SQL modes can leave zero TIMESTAMP values in stats. For a
-			// bucket like [0000-00-00 00:00:00, 1970-01-01 00:00:03], using
-			// Time.Sub directly turns the zero bound into math.MinInt64 ns, so
-			// 1970-01-01 00:00:02 looks almost at the upper bound instead of the
-			// middle. Put before-min values just before the legal TIMESTAMP range.
+			// Relaxed SQL modes can leave zero TIMESTAMP values in stats. The
+			// old scalar path subtracted MinTimestamp (1970-01-01 00:00:01) from
+			// a zero TIMESTAMP; GoTime normalizes the zero value to -0001-11-30,
+			// and the subtraction saturates to math.MinInt64 ns. That creates an
+			// artificial huge distance from normal TIMESTAMP values and skews
+			// fraction/out-of-range estimates, so keep before-min values finite
+			// and just before the legal TIMESTAMP range.
 			return -1
 		}
 		if valueTime.Compare(types.MaxTimestamp) > 0 {

--- a/pkg/statistics/scalar.go
+++ b/pkg/statistics/scalar.go
@@ -95,13 +95,18 @@ func convertMysqlTimeToScalar(valueTime types.Time) float64 {
 	case mysql.TypeTimestamp:
 		minTime = types.MinTimestamp
 		if valueTime.Compare(types.MinTimestamp) < 0 {
-			// Relaxed SQL modes can leave zero TIMESTAMP values in stats, and
-			// historical stats may also contain out-of-range bounds. Keep values
-			// outside the legal range adjacent to the valid range so scalar
-			// estimation stays finite and ordered.
+			// Relaxed SQL modes can leave zero TIMESTAMP values in stats. For a
+			// bucket like [0000-00-00 00:00:00, 1970-01-01 00:00:03], using
+			// Time.Sub directly turns the zero bound into math.MinInt64 ns, so
+			// 1970-01-01 00:00:02 looks almost at the upper bound instead of the
+			// middle. Put before-min values just before the legal TIMESTAMP range.
 			return -1
 		}
 		if valueTime.Compare(types.MaxTimestamp) > 0 {
+			// Historical stats may also contain above-max TIMESTAMP bounds. Put
+			// them just after the legal maximum. maxScalar + 1 is not enough here:
+			// at this magnitude float64 rounds it back to maxScalar, collapsing a
+			// [MaxTimestamp, after-max] bucket into a zero-width interval.
 			maxTimestamp := types.MaxTimestamp
 			maxScalar := float64(maxTimestamp.Sub(UTCWithAllowInvalidDateCtx, &minTime).Duration)
 			return math.Nextafter(maxScalar, math.Inf(1))

--- a/pkg/statistics/scalar.go
+++ b/pkg/statistics/scalar.go
@@ -103,7 +103,8 @@ func convertMysqlTimeToScalar(valueTime types.Time) float64 {
 		}
 		if valueTime.Compare(types.MaxTimestamp) > 0 {
 			maxTimestamp := types.MaxTimestamp
-			return float64(maxTimestamp.Sub(UTCWithAllowInvalidDateCtx, &minTime).Duration) + 1
+			maxScalar := float64(maxTimestamp.Sub(UTCWithAllowInvalidDateCtx, &minTime).Duration)
+			return math.Nextafter(maxScalar, math.Inf(1))
 		}
 	}
 	return float64(valueTime.Sub(UTCWithAllowInvalidDateCtx, &minTime).Duration)

--- a/pkg/statistics/scalar_test.go
+++ b/pkg/statistics/scalar_test.go
@@ -150,6 +150,13 @@ func TestCalcFraction(t *testing.T) {
 			tp:       types.NewFieldType(mysql.TypeTimestamp),
 		},
 		{
+			lower:    types.NewTimeDatum(types.MaxTimestamp),
+			upper:    types.NewTimeDatum(types.NewTime(types.FromDate(9999, 12, 31, 23, 59, 59, 0), mysql.TypeTimestamp, types.DefaultFsp)),
+			value:    types.NewTimeDatum(types.NewTime(types.FromDate(9999, 12, 31, 23, 59, 59, 0), mysql.TypeTimestamp, types.DefaultFsp)),
+			fraction: 1.0,
+			tp:       types.NewFieldType(mysql.TypeTimestamp),
+		},
+		{
 			lower:    types.NewTimeDatum(getTime(2017, 1, 1, mysql.TypeDatetime)),
 			upper:    types.NewTimeDatum(getTime(2017, 4, 1, mysql.TypeDatetime)),
 			value:    types.NewTimeDatum(getTime(2017, 2, 1, mysql.TypeDatetime)),
@@ -207,7 +214,8 @@ func TestConvertDatumToScalarZeroTimestampDoesNotLog(t *testing.T) {
 	maxTimestamp := types.NewTimeDatum(types.MaxTimestamp)
 	maxTimestampScalar := convertDatumToScalar(&maxTimestamp, 0)
 	afterMaxTimestamp := types.NewTimeDatum(types.NewTime(types.FromDate(9999, 12, 31, 23, 59, 59, 0), mysql.TypeTimestamp, types.DefaultFsp))
-	require.Equal(t, maxTimestampScalar+1, convertDatumToScalar(&afterMaxTimestamp, 0))
+	afterMaxTimestampScalar := convertDatumToScalar(&afterMaxTimestamp, 0)
+	require.Greater(t, afterMaxTimestampScalar, maxTimestampScalar)
 
 	hg := NewHistogram(0, 0, 0, 0, types.NewFieldType(mysql.TypeTimestamp), 1, 0)
 	upper := types.NewTimeDatum(types.NewTime(types.FromDate(1970, 1, 1, 0, 0, 3, 0), mysql.TypeTimestamp, types.DefaultFsp))

--- a/pkg/statistics/scalar_test.go
+++ b/pkg/statistics/scalar_test.go
@@ -204,6 +204,11 @@ func TestConvertDatumToScalarZeroTimestampDoesNotLog(t *testing.T) {
 	minTimestamp := types.NewTimeDatum(types.MinTimestamp)
 	require.Equal(t, float64(0), convertDatumToScalar(&minTimestamp, 0))
 
+	maxTimestamp := types.NewTimeDatum(types.MaxTimestamp)
+	maxTimestampScalar := convertDatumToScalar(&maxTimestamp, 0)
+	afterMaxTimestamp := types.NewTimeDatum(types.NewTime(types.FromDate(9999, 12, 31, 23, 59, 59, 0), mysql.TypeTimestamp, types.DefaultFsp))
+	require.Equal(t, maxTimestampScalar+1, convertDatumToScalar(&afterMaxTimestamp, 0))
+
 	hg := NewHistogram(0, 0, 0, 0, types.NewFieldType(mysql.TypeTimestamp), 1, 0)
 	upper := types.NewTimeDatum(types.NewTime(types.FromDate(1970, 1, 1, 0, 0, 3, 0), mysql.TypeTimestamp, types.DefaultFsp))
 	hg.AppendBucket(&datum, &upper, 2, 1)
@@ -212,7 +217,9 @@ func TestConvertDatumToScalarZeroTimestampDoesNotLog(t *testing.T) {
 	ctx.GetSessionVars().RiskRangeSkewRatio = 0.5
 	right := types.NewTimeDatum(types.NewTime(types.FromDate(1970, 1, 1, 0, 0, 4, 0), mysql.TypeTimestamp, types.DefaultFsp))
 	estimate := hg.OutOfRangeRowCount(ctx, &upper, &right, 100, 100, 2)
-	require.Greater(t, estimate.Est, 20.0)
+	require.InDelta(t, 45.937499984687506, estimate.Est, eps)
+	require.InDelta(t, 18.374999993875, estimate.MinEst, eps)
+	require.InDelta(t, 73.4999999755, estimate.MaxEst, eps)
 }
 
 func TestEnumRangeValues(t *testing.T) {

--- a/pkg/statistics/scalar_test.go
+++ b/pkg/statistics/scalar_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -142,6 +143,13 @@ func TestCalcFraction(t *testing.T) {
 			tp:       types.NewFieldType(mysql.TypeTimestamp),
 		},
 		{
+			lower:    types.NewTimeDatum(types.NewTime(types.ZeroCoreTime, mysql.TypeTimestamp, types.DefaultFsp)),
+			upper:    types.NewTimeDatum(types.NewTime(types.FromDate(1970, 1, 1, 0, 0, 3, 0), mysql.TypeTimestamp, types.DefaultFsp)),
+			value:    types.NewTimeDatum(types.NewTime(types.FromDate(1970, 1, 1, 0, 0, 2, 0), mysql.TypeTimestamp, types.DefaultFsp)),
+			fraction: 0.5,
+			tp:       types.NewFieldType(mysql.TypeTimestamp),
+		},
+		{
 			lower:    types.NewTimeDatum(getTime(2017, 1, 1, mysql.TypeDatetime)),
 			upper:    types.NewTimeDatum(getTime(2017, 4, 1, mysql.TypeDatetime)),
 			value:    types.NewTimeDatum(getTime(2017, 2, 1, mysql.TypeDatetime)),
@@ -188,9 +196,23 @@ func TestConvertDatumToScalarZeroTimestampDoesNotLog(t *testing.T) {
 	defer restore()
 
 	datum := types.NewTimeDatum(types.NewTime(types.ZeroCoreTime, mysql.TypeTimestamp, types.DefaultFsp))
-	_ = convertDatumToScalar(&datum, 0)
+	scalar := convertDatumToScalar(&datum, 0)
 
 	require.Empty(t, recorded.FilterMessage("encountered error").All())
+	require.Equal(t, float64(-1), scalar)
+
+	minTimestamp := types.NewTimeDatum(types.MinTimestamp)
+	require.Equal(t, float64(0), convertDatumToScalar(&minTimestamp, 0))
+
+	hg := NewHistogram(0, 0, 0, 0, types.NewFieldType(mysql.TypeTimestamp), 1, 0)
+	upper := types.NewTimeDatum(types.NewTime(types.FromDate(1970, 1, 1, 0, 0, 3, 0), mysql.TypeTimestamp, types.DefaultFsp))
+	hg.AppendBucket(&datum, &upper, 2, 1)
+
+	ctx := mock.NewContext()
+	ctx.GetSessionVars().RiskRangeSkewRatio = 0.5
+	right := types.NewTimeDatum(types.NewTime(types.FromDate(1970, 1, 1, 0, 0, 4, 0), mysql.TypeTimestamp, types.DefaultFsp))
+	estimate := hg.OutOfRangeRowCount(ctx, &upper, &right, 100, 100, 2)
+	require.Greater(t, estimate.Est, 20.0)
 }
 
 func TestEnumRangeValues(t *testing.T) {

--- a/pkg/statistics/scalar_test.go
+++ b/pkg/statistics/scalar_test.go
@@ -18,9 +18,12 @@ import (
 	"math"
 	"testing"
 
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 const eps = 1e-9
@@ -174,6 +177,20 @@ func TestCalcFraction(t *testing.T) {
 		fraction := hg.calcFraction(0, &test.value)
 		require.InDelta(t, test.fraction, fraction, eps)
 	}
+}
+
+func TestConvertDatumToScalarZeroTimestampDoesNotLog(t *testing.T) {
+	core, recorded := observer.New(zap.ErrorLevel)
+	restore := log.ReplaceGlobals(
+		zap.New(core),
+		&log.ZapProperties{Core: core, Level: zap.NewAtomicLevelAt(zap.InfoLevel)},
+	)
+	defer restore()
+
+	datum := types.NewTimeDatum(types.NewTime(types.ZeroCoreTime, mysql.TypeTimestamp, types.DefaultFsp))
+	_ = convertDatumToScalar(&datum, 0)
+
+	require.Empty(t, recorded.FilterMessage("encountered error").All())
 }
 
 func TestEnumRangeValues(t *testing.T) {

--- a/pkg/statistics/scalar_test.go
+++ b/pkg/statistics/scalar_test.go
@@ -194,7 +194,10 @@ func TestCalcFraction(t *testing.T) {
 	}
 }
 
-func TestConvertDatumToScalarZeroTimestampDoesNotLog(t *testing.T) {
+// TestConvertMysqlTimeToScalarTimestampBounds verifies that zero/before-min and
+// above-max TIMESTAMP values are clamped to finite, ordered scalars and that
+// the zero-TIMESTAMP path does not emit tolerated GoTime error logs.
+func TestConvertMysqlTimeToScalarTimestampBounds(t *testing.T) {
 	core, recorded := observer.New(zap.ErrorLevel)
 	restore := log.ReplaceGlobals(
 		zap.New(core),
@@ -216,6 +219,13 @@ func TestConvertDatumToScalarZeroTimestampDoesNotLog(t *testing.T) {
 	afterMaxTimestamp := types.NewTimeDatum(types.NewTime(types.FromDate(9999, 12, 31, 23, 59, 59, 0), mysql.TypeTimestamp, types.DefaultFsp))
 	afterMaxTimestampScalar := convertDatumToScalar(&afterMaxTimestamp, 0)
 	require.Greater(t, afterMaxTimestampScalar, maxTimestampScalar)
+}
+
+// TestOutOfRangeRowCountZeroTimestampLowerBound verifies the end-to-end
+// out-of-range estimate when a histogram bucket has a zero TIMESTAMP (clamped
+// to scalar -1) as its lower bound.
+func TestOutOfRangeRowCountZeroTimestampLowerBound(t *testing.T) {
+	datum := types.NewTimeDatum(types.NewTime(types.ZeroCoreTime, mysql.TypeTimestamp, types.DefaultFsp))
 
 	hg := NewHistogram(0, 0, 0, 0, types.NewFieldType(mysql.TypeTimestamp), 1, 0)
 	upper := types.NewTimeDatum(types.NewTime(types.FromDate(1970, 1, 1, 0, 0, 3, 0), mysql.TypeTimestamp, types.DefaultFsp))

--- a/pkg/types/BUILD.bazel
+++ b/pkg/types/BUILD.bazel
@@ -116,8 +116,11 @@ go_test(
         "//pkg/util/hack",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_log//:log",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
+        "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zaptest/observer",
     ],
 )

--- a/pkg/types/time.go
+++ b/pkg/types/time.go
@@ -725,6 +725,11 @@ func (t *Time) Sub(ctx Context, t1 *Time) Duration {
 	}
 }
 
+// logTimeSubGoTimeErr logs a GoTime conversion error produced by Time.Sub for
+// TIMESTAMP operands. Such errors are expected when the context tolerates
+// invalid/zero dates (e.g. zero TIMESTAMP values read from stats under relaxed
+// SQL modes), and are suppressed there to avoid log noise; in strict contexts
+// the original terror.Log behavior is preserved.
 func logTimeSubGoTimeErr(ctx Context, err error) {
 	if err == nil {
 		return

--- a/pkg/types/time.go
+++ b/pkg/types/time.go
@@ -702,9 +702,9 @@ func (t *Time) Sub(ctx Context, t1 *Time) Duration {
 	var duration gotime.Duration
 	if t.Type() == mysql.TypeTimestamp && t1.Type() == mysql.TypeTimestamp {
 		a, err := t.GoTime(ctx.Location())
-		terror.Log(errors.Trace(err))
+		logTimeSubGoTimeErr(ctx, err)
 		b, err := t1.GoTime(ctx.Location())
-		terror.Log(errors.Trace(err))
+		logTimeSubGoTimeErr(ctx, err)
 		duration = a.Sub(b)
 	} else {
 		seconds, microseconds, neg := calcTimeTimeDiff(t.coreTime, t1.coreTime, 1)
@@ -723,6 +723,17 @@ func (t *Time) Sub(ctx Context, t1 *Time) Duration {
 		Duration: duration,
 		Fsp:      fsp,
 	}
+}
+
+func logTimeSubGoTimeErr(ctx Context, err error) {
+	if err == nil {
+		return
+	}
+	flags := ctx.Flags()
+	if flags.IgnoreInvalidDateErr() || flags.IgnoreZeroInDate() {
+		return
+	}
+	terror.Log(errors.Trace(err))
 }
 
 // Add adds d to t, returns the result time value.

--- a/pkg/types/time_test.go
+++ b/pkg/types/time_test.go
@@ -1995,17 +1995,52 @@ func TestTimeSubTimestampGoTimeErrorLogRespectsContextFlags(t *testing.T) {
 	zeroTimestamp := types.NewTime(types.ZeroCoreTime, mysql.TypeTimestamp, types.DefaultFsp)
 	minTimestamp := types.MinTimestamp
 
-	strictDuration, strictLogs := timeSubWithObservedErrorLogs(t, types.StrictContext, &zeroTimestamp, &minTimestamp)
-	require.Len(t, strictLogs.FilterMessage("encountered error").All(), 1)
+	testCases := []struct {
+		name              string
+		ctx               types.Context
+		expectedErrorLogs int
+	}{
+		{
+			name:              "strict context logs GoTime error",
+			ctx:               types.StrictContext,
+			expectedErrorLogs: 1,
+		},
+		{
+			name: "ignore invalid date error suppresses GoTime error log",
+			ctx: types.NewContext(
+				types.DefaultStmtFlags|types.FlagIgnoreInvalidDateErr,
+				time.UTC,
+				contextutil.IgnoreWarn,
+			),
+		},
+		{
+			name: "ignore zero in date suppresses GoTime error log",
+			ctx: types.NewContext(
+				types.DefaultStmtFlags|types.FlagIgnoreZeroInDateErr,
+				time.UTC,
+				contextutil.IgnoreWarn,
+			),
+		},
+		{
+			name: "ignore invalid date error and zero in date suppress GoTime error log",
+			ctx: types.NewContext(
+				types.DefaultStmtFlags|types.FlagIgnoreInvalidDateErr|types.FlagIgnoreZeroInDateErr,
+				time.UTC,
+				contextutil.IgnoreWarn,
+			),
+		},
+	}
 
-	tolerantCtx := types.NewContext(
-		types.DefaultStmtFlags|types.FlagIgnoreInvalidDateErr|types.FlagIgnoreZeroInDateErr,
-		time.UTC,
-		contextutil.IgnoreWarn,
-	)
-	tolerantDuration, tolerantLogs := timeSubWithObservedErrorLogs(t, tolerantCtx, &zeroTimestamp, &minTimestamp)
-	require.Empty(t, tolerantLogs.FilterMessage("encountered error").All())
-	require.Equal(t, strictDuration, tolerantDuration)
+	var strictDuration types.Duration
+	for i, tc := range testCases {
+		duration, logs := timeSubWithObservedErrorLogs(t, tc.ctx, &zeroTimestamp, &minTimestamp)
+		require.Lenf(t, logs.FilterMessage("encountered error").All(), tc.expectedErrorLogs, "%s", tc.name)
+		if i == 0 {
+			strictDuration = duration
+			continue
+		}
+		require.Equalf(t, strictDuration, duration, "%s", tc.name)
+	}
 }
 
 func timeSubWithObservedErrorLogs(t *testing.T, ctx types.Context, left, right *types.Time) (types.Duration, *observer.ObservedLogs) {

--- a/pkg/types/time_test.go
+++ b/pkg/types/time_test.go
@@ -2012,6 +2012,7 @@ func TestTimeSubTimestampGoTimeErrorLogRespectsContextFlags(t *testing.T) {
 				time.UTC,
 				contextutil.IgnoreWarn,
 			),
+			expectedErrorLogs: 0,
 		},
 		{
 			name: "ignore zero in date suppresses GoTime error log",
@@ -2020,6 +2021,7 @@ func TestTimeSubTimestampGoTimeErrorLogRespectsContextFlags(t *testing.T) {
 				time.UTC,
 				contextutil.IgnoreWarn,
 			),
+			expectedErrorLogs: 0,
 		},
 		{
 			name: "ignore invalid date error and zero in date suppress GoTime error log",
@@ -2028,6 +2030,7 @@ func TestTimeSubTimestampGoTimeErrorLogRespectsContextFlags(t *testing.T) {
 				time.UTC,
 				contextutil.IgnoreWarn,
 			),
+			expectedErrorLogs: 0,
 		},
 	}
 

--- a/pkg/types/time_test.go
+++ b/pkg/types/time_test.go
@@ -23,11 +23,14 @@ import (
 	"unsafe"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/types"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestTimeEncoding(t *testing.T) {
@@ -1986,6 +1989,36 @@ func TestTimeSub(t *testing.T) {
 		rec := v1.Sub(typeCtx, &v2)
 		require.Equal(t, dur, rec)
 	}
+}
+
+func TestTimeSubTimestampGoTimeErrorLogRespectsContextFlags(t *testing.T) {
+	zeroTimestamp := types.NewTime(types.ZeroCoreTime, mysql.TypeTimestamp, types.DefaultFsp)
+	minTimestamp := types.MinTimestamp
+
+	strictDuration, strictLogs := timeSubWithObservedErrorLogs(t, types.StrictContext, &zeroTimestamp, &minTimestamp)
+	require.Len(t, strictLogs.FilterMessage("encountered error").All(), 1)
+
+	tolerantCtx := types.NewContext(
+		types.DefaultStmtFlags|types.FlagIgnoreInvalidDateErr|types.FlagIgnoreZeroInDateErr,
+		time.UTC,
+		contextutil.IgnoreWarn,
+	)
+	tolerantDuration, tolerantLogs := timeSubWithObservedErrorLogs(t, tolerantCtx, &zeroTimestamp, &minTimestamp)
+	require.Empty(t, tolerantLogs.FilterMessage("encountered error").All())
+	require.Equal(t, strictDuration, tolerantDuration)
+}
+
+func timeSubWithObservedErrorLogs(t *testing.T, ctx types.Context, left, right *types.Time) (types.Duration, *observer.ObservedLogs) {
+	t.Helper()
+
+	core, recorded := observer.New(zap.ErrorLevel)
+	restore := log.ReplaceGlobals(
+		zap.New(core),
+		&log.ZapProperties{Core: core, Level: zap.NewAtomicLevelAt(zap.InfoLevel)},
+	)
+	defer restore()
+
+	return left.Sub(ctx, right), recorded
 }
 
 func TestCheckMonthDay(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69440

Problem Summary:

Plan-time cardinality estimation can scalarize zero or otherwise invalid `TIMESTAMP` histogram bounds through `statistics.convertDatumToScalar -> types.Time.Sub`. The statement still succeeds, but the old path could log tolerated `GoTime` conversion errors at ERROR level and map zero `TIMESTAMP` to a saturated duration, which can distort histogram fraction and out-of-range row estimates.

### What changed and how does it work?

This PR makes `types.Time.Sub` respect tolerant context flags before logging `TIMESTAMP` `GoTime` conversion errors. Strict/default contexts still log the error, while contexts with `IgnoreInvalidDateErr` or `IgnoreZeroInDate` suppress the internal ERROR log.

It also keeps invalid `TIMESTAMP` bounds finite and ordered in statistics scalarization:

- values below `types.MinTimestamp`, including zero `TIMESTAMP`, map to `-1`, immediately before the legal min scalar `0`
- values above `types.MaxTimestamp` map to the next representable float64 after the legal max scalar, so they stay strictly after the valid range

Focused regression coverage verifies strict and tolerant `Time.Sub` logging behavior, statistics scalar conversion, histogram fraction calculation, and out-of-range row estimation for zero/out-of-range `TIMESTAMP` bounds.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```bash
./tools/check/failpoint-go-test.sh pkg/statistics -run '^(TestCalcFraction|TestConvertDatumToScalarZeroTimestampDoesNotLog)$' -count=1
go test -run '^TestTimeSub' -tags=intest,deadlock -count=1 ./pkg/types
make bazel_prepare
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that zero or out-of-range TIMESTAMP bounds in statistics can emit unexpected ERROR logs or distort cardinality estimates during plan-time estimation.
```
